### PR TITLE
Add group title option to the OGDS Synchronisation.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ---------------------
 
 - Add a tabbed view for Administrators and Managers to reporoot - repofolder - dossier for listing child dossiers with blocked local roles. [Rotonen]
+- Add group title option to the OGDS Synchronisation. [phgross]
 - Add missing default value for dossier protection fields. [elioschmutz]
 - Show filterlist also on empty tabbedview listings. [phgross]
 - Fix redirection when creating new sablon templates. [tarnap]

--- a/opengever/core/profiles/default/registry.xml
+++ b/opengever/core/profiles/default/registry.xml
@@ -3,6 +3,7 @@
   <!--migrated from opengever/ogds/base/profiles/default/registry.xml-->
   <records interface="opengever.ogds.base.interfaces.IAdminUnitConfiguration" />
 
+  <records interface="opengever.ogds.base.interfaces.IOGDSSyncConfiguration" />
 
   <!--migrated from opengever/base/profiles/default/registry.xml-->
   <records interface="opengever.base.interfaces.IBaseCustodyPeriods" />

--- a/opengever/core/upgrades/20171121100830_add_ogds_sync_configuration/registry.xml
+++ b/opengever/core/upgrades/20171121100830_add_ogds_sync_configuration/registry.xml
@@ -1,0 +1,3 @@
+<registry>
+  <records interface="opengever.ogds.base.interfaces.IOGDSSyncConfiguration" />
+</registry>

--- a/opengever/core/upgrades/20171121100830_add_ogds_sync_configuration/upgrade.py
+++ b/opengever/core/upgrades/20171121100830_add_ogds_sync_configuration/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddOGDSSyncConfiguration(UpgradeStep):
+    """Add OGDS sync configuration.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/ogds/base/interfaces.py
+++ b/opengever/ogds/base/interfaces.py
@@ -113,6 +113,14 @@ class IAdminUnitConfiguration(Interface):
     )
 
 
+class IOGDSSyncConfiguration(Interface):
+
+    group_title_ldap_attribute = schema.TextLine(
+        title=u'LDAP attribute name for the group title.',
+        description=u'If attribute is not set, group title will not be synced.'
+    )
+
+
 class ISyncStamp(Interface):
     """Adapter Inteface for the Import Stamp"""
 


### PR DESCRIPTION
Add an registry configuration option to define an LDAP attribute name, which should be used when syncing LDAP groups into the OGDS.

This allow us to use the group description as group title on some installations, thats a part of the OGIP 23 changes.