### PR TITLE
Add files from solr-conf to data_files

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2018.1.2 (unreleased)
 ---------------------
 
+- Include solr-conf files in data_files so they get installed into the egg. [lgraf]
 - Add some minimal logging for send_digest handler. [lgraf]
 - Fix bin/mtest output encoding. [lgraf]
 - Bump ftw.tabbedview to 4.1.0 to fix filter clearing in IE. [lgraf]

--- a/opengever/base/tests/test_solr.py
+++ b/opengever/base/tests/test_solr.py
@@ -5,6 +5,7 @@ from opengever.base.solr import OGSolrContentListingObject
 from opengever.base.solr import OGSolrDocument
 from opengever.tabbedview import BaseCatalogListingTab
 from opengever.testing import IntegrationTestCase
+from pkg_resources import get_distribution
 import os
 import pkg_resources
 import unittest
@@ -83,3 +84,33 @@ class TestOGSolrDocument(unittest.TestCase):
         doc = OGSolrDocument(data={'Description': 'My Description'})
         obj = OGSolrContentListingObject(doc)
         self.assertEqual(obj.CroppedDescription(), 'My Description')
+
+
+class TestSolrConfigIncludedDataFiles(unittest.TestCase):
+
+    def test_data_files_included(self):
+        """This test verifies that files in solr-conf/ are explicitely listed
+        in setup.py's data_files. This is required for them to be copied
+        into the .egg during installation time (just having them in
+        MANIFEST.in is not enough, that will only make sure they get included
+        in the source distribution).
+
+        Because they need to be listed in data_files explicitely (globs are
+        not supported), these are prone to be missed, and a failure to include
+        them would only be noticed after release / at deployment time.
+        Hence this test.
+        """
+        og_core = get_distribution('opengever.core').location
+        with open(os.path.join(og_core, 'setup.py')) as setup_py_file:
+            setup_py = setup_py_file.read()
+
+        # This is a simplistic test for now. Needs to be adapted if the
+        # solr-conf directory is renamed or moved, or if subdirectories
+        # are added.
+        files_in_solr_conf = os.listdir(os.path.join(og_core, 'solr-conf'))
+        for fn in files_in_solr_conf:
+            path = 'solr-conf/%s' % fn
+            if path not in setup_py:
+                self.fail(
+                    "Expected %r to appear in setup.py but it didn't. "
+                    "(Should be listed in data_files)" % path)

--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,15 @@ setup(name='opengever.core',
           'opengever.portlets',
       ],
       include_package_data=True,
+      data_files=[
+          ('solr-conf', [
+              'solr-conf/managed-schema',
+              'solr-conf/mapping-FoldToASCII.txt',
+              'solr-conf/solrconfig.xml',
+              'solr-conf/stopwords.txt',
+              'solr-conf/synonyms.txt',
+          ]),
+      ],
       zip_safe=False,
       install_requires=[
           'alembic >= 0.7.0',


### PR DESCRIPTION
Add files from `solr-conf` to `data_files`: This is needed so that they get placed into the `.egg` during installation.

Including them in `MANIFEST` only ensures these files are included in the source tarball - but for files *outside* of Python packages, these need to be explicitely listed in `data_files` in order for them to be copied *into the egg* during buildout time.

---

Also: The [documentation for `data_files`](https://docs.python.org/2/distutils/setupscript.html#installing-additional-files) **lies**: Those files get placed relative to the `.egg` root, not `sys.prefix` (at least that's what I'm seeing in a local test).

