### PR TITLE
Update object security when moving objects

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2018.2.0 (unreleased)
 ---------------------
 
+- Update object security when objects are moved (account for changes in placeful workflow). [lgraf]
 - Only allow to add contacts when IContactSettings.is_feature_enabled is disabled [njohner]
 - Cleanup leftovers from ICreatorAware interface in index [njohner]
 - Update policy template to set flags for new features [njohner]

--- a/opengever/base/configure.zcml
+++ b/opengever/base/configure.zcml
@@ -234,6 +234,12 @@
       />
 
   <subscriber
+      for="plone.dexterity.interfaces.IDexterityContent
+           zope.lifecycleevent.IObjectMovedEvent"
+      handler=".handlers.object_moved_or_added"
+      />
+
+  <subscriber
       for="ZPublisher.interfaces.IPubAfterTraversal"
       handler=".subscribers.disallow_anonymous_views_on_site_root"
       />

--- a/opengever/base/handlers.py
+++ b/opengever/base/handlers.py
@@ -1,0 +1,26 @@
+from ftw.upgrade.helpers import update_security_for
+from plone import api
+from Products.CMFCore.CMFCatalogAware import CatalogAware
+from zope.lifecycleevent import IObjectRemovedEvent
+
+
+def object_moved_or_added(context, event):
+    if IObjectRemovedEvent.providedBy(event):
+        return
+
+    # Update object security after moving or copying.
+    # Specifically, this is needed for the case where an object is moved out
+    # of a location where a Placeful Workflow Policy applies to a location
+    # where it doesn't.
+    #
+    #  Plone then no longer provides the placeful workflow for that object,
+    # but doesn't automatically update the object's security.
+    #
+    # We use ftw.upgrade's update_security_for() here to correctly
+    # recalculate security, but do the reindexing ourselves because otherwise
+    # Plone will do it recursively (unnecessarily so).
+    changed = update_security_for(context, reindex_security=False)
+    if changed:
+        catalog = api.portal.get_tool('portal_catalog')
+        catalog.reindexObject(context, idxs=CatalogAware._cmf_security_indexes,
+                              update_metadata=0)


### PR DESCRIPTION
This is to deal with the fact that Plone doesn't automatically update object security when an **object gets moved out of a location where a placeful workflow applies**.

This fixes users not having view permissions on documents that got moved out of the private area of a user.

I used `ftw.upgrade.helpers.update_security_for()` do the job of actually taking care of updating the object security as needed.

Therefore, questions for @jone 😉 :
- Is this a good idea? (is that function considered a part of the public API?)
- This function delegates to [`obj.reindexObjectSecurity()`](https://github.com/zopefoundation/Products.CMFCore/blob/2.2.10/Products/CMFCore/CMFCatalogAware.py#L93-L120), which is recursive. Do you see an issue with that (performace wise)? Currently, in the `private area`, users can only move documents (but not dossiers) anyway - so recursive doesn't really apply there. And outside the private area, object security usually doesn't change anyway when moving objects, so the reindexing is never triggered. So I think it should be ok.

**General remarks**:
I chose to *always* update object security via the handler whenever a document is moved or added. This might result in a performance penalty, but I feel this is the better solution than doing it selectively, because then it should be fixed once and for all, for all types of objects, and also possible future placeful workflows.

I measured whether there was a significant performance impact, and I couldn't find one. I moved large batches of documents out of the private area, and also moved complex dossier structures including many levels of subdossiers and tasks around in the public area - couldn't notice a difference in performance.
 

