### PR TITLE
Make sure solr-conf is in released egg.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,7 @@ recursive-include opengever *
 recursive-include docs *
 include *.rst
 include *.txt
+graft solr-conf
 global-exclude *.pyc
 global-exclude ._*
 global-exclude *.mo


### PR DESCRIPTION
I think without this line the conf is skipped. We rely on it in our buildout recipes though.