### PR TITLE
Add service to create OC JWT URLs

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -10,6 +10,7 @@ Changelog
 - No longer show unsortable columns as sortable, bump ftw.tabbedview to 4.1.1. [deiferni]
 - Add debug views for agenda_items and docxcompose. [deiferni]
 - Fix API get request on private dossiers. [phgross]
+- Add service to create office connector JWT for oneoffixx action. [njohner]
 - Fix favorite etag adapter for webdav requests. [phgross]
 - Fix get_css_class helper for task objects. [phgross]
 - Fix path filterd Solr searches. [phgross]

--- a/opengever/document/document.py
+++ b/opengever/document/document.py
@@ -6,6 +6,7 @@ from Acquisition import aq_parent
 from collective import dexteritytextindexer
 from ftw.mail.interfaces import IEmailAddress
 from ftw.tabbedview.interfaces import ITabbedviewUploadable
+from opengever.oneoffixx import is_oneoffixx_feature_enabled
 from opengever.base.interfaces import IRedirector
 from opengever.document import _
 from opengever.document.base import BaseDocumentMixin
@@ -369,12 +370,16 @@ class Document(Item, BaseDocumentMixin):
                 redirector.redirect(create_oc_url(
                     request,
                     self,
-                    dict(action='checkout'),
+                    dict(action=action),
                 ))
             else:
                 redirector.redirect(
                     '%s/external_edit' % self.absolute_url(),
                     target='_self',
                     timeout=1000)
-        elif action == "oneoffixx":
-            pass
+        elif action == "oneoffixx" and is_oneoffixx_feature_enabled():
+            redirector.redirect(create_oc_url(
+                    request,
+                    self,
+                    dict(action=action),
+                ))

--- a/opengever/locking/tests/test_force_unlock.py
+++ b/opengever/locking/tests/test_force_unlock.py
@@ -19,7 +19,7 @@ class TestDocumentForceUnlock(OCIntegrationTestCase):
         with freeze():
             self.login(self.regular_user, browser)
             oc_url = self.fetch_document_checkout_oc_url(browser, self.document)
-            tokens = self.validate_checkout_token(self.regular_user, oc_url)
+            tokens = self.validate_checkout_token(self.regular_user, oc_url, self.document)
             self.lock_document(browser, tokens, self.document)
 
             self.login(self.meeting_user, browser)
@@ -36,7 +36,7 @@ class TestDocumentForceUnlock(OCIntegrationTestCase):
     def test_force_unlock_clears_lock(self, browser):
         self.login(self.regular_user, browser)
         oc_url = self.fetch_document_checkout_oc_url(browser, self.document)
-        tokens = self.validate_checkout_token(self.regular_user, oc_url)
+        tokens = self.validate_checkout_token(self.regular_user, oc_url, self.document)
         lockable = ILockable(self.document)
 
         self.lock_document(browser, tokens, self.document)

--- a/opengever/officeconnector/configure.zcml
+++ b/opengever/officeconnector/configure.zcml
@@ -50,6 +50,15 @@
       />
 
   <plone:service
+      method="GET"
+      for="opengever.document.document.IDocumentSchema"
+      accept="application/json"
+      factory=".service.OfficeConnectorOneOffixxURL"
+      name="officeconnector_oneoffixx_url"
+      permission="cmf.ModifyPortalContent"
+      />
+
+  <plone:service
       method="POST"
       for="Products.CMFPlone.interfaces.IPloneSiteRoot"
       accept="application/json"

--- a/opengever/officeconnector/helpers.py
+++ b/opengever/officeconnector/helpers.py
@@ -32,7 +32,7 @@ def parse_bcc(request):
     return None
 
 
-def parse_documents(request, context):
+def parse_documents(request, context, action):
     documents = []
 
     if (
@@ -44,7 +44,10 @@ def parse_documents(request, context):
         if not IBaseDocument.providedBy(context):
             raise NotFound
 
-        if not context.has_file():
+        # for checkout and attach actions, the document needs to have a file
+        # for the oneoffixx action, the document should be in the shadow state
+        if not (context.has_file()
+                or action == "oneoffixx" and context.is_shadow_document()):
             raise NotFound
 
         documents.append(context)
@@ -120,7 +123,7 @@ def create_oc_url(request, context, payload):
 
     bcc = parse_bcc(request)
 
-    documents = parse_documents(request, context)
+    documents = parse_documents(request, context, action)
 
     if not documents:
         raise NotFound

--- a/opengever/officeconnector/service.py
+++ b/opengever/officeconnector/service.py
@@ -6,6 +6,7 @@ from opengever.officeconnector import _
 from opengever.officeconnector.helpers import create_oc_url
 from opengever.officeconnector.helpers import is_officeconnector_attach_feature_enabled  # noqa
 from opengever.officeconnector.helpers import is_officeconnector_checkout_feature_enabled  # noqa
+from opengever.oneoffixx import is_oneoffixx_feature_enabled
 from plone import api
 from plone.protect import createToken
 from plone.rest import Service
@@ -78,6 +79,23 @@ class OfficeConnectorCheckoutURL(OfficeConnectorURL):
     def render(self):
         if is_officeconnector_checkout_feature_enabled():
             payload = {'action': 'checkout'}
+
+            return self.create_officeconnector_url_json(payload)
+
+        # Fail per default
+        raise NotFound
+
+
+class OfficeConnectorOneOffixxURL(OfficeConnectorURL):
+    """Create oc:<JWT> URLs for javascript to fetch and pass to the OS.
+
+    Instruct where to fetch an OfficeConnector 'oneoffixx' action payload for
+    this document.
+    """
+
+    def render(self):
+        if is_oneoffixx_feature_enabled():
+            payload = {'action': 'oneoffixx'}
 
             return self.create_officeconnector_url_json(payload)
 

--- a/opengever/officeconnector/testing.py
+++ b/opengever/officeconnector/testing.py
@@ -53,6 +53,19 @@ class OCIntegrationTestCase(IntegrationTestCase):
 
         return url
 
+    def fetch_document_oneoffixx_oc_url(self, browser, document):
+        headers = {
+            'Accept': 'application/json',
+            }
+
+        url = browser.open(
+            document,
+            headers=headers,
+            view='officeconnector_oneoffixx_url',
+            ).json.get('url', None)
+
+        return url
+
     def fetch_dossier_bcc(self, browser, dossier):
         headers = {
             'Accept': 'application/json',
@@ -87,15 +100,15 @@ class OCIntegrationTestCase(IntegrationTestCase):
 
         return url
 
-    def validate_attach_token(self, user, oc_url, documents):
+    def validate_token(self, user, oc_url, documents, action):
         raw_token = oc_url.split(':')[-1]
         token = jwt.decode(raw_token, verify=False)
-        self.assertEquals('attach', token.get('action', None))
+        self.assertEquals(action, token.get('action', None))
 
         url = token.get('url', None)
         expected_url = '/'.join((
             api.portal.get().absolute_url(),
-            'oc_attach',
+            'oc_' + action,
             ))
         self.assertEquals(expected_url, url)
 
@@ -118,6 +131,15 @@ class OCIntegrationTestCase(IntegrationTestCase):
             }
 
         return tokens
+
+    def validate_attach_token(self, user, oc_url, documents):
+        return self.validate_token(user, oc_url, documents, "attach")
+
+    def validate_checkout_token(self, user, oc_url, documents):
+        return self.validate_token(user, oc_url, documents, "checkout")
+
+    def validate_oneoffixx_token(self, user, oc_url, documents):
+        return self.validate_token(user, oc_url, documents, "oneoffixx")
 
     def fetch_document_attach_payloads(self, browser, tokens):
         with self.as_officeconnector(browser):
@@ -173,29 +195,6 @@ class OCIntegrationTestCase(IntegrationTestCase):
                 self.request).get_email_for_object(parent_dossier)
             self.assertEquals(bcc, dossier_bcc)
 
-    def validate_checkout_token(self, user, oc_url):
-        raw_token = oc_url.split(':')[-1]
-        token = jwt.decode(raw_token, verify=False)
-        self.assertEquals('checkout', token.get('action', None))
-
-        url = token.get('url', None)
-        self.assertTrue(url)
-
-        documents = token.get('documents', [])
-        self.assertEquals(1, len(documents))
-        self.assertEquals(api.content.get_uuid(self.document), documents[0])
-
-        self.assertEquals(user.id, token.get('sub', None))
-
-        expiry = int(token.get('exp', 0))
-        self.assertLess(int(time()), expiry)
-
-        tokens = {
-            'raw_token': raw_token,
-            'token': token,
-            }
-
-        return tokens
 
     def fetch_document_checkout_payloads(self, browser, tokens):
         with self.as_officeconnector(browser):
@@ -247,6 +246,30 @@ class OCIntegrationTestCase(IntegrationTestCase):
 
         upload_form = payload.get('upload-form', None)
         self.assertEquals('file_upload', upload_form)
+
+    def validate_oneoffixx_token(self, user, oc_url):
+        raw_token = oc_url.split(':')[-1]
+        token = jwt.decode(raw_token, verify=False)
+        self.assertEquals('oneoffixx', token.get('action', None))
+
+        url = token.get('url', None)
+        self.assertTrue(url)
+
+        documents = token.get('documents', [])
+        self.assertEquals(1, len(documents))
+        self.assertEquals(api.content.get_uuid(self.document), documents[0])
+
+        self.assertEquals(user.id, token.get('sub', None))
+
+        expiry = int(token.get('exp', 0))
+        self.assertLess(int(time()), expiry)
+
+        tokens = {
+            'raw_token': raw_token,
+            'token': token,
+            }
+
+        return tokens
 
     def checkout_document(self, browser, tokens, payload, document):
         """Logs out, uses JWT to check out the document and logs back in."""

--- a/opengever/officeconnector/tests/test_api_dossier_checkout.py
+++ b/opengever/officeconnector/tests/test_api_dossier_checkout.py
@@ -173,7 +173,7 @@ class TestOfficeconnectorDossierAPIWithCheckout(OCIntegrationTestCase):
         self.assertIsNotNone(oc_url)
         self.assertEquals(200, browser.status_code)
 
-        tokens = self.validate_checkout_token(self.regular_user, oc_url)
+        tokens = self.validate_checkout_token(self.regular_user, oc_url, self.document)
         payload = self.fetch_document_checkout_payloads(browser, tokens)[0]
 
         self.validate_checkout_payload(payload, self.document)
@@ -208,7 +208,7 @@ class TestOfficeconnectorDossierAPIWithCheckout(OCIntegrationTestCase):
         self.assertIsNotNone(oc_url)
         self.assertEquals(200, browser.status_code)
 
-        tokens = self.validate_checkout_token(self.regular_user, oc_url)
+        tokens = self.validate_checkout_token(self.regular_user, oc_url, self.document)
         payload = self.fetch_document_checkout_payloads(browser, tokens)[0]
 
         self.validate_checkout_payload(payload, self.document)

--- a/opengever/officeconnector/tests/test_api_dossier_disabled.py
+++ b/opengever/officeconnector/tests/test_api_dossier_disabled.py
@@ -223,3 +223,13 @@ class TestOfficeconnectorDossierAPIDisabled(OCIntegrationTestCase):
                 )
 
             self.assertIsNone(oc_url)
+
+    @browsing
+    def test_create_with_oneoffixx(self, browser):
+        self.login(self.dossier_responsible, browser)
+        self.document.file = None
+        self.document.as_shadow_document()
+
+        with browser.expect_http_error(404):
+            oc_url = self.fetch_document_oneoffixx_oc_url(browser, self.document)
+            self.assertIsNone(oc_url)

--- a/opengever/officeconnector/tests/test_api_dossier_oneoffixx.py
+++ b/opengever/officeconnector/tests/test_api_dossier_oneoffixx.py
@@ -1,0 +1,33 @@
+from ftw.testbrowser import browsing
+from opengever.officeconnector.testing import OCIntegrationTestCase
+
+
+class TestOfficeconnectorDossierAPIWithOneOffixx(OCIntegrationTestCase):
+    features = (
+        'officeconnector-checkout',
+        'oneoffixx'
+    )
+
+    @browsing
+    def test_create_with_oneoffixx(self, browser):
+        self.login(self.dossier_responsible, browser)
+        self.document.file = None
+        self.document.as_shadow_document()
+
+        oc_url = self.fetch_document_oneoffixx_oc_url(browser, self.document)
+
+        self.assertIsNotNone(oc_url)
+        self.assertEquals(200, browser.status_code)
+
+        tokens = self.validate_oneoffixx_token(self.dossier_responsible, oc_url, (self.document,))
+
+
+    @browsing
+    def test_create_with_oneoffixx_when_not_shadow_document(self, browser):
+        self.login(self.dossier_responsible, browser)
+        self.document.file = None
+
+        with browser.expect_http_error(404):
+            oc_url = self.fetch_document_oneoffixx_oc_url(browser, self.document)
+
+            self.assertIsNone(oc_url)

--- a/opengever/officeconnector/tests/test_zopemaster.py
+++ b/opengever/officeconnector/tests/test_zopemaster.py
@@ -52,7 +52,7 @@ class TestOfficeconnectorAsZopemasterDossierAPIWithCheckout(OCIntegrationTestCas
         self.assertIsNotNone(oc_url)
         self.assertEquals(200, browser.status_code)
 
-        tokens = self.validate_checkout_token(self.manager, oc_url)
+        tokens = self.validate_checkout_token(self.manager, oc_url, self.document)
         payload = self.fetch_document_checkout_payloads(browser, tokens)[0]
 
         self.validate_checkout_payload(payload, self.document)


### PR DESCRIPTION
Add the service to create a JWT for the `oneoffixx` action for office connector.

resolves #4136 