### PR TITLE
 Allow attaching documents of sibling proposals to proposals

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,7 @@ Changelog
 
 - Team add portal action permissions: Administrators to add. [Rotonen]
 - Omit parentheses if no abbreviation for directorate or department available. [tarnap]
+- Allow attaching documents of sibling proposals to proposals. [Rotonen]
 - Make document mimetype lookups case insensitive. [Rotonen]
 - Reset task responsible to the task issuer upon task rejection. [Rotonen]
 - Do not apply the current date to meeting titles. [Rotonen]

--- a/opengever/meeting/proposal.py
+++ b/opengever/meeting/proposal.py
@@ -133,11 +133,13 @@ class IProposal(model.Schema):
             source=DossierPathSourceBinder(
                 portal_type=("opengever.document.document", "ftw.mail.mail"),
                 navigation_tree_query={
-                    'object_provides':
-                        ['opengever.dossier.behaviors.dossier.IDossierMarker',
-                         'opengever.document.document.IDocumentSchema',
-                         'opengever.task.task.ITask',
-                         'ftw.mail.mail.IMail', ],
+                    'object_provides': [
+                        'opengever.dossier.behaviors.dossier.IDossierMarker',
+                        'opengever.document.document.IDocumentSchema',
+                        'opengever.task.task.ITask',
+                        'opengever.meeting.proposal.IProposal',
+                        'ftw.mail.mail.IMail',
+                        ],
                     }),
             ),
         required=False,

--- a/opengever/meeting/tests/test_proposal_template.py
+++ b/opengever/meeting/tests/test_proposal_template.py
@@ -1,65 +1,53 @@
-from ftw.builder import Builder
-from ftw.builder import create
 from ftw.testbrowser import browsing
 from ftw.testbrowser.pages import factoriesmenu
 from ftw.testbrowser.pages import statusmessages
-from opengever.core.testing import activate_meeting_word_implementation
 from opengever.meeting.command import MIME_DOCX
-from opengever.meeting.interfaces import IMeetingSettings
-from opengever.testing import FunctionalTestCase
-from plone import api
-import transaction
+from opengever.testing import IntegrationTestCase
 
 
-class TestProposalTemplate(FunctionalTestCase):
+class TestProposalTemplateWordEnabled(IntegrationTestCase):
+    features = (
+        'meeting',
+        'word-meeting',
+        )
 
-    def setUp(self):
-        super(TestProposalTemplate, self).setUp()
-        activate_meeting_word_implementation()
+    @browsing
+    def test_proposal_templates_addable_when_feature_enabled(self, browser):
+        self.login(self.administrator, browser)
+        browser.open(self.templates)
+        self.assertIn('Proposal Template', factoriesmenu.addable_types(browser))
 
     @browsing
     def test_adding_new_proposal_template(self, browser):
-        vorlagen = create(Builder('templatefolder').titled(u'Vorlagen'))
-        browser.login().open(vorlagen)
-        factoriesmenu.add('Proposal Template')
-
-        browser.fill({
-            'Title': 'Baugesuch',
-            'File': ('Binary Data', 'Baugesuch.docx', MIME_DOCX)}).save()
+        self.login(self.administrator, browser)
+        browser.open(self.templates, view='++add++opengever.meeting.proposaltemplate')
+        browser.fill({'Title': 'Baugesuch', 'File': ('Binary Data', 'Baugesuch.docx', MIME_DOCX)}).save()
         statusmessages.assert_no_error_messages()
-
-        baugesuch, = vorlagen.objectValues()
+        baugesuch = self.templates.objectValues()[-1]
         browser.open(baugesuch, view='tabbedview_view-overview')
-        self.assertDictContainsSubset(
-            {'Title': 'Baugesuch'},
-            dict(browser.css('.documentMetadata table').first.lists()))
-
-        self.assertEquals(
-            'baugesuch.docx',
-            browser.css('.documentMetadata span.filename').first.text)
+        self.assertDictContainsSubset({'Title': 'Baugesuch'}, dict(browser.css('.documentMetadata table').first.lists()))
+        self.assertEquals('baugesuch.docx', browser.css('.documentMetadata span.filename').first.text)
 
     @browsing
     def test_uploading_non_docx_files_is_not_allowed(self, browser):
-        vorlagen = create(Builder('templatefolder').titled(u'Vorlagen'))
-        browser.login().open(vorlagen)
-        factoriesmenu.add('Proposal Template')
-
-        browser.fill({
-            'Title': u'Geb\xfchren',
-            'File': ('DATA', 'Wrong.txt', 'text/plain')}).save()
+        self.login(self.administrator, browser)
+        browser.open(self.templates, view='++add++opengever.meeting.proposaltemplate')
+        browser.fill({'Title': u'Geb\xfchren', 'File': ('DATA', 'Wrong.txt', 'text/plain')}).save()
         statusmessages.assert_message('There were some errors.')
         self.assertEquals(
             ['Only word files (.docx) can be added here.'],
-            browser.css('#formfield-form-widgets-file .error').text)
+            browser.css('#formfield-form-widgets-file .error').text,
+            )
+
+
+class TestProposalTemplateWordDisabled(IntegrationTestCase):
+
+    features = (
+        'meeting',
+        )
 
     @browsing
     def test_proposal_templates_not_addable_when_feature_disabled(self, browser):
-        vorlagen = create(Builder('templatefolder').titled(u'Vorlagen'))
-        browser.login().open(vorlagen)
-        self.assertIn('Proposal Template', factoriesmenu.addable_types())
-
-        api.portal.set_registry_record('is_word_implementation_enabled', False,
-                                       interface=IMeetingSettings)
-        transaction.commit()
-        browser.reload()
-        self.assertNotIn('Proposal Template', factoriesmenu.addable_types())
+        self.login(self.administrator, browser)
+        browser.open(self.templates)
+        self.assertNotIn('Proposal Template', factoriesmenu.addable_types(browser))

--- a/opengever/meeting/tests/test_proposalhistory.py
+++ b/opengever/meeting/tests/test_proposalhistory.py
@@ -1,53 +1,17 @@
-from ftw.builder import Builder
-from ftw.builder import create
 from ftw.testbrowser import browser as default_browser
 from ftw.testbrowser import browsing
-from opengever.core.testing import OPENGEVER_FUNCTIONAL_MEETING_LAYER
 from opengever.meeting.interfaces import IHistory
-from opengever.testing import FunctionalTestCase
+from opengever.testing import IntegrationTestCase
 from plone import api
 from plone.namedfile.file import NamedBlobFile
 from plone.protect import createToken
-import transaction
 
 
-class TestProposalHistory(FunctionalTestCase):
+class TestIntegrationProposalHistory(IntegrationTestCase):
 
-    layer = OPENGEVER_FUNCTIONAL_MEETING_LAYER
-
-    def setUp(self):
-        super(TestProposalHistory, self).setUp()
-
-        # CommitteeResponsible is assigned globally here for the sake of
-        # simplicity
-        self.grant('Contributor', 'Editor', 'Reader', 'MeetingUser',
-                   'CommitteeResponsible')
-
-        self.admin_unit.public_url = 'http://nohost/plone'
-        self.repo, self.repo_folder = create(Builder('repository_tree'))
-        self.dossier = create(Builder('dossier').within(self.repo_folder))
-        self.meeting_dossier = create(
-            Builder('meeting_dossier').within(self.repo_folder))
-        self.excerpt_template = create(Builder('sablontemplate')
-                                       .with_asset_file('excerpt_template.docx'))
-        container = create(Builder('committee_container')
-                           .having(excerpt_template=self.excerpt_template))
-        self.committee = create(Builder('committee').within(container))
-        self.meeting = create(Builder('meeting')
-                              .having(committee=self.committee.load_model())
-                              .link_with(self.meeting_dossier))
-
-        self.repo, self.repo_folder = create(Builder('repository_tree'))
-        self.dossier = create(Builder('dossier').within(self.repo_folder))
-        self.document = create(Builder('document')
-                               .with_dummy_content()
-                               .within(self.dossier)
-                               .titled('A Document'))
-        self.proposal = create(Builder('proposal')
-                               .within(self.dossier)
-                               .having(title='Mach doch',
-                                       committee=self.committee.load_model())
-                               .relate_to(self.document))
+    features = (
+        'meeting',
+        )
 
     def open_overview(self, browser, proposal=None):
         proposal = proposal or self.proposal
@@ -59,13 +23,13 @@ class TestProposalHistory(FunctionalTestCase):
     def get_history_entries_text(self, browser):
         return browser.css('div.answers .answer h3').text
 
-    def submit_proposal(self):
-        self.proposal.execute_transition('pending-submitted')
-        transaction.commit()  # also make change visible in browser
-
-    def assert_proposal_history_records(self, expected_records,
-                                        browser=default_browser,
-                                        with_submitted=False):
+    def assert_proposal_history_records(
+            self,
+            expected_records,
+            proposal=None,
+            browser=default_browser,
+            with_submitted=False
+        ):
         """Assert that the last history entries of a proposal are correct.
 
         The parameter expected_records can be a string to assert for only the
@@ -75,200 +39,200 @@ class TestProposalHistory(FunctionalTestCase):
         If with_submitted is True also assert that the history entries are
         present for the submitted proposal. In that case also assert that uuids
         of history entries from proposal and submitted proposal match.
-
         """
+        if not proposal:
+            proposal = self.proposal
+
         # assert proposal record(s)
-        self.open_overview(browser)
+        self.open_overview(browser, proposal)
         if isinstance(expected_records, basestring):
-            self.assertEqual(
-                expected_records,
-                self.get_latest_history_entry_text(browser))
+            self.assertEqual(expected_records, self.get_latest_history_entry_text(browser))
         else:
             nof_records = len(expected_records)
-            self.assertSequenceEqual(
-                expected_records,
-                self.get_history_entries_text(browser)[:nof_records])
+            self.assertSequenceEqual(expected_records, self.get_history_entries_text(browser)[:nof_records])
 
         if not with_submitted:
             return
 
         # assert submitted proposal record(s)
-        proposal_model = self.proposal.load_model()
+        proposal_model = proposal.load_model()
         submitted_proposal = proposal_model.resolve_submitted_proposal()
         self.open_overview(browser, submitted_proposal)
-
         if isinstance(expected_records, basestring):
-            self.assertEqual(
-                expected_records,
-                self.get_latest_history_entry_text(browser))
+            self.assertEqual(expected_records, self.get_latest_history_entry_text(browser))
         else:
             nof_records = len(expected_records)
-            self.assertSequenceEqual(
-                expected_records,
-                self.get_history_entries_text(browser)[:nof_records])
+            self.assertSequenceEqual(expected_records, self.get_history_entries_text(browser)[:nof_records])
 
         # assert uuid of proposal and submitted proposal record match
-        proposal_history = IHistory(self.proposal)
+        proposal_history = IHistory(proposal)
         s_proposal_history = IHistory(submitted_proposal)
         proposal_history_record = list(proposal_history)[0]
         s_proposal_history_record = list(s_proposal_history)[0]
-
-        self.assertEqual(proposal_history_record.uuid,
-                         s_proposal_history_record.uuid)
+        self.assertEqual(proposal_history_record.uuid, s_proposal_history_record.uuid)
 
     @browsing
     def test_creation_creates_history_entry(self, browser):
-        browser.login()
+        self.login(self.regular_user, browser)
         self.assert_proposal_history_records(
-            u'Created by Test User (test_user_1_)')
+            u'Created by Ziegler Robert (robert.ziegler)',
+            self.draft_proposal,
+            browser,
+            )
 
     @browsing
     def test_submitting_proposal_creates_history_entries(self, browser):
-        browser.login()
-        self.open_overview(browser)
+        self.login(self.regular_user, browser)
+        self.open_overview(browser, self.draft_proposal)
         # submit proposal
         browser.css('#pending-submitted').first.click()
-
-        self.assert_proposal_history_records(
-            [u'Document A Document submitted in version 0 by Test User '
-             u'(test_user_1_)',
-             u'Submitted by Test User (test_user_1_)'],
-            with_submitted=True)
+        expected_history = [u'Submitted by B\xe4rfuss K\xe4thi (kathi.barfuss)']
+        with self.login(self.meeting_user, browser):
+            self.assert_proposal_history_records(expected_history, self.draft_proposal, browser, with_submitted=True)
 
     @browsing
     def test_rejecting_proposals_creates_history_entries(self, browser):
-        browser.login()
-        self.open_overview(browser)
-
-        # submit proposal
-        browser.css('#pending-submitted').first.click()
-        proposal = browser.context
-
+        self.login(self.regular_user, browser)
+        self.open_overview(browser, self.proposal)
         # reject submitted proposal
-        submitted_proposal = proposal.load_model().resolve_submitted_proposal()
-        browser.open(submitted_proposal, view='tabbedview_view-overview')
-        browser.find('Reject').click()
-        browser.fill({'Comment': u'Bitte \xfcberarbeiten'}).submit()
-
-        self.assert_proposal_history_records(
-            u'Rejected by Test User (test_user_1_)')
+        submitted_proposal = self.proposal.load_model().resolve_submitted_proposal()
+        with self.login(self.committee_responsible, browser):
+            self.open_overview(browser, submitted_proposal)
+            browser.find('Reject').click()
+            browser.fill({'Comment': u'Bitte \xfcberarbeiten'}).submit()
+        self.assert_proposal_history_records(u'Rejected by M\xfcller Fr\xe4nzi (franzi.muller)', self.proposal, browser)
 
     @browsing
     def test_cancelling_and_reactivating_proposal_creates_history_entry(self, browser):
-        browser.login()
-        self.open_overview(browser)
-
+        self.login(self.regular_user, browser)
+        self.open_overview(browser, self.draft_proposal)
         # cancel proposal
         browser.css('#pending-cancelled').first.click()
         self.assert_proposal_history_records(
-            u'Proposal cancelled by Test User (test_user_1_)')
-
+            u'Proposal cancelled by B\xe4rfuss K\xe4thi (kathi.barfuss)',
+            self.draft_proposal,
+            browser,
+            )
         # reactivate proposal
         browser.css('#cancelled-pending').first.click()
         self.assert_proposal_history_records(
-            u'Proposal reactivated by Test User (test_user_1_)')
+            u'Proposal reactivated by B\xe4rfuss K\xe4thi (kathi.barfuss)',
+            self.draft_proposal,
+            browser,
+            )
 
     @browsing
     def test_submitting_additional_document_creates_history_entry(self, browser):
-        self.submit_proposal()
-        document = create(Builder('document')
-                          .within(self.dossier)
-                          .titled('Another document'))
-
-        browser.login().visit(self.proposal)
+        self.login(self.regular_user, browser)
+        browser.open(self.proposal)
+        # submit additional document
         browser.find('Submit additional documents').click()
-        browser.fill({'Attachments': document})
+        browser.fill({'Attachments': self.subdocument})
         browser.find('Submit Attachments').click()
-
-        self.assert_proposal_history_records(
-            u'Document Another document submitted in version 0 by Test User '
-            u'(test_user_1_)',
-            with_submitted=True)
+        with self.login(self.meeting_user, browser):
+            self.assert_proposal_history_records(
+                u'Document \xdcbersicht der Vertr\xe4ge von 2016 submitted in version 0 '
+                u'by B\xe4rfuss K\xe4thi (kathi.barfuss)',
+                self.proposal,
+                browser,
+                with_submitted=True,
+                )
 
     @browsing
     def test_updating_existing_document_creates_history_entry(self, browser):
-        self.submit_proposal()
-
+        self.login(self.regular_user, browser)
         self.document.file = NamedBlobFile('New', filename=u'test.txt')
         repository = api.portal.get_tool('portal_repository')
         repository.save(self.document)
-        transaction.commit()
-
-        browser.login().visit(self.proposal)
+        browser.open(self.proposal)
         browser.find('Submit additional documents').click()
         browser.fill({'Attachments': self.document})
         browser.find('Submit Attachments').click()
-
-        self.assert_proposal_history_records(
-            u'Submitted document A Document updated to version 1 by Test User '
-            u'(test_user_1_)',
-            with_submitted=True)
+        with self.login(self.meeting_user, browser):
+            self.assert_proposal_history_records(
+                u'Submitted document Vertr\xe4gsentwurf updated to version 1 by B\xe4rfuss K\xe4thi (kathi.barfuss)',
+                self.proposal,
+                browser,
+                with_submitted=True,
+                )
 
     @browsing
     def test_scheduling_creates_history_entry(self, browser):
-        self.submit_proposal()
-        browser.login().open(
-            self.meeting.get_url(view='unscheduled_proposals/1/schedule'))
-
+        self.login(self.meeting_user, browser)
+        scheduling_url = self.meeting.model.get_url(view='unscheduled_proposals/1/schedule')
+        with self.login(self.committee_responsible, browser):
+            browser.open(scheduling_url)
         self.assert_proposal_history_records(
-            u'Scheduled for meeting C\xf6mmunity meeting by Test User '
-            u'(test_user_1_)',
-            with_submitted=True)
+            u'Scheduled for meeting 9. Sitzung der Rechnungspr\xfcfungskommission '
+            u'by M\xfcller Fr\xe4nzi (franzi.muller)',
+            self.proposal,
+            browser,
+            with_submitted=True,
+            )
 
     @browsing
     def test_removing_from_schedule_creates_history_entry(self, browser):
-        self.submit_proposal()
-        browser.login().open(
-            self.meeting.get_url(view='unscheduled_proposals/1/schedule'))
-
-        browser.login().open(self.meeting.get_url(view='agenda_items/1/delete'))
-
+        self.login(self.meeting_user, browser)
+        scheduling_url = self.meeting.model.get_url(view='unscheduled_proposals/1/schedule')
+        unscheduling_url = self.meeting.model.get_url(view='agenda_items/2/delete')
+        with self.login(self.committee_responsible, browser):
+            browser.open(scheduling_url)
+            browser.open(unscheduling_url)
         self.assert_proposal_history_records(
-            u'Removed from schedule of meeting C\xf6mmunity meeting by Test '
-            u'User (test_user_1_)',
-            with_submitted=True)
+            u'Removed from schedule of meeting 9. Sitzung der Rechnungspr\xfcfungskommission '
+            u'by M\xfcller Fr\xe4nzi (franzi.muller)',
+            self.proposal,
+            browser,
+            with_submitted=True,
+            )
 
     @browsing
     def test_reopening_creates_history_entry(self, browser):
-        self.submit_proposal()
-        transaction.commit()
-        browser.login().open(
-            self.meeting.get_url(view='unscheduled_proposals/1/schedule'))
-        browser.open(self.meeting.get_url(view='agenda_items/1/decide'),
-                     data={'_authenticator': createToken()})
-        browser.open(self.meeting.get_url(view='agenda_items/1/reopen'),
-                     data={'_authenticator': createToken()})
-
+        self.login(self.meeting_user, browser)
+        scheduling_url = self.meeting.model.get_url(view='unscheduled_proposals/1/schedule')
+        deciding_url = self.meeting.model.get_url(view='agenda_items/2/decide')
+        reopening_url = self.meeting.model.get_url(view='agenda_items/2/reopen')
+        with self.login(self.committee_responsible, browser):
+            browser.open(scheduling_url)
+            browser.open(deciding_url, data={'_authenticator': createToken()})
+            browser.open(reopening_url, data={'_authenticator': createToken()})
         self.assert_proposal_history_records(
-            u'Proposal reopened by Test User (test_user_1_)',
-            with_submitted=True)
+            u'Proposal reopened by M\xfcller Fr\xe4nzi (franzi.muller)',
+            self.proposal,
+            browser,
+            with_submitted=True,
+            )
 
     @browsing
     def test_deciding_creates_history_entry(self, browser):
-        self.submit_proposal()
-        transaction.commit()
-        browser.login().open(
-            self.meeting.get_url(view='unscheduled_proposals/1/schedule'))
-        browser.open(self.meeting.get_url(view='agenda_items/1/decide'),
-                     data={'_authenticator': createToken()})
-
+        self.login(self.meeting_user, browser)
+        scheduling_url = self.meeting.model.get_url(view='unscheduled_proposals/1/schedule')
+        deciding_url = self.meeting.model.get_url(view='agenda_items/2/decide')
+        with self.login(self.committee_responsible, browser):
+            browser.open(scheduling_url)
+            browser.open(deciding_url, data={'_authenticator': createToken()})
         self.assert_proposal_history_records(
-            u'Proposal decided by Test User (test_user_1_)',
-            with_submitted=True)
+            u'Proposal decided by M\xfcller Fr\xe4nzi (franzi.muller)',
+            self.proposal,
+            browser,
+            with_submitted=True,
+            )
 
     @browsing
     def test_revising_creates_history_entry(self, browser):
-        self.submit_proposal()
-        transaction.commit()
-        browser.login().open(
-            self.meeting.get_url(view='unscheduled_proposals/1/schedule'))
-        browser.open(self.meeting.get_url(view='agenda_items/1/decide'),
-                     data={'_authenticator': createToken()})
-        browser.open(self.meeting.get_url(view='agenda_items/1/reopen'),
-                     data={'_authenticator': createToken()})
-        browser.open(self.meeting.get_url(view='agenda_items/1/revise'),
-                     data={'_authenticator': createToken()})
-
+        self.login(self.meeting_user, browser)
+        scheduling_url = self.meeting.model.get_url(view='unscheduled_proposals/1/schedule')
+        deciding_url = self.meeting.model.get_url(view='agenda_items/2/decide')
+        reopening_url = self.meeting.model.get_url(view='agenda_items/2/reopen')
+        revising_url = self.meeting.model.get_url(view='agenda_items/2/revise')
+        with self.login(self.committee_responsible, browser):
+            browser.open(scheduling_url)
+            browser.open(deciding_url, data={'_authenticator': createToken()})
+            browser.open(reopening_url, data={'_authenticator': createToken()})
+            browser.open(revising_url, data={'_authenticator': createToken()})
         self.assert_proposal_history_records(
-            u'Proposal revised by Test User (test_user_1_)',
-            with_submitted=True)
+            u'Proposal revised by M\xfcller Fr\xe4nzi (franzi.muller)',
+            self.proposal,
+            browser,
+            with_submitted=True,
+            )


### PR DESCRIPTION
Once figured out, a simple content source portal type whitelist amendment did the trick.