### PR TITLE
Ensure new versions are created when doc-properties change.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,7 @@ Changelog
 
 - Show icons in BlockedLocalRolesList. [njohner]
 - Fix bug when accepting a multiadmin unit team task. [phgross]
+- Ensure new versions are created when doc-properties change. [deiferni]
 - Make cassation_date field accessible only to manager. [njohner]
 - Use empty mimetype icon for empty document content types. [Kevin Bieri]
 - Pin ftw.keywordwidget to 1.4.2 to fix a term-lookup error. [elioschmutz]

--- a/opengever/bumblebee/tests/test_download.py
+++ b/opengever/bumblebee/tests/test_download.py
@@ -41,9 +41,9 @@ class TestBumblebeeDownloadView(FunctionalTestCase):
                               u'example.docx')
                           .checked_out())
 
-        document.update_file(filename=u'foo.txt',
+        document.update_file('foo',
                              content_type='text/plain',
-                             data='foo')
+                             filename=u'foo.txt')
         notify(ObjectModifiedEvent(document))
         transaction.commit()
 

--- a/opengever/bumblebee/tests/test_versions.py
+++ b/opengever/bumblebee/tests/test_versions.py
@@ -8,7 +8,6 @@ from opengever.core.testing import OPENGEVER_FUNCTIONAL_BUMBLEBEE_LAYER
 from opengever.document.interfaces import ICheckinCheckoutManager
 from opengever.document.versioner import Versioner
 from opengever.testing import FunctionalTestCase
-from plone import api
 from zope.component import getMultiAdapter
 from zope.event import notify
 from zope.lifecycleevent import ObjectModifiedEvent

--- a/opengever/bumblebee/tests/test_versions.py
+++ b/opengever/bumblebee/tests/test_versions.py
@@ -37,9 +37,9 @@ class TestBumblebeeChecksumForVersions(FunctionalTestCase):
                               u'example.docx')
                           .checked_out())
 
-        document.update_file(filename=u'foo.txt',
+        document.update_file('foo',
                              content_type='text/plain',
-                             data='foo')
+                             filename=u'foo.txt')
         notify(ObjectModifiedEvent(document))
         transaction.commit()
 

--- a/opengever/document/document.py
+++ b/opengever/document/document.py
@@ -279,7 +279,10 @@ class Document(Item, BaseDocumentMixin):
         """Return the current document history version."""
         return Versioner(self).get_current_version_id(missing_as_zero)
 
-    def update_file(self, filename, content_type, data):
+    def update_file(self, data, content_type=None, filename=None):
+        content_type = content_type or self.file.contentType
+        filename = filename or self.file.filename
+
         self.file = NamedBlobFile(
             data=data,
             filename=filename,

--- a/opengever/document/document.py
+++ b/opengever/document/document.py
@@ -14,7 +14,6 @@ from opengever.document.behaviors.related_docs import IRelatedDocuments
 from opengever.document.interfaces import ICheckinCheckoutManager
 from opengever.document.versioner import Versioner
 from opengever.dossier.behaviors.dossier import IDossierMarker
-from opengever.meeting.model.generateddocument import GeneratedExcerpt
 from opengever.meeting.proposal import IProposal
 from opengever.meeting.proposal import ISubmittedProposal
 from opengever.officeconnector.helpers import create_oc_url
@@ -46,6 +45,7 @@ from zope.interface import invariant
 from zope.intid.interfaces import IIntIds
 import logging
 import os.path
+
 
 LOG = logging.getLogger('opengever.document')
 MAIL_EXTENSIONS = ['.eml', '.msg']

--- a/opengever/document/quick_upload.py
+++ b/opengever/document/quick_upload.py
@@ -22,8 +22,9 @@ class QuickUploadFileUpdater(object):
         if not self.is_upload_allowed():
             raise Unauthorized
 
-        self.context.update_file(
-            self.get_file_name(filename), content_type, data)
+        self.context.update_file(data,
+                                 content_type=content_type,
+                                 filename=self.get_file_name(filename))
 
         return {'success': self.context}
 

--- a/opengever/document/tests/test_bumblebee.py
+++ b/opengever/document/tests/test_bumblebee.py
@@ -95,9 +95,9 @@ class TestBumblebeeIntegrationWithEnabledFeature(FunctionalTestCase):
             DOCX_CHECKSUM,
             IBumblebeeDocument(document).get_checksum())
 
-        document.update_file(filename=u'foo.txt',
+        document.update_file('foo',
                              content_type='text/plain',
-                             data='foo')
+                             filename=u'foo.txt')
         notify(ObjectModifiedEvent(document))
 
         self.assertEquals(
@@ -115,9 +115,9 @@ class TestBumblebeeIntegrationWithEnabledFeature(FunctionalTestCase):
         queue = get_queue()
         queue.reset()
 
-        document.update_file(filename=u'example.docx',
+        document.update_file(bumblebee_asset('example.docx').bytes(),
                              content_type='text/plain',
-                             data=bumblebee_asset('example.docx').bytes())
+                             filename=u'example.docx')
         manager = getMultiAdapter((document, self.portal.REQUEST),
                                   ICheckinCheckoutManager)
         manager.checkin()

--- a/opengever/document/tests/test_versioner.py
+++ b/opengever/document/tests/test_versioner.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 from ftw.testbrowser import browsing
 from opengever.document.versioner import Versioner
+from opengever.dossier.docprops import DocPropertyWriter
 from opengever.testing import IntegrationTestCase
 from plone.namedfile.file import NamedBlobFile
 from zope.filerepresentation.interfaces import IRawWriteFile
@@ -20,6 +21,19 @@ class TestInitialVersionCreation(IntegrationTestCase):
 
         self.assertFalse(versioner.has_initial_version())
         self.document.file = NamedBlobFile(data='New', filename=u'test.txt')
+        self.assertTrue(versioner.has_initial_version())
+        self.assertEquals(
+            1, versioner.get_history_metadata().getLength(countPurged=False))
+
+    def test_doc_property_writer_creates_initial_version(self):
+        self.activate_feature('doc-properties')
+        self.login(self.dossier_responsible)
+
+        versioner = Versioner(self.document)
+        self.assertFalse(versioner.has_initial_version())
+
+        DocPropertyWriter(self.document).update_doc_properties(only_existing=False)
+
         self.assertTrue(versioner.has_initial_version())
         self.assertEquals(
             1, versioner.get_history_metadata().getLength(countPurged=False))

--- a/opengever/dossier/docprops.py
+++ b/opengever/dossier/docprops.py
@@ -103,8 +103,8 @@ class DocPropertyWriter(object):
             if changed:
                 with open(tmpfile.path) as processed_tmpfile:
                     file_data = processed_tmpfile.read()
-                self.document.file.data = file_data
 
+                self.document.update_file(file_data)
                 notify(ObjectModifiedEvent(self.document))
 
             return changed

--- a/opengever/meeting/command.py
+++ b/opengever/meeting/command.py
@@ -32,7 +32,6 @@ from plone import api
 from plone.i18n.normalizer.interfaces import IIDNormalizer
 from plone.locking.interfaces import ILockable
 from plone.memoize import instance
-from plone.namedfile.file import NamedBlobFile
 from zope.component import getMultiAdapter
 from zope.component import getUtility
 from zope.globalrequest import getRequest
@@ -367,9 +366,7 @@ class MergeDocxProtocolCommand(CreateGeneratedDocumentCommand):
 
     def update_protocol_document(self):
         document = self.meeting.protocol_document.resolve_document()
-        document.file = NamedBlobFile(self.generate_file_data(),
-                                      contentType=document.file.contentType,
-                                      filename=document.file.filename)
+        document.update_file(self.generate_file_data())
 
         comment = translate(
             _(u'Updated with a newer generated version from meeting ${title}.',
@@ -444,10 +441,7 @@ class UpdateGeneratedDocumentCommand(object):
 
     def execute(self):
         document = Oguid.resolve_object(self.generated_document.oguid)
-        document.file.data = self.generate_file_data()
-        document.file = NamedBlobFile(self.generate_file_data(),
-                                      contentType=document.file.contentType,
-                                      filename=document.file.filename)
+        document.update_file(self.generate_file_data())
 
         comment = translate(
             _(u'Updated with a newer generated version from meeting ${title}.',

--- a/opengever/meeting/tests/test_excerpt.py
+++ b/opengever/meeting/tests/test_excerpt.py
@@ -43,9 +43,9 @@ class TestSyncExcerpt(IntegrationTestCase):
                                   ICheckinCheckoutManager)
         manager.checkout()
         self.document_in_proposal.update_file(
-            filename=u'example.docx',
+            'foo bar',
             content_type='text/plain',
-            data='foo bar')
+            filename=u'example.docx')
         manager.checkin()
 
         self.assertEqual(1, self.document_in_proposal.get_current_version_id())
@@ -59,9 +59,9 @@ class TestSyncExcerpt(IntegrationTestCase):
                                   ICheckinCheckoutManager)
         manager.checkout()
         self.document_in_proposal.update_file(
-            filename=u'example.docx',
+            'foo bar',
             content_type='text/plain',
-            data='foo bar')
+            filename=u'example.docx')
         manager.checkin()
 
         manager.revert_to_version(0)
@@ -71,9 +71,9 @@ class TestSyncExcerpt(IntegrationTestCase):
     def test_updates_excerpt_in_dossier_after_modification(self):
         self.assertEqual(None, self.document_in_dossier.get_current_version_id())
         self.document_in_proposal.update_file(
+            'foo bar',
             filename=u'example.docx',
-            content_type='text/plain',
-            data='foo bar')
+            content_type='text/plain')
         notify(ObjectModifiedEvent(self.document_in_proposal))
 
         self.assertEqual(1, self.document_in_dossier.get_current_version_id())


### PR DESCRIPTION
The doc-property updater did not set the a document's file with the setter as would be the "proper" way to do and as is also expected by changes in https://github.com/4teamwork/opengever.core/pull/3467. Instead it accessed the file's `data` directly, sidestepping lazy version creation. This PR fixes that issue by properly using the file attribute in this case (and also throughout GEVER). We also change the `update_file` method of a document a bit and allow it to re-use unchanged arguments from an already present `file`.

Fixes https://github.com/4teamwork/opengever.core/issues/3641.

Backport needed: [2017.6-stable](https://github.com/4teamwork/opengever.core/tree/2017.6-stable)