### PR TITLE
Change field description for forwardings responsible field

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2017.6.5 (unreleased)
 ---------------------
 
+- Correct field description for responsible person/entity when forwarding documents [njohner]
 - SPV-word: Fix renaming agenda items in meeting view. [tarnap]
 - Add a tabbed view for Administrators and Managers to reporoot - repofolder - dossier for listing child dossiers with blocked local roles. [Rotonen]
 - Add missing default value for dossier protection fields. [elioschmutz]

--- a/opengever/inbox/locales/de/LC_MESSAGES/opengever.inbox.po
+++ b/opengever/inbox/locales/de/LC_MESSAGES/opengever.inbox.po
@@ -57,7 +57,7 @@ msgstr "Diese Gruppe wird berechtigt, wenn dem Eingangskorb eine Aufgabe zugewie
 
 #: ./opengever/inbox/forwarding.py
 msgid "help_responsible"
-msgstr "Wählen Sie die verantwortliche Person bzw. den Eingangskorb des oben gewählten Mandanten aus."
+msgstr "Wählen Sie die verantwortliche Person bzw. den Eingangskorb des zuständigen Mandanten aus."
 
 #. Default: "Assigned tasks"
 #: ./opengever/inbox/browser/overview.py

--- a/opengever/inbox/locales/fr/LC_MESSAGES/opengever.inbox.po
+++ b/opengever/inbox/locales/fr/LC_MESSAGES/opengever.inbox.po
@@ -59,7 +59,7 @@ msgstr "Ce goupe est autorisé, dès qu'une tâche est attribuée à la boîte d
 
 #: ./opengever/inbox/forwarding.py
 msgid "help_responsible"
-msgstr "Choix de la personne responsable ou la boîte de réception du client mentionné ci-dessus."
+msgstr "Choix de la personne responsable ou de la boîte de réception du client compétent."
 
 #. Default: "Assigned tasks"
 #: ./opengever/inbox/browser/overview.py


### PR DESCRIPTION
Changed in German and French

I also noticed there seems to be confusion between *Auftraggeber* and *Auftragnehmer* in French, both translated by *Mandataire* (see screenshot). I had a quick look and it seems to be wrong in most of GEVER, where *mandataire* (Auftragnehmer) is used to translate *Auftraggeber*, which I would translate by *Mandant*

![screenshot_fr](https://user-images.githubusercontent.com/7374243/33117810-19c33976-cf6a-11e7-943e-30488ca3df4e.png)


![screen shot 2017-11-22 at 09 29 16](https://user-images.githubusercontent.com/7374243/33117626-6dfc839a-cf69-11e7-9f85-63e66120e25f.png)

fixes #3643 