### PR TITLE
Fix default value persistence edge case for title and description fields.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2018.4.0 (unreleased)
 ---------------------
 
+- Fix default value persistence for title and description fields. [lgraf]
 - Ensure default values get set by patching DX DefaultAddForm.create(). [lgraf]
 - Add support for properties to get_persisted_value_for_field() helper. [lgraf]
 - Update ftw.mobilenavigation to fix Unicode error. [tarnap]

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2018.4.0 (unreleased)
 ---------------------
 
+- Make proposal title defaultFactory more robust. [lgraf]
 - Fix default value persistence for title and description fields. [lgraf]
 - Ensure default values get set by patching DX DefaultAddForm.create(). [lgraf]
 - Add support for properties to get_persisted_value_for_field() helper. [lgraf]

--- a/opengever/base/monkey/patches/default_values.py
+++ b/opengever/base/monkey/patches/default_values.py
@@ -103,6 +103,7 @@ class PatchDXCreateContentInContainer(MonkeyPatch):
     """
 
     def __call__(self):
+        from opengever.base.default_values import inject_title_and_description_defaults  # noqa
         from opengever.base.default_values import set_default_values
         from plone.dexterity.interfaces import IDexterityFTI
         from plone.dexterity.utils import addContentToContainer
@@ -113,6 +114,11 @@ class PatchDXCreateContentInContainer(MonkeyPatch):
 
         def createContentWithDefaults(portal_type, container, **kw):
             fti = getUtility(IDexterityFTI, name=portal_type)
+
+            # Consider possible default values for title and description,
+            # and inject them into kw if necessary.
+            inject_title_and_description_defaults(kw, portal_type, container)
+
             content = createObject(fti.factory)
             set_default_values(content, container, kw)
 
@@ -152,6 +158,7 @@ class PatchInvokeFactory(MonkeyPatch):
     """
 
     def __call__(self):
+        from opengever.base.default_values import inject_title_and_description_defaults  # noqa
         from opengever.base.default_values import set_default_values
         from Products.CMFCore.utils import getToolByName
 
@@ -165,6 +172,10 @@ class PatchInvokeFactory(MonkeyPatch):
             if myType is not None:
                 if not myType.allowType( type_name ):
                     raise ValueError('Disallowed subobject type: %s' % type_name)
+
+            # Consider possible default values for title and description,
+            # and inject them into kw if necessary.
+            inject_title_and_description_defaults(kw, type_name, self)
 
             new_id = pt.constructContent(type_name, self, id, RESPONSE, *args, **kw)
             content = self[new_id]

--- a/opengever/meeting/proposal.py
+++ b/opengever/meeting/proposal.py
@@ -11,6 +11,7 @@ from opengever.base.source import DossierPathSourceBinder
 from opengever.base.source import SolrObjPathSourceBinder
 from opengever.base.utils import get_preferred_language_code
 from opengever.document.widgets.document_link import DocumentLinkWidget
+from opengever.dossier.behaviors.dossier import IDossierMarker
 from opengever.dossier.utils import get_containing_dossier
 from opengever.meeting import _
 from opengever.meeting.command import CopyProposalDocumentCommand
@@ -47,7 +48,14 @@ from zope.schema.interfaces import IContextAwareDefaultFactory
 
 @provider(IContextAwareDefaultFactory)
 def default_title(context):
-    return context.title
+    # At this point, only proposals (not submitted proposals) should acquire
+    # an actual default. This is indicated by the parent being a dossier.
+    if not IDossierMarker.providedBy(context):
+        return u''
+
+    # Use Title() accessor to make this defaultFactor robust in regard to
+    # objects with ITranslatedTitle behavior or titles stored in SQL
+    return context.Title().decode('utf-8')
 
 
 class IProposalModel(Interface):


### PR DESCRIPTION
This fixes an edge case for `title` or `description` fields with default values :

When a `title` or `description` field has a default(factory), there is one more pathological case where defaults weren't persisted correctly up until now:

The [constructor in `Products.CMFCore.PortalFolder.PortalFolderBase`](https://github.com/zopefoundation/Products.CMFCore/blob/ba14b57c0b3486a7bf5b60341ad97ead096b8f53/Products/CMFCore/PortalFolder.py#L71-L74) sets title and description specificially to the empty string if no **actual** field value was provided.

This then fools our own [`set_default_values()`](https://github.com/4teamwork/opengever.core/blob/master/opengever/base/default_values.py#L266-L310) which is called later: Because there already is a value persisted on the object for those fields, it doesn't attempt to determine and set default values. It has no way of knowing whether that empty string value was the value actually intended by the user, or the hardcoded value from the `PortalFolderBase` constructor.

We therefore treat these fields separately, and check if they have defaults **before** object construction. If so, and no **actual** value has been provided for the field in question, we inject the determined default into the `kw` dict, so that it then gets treated like it were a regular value.

---

This affected object construction for objects with a default for `title` or `descriptions`, constructed via `invokeFactory()` or `createContentInContainer()` - but not via `z3c.form` AddForms (because in add forms, the default values are pre-determined server side, and filled in as regular values into the client-side form).

---

One such case was the `title` field on the `Proposal` type: It defaults to the containing dossier's type. This PR therefore also contains a new default value test (which failed before this fix) for the Proposal type.