### PR TITLE
Fetch archivist group members from ogds.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2018.3.0 (unreleased)
 ---------------------
 
+- Fetch archivist group members from ogds. [phgross]
 - Set document date of generated journal pdfs to dossier end-date. [deiferni]
 - Enable favorites feature by default. [phgross]
 - Fix sorting of membership listing. [deiferni]

--- a/opengever/disposition/disposition.py
+++ b/opengever/disposition/disposition.py
@@ -16,6 +16,7 @@ from opengever.disposition.interfaces import IHistoryStorage
 from opengever.dossier.base import DOSSIER_STATES_OFFERABLE
 from opengever.dossier.behaviors.dossier import IDossier
 from opengever.ogds.base.utils import get_current_admin_unit
+from opengever.ogds.base.utils import ogds_service
 from persistent.dict import PersistentDict
 from persistent.list import PersistentList
 from plone import api
@@ -278,6 +279,7 @@ class Disposition(Container):
         acl_users = api.portal.get_tool('acl_users')
         role_manager = acl_users.get('portal_role_manager')
         for principal, title in role_manager.listAssignedPrincipals('Archivist'):
+
             info = role_manager.searchPrincipals(
                 id=principal, exact_match=True)
             # skip not existing or duplicated groups or users
@@ -285,8 +287,8 @@ class Disposition(Container):
                 continue
 
             if info[0].get('principal_type') == 'group':
-                group = acl_users.getGroupById(principal)
-                archivists += group.getGroupMemberIds()
+                archivists += [user.userid for user in
+                               ogds_service().fetch_group(principal).users]
             else:
                 archivists.append(principal)
 

--- a/opengever/disposition/tests/test_activities.py
+++ b/opengever/disposition/tests/test_activities.py
@@ -3,8 +3,10 @@ from ftw.builder import create
 from opengever.activity import notification_center
 from opengever.activity.model import Activity
 from opengever.activity.model import Resource
-from opengever.base.behaviors.lifecycle import ARCHIVAL_VALUE_WORTHY
+from opengever.activity.roles import DISPOSITION_ARCHIVIST_ROLE
+from opengever.activity.roles import DISPOSITION_RECORDS_MANAGER_ROLE
 from opengever.base.behaviors.lifecycle import ARCHIVAL_VALUE_UNWORTHY
+from opengever.base.behaviors.lifecycle import ARCHIVAL_VALUE_WORTHY
 from opengever.core.testing import OPENGEVER_FUNCTIONAL_ACTIVITY_LAYER
 from opengever.ogds.base.actor import Actor
 from opengever.testing import FunctionalTestCase
@@ -33,12 +35,33 @@ class TestDispositionNotifications(FunctionalTestCase):
         self.actor_link = Actor.lookup(TEST_USER_ID).get_link()
 
     def test_creator_and_all_archivist_are_registered_as_watchers(self):
+        acl_users = api.portal.get_tool('acl_users')
+        role_manager = acl_users.get('portal_role_manager')
+        role_manager.assignRoleToPrincipal(
+            'Archivist', self.org_unit.inbox_group.groupid)
+
+        create(Builder('ogds_user')
+               .id('peter.meier')
+               .having(firstname='peter', lastname='meier',
+                       email='meier@example.com')
+               .assign_to_org_units([self.org_unit])
+               .in_group(self.org_unit.inbox_group))
+
         create(Builder('disposition'))
 
         resource = Resource.query.one()
+
+        archivist_watchers = [
+            sub.watcher.actorid for sub in resource.subscriptions
+            if sub.role == DISPOSITION_ARCHIVIST_ROLE]
+        records_manager_watchers = [
+            sub.watcher.actorid for sub in resource.subscriptions
+            if sub.role == DISPOSITION_RECORDS_MANAGER_ROLE]
+
+        self.assertItemsEqual([TEST_USER_ID], records_manager_watchers)
         self.assertItemsEqual(
-            [TEST_USER_ID, u'hugo.boss', u'hans.boss'],
-            [watcher.actorid for watcher in resource.watchers])
+            [TEST_USER_ID, u'hugo.boss', u'hans.boss', u'peter.meier'],
+            archivist_watchers)
 
     def test_added_activity_is_recorded_when_a_disposition_is_created(self):
         create(Builder('disposition').titled(u'Angebot 13.49'))


### PR DESCRIPTION
Currently the archivist group members has been fetched via group's `getGroupMemberIds` but those does not respect nested groups and lead to incomplete dispositions watchers list.

The watchers list is not permission-critical, therefore the ogds is the right place to query the group members.