### PR TITLE
Correctly handle all responsibles while delegating.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -8,6 +8,8 @@ Changelog
 - Remove ZIP export action on plonesite. [phgross]
 - Make sure PDF Preview link is only available for documents not for mails. [phgross]
 - Don't display nochange/remove radio buttons for file in document add-form. [deiferni]
+- Fix an issue when delegating to inboxes. [deiferni]
+
 
 2017.7.0 (2017-11-28)
 ---------------------

--- a/opengever/task/browser/delegate/utils.py
+++ b/opengever/task/browser/delegate/utils.py
@@ -1,4 +1,5 @@
 from opengever.task.activities import TaskAddedActivity
+from opengever.task.util import update_reponsible_field_data
 from plone.dexterity.utils import addContentToContainer
 from plone.dexterity.utils import createContent
 from plone.dexterity.utils import iterSchemata
@@ -33,10 +34,9 @@ def create_subtasks(task, responsibles, documents, data):
     for responsible in responsibles:
         subtask_data = data.copy()
 
-        # responsible client & user
-        client, user = responsible.split(':', 1)
-        subtask_data['responsible_client'] = client
-        subtask_data['responsible'] = user
+        # correctly fill in responsible
+        subtask_data['responsible'] = responsible
+        update_reponsible_field_data(subtask_data)
 
         # remove predecessor
         subtask_data['predecessor'] = None


### PR DESCRIPTION
We need to use `update_reponsible_field_data` to correctly fill responsibles at the moment. This was not the case in this form yet.

Backport-needed: `2017.6-stable`

Tests will follow in a separate PR only for `master`. I've run into issues with local role datatypes in our test fixture.