### PR TITLE
Favorites: Fixes issues in state-sycing

### DIFF
--- a/opengever/base/browser/resources/Favorites.js
+++ b/opengever/base/browser/resources/Favorites.js
@@ -3,6 +3,10 @@
   function FavoriteController() {
     Controller.call(this);
 
+    this.toggle_favorite_marker = function(target) {
+      target.toggleClass('is-favorite');
+    }
+
     this.toggle_favorite = function(target) {
       if ($('#mark-as-favorite').hasClass('loading')){
         return;
@@ -76,7 +80,13 @@
         method: "click",
         target: "#mark-as-favorite",
         callback: this.toggle_favorite
+      },
+      {
+        method: "toggle-favorite-marker",
+        target: "#mark-as-favorite",
+        callback: this.toggle_favorite_marker
       }
+
     ];
 
     this.init();

--- a/opengever/portlets/tree/resources/tree.js
+++ b/opengever/portlets/tree/resources/tree.js
@@ -386,7 +386,7 @@ RepositoryFavorites = function(url, cache_param) {
   }
 
   function load_favorites(withCache) {
-    withCache = withCache || true;
+    withCache = (typeof withCache !== 'undefined') ?  withCache : true;
 
     var params = {}
 

--- a/opengever/portlets/tree/resources/tree.js
+++ b/opengever/portlets/tree/resources/tree.js
@@ -394,6 +394,13 @@ RepositoryFavorites = function(url, cache_param) {
       params.cache_key = cachekey
     } else {
       clearDataCache();
+      if (!!window.MSInputMethodContext && !!document.documentMode) {
+        // IE11 Fix: Requesting the ressource without a cache-key will return
+        // the currently cached ressource anyway. We have to fix this issue
+        // through adding a timestamp as a cache-key to be sure, the IE11 will
+        // perform the request to the server.
+        params.cache_key = Date.now();
+      }
     }
 
     favorites = $.Deferred();

--- a/opengever/portlets/tree/resources/tree.js
+++ b/opengever/portlets/tree/resources/tree.js
@@ -435,6 +435,11 @@ RepositoryFavorites = function(url, cache_param) {
                 $(this).addClass('bookmarked');
                 self.add($(this).data('uuid'));
               }
+              if ($(this).parent().hasClass('current')) {
+                  // Toggles the favorites-marker next to the title in the main
+                  // content.
+                  $('#mark-as-favorite').trigger('toggle-favorite-marker');
+              }
               annotate_link_title($(this));
             });
         self.favorites().then(function(favorites) {


### PR DESCRIPTION
This PR fixes three issues:

1.
`withCache` will be always `true` if you set it explicitly to `false`.

```node
> false || true
true
```

2. Requesting a cached resource without a caching parameter will not set Caching-Headers (https://github.com/4teamwork/opengever.core/blob/master/opengever/api/repository_favorites.py#L31), means, if a browser is requesting the resource without a `cache_key` parameter, the request should never be cached. This works fine for all browsers instead IE11. It is caching this request anyway. Setting a timestamp as a cachekey for requests without caching will solve this issue.

Before:
![screen2](https://user-images.githubusercontent.com/557005/39749067-0d372fd4-52b2-11e8-971a-fe138a5acf2e.gif)

After:
![screen1](https://user-images.githubusercontent.com/557005/39749079-12eb6ca6-52b2-11e8-8b13-a436e554a4e7.gif)

3. Adding sync from the tree-portelt to the context-title favorite-marker

Before:
![screen2](https://user-images.githubusercontent.com/557005/39751545-d0b86fee-52b8-11e8-82fb-7a557c64923d.gif)

After:
![screen1](https://user-images.githubusercontent.com/557005/39751508-b36d0b34-52b8-11e8-8c5d-076048142c02.gif)
