### PR TITLE
Fix bumblebee inbox documents gallery preview

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -11,6 +11,7 @@ Changelog
 - Add bumblebee auto refresh feature flag. [deiferni]
 - Fix dates for transported objects. [phgross]
 - Implement a view for the manger to see the current config. [Rotonen]
+- Fix content displayed in the inbox' bumblebee documents gallery. [tarnap]
 - OGDS sync: Fix handling of missing user after updating python-ldap. [lgraf]
 - Allow '\uf04a' in task text. [tarnap]
 - Make office connector mimetype checks case insensitive. [tarnap]

--- a/opengever/inbox/browser/configure.zcml
+++ b/opengever/inbox/browser/configure.zcml
@@ -84,6 +84,14 @@
       />
 
   <browser:page
+      name="tabbedview_view-documents-gallery"
+      for="opengever.inbox.inbox.IInbox"
+      class=".tabs.InboxDocumentsGallery"
+      permission="zope2.View"
+      allowed_attributes="fetch"
+      />
+
+  <browser:page
       name="tabbedview_view-trash"
       for="opengever.inbox.inbox.IInbox"
       class=".tabs.InboxTrash"

--- a/opengever/inbox/browser/tabs.py
+++ b/opengever/inbox/browser/tabs.py
@@ -5,6 +5,7 @@ from opengever.tabbedview.browser.tabs import Tasks
 from opengever.tabbedview.browser.tabs import Trash
 from opengever.tabbedview.browser.tasklisting import GlobalTaskListingTab
 from opengever.tabbedview.helper import external_edit_link
+from opengever.tabbedview.browser.bumblebee_gallery import BumblebeeGalleryMixin
 
 
 def _get_current_org_unit_id(context):
@@ -117,6 +118,12 @@ class InboxDocuments(Documents):
                    if action not in ('create_task',)]
         actions += ['create_forwarding']
         return actions
+
+
+class InboxDocumentsGallery(BumblebeeGalleryMixin, InboxDocuments):
+    """Bumblebee gallery for inbox documents
+    """
+    depth = 1
 
 
 class InboxTrash(Trash):

--- a/opengever/inbox/tests/test_inbox_bumblebee_gallery.py
+++ b/opengever/inbox/tests/test_inbox_bumblebee_gallery.py
@@ -1,0 +1,18 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.testbrowser import browsing
+from opengever.testing import IntegrationTestCase
+
+
+class TestInboxBumblebeeGallery(IntegrationTestCase):
+
+    features = ('bumblebee', )
+
+    @browsing
+    def test_gallery_does_not_display_redirected_inbox_elements(self, browser):
+        self.login(self.secretariat_user, browser)
+        browser.open(self.inbox, view='tabbedview_view-documents-gallery')
+        self.assertEquals(
+            [u'Dokument im Eingangsk\xf6rbli'],
+            [img.attrib.get('alt') for img in browser.css('img')]
+        )


### PR DESCRIPTION
When documents are redirected, they're stored in a subdossier. If the
depth is not set, the bumblebee gallery will display all objects of
subdossiers.
To prevent displaying redirected inbox documents, the depth is set to 1.

![bumblebee](https://user-images.githubusercontent.com/194114/39173988-9c456608-47a6-11e8-9109-18a595e219b3.gif)

Resolves #4191 