### PR TITLE
Normalize appearance of 'all' and 'none' shortcuts.

### DIFF
--- a/opengever/mail/browser/extract_attachments.py
+++ b/opengever/mail/browser/extract_attachments.py
@@ -152,3 +152,6 @@ class ExtractAttachments(BrowserView):
             self.context.delete_attachments(positions)
         elif delete_action == 'all':
             self.context.delete_all_attachments()
+
+    def get_number_of_attachments(self):
+        return len(self.context.get_attachments())

--- a/opengever/mail/browser/templates/extract_attachments.pt
+++ b/opengever/mail/browser/templates/extract_attachments.pt
@@ -51,8 +51,10 @@
               </div>
               <br />
               <p i18n:domain="opengever.tabbedview" >
-                  <span i18n:translate="Choose:">Choose</span>:
-                  <a i18n:translate="all" href="#" id="all">All</a>
+                  <span i18n:translate="Choose">Choose</span>
+                  <a href="#" id="all">
+                    <span i18n:translate="label_tabbedview_filter_all"/>
+                    (<span tal:replace="view/get_number_of_attachments"></span>)</a>,
                   <a i18n:translate="none" href="#" id="none">None</a>
               </p>
 

--- a/opengever/tabbedview/browser/selection_with_filters.pt
+++ b/opengever/tabbedview/browser/selection_with_filters.pt
@@ -1,7 +1,7 @@
 <div class="tabbedview_select" i18n:domain="ftw.tabbedview">
 
     <tal:condition tal:condition="view/show_selects">
-      <span i18n:translate="">Choose:</span>
+      <span i18n:translate="">Choose</span>
       <a href="javascript:tabbedview.select_all()" i18n:translate="">
           all (<span i18n:name="amount" tal:replace="python:len(view.contents)" />)</a>,
       <a href="javascript:tabbedview.select_none()" i18n:translate="">none</a>

--- a/opengever/tabbedview/locales/de/LC_MESSAGES/opengever.tabbedview.po
+++ b/opengever/tabbedview/locales/de/LC_MESSAGES/opengever.tabbedview.po
@@ -23,7 +23,7 @@ msgstr "Aktiv"
 msgid "All visible entries chosen <a href=\"#\">x</a>"
 msgstr "Alle Sichtbaren ausgewählt <a href=\"#\">x</a>"
 
-msgid "Choose:"
+msgid "Choose"
 msgstr "Auswählen"
 
 #. Default: "Ersteller"

--- a/opengever/tabbedview/locales/fr/LC_MESSAGES/opengever.tabbedview.po
+++ b/opengever/tabbedview/locales/fr/LC_MESSAGES/opengever.tabbedview.po
@@ -25,7 +25,7 @@ msgstr "Actif"
 msgid "All visible entries chosen <a href=\"#\">x</a>"
 msgstr "Choix de toutes les entrées visibles <a href=\"#\">x</a>"
 
-msgid "Choose:"
+msgid "Choose"
 msgstr "Choix"
 
 msgid "Creator"

--- a/opengever/tabbedview/locales/opengever.tabbedview-manual.pot
+++ b/opengever/tabbedview/locales/opengever.tabbedview-manual.pot
@@ -163,7 +163,7 @@ msgid "All visible entries chosen <a href=\"#\">x</a>"
 msgstr ""
 
 -#: ./opengever/tabbedview/browser/tabs_templates/generic.pt:12
-msgid "Choose:"
+msgid "Choose"
 msgstr ""
 
 #: ./opengever/tabbedview/browser/tabs_templates/generic.pt:13

--- a/opengever/tabbedview/locales/opengever.tabbedview.pot
+++ b/opengever/tabbedview/locales/opengever.tabbedview.pot
@@ -24,7 +24,7 @@ msgstr ""
 msgid "All visible entries chosen <a href=\"#\">x</a>"
 msgstr ""
 
-msgid "Choose:"
+msgid "Choose"
 msgstr ""
 
 msgid "Creator"


### PR DESCRIPTION
Done!

<img width="395" alt="screen shot 2017-12-01 at 12 59 33" src="https://user-images.githubusercontent.com/7374243/33482043-85092fb8-d697-11e7-810a-32c205a6436d.png">

solves #3388 
