### PR TITLE
Show filterlist also on empty tabbedview listings.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2017.6.5 (unreleased)
 ---------------------
 
+- Show filterlist also on empty tabbedview listings. [phgross]
 - SPV: Sort meetings by date. [tarnap]
 - SPV: Add concluded meetings to committee overview and reorder the blocks in the columns. [tarnap]
 - Fix syncing the submitted proposal title to sql. [deiferni]

--- a/opengever/tabbedview/browser/base_tabs.py
+++ b/opengever/tabbedview/browser/base_tabs.py
@@ -186,6 +186,7 @@ class BaseCatalogListingTab(GeverTabMixin, CatalogListingView):
     """
 
     selection = ViewPageTemplateFile("selection_with_filters.pt")
+    template = ViewPageTemplateFile("generic_with_filters.pt")
 
     columns = ()
 


### PR DESCRIPTION
Use gever's own generic template (`generic_with_filters.pt`) for all
CatalogListings, which always shows the filterlist, even on empty listings. Closes #2819.