### PR TITLE
 Append a missing context to the OC multiattach error message

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ---------------------
 
 - Fix bux when accepting a multi admin unit team task with option participate. [phgross]
+- Fix an untranslated OC error message. [Rotonen]
 - Use latest ruby (2.4.2) and nokogiri (1.8.1) [siegy22]
 - Show icons in BlockedLocalRolesList. [njohner]
 - Fix bug when accepting a multiadmin unit team task. [phgross]

--- a/opengever/officeconnector/service.py
+++ b/opengever/officeconnector/service.py
@@ -34,7 +34,11 @@ class OfficeConnectorURL(Service):
         self.request.response.setStatus(500)
         message = _(
             u'error_oc_url_too_long',
-            default=u"Unfortunately it's not currently possible to attach this many documents. Please try again with fewer documents selected.",
+            default=(
+                u"Unfortunately it's not currently possible to attach this "
+                u'many documents. Please try again with fewer documents '
+                u'selected.'
+                ),
             )
 
         return json.dumps(dict(
@@ -174,7 +178,11 @@ class OfficeConnectorCheckoutPayload(OfficeConnectorPayload):
         # form.
         for payload in payloads:
             # A permission check to verify the user is also able to upload
-            if api.user.has_permission('Modify portal content', obj=payload['document']):
+            authorized = api.user.has_permission(
+                'Modify portal content',
+                obj=payload['document'],
+                )
+            if authorized:
                 del payload['document']
                 payload['checkin-with-comment'] = '@@checkin_document'
                 payload['checkin-without-comment'] = 'checkin_without_comment'

--- a/opengever/officeconnector/service.py
+++ b/opengever/officeconnector/service.py
@@ -43,7 +43,10 @@ class OfficeConnectorURL(Service):
 
         return json.dumps(dict(
             error=dict(
-                message=translate(message)
+                message=translate(
+                    message,
+                    context=self.request,
+                    )
                 )
             ))
 


### PR DESCRIPTION
As discussed, the OC testing overhaul to easier enable testing for this without exploding the ZServer layer runtimes way out of hand will land later.

Closes #3640