### PR TITLE
Fix bin/mtest output encoding

### DIFF
--- a/bin/mtest
+++ b/bin/mtest
@@ -26,6 +26,8 @@ from subprocess import PIPE
 from subprocess import Popen
 from time import sleep
 from time import time
+import locale
+import sys
 
 
 def humanize_time(seconds):
@@ -88,9 +90,13 @@ def discover_test_layers():
     test_classes_per_layer = {}
     current_layer = None
 
+    output_encoding = sys.stdout.encoding
+    if output_encoding is None:
+        output_encoding = locale.getpreferredencoding()
+
     test_discovery = check_output(
         ('bin/test', '--list-tests', ),
-        ).decode('UTF-8').splitlines()
+        ).decode(output_encoding).splitlines()
 
     for result in test_discovery:
         is_layer_header = result.startswith('Listing')
@@ -252,6 +258,17 @@ def handle_results(results):
     success = []
     runtime = 0
 
+    # Set up a logger for writing output to stdout. We do this because
+    # the logging module handles I/O encoding properly, whereas with 'print'
+    # we'd need to do it ourselves. (Think piping the output of bin/mtest
+    # somewhere, or shell I/O redirection).
+    log_output = getLogger('mtest.output')
+    log_output.propagate = False
+    stdout_handler = StreamHandler(stream=sys.stdout)
+    stdout_handler.setFormatter(Formatter(''))
+    log_output.addHandler(stdout_handler)
+    log_output.setLevel(INFO)
+
     while results:
         sleep(1)
 
@@ -279,22 +296,21 @@ def handle_results(results):
 
             else:
                 success.append(False)
-                # This explicitly expects UTF-8 as the runtime locale!
-                print('')
-                print('STDERR')
-                print('')
-                print(result.get('layers'))
-                print('')
-                print(stderr.decode('UTF-8'), end='')
-                print('')
+                log_output.info('')
+                log_output.info('STDERR')
+                log_output.info('')
+                log_output.info(result.get('layers'))
+                log_output.info('')
+                log_output.info(stderr)
+                log_output.info('')
                 if returncode:
-                    print('')
-                    print('STDOUT')
-                    print('')
-                    print(result.get('layers'))
-                    print('')
-                    print(stdout.decode('UTF-8'), end='')
-                    print('')
+                    log_output.info('')
+                    log_output.info('STDOUT')
+                    log_output.info('')
+                    log_output.info(result.get('layers'))
+                    log_output.info('')
+                    log_output.info(stdout)
+                    log_output.info('')
 
     logger.debug(
         'Aggregate runtime %s.',

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2018.1.2 (unreleased)
 ---------------------
 
+- Fix bin/mtest output encoding. [lgraf]
 - Bump ftw.tabbedview to 4.1.0 to fix filter clearing in IE. [lgraf]
 
 


### PR DESCRIPTION
Fix `bin/mtest` output encoding:
The previous implementation attempted to display output by
`print()` -ing unicode text. This will fail (for content with non-ASCII characters) if the output isn't a terminal (e.g. when the output of bin/mtest is piped to another process, redirected using shell I/O
redirection, ...).

*(See https://ci.4teamwork.ch/builds/147573/tasks/232383 for an example where `bin/mtest` failed to render *any* of the test runner output because it contained a single Ç).*

Instead we use the logging module for displaying output, because it handles exactly these output encoding issues properly, depending on what encoding the output stream requires.

---

Related: #3995 *(Flaky test failures related to language selector viewlet*)