### PR TITLE
Add test attachment with wrong mimetype

### DIFF
--- a/opengever/mail/tests/test_extract_attachments.py
+++ b/opengever/mail/tests/test_extract_attachments.py
@@ -8,12 +8,15 @@ from ftw.testbrowser.pages import statusmessages
 from opengever.mail.browser.extract_attachments import content_type_helper
 from opengever.testing import FunctionalTestCase
 from opengever.testing import obj2brain
+from pkg_resources import resource_string
 from plone.app.testing import TEST_USER_ID
 from zope.annotation import IAnnotations
 from zope.i18n import translate
 
 
 MESSAGE_TEXT = 'Mime-Version: 1.0\nContent-Type: multipart/mixed; boundary=908752978\nTo: to@example.org\nFrom: from@example.org\nSubject: Attachment Test\nDate: Thu, 01 Jan 1970 01:00:00 +0100\nMessage-Id: <1>\n\n\n--908752978\nContent-Disposition: attachment;\n	filename*=iso-8859-1\'\'B%FCcher.txt\nContent-Type: text/plain;\n	name="=?iso-8859-1?Q?B=FCcher.txt?="\nContent-Transfer-Encoding: base64\n\nw6TDtsOcCg==\n\n--908752978--\n'
+MAIL_DATA_WRONG_MIMETYPE = resource_string(
+    'opengever.mail.tests', 'attachment_with_wrong_mimetype.txt')
 
 
 class TestExtractAttachmentView(FunctionalTestCase):
@@ -35,6 +38,16 @@ class TestExtractAttachmentView(FunctionalTestCase):
         self.assertEquals(
             'http://nohost/plone/dossier-1/document-1/extract_attachments',
             browser.url)
+
+    @browsing
+    def test_extract_attachments_can_handle_attachment_with_wrong_mimetype(self, browser):
+        # When rewriting as integration layer, use change_mail_data here
+        mail = create(
+            Builder("mail").with_message(MAIL_DATA_WRONG_MIMETYPE))
+        browser.login().open(mail, view='extract_attachments')
+        self.assertIsNotNone(browser.css('.icon-dokument_verweis'))
+        self.assertEquals([u'B\xfccher.txt'],
+                          browser.css('.listing td a').text)
 
     @browsing
     def test_shows_info_statusmessage_by_success(self, browser):
@@ -111,6 +124,11 @@ class TestContentTypeHelper(FunctionalTestCase):
         self.assertEquals(
             '<span class=icon-image />',
             content_type_helper({}, 'image/gif'))
+
+        # default for unknown types
+        self.assertEquals(
+            '<span class=icon-dokument_verweis />',
+            content_type_helper({}, 'something/unknown'))
 
     def test_lookup_via_filename_when_contenttype_is_octet_stream(self):
         item = {'position': 5,


### PR DESCRIPTION
Add tests to
* verify that mimetype lookup can handle unknown mimetypes
* verify that `extract_attachments` view can handle attachments with unknown mimetypes

solves #3689 