### PR TITLE
Make sure bumblebee checksum gets calculated for docs created via REST API

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2018.2.1 (unreleased)
 ---------------------
 
+- Make sure bumblebee checksum gets calculated for docs created via REST API. [lgraf]
 - Implement bumblebee tooltip backdrop. [Kevin Bieri]
 - Add favorite SQL-Model. [phgross]
 - Change label of "checkout/edit" button to "checkout and edit" [njohner]

--- a/opengever/api/tests/test_content_creation.py
+++ b/opengever/api/tests/test_content_creation.py
@@ -1,5 +1,6 @@
 from ftw.builder import Builder
 from ftw.builder import create
+from ftw.bumblebee.interfaces import IBumblebeeDocument
 from opengever.api.testing import RelativeSession
 from opengever.core.testing import OPENGEVER_FUNCTIONAL_ZSERVER_TESTING
 from opengever.testing import FunctionalTestCase
@@ -76,3 +77,6 @@ class TestContentCreation(FunctionalTestCase):
         doc = self.dossier.restrictedTraverse('document-1')
         self.assertEqual(u'Sanierung B\xe4rengraben 2016', doc.title)
         self.assertEqual(u'sanierung-barengraben-2016.txt', doc.file.filename)
+
+        checksum = IBumblebeeDocument(doc).get_checksum()
+        self.assertIsNotNone(checksum)

--- a/opengever/bumblebee/document.py
+++ b/opengever/bumblebee/document.py
@@ -1,5 +1,6 @@
 from ftw.bumblebee.dexterity.document import DXBumblebeeDocument
 from opengever.document.document import IDocumentSchema
+from opengever.document.subscribers import set_digitally_available
 from opengever.mail.mail import IOGMailMarker
 from zope.component import adapter
 
@@ -17,6 +18,14 @@ class DocumentBumblebeeDocument(DXBumblebeeDocument):
         """
         if self.context.is_checked_out():
             return
+
+        # Ensure that digitally_available is up to date, because
+        # is_convertable() below relies on it.
+        #
+        # This is needed because the event handler that updates it also
+        # listens to ObjectModified, and we can't control the order in which
+        # subscribers for the same event type are executed.
+        set_digitally_available(self.context, None)
 
         return super(DocumentBumblebeeDocument, self)._handle_update(force=force)
 


### PR DESCRIPTION
The event handler in `opengever.bumblebee` that does so on `ObjectModified` events
relies on `doc.digitally_available` being up-to-date. This was not the case because both event handlers are registered for the same event type, and we can't control the order in which these event handlers are executed.

We therefore must make sure to update `doc.digitally_available` before checking against it.