### PR TITLE
 Break activity details out per paragraph

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,7 @@ Changelog
 
 - Fix transport of dates across admin units. [Rotonen]
 - Make sure bumblebee checksum gets calculated for docs created via REST API. [lgraf]
+- Break activity details out per paragraph. [Rotonen]
 - Implement bumblebee tooltip backdrop. [Kevin Bieri]
 - Add favorite API endpoints. [phgross]
 - Add favorite SQL-Model. [phgross]

--- a/opengever/activity/mailer.py
+++ b/opengever/activity/mailer.py
@@ -23,7 +23,10 @@ class Mailer(object):
     def send_mail(self, msg):
         self.mailhost.send(msg)
 
-    def prepare_mail(self, subject=u'', to_userid=None, from_userid=None, data={}):
+    def prepare_mail(self, subject=u'', to_userid=None, from_userid=None, data=None):
+        if data is None:
+            data = {}
+
         msg = MIMEMultipart('related')
 
         if from_userid:

--- a/opengever/activity/mailer.py
+++ b/opengever/activity/mailer.py
@@ -41,6 +41,10 @@ class Mailer(object):
         msg['To'] = recipient.email
         msg['Subject'] = Header(subject, 'utf-8')
 
+        # Break (potential) description out into a list element per newline
+        if 'description' in data:
+            data['description'] = [line for line in data.get('description').splitlines()]
+
         html = self.prepare_html(data)
         msg.attach(MIMEText(html.encode('utf-8'), 'html', 'utf-8'))
         return msg

--- a/opengever/activity/templates/notification.pt
+++ b/opengever/activity/templates/notification.pt
@@ -40,7 +40,9 @@
 
     <tal:block tal:condition="options/description">
       <p class="details" i18n:translate="label_details">Details:</p>
-      <div tal:content="structure options/description"></div>
+      <tal:block tal:repeat="paragraph options/description">
+        <p tal:content="structure paragraph" />
+      </tal:block>
     </tal:block>
   </body>
 

--- a/opengever/activity/tests/test_mail.py
+++ b/opengever/activity/tests/test_mail.py
@@ -3,132 +3,86 @@ from ftw.builder import create
 from ftw.mail.utils import get_header
 from ftw.testbrowser import browsing
 from ftw.testing.mailing import Mailing
-from opengever.activity.hooks import insert_notification_defaults
-from opengever.core.testing import OPENGEVER_FUNCTIONAL_ACTIVITY_LAYER
-from opengever.testing import FunctionalTestCase
+from opengever.activity.roles import TASK_RESPONSIBLE_ROLE
+from opengever.globalindex.model.task import Task
+from opengever.testing import IntegrationTestCase
 import email
 
 
-class TestEmailNotification(FunctionalTestCase):
+class TestEmailNotification(IntegrationTestCase):
 
-    layer = OPENGEVER_FUNCTIONAL_ACTIVITY_LAYER
+    features = (
+        'activity',
+        )
 
     def setUp(self):
         super(TestEmailNotification, self).setUp()
-        # setup mail
-        Mailing(self.portal).set_up()
+        # XXX - we cannot yet fixturize SQL objects
+        create(Builder('watcher').having(actorid=self.regular_user.id))
+        # XXX - we cannot yet fixturize SQL objects
+        # The secretariat user is a part of the inbox group
+        create(Builder('watcher').having(actorid=self.secretariat_user.id))
 
-        self.hugo = create(Builder('ogds_user')
-                           .assign_to_org_units([self.org_unit])
-                           .having(userid='hugo.boss',
-                                   firstname='Hugo',
-                                   lastname='Boss',
-                                   email='hugo.boss@example.org'))
-
-        self.franz = create(Builder('ogds_user')
-               .assign_to_org_units([self.org_unit])
-               .having(userid='franz.michel',
-                       firstname='Franz',
-                       lastname='Michel',
-                       email='franz.michel@example.org'))
-
-        create(Builder('watcher').having(actorid='hugo.boss'))
-
-        self.dossier = create(Builder('dossier').titled(u'Dossier A'))
-
-        insert_notification_defaults(self.portal)
-
-    def tearDown(self):
-        super(TestEmailNotification, self).tearDown()
-        Mailing(self.layer['portal']).tear_down()
+    def create_task_via_browser(self, browser, inbox=False):
+        browser.open(self.dossier, view='++add++opengever.task.task')
+        browser.fill({'Title': 'Test Task', 'Task Type': 'comment'})
+        # XXX - we cannot yet fixturize SQL objects so we have to hardcode here
+        org_unit_id = u'fa'
+        form = browser.find_form_by_field('Responsible')
+        responsible_id = u':'.join((org_unit_id, self.regular_user.id, ))
+        form.find_widget('Responsible').fill(responsible_id)
+        if inbox:
+            # XXX - How to get the correct id from the fixtured objects?
+            inbox_id = u':'.join(('inbox', org_unit_id, ))
+            form.find_widget('Issuer').fill(inbox_id)
+        browser.css('#form-buttons-save').first.click()
 
     @browsing
     def test_subject_is_title(self, browser):
-        browser.login().open(self.dossier, view='++add++opengever.task.task')
-        browser.fill({'Title': 'Test Task',
-                      'Task Type': 'comment'})
-
-        form = browser.find_form_by_field('Responsible')
-        form.find_widget('Responsible').fill(self.org_unit.id() + ':hugo.boss')
-
-        browser.css('#form-buttons-save').first.click()
-
+        self.login(self.dossier_responsible, browser)
+        self.create_task_via_browser(browser)
         mail = email.message_from_string(Mailing(self.portal).pop())
-
         self.assertEquals('GEVER Task: Test Task', mail.get('Subject'))
 
     @browsing
-    def test_from_and_to_addresses(self, browser):
-        browser.login().open(self.dossier, view='++add++opengever.task.task')
-        browser.fill({'Title': 'Test Task',
-                      'Task Type': 'comment'})
-
-        form = browser.find_form_by_field('Responsible')
-        form.find_widget('Responsible').fill(self.org_unit.id() + ':hugo.boss')
         browser.css('#form-buttons-save').first.click()
 
+    @browsing
+    def test_from_and_to_addresses(self, browser):
+        self.login(self.dossier_responsible, browser)
+        self.create_task_via_browser(browser)
         mail = email.message_from_string(Mailing(self.portal).pop())
-        self.assertEquals('hugo.boss@example.org', mail.get('To'))
-        self.assertEquals(
-            'Test User <test@example.org>', get_header(mail, 'From'))
+        self.assertEquals('foo@example.com', mail.get('To'))
+        self.assertEquals('Ziegler Robert <robert.ziegler@gever.local>', get_header(mail, 'From'))
 
     @browsing
     def test_task_title_is_linked_to_resolve_notification_view(self, browser):
-        browser.login().open(self.dossier, view='++add++opengever.task.task')
-        browser.fill({'Title': 'Test Task',
-                      'Task Type': 'comment'})
-
-        form = browser.find_form_by_field('Responsible')
-        form.find_widget('Responsible').fill(self.org_unit.id() + ':hugo.boss')
-        browser.css('#form-buttons-save').first.click()
-
-        mail = email.message_from_string(Mailing(self.portal).pop())
-        html_part = mail.get_payload()[0].as_string()
-
-        link = '<p><a href=3D"http://example.com/@@resolve_notification' \
-               '?notification_id=\n=3D1">Test Task</a></p>'
-
-        self.assertIn(link, html_part)
+        self.login(self.dossier_responsible, browser)
+        self.create_task_via_browser(browser)
+        raw_mail = Mailing(self.portal).pop()
+        link = '<p><a href=3D"http://nohost/plone/@@resolve_notification?notification_i=\nd=3D1">Test Task</a></p>'
+        self.assertIn(link, raw_mail.strip())
 
     @browsing
     def test_mail_dispatcher_respects_dispatcher_roles(self, browser):
         """By default only the responsible should be notified by mail, when
         a task gets added.
         """
-        browser.login().open(self.dossier, view='++add++opengever.task.task')
-        browser.fill({'Title': 'Test Task',
-                      'Task Type': 'comment'})
-
-        form = browser.find_form_by_field('Responsible')
-        form.find_widget('Responsible').fill(self.org_unit.id() + ':hugo.boss')
-        browser.css('#form-buttons-save').first.click()
-
+        self.login(self.dossier_responsible, browser)
+        browser.open(self.dossier, view='++add++opengever.task.task')
+        self.create_task_via_browser(browser)
         self.assertEquals(1, len(Mailing(self.portal).get_messages()))
         mail = email.message_from_string(Mailing(self.portal).pop())
-        self.assertEquals(
-            'hugo.boss@example.org', get_header(mail, 'To'))
+        self.assertEquals('foo@example.com', get_header(mail, 'To'))
 
     @browsing
     def test_mail_dispatcher_respects_dispatcher_roles_even_if_its_a_group(self, browser):
         """By default only the responsible should be notified by mail, when
         a task gets added.
         """
-
-        inbox_group = self.org_unit.inbox_group
-        inbox_group.users.append(self.hugo)
-        inbox_group.users.append(self.franz)
-
-        browser.login().open(self.dossier, view='++add++opengever.task.task')
-        browser.fill({'Title': 'Test Task',
-                      'Task Type': 'comment'})
-        form = browser.find_form_by_field('Responsible')
-        form.find_widget('Responsible').fill(
-            self.org_unit.id() + ':franz.michel')
-        form.find_widget('Issuer').fill('inbox:client1')
-
-        browser.css('#form-buttons-save').first.click()
-
+        self.login(self.dossier_responsible, browser)
+        browser.open(self.dossier, view='++add++opengever.task.task')
+        self.create_task_via_browser(browser, inbox=True)
         self.assertEquals(1, len(Mailing(self.portal).get_messages()))
         mail = email.message_from_string(Mailing(self.portal).pop())
-        self.assertEquals(
-            'franz.michel@example.org', get_header(mail, 'To'))
+        self.assertEquals('foo@example.com', get_header(mail, 'To'))

--- a/opengever/testing/integration_test_case.py
+++ b/opengever/testing/integration_test_case.py
@@ -3,7 +3,9 @@ from AccessControl.SecurityManagement import setSecurityManager
 from contextlib import contextmanager
 from ftw.flamegraph import flamegraph
 from ftw.mail.mail import IMail
+from ftw.testing.mailing import Mailing
 from functools import wraps
+from opengever.activity.hooks import insert_notification_defaults
 from opengever.base.oguid import Oguid
 from opengever.core.testing import OPENGEVER_INTEGRATION_TESTING
 from opengever.document.interfaces import ICheckinCheckoutManager
@@ -68,6 +70,14 @@ class IntegrationTestCase(TestCase):
         self.request = self.layer['request']
         self.deactivate_extjs()
         map(self.activate_feature, self.features)
+        if 'activity' in self.features:
+            Mailing(self.portal).set_up()
+            insert_notification_defaults(self.portal)
+
+    def tearDown(self):
+        super(IntegrationTestCase, self).tearDown()
+        if 'activity' in self.features:
+            Mailing(self.portal).tear_down()
 
     @staticmethod
     def open_flamegraph(func):


### PR DESCRIPTION
* Breaks the activity details out per paragraphs on notify mails with multi line details

As far as I can tell these are not printed on digests.

Closes https://github.com/4teamwork/opengever.core/issues/3365