### PR TITLE
Enable Mind Manager with Office Connector

### DIFF
--- a/opengever/core/profiles/default/registry.xml
+++ b/opengever/core/profiles/default/registry.xml
@@ -167,6 +167,9 @@
       <!-- Apple Pages -->
       <element>application/x-iwork-pages-sffpages</element>
 
+      <!-- Mindjet Mind Manager -->
+      <element>application/vnd.mindjet.mindmanager</element>
+
     </value>
   </record>
 

--- a/opengever/core/upgrades/20180214153212_enable_mind_manager_with_office_connector/registry.xml
+++ b/opengever/core/upgrades/20180214153212_enable_mind_manager_with_office_connector/registry.xml
@@ -1,0 +1,11 @@
+<registry>
+
+  <record
+      interface="opengever.officeconnector.interfaces.IOfficeConnectorSettings"
+      field="officeconnector_editable_types">
+    <value purge="False">
+      <element>application/vnd.mindjet.mindmanager</element>
+    </value>
+  </record>
+
+</registry>

--- a/opengever/core/upgrades/20180214153212_enable_mind_manager_with_office_connector/upgrade.py
+++ b/opengever/core/upgrades/20180214153212_enable_mind_manager_with_office_connector/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class EnableMindManagerWithOfficeConnector(UpgradeStep):
+    """Enable mind manager with office connector.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()


### PR DESCRIPTION
Mind Manager is supported in Office Connector 1.5.0 and later.