### PR TITLE
Add the new issuer field to a proposal

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -17,6 +17,7 @@ Changelog
 - Make proposal title defaultFactory more robust. [lgraf]
 - Fix default value persistence for title and description fields. [lgraf]
 - Ensure default values get set by patching DX DefaultAddForm.create(). [lgraf]
+- Add issuer-attribute to the proposal content-type. [elioschmutz]
 - Add support for properties to get_persisted_value_for_field() helper. [lgraf]
 - Update ftw.mobilenavigation to fix Unicode error. [tarnap]
 - Fix sorting of deeply nester repository folders. [tarnap]

--- a/opengever/base/tests/test_default_values_for_types.py
+++ b/opengever/base/tests/test_default_values_for_types.py
@@ -232,11 +232,15 @@ CONTACT_MISSING_VALUES = {
 
 
 PROPOSAL_REQUIREDS = {
+    'issuer': TEST_USER_ID,
 }
 PROPOSAL_DEFAULTS = {
     'title': u'Containing Dossier Title',
+    'issuer': TEST_USER_ID,
 }
-PROPOSAL_FORM_DEFAULTS = {}
+PROPOSAL_FORM_DEFAULTS = {
+    'issuer': TEST_USER_ID,
+}
 PROPOSAL_MISSING_VALUES = {
     'relatedItems': [],
     'predecessor_proposal': None,
@@ -911,6 +915,7 @@ class TestProposalDefaults(TestDefaultsBase):
         proposal = createContentInContainer(
             self.dossier,
             'opengever.meeting.proposal',
+            issuer=PROPOSAL_REQUIREDS['issuer'],
         )
 
         persisted_values = get_persisted_values_for_obj(proposal)
@@ -922,6 +927,7 @@ class TestProposalDefaults(TestDefaultsBase):
         new_id = self.dossier.invokeFactory(
             'opengever.meeting.proposal',
             'proposal-1',
+            issuer=PROPOSAL_REQUIREDS['issuer'],
         )
         proposal = self.dossier[new_id]
 

--- a/opengever/core/upgrades/20180620155146_rename_proposal_column_creator_to_issuer/upgrade.py
+++ b/opengever/core/upgrades/20180620155146_rename_proposal_column_creator_to_issuer/upgrade.py
@@ -1,0 +1,10 @@
+from opengever.core.upgrade import SchemaMigration
+
+
+class RenameProposalColumnCreatorToIssuer(SchemaMigration):
+    """Rename proposal column creator to issuer
+    """
+
+    def migrate(self):
+        self.op.alter_column('proposals', 'creator',
+                             new_column_name='issuer')

--- a/opengever/core/upgrades/20180620155221_migrate_proposal_creator_to_issuer/upgrade.py
+++ b/opengever/core/upgrades/20180620155221_migrate_proposal_creator_to_issuer/upgrade.py
@@ -1,0 +1,16 @@
+from ftw.upgrade import UpgradeStep
+
+
+class MigrateProposalCreatorToIssuer(UpgradeStep):
+    """Migrate proposal creator to issuer.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()
+        for proposal in self.objects(
+                {'portal_type': ['opengever.meeting.proposal',
+                                 'opengever.meeting.submittedproposal']},
+                'Migrate proposal creator to issuer'):
+
+            if not proposal.issuer:
+                proposal.issuer = proposal.Creator()

--- a/opengever/meeting/browser/documents/proposalstab.py
+++ b/opengever/meeting/browser/documents/proposalstab.py
@@ -8,6 +8,7 @@ from opengever.tabbedview import FilteredListingTab
 from opengever.tabbedview import SqlTableSource
 from opengever.tabbedview.filters import Filter
 from opengever.tabbedview.filters import FilterList
+from opengever.tabbedview.helper import linked_ogds_author
 from zope.component import adapter
 from zope.globalrequest import getRequest
 from zope.i18n import translate
@@ -114,6 +115,14 @@ class ProposalListingTab(FilteredListingTab):
              'sortable': True,
              'groupable': True,
              'width': 120},
+
+            {'column': 'issuer',
+             'column_title': _(u'label_issuer',
+                               default=u'Issuer'),
+             'transform': linked_ogds_author,
+             'sortable': True,
+             'groupable': True,
+             'width': 200},
 
         )
 

--- a/opengever/meeting/browser/resources/proposal.js
+++ b/opengever/meeting/browser/resources/proposal.js
@@ -2,7 +2,8 @@
 
   $(function() {
     if($(".template-add-membership, .template-opengever-meeting-proposal, .portaltype-opengever-meeting-proposal.template-edit").length) {
-      new SelectAutocomplete();
+      new SelectAutocomplete({
+          target: 'select#form-widgets-committee, select#form-widgets-language, select#form-widgets-member'});
     }
   });
 

--- a/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-06-06 13:41+0000\n"
+"POT-Creation-Date: 2018-06-13 13:35+0000\n"
 "PO-Revision-Date: 2017-10-23 18:40+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -606,7 +606,7 @@ msgid "empty_proposal"
 msgstr "Der Freitext darf nicht leer sein."
 
 #. Default: "Cannot change the state because the proposal contains checked out documents."
-#: ./opengever/meeting/browser/proposaltransitions.py
+#: ./opengever/meeting/proposal_transition_comment.py
 msgid "error_must_checkin_documents_for_transition"
 msgstr "Der Status kann nicht geändert werden solange der Antrag ausgecheckte Dokumente enthält."
 
@@ -966,6 +966,11 @@ msgstr "Einfügen"
 #: ./opengever/meeting/browser/templates/sablon_validation_state.pt
 msgid "label_invalid_sablon_template"
 msgstr "Gültigkeitsstatus"
+
+#. Default: "Issuer"
+#: ./opengever/meeting/proposal.py
+msgid "label_issuer"
+msgstr "Antragssteller"
 
 #. Default: "Last Meeting:"
 #: ./opengever/meeting/browser/templates/committee.pt

--- a/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
@@ -972,7 +972,7 @@ msgstr "Etat de validité"
 #. Default: "Issuer"
 #: ./opengever/meeting/proposal.py
 msgid "label_issuer"
-msgstr ""
+msgstr "Mandant"
 
 #. Default: "Last Meeting:"
 #: ./opengever/meeting/browser/templates/committee.pt

--- a/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-06-06 13:41+0000\n"
+"POT-Creation-Date: 2018-06-13 13:35+0000\n"
 "PO-Revision-Date: 2018-05-22 10:15+0000\n"
 "Last-Translator: Niklaus Johner <Niklaus.johner@4teamwork.ch>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-meeting/fr/>\n"
@@ -608,7 +608,7 @@ msgid "empty_proposal"
 msgstr "Ce texte libre ne doit pas être vide."
 
 #. Default: "Cannot change the state because the proposal contains checked out documents."
-#: ./opengever/meeting/browser/proposaltransitions.py
+#: ./opengever/meeting/proposal_transition_comment.py
 msgid "error_must_checkin_documents_for_transition"
 msgstr "L'état ne peut pas être changé tant que la proposition contient des documents qui ont été extraits."
 
@@ -968,6 +968,11 @@ msgstr "Insérer"
 #: ./opengever/meeting/browser/templates/sablon_validation_state.pt
 msgid "label_invalid_sablon_template"
 msgstr "Etat de validité"
+
+#. Default: "Issuer"
+#: ./opengever/meeting/proposal.py
+msgid "label_issuer"
+msgstr ""
 
 #. Default: "Last Meeting:"
 #: ./opengever/meeting/browser/templates/committee.pt

--- a/opengever/meeting/locales/opengever.meeting.pot
+++ b/opengever/meeting/locales/opengever.meeting.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-06-06 13:41+0000\n"
+"POT-Creation-Date: 2018-06-13 13:35+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -605,7 +605,7 @@ msgid "empty_proposal"
 msgstr ""
 
 #. Default: "Cannot change the state because the proposal contains checked out documents."
-#: ./opengever/meeting/browser/proposaltransitions.py
+#: ./opengever/meeting/proposal_transition_comment.py
 msgid "error_must_checkin_documents_for_transition"
 msgstr ""
 
@@ -964,6 +964,11 @@ msgstr ""
 #. Default: "Sablon template invalid"
 #: ./opengever/meeting/browser/templates/sablon_validation_state.pt
 msgid "label_invalid_sablon_template"
+msgstr ""
+
+#. Default: "Issuer"
+#: ./opengever/meeting/proposal.py
+msgid "label_issuer"
 msgstr ""
 
 #. Default: "Last Meeting:"

--- a/opengever/meeting/model/proposal.py
+++ b/opengever/meeting/model/proposal.py
@@ -99,7 +99,7 @@ class Proposal(Base):
     int_id = Column(Integer, nullable=False)
     oguid = composite(Oguid, admin_unit_id, int_id)
     physical_path = Column(UnicodeCoercingText, nullable=False)
-    creator = Column(String(USER_ID_LENGTH), nullable=False)
+    issuer = Column(String(USER_ID_LENGTH), nullable=False)
 
     title = Column(String(MAX_TITLE_LENGTH), index=True)
     submitted_title = Column(String(MAX_TITLE_LENGTH), index=True)

--- a/opengever/meeting/model/query.py
+++ b/opengever/meeting/model/query.py
@@ -60,8 +60,8 @@ class ProposalQuery(BaseQuery):
         return self.filter(Proposal.workflow_state.in_(
             [state.name for state in states]))
 
-    def by_creator(self, creator_id):
-        return self.filter(Proposal.creator == creator_id)
+    def by_issuer(self, issuer_id):
+        return self.filter(Proposal.issuer == issuer_id)
 
 
 Proposal.query_cls = ProposalQuery

--- a/opengever/meeting/proposal.py
+++ b/opengever/meeting/proposal.py
@@ -547,7 +547,7 @@ class Proposal(ProposalBase):
                          physical_path=aq_wrapped_self.get_physical_path(),
                          dossier_reference_number=reference_number,
                          repository_folder_title=repository_folder_title,
-                         creator=aq_wrapped_self.Creator()))
+                         issuer=self.issuer))
         return data
 
     def update_model(self, data):

--- a/opengever/meeting/proposal.py
+++ b/opengever/meeting/proposal.py
@@ -3,6 +3,7 @@ from Acquisition import aq_inner
 from Acquisition import aq_parent
 from collective import dexteritytextindexer
 from datetime import date
+from ftw.keywordwidget.widget import KeywordFieldWidget
 from opengever.base.command import CreateDocumentCommand
 from opengever.base.interfaces import IReferenceNumber
 from opengever.base.oguid import Oguid
@@ -23,12 +24,15 @@ from opengever.meeting.container import ModelContainer
 from opengever.meeting.interfaces import IHistory
 from opengever.meeting.model import SubmittedDocument
 from opengever.meeting.model.proposal import Proposal as ProposalModel
+from opengever.ogds.base.actor import Actor
+from opengever.ogds.base.sources import AssignedUsersSourceBinder
 from opengever.ogds.base.utils import get_current_admin_unit
 from opengever.ogds.base.utils import ogds_service
 from plone import api
 from plone.app.uuid.utils import uuidToObject
 from plone.autoform.directives import mode
 from plone.autoform.directives import omitted
+from plone.autoform.directives import widget
 from plone.supermodel import model
 from plone.uuid.interfaces import IUUID
 from Products.CMFPlone.utils import safe_unicode
@@ -109,6 +113,13 @@ class IProposal(model.Schema):
         required=False,
         )
 
+    widget('issuer', KeywordFieldWidget, async=True)
+    issuer = schema.Choice(
+        title=_(u"label_issuer", default="Issuer"),
+        source=AssignedUsersSourceBinder(),
+        required=True,
+    )
+
     mode(predecessor_proposal='hidden')
     predecessor_proposal = RelationChoice(
         title=u'Predecessor proposal',
@@ -168,6 +179,10 @@ class ProposalBase(ModelContainer):
 
             {'label': _('label_meeting', default=u'Meeting'),
              'value': model.get_meeting_link(),
+             'is_html': True},
+
+            {'label': _('label_issuer', default=u'Issuer'),
+             'value': Actor.lookup(self.issuer).get_label(),
              'is_html': True},
         ]
 
@@ -553,6 +568,7 @@ class Proposal(ProposalBase):
         proposal_model.dossier_reference_number = reference_number
         proposal_model.repository_folder_title = repository_folder_title
         proposal_model.title = self.title
+        proposal_model.issuer = self.issuer
         proposal_model.date_of_submission = self.date_of_submission
 
     def is_submit_additional_documents_allowed(self):

--- a/opengever/meeting/tests/test_proposal_listings.py
+++ b/opengever/meeting/tests/test_proposal_listings.py
@@ -214,10 +214,10 @@ class TestMyProposals(IntegrationTestCase):
     maxDiff = None
 
     @browsing
-    def test_lists_only_proposals_created_by_current_user(self, browser):
+    def test_lists_only_proposals_issued_by_the_current_user(self, browser):
         with self.login(self.dossier_responsible):
             userid = self.regular_user.getId()
-            self.draft_proposal.load_model().creator = userid
+            self.draft_proposal.load_model().issuer = userid
 
         self.login(self.regular_user, browser)
         browser.open(view='tabbedview_view-myproposals')

--- a/opengever/meeting/tests/test_proposal_listings.py
+++ b/opengever/meeting/tests/test_proposal_listings.py
@@ -1,6 +1,7 @@
 from copy import deepcopy
 from ftw.testbrowser import browsing
 from opengever.testing import IntegrationTestCase
+from copy import deepcopy
 
 
 SUBMITTED_PROPOSAL = {
@@ -9,7 +10,8 @@ SUBMITTED_PROPOSAL = {
     'State': 'Submitted',
     'Comittee': u'Rechnungspr\xfcfungskommission',
     'Title': u'Vertragsentwurf f\xfcr weitere Bearbeitung bewilligen',
-    'Date of submission': '31.08.2016'}
+    'Date of submission': '31.08.2016',
+    'Issuer': 'Ziegler Robert (robert.ziegler)'}
 
 DRAFT_PROPOSAL = {
      'Decision number': '',
@@ -17,7 +19,8 @@ DRAFT_PROPOSAL = {
      'State': 'Pending',
      'Comittee': u'Kommission f\xfcr Verkehr',
      'Title': u'Antrag f\xfcr Kreiselbau',
-     'Date of submission': ''}
+     'Date of submission': '',
+     'Issuer': 'Ziegler Robert (robert.ziegler)'}
 
 DECIDED_PROPOSAL = {
     'Decision number': '2016 / 1',
@@ -25,7 +28,8 @@ DECIDED_PROPOSAL = {
     'State': 'Decided',
     'Comittee': u'Rechnungspr\xfcfungskommission',
     'Title': u'Initialvertrag f\xfcr Bearbeitung',
-    'Date of submission': '31.08.2016'}
+    'Date of submission': '31.08.2016',
+    'Issuer': 'Ziegler Robert (robert.ziegler)'}
 
 SUBMITTED_WORD_PROPOSAL = {
     'Decision number': '',
@@ -33,7 +37,8 @@ SUBMITTED_WORD_PROPOSAL = {
     'State': 'Submitted',
     'Comittee': u'Rechnungspr\xfcfungskommission',
     'Title': u'\xc4nderungen am Personalreglement',
-    'Date of submission': '31.08.2016'}
+    'Date of submission': '31.08.2016',
+    'Issuer': 'Ziegler Robert (robert.ziegler)'}
 
 DRAFT_WORD_PROPOSAL = {
     'Decision number': '',
@@ -41,7 +46,8 @@ DRAFT_WORD_PROPOSAL = {
     'State': 'Pending',
     'Comittee': u'Kommission f\xfcr Verkehr',
     'Title': u'\xdcberarbeitung der GAV',
-    'Date of submission': ''}
+    'Date of submission': '',
+    'Issuer': 'Ziegler Robert (robert.ziegler)'}
 
 
 def proposals_table(browser):
@@ -82,30 +88,35 @@ class TestDossierProposalListing(IntegrationTestCase):
         self.assertEquals(
             [{u'Comit\xe9': u'Rechnungspr\xfcfungskommission',
               'Etat': 'Soumis',
+              'Mandant': 'Ziegler Robert (robert.ziegler)',
               u'Num\xe9ro de d\xe9cision': '',
               u'R\xe9union': '',
               'Soumis le': '31.08.2016',
               'Titre': u'Vertragsentwurf f\xfcr weitere Bearbeitung bewilligen'},
              {u'Comit\xe9': u'Kommission f\xfcr Verkehr',
               'Etat': 'En modification',
+              'Mandant': 'Ziegler Robert (robert.ziegler)',
               u'Num\xe9ro de d\xe9cision': '',
               u'R\xe9union': '',
               'Soumis le': '',
               'Titre': u'Antrag f\xfcr Kreiselbau'},
              {u'Comit\xe9': u'Rechnungspr\xfcfungskommission',
               'Etat': u'Cl\xf4tur\xe9',
+              'Mandant': 'Ziegler Robert (robert.ziegler)',
               u'Num\xe9ro de d\xe9cision': '2016 / 1',
               u'R\xe9union': u'8. Sitzung der Rechnungspr\xfcfungskommission',
               'Soumis le': '31.08.2016',
               'Titre': u'Initialvertrag f\xfcr Bearbeitung'},
              {u'Comit\xe9': u'Rechnungspr\xfcfungskommission',
               'Etat': 'Soumis',
+              'Mandant': 'Ziegler Robert (robert.ziegler)',
               u'Num\xe9ro de d\xe9cision': '',
               u'R\xe9union': '',
               'Soumis le': '31.08.2016',
               'Titre': u'\xc4nderungen am Personalreglement'},
              {u'Comit\xe9': u'Kommission f\xfcr Verkehr',
               'Etat': 'En modification',
+              'Mandant': 'Ziegler Robert (robert.ziegler)',
               u'Num\xe9ro de d\xe9cision': '',
               u'R\xe9union': '',
               'Soumis le': '',
@@ -215,13 +226,16 @@ class TestMyProposals(IntegrationTestCase):
 
     @browsing
     def test_lists_only_proposals_issued_by_the_current_user(self, browser):
+        REGULAR_USER_DRAFT_PROPOSAL = deepcopy(DRAFT_PROPOSAL)
+        REGULAR_USER_DRAFT_PROPOSAL['Issuer'] = u'B\xe4rfuss K\xe4thi (kathi.barfuss)'
+
         with self.login(self.dossier_responsible):
             userid = self.regular_user.getId()
             self.draft_proposal.load_model().issuer = userid
 
         self.login(self.regular_user, browser)
         browser.open(view='tabbedview_view-myproposals')
-        self.assertEquals([DRAFT_PROPOSAL], proposal_dicts(browser))
+        self.assertEquals([REGULAR_USER_DRAFT_PROPOSAL], proposal_dicts(browser))
 
     @browsing
     def test_listing_shows_active_proposals_by_default(self, browser):

--- a/opengever/meeting/tests/test_submitted_proposal.py
+++ b/opengever/meeting/tests/test_submitted_proposal.py
@@ -81,6 +81,7 @@ class TestSubmittedProposal(IntegrationTestCase):
              u'label_committee',
              u'label_dossier',
              u'label_meeting',
+             u'label_issuer',
              u'proposal_document',
              u'label_workflow_state',
              u'label_decision_number'],

--- a/opengever/tabbedview/browser/personal_overview.py
+++ b/opengever/tabbedview/browser/personal_overview.py
@@ -265,7 +265,7 @@ class IssuedTasks(GlobalTaskListingTab):
 class MyProposals(ProposalListingTab):
 
     def get_base_query(self):
-        return Proposal.query.by_creator(api.user.get_current().getId())
+        return Proposal.query.by_issuer(api.user.get_current().getId())
 
 
 class AllTasks(GlobalTaskListingTab):

--- a/opengever/testing/builders/dx.py
+++ b/opengever/testing/builders/dx.py
@@ -332,7 +332,8 @@ class ProposalBuilder(TransparentModelLoader, DexterityBuilder):
     def __init__(self, session):
         super(ProposalBuilder, self).__init__(session)
         self.arguments = {'title': 'Fooo',
-                          'language': TranslatedTitle.FALLBACK_LANGUAGE}
+                          'language': TranslatedTitle.FALLBACK_LANGUAGE,
+                          'issuer': TEST_USER_ID}
         self.model_arguments = None
         self._transition = None
         self._proposal_file_data = assets.load('empty.docx')
@@ -420,7 +421,7 @@ class SubmittedProposalBuilder(TransparentModelLoader, DexterityBuilder):
                           'workflow_state': 'invalid',
                           'dossier_reference_number': '123',
                           'repository_folder_title': 'repo',
-                          'creator': TEST_USER_ID}
+                          'issuer': TEST_USER_ID}
         self.model_arguments = None
 
     def before_create(self):
@@ -433,6 +434,7 @@ class SubmittedProposalBuilder(TransparentModelLoader, DexterityBuilder):
 
     def after_create(self, obj):
         self.model_arguments['submitted_oguid'] = Oguid.for_object(obj)
+        self.model_arguments['issuer'] = TEST_USER_ID
         model = obj.create_model(self.model_arguments, self.container)
         obj.sync_model(proposal_model=model)
         super(SubmittedProposalBuilder, self).after_create(obj)

--- a/opengever/testing/builders/sql.py
+++ b/opengever/testing/builders/sql.py
@@ -180,7 +180,7 @@ class ProposalModelBuilder(SqlObjectBuilder):
         self.arguments['dossier_reference_number'] = 'FD 1.2.3 / 1'
         self.arguments['language'] = 'en'
         self.arguments['repository_folder_title'] = 'Just a Repo-Folder'
-        self.arguments['creator'] = TEST_USER_ID
+        self.arguments['issuer'] = TEST_USER_ID
 
     def id(self, identifier):
         """Proposals have a composite primary key, admin_unit_id and int_id.

--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -878,6 +878,7 @@ class OpengeverContentFixture(object):
                 .having(
                     title=u'\xc4nderungen am Personalreglement',
                     committee=self.committee.load_model(),
+                    issuer=self.dossier_responsible.getId(),
                     )
                 .relate_to(self.document)
                 .with_proposal_file(assets.load('vertragsentwurf.docx'))

--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -826,6 +826,7 @@ class OpengeverContentFixture(object):
                 .having(
                     title=u'Vertragsentwurf f\xfcr weitere Bearbeitung bewilligen',
                     committee=self.committee.load_model(),
+                    issuer=self.dossier_responsible.getId(),
                     )
                 .relate_to(self.document)
                 .as_submitted()
@@ -852,6 +853,7 @@ class OpengeverContentFixture(object):
                 .having(
                     title=u'Antrag f\xfcr Kreiselbau',
                     committee=self.empty_committee.load_model(),
+                    issuer=self.dossier_responsible.getId(),
                     )
                 ))
 
@@ -861,6 +863,7 @@ class OpengeverContentFixture(object):
                 .having(
                     title=u'Initialvertrag f\xfcr Bearbeitung',
                     committee=self.committee.load_model(),
+                    issuer=self.dossier_responsible.getId(),
                     )
                 .as_submitted()
                 )
@@ -898,6 +901,7 @@ class OpengeverContentFixture(object):
                 .having(
                     title=u'\xdcberarbeitung der GAV',
                     committee=self.empty_committee.load_model(),
+                    issuer=self.dossier_responsible.getId(),
                     )
                 ))
 


### PR DESCRIPTION
closes #4412 

- Add attribute `issuer` to the proposal type
- migrate `creator` to `issuer`

See issue #4412 for more details about.

