### PR TITLE
Fix redirector after sablon template creation

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ---------------------
 
 - Show filterlist also on empty tabbedview listings. [phgross]
+- Fix redirection when creating new sablon templates. [tarnap]
 - SPV: Sort meetings by date. [tarnap]
 - SPV: Add concluded meetings to committee overview and reorder the blocks in the columns. [tarnap]
 - Fix syncing the submitted proposal title to sql. [deiferni]

--- a/opengever/core/profiles/default/types/opengever.meeting.sablontemplate.xml
+++ b/opengever/core/profiles/default/types/opengever.meeting.sablontemplate.xml
@@ -35,7 +35,7 @@
 
   <!-- View information -->
   <property name="default_view">tabbed_view</property>
-  <property name="immediate_view">tabbed_view</property>
+  <property name="immediate_view">../sablon-template-redirector</property>
   <property name="default_view_fallback">False</property>
   <property name="view_methods">
     <element value="view" />

--- a/opengever/core/upgrades/20171117151801_fix_redirector_after_salon_creation/types/opengever.meeting.sablontemplate.xml
+++ b/opengever/core/upgrades/20171117151801_fix_redirector_after_salon_creation/types/opengever.meeting.sablontemplate.xml
@@ -1,0 +1,3 @@
+<object xmlns:i18n="http://xml.zope.org/namespaces/i18n" name="opengever.meeting.sablontemplate" meta_type="Dexterity FTI" i18n:domain="opengever.core">
+  <property name="immediate_view">../sablon-template-redirector</property>
+</object>

--- a/opengever/core/upgrades/20171117151801_fix_redirector_after_salon_creation/upgrade.py
+++ b/opengever/core/upgrades/20171117151801_fix_redirector_after_salon_creation/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class FixRedirectorAfterSalonCreation(UpgradeStep):
+    """Fix redirector after salon creation.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/tabbedview/browser/configure.zcml
+++ b/opengever/tabbedview/browser/configure.zcml
@@ -14,6 +14,13 @@
       />
 
   <browser:page
+      for="plone.dexterity.interfaces.IDexterityContainer"
+      name="sablon-template-redirector"
+      class=".tabs.SablonTemplateRedirector"
+      permission="cmf.AddPortalContent"
+      />
+
+  <browser:page
       for="*"
       name="personal_overview"
       class=".personal_overview.PersonalOverview"

--- a/opengever/tabbedview/browser/tabs.py
+++ b/opengever/tabbedview/browser/tabs.py
@@ -386,3 +386,17 @@ class DocumentRedirector(BrowserView):
 
         return self.context.REQUEST.RESPONSE.redirect(
             self.context.absolute_url())
+
+
+class SablonTemplateRedirector(BrowserView):
+    """Redirector View is called after a Sablon Template is created,
+    """
+
+    def __call__(self):
+        referer = self.context.REQUEST.environ.get('HTTP_REFERER')
+        if '++add++opengever.meeting.sablontemplate' in referer:
+            return self.context.REQUEST.RESPONSE.redirect(
+                '%s#sablontemplates-proxy' % self.context.absolute_url())
+
+        return self.context.REQUEST.RESPONSE.redirect(
+            self.context.absolute_url())

--- a/opengever/tabbedview/tests/test_redirectors.py
+++ b/opengever/tabbedview/tests/test_redirectors.py
@@ -1,0 +1,20 @@
+from ftw.testbrowser import browsing
+from ftw.testbrowser.pages import statusmessages
+from opengever.testing import IntegrationTestCase
+
+
+class RedirectorTests(IntegrationTestCase):
+
+    @browsing
+    def test_sablon_template_redirector(self, browser):
+        self.login(self.administrator, browser)
+        browser.open(self.templates, view='++add++opengever.meeting.sablontemplate')
+
+        browser.fill({
+            'Title': u'Sablonv\xferlage',
+            'File': ('Sablon Template', 'sablon_template.docx', 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'),
+        }).save()
+        statusmessages.assert_no_error_messages()
+
+        self.assertEquals('http://nohost/plone/vorlagen#sablontemplates-proxy',
+                          browser.url)


### PR DESCRIPTION
Previously: ![sablom bug](https://user-images.githubusercontent.com/194114/32783319-99bbaa84-c94b-11e7-87b7-c9aa4d8702f0.gif)

And now: 
![sablom bug_fixed](https://user-images.githubusercontent.com/194114/32954710-276603ce-cbb4-11e7-83ac-3f1e0c98037c.gif)

Resolves #3609 