### PR TITLE
AdvancedSearch: Fix user sources for dossier responsible, task issuer and document checked_out

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2018.2.0 (unreleased)
 ---------------------
 
+- AdvancedSearch: Fix user sources for dossier responsible, task issuer and doc checked_out. [lgraf]
 - Fix displaying quickupload uploadbox for template folders. [deiferni]
 - Homogenize eCH-0147 import/export action titles. [lgraf]
 - Update object security when objects are moved (account for changes in placeful workflow). [lgraf]

--- a/opengever/advancedsearch/advanced_search.py
+++ b/opengever/advancedsearch/advanced_search.py
@@ -161,7 +161,7 @@ class IAdvancedSearch(model.Schema):
 
     responsible = schema.Choice(
         title=_('label_reponsible', default='Responsible'),
-        source=AllUsersSourceBinder(),
+        source=AllUsersSourceBinder(only_active_orgunits=False),
         required=False,
     )
 
@@ -214,7 +214,7 @@ class IAdvancedSearch(model.Schema):
 
     checked_out = schema.Choice(
         title=_('label_checked_out', default='Checked out by'),
-        source=AllUsersSourceBinder(),
+        source=AllUsersSourceBinder(only_active_orgunits=False),
         required=False,
     )
 
@@ -227,7 +227,7 @@ class IAdvancedSearch(model.Schema):
     issuer = schema.Choice(
         title=_(u"label_issuer", default=u"Issuer"),
         description=_('help_issuer', default=u""),
-        source=UsersContactsInboxesSourceBinder(),
+        source=UsersContactsInboxesSourceBinder(only_active_orgunits=False),
         required=False,
     )
 

--- a/opengever/advancedsearch/tests/test_search.py
+++ b/opengever/advancedsearch/tests/test_search.py
@@ -201,6 +201,69 @@ class TestSearchWithoutContent(FunctionalTestCase):
         ])
 
     @browsing
+    def test_can_select_dossier_responsible_from_inactive_ou_in_widget(self, browser):
+        create(Builder('ogds_user')
+               .having(firstname='Without', lastname='Orgunit',
+                       userid='user.without.orgunit'))
+
+        # We manually do a request on the widget here because
+        # ftw.keywordwidget.tests.widget.AsyncKeywordWidget
+        # doesn't support .query() yet
+        widget_url = '/'.join((
+            self.portal.absolute_url(),
+            'advanced_search',
+            '++widget++form.widgets.responsible'))
+        browser.login().open(widget_url + '/search?q=without')
+
+        self.assertIn(
+            {'id': 'user.without.orgunit',
+             'text': 'Orgunit Without (user.without.orgunit)',
+             '_resultId': 'user.without.orgunit'},
+            browser.json['results'])
+
+    @browsing
+    def test_can_select_task_issuer_from_inactive_ou_in_widget(self, browser):
+        create(Builder('ogds_user')
+               .having(firstname='Without', lastname='Orgunit',
+                       userid='user.without.orgunit'))
+
+        # We manually do a request on the widget here because
+        # ftw.keywordwidget.tests.widget.AsyncKeywordWidget
+        # doesn't support .query() yet
+        widget_url = '/'.join((
+            self.portal.absolute_url(),
+            'advanced_search',
+            '++widget++form.widgets.issuer'))
+        browser.login().open(widget_url + '/search?q=without')
+
+        self.assertIn(
+            {'id': 'user.without.orgunit',
+             'text': 'Orgunit Without (user.without.orgunit)',
+             '_resultId': 'user.without.orgunit'},
+            browser.json['results'])
+
+    @browsing
+    def test_can_select_doc_checked_out_from_inactive_ou_in_widget(self, browser):
+        create(Builder('ogds_user')
+               .having(firstname='Without', lastname='Orgunit',
+                       userid='user.without.orgunit'))
+
+        # We manually do a request on the widget here because
+        # ftw.keywordwidget.tests.widget.AsyncKeywordWidget
+        # doesn't support .query() yet
+        widget_url = '/'.join((
+            self.portal.absolute_url(),
+            'advanced_search',
+            '++widget++form.widgets.checked_out'))
+        browser.login().open(widget_url + '/search?q=without')
+
+        self.assertIn(
+            {'id': 'user.without.orgunit',
+             'text': 'Orgunit Without (user.without.orgunit)',
+             '_resultId': 'user.without.orgunit'},
+            browser.json['results'])
+
+    @browsing
     def test_validate_searchstring_for_documents(self, browser):
         browser.login().open(view='advanced_search')
         browser.fill({'form.widgets.searchableText': "document1",

--- a/opengever/ogds/base/sources.py
+++ b/opengever/ogds/base/sources.py
@@ -429,7 +429,7 @@ class UsersContactsInboxesSourceBinder(object):
 
 
 class AllUsersSource(AllUsersInboxesAndTeamsSource):
-    """Vocabulary of all users assigned to the current admin unit.
+    """Vocabulary of all users.
     """
 
     @property

--- a/opengever/ogds/base/sources.py
+++ b/opengever/ogds/base/sources.py
@@ -125,6 +125,7 @@ class AllUsersInboxesAndTeamsSource(BaseQuerySoure):
         self.client_id = self.get_client_id()
 
         self.only_current_orgunit = kwargs.get('only_current_orgunit', False)
+        self.only_active_orgunits = kwargs.get('only_active_orgunits', True)
         self.only_current_inbox = kwargs.get('only_current_inbox', False)
         self.include_teams = kwargs.get('include_teams', False)
 
@@ -149,14 +150,19 @@ class AllUsersInboxesAndTeamsSource(BaseQuerySoure):
             - only_users: Decide if only the user model will be returned
             - only_current_orgunit: Decide if only the current Orgunit will
               be queried.
-
-        The search_query also filters results from disabled orgunits by default.
+            - only_active_orgunits: Filter out actors that don't have an org
+              unit at all, or an inactive one (true by default).
         """
         models = (User, ) if self.only_users else (User, OrgUnit)
-        query = create_session().query(*models) \
-                                .join(OrgUnit.users_group) \
-                                .join(Group.users)
-        query = query.filter(OrgUnit.enabled == True)  # noqa
+        query = create_session().query(*models)
+
+        # When filtering by orgunit criteria, join tables accordingly
+        if self.only_active_orgunits or self.only_current_orgunit:
+            query = query.join(OrgUnit.users_group) \
+                         .join(Group.users)
+
+        if self.only_active_orgunits:
+            query = query.filter(OrgUnit.enabled == True)  # noqa
 
         if self.only_current_orgunit:
             query = query.filter(OrgUnit.unit_id == self.client_id)
@@ -319,10 +325,12 @@ class AllUsersInboxesAndTeamsSourceBinder(object):
 
     def __init__(self,
                  only_current_orgunit=False,
+                 only_active_orgunits=True,
                  only_current_inbox=False,
                  include_teams=False):
 
         self.only_current_orgunit = only_current_orgunit
+        self.only_active_orgunits = only_active_orgunits
         self.only_current_inbox = only_current_inbox
         self.include_teams = include_teams
 
@@ -330,6 +338,7 @@ class AllUsersInboxesAndTeamsSourceBinder(object):
         return AllUsersInboxesAndTeamsSource(
             context,
             only_current_orgunit=self.only_current_orgunit,
+            only_active_orgunits=self.only_active_orgunits,
             only_current_inbox=self.only_current_inbox,
             include_teams=self.include_teams)
 

--- a/opengever/ogds/base/sources.py
+++ b/opengever/ogds/base/sources.py
@@ -433,8 +433,24 @@ class UsersContactsInboxesSource(AllUsersInboxesAndTeamsSource):
 @implementer(IContextSourceBinder)
 class UsersContactsInboxesSourceBinder(object):
 
+    def __init__(self,
+                 only_current_orgunit=False,
+                 only_active_orgunits=True,
+                 only_current_inbox=False,
+                 include_teams=False):
+
+        self.only_current_orgunit = only_current_orgunit
+        self.only_active_orgunits = only_active_orgunits
+        self.only_current_inbox = only_current_inbox
+        self.include_teams = include_teams
+
     def __call__(self, context):
-        return UsersContactsInboxesSource(context)
+        return UsersContactsInboxesSource(
+            context,
+            only_current_orgunit=self.only_current_orgunit,
+            only_active_orgunits=self.only_active_orgunits,
+            only_current_inbox=self.only_current_inbox,
+            include_teams=self.include_teams)
 
 
 class AllUsersSource(AllUsersInboxesAndTeamsSource):
@@ -493,8 +509,19 @@ class AllUsersSource(AllUsersInboxesAndTeamsSource):
 @implementer(IContextSourceBinder)
 class AllUsersSourceBinder(object):
 
+    def __init__(self,
+                 only_current_orgunit=False,
+                 only_active_orgunits=True):
+
+        self.only_current_orgunit = only_current_orgunit
+        self.only_active_orgunits = only_active_orgunits
+
     def __call__(self, context):
-        return AllUsersSource(context)
+        return AllUsersSource(
+            context,
+            only_current_orgunit=self.only_current_orgunit,
+            only_active_orgunits=self.only_active_orgunits,
+        )
 
 
 class AssignedUsersSource(AllUsersSource):

--- a/opengever/ogds/base/tests/test_sources.py
+++ b/opengever/ogds/base/tests/test_sources.py
@@ -553,20 +553,36 @@ class TestAllUsersSource(FunctionalTestCase):
                .having(firstname='Simon', lastname='Says')
                .assign_to_org_units([disabled_unit]))
 
+        create(Builder('ogds_user').id('without.orgunit')
+               .having(firstname='User Without', lastname='Orgunit'))
+
         self.source = AllUsersSource(self.portal)
 
     def test_all_users_are_valid(self):
-
         self.assertIn('hugo.boss', self.source)
         self.assertIn('peter.muster', self.source)
         self.assertIn('jamie.lannister', self.source)
         self.assertIn(TEST_USER_ID, self.source)
         self.assertIn('peter.meier', self.source)
         self.assertIn('john.doe', self.source)
+        self.assertIn('without.orgunit', self.source)
 
-    def test_users_from_inactive_orgunits_are_valid_but_not_foudn_by_the_search(self):
+    def test_users_from_inactive_orgunits_are_valid_but_not_found_by_search(self):
         self.assertIn('simon.says', self.source)
         self.assertEquals([], self.source.search('simon'))
+
+    def test_users_without_orgunits_are_valid_but_not_found_by_search(self):
+        self.assertIn('without.orgunit', self.source)
+        self.assertEquals([], self.source.search('without'))
+
+    def test_users_assigned_to_other_admin_units_are_valid_and_found_by_search(self):
+        self.assertIn('peter.meier', self.source)
+        result = self.source.search('meier')
+        self.assertEquals(
+            1, len(result),
+            'Expected user Peter Meier from other admin unit in result')
+
+        self.assertEquals('peter.meier', result[0].token)
 
     def test_return_no_search_result_for_inactive_orgunits(self):
         result = self.source.search('Simon')

--- a/opengever/ogds/base/tests/test_sources.py
+++ b/opengever/ogds/base/tests/test_sources.py
@@ -575,6 +575,17 @@ class TestAllUsersSource(FunctionalTestCase):
         self.assertIn('without.orgunit', self.source)
         self.assertEquals([], self.source.search('without'))
 
+    def test_users_without_orgunits_are_valid_and_found_by_search_if_requested(self):
+        source = AllUsersSource(self.portal, only_active_orgunits=False)
+        self.assertIn('without.orgunit', source)
+
+        result = source.search('without')
+        self.assertEquals(
+            1, len(result),
+            'Expected user Without Orgunit in result')
+
+        self.assertEquals('without.orgunit', result[0].token)
+
     def test_users_assigned_to_other_admin_units_are_valid_and_found_by_search(self):
         self.assertIn('peter.meier', self.source)
         result = self.source.search('meier')


### PR DESCRIPTION
This ensures that in the advanced search form, one can also select users from inactive org units (or with not org unit at all) in the widgets for dossier `reponsible`, task `issuer` and document `checked_out`.

In order to accomplish this with as few side effects as possible, I introduced a new property `only_active_orgunits` (default: `True`) that gets passed through to the source(s) by the source binders, and is only configured differently for those three fields in the advanced search form.