### PR TITLE
Display document mimetype icon on livesearch results.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -11,6 +11,7 @@ Changelog
 - OGIP 17: Implement sequence_number and NameFromTitle behavior for Workspace. [mathias.leimgruber]
 - OGIP 17: Add tabbedviews for opengever.workspace types. [mathias.leimgruber]
 - Prepare HTML structure for dossier title alignment. [Kevin Bieri]
+- Display document mimetype icon on livesearch results. [Kevin Bieri]
 - Add filename and filesize in bumblebee overlay. [njohner]
 - OGIP 17: Add workspace folder content type [raphael-s]
 - Fix plonesite removal. [phgross]

--- a/opengever/advancedsearch/skins/advancedsearch_resources/livesearch_reply.py
+++ b/opengever/advancedsearch/skins/advancedsearch_resources/livesearch_reply.py
@@ -49,6 +49,24 @@ def quote_bad_chars(s):
         s = s.replace(char, quotestring(char))
     return s
 
+
+# https://github.com/4teamwork/opengever.core/blob/master/opengever/base/browser/helper.py#L20
+def get_mimetype_icon_klass(item):
+    # It just makes sense to guess the mimetype of documents
+    if not item.portal_type == 'opengever.document.document':
+        return ''
+
+    icon = item.getIcon
+
+    # Fallback for unknown file type
+    if icon == '':
+        return "icon-document_empty"
+
+    # Strip '.gif' from end of icon name and remove
+    # leading 'icon_'
+    filetype = icon[:icon.rfind('.')].replace('icon_', '')
+    return 'icon-%s' % context.plone_utils.normalizeString(filetype)
+
 # for now we just do a full search to prove a point, this is not the
 # way to do this in the future, we'd use a in-memory probability based
 # result set.
@@ -164,8 +182,13 @@ else:
             display_title = full_title
 
         full_title = full_title.replace('"', '&quot;')
-        klass = 'contenttype-%s' % ploneUtils.normalizeString(result.portal_type)
-        write('''<a href="%s" title="%s" class="%s">%s</a>''' % (itemUrl, full_title, klass, display_title))
+
+        css_klass = 'contenttype-%s' % ploneUtils.normalizeString(result.portal_type)
+        mime_type_klass = get_mimetype_icon_klass(result)
+        if mime_type_klass:
+            css_klass = mime_type_klass
+
+        write('''<a href="%s" title="%s" class="%s">%s</a>''' % (itemUrl, full_title, css_klass, display_title))
         display_description = safe_unicode(result.Description)
         if len(display_description) > MAX_DESCRIPTION:
             display_description = ''.join((display_description[:MAX_DESCRIPTION], '...'))


### PR DESCRIPTION
<img width="1324" alt="screen shot 2017-12-27 at 15 07 17" src="https://user-images.githubusercontent.com/1637820/34383772-fdb59ac0-eb17-11e7-93b2-de500767d834.png">
<img width="1325" alt="screen shot 2017-12-27 at 15 07 30" src="https://user-images.githubusercontent.com/1637820/34383773-fdd5a680-eb17-11e7-8c75-482aed7defc0.png">

Closes https://github.com/4teamwork/opengever.core/issues/3732