### PR TITLE
Set next upcoming release to 2018.1.0.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -2,7 +2,7 @@
 Changelog
 =========
 
-2017.8.0 (unreleased)
+2018.1.0 (unreleased)
 ---------------------
 
 - Fix bumblebee preview in ECH0147 import. [deiferni]

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 import os
 
 
-version = '2017.8.0.dev0'
+version = '2018.1.0.dev0'
 maintainer = '4teamwork AG'
 
 


### PR DESCRIPTION
We're close to cutting a release and customers start testing. They should see the next released version.