### PR TITLE
 Don't display nochange/remove for file in add-form.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ---------------------
 
 - Make sure PDF Preview link is only available for documents not for mails. [phgross]
+- Don't display nochange/remove radio buttons for file in document add-form. [deiferni]
 
 2017.7.0 (2017-11-28)
 ---------------------

--- a/opengever/document/configure.zcml
+++ b/opengever/document/configure.zcml
@@ -85,6 +85,22 @@
       for="*"
       />
 
+  <!-- custom add form for documents -->
+  <adapter
+      for="Products.CMFCore.interfaces.IFolderish
+           zope.publisher.interfaces.browser.IDefaultBrowserLayer
+           plone.dexterity.interfaces.IDexterityFTI"
+      provides="zope.publisher.interfaces.browser.IBrowserPage"
+      factory=".forms.DocumentAddView"
+      name="opengever.document.document"
+      />
+  <class class=".forms.DocumentAddView">
+    <require
+        permission="cmf.AddPortalContent"
+        interface="zope.publisher.interfaces.browser.IBrowserPage"
+        />
+  </class>
+
   <!-- custom edit form for documents -->
   <browser:page
       for="opengever.document.document.IDocumentSchema"

--- a/opengever/document/document.py
+++ b/opengever/document/document.py
@@ -133,9 +133,9 @@ class UploadValidator(validator.SimpleFieldValidator):
 
         raise Invalid(_(
             u'error_mail_upload',
-            default=u"It's not possible to add E-mails here, please '\
-            'send it to ${mailaddress} or drag it to the dossier '\
-            ' (Dragn'n'Drop).",
+            default=u"It's not possible to add E-mails here, please "
+            "send it to ${mailaddress} or drag it to the dossier "
+            "(Dragn'n'Drop).",
             mapping={'mailaddress': mail_address}
             ))
 

--- a/opengever/document/document.py
+++ b/opengever/document/document.py
@@ -131,6 +131,15 @@ class UploadValidator(validator.SimpleFieldValidator):
             mail_address = IEmailAddress(
                 self.request).get_email_for_object(parent)
 
+        # Remove widget value in order to disable that the widget renders
+        # radio-buttons (nochange/remove/replace) once a file has been
+        # uploaded.
+        # This is a special case since we are an additional validator
+        # for the file field that may block an otherwise valid file upload.
+        # The widget does not expect this to happen though.
+        if getattr(self.view.parentForm, '_nullify_file_on_error', False):
+            self.widget.value = None
+
         raise Invalid(_(
             u'error_mail_upload',
             default=u"It's not possible to add E-mails here, please "

--- a/opengever/document/forms.py
+++ b/opengever/document/forms.py
@@ -4,12 +4,24 @@ from opengever.document.interfaces import ICheckinCheckoutManager
 from opengever.document.interfaces import NO_DOWNLOAD_DISPLAY_MODE
 from opengever.document.interfaces import NO_DOWNLOAD_INPUT_MODE
 from plone.autoform import directives as form
+from plone.dexterity.browser import add
 from plone.dexterity.browser.edit import DefaultEditForm
 from plone.dexterity.events import EditFinishedEvent
 from plone.z3cform import layout
 from z3c.form import button
 from zope.component import queryMultiAdapter
 from zope.event import notify
+
+
+class DocumentAddForm(add.DefaultAddForm):
+
+    # hackishly tell validator to nullify uploaded file on validation
+    # errors for this add form.
+    _nullify_file_on_error = True
+
+
+class DocumentAddView(add.DefaultAddView):
+    form = DocumentAddForm
 
 
 class DocumentEditForm(DefaultEditForm):

--- a/opengever/document/tests/test_document.py
+++ b/opengever/document/tests/test_document.py
@@ -18,6 +18,7 @@ from opengever.officeconnector.interfaces import IOfficeConnectorSettings
 from opengever.testing import create_ogds_user
 from opengever.testing import FunctionalTestCase
 from opengever.testing import index_data_for
+from opengever.testing import IntegrationTestCase
 from opengever.testing import obj2brain
 from opengever.testing import OPENGEVER_FUNCTIONAL_TESTING
 from plone import api
@@ -533,17 +534,13 @@ class TestDocumentAuthorResolving(FunctionalTestCase):
         self.assertEquals('Muster Peter', document.document_author)
 
 
-class TestDocumentValidatorsInAddForm(FunctionalTestCase):
-
-    layer = OPENGEVER_FUNCTIONAL_TESTING
-
-    def setUp(self):
-        super(TestDocumentValidatorsInAddForm, self).setUp()
-        self.dossier = create(Builder('dossier'))
+class TestDocumentValidatorsInAddForm(IntegrationTestCase):
 
     @browsing
     def test_doc_without_either_file_or_paper_form_is_invalid(self, browser):
-        browser.login().open(self.dossier.absolute_url())
+        self.login(self.dossier_responsible, browser)
+        browser.open(self.dossier)
+
         factoriesmenu.add('Document')
         # No file, not preserved as paper
         browser.fill({'Title': 'My Document',
@@ -556,7 +553,9 @@ class TestDocumentValidatorsInAddForm(FunctionalTestCase):
 
     @browsing
     def test_doc_without_file_but_preserved_as_paper_is_valid(self, browser):
-        browser.login().open(self.dossier.absolute_url())
+        self.login(self.dossier_responsible, browser)
+        browser.open(self.dossier)
+
         factoriesmenu.add('Document')
         # No file, but preserved as paper
         browser.fill({'Title': 'My Document',
@@ -565,7 +564,9 @@ class TestDocumentValidatorsInAddForm(FunctionalTestCase):
 
     @browsing
     def test_doc_with_file_but_not_preserved_as_paper_is_valid(self, browser):
-        browser.login().open(self.dossier.absolute_url())
+        self.login(self.dossier_responsible, browser)
+        browser.open(self.dossier)
+
         factoriesmenu.add('Document')
         # File, but not preserved as paper
         browser.fill({'File': ('File data', 'file.txt', 'text/plain'),
@@ -574,7 +575,9 @@ class TestDocumentValidatorsInAddForm(FunctionalTestCase):
 
     @browsing
     def test_doc_with_both_file_and_preserved_as_paper_is_valid(self, browser):
-        browser.login().open(self.dossier.absolute_url())
+        self.login(self.dossier_responsible, browser)
+        browser.open(self.dossier)
+
         factoriesmenu.add('Document')
         # File AND preserved as paper
         browser.fill({'File': ('File data', 'file.txt', 'text/plain'),

--- a/opengever/document/tests/test_document.py
+++ b/opengever/document/tests/test_document.py
@@ -7,7 +7,8 @@ from ftw.testbrowser.pages.dexterity import erroneous_fields
 from ftw.testbrowser.pages.statusmessages import assert_message
 from ftw.testbrowser.pages.statusmessages import assert_no_error_messages
 from ftw.testing import freeze
-from opengever.base.interfaces import IReferenceNumber, ISequenceNumber
+from opengever.base.interfaces import IReferenceNumber
+from opengever.base.interfaces import ISequenceNumber
 from opengever.document.behaviors import IBaseDocument
 from opengever.document.document import IDocumentSchema
 from opengever.document.document import UploadValidator
@@ -29,9 +30,11 @@ from plone.namedfile.file import NamedBlobFile
 from Products.CMFCore.utils import getToolByName
 from z3c.form import interfaces
 from zope.component import createObject
+from zope.component import getAdapter
 from zope.component import getMultiAdapter
-from zope.component import queryMultiAdapter, getAdapter
-from zope.component import queryUtility, getUtility
+from zope.component import getUtility
+from zope.component import queryMultiAdapter
+from zope.component import queryUtility
 from zope.interface import Invalid
 from zope.schema import getFields
 import mimetypes


### PR DESCRIPTION
Backport needed: `2017.6-stable`

Don't display radio buttons to keep or remove a file in the add form, when there are validation errors. It does not make sense there since the document is being created.

The widget is rendered as follows:
![screen shot 2017-11-29 at 16 42 46](https://user-images.githubusercontent.com/736583/33383735-5e5178c2-d524-11e7-8f6f-37f5b01b641b.png)

Vs. old widget:
![screen shot 2017-11-29 at 10 52 03](https://user-images.githubusercontent.com/736583/33383746-62e507f0-d524-11e7-9dc8-798a117e97aa.png)
