### PR TITLE
Drop unused SQL sequences

### DIFF
--- a/opengever/core/upgrades/20180131153203_drop_unused_sequences/upgrade.py
+++ b/opengever/core/upgrades/20180131153203_drop_unused_sequences/upgrade.py
@@ -1,0 +1,28 @@
+from opengever.core.upgrade import SchemaMigration
+from sqlalchemy.schema import DropSequence
+from sqlalchemy.schema import Sequence
+
+
+class DropUnusedSequences(SchemaMigration):
+    """Drop unused sequences."""
+
+    def migrate(self):
+        # We'll only attempt to do this for postgresql
+        if self.is_postgres:
+            sequences_to_drop = (
+                'proposal_history_id_seq',
+                'subscriptions_resource_id_seq',
+                )
+
+            matching_sequences = tuple(
+                Sequence(sequence['relname'])
+                for sequence in self.execute(
+                    "select relname from pg_class "
+                    "where relkind = 'S' "
+                    "and relname in {}"
+                    .format(sequences_to_drop)
+                    ).fetchall()
+                )
+
+            for sequence in matching_sequences:
+                self.execute(DropSequence(sequence))


### PR DESCRIPTION
Ran `SELECT c.relname FROM pg_class c WHERE c.relkind = 'S';` on an older client installation and a fresh installation and diffed:

```
--- fresh.txt	2018-01-30 18:41:38.000000000 +0100
+++ <redacted>.txt	2018-01-30 18:41:29.000000000 +0100
@@ -23,9 +23,11 @@
 participations_id_seq
 periods_id_seq
 phonenumber_id_seq
+proposal_history_id_seq
 proposal_id_seq
 resources_id_seq
 submitteddocument_id_seq
+subscriptions_resource_id_seq
 task_id_seq
 teams_id_seq
 urls_id_seq
```

Closes #3477.