### PR TITLE
Cleanup history and bump version for next release to 2018.3.0

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -2,20 +2,25 @@
 Changelog
 =========
 
-2018.2.1 (unreleased)
+2018.3.0 (unreleased)
 ---------------------
 
-- Fix datetime picker when adding a new meeting. [phgross]
 - Make sure bumblebee checksum gets calculated for docs created via REST API. [lgraf]
 - Implement bumblebee tooltip backdrop. [Kevin Bieri]
 - Add favorite SQL-Model. [phgross]
 - Change label of "checkout/edit" button to "checkout and edit" [njohner]
 
 
-2018.2.0 (2018-04-04)
+2018.2.1 (2018-04-12)
 ---------------------
 
 - Fix logout worker when using SSO. [Kevin Bieri]
+- Fix datetime picker when adding a new meeting. [phgross]
+
+
+2018.2.0 (2018-04-04)
+---------------------
+
 - AdvancedSearch: Fix user sources for dossier responsible, task issuer and doc checked_out. [lgraf]
 - Fix displaying quickupload uploadbox for template folders. [deiferni]
 - Homogenize eCH-0147 import/export action titles. [lgraf]

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 import os
 
 
-version = '2018.2.1.dev0'
+version = '2018.3.0.dev0'
 maintainer = '4teamwork AG'
 
 


### PR DESCRIPTION
after bugfix release 2018.2.1 has been released via `2018.2-stable` branch.