### PR TITLE
Refactor committee container tests.

### DIFF
--- a/opengever/meeting/tests/test_committee_container.py
+++ b/opengever/meeting/tests/test_committee_container.py
@@ -237,30 +237,3 @@ class TestCommitteesTab(IntegrationTestCase):
         self.assertEquals(self.meeting.model.get_url(),
                           last_meeting.get('href'))
         self.assertEquals(meeting.get_url(), next_meeting.get('href'))
-
-    @browsing
-    def test_visible_fields_in_forms(self, browser):
-        """Some fields should only be displayed when the word feature is
-        disabled.
-        Therefore we test the appearance of all fields.
-        """
-        fields = ['Title',
-                  'Protocol header template',
-                  'Protocol suffix template',
-                  'Agenda item header template for the protocol',
-                  'Agenda item suffix template for the protocol',
-                  'Excerpt header template',
-                  'Excerpt suffix template',
-                  'Agendaitem list template',
-                  'Table of contents template',
-                  'Ad hoc agenda item template',
-                  'Paragraph template']
-
-        self.login(self.manager, browser)
-
-        browser.open()
-        factoriesmenu.add('Committee Container')
-        self.assertEquals(fields, browser.css('form#form > div.field > label').text)
-
-        browser.open(self.committee_container, view='edit')
-        self.assertEquals(fields, browser.css('form#form > div.field > label').text)

--- a/opengever/meeting/tests/test_committee_container.py
+++ b/opengever/meeting/tests/test_committee_container.py
@@ -110,11 +110,7 @@ class TestCommitteeContainer(IntegrationTestCase):
                          browser.context.get_excerpt_suffix_template())
 
     @browsing
-    def test_visible_fields_in_forms(self, browser):
-        """Some fields should only be displayed when the word feature is
-        enabled.
-        Therefore we test the appearance of all fields.
-        """
+    def test_visible_fields_order_in_form(self, browser):
         fields = [u'Title',
                   u'Protocol header template',
                   u'Protocol suffix template',

--- a/opengever/meeting/tests/test_committee_container.py
+++ b/opengever/meeting/tests/test_committee_container.py
@@ -11,48 +11,6 @@ from opengever.testing import IntegrationTestCase
 from unittest import skip
 
 
-class TestCommitteeContainer(IntegrationTestCase):
-
-    features = ('meeting',)
-
-    @skip("This test currently fails in a flaky way on CI."
-          "See https://github.com/4teamwork/opengever.core/issues/3995")
-    @browsing
-    def test_supports_translated_title(self, browser):
-        self.login(self.manager, browser)
-        add_languages(['de-ch', 'fr-ch'])
-        browser.open()
-        factoriesmenu.add('Committee Container')
-        browser.fill({'Title (German)': u'Sitzungen',
-                      'Title (French)': u's\xe9ance',
-                      'Protocol template': self.sablon_template,
-                      'Excerpt template': self.sablon_template,
-                      'Table of contents template': self.sablon_template}).save()
-        statusmessages.assert_no_error_messages()
-
-        browser.find(u'Fran\xe7ais').click()
-        self.assertEquals(u's\xe9ance', browser.css('h1').first.text)
-
-        browser.find('Deutsch').click()
-        self.assertEquals(u'Sitzungen', browser.css('h1').first.text)
-
-    def test_get_toc_template(self):
-        self.login(self.manager)
-
-        self.assertIsNone(self.committee_container.toc_template)
-        self.assertIsNone(self.committee_container.get_toc_template())
-
-        self.committee_container.toc_template = self.as_relation_value(
-            self.sablon_template)
-
-        self.assertEqual(
-            self.sablon_template, self.committee_container.get_toc_template())
-
-    def test_portlets_inheritance_is_blocked(self):
-        self.login(self.manager)
-        self.assert_portlet_inheritance_blocked(
-            'plone.leftcolumn', self.committee_container)
-
 
 class TestCommitteesTab(IntegrationTestCase):
 

--- a/opengever/meeting/tests/test_committee_container_tabs.py
+++ b/opengever/meeting/tests/test_committee_container_tabs.py
@@ -3,16 +3,11 @@ from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
 from ftw.testbrowser.pages import editbar
-from ftw.testbrowser.pages import factoriesmenu
-from ftw.testbrowser.pages import statusmessages
 from opengever.base.date_time import utcnow_tz_aware
-from opengever.testing import add_languages
 from opengever.testing import IntegrationTestCase
-from unittest import skip
 
 
-
-class TestCommitteesTab(IntegrationTestCase):
+class TestCommitteeContainerCommitteeTab(IntegrationTestCase):
 
     features = ('meeting',)
 

--- a/opengever/meeting/tests/test_committee_container_word.py
+++ b/opengever/meeting/tests/test_committee_container_word.py
@@ -1,12 +1,52 @@
 from ftw.testbrowser import browsing
-from ftw.testbrowser.pages import statusmessages
-from opengever.testing import IntegrationTestCase
 from ftw.testbrowser.pages import factoriesmenu
+from ftw.testbrowser.pages import statusmessages
+from opengever.testing import add_languages
+from opengever.testing import IntegrationTestCase
+from unittest import skip
 
 
 class TestCommitteeContainer(IntegrationTestCase):
 
     features = ('meeting',)
+
+    @skip("This test currently fails in a flaky way on CI."
+          "See https://github.com/4teamwork/opengever.core/issues/3995")
+    @browsing
+    def test_supports_translated_title(self, browser):
+        self.login(self.manager, browser)
+        add_languages(['de-ch', 'fr-ch'])
+        browser.open()
+        factoriesmenu.add('Committee Container')
+        browser.fill({'Title (German)': u'Sitzungen',
+                      'Title (French)': u's\xe9ance',
+                      'Protocol template': self.sablon_template,
+                      'Excerpt template': self.sablon_template,
+                      'Table of contents template': self.sablon_template}).save()
+        statusmessages.assert_no_error_messages()
+
+        browser.find(u'Fran\xe7ais').click()
+        self.assertEquals(u's\xe9ance', browser.css('h1').first.text)
+
+        browser.find('Deutsch').click()
+        self.assertEquals(u'Sitzungen', browser.css('h1').first.text)
+
+    def test_get_toc_template(self):
+        self.login(self.manager)
+
+        self.assertIsNone(self.committee_container.toc_template)
+        self.assertIsNone(self.committee_container.get_toc_template())
+
+        self.committee_container.toc_template = self.as_relation_value(
+            self.sablon_template)
+
+        self.assertEqual(
+            self.sablon_template, self.committee_container.get_toc_template())
+
+    def test_portlets_inheritance_is_blocked(self):
+        self.login(self.manager)
+        self.assert_portlet_inheritance_blocked(
+            'plone.leftcolumn', self.committee_container)
 
     @browsing
     def test_can_configure_ad_hoc_template(self, browser):


### PR DESCRIPTION
Update naming, drop duplicated tests and split nicely into files as appropriate.

Part of https://github.com/4teamwork/opengever.core/issues/4399.

_Follow up of https://github.com/4teamwork/opengever.core/pull/4397. No separate CL entry necessary IMO._