### PR TITLE
Make `TaskTemplate` sortable.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2018.4.0 (unreleased)
 ---------------------
 
+- Make tasktemplates sortable. [njohner]
 - Bump ftw.datepicker to get JS fix for language format selection. [lgraf]
 - Fix stuck tabbedview spinner on firefox. [Kevin Bieri]
 - Normalize query strings of template filter. [Kevin Bieri]

--- a/opengever/core/upgrades/20180524145042_reset_task_templates_listing_cache/upgrade.py
+++ b/opengever/core/upgrades/20180524145042_reset_task_templates_listing_cache/upgrade.py
@@ -1,0 +1,41 @@
+from ftw.dictstorage.sql import DictStorageModel
+from ftw.upgrade import UpgradeStep
+from opengever.base.model import create_session
+import json
+import logging
+
+log = logging.getLogger('opengever.tabbedview')
+
+
+class ResetTaskTemplatesListingCache(UpgradeStep):
+    """Reset task templates listing cache.
+    """
+
+    def __call__(self):
+        self.reset_tasktemplates_dict_storage()
+
+    def reset_tasktemplates_dict_storage(self):
+        session = create_session()
+        query = session.query(DictStorageModel).filter(
+            DictStorageModel.key.contains('tabbedview_view-tasktemplates'))
+
+        for record in query:
+            # Deal with broken DictStorage entries (NULL)
+            if record.value is None:
+                log.warn("DictStorage record with key '%s' has "
+                         "NULL value - skipping record!" % record.key)
+                continue
+
+            try:
+                data = json.loads(record.value.encode('utf-8'))
+            except ValueError:
+                log.warn("DictStorage record with key '%s' has invalid value "
+                         "- skipping record!" % record.key)
+                continue
+
+            columns = data.get('columns')
+            for column in columns:
+                column["sortable"] = False
+
+            data['columns'] = columns
+            record.value = json.dumps(data)

--- a/opengever/tasktemplates/browser/tasktemplates.py
+++ b/opengever/tasktemplates/browser/tasktemplates.py
@@ -25,6 +25,12 @@ class TaskTemplates(BaseCatalogListingTab):
     columns = (
         {'column': '',
          'column_title': '',
+         'transform': helper.draggable,
+         'sortable': False,
+         'width': 30},
+
+        {'column': '',
+         'column_title': '',
          'transform': helper.path_checkbox,
          'sortable': False,
          'groupable': False,
@@ -33,25 +39,31 @@ class TaskTemplates(BaseCatalogListingTab):
         {'column': 'Title',
          'column_title': _(u'label_title', default=u'Title'),
          'sort_index': 'sortable_title',
+         'sortable': False,
          'transform': linked},
 
         {'column': 'task_type',
          'column_title': taskmsg(u'label_task_type', 'Task Type'),
+         'sortable': False,
          'transform': task_type_helper},
 
         {'column': 'issuer',
          'column_title': _(u'label_issuer', 'Issuer'),
+         'sortable': False,
          'transform': interactive_user_helper},
 
         {'column': 'responsible',
          'column_title': _(u'label_responsible_task', default=u'Responsible'),
+         'sortable': False,
          'transform': interactive_user_helper},
 
         {'column': 'deadline',
+         'sortable': False,
          'column_title': _(u"label_deadline", default=u"Deadline in Days")},
 
         {'column': 'preselected',
          'column_title': _(u"label_preselected", default=u"Preselect"),
+         'sortable': False,
          'transform': preselected_helper},
         )
 

--- a/opengever/tasktemplates/browser/trigger.py
+++ b/opengever/tasktemplates/browser/trigger.py
@@ -11,6 +11,7 @@ from opengever.tasktemplates import INTERACTIVE_USERS
 from opengever.tasktemplates.content.tasktemplate import ITaskTemplate
 from plone import api
 from plone.autoform.widgets import ParameterizedWidget
+from plone.app.uuid.utils import uuidToObject
 from plone.supermodel import model
 from plone.z3cform.interfaces import IDeferSecurityCheck
 from plone.z3cform.layout import FormWrapper
@@ -196,7 +197,6 @@ class SelectTaskTemplatesWizardStep(BaseWizardStepForm, Form):
         templates = api.content.find(
             context=self.get_selected_task_templatefolder(),
             portal_type='opengever.tasktemplates.tasktemplate')
-
         return [template.UID for template in templates
                 if template.getObject().preselected]
 
@@ -322,15 +322,13 @@ class SelectResponsiblesWizardStep(BaseWizardStepForm, Form):
 
     def get_selected_tasktemplates(self):
         tasktemplates = get_wizard_data(self.context, 'tasktemplates')
-        catalog = api.portal.get_tool('portal_catalog')
-        return [brain.getObject() for brain in catalog(UID=tasktemplates)]
+        return [uuidToObject(uid) for uid in tasktemplates]
 
     @buttonAndHandler(_(u'button_trigger', default=u'Trigger'), name='trigger')
     def handle_continue(self, action):
         data, errors = self.extractData()
         if errors:
             return
-
         tasktemplatefolder = self.get_selected_task_templatefolder()
         related_documents = self.get_selected_related_documents()
         start_immediately = get_wizard_data(self.context, 'start_immediately')

--- a/opengever/tasktemplates/tests/test_trigger.py
+++ b/opengever/tasktemplates/tests/test_trigger.py
@@ -231,11 +231,11 @@ class TestTriggeringTaskTemplate(IntegrationTestCase):
         ids = main_task.objectIds()
         task1, task2 = [main_task.get(_id) for _id in ids]
 
-        self.assertEquals(u'User Accounts erstellen.', task1.title)
-        self.assertEquals(u'jurgen.konig', task1.responsible)
+        self.assertEquals(u'Arbeitsplatz einrichten.', task1.title)
+        self.assertEquals(u'robert.ziegler', task1.responsible)
 
-        self.assertEquals(u'Arbeitsplatz einrichten.', task2.title)
-        self.assertEquals(u'robert.ziegler', task2.responsible)
+        self.assertEquals(u'User Accounts erstellen.', task2.title)
+        self.assertEquals(u'jurgen.konig', task2.responsible)
 
     @browsing
     def test_step3_responsible_fields_are_required(self, browser):

--- a/opengever/tasktemplates/vocabularies.py
+++ b/opengever/tasktemplates/vocabularies.py
@@ -70,4 +70,6 @@ class TasktemplatesVocabulary(object):
     def get_tasktemplates(self, tasktemplatefolder):
         return api.content.find(
             context=tasktemplatefolder,
-            portal_type='opengever.tasktemplates.tasktemplate')
+            portal_type='opengever.tasktemplates.tasktemplate',
+            sort_on='getObjPositionInParent'
+            )


### PR DESCRIPTION
We allow ordering of `TaskTemplate` in `TaskTemplateFolder` in a `TaskTemplateFolder` with a drag and drop column in the `TaskTemplates` listing view.
This order is then used for selection of tasks in the `add-tasktemplate` action, and selected actions are created in the same order they appear in the `TaskTemplateFolder`.

**Task template with tasks ordered test2; test3; test1**

![screen shot 2018-05-25 at 16 03 22](https://user-images.githubusercontent.com/7374243/40548683-b395d264-6035-11e8-8e05-b034441c3213.png)

**Task selection step, same order**

![screen shot 2018-05-25 at 16 01 32](https://user-images.githubusercontent.com/7374243/40548723-d2445e38-6035-11e8-9450-b75ce390563b.png)

**Responsible selection step**

![screen shot 2018-05-25 at 16 01 41](https://user-images.githubusercontent.com/7374243/40548746-e1f00648-6035-11e8-8e46-56290a74447d.png)

**Tasks created in the order given in the template. Can be ordered by *Laufnummer* to retrieve that order**

![screen shot 2018-05-25 at 16 03 06](https://user-images.githubusercontent.com/7374243/40548784-f922c594-6035-11e8-9b7a-59a43e5d79e4.png)

**Subtasks in the main task are also ordered as in the template**

![screen shot 2018-05-25 at 16 06 46](https://user-images.githubusercontent.com/7374243/40548829-1b1e3d18-6036-11e8-8884-fbaab872b933.png)

resolves #4171 