### PR TITLE
Allow force checkin for users with `Manage portal` permissions

### DIFF
--- a/opengever/document/browser/actionbuttons.py
+++ b/opengever/document/browser/actionbuttons.py
@@ -170,6 +170,10 @@ class ActionButtonRendererMixin(object):
         manager = queryMultiAdapter(
             (self.context, self.request), ICheckinCheckoutManager)
 
+        if not manager:
+            # This is probably a mail
+            return False
+
         return manager.is_checkin_allowed()
 
     def is_checkout_cancel_available(self):

--- a/opengever/document/browser/templates/macros.pt
+++ b/opengever/document/browser/templates/macros.pt
@@ -28,7 +28,7 @@
             office_connector_editable view/is_office_connector_editable;
             copy_download_available view/is_download_copy_available;
             attach_to_email_available view/is_attach_to_email_available;
-            checked_out_by_current_user view/is_checked_out_by_current_user;
+            is_checkin_allowed view/_is_checkin_allowed;
             is_cancel_allowed view/is_checkout_cancel_available;
             new_external_edit_enabled context/@@officeconnector_settings/is_checkout_enabled">
 
@@ -76,7 +76,7 @@
                 </span>
             </tal:checkout_and_edit_disabled>
 
-            <tal:checked_out tal:condition="checked_out_by_current_user">
+            <tal:checked_out tal:condition="is_checkin_allowed">
               <tal:checkin_without_comment tal:condition="not: view/is_locked">
                 <a tal:attributes="href view/get_checkin_without_comment_url; class string:function-checkin" i18n:translate="">
                     Checkin without comment

--- a/opengever/document/checkout/checkin.py
+++ b/opengever/document/checkout/checkin.py
@@ -230,6 +230,11 @@ class CheckinDocumentWithoutComment(BrowserView):
         self.checkin_controller = CheckinController(self.request)
 
     def __call__(self):
+        manager = getMultiAdapter((self.context, self.request),
+                                  ICheckinCheckoutManager)
+        if not manager.is_checkin_without_comment_allowed():
+            checkin_with_comment = CheckinDocuments(self.context, self.request)
+            return checkin_with_comment.__call__()
         self.checkin()
         return self.redirect()
 
@@ -245,6 +250,9 @@ class CheckinDocumentsWithoutComment(CheckinDocumentWithoutComment):
 
     This view is called from a tabbed_view.
     """
+    def __call__(self):
+        self.checkin()
+        return self.redirect()
 
     def checkin(self):
         try:

--- a/opengever/document/checkout/manager.py
+++ b/opengever/document/checkout/manager.py
@@ -95,6 +95,11 @@ class CheckinCheckoutManager(object):
         # fire the event
         notify(ObjectCheckedOutEvent(self.context, ''))
 
+    def is_checkin_without_comment_allowed(self):
+        if self.is_checkin_allowed() and not self.is_locked():
+            return True
+        return False
+
     def is_checkin_allowed(self):
         """Checks whether checkin is allowed for the current user on the
         adapted document.
@@ -119,12 +124,10 @@ class CheckinCheckoutManager(object):
         if not self.check_permission('opengever.document: Checkin'):
             return False
 
-        # is the user either the one who owns the checkout or
-        # a manager?
-        is_manager = self.check_permission('Manage portal')
+        # is the user the one who owns the checkout
         current_user_id = getSecurityManager().getUser().getId()
 
-        return bool(self.get_checked_out_by() == current_user_id or is_manager)
+        return self.get_checked_out_by() == current_user_id
 
     def checkin(self, comment=''):
         """Checkin the adapted document, using the `comment` for the

--- a/opengever/document/tests/test_force_checkin.py
+++ b/opengever/document/tests/test_force_checkin.py
@@ -48,4 +48,6 @@ class TestForceCheckin(IntegrationTestCase):
             browser.click_on('without comment')
 
         browser.open(self.document, view='@@checkin_without_comment')
-        assert_message(u'Could not check in document Vertr\xe4gsentwurf')
+        assert_message("This item is being checked out by Ziegler Robert (robert.ziegler).")
+        browser.click_on('Checkin')
+        assert_message(u'You have not selected any documents.')


### PR DESCRIPTION
- verify that both checkin views (with and without comment) remove the locks:
  - yes, both actions call the `checkin` method of the `CheckinCheckoutManager`
- verify that this behavior is tested.
  - Behavior is tested for checkin without comment
  - Added a test to check that force checkin by another user 
- make sure that forcing checkin (checking in documents checked out by other users) is based on the `opengever.document: Force Checkin` permission
  - There are two permissions that allow force checkin:
    - `Force Checkin`
    - `Manage portal`
  - I also added a test that `Force Checkin` gives the permission. Note that with just this permission, the checkin will raise an `Unauthorized` probably because the user cannot save the file (the file gets checked in though and the lock cleared). So this is a bit of a strange situation, but it is also an artificial situation from the test setting.
- make sure that the (force) checkin action is also visible in the file action button listing:
  - Corrected the condition for showing the `checkin` action buttons
- actions in the file action button listing should check if they are still executable:
  - We now check whether the checkin is allowed when executing it.
  - We only allow checkin with comment for a force checkin (we actually check that the comment is not empty in that case)

**`checkin with comment` is now shown for administrators when force checkin is allowed**

<img width="1178" alt="screen shot 2018-03-05 at 10 33 54" src="https://user-images.githubusercontent.com/7374243/36968816-f6e6eec0-2063-11e8-9d67-a7a7be24fc2d.png">

**Simple `checkin` or checkin with an empty comment will not work for force checkin and display an error message**

<img width="1178" alt="screen shot 2018-03-05 at 11 06 20" src="https://user-images.githubusercontent.com/7374243/36969305-67ef31b2-2065-11e8-8bc3-557c4146d901.png">

resolves #3716 