### PR TITLE
Fix multi admin unit setup.

### DIFF
--- a/opengever/core/upgrade.py
+++ b/opengever/core/upgrade.py
@@ -6,7 +6,6 @@ from ftw.upgrade.directory.recorder import UpgradeStepRecorder
 from opengever.base.model import create_session
 from plone.memoize import forever
 from Products.CMFCore.utils import getToolByName
-from Products.GenericSetup.upgrade import listUpgradeSteps
 from sqlalchemy import BigInteger
 from sqlalchemy import Column
 from sqlalchemy import MetaData
@@ -417,6 +416,9 @@ class GeverUpgradeStepRecorder(UpgradeStepRecorder):
     def mark_as_installed_in_sql(self, target_version):
         if not self.is_schema_migration(target_version):
             return False  # we only track SchemaMigration upgrade steps in SQL
+
+        if self.is_marked_installed_in_sql(target_version):
+            return False  # Version is already marked as installed.
 
         self._setup_db_connection()
         mark_changed(self.session)


### PR DESCRIPTION
When setting up an admin unit (Plone site), all past schema migrations are tracked as installed by inserting rows into the shared SQL.
Since we did not check whether the row was already added by another admin unit, there were SQL insertion errors when installing the second admin unit.

- Also removed an unused import.
- No changelog since initial implementation is in same release.