### PR TITLE
JavaScript filter field for choosing templates

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -537,7 +537,7 @@ Objects
           - self.document
           - self.draft_proposal
           - self.draft_word_proposal
-          - self.mail_eml
+          - self.mail
           - self.mail_msg
           - self.proposal
           - self.subdossier
@@ -557,10 +557,16 @@ Objects
             - self.meeting_subtask
     - self.empty_repofolder
   - self.templates
+    - self.asset_template
+    - self.docprops_template
     - self.dossiertemplate
       - self.subdossiertemplate
+    - self.empty_template
+    - self.normal_template
     - self.proposal_template
     - self.sablon_template
+    - self.subtemplates
+      - self.subtemplate
     - self.tasktemplatefolder
       - self.tasktemplate
   - self.workspace_root

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,7 @@ Changelog
 
 - Only allow to add contacts when IContactSettings.is_feature_enabled is disabled [njohner]
 - Implemented a JavaScript filter field for choosing templates. [Rotonen]
+- Add filter to proposal and dossier from template addform. [deiferni]
 - Cleanup leftovers from ICreatorAware interface in index [njohner]
 - Update policy template to set flags for new features [njohner]
 - Add French translations of the Ordnungssystem in the example content [njohner]

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ---------------------
 
 - Only allow to add contacts when IContactSettings.is_feature_enabled is disabled [njohner]
+- Implemented a JavaScript filter field for choosing templates. [Rotonen]
 - Cleanup leftovers from ICreatorAware interface in index [njohner]
 - Update policy template to set flags for new features [njohner]
 - Add French translations of the Ordnungssystem in the example content [njohner]

--- a/opengever/api/tests/test_serializer.py
+++ b/opengever/api/tests/test_serializer.py
@@ -54,11 +54,11 @@ class TestDocumentSerializer(IntegrationTestCase):
         self.login(self.administrator, browser)
         browser.open(self.document, headers={'Accept': 'application/json'})
         self.assertEqual(browser.status_code, 200)
-        self.assertEqual(browser.json.get(u'reference_number'), u'Client1 1.1 / 1 / 5')
+        self.assertEqual(browser.json.get(u'reference_number'), u'Client1 1.1 / 1 / 10')
 
     @browsing
     def test_mail_serialization_contains_reference_number(self, browser):
         self.login(self.administrator, browser)
         browser.open(self.mail, headers={'Accept': 'application/json'})
         self.assertEqual(browser.status_code, 200)
-        self.assertEqual(browser.json.get(u'reference_number'), u'Client1 1.1 / 1 / 15')
+        self.assertEqual(browser.json.get(u'reference_number'), u'Client1 1.1 / 1 / 20')

--- a/opengever/api/tests/test_summary.py
+++ b/opengever/api/tests/test_summary.py
@@ -100,13 +100,13 @@ class TestGeverJSONSummarySerializer(IntegrationTestCase):
             summary,
             {
                 u'@id': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-'
-                u'und-vereinbarungen/dossier-1/document-5',
+                        u'und-vereinbarungen/dossier-1/document-10',
                 u'created': u'2016-08-31T15:07:33+02:00',
                 u'creator': u'robert.ziegler',
                 u'filename': u'vertragsentwurf.docx',
                 u'filesize': 27413,
                 u'mimetype': u'application/vnd.openxmlformats-officedocument.'
-                u'wordprocessingml.document',
+                             u'wordprocessingml.document',
                 u'modified': u'2016-08-31T15:07:33+02:00',
             })
 
@@ -123,6 +123,6 @@ class TestGeverJSONSummarySerializer(IntegrationTestCase):
             summary,
             {
                 u'@id': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-'
-                u'und-vereinbarungen/dossier-1/document-5',
-                u'reference_number': u'Client1 1.1 / 1 / 5',
+                        u'und-vereinbarungen/dossier-1/document-10',
+                u'reference_number': u'Client1 1.1 / 1 / 10',
             })

--- a/opengever/base/browser/resources/TableRadioWidget.js
+++ b/opengever/base/browser/resources/TableRadioWidget.js
@@ -1,4 +1,23 @@
 $(function() {
+  function tableradio_searchfilter() {
+    var filter, tr, td;
+    filter = $('#tableradio-searchbox').val().toUpperCase();
+    tr = $('.tableradio-widget-wrapper tbody tr');
+
+    tr.each(function(_, tr) {
+      // Second cell is the title
+      td = tr.cells[1];
+      tr = $(tr);
+      if (td.textContent.trim().toUpperCase().indexOf(filter) > -1) {
+        tr.show();
+      } else {
+        tr.hide();
+      }
+    });
+  }
+
+  $('#tableradio-searchbox').on('keyup', tableradio_searchfilter);
+
   $('.tableradio-widget-wrapper[data-vocabulary-depends-on]').each(function() {
     /** When a table radio widget has a list of fieldnames configured
         in  "vocabulary-depends-on", the widget should be re-rendered

--- a/opengever/base/browser/resources/TableRadioWidget.js
+++ b/opengever/base/browser/resources/TableRadioWidget.js
@@ -1,14 +1,16 @@
 $(function() {
   function tableradio_searchfilter() {
-    var filter, tr, td;
-    filter = $('#tableradio-searchbox').val().toUpperCase();
-    tr = $('.tableradio-widget-wrapper tbody tr');
+    var filter = $(this);
+    var text = filter.val().toUpperCase();
+    var widget = filter.closest('.tableradioSearchboxContainer').next('.tableradio-widget-wrapper');
+    var tr = widget.find('tbody tr');
+    var td;
 
     tr.each(function(_, tr) {
       // Second cell is the title
       td = tr.cells[1];
       tr = $(tr);
-      if (td.textContent.trim().toUpperCase().indexOf(filter) > -1) {
+      if (td.textContent.trim().toUpperCase().indexOf(text) > -1) {
         tr.show();
       } else {
         tr.hide();
@@ -16,7 +18,7 @@ $(function() {
     });
   }
 
-  $('#tableradio-searchbox').on('keyup', tableradio_searchfilter);
+  $('.tableradioSearchbox').on('input', tableradio_searchfilter);
 
   $('.tableradio-widget-wrapper[data-vocabulary-depends-on]').each(function() {
     /** When a table radio widget has a list of fieldnames configured

--- a/opengever/base/schema.py
+++ b/opengever/base/schema.py
@@ -49,10 +49,16 @@ class TableChoice(schema.Choice):
     a list of field names which influence the result of the table.
     This allows the widget to be reloaded automatically when the here
     listed fields change its values.
+
+    If show_filter is `True` a filter-box will be rendered before the
+    table. WARNING: the filter is currently hard-coded to search the first
+    non-radio button ONLY colum.
     """
     implements(ITableChoice)
 
-    def __init__(self, columns=tuple(), vocabulary_depends_on=(), **kwargs):
+    def __init__(self, columns=tuple(), vocabulary_depends_on=(),
+                 show_filter=False, **kwargs):
         self.columns = columns
         self.vocabulary_depends_on = vocabulary_depends_on
+        self.show_filter = show_filter
         super(TableChoice, self).__init__(**kwargs)

--- a/opengever/base/templates/tableradio_input.pt
+++ b/opengever/base/templates/tableradio_input.pt
@@ -2,6 +2,20 @@
       xmlns:tal="http://xml.zope.org/namespaces/tal"
       tal:omit-tag="">
 
+<div i18n:domain="ftw.tabbedview">
+  <label for="tableradio-searchbox"
+         class="hiddenStructure"
+         i18n:translate="label_filter">
+  </label>
+  <input type="text"
+         name="searchable_text"
+         id="tableradio-searchbox"
+         class="inputLabel"
+         autocomplete="false"
+         i18n:domain="ftw.tabbedview"
+         i18n:attributes="title filter; placeholder filter" />
+ </div>
+
 <div tal:content="structure view/render_table" tal:condition="view/has_items"
      tal:attributes="data-vocabulary-depends-on view/get_vocabulary_depends_on"
      class="tableradio-widget-wrapper" />

--- a/opengever/base/templates/tableradio_input.pt
+++ b/opengever/base/templates/tableradio_input.pt
@@ -2,18 +2,18 @@
       xmlns:tal="http://xml.zope.org/namespaces/tal"
       tal:omit-tag="">
 
-<div i18n:domain="ftw.tabbedview">
+
+<div i18n:domain="ftw.tabbedview" tal:condition="view/show_filter" class="tableradioSearchboxContainer">
   <label for="tableradio-searchbox"
          class="hiddenStructure"
          i18n:translate="label_filter">
   </label>
   <input type="text"
          name="searchable_text"
-         id="tableradio-searchbox"
-         class="inputLabel"
+         class="inputLabel tableradioSearchbox"
          autocomplete="false"
          i18n:domain="ftw.tabbedview"
-         i18n:attributes="title filter; placeholder filter" />
+         i18n:attributes="title filter; placeholder filter"/>
  </div>
 
 <div tal:content="structure view/render_table" tal:condition="view/has_items"

--- a/opengever/base/tests/test_contentlisting.py
+++ b/opengever/base/tests/test_contentlisting.py
@@ -201,7 +201,7 @@ class TestOpengeverContentListing(IntegrationTestCase):
                 'Title': 'Vertr\xc3\xa4gsentwurf',
                 'absolute_url': (
                     'http://nohost/plone/ordnungssystem/fuhrung'
-                    '/vertrage-und-vereinbarungen/dossier-1/document-5'
+                    '/vertrage-und-vereinbarungen/dossier-1/document-10'
                     ),
                 },
             )

--- a/opengever/base/tests/test_widget.py
+++ b/opengever/base/tests/test_widget.py
@@ -125,7 +125,7 @@ class TestRadioTableWidget(FunctionalTestCase):
         inputs = browser.css(
             '#formfield-form-widgets-default_radio_table_field input')
         expected_inputs = [
-            u'<input type="text" name="searchable_text" id="tableradio-searchbox" class="inputLabel" autocomplete="false" '
+            u'<input type="text" name="searchable_text" class="inputLabel tableradioSearchbox" autocomplete="false" '
             u'placeholder="Filter" title="Filter">',
             u'<input id="form-widgets-default_radio_table_field-1" '
             u'name="form.widgets.default_radio_table_field" value="1" title="foo" type="radio">',
@@ -142,6 +142,7 @@ class TestRadioTableWidget(FunctionalTestCase):
             "No items available",
             browser.css('#formfield-form-widgets-empty_radio_table_field .empty_message').first.text
         )
+
 
 class TestUnitTrixStripWhitespace(TestCase):
 

--- a/opengever/base/tests/test_widget.py
+++ b/opengever/base/tests/test_widget.py
@@ -124,12 +124,16 @@ class TestRadioTableWidget(FunctionalTestCase):
         browser.login().visit(view='test-z3cform-widget')
         inputs = browser.css(
             '#formfield-form-widgets-default_radio_table_field input')
-        self.assertEqual(
-            [u'<input id="form-widgets-default_radio_table_field-1" name="form.widgets.default_radio_table_field" value="1" title="foo" type="radio">',
-             u'<input id="form-widgets-default_radio_table_field-2" name="form.widgets.default_radio_table_field" value="2" title="bar" type="radio">',
-             u'<input name="form.widgets.default_radio_table_field-empty-marker" type="hidden" value="1">'],
-            [each.normalized_outerHTML for each in inputs]
-        )
+        expected_inputs = [
+            u'<input type="text" name="searchable_text" id="tableradio-searchbox" class="inputLabel" autocomplete="false" '
+            u'placeholder="Filter" title="Filter">',
+            u'<input id="form-widgets-default_radio_table_field-1" '
+            u'name="form.widgets.default_radio_table_field" value="1" title="foo" type="radio">',
+            u'<input id="form-widgets-default_radio_table_field-2" '
+            u'name="form.widgets.default_radio_table_field" value="2" title="bar" type="radio">',
+            u'<input name="form.widgets.default_radio_table_field-empty-marker" type="hidden" value="1">',
+            ]
+        self.assertEqual(expected_inputs, [each.normalized_outerHTML for each in inputs])
 
     @browsing
     def test_renders_empty_message(self, browser):

--- a/opengever/base/tests/views/z3cforms.py
+++ b/opengever/base/tests/views/z3cforms.py
@@ -37,6 +37,7 @@ class IWidgetTestFormSchema(Interface):
     default_radio_table_field = TableChoice(
         required=False,
         title=u"default_table",
+        show_filter=True,
         vocabulary=get_radio_table_vocabulary(),)
     # field with custom columns
     custom_radio_table_field = TableChoice(

--- a/opengever/base/widgets.py
+++ b/opengever/base/widgets.py
@@ -76,6 +76,9 @@ class TableRadioWidget(widget.HTMLInputWidget, SequenceWidget):
 
     empty_message = _("msg_no_items_available", default=u"No items available")
 
+    def show_filter(self):
+        return self.field.show_filter
+
     def is_checked(self, term):
         return term.token in self.value
 

--- a/opengever/bumblebee/tests/test_overlay_adapter_mail.py
+++ b/opengever/bumblebee/tests/test_overlay_adapter_mail.py
@@ -66,7 +66,7 @@ class TestGetOpenAsPdfLink(IntegrationTestCase):
 
         expected_url = (
             'http://nohost/plone/ordnungssystem/fuhrung'
-            '/vertrage-und-vereinbarungen/dossier-1/document-15'
+            '/vertrage-und-vereinbarungen/dossier-1/document-20'
             '/bumblebee-open-pdf?filename=die-burgschaft.pdf'
             )
 
@@ -79,7 +79,7 @@ class TestGetOpenAsPdfLink(IntegrationTestCase):
 
         expected_url = (
             u'http://nohost/plone/ordnungssystem/fuhrung'
-            u'/vertrage-und-vereinbarungen/dossier-1/document-15'
+            u'/vertrage-und-vereinbarungen/dossier-1/document-20'
             u'/bumblebee-open-pdf?filename=GEVER%20-%20%C3%9Cbernahme.pdf'
             )
 

--- a/opengever/core/testing.py
+++ b/opengever/core/testing.py
@@ -327,17 +327,6 @@ class ActivityLayer(PloneSandboxLayer):
 OPENGEVER_FUNCTIONAL_ACTIVITY_LAYER = ActivityLayer()
 
 
-class DossierTemplateLayer(PloneSandboxLayer):
-
-    def setUpPloneSite(self, portal):
-        toggle_feature(IDossierTemplateSettings, enabled=True)
-
-    defaultBases = (OPENGEVER_FUNCTIONAL_TESTING,)
-
-
-OPENGEVER_FUNCTIONAL_DOSSIER_TEMPLATE_LAYER = DossierTemplateLayer()
-
-
 class BumblebeeLayer(PloneSandboxLayer):
 
     def setUpZope(self, app, configurationContext):

--- a/opengever/document/tests/test_bumblebee.py
+++ b/opengever/document/tests/test_bumblebee.py
@@ -119,7 +119,7 @@ class TestBumblebeeIntegrationWithEnabledFeature(IntegrationTestCase):
             'deferred': False,
             'url': (
                 '/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen'
-                '/dossier-1/dossier-2/document-12/bumblebee_trigger_storing'
+                '/dossier-1/dossier-2/document-17/bumblebee_trigger_storing'
                 ),
             }
 
@@ -163,7 +163,7 @@ class TestBumblebeeIntegrationWithEnabledFeature(IntegrationTestCase):
             'deferred': False,
             'url': (
                 '/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen'
-                '/dossier-1/dossier-2/document-12/bumblebee_trigger_storing'
+                '/dossier-1/dossier-2/document-17/bumblebee_trigger_storing'
                 ),
             }
 

--- a/opengever/dossier/dossiertemplate/form.py
+++ b/opengever/dossier/dossiertemplate/form.py
@@ -101,6 +101,7 @@ class ICreateDossierFromTemplate(model.Schema):
         title=_(u"label_template", default=u"Template"),
         source=get_dossier_templates,
         required=True,
+        show_filter=True,
         columns=(
             {'column': 'title',
              'column_title': _(u'label_title', default=u'Title'),

--- a/opengever/dossier/templatefolder/form.py
+++ b/opengever/dossier/templatefolder/form.py
@@ -63,6 +63,7 @@ class ICreateDocumentFromTemplate(model.Schema):
         title=_(u"label_template", default=u"Template"),
         source=get_templates,
         required=True,
+        show_filter=True,
         columns=(
             {'column': 'title',
              'column_title': _(u'label_title', default=u'Title'),

--- a/opengever/dossier/tests/__init__.py
+++ b/opengever/dossier/tests/__init__.py
@@ -59,11 +59,11 @@ EXPECTED_DOSSIER_PROPERTIES = {
 }
 
 EXPECTED_DOCUMENT_PROPERTIES = {
-    'Document.ReferenceNumber': 'Client1 1.1 / 1 / 5',
-    'Document.SequenceNumber': '5',
+    'Document.ReferenceNumber': 'Client1 1.1 / 1 / 10',
+    'Document.SequenceNumber': '10',
     'ogg.document.title': u'Vertr\xe4gsentwurf',
-    'ogg.document.reference_number': 'Client1 1.1 / 1 / 5',
-    'ogg.document.sequence_number': '5',
+    'ogg.document.reference_number': 'Client1 1.1 / 1 / 10',
+    'ogg.document.sequence_number': '10',
     'ogg.document.document_author': TEST_USER_ID,
     'ogg.document.document_date': datetime(2010, 1, 3),
     'ogg.document.document_type': u'Contract',

--- a/opengever/dossier/tests/test_documents_tab.py
+++ b/opengever/dossier/tests/test_documents_tab.py
@@ -32,7 +32,7 @@ class TestDocumentsTab(IntegrationTestCase):
 
         expected_url = (
             'http://nohost/plone/ordnungssystem/fuhrung'
-            '/vertrage-und-vereinbarungen/dossier-1/dossier-2/document-12'
+            '/vertrage-und-vereinbarungen/dossier-1/dossier-2/document-17'
             )
 
         self.assertEqual(expected_url, items.first.get('href'))

--- a/opengever/dossier/tests/test_dossier_template.py
+++ b/opengever/dossier/tests/test_dossier_template.py
@@ -146,18 +146,19 @@ class TestDossierTemplate(IntegrationTestCase):
         self.login(self.administrator, browser=browser)
 
         create(Builder('document')
-               .titled(u'Template document')
-               .within(self.templates))
-        create(Builder('document')
                .titled(u'Dossiertemplate document')
                .within(self.dossiertemplate))
 
-        browser.open(
-            self.templates, view="tabbedview_view-documents-proxy")
+        browser.open(self.templates, view="tabbedview_view-documents-proxy")
 
-        self.assertEqual(
-            ['Template document'],
-            browser.css('.listing td .linkWrapper').text)
+        expected_documents = [
+            u'T\xc3\xb6mpl\xc3\xb6te Mit',
+            u'T\xc3\xb6mpl\xc3\xb6te Ohne',
+            u'T\xc3\xb6mpl\xc3\xb6te Normal',
+            u'T\xc3\xb6mpl\xc3\xb6te Leer',
+            ]
+
+        self.assertEqual(expected_documents, browser.css('.listing td .linkWrapper').text)
 
     @browsing
     def test_show_only_whitelisted_schema_fields_in_add_form(self, browser):

--- a/opengever/dossier/tests/test_templatefolder.py
+++ b/opengever/dossier/tests/test_templatefolder.py
@@ -9,8 +9,6 @@ from ftw.testbrowser.pages import plone
 from ftw.testing import freeze
 from ooxml_docprops import read_properties
 from opengever.contact.interfaces import IContactSettings
-from opengever.core.testing import activate_meeting_word_implementation
-from opengever.core.testing import OPENGEVER_FUNCTIONAL_MEETING_LAYER
 from opengever.dossier.docprops import TemporaryDocFile
 from opengever.dossier.interfaces import ITemplateFolderProperties
 from opengever.dossier.templatefolder import get_template_folder
@@ -637,34 +635,48 @@ class TestTemplateFolder(FunctionalTestCase):
         self.assertFalse(assignable.getBlacklistStatus(CONTEXT_CATEGORY))
 
 
-class TestTemplateFolderMeetingEnabled(FunctionalTestCase):
+class TestTemplateFolderMeetingEnabled(IntegrationTestCase):
 
-    layer = OPENGEVER_FUNCTIONAL_MEETING_LAYER
-
-    def setUp(self):
-        super(TestTemplateFolderMeetingEnabled, self).setUp()
-        self.grant('Manager')
+    features = (
+        'meeting',
+        )
 
     @browsing
     def test_addable_types_with_meeting_feature(self, browser):
-        templatefolder = create(Builder('templatefolder'))
-        browser.login().open(templatefolder)
+        self.login(self.manager, browser)
+        browser.open(self.templates)
 
-        self.assertEquals(
-            ['Document', 'Sablon Template', 'TaskTemplateFolder',
-             'Template Folder'],
-            factoriesmenu.addable_types())
+        expected_addable_types = [
+            'Document',
+            'Sablon Template',
+            'TaskTemplateFolder',
+            'Template Folder',
+            ]
+
+        self.assertEquals(expected_addable_types, factoriesmenu.addable_types())
+
+
+class TestTemplateFolderWordMeetingEnabled(IntegrationTestCase):
+
+    features = (
+        'meeting',
+        'word-meeting',
+        )
 
     @browsing
     def test_addable_types_with_meeting_word_implementation(self, browser):
-        activate_meeting_word_implementation()
-        templatefolder = create(Builder('templatefolder'))
-        browser.login().open(templatefolder)
+        self.login(self.manager, browser)
+        browser.open(self.templates)
 
-        self.assertEquals(
-            ['Document', 'Proposal Template', 'Sablon Template',
-             'TaskTemplateFolder', 'Template Folder'],
-            factoriesmenu.addable_types())
+        expected_addable_types = [
+            'Document',
+            'Proposal Template',
+            'Sablon Template',
+            'TaskTemplateFolder',
+            'Template Folder',
+            ]
+
+        self.assertEquals(expected_addable_types, factoriesmenu.addable_types())
 
 
 class TestTemplateFolderUtility(FunctionalTestCase):

--- a/opengever/dossier/tests/test_templatefolder.py
+++ b/opengever/dossier/tests/test_templatefolder.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-
 from datetime import date
 from datetime import datetime
 from ftw.builder import Builder
@@ -11,7 +10,6 @@ from ftw.testing import freeze
 from ooxml_docprops import read_properties
 from opengever.contact.interfaces import IContactSettings
 from opengever.core.testing import activate_meeting_word_implementation
-from opengever.core.testing import OPENGEVER_FUNCTIONAL_DOSSIER_TEMPLATE_LAYER
 from opengever.core.testing import OPENGEVER_FUNCTIONAL_MEETING_LAYER
 from opengever.dossier.docprops import TemporaryDocFile
 from opengever.dossier.interfaces import ITemplateFolderProperties
@@ -24,6 +22,7 @@ from opengever.officeconnector.interfaces import IOfficeConnectorSettings
 from opengever.ogds.base.actor import Actor
 from opengever.testing import add_languages
 from opengever.testing import FunctionalTestCase
+from opengever.testing import IntegrationTestCase
 from opengever.testing.helpers import get_contacts_token
 from opengever.testing.pages import sharing_tab_data
 from plone import api
@@ -846,23 +845,22 @@ class TestTemplateDocumentTabs(FunctionalTestCase):
                           sharing_tab_data())
 
 
-class TestDossierTemplateFeature(FunctionalTestCase):
-
-    layer = OPENGEVER_FUNCTIONAL_DOSSIER_TEMPLATE_LAYER
+class TestDossierTemplateFeature(IntegrationTestCase):
+    features = (
+        'dossiertemplate',
+        )
 
     @browsing
     def test_dossier_template_is_addable_if_dossier_template_feature_is_enabled(self, browser):
-        templatefolder = create(Builder('templatefolder'))
-        browser.login().open(templatefolder)
+        self.login(self.manager, browser)
+        browser.open(self.templates)
 
-        self.assertIn('Dossier template', factoriesmenu.addable_types())
+        expected_addable_types = ['Document', 'Dossier template', 'TaskTemplateFolder', 'Template Folder']
+        self.assertEqual(expected_addable_types, factoriesmenu.addable_types())
 
     @browsing
     def test_show_dossier_templates_tab(self, browser):
-        templatefolder = create(Builder('templatefolder'))
+        self.login(self.regular_user, browser)
+        browser.open(self.templates)
 
-        browser.login().visit(templatefolder)
-
-        self.assertEqual(
-            'Dossier templates',
-            browser.css('.formTab #tab-dossiertemplates').first.text)
+        self.assertEqual('Dossier templates', browser.css('.formTab #tab-dossiertemplates').first.text)

--- a/opengever/dossier/tests/test_templatefolder.py
+++ b/opengever/dossier/tests/test_templatefolder.py
@@ -16,7 +16,6 @@ from opengever.dossier.templatefolder.interfaces import ITemplateFolder
 from opengever.dossier.tests import OGDS_USER_ATTRIBUTES
 from opengever.journal.handlers import DOC_PROPERTIES_UPDATED
 from opengever.journal.tests.utils import get_journal_entry
-from opengever.officeconnector.interfaces import IOfficeConnectorSettings
 from opengever.ogds.base.actor import Actor
 from opengever.testing import add_languages
 from opengever.testing import FunctionalTestCase
@@ -29,69 +28,318 @@ from plone.portlets.constants import CONTEXT_CATEGORY
 from plone.portlets.interfaces import ILocalPortletAssignmentManager
 from plone.portlets.interfaces import IPortletAssignmentMapping
 from plone.portlets.interfaces import IPortletManager
-from plone.registry.interfaces import IRegistry
 from unittest import skip
 from zope.app.intid.interfaces import IIntIds
 from zope.component import getMultiAdapter
 from zope.component import getUtility
 
 
-def _make_token(document):
-    intids = getUtility(IIntIds)
-    return str(intids.getId(document))
+class TestDocumentWithTemplateFormPlain(IntegrationTestCase):
+
+    @browsing
+    def test_form_lists_all_templates_alphabetically_including_nested(self, browser):
+        self.login(self.regular_user, browser)
+        browser.open(self.dossier, view='document_with_template')
+
+        expected_listing = [
+            {'': '', 'Creator': 'nicole.kohler', 'Modified': '28.12.2010', 'Title': u'T\xc3\xb6mpl\xc3\xb6te Mit'},
+            {'': '', 'Creator': 'nicole.kohler', 'Modified': '31.08.2016', 'Title': u'T\xc3\xb6mpl\xc3\xb6te Normal'},
+            {'': '', 'Creator': 'nicole.kohler', 'Modified': '31.08.2016', 'Title': u'T\xc3\xb6mpl\xc3\xb6te Ohne'},
+            {'': '', 'Creator': 'nicole.kohler', 'Modified': '29.02.2020', 'Title': u'T\xc3\xb6mpl\xc3\xb6te Sub'},
+            ]
+
+        self.assertEquals(expected_listing, browser.css('table.listing').first.dicts())
+
+    @browsing
+    def test_form_does_not_inlcude_participants_with_disabled_feature(self, browser):
+        self.login(self.regular_user, browser)
+        browser.open(self.dossier, view='document_with_template')
+
+        # XXX - The CheckBoxWidget is rendered with two labels (only in testing).
+        # The reason for that is a wrong widget renderer adapter lookup because
+        # of the stacked globalregistry (see plone.testing.zca: pushGlobalRegistry
+        # for more information).
+        expected_labels = [
+            u'Template',
+            u'Title',
+            u'Edit after creation',
+            ]
+
+        self.assertEqual(expected_labels, browser.css('#form label').text)
+
+    @browsing
+    def test_cancel_redirects_to_the_dossier(self, browser):
+        self.login(self.regular_user, browser)
+        browser.open(self.dossier, view='document_with_template')
+
+        browser.find('Cancel').click()
+
+        self.assertEquals(self.dossier, browser.context)
+        self.assertEquals('tabbed_view', plone.view())
+
+    @browsing
+    def test_save_redirects_to_the_dossiers_document_tab(self, browser):
+        self.login(self.regular_user, browser)
+        browser.open(self.dossier, view='document_with_template')
+
+        browser.fill({
+            'form.widgets.template': str(getUtility(IIntIds).getId(self.normal_template)),
+            'Title': 'Test Document',
+            'Edit after creation': False,
+            }).save()
+
+        self.assertEquals(self.dossier, browser.context)
+        self.assertEquals(self.dossier.absolute_url() + '#documents', browser.url)
+
+    @browsing
+    def test_new_document_is_titled_with_the_form_value(self, browser):
+        self.login(self.regular_user, browser)
+        browser.open(self.dossier, view='document_with_template')
+        browser.fill({
+            'form.widgets.template': str(getUtility(IIntIds).getId(self.normal_template)),
+            'Title': 'Test Document',
+            }).save()
+
+        document = self.dossier.listFolderContents()[-1]
+        self.assertEquals('Test Document', document.title)
+
+    @browsing
+    def test_new_document_values_are_filled_with_default_values(self, browser):
+        self.login(self.regular_user, browser)
+        browser.open(self.dossier, view='document_with_template')
+        browser.fill({
+            'form.widgets.template': str(getUtility(IIntIds).getId(self.normal_template)),
+            'Title': 'Test Document',
+            }).save()
+
+        document = self.dossier.listFolderContents()[-1]
+        self.assertEquals(date.today(), document.document_date)
+        self.assertEquals(u'privacy_layer_no', document.privacy_layer)
+
+    @browsing
+    def test_file_of_the_new_document_is_a_copy_of_the_template(self, browser):
+        self.login(self.regular_user, browser)
+        browser.open(self.dossier, view='document_with_template')
+        browser.fill({
+            'form.widgets.template': str(getUtility(IIntIds).getId(self.normal_template)),
+            'Title': 'Test Document',
+            }).save()
+
+        document = self.dossier.listFolderContents()[-1]
+
+        self.assertEquals(self.normal_template.file.data, document.file.data)
+        self.assertNotEquals(self.normal_template.file, document.file)
+
+    @browsing
+    def test_doc_properties_are_not_created_when_disabled(self, browser):
+        self.login(self.regular_user, browser)
+
+        with freeze(datetime(2020, 10, 28, 0, 0)):
+            browser.open(self.dossier, view='document_with_template')
+            browser.fill({
+                'form.widgets.template': str(getUtility(IIntIds).getId(self.asset_template)),
+                'Title': 'Test Docx',
+                }).save()
+
+        document = self.dossier.listFolderContents()[-1]
+        self.assertEquals(u'test-docx.docx', document.file.filename)
+
+        with TemporaryDocFile(document.file) as tmpfile:
+            self.assertItemsEqual([], read_properties(tmpfile.path))
+
+    @browsing
+    def test_templates_without_a_file_are_not_listed(self, browser):
+        self.login(self.regular_user, browser)
+        browser.open(self.dossier, view='document_with_template')
+
+        expected_documents = [
+            u'T\xc3\xb6mpl\xc3\xb6te Mit',
+            u'T\xc3\xb6mpl\xc3\xb6te Normal',
+            u'T\xc3\xb6mpl\xc3\xb6te Ohne',
+            u'T\xc3\xb6mpl\xc3\xb6te Sub',
+            ]
+
+        found_documents = [
+            row.get('Title')
+            for row in browser.css('table.listing').first.dicts()
+            ]
+
+        self.assertEquals(expected_documents, found_documents)
+        self.assertNotIn(u'T\xc3\xb6mpl\xc3\xb6te Leer', found_documents)
 
 
-class TestDocumentWithTemplateForm(FunctionalTestCase):
+class TestDocumentWithTemplateFormWithDocProperties(IntegrationTestCase):
+    features = (
+        'doc-properties',
+        )
 
+    def assert_doc_properties_updated_journal_entry_generated(self, document, user):
+        entry = get_journal_entry(document)
+
+        self.assertEqual(DOC_PROPERTIES_UPDATED, entry['action']['type'])
+        self.assertEqual(user.id, entry['actor'])
+        self.assertEqual('', entry['comments'])
+
+    @browsing
+    def test_properties_are_added_when_created_from_template_with_doc_properties(self, browser):
+        self.login(self.regular_user, browser)
+
+        with freeze(datetime(2020, 9, 28, 0, 0)):
+            browser.open(self.dossier, view='document_with_template')
+            browser.fill({
+                'form.widgets.template': str(getUtility(IIntIds).getId(self.docprops_template)),
+                'Title': 'Test Docx',
+                }).save()
+
+        document = self.dossier.listFolderContents()[-1]
+        self.assertEquals(u'test-docx.docx', document.file.filename)
+
+        expected_doc_properties = {
+            'Document.ReferenceNumber': 'Client1 1.1 / 1 / 27',
+            'Document.SequenceNumber': '27',
+            'Dossier.ReferenceNumber': 'Client1 1.1 / 1',
+            'Dossier.Title': u'Vertr\xe4ge mit der kantonalen Finanzverwaltung',
+            'User.FullName': u'B\xe4rfuss K\xe4thi',
+            'User.ID': 'kathi.barfuss',
+            'ogg.document.document_date': datetime(2020, 9, 28, 0, 0),
+            'ogg.document.reference_number': 'Client1 1.1 / 1 / 27',
+            'ogg.document.sequence_number': '27',
+            'ogg.document.title': 'Test Docx',
+            'ogg.document.version_number': 0,
+            'ogg.dossier.reference_number': 'Client1 1.1 / 1',
+            'ogg.dossier.sequence_number': '1',
+            'ogg.dossier.title': u'Vertr\xe4ge mit der kantonalen Finanzverwaltung',
+            'ogg.user.address1': 'Kappelenweg 13',
+            'ogg.user.address2': 'Postfach 1234',
+            'ogg.user.city': 'Vorkappelen',
+            'ogg.user.country': 'Schweiz',
+            'ogg.user.department': 'Staatskanzlei',
+            'ogg.user.department_abbr': 'SK',
+            'ogg.user.description': 'nix',
+            'ogg.user.directorate': 'Staatsarchiv',
+            'ogg.user.directorate_abbr': 'Arch',
+            'ogg.user.email': 'foo@example.com',
+            'ogg.user.email2': 'bar@example.com',
+            'ogg.user.firstname': u'K\xe4thi',
+            'ogg.user.lastname': u'B\xe4rfuss',
+            'ogg.user.phone_fax': '012 34 56 77',
+            'ogg.user.phone_mobile': '012 34 56 76',
+            'ogg.user.phone_office': '012 34 56 78',
+            'ogg.user.salutation': 'Prof. Dr.',
+            'ogg.user.title': u'B\xe4rfuss K\xe4thi',
+            'ogg.user.url': 'http://www.example.com',
+            'ogg.user.userid': 'kathi.barfuss',
+            'ogg.user.zip_code': '1234',
+            }
+
+        with TemporaryDocFile(document.file) as tmpfile:
+            self.assertItemsEqual(
+                expected_doc_properties.items() + [('Test', 'Peter')],
+                read_properties(tmpfile.path))
+        self.assert_doc_properties_updated_journal_entry_generated(document, self.regular_user)
+
+    @browsing
+    def test_properties_are_added_when_created_from_template_without_doc_properties(self, browser):
+        self.login(self.regular_user, browser)
+
+        with freeze(datetime(2020, 10, 28, 0, 0)):
+            browser.open(self.dossier, view='document_with_template')
+            browser.fill({
+                'form.widgets.template': str(getUtility(IIntIds).getId(self.asset_template)),
+                'Title': 'Test Docx',
+                }).save()
+
+        document = self.dossier.listFolderContents()[-1]
+        self.assertEquals(u'test-docx.docx', document.file.filename)
+
+        expected_doc_properties = {
+            'Document.ReferenceNumber': 'Client1 1.1 / 1 / 27',
+            'Document.SequenceNumber': '27',
+            'Dossier.ReferenceNumber': 'Client1 1.1 / 1',
+            'Dossier.Title': u'Vertr\xe4ge mit der kantonalen Finanzverwaltung',
+            'User.FullName': u'B\xe4rfuss K\xe4thi',
+            'User.ID': 'kathi.barfuss',
+            'ogg.document.document_date': datetime(2020, 10, 28, 0, 0),
+            'ogg.document.reference_number': 'Client1 1.1 / 1 / 27',
+            'ogg.document.sequence_number': '27',
+            'ogg.document.title': 'Test Docx',
+            'ogg.document.version_number': 0,
+            'ogg.dossier.reference_number': 'Client1 1.1 / 1',
+            'ogg.dossier.sequence_number': '1',
+            'ogg.dossier.title': u'Vertr\xe4ge mit der kantonalen Finanzverwaltung',
+            'ogg.user.address1': 'Kappelenweg 13',
+            'ogg.user.address2': 'Postfach 1234',
+            'ogg.user.city': 'Vorkappelen',
+            'ogg.user.country': 'Schweiz',
+            'ogg.user.department': 'Staatskanzlei',
+            'ogg.user.department_abbr': 'SK',
+            'ogg.user.description': 'nix',
+            'ogg.user.directorate': 'Staatsarchiv',
+            'ogg.user.directorate_abbr': 'Arch',
+            'ogg.user.email': 'foo@example.com',
+            'ogg.user.email2': 'bar@example.com',
+            'ogg.user.firstname': u'K\xe4thi',
+            'ogg.user.lastname': u'B\xe4rfuss',
+            'ogg.user.phone_fax': '012 34 56 77',
+            'ogg.user.phone_mobile': '012 34 56 76',
+            'ogg.user.phone_office': '012 34 56 78',
+            'ogg.user.salutation': 'Prof. Dr.',
+            'ogg.user.title': u'B\xe4rfuss K\xe4thi',
+            'ogg.user.url': 'http://www.example.com',
+            'ogg.user.userid': 'kathi.barfuss',
+            'ogg.user.zip_code': '1234',
+            }
+
+        with TemporaryDocFile(document.file) as tmpfile:
+            self.assertItemsEqual(
+                expected_doc_properties.items(),
+                read_properties(tmpfile.path))
+        self.assert_doc_properties_updated_journal_entry_generated(document, self.regular_user)
+
+
+class TestDocumentWithTemplateFormWithContacts(FunctionalTestCase):
     document_date = datetime(2015, 9, 28, 0, 0)
 
     expected_doc_properties = {
-         'Document.ReferenceNumber': 'Client1 / 1 / 4',
-         'Document.SequenceNumber': '4',
-         'Dossier.ReferenceNumber': 'Client1 / 1',
-         'Dossier.Title': 'My Dossier',
-         'User.FullName': 'Test User',
-         'User.ID': TEST_USER_ID,
-         'ogg.document.document_date': document_date,
-         'ogg.document.reference_number': 'Client1 / 1 / 4',
-         'ogg.document.sequence_number': '4',
-         'ogg.document.title': 'Test Docx',
-         'ogg.document.version_number': 0,
-         'ogg.dossier.reference_number': 'Client1 / 1',
-         'ogg.dossier.sequence_number': '1',
-         'ogg.dossier.title': 'My Dossier',
-         'ogg.user.email': 'test@example.org',
-         'ogg.user.firstname': 'User',
-         'ogg.user.lastname': 'Test',
-         'ogg.user.title': 'Test User',
-         'ogg.user.userid': TEST_USER_ID
-    }
+        'Document.ReferenceNumber': 'Client1 / 1 / 2',
+        'Document.SequenceNumber': '2',
+        'Dossier.ReferenceNumber': 'Client1 / 1',
+        'Dossier.Title': 'My Dossier',
+        'User.FullName': 'Test User',
+        'User.ID': TEST_USER_ID,
+        'ogg.document.document_date': document_date,
+        'ogg.document.reference_number': 'Client1 / 1 / 2',
+        'ogg.document.sequence_number': '2',
+        'ogg.document.title': 'Test Docx',
+        'ogg.document.version_number': 0,
+        'ogg.dossier.reference_number': 'Client1 / 1',
+        'ogg.dossier.sequence_number': '1',
+        'ogg.dossier.title': 'My Dossier',
+        'ogg.user.email': 'test@example.org',
+        'ogg.user.firstname': 'User',
+        'ogg.user.lastname': 'Test',
+        'ogg.user.title': 'Test User',
+        'ogg.user.userid': TEST_USER_ID,
+        }
 
     def setUp(self):
-        super(TestDocumentWithTemplateForm, self).setUp()
+        super(TestDocumentWithTemplateFormWithContacts, self).setUp()
+        api.portal.set_registry_record('create_doc_properties', True, interface=ITemplateFolderProperties)
+        api.portal.set_registry_record('is_feature_enabled', True, interface=IContactSettings)
+
         self.setup_fullname(fullname='Peter')
-
-        registry = getUtility(IRegistry)
-        self.props = registry.forInterface(ITemplateFolderProperties)
-        self.props.create_doc_properties = True
-
         self.modification_date = datetime(2012, 12, 28)
-
         self.templatefolder = create(Builder('templatefolder'))
-        self.template_a = create(Builder('document')
-                                 .titled('Template A')
-                                 .with_dummy_content()
-                                 .within(self.templatefolder)
-                                 .with_dummy_content()
-                                 .with_modification_date(self.modification_date))
-        self.template_b = create(Builder('document')
-                                 .titled('Template B')
-                                 .within(self.templatefolder)
-                                 .with_dummy_content()
-                                 .with_modification_date(self.modification_date))
-        self.dossier = create(Builder('dossier').titled(u'My Dossier'))
 
-        self.template_b_token = _make_token(self.template_b)
+        self.template_word = create(
+            Builder('document')
+            .titled('Word Docx template')
+            .within(self.templatefolder)
+            .with_asset_file('without_custom_properties.docx'),
+            )
+
+        self.dossier = create(Builder('dossier').titled(u'My Dossier'))
+        self.peter = create(Builder('person').having(firstname=u'Peter', lastname=u'M\xfcller'))
 
     def assert_doc_properties_updated_journal_entry_generated(self, document):
         entry = get_journal_entry(document)
@@ -100,182 +348,70 @@ class TestDocumentWithTemplateForm(FunctionalTestCase):
         self.assertEqual(TEST_USER_ID, entry['actor'])
         self.assertEqual('', entry['comments'])
 
-    @browsing
-    def test_templates_are_sorted_alphabetically_ascending(self, browser):
-        create(Builder('document')
-               .titled('AAA Template')
-               .within(self.templatefolder)
-               .with_dummy_content()
-               .with_modification_date(datetime(2010, 12, 28)))
-
-        browser.login().open(self.dossier, view='document_with_template')
-        self.assertEquals(
-            [{'': '',
-              'Creator': 'test_user_1_',
-              'Modified': '28.12.2010',
-              'Title': 'AAA Template'},
-
-             {'': '',
-              'Creator': 'test_user_1_',
-              'Modified': '28.12.2012',
-              'Title': 'Template A'},
-
-             {'': '',
-              'Creator': 'test_user_1_',
-              'Modified': '28.12.2012',
-              'Title': 'Template B'}],
-            browser.css('table.listing').first.dicts())
-
-    @browsing
-    def test_form_list_all_templates(self, browser):
-        browser.login().open(self.dossier, view='document_with_template')
-        self.assertEquals(
-            [{'': '',
-              'Creator': 'test_user_1_',
-              'Modified': '28.12.2012',
-              'Title': 'Template A'},
-
-             {'': '',
-              'Creator': 'test_user_1_',
-              'Modified': '28.12.2012',
-              'Title': 'Template B'}],
-            browser.css('table.listing').first.dicts())
-
-    @browsing
-    def test_template_list_includes_nested_templates(self, browser):
-        subtemplatefolder = create(Builder('templatefolder')
-                                    .within(self.templatefolder))
-        create(Builder('document')
-               .titled('Template C')
-               .within(subtemplatefolder)
-               .with_dummy_content()
-               .with_modification_date(self.modification_date))
-
-        browser.login().open(self.dossier, view='document_with_template')
-
-        self.assertEquals(
-            [{'': '',
-              'Creator': 'test_user_1_',
-              'Modified': '28.12.2012',
-              'Title': 'Template A'},
-             {'': '',
-              'Creator': 'test_user_1_',
-              'Modified': '28.12.2012',
-              'Title': 'Template B'},
-             {'': '',
-              'Creator': 'test_user_1_',
-              'Modified': '28.12.2012',
-              'Title': 'Template C'}],
-
-            browser.css('table.listing').first.dicts())
-
-    @browsing
-    def test_form_does_not_inlcude_participants_with_disabled_feature(self, browser):
-        browser.login().open(self.dossier, view='document_with_template')
-
-        # The CheckBoxWidget is rendered with two labels (only in testing).
-        # The reason for that is a wrong widget renderer adapter lookup because
-        # of the stacked globalregistry (see plone.testing.zca: pushGlobalRegistry
-        # for more information).
-        self.assertEqual([u'Template', u'Title', u'Edit after creation'],
-                         browser.css('#form label').text)
-
-    @browsing
-    def test_cancel_redirects_to_the_dossier(self, browser):
-        browser.login().open(self.dossier, view='document_with_template')
-        browser.find('Cancel').click()
-        self.assertEquals(self.dossier, browser.context)
-        self.assertEquals('tabbed_view', plone.view())
-
-    @browsing
-    def test_save_redirects_to_the_dossiers_document_tab(self, browser):
-        browser.login().open(self.dossier, view='document_with_template')
-        browser.fill({'form.widgets.template': self.template_b_token,
-                      'Title': 'Test Document',
-                      'Edit after creation': False}).save()
-
-        self.assertEquals(self.dossier, browser.context)
-        self.assertEquals(self.dossier.absolute_url() + '#documents',
-                          browser.url)
-
-    @browsing
-    def test_new_document_is_titled_with_the_form_value(self, browser):
-        browser.login().open(self.dossier, view='document_with_template')
-        browser.fill({'form.widgets.template': self.template_b_token,
-                      'Title': 'Test Document'}).save()
-
-        document = self.dossier.listFolderContents()[0]
-
-        self.assertEquals('Test Document', document.title)
-
-    @browsing
-    def test_new_document_values_are_filled_with_default_values(self, browser):
-        browser.login().open(self.dossier, view='document_with_template')
-        browser.fill({'form.widgets.template': self.template_b_token,
-                      'Title': 'Test Document'}).save()
-
-        document = self.dossier.listFolderContents()[0]
-        self.assertEquals(date.today(), document.document_date)
-        self.assertEquals(u'privacy_layer_no', document.privacy_layer)
-
-    @browsing
-    def test_file_of_the_new_document_is_a_copy_of_the_template(self, browser):
-        browser.login().open(self.dossier, view='document_with_template')
-        browser.fill({'form.widgets.template': self.template_b_token,
-                      'Title': 'Test Document'}).save()
-
-        document = self.dossier.listFolderContents()[0]
-
-        self.assertEquals(self.template_b.file.data, document.file.data)
-        self.assertNotEquals(self.template_b.file, document.file)
+    @staticmethod
+    def _make_token(document):
+        intids = getUtility(IIntIds)
+        return str(intids.getId(document))
 
     @browsing
     def test_contact_recipient_properties_are_added(self, browser):
-        api.portal.set_registry_record(
-            'is_feature_enabled', True, interface=IContactSettings)
+        address1 = create(
+            Builder('address')
+            .for_contact(self.peter)
+            .labeled(u'Home')
+            .having(
+                street=u'Musterstrasse 283',
+                zip_code=u'1234',
+                city=u'Hinterkappelen',
+                country=u'Schweiz',
+                ),
+            )
 
-        template_word = create(Builder('document')
-                               .titled('Word Docx template')
-                               .within(self.templatefolder)
-                               .with_asset_file('without_custom_properties.docx'))
-        peter = create(Builder('person')
-                       .having(firstname=u'Peter', lastname=u'M\xfcller'))
-        address1 = create(Builder('address')
-                          .for_contact(peter)
-                          .labeled(u'Home')
-                          .having(street=u'Musterstrasse 283',
-                                  zip_code=u'1234',
-                                  city=u'Hinterkappelen',
-                                  country=u'Schweiz'))
-        create(Builder('address')
-               .for_contact(peter)
-               .labeled(u'Home')
-               .having(street=u'Hauptstrasse 1', city=u'Vorkappelen'))
-        mailaddress = create(Builder('mailaddress')
-                             .for_contact(peter)
-                             .having(address=u'foo@example.com'))
-        phonenumber = create(Builder('phonenumber')
-                             .for_contact(peter)
-                             .having(phone_number=u'1234 123 123'))
-        url = create(Builder('url')
-                     .for_contact(peter)
-                     .having(url=u'http://www.example.com'))
+        create(
+            Builder('address')
+            .for_contact(self.peter)
+            .labeled(u'Home')
+            .having(
+                street=u'Hauptstrasse 1',
+                city=u'Vorkappelen',
+                ),
+            )
+
+        mailaddress = create(
+            Builder('mailaddress')
+            .for_contact(self.peter)
+            .having(address=u'foo@example.com'),
+            )
+
+        phonenumber = create(
+            Builder('phonenumber')
+            .for_contact(self.peter)
+            .having(phone_number=u'1234 123 123'),
+            )
+
+        url = create(
+            Builder('url')
+            .for_contact(self.peter)
+            .having(url=u'http://www.example.com'),
+            )
 
         with freeze(self.document_date):
             # submit first wizard step
             browser.login().open(self.dossier, view='document_with_template')
-            browser.fill({'form.widgets.template': _make_token(template_word),
-                          'Title': 'Test Docx'})
+            browser.fill({
+                'form.widgets.template': self._make_token(self.template_word),
+                'Title': 'Test Docx',
+                })
             form = browser.find_form_by_field('Recipient')
-            form.find_widget('Recipient').fill(get_contacts_token(peter))
+            form.find_widget('Recipient').fill(get_contacts_token(self.peter))
             form.save()
             # submit second wizard step
-            browser.fill(
-                {'form.widgets.address': str(address1.address_id),
-                 'form.widgets.mail_address': str(mailaddress.mailaddress_id),
-                 'form.widgets.phonenumber': str(phonenumber.phone_number_id),
-                 'form.widgets.url': str(url.url_id)}
-            ).save()
+            browser.fill({
+                'form.widgets.address': str(address1.address_id),
+                'form.widgets.mail_address': str(mailaddress.mailaddress_id),
+                'form.widgets.phonenumber': str(phonenumber.phone_number_id),
+                'form.widgets.url': str(url.url_id),
+                }).save()
 
         document = self.dossier.listFolderContents()[0]
         self.assertEquals(u'test-docx.docx', document.file.filename)
@@ -291,64 +427,78 @@ class TestDocumentWithTemplateForm(FunctionalTestCase):
             'ogg.recipient.email.address': u'foo@example.com',
             'ogg.recipient.phone.number': u'1234 123 123',
             'ogg.recipient.url.url': u'http://www.example.com',
-        }
+            }
         expected_person_properties.update(self.expected_doc_properties)
 
         with TemporaryDocFile(document.file) as tmpfile:
-            self.assertItemsEqual(
-                expected_person_properties.items(),
-                read_properties(tmpfile.path))
+            self.assertItemsEqual(expected_person_properties.items(), read_properties(tmpfile.path))
         self.assert_doc_properties_updated_journal_entry_generated(document)
 
     @browsing
     def test_org_role_recipient_properties_are_added(self, browser):
-        api.portal.set_registry_record(
-            'is_feature_enabled', True, interface=IContactSettings)
+        organization = create(
+            Builder('organization')
+            .having(name=u'Meier AG'),
+            )
 
-        template_word = create(Builder('document')
-                               .titled('Word Docx template')
-                               .within(self.templatefolder)
-                               .with_asset_file('without_custom_properties.docx'))
-        peter = create(Builder('person')
-                       .having(firstname=u'Peter', lastname=u'M\xfcller'))
-        organization = create(Builder('organization')
-                              .having(name=u'Meier AG'))
-        org_role = create(Builder('org_role').having(
-            person=peter, organization=organization, function=u'cheffe'))
+        org_role = create(
+            Builder('org_role')
+            .having(
+                person=self.peter,
+                organization=organization,
+                function=u'cheffe',
+                ),
+            )
 
-        create(Builder('address')
-               .for_contact(organization)
-               .labeled(u'Home')
-               .having(street=u'Musterstrasse 283',
-                       zip_code=u'1234',
-                       city=u'Hinterkappelen',
-                       country=u'Schweiz'))
-        mailaddress = create(Builder('mailaddress')
-                             .for_contact(organization)
-                             .having(address=u'foo@example.com'))
-        phonenumber = create(Builder('phonenumber')
-                             .for_contact(peter)
-                             .having(phone_number=u'1234 123 123'))
-        url = create(Builder('url')
-                     .for_contact(organization)
-                     .having(url=u'http://www.example.com'))
+        create(
+            Builder('address')
+            .for_contact(organization)
+            .labeled(u'Home')
+            .having(
+                street=u'Musterstrasse 283',
+                zip_code=u'1234',
+                city=u'Hinterkappelen',
+                country=u'Schweiz',
+                ),
+            )
+
+        mailaddress = create(
+            Builder('mailaddress')
+            .for_contact(organization)
+            .having(address=u'foo@example.com'),
+            )
+
+        phonenumber = create(
+            Builder('phonenumber')
+            .for_contact(self.peter)
+            .having(phone_number=u'1234 123 123'),
+            )
+
+        url = create(
+            Builder('url')
+            .for_contact(organization)
+            .having(url=u'http://www.example.com'),
+            )
+
         address_id = org_role.addresses[0].address_id
 
         with freeze(self.document_date):
             # submit first wizard step
             browser.login().open(self.dossier, view='document_with_template')
-            browser.fill({'form.widgets.template': _make_token(template_word),
-                          'Title': 'Test Docx'})
+            browser.fill({
+                'form.widgets.template': self._make_token(self.template_word),
+                'Title': 'Test Docx',
+                })
             form = browser.find_form_by_field('Recipient')
             form.find_widget('Recipient').fill(get_contacts_token(org_role))
             form.save()
             # submit second wizard step
-            browser.fill(
-                {'form.widgets.address': address_id,
-                 'form.widgets.mail_address': str(mailaddress.mailaddress_id),
-                 'form.widgets.phonenumber': str(phonenumber.phone_number_id),
-                 'form.widgets.url': str(url.url_id)}
-            ).save()
+            browser.fill({
+                'form.widgets.address': address_id,
+                'form.widgets.mail_address': str(mailaddress.mailaddress_id),
+                'form.widgets.phonenumber': str(phonenumber.phone_number_id),
+                'form.widgets.url': str(url.url_id),
+                }).save()
 
         document = self.dossier.listFolderContents()[0]
         self.assertEquals(u'test-docx.docx', document.file.filename)
@@ -365,45 +515,39 @@ class TestDocumentWithTemplateForm(FunctionalTestCase):
             'ogg.recipient.email.address': u'foo@example.com',
             'ogg.recipient.phone.number': u'1234 123 123',
             'ogg.recipient.url.url': u'http://www.example.com',
-        }
+            }
         expected_org_role_properties.update(self.expected_doc_properties)
 
         with TemporaryDocFile(document.file) as tmpfile:
-            self.assertItemsEqual(
-                expected_org_role_properties.items(),
-                read_properties(tmpfile.path))
+            self.assertItemsEqual(expected_org_role_properties.items(), read_properties(tmpfile.path))
         self.assert_doc_properties_updated_journal_entry_generated(document)
 
     @browsing
     def test_ogds_user_recipient_properties_are_added(self, browser):
-        api.portal.set_registry_record(
-            'is_feature_enabled', True, interface=IContactSettings)
-
-        template_word = create(Builder('document')
-                               .titled('Word Docx template')
-                               .within(self.templatefolder)
-                               .with_asset_file('without_custom_properties.docx'))
-
-        ogds_user = create(Builder('ogds_user')
-                           .id('peter')
-                           .having(**OGDS_USER_ATTRIBUTES)
-                           .as_contact_adapter())
+        ogds_user = create(
+            Builder('ogds_user')
+            .id('ogds-peter')
+            .having(**OGDS_USER_ATTRIBUTES)
+            .as_contact_adapter(),
+            )
 
         with freeze(self.document_date):
             # submit first wizard step
             browser.login().open(self.dossier, view='document_with_template')
-            browser.fill({'form.widgets.template': _make_token(template_word),
-                          'Title': 'Test Docx'})
+            browser.fill({
+                'form.widgets.template': self._make_token(self.template_word),
+                'Title': 'Test Docx',
+                })
             form = browser.find_form_by_field('Recipient')
             form.find_widget('Recipient').fill(get_contacts_token(ogds_user))
             form.save()
             # submit second wizard step
-            browser.fill(
-                {'form.widgets.address': '{}_1'.format(ogds_user.id),
-                 'form.widgets.mail_address': '{}_2'.format(ogds_user.id),
-                 'form.widgets.phonenumber': '{}_3'.format(ogds_user.id),
-                 'form.widgets.url': '{}_1'.format(ogds_user.id)}
-            ).save()
+            browser.fill({
+                'form.widgets.address': '{}_1'.format(ogds_user.id),
+                'form.widgets.mail_address': '{}_2'.format(ogds_user.id),
+                'form.widgets.phonenumber': '{}_3'.format(ogds_user.id),
+                'form.widgets.url': '{}_1'.format(ogds_user.id),
+                }).save()
 
         document = self.dossier.listFolderContents()[0]
         self.assertEquals(u'test-docx.docx', document.file.filename)
@@ -425,100 +569,29 @@ class TestDocumentWithTemplateForm(FunctionalTestCase):
         expected_org_role_properties.update(self.expected_doc_properties)
 
         with TemporaryDocFile(document.file) as tmpfile:
-            self.assertItemsEqual(
-                expected_org_role_properties.items(),
-                read_properties(tmpfile.path))
+            self.assertItemsEqual(expected_org_role_properties.items(), read_properties(tmpfile.path))
         self.assert_doc_properties_updated_journal_entry_generated(document)
 
-    @browsing
-    def test_properties_are_added_when_created_from_template_with_doc_properties(self, browser):
-        template_word = create(Builder('document')
-                               .titled('Word Docx template')
-                               .within(self.templatefolder)
-                               .with_asset_file('with_custom_properties.docx'))
 
-        with freeze(self.document_date):
-            browser.login().open(self.dossier, view='document_with_template')
-            browser.fill({'form.widgets.template': _make_token(template_word),
-                          'Title': 'Test Docx'}).save()
-
-        document = self.dossier.listFolderContents()[0]
-        self.assertEquals(u'test-docx.docx', document.file.filename)
-        with TemporaryDocFile(document.file) as tmpfile:
-            self.assertItemsEqual(
-                self.expected_doc_properties.items() + [('Test', 'Peter')],
-                read_properties(tmpfile.path))
-        self.assert_doc_properties_updated_journal_entry_generated(document)
-
-    @browsing
-    def test_properties_are_added_when_created_from_template_without_doc_properties(self, browser):
-        template_word = create(Builder('document')
-                               .titled('Word Docx template')
-                               .within(self.templatefolder)
-                               .with_asset_file('without_custom_properties.docx'))
-
-        with freeze(self.document_date):
-            browser.login().open(self.dossier, view='document_with_template')
-            browser.fill({'form.widgets.template': _make_token(template_word),
-                          'Title': 'Test Docx'}).save()
-
-        document = self.dossier.listFolderContents()[0]
-        self.assertEquals(u'test-docx.docx', document.file.filename)
-        with TemporaryDocFile(document.file) as tmpfile:
-            self.assertItemsEqual(
-                self.expected_doc_properties.items(),
-                read_properties(tmpfile.path))
-        self.assert_doc_properties_updated_journal_entry_generated(document)
-
-    @browsing
-    def test_doc_properties_are_not_created_when_disabled(self, browser):
-        self.props.create_doc_properties = False
-        template_word = create(Builder('document')
-                               .titled('Word Docx template')
-                               .within(self.templatefolder)
-                               .with_asset_file('without_custom_properties.docx'))
-
-        browser.login().open(self.dossier, view='document_with_template')
-        browser.fill({'form.widgets.template': _make_token(template_word),
-                      'Title': 'Test Docx'}).save()
-
-        document = self.dossier.listFolderContents()[0]
-        self.assertEquals(u'test-docx.docx', document.file.filename)
-        with TemporaryDocFile(document.file) as tmpfile:
-            self.assertItemsEqual([], read_properties(tmpfile.path))
-
-    @browsing
-    def test_templates_without_a_file_are_not_listed(self, browser):
-        create(Builder('document')
-               .titled(u'Template with no content')
-               .within(self.templatefolder))
-
-        browser.login().open(self.dossier, view='document_with_template')
-
-        self.assertEquals(
-            ['Template A', 'Template B'],
-            [row.get('Title')
-             for row in browser.css('table.listing').first.dicts()])
+class TestDocumentWithTemplateFormWithOfficeConnector(IntegrationTestCase):
+    features = (
+        'officeconnector-checkout',
+        )
 
     @browsing
     def test_opens_doc_with_officeconnector_when_feature_flaged(self, browser):
-        api.portal.set_registry_record('direct_checkout_and_edit_enabled',
-                                       True,
-                                       interface=IOfficeConnectorSettings)
-
-        template_word = create(Builder('document')
-                               .titled('Word Docx template')
-                               .within(self.templatefolder)
-                               .with_dummy_content())
-
-        browser.login().open(self.dossier, view='document_with_template')
-        browser.fill({'form.widgets.template': _make_token(template_word),
-                      'Title': 'Test OfficeConnector'}).save()
+        self.login(self.regular_user, browser)
+        browser.open(self.dossier, view='document_with_template')
+        browser.fill({
+            'form.widgets.template': str(getUtility(IIntIds).getId(self.normal_template)),
+            'Title': 'Test OfficeConnector',
+            }).save()
 
         self.assertIn(
             "'oc:",
             browser.css('script.redirector').first.text,
-            'OfficeConnector redirection script not found')
+            'OfficeConnector redirection script not found',
+            )
 
 
 class TestTemplateFolder(FunctionalTestCase):
@@ -692,15 +765,6 @@ class TestTemplateFolderUtility(FunctionalTestCase):
                .within(templatefolder))
 
         self.assertEquals(templatefolder, get_template_folder())
-
-
-OVERVIEW_TAB = 'tabbedview_view-overview'
-DOCUMENT_TAB = 'tabbedview_view-documents'
-TRASH_TAB = 'tabbedview_view-trash'
-JOURNAL_TAB = 'tabbedview_view-journal'
-INFO_TAB = 'tabbedview_view-sharing'
-SABLONTEMPLATES_TAB = 'tabbedview_view-sablontemplates'
-PROPOSALTEMPLATES_TAB = 'tabbedview_view-proposaltemplates'
 
 
 class TestTemplateFolderListings(IntegrationTestCase):

--- a/opengever/dossier/tests/test_templatefolder.py
+++ b/opengever/dossier/tests/test_templatefolder.py
@@ -61,6 +61,7 @@ class TestDocumentWithTemplateFormPlain(IntegrationTestCase):
         # for more information).
         expected_labels = [
             u'Template',
+            u'Filter',
             u'Title',
             u'Edit after creation',
             ]

--- a/opengever/mail/tests/test_indexers.py
+++ b/opengever/mail/tests/test_indexers.py
@@ -47,4 +47,4 @@ class TestMailIndexers(IntegrationTestCase):
             u'IDocumentSchema',
             )
 
-        self.assertEquals('Client1 1.1 / 1 / 15 15', extender())
+        self.assertEquals('Client1 1.1 / 1 / 20 20', extender())

--- a/opengever/meeting/browser/proposalforms.py
+++ b/opengever/meeting/browser/proposalforms.py
@@ -96,6 +96,7 @@ class IAddProposal(IProposal):
         title=_('label_proposal_template', default=u'Proposal template'),
         vocabulary='opengever.meeting.ProposalTemplatesForCommitteeVocabulary',
         required=True,
+        show_filter=True,
         vocabulary_depends_on=['form.widgets.committee'],
         columns=(
             {'column': 'title',

--- a/opengever/meeting/tests/test_zipexport.py
+++ b/opengever/meeting/tests/test_zipexport.py
@@ -68,7 +68,7 @@ class TestZipExportWithWord(IntegrationTestCase):
                 'title': u'\xc4nderungen am Personalreglement',
             }],
             'committee': {
-                'oguid': u'plone:1008293300',
+                'oguid': u'plone:1009233300',
                 'title': u'Rechnungspr\xfcfungskommission',
             },
             'end': u'2016-09-12T17:00:00+00:00',
@@ -126,7 +126,7 @@ class TestZipExportWithWord(IntegrationTestCase):
                      },
                      'title': u'\xc4nderungen am Personalreglement'}
                  ],
-                 'committee': {'oguid': 'plone:1008293300',
+                 'committee': {'oguid': 'plone:1009233300',
                                'title': u'Rechnungspr\xfcfungskommission'},
                  'end': '2016-09-12T17:00:00+00:00',
                  'location': u'B\xfcren an der Aare',

--- a/opengever/private/tests/test_reference_number.py
+++ b/opengever/private/tests/test_reference_number.py
@@ -138,7 +138,7 @@ class TestPrivateReferenceNumber(IntegrationTestCase):
         self.login(self.regular_user, browser)
         browser.open(self.private_document)
 
-        expected_reference_number = 'P Client1 kathi-barfuss / 1 / 21'
+        expected_reference_number = 'P Client1 kathi-barfuss / 1 / 26'
         found_reference_number = browser.css('.referenceNumber .value').text[0]
 
         self.assertEqual(found_reference_number, expected_reference_number)

--- a/opengever/repository/tests/test_repositoryfolder_tabs.py
+++ b/opengever/repository/tests/test_repositoryfolder_tabs.py
@@ -99,8 +99,8 @@ class TestRepositoryFolderDocumentsTab(IntegrationTestCase):
             'Dossier': u'Vertr\xe4ge mit der kantonalen Finanzverwaltung',
             'Public Trial': 'unchecked',
             'Receipt Date': '03.01.2010',
-            'Reference Number': 'Client1 1.1 / 1 / 5',
-            'Sequence Number': '5',
+            'Reference Number': 'Client1 1.1 / 1 / 10',
+            'Sequence Number': '10',
             'Subdossier': '',
             'Title': u'Vertr\xe4gsentwurf',
             }

--- a/opengever/tabbedview/tests/test_document_listing.py
+++ b/opengever/tabbedview/tests/test_document_listing.py
@@ -19,8 +19,8 @@ class TestDocumentListing(IntegrationTestCase):
             'Document Date': '03.01.2010',
             'Public Trial': 'unchecked',
             'Receipt Date': '03.01.2010',
-            'Reference Number': 'Client1 1.1 / 1 / 5',
-            'Sequence Number': '5',
+            'Reference Number': 'Client1 1.1 / 1 / 10',
+            'Sequence Number': '10',
             'Subdossier': '',
             'Title': u'Vertr\xe4gsentwurf',
             }

--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -41,25 +41,33 @@ class OpengeverContentFixture(object):
             'manager': ('user', SITE_OWNER_NAME),
             }
 
-        with self.freeze_at_hour(5):
+        with self.freeze_at_hour(4):
             self.create_units()
 
-        with self.freeze_at_hour(6):
+        with self.freeze_at_hour(5):
             self.create_users()
 
-        with self.freeze_at_hour(7):
+        with self.freeze_at_hour(6):
             self.create_teams()
             self.create_contacts()
 
-        with self.freeze_at_hour(8):
+        with self.freeze_at_hour(7):
             with self.login(self.administrator):
                 self.create_repository_tree()
+
+        with self.freeze_at_hour(8):
+            with self.login(self.administrator):
                 self.create_templates()
+
+        with self.freeze_at_hour(9):
+            with self.login(self.administrator):
+                self.create_special_templates()
+                self.create_subtemplates()
 
                 with self.features('meeting'):
                     self.create_committees()
 
-        with self.freeze_at_hour(9):
+        with self.freeze_at_hour(10):
             with self.login(self.administrator):
                 self.create_inbox()
                 self.create_workspace_root()
@@ -361,21 +369,51 @@ class OpengeverContentFixture(object):
 
     @staticuid()
     def create_templates(self):
-        templates = self.register('templates', create(
+        self.templates = self.register('templates', create(
             Builder('templatefolder')
             .titled(u'Vorlagen')
-            .having(id='vorlagen')))
-        templates.manage_setLocalRoles(self.org_unit.users_group_id,
-                                       ['Reader'])
-        templates.manage_setLocalRoles(self.administrator.getId(),
-                                       ['Reader', 'Contributor', 'Editor'])
-        templates.manage_setLocalRoles(self.dossier_responsible.getId(),
-                                       ['Reader', 'Contributor', 'Editor'])
-        templates.reindexObjectSecurity()
+            .having(id='vorlagen')
+            ))
 
+        self.templates.manage_setLocalRoles(self.org_unit.users_group_id, ['Reader'])
+        self.templates.manage_setLocalRoles(self.administrator.getId(), ['Reader', 'Contributor', 'Editor'])
+        self.templates.manage_setLocalRoles(self.dossier_responsible.getId(), ['Reader', 'Contributor', 'Editor'])
+        self.templates.reindexObjectSecurity()
+
+        self.register('asset_template', create(
+            Builder('document')
+            .titled(u'T\xc3\xb6mpl\xc3\xb6te Ohne')
+            .with_asset_file('without_custom_properties.docx')
+            .within(self.templates)
+            ))
+
+        self.register('normal_template', create(
+            Builder('document')
+            .titled(u'T\xc3\xb6mpl\xc3\xb6te Normal')
+            .with_dummy_content()
+            .within(self.templates)
+            ))
+
+        self.register('empty_template', create(
+            Builder('document')
+            .titled(u'T\xc3\xb6mpl\xc3\xb6te Leer')
+            .within(self.templates)
+            ))
+
+        with self.features('doc-properties', ):
+            self.register('docprops_template', create(
+                Builder('document')
+                .titled(u'T\xc3\xb6mpl\xc3\xb6te Mit')
+                .with_asset_file('with_custom_properties.docx')
+                .with_modification_date(datetime(2010, 12, 28))
+                .within(self.templates)
+                ))
+
+    @staticuid()
+    def create_special_templates(self):
         self.sablon_template = self.register('sablon_template', create(
             Builder('sablontemplate')
-            .within(templates)
+            .within(self.templates)
             .with_asset_file('sablon_template.docx')
             ))
 
@@ -384,14 +422,14 @@ class OpengeverContentFixture(object):
                 Builder('proposaltemplate')
                 .titled(u'Geb\xfchren')
                 .with_asset_file(u'vertragsentwurf.docx')
-                .within(templates)
+                .within(self.templates)
                 ))
 
         self.tasktemplatefolder = self.register('tasktemplatefolder', create(
             Builder('tasktemplatefolder')
             .titled(u'Verfahren Neuanstellung')
             .in_state('tasktemplatefolder-state-activ')
-            .within(templates)
+            .within(self.templates)
             ))
 
         self.tasktemplate = self.register('tasktemplate', create(
@@ -415,13 +453,34 @@ class OpengeverContentFixture(object):
                 'comments': 'this is very special',
                 'filing_prefix': 'department',
                 })
-            .within(templates)
+            .within(self.templates)
             ))
 
         self.subdossiertemplate = self.register('subdossiertemplate', create(
             Builder('dossiertemplate')
             .titled(u'Anfragen')
             .within(self.dossiertemplate)
+            ))
+
+    @staticuid()
+    def create_subtemplates(self):
+        subtemplates = self.register('subtemplates', create(
+            Builder('templatefolder')
+            .titled(u'Vorlagen neu')
+            .having(id='vorlagen-neu')
+            .within(self.templates)
+            ))
+        subtemplates.manage_setLocalRoles(self.org_unit.users_group_id, ['Reader'])
+        subtemplates.manage_setLocalRoles(self.administrator.getId(), ['Reader', 'Contributor', 'Editor'])
+        subtemplates.manage_setLocalRoles(self.dossier_responsible.getId(), ['Reader', 'Contributor', 'Editor'])
+        subtemplates.reindexObjectSecurity()
+
+        self.register('subtemplate', create(
+            Builder('document')
+            .titled(u'T\xc3\xb6mpl\xc3\xb6te Sub')
+            .with_dummy_content()
+            .with_modification_date(datetime(2020, 2, 29))
+            .within(subtemplates)
             ))
 
     @staticuid()

--- a/opengever/testing/tests/test_fixtures.py
+++ b/opengever/testing/tests/test_fixtures.py
@@ -18,12 +18,12 @@ class TestTestingFixture(IntegrationTestCase):
 
     def test_repository_root_has_static_creation_date(self):
         self.login(self.regular_user)
-        self.assertEquals(DateTime('2016/08/31 09:01:33 GMT+2'),
+        self.assertEquals(DateTime('2016/08/31 08:01:33 GMT+2'),
                           self.repository_root.created())
 
     def test_repository_root_has_static_intid(self):
         self.login(self.regular_user)
-        self.assertEquals(1008013300,
+        self.assertEquals(1007013300,
                           getUtility(IIntIds).getId(self.repository_root))
 
     def test_dossier_has_static_intid(self):


### PR DESCRIPTION
* Ported the template form tests to integration tests where sensible and currently possible
* Implemented a template-side JS filter field for `TableChoice`
* The JS filter is active for:
  - Document templates
  - Dossier templates
  - Proposals

Theming PR: https://github.com/4teamwork/plonetheme.teamraum/pull/622

![filter](https://user-images.githubusercontent.com/935317/37787410-20e6b7fc-2dff-11e8-9d4d-2056eb7d653d.gif)

The filter is also visible for proposals and dossier-templates:

![screen shot 2018-03-27 at 11 05 32](https://user-images.githubusercontent.com/736583/37957703-e9dc781a-31ae-11e8-88d8-396432531d3e.png)
![screen shot 2018-03-27 at 11 05 51](https://user-images.githubusercontent.com/736583/37957704-e9facc3e-31ae-11e8-880b-a7bedf950290.png)




Closes https://github.com/4teamwork/opengever.core/issues/3189