### PR TITLE
Only allow to add contacts when `IContactSettings.is_feature_enabled` is disabled

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2018.2.0 (unreleased)
 ---------------------
 
+- Only allow to add contacts when IContactSettings.is_feature_enabled is disabled [njohner]
 - Cleanup leftovers from ICreatorAware interface in index [njohner]
 - Update policy template to set flags for new features [njohner]
 - Add French translations of the Ordnungssystem in the example content [njohner]

--- a/opengever/contact/browser/configure.zcml
+++ b/opengever/contact/browser/configure.zcml
@@ -20,6 +20,12 @@
       template="templates/contact_view.pt"
       />
 
+  <adapter
+      provides="zope.publisher.interfaces.browser.IBrowserPage"
+      factory=".contact_forms.ContactAddView"
+      name="opengever.contact.contact"
+      />
+
   <browser:page
       name="tabbedview_view-local"
       for="plone.dexterity.interfaces.IDexterityContainer"

--- a/opengever/contact/browser/contact_forms.py
+++ b/opengever/contact/browser/contact_forms.py
@@ -1,0 +1,23 @@
+from plone.dexterity.browser.add import DefaultAddForm
+from plone.dexterity.browser.add import DefaultAddView
+from plone.dexterity.interfaces import IDexterityFTI
+from Products.CMFCore.interfaces import IFolderish
+from zExceptions import Unauthorized
+from zope.component import adapter
+from zope.component import getUtility
+from zope.publisher.interfaces.browser import IDefaultBrowserLayer
+
+
+class ContactAddForm(DefaultAddForm):
+
+    def render(self):
+        fti = getUtility(IDexterityFTI, name=self.portal_type)
+        if fti not in self.context.allowedContentTypes():
+            raise Unauthorized
+
+        return super(ContactAddForm, self).render()
+
+
+@adapter(IFolderish, IDefaultBrowserLayer, IDexterityFTI)
+class ContactAddView(DefaultAddView):
+    form = ContactAddForm

--- a/opengever/contact/contactfolder.py
+++ b/opengever/contact/contactfolder.py
@@ -1,4 +1,5 @@
 from opengever.base.behaviors.translated_title import TranslatedTitleMixin
+from opengever.contact import is_contact_feature_enabled
 from opengever.contact.interfaces import IContactFolder
 from opengever.contact.models import Contact
 from opengever.ogds.base.wrapper import TeamWrapper
@@ -43,3 +44,13 @@ class ContactFolder(Container, TranslatedTitleMixin):
         if default is _marker:
             raise KeyError(id_)
         return default
+
+    def allowedContentTypes(self, *args, **kwargs):
+        types = super(ContactFolder, self).allowedContentTypes(*args, **kwargs)
+
+        def filter_type(fti):
+            if fti.id == "opengever.contact.contact":
+                return not is_contact_feature_enabled()
+            return True
+
+        return filter(filter_type, types)

--- a/opengever/contact/tests/test_contact.py
+++ b/opengever/contact/tests/test_contact.py
@@ -1,11 +1,14 @@
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
+from ftw.testbrowser import InsufficientPrivileges
 from ftw.testbrowser.pages import factoriesmenu
+from opengever.contact.interfaces import IContactSettings
 from opengever.testing import add_languages
 from opengever.testing import FunctionalTestCase
 from opengever.testing import obj2brain
 from plone import api
+import transaction
 
 
 class TestContact(FunctionalTestCase):
@@ -30,6 +33,23 @@ class TestContact(FunctionalTestCase):
             'http://nohost/plone/opengever-contact-contactfolder/durr-hanspeter/contact_view',
             browser.url)
         self.assertEquals(u'D\xfcrr Hanspeter', browser.css('h1').first.text)
+
+    @browsing
+    def test_cannot_add_a_contact_with_contact_feature_enabled(self, browser):
+        contactfolder = create(Builder('contactfolder'))
+
+        browser.login().open(contactfolder)
+        self.assertIn('Contact', factoriesmenu.addable_types())
+        browser.visit(contactfolder, view="++add++opengever.contact.contact")
+
+        api.portal.set_registry_record(
+          'is_feature_enabled', True, interface=IContactSettings)
+        transaction.commit()
+
+        browser.open(contactfolder)
+        self.assertNotIn('Contact', factoriesmenu.addable_types())
+        with self.assertRaises(InsufficientPrivileges):
+            browser.visit(contactfolder, view="++add++opengever.contact.contact")
 
     @browsing
     def test_edit_a_contact(self, browser):


### PR DESCRIPTION
`IContactSettings.is_feature_enabled` is enabled, one should not be able to add contacts.
* implement `allowedContentTypes` to only allow `contact` when the feature is disabled
* Make the add form unavailable when the feature is enabled.

**With the feature enabled, contact is not in the add menu anymore**
![screen shot 2018-03-22 at 10 09 13](https://user-images.githubusercontent.com/7374243/37764140-2b7bc11e-2dc1-11e8-9477-c8c562e7d40b.png)

**Unauthorized is raised when directly accessing the add form**
![screen shot 2018-03-22 at 10 09 53](https://user-images.githubusercontent.com/7374243/37764184-49007838-2dc1-11e8-955e-2ee4132639a8.png)

**When the feature is disabled, contacts can be added**
![screen shot 2018-03-22 at 11 10 02](https://user-images.githubusercontent.com/7374243/37764447-039bd9b2-2dc2-11e8-82aa-73a9e04eb5a8.png)

resolves #4086 