### PR TITLE
Use localstorage for tracking expanded_uids instead of cookie.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -8,6 +8,7 @@ Changelog
 - Add missing default value for dossier protection fields. [elioschmutz]
 - Show filterlist also on empty tabbedview listings. [phgross]
 - Fix redirection when creating new sablon templates. [tarnap]
+- Use localstorage for tracking expanded tree uids instead of cookie. [Kevin Bieri]
 - SPV: Sort meetings by date. [tarnap]
 - SPV: Add concluded meetings to committee overview and reorder the blocks in the columns. [tarnap]
 - Update bumblebee checksum when modifying document doc properties. [deiferni]

--- a/opengever/portlets/tree/resources/tree.js
+++ b/opengever/portlets/tree/resources/tree.js
@@ -233,17 +233,14 @@ function Tree(nodes, config) {
 }
 
 
-ExpandStore = function(cookie_name, identifier_key) {
+ExpandStore = function(store_name, identifier_key) {
   function get() {
-    var cookie = $.cookie(cookie_name);
-    if (!cookie) {
-      return [];
-    }
-    return cookie.split(';');
+    var expanded = localStorage.getItem(store_name);
+    return expanded ? JSON.parse(expanded) : [];
   }
 
   function set(uids) {
-    $.cookie(cookie_name, uids.join(';'), {path: '/'});
+    return localStorage.setItem(store_name, JSON.stringify(uids));
   }
 
   function identifier(node) {


### PR DESCRIPTION
Closes https://github.com/4teamwork/opengever.core/issues/2830