### PR TITLE
Make document mimetype lookups case insensitive

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2018.4.0 (unreleased)
 ---------------------
 
+- Make document mimetype lookups case insensitive. [Rotonen]
 - Reset task responsible to the task issuer upon task rejection. [Rotonen]
 - Rename cancelled task in German from "storniert" to "abgebrochen" .
 - Make tasktemplates sortable. [njohner]

--- a/opengever/document/tests/test_document.py
+++ b/opengever/document/tests/test_document.py
@@ -502,6 +502,16 @@ class TestDocumentMimetype(FunctionalTestCase):
         doc = browser.context.restrictedTraverse('document-1')
         self.assertEquals('application/foobar', doc.file.contentType)
 
+    def test_mimetype_lookups_are_case_insensitive(self):
+        doc = create(Builder('document').within(self.dossier).with_dummy_content())
+        self.assertEqual(str(doc.get_mimetype()[0]), 'application/msword')
+        doc.file.contentType = 'application/MSWORD'
+        self.assertEqual(str(doc.get_mimetype()[0]), 'application/msword')
+        doc.file.contentType = 'application/vnd.ms-excel.sheet.macroEnabled.12'
+        self.assertEqual(str(doc.get_mimetype()[0]), 'application/vnd.ms-excel.sheet.macroEnabled.12')
+        doc.file.contentType = 'application/vnd.ms-excel.sheet.macroenabled.12'
+        self.assertEqual(str(doc.get_mimetype()[0]), 'application/vnd.ms-excel.sheet.macroEnabled.12')
+
 
 class TestDocumentAuthorResolving(FunctionalTestCase):
 


### PR DESCRIPTION
As the mimetype registry is a persistent mapping of persistent mappings, I brought the logic into `document/base.py` where I recurse into a second round of case insensitive checking on dict-comprehension-lowercased mappings if we've had a miss on the normal lookup.

Testing the insensitivity both ways.

Closes #4281 