### PR TITLE
Also pin test-depdenency requests_toolbelt.

### DIFF
--- a/versions.cfg
+++ b/versions.cfg
@@ -185,6 +185,7 @@ python-ldap = 2.4.19
 raven = 6.1.0
 repoze.catalog = 0.8.3
 requests = 2.17.3
+requests-toolbelt = 0.8.0
 rfc6266 = 0.0.4
 setuptools = 33.1.1
 snowballstemmer = 1.2.1


### PR DESCRIPTION
It is only a test-dependency but since requests is pinned, pinning toolbelt also should avoid running into incompatibility issues later.