### PR TITLE
Request confirmation before cancelling a document checkout

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -28,6 +28,7 @@ Changelog
 - Break activity details out per paragraph. [Rotonen]
 - Delete shadowed documents when resolving a dossier [njohner]
 - Moved the secretary selection in a meeting from the participants view to the metadata edit form and made it a keyword widget. [Rotonen]
+- Require confirmation to cancel document checkouts [njohner]
 - Implement bumblebee tooltip backdrop. [Kevin Bieri]
 - Add favorite API endpoints. [phgross]
 - Add favorite SQL-Model. [phgross]

--- a/opengever/core/profiles/default/actions.xml
+++ b/opengever/core/profiles/default/actions.xml
@@ -139,7 +139,7 @@
     <object name="cancel" meta_type="CMF Action" i18n:domain="opengever.core">
       <property name="title" i18n:translate="">Cancel</property>
       <property name="description" i18n:translate="" />
-      <property name="url_expr">string:cancel_document_checkouts:method</property>
+      <property name="url_expr">string:cancel_documents_checkout_confirmation:method</property>
       <property name="icon_expr" />
       <property name="available_expr" />
       <property name="permissions">

--- a/opengever/core/profiles/default/jsregistry.xml
+++ b/opengever/core/profiles/default/jsregistry.xml
@@ -358,9 +358,20 @@
       cookable="True"
       expression=""
       enabled="True"
-      id="++resource++opengever.document/officeconnector.js"
+      id="++resource++opengever.document/cancel_checkout_confirmation.js"
       inline="False"
       insert-after="++resource++opengever.document/download_confirmation.js"
+      />
+
+  <javascript
+      cacheable="True"
+      compression="safe"
+      cookable="True"
+      expression=""
+      enabled="True"
+      id="++resource++opengever.document/officeconnector.js"
+      inline="False"
+      insert-after="++resource++opengever.document/cancel_checkout_confirmation.js"
       />
 
   <javascript

--- a/opengever/core/upgrades/20180403175143_add_confirmation_to_cancel_checkout/actions.xml
+++ b/opengever/core/upgrades/20180403175143_add_confirmation_to_cancel_checkout/actions.xml
@@ -1,0 +1,17 @@
+<object xmlns:i18n="http://xml.zope.org/namespaces/i18n" name="portal_actions" meta_type="Plone Actions Tool">
+
+  <!-- FOLDER BUTTONS -->
+  <object name="folder_buttons" meta_type="CMF Action Category">
+    <object name="cancel" meta_type="CMF Action" i18n:domain="opengever.core">
+      <property name="title" i18n:translate="">Cancel</property>
+      <property name="description" i18n:translate="" />
+      <property name="url_expr">string:cancel_documents_checkout_confirmation:method</property>
+      <property name="icon_expr" />
+      <property name="available_expr" />
+      <property name="permissions">
+        <element value="opengever.document: Cancel" />
+      </property>
+      <property name="visible">True</property>
+    </object>
+  </object>
+</object>

--- a/opengever/core/upgrades/20180403175143_add_confirmation_to_cancel_checkout/jsregistry.xml
+++ b/opengever/core/upgrades/20180403175143_add_confirmation_to_cancel_checkout/jsregistry.xml
@@ -1,0 +1,16 @@
+<object name="portal_javascripts" meta_type="JavaScripts Registry">
+
+
+  <javascript
+      cacheable="True"
+      compression="safe"
+      cookable="True"
+      expression=""
+      enabled="True"
+      id="++resource++opengever.document/cancel_checkout_confirmation.js"
+      inline="False"
+      insert-after="++resource++opengever.document/download_confirmation.js"
+      />
+
+
+</object>

--- a/opengever/core/upgrades/20180403175143_add_confirmation_to_cancel_checkout/upgrade.py
+++ b/opengever/core/upgrades/20180403175143_add_confirmation_to_cancel_checkout/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddConfirmationToCancelCheckout(UpgradeStep):
+    """Add confirmation to cancel checkout.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/document/browser/actionbuttons.py
+++ b/opengever/document/browser/actionbuttons.py
@@ -1,12 +1,14 @@
 from opengever.base.pdfconverter import is_pdfconverter_enabled
 from opengever.document.browser.download import DownloadConfirmationHelper
 from opengever.document.document import IDocumentSchema
+from opengever.document import _
 from opengever.document.interfaces import ICheckinCheckoutManager
 from opengever.officeconnector.helpers import is_officeconnector_attach_feature_enabled  # noqa
 from plone import api
 from plone.locking.interfaces import IRefreshableLockable
 from plone.protect import createToken
 from zope.component import queryMultiAdapter
+from zope.i18n import translate
 
 
 class ActionButtonRendererMixin(object):
@@ -185,13 +187,17 @@ class ActionButtonRendererMixin(object):
 
         return manager.is_cancel_allowed()
 
-    def get_checkout_cancel_url(self):
+    def get_checkout_cancel_tag(self):
         if not self.has_file() or not self.is_checkout_cancel_available():
             return None
-
-        url = u'{}/@@cancel_document_checkouts'.format(
+        clazz = 'link-overlay modal function-revert'
+        url = u'{}/@@cancel_document_checkout_confirmation'.format(
             self.context.absolute_url())
-        return url
+        label = translate(_(u'Cancel checkout'),
+                          context=self.request).encode('utf-8')
+        return ('<a href="{0}" '
+                'id="action-cancel-checkout" '
+                'class="{1}">{2}</a>').format(url, clazz, label)
 
     def has_file(self):
         return self.context.has_file()

--- a/opengever/document/browser/templates/macros.pt
+++ b/opengever/document/browser/templates/macros.pt
@@ -88,9 +88,7 @@
             </tal:checked_out>
 
             <tal:check_out_cancel tal:condition="is_cancel_allowed">
-              <a tal:attributes="href view/get_checkout_cancel_url; class string:function-revert" i18n:translate="">
-                  Cancel checkout
-              </a>
+                <span tal:replace="structure view/get_checkout_cancel_tag"></span>
             </tal:check_out_cancel>
 
             <tal:download_copy_enabled tal:condition="copy_download_available">

--- a/opengever/document/checkout/configure.zcml
+++ b/opengever/document/checkout/configure.zcml
@@ -29,6 +29,22 @@
 
   <browser:page
       for="*"
+      name="cancel_document_checkout_confirmation"
+      class=".cancel.CancelDocumentCheckoutConfirmation"
+      template="templates/cancelconfirmation.pt"
+      permission="zope2.View"
+      />
+
+  <browser:page
+      for="*"
+      name="cancel_documents_checkout_confirmation"
+      class=".cancel.CancelDocumentsCheckoutConfirmation"
+      template="templates/cancelconfirmationform.pt"
+      permission="zope2.View"
+      />
+
+  <browser:page
+      for="*"
       name="cancel_document_checkouts"
       class=".cancel.CancelDocuments"
       permission="zope2.View"

--- a/opengever/document/checkout/templates/cancelconfirmation.pt
+++ b/opengever/document/checkout/templates/cancelconfirmation.pt
@@ -1,0 +1,17 @@
+<form id="cancel_confirmation" name="cancel_overlay" method="POST"
+    i18n:domain="opengever.document" tal:attributes="action view/get_checkout_cancel_url">
+
+  <h1 class="documentFirstHeading" i18n:translate="Cancel checkout">
+      Cancel checkout
+  </h1>
+
+  <div class="details">
+    <p i18n:translate="cancel_checkout_confirmation">Are you sure you want to cancel the checkout?</p>
+  </div>
+  <div class="formControls">
+    <input type="submit" class="context" value="Cancel checkout" i18n:attributes="value"/>
+    <input id="cancel" type="button" class="standalone" value="label_cancel" i18n:attributes="value" />
+  </div>
+
+
+</form>

--- a/opengever/document/checkout/templates/cancelconfirmationform.pt
+++ b/opengever/document/checkout/templates/cancelconfirmationform.pt
@@ -1,0 +1,31 @@
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en"
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      xmlns:metal="http://xml.zope.org/namespaces/metal"
+      xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+      lang="en"
+      metal:use-macro="context/main_template/macros/master"
+      i18n:domain="opengever.document">
+  <metal:main metal:fill-slot="main">
+    <metal:title metal:fill-slot="content-title">
+      <div id="tabbedview-header">
+        <h1 class="documentFirstHeading" i18n:translate="Cancel checkout">Cancel checkout
+        </h1>
+      </div>
+    </metal:title>
+
+    <metal:content-core fill-slot="content-core">
+
+      <p i18n:translate="cancel_checkout_confirmation">Are you sure you want to cancel the checkout?</p>
+      <h3 i18n:translate="">Chosen documents</h3>
+      <ul>
+        <tal:filenames tal:repeat="filename view/form_instance/get_filenames">
+          <li class="document-list" tal:content="filename"></li>
+        </tal:filenames>
+      </ul>
+      <div id="form-input">
+          <span tal:replace="structure view/contents" />
+      </div>
+
+    </metal:content-core>
+  </metal:main>
+</html>

--- a/opengever/document/locales/de/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/de/LC_MESSAGES/opengever.document.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2018-01-29 09:52+0000\n"
+"POT-Creation-Date: 2018-04-06 06:16+0000\n"
 "PO-Revision-Date: 2017-10-13 14:27+0200\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -23,7 +23,10 @@ msgstr "Mit Mailprogramm versenden"
 msgid "Can't edit the document at moment, beacuse it's locked."
 msgstr "Das Dokument kann momentan nicht bearbeitet werden, es ist gesperrt."
 
-#: ./opengever/document/browser/templates/macros.pt
+#. Default: "Cancel checkout"
+#: ./opengever/document/browser/actionbuttons.py
+#: ./opengever/document/checkout/cancel.py
+#: ./opengever/document/checkout/templates/cancelconfirmation.pt
 msgid "Cancel checkout"
 msgstr "Checkout widerrufen"
 
@@ -49,6 +52,10 @@ msgstr "Mit Kommentar einchecken"
 #: ./opengever/document/upgrades/profiles/4000/actions.xml
 msgid "Checkin without comment"
 msgstr "Ohne Kommentar einchecken"
+
+#: ./opengever/document/checkout/templates/cancelconfirmationform.pt
+msgid "Chosen documents"
+msgstr "Gewählte Dokumente"
 
 #: ./opengever/document/checkout/cancel.py
 msgid "Could not cancel checkout on document ${title}."
@@ -141,6 +148,7 @@ msgid "alert_not_checked_in_documents"
 msgstr "Sie haben noch ausgecheckte Dokumente. Wollen Sie OneGov GEVER wirklich verlassen?"
 
 #. Default: "Cancel"
+#: ./opengever/document/checkout/cancel.py
 #: ./opengever/document/checkout/checkin.py
 msgid "button_cancel"
 msgstr "Abbrechen"
@@ -159,6 +167,12 @@ msgstr "Trotzdem einchecken"
 #: ./opengever/document/browser/versions_tab.py
 msgid "button_pdf"
 msgstr "PDF-Vorschau"
+
+#. Default: "Are you sure you want to cancel the checkout?"
+#: ./opengever/document/checkout/templates/cancelconfirmation.pt
+#: ./opengever/document/checkout/templates/cancelconfirmationform.pt
+msgid "cancel_checkout_confirmation"
+msgstr "Wollen Sie den Checkout wirklich widerrufen? Bereits gemachte Änderungen am Dokument gehen dabei verloren."
 
 #. Default: "copy of"
 #: ./opengever/document/subscribers.py
@@ -312,6 +326,7 @@ msgid "label_by_author"
 msgstr "Autor"
 
 #: ./opengever/document/browser/templates/downloadconfirmation.pt
+#: ./opengever/document/checkout/templates/cancelconfirmation.pt
 msgid "label_cancel"
 msgstr "Abbrechen"
 

--- a/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-01-29 09:52+0000\n"
+"POT-Creation-Date: 2018-04-06 06:16+0000\n"
 "PO-Revision-Date: 2017-09-03 08:50+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-document/fr/>\n"
@@ -25,7 +25,10 @@ msgstr "Envoyer par le programme de messagerie"
 msgid "Can't edit the document at moment, beacuse it's locked."
 msgstr "Impossible de modifier le document en ce moment car il est verrouillé."
 
-#: ./opengever/document/browser/templates/macros.pt
+#. Default: "Cancel checkout"
+#: ./opengever/document/browser/actionbuttons.py
+#: ./opengever/document/checkout/cancel.py
+#: ./opengever/document/checkout/templates/cancelconfirmation.pt
 msgid "Cancel checkout"
 msgstr "Annuler le checkout"
 
@@ -52,9 +55,13 @@ msgstr "Checkin avec commentaire"
 msgid "Checkin without comment"
 msgstr "Checkin sans commentaire"
 
+#: ./opengever/document/checkout/templates/cancelconfirmationform.pt
+msgid "Chosen documents"
+msgstr "Documents sélectionnés"
+
 #: ./opengever/document/checkout/cancel.py
 msgid "Could not cancel checkout on document ${title}."
-msgstr "Checkout du document ${title} inabouti."
+msgstr "Annulation du checkout du document ${title} inabouti."
 
 #: ./opengever/document/checkout/checkin.py
 msgid "Could not check in ${title}, it is not a document."
@@ -143,6 +150,7 @@ msgid "alert_not_checked_in_documents"
 msgstr "Vous avez encore des documents en checkout! Voulez-vous quand même quitter GEVER?"
 
 #. Default: "Cancel"
+#: ./opengever/document/checkout/cancel.py
 #: ./opengever/document/checkout/checkin.py
 msgid "button_cancel"
 msgstr "Annuler"
@@ -161,6 +169,12 @@ msgstr "Checkin malgré tout"
 #: ./opengever/document/browser/versions_tab.py
 msgid "button_pdf"
 msgstr "Aperçu pdf"
+
+#. Default: "Are you sure you want to cancel the checkout?"
+#: ./opengever/document/checkout/templates/cancelconfirmation.pt
+#: ./opengever/document/checkout/templates/cancelconfirmationform.pt
+msgid "cancel_checkout_confirmation"
+msgstr "Voulez-vous vraiment annuler le checkout? Les changements déjà effectués sur le document seront alors perdus."
 
 #. Default: "copy of"
 #: ./opengever/document/subscribers.py
@@ -309,6 +323,7 @@ msgid "label_by_author"
 msgstr "Auteur"
 
 #: ./opengever/document/browser/templates/downloadconfirmation.pt
+#: ./opengever/document/checkout/templates/cancelconfirmation.pt
 msgid "label_cancel"
 msgstr "Annuler"
 

--- a/opengever/document/locales/opengever.document.pot
+++ b/opengever/document/locales/opengever.document.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-01-29 09:52+0000\n"
+"POT-Creation-Date: 2018-04-06 06:16+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -26,7 +26,9 @@ msgstr ""
 msgid "Can't edit the document at moment, beacuse it's locked."
 msgstr ""
 
-#: ./opengever/document/browser/templates/macros.pt
+#: ./opengever/document/browser/actionbuttons.py
+#: ./opengever/document/checkout/cancel.py
+#: ./opengever/document/checkout/templates/cancelconfirmation.pt
 msgid "Cancel checkout"
 msgstr ""
 
@@ -51,6 +53,10 @@ msgstr ""
 #: ./opengever/document/browser/templates/macros.pt
 #: ./opengever/document/upgrades/profiles/4000/actions.xml
 msgid "Checkin without comment"
+msgstr ""
+
+#: ./opengever/document/checkout/templates/cancelconfirmationform.pt
+msgid "Chosen documents"
 msgstr ""
 
 #: ./opengever/document/checkout/cancel.py
@@ -144,6 +150,7 @@ msgid "alert_not_checked_in_documents"
 msgstr ""
 
 #. Default: "Cancel"
+#: ./opengever/document/checkout/cancel.py
 #: ./opengever/document/checkout/checkin.py
 msgid "button_cancel"
 msgstr ""
@@ -161,6 +168,12 @@ msgstr ""
 #. Default: "PDF"
 #: ./opengever/document/browser/versions_tab.py
 msgid "button_pdf"
+msgstr ""
+
+#. Default: "Are you sure you want to cancel the checkout?"
+#: ./opengever/document/checkout/templates/cancelconfirmation.pt
+#: ./opengever/document/checkout/templates/cancelconfirmationform.pt
+msgid "cancel_checkout_confirmation"
 msgstr ""
 
 #. Default: "copy of"
@@ -310,6 +323,7 @@ msgid "label_by_author"
 msgstr ""
 
 #: ./opengever/document/browser/templates/downloadconfirmation.pt
+#: ./opengever/document/checkout/templates/cancelconfirmation.pt
 msgid "label_cancel"
 msgstr ""
 

--- a/opengever/document/static/cancel_checkout_confirmation.js
+++ b/opengever/document/static/cancel_checkout_confirmation.js
@@ -1,0 +1,17 @@
+function initCheckoutCancelConfirmation(){
+
+  // submitting
+  $('form#cancel_confirmation').live('submit', function(e){
+    $(this).parents('.pb-ajax').siblings('.close').click();
+    return true
+  });
+
+  // cancel
+  $('form#cancel_confirmation #cancel').live('click', function(e){
+    $(this).parents('.pb-ajax').siblings('.close').click();
+  });
+}
+
+$(document).ready(function(){
+  initCheckoutCancelConfirmation();
+});


### PR DESCRIPTION
Request a confirmation to cancel the checkout of a document.

When cancelling the checkout of a single document from the document actions, a popup window asks for confirmation. When using the table actions from the `TabbedView`, the confirmation is handled by a form (see snapshots below).

I also checked that it still works for `proposaltemplate`.


**pop up for cancelling checkout of a single document**
![screen shot 2018-04-06 at 08 19 30](https://user-images.githubusercontent.com/7374243/38407667-aed04160-397a-11e8-91a5-200df9191bf8.png)

**form for cancelling checkout of multiple documents. The form lists the files that were selected for checkout cancel**
![screen shot 2018-04-06 at 08 20 53](https://user-images.githubusercontent.com/7374243/38407669-af070344-397a-11e8-9460-a3e3b68c37f1.png)

**Messages after cancelling checkout, here of three documents, with one of them that wasn't checked out, so the cancel failed for that one**
![screen shot 2018-04-06 at 08 21 17](https://user-images.githubusercontent.com/7374243/38407668-aeeb28c2-397a-11e8-9655-aebc6a7b301a.png)



resolves #4119 