### PR TITLE
Do not check for delete permission in `@move` endpoint

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -9,6 +9,7 @@ Changelog
 - Fix NotificationDefault hook. [phgross]
 - Fix deleting agenda items for non-word agenda items. [deiferni]
 - Improve checking for truthy dates in sablon template data. [deiferni]
+- Fix REST API @move endpoint: Do not require delete permission when moving objects. [buchi]
 
 2018.1.3 (2018-02-20)
 ---------------------

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -60,4 +60,13 @@
       permission="zope2.View"
       />
 
+  <plone:service
+      method="POST"
+      name="@move"
+      for="Products.CMFCore.interfaces.IFolderish"
+      factory=".move.Move"
+      permission="zope2.View"
+      layer="opengever.base.interfaces.IOpengeverBaseLayer"
+      />
+
 </configure>

--- a/opengever/api/move.py
+++ b/opengever/api/move.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+from Acquisition import aq_parent
+from Products.CMFCore.utils import getToolByName
+from plone.restapi.deserializer import json_body
+from plone.restapi.services.copymove.copymove import Move
+from zExceptions import BadRequest
+from zope.interface import alsoProvides
+from zope.security import checkPermission
+
+import plone
+
+
+class Move(Move):
+    """Moves existing content objects.
+    """
+
+    # Copied from plone.restapi 1.1.0
+    # Disables DeleteObjects permission check
+    def reply(self):
+        # return 401/403 Forbidden if the user has no permission
+        if not checkPermission('cmf.AddPortalContent', self.context):
+            pm = getToolByName(self.context, 'portal_membership')
+            if bool(pm.isAnonymousUser()):
+                self.request.response.setStatus(401)
+            else:
+                self.request.response.setStatus(403)
+            return
+
+        data = json_body(self.request)
+
+        source = data.get('source', None)
+
+        if not source:
+            raise BadRequest("Property 'source' is required")
+
+        # Disable CSRF protection
+        if 'IDisableCSRFProtection' in dir(plone.protect.interfaces):
+            alsoProvides(self.request,
+                         plone.protect.interfaces.IDisableCSRFProtection)
+
+        if not isinstance(source, list):
+            source = [source]
+
+        parents_ids = {}
+        for item in source:
+            obj = self.get_object(item)
+            if obj is not None:
+                # -- Commented out the following block to disable checking for
+                # -- delete permission, as in GEVER the user is not allowed to
+                # -- delete content.
+                # if self.is_moving:
+                #     # To be able to safely move the object, the user requires
+                #     # permissions on the parent
+                #     if not checkPermission('zope2.DeleteObjects', obj) and \
+                #        not checkPermission(
+                #             'zope2.DeleteObjects', aq_parent(obj)):
+                #         self.request.response.setStatus(403)
+                #         return
+                parent = aq_parent(obj)
+                if parent in parents_ids:
+                    parents_ids[parent].append(obj.getId())
+                else:
+                    parents_ids[parent] = [obj.getId()]
+
+        results = []
+        for parent, ids in parents_ids.items():
+            result = self.context.manage_pasteObjects(
+                cb_copy_data=self.clipboard(parent, ids))
+            for res in result:
+                results.append({
+                    'source': '{}/{}'.format(
+                        parent.absolute_url(), res['id']),
+                    'target': '{}/{}'.format(
+                        self.context.absolute_url(), res['new_id']),
+                })
+        return results

--- a/opengever/api/tests/test_move.py
+++ b/opengever/api/tests/test_move.py
@@ -1,0 +1,25 @@
+from ftw.testbrowser import browsing
+from plone.app.testing import setRoles
+from opengever.testing import IntegrationTestCase
+import json
+
+
+class TestMove(IntegrationTestCase):
+
+    def setUp(self):
+        super(TestMove, self).setUp()
+
+    @browsing
+    def test_regular_user_can_move_document(self, browser):
+        self.login(self.regular_user, browser)
+        setRoles(self.portal, self.regular_user.getId(), ['APIUser'])
+        doc_id = self.document.getId()
+        browser.open(
+            self.subdossier.absolute_url() + '/@move',
+            data=json.dumps({"source": self.document.absolute_url()}),
+            method='POST',
+            headers={'Accept': 'application/json',
+                     'Content-Type': 'application/json'},
+        )
+        self.assertEqual(200, browser.status_code)
+        self.assertIn(doc_id, self.subdossier)


### PR DESCRIPTION
Customize `@move` endpoint and comment out delete permission checks.