### PR TITLE
Improve wording for meeting buttons/descriptions.

### DIFF
--- a/opengever/meeting/browser/meetings/templates/meeting-noword.pt
+++ b/opengever/meeting/browser/meetings/templates/meeting-noword.pt
@@ -79,7 +79,7 @@
         <div class="overlay" id="confirm_hold_meeting">
           <h2 i18n:translate="decide_agendaitem">Decide Agendaitem</h2>
           <p i18n:translate="msg_hold_meeting_dialog">
-            When deciding an agendaitem the meeting will sent to hold state. Once the meeting is held, the agenda list is no longer editable.
+            When deciding an agendaitem the agenda list is no longer editable.
           </p>
           <p i18n:translate="">
             Are you sure, you want to decide this agendaitem?

--- a/opengever/meeting/browser/meetings/templates/meeting-word.pt
+++ b/opengever/meeting/browser/meetings/templates/meeting-word.pt
@@ -95,7 +95,7 @@
         <div class="overlay" id="confirm_hold_meeting">
           <h2 i18n:translate="decide_agendaitem">Decide Agendaitem</h2>
           <p i18n:translate="msg_hold_meeting_dialog">
-            When deciding an agendaitem the meeting will sent to hold state. Once the meeting is held, the agenda list is no longer editable.
+            When deciding an agendaitem the agenda list is no longer editable.
           </p>
           <p i18n:translate="">
             Are you sure, you want to decide this agendaitem?

--- a/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
@@ -94,7 +94,7 @@ msgstr "Wollen Sie diesen Protokollauszug wirklich an den Antragsteller zurücks
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
 #: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "Are you sure, you want to decide this agendaitem?"
-msgstr "Sind Sie sicher, dass Sie dieses Traktandum beschliessen möchten?"
+msgstr "Sind Sie sicher, dass Sie dieses Traktandum abschliessen möchten?"
 
 #: ./opengever/meeting/browser/memberships.py
 msgid "Can't add membership, it overlaps an existing membership from ${date_from} to ${date_to}."
@@ -1004,7 +1004,7 @@ msgstr "Gremium deaktivieren"
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
 #: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "label_decide"
-msgstr "Beschliessen"
+msgstr "Abschliessen"
 
 #. Default: "Decide this agenda item"
 #: ./opengever/meeting/browser/meetings/meeting.py

--- a/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-11-16 10:22+0000\n"
+"POT-Creation-Date: 2017-11-27 14:08+0000\n"
 "PO-Revision-Date: 2017-10-23 18:40+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1580,11 +1580,11 @@ msgstr "Es ist keine Vorlage für die Traktandenliste konfiguriert, die Traktand
 msgid "msg_error_protocol_already_generated"
 msgstr "Das Protokoll für die Sitzung ${title} wurde schon erstellt."
 
-#. Default: "When deciding an agendaitem the meeting will sent to hold state. Once the meeting is held, the agenda list is no longer editable."
+#. Default: "When deciding an agendaitem the agenda list is no longer editable."
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
 #: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "msg_hold_meeting_dialog"
-msgstr "Beim Abschluss dieses Traktandums wird die Sitzung in den Status `Durchgeführt`  versetzt. Anschliessend kann die Traktandenliste nicht mehr bearbeitet werden."
+msgstr "Nach Abschluss eines Traktandums kann die Traktandenliste nicht mehr bearbeitet werden."
 
 #. Default: "The selected committeee has been deactivated, the proposal could not been submitted."
 #: ./opengever/meeting/model/proposal.py

--- a/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-11-16 10:22+0000\n"
+"POT-Creation-Date: 2017-11-27 14:08+0000\n"
 "PO-Revision-Date: 2017-06-22 09:02+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-meeting/fr/>\n"
@@ -1582,7 +1582,7 @@ msgstr ""
 msgid "msg_error_protocol_already_generated"
 msgstr "Le protocole pour la réunion ${title} a déjà été créé."
 
-#. Default: "When deciding an agendaitem the meeting will sent to hold state. Once the meeting is held, the agenda list is no longer editable."
+#. Default: "When deciding an agendaitem the agenda list is no longer editable."
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
 #: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "msg_hold_meeting_dialog"

--- a/opengever/meeting/locales/opengever.meeting.pot
+++ b/opengever/meeting/locales/opengever.meeting.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-11-16 10:22+0000\n"
+"POT-Creation-Date: 2017-11-27 14:08+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1579,7 +1579,7 @@ msgstr ""
 msgid "msg_error_protocol_already_generated"
 msgstr ""
 
-#. Default: "When deciding an agendaitem the meeting will sent to hold state. Once the meeting is held, the agenda list is no longer editable."
+#. Default: "When deciding an agendaitem the agenda list is no longer editable."
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
 #: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "msg_hold_meeting_dialog"


### PR DESCRIPTION
- Use `abschliessen` instead of `beschliessen` more consistently.
- Shorten description, drop technical details.