### PR TITLE
Fix toc download on IE11 and Edge

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2018.1.3 (unreleased)
 ---------------------
 
+- Fix period ToC downloads on IE 11 and Edge. [bierik]
 - Fix an issue with bumblebee preview not being renderend upon ECH0147 import. [deiferni]
 
 

--- a/opengever/base/browser/resources/generateToc.js
+++ b/opengever/base/browser/resources/generateToc.js
@@ -1,26 +1,44 @@
 (function(global, $, Controller) {
 
   function downloadFile(url) {
-
     var loaded = $.Deferred();
-
     var request = new XMLHttpRequest();
 
-    request.responseType = "blob";
     request.open('GET', url);
-    request.send();
-    request.onreadystatechange = function() {
-      this.onload = function() {
-        var contentDisposition = this.getResponseHeader('content-disposition');
-        var filename = contentDisposition.match(/filename="(.+)"/)[1];
-        var file = URL.createObjectURL(this.response);
+    // ! setting the responseType has to be after the `request.open`
+    // `arraybuffer` is necessary for Internet Explorer and Edge becuase
+    // they do not support `blob` as response type
+    request.responseType = "arraybuffer";
+    request.onload = function() {
+      loaded.resolve();
+      var contentDisposition = this.getResponseHeader('content-disposition');
+      var contentType = this.getResponseHeader('content-type');
+      var filename = contentDisposition.match(/filename="(.+)"/)[1];
+      var file = new Blob([this.response], { type: contentType });
+      // For Internet Explorer and Edge
+      if ('msSaveOrOpenBlob' in window.navigator) {
+        window.navigator.msSaveOrOpenBlob(file, filename);
+      }
+      // For Firefox and Chrome
+      else {
+        // Bind blob on disk to ObjectURL
+        var data = URL.createObjectURL(file);
         var a = document.createElement("a");
-        a.href = file;
+        a.style = "display: none";
+        a.href = data;
         a.download = filename;
+        document.body.appendChild(a);
         a.click();
-      };
-      this.onloadend = function() { loaded.resolve(); };
+        // For Firefox
+        setTimeout(function(){
+          document.body.removeChild(a);
+          // Release resource on disk after triggering the download
+          window.URL.revokeObjectURL(data);
+        }, 100);
+      }
     };
+    request.onloadend = function() { loaded.resolve(); };
+    request.send();
 
     return loaded;
   }


### PR DESCRIPTION
https://github.com/4teamwork/opengever.core/issues/3936

IE11 and Edge do not support `blob` as repsonse type for XHR requests.
So use `arraybuffer` and build the blob manually.