### PR TITLE
Avoid checking out the document via the redirector on an OC reauth.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -10,6 +10,7 @@ Changelog
 - Update ftw.datepicker to version 1.3.0. [mathias.leimgruber]
 - Temporarily disable upgrade step to fix broken references until we're sure it's safe. [lgraf]
 - Install and integrate ftw.tokenauth. [lgraf]
+- Avoid checking out the document via the redirector on an OC reauth. [Rotonen]
 - Make sure to URLEncode links to the list_groupmember view in sharing views. [lgraf]
 - Ensure correct dossier reference numbers for proposals after a dossier move operation. [Rotonen]
 - Implement related document icon. [Kevin Bieri]

--- a/opengever/document/checkout/checkout.py
+++ b/opengever/document/checkout/checkout.py
@@ -45,18 +45,19 @@ class CheckoutDocuments(BrowserView):
             objects = [self.context]
 
         # now, lets checkout every document
-        for obj in objects:
-            if not IDocumentSchema.providedBy(obj):
-                # notify the user. we have a no-checkoutable object
-                msg = _(
-                    u'Could not check out object: ${title}, '
-                    'it is not a document.',
-                    mapping={'title': obj.Title().decode('utf-8')})
-                IStatusMessage(
-                    self.request).addStatusMessage(msg, type='error')
-                continue
+        if not self.request.get('reauth') == '1':
+            for obj in objects:
+                if not IDocumentSchema.providedBy(obj):
+                    # notify the user. we have a no-checkoutable object
+                    msg = _(
+                        u'Could not check out object: ${title}, '
+                        'it is not a document.',
+                        mapping={'title': obj.Title().decode('utf-8')})
+                    IStatusMessage(
+                        self.request).addStatusMessage(msg, type='error')
+                    continue
 
-            self.checkout(obj)
+                self.checkout(obj)
 
         # lets register a redirector for starting external
         # editor - if requested


### PR DESCRIPTION
Added a `reauth=1` querystrhing parametre to the checkout redirector to skip the checkout when used only for the reauth.

Closes https://github.com/4teamwork/opengever.core/issues/3941