### PR TITLE
Fix favorites-migration: skip no longer existing repo-favorites.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2018.3.1 (unreleased)
 ---------------------
 
-- Nothing changed yet.
+- Fix favorites-migration: skip no longer existing repo-favorites. [phgross]
 
 
 2018.3.0 (2018-05-22)

--- a/opengever/core/upgrades/20180427103952_migrate_favorites/upgrade.py
+++ b/opengever/core/upgrades/20180427103952_migrate_favorites/upgrade.py
@@ -23,6 +23,10 @@ class MigrateFavorites(SQLUpgradeStep):
             for userid, uuids in storage.items():
                 objs = map(uuidToObject, uuids)
                 for obj in self.drop_existing(objs, userid):
+                    if not obj:
+                        # Object does no longer existng - skip it
+                        continue
+
                     FavoriteManager().add(userid, obj)
 
             self.remove_storage(repo)


### PR DESCRIPTION
Repositoryfolder can be removed by administrators or managers.