### PR TITLE
Improve error handling on the @scan-in API endpoint

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,7 @@ Changelog
 
 - Fix stuck tabbedview spinner on firefox. [Kevin Bieri]
 - Normalize query strings of template filter. [Kevin Bieri]
+- Improve error handling on the @scan-in API endpoint. [Rotonen]
 - Bumblebee bugfix: no longer defer preview for new documents. [deiferni]
 - Display dossier resolve properties in the config view. [tarnap]
 - Integrate plonetheme.teamraum. [deiferni]


### PR DESCRIPTION
* Move error returns to destination discovery
* Duck type the destination for error handling
* Use a fall-through default 404 on the destination discovery

Closes #4202