### PR TITLE
Fix resolving tasks when original was delegated

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -10,6 +10,7 @@ Changelog
 - Normalize query strings of template filter. [Kevin Bieri]
 - Improve error handling on the @scan-in API endpoint. [Rotonen]
 - Fix missing translation for committee filter. [tarnap]
+- Fix resolving multi admin unit tasks when subtasks for original task exist. [tarnap]
 - Bumblebee bugfix: no longer defer preview for new documents. [deiferni]
 - Display dossier resolve properties in the config view. [tarnap]
 - Add a tasktemplatefolder to GEVER examplecontent. [phgross]

--- a/opengever/task/browser/transitioncontroller.py
+++ b/opengever/task/browser/transitioncontroller.py
@@ -569,7 +569,14 @@ class TaskChecker(object):
 
     @property
     def all_subtasks_finished(self):
-        query = Task.query.subtasks_by_task(self.task)
+
+        task = self.task
+
+        if task.predecessor is not None:
+            query = Task.query.subtasks_by_tasks([task, task.predecessor])
+        else:
+            query = Task.query.subtasks_by_task(task)
+
         query = query.filter(
             ~Task.query._attribute('review_state').in_(FINISHED_TASK_STATES))
 


### PR DESCRIPTION
When working with multi admin setups, tasks may span over several admin
units.

We assume to have two admin units: FD and RK

Anton creates a task in FD and gives it to Berta in RK
At the same time, Anton delegates the task to Carlos and David in FD
When Berta tries to resolve the task, the subtasks delegated to Carlos
and David should be checked for completeness as well.

Therefore the check on Berta's side should get all the subtasks from
Berta's and Anton's task.

Resolves #4230 