### PR TITLE
Add tabbed_view with one tab listing all workspaces to workspace root

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,8 @@ Changelog
 
 - Change msg2mime transform to use msgconvert executable from $PATH instead of shipping our own wrapper script. [lgraf]
 - Add partial reindex optimization for trashing and untrashing objects. [elioschmutz]
+- OGIP 17: Implement sequence_number and NameFromTitle behavior for Workspace. [mathias.leimgruber]
+- OGIP 17: Add tabbedviews for opengever.workspace types. [mathias.leimgruber]
 - Add filename and filesize in bumblebee overlay. [njohner]
 - Fix plonesite removal. [phgross]
 - Fix required input validation for the recipients field, when delegating a task. [phgross]

--- a/opengever/core/profiles/default/types/opengever.workspace.root.xml
+++ b/opengever/core/profiles/default/types/opengever.workspace.root.xml
@@ -28,11 +28,11 @@
   </property>
 
   <!-- View information -->
-  <property name="immediate_view">view</property>
-  <property name="default_view">view</property>
+  <property name="immediate_view">tabbed_view</property>
+  <property name="default_view">tabbed_view</property>
   <property name="default_view_fallback">False</property>
   <property name="view_methods">
-    <element value="view" />
+    <element value="tabbed_view" />
   </property>
 
   <!-- Method aliases -->

--- a/opengever/core/upgrades/20171220185847_configure_tabbedview_for_workspace_root_as_default_view/types/opengever.workspace.root.xml
+++ b/opengever/core/upgrades/20171220185847_configure_tabbedview_for_workspace_root_as_default_view/types/opengever.workspace.root.xml
@@ -1,0 +1,11 @@
+<object xmlns:i18n="http://xml.zope.org/namespaces/i18n" name="opengever.workspace.root" meta_type="Dexterity FTI" i18n:domain="opengever.core">
+
+  <!-- View information -->
+  <property name="immediate_view">tabbed_view</property>
+  <property name="default_view">tabbed_view</property>
+  <property name="default_view_fallback">False</property>
+  <property name="view_methods">
+    <element value="tabbed_view" />
+  </property>
+
+</object>

--- a/opengever/core/upgrades/20171220185847_configure_tabbedview_for_workspace_root_as_default_view/upgrade.py
+++ b/opengever/core/upgrades/20171220185847_configure_tabbedview_for_workspace_root_as_default_view/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class ConfigureTabbedviewForWorkspaceRootAsDefaultView(UpgradeStep):
+    """Configure tabbedview for workspace root as default view.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/workspace/browser/configure.zcml
+++ b/opengever/workspace/browser/configure.zcml
@@ -11,4 +11,20 @@
       allowed_interface="ftw.tabbedview.interfaces.ITabbedViewEndpoints"
       />
 
+
+  <browser:page
+      for="opengever.workspace.interfaces.IWorkspaceRoot"
+      name="tabbed_view"
+      class=".tabbed.WorkspaceRootTabbedView"
+      permission="zope2.View"
+      allowed_interface="ftw.tabbedview.interfaces.ITabbedViewEndpoints"
+      />
+
+  <browser:page
+      for="*"
+      name="tabbedview_view-workspaces"
+      class=".tabs.Workspaces"
+      permission="zope2.View"
+      />
+
 </configure>

--- a/opengever/workspace/browser/tabbed.py
+++ b/opengever/workspace/browser/tabbed.py
@@ -37,4 +37,18 @@ class WorkspaceTabbedView(GeverTabbedView):
             self.tasks_tab,
             self.trash_tab,
             self.journal_tab,
+
+        ])
+
+
+class WorkspaceRootTabbedView(GeverTabbedView):
+
+    workspaces_tab = {
+        'id': 'workspaces',
+        'title': _(u'label_workspaces', default=u'Workspaces'),
+        }
+
+    def _get_tabs(self):
+        return filter(None, [
+            self.workspaces_tab,
         ])

--- a/opengever/workspace/browser/tabs.py
+++ b/opengever/workspace/browser/tabs.py
@@ -2,7 +2,7 @@ from ftw.table import helper
 from opengever.tabbedview.browser.tabs import Dossiers
 from opengever.tabbedview.helper import linked
 from opengever.tabbedview.helper import readable_ogds_author
-from opengever.tabbedview import _
+from opengever.workspace import _
 
 
 class Workspaces(Dossiers):

--- a/opengever/workspace/browser/tabs.py
+++ b/opengever/workspace/browser/tabs.py
@@ -1,4 +1,3 @@
-from ftw.table import helper
 from opengever.tabbedview.browser.tabs import Dossiers
 from opengever.tabbedview.helper import linked
 from opengever.tabbedview.helper import readable_ogds_author
@@ -8,15 +7,10 @@ from opengever.workspace import _
 class Workspaces(Dossiers):
 
     filterlist_available = False
+    major_actions = []
+    enabled_actions = []
 
     columns = (
-
-        {'column': '',
-         'column_title': '',
-         'transform': helper.path_checkbox,
-         'sortable': False,
-         'groupable': False,
-         'width': 30},
 
         {'column': 'reference',
          'column_title': _(u'label_reference', default=u'Reference Number'),

--- a/opengever/workspace/browser/tabs.py
+++ b/opengever/workspace/browser/tabs.py
@@ -1,0 +1,36 @@
+from ftw.table import helper
+from opengever.tabbedview.browser.tabs import Dossiers
+from opengever.tabbedview.helper import linked
+from opengever.tabbedview.helper import readable_ogds_author
+from opengever.tabbedview import _
+
+
+class Workspaces(Dossiers):
+
+    filterlist_available = False
+
+    columns = (
+
+        {'column': '',
+         'column_title': '',
+         'transform': helper.path_checkbox,
+         'sortable': False,
+         'groupable': False,
+         'width': 30},
+
+        {'column': 'reference',
+         'column_title': _(u'label_reference', default=u'Reference Number'),
+         'width': 120},
+
+        {'column': 'Title',
+         'column_title': _(u'label_title', default=u'Title'),
+         'sort_index': 'sortable_title',
+         'transform': linked,
+         'width': 500},
+
+        {'column': 'responsible',
+         'column_title': _(u'label_dossier_responsible',
+                           default=u"Responsible"),
+         'transform': readable_ogds_author,
+         'width': 300}
+    )

--- a/opengever/workspace/locales/de/LC_MESSAGES/opengever.workspace.po
+++ b/opengever/workspace/locales/de/LC_MESSAGES/opengever.workspace.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-12-20 15:12+0000\n"
+"POT-Creation-Date: 2017-12-20 18:03+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,6 +19,11 @@ msgstr ""
 msgid "label_documents"
 msgstr "Dokumente"
 
+#. Default: "Responsible"
+#: ./opengever/workspace/browser/tabs.py
+msgid "label_dossier_responsible"
+msgstr "Verantwortlicher"
+
 #. Default: "Journal"
 #: ./opengever/workspace/browser/tabbed.py
 msgid "label_journal"
@@ -29,12 +34,27 @@ msgstr "Journal"
 msgid "label_overview"
 msgstr "Übersicht"
 
+#. Default: "Reference Number"
+#: ./opengever/workspace/browser/tabs.py
+msgid "label_reference"
+msgstr "Aktenzeichen"
+
 #. Default: "Tasks"
 #: ./opengever/workspace/browser/tabbed.py
 msgid "label_tasks"
 msgstr "Aufgaben"
 
+#. Default: "Title"
+#: ./opengever/workspace/browser/tabs.py
+msgid "label_title"
+msgstr "Titel"
+
 #. Default: "Trash"
 #: ./opengever/workspace/browser/tabbed.py
 msgid "label_trash"
 msgstr "Papierkorb"
+
+#. Default: "Workspaces"
+#: ./opengever/workspace/browser/tabbed.py
+msgid "label_workspaces"
+msgstr "Teamräume"

--- a/opengever/workspace/locales/fr/LC_MESSAGES/opengever.workspace.po
+++ b/opengever/workspace/locales/fr/LC_MESSAGES/opengever.workspace.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-12-20 15:12+0000\n"
+"POT-Creation-Date: 2017-12-20 18:03+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,6 +19,11 @@ msgstr ""
 msgid "label_documents"
 msgstr ""
 
+#. Default: "Responsible"
+#: ./opengever/workspace/browser/tabs.py
+msgid "label_dossier_responsible"
+msgstr ""
+
 #. Default: "Journal"
 #: ./opengever/workspace/browser/tabbed.py
 msgid "label_journal"
@@ -29,12 +34,27 @@ msgstr ""
 msgid "label_overview"
 msgstr ""
 
+#. Default: "Reference Number"
+#: ./opengever/workspace/browser/tabs.py
+msgid "label_reference"
+msgstr ""
+
 #. Default: "Tasks"
 #: ./opengever/workspace/browser/tabbed.py
 msgid "label_tasks"
 msgstr ""
 
+#. Default: "Title"
+#: ./opengever/workspace/browser/tabs.py
+msgid "label_title"
+msgstr ""
+
 #. Default: "Trash"
 #: ./opengever/workspace/browser/tabbed.py
 msgid "label_trash"
+msgstr ""
+
+#. Default: "Workspaces"
+#: ./opengever/workspace/browser/tabbed.py
+msgid "label_workspaces"
 msgstr ""

--- a/opengever/workspace/locales/opengever.workspace.pot
+++ b/opengever/workspace/locales/opengever.workspace.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-12-20 15:12+0000\n"
+"POT-Creation-Date: 2017-12-20 18:03+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -22,6 +22,11 @@ msgstr ""
 msgid "label_documents"
 msgstr ""
 
+#. Default: "Responsible"
+#: ./opengever/workspace/browser/tabs.py
+msgid "label_dossier_responsible"
+msgstr ""
+
 #. Default: "Journal"
 #: ./opengever/workspace/browser/tabbed.py
 msgid "label_journal"
@@ -32,12 +37,27 @@ msgstr ""
 msgid "label_overview"
 msgstr ""
 
+#. Default: "Reference Number"
+#: ./opengever/workspace/browser/tabs.py
+msgid "label_reference"
+msgstr ""
+
 #. Default: "Tasks"
 #: ./opengever/workspace/browser/tabbed.py
 msgid "label_tasks"
 msgstr ""
 
+#. Default: "Title"
+#: ./opengever/workspace/browser/tabs.py
+msgid "label_title"
+msgstr ""
+
 #. Default: "Trash"
 #: ./opengever/workspace/browser/tabbed.py
 msgid "label_trash"
+msgstr ""
+
+#. Default: "Workspaces"
+#: ./opengever/workspace/browser/tabbed.py
+msgid "label_workspaces"
 msgstr ""


### PR DESCRIPTION
This PR bases on #3824, please merge this one first.

Currently we have only one tab... I know this is no useful, but it will be replaces really soon. 