### PR TITLE
Fix pre-filling committee group id in edit form.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ---------------------
 
 - Fix plonesite removal. [phgross]
+- Fix pre-filling committee group id in edit form. [deiferni]
 - Bump ftw.bumblebee to skip checksum calculation for unsupported mimetypes. [deiferni]
 - Fix dossier responsible widget, in the DossierAddFormView step, when accepting a task.  [phgross]
 - OGIP 17: Add workspace root content type [raphael-s]

--- a/opengever/meeting/form.py
+++ b/opengever/meeting/form.py
@@ -1,4 +1,5 @@
 from opengever.meeting import is_meeting_feature_enabled
+from z3c.form.interfaces import IDataConverter
 from zExceptions import Unauthorized
 
 
@@ -55,18 +56,19 @@ class ModelProxyEditForm(object):
         if self.request.method != 'GET':
             return
 
-        prefix = 'form.widgets.'
         values = self.get_edit_values(self.fields.keys())
 
         for fieldname, value in values.items():
-            self.request[prefix + fieldname] = value
+            widget = self.widgets[fieldname]
+            value = IDataConverter(widget).toWidgetValue(value)
+            widget.value = value
 
     def get_edit_values(self, keys):
         return self.context.get_edit_values(keys)
 
     def updateWidgets(self):
-        self.inject_initial_data()
         super(ModelProxyEditForm, self).updateWidgets()
+        self.inject_initial_data()
 
     def partition_data(self, data):
         obj_data, model_data = self.content_type.partition_data(data)

--- a/opengever/meeting/proposal.py
+++ b/opengever/meeting/proposal.py
@@ -632,14 +632,6 @@ class Proposal(ProposalBase):
             self.get_repository_folder_title(language))
         return super(Proposal, self).update_model(data)
 
-    def get_edit_values(self, fieldnames):
-        values = super(Proposal, self).get_edit_values(fieldnames)
-        committee = values.pop('committee', None)
-        if committee:
-            committee = str(committee.committee_id)
-            values['committee'] = committee
-        return values
-
     def sync_model(self, proposal_model=None):
         proposal_model = proposal_model or self.load_model()
 

--- a/opengever/meeting/tests/test_committee.py
+++ b/opengever/meeting/tests/test_committee.py
@@ -217,6 +217,9 @@ class TestCommittee(IntegrationTestCase):
         self.assertIsNotNone(model)
         self.assertEqual(u'A c\xf6mmittee', model.title)
 
+        browser.open(self.committee, view='edit')
+        self.assertEqual('committee_ver_group', browser.find('Group').value)
+
 
 class TestCommitteeWorkflow(IntegrationTestCase):
 

--- a/opengever/meeting/vocabulary.py
+++ b/opengever/meeting/vocabulary.py
@@ -21,7 +21,7 @@ class CommitteeVocabulary(object):
     def __call__(self, context):
         return SimpleVocabulary([
             SimpleTerm(value=committee,
-                       token=committee.committee_id,
+                       token=str(committee.committee_id),
                        title=committee.title)
             for committee in self.get_committees()
         ])

--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -301,6 +301,7 @@ class OpengeverContentFixture(object):
             title=u'Rechnungspr\xfcfungskommission',
             repository_folder=self.repofolder1,
             group_id='committee_rpk_group',
+            group_title=u'Gruppe Rechnungspr\xfcfungskommission',
             responsibles=[self.administrator,
                           self.committee_responsible]))
         self.register_raw('committee_id', self.committee.load_model().committee_id)
@@ -357,6 +358,7 @@ class OpengeverContentFixture(object):
                 title=u'Kommission f\xfcr Verkehr',
                 repository_folder=self.repofolder1,
                 group_id='committee_ver_group',
+                group_title=u'Gruppe Kommission f\xfcr Verkehr',
                 responsibles=[self.administrator,
                               self.committee_responsible]))
         self.register_raw('empty_committee_id',
@@ -831,7 +833,7 @@ class OpengeverContentFixture(object):
             member.get_url(self.committee_container).encode('utf-8'))
         return member
 
-    def create_committee(self, title, repository_folder, group_id,
+    def create_committee(self, title, repository_folder, group_id, group_title,
                          responsibles):
         # XXX I would have expected the commitee builder to do all of that.
         ogds_members = map(ogds_service().find_user,
@@ -842,6 +844,7 @@ class OpengeverContentFixture(object):
                        users=ogds_members))
         create(Builder('group')
                .with_groupid(group_id)
+               .having(title=group_title)
                .with_members(*responsibles))
         committee = create(
             Builder('committee')


### PR DESCRIPTION
This PR uses the widget to inject initial data instead of the request.

This is a better way of loading data especially since the data is set from a data converter which can also deal with vocabularies that have values that differ from their tokens.