### PR TITLE
Upgrade TaskTemplateFolder objects to set sequence_type

### DIFF
--- a/opengever/core/upgrades/20180525170340_migrate_task_template_folders/upgrade.py
+++ b/opengever/core/upgrades/20180525170340_migrate_task_template_folders/upgrade.py
@@ -1,0 +1,13 @@
+from ftw.upgrade import UpgradeStep
+
+
+class MigrateTaskTemplateFolders(UpgradeStep):
+    """Migrate task template folders.
+    """
+
+    def __call__(self):
+        for obj in self.objects(
+                {'portal_type': ['opengever.tasktemplates.tasktemplatefolder']},
+                "Make sure sequence_type is set for all TaskTempalteFolder"):
+            if not obj.sequence_type:
+                obj.sequence_type = u"parallel"


### PR DESCRIPTION
Add an upgrade step to set the value of the new `sequence_type` attribute for all `TaskTemplateFolder` objects.

resolves #4539