### PR TITLE
No longer require paragraph template.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2018.3.0 (unreleased)
 ---------------------
 
+- No longer require a paragraph template for committee containers. [deiferni]
 - Add responsible and issuer to notification mail for TaskAdded activities. [phgross]
 - Fetch archivist group members from ogds. [phgross]
 - Fix content displayed in the templatefolder's gallery view. [phgross]

--- a/opengever/meeting/committeecontainer.py
+++ b/opengever/meeting/committeecontainer.py
@@ -93,7 +93,7 @@ class ICommitteeContainer(model.Schema):
         title=_('label_paragraph_template',
                 default=u'Paragraph template'),
         source=sablon_template_source,
-        required=True,
+        required=False,
     )
 
 

--- a/opengever/meeting/exceptions.py
+++ b/opengever/meeting/exceptions.py
@@ -39,11 +39,6 @@ class MissingProtocolHeaderTemplate(Exception):
     """
 
 
-class MissingParagraphTemplate(Exception):
-    """No paragraph template could be found for the committee or its container.
-    """
-
-
 class WrongAgendaItemState(Exception):
     """The agenda item is not in the correct state to perform the desired
     action.


### PR DESCRIPTION
This PR no longer requires the paragraph template for committees and their containers. It also removes the Exception that was raised in such a case.

It may not be required by customers, which is a valid state but uncommon. The system should not forbid it though as there is no reason to do so.