### PR TITLE
Favorites API endpoints

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,7 @@ Changelog
 
 - Make sure bumblebee checksum gets calculated for docs created via REST API. [lgraf]
 - Implement bumblebee tooltip backdrop. [Kevin Bieri]
+- Add favorite API endpoints. [phgross]
 - Add favorite SQL-Model. [phgross]
 - Change label of "checkout/edit" button to "checkout and edit" [njohner]
 

--- a/docs/public/dev-manual/api/favorite.rst
+++ b/docs/public/dev-manual/api/favorite.rst
@@ -1,0 +1,161 @@
+.. _favorites:
+
+Favoriten
+=========
+
+Der ``@favorites`` endpoint bietet alle Funktion für die Auflistung und Bearbeitung der globalen Favoriten welche pro Benutzer aber über einen kompletten GEVER Verbund zentral verwaltet werden. Der Endpoint steht nur auf Stufe PloneSite zur Verfügung und erwartet eine Einschränkung auf einen Benutzer via Benutzer-ID. Die URL setzt sich somit folgendermassen zusammen:
+
+``http://example.org/fd/@favorites/peter.mueller``
+
+
+Auflistung:
+-----------
+Mittels eines GET Request können Favoriten des Benutzers abgefragt werden. Dabei werden alle, also global über den ganzen Mandanten-Verbundes, zurückgegeben.
+
+
+**Beispiel-Request**:
+
+   .. sourcecode:: http
+
+       GET /@favorites/peter.mueller HTTP/1.1
+       Accept: application/json
+
+
+**Beispiel-Response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 200 OK
+      Content-Type: application/json
+
+      [
+          {
+              "@id": "http://localhost:8080/fd/@favorites/peter.mueller/3",
+              "favorite_id": 3,
+              "icon_class": "icon-dokument_word",
+              "oguid": "fd:68398212",
+              "title": "Richtlinien Gesetzesentwürfe",
+              "position": 1,
+              "target_url": "http://localhost:8080/fd/resolve_oguid/fd:68398212"
+          }
+          ,
+          {
+              "@id": "http://localhost:8080/fd/@favorites/peter.mueller/57",
+              "favorite_id": 57,
+              "icon_class": "contenttype-opengever-dossier-businesscasedossier",
+              "oguid": "fd:68336212",
+              "title": "Anfragen 2018",
+              "position": 2,
+              "target_url": "http://localhost:8080/fd/resolve_oguid/fd:68336212"
+          }
+      ]
+
+Favorit hinzufügen:
+-------------------
+Ein Favorit für ein beliebiges Objekt kann mittels POST Request hinzugefügt werden. Dabei wird die Oguid des Objektes im Paramter ``oguid`` erwartet.
+
+
+**Beispiel-Request**:
+
+   .. sourcecode:: http
+
+       POST /@favorites/peter.mueller HTTP/1.1
+       Accept: application/json
+
+       {
+        "oguid": "fd:68398212"
+       }
+
+
+**Beispiel-Response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 201 Created
+      Content-Type: application/json
+      Location: http://localhost:8080/fd/@favorites/peter.mueller/20
+
+      {
+          "@id": "http://localhost:8080/fd/@favorites/peter.mueller/20",
+          "favorite_id": 20,
+          "icon_class": "icon-dokument_word",
+          "oguid": "fd:68398212",
+          "title": "Anfrage 2018",
+          "position": 1,
+          "target_url": "http://localhost:8080/fd/resolve_oguid/fd:68398212"
+      }
+
+
+
+Favorit bearbeiten:
+-------------------
+Ein bestehender Favorit kann mittels PATCH Request überarbeitet werden. Es werden nur die Parameter `title` und `position` beachtet. Wird der Titel eines Favoriten verändert, so wird automatisch auch das flag `is_title_personalized` aktiviert.
+
+Die URL setzt sich dabei folgendermassen zusammen:
+``gever-url/@favorites/{userid}/{favoriten-id}``
+
+
+**Beispiel-Request**:
+
+   .. sourcecode:: http
+
+       PATCH /@favorites/peter.mueller/20 HTTP/1.1
+       Accept: application/json
+
+       {
+        "title": "Weekly Document",
+        "position": 35
+       }
+
+
+Ein erfolgreicher Patch-Request wird standardmässig mit einer 204 No content Response beantwortet.
+
+**Beispiel-Response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 204 No content
+
+
+Es ist aber möglich bei einem PATCH request die Objekt-Repräsentation als Response zuerhalten, hierzu muss ein ``Prefer`` Header mit dem Wert ``return=representation`` gesetzt werden.
+
+**Beispiel-Response mit Prefer Header**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 200 OK
+      Content-Type: application/json
+
+      {
+          "@id": "http://localhost:8080/fd/@favorites/peter.mueller/20",
+          "favorite_id": 20,
+          "icon_class": "icon-dokument_word",
+          "oguid": "fd:68398212",
+          "title": "Weekly Document",
+          "position": 35,
+          "target_url": "http://localhost:8080/fd/resolve_oguid/fd:68398212"
+      }
+
+
+
+Favorit entfernen:
+------------------
+Ein bestehender Favorit kann mittels DELETE Request auf die entsprechender URL gelöscht werden.
+
+Die URL setzt sich dabei folgendermassen zusammen:
+``gever-url/@favorites/{userid}/{favoriten-id}``
+
+
+**Beispiel-Request**:
+
+   .. sourcecode:: http
+
+       DELETE /@favorites/peter.mueller/20 HTTP/1.1
+       Accept: application/json
+
+
+**Beispiel-Response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 204 No Content

--- a/docs/public/dev-manual/api/index.rst
+++ b/docs/public/dev-manual/api/index.rst
@@ -20,6 +20,7 @@ Inhalt:
    content_types.rst
    metadata.rst
    config.rst
+   favorite.rst
    examples/index.rst
    docs_changelog.rst
 

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -113,4 +113,12 @@
       permission="cmf.SetOwnProperties"
       />
 
+  <plone:service
+      method="GET"
+      name="@repository-favorites"
+      for="Products.CMFPlone.interfaces.IPloneSiteRoot"
+      factory=".repository_favorites.RepositoryFavoritesGet"
+      permission="zope2.View"
+      />
+
 </configure>

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -81,4 +81,36 @@
       permission="zope2.View"
       />
 
+  <plone:service
+      method="GET"
+      name="@favorites"
+      for="Products.CMFPlone.interfaces.IPloneSiteRoot"
+      factory=".favorites.FavoritesGet"
+      permission="zope2.View"
+      />
+
+  <plone:service
+      method="POST"
+      name="@favorites"
+      for="Products.CMFPlone.interfaces.IPloneSiteRoot"
+      factory=".favorites.FavoritesPost"
+      permission="cmf.SetOwnProperties"
+      />
+
+  <plone:service
+      method="DELETE"
+      name="@favorites"
+      for="Products.CMFPlone.interfaces.IPloneSiteRoot"
+      factory=".favorites.FavoritesDelete"
+      permission="cmf.SetOwnProperties"
+      />
+
+  <plone:service
+      method="PATCH"
+      name="@favorites"
+      for="Products.CMFPlone.interfaces.IPloneSiteRoot"
+      factory=".favorites.FavoritesPatch"
+      permission="cmf.SetOwnProperties"
+      />
+
 </configure>

--- a/opengever/api/favorites.py
+++ b/opengever/api/favorites.py
@@ -1,0 +1,202 @@
+from opengever.base.favorite import FavoriteManager
+from opengever.base.model.favorite import Favorite
+from opengever.base.oguid import Oguid
+from plone import api
+from plone.restapi.deserializer import json_body
+from plone.restapi.services import Service
+from zExceptions import BadRequest
+from zExceptions import NotFound
+from zExceptions import Unauthorized
+from zope.interface import implements
+from zope.publisher.interfaces import IPublishTraverse
+
+
+class FavoritesGet(Service):
+    """API Endpoint which returns a list of all favorites for a
+    particular user.
+
+    GET /@favorites/peter.mueller HTTP/1.1
+    """
+
+    implements(IPublishTraverse)
+
+    def __init__(self, context, request):
+        super(FavoritesGet, self).__init__(context, request)
+        self.params = []
+
+    def publishTraverse(self, request, name):
+        # Consume any path segments after /@favorites as parameters
+        self.params.append(name)
+        return self
+
+    def reply(self):
+        userid, fav_id = self.read_params()
+
+        if userid != api.user.get_current().getId():
+            raise Unauthorized(
+                "It's not allowed to access favorites of other users.")
+
+        portal_url = api.portal.get().absolute_url()
+
+        if fav_id:
+            favorite = Favorite.query.by_userid_and_id(fav_id, userid).first()
+            if not favorite:
+                # inexistent favorite-id or not ownded by given user
+                raise NotFound
+
+            return favorite.serialize(portal_url)
+        else:
+            favorites = FavoriteManager().list_all(userid)
+            return [fav.serialize(portal_url) for fav in favorites]
+
+    def read_params(self):
+        if len(self.params) not in [1, 2]:
+            raise BadRequest("Must supply user ID as URL and optional "
+                             "the favorite id as path parameter.")
+
+        if len(self.params) == 2:
+            return self.params
+
+        return self.params[0], None
+
+
+class FavoritesPost(Service):
+    """API Endpoint to add a new favorite for the given oguid and user.
+
+    POST /@favorites/peter.mueller HTTP/1.1
+    {
+        "oguid": "fd:68398212"
+    }
+    """
+
+    implements(IPublishTraverse)
+
+    def __init__(self, context, request):
+        super(FavoritesPost, self).__init__(context, request)
+        self.params = []
+
+    def publishTraverse(self, request, name):
+        # Consume any path segments after /@favorites as parameters
+        self.params.append(name)
+        return self
+
+    def reply(self):
+        userid = self.get_userid()
+        if userid != api.user.get_current().getId():
+            raise Unauthorized(
+                "It's not allowed to add favorites for other users.")
+
+        data = json_body(self.request)
+        if not data.get('oguid'):
+            raise BadRequest('Missing parameter oguid')
+
+        oguid = Oguid.parse(data.get('oguid'))
+        obj = oguid.resolve_object()
+        if not obj:
+            raise BadRequest('Invalid oguid, could not be resolved.')
+
+        favorite = FavoriteManager().add(userid, obj)
+
+        self.request.response.setStatus(201)
+        url = favorite.api_url(api.portal.get().absolute_url())
+        self.request.response.setHeader('Location', url)
+
+        return favorite.serialize(api.portal.get().absolute_url())
+
+    def get_userid(self):
+        if len(self.params) != 1:
+            raise BadRequest("Must supply user ID as URL path parameters.")
+        return self.params[0]
+
+
+class FavoritesDelete(Service):
+    """API Endpoint to delete an existing favorite.
+
+    DELETE /@favorites/peter.mueller/23 HTTP/1.1
+    """
+
+    implements(IPublishTraverse)
+
+    def __init__(self, context, request):
+        super(FavoritesDelete, self).__init__(context, request)
+        self.params = []
+
+    def publishTraverse(self, request, name):
+        # Consume any path segments after /@favorites as parameters
+        self.params.append(name)
+        return self
+
+    def reply(self):
+        userid, fav_id = self.read_params()
+        if userid != api.user.get_current().getId():
+            raise Unauthorized(
+                "It's not allowed to delete favorites of other users.")
+
+        FavoriteManager().delete(userid, fav_id)
+
+        self.request.response.setStatus(204)
+        return None
+
+    def read_params(self):
+        """Returns userid and favorite id, passed in via traversal parameters.
+        """
+        if len(self.params) != 2:
+            raise BadRequest(
+                "Must supply exactly two parameters (user id and favorite id)")
+
+        return self.params[0], self.params[1]
+
+
+class FavoritesPatch(Service):
+    """API Endpoint to update an existing favorite.
+
+    PATCH /@favorites/peter.mueller/23 HTTP/1.1
+    {
+        "title": "Weekly Document",
+        "position": 35
+    }
+    """
+
+    implements(IPublishTraverse)
+
+    def __init__(self, context, request):
+        super(FavoritesPatch, self).__init__(context, request)
+        self.params = []
+
+    def publishTraverse(self, request, name):
+        # Consume any path segments after /@favorites as parameters
+        self.params.append(name)
+        return self
+
+    def reply(self):
+        userid, fav_id = self.read_params()
+
+        if userid != api.user.get_current().getId():
+            raise Unauthorized(
+                "It's not allowed to update favorites of other users.")
+
+        data = json_body(self.request)
+        if data.get('title') is None and data.get('position') is None:
+            raise BadRequest('Missing parameter title or position')
+
+        FavoriteManager().update(
+            userid, fav_id, title=data.get('title'),
+            position=data.get('position'))
+
+        prefer = self.request.getHeader('Prefer')
+        if prefer == 'return=representation':
+            self.request.response.setStatus(200)
+            favorite = Favorite.query.get(fav_id)
+            return favorite.serialize(api.portal.get().absolute_url())
+
+        self.request.response.setStatus(204)
+        return None
+
+    def read_params(self):
+        """Returns userid and favorite id, passed in via traversal parameters.
+        """
+        if len(self.params) != 2:
+            raise BadRequest(
+                "Must supply user ID and favorite ID as URL path parameters.")
+
+        return self.params[0], self.params[1]

--- a/opengever/api/repository_favorites.py
+++ b/opengever/api/repository_favorites.py
@@ -1,0 +1,37 @@
+from opengever.base.favorite import FavoriteManager
+from plone import api
+from plone.restapi.services import Service
+from zExceptions import BadRequest
+from zExceptions import Unauthorized
+from zope.interface import implements
+from zope.publisher.interfaces import IPublishTraverse
+
+
+class RepositoryFavoritesGet(Service):
+
+    implements(IPublishTraverse)
+
+    def __init__(self, context, request):
+        super(RepositoryFavoritesGet, self).__init__(context, request)
+        self.params = []
+
+    def publishTraverse(self, request, name):
+        # Consume any path segments after /@favorites as parameters
+        self.params.append(name)
+        return self
+
+    def reply(self):
+        userid = self.get_userid()
+        if userid != api.user.get_current().getId():
+            raise Unauthorized(
+                "It's not allowed to delete favorites of other users.")
+
+        favorites = FavoriteManager().list_all_repository_favorites(userid)
+
+        return [fav.plone_uid for fav in favorites]
+
+    def get_userid(self):
+        if len(self.params) != 1:
+            raise BadRequest(
+                "Must supply exactly one parameter (user id)")
+        return self.params[0]

--- a/opengever/api/tests/test_favorites.py
+++ b/opengever/api/tests/test_favorites.py
@@ -1,0 +1,508 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.testbrowser import browsing
+from opengever.base.model.favorite import Favorite
+from opengever.base.oguid import Oguid
+from opengever.testing import IntegrationTestCase
+import json
+
+
+class TestFavoritesGet(IntegrationTestCase):
+
+    @browsing
+    def test_list_all_favorites_for_the_given_userid(self, browser):
+        self.login(self.administrator, browser=browser)
+
+        create(Builder('favorite')
+               .for_user(self.administrator)
+               .for_object(self.dossier)
+               .having(position=23))
+
+        create(Builder('favorite')
+               .for_user(self.administrator)
+               .for_object(self.document)
+               .having(position=21))
+
+        create(Builder('favorite')
+               .for_user(self.regular_user)
+               .for_object(self.empty_dossier))
+
+        url = '{}/@favorites/{}'.format(self.portal.absolute_url(), self.administrator.getId())
+        browser.open(url, method='GET', headers={'Accept': 'application/json'})
+
+        self.assertEqual(200, browser.status_code)
+        self.assertEquals(
+            [{u'@id': u'http://nohost/plone/@favorites/nicole.kohler/1',
+              u'favorite_id': 1,
+              u'position': 23,
+              u'oguid': u'plone:1014013300',
+              u'admin_unit': u'Hauptmandant',
+              u'target_url': u'http://nohost/plone/resolve_oguid/plone:1014013300',
+              u'tooltip_url': None,
+              u'icon_class': u'contenttype-opengever-dossier-businesscasedossier',
+              u'title': u'Vertr\xe4ge mit der kantonalen Finanzverwaltung'},
+             {u'@id': u'http://nohost/plone/@favorites/nicole.kohler/2',
+              u'favorite_id': 2,
+              u'position': 21,
+              u'oguid': u'plone:1014073300',
+              u'admin_unit': u'Hauptmandant',
+              u'target_url': u'http://nohost/plone/resolve_oguid/plone:1014073300',
+              u'tooltip_url': u'http://nohost/plone/resolve_oguid/plone:1014073300/tooltip',
+              u'icon_class': u'icon-docx',
+              u'title': u'Vertr\xe4gsentwurf'}],
+            browser.json)
+
+    @browsing
+    def test_returns_serialized_favorites_for_the_given_userid_and_favorite_id(self, browser):
+        self.login(self.administrator, browser=browser)
+
+        create(Builder('favorite')
+               .for_user(self.administrator)
+               .for_object(self.dossier)
+               .having(position=23))
+
+        url = '{}/@favorites/{}/1'.format(
+            self.portal.absolute_url(), self.administrator.getId())
+        browser.open(url, method='GET', headers={'Accept': 'application/json'})
+
+        self.assertEqual(200, browser.status_code)
+        self.assertEquals(
+            {u'@id': u'http://nohost/plone/@favorites/nicole.kohler/1',
+             u'favorite_id': 1,
+             u'position': 23,
+             u'oguid': u'plone:1014013300',
+             u'admin_unit': u'Hauptmandant',
+             u'target_url': u'http://nohost/plone/resolve_oguid/plone:1014013300',
+             u'tooltip_url': None,
+             u'icon_class': u'contenttype-opengever-dossier-businesscasedossier',
+             u'title': u'Vertr\xe4ge mit der kantonalen Finanzverwaltung'},
+            browser.json)
+
+    @browsing
+    def test_raises_when_userid_is_missing(self, browser):
+        self.login(self.administrator, browser=browser)
+
+        with browser.expect_http_error(400):
+            url = '{}/@favorites'.format(self.portal.absolute_url())
+            browser.open(url, method='GET',
+                         headers={'Accept': 'application/json'})
+
+        self.assertEqual(
+            {"message": "Must supply user ID as URL and optional the "
+             "favorite id as path parameter.",
+             "type": "BadRequest"},
+            browser.json)
+
+    @browsing
+    def test_raises_unauthorized_when_accessing_favorites_of_other_user(self, browser):
+        self.login(self.administrator, browser=browser)
+
+        with browser.expect_http_error(401):
+            url = '{}/@favorites/{}'.format(
+                self.portal.absolute_url(), self.regular_user.getId())
+            browser.open(url, method='GET',
+                         headers={'Accept': 'application/json'})
+
+        self.assertEqual(
+            {u'message': u"It's not allowed to access favorites of other users.",
+             u'type': u'Unauthorized'},
+            browser.json)
+
+
+class TestFavoritesPost(IntegrationTestCase):
+
+    @browsing
+    def test_adding_favorite(self, browser):
+        self.login(self.administrator, browser=browser)
+
+        oguid = Oguid.for_object(self.document)
+        url = '{}/@favorites/{}'.format(
+            self.portal.absolute_url(), self.administrator.getId())
+
+        data = json.dumps({'oguid': oguid.id})
+        browser.open(url, data=data, method='POST',
+                     headers={'Accept': 'application/json',
+                              'Content-Type': 'application/json'})
+
+        self.assertEqual(201, browser.status_code)
+
+        self.assertEqual(u'http://nohost/plone/@favorites/nicole.kohler/1',
+                         browser.headers.get('location'))
+
+        browser.open(browser.headers.get('location'), method='GET',
+                     headers={'Accept': 'application/json',
+                              'Content-Type': 'application/json'})
+
+        self.assertEquals(
+            {u'@id': u'http://nohost/plone/@favorites/nicole.kohler/1',
+             u'favorite_id': 1,
+             u'oguid': u'plone:1014073300',
+             u'position': 0,
+             u'target_url': u'http://nohost/plone/resolve_oguid/plone:1014073300',
+             u'tooltip_url': u'http://nohost/plone/resolve_oguid/plone:1014073300/tooltip',
+             u'icon_class': u'icon-docx',
+             u'admin_unit': u'Hauptmandant',
+             u'title': u'Vertr\xe4gsentwurf'}, browser.json)
+
+        self.assertEqual(1, Favorite.query.count())
+        fav = Favorite.query.first()
+        self.assertEquals(self.administrator.getId(), fav.userid)
+        self.assertEquals(oguid, fav.oguid)
+
+    @browsing
+    def test_raises_with_missing_oguid(self, browser):
+        self.login(self.administrator, browser=browser)
+
+        url = '{}/@favorites/{}'.format(
+            self.portal.absolute_url(), self.administrator.getId())
+
+        with browser.expect_http_error(400):
+            browser.open(url, method='POST', data="{}",
+                         headers={'Accept': 'application/json',
+                                  'Content-Type': 'application/json'})
+
+        self.assertEquals(
+            {u'message': u'Missing parameter oguid', u'type': u'BadRequest'},
+            browser.json)
+
+    @browsing
+    def test_raises_unauthorized_when_accessing_favorites_of_other_user(self, browser):
+        self.login(self.administrator, browser=browser)
+
+        oguid = Oguid.for_object(self.document)
+        url = '{}/@favorites/{}'.format(
+            self.portal.absolute_url(), self.regular_user.getId())
+
+        data = json.dumps({'oguid': oguid.id})
+        with browser.expect_http_error(401):
+            browser.open(url, data=data, method='POST',
+                         headers={'Accept': 'application/json',
+                                  'Content-Type': 'application/json'})
+
+        self.assertEqual(
+            {u'message': u"It's not allowed to add favorites for other users.",
+             u'type': u'Unauthorized'},
+            browser.json)
+
+
+class TestFavoritesDelete(IntegrationTestCase):
+
+    @browsing
+    def test_raises_when_id_is_missing(self, browser):
+        self.login(self.administrator, browser=browser)
+
+        create(Builder('favorite')
+               .for_user(self.administrator)
+               .for_object(self.dossier))
+
+        self.assertEqual(1, Favorite.query.count())
+
+        with browser.expect_http_error(400):
+            url = '{}/@favorites/{}'.format(
+                self.portal.absolute_url(), self.administrator.getId())
+            browser.open(url, method='DELETE',
+                         headers={'Accept': 'application/json'})
+
+        self.assertEqual(
+            {u'message': u'Must supply exactly two parameters (user id and favorite id)',
+             u'type': u'BadRequest'}, browser.json)
+
+    @browsing
+    def test_raises_when_favorite_is_not_owned_by_the_given_user(self, browser):
+        self.login(self.administrator, browser=browser)
+
+        favorite = create(Builder('favorite')
+                          .for_user(self.regular_user)
+                          .for_object(self.dossier))
+
+        self.assertEqual(1, Favorite.query.count())
+
+        with browser.expect_http_error(404):
+            url = '{}/@favorites/{}/{}'.format(
+                self.portal.absolute_url(),
+                self.administrator.getId(),
+                favorite.favorite_id)
+
+            browser.open(url, method='DELETE',
+                         headers={'Accept': 'application/json'})
+
+        self.assertEqual(
+            {u"message": u'Resource not found: http://nohost/plone/@favorites/nicole.kohler/1',
+             u"type": u"NotFound"}, browser.json)
+
+    @browsing
+    def test_removes_favorite_when_already_exists_for_user(self, browser):
+        self.login(self.administrator, browser=browser)
+
+        favorite = create(Builder('favorite')
+                          .for_user(self.administrator)
+                          .for_object(self.dossier))
+
+        self.assertEqual(1, Favorite.query.count())
+
+        url = '{}/@favorites/{}/{}'.format(
+            self.portal.absolute_url(), self.administrator.getId(),
+            favorite.favorite_id)
+        browser.open(url, method='DELETE', headers={'Accept': 'application/json'})
+
+        self.assertEqual(204, browser.status_code)
+        self.assertEqual(0, Favorite.query.count())
+
+    @browsing
+    def test_raises_unauthorized_when_removing_a_favorite_of_a_other_user(self, browser):
+        self.login(self.administrator, browser=browser)
+
+        favorite = create(Builder('favorite')
+                          .for_user(self.regular_user)
+                          .for_object(self.dossier))
+
+        self.assertEqual(1, Favorite.query.count())
+
+        url = '{}/@favorites/{}/{}'.format(
+            self.portal.absolute_url(), self.regular_user.getId(),
+            favorite.favorite_id)
+
+        with browser.expect_http_error(401):
+            browser.open(url, method='DELETE', headers={'Accept': 'application/json'})
+
+        self.assertEqual(
+            {u'message': u"It's not allowed to delete favorites of other users.",
+             u'type': u'Unauthorized'},
+            browser.json)
+
+
+class TestFavoritesPatch(IntegrationTestCase):
+
+    @browsing
+    def test_raises_when_id_is_missing(self, browser):
+        self.login(self.administrator, browser=browser)
+
+        create(Builder('favorite')
+               .for_user(self.administrator)
+               .for_object(self.dossier))
+
+        with browser.expect_http_error(400):
+            url = '{}/@favorites/{}'.format(
+                self.portal.absolute_url(), self.administrator.getId())
+
+            browser.open(url, method='PATCH',
+                         data=json.dumps({"title": "GEVER Weeklies"}),
+                         headers={'Accept': 'application/json',
+                                  'Content-Type': 'application/json'})
+
+        self.assertEqual(
+            {u'message': u'Must supply user ID and favorite ID as URL path parameters.',
+             u'type': u'BadRequest'}, browser.json)
+
+    @browsing
+    def test_raises_when_favorite_is_not_owned_by_the_given_user(self, browser):
+        self.login(self.administrator, browser=browser)
+
+        create(Builder('favorite')
+               .for_user(self.regular_user)
+               .for_object(self.dossier))
+        favorite = Favorite.query.one()
+
+        with browser.expect_http_error(404):
+            url = '{}/@favorites/{}/{}'.format(
+                self.portal.absolute_url(),
+                self.administrator.getId(),
+                favorite.favorite_id)
+
+            browser.open(url, method='PATCH',
+                         data=json.dumps({"title": "GEVER Weeklies"}),
+                         headers={'Accept': 'application/json',
+                                  'Content-Type': 'application/json'})
+
+        self.assertEqual(
+            {u"message": u'Resource not found: http://nohost/plone/@favorites/nicole.kohler/1',
+             u"type": u"NotFound"}, browser.json)
+
+    @browsing
+    def test_raises_unauthorized_when_updating_favorite_of_a_other_user(self, browser):
+        self.login(self.administrator, browser=browser)
+
+        create(Builder('favorite')
+               .for_user(self.regular_user)
+               .for_object(self.dossier))
+
+        favorite = Favorite.query.one()
+
+        url = '{}/@favorites/{}/{}'.format(
+            self.portal.absolute_url(), self.regular_user.getId(),
+            favorite.favorite_id)
+
+        with browser.expect_http_error(401):
+            browser.open(url, method='PATCH',
+                         data=json.dumps({'title': u'\xdcbersicht OGIPs'}),
+                         headers={'Accept': 'application/json',
+                                  'Content-Type': 'application/json'})
+
+        self.assertEqual(
+            {u'message': u"It's not allowed to update favorites of other users.",
+             u'type': u'Unauthorized'},
+            browser.json)
+
+    @browsing
+    def test_rename_favorite_title(self, browser):
+        self.login(self.administrator, browser=browser)
+
+        create(Builder('favorite')
+               .for_user(self.administrator)
+               .for_object(self.dossier))
+
+        favorite = Favorite.query.one()
+
+        url = '{}/@favorites/{}/{}'.format(
+            self.portal.absolute_url(), self.administrator.getId(),
+            favorite.favorite_id)
+
+        browser.open(url, method='PATCH',
+                     data=json.dumps({'title': u'\xdcbersicht OGIPs'}),
+                     headers={'Accept': 'application/json',
+                              'Content-Type': 'application/json'})
+
+        self.assertEqual(204, browser.status_code)
+        self.assertEqual(u'\xdcbersicht OGIPs', favorite.title)
+        self.assertTrue(favorite.is_title_personalized)
+
+    @browsing
+    def test_prefer_header_is_respected_return_representation(self, browser):
+        self.login(self.administrator, browser=browser)
+
+        create(Builder('favorite')
+               .for_user(self.administrator)
+               .for_object(self.dossier))
+
+        favorite = Favorite.query.one()
+
+        url = '{}/@favorites/{}/{}'.format(
+            self.portal.absolute_url(), self.administrator.getId(),
+            favorite.favorite_id)
+
+        browser.open(url, method='PATCH',
+                     data=json.dumps({'title': u'\xdcbersicht OGIPs'}),
+                     headers={'Accept': 'application/json',
+                              'Prefer': 'return=representation',
+                              'Content-Type': 'application/json'})
+
+        self.assertEqual(200, browser.status_code)
+        self.assertEqual(
+            {u'@id': u'http://nohost/plone/@favorites/nicole.kohler/1',
+             u'favorite_id': 1,
+             u'title': u'\xdcbersicht OGIPs',
+             u'target_url': u'http://nohost/plone/resolve_oguid/plone:1014013300',
+             u'icon_class': u'contenttype-opengever-dossier-businesscasedossier',
+             u'tooltip_url': None,
+             u'oguid': u'plone:1014013300',
+             u'admin_unit': u'Hauptmandant',
+             u'position': None}, browser.json)
+
+    @browsing
+    def test_update_position(self, browser):
+        self.login(self.administrator, browser=browser)
+
+        create(Builder('favorite')
+               .for_user(self.administrator)
+               .for_object(self.dossier)
+               .having(position=0))
+
+        favorite = Favorite.query.one()
+
+        url = '{}/@favorites/{}/{}'.format(
+            self.portal.absolute_url(), self.administrator.getId(),
+            favorite.favorite_id)
+
+        browser.open(url, method='PATCH',
+                     data=json.dumps({'position': 31}),
+                     headers={'Accept': 'application/json',
+                              'Content-Type': 'application/json'})
+
+        self.assertEqual(204, browser.status_code)
+        self.assertEqual(31, favorite.position)
+        self.assertEqual(
+            u'Vertr\xe4ge mit der kantonalen Finanzverwaltung', favorite.title)
+        self.assertFalse(favorite.is_title_personalized)
+
+    @browsing
+    def test_update_position_recalculates_positions_move_up(self, browser):
+        self.login(self.administrator, browser=browser)
+
+        create(Builder('favorite')
+               .for_user(self.administrator)
+               .for_object(self.dossier)
+               .having(position=0))
+
+        create(Builder('favorite')
+               .for_user(self.administrator)
+               .for_object(self.document)
+               .having(position=1))
+
+        create(Builder('favorite')
+               .for_user(self.administrator)
+               .for_object(self.leaf_repofolder)
+               .having(position=2))
+
+        create(Builder('favorite')
+               .for_user(self.administrator)
+               .for_object(self.branch_repofolder)
+               .having(position=3))
+
+        self.assertEquals(
+            [self.dossier, self.document, self.leaf_repofolder,
+             self.branch_repofolder],
+            [fav.oguid.resolve_object() for fav in
+             Favorite.query.order_by(Favorite.position)])
+
+        url = '{}/@favorites/{}/4'.format(
+            self.portal.absolute_url(), self.administrator.getId())
+        browser.open(url, method='PATCH',
+                     data=json.dumps({'position': 1}),
+                     headers={'Accept': 'application/json',
+                              'Content-Type': 'application/json'})
+
+        self.assertEquals(
+            [self.dossier, self.branch_repofolder, self.document,
+             self.leaf_repofolder],
+            [fav.oguid.resolve_object() for fav in Favorite.query.order_by(Favorite.position)])
+
+    @browsing
+    def test_update_position_recalculates_positions_move_down(self, browser):
+        self.login(self.administrator, browser=browser)
+
+        create(Builder('favorite')
+               .for_user(self.administrator)
+               .for_object(self.dossier)
+               .having(position=0, title='Dossier'))
+
+        create(Builder('favorite')
+               .for_user(self.administrator)
+               .for_object(self.document)
+               .having(position=1, title='Document'))
+
+        create(Builder('favorite')
+               .for_user(self.administrator)
+               .for_object(self.leaf_repofolder)
+               .having(position=2, title='Leaf repofolder'))
+
+        create(Builder('favorite')
+               .for_user(self.administrator)
+               .for_object(self.branch_repofolder)
+               .having(position=3, title='Branch repofolder'))
+
+        self.assertEquals(
+            [self.dossier, self.document, self.leaf_repofolder,
+             self.branch_repofolder],
+            [fav.oguid.resolve_object() for fav in
+             Favorite.query.order_by(Favorite.position)])
+
+        url = '{}/@favorites/{}/1'.format(
+            self.portal.absolute_url(), self.administrator.getId())
+        browser.open(url, method='PATCH',
+                     data=json.dumps({'position': 2}),
+                     headers={'Accept': 'application/json',
+                              'Content-Type': 'application/json'})
+
+        self.assertEquals(
+            [self.document, self.leaf_repofolder, self.dossier, self.branch_repofolder],
+            [fav.oguid.resolve_object() for fav in Favorite.query.order_by(Favorite.position)])

--- a/opengever/api/tests/test_repository_favorites.py
+++ b/opengever/api/tests/test_repository_favorites.py
@@ -1,0 +1,99 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.testbrowser import browsing
+from opengever.testing import IntegrationTestCase
+
+
+class TestRepositoryFavoritesGet(IntegrationTestCase):
+
+    @browsing
+    def test_returns_list_of_uids(self, browser):
+        self.login(self.administrator, browser=browser)
+
+        favorite1 = create(Builder('favorite')
+                           .for_user(self.administrator)
+                           .for_object(self.branch_repofolder))
+
+        favorite2 = create(Builder('favorite')
+                           .for_user(self.administrator)
+                           .for_object(self.leaf_repofolder))
+
+        url = '{}/@repository-favorites/{}'.format(
+            self.portal.absolute_url(), self.administrator.getId())
+        browser.open(url, method='GET', headers={'Accept': 'application/json'})
+
+        self.assertEqual(200, browser.status_code)
+        self.assertEqual([favorite1.plone_uid, favorite2.plone_uid],
+                         browser.json)
+
+    @browsing
+    def test_list_only_favorites_for_given_user(self, browser):
+        self.login(self.administrator, browser=browser)
+
+        favorite1 = create(Builder('favorite')
+                           .for_user(self.administrator)
+                           .for_object(self.branch_repofolder))
+
+        create(Builder('favorite')
+               .for_user(self.regular_user)
+               .for_object(self.leaf_repofolder))
+
+        url = '{}/@repository-favorites/{}'.format(
+            self.portal.absolute_url(), self.administrator.getId())
+        browser.open(url, method='GET', headers={'Accept': 'application/json'})
+
+        self.assertEqual(200, browser.status_code)
+        self.assertEqual([favorite1.plone_uid], browser.json)
+
+    @browsing
+    def test_list_only_repositoryfolder_favorites(self, browser):
+        self.login(self.administrator, browser=browser)
+
+        favorite1 = create(Builder('favorite')
+                           .for_user(self.administrator)
+                           .for_object(self.branch_repofolder))
+
+        create(Builder('favorite')
+               .for_user(self.administrator)
+               .for_object(self.dossier))
+
+        url = '{}/@repository-favorites/{}'.format(
+            self.portal.absolute_url(), self.administrator.getId())
+        browser.open(url, method='GET', headers={'Accept': 'application/json'})
+
+        self.assertEqual(200, browser.status_code)
+        self.assertEqual([favorite1.plone_uid], browser.json)
+
+    @browsing
+    def test_list_only_favorites_from_current_admin_unit(self, browser):
+        self.login(self.administrator, browser=browser)
+
+        favorite1 = create(Builder('favorite')
+                           .for_user(self.administrator)
+                           .for_object(self.branch_repofolder))
+
+        create(Builder('favorite')
+               .for_user(self.administrator)
+               .for_object(self.leaf_repofolder)
+               .having(admin_unit_id='sk'))
+
+        url = '{}/@repository-favorites/{}'.format(
+            self.portal.absolute_url(), self.administrator.getId())
+        browser.open(url, method='GET', headers={'Accept': 'application/json'})
+
+        self.assertEqual(200, browser.status_code)
+        self.assertEqual([favorite1.plone_uid], browser.json)
+
+    @browsing
+    def test_raises_when_userid_is_missing(self, browser):
+        self.login(self.administrator, browser=browser)
+
+        with browser.expect_http_error(400):
+            url = '{}/@repository-favorites'.format(self.portal.absolute_url())
+            browser.open(url, method='GET',
+                         headers={'Accept': 'application/json'})
+
+        self.assertEqual(
+            {"message": "Must supply exactly one parameter (user id)",
+             "type": "BadRequest"},
+            browser.json)

--- a/opengever/base/favorite.py
+++ b/opengever/base/favorite.py
@@ -2,6 +2,7 @@ from opengever.base.browser.helper import get_css_class
 from opengever.base.model import create_session
 from opengever.base.model.favorite import Favorite
 from opengever.base.oguid import Oguid
+from opengever.ogds.base.utils import get_current_admin_unit
 from plone.uuid.interfaces import IUUID
 from sqlalchemy import and_
 from zExceptions import NotFound
@@ -79,3 +80,8 @@ class FavoriteManager(object):
 
     def list_all(self, userid):
         return Favorite.query.by_userid(userid=userid).all()
+
+    def list_all_repository_favorites(self, userid):
+        favorites = Favorite.query.only_repository_favorites(
+            userid, get_current_admin_unit().id()).all()
+        return favorites

--- a/opengever/base/favorite.py
+++ b/opengever/base/favorite.py
@@ -1,0 +1,81 @@
+from opengever.base.browser.helper import get_css_class
+from opengever.base.model import create_session
+from opengever.base.model.favorite import Favorite
+from opengever.base.oguid import Oguid
+from plone.uuid.interfaces import IUUID
+from sqlalchemy import and_
+from zExceptions import NotFound
+
+
+class FavoriteManager(object):
+
+    def delete(self, userid, fav_id):
+        favorite = Favorite.query.by_userid_and_id(fav_id, userid).first()
+        if not favorite:
+            # inexistent favorite-id or not ownded by given user
+            raise NotFound
+
+        create_session().delete(favorite)
+
+    def add(self, userid, obj):
+        favorite = Favorite(
+            userid=userid,
+            oguid=Oguid.for_object(obj),
+            title=obj.Title().decode('utf-8'),
+            portal_type=obj.portal_type,
+            icon_class=get_css_class(obj),
+            plone_uid=IUUID(obj),
+            position=self.get_next_position(userid))
+
+        create_session().add(favorite)
+        create_session().flush()
+        return favorite
+
+    def get_next_position(self, userid):
+        position = Favorite.query.get_highest_position(userid)
+        if position is None:
+            return 0
+
+        return position + 1
+
+    def update(self, userid, fav_id, title, position):
+        favorite = Favorite.query.by_userid_and_id(fav_id, userid).first()
+        if not favorite:
+            # inexistent favorite-id or not ownded by given user
+            raise NotFound
+
+        if title:
+            favorite.title = title
+            favorite.is_title_personalized = True
+
+        if position:
+            self.update_position(favorite, position, userid)
+
+        return favorite
+
+    def update_position(self, fav_to_updated, position, userid):
+        """Update the position all favorites affected by the reordering."""
+
+        old_position = fav_to_updated.position
+
+        if old_position == position:
+            return
+        elif old_position < position:
+            # move down
+            favorites_to_reduce = Favorite.query.by_userid(userid).filter(
+                and_(Favorite.position > old_position,
+                     Favorite.position <= position))
+            for favorite in favorites_to_reduce:
+                favorite.position = favorite.position - 1
+        else:
+            # move up
+            favorites_to_raise = Favorite.query.by_userid(userid).filter(
+                and_(Favorite.position >= position,
+                     Favorite.position < old_position))
+            for favorite in favorites_to_raise:
+                favorite.position = favorite.position + 1
+
+        fav_to_updated.position = position
+
+    def list_all(self, userid):
+        return Favorite.query.by_userid(userid=userid).all()

--- a/opengever/base/model/favorite.py
+++ b/opengever/base/model/favorite.py
@@ -100,4 +100,11 @@ class FavoriteQuery(BaseQuery):
         return self.session.query(
             func.max(Favorite.position)).filter_by(userid=userid).scalar()
 
+    def only_repository_favorites(self, userid, admin_unit_id):
+        query = self.by_userid(userid)
+        query = query.filter_by(
+            portal_type='opengever.repository.repositoryfolder')
+        return query.filter_by(admin_unit_id=admin_unit_id)
+
+
 Favorite.query_cls = FavoriteQuery

--- a/opengever/base/model/favorite.py
+++ b/opengever/base/model/favorite.py
@@ -6,11 +6,15 @@ from opengever.base.model import PORTAL_TYPE_LENGTH
 from opengever.base.model import UID_LENGTH
 from opengever.base.model import UTCDateTime
 from opengever.base.oguid import Oguid
+from opengever.bumblebee import is_bumblebeeable
 from opengever.ogds.models import UNIT_ID_LENGTH
 from opengever.ogds.models import USER_ID_LENGTH
+from opengever.ogds.models.admin_unit import AdminUnit
 from opengever.ogds.models.query import BaseQuery
+from sqlalchemy import and_
 from sqlalchemy import Boolean
 from sqlalchemy import Column
+from sqlalchemy import func
 from sqlalchemy import Integer
 from sqlalchemy import String
 from sqlalchemy.orm import composite
@@ -42,6 +46,38 @@ class Favorite(Base):
                       default=utcnow_tz_aware,
                       onupdate=utcnow_tz_aware)
 
+    def serialize(self, portal_url):
+        return {
+            '@id': self.api_url(portal_url),
+            'favorite_id': self.favorite_id,
+            'oguid': self.oguid.id,
+            'title': self.title,
+            'icon_class': self.icon_class,
+            'target_url': self.get_target_url(),
+            'tooltip_url': self.get_tooltip_url(),
+            'position': self.position,
+            'admin_unit': AdminUnit.query.get(self.admin_unit_id).title}
+
+    def api_url(self, portal_url):
+        return '{}/@favorites/{}/{}'.format(
+            portal_url, self.userid, self.favorite_id)
+
+    @property
+    def tooltip_view(self):
+        if is_bumblebeeable(self):
+            return 'tooltip'
+
+    def get_tooltip_url(self):
+        url = self.get_target_url()
+        if self.tooltip_view:
+            return u'{}/{}'.format(url, self.tooltip_view)
+
+        return None
+
+    def get_target_url(self):
+        admin_unit = AdminUnit.query.get(self.admin_unit_id)
+        return u'{}/resolve_oguid/{}'.format(admin_unit.public_url, self.oguid)
+
 
 class FavoriteQuery(BaseQuery):
 
@@ -53,5 +89,15 @@ class FavoriteQuery(BaseQuery):
         oguid = Oguid.for_object(obj)
         return self.filter_by(oguid=oguid, userid=user.getId())
 
+    def by_userid(self, userid):
+        return self.filter_by(userid=userid)
+
+    def by_userid_and_id(self, fav_id, userid):
+        return Favorite.query.filter(
+            and_(Favorite.favorite_id == fav_id, Favorite.userid == userid))
+
+    def get_highest_position(self, userid):
+        return self.session.query(
+            func.max(Favorite.position)).filter_by(userid=userid).scalar()
 
 Favorite.query_cls = FavoriteQuery


### PR DESCRIPTION
Based on #4128 .
 
This PR adds the favorite API endpoints which are used for the new favorite-feature  (OGIP 32):

 - @favorites (GET, POST, PATCH and DELETE)
 - @repository-favorites (GET)

For further information see documentation https://github.com/4teamwork/opengever.core/blob/6636677a4dbe0b5b5ab09f737fae4ce97f2fe05b/docs/public/dev-manual/api/favorite.rst

**Permission and protection:**
 - the GET service requires`zope2.View` all other services requires the `setOwnProperties` permission.
 - All services are protected with an additional check `userid == api.user.get_current()`, which avoid that a user can manipulate favorites of an other user.