### PR TITLE
Return `None` when no meeting date is available.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,7 @@ Changelog
 
 - Remove all uses of enableHTTPCompression in GEVER. [lgraf]
 - Fix deleting agenda items for non-word agenda items. [deiferni]
+- Improve checking for truthy dates in sablon template data. [deiferni]
 
 
 2018.1.3 (2018-02-20)

--- a/opengever/meeting/model/meeting.py
+++ b/opengever/meeting/model/meeting.py
@@ -402,7 +402,7 @@ class Meeting(Base, SQLFormSupport):
 
     def get_end_time(self):
         if not self.end:
-            return ''
+            return None
 
         return self._get_localized_time(self.end)
 
@@ -420,7 +420,7 @@ class Meeting(Base, SQLFormSupport):
 
     def _get_localized_time(self, date):
         if not date:
-            return ''
+            return None
 
         return api.portal.get_localized_time(datetime=date, time_only=True)
 


### PR DESCRIPTION
This makes checks for presence in `sablon` templates easier, as the variable can then be used in an `<<if>>` to check for presence.

With empty strings we currently have the problem that they are always considered truthy, see https://github.com/senny/sablon#conditionals. Thus we don't have an option to build an `<<if>>` in `sablon` that only evaluates to `true` for non-empty strings without either introducing new dependencies (like `activesupport`) or modifications to sablon itself. Fixing it in gever is easier.