### PR TITLE
Disallow checkin-anyway for multi-checkin action

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,9 @@ Changelog
 ---------------------
 
 - Update object security when objects are moved (account for changes in placeful workflow). [lgraf]
+- Disallow force-checkin for mutli-checkin action (table action) [njohner]
+- Make sure to warn users before they can force-checkin a document [njohner]
+- Add checkin button for force-checkin in the document actions [njohner]
 - Only allow to add contacts when IContactSettings.is_feature_enabled is disabled [njohner]
 - Cleanup leftovers from ICreatorAware interface in index [njohner]
 - Update policy template to set flags for new features [njohner]

--- a/opengever/document/checkout/manager.py
+++ b/opengever/document/checkout/manager.py
@@ -95,8 +95,11 @@ class CheckinCheckoutManager(object):
         # fire the event
         notify(ObjectCheckedOutEvent(self.context, ''))
 
-    def is_checkin_without_comment_allowed(self):
-        if self.is_checkin_allowed() and not self.is_locked():
+    def is_simple_checkin_allowed(self):
+        return self.is_checkin_allowed() and not self.is_locked()
+
+    def is_only_force_checkin_allowed(self):
+        if self.is_checkin_allowed() and self.is_locked():
             return True
         return False
 

--- a/opengever/document/tests/test_checkout.py
+++ b/opengever/document/tests/test_checkout.py
@@ -545,16 +545,7 @@ class TestCheckinViews(IntegrationTestCase):
         browser.open(self.document, view='tabbedview_view-overview')
         browser.find('Checkout and edit').click()
 
-        document2 = create(
-            Builder("document")
-            .within(self.dossier)
-            .attach_file_containing(
-                asset('example.docx').bytes(),
-                u'vertragsentwurf.docx',
-                ),
-            )
-
-        browser.open(document2, view='tabbedview_view-overview')
+        browser.open(self.subdocument, view='tabbedview_view-overview')
         browser.find('Checkout and edit').click()
 
         browser.open(
@@ -563,7 +554,7 @@ class TestCheckinViews(IntegrationTestCase):
             data={
                 'paths': [
                     obj2brain(self.document).getPath(),
-                    obj2brain(document2).getPath(),
+                    obj2brain(self.subdocument).getPath(),
                     ],
                 'checkin_documents:method': 1,
                 '_authenticator': createToken(),
@@ -578,7 +569,7 @@ class TestCheckinViews(IntegrationTestCase):
 
         browser.css('#form-buttons-button_checkin').first.click()
 
-        for doc in (self.document, document2, ):
+        for doc in (self.document, self.subdocument, ):
             manager = getMultiAdapter(
                 (doc, self.portal.REQUEST),
                 ICheckinCheckoutManager,
@@ -625,16 +616,7 @@ class TestCheckinViews(IntegrationTestCase):
         browser.open(self.document, view='tabbedview_view-overview')
         browser.find('Checkout and edit').click()
 
-        document2 = create(
-            Builder("document")
-            .within(self.dossier)
-            .attach_file_containing(
-                asset('example.docx').bytes(),
-                u'vertragsentwurf.docx',
-                ),
-            )
-
-        browser.open(document2, view='tabbedview_view-overview')
+        browser.open(self.subdocument, view='tabbedview_view-overview')
         browser.find('Checkout and edit').click()
 
         browser.open(
@@ -643,14 +625,14 @@ class TestCheckinViews(IntegrationTestCase):
             data={
                 'paths': [
                     obj2brain(self.document).getPath(),
-                    obj2brain(document2).getPath(),
+                    obj2brain(self.subdocument).getPath(),
                     ],
                 'checkin_without_comment:method': 1,
                 '_authenticator': createToken(),
                 },
             )
 
-        for doc in (self.document, document2, ):
+        for doc in (self.document, self.subdocument):
             manager = getMultiAdapter(
                 (doc, self.portal.REQUEST),
                 ICheckinCheckoutManager,

--- a/opengever/document/tests/test_force_checkin.py
+++ b/opengever/document/tests/test_force_checkin.py
@@ -49,5 +49,5 @@ class TestForceCheckin(IntegrationTestCase):
 
         browser.open(self.document, view='@@checkin_without_comment')
         assert_message("This item is being checked out by Ziegler Robert (robert.ziegler).")
-        browser.click_on('Checkin')
-        assert_message(u'You have not selected any documents.')
+
+        assert_message(u"Could not check in document Vertr\xe4gsentwurf")


### PR DESCRIPTION
* Do not check-in locked documents when the multi-checkin action is called. 
  * Display a message for each document that could not be checked-in
  * Addition of a `force` argument to methods of the checkin controller to make the use of force checkin more deliberate and clear.

Apart from the main bug fixed, another one was also fixed and tests improved:
* Correct a bug for checkin without comment. When doing a checkin without comment on a document that could not be checked-in, one would be redirected to the checkin with comment. This was intended for locked documents, but would also happen for documents that could not be checked in for other reasons (for example not checked out)
* Improved existing multi-checkin tests by better using the fixture (remove unnecessary document creation)

**Checkin from table action on two locked documents**
![screen shot 2018-03-26 at 10 02 24](https://user-images.githubusercontent.com/7374243/37893996-efb79d64-30dc-11e8-8111-c4a5a389a613.png)


resolves #4091 