### PR TITLE
Set document date of generated journal pdfs to dossier end-date.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2018.3.0 (unreleased)
 ---------------------
 
+- Set document date of generated journal pdfs to dossier end-date. [deiferni]
 - Enable favorites feature by default. [phgross]
 - Skip plonesite removals in ObjectRemovedEvent handler, to fix plonesite removal. [phgross]
 - Add view to get the Connect XML for OneOffixx. [njohner]

--- a/opengever/dossier/tests/test_resolve.py
+++ b/opengever/dossier/tests/test_resolve.py
@@ -1,4 +1,3 @@
-from Acquisition import aq_parent
 from datetime import date
 from datetime import datetime
 from ftw.builder import Builder
@@ -13,7 +12,6 @@ from ftw.testbrowser.pages.statusmessages import error_messages
 from ftw.testbrowser.pages.statusmessages import info_messages
 from ftw.testing import freeze
 from opengever.core.testing import OPENGEVER_FUNCTIONAL_BUMBLEBEE_LAYER
-from opengever.document.behaviors import IBaseDocument
 from opengever.dossier.behaviors.dossier import IDossier
 from opengever.dossier.interfaces import IDossierResolveProperties
 from opengever.testing import FunctionalTestCase

--- a/opengever/dossier/tests/test_resolve.py
+++ b/opengever/dossier/tests/test_resolve.py
@@ -17,6 +17,7 @@ from opengever.document.behaviors import IBaseDocument
 from opengever.dossier.behaviors.dossier import IDossier
 from opengever.dossier.interfaces import IDossierResolveProperties
 from opengever.testing import FunctionalTestCase
+from opengever.testing import IntegrationTestCase
 from plone import api
 from plone.app.testing import applyProfile
 from plone.protect import createToken
@@ -42,35 +43,29 @@ class TestResolverVocabulary(FunctionalTestCase):
             vocabulary.by_value.keys())
 
 
-class TestResolvingDossiers(FunctionalTestCase):
+class TestResolvingDossiers(IntegrationTestCase):
 
     @browsing
     def test_archive_form_is_omitted_for_sites_without_filing_number_support(self, browser):
-        self.grant('Manager')
-        dossier = create(Builder('dossier')
-                         .having(start=date(2013, 11, 5)))
+        self.login(self.secretariat_user, browser)
 
-        browser.login().open(dossier,
-                             {'_authenticator': createToken()},
-                             view='transition-resolve')
+        browser.open(self.empty_dossier,
+                    {'_authenticator': createToken()},
+                    view='transition-resolve')
 
-        self.assertEquals(dossier.absolute_url(), browser.url)
+        self.assertEquals(self.empty_dossier.absolute_url(), browser.url)
         self.assertEquals(['The dossier has been succesfully resolved.'],
                           info_messages())
 
     @browsing
     def test_archive_form_is_omitted_when_resolving_subdossiers(self, browser):
-        self.grant('Manager')
-        dossier = create(Builder('dossier'))
-        subdossier = create(Builder('dossier')
-                            .within(dossier)
-                            .having(start=date(2013, 11, 5)))
+        self.login(self.secretariat_user, browser)
 
-        browser.login().open(subdossier,
-                             {'_authenticator': createToken()},
-                             view='transition-resolve')
+        browser.open(self.subdossier,
+                    {'_authenticator': createToken()},
+                     view='transition-resolve')
 
-        self.assertEquals(subdossier.absolute_url(), browser.url)
+        self.assertEquals(self.subdossier.absolute_url(), browser.url)
         self.assertEquals(['The subdossier has been succesfully resolved.'],
                           info_messages())
 

--- a/opengever/dossier/tests/test_resolve.py
+++ b/opengever/dossier/tests/test_resolve.py
@@ -170,8 +170,6 @@ class TestResolveJobs(FunctionalTestCase):
     def test_only_shadowed_documents_are_deleted_when_resolving_a_dossier(self):
         doc1 = create(Builder('document').within(self.dossier))
         doc2 = create(Builder('document').within(self.dossier).as_shadow_document())
-        doc1.reindexObject(idxs=["review_state"])
-        doc2.reindexObject(idxs=["review_state"])
 
         api.content.transition(obj=self.dossier,
                                transition='dossier-transition-resolve')
@@ -187,8 +185,6 @@ class TestResolveJobs(FunctionalTestCase):
         subdossier = create(Builder('dossier').within(self.dossier))
         doc1 = create(Builder('document').within(subdossier))
         doc2 = create(Builder('document').within(subdossier).as_shadow_document())
-        doc1.reindexObject(idxs=["review_state"])
-        doc2.reindexObject(idxs=["review_state"])
 
         api.content.transition(obj=self.dossier,
                                transition='dossier-transition-resolve')

--- a/opengever/testing/builders/dx.py
+++ b/opengever/testing/builders/dx.py
@@ -128,6 +128,7 @@ class DocumentBuilder(DexterityBuilder):
 
         if self._is_shadow:
             obj.as_shadow_document()
+            obj.reindexObject(idxs=["review_state"])
 
         super(DocumentBuilder, self).after_create(obj)
 

--- a/opengever/testing/integration_test_case.py
+++ b/opengever/testing/integration_test_case.py
@@ -58,6 +58,8 @@ FEATURE_FLAGS = {
     'workspace': 'opengever.workspace.interfaces.IWorkspaceSettings.is_feature_enabled',
     'favorites': 'opengever.base.interfaces.IFavoritesSettings.is_feature_enabled',
     'solr': 'opengever.base.interfaces.ISearchSettings.use_solr',
+    'purge-trash': 'opengever.dossier.interfaces.IDossierResolveProperties.purge_trash_enabled',
+    'journal-pdf': 'opengever.dossier.interfaces.IDossierResolveProperties.journal_pdf_enabled',
     }
 
 FEATURE_PROFILES = {
@@ -67,7 +69,6 @@ FEATURE_PROFILES = {
 FEATURE_METHODS = {
     'private': enable_opengever_private,
 }
-
 
 
 class IntegrationTestCase(TestCase):


### PR DESCRIPTION
Set the document date of journal pdfs to their to dossiers end-date, if the dossier has an end-date. This prevents the dossier from entering an invalid state with a document date outside the dossiers start-end range.

This also fixes the tests by calling the browser-view to resolve the dossier as that view recursively resolves the dossiers whereas just calling the transition will behave differently.

Also port `TestResolvingDossiers` and `TestResolveJobs` from functional to an integration test case.

Closes #4270.