### PR TITLE
Make sure notification-default for the forwarding-added kind exists.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -12,6 +12,7 @@ Changelog
 - Fix REST API @move endpoint: Do not require delete permission when moving objects. [buchi]
 - Add REST API endpoint for querying configuration settings. [buchi]
 
+- Make sure notification-default for the forwarding-added kind exists. [phgross]
 
 2018.1.3 (2018-02-20)
 ---------------------

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -11,8 +11,8 @@ Changelog
 - Improve checking for truthy dates in sablon template data. [deiferni]
 - Fix REST API @move endpoint: Do not require delete permission when moving objects. [buchi]
 - Add REST API endpoint for querying configuration settings. [buchi]
-
 - Make sure notification-default for the forwarding-added kind exists. [phgross]
+
 
 2018.1.3 (2018-02-20)
 ---------------------

--- a/opengever/core/upgrades/20180226144641_add_missing_forwarding_added_notification_default/upgrade.py
+++ b/opengever/core/upgrades/20180226144641_add_missing_forwarding_added_notification_default/upgrade.py
@@ -1,0 +1,43 @@
+from opengever.core.upgrade import SchemaMigration
+from sqlalchemy.schema import Sequence
+from sqlalchemy.sql.expression import column
+from sqlalchemy.sql.expression import table
+import json
+
+
+TASK_ISSUER_ROLE = 'task_issuer'
+TASK_RESPONSIBLE_ROLE = 'task_responsible'
+
+
+class AddMissingForwardingAddedNotificationDefault(SchemaMigration):
+    """Add missing forwarding-added notification_default.
+    """
+
+    defaults_table = table(
+        "notification_defaults",
+        column("id"),
+        column("kind"),
+        column("mail_notification_roles"),
+        column("badge_notification_roles")
+    )
+
+    def migrate(self):
+        query = self.defaults_table.select().where(
+            self.defaults_table.c.kind == 'forwarding-added')
+        forwarding_added = self.connection.execute(query).fetchall()
+
+        if not len(forwarding_added):
+            self.insert_forwarding_added_default()
+
+    def insert_forwarding_added_default(self):
+        values = {
+            'kind': 'forwarding-added',
+            'mail_notification_roles': json.dumps([TASK_RESPONSIBLE_ROLE]),
+            'badge_notification_roles': json.dumps(
+                [TASK_RESPONSIBLE_ROLE, TASK_ISSUER_ROLE])}
+
+        seq = Sequence('notification_defaults_id_seq')
+        if self.supports_sequences:
+            values['id'] = self.execute(seq)
+
+        self.execute(self.defaults_table.insert().values(**values))


### PR DESCRIPTION
With the commit 064ca0f8284c633bf0e7925f4d0125b9aa055604 the missing `forwarding-added` notification-default has been added retroactively, but the changed upgradestep was already installed on some installations, which leads now to an error on the notification-settings page (see https://sentry.4teamwork.ch/sentry/onegov-gever/issues/4732) because of the missing entry for the kind `forwarding-added`.

This PR makes sure that the entry exists.

⚠️ Only merge after https://github.com/4teamwork/opengever.core/pull/4019 has been merged.