### PR TITLE
Correct dossier overview tests

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -534,6 +534,9 @@ Objects
           - self.word_proposal
         - self.empty_dossier
         - self.meeting_dossier
+          - self.meeting_document
+          - self.meeting_task
+            - self.meeting_subtask
     - self.empty_repofolder
   - self.templates
     - self.dossiertemplate

--- a/opengever/contentstats/tests/test_content_stats_integration.py
+++ b/opengever/contentstats/tests/test_content_stats_integration.py
@@ -178,11 +178,10 @@ class TestContentStatsIntegration(IntegrationTestCase):
             IStatsProvider, name='file_mimetypes')
 
         self.assertEqual({
-            '': 1,
             'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': 1,
             'application/vnd.openxmlformats-officedocument.wordprocessingml.document': 11,
             'message/rfc822': 2,
-            'text/plain': 1},
+            'text/plain': 2},
             stats_provider.get_raw_stats())
 
     @browsing
@@ -193,11 +192,10 @@ class TestContentStatsIntegration(IntegrationTestCase):
         table = browser.css('#content-stats-file_mimetypes').first
 
         self.assertEquals([
-            ['', '', '1'],
             ['', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', '1'],
             ['', 'application/vnd.openxmlformats-officedocument.wordprocessingml.document', '11'],
             ['', 'message/rfc822', '2'],
-            ['', 'text/plain', '1']],
+            ['', 'text/plain', '2']],
             table.lists())
 
     @browsing

--- a/opengever/contentstats/tests/test_content_stats_integration.py
+++ b/opengever/contentstats/tests/test_content_stats_integration.py
@@ -161,14 +161,14 @@ class TestContentStatsIntegration(IntegrationTestCase):
             (self.portal, self.portal.REQUEST),
             IStatsProvider, name='checked_out_docs')
 
-        self.assertEqual({'checked_out': 0, 'checked_in': 17},
+        self.assertEqual({'checked_out': 0, 'checked_in': 18},
                          stats_provider.get_raw_stats())
 
         # Check out a document
         getMultiAdapter((self.document, self.document.REQUEST),
                         ICheckinCheckoutManager).checkout()
 
-        self.assertEqual({'checked_out': 1, 'checked_in': 16},
+        self.assertEqual({'checked_out': 1, 'checked_in': 17},
                          stats_provider.get_raw_stats())
 
     def test_file_mimetypes_provider(self):
@@ -178,6 +178,7 @@ class TestContentStatsIntegration(IntegrationTestCase):
             IStatsProvider, name='file_mimetypes')
 
         self.assertEqual({
+            '': 1,
             'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': 1,
             'application/vnd.openxmlformats-officedocument.wordprocessingml.document': 11,
             'message/rfc822': 2,
@@ -192,6 +193,7 @@ class TestContentStatsIntegration(IntegrationTestCase):
         table = browser.css('#content-stats-file_mimetypes').first
 
         self.assertEquals([
+            ['', '', '1'],
             ['', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', '1'],
             ['', 'application/vnd.openxmlformats-officedocument.wordprocessingml.document', '11'],
             ['', 'message/rfc822', '2'],
@@ -206,7 +208,7 @@ class TestContentStatsIntegration(IntegrationTestCase):
         table = browser.css('#content-stats-checked_out_docs').first
 
         self.assertEquals(
-            [['', 'checked_in', '17'], ['', 'checked_out', '0']],
+            [['', 'checked_in', '18'], ['', 'checked_out', '0']],
             table.lists())
 
         # Check out a document
@@ -217,5 +219,5 @@ class TestContentStatsIntegration(IntegrationTestCase):
         table = browser.css('#content-stats-checked_out_docs').first
 
         self.assertEquals(
-            [['', 'checked_in', '16'], ['', 'checked_out', '1']],
+            [['', 'checked_in', '17'], ['', 'checked_out', '1']],
             table.lists())

--- a/opengever/meeting/tests/test_agendaitem_adhoc.py
+++ b/opengever/meeting/tests/test_agendaitem_adhoc.py
@@ -50,6 +50,18 @@ class TestWordAgendaItem(IntegrationTestCase):
 
     @browsing
     def test_cant_create_adhoc_when_no_access_to_meeting_dossier(self, browser):
+        self.login(self.committee_responsible, browser)
+        browser.open(self.meeting, view='agenda_items/schedule_text',
+                     data={'title': u'Fail',
+                           '_authenticator': createToken()})
+        self.assertEquals(
+            {u'messages': [
+                {u'messageTitle': u'Information',
+                 u'message': u'Text successfully added.',
+                 u'messageClass': u'info'}],
+             u'proceed': True},
+            browser.json)
+
         with self.login(self.administrator):
             # Let committee_responsible have no access to meeting_dossier
             self.meeting_dossier.__ac_local_roles_block__ = True

--- a/opengever/meeting/tests/test_meeting_dossier_overview.py
+++ b/opengever/meeting/tests/test_meeting_dossier_overview.py
@@ -1,14 +1,40 @@
 from ftw.testbrowser import browsing
-from opengever.dossier.tests.test_overview import TestOverview
+from opengever.dossier.tests import test_overview
 
 
-class TestMeetingDossierOverview(TestOverview):
+class TestMeetingDossierOverview(test_overview.TestOverview):
+
+    @property
+    def tested_dossier(self):
+        return self.meeting_dossier
+
+    @property
+    def tested_document(self):
+        return self.meeting_document
+
+    @property
+    def tested_task(self):
+        return self.meeting_task
+
+    @property
+    def tested_subtask(self):
+        return self.meeting_subtask
+
+    @property
+    def participants(self):
+        return [u'B\xe4rfuss K\xe4thi (kathi.barfuss)',
+                u'M\xfcller Fr\xe4nzi (franzi.muller)']
+
+    @property
+    def task_titles(self):
+        return [u'Programm \xdcberpr\xfcfen',
+                u'H\xf6rsaal reservieren']
 
     @browsing
     def test_meeting_is_linked_on_overview(self, browser):
         self.login(self.meeting_user, browser)
 
-        browser.login().open(self.meeting_dossier, view='tabbedview_view-overview')
+        browser.visit(self.meeting_dossier, view='tabbedview_view-overview')
 
         link = browser.css('#linked_meetingBox a').first
         self.assertEqual(

--- a/opengever/tabbedview/tests/test_personaloverview.py
+++ b/opengever/tabbedview/tests/test_personaloverview.py
@@ -169,7 +169,9 @@ class TestGlobalTaskListings(IntegrationTestCase):
 
         self.assertEquals(
             [u'Rechtliche Grundlagen in Vertragsentwurf \xdcberpr\xfcfen',
-             u'Vertragsentwurf \xdcberpr\xfcfen'],
+             u'Vertragsentwurf \xdcberpr\xfcfen',
+             u'Programm \xdcberpr\xfcfen',
+             u'H\xf6rsaal reservieren'],
             [row.get('Title') for row in browser.css('.listing').first.dicts()]
         )
 
@@ -177,7 +179,9 @@ class TestGlobalTaskListings(IntegrationTestCase):
 
         browser.open(view='tabbedview_view-myissuedtasks')
         self.assertEquals(
-            [u'Rechtliche Grundlagen in Vertragsentwurf \xdcberpr\xfcfen'],
+            [u'Rechtliche Grundlagen in Vertragsentwurf \xdcberpr\xfcfen',
+             u'Programm \xdcberpr\xfcfen',
+             u'H\xf6rsaal reservieren'],
             [row.get('Title') for row in browser.css('.listing').first.dicts()]
         )
 
@@ -188,7 +192,8 @@ class TestGlobalTaskListings(IntegrationTestCase):
 
         self.assertEquals(
             [u'Rechtliche Grundlagen in Vertragsentwurf \xdcberpr\xfcfen',
-             u'Vertragsentwurf \xdcberpr\xfcfen'],
+             u'Vertragsentwurf \xdcberpr\xfcfen', u'Programm \xdcberpr\xfcfen',
+             u'H\xf6rsaal reservieren'],
             [row.get('Title') for row in browser.css('.listing').first.dicts()]
         )
 
@@ -196,7 +201,8 @@ class TestGlobalTaskListings(IntegrationTestCase):
 
         browser.open(view='tabbedview_view-alltasks')
         self.assertEquals(
-            [u'Rechtliche Grundlagen in Vertragsentwurf \xdcberpr\xfcfen'],
+            [u'Rechtliche Grundlagen in Vertragsentwurf \xdcberpr\xfcfen',
+             u'Programm \xdcberpr\xfcfen', u'H\xf6rsaal reservieren'],
             [row.get('Title') for row in browser.css('.listing').first.dicts()]
         )
 
@@ -207,7 +213,9 @@ class TestGlobalTaskListings(IntegrationTestCase):
 
         self.assertEquals(
             [u'Rechtliche Grundlagen in Vertragsentwurf \xdcberpr\xfcfen',
-             u'Vertragsentwurf \xdcberpr\xfcfen'],
+             u'Vertragsentwurf \xdcberpr\xfcfen',
+             u'Programm \xdcberpr\xfcfen',
+             u'H\xf6rsaal reservieren'],
             [row.get('Title') for row in browser.css('.listing').first.dicts()]
         )
 
@@ -220,6 +228,7 @@ class TestGlobalTaskListings(IntegrationTestCase):
 
         browser.open(view='tabbedview_view-allissuedtasks')
         self.assertEquals(
-            [u'Rechtliche Grundlagen in Vertragsentwurf \xdcberpr\xfcfen'],
+            [u'Rechtliche Grundlagen in Vertragsentwurf \xdcberpr\xfcfen',
+             u'Programm \xdcberpr\xfcfen', u'H\xf6rsaal reservieren'],
             [row.get('Title') for row in browser.css('.listing').first.dicts()]
         )

--- a/opengever/task/tests/test_team_tasks.py
+++ b/opengever/task/tests/test_team_tasks.py
@@ -27,7 +27,7 @@ class TestTeamTasks(IntegrationTestCase):
         form.find_widget('Responsible').fill('team:1')
         browser.find('Save').click()
 
-        task = self.dossier.get('task-3')
+        task = self.dossier.get('task-5')
 
         self.assertEquals('Team Task', task.title)
         self.assertEquals('team:1', task.responsible)
@@ -72,7 +72,7 @@ class TestTeamTasks(IntegrationTestCase):
         browser.find('Save').click()
         create_session().flush()
 
-        task = self.dossier.get('task-3')
+        task = self.dossier.get('task-5')
 
         center = notification_center()
         # Assign watchers to a local variable in order to avoid having
@@ -167,9 +167,9 @@ class TestTeamTasks(IntegrationTestCase):
         self.login(self.regular_user, browser=browser)
 
         ra_admin_unit = create(Builder('admin_unit')
-                                 .having(title=u'Ratskanzlei',
-                                         unit_id=u'rk',
-                                         public_url='http://nohost/plone'))
+                                .having(title=u'Ratskanzlei',
+                                        unit_id=u'rk',
+                                        public_url='http://nohost/plone'))
 
         create(Builder('org_unit')
                .id('rk')

--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -595,7 +595,8 @@ class OpengeverContentFixture(object):
             Builder('document').within(self.meeting_dossier)
             .titled(u'Programm')
             .having(document_date=datetime(2016, 12, 1),
-                    document_author=TEST_USER_ID)))
+                    document_author=TEST_USER_ID)
+            .with_asset_file('text.txt')))
 
         self.meeting = create(
             Builder('meeting')


### PR DESCRIPTION
Tests for the `MeetingDossier` overview were not executed anymore since we moved them to `IntegrationTestCase`. Instead we executed the tests twice for the `Dossier` overview. This test inherits from the `dossier.tests.test_overview.TestOverview`, and used to (when still on the `FunctionalLayer`) redefine the `setUp` method to work on a `MeetingDossier` instead of a `Dossier`. This is not so easily done in the `IntegrationLayer` and had not been taken care of.

Several elements were missing in the fixture to allow testing of the `MeetingDossier` overview. To reuse the test of the `Dossier` for the `MeetingDossier` I needed a similar structure in both the `dossier` and `meeting_dossier`. The `OpengeverContentFixture` was modified as follows:
* Add a document `meeting_document` in the `meeting_dossier`
* Add a task `meeting_task` in the `meeting_dossier`
* Add a sub-task in `meeting_task`
* Related the `closed_meeting_dossier` to both the `dossier` and `meeting_dossier`
* Removed relation between `meeting_dossier` and `dossier`

To run the same tests once on the `dossier` and once on the `meeting_dossier` of the `OpengeverContentFixture`, we defined the tested elements and expected results in the `setUp` method. As we're not allowed to access the `ordnungssystem` in this context, we define them as `str` and then use the `eval` function in the tests. This is a bit of a hack and if you have a cleaner solution let me know!

Of course I also had to adapt a few other tests to account for the changes in the `OpengeverContentFixture`.