### PR TITLE
Implement cross tab logout mechanism.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -22,6 +22,7 @@ Changelog
 - Display document mimetype icon on livesearch results. [Kevin Bieri]
 - Save current treeportlet index in localstorage. [Kevin Bieri]
 - Fix autofocus on forms with keywordwidget.[Kevin Bieri]
+- Implement cross tab logout mechanism. [Kevin Bieri]
 - Add filename and filesize in bumblebee overlay. [njohner]
 - OGIP 17: Add workspace folder content type [raphael-s]
 - Fix plonesite removal. [phgross]

--- a/opengever/base/browser/resources/logoutClient.js
+++ b/opengever/base/browser/resources/logoutClient.js
@@ -1,0 +1,30 @@
+(function(global, $) {
+  var logoutWorker;
+
+  // Setup the shared worker which holds all open gever tabs
+  function initWorker() {
+    var workerSrc = global.portal_url + "/++resource++opengever.base/logoutWorker.js";
+    logoutWorker = new SharedWorker(workerSrc);
+    // Reload the tab when the LogoutBus sends a broadcast message
+    logoutWorker.port.onmessage = function() { location.reload(); };
+    setupListeners();
+  }
+
+  // Prevent the default login behavior. Broadcast a logout message to all open gever tabs instead.
+  function trackLogout(e) {
+    e.preventDefault();
+    e.stopPropagation();
+    $.get(global.portal_url + '/logout').done(() => {
+      logoutWorker.port.postMessage('logout');
+    });
+  }
+
+  function setupListeners() {
+    var logoutButton = $('#personaltools-logout > a');
+    logoutButton.on('click', trackLogout);
+  }
+
+  if('SharedWorker' in window) {
+    $(initWorker);
+  }
+})(window, window.jQuery);

--- a/opengever/base/browser/resources/logoutWorker.js
+++ b/opengever/base/browser/resources/logoutWorker.js
@@ -1,0 +1,12 @@
+// Holds all open gever tabs
+var clients = new Set();
+
+onconnect = function(e) {
+  var port = e.ports[0];
+  clients.add(port);
+  port.start();
+  port.onmessage = function() {
+    // Broadcast logout message to all open gever tabs
+    clients.forEach(c => { c.postMessage('logout'); });
+  };
+};

--- a/opengever/core/profiles/default/jsregistry.xml
+++ b/opengever/core/profiles/default/jsregistry.xml
@@ -484,4 +484,15 @@
       insert-before="++resource++ftw.keywordwidget/js/keywordwidget.js"
       />
 
+  <javascript
+      cacheable="True"
+      compression="none"
+      cookable="True"
+      expression=""
+      enabled="True"
+      id="++resource++opengever.base/logoutClient.js"
+      inline="False"
+      insert-after="++resource++opengever.base/keywordwidget.js"
+      />
+
 </object>

--- a/opengever/core/upgrades/20171221172209_install_logout_shared_worker/jsregistry.xml
+++ b/opengever/core/upgrades/20171221172209_install_logout_shared_worker/jsregistry.xml
@@ -1,0 +1,14 @@
+<object name="portal_javascripts" meta_type="JavaScripts Registry">
+
+<javascript
+      cacheable="True"
+      compression="none"
+      cookable="True"
+      expression=""
+      enabled="True"
+      id="++resource++opengever.base/logoutClient.js"
+      inline="False"
+      insert-after="++resource++opengever.base/keywordwidget.js"
+      />
+
+</object>

--- a/opengever/core/upgrades/20171221172209_install_logout_shared_worker/upgrade.py
+++ b/opengever/core/upgrades/20171221172209_install_logout_shared_worker/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class InstallLogoutSharedWorker(UpgradeStep):
+    """Install logout shared worker.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()


### PR DESCRIPTION
![gever-logout-worker](https://user-images.githubusercontent.com/1637820/34266574-fdcffcd2-e679-11e7-808a-4088df6384e5.gif)

When a logout is triggered in one gever tab, all other tabs are reloaded
automatically.
This is done through a SharedWorker. All tabs are connected with this
SharedWorker. If one tab sends a logout message to the worker the worker
broadcasts a logout message to all open gever tabs.

According to https://caniuse.com/#feat=sharedworkers this is just
working in Chrome and Firefox.

⚠️ This implementation is not working for cross-site worker invocations. As far as I know the SharedWorkers obey the cross origin security. Maybe a simple CORS header will do the trick.

/cc @Rotonen Thanks for the tip 👍 