### PR TITLE
Disable "Drop unused sequences" upgrade step because it failed on TEST:

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2018.1.3 (unreleased)
 ---------------------
 
+- Disable "Drop unused sequences" upgrade step because it failed on TEST. [lgraf]
 - Fix period ToC downloads on IE 11 and Edge. [bierik]
 - Fix an issue with bumblebee preview not being renderend upon ECH0147 import. [deiferni]
 - Add Creator to Solr schema. [buchi]

--- a/opengever/core/upgrades/20180131153203_drop_unused_sequences/upgrade.py
+++ b/opengever/core/upgrades/20180131153203_drop_unused_sequences/upgrade.py
@@ -1,28 +1,11 @@
 from opengever.core.upgrade import SchemaMigration
-from sqlalchemy.schema import DropSequence
-from sqlalchemy.schema import Sequence
 
 
 class DropUnusedSequences(SchemaMigration):
-    """Drop unused sequences."""
+    """DISABLED: Drop unused sequences."""
 
     def migrate(self):
-        # We'll only attempt to do this for postgresql
-        if self.is_postgres:
-            sequences_to_drop = (
-                'proposal_history_id_seq',
-                'subscriptions_resource_id_seq',
-                )
-
-            matching_sequences = tuple(
-                Sequence(sequence['relname'])
-                for sequence in self.execute(
-                    "select relname from pg_class "
-                    "where relkind = 'S' "
-                    "and relname in {}"
-                    .format(sequences_to_drop)
-                    ).fetchall()
-                )
-
-            for sequence in matching_sequences:
-                self.execute(DropSequence(sequence))
+        # This upgrade is disabled because it failed when deploying on TEST,
+        # indicating that at least the 'subscriptions_resource_id_seq'
+        # sequence was still being used.
+        return


### PR DESCRIPTION
Disable "Drop unused sequences" upgrade step because it failed on TEST: We're disabling this upgrade step because it failed when deploying on TEST, indicating that at least the `subscriptions_resource_id_seq` sequence was still being used.

```
2018-02-19T18:35:04 ERROR ftw.upgrade FAILED
Traceback (most recent call last):
  File "ftw.upgrade-2.11.0-py2.7.egg/ftw/upgrade/jsonapi/plonesite.py", line 158, in _install_upgrades
    executioner.install_upgrades_by_api_ids(*api_ids)
  File "ftw.upgrade-2.11.0-py2.7.egg/ftw/upgrade/executioner.py", line 57, in install_upgrades_by_api_ids
    return self.install(data)
  File "ftw.upgrade-2.11.0-py2.7.egg/ftw/upgrade/executioner.py", line 43, in install
    self._upgrade_profile(profileid, upgradeids)
  File "ftw.upgrade-2.11.0-py2.7.egg/ftw/upgrade/executioner.py", line 106, in _upgrade_profile
    last_dest_version = self._do_upgrade(profileid, upgradeid) \
  File "ftw.upgrade-2.11.0-py2.7.egg/ftw/upgrade/executioner.py", line 145, in _do_upgrade
    step.doStep(self.portal_setup)
  File "Products.GenericSetup-1.8.8-py2.7.egg/Products/GenericSetup/upgrade.py", line 166, in doStep
    self.handler(tool)
  File "ftw.upgrade-2.11.0-py2.7.egg/ftw/upgrade/directory/wrapper.py", line 13, in upgrade_step_wrapper
    target_version=target_version)
  File "ftw.upgrade-2.11.0-py2.7.egg/ftw/upgrade/step.py", line 49, in __new__
    return obj()
  File "opengever.core-2018.1.2-py2.7.egg/opengever/core/upgrade.py", line 318, in __call__
    self.migrate()
  File "opengever.core-2018.1.2-py2.7.egg/opengever/core/upgrades/20180131153203_drop_unused_sequences/upgrade.py", line 28, in migrate
    self.execute(DropSequence(sequence))
  File "opengever.core-2018.1.2-py2.7.egg/opengever/core/upgrade.py", line 300, in execute
    return self.connection.execute(statement)
  File "SQLAlchemy-1.1.10-py2.7-linux-x86_64.egg/sqlalchemy/engine/base.py", line 945, in execute
    return meth(self, multiparams, params)
  File "SQLAlchemy-1.1.10-py2.7-linux-x86_64.egg/sqlalchemy/sql/ddl.py", line 68, in _execute_on_connection
    return connection._execute_ddl(self, multiparams, params)
  File "SQLAlchemy-1.1.10-py2.7-linux-x86_64.egg/sqlalchemy/engine/base.py", line 1002, in _execute_ddl
    compiled
  File "SQLAlchemy-1.1.10-py2.7-linux-x86_64.egg/sqlalchemy/engine/base.py", line 1189, in _execute_context
    context)
  File "SQLAlchemy-1.1.10-py2.7-linux-x86_64.egg/sqlalchemy/engine/base.py", line 1402, in _handle_dbapi_exception
    exc_info
  File "SQLAlchemy-1.1.10-py2.7-linux-x86_64.egg/sqlalchemy/util/compat.py", line 203, in raise_from_cause
    reraise(type(exception), exception, tb=exc_tb, cause=cause)
  File "SQLAlchemy-1.1.10-py2.7-linux-x86_64.egg/sqlalchemy/engine/base.py", line 1182, in _execute_context
    context)
  File "SQLAlchemy-1.1.10-py2.7-linux-x86_64.egg/sqlalchemy/engine/default.py", line 470, in do_execute
    cursor.execute(statement, parameters)
InternalError: (psycopg2.InternalError) cannot drop sequence subscriptions_resource_id_seq because other objects depend on it
DETAIL:  default for table subscriptions column resource_id depends on sequence subscriptions_resource_id_seq
HINT:  Use DROP ... CASCADE to drop the dependent objects too.
 [SQL: 'DROP SEQUENCE subscriptions_resource_id_seq']
```

Reopens #3477