### PR TITLE
Make sure PDF Preview link is only available for documents,

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,8 +5,7 @@ Changelog
 2017.7.1 (unreleased)
 ---------------------
 
-- Nothing changed yet.
-
+- Make sure PDF Preview link is only available for documents not for mails. [phgross]
 
 2017.7.0 (2017-11-28)
 ---------------------

--- a/opengever/document/browser/actionbuttons.py
+++ b/opengever/document/browser/actionbuttons.py
@@ -1,5 +1,6 @@
 from opengever.base.pdfconverter import is_pdfconverter_enabled
 from opengever.document.browser.download import DownloadConfirmationHelper
+from opengever.document.document import IDocumentSchema
 from opengever.document.interfaces import ICheckinCheckoutManager
 from opengever.officeconnector.helpers import is_officeconnector_attach_feature_enabled  # noqa
 from plone import api
@@ -42,6 +43,15 @@ class ActionButtonRendererMixin(object):
         # XXX TODO: should be persistent called two times
         if is_pdfconverter_enabled():
             return True
+        return False
+
+    def is_download_pdfpreview_available(self):
+        """PDF Preview link is only available for documents and
+        opengever.pdfconverter is installed.
+        """
+
+        if self.is_preview_supported():
+            return IDocumentSchema.providedBy(self.context)
         return False
 
     def is_checkout_and_edit_available(self):

--- a/opengever/document/browser/templates/macros.pt
+++ b/opengever/document/browser/templates/macros.pt
@@ -99,7 +99,7 @@
 
             </tal:attach_feature_enabled>
 
-            <tal:pdf_preview tal:condition="preview_supported">
+            <tal:pdf_preview tal:condition="view/is_download_pdfpreview_available">
                 <a class="function-download-pdf" href="#"
                     tal:attributes="href string:${context/absolute_url}/download_pdfpreview?_authenticator=${context/@@authenticator/token}"
                     i18n:translate="label_pdf_preview">

--- a/opengever/document/tests/test_document_tooltip.py
+++ b/opengever/document/tests/test_document_tooltip.py
@@ -96,7 +96,7 @@ class TestDocumentTooltip(FunctionalTestCase):
     def test_preview_link_is_only_available_for_documents(self, browser):
         with PDFConverterAvailability(False):
             document = create(Builder('document').with_dummy_content())
-            mail = create(Builder('mail'))
+            mail = create(Builder('mail').with_dummy_message())
 
         with PDFConverterAvailability(True):
             browser.login().open(document, view='tooltip')

--- a/opengever/mail/tests/test_mail_overviewtab.py
+++ b/opengever/mail/tests/test_mail_overviewtab.py
@@ -51,7 +51,7 @@ class TestOverview(FunctionalTestCase):
                   ['Foreign Reference', ''],
                   ['Original message',
                    u'mehrere-anhange.eml \u2014 32 KB '
-                   u'Checkout and edit Download copy PDF Preview'],
+                   u'Checkout and edit Download copy'],
                   ['Attachments',
                    'Inneres Testma?il ohne Attachments.eml 1 KB '
                    'word_document.docx 22.4 KB '


### PR DESCRIPTION
not for mails. The opengever.pdfconverter only converts documents not mails.

There already a test for that case, but didn't fail because it tests
the actions with an empty mail.

Needs Backport: `2017.6-stable`