### PR TITLE
Fix notification counter, count only badge notifications.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ---------------------
 
 - Add partial reindex optimization for trashing and untrashing objects. [elioschmutz]
+- Fix notification counter, count only badge notifications. [phgross]
 - Add filename and filesize in bumblebee overlay. [njohner]
 - Fix plonesite removal. [phgross]
 - Fix required input validation for the recipients field, when delegating a task. [phgross]

--- a/opengever/activity/center.py
+++ b/opengever/activity/center.py
@@ -137,8 +137,10 @@ class NotificationCenter(object):
             Notification.activity).order_by(desc(Activity.created))
         return query.limit(limit).all()
 
-    def count_users_unread_notifications(self, userid):
+    def count_users_unread_notifications(self, userid, badge_only=False):
         query = Notification.query.by_user(userid)
+        if badge_only:
+            query = query.filter(Notification.is_badge.is_(True))
         return query.filter(Notification.is_read.is_(False)).count()
 
     def mark_notification_as_read(self, notification_id):
@@ -247,9 +249,9 @@ class PloneNotificationCenter(NotificationCenter):
         oguid = self._get_oguid_for(obj)
         return super(PloneNotificationCenter, self).fetch_resource(oguid)
 
-    def count_current_users_unread_notifications(self):
+    def count_current_users_unread_notifications(self, badge_only=False):
         return super(PloneNotificationCenter, self).count_users_unread_notifications(
-            api.user.get_current().getId())
+            api.user.get_current().getId(), badge_only)
 
     def get_current_users_notifications(self, only_unread=False, limit=None):
         return super(PloneNotificationCenter, self).get_users_notifications(

--- a/opengever/activity/tests/test_notification_viewlet.py
+++ b/opengever/activity/tests/test_notification_viewlet.py
@@ -63,6 +63,20 @@ class TestNotificationViewlet(FunctionalTestCase):
             browser.css('#portal-notifications .unread_number').first.text)
 
     @browsing
+    def test_number_of_unread_messages_counts_only_badge_notifications(self, browser):
+        create(Builder('notification')
+               .watcher(self.test_watcher)
+               .having(activity=self.activity_a))
+        create(Builder('notification')
+               .watcher(self.test_watcher)
+               .having(activity=self.activity_b, is_badge=False))
+
+        browser.login().open()
+        self.assertEquals(
+            '1',
+            browser.css('#portal-notifications .unread_number').first.text)
+
+    @browsing
     def test_number_of_unread_messages_is_not_display_when_its_0(self, browser):
         browser.login().open()
         self.assertEquals([], browser.css('#portal-notifications .num-unread'))

--- a/opengever/activity/viewlets/notification.py
+++ b/opengever/activity/viewlets/notification.py
@@ -19,7 +19,8 @@ class NotificationViewlet(common.ViewletBase):
         return is_activity_feature_enabled()
 
     def num_unread(self):
-        return notification_center().count_current_users_unread_notifications()
+        center = notification_center()
+        return center.count_current_users_unread_notifications(badge_only=True)
 
     @property
     def read_url(self):


### PR DESCRIPTION
Since the the personal settings feature, the badge icon is a separate channel. But the number getter in the viewlet counts all notifications not only the badge notifications wich leads in wrong/confusing unread numbers. This PR fixes #3842.