### PR TITLE
Fix transport of dates across admin units

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2018.3.0 (unreleased)
 ---------------------
 
+- Fix transport of dates across admin units. [Rotonen]
 - Make sure bumblebee checksum gets calculated for docs created via REST API. [lgraf]
 - Implement bumblebee tooltip backdrop. [Kevin Bieri]
 - Add favorite API endpoints. [phgross]

--- a/opengever/base/tests/test_transport.py
+++ b/opengever/base/tests/test_transport.py
@@ -1,4 +1,5 @@
 from datetime import date
+from datetime import datetime
 from ftw.builder import Builder
 from ftw.builder import create
 from opengever.base.behaviors.classification import IClassification
@@ -98,3 +99,16 @@ class TestTransporter(FunctionalTestCase):
         Transporter().transport_to(
             task, 'client1', target_path,
             view='transporter-privileged-receive-object')
+
+    def test_transport_to_does_not_break_deadline_datatype(self):
+        source = create(Builder("dossier").titled(u"Source"))
+        target = create(Builder("dossier").titled(u"Target"))
+        target_path = '/'.join(target.getPhysicalPath())
+        task = create(
+            Builder("task")
+            .within(source)
+            .titled(u'Fo\xf6')
+            .having(deadline=date(2014, 7, 1)),
+            )
+        Transporter().transport_to(task, 'client1', target_path, view='transporter-privileged-receive-object')
+        self.assertFalse(isinstance(target.getFirstChild().deadline, datetime))

--- a/opengever/base/transport.py
+++ b/opengever/base/transport.py
@@ -275,12 +275,15 @@ class DexterityFieldDataCollector(object):
         are stored on the field later.
         """
         if self._provided_by_one_of(field, [
-                schema.interfaces.IDate,
                 schema.interfaces.ITime,
                 schema.interfaces.IDatetime,
                 ]):
             if value:
                 return DateTime.DateTime(value).asdatetime()
+
+        if self._provided_by_one_of(field, [schema.interfaces.IDate]):
+            if value:
+                return DateTime.DateTime(value).asdatetime().date()
 
         if self._provided_by_one_of(field, [INamedFileField]):
             if value and isinstance(value, dict):


### PR DESCRIPTION
Turns out the transport deserialization logic on the receiving side turned dates into datetimes.

I've tested the test both ways and it does fail with the old logic.

Closes #4068