### PR TITLE
Combine similar transitions to one in the activity settings page.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -15,6 +15,7 @@ Changelog
 - Prevent navigation tree from getting favorites multiple times. [Kevin Bieri]
 - Fix bumblebee for *.bmp and *.ini files. [deiferni]
 - Fix select2 value dropdowns, which has been hidden by the exposator. [phgross]
+- Combine similar transitions to one in the activity settings page. [phgross]
 - SPV: Rename "abgeschlossene Sitzungen" to "vergangene Sitzungen". [tarnap]
 - SPV: Sort memberships by member's last name. [tarnap]
 - Fix logout overlay when used with cross tab logout. [Kevin Bieri]

--- a/opengever/activity/browser/settings.py
+++ b/opengever/activity/browser/settings.py
@@ -37,7 +37,6 @@ ACTIVITY_GROUPS = [
          'task-transition-open-rejected',
          'task-commented',
          'task-transition-reassign',
-         'task-transition-rejected-open',
          'task-transition-resolved-in-progress',
      ]},
 
@@ -62,7 +61,12 @@ ALIASES = {
     ),
     'task-transition-in-progress-resolved': (
         'task-transition-in-progress-resolved',
-        'task-transition-open-resolved')
+        'task-transition-open-resolved',
+    ),
+    'task-transition-cancelled-open': (
+        'task-transition-cancelled-open',
+        'task-transition-rejected-open',
+    ),
 }
 
 

--- a/opengever/activity/tests/test_settings.py
+++ b/opengever/activity/tests/test_settings.py
@@ -22,7 +22,8 @@ class TestListSettings(IntegrationTestCase):
 
         aliased = ['task-transition-open-tested-and-closed',
                    'task-transition-resolved-tested-and-closed',
-                   'task-transition-open-resolved']
+                   'task-transition-open-resolved',
+                   'task-transition-rejected-open']
 
         self.assertItemsEqual(
             [item.get('kind') for item in activities],

--- a/opengever/activity/tests/test_settings.py
+++ b/opengever/activity/tests/test_settings.py
@@ -14,14 +14,20 @@ class TestListSettings(IntegrationTestCase):
     features = ('activity', )
 
     @browsing
-    def test_list_all_settings(self, browser):
+    def test_list_all_settings_expect_aliased_objects(self, browser):
         self.login(self.regular_user, browser=browser)
         browser.open(self.portal, view='notification-settings/list')
 
         activities = browser.json.get('activities')
-        self.assertEquals(
+
+        aliased = ['task-transition-open-tested-and-closed',
+                   'task-transition-resolved-tested-and-closed',
+                   'task-transition-open-resolved']
+
+        self.assertItemsEqual(
             [item.get('kind') for item in activities],
-            [item.get('kind') for item in DEFAULT_SETTINGS])
+            [item.get('kind') for item in DEFAULT_SETTINGS
+             if item.get('kind') not in aliased])
 
         task_added = [item for item in activities if item.get('kind') == 'task-added'][0]
         self.assertEquals({u'task_issuer': False, u'task_responsible': True},
@@ -108,6 +114,30 @@ class TestSaveSettings(IntegrationTestCase):
                           settings[0].digest_notification_roles)
 
     @browsing
+    def test_save_adds_personal_setting_also_for_aliased_kinds(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        data = self.data.copy()
+        data['kind'] = 'task-transition-in-progress-tested-and-closed'
+
+        browser.open(self.portal, view='notification-settings/save', data=data)
+
+        settings = NotificationSetting.query.filter_by(
+            userid=self.regular_user.getId()).all()
+
+        self.assertEquals(3, len(settings))
+        self.assertEquals(
+            [u'task-transition-in-progress-tested-and-closed',
+             u'task-transition-open-tested-and-closed',
+             u'task-transition-resolved-tested-and-closed'],
+            [setting.kind for setting in settings])
+
+        self.assertEquals(frozenset([TASK_RESPONSIBLE_ROLE, TASK_ISSUER_ROLE]),
+                          settings[1].mail_notification_roles)
+        self.assertEquals(frozenset([TASK_ISSUER_ROLE]),
+                          settings[1].badge_notification_roles)
+
+    @browsing
     def test_save_updates_personal_setting_when_exists(self, browser):
         create(Builder('notification_setting')
                .having(kind='task-added',
@@ -136,7 +166,7 @@ class TestResetSetting(IntegrationTestCase):
     features = ('activity', )
 
     @browsing
-    def test_save_updates_personal_setting_when_exists(self, browser):
+    def test_reset_removes_personal_setting_when_exists(self, browser):
         create(Builder('notification_setting')
                .having(kind='task-added',
                        userid=self.regular_user.getId(),
@@ -150,5 +180,25 @@ class TestResetSetting(IntegrationTestCase):
         self.login(self.regular_user, browser=browser)
         browser.open(self.portal, view='notification-settings/reset',
                      data={'kind': 'task-added'})
+
+        self.assertEquals(0, query.count())
+
+    @browsing
+    def test_reset_removes_also_aliased_settings_when_exists(self, browser):
+        for kind in ['task-transition-in-progress-tested-and-closed',
+                     'task-transition-open-tested-and-closed',
+                     'task-transition-resolved-tested-and-closed']:
+            create(Builder('notification_setting')
+                   .having(kind=kind,
+                           userid=self.regular_user.getId(),
+                           mail_notification_roles=[],
+                           badge_notification_roles=[]))
+
+        query = NotificationSetting.query.filter_by(userid=self.regular_user.getId())
+        self.assertEquals(3, query.count())
+
+        self.login(self.regular_user, browser=browser)
+        browser.open(self.portal, view='notification-settings/reset',
+                     data={'kind': 'task-transition-in-progress-tested-and-closed'})
 
         self.assertEquals(0, query.count())

--- a/opengever/core/upgrades/20180213141432_migrate_grouped_notification_settings/upgrade.py
+++ b/opengever/core/upgrades/20180213141432_migrate_grouped_notification_settings/upgrade.py
@@ -1,0 +1,166 @@
+from ftw.upgrade import UpgradeStep
+from opengever.activity.model import NotificationDefault
+from opengever.activity.model import NotificationSetting
+from opengever.ogds.base.utils import create_session
+import logging
+
+
+log = logging.getLogger('ftw.upgrade')
+
+
+ALIASED_SETTINGS = {
+    'task-transition-in-progress-tested-and-closed': (
+        'task-transition-in-progress-tested-and-closed',
+        'task-transition-open-tested-and-closed',
+        'task-transition-resolved-tested-and-closed',
+    ),
+    'task-transition-in-progress-resolved': (
+        'task-transition-in-progress-resolved',
+        'task-transition-open-resolved',
+    ),
+    'task-transition-cancelled-open': (
+        'task-transition-cancelled-open',
+        'task-transition-rejected-open',
+    ),
+}
+
+
+CHANNELS = (
+    'badge_notification_roles',
+    'mail_notification_roles',
+    'digest_notification_roles',
+)
+
+
+class MigrateGroupedNotificationSettings(UpgradeStep):
+    """Migrate grouped notification settings (alias groups).
+
+    This is required because if the settings for aliased groups aren't
+    homogenous for a specific alias group, the UI might show different
+    settings than those that will actually be used.
+    """
+
+    def __call__(self):
+        log.info("Migrating notification settings for aliased groups...")
+        self.session = create_session()
+        self.new_settings_to_insert = {}
+
+        # Determine notification defaults *once*, ahead of time
+        self.notification_defaults = {
+            default.kind: default for default in NotificationDefault.query}
+
+        # Get a list of distinct userids of users that have any settings stored
+        users_with_settings = [
+            r[0] for r in self.session.query(
+                NotificationSetting.userid.distinct())
+        ]
+
+        # For each user, homogenize their settings
+        for userid in users_with_settings:
+            self.homogenize_settings(userid)
+
+        # Finally, add any new setting rows that were missing (necessary where
+        # only some kinds of an alias group had non-default settings)
+        self.insert_newly_required_settings()
+        log.info("Done migrating notification settings for aliased groups")
+
+    def homogenize_settings(self, userid):
+        """For each group of aliased kinds, make sure they all have the same
+        roles ticked for a given channel. We set the ticked roles to the
+        union of all roles across the alias group.
+        """
+        for alias_group in ALIASED_SETTINGS.values():
+            settings_group = NotificationSetting.query.filter_by(
+                userid=userid).filter(
+                    NotificationSetting.kind.in_(alias_group)).all()
+
+            for channel in CHANNELS:
+
+                # Determine the new roles to set. Union of all roles across
+                # all aliased kinds for this channel.
+                new_roles = set()
+                for setting in settings_group:
+                    for role in getattr(setting, channel):
+                        new_roles.add(role)
+                new_roles = list(new_roles)
+
+                # Update existing settings with the new roles
+                self.update_existing_settings(
+                    userid, settings_group, channel, new_roles)
+
+                # Check if any new setting rows are needed. These are necessary
+                # where only *some* kinds of an alias group had non-default
+                # settings, but not all
+                self.prepare_newly_required_settings(
+                    userid, alias_group, settings_group, channel, new_roles)
+
+    def prepare_newly_required_settings(self, userid, alias_group, settings_group, channel, new_roles):  # noqa
+        """Check if any new setting rows are needed, and prepare them for
+        insertion (in order to determine defaults and newly required ticks
+        for *other channels* at the very end)
+        """
+        if settings_group != []:
+            for aliased_kind in alias_group:
+                if aliased_kind not in [s.kind for s in settings_group]:
+                    # This kind (transition ID) doesn't have a row yet
+                    # Make sure one gets added with the new roles for
+                    # this user, kind and channel
+                    self.queue_new_setting_for_insertion(
+                        userid, aliased_kind, channel, new_roles)
+
+    def update_existing_settings(self, userid, settings_group, channel, new_roles):  # noqa
+        for setting in settings_group:
+            old_roles = getattr(setting, channel)
+            if set(new_roles) != set(old_roles):
+                log.info("Changed: %s - %s - %s" % (
+                    userid, channel, setting.kind))
+                log.info("  Old roles: %s" % old_roles)
+                log.info("  New roles: %s" % new_roles)
+            setattr(setting, channel, new_roles)
+
+    def insert_newly_required_settings(self):
+        """Based on the list of queued settings to insert, add these new
+        setting rows, which respecting defaults.
+        """
+        to_insert = self.new_settings_to_insert
+
+        for userid in to_insert:
+            for aliased_kind in to_insert[userid]:
+                log.info(
+                    "Adding new setting: %s - %s" % (userid, aliased_kind))
+                new_setting = self.create_setting_with_defaults(
+                    aliased_kind, userid)
+
+                settings_by_channel = to_insert[userid][aliased_kind]
+                for channel in settings_by_channel:
+                    new_roles = settings_by_channel[channel]
+                    setattr(new_setting, channel, new_roles)
+                    log.info("  %s - %s" % (channel, new_roles))
+                self.session.add(new_setting)
+
+    def create_setting_with_defaults(self, kind, userid):
+        new_setting = NotificationSetting(kind=kind, userid=userid)
+
+        kind_defaults = self.notification_defaults[kind]
+        for channel in CHANNELS:
+            channel_defaults = getattr(kind_defaults, channel)
+            setattr(new_setting, channel, list(channel_defaults))
+        return new_setting
+
+    def queue_new_setting_for_insertion(self, userid, aliased_kind, channel, new_roles):  # noqa
+        """Queue a new setting row for insertion, by adding the specific
+        new_roles that are needed. Other new roles might be needed and
+        inserted here for other channels, which is why we don't construct the
+        new settings entity immediately, so we can defer its creation to the
+        very end, and properly determine defaults vs. actualized values for
+        roles.
+        """
+        to_insert = self.new_settings_to_insert
+        if userid not in to_insert:
+            to_insert[userid] = {}
+
+        if aliased_kind not in to_insert[userid]:
+            to_insert[userid][aliased_kind] = {}
+
+        if channel not in to_insert[userid][aliased_kind]:
+            to_insert[userid][aliased_kind][channel] = new_roles

--- a/opengever/core/upgrades/20180213141432_migrate_grouped_notification_settings/upgrade.py
+++ b/opengever/core/upgrades/20180213141432_migrate_grouped_notification_settings/upgrade.py
@@ -1,6 +1,6 @@
-from ftw.upgrade import UpgradeStep
 from opengever.activity.model import NotificationDefault
 from opengever.activity.model import NotificationSetting
+from opengever.core.upgrade import SchemaMigration
 from opengever.ogds.base.utils import create_session
 import logging
 
@@ -32,15 +32,19 @@ CHANNELS = (
 )
 
 
-class MigrateGroupedNotificationSettings(UpgradeStep):
+class MigrateGroupedNotificationSettings(SchemaMigration):
     """Migrate grouped notification settings (alias groups).
 
     This is required because if the settings for aliased groups aren't
     homogenous for a specific alias group, the UI might show different
     settings than those that will actually be used.
+
+    Implemented as a "schema migration" because this ensures this upgrade
+    step is only executed once per cluster, and therefore shouldn't be
+    affected by actual schema migrations.
     """
 
-    def __call__(self):
+    def migrate(self):
         log.info("Migrating notification settings for aliased groups...")
         self.session = create_session()
         self.new_settings_to_insert = {}


### PR DESCRIPTION
There are some different task-transitions which ends in the same review_state, therefore ther are multiple options in the activity settings page for closing a task. Thats confusing for the user, therefore we combine them together and introduce a list of "aliased transitions". 
