### PR TITLE
Point download link to archive.apache.org.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -231,7 +231,7 @@ Extend the Solr configuration in your `buildout.cfg` and add the Solr directive:
     solr-port = 8983
 
     [solr]
-    url = http://www-eu.apache.org/dist/lucene/solr/7.3.0/solr-7.3.0.tgz
+    url = http://archive.apache.org/dist/lucene/solr/7.3.0/solr-7.3.0.tgz
     md5sum = dfb6893fc656e14919df48ff654d38f2
 
 


### PR DESCRIPTION
Otherwise it will break in the near future when the next version is released. 

Assuming that https://github.com/4teamwork/ftw.solr/pull/118 will be merged soon.