### PR TITLE
Upgrade to cleanup leftovers from ICreatorAware

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2018.2.0 (unreleased)
 ---------------------
 
+- Cleanup leftovers from ICreatorAware interface in index [njohner]
 - Update policy template to set flags for new features [njohner]
 - Add French translations of the Ordnungssystem in the example content [njohner]
 - Update ftw.datepicker to version 1.3.0. [mathias.leimgruber]

--- a/opengever/core/upgrades/20180319170439_cleanup_i_creator_leftovers/upgrade.py
+++ b/opengever/core/upgrades/20180319170439_cleanup_i_creator_leftovers/upgrade.py
@@ -1,0 +1,19 @@
+from ftw.upgrade import UpgradeStep
+from plone import api
+
+
+class CleanupICreatorLeftovers(UpgradeStep):
+    """Cleanup i creator leftovers.
+    """
+
+    def __call__(self):
+        self.reindex_object_provides()
+
+    def reindex_object_provides(self):
+        catalog = api.portal.get().portal_catalog
+        query = {'object_provides': ['opengever.base.behaviors.creator.ICreatorAware']}
+        message = "Remove references to ICreatorAware interface:"
+        message += " reindexing object_provides"
+        for obj in self.objects(query, message):
+            catalog.reindexObject(
+                obj, idxs=['object_provides'], update_metadata=False)


### PR DESCRIPTION
Upgrade step to remove references to the `ICreatorAware` interface in the index.
This was tested locally by reverting the commits removing the interface, setting up a new gever with content and then reapplying the commits and corresponding upgrade steps. This upgrade step could then be applied and tested.

resolves #4048 