### PR TITLE
Fix API get request on private dossiers.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -484,6 +484,7 @@ Users
 - ``self.dossier_responsible``: ``robert.ziegler``
 - ``self.manager``: ``admin``
 - ``self.meeting_user``: ``herbert.jager``
+- ``self.member_admin``: ``david.meier``
 - ``self.records_manager``: ``ramon.flucht``
 - ``self.regular_user``: ``kathi.barfuss``
 - ``self.secretariat_user``: ``jurgen.konig``
@@ -525,6 +526,7 @@ Objects
     - self.private_folder
       - self.private_dossier
         - self.private_document
+        - self.private_mail
   - self.repository_root
     - self.branch_repofolder
       - self.leaf_repofolder

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,7 @@ Changelog
 
 - No longer show unsortable columns as sortable, bump ftw.tabbedview to 4.1.1. [deiferni]
 - Add debug views for agenda_items and docxcompose. [deiferni]
+- Fix API get request on private dossiers. [phgross]
 - Fix favorite etag adapter for webdav requests. [phgross]
 - Fix get_css_class helper for task objects. [phgross]
 - Fix path filterd Solr searches. [phgross]

--- a/opengever/base/contentlisting.py
+++ b/opengever/base/contentlisting.py
@@ -1,3 +1,4 @@
+from Acquisition import aq_base
 from ftw import bumblebee
 from Missing import Value as MissingValue
 from opengever.base.browser.helper import get_css_class
@@ -7,6 +8,7 @@ from opengever.document.document import Document
 from opengever.document.widgets.document_link import DocumentLinkWidget
 from opengever.mail.mail import OGMail
 from plone.app.contentlisting.catalog import CatalogContentListingObject
+from plone.app.contentlisting.realobject import RealContentListingObject
 from zope.browserpage.viewpagetemplatefile import ViewPageTemplateFile
 from zope.component import getMultiAdapter
 
@@ -126,3 +128,22 @@ class OpengeverCatalogContentListingObject(CatalogContentListingObject):
     def _render_simplelink(self):
         self.context = self
         return self.simple_link_template(self, self.request)
+
+
+class OpengeverRealContentListingObject(RealContentListingObject):
+
+    def __getattr__(self, name):
+        """The original RealContentListingObject drops the aquistion
+        information, when accessing the value. This lead to problems when
+        calling getOwner in the Title accessor for example.
+
+        Customization can be removed as soon the bug gets fixed in
+        plone.app.contentlisting.
+        """
+        if name.startswith('_'):
+            raise AttributeError(name)
+        obj = self.getObject()
+        if hasattr(aq_base(obj), name):
+            return getattr(obj, name)
+        else:
+            raise AttributeError(name)

--- a/opengever/base/overrides.zcml
+++ b/opengever/base/overrides.zcml
@@ -53,4 +53,9 @@
       factory=".protect.ProtectAwareAttributeAnnotations"
       />
 
+  <adapter
+      factory=".contentlisting.OpengeverRealContentListingObject"
+      for="Products.CMFCore.interfaces.IContentish"
+      />
+
 </configure>

--- a/opengever/dossier/tests/test_templatefolder.py
+++ b/opengever/dossier/tests/test_templatefolder.py
@@ -196,15 +196,15 @@ class TestDocumentWithTemplateFormWithDocProperties(IntegrationTestCase):
         self.assertEquals(u'test-docx.docx', document.file.filename)
 
         expected_doc_properties = {
-            'Document.ReferenceNumber': 'Client1 1.1 / 1 / 27',
-            'Document.SequenceNumber': '27',
+            'Document.ReferenceNumber': 'Client1 1.1 / 1 / 28',
+            'Document.SequenceNumber': '28',
             'Dossier.ReferenceNumber': 'Client1 1.1 / 1',
             'Dossier.Title': u'Vertr\xe4ge mit der kantonalen Finanzverwaltung',
             'User.FullName': u'B\xe4rfuss K\xe4thi',
             'User.ID': 'kathi.barfuss',
             'ogg.document.document_date': datetime(2020, 9, 28, 0, 0),
-            'ogg.document.reference_number': 'Client1 1.1 / 1 / 27',
-            'ogg.document.sequence_number': '27',
+            'ogg.document.reference_number': 'Client1 1.1 / 1 / 28',
+            'ogg.document.sequence_number': '28',
             'ogg.document.title': 'Test Docx',
             'ogg.document.version_number': 0,
             'ogg.dossier.reference_number': 'Client1 1.1 / 1',
@@ -254,15 +254,15 @@ class TestDocumentWithTemplateFormWithDocProperties(IntegrationTestCase):
         self.assertEquals(u'test-docx.docx', document.file.filename)
 
         expected_doc_properties = {
-            'Document.ReferenceNumber': 'Client1 1.1 / 1 / 27',
-            'Document.SequenceNumber': '27',
+            'Document.ReferenceNumber': 'Client1 1.1 / 1 / 28',
+            'Document.SequenceNumber': '28',
             'Dossier.ReferenceNumber': 'Client1 1.1 / 1',
             'Dossier.Title': u'Vertr\xe4ge mit der kantonalen Finanzverwaltung',
             'User.FullName': u'B\xe4rfuss K\xe4thi',
             'User.ID': 'kathi.barfuss',
             'ogg.document.document_date': datetime(2020, 10, 28, 0, 0),
-            'ogg.document.reference_number': 'Client1 1.1 / 1 / 27',
-            'ogg.document.sequence_number': '27',
+            'ogg.document.reference_number': 'Client1 1.1 / 1 / 28',
+            'ogg.document.sequence_number': '28',
             'ogg.document.title': 'Test Docx',
             'ogg.document.version_number': 0,
             'ogg.dossier.reference_number': 'Client1 1.1 / 1',

--- a/opengever/private/tests/test_deactivate_action.py
+++ b/opengever/private/tests/test_deactivate_action.py
@@ -8,7 +8,7 @@ class TestDeleteActionInPrivateFolderTabbedViews(IntegrationTestCase):
 
     @browsing
     def test_deactivate_action_is_not_displayed_for_administrator(self, browser):
-        self.login(self.administrator, browser)
+        self.login(self.member_admin, browser)
         browser.open(self.private_dossier)
         statusmessages.assert_no_error_messages()
 

--- a/opengever/private/tests/test_delete_action.py
+++ b/opengever/private/tests/test_delete_action.py
@@ -7,30 +7,6 @@ from opengever.testing import obj2paths
 class TestDeleteActionInPrivateFolderTabbedViews(IntegrationTestCase):
 
     @browsing
-    def test_delete_action_is_displayed_for_administrator(self, browser):
-        self.login(self.administrator, browser)
-        browser.open(self.private_folder, view='tabbedview_view-dossiers')
-
-        self.assertIn('Delete', browser.css('.actionMenuContent a').text)
-
-    @browsing
-    def test_delete_action_works_for_administrator(self, browser):
-        self.login(self.administrator, browser)
-
-        browser.open(
-            self.private_folder,
-            view='folder_delete_confirmation',
-            data={'paths:list': obj2paths([self.private_dossier])},
-            )
-
-        browser.find('Delete').click()
-
-        statusmessages.assert_message(u'Items successfully deleted.')
-
-        with self.assertRaises(KeyError):
-            self.assertIsNone(self.private_dossier)
-
-    @browsing
     def test_delete_action_is_displayed_for_owner(self, browser):
         self.login(self.regular_user, browser)
         browser.open(self.private_folder, view='tabbedview_view-dossiers')
@@ -58,28 +34,6 @@ class TestDeleteActionInPrivateFolderTabbedViews(IntegrationTestCase):
 class TestDeleteActionInPrivateFolderContentViews(IntegrationTestCase):
 
     @browsing
-    def test_delete_action_is_displayed_for_administrator_on_dossier(
-            self,
-            browser,
-        ):
-        self.login(self.administrator, browser)
-        browser.open(self.private_dossier)
-
-        self.assertIn('Delete', browser.css('.actionMenuContent a span').text)
-
-    @browsing
-    def test_delete_action_works_for_administrator_on_dossier(self, browser):
-        self.login(self.administrator, browser)
-        browser.open(self.private_dossier)
-        browser.find('Delete').click()
-        browser.find('Delete').click()
-
-        statusmessages.assert_message(u'Mein Dossier 1 has been deleted.')
-
-        with self.assertRaises(KeyError):
-            self.assertIsNone(self.private_dossier)
-
-    @browsing
     def test_delete_action_is_displayed_for_owner_on_dossier(self, browser):
         self.login(self.regular_user, browser)
         browser.open(self.private_dossier)
@@ -97,28 +51,6 @@ class TestDeleteActionInPrivateFolderContentViews(IntegrationTestCase):
 
         with self.assertRaises(KeyError):
             self.assertIsNone(self.private_dossier)
-
-    @browsing
-    def test_delete_action_is_displayed_for_administrator_on_document(
-            self,
-            browser,
-        ):
-        self.login(self.administrator, browser)
-        browser.open(self.private_document)
-
-        self.assertIn('Delete', browser.css('.actionMenuContent a span').text)
-
-    @browsing
-    def test_delete_action_works_for_administrator_on_document(self, browser):
-        self.login(self.administrator, browser)
-        browser.open(self.private_document)
-        browser.find('Delete').click()
-        browser.find('Delete').click()
-
-        statusmessages.assert_message(u'Testdokum\xe4nt has been deleted.')
-
-        with self.assertRaises(KeyError):
-            self.assertIsNone(self.private_document)
 
     @browsing
     def test_delete_action_is_displayed_for_owner_on_document(self, browser):

--- a/opengever/private/tests/test_dossier.py
+++ b/opengever/private/tests/test_dossier.py
@@ -177,3 +177,21 @@ class TestPrivateDossierWorkflow(IntegrationTestCase):
                           info_messages())
         self.assertEqual('dossier-state-resolved',
                          api.content.get_state(self.private_dossier))
+
+    @browsing
+    def test_accessing_dossier_via_rest_api(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        browser.open(
+            self.private_dossier.absolute_url(), method='GET',
+            headers={'Accept': 'application/json'})
+
+        self.assertEqual(200, browser.status_code)
+        self.assertEqual(u'Mein Dossier 1', browser.json['title'])
+        self.assertEqual(
+            {u'@id': u'http://nohost/plone/private/kathi-barfuss',
+             u'@type': u'opengever.private.folder',
+             u'description': u'',
+             u'review_state': u'folder-state-active',
+             u'title': u'B\xe4rfuss K\xe4thi (kathi.barfuss)'},
+            browser.json['parent'])

--- a/opengever/private/tests/test_dossier.py
+++ b/opengever/private/tests/test_dossier.py
@@ -3,33 +3,25 @@ from ftw.builder import create
 from ftw.testbrowser import browsing
 from ftw.testbrowser.pages import factoriesmenu
 from ftw.testbrowser.pages.statusmessages import info_messages
-from opengever.base.interfaces import IReferenceNumber
 from opengever.base.interfaces import ISequenceNumber
-from opengever.core.testing import OPENGEVER_FUNCTIONAL_PRIVATE_FOLDER_LAYER
 from opengever.dossier.behaviors.dossier import IDossier
-from opengever.private.tests import create_members_folder
-from opengever.testing import FunctionalTestCase
+from opengever.testing import IntegrationTestCase
 from plone import api
 from plone.app.testing import TEST_USER_ID
 from plone.protect import createToken
 from zope.component import getUtility
 
 
-class TestPrivateDossier(FunctionalTestCase):
+class TestPrivateDossier(IntegrationTestCase):
 
-    layer = OPENGEVER_FUNCTIONAL_PRIVATE_FOLDER_LAYER
-
-    def setUp(self):
-        super(TestPrivateDossier, self).setUp()
-        self.root = create(Builder('private_root'))
-        self.folder = create_members_folder(self.root)
+    features = ('private', )
 
     @browsing
     def test_is_addable_to_a_private_folder(self, browser):
-        browser.login().open(self.folder)
+        self.login(self.regular_user, browser=browser)
+        browser.open(self.private_folder)
         factoriesmenu.add('Private Dossier')
-        browser.fill({'Title': u'My Personal Stuff',
-                      'Responsible': TEST_USER_ID})
+        browser.fill({'Title': u'My Personal Stuff'})
         browser.click_on('Save')
 
         self.assertEquals([u'My Personal Stuff'],
@@ -37,75 +29,66 @@ class TestPrivateDossier(FunctionalTestCase):
 
     @browsing
     def test_responsible_is_current_user_by_default(self, browser):
-        browser.login().open(self.folder)
+        self.login(self.regular_user, browser=browser)
+        browser.open(self.private_folder)
+
         factoriesmenu.add('Private Dossier')
         browser.fill({'Title': u'My Personal Stuff'})
         browser.click_on('Save')
 
-        self.assertEquals(TEST_USER_ID,
-                          IDossier(self.folder.get('dossier-1')).responsible)
+        self.assertEquals(
+            self.regular_user.getId(),
+            IDossier(browser.context).responsible)
 
     def test_use_same_id_schema_as_regular_dossiers(self):
-        dossier1 = create(Builder('private_dossier').titled(u'Zuz\xfcge'))
-        dossier2 = create(Builder('private_dossier').titled(u'Abg\xe4nge'))
-
-        self.assertEquals('dossier-1', dossier1.getId())
-        self.assertEquals('dossier-2', dossier2.getId())
+        self.login(self.regular_user)
+        self.assertEquals(
+            ['dossier-11', 'dossier-12'],
+            [dos.getId() for dos in self.private_folder.listFolderContents()])
 
     def test_uses_the_same_sequence_counter_as_regular_dossiers(self):
-        dossier1 = create(Builder('private_dossier'))
-        dossier2 = create(Builder('dossier'))
-        dossier3 = create(Builder('private_dossier'))
+        self.login(self.regular_user)
 
         sequence_number = getUtility(ISequenceNumber)
-        self.assertEquals(1, sequence_number.get_number(dossier1))
-        self.assertEquals(2, sequence_number.get_number(dossier2))
-        self.assertEquals(3, sequence_number.get_number(dossier3))
+        self.assertEquals(
+            [11, 12],
+            [sequence_number.get_number(dos) for dos
+             in self.private_folder.listFolderContents()])
 
     def test_allow_one_level_of_subdossiers(self):
-        dossier = create(Builder('private_dossier')
-                         .within(self.folder)
-                         .having(responsible=TEST_USER_ID))
+        self.login(self.regular_user)
+
         subdossier = create(Builder('private_dossier')
-                            .within(dossier)
+                            .within(self.private_dossier)
                             .having(responsible=TEST_USER_ID))
 
         self.assertItemsEqual(
             ['opengever.document.document',
              'ftw.mail.mail',
              'opengever.private.dossier'],
-            [fti.id for fti in dossier.allowedContentTypes()])
+            [fti.id for fti in self.private_dossier.allowedContentTypes()])
 
         self.assertItemsEqual(
             ['opengever.document.document', 'ftw.mail.mail'],
             [fti.id for fti in subdossier.allowedContentTypes()])
 
     def test_does_not_support_participations(self):
-        dossier = create(Builder('private_dossier')
-                         .within(self.folder)
-                         .having(responsible=TEST_USER_ID))
-        self.assertFalse(dossier.has_participation_support())
+        self.login(self.regular_user)
+        self.assertFalse(self.private_dossier.has_participation_support())
 
     def test_does_not_support_tasks(self):
-        dossier = create(Builder('private_dossier')
-                         .within(self.folder)
-                         .having(responsible=TEST_USER_ID))
-        self.assertFalse(dossier.has_task_support())
+        self.login(self.regular_user)
+        self.assertFalse(self.private_dossier.has_task_support())
 
 
-class TestPrivateDossierTabbedView(FunctionalTestCase):
+class TestPrivateDossierTabbedView(IntegrationTestCase):
 
-    def setUp(self):
-        super(TestPrivateDossierTabbedView, self).setUp()
-        self.root = create(Builder('private_root'))
-        self.folder = create(Builder('private_folder')
-                             .having(userid=TEST_USER_ID)
-                             .within(self.root))
+    features = ('private', )
 
     @browsing
     def test_task_proposal_participations_and_info_tab_are_hidden(self, browser):
-        dossier = create(Builder('private_dossier').within(self.folder))
-        browser.login().open(dossier)
+        self.login(self.regular_user, browser=browser)
+        browser.open(self.private_dossier)
 
         self.assertEquals(
             ['Overview', 'Subdossiers', 'Documents', 'Trash', 'Journal'],
@@ -113,8 +96,8 @@ class TestPrivateDossierTabbedView(FunctionalTestCase):
 
     @browsing
     def test_action_menu_is_displayed_correctly(self, browser):
-        dossier = create(Builder('private_dossier').within(self.folder))
-        browser.login().open(dossier)
+        self.login(self.regular_user, browser=browser)
+        browser.open(self.private_dossier)
 
         self.assertEqual(
             ['Delete', 'Export as Zip', 'Properties',
@@ -124,8 +107,8 @@ class TestPrivateDossierTabbedView(FunctionalTestCase):
 
     @browsing
     def test_participation_and_task_box_are_hidden_on_overview(self, browser):
-        dossier = create(Builder('private_dossier').within(self.folder))
-        browser.login().open(dossier, view='tabbedview_view-overview')
+        self.login(self.regular_user, browser=browser)
+        browser.open(self.private_dossier, view='tabbedview_view-overview')
 
         self.assertEquals(
             ['Dossier structure', 'Comments', 'Linked Dossiers',
@@ -136,28 +119,25 @@ class TestPrivateDossierTabbedView(FunctionalTestCase):
         """Some columns do not make a lot of sense in a private dossier.
         We hide them in the default configuration.
         """
+        self.login(self.regular_user)
 
-        dossier = create(Builder('private_dossier').within(self.folder))
-        view = dossier.unrestrictedTraverse('tabbedview_view-documents')
+        view = self.private_dossier.unrestrictedTraverse(
+            'tabbedview_view-documents')
         columns_by_name = {col['column']: col for col in view.columns}
+
         self.assertTrue(columns_by_name['public_trial'].get('hidden', None))
         self.assertTrue(columns_by_name['receipt_date'].get('hidden', None))
         self.assertTrue(columns_by_name['delivery_date'].get('hidden', None))
 
 
-class TestPrivateDossierWorkflow(FunctionalTestCase):
+class TestPrivateDossierWorkflow(IntegrationTestCase):
 
-    def setUp(self):
-        super(TestPrivateDossierWorkflow, self).setUp()
-        self.root = create(Builder('private_root'))
-        self.folder = create(Builder('private_folder')
-                             .having(userid=TEST_USER_ID)
-                             .within(self.root))
-        self.dossier = create(Builder('private_dossier').within(self.folder))
+    features = ('private', )
 
     @browsing
     def test_tasks_and_propsoals_are_not_addable(self, browser):
-        browser.login().open(self.dossier)
+        self.login(self.regular_user, browser=browser)
+        browser.open(self.private_dossier)
 
         self.assertEquals(
             ['Document', 'document_with_template', 'Subdossier'],
@@ -165,37 +145,35 @@ class TestPrivateDossierWorkflow(FunctionalTestCase):
 
     @browsing
     def test_adding_subdossiers_is_allowed(self, browser):
-        browser.login().open(self.dossier)
+        self.login(self.regular_user, browser=browser)
+        browser.open(self.private_dossier)
+
         factoriesmenu.add('Subdossier')
-        browser.fill({'Title': u'Sub 1',
-                      'Responsible': TEST_USER_ID})
+        browser.fill({'Title': u'Sub 1'})
         browser.click_on('Save')
 
         self.assertEquals(['Item created'], info_messages())
 
     @browsing
     def test_trashing_documents_in_private_folder_is_possible(self, browser):
-        document = create(Builder('document')
-                          .within(self.dossier)
-                          .titled(u'My private document'))
+        self.login(self.regular_user, browser=browser)
+        browser.open(self.private_dossier)
 
-        data = {'paths:list': ['/'.join(document.getPhysicalPath())],
+        data = {'paths:list': ['/'.join(self.private_document.getPhysicalPath())],
                 '_authenticator': createToken()}
 
-        self.grant('Member', 'Reader')
-
-        browser.login().open(self.dossier, view="trashed", data=data)
-
-        self.assertEquals([u'the object My private document trashed'],
+        browser.open(self.dossier, view="trashed", data=data)
+        self.assertEquals([u'the object Testdokum\xe4nt trashed'],
                           info_messages())
 
     @browsing
     def test_private_dossier_can_be_resolved(self, browser):
-        browser.login().open(self.dossier,
-                             {'_authenticator': createToken()},
-                             view='transition-resolve')
+        self.login(self.regular_user, browser=browser)
+        browser.open(self.private_dossier,
+                     {'_authenticator': createToken()},
+                     view='transition-resolve')
+
         self.assertEquals(['The dossier has been succesfully resolved.'],
                           info_messages())
-
         self.assertEqual('dossier-state-resolved',
-                         api.content.get_state(self.dossier))
+                         api.content.get_state(self.private_dossier))

--- a/opengever/private/tests/test_quota.py
+++ b/opengever/private/tests/test_quota.py
@@ -1,25 +1,22 @@
 from opengever.private.interfaces import IPrivateFolderQuotaSettings
+from opengever.quota.interfaces import IQuotaSizeSettings
+from opengever.testing import IntegrationTestCase
 from plone.registry.interfaces import IRegistry
 from zope.component import getUtility
-from ftw.builder import Builder
-from ftw.builder import create
-from opengever.core.testing import OPENGEVER_FUNCTIONAL_PRIVATE_FOLDER_LAYER
-from opengever.private.tests import create_members_folder
-from opengever.quota.interfaces import IQuotaSizeSettings
-from opengever.testing import FunctionalTestCase
 
 
-class TestPrivateFolderQuota(FunctionalTestCase):
-    layer = OPENGEVER_FUNCTIONAL_PRIVATE_FOLDER_LAYER
+class TestPrivateFolderQuota(IntegrationTestCase):
+
+    features = ('private',)
 
     def test_configured_quota_settings_are_available_in_qutoa_adapter(self):
-        private_folder = create_members_folder(create(Builder('private_root')))
-        self.assertEquals(0, IQuotaSizeSettings(private_folder).get_soft_limit())
-        self.assertEquals(0, IQuotaSizeSettings(private_folder).get_hard_limit())
+        self.login(self.regular_user)
+        self.assertEquals(0, IQuotaSizeSettings(self.private_folder).get_soft_limit())
+        self.assertEquals(0, IQuotaSizeSettings(self.private_folder).get_hard_limit())
 
         settings = getUtility(IRegistry).forInterface(
             IPrivateFolderQuotaSettings)
         settings.size_soft_limit = 77
         settings.size_hard_limit = 88
-        self.assertEquals(77, IQuotaSizeSettings(private_folder).get_soft_limit())
-        self.assertEquals(88, IQuotaSizeSettings(private_folder).get_hard_limit())
+        self.assertEquals(77, IQuotaSizeSettings(self.private_folder).get_soft_limit())
+        self.assertEquals(88, IQuotaSizeSettings(self.private_folder).get_hard_limit())

--- a/opengever/private/tests/test_reference_number.py
+++ b/opengever/private/tests/test_reference_number.py
@@ -8,7 +8,7 @@ from plone import api
 class TestPrivateReferenceNumber(IntegrationTestCase):
 
     def test_dotted_reference_number(self):
-        self.login(self.administrator)
+        self.login(self.regular_user)
 
         api.portal.set_registry_record(
             'formatter',
@@ -32,7 +32,7 @@ class TestPrivateReferenceNumber(IntegrationTestCase):
             )
 
     def test_grouped_by_three_reference_number(self):
-        self.login(self.administrator)
+        self.login(self.regular_user)
 
         api.portal.set_registry_record(
             'formatter',
@@ -56,7 +56,7 @@ class TestPrivateReferenceNumber(IntegrationTestCase):
             )
 
     def test_no_client_id_dotted_reference_number(self):
-        self.login(self.administrator)
+        self.login(self.regular_user)
 
         api.portal.set_registry_record(
             'formatter',
@@ -80,7 +80,7 @@ class TestPrivateReferenceNumber(IntegrationTestCase):
             )
 
     def test_no_client_id_grouped_by_three_reference_number(self):
-        self.login(self.administrator)
+        self.login(self.regular_user)
 
         api.portal.set_registry_record(
             'formatter',

--- a/opengever/private/tests/test_root.py
+++ b/opengever/private/tests/test_root.py
@@ -2,17 +2,17 @@ from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
 from ftw.testbrowser.pages import factoriesmenu
-from opengever.testing import FunctionalTestCase
+from opengever.testing import IntegrationTestCase
 from zExceptions import Unauthorized
+from ftw.testbrowser import InsufficientPrivileges
 
-
-class TestPrivateRoot(FunctionalTestCase):
+class TestPrivateRoot(IntegrationTestCase):
 
     @browsing
     def test_is_addable_on_plone_site(self, browser):
-        self.grant('Manager')
+        self.login(self.manager, browser=browser)
 
-        browser.login().open()
+        browser.open()
         factoriesmenu.add('Private Root')
         browser.fill({'Title (German)': u'Meine Ablage',
                       'Title (French)': u'Mon d\xe9p\xf4t'})
@@ -22,31 +22,26 @@ class TestPrivateRoot(FunctionalTestCase):
 
     @browsing
     def test_is_only_addable_by_manager(self, browser):
-        browser.login().open(
-            self.portal, view='++add++opengever.private.root')
-        browser.fill({'Title (German)': u'Meine Ablage',
-                      'Title (French)': u'Mon d\xe9p\xf4t'})
+        self.login(self.regular_user, browser=browser)
 
-        browser.exception_bubbling = True
-        with self.assertRaises(Unauthorized):
+        with self.assertRaises(InsufficientPrivileges):
+            browser.open(self.portal, view='++add++opengever.private.root')
+            browser.fill({'Title (German)': u'Meine Ablage',
+                          'Title (French)': u'Mon d\xe9p\xf4t'})
             browser.click_on('Save')
 
     @browsing
     def test_is_excluded_from_the_navigation(self, browser):
+        self.login(self.manager, browser=browser)
         create(Builder('private_root').titled(u'Meine Ablage'))
-        browser.login().open()
+        browser.open()
         self.assertNotIn('meine-ablage',
                          browser.css('#portal-globalnav li').text)
 
     @browsing
     def test_portlet_inheritance_is_blocked(self, browser):
-        self.grant('Manager')
-
-        browser.login().open()
-        factoriesmenu.add('Private Root')
-        browser.fill({'Title (German)': u'Meine Ablage',
-                      'Title (French)': u'Mon d\xe9p\xf4t'})
-        browser.click_on('Save')
+        self.login(self.manager, browser=browser)
+        browser.open(self.private_root)
 
         self.assert_portlet_inheritance_blocked(
             'plone.leftcolumn', browser.context)

--- a/opengever/private/tests/test_viewlets_quotawarning.py
+++ b/opengever/private/tests/test_viewlets_quotawarning.py
@@ -2,31 +2,30 @@ from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
 from ftw.testbrowser.pages import statusmessages
-from opengever.core.testing import OPENGEVER_FUNCTIONAL_PRIVATE_FOLDER_LAYER
 from opengever.private.interfaces import IPrivateFolderQuotaSettings
 from opengever.private.tests import create_members_folder
-from opengever.testing import FunctionalTestCase
+from opengever.testing import IntegrationTestCase
 from plone.registry.interfaces import IRegistry
 from zope.component import getUtility
 import transaction
 
 
-class TestQuotaWarningViewlet(FunctionalTestCase):
-    layer = OPENGEVER_FUNCTIONAL_PRIVATE_FOLDER_LAYER
+class TestQuotaWarningViewlet(IntegrationTestCase):
+
+    features = ('private', )
 
     @browsing
     def test_warning_visible_when_quota_exceeded(self, browser):
-        user_folder = create_members_folder(create(Builder('private_root')))
-        settings = getUtility(IRegistry).forInterface(
-            IPrivateFolderQuotaSettings)
-        create(Builder('document').attach_file_containing('X' * 100)
-               .within(user_folder))
+        self.login(self.regular_user, browser=browser)
 
-        browser.login().open(user_folder)
+        settings = getUtility(IRegistry).forInterface(IPrivateFolderQuotaSettings)
+        create(Builder('document').attach_file_containing('X' * 100)
+               .within(self.private_dossier))
+
+        browser.open(self.private_folder)
         statusmessages.assert_no_messages()
 
         settings.size_soft_limit = 70
-        transaction.commit()
         browser.reload()
         statusmessages.assert_message(
             u'The quota of your private folder will exceed soon.')
@@ -40,6 +39,5 @@ class TestQuotaWarningViewlet(FunctionalTestCase):
 
         settings.size_soft_limit = 0
         settings.size_hard_limit = 0
-        transaction.commit()
         browser.reload()
         statusmessages.assert_no_messages()

--- a/opengever/private/tests/test_workflows.py
+++ b/opengever/private/tests/test_workflows.py
@@ -1,165 +1,122 @@
-from ftw.builder import Builder
-from ftw.builder import create
 from ftw.testbrowser import browsing
 from ftw.testbrowser.pages import factoriesmenu
-from opengever.core.testing import OPENGEVER_FUNCTIONAL_PRIVATE_FOLDER_LAYER
-from opengever.private.tests import create_members_folder
-from opengever.testing import FunctionalTestCase
+from opengever.testing import IntegrationTestCase
 from plone import api
-import transaction
+from plone.app.testing import TEST_USER_ID
+from zExceptions import Unauthorized
 
 
-class TestPrivateFolderWorkflow(FunctionalTestCase):
+class TestPrivateFolderWorkflow(IntegrationTestCase):
 
-    layer = OPENGEVER_FUNCTIONAL_PRIVATE_FOLDER_LAYER
-
-    def setUp(self):
-        super(TestPrivateFolderWorkflow, self).setUp()
-        self.root = create(Builder('private_root'))
-
-        private_policy_id = 'opengever_private_policy'
-        # enable opengever.private placeful workflow policy
-        self.root.manage_addProduct[
-            'CMFPlacefulWorkflow'].manage_addWorkflowPolicyConfig()
-        pwf_tool = api.portal.get_tool('portal_placeful_workflow')
-        policy_config = pwf_tool.getWorkflowPolicyConfig(self.root)
-        policy_config.setPolicyIn(private_policy_id, update_security=False)
-        policy_config.setPolicyBelow(private_policy_id, update_security=False)
-
-        self.folder = create_members_folder(self.root)
-        self.hugo = create(Builder('user')
-                           .named('Hugo', 'Boss')
-                           .with_roles('Member', 'Reader'))
-        self.admin = create(Builder('user')
-                            .named('Ad', 'Min')
-                            .with_roles('Member', 'Administrator'))
-        self.member_admin = create(Builder('user')
-                            .named('MemberAreaAdmin', 'MAdm')
-                            .with_roles('Member',
-                                        'MemberAreaAdministrator'))
+    features = ('private', )
 
     @browsing
     def test_only_owner_and_memberareaadmin_can_see_private_folder(self, browser):
-        browser.login().open(self.folder)
-        browser.login(self.member_admin).open(self.folder)
-        with browser.expect_unauthorized():
-            browser.login(self.hugo).open(self.folder)
+        self.login(self.regular_user, browser=browser)
+        browser.open(self.private_folder)
 
-        with browser.expect_unauthorized():
-            browser.login(self.admin).open(self.folder)
+        self.login(self.member_admin, browser=browser)
+        browser.open(self.private_folder)
+
+        with self.assertRaises(Unauthorized):
+            self.login(self.dossier_responsible, browser=browser)
+            browser.open(self.private_folder)
+
+        with self.assertRaises(Unauthorized):
+            self.login(self.administrator, browser=browser)
+            browser.open(self.private_folder)
 
     @browsing
     def test_owner_can_add_private_dossiers(self, browser):
-        browser.login().open(self.folder)
+        self.login(self.regular_user, browser=browser)
+        browser.open(self.private_folder)
         self.assertIn('Private Dossier', factoriesmenu.addable_types())
 
     @browsing
     def test_admin_cant_access_private_dossier(self, browser):
-        dossier = create(Builder('private_dossier')
-                         .within(self.folder)
-                         .titled(u'Zuz\xfcge'))
+        self.login(self.administrator, browser=browser)
 
-        with browser.expect_unauthorized():
-            browser.login(self.admin).open(dossier)
+        with self.assertRaises(Unauthorized):
+            browser.open(self.private_dossier)
 
     @browsing
-    def test_admin_cant_add_in_private_content(self, browser):
-        dossier = create(Builder('private_dossier')
-                         .within(self.folder)
-                         .titled(u'Zuz\xfcge'))
+    def test_member_admin_cant_add_in_private_content(self, browser):
+        self.login(self.member_admin, browser=browser)
 
-        browser.login(self.member_admin)
-
-        browser.open(self.folder)
+        browser.open(self.private_folder)
         self.assertFalse(factoriesmenu.visible())
 
-        browser.open(dossier)
+        browser.open(self.private_dossier)
         self.assertFalse(factoriesmenu.visible())
 
     @browsing
     def test_only_owner_and_memberareaadmin_can_see_private_dossiers(self, browser):
-        dossier = create(Builder('private_dossier')
-                         .within(self.folder)
-                         .titled(u'Zuz\xfcge'))
+        self.login(self.regular_user, browser=browser)
+        browser.open(self.private_dossier)
 
-        browser.login().visit(dossier)
-        browser.login(self.member_admin).visit(dossier)
-        with browser.expect_unauthorized():
-            browser.login(self.hugo).visit(dossier)
+        self.login(self.member_admin, browser=browser)
+        browser.open(self.private_dossier)
+
+        with self.assertRaises(Unauthorized):
+            self.login(self.dossier_responsible, browser=browser)
+            browser.open(self.private_dossier)
+
+        with self.assertRaises(Unauthorized):
+            self.login(self.administrator, browser=browser)
+            browser.open(self.private_dossier)
 
     @browsing
     def test_only_owner_and_member_admins_can_see_private_documents(self, browser):
-        dossier = create(Builder('private_dossier')
-                         .within(self.folder)
-                         .titled(u'Zuz\xfcge'))
-        document = create(Builder('document')
-                          .within(dossier)
-                          .with_dummy_content()
-                          .titled(u'Some File'))
+        self.login(self.regular_user, browser=browser)
+        browser.open(self.private_document)
 
-        browser.login().visit(document)
-        browser.login(self.member_admin).visit(document)
+        self.login(self.member_admin, browser=browser)
+        browser.open(self.private_document)
 
-        with browser.expect_unauthorized():
-            browser.login(self.admin).visit(document)
-            browser.login(self.hugo).visit(document)
+        with self.assertRaises(Unauthorized):
+            self.login(self.dossier_responsible, browser=browser)
+            browser.open(self.private_document)
+
+        with self.assertRaises(Unauthorized):
+            self.login(self.administrator, browser=browser)
+            browser.open(self.private_document)
 
     @browsing
     def test_only_owner_and_member_admins_can_see_private_mails(self, browser):
-        dossier = create(Builder('private_dossier')
-                         .within(self.folder)
-                         .titled(u'Zuz\xfcge'))
-        mail = create(Builder('mail')
-                      .within(dossier)
-                      .with_dummy_message())
+        self.login(self.regular_user, browser=browser)
+        browser.open(self.private_mail)
 
-        browser.login().visit(mail)
-        browser.login(self.member_admin).visit(mail)
+        self.login(self.member_admin, browser=browser)
+        browser.open(self.private_mail)
 
-        with browser.expect_unauthorized():
-            browser.login(self.admin).visit(mail)
-            browser.login(self.hugo).visit(mail)
+        with self.assertRaises(Unauthorized):
+            self.login(self.dossier_responsible, browser=browser)
+            browser.open(self.private_mail)
+
+        with self.assertRaises(Unauthorized):
+            self.login(self.administrator, browser=browser)
+            browser.open(self.private_mail)
 
     def test_make_sure_private_root_has_no_additional_local_roles(self):
-        self.assertEquals({'test_user_1_': ['Owner']},
-                          self.root.__ac_local_roles__)
+        self.login(self.regular_user)
+
+        self.assertEquals({TEST_USER_ID: ['Owner']},
+                          self.private_root.__ac_local_roles__)
 
     @browsing
     def test_moving_documents_out_of_private_area(self, browser):
-        dossier = create(Builder('private_dossier')
-                         .within(self.folder)
-                         .titled(u'Zuz\xfcge'))
-        document = create(Builder('document')
-                          .within(dossier)
-                          .with_dummy_content()
-                          .titled(u'Some File'))
-
-        public_dossier = create(Builder('dossier')
-                                .titled(u'Public Dossier'))
-
-        api.content.move(document, public_dossier)
-        transaction.commit()
+        self.login(self.regular_user)
+        document = api.content.move(self.private_document, self.dossier)
 
         # Other users should be allowed to view document in public repo
-        pasted_document = public_dossier.objectValues()[0]
-        browser.login(self.hugo).visit(pasted_document)
+        self.login(self.regular_user, browser=browser)
+        browser.open(document)
 
     @browsing
     def test_copying_documents_out_of_private_area(self, browser):
-        dossier = create(Builder('private_dossier')
-                         .within(self.folder)
-                         .titled(u'Zuz\xfcge'))
-        document = create(Builder('document')
-                          .within(dossier)
-                          .with_dummy_content()
-                          .titled(u'Some File'))
-
-        public_dossier = create(Builder('dossier')
-                                .titled(u'Public Dossier'))
-
-        api.content.copy(document, public_dossier)
-        transaction.commit()
+        self.login(self.regular_user)
+        copy = api.content.copy(self.private_document, self.dossier)
 
         # Other users should be allowed to view document in public repo
-        pasted_document = public_dossier.objectValues()[0]
-        browser.login(self.hugo).visit(pasted_document)
+        self.login(self.regular_user, browser=browser)
+        browser.open(copy)

--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -17,6 +17,7 @@ from opengever.base.model import create_session
 from opengever.mail.tests import MAIL_DATA
 from opengever.meeting.proposalhistory import BaseHistoryRecord
 from opengever.ogds.base.utils import ogds_service
+from opengever.private import MEMBERSFOLDER_ID
 from opengever.testing import assets
 from opengever.testing.helpers import time_based_intids
 from opengever.testing.integration_test_case import FEATURE_FLAGS
@@ -659,8 +660,13 @@ class OpengeverContentFixture(object):
     def create_private_root(self):
         self.private_root = self.register('private_root', create(
             Builder('private_root')
-            .titled(u'Meine Ablage')
-            ))
+            .titled(u'Private')
+        ))
+
+        # The id of the private_root needs to match the MEMBERSFOLDER_ID
+        # and setting the id is not possible when using dexterity builder,
+        # we use the id ad title and rename it after creation.
+        self.private_root.title_de = 'Meine Ablage'
 
     @staticuid()
     def create_private_folder(self):

--- a/opengever/testing/integration_test_case.py
+++ b/opengever/testing/integration_test_case.py
@@ -14,6 +14,7 @@ from opengever.meeting.model import SubmittedDocument
 from opengever.meeting.model.agendaitem import AgendaItem
 from opengever.meeting.wrapper import MeetingWrapper
 from opengever.ogds.base.utils import ogds_service
+from opengever.private import enable_opengever_private
 from opengever.task.task import ITask
 from operator import methodcaller
 from plone import api
@@ -60,6 +61,11 @@ FEATURE_FLAGS = {
 FEATURE_PROFILES = {
     'filing_number': 'opengever.dossier:filing',
 }
+
+FEATURE_METHODS = {
+    'private': enable_opengever_private,
+}
+
 
 
 class IntegrationTestCase(TestCase):
@@ -183,6 +189,8 @@ class IntegrationTestCase(TestCase):
             api.portal.set_registry_record(FEATURE_FLAGS[feature], True)
         elif feature in FEATURE_PROFILES:
             applyProfile(self.portal, FEATURE_PROFILES[feature])
+        elif feature in FEATURE_METHODS:
+            FEATURE_METHODS[feature]()
         else:
             raise ValueError('Invalid {!r}'.format(feature))
 
@@ -192,6 +200,8 @@ class IntegrationTestCase(TestCase):
         if feature in FEATURE_FLAGS:
             api.portal.set_registry_record(FEATURE_FLAGS[feature], False)
         elif feature in FEATURE_PROFILES:
+            raise NotImplementedError('Feel free to implement.')
+        elif feature in FEATURE_METHODS:
             raise NotImplementedError('Feel free to implement.')
         else:
             raise ValueError('Invalid {!r}'.format(feature))


### PR DESCRIPTION
Currently API requests on a private dossiers raises an `TypeError: 'str' object is not callable`. Because of an incorrect handling in the `plone.app.contentlisting` the adapted IContentListing-object looses the acquisition context which leads then to problems when getting the owner on in the title accessor of a PrivateFolder.

I fixed the issue by overriding the `RealContentListingObject` adapter. I'll add also an PR to the `plone.app.contentlisting` package, but that needs some more time and a general test-example. Closes #4166.

Besides that I've converted all opengever.private tests to integration tests. closes #3903 .