### PR TITLE
Implement new validation of preserved as paper

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2018.4.0 (unreleased)
 ---------------------
 
+- Improve the validation of "preserved as paper" for related documents. [tarnap]
 - Omit parentheses if no abbreviation for directorate or department available. [tarnap]
 - Allow attaching documents of sibling proposals to proposals. [Rotonen]
 - Add today to the data passed to the sablon template. [tarnap]


### PR DESCRIPTION
> Will man ein Platzhalter Dokument in einem Dossier ablegen, um z.B. ein Dokument aus einem anderen Dossier zu referenzieren, so muss die Option in Papierform aufbewahrt angewählt werden, dies ist im Falle eines Platzhalter-Objekt falsch. Die Validierung des Feldes in Papierform aufbewahrt müsste so angepasst werden, das nicht nur das Feld Datei sondern auch die verwandten Dokumente überprüft werden.

The changes from line 117 to 121 are due to the qa-test: See https://ci.4teamwork.ch/builds/166324/tasks/263812

Resolves #4371 