### PR TITLE
Form for personal activity settings

### DIFF
--- a/opengever/activity/__init__.py
+++ b/opengever/activity/__init__.py
@@ -27,3 +27,53 @@ def notification_center():
 
     return PloneNotificationCenter(
         dispatchers=[PloneNotificationMailer(), BadgeIconDispatcher()])
+
+
+ACTIVITY_TRANSLATIONS = {
+    'task-added': _('task-added', default=u'Task added'),
+    'task-transition-cancelled-open': _(
+        'task-transition-cancelled-open', default=u'Task reopend'),
+    'task-transition-delegate': _(
+        'task-transition-delegate', default=u'Task delegated'),
+    'task-transition-in-progress-resolved': _(
+        'task-transition-in-progress-resolved', default=u'Task resolved'),
+    'task-transition-in-progress-tested-and-closed': _(
+        'task-transition-in-progress-tested-and-closed',
+        default=u'Task closed'),
+    'task-transition-modify-deadline': _(
+        'task-transition-modify-deadline', default=u'Task deadline modified'),
+    'task-transition-open-cancelled': _(
+        'task-transition-open-cancelled', default=u'Task cancelled'),
+    'task-transition-open-in-progress': _(
+        'task-transition-open-in-progress', default=u'Task accepted'),
+    'task-transition-open-rejected': _(
+        'task-transition-open-rejected', default=u'Task rejected'),
+    'task-transition-open-resolved': _(
+        'task-transition-open-resolved', default=u'Task resolved'),
+    'task-transition-open-tested-and-closed': _(
+        'task-transition-open-tested-and-closed', default=u'Task closed'),
+    'task-commented': _('task-commented', default=u'Task commented'),
+    'task-transition-reassign': _(
+        'task-transition-reassign', default=u'Task reassign'),
+    'task-transition-rejected-open': _(
+        'task-transition-rejected-open', default=u'Task reopened'),
+    'task-transition-resolved-in-progress': _(
+        'task-transition-resolved-in-progress', default=u'Task revision wanted'),
+    'task-transition-resolved-tested-and-closed': _(
+        'task-transition-resolved-tested-and-closed', default=u'Task closed'),
+    'forwarding-added':_(
+        'forwarding-added', default=u'Forwarding added'),
+    'forwarding-transition-accept': _(
+        'forwarding-transition-accept', default=u'Forwarding accepted'),
+    'forwarding-transition-assign-to-dossier': _(
+        'forwarding-transition-assign-to-dossier',
+        default=u'Forwarding assigned to dossier'),
+    'forwarding-transition-close': _('forwarding-transition-close', default=u'Forwarding closed'),
+    'forwarding-transition-reassign': _(
+        'forwarding-transition-reassign', default=u'Forwarding reassigned'),
+    'forwarding-transition-reassign-refused': _(
+        'forwarding-transition-reassign-refused',
+        default=u'Forwarding reassigned and refused'),
+    'forwarding-transition-refuse': _(
+        'forwarding-transition-refuse', default=u'Forwarding refused')
+}

--- a/opengever/activity/badge.py
+++ b/opengever/activity/badge.py
@@ -3,6 +3,7 @@ from opengever.activity.dispatcher import NotificationDispatcher
 
 class BadgeIconDispatcher(NotificationDispatcher):
 
+    _id = 'badge'
     roles_key = 'badge_notification_roles'
 
     def dispatch_notification(self, notification):

--- a/opengever/activity/browser/configure.zcml
+++ b/opengever/activity/browser/configure.zcml
@@ -32,15 +32,6 @@
 
   <browser:page
       for="Products.CMFPlone.interfaces.IPloneSiteRoot"
-      name="notification-settings-form"
-      class=".settings.NotificationSettingsForm"
-      permission="zope2.View"
-      template="templates/settings.pt"
-      allowed_attributes="get_activities"
-      />
-
-  <browser:page
-      for="Products.CMFPlone.interfaces.IPloneSiteRoot"
       name="notification-settings"
       class=".settings.NotificationSettings"
       permission="zope2.View"

--- a/opengever/activity/browser/configure.zcml
+++ b/opengever/activity/browser/configure.zcml
@@ -30,6 +30,23 @@
       permission="zope2.View"
       />
 
+  <browser:page
+      for="Products.CMFPlone.interfaces.IPloneSiteRoot"
+      name="notification-settings-form"
+      class=".settings.NotificationSettingsForm"
+      permission="zope2.View"
+      template="templates/settings.pt"
+      allowed_attributes="get_activities"
+      />
+
+  <browser:page
+      for="Products.CMFPlone.interfaces.IPloneSiteRoot"
+      name="notification-settings"
+      class=".settings.NotificationSettings"
+      permission="zope2.View"
+      allowed_attributes="list save reset"
+      />
+
   <adapter factory=".listing.NotificationTableSource" />
 
 </configure>

--- a/opengever/activity/browser/resources/settings.js
+++ b/opengever/activity/browser/resources/settings.js
@@ -54,7 +54,9 @@
           activities[activity.kind] = new SettingRow(activity);
         });
       }
-      return this.template({ activities: Object.values(activities), translations: data.translations });
+
+      var values = Object.keys(activities).map(function(e) { return activities[e] })
+      return this.template({ activities: values, translations: data.translations });
     };
 
     this.save_setting = function(target, event) {

--- a/opengever/activity/browser/resources/settings.js
+++ b/opengever/activity/browser/resources/settings.js
@@ -1,0 +1,147 @@
+(function(global, $, Controller, EditboxController, Pin, HBS) {
+
+  "use strict";
+
+  HBS.registerHelper({
+    or: function (v1, v2) {return v1 || v2;}
+  });
+
+  HBS.registerHelper('equals', function(arg1, arg2, options) {
+    return (arg1 === arg2) ? options.fn(this) : options.inverse(this);
+  });
+
+  HBS.registerHelper('translate', function(messageString, options) {
+    return options.data.root.translations[messageString];
+  });
+
+  function SettingRow(data) {
+    this.kind = data.kind;
+    this.type_id = data.type_id;
+    this.kind_title = data.kind_title;
+    this.css_class = data.css_class;
+    this.mail = data.mail;
+    this.badge = data.badge;
+    this.setting_type = data.setting_type;
+    this.changed = false;
+  }
+
+
+  function SettingsFormController(options) {
+    global.Controller.call(
+      this,
+      $('#settingsForm').html(),
+      $('#notification-settings-form'));
+
+    this.fetch = function(){
+      return $.get($('#notification-settings-form').data('list-url'));
+    };
+
+    var activities;
+
+    this.render = function(data) {
+      if (activities) {
+        // Rendering after update
+        data.activities.forEach(function(activity) {
+          if (!activities[activity.kind].changed) {
+            activities[activity.kind] = new SettingRow(activity);
+          }
+        });
+      } else {
+        // Initial rendering
+        activities = {};
+
+        data.activities.forEach(function(activity) {
+          activities[activity.kind] = new SettingRow(activity);
+        });
+      }
+      return this.template({ activities: Object.values(activities), translations: data.translations });
+    };
+
+    this.save_setting = function(target, event) {
+      var row = target.parents('tr');
+      var mail = row.find("ul.mail input:checkbox:checked").map(function(){ return $(this).val(); }).get();
+      var badge = row.find("ul.badge input:checkbox:checked").map(function(){ return $(this).val(); }).get();
+
+      return this.request($('#notification-settings-form').data('save-url'), {
+        method: "POST",
+        data: { kind: row.data('kind'),
+                mail: JSON.stringify(mail),
+                badge: JSON.stringify(badge)}
+      }).done(function() {
+        activities[row.data('kind')].changed = false;
+      });
+    };
+
+    this.reset_setting = function(target, event){
+      var row = target.parents('tr');
+      var kind = row.data('kind');
+      return this.request($('#notification-settings-form').data('reset-url'), {
+        method: "POST", data: {kind: kind}
+      }).done(function(){
+        activities[row.data('kind')].changed = false;
+      });
+    };
+
+    this.cancel_setting = function(target, event){
+      var row = target.parents('tr');
+      activities[row.data('kind')].changed = false;
+    };
+
+
+    this.track_settings_changes = function(target) {
+      var row = activities[target.parents('tr').data().kind];
+
+      row.changed = true;
+      var name = target.attr('name');
+      var value = target.val();
+
+      row[name][value] = target.prop('checked');
+      this.refresh();
+    };
+
+    this.events = [
+      {
+        method: "click",
+        target: ".save-setting",
+        callback: this.save_setting,
+        options: {
+          update: true
+        }
+      },
+      {
+        method: "click",
+        target: ".reset-setting",
+        callback: this.reset_setting,
+        options: {
+          update: true
+        }
+      },
+      {
+        method: "click",
+        target: ".cancel-setting",
+        callback: this.cancel_setting,
+        options: {
+          update: true
+        }
+      },
+
+      {
+        method: "change",
+        target: ".settings-trigger",
+        callback: this.track_settings_changes
+      }
+    ];
+
+    this.init();
+
+  }
+
+  $(function() {
+
+    if($("#notification-settings-form").length) {
+      var settingsFormController = new SettingsFormController();
+    }
+
+  });
+
+}(window, window.jQuery, window.Controller, window.EditboxController, window.Pin, window.Handlebars));

--- a/opengever/activity/browser/settings.py
+++ b/opengever/activity/browser/settings.py
@@ -12,6 +12,7 @@ from opengever.task.response_description import ResponseDescription
 from path import Path
 from plone import api
 from Products.Five import BrowserView
+from zope.browserpage.viewpagetemplatefile import ViewPageTemplateFile
 from zope.i18n import translate
 import json
 
@@ -174,6 +175,11 @@ class NotificationSettingsForm(BrowserView):
 
     Frontend functionality implemented in setting.js.
     """
+
+    template = ViewPageTemplateFile('templates/settings.pt')
+
+    def __call__(self):
+        return self.template()
 
     def render_form_template(self):
         return prepare_handlebars_template(

--- a/opengever/activity/browser/settings.py
+++ b/opengever/activity/browser/settings.py
@@ -1,0 +1,199 @@
+from opengever.activity import _
+from opengever.activity import ACTIVITY_TRANSLATIONS
+from opengever.activity import notification_center
+from opengever.activity.model.settings import NotificationDefault
+from opengever.activity.model.settings import NotificationSetting
+from opengever.activity.roles import TASK_ISSUER_ROLE
+from opengever.activity.roles import TASK_RESPONSIBLE_ROLE
+from opengever.base.handlebars import prepare_handlebars_template
+from opengever.base.model import create_session
+from opengever.base.response import JSONResponse
+from opengever.task.response_description import ResponseDescription
+from path import Path
+from plone import api
+from Products.Five import BrowserView
+from zope.i18n import translate
+import json
+
+
+TEMPLATES_DIR = Path(__file__).joinpath('..', 'templates').abspath()
+
+
+# The following list contains all necessary informations about the activity
+# groups which should be exposed in the notification settings form.
+ACTIVITY_GROUPS = [
+    {'id': 'task',
+     'roles': [TASK_ISSUER_ROLE, TASK_RESPONSIBLE_ROLE],
+     'activities': [
+         'task-added',
+         'task-transition-cancelled-open',
+         'task-transition-delegate',
+         'task-transition-in-progress-resolved',
+         'task-transition-in-progress-tested-and-closed',
+         'task-transition-modify-deadline',
+         'task-transition-open-cancelled',
+         'task-transition-open-in-progress',
+         'task-transition-open-rejected',
+         'task-transition-open-resolved',
+         'task-transition-open-tested-and-closed',
+         'task-commented',
+         'task-transition-reassign',
+         'task-transition-rejected-open',
+         'task-transition-resolved-in-progress',
+         'task-transition-resolved-tested-and-closed'
+     ]},
+
+    {'id': 'forwarding',
+     'roles': [TASK_ISSUER_ROLE, TASK_RESPONSIBLE_ROLE],
+     'activities': [
+         'forwarding-added',
+         'forwarding-transition-accept',
+         'forwarding-transition-assign-to-dossier',
+         'forwarding-transition-close',
+         'forwarding-transition-reassign',
+         'forwarding-transition-reassign-refused',
+         'forwarding-transition-refuse']
+     }
+]
+
+
+class NotificationSettings(BrowserView):
+    """Settings-form endpoints.
+    """
+
+    user_settings = None
+    defaults = None
+
+    def save(self):
+        """Save setting change
+        """
+        kind = self.request.form['kind']
+        mail = json.loads(self.request.form['mail'])
+        badge = json.loads(self.request.form['badge'])
+
+        # todo check roles before save
+        setting = self.get_or_create_setting(kind)
+        setting.mail_notification_roles = mail
+        setting.badge_notification_roles = badge
+
+        return JSONResponse(self.request).proceed().dump()
+
+    def reset(self):
+        """Reset a personal setting
+        """
+        kind = self.request.form['kind']
+        setting = self.get_setting(kind)
+        create_session().delete(setting)
+        return JSONResponse(self.request).proceed().dump()
+
+    def list(self):
+        """Returns settings for the current user.
+        """
+        activities = []
+        for group in ACTIVITY_GROUPS:
+            for kind in group.get('activities'):
+                kind_title = translate(
+                    ACTIVITY_TRANSLATIONS[kind], context=self.request)
+
+                item = {'kind_title': kind_title,
+                        'edit_mode': True,
+                        'css_class': ResponseDescription.get(transition=kind).css_class,
+                        'kind': kind,
+                        'type_id': group.get('id')}
+
+                activities.append(
+                    self.add_values(kind, item, group.get('roles')))
+
+        return JSONResponse(self.request).data(
+            activities=activities,
+            translations=self.get_role_translations()).dump()
+
+    def get_role_translations(self):
+        roles = {}
+        for group in ACTIVITY_GROUPS:
+            for role in group.get('roles'):
+                if role in roles:
+                    continue
+
+                roles[role] = translate(
+                    role, domain='opengever.activity', context=self.request)
+
+        return roles
+
+    def dispatchers(self):
+        return notification_center().dispatchers
+
+    def get_user_settings(self):
+        userid = api.user.get_current().getId()
+        if not self.user_settings:
+            self.user_settings = {
+                setting.kind: setting for setting
+                in NotificationSetting.query.filter_by(userid=userid)}
+
+        return self.user_settings
+
+    def get_defaults(self):
+        if not self.defaults:
+            self.defaults = {default.kind: default
+                             for default in NotificationDefault.query}
+
+        return self.defaults
+
+    def get_setting(self, kind):
+        userid = api.user.get_current().getId()
+        return NotificationSetting.query.filter_by(
+            userid=userid, kind=kind).first()
+
+    def get_or_create_setting(self, kind):
+        setting = self.get_setting(kind)
+        if not setting:
+            setting = NotificationSetting(
+                kind=kind, userid=api.user.get_current().getId())
+            create_session().add(setting)
+
+        return setting
+
+    def add_values(self, kind, item, roles):
+        setting = self.get_user_settings().get(kind)
+
+        if not setting:
+            item['setting_type'] = 'default'
+            setting = self.get_defaults()[kind]
+        else:
+            item['setting_type'] = 'personal'
+
+        for dispatcher in self.dispatchers():
+            values = getattr(setting, dispatcher.roles_key)
+            item[dispatcher._id] = {role: bool(role in values) for role in roles}
+
+        return item
+
+
+class NotificationSettingsForm(BrowserView):
+    """Person notification settings form.
+
+    Frontend functionality implemented in setting.js.
+    """
+
+    def render_form_template(self):
+        return prepare_handlebars_template(
+            TEMPLATES_DIR.joinpath('settings-form.html'),
+            translations=[
+                _('label_activity', default=u'Activity'),
+                _('label_badge', default=u'Badge'),
+                _('label_mail', default=u'Mail'),
+                _('btn_save', default=u'Save'),
+                _('btn_cancel', default=u'Cancel'),
+                _('btn_reset', default=u'Reset')])
+
+    def list_url(self):
+        return '{}/notification-settings/list'.format(
+            api.portal.get().absolute_url())
+
+    def save_url(self):
+        return '{}/notification-settings/save'.format(
+            api.portal.get().absolute_url())
+
+    def reset_url(self):
+        return '{}/notification-settings/reset'.format(
+            api.portal.get().absolute_url())

--- a/opengever/activity/browser/templates/settings-form.html
+++ b/opengever/activity/browser/templates/settings-form.html
@@ -1,0 +1,61 @@
+<script id="settingsForm" type="text/x-handlebars-template">
+
+  <table class="listing notifications-settings-form">
+    <thead>
+      <tr>
+        <th>%(label_activity)s</th>
+        <th><span class="badge-title">%(label_badge)s</span></th>
+        <th><span class="mail-title">%(label_mail)s</span></th>
+        <th class="actions-column"></th>
+      </tr>
+    </thead>
+
+    {{#each activities}}
+
+    <tr class="{{#if changed}}settings-changed{{/if}} {{setting_type}}" data-kind="{{kind}}">
+      <td class="notification-settings-kind">
+        <span class="{{css_class}}">{{kind_title}}</span>
+      </td>
+
+      <td>
+        <ul class="badge" >
+          {{#each badge}}
+          <li>
+            {{#if this}}
+              <input type="checkbox" class="settings-trigger" name="badge" id="{{../kind}}-badge-{{@key}}" value="{{@key}}" checked="checked"/>
+              {{else}}
+              <input type="checkbox" class="settings-trigger" name="badge" id="{{../kind}}-badge-{{@key}}" value="{{@key}}" />
+              {{/if}}
+              <label for="{{../kind}}-badge-{{@key}}">{{translate @key}}</label>
+            </li>
+          {{/each}}
+        </ul>
+      </td>
+
+      <td>
+        <ul class="mail" >
+          {{#each mail}}
+          <li>
+            {{#if this}}
+            <input type="checkbox" class="settings-trigger" name="mail" id="{{../kind}}-mail-{{@key}}" value="{{@key}}" checked="checked"/>
+            {{else}}
+            <input type="checkbox" class="settings-trigger" name="mail" id="{{../kind}}-mail-{{@key}}" value="{{@key}}" />
+            {{/if}}
+            <label for="{{../kind}}-mail-{{@key}}">{{translate @key}}</label>
+          </li>
+          {{/each}}
+        </ul>
+      </td>
+
+      <td>
+        <a href="" class="action save-setting">%(btn_save)s</a>
+        <a href="" class="action cancel-setting">%(btn_cancel)s</a>
+        {{#equals setting_type "personal"}}
+        <a href="" class="action reset-setting">%(btn_reset)s</a>
+        {{/equals}}
+
+      </td>
+    </tr>
+    {{/each}}
+  </table>
+</script>

--- a/opengever/activity/browser/templates/settings.pt
+++ b/opengever/activity/browser/templates/settings.pt
@@ -16,7 +16,8 @@
   </metal:title>
 
   <metal:override fill-slot="top_slot"
-                  tal:define="disable_column_one python:request.set('disable_plone.leftcolumn',1);"/>
+                  tal:define="portlet python:request.set('disable_plone.leftcolumn',1);
+                              dummy python:request.set('disable_border',1)" />
 
   <metal:content-core fill-slot="content-core">
     <metal:content-core define-macro="content-core"

--- a/opengever/activity/browser/templates/settings.pt
+++ b/opengever/activity/browser/templates/settings.pt
@@ -3,7 +3,7 @@
       xmlns:metal="http://xml.zope.org/namespaces/metal"
       xmlns:i18n="http://xml.zope.org/namespaces/i18n"
       lang="en"
-      metal:use-macro="here/main_template/macros/master"
+      metal:use-macro="context/main_template/macros/master"
       i18n:domain="opengever.activity">
 
   <metal:title metal:fill-slot="content-title">
@@ -15,19 +15,12 @@
     </div>
   </metal:title>
 
+  <metal:override fill-slot="top_slot"
+                  tal:define="disable_column_one python:request.set('disable_plone.leftcolumn',1);"/>
+
   <metal:content-core fill-slot="content-core">
     <metal:content-core define-macro="content-core"
                         tal:define="toLocalizedTime nocall:context/@@plone/toLocalizedTime">
-
-      <div class="notification-settings-description">
-        <p i18n:translate="help_notification_settings_form">
-          The form below shows the currently "" notification rules and provide the possibility to manage on which activity in which roles over which channel you want get informed.
-        </p>
-
-        <p i18n:translate="warning_own_activities_ignored">
-          Notifications about activities which has been created by your own are ignored and will not be delivered.
-        </p>
-      </div>
 
       <div id="notification-settings-form"
            tal:attributes="data-list-url view/list_url;

--- a/opengever/activity/browser/templates/settings.pt
+++ b/opengever/activity/browser/templates/settings.pt
@@ -1,0 +1,47 @@
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en"
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      xmlns:metal="http://xml.zope.org/namespaces/metal"
+      xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+      lang="en"
+      metal:use-macro="here/main_template/macros/master"
+      i18n:domain="opengever.activity">
+
+  <metal:title metal:fill-slot="content-title">
+    <metal:use use-macro="context/@@gever-macros/js_default_error_messages" />
+    <div id="tabbedview-header">
+      <h1 class="documentFirstHeading" i18n:translate="label_notification_settings">
+        Notification settings
+      </h1>
+    </div>
+  </metal:title>
+
+  <metal:content-core fill-slot="content-core">
+    <metal:content-core define-macro="content-core"
+                        tal:define="toLocalizedTime nocall:context/@@plone/toLocalizedTime">
+
+      <div class="notification-settings-description">
+        <p i18n:translate="help_notification_settings_form">
+          The form below shows the currently "" notification rules and provide the possibility to manage on which activity in which roles over which channel you want get informed.
+        </p>
+
+        <p i18n:translate="warning_own_activities_ignored">
+          Notifications about activities which has been created by your own are ignored and will not be delivered.
+        </p>
+      </div>
+
+      <div id="notification-settings-form"
+           tal:attributes="data-list-url view/list_url;
+                           data-save-url view/save_url;
+                           data-reset-url view/reset_url">
+
+        <tbody>
+          <tal:block tal:replace="structure view/render_form_template"></tal:block>
+        </tbody>
+
+        <div class="visualClear"><!----></div>
+      </div>
+
+    </metal:content-core>
+  </metal:content-core>
+
+</html>

--- a/opengever/activity/center.py
+++ b/opengever/activity/center.py
@@ -3,9 +3,9 @@ from opengever.activity.model import Notification
 from opengever.activity.model import Resource
 from opengever.activity.model import Subscription
 from opengever.activity.model import Watcher
-from opengever.activity.model.subscription import TASK_ISSUER_ROLE
-from opengever.activity.model.subscription import TASK_RESPONSIBLE_ROLE
-from opengever.activity.model.subscription import WATCHER_ROLE
+from opengever.activity.roles import TASK_ISSUER_ROLE
+from opengever.activity.roles import TASK_RESPONSIBLE_ROLE
+from opengever.activity.roles import WATCHER_ROLE
 from opengever.base.model import create_session
 from opengever.base.oguid import Oguid
 from plone import api

--- a/opengever/activity/hooks.py
+++ b/opengever/activity/hooks.py
@@ -1,6 +1,6 @@
 from opengever.activity.model import NotificationDefault
-from opengever.activity.model.subscription import TASK_ISSUER_ROLE
-from opengever.activity.model.subscription import TASK_RESPONSIBLE_ROLE
+from opengever.activity.roles import TASK_ISSUER_ROLE
+from opengever.activity.roles import TASK_RESPONSIBLE_ROLE
 from opengever.base.model import create_session
 from sqlalchemy.orm.exc import NoResultFound
 

--- a/opengever/activity/locales/de/LC_MESSAGES/opengever.activity.po
+++ b/opengever/activity/locales/de/LC_MESSAGES/opengever.activity.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-10-02 12:51+0000\n"
+"POT-Creation-Date: 2017-11-19 14:59+0000\n"
 "PO-Revision-Date: 2015-02-24 08:40+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,6 +16,26 @@ msgstr ""
 "Language-Name: English\n"
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
+
+#. Default: "Archivist"
+#: ./opengever/activity/roles.py
+msgid "archivist"
+msgstr "Archivar"
+
+#. Default: "Cancel"
+#: ./opengever/activity/browser/settings.py
+msgid "btn_cancel"
+msgstr "Abbrechen"
+
+#. Default: "Reset"
+#: ./opengever/activity/browser/settings.py
+msgid "btn_reset"
+msgstr "Auf Standard zurücksetzen"
+
+#. Default: "Save"
+#: ./opengever/activity/browser/settings.py
+msgid "btn_save"
+msgstr "Speichern"
 
 #. Default: "Actor"
 #: ./opengever/activity/browser/listing.py
@@ -37,15 +57,70 @@ msgstr "Titel"
 msgid "created"
 msgstr "Erstellt"
 
+#. Default: "Forwarding added"
+#: ./opengever/activity/__init__.py
+msgid "forwarding-added"
+msgstr "Weiterleitung hinzugefügt"
+
+#. Default: "Forwarding accepted"
+#: ./opengever/activity/__init__.py
+msgid "forwarding-transition-accept"
+msgstr "Weiterleitung akzeptiert"
+
+#. Default: "Forwarding assigned to dossier"
+#: ./opengever/activity/__init__.py
+msgid "forwarding-transition-assign-to-dossier"
+msgstr "Weiterleitung einem Dossier zugewiesen"
+
+#. Default: "Forwarding closed"
+#: ./opengever/activity/__init__.py
+msgid "forwarding-transition-close"
+msgstr "Weiterleitung abgeschlossen"
+
+#. Default: "Forwarding reassigned"
+#: ./opengever/activity/__init__.py
+msgid "forwarding-transition-reassign"
+msgstr "Weiterleitung neu zugewiesen"
+
+#. Default: "Forwarding reassigned and refused"
+#: ./opengever/activity/__init__.py
+msgid "forwarding-transition-reassign-refused"
+msgstr "Weiterleitung neu zugewiesen und abgelehnt"
+
+#. Default: "Forwarding refused"
+#: ./opengever/activity/__init__.py
+msgid "forwarding-transition-refuse"
+msgstr "Weiterleitung abgelehnt"
+
 #. Default: "Notifications"
 #: ./opengever/activity/viewlets/notification.pt
 msgid "heading_notifications"
 msgstr "Benachrichtigungen"
 
+#. Default: "Activity"
+#: ./opengever/activity/browser/settings.py
+msgid "label_activity"
+msgstr "Aktivität"
+
+#. Default: "Badge"
+#: ./opengever/activity/browser/settings.py
+msgid "label_badge"
+msgstr "Badge"
+
 #. Default: "Details:"
 #: ./opengever/activity/templates/notification.pt
 msgid "label_details"
 msgstr "Details:"
+
+#. Default: "Mail"
+#: ./opengever/activity/browser/settings.py
+msgid "label_mail"
+msgstr "Mail"
+
+#. Default: "Notification settings"
+#: ./opengever/activity/browser/templates/settings.pt
+msgid "label_notification_settings"
+msgstr "Benachrichtigungs-Einstellungen"
 
 #. Default: "All Notifications"
 #: ./opengever/activity/viewlets/notification.pt
@@ -57,8 +132,112 @@ msgstr "Alle Benachrichtigungen"
 msgid "msg_error_not_notified"
 msgstr "Während dem Erzeugen der Benachrichtigung ist ein Fehler aufgetreten. Die Benachrichtigung wurde deshalb nicht oder nur zum Teil ausgelöst."
 
+#. Default: "Records Manager"
+#: ./opengever/activity/roles.py
+msgid "records_manager"
+msgstr "Records Manager"
+
+#. Default: "Watcher"
+#: ./opengever/activity/roles.py
+msgid "regular_watcher"
+msgstr "Überwacher"
+
 #. Default: "GEVER Task"
 #: ./opengever/activity/mail.py
 msgid "subject_prefix"
 msgstr "GEVER Aufgabe"
 
+#. Default: "Task added"
+#: ./opengever/activity/__init__.py
+msgid "task-added"
+msgstr "Aufgabe hinzugefügt"
+
+#. Default: "Task commented"
+#: ./opengever/activity/__init__.py
+msgid "task-commented"
+msgstr "Aufgabe kommentiert"
+
+#. Default: "Task reopend"
+#: ./opengever/activity/__init__.py
+msgid "task-transition-cancelled-open"
+msgstr "Aufgabe wieder eröffnet"
+
+#. Default: "Task delegated"
+#: ./opengever/activity/__init__.py
+msgid "task-transition-delegate"
+msgstr "Aufgabe delegiert"
+
+#. Default: "Task resolved"
+#: ./opengever/activity/__init__.py
+msgid "task-transition-in-progress-resolved"
+msgstr "Aufgabe erledigt"
+
+#. Default: "Task closed"
+#: ./opengever/activity/__init__.py
+msgid "task-transition-in-progress-tested-and-closed"
+msgstr "Aufgabe abgeschlossen"
+
+#. Default: "Task deadline modified"
+#: ./opengever/activity/__init__.py
+msgid "task-transition-modify-deadline"
+msgstr "Aufgaben-Frist verändert"
+
+#. Default: "Task cancelled"
+#: ./opengever/activity/__init__.py
+msgid "task-transition-open-cancelled"
+msgstr "Aufgaben storniert"
+
+#. Default: "Task accepted"
+#: ./opengever/activity/__init__.py
+msgid "task-transition-open-in-progress"
+msgstr "Aufgabe akzeptiert"
+
+#. Default: "Task rejected"
+#: ./opengever/activity/__init__.py
+msgid "task-transition-open-rejected"
+msgstr "Aufgabe abgelehnt"
+
+#. Default: "Task resolved"
+#: ./opengever/activity/__init__.py
+msgid "task-transition-open-resolved"
+msgstr "Aufgabe erledigt"
+
+#. Default: "Task closed"
+#: ./opengever/activity/__init__.py
+msgid "task-transition-open-tested-and-closed"
+msgstr "Aufgabe abgeschlossen"
+
+#. Default: "Task reassign"
+#: ./opengever/activity/__init__.py
+msgid "task-transition-reassign"
+msgstr "Aufgabe neu zugewiesen"
+
+#. Default: "Task reopened"
+#: ./opengever/activity/__init__.py
+msgid "task-transition-rejected-open"
+msgstr "Aufgabe wieder eröffnet"
+
+#. Default: "Task revision wanted"
+#: ./opengever/activity/__init__.py
+msgid "task-transition-resolved-in-progress"
+msgstr "Aufgaben-Überarbeitung gefordert"
+
+#. Default: "Task closed"
+#: ./opengever/activity/__init__.py
+msgid "task-transition-resolved-tested-and-closed"
+msgstr "Aufgabe abgeschlossen"
+
+#. Default: "Task issuer"
+#: ./opengever/activity/roles.py
+msgid "task_issuer"
+msgstr "Auftraggeber"
+
+#. Default: "Task former responsible"
+#: ./opengever/activity/roles.py
+msgid "task_old_responsible"
+msgstr "Früherer Auftragnehmer"
+
+#. Default: "Task responsible"
+#: ./opengever/activity/roles.py
+msgid "task_responsible"
+msgstr "Auftragnehmer"

--- a/opengever/activity/locales/fr/LC_MESSAGES/opengever.activity.po
+++ b/opengever/activity/locales/fr/LC_MESSAGES/opengever.activity.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-10-02 12:51+0000\n"
+"POT-Creation-Date: 2017-11-19 14:59+0000\n"
 "PO-Revision-Date: 2016-08-10 04:42+0000\n"
 "Last-Translator: Philippe Gross <gross.philippe@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-activity/fr/>\n"
@@ -18,6 +18,26 @@ msgstr ""
 "Domain: DOMAIN\n"
 "Language: fr\n"
 "X-Generator: Weblate 2.7-dev\n"
+
+#. Default: "Archivist"
+#: ./opengever/activity/roles.py
+msgid "archivist"
+msgstr ""
+
+#. Default: "Cancel"
+#: ./opengever/activity/browser/settings.py
+msgid "btn_cancel"
+msgstr ""
+
+#. Default: "Reset"
+#: ./opengever/activity/browser/settings.py
+msgid "btn_reset"
+msgstr ""
+
+#. Default: "Save"
+#: ./opengever/activity/browser/settings.py
+msgid "btn_save"
+msgstr ""
 
 #. Default: "Actor"
 #: ./opengever/activity/browser/listing.py
@@ -39,15 +59,70 @@ msgstr "Titre"
 msgid "created"
 msgstr "Créé"
 
+#. Default: "Forwarding added"
+#: ./opengever/activity/__init__.py
+msgid "forwarding-added"
+msgstr ""
+
+#. Default: "Forwarding accepted"
+#: ./opengever/activity/__init__.py
+msgid "forwarding-transition-accept"
+msgstr ""
+
+#. Default: "Forwarding assigned to dossier"
+#: ./opengever/activity/__init__.py
+msgid "forwarding-transition-assign-to-dossier"
+msgstr ""
+
+#. Default: "Forwarding closed"
+#: ./opengever/activity/__init__.py
+msgid "forwarding-transition-close"
+msgstr ""
+
+#. Default: "Forwarding reassigned"
+#: ./opengever/activity/__init__.py
+msgid "forwarding-transition-reassign"
+msgstr ""
+
+#. Default: "Forwarding reassigned and refused"
+#: ./opengever/activity/__init__.py
+msgid "forwarding-transition-reassign-refused"
+msgstr ""
+
+#. Default: "Forwarding refused"
+#: ./opengever/activity/__init__.py
+msgid "forwarding-transition-refuse"
+msgstr ""
+
 #. Default: "Notifications"
 #: ./opengever/activity/viewlets/notification.pt
 msgid "heading_notifications"
 msgstr "Notifications"
 
+#. Default: "Activity"
+#: ./opengever/activity/browser/settings.py
+msgid "label_activity"
+msgstr ""
+
+#. Default: "Badge"
+#: ./opengever/activity/browser/settings.py
+msgid "label_badge"
+msgstr ""
+
 #. Default: "Details:"
 #: ./opengever/activity/templates/notification.pt
 msgid "label_details"
 msgstr "Détails:"
+
+#. Default: "Mail"
+#: ./opengever/activity/browser/settings.py
+msgid "label_mail"
+msgstr ""
+
+#. Default: "Notification settings"
+#: ./opengever/activity/browser/templates/settings.pt
+msgid "label_notification_settings"
+msgstr ""
 
 #. Default: "All Notifications"
 #: ./opengever/activity/viewlets/notification.pt
@@ -59,8 +134,112 @@ msgstr "Toutes les notifications"
 msgid "msg_error_not_notified"
 msgstr "Un problème a apparu pendant la création de la notification. La notification n’a pas pu être produite ou seulement partiellement."
 
+#. Default: "Records Manager"
+#: ./opengever/activity/roles.py
+msgid "records_manager"
+msgstr ""
+
+#. Default: "Watcher"
+#: ./opengever/activity/roles.py
+msgid "regular_watcher"
+msgstr ""
+
 #. Default: "GEVER Task"
 #: ./opengever/activity/mail.py
 msgid "subject_prefix"
 msgstr "Tâche GEVER"
 
+#. Default: "Task added"
+#: ./opengever/activity/__init__.py
+msgid "task-added"
+msgstr ""
+
+#. Default: "Task commented"
+#: ./opengever/activity/__init__.py
+msgid "task-commented"
+msgstr ""
+
+#. Default: "Task reopend"
+#: ./opengever/activity/__init__.py
+msgid "task-transition-cancelled-open"
+msgstr ""
+
+#. Default: "Task delegated"
+#: ./opengever/activity/__init__.py
+msgid "task-transition-delegate"
+msgstr ""
+
+#. Default: "Task resolved"
+#: ./opengever/activity/__init__.py
+msgid "task-transition-in-progress-resolved"
+msgstr ""
+
+#. Default: "Task closed"
+#: ./opengever/activity/__init__.py
+msgid "task-transition-in-progress-tested-and-closed"
+msgstr ""
+
+#. Default: "Task deadline modified"
+#: ./opengever/activity/__init__.py
+msgid "task-transition-modify-deadline"
+msgstr ""
+
+#. Default: "Task cancelled"
+#: ./opengever/activity/__init__.py
+msgid "task-transition-open-cancelled"
+msgstr ""
+
+#. Default: "Task accepted"
+#: ./opengever/activity/__init__.py
+msgid "task-transition-open-in-progress"
+msgstr ""
+
+#. Default: "Task rejected"
+#: ./opengever/activity/__init__.py
+msgid "task-transition-open-rejected"
+msgstr ""
+
+#. Default: "Task resolved"
+#: ./opengever/activity/__init__.py
+msgid "task-transition-open-resolved"
+msgstr ""
+
+#. Default: "Task closed"
+#: ./opengever/activity/__init__.py
+msgid "task-transition-open-tested-and-closed"
+msgstr ""
+
+#. Default: "Task reassign"
+#: ./opengever/activity/__init__.py
+msgid "task-transition-reassign"
+msgstr ""
+
+#. Default: "Task reopened"
+#: ./opengever/activity/__init__.py
+msgid "task-transition-rejected-open"
+msgstr ""
+
+#. Default: "Task revision wanted"
+#: ./opengever/activity/__init__.py
+msgid "task-transition-resolved-in-progress"
+msgstr ""
+
+#. Default: "Task closed"
+#: ./opengever/activity/__init__.py
+msgid "task-transition-resolved-tested-and-closed"
+msgstr ""
+
+#. Default: "Task issuer"
+#: ./opengever/activity/roles.py
+msgid "task_issuer"
+msgstr ""
+
+#. Default: "Task former responsible"
+#: ./opengever/activity/roles.py
+msgid "task_old_responsible"
+msgstr ""
+
+#. Default: "Task responsible"
+#: ./opengever/activity/roles.py
+msgid "task_responsible"
+msgstr ""

--- a/opengever/activity/locales/opengever.activity.pot
+++ b/opengever/activity/locales/opengever.activity.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-10-02 12:51+0000\n"
+"POT-Creation-Date: 2017-11-19 14:59+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,6 +16,26 @@ msgstr ""
 "Language-Name: English\n"
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: opengever.activity\n"
+
+#. Default: "Archivist"
+#: ./opengever/activity/roles.py
+msgid "archivist"
+msgstr ""
+
+#. Default: "Cancel"
+#: ./opengever/activity/browser/settings.py
+msgid "btn_cancel"
+msgstr ""
+
+#. Default: "Reset"
+#: ./opengever/activity/browser/settings.py
+msgid "btn_reset"
+msgstr ""
+
+#. Default: "Save"
+#: ./opengever/activity/browser/settings.py
+msgid "btn_save"
+msgstr ""
 
 #. Default: "Actor"
 #: ./opengever/activity/browser/listing.py
@@ -37,14 +57,69 @@ msgstr ""
 msgid "created"
 msgstr ""
 
+#. Default: "Forwarding added"
+#: ./opengever/activity/__init__.py
+msgid "forwarding-added"
+msgstr ""
+
+#. Default: "Forwarding accepted"
+#: ./opengever/activity/__init__.py
+msgid "forwarding-transition-accept"
+msgstr ""
+
+#. Default: "Forwarding assigned to dossier"
+#: ./opengever/activity/__init__.py
+msgid "forwarding-transition-assign-to-dossier"
+msgstr ""
+
+#. Default: "Forwarding closed"
+#: ./opengever/activity/__init__.py
+msgid "forwarding-transition-close"
+msgstr ""
+
+#. Default: "Forwarding reassigned"
+#: ./opengever/activity/__init__.py
+msgid "forwarding-transition-reassign"
+msgstr ""
+
+#. Default: "Forwarding reassigned and refused"
+#: ./opengever/activity/__init__.py
+msgid "forwarding-transition-reassign-refused"
+msgstr ""
+
+#. Default: "Forwarding refused"
+#: ./opengever/activity/__init__.py
+msgid "forwarding-transition-refuse"
+msgstr ""
+
 #. Default: "Notifications"
 #: ./opengever/activity/viewlets/notification.pt
 msgid "heading_notifications"
 msgstr ""
 
+#. Default: "Activity"
+#: ./opengever/activity/browser/settings.py
+msgid "label_activity"
+msgstr ""
+
+#. Default: "Badge"
+#: ./opengever/activity/browser/settings.py
+msgid "label_badge"
+msgstr ""
+
 #. Default: "Details:"
 #: ./opengever/activity/templates/notification.pt
 msgid "label_details"
+msgstr ""
+
+#. Default: "Mail"
+#: ./opengever/activity/browser/settings.py
+msgid "label_mail"
+msgstr ""
+
+#. Default: "Notification settings"
+#: ./opengever/activity/browser/templates/settings.pt
+msgid "label_notification_settings"
 msgstr ""
 
 #. Default: "All Notifications"
@@ -57,8 +132,112 @@ msgstr ""
 msgid "msg_error_not_notified"
 msgstr ""
 
+#. Default: "Records Manager"
+#: ./opengever/activity/roles.py
+msgid "records_manager"
+msgstr ""
+
+#. Default: "Watcher"
+#: ./opengever/activity/roles.py
+msgid "regular_watcher"
+msgstr ""
+
 #. Default: "GEVER Task"
 #: ./opengever/activity/mail.py
 msgid "subject_prefix"
 msgstr ""
 
+#. Default: "Task added"
+#: ./opengever/activity/__init__.py
+msgid "task-added"
+msgstr ""
+
+#. Default: "Task commented"
+#: ./opengever/activity/__init__.py
+msgid "task-commented"
+msgstr ""
+
+#. Default: "Task reopend"
+#: ./opengever/activity/__init__.py
+msgid "task-transition-cancelled-open"
+msgstr ""
+
+#. Default: "Task delegated"
+#: ./opengever/activity/__init__.py
+msgid "task-transition-delegate"
+msgstr ""
+
+#. Default: "Task resolved"
+#: ./opengever/activity/__init__.py
+msgid "task-transition-in-progress-resolved"
+msgstr ""
+
+#. Default: "Task closed"
+#: ./opengever/activity/__init__.py
+msgid "task-transition-in-progress-tested-and-closed"
+msgstr ""
+
+#. Default: "Task deadline modified"
+#: ./opengever/activity/__init__.py
+msgid "task-transition-modify-deadline"
+msgstr ""
+
+#. Default: "Task cancelled"
+#: ./opengever/activity/__init__.py
+msgid "task-transition-open-cancelled"
+msgstr ""
+
+#. Default: "Task accepted"
+#: ./opengever/activity/__init__.py
+msgid "task-transition-open-in-progress"
+msgstr ""
+
+#. Default: "Task rejected"
+#: ./opengever/activity/__init__.py
+msgid "task-transition-open-rejected"
+msgstr ""
+
+#. Default: "Task resolved"
+#: ./opengever/activity/__init__.py
+msgid "task-transition-open-resolved"
+msgstr ""
+
+#. Default: "Task closed"
+#: ./opengever/activity/__init__.py
+msgid "task-transition-open-tested-and-closed"
+msgstr ""
+
+#. Default: "Task reassign"
+#: ./opengever/activity/__init__.py
+msgid "task-transition-reassign"
+msgstr ""
+
+#. Default: "Task reopened"
+#: ./opengever/activity/__init__.py
+msgid "task-transition-rejected-open"
+msgstr ""
+
+#. Default: "Task revision wanted"
+#: ./opengever/activity/__init__.py
+msgid "task-transition-resolved-in-progress"
+msgstr ""
+
+#. Default: "Task closed"
+#: ./opengever/activity/__init__.py
+msgid "task-transition-resolved-tested-and-closed"
+msgstr ""
+
+#. Default: "Task issuer"
+#: ./opengever/activity/roles.py
+msgid "task_issuer"
+msgstr ""
+
+#. Default: "Task former responsible"
+#: ./opengever/activity/roles.py
+msgid "task_old_responsible"
+msgstr ""
+
+#. Default: "Task responsible"
+#: ./opengever/activity/roles.py
+msgid "task_responsible"
+msgstr ""

--- a/opengever/activity/mail.py
+++ b/opengever/activity/mail.py
@@ -22,6 +22,7 @@ class PloneNotificationMailer(NotificationDispatcher):
     the corresponding watcher.
     """
 
+    _id = 'mail'
     roles_key = 'mail_notification_roles'
 
     def __init__(self):

--- a/opengever/activity/model/subscription.py
+++ b/opengever/activity/model/subscription.py
@@ -6,13 +6,6 @@ from sqlalchemy import String
 from sqlalchemy.orm import relationship
 
 
-TASK_ISSUER_ROLE = 'task_issuer'
-TASK_RESPONSIBLE_ROLE = 'task_responsible'
-TASK_OLD_RESPONSIBLE_ROLE = 'task_old_responsible'
-DISPOSITION_RECORDS_MANAGER_ROLE = 'records_manager'
-DISPOSITION_ARCHIVIST_ROLE = 'archivist'
-WATCHER_ROLE = 'regular_watcher'
-
 
 class Subscription(Base):
     __tablename__ = 'subscriptions'

--- a/opengever/activity/roles.py
+++ b/opengever/activity/roles.py
@@ -1,0 +1,19 @@
+from zope.i18nmessageid import MessageFactory
+
+_ = MessageFactory("opengever.activity")
+
+
+TASK_ISSUER_ROLE = 'task_issuer'
+TASK_RESPONSIBLE_ROLE = 'task_responsible'
+TASK_OLD_RESPONSIBLE_ROLE = 'task_old_responsible'
+DISPOSITION_RECORDS_MANAGER_ROLE = 'records_manager'
+DISPOSITION_ARCHIVIST_ROLE = 'archivist'
+WATCHER_ROLE = 'regular_watcher'
+
+
+_('task_issuer', default=u"Task issuer")
+_('task_responsible', default=u"Task responsible")
+_('task_old_responsible', default=u"Task former responsible")
+_('records_manager', default=u"Records Manager")
+_('archivist', default=u"Archivist")
+_('regular_watcher', default=u"Watcher")

--- a/opengever/activity/tests/test_listing.py
+++ b/opengever/activity/tests/test_listing.py
@@ -5,7 +5,7 @@ from opengever.activity.badge import BadgeIconDispatcher
 from opengever.activity.center import NotificationCenter
 from opengever.activity.model.notification import Notification
 from opengever.activity.model.settings import NotificationDefault
-from opengever.activity.model.subscription import WATCHER_ROLE
+from opengever.activity.roles import WATCHER_ROLE
 from opengever.base.oguid import Oguid
 from opengever.testing import IntegrationTestCase
 from plone import api

--- a/opengever/activity/tests/test_model.py
+++ b/opengever/activity/tests/test_model.py
@@ -1,9 +1,9 @@
 from ftw.builder import Builder
 from ftw.builder import create
 from opengever.activity.model.notification import Notification
-from opengever.activity.model.subscription import TASK_ISSUER_ROLE
-from opengever.activity.model.subscription import TASK_RESPONSIBLE_ROLE
-from opengever.activity.model.subscription import WATCHER_ROLE
+from opengever.activity.roles import TASK_ISSUER_ROLE
+from opengever.activity.roles import TASK_RESPONSIBLE_ROLE
+from opengever.activity.roles import WATCHER_ROLE
 from opengever.activity.tests.base import ActivityTestCase
 from sqlalchemy.exc import IntegrityError
 import transaction

--- a/opengever/activity/tests/test_notification_center.py
+++ b/opengever/activity/tests/test_notification_center.py
@@ -6,9 +6,9 @@ from opengever.activity.mail import NotificationDispatcher
 from opengever.activity.model import Notification
 from opengever.activity.model import Resource
 from opengever.activity.model import Watcher
-from opengever.activity.model.subscription import TASK_ISSUER_ROLE
-from opengever.activity.model.subscription import TASK_RESPONSIBLE_ROLE
-from opengever.activity.model.subscription import WATCHER_ROLE
+from opengever.activity.roles import TASK_ISSUER_ROLE
+from opengever.activity.roles import TASK_RESPONSIBLE_ROLE
+from opengever.activity.roles import WATCHER_ROLE
 from opengever.activity.tests.base import ActivityTestCase
 from opengever.base.oguid import Oguid
 from sqlalchemy.exc import IntegrityError

--- a/opengever/activity/tests/test_settings.py
+++ b/opengever/activity/tests/test_settings.py
@@ -137,21 +137,3 @@ class TestResetSetting(IntegrationTestCase):
                      data={'kind': 'task-added'})
 
         self.assertEquals(0, query.count())
-
-
-class TestSettingsForm(IntegrationTestCase):
-
-    features = ('activity', )
-
-    @browsing
-    def test_endpoint_urls(self, browser):
-        self.login(self.regular_user, browser=browser)
-        browser.open(self.portal, view='notification-settings-form')
-
-        div = browser.css('#notification-settings-form').first
-        self.assertEquals('http://nohost/plone/notification-settings/list',
-                          div.get('data-list-url'))
-        self.assertEquals('http://nohost/plone/notification-settings/save',
-                          div.get('data-save-url'))
-        self.assertEquals('http://nohost/plone/notification-settings/reset',
-                          div.get('data-reset-url'))

--- a/opengever/activity/tests/test_settings.py
+++ b/opengever/activity/tests/test_settings.py
@@ -1,0 +1,157 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.testbrowser import browsing
+from opengever.activity.hooks import DEFAULT_SETTINGS
+from opengever.activity.model.settings import NotificationSetting
+from opengever.activity.roles import TASK_ISSUER_ROLE
+from opengever.activity.roles import TASK_RESPONSIBLE_ROLE
+from opengever.testing import IntegrationTestCase
+import json
+
+
+class TestListSettings(IntegrationTestCase):
+
+    features = ('activity', )
+
+    @browsing
+    def test_list_all_settings(self, browser):
+        self.login(self.regular_user, browser=browser)
+        browser.open(self.portal, view='notification-settings/list')
+
+        activities = browser.json.get('activities')
+        self.assertEquals(
+            [item.get('kind') for item in activities],
+            [item.get('kind') for item in DEFAULT_SETTINGS])
+
+        task_added = [item for item in activities if item.get('kind') == 'task-added'][0]
+        self.assertEquals({u'task_issuer': False, u'task_responsible': True},
+                          task_added['mail'])
+        self.assertEquals({u'task_issuer': False, u'task_responsible': False},
+                          task_added['badge'])
+        self.assertEquals('default', task_added['setting_type'])
+
+    @browsing
+    def test_list_returns_personal_setting_if_exists(self, browser):
+        create(Builder('notification_setting')
+               .having(kind='task-transition-open-in-progress',
+                       userid=self.regular_user.getId(),
+                       mail_notification_roles=[TASK_RESPONSIBLE_ROLE],
+                       badge_notification_roles=[TASK_ISSUER_ROLE,
+                                                 TASK_RESPONSIBLE_ROLE]))
+
+        self.login(self.regular_user, browser=browser)
+        browser.open(self.portal, view='notification-settings/list')
+
+        activities = browser.json.get('activities')
+        accept = [
+            item for item in activities
+            if item.get('kind') == 'task-transition-open-in-progress'][0]
+
+        self.assertEquals({u'task_issuer': False, u'task_responsible': True},
+                          accept['mail'])
+        self.assertEquals({u'task_issuer': True, u'task_responsible': True},
+                          accept['badge'])
+        self.assertEquals('personal', accept['setting_type'])
+
+
+class TestSaveSettings(IntegrationTestCase):
+
+    features = ('activity', )
+
+    data = {'kind': 'task-added',
+            'mail': json.dumps([TASK_RESPONSIBLE_ROLE, TASK_ISSUER_ROLE]),
+            'badge': json.dumps([TASK_ISSUER_ROLE])}
+
+    @browsing
+    def test_save_setting_raises_keyerror_when_parameter_is_missing(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        with browser.expect_http_error(503):
+            browser.open(
+                self.portal, view='notification-settings/save',
+                data={key: self.data[key] for key in self.data if key != 'kind'})
+
+        with browser.expect_http_error(503):
+            browser.open(
+                self.portal, view='notification-settings/save',
+                data={key: self.data[key] for key in self.data if key != 'mail'})
+
+        with browser.expect_http_error(503):
+            browser.open(
+                self.portal, view='notification-settings/save',
+                data={key: self.data[key] for key in self.data if key != 'badge'})
+
+    @browsing
+    def test_save_setting_adds_personal_setting(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        browser.open(self.portal, view='notification-settings/save', data=self.data)
+
+        settings = NotificationSetting.query.filter_by(userid=self.regular_user.getId()).all()
+        self.assertEquals(1, len(settings))
+
+        self.assertEquals('task-added', settings[0].kind)
+        self.assertEquals(frozenset([TASK_RESPONSIBLE_ROLE, TASK_ISSUER_ROLE]),
+                          settings[0].mail_notification_roles)
+        self.assertEquals(frozenset([TASK_ISSUER_ROLE]),
+                          settings[0].badge_notification_roles)
+
+    @browsing
+    def test_save_updates_personal_setting_when_exists(self, browser):
+        create(Builder('notification_setting')
+               .having(kind='task-added',
+                       userid=self.regular_user.getId(),
+                       mail_notification_roles=[],
+                       badge_notification_roles=[]))
+
+        self.login(self.regular_user, browser=browser)
+        browser.open(self.portal, view='notification-settings/save', data=self.data)
+
+        settings = NotificationSetting.query.filter_by(userid=self.regular_user.getId()).all()
+        self.assertEquals(1, len(settings))
+
+        self.assertEquals('task-added', settings[0].kind)
+        self.assertEquals(frozenset([TASK_RESPONSIBLE_ROLE, TASK_ISSUER_ROLE]),
+                          settings[0].mail_notification_roles)
+        self.assertEquals(frozenset([TASK_ISSUER_ROLE]),
+                          settings[0].badge_notification_roles)
+
+
+class TestResetSetting(IntegrationTestCase):
+
+    features = ('activity', )
+
+    @browsing
+    def test_save_updates_personal_setting_when_exists(self, browser):
+        create(Builder('notification_setting')
+               .having(kind='task-added',
+                       userid=self.regular_user.getId(),
+                       mail_notification_roles=[],
+                       badge_notification_roles=[]))
+
+        query = NotificationSetting.query.filter_by(userid=self.regular_user.getId())
+        self.assertEquals(1, query.count())
+
+        self.login(self.regular_user, browser=browser)
+        browser.open(self.portal, view='notification-settings/reset',
+                     data={'kind': 'task-added'})
+
+        self.assertEquals(0, query.count())
+
+
+class TestSettingsForm(IntegrationTestCase):
+
+    features = ('activity', )
+
+    @browsing
+    def test_endpoint_urls(self, browser):
+        self.login(self.regular_user, browser=browser)
+        browser.open(self.portal, view='notification-settings-form')
+
+        div = browser.css('#notification-settings-form').first
+        self.assertEquals('http://nohost/plone/notification-settings/list',
+                          div.get('data-list-url'))
+        self.assertEquals('http://nohost/plone/notification-settings/save',
+                          div.get('data-save-url'))
+        self.assertEquals('http://nohost/plone/notification-settings/reset',
+                          div.get('data-reset-url'))

--- a/opengever/base/browser/configure.zcml
+++ b/opengever/base/browser/configure.zcml
@@ -164,6 +164,14 @@
       class=".edit_public_trial.EditPublicTrialForm"
       />
 
+  <browser:page
+      for="plone.app.layout.navigation.interfaces.INavigationRoot"
+      name="personal-preferences"
+      class=".personalpreferences.PersonalPreferences"
+      permission="cmf.SetOwnProperties"
+      layer="opengever.base.interfaces.IOpengeverBaseLayer"
+      />
+
   <browser:viewlet
       name="exposator"
       manager="plone.app.layout.viewlets.interfaces.IPortalHeader"

--- a/opengever/base/browser/personalpreferences.py
+++ b/opengever/base/browser/personalpreferences.py
@@ -1,0 +1,9 @@
+from opengever.activity.browser.settings import NotificationSettingsForm
+
+
+class PersonalPreferences(NotificationSettingsForm):
+    """The personal preferences form, linked in the users personal menu.
+
+    The form currently contains only the NotificationSettingsForm, therefore
+    this view inherits the `NotificationSettingsForm`.
+    """

--- a/opengever/base/tests/test_personalpreferences.py
+++ b/opengever/base/tests/test_personalpreferences.py
@@ -1,0 +1,20 @@
+from ftw.testbrowser import browsing
+from opengever.testing import IntegrationTestCase
+
+
+class TestPersonalPreferencesForm(IntegrationTestCase):
+
+    features = ('activity', )
+
+    @browsing
+    def test_shows_notification_form(self, browser):
+        self.login(self.regular_user, browser=browser)
+        browser.open(self.portal, view='personal-preferences')
+
+        div = browser.css('#notification-settings-form').first
+        self.assertEquals('http://nohost/plone/notification-settings/list',
+                          div.get('data-list-url'))
+        self.assertEquals('http://nohost/plone/notification-settings/save',
+                          div.get('data-save-url'))
+        self.assertEquals('http://nohost/plone/notification-settings/reset',
+                          div.get('data-reset-url'))

--- a/opengever/core/profiles/default/actions.xml
+++ b/opengever/core/profiles/default/actions.xml
@@ -686,9 +686,9 @@
       <property name="icon_expr" />
       <property name="available_expr">python:member is not None</property>
       <property name="permissions">
-        <element value="View" />
+        <element value="Set own properties" />
       </property>
-      <property name="visible">False</property>
+      <property name="visible">True</property>
     </object>
 
     <object name="plone_setup" meta_type="CMF Action" i18n:domain="plone">

--- a/opengever/core/profiles/default/jsregistry.xml
+++ b/opengever/core/profiles/default/jsregistry.xml
@@ -114,6 +114,17 @@
       cacheable="True"
       compression="safe"
       cookable="True"
+      enabled="on"
+      expression=""
+      id="++resource++opengever.activity.resources/settings.js"
+      insert-after="++resource++opengever.activity.resources/notifications.js"
+      inline="False"
+      />
+
+  <javascript
+      cacheable="True"
+      compression="safe"
+      cookable="True"
       expression=""
       enabled="True"
       id="++resource++opengever.base/Controller.js"

--- a/opengever/core/upgrades/20171115102946_add_notification_settings_js/jsregistry.xml
+++ b/opengever/core/upgrades/20171115102946_add_notification_settings_js/jsregistry.xml
@@ -1,0 +1,14 @@
+<object name="portal_javascripts" meta_type="JavaScripts Registry">
+
+  <javascript
+      cacheable="True"
+      compression="safe"
+      cookable="True"
+      enabled="on"
+      expression=""
+      id="++resource++opengever.activity.resources/settings.js"
+      insert-after="++resource++opengever.activity.resources/notifications.js"
+      inline="False"
+      />
+
+</object>

--- a/opengever/core/upgrades/20171115102946_add_notification_settings_js/upgrade.py
+++ b/opengever/core/upgrades/20171115102946_add_notification_settings_js/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddNotificationSettingsJS(UpgradeStep):
+    """Add notification settings JS.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/core/upgrades/20171120165257_enable_personal_preferences_action/actions.xml
+++ b/opengever/core/upgrades/20171120165257_enable_personal_preferences_action/actions.xml
@@ -1,0 +1,22 @@
+<object xmlns:i18n="http://xml.zope.org/namespaces/i18n" name="portal_actions" meta_type="Plone Actions Tool">
+
+  <!-- ###################################################### /-->
+  <object name="user" meta_type="CMF Action Category">
+
+    <object name="preferences" meta_type="CMF Action" i18n:domain="plone">
+      <property name="title" i18n:translate="">Preferences</property>
+      <property name="description" i18n:translate="" />
+      <property name="url_expr">string:${globals_view/navigationRootUrl}/@@personal-preferences</property>
+      <property name="link_target" />
+      <property name="icon_expr" />
+      <property name="available_expr">python:member is not None</property>
+      <property name="permissions">
+        <element value="Set own properties" />
+      </property>
+      <property name="visible">True</property>
+    </object>
+
+  </object>
+
+
+</object>

--- a/opengever/core/upgrades/20171120165257_enable_personal_preferences_action/upgrade.py
+++ b/opengever/core/upgrades/20171120165257_enable_personal_preferences_action/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class EnablePersonalPreferencesAction(UpgradeStep):
+    """Enable personal-preferences action.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/disposition/disposition.py
+++ b/opengever/disposition/disposition.py
@@ -3,8 +3,8 @@ from Acquisition import aq_parent
 from collective import dexteritytextindexer
 from datetime import date
 from opengever.activity import notification_center
-from opengever.activity.model.subscription import DISPOSITION_ARCHIVIST_ROLE
-from opengever.activity.model.subscription import DISPOSITION_RECORDS_MANAGER_ROLE
+from opengever.activity.roles import DISPOSITION_ARCHIVIST_ROLE
+from opengever.activity.roles import DISPOSITION_RECORDS_MANAGER_ROLE
 from opengever.base.behaviors.classification import IClassification
 from opengever.base.behaviors.lifecycle import ILifeCycle
 from opengever.base.security import elevated_privileges

--- a/opengever/task/activities.py
+++ b/opengever/task/activities.py
@@ -1,5 +1,5 @@
 from opengever.activity.base import BaseActivity
-from opengever.activity.model.subscription import TASK_OLD_RESPONSIBLE_ROLE
+from opengever.activity.roles import TASK_OLD_RESPONSIBLE_ROLE
 from opengever.base.model import get_locale
 from opengever.ogds.base.actor import Actor
 from opengever.task import _

--- a/opengever/task/response_description.py
+++ b/opengever/task/response_description.py
@@ -364,6 +364,25 @@ class TaskCommented(ResponseDescription):
 ResponseDescription.add_description(TaskCommented)
 
 
+class TaskAdded(ResponseDescription):
+
+    transition = 'task-added'
+    css_class = 'created'
+
+
+ResponseDescription.add_description(TaskAdded)
+
+
+class ForwardingAdded(ResponseDescription):
+
+    transition = 'forwarding-added'
+    css_class = 'created'
+
+
+ResponseDescription.add_description(ForwardingAdded)
+
+
+
 class NullResponseDescription(ResponseDescription):
     """Fallback description for responses without any transition information.
     """

--- a/opengever/task/tests/test_activities.py
+++ b/opengever/task/tests/test_activities.py
@@ -7,9 +7,9 @@ from ftw.testing.mailing import Mailing
 from opengever.activity import notification_center
 from opengever.activity.hooks import insert_notification_defaults
 from opengever.activity.model import Activity
-from opengever.activity.model.subscription import TASK_ISSUER_ROLE
-from opengever.activity.model.subscription import TASK_RESPONSIBLE_ROLE
-from opengever.activity.model.subscription import WATCHER_ROLE
+from opengever.activity.roles import TASK_ISSUER_ROLE
+from opengever.activity.roles import TASK_RESPONSIBLE_ROLE
+from opengever.activity.roles import WATCHER_ROLE
 from opengever.core.testing import OPENGEVER_FUNCTIONAL_ACTIVITY_LAYER
 from opengever.task.browser.accept.utils import accept_task_with_successor
 from opengever.testing import FunctionalTestCase

--- a/opengever/testing/builders/activity.py
+++ b/opengever/testing/builders/activity.py
@@ -6,7 +6,7 @@ from opengever.activity.model import NotificationSetting
 from opengever.activity.model import Resource
 from opengever.activity.model import Subscription
 from opengever.activity.model import Watcher
-from opengever.activity.model.subscription import WATCHER_ROLE
+from opengever.activity.roles import WATCHER_ROLE
 from opengever.base.oguid import Oguid
 from opengever.ogds.models.tests.builders import SqlObjectBuilder
 from opengever.testing.builders.base import TEST_USER_ID


### PR DESCRIPTION
The form is implemented as a small JS form with a handlebars template.

![notification settings 2](https://user-images.githubusercontent.com/485755/32962504-04a78466-cbcd-11e7-9d28-4e453d16ef4b.gif)

Styling in an separate PR: https://github.com/4teamwork/plonetheme.teamraum/pull/601

Currently the Endpoints are not plone.REST endpoints. But I'll not change this in this PR, because I wont some testing feedback, as soon as possible. 

The NotificationSettingsForm is not directly registered in opengever.activity or available via a separate URL, instead the PersonalPreferences View inherits the `NotificationSettingsForm`. The reason for that workaround is that we plan that the personal-preferences view provides some more personal settings and the notification form will only be a part of that. But it makes no sense to build a "complex form inheritance" for a possible feature change.