### PR TITLE
Add missing default value for dossier protection fields.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2017.6.5 (unreleased)
 ---------------------
 
+- Add missing default value for dossier protection fields. [elioschmutz]
 - Show filterlist also on empty tabbedview listings. [phgross]
 - SPV: Sort meetings by date. [tarnap]
 - SPV: Add concluded meetings to committee overview and reorder the blocks in the columns. [tarnap]

--- a/opengever/dossier/behaviors/protect_dossier.py
+++ b/opengever/dossier/behaviors/protect_dossier.py
@@ -62,6 +62,7 @@ class IProtectDossier(model.Schema):
             default=u'Choose users and groups which have only readable access to the dossier'),
         value_type=schema.Choice(source=AllUsersAndGroupsSourceBinder()),
         required=False,
+        default=[],
         missing_value=[],
         )
 
@@ -76,6 +77,7 @@ class IProtectDossier(model.Schema):
             default=u'Choose users and groups which have readable and writing access to the dossier'),
         value_type=schema.Choice(source=AllUsersAndGroupsSourceBinder()),
         required=False,
+        default=[],
         missing_value=[],
         )
 


### PR DESCRIPTION
This PR adds the proper default value for list fields in the IProtectDossier behavior schema.

closes #3624 