### PR TITLE
Bump version for next release to 2018.4.0:

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -2,7 +2,7 @@
 Changelog
 =========
 
-2018.3.2 (unreleased)
+2018.4.0 (unreleased)
 ---------------------
 
 - Integrate plonetheme.teamraum. [deiferni]

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 import os
 
 
-version = '2018.3.2.dev0'
+version = '2018.4.0.dev0'
 maintainer = '4teamwork AG'
 
 


### PR DESCRIPTION
We now started merging 2018.4 features, which should not be released as 2018.3