### PR TITLE
Improve input position for the transfer number

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -31,6 +31,7 @@ Changelog
 - Add reference number to REST API summary. [buchi]
 - Include 'is_leafnode' in serialization of repository folder. [buchi]
 
+- Improve input position for the transfer number. [phgross]
 
 2018.1.3 (2018-02-20)
 ---------------------

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ---------------------
 
 - Temporarily disable upgrade step to fix broken references until we're sure it's safe. [lgraf]
+- Improve input position for the transfer number. [phgross]
 - Install and integrate ftw.tokenauth. [lgraf]
 - Make sure to URLEncode links to the list_groupmember view in sharing views. [lgraf]
 - Ensure correct dossier reference numbers for proposals after a dossier move operation. [Rotonen]
@@ -31,7 +32,6 @@ Changelog
 - Add reference number to REST API summary. [buchi]
 - Include 'is_leafnode' in serialization of repository folder. [buchi]
 
-- Improve input position for the transfer number. [phgross]
 
 2018.1.3 (2018-02-20)
 ---------------------

--- a/opengever/base/browser/gever_state.py
+++ b/opengever/base/browser/gever_state.py
@@ -2,6 +2,9 @@ from opengever.base.casauth import get_cas_server_url
 from opengever.base.casauth import get_cluster_base_url
 from opengever.base.casauth import get_gever_portal_url
 from opengever.base.interfaces import IGeverState
+from opengever.contact.interfaces import IContactFolder
+from opengever.inbox.yearfolder import IYearFolder
+from plone.memoize.view import memoize
 from plone.memoize.view import memoize_contextless
 from Products.Five import BrowserView
 from zope.interface import implements
@@ -24,3 +27,16 @@ class GeverStateView(BrowserView):
     @memoize_contextless
     def cas_server_url(self):
         return get_cas_server_url()
+
+    @memoize
+    def properties_action_available(self):
+        plone_view = self.context.restrictedTraverse("@@plone")
+        if plone_view.getViewTemplateId() == 'view' or \
+           plone_view.isPortalOrPortalDefaultPage():
+            return False
+
+        if IContactFolder.providedBy(self.context) \
+           or IYearFolder.providedBy(self.context):
+            return False
+
+        return True

--- a/opengever/base/interfaces.py
+++ b/opengever/base/interfaces.py
@@ -275,6 +275,10 @@ class IGeverState(Interface):
         """URL of the CAS server.
         """
 
+    def properties_action_available():
+        """Check if properties action is available.
+        """
+
 
 class ISQLObjectWrapper(Interface):
     """Marker interface for sql object wrappers."""

--- a/opengever/base/tests/test_gever_state.py
+++ b/opengever/base/tests/test_gever_state.py
@@ -1,9 +1,12 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.testbrowser import browsing
 from opengever.ogds.base.utils import get_current_admin_unit
-from opengever.testing import FunctionalTestCase
+from opengever.testing import IntegrationTestCase
 from plone.app.testing import applyProfile
 
 
-class TestGeverStateView(FunctionalTestCase):
+class TestGeverStateView(IntegrationTestCase):
 
     def setUp(self):
         super(TestGeverStateView, self).setUp()
@@ -12,14 +15,12 @@ class TestGeverStateView(FunctionalTestCase):
     def test_cluster_base_url(self):
         self.assertEquals(
             'http://foo.org/cluster/',
-            self.portal.restrictedTraverse('@@gever_state/cluster_base_url')(),
-        )
+            self.portal.restrictedTraverse('@@gever_state/cluster_base_url')())
 
     def test_gever_portal_url(self):
         self.assertEquals(
             'http://foo.org/cluster/portal',
-            self.portal.restrictedTraverse('@@gever_state/gever_portal_url')(),
-        )
+            self.portal.restrictedTraverse('@@gever_state/gever_portal_url')())
 
     def test_cas_server_url(self):
         applyProfile(self.portal, 'opengever.setup:casauth')
@@ -27,3 +28,45 @@ class TestGeverStateView(FunctionalTestCase):
             'http://foo.org/cluster/portal',
             self.portal.restrictedTraverse('@@gever_state/cas_server_url')(),
         )
+
+    @browsing
+    def test_properties_action_only_available_on_types_with_different_default_view(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        browser.open(self.dossier, 'tabbed_view')
+        self.assertIn(
+            'Properties',
+            browser.css('#plone-contentmenu-actions .actionMenuContent a').text)
+
+        browser.open(self.tasktemplate, 'view')
+        self.assertNotIn(
+            'Properties',
+            browser.css('#plone-contentmenu-actions .actionMenuContent a').text)
+
+    @browsing
+    def test_properties_action_not_available_on_portal(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        browser.open(self.portal)
+        self.assertNotIn(
+            'Properties',
+            browser.css('#plone-contentmenu-actions .actionMenuContent a').text)
+
+    @browsing
+    def test_properties_action_not_available_on_yearfolder(self, browser):
+        self.login(self.manager, browser=browser)
+        yearfolder = create(Builder('yearfolder').within(self.inbox))
+
+        browser.open(yearfolder)
+        self.assertNotIn(
+            'Properties',
+            browser.css('#plone-contentmenu-actions .actionMenuContent a').text)
+
+    @browsing
+    def test_properties_action_not_available_on_contactfolder(self, browser):
+        self.login(self.manager, browser=browser)
+
+        browser.open(self.contactfolder)
+        self.assertNotIn(
+            'Properties',
+            browser.css('#plone-contentmenu-actions .actionMenuContent a').text)

--- a/opengever/core/profiles/default/actions.xml
+++ b/opengever/core/profiles/default/actions.xml
@@ -464,9 +464,7 @@
       <property name="description" i18n:translate="" />
       <property name="url_expr">string:${object_url}/view</property>
       <property name="icon_expr" />
-      <property name="available_expr">
-                python: here.restrictedTraverse('@@plone_context_state').view_template_id() != 'view' and here.portal_type not in ('opengever.contact.contactfolder', 'opengever.inbox.yearfolder') and not globals_view.isPortalOrPortalDefaultPage()
-            </property>
+      <property name="available_expr">python:here.restrictedTraverse('@@gever_state').properties_action_available()</property>
       <property name="permissions">
         <element value="View" />
       </property>

--- a/opengever/core/upgrades/20180221144648_update_properties_action_available_expression/actions.xml
+++ b/opengever/core/upgrades/20180221144648_update_properties_action_available_expression/actions.xml
@@ -1,0 +1,13 @@
+<object xmlns:i18n="http://xml.zope.org/namespaces/i18n" name="portal_actions" meta_type="Plone Actions Tool">
+
+  <!-- OBJECT -->
+  <object name="object_buttons" meta_type="CMF Action Category">
+
+    <object name="properties" meta_type="CMF Action" i18n:domain="opengever.core">
+      <property name="title" i18n:translate="">Properties</property>
+      <property name="available_expr">python:here.restrictedTraverse('@@gever_state').properties_action_available()</property>
+    </object>
+
+  </object>
+
+</object>

--- a/opengever/core/upgrades/20180221144648_update_properties_action_available_expression/upgrade.py
+++ b/opengever/core/upgrades/20180221144648_update_properties_action_available_expression/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class UpdatePropertiesActionAvailableExpression(UpgradeStep):
+    """Update properties action available expression.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/disposition/browser/configure.zcml
+++ b/opengever/disposition/browser/configure.zcml
@@ -61,6 +61,13 @@
       />
 
   <browser:page
+      class=".views.UpdateTransferNumberView"
+      for="opengever.disposition.interfaces.IDisposition"
+      name="update-transfer-number"
+      permission="opengever.disposition.EditTransferNumber"
+      />
+
+  <browser:page
       class=".views.AppraiseView"
       for="opengever.disposition.interfaces.IDisposition"
       name="appraise-transition"

--- a/opengever/disposition/browser/overview.py
+++ b/opengever/disposition/browser/overview.py
@@ -114,3 +114,10 @@ class DispositionOverview(BrowserView):
 
     def get_current_state(self):
         return api.content.get_state(self.context)
+
+    def update_transfer_number_url(self):
+        return '{}/update-transfer-number'.format(self.context.absolute_url())
+
+    def is_transfer_number_editable(self):
+        return api.user.has_permission(
+            'opengever.disposition: Edit transfer number', obj=self.context)

--- a/opengever/disposition/browser/resources/disposition.js
+++ b/opengever/disposition/browser/resources/disposition.js
@@ -31,6 +31,31 @@
       });
     };
 
+    this.update_transfer_number = function(target){
+      var url = $('#transfer_number_dialog').data('transfer-number-save-url');
+      return this.request(url, {
+        method: "POST",
+        data: {
+          transfer_number: $('#transfer_number_field').val()
+        }
+      }).done(function() {
+        $('#transfer-number-value').text($('#transfer_number_field').val());
+        $('#transfer_number_dialog').data('overlay').close();
+      });
+    };
+
+    this.cancel_transfer_number = function(target){
+      $('#transfer_number_dialog').data('overlay').close();
+    };
+
+    this.show_transfer_number_dialog = function(){
+      var dialog = $('#transfer_number_dialog')
+      if (dialog.data('overlay') === undefined){
+        dialog.overlay();
+      }
+      dialog.data('overlay').load();
+    }
+
     this.events = [
       {
         method: "click",
@@ -41,10 +66,28 @@
         method: "click",
         target: ".repo-appraisal-button-group a",
         callback: this.update_repository_appraisal
+      },
+      {
+        method: "click",
+        target: ".edit_transfer_number",
+        callback: this.show_transfer_number_dialog
+      },
+
+      {
+        method: "click",
+        target: ".save_transfer_number",
+        callback: this.update_transfer_number
+      },
+      {
+        method: "click",
+        target: ".cancel_transfer_number",
+        callback: this.cancel_transfer_number
       }
+
     ];
 
     this.init();
+
   }
 
   new DispositionController();

--- a/opengever/disposition/browser/templates/overview.pt
+++ b/opengever/disposition/browser/templates/overview.pt
@@ -24,7 +24,7 @@
             </div>
 
             <div>
-              <h3 class="metadata" i18n:translate="label_proces">Process</h3>
+              <h3 class="metadata" i18n:translate="label_process">Process</h3>
               <div class="workflow_wizard">
                 <ul class="wizard_steps" tal:define="current_state view/get_current_state" >
                   <li tal:repeat="state view/get_states"

--- a/opengever/disposition/browser/templates/overview.pt
+++ b/opengever/disposition/browser/templates/overview.pt
@@ -5,7 +5,7 @@
         xmlns:i18n="http://xml.zope.org/namespaces/i18n"
         lang="en"
         metal:use-macro="context/main_template/macros/master"
-        i18n:domain="ftw.tabbedview">
+        i18n:domain="opengever.disposition">
 
     <body>
       <div metal:fill-slot="main">
@@ -24,6 +24,7 @@
             </div>
 
             <div>
+              <h3 class="metadata" i18n:translate="label_proces">Process</h3>
               <div class="workflow_wizard">
                 <ul class="wizard_steps" tal:define="current_state view/get_current_state" >
                   <li tal:repeat="state view/get_states"
@@ -33,6 +34,18 @@
                   </li>
                 </ul>
               </div>
+            </div>
+
+            <div class="metadata">
+              <h3 class="metadata" i18n:translate="label_metadata">Metadata</h3>
+              <div>
+
+                <span class="label" i18n:translate="label_transfer_number">Transfer number</span>
+                <span id="transfer-number-value" tal:content="context/transfer_number"></span>
+                <a href="#" class="edit edit_transfer_number" tal:condition="view/is_transfer_number_editable" i18n:translate="label_edit">Edit</a>
+
+              </div>
+
             </div>
 
             <ul class="list-group" tal:repeat="dossier_list view/get_dossier_lists">
@@ -247,8 +260,31 @@
               </div>
 
             </div>
+
+            <div class="overlay" id="transfer_number_dialog"
+                 tal:attributes="data-transfer-number-save-url view/update_transfer_number_url">
+              <h2 i18n:translate="edit_transfer_number">Edit transfer number</h2>
+              <form>
+                <div class="input-group">
+                  <label for="transfer_number"
+                         i18n:translate="label_transfer_number">Transfer number</label>
+                  <input type="text"
+                         name="transfer_number"
+                         tal:attributes="value context/transfer_number"
+                         id="transfer_number_field" />
+                </div>
+                <div class="button-group">
+                  <button class="button confirm context save_transfer_number"
+                          i18n:translate="label_save">Save</button>
+                  <button class="button cancel cancel_transfer_number"
+                          i18n:translate="label_cancel">Cancel</button>
+                </div>
+              </form>
+            </div>
+
           </metal:main-macro>
         </div>
+
       </body>
     </html>
   </metal:page>

--- a/opengever/disposition/browser/views.py
+++ b/opengever/disposition/browser/views.py
@@ -1,5 +1,7 @@
+from opengever.base.response import JSONResponse
 from opengever.disposition import _
 from opengever.disposition.appraisal import IAppraisal
+from opengever.disposition.disposition import IDisposition
 from plone import api
 from Products.Five.browser import BrowserView
 import json
@@ -45,6 +47,14 @@ class AppraiseView(BrowserView):
         return self.request.RESPONSE.redirect(
             '{}/content_status_modify?workflow_action={}'.format(
                 self.context.absolute_url(), self.transition))
+
+
+class UpdateTransferNumberView(BrowserView):
+
+    def __call__(self):
+        transfer_number = self.request.form['transfer_number']
+        IDisposition(self.context).transfer_number = transfer_number
+        return JSONResponse(self.request).proceed().dump()
 
 
 class GuardsView(BrowserView):

--- a/opengever/disposition/locales/de/LC_MESSAGES/opengever.disposition.po
+++ b/opengever/disposition/locales/de/LC_MESSAGES/opengever.disposition.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-11-20 14:11+0000\n"
+"POT-Creation-Date: 2018-03-19 12:59+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -35,6 +35,11 @@ msgstr "bewertungsliste"
 #: ./opengever/disposition/browser/listing.py
 msgid "document_sequence_number"
 msgstr "Laufnummer"
+
+#. Default: "Edit transfer number"
+#: ./opengever/disposition/browser/templates/overview.pt
+msgid "edit_transfer_number"
+msgstr "Ablieferungsnummer bearbeiten"
 
 #. Default: "The dossier ${title} is already offered in a different disposition."
 #: ./opengever/disposition/validators.py
@@ -80,6 +85,11 @@ msgstr "Alle archivieren"
 #: ./opengever/disposition/browser/removal_protocol.py
 msgid "label_archived"
 msgstr "Archiviert"
+
+#. Default: "Cancel"
+#: ./opengever/disposition/browser/templates/overview.pt
+msgid "label_cancel"
+msgstr "Abbrechen"
 
 #. Default: "Details:"
 #: ./opengever/disposition/browser/templates/overview.pt
@@ -134,6 +144,11 @@ msgstr "Dossiers"
 msgid "label_download_removal_protocol"
 msgstr "Löschprotokoll herunterladen"
 
+#. Default: "Edit"
+#: ./opengever/disposition/browser/templates/overview.pt
+msgid "label_edit"
+msgstr "Bearbeiten"
+
 #. Default: "Export appraisal list as excel"
 #: ./opengever/disposition/browser/overview.py
 msgid "label_export_appraisal_list_as_excel"
@@ -149,10 +164,20 @@ msgstr "Verlauf"
 msgid "label_inactive_dossiers"
 msgstr "Stornierte Dossiers"
 
+#. Default: "Metadata"
+#: ./opengever/disposition/browser/templates/overview.pt
+msgid "label_metadata"
+msgstr "Metadaten"
+
 #. Default: "No"
 #: ./opengever/disposition/browser/removal_protocol.py
 msgid "label_no"
 msgstr "Nein"
+
+#. Default: "Process"
+#: ./opengever/disposition/browser/templates/overview.pt
+msgid "label_process"
+msgstr "Prozess"
 
 #. Default: "Reference number"
 #: ./opengever/disposition/browser/removal_protocol.py
@@ -174,6 +199,11 @@ msgstr "Abgeschlossene Dossiers"
 msgid "label_review_state"
 msgstr "Status"
 
+#. Default: "Save"
+#: ./opengever/disposition/browser/templates/overview.pt
+msgid "label_save"
+msgstr "Speichern"
+
 #. Default: "Time"
 #: ./opengever/disposition/browser/removal_protocol.py
 msgid "label_time"
@@ -188,6 +218,7 @@ msgstr "Titel"
 
 #. Default: "Transfer number"
 #: ./opengever/disposition/browser/removal_protocol.py
+#: ./opengever/disposition/browser/templates/overview.pt
 #: ./opengever/disposition/disposition.py
 msgid "label_transfer_number"
 msgstr "Ablieferungsnummer"

--- a/opengever/disposition/locales/fr/LC_MESSAGES/opengever.disposition.po
+++ b/opengever/disposition/locales/fr/LC_MESSAGES/opengever.disposition.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-11-20 14:11+0000\n"
+"POT-Creation-Date: 2018-03-19 12:59+0000\n"
 "PO-Revision-Date: 2017-06-04 17:02+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-disposition/fr/>\n"
@@ -37,6 +37,11 @@ msgstr "liste_evaluation"
 #: ./opengever/disposition/browser/listing.py
 msgid "document_sequence_number"
 msgstr "Numéro courant"
+
+#. Default: "Edit transfer number"
+#: ./opengever/disposition/browser/templates/overview.pt
+msgid "edit_transfer_number"
+msgstr ""
 
 #. Default: "The dossier ${title} is already offered in a different disposition."
 #: ./opengever/disposition/validators.py
@@ -81,6 +86,11 @@ msgstr ""
 #. Default: "Archived"
 #: ./opengever/disposition/browser/removal_protocol.py
 msgid "label_archived"
+msgstr ""
+
+#. Default: "Cancel"
+#: ./opengever/disposition/browser/templates/overview.pt
+msgid "label_cancel"
 msgstr ""
 
 #. Default: "Details:"
@@ -136,6 +146,11 @@ msgstr "Dossiers"
 msgid "label_download_removal_protocol"
 msgstr ""
 
+#. Default: "Edit"
+#: ./opengever/disposition/browser/templates/overview.pt
+msgid "label_edit"
+msgstr ""
+
 #. Default: "Export appraisal list as excel"
 #: ./opengever/disposition/browser/overview.py
 msgid "label_export_appraisal_list_as_excel"
@@ -151,10 +166,20 @@ msgstr ""
 msgid "label_inactive_dossiers"
 msgstr ""
 
+#. Default: "Metadata"
+#: ./opengever/disposition/browser/templates/overview.pt
+msgid "label_metadata"
+msgstr ""
+
 #. Default: "No"
 #: ./opengever/disposition/browser/removal_protocol.py
 msgid "label_no"
 msgstr "Non"
+
+#. Default: "Process"
+#: ./opengever/disposition/browser/templates/overview.pt
+msgid "label_process"
+msgstr ""
 
 #. Default: "Reference number"
 #: ./opengever/disposition/browser/removal_protocol.py
@@ -176,6 +201,11 @@ msgstr ""
 msgid "label_review_state"
 msgstr "Etat"
 
+#. Default: "Save"
+#: ./opengever/disposition/browser/templates/overview.pt
+msgid "label_save"
+msgstr ""
+
 #. Default: "Time"
 #: ./opengever/disposition/browser/removal_protocol.py
 msgid "label_time"
@@ -190,6 +220,7 @@ msgstr "Titre"
 
 #. Default: "Transfer number"
 #: ./opengever/disposition/browser/removal_protocol.py
+#: ./opengever/disposition/browser/templates/overview.pt
 #: ./opengever/disposition/disposition.py
 msgid "label_transfer_number"
 msgstr ""

--- a/opengever/disposition/locales/opengever.disposition.pot
+++ b/opengever/disposition/locales/opengever.disposition.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-11-20 14:11+0000\n"
+"POT-Creation-Date: 2018-03-19 12:59+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -37,6 +37,11 @@ msgstr ""
 #. Default: "Sequence Number"
 #: ./opengever/disposition/browser/listing.py
 msgid "document_sequence_number"
+msgstr ""
+
+#. Default: "Edit transfer number"
+#: ./opengever/disposition/browser/templates/overview.pt
+msgid "edit_transfer_number"
 msgstr ""
 
 #. Default: "The dossier ${title} is already offered in a different disposition."
@@ -82,6 +87,11 @@ msgstr ""
 #. Default: "Archived"
 #: ./opengever/disposition/browser/removal_protocol.py
 msgid "label_archived"
+msgstr ""
+
+#. Default: "Cancel"
+#: ./opengever/disposition/browser/templates/overview.pt
+msgid "label_cancel"
 msgstr ""
 
 #. Default: "Details:"
@@ -137,6 +147,11 @@ msgstr ""
 msgid "label_download_removal_protocol"
 msgstr ""
 
+#. Default: "Edit"
+#: ./opengever/disposition/browser/templates/overview.pt
+msgid "label_edit"
+msgstr ""
+
 #. Default: "Export appraisal list as excel"
 #: ./opengever/disposition/browser/overview.py
 msgid "label_export_appraisal_list_as_excel"
@@ -152,9 +167,19 @@ msgstr ""
 msgid "label_inactive_dossiers"
 msgstr ""
 
+#. Default: "Metadata"
+#: ./opengever/disposition/browser/templates/overview.pt
+msgid "label_metadata"
+msgstr ""
+
 #. Default: "No"
 #: ./opengever/disposition/browser/removal_protocol.py
 msgid "label_no"
+msgstr ""
+
+#. Default: "Process"
+#: ./opengever/disposition/browser/templates/overview.pt
+msgid "label_process"
 msgstr ""
 
 #. Default: "Reference number"
@@ -177,6 +202,11 @@ msgstr ""
 msgid "label_review_state"
 msgstr ""
 
+#. Default: "Save"
+#: ./opengever/disposition/browser/templates/overview.pt
+msgid "label_save"
+msgstr ""
+
 #. Default: "Time"
 #: ./opengever/disposition/browser/removal_protocol.py
 msgid "label_time"
@@ -191,6 +221,7 @@ msgstr ""
 
 #. Default: "Transfer number"
 #: ./opengever/disposition/browser/removal_protocol.py
+#: ./opengever/disposition/browser/templates/overview.pt
 #: ./opengever/disposition/disposition.py
 msgid "label_transfer_number"
 msgstr ""

--- a/opengever/disposition/tests/test_overview.py
+++ b/opengever/disposition/tests/test_overview.py
@@ -41,11 +41,9 @@ class TestDispositionOverview(FunctionalTestCase):
                                        archival_value_annotation=u''
                                        u'In Absprache mit ARCH.'))
 
-        self.disposition = create(Builder('disposition')
-                                  .having(dossiers=[
-                                      self.dossier1,
-                                      self.dossier2,
-                                      ]))
+        self.disposition = create(Builder('disposition').having(
+            dossiers=[self.dossier1, self.dossier2],
+            transfer_number=u'Ablieferung 2013-44'))
 
     @browsing
     def test_list_only_all_disposition_dossiers(self, browser):
@@ -290,6 +288,25 @@ class TestDispositionOverview(FunctionalTestCase):
         self.assertEquals(
             ['Dossier E', 'Dossier D', 'Dossier C'],
             repos.css('h3.title a').text)
+
+    @browsing
+    def test_does_not_show_transfer_number_edit_button_when_readonly(self, browser):
+        browser.login().open(self.disposition, view='overview')
+
+        self.assertEquals(['Ablieferung 2013-44'],
+                          browser.css('div.metadata #transfer-number-value').text)
+        self.assertEquals([],
+                          browser.css('div.metadata .edit_transfer_number').text)
+
+    @browsing
+    def test_shows_transfer_number_in_text_field_when_editable(self, browser):
+        self.grant('Archivist')
+        browser.login().open(self.disposition, view='overview')
+
+        self.assertEquals(['Ablieferung 2013-44'],
+                          browser.css('div.metadata #transfer-number-value').text)
+        self.assertEquals(['Edit'],
+                          browser.css('div.metadata .edit_transfer_number').text)
 
 
 class TestClosedDispositionOverview(FunctionalTestCase):

--- a/opengever/disposition/tests/test_views.py
+++ b/opengever/disposition/tests/test_views.py
@@ -1,0 +1,46 @@
+from datetime import date
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.testbrowser import browsing
+from opengever.base.behaviors.lifecycle import ARCHIVAL_VALUE_SAMPLING
+from opengever.disposition.disposition import IDisposition
+from opengever.testing import FunctionalTestCase
+from plone.protect import createToken
+
+
+class TestUpdateTransferNumber(FunctionalTestCase):
+    """Test disposition overviews function as intended."""
+
+    def setUp(self):
+        super(TestUpdateTransferNumber, self).setUp()
+        self.grant('Records Manager')
+        self.root = create(Builder('repository_root'))
+        self.repository = create(Builder('repository')
+                                 .titled(u'Repository A')
+                                 .having(
+                                     archival_value=ARCHIVAL_VALUE_SAMPLING)
+                                 .within(self.root))
+        self.dossier1 = create(Builder('dossier')
+                               .as_expired()
+                               .within(self.repository)
+                               .having(title=u'Dossier A',
+                                       start=date(2016, 1, 19),
+                                       end=date(2016, 3, 19),
+                                       public_trial='limited-public',
+                                       archival_value='archival worthy'))
+
+        self.disposition = create(Builder('disposition').having(
+            dossiers=[self.dossier1],
+            transfer_number=u'Ablieferung 2013-44'))
+
+    @browsing
+    def test_update_transfer_number(self, browser):
+        self.grant('Archivist')
+        browser.login().open(self.disposition,
+                             {'transfer_number': u'Ablieferung 2018-1',
+                              '_authenticator': createToken()},
+                             view=u'update-transfer-number')
+
+        self.assertEquals({u'proceed': True}, browser.json)
+        self.assertEquals(u'Ablieferung 2018-1',
+                          IDisposition(self.disposition).transfer_number)


### PR DESCRIPTION
The transfer_number is now shown on the disposition overview and directly editable for users, which has the `edit transfer number` permission.  The transfer_number update is made via a simple AJAX call on a specific endpoint. Closes #2811.

Additionally I've fixed also an issue with the `available-expression` on the properties action.

The added tests are still Functional tests, the conversion to integration is a bigger work and will follow in a separate PR.

with edit transfer number permission:
<img width="861" alt="bildschirmfoto 2018-02-21 um 17 11 44" src="https://user-images.githubusercontent.com/485755/36491127-53f9c184-172a-11e8-8f5e-f48f2311a818.png">


<img width="864" alt="bildschirmfoto 2018-02-21 um 17 04 25" src="https://user-images.githubusercontent.com/485755/36491078-2a70d97e-172a-11e8-913d-5c4d86f8c083.png">

without permission:
<img width="870" alt="bildschirmfoto 2018-02-21 um 17 05 35" src="https://user-images.githubusercontent.com/485755/36491074-27ad8520-172a-11e8-96a4-ef11914ae8db.png">

Styling: https://github.com/4teamwork/plonetheme.teamraum/pull/617