### PR TITLE
Reorder buildouts to minimize CI test run buildout time

### DIFF
--- a/base-plone-4.3.x.cfg
+++ b/base-plone-4.3.x.cfg
@@ -1,0 +1,15 @@
+[buildout]
+extends =
+    https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-package.cfg
+    versions.cfg
+    sources.cfg
+    https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-versions.cfg
+
+package-name = opengever.core
+package-namespace = opengever
+test-egg = opengever.core[api, tests]
+
+[test]
+arguments = ['-s', '${buildout:package-namespace}', '--exit-with-status', '--auto-color', '--auto-progress', '--xml', '--package-path', '${buildout:directory}/${buildout:package-namespace}', '${buildout:package-namespace}']
+eggs +=
+    ${buildout:hotfix-eggs}

--- a/development.cfg
+++ b/development.cfg
@@ -1,6 +1,6 @@
 [buildout]
 extends =
-    test-plone-4.3.x.cfg
+    base-plone-4.3.x.cfg
     https://raw.githubusercontent.com/4teamwork/gever-buildouts/master/standard-dev.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/plone-development-tika.cfg
     https://raw.github.com/4teamwork/ftw-buildouts/master/bumblebee.cfg

--- a/test-plone-4.3.x.cfg
+++ b/test-plone-4.3.x.cfg
@@ -1,19 +1,19 @@
 [buildout]
 extends =
-    https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-package.cfg
-    versions.cfg
-    sources.cfg
-    https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-versions.cfg
+    base-plone-4.3.x.cfg
+
+parts =
+    test
+    test-jenkins
 
 jenkins_python = $PYTHON27
-package-name = opengever.core
-package-namespace = opengever
-test-egg = opengever.core[api, tests]
-
-[test]
-arguments = ['-s', '${buildout:package-namespace}', '--exit-with-status', '--auto-color', '--auto-progress', '--xml', '--package-path', '${buildout:directory}/${buildout:package-namespace}', '${buildout:package-namespace}']
-eggs +=
-    ${buildout:hotfix-eggs}
 
 [test-jenkins]
 test-command-no-coverage = bin/mtest -d -j5 $@
+input = inline:
+    #!/bin/sh
+    ${test-jenkins:pre-test}
+    ${test-jenkins:test-command}
+    result=$?
+    ${test-jenkins:post-test}
+    exit $result


### PR DESCRIPTION
This time without destroying `development.cfg`. A basically free ~40s CI job runtime gain.