### PR TITLE
Fix displaying quickupload uploadbox for template folders.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2018.2.0 (unreleased)
 ---------------------
 
+- Fix displaying quickupload uploadbox for template folders. [deiferni]
 - Homogenize eCH-0147 import/export action titles. [lgraf]
 - Update object security when objects are moved (account for changes in placeful workflow). [lgraf]
 - Disallow force-checkin for mutli-checkin action (table action) [njohner]

--- a/opengever/core/upgrades/20180328132504_fix_d_d_upload_for_template_folders/upgrade.py
+++ b/opengever/core/upgrades/20180328132504_fix_d_d_upload_for_template_folders/upgrade.py
@@ -1,0 +1,19 @@
+from ftw.upgrade import UpgradeStep
+from plone import api
+
+
+class FixDDUploadForTemplateFolders(UpgradeStep):
+    """Fix d&d upload for template folders.
+    """
+
+    def __call__(self):
+        self.reindex_object_provides()
+
+    def reindex_object_provides(self):
+        catalog = api.portal.get_tool('portal_catalog')
+        query = {'portal_type': ['opengever.dossier.templatefolder']}
+        message = "Reindex object_provides for template folders"
+
+        for obj in self.objects(query, message):
+            catalog.reindexObject(
+                obj, idxs=['object_provides'], update_metadata=False)

--- a/opengever/dossier/templatefolder/interfaces.py
+++ b/opengever/dossier/templatefolder/interfaces.py
@@ -1,5 +1,5 @@
-from zope.interface import Interface
+from ftw.tabbedview.interfaces import ITabbedviewUploadable
 
 
-class ITemplateFolder(Interface):
+class ITemplateFolder(ITabbedviewUploadable):
     pass

--- a/opengever/dossier/tests/test_templatefolder.py
+++ b/opengever/dossier/tests/test_templatefolder.py
@@ -771,6 +771,15 @@ class TestTemplateFolderUtility(FunctionalTestCase):
 class TestTemplateFolderListings(IntegrationTestCase):
 
     @browsing
+    def test_renders_quickupload_uploadbox(self, browser):
+        self.login(self.administrator, browser) # admins can add templates
+        browser.open(self.templates)
+
+        self.assertIsNotNone(
+            browser.css('#uploadbox').first,
+            'Upload box should be available in template folders')
+
+    @browsing
     def test_receipt_delivery_and_subdossier_column_are_hidden_in_document_tab(self, browser):
         self.login(self.regular_user, browser)
         browser.open(self.templates, view='tabbedview_view-documents')


### PR DESCRIPTION
This PR fixes an issue where the upload box would not be rendered for template folders. 

The template folder did no longer provide the `ITabbedviewUploadable` interface, which is required (also for containers that is uploaded into).

In https://github.com/4teamwork/opengever.core/pull/3081 the inheritance of template folders has changed. I suspect that this removed the upload functionality.

Fixes #4114.