### PR TITLE
Make sure IE 11 does not cache favorites fetch requets.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ---------------------
 
 - Set document date of generated journal pdfs to dossier end-date. [deiferni]
+- Make sure IE 11 does not cache favorites fetch requets. [phgross]
 - Enable favorites feature by default. [phgross]
 - Fix sorting of membership listing. [deiferni]
 - Skip plonesite removals in ObjectRemovedEvent handler, to fix plonesite removal. [phgross]

--- a/opengever/base/browser/resources/favorites_app.js
+++ b/opengever/base/browser/resources/favorites_app.js
@@ -70,7 +70,9 @@ var app = new Vue({
 
     fetchData: function () {
       var self = this;
-      this.requester.get(this.endpoint).then(function (response) {
+      // make sure IE 11 does not cache the fetch request
+      var url = this.endpoint+ '?_t=' + Date.now().toString();
+      this.requester.get(url).then(function (response) {
         var items = response.data.sort(function(a, b){
           if (a.position > b.position) {
             return 1;

--- a/opengever/base/browser/resources/favorites_menu_app.js
+++ b/opengever/base/browser/resources/favorites_menu_app.js
@@ -61,7 +61,9 @@ function init() {
         this.isOpen = false;
       },
       fetchData: function () {
-        return this.requester.get(this.endpoint)
+        // make sure IE 11 does not cache the fetch request
+        var url = this.endpoint + '?_t=' + Date.now().toString();
+        return this.requester.get(url)
           .then(function (response) {
           var items = response.data.sort(function(a, b){
             return a.position - b.position;


### PR DESCRIPTION
IE 11 ignores `Cache-Control` headers on AJAX GET calls, therefore we need to extend the fetch url with a timestamp parameter.

This solves different IE 11 issues with the new favorites feature.