### PR TITLE
Fix mimetype registries.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ---------------------
 
 - Prevent navigation tree from getting favorites multiple times. [Kevin Bieri]
+- Fix bumblebee for *.bmp and *.ini files. [deiferni]
 - SPV: Rename "abgeschlossene Sitzungen" to "vergangene Sitzungen". [tarnap]
 - SPV: Sort memberships by member's last name. [tarnap]
 - Fix logout overlay when used with cross tab logout. [Kevin Bieri]

--- a/opengever/document/extra_mimetypes.py
+++ b/opengever/document/extra_mimetypes.py
@@ -133,4 +133,7 @@ ADDITIONAL_TYPES = [
 
     # Apple numbers
     ('application/x-iwork-numbers-sffnumbers', '.numbers'),
+
+    # Plain text
+    ('text/plain', '.ini'),
 ]

--- a/opengever/policy/base/profiles/mimetype/mimetypes.xml
+++ b/opengever/policy/base/profiles/mimetype/mimetypes.xml
@@ -22,6 +22,7 @@
                  image/x-bmp
                  image/x-MS-bmp"
       icon_path="icon_dokument_bilddatei.gif"
+      extensions="bmp"
       />
 
   <mimetype
@@ -32,6 +33,7 @@
   <mimetype
       mimetypes="text/plain"
       icon_path="icon_dokument_text.gif"
+      extensions="txt diff conf def in text pot ksh list log asc ini"
       />
 
   <mimetype

--- a/opengever/policy/base/upgrades_mimetypes/20180207161442_add_missing_extensions_to_mimetype_registry/mimetypes.xml
+++ b/opengever/policy/base/upgrades_mimetypes/20180207161442_add_missing_extensions_to_mimetype_registry/mimetypes.xml
@@ -1,0 +1,17 @@
+<object name="mimetypes_registry" meta_type="MimeTypes Registry">
+
+  <mimetype
+      mimetypes="image/bmp
+                 image/x-bmp
+                 image/x-MS-bmp"
+      icon_path="icon_dokument_bilddatei.gif"
+      extensions="bmp"
+      />
+
+  <mimetype
+      mimetypes="text/plain"
+      icon_path="icon_dokument_text.gif"
+      extensions="txt diff conf def in text pot ksh list log asc ini"
+      />
+
+</object>

--- a/opengever/policy/base/upgrades_mimetypes/20180207161442_add_missing_extensions_to_mimetype_registry/upgrade.py
+++ b/opengever/policy/base/upgrades_mimetypes/20180207161442_add_missing_extensions_to_mimetype_registry/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddMissingExtensionsToMimetypeRegistry(UpgradeStep):
+    """Add missing extensions to mimetype registry.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()


### PR DESCRIPTION
This PR fixes the various mimetype registries in such a way that they yield results as epxpected by bumblebee, see also https://github.com/4teamwork/ftw.bumblebee/blob/bc7b6f9ad9efe7bffd91a50b7a984797b0018d32/ftw/bumblebee/mimetypes.py#L19-L64.

Bumblebee expects the extension to be set for a mime-type in the plone mimetypes registry:
- Add `bmp` extension to `image/bmp`
- Add `ini` extension to `text/plain`

Also we need to register `ini` with python:
- Treat `ini` as `text/plain`