### PR TITLE
Ensure bumblebee overlay view download links point to the correct version

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ---------------------
 
 - Improve description for committee group label. [deiferni]
+- Ensure bumblebee overlay view download links point to the correct version. [Rotonen]
 - Make teams available as tasktemplate responsibles. [phgross]
 - Fix JWT authentication for users from the Zope root acl_users. [Rotonen]
 - Fix bumblebee preview in ECH0147 import. [deiferni]

--- a/opengever/bumblebee/tests/test_overlay_view.py
+++ b/opengever/bumblebee/tests/test_overlay_view.py
@@ -22,6 +22,71 @@ class TestBumblebeeOverlayListing(IntegrationTestCase):
         self.assertEqual(1, len(browser.css('#file-preview')))
 
     @browsing
+    def test_render_download_link(self, browser):
+        self.login(self.regular_user, browser)
+
+        browser.open(self.document, view='bumblebee-overlay-listing')
+        download_link = browser.css('#action-download')[0].get('href')
+
+        self.assertNotIn(
+            'version_id',
+            download_link,
+            )
+
+        create_document_version(self.document, version_id=0)
+
+        browser.open(self.document, view='bumblebee-overlay-listing')
+        download_link = browser.css('#action-download')[0].get('href')
+
+        self.assertNotIn(
+            'version_id',
+            download_link,
+            )
+
+        browser.open(
+            self.document,
+            view='bumblebee-overlay-listing?version_id=0',
+            )
+        download_link = browser.css('#action-download')[0].get('href')
+
+        self.assertNotIn(
+            'version_id',
+            download_link,
+            )
+
+        create_document_version(self.document, version_id=1)
+
+        browser.open(self.document, view='bumblebee-overlay-listing')
+        download_link = browser.css('#action-download')[0].get('href')
+
+        self.assertNotIn(
+            'version_id',
+            download_link,
+            )
+
+        browser.open(
+            self.document,
+            view='bumblebee-overlay-listing?version_id=0',
+            )
+        download_link = browser.css('#action-download')[0].get('href')
+
+        self.assertIn(
+            'version_id=0',
+            download_link,
+            )
+
+        browser.open(
+            self.document,
+            view='bumblebee-overlay-listing?version_id=1',
+            )
+        download_link = browser.css('#action-download')[0].get('href')
+
+        self.assertNotIn(
+            'version_id',
+            download_link,
+            )
+
+    @browsing
     def test_open_pdf_in_a_new_window_disabled(self, browser):
         self.login(self.regular_user, browser)
 

--- a/opengever/document/browser/actionbuttons.py
+++ b/opengever/document/browser/actionbuttons.py
@@ -81,11 +81,26 @@ class ActionButtonRendererMixin(object):
         links to the orginal message download view.
         """
         dc_helper = DownloadConfirmationHelper(self.context)
-        return dc_helper.get_html_tag(
-            additional_classes=['function-download-copy'],
-            viewname=self.context.get_download_view_name(),
-            include_token=True,
-        )
+
+        kwargs = {
+            'additional_classes': ['function-download-copy'],
+            'viewname': self.context.get_download_view_name(),
+            'include_token': True,
+            }
+
+        requested_version_id = self.request.get('version_id')
+
+        if requested_version_id:
+            requested_version_id = int(requested_version_id)
+            current_version_id = self.context.get_current_version_id()
+
+            if requested_version_id != current_version_id:
+                kwargs['url_extension'] = (
+                    '?version_id={}'
+                    .format(requested_version_id)
+                    )
+
+        return dc_helper.get_html_tag(**kwargs)
 
     def is_attach_to_email_available(self):
         if not is_officeconnector_attach_feature_enabled():


### PR DESCRIPTION
Appends the version_id parametre to download links if it is present in the request and that is not the current version.

Closes #3863 