### PR TITLE
Fix testing cache by dropping opengever_upgrade_version table.

### DIFF
--- a/opengever/core/cached_testing.py
+++ b/opengever/core/cached_testing.py
@@ -312,10 +312,10 @@ class DBCacheManager(object):
 
         self._ensure_sql_database_is_empty()
         sql_file = stack['path'].joinpath('dump.sql')
+        sql_statements = ['DROP TABLE IF EXISTS opengever_upgrade_version']
+        sql_statements.extend(re.split(r';\n', sql_file.bytes().decode('utf-8')))
         session = create_session()
-        map(session.execute,
-            map(text,
-                re.split(r';\n', sql_file.bytes().decode('utf-8'))))
+        map(session.execute, map(text, sql_statements))
         transaction.commit()
 
     def _ensure_sql_database_is_empty(self):


### PR DESCRIPTION
When running functional tests, the opengever_upgrade_version may be left over because it is not registered in the metadata because of it's special nature (it is created on the fly).

This leads to problems when running integration tests from cache after running functional tests: in this case we have the table in our cache and cannot recreate it because it already exists.

The easiest solution is to just drop the table before loading from cache.