### PR TITLE
Prevent navigation tree from getting favorites multiple times.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2018.1.0 (unreleased)
 ---------------------
 
+- Prevent navigation tree from getting favorites multiple times. [Kevin Bieri]
 - SPV: Rename "abgeschlossene Sitzungen" to "vergangene Sitzungen". [tarnap]
 - SPV: Sort memberships by member's last name. [tarnap]
 - Fix logout overlay when used with cross tab logout. [Kevin Bieri]

--- a/opengever/portlets/tree/resources/init_tree.js
+++ b/opengever/portlets/tree/resources/init_tree.js
@@ -24,7 +24,7 @@ $(function() {
     if ($(this).data('initialized')) {return;} $(this).data('initialized', 'true');
 
     var tree_node = $(this).find('>ul');
-    navigation_json.load(
+    navigation_json.load().then(
         function(tree_data) {
           var expand_store = ExpandStore('expanded_uids', 'uid');
           var navtree = make_tree(tree_data, {
@@ -48,7 +48,7 @@ $(function() {
   var favorites_tree;
   function render_favorites_tree() {
     var tree_node = portlet.find('#tree-favorites').find('>ul');
-    navigation_json.load(function(tree_data) {
+    navigation_json.load().then(function(tree_data) {
       favorites_store.load(function(favorites) {
         var fav_expand_store = ExpandStore('expanded_fav_uids', 'uid');
         var favorite_nodes = make_tree(tree_data).clone_by_uids(favorites);


### PR DESCRIPTION
Closes https://github.com/4teamwork/opengever.core/issues/3359

Every time the navigation tree wants to mark an entry with a favorite
tag, it triggers an XHR for getting all favorites entries.
So use promises to keep the loading task of the favorites pending until the data is
retrieved by the ajax call.