### PR TITLE
Increase group title length.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2017.7.0 (unreleased)
 ---------------------
 
+- Increase group title length. [phgross]
 - Fix bux when accepting a multi admin unit team task with option participate. [phgross]
 - Fix an untranslated OC error message. [Rotonen]
 - Fix bug for unknown mimetypes [njohner]

--- a/opengever/core/upgrades/20171128092302_increase_group_title_length/upgrade.py
+++ b/opengever/core/upgrades/20171128092302_increase_group_title_length/upgrade.py
@@ -1,0 +1,18 @@
+from opengever.core.upgrade import SchemaMigration
+from sqlalchemy import String
+
+
+GROUP_TITLE_LENGTH = 255
+
+
+class IncreaseGroupTitleLength(SchemaMigration):
+    """Increase group title length.
+    """
+
+    def migrate(self):
+        self.op.alter_column(
+            'groups',
+            'title',
+            type_=String(GROUP_TITLE_LENGTH),
+            existing_nullable=True,
+            existing_type=String(50))

--- a/sources.cfg
+++ b/sources.cfg
@@ -10,6 +10,7 @@ development-packages =
   collective.js.timeago
 # https://github.com/4teamwork/plonetheme.teamraum/pull/595
   plonetheme.teamraum
+  opengever.ogds.models
 
 # Please cleanup your pull-request so that you are not adding ftw.*-packages
 # to the development-packages. It is your responsibility to release the


### PR DESCRIPTION
The limit of 50 makes no sense and bring problems with the new group title sync option (see https://github.com/4teamwork/opengever.core/pull/3638).

This PR contains only the schema migration, schema change in https://github.com/4teamwork/opengever.ogds.models/pull/50.