### PR TITLE
Correct French translations

### DIFF
--- a/opengever/core/locales/fr/LC_MESSAGES/opengever.core.po
+++ b/opengever/core/locales/fr/LC_MESSAGES/opengever.core.po
@@ -73,7 +73,7 @@ msgstr "Copier"
 
 #: ./opengever/core/profiles/default/actions.xml
 msgid "Cover (PDF)"
-msgstr "Couvertrure (PDF)"
+msgstr "Couverture (PDF)"
 
 #: ./opengever/core/profiles/default/actions.xml
 msgid "Create Disposition"

--- a/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
@@ -549,7 +549,7 @@ msgstr ""
 #: ./opengever/meeting/browser/documents/submit.py
 #: ./opengever/meeting/browser/submitdocuments.py
 msgid "button_submit_attachments"
-msgstr "Soumettre des appendices"
+msgstr "Soumettre les documents additionnels"
 
 #. Default: "Cancel"
 #: ./opengever/meeting/model/proposal.py
@@ -912,7 +912,7 @@ msgstr ""
 #: ./opengever/meeting/browser/submitdocuments.py
 #: ./opengever/meeting/browser/templates/proposaloverview.pt
 msgid "label_attachments"
-msgstr "Appendices"
+msgstr "Pièces jointes"
 
 #. Default: "Cancel"
 #: ./opengever/meeting/browser/meetings/excerpt.py


### PR DESCRIPTION
In French translations:
* Correct a typo
* Change "appendices" in two more cases (generally replace by "pièces jointes", but in one case here simply by "documents additionnels" which made more sense in that context, as it is a confirmation of an action that was termed"Soumettre des documents additionnels")

resolves https://extranet.4teamwork.ch/support/edk/tracker-support-gever-edk/83

Other instances of this translation had been corrected in
https://github.com/4teamwork/opengever.core/pull/3811