### PR TITLE
Fix restapi reference number

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -12,6 +12,7 @@ Changelog
 - Fix REST API @move endpoint: Do not require delete permission when moving objects. [buchi]
 - Add REST API endpoint for querying configuration settings. [buchi]
 - Make sure notification-default for the forwarding-added kind exists. [phgross]
+- Fix reference number in REST API GET. [buchi]
 
 
 2018.1.3 (2018-02-20)

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -12,6 +12,9 @@
   <adapter factory=".summary.GeverJSONSummarySerializer" />
   <adapter factory=".fields.ChoiceFieldDeserializer" />
 
+  <adapter factory=".dossier.SerializeDossierToJson" />
+  <adapter factory=".document.SerializeDocumentToJson" />
+
   <plone:service
       method="POST"
       name="@checkout"

--- a/opengever/api/document.py
+++ b/opengever/api/document.py
@@ -1,0 +1,20 @@
+from opengever.base.interfaces import IReferenceNumber
+from opengever.document.behaviors import IBaseDocument
+from plone.restapi.interfaces import ISerializeToJson
+from plone.restapi.serializer.dxcontent import SerializeToJson
+from zope.component import adapter
+from zope.interface import implementer
+from zope.interface import Interface
+
+
+@implementer(ISerializeToJson)
+@adapter(IBaseDocument, Interface)
+class SerializeDocumentToJson(SerializeToJson):
+
+    def __call__(self, *args, **kwargs):
+        result = super(SerializeDocumentToJson, self).__call__(*args, **kwargs)
+
+        ref_num = IReferenceNumber(self.context)
+        result[u'reference_number'] = ref_num.get_number()
+
+        return result

--- a/opengever/api/dossier.py
+++ b/opengever/api/dossier.py
@@ -1,0 +1,18 @@
+from opengever.dossier.behaviors.dossier import IDossierMarker
+from plone.restapi.interfaces import ISerializeToJson
+from plone.restapi.serializer.dxcontent import SerializeFolderToJson
+from zope.component import adapter
+from zope.interface import implementer
+from zope.interface import Interface
+
+
+@implementer(ISerializeToJson)
+@adapter(IDossierMarker, Interface)
+class SerializeDossierToJson(SerializeFolderToJson):
+
+    def __call__(self, *args, **kwargs):
+        result = super(SerializeDossierToJson, self).__call__(*args, **kwargs)
+
+        result[u'reference_number'] = self.context.get_reference_number()
+
+        return result

--- a/opengever/api/tests/test_serializer.py
+++ b/opengever/api/tests/test_serializer.py
@@ -1,0 +1,40 @@
+from ftw.testbrowser import browsing
+from opengever.testing import IntegrationTestCase
+from plone import api
+
+
+class TestDossierSerializer(IntegrationTestCase):
+
+    def setUp(self):
+        super(TestDossierSerializer, self).setUp()
+        lang_tool = api.portal.get_tool('portal_languages')
+        lang_tool.setDefaultLanguage('de-ch')
+
+    @browsing
+    def test_dossier_serialization_contains_reference_number(self, browser):
+        self.login(self.administrator, browser)
+        browser.open(self.dossier, headers={'Accept': 'application/json'})
+        self.assertEqual(browser.status_code, 200)
+        self.assertEqual(browser.json.get(u'reference_number'), u'Client1 1.1 / 1')
+
+
+class TestDocumentSerializer(IntegrationTestCase):
+
+    def setUp(self):
+        super(TestDocumentSerializer, self).setUp()
+        lang_tool = api.portal.get_tool('portal_languages')
+        lang_tool.setDefaultLanguage('de-ch')
+
+    @browsing
+    def test_document_serialization_contains_reference_number(self, browser):
+        self.login(self.administrator, browser)
+        browser.open(self.document, headers={'Accept': 'application/json'})
+        self.assertEqual(browser.status_code, 200)
+        self.assertEqual(browser.json.get(u'reference_number'), u'Client1 1.1 / 1 / 5')
+
+    @browsing
+    def test_mail_serialization_contains_reference_number(self, browser):
+        self.login(self.administrator, browser)
+        browser.open(self.mail, headers={'Accept': 'application/json'})
+        self.assertEqual(browser.status_code, 200)
+        self.assertEqual(browser.json.get(u'reference_number'), u'Client1 1.1 / 1 / 15')

--- a/opengever/base/default_values.py
+++ b/opengever/base/default_values.py
@@ -270,6 +270,10 @@ def set_default_values(content, container, values):
     """
     for schema in iterSchemata(content):
         for name, field in getFieldsInOrder(schema):
+
+            if field.readonly:
+                continue
+
             if name in values:
                 # Only set default if no *actual* value was supplied as
                 # an argument to object construction

--- a/opengever/base/tests/test_default_values_for_types.py
+++ b/opengever/base/tests/test_default_values_for_types.py
@@ -111,7 +111,6 @@ DOSSIER_MISSING_VALUES = {
     'filing_prefix': None,
     'former_reference_number': None,
     'number_of_containers': None,
-    'reference_number': None,
     'responsible': None,
     'retention_period_annotation': None,
     'temporary_former_reference_number': None,

--- a/opengever/bundle/tests/test_oggbundle_pipeline.py
+++ b/opengever/bundle/tests/test_oggbundle_pipeline.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from ftw.testing import freeze
 from opengever.base.behaviors.classification import IClassification
 from opengever.base.behaviors.lifecycle import ILifeCycle
+from opengever.base.interfaces import IReferenceNumber
 from opengever.base.security import elevated_privileges
 from opengever.bundle.console import add_guid_index
 from opengever.bundle.loader import GUID_INDEX_NAME
@@ -284,7 +285,8 @@ class TestOggBundlePipeline(IntegrationTestCase):
             u'Vreni Meier ist ein Tausendsassa',
             IDossier(dossier_peter).comments)
         self.assertEqual(tuple(), IDossier(dossier_peter).keywords)
-        self.assertEqual('1', IDossier(dossier_peter).reference_number)
+        self.assertEqual(
+            'Client1 0.3 / 1', IReferenceNumber(dossier_peter).get_number())
         self.assertEqual([], IDossier(dossier_peter).relatedDossier)
         self.assertEqual(u'lukas.graf', IDossier(dossier_peter).responsible)
         self.assertEqual('dossier-state-active',
@@ -341,8 +343,7 @@ class TestOggBundlePipeline(IntegrationTestCase):
             u'privacy_layer_yes',
             IClassification(dossier_peter).privacy_layer)
         self.assertEqual(
-            '7',
-            IDossier(dossier_peter).reference_number)
+            'Client1 0.3 / 7', IReferenceNumber(dossier_peter).get_number())
         self.assertEqual(
             [],
             IDossier(dossier_peter).relatedDossier)

--- a/opengever/dossier/behaviors/dossier.py
+++ b/opengever/dossier/behaviors/dossier.py
@@ -179,9 +179,11 @@ class IDossier(model.Schema):
     )
 
     form.widget(reference_number=referenceNumberWidgetFactory)
+    form.mode(reference_number='display')
     reference_number = schema.TextLine(
         title=_(u'label_reference_number', default=u'Reference Number'),
         required=False,
+        readonly=True,
     )
 
     @invariant

--- a/opengever/dossier/browser/forms.py
+++ b/opengever/dossier/browser/forms.py
@@ -3,11 +3,13 @@ from Acquisition import aq_inner, aq_parent
 from ftw.keywordwidget.widget import KeywordWidget
 from opengever.base.behaviors.utils import hide_fields_from_behavior
 from opengever.dossier import _
+from opengever.dossier.behaviors.dossier import IDossier
 from opengever.dossier.behaviors.dossier import IDossierMarker
 from opengever.dossier.behaviors.participation import IParticipation
 from opengever.dossier.behaviors.participation import IParticipationAware
 from opengever.dossier.behaviors.protect_dossier import IProtectDossier
 from opengever.dossier.behaviors.protect_dossier import IProtectDossierMarker
+from opengever.dossier.widget import referenceNumberWidgetFactory
 from plone.autoform.widgets import ParameterizedWidget
 from plone.dexterity.browser import add
 from plone.dexterity.browser import edit
@@ -83,6 +85,17 @@ class DossierEditForm(edit.DefaultEditForm):
 
     def updateFields(self):
         super(DossierEditForm, self).updateFields()
+
+        # Add read-only field 'reference_number'
+        # plone.autoform ingores read-only fields, but we want to display it in
+        # the edit form.
+        for group in self.groups:
+            if group.label == u'fieldset_filing':
+                group.fields += Fields(
+                    IDossier['reference_number'], prefix='IDossier')
+                group.fields['IDossier.reference_number'].widgetFactory = referenceNumberWidgetFactory
+                group.fields['IDossier.reference_number'].mode = 'display'
+
         hide_fields_from_behavior(self,
                                   ['IClassification.public_trial',
                                    'IClassification.public_trial_statement'])

--- a/opengever/dossier/widget.py
+++ b/opengever/dossier/widget.py
@@ -19,8 +19,7 @@ class ReferenceNumberWidget(widget.HTMLTextInputWidget, Widget):
 
     def update(self):
         super(ReferenceNumberWidget, self).update()
-        self.mode = 'display'
-        #check if is a add- or a editForm
+        # check if is a add- or a editForm
         if IAddForm.providedBy(self.form.parentForm):
             self.value = _(
                 u'label_no_reference_number',


### PR DESCRIPTION
- Customize serializer for dossiers and documents to return the correct reference number.
- Make reference_number a read-only field to prevent setting it through the REST API.

Having the reference number as a field in the schema is highly questionable for me.
I'm keeping it in the edit form for now as removing it, is out of scope of this PR.

Having it in the schema seems to confuse people as various tests show that try to set/get the value of the reference number field.
Further the document schema doesn't contain the reference number field.

