### PR TITLE
Fix bug when accepting a multi admin_unit team task.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2017.7.0 (unreleased)
 ---------------------
 
+- Fix bug when accepting a multiadmin unit team task. [phgross]
 - Make cassation_date field accessible only to manager. [njohner]
 - Use empty mimetype icon for empty document content types. [Kevin Bieri]
 - Add mimetype for MS OneNote. [phgross]

--- a/opengever/task/util.py
+++ b/opengever/task/util.py
@@ -156,12 +156,13 @@ def change_task_workflow_state(task, transition, **kwargs):
     before = wftool.getInfoFor(task, 'review_state')
     before = wftool.getTitleForStateOnType(before, task.Type())
 
+    response = add_simple_response(task, transition=transition, **kwargs)
+
     wftool.doActionFor(task, transition)
 
     after = wftool.getInfoFor(task, 'review_state')
     after = wftool.getTitleForStateOnType(after, task.Type())
 
-    response = add_simple_response(task, transition=transition, **kwargs)
     response.add_change('review_state', _(u'Issue state'),
                         before, after)
     response.transition = transition


### PR DESCRIPTION
Make sure `Response` object is already added to the task before changing the workflow state, so event handlers as the `reassign_team_tasks` are able to extend the response changes.

See https://sentry.4teamwork.ch/sentry/onegov-gever/issues/4530/