### PR TITLE
Fix malformed version URL on documents

### DIFF
--- a/opengever/tabbedview/helper.py
+++ b/opengever/tabbedview/helper.py
@@ -199,11 +199,10 @@ def linked_version_preview(item, value):
             _('label_preview', default='Preview'),
             context=getRequest()).encode('utf-8')
     }
-
     return """
     <div>
         <a class="showroom-item function-preview-pdf"
-           href="{%(url)s}"
+           href="%(url)s"
            data-showroom-target="%(showroom_url)s"
            data-showroom-title="%(showroom_title)s">%(title)s</a>
     </div>


### PR DESCRIPTION
Seems like a trivial copy/paste or carelessness from the initial implementation. It only ever acted as a fallback of the JS having failed to interject.

Closes #3922