### PR TITLE
Change faulty content types from unauthorized document revert redirects

### DIFF
--- a/opengever/document/checkout/manager.py
+++ b/opengever/document/checkout/manager.py
@@ -272,6 +272,8 @@ class CheckinCheckoutManager(object):
         reverting.
         """
         if not force and not self.is_revert_allowed():
+            # Avoid plone.protect unnecessarily jumping in
+            self.request.response.setHeader('content-type', 'text/plain')
             raise Unauthorized()
 
         version = self.versioner.retrieve_version(version_id)

--- a/opengever/document/checkout/revert.py
+++ b/opengever/document/checkout/revert.py
@@ -6,8 +6,8 @@ from zope.component import getMultiAdapter
 
 
 class RevertFileToVersion(BrowserView):
-    """Reverts the file of a document to a specific version.
-    """
+    """Reverts the file of a document to a specific version."""
+
     def __call__(self):
         version_id = self.request.get('version_id')
 
@@ -19,7 +19,7 @@ class RevertFileToVersion(BrowserView):
         # create a status message
         msg = _(u'Reverted file to version ${version_id}.',
                 mapping=dict(version_id=version_id))
-        IStatusMessage(self.request).addStatusMessage(msg, type='info')
+        IStatusMessage(self.request).addStatusMessage(msg)
 
         # redirect back to file view
         return self.request.RESPONSE.redirect(self.context.absolute_url())


### PR DESCRIPTION
The redirect cascade upon `Unauthorized` access currently makes `plone.protect` jump in 4 times unnecessarily.

Also cleaned up the checkout manager a bit.