### PR TITLE
Set cassation_date field permissions to manager

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2017.7.0 (unreleased)
 ---------------------
 
+- Make cassation_date field accessible only to manager. [njohner]
 - Add mimetype for MS OneNote. [phgross]
 - Correct field description for responsible person/entity when forwarding documents [njohner]
 - SPV-word: Fix renaming agenda items in meeting view. [tarnap]

--- a/opengever/base/behaviors/lifecycle.py
+++ b/opengever/base/behaviors/lifecycle.py
@@ -75,7 +75,8 @@ class ILifeCycle(model.Schema):
         required=True,
     )
 
-    form.write_permission(date_of_cassation='opengever.base.EditDateOfCassation')
+    form.write_permission(date_of_cassation='cmf.ManagePortal')
+    form.read_permission(date_of_cassation='cmf.ManagePortal')
     form.widget(date_of_cassation=DatePickerFieldWidget)
     date_of_cassation = schema.Date(
         title=_(u'label_dateofcassation', default=u'Date of cassation'),


### PR DESCRIPTION
The date is now visible only for managers.
Should this be done with lawgiver?

Manager:
<img width="259" alt="cassation_data_zopemaster" src="https://user-images.githubusercontent.com/7374243/33060817-dd5f8078-ce99-11e7-8bf6-bf617f9ce5d2.png">
Other User:
<img width="258" alt="cassation_date_hb" src="https://user-images.githubusercontent.com/7374243/33060820-de92f646-ce99-11e7-887a-469a8327edcb.png">
