### PR TITLE
use weight 5 on jenkins for test-plone-4.3.x.cfg

### DIFF
--- a/.ci_governor.yml
+++ b/.ci_governor.yml
@@ -1,0 +1,4 @@
+---
+job_template: python
+weight:
+  test-plone-4.3.x.cfg: 5


### PR DESCRIPTION
To ensure that we don't use too many resources on our jenkins, we now have weight based builds. 
So we can make sure we don't block any other builds, and also use the maximum resources without overloading our jenkins.