### PR TITLE
Fix upgrade steps for oracle.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2018.1.0 (unreleased)
 ---------------------
 
+- Fix tracking table creation for oracle. [deiferni]
 - Use subject instead of summary as default mail title. [deiferni]
 - Fix repository favorites cache key generation for Anonymous users. [lgraf]
 - Update plone.restapi to 1.1.0 and plone.rest to 1.0.0. [buchi]

--- a/opengever/core/upgrade.py
+++ b/opengever/core/upgrade.py
@@ -463,8 +463,9 @@ class GeverUpgradeStepRecorder(UpgradeStepRecorder):
             # to track / record each upgrade step for a profile; we used to only store
             # the newest version.
             mark_changed(self.session)
-            self.operations.drop_constraint('opengever_upgrade_version_pkey',
-                                            TRACKING_TABLE_NAME)
+            for constraint in table.constraints:
+                self.operations.drop_constraint(constraint.name,
+                                                TRACKING_TABLE_NAME)
             self.operations.create_primary_key('opengever_upgrade_version_pkey',
                                                TRACKING_TABLE_NAME,
                                                ['profileid', 'upgradeid'])


### PR DESCRIPTION
Creating the tracking table failed for oracle due to a different auto naming schema.