### PR TITLE
Omit search keywords from advanced search on site search prefill

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2018.3.0 (unreleased)
 ---------------------
 
+- Omit search keywords from advanced search on site search prefill. [Rotonen]
 - Bump ftw.datepicker to 1.3.2 [lgraf]
 - Bump ftw.tokenauth version to 1.0.1 [lgraf]
 - Fix transport of dates across admin units. [Rotonen]

--- a/opengever/base/tests/test_search.py
+++ b/opengever/base/tests/test_search.py
@@ -61,6 +61,17 @@ class TestOpengeverSearch(FunctionalTestCase):
         browser.login().open(self.portal, view='search')
         self.assertEqual(0, len(browser.css('.searchImage')))
 
+    @browsing
+    def test_prefill_from_advanced_search_omits_searchable_text_keywords(self, browser):
+        browser.login().open(
+            self.portal,
+            view='advanced_search?SearchableText=foo+NOT+bar+AND+qwe+OR+asd+AND+zxc+OR+dsa+NOT+rsa',
+            )
+        prefill = browser.css('#searchGadget').first.value
+        self.assertNotIn('AND', prefill)
+        self.assertNotIn('OR', prefill)
+        self.assertNotIn('NOT', prefill)
+
 
 class TestBumblebeePreview(FunctionalTestCase):
 

--- a/opengever/base/viewlets/searchbox.pt
+++ b/opengever/base/viewlets/searchbox.pt
@@ -24,7 +24,7 @@
              title="Search Site"
              accesskey="4"
              i18n:attributes="title title_search_site"
-             tal:attributes="value request/form/SearchableText|nothing;
+             tal:attributes="value view/prefill|nothing;
                              id search_input_id;
                              placeholder view/placeholder"
              class="searchField inputLabel" /><input class="searchButton"
@@ -57,7 +57,7 @@
                i18n:translate="label_advanced_search">Advanced Search&#8230;</a>
           </div>
 		  <!-- END GEVER custom -->
-		  
+
         </div>
       </div>
     </div>

--- a/opengever/base/viewlets/searchbox.py
+++ b/opengever/base/viewlets/searchbox.py
@@ -20,3 +20,9 @@ class SearchBoxViewlet(SearchBoxViewlet):
         placeholder = getattr(self.context, 'search_label',
                               u'title_search_site')
         return translate(placeholder, domain='plone', context=self.request)
+
+    def prefill(self):
+        searchable_text = self.request.form.get('SearchableText')
+        if searchable_text:
+            return searchable_text.replace(' AND', '').replace(' OR', '').replace(' NOT', '')
+        return ''


### PR DESCRIPTION
I'm not very happy about this logic being on the template / view level nor about the way of filtering out, but any alternative I can think of would be horrendously complex.

Closes #4118 