### PR TITLE
Sort related dossiers alphabetically

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,8 +5,9 @@ Changelog
 2018.2.0 (unreleased)
 ---------------------
 
-- Change action names for meeting agenda items.
+- Change action names for meeting agenda items. [njohner]
 - Order agenda item attachements alphabetically. [njohner]
+- Sort related dossiers alphabetically in dossier overview. [njohner]
 
 
 2018.1.4 (2018-03-06)

--- a/opengever/dossier/browser/overview.py
+++ b/opengever/dossier/browser/overview.py
@@ -188,7 +188,7 @@ class DossierOverview(BoxesViewMixin, BrowserView, GeverTabMixin):
                      'getURL': obj.absolute_url(),
                      'css_class': get_css_class(obj)})
 
-        return references
+        return sorted(references, key=lambda reference: reference["Title"]().lower())
 
     def get_dossier_back_relations(self):
         """Returns a list of intids form all dossiers which relates to the


### PR DESCRIPTION
Sort the related dossiers alphabetically in the dossier overview.

**now**

<img width="1239" alt="screen shot 2018-03-06 at 16 05 18" src="https://user-images.githubusercontent.com/7374243/37039742-79a47cac-2158-11e8-82d5-256d2871e336.png">

**before**

<img width="1239" alt="screen shot 2018-03-06 at 15 58 48" src="https://user-images.githubusercontent.com/7374243/37039740-79888664-2158-11e8-98f6-1bee976dde77.png">

resolves #3825 