### PR TITLE
Fix bumblebee, fire modified once document is renamed.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2018.1.3 (unreleased)
 ---------------------
 
-- Nothing changed yet.
+- Fix an issue with bumblebee preview not being renderend upon ECH0147 import. [deiferni]
 
 
 2018.1.2 (2018-02-19)

--- a/opengever/ech0147/utils.py
+++ b/opengever/ech0147/utils.py
@@ -112,12 +112,15 @@ def create_document(container, document, zipfile):
             contentType=file_.mimeType,
             filename=filename)
 
-        # work around possible event handler ordering issue
-        set_digitally_available(obj, None)
-        notify(ObjectModifiedEvent(obj))
-
     # Rename document
     chooser = INameChooser(container)
     name = chooser.chooseName(None, obj)
     transaction.savepoint(optimistic=True)
+
     container.manage_renameObject(obj.getId(), name)
+
+    # work around possible event handler ordering issue
+    set_digitally_available(obj, None)
+    # fire final modified event after rename to make sure bumblebee trigger
+    # storing views/handlers use correct document url
+    notify(ObjectModifiedEvent(obj))


### PR DESCRIPTION
This fixes an issue with bumblebee preview not being rendered correctly upon ECH0147 import.

It fixes a previous fix in https://github.com/4teamwork/opengever.core/pull/3891 which made sure checksums are calculated upon import, but does not take the storing mechanism into account. Storing checksums in bumblebee (with the `BumblebeeTriggerStoring` view) calls a view which then stores the documents in bumblebee, once the transaction has been commited. For this to succeed we need to fire the modified event when the document id is final, i.e. after it has been moved.

The issues was not discovered previously as we seem to have tested with documents that were already stored in bumblebee.