### PR TITLE
Register locales for opengever.officeconnector

### DIFF
--- a/opengever/officeconnector/configure.zcml
+++ b/opengever/officeconnector/configure.zcml
@@ -5,6 +5,8 @@
     xmlns:plone="http://namespaces.plone.org/plone"
     i18n_domain="opengever.officeconnector">
 
+  <i18n:registerTranslations directory="locales" />
+
   <include package=".browser" />
 
   <genericsetup:registerProfile


### PR DESCRIPTION
Seems I initially forgot to register the locales in ZCML and this caused translations to not work within the endpoint.