### PR TITLE
Fix manual journal entry link on documents journal.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ---------------------
 
 - Remove ZIP export action on plonesite. [phgross]
+- Fix manual journal entry link on documents journal. [phgross]
 - Make sure PDF Preview link is only available for documents not for mails. [phgross]
 - Don't display nochange/remove radio buttons for file in document add-form. [deiferni]
 

--- a/opengever/journal/templates/journal_selection.pt
+++ b/opengever/journal/templates/journal_selection.pt
@@ -1,5 +1,6 @@
 <div class="actions" tal:condition="view/manual_entry_allowed">
   <a class="add_journal_entry" href="add-journal-entry"
+     tal:attributes="href string:${context/absolute_url}/add-journal-entry"
      i18n:domain="opengever.journal" i18n:translate="label_add_journal_entry">
     Add journal entry
   </a>

--- a/opengever/journal/tests/test_journal_tab.py
+++ b/opengever/journal/tests/test_journal_tab.py
@@ -105,6 +105,18 @@ class TestJournalTab(FunctionalTestCase):
         self.assertEquals([], browser.css('.add_journal_entry'))
 
     @browsing
+    def test_add_journal_entry_link_is_linked_to_current_context(self, browser):
+        dossier = create(Builder('dossier'))
+        document = create(Builder('document').within(dossier))
+
+        browser.login().open(document, view=u'tabbedview_view-journal')
+
+        link = browser.css('.add_journal_entry').first
+        self.assertEquals(
+            '{}/add-journal-entry'.format(document.absolute_url()),
+            link.get('href'))
+
+    @browsing
     def test_add_journal_entry_is_xss_safe(self, browser):
         dossier = create(Builder('dossier'))
 


### PR DESCRIPTION
Make sure the manual entry add form is called on the current context, so that the entry is added to the right journal.

Backport-needed: `2017.6-stable`