### PR TITLE
Use ZCML instead of provideAdapter.

### DIFF
--- a/opengever/dossier/archive.py
+++ b/opengever/dossier/archive.py
@@ -21,7 +21,7 @@ from ZODB.POSException import ConflictError
 from zope import schema
 from zope.annotation.interfaces import IAnnotations
 from zope.component import adapter
-from zope.component import getUtility, provideAdapter
+from zope.component import getUtility
 from zope.interface import implementer
 from zope.interface import Invalid
 from zope.interface import invariant
@@ -296,9 +296,6 @@ validator.WidgetValidatorDiscriminators(
     EnddateValidator,
     field=IArchiveFormSchema['dossier_enddate'],
 )
-
-
-provideAdapter(EnddateValidator)
 
 
 @implementer(IDossierArchiver)

--- a/opengever/dossier/configure.zcml
+++ b/opengever/dossier/configure.zcml
@@ -29,10 +29,8 @@
 
   <i18n:registerTranslations directory="locales" />
 
-  <adapter
-      factory=".move_items.DestinationValidator"
-      provides="z3c.form.interfaces.IValidator"
-      />
+  <adapter factory=".archive.EnddateValidator" />
+  <adapter factory=".move_items.DestinationValidator" />
 
   <adapter
       factory=".statestorage.GeverTabbedviewDictStorage"

--- a/opengever/dossier/move_items.py
+++ b/opengever/dossier/move_items.py
@@ -19,7 +19,6 @@ from z3c.form import validator
 from z3c.form.interfaces import HIDDEN_MODE
 from z3c.relationfield.schema import RelationChoice
 from zope import schema
-from zope.component import provideAdapter
 from zope.interface import Interface, Invalid
 import z3c.form
 
@@ -275,6 +274,3 @@ class DestinationValidator(validator.SimpleFieldValidator):
 
 validator.WidgetValidatorDiscriminators(
     DestinationValidator, field=IMoveItemsSchema['destination_folder'])
-
-
-provideAdapter(DestinationValidator)

--- a/opengever/mail/browser/configure.zcml
+++ b/opengever/mail/browser/configure.zcml
@@ -1,6 +1,10 @@
 <configure
+    xmlns="http://namespaces.zope.org/zope"
     xmlns:zope="http://namespaces.zope.org/zope"
     xmlns:browser="http://namespaces.zope.org/browser">
+
+  <adapter factory=".send_document.DocumentSizeValidator" />
+  <adapter factory=".send_document.AddressValidator" />
 
   <browser:viewlet
       name="plone.belowcontenttitle.documentbyline"

--- a/opengever/mail/browser/send_document.py
+++ b/opengever/mail/browser/send_document.py
@@ -135,6 +135,7 @@ class ISendDocumentSchema(Interface):
             raise NoMail(_(u'You have to select a intern \
                             or enter a extern mail-addres'))
 
+
 # put the validators
 validator.WidgetValidatorDiscriminators(
     DocumentSizeValidator,

--- a/opengever/mail/browser/send_document.py
+++ b/opengever/mail/browser/send_document.py
@@ -35,7 +35,6 @@ from z3c.relationfield.schema import RelationChoice
 from z3c.relationfield.schema import RelationList
 from zope import schema
 from zope.component import getUtility
-from zope.component import provideAdapter
 from zope.event import notify
 from zope.i18n import translate
 from zope.interface import Interface
@@ -146,9 +145,6 @@ validator.WidgetValidatorDiscriminators(
     AddressValidator,
     field=ISendDocumentSchema['extern_receiver'],
     )
-
-provideAdapter(DocumentSizeValidator)
-provideAdapter(AddressValidator)
 
 
 class SendDocumentForm(form.Form):

--- a/opengever/task/browser/assign.py
+++ b/opengever/task/browser/assign.py
@@ -21,7 +21,6 @@ from z3c.form.form import Form
 from z3c.form.interfaces import HIDDEN_MODE
 from z3c.form.interfaces import INPUT_MODE
 from zope import schema
-from zope.component import provideAdapter
 from zope.event import notify
 from zope.interface import Invalid
 from zope.lifecycleevent import ObjectModifiedEvent
@@ -70,8 +69,6 @@ validator.WidgetValidatorDiscriminators(
     NoTeamsInProgressStateValidator,
     field=IAssignSchema['responsible'],
 )
-
-provideAdapter(NoTeamsInProgressStateValidator)
 
 
 class AssignTaskForm(Form):

--- a/opengever/task/browser/complete.py
+++ b/opengever/task/browser/complete.py
@@ -37,7 +37,6 @@ from zExceptions import Unauthorized
 from zope import schema
 from zope.app.intid.interfaces import IIntIds
 from zope.component import getUtility, getAdapter
-from zope.component import provideAdapter
 from zope.event import notify
 from zope.i18n import translate
 from zope.interface import provider
@@ -110,7 +109,6 @@ class ICompleteSuccessorTaskSchema(Schema):
 
 validator.WidgetValidatorDiscriminators(
     NoCheckedoutDocsValidator, field=ICompleteSuccessorTaskSchema['documents'])
-provideAdapter(NoCheckedoutDocsValidator)
 
 
 class CompleteSuccessorTaskForm(Form):

--- a/opengever/task/browser/configure.zcml
+++ b/opengever/task/browser/configure.zcml
@@ -6,6 +6,9 @@
   <include package=".accept" />
   <include package=".delegate" />
 
+  <adapter factory=".complete.NoCheckedoutDocsValidator" />
+  <adapter factory=".assign.NoTeamsInProgressStateValidator" />
+
   <browser:page
       name="task_transition_controller"
       for="opengever.task.task.ITask"

--- a/opengever/task/configure.zcml
+++ b/opengever/task/configure.zcml
@@ -22,6 +22,8 @@
 
   <i18n:registerTranslations directory="locales" />
 
+  <adapter factory=".task.NoCheckedoutDocsValidator" />
+
   <browser:page
       name="task_response_delete"
       for="opengever.task.task.ITask"

--- a/opengever/task/task.py
+++ b/opengever/task/task.py
@@ -44,7 +44,6 @@ from zope import schema
 from zope.app.intid.interfaces import IIntIds
 from zope.component import getMultiAdapter
 from zope.component import getUtility
-from zope.component import provideAdapter
 from zope.interface import implements
 from zope.schema.vocabulary import getVocabularyRegistry
 
@@ -235,8 +234,6 @@ validator.WidgetValidatorDiscriminators(
     NoCheckedoutDocsValidator,
     field=ITask['relatedItems'],
     )
-
-provideAdapter(NoCheckedoutDocsValidator)
 
 
 default_responsible_client = widget.ComputedWidgetAttribute(


### PR DESCRIPTION
`provideAdapter` should never be used on module level because:
1. it cannot be isolated in tests
2. it is not consistent: all other adapters are registered in ZCML.

Fixes #3928