### PR TITLE
Restapi items fieldlist

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -77,6 +77,7 @@ Changelog
 - Improve Office Connector testing. [Rotonen]
 - SPV: Make title and dossier column wider and remove invalid sorting options in meetings tab. [tarnap]
 - Integrate Solr into search form, live search and tabbedview filter. [buchi]
+- Add option to get a custom field list in REST API summaries. [buchi]
 
 
 2017.7.8 (2018-01-23)

--- a/docs/public/dev-manual/api/examples/example_get_custom_summary.py
+++ b/docs/public/dev-manual/api/examples/example_get_custom_summary.py
@@ -1,0 +1,3 @@
+url = 'https://example.org/ordnungssystem/fuehrung/?items.fl=filesize,filename'
+response = session.get(url)
+items = response.json()['items']

--- a/docs/public/dev-manual/api/index.rst
+++ b/docs/public/dev-manual/api/index.rst
@@ -12,6 +12,7 @@ Inhalt:
    exploring.rst
    serialization.rst
    batching.rst
+   summaries.rst
    searching.rst
    workflow.rst
    scanin.rst

--- a/docs/public/dev-manual/api/operations.rst
+++ b/docs/public/dev-manual/api/operations.rst
@@ -24,8 +24,9 @@ Mit einem ``GET`` Request auf die URL eines Objekts können die Daten
 (Metadaten wie auch Primärdaten) eines Objekts ausgelesen werden.
 
 Im Fall eines Objekts das "folderish" ist (ein Container), gibt es ein
-spezielles Attribut ``items``, welches eine summarische Auflistung der
-Unterobjekte enthält (direkte children des Objekts).
+spezielles Attribut ``items``, welches eine
+:ref:`summarische Auflistung <summaries>` der Unterobjekte enthält (direkte
+children des Objekts).
 
 
 .. http:get:: /(path)

--- a/docs/public/dev-manual/api/searching.rst
+++ b/docs/public/dev-manual/api/searching.rst
@@ -97,4 +97,10 @@ können diese mittels der Option ``metadata_fields`` verlangt werden:
 Um *alle* im Suchkatalog verfügbaren Metadaten direkt in den Suchresultaten
 darzustellen, kann ``metadata_fields=_all`` verwendet werden.
 
+.. note::
+    Die Verwendung des ``metadata_fields`` Parameters bedingt Kenntnis der
+    internen Index-Namen, und sollte daher mit 4teamwork abgesprochen werden.
+    Für :ref:`summarische Auflistungen bei GET requests <summaries>` gibt es
+    einen separaten Mechanismus.
+
 .. disqus::

--- a/docs/public/dev-manual/api/summaries.rst
+++ b/docs/public/dev-manual/api/summaries.rst
@@ -1,0 +1,97 @@
+.. _summaries:
+
+Summarische Auflistungen
+------------------------
+
+Einträge in summarischen Auflistungen von Containern ("Foldern") enthalten
+standardmässig die Felder ``@type``, ``title``, ``description`` und ``review_state``.
+
+Über den Query-String Parameter ``items.fl`` kann die gewünschte Liste der
+Felder jedoch angegeben werden (kommagetrennt), um spezifische Metadaten
+in der summarischen Auflistung zu erhalten.
+
+Die zur Zeit unterstützden Felder für summarische Auflistungen sind die
+folgenden:
+
+- ``@type`` (Inhaltstyp)
+- ``created`` (Erstellungsdatum)
+- ``creator`` (Ersteller)
+- ``description`` (Beschreibung)
+- ``filename`` (Dateiname, falls Dokument)
+- ``filesize`` (Dateigrösse, falls Dokument)
+- ``mimetype`` (Datetyp, falls Dokument)
+- ``modified`` (Modifikationsdatum)
+- ``review_state`` (Workflow-Status)
+- ``title`` (Titel)
+
+
+Der Query-String Parameter ``items.fl`` kann verwendet werden, um die in
+summarische Auflistungen für ``GET`` requests zu steuern.
+
+.. note::
+    Die summarischen Auflistungen von Suchresultaten des ``@search`` endpoints
+    haben einen ähnlichen Mechanismus (``metdata_fields``), der aber Kenntnis
+    der internen Index-Namen voraussetzt, und deshalb anders benannt ist.
+
+
+Beispiel anhand eines ``GET`` requests
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. http:get:: /(path)?items.fl=(fieldlist)
+
+   Liefert die Attribute des Objekts unter `path` zurück, mit den in
+   `fieldlist` angegebenen Feldern in der summarischen Auflistung
+   der children (``items``).
+
+   **Beispiel-Request**:
+
+   .. sourcecode:: http
+
+      GET /ordnungssystem/fuehrung/dossier-23?items.fl=filesize,filename HTTP/1.1
+      Accept: application/json
+
+   **Beispiel-Response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 200 OK
+      Content-Type: application/json
+
+      {
+        "@context": "http://www.w3.org/ns/hydra/context.jsonld",
+        "@id": "https://example.org/ordnungssystem/fuehrung/dossier-23",
+        "@type": "opengever.dossier.businesscasedossier",
+        "title": "Ein Geschäftsdossier",
+
+        "...": "",
+
+        "items": [
+          {
+            "@id": "https://example.org/ordnungssystem/fuehrung/dossier-23/document-259",
+            "filesize": 42560,
+            "filename": "vortrag.docx",
+          },
+          {
+            "@id": "https://example.org/ordnungssystem/fuehrung/dossier-23/document-260",
+            "filesize": 73536,
+            "filename": "bewerbung.docx",
+          }
+        ],
+        "parent": {
+          "@id": "https://example.org/ordnungssystem/fuehrung",
+          "filesize": null,
+          "filename": null,
+        },
+
+        "...": ""
+
+      }
+
+
+.. container:: collapsible
+
+    .. container:: header
+
+       **Code-Beispiel (Python)**
+
+    .. literalinclude:: examples/example_get_custom_summary.py

--- a/opengever/api/summary.py
+++ b/opengever/api/summary.py
@@ -90,6 +90,7 @@ def filename(obj):
 FIELD_ACCESSORS = {
     '@type': 'PortalType',
     'created': 'created',
+    'creator': 'Creator',
     'description': 'Description',
     'filename': filename,
     'filesize': filesize,

--- a/opengever/api/tests/test_summary.py
+++ b/opengever/api/tests/test_summary.py
@@ -1,87 +1,88 @@
-from ftw.builder import Builder
-from ftw.builder import create
+# -*- coding: utf-8 -*-
+from ftw.testbrowser import browsing
 from opengever.api.testing import RelativeSession
-from opengever.core.testing import OPENGEVER_FUNCTIONAL_ZSERVER_TESTING
-from opengever.testing import FunctionalTestCase
+from opengever.testing import IntegrationTestCase
 from plone import api
 from plone.app.testing import SITE_OWNER_NAME
 from plone.app.testing import SITE_OWNER_PASSWORD
-import transaction
 
 
-class TestGeverJSONSummarySerializer(FunctionalTestCase):
-
-    layer = OPENGEVER_FUNCTIONAL_ZSERVER_TESTING
+class TestGeverJSONSummarySerializer(IntegrationTestCase):
 
     def setUp(self):
         super(TestGeverJSONSummarySerializer, self).setUp()
-        self.portal = self.layer['portal']
 
         self.api = RelativeSession(self.portal.absolute_url())
         self.api.headers.update({'Accept': 'application/json'})
         self.api.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
 
-        self.repo = create(Builder('repository_root')
-                           .having(id='ordnungssystem',
-                                   title_de=u'Ordnungssystem',
-                                   title_fr=u'Syst\xe8me de classement'))
-        self.repofolder = create(Builder('repository')
-                                 .within(self.repo)
-                                 .having(title_de=u'Ordnungsposition',
-                                         title_fr=u'Position'))
-        self.dossier = create(Builder('dossier')
-                              .within(self.repofolder)
-                              .titled(u'Mein Dossier'))
-
         lang_tool = api.portal.get_tool('portal_languages')
         lang_tool.setDefaultLanguage('de-ch')
         lang_tool.supported_langs = ['fr-ch', 'de-ch']
-        transaction.commit()
 
-    def test_portal_type_is_included(self):
-        response = self.api.get('/ordnungssystem')
-        repofolder_summary = response.json()['items'][0]
+    @browsing
+    def test_portal_type_is_included(self, browser):
+        self.login(self.administrator, browser)
+        browser.open(
+            self.repository_root.absolute_url(),
+            headers={'Accept': 'application/json'})
+        repofolder_summary = browser.json['items'][0]
 
         self.assertDictContainsSubset(
             {u'@type': u'opengever.repository.repositoryfolder'},
             repofolder_summary)
 
-        response = self.api.get('/ordnungssystem/ordnungsposition')
-        dossier_summary = response.json()['items'][0]
+        browser.open(
+            self.leaf_repofolder.absolute_url(),
+            headers={'Accept': 'application/json'})
+        dossier_summary = browser.json['items'][0]
 
         self.assertDictContainsSubset(
             {u'@type': u'opengever.dossier.businesscasedossier'},
             dossier_summary)
 
-    def test_translated_title_contained_in_summary_if_obj_translated(self):
-        response = self.api.get(
-            '/ordnungssystem', headers={'Accept-Language': 'de-ch'})
-        repofolder_summary = response.json()['items'][0]
+    @browsing
+    def test_translated_title_contained_in_summary_if_obj_translated(
+            self, browser):
+        self.login(self.administrator, browser)
+        browser.open(
+            self.repository_root.absolute_url(),
+            headers={'Accept': 'application/json', 'Accept-Language': 'de-ch'})
+        repofolder_summary = browser.json['items'][0]
 
         self.assertDictContainsSubset(
-            {u'title': u'1. Ordnungsposition'},
+            {u'title': u'1. Führung'},
             repofolder_summary)
 
-        response = self.api.get(
-            '/ordnungssystem', headers={'Accept-Language': 'fr-ch'})
-        repofolder_summary = response.json()['items'][0]
+        browser.open(
+            self.repository_root.absolute_url(),
+            headers={'Accept': 'application/json', 'Accept-Language': 'fr-ch'})
+        repofolder_summary = browser.json['items'][0]
 
         self.assertDictContainsSubset(
-            {u'title': u'1. Position'},
+            {u'title': u'1. Direction'},
             repofolder_summary)
 
-    def test_translated_titles_default_to_german(self):
-        response = self.api.get('/ordnungssystem')
-        repofolder_summary = response.json()['items'][0]
+    @browsing
+    def test_translated_titles_default_to_german(self, browser):
+        self.login(self.administrator, browser)
+        browser.open(
+            self.repository_root.absolute_url(),
+            headers={'Accept': 'application/json'})
+        repofolder_summary = browser.json['items'][0]
 
         self.assertDictContainsSubset(
-            {u'title': u'1. Ordnungsposition'},
+            {u'title': u'1. Führung'},
             repofolder_summary)
 
-    def test_regular_title_in_summary_if_obj_not_translated(self):
-        response = self.api.get('/ordnungssystem/ordnungsposition')
-        dossier_summary = response.json()['items'][0]
+    @browsing
+    def test_regular_title_in_summary_if_obj_not_translated(self, browser):
+        self.login(self.administrator, browser)
+        browser.open(
+            self.leaf_repofolder.absolute_url(),
+            headers={'Accept': 'application/json'})
+        dossier_summary = browser.json['items'][0]
 
         self.assertDictContainsSubset(
-            {u'title': u'Mein Dossier'},
+            {u'title': u'Verträge mit der kantonalen Finanzverwaltung'},
             dossier_summary)

--- a/opengever/api/tests/test_summary.py
+++ b/opengever/api/tests/test_summary.py
@@ -86,3 +86,25 @@ class TestGeverJSONSummarySerializer(IntegrationTestCase):
         self.assertDictContainsSubset(
             {u'title': u'Verträge mit der kantonalen Finanzverwaltung'},
             dossier_summary)
+
+    @browsing
+    def test_summary_with_custom_field_list(self, browser):
+        self.login(self.administrator, browser)
+        browser.open(
+            self.dossier.absolute_url() +
+            '?items.fl=filesize,filename,modified,created,mimetype',
+            headers={'Accept': 'application/json'})
+
+        summary = browser.json['items'][0]
+        self.assertEqual(
+            summary,
+            {
+                u'@id': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-'
+                u'und-vereinbarungen/dossier-1/document-5',
+                u'created': u'2016-08-31T15:07:33+02:00',
+                u'filename': u'vertragsentwurf.docx',
+                u'filesize': 27413,
+                u'mimetype': u'application/vnd.openxmlformats-officedocument.'
+                u'wordprocessingml.document',
+                u'modified': u'2016-08-31T15:07:33+02:00',
+            })

--- a/opengever/api/tests/test_summary.py
+++ b/opengever/api/tests/test_summary.py
@@ -92,7 +92,7 @@ class TestGeverJSONSummarySerializer(IntegrationTestCase):
         self.login(self.administrator, browser)
         browser.open(
             self.dossier.absolute_url() +
-            '?items.fl=filesize,filename,modified,created,mimetype',
+            '?items.fl=filesize,filename,modified,created,mimetype,creator',
             headers={'Accept': 'application/json'})
 
         summary = browser.json['items'][0]
@@ -102,6 +102,7 @@ class TestGeverJSONSummarySerializer(IntegrationTestCase):
                 u'@id': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-'
                 u'und-vereinbarungen/dossier-1/document-5',
                 u'created': u'2016-08-31T15:07:33+02:00',
+                u'creator': u'robert.ziegler',
                 u'filename': u'vertragsentwurf.docx',
                 u'filesize': 27413,
                 u'mimetype': u'application/vnd.openxmlformats-officedocument.'


### PR DESCRIPTION
It's now possible to specify additional fields that should be returned in summaries of GET requests.

The requested fields are given with the url parameter `items.fl`.
Example: `items.fl=filename,filesize,modified`

 