### PR TITLE
Testing cache: add verbosity option for debugging.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -843,6 +843,14 @@ You can manually remove / rebuild the caches:
 
 This feature is disabled on the CI server.
 
+When the environment variable ``GEVER_CACHE_VERBOSE`` is set to ``true``,
+a list of modified files will be printed whenever a cachekey is invalidated.
+This can be useful to debug problems with the fixture cache:
+
+.. code:: sh
+
+    GEVER_CACHE_VERBOSE=true bin/test-cached -m opengever.dossier.tests.test_activate
+
 
 Builder API
 ~~~~~~~~~~~

--- a/opengever/core/cached_testing.py
+++ b/opengever/core/cached_testing.py
@@ -23,6 +23,8 @@ import transaction
 
 CACHE_ENABLED = (os.environ.get('GEVER_CACHE_TEST_DB', '')
                  .lower().strip() == 'true')
+CACHE_VERBOSE = (os.environ.get('GEVER_CACHE_VERBOSE', '')
+                 .lower().strip() == 'true')
 BUILDOUT_DIR = Path(__file__).joinpath('..', '..', '..').abspath()
 
 
@@ -190,7 +192,7 @@ class DBCacheManager(object):
                 return stack
         return None
 
-    def _is_stack_valid_to_load(self, stack):
+    def _is_stack_valid_to_load(self, stack, verbose=CACHE_VERBOSE):
         """A cache is valid when
         - the cache exists
         - the parent cache is valid, when there is one
@@ -200,10 +202,22 @@ class DBCacheManager(object):
             return False
 
         if stack.get('extends') and \
-           not self._is_stack_valid_to_load(stack['extends']):
+           not self._is_stack_valid_to_load(stack['extends'], verbose=False):
             return False
 
-        return stack['cachekey'] == self._load_cachekey(stack)
+        previous_cachekey = self._load_cachekey(stack)
+        if verbose and stack['cachekey'] != previous_cachekey:
+            print ''
+            print '-' * 40
+            print 'Cachekey changes in', stack['id']
+
+            for path in sorted(set(stack['cachekey']) | set(previous_cachekey)):
+                if stack['cachekey'].get(path) != previous_cachekey.get(path):
+                    print '-', Path(path).relpath(BUILDOUT_DIR)
+
+            print '-' * 40
+
+        return stack['cachekey'] == previous_cachekey
 
     def _dump_zodb_to(self, zodbDB, stack):
         """Dump the zodbDB into a data.fs by constructing a FileStorage database


### PR DESCRIPTION
The new environment variable ``GEVER_CACHE_VERBOSE`` causes a list of modified files to be printed when a testing cache stack's cachekey is considered invalid. This can be useful for debugging the test caching.

<img width="715" alt="bildschirmfoto 2018-01-16 um 15 23 13" src="https://user-images.githubusercontent.com/7469/34993855-f4822418-fad1-11e7-9868-604e71eb96e3.png">
