### PR TITLE
Delete shadowed documents when resolving a dossier

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -11,6 +11,7 @@ Changelog
 - Fix transport of dates across admin units. [Rotonen]
 - Make sure bumblebee checksum gets calculated for docs created via REST API. [lgraf]
 - Break activity details out per paragraph. [Rotonen]
+- Delete shadowed documents when resolving a dossier [njohner]
 - Implement bumblebee tooltip backdrop. [Kevin Bieri]
 - Add favorite API endpoints. [phgross]
 - Add favorite SQL-Model. [phgross]

--- a/opengever/dossier/resolve.py
+++ b/opengever/dossier/resolve.py
@@ -176,14 +176,30 @@ class StrictDossierResolver(object):
     def after_resolve(self):
         """After resolving a dossier, some cleanup jobs have to be executed:
 
+        - Remove all shadowed documents.
         - Remove all trashed documents.
         - (Trigger PDF-A conversion).
         - Generate a PDF output of the journal.
         """
 
+        self.trash_shadowed_docs()
         self.purge_trash()
         self.create_journal_pdf()
         self.trigger_pdf_conversion()
+
+    def trash_shadowed_docs(self):
+        """Trash all documents that are in shadow state (recursive).
+        """
+        portal_catalog = api.portal.get_tool('portal_catalog')
+        query = {'path': {'query': self.context.absolute_url_path(), 'depth': -1},
+                'object_provides': [IBaseDocument.__identifier__],
+                'review_state': "document-state-shadow"}
+        shadowed_docs = portal_catalog.unrestrictedSearchResults(query)
+
+        if shadowed_docs:
+            with elevated_privileges():
+                api.content.delete(
+                    objects=[brain.getObject() for brain in shadowed_docs])
 
     def purge_trash(self):
         """Delete all trashed documents inside the dossier (recursive).


### PR DESCRIPTION
I gave up writing the tests as integration test cases. I anyway had to build new dossiers and documents, as the `self.dossier` from the `fixture` cannot be resolved (there are documents in it and it contains subdocuments, moreover we would first have to set proper states for all the tasks and such).

resolves #4138 