### PR TITLE
Add index to sort committees by title

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -18,6 +18,7 @@ Changelog
 - OGIP 17: Introduce workspace specific sources used in Tasks [mathias.leimgruber]
 - Fix broken advanced search js initialization. [deiferni]
 - Tidy up XML files in default profile [raphael-s]
+- Use index to sort the committees by title. [tarnap]
 - Trigger SQL task synchronisation when changing task state. [phgross]
 - Change msg2mime transform to use msgconvert executable from $PATH instead of shipping our own wrapper script. [lgraf]
 - Add action to revive bumblebee previews. [elioschmutz]

--- a/opengever/core/upgrades/20180109091110_add_index_to_committee_title/upgrade.py
+++ b/opengever/core/upgrades/20180109091110_add_index_to_committee_title/upgrade.py
@@ -1,0 +1,12 @@
+from opengever.core.upgrade import SchemaMigration
+
+
+class AddCommitteeTitleIndex(SchemaMigration):
+    """Add index to committee title.
+    """
+
+    def migrate(self):
+        self.op.create_index(
+            'ix_committee_title',
+            'committees',
+            ['title'])

--- a/opengever/meeting/model/committee.py
+++ b/opengever/meeting/model/committee.py
@@ -50,7 +50,7 @@ class Committee(Base):
     admin_unit_id = Column(String(UNIT_ID_LENGTH), nullable=False)
     int_id = Column(Integer, nullable=False)
     oguid = composite(Oguid, admin_unit_id, int_id)
-    title = Column(String(256))
+    title = Column(String(256), index=True)
     physical_path = Column(String(256), nullable=False)
     workflow_state = Column(String(WORKFLOW_STATE_LENGTH),
                             nullable=False,


### PR DESCRIPTION
The select statement explained (before adding the index):

```
opengever.kern=# EXPLAIN SELECT committees.id AS committees_id, committees.group_id AS committees_group_id, committees.admin_unit_id AS committees_admin_unit_id, committees.int_id AS committees_int_id, committees.title AS committees_title, committees.physical_path AS committees_physical_path, committees.workflow_state AS committees_workflow_state FROM committees ORDER BY committees.title;
                             QUERY PLAN                              
---------------------------------------------------------------------
 Sort  (cost=11.04..11.11 rows=30 width=2150)
   Sort Key: title
   ->  Seq Scan on committees  (cost=0.00..10.30 rows=30 width=2150)
(3 rows)
```

The select statement explained (after running the upgrade step):

```
opengever.kern=# EXPLAIN SELECT committees.id AS committees_id, committees.group_id AS committees_group_id, committees.admin_unit_id AS committees_admin_unit_id, committees.int_id AS committees_int_id, committees.title AS committees_title, committees.physical_path AS committees_physical_path, committees.workflow_state AS committees_workflow_state 
FROM committees ORDER BY committees.title;
                            QUERY PLAN                             
-------------------------------------------------------------------
 Sort  (cost=1.05..1.06 rows=3 width=2150)
   Sort Key: title
   ->  Seq Scan on committees  (cost=0.00..1.03 rows=3 width=2150)
(3 rows)
```

Resolves #3559