### PR TITLE
Add sortable_title indexer for repository folders

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2018.4.0 (unreleased)
 ---------------------
 
+- Fix sorting of deeply nester repository folders. [tarnap]
 - Add fr-ch translations to vdex files. [tarnap]
 - Document generation of policies in internal docs. [tarnap]
 - Implement recently touched menu that lists checked out documents and recently touched objects. [lgraf]

--- a/opengever/repository/configure.zcml
+++ b/opengever/repository/configure.zcml
@@ -28,6 +28,11 @@
       name="blocked_local_roles"
       />
 
+  <adapter
+      factory=".indexers.sortable_title"
+      name="sortable_title"
+      />
+
   <adapter factory=".repositoryfolder.NameFromTitle" />
 
   <adapter factory=".repositoryroot.RepositoryRootNameFromTitle" />

--- a/opengever/repository/indexers.py
+++ b/opengever/repository/indexers.py
@@ -1,6 +1,13 @@
 from Acquisition import aq_inner
 from opengever.repository.repositoryfolder import IRepositoryFolder
+from plone.i18n.normalizer.base import mapUnicode
 from plone.indexer import indexer
+from Products.CMFPlone.CatalogTool import MAX_SORTABLE_TITLE
+from Products.CMFPlone.CatalogTool import num_sort_regex
+from Products.CMFPlone.CatalogTool import zero_fill
+from Products.CMFPlone.utils import safe_callable
+from Products.CMFPlone.utils import safe_unicode
+import re
 
 
 @indexer(IRepositoryFolder)
@@ -17,3 +24,39 @@ def title_fr_indexer(obj):
 def blocked_local_roles(obj):
     """Return whether acquisition is blocked or not."""
     return bool(getattr(aq_inner(obj), '__ac_local_roles_block__', False))
+
+
+@indexer(IRepositoryFolder)
+def sortable_title(obj):
+    """Custom sortable_title indexer for RepositoryFolders.
+
+    This implementation doesn't count space needed for zero padded numbers
+    towards the maximum length. We need this for repofolders because otherwise
+    for deeply nested folders the reference numbers alone eat up all
+    the available space (40 characters).
+    """
+    title = getattr(obj, 'Title', None)
+    if title is not None:
+        if safe_callable(title):
+            title = title()
+
+        if isinstance(title, basestring):
+            # Ignore case, normalize accents, strip spaces
+            sortabletitle = mapUnicode(safe_unicode(title)).lower().strip()
+            # Replace numbers with zero filled numbers
+            sortabletitle = num_sort_regex.sub(zero_fill, sortabletitle)
+
+            # Determine the length of the sortable title
+            padded_numbers = re.findall(num_sort_regex, sortabletitle)
+            max_length = MAX_SORTABLE_TITLE + sum([
+                len(match) - len(match.lstrip('0'))
+                for match in padded_numbers
+            ])
+
+            # Truncate to prevent bloat, take bits from start and end
+            if len(sortabletitle) > max_length:
+                start = sortabletitle[:(max_length - 13)]
+                end = sortabletitle[-10:]
+                sortabletitle = start + '...' + end
+            return sortabletitle.encode('utf-8')
+    return ''

--- a/opengever/repository/tests/test_indexer.py
+++ b/opengever/repository/tests/test_indexer.py
@@ -1,10 +1,33 @@
+from ftw.builder import Builder
+from ftw.builder import create
 from opengever.testing import IntegrationTestCase
-from zope.event import notify
 from opengever.sharing.events import LocalRolesAcquisitionActivated
 from opengever.sharing.events import LocalRolesAcquisitionBlocked
+from opengever.repository.indexers import sortable_title
+from zope.event import notify
 
 
 class TestRepositoryFolderIndexers(IntegrationTestCase):
+
+    def test_sortable_title_index_ignores_refernce_number_length(self):
+        self.login(self.secretariat_user)
+
+        # create a 5 fold nested folder
+        repofolder = reduce(
+            lambda repofolder, level: create(
+                Builder('repository')
+                .within(repofolder)
+                .having(
+                    title_de=u'Vertr\xe4ge {}'.format(level),
+                    title_fr=u'Contrats {}'.format(level),
+                )),
+            range(5),
+            self.leaf_repofolder,
+        )
+
+        self.assertEquals(
+            '0001.0001.0001.0001.0001.0001.0001. vertrage 0004',
+            sortable_title(repofolder)())
 
     def test_blocked_local_roles(self):
         self.login(self.regular_user)


### PR DESCRIPTION
Deeply nested repository folder titles are bloated with padded zeroes.

```
(Pdb) self.context.Title
'1.1.1.5.1.1. Dienstzweig Abfallbewirtschaftung und Deponie (AD)'
from Products.CMFPlone.CatalogTool import sortable_title
(Pdb) sortable_title(self.context)()
'0001.0001.0001.0005.0001.00...ponie (ad)'
```

By registering a custom index for the repository folder, we can determine how the length of the sortable title varies.

The default `sortable_title` is barely reusable:
https://github.com/plone/Products.CMFPlone/blob/2df112f3a281f2799da4e37cc169809940db8a2f/Products/CMFPlone/CatalogTool.py#L183-L203
therefore a custom filter was implemented using the same logic.

Resolves #4398