### PR TITLE
Fix policy template

### DIFF
--- a/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/profiles/default/registry.xml.bob
+++ b/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/profiles/default/registry.xml.bob
@@ -1,6 +1,5 @@
 <registry>
 
-{{% endif %}}
 {{% if not setup.enable_activity_feature %}}
   <record interface="opengever.activity.interfaces.IActivitySettings" field="is_feature_enabled">
     <field type="plone.registry.field.Bool" />


### PR DESCRIPTION
While removing the obsolete "opengever.portlets.tree.enable_favorites" registry entry, an "endif" was forgotten which broke the policy template.

https://github.com/4teamwork/opengever.core/commit/e99eb74aca16fd256fdcfa06ae0ccd9b2b4c3bfa#diff-29f5e91b71244d611e5d4131d17d94bb

Resolves #4273 