### PR TITLE
Task globalindex: set the created time in sql from the Plone object.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2017.8.0 (unreleased)
 ---------------------
 
+- Task globalindex: set the created time in sql from the Plone object. [jone]
 - Add tasks tab to repository folder. [jone]
 - Add documents tab to repository folder. [jone]
 - Add DocProperty ogg.document.version_number.  [njohner]

--- a/opengever/globalindex/handlers/task.py
+++ b/opengever/globalindex/handlers/task.py
@@ -24,7 +24,8 @@ class TaskSqlSyncer(SqlSyncer):
             task = Task(self.obj_id, admin_unit_id,
                         issuing_org_unit=current_org_unit_id,
                         assigned_org_unit=assigned_org_unit,
-                        sequence_number=sequence_number)
+                        sequence_number=sequence_number,
+                        created=self.obj.created().asdatetime())
             Session.add(task)
         return task
 

--- a/opengever/repository/tests/test_repositoryfolder_tabs.py
+++ b/opengever/repository/tests/test_repositoryfolder_tabs.py
@@ -118,7 +118,7 @@ class TestRepositoryFolderTasksTab(IntegrationTestCase):
              'Date of completion': '',
              'Deadline': 'Nov 1, 2016',
              'Dossier': u'Vertr\xe4ge mit der kantonalen Finanzverwaltung',
-             'Issued at': '16.01.2018',
+             'Issued at': '31.08.2016',
              'Issuer': 'Ziegler Robert (robert.ziegler)',
              'Responsible': u'B\xe4rfuss K\xe4thi (kathi.barfuss)',
              'Review state': 'task-state-in-progress',


### PR DESCRIPTION
When inserting the task entry in the globalindex, the "created" value was set to the current database time and not the Plone object's created time.

This can lead to a small difference in production and it makes testing harder because it is not predictable.

This change should fix the tests and will make testing easier in the future.
It has a low impact on production. 
We are not reindexing current entries and leave them inconsistent because this would be too expensive and has no known pratical gain other than better consistency.