### PR TITLE
Fix datetime picker when adding a new meeting.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2018.2.1 (unreleased)
 ---------------------
 
+- Fix datetime picker when adding a new meeting. [phgross]
 - Make sure bumblebee checksum gets calculated for docs created via REST API. [lgraf]
 - Implement bumblebee tooltip backdrop. [Kevin Bieri]
 - Add favorite SQL-Model. [phgross]

--- a/opengever/meeting/browser/resources/datetimepicker.js
+++ b/opengever/meeting/browser/resources/datetimepicker.js
@@ -30,19 +30,20 @@
     };
 
     if (!this.start.val()) {
-      var roundedStartDateTime = roundMinutes(this.startwidget.getCurrentTime());
-      this.start.val(this.startwidget.str(roundedStartDateTime));
+      var roundedStartDateTime = roundMinutes(this.startwidget.now());
+      this.startwidget.setCurrentTime(roundedStartDateTime);
+      this.start.val(this.startwidget.str());
     }
 
     self.getMinTime = function () {
       var start = self.startwidget.getCurrentTime();
       var end = self.endwidget.getCurrentTime();
-      if (end.getDayOfYear() <= start.getDayOfYear()) {
-        return start.format2();
+      if (end.getYear() <= start.getYear() && end.getDay() <= start.getDay()) {
+        return self.startwidget.getCurrentTime();
       } else {
         return false;
       }
-    }
+    };
 
     // make sure no date is selected before the start of the range by looking
     // up the earliest valid time in the startwidget
@@ -60,7 +61,7 @@
                     }
     });
 
-    // avoid ftw.datetimepicker destroying our end datetime picker 
+    // avoid ftw.datetimepicker destroying our end datetime picker
     $(document).off('change', '.datetimepicker-widget');
   };
 


### PR DESCRIPTION
With the new ftw.datepicker version 1.3.0 the xdsoft widget has been
updated (see https://github.com/4teamwork/ftw.datepicker/pull/16) and
now the API has been changed which lead in to JS failures when adding a new meeting. Closes #4143 

Backport Needed: `2018.2-stable`