### PR TITLE
Grant team add and edit permissions to site admins

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ---------------------
 
 - Drop unused pinnings. [lgraf]
+- Grant team add and edit permissions to Adminstrators. [Rotonen]
 - Omit search keywords from advanced search on site search prefill. [Rotonen]
 - Prefix tasks in zip exports. [Rotonen]
 - Allow REST API request for all members. [phgross]

--- a/opengever/contact/permissions.zcml
+++ b/opengever/contact/permissions.zcml
@@ -10,4 +10,8 @@
 
   <permission id="opengever.contact.EditPerson" title="opengever.contact: Edit person" />
 
+  <permission id="opengever.contact.AddTeam" title="opengever.contact: Add team" />
+
+  <permission id="opengever.contact.EditTeam" title="opengever.contact: Edit team" />
+
 </configure>

--- a/opengever/core/lawgiver.zcml
+++ b/opengever/core/lawgiver.zcml
@@ -299,4 +299,12 @@
                    "
       />
 
+  <!-- Should be ignored, teams are site-global. -->
+  <lawgiver:ignore
+      permissions="
+                   opengever.contact: Add team,
+                   opengever.contact: Edit team,
+                   "
+      />
+
 </configure>

--- a/opengever/core/profiles/default/rolemap.xml
+++ b/opengever/core/profiles/default/rolemap.xml
@@ -73,6 +73,16 @@
       <role name="Administrator" />
     </permission>
 
+    <permission name="opengever.contact: Add team" acquire="True">
+      <role name="Manager" />
+      <role name="Administrator" />
+    </permission>
+
+    <permission name="opengever.contact: Edit team" acquire="True">
+      <role name="Manager" />
+      <role name="Administrator" />
+    </permission>
+
     <!-- DISPOSITION -->
     <permission name="opengever.disposition: Add disposition" acquire="True">
       <role name="Manager" />

--- a/opengever/core/upgrades/20180417143819_create_new_team_add_and_edit_permissions/rolemap.xml
+++ b/opengever/core/upgrades/20180417143819_create_new_team_add_and_edit_permissions/rolemap.xml
@@ -1,0 +1,17 @@
+<rolemap>
+
+  <permissions>
+
+    <permission name="opengever.contact: Add team" acquire="True">
+      <role name="Manager" />
+      <role name="Administrator" />
+    </permission>
+
+    <permission name="opengever.contact: Edit team" acquire="True">
+      <role name="Manager" />
+      <role name="Administrator" />
+    </permission>
+
+  </permissions>
+
+</rolemap>

--- a/opengever/core/upgrades/20180417143819_create_new_team_add_and_edit_permissions/upgrade.py
+++ b/opengever/core/upgrades/20180417143819_create_new_team_add_and_edit_permissions/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class CreateNewTeamAddAndEditPermissions(UpgradeStep):
+    """Create new team add and edit permissions.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/ogds/base/browser/configure.zcml
+++ b/opengever/ogds/base/browser/configure.zcml
@@ -66,14 +66,14 @@
       for="opengever.contact.contactfolder.IContactFolder"
       name="add-team"
       class=".team_forms.TeamAddForm"
-      permission="cmf.ManagePortal"
+      permission="opengever.contact.AddTeam"
       />
 
   <browser:page
       name="edit"
       for="opengever.ogds.base.interfaces.ITeam"
       class=".team_forms.TeamEditForm"
-      permission="cmf.ManagePortal"
+      permission="opengever.contact.EditTeam"
       />
 
 </configure>

--- a/opengever/ogds/base/browser/teamdetails.py
+++ b/opengever/ogds/base/browser/teamdetails.py
@@ -18,13 +18,11 @@ class TeamDetails(BrowserView):
         self.request = request
 
     def prepare_model_tabs(self, viewlet):
-        if api.user.has_permission('cmf.ManagePortal', obj=self.context):
-            url = u'{}/team-{}/edit'.format(
-                self.context.parent.absolute_url(), self.model.team_id)
+        if api.user.get_current().checkPermission('opengever.contact: Edit team', self.context):
+            url = u'{}/team-{}/edit'.format(self.context.parent.absolute_url(), self.model.team_id)
             return viewlet.prepare_edit_tab(url)
 
         return tuple()
 
     def get_team_members(self):
-        return [Actor.user(user.userid)
-                for user in self.model.group.users]
+        return [Actor.user(user.userid) for user in self.model.group.users]

--- a/opengever/ogds/base/tests/test_team_forms.py
+++ b/opengever/ogds/base/tests/test_team_forms.py
@@ -7,30 +7,30 @@ from opengever.testing import IntegrationTestCase
 class TestTeamAddForm(IntegrationTestCase):
 
     @browsing
-    def test_add_new_team_form_is_only_available_for_manager(self, browser):
+    def test_add_new_team_form_is_only_available_for_administrators_and_managers(self, browser):
         self.login(self.regular_user, browser)
 
         with browser.expect_unauthorized():
             browser.open(self.contactfolder, view='add-team')
+
+        self.login(self.administrator, browser)
+        browser.open(self.contactfolder, view='add-team')
 
         self.login(self.manager, browser)
         browser.open(self.contactfolder, view='add-team')
 
     @browsing
     def test_add_new_team(self, browser):
-        self.login(self.manager, browser)
-
+        self.login(self.administrator, browser)
         browser.raise_http_errors = False
-
         browser.open(self.contactfolder, view='add-team')
         browser.fill({'Title': u'Projekt \xdcberbaung Dorfmatte'})
-
         form = browser.find_form_by_field('Group')
         form.find_widget('Org Unit').fill('fa')
         form.find_widget('Group').fill('projekt_a')
         browser.find('Save').click()
-
         self.assertEquals(3, len(Team.query.all()))
+
         team = Team.query.get(3)
         self.assertEquals('projekt_a', team.groupid)
         self.assertEquals(u'Projekt \xdcberbaung Dorfmatte', team.title)
@@ -41,41 +41,35 @@ class TestTeamEditForm(IntegrationTestCase):
 
     @browsing
     def test_editing_a_team(self, browser):
-        self.login(self.manager, browser=browser)
+        self.login(self.administrator, browser=browser)
         browser.open(self.contactfolder, view='team-1/edit')
-
         browser.fill({'Title': u'Projekt \xdcberbaung Dorf S\xfcd'})
         browser.click_on('Save')
 
         self.assertEquals(['Changes saved'], info_messages())
-        self.assertEquals(
-            u'Projekt \xdcberbaung Dorf S\xfcd', Team.get('1').title)
+        self.assertEquals(u'Projekt \xdcberbaung Dorf S\xfcd', Team.get('1').title)
 
     @browsing
     def test_values_injected_correclty(self, browser):
-        self.login(self.manager, browser=browser)
-
+        self.login(self.administrator, browser=browser)
         team = Team.get(1)
         team.active = False
-
         browser.open(self.contactfolder, view='team-1/edit')
 
         form = browser.forms['form']
-        self.assertEquals(
-            u'Projekt \xdcberbaung Dorfmatte', form.find_field('Title').value)
+        self.assertEquals(u'Projekt \xdcberbaung Dorfmatte', form.find_field('Title').value)
         self.assertIsNone(form.find_field('Active').get('checked'))
         self.assertEquals(u'projekt_a', form.find_field('Group').value)
         self.assertEquals(u'fa', form.find_field('Org Unit').value)
 
     @browsing
-    def test_editing_is_only_available_for_managers(self, browser):
+    def test_editing_is_only_available_for_administrators_and_managers(self, browser):
         with browser.expect_unauthorized():
             self.login(self.regular_user, browser=browser)
             browser.open(self.contactfolder, view='team-1/edit')
 
-        with browser.expect_unauthorized():
-            self.login(self.administrator, browser=browser)
-            browser.open(self.contactfolder, view='team-1/edit')
+        self.login(self.administrator, browser=browser)
+        browser.open(self.contactfolder, view='team-1/edit')
 
         self.login(self.manager, browser=browser)
         browser.open(self.contactfolder, view='team-1/edit')
@@ -84,18 +78,25 @@ class TestTeamEditForm(IntegrationTestCase):
 class TestTeamEditAction(IntegrationTestCase):
 
     @browsing
+    def test_edit_link_is_visible_for_administrators(self, browser):
+        self.login(self.administrator, browser=browser)
+        browser.open(self.contactfolder, view='team-1/view')
+        self.assertEquals(['Edit'], browser.css('#content-views').text)
+
+        url = browser.css('#content-views a')[0].get('href')
+        self.assertTrue(url.startswith('http://nohost/plone/kontakte/team-1/edit'))
+
+    @browsing
     def test_edit_link_is_visible_for_managers(self, browser):
         self.login(self.manager, browser=browser)
         browser.open(self.contactfolder, view='team-1/view')
-
         self.assertEquals(['Edit'], browser.css('#content-views').text)
+
         url = browser.css('#content-views a')[0].get('href')
-        self.assertTrue(
-            url.startswith('http://nohost/plone/kontakte/team-1/edit'))
+        self.assertTrue(url.startswith('http://nohost/plone/kontakte/team-1/edit'))
 
     @browsing
     def test_edit_link_is_not_visible_for_regular_users(self, browser):
         self.login(self.regular_user, browser=browser)
         browser.open(self.contactfolder, view='team-1/view')
-
         self.assertEquals([''], browser.css('#content-views').text)


### PR DESCRIPTION
* Defined new roles
* Amended rolemap + added a migration for it
* Amended view registrations
* Amended team details view logic on edit link visibility
* Amended tests
* Ignored in lawgiver as teams are site-global

Closes #4054 