### PR TITLE
Add support for properties to get_persisted_value_for_field() helper

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2018.4.0 (unreleased)
 ---------------------
 
+- Add support for properties to get_persisted_value_for_field() helper. [lgraf]
 - Update ftw.mobilenavigation to fix Unicode error. [tarnap]
 - Fix sorting of deeply nester repository folders. [tarnap]
 - Add fr-ch translations to vdex files. [tarnap]

--- a/opengever/base/tests/test_default_values_for_types.py
+++ b/opengever/base/tests/test_default_values_for_types.py
@@ -40,6 +40,7 @@ REPOROOT_REQUIREDS = {
 REPOROOT_DEFAULTS = {}
 REPOROOT_FORM_DEFAULTS = {}
 REPOROOT_MISSING_VALUES = {
+    'title_fr': None,
     'valid_from': None,
     'valid_until': None,
     'version': None,
@@ -72,6 +73,7 @@ REPOFOLDER_MISSING_VALUES = {
     'location': None,
     'referenced_activity': None,
     'retention_period_annotation': None,
+    'title_fr': None,
     'valid_from': None,
     'valid_until': None,
 }
@@ -160,6 +162,7 @@ MAIL_DEFAULTS = {
     'public_trial': u'unchecked',
     'public_trial_statement': '',
     'receipt_date': FROZEN_TODAY,
+    'title': 'Lorem Ipsum',
 }
 MAIL_FORM_DEFAULTS = {}
 MAIL_MISSING_VALUES = {
@@ -630,6 +633,8 @@ class TestMailDefaults(TestDefaultsBase):
         persisted_values = get_persisted_values_for_obj(mail)
         expected = self.get_type_defaults()
 
+        expected['message'] = mail._message
+
         self.assertDictEqual(expected, persisted_values)
 
     def test_invoke_factory(self):
@@ -642,6 +647,8 @@ class TestMailDefaults(TestDefaultsBase):
 
         persisted_values = get_persisted_values_for_obj(mail)
         expected = self.get_type_defaults()
+
+        expected['message'] = mail._message
 
         self.assertDictEqual(expected, persisted_values)
 
@@ -657,6 +664,8 @@ class TestMailDefaults(TestDefaultsBase):
 
         persisted_values = get_persisted_values_for_obj(mail)
         expected = self.get_z3c_form_defaults()
+
+        expected['message'] = mail._message
 
         # XXX: Don't know why this happens
         expected['public_trial_statement'] = None


### PR DESCRIPTION
The `get_persisted_value_for_field()` helper function previously wasn't able to fetch persisted values for fields that were implemented as properties. This change adds support for also correctly looking up those values.

If we're dealing with attribute storage and a field's value can't be found in the instance dict, we need to check for a property in the class dict as a last resort before raising an `AttributeError`.