### PR TITLE
Move test_dossier_workflow to IntegrationLayer

### DIFF
--- a/opengever/dossier/tests/test_dossier_workflow.py
+++ b/opengever/dossier/tests/test_dossier_workflow.py
@@ -1,40 +1,38 @@
-from ftw.builder import Builder
-from ftw.builder import create
 from ftw.testbrowser import browsing
-from opengever.testing import FunctionalTestCase
+from ftw.testbrowser.pages import editbar
+from opengever.testing import IntegrationTestCase
 from plone import api
 from zExceptions import Unauthorized
 
 
-class TestDossierWorkflow(FunctionalTestCase):
+class TestDossierWorkflow(IntegrationTestCase):
 
     def test_deleting_dossier_is_only_allowed_for_managers(self):
-        repository_root, repository = create(Builder('repository_tree'))
-        dossier = create(Builder('dossier').within(repository))
-
-        acl_users = api.portal.get_tool('acl_users')
-        valid_roles = list(acl_users.portal_role_manager.valid_roles())
-        valid_roles.remove('Manager')
-        self.grant(*valid_roles)
-
+        self.login(self.dossier_manager)
+        self.assert_has_not_permissions(["Delete objects"], self.dossier)
         with self.assertRaises(Unauthorized):
-            api.content.delete(obj=dossier)
+            api.content.delete(obj=self.dossier)
+        self.login(self.manager)
+        self.assert_has_permissions(["Delete objects"], self.dossier)
+
+    @staticmethod
+    def get_action_menu_content():
+        editbar.menu("Actions")
+        actions = editbar.menu("Actions").css("li")
+        return [el.text for el in actions]
 
     @browsing
     def test_offer_transition_is_hidden_in_action_menu(self, browser):
-        self.grant('Manager')
-        dossier = create(Builder('dossier').as_expired())
-
-        browser.login().open(dossier)
-        self.assertEquals(
-            [], browser.css('#workflow-transition-dossier-transition-offer'))
+        self.login(self.manager, browser)
+        browser.visit(self.archive_dossier)
+        expected = ['Cover (PDF)', 'Delete', 'Export as Zip',
+                    'Print details (PDF)', 'Properties', 'Sharing']
+        self.assertItemsEqual(expected, self.get_action_menu_content())
 
     @browsing
     def test_archive_transition_is_hidden_in_action_menu(self, browser):
-        self.grant('Manager')
-        dossier = create(Builder('dossier')
-                         .in_state('dossier-state-offered'))
-
-        browser.login().open(dossier)
-        self.assertEquals(
-            [], browser.css('#workflow-transition-dossier-transition-archive'))
+        self.login(self.dossier_manager, browser)
+        browser.visit(self.dossier)
+        expected = ['Cover (PDF)', 'Export as Zip', 'Print details (PDF)',
+                    'Properties', 'dossier-transition-deactivate']
+        self.assertItemsEqual(expected, self.get_action_menu_content())


### PR DESCRIPTION
I think I would need some input here. All 3 tests tested were testing only negative results, which is not very robust. I added a positive test for `test_deleting_dossier_is_only_allowed_for_managers`. For the two others I could not find any situation where these two workflow transitions appear in the action menu.