### PR TITLE
Content stats: Add custom GEVERPortalTypesProvider that sums up docs and mails

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2018.1.0 (unreleased)
 ---------------------
 
+- Content stats: Add custom GEVERPortalTypesProvider that sums up docs and mails. [lgraf]
 - Include favorites cache key in page cache key. [Kevin Bieri]
 - Content stats: Avoid producing empty string key in mimetypes stats. [lgraf]
 - Prevent navigation tree from getting favorites multiple times. [Kevin Bieri]

--- a/opengever/contentstats/configure.zcml
+++ b/opengever/contentstats/configure.zcml
@@ -13,6 +13,11 @@
       />
 
   <adapter
+      factory=".providers.GEVERPortalTypesProvider"
+      name="portal_types"
+      />
+
+  <adapter
       factory=".providers.CheckedOutDocsProvider"
       name="checked_out_docs"
       />

--- a/opengever/contentstats/filters.py
+++ b/opengever/contentstats/filters.py
@@ -39,6 +39,10 @@ class PortalTypesFilter(object):
         if key in OG_TYPES_BLACKLIST:
             return False
 
+        if key == '_opengever.document.behaviors.IBaseDocument':
+            # Fake portal type that sums up docs and mails
+            return True
+
         # Otherwise default to including all opengever.* types, and excluding
         # all the other ones (Plone stock types)
         if key.startswith('opengever.'):

--- a/opengever/contentstats/tests/test_content_stats_integration.py
+++ b/opengever/contentstats/tests/test_content_stats_integration.py
@@ -67,6 +67,9 @@ class TestContentStatsIntegration(IntegrationTestCase):
         # But any potential future type in opengever.* should be kept
         self.assertTrue(flt.keep('opengever.doesnt.exist.just.yet'))
 
+        # The fake portal_type that sums up docs and mails should also be kept
+        self.assertTrue(flt.keep('_opengever.document.behaviors.IBaseDocument'))  # noqa
+
     def test_review_states_filter(self):
         flt = getMultiAdapter(
             (self.portal, self.portal.REQUEST),
@@ -276,3 +279,14 @@ class TestContentStatsIntegrationWithFixture(FunctionalTestCase):
         self.assertEquals(
             [['', 'checked_in', '3'], ['', 'checked_out', '1']],
             table.lists())
+
+    def test_gever_portal_types_contains_base_documents(self):
+        stats_provider = getMultiAdapter(
+            (self.portal, self.portal.REQUEST),
+            IStatsProvider, name='portal_types')
+        stats = stats_provider.get_raw_stats()
+
+        self.assertIn('_opengever.document.behaviors.IBaseDocument', stats)
+        self.assertEquals(
+            stats['opengever.document.document'] + stats['ftw.mail.mail'],
+            stats['_opengever.document.behaviors.IBaseDocument'])


### PR DESCRIPTION
**Content stats**: Add custom GEVERPortalTypesProvider that sums up docs and mails:

This provider extends the list of `portal_types` with a new, fake portal_type `_opengever.document.behaviors.IBaseDocument` that contains the sum of regular documents and mails.

This is needed for easier processing down the line in the ELK stack.