### PR TITLE
Add today in the right format to the sablon data

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -8,6 +8,7 @@ Changelog
 - Team add portal action permissions: Administrators to add. [Rotonen]
 - Omit parentheses if no abbreviation for directorate or department available. [tarnap]
 - Allow attaching documents of sibling proposals to proposals. [Rotonen]
+- Add today to the data passed to the sablon template. [tarnap]
 - Make document mimetype lookups case insensitive. [Rotonen]
 - Reset task responsible to the task issuer upon task rejection. [Rotonen]
 - Do not apply the current date to meeting titles. [Rotonen]

--- a/docs/public/admin-manual/meeting/mergefields.rst
+++ b/docs/public/admin-manual/meeting/mergefields.rst
@@ -15,6 +15,13 @@ Worddokument zu erzeugen.
 
 Die folgenden Seriendruckfelder können standardmässig verwendet werden:
 
+Generelle Metadaten:
+~~~~~~~~~~~~~~~~~~~~
+
+- ``document.generated``
+
+  Generierungsdatum des Dokuments (String)
+
 Metadaten zur Sitzung:
 ~~~~~~~~~~~~~~~~~~~~~~
 

--- a/opengever/meeting/protocol.py
+++ b/opengever/meeting/protocol.py
@@ -1,6 +1,8 @@
+from datetime import datetime
 from opengever.meeting import _
 from opengever.meeting.model.membership import Membership
 from opengever.ogds.base.utils import get_current_admin_unit
+from plone import api
 from zope.globalrequest import getRequest
 from zope.i18n import translate
 import json
@@ -36,6 +38,7 @@ class ProtocolData(object):
         self.add_meeting()
         self.add_commitee()
         self.add_agenda_items()
+        self.add_general_metadata()
 
     def add_settings(self):
         if not self.meeting.protocol_start_page_number:
@@ -144,6 +147,12 @@ class ProtocolData(object):
                     include_disclose_to=self.include_disclose_to,
                     include_copy_for_attention=self.include_copy_for_attention
                 ))
+
+    def add_general_metadata(self):
+        self.data['document'] = {
+            'generated': api.portal.get_localized_time(
+                datetime=datetime.now()),
+        }
 
     def as_json(self, pretty=False):
         indent = 4 if pretty else None

--- a/opengever/meeting/tests/test_protocol_json_data.py
+++ b/opengever/meeting/tests/test_protocol_json_data.py
@@ -1,11 +1,14 @@
 from datetime import date
+from datetime import datetime
 from ftw.builder import Builder
 from ftw.builder import create
+from ftw.testing import freeze
 from opengever.base.model import create_session
 from opengever.meeting.browser.sablontemplate import SAMPLE_MEETING_DATA
 from opengever.meeting.protocol import ExcerptProtocolData
 from opengever.meeting.protocol import ProtocolData
 from opengever.testing import FunctionalTestCase
+import copy
 
 
 class TestProtocolJsonData(FunctionalTestCase):
@@ -111,8 +114,11 @@ class TestProtocolJsonData(FunctionalTestCase):
                 decision_number=1))
 
     def test_protocol_json(self):
-        data = ProtocolData(self.meeting).data
-        self.assertDictEqual(SAMPLE_MEETING_DATA, data)
+        with freeze(datetime(2018, 5, 4)):
+            data = ProtocolData(self.meeting).data
+        expected_data = copy.deepcopy(SAMPLE_MEETING_DATA)
+        expected_data.update({'document': {'generated': u'May 04, 2018'}})
+        self.assertDictEqual(expected_data, data)
 
     def test_add_members_handles_participants_are_no_longer_committee_memberships(self):
         create_session().delete(self.membership_anna)
@@ -148,10 +154,13 @@ class TestExcerptJsonData(FunctionalTestCase):
             meeting_number=11,))
 
     def test_excerpt_json_does_not_contain_start_page(self):
-        data = ExcerptProtocolData(self.meeting).data
+        with freeze(datetime(2018, 5, 4)):
+            data = ExcerptProtocolData(self.meeting).data
+
         self.assertEqual({
             'agenda_items': [],
             'protocol': {'type': u'Protocol-Excerpt'},
+            'document': {'generated': u'May 04, 2018'},
             'participants': {'other': [], 'members': []},
             'committee': {'name': u'Gemeinderat'},
             'mandant': {'name': u'Client1'},


### PR DESCRIPTION
In order to display the protocol generation data, the date needs to be passed inside the data.
This adds a formatted `today`.

Resolves #4216 