### PR TITLE
Rename the zserver test layer so we can have a catch-all job

### DIFF
--- a/opengever/core/testing.py
+++ b/opengever/core/testing.py
@@ -269,7 +269,7 @@ OPENGEVER_FUNCTIONAL_ZSERVER_TESTING = FunctionalTesting(
     bases=(z2.ZSERVER_FIXTURE,
            OPENGEVER_FIXTURE_SQLITE,
            set_builder_session_factory(functional_session_factory)),
-    name="opengever.core:functional:zserver")
+    name="opengever.core:zserver")
 
 
 def activate_filing_number(portal):

--- a/test-plone-4.3.x-functional.cfg
+++ b/test-plone-4.3.x-functional.cfg
@@ -11,11 +11,7 @@ jenkins_python = $PYTHON27
 [test-jenkins]
 test-command-no-coverage =
     #!/bin/sh
-    bin/mtest \
-        --layer 'opengever.core.testing.opengever.core:functional' \
-        --layer '!opengever.core.testing.opengever.core:functional:zserver' \
-        -j 3 \
-        $@
+    bin/mtest --layer 'opengever.core.testing.opengever.core:functional' -j 3 $@
 input = inline:
     #!/bin/sh
     ${test-jenkins:pre-test}

--- a/test-plone-4.3.x.cfg
+++ b/test-plone-4.3.x.cfg
@@ -12,18 +12,8 @@ jenkins_python = $PYTHON27
 test-command-no-coverage =
     #!/bin/sh
     ZSERVER_PORT="$PORT1" bin/test \
-        --layer 'ftw.testing.genericsetup.genericsetup-uninstall:TestGenericSetupUninstall' \
-        --layer 'ftw.testing.layer.ComponentUnitTesting' \
-        --layer 'ftw.testing.layer.LatexZCMLLayer' \
-        --layer 'opengever.core.testing.ActivityLayer' \
-        --layer 'opengever.core.testing.BumblebeeLayer' \
-        --layer 'opengever.core.testing.MeetingLayer' \
-        --layer 'opengever.core.testing.OfficeatworkLayer' \
-        --layer 'opengever.core.testing.opengever:core:memory_db' \
-        --layer 'opengever.core.testing.opengever.core:functional:zserver' \
-        --layer 'opengever.core.testing.PrivateFolderLayer' \
-        --layer 'plonetheme.teamraum.testing.plonetheme.teamraum:functional' \
-        --layer 'zope.testrunner.layer.UnitTests' \
+        --layer '!opengever.core.testing.opengever.core:functional' \
+        --layer '!opengever.core.testing.opengever.core:integration' \
         $@
 input = inline:
     #!/bin/sh


### PR DESCRIPTION
Renaming the layer was simpler than I anticipated.

This way we do not need to manually muck around with the layers every time something is killed or added - only if something is provenly too slow (or now quick enough).