### PR TITLE
Implement bumblebee's auto refresh functionality

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ---------------------
 
 - Fix path filterd Solr searches. [phgross]
+- Implement bumblebee's auto refresh functionality. [siegy]
 - OGDS sync: Fix handling of missing user after updating python-ldap. [lgraf]
 - Allow '\uf04a' in task text. [tarnap]
 - Make office connector mimetype checks case insensitive. [tarnap]

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,7 @@ Changelog
 
 - Fix path filterd Solr searches. [phgross]
 - Implement bumblebee's auto refresh functionality. [siegy]
+- Add bumblebee auto refresh feature flag. [deiferni]
 - OGDS sync: Fix handling of missing user after updating python-ldap. [lgraf]
 - Allow '\uf04a' in task text. [tarnap]
 - Make office connector mimetype checks case insensitive. [tarnap]

--- a/opengever/api/config.py
+++ b/opengever/api/config.py
@@ -54,6 +54,8 @@ class Config(Service):
             'direct_checkout_and_edit_enabled', interface=IOfficeConnectorSettings)
         config['features']['preview'] = api.portal.get_registry_record(
             'is_feature_enabled', interface=IGeverBumblebeeSettings)
+        config['features']['preview_auto_refresh'] = api.portal.get_registry_record(
+            'is_auto_refresh_enabled', interface=IGeverBumblebeeSettings)
         config['features']['preview_open_pdf_in_new_window'] = api.portal.get_registry_record(
             'open_pdf_in_a_new_window', interface=IGeverBumblebeeSettings)
         config['features']['repositoryfolder_documents_tab'] = api.portal.get_registry_record(

--- a/opengever/api/tests/test_config.py
+++ b/opengever/api/tests/test_config.py
@@ -35,6 +35,7 @@ class TestConfig(IntegrationTestCase):
                 u'officeconnector_attach': False,
                 u'officeconnector_checkout': False,
                 u'preview': False,
+                u'preview_auto_refresh': False,
                 u'preview_open_pdf_in_new_window': False,
                 u'repositoryfolder_documents_tab': True,
                 u'repositoryfolder_tasks_tab': True,

--- a/opengever/base/browser/configure.zcml
+++ b/opengever/base/browser/configure.zcml
@@ -187,4 +187,12 @@
       permission="zope2.View"
       />
 
+  <browser:page
+      for="*"
+      name="plone_javascript_variables.js"
+      class=".jsvariables.GeverJSVariables"
+      permission="zope.Public"
+      layer="opengever.base.interfaces.IOpengeverBaseLayer"
+      />
+
 </configure>

--- a/opengever/base/browser/jsvariables.py
+++ b/opengever/base/browser/jsvariables.py
@@ -1,0 +1,23 @@
+from Products.CMFPlone.browser.jsvariables import JSVariables
+from ftw import bumblebee
+
+
+TEMPLATE = u"{other_vars}\
+var bumblebee_notification_url = '{bumblebee_notification_url}';"
+
+
+class GeverJSVariables(JSVariables):
+    """Expose variables to javascript
+
+    For instance we need bumblebee's notifications URL to be
+    available in the javascript part. GEVER knows how to build
+    bumblebee URLs, so we expose the generated URL to javascript.
+    """
+
+    def __call__(self, *args, **kwargs):
+        other_vars = super(GeverJSVariables, self).__call__(*args, **kwargs)
+        notification_url = bumblebee.get_service_v3().get_notifications_url()
+
+        return TEMPLATE.format(
+            other_vars=other_vars,
+            bumblebee_notification_url=notification_url)

--- a/opengever/base/browser/jsvariables.py
+++ b/opengever/base/browser/jsvariables.py
@@ -1,5 +1,6 @@
-from Products.CMFPlone.browser.jsvariables import JSVariables
 from ftw import bumblebee
+from opengever.bumblebee import is_auto_refresh_enabled
+from Products.CMFPlone.browser.jsvariables import JSVariables
 
 
 TEMPLATE = u"{other_vars}\
@@ -17,6 +18,9 @@ class GeverJSVariables(JSVariables):
     def __call__(self, *args, **kwargs):
         other_vars = super(GeverJSVariables, self).__call__(*args, **kwargs)
         notification_url = bumblebee.get_service_v3().get_notifications_url()
+
+        if not is_auto_refresh_enabled():
+            return other_vars
 
         return TEMPLATE.format(
             other_vars=other_vars,

--- a/opengever/base/browser/search.pt
+++ b/opengever/base/browser/search.pt
@@ -368,7 +368,9 @@
                         <div class="searchImage" tal:condition="item/is_bumblebeeable">
                           <img class="showroom-reference bumblebeeSearchPreview"
                                tal:attributes="src item/get_preview_image_url;
-                                               data-showroom-id string:showroom-id-${item/UID};" />
+                                               data-showroom-id string:showroom-id-${item/UID};
+                                               data-bumblebee-src item/get_preview_image_url;
+                                               data-bumblebee-checksum item/bumblebee_checksum" />
                         </div>
                       </div>
                       <div class="visualClear"><!-- --></div>

--- a/opengever/base/tests/test_jsvariables.py
+++ b/opengever/base/tests/test_jsvariables.py
@@ -1,0 +1,17 @@
+from opengever.testing import IntegrationTestCase
+
+BUMBLEBEE_NOTIFICATION_URL = 'http://bumblebee/YnVtYmxlYmVl/api/notifications'
+
+
+class TestGeverJSVariables(IntegrationTestCase):
+    """Test the base behavior with the help of businesscase dossier.
+    """
+
+    def test_geverjs_variables(self):
+        self.login(self.regular_user)
+
+        view = self.portal.restrictedTraverse('plone_javascript_variables.js')
+        url_definition = "var bumblebee_notification_url = '{}';".format(
+            BUMBLEBEE_NOTIFICATION_URL
+        )
+        self.assertIn(url_definition, view().split('\n'))

--- a/opengever/base/tests/test_jsvariables.py
+++ b/opengever/base/tests/test_jsvariables.py
@@ -7,6 +7,10 @@ class TestGeverJSVariables(IntegrationTestCase):
     """Test the base behavior with the help of businesscase dossier.
     """
 
+    features = (
+        'bumblebee-auto-refresh',
+    )
+
     def test_geverjs_variables(self):
         self.login(self.regular_user)
 

--- a/opengever/bumblebee/__init__.py
+++ b/opengever/bumblebee/__init__.py
@@ -16,6 +16,11 @@ def is_bumblebee_feature_enabled():
         'is_feature_enabled', interface=IGeverBumblebeeSettings)
 
 
+def is_auto_refresh_enabled():
+    return api.portal.get_registry_record(
+        'is_auto_refresh_enabled', interface=IGeverBumblebeeSettings)
+
+
 def set_preferred_listing_view(value):
     request = getRequest()
     request.RESPONSE.setCookie(BUMBLEBEE_VIEW_COOKIE_NAME, value, path='/')

--- a/opengever/bumblebee/browser/overlay.py
+++ b/opengever/bumblebee/browser/overlay.py
@@ -1,6 +1,7 @@
 from Acquisition import aq_parent
 from ftw import bumblebee
 from ftw.bumblebee.mimetypes import is_mimetype_supported
+from ftw.bumblebee.interfaces import IBumblebeeDocument
 from opengever.base.browser.helper import get_css_class
 from opengever.base.interfaces import IReferenceNumber
 from opengever.base.interfaces import ISequenceNumber
@@ -57,6 +58,9 @@ class BumblebeeBaseDocumentOverlay(ActionButtonRendererMixin):
     def get_preview_pdf_url(self):
         return bumblebee.get_service_v3().get_representation_url(
             self.context, 'preview')
+
+    def get_bumblebee_checksum(self):
+        return IBumblebeeDocument(self.context).get_checksum()
 
     def get_mime_type_css_class(self):
         return get_css_class(self.context)

--- a/opengever/bumblebee/browser/preview_listing.py
+++ b/opengever/bumblebee/browser/preview_listing.py
@@ -1,4 +1,5 @@
 from ftw import bumblebee
+from ftw.bumblebee.interfaces import IBumblebeeDocument
 from opengever.base.browser.helper import get_css_class
 from plone.uuid.interfaces import IUUID
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
@@ -146,6 +147,7 @@ class PreviewListingObjects(PreviewListingItems):
             'title': obj.Title(),
             'overlay_url': obj.absolute_url() + '/@@bumblebee-overlay-listing',
             'uid': IUUID(obj),
+            'checksum': IBumblebeeDocument(obj).get_checksum(),
             'mime_type_css_class': get_css_class(obj),
             'preview_image_url': bumblebee.get_service_v3().get_representation_url(
                 obj, 'thumbnail')}
@@ -158,6 +160,7 @@ class PreviewListingBrains(PreviewListingItems):
             'title': brain.Title,
             'overlay_url': brain.getURL() + '/@@bumblebee-overlay-listing',
             'uid': brain.UID,
+            'checksum': brain.bumblebee_checksum,
             'mime_type_css_class': get_css_class(brain),
             'preview_image_url': bumblebee.get_service_v3().get_representation_url(
                 brain, 'thumbnail')}

--- a/opengever/bumblebee/browser/resources/bumblebee-cable.js
+++ b/opengever/bumblebee/browser/resources/bumblebee-cable.js
@@ -1,0 +1,874 @@
+/**
+ * Version 0.3.0
+ * This file is from https://github.com/4teamwork/bumblebee-cable.js
+ * To update, copy the contents of "bumblebee-cable.js" from the dist folder in here.
+ */
+var BumblebeeCable =
+/******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+/******/
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId])
+/******/ 			return installedModules[moduleId].exports;
+/******/
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			i: moduleId,
+/******/ 			l: false,
+/******/ 			exports: {}
+/******/ 		};
+/******/
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/
+/******/ 		// Flag the module as loaded
+/******/ 		module.l = true;
+/******/
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/
+/******/
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+/******/
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+/******/
+/******/ 	// identity function for calling harmony imports with the correct context
+/******/ 	__webpack_require__.i = function(value) { return value; };
+/******/
+/******/ 	// define getter function for harmony exports
+/******/ 	__webpack_require__.d = function(exports, name, getter) {
+/******/ 		if(!__webpack_require__.o(exports, name)) {
+/******/ 			Object.defineProperty(exports, name, {
+/******/ 				configurable: false,
+/******/ 				enumerable: true,
+/******/ 				get: getter
+/******/ 			});
+/******/ 		}
+/******/ 	};
+/******/
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = function(module) {
+/******/ 		var getter = module && module.__esModule ?
+/******/ 			function getDefault() { return module['default']; } :
+/******/ 			function getModuleExports() { return module; };
+/******/ 		__webpack_require__.d(getter, 'a', getter);
+/******/ 		return getter;
+/******/ 	};
+/******/
+/******/ 	// Object.prototype.hasOwnProperty.call
+/******/ 	__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
+/******/
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "";
+/******/
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(__webpack_require__.s = 2);
+/******/ })
+/************************************************************************/
+/******/ ([
+/* 0 */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _actioncable = __webpack_require__(1);
+
+var _actioncable2 = _interopRequireDefault(_actioncable);
+
+var _BumblebeeNode = __webpack_require__(3);
+
+var _BumblebeeNode2 = _interopRequireDefault(_BumblebeeNode);
+
+var _helpers = __webpack_require__(4);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var DEFAULT_BUMBLEBEE_API_VERSION = 'V3';
+
+// This object represents all bumblebee nodes with their corresponding checksum.
+var bumblebeeNodes = {
+  data: {},
+  /**
+   * will reload all dom elements which
+   * are mapped to the given checksum
+   */
+  reload: function reload(checksum) {
+    var targetNodes = this.data[checksum] || [];
+    targetNodes.forEach(function (node) {
+      node.reload();
+    });
+  },
+
+  /**
+   * gathers all nodes that are marked as bumblebee nodes
+   */
+  gather: function gather() {
+    var _this = this;
+
+    this.data = {};
+    (0, _helpers.toArray)(document.querySelectorAll("[data-bumblebee-src][data-bumblebee-checksum]")).forEach(function (node) {
+      var bumblebeeNode = new _BumblebeeNode2.default(node);
+      var checksum = bumblebeeNode.checksum;
+      _this.data[checksum] = _this.data[checksum] || [];
+      _this.data[checksum].push(bumblebeeNode);
+    });
+  }
+};
+
+/**
+ * The BumblebeeCable represents the clientcomponent
+ * to listen for any finished documents produced by Bumblebee
+ */
+var BumblebeeCable = {
+  /**
+   * Initialize the BumblebeeCable with the
+   * Bumblebee websocket endpoint.
+   * This is usually /YnVtYmxlYmVl/api/notifications.
+   */
+  init: function init(url) {
+    var version = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : DEFAULT_BUMBLEBEE_API_VERSION;
+
+    this.url = url;
+    this.version = version;
+    this.gatherNodes();
+    if (!this.connected) {
+      this.connect(url);
+    }
+  },
+  gatherNodes: function gatherNodes() {
+    bumblebeeNodes.gather();
+  },
+  connect: function connect(url) {
+    var _this2 = this;
+
+    if (typeof WebSocket === "undefined") {
+      return;
+    }
+    // Check if the webserver is able to deal with websockets
+    // e.g. apache has issues with that
+    var testSocket = new WebSocket(_actioncable2.default.createWebSocketURL(url));
+    testSocket.onopen = function () {
+      testSocket.close();
+      var consumer = _actioncable2.default.createConsumer(url);
+      _this2.subscription = consumer.subscriptions.create(_this2.version + '::DocumentChannel', {
+        connected: function connected() {
+          _this2.connected = true;
+          _this2.gatherNodes();
+        },
+        received: function received(data) {
+          bumblebeeNodes.reload(data.finished);
+        }
+      });
+    };
+  },
+  disconnect: function disconnect() {
+    this.subscription.unsubscribe();
+  }
+};
+
+Object.defineProperty(BumblebeeCable, 'nodes', {
+  get: function get() {
+    return bumblebeeNodes;
+  }
+});
+
+exports.default = BumblebeeCable;
+
+/***/ }),
+/* 1 */
+/***/ (function(module, exports, __webpack_require__) {
+
+var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_RESULT__;(function() {
+  (function() {
+    (function() {
+      var slice = [].slice;
+
+      this.ActionCable = {
+        INTERNAL: {
+          "message_types": {
+            "welcome": "welcome",
+            "ping": "ping",
+            "confirmation": "confirm_subscription",
+            "rejection": "reject_subscription"
+          },
+          "default_mount_path": "/cable",
+          "protocols": ["actioncable-v1-json", "actioncable-unsupported"]
+        },
+        createConsumer: function(url) {
+          var ref;
+          if (url == null) {
+            url = (ref = this.getConfig("url")) != null ? ref : this.INTERNAL.default_mount_path;
+          }
+          return new ActionCable.Consumer(this.createWebSocketURL(url));
+        },
+        getConfig: function(name) {
+          var element;
+          element = document.head.querySelector("meta[name='action-cable-" + name + "']");
+          return element != null ? element.getAttribute("content") : void 0;
+        },
+        createWebSocketURL: function(url) {
+          var a;
+          if (url && !/^wss?:/i.test(url)) {
+            a = document.createElement("a");
+            a.href = url;
+            a.href = a.href;
+            a.protocol = a.protocol.replace("http", "ws");
+            return a.href;
+          } else {
+            return url;
+          }
+        },
+        startDebugging: function() {
+          return this.debugging = true;
+        },
+        stopDebugging: function() {
+          return this.debugging = null;
+        },
+        log: function() {
+          var messages;
+          messages = 1 <= arguments.length ? slice.call(arguments, 0) : [];
+          if (this.debugging) {
+            messages.push(Date.now());
+            return console.log.apply(console, ["[ActionCable]"].concat(slice.call(messages)));
+          }
+        }
+      };
+
+    }).call(this);
+  }).call(this);
+
+  var ActionCable = this.ActionCable;
+
+  (function() {
+    (function() {
+      var bind = function(fn, me){ return function(){ return fn.apply(me, arguments); }; };
+
+      ActionCable.ConnectionMonitor = (function() {
+        var clamp, now, secondsSince;
+
+        ConnectionMonitor.pollInterval = {
+          min: 3,
+          max: 30
+        };
+
+        ConnectionMonitor.staleThreshold = 6;
+
+        function ConnectionMonitor(connection) {
+          this.connection = connection;
+          this.visibilityDidChange = bind(this.visibilityDidChange, this);
+          this.reconnectAttempts = 0;
+        }
+
+        ConnectionMonitor.prototype.start = function() {
+          if (!this.isRunning()) {
+            this.startedAt = now();
+            delete this.stoppedAt;
+            this.startPolling();
+            document.addEventListener("visibilitychange", this.visibilityDidChange);
+            return ActionCable.log("ConnectionMonitor started. pollInterval = " + (this.getPollInterval()) + " ms");
+          }
+        };
+
+        ConnectionMonitor.prototype.stop = function() {
+          if (this.isRunning()) {
+            this.stoppedAt = now();
+            this.stopPolling();
+            document.removeEventListener("visibilitychange", this.visibilityDidChange);
+            return ActionCable.log("ConnectionMonitor stopped");
+          }
+        };
+
+        ConnectionMonitor.prototype.isRunning = function() {
+          return (this.startedAt != null) && (this.stoppedAt == null);
+        };
+
+        ConnectionMonitor.prototype.recordPing = function() {
+          return this.pingedAt = now();
+        };
+
+        ConnectionMonitor.prototype.recordConnect = function() {
+          this.reconnectAttempts = 0;
+          this.recordPing();
+          delete this.disconnectedAt;
+          return ActionCable.log("ConnectionMonitor recorded connect");
+        };
+
+        ConnectionMonitor.prototype.recordDisconnect = function() {
+          this.disconnectedAt = now();
+          return ActionCable.log("ConnectionMonitor recorded disconnect");
+        };
+
+        ConnectionMonitor.prototype.startPolling = function() {
+          this.stopPolling();
+          return this.poll();
+        };
+
+        ConnectionMonitor.prototype.stopPolling = function() {
+          return clearTimeout(this.pollTimeout);
+        };
+
+        ConnectionMonitor.prototype.poll = function() {
+          return this.pollTimeout = setTimeout((function(_this) {
+            return function() {
+              _this.reconnectIfStale();
+              return _this.poll();
+            };
+          })(this), this.getPollInterval());
+        };
+
+        ConnectionMonitor.prototype.getPollInterval = function() {
+          var interval, max, min, ref;
+          ref = this.constructor.pollInterval, min = ref.min, max = ref.max;
+          interval = 5 * Math.log(this.reconnectAttempts + 1);
+          return Math.round(clamp(interval, min, max) * 1000);
+        };
+
+        ConnectionMonitor.prototype.reconnectIfStale = function() {
+          if (this.connectionIsStale()) {
+            ActionCable.log("ConnectionMonitor detected stale connection. reconnectAttempts = " + this.reconnectAttempts + ", pollInterval = " + (this.getPollInterval()) + " ms, time disconnected = " + (secondsSince(this.disconnectedAt)) + " s, stale threshold = " + this.constructor.staleThreshold + " s");
+            this.reconnectAttempts++;
+            if (this.disconnectedRecently()) {
+              return ActionCable.log("ConnectionMonitor skipping reopening recent disconnect");
+            } else {
+              ActionCable.log("ConnectionMonitor reopening");
+              return this.connection.reopen();
+            }
+          }
+        };
+
+        ConnectionMonitor.prototype.connectionIsStale = function() {
+          var ref;
+          return secondsSince((ref = this.pingedAt) != null ? ref : this.startedAt) > this.constructor.staleThreshold;
+        };
+
+        ConnectionMonitor.prototype.disconnectedRecently = function() {
+          return this.disconnectedAt && secondsSince(this.disconnectedAt) < this.constructor.staleThreshold;
+        };
+
+        ConnectionMonitor.prototype.visibilityDidChange = function() {
+          if (document.visibilityState === "visible") {
+            return setTimeout((function(_this) {
+              return function() {
+                if (_this.connectionIsStale() || !_this.connection.isOpen()) {
+                  ActionCable.log("ConnectionMonitor reopening stale connection on visibilitychange. visbilityState = " + document.visibilityState);
+                  return _this.connection.reopen();
+                }
+              };
+            })(this), 200);
+          }
+        };
+
+        now = function() {
+          return new Date().getTime();
+        };
+
+        secondsSince = function(time) {
+          return (now() - time) / 1000;
+        };
+
+        clamp = function(number, min, max) {
+          return Math.max(min, Math.min(max, number));
+        };
+
+        return ConnectionMonitor;
+
+      })();
+
+    }).call(this);
+    (function() {
+      var i, message_types, protocols, ref, supportedProtocols, unsupportedProtocol,
+        slice = [].slice,
+        bind = function(fn, me){ return function(){ return fn.apply(me, arguments); }; },
+        indexOf = [].indexOf || function(item) { for (var i = 0, l = this.length; i < l; i++) { if (i in this && this[i] === item) return i; } return -1; };
+
+      ref = ActionCable.INTERNAL, message_types = ref.message_types, protocols = ref.protocols;
+
+      supportedProtocols = 2 <= protocols.length ? slice.call(protocols, 0, i = protocols.length - 1) : (i = 0, []), unsupportedProtocol = protocols[i++];
+
+      ActionCable.Connection = (function() {
+        Connection.reopenDelay = 500;
+
+        function Connection(consumer) {
+          this.consumer = consumer;
+          this.open = bind(this.open, this);
+          this.subscriptions = this.consumer.subscriptions;
+          this.monitor = new ActionCable.ConnectionMonitor(this);
+          this.disconnected = true;
+        }
+
+        Connection.prototype.send = function(data) {
+          if (this.isOpen()) {
+            this.webSocket.send(JSON.stringify(data));
+            return true;
+          } else {
+            return false;
+          }
+        };
+
+        Connection.prototype.open = function() {
+          if (this.isActive()) {
+            ActionCable.log("Attempted to open WebSocket, but existing socket is " + (this.getState()));
+            throw new Error("Existing connection must be closed before opening");
+          } else {
+            ActionCable.log("Opening WebSocket, current state is " + (this.getState()) + ", subprotocols: " + protocols);
+            if (this.webSocket != null) {
+              this.uninstallEventHandlers();
+            }
+            this.webSocket = new WebSocket(this.consumer.url, protocols);
+            this.installEventHandlers();
+            this.monitor.start();
+            return true;
+          }
+        };
+
+        Connection.prototype.close = function(arg) {
+          var allowReconnect, ref1;
+          allowReconnect = (arg != null ? arg : {
+            allowReconnect: true
+          }).allowReconnect;
+          if (!allowReconnect) {
+            this.monitor.stop();
+          }
+          if (this.isActive()) {
+            return (ref1 = this.webSocket) != null ? ref1.close() : void 0;
+          }
+        };
+
+        Connection.prototype.reopen = function() {
+          var error;
+          ActionCable.log("Reopening WebSocket, current state is " + (this.getState()));
+          if (this.isActive()) {
+            try {
+              return this.close();
+            } catch (error1) {
+              error = error1;
+              return ActionCable.log("Failed to reopen WebSocket", error);
+            } finally {
+              ActionCable.log("Reopening WebSocket in " + this.constructor.reopenDelay + "ms");
+              setTimeout(this.open, this.constructor.reopenDelay);
+            }
+          } else {
+            return this.open();
+          }
+        };
+
+        Connection.prototype.getProtocol = function() {
+          var ref1;
+          return (ref1 = this.webSocket) != null ? ref1.protocol : void 0;
+        };
+
+        Connection.prototype.isOpen = function() {
+          return this.isState("open");
+        };
+
+        Connection.prototype.isActive = function() {
+          return this.isState("open", "connecting");
+        };
+
+        Connection.prototype.isProtocolSupported = function() {
+          var ref1;
+          return ref1 = this.getProtocol(), indexOf.call(supportedProtocols, ref1) >= 0;
+        };
+
+        Connection.prototype.isState = function() {
+          var ref1, states;
+          states = 1 <= arguments.length ? slice.call(arguments, 0) : [];
+          return ref1 = this.getState(), indexOf.call(states, ref1) >= 0;
+        };
+
+        Connection.prototype.getState = function() {
+          var ref1, state, value;
+          for (state in WebSocket) {
+            value = WebSocket[state];
+            if (value === ((ref1 = this.webSocket) != null ? ref1.readyState : void 0)) {
+              return state.toLowerCase();
+            }
+          }
+          return null;
+        };
+
+        Connection.prototype.installEventHandlers = function() {
+          var eventName, handler;
+          for (eventName in this.events) {
+            handler = this.events[eventName].bind(this);
+            this.webSocket["on" + eventName] = handler;
+          }
+        };
+
+        Connection.prototype.uninstallEventHandlers = function() {
+          var eventName;
+          for (eventName in this.events) {
+            this.webSocket["on" + eventName] = function() {};
+          }
+        };
+
+        Connection.prototype.events = {
+          message: function(event) {
+            var identifier, message, ref1, type;
+            if (!this.isProtocolSupported()) {
+              return;
+            }
+            ref1 = JSON.parse(event.data), identifier = ref1.identifier, message = ref1.message, type = ref1.type;
+            switch (type) {
+              case message_types.welcome:
+                this.monitor.recordConnect();
+                return this.subscriptions.reload();
+              case message_types.ping:
+                return this.monitor.recordPing();
+              case message_types.confirmation:
+                return this.subscriptions.notify(identifier, "connected");
+              case message_types.rejection:
+                return this.subscriptions.reject(identifier);
+              default:
+                return this.subscriptions.notify(identifier, "received", message);
+            }
+          },
+          open: function() {
+            ActionCable.log("WebSocket onopen event, using '" + (this.getProtocol()) + "' subprotocol");
+            this.disconnected = false;
+            if (!this.isProtocolSupported()) {
+              ActionCable.log("Protocol is unsupported. Stopping monitor and disconnecting.");
+              return this.close({
+                allowReconnect: false
+              });
+            }
+          },
+          close: function(event) {
+            ActionCable.log("WebSocket onclose event");
+            if (this.disconnected) {
+              return;
+            }
+            this.disconnected = true;
+            this.monitor.recordDisconnect();
+            return this.subscriptions.notifyAll("disconnected", {
+              willAttemptReconnect: this.monitor.isRunning()
+            });
+          },
+          error: function() {
+            return ActionCable.log("WebSocket onerror event");
+          }
+        };
+
+        return Connection;
+
+      })();
+
+    }).call(this);
+    (function() {
+      var slice = [].slice;
+
+      ActionCable.Subscriptions = (function() {
+        function Subscriptions(consumer) {
+          this.consumer = consumer;
+          this.subscriptions = [];
+        }
+
+        Subscriptions.prototype.create = function(channelName, mixin) {
+          var channel, params, subscription;
+          channel = channelName;
+          params = typeof channel === "object" ? channel : {
+            channel: channel
+          };
+          subscription = new ActionCable.Subscription(this.consumer, params, mixin);
+          return this.add(subscription);
+        };
+
+        Subscriptions.prototype.add = function(subscription) {
+          this.subscriptions.push(subscription);
+          this.consumer.ensureActiveConnection();
+          this.notify(subscription, "initialized");
+          this.sendCommand(subscription, "subscribe");
+          return subscription;
+        };
+
+        Subscriptions.prototype.remove = function(subscription) {
+          this.forget(subscription);
+          if (!this.findAll(subscription.identifier).length) {
+            this.sendCommand(subscription, "unsubscribe");
+          }
+          return subscription;
+        };
+
+        Subscriptions.prototype.reject = function(identifier) {
+          var i, len, ref, results, subscription;
+          ref = this.findAll(identifier);
+          results = [];
+          for (i = 0, len = ref.length; i < len; i++) {
+            subscription = ref[i];
+            this.forget(subscription);
+            this.notify(subscription, "rejected");
+            results.push(subscription);
+          }
+          return results;
+        };
+
+        Subscriptions.prototype.forget = function(subscription) {
+          var s;
+          this.subscriptions = (function() {
+            var i, len, ref, results;
+            ref = this.subscriptions;
+            results = [];
+            for (i = 0, len = ref.length; i < len; i++) {
+              s = ref[i];
+              if (s !== subscription) {
+                results.push(s);
+              }
+            }
+            return results;
+          }).call(this);
+          return subscription;
+        };
+
+        Subscriptions.prototype.findAll = function(identifier) {
+          var i, len, ref, results, s;
+          ref = this.subscriptions;
+          results = [];
+          for (i = 0, len = ref.length; i < len; i++) {
+            s = ref[i];
+            if (s.identifier === identifier) {
+              results.push(s);
+            }
+          }
+          return results;
+        };
+
+        Subscriptions.prototype.reload = function() {
+          var i, len, ref, results, subscription;
+          ref = this.subscriptions;
+          results = [];
+          for (i = 0, len = ref.length; i < len; i++) {
+            subscription = ref[i];
+            results.push(this.sendCommand(subscription, "subscribe"));
+          }
+          return results;
+        };
+
+        Subscriptions.prototype.notifyAll = function() {
+          var args, callbackName, i, len, ref, results, subscription;
+          callbackName = arguments[0], args = 2 <= arguments.length ? slice.call(arguments, 1) : [];
+          ref = this.subscriptions;
+          results = [];
+          for (i = 0, len = ref.length; i < len; i++) {
+            subscription = ref[i];
+            results.push(this.notify.apply(this, [subscription, callbackName].concat(slice.call(args))));
+          }
+          return results;
+        };
+
+        Subscriptions.prototype.notify = function() {
+          var args, callbackName, i, len, results, subscription, subscriptions;
+          subscription = arguments[0], callbackName = arguments[1], args = 3 <= arguments.length ? slice.call(arguments, 2) : [];
+          if (typeof subscription === "string") {
+            subscriptions = this.findAll(subscription);
+          } else {
+            subscriptions = [subscription];
+          }
+          results = [];
+          for (i = 0, len = subscriptions.length; i < len; i++) {
+            subscription = subscriptions[i];
+            results.push(typeof subscription[callbackName] === "function" ? subscription[callbackName].apply(subscription, args) : void 0);
+          }
+          return results;
+        };
+
+        Subscriptions.prototype.sendCommand = function(subscription, command) {
+          var identifier;
+          identifier = subscription.identifier;
+          return this.consumer.send({
+            command: command,
+            identifier: identifier
+          });
+        };
+
+        return Subscriptions;
+
+      })();
+
+    }).call(this);
+    (function() {
+      ActionCable.Subscription = (function() {
+        var extend;
+
+        function Subscription(consumer, params, mixin) {
+          this.consumer = consumer;
+          if (params == null) {
+            params = {};
+          }
+          this.identifier = JSON.stringify(params);
+          extend(this, mixin);
+        }
+
+        Subscription.prototype.perform = function(action, data) {
+          if (data == null) {
+            data = {};
+          }
+          data.action = action;
+          return this.send(data);
+        };
+
+        Subscription.prototype.send = function(data) {
+          return this.consumer.send({
+            command: "message",
+            identifier: this.identifier,
+            data: JSON.stringify(data)
+          });
+        };
+
+        Subscription.prototype.unsubscribe = function() {
+          return this.consumer.subscriptions.remove(this);
+        };
+
+        extend = function(object, properties) {
+          var key, value;
+          if (properties != null) {
+            for (key in properties) {
+              value = properties[key];
+              object[key] = value;
+            }
+          }
+          return object;
+        };
+
+        return Subscription;
+
+      })();
+
+    }).call(this);
+    (function() {
+      ActionCable.Consumer = (function() {
+        function Consumer(url) {
+          this.url = url;
+          this.subscriptions = new ActionCable.Subscriptions(this);
+          this.connection = new ActionCable.Connection(this);
+        }
+
+        Consumer.prototype.send = function(data) {
+          return this.connection.send(data);
+        };
+
+        Consumer.prototype.connect = function() {
+          return this.connection.open();
+        };
+
+        Consumer.prototype.disconnect = function() {
+          return this.connection.close({
+            allowReconnect: false
+          });
+        };
+
+        Consumer.prototype.ensureActiveConnection = function() {
+          if (!this.connection.isActive()) {
+            return this.connection.open();
+          }
+        };
+
+        return Consumer;
+
+      })();
+
+    }).call(this);
+  }).call(this);
+
+  if (typeof module === "object" && module.exports) {
+    module.exports = ActionCable;
+  } else if (true) {
+    !(__WEBPACK_AMD_DEFINE_FACTORY__ = (ActionCable),
+				__WEBPACK_AMD_DEFINE_RESULT__ = (typeof __WEBPACK_AMD_DEFINE_FACTORY__ === 'function' ?
+				(__WEBPACK_AMD_DEFINE_FACTORY__.call(exports, __webpack_require__, exports, module)) :
+				__WEBPACK_AMD_DEFINE_FACTORY__),
+				__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
+  }
+}).call(this);
+
+
+/***/ }),
+/* 2 */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+var _bumblebee = __webpack_require__(0);
+
+var _bumblebee2 = _interopRequireDefault(_bumblebee);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+module.exports = _bumblebee2.default;
+
+/***/ }),
+/* 3 */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+/**
+ * The BumblebeeNode represents a DOM element
+ * whose content is related to a bumblebee asset.
+ * For example an image tag showing a preview
+ * representation generated by bumblebee.
+ */
+var BumlebeeNode = function () {
+  function BumlebeeNode(node) {
+    _classCallCheck(this, BumlebeeNode);
+
+    this.node = node;
+    this.src = node.getAttribute('data-bumblebee-src');
+    this.checksum = node.getAttribute('data-bumblebee-checksum');
+  }
+
+  _createClass(BumlebeeNode, [{
+    key: 'reload',
+    value: function reload() {
+      var timestamp = new Date().getTime();
+      // Append useless parameter to
+      // invalidate the browser's cache
+      this.node.src = this.src + '&_=' + timestamp;
+    }
+  }]);
+
+  return BumlebeeNode;
+}();
+
+exports.default = BumlebeeNode;
+
+/***/ }),
+/* 4 */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.toArray = toArray;
+// This helper function will make an non-arrayish
+// object to a real array. (e.g. to use nodelist as an array)
+function toArray(nonArrayish) {
+  return [].slice.call(nonArrayish);
+}
+
+/***/ })
+/******/ ]);

--- a/opengever/bumblebee/browser/resources/bumblebee.js
+++ b/opengever/bumblebee/browser/resources/bumblebee.js
@@ -225,8 +225,8 @@
       $(document).ajaxComplete(function(event, jqXHR, params) {
         if (params.url.indexOf("@@updated_search") !== -1 &&
             params.url.indexOf("deactivate_update=true") === -1) {
-
           updateShowroom();
+          BumblebeeCable.gatherNodes();
         }
 
       });
@@ -330,11 +330,24 @@
   }
 
   $(document)
-    .on("reload", updateShowroom)
-    .on("viewReady", updateShowroom)
+    .on("reload", function() {
+      BumblebeeCable.gatherNodes();
+      updateShowroom();
+    })
+    .on("ready", function() {
+      BumblebeeCable.init(window.bumblebee_notification_url);
+    })
+    .on("tooltip.show", function() {
+      scanForBrokenImages(".bumblebee-thumbnail");
+      BumblebeeCable.gatherNodes();
+    })
+    .on("showroom:item:shown", BumblebeeCable.gatherNodes)
+    .on("viewReady", function() {
+      BumblebeeCable.gatherNodes();
+      updateShowroom();
+    })
     .on("agendaItemsReady", updateShowroom)
     .on("click", ".bumblebeeGalleryShowMore", loadNextTabbedviewGalleryView)
-    .on("tooltip.show", function() { scanForBrokenImages(".bumblebee-thumbnail"); })
     .on("click", "#ftw-showroom-menu", toggleMenu);
   $(init);
 

--- a/opengever/bumblebee/browser/resources/bumblebee.js
+++ b/opengever/bumblebee/browser/resources/bumblebee.js
@@ -335,7 +335,10 @@
       updateShowroom();
     })
     .on("ready", function() {
-      BumblebeeCable.init(window.bumblebee_notification_url);
+      var nofitication_url = window.bumblebee_notification_url;
+      if (typeof nofitication_url !== 'undefined') {
+        BumblebeeCable.init(window.bumblebee_notification_url);
+      }
     })
     .on("tooltip.show", function() {
       scanForBrokenImages(".bumblebee-thumbnail");

--- a/opengever/bumblebee/browser/templates/bumblebeeoverlay.pt
+++ b/opengever/bumblebee/browser/templates/bumblebeeoverlay.pt
@@ -53,9 +53,15 @@
     </div>
   </footer>
 </aside>
-<article id="file-preview"
-         tal:define="pdf_url view/overlay/get_preview_pdf_url;
-                     has_file view/overlay/has_file">
-  <iframe tal:condition="has_file" tal:attributes="src pdf_url" />
-  <img class="bumblebee-thumbnail" tal:condition="not:has_file" tal:attributes="src pdf_url" />
+<article id="file-preview" tal:define="pdf_url view/overlay/get_preview_pdf_url;
+                                       has_file view/overlay/has_file;
+                                       checksum view/overlay/get_bumblebee_checksum">
+  <iframe tal:condition="has_file" tal:attributes="src pdf_url;
+                                                   data-bumblebee-src pdf_url;
+                                                   data-bumblebee-checksum checksum" />
+
+  <img class="bumblebee-thumbnail" tal:condition="not:has_file"
+                                   tal:attributes="src pdf_url;
+                                                   data-bumblebee-src pdf_url;
+                                                   data-bumblebee-checksum checksum" />
 </article>

--- a/opengever/bumblebee/browser/templates/previews.pt
+++ b/opengever/bumblebee/browser/templates/previews.pt
@@ -11,7 +11,10 @@
                          id preview/uid">
       <span tal:attributes="class string:file-mimetype ${preview/mime_type_css_class}"></span>
 
-      <img tal:attributes="src preview/preview_image_url; alt preview/title"
+      <img tal:attributes="src preview/preview_image_url;
+                           alt preview/title;
+                           data-bumblebee-src preview/preview_image_url;
+                           data-bumblebee-checksum preview/checksum"
            class="file-preview bumblebee-thumbnail" />
 
       <div class="bumblebeeTitle">

--- a/opengever/bumblebee/interfaces.py
+++ b/opengever/bumblebee/interfaces.py
@@ -21,6 +21,11 @@ class IGeverBumblebeeSettings(Interface):
         description=u'Sets target="_blank" for links to PDF files.',
         default=False)
 
+    is_auto_refresh_enabled = schema.Bool(
+        title=u'Enable bumblebee auto refresh feature',
+        description=u'Automatically load preview images once available.',
+        default=False)
+
 
 class IVersionedContextMarker(Interface):
     """Marker interface for a versioned context.

--- a/opengever/bumblebee/tests/test_preview_listing.py
+++ b/opengever/bumblebee/tests/test_preview_listing.py
@@ -53,7 +53,8 @@ class TestPreviewListing(IntegrationTestCase):
             dict(browser.css('div.showroom-item > span').first.attrib))
 
         img_attrs = dict(browser.css('div.showroom-item > img').first.attrib)
-        img_attrs.pop('src')
+        for e in ['src', 'data-bumblebee-src', 'data-bumblebee-checksum']:
+            img_attrs.pop(e)
         self.assertDictEqual(
             {'class': 'file-preview bumblebee-thumbnail',
              'alt': u'Vertr\xe4gsentwurf'},

--- a/opengever/core/profiles/default/jsregistry.xml
+++ b/opengever/core/profiles/default/jsregistry.xml
@@ -440,9 +440,19 @@
       cookable="True"
       enabled="True"
       expression=""
-      id="++resource++opengever.bumblebee.resources/bumblebee.js"
+      id="++resource++opengever.bumblebee.resources/bumblebee-cable.js"
       insert-after="++resource++opengever.meeting/datetimepicker.js"
       inline="False"
+      />
+
+  <javascript
+      cacheable="True"
+      compression="safe"
+      cookable="True"
+      enabled="True"
+      expression=""
+      id="++resource++opengever.bumblebee.resources/bumblebee.js"
+      insert-after="++resource++opengever.bumblebee.resources/bumblebee-cable.js"
       />
 
   <javascript

--- a/opengever/core/tests/test_view_security.py
+++ b/opengever/core/tests/test_view_security.py
@@ -23,6 +23,7 @@ WHITELIST = (
     'opengever.base.browser.context.WrapperContextState',
     'opengever.base.browser.ploneform_macros.Macros',
     'opengever.base.widgets.GeverRenderWidget',
+    'opengever.base.browser.jsvariables.GeverJSVariables',
 
     # The bumblebee token is verified in these views:
     'opengever.bumblebee.browser.callback.StoreArchivalFile',

--- a/opengever/core/upgrades/20180202111739_register_bumblebee_cable_js/jsregistry.xml
+++ b/opengever/core/upgrades/20180202111739_register_bumblebee_cable_js/jsregistry.xml
@@ -1,0 +1,18 @@
+<object name="portal_javascripts" meta_type="JavaScripts Registry" autogroup="False">
+  <javascript
+      cacheable="True"
+      compression="safe"
+      cookable="True"
+      enabled="True"
+      expression=""
+      id="++resource++opengever.bumblebee.resources/bumblebee-cable.js"
+      insert-after="++resource++opengever.meeting/datetimepicker.js"
+      inline="False"
+      />
+
+  <javascript
+      id="++resource++opengever.bumblebee.resources/bumblebee.js"
+      insert-after="++resource++opengever.bumblebee.resources/bumblebee-cable.js"
+      />
+
+</object>

--- a/opengever/core/upgrades/20180202111739_register_bumblebee_cable_js/upgrade.py
+++ b/opengever/core/upgrades/20180202111739_register_bumblebee_cable_js/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class RegisterBumblebeeCableJs(UpgradeStep):
+    """Register bumblebee cable js.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/core/upgrades/20180423163916_add_bumblebee_auto_refresh_feature_flag/registry.xml
+++ b/opengever/core/upgrades/20180423163916_add_bumblebee_auto_refresh_feature_flag/registry.xml
@@ -1,0 +1,4 @@
+<registry>
+  <record interface="opengever.bumblebee.interfaces.IGeverBumblebeeSettings"
+          field="is_auto_refresh_enabled" />
+</registry>

--- a/opengever/core/upgrades/20180423163916_add_bumblebee_auto_refresh_feature_flag/upgrade.py
+++ b/opengever/core/upgrades/20180423163916_add_bumblebee_auto_refresh_feature_flag/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddBumblebeeAutoRefreshFeatureFlag(UpgradeStep):
+    """Add bumblebee auto refresh feature flag.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/document/browser/overview.py
+++ b/opengever/document/browser/overview.py
@@ -1,5 +1,6 @@
 from AccessControl import getSecurityManager
 from ftw import bumblebee
+from ftw.bumblebee.interfaces import IBumblebeeDocument
 from opengever.base import _ as ogbmf
 from opengever.base.browser import edit_public_trial
 from opengever.base.browser.helper import get_css_class
@@ -278,6 +279,9 @@ class Overview(DefaultView, GeverTabMixin, ActionButtonRendererMixin):
     def get_preview_image_url(self):
         return bumblebee.get_service_v3().get_representation_url(
             self.context, 'image')
+
+    def get_bumblebee_checksum(self):
+        return IBumblebeeDocument(self.context).get_checksum()
 
     def get_overlay_url(self):
         return '{}/@@bumblebee-overlay-document'.format(

--- a/opengever/document/browser/templates/overview.pt
+++ b/opengever/document/browser/templates/overview.pt
@@ -22,7 +22,9 @@
                  tal:attributes="data-showroom-target view/get_overlay_url;
                                  data-showroom-title string:${context/title};
                                  src view/get_preview_image_url;
-                                 alt context/title" />
+                                 alt context/title;
+                                 data-bumblebee-src view/get_preview_image_url;
+                                 data-bumblebee-checksum view/get_bumblebee_checksum" />
         </div>
     </div>
 </body>

--- a/opengever/document/widgets/tooltip.pt
+++ b/opengever/document/widgets/tooltip.pt
@@ -10,7 +10,10 @@
   <div class="preview" tal:condition="view/document/is_bumblebeeable">
     <a href="#" class="showroom-reference"
        tal:attributes="data-showroom-id string:showroom-id-${view/document/uuid}">
-      <img tal:attributes="src view/document/get_preview_image_url; alt context/title"
+      <img tal:attributes="src view/document/get_preview_image_url;
+                           alt context/title;
+                           data-bumblebee-src view/document/get_preview_image_url;
+                           data-bumblebee-checksum  view/get_bumblebee_checksum"
            width="200" class="file-preview bumblebee-thumbnail" />
       <span i18n:domain="opengever.document" i18n:translate="label_open_document_preview">Open document preview</span>
     </a>

--- a/opengever/document/widgets/tooltip.py
+++ b/opengever/document/widgets/tooltip.py
@@ -1,3 +1,4 @@
+from ftw.bumblebee.interfaces import IBumblebeeDocument
 from opengever.document.browser.actionbuttons import ActionButtonRendererMixin
 from plone.app.contentlisting.interfaces import IContentListingObject
 
@@ -9,3 +10,6 @@ class TooltipView(ActionButtonRendererMixin):
         super(TooltipView, self).__init__(context, request)
         self.document = IContentListingObject(self.context)
         self.request.response.setHeader('X-Tooltip-Response', True)
+
+    def get_bumblebee_checksum(self):
+        return IBumblebeeDocument(self.context).get_checksum()

--- a/opengever/examplecontent/profiles/default/registry.xml
+++ b/opengever/examplecontent/profiles/default/registry.xml
@@ -14,6 +14,7 @@
 
   <records interface="opengever.bumblebee.interfaces.IGeverBumblebeeSettings">
     <value key="is_feature_enabled">True</value>
+    <value key="is_auto_refresh_enabled">True</value>
   </records>
 
   <records interface="opengever.contact.interfaces.IContactSettings">

--- a/opengever/testing/integration_test_case.py
+++ b/opengever/testing/integration_test_case.py
@@ -40,6 +40,7 @@ FEATURE_FLAGS = {
     'activity': 'opengever.activity.interfaces.IActivitySettings.is_feature_enabled',
     'bumblebee': 'opengever.bumblebee.interfaces.IGeverBumblebeeSettings.is_feature_enabled',
     'bumblebee-open-pdf-new-tab': 'opengever.bumblebee.interfaces.IGeverBumblebeeSettings.open_pdf_in_a_new_window',
+    'bumblebee-auto-refresh': 'opengever.bumblebee.interfaces.IGeverBumblebeeSettings.is_auto_refresh_enabled',
     'contact': 'opengever.contact.interfaces.IContactSettings.is_feature_enabled',
     'doc-properties': 'opengever.dossier.interfaces.ITemplateFolderProperties.create_doc_properties',
     'dossiertemplate': 'opengever.dossier.dossiertemplate.interfaces.IDossierTemplateSettings.is_feature_enabled',


### PR DESCRIPTION
See https://github.com/4teamwork/opengever.core/issues/4052

As bumblebee has the capability to send a notification to a client
using WebSockets when a document has finished, we can now profit from
that, embedding the client library [bumblebee-cable.js](https://github.com/4teamwork/bumblebee-cable.js).

When a user accesses a GEVER page, he'll first get the thumbnail. If bumblebee finished converting the document, the preview container (either image or iframe) will automatically refresh.

This feature has **low** impact, when the webserver of GEVER, or the webserver of Bumblebee is not able to handle WebSocket requests, this won't raise any error in the javascript part. 
The initial loading of the images is not changed. It's still an `img` or `iframe` tag. The reloading is done through adding a random parameter to the `img` odr `iframe`'s src url, to invalidate the browser's cache.

To make this feature work, the servers need to be configured properly. As of today (12.03.2018) we don't have an automatized (puppet) way to do that. If you still want to try it out, you need to setup nginx as a reverse proxy for GEVER as well as for Bumblebee. Use puma as the bumblebee application server.

### Browser compatibility
https://caniuse.com/#feat=websockets

Tested on:
- Windows
  - IE 11
  - Edge 40
  - Mozilla Firefox 58
- Mac OS X
  - Chrome 64/65
  - Safari 11

See the new feature in action:

### Search (from quick search in the nav)
![mar-08-2018 15-34-23](https://user-images.githubusercontent.com/8779283/37156441-64c765ee-22e6-11e8-8c0a-5964dedeed17.gif)

### Search (without reloading the whole page)
![mar-08-2018 15-33-50](https://user-images.githubusercontent.com/8779283/37156442-64e38b16-22e6-11e8-90cb-6a00153ae104.gif)

### Detail view of document
![mar-08-2018 15-28-13](https://user-images.githubusercontent.com/8779283/37156443-6505eda0-22e6-11e8-89f7-fad21af24646.gif)

### In tooltip
![mar-08-2018 15-25-54](https://user-images.githubusercontent.com/8779283/37156444-6529d86e-22e6-11e8-96ec-1b4db603088f.gif)

### Tile view in listing
![mar-08-2018 15-24-20](https://user-images.githubusercontent.com/8779283/37156445-6546e5c6-22e6-11e8-8178-06dbce905ea4.gif)

### Showroom overlay
![mar-08-2018 15-23-34](https://user-images.githubusercontent.com/8779283/37156446-65612850-22e6-11e8-92fd-c3f6a01a7401.gif)
