### PR TITLE
Add SKA admin unit for development.

### DIFF
--- a/opengever/examplecontent/configure.zcml
+++ b/opengever/examplecontent/configure.zcml
@@ -11,7 +11,7 @@
 
 
   <opengever:registerDeployment
-      title="Development with examplecontent"
+      title="Development with examplecontent (FD)"
       policy_profile="opengever.examplecontent:default"
       additional_profiles="opengever.setup:default_content
                            opengever.examplecontent:empty_templates
@@ -19,6 +19,19 @@
                            opengever.examplecontent:municipality_content
                            opengever.examplecontent:init"
       admin_unit_id="fd"
+      records_manager_group="record_managers"
+      archivist_group="archiv"
+      />
+
+  <opengever:registerDeployment
+      title="Development with examplecontent (SKA)"
+      policy_profile="opengever.examplecontent:default-ska"
+      additional_profiles="opengever.setup:default_content
+                           opengever.examplecontent:empty_templates
+                           opengever.examplecontent:repository_minimal
+                           opengever.examplecontent:municipality_content
+                           opengever.examplecontent:init"
+      admin_unit_id="ska"
       records_manager_group="record_managers"
       archivist_group="archiv"
       />
@@ -36,6 +49,13 @@
       provides="Products.GenericSetup.interfaces.EXTENSION"
       />
   <include package=".upgrades" />
+
+  <genericsetup:registerProfile
+      name="default-ska"
+      title="opengever.examplecontent: default-ska"
+      directory="profiles/default-ska"
+      provides="Products.GenericSetup.interfaces.EXTENSION"
+      />
 
   <genericsetup:registerProfile
       name="init"

--- a/opengever/examplecontent/profiles/default-ska/metadata.xml
+++ b/opengever/examplecontent/profiles/default-ska/metadata.xml
@@ -1,0 +1,2 @@
+<metadata>
+</metadata>

--- a/opengever/examplecontent/profiles/default-ska/unit_creation/admin_units.json
+++ b/opengever/examplecontent/profiles/default-ska/unit_creation/admin_units.json
@@ -1,0 +1,10 @@
+[
+  {
+    "unit_id": "ska",
+    "title": "Staatskanzlei",
+    "ip_address": "127.0.0.1",
+    "site_url": "http://localhost:8080/ska",
+    "public_url": "http://localhost:8080/ska",
+    "abbreviation": "SKA"
+  }
+]

--- a/opengever/examplecontent/profiles/default-ska/unit_creation/org_units.json
+++ b/opengever/examplecontent/profiles/default-ska/unit_creation/org_units.json
@@ -1,0 +1,9 @@
+[
+  {
+    "unit_id": "ska-sk",
+    "title": "Sekretariat Staatskanzlei",
+    "admin_unit_id": "ska",
+    "users_group_id": "og_demo-ftw_users",
+    "inbox_group_id": "og_demo-ftw_users"
+  }
+]


### PR DESCRIPTION
In development, we have only one admin unit "FD" (=Plone site). In order to test things locally with two admin units, this adds a second admin unit "SKA" with one org unit, allowing for a easier setup.

When using it, make sure to not purge the SQL on setup.