### PR TITLE
Do not allow reactivation of deleted document

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -11,6 +11,7 @@ Changelog
 - Normalize query strings of template filter. [Kevin Bieri]
 - Improve error handling on the @scan-in API endpoint. [Rotonen]
 - Fix missing translation for committee filter. [tarnap]
+- Do not allow to reactivate deleted documents. [njohner]
 - Bumblebee bugfix: no longer defer preview for new documents. [deiferni]
 - Display dossier resolve properties in the config view. [tarnap]
 - Add a tasktemplatefolder to GEVER examplecontent. [phgross]

--- a/opengever/trash/locales/de/LC_MESSAGES/opengever.trash.po
+++ b/opengever/trash/locales/de/LC_MESSAGES/opengever.trash.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: opengever.trash 1.0\n"
-"POT-Creation-Date: 2017-10-02 12:52+0000\n"
+"POT-Creation-Date: 2018-05-24 07:27+0000\n"
 "PO-Revision-Date: 2017-05-03 09:38+0200\n"
 "Last-Translator: Julian Infanger <julian.infangner.@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -95,6 +95,11 @@ msgstr "Das Dokument ist noch ausgecheckt."
 msgid "msg_is_not_trashed"
 msgstr "Das Dokument ist noch nicht im Papierkorb."
 
+#. Default: "The document is already removed."
+#: ./opengever/trash/remover.py
+msgid "msg_is_removed"
+msgstr "Das Dokument ist schon gelöscht"
+
 #: ./opengever/trash/upgrades/profiles/4100/actions.xml
 msgid "remove"
 msgstr "Löschen"
@@ -102,4 +107,3 @@ msgstr "Löschen"
 #: ./opengever/trash/browser/trash.py
 msgid "the object ${obj} trashed"
 msgstr "Das Objekt ${obj} wurde in den Papierkorb verschoben."
-

--- a/opengever/trash/locales/fr/LC_MESSAGES/opengever.trash.po
+++ b/opengever/trash/locales/fr/LC_MESSAGES/opengever.trash.po
@@ -1,21 +1,20 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-10-02 12:52+0000\n"
+"POT-Creation-Date: 2018-05-24 07:27+0000\n"
 "PO-Revision-Date: 2017-12-03 12:24+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
-"Language-Team: French <https://translations.onegovgever.ch/projects/onegov-"
-"gever/opengever-trash/fr/>\n"
-"Language: fr\n"
+"Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-trash/fr/>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
-"X-Generator: Weblate 2.13.1\n"
 "Language-Code: en\n"
 "Language-Name: English\n"
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
+"Language: fr\n"
+"X-Generator: Weblate 2.13.1\n"
 
 #: ./opengever/trash/browser/trash.py
 msgid "Trashing ${title} is forbidden"
@@ -96,6 +95,11 @@ msgstr "Le document est encore en checkout."
 #: ./opengever/trash/remover.py
 msgid "msg_is_not_trashed"
 msgstr "Le document n'est pas encore dans la corbeille."
+
+#. Default: "The document is already removed."
+#: ./opengever/trash/remover.py
+msgid "msg_is_removed"
+msgstr "Le document est déjà effacé"
 
 #: ./opengever/trash/upgrades/profiles/4100/actions.xml
 msgid "remove"

--- a/opengever/trash/locales/opengever.trash.pot
+++ b/opengever/trash/locales/opengever.trash.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-10-02 12:52+0000\n"
+"POT-Creation-Date: 2018-05-24 07:27+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -97,6 +97,11 @@ msgstr ""
 msgid "msg_is_not_trashed"
 msgstr ""
 
+#. Default: "The document is already removed."
+#: ./opengever/trash/remover.py
+msgid "msg_is_removed"
+msgstr ""
+
 #: ./opengever/trash/upgrades/profiles/4100/actions.xml
 msgid "remove"
 msgstr ""
@@ -104,4 +109,3 @@ msgstr ""
 #: ./opengever/trash/browser/trash.py
 msgid "the object ${obj} trashed"
 msgstr ""
-

--- a/opengever/trash/remover.py
+++ b/opengever/trash/remover.py
@@ -40,6 +40,7 @@ class RemoveConditionsChecker(object):
         self.verify_checked_in()
         self.verify_no_relations()
         self.verify_is_trashed()
+        self.verify_is_not_removed()
 
         if self.error_msg:
             return False
@@ -75,6 +76,12 @@ class RemoveConditionsChecker(object):
             self.error_msg.append(
                 _(u'msg_is_not_trashed',
                   default=u'The document is not trashed.'))
+
+    def verify_is_not_removed(self):
+        if self.document.is_removed:
+            self.error_msg.append(
+                _(u'msg_is_removed',
+                  default=u'The document is already removed.'))
 
     def get_backreferences(self):
         catalog = getUtility(ICatalog)

--- a/opengever/trash/tests/test_remove_conditions.py
+++ b/opengever/trash/tests/test_remove_conditions.py
@@ -71,6 +71,16 @@ class TestRemoveConditionsChecker(FunctionalTestCase):
             [u'The document is not trashed.'],
             checker.error_msg)
 
+    def test_document_must_not_already_be_removed(self):
+        document = create(Builder('document')
+                          .trashed()
+                          .removed())
+        checker = RemoveConditionsChecker(document)
+        self.assertFalse(checker.removal_allowed())
+        self.assert_error_messages(
+            [u'The document is already removed.'],
+            checker.error_msg)
+
     def test_removal_allowed(self):
         document = create(Builder('document').trashed())
         checker = RemoveConditionsChecker(document)

--- a/opengever/trash/trash.py
+++ b/opengever/trash/trash.py
@@ -95,6 +95,9 @@ class Trasher(object):
         if not _checkPermission('opengever.trash: Trash content', folder):
             raise Unauthorized()
 
+        if not ITrashed.providedBy(self.context) or self.context.is_removed:
+            raise Unauthorized()
+
         noLongerProvides(self.context, ITrashed)
 
         self.reindex()


### PR DESCRIPTION
`removed` documents could be reactivated (untrashed), leading to documents that are in the state `document-state-removed` but not in the trash.
Moreover, `removed` documents could be removed again, leading to an error.

We now test whether a document is in the state `document-state-removed` before removing it, otherwise raising an error message:

![screen shot 2018-05-24 at 09 34 36](https://user-images.githubusercontent.com/7374243/40476973-9f97f12a-5f45-11e8-9b7d-150854001751.png)

Reactivation of documents in the state `document-state-removed` is now forbidding, also raising an error message.
![screen shot 2018-05-24 at 11 20 02](https://user-images.githubusercontent.com/7374243/40609447-eb67b4ec-626e-11e8-88d0-a5b1d1275545.png)


resolves #4233 