### PR TITLE
Sort query only if column exists

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -47,6 +47,7 @@ Changelog
 - Fix broken advanced search js initialization. [deiferni]
 - Tidy up XML files in default profile [raphael-s]
 - Use index to sort the committees by title. [tarnap]
+- Sort tabbed view by column only if column exists. [tarnap]
 - Trigger SQL task synchronisation when changing task state. [phgross]
 - Change msg2mime transform to use msgconvert executable from $PATH instead of shipping our own wrapper script. [lgraf]
 - Add action to revive bumblebee previews. [elioschmutz]

--- a/opengever/tabbedview/tests/test_sorting.py
+++ b/opengever/tabbedview/tests/test_sorting.py
@@ -1,0 +1,47 @@
+from opengever.base.model import create_session
+from opengever.tabbedview.sqlsource import sort_column_exists
+from opengever.testing import FunctionalTestCase
+from sqlalchemy import Column
+from sqlalchemy import ForeignKey
+from sqlalchemy import Integer
+from sqlalchemy import String
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import aliased
+from sqlalchemy.orm import relationship
+
+Base = declarative_base()
+
+
+class Something(Base):
+    __tablename__ = 'something'
+
+    some_id = Column(Integer, primary_key=True)
+    some_string = Column(String)
+    some_entity = Column(Integer, ForeignKey('somethong.some_id'))
+
+
+class Somethong(Base):
+    __tablename__ = 'somethong'
+
+    some_id = Column(Integer, primary_key=True)
+    some_thing = relationship('Something', backref='some_aliases')
+
+
+class TestSortColumnExists(FunctionalTestCase):
+
+    def setUp(self):
+        super(TestSortColumnExists, self).setUp()
+        self.session = create_session()
+
+    def test_sorting_by_column(self):
+        query = self.session.query(Something)
+        self.assertTrue(sort_column_exists(query, 'some_string'))
+
+    def test_sorting_by_entity(self):
+        query = self.session.query(Something)
+        self.assertTrue(sort_column_exists(query, 'some_entity'))
+
+    def test_sorting_by_alias(self):
+        query = self.session.query(Something,
+                                   aliased(Something, name='some_alias'))
+        self.assertTrue(sort_column_exists(query, 'some_alias'))

--- a/opengever/tabbedview/tests/test_sqlsource.py
+++ b/opengever/tabbedview/tests/test_sqlsource.py
@@ -70,6 +70,20 @@ class TestSQLAlchemySortIndexes(FunctionalTestCase):
         self.assertIn('ORDER BY memberships.member_id',
                       str(source.build_query()))
 
+    def test_no_sorting_if_column_does_not_exist(self):
+        config = DummySQLTableSourceConfig(
+            self.portal,
+            self.request,
+            sql_indexes={'member_id': Membership.member_id})
+        config.sort_on = 'this_column_does_not_exist'
+        source = SqlTableSource(config, self.request)
+
+        query = source.build_query()
+        sorted_query = source.extend_query_with_ordering(query)
+
+        self.assertNotIn(
+            'ORDER BY this_column_does_not_exist',
+            str(sorted_query))
 
 class TestTextFilter(FunctionalTestCase):
 


### PR DESCRIPTION
The tabbed view allows to configure the sorting of tables for each user.
If after a migration the column the user used to sort the data is not available anymore, the server responds with an error.
This prevents sorting by unavailable columns.

Resolves #3468