### PR TITLE
Fix force checkin button

### DIFF
--- a/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
@@ -155,7 +155,7 @@ msgstr "Checkin"
 #. Default: "Checkin anyway"
 #: ./opengever/document/checkout/checkin.py
 msgid "button_checkin_anyway"
-msgstr ""
+msgstr "Checkin malgré tout"
 
 #. Default: "PDF"
 #: ./opengever/document/browser/versions_tab.py
@@ -535,7 +535,7 @@ msgstr "Version"
 #. Default: " This document is currently being worked on."
 #: ./opengever/document/checkout/checkin.py
 msgid "label_warn_checkout_locked"
-msgstr ""
+msgstr "Quelqu'un travaille actuellement sur ce document. Les modifications seront perdues si vous faites un checkin manuel. Veuillez s'il vous plait permettre au processus d'edition actuel de se terminer."
 
 #. Default: "yes"
 #: ./opengever/document/browser/overview.py
@@ -545,7 +545,7 @@ msgstr "Oui"
 #. Default: "This item is being checked out by ${creator}."
 #: ./opengever/document/checkout/templates/checkedoutviewlet.pt
 msgid "message_checkout_info"
-msgstr "Ce document a été verrouillé par ${creator}."
+msgstr "${creator} a fait un checkout de ce document."
 
 #. Default: "Could not cancel checkout on document ${title}, mails does not support the checkin checkout process."
 #: ./opengever/document/checkout/cancel.py

--- a/opengever/document/tests/test_checkout.py
+++ b/opengever/document/tests/test_checkout.py
@@ -5,6 +5,7 @@ from ftw.builder import Builder
 from ftw.builder import create
 from ftw.bumblebee.tests.helpers import asset
 from ftw.testbrowser import browsing
+from ftw.testbrowser.exceptions import NoElementFound
 from ftw.testbrowser.pages.statusmessages import assert_message
 from ftw.testbrowser.pages.statusmessages import error_messages
 from ftw.testbrowser.pages.statusmessages import info_messages
@@ -336,6 +337,30 @@ class TestCheckinViews(IntegrationTestCase):
     """Tests for the checkin views."""
 
     @browsing
+    def test_checkin_anyway_shown_for_locked_documents(self, browser):
+        self.login(self.regular_user, browser)
+
+        browser.open(self.document, view='tabbedview_view-overview')
+        browser.find('Checkout and edit').click()
+
+        browser.open(self.document)
+        browser.css('#checkin_with_comment').first.click()
+        with self.assertRaises(NoElementFound):
+            browser.css('#form-buttons-button_checkin_anyway').first
+
+        self.assertEqual(browser.css('#form-buttons-button_checkin').first.name, 'form.buttons.button_checkin')
+
+        # Lock document
+        IRefreshableLockable(self.document).lock()
+
+        browser.open(self.document)
+        browser.css('#checkin_with_comment').first.click()
+        with self.assertRaises(NoElementFound):
+            browser.css('#form-buttons-button_checkin').first
+
+        self.assertEqual(browser.css('#form-buttons-button_checkin_anyway').first.name, 'form.buttons.button_checkin_anyway')
+
+    @browsing
     def test_single_checkin_with_comment(self, browser):
         self.login(self.regular_user, browser)
 
@@ -377,7 +402,6 @@ class TestCheckinViews(IntegrationTestCase):
 
         # Lock document
         IRefreshableLockable(self.document).lock()
-        transaction.commit()
 
         browser.open(self.document)
 
@@ -394,7 +418,7 @@ class TestCheckinViews(IntegrationTestCase):
 
         self.assertIn(
             'Checkin anyway',
-            browser.css('#form-buttons-button_checkin')[0].outerHTML
+            browser.css('#form-buttons-button_checkin_anyway')[0].outerHTML
             )
 
         self.assertNotIn(
@@ -408,7 +432,7 @@ class TestCheckinViews(IntegrationTestCase):
             u'Journal Comment': journal_comment,
             })
 
-        browser.css('#form-buttons-button_checkin').first.click()
+        browser.css('#form-buttons-button_checkin_anyway').first.click()
 
         manager = getMultiAdapter(
             (self.document, self.portal.REQUEST),


### PR DESCRIPTION
Buttons get defined on the class level, so conditionally changing the button label is not a good idea. Instead we now have 2 buttons that are displayed conditionally.
I also added the French translation of the button label.

**Before, once the label was changed to "checking anyway", it could remain in that state even if the document is not locked anymore**
![screen shot 2018-03-19 at 14 18 23](https://user-images.githubusercontent.com/7374243/37597712-7517acd6-2b80-11e8-9bd7-7a9b9bfe8227.png)

**Now  we get the correct labels**
![screen shot 2018-03-19 at 13 56 20](https://user-images.githubusercontent.com/7374243/37597544-06b45dd4-2b80-11e8-8fa7-db03dcf69d73.png)
![screen shot 2018-03-19 at 13 57 16](https://user-images.githubusercontent.com/7374243/37597545-06d6afe2-2b80-11e8-843a-55021476a8c8.png)
**And the french translation**
<img width="961" alt="screen shot 2018-03-19 at 14 02 09" src="https://user-images.githubusercontent.com/7374243/37597554-0a6b32cc-2b80-11e8-90e9-7d8d4d0da7cd.png">


resolves https://extranet.4teamwork.ch/support/edk/tracker-support-gever-edk/102