### PR TITLE
Fix repository favorites cache key generation for Anonymous users

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2018.1.0 (unreleased)
 ---------------------
 
+- Fix repository favorites cache key generation for Anonymous users. [lgraf]
 - Update plone.restapi to 1.1.0 and plone.rest to 1.0.0. [buchi]
 - Bump Products.LDAPMultiPlugins to 1.15.post3 to handle commas in CNs. [lgraf]
 - Content stats: Add custom GEVERPortalTypesProvider that sums up docs and mails. [lgraf]

--- a/opengever/portlets/tree/favorites.py
+++ b/opengever/portlets/tree/favorites.py
@@ -5,6 +5,7 @@ from opengever.base.protect import unprotected_write
 from opengever.portlets.tree.interfaces import IRepositoryFavorites
 from opengever.repository.repositoryroot import IRepositoryRoot
 from persistent.list import PersistentList
+from plone import api
 from plone.app.caching.interfaces import IETagValue
 from Products.Five import BrowserView
 from zope.annotation.interfaces import IAnnotations
@@ -143,6 +144,10 @@ class RepositoryFavoritesETagValue(object):
                             self.get_repository_roots()))
 
     def get_cache_key_for_repository_root(self, repository_root):
+        if api.user.is_anonymous():
+            # Anonymous users can't have repository favorites - short circuit
+            # cache key generation, no need to ask the view
+            return ''
         view = repository_root.restrictedTraverse('repository-favorites')
         return view.get_cache_key()
 

--- a/opengever/portlets/tree/tests/test_favorites.py
+++ b/opengever/portlets/tree/tests/test_favorites.py
@@ -4,6 +4,7 @@ from ftw.testbrowser import browsing
 from opengever.portlets.tree.interfaces import IRepositoryFavorites
 from opengever.testing import FunctionalTestCase
 from plone.app.caching.interfaces import IETagValue
+from plone.app.testing import logout
 from plone.app.testing import TEST_USER_ID
 from zope.component import getMultiAdapter
 
@@ -76,6 +77,10 @@ class TestRepositoryFavoritesView(FunctionalTestCase):
         self.assertEquals(value, self.get_etag_value_for(self.portal))
         self.favorites_for(TEST_USER_ID).add('foo!')
         self.assertNotEqual(value, self.get_etag_value_for(self.root))
+
+    def test_etag_value_for_anonymous(self):
+        logout()
+        self.assertEquals('', self.get_etag_value_for(self.root))
 
     def favorites_for(self, username):
         return getMultiAdapter((self.root, username), IRepositoryFavorites)


### PR DESCRIPTION
Fix repository favorites cache key generation for Anonymous users: Anonymous users can't have repository favorites - we therefore short circuit cache key generation, no need to ask the view.

This avoids `Unauthorized` exceptions where we attempted to traverse to the view as Anonymous users, just to ask it for its `ETag` contribution.