### PR TITLE
Add tests for delegating a task to an inbox.

### DIFF
--- a/opengever/api/tests/test_scanin.py
+++ b/opengever/api/tests/test_scanin.py
@@ -14,13 +14,13 @@ class TestScanIn(IntegrationTestCase):
     def create_single_inbox(self):
         inbox = create(Builder('inbox').titled(u'Inbox'))
         inbox.manage_setLocalRoles(self.regular_user.getId(),
-                                   ('Reader', 'Contributor', 'Editor'))
+                                   ['Reader', 'Contributor', 'Editor'])
         return inbox
 
     def create_org_unit_inbox(self):
         container = create(Builder('inbox_container').titled(u'Inboxes'))
         container.manage_setLocalRoles(self.regular_user.getId(),
-                                       ('Reader', 'Contributor', 'Editor'))
+                                       ['Reader', 'Contributor', 'Editor'])
         return create(Builder('inbox')
                       .titled(u'Inbox')
                       .within(container)

--- a/opengever/dossier/tests/test_protect_dossier.py
+++ b/opengever/dossier/tests/test_protect_dossier.py
@@ -26,7 +26,8 @@ class TestProtectDossier(IntegrationTestCase):
     def test_user_has_dossier_protect_permission_if_it_has_dossier_manager_on_repo_root(self):
         self.login(self.regular_user)
 
-        self.repository_root.manage_setLocalRoles(self.regular_user.getId(), ('DossierManager', ))
+        self.repository_root.manage_setLocalRoles(
+            self.regular_user.getId(), ['DossierManager'])
 
         self.assertTrue(
             api.user.has_permission('opengever.dossier: Protect dossier',
@@ -35,7 +36,8 @@ class TestProtectDossier(IntegrationTestCase):
     def test_user_has_permission_if_dossier_manager_on_repo(self):
         self.login(self.regular_user)
 
-        self.leaf_repofolder.manage_setLocalRoles(self.regular_user.getId(), ('DossierManager', ))
+        self.leaf_repofolder.manage_setLocalRoles(
+            self.regular_user.getId(), ['DossierManager'])
 
         self.assertTrue(
             api.user.has_permission('opengever.dossier: Protect dossier',
@@ -66,7 +68,7 @@ class TestProtectDossier(IntegrationTestCase):
         form.find_widget('Reading and writing').fill([self.regular_user.getId()])
         browser.click_on('Save')
         new_dossier = browser.context
-        new_dossier.manage_setLocalRoles('projekt_a', ('Contributor', ))
+        new_dossier.manage_setLocalRoles('projekt_a', ['Contributor'])
 
         self.assert_local_roles(
             IProtectDossier(new_dossier).READING_AND_WRITING_ROLES,
@@ -94,7 +96,7 @@ class TestProtectDossier(IntegrationTestCase):
         form.find_widget('Reading and writing').fill(self.regular_user.getId())
         browser.click_on('Save')
         new_dossier = browser.context
-        new_dossier.manage_setLocalRoles('projekt_a', ('Contributor', ))
+        new_dossier.manage_setLocalRoles('projekt_a', ['Contributor'])
 
         self.assert_local_roles(
             IProtectDossier(new_dossier).READING_AND_WRITING_ROLES,
@@ -324,7 +326,7 @@ class TestProtectDossier(IntegrationTestCase):
         dossier_protector = IProtectDossier(self.dossier)
         dossier_protector.reading = [self.regular_user.getId()]
         dossier_protector.protect()
-        self.dossier.manage_setLocalRoles(self.regular_user.getId(), ('DossierManager', ))
+        self.dossier.manage_setLocalRoles(self.regular_user.getId(), ['DossierManager'])
         view = getMultiAdapter((self.dossier, self.request),
                                name="check_protect_dossier_consistency")
 

--- a/opengever/meeting/tests/test_agendaitem_adhoc.py
+++ b/opengever/meeting/tests/test_agendaitem_adhoc.py
@@ -209,9 +209,9 @@ class TestWordAgendaItem(IntegrationTestCase):
     def test_error_when_no_access_to_meeting_dossier(self, browser):
         with self.login(self.administrator):
             self.committee_container.manage_setLocalRoles(
-                self.regular_user.getId(), ('Reader',))
+                self.regular_user.getId(), ['Reader'])
             self.committee.manage_setLocalRoles(
-                self.regular_user.getId(), ('CommitteeResponsible', 'Editor'))
+                self.regular_user.getId(), ['CommitteeResponsible', 'Editor'])
             self.committee_container.reindexObjectSecurity()
             # Let regular_user have no access to meeting_dossier
             self.meeting_dossier.__ac_local_roles_block__ = True

--- a/opengever/meeting/tests/test_agendaitem_word.py
+++ b/opengever/meeting/tests/test_agendaitem_word.py
@@ -299,9 +299,9 @@ class TestWordAgendaItem(IntegrationTestCase):
     def test_error_when_no_access_to_meeting_dossier(self, browser):
         with self.login(self.administrator):
             self.committee_container.manage_setLocalRoles(
-                self.regular_user.getId(), ('Reader',))
+                self.regular_user.getId(), ['Reader'])
             self.committee.manage_setLocalRoles(
-                self.regular_user.getId(), ('CommitteeResponsible', 'Editor'))
+                self.regular_user.getId(), ['CommitteeResponsible', 'Editor'])
             self.committee_container.reindexObjectSecurity()
             # Let regular_user have no access to meeting_dossier
             self.meeting_dossier.__ac_local_roles_block__ = True

--- a/opengever/task/tests/test_delegate.py
+++ b/opengever/task/tests/test_delegate.py
@@ -1,9 +1,36 @@
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
+from ftw.testbrowser.pages import statusmessages
+from opengever.ogds.base.utils import get_current_org_unit
 from opengever.testing import FunctionalTestCase
+from opengever.testing import IntegrationTestCase
 from plone.app.testing import TEST_USER_ID
 import datetime
+
+
+class TestDelegateTaskToInbox(IntegrationTestCase):
+
+    @browsing
+    def test_delegate_to_inbox(self, browser):
+        self.login(self.secretariat_user, browser)
+
+        browser.open(self.task,
+                     view='@@task_transition_controller',
+                     data={'transition': 'task-transition-delegate'})
+
+        form = browser.find_form_by_field('Responsibles')
+        form.find_widget('Responsibles').fill(
+            ['inbox:{}'.format(get_current_org_unit().id())])
+        browser.css('#form-buttons-save').first.click()  # can't use submit()
+
+        form = browser.find_form_by_field('Issuer')
+        form.find_widget('Issuer').fill(self.dossier_responsible.getId())
+
+        browser.css('#form-buttons-save').first.click()  # can't use submit()
+
+        self.assertEqual(['1 subtasks were create.'],
+                         statusmessages.info_messages())
 
 
 class TestDelegateTaskForm(FunctionalTestCase):

--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -159,9 +159,9 @@ class OpengeverContentFixture(object):
             .having(title_de=u'Ordnungssystem',
                     title_fr=u'Syst\xe8me de classement')))
         self.root.manage_setLocalRoles(self.org_unit.users_group_id,
-                                       ('Reader', 'Contributor', 'Editor'))
+                                       ['Reader', 'Contributor', 'Editor'])
         self.root.manage_setLocalRoles(self.secretariat_user.getId(),
-                                       ('Reviewer', 'Publisher'))
+                                       ['Reviewer', 'Publisher'])
         self.root.reindexObjectSecurity()
 
         self.repofolder0 = self.register('branch_repofolder', create(
@@ -171,7 +171,7 @@ class OpengeverContentFixture(object):
                     description=u'Alles zum Thema F\xfchrung.')))
 
         self.repofolder0.manage_setLocalRoles(self.dossier_manager.getId(),
-                                              ('DossierManager', ))
+                                              ['DossierManager'])
 
         self.repofolder0.reindexObjectSecurity()
 
@@ -193,9 +193,9 @@ class OpengeverContentFixture(object):
             .having(id='kontakte')))
 
         self.contactfolder.manage_setLocalRoles(
-            self.org_unit.users_group_id, ('Reader',))
+            self.org_unit.users_group_id, ['Reader'])
         self.contactfolder.manage_setLocalRoles(
-            self.org_unit.users_group_id, ('Reader', 'Contributor', 'Editor'))
+            self.org_unit.users_group_id, ['Reader', 'Contributor', 'Editor'])
         self.contactfolder.reindexObjectSecurity()
 
         self.hanspeter_duerr = self.register('hanspeter_duerr', create(
@@ -224,9 +224,9 @@ class OpengeverContentFixture(object):
             .titled(u'Vorlagen')
             .having(id='vorlagen')))
         templates.manage_setLocalRoles(self.org_unit.users_group_id,
-                                       ('Reader', ))
+                                       ['Reader'])
         templates.manage_setLocalRoles(self.administrator.getId(),
-                                       ('Reader', 'Contributor', 'Editor'))
+                                       ['Reader', 'Contributor', 'Editor'])
         templates.reindexObjectSecurity()
 
         self.sablon_template = self.register('sablon_template', create(
@@ -287,11 +287,11 @@ class OpengeverContentFixture(object):
                 )
             ))
         self.committee_container.manage_setLocalRoles(
-            self.committee_responsible.getId(), ('MeetingUser',))
+            self.committee_responsible.getId(), ['MeetingUser'])
         self.committee_container.manage_setLocalRoles(
-            self.meeting_user.getId(), ('MeetingUser',))
+            self.meeting_user.getId(), ['MeetingUser'])
         self.committee_container.manage_setLocalRoles(
-            self.administrator.getId(), ('CommitteeAdministrator',))
+            self.administrator.getId(), ['CommitteeAdministrator'])
         self.committee_container.reindexObjectSecurity()
 
         self.committee = self.register('committee', self.create_committee(
@@ -302,7 +302,7 @@ class OpengeverContentFixture(object):
                           self.committee_responsible]))
         self.register_raw('committee_id', self.committee.load_model().committee_id)
         self.committee.manage_setLocalRoles(
-            self.meeting_user.getId(), ('CommitteeMember',))
+            self.meeting_user.getId(), ['CommitteeMember'])
 
         self.committee_president = self.create_committee_membership(
             self.committee,
@@ -359,7 +359,7 @@ class OpengeverContentFixture(object):
         self.register_raw('empty_committee_id',
                           self.empty_committee.load_model().committee_id)
         self.empty_committee.manage_setLocalRoles(
-            self.meeting_user.getId(), ('CommitteeMember',))
+            self.meeting_user.getId(), ['CommitteeMember'])
         self.empty_committee.reindexObjectSecurity()
 
     @staticuid()
@@ -375,7 +375,7 @@ class OpengeverContentFixture(object):
             .titled(u'Dokument im Eingangsk\xf6rbli')
             .with_asset_file('text.txt')))
         self.inbox.manage_setLocalRoles(
-            self.secretariat_user.getId(), ('Contributor', 'Editor', 'Reader'))
+            self.secretariat_user.getId(), ['Contributor', 'Editor', 'Reader'])
         self.inbox.reindexObjectSecurity()
 
     @staticuid()
@@ -409,7 +409,9 @@ class OpengeverContentFixture(object):
         ))
 
         self.private_folder.manage_setLocalRoles(
-            self.regular_user.getId(), ('Publisher', 'Contributor', 'Reader', 'Owner', 'Reviewer', 'Editor'))
+            self.regular_user.getId(),
+            ['Publisher', 'Contributor', 'Reader', 'Owner', 'Reviewer',
+             'Editor'])
         self.private_folder.reindexObjectSecurity()
 
     @staticuid()

--- a/opengever/testing/test_case.py
+++ b/opengever/testing/test_case.py
@@ -121,7 +121,7 @@ class FunctionalTestCase(TestCase):
         if context is None:
             setRoles(self.portal, user_id, list(roles))
         else:
-            context.manage_setLocalRoles(user_id, tuple(roles))
+            context.manage_setLocalRoles(user_id, list(roles))
             context.reindexObjectSecurity()
 
         transaction.commit()


### PR DESCRIPTION
Add tests for https://github.com/4teamwork/opengever.core/pull/3708. This is a separate PR in order to avoid too many changes in the predecessor PR and make back-porting easier.

Also always use a `list` for local roles as this is expected by plone and may trip up `_mergedLocalRoles` when not doing so.

_CL was already provided in https://github.com/4teamwork/opengever.core/pull/3708, an additional one should not be necessary._

