### PR TITLE
Cleanup component unit tests and mock tests and rename ANNOTATION_LAYER.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -881,6 +881,32 @@ Then you can use the ``Builder`` function in your test cases:
 Note that when using the ``OPENGEVER_FUNCTIONAL_TESTING`` Layer the ``Builder`` will automatically do a ``transaction.commit()`` when ``create()`` is called.
 
 
+Unit testing and mock tests
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+opengever.core has some unit tests (without a testing layer) and some mock test cases (usually
+with the ``COMPONENT_UNIT_TESTING`` testing layer).
+
+When writing unit tests (with no layer), the developer must take into account that there is no
+isolation at all. The developer must make sure that neither the test nor any component used
+in the test leaks, or isolation must be ensured manually.
+The developer should also take into account that components under tests (or their dependencies)
+may be changed in the future.
+
+By leaking we mean any kind of thing changed outside of the test scope. This includes registering
+components (adapters, utilites), changing globals (``setSite``, registering transmogrifier
+blueprints, environment variables) or any other action that can influence other components later.
+
+If a developer cannot guarantee that the test is not leaking he/she shall not write a unit test,
+but use at least the ``COMPONENT_UNIT_TESTING`` layer or write an integration test.
+
+The ``COMPONENT_UNIT_TESTING`` provides a minimal isolation of z3 componentes (adapters,
+utilites) and registers basic adapters such as annotations.
+
+When using mock tests cases, which discourage from in general, always import the
+``MockTestCase`` from ``ftw.testing`` in order to be compatible with ``COMPONENT_UNIT_TESTING``.
+
+
 Testing Inbound Mail
 --------------------
 

--- a/opengever/base/tests/test_wizard_storage.py
+++ b/opengever/base/tests/test_wizard_storage.py
@@ -3,7 +3,7 @@ from datetime import timedelta
 from ftw.testing import MockTestCase
 from opengever.base.browser.wizard import storage
 from opengever.base.browser.wizard.interfaces import IWizardDataStorage
-from opengever.core.testing import ANNOTATION_LAYER
+from opengever.core.testing import COMPONENT_UNIT_TESTING
 from persistent.dict import PersistentDict
 from zope.annotation.interfaces import IAttributeAnnotatable
 from zope.component import getSiteManager
@@ -15,7 +15,7 @@ import AccessControl
 
 class TestAcceptTaskStorageManager(MockTestCase):
 
-    layer = ANNOTATION_LAYER
+    layer = COMPONENT_UNIT_TESTING
 
     def setUp(self):
         super(TestAcceptTaskStorageManager, self).setUp()

--- a/opengever/core/testing.py
+++ b/opengever/core/testing.py
@@ -132,17 +132,19 @@ class PDFConverterAvailability(object):
         pdfconverter_available_lock.release()
 
 
-class AnnotationLayer(ComponentRegistryLayer):
-    """Loads ZML of zope.annotation.
+class ComponentUnitTesting(ComponentRegistryLayer):
+    """Testing layer for unit-testing zope components.
+    This test provides isolation of the component registry and the site hooks
+    as well as minimal components such as annotations.
     """
 
     def setUp(self):
-        super(AnnotationLayer, self).setUp()
+        super(ComponentUnitTesting, self).setUp()
         import zope.annotation
         self.load_zcml_file('configure.zcml', zope.annotation)
 
 
-ANNOTATION_LAYER = AnnotationLayer()
+COMPONENT_UNIT_TESTING = ComponentUnitTesting()
 
 
 class OpengeverFixture(PloneSandboxLayer):

--- a/opengever/document/tests/test_indexers.py
+++ b/opengever/document/tests/test_indexers.py
@@ -1,6 +1,7 @@
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testing import MockTestCase
+from opengever.core.testing import ANNOTATION_LAYER
 from opengever.document.checkout.manager import CHECKIN_CHECKOUT_ANNOTATIONS_KEY
 from opengever.document.indexers import DefaultDocumentIndexer
 from opengever.document.indexers import metadata
@@ -160,6 +161,7 @@ class TestDocumentIndexers(FunctionalTestCase):
 
 
 class TestDefaultDocumentIndexer(MockTestCase):
+    layer = ANNOTATION_LAYER
 
     def test_default_document_indexer_calls_portal_transforms_correctly(self):
         # Sample file conforming to NamedFile interface

--- a/opengever/document/tests/test_indexers.py
+++ b/opengever/document/tests/test_indexers.py
@@ -1,7 +1,7 @@
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testing import MockTestCase
-from opengever.core.testing import ANNOTATION_LAYER
+from opengever.core.testing import COMPONENT_UNIT_TESTING
 from opengever.document.checkout.manager import CHECKIN_CHECKOUT_ANNOTATIONS_KEY
 from opengever.document.indexers import DefaultDocumentIndexer
 from opengever.document.indexers import metadata
@@ -161,7 +161,7 @@ class TestDocumentIndexers(FunctionalTestCase):
 
 
 class TestDefaultDocumentIndexer(MockTestCase):
-    layer = ANNOTATION_LAYER
+    layer = COMPONENT_UNIT_TESTING
 
     def test_default_document_indexer_calls_portal_transforms_correctly(self):
         # Sample file conforming to NamedFile interface

--- a/opengever/dossier/tests/test_archiver.py
+++ b/opengever/dossier/tests/test_archiver.py
@@ -5,7 +5,7 @@ from ftw.builder import create
 from ftw.testbrowser import browsing
 from ftw.testbrowser.pages import statusmessages
 from ftw.testing import MockTestCase
-from opengever.core.testing import ANNOTATION_LAYER
+from opengever.core.testing import COMPONENT_UNIT_TESTING
 from opengever.document.behaviors.metadata import IDocumentMetadata
 from opengever.dossier.archive import Archiver
 from opengever.dossier.archive import EnddateValidator
@@ -105,7 +105,7 @@ class TestArchiver(IntegrationTestCase):
 
 class TestArchiving(MockTestCase):
 
-    layer = ANNOTATION_LAYER
+    layer = COMPONENT_UNIT_TESTING
 
     def setUp(self):
         super(TestArchiving, self).setUp()

--- a/opengever/dossier/tests/test_participation.py
+++ b/opengever/dossier/tests/test_participation.py
@@ -15,9 +15,11 @@ class TestParticipationHanlder(MockTestCase):
         super(TestParticipationHanlder, self).setUp()
         self.context = self.mocker.mock()
 
-        #annotation mock
         annonation_storage = {}
-        annotation_adapter = lambda obj: annonation_storage
+
+        def annotation_adapter(obj):
+            return annonation_storage
+
         self.mock_adapter(annotation_adapter, IAnnotations, [Interface, ])
 
         created_handler = self.mocker.mock()

--- a/opengever/dossier/tests/test_participation.py
+++ b/opengever/dossier/tests/test_participation.py
@@ -1,6 +1,6 @@
 from ftw.testing import MockTestCase
 from mocker import ANY
-from opengever.core.testing import ANNOTATION_LAYER
+from opengever.core.testing import COMPONENT_UNIT_TESTING
 from opengever.dossier.behaviors.participation import ParticipationHandler
 from opengever.dossier.interfaces import IParticipationCreated
 from opengever.dossier.interfaces import IParticipationRemoved
@@ -9,7 +9,7 @@ from zope.interface import Interface
 
 
 class TestParticipationHanlder(MockTestCase):
-    layer = ANNOTATION_LAYER
+    layer = COMPONENT_UNIT_TESTING
 
     def setUp(self):
         super(TestParticipationHanlder, self).setUp()

--- a/opengever/dossier/tests/test_participation.py
+++ b/opengever/dossier/tests/test_participation.py
@@ -1,13 +1,15 @@
+from ftw.testing import MockTestCase
 from mocker import ANY
+from opengever.core.testing import ANNOTATION_LAYER
 from opengever.dossier.behaviors.participation import ParticipationHandler
 from opengever.dossier.interfaces import IParticipationCreated
 from opengever.dossier.interfaces import IParticipationRemoved
-from plone.mocktestcase import MockTestCase
 from zope.annotation.interfaces import IAnnotations
 from zope.interface import Interface
 
 
 class TestParticipationHanlder(MockTestCase):
+    layer = ANNOTATION_LAYER
 
     def setUp(self):
         super(TestParticipationHanlder, self).setUp()

--- a/opengever/mail/tests/test_validators.py
+++ b/opengever/mail/tests/test_validators.py
@@ -23,7 +23,7 @@ class TestValidators(MockTestCase):
 
         context = self.stub()
         request = self.stub()
-        mail1 = self.providing_stub([IMail,])
+        mail1 = self.providing_stub([IMail])
         doc1 = self.stub()
         self.expect(mail1.message.getSize()).result(300000)
         self.expect(doc1.file.getSize()).result(800000)
@@ -49,7 +49,6 @@ class TestValidators(MockTestCase):
             self.expect(
                 request.get('form.widgets.documents_as_links')).result(['selected', ])
             self.expect(reg_proxy.max_size).result(1)
-
 
         self.replay()
 

--- a/opengever/mail/tests/test_validators.py
+++ b/opengever/mail/tests/test_validators.py
@@ -4,6 +4,7 @@ from ftw.mail.mail import IMail
 from ftw.testbrowser import browsing
 from ftw.testbrowser.pages.statusmessages import assert_no_error_messages
 from ftw.testing import MockTestCase
+from opengever.core.testing import ANNOTATION_LAYER
 from opengever.mail.interfaces import ISendDocumentConf
 from opengever.mail.validators import AddressValidator
 from opengever.mail.validators import DocumentSizeValidator
@@ -16,6 +17,7 @@ from zope.schema.interfaces import RequiredMissing
 
 
 class TestValidators(MockTestCase):
+    layer = ANNOTATION_LAYER
 
     def test_document_size_validator(self):
 

--- a/opengever/mail/tests/test_validators.py
+++ b/opengever/mail/tests/test_validators.py
@@ -4,7 +4,7 @@ from ftw.mail.mail import IMail
 from ftw.testbrowser import browsing
 from ftw.testbrowser.pages.statusmessages import assert_no_error_messages
 from ftw.testing import MockTestCase
-from opengever.core.testing import ANNOTATION_LAYER
+from opengever.core.testing import COMPONENT_UNIT_TESTING
 from opengever.mail.interfaces import ISendDocumentConf
 from opengever.mail.validators import AddressValidator
 from opengever.mail.validators import DocumentSizeValidator
@@ -17,7 +17,7 @@ from zope.schema.interfaces import RequiredMissing
 
 
 class TestValidators(MockTestCase):
-    layer = ANNOTATION_LAYER
+    layer = COMPONENT_UNIT_TESTING
 
     def test_document_size_validator(self):
 

--- a/opengever/meeting/tests/test_unit_proposalhistory.py
+++ b/opengever/meeting/tests/test_unit_proposalhistory.py
@@ -1,4 +1,6 @@
 from datetime import datetime
+from ftw.testing import MockTestCase
+from opengever.core.testing import ANNOTATION_LAYER
 from opengever.meeting.proposalhistory import BaseHistoryRecord
 from opengever.meeting.proposalhistory import ProposalHistory
 from opengever.testing import IntegrationTestCase
@@ -6,9 +8,11 @@ from persistent.mapping import PersistentMapping
 from unittest import TestCase
 
 
-class TestUnitPorposalHistory(TestCase):
+class TestUnitPorposalHistory(MockTestCase):
+    layer = ANNOTATION_LAYER
 
     def setUp(self):
+        super(TestUnitPorposalHistory, self).setUp()
         self.history = ProposalHistory(context=None)
 
     def test_append_record_raises_when_timestamp_is_not_datetime(self):

--- a/opengever/meeting/tests/test_unit_proposalhistory.py
+++ b/opengever/meeting/tests/test_unit_proposalhistory.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from ftw.testing import MockTestCase
-from opengever.core.testing import ANNOTATION_LAYER
+from opengever.core.testing import COMPONENT_UNIT_TESTING
 from opengever.meeting.proposalhistory import BaseHistoryRecord
 from opengever.meeting.proposalhistory import ProposalHistory
 from opengever.testing import IntegrationTestCase
@@ -9,7 +9,7 @@ from unittest import TestCase
 
 
 class TestUnitPorposalHistory(MockTestCase):
-    layer = ANNOTATION_LAYER
+    layer = COMPONENT_UNIT_TESTING
 
     def setUp(self):
         super(TestUnitPorposalHistory, self).setUp()

--- a/opengever/tabbedview/tests/test_containing_documents_tab.py
+++ b/opengever/tabbedview/tests/test_containing_documents_tab.py
@@ -1,10 +1,12 @@
 from ftw.testing import MockTestCase
 from mocker import ANY
+from opengever.core.testing import ANNOTATION_LAYER
 from opengever.tabbedview.utils import get_containing_document_tab_url
 from zope.interface import Interface
 
 
 class TestContainingDocumentsTabFunction(MockTestCase):
+    layer = ANNOTATION_LAYER
 
     def mock_obj(self, absolute_url=None):
         obj = self.stub()

--- a/opengever/tabbedview/tests/test_containing_documents_tab.py
+++ b/opengever/tabbedview/tests/test_containing_documents_tab.py
@@ -1,12 +1,12 @@
 from ftw.testing import MockTestCase
 from mocker import ANY
-from opengever.core.testing import ANNOTATION_LAYER
+from opengever.core.testing import COMPONENT_UNIT_TESTING
 from opengever.tabbedview.utils import get_containing_document_tab_url
 from zope.interface import Interface
 
 
 class TestContainingDocumentsTabFunction(MockTestCase):
-    layer = ANNOTATION_LAYER
+    layer = COMPONENT_UNIT_TESTING
 
     def mock_obj(self, absolute_url=None):
         obj = self.stub()

--- a/opengever/task/tests/test_unit_related_documents.py
+++ b/opengever/task/tests/test_unit_related_documents.py
@@ -3,7 +3,7 @@ from ftw.testing import MockTestCase
 from mocker import ANY
 from opengever.task.browser.related_documents import \
     RelatedDocumentsCatalogTableSource
-from opengever.core.testing import ANNOTATION_LAYER
+from opengever.core.testing import COMPONENT_UNIT_TESTING
 from plone.uuid.interfaces import IUUID
 from zope.interface import Interface
 from ftw.table.catalog_source import default_custom_sort
@@ -11,7 +11,7 @@ from ftw.table.catalog_source import default_custom_sort
 
 class ExtendQueryWithOrdering(MockTestCase):
 
-    layer = ANNOTATION_LAYER
+    layer = COMPONENT_UNIT_TESTING
 
     def setUp(self):
         super(ExtendQueryWithOrdering, self).setUp()
@@ -220,7 +220,7 @@ class ExtendQueryWithOrdering(MockTestCase):
 
 class ExtendQueryWithTextfilterTests(MockTestCase):
 
-    layer = ANNOTATION_LAYER
+    layer = COMPONENT_UNIT_TESTING
 
     def setUp(self):
         super(ExtendQueryWithTextfilterTests, self).setUp()
@@ -296,7 +296,7 @@ class ExtendQueryWithTextfilterTests(MockTestCase):
 
 class GetRelatedDocumentsTests(MockTestCase):
 
-    layer = ANNOTATION_LAYER
+    layer = COMPONENT_UNIT_TESTING
 
     def setUp(self):
         super(GetRelatedDocumentsTests, self).setUp()
@@ -397,7 +397,7 @@ class GetRelatedDocumentsTests(MockTestCase):
 
 class BuildQueryTests(MockTestCase):
 
-    layer = ANNOTATION_LAYER
+    layer = COMPONENT_UNIT_TESTING
 
     def setUp(self):
         super(BuildQueryTests, self).setUp()

--- a/opengever/task/tests/test_validators.py
+++ b/opengever/task/tests/test_validators.py
@@ -1,4 +1,4 @@
-from opengever.core.testing import ANNOTATION_LAYER
+from opengever.core.testing import COMPONENT_UNIT_TESTING
 from ftw.testing import MockTestCase
 from opengever.task.browser.complete import ICompleteSuccessorTaskSchema
 from opengever.task.browser.complete import NoCheckedoutDocsValidator
@@ -10,7 +10,7 @@ from zope.schema import getFields
 
 
 class TestTaskCompletion(MockTestCase):
-    layer = ANNOTATION_LAYER
+    layer = COMPONENT_UNIT_TESTING
 
     def test_nocheckedout_docs_validator(self):
 

--- a/opengever/task/tests/test_validators.py
+++ b/opengever/task/tests/test_validators.py
@@ -1,3 +1,4 @@
+from opengever.core.testing import ANNOTATION_LAYER
 from ftw.testing import MockTestCase
 from opengever.task.browser.complete import ICompleteSuccessorTaskSchema
 from opengever.task.browser.complete import NoCheckedoutDocsValidator
@@ -9,6 +10,7 @@ from zope.schema import getFields
 
 
 class TestTaskCompletion(MockTestCase):
+    layer = ANNOTATION_LAYER
 
     def test_nocheckedout_docs_validator(self):
 


### PR DESCRIPTION
Fixes #3876.

Unit tests (=tests without a layer) do not have isolation. So all global things registered in those tests, such as adapters, utilites, the site hook or other globals, are not isolated (!). We've had quite a lot of tests which blindly changed global things without any isolation.

I've cleaned it up a bit:
1. rename `ANNOTATION_LAYER` to `COMPONENT_UNIT_TESTING`: the layer can be used for all tests which test components (e.g. adapters, annotations) or rely on components beeing available.
2. let candidates I found use the `COMPONENT_UNIT_TESTING`.

@4teamwork/gever be advised: when writing unit tests, you must be 100% sure that your test and all things your tests use do not use any adapters or other components or will in the future. The unit test must not ever write to globals unless carefully isolated (tear down).
If you are not 100% sure, simply avoid writing unit tests, or at least use the `COMPONENT_UNIT_TESTING` layer 😉.

Also be aware that when using the `COMPONENT_UNIT_TESTING` layer, the `MockTestCase` class must be imported from `ftw.testing` rather than `plone.mocktestcase`.