### PR TITLE
Always manually sync proposals for dossier reference number prefixes

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ---------------------
 
 - Make sure to URLEncode links to the list_groupmember view in sharing views. [lgraf]
+- Ensure correct dossier reference numbers for proposals after a dossier move operation. [Rotonen]
 - No longer duplicate members with special role in protocol JSON data. [deiferni]
 - Change action names for meeting agenda items. [njohner]
 - Order agenda item attachements alphabetically. [njohner]

--- a/opengever/dossier/handlers.py
+++ b/opengever/dossier/handlers.py
@@ -8,6 +8,7 @@ from opengever.dossier.behaviors.dossier import IDossierMarker
 from opengever.dossier.resolve import get_resolver
 from opengever.globalindex.handlers.task import sync_task
 from opengever.globalindex.handlers.task import TaskSqlSyncer
+from opengever.meeting.handlers import ProposalSqlSyncer
 from plone import api
 from plone.app.workflow.interfaces import ILocalrolesModifiedEvent
 from zope.component import getAdapter
@@ -75,6 +76,14 @@ def save_reference_number_prefix(obj, event):
         'depth': -1})
     for task in tasks:
         TaskSqlSyncer(task.getObject(), None).sync()
+
+    # And also proposals
+    proposals = catalog({
+        'path': '/'.join(obj.getPhysicalPath()),
+        'object_provides': 'opengever.meeting.proposal.IProposal',
+        'depth': -1})
+    for proposal in proposals:
+        ProposalSqlSyncer(proposal.getObject(), None).sync()
 
     obj.reindexObject(idxs=['reference'])
 

--- a/opengever/meeting/tests/test_proposal.py
+++ b/opengever/meeting/tests/test_proposal.py
@@ -249,8 +249,7 @@ class TestProposal(IntegrationTestCase):
                          u'/dossier-1/proposal-2', model.physical_path)
         self.assertEqual(u'Rechnungspr\xfcfungskommission',
                          model.repository_folder_title)
-        # XXX is this correct??
-        self.assertEqual(u'Client1 2',
+        self.assertEqual(u'Client1 2 / 1',
                          model.dossier_reference_number)
 
     @browsing


### PR DESCRIPTION
Seems there was already something similar in place for tasks.

Closes #3234