### PR TITLE
Show subdossier depending on max dossier depth.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -8,6 +8,7 @@ Changelog
 - Make cassation_date field accessible only to manager. [njohner]
 - Use empty mimetype icon for empty document content types. [Kevin Bieri]
 - Add mimetype for MS OneNote. [phgross]
+- Only show subdossier tab on dossiers where the max depth allows to add subdossiers.  [phgross]
 - Correct field description for responsible person/entity when forwarding documents [njohner]
 - SPV-word: Fix renaming agenda items in meeting view. [tarnap]
 - Don't remove doc-properties for excerpts, use correct document as master. [deiferni]

--- a/opengever/dossier/base.py
+++ b/opengever/dossier/base.py
@@ -24,14 +24,12 @@ from opengever.task.task import ITask
 from plone import api
 from plone.dexterity.content import Container
 from plone.dexterity.interfaces import IDexterityFTI
-from plone.registry.interfaces import IRegistry
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.interfaces.siteroot import IPloneSiteRoot
 from zExceptions import Unauthorized
 from zope.component import adapter
 from zope.component import getUtility
 from zope.component import queryMultiAdapter
-from zope.component import queryUtility
 from zope.interface import implementer
 from zope.interface import Interface
 
@@ -136,15 +134,15 @@ class DossierContainer(Container):
                 break
         return prev
 
-    def show_subdossier(self):
-        registry = queryUtility(IRegistry)
-        reg_proxy = registry.forInterface(IDossierContainerTypes)
-        depth = self._get_dossier_depth()
+    def is_subdossier_addable(self):
+        """Only checks if the maximum dossier depth allows another level
+        of subdossiers but not for permissions.
+        """
+        max_depth = api.portal.get_registry_record(
+            name='maximum_dossier_depth',
+            interface=IDossierContainerTypes, default=100)
 
-        if depth > getattr(reg_proxy, 'maximum_dossier_depth', 100):
-            return False
-        else:
-            return True
+        return self._get_dossier_depth() <= max_depth
 
     def has_subdossiers(self):
         return len(self.get_subdossiers()) > 0

--- a/opengever/dossier/browser/tabbed.py
+++ b/opengever/dossier/browser/tabbed.py
@@ -1,6 +1,7 @@
 from opengever.contact import is_contact_feature_enabled
 from opengever.dossier import _
 from opengever.dossier.dossiertemplate import is_dossier_template_feature_enabled
+from opengever.dossier.dossiertemplate.interfaces import IDossierTemplateSettings
 from opengever.meeting import is_meeting_feature_enabled
 from opengever.meeting import is_word_meeting_implementation_enabled
 from opengever.tabbedview import GeverTabbedView
@@ -40,9 +41,19 @@ class DossierTabbedView(GeverTabbedView):
         'title': _(u'label_info', default=u'Info'),
         }
 
+    def is_subdossier_visible(self):
+        """Depending on the `respect_max_depth' property we check if
+        subdossiers are addable or not.
+        """
+
+        if self.context.is_subdossier_addable():
+            return True
+
+        return self.context.has_subdossiers()
+
     @property
     def subdossiers_tab(self):
-        if self.context.is_subdossier_addable():
+        if self.is_subdossier_visible():
             return {
                 'id': 'subdossiers',
                 'title': _(u'label_subdossiers', default=u'Subdossiers'),

--- a/opengever/dossier/browser/tabbed.py
+++ b/opengever/dossier/browser/tabbed.py
@@ -42,7 +42,7 @@ class DossierTabbedView(GeverTabbedView):
 
     @property
     def subdossiers_tab(self):
-        if self.context.show_subdossier():
+        if self.context.is_subdossier_addable():
             return {
                 'id': 'subdossiers',
                 'title': _(u'label_subdossiers', default=u'Subdossiers'),

--- a/opengever/dossier/browser/tabbed.py
+++ b/opengever/dossier/browser/tabbed.py
@@ -42,7 +42,7 @@ class DossierTabbedView(GeverTabbedView):
 
     @property
     def subdossiers_tab(self):
-        if self.context.show_subdossier:
+        if self.context.show_subdossier():
             return {
                 'id': 'subdossiers',
                 'title': _(u'label_subdossiers', default=u'Subdossiers'),

--- a/opengever/dossier/dossiertemplate/dossiertemplate.py
+++ b/opengever/dossier/dossiertemplate/dossiertemplate.py
@@ -118,7 +118,7 @@ class DossierTemplate(Container):
                 values[key] = getattr(field.interface(self), fieldname)
         return values
 
-    def show_subdossier(self):
+    def is_subdossier_addable(self):
         """We do not restrict dossier depth in a dossiertemplate.
         """
         return True

--- a/opengever/dossier/tests/test_tabbed.py
+++ b/opengever/dossier/tests/test_tabbed.py
@@ -30,3 +30,16 @@ class TestContactParticipationTab(IntegrationTestCase):
         self.assertEqual(
             'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/#participations',
             browser.url)
+
+
+class TestDossierTabbedView(IntegrationTestCase):
+
+    @browsing
+    def test_subdossier_tab_only_shown_where_subdossiers_are_addable(self, browser):
+        self.login(self.dossier_responsible, browser)
+
+        browser.open(self.dossier, view='tabbed_view')
+        self.assertIn('Subdossiers', browser.css('.formTab').text)
+
+        browser.open(self.subdossier, view='tabbed_view')
+        self.assertNotIn('Subdossiers', browser.css('.formTab').text)

--- a/opengever/dossier/tests/test_tabbed.py
+++ b/opengever/dossier/tests/test_tabbed.py
@@ -1,5 +1,9 @@
+from ftw.builder import Builder
+from ftw.builder import create
 from ftw.testbrowser import browsing
+from opengever.dossier.dossiertemplate.interfaces import IDossierTemplateSettings
 from opengever.testing import IntegrationTestCase
+from plone import api
 
 
 class TestParticipationTab(IntegrationTestCase):
@@ -36,6 +40,14 @@ class TestDossierTabbedView(IntegrationTestCase):
 
     @browsing
     def test_subdossier_tab_only_shown_where_subdossiers_are_addable(self, browser):
+        """When respect_max_depth flag is enabled the subdossier tab should
+        only be visible on dossiers where the maximum depth allows subdossiers.
+        """
+
+        api.portal.set_registry_record(
+            name='respect_max_depth',
+            interface=IDossierTemplateSettings, value=True)
+
         self.login(self.dossier_responsible, browser)
 
         browser.open(self.dossier, view='tabbed_view')
@@ -43,3 +55,17 @@ class TestDossierTabbedView(IntegrationTestCase):
 
         browser.open(self.subdossier, view='tabbed_view')
         self.assertNotIn('Subdossiers', browser.css('.formTab').text)
+
+    @browsing
+    def test_subdossier_tab_always_shown_when_dossier_contains_subdossier(self, browser):
+        self.login(self.dossier_responsible, browser)
+
+        browser.open(self.subdossier, view='tabbed_view')
+        self.assertNotIn('Subdossiers', browser.css('.formTab').text)
+
+        create(Builder('dossier')
+               .within(self.subdossier)
+               .titled(u'Sub Sub Dossier'))
+
+        browser.open(self.subdossier, view='tabbed_view')
+        self.assertIn('Subdossiers', browser.css('.formTab').text)


### PR DESCRIPTION
- Only show subdossier tab on dossiers where the max depth allows to add subdossiers.
- Reworked and renamed the `is_subdossier_addable` method.
- Always show the subdossier tab, when subdossiers exists, even when there not allowed by the max_depth.

Backport needed: 2017.5.x