### PR TITLE
Fix dates for transported objects.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -8,6 +8,7 @@ Changelog
 - Fix path filterd Solr searches. [phgross]
 - Implement bumblebee's auto refresh functionality. [siegy]
 - Add bumblebee auto refresh feature flag. [deiferni]
+- Fix dates for transported objects. [phgross]
 - OGDS sync: Fix handling of missing user after updating python-ldap. [lgraf]
 - Allow '\uf04a' in task text. [tarnap]
 - Make office connector mimetype checks case insensitive. [tarnap]

--- a/opengever/core/upgrade.py
+++ b/opengever/core/upgrade.py
@@ -12,6 +12,8 @@ from sqlalchemy import MetaData
 from sqlalchemy import String
 from sqlalchemy.schema import CreateSequence
 from sqlalchemy.schema import Sequence
+from sqlalchemy.sql.expression import column
+from sqlalchemy.sql.expression import table
 from zope.interface import implementer
 from zope.interface import Interface
 from zope.sqlalchemy.datamanager import mark_changed
@@ -302,6 +304,11 @@ class SQLUpgradeStep(UpgradeStep):
     def _setup_db_connection(self):
         self.session = create_session()
         self.connection = self.session.connection()
+
+    def has_multiple_admin_units(self):
+        admin_unit_table = table("admin_units", column("unit_id"))
+        query = self.session.query(admin_unit_table.c.unit_id)
+        return query.count() > 1
 
 
 @implementer(ISchemaMigration)

--- a/opengever/core/upgrades/20180424145246_fix_date_for_transported_objects/upgrade.py
+++ b/opengever/core/upgrades/20180424145246_fix_date_for_transported_objects/upgrade.py
@@ -1,0 +1,60 @@
+from datetime import datetime
+from opengever.core.upgrade import SQLUpgradeStep
+from opengever.document.behaviors import IBaseDocument
+from opengever.task.task import ITask
+
+
+TASK_DATE_FIELDS = [
+    ('deadline', 'deadline'),
+    ('date_of_completion', 'date_of_completion'),
+    ('expectedStartOfWork', None)]
+
+DOCUMENT_DATE_FIELDS = [
+    ('document_date', 'document_date'),
+    ('receipt_date', 'receipt_date'),
+    ('delivery_date', 'delivery_date')]
+
+
+class FixDateForTransportedObjects(SQLUpgradeStep):
+    """Fix date for transported objects.
+    """
+
+    def migrate(self):
+        if not self.has_multiple_admin_units():
+            # Transporter is only used on deployments with multiple adminunits,
+            # therefore we skip on single admin unit sites.
+            return
+
+        query = {'object_provides': ITask.__identifier__}
+        for obj in self.objects(query, 'Fix task dates'):
+            self.fix_task_dates(obj)
+
+        query = {'object_provides': IBaseDocument.__identifier__}
+        for obj in self.objects(query, 'Fix document dates'):
+            self.fix_document_dates(obj)
+
+    def fix_task_dates(self, task):
+        indexes_to_update = []
+
+        for date_field, index in TASK_DATE_FIELDS:
+            value = getattr(task, date_field)
+            if value and isinstance(value, datetime):
+                setattr(task, date_field, value.date())
+                if index:
+                    indexes_to_update.append(index)
+
+        if indexes_to_update:
+            task.reindexObject(idxs=indexes_to_update)
+
+    def fix_document_dates(self, document):
+        indexes_to_update = []
+
+        for date_field, index in DOCUMENT_DATE_FIELDS:
+            value = getattr(document, date_field)
+            if value and isinstance(value, datetime):
+                setattr(document, date_field, value.date())
+                if index:
+                    indexes_to_update.append(index)
+
+        if indexes_to_update:
+            document.reindexObject(idxs=indexes_to_update)


### PR DESCRIPTION
Adds an upgradestep which fixes dates for transported objects (closes #4156). See #4155 for more information.

The upgradestep is skipped on a single admin_unit deployment, because the transporter is only used in multi admin_unit communication and potentially long running.