### PR TITLE
Trigger SQL task synchronisation when changing task state.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2017.8.0 (unreleased)
 ---------------------
 
+- Trigger SQL task synchronisation when changing task state. [phgross]
 - Change msg2mime transform to use msgconvert executable from $PATH instead of shipping our own wrapper script. [lgraf]
 - Add partial reindex optimization for trashing and untrashing objects. [elioschmutz]
 - Fix notification counter, count only badge notifications. [phgross]

--- a/opengever/task/util.py
+++ b/opengever/task/util.py
@@ -1,4 +1,5 @@
 from collective.elephantvocabulary import wrap_vocabulary
+from opengever.globalindex.handlers.task import TaskSqlSyncer
 from opengever.ogds.base.actor import ActorLookup
 from opengever.ogds.models.team import Team
 from opengever.task import _
@@ -159,6 +160,7 @@ def change_task_workflow_state(task, transition, **kwargs):
     response = add_simple_response(task, transition=transition, **kwargs)
 
     wftool.doActionFor(task, transition)
+    TaskSqlSyncer(task, None).sync()
 
     after = wftool.getInfoFor(task, 'review_state')
     after = wftool.getTitleForStateOnType(after, task.Type())


### PR DESCRIPTION
This fixes an issue when completing a task (in-progress to resolved)
the state is not updated in the globalindex.