### PR TITLE
Update favorites when content changes

### DIFF
--- a/opengever/base/configure.zcml
+++ b/opengever/base/configure.zcml
@@ -250,6 +250,12 @@
       handler=".handlers.remove_favorites"
       />
 
+  <subscriber
+      for="plone.dexterity.interfaces.IDexterityContent
+           opengever.trash.trash.ITrashedEvent"
+      handler=".handlers.remove_favorites"
+      />
+
   <adapter
       factory=".indexes.referenceIndexer"
       name="reference"

--- a/opengever/base/configure.zcml
+++ b/opengever/base/configure.zcml
@@ -256,6 +256,12 @@
       handler=".handlers.remove_favorites"
       />
 
+  <subscriber
+      for="plone.dexterity.interfaces.IDexterityContent
+           zope.lifecycleevent.interfaces.IObjectModifiedEvent"
+      handler=".handlers.update_favorites_title"
+      />
+
   <adapter
       factory=".indexes.referenceIndexer"
       name="reference"

--- a/opengever/base/configure.zcml
+++ b/opengever/base/configure.zcml
@@ -244,6 +244,12 @@
       handler=".subscribers.disallow_anonymous_views_on_site_root"
       />
 
+  <subscriber
+      for="plone.dexterity.interfaces.IDexterityContent
+           zope.lifecycleevent.IObjectRemovedEvent"
+      handler=".handlers.remove_favorites"
+      />
+
   <adapter
       factory=".indexes.referenceIndexer"
       name="reference"

--- a/opengever/base/handlers.py
+++ b/opengever/base/handlers.py
@@ -3,8 +3,12 @@ from opengever.base.model import create_session
 from opengever.base.model.favorite import Favorite
 from opengever.base.oguid import Oguid
 from plone import api
+from plone.app.workflow.interfaces import ILocalrolesModifiedEvent
 from Products.CMFCore.CMFCatalogAware import CatalogAware
+from sqlalchemy import and_
+from zope.container.interfaces import IContainerModifiedEvent
 from zope.lifecycleevent import IObjectRemovedEvent
+from zope.sqlalchemy.datamanager import mark_changed
 
 
 def object_moved_or_added(context, event):
@@ -37,3 +41,30 @@ def remove_favorites(context, event):
 
     stmt = Favorite.__table__.delete().where(Favorite.oguid == oguid)
     create_session().execute(stmt)
+
+
+def is_title_changed(descriptions):
+    for desc in descriptions:
+        for attr in desc.attributes:
+            if attr in ['IOpenGeverBase.title', 'title']:
+                return True
+    return False
+
+
+def update_favorites_title(context, event):
+    """Event handler which updates the titles of all existing favorites for the
+    current context, unless the title is personalized.
+    """
+    if IContainerModifiedEvent.providedBy(event):
+        return
+
+    if ILocalrolesModifiedEvent.providedBy(event):
+        return
+
+    if is_title_changed(event.descriptions):
+        query = Favorite.query.filter(
+            and_(Favorite.oguid == Oguid.for_object(context),
+                 Favorite.is_title_personalized == False))  # noqa
+        query.update({'title': context.title})
+
+        mark_changed(create_session())

--- a/opengever/base/handlers.py
+++ b/opengever/base/handlers.py
@@ -1,4 +1,7 @@
 from ftw.upgrade.helpers import update_security_for
+from opengever.base.model import create_session
+from opengever.base.model.favorite import Favorite
+from opengever.base.oguid import Oguid
 from plone import api
 from Products.CMFCore.CMFCatalogAware import CatalogAware
 from zope.lifecycleevent import IObjectRemovedEvent
@@ -24,3 +27,13 @@ def object_moved_or_added(context, event):
         catalog = api.portal.get_tool('portal_catalog')
         catalog.reindexObject(context, idxs=CatalogAware._cmf_security_indexes,
                               update_metadata=0)
+
+
+def remove_favorites(context, event):
+    """Event handler which removes all existing favorites for the
+    current context.
+    """
+    oguid = Oguid.for_object(context)
+
+    stmt = Favorite.__table__.delete().where(Favorite.oguid == oguid)
+    create_session().execute(stmt)

--- a/opengever/base/tests/test_favorite.py
+++ b/opengever/base/tests/test_favorite.py
@@ -4,6 +4,7 @@ from opengever.base.model import create_session
 from opengever.base.model.favorite import Favorite
 from opengever.base.oguid import Oguid
 from opengever.testing import IntegrationTestCase
+from plone import api
 
 
 class TestFavoriteModel(IntegrationTestCase):
@@ -40,3 +41,23 @@ class TestFavoriteModel(IntegrationTestCase):
             Favorite.query.is_marked_as_favorite(self.document, self.regular_user))
         self.assertFalse(
             Favorite.query.is_marked_as_favorite(self.dossier, self.regular_user))
+
+
+class TestHandlers(IntegrationTestCase):
+
+    def test_all_favorites_are_deleted_when_removing_object(self):
+        self.login(self.manager)
+
+        create(Builder('favorite')
+               .for_object(self.dossier)
+               .for_user(self.administrator))
+
+        create(Builder('favorite')
+               .for_object(self.empty_dossier)
+               .for_user(self.dossier_responsible))
+
+        self.assertEquals(2, Favorite.query.count())
+
+        api.content.delete(obj=self.empty_dossier)
+
+        self.assertEquals(1, Favorite.query.count())

--- a/opengever/base/tests/test_favorite.py
+++ b/opengever/base/tests/test_favorite.py
@@ -4,6 +4,7 @@ from opengever.base.model import create_session
 from opengever.base.model.favorite import Favorite
 from opengever.base.oguid import Oguid
 from opengever.testing import IntegrationTestCase
+from opengever.trash.trash import Trasher
 from plone import api
 
 
@@ -59,5 +60,22 @@ class TestHandlers(IntegrationTestCase):
         self.assertEquals(2, Favorite.query.count())
 
         api.content.delete(obj=self.empty_dossier)
+
+        self.assertEquals(1, Favorite.query.count())
+
+    def test_all_favorites_are_deleted_when_moving_a_document_to_trash(self):
+        self.login(self.regular_user)
+
+        create(Builder('favorite')
+               .for_object(self.dossier)
+               .for_user(self.administrator))
+
+        create(Builder('favorite')
+               .for_object(self.document)
+               .for_user(self.dossier_responsible))
+
+        self.assertEquals(2, Favorite.query.count())
+
+        Trasher(self.document).trash()
 
         self.assertEquals(1, Favorite.query.count())


### PR DESCRIPTION
- Remove favorites when an objects gets trashed or deleted.
- Update favorite title when the object title gets changed, unless the title is personalized.

Closes #4109 