### PR TITLE
Show responsible and issuer to notification mail for TaskAdded activities.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2018.3.0 (unreleased)
 ---------------------
 
+- Add responsible and issuer to notification mail for TaskAdded activities. [phgross]
 - Fetch archivist group members from ogds. [phgross]
 - Set document date of generated journal pdfs to dossier end-date. [deiferni]
 - Make sure IE 11 does not cache favorites fetch requets. [phgross]

--- a/opengever/task/activities.py
+++ b/opengever/task/activities.py
@@ -61,7 +61,11 @@ class TaskAddedActivity(BaseActivity):
             [_('label_dossier_title', u'Dossier title'),
              self.parent.title],
             [_('label_text', u'Text'),
-             self.context.text if self.context.text else u'-' ]
+             self.context.text if self.context.text else u'-'],
+            [_('label_responsible', u'Responsible'),
+             self.context.get_responsible_actor().get_label()],
+            [_('label_issuer', u'Issuer'),
+             self.context.get_issuer_actor().get_label()]
         ]
 
     def before_recording(self):

--- a/opengever/task/task.py
+++ b/opengever/task/task.py
@@ -322,6 +322,9 @@ class Task(Container):
     def get_responsible_actor(self):
         return Actor.lookup(self.responsible)
 
+    def get_issuer_actor(self):
+        return Actor.lookup(self.issuer)
+
     def get_responsible_org_unit(self):
         return ogds_service().fetch_org_unit(self.responsible_client)
 

--- a/opengever/task/tests/test_activities.py
+++ b/opengever/task/tests/test_activities.py
@@ -49,16 +49,18 @@ class TestTaskActivites(FunctionalTestCase):
         self.assertEquals(u'Abkl\xe4rung Fall Meier', activity.title)
         self.assertEquals(u'New task added by Test User', activity.summary)
 
-        # XXX should be a better assertion like the ftw.testbrowser table
-        # dict representation
-        self.maxDiff = None
-        expected = (u'<table><tbody>'
-                    u'<tr><td class="label">Task title</td><td>Abkl\xe4rung Fall Meier</td></tr>'
-                    u'<tr><td class="label">Deadline</td><td>Feb 13, 2015</td></tr>'
-                    u'<tr><td class="label">Task Type</td><td>To comment</td></tr>'
-                    u'<tr><td class="label">Dossier title</td><td>Dossier XY</td></tr>'
-                    u'<tr><td class="label">Text</td><td>Lorem ipsum</td></tr></tbody></table>')
-        self.assertEquals(expected, activity.description)
+        browser.open_html(activity.description)
+        rows = browser.css('table').first.rows
+
+        self.assertEquals(
+            [['Task title', u'Abkl\xe4rung Fall Meier'],
+             ['Deadline', 'Feb 13, 2015'],
+             ['Task Type', 'To comment'],
+             ['Dossier title', 'Dossier XY'],
+             ['Text', 'Lorem ipsum'],
+             ['Responsible', 'Boss Hugo (hugo.boss)'],
+             ['Issuer', 'Test User (test_user_1_)']],
+            [row.css('td').text for row in rows])
 
     @browsing
     def test_adding_task_adds_responsible_and_issuer_to_watchers(self, browser):


### PR DESCRIPTION
Refactoring the complete mail template, using the same default-template as the digest mail, will be handled in a separate PR.

![bildschirmfoto 2018-05-14 um 16 36 33](https://user-images.githubusercontent.com/485755/40017855-e0c529b6-57ba-11e8-8066-9eadb4e5ae7e.png)

Closes #4242 