### PR TITLE
Export repository roots as reimportable excel files

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -12,6 +12,8 @@ Changelog
 - Document generation of policies in internal docs. [tarnap]
 - Add registry field to customize date format for sablon templates. [njohner]
 - Remove no longer used plonetheme.teamraum uninstall profile since it's integrated into opengever.core. [elioschmutz]
+- Add the ability to export repositories as excel files. [Rotonen]
+- Autosize columns on excel exports. [Rotonen]
 - Implement recently touched menu that lists checked out documents and recently touched objects. [lgraf]
 - Sort the entries of the reference browser widget. [tarnap]
 - Drop non-word meeting feature. [deiferni]

--- a/opengever/base/reporter.py
+++ b/opengever/base/reporter.py
@@ -68,7 +68,8 @@ class XLSReporter(object):
     """
 
     def __init__(self, request, attributes, results,
-                 sheet_title=u' ', footer=u'', portrait_format=False):
+                 sheet_title=u' ', footer=u'', portrait_format=False,
+                 blank_header_rows=0):
         """Initalize the XLS reporter
         Arguments:
         attributes -- a list of mappings (with 'id', 'title', 'transform')
@@ -81,6 +82,7 @@ class XLSReporter(object):
         self.sheet_title = sheet_title
         self.footer = footer
         self.portrait_format = portrait_format
+        self.blank_header_rows = blank_header_rows
 
     def __call__(self):
         workbook = self.prepare_workbook()
@@ -112,14 +114,14 @@ class XLSReporter(object):
     def insert_label_row(self, sheet):
         title_font = Font(bold=True)
         for i, attr in enumerate(self.attributes, 1):
-            cell = sheet.cell(row=1, column=i)
+            cell = sheet.cell(row=self.blank_header_rows + 1, column=i)
             cell.value = translate(attr.get('title', ''), context=self.request)
             cell.font = title_font
 
     def insert_value_rows(self, sheet):
         for row, obj in enumerate(self.results, 2):
             for column, attr in enumerate(self.attributes, 1):
-                cell = sheet.cell(row=row, column=column)
+                cell = sheet.cell(row=self.blank_header_rows + row, column=column)
 
                 if 'default' in attr:
                     value = getattr(obj, attr.get('id'), attr.get('default'))

--- a/opengever/base/reporter.py
+++ b/opengever/base/reporter.py
@@ -96,6 +96,8 @@ class XLSReporter(object):
             for column, attr in enumerate(self.attributes, 1):
                 cell = sheet.cell(row=row, column=column)
                 value = getattr(obj, attr.get('id'))
+                if attr.get('callable'):
+                    value = value()
                 if attr.get('transform'):
                     value = attr.get('transform')(value)
                 if value == MissingValue:

--- a/opengever/base/reporter.py
+++ b/opengever/base/reporter.py
@@ -136,3 +136,6 @@ class XLSReporter(object):
 
                 if 'number_format' in attr:
                     cell.number_format = attr.get('number_format')
+
+                if 'fold_by_method' in attr:
+                    sheet.row_dimensions[cell.row].outlineLevel = attr.get('fold_by_method')(value)

--- a/opengever/base/reporter.py
+++ b/opengever/base/reporter.py
@@ -95,7 +95,11 @@ class XLSReporter(object):
         for row, obj in enumerate(self.results, 2):
             for column, attr in enumerate(self.attributes, 1):
                 cell = sheet.cell(row=row, column=column)
-                value = getattr(obj, attr.get('id'))
+
+                if 'default' in attr:
+                    value = getattr(obj, attr.get('id'), attr.get('default'))
+                else:
+                    value = getattr(obj, attr.get('id'))
                 if attr.get('callable'):
                     value = value()
                 if attr.get('transform'):

--- a/opengever/base/tests/test_reporter.py
+++ b/opengever/base/tests/test_reporter.py
@@ -1,94 +1,44 @@
-from datetime import datetime
-from datetime import timedelta
-from ftw.builder import Builder
-from ftw.builder import create
-from ftw.testing import MockTestCase
-from Missing import Value as MissingValue
 from opengever.base import _
-from opengever.base.reporter import DATE_NUMBER_FORMAT
-from opengever.base.reporter import readable_author
 from opengever.base.reporter import StringTranslater
 from opengever.base.reporter import XLSReporter
-from opengever.testing import MEMORY_DB_LAYER
+from opengever.testing import IntegrationTestCase
 from openpyxl import load_workbook
 from tempfile import NamedTemporaryFile
 from zope.i18n.tests.test_itranslationdomain import Environment
 
 
-class TestReporter(MockTestCase):
-
-    layer = MEMORY_DB_LAYER
-
-    def setUp(self):
-        super(TestReporter, self).setUp()
-
-        create(Builder('ogds_user').id('test_user_0'))
-        create(Builder('ogds_user').id('test_user_1'))
-
-        self.request = self.mocker.mock()
-        self.brains = []
-        for i in range(2):
-            brain = self.stub()
-            self.expect(brain.Title).result('Objekt %i' % (i))
-            self.expect(brain.missing).result(MissingValue)
-            self.expect(brain.start).result(
-                datetime(2012, 2, 25) + timedelta(i))
-            self.expect(brain.responsible).result('test_user_%i' % (i))
-            self.expect(brain.review_state).result('dossier-state-active')
-            self.brains.append(brain)
-
-        self.replay()
-
-        translation_request = Environment(('de', 'de'))
-
-        self.test_attributes = [
-            {'id': 'Title', 'title': _('label_title', default='Title')},
-            {'id': 'missing', 'missing': 'Missing', },
-            {'id': 'start', 'title': _('label_start', default='Start'),
-             'number_format': DATE_NUMBER_FORMAT},
-            {'id': 'responsible',
-             'title': _('label_responsible', default='Responsible'),
-             'transform': readable_author},
-            {'id': 'review_state',
-             'title': _('label_review_state', default='Review state'),
-             'transform': StringTranslater(
-                 translation_request, 'plone').translate},
-        ]
-
-    def test_label_row_is_translated_attribute_titles(self):
-        reporter = XLSReporter(self.request, self.test_attributes, self.brains)
-        workbook = self.get_workbook(reporter())
-        self.assertEquals(
-            [u'Title', None, u'Start', u'Responsible', u'Review state'],
-            [cell.value for cell in list(workbook.active.rows)[0]])
-
-    def test_value_rows(self):
-        reporter = XLSReporter(self.request, self.test_attributes, self.brains)
-        workbook = self.get_workbook(reporter())
-
-        rows = list(workbook.active.rows)
-        self.assertEquals(
-            [u'Objekt 0', None, datetime(2012, 2, 25),
-             u'test_user_0 (test_user_0)', u'dossier-state-active'],
-            [cell.value for cell in rows[1]])
-
-        self.assertEquals(
-            [u'Objekt 1', None, datetime(2012, 2, 26),
-             u'test_user_1 (test_user_1)', 'dossier-state-active'],
-            [cell.value for cell in rows[2]])
-
-    def test_set_sheet_title_for_active_workbook_sheet(self):
-        title = 'Aufgaben\xc3\xbcbersicht'.decode('utf-8')
-        reporter = XLSReporter(
-            None, [], [], sheet_title=title)
-
-        workbook = self.get_workbook(reporter())
-        self.assertEquals(title, workbook.active.title)
-
+class ReporterTestingMixin(object):
     def get_workbook(self, data):
         with NamedTemporaryFile(delete=False, suffix='.xlsx') as tmpfile:
             tmpfile.write(data)
             tmpfile.flush()
             workbook = load_workbook(tmpfile.name)
-
         return workbook
+
+
+class TestReporter(IntegrationTestCase, ReporterTestingMixin):
+    def test_label_row_is_translated_attribute_titles(self):
+        columns = ({'id': 'title', 'title': _('label_title', default='Title')}, )
+        self.login(self.regular_user)
+        reporter = XLSReporter(self.request, columns, (self.document, ))
+        workbook = self.get_workbook(reporter())
+        self.assertEquals([u'Title'], [cell.value for cell in list(workbook.active.rows)[0]])
+
+    def test_excel_reporter_value_rows(self):
+        translation_request = Environment(('de', 'ch'))
+        base_translater = StringTranslater(translation_request, 'opengever.base').translate
+        columns = (
+            {'id': 'title', 'title': _('label_title', default='Title')},
+            {'id': 'classification', 'title': u'fooclass', 'transform': base_translater},
+            )
+        self.login(self.regular_user)
+        reporter = XLSReporter(self.request, columns, (self.document, ))
+        workbook = self.get_workbook(reporter())
+        expected_row = [u'Vertr\xe4gsentwurf', u'Nicht klassifiziert']
+        self.assertEquals(expected_row, [cell.value for cell in list(workbook.active.rows)[-1]])
+
+    def test_set_sheet_title_for_active_workbook_sheet(self):
+        title = 'Aufgaben\xc3\xbcbersicht'.decode('utf-8')
+        reporter = XLSReporter(None, (), (), sheet_title=title)
+        workbook = self.get_workbook(reporter())
+        self.assertEquals(title, workbook.active.title)

--- a/opengever/base/tests/test_reporter.py
+++ b/opengever/base/tests/test_reporter.py
@@ -30,11 +30,12 @@ class TestReporter(IntegrationTestCase, ReporterTestingMixin):
         columns = (
             {'id': 'title', 'title': _('label_title', default='Title')},
             {'id': 'classification', 'title': u'fooclass', 'transform': base_translater},
+            {'id': 'Title', 'title': u'footitle', 'callable': True},
             )
         self.login(self.regular_user)
         reporter = XLSReporter(self.request, columns, (self.document, ))
         workbook = self.get_workbook(reporter())
-        expected_row = [u'Vertr\xe4gsentwurf', u'Nicht klassifiziert']
+        expected_row = [u'Vertr\xe4gsentwurf', u'Nicht klassifiziert', u'Vertr\xe4gsentwurf']
         self.assertEquals(expected_row, [cell.value for cell in list(workbook.active.rows)[-1]])
 
     def test_set_sheet_title_for_active_workbook_sheet(self):

--- a/opengever/base/tests/test_reporter.py
+++ b/opengever/base/tests/test_reporter.py
@@ -31,11 +31,12 @@ class TestReporter(IntegrationTestCase, ReporterTestingMixin):
             {'id': 'title', 'title': _('label_title', default='Title')},
             {'id': 'classification', 'title': u'fooclass', 'transform': base_translater},
             {'id': 'Title', 'title': u'footitle', 'callable': True},
+            {'id': 'unicorn', 'title': _('label_unicorn', default='Pony'), 'default': u'Rainbows!'},
             )
         self.login(self.regular_user)
         reporter = XLSReporter(self.request, columns, (self.document, ))
         workbook = self.get_workbook(reporter())
-        expected_row = [u'Vertr\xe4gsentwurf', u'Nicht klassifiziert', u'Vertr\xe4gsentwurf']
+        expected_row = [u'Vertr\xe4gsentwurf', u'Nicht klassifiziert', u'Vertr\xe4gsentwurf', u'Rainbows!']
         self.assertEquals(expected_row, [cell.value for cell in list(workbook.active.rows)[-1]])
 
     def test_set_sheet_title_for_active_workbook_sheet(self):

--- a/opengever/core/profiles/default/types/opengever.repository.repositoryroot.xml
+++ b/opengever/core/profiles/default/types/opengever.repository.repositoryroot.xml
@@ -66,4 +66,13 @@
     <permission value="Modify portal content" />
   </action>
 
+  <action
+      title="Download Excel"
+      action_id="download_excel"
+      category="object"
+      url_expr="string:${object_url}/download_excel"
+      visible="True">
+    <permission value="opengever.repository.AddRepositoryFolder" />
+  </action>
+
 </object>

--- a/opengever/core/upgrades/20180604222451_add_excel_export_action_to_repository_roots_for_administrators/types/opengever.repository.repositoryroot.xml
+++ b/opengever/core/upgrades/20180604222451_add_excel_export_action_to_repository_roots_for_administrators/types/opengever.repository.repositoryroot.xml
@@ -1,0 +1,11 @@
+<object xmlns:i18n="http://xml.zope.org/namespaces/i18n" name="opengever.repository.repositoryroot" meta_type="Dexterity FTI" i18n:domain="opengever.core">
+  <!-- Actions -->
+  <action
+      title="Download Excel"
+      action_id="download_excel"
+      category="object"
+      url_expr="string:${object_url}/download_excel"
+      visible="True">
+    <permission value="opengever.repository.AddRepositoryFolder" />
+  </action>
+</object>

--- a/opengever/core/upgrades/20180604222451_add_excel_export_action_to_repository_roots_for_administrators/upgrade.py
+++ b/opengever/core/upgrades/20180604222451_add_excel_export_action_to_repository_roots_for_administrators/upgrade.py
@@ -1,0 +1,8 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddExcelExportActionToRepositoryRootsForAdministrators(UpgradeStep):
+    """Add excel export action to repository roots for administrators."""
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/repository/browser/configure.zcml
+++ b/opengever/repository/browser/configure.zcml
@@ -107,4 +107,11 @@
       permission="zope2.View"
       />
 
+  <browser:page
+      for="opengever.repository.repositoryroot.IRepositoryRoot"
+      name="download_excel"
+      class=".excel_export.RepositoryRootExcelExport"
+      permission="opengever.repository.AddRepositoryFolder"
+      />
+
 </configure>

--- a/opengever/repository/browser/excel_export.py
+++ b/opengever/repository/browser/excel_export.py
@@ -1,0 +1,140 @@
+from opengever.base.behaviors.utils import set_attachment_content_disposition
+from opengever.base.reporter import StringTranslater
+from opengever.base.reporter import XLSReporter
+from opengever.repository import _
+from opengever.repository.interfaces import IRepositoryFolder
+from plone import api
+from Products.Five.browser import BrowserView
+from Products.statusmessages.interfaces import IStatusMessage
+
+
+def repository_number_to_outine_level(repository_number):
+    # All of the current repository number formatters are dot separated
+    return len(repository_number.split('.')) - 1
+
+
+def bool_label(value):
+    translater = StringTranslater(api.portal.get().REQUEST, 'opengever.repository').translate
+    return (
+        translater(_(u'label_true', default='Yes'))
+        if value
+        else
+        translater(_(u'label_false', default='No'))
+        )
+
+
+class RepositoryRootExcelExport(BrowserView):
+    """Export a repository tree as an Excel document."""
+
+    def __call__(self):
+        data = generate_report(self.request, self.context)
+        if not data:
+            msg = StringTranslater(self.request, 'opengever.repository').translate(_(u'Could not generate the report.'))
+            IStatusMessage(self.request).addStatusMessage(msg, type='error')
+            return self.request.RESPONSE.redirect(self.context.absolute_url())
+        response = self.request.RESPONSE
+        response.setHeader('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet')
+        set_attachment_content_disposition(self.request, "repository_report.xlsx")
+        return data
+
+
+def generate_report(request, context):
+    # Translations from opengever.base
+    base_translater = StringTranslater(request, 'opengever.base').translate
+    label_classification = base_translater(u'label_classification')
+    label_privacy_layer = base_translater(u'label_privacy_layer')
+    label_public_trial = base_translater(u'label_public_trial')
+    label_retention_period = base_translater(u'label_retention_period')
+    label_retention_period_annotation = base_translater(u'label_retention_period_annotation')
+    label_archival_value = base_translater(u'label_archival_value')
+    label_archival_value_annotation = base_translater(u'label_archival_value_annotation')
+    label_custody_period = base_translater(u'label_custody_period')
+
+    # Translations local to opengever.repository
+    repository_translater = StringTranslater(request, 'opengever.repository').translate
+    label_valid_from = repository_translater(u'label_valid_from')
+    label_valid_until = repository_translater(u'label_valid_until')
+
+    # Translations defined here for opengever.repository
+    label_repository_number = repository_translater(_(
+        u'label_repository_number',
+        default=u'Repository number',
+        ))
+    label_repositoryfolder_title_de = repository_translater(_(
+        u'label_repositoryfolder_title_de',
+        default=u'Repositoryfolder title (German)',
+        ))
+    label_repositoryfolder_title_fr = repository_translater(_(
+        u'label_repositoryfolder_title_fr',
+        default=u'Repositoryfolder title (French)',
+        ))
+    label_repositoryfolder_description = repository_translater(_(
+        u'label_repositoryfolder_description',
+        default=u'Repositoryfolder description',
+        ))
+    label_blocked_inheritance = repository_translater(_(
+        u'label_blocked_inheritance',
+        default=u'Blocked inheritance',
+        ))
+    label_groupnames_with_reader_role = repository_translater(_(
+        u'label_groupnames_with_reader_role',
+        default=u'Read dossiers',
+        ))
+    label_groupnames_with_contributor_role = repository_translater(_(
+        u'label_groupnames_with_contributor_role',
+        default=u'Create dossiers',
+        ))
+    label_groupnames_with_editor_role = repository_translater(_(
+        u'label_groupnames_with_editor_role',
+        default=u'Edit dossiers',
+        ))
+    label_groupnames_with_reviewer_role = repository_translater(_(
+        u'label_groupnames_with_reviewer_role',
+        default=u'Close dossiers',
+        ))
+    label_groupnames_with_publisher_role = repository_translater(_(
+        u'label_groupnames_with_publisher_role',
+        default=u'Reactivate dossiers',
+        ))
+    label_groupnames_with_manager_role = repository_translater(_(
+        u'label_groupnames_with_manager_role',
+        default=u'Manage dossiers',
+        ))
+
+    column_map = (
+        {'id': 'get_repository_number', 'title': label_repository_number, 'fold_by_method': repository_number_to_outine_level, 'callable': True},  # noqa
+        {'id': 'title_de', 'title': label_repositoryfolder_title_de},
+        {'id': 'title_fr', 'title': label_repositoryfolder_title_fr},
+        {'id': 'description', 'title': label_repositoryfolder_description},
+        {'id': 'classification', 'title': label_classification, 'transform': base_translater, 'default': u''},
+        {'id': 'privacy_layer', 'title': label_privacy_layer, 'transform': base_translater, 'default': u''},
+        {'id': 'public_trial', 'title': label_public_trial, 'transform': base_translater, 'default': u''},
+        {'id': 'get_retention_period', 'title': label_retention_period, 'callable': True, 'default': u''},
+        {'id': 'get_retention_period_annotation', 'title': label_retention_period_annotation, 'callable': True, 'default': u''},  # noqa
+        {'id': 'get_archival_value', 'title': label_archival_value, 'transform': base_translater, 'callable': True, 'default': u''},  # noqa
+        {'id': 'get_archival_value_annotation', 'title': label_archival_value_annotation, 'callable': True, 'default': u''},
+        {'id': 'get_custody_period', 'title': label_custody_period, 'callable': True, 'default': u''},
+        {'id': 'valid_from', 'title': label_valid_from},
+        {'id': 'valid_until', 'title': label_valid_until},
+        {'id': '__ac_local_roles_block__', 'title': label_blocked_inheritance, 'transform': bool_label, 'default': False},
+        {'id': 'get_groupnames_with_reader_role', 'title': label_groupnames_with_reader_role, 'callable': True},
+        {'id': 'get_groupnames_with_contributor_role', 'title': label_groupnames_with_contributor_role, 'callable': True},
+        {'id': 'get_groupnames_with_editor_role', 'title': label_groupnames_with_editor_role, 'callable': True},
+        {'id': 'get_groupnames_with_reviewer_role', 'title': label_groupnames_with_reviewer_role, 'callable': True},
+        {'id': 'get_groupnames_with_publisher_role', 'title': label_groupnames_with_publisher_role, 'callable': True},
+        {'id': 'get_groupnames_with_manager_role', 'title': label_groupnames_with_manager_role, 'callable': True},
+        )
+
+    repository_folders = [context] + [
+        brain.getObject()
+        for brain in api.content.find(context, object_provides=IRepositoryFolder.__identifier__)
+        ]
+
+    # XXX - the excel importer expects 4 non-meaningful rows
+    return XLSReporter(
+        request,
+        column_map,
+        repository_folders,
+        sheet_title=repository_translater(u'RepositoryRoot'),
+        blank_header_rows=4,
+        )()

--- a/opengever/repository/locales/de/LC_MESSAGES/opengever.repository.po
+++ b/opengever/repository/locales/de/LC_MESSAGES/opengever.repository.po
@@ -3,7 +3,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2018-01-16 13:43+0000\n"
+"POT-Creation-Date: 2018-06-04 11:35+0000\n"
 "PO-Revision-Date: 2014-11-25 11:31+0100\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: Jonas Baumann <j.baumann@4teamwork.ch>\n"
@@ -16,6 +16,10 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
 "X-Is-Fallback-For: de-at de-li de-lu de-ch de-de\n"
+
+#: ./opengever/repository/browser/excel_export.py
+msgid "Could not generate the report."
+msgstr "Rapport konnte nicht generiert werden."
 
 #: ./opengever/repository/browser/templates/referenceprefixmanager.pt
 msgid "In use"
@@ -71,6 +75,11 @@ msgstr "Eine kurze Beschreibung des Inhalts."
 msgid "label_addable_dossier_types"
 msgstr "Erlaubte Spezialdossiers"
 
+#. Default: "Blocked inheritance"
+#: ./opengever/repository/browser/excel_export.py
+msgid "label_blocked_inheritance"
+msgstr "Unterbruch Vererbung"
+
 #. Default: "Protected Objects"
 #: ./opengever/repository/browser/tabbed.py
 msgid "label_blocked_local_roles"
@@ -106,10 +115,45 @@ msgstr "Dokumente"
 msgid "label_dossiers"
 msgstr "Dossiers"
 
+#. Default: "No"
+#: ./opengever/repository/browser/excel_export.py
+msgid "label_false"
+msgstr "nein"
+
 #. Default: "Former reference"
 #: ./opengever/repository/repositoryfolder.py
 msgid "label_former_reference"
 msgstr "Früheres Zeichen"
+
+#. Default: "Create dossiers"
+#: ./opengever/repository/browser/excel_export.py
+msgid "label_groupnames_with_contributor_role"
+msgstr "Dossiers hinzufügen"
+
+#. Default: "Edit dossiers"
+#: ./opengever/repository/browser/excel_export.py
+msgid "label_groupnames_with_editor_role"
+msgstr "Dossiers bearbeiten"
+
+#. Default: "Manage dossiers"
+#: ./opengever/repository/browser/excel_export.py
+msgid "label_groupnames_with_manager_role"
+msgstr "Dossiers verwalten"
+
+#. Default: "Reactivate dossiers"
+#: ./opengever/repository/browser/excel_export.py
+msgid "label_groupnames_with_publisher_role"
+msgstr "Dossiers reaktivieren"
+
+#. Default: "Read dossiers"
+#: ./opengever/repository/browser/excel_export.py
+msgid "label_groupnames_with_reader_role"
+msgstr "Dossiers lesen"
+
+#. Default: "Close dossiers"
+#: ./opengever/repository/browser/excel_export.py
+msgid "label_groupnames_with_reviewer_role"
+msgstr "Dossiers abschliessen"
 
 #. Default: "Info"
 #: ./opengever/repository/browser/tabbed.py
@@ -141,6 +185,26 @@ msgstr "Präfix des Aktenzeichens"
 msgid "label_referenced_activity"
 msgstr "Leistung"
 
+#. Default: "Repository number"
+#: ./opengever/repository/browser/excel_export.py
+msgid "label_repository_number"
+msgstr "Ordnungspositionsnummer"
+
+#. Default: "Repositoryfolder description"
+#: ./opengever/repository/browser/excel_export.py
+msgid "label_repositoryfolder_description"
+msgstr "Beschreibung (optional)"
+
+#. Default: "Repositoryfolder title (German)"
+#: ./opengever/repository/browser/excel_export.py
+msgid "label_repositoryfolder_title_de"
+msgstr "Titel der Ordnungsposition"
+
+#. Default: "Repositoryfolder title (French)"
+#: ./opengever/repository/browser/excel_export.py
+msgid "label_repositoryfolder_title_fr"
+msgstr "Titel der Ordnungsposition (französisch)"
+
 #. Default: "The repository have been successfully deleted."
 #: ./opengever/repository/browser/deletion.py
 msgid "label_successfully_deleted"
@@ -150,6 +214,11 @@ msgstr "Die Ordnungsposition wurde erfolgreich gelöscht."
 #: ./opengever/repository/browser/tabbed.py
 msgid "label_tasks"
 msgstr "Aufgaben"
+
+#. Default: "Yes"
+#: ./opengever/repository/browser/excel_export.py
+msgid "label_true"
+msgstr "ja"
 
 #. Default: "Valid from"
 #: ./opengever/repository/repositoryfolder.py

--- a/opengever/repository/locales/fr/LC_MESSAGES/opengever.repository.po
+++ b/opengever/repository/locales/fr/LC_MESSAGES/opengever.repository.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-01-16 13:43+0000\n"
+"POT-Creation-Date: 2018-06-04 11:35+0000\n"
 "PO-Revision-Date: 2017-12-03 11:31+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-repository/fr/>\n"
@@ -15,6 +15,10 @@ msgstr ""
 "Domain: DOMAIN\n"
 "Language: fr\n"
 "X-Generator: Weblate 2.13.1\n"
+
+#: ./opengever/repository/browser/excel_export.py
+msgid "Could not generate the report."
+msgstr ""
 
 #: ./opengever/repository/browser/templates/referenceprefixmanager.pt
 msgid "In use"
@@ -70,6 +74,11 @@ msgstr "Brève description du contenu."
 msgid "label_addable_dossier_types"
 msgstr "Types de dossiers à ajouter"
 
+#. Default: "Blocked inheritance"
+#: ./opengever/repository/browser/excel_export.py
+msgid "label_blocked_inheritance"
+msgstr ""
+
 #. Default: "Protected Objects"
 #: ./opengever/repository/browser/tabbed.py
 msgid "label_blocked_local_roles"
@@ -105,10 +114,45 @@ msgstr "Documents"
 msgid "label_dossiers"
 msgstr "Dossiers"
 
+#. Default: "No"
+#: ./opengever/repository/browser/excel_export.py
+msgid "label_false"
+msgstr ""
+
 #. Default: "Former reference"
 #: ./opengever/repository/repositoryfolder.py
 msgid "label_former_reference"
 msgstr "Ancien numéro de référence"
+
+#. Default: "Create dossiers"
+#: ./opengever/repository/browser/excel_export.py
+msgid "label_groupnames_with_contributor_role"
+msgstr ""
+
+#. Default: "Edit dossiers"
+#: ./opengever/repository/browser/excel_export.py
+msgid "label_groupnames_with_editor_role"
+msgstr ""
+
+#. Default: "Manage dossiers"
+#: ./opengever/repository/browser/excel_export.py
+msgid "label_groupnames_with_manager_role"
+msgstr ""
+
+#. Default: "Reactivate dossiers"
+#: ./opengever/repository/browser/excel_export.py
+msgid "label_groupnames_with_publisher_role"
+msgstr ""
+
+#. Default: "Read dossiers"
+#: ./opengever/repository/browser/excel_export.py
+msgid "label_groupnames_with_reader_role"
+msgstr ""
+
+#. Default: "Close dossiers"
+#: ./opengever/repository/browser/excel_export.py
+msgid "label_groupnames_with_reviewer_role"
+msgstr ""
 
 #. Default: "Info"
 #: ./opengever/repository/browser/tabbed.py
@@ -140,6 +184,26 @@ msgstr "Préfixe référence"
 msgid "label_referenced_activity"
 msgstr "Performance"
 
+#. Default: "Repository number"
+#: ./opengever/repository/browser/excel_export.py
+msgid "label_repository_number"
+msgstr ""
+
+#. Default: "Repositoryfolder description"
+#: ./opengever/repository/browser/excel_export.py
+msgid "label_repositoryfolder_description"
+msgstr ""
+
+#. Default: "Repositoryfolder title (German)"
+#: ./opengever/repository/browser/excel_export.py
+msgid "label_repositoryfolder_title_de"
+msgstr ""
+
+#. Default: "Repositoryfolder title (French)"
+#: ./opengever/repository/browser/excel_export.py
+msgid "label_repositoryfolder_title_fr"
+msgstr ""
+
 #. Default: "The repository have been successfully deleted."
 #: ./opengever/repository/browser/deletion.py
 msgid "label_successfully_deleted"
@@ -149,6 +213,11 @@ msgstr "Le numéro de la position a été effacé avec succès."
 #: ./opengever/repository/browser/tabbed.py
 msgid "label_tasks"
 msgstr "Tâches"
+
+#. Default: "Yes"
+#: ./opengever/repository/browser/excel_export.py
+msgid "label_true"
+msgstr ""
 
 #. Default: "Valid from"
 #: ./opengever/repository/repositoryfolder.py

--- a/opengever/repository/locales/opengever.repository.pot
+++ b/opengever/repository/locales/opengever.repository.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-01-16 13:43+0000\n"
+"POT-Creation-Date: 2018-06-04 11:35+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,6 +16,10 @@ msgstr ""
 "Language-Name: English\n"
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: opengever.repository\n"
+
+#: ./opengever/repository/browser/excel_export.py
+msgid "Could not generate the report."
+msgstr ""
 
 #: ./opengever/repository/browser/templates/referenceprefixmanager.pt
 msgid "In use"
@@ -71,6 +75,11 @@ msgstr ""
 msgid "label_addable_dossier_types"
 msgstr ""
 
+#. Default: "Blocked inheritance"
+#: ./opengever/repository/browser/excel_export.py
+msgid "label_blocked_inheritance"
+msgstr ""
+
 #. Default: "Protected Objects"
 #: ./opengever/repository/browser/tabbed.py
 msgid "label_blocked_local_roles"
@@ -106,9 +115,44 @@ msgstr ""
 msgid "label_dossiers"
 msgstr ""
 
+#. Default: "No"
+#: ./opengever/repository/browser/excel_export.py
+msgid "label_false"
+msgstr ""
+
 #. Default: "Former reference"
 #: ./opengever/repository/repositoryfolder.py
 msgid "label_former_reference"
+msgstr ""
+
+#. Default: "Create dossiers"
+#: ./opengever/repository/browser/excel_export.py
+msgid "label_groupnames_with_contributor_role"
+msgstr ""
+
+#. Default: "Edit dossiers"
+#: ./opengever/repository/browser/excel_export.py
+msgid "label_groupnames_with_editor_role"
+msgstr ""
+
+#. Default: "Manage dossiers"
+#: ./opengever/repository/browser/excel_export.py
+msgid "label_groupnames_with_manager_role"
+msgstr ""
+
+#. Default: "Reactivate dossiers"
+#: ./opengever/repository/browser/excel_export.py
+msgid "label_groupnames_with_publisher_role"
+msgstr ""
+
+#. Default: "Read dossiers"
+#: ./opengever/repository/browser/excel_export.py
+msgid "label_groupnames_with_reader_role"
+msgstr ""
+
+#. Default: "Close dossiers"
+#: ./opengever/repository/browser/excel_export.py
+msgid "label_groupnames_with_reviewer_role"
 msgstr ""
 
 #. Default: "Info"
@@ -141,6 +185,26 @@ msgstr ""
 msgid "label_referenced_activity"
 msgstr ""
 
+#. Default: "Repository number"
+#: ./opengever/repository/browser/excel_export.py
+msgid "label_repository_number"
+msgstr ""
+
+#. Default: "Repositoryfolder description"
+#: ./opengever/repository/browser/excel_export.py
+msgid "label_repositoryfolder_description"
+msgstr ""
+
+#. Default: "Repositoryfolder title (German)"
+#: ./opengever/repository/browser/excel_export.py
+msgid "label_repositoryfolder_title_de"
+msgstr ""
+
+#. Default: "Repositoryfolder title (French)"
+#: ./opengever/repository/browser/excel_export.py
+msgid "label_repositoryfolder_title_fr"
+msgstr ""
+
 #. Default: "The repository have been successfully deleted."
 #: ./opengever/repository/browser/deletion.py
 msgid "label_successfully_deleted"
@@ -149,6 +213,11 @@ msgstr ""
 #. Default: "Tasks"
 #: ./opengever/repository/browser/tabbed.py
 msgid "label_tasks"
+msgstr ""
+
+#. Default: "Yes"
+#: ./opengever/repository/browser/excel_export.py
+msgid "label_true"
 msgstr ""
 
 #. Default: "Valid from"

--- a/opengever/repository/mixin.py
+++ b/opengever/repository/mixin.py
@@ -1,0 +1,26 @@
+class RepositoryMixin(object):
+    def get_groupnames_with_role(self, rolename):
+        return ','.join(set([
+            group
+            for group, roles in self.get_local_roles()
+            for role in roles
+            if role == rolename
+            ]))
+
+    def get_groupnames_with_reader_role(self):
+        return self.get_groupnames_with_role('Reader')
+
+    def get_groupnames_with_contributor_role(self):
+        return self.get_groupnames_with_role('Contributor')
+
+    def get_groupnames_with_editor_role(self):
+        return self.get_groupnames_with_role('Editor')
+
+    def get_groupnames_with_reviewer_role(self):
+        return self.get_groupnames_with_role('Reviewer')
+
+    def get_groupnames_with_publisher_role(self):
+        return self.get_groupnames_with_role('Publisher')
+
+    def get_groupnames_with_manager_role(self):
+        return self.get_groupnames_with_role('Manager')

--- a/opengever/repository/repositoryroot.py
+++ b/opengever/repository/repositoryroot.py
@@ -1,6 +1,7 @@
 from opengever.base.behaviors.translated_title import ITranslatedTitle
 from opengever.base.behaviors.translated_title import TranslatedTitleMixin
 from opengever.repository import _
+from opengever.repository.mixin import RepositoryMixin
 from plone.app.content.interfaces import INameFromTitle
 from plone.dexterity.content import Container
 from plone.supermodel import model
@@ -29,11 +30,35 @@ class IRepositoryRoot(model.Schema):
         )
 
 
-class RepositoryRoot(Container, TranslatedTitleMixin):
+class RepositoryRoot(Container, RepositoryMixin, TranslatedTitleMixin):
     """A Repositoryroot.
     """
 
     Title = TranslatedTitleMixin.Title
+
+    # XXX - a dummy stub for the excel export
+    def get_repository_number(self):
+        return u''
+
+    # XXX - a dummy stub for the excel export
+    def get_retention_period(self):
+        return u''
+
+    # XXX - a dummy stub for the excel export
+    def get_retention_period_annotation(self):
+        return u''
+
+    # XXX - a dummy stub for the excel export
+    def get_archival_value(self):
+        return u''
+
+    # XXX - a dummy stub for the excel export
+    def get_archival_value_annotation(self):
+        return u''
+
+    # XXX - a dummy stub for the excel export
+    def get_custody_period(self):
+        return u''
 
 
 @implementer(INameFromTitle)

--- a/opengever/repository/tests/test_excel_export.py
+++ b/opengever/repository/tests/test_excel_export.py
@@ -1,0 +1,72 @@
+from opengever.repository.browser.excel_export import generate_report
+from opengever.setup.sections.xlssource import XlsSource
+from opengever.testing import IntegrationTestCase
+from plone import api
+from tempfile import NamedTemporaryFile
+from tempfile import mkdtemp
+import os
+
+
+class TestRepositoryRootExcelExport(IntegrationTestCase):
+    def test_importability_of_exported_repository_root(self):
+        self.login(self.regular_user)
+        report_data = generate_report(api.portal.get().REQUEST, self.repository_root)
+        tempdir = mkdtemp()
+        with NamedTemporaryFile(dir=tempdir, suffix='.xlsx') as tmpfile:
+            tmpfile.write(report_data)
+            tmpfile.flush()
+            file_basename = os.path.splitext(os.path.basename(tmpfile.name))[0]
+            imported_data = list(XlsSource(None, '', {'directory': tempdir, 'client_id': 'test'}, []))
+        os.rmdir(tempdir)
+        expected_reporoot = {
+                '_repo_root_id': file_basename,
+                '_type': u'opengever.repository.repositoryroot',
+                u'Blocked inheritance': u'No',
+                u'Close dossiers': u'jurgen.konig',
+                u'Create dossiers': u'fa_users',
+                u'Edit dossiers': u'fa_users',
+                u'label_archival_value_annotation': u'',
+                u'label_archival_value': u'',
+                u'label_classification': u'',
+                u'label_custody_period': u'',
+                u'label_privacy_layer': u'',
+                u'label_public_trial': u'',
+                u'label_retention_period_annotation': u'',
+                u'label_retention_period': u'',
+                u'label_valid_from': u'',
+                u'label_valid_until': u'',
+                u'Manage dossiers': u'',
+                u'Reactivate dossiers': u'jurgen.konig',
+                u'Read dossiers': u'fa_users',
+                u'Repository number': u'',
+                u'Repositoryfolder description': u'',
+                u'Repositoryfolder title (French)': u'Syst\xe8me de classement',
+                u'Repositoryfolder title (German)': u'Ordnungssystem',
+                }
+        self.assertEqual(imported_data[0], expected_reporoot)
+        expected_repofolder = {
+            '_repo_root_id': file_basename,
+            '_type': u'opengever.repository.repositoryfolder',
+            u'Blocked inheritance': u'No',
+            u'Close dossiers': u'',
+            u'Create dossiers': u'',
+            u'Edit dossiers': u'',
+            u'label_archival_value_annotation': u'',
+            u'label_archival_value': u'unchecked',
+            u'label_classification': u'unprotected',
+            u'label_custody_period': 30,
+            u'label_privacy_layer': u'privacy_layer_no',
+            u'label_public_trial': u'unchecked',
+            u'label_retention_period_annotation': u'',
+            u'label_retention_period': 5,
+            u'label_valid_from': u'',
+            u'label_valid_until': u'',
+            u'Manage dossiers': u'',
+            u'Reactivate dossiers': u'',
+            u'Read dossiers': u'',
+            u'Repository number': u'1',
+            u'Repositoryfolder description': u'Alles zum Thema F\xfchrung.',
+            u'Repositoryfolder title (French)': u'Direction',
+            u'Repositoryfolder title (German)': u'F\xfchrung',
+            }
+        self.assertEqual(imported_data[1], expected_repofolder)


### PR DESCRIPTION
* Can reimport the exported output
* Adds an action on the repository root
* Extends necessary missing functionality to the excel reporter

Closes #4221 