### PR TITLE
Tests: Whitelist ERROR level messages from plone.app.viewletmanager:

### DIFF
--- a/opengever/core/testing.py
+++ b/opengever/core/testing.py
@@ -51,6 +51,7 @@ import transaction
 loghandler = logging.StreamHandler(stream=sys.stdout)
 loghandler.setLevel(logging.WARNING)
 for name, level in {'plone.protect': logging.INFO,
+                    'plone.app.viewletmanager': logging.ERROR,
                     'opengever.base.protect': logging.INFO}.items():
     logger = logging.getLogger(name)
     logger.addHandler(loghandler)


### PR DESCRIPTION
This is to aid with debugging failing / flaky tests that only leave a `"error while rendering <viewletname>"` behind in the markup as their only piece of evidence.

Like [this one](https://ci.4teamwork.ch/builds/166128/tasks/263455) for example:

```
ftw.testbrowser dump: /tmp/ftw.testbrowser-MwIM1J.html

Error in test test_prefill_from_advanced_search_omits_searchable_text_keywords (opengever.base.tests.test_search.TestOpengeverSearch)
# ...
NoElementFound: Empty result set: <ftw.browser.core.Browser instance>.css('#searchGadget') did not match any nodes.
```

Even if you manage to get your hands on `/tmp/ftw.testbrowser-MwIM1J.html`, all it contains regarding this failure is `error while rendering plone.searchbox`.

`plone.app.viewletmanager` would actually [log a helpful, detailed stacktrace](https://github.com/plone/plone.app.viewletmanager/blob/e1cb5e3302e3048ec5b87ef40983d79842e3c262/plone/app/viewletmanager/manager.py#L110-L116), but during tests this log output intentionally gets [suppressed by `zope.testrunner`](https://github.com/zopefoundation/zope.testrunner/blob/7034db4bf6adc1154a3055bf263f452f43d26198/src/zope/testrunner/logsupport.py#L47).

We therefore register a specific log handler so we get messages for viewlet failures in the output.

Once we have this in place, we should be able to re-enable the flaky language-selector tests (see #3995) and get a step further with debugging them.