### PR TITLE
Examplecontent: Make sure meeting dossiers have a responsible.

### DIFF
--- a/opengever/examplecontent/meeting.py
+++ b/opengever/examplecontent/meeting.py
@@ -123,8 +123,10 @@ class MeetingExampleContentCreator(object):
             api.portal.get_localized_time(datetime=start))
 
         dossier = create(Builder('meeting_dossier')
-                         .having(title=u'Meeting {}'.format(
-                             api.portal.get_localized_time(start)),)
+                         .having(
+                             responsible=u'lukas.graf',
+                             title=u'Meeting {}'.format(
+                                 api.portal.get_localized_time(start)),)
                          .within(self.repository_folder_meeting_word))
         meeting = create(Builder('meeting')
                          .having(title=title,


### PR DESCRIPTION
The five meeting dossiers in our example content didn't have a value for the required `responsible` field yet.

This flared up when checking the [script to check for non-persisted fields](https://github.com/4teamwork/opengever.maintenance/pull/134) against a recent local development instance.

*(No changelog because it's an internal change only)*