### PR TITLE
Fix favorite etag adapter for webdav requests.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2018.3.0 (unreleased)
 ---------------------
 
+- Fix favorite etag adapter for webdav requests. [phgross]
 - Fix path filterd Solr searches. [phgross]
 - Implement bumblebee's auto refresh functionality. [siegy]
 - Add bumblebee auto refresh feature flag. [deiferni]

--- a/opengever/base/tests/test_favorite_action.py
+++ b/opengever/base/tests/test_favorite_action.py
@@ -4,6 +4,8 @@ from ftw.testbrowser import browsing
 from opengever.base.model import create_session
 from opengever.base.model.favorite import Favorite
 from opengever.base.oguid import Oguid
+from opengever.base.viewlets.favorite_action import FavoriteETagValue
+from opengever.document.browser.tabbed import DocumentTabbedView
 from opengever.testing import IntegrationTestCase
 
 
@@ -55,3 +57,32 @@ class TestFavoriteAction(IntegrationTestCase):
         browser.open(self.document)
         self.assertEqual(
             '', browser.css('#mark-as-favorite').first.get('class'))
+
+
+class TestFavoriteEtagValue(IntegrationTestCase):
+    """Exceptions in the etag value adapter are failing silently,
+    therefore we tests the etag adapter unittest like.
+    """
+
+    features = ('favorites', )
+
+    def test_handles_regular_requests(self):
+        self.login(self.regular_user)
+
+        create(Builder('favorite')
+               .for_user(self.regular_user)
+               .for_object(self.document))
+
+        view = DocumentTabbedView(self.document, None)
+        value = FavoriteETagValue(view, None)()
+        self.assertEqual('1', value)
+
+    def test_handles_webdav_requests(self):
+        self.login(self.regular_user)
+
+        create(Builder('favorite')
+               .for_user(self.regular_user)
+               .for_object(self.document))
+
+        value = FavoriteETagValue(self.document, None)()
+        self.assertEqual('1', value)

--- a/opengever/base/viewlets/favorite_action.py
+++ b/opengever/base/viewlets/favorite_action.py
@@ -5,6 +5,7 @@ from plone import api
 from plone.app.caching.interfaces import IETagValue
 from plone.app.layout.viewlets import common
 from plone.dexterity.interfaces import IDexterityContent
+from Products.CMFCore.interfaces import IContentish
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from zope.component import adapts
 from zope.interface import implements
@@ -42,8 +43,13 @@ class FavoriteETagValue(object):
         self.request = request
 
     def __call__(self):
+        if IContentish.providedBy(self.published):
+            context = self.published
+        else:
+            context = self.published.context
+
         favorite = FavoriteManager().get_favorite(
-            self.published.context, api.user.get_current())
+            context, api.user.get_current())
 
         if not favorite:
             return None


### PR DESCRIPTION
The self.published value, first parameter of an etag adapter, differs between a
webdav requests than a regular request. On a webdav request self.published is directly the context itself, therefore we have to handle it separately: