### PR TITLE
Improve Tabbedview filter in Solr

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -8,6 +8,7 @@ Changelog
 - Add some minimal logging for send_digest handler. [lgraf]
 - Fix bin/mtest output encoding. [lgraf]
 - Bump ftw.tabbedview to 4.1.0 to fix filter clearing in IE. [lgraf]
+- Improve Tabbedview filter in Solr, e.g. allow filtering by reference number. [buchi]
 
 
 2018.1.1 (2018-02-15)

--- a/opengever/base/tests/test_search.py
+++ b/opengever/base/tests/test_search.py
@@ -275,9 +275,9 @@ class TestSolrSearch(IntegrationTestCase):
         self.search.solr_results()
         self.solr.search.assert_called_with(
             query=(u'{!boost b=recip(ms(NOW,modified),3.858e-10,10,1)}'
-                   u'Title:foo^100 OR Title:foo*^10 OR SearchableText:foo^10 '
-                   u'OR SearchableText:foo* '
-                   u'OR sequence_number_string:foo^2000'),
+                   u'Title:foo^100 OR Title:foo*^20 OR SearchableText:foo^5 '
+                   u'OR SearchableText:foo* OR metadata:foo^10 '
+                   u'OR metadata:foo*^2 OR sequence_number_string:foo^2000'),
             filters=[u'trashed:false'],
             start=0,
             rows=10,

--- a/opengever/core/profiles/default/registry.xml
+++ b/opengever/core/profiles/default/registry.xml
@@ -199,8 +199,8 @@
   <!-- Solr settings -->
   <records interface="ftw.solr.interfaces.ISolrSettings">
     <value key="local_query_parameters">{!boost b=recip(ms(NOW,modified),3.858e-10,10,1)}</value>
-    <value key="simple_search_term_pattern">Title:{term}^100 OR Title:{term}*^10 OR SearchableText:{term}^10 OR SearchableText:{term}* OR sequence_number_string:{term}^2000</value>
-    <value key="simple_search_phrase_pattern">Title:"{phrase}"^500 OR Title:"{phrase}*"^200 OR SearchableText:"{phrase}"^200 OR SearchableText:"{phrase}*"^20</value>
+    <value key="simple_search_term_pattern">Title:{term}^100 OR Title:{term}*^20 OR SearchableText:{term}^5 OR SearchableText:{term}* OR metadata:{term}^10 OR metadata:{term}*^2 OR sequence_number_string:{term}^2000</value>
+    <value key="simple_search_phrase_pattern">Title:"{phrase}"^500 OR SearchableText:"{phrase}"^200 OR metadata:"{phrase}"^300</value>
     <value key="complex_search_pattern">Title:({term})^10 OR SearchableText:({term})</value>
   </records>
   <records interface="opengever.base.interfaces.ISearchSettings" />

--- a/opengever/core/upgrades/20180219150514_improve_search_pattern/registry.xml
+++ b/opengever/core/upgrades/20180219150514_improve_search_pattern/registry.xml
@@ -1,0 +1,8 @@
+<registry>
+
+  <records interface="ftw.solr.interfaces.ISolrSettings">
+    <value key="simple_search_term_pattern">Title:{term}^100 OR Title:{term}*^20 OR SearchableText:{term}^5 OR SearchableText:{term}* OR metadata:{term}^10 OR metadata:{term}*^2 OR sequence_number_string:{term}^2000</value>
+    <value key="simple_search_phrase_pattern">Title:"{phrase}"^500 OR SearchableText:"{phrase}"^200 OR metadata:"{phrase}"^300</value>
+  </records>
+
+</registry>

--- a/opengever/core/upgrades/20180219150514_improve_search_pattern/upgrade.py
+++ b/opengever/core/upgrades/20180219150514_improve_search_pattern/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class ImproveSearchPattern(UpgradeStep):
+    """Improve search pattern.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/document/configure.zcml
+++ b/opengever/document/configure.zcml
@@ -260,6 +260,11 @@
       name="public_trial"
       />
 
+  <adapter
+      factory=".indexers.metadata"
+      name="metadata"
+      />
+
   <adapter factory=".document.UploadValidator" />
 
 </configure>

--- a/opengever/document/indexers.py
+++ b/opengever/document/indexers.py
@@ -177,3 +177,21 @@ def public_trial(obj):
         return public_trial
 
     return ''
+
+
+@indexer(IBaseDocument)
+def metadata(obj):
+    metadata = []
+
+    reference_number = IReferenceNumber(obj)
+    metadata.append(reference_number.get_number())
+
+    doc_metadata = IDocumentMetadata(obj)
+    if doc_metadata.description:
+        metadata.append(doc_metadata.description.encode('utf8'))
+    if doc_metadata.keywords:
+        metadata.extend([k.encode('utf8') for k in doc_metadata.keywords])
+    if doc_metadata.foreign_reference:
+        metadata.append(doc_metadata.foreign_reference.encode('utf8'))
+
+    return ' '.join(metadata)

--- a/opengever/document/tests/test_indexers.py
+++ b/opengever/document/tests/test_indexers.py
@@ -3,6 +3,7 @@ from ftw.builder import create
 from ftw.testing import MockTestCase
 from opengever.document.checkout.manager import CHECKIN_CHECKOUT_ANNOTATIONS_KEY
 from opengever.document.indexers import DefaultDocumentIndexer
+from opengever.document.indexers import metadata
 from opengever.document.interfaces import IDocumentIndexer
 from opengever.testing import FunctionalTestCase
 from opengever.testing import index_data_for
@@ -140,6 +141,22 @@ class TestDocumentIndexers(FunctionalTestCase):
                         'Expect one item with Keyword 1')
         self.assertTrue(len(catalog(Subject=u'Keyword with \xf6')),
                         u'Expect one item with Keyword with \xf6')
+
+    def test_metadata_contains_reference_number(self):
+        doc = create(Builder("document"))
+        self.assertEqual(metadata(doc)(), 'Client1 / 1')
+
+    def test_metadata_contains_description(self):
+        doc = create(Builder("document").having(description=u'Foo bar baz.'))
+        self.assertEqual(metadata(doc)(), 'Client1 / 1 Foo bar baz.')
+
+    def test_metadata_contains_keywords(self):
+        doc = create(Builder("document").having(keywords=(u'Foo', u'Bar')))
+        self.assertEqual(metadata(doc)(), 'Client1 / 1 Foo Bar')
+
+    def test_metadata_contains_foreign_reference(self):
+        doc = create(Builder("document").having(foreign_reference=u'Ref 123'))
+        self.assertEqual(metadata(doc)(), 'Client1 / 1 Ref 123')
 
 
 class TestDefaultDocumentIndexer(MockTestCase):

--- a/opengever/tabbedview/tests/test_catalog_source.py
+++ b/opengever/tabbedview/tests/test_catalog_source.py
@@ -39,10 +39,17 @@ class TestSolrSearch(IntegrationTestCase):
             BaseCatalogListingTab(self.portal, self.request), self.request)
 
     def test_solr_query_contains_searchable_text(self):
-        self.source.solr_results({'SearchableText': 'foo'})
+        self.source.solr_results({'SearchableText': 'foo*'})
         self.assertEqual(
             self.solr.search.call_args[1]['query'],
-            u'Title:foo OR SearchableText:foo')
+            u'(Title:foo* OR SearchableText:foo* OR metadata:foo*)')
+
+    def test_solr_query_contains_pattern_for_each_term(self):
+        self.source.solr_results({'SearchableText': 'foo bar*'})
+        self.assertEqual(
+            self.solr.search.call_args[1]['query'],
+            u'(Title:foo* OR SearchableText:foo* OR metadata:foo*) AND '
+            u'(Title:bar* OR SearchableText:bar* OR metadata:bar*)')
 
     def test_solr_filters_contain_trashed(self):
         self.source.solr_results(

--- a/solr-conf/managed-schema
+++ b/solr-conf/managed-schema
@@ -267,16 +267,6 @@
         <tokenizer class="solr.WhitespaceTokenizerFactory"/>
         <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" />
-        <filter class="solr.WordDelimiterGraphFilterFactory"
-              splitOnCaseChange="1"
-              splitOnNumerics="1"
-              stemEnglishPossessive="1"
-              generateWordParts="1"
-              generateNumberParts="1"
-              catenateWords="0"
-              catenateNumbers="0"
-              catenateAll="0"
-              preserveOriginal="0"/>
         <filter class="solr.LowerCaseFilterFactory"/>
       </analyzer>
     </fieldType>

--- a/solr-conf/managed-schema
+++ b/solr-conf/managed-schema
@@ -244,7 +244,7 @@
     <fieldType name="text" class="solr.TextField" positionIncrementGap="100">
       <analyzer type="index">
         <charFilter class="solr.MappingCharFilterFactory" mapping="mapping-FoldToASCII.txt"/>
-        <tokenizer class="solr.StandardTokenizerFactory"/>
+        <tokenizer class="solr.WhitespaceTokenizerFactory"/>
         <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="false"/>
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" />
         <filter class="solr.WordDelimiterGraphFilterFactory"
@@ -256,7 +256,7 @@
               catenateWords="1"
               catenateNumbers="1"
               catenateAll="0"
-              preserveOriginal="0"/>
+              preserveOriginal="1"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.ReversedWildcardFilterFactory" withOriginal="true"
                 maxPosAsterisk="2" maxPosQuestion="1" minTrailing="2" maxFractionAsterisk="0"/>
@@ -264,7 +264,7 @@
       </analyzer>
       <analyzer type="query">
         <charFilter class="solr.MappingCharFilterFactory" mapping="mapping-FoldToASCII.txt"/>
-        <tokenizer class="solr.StandardTokenizerFactory"/>
+        <tokenizer class="solr.WhitespaceTokenizerFactory"/>
         <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" />
         <filter class="solr.WordDelimiterGraphFilterFactory"

--- a/solr-conf/managed-schema
+++ b/solr-conf/managed-schema
@@ -139,6 +139,7 @@
     <field name="is_subdossier" type="boolean" indexed="true" stored="false" />
     <field name="issuer" type="string" indexed="true" stored="false" />
     <field name="lastname" type="string" indexed="true" stored="false" />
+    <field name="metadata" type="text" indexed="true" stored="true"/>
     <field name="object_provides" type="string" indexed="true" stored="false" multiValued="true"/>
     <field name="phone_office" type="string" indexed="true" stored="false" />
     <field name="preselected" type="boolean" indexed="true" stored="false" />


### PR DESCRIPTION
Add new field `metadata` for indexing document metadata as searchable text.
Use `metadata` field in Tabbedview filter and in search/livesearch.

Solr configuration changes:
- Preserve original term in text fields (allows using wilcards in terms that contain non-alphanumeric characters, e.g. _ice-cream_ can be found by querying for _ice-cr*_)
- Prevent splitting of search terms on non-alphanumeric, non-whitespace characters (e.g. do not split 3.9.2 into 3 9 2)

