### PR TITLE
Backport usability changes of mtest from buildout.coredev

### DIFF
--- a/.ci_governor.yml
+++ b/.ci_governor.yml
@@ -1,4 +1,5 @@
 ---
 job_template: python
 weight:
-  test-plone-4.3.x.cfg: 5
+  test-plone-4.3.x-functional.cfg: 3
+  test-plone-4.3.x-integration.cfg: 3

--- a/bin/mtest
+++ b/bin/mtest
@@ -187,7 +187,6 @@ def split(batch):
 
 def create_test_run_params(layers=None, modules=None):
     test_run_params = []
-    port = 0
 
     for layer, testclasses in discover_tests(layers, modules).iteritems():
         batch = {}
@@ -196,9 +195,7 @@ def create_test_run_params(layers=None, modules=None):
         batch['original_count'] = sum(testclasses.values())
         split_batches = split(batch)
         for i, split_batch in enumerate(split_batches):
-            split_batch['port'] = port
             split_batch['batchinfo'] = '{}/{}'.format(i + 1, len(split_batches))
-            port += 1
             test_run_params.append(split_batch)
 
     return tuple(sorted(
@@ -233,7 +230,6 @@ def run_tests(test_run_params):
     batchinfo = test_run_params.get('batchinfo')
     testclasses = test_run_params.get('testclasses', ())
     count = test_run_params.get('count')
-    port = test_run_params.get('port')
 
     if layer:
         params.append('--layer')
@@ -257,8 +253,6 @@ def run_tests(test_run_params):
     memory_handler.flush()
 
     env = environ.copy()
-    # ZServer layers need unique ports
-    env['ZSERVER_PORT'] = env.get('PORT{}'.format(port), str(55000 + port))
     # We cannot access cached sqlite fixtures in parallel yet
     env['GEVER_CACHE_TEST_DB'] = 'false'
 

--- a/bin/mtest
+++ b/bin/mtest
@@ -1,23 +1,25 @@
 #!/usr/bin/env python
-"""A concurrent wrapper for timing xmltestrunner tests for opengever.core."""
+"""A concurrent wrapper for timing xmltestrunner tests for buildout.coredev."""
 from __future__ import print_function
 from argparse import ArgumentParser
 from fnmatch import fnmatch
-from logging import DEBUG
+from itertools import cycle
 from logging import Formatter
 from logging import getLogger
 from logging import INFO
 from logging import StreamHandler
 from logging.handlers import MemoryHandler
-from math import ceil
 from multiprocessing import cpu_count
 from multiprocessing import Pool
+from os import access
 from os import environ
 from os import killpg
 from os import path
+from os import pathsep
 from os import setpgrp
 from os import unlink
 from os import walk
+from os import X_OK
 from signal import SIGINT
 from signal import SIGKILL
 from signal import signal
@@ -27,33 +29,25 @@ from subprocess import Popen
 from time import sleep
 from time import time
 import locale
+import re
 import sys
 
 
-# From https://gist.github.com/moshekaplan/4678925
-def chunks(chunkable, n):
-    """Yield successive n-sized chunks from l."""
-    for i in xrange(0, len(chunkable), n):
-        yield tuple(chunkable[i:i + n])
+def which(program):
+    def is_exe(fpath):
+        return path.isfile(fpath) and access(fpath, X_OK)
 
+    fpath, fname = path.split(program)
+    if fpath:
+        if is_exe(program):
+            return program
+    else:
+        for dpath in environ["PATH"].split(pathsep):
+            exe_file = path.join(dpath, program)
+            if is_exe(exe_file):
+                return exe_file
 
-def split_into_batches(
-        iterable,
-        chunk_count=None,
-        minimum_chunk_count=3,
-        minimum_chunk_size=8,
-        optimal_chunk_size=64,
-    ):
-    length = len(iterable)
-
-    if length / float(minimum_chunk_count) < minimum_chunk_size:
-        return (iterable, )
-
-    if not chunk_count:
-        chunk_count = max(length / optimal_chunk_size, minimum_chunk_count)
-    chunksize = int(ceil(length / float(chunk_count)))
-
-    return chunks(iterable, chunksize)
+    return None
 
 
 def humanize_time(seconds):
@@ -75,15 +69,20 @@ def humanize_time(seconds):
     output = []
 
     if weeks:
-        output.append('{:02d} weeks'.format(weeks))
+        quantifier = 'weeks' if weeks > 1 or weeks == 0 else 'week'
+        output.append('{} {}'.format(weeks, quantifier))
     if days:
-        output.append('{:02d} days'.format(days))
+        quantifier = 'days' if days > 1 or days == 0 else 'day'
+        output.append('{} {}'.format(days, quantifier))
     if hours:
-        output.append('{:02d} hours'.format(hours))
+        quantifier = 'hours' if hours > 1 or hours == 0 else 'hour'
+        output.append('{} {}'.format(hours, quantifier))
     if minutes:
-        output.append('{:02d} minutes'.format(minutes))
+        quantifier = 'minutes' if minutes > 1 or minutes == 0 else 'minute'
+        output.append('{} {}'.format(minutes, quantifier))
 
-    output.append('{:02d} seconds'.format(seconds))
+    quantifier = 'seconds' if seconds > 1 or seconds == 0 else 'second'
+    output.append('{} {}'.format(seconds, quantifier))
 
     return ' '.join(output)
 
@@ -99,89 +98,107 @@ def setup_termination():
     signal(SIGINT, terminate)
 
 
-def get_concurrency():
-    # Counter system congestion and hyperthreading, FWIW
-    concurrency = cpu_count() // 2 - 1
-
-    # Make sure we use at least one core
-    if concurrency < 1:
-        concurrency = 1
-
-    return concurrency
-
-
 def discover_tests(layers=None, modules=None):
-    logger.info('Discovering test classes')
+    logger.info('Discovering tests.')
+    memory_handler.flush()
 
-    test_classes_per_layer = {}
-    current_layer = None
+    batches = {}
 
-    arguments = [
-        'bin/test',
-        '--list-tests',
-        ]
+    layer = None
+    classname = None
+
+    for line in test_discovery(layers, modules):
+        if line.startswith('Listing'):
+            layer = re.search('^Listing (.*) tests:', line).groups()[0]
+            batches[layer] = {}
+
+        # All listed tests are indented with 2 spaces
+        if layer and line.startswith('  '):
+            if '(' in line:
+                classname = re.search(r'.*\((.*)\).*', line).groups()[0]
+
+            # Count discovered tests per testclass
+            if not batches.get(layer).get(classname):
+                batches[layer][classname] = 0
+
+            batches[layer][classname] += 1
+
+    return batches
+
+
+def test_discovery(layers=None, modules=None):
+    if not layers:
+        layers = ()
+    if not modules:
+        modules = ()
+
     output_encoding = sys.stdout.encoding
+
     if output_encoding is None:
         output_encoding = locale.getpreferredencoding()
 
-    if layers:
-        for layer in layers:
-            arguments.append('--layer')
-            arguments.append(layer)
+    cmdline = ['bin/test', '--list-tests']
+    for layer in layers:
+        cmdline.append('--layer')
+        cmdline.append(layer)
+    for module in modules:
+        cmdline.append('-m')
+        cmdline.append(module)
+    return check_output(cmdline).decode(output_encoding).splitlines()
 
-    if modules:
-        for module in modules:
-            arguments.append('-m')
-            arguments.append(module)
 
-    test_discovery = check_output(arguments).decode(output_encoding).splitlines()
+def split(batch, maxcount=256):
+    batch['count'] = sum(batch.get('testclasses').values())
+    if batch.get('count') <= maxcount or len(batch.get('testclasses')) == 1:
+        return (batch, )
 
-    for result in test_discovery:
-        is_layer_header = result.startswith('Listing')
+    sorted_testclasses = sorted(
+        batch.get('testclasses').iteritems(),
+        key=lambda testclass: -testclass[1],
+        )
 
-        # We're guaranteed the output format so we can just set this
-        if is_layer_header:
-            current_layer = result.split()[1]
-            test_classes_per_layer[current_layer] = []
+    split_batches = [
+        {'layer': batch.get('layer'), 'testclasses': {}, 'original_count': batch.get('original_count')},
+        {'layer': batch.get('layer'), 'testclasses': {}, 'original_count': batch.get('original_count')},
+        ]
 
-        # There are unrelated lines in the beginning we do not want to catch
-        if current_layer and not is_layer_header:
-            test_classes_per_layer[current_layer].append(
-                result.split()[-1].strip('()'),
-                )
+    alternator = cycle((0, 1, ))
 
-    # Prune to unique test classes per layer
-    return {
-        layer: sorted(set(tests))
-        for layer, tests in test_classes_per_layer.iteritems()
-        }
+    while sorted_testclasses:
+        testclass = sorted_testclasses.pop(0)
+        split_batches[alternator.next()]['testclasses'][testclass[0]] = testclass[1]
+
+    return tuple(sorted(
+        (a for b in split_batches for a in split(b)),
+        key=lambda batch: -batch.get('count'),
+        ))
 
 
 def create_test_run_params(layers=None, modules=None):
     test_run_params = []
+    port = 0
 
-    for layer, test_classes in discover_tests(layers, modules).iteritems():
-        layersize = len(test_classes)
-        batches = tuple(split_into_batches(test_classes))
-        batches_count = len(batches)
+    for layer, testclasses in discover_tests(layers, modules).iteritems():
+        batch = {}
+        batch['layer'] = layer
+        batch['testclasses'] = testclasses
+        batch['original_count'] = sum(testclasses.values())
+        split_batches = split(batch)
+        for i, split_batch in enumerate(split_batches):
+            split_batch['port'] = port
+            split_batch['batchinfo'] = '{}/{}'.format(i + 1, len(split_batches))
+            port += 1
+            test_run_params.append(split_batch)
 
-        for i, batch in enumerate(batches):
-            n = i + 1
-
-            test_run_params.append({
-                'layers': (layer, ),
-                'test_classes': batch,
-                'batch': '{} / {}'.format(n, batches_count),
-                'count': len(batch),
-                'port': n,
-                'layersize': layersize,
-                })
-
-    return sorted(test_run_params, key=lambda batch: -batch.get('layersize'))
+    return tuple(sorted(
+        test_run_params,
+        key=lambda batch: (-batch.get('original_count'), -batch.get('count'), ),
+        ))
 
 
 def remove_bytecode_files(directory_path):
     logger.info('Removing bytecode files from %s', directory_path)
+
     for filename in find_bytecode_files(directory_path):
         unlink(filename)
 
@@ -198,37 +215,43 @@ def run_tests(test_run_params):
 
     Return the module name, layer name and stderr.
     """
-    params = ['bin/test']
 
-    layers = test_run_params.get('layers')
-    test_classes = test_run_params.get('test_classes')
-    batch = test_run_params.get('batch')
+    params = ['bin/test']
+    params.append('--xml')
+
+    layer = test_run_params.get('layer')
+    batchinfo = test_run_params.get('batchinfo')
+    testclasses = test_run_params.get('testclasses', ())
     count = test_run_params.get('count')
     port = test_run_params.get('port')
 
-    if layers:
-        for layer in layers:
-            params.append('--layer')
-            params.append(layer)
+    if layer:
+        params.append('--layer')
+        params.append(layer)
 
-    if test_classes:
-        for test_class in test_classes:
-            params.append('-t')
-            params.append(test_class)
+    for testclass in testclasses:
+        params.append('-t')
+        params.append(testclass)
 
-    printable_layers = ', '.join(layers)
-    printable_params = ' '.join(params)
+    printable_params = ' '.join(["'{}'".format(param) if ' ' in param else param for param in params])
 
-    logger.debug(
-        'Start: %s - %d test classes - batch %s - commandline: %s',
-        printable_layers,
+    logger.info(
+        "START - %s %s - %d %s",
+        layer,
+        batchinfo,
         count,
-        batch,
-        printable_params,
+        'test' if count == 1 else 'tests',
         )
 
+    # Explicitly flush to trigger IPC over cPickle
+    memory_handler.flush()
+
     env = environ.copy()
+
+    # ZServer layers need unique ports
     env['ZSERVER_PORT'] = env.get('PORT{}'.format(port), str(55000 + port))
+
+    # We cannot access cached sqlite fixtures in parallel yet
     env['GEVER_CACHE_TEST_DB'] = 'false'
 
     start = time()
@@ -246,44 +269,73 @@ def run_tests(test_run_params):
     runtime = time() - start
 
     result = {
-        'params': printable_params,
-        'layers': layers,
-        'test_classes': test_classes,
-        'batch': batch,
-        'port': env.get('ZSERVER_PORT'),
+        'layer': layer,
         'returncode': returncode,
         'runtime': runtime,
         'stderr': stderr,
-        'stdout': stdout,
         }
 
-    logger.debug(
-        'Done : %s - %d test classes - batch %s in %s at %.2fs / test class - commandline: %s',
-        printable_layers,
+    done_args = (
+        'DONE - %s %s - %d %s in %s',
+        layer,
+        batchinfo,
         count,
-        batch,
+        'test' if count == 1 else 'tests',
         humanize_time(runtime),
-        runtime / len(test_classes),
-        printable_params,
         )
+
+    if returncode:
+        logger.error(*done_args)
+    else:
+        logger.info(*done_args)
+
+    # Explicitly flush to trigger IPC over cPickle (and to avoid
+    # carryover-fragment-via-pickling)
+    memory_handler.flush()
+
+    if returncode:
+        log_output.error('')
+        log_output.error('Command line')
+        log_output.error('')
+        log_output.error(printable_params)
+        log_output.error('')
+
+        if stderr:
+            log_output.error('STDERR')
+            log_output.error('')
+            log_output.error(stderr)
+            log_output.error('')
+
+        if returncode:
+            log_output.error('STDOUT')
+            log_output.error('')
+            log_output.error(stdout)
+            log_output.error('')
+
+    elif stderr:
+        log_output.info('')
+        log_output.info('Command line')
+        log_output.info('')
+        log_output.info(printable_params)
+        log_output.info('')
+
+        log_output.info('STDERR')
+        log_output.info('')
+        log_output.info(stderr)
+        log_output.info('')
+
+        # Explicitly flush to trigger IPC over cPickle (and to avoid
+        # carryover-fragment-via-pickling)
+        stdout_handler.flush()
 
     return result
 
 
 def handle_results(results):
-    success = []
+    failed_tests = set()
+    unclean_stderr = set()
+    job_count = len(results)
     runtime = 0
-
-    # Set up a logger for writing output to stdout. We do this because
-    # the logging module handles I/O encoding properly, whereas with 'print'
-    # we'd need to do it ourselves. (Think piping the output of bin/mtest
-    # somewhere, or shell I/O redirection).
-    log_output = getLogger('mtest.output')
-    log_output.propagate = False
-    stdout_handler = StreamHandler(stream=sys.stdout)
-    stdout_handler.setFormatter(Formatter(''))
-    log_output.addHandler(stdout_handler)
-    log_output.setLevel(INFO)
 
     while results:
         sleep(1)
@@ -301,42 +353,38 @@ def handle_results(results):
             mature_results.append(results.pop(i).get())
 
         for result in mature_results:
-            # For some reason we get the test run result dict wrapped in a list
             returncode = result.get('returncode', 1)
             stderr = result.get('stderr')
-            stdout = result.get('stdout')
             runtime += result.get('runtime')
 
-            if not returncode:
-                success.append(True)
+            if returncode:
+                failed_tests.add(result.get('layer'))
 
-            else:
-                success.append(False)
-                log_output.info('')
-                log_output.info('Command line')
-                log_output.info('')
-                log_output.info(result.get('params'))
-                log_output.info('')
+            if stderr:
+                unclean_stderr.add(result.get('layer'))
 
-                if stderr:
-                    log_output.info('STDERR')
-                    log_output.info('')
-                    log_output.info(stderr)
-                    log_output.info('')
+    error_count = len(failed_tests)
 
-                if returncode:
-                    log_output.info('STDOUT')
-                    log_output.info('')
-                    log_output.info(stdout)
-                    log_output.info('')
+    if error_count:
+        logger.error('%d / %d jobs failed.', error_count, job_count)
 
-    logger.debug(
+        for layer in failed_tests:
+            logger.error('Failures in %s', layer)
+
+    stderr_count = len(unclean_stderr)
+
+    if stderr_count:
+        logger.info('%d / %d jobs had an unclean STDERR.', stderr_count, job_count)
+
+        for layer in unclean_stderr:
+            logger.info('Unclean STDERR in %s', layer)
+
+    logger.info(
         'Aggregate runtime %s.',
         humanize_time(runtime)
         )
 
-    # Nothing returned False, everything went fine
-    return all(r is True for r in success)
+    return len(failed_tests) == 0
 
 
 def main(layers=None, modules=None):
@@ -346,29 +394,37 @@ def main(layers=None, modules=None):
     #
     # Setting PYTHONDONTWRITEBYTECODE is not enough, because running buildout
     # also already precompiles bytecode for some eggs.
-    logger.info('Cleaning bytecode files')
     remove_bytecode_files(OPENGEVER_PATH)
-    remove_bytecode_files('src')
+    remove_bytecode_files(SOURCE_PATH)
 
+    start = time()
     test_run_params = create_test_run_params(layers, modules)
+    logger.info('Discovered tests in %s', humanize_time(time() - start))
+    logger.info('Split the tests into %d jobs', len(test_run_params))
+    logger.info('Running the jobs in up to %d processes in parallel', CONCURRENCY)
+
+    # We need to explicitly flush here in order to avoid multiprocessing
+    # related log output duplications due to picking inputs and globals as the
+    # default IPC mechanism
+    memory_handler.flush()
 
     start = time()
 
-    logger.info('Running tests')
-
     pool = Pool(CONCURRENCY)
 
-    results = [
-        pool.apply_async(run_tests, (params, ))
-        for params in test_run_params
-        ]
+    results = []
+
+    for params in test_run_params:
+        # Alleviate cPickle load bursting for IPC
+        sleep(0.25)
+        results.append(pool.apply_async(run_tests, (params, )))
 
     success = handle_results(results)
 
     pool.close()
     pool.join()
 
-    logger.debug('Wallclock runtime %s.', humanize_time(time() - start))
+    logger.info('Wallclock runtime %s.', humanize_time(time() - start))
 
     if success:
         logger.info('No failed tests.')
@@ -383,15 +439,22 @@ if __name__ == '__main__':
     environ['PYTHONUNBUFFERED'] = '1'
     environ['PYTHONDONTWRITEBYTECODE'] = '1'
 
-    DEBUG_MODE = False
-
-    CONCURRENCY = int(environ.get('MTEST_PROCESSORS', get_concurrency()))
-
+    CONCURRENCY = int(environ.get('MTEST_PROCESSORS', cpu_count()))
     BUILDOUT_PATH = path.abspath(path.join(__file__, '..', '..'))
     OPENGEVER_PATH = path.join(BUILDOUT_PATH, 'opengever')
+    SOURCE_PATH = path.join(BUILDOUT_PATH, 'src')
 
     # CLI arguments
-    parser = ArgumentParser(description='Run tests in parallel.')
+    parser = ArgumentParser(
+        description='Run tests in parallel.',
+        )
+
+    parser.add_argument(
+        '-j',
+        '--jobs',
+        type=int,
+        help='Set the testing concurrency level.',
+        )
 
     parser.add_argument(
         '-l',
@@ -407,29 +470,12 @@ if __name__ == '__main__':
         action='append',
         )
 
-    parser.add_argument(
-        '-d',
-        '--debug',
-        help='Set the log level to debug.',
-        action='store_true',
-        )
-
-    parser.add_argument(
-        '-j',
-        '--jobs',
-        help='Set the testing concurrency level.',
-        )
-
     args = parser.parse_args()
 
     if args.jobs:
         CONCURRENCY = int(args.jobs)
 
-    if args.debug:
-        DEBUG_MODE = True
-        default_loglevel = DEBUG
-    else:
-        default_loglevel = INFO
+    default_loglevel = INFO
 
     # Logging
     logger = getLogger('mtest')
@@ -441,23 +487,26 @@ if __name__ == '__main__':
     log_formatter = Formatter(
         ' - '.join((
             '%(asctime)s',
-            '%(name)s',
             '%(levelname)s',
             '%(message)s',
             )),
         )
     stream_handler.setFormatter(log_formatter)
-
-    # Buffer log messages so we do not get broken-by-racecondition
-    # debug log lines in stdout
-    memory_handler = MemoryHandler(
-        4096,
-        flushLevel=DEBUG,
-        target=stream_handler,
-        )
+    # Buffer log messages so we do not get broken-by-racecondition lines
+    memory_handler = MemoryHandler(2, target=stream_handler)
     memory_handler.setLevel(default_loglevel)
-
     logger.addHandler(memory_handler)
+
+    # Set up a separate logger for writing failure output to stdout. We do this
+    # because the logging module handles I/O encoding properly, whereas with
+    # 'print' we'd need to do it ourselves. (Think piping the output of
+    # bin/mtest somewhere, or shell I/O redirection).
+    log_output = getLogger('mtest.output')
+    log_output.propagate = False
+    stdout_handler = StreamHandler(stream=sys.stdout)
+    stdout_handler.setFormatter(Formatter(''))
+    log_output.addHandler(stdout_handler)
+    log_output.setLevel(INFO)
 
     setup_termination()
 

--- a/bin/mtest
+++ b/bin/mtest
@@ -3,12 +3,12 @@
 from __future__ import print_function
 from argparse import ArgumentParser
 from fnmatch import fnmatch
-from itertools import cycle
 from logging import Formatter
 from logging import getLogger
 from logging import INFO
 from logging import StreamHandler
 from logging.handlers import MemoryHandler
+from math import ceil
 from multiprocessing import cpu_count
 from multiprocessing import Pool
 from os import access
@@ -147,29 +147,40 @@ def test_discovery(layers=None, modules=None):
     return check_output(cmdline).decode(output_encoding).splitlines()
 
 
-def split(batch, maxcount=256):
-    batch['count'] = sum(batch.get('testclasses').values())
-    if batch.get('count') <= maxcount or len(batch.get('testclasses')) == 1:
+def chunks(chunkable, chunksize):
+    output = []
+    while chunkable:
+        output.append([])
+        size = 0
+        while chunkable and size < chunksize:
+            output[-1].append(chunkable.pop(0))
+            size = sum(testclass[-1] for testclass in output[-1])
+    return output
+
+
+def split(batch):
+    minsize_mapping = {
+        'opengever.core.testing.opengever.core:integration': 200,
+        'opengever.core.testing.opengever.core:functional': 100,
+        'opengever.core.testing.MeetingLayer': 25,
+        }
+
+    layer = batch.get('layer')
+
+    if layer not in minsize_mapping or CONCURRENCY < 2:
+        batch['count'] = sum(batch.get('testclasses').values())
         return (batch, )
 
-    sorted_testclasses = sorted(
-        batch.get('testclasses').iteritems(),
-        key=lambda testclass: -testclass[1],
-        )
+    original_count = batch.get('original_count')
+    chunksize = max(minsize_mapping.get(layer), int(ceil(original_count / float(CONCURRENCY))))
 
-    split_batches = [
-        {'layer': batch.get('layer'), 'testclasses': {}, 'original_count': batch.get('original_count')},
-        {'layer': batch.get('layer'), 'testclasses': {}, 'original_count': batch.get('original_count')},
-        ]
-
-    alternator = cycle((0, 1, ))
-
-    while sorted_testclasses:
-        testclass = sorted_testclasses.pop(0)
-        split_batches[alternator.next()]['testclasses'][testclass[0]] = testclass[1]
+    splinters = []
+    for chunk in chunks(batch.get('testclasses').items(), chunksize):
+        splinters.append({'layer': layer, 'testclasses': dict(chunk), 'original_count': original_count})
+        splinters[-1]['count'] = sum(splinters[-1].get('testclasses').values())
 
     return tuple(sorted(
-        (a for b in split_batches for a in split(b)),
+        splinters,
         key=lambda batch: -batch.get('count'),
         ))
 
@@ -192,7 +203,7 @@ def create_test_run_params(layers=None, modules=None):
 
     return tuple(sorted(
         test_run_params,
-        key=lambda batch: (-batch.get('original_count'), -batch.get('count'), ),
+        key=lambda batch: -batch.get('original_count'),
         ))
 
 
@@ -215,7 +226,6 @@ def run_tests(test_run_params):
 
     Return the module name, layer name and stderr.
     """
-
     params = ['bin/test']
     params.append('--xml')
 
@@ -247,10 +257,8 @@ def run_tests(test_run_params):
     memory_handler.flush()
 
     env = environ.copy()
-
     # ZServer layers need unique ports
     env['ZSERVER_PORT'] = env.get('PORT{}'.format(port), str(55000 + port))
-
     # We cannot access cached sqlite fixtures in parallel yet
     env['GEVER_CACHE_TEST_DB'] = 'false'
 
@@ -416,7 +424,7 @@ def main(layers=None, modules=None):
 
     for params in test_run_params:
         # Alleviate cPickle load bursting for IPC
-        sleep(0.25)
+        sleep(0.1)
         results.append(pool.apply_async(run_tests, (params, )))
 
     success = handle_results(results)
@@ -433,13 +441,18 @@ def main(layers=None, modules=None):
     return False
 
 
+def get_concurrency():
+    # Counter system congestion and hyperthreading, FWIW
+    return max(cpu_count() // 2 - 1, 1)
+
+
 # Having the __main__ guard is necessary for multiprocessing.Pool().
 if __name__ == '__main__':
     # Globals
     environ['PYTHONUNBUFFERED'] = '1'
     environ['PYTHONDONTWRITEBYTECODE'] = '1'
 
-    CONCURRENCY = int(environ.get('MTEST_PROCESSORS', cpu_count()))
+    CONCURRENCY = int(environ.get('MTEST_PROCESSORS', get_concurrency()))
     BUILDOUT_PATH = path.abspath(path.join(__file__, '..', '..'))
     OPENGEVER_PATH = path.join(BUILDOUT_PATH, 'opengever')
     SOURCE_PATH = path.join(BUILDOUT_PATH, 'src')

--- a/opengever/bundle/report.py
+++ b/opengever/bundle/report.py
@@ -210,7 +210,7 @@ class XLSXReportBuilderBase(object):
 
     def __init__(self, *args, **kwargs):
         self.workbook = Workbook()
-        self.workbook.remove_sheet(self.workbook.active)
+        self.workbook.remove(self.workbook.active)
 
     def build_and_save(self, report_path):
         self.write_report_data()

--- a/opengever/document/tests/test_document.py
+++ b/opengever/document/tests/test_document.py
@@ -621,7 +621,7 @@ class TestDocumentValidatorsInAddForm(IntegrationTestCase):
         error_field = browser.css(selector).first
         self.assertIn(
             "It's not possible to add E-mails here, please send it to",
-            error_field.normalized_text())
+            error_field.text)
 
         self.assertEqual(
             1, len(browser.css('#formfield-form-widgets-file input')),

--- a/opengever/ech0147/tests/test_export.py
+++ b/opengever/ech0147/tests/test_export.py
@@ -14,7 +14,7 @@ class TestExport(IntegrationTestCase):
         browser.open(self.dossier)
         actions = browser.css(
             '#plone-contentmenu-actions .actionMenuContent .subMenuTitle'
-            ).normalized_text()
+            ).text
         self.assertNotIn('eCH-0147 Export', actions)
 
     @browsing
@@ -24,7 +24,7 @@ class TestExport(IntegrationTestCase):
         browser.open(self.dossier)
         actions = browser.css(
             '#plone-contentmenu-actions .actionMenuContent .subMenuTitle'
-            ).normalized_text()
+            ).text
         self.assertIn('eCH-0147 Export', actions)
 
     @browsing

--- a/opengever/ech0147/tests/test_import.py
+++ b/opengever/ech0147/tests/test_import.py
@@ -16,7 +16,7 @@ class TestImport(IntegrationTestCase):
         browser.open(self.leaf_repofolder)
         actions = browser.css(
             '#plone-contentmenu-actions .actionMenuContent .subMenuTitle'
-            ).normalized_text()
+            ).text
         self.assertNotIn('eCH-0147 Import', actions)
 
     @browsing
@@ -26,7 +26,7 @@ class TestImport(IntegrationTestCase):
         browser.open(self.leaf_repofolder)
         actions = browser.css(
             '#plone-contentmenu-actions .actionMenuContent .subMenuTitle'
-            ).normalized_text()
+            ).text
         self.assertIn('eCH-0147 Import', actions)
 
     @browsing

--- a/test-plone-4.3.x-functional.cfg
+++ b/test-plone-4.3.x-functional.cfg
@@ -1,0 +1,25 @@
+[buildout]
+extends =
+    base-plone-4.3.x.cfg
+
+parts =
+    test
+    test-jenkins
+
+jenkins_python = $PYTHON27
+
+[test-jenkins]
+test-command-no-coverage =
+    #!/bin/sh
+    bin/mtest \
+        --layer 'opengever.core.testing.opengever.core:functional' \
+        --layer '!opengever.core.testing.opengever.core:functional:zserver' \
+        -j 3 \
+        $@
+input = inline:
+    #!/bin/sh
+    ${test-jenkins:pre-test}
+    ${test-jenkins:test-command}
+    result=$?
+    ${test-jenkins:post-test}
+    exit $result

--- a/test-plone-4.3.x-integration.cfg
+++ b/test-plone-4.3.x-integration.cfg
@@ -1,0 +1,19 @@
+[buildout]
+extends =
+    base-plone-4.3.x.cfg
+
+parts =
+    test
+    test-jenkins
+
+jenkins_python = $PYTHON27
+
+[test-jenkins]
+test-command-no-coverage = bin/mtest --layer 'opengever.core.testing.opengever.core:integration' -j 3 $@
+input = inline:
+    #!/bin/sh
+    ${test-jenkins:pre-test}
+    ${test-jenkins:test-command}
+    result=$?
+    ${test-jenkins:post-test}
+    exit $result

--- a/test-plone-4.3.x.cfg
+++ b/test-plone-4.3.x.cfg
@@ -9,7 +9,22 @@ parts =
 jenkins_python = $PYTHON27
 
 [test-jenkins]
-test-command-no-coverage = bin/mtest -j5 $@
+test-command-no-coverage =
+    #!/bin/sh
+    ZSERVER_PORT="$PORT1" bin/test \
+        --layer 'ftw.testing.genericsetup.genericsetup-uninstall:TestGenericSetupUninstall' \
+        --layer 'ftw.testing.layer.ComponentUnitTesting' \
+        --layer 'ftw.testing.layer.LatexZCMLLayer' \
+        --layer 'opengever.core.testing.ActivityLayer' \
+        --layer 'opengever.core.testing.BumblebeeLayer' \
+        --layer 'opengever.core.testing.MeetingLayer' \
+        --layer 'opengever.core.testing.OfficeatworkLayer' \
+        --layer 'opengever.core.testing.opengever:core:memory_db' \
+        --layer 'opengever.core.testing.opengever.core:functional:zserver' \
+        --layer 'opengever.core.testing.PrivateFolderLayer' \
+        --layer 'plonetheme.teamraum.testing.plonetheme.teamraum:functional' \
+        --layer 'zope.testrunner.layer.UnitTests' \
+        $@
 input = inline:
     #!/bin/sh
     ${test-jenkins:pre-test}

--- a/test-plone-4.3.x.cfg
+++ b/test-plone-4.3.x.cfg
@@ -9,7 +9,7 @@ parts =
 jenkins_python = $PYTHON27
 
 [test-jenkins]
-test-command-no-coverage = bin/mtest -d -j5 $@
+test-command-no-coverage = bin/mtest -j5 $@
 input = inline:
     #!/bin/sh
     ${test-jenkins:pre-test}


### PR DESCRIPTION
I've been slowly fiddling with parallelising the buildout.coredev CI builds and this process has led into some usability improvements for mtest. I've now backported some of these and also gone and fiddled a bit with the layer split and execution order stuff, as the power-of-two zipper-unweaving techniques from buildout.coredev does not work well for opengever.core.

* STDERR gets printed as a FYI, but will not get logged as an error or trip the build up
* Cleaned up STDERR as the two current things were deprecation warning related trivialities
* Nonzero returns will get logged as errors and trip the build up
* Improved printing logic - the debug mode is not necessary anymore
* Splitting strategies are now based on actual test class assertion counts
* Reintroduced split mapping - generalized rulesets fall apart too easily
  *  The new split mapping technique works rather well for module scoped local test runs

Also split the big test run into multiple subruns so it can run across multiple CI servers.

Give it a spin locally for reference. Suggestions on a path to check out:

`bin/mtest -m opengever.core`
`bin/mtest -m opengever.core -m opengever.base`
`bin/mtest -m opengever.core -m opengever.base -m opengever.dossier`
`bin/mtest -m opengever.core -m opengever.base -m opengever.dossier -m opengever.document -m opengever.inbox`
`bin/mtest`