### PR TITLE
Customize insufficient privileges error page.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -8,6 +8,7 @@ Changelog
 - Distinguish icons for docs checked out by current user vs. someone else. [lgraf]
 - Allow Editors and Administrators to delete tasktemplates. [phgross]
 - Fix NotificationMailer for TaskReassigned activities. [phgross]
+- Customize insufficient privileges error page. [phgross]
 - No longer require a paragraph template for committee containers. [deiferni]
 - Fix autocomplete for relation list widgets when solr is enabled. [deiferni]
 - Add responsible and issuer to notification mail for TaskAdded activities. [phgross]

--- a/opengever/base/locales/de/LC_MESSAGES/opengever.base.po
+++ b/opengever/base/locales/de/LC_MESSAGES/opengever.base.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-04-19 14:14+0000\n"
+"POT-Creation-Date: 2018-05-17 08:15+0000\n"
 "PO-Revision-Date: 2014-09-04 01:03+0200\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: Jonas Baumann <j.baumann@4teamwork.ch>\n"
@@ -98,6 +98,11 @@ msgstr "Bestätigen Sie bitte, dass Sie diese Aktion durchführen möchten."
 msgid "description_include_error_in_admin_message"
 msgstr "Wenn Sie diesen Fehler dem Fachapplikationsverantwortlichen melden wollen, fügen Sie bitte die Fehlernummer hinzu."
 
+#. Default: "You do not have sufficient privileges to view this page. If you believe you are receiving this message by mistake, please contact the responsible person."
+#: ./opengever/base/skins/opengever.base_scripts/insufficient_privileges.pt
+msgid "description_no_privileges_for_page"
+msgstr "Sie haben unzureichende Berechtigungen um diese Seite anzuzeigen. Wenn Sie meinen diese Meldung fehlerhafterweise angezeigt zu bekommen, kontaktieren Sie bitte die fachapplikationsverantwortliche Person."
+
 #. Default: "We apologize for the inconvenience, but the page you were trying to access is not at this address."
 #: ./opengever/base/browser/templates/error.pt
 msgid "description_site_error"
@@ -106,7 +111,7 @@ msgstr "Entschuldigung, aber die Webseite die Sie versucht haben zu erreichen is
 #. Default: "Please contact the responsible person if this problem persists."
 #: ./opengever/base/browser/templates/error.pt
 msgid "description_site_error_site_admin"
-msgstr "Bitte kontaktieren Sie den Fachapplikationsverantwortlichen, wenn dieses Problem längerfristig besteht."
+msgstr "Bitte kontaktieren Sie die fachapplikationsverantwortliche Person, wenn dieses Problem längerfristig besteht."
 
 #. Default: "You have not selected any Items."
 #: ./opengever/base/browser/copy_items.py

--- a/opengever/base/locales/fr/LC_MESSAGES/opengever.base.po
+++ b/opengever/base/locales/fr/LC_MESSAGES/opengever.base.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-04-19 14:14+0000\n"
+"POT-Creation-Date: 2018-05-17 08:15+0000\n"
 "PO-Revision-Date: 2017-11-29 10:53+0000\n"
 "Last-Translator: Philippe Gross <gross.philippe@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-base/fr/>\n"
@@ -98,6 +98,11 @@ msgstr "Veuillez confirmer que vous souhaitez effectuer cette action."
 #: ./opengever/base/browser/templates/error.pt
 msgid "description_include_error_in_admin_message"
 msgstr "Si vous voulez signaler cette erreur au responsable de l'application, veuillez ajouter le numéro d'erreur,  s'il vous plaît."
+
+#. Default: "You do not have sufficient privileges to view this page. If you believe you are receiving this message by mistake, please contact the responsible person."
+#: ./opengever/base/skins/opengever.base_scripts/insufficient_privileges.pt
+msgid "description_no_privileges_for_page"
+msgstr ""
 
 #. Default: "We apologize for the inconvenience, but the page you were trying to access is not at this address."
 #: ./opengever/base/browser/templates/error.pt

--- a/opengever/base/locales/opengever.base.pot
+++ b/opengever/base/locales/opengever.base.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-04-19 14:14+0000\n"
+"POT-Creation-Date: 2018-05-17 08:15+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -95,6 +95,11 @@ msgstr ""
 #. Default: "If you need to report this to the responsible person, please include this entry number in your message."
 #: ./opengever/base/browser/templates/error.pt
 msgid "description_include_error_in_admin_message"
+msgstr ""
+
+#. Default: "You do not have sufficient privileges to view this page. If you believe you are receiving this message by mistake, please contact the responsible person."
+#: ./opengever/base/skins/opengever.base_scripts/insufficient_privileges.pt
+msgid "description_no_privileges_for_page"
 msgstr ""
 
 #. Default: "We apologize for the inconvenience, but the page you were trying to access is not at this address."

--- a/opengever/base/skins/opengever.base_scripts/insufficient_privileges.pt
+++ b/opengever/base/skins/opengever.base_scripts/insufficient_privileges.pt
@@ -1,0 +1,23 @@
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en"
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      xmlns:metal="http://xml.zope.org/namespaces/metal"
+      xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+      lang="en"
+      metal:use-macro="context/main_template/macros/master"
+      i18n:domain="plone">
+
+<body>
+
+<metal:main fill-slot="main">
+
+      <h1 class="documentFirstHeading"
+          i18n:translate="heading_no_privileges">Insufficient Privileges</h1>
+
+      <div class="documentDescription" i18n:domain="opengever.base" i18n:translate="description_no_privileges_for_page">
+        You do not have sufficient privileges to view this page. If you believe
+        you are receiving this message by mistake, please contact the responsible person.
+      </div>
+</metal:main>
+
+</body>
+</html>


### PR DESCRIPTION
Closes #4305 

![bildschirmfoto 2018-05-17 um 10 18 43](https://user-images.githubusercontent.com/485755/40165238-bf4c1f08-59bb-11e8-97f9-19da90a02439.png)

Use neutral of `Fachapplikationsverantwortlichen` on all error pages.