### PR TITLE
Make teams available on forwardings

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,7 @@ Changelog
 
 - Fix bumblebee preview in ECH0147 import. [deiferni]
 - Disable outdated checkout/edit action and move checkout cancel action [njohner]
+- Make teams available when reassigning an open task or forwarding. [phgross]
 - Support teams as forwarding responsibles. [phgross]
 - Prefix the reference numbers on private dossiers with a P. [Rotonen]
 - Fix attaching to email from documents within forwardings within the inbox. [Rotonen]

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,7 @@ Changelog
 
 - Fix bumblebee preview in ECH0147 import. [deiferni]
 - Disable outdated checkout/edit action and move checkout cancel action [njohner]
+- Support teams as forwarding responsibles. [phgross]
 - Prefix the reference numbers on private dossiers with a P. [Rotonen]
 - Fix attaching to email from documents within forwardings within the inbox. [Rotonen]
 - Task globalindex: set the created time in sql from the Plone object. [jone]

--- a/opengever/inbox/browser/assign.py
+++ b/opengever/inbox/browser/assign.py
@@ -18,7 +18,7 @@ class IForwardingAssignSchema(IAssignSchema):
     responsible = schema.Choice(
         title=task_mf(u"label_responsible", default=u"Responsible"),
         description=task_mf(u"help_responsible", default=""),
-        source=AllUsersInboxesAndTeamsSourceBinder(),
+        source=AllUsersInboxesAndTeamsSourceBinder(include_teams=True),
         required=True,
         )
 

--- a/opengever/inbox/forwarding.py
+++ b/opengever/inbox/forwarding.py
@@ -58,8 +58,7 @@ class IForwarding(ITask):
         title=_(u"label_responsible", default=u"Responsible"),
         description=_(u"help_responsible", default=""),
         source=AllUsersInboxesAndTeamsSourceBinder(
-            only_current_orgunit=True,
-            ),
+            only_current_orgunit=True, include_teams=True),
         required=True,
     )
 

--- a/opengever/inbox/tests/test_forwarding.py
+++ b/opengever/inbox/tests/test_forwarding.py
@@ -3,103 +3,74 @@ from ftw.builder import create
 from ftw.testbrowser import browsing
 from ftw.testbrowser.pages import statusmessages
 from ftw.testbrowser.pages.factoriesmenu import addable_types
-from opengever.testing import FunctionalTestCase
+from opengever.testing import IntegrationTestCase
 
 
-class TestForwarding(FunctionalTestCase):
-
-    def setUp(self):
-        super(TestForwarding, self).setUp()
-        self.inbox = create(Builder('inbox'))
+class TestForwarding(IntegrationTestCase):
 
     @browsing
     def test_forwarding_is_not_addable_over_the_factory_menu(self, browser):
-        browser.login().open(self.inbox)
+        self.login(self.secretariat_user, browser=browser)
+        browser.open(self.inbox)
 
         self.assertEqual(['Document'], addable_types(browser))
 
     @browsing
     def test_at_least_one_document_references_is_required(self, browser):
-        browser.login().open(
-            self.inbox,
-            view='++add++opengever.inbox.forwarding',
-            )
+        self.login(self.secretariat_user, browser=browser)
+        browser.open(self.inbox,
+                     view='++add++opengever.inbox.forwarding')
 
         messages = statusmessages.messages()
         self.assertEqual(
             ['Error: Please select at least one document to forward.'],
-            messages.get('error'),
-            )
+            messages.get('error'))
 
     @browsing
     def test_creation_moves_document_in_to_the_forwarding(self, browser):
+        self.login(self.secretariat_user, browser=browser)
+
         doc1 = create(Builder('document').within(self.inbox).titled(u'Doc 1'))
         doc2 = create(Builder('document').within(self.inbox).titled(u'Doc 2'))
         doc3 = create(Builder('document').within(self.inbox).titled(u'Doc 3'))
 
         data = {
-            'paths': ['/'.join(doc.getPhysicalPath()) for doc in [doc1, doc3]],
-            }
+            'paths': ['/'.join(doc.getPhysicalPath()) for doc in [doc1, doc3]]}
 
-        browser.login().open(
-            self.inbox,
-            data,
-            view='++add++opengever.inbox.forwarding',
-            )
-
-        browser.fill({
-            'Title': u'Test forwarding',
-            'Responsible': 'inbox:client1',
-            })
-
+        browser.open(
+            self.inbox, data, view='++add++opengever.inbox.forwarding')
+        browser.fill({'Title': u'Test forwarding',
+                      'Responsible': 'inbox:fa'})
         browser.css('#form-buttons-save').first.click()
 
-        forwarding = self.inbox.get('forwarding-1')
+        forwarding = self.inbox.objectValues()[-1]
 
-        self.assertEqual(
-            ['Item created'],
-            statusmessages.messages().get('info'),
-            )
-
+        self.assertEqual(['Item created'],
+                         statusmessages.messages().get('info'))
         self.assertEqual([doc1, doc3], forwarding.listFolderContents())
-
-        self.assertEqual(
-            [doc2],
-            self.inbox.listFolderContents({
-                'portal_type': 'opengever.document.document',
-                }),
-            )
+        self.assertIn(doc2, self.inbox.listFolderContents())
 
     @browsing
     def test_forwarding_add_form_does_not_render_empty_fieldset_additional(
-            self,
-            browser,
-        ):
-        doc = create(Builder('document').within(self.inbox).titled(u'Doc 1'))
-        data = dict(paths=[doc.getPhysicalPath()])
+            self, browser):
 
-        browser.login().open(
-            self.inbox,
-            data,
-            view='++add++opengever.inbox.forwarding',
-            )
+        self.login(self.secretariat_user, browser=browser)
+
+        data = self.make_path_param(self.inbox_document)
+        browser.open(
+            self.inbox, data, view='++add++opengever.inbox.forwarding')
 
         fieldsets = browser.css('form#form fieldset')
-
         self.assertEqual(1, len(fieldsets))
         self.assertEqual('Common', fieldsets.first.css('legend').first.text)
 
     @browsing
     def test_forwarding_edit_form_does_not_render_empty_fieldset_additional(
-            self,
-            browser,
-        ):
-        forwarding = create(Builder('forwarding').within(self.inbox))
+            self, browser):
 
-        self.grant('Manager')
-        browser.login().open(forwarding, view='edit')
+        self.login(self.manager, browser=browser)
+        browser.open(self.inbox_forwarding, view='edit')
 
         fieldsets = browser.css('form#form fieldset')
-
         self.assertEqual(1, len(fieldsets))
         self.assertEqual('Common', fieldsets.first.css('legend').first.text)

--- a/opengever/task/browser/assign.py
+++ b/opengever/task/browser/assign.py
@@ -74,7 +74,6 @@ validator.WidgetValidatorDiscriminators(
 provideAdapter(NoTeamsInProgressStateValidator)
 
 
-
 class AssignTaskForm(Form):
     """Form for assigning task.
     """
@@ -112,7 +111,6 @@ class AssignTaskForm(Form):
 
             self.reassign_task(**data)
             return self.request.RESPONSE.redirect(self.context.absolute_url())
-
 
     def reassign_task(self, **kwargs):
         response = self.add_response(**kwargs)

--- a/opengever/task/browser/assign.py
+++ b/opengever/task/browser/assign.py
@@ -81,13 +81,14 @@ class AssignTaskForm(Form):
                         default=u'No changes: same responsible selected')
                 IStatusMessage(self.request).addStatusMessage(
                     msg, type='error')
-                return self.request.RESPONSE.redirect('.')
+                return self.request.RESPONSE.redirect(
+                    self.context.absolute_url())
 
-            self.reassing_task(**data)
+            self.reassign_task(**data)
 
-        return self.request.RESPONSE.redirect('.')
+        return self.request.RESPONSE.redirect(self.context.absolute_url())
 
-    def reassing_task(self, **kwargs):
+    def reassign_task(self, **kwargs):
         response = self.add_response(**kwargs)
         self.update_task(**kwargs)
         notify(ObjectModifiedEvent(self.context))

--- a/opengever/task/locales/de/LC_MESSAGES/opengever.task.po
+++ b/opengever/task/locales/de/LC_MESSAGES/opengever.task.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2017-10-30 13:29+0000\n"
+"POT-Creation-Date: 2018-01-24 11:25+0000\n"
 "PO-Revision-Date: 2015-02-17 18:41+0100\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -210,6 +210,11 @@ msgstr "Verantwortliche"
 #: ./opengever/task/validators.py
 msgid "error_checked_out_document"
 msgstr "Die folgenden Dokumente (${title}) müssen noch eingecheckt werden."
+
+#. Default: "Team responsibles are only allowed if the task or forwarding is open."
+#: ./opengever/task/browser/assign.py
+msgid "error_no_team_responsible_in_progress_state"
+msgstr "Teams sind nur bei offenen Aufgaben oder Weiterleitungen als Auftragnehmer erlaubt."
 
 #. Default: "No changes: same responsible selected"
 #: ./opengever/task/browser/assign.py

--- a/opengever/task/locales/fr/LC_MESSAGES/opengever.task.po
+++ b/opengever/task/locales/fr/LC_MESSAGES/opengever.task.po
@@ -1,21 +1,20 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-10-30 13:29+0000\n"
+"POT-Creation-Date: 2018-01-24 11:25+0000\n"
 "PO-Revision-Date: 2017-12-03 11:47+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
-"Language-Team: French <https://translations.onegovgever.ch/projects/onegov-"
-"gever/opengever-task/fr/>\n"
-"Language: fr\n"
+"Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-task/fr/>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
-"X-Generator: Weblate 2.13.1\n"
 "Language-Code: en\n"
 "Language-Name: English\n"
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
+"Language: fr\n"
+"X-Generator: Weblate 2.13.1\n"
 
 #: ./opengever/task/browser/close.py
 msgid "${num} documents were copied."
@@ -114,9 +113,7 @@ msgstr "Vous n'étes pas l'autorisation pour éditer ces réponses"
 
 #: ./opengever/task/browser/accept/main.py
 msgid "You are not assigned to the responsible client (${client}). You can only process the task in the issuers dossier."
-msgstr ""
-"Vous n'avez pas été assigné au mandant responsable. Vous ne pouvez traiter "
-"la tâche que dans le dossier du mandant."
+msgstr "Vous n'avez pas été assigné au mandant responsable. Vous ne pouvez traiter la tâche que dans le dossier du mandant."
 
 #: ./opengever/task/browser/close.py
 msgid "You cannot add documents to the selected dossier. Either the dossier is closed or you do not have the privileges."
@@ -216,6 +213,11 @@ msgstr "Responsable"
 msgid "error_checked_out_document"
 msgstr "Les documents suivants (${title}) sont en checkout. Vous devez faire un checkin pour pouvoir les déposer."
 
+#. Default: "Team responsibles are only allowed if the task or forwarding is open."
+#: ./opengever/task/browser/assign.py
+msgid "error_no_team_responsible_in_progress_state"
+msgstr ""
+
 #. Default: "No changes: same responsible selected"
 #: ./opengever/task/browser/assign.py
 msgid "error_same_responsible"
@@ -280,9 +282,7 @@ msgstr "En cas de besoin, choix des documents à copier dans un autre dossier."
 #. Default: "Select the documents you want to deliver to the issuer of the task. They will be attached to the original task of the issuer."
 #: ./opengever/task/browser/complete.py
 msgid "help_complete_documents"
-msgstr ""
-"Choix des documents à livrer au mandant. Ils seront ensuite attachés "
-"automatiquement à la tâche originale."
+msgstr "Choix des documents à livrer au mandant. Ils seront ensuite attachés automatiquement à la tâche originale."
 
 #. Default: "Enter a answer text which will be shown as response when the task is completed."
 #: ./opengever/task/browser/complete.py
@@ -825,9 +825,7 @@ msgstr "Accepté par ${user}"
 #. Default: "Accepted by ${user}, responsible changed from ${old_responsible} to ${new_responsible}."
 #: ./opengever/task/response_description.py
 msgid "transition_msg_accept_team_task"
-msgstr ""
-"Accepté par ${user}, mandataire changé de ${old_responsible} à "
-"${new_responsible}."
+msgstr "Accepté par ${user}, mandataire changé de ${old_responsible} à ${new_responsible}."
 
 #. Default: "Assigned to dossier by ${user} successor=${successor}"
 #: ./opengever/task/response_description.py

--- a/opengever/task/locales/opengever.task.pot
+++ b/opengever/task/locales/opengever.task.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2017-10-30 13:29+0000\n"
+"POT-Creation-Date: 2018-01-24 11:25+0000\n"
 "PO-Revision-Date: 2009-02-25 14:39+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -210,6 +210,11 @@ msgstr ""
 #. Default: "The documents (${title}) are still checked out.                                 Please checkin them in bevore deliver"
 #: ./opengever/task/validators.py
 msgid "error_checked_out_document"
+msgstr ""
+
+#. Default: "Team responsibles are only allowed if the task or forwarding is open."
+#: ./opengever/task/browser/assign.py
+msgid "error_no_team_responsible_in_progress_state"
 msgstr ""
 
 #. Default: "No changes: same responsible selected"

--- a/opengever/task/task.py
+++ b/opengever/task/task.py
@@ -310,6 +310,9 @@ class Task(Container):
         """Is true if the task responsible is a team."""
         return ActorLookup(self.responsible).is_team()
 
+    def is_open(self):
+        return api.content.get_state(self) in TaskModel.OPEN_STATES
+
     def get_issuer_label(self):
         return self.get_sql_object().get_issuer_label()
 

--- a/opengever/task/tests/test_assign.py
+++ b/opengever/task/tests/test_assign.py
@@ -98,6 +98,26 @@ class TestAssignTask(IntegrationTestCase):
               u'text': u'Finanzamt: Ziegler Robert (robert.ziegler)'}],
             browser.json.get('results'))
 
+    @browsing
+    def test_reassign_task_to_a_team_is_possible(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        self.set_workflow_state('task-state-open', self.task)
+
+        self.assign_task('team:1', 'Do something')
+        self.assertEquals('team:1', self.task.responsible)
+
+    @browsing
+    def test_reassign_task_in_progress_state_to_a_team_isnt_possible(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        self.assign_task('team:1', 'Do something')
+
+        self.assertEquals(
+            ['Team responsibles are only allowed if the task or forwarding is open.'],
+            browser.css('.fieldErrorBox .error').text)
+        self.assertEquals(self.regular_user.getId(), self.task.responsible)
+
 
 class TestAssignTaskWithSuccessors(IntegrationTestCase):
 


### PR DESCRIPTION
And support teams also when reassigning task/forwardings, but only when the task/forwarding is in an open state, otherwise the User is informed via message.

![bildschirmfoto 2018-01-24 um 18 10 13](https://user-images.githubusercontent.com/485755/35346241-00bf8746-0132-11e8-9f60-392c43af68bc.png)


Closes #3888 

Was a missing part of the OGIP 24 Teamaufgaben
