### PR TITLE
Add view returning oneoffixx xml

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2018.3.0 (unreleased)
 ---------------------
 
+- Add view to get the Connect XML for OneOffixx. [njohner]
 - Fix favorite etag adapter for webdav requests. [phgross]
 - Fix get_css_class helper for task objects. [phgross]
 - Fix path filterd Solr searches. [phgross]

--- a/opengever/oneoffixx/browser/configure.zcml
+++ b/opengever/oneoffixx/browser/configure.zcml
@@ -17,4 +17,11 @@
       permission="zope2.View"
       />
 
+  <browser:page
+      for="opengever.document.behaviors.IBaseDocument"
+      name="oneoffix_connect_xml"
+      class=".connect_xml.OneoffixxConnectXml"
+      permission="cmf.ModifyPortalContent"
+      />
+
 </configure>

--- a/opengever/oneoffixx/browser/connect_xml.py
+++ b/opengever/oneoffixx/browser/connect_xml.py
@@ -1,0 +1,144 @@
+from lxml import etree
+from opengever.base.interfaces import IReferenceNumber
+from plone import api
+from Products.Five import BrowserView
+from zExceptions import NotFound
+from zope.annotation.interfaces import IAnnotations
+
+
+class OneoffixxConnectXml(BrowserView):
+
+    def __call__(self):
+        if not self.is_allowed():
+            raise NotFound()
+
+        self.settings = {"KeepConnector": "true",
+                         "CreateConnectorResult": "true",
+                         "CreateConnectorResultOnError": "true"}
+
+        self.commands = {"DefaultProcess": (("start", "false"),),
+                         "ConvertToDocument": tuple(),
+                         "SaveAs": (("Overwrite", "true"),
+                                    ("CreateFolder", "true"),
+                                    ("AllowUpdateDocumentPart", "false"),
+                                    ("Filename", ""))
+                         }
+
+        self.request.RESPONSE.setHeader("Content-type", "application/xml")
+        return self.generate_xml()
+
+    def is_allowed(self):
+        if api.content.get_state(self.context) == 'document-state-shadow':
+            return True
+        return False
+
+    def generate_xml(self):
+        nsmap = {None: "http://schema.oneoffixx.com/OneOffixxConnectBatch/1",
+                 "xsi": "http://www.w3.org/2001/XMLSchema-instance"}
+        batch = etree.Element("OneOffixxConnectBatch", nsmap=nsmap)
+        batch.append(self.generate_settings_tag())
+
+        entries = etree.SubElement(batch, "Entries")
+        entries.append(self.generate_one_offixx_connect_tag())
+        return etree.tostring(batch, pretty_print=True)
+
+    def generate_settings_tag(self):
+        settings_tag = etree.Element("Settings")
+        for key, value in self.settings.iteritems():
+            setting_tag = etree.SubElement(settings_tag, "Add")
+            setting_tag.set("key", key)
+            setting_tag.text = value
+        return settings_tag
+
+    @staticmethod
+    def choose_language(languages):
+        """ Templates can exist in several languages and we need
+        to pick one. 2055 is for German Switzerland.
+        """
+        if 2055 in languages:
+            return "2055"
+        else:
+            return str(languages[0])
+
+    def generate_one_offixx_connect_tag(self):
+        connect = etree.Element("OneOffixxConnect")
+        arguments = etree.SubElement(connect, "Arguments")
+
+        annotations = IAnnotations(self.context)
+        if annotations.get('template-id'):
+            template_id = etree.SubElement(arguments, "TemplateId")
+            template_id.text = annotations['template-id']
+        if annotations.get('languages'):
+            language_id = etree.SubElement(arguments, "LanguageLcid")
+            language = self.choose_language(annotations['languages'])
+            language_id.text = language
+
+        custom_interface = self.generate_custom_interface_connector_tag()
+        connect.append(custom_interface)
+        metadata = self.generate_metadata_tag()
+        connect.append(metadata)
+        commands = self.generate_commands_tag()
+        connect.append(commands)
+        return connect
+
+    def generate_commands_tag(self):
+        commands_tag = etree.Element("Commands")
+        for command in self.commands:
+            command_tag = etree.SubElement(commands_tag, "Command")
+            command_tag.set("Name", command)
+            parameters = self.commands[command]
+            if not parameters:
+                continue
+            parameters_tag = etree.SubElement(command_tag, "Parameters")
+            for key, value in parameters:
+                parameter_tag = etree.SubElement(parameters_tag, "Add")
+                parameter_tag.set("key", key)
+                parameter_tag.text = value
+
+        return commands_tag
+
+    def generate_custom_interface_connector_tag(self):
+        function = etree.Element("Function")
+        function.set("name", "CustomInterfaceConnector")
+        function.set("id", "70E94788-CE84-4460-9698-5663878A295B")
+
+        arguments = etree.SubElement(function, "Arguments")
+
+        interface = etree.SubElement(arguments, "Interface")
+        interface.set("Name", "OneGovGEVER")
+
+        node = etree.SubElement(interface, "Node")
+        node.set("Id", "ogg.document.title")
+        node.text = self.context.Title().decode("utf-8")
+
+        reference_number = IReferenceNumber(self.context)
+        node = etree.SubElement(interface, "Node")
+        node.set("Id", "ogg.document.reference_number")
+        node.text = reference_number.get_number()
+
+        node = etree.SubElement(interface, "Node")
+        node.set("Id", "ogg.document.sequence_number")
+        node.text = reference_number.get_local_number()
+        return function
+
+    def generate_metadata_tag(self):
+        function = etree.Element("Function")
+        function.set("name", "MetaData")
+        function.set("id", "c364b495-7176-4ce2-9f7c-e71f302b8096")
+
+        node = etree.SubElement(function, "Value")
+        node.set("key", "ogg.document.title")
+        node.set("type", "string")
+        node.text = self.context.Title().decode("utf-8")
+
+        reference_number = IReferenceNumber(self.context)
+        node = etree.SubElement(function, "Value")
+        node.set("key", "ogg.document.reference_number")
+        node.set("type", "string")
+        node.text = reference_number.get_number()
+
+        node = etree.SubElement(function, "Value")
+        node.set("key", "ogg.document.sequence_number")
+        node.set("type", "string")
+        node.text = reference_number.get_local_number()
+        return function

--- a/opengever/oneoffixx/tests/assets/oneoffixx_connect_xml.txt
+++ b/opengever/oneoffixx/tests/assets/oneoffixx_connect_xml.txt
@@ -1,0 +1,45 @@
+<OneOffixxConnectBatch xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://schema.oneoffixx.com/OneOffixxConnectBatch/1">
+  <Settings>
+    <Add key="KeepConnector">true</Add>
+    <Add key="CreateConnectorResultOnError">true</Add>
+    <Add key="CreateConnectorResult">true</Add>
+  </Settings>
+  <Entries>
+    <OneOffixxConnect>
+      <Arguments>
+        <TemplateId>2574d08d-95ea-4639-beab-3103fe4c3bc7</TemplateId>
+        <LanguageLcid>2055</LanguageLcid>
+      </Arguments>
+      <Function name="CustomInterfaceConnector" id="70E94788-CE84-4460-9698-5663878A295B">
+        <Arguments>
+          <Interface Name="OneGovGEVER">
+            <Node Id="ogg.document.title">A doc</Node>
+            <Node Id="ogg.document.reference_number">Client1 1.1 / 1 / 27</Node>
+            <Node Id="ogg.document.sequence_number">27</Node>
+          </Interface>
+        </Arguments>
+      </Function>
+      <Function name="MetaData" id="c364b495-7176-4ce2-9f7c-e71f302b8096">
+        <Value key="ogg.document.title" type="string">A doc</Value>
+        <Value key="ogg.document.reference_number" type="string">Client1 1.1 / 1 / 27</Value>
+        <Value key="ogg.document.sequence_number" type="string">27</Value>
+      </Function>
+      <Commands>
+        <Command Name="DefaultProcess">
+          <Parameters>
+            <Add key="start">false</Add>
+          </Parameters>
+        </Command>
+        <Command Name="SaveAs">
+          <Parameters>
+            <Add key="Overwrite">true</Add>
+            <Add key="CreateFolder">true</Add>
+            <Add key="AllowUpdateDocumentPart">false</Add>
+            <Add key="Filename"></Add>
+          </Parameters>
+        </Command>
+        <Command Name="ConvertToDocument"/>
+      </Commands>
+    </OneOffixxConnect>
+  </Entries>
+</OneOffixxConnectBatch>

--- a/opengever/oneoffixx/tests/test_connect_xml.py
+++ b/opengever/oneoffixx/tests/test_connect_xml.py
@@ -1,0 +1,52 @@
+from ftw.testbrowser import browsing
+from ftw.testbrowser.pages import factoriesmenu
+from lxml import etree
+from opengever.testing import IntegrationTestCase
+from pkg_resources import resource_string
+
+
+class TestConnectXML(IntegrationTestCase):
+    features = ("officeconnector-checkout", "oneoffixx")
+
+    def create_document(self, browser):
+        self.login(self.regular_user, browser)
+        browser.open(self.dossier)
+        factoriesmenu.add('document_with_oneoffixx_template')
+
+        node = browser.css("#form-widgets-template-2574d08d-95ea-4639-beab-3103fe4c3bc7").first
+        browser.fill({'Title': 'A doc'})
+        browser.fill({'Template': node.get("title")})
+        browser.find('Save').click()
+        return browser.context
+
+    @browsing
+    def test_connect_xml_view_returns_xml_for_doc_created_from_oneoffixx(self, browser):
+        document = self.create_document(browser)
+        browser.open(document, view="oneoffix_connect_xml")
+        xml = etree.fromstring(browser.contents)
+
+        namespace = "http://schema.oneoffixx.com/OneOffixxConnectBatch/1"
+        self.assertEqual("{%s}OneOffixxConnectBatch" % namespace, xml.tag)
+
+        templateid_tag = xml.find(".//{%s}TemplateId" % namespace)
+        self.assertEqual('2574d08d-95ea-4639-beab-3103fe4c3bc7',
+                         templateid_tag.text)
+
+    @browsing
+    def test_connect_xml_content(self, browser):
+        document = self.create_document(browser)
+        browser.open(document, view="oneoffix_connect_xml")
+
+        xml = resource_string("opengever.oneoffixx.tests.assets", "oneoffixx_connect_xml.txt")
+        self.assertEqual(xml, browser.contents)
+
+        self.assertEqual("application/xml", browser.headers["Content-type"])
+
+    @browsing
+    def test_connect_xml_view_allowed_only_on_documents_in_shadow_state(self, browser):
+        self.login(self.manager, browser)
+        with browser.expect_http_error(404):
+            browser.open(self.document, view="oneoffix_connect_xml")
+
+        self.document.as_shadow_document()
+        browser.open(self.document, view="oneoffix_connect_xml")


### PR DESCRIPTION
* `TemplateId` and `LanguageLcid` elements are only added to the XML if they are present in the annotation. That's what I understood @buchi wanted? If you'd rather have a different behaviour, maybe empty tags or simply no XML at all when this information is missing, let me know.
* A template can be available in different languages, so the in the template metadata, that field is a list. In the XML there can be only one. Current choice is `2055`, i.e. *German Switzerland* if that language is in the list, otherwise the first language from the list.

Here is an example of xml generated by the view:

```
<oneoffixxconnectbatch xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://schema.oneoffixx.com/OneOffixxConnectBatch/1">
  <settings>
    <add key="KeepConnector">true</add>
    <add key="CreateConnectorResultOnError">true</add>
    <add key="CreateConnectorResult">true</add>
  </settings>
  <entries>
    <oneoffixxconnect>
      <arguments>
        <templateid>2574d08d-95ea-4639-beab-3103fe4c3bc7</templateid>
        <languagelcid>2055</languagelcid>
      </arguments>
      <function name="CustomInterfaceConnector" id="70E94788-CE84-4460-9698-5663878A295B">
        <arguments>
          <interface name="OneGovGEVER">
            <node id="ogg.document.title">A doc</node>
            <node id="ogg.document.reference_number">Client1 1.1 / 1 / 27</node>
            <node id="ogg.document.sequence_number">27</node>
          </interface>
        </arguments>
      </function>
      <function name="MetaData" id="c364b495-7176-4ce2-9f7c-e71f302b8096">
        <value key="ogg.document.title" type="string">A doc</value>
        <value key="ogg.document.reference_number" type="string">Client1 1.1 / 1 / 27</value>
        <value key="ogg.document.sequence_number" type="string">27</value>
      </function>
      <commands>
        <command name="DefaultProcess">
          <parameters>
            <add key="start">false</add>
          </parameters>
        </command>
        <command name="SaveAs">
          <parameters>
            <add key="Overwrite">true</add>
            <add key="CreateFolder">true</add>
            <add key="AllowUpdateDocumentPart">false</add>
            <add key="Filename"/>
          </parameters>
        </command>
        <command name="ConvertToDocument"/>
      </commands>
    </oneoffixxconnect>
  </entries>
</oneoffixxconnectbatch>
```
resolves #4135 