### PR TITLE
Distinguish icons for docs checked out by current user vs. someone else.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2018.3.0 (unreleased)
 ---------------------
 
+- Distinguish icons for docs checked out by current user vs. someone else. [lgraf]
 - Allow Editors and Administrators to delete tasktemplates. [phgross]
 - No longer require a paragraph template for committee containers. [deiferni]
 - Fix autocomplete for relation list widgets when solr is enabled. [deiferni]

--- a/opengever/base/tests/test_helper.py
+++ b/opengever/base/tests/test_helper.py
@@ -59,7 +59,8 @@ class TestCssClassHelpers(IntegrationTestCase):
         self.assertEquals('icon-docx', get_css_class(self.document))
 
         self.checkout_document(self.document)
-        self.assertEquals('icon-docx is-checked-out', get_css_class(self.document))
+        self.assertEquals('icon-docx is-checked-out-by-current-user',
+                          get_css_class(self.document))
 
     def test_document_brain_checked_out_suffix(self):
         self.login(self.dossier_responsible)
@@ -67,7 +68,7 @@ class TestCssClassHelpers(IntegrationTestCase):
         self.assertEquals('icon-docx', get_css_class(obj2brain(self.document)))
 
         self.checkout_document(self.document)
-        self.assertEquals('icon-docx is-checked-out',
+        self.assertEquals('icon-docx is-checked-out-by-current-user',
                           get_css_class(obj2brain(self.document)))
 
     def test_proposaltemplate_checked_out_suffix(self):
@@ -76,5 +77,29 @@ class TestCssClassHelpers(IntegrationTestCase):
         self.assertEquals('icon-docx', get_css_class(self.proposal_template))
 
         self.checkout_document(self.proposal_template)
+        self.assertEquals('icon-docx is-checked-out-by-current-user',
+                          get_css_class(obj2brain(self.proposal_template)))
+
+    def test_document_obj_checked_out_by_other_suffix(self):
+        self.login(self.dossier_responsible)
+        self.checkout_document(self.document)
+
+        self.login(self.regular_user)
+        self.assertEquals('icon-docx is-checked-out',
+                          get_css_class(self.document))
+
+    def test_document_brain_checked_out_by_other_suffix(self):
+        self.login(self.dossier_responsible)
+        self.checkout_document(self.document)
+
+        self.login(self.regular_user)
+        self.assertEquals('icon-docx is-checked-out',
+                          get_css_class(obj2brain(self.document)))
+
+    def test_proposaltemplate_checked_out_by_other_suffix(self):
+        self.login(self.dossier_responsible)
+        self.checkout_document(self.proposal_template)
+
+        self.login(self.regular_user)
         self.assertEquals('icon-docx is-checked-out',
                           get_css_class(obj2brain(self.proposal_template)))


### PR DESCRIPTION
This introduces a new CSS class to mark documents that are checked out by the **current user**:

| State | Example CSS Classes |
| --- | --- |
| Not checked out | `icon-docx` |
| Checked out by current user | `icon-docx is-checked-out-by-current-user` |
| Checked out by someone else | `icon-docx is-checked-out` |


This depends on 4teamwork/plonetheme.teamraum#635 for styling.