### PR TITLE
Document debug_docxcompose in docs.

### DIFF
--- a/docs/public/admin-manual/meeting/debugging.rst
+++ b/docs/public/admin-manual/meeting/debugging.rst
@@ -16,4 +16,9 @@ Verfügung:
   Protokoll einer Sitzung zu generieren und herunterzuladen, ohne dass das
   bestehende Protokoll (das im GEVER abgelegte Dokument) verändert wird.
 
+- Inhaltstyp Sitzung: ``debug_docxcompose`` ermöglicht es die ``docx`` Dateien,
+  die zum Protokoll zusammengesetzt werden, separat in einem ``zip``
+  herunterzuladen. Dies ermöglicht es Fehler im docxcompose einfacher zu
+  analysieren.
+
 .. disqus::


### PR DESCRIPTION
Add documentation for view added in https://github.com/4teamwork/opengever.core/pull/3710.