### PR TITLE
Pin plone.recipe.command version to 1.1

### DIFF
--- a/versions.cfg
+++ b/versions.cfg
@@ -164,6 +164,7 @@ plone.app.versioningbehavior = 1.3.1
 plone.intelligenttext = 2.2.0
 plone.principalsource = 1.0
 plone.protect = 3.0.25
+plone.recipe.command = 1.1
 plone.recipe.precompiler = 0.6
 plone.rest = 1.0b1
 plone.restapi = 1.0a23


### PR DESCRIPTION
because of using production-v2.cfg in ftw-buildouts on our new gever server, we have to pin "plone.recipe.command = 1.1" in versions.cfg.