### PR TITLE
OGDS sync: Fix handling of missing user after updating python-ldap:

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2018.3.0 (unreleased)
 ---------------------
 
+- OGDS sync: Fix handling of missing user after updating python-ldap. [lgraf]
 - Make office connector mimetype checks case insensitive. [tarnap]
 - Update dependencies. [lgraf]
 - Fix i18n domain in the types xml of the filing profile. [phgross]

--- a/opengever/ogds/base/sync/ldap_util.py
+++ b/opengever/ogds/base/sync/ldap_util.py
@@ -362,7 +362,11 @@ class LDAPSearch(object):
         """
         results = self.search(base_dn=dn, scope=ldap.SCOPE_BASE)
 
-        # We query for a specific DN and therefor expect at most one entry
+        if not results:
+            # No results found
+            return None
+
+        # We query for a specific DN and therefore expect at most one entry
         entry = results[0]
 
         entry = self.apply_schema_map(entry)

--- a/opengever/ogds/base/sync/ldap_util.py
+++ b/opengever/ogds/base/sync/ldap_util.py
@@ -206,7 +206,11 @@ class LDAPSearch(object):
                         is_last_page = True
             else:
                 is_last_page = True
-                logger.warn("Server ignores paged results control (RFC 2696).")
+                if results:
+                    # If the search returned an empty result, page controls
+                    # aren't included - so don't produce a bogus warning
+                    logger.warn(
+                        "Server ignores paged results control (RFC 2696).")
 
         return results
 

--- a/opengever/ogds/base/sync/ldap_util.py
+++ b/opengever/ogds/base/sync/ldap_util.py
@@ -215,8 +215,8 @@ class LDAPSearch(object):
         """Search LDAP for entries matching the given criteria, using result
         pagination if appropriate, and return the results immediately.
 
-        `base_dn`, `scope`, `search_filter` and `attrs` have the same meaning as the
-        corresponding arguments on the ldap.search* methods.
+        `base_dn`, `scope`, `search_filter` and `attrs` have the same meaning
+        as the corresponding arguments on the ldap.search* methods.
         """
         if base_dn is None:
             base_dn = self.base_dn
@@ -455,7 +455,7 @@ class LDAPSearch(object):
         """
         schema_maps = self.context.getSchemaDict()
         for schema_map in schema_maps:
-            pattern = '\(%s([><~]?=)' % schema_map['public_name']
+            pattern = '\\(%s([><~]?=)' % schema_map['public_name']
             repl = '(%s\\1' % schema_map['ldap_name']
             filterstr = re.sub(pattern, repl, filterstr)
         return filterstr

--- a/opengever/ogds/base/tests/ldaphelpers.py
+++ b/opengever/ogds/base/tests/ldaphelpers.py
@@ -3,7 +3,6 @@ from Products.LDAPMultiPlugins.interfaces import ILDAPMultiPlugin
 from zope.component import adapts
 from zope.interface import implements
 from zope.interface import Interface
-import ldap
 
 
 class IFakeLDAPUserFolder(Interface):
@@ -92,4 +91,4 @@ class FakeLDAPSearchUtility(object):
         for entry in entries:
             if entry[0] == dn:
                 return entry
-        raise ldap.NO_SUCH_OBJECT(dn)
+        return None


### PR DESCRIPTION
Starting with 2.4.21, `python-ldap` now doesn't raise `ldap.NO_SUCH_OBJECT` anymore if case of empty search results, but instead returns an empty list.

See https://github.com/python-ldap/python-ldap/blob/28f5251fd534fd50d333b522c857a2b0aaa56787/CHANGES#L543-L544