### PR TITLE
Duplicate fr translations to fr-ch in vdex files

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2018.4.0 (unreleased)
 ---------------------
 
+- Add fr-ch translations to vdex files. [tarnap]
 - Implement recently touched menu that lists checked out documents and recently touched objects. [lgraf]
 - Sort the entries of the reference browser widget. [tarnap]
 - Drop non-word meeting feature. [deiferni]

--- a/opengever/document/vdexvocabs/document_types.vdex
+++ b/opengever/document/vdexvocabs/document_types.vdex
@@ -10,6 +10,7 @@
             <langstring language="de-ch">Antrag</langstring>
             <langstring language="de">Antrag</langstring>
             <langstring language="fr">Requête</langstring>
+            <langstring language="fr-ch">Requête</langstring>
         </caption>
     </term>
     <term>
@@ -19,6 +20,7 @@
             <langstring language="de-ch">Anfrage</langstring>
             <langstring language="de">Anfrage</langstring>
             <langstring language="fr">Demande</langstring>
+            <langstring language="fr-ch">Demande</langstring>
         </caption>
     </term>
     <term>
@@ -28,6 +30,7 @@
             <langstring language="de-ch">Bericht</langstring>
             <langstring language="de">Bericht</langstring>
             <langstring language="fr">Rapport</langstring>
+            <langstring language="fr-ch">Rapport</langstring>
         </caption>
     </term>
     <term>
@@ -37,6 +40,7 @@
             <langstring language="de">Offerte</langstring>
             <langstring language="de-ch">Offerte</langstring>
             <langstring language="fr">Offre</langstring>
+            <langstring language="fr-ch">Offre</langstring>
         </caption>
     </term>
     <term>
@@ -46,6 +50,7 @@
             <langstring language="de-ch">Protokoll</langstring>
             <langstring language="de">Protokoll</langstring>
             <langstring language="fr">Procès-verbal</langstring>
+            <langstring language="fr-ch">Procès-verbal</langstring>
         </caption>
     </term>
     <term>
@@ -55,6 +60,7 @@
             <langstring language="de-ch">Vertrag</langstring>
             <langstring language="de">Vertrag</langstring>
             <langstring language="fr">Contrat</langstring>
+            <langstring language="fr-ch">Contrat</langstring>
         </caption>
     </term>
     <term>
@@ -64,6 +70,7 @@
             <langstring language="de-ch">Weisung</langstring>
             <langstring language="de">Weisung</langstring>
             <langstring language="fr">Directive</langstring>
+            <langstring language="fr-ch">Directive</langstring>
         </caption>
     </term>
     <term>
@@ -73,6 +80,7 @@
             <langstring language="de-ch">Reglement</langstring>
             <langstring language="de">Reglement</langstring>
             <langstring language="fr">Règlement</langstring>
+            <langstring language="fr-ch">Règlement</langstring>
         </caption>
     </term>
 </vdex>

--- a/opengever/dossier/vdexvocabs/container_types.vdex
+++ b/opengever/dossier/vdexvocabs/container_types.vdex
@@ -10,6 +10,7 @@
             <langstring language="de-ch">Ordner</langstring>
             <langstring language="de">Ordner</langstring>
             <langstring language="fr">Classeur</langstring>
+            <langstring language="fr-ch">Classeur</langstring>
         </caption>
     </term>
     <term>
@@ -19,6 +20,7 @@
             <langstring language="de-ch">Schachtel</langstring>
             <langstring language="de">Schachtel</langstring>
             <langstring language="fr">Boîte</langstring>
+            <langstring language="fr-ch">Boîte</langstring>
         </caption>
     </term>
     <term>
@@ -28,6 +30,7 @@
             <langstring language="de-ch">Dossier</langstring>
             <langstring language="de">Dossier</langstring>
             <langstring language="fr">Dossier</langstring>
+            <langstring language="fr-ch">Dossier</langstring>
         </caption>
     </term>
 </vdex>

--- a/opengever/dossier/vdexvocabs/participation_roles.vdex
+++ b/opengever/dossier/vdexvocabs/participation_roles.vdex
@@ -10,6 +10,7 @@
             <langstring language="de-ch">Mitwirkung</langstring>
             <langstring language="de">Mitwirkung</langstring>
             <langstring language="fr">Participation</langstring>
+            <langstring language="fr-ch">Participation</langstring>
         </caption>
     </term>
     <term>
@@ -19,6 +20,7 @@
             <langstring language="de-ch">Schlusszeichnung</langstring>
             <langstring language="de">Schlusszeichnung</langstring>
             <langstring language="fr">Signature finale</langstring>
+            <langstring language="fr-ch">Signature finale</langstring>
         </caption>
     </term>
     <term>
@@ -28,6 +30,7 @@
             <langstring language="de-ch">Kenntnisnahme</langstring>
             <langstring language="de">Kenntnisnahme</langstring>
             <langstring language="fr">Prise de connaissance</langstring>
+            <langstring language="fr-ch">Prise de connaissance</langstring>
         </caption>
     </term>
 

--- a/opengever/dossier/vdexvocabs/type_prefixes.vdex
+++ b/opengever/dossier/vdexvocabs/type_prefixes.vdex
@@ -10,6 +10,7 @@
             <langstring language="de-ch">Amt</langstring>
             <langstring language="de">Amt</langstring>
             <langstring language="fr">Service</langstring>
+            <langstring language="fr-ch">Service</langstring>
         </caption>
     </term>
     <term>
@@ -19,6 +20,7 @@
             <langstring language="de-ch">Direktion</langstring>
             <langstring language="de">Direktion</langstring>
             <langstring language="fr">Direction</langstring>
+            <langstring language="fr-ch">Direction</langstring>
         </caption>
     </term>
     <term>
@@ -28,6 +30,7 @@
             <langstring language="de-ch">Personal</langstring>
             <langstring language="de">Personal</langstring>
             <langstring language="fr">Personnel</langstring>
+            <langstring language="fr-ch">Personnel</langstring>
         </caption>
     </term>
     <term>
@@ -37,6 +40,7 @@
             <langstring language="de-ch">Leitung</langstring>
             <langstring language="de">Leitung</langstring>
             <langstring language="fr">Administration</langstring>
+            <langstring language="fr-ch">Administration</langstring>
         </caption>
     </term>
     <term>
@@ -46,6 +50,7 @@
             <langstring language="de-ch">Regierungsrat</langstring>
             <langstring language="de">Regierungsrat</langstring>
             <langstring language="fr">Gouvernement</langstring>
+            <langstring language="fr-ch">Gouvernement</langstring>
         </caption>
     </term>
 </vdex>

--- a/opengever/journal/vdexvocabs/manual_journal_entry_categories.vdex
+++ b/opengever/journal/vdexvocabs/manual_journal_entry_categories.vdex
@@ -10,6 +10,7 @@
             <langstring language="de-ch">Telefongespräch</langstring>
             <langstring language="de">Telefongespräch</langstring>
             <langstring language="fr">Conversation téléphonique</langstring>
+            <langstring language="fr-ch">Conversation téléphonique</langstring>
         </caption>
     </term>
     <term>
@@ -19,6 +20,7 @@
             <langstring language="de-ch">Sitzung</langstring>
             <langstring language="de">Sitzung</langstring>
             <langstring language="fr">Séances</langstring>
+            <langstring language="fr-ch">Séances</langstring>
         </caption>
     </term>
     <term>
@@ -28,6 +30,7 @@
             <langstring language="de-ch">Information</langstring>
             <langstring language="de">Information</langstring>
             <langstring language="fr">Information</langstring>
+            <langstring language="fr-ch">Information</langstring>
         </caption>
     </term>
     <term>
@@ -37,6 +40,7 @@
             <langstring language="de-ch">Sonstiges</langstring>
             <langstring language="de">Sonstiges</langstring>
             <langstring language="fr">Divers</langstring>
+            <langstring language="fr-ch">Divers</langstring>
         </caption>
     </term>
 </vdex>

--- a/opengever/task/vdexvocabs/bidirectional_by_reference.vdex
+++ b/opengever/task/vdexvocabs/bidirectional_by_reference.vdex
@@ -10,6 +10,7 @@
             <langstring language="de-ch">Zur Stellungnahme</langstring>
             <langstring language="de">Zur Stellungnahme</langstring>
             <langstring language="fr">Pour prise de position</langstring>
+            <langstring language="fr-ch">Pour prise de position</langstring>
         </caption>
     </term>
 
@@ -20,6 +21,7 @@
             <langstring language="de">Zur Genehmigung</langstring>
             <langstring language="de-ch">Zur Genehmigung</langstring>
             <langstring language="fr">Pour accord</langstring>
+            <langstring language="fr-ch">Pour accord</langstring>
         </caption>
     </term>
 
@@ -30,6 +32,7 @@
             <langstring language="de-ch">Zur Prüfung / Korrektur</langstring>
             <langstring language="de">Zur Prüfung / Korrektur</langstring>
             <langstring language="fr">Pour contrôle / correction</langstring>
+            <langstring language="fr-ch">Pour contrôle / correction</langstring>
         </caption>
     </term>
 
@@ -40,6 +43,7 @@
             <langstring language="de-ch">Zum Bericht / Antrag</langstring>
             <langstring language="de">Zum Bericht / Antrag</langstring>
             <langstring language="fr">Pour rapport / demande</langstring>
+            <langstring language="fr-ch">Pour rapport / demande</langstring>
         </caption>
     </term>
 

--- a/opengever/task/vdexvocabs/unidirectional_by_reference.vdex
+++ b/opengever/task/vdexvocabs/unidirectional_by_reference.vdex
@@ -10,6 +10,7 @@
             <langstring language="de-ch">Zur Kenntnisnahme</langstring>
             <langstring language="de">Zur Kenntnisnahme</langstring>
             <langstring language="fr">Pour prendre connaissance</langstring>
+            <langstring language="fr-ch">Pour prendre connaissance</langstring>
         </caption>
     </term>
 

--- a/opengever/task/vdexvocabs/unidirectional_by_value.vdex
+++ b/opengever/task/vdexvocabs/unidirectional_by_value.vdex
@@ -10,6 +10,7 @@
             <langstring language="de-ch">Zur direkten Erledigung</langstring>
             <langstring language="de">Zur direkten Erledigung</langstring>
             <langstring language="fr">Pour réalisation immédiate</langstring>
+            <langstring language="fr-ch">Pour réalisation immédiate</langstring>
         </caption>
     </term>
 


### PR DESCRIPTION
![Fehlende Übersetzung](https://user-images.githubusercontent.com/1231822/40958097-549e7c46-6898-11e8-8f1c-0222753d47f7.png)

PHVS waren die ersten Kunden, bei denen die GEVER auf Französisch umgesetzt wurde, dann wurde `fr` gewählt:
https://github.com/4teamwork/opengever.phvs/blob/061cd37332c56a88f301b20a00e03a24835cbd72/opengever/phvs/profiles/default/portal_languages.xml#L4

Generell wird aber `fr-ch` verwendet (z.b. demo):
https://github.com/4teamwork/opengever.demo/blob/7678109ab712861d73b42d2ac2a29b3eae1aed37/opengever/demo/profiles/default/portal_languages.xml#L5

Daher die doppelten Einträge (analog de, de-ch)

See also #4403 