### PR TITLE
Explicitly set globstar for the i18n tripwire script

### DIFF
--- a/test-i18n-de.cfg
+++ b/test-i18n-de.cfg
@@ -18,6 +18,8 @@ recipe = collective.recipe.template
 input = inline:
     #!/bin/bash
 
+    shopt -s globstar
+
     OUTPUT=""
 
     # Test building locales - split into 2 passes for different context lengths


### PR DESCRIPTION
Shell defaults and implementation details have varied over time and this is the most portable way to ensure the behaviour we seek.

Closes #3458