### PR TITLE
Version and changelog cleanup after 2017.7.3 hotfix release

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -10,7 +10,12 @@ Changelog
 - Improve Office Connector testing. [Rotonen]
 - SPV: Make title and dossier column wider and remove invalid sorting options in meetings tab. [tarnap]
 
+
+2017.7.3 (2017-12-08)
+---------------------
+
 - Ignore ContainerModifiedEvents on ObjectModified event handlers. [phgross]
+
 
 2017.7.2 (2017-12-01)
 ---------------------

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -2,7 +2,7 @@
 Changelog
 =========
 
-2017.7.3 (unreleased)
+2017.8.0 (unreleased)
 ---------------------
 
 - Implement workspace module basics [raphael-s]

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 import os
 
 
-version = '2017.7.3.dev0'
+version = '2017.8.0.dev0'
 maintainer = '4teamwork AG'
 
 


### PR DESCRIPTION
- Bump next version to 2017.8.0.
- Clean up changelog after releasing hotfix-relase 2017.7.3. Release has been created from 2017.7-stable release
