### PR TITLE
Fix unicode error on proposal listings

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -13,6 +13,7 @@ Changelog
 - Add today to the data passed to the sablon template. [tarnap]
 - Display a tooltip for the favorite action. [tarnap]
 - Make document mimetype lookups case insensitive. [Rotonen]
+- Fix unicode error on proposal listings. [phgross]
 - Reset task responsible to the task issuer upon task rejection. [Rotonen]
 - Do not apply the current date to meeting titles. [Rotonen]
 - Rename cancelled task in German from "storniert" to "abgebrochen" .

--- a/opengever/meeting/browser/documents/proposalstab.py
+++ b/opengever/meeting/browser/documents/proposalstab.py
@@ -32,7 +32,7 @@ def proposal_link(item, value):
 
 
 def translated_state(item, value):
-    wrapper = '<span class="wf-proposal-state-{0}">{1}</span>'
+    wrapper = u'<span class="wf-proposal-state-{0}">{1}</span>'
     return wrapper.format(
         item.get_state().title,
         translate(item.get_state().title, context=getRequest()))

--- a/opengever/meeting/tests/test_proposal_listings.py
+++ b/opengever/meeting/tests/test_proposal_listings.py
@@ -67,6 +67,51 @@ class TestDossierProposalListing(IntegrationTestCase):
             proposal_dicts(browser))
 
     @browsing
+    def test_listing_shows_translated_state(self, browser):
+        # Switch to french to tests for encoding errors
+        self.enable_languages()
+        self.login(self.dossier_responsible, browser)
+        browser.open()
+        browser.click_on(u'Fran\xe7ais')
+
+        browser.open(self.dossier,
+                     view='tabbedview_view-proposals',
+                     data={'proposal_state_filter': 'filter_proposals_all'})
+
+        self.assertEquals(
+            [{u'Comit\xe9': u'Rechnungspr\xfcfungskommission',
+              'Etat': 'Soumis',
+              u'Num\xe9ro de d\xe9cision': '',
+              u'R\xe9union': '',
+              'Soumis le': '31.08.2016',
+              'Titre': u'Vertragsentwurf f\xfcr weitere Bearbeitung bewilligen'},
+             {u'Comit\xe9': u'Kommission f\xfcr Verkehr',
+              'Etat': 'En modification',
+              u'Num\xe9ro de d\xe9cision': '',
+              u'R\xe9union': '',
+              'Soumis le': '',
+              'Titre': u'Antrag f\xfcr Kreiselbau'},
+             {u'Comit\xe9': u'Rechnungspr\xfcfungskommission',
+              'Etat': u'Cl\xf4tur\xe9',
+              u'Num\xe9ro de d\xe9cision': '1',
+              u'R\xe9union': u'8. Sitzung der Rechnungspr\xfcfungskommission',
+              'Soumis le': '31.08.2016',
+              'Titre': u'Initialvertrag f\xfcr Bearbeitung'},
+             {u'Comit\xe9': u'Rechnungspr\xfcfungskommission',
+              'Etat': 'Soumis',
+              u'Num\xe9ro de d\xe9cision': '',
+              u'R\xe9union': '',
+              'Soumis le': '31.08.2016',
+              'Titre': u'\xc4nderungen am Personalreglement'},
+             {u'Comit\xe9': u'Kommission f\xfcr Verkehr',
+              'Etat': 'En modification',
+              u'Num\xe9ro de d\xe9cision': '',
+              u'R\xe9union': '',
+              'Soumis le': '',
+              'Titre': u'\xdcberarbeitung der GAV'}],
+            browser.css('.listing').first.dicts())
+
+    @browsing
     def test_proposals_are_linked_correctly(self, browser):
         self.login(self.dossier_responsible, browser)
         browser.open(self.dossier, view='tabbedview_view-proposals')


### PR DESCRIPTION
The `translated_state` could not handle state translations containing
umlauts (see https://sentry.4teamwork.ch/sentry/onegov-gever/issues/7224/ for more information).

@bierik @deiferni not sure which one of you need to fill the 🐷 