### PR TITLE
Fix i18n domain in the types xml of the filing profile.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ---------------------
 
 - Update dependencies. [lgraf]
+- Fix i18n domain in the types xml of the filing profile. [phgross]
 - Drop unused pinnings. [lgraf]
 - Grant team add and edit permissions to Adminstrators. [Rotonen]
 - Omit search keywords from advanced search on site search prefill. [Rotonen]

--- a/opengever/dossier/profiles/filing/types/opengever.dossier.businesscasedossier.xml
+++ b/opengever/dossier/profiles/filing/types/opengever.dossier.businesscasedossier.xml
@@ -1,4 +1,4 @@
-<object xmlns:i18n="http://xml.zope.org/namespaces/i18n" name="opengever.dossier.businesscasedossier" meta_type="Dexterity FTI" i18n:domain="opengever.dossier">
+<object xmlns:i18n="http://xml.zope.org/namespaces/i18n" name="opengever.dossier.businesscasedossier" meta_type="Dexterity FTI" i18n:domain="opengever.core">
 
   <!-- enabled behaviors -->
   <property name="behaviors" purge="False">


### PR DESCRIPTION
Currently the translation for "Businesscase Dossier" in the factory menu is broken after installing the filing profile, because the i18n domain has changed since the profile-merge.