### PR TITLE
Implement related document icon.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -8,6 +8,7 @@ Changelog
 - Install and integrate ftw.tokenauth. [lgraf]
 - Make sure to URLEncode links to the list_groupmember view in sharing views. [lgraf]
 - Ensure correct dossier reference numbers for proposals after a dossier move operation. [Rotonen]
+- Implement related document icon. [Kevin Bieri]
 - No longer duplicate members with special role in protocol JSON data. [deiferni]
 - Change action names for meeting agenda items. [njohner]
 - Order agenda item attachements alphabetically. [njohner]

--- a/opengever/base/browser/helper.py
+++ b/opengever/base/browser/helper.py
@@ -41,28 +41,27 @@ def get_css_class(item, type_icon_only=False):
                               'opengever.meeting.sablontemplate',
                               'opengever.meeting.proposaltemplate']:
 
+        # It's a document, we therefore want to display an icon
+        # for the mime type of the contained file
+        icon = getattr(item, 'getIcon', '')
+        if callable(icon):
+            icon = icon()
+
+        if icon:
+            # Strip '.gif' from end of icon name and remove
+            # leading 'icon_'
+            filetype = icon[:icon.rfind('.')].replace('icon_', '')
+            css_class = 'icon-%s' % normalize(filetype)
+        else:
+            # Fallback for unknown file type
+            css_class = "icon-document_empty"
+
         if getattr(item, '_v__is_relation', False):
             # Document was listed as a relation, so we use a special icon.
-            css_class = "icon-dokument_verweis"
+            css_class += " is-document-relation"
             # Immediatly set the volatile attribute to False so it doesn't
             # affect other views using the same object instance
             item._v__is_relation = False
-
-        else:
-            # It's a document, we therefore want to display an icon
-            # for the mime type of the contained file
-            icon = getattr(item, 'getIcon', '')
-            if callable(icon):
-                icon = icon()
-
-            if not icon == '':
-                # Strip '.gif' from end of icon name and remove
-                # leading 'icon_'
-                filetype = icon[:icon.rfind('.')].replace('icon_', '')
-                css_class = 'icon-%s' % normalize(filetype)
-            else:
-                # Fallback for unknown file type
-                css_class = "icon-document_empty"
 
     if css_class is None:
         css_class = "contenttype-%s" % normalize(item.portal_type)

--- a/opengever/base/tests/test_helper.py
+++ b/opengever/base/tests/test_helper.py
@@ -1,105 +1,49 @@
-from ftw.testing import MockTestCase
+from opengever.testing import IntegrationTestCase
+from opengever.testing.helpers import obj2brain
 from opengever.base.browser.helper import get_css_class
-from opengever.ogds.base import utils
-from plone.i18n.normalizer import idnormalizer, IIDNormalizer
 
 
-class TestCssClassHelpers(MockTestCase):
-
-    def setUp(self):
-        super(TestCssClassHelpers, self).setUp()
-
-        self.ori_get_current_admin_unit = utils.get_current_admin_unit
-        get_current_admin_unit = self.mocker.replace(
-            'opengever.ogds.base.utils.get_current_admin_unit', count=False)
-
-        admin_unit = self.stub()
-        self.expect(get_current_admin_unit()).result(admin_unit)
-        self.expect(admin_unit.id()).result('client1')
-
-        self.mock_utility(idnormalizer, IIDNormalizer)
-
-    def tearDown(self):
-        utils.get_current_admin_unit = self.ori_get_current_admin_unit
-
-    def test_obj(self):
-        obj = self.stub()
-        self.expect(obj.portal_type).result('ftw.obj.obj')
-
-        self.replay()
-
-        self.assertEquals(get_css_class(obj), 'contenttype-ftw-obj-obj')
-
-    def test_document_brain_with_icon(self):
-        brain = self.stub()
-        self.expect(brain.portal_type).result('opengever.document.document')
-        self.expect(getattr(brain, '_v__is_relation', False)).result(False)
-        self.expect(brain.getIcon).result('icon_dokument_pdf.gif')
-
-        self.replay()
-
-        self.assertEquals(get_css_class(brain), 'icon-dokument_pdf')
-
-    def test_document_obj_with_icon(self):
-        obj = self.stub()
-        self.expect(obj.portal_type).result('opengever.document.document')
-        self.expect(getattr(obj, '_v__is_relation', False)).result(False)
-        self.expect(obj.getIcon()).result('icon_dokument_word.gif')
-
-        self.replay()
-
-        self.assertEquals(get_css_class(obj), 'icon-dokument_word')
+class TestCssClassHelpers(IntegrationTestCase):
 
     def test_document_obj_with_relation_flag(self):
-        obj = self.stub()
-        self.expect(obj.portal_type).result('opengever.document.document')
-        self.expect(getattr(obj, '_v__is_relation', False)).result(True)
-        obj._v__is_relation = False
+        self.login(self.dossier_responsible)
+        setattr(self.document, '_v__is_relation', True)
+        self.assertEquals(
+            get_css_class(self.document),
+            'icon-docx is-document-relation')
 
-        self.replay()
+    def test_document_brain_with_icon(self):
+        self.login(self.dossier_responsible)
+        brain = obj2brain(self.document)
+        self.assertEquals(brain.getIcon, 'docx.png')
+        self.assertEquals(get_css_class(brain), 'icon-docx')
 
-        self.assertEquals(get_css_class(obj), 'icon-dokument_verweis')
+    def test_document_obj_with_icon(self):
+        self.login(self.dossier_responsible)
+        setattr(self.document, '_v__is_relation', False)
+        self.assertEquals(self.document.getIcon(), 'docx.png')
+        self.assertEquals(get_css_class(self.document), 'icon-docx')
 
     def test_sablontemplate_brain_with_icon(self):
-        brain = self.stub()
-        self.expect(brain.portal_type).result(
-            'opengever.meeting.sablontemplate')
-        self.expect(getattr(brain, '_v__is_relation', False)).result(False)
-        self.expect(brain.getIcon).result('icon_dokument_pdf.gif')
-
-        self.replay()
-
-        self.assertEquals(get_css_class(brain), 'icon-dokument_pdf')
+        self.login(self.dossier_responsible)
+        brain = obj2brain(self.sablon_template)
+        self.assertEquals(brain.getIcon, 'docx.png')
+        self.assertEquals(get_css_class(brain), 'icon-docx')
 
     def test_sablontemplate_obj_with_icon(self):
-        obj = self.stub()
-        self.expect(obj.portal_type).result(
-            'opengever.meeting.sablontemplate')
-        self.expect(getattr(obj, '_v__is_relation', False)).result(False)
-        self.expect(obj.getIcon()).result('icon_dokument_word.gif')
-
-        self.replay()
-
-        self.assertEquals(get_css_class(obj), 'icon-dokument_word')
+        self.login(self.dossier_responsible)
+        setattr(self.sablon_template, '_v__is_relation', False)
+        self.assertEquals(self.sablon_template.getIcon(), 'docx.png')
+        self.assertEquals(get_css_class(self.sablon_template), 'icon-docx')
 
     def test_proposaltemplate_brain_with_icon(self):
-        brain = self.stub()
-        self.expect(brain.portal_type).result(
-            'opengever.meeting.proposaltemplate')
-        self.expect(getattr(brain, '_v__is_relation', False)).result(False)
-        self.expect(brain.getIcon).result('icon_dokument_pdf.gif')
-
-        self.replay()
-
-        self.assertEquals(get_css_class(brain), 'icon-dokument_pdf')
+        self.login(self.dossier_responsible)
+        brain = obj2brain(self.proposal_template)
+        self.assertEquals(brain.getIcon, 'docx.png')
+        self.assertEquals(get_css_class(brain), 'icon-docx')
 
     def test_proposaltemplate_obj_with_icon(self):
-        obj = self.stub()
-        self.expect(obj.portal_type).result(
-            'opengever.meeting.proposaltemplate')
-        self.expect(getattr(obj, '_v__is_relation', False)).result(False)
-        self.expect(obj.getIcon()).result('icon_dokument_word.gif')
-
-        self.replay()
-
-        self.assertEquals(get_css_class(obj), 'icon-dokument_word')
+        self.login(self.dossier_responsible)
+        setattr(self.proposal_template, '_v__is_relation', False)
+        self.assertEquals(self.proposal_template.getIcon(), 'docx.png')
+        self.assertEquals(get_css_class(self.proposal_template), 'icon-docx')


### PR DESCRIPTION
Closes https://github.com/4teamwork/opengever.core/issues/3908

⚠️ depends on https://github.com/4teamwork/plonetheme.teamraum/pull/619

<img width="1919" alt="screen shot 2018-03-15 at 11 31 11" src="https://user-images.githubusercontent.com/1637820/37458184-837d6aac-2844-11e8-8727-195c2c184d2b.png">
