### PR TITLE
Add sequence number to Solr search pattern

### DIFF
--- a/opengever/base/tests/test_search.py
+++ b/opengever/base/tests/test_search.py
@@ -276,7 +276,8 @@ class TestSolrSearch(IntegrationTestCase):
         self.solr.search.assert_called_with(
             query=(u'{!boost b=recip(ms(NOW,modified),3.858e-10,10,1)}'
                    u'Title:foo^100 OR Title:foo*^10 OR SearchableText:foo^10 '
-                   u'OR SearchableText:foo*'),
+                   u'OR SearchableText:foo* '
+                   u'OR sequence_number_string:foo^2000'),
             filters=[u'trashed:false'],
             start=0,
             rows=10,

--- a/opengever/core/profiles/default/registry.xml
+++ b/opengever/core/profiles/default/registry.xml
@@ -196,7 +196,7 @@
   <!-- Solr settings -->
   <records interface="ftw.solr.interfaces.ISolrSettings">
     <value key="local_query_parameters">{!boost b=recip(ms(NOW,modified),3.858e-10,10,1)}</value>
-    <value key="simple_search_term_pattern">Title:{term}^100 OR Title:{term}*^10 OR SearchableText:{term}^10 OR SearchableText:{term}*</value>
+    <value key="simple_search_term_pattern">Title:{term}^100 OR Title:{term}*^10 OR SearchableText:{term}^10 OR SearchableText:{term}* OR sequence_number_string:{term}^2000</value>
     <value key="simple_search_phrase_pattern">Title:"{phrase}"^500 OR Title:"{phrase}*"^200 OR SearchableText:"{phrase}"^200 OR SearchableText:"{phrase}*"^20</value>
     <value key="complex_search_pattern">Title:({term})^10 OR SearchableText:({term})</value>
   </records>

--- a/opengever/core/upgrades/20180214115035_add_sequence_number_to_solr_pattern/registry.xml
+++ b/opengever/core/upgrades/20180214115035_add_sequence_number_to_solr_pattern/registry.xml
@@ -1,0 +1,7 @@
+<registry>
+
+  <records interface="ftw.solr.interfaces.ISolrSettings">
+    <value key="simple_search_term_pattern">Title:{term}^100 OR Title:{term}*^10 OR SearchableText:{term}^10 OR SearchableText:{term}* OR sequence_number_string:{term}^2000</value>
+  </records>
+
+</registry>

--- a/opengever/core/upgrades/20180214115035_add_sequence_number_to_solr_pattern/upgrade.py
+++ b/opengever/core/upgrades/20180214115035_add_sequence_number_to_solr_pattern/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddSequenceNumberToSolrPattern(UpgradeStep):
+    """Add sequence number to solr pattern.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/solr-conf/managed-schema
+++ b/solr-conf/managed-schema
@@ -147,11 +147,13 @@
     <field name="reference" type="string" indexed="true" stored="false" />
     <field name="responsible" type="string" indexed="true" stored="false" />
     <field name="sequence_number" type="pint" indexed="true" stored="false" />
+    <field name="sequence_number_string" type="string" indexed="true" stored="false" />
     <field name="start" type="pdate" indexed="true" stored="false" />
     <field name="task_type" type="string" indexed="true" stored="false" />
     <field name="trashed" type="boolean" indexed="true" stored="false" />
 
     <copyField source="path" dest="path_parent"/>
+    <copyField source="sequence_number" dest="sequence_number_string"/>
 
     <dynamicField name="ignored_*" type="ignored"/>
 


### PR DESCRIPTION
Also index sequence number as string because querying an int field with a string value results in an error.