### PR TITLE
Add bumblebee auto-refresh feature flag.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ---------------------
 
 - Implement bumblebee's auto refresh functionality. [siegy]
+- Add bumblebee auto refresh feature flag. [deiferni]
 - OGDS sync: Fix handling of missing user after updating python-ldap. [lgraf]
 - Make office connector mimetype checks case insensitive. [tarnap]
 - Update dependencies. [lgraf]

--- a/opengever/base/browser/jsvariables.py
+++ b/opengever/base/browser/jsvariables.py
@@ -1,5 +1,6 @@
-from Products.CMFPlone.browser.jsvariables import JSVariables
 from ftw import bumblebee
+from opengever.bumblebee import is_auto_refresh_enabled
+from Products.CMFPlone.browser.jsvariables import JSVariables
 
 
 TEMPLATE = u"{other_vars}\
@@ -17,6 +18,9 @@ class GeverJSVariables(JSVariables):
     def __call__(self, *args, **kwargs):
         other_vars = super(GeverJSVariables, self).__call__(*args, **kwargs)
         notification_url = bumblebee.get_service_v3().get_notifications_url()
+
+        if not is_auto_refresh_enabled():
+            return other_vars
 
         return TEMPLATE.format(
             other_vars=other_vars,

--- a/opengever/base/tests/test_jsvariables.py
+++ b/opengever/base/tests/test_jsvariables.py
@@ -7,6 +7,10 @@ class TestGeverJSVariables(IntegrationTestCase):
     """Test the base behavior with the help of businesscase dossier.
     """
 
+    features = (
+        'bumblebee-auto-refresh',
+    )
+
     def test_geverjs_variables(self):
         self.login(self.regular_user)
 

--- a/opengever/bumblebee/__init__.py
+++ b/opengever/bumblebee/__init__.py
@@ -16,6 +16,11 @@ def is_bumblebee_feature_enabled():
         'is_feature_enabled', interface=IGeverBumblebeeSettings)
 
 
+def is_auto_refresh_enabled():
+    return api.portal.get_registry_record(
+        'is_auto_refresh_enabled', interface=IGeverBumblebeeSettings)
+
+
 def set_preferred_listing_view(value):
     request = getRequest()
     request.RESPONSE.setCookie(BUMBLEBEE_VIEW_COOKIE_NAME, value, path='/')

--- a/opengever/bumblebee/browser/resources/bumblebee.js
+++ b/opengever/bumblebee/browser/resources/bumblebee.js
@@ -335,7 +335,10 @@
       updateShowroom();
     })
     .on("ready", function() {
-      BumblebeeCable.init(window.bumblebee_notification_url);
+      var nofitication_url = window.bumblebee_notification_url;
+      if (typeof nofitication_url !== 'undefined') {
+        BumblebeeCable.init(window.bumblebee_notification_url);
+      }
     })
     .on("tooltip.show", function() {
       scanForBrokenImages(".bumblebee-thumbnail");

--- a/opengever/bumblebee/interfaces.py
+++ b/opengever/bumblebee/interfaces.py
@@ -21,6 +21,11 @@ class IGeverBumblebeeSettings(Interface):
         description=u'Sets target="_blank" for links to PDF files.',
         default=False)
 
+    is_auto_refresh_enabled = schema.Bool(
+        title=u'Enable bumblebee auto refresh feature',
+        description=u'Automatically load preview images once available.',
+        default=False)
+
 
 class IVersionedContextMarker(Interface):
     """Marker interface for a versioned context.

--- a/opengever/core/upgrades/20180423163916_add_bumblebee_auto_refresh_feature_flag/registry.xml
+++ b/opengever/core/upgrades/20180423163916_add_bumblebee_auto_refresh_feature_flag/registry.xml
@@ -1,0 +1,4 @@
+<registry>
+  <record interface="opengever.bumblebee.interfaces.IGeverBumblebeeSettings"
+          field="is_auto_refresh_enabled" />
+</registry>

--- a/opengever/core/upgrades/20180423163916_add_bumblebee_auto_refresh_feature_flag/upgrade.py
+++ b/opengever/core/upgrades/20180423163916_add_bumblebee_auto_refresh_feature_flag/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddBumblebeeAutoRefreshFeatureFlag(UpgradeStep):
+    """Add bumblebee auto refresh feature flag.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/examplecontent/profiles/default/registry.xml
+++ b/opengever/examplecontent/profiles/default/registry.xml
@@ -14,6 +14,7 @@
 
   <records interface="opengever.bumblebee.interfaces.IGeverBumblebeeSettings">
     <value key="is_feature_enabled">True</value>
+    <value key="is_auto_refresh_enabled">True</value>
   </records>
 
   <records interface="opengever.contact.interfaces.IContactSettings">

--- a/opengever/testing/integration_test_case.py
+++ b/opengever/testing/integration_test_case.py
@@ -40,6 +40,7 @@ FEATURE_FLAGS = {
     'activity': 'opengever.activity.interfaces.IActivitySettings.is_feature_enabled',
     'bumblebee': 'opengever.bumblebee.interfaces.IGeverBumblebeeSettings.is_feature_enabled',
     'bumblebee-open-pdf-new-tab': 'opengever.bumblebee.interfaces.IGeverBumblebeeSettings.open_pdf_in_a_new_window',
+    'bumblebee-auto-refresh': 'opengever.bumblebee.interfaces.IGeverBumblebeeSettings.is_auto_refresh_enabled',
     'contact': 'opengever.contact.interfaces.IContactSettings.is_feature_enabled',
     'doc-properties': 'opengever.dossier.interfaces.ITemplateFolderProperties.create_doc_properties',
     'dossiertemplate': 'opengever.dossier.dossiertemplate.interfaces.IDossierTemplateSettings.is_feature_enabled',


### PR DESCRIPTION
Add a feature-flag to enable/disable bumblebee auto-refresh. This allows us to avoid 404s in the browser console when the backend's `notifications` endpoint is not available.