### PR TITLE
Add opengever.core[tests] to tests_requires.

### DIFF
--- a/opengever/policytemplates/policy_template/opengever.+package.name+/setup.py.bob
+++ b/opengever/policytemplates/policy_template/opengever.+package.name+/setup.py.bob
@@ -8,6 +8,7 @@ tests_require = [
     'ftw.builder',
     'ftw.testbrowser',
     'ftw.testing',
+    'opengever.core[tests]',
     'plone.app.testing',
 ]
 


### PR DESCRIPTION
Otherwise policies won't include necessary test dependency and thus tests will fail for new generated policies.

_CL entry not necessary i'd say._