### PR TITLE
Move test_move_items to IntegrationLayer.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -524,6 +524,7 @@ Objects
       - self.leaf_repofolder
         - self.archive_dossier
           - self.archive_document
+          - self.archive_task
         - self.closed_meeting_dossier
         - self.decided_meeting_dossier
         - self.dossier
@@ -541,6 +542,9 @@ Objects
             - self.taskdocument
           - self.word_proposal
         - self.empty_dossier
+        - self.inactive_dossier
+          - self.inactive_document
+          - self.inactive_task
         - self.meeting_dossier
           - self.meeting_document
           - self.meeting_task

--- a/opengever/bumblebee/tests/test_overlay_adapter_mail.py
+++ b/opengever/bumblebee/tests/test_overlay_adapter_mail.py
@@ -65,7 +65,7 @@ class TestGetOpenAsPdfLink(IntegrationTestCase):
 
         adapter = getMultiAdapter((self.mail, self.request), IBumblebeeOverlay)
         self.assertEqual(
-            'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/document-13/bumblebee-open-pdf?filename=die-burgschaft.pdf',
+            'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/document-14/bumblebee-open-pdf?filename=die-burgschaft.pdf',
             adapter.get_open_as_pdf_url())
 
     def test_handles_non_ascii_characters_in_filename(self):
@@ -75,7 +75,7 @@ class TestGetOpenAsPdfLink(IntegrationTestCase):
 
         adapter = getMultiAdapter((self.mail, self.request), IBumblebeeOverlay)
         self.assertEqual(
-            u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/document-13/bumblebee-open-pdf?filename=GEVER%20-%20%C3%9Cbernahme.pdf',
+            u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/document-14/bumblebee-open-pdf?filename=GEVER%20-%20%C3%9Cbernahme.pdf',
             adapter.get_open_as_pdf_url())
 
 

--- a/opengever/bundle/tests/test_oggbundle_pipeline.py
+++ b/opengever/bundle/tests/test_oggbundle_pipeline.py
@@ -279,7 +279,7 @@ class TestOggBundlePipeline(IntegrationTestCase):
         return self.assert_dossier_hanspeter_created(parent)
 
     def assert_dossier_peter_schneider_created(self, parent):
-        dossier_peter = parent.get('dossier-11')
+        dossier_peter = parent.get('dossier-12')
         self.assertEqual(
             u'Vreni Meier ist ein Tausendsassa',
             IDossier(dossier_peter).comments)
@@ -296,7 +296,7 @@ class TestOggBundlePipeline(IntegrationTestCase):
             index_data_for(dossier_peter)[GUID_INDEX_NAME])
 
     def assert_dossier_vreni_created(self, parent):
-        dossier = self.leaf_repofolder.get('dossier-13')
+        dossier = self.leaf_repofolder.get('dossier-14')
         self.assertEqual(u'Vreni Meier ist ein Tausendsassa',
                          IDossier(dossier).comments)
         self.assertEqual(tuple(), IDossier(dossier).keywords)
@@ -312,7 +312,7 @@ class TestOggBundlePipeline(IntegrationTestCase):
             index_data_for(dossier)[GUID_INDEX_NAME])
 
     def assert_dossier_hanspeter_created(self, parent):
-        dossier_peter = parent.get('dossier-12')
+        dossier_peter = parent.get('dossier-13')
         self.assertEqual(
             u'archival worthy',
             ILifeCycle(dossier_peter).archival_value)

--- a/opengever/dossier/tests/test_base.py
+++ b/opengever/dossier/tests/test_base.py
@@ -100,7 +100,7 @@ class TestDossierContainer(IntegrationTestCase):
             'subdossier': 2,
             'subdossier2': 3,
             'archive_dossier': 4,
-            'empty_dossier': 5}
+            'empty_dossier': 6}
         got = {name: getattr(self, name).get_sequence_number()
                for name in expected.keys()}
         self.assertDictEqual(expected, got)
@@ -120,7 +120,7 @@ class TestDossierContainer(IntegrationTestCase):
             'subdossier': 'Client1 1.1 / 1.1',
             'subdossier2': 'Client1 1.1 / 1.2',
             'archive_dossier': 'Client1 1.1 / 2',
-            'empty_dossier': 'Client1 1.1 / 3'}
+            'empty_dossier': 'Client1 1.1 / 4'}
         got = {name: getattr(self, name).get_reference_number()
                for name in expected.keys()}
         self.assertDictEqual(expected, got)

--- a/opengever/dossier/tests/test_dossier.py
+++ b/opengever/dossier/tests/test_dossier.py
@@ -180,7 +180,7 @@ class TestDossier(IntegrationTestCase):
         browser.find_link_by_text(u'Vertr\xe4ge').click()
         search_result = browser.css('.searchResults dt a')
 
-        self.assertEquals(3, len(search_result))
+        self.assertEquals(4, len(search_result))
         self.assertIn(self.dossier.title, search_result.text)
         self.assertIn(self.meeting_dossier.title, search_result.text)
         self.assertIn(self.archive_dossier.title, search_result.text)

--- a/opengever/dossier/tests/test_indexer.py
+++ b/opengever/dossier/tests/test_indexer.py
@@ -125,7 +125,7 @@ class TestDossierIndexers(IntegrationTestCase):
             )
 
         self.assertEquals(
-            3,
+            4,
             len(catalog(Subject=u'Vertr\xe4ge')),
             u'Expected three items with Keyword "Vertr\xe4ge"',
             )

--- a/opengever/mail/tests/test_indexers.py
+++ b/opengever/mail/tests/test_indexers.py
@@ -38,4 +38,4 @@ class TestMailIndexers(IntegrationTestCase):
         extender = getAdapter(
             self.mail_eml, IDynamicTextIndexExtender, u'IDocumentSchema')
 
-        self.assertEquals('Client1 1.1 / 1 / 13 13', extender())
+        self.assertEquals('Client1 1.1 / 1 / 14 14', extender())

--- a/opengever/meeting/tests/test_meeting_listings.py
+++ b/opengever/meeting/tests/test_meeting_listings.py
@@ -38,7 +38,7 @@ class TestMeetingListing(IntegrationTestCase):
 
         self.assertEquals(
             '<a href="http://nohost/plone/ordnungssystem/fuhrung/'
-            'vertrage-und-vereinbarungen/dossier-6" '
+            'vertrage-und-vereinbarungen/dossier-7" '
             'title="Sitzungsdossier 9/2017" '
             'class="contenttype-opengever-meeting-meetingdossier"'
             '>Sitzungsdossier 9/2017</a>',

--- a/opengever/tabbedview/tests/test_personaloverview.py
+++ b/opengever/tabbedview/tests/test_personaloverview.py
@@ -122,7 +122,9 @@ class TestGlobalTaskListings(IntegrationTestCase):
         browser.open(view='tabbedview_view-mytasks')
         self.assertEquals(
             [u'Rechtliche Grundlagen in Vertragsentwurf \xdcberpr\xfcfen',
-             u'Vertragsentwurf \xdcberpr\xfcfen'],
+             u'Vertragsentwurf \xdcberpr\xfcfen',
+             u'Vertr\xe4ge abschliessen',
+             u'Status \xdcberpr\xfcfen'],
             [row.get('Title') for row in browser.css('.listing').first.dicts()]
         )
 
@@ -130,7 +132,9 @@ class TestGlobalTaskListings(IntegrationTestCase):
 
         browser.open(view='tabbedview_view-mytasks')
         self.assertEquals(
-            [u'Rechtliche Grundlagen in Vertragsentwurf \xdcberpr\xfcfen'],
+            [u'Rechtliche Grundlagen in Vertragsentwurf \xdcberpr\xfcfen',
+             u'Vertr\xe4ge abschliessen',
+             u'Status \xdcberpr\xfcfen'],
             [row.get('Title') for row in browser.css('.listing').first.dicts()]
         )
 
@@ -170,6 +174,8 @@ class TestGlobalTaskListings(IntegrationTestCase):
         self.assertEquals(
             [u'Rechtliche Grundlagen in Vertragsentwurf \xdcberpr\xfcfen',
              u'Vertragsentwurf \xdcberpr\xfcfen',
+             u'Vertr\xe4ge abschliessen',
+             u'Status \xdcberpr\xfcfen',
              u'Programm \xdcberpr\xfcfen',
              u'H\xf6rsaal reservieren'],
             [row.get('Title') for row in browser.css('.listing').first.dicts()]
@@ -180,6 +186,8 @@ class TestGlobalTaskListings(IntegrationTestCase):
         browser.open(view='tabbedview_view-myissuedtasks')
         self.assertEquals(
             [u'Rechtliche Grundlagen in Vertragsentwurf \xdcberpr\xfcfen',
+             u'Vertr\xe4ge abschliessen',
+             u'Status \xdcberpr\xfcfen',
              u'Programm \xdcberpr\xfcfen',
              u'H\xf6rsaal reservieren'],
             [row.get('Title') for row in browser.css('.listing').first.dicts()]
@@ -192,7 +200,10 @@ class TestGlobalTaskListings(IntegrationTestCase):
 
         self.assertEquals(
             [u'Rechtliche Grundlagen in Vertragsentwurf \xdcberpr\xfcfen',
-             u'Vertragsentwurf \xdcberpr\xfcfen', u'Programm \xdcberpr\xfcfen',
+             u'Vertragsentwurf \xdcberpr\xfcfen',
+             u'Vertr\xe4ge abschliessen',
+             u'Status \xdcberpr\xfcfen',
+             u'Programm \xdcberpr\xfcfen',
              u'H\xf6rsaal reservieren'],
             [row.get('Title') for row in browser.css('.listing').first.dicts()]
         )
@@ -202,7 +213,10 @@ class TestGlobalTaskListings(IntegrationTestCase):
         browser.open(view='tabbedview_view-alltasks')
         self.assertEquals(
             [u'Rechtliche Grundlagen in Vertragsentwurf \xdcberpr\xfcfen',
-             u'Programm \xdcberpr\xfcfen', u'H\xf6rsaal reservieren'],
+             u'Vertr\xe4ge abschliessen',
+             u'Status \xdcberpr\xfcfen',
+             u'Programm \xdcberpr\xfcfen',
+             u'H\xf6rsaal reservieren'],
             [row.get('Title') for row in browser.css('.listing').first.dicts()]
         )
 
@@ -214,6 +228,8 @@ class TestGlobalTaskListings(IntegrationTestCase):
         self.assertEquals(
             [u'Rechtliche Grundlagen in Vertragsentwurf \xdcberpr\xfcfen',
              u'Vertragsentwurf \xdcberpr\xfcfen',
+             u'Vertr\xe4ge abschliessen',
+             u'Status \xdcberpr\xfcfen',
              u'Programm \xdcberpr\xfcfen',
              u'H\xf6rsaal reservieren'],
             [row.get('Title') for row in browser.css('.listing').first.dicts()]
@@ -229,6 +245,9 @@ class TestGlobalTaskListings(IntegrationTestCase):
         browser.open(view='tabbedview_view-allissuedtasks')
         self.assertEquals(
             [u'Rechtliche Grundlagen in Vertragsentwurf \xdcberpr\xfcfen',
-             u'Programm \xdcberpr\xfcfen', u'H\xf6rsaal reservieren'],
+             u'Vertr\xe4ge abschliessen',
+             u'Status \xdcberpr\xfcfen',
+             u'Programm \xdcberpr\xfcfen',
+             u'H\xf6rsaal reservieren'],
             [row.get('Title') for row in browser.css('.listing').first.dicts()]
         )

--- a/opengever/task/tests/test_team_tasks.py
+++ b/opengever/task/tests/test_team_tasks.py
@@ -27,7 +27,7 @@ class TestTeamTasks(IntegrationTestCase):
         form.find_widget('Responsible').fill('team:1')
         browser.find('Save').click()
 
-        task = self.dossier.get('task-5')
+        task = self.dossier.get('task-7')
 
         self.assertEquals('Team Task', task.title)
         self.assertEquals('team:1', task.responsible)
@@ -72,7 +72,7 @@ class TestTeamTasks(IntegrationTestCase):
         browser.find('Save').click()
         create_session().flush()
 
-        task = self.dossier.get('task-5')
+        task = self.dossier.get('task-7')
 
         center = notification_center()
         # Assign watchers to a local variable in order to avoid having

--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -463,7 +463,7 @@ class OpengeverContentFixture(object):
                     bumblebee_asset('example.docx').bytes(),
                     u'vertragsentwurf.docx')))
 
-        task = self.register('task', create(
+        self.task = self.register('task', create(
             Builder('task').within(self.dossier)
             .titled(u'Vertragsentwurf \xdcberpr\xfcfen')
             .having(responsible_client=self.org_unit.id(),
@@ -475,7 +475,7 @@ class OpengeverContentFixture(object):
             .relate_to(self.document)))
 
         self.register('subtask', create(
-            Builder('task').within(task)
+            Builder('task').within(self.task)
             .titled(u'Rechtliche Grundlagen in Vertragsentwurf \xdcberpr\xfcfen')
             .having(responsible_client=self.org_unit.id(),
                     responsible=self.regular_user.getId(),
@@ -486,7 +486,7 @@ class OpengeverContentFixture(object):
             .relate_to(self.document)))
 
         self.register('taskdocument', create(
-            Builder('document').within(task)
+            Builder('document').within(self.task)
             .titled(u'Feedback zum Vertragsentwurf')
             .attach_file_containing('Feedback text',
                                     u'vertr\xe4g sentwurf.docx')))
@@ -559,12 +559,49 @@ class OpengeverContentFixture(object):
                     responsible=self.dossier_responsible.getId())
             .in_state('dossier-state-resolved')))
 
-        self.register('archive_document', create(
+        archive_document = self.register('archive_document', create(
             Builder('document')
             .within(archive_dossier)
+            .titled(u'\xdcbersicht der Vertr\xe4ge vor 2016')
             .attach_archival_file_containing('TEST', name=u'test.pdf')
-            .with_dummy_content()
-            ))
+            .with_dummy_content()))
+
+        self.register('archive_task', create(
+            Builder('task').within(archive_dossier)
+            .titled(u'Vertr\xe4ge abschliessen')
+            .having(responsible_client=self.org_unit.id(),
+                    responsible=self.regular_user.getId(),
+                    issuer=self.dossier_responsible.getId(),
+                    task_type='correction',
+                    deadline=date(2015, 12, 31))
+            .in_state('task-state-resolved')
+            .relate_to(archive_document)))
+
+        inactive_dossier = self.register('inactive_dossier', create(
+            Builder('dossier').within(self.repofolder00)
+            .titled(u'Inaktive Vertr\xe4ge')
+            .having(description=u'Inaktive Vertr\xe4ge von 2016.',
+                    keywords=(u'Vertr\xe4ge'),
+                    start=date(2016, 1, 1),
+                    end=date(2016, 12, 31),
+                    responsible=self.dossier_responsible.getId())
+            .in_state('dossier-state-inactive')))
+
+        inactive_document = self.register('inactive_document', create(
+            Builder('document').within(inactive_dossier)
+            .titled(u'\xdcbersicht der Inaktiven Vertr\xe4ge von 2016')
+            .attach_file_containing('Excel dummy content', u'tab\xe4lle.xlsx')))
+
+        self.register('inactive_task', create(
+            Builder('task').within(inactive_dossier)
+            .titled(u'Status \xdcberpr\xfcfen')
+            .having(responsible_client=self.org_unit.id(),
+                    responsible=self.regular_user.getId(),
+                    issuer=self.dossier_responsible.getId(),
+                    task_type='correction',
+                    deadline=date(2016, 11, 1))
+            .in_state('task-state-in-progress')
+            .relate_to(inactive_document)))
 
     @staticuid()
     def create_empty_dossier(self):


### PR DESCRIPTION
I've added quite a few elements to the fixture as we needed different elements in different states. We could obviously do without, by changing the state of existing elements instead. This is pretty slow though (around 0.2s or so). I guess in the end this will depend on how many tests use different elements from the fixture.
  