### PR TITLE
 Prefix the reference numbers on private dossiers with a P

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2017.8.0 (unreleased)
 ---------------------
 
+- Prefix the reference numbers on private dossiers with a P. [Rotonen]
 - Task globalindex: set the created time in sql from the Plone object. [jone]
 - Add tasks tab to repository folder. [jone]
 - Add documents tab to repository folder. [jone]

--- a/opengever/base/reference.py
+++ b/opengever/base/reference.py
@@ -16,8 +16,8 @@ from zope.interface import implementer
 @implementer(IReferenceNumber)
 @adapter(IDexterityContent)
 class BasicReferenceNumber(object):
-    """ Basic reference number adapter
-    """
+    """Basic reference number adapter."""
+
     ref_type = 'basic'
 
     def __init__(self, context):
@@ -41,6 +41,7 @@ class BasicReferenceNumber(object):
     def append_local_number(self, numbers):
         if not numbers.get(self.ref_type):
             numbers[self.ref_type] = []
+
         numbers[self.ref_type].insert(0, self.get_local_number())
 
     def get_parent_numbers(self):
@@ -48,9 +49,11 @@ class BasicReferenceNumber(object):
         self.append_local_number(numbers)
 
         parent = self.context
+
         while parent and not ISiteRoot.providedBy(parent):
             parent = aq_parent(aq_inner(parent))
             parent_reference_adapter = queryAdapter(parent, IReferenceNumber)
+
             if parent_reference_adapter:
                 parent_reference_adapter.append_local_number(numbers)
 
@@ -59,9 +62,10 @@ class BasicReferenceNumber(object):
 
 @adapter(ISiteRoot)
 class PlatformReferenceNumber(BasicReferenceNumber):
-    """ Reference number generator for the plone site. The reference
+    """Reference number generator for the plone site. The reference
     number part of a PloneSite is the current_admin_unit's abbreviation.
     """
+
     ref_type = 'site'
 
     def get_local_number(self):

--- a/opengever/private/browser/tabbed.py
+++ b/opengever/private/browser/tabbed.py
@@ -7,10 +7,11 @@ from opengever.tabbedview.browser.tabs import SubDossiers
 
 
 class PrivateFolderTabbedView(GeverTabbedView):
+    """List dossiers within a private folder."""
 
     dossier_tab = {
         'id': 'dossiers',
-        'title': _(u'label_dossiers', default=u'Dossiers')
+        'title': _(u'label_dossiers', default=u'Dossiers'),
     }
 
     def _get_tabs(self):
@@ -18,17 +19,23 @@ class PrivateFolderTabbedView(GeverTabbedView):
 
 
 class PrivateFolderDossiers(Dossiers):
+    """Whitelist portal actions for dossiers in private folders."""
 
-    enabled_actions = ['pdf_dossierlisting', 'export_dossiers', 'folder_delete_confirmation']
+    enabled_actions = [
+        'pdf_dossierlisting',
+        'export_dossiers',
+        'folder_delete_confirmation',
+        ]
 
 
 class PrivateFolderSubDossiers(SubDossiers):
+    """Whitelist portal actions for subdossiers in private folders."""
 
     @property
     def enabled_actions(self):
         return super(PrivateFolderSubDossiers, self).enabled_actions + [
-            'folder_delete_confirmation'
-        ]
+            'folder_delete_confirmation',
+            ]
 
 
 class PrivateDossierTabbedView(DossierTabbedView):
@@ -37,26 +44,34 @@ class PrivateDossierTabbedView(DossierTabbedView):
     """
 
     def _get_tabs(self):
-        return [self.overview_tab,
-                self.subdossiers_tab,
-                self.documents_tab,
-                self.trash_tab,
-                self.journal_tab]
+        return [
+            self.overview_tab,
+            self.subdossiers_tab,
+            self.documents_tab,
+            self.trash_tab,
+            self.journal_tab,
+            ]
 
 
 class PrivateDossierDocuments(Documents):
+    """Whitelist portal actions and metadata columns for documents in private
+    dossiers.
+    """
 
     @property
     def enabled_actions(self):
         return super(PrivateDossierDocuments, self).enabled_actions + [
-            'folder_delete_confirmation'
-        ]
+            'folder_delete_confirmation',
+            ]
 
     @property
     def columns(self):
         columns = super(PrivateDossierDocuments, self).columns
+
         cols_by_name = {col['column']: col for col in columns}
+
         cols_by_name['public_trial']['hidden'] = True
         cols_by_name['receipt_date']['hidden'] = True
         cols_by_name['delivery_date']['hidden'] = True
+
         return columns

--- a/opengever/private/dossier.py
+++ b/opengever/private/dossier.py
@@ -1,6 +1,10 @@
+from opengever.base.interfaces import IReferenceNumberFormatter
+from opengever.base.interfaces import IReferenceNumberSettings
 from opengever.dossier.base import DossierContainer
 from opengever.dossier.businesscase import IBusinessCaseDossier
 from opengever.private.interfaces import IPrivateContainer
+from plone import api
+from zope.component import queryAdapter
 
 
 class IPrivateDossier(IBusinessCaseDossier, IPrivateContainer):
@@ -12,3 +16,23 @@ class PrivateDossier(DossierContainer):
     """A specific dossier type, only addable to a PrivateFolder in the
     private Area and only visible for the Owner and Managers.
     """
+
+    def get_reference_number(self):
+        """Prefix reference numbers of private dossiers with a 'P'."""
+        active_formatter_name = api.portal.get_registry_record(
+            name='formatter',
+            interface=IReferenceNumberSettings,
+            )
+
+        formatter = queryAdapter(
+            api.portal.get(),
+            IReferenceNumberFormatter,
+            name=active_formatter_name,
+            )
+
+        separator = getattr(formatter, 'repository_dossier_separator', u' ')
+
+        return separator.join((
+            'P',
+            super(PrivateDossier, self).get_reference_number(),
+            ))

--- a/opengever/private/quota.py
+++ b/opengever/private/quota.py
@@ -10,6 +10,7 @@ from zope.interface import implementer
 @implementer(IQuotaSizeSettings)
 @adapter(IPrivateFolder)
 class PrivateFolderQuotaSizeSettings(object):
+    """Provide persistence for private folder quota settings."""
 
     def __init__(self, context):
         self.context = context
@@ -17,9 +18,11 @@ class PrivateFolderQuotaSizeSettings(object):
     def get_soft_limit(self):
         settings = getUtility(IRegistry).forInterface(
             IPrivateFolderQuotaSettings)
+
         return settings.size_soft_limit
 
     def get_hard_limit(self):
         settings = getUtility(IRegistry).forInterface(
             IPrivateFolderQuotaSettings)
+
         return settings.size_hard_limit

--- a/opengever/private/reference.py
+++ b/opengever/private/reference.py
@@ -8,6 +8,7 @@ class PrivateFolderReferenceNumber(BasicReferenceNumber):
     """Reference number adapter for private folder. It uses the userid
     as local number part.
     """
+
     ref_type = 'repository'
 
     def get_local_number(self):

--- a/opengever/private/tests/__init__.py
+++ b/opengever/private/tests/__init__.py
@@ -1,6 +1,5 @@
 from AccessControl import getSecurityManager
 from plone import api
-from plone.app.testing import TEST_USER_ID
 import transaction
 
 

--- a/opengever/private/tests/test_delete_action.py
+++ b/opengever/private/tests/test_delete_action.py
@@ -1,4 +1,3 @@
-import unittest
 from ftw.testbrowser import browsing
 from ftw.testbrowser.pages import statusmessages
 from opengever.testing import IntegrationTestCase
@@ -11,46 +10,61 @@ class TestDeleteActionInPrivateFolderTabbedViews(IntegrationTestCase):
     def test_delete_action_is_displayed_for_administrator(self, browser):
         self.login(self.administrator, browser)
         browser.open(self.private_folder, view='tabbedview_view-dossiers')
+
         self.assertIn('Delete', browser.css('.actionMenuContent a').text)
 
     @browsing
     def test_delete_action_works_for_administrator(self, browser):
         self.login(self.administrator, browser)
-        browser.open(self.private_folder,
-                     view='folder_delete_confirmation',
-                     data={'paths:list': obj2paths([self.private_dossier])})
+
+        browser.open(
+            self.private_folder,
+            view='folder_delete_confirmation',
+            data={'paths:list': obj2paths([self.private_dossier])},
+            )
 
         browser.find('Delete').click()
+
         statusmessages.assert_message(u'Items successfully deleted.')
 
         with self.assertRaises(KeyError):
-            self.private_dossier
+            self.assertIsNone(self.private_dossier)
 
     @browsing
     def test_delete_action_is_displayed_for_owner(self, browser):
         self.login(self.regular_user, browser)
         browser.open(self.private_folder, view='tabbedview_view-dossiers')
+
         self.assertIn('Delete', browser.css('.actionMenuContent a').text)
 
     @browsing
     def test_delete_action_works_for_owner(self, browser):
         self.login(self.regular_user, browser)
-        browser.open(self.private_folder,
-                     view='folder_delete_confirmation',
-                     data={'paths:list': obj2paths([self.private_dossier])})
+
+        browser.open(
+            self.private_folder,
+            view='folder_delete_confirmation',
+            data={'paths:list': obj2paths([self.private_dossier])},
+            )
+
         browser.find('Delete').click()
+
         statusmessages.assert_message(u'Items successfully deleted.')
 
         with self.assertRaises(KeyError):
-            self.private_dossier
+            self.assertIsNone(self.private_dossier)
 
 
 class TestDeleteActionInPrivateFolderContentViews(IntegrationTestCase):
 
     @browsing
-    def test_delete_action_is_displayed_for_administrator_on_dossier(self, browser):
+    def test_delete_action_is_displayed_for_administrator_on_dossier(
+            self,
+            browser,
+        ):
         self.login(self.administrator, browser)
         browser.open(self.private_dossier)
+
         self.assertIn('Delete', browser.css('.actionMenuContent a span').text)
 
     @browsing
@@ -59,15 +73,17 @@ class TestDeleteActionInPrivateFolderContentViews(IntegrationTestCase):
         browser.open(self.private_dossier)
         browser.find('Delete').click()
         browser.find('Delete').click()
+
         statusmessages.assert_message(u'Mein Dossier 1 has been deleted.')
 
         with self.assertRaises(KeyError):
-            self.private_dossier
+            self.assertIsNone(self.private_dossier)
 
     @browsing
     def test_delete_action_is_displayed_for_owner_on_dossier(self, browser):
         self.login(self.regular_user, browser)
         browser.open(self.private_dossier)
+
         self.assertIn('Delete', browser.css('.actionMenuContent a span').text)
 
     @browsing
@@ -76,15 +92,20 @@ class TestDeleteActionInPrivateFolderContentViews(IntegrationTestCase):
         browser.open(self.private_dossier)
         browser.find('Delete').click()
         browser.find('Delete').click()
+
         statusmessages.assert_message(u'Mein Dossier 1 has been deleted.')
 
         with self.assertRaises(KeyError):
-            self.private_dossier
+            self.assertIsNone(self.private_dossier)
 
     @browsing
-    def test_delete_action_is_displayed_for_administrator_on_document(self, browser):
+    def test_delete_action_is_displayed_for_administrator_on_document(
+            self,
+            browser,
+        ):
         self.login(self.administrator, browser)
         browser.open(self.private_document)
+
         self.assertIn('Delete', browser.css('.actionMenuContent a span').text)
 
     @browsing
@@ -93,15 +114,17 @@ class TestDeleteActionInPrivateFolderContentViews(IntegrationTestCase):
         browser.open(self.private_document)
         browser.find('Delete').click()
         browser.find('Delete').click()
+
         statusmessages.assert_message(u'Testdokum\xe4nt has been deleted.')
 
         with self.assertRaises(KeyError):
-            self.private_document
+            self.assertIsNone(self.private_document)
 
     @browsing
     def test_delete_action_is_displayed_for_owner_on_document(self, browser):
         self.login(self.regular_user, browser)
         browser.open(self.private_document)
+
         self.assertIn('Delete', browser.css('.actionMenuContent a span').text)
 
     @browsing
@@ -110,7 +133,8 @@ class TestDeleteActionInPrivateFolderContentViews(IntegrationTestCase):
         browser.open(self.private_document)
         browser.find('Delete').click()
         browser.find('Delete').click()
+
         statusmessages.assert_message(u'Testdokum\xe4nt has been deleted.')
 
         with self.assertRaises(KeyError):
-            self.private_document
+            self.assertIsNone(self.private_document)

--- a/opengever/private/tests/test_reference_number.py
+++ b/opengever/private/tests/test_reference_number.py
@@ -1,0 +1,102 @@
+from opengever.base.interfaces import IReferenceNumberSettings
+from opengever.testing import IntegrationTestCase
+from plone import api
+
+
+class TestPrivateReferenceNumber(IntegrationTestCase):
+
+    def test_dotted_reference_number(self):
+        self.login(self.administrator)
+
+        api.portal.set_registry_record(
+            'formatter',
+            'dotted',
+            interface=IReferenceNumberSettings,
+            )
+
+        expected_reference_numbers = {
+            'private_dossier': 'P Client1 kathi-barfuss / 1',
+            'private_document': 'P Client1 kathi-barfuss / 1',
+            }
+
+        found_reference_numbers = {
+            name: getattr(self, name).get_reference_number()
+            for name in expected_reference_numbers
+            }
+
+        self.assertDictEqual(
+            expected_reference_numbers,
+            found_reference_numbers,
+            )
+
+    def test_grouped_by_three_reference_number(self):
+        self.login(self.administrator)
+
+        api.portal.set_registry_record(
+            'formatter',
+            'grouped_by_three',
+            interface=IReferenceNumberSettings,
+            )
+
+        expected_reference_numbers = {
+            'private_dossier': 'P Client1 kathi-barfuss-1',
+            'private_document': 'P Client1 kathi-barfuss-1',
+            }
+
+        found_reference_numbers = {
+            name: getattr(self, name).get_reference_number()
+            for name in expected_reference_numbers
+            }
+
+        self.assertDictEqual(
+            expected_reference_numbers,
+            found_reference_numbers,
+            )
+
+    def test_no_client_id_dotted_reference_number(self):
+        self.login(self.administrator)
+
+        api.portal.set_registry_record(
+            'formatter',
+            'no_client_id_dotted',
+            interface=IReferenceNumberSettings,
+            )
+
+        expected_reference_numbers = {
+            'private_dossier': 'P kathi-barfuss / 1',
+            'private_document': 'P kathi-barfuss / 1',
+            }
+
+        found_reference_numbers = {
+            name: getattr(self, name).get_reference_number()
+            for name in expected_reference_numbers
+            }
+
+        self.assertDictEqual(
+            expected_reference_numbers,
+            found_reference_numbers,
+            )
+
+    def test_no_client_id_grouped_by_three_reference_number(self):
+        self.login(self.administrator)
+
+        api.portal.set_registry_record(
+            'formatter',
+            'no_client_id_grouped_by_three',
+            interface=IReferenceNumberSettings,
+            )
+
+        expected_reference_numbers = {
+            'private_dossier': 'P kathi-barfuss-1',
+            'private_document': 'P kathi-barfuss-1',
+            }
+
+        found_reference_numbers = {
+            name: getattr(self, name).get_reference_number()
+            for name in expected_reference_numbers
+            }
+
+        self.assertDictEqual(
+            expected_reference_numbers,
+            found_reference_numbers,
+            )

--- a/opengever/private/viewlets/quotawarning.py
+++ b/opengever/private/viewlets/quotawarning.py
@@ -14,33 +14,45 @@ from zope.interface import Interface
 
 def get_quota_warning_type_to_show_in(context):
     private_folders = filter(IPrivateFolder.providedBy, aq_chain(context))
+
     if not private_folders:
         return None
 
     private_folder, = private_folders
+
     return ISizeQuota(private_folder).exceeded_limit()
 
 
 class QuotaWarningViewlet(ViewletBase):
+    """Provide a warning viewlet for exceeding private folder quotas."""
+
     index = ViewPageTemplateFile('templates/quotawarning.pt')
 
     def get_message_to_show(self):
         warning_type = get_quota_warning_type_to_show_in(self.context)
         if warning_type == HARD_LIMIT_EXCEEDED:
-            return {'type': 'error',
-                    'message': _(u'The quota of your private folder'
-                                 u' has exceeded, you can not add any'
-                                 u' new files or mails.')}
+            return {
+                'type': 'error',
+                'message': _(
+                    u'The quota of your private folder has exceeded, you can '
+                    u'not add any new files or mails.',
+                    ),
+                }
 
         elif warning_type == SOFT_LIMIT_EXCEEDED:
-            return {'type': 'warning',
-                    'message': _(u'The quota of your private folder'
-                                 u' will exceed soon.')}
-        else:
-            return None
+            return {
+                'type': 'warning',
+                'message': _(
+                    u'The quota of your private folder will exceed soon.',
+                    ),
+                }
+
+        return None
 
 
 class QuotaWarningETagValue(object):
+    """Provide ETags for per user caching of quota warnings."""
+
     implements(IETagValue)
     adapts(Interface, Interface)
 
@@ -50,9 +62,11 @@ class QuotaWarningETagValue(object):
 
     def __call__(self):
         warning_type = get_quota_warning_type_to_show_in(self.published)
+
         if warning_type == HARD_LIMIT_EXCEEDED:
             return 'h'
+
         elif warning_type == SOFT_LIMIT_EXCEEDED:
             return 's'
-        else:
-            return '-'
+
+        return '-'


### PR DESCRIPTION
* Amended the private dossier reference number getter
  * Get the current formatter
  * If possible, use the current separator
  * Default to a space

Did not go for making the prefix configurable per repository root / repository folder. Splitting that onto its own issue to be tackled later down the line.

Closes #3571 