### PR TITLE
Fix too long physical_path value issue.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2018.3.0 (unreleased)
 ---------------------
 
+- Fix an issue where the physical_path value could be too long. [deiferni]
 - Distinguish icons for docs checked out by current user vs. someone else. [lgraf]
 - Allow Editors and Administrators to delete tasktemplates. [phgross]
 - Fix NotificationMailer for TaskReassigned activities. [phgross]

--- a/opengever/core/upgrades/20180517160709_change_physical_path_column_type/upgrade.py
+++ b/opengever/core/upgrades/20180517160709_change_physical_path_column_type/upgrade.py
@@ -1,0 +1,37 @@
+from opengever.core.upgrade import SchemaMigration
+from sqlalchemy import Text
+from sqlalchemy import String
+
+
+class ChangePhysicalPathColumnType(SchemaMigration):
+    """Change physical path column type.
+    """
+
+    def migrate(self):
+        self.op.alter_column(
+            'tasks',
+            'physical_path',
+            type_=Text,
+            existing_nullable=True,
+            existing_type=String(256))
+
+        self.op.alter_column(
+            'proposals',
+            'physical_path',
+            type_=Text,
+            existing_nullable=False,
+            existing_type=String(256))
+
+        self.op.alter_column(
+            'proposals',
+            'submitted_physical_path',
+            type_=Text,
+            existing_nullable=True,
+            existing_type=String(256))
+
+        self.op.alter_column(
+            'committees',
+            'physical_path',
+            type_=Text,
+            existing_nullable=False,
+            existing_type=String(256))

--- a/opengever/globalindex/model/task.py
+++ b/opengever/globalindex/model/task.py
@@ -75,7 +75,7 @@ class Task(Base):
     title = Column(String(MAX_TITLE_LENGTH))
     text = Column(UnicodeCoercingText())
     breadcrumb_title = Column(String(MAX_BREADCRUMB_LENGTH))
-    physical_path = Column(String(256))
+    physical_path = Column(UnicodeCoercingText)
     review_state = Column(String(WORKFLOW_STATE_LENGTH))
     icon = Column(String(50))
 

--- a/opengever/meeting/model/committee.py
+++ b/opengever/meeting/model/committee.py
@@ -14,6 +14,7 @@ from opengever.meeting.workflow import Workflow
 from opengever.ogds.base.utils import ogds_service
 from opengever.ogds.models import GROUP_ID_LENGTH
 from opengever.ogds.models import UNIT_ID_LENGTH
+from opengever.ogds.models.types import UnicodeCoercingText
 from sqlalchemy import and_
 from sqlalchemy import Column
 from sqlalchemy import Integer
@@ -55,7 +56,7 @@ class Committee(Base):
     int_id = Column(Integer, nullable=False)
     oguid = composite(Oguid, admin_unit_id, int_id)
     title = Column(String(256), index=True)
-    physical_path = Column(String(256), nullable=False)
+    physical_path = Column(UnicodeCoercingText, nullable=False)
     workflow_state = Column(String(WORKFLOW_STATE_LENGTH),
                             nullable=False,
                             default=workflow.default_state.name)

--- a/opengever/meeting/model/proposal.py
+++ b/opengever/meeting/model/proposal.py
@@ -99,7 +99,7 @@ class Proposal(Base):
     admin_unit_id = Column(String(UNIT_ID_LENGTH), nullable=False)
     int_id = Column(Integer, nullable=False)
     oguid = composite(Oguid, admin_unit_id, int_id)
-    physical_path = Column(String(256), nullable=False)
+    physical_path = Column(UnicodeCoercingText, nullable=False)
     creator = Column(String(USER_ID_LENGTH), nullable=False)
 
     title = Column(String(MAX_TITLE_LENGTH), index=True)
@@ -111,7 +111,7 @@ class Proposal(Base):
     submitted_int_id = Column(Integer)
     submitted_oguid = composite(
         Oguid, submitted_admin_unit_id, submitted_int_id)
-    submitted_physical_path = Column(String(256))
+    submitted_physical_path = Column(UnicodeCoercingText)
 
     excerpt_document_id = Column(Integer, ForeignKey('generateddocuments.id'))
     excerpt_document = relationship(


### PR DESCRIPTION
This PR fixes issue where the physical_path value could be too long. I'm fixing it for all the `physical_paths` we store in the relational database.

After a brief discussion with @Rotonen and @lukasgraf we decided against adding an index for now.

_The `existing_...` params would not be necessary for postgres but i find they are helping in documenting what we're doing._

Fixes #4235.

Needs backport to: `2018.1-stable` and `2018.2-stable`