### PR TITLE
OGIP 17:  Add workspace folder content type

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -548,6 +548,7 @@ Objects
       - self.tasktemplate
   - self.workspace_root
     - self.workspace
+      - self.workspace_folder
 
 .. </fixture:objects>
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ---------------------
 
 - Add filename and filesize in bumblebee overlay. [njohner]
+- OGIP 17: Add workspace folder content type [raphael-s]
 - Fix plonesite removal. [phgross]
 - Fix pre-filling committee group id in edit form. [deiferni]
 - Fix required input validation for the recipients field, when delegating a task. [phgross]

--- a/opengever/core/lawgiver.zcml
+++ b/opengever/core/lawgiver.zcml
@@ -202,6 +202,7 @@
       permissions="
                    opengever.workspace: Add WorkspaceRoot,
                    opengever.workspace: Add Workspace,
+                   opengever.workspace: Add WorkspaceFolder,
                    "
       />
 

--- a/opengever/core/locales/de/LC_MESSAGES/opengever.core.po
+++ b/opengever/core/locales/de/LC_MESSAGES/opengever.core.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2017-12-13 17:10+0000\n"
+"POT-Creation-Date: 2017-12-20 14:47+0000\n"
 "PO-Revision-Date: 2017-09-18 15:21+0200\n"
 "Last-Translator: Philippe Gross <p.gross@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -235,6 +235,11 @@ msgstr "Freigabe von ungebrauchten Aktenzeichen Prefixen."
 #: ./opengever/core/upgrades/20171213174551_add_workspace_content_type/types/opengever.workspace.workspace.xml
 msgid "Workspace"
 msgstr "Teamraum"
+
+#: ./opengever/core/profiles/default/types/opengever.workspace.folder.xml
+#: ./opengever/core/upgrades/20171220151710_add_workspace_folder_content_type/types/opengever.workspace.folder.xml
+msgid "WorkspaceFolder"
+msgstr "Ordner"
 
 #: ./opengever/core/profiles/default/types/opengever.workspace.root.xml
 msgid "WorkspaceRoot"

--- a/opengever/core/locales/fr/LC_MESSAGES/opengever.core.po
+++ b/opengever/core/locales/fr/LC_MESSAGES/opengever.core.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2017-12-13 17:10+0000\n"
+"POT-Creation-Date: 2017-12-20 14:47+0000\n"
 "PO-Revision-Date: 2013-03-27 10:44+0100\n"
 "Last-Translator: Philippe Gross <p.gross@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -230,6 +230,11 @@ msgstr "Déblocage de préfixes de référence inutilisés."
 #: ./opengever/core/upgrades/20171213174551_add_workspace_content_type/types/opengever.workspace.workspace.xml
 msgid "Workspace"
 msgstr "Teamraum"
+
+#: ./opengever/core/profiles/default/types/opengever.workspace.folder.xml
+#: ./opengever/core/upgrades/20171220151710_add_workspace_folder_content_type/types/opengever.workspace.folder.xml
+msgid "WorkspaceFolder"
+msgstr "Fichier"
 
 #: ./opengever/core/profiles/default/types/opengever.workspace.root.xml
 msgid "WorkspaceRoot"

--- a/opengever/core/locales/opengever.core.pot
+++ b/opengever/core/locales/opengever.core.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-12-13 17:10+0000\n"
+"POT-Creation-Date: 2017-12-20 14:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -232,6 +232,11 @@ msgstr ""
 #: ./opengever/core/profiles/default/types/opengever.workspace.workspace.xml
 #: ./opengever/core/upgrades/20171213174551_add_workspace_content_type/types/opengever.workspace.workspace.xml
 msgid "Workspace"
+msgstr ""
+
+#: ./opengever/core/profiles/default/types/opengever.workspace.folder.xml
+#: ./opengever/core/upgrades/20171220151710_add_workspace_folder_content_type/types/opengever.workspace.folder.xml
+msgid "WorkspaceFolder"
 msgstr ""
 
 #: ./opengever/core/profiles/default/types/opengever.workspace.root.xml

--- a/opengever/core/profiles/default/rolemap.xml
+++ b/opengever/core/profiles/default/rolemap.xml
@@ -231,6 +231,10 @@
       <role name="Manager" />
     </permission>
 
+    <permission name="opengever.workspace: Add WorkspaceFolder" acquire="True">
+      <role name="Manager" />
+    </permission>
+
 
     <!--migrated from opengever/policy/base/profiles/default/rolemap.xml-->
     <permission name="plone.restapi: Use REST API" acquire="True">

--- a/opengever/core/profiles/default/types.xml
+++ b/opengever/core/profiles/default/types.xml
@@ -66,6 +66,7 @@
 
   <object name="opengever.workspace.root" meta_type="Dexterity FTI" />
   <object name="opengever.workspace.workspace" meta_type="Dexterity FTI" />
+  <object name="opengever.workspace.folder" meta_type="Dexterity FTI" />
 
   <!--migrated from opengever/policy/base/profiles/default/types.xml-->
   <object name="Plone Site" meta_type="Factory-based Type Information with dynamic views" />

--- a/opengever/core/profiles/default/types/opengever.workspace.folder.xml
+++ b/opengever/core/profiles/default/types/opengever.workspace.folder.xml
@@ -1,7 +1,7 @@
-<object xmlns:i18n="http://xml.zope.org/namespaces/i18n" name="opengever.workspace.workspace" meta_type="Dexterity FTI" i18n:domain="opengever.core">
+<object xmlns:i18n="http://xml.zope.org/namespaces/i18n" name="opengever.workspace.folder" meta_type="Dexterity FTI" i18n:domain="opengever.core">
 
   <!-- Basic metadata -->
-  <property name="title" i18n:translate="">Workspace</property>
+  <property name="title" i18n:translate="">WorkspaceFolder</property>
   <property name="description" i18n:translate="" />
   <property name="icon_expr" />
   <property name="allow_discussion">False</property>
@@ -9,19 +9,17 @@
   <property name="filter_content_types">True</property>
   <property name="allowed_content_types">
     <element value="opengever.document.document" />
-    <element value="ftw.mail.mail" />
-    <element value="opengever.task.task" />
     <element value="opengever.workspace.folder" />
   </property>
 
   <!-- schema interface -->
-  <property name="schema">opengever.workspace.workspace.IWorkspaceSchema</property>
+  <property name="schema">opengever.workspace.workspace_folder.IWorkspaceFolderSchema</property>
 
   <!-- class used for content items -->
-  <property name="klass">opengever.workspace.workspace.Workspace</property>
+  <property name="klass">opengever.workspace.workspace_folder.WorkspaceFolder</property>
 
   <!-- add permission -->
-  <property name="add_permission">opengever.workspace.AddWorkspace</property>
+  <property name="add_permission">opengever.workspace.AddWorkspaceFolder</property>
 
   <!-- enabled behaviors -->
   <property name="behaviors">
@@ -29,21 +27,20 @@
     <element value="ftw.journal.interfaces.IAnnotationsJournalizable" />
     <element value="opengever.base.behaviors.base.IOpenGeverBase" />
     <element value="opengever.base.behaviors.sequence.ISequenceNumberBehavior" />
-    <element value="opengever.workspace.behaviors.namefromtitle.IWorkspaceNameFromTitle" />
     <element value="opengever.dossier.behaviors.dossier.IDossier" />
+    <element value="opengever.dossier.behaviors.dossiernamefromtitle.IDossierNameFromTitle" />
     <element value="opengever.mail.behaviors.ISendableDocsContainer" />
     <element value="opengever.tabbedview.interfaces.ITabbedViewEnabled" />
     <element value="opengever.trash.trash.ITrashable" />
     <element value="plone.app.lockingbehavior.behaviors.ILocking" />
   </property>
 
-
   <!-- View information -->
-  <property name="immediate_view">tabbed_view</property>
-  <property name="default_view">tabbed_view</property>
+  <property name="immediate_view">view</property>
+  <property name="default_view">view</property>
   <property name="default_view_fallback">False</property>
   <property name="view_methods">
-    <element value="tabbed_view" />
+    <element value="view" />
   </property>
 
   <!-- Method aliases -->

--- a/opengever/core/profiles/default/types/opengever.workspace.folder.xml
+++ b/opengever/core/profiles/default/types/opengever.workspace.folder.xml
@@ -27,8 +27,8 @@
     <element value="ftw.journal.interfaces.IAnnotationsJournalizable" />
     <element value="opengever.base.behaviors.base.IOpenGeverBase" />
     <element value="opengever.base.behaviors.sequence.ISequenceNumberBehavior" />
+    <element value="opengever.workspace.behaviors.namefromtitle.IWorkspaceFolderNameFromTitle" />
     <element value="opengever.dossier.behaviors.dossier.IDossier" />
-    <element value="opengever.dossier.behaviors.dossiernamefromtitle.IDossierNameFromTitle" />
     <element value="opengever.mail.behaviors.ISendableDocsContainer" />
     <element value="opengever.tabbedview.interfaces.ITabbedViewEnabled" />
     <element value="opengever.trash.trash.ITrashable" />

--- a/opengever/core/profiles/default/workflows.xml
+++ b/opengever/core/profiles/default/workflows.xml
@@ -134,6 +134,7 @@
 
     <type type_id="opengever.workspace.root" />
     <type type_id="opengever.workspace.workspace" />
+    <type type_id="opengever.workspace.folder" />
   </bindings>
 
 </object>

--- a/opengever/core/tests/test_relations.py
+++ b/opengever/core/tests/test_relations.py
@@ -150,7 +150,8 @@ EXPECTED_TYPES_WITH_RELATIONS = [
     'opengever.meeting.proposaltemplate',
     'opengever.private.dossier',
     'opengever.disposition.disposition',
-    'opengever.workspace.workspace'
+    'opengever.workspace.workspace',
+    'opengever.workspace.folder'
 ]
 
 

--- a/opengever/core/upgrades/20171220151710_add_workspace_folder_content_type/rolemap.xml
+++ b/opengever/core/upgrades/20171220151710_add_workspace_folder_content_type/rolemap.xml
@@ -1,0 +1,9 @@
+<rolemap>
+
+  <permissions>
+    <permission name="opengever.workspace: Add WorkspaceFolder" acquire="True">
+      <role name="Manager" />
+    </permission>
+  </permissions>
+
+</rolemap>

--- a/opengever/core/upgrades/20171220151710_add_workspace_folder_content_type/types.xml
+++ b/opengever/core/upgrades/20171220151710_add_workspace_folder_content_type/types.xml
@@ -1,0 +1,5 @@
+<object name="portal_types" meta_type="Plone Types Tool">
+
+  <object name="opengever.workspace.folder" meta_type="Dexterity FTI" />
+
+</object>

--- a/opengever/core/upgrades/20171220151710_add_workspace_folder_content_type/types/opengever.workspace.folder.xml
+++ b/opengever/core/upgrades/20171220151710_add_workspace_folder_content_type/types/opengever.workspace.folder.xml
@@ -1,7 +1,7 @@
-<object xmlns:i18n="http://xml.zope.org/namespaces/i18n" name="opengever.workspace.workspace" meta_type="Dexterity FTI" i18n:domain="opengever.core">
+<object xmlns:i18n="http://xml.zope.org/namespaces/i18n" name="opengever.workspace.folder" meta_type="Dexterity FTI" i18n:domain="opengever.core">
 
   <!-- Basic metadata -->
-  <property name="title" i18n:translate="">Workspace</property>
+  <property name="title" i18n:translate="">WorkspaceFolder</property>
   <property name="description" i18n:translate="" />
   <property name="icon_expr" />
   <property name="allow_discussion">False</property>
@@ -9,27 +9,23 @@
   <property name="filter_content_types">True</property>
   <property name="allowed_content_types">
     <element value="opengever.document.document" />
-    <element value="ftw.mail.mail" />
-    <element value="opengever.task.task" />
     <element value="opengever.workspace.folder" />
   </property>
 
   <!-- schema interface -->
-  <property name="schema">opengever.workspace.workspace.IWorkspaceSchema</property>
+  <property name="schema">opengever.workspace.workspace_folder.IWorkspaceFolderSchema</property>
 
   <!-- class used for content items -->
-  <property name="klass">opengever.workspace.workspace.Workspace</property>
+  <property name="klass">opengever.workspace.workspace_folder.WorkspaceFolder</property>
 
   <!-- add permission -->
-  <property name="add_permission">opengever.workspace.AddWorkspace</property>
+  <property name="add_permission">opengever.workspace.AddWorkspaceFolder</property>
 
   <!-- enabled behaviors -->
   <property name="behaviors">
     <element value="collective.dexteritytextindexer.behavior.IDexterityTextIndexer" />
     <element value="ftw.journal.interfaces.IAnnotationsJournalizable" />
     <element value="opengever.base.behaviors.base.IOpenGeverBase" />
-    <element value="opengever.base.behaviors.sequence.ISequenceNumberBehavior" />
-    <element value="opengever.workspace.behaviors.namefromtitle.IWorkspaceNameFromTitle" />
     <element value="opengever.dossier.behaviors.dossier.IDossier" />
     <element value="opengever.mail.behaviors.ISendableDocsContainer" />
     <element value="opengever.tabbedview.interfaces.ITabbedViewEnabled" />
@@ -37,13 +33,12 @@
     <element value="plone.app.lockingbehavior.behaviors.ILocking" />
   </property>
 
-
   <!-- View information -->
-  <property name="immediate_view">tabbed_view</property>
-  <property name="default_view">tabbed_view</property>
+  <property name="immediate_view">view</property>
+  <property name="default_view">view</property>
   <property name="default_view_fallback">False</property>
   <property name="view_methods">
-    <element value="tabbed_view" />
+    <element value="view" />
   </property>
 
   <!-- Method aliases -->

--- a/opengever/core/upgrades/20171220151710_add_workspace_folder_content_type/types/opengever.workspace.folder.xml
+++ b/opengever/core/upgrades/20171220151710_add_workspace_folder_content_type/types/opengever.workspace.folder.xml
@@ -26,6 +26,8 @@
     <element value="collective.dexteritytextindexer.behavior.IDexterityTextIndexer" />
     <element value="ftw.journal.interfaces.IAnnotationsJournalizable" />
     <element value="opengever.base.behaviors.base.IOpenGeverBase" />
+    <element value="opengever.base.behaviors.sequence.ISequenceNumberBehavior" />
+    <element value="opengever.workspace.behaviors.namefromtitle.IWorkspaceFolderNameFromTitle" />
     <element value="opengever.dossier.behaviors.dossier.IDossier" />
     <element value="opengever.mail.behaviors.ISendableDocsContainer" />
     <element value="opengever.tabbedview.interfaces.ITabbedViewEnabled" />

--- a/opengever/core/upgrades/20171220151710_add_workspace_folder_content_type/types/opengever.workspace.workspace.xml
+++ b/opengever/core/upgrades/20171220151710_add_workspace_folder_content_type/types/opengever.workspace.workspace.xml
@@ -1,0 +1,7 @@
+<object xmlns:i18n="http://xml.zope.org/namespaces/i18n" name="opengever.workspace.workspace" meta_type="Dexterity FTI" i18n:domain="opengever.core">
+
+  <property name="allowed_content_types" purge="False">
+    <element value="opengever.workspace.folder" />
+  </property>
+
+</object>

--- a/opengever/core/upgrades/20171220151710_add_workspace_folder_content_type/upgrade.py
+++ b/opengever/core/upgrades/20171220151710_add_workspace_folder_content_type/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddWorkspaceFolderContentType(UpgradeStep):
+    """Add workspace folder content type.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/core/upgrades/20171220151710_add_workspace_folder_content_type/workflows.xml
+++ b/opengever/core/upgrades/20171220151710_add_workspace_folder_content_type/workflows.xml
@@ -1,0 +1,7 @@
+<object name="portal_workflow" meta_type="Plone Workflow Tool">
+
+  <bindings>
+    <type type_id="opengever.workspace.folder" />
+  </bindings>
+
+</object>

--- a/opengever/testing/builders/dx.py
+++ b/opengever/testing/builders/dx.py
@@ -570,3 +570,10 @@ class WorkspaceBuilder(DexterityBuilder):
 
 
 builder_registry.register('workspace', WorkspaceBuilder)
+
+
+class WorkspaceFolderBuilder(DexterityBuilder):
+    portal_type = 'opengever.workspace.folder'
+
+
+builder_registry.register('workspace folder', WorkspaceFolderBuilder)

--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -77,7 +77,7 @@ class OpengeverContentFixture(object):
 
         with self.freeze_at_hour(18):
             with self.login(self.administrator):
-                self.create_workspace()
+                self.create_workspace_folder_and_workspace()
 
         logger.info('(fixture setup in %ds) ', round(time() - start, 3))
 
@@ -873,11 +873,16 @@ class OpengeverContentFixture(object):
                                              title_de=u'Teamr\xe4ume',
                                              title_fr=u'Espace partag\xe9')))
 
-    def create_workspace(self):
+    def create_workspace_folder_and_workspace(self):
         self.workspace = self.register('workspace', create(
             Builder('workspace').having(title_de=u'Teamraum',
                                         title_fr=u'Espace partag\xe9')
                                 .within(self.workspace_root)))
+
+        self.workspace_folder = self.register('workspace_folder', create(
+            Builder('workspace folder').having(title_de=u'WS F\xc3lder',
+                                               title_fr=u'WS fichi\xe9r')
+                                       .within(self.workspace)))
 
     @contextmanager
     def login(self, user):

--- a/opengever/workspace/behaviors/configure.zcml
+++ b/opengever/workspace/behaviors/configure.zcml
@@ -13,4 +13,11 @@
       for="opengever.workspace.interfaces.IWorkspace"
       />
 
+  <plone:behavior
+      title="workspace folder name from title"
+      provides=".namefromtitle.IWorkspaceFolderNameFromTitle"
+      factory=".namefromtitle.WorkspaceFolderNameFromTitle"
+      for="opengever.workspace.interfaces.IWorkspaceFolder"
+      />
+
 </configure>

--- a/opengever/workspace/behaviors/namefromtitle.py
+++ b/opengever/workspace/behaviors/namefromtitle.py
@@ -17,3 +17,16 @@ class WorkspaceNameFromTitle(dossiernamefromtitle.DossierNameFromTitle):
     implements(IWorkspaceNameFromTitle)
 
     format = u'workspace-%i'
+
+
+class IWorkspaceFolderNameFromTitle(INameFromTitle):
+    """ Behavior interface.
+    """
+
+
+class WorkspaceFolderNameFromTitle(dossiernamefromtitle.DossierNameFromTitle):
+    """ The ID of a workspace folder should be 'folder-{sequence number}'.
+    """
+    implements(IWorkspaceFolderNameFromTitle)
+
+    format = u'folder-%i'

--- a/opengever/workspace/configure.zcml
+++ b/opengever/workspace/configure.zcml
@@ -11,5 +11,6 @@
   <include package=".behaviors" />
 
   <adapter factory=".sequence.WorkspaceSequenceNumberGenerator" />
+  <adapter factory=".sequence.WorkspaceFolderSequenceNumberGenerator" />
 
 </configure>

--- a/opengever/workspace/interfaces.py
+++ b/opengever/workspace/interfaces.py
@@ -11,6 +11,10 @@ class IWorkspace(IDossierMarker):
     """ Marker interface for Workspace """
 
 
+class IWorkspaceFolder(Interface):
+    """ Marker interface for Workspace Folders """
+
+
 class IWorkspaceSettings(Interface):
 
     is_feature_enabled = schema.Bool(

--- a/opengever/workspace/interfaces.py
+++ b/opengever/workspace/interfaces.py
@@ -11,7 +11,7 @@ class IWorkspace(IDossierMarker):
     """ Marker interface for Workspace """
 
 
-class IWorkspaceFolder(Interface):
+class IWorkspaceFolder(IDossierMarker):
     """ Marker interface for Workspace Folders """
 
 

--- a/opengever/workspace/permissions.zcml
+++ b/opengever/workspace/permissions.zcml
@@ -6,4 +6,6 @@
 
   <permission id="opengever.workspace.AddWorkspace" title="opengever.workspace: Add Workspace" />
 
+  <permission id="opengever.workspace.AddWorkspaceFolder" title="opengever.workspace: Add WorkspaceFolder" />
+
 </configure>

--- a/opengever/workspace/sequence.py
+++ b/opengever/workspace/sequence.py
@@ -1,5 +1,6 @@
 from opengever.base.sequence import DefaultSequenceNumberGenerator
 from opengever.workspace.interfaces import IWorkspace
+from opengever.workspace.interfaces import IWorkspaceFolder
 from zope.component import adapter
 
 
@@ -9,3 +10,11 @@ class WorkspaceSequenceNumberGenerator(DefaultSequenceNumberGenerator):
     """
 
     key = 'WorkspaceSequenceNumberGenerator'
+
+
+@adapter(IWorkspaceFolder)
+class WorkspaceFolderSequenceNumberGenerator(DefaultSequenceNumberGenerator):
+    """ All workspace folders should use the same range/key of sequence numbers.
+    """
+
+    key = 'WorkspaceFolderSequenceNumberGenerator'

--- a/opengever/workspace/tests/test_workspace_folder.py
+++ b/opengever/workspace/tests/test_workspace_folder.py
@@ -1,0 +1,20 @@
+from ftw.testbrowser import browsing
+from ftw.testbrowser.pages import factoriesmenu
+from ftw.testbrowser.pages.statusmessages import assert_no_error_messages
+from opengever.testing import IntegrationTestCase
+
+
+class TestWorkspaceFolder(IntegrationTestCase):
+
+    @browsing
+    def test_workspacefolder_is_addable_in_workspacefolder(self, browser):
+        self.login(self.manager, browser)
+        browser.visit(self.workspace_folder)
+        factoriesmenu.add('WorkspaceFolder')
+
+        form = browser.find_form_by_field('Title')
+        form.find_widget('Responsible').fill(self.regular_user.getId())
+        form.fill({'Title': 'Example Workspace'})
+        form.save()
+
+        assert_no_error_messages(browser)

--- a/opengever/workspace/tests/test_workspace_folder.py
+++ b/opengever/workspace/tests/test_workspace_folder.py
@@ -1,7 +1,9 @@
 from ftw.testbrowser import browsing
 from ftw.testbrowser.pages import factoriesmenu
 from ftw.testbrowser.pages.statusmessages import assert_no_error_messages
+from opengever.base.interfaces import ISequenceNumber
 from opengever.testing import IntegrationTestCase
+from zope.component import getUtility
 
 
 class TestWorkspaceFolder(IntegrationTestCase):
@@ -18,3 +20,10 @@ class TestWorkspaceFolder(IntegrationTestCase):
         form.save()
 
         assert_no_error_messages(browser)
+
+    def test_sequence_number(self):
+        self.assertEquals(
+            1, getUtility(ISequenceNumber).get_number(self.workspace_folder))
+
+    def test_workspace_generated_ids(self):
+        self.assertEquals('folder-1', self.workspace_folder.getId())

--- a/opengever/workspace/workspace_folder.py
+++ b/opengever/workspace/workspace_folder.py
@@ -1,0 +1,15 @@
+from opengever.dossier.base import DossierContainer
+from opengever.workspace.interfaces import IWorkspaceFolder
+from plone.autoform.interfaces import IFormFieldProvider
+from plone.supermodel import model
+from zope.interface import implements
+from zope.interface import provider
+
+
+@provider(IFormFieldProvider)
+class IWorkspaceFolderSchema(model.Schema):
+    """ """
+
+
+class WorkspaceFolder(DossierContainer):
+    implements(IWorkspaceFolder)


### PR DESCRIPTION
Adds a new content type `WorkspaceFolder` which is only addable inside a Workspace and inside itself.

closes #3677 