### PR TITLE
Remove hints about izug.basetheme.

### DIFF
--- a/opengever/base/skins/opengever.base_scripts/search.py
+++ b/opengever/base/skins/opengever.base_scripts/search.py
@@ -1,7 +1,6 @@
 # This view is needed because the search skin template
 # is still in the `plone_depracted` folder and therfore active.
 # This file should be removed when the search template is dropped
-# out of the `plone_deprecated` skins folder or when plone_deprecated
-# is deactivated for the izug.basetheme gever profile.
+# out of the `plone_deprecated` skins folder
 
 return context.REQUEST.RESPONSE.redirect('@@search')

--- a/setup.py
+++ b/setup.py
@@ -185,9 +185,6 @@ setup(name='opengever.core',
       dump_schemas = opengever.base.schemadump:dump_schemas_zopectl_handler
       import = opengever.bundle.console:import_oggbundle
 
-      [izug.basetheme]
-      version = opengever.core
-
       [console_scripts]
       create-policy = opengever.policytemplates.cli:main
       pyxbgen = opengever.disposition.ech0160.pyxbgen:main


### PR DESCRIPTION
The package `izug.basetheme` is mentioned in two places. Afaik it has been long deprecated now, so this cleanup should be justified.