### PR TITLE
Actually make a copy of os.environ for the workers

### DIFF
--- a/bin/mtest
+++ b/bin/mtest
@@ -2,7 +2,6 @@
 """A concurrent wrapper for timing xmltestrunner tests for opengever.core."""
 from __future__ import print_function
 from argparse import ArgumentParser
-from copy import copy
 from fnmatch import fnmatch
 from logging import DEBUG
 from logging import Formatter
@@ -173,7 +172,7 @@ def run_tests(test_run_params):
 
     # ZServer tests will be run separately of everything else per layer
     # separation
-    env = copy(environ)
+    env = environ.copy()
     env['ZSERVER_PORT'] = env.get('PORT1', '55000')
 
     start = time()

--- a/bin/mtest
+++ b/bin/mtest
@@ -100,8 +100,15 @@ def create_test_run_params():
         )
 
     if CONCURRENCY > 1:
-        module_negation = tuple(''.join(('!', module, )) for module in standalone_modules)
-        layer_negation = tuple(''.join(('!', layer, )) for layer in standalone_layers)
+        module_negation = tuple(
+            ''.join(('!', module, ))
+            for module in standalone_modules
+            )
+
+        layer_negation = tuple(
+            ''.join(('!', layer, ))
+            for layer in standalone_layers
+            )
 
         for layer in standalone_layers:
             test_run_params.append({
@@ -164,7 +171,8 @@ def run_tests(test_run_params):
 
     logger.debug('Start: %s %s', layers, modules)
 
-    # ZServer tests will be run separately of everything else per layer separation
+    # ZServer tests will be run separately of everything else per layer
+    # separation
     env = copy(environ)
     env['ZSERVER_PORT'] = env.get('PORT1', '55000')
 
@@ -256,7 +264,14 @@ def main():
     pool.close()
     pool.join()
 
-    logger.debug('Aggregate runtime %s.', humanize_time(sum(i.get('runtime', 0.0) for i in results)))
+    logger.debug(
+        'Aggregate runtime %s.',
+        humanize_time(sum(
+            i.get('runtime', 0.0)
+            for i in results
+            ))
+        )
+
     logger.debug('Wallclock runtime %s.', humanize_time(time() - start))
 
     handle_results(results)
@@ -309,11 +324,23 @@ if __name__ == '__main__':
     # Set up logging to stdout
     stream_handler = StreamHandler()
     stream_handler.setLevel(default_loglevel)
-    log_formatter = Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+    log_formatter = Formatter(
+        ' - '.join((
+            '%(asctime)s',
+            '%(name)s',
+            '%(levelname)s',
+            '%(message)s',
+            )),
+        )
     stream_handler.setFormatter(log_formatter)
 
-    # Buffer log messages so we do not get broken-by-racecondition debug log lines in stdout
-    memory_handler = MemoryHandler(4096, flushLevel=DEBUG, target=stream_handler)
+    # Buffer log messages so we do not get broken-by-racecondition
+    # debug log lines in stdout
+    memory_handler = MemoryHandler(
+        4096,
+        flushLevel=DEBUG,
+        target=stream_handler,
+        )
     memory_handler.setLevel(default_loglevel)
 
     logger.addHandler(memory_handler)


### PR DESCRIPTION
https://bugs.python.org/issue15373

Stumbled upon that. Apparently we were still not making a proper copy of the environment for the workers. Even though this is now moot for mtest as we run the ZServer layer in its own runner, this is still good practice.