### PR TITLE
Enhance resolve_oguid view, to support other views.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -8,6 +8,7 @@ Changelog
 - Make sure bumblebee checksum gets calculated for docs created via REST API. [lgraf]
 - Implement bumblebee tooltip backdrop. [Kevin Bieri]
 - Add favorite SQL-Model. [phgross]
+- Enhance resolve_oguid view, to support other views. [phgross]
 - Change label of "checkout/edit" button to "checkout and edit" [njohner]
 
 

--- a/opengever/base/browser/resolveoguid.py
+++ b/opengever/base/browser/resolveoguid.py
@@ -6,15 +6,39 @@ from Products.CMFCore.utils import getToolByName
 from Products.Five import BrowserView
 from zExceptions import Unauthorized
 from zope.component import getUtility
+from zope.interface import implementer
 from zope.intid.interfaces import IIntIds
+from zope.publisher.interfaces import IPublishTraverse
 
 
+@implementer(IPublishTraverse)
 class ResolveOGUIDView(BrowserView):
+    """The view supports the following url formats:
+
+    GET paramater: /fd/resolve_oguid?oguid=fd:123
+    Traversal based paramater: /fd/resolve_oguid/fd:123
+    Specific view: /fd/resolve_oguid/fd:123/tooltip
+    """
+
+    oguid_str = None
+    view_name = None
+
+    def publishTraverse(self, request, name):
+        if self.oguid_str:
+            self.view_name = name
+        else:
+            self.oguid_str = name
+
+        return self
 
     @classmethod
-    def url_for(cls, oguid, admin_unit=None):
+    def url_for(cls, oguid, admin_unit=None, view_name=None):
         if not admin_unit:
             admin_unit = get_current_admin_unit()
+
+        if view_name:
+            return "{}/@@resolve_oguid/{}/{}".format(admin_unit.public_url,
+                                                     oguid, view_name)
 
         return "{}/@@resolve_oguid?oguid={}".format(admin_unit.public_url,
                                                     oguid)
@@ -23,15 +47,22 @@ class ResolveOGUIDView(BrowserView):
         return admin_unit_id != get_current_admin_unit().id()
 
     def __call__(self):
-        oguid = Oguid.parse(self.request.get('oguid'))
+        if not self.oguid_str:
+            self.oguid_str = self.request.get('oguid')
+
+        oguid = Oguid.parse(self.oguid_str)
 
         if self._is_on_different_admin_unit(oguid.admin_unit_id):
             admin_unit = ogds_service().fetch_admin_unit(oguid.admin_unit_id)
-            url = self.url_for(oguid, admin_unit)
-            return self.request.RESPONSE.redirect(url)
+            url = self.url_for(oguid, admin_unit, self.view_name)
 
-        obj = self._get_object(oguid.int_id)
-        return self.request.RESPONSE.redirect(obj.absolute_url())
+        else:
+            obj = self._get_object(oguid.int_id)
+            url = obj.absolute_url()
+            if self.view_name:
+                url = '/'.join((url, self.view_name))
+
+        return self.request.RESPONSE.redirect(url)
 
     def _get_object(self, iid):
         intids = getUtility(IIntIds)

--- a/opengever/base/tests/test_resolve_oguid.py
+++ b/opengever/base/tests/test_resolve_oguid.py
@@ -28,3 +28,37 @@ class TestResolveOGUIDView(IntegrationTestCase):
 
         browser.open(url)
         self.assertEqual(self.task.absolute_url(), browser.url)
+
+    @browsing
+    def test_with_get_parameter_ids(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        oguid = Oguid.for_object(self.task)
+        url = "{}/@@resolve_oguid?oguid={}".format(
+            self.portal.absolute_url(), oguid)
+
+        browser.open(url)
+        self.assertEqual(self.task.absolute_url(), browser.url)
+
+    @browsing
+    def test_with_traversal_based_ids(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        oguid = Oguid.for_object(self.document)
+        url = "{}/@@resolve_oguid/{}".format(
+            self.portal.absolute_url(), oguid)
+
+        browser.open(url)
+        self.assertEqual(self.document.absolute_url(), browser.url)
+
+    @browsing
+    def test_to_specific_view(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        oguid = Oguid.for_object(self.document)
+        url = "{}/@@resolve_oguid/{}/tooltip".format(
+            self.portal.absolute_url(), oguid)
+
+        browser.open(url)
+        self.assertEqual(
+            '{}/tooltip'.format(self.document.absolute_url()), browser.url)


### PR DESCRIPTION
The view supports now traversal based oguids and other views.

GET paramater: `/fd/resolve_oguid?fd:123`
Traversal based paramater: `/fd/resolve_oguid/fd:123`
Specific view: `/fd/resolve_oguid/fd:123/tooltip`

Closes #4101