### PR TITLE
Tidy up XML files in default profile of opengever.core

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -9,6 +9,8 @@ Changelog
 - OGIP 17: Add workspace workflows and add workspace support to document workflow. [jone]
 - OGIP 17: Introduce workspace specific sources used in Tasks [mathias.leimgruber]
 - Fix broken advanced search js initialization. [deiferni]
+- Tidy up XML files in default profile [raphael-s]
+- Trigger SQL task synchronisation when changing task state. [phgross]
 - Change msg2mime transform to use msgconvert executable from $PATH instead of shipping our own wrapper script. [lgraf]
 - Add partial reindex optimization for trashing and untrashing objects. [elioschmutz]
 - OGIP 17: Implement sequence_number and NameFromTitle behavior for Workspace. [mathias.leimgruber]

--- a/opengever/core/profiles/default/actions.xml
+++ b/opengever/core/profiles/default/actions.xml
@@ -1,10 +1,8 @@
 <object xmlns:i18n="http://xml.zope.org/namespaces/i18n" name="portal_actions" meta_type="Plone Actions Tool">
 
-
-  <!-- ###################################################### /-->
+  <!-- DOCUMENT ACTIONS -->
   <object name="document_actions" meta_type="CMF Action Category">
 
-    <!--migrated from opengever/policy/base/profiles/default/actions.xml-->
     <object name="watch" meta_type="CMF Action">
       <property name="visible">False</property>
     </object>
@@ -16,10 +14,9 @@
   </object>
 
 
-  <!-- ###################################################### /-->
+  <!-- SITE ACTIONS -->
   <object name="site_actions" meta_type="CMF Action Category">
 
-    <!--migrated from opengever/base/profiles/default/actions.xml-->
     <object name="sitemap" meta_type="CMF Action" i18n:domain="plone">
       <property name="visible">False</property>
     </object>
@@ -27,10 +24,9 @@
   </object>
 
 
-  <!-- ###################################################### /-->
+  <!-- FOLDER BUTTONS -->
   <object name="folder_buttons" meta_type="CMF Action Category">
 
-    <!--migrated from opengever/globalindex/profiles/default/actions.xml-->
     <object name="export_tasks" meta_type="CMF Action" i18n:domain="opengever.core">
       <property name="title" i18n:translate="">Export selection</property>
       <property name="description" i18n:translate="" />
@@ -43,7 +39,6 @@
       <property name="visible">True</property>
     </object>
 
-    <!--migrated from opengever/base/profiles/default/actions.xml-->
     <object name="copy_items" meta_type="CMF Action" i18n:domain="opengever.core">
       <property name="title" i18n:translate="">Copy Items</property>
       <property name="description" i18n:translate="" />
@@ -93,7 +88,6 @@
       <property name="visible">False</property>
     </object>
 
-    <!--migrated from opengever/document/profiles/default/actions.xml-->
     <object name="send_as_email" meta_type="CMF Action" i18n:domain="opengever.core">
       <property name="title" i18n:translate="">Send as email</property>
       <property name="description" i18n:translate="" />
@@ -215,7 +209,6 @@
       <property name="visible">True</property>
     </object>
 
-    <!--migrated from opengever/dossier/profiles/default/actions.xml-->
     <object name="delete_participants" meta_type="CMF Action" i18n:domain="opengever.core">
       <property name="title" i18n:translate="">Delete</property>
       <property name="description" i18n:translate="" />
@@ -264,7 +257,6 @@
       <property name="visible">True</property>
     </object>
 
-    <!--migrated from opengever/trash/profiles/default/actions.xml-->
     <object name="trashed" meta_type="CMF Action" i18n:domain="opengever.core">
       <property name="title" i18n:translate="">trashed</property>
       <property name="description" i18n:translate="" />
@@ -301,7 +293,6 @@
       <property name="visible">True</property>
     </object>
 
-    <!--migrated from opengever/inbox/profiles/default/actions.xml-->
     <object name="create_forwarding" meta_type="CMF Action" i18n:domain="opengever.core">
       <property name="title" i18n:translate="">Forward</property>
       <property name="description" i18n:translate="" />
@@ -314,7 +305,6 @@
       <property name="visible">True</property>
     </object>
 
-    <!--migrated from opengever/latex/profiles/default/actions.xml-->
     <object name="pdf_dossierlisting" meta_type="CMF Action" i18n:domain="opengever.core">
       <property name="title" i18n:translate="">Print selection (PDF)</property>
       <property name="description" i18n:translate="" />
@@ -339,7 +329,6 @@
       <property name="visible">True</property>
     </object>
 
-    <!--migrated from opengever/disposition/profiles/default/actions.xml-->
     <object name="create_disposition" meta_type="CMF Action" i18n:domain="opengever.core">
       <property name="title" i18n:translate="">Create Disposition</property>
       <property name="description" i18n:translate="" />
@@ -367,10 +356,9 @@
   </object>
 
 
-  <!-- ###################################################### /-->
+  <!-- OBJECT -->
   <object name="object" meta_type="CMF Action Category">
 
-    <!--migrated from opengever/policy/base/profiles/default/actions.xml-->
     <object name="local_roles" meta_type="CMF Action">
       <property name="visible">False</property>
     </object>
@@ -396,10 +384,9 @@
   </object>
 
 
-  <!-- ###################################################### /-->
+  <!-- OBJECT BUTTONS -->
   <object name="object_buttons" meta_type="CMF Action Category">
 
-    <!--migrated from opengever/base/profiles/default/actions.xml-->
     <object name="cut" meta_type="CMF Action" i18n:domain="plone">
       <property name="title" i18n:translate="">Cut</property>
       <property name="description" i18n:translate="" />
@@ -534,7 +521,6 @@
       <property name="visible">True</property>
     </object>
 
-    <!--migrated from opengever/repository/profiles/default/actions.xml-->
     <object name="prefix_manager" meta_type="CMF Action" i18n:domain="opengever.core">
       <property name="title" i18n:translate="">Prefix Manager</property>
       <property name="description" i18n:translate="">Unlock unused repository prefixes.</property>
@@ -561,7 +547,6 @@
       <property name="visible">True</property>
     </object>
 
-    <!--migrated from opengever/latex/profiles/default/actions.xml-->
     <object name="pdf_dossierdetails" meta_type="CMF Action" i18n:domain="opengever.core">
       <property name="title" i18n:translate="">Print details (PDF)</property>
       <property name="description" i18n:translate="" />
@@ -627,10 +612,9 @@
   </object>
 
 
-  <!-- ###################################################### /-->
+  <!-- PORTAL TABS -->
   <object name="portal_tabs" meta_type="CMF Action Category">
 
-    <!--migrated from opengever/base/profiles/default/actions.xml-->
     <object name="index_html" meta_type="CMF Action" i18n:domain="plone">
       <property name="title" i18n:translate="">Overview</property>
       <property name="description" i18n:translate="" />
@@ -644,7 +628,6 @@
       <property name="visible">True</property>
     </object>
 
-    <!--migrated from opengever/private/profiles/default/actions.xml-->
     <object name="my_repository" meta_type="CMF Action" i18n:domain="opengever.core">
       <property name="title" i18n:translate="">My repository</property>
       <property name="description" i18n:translate="" />
@@ -661,10 +644,9 @@
   </object>
 
 
-  <!-- ###################################################### /-->
+  <!-- USER -->
   <object name="user" meta_type="CMF Action Category">
 
-    <!--migrated from opengever/policy/base/profiles/default/actions.xml-->
     <object name="dashboard" meta_type="CMF Action" i18n:domain="plone">
       <property name="title" i18n:translate="">Dashboard</property>
       <property name="description" i18n:translate="" />
@@ -746,18 +728,17 @@
   </object>
 
 
-  <!-- ###################################################### /-->
+  <!-- CONTROLPANEL -->
   <object name="controlpanel" meta_type="CMF Action Category" />
 
 
-  <!-- ###################################################### /-->
+  <!-- JQUERYUI PANELS -->
   <object name="jqueryui_panels" meta_type="CMF Action Category" />
 
 
-  <!-- ###################################################### /-->
+  <!-- MOBILE BUTTONS -->
   <object name="mobile_buttons" meta_type="CMF Action Category">
 
-    <!--migrated from opengever/ogds/base/profiles/default/actions.xml-->
     <object name="toggle_orgunitselector" meta_type="CMF Action" i18n:domain="opengever.core">
       <property name="title" i18n:translate="">Toggle orgunit selector</property>
       <property name="description" i18n:translate="" />
@@ -773,10 +754,9 @@
   </object>
 
 
-  <!-- ###################################################### /-->
+  <!-- OBJECT CHECKIN MENU -->
   <object name="object_checkin_menu" meta_type="CMF Action Category">
 
-    <!--migrated from opengever/document/profiles/default/actions.xml-->
     <object name="checkin_with_comment" meta_type="CMF Action" i18n:domain="opengever.core">
       <property name="title" i18n:translate="">with comment</property>
       <property name="description" i18n:translate="" />
@@ -802,6 +782,5 @@
     </object>
 
   </object>
-
 
 </object>

--- a/opengever/core/profiles/default/browserlayer.xml
+++ b/opengever/core/profiles/default/browserlayer.xml
@@ -1,9 +1,9 @@
 <layers>
 
-  <!--migrated from opengever/base/profiles/default/browserlayer.xml-->
+  <!-- OPENGEVER BASE LAYER -->
   <layer name="opengever.base.layer" interface="opengever.base.interfaces.IOpengeverBaseLayer" />
 
 
-  <!--migrated from opengever/sharing/profiles/default/browserlayer.xml-->
+  <!-- OPENGEVER SHARING -->
   <layer name="opengever.sharing" interface="opengever.sharing.interfaces.IOpengeverSharing" />
 </layers>

--- a/opengever/core/profiles/default/catalog.xml
+++ b/opengever/core/profiles/default/catalog.xml
@@ -1,5 +1,8 @@
 <object name="portal_catalog">
 
+  <!-- Add indexes here on penalty of death or worse.
+       See INDEXES in config.py instead. -->
+
   <!-- BASE -->
   <column value="css_icon_class" />
   <index name="reference" meta_type="FieldIndex">
@@ -9,6 +12,13 @@
   <column value="title_de" />
   <column value="title_fr" />
 
+  <!-- CONTACT -->
+  <column value="contactid" />
+  <column value="email" />
+  <column value="email2" />
+  <column value="firstname" />
+  <column value="lastname" />
+  <column value="phone_office" />
 
   <!-- DOCUMENT -->
   <column value="document_author" />
@@ -18,12 +28,10 @@
   <column value="checked_out" />
   <column value="public_trial" />
 
-
   <!-- DOSSIER -->
   <column value="containing_subdossier" />
   <column value="containing_dossier" />
   <column value="retention_expiration" />
-
 
   <!-- TASK -->
   <column value="deadline" />
@@ -36,25 +44,10 @@
   <column value="is_subtask" />
   <column value="predecessor" />
 
+  <!-- TASKTEMPLATES -->
+  <column value="preselected" />
 
   <!-- TRASH -->
   <column value="trashed" />
-
-
-  <!-- TASKTEMPLATES -->
-  <!-- Add indexes here on penalty of death or worse.
-       See add_catalog_indexes in setuphandlers.py instead. -->
-  <column value="preselected" />
-
-
-  <!-- CONTACT -->
-  <!-- Add indexes here on penalty of death or worse.
-       See INDEXES in config.py instead. -->
-  <column value="contactid" />
-  <column value="email" />
-  <column value="email2" />
-  <column value="firstname" />
-  <column value="lastname" />
-  <column value="phone_office" />
 
 </object>

--- a/opengever/core/profiles/default/catalog.xml
+++ b/opengever/core/profiles/default/catalog.xml
@@ -1,6 +1,6 @@
 <object name="portal_catalog">
 
-  <!--migrated from opengever/base/profiles/default/catalog.xml-->
+  <!-- BASE -->
   <column value="css_icon_class" />
   <index name="reference" meta_type="FieldIndex">
     <indexed_attr value="reference" />
@@ -10,7 +10,7 @@
   <column value="title_fr" />
 
 
-  <!--migrated from opengever/document/profiles/default/catalog.xml-->
+  <!-- DOCUMENT -->
   <column value="document_author" />
   <column value="document_date" />
   <column value="receipt_date" />
@@ -19,13 +19,13 @@
   <column value="public_trial" />
 
 
-  <!--migrated from opengever/dossier/profiles/default/catalog.xml-->
+  <!-- DOSSIER -->
   <column value="containing_subdossier" />
   <column value="containing_dossier" />
   <column value="retention_expiration" />
 
 
-  <!--migrated from opengever/task/profiles/default/catalog.xml-->
+  <!-- TASK -->
   <column value="deadline" />
   <column value="date_of_completion" />
   <column value="responsible" />
@@ -37,21 +37,19 @@
   <column value="predecessor" />
 
 
-  <!--migrated from opengever/trash/profiles/default/catalog.xml-->
+  <!-- TRASH -->
   <column value="trashed" />
 
 
-  <!--migrated from opengever/tasktemplates/profiles/default/catalog.xml-->
+  <!-- TASKTEMPLATES -->
   <!-- Add indexes here on penalty of death or worse.
-         See add_catalog_indexes in setuphandlers.py instead. -->
-
+       See add_catalog_indexes in setuphandlers.py instead. -->
   <column value="preselected" />
 
 
-  <!--migrated from opengever/contact/profiles/default/catalog.xml-->
+  <!-- CONTACT -->
   <!-- Add indexes here on penalty of death or worse.
-         See INDEXES in config.py instead. -->
-
+       See INDEXES in config.py instead. -->
   <column value="contactid" />
   <column value="email" />
   <column value="email2" />

--- a/opengever/core/profiles/default/controlpanel.xml
+++ b/opengever/core/profiles/default/controlpanel.xml
@@ -1,5 +1,6 @@
 <object name="portal_controlpanel">
 
+  <!-- LDAP SYNCHRONISATION CONTROL PANEL -->
   <configlet
       title="LDAP Synchronisation Control Panel"
       action_id="ldap_controlpanel"
@@ -12,34 +13,7 @@
     <permission>Manage portal</permission>
   </configlet>
 
-  <configlet
-      title="LDAP Synchronisation Control Panel"
-      action_id="ldap_controlpanel"
-      appId="opengever.ogds.base"
-      category="Products"
-      url_expr="string:${portal_url}/@@ldap_controlpanel"
-      condition_expr=""
-      icon_expr="string:$portal_url/++resource++plone.app.registry/icon.png"
-      visible="True">
-    <permission>Manage portal</permission>
-  </configlet>
-
-
-  <!--migrated from opengever/ogds/base/profiles/default/controlpanel.xml-->
-  <configlet
-      title="LDAP Synchronisation Control Panel"
-      action_id="ldap_controlpanel"
-      appId="opengever.ogds.base"
-      category="Products"
-      url_expr="string:${portal_url}/@@ldap_controlpanel"
-      condition_expr=""
-      icon_expr="string:$portal_url/++resource++plone.app.registry/icon.png"
-      visible="True">
-    <permission>Manage portal</permission>
-  </configlet>
-
-
-  <!--migrated from opengever/tabbedview/profiles/default/controlpanel.xml-->
+  <!-- OGDS CONTROL PANEL -->
   <configlet
       title="OGDS Control Panel"
       action_id="ogds-controlpanel"

--- a/opengever/core/profiles/default/cssregistry.xml
+++ b/opengever/core/profiles/default/cssregistry.xml
@@ -1,8 +1,8 @@
 <object name="portal_css">
 
   <stylesheet
-      remove="True"
       id="++resource++plone.formwidget.autocomplete/jquery.autocomplete.css"
+      remove="True"
       />
 
   <stylesheet

--- a/opengever/core/profiles/default/portal_languages.xml
+++ b/opengever/core/profiles/default/portal_languages.xml
@@ -1,6 +1,4 @@
 <object>
-
-  <!--migrated from opengever/policy/base/profiles/default/portal_languages.xml-->
   <default_language value="de-ch" />
   <use_combined_language_codes value="True" />
   <display_flags value="False" />

--- a/opengever/core/profiles/default/portlets.xml
+++ b/opengever/core/profiles/default/portlets.xml
@@ -1,8 +1,6 @@
 <portlets>
 
-  <!--migrated from opengever/portlets/tree/profiles/default/portlets.xml-->
-  <!-- Portlet type registrations -->
-
+  <!-- TREE PORTLET -->
   <portlet
       addview="opengever.portlets.tree.TreePortlet"
       title="Tree portlet"

--- a/opengever/core/profiles/default/properties.xml
+++ b/opengever/core/profiles/default/properties.xml
@@ -1,6 +1,4 @@
 <site>
-
-  <!--migrated from opengever/base/profiles/default/properties.xml-->
   <property name="layout" type="string">@@personal_overview</property>
   <property name="search_label" type="string">Search OneGov Gever</property>
 </site>

--- a/opengever/core/profiles/default/propertiestool.xml
+++ b/opengever/core/profiles/default/propertiestool.xml
@@ -1,5 +1,10 @@
 <object name="portal_properties" meta_type="Plone Properties Tool">
 
+  <!-- SITE PROPERTIES -->
+  <object name="site_properties" meta_type="Plone Property Sheet">
+    <property name="icon_visibility" type="string">enabled</property>
+  </object>
+
   <!-- NAVTREE PROPERTIES -->
   <object name="navtree_properties" meta_type="Plone Property Sheet">
     <property name="metaTypesNotToList" type="lines">
@@ -41,8 +46,4 @@
     </property>
   </object>
 
-  <!-- SITE PROPERTIES -->
-  <object name="site_properties" meta_type="Plone Property Sheet">
-    <property name="icon_visibility" type="string">enabled</property>
-  </object>
 </object>

--- a/opengever/core/profiles/default/propertiestool.xml
+++ b/opengever/core/profiles/default/propertiestool.xml
@@ -1,6 +1,6 @@
 <object name="portal_properties" meta_type="Plone Properties Tool">
 
-  <!--migrated from opengever/base/profiles/default/propertiestool.xml-->
+  <!-- NAVTREE PROPERTIES -->
   <object name="navtree_properties" meta_type="Plone Property Sheet">
     <property name="metaTypesNotToList" type="lines">
       <element value="ATBooleanCriterion" />
@@ -30,17 +30,18 @@
       <element value="ftw.mail.mail" />
       <element value="opengever.contact.contact" />
       <element value="opengever.document.document" />
+      <element value="opengever.dossier.dossiertemplate" />
       <element value="opengever.inbox.forwarding" />
+      <element value="opengever.meeting.proposaltemplate" />
       <element value="opengever.meeting.sablontemplate" />
+      <element value="opengever.private.root" />
       <element value="opengever.task.task" />
       <element value="opengever.tasktemplates.tasktemplate" />
       <element value="opengever.tasktemplates.tasktemplatefolder" />
-      <element value="opengever.dossier.dossiertemplate" />
-      <element value="opengever.private.root" />
-      <element value="opengever.meeting.proposaltemplate" />
     </property>
   </object>
 
+  <!-- SITE PROPERTIES -->
   <object name="site_properties" meta_type="Plone Property Sheet">
     <property name="icon_visibility" type="string">enabled</property>
   </object>

--- a/opengever/core/profiles/default/registry.xml
+++ b/opengever/core/profiles/default/registry.xml
@@ -1,9 +1,7 @@
 <registry>
 
-  <!-- OGDS -->
-  <records interface="opengever.ogds.base.interfaces.IAdminUnitConfiguration" />
-  <records interface="opengever.ogds.base.interfaces.IOGDSSyncConfiguration" />
-
+  <!-- ACTIVITY -->
+  <records interface="opengever.activity.interfaces.IActivitySettings" />
 
   <!-- BASE -->
   <records interface="opengever.base.interfaces.IBaseCustodyPeriods" />
@@ -11,112 +9,8 @@
   <records interface="opengever.base.interfaces.IReferenceNumberSettings" />
   <records interface="opengever.base.behaviors.classification.IClassificationSettings" />
 
-
-  <!-- DOCUMENT -->
-  <records interface="opengever.document.interfaces.IDocumentType" />
-  <records interface="opengever.document.interfaces.IDocumentSettings" />
-
-
-  <!-- MAIL -->
-  <records interface="opengever.mail.interfaces.ISendDocumentConf" />
-  <records interface="opengever.mail.interfaces.IMailTabbedviewSettings" />
-
-
-  <!-- DOSSIER -->
-  <records interface="opengever.dossier.interfaces.IDossierContainerTypes" />
-  <records interface="opengever.dossier.interfaces.IDossierParticipants" />
-  <records interface="opengever.dossier.interfaces.ITemplateFolderProperties" />
-  <records interface="opengever.dossier.interfaces.IDossierResolveProperties" />
-  <records interface="opengever.dossier.dossiertemplate.interfaces.IDossierTemplateSettings" />
-
-
-  <!-- REPOSITORY -->
-  <records interface="opengever.repository.interfaces.IRepositoryFolderRecords" />
-
-
-  <!-- TASK -->
-  <records interface="opengever.task.interfaces.ITaskSettings" />
-
-
-  <!-- TABBEDVIEW -->
-  <record
-      interface="ftw.tabbedview.interfaces.ITabbedView"
-      field="extjs_enabled">
-    <field type="plone.registry.field.Bool" />
-    <value>True</value>
-  </record>
-
-  <record
-      interface="ftw.tabbedview.interfaces.ITabbedView"
-      field="quickupload_addable_types">
-    <field type="plone.registry.field.List">
-      <value_type type="plone.registry.field.TextLine" />
-    </field>
-    <value>
-      <element>opengever.document.document</element>
-      <element>ftw.mail.mail</element>
-    </value>
-  </record>
-
-
-  <!-- TREE -->
-  <record name="opengever.portlets.tree.enable_favorites">
-    <field type="plone.registry.field.Bool">
-      <title>Enable favorites in tree portlet</title>
-    </field>
-    <value>false</value>
-  </record>
-
-
-  <!-- CONTACT -->
-  <records interface="opengever.contact.interfaces.IContactSettings" />
-
-
-  <!-- SHARING -->
-  <records interface="opengever.sharing.interfaces.ISharingConfiguration" />
-
-
-  <!-- LATEX -->
-  <records interface="opengever.latex.interfaces.ILaTeXSettings" />
-
-
-  <!-- MEETING -->
-  <records interface="opengever.meeting.interfaces.IMeetingSettings" />
-
-
-  <!-- ACTIVITY -->
-  <records interface="opengever.activity.interfaces.IActivitySettings" />
-
-
   <!-- BUMBLEBEE -->
   <records interface="opengever.bumblebee.interfaces.IGeverBumblebeeSettings" />
-
-
-  <!-- OFFICEATWORK -->
-  <records interface="opengever.officeatwork.interfaces.IOfficeatworkSettings" />
-
-
-  <!-- OFFICECONNECTOR -->
-  <records interface="opengever.officeconnector.interfaces.IOfficeConnectorSettings" />
-
-
-  <!-- PRIVATE -->
-  <records interface="opengever.private.interfaces.IPrivateFolderQuotaSettings" />
-
-
-  <!-- ECH-0147 -->
-  <records interface="opengever.ech0147.interfaces.IECH0147Settings" />
-
-
-  <!-- POLICY -->
-  <records interface="ftw.zipexport.interfaces.IZipExportSettings">
-    <value key="enabled_dotted_names">
-      <element>opengever.dossier.behaviors.dossier.IDossierMarker</element>
-      <element>opengever.dossier.templatefolder.interfaces.ITemplateFolder</element>
-      <element>opengever.task.task.ITask</element>
-    </value>
-  </records>
-
 
   <!-- CACHING -->
   <record name="plone.caching.interfaces.ICacheSettings.enabled">
@@ -151,7 +45,95 @@
     </value>
   </record>
 
+  <!-- CONTACT -->
+  <records interface="opengever.contact.interfaces.IContactSettings" />
+
+  <!-- DATEPICKER -->
   <record name="ftw.datepicker.interfaces.IDatetimeRegistry.various">
     <value>{"dayOfWeekStart": 1, "scrollMonth": false, "scrollTime": false, "scrollInput": false}</value>
   </record>
+
+  <!-- DOCUMENT -->
+  <records interface="opengever.document.interfaces.IDocumentType" />
+  <records interface="opengever.document.interfaces.IDocumentSettings" />
+
+  <!-- DOSSIER -->
+  <records interface="opengever.dossier.interfaces.IDossierContainerTypes" />
+  <records interface="opengever.dossier.interfaces.IDossierParticipants" />
+  <records interface="opengever.dossier.interfaces.ITemplateFolderProperties" />
+  <records interface="opengever.dossier.interfaces.IDossierResolveProperties" />
+  <records interface="opengever.dossier.dossiertemplate.interfaces.IDossierTemplateSettings" />
+
+  <!-- ECH-0147 -->
+  <records interface="opengever.ech0147.interfaces.IECH0147Settings" />
+
+  <!-- LATEX -->
+  <records interface="opengever.latex.interfaces.ILaTeXSettings" />
+
+  <!-- MAIL -->
+  <records interface="opengever.mail.interfaces.ISendDocumentConf" />
+  <records interface="opengever.mail.interfaces.IMailTabbedviewSettings" />
+
+  <!-- MEETING -->
+  <records interface="opengever.meeting.interfaces.IMeetingSettings" />
+
+  <!-- OFFICEATWORK -->
+  <records interface="opengever.officeatwork.interfaces.IOfficeatworkSettings" />
+
+  <!-- OFFICECONNECTOR -->
+  <records interface="opengever.officeconnector.interfaces.IOfficeConnectorSettings" />
+
+  <!-- OGDS -->
+  <records interface="opengever.ogds.base.interfaces.IAdminUnitConfiguration" />
+  <records interface="opengever.ogds.base.interfaces.IOGDSSyncConfiguration" />
+
+  <!-- POLICY -->
+  <records interface="ftw.zipexport.interfaces.IZipExportSettings">
+    <value key="enabled_dotted_names">
+      <element>opengever.dossier.behaviors.dossier.IDossierMarker</element>
+      <element>opengever.dossier.templatefolder.interfaces.ITemplateFolder</element>
+      <element>opengever.task.task.ITask</element>
+    </value>
+  </records>
+
+  <!-- PRIVATE -->
+  <records interface="opengever.private.interfaces.IPrivateFolderQuotaSettings" />
+
+  <!-- REPOSITORY -->
+  <records interface="opengever.repository.interfaces.IRepositoryFolderRecords" />
+
+  <!-- SHARING -->
+  <records interface="opengever.sharing.interfaces.ISharingConfiguration" />
+
+  <!-- TABBEDVIEW -->
+  <record
+      interface="ftw.tabbedview.interfaces.ITabbedView"
+      field="extjs_enabled">
+    <field type="plone.registry.field.Bool" />
+    <value>True</value>
+  </record>
+
+  <record
+      interface="ftw.tabbedview.interfaces.ITabbedView"
+      field="quickupload_addable_types">
+    <field type="plone.registry.field.List">
+      <value_type type="plone.registry.field.TextLine" />
+    </field>
+    <value>
+      <element>opengever.document.document</element>
+      <element>ftw.mail.mail</element>
+    </value>
+  </record>
+
+  <!-- TASK -->
+  <records interface="opengever.task.interfaces.ITaskSettings" />
+
+  <!-- TREE -->
+  <record name="opengever.portlets.tree.enable_favorites">
+    <field type="plone.registry.field.Bool">
+      <title>Enable favorites in tree portlet</title>
+    </field>
+    <value>false</value>
+  </record>
+
 </registry>

--- a/opengever/core/profiles/default/registry.xml
+++ b/opengever/core/profiles/default/registry.xml
@@ -1,28 +1,28 @@
 <registry>
 
-  <!--migrated from opengever/ogds/base/profiles/default/registry.xml-->
+  <!-- OGDS -->
   <records interface="opengever.ogds.base.interfaces.IAdminUnitConfiguration" />
-
   <records interface="opengever.ogds.base.interfaces.IOGDSSyncConfiguration" />
 
-  <!--migrated from opengever/base/profiles/default/registry.xml-->
+
+  <!-- BASE -->
   <records interface="opengever.base.interfaces.IBaseCustodyPeriods" />
   <records interface="opengever.base.interfaces.IRetentionPeriodRegister" />
   <records interface="opengever.base.interfaces.IReferenceNumberSettings" />
   <records interface="opengever.base.behaviors.classification.IClassificationSettings" />
 
 
-  <!--migrated from opengever/document/profiles/default/registry.xml-->
+  <!-- DOCUMENT -->
   <records interface="opengever.document.interfaces.IDocumentType" />
   <records interface="opengever.document.interfaces.IDocumentSettings" />
 
 
-  <!--migrated from opengever/mail/profiles/default/registry.xml-->
+  <!-- MAIL -->
   <records interface="opengever.mail.interfaces.ISendDocumentConf" />
   <records interface="opengever.mail.interfaces.IMailTabbedviewSettings" />
 
 
-  <!--migrated from opengever/dossier/profiles/default/registry.xml-->
+  <!-- DOSSIER -->
   <records interface="opengever.dossier.interfaces.IDossierContainerTypes" />
   <records interface="opengever.dossier.interfaces.IDossierParticipants" />
   <records interface="opengever.dossier.interfaces.ITemplateFolderProperties" />
@@ -30,15 +30,15 @@
   <records interface="opengever.dossier.dossiertemplate.interfaces.IDossierTemplateSettings" />
 
 
-  <!--migrated from opengever/repository/profiles/default/registry.xml-->
+  <!-- REPOSITORY -->
   <records interface="opengever.repository.interfaces.IRepositoryFolderRecords" />
 
 
-  <!--migrated from opengever/task/profiles/default/registry.xml-->
+  <!-- TASK -->
   <records interface="opengever.task.interfaces.ITaskSettings" />
 
 
-  <!--migrated from opengever/tabbedview/profiles/default/registry.xml-->
+  <!-- TABBEDVIEW -->
   <record
       interface="ftw.tabbedview.interfaces.ITabbedView"
       field="extjs_enabled">
@@ -59,7 +59,7 @@
   </record>
 
 
-  <!--migrated from opengever/portlets/tree/profiles/default/registry.xml-->
+  <!-- TREE -->
   <record name="opengever.portlets.tree.enable_favorites">
     <field type="plone.registry.field.Bool">
       <title>Enable favorites in tree portlet</title>
@@ -68,44 +68,47 @@
   </record>
 
 
-  <!--migrated from opengever/contact/profiles/default/registry.xml-->
+  <!-- CONTACT -->
   <records interface="opengever.contact.interfaces.IContactSettings" />
 
 
-  <!--migrated from opengever/sharing/profiles/default/registry.xml-->
+  <!-- SHARING -->
   <records interface="opengever.sharing.interfaces.ISharingConfiguration" />
 
 
-  <!--migrated from opengever/latex/profiles/default/registry.xml-->
+  <!-- LATEX -->
   <records interface="opengever.latex.interfaces.ILaTeXSettings" />
 
 
-  <!--migrated from opengever/meeting/profiles/default/registry.xml-->
+  <!-- MEETING -->
   <records interface="opengever.meeting.interfaces.IMeetingSettings" />
 
 
-  <!--migrated from opengever/activity/profiles/default/registry.xml-->
+  <!-- ACTIVITY -->
   <records interface="opengever.activity.interfaces.IActivitySettings" />
 
 
-  <!--migrated from opengever/bumblebee/profiles/default/registry.xml-->
+  <!-- BUMBLEBEE -->
   <records interface="opengever.bumblebee.interfaces.IGeverBumblebeeSettings" />
 
 
-  <!--migrated from opengever/officeatwork/profiles/default/registry.xml-->
+  <!-- OFFICEATWORK -->
   <records interface="opengever.officeatwork.interfaces.IOfficeatworkSettings" />
 
 
-  <!--migrated from opengever/officeconnector/profiles/default/registry.xml-->
+  <!-- OFFICECONNECTOR -->
   <records interface="opengever.officeconnector.interfaces.IOfficeConnectorSettings" />
 
 
-  <!--migrated from opengever/private/profiles/default/registry.xml-->
+  <!-- PRIVATE -->
   <records interface="opengever.private.interfaces.IPrivateFolderQuotaSettings" />
 
+
+  <!-- ECH-0147 -->
   <records interface="opengever.ech0147.interfaces.IECH0147Settings" />
 
-  <!--migrated from opengever/policy/base/profiles/default/registry.xml-->
+
+  <!-- POLICY -->
   <records interface="ftw.zipexport.interfaces.IZipExportSettings">
     <value key="enabled_dotted_names">
       <element>opengever.dossier.behaviors.dossier.IDossierMarker</element>
@@ -113,6 +116,7 @@
       <element>opengever.task.task.ITask</element>
     </value>
   </records>
+
 
   <!-- CACHING -->
   <record name="plone.caching.interfaces.ICacheSettings.enabled">
@@ -124,7 +128,7 @@
   </record>
 
   <!-- disable cache purging for now, since we have no proxies configured
-         to be purged -->
+       to be purged -->
   <record name="plone.cachepurging.interfaces.ICachePurgingSettings.enabled">
     <value>False</value>
   </record>

--- a/opengever/core/profiles/default/repositorytool.xml
+++ b/opengever/core/profiles/default/repositorytool.xml
@@ -1,6 +1,6 @@
 <repositorytool>
 
-  <!--migrated from opengever/document/profiles/default/repositorytool.xml-->
+  <!-- DOCUMENT -->
   <policymap purge="false">
     <type name="opengever.document.document">
       <policy name="version_on_revert" />
@@ -8,7 +8,7 @@
   </policymap>
 
 
-  <!--migrated from opengever/mail/profiles/default/repositorytool.xml-->
+  <!-- MAIL -->
   <policymap purge="false">
     <type name="ftw.mail.mail">
       <policy name="version_on_revert" />
@@ -16,7 +16,7 @@
   </policymap>
 
 
-  <!--migrated from opengever/meeting/profiles/default/repositorytool.xml-->
+  <!-- MEETING -->
   <policymap purge="false">
     <type name="opengever.meeting.sablontemplate">
       <policy name="version_on_revert" />
@@ -25,4 +25,5 @@
       <policy name="version_on_revert" />
     </type>
   </policymap>
+
 </repositorytool>

--- a/opengever/core/profiles/default/rolemap.xml
+++ b/opengever/core/profiles/default/rolemap.xml
@@ -1,17 +1,17 @@
 <rolemap>
 
   <roles>
-    <role name="Administrator" />
     <role name="APIUser" />
+    <role name="Administrator" />
     <role name="Archivist" />
     <role name="CommitteeAdministrator" />
     <role name="CommitteeMember" />
     <role name="CommitteeResponsible" />
+    <role name="DossierManager" />
     <role name="MeetingUser" />
     <role name="Publisher" />
     <role name="Records Manager" />
     <role name="Role Manager" />
-    <role name="DossierManager" />
     <role name="WorkspaceAdmin" />
     <role name="WorkspaceGuest" />
     <role name="WorkspaceMember" />
@@ -21,6 +21,172 @@
   </roles>
 
   <permissions>
+
+    <!-- BASE -->
+    <permission name="Remove GEVER content" acquire="True">
+      <role name="Manager" />
+    </permission>
+
+    <permission name="Delete objects" acquire="True">
+      <role name="Manager" />
+    </permission>
+
+    <permission name="Edit date of submission" acquire="True">
+      <role name="Manager" />
+    </permission>
+
+    <permission name="Edit date of cassation" acquire="True">
+      <role name="Manager" />
+    </permission>
+
+    <permission name="ftw.keywordwidget: Add new term" acquire="False">
+      <role name="Manager" />
+      <role name="Site Administrator" />
+      <role name="Contributor" />
+    </permission>
+
+    <!-- CMFEDITIONS -->
+    <permission name="CMFEditions: Save new version" acquire="True">
+      <role name="Administrator" />
+      <role name="Manager" />
+      <role name="Contributor" />
+      <role name="Editor" />
+      <role name="Reviewer" />
+    </permission>
+
+    <!-- CONTACT -->
+    <permission name="opengever.contact: Add person" acquire="True">
+      <role name="Manager" />
+      <role name="Contributor" />
+      <role name="Administrator" />
+    </permission>
+
+    <permission name="opengever.contact: Edit person" acquire="True">
+      <role name="Manager" />
+      <role name="Contributor" />
+      <role name="Administrator" />
+    </permission>
+
+    <!-- DISPOSITION -->
+    <permission name="opengever.disposition: Add disposition" acquire="True">
+      <role name="Manager" />
+      <role name="Records Manager" />
+      <role name="Archivist" />
+    </permission>
+
+    <permission name="opengever.disposition: Download SIP Package" acquire="True">
+      <role name="Manager" />
+    </permission>
+
+    <permission name="opengever.disposition: Edit transfer number" acquire="True">
+      <role name="Manager" />
+    </permission>
+
+    <!-- DOCUMENT -->
+    <permission name="opengever.document: Add document" acquire="True">
+      <role name="Manager" />
+      <role name="Owner" />
+      <role name="Contributor" />
+      <role name="Administrator" />
+    </permission>
+
+    <permission name="opengever.document: Force Checkin" acquire="True">
+      <role name="Manager" />
+      <role name="Administrator" />
+    </permission>
+
+    <permission name="opengever.document: Modify archival file" acquire="True">
+      <role name="Manager" />
+    </permission>
+
+    <!-- DOSSIER -->
+    <permission name="opengever.dossier: Add businesscasedossier" acquire="True">
+      <role name="Manager" />
+      <role name="Owner" />
+      <role name="Contributor" />
+      <role name="Administrator" />
+    </permission>
+
+    <permission name="opengever.dossier: Add templatefolder" acquire="True">
+      <role name="Manager" />
+    </permission>
+
+    <permission name="opengever.dossier: Add dossiertemplate" acquire="True">
+      <role name="Manager" />
+      <role name="Contributor" />
+      <role name="Administrator" />
+    </permission>
+
+    <!-- INBOX -->
+    <permission name="opengever.inbox: Add Inbox" acquire="True">
+      <role name="Manager" />
+    </permission>
+
+    <permission name="opengever.inbox: Add Forwarding" acquire="True" />
+
+    <!-- MEETING -->
+    <permission name="opengever.meeting: Add Proposal" acquire="True">
+      <role name="Manager" />
+      <role name="Contributor" />
+      <role name="Administrator" />
+    </permission>
+
+    <permission name="opengever.meeting: Add CommitteeContainer" acquire="True">
+      <role name="Manager" />
+    </permission>
+
+    <permission name="opengever.meeting: Add Committee" acquire="True">
+      <role name="Manager" />
+      <role name="Contributor" />
+      <role name="Administrator" />
+    </permission>
+
+    <permission name="opengever.meeting: Add Member" acquire="True">
+      <role name="Manager" />
+      <role name="Contributor" />
+      <role name="Administrator" />
+    </permission>
+
+    <permission name="opengever.meeting: Add Sablon Template" acquire="True">
+      <role name="Manager" />
+      <role name="Administrator" />
+    </permission>
+
+    <!-- POLICY -->
+    <permission name="plone.restapi: Use REST API" acquire="True">
+      <role name="Manager" />
+      <role name="APIUser" />
+    </permission>
+
+    <permission name="List folder contents" acquire="True">
+      <role name="Manager" />
+    </permission>
+
+    <!-- PRIVATE -->
+    <permission name="opengever.private: Add private root" acquire="True">
+      <role name="Manager" />
+    </permission>
+
+    <permission name="opengever.private: Add private folder" acquire="True">
+      <role name="Manager" />
+    </permission>
+
+    <!-- REPOSITORY -->
+    <permission name="opengever.repository: Add repositoryfolder" acquire="True">
+      <role name="Manager" />
+      <role name="Owner" />
+      <role name="Contributor" />
+      <role name="Administrator" />
+    </permission>
+
+    <permission name="opengever.repository: Add repositoryroot" acquire="True">
+      <role name="Manager" />
+    </permission>
+
+    <permission name="opengever.repository: Unlock Reference Prefix" acquire="True">
+      <role name="Manager" />
+      <role name="Administrator" />
+    </permission>
 
     <!-- SHARING -->
     <permission name="Sharing page: Delegate Administrator role" acquire="True">
@@ -61,95 +227,6 @@
       <role name="Manager" />
     </permission>
 
-
-    <!-- CMFEDITIONS -->
-    <permission name="CMFEditions: Save new version" acquire="True">
-      <role name="Administrator" />
-      <role name="Manager" />
-      <role name="Contributor" />
-      <role name="Editor" />
-      <role name="Reviewer" />
-    </permission>
-
-    <!-- BASE -->
-    <permission name="Remove GEVER content" acquire="True">
-      <role name="Manager" />
-    </permission>
-
-    <permission name="Delete objects" acquire="True">
-      <role name="Manager" />
-    </permission>
-
-    <permission name="Edit date of submission" acquire="True">
-      <role name="Manager" />
-    </permission>
-
-    <permission name="Edit date of cassation" acquire="True">
-      <role name="Manager" />
-    </permission>
-
-    <permission name="ftw.keywordwidget: Add new term" acquire="False">
-      <role name="Manager" />
-      <role name="Site Administrator" />
-      <role name="Contributor" />
-    </permission>
-
-
-    <!-- DOCUMENT -->
-    <permission name="opengever.document: Add document" acquire="True">
-      <role name="Manager" />
-      <role name="Owner" />
-      <role name="Contributor" />
-      <role name="Administrator" />
-    </permission>
-
-    <permission name="opengever.document: Force Checkin" acquire="True">
-      <role name="Manager" />
-      <role name="Administrator" />
-    </permission>
-
-    <permission name="opengever.document: Modify archival file" acquire="True">
-      <role name="Manager" />
-    </permission>
-
-
-    <!-- DOSSIER -->
-    <permission name="opengever.dossier: Add businesscasedossier" acquire="True">
-      <role name="Manager" />
-      <role name="Owner" />
-      <role name="Contributor" />
-      <role name="Administrator" />
-    </permission>
-
-    <permission name="opengever.dossier: Add templatefolder" acquire="True">
-      <role name="Manager" />
-    </permission>
-
-    <permission name="opengever.dossier: Add dossiertemplate" acquire="True">
-      <role name="Manager" />
-      <role name="Contributor" />
-      <role name="Administrator" />
-    </permission>
-
-
-    <!-- REPOSITORY -->
-    <permission name="opengever.repository: Add repositoryfolder" acquire="True">
-      <role name="Manager" />
-      <role name="Owner" />
-      <role name="Contributor" />
-      <role name="Administrator" />
-    </permission>
-
-    <permission name="opengever.repository: Add repositoryroot" acquire="True">
-      <role name="Manager" />
-    </permission>
-
-    <permission name="opengever.repository: Unlock Reference Prefix" acquire="True">
-      <role name="Manager" />
-      <role name="Administrator" />
-    </permission>
-
-
     <!-- TASK -->
     <permission name="opengever.task: Add task" acquire="True">
       <role name="Manager" />
@@ -165,7 +242,6 @@
       <role name="Administrator" />
     </permission>
 
-
     <!-- TRASH -->
     <permission name="opengever.trash: Trash content" acquire="True">
       <role name="Manager" />
@@ -176,85 +252,6 @@
       <role name="Manager" />
       <role name="Administrator" />
     </permission>
-
-
-    <!-- INBOX -->
-    <permission name="opengever.inbox: Add Inbox" acquire="True">
-      <role name="Manager" />
-    </permission>
-
-    <permission name="opengever.inbox: Add Forwarding" acquire="True">
-    </permission>
-
-
-    <!-- CONTACT -->
-    <permission name="opengever.contact: Add person" acquire="True">
-      <role name="Manager" />
-      <role name="Contributor" />
-      <role name="Administrator" />
-    </permission>
-
-    <permission name="opengever.contact: Edit person" acquire="True">
-      <role name="Manager" />
-      <role name="Contributor" />
-      <role name="Administrator" />
-    </permission>
-
-
-    <!-- MEETING -->
-    <permission name="opengever.meeting: Add Proposal" acquire="True">
-      <role name="Manager" />
-      <role name="Contributor" />
-      <role name="Administrator" />
-    </permission>
-
-    <permission name="opengever.meeting: Add CommitteeContainer" acquire="True">
-      <role name="Manager" />
-    </permission>
-
-    <permission name="opengever.meeting: Add Committee" acquire="True">
-      <role name="Manager" />
-      <role name="Contributor" />
-      <role name="Administrator" />
-    </permission>
-
-    <permission name="opengever.meeting: Add Member" acquire="True">
-      <role name="Manager" />
-      <role name="Contributor" />
-      <role name="Administrator" />
-    </permission>
-
-    <permission name="opengever.meeting: Add Sablon Template" acquire="True">
-      <role name="Manager" />
-      <role name="Administrator" />
-    </permission>
-
-
-    <!-- PRIVATE -->
-    <permission name="opengever.private: Add private root" acquire="True">
-      <role name="Manager" />
-    </permission>
-
-    <permission name="opengever.private: Add private folder" acquire="True">
-      <role name="Manager" />
-    </permission>
-
-
-    <!-- DISPOSITION -->
-    <permission name="opengever.disposition: Add disposition" acquire="True">
-      <role name="Manager" />
-      <role name="Records Manager" />
-      <role name="Archivist" />
-    </permission>
-
-    <permission name="opengever.disposition: Download SIP Package" acquire="True">
-      <role name="Manager" />
-    </permission>
-
-    <permission name="opengever.disposition: Edit transfer number" acquire="True">
-      <role name="Manager" />
-    </permission>
-
 
     <!-- WORKSPACE -->
     <permission name="opengever.workspace: Add WorkspaceRoot" acquire="True">
@@ -269,16 +266,6 @@
       <role name="Manager" />
     </permission>
 
-
-    <!-- POLICY -->
-    <permission name="plone.restapi: Use REST API" acquire="True">
-      <role name="Manager" />
-      <role name="APIUser" />
-    </permission>
-
-    <permission name="List folder contents" acquire="True">
-      <role name="Manager" />
-    </permission>
-
   </permissions>
+
 </rolemap>

--- a/opengever/core/profiles/default/rolemap.xml
+++ b/opengever/core/profiles/default/rolemap.xml
@@ -1,4 +1,5 @@
 <rolemap>
+
   <roles>
     <role name="Administrator" />
     <role name="APIUser" />
@@ -18,8 +19,10 @@
     <role name="WorkspacesCreator" />
     <role name="WorkspacesUser" />
   </roles>
+
   <permissions>
 
+    <!-- SHARING -->
     <permission name="Sharing page: Delegate Administrator role" acquire="True">
       <role name="Administrator" />
       <role name="Manager" />
@@ -54,6 +57,12 @@
       <role name="Manager" />
     </permission>
 
+    <permission name="Modify view template" acquire="False">
+      <role name="Manager" />
+    </permission>
+
+
+    <!-- CMFEDITIONS -->
     <permission name="CMFEditions: Save new version" acquire="True">
       <role name="Administrator" />
       <role name="Manager" />
@@ -62,19 +71,23 @@
       <role name="Reviewer" />
     </permission>
 
-    <!--migrated from opengever/base/profiles/default/rolemap.xml-->
+    <!-- BASE -->
     <permission name="Remove GEVER content" acquire="True">
       <role name="Manager" />
     </permission>
+
     <permission name="Delete objects" acquire="True">
       <role name="Manager" />
     </permission>
+
     <permission name="Edit date of submission" acquire="True">
       <role name="Manager" />
     </permission>
+
     <permission name="Edit date of cassation" acquire="True">
       <role name="Manager" />
     </permission>
+
     <permission name="ftw.keywordwidget: Add new term" acquire="False">
       <role name="Manager" />
       <role name="Site Administrator" />
@@ -82,32 +95,36 @@
     </permission>
 
 
-    <!--migrated from opengever/document/profiles/default/rolemap.xml-->
+    <!-- DOCUMENT -->
     <permission name="opengever.document: Add document" acquire="True">
       <role name="Manager" />
       <role name="Owner" />
       <role name="Contributor" />
       <role name="Administrator" />
     </permission>
+
     <permission name="opengever.document: Force Checkin" acquire="True">
       <role name="Manager" />
       <role name="Administrator" />
     </permission>
+
     <permission name="opengever.document: Modify archival file" acquire="True">
       <role name="Manager" />
     </permission>
 
 
-    <!--migrated from opengever/dossier/profiles/default/rolemap.xml-->
+    <!-- DOSSIER -->
     <permission name="opengever.dossier: Add businesscasedossier" acquire="True">
       <role name="Manager" />
       <role name="Owner" />
       <role name="Contributor" />
       <role name="Administrator" />
     </permission>
+
     <permission name="opengever.dossier: Add templatefolder" acquire="True">
       <role name="Manager" />
     </permission>
+
     <permission name="opengever.dossier: Add dossiertemplate" acquire="True">
       <role name="Manager" />
       <role name="Contributor" />
@@ -115,30 +132,32 @@
     </permission>
 
 
-    <!--migrated from opengever/repository/profiles/default/rolemap.xml-->
+    <!-- REPOSITORY -->
     <permission name="opengever.repository: Add repositoryfolder" acquire="True">
       <role name="Manager" />
       <role name="Owner" />
       <role name="Contributor" />
       <role name="Administrator" />
     </permission>
+
     <permission name="opengever.repository: Add repositoryroot" acquire="True">
       <role name="Manager" />
     </permission>
+
     <permission name="opengever.repository: Unlock Reference Prefix" acquire="True">
       <role name="Manager" />
       <role name="Administrator" />
     </permission>
 
 
-    <!--migrated from opengever/task/profiles/default/rolemap.xml-->
+    <!-- TASK -->
     <permission name="opengever.task: Add task" acquire="True">
       <role name="Manager" />
       <role name="Owner" />
       <role name="Contributor" />
       <role name="Administrator" />
-
     </permission>
+
     <permission name="opengever.task: Edit task" acquire="True">
       <role name="Manager" />
       <role name="Owner" />
@@ -147,18 +166,19 @@
     </permission>
 
 
-    <!--migrated from opengever/trash/profiles/default/rolemap.xml-->
+    <!-- TRASH -->
     <permission name="opengever.trash: Trash content" acquire="True">
       <role name="Manager" />
       <role name="Administrator" />
     </permission>
+
     <permission name="opengever.trash: Untrash content" acquire="True">
       <role name="Manager" />
       <role name="Administrator" />
     </permission>
 
 
-    <!--migrated from opengever/inbox/profiles/default/rolemap.xml-->
+    <!-- INBOX -->
     <permission name="opengever.inbox: Add Inbox" acquire="True">
       <role name="Manager" />
     </permission>
@@ -167,7 +187,7 @@
     </permission>
 
 
-    <!--migrated from opengever/contact/profiles/default/rolemap.xml-->
+    <!-- CONTACT -->
     <permission name="opengever.contact: Add person" acquire="True">
       <role name="Manager" />
       <role name="Contributor" />
@@ -181,13 +201,7 @@
     </permission>
 
 
-    <!--migrated from opengever/sharing/profiles/default/rolemap.xml-->
-    <permission name="Modify view template" acquire="False">
-      <role name="Manager" />
-    </permission>
-
-
-    <!--migrated from opengever/meeting/profiles/default/rolemap.xml-->
+    <!-- MEETING -->
     <permission name="opengever.meeting: Add Proposal" acquire="True">
       <role name="Manager" />
       <role name="Contributor" />
@@ -216,7 +230,7 @@
     </permission>
 
 
-    <!--migrated from opengever/private/profiles/default/rolemap.xml-->
+    <!-- PRIVATE -->
     <permission name="opengever.private: Add private root" acquire="True">
       <role name="Manager" />
     </permission>
@@ -226,20 +240,23 @@
     </permission>
 
 
-    <!--migrated from opengever/disposition/profiles/default/rolemap.xml-->
+    <!-- DISPOSITION -->
     <permission name="opengever.disposition: Add disposition" acquire="True">
       <role name="Manager" />
       <role name="Records Manager" />
       <role name="Archivist" />
     </permission>
+
     <permission name="opengever.disposition: Download SIP Package" acquire="True">
       <role name="Manager" />
     </permission>
+
     <permission name="opengever.disposition: Edit transfer number" acquire="True">
       <role name="Manager" />
     </permission>
 
 
+    <!-- WORKSPACE -->
     <permission name="opengever.workspace: Add WorkspaceRoot" acquire="True">
       <role name="Manager" />
     </permission>
@@ -253,7 +270,7 @@
     </permission>
 
 
-    <!--migrated from opengever/policy/base/profiles/default/rolemap.xml-->
+    <!-- POLICY -->
     <permission name="plone.restapi: Use REST API" acquire="True">
       <role name="Manager" />
       <role name="APIUser" />

--- a/opengever/core/profiles/default/skins.xml
+++ b/opengever/core/profiles/default/skins.xml
@@ -1,18 +1,17 @@
 <object name="portal_skins">
 
-  <!-- BASE -->
-  <object name="opengever.base_scripts" meta_type="Filesystem Directory View" directory="opengever.base:skins/opengever.base_scripts" />
-
-  <skin-path name="*">
-    <layer name="opengever.base_scripts" insert-after="custom" />
-  </skin-path>
-
-
   <!-- ADVANCEDSEARCH -->
   <object name="advancedsearch_resources" meta_type="Filesystem Directory View" directory="opengever.advancedsearch:skins/advancedsearch_resources" />
 
   <skin-path name="*">
     <layer name="advancedsearch_resources" insert-after="custom" />
+  </skin-path>
+
+  <!-- BASE -->
+  <object name="opengever.base_scripts" meta_type="Filesystem Directory View" directory="opengever.base:skins/opengever.base_scripts" />
+
+  <skin-path name="*">
+    <layer name="opengever.base_scripts" insert-after="custom" />
   </skin-path>
 
 </object>

--- a/opengever/core/profiles/default/skins.xml
+++ b/opengever/core/profiles/default/skins.xml
@@ -1,6 +1,6 @@
 <object name="portal_skins">
 
-  <!--migrated from opengever/base/profiles/default/skins.xml-->
+  <!-- BASE -->
   <object name="opengever.base_scripts" meta_type="Filesystem Directory View" directory="opengever.base:skins/opengever.base_scripts" />
 
   <skin-path name="*">
@@ -8,7 +8,7 @@
   </skin-path>
 
 
-  <!--migrated from opengever/advancedsearch/profiles/default/skins.xml-->
+  <!-- ADVANCEDSEARCH -->
   <object name="advancedsearch_resources" meta_type="Filesystem Directory View" directory="opengever.advancedsearch:skins/advancedsearch_resources" />
 
   <skin-path name="*">

--- a/opengever/core/profiles/default/types.xml
+++ b/opengever/core/profiles/default/types.xml
@@ -3,25 +3,20 @@
   <!-- DOCUMENT -->
   <object name="opengever.document.document" meta_type="Dexterity FTI" />
 
-
   <!-- MAIL -->
   <object name="ftw.mail.mail" meta_type="Dexterity FTI" />
-
 
   <!-- DOSSIER -->
   <object name="opengever.dossier.businesscasedossier" meta_type="Dexterity FTI" />
   <object name="opengever.dossier.templatefolder" meta_type="Dexterity FTI" />
   <object name="opengever.dossier.dossiertemplate" meta_type="Dexterity FTI" />
 
-
   <!-- REPOSITORY -->
   <object name="opengever.repository.repositoryfolder" meta_type="Dexterity FTI" />
   <object name="opengever.repository.repositoryroot" meta_type="Dexterity FTI" />
 
-
   <!-- TASK -->
   <object name="opengever.task.task" meta_type="Dexterity FTI" />
-
 
   <!-- INBOX -->
   <object name="opengever.inbox.inbox" meta_type="Dexterity FTI" />
@@ -29,20 +24,16 @@
   <object name="opengever.inbox.yearfolder" meta_type="Dexterity FTI" />
   <object name="opengever.inbox.container" meta_type="Dexterity FTI" />
 
-
   <!-- TASKTEMPLATES -->
   <object name="opengever.tasktemplates.tasktemplate" meta_type="Dexterity FTI" />
   <object name="opengever.tasktemplates.tasktemplatefolder" meta_type="Dexterity FTI" />
-
 
   <!-- CONTACT -->
   <object name="opengever.contact.contactfolder" meta_type="Dexterity FTI" />
   <object name="opengever.contact.contact" meta_type="Dexterity FTI" />
 
-
   <!-- LATEX -->
   <object name="Plone Site" meta_type="Factory-based Type Information with dynamic views" />
-
 
   <!-- MEETING -->
   <object name="opengever.meeting.proposal" meta_type="Dexterity FTI" />
@@ -53,12 +44,10 @@
   <object name="opengever.meeting.meetingdossier" meta_type="Dexterity FTI" />
   <object name="opengever.meeting.proposaltemplate" meta_type="Dexterity FTI" />
 
-
   <!-- PRIVATE -->
   <object name="opengever.private.root" meta_type="Dexterity FTI" />
   <object name="opengever.private.folder" meta_type="Dexterity FTI" />
   <object name="opengever.private.dossier" meta_type="Dexterity FTI" />
-
 
   <!-- DISPOSITION -->
   <object name="opengever.disposition.disposition" meta_type="Dexterity FTI" />
@@ -70,4 +59,5 @@
 
   <!-- POLICY -->
   <object name="Plone Site" meta_type="Factory-based Type Information with dynamic views" />
+
 </object>

--- a/opengever/core/profiles/default/types.xml
+++ b/opengever/core/profiles/default/types.xml
@@ -1,51 +1,50 @@
 <object name="portal_types" meta_type="Plone Types Tool">
 
-  <!--migrated from opengever/document/profiles/default/types.xml-->
+  <!-- DOCUMENT -->
   <object name="opengever.document.document" meta_type="Dexterity FTI" />
 
 
-  <!--migrated from opengever/mail/profiles/default/types.xml-->
+  <!-- MAIL -->
   <object name="ftw.mail.mail" meta_type="Dexterity FTI" />
 
 
-  <!--migrated from opengever/dossier/profiles/default/types.xml-->
+  <!-- DOSSIER -->
   <object name="opengever.dossier.businesscasedossier" meta_type="Dexterity FTI" />
   <object name="opengever.dossier.templatefolder" meta_type="Dexterity FTI" />
   <object name="opengever.dossier.dossiertemplate" meta_type="Dexterity FTI" />
-  <!--object name="opengever.base.subjectdossier" meta_type="Dexterity FTI" /-->
 
 
-  <!--migrated from opengever/repository/profiles/default/types.xml-->
+  <!-- REPOSITORY -->
   <object name="opengever.repository.repositoryfolder" meta_type="Dexterity FTI" />
   <object name="opengever.repository.repositoryroot" meta_type="Dexterity FTI" />
 
 
-  <!--migrated from opengever/task/profiles/default/types.xml-->
+  <!-- TASK -->
   <object name="opengever.task.task" meta_type="Dexterity FTI" />
 
 
-  <!--migrated from opengever/inbox/profiles/default/types.xml-->
+  <!-- INBOX -->
   <object name="opengever.inbox.inbox" meta_type="Dexterity FTI" />
   <object name="opengever.inbox.forwarding" meta_type="Dexterity FTI" />
   <object name="opengever.inbox.yearfolder" meta_type="Dexterity FTI" />
   <object name="opengever.inbox.container" meta_type="Dexterity FTI" />
 
 
-  <!--migrated from opengever/tasktemplates/profiles/default/types.xml-->
+  <!-- TASKTEMPLATES -->
   <object name="opengever.tasktemplates.tasktemplate" meta_type="Dexterity FTI" />
   <object name="opengever.tasktemplates.tasktemplatefolder" meta_type="Dexterity FTI" />
 
 
-  <!--migrated from opengever/contact/profiles/default/types.xml-->
+  <!-- CONTACT -->
   <object name="opengever.contact.contactfolder" meta_type="Dexterity FTI" />
   <object name="opengever.contact.contact" meta_type="Dexterity FTI" />
 
 
-  <!--migrated from opengever/latex/profiles/default/types.xml-->
+  <!-- LATEX -->
   <object name="Plone Site" meta_type="Factory-based Type Information with dynamic views" />
 
 
-  <!--migrated from opengever/meeting/profiles/default/types.xml-->
+  <!-- MEETING -->
   <object name="opengever.meeting.proposal" meta_type="Dexterity FTI" />
   <object name="opengever.meeting.submittedproposal" meta_type="Dexterity FTI" />
   <object name="opengever.meeting.committee" meta_type="Dexterity FTI" />
@@ -55,19 +54,20 @@
   <object name="opengever.meeting.proposaltemplate" meta_type="Dexterity FTI" />
 
 
-  <!--migrated from opengever/private/profiles/default/types.xml-->
+  <!-- PRIVATE -->
   <object name="opengever.private.root" meta_type="Dexterity FTI" />
   <object name="opengever.private.folder" meta_type="Dexterity FTI" />
   <object name="opengever.private.dossier" meta_type="Dexterity FTI" />
 
 
-  <!--migrated from opengever/disposition/profiles/default/types.xml-->
+  <!-- DISPOSITION -->
   <object name="opengever.disposition.disposition" meta_type="Dexterity FTI" />
 
+  <!-- WORKSPACE -->
   <object name="opengever.workspace.root" meta_type="Dexterity FTI" />
   <object name="opengever.workspace.workspace" meta_type="Dexterity FTI" />
   <object name="opengever.workspace.folder" meta_type="Dexterity FTI" />
 
-  <!--migrated from opengever/policy/base/profiles/default/types.xml-->
+  <!-- POLICY -->
   <object name="Plone Site" meta_type="Factory-based Type Information with dynamic views" />
 </object>

--- a/opengever/core/profiles/default/types/Plone_Site.xml
+++ b/opengever/core/profiles/default/types/Plone_Site.xml
@@ -11,8 +11,7 @@
     <element value="opengever.workspace.root" />
   </property>
 
-
-  <!--migrated from opengever/latex/profiles/default/types/Plone_Site.xml-->
+  <!-- Actions -->
   <action
       action_id="pdf-open-task-report"
       visible="True"

--- a/opengever/core/profiles/default/types/Plone_Site.xml
+++ b/opengever/core/profiles/default/types/Plone_Site.xml
@@ -1,4 +1,6 @@
 <object name="Plone Site">
+
+  <!-- Basic metadata -->
   <property name="filter_content_types">True</property>
   <property name="allowed_content_types">
     <element value="opengever.contact.contactfolder" />

--- a/opengever/core/profiles/default/types/ftw.mail.mail.xml
+++ b/opengever/core/profiles/default/types/ftw.mail.mail.xml
@@ -1,10 +1,40 @@
 <object name="ftw.mail.mail" meta_type="Dexterity FTI">
 
+  <!-- Basic metadata -->
   <property name="icon_expr" />
 
-  <!-- class used for content items -->
+  <!-- Class used for content items -->
   <property name="klass">opengever.mail.mail.OGMail</property>
 
+  <!-- View information -->
+  <property name="default_view">tabbed_view</property>
+  <property name="default_view_fallback">False</property>
+  <property name="view_methods">
+    <element value="view" />
+    <element value="tabbed_view" />
+  </property>
+
+  <!-- Enabled behaviors -->
+  <property name="behaviors" purge="False">
+    <element value="ftw.journal.interfaces.IAnnotationsJournalizable" />
+    <element value="opengever.base.behaviors.classification.IClassification" />
+    <element value="opengever.base.behaviors.sequence.ISequenceNumberBehavior" />
+    <element value="opengever.document.behaviors.IBaseDocument" />
+    <element value="opengever.document.behaviors.metadata.IDocumentMetadata" />
+    <element value="opengever.document.behaviors.name_from_title.IDocumentNameFromTitle" />
+    <element value="opengever.mail.mail.IOGMail" />
+    <element value="opengever.trash.trash.ITrashable" />
+    <element
+        value="plone.app.content.interfaces.INameFromTitle"
+        remove="True"
+        />
+    <element value="plone.app.versioningbehavior.behaviors.IVersionable" />
+    <element value="plone.app.lockingbehavior.behaviors.ILocking" />
+    <element value="ftw.bumblebee.interfaces.IBumblebeeable" />
+    <element value="opengever.quota.primary.IPrimaryBlobFieldQuota" />
+  </property>
+
+  <!-- Actions -->
   <action
       action_id="save_attachments"
       title="save attachments"
@@ -24,30 +54,4 @@
     <permission value="Modify portal content" />
   </action>
 
-  <!-- View information -->
-  <property name="default_view">tabbed_view</property>
-  <property name="default_view_fallback">False</property>
-  <property name="view_methods">
-    <element value="view" />
-    <element value="tabbed_view" />
-  </property>
-
-  <property name="behaviors" purge="False">
-    <element value="ftw.journal.interfaces.IAnnotationsJournalizable" />
-    <element value="opengever.base.behaviors.classification.IClassification" />
-    <element value="opengever.base.behaviors.sequence.ISequenceNumberBehavior" />
-    <element value="opengever.document.behaviors.IBaseDocument" />
-    <element value="opengever.document.behaviors.metadata.IDocumentMetadata" />
-    <element value="opengever.document.behaviors.name_from_title.IDocumentNameFromTitle" />
-    <element value="opengever.mail.mail.IOGMail" />
-    <element value="opengever.trash.trash.ITrashable" />
-    <element
-        value="plone.app.content.interfaces.INameFromTitle"
-        remove="True"
-        />
-    <element value="plone.app.versioningbehavior.behaviors.IVersionable" />
-    <element value="plone.app.lockingbehavior.behaviors.ILocking" />
-    <element value="ftw.bumblebee.interfaces.IBumblebeeable" />
-    <element value="opengever.quota.primary.IPrimaryBlobFieldQuota" />
-  </property>
 </object>

--- a/opengever/core/profiles/default/types/opengever.contact.contact.xml
+++ b/opengever/core/profiles/default/types/opengever.contact.contact.xml
@@ -8,16 +8,16 @@
   <property name="global_allow">False</property>
   <property name="filter_content_types">False</property>
 
-  <!-- schema interface -->
+  <!-- Schema interface -->
   <property name="schema">opengever.contact.contact.IContact</property>
 
-  <!-- class used for content items -->
+  <!-- Class used for content items -->
   <property name="klass">opengever.contact.contact.Contact</property>
 
-  <!-- add permission -->
+  <!-- Add permission -->
   <property name="add_permission">opengever.contact.AddContact</property>
 
-  <!-- enabled behaviors -->
+  <!-- Enabled behaviors -->
   <property name="behaviors" purge="False">
     <element value="collective.dexteritytextindexer.behavior.IDexterityTextIndexer" />
     <element value="plone.app.content.interfaces.INameFromTitle" />
@@ -49,6 +49,7 @@
       visible="False">
     <permission value="View" />
   </action>
+
   <action
       title="Edit"
       action_id="edit"
@@ -58,4 +59,5 @@
       visible="True">
     <permission value="Modify portal content" />
   </action>
+
 </object>

--- a/opengever/core/profiles/default/types/opengever.contact.contactfolder.xml
+++ b/opengever/core/profiles/default/types/opengever.contact.contactfolder.xml
@@ -11,16 +11,16 @@
     <element value="opengever.contact.contact" />
   </property>
 
-  <!-- schema interface -->
+  <!-- Schema interface -->
   <property name="schema" />
 
-  <!-- class used for content items -->
+  <!-- Class used for content items -->
   <property name="klass">opengever.contact.contactfolder.ContactFolder</property>
 
-  <!-- add permission -->
+  <!-- Add permission -->
   <property name="add_permission">opengever.contact.AddContactFolder</property>
 
-  <!-- enabled behaviors -->
+  <!-- Enabled behaviors -->
   <property name="behaviors">
     <element value="plone.app.content.interfaces.INameFromTitle" />
     <element value="opengever.tabbedview.interfaces.ITabbedViewEnabled" />

--- a/opengever/core/profiles/default/types/opengever.disposition.disposition.xml
+++ b/opengever/core/profiles/default/types/opengever.disposition.disposition.xml
@@ -10,16 +10,16 @@
   <property name="allowed_content_types">
     </property>
 
-  <!-- schema interface -->
+  <!-- Schema interface -->
   <property name="schema">opengever.disposition.disposition.IDispositionSchema</property>
 
-  <!-- class used for content items -->
+  <!-- Class used for content items -->
   <property name="klass">opengever.disposition.disposition.Disposition</property>
 
-  <!-- add permission -->
+  <!-- Add permission -->
   <property name="add_permission">opengever.disposition.AddDisposition</property>
 
-  <!-- enabled behaviors -->
+  <!-- Enabled behaviors -->
   <property name="behaviors">
     <element value="collective.dexteritytextindexer.behavior.IDexterityTextIndexer" />
     <element value="opengever.base.behaviors.sequence.ISequenceNumberBehavior" />

--- a/opengever/core/profiles/default/types/opengever.document.document.xml
+++ b/opengever/core/profiles/default/types/opengever.document.document.xml
@@ -7,16 +7,16 @@
   <property name="allow_discussion">False</property>
   <property name="global_allow">True</property>
 
-  <!-- schema interface -->
+  <!-- Schema interface -->
   <property name="schema">opengever.document.document.IDocumentSchema</property>
 
-  <!-- class used for content items -->
+  <!-- Class used for content items -->
   <property name="klass">opengever.document.document.Document</property>
 
-  <!-- add permission -->
+  <!-- Add permission -->
   <property name="add_permission">opengever.document.AddDocument</property>
 
-  <!-- enabled behaviors -->
+  <!-- Enabled behaviors -->
   <property name="behaviors" purge="False">
     <element value="collective.dexteritytextindexer.behavior.IDexterityTextIndexer" />
     <element value="ftw.journal.interfaces.IAnnotationsJournalizable" />
@@ -59,6 +59,7 @@
       visible="False">
     <permission value="View" />
   </action>
+
   <action
       title="Edit metadata"
       action_id="edit"
@@ -69,7 +70,7 @@
     <permission value="Modify portal content" />
   </action>
 
-  <!-- Tab Actions -->
+  <!-- Tab actions -->
   <action
       title="overview"
       action_id="overview"
@@ -78,6 +79,7 @@
       url_expr="string:#"
       visible="True"
       />
+
   <action
       title="Versions"
       action_id="versions"
@@ -86,6 +88,7 @@
       url_expr="string:#"
       visible="True"
       />
+
   <action
       title="tasks"
       action_id="tasks"
@@ -94,6 +97,7 @@
       url_expr="string:#"
       visible="False"
       />
+
   <action
       title="journal"
       action_id="journal"
@@ -103,7 +107,7 @@
       visible="True"
       />
 
-  <!-- disable some old actions -->
+  <!-- Disable some old actions -->
   <action
       title="Versions"
       action_id="versions_history_form"
@@ -124,8 +128,7 @@
     <permission value="View" />
   </action>
 
-
-  <!-- actions for staging -->
+  <!-- Actions for staging -->
   <action
       action_id="checkout_document"
       visible="True"

--- a/opengever/core/profiles/default/types/opengever.dossier.businesscasedossier.xml
+++ b/opengever/core/profiles/default/types/opengever.dossier.businesscasedossier.xml
@@ -15,16 +15,16 @@
     <element value="ftw.mail.mail" />
   </property>
 
-  <!-- schema interface -->
+  <!-- Schema interface -->
   <property name="schema">opengever.dossier.businesscase.IBusinessCaseDossier</property>
 
-  <!-- class used for content items -->
+  <!-- Class used for content items -->
   <property name="klass">opengever.dossier.base.DossierContainer</property>
 
-  <!-- add permission -->
+  <!-- Add permission -->
   <property name="add_permission">opengever.dossier.AddBusinessCaseDossier</property>
 
-  <!-- enabled behaviors -->
+  <!-- Enabled behaviors -->
   <property name="behaviors">
     <element value="collective.dexteritytextindexer.behavior.IDexterityTextIndexer" />
     <element value="opengever.base.behaviors.base.IOpenGeverBase" />
@@ -126,10 +126,6 @@
       visible="True">
     <permission value="Modify portal content" />
   </action>
-
-
-  <!--migrated from opengever/tasktemplates/profiles/default/types/opengever.dossier.businesscasedossier.xml-->
-  <!-- Actions -->
 
   <action
       action_id="add_tasktemplate"

--- a/opengever/core/profiles/default/types/opengever.dossier.dossiertemplate.xml
+++ b/opengever/core/profiles/default/types/opengever.dossier.dossiertemplate.xml
@@ -12,16 +12,16 @@
     <element value="opengever.document.document" />
   </property>
 
-  <!-- schema interface -->
+  <!-- Schema interface -->
   <property name="schema">opengever.dossier.dossiertemplate.behaviors.IDossierTemplateSchema</property>
 
-  <!-- class used for content items -->
+  <!-- Class used for content items -->
   <property name="klass">opengever.dossier.dossiertemplate.dossiertemplate.DossierTemplate</property>
 
-  <!-- add permission -->
+  <!-- Add permission -->
   <property name="add_permission">opengever.dossier.AddDossierTemplate</property>
 
-  <!-- enabled behaviors -->
+  <!-- Enabled behaviors -->
   <property name="behaviors">
     <element value="collective.dexteritytextindexer.behavior.IDexterityTextIndexer" />
     <element value="opengever.base.behaviors.base.IOpenGeverBase" />

--- a/opengever/core/profiles/default/types/opengever.dossier.templatefolder.xml
+++ b/opengever/core/profiles/default/types/opengever.dossier.templatefolder.xml
@@ -16,16 +16,16 @@
     <element value="opengever.meeting.proposaltemplate" />
   </property>
 
-  <!-- schema interface -->
+  <!-- Schema interface -->
   <property name="schema">opengever.dossier.templatefolder.ITemplateFolder</property>
 
-  <!-- class used for content items -->
+  <!-- Class used for content items -->
   <property name="klass">opengever.dossier.templatefolder.TemplateFolder</property>
 
-  <!-- add permission -->
+  <!-- Add permission -->
   <property name="add_permission">opengever.dossier.AddTemplateFolder</property>
 
-  <!-- enabled behaviors -->
+  <!-- Enabled behaviors -->
   <property name="behaviors">
     <element value="collective.dexteritytextindexer.behavior.IDexterityTextIndexer" />
     <element value="opengever.base.behaviors.translated_title.ITranslatedTitle" />
@@ -62,6 +62,7 @@
       visible="False">
     <permission value="View" />
   </action>
+
   <action
       title="Edit"
       action_id="edit"

--- a/opengever/core/profiles/default/types/opengever.inbox.container.xml
+++ b/opengever/core/profiles/default/types/opengever.inbox.container.xml
@@ -11,16 +11,16 @@
     <element value="opengever.inbox.inbox" />
   </property>
 
-  <!-- schema interface -->
+  <!-- Schema interface -->
   <property name="schema">opengever.inbox.container.IInboxContainer</property>
 
-  <!-- class used for content items -->
+  <!-- Class used for content items -->
   <property name="klass">opengever.inbox.container.InboxContainer</property>
 
-  <!-- add permission -->
+  <!-- Add permission -->
   <property name="add_permission">opengever.inbox.AddInbox</property>
 
-  <!-- enabled behaviors -->
+  <!-- Enabled behaviors -->
   <property name="behaviors">
     <element value="opengever.base.behaviors.translated_title.ITranslatedTitle" />
     <element value="plone.app.content.interfaces.INameFromTitle" />

--- a/opengever/core/profiles/default/types/opengever.inbox.forwarding.xml
+++ b/opengever/core/profiles/default/types/opengever.inbox.forwarding.xml
@@ -13,17 +13,16 @@
     <element value="ftw.mail.mail" />
   </property>
 
-
-  <!-- schema interface -->
+  <!-- Schema interface -->
   <property name="schema">opengever.inbox.forwarding.IForwarding</property>
 
-  <!-- class used for content items -->
+  <!-- Class used for content items -->
   <property name="klass">opengever.inbox.forwarding.Forwarding</property>
 
-  <!-- add permission -->
+  <!-- Add permission -->
   <property name="add_permission">opengever.inbox.AddForwarding</property>
 
-  <!-- enabled behaviors -->
+  <!-- Enabled behaviors -->
   <property name="behaviors">
     <element value="collective.dexteritytextindexer.behavior.IDexterityTextIndexer" />
     <element value="opengever.tabbedview.interfaces.ITabbedViewEnabled" />
@@ -79,6 +78,7 @@
       visible="True">
     <permission value="View" />
   </action>
+
   <action
       i18n:domain="opengever.core"
       title="Related Documents"
@@ -89,4 +89,5 @@
       visible="True">
     <permission value="View" />
   </action>
+
 </object>

--- a/opengever/core/profiles/default/types/opengever.inbox.inbox.xml
+++ b/opengever/core/profiles/default/types/opengever.inbox.inbox.xml
@@ -14,16 +14,16 @@
     <element value="opengever.inbox.yearfolder" />
   </property>
 
-  <!-- schema interface -->
+  <!-- Schema interface -->
   <property name="schema">opengever.inbox.inbox.IInbox</property>
 
-  <!-- class used for content items -->
+  <!-- Class used for content items -->
   <property name="klass">opengever.inbox.inbox.Inbox</property>
 
-  <!-- add permission -->
+  <!-- Add permission -->
   <property name="add_permission">opengever.inbox.AddInbox</property>
 
-  <!-- enabled behaviors -->
+  <!-- Enabled behaviors -->
   <property name="behaviors">
     <element value="opengever.base.behaviors.translated_title.ITranslatedTitle" />
     <element value="ftw.journal.interfaces.IAnnotationsJournalizable" />
@@ -70,7 +70,7 @@
     <permission value="Modify portal content" />
   </action>
 
-  <!-- Tabbedview tabs-->
+  <!-- Tabbedview actions -->
   <action
       title="Overview"
       action_id="overview"

--- a/opengever/core/profiles/default/types/opengever.inbox.yearfolder.xml
+++ b/opengever/core/profiles/default/types/opengever.inbox.yearfolder.xml
@@ -11,16 +11,16 @@
     <element value="opengever.inbox.forwarding" />
   </property>
 
-  <!-- schema interface -->
+  <!-- Schema interface -->
   <property name="schema">opengever.inbox.yearfolder.IYearFolder</property>
 
-  <!-- class used for content items -->
+  <!-- Class used for content items -->
   <property name="klass">plone.dexterity.content.Container</property>
 
-  <!-- add permission -->
+  <!-- Add permission -->
   <property name="add_permission">opengever.inbox.AddYearFolder</property>
 
-  <!-- enabled behaviors -->
+  <!-- Enabled behaviors -->
   <property name="behaviors">
     <element value="opengever.base.behaviors.base.IOpenGeverBase" />
     <element value="ftw.journal.interfaces.IAnnotationsJournalizable" />
@@ -63,7 +63,7 @@
     <permission value="Modify portal content" />
   </action>
 
-  <!-- Tabbedview tabs-->
+  <!-- Tabbedview actions -->
   <action
       action_id="closed-forwardings"
       visible="True"

--- a/opengever/core/profiles/default/types/opengever.meeting.committee.xml
+++ b/opengever/core/profiles/default/types/opengever.meeting.committee.xml
@@ -10,16 +10,16 @@
     <element value="opengever.meeting.submittedproposal" />
   </property>
 
-  <!-- schema interface -->
+  <!-- Schema interface -->
   <property name="schema">opengever.meeting.committee.ICommittee</property>
 
-  <!-- class used for content items -->
+  <!-- Class used for content items -->
   <property name="klass">opengever.meeting.committee.Committee</property>
 
-  <!-- add permission -->
+  <!-- Add permission -->
   <property name="add_permission">opengever.meeting.AddCommittee</property>
 
-  <!-- enabled behaviors -->
+  <!-- Enabled behaviors -->
   <property name="behaviors" purge="False">
     <element value="opengever.meeting.behaviors.namefromtitle.ICommitteeNameFromTitle" />
     <element value="opengever.base.behaviors.sequence.ISequenceNumberBehavior" />

--- a/opengever/core/profiles/default/types/opengever.meeting.committeecontainer.xml
+++ b/opengever/core/profiles/default/types/opengever.meeting.committeecontainer.xml
@@ -11,16 +11,16 @@
     <element value="opengever.meeting.committee" />
   </property>
 
-  <!-- schema interface -->
+  <!-- Schema interface -->
   <property name="schema">opengever.meeting.committeecontainer.ICommitteeContainer</property>
 
-  <!-- class used for content items -->
+  <!-- Class used for content items -->
   <property name="klass">opengever.meeting.committeecontainer.CommitteeContainer</property>
 
-  <!-- add permission -->
+  <!-- Add permission -->
   <property name="add_permission">opengever.meeting.AddCommitteeContainer</property>
 
-  <!-- enabled behaviors -->
+  <!-- Enabled behaviors -->
   <property name="behaviors">
     <element value="opengever.base.behaviors.translated_title.ITranslatedTitle" />
     <element value="plone.app.content.interfaces.INameFromTitle" />
@@ -40,17 +40,6 @@
   <alias from="edit" to="@@edit" />
   <alias from="sharing" to="@@sharing" />
   <alias from="view" to="@@view" />
-
-  <action
-      action_id="add-member"
-      visible="True"
-      title="Committee Member"
-      category="folder_factories"
-      url_expr="string:${object_url}/add-member"
-      icon_expr=""
-      condition_expr="">
-    <permission value="opengever.meeting: Add Member" />
-  </action>
 
   <!-- Actions -->
   <action
@@ -73,6 +62,17 @@
     <permission value="Modify portal content" />
   </action>
 
+  <action
+      action_id="add-member"
+      visible="True"
+      title="Committee Member"
+      category="folder_factories"
+      url_expr="string:${object_url}/add-member"
+      icon_expr=""
+      condition_expr="">
+    <permission value="opengever.meeting: Add Member" />
+  </action>
+
   <!-- Tab Actions -->
   <action
       title="committees"
@@ -82,6 +82,7 @@
       url_expr="string:#"
       visible="True">
   </action>
+
   <action
       title="members"
       action_id="members"

--- a/opengever/core/profiles/default/types/opengever.meeting.meetingdossier.xml
+++ b/opengever/core/profiles/default/types/opengever.meeting.meetingdossier.xml
@@ -15,16 +15,16 @@
     <element value="ftw.mail.mail" />
   </property>
 
-  <!-- schema interface -->
+  <!-- Schema interface -->
   <property name="schema">opengever.meeting.interfaces.IMeetingDossier</property>
 
-  <!-- class used for content items -->
+  <!-- Class used for content items -->
   <property name="klass">opengever.meeting.dossier.MeetingDossier</property>
 
-  <!-- add permission -->
+  <!-- Add permission -->
   <property name="add_permission">opengever.dossier.AddBusinessCaseDossier</property>
 
-  <!-- enabled behaviors -->
+  <!-- Enabled behaviors -->
   <property name="behaviors">
     <element value="collective.dexteritytextindexer.behavior.IDexterityTextIndexer" />
     <element value="opengever.base.behaviors.base.IOpenGeverBase" />
@@ -116,19 +116,6 @@
   </action>
 
   <action
-      i18n:domain="opengever.core"
-      title="Give Filing Number"
-      action_id="filing_nr"
-      category="object_buttons"
-      condition_expr="python: object.portal_workflow.getInfoFor(object, 'review_state', None) == 'dossier-state-resolved' and getattr( object, 'filing_no', None) == None"
-      url_expr="string:${object_url}/transition-archive"
-      visible="True">
-    <permission value="Modify portal content" />
-  </action>
-
-
-  <!--migrated from opengever/tasktemplates/profiles/default/types/opengever.meeting.meetingdossier.xml-->
-  <action
       action_id="add_tasktemplate"
       visible="True"
       title="Add task from template"
@@ -137,6 +124,17 @@
       icon_expr=""
       i18n:domain="opengever.core">
     <permission value="Add portal content" />
+  </action>
+
+  <action
+      i18n:domain="opengever.core"
+      title="Give Filing Number"
+      action_id="filing_nr"
+      category="object_buttons"
+      condition_expr="python: object.portal_workflow.getInfoFor(object, 'review_state', None) == 'dossier-state-resolved' and getattr( object, 'filing_no', None) == None"
+      url_expr="string:${object_url}/transition-archive"
+      visible="True">
+    <permission value="Modify portal content" />
   </action>
 
 </object>

--- a/opengever/core/profiles/default/types/opengever.meeting.proposal.xml
+++ b/opengever/core/profiles/default/types/opengever.meeting.proposal.xml
@@ -10,16 +10,16 @@
     <element value="opengever.document.document" />
   </property>
 
-  <!-- schema interface -->
+  <!-- Schema interface -->
   <property name="schema">opengever.meeting.proposal.IProposal</property>
 
-  <!-- class used for content items -->
+  <!-- Class used for content items -->
   <property name="klass">opengever.meeting.proposal.Proposal</property>
 
-  <!-- add permission -->
+  <!-- Add permission -->
   <property name="add_permission">opengever.meeting.AddProposal</property>
 
-  <!-- enabled behaviors -->
+  <!-- Enabled behaviors -->
   <property name="behaviors" purge="False">
     <element value="collective.dexteritytextindexer.behavior.IDexterityTextIndexer" />
     <element value="opengever.meeting.behaviors.namefromtitle.IProposalNameFromTitle" />

--- a/opengever/core/profiles/default/types/opengever.meeting.proposaltemplate.xml
+++ b/opengever/core/profiles/default/types/opengever.meeting.proposaltemplate.xml
@@ -7,16 +7,16 @@
   <property name="allow_discussion">False</property>
   <property name="global_allow">False</property>
 
-  <!-- schema interface -->
+  <!-- Schema interface -->
   <property name="schema">opengever.meeting.proposaltemplate.IProposalTemplate</property>
 
-  <!-- class used for content items -->
+  <!-- Class used for content items -->
   <property name="klass">opengever.meeting.proposaltemplate.ProposalTemplate</property>
 
-  <!-- add permission -->
+  <!-- Add permission -->
   <property name="add_permission">opengever.meeting.AddProposalTemplate</property>
 
-  <!-- enabled behaviors -->
+  <!-- Enabled behaviors -->
   <property name="behaviors" purge="False">
     <element value="collective.dexteritytextindexer.behavior.IDexterityTextIndexer" />
     <element value="ftw.journal.interfaces.IAnnotationsJournalizable" />
@@ -59,6 +59,7 @@
       visible="False">
     <permission value="View" />
   </action>
+
   <action
       title="Edit metadata"
       action_id="edit"
@@ -78,6 +79,7 @@
       url_expr="string:#"
       visible="True"
       />
+
   <action
       title="Versions"
       action_id="versions"
@@ -86,6 +88,7 @@
       url_expr="string:#"
       visible="True"
       />
+
   <action
       title="journal"
       action_id="journal"
@@ -95,7 +98,7 @@
       visible="True"
       />
 
-  <!-- actions for staging -->
+  <!-- Actions for staging -->
   <action
       action_id="checkout_document"
       visible="True"

--- a/opengever/core/profiles/default/types/opengever.meeting.sablontemplate.xml
+++ b/opengever/core/profiles/default/types/opengever.meeting.sablontemplate.xml
@@ -7,16 +7,16 @@
   <property name="allow_discussion">False</property>
   <property name="global_allow">True</property>
 
-  <!-- schema interface -->
+  <!-- Schema interface -->
   <property name="schema">opengever.meeting.sablontemplate.ISablonTemplate</property>
 
-  <!-- class used for content items -->
+  <!-- Class used for content items -->
   <property name="klass">opengever.meeting.sablontemplate.SablonTemplate</property>
 
-  <!-- add permission -->
+  <!-- Add permission -->
   <property name="add_permission">opengever.meeting.AddSablonTemplate</property>
 
-  <!-- enabled behaviors -->
+  <!-- Enabled behaviors -->
   <property name="behaviors" purge="False">
     <element value="collective.dexteritytextindexer.behavior.IDexterityTextIndexer" />
     <element value="ftw.journal.interfaces.IAnnotationsJournalizable" />
@@ -58,6 +58,7 @@
       visible="False">
     <permission value="View" />
   </action>
+
   <action
       title="Edit metadata"
       action_id="edit"
@@ -94,7 +95,7 @@
       visible="True"
       />
 
-  <!-- disable some old actions -->
+  <!-- Disable some old actions -->
   <action
       title="Versions"
       action_id="versions_history_form"
@@ -116,7 +117,7 @@
   </action>
 
 
-  <!-- actions for staging -->
+  <!-- Actions for staging -->
   <action
       action_id="checkout_document"
       visible="True"

--- a/opengever/core/profiles/default/types/opengever.meeting.submittedproposal.xml
+++ b/opengever/core/profiles/default/types/opengever.meeting.submittedproposal.xml
@@ -11,16 +11,16 @@
     <element value="ftw.mail.mail" />
   </property>
 
-  <!-- schema interface -->
+  <!-- Schema interface -->
   <property name="schema">opengever.meeting.proposal.ISubmittedProposal</property>
 
-  <!-- class used for content items -->
+  <!-- Class used for content items -->
   <property name="klass">opengever.meeting.proposal.SubmittedProposal</property>
 
-  <!-- add permission -->
+  <!-- Add permission -->
   <property name="add_permission">opengever.meeting.AddProposal</property>
 
-  <!-- enabled behaviors -->
+  <!-- Enabled behaviors -->
   <property name="behaviors" purge="False">
     <element value="collective.dexteritytextindexer.behavior.IDexterityTextIndexer" />
     <element value="plone.app.lockingbehavior.behaviors.ILocking" />

--- a/opengever/core/profiles/default/types/opengever.private.dossier.xml
+++ b/opengever/core/profiles/default/types/opengever.private.dossier.xml
@@ -13,16 +13,16 @@
     <element value="ftw.mail.mail" />
   </property>
 
-  <!-- schema interface -->
+  <!-- Schema interface -->
   <property name="schema">opengever.private.dossier.IPrivateDossier</property>
 
-  <!-- class used for content items -->
+  <!-- Class used for content items -->
   <property name="klass">opengever.private.dossier.PrivateDossier</property>
 
-  <!-- add permission -->
+  <!-- Add permission -->
   <property name="add_permission">opengever.private.AddPrivateDossier</property>
 
-  <!-- enabled behaviors -->
+  <!-- Enabled behaviors -->
   <property name="behaviors">
     <element value="collective.dexteritytextindexer.behavior.IDexterityTextIndexer" />
     <element value="opengever.base.behaviors.base.IOpenGeverBase" />

--- a/opengever/core/profiles/default/types/opengever.private.folder.xml
+++ b/opengever/core/profiles/default/types/opengever.private.folder.xml
@@ -11,16 +11,16 @@
     <element value="opengever.private.dossier" />
   </property>
 
-  <!-- schema interface -->
+  <!-- Schema interface -->
   <property name="schema">opengever.private.folder.IPrivateFolder</property>
 
-  <!-- class used for content items -->
+  <!-- Class used for content items -->
   <property name="klass">opengever.private.folder.PrivateFolder</property>
 
-  <!-- add permission -->
+  <!-- Add permission -->
   <property name="add_permission">opengever.private.AddPrivateFolder</property>
 
-  <!-- enabled behaviors -->
+  <!-- Enabled behaviors -->
   <property name="behaviors">
     <element value="opengever.sharing.behaviors.IDossier" />
     <element value="opengever.tabbedview.interfaces.ITabbedViewEnabled" />

--- a/opengever/core/profiles/default/types/opengever.private.root.xml
+++ b/opengever/core/profiles/default/types/opengever.private.root.xml
@@ -11,16 +11,16 @@
     <element value="opengever.private.folder" />
   </property>
 
-  <!-- schema interface -->
+  <!-- Schema interface -->
   <property name="schema">opengever.private.root.IPrivateRoot</property>
 
-  <!-- class used for content items -->
+  <!-- Class used for content items -->
   <property name="klass">opengever.private.root.PrivateRoot</property>
 
-  <!-- add permission -->
+  <!-- Add permission -->
   <property name="add_permission">opengever.private.AddPrivateRoot</property>
 
-  <!-- enabled behaviors -->
+  <!-- Enabled behaviors -->
   <property name="behaviors">
     <element value="plone.app.content.interfaces.INameFromTitle" />
     <element value="opengever.tabbedview.interfaces.ITabbedViewEnabled" />

--- a/opengever/core/profiles/default/types/opengever.repository.repositoryfolder.xml
+++ b/opengever/core/profiles/default/types/opengever.repository.repositoryfolder.xml
@@ -14,16 +14,16 @@
     <element value="opengever.meeting.meetingdossier" />
   </property>
 
-  <!-- schema interface -->
+  <!-- Schema interface -->
   <property name="schema">opengever.repository.repositoryfolder.IRepositoryFolderSchema</property>
 
-  <!-- class used for content items -->
+  <!-- Class used for content items -->
   <property name="klass">opengever.repository.repositoryfolder.RepositoryFolder</property>
 
-  <!-- add permission -->
+  <!-- Add permission -->
   <property name="add_permission">opengever.repository.AddRepositoryFolder</property>
 
-  <!-- enabled behaviors -->
+  <!-- Enabled behaviors -->
   <property name="behaviors">
     <element value="opengever.base.behaviors.classification.IClassification" />
     <element value="opengever.base.behaviors.translated_title.ITranslatedTitle" />
@@ -83,5 +83,4 @@
     <permission value="opengever.dossier: Add businesscasedossier" />
   </action>
 
-  <!--migrated from opengever/meeting/profiles/default/types/opengever.repository.repositoryfolder.xml-->
 </object>

--- a/opengever/core/profiles/default/types/opengever.repository.repositoryroot.xml
+++ b/opengever/core/profiles/default/types/opengever.repository.repositoryroot.xml
@@ -12,16 +12,16 @@
     <element value="opengever.disposition.disposition" />
   </property>
 
-  <!-- schema interface -->
+  <!-- Schema interface -->
   <property name="schema">opengever.repository.repositoryroot.IRepositoryRoot</property>
 
-  <!-- class used for content items -->
+  <!-- Class used for content items -->
   <property name="klass">opengever.repository.repositoryroot.RepositoryRoot</property>
 
-  <!-- add permission -->
+  <!-- Add permission -->
   <property name="add_permission">opengever.repository.AddRepositoryRoot</property>
 
-  <!-- enabled behaviors -->
+  <!-- Enabled behaviors -->
   <property name="behaviors">
     <element value="opengever.tabbedview.interfaces.ITabbedViewEnabled" />
     <element value="opengever.sharing.behaviors.IDossier" />
@@ -45,9 +45,7 @@
   <alias from="sharing" to="@@sharing" />
   <alias from="view" to="@@view" />
 
-
   <!-- Actions -->
-
   <action
       title="View"
       action_id="view"

--- a/opengever/core/profiles/default/types/opengever.task.task.xml
+++ b/opengever/core/profiles/default/types/opengever.task.task.xml
@@ -4,7 +4,6 @@
   <property name="title" i18n:translate="">Task</property>
   <property name="description" i18n:translate="" />
   <property name="icon_expr" />
-
   <property name="allow_discussion">False</property>
   <property name="global_allow">True</property>
   <property name="filter_content_types">True</property>
@@ -14,17 +13,16 @@
     <element value="ftw.mail.mail" />
   </property>
 
-
-  <!-- schema interface -->
+  <!-- Schema interface -->
   <property name="schema">opengever.task.task.ITask</property>
 
-  <!-- class used for content items -->
+  <!-- Class used for content items -->
   <property name="klass">opengever.task.task.Task</property>
 
-  <!-- add permission -->
+  <!-- Add permission -->
   <property name="add_permission">opengever.task.AddTask</property>
 
-  <!-- enabled behaviors -->
+  <!-- Enabled behaviors -->
   <property name="behaviors">
     <element value="collective.dexteritytextindexer.behavior.IDexterityTextIndexer" />
     <element value="opengever.tabbedview.interfaces.ITabbedViewEnabled" />
@@ -81,6 +79,7 @@
       visible="True">
     <permission value="View" />
   </action>
+
   <action
       i18n:domain="opengever.core"
       title="Related Documents"
@@ -91,4 +90,5 @@
       visible="True">
     <permission value="View" />
   </action>
+
 </object>

--- a/opengever/core/profiles/default/types/opengever.tasktemplates.tasktemplate.xml
+++ b/opengever/core/profiles/default/types/opengever.tasktemplates.tasktemplate.xml
@@ -4,24 +4,19 @@
   <property name="title" i18n:translate="">TaskTemplate</property>
   <property name="description" i18n:translate="" />
   <property name="icon_expr" />
-
   <property name="allow_discussion">False</property>
   <property name="global_allow">True</property>
   <property name="filter_content_types">True</property>
   <property name="allowed_content_types">
   </property>
 
-
-  <!-- schema interface -->
+  <!-- Schema interface -->
   <property name="schema">opengever.tasktemplates.content.tasktemplate.ITaskTemplate</property>
 
-  <!-- class used for content items -->
+  <!-- Class used for content items -->
   <property name="klass">opengever.tasktemplates.content.tasktemplate.TaskTemplate</property>
 
-  <!-- add permission -->
-  <!--><property name="add_permission">opengever.task.AddTask</property>-->
-
-  <!-- enabled behaviors -->
+  <!-- Enabled behaviors -->
   <property name="behaviors">
     <element value="opengever.tabbedview.interfaces.ITabbedViewEnabled" />
     <element value="plone.app.lockingbehavior.behaviors.ILocking" />
@@ -33,7 +28,6 @@
   <property name="default_view_fallback">False</property>
   <property name="view_methods">
     <element value="view" />
-
   </property>
 
   <!-- Method aliases -->
@@ -52,6 +46,7 @@
       visible="False">
     <permission value="View" />
   </action>
+
   <action
       title="Edit"
       action_id="edit"

--- a/opengever/core/profiles/default/types/opengever.tasktemplates.tasktemplatefolder.xml
+++ b/opengever/core/profiles/default/types/opengever.tasktemplates.tasktemplatefolder.xml
@@ -10,17 +10,16 @@
     <element value="opengever.tasktemplates.tasktemplate" />
   </property>
 
+  <!-- Schema interface -->
+  <property name="schema">opengever.tasktemplates.content.templatefoldersschema.ITaskTemplateFolderSchema</property>
 
-  <!-- schema interface -->
-  <property name="schema" />
-
-  <!-- class used for content items -->
+  <!-- Class used for content items -->
   <property name="klass">plone.dexterity.content.Container</property>
 
-  <!-- add permission -->
+  <!-- Add permission -->
   <property name="add_permission">cmf.AddPortalContent</property>
 
-  <!-- enabled behaviors -->
+  <!-- Enabled behaviors -->
   <property name="behaviors">
     <element value="plone.app.content.interfaces.INameFromTitle" />
     <element value="opengever.tabbedview.interfaces.ITabbedViewEnabled" />
@@ -35,7 +34,7 @@
   <property name="view_methods">
     <element value="tabbed_view" />
   </property>
-  <property name="schema">opengever.tasktemplates.content.templatefoldersschema.ITaskTemplateFolderSchema</property>
+
   <!-- Method aliases -->
   <alias from="(Default)" to="(selected layout)" />
   <alias from="edit" to="@@edit" />

--- a/opengever/core/profiles/default/types/opengever.workspace.root.xml
+++ b/opengever/core/profiles/default/types/opengever.workspace.root.xml
@@ -11,16 +11,16 @@
     <element value="opengever.workspace.workspace" />
   </property>
 
-  <!-- schema interface -->
+  <!-- Schema interface -->
   <property name="schema">opengever.workspace.workspace_root.IWorkspaceRootSchema</property>
 
-  <!-- class used for content items -->
+  <!-- Class used for content items -->
   <property name="klass">opengever.workspace.workspace_root.WorkspaceRoot</property>
 
-  <!-- add permission -->
+  <!-- Add permission -->
   <property name="add_permission">opengever.workspace.AddWorkspaceRoot</property>
 
-  <!-- enabled behaviors -->
+  <!-- Enabled behaviors -->
   <property name="behaviors">
     <element value="plone.app.lockingbehavior.behaviors.ILocking" />
     <element value="ftw.journal.interfaces.IAnnotationsJournalizable" />

--- a/opengever/core/profiles/default/types/opengever.workspace.workspace.xml
+++ b/opengever/core/profiles/default/types/opengever.workspace.workspace.xml
@@ -14,16 +14,16 @@
     <element value="opengever.workspace.folder" />
   </property>
 
-  <!-- schema interface -->
+  <!-- Schema interface -->
   <property name="schema">opengever.workspace.workspace.IWorkspaceSchema</property>
 
-  <!-- class used for content items -->
+  <!-- Class used for content items -->
   <property name="klass">opengever.workspace.workspace.Workspace</property>
 
-  <!-- add permission -->
+  <!-- Add permission -->
   <property name="add_permission">opengever.workspace.AddWorkspace</property>
 
-  <!-- enabled behaviors -->
+  <!-- Enabled behaviors -->
   <property name="behaviors">
     <element value="collective.dexteritytextindexer.behavior.IDexterityTextIndexer" />
     <element value="ftw.journal.interfaces.IAnnotationsJournalizable" />
@@ -36,7 +36,6 @@
     <element value="opengever.trash.trash.ITrashable" />
     <element value="plone.app.lockingbehavior.behaviors.ILocking" />
   </property>
-
 
   <!-- View information -->
   <property name="immediate_view">tabbed_view</property>

--- a/opengever/core/profiles/default/viewlets.xml
+++ b/opengever/core/profiles/default/viewlets.xml
@@ -16,7 +16,7 @@
 
 
   <!-- skinname="*" is buggy and only seems to work sometimes, but not reliably,
-     so we explicitely hide the viewlet for all the skins -->
+       so we explicitely hide the viewlet for all the skins -->
 
   <hidden manager="plone.belowcontenttitle" skinname="Plone Classic Theme">
     <viewlet name="ftw.mail.mail-in" />


### PR DESCRIPTION
- Removes unnecessary comments
- Adds comments to structure the files
- Unify the structure of all the files

`types.xml` and `actions.xml` cant be sorted because it would change the order of things in the gui, and we dont want that.

