### PR TITLE
Fix sorting of memberships by fullname.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ---------------------
 
 - Enable favorites feature by default. [phgross]
+- Fix sorting of membership listing. [deiferni]
 - Skip plonesite removals in ObjectRemovedEvent handler, to fix plonesite removal. [phgross]
 - Add view to get the Connect XML for OneOffixx. [njohner]
 - Show group title in the sharing view. [phgross]

--- a/opengever/tabbedview/sqlsource.py
+++ b/opengever/tabbedview/sqlsource.py
@@ -28,24 +28,24 @@ def sort_column_exists(query, sort_on):
     for _column in query.column_descriptions:
 
         column_exists = (
-            not _column.get('aliased') and
-            str(sort_on) in _column.get('entity').__table__.columns or
-            False
+            not _column.get('aliased')
+            and str(sort_on) in _column.get('entity').__table__.columns
+            or False
         )
 
         entity_exists = (
-            not _column.get('aliased') and
-            str(sort_on).replace(
+            not _column.get('aliased')
+            and str(sort_on).replace(
                 '{}.'.format(_column.get('name')),
                 ''
-            ) in _column.get('entity').__table__.columns or
-            False
+            ) in _column.get('entity').__table__.columns
+            or False
         )
 
         alias_exists = (
-            _column.get('aliased') and
-            str(sort_on) in _column.get('name') or
-            False
+            _column.get('aliased')
+            and str(sort_on) in _column.get('name')
+            or False
         )
 
         if any((column_exists, entity_exists, alias_exists)):

--- a/opengever/tabbedview/tests/test_sqlsource.py
+++ b/opengever/tabbedview/tests/test_sqlsource.py
@@ -85,6 +85,7 @@ class TestSQLAlchemySortIndexes(FunctionalTestCase):
             'ORDER BY this_column_does_not_exist',
             str(sorted_query))
 
+
 class TestTextFilter(FunctionalTestCase):
 
     def setUp(self):


### PR DESCRIPTION
In https://github.com/4teamwork/opengever.core/pull/3851 we introduced a check to only sort by columns that exist. This is too strict and filters out sorting by special sqlalchemy constructs, e.g. a `column_property`.

This PR loosens the checks and allows to sort by anything that comes out of the `sqlalchemy_sort_indexes` mapping.

Fixes #4195.