### PR TITLE
Make sure to URL encode links to the list_groupmember view in sharing views:

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2018.2.0 (unreleased)
 ---------------------
 
+- Make sure to URLEncode links to the list_groupmember view in sharing views. [lgraf]
 - No longer duplicate members with special role in protocol JSON data. [deiferni]
 - Change action names for meeting agenda items. [njohner]
 - Order agenda item attachements alphabetically. [njohner]

--- a/opengever/sharing/browser/sharing.pt
+++ b/opengever/sharing/browser/sharing.pt
@@ -84,7 +84,8 @@
                                     sticky python:entry['id'] in view.STICKY"
                         tal:attributes="class python:oddrow and 'odd' or 'even'">
                         <td>
-                            <a tal:attributes="href string:list_groupmembers?group=${entry/id}"
+                            <a tal:define="groupmembers_url python:view.groupmembers_url(entry['id'])"
+                               tal:attributes="href groupmembers_url"
                                tal:omit-tag="not:is_group" class="link-overlay">
 							  <span tal:condition="is_group" tal:attributes="class string:contenttype-opengever-contact-contactfolder"></span>
 							  <span tal:condition="not:is_group" tal:attributes="class string:function-user"></span>

--- a/opengever/sharing/browser/sharing.py
+++ b/opengever/sharing/browser/sharing.py
@@ -10,12 +10,14 @@ from opengever.sharing.events import LocalRolesAcquisitionActivated
 from opengever.sharing.events import LocalRolesAcquisitionBlocked
 from opengever.sharing.events import LocalRolesModified
 from opengever.sharing.interfaces import ISharingConfiguration
+from plone import api
 from plone.app.workflow.browser.sharing import SharingView
 from plone.app.workflow.interfaces import ISharingPageRole
 from plone.memoize.instance import memoize
 from plone.registry.interfaces import IRegistry
 from Products.CMFCore.utils import getToolByName
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+from urllib import urlencode
 from zope.component import getUtilitiesFor
 from zope.component import getUtility
 from zope.event import notify
@@ -221,6 +223,11 @@ class OpengeverSharingView(SharingView):
             else:
                 results.append(principal)
         return results
+
+    def groupmembers_url(self, groupid):
+        portal = api.portal.get()
+        qs = urlencode({'group': groupid})
+        return '/'.join((portal.portal_url(), '@@list_groupmembers?%s' % qs))
 
 
 class SharingTab(OpengeverSharingView):

--- a/opengever/sharing/browser/sharing_tab.pt
+++ b/opengever/sharing/browser/sharing_tab.pt
@@ -25,7 +25,8 @@
                         sticky python:entry['id'] in view.STICKY"
             tal:attributes="class python:oddrow and 'odd' or 'even'">
           <td>
-            <a tal:attributes="href string:list_groupmembers?group=${entry/id}"
+            <a tal:define="groupmembers_url python:view.groupmembers_url(entry['id'])"
+               tal:attributes="href groupmembers_url"
                tal:omit-tag="not:is_group" class="link-overlay">
 			  <span tal:condition="is_group" tal:attributes="class string:contenttype-opengever-contact-contactfolder"></span>
 			  <span tal:condition="not:is_group" tal:attributes="class string:function-user"></span>


### PR DESCRIPTION
Make sure to URL encode links to the `list_groupmember` view in **sharing views**:

This ensures members for groups with **spaces in their ID** can also be listed in the overlay. This is a follow up to PR #3961 which fixed this issue for the user details view, but not the sharing pages.