### PR TITLE
Enable edit border for committee members on meeting view.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2017.8.0 (unreleased)
 ---------------------
 
+- Enable edit border for committee members on meeting view. [phgross]
 - Add filename and filesize in bumblebee overlay. [njohner]
 - Fix plonesite removal. [phgross]
 - Fix pre-filling committee group id in edit form. [deiferni]

--- a/opengever/meeting/browser/meetings/meeting.py
+++ b/opengever/meeting/browser/meetings/meeting.py
@@ -228,6 +228,12 @@ class MeetingView(BrowserView):
 
     def __call__(self):
         if is_word_meeting_implementation_enabled():
+            # Enable border to show the zip export action also for
+            # committee members. Because the plone_view's `showEditableBorder`
+            # checks for `ModifyPortalContent`, we have to enable the border
+            # manually.
+            self.request.set('enable_border', True)
+
             return self.word_template()
         else:
             return self.noword_template()

--- a/opengever/meeting/tests/test_meeting_edit.py
+++ b/opengever/meeting/tests/test_meeting_edit.py
@@ -22,9 +22,8 @@ class TestEditMeeting(IntegrationTestCase):
     def test_edit_meeting_not_visibile_to_meeting_(self, browser):
         self.login(self.meeting_user, browser)
         browser.open(self.meeting)
-        # The "Edit" action is not visibile since the complete editbar
-        # is not visible.
-        self.assertFalse(editbar.visible())
+
+        self.assertEquals([], editbar.contentviews())
 
     @browsing
     def test_edit_meeting_metadata(self, browser):

--- a/opengever/meeting/tests/test_meeting_view_word.py
+++ b/opengever/meeting/tests/test_meeting_view_word.py
@@ -175,6 +175,20 @@ class TestWordMeetingView(IntegrationTestCase):
              'reopen_url': self.get_meeting_transition_url('closed-held')},
             view.get_closing_infos())
 
+    @browsing
+    def test_zip_export_action_is_available_for_committee_member(self, browser):
+        self.login(self.meeting_user, browser=browser)
+        browser.open(self.meeting)
+
+        self.assertIn('Export as Zip',
+                      browser.css('#contentActionMenus a').text)
+
+        browser.click_on('Export as Zip')
+        self.assertEquals('application/zip', browser.headers.get('content-type'))
+        self.assertEquals(
+            'inline; filename="9. Sitzung der Rechnungsprufungskommission.zip"',
+            browser.headers.get('content-disposition'))
+
     def get_meeting_transition_url(self, transition_name):
         transition_controller = self.meeting.model.workflow.transition_controller
         return transition_controller.url_for(self.meeting,


### PR DESCRIPTION
Because the plone_view's `showEditableBorder` checks for `ModifyPortalContent`, we have to enable the border manually otherwise the zip export action is not available for committee members.

Closes #3828 

Backport-to: `2017.7-stable`