### PR TITLE
Fix bug for unknown mimetypes

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,7 @@ Changelog
 
 - Fix bux when accepting a multi admin unit team task with option participate. [phgross]
 - Fix an untranslated OC error message. [Rotonen]
+- Fix bug for unknown mimetypes [njohner]
 - Use latest ruby (2.4.2) and nokogiri (1.8.1) [siegy22]
 - Show icons in BlockedLocalRolesList. [njohner]
 - Fix bug when accepting a multiadmin unit team task. [phgross]

--- a/opengever/mail/browser/extract_attachments.py
+++ b/opengever/mail/browser/extract_attachments.py
@@ -33,6 +33,8 @@ def content_type_helper(item, content_type):
         result = mtr.lookup(content_type)
         if result and isinstance(result, tuple):
             mimetype = result[0]
+        else:
+            mimetype = None
 
     if mimetype:
         # Strip '.gif' from end of icon name and remove leading 'icon_'


### PR DESCRIPTION
One of the jpg has `image/jpg` as content type which is not a registered mimetype. I tried to add it as a new mimetype but could not make it work yet.

For now, simply fixing the missing condition will avoid crash and simply give a missing icon in the table, see below. That safeguard should anyway be there.

![screen shot 2017-11-27 at 16 54 56](https://user-images.githubusercontent.com/7374243/33276241-485679e0-d395-11e7-8543-5666cf533541.png)
fixes #3637 