### PR TITLE
Fix content displayed in the templatefolder's gallery view.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ---------------------
 
 - Fetch archivist group members from ogds. [phgross]
+- Fix content displayed in the templatefolder's gallery view. [phgross]
 - Set document date of generated journal pdfs to dossier end-date. [deiferni]
 - Make sure IE 11 does not cache favorites fetch requets. [phgross]
 - Enable favorites feature by default. [phgross]

--- a/opengever/dossier/templatefolder/configure.zcml
+++ b/opengever/dossier/templatefolder/configure.zcml
@@ -32,6 +32,14 @@
       />
 
   <browser:page
+      name="tabbedview_view-documents-gallery"
+      for="opengever.dossier.templatefolder.interfaces.ITemplateFolder"
+      class=".tabs.TemplateFolderDocumentsGallery"
+      permission="zope2.View"
+      allowed_attributes="fetch"
+      />
+
+  <browser:page
       for="opengever.dossier.templatefolder.interfaces.ITemplateFolder"
       name="tabbedview_view-sablontemplates-proxy"
       class=".tabs.TemplateFolderSablonTemplatesProxy"

--- a/opengever/dossier/templatefolder/tabs.py
+++ b/opengever/dossier/templatefolder/tabs.py
@@ -50,6 +50,15 @@ class TemplateFolderDocuments(Documents):
     ]
 
 
+class TemplateFolderDocumentsGallery(BumblebeeGalleryMixin, TemplateFolderDocuments):
+    """Bumblebee gallery for templates (documents inside templatefolder).
+
+    Shows only documens directly inside the templatefolder not recursive.
+    """
+
+    depth = 1
+
+
 class TemplateFolderSablonTemplatesProxy(BaseTabProxy):
     """This proxyview is looking for the last used documents
     view (list or gallery) and reopens this view.

--- a/opengever/dossier/tests/test_templatefolder.py
+++ b/opengever/dossier/tests/test_templatefolder.py
@@ -772,7 +772,7 @@ class TestTemplateFolderListings(IntegrationTestCase):
 
     @browsing
     def test_renders_quickupload_uploadbox(self, browser):
-        self.login(self.administrator, browser) # admins can add templates
+        self.login(self.administrator, browser)  # admins can add templates
         browser.open(self.templates)
 
         self.assertIsNotNone(
@@ -979,6 +979,8 @@ class TestTemplateFolderListings(IntegrationTestCase):
 
 class TestTemplateDocumentTabs(IntegrationTestCase):
 
+    features = ('bumblebee', )
+
     @browsing
     def test_template_overview_tab(self, browser):
         self.login(self.regular_user, browser)
@@ -1010,6 +1012,23 @@ class TestTemplateDocumentTabs(IntegrationTestCase):
             ]
 
         self.assertEquals(expected_sharing_tab_data, sharing_tab_data())
+
+    @browsing
+    def test_documents_tab_shows_only_docs_directly_inside_the_folder(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        # main templatefolder
+        browser.open(self.templates, view='tabbedview_view-documents-gallery')
+        self.assertEquals(
+            [self.empty_template.title, self.normal_template.title,
+             self.asset_template.title, self.docprops_template.title],
+            [img.attrib.get('alt') for img in browser.css('img')])
+
+        # subtemplatefolder
+        browser.open(self.subtemplates, view='tabbedview_view-documents-gallery')
+        self.assertEquals(
+            [self.subtemplate.title],
+            [img.attrib.get('alt') for img in browser.css('img')])
 
 
 class TestDossierTemplateFeature(IntegrationTestCase):


### PR DESCRIPTION
The document listing of a templatefolder only shows documents directly inside the folder, but the gallery view showed recursive all documents.

Closes #4191 