### PR TITLE
Fix stuck tabbedview spinner on firefox

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2018.4.0 (unreleased)
 ---------------------
 
+- Fix stuck tabbedview spinner on firefox. [Kevin Bieri]
 - Bumblebee bugfix: no longer defer preview for new documents. [deiferni]
 - Display dossier resolve properties in the config view. [tarnap]
 - Integrate plonetheme.teamraum. [deiferni]

--- a/opengever/base/redirector.py
+++ b/opengever/base/redirector.py
@@ -93,7 +93,7 @@ class RedirectorViewlet(ViewletBase):
 
     JS_TEMPLATE = '''
 <script type="text/javascript" class="redirector">
-$(function() {
+$(document).on('reload', function() {
   if ('%(url)s'.split(':')[0] == 'oc') {
     window.location = '%(url)s';
   } else {


### PR DESCRIPTION
See https://github.com/4teamwork/opengever.core/issues/4147

The `reload` event is fired after the tabbedview has been loaded. So open the oc url after this event happened.