### PR TITLE
Use excerpt header template as master, if available.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -11,6 +11,7 @@ Changelog
 - Add tasks tab to repository folder. [jone]
 - Add documents tab to repository folder. [jone]
 - OGIP 17: Implement invitation storage for workspace invitations. [mathias.leimgruber]
+- Use excerpt header template as excerpt master document. [deiferni]
 - Add DocProperty ogg.document.version_number.  [njohner]
 - OGIP 17: Add workspace workflows and add workspace support to document workflow. [jone]
 - OGIP 17: Introduce workspace specific sources used in Tasks [mathias.leimgruber]


### PR DESCRIPTION
If no excerpt header template is available, fall back to agenda item`s document as master.

This fixes an issue with headings not taken from the correct file in the merged word documents.

Needs backport to `2017.7`.