### PR TITLE
Add REST API endpoint for querying configuration settings

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -10,6 +10,8 @@ Changelog
 - Fix deleting agenda items for non-word agenda items. [deiferni]
 - Improve checking for truthy dates in sablon template data. [deiferni]
 - Fix REST API @move endpoint: Do not require delete permission when moving objects. [buchi]
+- Add REST API endpoint for querying configuration settings. [buchi]
+
 
 2018.1.3 (2018-02-20)
 ---------------------

--- a/docs/public/dev-manual/api/config.rst
+++ b/docs/public/dev-manual/api/config.rst
@@ -1,0 +1,110 @@
+.. _config:
+
+Konfiguration
+=============
+
+Über den ``/@config`` Endpoint können diverse Konfigurationsoptionen des
+GEVER-Mandanten abgefragt werden.
+
+**Beispiel-Request**:
+
+   .. sourcecode:: http
+
+       GET /@config HTTP/1.1
+       Accept: application/json
+
+**Beispiel-Response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 200 OK
+      Content-Type: application/json
+
+      {
+          "@id": "http://localhost:8080/fd/@config",
+          "features": {
+              "activity": true,
+              "contacts": false,
+              "doc_properties": true,
+              "dossier_templates": true,
+              "ech0147_export": true,
+              "ech0147_import": true,
+              "meetings": true,
+              "officeatwork": true,
+              "officeconnector_attach": false,
+              "officeconnector_checkout": true,
+              "preview": false,
+              "preview_open_pdf_in_new_window": false,
+              "repositoryfolder_documents_tab": true,
+              "repositoryfolder_tasks_tab": true,
+              "solr": true,
+              "word_meetings": false,
+              "workspace": false
+          },
+          "max_dossier_levels": 2,
+          "max_repositoryfolder_levels": 3
+      }
+
+
+Konfigurationsoptionen
+----------------------
+
+max_repositoryfolder_levels
+    Maximale Verschachtelungstiefe von Ordnungspositionen
+
+max_dossier_levels
+    Maximale Verschachtelungstiefe von Dossiers
+
+features
+    Optional aktivierbare Features:
+
+    activity
+        Benachrichtigungen
+
+    contacts
+        Erweitertes Kontaktmodul
+
+    doc_properties
+        Hinzufügen von DocProperties bei aus Vorlagen erstellen Word-Dokumenten
+
+    dossier_templates
+        Dossiervorlagen
+
+    ech0147_export
+        eCH-0039/eCH-0147 Export von Dossiers und Dokumenten
+
+    ech0147_import
+        eCH-0039/eCH-0147 Import von Dossiers und Dokumenten
+
+    meetings
+        Sitzungs- und Protokollverwaltung (SPV)
+
+    officeatwork
+        Unterstützung für Officeatwork Vorlagen
+
+    officeconnector_attach
+        Versand von E-Mails über Outlook
+
+    officeconnector_checkout
+        Checkout und Checkin von Dokumenten über Office Connector
+
+    preview
+        Dokumentvorschau
+
+    preview_open_pdf_in_new_window
+        PDF in der Dokumentvorschau werden in einem neuen Fenster geöffnet
+
+    repositoryfolder_documents_tab
+        Dokumente-Tab bei Ordnungspositionen
+
+    repositoryfolder_tasks_tab
+        Aufgaben-Tab bei Ordnungspositionen
+
+    solr
+        Suche über Apache Solr
+
+    word_meetings
+        Sitzungs- und Protokollverwaltung auf Basis von Word-Dokumenten
+
+    workspace
+        Arbeitsräume

--- a/docs/public/dev-manual/api/docs_changelog.rst
+++ b/docs/public/dev-manual/api/docs_changelog.rst
@@ -5,6 +5,11 @@ Changelog
 
 Im Folgenden sind (substantielle) Änderungen an der Dokumentation aufgeführt.
 
+2018-03-02
+----------
+
+- Kapitel "Konfiguration" hinzugefügt
+
 2017-10-09
 ----------
 

--- a/docs/public/dev-manual/api/index.rst
+++ b/docs/public/dev-manual/api/index.rst
@@ -19,6 +19,7 @@ Inhalt:
    scanin.rst
    content_types.rst
    metadata.rst
+   config.rst
    examples/index.rst
    docs_changelog.rst
 

--- a/opengever/api/config.py
+++ b/opengever/api/config.py
@@ -1,0 +1,69 @@
+from opengever.activity.interfaces import IActivitySettings
+from opengever.base.interfaces import ISearchSettings
+from opengever.bumblebee.interfaces import IGeverBumblebeeSettings
+from opengever.contact.interfaces import IContactSettings
+from opengever.dossier.dossiertemplate.interfaces import IDossierTemplateSettings
+from opengever.dossier.interfaces import IDossierContainerTypes
+from opengever.dossier.interfaces import ITemplateFolderProperties
+from opengever.ech0147.interfaces import IECH0147Settings
+from opengever.meeting.interfaces import IMeetingSettings
+from opengever.officeatwork.interfaces import IOfficeatworkSettings
+from opengever.officeconnector.interfaces import IOfficeConnectorSettings
+from opengever.repository.interfaces import IRepositoryFolderRecords
+from opengever.workspace.interfaces import IWorkspaceSettings
+from plone import api
+from plone.restapi.services import Service
+
+
+class Config(Service):
+    """GEVER configuration"""
+
+    def reply(self):
+        config = {}
+
+        config['@id'] = api.portal.get().absolute_url() + '/@config'
+
+        config['max_repositoryfolder_levels'] = api.portal.get_registry_record(
+            'maximum_repository_depth', interface=IRepositoryFolderRecords)
+
+        config['max_dossier_levels'] = api.portal.get_registry_record(
+            'maximum_dossier_depth', interface=IDossierContainerTypes) + 1
+
+        config['features'] = {}
+
+        config['features']['activity'] = api.portal.get_registry_record(
+            'is_feature_enabled', interface=IActivitySettings)
+        config['features']['contacts'] = api.portal.get_registry_record(
+            'is_feature_enabled', interface=IContactSettings)
+        config['features']['doc_properties'] = api.portal.get_registry_record(
+            'create_doc_properties', interface=ITemplateFolderProperties)
+        config['features']['dossier_templates'] = api.portal.get_registry_record(
+            'is_feature_enabled', interface=IDossierTemplateSettings)
+        config['features']['ech0147_export'] = api.portal.get_registry_record(
+            'ech0147_export_enabled', interface=IECH0147Settings)
+        config['features']['ech0147_import'] = api.portal.get_registry_record(
+            'ech0147_import_enabled', interface=IECH0147Settings)
+        config['features']['meetings'] = api.portal.get_registry_record(
+            'is_feature_enabled', interface=IMeetingSettings)
+        config['features']['officeatwork'] = api.portal.get_registry_record(
+            'is_feature_enabled', interface=IOfficeatworkSettings)
+        config['features']['officeconnector_attach'] = api.portal.get_registry_record(
+            'attach_to_outlook_enabled', interface=IOfficeConnectorSettings)
+        config['features']['officeconnector_checkout'] = api.portal.get_registry_record(
+            'direct_checkout_and_edit_enabled', interface=IOfficeConnectorSettings)
+        config['features']['preview'] = api.portal.get_registry_record(
+            'is_feature_enabled', interface=IGeverBumblebeeSettings)
+        config['features']['preview_open_pdf_in_new_window'] = api.portal.get_registry_record(
+            'open_pdf_in_a_new_window', interface=IGeverBumblebeeSettings)
+        config['features']['repositoryfolder_documents_tab'] = api.portal.get_registry_record(
+            'show_documents_tab', interface=IRepositoryFolderRecords)
+        config['features']['repositoryfolder_tasks_tab'] = api.portal.get_registry_record(
+            'show_tasks_tab', interface=IRepositoryFolderRecords)
+        config['features']['word_meetings'] = api.portal.get_registry_record(
+            'is_word_implementation_enabled', interface=IMeetingSettings)
+        config['features']['workspace'] = api.portal.get_registry_record(
+            'is_feature_enabled', interface=IWorkspaceSettings)
+        config['features']['solr'] = api.portal.get_registry_record(
+            'use_solr', interface=ISearchSettings)
+
+        return config

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -69,4 +69,12 @@
       layer="opengever.base.interfaces.IOpengeverBaseLayer"
       />
 
+  <plone:service
+      method="GET"
+      name="@config"
+      for="Products.CMFPlone.interfaces.IPloneSiteRoot"
+      factory=".config.Config"
+      permission="zope2.View"
+      />
+
 </configure>

--- a/opengever/api/tests/test_config.py
+++ b/opengever/api/tests/test_config.py
@@ -1,0 +1,60 @@
+from ftw.testbrowser import browsing
+from opengever.testing import IntegrationTestCase
+
+
+class TestConfig(IntegrationTestCase):
+
+    def setUp(self):
+        super(TestConfig, self).setUp()
+
+    @browsing
+    def test_config_contains_id(self, browser):
+        self.login(self.administrator, browser)
+        url = self.portal.absolute_url() + '/@config'
+        browser.open(url, headers={'Accept': 'application/json'})
+        self.assertEqual(browser.status_code, 200)
+        self.assertEqual(browser.json.get(u'@id'), url)
+
+    @browsing
+    def test_config_contains_features(self, browser):
+        self.login(self.administrator, browser)
+        browser.open(self.portal.absolute_url() + '/@config',
+                     headers={'Accept': 'application/json'})
+        self.assertEqual(browser.status_code, 200)
+        self.assertEqual(
+            browser.json.get(u'features'),
+            {
+                u'activity': False,
+                u'contacts': False,
+                u'doc_properties': False,
+                u'dossier_templates': False,
+                u'ech0147_export': False,
+                u'ech0147_import': False,
+                u'meetings': False,
+                u'officeatwork': False,
+                u'officeconnector_attach': False,
+                u'officeconnector_checkout': False,
+                u'preview': False,
+                u'preview_open_pdf_in_new_window': False,
+                u'repositoryfolder_documents_tab': True,
+                u'repositoryfolder_tasks_tab': True,
+                u'solr': False,
+                u'word_meetings': False,
+                u'workspace': False,
+            })
+
+    @browsing
+    def test_config_contains_max_subdossier_depth(self, browser):
+        self.login(self.administrator, browser)
+        browser.open(self.portal.absolute_url() + '/@config',
+                     headers={'Accept': 'application/json'})
+        self.assertEqual(browser.status_code, 200)
+        self.assertEqual(browser.json.get(u'max_dossier_levels'), 2)
+
+    @browsing
+    def test_config_contains_max_repository_depth(self, browser):
+        self.login(self.administrator, browser)
+        browser.open(self.portal.absolute_url() + '/@config',
+                     headers={'Accept': 'application/json'})
+        self.assertEqual(browser.status_code, 200)
+        self.assertEqual(browser.json.get(u'max_repositoryfolder_levels'), 3)


### PR DESCRIPTION
Provides a new endpoint for querying configuration settings that may be needed in clients.

Currently it returns:
- maximum subdossier depth
- maximum repository depth
- activated and disabled features

Example Response:
```json
{
    "@id": "http://localhost:8080/fd/@config",
    "features": {
        "activity": true,
        "bumblebee": false,
        "contacts": false,
        "dossier_templates": true,
        "meetings": true,
        "officatwork": true,
        "solr": true,
        "workspace": false
    },
    "maximum_repository_depth": 3,
    "maximum_subdossier_depth": 1
}
```