### PR TITLE
OGIP 17: Implement AllUsersInboxesAndTeamsSource also for Workspace.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2017.8.0 (unreleased)
 ---------------------
 
+- OGIP 17: Introduce workspace specific sources used in Tasks [mathias.leimgruber]
 - Fix broken advanced search js initialization. [deiferni]
 - Change msg2mime transform to use msgconvert executable from $PATH instead of shipping our own wrapper script. [lgraf]
 - Add partial reindex optimization for trashing and untrashing objects. [elioschmutz]

--- a/opengever/workspace/__init__.py
+++ b/opengever/workspace/__init__.py
@@ -1,4 +1,3 @@
-from opengever.workspace.interfaces import IWorkspaceSettings
 from plone import api
 from zope.i18nmessageid import MessageFactory
 
@@ -6,5 +5,6 @@ _ = MessageFactory('opengever.workspace')
 
 
 def is_workspace_feature_enabled():
+    from opengever.workspace.interfaces import IWorkspaceSettings
     return api.portal.get_registry_record(
         'is_feature_enabled', interface=IWorkspaceSettings)

--- a/opengever/workspace/tests/test_workspace_sources.py
+++ b/opengever/workspace/tests/test_workspace_sources.py
@@ -1,0 +1,111 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from opengever.ogds.base.utils import get_current_admin_unit
+from opengever.ogds.base.utils import get_current_org_unit
+from opengever.ogds.base.interfaces import IAdminUnitConfiguration
+from opengever.ogds.base.sources import AllEmailContactsAndUsersSource
+from opengever.ogds.base.sources import AllGroupsSource
+from opengever.ogds.base.sources import AllOrgUnitsSource
+from opengever.ogds.base.sources import AllUsersAndGroupsSource
+from opengever.ogds.base.sources import AllUsersInboxesAndTeamsSource
+from opengever.ogds.base.sources import AllUsersSource
+from opengever.ogds.base.sources import AssignedUsersSource
+from opengever.ogds.base.sources import ContactsSource
+from opengever.ogds.base.sources import UsersContactsInboxesSource
+from opengever.ogds.models.group import Group
+from opengever.testing import IntegrationTestCase
+from opengever.workspace.utils import get_workspace_user_ids
+from opengever.workspace.utils import is_within_workspace
+from plone.app.testing import TEST_USER_ID
+
+
+class TestAllUsersInboxesAndTeamsSourceForWorkspace(IntegrationTestCase):
+
+    def setUp(self):
+        super(TestAllUsersInboxesAndTeamsSourceForWorkspace, self).setUp()
+        self.login(self.administrator)
+        self.org_unit2 = create(Builder('org_unit')
+                                .id('unit2')
+                                .having(title=u'Finanzdirektion',
+                                        admin_unit=get_current_admin_unit())
+                                .with_default_groups())
+
+        self.john = create(Builder('ogds_user')
+                           .id('john')
+                           .having(firstname=u'John', lastname=u'Doe')
+                           .assign_to_org_units([get_current_org_unit()]))
+        self.hugo = create(Builder('ogds_user')
+                           .id('hugo')
+                           .having(firstname=u'Hugo', lastname=u'Boss')
+                           .assign_to_org_units([get_current_org_unit()]))
+        self.hans = create(Builder('ogds_user')
+                           .id('hans')
+                           .having(firstname=u'Hans', lastname=u'Peter')
+                           .assign_to_org_units([get_current_org_unit(),
+                                                 self.org_unit2]))
+        self.reto = create(Builder('ogds_user')
+                           .id('reto')
+                           .having(firstname=u'Reto', lastname=u'Rageto')
+                           .assign_to_org_units([self.org_unit2]))
+
+    def set_permissions_on_workspace(self):
+        self.workspace.manage_permission('View', roles=['Contributor', ])
+        self.workspace.manage_setLocalRoles(self.john.userid, ['Contributor'])
+        self.workspace.manage_setLocalRoles(self.hugo.userid, ['Contributor'])
+
+    def test_is_within_workspace(self):
+        self.assertFalse(is_within_workspace(self.dossier),
+                         'Dossier is not within workspace')
+        self.assertFalse(is_within_workspace(self.workspace_root),
+                         'WorkspaceRoot is not within workspace')
+
+        self.assertTrue(is_within_workspace(self.workspace),
+                        'Workspace is within Workspace')
+
+        doc_in_workspace = create(Builder('document').within(self.workspace))
+        self.assertTrue(is_within_workspace(doc_in_workspace),
+                        'Document in workspace is within workspace')
+
+    def test_get_workspace_user_ids(self):
+        self.assertFalse(get_workspace_user_ids(self.workspace),
+                         'Expect ids, since there are no local roles')
+
+        self.set_permissions_on_workspace()
+        self.assertEquals([self.john.userid, self.hugo.userid],
+                          get_workspace_user_ids(self.workspace))
+
+    def test_only_local_roles_with_view_permission_are_selectable(self):
+        source = AllUsersInboxesAndTeamsSource(self.workspace)
+        self.assertNotIn(u'fa:john', source)
+        self.assertNotIn(u'fa:hugo', source)
+        self.assertNotIn(u'fa:hans', source)
+        self.assertNotIn(u'unit2:hans', source)
+        self.assertNotIn(u'unit2:reto', source)
+        self.assertNotIn(u'unit2:john', source)
+
+    def test_local_roles_from_workspace_are_in_source(self):
+        self.set_permissions_on_workspace()
+        source = AllUsersInboxesAndTeamsSource(self.workspace)
+
+        self.assertIn(u'fa:john', source)
+        self.assertIn(u'fa:hugo', source)
+        self.assertIn(u'unit2:john', source)
+        self.assertNotIn(u'fa:hans', source)
+        self.assertNotIn(u'unit2:hans', source)
+        self.assertNotIn(u'unit2:reto', source)
+
+    def test_search_for_users_within_workspace(self):
+        source = AllUsersInboxesAndTeamsSource(self.workspace)
+        result = source.search('John')
+
+        self.assertFalse(
+            result,
+            'Expect no result, since there are no permissions set.')
+
+        self.set_permissions_on_workspace()
+
+        result = source.search('John')
+        self.assertEqual(1, len(result), 'Expect one result. only John')
+
+        result = source.search('Hugo')
+        self.assertEqual(1, len(result), 'Expect one result. only John')

--- a/opengever/workspace/utils.py
+++ b/opengever/workspace/utils.py
@@ -1,0 +1,56 @@
+from AccessControl.interfaces import IRoleManager
+from AccessControl.Permission import Permission
+from Acquisition import aq_base
+from Acquisition import aq_chain
+from operator import itemgetter
+from plone import api
+
+
+def roles_of_permission(context, permission):
+    """Return all roles which have the given permission
+    on the current context."""
+
+    role_manager = IRoleManager(context)
+    for p in role_manager.ac_inherited_permissions(1):
+        name, value = p[:2]
+        if name == permission:
+            p = Permission(name, value, role_manager)
+            roles = p.getRoles()
+            return roles
+
+
+def is_within_workspace(context):
+    """ Checks, if the content is a workspace or is within the workspace.
+    """
+    # Avoid circular imports
+    from opengever.workspace.interfaces import IWorkspace
+    return bool(filter(IWorkspace.providedBy, aq_chain(context)))
+
+
+def get_workspace_user_ids(context):
+    """ Walks up the Acquisition chain and collects all userids assigned
+    to a role with the View permission.
+    """
+    if not is_within_workspace(context):
+        return []
+
+    users = set([])
+    allowed_roles_to_view = roles_of_permission(context, 'View')
+    portal = api.portal.get()
+
+    def is_valid_userid(*args):
+        user, roles, role_type, name = args
+        return role_type == u'user' and set(roles) & set(allowed_roles_to_view)
+
+    for content in aq_chain(context):
+        if aq_base(content) == aq_base(portal):
+            break
+        userroles = portal.acl_users._getLocalRolesForDisplay(content)
+        users = users.union(set(
+            map(itemgetter(0),
+                filter(lambda args: is_valid_userid(*args), userroles))))
+
+        if getattr(aq_base(context), '__ac_local_roles_block__', None):
+            break
+
+    return list(users)


### PR DESCRIPTION
- Only users with a role having the View permission are selectable.
The implementation is basically taken from my.teamraum.com

1. Get all Roles with View permission
2. Walk up the aq_chain and get all userids with having the local roles having the view permission.
3. Extend the sources queries with the collected userids if the Task is added in a Workspace.

I tried to avoid filtering for empty list, since this may have a performance impact.