### PR TITLE
Use mail subject as title.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2018.1.0 (unreleased)
 ---------------------
 
+- Use subject instead of summary as default mail title. [deiferni]
 - Fix repository favorites cache key generation for Anonymous users. [lgraf]
 - Update plone.restapi to 1.1.0 and plone.rest to 1.0.0. [buchi]
 - Bump Products.LDAPMultiPlugins to 1.15.post3 to handle commas in CNs. [lgraf]

--- a/opengever/activity/mail.py
+++ b/opengever/activity/mail.py
@@ -38,6 +38,7 @@ class PloneNotificationMailer(NotificationDispatcher, Mailer):
     def get_data(self, notification):
         language = self.get_users_language()
         return {
+            'subject': self.get_subject(notification),
             'title': notification.activity.translations[language].title,
             'label': notification.activity.translations[language].label,
             'summary': notification.activity.translations[language].summary,

--- a/opengever/activity/templates/notification.pt
+++ b/opengever/activity/templates/notification.pt
@@ -9,7 +9,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
 
-    <title tal:content="structure options/summary"></title>
+    <title tal:content="structure options/subject"></title>
     <style>
       body{
         font-family: sans-serif;


### PR DESCRIPTION
The summary contains markup elements which is not displayed well by certain mail clients.

Backref https://basecamp.com/2768704/projects/12554551/todos/341966157.