### PR TITLE
Add some minimal logging for send_digest handler

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2018.1.2 (unreleased)
 ---------------------
 
+- Add some minimal logging for send_digest handler. [lgraf]
 - Fix bin/mtest output encoding. [lgraf]
 - Bump ftw.tabbedview to 4.1.0 to fix filter clearing in IE. [lgraf]
 

--- a/opengever/activity/__init__.py
+++ b/opengever/activity/__init__.py
@@ -10,7 +10,6 @@ from opengever.core.debughelpers import setup_plone
 from plone.registry.interfaces import IRegistry
 from zope.component import getUtility
 from zope.i18nmessageid import MessageFactory
-from zope.interface import Interface
 import transaction
 import logging
 
@@ -44,7 +43,7 @@ def send_digest_zopectl_handler(app, args):
     stream_handler = logger.root.handlers[0]
     stream_handler.setLevel(logging.INFO)
 
-    plone = setup_plone(get_first_plone_site(app))
+    setup_plone(get_first_plone_site(app))
     DigestMailer().send_digests()
     transaction.commit()
 
@@ -78,7 +77,7 @@ ACTIVITY_TRANSLATIONS = {
     'task-transition-rejected-open': _(
         'task-transition-rejected-open', default=u'Task reopened'),
     'task-transition-resolved-in-progress': _(
-        'task-transition-resolved-in-progress', default=u'Task revision wanted'),
+        'task-transition-resolved-in-progress', default=u'Task revision wanted'),  # noqa
     'task-transition-resolved-tested-and-closed': _(
         'task-transition-resolved-tested-and-closed', default=u'Task closed'),
     'forwarding-added': _(
@@ -88,7 +87,7 @@ ACTIVITY_TRANSLATIONS = {
     'forwarding-transition-assign-to-dossier': _(
         'forwarding-transition-assign-to-dossier',
         default=u'Forwarding assigned to dossier'),
-    'forwarding-transition-close': _('forwarding-transition-close', default=u'Forwarding closed'),
+    'forwarding-transition-close': _('forwarding-transition-close', default=u'Forwarding closed'),  # noqa
     'forwarding-transition-reassign': _(
         'forwarding-transition-reassign', default=u'Forwarding reassigned'),
     'forwarding-transition-reassign-refused': _(

--- a/opengever/activity/__init__.py
+++ b/opengever/activity/__init__.py
@@ -26,7 +26,7 @@ def is_activity_feature_enabled():
         registry = getUtility(IRegistry)
         return registry.forInterface(IActivitySettings).is_feature_enabled
 
-    except KeyError, AttributeError:
+    except (KeyError, AttributeError):
         return False
 
 

--- a/opengever/activity/__init__.py
+++ b/opengever/activity/__init__.py
@@ -12,6 +12,10 @@ from zope.component import getUtility
 from zope.i18nmessageid import MessageFactory
 from zope.interface import Interface
 import transaction
+import logging
+
+
+logger = logging.getLogger('opengever.activity')
 
 
 _ = MessageFactory("opengever.activity")
@@ -35,6 +39,11 @@ def notification_center():
 
 
 def send_digest_zopectl_handler(app, args):
+    # Set Zope's default StreamHandler's level to INFO (default is WARNING)
+    # to make sure send_digests()'s output gets logged on console
+    stream_handler = logger.root.handlers[0]
+    stream_handler.setLevel(logging.INFO)
+
     plone = setup_plone(get_first_plone_site(app))
     DigestMailer().send_digests()
     transaction.commit()

--- a/opengever/activity/digest.py
+++ b/opengever/activity/digest.py
@@ -13,10 +13,13 @@ from plone import api
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from zope.i18n import translate
 from zope.i18nmessageid import MessageFactory
+import logging
 
+
+logger = logging.getLogger('opengever.activity.digest')
+logger.setLevel(logging.INFO)
 
 _ = MessageFactory("opengever.activity")
-
 
 DIGEST_INTERVAL_HOURS = 24
 
@@ -81,6 +84,7 @@ class DigestMailer(Mailer):
             'description': activity.translations[language].description}
 
     def send_digests(self):
+        logger.info('Sending digests...')
         for userid, notifications in self.get_notifications().items():
             # skip when digest interval is not expired yet
             if not self.is_interval_expired(userid):
@@ -111,6 +115,9 @@ class DigestMailer(Mailer):
             self.send_mail(msg)
             self.mark_as_sent(notifications)
             self.record_digest(userid)
+            logger.info('  Digest sent for %s (%s)' % (userid, user.email))
+
+        logger.info('Done sending digests.')
 
     def mark_as_sent(self, notifications):
         for notification in notifications:


### PR DESCRIPTION
Add some minimal logging for `send_digest` handler, so it's obvious during debugging whether or not digests have been send, and to which addresses.

Example output:

```
2018-02-19 14:45:00 INFO opengever.activity.digest Sending digests...
2018-02-19 14:45:00 INFO opengever.activity.digest   Digest sent for lukas.graf (lukas@example.org)
2018-02-19 14:45:00 INFO opengever.activity.digest   Digest sent for david.erni (deif@example.org)
2018-02-19 14:45:00 INFO opengever.activity.digest Done sending digests.
```