### PR TITLE
Fix deleting agenda items for non-word agenda items.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2018.1.4 (unreleased)
 ---------------------
 
-- Nothing changed yet.
+- Fix deleting agenda items for non-word agenda items. [deiferni]
 
 
 2018.1.3 (2018-02-20)

--- a/opengever/meeting/browser/resources/meeting.js
+++ b/opengever/meeting/browser/resources/meeting.js
@@ -332,7 +332,9 @@
       };
 
       self.cancel = function() {
-        self.overlay.close();
+        if (typeof(self.overlay) !== 'undefined') {
+          self.overlay.close();
+        }
       };
     };
 
@@ -408,9 +410,7 @@
       if (typeof(createExcerptDialog) !== 'undefined') {
         createExcerptDialog.close();
       }
-      if (typeof(renameAgendaItemDialog) !== 'undefined') {
-        renameAgendaItemDialog.cancel();
-      }
+      renameAgendaItemDialog.cancel();
     };
 
     this.updateSortOrder = function() {


### PR DESCRIPTION
The code seems to have been refactored so that renameAgendaItemDialog is now a function which wraps the overlay. The definition check needs to be moved closer to the overlay.

Fixes #4024.