### PR TITLE
Set excel file name to dossier title when creating a disposition report.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -26,6 +26,7 @@ Changelog
 - Add the "Protect dossier" functionality to a dossier. [elioschmutz]
 - Make notification badge a separate channel. [phgross]
 - Allow administrator and owner to delete objects in private folders. [tarnap]
+- Set excel file name to dossier title when creating a disposition report. [njohner]
 - Exclude the latest version in the bumblebee versioning warning logic. [Rotonen]
 - SPV word: Remove fields which are intended for no word version. [tarnap]
 - Add personal notification settings support. [phgross]

--- a/opengever/disposition/browser/excel_export.py
+++ b/opengever/disposition/browser/excel_export.py
@@ -8,7 +8,9 @@ from opengever.base.reporter import XLSReporter
 from opengever.disposition import _
 from opengever.dossier import _ as dossier_mf
 from plone import api
+from plone.i18n.normalizer.interfaces import IIDNormalizer
 from Products.Five.browser import BrowserView
+from zope.component import getUtility
 from zope.globalrequest import getRequest
 from zope.i18n import translate
 
@@ -81,9 +83,19 @@ class DispositionExcelExport(BrowserView):
             'Content-Type',
             'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet')
         set_attachment_content_disposition(
-            self.request, "disposition_report.xlsx")
+            self.request, self.get_file_name())
 
         return data
+
+    def get_file_name(self):
+        """Returns the filename for the excel spreadsheet.
+        """
+        normalizer = getUtility(IIDNormalizer)
+        name_basis = _(u'appraisal_list', default=u'appraisal_list')
+        file_name = "{0}_{1}.xlsx".format(
+            translate(name_basis, context=self.request),
+            normalizer.normalize(self.context.title_or_id()))
+        return file_name
 
     def get_sheet_title(self):
         """Returns current disposition title. Crop it to 30 characters

--- a/opengever/disposition/locales/de/LC_MESSAGES/opengever.disposition.po
+++ b/opengever/disposition/locales/de/LC_MESSAGES/opengever.disposition.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-10-02 12:51+0000\n"
+"POT-Creation-Date: 2017-11-20 14:11+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -25,6 +25,11 @@ msgstr "Aktiv"
 #: ./opengever/disposition/browser/listing.py
 msgid "all"
 msgstr "Alle"
+
+#. Default: "appraisal_list"
+#: ./opengever/disposition/browser/excel_export.py
+msgid "appraisal_list"
+msgstr "bewertungsliste"
 
 #. Default: "Sequence Number"
 #: ./opengever/disposition/browser/listing.py
@@ -256,4 +261,3 @@ msgstr "Neues Angebot hinzugefügt durch ${user} im Mandanten ${admin_unit}"
 #: ./opengever/disposition/browser/removal_protocol.py
 msgid "title_removal_protocol"
 msgstr "Löschprotokoll zu ${disposition}"
-

--- a/opengever/disposition/locales/fr/LC_MESSAGES/opengever.disposition.po
+++ b/opengever/disposition/locales/fr/LC_MESSAGES/opengever.disposition.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-10-02 12:51+0000\n"
+"POT-Creation-Date: 2017-11-20 14:11+0000\n"
 "PO-Revision-Date: 2017-06-04 17:02+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-disposition/fr/>\n"
@@ -27,6 +27,11 @@ msgstr "Actif"
 #: ./opengever/disposition/browser/listing.py
 msgid "all"
 msgstr ""
+
+#. Default: "appraisal_list"
+#: ./opengever/disposition/browser/excel_export.py
+msgid "appraisal_list"
+msgstr "liste_evaluation"
 
 #. Default: "Sequence Number"
 #: ./opengever/disposition/browser/listing.py
@@ -258,4 +263,3 @@ msgstr ""
 #: ./opengever/disposition/browser/removal_protocol.py
 msgid "title_removal_protocol"
 msgstr ""
-

--- a/opengever/disposition/locales/opengever.disposition.pot
+++ b/opengever/disposition/locales/opengever.disposition.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-10-02 12:51+0000\n"
+"POT-Creation-Date: 2017-11-20 14:11+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -27,6 +27,11 @@ msgstr ""
 
 #: ./opengever/disposition/browser/listing.py
 msgid "all"
+msgstr ""
+
+#. Default: "appraisal_list"
+#: ./opengever/disposition/browser/excel_export.py
+msgid "appraisal_list"
 msgstr ""
 
 #. Default: "Sequence Number"
@@ -259,4 +264,3 @@ msgstr ""
 #: ./opengever/disposition/browser/removal_protocol.py
 msgid "title_removal_protocol"
 msgstr ""
-


### PR DESCRIPTION
Dossier title seemed to be the most appropriate basis for the report filename.

Should this kind of change be marked in the HISTORY.txt file?