### PR TITLE
Fix the label for the translation

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -8,6 +8,7 @@ Changelog
 - Fix stuck tabbedview spinner on firefox. [Kevin Bieri]
 - Normalize query strings of template filter. [Kevin Bieri]
 - Improve error handling on the @scan-in API endpoint. [Rotonen]
+- Fix missing translation for committee filter. [tarnap]
 - Bumblebee bugfix: no longer defer preview for new documents. [deiferni]
 - Display dossier resolve properties in the config view. [tarnap]
 - Integrate plonetheme.teamraum. [deiferni]

--- a/opengever/contact/browser/organization_listing.py
+++ b/opengever/contact/browser/organization_listing.py
@@ -61,7 +61,7 @@ class Organizations(OrganizationListingTab):
     filterlist_name = 'organization_state_filter'
     filterlist_available = True
     filterlist = FilterList(
-        Filter('filter_all', tmf('all')),
+        Filter('filter_all', tmf('label_tabbedview_filter_all')),
         ActiveOnlyFilter('filter_active', tmf('Active'), default=True))
 
     enabled_actions = []

--- a/opengever/contact/browser/person_listing.py
+++ b/opengever/contact/browser/person_listing.py
@@ -90,7 +90,7 @@ class Persons(PersonListingTab):
     filterlist_name = 'person_state_filter'
     filterlist_available = True
     filterlist = FilterList(
-        Filter('filter_all', tmf('all')),
+        Filter('filter_all', tmf('label_tabbedview_filter_all')),
         ActiveOnlyFilter('filter_active', tmf('Active'), default=True))
 
     enabled_actions = []

--- a/opengever/contact/tests/test_organization_listing.py
+++ b/opengever/contact/tests/test_organization_listing.py
@@ -41,7 +41,7 @@ class TestOrganizationListing(FunctionalTestCase):
         browser.login().open(
             self.contactfolder, view='tabbedview_view-organizations')
 
-        self.assertEquals(['all', 'Active'],
+        self.assertEquals(['label_tabbedview_filter_all', 'Active'],
                           browser.css('.state_filters a').text)
 
     @browsing

--- a/opengever/meeting/browser/committeecontainertabs.py
+++ b/opengever/meeting/browser/committeecontainertabs.py
@@ -21,7 +21,7 @@ class Committees(BrowserView, GeverTabMixin):
     filterlist_name = 'committee_state_filter'
     filterlist_available = True
     filterlist = FilterList(
-        Filter('filter_all', tmf('all')),
+        Filter('filter_all', tmf('label_tabbedview_filter_all')),
         ActiveOnlyFilter('filter_active', tmf('Active'), default=True))
 
     def __call__(self):


### PR DESCRIPTION
The filter now correctly display "Alle" instead of "all":

<img width="1072" alt="screen shot 2018-05-24 at 08 51 38" src="https://user-images.githubusercontent.com/194114/40469266-3bbfc43a-5f30-11e8-804f-48db983c0a57.png">

Resolves #4342 