### PR TITLE
Don't enable auto refresh in example content.

### DIFF
--- a/opengever/examplecontent/profiles/default/registry.xml
+++ b/opengever/examplecontent/profiles/default/registry.xml
@@ -14,7 +14,6 @@
 
   <records interface="opengever.bumblebee.interfaces.IGeverBumblebeeSettings">
     <value key="is_feature_enabled">True</value>
-    <value key="is_auto_refresh_enabled">True</value>
   </records>
 
   <records interface="opengever.contact.interfaces.IContactSettings">


### PR DESCRIPTION
We don't want this enabled for dev by default (for now) as it results in console error messages when bumblebee is not running in dev (which is usually the case).

_As just discussed before lunch._