### PR TITLE
Checkout/Edit only for office connector supported file formats supported

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -9,6 +9,7 @@ Changelog
 - OGIP 17: Implement internal invitations for Workspaces. [mathias.leimgruber]
 - Improve description for committee group label. [deiferni]
 - Ensure bumblebee overlay view download links point to the correct version. [Rotonen]
+- Add keynote, numbers and pages mimetypes [njohner]
 - Checkout/Edit only for office connector supported file formats supported [njohner]
 - Make teams available as tasktemplate responsibles. [phgross]
 - Fix JWT authentication for users from the Zope root acl_users. [Rotonen]

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -9,6 +9,7 @@ Changelog
 - OGIP 17: Implement internal invitations for Workspaces. [mathias.leimgruber]
 - Improve description for committee group label. [deiferni]
 - Ensure bumblebee overlay view download links point to the correct version. [Rotonen]
+- Checkout/Edit only for office connector supported file formats supported [njohner]
 - Make teams available as tasktemplate responsibles. [phgross]
 - Fix JWT authentication for users from the Zope root acl_users. [Rotonen]
 - Fix bumblebee preview in ECH0147 import. [deiferni]

--- a/opengever/core/profiles/default/registry.xml
+++ b/opengever/core/profiles/default/registry.xml
@@ -82,6 +82,82 @@
 
   <!-- OFFICECONNECTOR -->
   <records interface="opengever.officeconnector.interfaces.IOfficeConnectorSettings" />
+  <record
+      interface="opengever.officeconnector.interfaces.IOfficeConnectorSettings"
+      field="officeconnector_editable_types">
+    <field type="plone.registry.field.List">
+      <value_type type="plone.registry.field.TextLine" />
+    </field>
+    <value>
+      <!-- TextEdit -->
+      <element>text/plain</element>
+      <element>application/rtf</element>
+      <element>text/csv</element>
+      <element>text/css</element>
+      <element>text/xml</element>
+      <element>text/tab-separated-values</element>
+      <element>text/richtext</element>
+      <element>text/html</element>
+
+      <!-- Acrobat Pro, Reader, Preview -->
+      <element>application/pdf</element>
+      <element>application/postscript</element>
+
+      <!-- Preview -->
+      <element>image/jpeg</element>
+      <element>image/jpg</element>
+      <element>image/tiff</element>
+      <element>image/gif</element>
+      <element>image/png</element>
+
+      <!-- MS Visio -->
+      <element>application/vnd.visio</element>
+
+      <!-- MS Project -->
+      <element>application/vnd.ms-project</element>
+
+      <!-- MS Project (generic) -->
+      <element>application/x-project</element>
+
+      <!-- Adobe InDesign -->
+      <element>application/x-indesign</element>
+
+      <!-- Adobe Photoshop -->
+      <element>image/vnd.adobe.photoshop</element>
+
+      <!-- Adobe Illustrator -->
+      <element>application/illustrator</element>
+
+      <!-- MS OneNote -->
+      <element>application/onenote</element>
+
+      <!-- MS Excel -->
+      <element>application/vnd.ms-excel</element>
+      <element>application/vnd.openxmlformats-officedocument.spreadsheetml.sheet</element>
+      <element>application/vnd.openxmlformats-officedocument.spreadsheetml.template</element>
+      <element>application/vnd.ms-excel.sheet.macroEnabled.12</element>
+      <element>application/vnd.ms-excel.sheet.binary.macroEnabled.12</element>
+      <element>application/vnd.ms-excel.template.macroEnabled.12</element>
+      <element>application/vnd.ms-excel.addin.macroEnabled.12</element>
+
+      <!-- MS Powerpoint -->
+      <element>application/vnd.ms-powerpoint</element>
+      <element>application/vnd.ms-powerpoint.addin.macroEnabled.12</element>
+      <element>application/vnd.ms-powerpoint.presentation.macroEnabled.12</element>
+      <element>application/vnd.ms-powerpoint.slideshow.macroEnabled.12</element>
+      <element>application/vnd.openxmlformats-officedocument.presentationml.presentation</element>
+      <element>application/vnd.openxmlformats-officedocument.presentationml.template</element>
+      <element>application/vnd.openxmlformats-officedocument.presentationml.slideshow</element>
+
+      <!-- MS Word -->
+      <element>application/msword</element>
+      <element>application/vnd.ms-word.document.macroEnabled.12</element>
+      <element>application/vnd.ms-word.template.macroEnabled.12</element>
+      <element>application/vnd.openxmlformats-officedocument.wordprocessingml.document</element>
+      <element>application/vnd.openxmlformats-officedocument.wordprocessingml.template</element>
+    </value>
+  </record>
+
 
   <!-- OGDS -->
   <records interface="opengever.ogds.base.interfaces.IAdminUnitConfiguration" />

--- a/opengever/core/profiles/default/registry.xml
+++ b/opengever/core/profiles/default/registry.xml
@@ -155,6 +155,16 @@
       <element>application/vnd.ms-word.template.macroEnabled.12</element>
       <element>application/vnd.openxmlformats-officedocument.wordprocessingml.document</element>
       <element>application/vnd.openxmlformats-officedocument.wordprocessingml.template</element>
+
+      <!-- Apple Numbers -->
+      <element>application/x-iwork-numbers-sffnumbers</element>
+
+      <!-- Apple Keynote -->
+      <element>application/x-iwork-keynote-sffkey</element>
+
+      <!-- Apple Pages -->
+      <element>application/x-iwork-pages-sffpages</element>
+
     </value>
   </record>
 

--- a/opengever/core/upgrades/20180123155812_checkout_edit_only_for_office_connector_editable/mimetypes.xml
+++ b/opengever/core/upgrades/20180123155812_checkout_edit_only_for_office_connector_editable/mimetypes.xml
@@ -1,0 +1,34 @@
+
+<object name="mimetypes_registry" meta_type="MimeTypes Registry">
+
+  <!-- Numbers -->
+  <mimetype
+      name="Numbers"
+      binary="True"
+      extensions="numbers"
+      globs="*.numbers"
+      icon_path="icon_dokument_numbers.gif"
+      mimetypes="application/x-iwork-numbers-sffnumbers"
+      />
+
+  <!-- Keynote -->
+  <mimetype
+      name="Keynote"
+      binary="True"
+      extensions="key"
+      globs="*.key"
+      icon_path="icon_dokument_keynote.gif"
+      mimetypes="application/x-iwork-keynote-sffkey"
+      />
+
+  <!-- Pages -->
+  <mimetype
+      name="Pages"
+      binary="True"
+      extensions="pages"
+      globs="*.pages"
+      icon_path="icon_dokument_pages.gif"
+      mimetypes="application/x-iwork-pages-sffpages"
+      />
+
+</object>

--- a/opengever/core/upgrades/20180123155812_checkout_edit_only_for_office_connector_editable/registry.xml
+++ b/opengever/core/upgrades/20180123155812_checkout_edit_only_for_office_connector_editable/registry.xml
@@ -72,6 +72,16 @@
       <element>application/vnd.ms-word.template.macroEnabled.12</element>
       <element>application/vnd.openxmlformats-officedocument.wordprocessingml.document</element>
       <element>application/vnd.openxmlformats-officedocument.wordprocessingml.template</element>
+
+      <!-- Apple Numbers -->
+      <element>application/x-iwork-numbers-sffnumbers</element>
+
+      <!-- Apple Keynote -->
+      <element>application/x-iwork-keynote-sffkey</element>
+
+      <!-- Apple Pages -->
+      <element>application/x-iwork-pages-sffpages</element>
+
     </value>
   </record>
 </registry>

--- a/opengever/core/upgrades/20180123155812_checkout_edit_only_for_office_connector_editable/registry.xml
+++ b/opengever/core/upgrades/20180123155812_checkout_edit_only_for_office_connector_editable/registry.xml
@@ -1,0 +1,77 @@
+<registry>
+  <record
+      interface="opengever.officeconnector.interfaces.IOfficeConnectorSettings"
+      field="officeconnector_editable_types">
+    <field type="plone.registry.field.List">
+      <value_type type="plone.registry.field.TextLine" />
+    </field>
+    <value>
+      <!-- TextEdit -->
+      <element>text/plain</element>
+      <element>application/rtf</element>
+      <element>text/csv</element>
+      <element>text/css</element>
+      <element>text/xml</element>
+      <element>text/tab-separated-values</element>
+      <element>text/richtext</element>
+      <element>text/html</element>
+
+      <!-- Acrobat Pro, Reader, Preview -->
+      <element>application/pdf</element>
+      <element>application/postscript</element>
+
+      <!-- Preview -->
+      <element>image/jpeg</element>
+      <element>image/jpg</element>
+      <element>image/tiff</element>
+      <element>image/gif</element>
+      <element>image/png</element>
+
+      <!-- MS Visio -->
+      <element>application/vnd.visio</element>
+
+      <!-- MS Project -->
+      <element>application/vnd.ms-project</element>
+
+      <!-- MS Project (generic) -->
+      <element>application/x-project</element>
+
+      <!-- Adobe InDesign -->
+      <element>application/x-indesign</element>
+
+      <!-- Adobe Photoshop -->
+      <element>image/vnd.adobe.photoshop</element>
+
+      <!-- Adobe Illustrator -->
+      <element>application/illustrator</element>
+
+      <!-- MS OneNote -->
+      <element>application/onenote</element>
+
+      <!-- MS Excel -->
+      <element>application/vnd.ms-excel</element>
+      <element>application/vnd.openxmlformats-officedocument.spreadsheetml.sheet</element>
+      <element>application/vnd.openxmlformats-officedocument.spreadsheetml.template</element>
+      <element>application/vnd.ms-excel.sheet.macroEnabled.12</element>
+      <element>application/vnd.ms-excel.sheet.binary.macroEnabled.12</element>
+      <element>application/vnd.ms-excel.template.macroEnabled.12</element>
+      <element>application/vnd.ms-excel.addin.macroEnabled.12</element>
+
+      <!-- MS Powerpoint -->
+      <element>application/vnd.ms-powerpoint</element>
+      <element>application/vnd.ms-powerpoint.addin.macroEnabled.12</element>
+      <element>application/vnd.ms-powerpoint.presentation.macroEnabled.12</element>
+      <element>application/vnd.ms-powerpoint.slideshow.macroEnabled.12</element>
+      <element>application/vnd.openxmlformats-officedocument.presentationml.presentation</element>
+      <element>application/vnd.openxmlformats-officedocument.presentationml.template</element>
+      <element>application/vnd.openxmlformats-officedocument.presentationml.slideshow</element>
+
+      <!-- MS Word -->
+      <element>application/msword</element>
+      <element>application/vnd.ms-word.document.macroEnabled.12</element>
+      <element>application/vnd.ms-word.template.macroEnabled.12</element>
+      <element>application/vnd.openxmlformats-officedocument.wordprocessingml.document</element>
+      <element>application/vnd.openxmlformats-officedocument.wordprocessingml.template</element>
+    </value>
+  </record>
+</registry>

--- a/opengever/core/upgrades/20180123155812_checkout_edit_only_for_office_connector_editable/upgrade.py
+++ b/opengever/core/upgrades/20180123155812_checkout_edit_only_for_office_connector_editable/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class CheckoutEditOnlyForOfficeConnectorEditable(UpgradeStep):
+    """Checkout edit only for office connector editable.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/document/browser/actionbuttons.py
+++ b/opengever/document/browser/actionbuttons.py
@@ -58,6 +58,9 @@ class ActionButtonRendererMixin(object):
             return IDocumentSchema.providedBy(self.context)
         return False
 
+    def is_office_connector_editable(self):
+        return self.context.is_office_connector_editable()
+
     def is_checkout_and_edit_available(self):
         if self.is_versioned():
             return False

--- a/opengever/document/browser/templates/macros.pt
+++ b/opengever/document/browser/templates/macros.pt
@@ -25,32 +25,48 @@
         <tal:file tal:condition="context/has_file"
             tal:define="preview_supported view/is_preview_supported;
             checkout_and_edit_available view/is_checkout_and_edit_available;
+            office_connector_editable view/is_office_connector_editable;
             copy_download_available view/is_download_copy_available;
             attach_to_email_available view/is_attach_to_email_available;
             checked_out_by_current_user view/is_checked_out_by_current_user;
-            is_cancel_allowed view/is_checkout_cancel_available">
+            is_cancel_allowed view/is_checkout_cancel_available;
+            new_external_edit_enabled context/@@officeconnector_settings/is_checkout_enabled">
 
             <tal:checkout_and_edit_enabled tal:condition="checkout_and_edit_available">
+                <tal:oc_editable tal:condition="office_connector_editable">
+                    <tal:oc_checkout tal:condition="new_external_edit_enabled">
+                        <a tal:attributes="href string:javascript:officeConnectorCheckout('${context/absolute_url}/officeconnector_checkout_url');;;
+                                           data-document-url context/absolute_url"
+                            class="function-edit oc-checkout"
+                            href="#"
+                            i18n:translate="label_checkout_and_edit">
+                            Checkout and edit
+                        </a>
+                    </tal:oc_checkout>
 
-                <tal:oc_checkout tal:condition="context/@@officeconnector_settings/is_checkout_enabled">
-                    <a tal:attributes="href string:javascript:officeConnectorCheckout('${context/absolute_url}/officeconnector_checkout_url');;;
-                                       data-document-url context/absolute_url"
-                        class="function-edit oc-checkout"
-                        href="#"
-                        i18n:translate="label_checkout_and_edit">
+                    <tal:zem_checkout tal:condition="not: new_external_edit_enabled">
+                        <a tal:attributes="href string:${context/absolute_url}/editing_document?_authenticator=${context/@@authenticator/token}"
+                            class="function-edit"
+                            href="#"
+                            i18n:translate="label_checkout_and_edit">
+                            Checkout and edit
+                        </a>
+                    </tal:zem_checkout>
+                </tal:oc_editable>
+
+                <tal:oc_uneditable tal:condition="not: office_connector_editable">
+                    <span class="fa-exclamation-triangle-after function-edit-inactive discreet" title="Office connector unsupported type" value="Checkout and edit"
+                    i18n:attributes="title oc_unsupported_message" i18n:translate="label_checkout_and_edit">
                         Checkout and edit
-                    </a>
-                </tal:oc_checkout>
+                    </span>
 
-                <tal:zem_checkout tal:condition="not: context/@@officeconnector_settings/is_checkout_enabled">
-                    <a tal:attributes="href string:${context/absolute_url}/editing_document?_authenticator=${context/@@authenticator/token}"
+                    <a tal:attributes="href string:${context/absolute_url}/@@checkout_documents?_authenticator=${context/@@authenticator/token}"
                         class="function-edit"
                         href="#"
-                        i18n:translate="label_checkout_and_edit">
-                        Checkout and edit
+                        i18n:translate="label_checkout">
+                        Checkout
                     </a>
-                </tal:zem_checkout>
-
+                </tal:oc_uneditable>
             </tal:checkout_and_edit_enabled>
 
             <tal:checkout_and_edit_disabled tal:condition="not: checkout_and_edit_available">

--- a/opengever/document/document.py
+++ b/opengever/document/document.py
@@ -142,9 +142,9 @@ class UploadValidator(validator.SimpleFieldValidator):
 
         raise Invalid(_(
             u'error_mail_upload',
-            default=u"It's not possible to add E-mails here, please "
+            default=(u"It's not possible to add E-mails here, please "
             "send it to ${mailaddress} or drag it to the dossier "
-            "(Dragn'n'Drop).",
+            "(Dragn'n'Drop)."),
             mapping={'mailaddress': mail_address}
             ))
 
@@ -255,6 +255,12 @@ class Document(Item, BaseDocumentMixin):
         manager = getMultiAdapter((self, self.REQUEST),
                                   ICheckinCheckoutManager)
         return manager.get_checked_out_by()
+
+    def is_office_connector_editable(self):
+        if self.file is None:
+            return False
+        return self.content_type() in api.portal.get_registry_record(
+            'opengever.officeconnector.interfaces.IOfficeConnectorSettings.officeconnector_editable_types')
 
     def is_checkout_and_edit_available(self):
         manager = queryMultiAdapter(

--- a/opengever/document/extra_mimetypes.py
+++ b/opengever/document/extra_mimetypes.py
@@ -124,4 +124,13 @@ ADDITIONAL_TYPES = [
 
     # MS Powerpoint Slideshow (Macro Enabled)
     ('application/vnd.ms-powerpoint.slideshow.macroEnabled.12', '.ppsm'),
+
+    # Apple Keynote
+    ('application/x-iwork-keynote-sffkey', '.key'),
+
+    # Apple pages
+    ('application/x-iwork-pages-sffpages', '.pages'),
+
+    # Apple numbers
+    ('application/x-iwork-numbers-sffnumbers', '.numbers'),
 ]

--- a/opengever/document/locales/de/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/de/LC_MESSAGES/opengever.document.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2017-11-27 13:45+0000\n"
+"POT-Creation-Date: 2018-01-29 09:52+0000\n"
 "PO-Revision-Date: 2017-10-13 14:27+0200\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -175,7 +175,7 @@ msgstr "Sie sind dabei, eine Kopie des Dokuments ${filename} herunterzuladen."
 msgid "error_file_and_preserved_as_paper"
 msgstr "Sie haben weder eine Datei ausgewählt noch ist das Dokument in Papierform aufbewahrt, bitte korrigieren."
 
-#. Default: "It's not possible to add E-mails here, please '                    'send it to ${mailaddress} or drag it to the dossier '                    ' (Dragn'n'Drop)."
+#. Default: "It's not possible to add E-mails here, please send it to ${mailaddress} or drag it to the dossier (Dragn'n'Drop)."
 #: ./opengever/document/document.py
 msgid "error_mail_upload"
 msgstr "Es ist nicht erlaubt hier E-Mails anzufügen. Bitte senden Sie das E-Mail an die Addresse ${mailaddress} oder ziehen Sie es in das Dossier (Drag'n'Drop)."
@@ -331,6 +331,11 @@ msgstr "Ausgecheckt"
 #: ./opengever/document/checkout/checkin.py
 msgid "label_checkin_journal_comment"
 msgstr "Journal-Kommentar"
+
+#. Default: "Checkout"
+#: ./opengever/document/browser/templates/macros.pt
+msgid "label_checkout"
+msgstr "Auschecken"
 
 #. Default: "Checkout and edit"
 #: ./opengever/document/browser/templates/macros.pt
@@ -555,6 +560,11 @@ msgstr "Das Dokument `${title}` konnte nicht ausgecheckt werden, da Mails den Ch
 #: ./opengever/document/browser/templates/macros.pt
 msgid "no_file"
 msgstr "Keine Datei"
+
+#. Default: "Office connector unsupported type"
+#: ./opengever/document/browser/templates/macros.pt
+msgid "oc_unsupported_message"
+msgstr "Dieses Dokumentformat wird vom Office Connector nicht unterstützt und kann deshalb nicht direkt bearbeitet werden."
 
 #. Default: "Following documents are checked out:"
 #: ./opengever/document/browser/templates/logout_overlay.pt

--- a/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-11-27 13:45+0000\n"
+"POT-Creation-Date: 2018-01-29 09:52+0000\n"
 "PO-Revision-Date: 2017-09-03 08:50+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-document/fr/>\n"
@@ -177,7 +177,7 @@ msgstr "Vous étes en train de télécharger une copie du document ${filename}."
 msgid "error_file_and_preserved_as_paper"
 msgstr "Vous n'avez pas sélectionné un fichier ni conservé un document en version papier. Merci de corriger cela."
 
-#. Default: "It's not possible to add E-mails here, please '                    'send it to ${mailaddress} or drag it to the dossier '                    ' (Dragn'n'Drop)."
+#. Default: "It's not possible to add E-mails here, please send it to ${mailaddress} or drag it to the dossier (Dragn'n'Drop)."
 #: ./opengever/document/document.py
 msgid "error_mail_upload"
 msgstr "Il n'est pas possible d'insérer des Email à cet endroit. Pour le faire, utilisez l'adresse E-Mail ${mailaddress}  ou glissez-le dans le dossier (Drag'n'Drop)."
@@ -328,6 +328,11 @@ msgstr "Avec check-out"
 #: ./opengever/document/checkout/checkin.py
 msgid "label_checkin_journal_comment"
 msgstr "Commentaire de l'historique"
+
+#. Default: "Checkout"
+#: ./opengever/document/browser/templates/macros.pt
+msgid "label_checkout"
+msgstr "Faire le check-out"
 
 #. Default: "Checkout and edit"
 #: ./opengever/document/browser/templates/macros.pt
@@ -552,6 +557,11 @@ msgstr "Le document `${title}` n'a pas pu être verrouillé, car les e-mails ne 
 #: ./opengever/document/browser/templates/macros.pt
 msgid "no_file"
 msgstr "Aucun fichier trouvé"
+
+#. Default: "Office connector unsupported type"
+#: ./opengever/document/browser/templates/macros.pt
+msgid "oc_unsupported_message"
+msgstr "Ce format de document n'est pas supporté par Office Connector et ne peut donc pas être directement édité."
 
 #. Default: "Following documents are checked out:"
 #: ./opengever/document/browser/templates/logout_overlay.pt

--- a/opengever/document/locales/opengever.document.pot
+++ b/opengever/document/locales/opengever.document.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-11-27 13:45+0000\n"
+"POT-Creation-Date: 2018-01-29 09:52+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -178,7 +178,7 @@ msgstr ""
 msgid "error_file_and_preserved_as_paper"
 msgstr ""
 
-#. Default: "It's not possible to add E-mails here, please '                    'send it to ${mailaddress} or drag it to the dossier '                    ' (Dragn'n'Drop)."
+#. Default: "It's not possible to add E-mails here, please send it to ${mailaddress} or drag it to the dossier (Dragn'n'Drop)."
 #: ./opengever/document/document.py
 msgid "error_mail_upload"
 msgstr ""
@@ -328,6 +328,11 @@ msgstr ""
 #. Default: "Journal Comment"
 #: ./opengever/document/checkout/checkin.py
 msgid "label_checkin_journal_comment"
+msgstr ""
+
+#. Default: "Checkout"
+#: ./opengever/document/browser/templates/macros.pt
+msgid "label_checkout"
 msgstr ""
 
 #. Default: "Checkout and edit"
@@ -552,6 +557,11 @@ msgstr ""
 #: ./opengever/document/browser/templates/archiv_file.pt
 #: ./opengever/document/browser/templates/macros.pt
 msgid "no_file"
+msgstr ""
+
+#. Default: "Office connector unsupported type"
+#: ./opengever/document/browser/templates/macros.pt
+msgid "oc_unsupported_message"
 msgstr ""
 
 #. Default: "Following documents are checked out:"

--- a/opengever/document/tests/test_overview.py
+++ b/opengever/document/tests/test_overview.py
@@ -255,6 +255,42 @@ class TestDocumentOverviewVanilla(IntegrationTestCase):
             )
 
     @browsing
+    def test_inactive_links_if_unsupported_format(self, browser):
+        """Check the document overview when the document's format is not,
+        supported by office connector:
+        - Edit link is inactive
+        - Checkout link is active
+        """
+        self.login(self.regular_user, browser)
+        browser.open(self.document, view='tabbedview_view-overview')
+        self.assertFalse(browser.css('.function-edit-inactive'),
+                        'There should not be an inactive edit button')
+
+        self.document.file.contentType = "application/foo"
+        browser.open(self.document, view='tabbedview_view-overview')
+
+        edit_button = browser.css('a.function-edit')
+
+        self.assertEquals(
+            1,
+            len(edit_button.text),
+        )
+
+        self.assertEquals(
+            'Checkout',
+            edit_button.first.text,
+        )
+
+        self.assertIn(
+            '/@@checkout_documents',
+            edit_button.first.attrib['href'],
+        )
+
+        self.assertTrue(browser.css('.function-edit-inactive'),
+                        'There should be an inactive edit button')
+
+
+    @browsing
     def test_checkout_not_possible_if_locked_by_another_user(self, browser):
         self.login(self.dossier_responsible, browser)
 

--- a/opengever/mail/mail.py
+++ b/opengever/mail/mail.py
@@ -311,6 +311,11 @@ class OGMail(Mail, BaseDocumentMixin):
         """
         return False
 
+    def is_office_connector_editable(self):
+        """Mail cannot be edited with office connector
+        """
+        return False
+
     def get_current_version_id(self, missing_as_zero=False):
         """Mails cannot be edited, they are read-only."""
         return 0

--- a/opengever/policy/base/profiles/mimetype/mimetypes.xml
+++ b/opengever/policy/base/profiles/mimetype/mimetypes.xml
@@ -461,7 +461,7 @@
       globs="*.oth"
       icon_path="icon_dokument_openoffice_writer.gif"
       mimetypes="application/vnd.oasis.opendocument.text-web"
-      /> 
+      />
 
   <mimetype
       name="ODS spreadsheet"
@@ -524,6 +524,36 @@
       globs="*.odf"
       icon_path="icon_dokument_openoffice_math.gif"
       mimetypes="application/vnd.oasis.opendocument.formula"
+      />
+
+  <!-- Numbers -->
+  <mimetype
+      name="Numbers"
+      binary="True"
+      extensions="numbers"
+      globs="*.numbers"
+      icon_path="icon_dokument_numbers.gif"
+      mimetypes="application/x-iwork-numbers-sffnumbers"
+      />
+
+  <!-- Keynote -->
+  <mimetype
+      name="Keynote"
+      binary="True"
+      extensions="key"
+      globs="*.key"
+      icon_path="icon_dokument_keynote.gif"
+      mimetypes="application/x-iwork-keynote-sffkey"
+      />
+
+  <!-- Pages -->
+  <mimetype
+      name="Pages"
+      binary="True"
+      extensions="pages"
+      globs="*.pages"
+      icon_path="icon_dokument_pages.gif"
+      mimetypes="application/x-iwork-pages-sffpages"
       />
 
   <!-- Various other file formats -->


### PR DESCRIPTION
Only allow Checkout/Edit button for file formats supported by office connector.

If office connector is unavailable or if the file format cannot be handled by office connector:
* Make Checkout/Edit button discreet
* Add tooltip explaining why the function is unavailable (tooltip either says that office connector is unavailable or that the file type is not supported by office connector)
* Add Checkout button

**Remarks**
* I did not find the list of supported file formats for `OfficeConnector`, so the registry needs to be updated
* Would it make more sense to have the registry in the `OfficeConnector` code?

**For a content type that cannot be edited in office connector**
![checkout](https://user-images.githubusercontent.com/7374243/34522790-b184577c-f094-11e7-9ec2-e4cb0badc0f6.png)

**For a content type that can be edited in office connector**
![checkout_edit](https://user-images.githubusercontent.com/7374243/34522791-b4186d66-f094-11e7-8737-474a53c2f648.png)

resolves #3665 