### PR TITLE
Fix logout worker when using SSO

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -11,6 +11,7 @@ Changelog
 2018.2.0 (2018-04-04)
 ---------------------
 
+- Fix logout worker when using SSO. [Kevin Bieri]
 - AdvancedSearch: Fix user sources for dossier responsible, task issuer and doc checked_out. [lgraf]
 - Fix displaying quickupload uploadbox for template folders. [deiferni]
 - Homogenize eCH-0147 import/export action titles. [lgraf]

--- a/opengever/base/browser/resources/logoutClient.js
+++ b/opengever/base/browser/resources/logoutClient.js
@@ -3,10 +3,12 @@
 
   // Setup the shared worker which holds all open gever tabs
   function initWorker() {
-    var workerSrc = global.portal_url + "/++resource++opengever.base/logoutWorker.js";
+    var workerSrc = global.portal_url + "/++resource++opengever.base/logoutWorker.js?r=1";
     logoutWorker = new SharedWorker(workerSrc);
     // Reload the tab when the LogoutBus sends a broadcast message
-    logoutWorker.port.onmessage = function() { location.reload(); };
+    logoutWorker.port.onmessage = function(e) {
+      window.location = e.data[0];
+    };
   }
 
   // Prevent the default login behavior. Broadcast a logout message to all open gever tabs instead.
@@ -17,9 +19,8 @@
     }
 
     // Trigger the logout and broadcast to the other gever tabs
-    return $.get(url).done(function() {
-      logoutWorker.port.postMessage('logout');
-    });
+    logoutWorker.port.postMessage([url]);
+    return $.Deferred().resolve();
   }
 
   // Check if SharedWorker is supported

--- a/opengever/base/browser/resources/logoutWorker.js
+++ b/opengever/base/browser/resources/logoutWorker.js
@@ -5,8 +5,8 @@ onconnect = function(e) {
   var port = e.ports[0];
   clients.add(port);
   port.start();
-  port.onmessage = function() {
+  port.onmessage = function(e) {
     // Broadcast logout message to all open gever tabs
-    clients.forEach(c => { c.postMessage('logout'); });
+    clients.forEach(c => { c.postMessage(e.data); });
   };
 };


### PR DESCRIPTION
Reload the page with the actual URL instead of a simple location reload.
This should trigger the reload with the correct URL eg. portal logout
URL.

Backport needed: `2018.2-stable`