### PR TITLE
OGIP 26: Reset responsible to issuer on task rejection

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2018.4.0 (unreleased)
 ---------------------
 
+- Reset task responsible to the task issuer upon task rejection. [Rotonen]
 - Rename cancelled task in German from "storniert" to "abgebrochen" .
 - Make tasktemplates sortable. [njohner]
 - Bump ftw.datepicker to get JS fix for language format selection. [lgraf]

--- a/opengever/inbox/tests/test_transition_actions.py
+++ b/opengever/inbox/tests/test_transition_actions.py
@@ -1,10 +1,10 @@
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
-from opengever.task.tests.test_transition_actions import BaseTransitionActionTest
+from opengever.task.tests.test_transition_actions import BaseTransitionActionFunctionalTest
 
 
-class TestAcceptAction(BaseTransitionActionTest):
+class TestAcceptAction(BaseTransitionActionFunctionalTest):
     transition = 'forwarding-transition-accept'
 
     def setUp(self):
@@ -21,14 +21,11 @@ class TestAcceptAction(BaseTransitionActionTest):
     def test_is_accept_wizzard(self, browser):
         forwarding = create(Builder('forwarding')
                       .having(responsible_client='additional'))
-
-        self.do_transition(forwarding)
-
-        self.assert_action(
-            'http://nohost/plone/forwarding-1/@@accept_choose_method')
+        self.do_transition(browser, forwarding)
+        self.assert_action(browser, 'http://nohost/plone/forwarding-1/@@accept_choose_method')
 
 
-class TestRefuseAction(BaseTransitionActionTest):
+class TestRefuseAction(BaseTransitionActionFunctionalTest):
     transition = 'forwarding-transition-refuse'
 
     def setUp(self):
@@ -45,42 +42,37 @@ class TestRefuseAction(BaseTransitionActionTest):
     def test_is_refuse_form(self, browser):
         forwarding = create(Builder('forwarding')
                       .having(responsible_client='additional'))
-
-        self.do_transition(forwarding)
-
+        self.do_transition(browser, forwarding)
         self.assert_action(
-            'http://nohost/plone/forwarding-1/@@refuse-task?'
-            'form.widgets.transition=forwarding-transition-refuse')
+            browser,
+            'http://nohost/plone/forwarding-1/@@refuse-task?form.widgets.transition=forwarding-transition-refuse',
+            )
 
 
-class TestAssignToDossierAction(BaseTransitionActionTest):
+class TestAssignToDossierAction(BaseTransitionActionFunctionalTest):
     transition = 'forwarding-transition-assign-to-dossier'
 
     @browsing
     def test_is_assign_wizzard(self, browser):
         forwarding = create(Builder('forwarding'))
-
-        self.do_transition(forwarding)
-
-        self.assert_action(
-            'http://nohost/plone/forwarding-1/@@assign_choose_method')
+        self.do_transition(browser, forwarding)
+        self.assert_action(browser, 'http://nohost/plone/forwarding-1/@@assign_choose_method')
 
 
-class TestReassignToDossierAction(BaseTransitionActionTest):
+class TestReassignToDossierAction(BaseTransitionActionFunctionalTest):
     transition = 'forwarding-transition-reassign'
 
     @browsing
     def test_is_assign_task_form(self, browser):
         forwarding = create(Builder('forwarding'))
-
-        self.do_transition(forwarding)
-
+        self.do_transition(browser, forwarding)
         self.assert_action(
-            'http://nohost/plone/forwarding-1/@@assign-task?'
-            'form.widgets.transition=forwarding-transition-reassign')
+            browser,
+            'http://nohost/plone/forwarding-1/@@assign-task?form.widgets.transition=forwarding-transition-reassign',
+            )
 
 
-class TestReassignRefuseAction(BaseTransitionActionTest):
+class TestReassignRefuseAction(BaseTransitionActionFunctionalTest):
 
     transition = 'forwarding-transition-reassign-refused'
 
@@ -88,23 +80,20 @@ class TestReassignRefuseAction(BaseTransitionActionTest):
     def test_is_assign_fowarding_form(self, browser):
         forwarding = create(Builder('forwarding')
                             .in_state('forwarding-state-refused'))
-
-        self.do_transition(forwarding)
-
+        self.do_transition(browser, forwarding)
         self.assert_action(
-            'http://nohost/plone/forwarding-1/@@assign-forwarding?'
-            'form.widgets.transition=forwarding-transition-reassign-refused')
+            browser,
+            'http://nohost/plone/forwarding-1/@@assign-forwarding'
+            '?form.widgets.transition=forwarding-transition-reassign-refused',
+            )
 
 
-class TestCloseAction(BaseTransitionActionTest):
+class TestCloseAction(BaseTransitionActionFunctionalTest):
 
     transition = 'forwarding-transition-close'
 
     @browsing
     def test_is_assign_fowarding_form(self, browser):
         forwarding = create(Builder('forwarding'))
-
-        self.do_transition(forwarding)
-
-        self.assert_action(
-            'http://nohost/plone/forwarding-1/@@close-forwarding')
+        self.do_transition(browser, forwarding)
+        self.assert_action(browser, 'http://nohost/plone/forwarding-1/@@close-forwarding')

--- a/opengever/task/configure.zcml
+++ b/opengever/task/configure.zcml
@@ -124,6 +124,12 @@
       handler=".handlers.cancel_subtasks"
       />
 
+  <subscriber
+      for="opengever.task.task.ITask
+           Products.CMFCore.interfaces.IActionSucceededEvent"
+      handler=".handlers.set_responsible_to_issuer_on_reject"
+      />
+
   <adapter
       factory=".indexers.date_of_completion"
       name="date_of_completion"

--- a/opengever/task/handlers.py
+++ b/opengever/task/handlers.py
@@ -1,5 +1,7 @@
 from Acquisition import aq_inner, aq_parent
 from datetime import date
+from opengever.activity import notification_center
+from opengever.activity.roles import TASK_RESPONSIBLE_ROLE
 from opengever.document.behaviors import IBaseDocument
 from opengever.globalindex.handlers.task import TaskSqlSyncer
 from opengever.task import _
@@ -69,6 +71,12 @@ def reassign_team_tasks(task, event):
             'responsible',
             _(u"label_responsible", default=u"Responsible"),
             old_responsible, ITask(task).responsible)
+
+
+def set_responsible_to_issuer_on_reject(task, event):
+    if event.action == 'task-transition-open-rejected':
+        notification_center().remove_watcher_from_resource(task.oguid, task.responsible, TASK_RESPONSIBLE_ROLE)
+        task.responsible = task.issuer
 
 
 def cancel_subtasks(task, event):

--- a/opengever/task/tests/test_transition_actions.py
+++ b/opengever/task/tests/test_transition_actions.py
@@ -8,7 +8,7 @@ import re
 URL_WIHOUT_TOKEN_RE = re.compile(r'(.*)([\?, &]_authenticator=.*)')
 
 
-class BaseTransitionActionTest(FunctionalTestCase):
+class BaseTransitionActionFunctionalTest(FunctionalTestCase):
 
     def assert_action(self, browser, expected):
         url = URL_WIHOUT_TOKEN_RE.match(browser.url).groups()[0]
@@ -19,7 +19,7 @@ class BaseTransitionActionTest(FunctionalTestCase):
         browser.css('#workflow-transition-{}'.format(self.transition)).first.click()
 
 
-class TestDelegateAction(BaseTransitionActionTest):
+class TestDelegateAction(BaseTransitionActionFunctionalTest):
     transition = 'task-transition-delegate'
 
     @browsing
@@ -30,7 +30,7 @@ class TestDelegateAction(BaseTransitionActionTest):
         self.assertEquals('Delegate task', browser.css('.documentFirstHeading').first.text)
 
 
-class TestModifyDeadlineAction(BaseTransitionActionTest):
+class TestModifyDeadlineAction(BaseTransitionActionFunctionalTest):
     transition = 'task-transition-modify-deadline'
 
     @browsing
@@ -44,7 +44,7 @@ class TestModifyDeadlineAction(BaseTransitionActionTest):
             )
 
 
-class TestReOpenAction(BaseTransitionActionTest):
+class TestReOpenAction(BaseTransitionActionFunctionalTest):
     transition = 'task-transition-cancelled-open'
 
     @browsing
@@ -57,7 +57,7 @@ class TestReOpenAction(BaseTransitionActionTest):
             )
 
 
-class TestReassignAction(BaseTransitionActionTest):
+class TestReassignAction(BaseTransitionActionFunctionalTest):
     transition = 'task-transition-reassign'
 
     @browsing
@@ -70,7 +70,7 @@ class TestReassignAction(BaseTransitionActionTest):
             )
 
 
-class TestCancelAction(BaseTransitionActionTest):
+class TestCancelAction(BaseTransitionActionFunctionalTest):
     transition = 'task-transition-open-cancelled'
 
     @browsing
@@ -83,7 +83,7 @@ class TestCancelAction(BaseTransitionActionTest):
             )
 
 
-class TestRejectAction(BaseTransitionActionTest):
+class TestRejectAction(BaseTransitionActionFunctionalTest):
 
     transition = 'task-transition-open-rejected'
 
@@ -97,7 +97,7 @@ class TestRejectAction(BaseTransitionActionTest):
             )
 
 
-class TestInProgressResolveAction(BaseTransitionActionTest):
+class TestInProgressResolveAction(BaseTransitionActionFunctionalTest):
     transition = 'task-transition-in-progress-resolved'
 
     @browsing
@@ -149,7 +149,7 @@ class TestInProgressResolveAction(BaseTransitionActionTest):
             )
 
 
-class TestOpenResolveAction(BaseTransitionActionTest):
+class TestOpenResolveAction(BaseTransitionActionFunctionalTest):
 
     transition = 'task-transition-open-resolved'
 
@@ -163,7 +163,7 @@ class TestOpenResolveAction(BaseTransitionActionTest):
             )
 
 
-class TestInProgressTestedAndClosedAction(BaseTransitionActionTest):
+class TestInProgressTestedAndClosedAction(BaseTransitionActionFunctionalTest):
 
     transition = 'task-transition-in-progress-tested-and-closed'
     task_type = 'direct-execution'
@@ -209,7 +209,7 @@ class TestInProgressTestedAndClosedAction(BaseTransitionActionTest):
             )
 
 
-class TestAccept(BaseTransitionActionTest):
+class TestAccept(BaseTransitionActionFunctionalTest):
 
     transition = 'task-transition-open-in-progress'
 
@@ -244,7 +244,7 @@ class TestAccept(BaseTransitionActionTest):
             )
 
 
-class TestOpenToClose(BaseTransitionActionTest):
+class TestOpenToClose(BaseTransitionActionFunctionalTest):
 
     transition = 'task-transition-open-tested-and-closed'
 
@@ -302,7 +302,7 @@ class TestOpenToClose(BaseTransitionActionTest):
             )
 
 
-class TestReworkAction(BaseTransitionActionTest):
+class TestReworkAction(BaseTransitionActionFunctionalTest):
 
     transition = 'task-transition-resolved-in-progress'
 

--- a/opengever/task/tests/test_transition_actions.py
+++ b/opengever/task/tests/test_transition_actions.py
@@ -8,11 +8,14 @@ import re
 URL_WIHOUT_TOKEN_RE = re.compile(r'(.*)([\?, &]_authenticator=.*)')
 
 
-class BaseTransitionActionFunctionalTest(FunctionalTestCase):
+class BaseTransitionActionTestMixin(object):
 
     def assert_action(self, browser, expected):
         url = URL_WIHOUT_TOKEN_RE.match(browser.url).groups()[0]
         self.assertEquals(expected, url)
+
+
+class BaseTransitionActionFunctionalTest(FunctionalTestCase, BaseTransitionActionTestMixin):
 
     def do_transition(self, browser, task):
         browser.login().open(task)

--- a/opengever/task/tests/test_transition_actions.py
+++ b/opengever/task/tests/test_transition_actions.py
@@ -1,6 +1,5 @@
 from ftw.builder import Builder
 from ftw.builder import create
-from ftw.testbrowser import browser
 from ftw.testbrowser import browsing
 from opengever.testing import FunctionalTestCase
 import re
@@ -11,14 +10,13 @@ URL_WIHOUT_TOKEN_RE = re.compile(r'(.*)([\?, &]_authenticator=.*)')
 
 class BaseTransitionActionTest(FunctionalTestCase):
 
-    def assert_action(self, expected):
+    def assert_action(self, browser, expected):
         url = URL_WIHOUT_TOKEN_RE.match(browser.url).groups()[0]
         self.assertEquals(expected, url)
 
-    def do_transition(self, task):
+    def do_transition(self, browser, task):
         browser.login().open(task)
-        browser.css(
-            '#workflow-transition-{}'.format(self.transition)).first.click()
+        browser.css('#workflow-transition-{}'.format(self.transition)).first.click()
 
 
 class TestDelegateAction(BaseTransitionActionTest):
@@ -27,11 +25,9 @@ class TestDelegateAction(BaseTransitionActionTest):
     @browsing
     def test_is_delegate_form(self, browser):
         task = create(Builder('task').in_state('task-state-in-progress'))
-        self.do_transition(task)
-
-        self.assert_action('http://nohost/plone/task-1/@@delegate_recipients')
-        self.assertEquals('Delegate task',
-                          browser.css('.documentFirstHeading').first.text)
+        self.do_transition(browser, task)
+        self.assert_action(browser, 'http://nohost/plone/task-1/@@delegate_recipients')
+        self.assertEquals('Delegate task', browser.css('.documentFirstHeading').first.text)
 
 
 class TestModifyDeadlineAction(BaseTransitionActionTest):
@@ -40,13 +36,12 @@ class TestModifyDeadlineAction(BaseTransitionActionTest):
     @browsing
     def test_is_modify_deadline_form(self, browser):
         task = create(Builder('task').in_state('task-state-in-progress'))
-        self.do_transition(task)
-
-        self.assertEquals('Modify deadline',
-                          browser.css('.documentFirstHeading').first.text)
+        self.do_transition(browser, task)
+        self.assertEquals('Modify deadline', browser.css('.documentFirstHeading').first.text)
         self.assert_action(
-            'http://nohost/plone/task-1/@@modify_deadline?'
-            'form.widgets.transition=task-transition-modify-deadline')
+            browser,
+            'http://nohost/plone/task-1/@@modify_deadline?form.widgets.transition=task-transition-modify-deadline',
+            )
 
 
 class TestReOpenAction(BaseTransitionActionTest):
@@ -55,11 +50,11 @@ class TestReOpenAction(BaseTransitionActionTest):
     @browsing
     def test_is_responseform(self, browser):
         task = create(Builder('task').in_state('task-state-cancelled'))
-        self.do_transition(task)
-
+        self.do_transition(browser, task)
         self.assert_action(
-            'http://nohost/plone/task-1/addresponse?form.widgets.transition='
-            'task-transition-cancelled-open')
+            browser,
+            'http://nohost/plone/task-1/addresponse?form.widgets.transition=task-transition-cancelled-open',
+            )
 
 
 class TestReassignAction(BaseTransitionActionTest):
@@ -68,11 +63,11 @@ class TestReassignAction(BaseTransitionActionTest):
     @browsing
     def test_is_reassign_form(self, browser):
         task = create(Builder('task'))
-        self.do_transition(task)
-
+        self.do_transition(browser, task)
         self.assert_action(
-            'http://nohost/plone/task-1/@@assign-task?'
-            'form.widgets.transition=task-transition-reassign')
+            browser,
+            'http://nohost/plone/task-1/@@assign-task?form.widgets.transition=task-transition-reassign',
+            )
 
 
 class TestCancelAction(BaseTransitionActionTest):
@@ -81,11 +76,11 @@ class TestCancelAction(BaseTransitionActionTest):
     @browsing
     def test_is_responseform(self, browser):
         task = create(Builder('task'))
-        self.do_transition(task)
-
+        self.do_transition(browser, task)
         self.assert_action(
-            'http://nohost/plone/task-1/addresponse?form.widgets.transition='
-            'task-transition-open-cancelled')
+            browser,
+            'http://nohost/plone/task-1/addresponse?form.widgets.transition=task-transition-open-cancelled',
+            )
 
 
 class TestRejectAction(BaseTransitionActionTest):
@@ -95,11 +90,11 @@ class TestRejectAction(BaseTransitionActionTest):
     @browsing
     def test_is_responseform(self, browser):
         task = create(Builder('task'))
-        self.do_transition(task)
-
+        self.do_transition(browser, task)
         self.assert_action(
-            'http://nohost/plone/task-1/addresponse?form.widgets.transition='
-            'task-transition-open-rejected')
+            browser,
+            'http://nohost/plone/task-1/addresponse?form.widgets.transition=task-transition-open-rejected',
+            )
 
 
 class TestInProgressResolveAction(BaseTransitionActionTest):
@@ -110,21 +105,21 @@ class TestInProgressResolveAction(BaseTransitionActionTest):
         task = create(Builder('task')
                       .having(task_type='information')
                       .in_state('task-state-in-progress'))
-        self.do_transition(task)
-
+        self.do_transition(browser, task)
         self.assert_action(
-            'http://nohost/plone/task-1/addresponse?'
-            'form.widgets.transition=task-transition-in-progress-resolved')
+            browser,
+            'http://nohost/plone/task-1/addresponse?form.widgets.transition=task-transition-in-progress-resolved',
+            )
 
     @browsing
     def test_is_responseform_for_bidirectional_orgunit_intern_tasks(self, browser):
         task = create(Builder('task')
                       .in_state('task-state-in-progress'))
-        self.do_transition(task)
-
+        self.do_transition(browser, task)
         self.assert_action(
-            'http://nohost/plone/task-1/addresponse?'
-            'form.widgets.transition=task-transition-in-progress-resolved')
+            browser,
+            'http://nohost/plone/task-1/addresponse?form.widgets.transition=task-transition-in-progress-resolved',
+            )
 
     @browsing
     def test_is_complete_successor_form_for_successors(self, browser):
@@ -135,12 +130,11 @@ class TestInProgressResolveAction(BaseTransitionActionTest):
                       .having(task_type='comment')
                       .in_state('task-state-in-progress')
                       .successor_from(predecessor))
-
-        self.do_transition(task)
-
+        self.do_transition(browser, task)
         self.assert_action(
-            'http://nohost/plone/dossier-1/task-2/@@complete_successor_task?'
-            'transition=task-transition-in-progress-resolved')
+            browser,
+            'http://nohost/plone/dossier-1/task-2/@@complete_successor_task?transition=task-transition-in-progress-resolved',
+            )
 
     @browsing
     def test_is_responseform_for_forwarding_successors(self, browser):
@@ -148,12 +142,11 @@ class TestInProgressResolveAction(BaseTransitionActionTest):
         task = create(Builder('task')
                       .in_state('task-state-in-progress')
                       .successor_from(forwarding))
-
-        self.do_transition(task)
-
+        self.do_transition(browser, task)
         self.assert_action(
-            'http://nohost/plone/task-1/addresponse?'
-            'form.widgets.transition=task-transition-in-progress-resolved')
+            browser,
+            'http://nohost/plone/task-1/addresponse?form.widgets.transition=task-transition-in-progress-resolved',
+            )
 
 
 class TestOpenResolveAction(BaseTransitionActionTest):
@@ -163,11 +156,11 @@ class TestOpenResolveAction(BaseTransitionActionTest):
     @browsing
     def test_is_responseform(self, browser):
         task = create(Builder('task'))
-        self.do_transition(task)
-
+        self.do_transition(browser, task)
         self.assert_action(
-            'http://nohost/plone/task-1/addresponse?form.widgets.transition='
-            'task-transition-open-resolved')
+            browser,
+            'http://nohost/plone/task-1/addresponse?form.widgets.transition=task-transition-open-resolved',
+            )
 
 
 class TestInProgressTestedAndClosedAction(BaseTransitionActionTest):
@@ -180,11 +173,11 @@ class TestInProgressTestedAndClosedAction(BaseTransitionActionTest):
         task = create(Builder('task')
                       .having(task_type=self.task_type)
                       .in_state('task-state-in-progress'))
-        self.do_transition(task)
-
+        self.do_transition(browser, task)
         self.assert_action(
-            'http://nohost/plone/task-1/addresponse?form.widgets.transition='
-            'task-transition-in-progress-tested-and-closed')
+            browser,
+            'http://nohost/plone/task-1/addresponse?form.widgets.transition=task-transition-in-progress-tested-and-closed',
+            )
 
     @browsing
     def test_is_complete_successor_form_for_successors(self, browser):
@@ -195,12 +188,12 @@ class TestInProgressTestedAndClosedAction(BaseTransitionActionTest):
                       .having(task_type=self.task_type)
                       .in_state('task-state-in-progress')
                       .successor_from(predecessor))
-
-        self.do_transition(task)
-
+        self.do_transition(browser, task)
         self.assert_action(
-            'http://nohost/plone/dossier-1/task-2/@@complete_successor_task?'
-            'transition=task-transition-in-progress-tested-and-closed')
+            browser,
+            'http://nohost/plone/dossier-1/task-2/@@complete_successor_task'
+            '?transition=task-transition-in-progress-tested-and-closed',
+            )
 
     @browsing
     def test_is_responseform_for_forwarding_successors(self, browser):
@@ -209,12 +202,11 @@ class TestInProgressTestedAndClosedAction(BaseTransitionActionTest):
                       .having(task_type=self.task_type)
                       .in_state('task-state-in-progress')
                       .successor_from(forwarding))
-
-        self.do_transition(task)
-
+        self.do_transition(browser, task)
         self.assert_action(
-            'http://nohost/plone/task-1/addresponse?form.widgets.transition='
-            'task-transition-in-progress-tested-and-closed')
+            browser,
+            'http://nohost/plone/task-1/addresponse?form.widgets.transition=task-transition-in-progress-tested-and-closed',
+            )
 
 
 class TestAccept(BaseTransitionActionTest):
@@ -223,7 +215,6 @@ class TestAccept(BaseTransitionActionTest):
 
     def setUp(self):
         super(TestAccept, self).setUp()
-
         additional = create(Builder('admin_unit').id(u'additional'))
         create(Builder('org_unit')
                .id(u'additional')
@@ -235,22 +226,22 @@ class TestAccept(BaseTransitionActionTest):
     def test_is_responseform_for_adminunit_intern_tasks(self, browser):
         task = create(Builder('task')
                       .having(responsible_client='client1'))
-
-        self.do_transition(task)
-
+        self.do_transition(browser, task)
         self.assert_action(
-            'http://nohost/plone/task-1/addresponse?'
-            'form.widgets.transition=task-transition-open-in-progress')
+            browser,
+            'http://nohost/plone/task-1/addresponse?form.widgets.transition=task-transition-open-in-progress',
+            )
 
     @browsing
     def test_is_accept_wizzard_for_task_assigned_to_foreign_adminunit(self, browser):
         task = create(Builder('task')
                       .having(responsible_client='additional'))
-
-        self.do_transition(task)
+        self.do_transition(browser, task)
 
         self.assert_action(
-            'http://nohost/plone/task-1/@@accept_choose_method')
+            browser,
+            'http://nohost/plone/task-1/@@accept_choose_method',
+            )
 
 
 class TestOpenToClose(BaseTransitionActionTest):
@@ -259,7 +250,6 @@ class TestOpenToClose(BaseTransitionActionTest):
 
     def setUp(self):
         super(TestOpenToClose, self).setUp()
-
         additional = create(Builder('admin_unit').id(u'additional'))
         create(Builder('org_unit')
                .id(u'additional')
@@ -271,35 +261,33 @@ class TestOpenToClose(BaseTransitionActionTest):
     def test_is_addform_for_bidirectional_tasks(self, browser):
         task = create(Builder('task')
                       .having(task_type='comment'))
-
-        self.do_transition(task)
-
+        self.do_transition(browser, task)
         self.assert_action(
-            'http://nohost/plone/task-1/addresponse?'
-            'form.widgets.transition=task-transition-open-tested-and-closed')
+            browser,
+            'http://nohost/plone/task-1/addresponse?form.widgets.transition=task-transition-open-tested-and-closed',
+            )
 
     @browsing
     def test_is_addform_for_unidirectional_adminunit_intern_tasks(self, browser):
         task = create(Builder('task')
                       .having(task_type='information'))
-
-        self.do_transition(task)
-
+        self.do_transition(browser, task)
         self.assert_action(
-            'http://nohost/plone/task-1/addresponse?'
-            'form.widgets.transition=task-transition-open-tested-and-closed')
+            browser,
+            'http://nohost/plone/task-1/addresponse?form.widgets.transition=task-transition-open-tested-and-closed',
+            )
 
     @browsing
     def test_is_responseform_for_unidirectional_tasks_on_foreign_admin_unit_without_documents(self, browser):
         task = create(Builder('task')
                       .having(task_type='information',
                               responsible_client='additional'))
-
-        self.do_transition(task)
+        self.do_transition(browser, task)
 
         self.assert_action(
-            'http://nohost/plone/task-1/addresponse?'
-            'form.widgets.transition=task-transition-open-tested-and-closed')
+            browser,
+            'http://nohost/plone/task-1/addresponse?form.widgets.transition=task-transition-open-tested-and-closed',
+            )
 
     @browsing
     def test_is_closetask_wizard_for_unidirectional_tasks_on_foreign_admin_unit_with_documents(self, browser):
@@ -307,11 +295,11 @@ class TestOpenToClose(BaseTransitionActionTest):
                       .having(task_type='information',
                               responsible_client='additional'))
         create(Builder('document').within(task))
-
-        self.do_transition(task)
-
+        self.do_transition(browser, task)
         self.assert_action(
-            'http://nohost/plone/task-1/@@close-task-wizard_select-documents')
+            browser,
+            'http://nohost/plone/task-1/@@close-task-wizard_select-documents',
+            )
 
 
 class TestReworkAction(BaseTransitionActionTest):
@@ -321,8 +309,8 @@ class TestReworkAction(BaseTransitionActionTest):
     @browsing
     def test_is_addform(self, browser):
         task = create(Builder('task').in_state('task-state-resolved'))
-        self.do_transition(task)
-
+        self.do_transition(browser, task)
         self.assert_action(
-            'http://nohost/plone/task-1/addresponse?form.widgets.transition='
-            'task-transition-resolved-in-progress')
+            browser,
+            'http://nohost/plone/task-1/addresponse?form.widgets.transition=task-transition-resolved-in-progress',
+            )


### PR DESCRIPTION
* Ported some task transition action tests to integration tests where trivial
* Reset task responsible to issuer upon task rejection
  * Also remove the activity subscription of the previous responsible

Closes #4177