### PR TITLE
User details view: URLEncode group IDs in links to group members

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ---------------------
 
 - Content stats: Add custom GEVERPortalTypesProvider that sums up docs and mails. [lgraf]
+- User details view: URLEncode groupid's in links to group members. [lgraf]
 - Include favorites cache key in page cache key. [Kevin Bieri]
 - Content stats: Avoid producing empty string key in mimetypes stats. [lgraf]
 - Prevent navigation tree from getting favorites multiple times. [Kevin Bieri]

--- a/opengever/ogds/base/browser/templates/userdetails.pt
+++ b/opengever/ogds/base/browser/templates/userdetails.pt
@@ -118,7 +118,10 @@
               <td>
                   <ul class="groups">
                       <li tal:repeat="group groups">
-                        <a class="group link-overlay" tal:attributes="href string:list_groupmembers?group=${group/groupid}" tal:content="python: group.title or group.groupid"></a>
+                        <a class="group link-overlay"
+                           tal:define="groupmembers_url python:view.groupmembers_url(group.groupid)"
+                           tal:attributes="href groupmembers_url"
+                           tal:content="python: group.title or group.groupid"></a>
                       </li>
                   </ul>
               </td>

--- a/opengever/ogds/base/browser/userdetails.py
+++ b/opengever/ogds/base/browser/userdetails.py
@@ -2,6 +2,7 @@ from opengever.contact.utils import get_contactfolder_url
 from opengever.ogds.base.utils import ogds_service
 from opengever.ogds.models.exceptions import RecordNotFound
 from Products.Five import BrowserView
+from urllib import urlencode
 from zExceptions import NotFound
 from zope.component.hooks import getSite
 from zope.interface import implementer
@@ -41,3 +42,8 @@ class UserDetails(BrowserView):
 
     def contactfolder_url(team_id):
         return get_contactfolder_url()
+
+    def groupmembers_url(self, groupid):
+        portal = getSite()
+        qs = urlencode({'group': groupid})
+        return '/'.join((portal.portal_url(), '@@list_groupmembers?%s' % qs))

--- a/opengever/ogds/base/tests/test_userdetails.py
+++ b/opengever/ogds/base/tests/test_userdetails.py
@@ -28,10 +28,10 @@ class TestUserDetails(IntegrationTestCase):
             'Salutation': 'Prof. Dr.',
             'Teams': u'Projekt \xdcberbaung Dorfmatte',
             'URL': 'http://www.example.com',
-             }, metadata)
+        }, metadata)
 
     @browsing
-    def test_user_details_return_not_found_for_not_exisiting_user(self, browser):
+    def test_user_details_return_not_found_for_not_exisiting_user(self, browser):  # noqa
         with browser.expect_http_error(code=404):
             browser.login().open(self.portal, view='@@user-details/not.found')
 

--- a/opengever/ogds/base/tests/test_userdetails.py
+++ b/opengever/ogds/base/tests/test_userdetails.py
@@ -1,4 +1,5 @@
 from ftw.testbrowser import browsing
+from opengever.ogds.models.group import Group
 from opengever.testing import IntegrationTestCase
 
 
@@ -44,3 +45,35 @@ class TestUserDetails(IntegrationTestCase):
             [u'Projekt \xdcberbaung Dorfmatte'], browser.css('.teams li').text)
         self.assertEquals('http://nohost/plone/kontakte/team-1/view',
                           browser.css('.teams a').first.get('href'))
+
+    @browsing
+    def test_lists_group_memberships(self, browser):
+        self.login(self.regular_user, browser)
+
+        browser.open(self.portal, view='@@user-details/kathi.barfuss')
+
+        self.assertEqual(
+            ['fa_users', 'Projekt A'], browser.css('.groups li').text)
+
+        group_links = [a.get('href') for a in browser.css('.groups li a')]
+        self.assertEqual(
+            ['http://nohost/plone/@@list_groupmembers?group=fa_users',
+             'http://nohost/plone/@@list_groupmembers?group=projekt_a'],
+            group_links)
+
+    @browsing
+    def test_urlencodes_group_member_urls(self, browser):
+        self.login(self.regular_user, browser)
+        user = self.get_ogds_user(self.regular_user)
+
+        group_with_spaces = Group(groupid='with spaces')
+        user.groups.append(group_with_spaces)
+
+        browser.open(self.portal, view='@@user-details/kathi.barfuss')
+
+        group_links = [a.get('href') for a in browser.css('.groups li a')]
+        self.assertEqual(
+            ['http://nohost/plone/@@list_groupmembers?group=fa_users',
+             'http://nohost/plone/@@list_groupmembers?group=projekt_a',
+             'http://nohost/plone/@@list_groupmembers?group=with+spaces'],
+            group_links)


### PR DESCRIPTION
User details view: URLEncode group IDs in links to group members. This for example is necessary to make groups with spaces in their ID work.