### PR TITLE
Delegate task form: Fix required input validation for the recipients field

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,7 @@ Changelog
 
 - Fix plonesite removal. [phgross]
 - Fix pre-filling committee group id in edit form. [deiferni]
+- Fix required input validation for the recipients field, when delegating a task. [phgross]
 - Bump ftw.bumblebee to skip checksum calculation for unsupported mimetypes. [deiferni]
 - Fix dossier responsible widget, in the DossierAddFormView step, when accepting a task.  [phgross]
 - OGIP 17: Add workspace root content type [raphael-s]

--- a/opengever/task/browser/delegate/metadata.py
+++ b/opengever/task/browser/delegate/metadata.py
@@ -12,6 +12,7 @@ from Products.statusmessages.interfaces import IStatusMessage
 from z3c.form.button import buttonAndHandler
 from z3c.form.field import Fields
 from z3c.form.form import Form
+from z3c.form.interfaces import IDataConverter
 from zope import schema
 from zope.interface import provider
 from zope.schema.interfaces import IContextAwareDefaultFactory
@@ -95,7 +96,9 @@ class UpdateMetadataForm(DelegateWizardFormMixin, Form):
 
     def updateWidgets(self):
         super(UpdateMetadataForm, self).updateWidgets()
-        self.widgets['issuer'].value = [api.user.get_current().getId()]
+        widget = self.widgets['issuer']
+        value = api.user.get_current().getId()
+        widget.value = IDataConverter(widget).toWidgetValue(value)
 
 
 class UpdateMetadataStepView(FormWrapper):

--- a/opengever/task/browser/delegate/recipients.py
+++ b/opengever/task/browser/delegate/recipients.py
@@ -27,6 +27,7 @@ class ISelectRecipientsSchema(Schema):
             default=u'Select one or more responsibles. For each selected '
             u'responsible a subtask will be created and assigned.'),
         required=True,
+        missing_value=[],
         value_type=schema.Choice(
             source=AllUsersInboxesAndTeamsSourceBinder()))
 

--- a/opengever/task/tests/test_delegate.py
+++ b/opengever/task/tests/test_delegate.py
@@ -66,3 +66,14 @@ class TestDelegateTaskForm(IntegrationTestCase):
 
         self.assertEqual(
             self.regular_user.getId(), browser.find('Issuer').value)
+
+    @browsing
+    def test_responsible_is_required(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        browser.open(self.task, view='delegate_recipients')
+        browser.css('#form-buttons-save').first.click()
+
+        self.assertEqual(
+            ['Required input is missing.'],
+            browser.css('#formfield-form-widgets-responsibles .error').text)


### PR DESCRIPTION
Set missing_value for the `responsible` field in the delegate task form, otherwise the `z3c.form.field.FieldWidgets.extract` those not raise an requiredinput validation error.