### PR TITLE
Display all LDAP groups for the committee.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ---------------------
 
 - Upgrade docxcompose version pinning. [tarnap]
+- Fix listing groups for committees. [deiferni]
 - Fix listing the members of an empty group. [tarnap]
 - Trigger SQL task synchronisation when changing task state. [phgross]
 - Change msg2mime transform to use msgconvert executable from $PATH instead of shipping our own wrapper script. [lgraf]

--- a/opengever/meeting/committee.py
+++ b/opengever/meeting/committee.py
@@ -36,14 +36,10 @@ from zope.schema.vocabulary import SimpleVocabulary
 @provider(IContextSourceBinder)
 def get_group_vocabulary(context):
     service = ogds_service()
-    userid = api.user.get_current().getId()
     normalize = getUtility(IIDNormalizer).normalize
     terms = []
 
-    if api.user.has_permission('cmf.ManagePortal', obj=context):
-        groups = service.all_groups()
-    else:
-        groups = service.assigned_groups(userid)
+    groups = service.all_groups()
 
     for group in groups:
         terms.append(SimpleTerm(

--- a/opengever/meeting/tests/test_committee_roles.py
+++ b/opengever/meeting/tests/test_committee_roles.py
@@ -3,8 +3,7 @@ from ftw.builder import create
 from opengever.meeting.committee import get_group_vocabulary
 from opengever.meeting.committeeroles import CommitteeRoles
 from opengever.testing import FunctionalTestCase
-from plone.app.testing import login
-from plone.app.testing import setRoles
+from opengever.testing import IntegrationTestCase
 
 
 class TestCommitteeTabs(FunctionalTestCase):
@@ -51,48 +50,17 @@ class TestCommitteeTabs(FunctionalTestCase):
             self.assertTrue(isinstance(principal, str), 'Not a byte string')
 
 
-class TestCommitteeGroupsVocabulary(FunctionalTestCase):
+class TestCommitteeGroupsVocabulary(IntegrationTestCase):
 
-    def test_return_empty_vocabulary_if_user_is_not_assigned_to_any_group(self):
-        container = create(Builder('committee_container'))
+    def test_return_all_groups(self):
+        self.login(self.committee_responsible)
 
-        create(Builder('user').with_userid('hugo.boss'))
-        create(Builder('ogds_user').id('hugo.boss'))
-
-        login(self.layer['portal'], 'hugo.boss')
-
-        self.assertEqual(
-            [],
-            [term for term in get_group_vocabulary(container)])
-
-    def test_return_only_groups_where_the_user_is_assigned(self):
-        container = create(Builder('committee_container'))
-
-        create(Builder('user').with_userid('hugo.boss'))
-        ogds_user = create(Builder('ogds_user').id('hugo.boss'))
-
-        create(Builder('ogds_group').id('foo').having(users=[ogds_user, ]))
-        create(Builder('ogds_group').id('bar'))
-
-        login(self.layer['portal'], 'hugo.boss')
-
-        self.assertEqual(
-            [u'foo'],
-            [term.value for term in get_group_vocabulary(container)])
-
-    def test_return_all_groups_if_the_user_has_manager_role(self):
-        container = create(Builder('committee_container'))
-
-        create(Builder('user').with_userid('hugo.boss'))
-        ogds_user = create(Builder('ogds_user').id('hugo.boss'))
-
-        create(Builder('ogds_group').id('foo').having(users=[ogds_user, ]))
-        create(Builder('ogds_group').id('bar'))
-
-        setRoles(self.layer['portal'], 'hugo.boss', ['Manager'])
-
-        login(self.layer['portal'], 'hugo.boss')
-
-        self.assertEqual(
-            [u'client1_users', u'client1_inbox_users', u'foo', u'bar'],
-            [term.value for term in get_group_vocabulary(container)])
+        self.assertItemsEqual(
+            [u'fa_users',
+             u'fa_inbox_users',
+             u'projekt_a',
+             u'projekt_b',
+             u'committee_rpk_group',
+             u'committee_ver_group'],
+            [term.value for term in
+             get_group_vocabulary(self.committee_container)])


### PR DESCRIPTION
Viewing and editing the committee are now not coupled to only the group selectable in the committee any more. We should always display all groups since it is valid that users that are not in the group can edit the committee (i.e. when they have the CommitteeResponsible role).

This fixes an issue where the group would always be changed to another one since the `CommitteeResponsible` was not in said group but still able to edit the committee.

Needs backport to `2017.7-stable`.