### PR TITLE
Temporarily disable upgrade step to fix broken references until we're sure it's safe

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2018.2.0 (unreleased)
 ---------------------
 
-- Make upgrade step to fix broken references more robust. [lgraf]
+- Temporarily disable upgrade step to fix broken references until we're sure it's safe. [lgraf]
 - Install and integrate ftw.tokenauth. [lgraf]
 - Make sure to URLEncode links to the list_groupmember view in sharing views. [lgraf]
 - Ensure correct dossier reference numbers for proposals after a dossier move operation. [Rotonen]

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2018.2.0 (unreleased)
 ---------------------
 
+- Make upgrade step to fix broken references more robust. [lgraf]
 - Install and integrate ftw.tokenauth. [lgraf]
 - Make sure to URLEncode links to the list_groupmember view in sharing views. [lgraf]
 - Ensure correct dossier reference numbers for proposals after a dossier move operation. [Rotonen]

--- a/opengever/core/upgrades/20180306101228_fix_relation_catalog_references/upgrade.py
+++ b/opengever/core/upgrades/20180306101228_fix_relation_catalog_references/upgrade.py
@@ -19,6 +19,14 @@ class FixRelationCatalogReferences(UpgradeStep):
     """
 
     def __call__(self):
+        # Disable this upgrade step until we figure out what exactly is going
+        # on in issue #4074 - right now it seems that pickling a persistent
+        # object (just to check whether it's in an ok state) might be a bad
+        # idea and not be side-effect free.
+        #
+        # Until we're sure this isn't harmful, we disable this upgrade step.
+        return
+
         catalog = getUtility(ICatalog)
 
         for mapping_key in POTENTIALLY_BROKEN:

--- a/opengever/core/upgrades/20180306101228_fix_relation_catalog_references/upgrade.py
+++ b/opengever/core/upgrades/20180306101228_fix_relation_catalog_references/upgrade.py
@@ -43,4 +43,9 @@ class FixRelationCatalogReferences(UpgradeStep):
         except cPickle.PicklingError as e:
             return True
 
+        except Exception as e:
+            # Make sure any other errors don't make this check fail
+            logger.warning('Trying to pickle %r failed with %r' % (btree, e))
+            return False
+
         return False


### PR DESCRIPTION
Disable this upgrade step until we figure out what exactly is going
on in issue #4074 - right now it seems that pickling a persistent
object (just to check whether it's in an ok state) might be a bad
idea and not be side-effect free.

Until we're sure this isn't harmful, we disable this upgrade step.

See #4074 for a more detailed explanation.