### PR TITLE
Change translation of properties

### DIFF
--- a/opengever/core/locales/de/LC_MESSAGES/opengever.core.po
+++ b/opengever/core/locales/de/LC_MESSAGES/opengever.core.po
@@ -181,7 +181,7 @@ msgstr "Persönlicher Ordner"
 #: ./opengever/core/profiles/default/actions.xml
 #: ./opengever/core/upgrades/20180221144648_update_properties_action_available_expression/actions.xml
 msgid "Properties"
-msgstr "Eigenschaften"
+msgstr "Metadaten anzeigen"
 
 #. Default: "Proposal"
 #: ./opengever/core/profiles/default/types/opengever.meeting.proposal.xml

--- a/opengever/core/locales/fr/LC_MESSAGES/opengever.core.po
+++ b/opengever/core/locales/fr/LC_MESSAGES/opengever.core.po
@@ -178,7 +178,7 @@ msgstr "Dossier personnel"
 #: ./opengever/core/profiles/default/actions.xml
 #: ./opengever/core/upgrades/20180221144648_update_properties_action_available_expression/actions.xml
 msgid "Properties"
-msgstr "Propriétés"
+msgstr "Afficher les métadonnées"
 
 #. Default: "Proposal"
 #: ./opengever/core/profiles/default/types/opengever.meeting.proposal.xml


### PR DESCRIPTION
For documents we used "Metadaten bearbeiten" to edit the metadata but "Eigenschaften" to view them. Clients proposed that we standardise the terms. Finally we only change the "Eigenschaften" to "Metadaten anzeigen". That makes it very clear for documents.

For other types, we still use "Bearbeiten" to edit the object, and now "metadaten anzeigen" to view the properties.

**Preview for a meetingdossier**

![screen shot 2018-05-07 at 08 27 43](https://user-images.githubusercontent.com/7374243/39687925-c88ac7e2-51d0-11e8-8f1f-3dc2d9e5d405.png)

**Preview for a document**

![screen shot 2018-05-07 at 08 26 41](https://user-images.githubusercontent.com/7374243/39687921-c5af2b4e-51d0-11e8-87b7-1003add71a17.png)

resolves #4050 