### PR TITLE
Port bumblebee tests to integration tests.

### DIFF
--- a/opengever/core/testing.py
+++ b/opengever/core/testing.py
@@ -7,8 +7,6 @@ from ftw.bumblebee.tests.helpers import BumblebeeTestTaskQueue
 from ftw.testbrowser import TRAVERSAL_BROWSER_FIXTURE
 from ftw.testing import ComponentRegistryLayer
 from ftw.testing import FTWIntegrationTesting
-from ftw.testing import FTWIntegrationTesting
-from ftw.testing import TransactionInterceptor
 from ftw.testing.layer import COMPONENT_REGISTRY_ISOLATION
 from ftw.testing.quickinstaller import snapshots
 from opengever.activity.interfaces import IActivitySettings
@@ -28,27 +26,21 @@ from opengever.private import enable_opengever_private
 from plone import api
 from plone.app.testing import applyProfile
 from plone.app.testing import FunctionalTesting
-from plone.app.testing import IntegrationTesting
 from plone.app.testing import logout
 from plone.app.testing import PloneSandboxLayer
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
 from plone.browserlayer.utils import unregister_layer
 from plone.dexterity.schema import SCHEMA_CACHE
-from plone.protect.auto import safeWrite
 from plone.testing import z2
-from plone.transformchain.interfaces import ITransform
 from Products.CMFCore.utils import getToolByName
 from Testing.ZopeTestCase.utils import setupCoreSessions
 from unittest import TestCase
-from zope.component import getGlobalSiteManager
-from zope.component import getMultiAdapter
 from zope.component import getSiteManager
 from zope.configuration import xmlconfig
 from zope.globalrequest import setRequest
 from zope.sqlalchemy import datamanager
 from zope.sqlalchemy.datamanager import mark_changed
-from ZPublisher.interfaces import IPubAfterTraversal
 import logging
 import os
 import sys

--- a/opengever/document/tests/test_bumblebee.py
+++ b/opengever/document/tests/test_bumblebee.py
@@ -19,35 +19,30 @@ from plone.uuid.interfaces import IUUID
 from zope.component import getMultiAdapter
 from zope.event import notify
 from zope.lifecycleevent import ObjectModifiedEvent
+from opengever.testing import IntegrationTestCase
 
 
-class TestBumblebeeIntegrationWithDisabledFeature(FunctionalTestCase):
+class TestBumblebeeIntegrationWithDisabledFeature(IntegrationTestCase):
     """Test integration of ftw.bumblebee."""
 
-    def setUp(self):
-        super(TestBumblebeeIntegrationWithDisabledFeature, self).setUp()
-
-        self.document = create(Builder('document')
-                               .attach_file_containing(
-                                   bumblebee_asset('example.docx').bytes(),
-                                   u'example.docx'))
-
     def test_bumblebee_checksum_is_calculated_for_opengever_docs(self):
+        self.login(self.dossier_responsible)
+
         self.assertEquals(
             DOCX_CHECKSUM,
             IBumblebeeDocument(self.document).get_checksum())
 
     def test_opengever_documents_have_a_primary_field(self):
+        self.login(self.dossier_responsible)
+
         fieldinfo = IPrimaryFieldInfo(self.document)
         self.assertEqual('file', fieldinfo.fieldname)
 
     @browsing
     def test_document_preview_is_hidden(self, browser):
-        dossier = create(Builder('dossier'))
-        document = create(Builder('document').within(dossier))
+        self.login(self.dossier_responsible, browser)
 
-        browser.login().visit(document, view='tabbedview_view-overview')
-
+        browser.visit(self.document, view='tabbedview_view-overview')
         self.assertEqual(0, len(browser.css('.documentPreview')))
 
 

--- a/opengever/document/tests/test_bumblebee.py
+++ b/opengever/document/tests/test_bumblebee.py
@@ -5,21 +5,13 @@ from ftw.bumblebee.tests.helpers import asset as bumblebee_asset
 from ftw.bumblebee.tests.helpers import DOCX_CHECKSUM
 from ftw.bumblebee.tests.helpers import get_queue
 from ftw.testbrowser import browsing
-from opengever.core.testing import OPENGEVER_FUNCTIONAL_BUMBLEBEE_LAYER
-from opengever.document.interfaces import ICheckinCheckoutManager
-from opengever.dossier.interfaces import ITemplateFolderProperties
 from opengever.testing import assets
-from opengever.testing import FunctionalTestCase
+from opengever.testing import IntegrationTestCase
 from opengever.testing import obj2brain
 from opengever.testing.helpers import create_document_version
-from plone import api
 from plone.namedfile.file import NamedBlobFile
 from plone.rfc822.interfaces import IPrimaryFieldInfo
 from plone.uuid.interfaces import IUUID
-from zope.component import getMultiAdapter
-from zope.event import notify
-from zope.lifecycleevent import ObjectModifiedEvent
-from opengever.testing import IntegrationTestCase
 
 
 class TestBumblebeeIntegrationWithDisabledFeature(IntegrationTestCase):
@@ -46,76 +38,61 @@ class TestBumblebeeIntegrationWithDisabledFeature(IntegrationTestCase):
         self.assertEqual(0, len(browser.css('.documentPreview')))
 
 
-class TestBumblebeeIntegrationWithEnabledFeature(FunctionalTestCase):
+class TestBumblebeeIntegrationWithEnabledFeature(IntegrationTestCase):
 
+    features = ('bumblebee', )
     maxDiff = None
-    layer = OPENGEVER_FUNCTIONAL_BUMBLEBEE_LAYER
 
     @browsing
     def test_document_preview_is_visible(self, browser):
-        dossier = create(Builder('dossier'))
-        document = create(Builder('document').within(dossier))
+        self.login(self.dossier_responsible, browser)
 
-        browser.login().visit(document, view='tabbedview_view-overview')
-
+        browser.visit(self.document, view='tabbedview_view-overview')
         self.assertEqual(1, len(browser.css('.documentPreview')))
 
     @browsing
     def test_link_previews_to_bumblebee_overlay_document(self, browser):
-        dossier = create(Builder('dossier'))
-        document = create(Builder('document').within(dossier))
+        self.login(self.dossier_responsible, browser)
 
-        create(Builder('document').within(dossier))
-
-        browser.login().visit(document, view="tabbedview_view-overview")
-
+        browser.visit(self.document, view="tabbedview_view-overview")
         preview_element = browser.css('.documentPreview .showroom-item')
-        self.assertEqual(
-            'http://nohost/plone/dossier-1/document-1/@@bumblebee-overlay-document',
-            preview_element.first.get('data-showroom-target'))
+        url = preview_element.first.get('data-showroom-target')
+        self.assertTrue(url.endswith('@@bumblebee-overlay-document'))
 
     def test_does_not_queue_bumblebee_storing_if_not_digitally_available(self):
-        create(Builder('document'))
+        self.login(self.dossier_responsible)
+
+        create(Builder('document').within(self.dossier))
         queue = get_queue()
         self.assertEquals(0, len(queue), 'Expected no job in the queue.')
 
     def test_prevents_checked_out_document_checksum_update(self):
-        document = create(Builder('document')
-                          .attach_file_containing(
-                              bumblebee_asset('example.docx').bytes(),
-                              u'example.docx')
-                          .checked_out())
+        self.login(self.dossier_responsible)
+        self.checkout_document(self.document)
 
         self.assertEquals(
             DOCX_CHECKSUM,
-            IBumblebeeDocument(document).get_checksum())
+            IBumblebeeDocument(self.document).get_checksum())
 
-        document.update_file('foo',
-                             content_type='text/plain',
-                             filename=u'foo.txt')
-        notify(ObjectModifiedEvent(document))
+        self.document.update_file('foo', content_type='text/plain',
+                                  filename=u'foo.txt')
+        IBumblebeeDocument(self.document).handle_modified()
 
         self.assertEquals(
             DOCX_CHECKSUM,
-            IBumblebeeDocument(document).get_checksum())
+            IBumblebeeDocument(self.document).get_checksum())
 
     def test_queues_bumblebee_storing_after_document_checkin(self):
-        dossier = create(Builder('dossier'))
-        document = create(Builder('document')
-                          .within(dossier)
-                          .attach_file_containing(
-                              'foo',
-                              u'example.docx')
-                          .checked_out())
+        self.login(self.dossier_responsible)
+
+        self.checkout_document(self.subdocument)
         queue = get_queue()
         queue.reset()
 
-        document.update_file(bumblebee_asset('example.docx').bytes(),
-                             content_type='text/plain',
-                             filename=u'example.docx')
-        manager = getMultiAdapter((document, self.portal.REQUEST),
-                                  ICheckinCheckoutManager)
-        manager.checkin()
+        self.subdocument.update_file(bumblebee_asset('example.docx').bytes(),
+                                     content_type='text/plain',
+                                     filename=u'example.docx')
+        self.checkin_document(self.subdocument)
 
         self.assertEquals(1, len(queue), 'Expected 1 job in the queue.')
         job, = queue.queue
@@ -124,29 +101,28 @@ class TestBumblebeeIntegrationWithEnabledFeature(FunctionalTestCase):
             {'application': 'local',
              'file_url': ('http://nohost/plone/bumblebee_download' +
                           '?checksum={}'.format(DOCX_CHECKSUM) +
-                          '&uuid={}'.format(IUUID(document))),
-             'salt': IUUID(document),
+                          '&uuid={}'.format(IUUID(self.subdocument))),
+             'salt': IUUID(self.subdocument),
              'checksum': DOCX_CHECKSUM,
              'deferred': False,
-             'url': '/plone/dossier-1/document-1/bumblebee_trigger_storing'},
+             'url': '/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen'
+                    '/dossier-1/dossier-2/document-11/'
+                    'bumblebee_trigger_storing'},
             job)
 
     def test_queues_bumblebee_storing_after_revert_to_previous_version(self):
-        dossier = create(Builder('dossier'))
-        document = create(Builder('document')
-                          .within(dossier)
-                          .attach_file_containing('bar', u'example.docx'))
+        self.login(self.dossier_responsible)
 
-        document.file = NamedBlobFile(data='foo', filename=u'example.docx')
+        self.subdocument.update_file('foo', content_type='text/plain',
+                                     filename=u'foo.txt')
 
-        create_document_version(document, 1,
+        create_document_version(self.subdocument, 1,
                                 data=bumblebee_asset('example.docx').bytes())
-        create_document_version(document, 2)
+        create_document_version(self.subdocument, 2)
         queue = get_queue()
         queue.reset()
 
-        manager = getMultiAdapter((document, self.portal.REQUEST),
-                                  ICheckinCheckoutManager)
+        manager = self.get_checkout_manager(self.subdocument)
         manager.revert_to_version(1)
 
         self.assertEquals(1, len(queue), 'Expected 1 job in the queue.')
@@ -156,37 +132,31 @@ class TestBumblebeeIntegrationWithEnabledFeature(FunctionalTestCase):
             {'application': 'local',
              'file_url': ('http://nohost/plone/bumblebee_download' +
                           '?checksum={}'.format(DOCX_CHECKSUM) +
-                          '&uuid={}'.format(IUUID(document))),
-             'salt': IUUID(document),
+                          '&uuid={}'.format(IUUID(self.subdocument))),
+             'salt': IUUID(self.subdocument),
              'checksum': DOCX_CHECKSUM,
              'deferred': False,
-             'url': '/plone/dossier-1/document-1/bumblebee_trigger_storing'},
+             'url': '/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen'
+                    '/dossier-1/dossier-2/document-11/'
+                    'bumblebee_trigger_storing'},
             job)
 
-    @browsing
-    def test_updates_checksum_and_queue_storing_after_docproperty_update(self, browser):
-        api.portal.set_registry_record('create_doc_properties',
-                                       interface=ITemplateFolderProperties,
-                                       value=True)
+    def test_updates_checksum_after_docproperty_update(self):
+        self.activate_feature('doc-properties')
+        self.login(self.dossier_responsible)
 
-        dossier = create(Builder('dossier'))
-        document = create(Builder('document')
-                          .within(dossier)
-                          .checked_out()
-                          .with_asset_file('with_gever_properties.docx'))
+        self.checkout_document(self.document)
 
-        # update
-        document.file = NamedBlobFile(
+        self.document.file = NamedBlobFile(
             data=assets.load(u'with_gever_properties_update.docx'),
             filename=u'with_gever_properties.docx')
-        checksum_before = IBumblebeeDocument(document).update_checksum()
+        checksum_before = IBumblebeeDocument(self.document).update_checksum()
 
-        browser.login().open(document)
-        browser.click_on('without comment')
+        self.checkin_document(self.document)
 
         self.assertNotEqual(
-            checksum_before, IBumblebeeDocument(document).get_checksum(),
+            checksum_before, IBumblebeeDocument(self.document).get_checksum(),
             'Document checksum not updated after docproperties update.')
         self.assertNotEqual(
-            checksum_before, obj2brain(document).bumblebee_checksum,
+            checksum_before, obj2brain(self.document).bumblebee_checksum,
             'Document checksum not updated after docproperties update.')

--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -7,6 +7,7 @@ from datetime import datetime
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.builder import ticking_creator
+from ftw.bumblebee.tests.helpers import asset as bumblebee_asset
 from ftw.testing import freeze
 from ftw.testing import staticuid
 from functools import wraps
@@ -449,7 +450,9 @@ class OpengeverContentFixture(object):
                     document_type='contract',
                     receipt_date=datetime(2010, 1, 3),
                     delivery_date=datetime(2010, 1, 3))
-            .with_asset_file('vertragsentwurf.docx')))
+            .attach_file_containing(
+                    bumblebee_asset('example.docx').bytes(),
+                    u'vertragsentwurf.docx')))
 
         task = self.register('task', create(
             Builder('task').within(self.dossier)

--- a/opengever/testing/integration_test_case.py
+++ b/opengever/testing/integration_test_case.py
@@ -433,6 +433,11 @@ class IntegrationTestCase(TestCase):
         """
         return self.get_checkout_manager(document).checkout()
 
+    def checkin_document(self, document):
+        """Checkin the given document.
+        """
+        return self.get_checkout_manager(document).checkin()
+
     def get_checkout_manager(self, document):
         """Returns the checkin checkout manager for a document.
         """


### PR DESCRIPTION
Port some bumblebee tests to integration tests.
Also provide setup required for bumblebee in the fixture, but make sure to turn it off by default. It  must be enabled with the `features` test class variable or per test with `enable_feature`.