### PR TITLE
Fix broken advanced search js initialization.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2017.8.0 (unreleased)
 ---------------------
 
+- Fix broken advanced search js initialization. [deiferni]
 - Change msg2mime transform to use msgconvert executable from $PATH instead of shipping our own wrapper script. [lgraf]
 - Add partial reindex optimization for trashing and untrashing objects. [elioschmutz]
 - OGIP 17: Implement sequence_number and NameFromTitle behavior for Workspace. [mathias.leimgruber]

--- a/opengever/advancedsearch/resources/advanced_search.js
+++ b/opengever/advancedsearch/resources/advanced_search.js
@@ -17,7 +17,11 @@ $(function(){
     // show current
     $('.'+selected).each(function(){
       $(this).parents('.field:first').show();
-      ftwKeywordWidgetInitSelect2($('.keyword-widget:visible'));
+
+    $('.keyword-widget:visible').each(function(index, widget){
+        window.ftwKeywordWidget.initWidget($(widget));
+    });
+
     });
 
     //hide others


### PR DESCRIPTION
Catch up with changes in https://github.com/4teamwork/ftw.keywordwidget/pull/24.

The function called in `opengever.core` no longer exists. We change widget initialization to the way it is done in `ftw.keywordwidget` now.

Fixes #3859.