### PR TITLE
Remove all uses of enableHTTPCompression in GEVER

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2018.1.4 (unreleased)
 ---------------------
 
+- Remove all uses of enableHTTPCompression in GEVER. [lgraf]
 - Fix deleting agenda items for non-word agenda items. [deiferni]
 
 

--- a/opengever/activity/browser/views.py
+++ b/opengever/activity/browser/views.py
@@ -60,7 +60,6 @@ class NotificationView(BrowserView):
         response = self.request.response
         response.setHeader('Content-Type', 'application/json')
         response.setHeader('X-Theme-Disabled', 'True')
-        response.enableHTTPCompression(REQUEST=self.request)
         return json.dumps(data)
 
     def dump_notifications(self, notifications):

--- a/opengever/base/browser/navigation.py
+++ b/opengever/base/browser/navigation.py
@@ -40,7 +40,6 @@ class JSONNavigation(BrowserView):
         response = self.request.response
         response.setHeader('Content-Type', 'application/json')
         response.setHeader('X-Theme-Disabled', 'True')
-        response.enableHTTPCompression(REQUEST=self.request)
 
         if self.request.get('cache_key'):
             # Only cache when there is a cache_key in the request.

--- a/opengever/base/browser/navigation.py
+++ b/opengever/base/browser/navigation.py
@@ -134,7 +134,10 @@ class JSONNavigation(BrowserView):
         # which the modified-index of the catalog cannot order correctly.
         # When we reach the next minute, return the newest modification
         # timestamp.
-        minute_of = lambda stamp: stamp.strftime('%Y-%m-%d %H:%M')
+
+        def minute_of(stamp):
+            return stamp.strftime('%Y-%m-%d %H:%M')
+
         previous = None
         newest = None
         for brain in brains:

--- a/opengever/dossier/browser/navigation.py
+++ b/opengever/dossier/browser/navigation.py
@@ -17,7 +17,6 @@ class JSONNavigation(BrowserView):
         response = self.request.response
         response.setHeader('Content-Type', 'application/json')
         response.setHeader('X-Theme-Disabled', 'True')
-        response.enableHTTPCompression(REQUEST=self.request)
 
         return self.json()
 

--- a/opengever/dossier/browser/navigation.py
+++ b/opengever/dossier/browser/navigation.py
@@ -12,6 +12,7 @@ class JSONNavigation(BrowserView):
     The navigation starts at the current context, i.e. the dossier.
 
     """
+
     def __call__(self):
         response = self.request.response
         response.setHeader('Content-Type', 'application/json')

--- a/opengever/meeting/browser/meetings/agendaitem_list.py
+++ b/opengever/meeting/browser/meetings/agendaitem_list.py
@@ -144,5 +144,4 @@ class DownloadGeneratedAgendaItemList(BrowserView):
         response = self.request.response
         response.setHeader('Content-Type', 'application/json')
         response.setHeader('X-Theme-Disabled', 'True')
-        response.enableHTTPCompression(REQUEST=self.request)
         return self.get_json_data(pretty=True)

--- a/opengever/meeting/browser/toc.py
+++ b/opengever/meeting/browser/toc.py
@@ -71,7 +71,6 @@ class DownloadAlphabeticalTOC(BrowserView):
         response = self.request.response
         response.setHeader('Content-Type', 'application/json')
         response.setHeader('X-Theme-Disabled', 'True')
-        response.enableHTTPCompression(REQUEST=self.request)
         return self.get_json_data(pretty=True)
 
 

--- a/opengever/portlets/tree/favorites.py
+++ b/opengever/portlets/tree/favorites.py
@@ -77,7 +77,6 @@ class RepositoryFavoritesView(BrowserView):
         response = self.request.response
         response.setHeader('Content-Type', 'application/json')
         response.setHeader('X-Theme-Disabled', 'True')
-        response.enableHTTPCompression(REQUEST=self.request)
 
         if self.request.get('cache_key'):
             # Only cache when there is a cache_key in the request.

--- a/opengever/workspace/participation/browser/manage_participants.py
+++ b/opengever/workspace/participation/browser/manage_participants.py
@@ -26,7 +26,6 @@ class ManageParticipants(BrowserView):
         response = self.request.response
         response.setHeader('Content-Type', 'application/json')
         response.setHeader('X-Theme-Disabled', 'True')
-        response.enableHTTPCompression(REQUEST=self.request)
         return json.dumps(data)
 
     def get_participants(self):


### PR DESCRIPTION
Removes all uses of `response.enableHTTPCompression()` in `opengever/*` code.

This is because the ZPublisher implementation of gzipping responses is buggy (prone to **double compression**), and therefore shouldn't be used at all (HTTP compression should be done at the Apache / Nginx frontend level anyway, instead of at the application level).

---

ZPublisher's implementation is buggy because multiple calls to `HTTPResponse.setBody()` may lead to double compression. The only way double compression is usually prevented is because the [`newlen < startlen` condition in HTTPRequest.setBody() evaluates to `False`.](https://github.com/zopefoundation/Zope/blob/master/src/ZPublisher/HTTPResponse.py#L538-L568)

Gzipping data twice usually increases its size. Except when it doesn't, then ZPublisher will happily double-compress your response body without realizing it.

Repeated calls to `setBody()` (for the same response) aren't uncommon, [`plone.transformchain` e.g. does this all the time](https://github.com/plone/plone.transformchain/blob/master/plone/transformchain/zpublisher.py#L82-L99).

This could possibly be fixed in ZPublisher by keeping track on the response whether it has already been compressed once or not (locking the response body is likely to break transforms down the line that need to modify it, like Diazo or `plone.protect`). But at this point that would mean monkey patching one beast of a method, and given it's the wrong place to do HTTP compression anyway, I'd simply advise against using it.

Also: [`plone.app.caching` dropped support for gzip compression using ZPublisher almost 3 years ago](https://github.com/plone/plone.app.caching/pull/16).

Fixes https://extranet.4teamwork.ch/support/gever-st-gallen/tracker/218