### PR TITLE
Digest: Set request language based on site wide preferred language

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2018.1.3 (unreleased)
 ---------------------
 
+- Digest: Set request language based on site wide preferred language. [lgraf]
 - Disable "Drop unused sequences" upgrade step because it failed on TEST. [lgraf]
 - Fix period ToC downloads on IE 11 and Edge. [bierik]
 - Fix an issue with bumblebee preview not being renderend upon ECH0147 import. [deiferni]

--- a/opengever/activity/digest.py
+++ b/opengever/activity/digest.py
@@ -93,17 +93,16 @@ class DigestMailer(Mailer):
             today = api.portal.get_localized_time(date.today())
             user = ogds_service().fetch_user(userid)
 
-            language = self.get_users_language()
             subject = translate(
                 _(u'subject_digest',
                   default=u'Daily Digest for ${date}',
                   mapping={'date': today}),
-                context=self.request, target_language=language,)
+                context=self.request)
             title = translate(
                 _(u'title_daily_digest',
                   default=u'Daily Digest for ${username}',
                   mapping={'username': user.fullname()}),
-                context=self.request, target_language=language,)
+                context=self.request)
             msg = self.prepare_mail(
                 subject=subject,
                 to_userid=userid,


### PR DESCRIPTION
Digest: Set request language based on site wide preferred language so that the i18n and l10n 
machinery down the line can pick it up automatically with as little manual guidance from us as
possible.

Fixes date formatting mentioned in https://basecamp.com/2768704/projects/12554551/todos/342457420