### PR TITLE
Rename "Schlagworte" zu "Schlagwörter"

### DIFF
--- a/docs/intern/kurzreferenzen/feedbackforum-prozess.rst
+++ b/docs/intern/kurzreferenzen/feedbackforum-prozess.rst
@@ -1,7 +1,7 @@
 Prozess Feedbackforum
 =====================
 Der Prozess innerhalb des Feedbackforums wird primär durch die Kategorien und
-Schlagworte bestimmt. Sobald durch einen OneGov GEVER-Benutzer ein neues Thema
+Schlagwörter bestimmt. Sobald durch einen OneGov GEVER-Benutzer ein neues Thema
 im Feedbackforum erstellt wird, wird die Kategorisierung und Setzung eines
 Schlagwortes durch den Feedbackforum-Moderator (aktuell primär durch Livia)
 vorgenommen und dadurch der Prozess jeweils angestossen.
@@ -18,11 +18,11 @@ Es wurden folgende Kategorien für die Themen definiert:
 
 - ``Intern:`` Thema wurde von 4tw-Mitarbeitern erfasst und beinhaltet Verbesserungs-Vorschläge.
 
-Schlagworte
------------
-Die Schlagworte können in folgende zwei Gruppen unterteilt werden:
+Schlagwörter
+------------
+Die Schlagwörter können in folgende zwei Gruppen unterteilt werden:
 
-1. Es gibt Schlagworte, die definieren den Status des Themas. Pro Thema darf immer nur ein Schlagwort von dieser Liste aktiv sein. Es können aber parallel Schlagworte von der zweiten Liste unten angewählt werden:
+1. Es gibt Schlagwörter, die definieren den Status des Themas. Pro Thema darf immer nur ein Schlagwort von dieser Liste aktiv sein. Es können aber parallel Schlagwörter von der zweiten Liste unten angewählt werden:
 
 - ``diskussion:`` Ein neuer Beitrag wird meist zuerst in diesen Status gesetzt, da die Community darüber diskutieren soll.
 
@@ -32,7 +32,7 @@ Die Schlagworte können in folgende zwei Gruppen unterteilt werden:
 
 - ``realisiert:`` Sobald das Thema realisert wurde, wird dieses Schlagwort gesetzt. Sobald der Release herauskommt, bei welchem dieses Thema eingespielt wird, kann das Thema dann geschlossen werden.
 
-2. Es gibt Schlagworte, die behandeln ein spezifisches Thema. Von diesen können mehrere aktiviert werden und es sollte max. 1 Schlagwort von der ersten Liste oben ergänzt werden:
+2. Es gibt Schlagwörter, die behandeln ein spezifisches Thema. Von diesen können mehrere aktiviert werden und es sollte max. 1 Schlagwort von der ersten Liste oben ergänzt werden:
 
 - ``spv:`` Alle Beiträge die sich mit der SPV (Sitzungs- und Protokollverwaltung) auseinander setzen.
 

--- a/docs/public/dev-manual/api/schemas/ftw.mail.mail.inc
+++ b/docs/public/dev-manual/api/schemas/ftw.mail.mail.inc
@@ -66,11 +66,11 @@
 
    .. py:attribute:: keywords
 
-       :Feldname: :field-title:`Schlagworte`
+       :Feldname: :field-title:`Schlagwörter`
        :Datentyp: ``Tuple``
        
        
-       :Beschreibung: Schlagwörter zur Umschreibung eines Dokuments. Nicht zu verwechseln mit der Ordnungsposition. <br>ACHTUNG: Beachten Sie bei der Verwendung von Schlagworten die Datenschutzvorgaben (z.B. keine Eigennamen).
+       :Beschreibung: Schlagwörter zur Umschreibung eines Dokuments. Nicht zu verwechseln mit der Ordnungsposition. <br>ACHTUNG: Beachten Sie bei der Verwendung von Schlagwörter die Datenschutzvorgaben (z.B. keine Eigennamen).
        
 
 

--- a/docs/public/dev-manual/api/schemas/opengever.document.document.inc
+++ b/docs/public/dev-manual/api/schemas/opengever.document.document.inc
@@ -86,11 +86,11 @@
 
    .. py:attribute:: keywords
 
-       :Feldname: :field-title:`Schlagworte`
+       :Feldname: :field-title:`Schlagwörter`
        :Datentyp: ``Tuple``
        
        
-       :Beschreibung: Schlagwörter zur Umschreibung eines Dokuments. Nicht zu verwechseln mit der Ordnungsposition. <br>ACHTUNG: Beachten Sie bei der Verwendung von Schlagworten die Datenschutzvorgaben (z.B. keine Eigennamen).
+       :Beschreibung: Schlagwörter zur Umschreibung eines Dokuments. Nicht zu verwechseln mit der Ordnungsposition. <br>ACHTUNG: Beachten Sie bei der Verwendung von Schlagwörter die Datenschutzvorgaben (z.B. keine Eigennamen).
        
 
 

--- a/docs/public/dev-manual/api/schemas/opengever.dossier.businesscasedossier.inc
+++ b/docs/public/dev-manual/api/schemas/opengever.dossier.businesscasedossier.inc
@@ -26,11 +26,11 @@
 
    .. py:attribute:: keywords
 
-       :Feldname: :field-title:`Schlagworte`
+       :Feldname: :field-title:`Schlagwörter`
        :Datentyp: ``Tuple``
        
        
-       :Beschreibung: Schlagwörter zur Umschreibung eines Dossiers. Nicht zu verwechseln mit der Ordnungsposition. <br>ACHTUNG: Beachten Sie bei der Verwendung von Schlagworten die Datenschutzvorgaben (z.B. keine Eigennamen).
+       :Beschreibung: Schlagwörter zur Umschreibung eines Dossiers. Nicht zu verwechseln mit der Ordnungsposition. <br>ACHTUNG: Beachten Sie bei der Verwendung von Schlagwörter die Datenschutzvorgaben (z.B. keine Eigennamen).
        
 
 

--- a/docs/public/user-manual/dokumente/metadatenpflegen.rst
+++ b/docs/public/user-manual/dokumente/metadatenpflegen.rst
@@ -30,7 +30,7 @@ Reiter Allgemein
 
 2.  **Beschreibung:** Erläuterungen, Ergänzungen zum Dokumentinhalt
 
-3.  **Schlagworte:** Zusätzlich zu Titel und Beschreibung können
+3.  **Schlagwörter:** Zusätzlich zu Titel und Beschreibung können
     Schlüsselwörter vergeben werden.
 
 4.  **Fremdzeichen:** Aktenzeichen des Absenders

--- a/docs/public/user-manual/dossiers/dossiervorlagen.rst
+++ b/docs/public/user-manual/dossiers/dossiervorlagen.rst
@@ -28,15 +28,15 @@ In der sich öffnenden Maske können folgende Felder abgefüllt werden:
     benannt werden.
 -  *Titel:* Titel der Dossiervorlage
 -  *Beschreibung:* Beschreibung des Einsatzes der Dossiervorlage
--  *Schlagworte:* Zur Umschreibung des Dossiers können Schlagworte gesetzt
+-  *Schlagwörter:* Zur Umschreibung des Dossiers können Schlagwörter gesetzt
     werden. Dabei können folgende beiden Optionen angewählt werden:
--  *Checkbox "Schlagworte vorausfüllen":*
+-  *Checkbox "Schlagwörter vorausfüllen":*
     Durch Aktivieren dieser Option werden bei der Erstellung des Dossiers ab
-    Vorlage die angegebenen Schlagworte bereits vorausgefüllt.
+    Vorlage die angegebenen Schlagwörter bereits vorausgefüllt.
 -  *Checkbox "Schlagwortkatalog einschränken"":*
     Durch Aktivieren dieser Option stehen bei der Erstellung des Dossiers ab
-    Vorlage nur noch die in der Vorlage angegebenen Schlagworte zur Auswahl.
-    Der Benutzer kann dadurch auch keine neuen Schlagworte erfassen.
+    Vorlage nur noch die in der Vorlage angegebenen Schlagwörter zur Auswahl.
+    Der Benutzer kann dadurch auch keine neuen Schlagwörter erfassen.
 -  *Kommentar:* Zusätzliche Bemerkungen können im Kommentar-Feld gemacht werden.
 
 Zuletzt die Aktion mit "Speichern" abschliessen. Ab diesem Zeitpunkt kann die
@@ -66,8 +66,8 @@ Gewünschte Dossiervorlage anklicken.
 |img-dossiervorlagen-5|
 
 Danach öffnet sich die bekannte Dossiermaske mitsamt Hinweisen auf den Titel
-sowie den definierten Schlagworten. (Im Beispiel unten wurde definiert, dass
-die Schlagworte nicht vorausgefült werden, aber nur jene welche im
+sowie den definierten Schlagwörter. (Im Beispiel unten wurde definiert, dass
+die Schlagwörter nicht vorausgefült werden, aber nur jene welche im
 Vorlagendossier definiert wurden, ausgewählt werden können.)
 
 |img-dossiervorlagen-6|

--- a/docs/public/user-manual/dossiers/eroeffnen.rst
+++ b/docs/public/user-manual/dossiers/eroeffnen.rst
@@ -56,8 +56,8 @@ Reiter.
    jedoch nur der Titel angezeigt. Die zentralen, identifizierenden
    Geschäftsinformationen müssen daher im Titelfeld enthalten sein.
 
-3. **Schlagworte:** Zusätzlich zu Titel und Beschreibung kann das
-   Dossier mit Schlagworten versehen werden.
+3. **Schlagwörter:** Zusätzlich zu Titel und Beschreibung kann das
+   Dossier mit Schlagwörter versehen werden.
 
 4. **Beginn:** Das Beginndatum eines Geschäfts entspricht dem ersten
    Dokument eines Dossiers. Standardmässig wird in OneGov GEVER das

--- a/docs/schema-dumps/ftw.mail.mail.schema.json
+++ b/docs/schema-dumps/ftw.mail.mail.schema.json
@@ -62,8 +62,8 @@
         },
         "keywords": {
             "type": "array",
-            "title": "Schlagworte",
-            "description": "Schlagw\u00f6rter zur Umschreibung eines Dokuments. Nicht zu verwechseln mit der Ordnungsposition. <br>ACHTUNG: Beachten Sie bei der Verwendung von Schlagworten die Datenschutzvorgaben (z.B. keine Eigennamen).",
+            "title": "Schlagw\u00f6rter",
+            "description": "Schlagw\u00f6rter zur Umschreibung eines Dokuments. Nicht zu verwechseln mit der Ordnungsposition. <br>ACHTUNG: Beachten Sie bei der Verwendung von Schlagw\u00f6rter die Datenschutzvorgaben (z.B. keine Eigennamen).",
             "_zope_schema_type": "Tuple"
         },
         "foreign_reference": {

--- a/docs/schema-dumps/opengever.document.document.schema.json
+++ b/docs/schema-dumps/opengever.document.document.schema.json
@@ -75,8 +75,8 @@
         },
         "keywords": {
             "type": "array",
-            "title": "Schlagworte",
-            "description": "Schlagw\u00f6rter zur Umschreibung eines Dokuments. Nicht zu verwechseln mit der Ordnungsposition. <br>ACHTUNG: Beachten Sie bei der Verwendung von Schlagworten die Datenschutzvorgaben (z.B. keine Eigennamen).",
+            "title": "Schlagw\u00f6rter",
+            "description": "Schlagw\u00f6rter zur Umschreibung eines Dokuments. Nicht zu verwechseln mit der Ordnungsposition. <br>ACHTUNG: Beachten Sie bei der Verwendung von Schlagw\u00f6rter die Datenschutzvorgaben (z.B. keine Eigennamen).",
             "_zope_schema_type": "Tuple"
         },
         "foreign_reference": {

--- a/docs/schema-dumps/opengever.dossier.businesscasedossier.schema.json
+++ b/docs/schema-dumps/opengever.dossier.businesscasedossier.schema.json
@@ -18,8 +18,8 @@
         },
         "keywords": {
             "type": "array",
-            "title": "Schlagworte",
-            "description": "Schlagw\u00f6rter zur Umschreibung eines Dossiers. Nicht zu verwechseln mit der Ordnungsposition. <br>ACHTUNG: Beachten Sie bei der Verwendung von Schlagworten die Datenschutzvorgaben (z.B. keine Eigennamen).",
+            "title": "Schlagw\u00f6rter",
+            "description": "Schlagw\u00f6rter zur Umschreibung eines Dossiers. Nicht zu verwechseln mit der Ordnungsposition. <br>ACHTUNG: Beachten Sie bei der Verwendung von Schlagw\u00f6rter die Datenschutzvorgaben (z.B. keine Eigennamen).",
             "_zope_schema_type": "Tuple"
         },
         "start": {

--- a/opengever/bundle/schemas/documents.schema.json
+++ b/opengever/bundle/schemas/documents.schema.json
@@ -99,8 +99,8 @@
                         "null",
                         "array"
                     ],
-                    "title": "Schlagworte",
-                    "description": "Schlagw\u00f6rter zur Umschreibung eines Dokuments. Nicht zu verwechseln mit der Ordnungsposition. <br>ACHTUNG: Beachten Sie bei der Verwendung von Schlagworten die Datenschutzvorgaben (z.B. keine Eigennamen).",
+                    "title": "Schlagw\u00f6rter",
+                    "description": "Schlagw\u00f6rter zur Umschreibung eines Dokuments. Nicht zu verwechseln mit der Ordnungsposition. <br>ACHTUNG: Beachten Sie bei der Verwendung von Schlagw\u00f6rter die Datenschutzvorgaben (z.B. keine Eigennamen).",
                     "_zope_schema_type": "Tuple"
                 },
                 "foreign_reference": {

--- a/opengever/bundle/schemas/dossiers.schema.json
+++ b/opengever/bundle/schemas/dossiers.schema.json
@@ -30,8 +30,8 @@
                         "null",
                         "array"
                     ],
-                    "title": "Schlagworte",
-                    "description": "Schlagw\u00f6rter zur Umschreibung eines Dossiers. Nicht zu verwechseln mit der Ordnungsposition. <br>ACHTUNG: Beachten Sie bei der Verwendung von Schlagworten die Datenschutzvorgaben (z.B. keine Eigennamen).",
+                    "title": "Schlagw\u00f6rter",
+                    "description": "Schlagw\u00f6rter zur Umschreibung eines Dossiers. Nicht zu verwechseln mit der Ordnungsposition. <br>ACHTUNG: Beachten Sie bei der Verwendung von Schlagw\u00f6rter die Datenschutzvorgaben (z.B. keine Eigennamen).",
                     "_zope_schema_type": "Tuple"
                 },
                 "start": {

--- a/opengever/document/locales/de/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/de/LC_MESSAGES/opengever.document.po
@@ -271,7 +271,7 @@ msgstr "Referenz auf das entsprechende Dossier des Absenders"
 
 #: ./opengever/document/behaviors/metadata.py
 msgid "help_keywords"
-msgstr "Schlagwörter zur Umschreibung eines Dokuments. Nicht zu verwechseln mit der Ordnungsposition. <br>ACHTUNG: Beachten Sie bei der Verwendung von Schlagworten die Datenschutzvorgaben (z.B. keine Eigennamen)."
+msgstr "Schlagwörter zur Umschreibung eines Dokuments. Nicht zu verwechseln mit der Ordnungsposition. <br>ACHTUNG: Beachten Sie bei der Verwendung von Schlagwörter die Datenschutzvorgaben (z.B. keine Eigennamen)."
 
 #. Default: ""
 #: ./opengever/document/behaviors/metadata.py
@@ -447,7 +447,7 @@ msgstr "Fremdzeichen"
 #. Default: "Keywords"
 #: ./opengever/document/behaviors/metadata.py
 msgid "label_keywords"
-msgstr "Schlagworte"
+msgstr "Schlagwörter"
 
 #. Default: "Meeting"
 #: ./opengever/document/browser/overview.py

--- a/opengever/dossier/locales/de/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/de/LC_MESSAGES/opengever.dossier.po
@@ -278,7 +278,7 @@ msgstr "Wählen Sie hier einen Benutzer oder eine Gruppe, welche nach dem Schüt
 #. Default: "The defined keywords will be preselected for new dossies from template."
 #: ./opengever/dossier/dossiertemplate/behaviors.py
 msgid "description_predefined_keywords"
-msgstr "Durch Aktivieren dieser Option werden bei der Erstellung des Dossiers ab Vorlage die angegebenen Schlagworte bereits vorausgefüllt."
+msgstr "Durch Aktivieren dieser Option werden bei der Erstellung des Dossiers ab Vorlage die angegebenen Schlagwörter bereits vorausgefüllt."
 
 #. Default: "Choose users and groups which have only readable access to the dossier"
 #: ./opengever/dossier/behaviors/protect_dossier.py
@@ -293,7 +293,7 @@ msgstr "Wählen Sie Benutzer und Gruppen aus, welche im Dossier lesend und schre
 #. Default: "The user can choose only from the defined keywords in a new dossier from template. It also prevents the user for creating new keywords"
 #: ./opengever/dossier/dossiertemplate/behaviors.py
 msgid "description_restrict_keywords"
-msgstr "Durch Aktivieren dieser Option stehen bei der Erstellung des Dossiers ab Vorlage nur noch die in der Vorlage angegebenen Schlagworte zur Auswahl.<br>Der Benutzer kann dadurch auch keine neuen Schlagworte erfassen."
+msgstr "Durch Aktivieren dieser Option stehen bei der Erstellung des Dossiers ab Vorlage nur noch die in der Vorlage angegebenen Schlagwörter zur Auswahl.<br>Der Benutzer kann dadurch auch keine neuen Schlagwörter erfassen."
 
 msgid "documents"
 msgstr "Dokumente"
@@ -415,7 +415,7 @@ msgstr "Geben Sie die vollständige Ablagenummer an."
 
 #: ./opengever/dossier/behaviors/dossier.py
 msgid "help_keywords"
-msgstr "Schlagwörter zur Umschreibung eines Dossiers. Nicht zu verwechseln mit der Ordnungsposition. <br>ACHTUNG: Beachten Sie bei der Verwendung von Schlagworten die Datenschutzvorgaben (z.B. keine Eigennamen)."
+msgstr "Schlagwörter zur Umschreibung eines Dossiers. Nicht zu verwechseln mit der Ordnungsposition. <br>ACHTUNG: Beachten Sie bei der Verwendung von Schlagwörter die Datenschutzvorgaben (z.B. keine Eigennamen)."
 
 #: ./opengever/dossier/behaviors/dossier.py
 msgid "help_number_of_containers"
@@ -608,7 +608,7 @@ msgstr "Journal"
 #: ./opengever/dossier/behaviors/dossier.py
 #: ./opengever/dossier/browser/overview.py
 msgid "label_keywords"
-msgstr "Schlagworte"
+msgstr "Schlagwörter"
 
 #. Default: "Label"
 #: ./opengever/dossier/templatefolder/form.py
@@ -669,7 +669,7 @@ msgstr "Telefonnummer"
 #. Default: "Predefined Keywords"
 #: ./opengever/dossier/dossiertemplate/behaviors.py
 msgid "label_predefined_keywords"
-msgstr "Schlagworte vorausfüllen"
+msgstr "Schlagwörter vorausfüllen"
 
 #. Default: "Proposal Templates"
 #: ./opengever/dossier/browser/tabbed.py


### PR DESCRIPTION
Here's the search for the "worte" string:
<img width="957" alt="screen shot 2018-05-16 at 08 50 26" src="https://user-images.githubusercontent.com/194114/40100990-4624e0d6-58e6-11e8-9193-426141e1788a.png">

Here's the search for the "worte" string in the docs:
<img width="957" alt="screen shot 2018-05-16 at 10 47 01" src="https://user-images.githubusercontent.com/194114/40106619-8af66b02-58f6-11e8-988e-662115a4b5d4.png">

As you can see, there's no further occurrence of "Schlagworte".

Resolves #3830 