### PR TITLE
Use latest ruby (2.4.2) and nokogiri (1.8.1)

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2017.7.0 (unreleased)
 ---------------------
 
+- Use latest ruby (2.4.2) and nokogiri (1.8.1) [siegy22]
 - Show icons in BlockedLocalRolesList. [njohner]
 - Fix bug when accepting a multiadmin unit team task. [phgross]
 - Ensure new versions are created when doc-properties change. [deiferni]

--- a/versions.cfg
+++ b/versions.cfg
@@ -7,8 +7,8 @@ extends =
 
 
 [ruby-versions]
-nokogiri = 1.7.2
-ruby = 2.3.3
+nokogiri = 1.8.1
+ruby = 2.4.2
 sablon = 0.0.21
 
 


### PR DESCRIPTION
Let's use the latest ruby and nokogiri version:

- ruby (2.3.3 -> 2.4.2)
- nokogiri (1.7.2 -> 1.8.1)