### PR TITLE
Fix force-checkin for administrators.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -8,6 +8,7 @@ Changelog
 - Bump ftw.bumblebee to skip checksum calculation for unsupported mimetypes. [deiferni]
 - Fix dossier responsible widget, in the DossierAddFormView step, when accepting a task.  [phgross]
 - OGIP 17: Add workspace root content type [raphael-s]
+- Fix force-checkin for administrators. [phgross]
 - Implement workspace module basics [raphael-s]
 - Allow to add proposal documents to tasks. [tarnap]
 - Improve Office Connector testing. [Rotonen]

--- a/opengever/core/profiles/default/rolemap.xml
+++ b/opengever/core/profiles/default/rolemap.xml
@@ -37,6 +37,14 @@
       <role name="Manager" />
     </permission>
 
+    <permission name="CMFEditions: Save new version" acquire="True">
+      <role name="Administrator" />
+      <role name="Manager" />
+      <role name="Contributor" />
+      <role name="Editor" />
+      <role name="Reviewer" />
+    </permission>
+
     <!--migrated from opengever/base/profiles/default/rolemap.xml-->
     <permission name="Remove GEVER content" acquire="True">
       <role name="Manager" />

--- a/opengever/core/upgrades/20171211081352_let_administrators_save_new_versions/rolemap.xml
+++ b/opengever/core/upgrades/20171211081352_let_administrators_save_new_versions/rolemap.xml
@@ -1,0 +1,13 @@
+<rolemap>
+  <permissions>
+
+    <permission name="CMFEditions: Save new version" acquire="True">
+      <role name="Administrator" />
+      <role name="Manager" />
+      <role name="Contributor" />
+      <role name="Editor" />
+      <role name="Reviewer" />
+    </permission>
+
+  </permissions>
+</rolemap>

--- a/opengever/core/upgrades/20171211081352_let_administrators_save_new_versions/upgrade.py
+++ b/opengever/core/upgrades/20171211081352_let_administrators_save_new_versions/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class LetAdministratorsSaveNewVersions(UpgradeStep):
+    """let administrators save new versions.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/document/tests/test_force_checkin.py
+++ b/opengever/document/tests/test_force_checkin.py
@@ -1,0 +1,51 @@
+from ftw.testbrowser import browsing
+from ftw.testbrowser.exceptions import NoElementFound
+from ftw.testbrowser.pages.statusmessages import assert_message
+from opengever.document.interfaces import ICheckinCheckoutManager
+from opengever.testing import IntegrationTestCase
+from zope.component import getMultiAdapter
+
+
+class TestForceCheckin(IntegrationTestCase):
+    """Force checkin is the description for checking in a document which has
+    been checked out by another user.
+    """
+
+    @browsing
+    def test_is_possible_for_administrators(self, browser):
+        self.login(self.dossier_responsible, browser=browser)
+        manager = getMultiAdapter((self.document, self.request),
+                                  ICheckinCheckoutManager)
+
+        # checkout
+        browser.open(self.document)
+        browser.click_on('Checkout')
+        self.assertEquals(self.dossier_responsible.getId(),
+                          manager.get_checked_out_by())
+        assert_message(u'Checked out: Vertr\xe4gsentwurf')
+
+        # force checkin as administrator
+        self.login(self.administrator, browser=browser)
+        browser.open(self.document)
+        browser.click_on('without comment')
+
+        assert_message(u'Checked in: Vertr\xe4gsentwurf')
+        self.assertIsNone(manager.get_checked_out_by())
+
+    @browsing
+    def test_not_possible_for_regular_user(self, browser):
+        self.login(self.dossier_responsible, browser=browser)
+        # checkout
+        browser.open(self.document)
+        browser.click_on('Checkout')
+        assert_message(u'Checked out: Vertr\xe4gsentwurf')
+
+        # force checkin as regular_user
+        self.login(self.regular_user, browser=browser)
+        browser.open(self.document)
+
+        with self.assertRaises(NoElementFound):
+            browser.click_on('without comment')
+
+        browser.open(self.document, view='@@checkin_without_comment')
+        assert_message(u'Could not check in document Vertr\xe4gsentwurf')


### PR DESCRIPTION
Give administrators the `CMFEditions save new version` permission, which is necessary to checkin a document and creating a new version.

Closes #3756.