### PR TITLE
Add missing translation domain.

### DIFF
--- a/opengever/tabbedview/browser/selection_with_filters.pt
+++ b/opengever/tabbedview/browser/selection_with_filters.pt
@@ -1,7 +1,7 @@
 <div class="tabbedview_select" i18n:domain="ftw.tabbedview">
 
     <tal:condition tal:condition="view/show_selects">
-      <span i18n:translate="">Choose</span>
+      <span i18n:domain="opengever.tabbedview" i18n:translate="">Choose</span>
       <a href="javascript:tabbedview.select_all()" i18n:translate="">
           all (<span i18n:name="amount" tal:replace="python:len(view.contents)" />)</a>,
       <a href="javascript:tabbedview.select_none()" i18n:translate="">none</a>

--- a/opengever/tabbedview/locales/de/LC_MESSAGES/opengever.tabbedview.po
+++ b/opengever/tabbedview/locales/de/LC_MESSAGES/opengever.tabbedview.po
@@ -23,6 +23,7 @@ msgstr "Aktiv"
 msgid "All visible entries chosen <a href=\"#\">x</a>"
 msgstr "Alle Sichtbaren ausgewählt <a href=\"#\">x</a>"
 
+#: ./opengever/tabbedview/browser/selection_with_filters.pt
 msgid "Choose"
 msgstr "Auswählen"
 

--- a/opengever/tabbedview/locales/fr/LC_MESSAGES/opengever.tabbedview.po
+++ b/opengever/tabbedview/locales/fr/LC_MESSAGES/opengever.tabbedview.po
@@ -26,6 +26,7 @@ msgstr "Actif"
 msgid "All visible entries chosen <a href=\"#\">x</a>"
 msgstr "Choix de toutes les entrées visibles <a href=\"#\">x</a>"
 
+#: ./opengever/tabbedview/browser/selection_with_filters.pt
 msgid "Choose"
 msgstr "Choix"
 

--- a/opengever/tabbedview/locales/opengever.tabbedview-manual.pot
+++ b/opengever/tabbedview/locales/opengever.tabbedview-manual.pot
@@ -162,10 +162,6 @@ msgstr ""
 msgid "All visible entries chosen <a href=\"#\">x</a>"
 msgstr ""
 
--#: ./opengever/tabbedview/browser/tabs_templates/generic.pt:12
-msgid "Choose"
-msgstr ""
-
 #: ./opengever/tabbedview/browser/tabs_templates/generic.pt:13
 msgid "Show all in this Folder"
 msgstr ""

--- a/opengever/tabbedview/locales/opengever.tabbedview.pot
+++ b/opengever/tabbedview/locales/opengever.tabbedview.pot
@@ -24,6 +24,7 @@ msgstr ""
 msgid "All visible entries chosen <a href=\"#\">x</a>"
 msgstr ""
 
+#: ./opengever/tabbedview/browser/selection_with_filters.pt
 msgid "Choose"
 msgstr ""
 


### PR DESCRIPTION
Add missing ftw.tabbedview domain as we translate the label in that domain for all listings.

Fixed:
<img width="216" alt="screen shot 2018-02-12 at 20 00 50" src="https://user-images.githubusercontent.com/736583/36114225-a7953d20-102f-11e8-8304-c8b11b9926c2.png">

Before:
![1feace2e-1018-11e8-87a1-a0369f35f0c0](https://user-images.githubusercontent.com/736583/36114208-9fa16cc4-102f-11e8-9bdd-b5933d460459.png)

Backref: https://basecamp.com/2768704/projects/12554551/todos/341841512