### PR TITLE
Change action names for meeting agenda items

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2018.2.0 (unreleased)
 ---------------------
 
-- Nothing changed yet.
+- Change action names for meeting agenda items.
 
 
 2018.1.4 (2018-03-06)

--- a/opengever/meeting/browser/meetings/agendaitem.py
+++ b/opengever/meeting/browser/meetings/agendaitem.py
@@ -263,7 +263,8 @@ class AgendaItemsView(BrowserView):
             if item.is_revise_possible():
                 data['revise_link'] = meeting.get_url(
                     view='agenda_items/{}/revise'.format(item.agenda_item_id))
-
+            if item.is_paragraph:
+                data['paragraph'] = True
             if is_word_meeting_implementation_enabled():
                 document = item.resolve_document()
                 if document:

--- a/opengever/meeting/browser/meetings/meeting.py
+++ b/opengever/meeting/browser/meetings/meeting.py
@@ -362,11 +362,14 @@ class MeetingView(BrowserView):
             translations=(
                 _('label_edit_cancel', default='Cancel'),
                 _('label_edit_save', default='Save'),
-                _('label_edit_action', default='edit title'),
-                _('label_delete_action', default='remove this agenda item'),
                 _('label_decide_action', default='Decide this agenda item'),
                 _('label_reopen_action', default='Reopen this agenda item'),
                 _('label_revise_action', default='Revise this agenda item'),
+                _('action_rename_agenda_item', default='Rename agenda item'),
+                _('action_rename_agenda_paragraph', default='Rename paragraph'),
+                _('action_remove_agenda_item', default='Remove agenda item'),
+                _('action_remove_agenda_paragraph', default='Remove paragraph'),
+
             ),
             max_proposal_title_length=ISubmittedProposal['title'].max_length)
 
@@ -386,7 +389,9 @@ class MeetingView(BrowserView):
                 _('action_decide', default='Decide'),
                 _('action_generate_excerpt', default='Generate excerpt'),
                 _('action_rename_agenda_item', default='Rename agenda item'),
+                _('action_rename_agenda_paragraph', default='Rename paragraph'),
                 _('action_remove_agenda_item', default='Remove agenda item'),
+                _('action_remove_agenda_paragraph', default='Remove paragraph'),
                 _('action_reopen', default='Reopen agenda item'),
                 _('action_return_excerpt', default='Return to proposal'),
                 _('help_return_excerpt',

--- a/opengever/meeting/browser/meetings/templates/agendaitems-noword.html
+++ b/opengever/meeting/browser/meetings/templates/agendaitems-noword.html
@@ -4,7 +4,7 @@
     {{#if ../agendalist_editable}}<td class="sortable-handle"></td>{{/if}}
     <td class="number">{{number}}</td>
     <td class="title">
-      <span>{{{link}}}</span>
+      <span class="proposal_title">{{{link}}}</span>
       {{#if has_proposal}}
       <ul class="attachements">
         {{#each documents}}
@@ -38,8 +38,13 @@
     <td class="actions">
       <div class="button-group">
         {{#if ../agendalist_editable}}
-        <a href="{{edit_link}}" title="%(label_edit_action)s" class="button edit-agenda-item"></a>
-        <a href="{{delete_link}}" title="%(label_delete_action)s" class="button delete-agenda-item"></a>
+          {{#if paragraph}}
+            <a href="{{edit_link}}" title="%(action_rename_agenda_paragraph)s" class="button edit-agenda-item"></a>
+            <a href="{{delete_link}}" title="%(action_remove_agenda_paragraph)s" class="button delete-agenda-item"></a>
+          {{else}}
+            <a href="{{edit_link}}" title="%(action_rename_agenda_item)s" class="button edit-agenda-item"></a>
+            <a href="{{delete_link}}" title="%(action_remove_agenda_item)s" class="button delete-agenda-item"></a>
+          {{/if}}
         {{/if}}
         {{#if decide_link}}
         <a href="{{decide_link}}" title="%(label_decide_action)s" class="button decide-agenda-item"><span></span></a>

--- a/opengever/meeting/browser/meetings/templates/agendaitems-word.html
+++ b/opengever/meeting/browser/meetings/templates/agendaitems-word.html
@@ -36,8 +36,13 @@
         {{#if (or ../agendalist_editable reopen_link)}}
         <ul class="editing-menu">
           {{#if ../agendalist_editable}}
-          <li><a href="{{edit_link}}" class="rename-agenda-item">%(action_rename_agenda_item)s</a></li>
-          <li><a href="{{delete_link}}" class="delete-agenda-item">%(action_remove_agenda_item)s</a></li>
+            {{#if paragraph}}
+              <li><a href="{{edit_link}}" class="rename-agenda-item">%(action_rename_agenda_paragraph)s</a></li>
+              <li><a href="{{delete_link}}" class="delete-agenda-item">%(action_remove_agenda_paragraph)s</a></li>
+            {{else}}
+              <li><a href="{{edit_link}}" class="rename-agenda-item">%(action_rename_agenda_item)s</a></li>
+              <li><a href="{{delete_link}}" class="delete-agenda-item">%(action_remove_agenda_item)s</a></li>
+            {{/if}}
           {{/if}}
           {{#if reopen_link}}
           <li><a href="{{reopen_link}}" class="reopen-agenda-item">%(action_reopen)s</a></li>

--- a/opengever/meeting/browser/meetings/templates/meeting-noword.pt
+++ b/opengever/meeting/browser/meetings/templates/meeting-noword.pt
@@ -28,7 +28,8 @@
           <div class="close">
             <a href="#" class="hiddenStructure" title="Close this box">Close this box.</a>
           </div>
-          <h2 i18n:translate="">Delete proposal</h2>
+          <h2 i18n:translate="title_confirm_delete_agenda_item">Delete proposal</h2>
+          <p id="confirm_delete_item_title"></p>
           <p i18n:translate="label_delete_agenda_item_confirm_text">Are you sure you want to delete this agendaitem?</p>
           <div class="button-group">
             <button class="button confirm destructive"
@@ -42,6 +43,7 @@
             <a href="#" class="hiddenStructure" title="Close this box">Close this box.</a>
           </div>
           <h2 i18n:translate="">Unschedule proposal</h2>
+          <p id="confirm_delete_item_title"></p>
           <p i18n:translate="label_unschedule_agenda_item_confirm_text">Are you sure you want to unschedule this agendaitem?</p>
           <div class="button-group">
             <button class="button confirm destructive"

--- a/opengever/meeting/browser/meetings/templates/meeting-word.pt
+++ b/opengever/meeting/browser/meetings/templates/meeting-word.pt
@@ -43,7 +43,8 @@
           <div class="close">
             <a href="#" class="hiddenStructure" title="Close this box">Close this box.</a>
           </div>
-          <h2 i18n:translate="">Delete proposal</h2>
+          <h2 i18n:translate="title_confirm_delete_agenda_item">Delete proposal</h2>
+          <p id="confirm_delete_item_title"></p>
           <p i18n:translate="label_delete_agenda_item_confirm_text">Are you sure you want to delete this agendaitem?</p>
           <div class="button-group">
             <button class="button confirm destructive"
@@ -58,6 +59,7 @@
             <a href="#" class="hiddenStructure" title="Close this box">Close this box.</a>
           </div>
           <h2 i18n:translate="">Unschedule proposal</h2>
+          <p id="confirm_unschedule_item_title"></p>
           <p i18n:translate="label_unschedule_agenda_item_confirm_text">Are you sure you want to unschedule this agendaitem?</p>
           <div class="button-group">
             <button class="button confirm destructive"

--- a/opengever/meeting/browser/resources/meeting.js
+++ b/opengever/meeting/browser/resources/meeting.js
@@ -255,13 +255,21 @@
     var unscheduleDialog = $( "#confirm_unschedule" ).overlay({
       speed: 0,
       closeSpeed: 0,
-      mask: { loadSpeed: 0 }
+      mask: { loadSpeed: 0 },
+      onBeforeLoad: function() {
+        var title = self.currentItem.parents("tr").find(".proposal_title").text();
+        $('#confirm_unschedule_item_title').text(title);
+      },
     }).data("overlay");
 
     var deleteDialog = $( "#confirm_delete" ).overlay({
       speed: 0,
       closeSpeed: 0,
-      mask: { loadSpeed: 0 }
+      mask: { loadSpeed: 0 },
+      onBeforeLoad: function() {
+        var title = self.currentItem.parents("tr").find(".proposal_title").text();
+        $('#confirm_delete_item_title').text(title);
+      },
     }).data("overlay");
 
     var holdDialog = $( "#confirm_hold_meeting" ).overlay({

--- a/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-01-25 08:39+0000\n"
+"POT-Creation-Date: 2018-03-06 10:53+0000\n"
 "PO-Revision-Date: 2017-10-23 18:40+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -136,11 +136,6 @@ msgstr "Das Protokoll wird beim erneuten Sitzungsabschluss nicht automatisch akt
 #: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "Delete"
 msgstr "Löschen"
-
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
-msgid "Delete proposal"
-msgstr "Traktandum streichen"
 
 #: ./opengever/meeting/browser/meetings/templates/protocol.pt
 msgid "Discard"
@@ -433,10 +428,20 @@ msgstr "Protokollauszug generieren"
 msgid "action_remove_agenda_item"
 msgstr "Traktandum streichen"
 
+#. Default: "Remove paragraph"
+#: ./opengever/meeting/browser/meetings/meeting.py
+msgid "action_remove_agenda_paragraph"
+msgstr "Zwischentitel streichen"
+
 #. Default: "Rename agenda item"
 #: ./opengever/meeting/browser/meetings/meeting.py
 msgid "action_rename_agenda_item"
 msgstr "Traktandum umbenennen"
+
+#. Default: "Rename paragraph"
+#: ./opengever/meeting/browser/meetings/meeting.py
+msgid "action_rename_agenda_paragraph"
+msgstr "Zwischentitel neu setzen"
 
 #. Default: "Reopen agenda item"
 #: ./opengever/meeting/browser/meetings/meeting.py
@@ -1046,16 +1051,11 @@ msgstr "Beschlussentwurf"
 msgid "label_decision_number"
 msgstr "Beschlussnummer"
 
-#. Default: "remove this agenda item"
-#: ./opengever/meeting/browser/meetings/meeting.py
-msgid "label_delete_action"
-msgstr "Traktandum entfernen"
-
 #. Default: "Are you sure you want to delete this agendaitem?"
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
 #: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "label_delete_agenda_item_confirm_text"
-msgstr "Wollen Sie dieses Traktandum wirklich streichen?"
+msgstr "Wollen Sie dieses Element wirklich streichen?"
 
 #. Default: "Disclose to"
 #: ./opengever/meeting/browser/meetings/protocol.py
@@ -1094,11 +1094,6 @@ msgstr "Inhaltsverzeichnis nach Ordnungsposition"
 #: ./opengever/meeting/browser/templates/periods.pt
 msgid "label_edit"
 msgstr "Bearbeiten"
-
-#. Default: "edit title"
-#: ./opengever/meeting/browser/meetings/meeting.py
-msgid "label_edit_action"
-msgstr "Titel bearbeiten"
 
 #. Default: "Edit after creation"
 #: ./opengever/meeting/browser/proposalforms.py
@@ -1866,10 +1861,16 @@ msgstr "Zeit"
 msgid "title_ad_hoc_document"
 msgstr "Traktandum ${title}"
 
+#. Default: "Delete proposal"
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
+msgid "title_confirm_delete_agenda_item"
+msgstr "Element streichen"
+
 #. Default: "Rename agenda item"
 #: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "title_rename_agenda_item"
-msgstr "Traktandum umbenennen"
+msgstr "Neuer Titel setzen"
 
 #. Default: "Remove from schedule"
 #: ./opengever/meeting/model/proposal.py

--- a/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-01-25 08:39+0000\n"
+"POT-Creation-Date: 2018-03-06 10:53+0000\n"
 "PO-Revision-Date: 2017-06-22 09:02+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-meeting/fr/>\n"
@@ -138,11 +138,6 @@ msgstr ""
 #: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "Delete"
 msgstr "Supprimer"
-
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
-msgid "Delete proposal"
-msgstr "Supprimer le point de l'ordre du jour"
 
 #: ./opengever/meeting/browser/meetings/templates/protocol.pt
 msgid "Discard"
@@ -433,11 +428,21 @@ msgstr ""
 #. Default: "Remove agenda item"
 #: ./opengever/meeting/browser/meetings/meeting.py
 msgid "action_remove_agenda_item"
-msgstr ""
+msgstr "Supprimer le point de l'ordre du jour"
+
+#. Default: "Remove paragraph"
+#: ./opengever/meeting/browser/meetings/meeting.py
+msgid "action_remove_agenda_paragraph"
+msgstr "Supprimer l'intertitre"
 
 #. Default: "Rename agenda item"
 #: ./opengever/meeting/browser/meetings/meeting.py
 msgid "action_rename_agenda_item"
+msgstr ""
+
+#. Default: "Rename paragraph"
+#: ./opengever/meeting/browser/meetings/meeting.py
+msgid "action_rename_agenda_paragraph"
 msgstr ""
 
 #. Default: "Reopen agenda item"
@@ -1048,16 +1053,11 @@ msgstr "Brouillon de la décision"
 msgid "label_decision_number"
 msgstr "Numéro de décision"
 
-#. Default: "remove this agenda item"
-#: ./opengever/meeting/browser/meetings/meeting.py
-msgid "label_delete_action"
-msgstr "Enlever ce point de l'ordre du jour"
-
 #. Default: "Are you sure you want to delete this agendaitem?"
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
 #: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "label_delete_agenda_item_confirm_text"
-msgstr "Êtes-vous sûr de vouloir enlever ce point de l'ordre du jour?"
+msgstr "Êtes-vous sûr de vouloir supprimer cet élément?"
 
 #. Default: "Disclose to"
 #: ./opengever/meeting/browser/meetings/protocol.py
@@ -1096,11 +1096,6 @@ msgstr "Table de matière selon l'ordre des points"
 #: ./opengever/meeting/browser/templates/periods.pt
 msgid "label_edit"
 msgstr "Editer"
-
-#. Default: "edit title"
-#: ./opengever/meeting/browser/meetings/meeting.py
-msgid "label_edit_action"
-msgstr "Editer le titre"
 
 #. Default: "Edit after creation"
 #: ./opengever/meeting/browser/proposalforms.py
@@ -1868,10 +1863,16 @@ msgstr "Temps"
 msgid "title_ad_hoc_document"
 msgstr ""
 
+#. Default: "Delete proposal"
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
+msgid "title_confirm_delete_agenda_item"
+msgstr "Supprimer élément"
+
 #. Default: "Rename agenda item"
 #: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "title_rename_agenda_item"
-msgstr ""
+msgstr "Modifier le titre"
 
 #. Default: "Remove from schedule"
 #: ./opengever/meeting/model/proposal.py

--- a/opengever/meeting/locales/opengever.meeting.pot
+++ b/opengever/meeting/locales/opengever.meeting.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-01-25 08:39+0000\n"
+"POT-Creation-Date: 2018-03-06 10:53+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -134,11 +134,6 @@ msgstr ""
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
 #: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
 msgid "Delete"
-msgstr ""
-
-#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
-#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
-msgid "Delete proposal"
 msgstr ""
 
 #: ./opengever/meeting/browser/meetings/templates/protocol.pt
@@ -432,9 +427,19 @@ msgstr ""
 msgid "action_remove_agenda_item"
 msgstr ""
 
+#. Default: "Remove paragraph"
+#: ./opengever/meeting/browser/meetings/meeting.py
+msgid "action_remove_agenda_paragraph"
+msgstr ""
+
 #. Default: "Rename agenda item"
 #: ./opengever/meeting/browser/meetings/meeting.py
 msgid "action_rename_agenda_item"
+msgstr ""
+
+#. Default: "Rename paragraph"
+#: ./opengever/meeting/browser/meetings/meeting.py
+msgid "action_rename_agenda_paragraph"
 msgstr ""
 
 #. Default: "Reopen agenda item"
@@ -1045,11 +1050,6 @@ msgstr ""
 msgid "label_decision_number"
 msgstr ""
 
-#. Default: "remove this agenda item"
-#: ./opengever/meeting/browser/meetings/meeting.py
-msgid "label_delete_action"
-msgstr ""
-
 #. Default: "Are you sure you want to delete this agendaitem?"
 #: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
 #: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
@@ -1092,11 +1092,6 @@ msgstr ""
 #: ./opengever/meeting/browser/templates/member.pt
 #: ./opengever/meeting/browser/templates/periods.pt
 msgid "label_edit"
-msgstr ""
-
-#. Default: "edit title"
-#: ./opengever/meeting/browser/meetings/meeting.py
-msgid "label_edit_action"
 msgstr ""
 
 #. Default: "Edit after creation"
@@ -1863,6 +1858,12 @@ msgstr ""
 #. Default: "Ad hoc agenda item ${title}"
 #: ./opengever/meeting/model/meeting.py
 msgid "title_ad_hoc_document"
+msgstr ""
+
+#. Default: "Delete proposal"
+#: ./opengever/meeting/browser/meetings/templates/meeting-noword.pt
+#: ./opengever/meeting/browser/meetings/templates/meeting-word.pt
+msgid "title_confirm_delete_agenda_item"
 msgstr ""
 
 #. Default: "Rename agenda item"


### PR DESCRIPTION
For actions on `AgendaItem` we now distinguish paragraphs, regular items and proposals.
Actions are named accordingly in the menus.
Clicking an action shows an overlay for confirmation. I made the text generic here but show the title of the item that will be deleted. If specific text (meaning either "Zwischentitel" or "Traktandum") is needed, I can make a new overlay instead.

**Action menu for paragraph**

<img width="801" alt="screen shot 2018-03-06 at 12 06 23" src="https://user-images.githubusercontent.com/7374243/37029205-e063eaa8-2136-11e8-9b94-a885034421f1.png">

**Action menu for agenda item**

<img width="810" alt="screen shot 2018-03-06 at 12 06 18" src="https://user-images.githubusercontent.com/7374243/37029204-dc9fba82-2136-11e8-9d0b-544f9f1373a4.png">


**Overlay for confirming item removal**

<img width="287" alt="screen shot 2018-03-06 at 12 06 36" src="https://user-images.githubusercontent.com/7374243/37029210-e3601600-2136-11e8-9930-2067cbc437c5.png">





resolves #4016 