### PR TITLE
Show group title in the sharing view

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ---------------------
 
 - Add view to get the Connect XML for OneOffixx. [njohner]
+- Show group title in the sharing view. [phgross]
 - No longer show unsortable columns as sortable, bump ftw.tabbedview to 4.1.1. [deiferni]
 - Add debug views for agenda_items and docxcompose. [deiferni]
 - Fix API get request on private dossiers. [phgross]

--- a/opengever/dossier/tests/test_templatefolder.py
+++ b/opengever/dossier/tests/test_templatefolder.py
@@ -1004,7 +1004,7 @@ class TestTemplateDocumentTabs(IntegrationTestCase):
 
         expected_sharing_tab_data = [
             ['Logged-in users', False, False, False],
-            ['fa Users Group (fa_users)', True, False, False],
+            ['fa_users', True, False, False],
             ['Kohler Nicole (nicole.kohler)', True, True, True],
             ['Ziegler Robert (robert.ziegler)', True, True, True],
             ]

--- a/opengever/examplecontent/profiles/default/registry.xml
+++ b/opengever/examplecontent/profiles/default/registry.xml
@@ -39,4 +39,8 @@
     <value key="direct_checkout_and_edit_enabled">True</value>
   </records>
 
+  <records interface="opengever.ogds.base.interfaces.IOGDSSyncConfiguration">
+    <value key="group_title_ldap_attribute">description</value>
+  </records>
+
 </registry>

--- a/opengever/sharing/tests/test_sharing_integration.py
+++ b/opengever/sharing/tests/test_sharing_integration.py
@@ -1,6 +1,7 @@
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
+from opengever.ogds.base.utils import get_current_org_unit
 from opengever.sharing.browser.sharing import OpengeverSharingView
 from opengever.sharing.browser.sharing import SharingTab
 from opengever.sharing.interfaces import ILocalRolesAcquisitionActivated
@@ -204,7 +205,7 @@ class TestOpengeverSharingWithBrowser(IntegrationTestCase):
 
         expected_users_and_roles = [
             'Logged-in users',
-            'fa Users Group (fa_users)',
+            'fa_users',
             u'B\xe4rfuss K\xe4thi (kathi.barfuss)',
             u'Fr\xfchling F\xe4ivel (faivel.fruhling)',
             u'K\xf6nig J\xfcrgen (jurgen.konig)',
@@ -255,3 +256,19 @@ class TestOpengeverSharingWithBrowser(IntegrationTestCase):
              'http://nohost/plone/@@list_groupmembers?group=fa_users',
              'http://nohost/plone/@@list_groupmembers?group=with+spaces'],
             group_links)
+
+    @browsing
+    def test_sharing_view_uses_group_title_attribute_if_exists(self, browser):
+        self.login(self.manager, browser)
+
+        inbox_group = get_current_org_unit().inbox_group
+        inbox_group.title = u'The inbox group title'
+        api.group.grant_roles(
+            groupname=inbox_group.id(), obj=self.dossier, roles=['Publisher'])
+
+        browser.open(self.dossier, view='@@sharing')
+        self.assertEqual(
+            ['Logged-in users',
+             'The inbox group title (fa_inbox_users)',
+             'fa_users'],
+            browser.css('#user-group-sharing-settings tr a').text)


### PR DESCRIPTION
With b1e2d59 a new configuration option `group_title_ldap_attribute` has been introduced, which sets the group title during the ogds syncrhonisation. We show now the title if exists in the Sharing view instead of only the id.

![bildschirmfoto 2018-05-02 um 14 28 25](https://user-images.githubusercontent.com/485755/39523252-32a98d76-4e15-11e8-9d80-bfe754058771.png)

Because our LDAP stack does not support mapping additional attributes, we fetch the title information from ogds groups.

Closes #3864.