### PR TITLE
Update extends in policy templates.

### DIFF
--- a/opengever/policytemplates/policy_template/opengever.+package.name+/versions.cfg.bob
+++ b/opengever/policytemplates/policy_template/opengever.+package.name+/versions.cfg.bob
@@ -1,6 +1,6 @@
 [buildout]
 extends =
-    http://kgs.4teamwork.ch/release/opengever/XXX
+    https://raw.githubusercontent.com/4teamwork/opengever.core/20XX.Y.Z/versions.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/4teamwork-psc.cfg
     https://raw.githubusercontent.com/4teamwork/opengever.core/master/sources.cfg
     https://raw.githubusercontent.com/4teamwork/gever-buildouts/master/standard-sources.cfg


### PR DESCRIPTION
Extends in our policy templates should include `versions.cfg` from a tag on github instead of the no longer used KGS url.

_CL entry not necessary i'd say._