### PR TITLE
Trivialities of `bin/mtest`

### DIFF
--- a/test-plone-4.3.x.cfg
+++ b/test-plone-4.3.x.cfg
@@ -16,4 +16,4 @@ eggs +=
     ${buildout:hotfix-eggs}
 
 [test-jenkins]
-test-command = bin/mtest -d -j5 $@
+test-command-no-coverage = bin/mtest -d -j5 $@

--- a/test-plone-4.3.x.cfg
+++ b/test-plone-4.3.x.cfg
@@ -16,4 +16,4 @@ eggs +=
     ${buildout:hotfix-eggs}
 
 [test-jenkins]
-test-command = bin/mtest -d $@
+test-command = bin/mtest -d -j5 $@

--- a/test-plone-4.3.x.cfg
+++ b/test-plone-4.3.x.cfg
@@ -16,4 +16,4 @@ eggs +=
     ${buildout:hotfix-eggs}
 
 [test-jenkins]
-test-command = bin/mtest $@
+test-command = bin/mtest -d $@


### PR DESCRIPTION
Observations piled up enough to take a small diversion:

1) We can save time by explicitly resetting buildout parts to the relevant ones for the main build
2) We should use `test-command-no-coverage` to fully adhere to the intentions of our buildouts
3) We should run the builds with the debug flag for better user feedback (and recorded timing data)
4) We should explicitly set the parallelity to match the build weight config