### PR TITLE
Rename task state cancelled in German from storniert to abgebrochen

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2018.4.0 (unreleased)
 ---------------------
 
+- Rename cancelled task in German from "storniert" to "abgebrochen" .
 - Make tasktemplates sortable. [njohner]
 - Bump ftw.datepicker to get JS fix for language format selection. [lgraf]
 - Fix stuck tabbedview spinner on firefox. [Kevin Bieri]

--- a/opengever/activity/locales/de/LC_MESSAGES/opengever.activity.po
+++ b/opengever/activity/locales/de/LC_MESSAGES/opengever.activity.po
@@ -196,7 +196,7 @@ msgstr "Aufgaben-Frist verändert"
 #. Default: "Task cancelled"
 #: ./opengever/activity/__init__.py
 msgid "task-transition-open-cancelled"
-msgstr "Aufgaben storniert"
+msgstr "Aufgaben abgebrochen"
 
 #. Default: "Task accepted"
 #: ./opengever/activity/__init__.py

--- a/opengever/base/locales/de/LC_MESSAGES/plone.po
+++ b/opengever/base/locales/de/LC_MESSAGES/plone.po
@@ -280,7 +280,7 @@ msgid "task-added"
 msgstr "Aufgabe hinzugefügt."
 
 msgid "task-state-cancelled"
-msgstr "Storniert"
+msgstr "Abgebrochen"
 
 msgid "task-state-in-progress"
 msgstr "In Arbeit"
@@ -319,7 +319,7 @@ msgid "task-transition-modify-deadline"
 msgstr "Frist ändern"
 
 msgid "task-transition-open-cancelled"
-msgstr "Stornieren"
+msgstr "Abbrechen"
 
 msgid "task-transition-open-in-progress"
 msgstr "Akzeptieren"

--- a/opengever/task/locales/de/LC_MESSAGES/opengever.task.po
+++ b/opengever/task/locales/de/LC_MESSAGES/opengever.task.po
@@ -772,7 +772,7 @@ msgstr "Weiterleitung zu einem Dossier hinzugefügt"
 #. Default: "Task cancelled"
 #: ./opengever/task/response_description.py
 msgid "transition_label_cancelled"
-msgstr "Aufgabe storniert"
+msgstr "Aufgabe abgebrochen"
 
 #. Default: "Task closed"
 #: ./opengever/task/response_description.py
@@ -848,7 +848,7 @@ msgstr "Einem Dossier zugewiesen durch ${user} Nachfolgeaufgabe=${successor}"
 #. Default: "Cancelled by ${user}"
 #: ./opengever/task/response_description.py
 msgid "transition_msg_cancel"
-msgstr "Storniert durch ${user}"
+msgstr "Abgebrochen durch ${user}"
 
 #. Default: "Closed by ${user}"
 #: ./opengever/task/response_description.py


### PR DESCRIPTION
My impression is that in french it should still be ok with "annulé", though maybe I just don't understand the difference in German well enough to propose something better in French...