### PR TITLE
Fix autofocus on forms with keywordwidget.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -21,6 +21,7 @@ Changelog
 - Prepare HTML structure for dossier title alignment. [Kevin Bieri]
 - Display document mimetype icon on livesearch results. [Kevin Bieri]
 - Save current treeportlet index in localstorage. [Kevin Bieri]
+- Fix autofocus on forms with keywordwidget.[Kevin Bieri]
 - Add filename and filesize in bumblebee overlay. [njohner]
 - OGIP 17: Add workspace folder content type [raphael-s]
 - Fix plonesite removal. [phgross]

--- a/opengever/base/browser/resources/base.js
+++ b/opengever/base/browser/resources/base.js
@@ -1,8 +1,13 @@
-$(function() {
+$(window).load(function(){
   // set focus on first form field
-  $("form#form input:text:visible, form#form textarea:visible").first().focus();
+  var firstFormElement = $("form#form input:text:visible, form#form textarea:visible, .keyword-widget").first();
+  // Check if element is select2 widget
+  if (firstFormElement.data('select2')) {
+    firstFormElement.select2('open');
+  } else {
+    firstFormElement.focus();
+  }
 });
-
 
 $(document).delegate('body', 'tabbedview.unknownresponse', function(event, overview, jqXHR) {
   if (jqXHR.getResponseHeader('X-GEVER-Service') === 'Portal') {

--- a/opengever/core/profiles/default/jsregistry.xml
+++ b/opengever/core/profiles/default/jsregistry.xml
@@ -283,7 +283,7 @@
       enabled="True"
       id="++resource++opengever.base/base.js"
       inline="False"
-      insert-after="++resource++opengever.meeting/meeting.js"
+      insert-after="++resource++ftw.keywordwidget/js/keywordwidget.js"
       />
 
   <javascript

--- a/opengever/core/upgrades/20171227115310_move_base_javascript_after_keywordwidget/jsregistry.xml
+++ b/opengever/core/upgrades/20171227115310_move_base_javascript_after_keywordwidget/jsregistry.xml
@@ -1,0 +1,8 @@
+<object name="portal_javascripts" meta_type="JavaScripts Registry">
+
+  <javascript
+      id="++resource++opengever.base/base.js"
+      insert-after="++resource++ftw.keywordwidget/js/keywordwidget.js"
+      />
+
+</object>

--- a/opengever/core/upgrades/20171227115310_move_base_javascript_after_keywordwidget/upgrade.py
+++ b/opengever/core/upgrades/20171227115310_move_base_javascript_after_keywordwidget/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class MoveBaseJavascriptAfterKeywordwidget(UpgradeStep):
+    """Move base javascript after keywordwidget.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()


### PR DESCRIPTION
The auto focus was just limited to textareas and text input elements.

Closes https://github.com/4teamwork/opengever.core/issues/3807