### PR TITLE
Regenerate and reindex reference numbers on private dossiers

### DIFF
--- a/opengever/base/reference_formatter.py
+++ b/opengever/base/reference_formatter.py
@@ -27,11 +27,20 @@ class DottedReferenceFormatter(object):
         """
         reference_number = u' '.join(numbers.get('site', []))
 
-        if self.repository_number(numbers):
+        if self.location_prefix(numbers):
             reference_number = u'%s %s' % (
+                self.location_prefix(numbers),
                 reference_number,
-                self.repository_number(numbers),
                 )
+
+        if self.repository_number(numbers):
+            if reference_number:
+                reference_number = u'%s %s' % (
+                    reference_number,
+                    self.repository_number(numbers),
+                    )
+            else:
+                reference_number = self.repository_number(numbers)
 
         if self.dossier_number(numbers):
             reference_number = u'%s%s%s' % (
@@ -48,6 +57,13 @@ class DottedReferenceFormatter(object):
                 )
 
         return reference_number.encode('utf-8')
+
+    def location_prefix(self, numbers):
+        """Return the location prefix of the context."""
+        location_prefix = numbers.get('location_prefix')
+        if location_prefix:
+            return ''.join(location_prefix)
+        return None
 
     def repository_number(self, numbers):
         """Generate the reposiotry reference number part.
@@ -216,8 +232,17 @@ class NoClientIdDottedReferenceFormatter(DottedReferenceFormatter):
         """Omit client id in this DottedReferenceFormatter."""
         reference_number = u''
 
+        if self.location_prefix(numbers):
+            reference_number = self.location_prefix(numbers)
+
         if self.repository_number(numbers):
-            reference_number = self.repository_number(numbers)
+            if reference_number:
+                reference_number = u'%s %s' % (
+                    reference_number,
+                    self.repository_number(numbers),
+                    )
+            else:
+                reference_number = self.repository_number(numbers)
 
         if self.dossier_number(numbers):
             reference_number = u'%s%s%s' % (
@@ -246,8 +271,17 @@ class NoClientIdGroupedByThreeFormatter(GroupedByThreeReferenceFormatter):
         """A client id omitting GroupedByThreeFormatter."""
         reference_number = u''
 
+        if self.location_prefix(numbers):
+            reference_number = self.location_prefix(numbers)
+
         if self.repository_number(numbers):
-            reference_number = self.repository_number(numbers)
+            if reference_number:
+                reference_number = u'%s %s' % (
+                    reference_number,
+                    self.repository_number(numbers),
+                    )
+            else:
+                reference_number = self.repository_number(numbers)
 
         if self.dossier_number(numbers):
             reference_number = u'%s%s%s' % (

--- a/opengever/core/upgrades/20180131180538_regenerate_and_reindex_reference_numbers_on_private_roots_and_their_contents/upgrade.py
+++ b/opengever/core/upgrades/20180131180538_regenerate_and_reindex_reference_numbers_on_private_roots_and_their_contents/upgrade.py
@@ -1,0 +1,26 @@
+from Acquisition import aq_inner
+from Acquisition import aq_parent
+from ftw.upgrade import UpgradeStep
+from opengever.base.interfaces import IReferenceNumberPrefix
+
+
+def regenerate_and_reindex_reference_number(obj):
+    parent = aq_parent(aq_inner(obj))
+    prefix_adapter = IReferenceNumberPrefix(parent)
+
+    prefix_adapter.set_number(obj)
+
+    obj.reindexObject(idxs=['reference'])
+
+    for child in obj.objectValues():
+        regenerate_and_reindex_reference_number(child)
+
+
+class RegenerateAndReindexReferenceNumbersOnPrivateRootsAndTheirContents(UpgradeStep):
+    """Regenerate and reindex reference numbers on private roots and their contents."""
+
+    def __call__(self):
+        query = {'portal_type': 'opengever.private.root'}
+
+        for obj in self.objects(query, 'Regenerate and reindex reference numbers on private roots and their contents.'):
+            regenerate_and_reindex_reference_number(obj)

--- a/opengever/private/configure.zcml
+++ b/opengever/private/configure.zcml
@@ -34,6 +34,7 @@
       handler=".subscribers.configure_private_root_portlets"
       />
 
+  <adapter factory=".reference.PrivateRootReferenceNumber" />
   <adapter factory=".reference.PrivateFolderReferenceNumber" />
 
 </configure>

--- a/opengever/private/dossier.py
+++ b/opengever/private/dossier.py
@@ -1,10 +1,6 @@
-from opengever.base.interfaces import IReferenceNumberFormatter
-from opengever.base.interfaces import IReferenceNumberSettings
 from opengever.dossier.base import DossierContainer
 from opengever.dossier.businesscase import IBusinessCaseDossier
 from opengever.private.interfaces import IPrivateContainer
-from plone import api
-from zope.component import queryAdapter
 
 
 class IPrivateDossier(IBusinessCaseDossier, IPrivateContainer):
@@ -16,23 +12,3 @@ class PrivateDossier(DossierContainer):
     """A specific dossier type, only addable to a PrivateFolder in the
     private Area and only visible for the Owner and Managers.
     """
-
-    def get_reference_number(self):
-        """Prefix reference numbers of private dossiers with a 'P'."""
-        active_formatter_name = api.portal.get_registry_record(
-            name='formatter',
-            interface=IReferenceNumberSettings,
-            )
-
-        formatter = queryAdapter(
-            api.portal.get(),
-            IReferenceNumberFormatter,
-            name=active_formatter_name,
-            )
-
-        separator = getattr(formatter, 'repository_dossier_separator', u' ')
-
-        return separator.join((
-            'P',
-            super(PrivateDossier, self).get_reference_number(),
-            ))

--- a/opengever/private/reference.py
+++ b/opengever/private/reference.py
@@ -1,6 +1,20 @@
 from opengever.base.reference import BasicReferenceNumber
 from opengever.private.folder import IPrivateFolder
+from opengever.private.root import IPrivateRoot
 from zope.component import adapter
+
+
+@adapter(IPrivateRoot)
+class PrivateRootReferenceNumber(BasicReferenceNumber):
+    """Reference number adapter for private roots.
+
+    Provides a local prefix for the reference number.
+    """
+
+    ref_type = 'location_prefix'
+
+    def get_local_number(self):
+        return getattr(self.context, 'location_prefix', None)
 
 
 @adapter(IPrivateFolder)

--- a/opengever/private/root.py
+++ b/opengever/private/root.py
@@ -17,3 +17,5 @@ class PrivateRoot(Container, TranslatedTitleMixin):
     implements(IHideFromBreadcrumbs)
 
     Title = TranslatedTitleMixin.Title
+
+    location_prefix = 'P'

--- a/opengever/private/tests/test_dossier.py
+++ b/opengever/private/tests/test_dossier.py
@@ -62,19 +62,6 @@ class TestPrivateDossier(FunctionalTestCase):
         self.assertEquals(2, sequence_number.get_number(dossier2))
         self.assertEquals(3, sequence_number.get_number(dossier3))
 
-    def test_uses_the_same_reference_number_schema_as_regular_dossiers(self):
-        dossier1 = create(Builder('private_dossier')
-                          .within(self.folder)
-                          .having(responsible=TEST_USER_ID))
-        dossier2 = create(Builder('private_dossier')
-                          .within(self.folder)
-                          .having(responsible=TEST_USER_ID))
-
-        self.assertEquals('Client1 test_user_1_ / 1',
-                          IReferenceNumber(dossier1).get_number())
-        self.assertEquals('Client1 test_user_1_ / 2',
-                          IReferenceNumber(dossier2).get_number())
-
     def test_allow_one_level_of_subdossiers(self):
         dossier = create(Builder('private_dossier')
                          .within(self.folder)

--- a/opengever/private/tests/test_folder.py
+++ b/opengever/private/tests/test_folder.py
@@ -36,7 +36,7 @@ class TestPrivateFolder(FunctionalTestCase):
         self.assertTrue(isinstance(self.folder.Title(), str))
 
     def test_uses_userid_as_reference_number_part(self):
-        self.assertEquals('Client1 test_user_1_',
+        self.assertIn('test_user_1_',
                           IReferenceNumber(self.folder).get_number())
 
     def test_adds_additonal_roles_after_creation(self):
@@ -99,9 +99,9 @@ class TestPrivateFolderTabbedView(FunctionalTestCase):
         self.assertEquals(
             [['', 'Reference Number', 'Title', 'Review state',
               'Responsible', 'Start', 'End'],
-             ['', 'Client1 test_user_1_ / 1', u'Zuz\xfcge',
+             ['', 'P Client1 test_user_1_ / 1', u'Zuz\xfcge',
               'dossier-state-active', '', '01.09.2015', ''],
-             ['', 'Client1 test_user_1_ / 2', u'Abg\xe4nge',
+             ['', 'P Client1 test_user_1_ / 2', u'Abg\xe4nge',
               'dossier-state-active', '', '01.09.2015', '']],
             browser.css('.listing').first.lists())
 

--- a/opengever/private/tests/test_reference_number.py
+++ b/opengever/private/tests/test_reference_number.py
@@ -1,5 +1,7 @@
+from ftw.testbrowser import browsing
 from opengever.base.interfaces import IReferenceNumberSettings
 from opengever.testing import IntegrationTestCase
+from opengever.testing.pages import tabbedview
 from plone import api
 
 
@@ -100,3 +102,43 @@ class TestPrivateReferenceNumber(IntegrationTestCase):
             expected_reference_numbers,
             found_reference_numbers,
             )
+
+    @browsing
+    def test_prefix_visible_on_private_folder(self, browser):
+        self.login(self.regular_user, browser)
+
+        browser.open(self.private_folder)
+        tabbedview.open('Dossiers')
+
+        urlified_user_id = self.regular_user.id.replace('.', '-')
+
+        expected_reference_numbers = [
+            'P Client1 kathi-barfuss / 1',
+            'P Client1 kathi-barfuss / 2',
+            ]
+
+        found_reference_numbers = [
+            item
+            for item in browser.css('.listing td').text
+            if urlified_user_id in item
+            ]
+
+        self.assertEqual(
+            len(expected_reference_numbers),
+            len(found_reference_numbers),
+            )
+
+        self.assertEqual(
+            sorted(expected_reference_numbers),
+            sorted(found_reference_numbers),
+            )
+
+    @browsing
+    def test_prefix_visible_on_private_document(self, browser):
+        self.login(self.regular_user, browser)
+        browser.open(self.private_document)
+
+        expected_reference_number = 'P Client1 kathi-barfuss / 1 / 21'
+        found_reference_number = browser.css('.referenceNumber .value').text[0]
+
+        self.assertEqual(found_reference_number, expected_reference_number)


### PR DESCRIPTION
Nicked the logic from: https://github.com/4teamwork/opengever.core/blob/a3eb6bb6b41d710441664de50bcd003c6f8ae1f7/opengever/dossier/handlers.py#L57-L79

Closes #3897