### PR TITLE
Fix IE 11 JS-bug in tree.js

### DIFF
--- a/opengever/portlets/tree/resources/tree.js
+++ b/opengever/portlets/tree/resources/tree.js
@@ -385,7 +385,9 @@ RepositoryFavorites = function(url, cache_param) {
     _data_cache = null;
   }
 
-  function load_favorites(withCache=true) {
+  function load_favorites(withCache) {
+    withCache = withCache || true;
+
     var params = {}
 
     if ( withCache ) {

--- a/opengever/portlets/tree/resources/tree.js
+++ b/opengever/portlets/tree/resources/tree.js
@@ -54,7 +54,7 @@ function Tree(nodes, config) {
     var $link = $('<a />').text(this.text).
         attr('href', this.url).
         attr('title', this.description).
-        addClass(function() { return this.active ? 'active' : 'inactive' }.bind(this));
+        addClass(function() { return this.active ? 'active' : 'inactive'; }.bind(this));
     $list_item.append($link);
     $(tree).trigger('tree:link-created', [this, $link]);
 
@@ -365,8 +365,8 @@ RepositoryFavorites = function(url, cache_param) {
     baseURL: window.portal_url + '/@repository-favorites/' + base.data('userid'),
     headers: {
       'Accept': 'application/json',
-      'Content-Type': 'application/json',
-    },
+      'Content-Type': 'application/json'
+    }
   });
   var _data_cache;
   var i18n_add = $('[data-i18n-add-to-favorites]').data('i18n-add-to-favorites') || '';


### PR DESCRIPTION
IE 11 does not support the ecmascript 6 feature `default function parameters` (see http://kangax.github.io/compat-table/es6/) , therefore we have to implement the common workaround.
https://stackoverflow.com/questions/15178700/javascript-functions-and-default-parameters-not-working-in-ie-and-chrome