### PR TITLE
Correct import in test_meeting_dossier_byline.

### DIFF
--- a/opengever/meeting/tests/test_meeting_dossier_byline.py
+++ b/opengever/meeting/tests/test_meeting_dossier_byline.py
@@ -1,10 +1,10 @@
 from datetime import date
 from ftw.builder import Builder
 from ftw.builder import create
-from opengever.dossier.tests.test_dossier_byline import TestDossierByline
+from opengever.dossier.tests import test_dossier_byline
 
 
-class TestMeetingDossierByline(TestDossierByline):
+class TestMeetingDossierByline(test_dossier_byline.TestDossierByline):
 
     def create_dossier(self):
         return create(Builder('meeting_dossier')


### PR DESCRIPTION
We should not import a test class in the current namespace. Otherwise all its tests get executed.
This happened only twice in the gever code, both are fixed now (the other one in https://github.com/4teamwork/opengever.core/pull/3725)