### PR TITLE
Fix get_css_class helper for task objects.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ---------------------
 
 - Fix favorite etag adapter for webdav requests. [phgross]
+- Fix get_css_class helper for task objects. [phgross]
 - Fix path filterd Solr searches. [phgross]
 - Implement bumblebee's auto refresh functionality. [siegy]
 - Add bumblebee auto refresh feature flag. [deiferni]

--- a/opengever/base/browser/helper.py
+++ b/opengever/base/browser/helper.py
@@ -1,5 +1,6 @@
 from ftw.solr.interfaces import ISolrDocument
 from opengever.globalindex.model.task import Task
+from opengever.task.task import ITask
 from plone.i18n.normalizer.interfaces import IIDNormalizer
 from Products.ZCatalog.interfaces import ICatalogBrain
 from sqlalchemy.ext.declarative import DeclarativeMeta
@@ -13,6 +14,9 @@ def _get_task_css_class(task):
     """
     if ICatalogBrain.providedBy(task) or ISolrDocument.providedBy(task):
         task = Task.query.by_brain(task)
+
+    if ITask.providedBy(task):
+        task = task.get_sql_object()
 
     return task.get_css_class()
 

--- a/opengever/base/tests/test_helper.py
+++ b/opengever/base/tests/test_helper.py
@@ -47,3 +47,8 @@ class TestCssClassHelpers(IntegrationTestCase):
         setattr(self.proposal_template, '_v__is_relation', False)
         self.assertEquals(self.proposal_template.getIcon(), 'docx.png')
         self.assertEquals(get_css_class(self.proposal_template), 'icon-docx')
+
+    def test_task_obj(self):
+        self.login(self.dossier_responsible)
+        self.assertEquals('contenttype-opengever-task-task',
+                          get_css_class(self.task))


### PR DESCRIPTION
Currently the helper failed with an `AttributeError: get_css_class` when passing in a task objects. So adding a favorite for a task was not possible.

