### PR TITLE
Skip some flaky tests for now

### DIFF
--- a/opengever/base/tests/test_anonymous.py
+++ b/opengever/base/tests/test_anonymous.py
@@ -1,5 +1,6 @@
 from ftw.testbrowser import browsing
 from opengever.testing import IntegrationTestCase
+from unittest import skip
 
 
 class TestAnonymousAccess(IntegrationTestCase):
@@ -15,6 +16,8 @@ class TestAnonymousAccess(IntegrationTestCase):
         self.assertEquals(self.portal.absolute_url() + '/login_form',
                           browser.url)
 
+    @skip("This test currently fails in a flaky way on CI."
+          "See https://github.com/4teamwork/opengever.core/issues/3995")
     @browsing
     def test_authenticated_can_access_search(self, browser):
         self.login(self.regular_user, browser=browser)

--- a/opengever/base/tests/test_navigation.py
+++ b/opengever/base/tests/test_navigation.py
@@ -7,6 +7,7 @@ from ftw.testing import freeze
 from opengever.testing import add_languages
 from opengever.testing import FunctionalTestCase
 from plone.uuid.interfaces import IUUID
+from unittest import skip
 from zope.event import notify
 from zope.lifecycleevent import ObjectModifiedEvent
 import transaction
@@ -38,6 +39,8 @@ class TestNavigation(FunctionalTestCase):
         with self.assert_changes(view.get_caching_url, msg):
             root.REQUEST.get('LANGUAGE_TOOL').LANGUAGE = 'de-ch'
 
+    @skip("This test currently fails in a flaky way on CI."
+          "See https://github.com/4teamwork/opengever.core/issues/3995")
     @browsing
     def test_json_is_valid(self, browser):
         add_languages(['de-ch'])

--- a/opengever/base/tests/test_translated_title.py
+++ b/opengever/base/tests/test_translated_title.py
@@ -14,6 +14,7 @@ from opengever.testing import obj2brain
 from opengever.testing import set_preferred_language
 from opengever.testing import TestCase
 from plone import api
+from unittest import skip
 import transaction
 
 
@@ -98,6 +99,8 @@ class TestTranslatedTitle(FunctionalTestCase):
         self.assertEquals(u"Ablage 1", repository_root.title_de)
         self.assertEquals(u"syst\xe8me d'ordre 1", repository_root.title_fr)
 
+    @skip("This test currently fails in a flaky way on CI."
+          "See https://github.com/4teamwork/opengever.core/issues/3995")
     @browsing
     def test_Title_returns_title_in_preffered_language_by_default(self, browser):
         repository_root = create(Builder('repository_root')
@@ -133,6 +136,8 @@ class TestTranslatedTitle(FunctionalTestCase):
             u"Ablage",
             ITranslatedTitle(repository_root).translated_title(language='it'))
 
+    @skip("This test currently fails in a flaky way on CI."
+          "See https://github.com/4teamwork/opengever.core/issues/3995")
     @browsing
     def test_fallback_for_title_is_the_german_title(self, browser):
         repository_root = create(Builder('repository_root')

--- a/opengever/contact/tests/test_contactfolder.py
+++ b/opengever/contact/tests/test_contactfolder.py
@@ -6,6 +6,7 @@ from opengever.contact.interfaces import IContactFolder
 from opengever.testing import add_languages
 from opengever.testing import IntegrationTestCase
 from plone import api
+from unittest import skip
 
 
 class TestContactFolder(IntegrationTestCase):
@@ -18,6 +19,8 @@ class TestContactFolder(IntegrationTestCase):
         self.login(self.manager)
         self.assertTrue(IContactFolder.providedBy(self.contactfolder))
 
+    @skip("This test currently fails in a flaky way on CI."
+          "See https://github.com/4teamwork/opengever.core/issues/3995")
     @browsing
     def test_supports_translated_title(self, browser):
         self.login(self.manager, browser=browser)

--- a/opengever/disposition/tests/test_excel_export.py
+++ b/opengever/disposition/tests/test_excel_export.py
@@ -7,6 +7,7 @@ from opengever.testing import FunctionalTestCase
 from openpyxl import load_workbook
 from plone import api
 from tempfile import NamedTemporaryFile
+from unittest import skip
 import transaction
 
 
@@ -82,6 +83,8 @@ class TestDispositionExcelExport(FunctionalTestCase):
                  u'not archival worthy'],
                 [cell.value for cell in rows[2]])
 
+    @skip("This test currently fails in a flaky way on CI."
+          "See https://github.com/4teamwork/opengever.core/issues/3995")
     @browsing
     def test_file_name(self, browser):
         # use the enable_languages method from

--- a/opengever/dossier/tests/test_templatefolder.py
+++ b/opengever/dossier/tests/test_templatefolder.py
@@ -33,6 +33,7 @@ from plone.portlets.interfaces import ILocalPortletAssignmentManager
 from plone.portlets.interfaces import IPortletAssignmentMapping
 from plone.portlets.interfaces import IPortletManager
 from plone.registry.interfaces import IRegistry
+from unittest import skip
 from zope.app.intid.interfaces import IIntIds
 from zope.component import getMultiAdapter
 from zope.component import getUtility
@@ -565,6 +566,8 @@ class TestTemplateFolder(FunctionalTestCase):
             ['Document', 'TaskTemplateFolder', 'Template Folder'],
             factoriesmenu.addable_types())
 
+    @skip("This test currently fails in a flaky way on CI."
+          "See https://github.com/4teamwork/opengever.core/issues/3995")
     @browsing
     def test_supports_translated_title(self, browser):
         add_languages(['de-ch', 'fr-ch'])

--- a/opengever/inbox/tests/test_inbox.py
+++ b/opengever/inbox/tests/test_inbox.py
@@ -9,6 +9,7 @@ from opengever.testing import add_languages
 from opengever.testing import FunctionalTestCase
 from plone.portlets.interfaces import IPortletAssignmentMapping
 from plone.portlets.interfaces import IPortletManager
+from unittest import skip
 from zope.component import getMultiAdapter
 from zope.component import getUtility
 import transaction
@@ -61,6 +62,8 @@ class TestInbox(FunctionalTestCase):
         self.assertEqual(None, inbox.get_sequence_number())
         transaction.commit()
 
+    @skip("This test currently fails in a flaky way on CI."
+          "See https://github.com/4teamwork/opengever.core/issues/3995")
     @browsing
     def test_supports_translated_title(self, browser):
         add_languages(['de-ch', 'fr-ch'])

--- a/opengever/inbox/tests/test_inbox_container.py
+++ b/opengever/inbox/tests/test_inbox_container.py
@@ -8,6 +8,7 @@ from ftw.testbrowser.pages import statusmessages
 from opengever.inbox.container import IInboxContainer
 from opengever.testing import add_languages
 from opengever.testing import FunctionalTestCase
+from unittest import skip
 
 
 class TestInboxContainer(FunctionalTestCase):
@@ -82,6 +83,8 @@ class TestInboxView(FunctionalTestCase):
             ['Your not allowed to access the inbox of Client1.'],
             statusmessages.messages().get('warning'))
 
+    @skip("This test currently fails in a flaky way on CI."
+          "See https://github.com/4teamwork/opengever.core/issues/3995")
     @browsing
     def test_supports_translated_title(self, browser):
         add_languages(['de-ch', 'fr-ch'])

--- a/opengever/meeting/tests/test_committee_container.py
+++ b/opengever/meeting/tests/test_committee_container.py
@@ -3,17 +3,20 @@ from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
 from ftw.testbrowser.pages import editbar
-from ftw.testbrowser.pages import statusmessages
 from ftw.testbrowser.pages import factoriesmenu
+from ftw.testbrowser.pages import statusmessages
 from opengever.base.date_time import utcnow_tz_aware
 from opengever.testing import add_languages
 from opengever.testing import IntegrationTestCase
+from unittest import skip
 
 
 class TestCommitteeContainer(IntegrationTestCase):
 
     features = ('meeting',)
 
+    @skip("This test currently fails in a flaky way on CI."
+          "See https://github.com/4teamwork/opengever.core/issues/3995")
     @browsing
     def test_supports_translated_title(self, browser):
         self.login(self.manager, browser)


### PR DESCRIPTION
Skip some flaky tests for now - see 4teamwork/opengever.core#3995 (related to language selector viewlet).

(Unfortunately it's more than I previously thought - 10 tests total).