### PR TITLE
Fix dossier responsible widget, in the DossierAddFormView step.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ---------------------
 
 - Bump ftw.bumblebee to skip checksum calculation for unsupported mimetypes. [deiferni]
+- Fix dossier responsible widget, in the DossierAddFormView step, when accepting a task.  [phgross]
 - Implement workspace module basics [raphael-s]
 - Allow to add proposal documents to tasks. [tarnap]
 - Improve Office Connector testing. [Rotonen]

--- a/opengever/task/browser/accept/newdossier.py
+++ b/opengever/task/browser/accept/newdossier.py
@@ -240,7 +240,8 @@ class DossierAddFormView(WizzardWrappedAddForm):
 
     @property
     def typename(self):
-        return self.request.get('dossier_type')
+        return self.request.get(
+            'dossier_type', 'opengever.dossier.businesscasedossier')
 
     def _create_form_class(self, parent_form_class, steptitle):
         class WrappedForm(AcceptWizardNewDossierFormMixin, parent_form_class):


### PR DESCRIPTION
When accepting a multi adminunit task and selecting the store and editing in a newdossier step. The dossier responsible field does not work. The AJAX call to the search endpoint ist not working (404).

The reason is that the typename, which is used by the WizzardWrappedAddForm, is not set in the widget_traversal request, therefore I add an fallback to the default dossier type.

Backport-needed to `2017.6-stable`