### PR TITLE
Improve workflow upgradesteps

### DIFF
--- a/opengever/dossier/upgrades/20170328131435_set_task_comment_permission/upgrade.py
+++ b/opengever/dossier/upgrades/20170328131435_set_task_comment_permission/upgrade.py
@@ -1,4 +1,6 @@
 from ftw.upgrade import UpgradeStep
+from opengever.dossier.behaviors.dossier import IDossierMarker
+from plone import api
 
 
 class SetTaskCommentPermission(UpgradeStep):
@@ -14,6 +16,11 @@ class SetTaskCommentPermission(UpgradeStep):
 
         # Also reindex security since, 20161125103319@opengever.dossier:default
         # probably indexed the security
-
         self.update_workflow_security(
-            ['opengever_dossier_workflow'], reindex_security=True)
+            ['opengever_dossier_workflow'],
+            reindex_security=self.has_offered_or_archived_dossiers())
+
+    def has_offered_or_archived_dossiers(self):
+        return bool(api.content.find(
+            object_provides=IDossierMarker,
+            review_state=['dossier-state-offered', 'dossier-state-archived']))


### PR DESCRIPTION
With #3642 three workflow and security reindexing upgradesteps has been merged togheter. But the check if a reindex_security is necessary at all has been dropped by mistake. This PR adds this check again (`has_offered_or_archived_dossiers`). See the diff from the previous PR for more details (https://github.com/4teamwork/opengever.core/pull/3642/commits/7aac61cd65d1a8063f49382daea8c80a9f7dffcc).