### PR TITLE
Show icons in BlockedLocalRolesList

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2017.7.0 (unreleased)
 ---------------------
 
+- Show icons in BlockedLocalRolesList. [njohner]
 - Fix bug when accepting a multiadmin unit team task. [phgross]
 - Make cassation_date field accessible only to manager. [njohner]
 - Use empty mimetype icon for empty document content types. [Kevin Bieri]

--- a/opengever/sharing/browser/admin_list.py
+++ b/opengever/sharing/browser/admin_list.py
@@ -1,3 +1,4 @@
+from opengever.base.browser.helper import get_css_class
 from opengever.base.utils import escape_html
 from opengever.dossier.behaviors.dossier import IDossierMarker
 from opengever.repository.interfaces import IRepositoryFolder
@@ -26,6 +27,7 @@ class BlockedLocalRolesList(BrowserView):
     def node_updater(self, brain, node):
         node['title'] = brain.Title
         node['url'] = brain.getURL()
+        node['css_class'] = get_css_class(brain)
 
     def render_tree(self):
         context_path = '/'.join(self.context.getPhysicalPath())
@@ -95,20 +97,22 @@ class BlockedLocalRolesList(BrowserView):
 
             title = escape_html(node.get('title'))
             url = escape_html(node.get('url'))
-            children = node.get('children')
+            css_class = node.get("css_class")
+            sub_children = node.get('children')
 
             if title:
                 if url and title:
                     anchor = (
-                        u'#blocked-local-roles' if children
+                        u'#blocked-local-roles' if sub_children
                         else u'#sharing'
                         )
                     target_url = u''.join((url.decode('UTF-8'), anchor, ))
 
                     output = u''.join((
                         output,
-                        u'<a class="blocked-local-roles-link" href="{}">{}</a>'
+                        u'<a class="{} blocked-local-roles-link" href="{}">{}</a>'
                         .format(
+                            css_class,
                             target_url,
                             title.decode('UTF-8'),
                             ),
@@ -116,15 +120,19 @@ class BlockedLocalRolesList(BrowserView):
                 else:
                     output = u''.join((
                         output,
-                        title,
+                        u'<span class="{} blocked-local-roles-link">{}</span>'
+                        .format(
+                            css_class,
+                            title.decode('UTF-8'),
+                            ),
                         ))
 
-            if children:
+            if sub_children:
                 output = u''.join((
                     output,
                     u'<ul class="level{}">\n{}\n</ul>\n'.format(
                         str(level),
-                        self._build_html_tree(children, level + 1),
+                        self._build_html_tree(sub_children, level + 1),
                         ),
                     ))
 

--- a/opengever/sharing/tests/test_blocked_local_roles_listing.py
+++ b/opengever/sharing/tests/test_blocked_local_roles_listing.py
@@ -205,6 +205,13 @@ class TestBlockedLocalRolesListing(IntegrationTestCase):
 
         self.assertFalse(browser.css('.level3 a').text)
 
+        nodes = browser.css('.blocked-local-roles-link')
+        repo = 'contenttype-opengever-repository-repositoryfolder'
+        dossier = 'contenttype-opengever-dossier-businesscasedossier'
+        self.assertIn(repo, nodes[0].classes)
+        self.assertIn(repo, nodes[1].classes)
+        self.assertIn(dossier, nodes[2].classes)
+
     @browsing
     def test_blocked_role_tab_tree_rendering_of_repofolder(self, browser):
         browser.append_request_header('Accept-Language', 'de-ch')
@@ -234,6 +241,11 @@ class TestBlockedLocalRolesListing(IntegrationTestCase):
             )
 
         self.assertFalse(browser.css('.level2 a').text)
+
+        nodes = browser.css('.blocked-local-roles-link')
+        repo = 'contenttype-opengever-repository-repositoryfolder'
+        self.assertIn(repo, nodes[0].classes)
+        self.assertIn(repo, nodes[1].classes)
 
     @browsing
     def test_blocked_role_tab_can_drill_down_to_dossier(self, browser):


### PR DESCRIPTION
I also changed the naming of the `children` variable which was redefined in a loop over `children`. While that works, it seemed to be a rather unfortunate choice 😄 
solves #3653 
![screen shot 2017-11-23 at 17 12 49](https://user-images.githubusercontent.com/7374243/33181732-96cd064c-d071-11e7-8e4e-3cf2282de576.png)
