### PR TITLE
 Fix JWT authentication for users from the Zope root acl_users for OC payloads

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ---------------------
 
 - Make teams available as tasktemplate responsibles. [phgross]
+- Fix JWT authentication for users from the Zope root acl_users. [Rotonen]
 - Fix bumblebee preview in ECH0147 import. [deiferni]
 - Disable outdated checkout/edit action and move checkout cancel action [njohner]
 - Prefix the reference numbers on private dossiers with a P. [Rotonen]

--- a/opengever/officeconnector/testing.py
+++ b/opengever/officeconnector/testing.py
@@ -173,7 +173,7 @@ class OCIntegrationTestCase(IntegrationTestCase):
                 self.request).get_email_for_object(parent_dossier)
             self.assertEquals(bcc, dossier_bcc)
 
-    def validate_checkout_token(self, oc_url):
+    def validate_checkout_token(self, user, oc_url):
         raw_token = oc_url.split(':')[-1]
         token = jwt.decode(raw_token, verify=False)
         self.assertEquals('checkout', token.get('action', None))
@@ -185,8 +185,7 @@ class OCIntegrationTestCase(IntegrationTestCase):
         self.assertEquals(1, len(documents))
         self.assertEquals(api.content.get_uuid(self.document), documents[0])
 
-        user = token.get('sub', None)
-        self.assertEquals(self.regular_user.id, user)
+        self.assertEquals(user.id, token.get('sub', None))
 
         expiry = int(token.get('exp', 0))
         self.assertLess(int(time()), expiry)

--- a/opengever/officeconnector/tests/test_api_dossier_checkout.py
+++ b/opengever/officeconnector/tests/test_api_dossier_checkout.py
@@ -172,7 +172,7 @@ class TestOfficeconnectorDossierAPIWithCheckout(OCIntegrationTestCase):
         self.assertIsNotNone(oc_url)
         self.assertEquals(200, browser.status_code)
 
-        tokens = self.validate_checkout_token(oc_url)
+        tokens = self.validate_checkout_token(self.regular_user, oc_url)
         payload = self.fetch_document_checkout_payloads(browser, tokens)[0]
 
         self.validate_checkout_payload(payload, self.document)
@@ -207,7 +207,7 @@ class TestOfficeconnectorDossierAPIWithCheckout(OCIntegrationTestCase):
         self.assertIsNotNone(oc_url)
         self.assertEquals(200, browser.status_code)
 
-        tokens = self.validate_checkout_token(oc_url)
+        tokens = self.validate_checkout_token(self.regular_user, oc_url)
         payload = self.fetch_document_checkout_payloads(browser, tokens)[0]
 
         self.validate_checkout_payload(payload, self.document)

--- a/opengever/officeconnector/tests/test_api_dossier_checkout.py
+++ b/opengever/officeconnector/tests/test_api_dossier_checkout.py
@@ -2,6 +2,7 @@ from ftw.testbrowser import browsing
 from hashlib import sha256
 from opengever.document.document import Document
 from opengever.officeconnector.testing import OCIntegrationTestCase
+from opengever.testing.assets import path_to_asset
 
 
 class TestOfficeconnectorDossierAPIWithCheckout(OCIntegrationTestCase):
@@ -185,7 +186,7 @@ class TestOfficeconnectorDossierAPIWithCheckout(OCIntegrationTestCase):
             self.download_document(browser, tokens, payload),
             ).hexdigest()
 
-        with open('../../opengever/testing/assets/addendum.docx') as f:
+        with open(path_to_asset('addendum.docx')) as f:
             self.upload_document(browser, tokens, payload, self.document, f)
 
         new_checksum = sha256(
@@ -220,7 +221,7 @@ class TestOfficeconnectorDossierAPIWithCheckout(OCIntegrationTestCase):
             self.download_document(browser, tokens, payload),
             ).hexdigest()
 
-        with open('../../opengever/testing/assets/addendum.docx') as f:
+        with open(path_to_asset('addendum.docx')) as f:
             self.upload_document(browser, tokens, payload, self.document, f)
 
         new_checksum = sha256(

--- a/opengever/officeconnector/tests/test_zopemaster.py
+++ b/opengever/officeconnector/tests/test_zopemaster.py
@@ -1,6 +1,7 @@
 from ftw.testbrowser import browsing
 from hashlib import sha256
 from opengever.officeconnector.testing import OCIntegrationTestCase
+from opengever.testing.assets import path_to_asset
 
 
 class TestOfficeconnectorAsZopemasterDossierAPIWithAttach(OCIntegrationTestCase):
@@ -64,7 +65,7 @@ class TestOfficeconnectorAsZopemasterDossierAPIWithCheckout(OCIntegrationTestCas
             self.download_document(browser, tokens, payload),
             ).hexdigest()
 
-        with open('../../opengever/testing/assets/addendum.docx') as f:
+        with open(path_to_asset('addendum.docx')) as f:
             self.upload_document(browser, tokens, payload, self.document, f)
 
         new_checksum = sha256(

--- a/opengever/officeconnector/tests/test_zopemaster.py
+++ b/opengever/officeconnector/tests/test_zopemaster.py
@@ -1,0 +1,78 @@
+from ftw.testbrowser import browsing
+from hashlib import sha256
+from opengever.officeconnector.testing import OCIntegrationTestCase
+
+
+class TestOfficeconnectorAsZopemasterDossierAPIWithAttach(OCIntegrationTestCase):
+    features = (
+        'officeconnector-attach',
+    )
+
+    @browsing
+    def test_attach_to_email_open_with_file(self, browser):
+        self.login(self.manager, browser)
+
+        oc_url = self.fetch_document_attach_oc_url(browser, self.document)
+
+        self.assertIsNotNone(oc_url)
+        self.assertEquals(200, browser.status_code)
+
+        tokens = self.validate_attach_token(
+            self.manager,
+            oc_url,
+            (self.document, ),
+            )
+
+        payloads = self.fetch_document_attach_payloads(browser, tokens)
+
+        self.assertEquals(200, browser.status_code)
+        self.validate_attach_payload(payloads[0], self.document)
+
+        file_contents = self.download_document(
+            browser,
+            tokens,
+            payloads[0],
+            )
+
+        self.assertEquals(file_contents, self.document.file.data)
+
+
+class TestOfficeconnectorAsZopemasterDossierAPIWithCheckout(OCIntegrationTestCase):
+    features = (
+        'officeconnector-checkout',
+    )
+
+    @browsing
+    def test_checkout_checkin_open_with_file_without_comment(self, browser):
+        self.login(self.manager, browser)
+
+        oc_url = self.fetch_document_checkout_oc_url(browser, self.document)
+
+        self.assertIsNotNone(oc_url)
+        self.assertEquals(200, browser.status_code)
+
+        tokens = self.validate_checkout_token(self.manager, oc_url)
+        payload = self.fetch_document_checkout_payloads(browser, tokens)[0]
+
+        self.validate_checkout_payload(payload, self.document)
+
+        self.checkout_document(browser, tokens, payload, self.document)
+
+        lock_token = self.lock_document(browser, tokens, self.document)
+
+        original_checksum = sha256(
+            self.download_document(browser, tokens, payload),
+            ).hexdigest()
+
+        with open('../../opengever/testing/assets/addendum.docx') as f:
+            self.upload_document(browser, tokens, payload, self.document, f)
+
+        new_checksum = sha256(
+            self.download_document(browser, tokens, payload),
+            ).hexdigest()
+
+        self.assertNotEquals(new_checksum, original_checksum)
+
+        self.unlock_document(browser, tokens, self.document, lock_token)
+
+        self.checkin_document(browser, tokens, payload, self.document)

--- a/opengever/testing/assets/__init__.py
+++ b/opengever/testing/assets/__init__.py
@@ -1,5 +1,10 @@
+from pkg_resources import resource_filename
 from pkg_resources import resource_string
 
 
 def load(asset_filename):
     return resource_string('opengever.testing.assets', asset_filename)
+
+
+def path_to_asset(asset_filename):
+    return resource_filename('opengever.testing.assets', asset_filename)


### PR DESCRIPTION
Just mirroring `plone.restapi` here.

We had cloned the logic from there as we needed to customize it, so the fix did not propagate down to what we're actually doing just by upgrading `plone.restapi`.