### PR TITLE
Fix listing members of an empty group

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2017.8.0 (unreleased)
 ---------------------
 
+- Fix listing the members of an empty group. [tarnap]
 - Trigger SQL task synchronisation when changing task state. [phgross]
 - Change msg2mime transform to use msgconvert executable from $PATH instead of shipping our own wrapper script. [lgraf]
 - Add partial reindex optimization for trashing and untrashing objects. [elioschmutz]

--- a/opengever/base/browser/list_groupmembers.py
+++ b/opengever/base/browser/list_groupmembers.py
@@ -15,9 +15,10 @@ class ListGroupMembers(BrowserView):
             return 'no group id'
 
         group = ogds_service().fetch_group(self.group_id)
-        self.active = group.active
+        self.active = getattr(group, 'active', None)
 
-        actors = [Actor.user(user.userid) for user in group.users]
+        actors = [Actor.user(user.userid)
+                  for user in getattr(group, 'users', [])]
         actors.sort(key=lambda actor: actor.get_label())
         self.members = [each.get_link() for each in actors]
 

--- a/opengever/base/tests/test_list_groupmembers.py
+++ b/opengever/base/tests/test_list_groupmembers.py
@@ -31,3 +31,14 @@ class TestResolveOGUIDView(FunctionalTestCase):
             [each.normalized_outerHTML for each in
              browser.css('.member_listing li a')]
         )
+
+    @browsing
+    def test_list_groupmembers_view_with_empty_group(self, browser):
+        group = create(Builder('ogds_group')
+                       .having(groupid='empty_group'))
+        browser.login().open(view='list_groupmembers',
+                             data={'group': group.groupid})
+        self.assertEqual(
+            'There are no members in this group.',
+            browser.css('p').text[0],
+        )


### PR DESCRIPTION
Before:
![empty_group_bug](https://user-images.githubusercontent.com/194114/34713730-5c49752a-f527-11e7-9a6e-b8b809e33cfd.png)

After:
![empty_group_fixed](https://user-images.githubusercontent.com/194114/34713739-61375908-f527-11e7-9e1a-a757ccbe3cc6.png)

Resolves #3605