### PR TITLE
Fix NotificationMailer for TaskReassigned activities.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ---------------------
 
 - Allow Editors and Administrators to delete tasktemplates. [phgross]
+- Fix NotificationMailer for TaskReassigned activities. [phgross]
 - No longer require a paragraph template for committee containers. [deiferni]
 - Fix autocomplete for relation list widgets when solr is enabled. [deiferni]
 - Add responsible and issuer to notification mail for TaskAdded activities. [phgross]

--- a/opengever/activity/mailer.py
+++ b/opengever/activity/mailer.py
@@ -42,8 +42,8 @@ class Mailer(object):
         msg['Subject'] = Header(subject, 'utf-8')
 
         # Break (potential) description out into a list element per newline
-        if 'description' in data:
-            data['description'] = [line for line in data.get('description').splitlines()]
+        if data.get('description'):
+            data['description'] = data.get('description').splitlines()
 
         html = self.prepare_html(data)
         msg.attach(MIMEText(html.encode('utf-8'), 'html', 'utf-8'))

--- a/opengever/activity/tests/test_mail.py
+++ b/opengever/activity/tests/test_mail.py
@@ -72,6 +72,25 @@ class TestEmailNotification(IntegrationTestCase):
         self.assertIn('<p>comment</p>', raw_mail)
 
     @browsing
+    def test_notification_mailer_handle_empty_activity_description(self, browser):
+        self.login(self.dossier_responsible, browser)
+        self.create_task_via_browser(browser)
+
+        # reassign task
+        task = self.dossier.objectValues()[-1]
+        data = {'form.widgets.transition': 'task-transition-reassign'}
+        browser.open(task, data, view='assign-task')
+        responsible = 'fa:{}'.format(self.secretariat_user.getId())
+        form = browser.find_form_by_field('Responsible')
+        form.find_widget('Responsible').fill(responsible)
+        browser.click_on('Assign')
+
+        mails = Mailing(self.portal).get_messages()
+        self.assertEqual(len(mails), 2)
+        raw_mail = mails[-1]
+        self.assertIn('Reassigned from', raw_mail)
+
+    @browsing
     def test_from_and_to_addresses(self, browser):
         self.login(self.dossier_responsible, browser)
         self.create_task_via_browser(browser)


### PR DESCRIPTION
The with #4152 introduced "splitlines" could not handle empty activity descriptions.

Closes #4307