### PR TITLE
Add service to generate payload for officeconnector oneoffixx action

### DIFF
--- a/opengever/officeconnector/configure.zcml
+++ b/opengever/officeconnector/configure.zcml
@@ -76,4 +76,13 @@
       permission="zope2.View"
       />
 
+  <plone:service
+      method="POST"
+      for="Products.CMFPlone.interfaces.IPloneSiteRoot"
+      accept="application/json"
+      factory=".service.OfficeConnectorOneOffixxPayload"
+      name="oc_oneoffixx"
+      permission="zope2.View"
+      />
+
 </configure>

--- a/opengever/officeconnector/helpers.py
+++ b/opengever/officeconnector/helpers.py
@@ -34,25 +34,25 @@ def parse_bcc(request):
 
 def parse_documents(request, context, action):
     documents = []
-
     if (
             request['REQUEST_METHOD'] == 'GET'
             or request['REQUEST_METHOD'] == 'POST'
-            and 'BODY' not in request
+            and ('BODY' not in request
+                 or isinstance(json.loads(request['BODY']), list))
         ):
         # Feature enabled for the wrong content type
         if not IBaseDocument.providedBy(context):
             raise NotFound
 
         # for checkout and attach actions, the document needs to have a file
-        # for the oneoffixx action, the document should be in the shadow state
-        if not (context.has_file()
-                or action == "oneoffixx" and context.is_shadow_document()):
+        # for the oneoffixx action or checkout action fetched from
+        # OfficeConnectorOneOffixxPayload, the document should be in the shadow state
+        if not (context.has_file() or context.is_shadow_document()):
             raise NotFound
 
         documents.append(context)
 
-    if request['REQUEST_METHOD'] == 'POST' and 'BODY' in request:
+    elif request['REQUEST_METHOD'] == 'POST' and 'BODY' in request:
         payload = json.loads(request['BODY'])
         paths = payload.get('documents', None)
 

--- a/opengever/officeconnector/testing.py
+++ b/opengever/officeconnector/testing.py
@@ -249,6 +249,39 @@ class OCIntegrationTestCase(IntegrationTestCase):
         upload_form = payload.get('upload-form', None)
         self.assertEquals('file_upload', upload_form)
 
+    def fetch_document_oneoffixx_payloads(self, browser, tokens):
+        with self.as_officeconnector(browser):
+            headers = {
+                'Accept': 'application/json',
+                'Authorization': 'Bearer {}'.format(tokens.get('raw_token')),
+                'Content-Type': 'application/json',
+            }
+
+            data = json.dumps(tokens.get('token').get('documents', []))
+
+        payloads = browser.open(
+            self.portal,
+            method='POST',
+            data=data,
+            headers=headers,
+            view='oc_oneoffixx',
+            ).json
+
+        return payloads
+
+    def validate_oneoffixx_payload(self, payload, document, user):
+        csrf_token = payload.get('csrf-token', None)
+        self.assertTrue(csrf_token)
+
+        document_url = payload.get('document-url', None)
+        self.assertEquals(document.absolute_url(), document_url)
+
+        connect_xml = payload.get('connect-xml', None)
+        self.assertEquals('@@oneoffix_connect_xml', connect_xml)
+
+        checkout_token = payload.get('checkout-url', None)
+        self.validate_checkout_token(user, checkout_token, (document,))
+
     def checkout_document(self, browser, tokens, payload, document):
         """Logs out, uses JWT to check out the document and logs back in."""
         self.assertFalse(document.checked_out_by())

--- a/opengever/officeconnector/tests/test_api_dossier_oneoffixx.py
+++ b/opengever/officeconnector/tests/test_api_dossier_oneoffixx.py
@@ -20,7 +20,9 @@ class TestOfficeconnectorDossierAPIWithOneOffixx(OCIntegrationTestCase):
         self.assertEquals(200, browser.status_code)
 
         tokens = self.validate_oneoffixx_token(self.dossier_responsible, oc_url, (self.document,))
+        payload = self.fetch_document_oneoffixx_payloads(browser, tokens)[0]
 
+        self.validate_oneoffixx_payload(payload, self.document, self.dossier_responsible)
 
     @browsing
     def test_create_with_oneoffixx_when_not_shadow_document(self, browser):

--- a/opengever/oneoffixx/browser/form.py
+++ b/opengever/oneoffixx/browser/form.py
@@ -153,17 +153,9 @@ class SelectOneOffixxTemplateDocumentWizardStep(Form):
                 new_doc.absolute_url())
 
     def activate_external_editing(self, new_doc):
-        """Check out the given document, and add the external_editor URL
-        to redirector queue.
+        """Add the oneoffixx external_editor URL to redirector queue.
         """
-        # Check out the new document
-        manager = self.context.restrictedTraverse('checkout_documents')
 
-        # When it will be implemented we should use the new oneoffix
-        # action instead of checkout
-        # we can extend setup_external_edit_redirect to take a keyword argument
-        # action
-        manager.checkout(new_doc)
         new_doc.setup_external_edit_redirect(self.request, action="oneoffixx")
 
     def create_document(self, data):

--- a/opengever/oneoffixx/command.py
+++ b/opengever/oneoffixx/command.py
@@ -21,4 +21,6 @@ class CreateDocumentFromOneOffixxTemplateCommand(BaseObjectCreatorCommand):
         annotations = IAnnotations(obj)
         annotations["template-id"] = self.template_id
         annotations["languages"] = self.languages
+        annotations["filename"] = self.filename
+
         return obj.as_shadow_document()


### PR DESCRIPTION
Add service to generate payload for the officeconnector oneoffixx action. The payload contains the necessary information to retrieve the connect XML (`connect-xml` key)

resolves #4137 