### PR TITLE
Have predictable intids in the fixture.

### DIFF
--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -17,6 +17,7 @@ from opengever.mail.tests import MAIL_DATA
 from opengever.meeting.proposalhistory import BaseHistoryRecord
 from opengever.ogds.base.utils import ogds_service
 from opengever.testing import assets
+from opengever.testing.helpers import time_based_intids
 from opengever.testing.integration_test_case import FEATURE_FLAGS
 from operator import methodcaller
 from plone import api
@@ -709,7 +710,8 @@ class OpengeverContentFixture(object):
         with freeze(datetime(2016, 8, 31, hour, 1, 33, tzinfo=pytz.UTC)) as clock:
             with ticking_creator(clock, minutes=2):
                 with self.ticking_proposal_history(clock, seconds=1):
-                    yield
+                    with time_based_intids():
+                        yield
 
     @contextmanager
     def ticking_proposal_history(self, clock, **forward):

--- a/opengever/testing/helpers.py
+++ b/opengever/testing/helpers.py
@@ -7,6 +7,9 @@ from opengever.document.versioner import Versioner
 from plone import api
 from Products.CMFCore.utils import getToolByName
 from Products.PloneLanguageTool.LanguageTool import LanguageBinding
+from zope.component import getUtility
+from zope.component.hooks import getSite
+from zope.intid.interfaces import IIntIds
 import pytz
 import transaction
 
@@ -19,9 +22,25 @@ def time_based_intids():
     """To ensure predictable IntIds in tests, this context manager patches
     the IntIds utility so that IntIds are created based on the current time
     """
-    # register intid utility
-    yield
-    # deregister intid utility
+    original_intids = getUtility(IIntIds)
+
+    class TimeBasedIntIds(type(original_intids)):
+
+        def __init__(self):
+            self.__dict__ = original_intids.__dict__
+
+        def _generateId(self):
+            intid = int(datetime.now(pytz.UTC).strftime('10%H%M%S00'))
+            while intid in self.refs:
+                intid += 1
+            return intid
+
+    patched_intids = TimeBasedIntIds()
+    getSite().getSiteManager().registerUtility(patched_intids, IIntIds)
+    try:
+        yield
+    finally:
+        getSite().getSiteManager().registerUtility(original_intids, IIntIds)
 
 
 def localized_datetime(*args, **kwargs):

--- a/opengever/testing/helpers.py
+++ b/opengever/testing/helpers.py
@@ -1,3 +1,4 @@
+from contextlib import contextmanager
 from datetime import datetime
 from lxml.cssselect import LxmlTranslator
 from opengever.base.date_time import as_utc
@@ -11,6 +12,16 @@ import transaction
 
 
 DEFAULT_TZ = pytz.timezone('Europe/Zurich')
+
+
+@contextmanager
+def time_based_intids():
+    """To ensure predictable IntIds in tests, this context manager patches
+    the IntIds utility so that IntIds are created based on the current time
+    """
+    # register intid utility
+    yield
+    # deregister intid utility
 
 
 def localized_datetime(*args, **kwargs):

--- a/opengever/testing/tests/test_fixtures.py
+++ b/opengever/testing/tests/test_fixtures.py
@@ -24,7 +24,12 @@ class TestTestingFixture(IntegrationTestCase):
     def test_repository_root_has_static_intid(self):
         self.login(self.regular_user)
         self.assertEquals(1008013300,
-                getUtility(IIntIds).getId(self.repository_root))
+                          getUtility(IIntIds).getId(self.repository_root))
+
+    def test_dossier_has_static_intid(self):
+        self.login(self.regular_user)
+        self.assertEquals(1014013300,
+                          getUtility(IIntIds).getId(self.dossier))
 
     def test_repository_root_has_static_uuid(self):
         self.login(self.regular_user)

--- a/opengever/testing/tests/test_fixtures.py
+++ b/opengever/testing/tests/test_fixtures.py
@@ -5,6 +5,8 @@ from opengever.repository.interfaces import IRepositoryFolder
 from opengever.testing import IntegrationTestCase
 from plone import api
 from plone.uuid.interfaces import IUUID
+from zope.app.intid.interfaces import IIntIds
+from zope.component import getUtility
 
 
 class TestTestingFixture(IntegrationTestCase):
@@ -18,6 +20,11 @@ class TestTestingFixture(IntegrationTestCase):
         self.login(self.regular_user)
         self.assertEquals(DateTime('2016/08/31 09:01:33 GMT+2'),
                           self.repository_root.created())
+
+    def test_repository_root_has_static_intid(self):
+        self.login(self.regular_user)
+        self.assertEquals(1008013300,
+                getUtility(IIntIds).getId(self.repository_root))
 
     def test_repository_root_has_static_uuid(self):
         self.login(self.regular_user)


### PR DESCRIPTION
**Goal:**
We want to have predictable intids in the tests, so that we can assert the intids and also oguids (which are based on intids).

**Thoughts:**
We freeze the time and already a use a static UID generator. The fixture is fragmented into groups, frozen to a specific hour and with a certain UID prefix so that we avoid conflicts while still beeing able to keep the values as static as possible.

Since the ID is a ten-digit integer, we cannot prefix it with a string. We've therefore decided to base the intid generation on the current time, which we expect to be already frozen.

**Implementation:**
The generated ID consists of: `100, hour, minute, second, 00`, wherease the ending `00` is used for conflict resolution incrementation, although this should not happen in the fixture when we don't break it.

The IntIds utility is a persistent component in the local site manager; therefore we need to override it and override it back.

We cannot use a regular wrapper since we would not be able to patch the `._generateId()`, which is called by the `.register()` method. Therefore we inherit the class and share the state while overriding the `._generateId()` method.