### PR TITLE
Sort entries of the reference widget

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2018.4.0 (unreleased)
 ---------------------
 
+- Sort the entries of the reference browser widget. [tarnap]
 - Improve the validation of "preserved as paper" for related documents. [tarnap]
 - Omit parentheses if no abbreviation for directorate or department available. [tarnap]
 - Allow attaching documents of sibling proposals to proposals. [Rotonen]

--- a/opengever/base/source.py
+++ b/opengever/base/source.py
@@ -23,6 +23,13 @@ class SolrObjPathSource(ObjPathSource):
     """
     def __init__(self, context, selectable_filter, navigation_tree_query=None,
                  default=None, defaultFactory=None):
+
+        if navigation_tree_query is not None:
+            navigation_tree_query.update({
+                'sort_on': navigation_tree_query.get('sort_on',
+                                                     'sortable_title'),
+            })
+
         super(SolrObjPathSource, self).__init__(
                 context, selectable_filter,
                 navigation_tree_query=navigation_tree_query,


### PR DESCRIPTION
The reference widget does sort its entries by the plone standard: `getObjectPositionInParent`
This can be overriden by defining a `navigation_tree_query['sort_on']`. 
The new index is 'searchable_title' (if a `navigation_tree_query` is provided but no `sort_on` key-value is present)

Before:
<img width="960" alt="screen shot 2018-06-04 at 15 36 01" src="https://user-images.githubusercontent.com/194114/40921761-b1b82dd8-6810-11e8-8759-013165d8846a.png">

After:
<img width="962" alt="screen shot 2018-06-04 at 15 57 49" src="https://user-images.githubusercontent.com/194114/40921762-b1d8ae00-6810-11e8-83a6-080ae65b7975.png">

Resolves #4286 