### PR TITLE
Generalize splitting layers in mtest

### DIFF
--- a/bin/mtest
+++ b/bin/mtest
@@ -2,6 +2,7 @@
 """A concurrent wrapper for timing xmltestrunner tests for opengever.core."""
 from __future__ import print_function
 from argparse import ArgumentParser
+from collections import OrderedDict
 from fnmatch import fnmatch
 from logging import DEBUG
 from logging import Formatter
@@ -20,8 +21,10 @@ from os import walk
 from signal import SIGINT
 from signal import SIGKILL
 from signal import signal
+from subprocess import check_output
 from subprocess import PIPE
 from subprocess import Popen
+from time import sleep
 from time import time
 
 
@@ -35,11 +38,11 @@ def humanize_time(seconds):
     days, hours = divmod(hours, 24)
     weeks, days = divmod(days, 7)
 
-    seconds = int(round(seconds))
-    minutes = int(round(minutes))
-    hours = int(round(hours))
-    days = int(round(days))
-    weeks = int(round(weeks))
+    seconds = int(seconds)
+    minutes = int(minutes)
+    hours = int(hours)
+    days = int(days)
+    weeks = int(weeks)
 
     output = []
 
@@ -79,60 +82,86 @@ def get_concurrency():
     return concurrency
 
 
+def discover_test_layers():
+    logger.info('Discovering test classes')
+
+    test_classes_per_layer = {}
+    current_layer = None
+
+    test_discovery = check_output(
+        ('bin/test', '--list-tests', ),
+        ).decode('UTF-8').splitlines()
+
+    for result in test_discovery:
+        is_layer_header = result.startswith('Listing')
+
+        # We're guaranteed the output format so we can just set this
+        if is_layer_header:
+            current_layer = result.split()[1]
+            test_classes_per_layer[current_layer] = []
+
+        # There are unrelated lines in the beginning we do not want to catch
+        if current_layer and not is_layer_header:
+            test_classes_per_layer[current_layer].append(
+                result.split()[-1].strip('()'),
+                )
+
+    # Prune to unique test classes per layer
+    return {
+        layer: tuple(sorted(set(tests)))
+        for layer, tests in test_classes_per_layer.iteritems()
+        }
+
+
 def create_test_run_params():
-    test_run_params = []
+    test_classes_per_layer = discover_test_layers()
 
-    # Manually ordered per metrification
-    standalone_modules = (
-        'opengever.document',
-        'opengever.base',
-        'opengever.task',
-        'opengever.dossier',
-        'opengever.disposition',
-        )
+    # Ordered by hand for a sensible run order
+    # The order is used below for ordering the test run
+    layers_to_split = OrderedDict()
+    layers_to_split[u'opengever.core.testing.MeetingLayer'] = 1
+    layers_to_split[u'opengever.core.testing.opengever.core:integration'] = 2
+    layers_to_split[u'opengever.core.testing.opengever.core:functional'] = 8
 
-    # Manually ordered per metrification
-    standalone_layers = (
-        'opengever.core.testing.MeetingLayer',
-        'opengever.core.testing.opengever.core:functional:zserver',
-        'opengever.core.testing.opengever.core:integration',
-        )
+    # The common grouping for all the small / quick layers
+    test_run_params = [{
+        'layers': [],
+        'test_classes': [],
+        'batch': '1 / 1',
+        }]
 
-    if CONCURRENCY > 1:
-        module_negation = tuple(
-            ''.join(('!', module, ))
-            for module in standalone_modules
-            )
-
-        layer_negation = tuple(
-            ''.join(('!', layer, ))
-            for layer in standalone_layers
-            )
-
-        for layer in standalone_layers:
-            test_run_params.append({
-                'layers': (layer, ),
-                'modules': None,
+    for layer, test_classes in test_classes_per_layer.iteritems():
+        if layer in layers_to_split:
+            n = layers_to_split.get(layer)
+            test_class_groups = [test_classes[i::n] for i in range(n)]
+            test_class_group_count = len(test_class_groups)
+            for i, test_class_group in enumerate(test_class_groups):
+                test_run_params.append({
+                    'layers': [layer],
+                    'test_classes': test_class_group,
+                    'batch': '{} / {}'.format(i + 1, test_class_group_count)
                 })
+        else:
+            test_run_params[0].get('layers').append(layer)
+            test_run_params[0].get('test_classes').extend(test_classes)
 
-        test_run_params.append({
-            'layers': layer_negation,
-            'modules': module_negation,
-            })
+    # Cement all the grouped layers
+    for i, params in enumerate(test_run_params):
+        params['layers'] = tuple(sorted(set(params['layers'])))
+        params['test_classes'] = tuple(sorted(set(params['test_classes'])))
+        params['port'] = i + 1
 
-        for module in standalone_modules:
-            test_run_params.append({
-                'layers': layer_negation,
-                'modules': (module, ),
-                })
+    # Make sure heavy stuff runs first - add light stuff on top
+    for priority_layer in layers_to_split:
+        for param in test_run_params:
+            if priority_layer in param.get('layers'):
+                test_run_params.insert(
+                    0,
+                    test_run_params.pop(test_run_params.index(param)),
+                    )
 
-    else:
-        test_run_params.append({
-            'layers': None,
-            'modules': None,
-            })
-
-    return tuple(test_run_params)
+    # Cement the test batches - reverse for proper ordering
+    return tuple(reversed(test_run_params))
 
 
 def remove_bytecode_files(directory_path):
@@ -155,25 +184,32 @@ def run_tests(test_run_params):
     """
     params = ['bin/test']
 
-    layers = test_run_params.get('layers', None)
-    modules = test_run_params.get('modules', None)
+    layers = test_run_params.get('layers')
+    test_classes = test_run_params.get('test_classes')
+    batch = test_run_params.get('batch')
+    port = test_run_params.get('port')
 
     if layers:
         for layer in layers:
             params.append('--layer')
             params.append(layer)
 
-    if modules:
-        for module in modules:
-            params.append('-m')
-            params.append(module)
+    if test_classes:
+        for test_class in test_classes:
+            params.append('-t')
+            params.append(test_class)
 
-    logger.debug('Start: %s %s', layers, modules)
+    printable_layers = ', '.join(layers)
 
-    # ZServer tests will be run separately of everything else per layer
-    # separation
+    logger.debug(
+        'Start: %s - %d test classes - batch %s',
+        printable_layers,
+        len(test_classes),
+        batch,
+        )
+
     env = environ.copy()
-    env['ZSERVER_PORT'] = env.get('PORT1', '55000')
+    env['ZSERVER_PORT'] = env.get('PORT{}'.format(port), str(55000 + port))
 
     start = time()
 
@@ -191,52 +227,82 @@ def run_tests(test_run_params):
 
     result = {
         'layers': layers,
-        'modules': modules,
+        'test_classes': test_classes,
+        'batch': batch,
+        'port': env.get('ZSERVER_PORT'),
         'returncode': returncode,
         'runtime': runtime,
         'stderr': stderr,
         'stdout': stdout,
         }
 
-    logger.debug('Done: %s %s in %s', layers, modules, humanize_time(runtime))
-    if DEBUG_MODE:
-        # This explicitly expects UTF-8 as the runtime locale!
-        if stderr:
-            print(stderr.decode('UTF-8'), end='')
-        if returncode:
-            print(stdout.decode('UTF-8'), end='')
+    logger.debug(
+        'Done : %s - %d test classes - batch %s in %s at %.2fs / test class',
+        printable_layers,
+        len(test_classes),
+        batch,
+        humanize_time(runtime),
+        runtime / len(test_classes),
+        )
 
     return result
 
 
 def handle_results(results):
     success = []
+    runtime = 0
 
-    for result in results:
-        # For some reason we get the test run result dict wrapped in a list
-        returncode = result.get('returncode', 1)
-        stderr = result.get('stderr', None)
-        stdout = result.get('stdout', None)
+    while results:
+        sleep(1)
 
-        if not stderr and not returncode:
-            success.append(True)
+        mature_indices = []
+        mature_results = []
 
-        else:
-            success.append(False)
-            # We already printed at test runtime
-            if not DEBUG_MODE:
+        for i, result in enumerate(results):
+            if result.ready():
+                mature_indices.append(i)
+                # The enumeration index can be off for the .pop() otherwise
+                break
+
+        for i in mature_indices:
+            mature_results.append(results.pop(i).get())
+
+        for result in mature_results:
+            # For some reason we get the test run result dict wrapped in a list
+            returncode = result.get('returncode', 1)
+            stderr = result.get('stderr')
+            stdout = result.get('stdout')
+            runtime += result.get('runtime')
+
+            if not stderr and not returncode:
+                success.append(True)
+
+            else:
+                success.append(False)
                 # This explicitly expects UTF-8 as the runtime locale!
+                print('')
+                print('STDERR')
+                print('')
+                print(result.get('layers'))
+                print('')
                 print(stderr.decode('UTF-8'), end='')
+                print('')
                 if returncode:
+                    print('')
+                    print('STDOUT')
+                    print('')
+                    print(result.get('layers'))
+                    print('')
                     print(stdout.decode('UTF-8'), end='')
+                    print('')
+
+    logger.debug(
+        'Aggregate runtime %s.',
+        humanize_time(runtime)
+        )
 
     # Nothing returned False, everything went fine
-    if all(r is True for r in success):
-        logger.info('No failed tests.')
-        exit(0)
-
-    # Fail per default
-    exit(1)
+    return all(r is True for r in success)
 
 
 def main():
@@ -246,34 +312,34 @@ def main():
     #
     # Setting PYTHONDONTWRITEBYTECODE is not enough, because running buildout
     # also already precompiles bytecode for some eggs.
-    logger.info('Cleaning bytecode files.')
+    logger.info('Cleaning bytecode files')
     remove_bytecode_files(OPENGEVER_PATH)
     remove_bytecode_files('src')
 
     test_run_params = create_test_run_params()
-    pool = Pool(CONCURRENCY)
 
     start = time()
 
-    results = tuple(sorted(
-        pool.map(run_tests, test_run_params),
-        key=lambda result: result.get('runtime', 0.0),
-        ))
+    logger.info('Running tests')
+
+    pool = Pool(CONCURRENCY)
+    results = [
+        pool.apply_async(run_tests, (params, ))
+        for params in test_run_params
+        ]
+
+    success = handle_results(results)
 
     pool.close()
     pool.join()
 
-    logger.debug(
-        'Aggregate runtime %s.',
-        humanize_time(sum(
-            i.get('runtime', 0.0)
-            for i in results
-            ))
-        )
-
     logger.debug('Wallclock runtime %s.', humanize_time(time() - start))
 
-    handle_results(results)
+    if success:
+        logger.info('No failed tests.')
+        return True
+
+    return False
 
 
 # Having the __main__ guard is necessary for multiprocessing.Pool().
@@ -345,4 +411,8 @@ if __name__ == '__main__':
     logger.addHandler(memory_handler)
 
     setup_termination()
-    main()
+
+    if main():
+        exit(0)
+
+    exit(1)


### PR DESCRIPTION
Motivation: We're already in a situation where adding new integration tests directly adds to the wallclock runtime. Good work, @njohner, you forced me into this corner again.

* Uses the test discovery output of `bin/test` to discover test classes per test layer
  * We're approaching a point where we could take this approach upstream to `zope.testrunner`
  * Upstream already splits layers onto processes with the `-j` parametre
  * The discovery penalty is about 6s on our CI infrastructure
* Provides clear knobs for tweaking when the reality of layer runtimes changes again
* Removes duplication of output printing in debug and non debug runs
* Improves debug output
* Fixes a rounding bug in `humanize_time()`
* Moves to use async futures returned from the pool
* Polls the futures every 1s for readiness, then pops off and handles the ready ones

With this in, every test improvement most likely lands us wallclock improvements.

With the timings I'm getting from debug runs, it would seem integration tests do not actually on average run significantly faster than functional tests. The main benefit of porting to those is to use a realistic fixture for everything. Seems like the integration testing runtime wins have so far come from rewriting badly written old tests.

Give this a local testrun with `GEVER_CACHE_TEST_DB=false bin/mtest -d` to give yourself room to keep working on the side (the default mode of operation) or `GEVER_CACHE_TEST_DB=false bin/mtest -d -j"$(sysctl -n hw.ncpu)"` for full blast system resource use.

The next hurdle up would be to figure out how to do DB caching when splitting the integration tests up into parallel runs.

Current test timings:

```
 0.065%              opengever.debug               02 seconds
 0.065%             opengever.policy               02 seconds
 0.066%             opengever.sphinx               02 seconds
 0.066%    opengever.policytemplates               02 seconds
 0.175%          opengever.workspace               06 seconds
 0.176%                opengever.api               06 seconds
 0.176%            opengever.testing               06 seconds
 0.177%     opengever.examplecontent               06 seconds
 0.184%            opengever.ech0147               07 seconds
 0.193%         opengever.repository               07 seconds
 0.577%    opengever.officeconnector               21 seconds
 0.639%       opengever.contentstats               23 seconds
 0.668%           opengever.portlets               24 seconds
 0.674%            opengever.sharing               24 seconds
 0.760%       opengever.officeatwork               28 seconds
 0.764%             opengever.bundle               28 seconds
 0.768%            opengever.locking               28 seconds
 0.775%               opengever.core               28 seconds
 0.825%              opengever.setup               30 seconds
 0.890%              opengever.quota               32 seconds
 0.927%     opengever.advancedsearch               34 seconds
 0.939%      opengever.tasktemplates               34 seconds
 1.049%      opengever.usermigration               38 seconds
 1.055%        opengever.globalindex               38 seconds
 1.069%      core:functional:zserver               39 seconds
 1.142%               opengever.ogds               41 seconds
 1.174%           opengever.activity               43 seconds
 1.442%              opengever.latex               52 seconds
 1.442%              opengever.trash               52 seconds
 1.502%            opengever.journal               54 seconds
 1.503%            opengever.private               54 seconds
 1.690%          opengever.bumblebee    01 minutes 01 seconds
 1.709%         opengever.tabbedview    01 minutes 02 seconds
 2.007%            opengever.contact    01 minutes 13 seconds
 2.597%              opengever.inbox    01 minutes 34 seconds
 2.981%            opengever.meeting    01 minutes 48 seconds
 3.383%               opengever.mail    02 minutes 03 seconds
 4.995%            opengever.dossier    03 minutes 01 seconds
 5.519%        opengever.disposition    03 minutes 20 seconds
 6.142%               opengever.base    03 minutes 43 seconds
 6.403%           opengever.document    03 minutes 52 seconds
 7.506%               opengever.task    04 minutes 32 seconds
14.373%                 MeetingLayer    08 minutes 41 seconds
18.767%             core:integration    11 minutes 20 seconds

Total:                01 hours 23 seconds
Wallclock:          20 minutes 40 seconds
```

Current layer timings:

```
 0.216%                           ftw.testing.layer.AnnotationLayer               06 seconds
 0.255%                            ftw.testing.layer.LatexZCMLLayer               07 seconds
 0.276%                             zope.testrunner.layer.UnitTests               08 seconds
 0.290%             opengever.core.testing.opengever:core:memory_db               08 seconds
 0.662%                 opengever.core.testing.DossierTemplateLayer               19 seconds
 0.809%                    opengever.core.testing.OfficeatworkLayer               23 seconds
 1.203%    opengever.core.testing.opengever.core:functional:zserver               35 seconds
 1.937%                   opengever.core.testing.PrivateFolderLayer               56 seconds
 2.662%                       opengever.core.testing.BumblebeeLayer    01 minutes 18 seconds
 4.304%                        opengever.core.testing.ActivityLayer    02 minutes 06 seconds
16.553%                         opengever.core.testing.MeetingLayer    08 minutes 05 seconds
23.121%           opengever.core.testing.opengever.core:integration    11 minutes 18 seconds
47.712%            opengever.core.testing.opengever.core:functional    23 minutes 20 seconds

Total:              48 minutes 55 seconds
Wallclock:          23 minutes 26 seconds
```

Current output on this branch:

```
2018-01-03 16:03:59,562 - mtest - INFO - Cleaning bytecode files
2018-01-03 16:03:59,562 - mtest - INFO - Removing bytecode files from /home/jor/opengever.core/opengever
2018-01-03 16:03:59,609 - mtest - INFO - Removing bytecode files from src
2018-01-03 16:03:59,611 - mtest - INFO - Discovering test classes
2018-01-03 16:04:05,808 - mtest - INFO - Running tests
2018-01-03 16:04:05,816 - mtest - DEBUG - Start: opengever.core.testing.MeetingLayer - 29 test classes - batch 1 / 1
2018-01-03 16:04:05,816 - mtest - DEBUG - Start: ftw.testing.layer.AnnotationLayer, ftw.testing.layer.LatexZCMLLayer, opengever.core.testing.ActivityLayer, opengever.core.testing.BumblebeeLayer, opengever.core.testing.DossierTemplateLayer, opengever.core.testing.OfficeatworkLayer, opengever.core.testing.PrivateFolderLayer, opengever.core.testing.opengever.core:functional:zserver, opengever.core.testing.opengever:core:memory_db, zope.testrunner.layer.UnitTests - 195 test classes - batch 1 / 1
2018-01-03 16:04:05,816 - mtest - DEBUG - Start: opengever.core.testing.opengever.core:integration - 108 test classes - batch 1 / 2
2018-01-03 16:04:05,816 - mtest - DEBUG - Start: opengever.core.testing.opengever.core:integration - 108 test classes - batch 2 / 2
2018-01-03 16:04:05,816 - mtest - DEBUG - Start: opengever.core.testing.opengever.core:functional - 56 test classes - batch 1 / 8
2018-01-03 16:08:02,955 - mtest - DEBUG - Done : opengever.core.testing.opengever.core:functional - 56 test classes - batch 1 / 8 in 03 minutes 57 seconds at 4.23s / test class
2018-01-03 16:08:02,955 - mtest - DEBUG - Start: opengever.core.testing.opengever.core:functional - 55 test classes - batch 2 / 8
2018-01-03 16:09:54,216 - mtest - DEBUG - Done : ftw.testing.layer.AnnotationLayer, ftw.testing.layer.LatexZCMLLayer, opengever.core.testing.ActivityLayer, opengever.core.testing.BumblebeeLayer, opengever.core.testing.DossierTemplateLayer, opengever.core.testing.OfficeatworkLayer, opengever.core.testing.PrivateFolderLayer, opengever.core.testing.opengever.core:functional:zserver, opengever.core.testing.opengever:core:memory_db, zope.testrunner.layer.UnitTests - 195 test classes - batch 1 / 1 in 05 minutes 48 seconds at 1.79s / test class
2018-01-03 16:09:54,216 - mtest - DEBUG - Start: opengever.core.testing.opengever.core:functional - 55 test classes - batch 3 / 8
2018-01-03 16:11:26,271 - mtest - DEBUG - Done : opengever.core.testing.opengever.core:integration - 108 test classes - batch 2 / 2 in 07 minutes 20 seconds at 4.08s / test class
2018-01-03 16:11:26,272 - mtest - DEBUG - Start: opengever.core.testing.opengever.core:functional - 55 test classes - batch 4 / 8
2018-01-03 16:11:50,658 - mtest - DEBUG - Done : opengever.core.testing.opengever.core:functional - 55 test classes - batch 2 / 8 in 03 minutes 48 seconds at 4.14s / test class
2018-01-03 16:11:50,658 - mtest - DEBUG - Start: opengever.core.testing.opengever.core:functional - 55 test classes - batch 5 / 8
2018-01-03 16:12:12,345 - mtest - DEBUG - Done : opengever.core.testing.opengever.core:integration - 108 test classes - batch 1 / 2 in 08 minutes 07 seconds at 4.50s / test class
2018-01-03 16:12:12,345 - mtest - DEBUG - Start: opengever.core.testing.opengever.core:functional - 55 test classes - batch 6 / 8
2018-01-03 16:12:55,542 - mtest - DEBUG - Done : opengever.core.testing.opengever.core:functional - 55 test classes - batch 3 / 8 in 03 minutes 01 seconds at 3.30s / test class
2018-01-03 16:12:55,542 - mtest - DEBUG - Start: opengever.core.testing.opengever.core:functional - 55 test classes - batch 7 / 8
2018-01-03 16:12:57,982 - mtest - DEBUG - Done : opengever.core.testing.MeetingLayer - 29 test classes - batch 1 / 1 in 08 minutes 52 seconds at 18.35s / test class
2018-01-03 16:12:57,983 - mtest - DEBUG - Start: opengever.core.testing.opengever.core:functional - 55 test classes - batch 8 / 8
2018-01-03 16:15:55,379 - mtest - DEBUG - Done : opengever.core.testing.opengever.core:functional - 55 test classes - batch 4 / 8 in 04 minutes 29 seconds at 4.89s / test class
2018-01-03 16:16:00,848 - mtest - DEBUG - Done : opengever.core.testing.opengever.core:functional - 55 test classes - batch 5 / 8 in 04 minutes 10 seconds at 4.55s / test class
2018-01-03 16:16:11,938 - mtest - DEBUG - Done : opengever.core.testing.opengever.core:functional - 55 test classes - batch 8 / 8 in 03 minutes 14 seconds at 3.53s / test class
2018-01-03 16:16:24,362 - mtest - DEBUG - Done : opengever.core.testing.opengever.core:functional - 55 test classes - batch 6 / 8 in 04 minutes 12 seconds at 4.58s / test class
2018-01-03 16:16:54,375 - mtest - DEBUG - Done : opengever.core.testing.opengever.core:functional - 55 test classes - batch 7 / 8 in 03 minutes 59 seconds at 4.34s / test class
2018-01-03 16:16:54,583 - mtest - DEBUG - Aggregate runtime 01 hours 58 seconds.
2018-01-03 16:16:54,583 - mtest - DEBUG - Wallclock runtime 12 minutes 49 seconds.
2018-01-03 16:16:54,607 - mtest - INFO - No failed tests.
```

Anything and everything off the `MeetingLayer` is a direct runtime win.
  
  