### PR TITLE
Detect and fix broken references to ICreatorAware in the relation catalog.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2018.1.4 (unreleased)
 ---------------------
 
+- Detect and fix broken references to ICreatorAware in the relation catalog. [deiferni]
 - Remove all uses of enableHTTPCompression in GEVER. [lgraf]
 - Fix NotificationDefault hook. [phgross]
 - Fix deleting agenda items for non-word agenda items. [deiferni]

--- a/opengever/core/upgrades/20180306101228_fix_relation_catalog_references/upgrade.py
+++ b/opengever/core/upgrades/20180306101228_fix_relation_catalog_references/upgrade.py
@@ -1,0 +1,46 @@
+from ftw.upgrade import UpgradeStep
+from zc.relation.interfaces import ICatalog
+from zope.component import getUtility
+import cPickle
+import logging
+import StringIO
+
+
+logger = logging.getLogger('opengever.core')
+
+POTENTIALLY_BROKEN = ('to_interfaces_flattened', 'from_interfaces_flattened')
+
+
+class FixRelationCatalogReferences(UpgradeStep):
+    """Fix relation catalog references.
+
+    This upgrade fixes an issue with btrees somehow still referencing the
+    already removed ICreatorAware class.
+    """
+
+    def __call__(self):
+        catalog = getUtility(ICatalog)
+
+        for mapping_key in POTENTIALLY_BROKEN:
+            btree = catalog._name_TO_mapping[mapping_key]
+            if self.has_broken_references(btree):
+                logger.warning(
+                    'Broken references on BTree "{}" detected'
+                    .format(mapping_key))
+                catalog._name_TO_mapping[mapping_key] = btree.__class__(btree)
+
+    def has_broken_references(self, btree):
+        """If the btree contains broken references they will result in a
+        pickling error, e.g:
+
+        Can't pickle <class 'opengever.base.behaviors.creator.ICreatorAware'>:
+        import of module opengever.base.behaviors.creator failed
+
+        """
+        pickler = cPickle.Pickler(StringIO.StringIO())
+        try:
+            pickler.dump(btree)
+        except cPickle.PicklingError as e:
+            return True
+
+        return False


### PR DESCRIPTION
We have detected that in rare cases there seems to be a reference from one of the relation catalogs `BTrees` to a previously removed class. 

- the class was removed in https://github.com/4teamwork/opengever.core/pull/2949
- the relation catalog was cleaned up in https://github.com/4teamwork/opengever.core/pull/3165

However there was still a reference according to `gc. get_referrers` from one of the `BTrees` in the `ICatalog` relation catalog utility. This resulted in a `PicklingError` when attempting to create new relations anywhere in the system, see https://sentry.4teamwork.ch/sentry/onegov-gever/issues/5485/. We have not found the reference though as neither keys nor values of the `BTree` contained the object. Also by investigating attributes of the `BTrees` and its `Buckets` no reference could be found. It could be a bug in the C implementation but we have not bothered to investigate further.

This upgrade step can get rid of the reference by re-initializing the `BTree`. It first attempts to pickle the `BTree` to detect broken references. If a broken reference is found a new instance of the `BTree` is created which seems to get rid of the reference. My suspicion is that in most cases `BTrees.check` detected problems already and the `BTree` was already re-initialized in an upgrade step:

https://github.com/4teamwork/opengever.core/blob/7d15d9bcd07a74fdf370a6da320c68588613c109/opengever/core/upgrades/20170720153900_cleanup_i_creator_interfaces_from_relation_catalog/upgrade.py#L41-L47
