### PR TITLE
Include favorites cache key in page cache key

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2018.1.0 (unreleased)
 ---------------------
 
+- Include favorites cache key in page cache key. [Kevin Bieri]
 - Content stats: Avoid producing empty string key in mimetypes stats. [lgraf]
 - Prevent navigation tree from getting favorites multiple times. [Kevin Bieri]
 - Fix bumblebee for *.bmp and *.ini files. [deiferni]

--- a/opengever/core/profiles/default/registry.xml
+++ b/opengever/core/profiles/default/registry.xml
@@ -33,6 +33,7 @@
       <element>quotawarning</element>
       <element>ouselector</element>
       <element>redirector</element>
+      <element>repository-favorites</element>
     </value>
   </record>
 
@@ -42,6 +43,7 @@
       <element>quotawarning</element>
       <element>ouselector</element>
       <element>redirector</element>
+      <element>repository-favorites</element>
     </value>
   </record>
 

--- a/opengever/core/upgrades/20180208155711_register_etag_value_for_repository_favorites/registry.xml
+++ b/opengever/core/upgrades/20180208155711_register_etag_value_for_repository_favorites/registry.xml
@@ -1,0 +1,15 @@
+<registry>
+
+  <record name="plone.app.caching.weakCaching.plone.content.itemView.etags">
+    <value purge="False">
+      <element>repository-favorites</element>
+    </value>
+  </record>
+
+  <record name="plone.app.caching.weakCaching.plone.content.folderView.etags">
+    <value purge="False">
+      <element>repository-favorites</element>
+    </value>
+  </record>
+
+</registry>

--- a/opengever/core/upgrades/20180208155711_register_etag_value_for_repository_favorites/upgrade.py
+++ b/opengever/core/upgrades/20180208155711_register_etag_value_for_repository_favorites/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class RegisterEtagValueForRepositoryFavorites(UpgradeStep):
+    """Register etag value for repository favorites.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/portlets/tree/configure.zcml
+++ b/opengever/portlets/tree/configure.zcml
@@ -55,4 +55,9 @@
       allowed_attributes="list add remove set"
       />
 
+  <adapter
+      factory=".favorites.RepositoryFavoritesETagValue"
+      name="repository-favorites"
+      />
+
 </configure>


### PR DESCRIPTION
Because the favorites cache key is placed in the page the cache for for the favorites request is never updated when the page comes from cache.