### PR TITLE
Fix path filterd Solr searches.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2018.3.0 (unreleased)
 ---------------------
 
+- Fix path filterd Solr searches. [phgross]
 - OGDS sync: Fix handling of missing user after updating python-ldap. [lgraf]
 - Make office connector mimetype checks case insensitive. [tarnap]
 - Update dependencies. [lgraf]

--- a/opengever/base/browser/search.py
+++ b/opengever/base/browser/search.py
@@ -104,6 +104,11 @@ class OpengeverSearch(Search):
             if key not in schema.fields:
                 continue
 
+            # ftw.solr expect an exact match on the 'path' index,
+            # so we have to use `path_parent`.
+            if key == 'path':
+                key = 'path_parent'
+
             if isinstance(key, str):
                 key = key.decode('utf8')
 

--- a/opengever/base/tests/test_search.py
+++ b/opengever/base/tests/test_search.py
@@ -262,6 +262,14 @@ class TestSolrSearch(IntegrationTestCase):
             self.search.solr_filters(),
             [u'responsible:hans.muster', u'sequence_number:123'])
 
+    def test_solr_filters_switch_path_to_parent_path(self):
+        self.request.environ['QUERY_STRING'] = (
+            'sequence_number:int=123&path=/fd/ordnungssystem')
+        self.request.processInputs()
+        self.assertEqual(
+            self.search.solr_filters(),
+            [u'path_parent:\\/fd\\/ordnungssystem', u'sequence_number:123'])
+
     def test_solr_sort_on_date(self):
         self.request.environ['QUERY_STRING'] = (
             'sort_on=Date&sort_order=reverse')


### PR DESCRIPTION
ftw.solr expects an exact match when filtering on 'path' index, so we have to use `path_parent` for the "search only in this are"- use case.

The livesearch is already handling this, no change needed (see
https://github.com/4teamwork/opengever.core/blob/master/opengever/base/browser/livesearch.py#L59).

Closes #4069.