### PR TITLE
Various improvements for Workspaces

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2018.1.0 (unreleased)
 ---------------------
 
+- OGIP 17: Use tabbedview as default view for WorkspaceFolder + Fix two display issues [mathias.leimgruber]
 - OGIP 17: Implement internal invitations for Workspaces. [mathias.leimgruber]
 - Improve description for committee group label. [deiferni]
 - Ensure bumblebee overlay view download links point to the correct version. [Rotonen]

--- a/opengever/base/browser/edit_public_trial.py
+++ b/opengever/base/browser/edit_public_trial.py
@@ -37,6 +37,9 @@ def can_access_public_trial_edit_form(user, content):
     for open_state in DOSSIER_STATES_OPEN:
         state = wftool.get(workflow_id).states.get(open_state)
 
+        if state is None:
+            continue
+
         roles_with_modify = state.permission_roles['Modify portal content']
 
         has_role = bool(set(roles_with_modify) & set(user_roles))

--- a/opengever/core/profiles/default/types/opengever.workspace.folder.xml
+++ b/opengever/core/profiles/default/types/opengever.workspace.folder.xml
@@ -36,11 +36,11 @@
   </property>
 
   <!-- View information -->
-  <property name="immediate_view">view</property>
-  <property name="default_view">view</property>
+  <property name="immediate_view">tabbed_view</property>
+  <property name="default_view">tabbed_view</property>
   <property name="default_view_fallback">False</property>
   <property name="view_methods">
-    <element value="view" />
+    <element value="tabbed_view" />
   </property>
 
   <!-- Method aliases -->

--- a/opengever/core/upgrades/20180123112216_change_default_view_of_workspace_folder/types/opengever.workspace.folder.xml
+++ b/opengever/core/upgrades/20180123112216_change_default_view_of_workspace_folder/types/opengever.workspace.folder.xml
@@ -1,0 +1,11 @@
+<object xmlns:i18n="http://xml.zope.org/namespaces/i18n" name="opengever.workspace.folder" meta_type="Dexterity FTI" i18n:domain="opengever.core">
+
+  <!-- View information -->
+  <property name="immediate_view">tabbed_view</property>
+  <property name="default_view">tabbed_view</property>
+  <property name="default_view_fallback">False</property>
+  <property name="view_methods">
+    <element value="tabbed_view" />
+  </property>
+
+</object>

--- a/opengever/core/upgrades/20180123112216_change_default_view_of_workspace_folder/upgrade.py
+++ b/opengever/core/upgrades/20180123112216_change_default_view_of_workspace_folder/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class ChangeDefaultViewOfWorkspaceFolder(UpgradeStep):
+    """Change default view of WorkspaceFolder.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/dossier/base.py
+++ b/opengever/dossier/base.py
@@ -36,6 +36,8 @@ from zope.interface import Interface
 
 DOSSIER_STATES_OPEN = [
     'dossier-state-active',
+    'opengever_workspace--STATUS--active',
+    'opengever_workspace_folder--STATUS--active',
 ]
 
 

--- a/opengever/workspace/browser/configure.zcml
+++ b/opengever/workspace/browser/configure.zcml
@@ -11,6 +11,13 @@
       allowed_interface="ftw.tabbedview.interfaces.ITabbedViewEndpoints"
       />
 
+  <browser:page
+      for="opengever.workspace.interfaces.IWorkspaceFolder"
+      name="tabbed_view"
+      class=".tabbed.WorkspaceFolderTabbedView"
+      permission="zope2.View"
+      allowed_interface="ftw.tabbedview.interfaces.ITabbedViewEndpoints"
+      />
 
   <browser:page
       for="opengever.workspace.interfaces.IWorkspaceRoot"

--- a/opengever/workspace/browser/tabbed.py
+++ b/opengever/workspace/browser/tabbed.py
@@ -41,6 +41,10 @@ class WorkspaceTabbedView(GeverTabbedView):
         ])
 
 
+class WorkspaceFolderTabbedView(WorkspaceTabbedView):
+    """Define tabs available on Workspace Folder"""
+
+
 class WorkspaceRootTabbedView(GeverTabbedView):
 
     workspaces_tab = {

--- a/opengever/workspace/tests/test_workspace_workspace.py
+++ b/opengever/workspace/tests/test_workspace_workspace.py
@@ -4,6 +4,7 @@ from ftw.testbrowser.pages import factoriesmenu
 from ftw.testbrowser.pages.statusmessages import assert_no_error_messages
 from opengever.base.interfaces import ISequenceNumber
 from opengever.testing import IntegrationTestCase
+from plone.uuid.interfaces import IUUID
 from zope.component import getUtility
 
 
@@ -98,3 +99,14 @@ class TestWorkspaceWorkspace(IntegrationTestCase):
 
         self.maxDiff = None
         self.assertEquals(expected, got)
+
+    @browsing
+    def test_workspace_overview_subdossierstructure(self, browser):
+        self.login(self.workspace_owner, browser=browser)
+        browser.visit(self.workspace, view='dossier_navigation.json')
+        self.assertEquals([{u'description': u'',
+                            u'nodes': [],
+                            u'text': u'',
+                            u'uid': IUUID(self.workspace_folder),
+                            u'url': self.workspace_folder.absolute_url()}],
+                          browser.json[0]['nodes'])

--- a/opengever/workspace/tests/test_workspace_workspace.py
+++ b/opengever/workspace/tests/test_workspace_workspace.py
@@ -1,7 +1,10 @@
+from ftw.builder import Builder
+from ftw.builder import create
 from ftw.testbrowser import browsing
 from ftw.testbrowser.pages import editbar
 from ftw.testbrowser.pages import factoriesmenu
 from ftw.testbrowser.pages.statusmessages import assert_no_error_messages
+from opengever.base.browser import edit_public_trial
 from opengever.base.interfaces import ISequenceNumber
 from opengever.testing import IntegrationTestCase
 from plone.uuid.interfaces import IUUID
@@ -77,7 +80,7 @@ class TestWorkspaceWorkspace(IntegrationTestCase):
             with self.login(user, browser):
                 browser.open(self.workspace)
                 got[user] = factoriesmenu.visible() \
-                            and 'Document' in factoriesmenu.addable_types()
+                    and 'Document' in factoriesmenu.addable_types()
 
         self.maxDiff = None
         self.assertEquals(expected, got)
@@ -95,7 +98,7 @@ class TestWorkspaceWorkspace(IntegrationTestCase):
             with self.login(user, browser):
                 browser.open(self.workspace)
                 got[user] = factoriesmenu.visible() \
-                            and 'WorkspaceFolder' in factoriesmenu.addable_types()
+                    and 'WorkspaceFolder' in factoriesmenu.addable_types()
 
         self.maxDiff = None
         self.assertEquals(expected, got)
@@ -110,3 +113,12 @@ class TestWorkspaceWorkspace(IntegrationTestCase):
                             u'uid': IUUID(self.workspace_folder),
                             u'url': self.workspace_folder.absolute_url()}],
                           browser.json[0]['nodes'])
+
+    def test_can_access_public_trial_edit_form_for_files_in_workspace(self):
+        self.login(self.workspace_owner)
+
+        document = create(Builder('document').within(self.workspace))
+        self.assertTrue(edit_public_trial.can_access_public_trial_edit_form(self.workspace_owner, document))
+        self.assertTrue(edit_public_trial.can_access_public_trial_edit_form(self.workspace_admin, document))
+        self.assertFalse(edit_public_trial.can_access_public_trial_edit_form(self.workspace_member, document))
+        self.assertFalse(edit_public_trial.can_access_public_trial_edit_form(self.workspace_guest, document))


### PR DESCRIPTION
- Use tabbedview as default view for WorkspaceFolder
- Fix Dossierstrcucture listing on overview tab
- Fix file detail view for files in workspace

<img width="980" alt="screen shot 2018-01-23 at 13 53 53" src="https://user-images.githubusercontent.com/437933/35276810-f50622a4-0044-11e8-8252-d80ea2f24870.png">


closes #3678