### PR TITLE
OGDS sync: handle multivalued group titles.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2017.7.0 (unreleased)
 ---------------------
 
+- OGDS sync: handle multivalued group titles. [phgross]
 - Increase group title length. [phgross]
 - Fix bux when accepting a multi admin unit team task with option participate. [phgross]
 - Fix an untranslated OC error message. [Rotonen]


### PR DESCRIPTION
The group title attribute is configurable by the IOGDSSyncConfiguration group_title_ldap_attribute configuration flag and can be a multivalued attribute.   