### PR TITLE
Reindex protected dossiers when blocking local roles

### DIFF
--- a/opengever/dossier/behaviors/protect_dossier.py
+++ b/opengever/dossier/behaviors/protect_dossier.py
@@ -225,6 +225,7 @@ class DossierProtection(AnnotationsFactoryImpl):
             return
 
         setattr(self.context, '__ac_local_roles_block__', new_value)
+        self.context.reindexObject(idxs=['blocked_local_roles'])
 
     def need_block_role_inheritance(self):
         return self.is_dossier_protected()

--- a/opengever/dossier/behaviors/protect_dossier.py
+++ b/opengever/dossier/behaviors/protect_dossier.py
@@ -106,8 +106,8 @@ class DossierProtection(AnnotationsFactoryImpl):
     READING_AND_WRITING_ROLES = READING_ROLES + ['Editor', 'Contributor', 'Reviewer', 'Publisher']
     DOSSIER_MANAGER_ROLES = READING_AND_WRITING_ROLES + ['DossierManager']
 
-    def __init__(self, context, schema):
-        super(DossierProtection, self).__init__(context, schema)
+    def __init__(self, context, annotation_schema):
+        super(DossierProtection, self).__init__(context, annotation_schema)
         self.context = context
 
     def protect(self, force_update=False):

--- a/opengever/sharing/tests/test_blocked_local_roles_listing.py
+++ b/opengever/sharing/tests/test_blocked_local_roles_listing.py
@@ -38,7 +38,7 @@ class TestBlockedLocalRolesListing(IntegrationTestCase):
             )
 
     @browsing
-    def test_blocked_role_tab_visible_for_manager_on_repository_root(self, browser):
+    def test_blocked_role_tab_visible_for_manager_on_repository_root(self, browser):  # noqa
         browser.append_request_header('Accept-Language', 'de-ch')
         self.login(self.manager, browser)
 
@@ -49,7 +49,7 @@ class TestBlockedLocalRolesListing(IntegrationTestCase):
             )
 
     @browsing
-    def test_blocked_role_tab_visible_for_manager_on_repository_folder(self, browser):
+    def test_blocked_role_tab_visible_for_manager_on_repository_folder(self, browser):  # noqa
         browser.append_request_header('Accept-Language', 'de-ch')
         self.login(self.manager, browser)
 
@@ -71,7 +71,7 @@ class TestBlockedLocalRolesListing(IntegrationTestCase):
             )
 
     @browsing
-    def test_blocked_role_tab_visible_for_administrator_on_repository_root(self, browser):
+    def test_blocked_role_tab_visible_for_administrator_on_repository_root(self, browser):  # noqa
         browser.append_request_header('Accept-Language', 'de-ch')
         self.login(self.administrator, browser)
 
@@ -82,7 +82,7 @@ class TestBlockedLocalRolesListing(IntegrationTestCase):
             )
 
     @browsing
-    def test_blocked_role_tab_visible_for_administrator_on_repository_folder(self, browser):
+    def test_blocked_role_tab_visible_for_administrator_on_repository_folder(self, browser):  # noqa
         browser.append_request_header('Accept-Language', 'de-ch')
         self.login(self.administrator, browser)
 
@@ -93,7 +93,7 @@ class TestBlockedLocalRolesListing(IntegrationTestCase):
             )
 
     @browsing
-    def test_blocked_role_tab_visible_for_administrator_on_dossier(self, browser):
+    def test_blocked_role_tab_visible_for_administrator_on_dossier(self, browser):  # noqa
         browser.append_request_header('Accept-Language', 'de-ch')
         self.login(self.administrator, browser)
 
@@ -104,18 +104,21 @@ class TestBlockedLocalRolesListing(IntegrationTestCase):
             )
 
     @browsing
-    def test_blocked_role_tab_does_not_render_tree_when_nothing_found(self, browser):
+    def test_blocked_role_tab_does_not_render_tree_when_nothing_found(self, browser):  # noqa
         browser.append_request_header('Accept-Language', 'de-ch')
         self.login(self.administrator, browser)
 
-        browser.open(self.repository_root, view="tabbedview_view-blocked-local-roles")
+        browser.open(
+            self.repository_root,
+            view="tabbedview_view-blocked-local-roles",
+            )
         self.assertEquals(
             browser.css('.blocked-local-roles-listing').first.text,
             u'Keine gesch\xfctzte Objekte in diesem Bereich gefunden.',
             )
 
     @browsing
-    def test_blocked_role_tab_does_not_render_tree_for_regular_user(self, browser):
+    def test_blocked_role_tab_does_not_render_tree_for_regular_user(self, browser):  # noqa
         browser.append_request_header('Accept-Language', 'de-ch')
         self.login(self.regular_user, browser)
 
@@ -123,7 +126,10 @@ class TestBlockedLocalRolesListing(IntegrationTestCase):
         self.dossier.reindexObject(idxs=['blocked_local_roles'])
 
         with browser.expect_http_error(reason='OK'):
-            browser.open(self.repository_root, view="tabbedview_view-blocked-local-roles")
+            browser.open(
+                self.repository_root,
+                view="tabbedview_view-blocked-local-roles",
+                )
 
     @browsing
     def test_blocked_role_tab_does_renders_tree_for_manager(self, browser):
@@ -133,21 +139,27 @@ class TestBlockedLocalRolesListing(IntegrationTestCase):
         self.dossier.__ac_local_roles_block__ = True
         self.dossier.reindexObject(idxs=['blocked_local_roles'])
 
-        browser.open(self.repository_root, view="tabbedview_view-blocked-local-roles")
+        browser.open(
+            self.repository_root,
+            view="tabbedview_view-blocked-local-roles",
+            )
         self.assertEquals(
             browser.css('.blocked-local-roles-listing a').first.text,
             u'1. F\xfchrung',
             )
 
     @browsing
-    def test_blocked_role_tab_does_renders_tree_for_administrator(self, browser):
+    def test_blocked_role_tab_does_renders_tree_for_administrator(self, browser):  # noqa
         browser.append_request_header('Accept-Language', 'de-ch')
         self.login(self.manager, browser)
 
         self.dossier.__ac_local_roles_block__ = True
         self.dossier.reindexObject(idxs=['blocked_local_roles'])
 
-        browser.open(self.repository_root, view="tabbedview_view-blocked-local-roles")
+        browser.open(
+            self.repository_root,
+            view="tabbedview_view-blocked-local-roles",
+            )
         self.assertEquals(
             browser.css('.blocked-local-roles-listing a').first.text,
             u'1. F\xfchrung',
@@ -161,7 +173,10 @@ class TestBlockedLocalRolesListing(IntegrationTestCase):
         self.dossier.__ac_local_roles_block__ = True
         self.dossier.reindexObject(idxs=['blocked_local_roles'])
 
-        browser.open(self.repository_root, view="tabbedview_view-blocked-local-roles")
+        browser.open(
+            self.repository_root,
+            view="tabbedview_view-blocked-local-roles",
+            )
 
         self.assertEquals(
             browser.css('.blocked-local-roles-link').text,
@@ -197,7 +212,10 @@ class TestBlockedLocalRolesListing(IntegrationTestCase):
         self.leaf_repofolder.__ac_local_roles_block__ = True
         self.leaf_repofolder.reindexObject(idxs=['blocked_local_roles'])
 
-        browser.open(self.repository_root, view="tabbedview_view-blocked-local-roles")
+        browser.open(
+            self.repository_root,
+            view="tabbedview_view-blocked-local-roles",
+            )
 
         self.assertEquals(
             browser.css('.blocked-local-roles-link').text,
@@ -224,7 +242,10 @@ class TestBlockedLocalRolesListing(IntegrationTestCase):
         self.dossier.__ac_local_roles_block__ = True
         self.dossier.reindexObject(idxs=['blocked_local_roles'])
 
-        browser.open(self.repository_root, view="tabbedview_view-blocked-local-roles")
+        browser.open(
+            self.repository_root,
+            view="tabbedview_view-blocked-local-roles",
+            )
         browser.css('.blocked-local-roles-link').first.click()
         expected_url = ''.join((
             self.branch_repofolder.absolute_url(),
@@ -235,7 +256,10 @@ class TestBlockedLocalRolesListing(IntegrationTestCase):
             browser.url,
             )
 
-        browser.open(self.branch_repofolder, view="tabbedview_view-blocked-local-roles")
+        browser.open(
+            self.branch_repofolder,
+            view="tabbedview_view-blocked-local-roles",
+            )
         browser.css('.blocked-local-roles-link').first.click()
         expected_url = ''.join((
             self.leaf_repofolder.absolute_url(),
@@ -246,7 +270,10 @@ class TestBlockedLocalRolesListing(IntegrationTestCase):
             browser.url,
             )
 
-        browser.open(self.leaf_repofolder, view="tabbedview_view-blocked-local-roles")
+        browser.open(
+            self.leaf_repofolder,
+            view="tabbedview_view-blocked-local-roles",
+            )
         browser.css('.blocked-local-roles-link').first.click()
         expected_url = ''.join((
             self.dossier.absolute_url(),
@@ -265,7 +292,10 @@ class TestBlockedLocalRolesListing(IntegrationTestCase):
         self.leaf_repofolder.__ac_local_roles_block__ = True
         self.leaf_repofolder.reindexObject(idxs=['blocked_local_roles'])
 
-        browser.open(self.repository_root, view="tabbedview_view-blocked-local-roles")
+        browser.open(
+            self.repository_root,
+            view="tabbedview_view-blocked-local-roles",
+            )
         browser.css('.blocked-local-roles-link').first.click()
         expected_url = ''.join((
             self.branch_repofolder.absolute_url(),
@@ -276,7 +306,10 @@ class TestBlockedLocalRolesListing(IntegrationTestCase):
             browser.url,
             )
 
-        browser.open(self.branch_repofolder, view="tabbedview_view-blocked-local-roles")
+        browser.open(
+            self.branch_repofolder,
+            view="tabbedview_view-blocked-local-roles",
+            )
         browser.css('.blocked-local-roles-link').first.click()
         expected_url = ''.join((
             self.leaf_repofolder.absolute_url(),

--- a/opengever/sharing/tests/test_blocked_local_roles_listing.py
+++ b/opengever/sharing/tests/test_blocked_local_roles_listing.py
@@ -1,4 +1,5 @@
 from ftw.testbrowser import browsing
+from ftw.testbrowser.pages import factoriesmenu
 from opengever.testing import IntegrationTestCase
 
 
@@ -318,4 +319,54 @@ class TestBlockedLocalRolesListing(IntegrationTestCase):
         self.assertEquals(
             expected_url,
             browser.url,
+            )
+
+    @browsing
+    def test_protected_dossiers_are_listed_for_manager(self, browser):
+        self.login(self.dossier_manager, browser)
+
+        browser.open(self.leaf_repofolder)
+        factoriesmenu.add(u'Business Case Dossier')
+        browser.fill({'Title': 'My Dossier'})
+        form = browser.find_form_by_field('Reading')
+        form.find_widget('Reading and writing').fill(self.regular_user.getId())
+        browser.click_on('Save')
+        new_dossier = browser.context
+
+        browser.append_request_header('Accept-Language', 'de-ch')
+        self.login(self.manager, browser)
+
+        browser.open(
+            self.repository_root,
+            view="tabbedview_view-blocked-local-roles",
+            )
+
+        self.assertIn(
+            new_dossier.title,
+            browser.css('.level2').text[0],
+            )
+
+    @browsing
+    def test_protected_dossiers_are_listed_for_administrator(self, browser):
+        self.login(self.dossier_manager, browser)
+
+        browser.open(self.leaf_repofolder)
+        factoriesmenu.add(u'Business Case Dossier')
+        browser.fill({'Title': 'My Dossier'})
+        form = browser.find_form_by_field('Reading')
+        form.find_widget('Reading and writing').fill(self.regular_user.getId())
+        browser.click_on('Save')
+        new_dossier = browser.context
+
+        browser.append_request_header('Accept-Language', 'de-ch')
+        self.login(self.administrator, browser)
+
+        browser.open(
+            self.repository_root,
+            view="tabbedview_view-blocked-local-roles",
+            )
+
+        self.assertIn(
+            new_dossier.title,
+            browser.css('.level2').text[0],
             )


### PR DESCRIPTION
Simply a case of not reindexing when setting the blocked local roles attribute.

Trivial fix on a fresh unreleased feature -> no changelog entry.

Closes #3650 