### PR TITLE
Revert "tmp id add"

### DIFF
--- a/opengever/meeting/model/meeting.py
+++ b/opengever/meeting/model/meeting.py
@@ -457,7 +457,6 @@ class Meeting(Base, SQLFormSupport):
     @require_word_meeting_feature
     def get_data_for_zip_export(self):
         meeting_data = {
-            'id': safe_unicode(self.meeting_id),
             'title': safe_unicode(self.title),
             'start': safe_unicode(self.start.isoformat()),
             'end': safe_unicode(self.end and self.end.isoformat() or ''),


### PR DESCRIPTION
This reverts commit c2ff55c4e956595aacae75db617f231bb58362ee.

Accidently pushed a temp commit (tried to run the tests on CI) but with the new magit default you push to origin/master.

(Yes the 🐷 already got its 5 CHF)