### PR TITLE
Disable flunking tests on an unclean stderr

### DIFF
--- a/bin/mtest
+++ b/bin/mtest
@@ -307,7 +307,7 @@ def handle_results(results):
             stdout = result.get('stdout')
             runtime += result.get('runtime')
 
-            if not stderr and not returncode:
+            if not returncode:
                 success.append(True)
 
             else:


### PR DESCRIPTION
We're having too many transient failures due to the mysterious potentially layer teardown related recursion depth issues.

https://ci.4teamwork.ch/builds/150747/tasks/238262