### PR TITLE
Add field description for keyword fields

### DIFF
--- a/docs/schema-dumps/ftw.mail.mail.schema.json
+++ b/docs/schema-dumps/ftw.mail.mail.schema.json
@@ -63,7 +63,7 @@
         "keywords": {
             "type": "array",
             "title": "Schlagworte",
-            "description": "Schlagw\u00f6rter zur Umschreibung eines Dossiers. Nicht zu verwechseln mit der Ordnungsposition",
+            "description": "Schlagw\u00f6rter zur Umschreibung eines Dokuments. Nicht zu verwechseln mit der Ordnungsposition. <br>ACHTUNG: Beachten Sie bei der Verwendung von Schlagworten die Datenschutzvorgaben (z.B. keine Eigennamen).",
             "_zope_schema_type": "Tuple"
         },
         "foreign_reference": {

--- a/docs/schema-dumps/opengever.document.document.schema.json
+++ b/docs/schema-dumps/opengever.document.document.schema.json
@@ -76,7 +76,7 @@
         "keywords": {
             "type": "array",
             "title": "Schlagworte",
-            "description": "Schlagw\u00f6rter zur Umschreibung eines Dossiers. Nicht zu verwechseln mit der Ordnungsposition",
+            "description": "Schlagw\u00f6rter zur Umschreibung eines Dokuments. Nicht zu verwechseln mit der Ordnungsposition. <br>ACHTUNG: Beachten Sie bei der Verwendung von Schlagworten die Datenschutzvorgaben (z.B. keine Eigennamen).",
             "_zope_schema_type": "Tuple"
         },
         "foreign_reference": {

--- a/docs/schema-dumps/opengever.dossier.businesscasedossier.schema.json
+++ b/docs/schema-dumps/opengever.dossier.businesscasedossier.schema.json
@@ -19,7 +19,7 @@
         "keywords": {
             "type": "array",
             "title": "Schlagworte",
-            "description": "Schlagw\u00f6rter zur Umschreibung eines Dossiers. Nicht zu verwechseln mit der Ordnungsposition",
+            "description": "Schlagw\u00f6rter zur Umschreibung eines Dossiers. Nicht zu verwechseln mit der Ordnungsposition. <br>ACHTUNG: Beachten Sie bei der Verwendung von Schlagworten die Datenschutzvorgaben (z.B. keine Eigennamen).",
             "_zope_schema_type": "Tuple"
         },
         "start": {

--- a/opengever/bundle/schemas/documents.schema.json
+++ b/opengever/bundle/schemas/documents.schema.json
@@ -100,7 +100,7 @@
                         "array"
                     ],
                     "title": "Schlagworte",
-                    "description": "Schlagw\u00f6rter zur Umschreibung eines Dossiers. Nicht zu verwechseln mit der Ordnungsposition",
+                    "description": "Schlagw\u00f6rter zur Umschreibung eines Dokuments. Nicht zu verwechseln mit der Ordnungsposition. <br>ACHTUNG: Beachten Sie bei der Verwendung von Schlagworten die Datenschutzvorgaben (z.B. keine Eigennamen).",
                     "_zope_schema_type": "Tuple"
                 },
                 "foreign_reference": {

--- a/opengever/bundle/schemas/dossiers.schema.json
+++ b/opengever/bundle/schemas/dossiers.schema.json
@@ -31,7 +31,7 @@
                         "array"
                     ],
                     "title": "Schlagworte",
-                    "description": "Schlagw\u00f6rter zur Umschreibung eines Dossiers. Nicht zu verwechseln mit der Ordnungsposition",
+                    "description": "Schlagw\u00f6rter zur Umschreibung eines Dossiers. Nicht zu verwechseln mit der Ordnungsposition. <br>ACHTUNG: Beachten Sie bei der Verwendung von Schlagworten die Datenschutzvorgaben (z.B. keine Eigennamen).",
                     "_zope_schema_type": "Tuple"
                 },
                 "start": {

--- a/opengever/document/locales/de/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/de/LC_MESSAGES/opengever.document.po
@@ -248,7 +248,7 @@ msgstr "Referenz auf das entsprechende Dossier des Absenders"
 
 #: ./opengever/document/behaviors/metadata.py
 msgid "help_keywords"
-msgstr "Schlagwörter zur Umschreibung eines Dossiers. Nicht zu verwechseln mit der Ordnungsposition"
+msgstr "Schlagwörter zur Umschreibung eines Dokuments. Nicht zu verwechseln mit der Ordnungsposition. <br>ACHTUNG: Beachten Sie bei der Verwendung von Schlagworten die Datenschutzvorgaben (z.B. keine Eigennamen)."
 
 #. Default: ""
 #: ./opengever/document/behaviors/metadata.py

--- a/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
@@ -247,7 +247,7 @@ msgstr "Référence sur le dossier correspondant de l'expéditeur"
 
 #: ./opengever/document/behaviors/metadata.py
 msgid "help_keywords"
-msgstr "Mots-clés pour la description du dossier. Ne pas confondre avec le numéro de classement."
+msgstr "Mots-clés pour la description du document. Ne pas confondre avec le numéro de classement. <br>ATTENTION: Veuillez vous conformer aux directives de Protection des Données lors de l'utilisation de Mots-clés (par ex. pas de noms propres)."
 
 #: ./opengever/document/behaviors/metadata.py
 msgid "help_preserved_as_paper"

--- a/opengever/dossier/locales/de/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/de/LC_MESSAGES/opengever.dossier.po
@@ -390,7 +390,7 @@ msgstr "Geben Sie die vollständige Ablagenummer an."
 
 #: ./opengever/dossier/behaviors/dossier.py
 msgid "help_keywords"
-msgstr "Schlagwörter zur Umschreibung eines Dossiers. Nicht zu verwechseln mit der Ordnungsposition"
+msgstr "Schlagwörter zur Umschreibung eines Dossiers. Nicht zu verwechseln mit der Ordnungsposition. <br>ACHTUNG: Beachten Sie bei der Verwendung von Schlagworten die Datenschutzvorgaben (z.B. keine Eigennamen)."
 
 #: ./opengever/dossier/behaviors/dossier.py
 msgid "help_number_of_containers"

--- a/opengever/dossier/locales/fr/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/fr/LC_MESSAGES/opengever.dossier.po
@@ -388,7 +388,7 @@ msgstr "Saisir le numéro d'inventaire complet."
 
 #: ./opengever/dossier/behaviors/dossier.py
 msgid "help_keywords"
-msgstr "Mots-clés pour la description du dossier. Ne pas confondre avec le numéro de classement."
+msgstr "Mots-clés pour la description du dossier. Ne pas confondre avec le numéro de classement. <br>ATTENTION: Veuillez vous conformer aux directives de Protection des Données lors de l'utilisation de Mots-clés (par ex. pas de noms propres)."
 
 #: ./opengever/dossier/behaviors/dossier.py
 msgid "help_number_of_containers"


### PR DESCRIPTION
I added the new description of the keyword fields in the translations.
I included a line-break to make it more readable.
I also added a french translation.
![screen shot 2017-11-17 at 15 41 57](https://user-images.githubusercontent.com/7374243/32953452-86206c46-cbb0-11e7-85d8-9a1293335380.png)
![screen shot 2017-11-17 at 15 44 47](https://user-images.githubusercontent.com/7374243/32953455-86fd967a-cbb0-11e7-821f-a2aff932d1e6.png)

