### PR TITLE
Ensure default values get set by patching DX DefaultAddForm.create

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2018.4.0 (unreleased)
 ---------------------
 
+- Ensure default values get set by patching DX DefaultAddForm.create(). [lgraf]
 - Add support for properties to get_persisted_value_for_field() helper. [lgraf]
 - Update ftw.mobilenavigation to fix Unicode error. [tarnap]
 - Fix sorting of deeply nester repository folders. [tarnap]

--- a/opengever/base/default_values.py
+++ b/opengever/base/default_values.py
@@ -281,13 +281,16 @@ def set_default_values(content, container, values):
                  into consideration when determining whether defaults should
                  apply or not.
     """
+    # Canonicalize field names to short form (no prefix)
+    fields_with_value = [k.split('.')[-1] for k in values.keys()]
+
     for schema in iterSchemata(content):
         for name, field in getFieldsInOrder(schema):
 
             if field.readonly:
                 continue
 
-            if name in values:
+            if name in fields_with_value:
                 # Only set default if no *actual* value was supplied as
                 # an argument to object construction
                 continue

--- a/opengever/base/tests/test_default_values_for_types.py
+++ b/opengever/base/tests/test_default_values_for_types.py
@@ -25,15 +25,6 @@ FROZEN_TODAY = FROZEN_NOW.date()
 DEFAULT_TITLE = u'My title'
 DEFAULT_CLIENT = u'client1'
 
-OMITTED_FORM_FIELDS = [
-    'creators', 'predecessor', 'preview', 'archival_file_state',
-    'thumbnail', 'former_reference_number', 'reference_number',
-    'temporary_former_reference_number'
-]
-DISPLAY_MODE_FORM_FIELDS = [
-    'message_source', 'original_message',
-]
-
 REPOROOT_REQUIREDS = {
     'title_de': DEFAULT_TITLE,
 }
@@ -271,12 +262,6 @@ class TestDefaultsBase(FunctionalTestCase):
         defaults.update(self.type_defaults)
         defaults.update(self.form_defaults)
         defaults.update(self.requireds)
-
-        for key in OMITTED_FORM_FIELDS:
-            defaults.pop(key, None)
-
-        for key in DISPLAY_MODE_FORM_FIELDS:
-            defaults.pop(key, None)
 
         return defaults
 


### PR DESCRIPTION
Ensure default values get set by patching DX [`DefaultAddForm.create()`](https://github.com/plone/plone.dexterity/blob/2.2.8/plone/dexterity/browser/add.py#L47-L70):

Object construction in DX `DefaultAddForm.create()` previously wasn't covered by our default value patches. That means that there were still some cases where default or missing values weren't properly persisted on objects for content created via Z3C forms.

These cases are:
- Fields where the current user doesn't have write permission
  (these get [filtered out completely in `p.autoform.utils.processFields()`](https://github.com/plone/plone.autoform/blob/1.6.2/plone/autoform/utils.py#L189-L217))
- Fields that are omitted from the form
- Fields whose widgets are in `DISPLAY_MODE` even in AddForms.

In addition, I updated the `set_default_values()` helper function to canonicalize the names of the fields to their short form (without their `z3c.form` prefix) before checking whether a field already has a supplied *actual* value.

I also added tests that now check that the `test_default_values_for_types` tests now cover **every single field** for **every schema** of the types we test there.

This meta-test ensures that for every field, we expect either a **default value**, a **missing value** or an actual **value** to be persisted on the object after creation.