### PR TITLE
Fix bux when accepting a multi admin unit team task

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2017.7.0 (unreleased)
 ---------------------
 
+- Fix bux when accepting a multi admin unit team task with option participate. [phgross]
 - Use latest ruby (2.4.2) and nokogiri (1.8.1) [siegy22]
 - Show icons in BlockedLocalRolesList. [njohner]
 - Fix bug when accepting a multiadmin unit team task. [phgross]

--- a/opengever/task/browser/accept/main.py
+++ b/opengever/task/browser/accept/main.py
@@ -6,6 +6,7 @@ step, where the user has to choose the method of participation.
 
 from opengever.base.browser.wizard import BaseWizardStepForm
 from opengever.base.browser.wizard.interfaces import IWizardDataStorage
+from opengever.globalindex.handlers.task import sync_task
 from opengever.ogds.base.utils import ogds_service
 from opengever.task import _
 from opengever.task.browser.accept.utils import accept_task_with_response
@@ -164,6 +165,8 @@ class ChooseMethodStepForm(AcceptWizardFormMixin, Form):
 
             if method == 'participate':
                 accept_task_with_response(self.context, data['text'])
+                sync_task(self.context, None)
+
                 IStatusMessage(self.request).addStatusMessage(
                     _(u'The task has been accepted.'), 'info')
                 return self.request.response.redirect(


### PR DESCRIPTION
with option participate. Make sure the SQL task objects gets updated after changing the workflow state, its possible that some of the metadata gets changed or updated when a task gets accepted, for an example when accepting a team task.