### PR TITLE
Add missing proposal.js that was only added in upgrade.

### DIFF
--- a/opengever/core/profiles/default/jsregistry.xml
+++ b/opengever/core/profiles/default/jsregistry.xml
@@ -226,6 +226,17 @@
       cookable="True"
       expression=""
       enabled="True"
+      id="++resource++opengever.meeting/proposal.js"
+      inline="False"
+      insert-after="++resource++opengever.base/SelectAutocomplete.js"
+      />
+
+  <javascript
+      cacheable="True"
+      compression="safe"
+      cookable="True"
+      expression=""
+      enabled="True"
       id="++resource++opengever.base/base.js"
       inline="False"
       insert-after="++resource++ftw.keywordwidget/js/keywordwidget.js"


### PR DESCRIPTION
This PR adds a missing file to the js registry.

The JS file is responsible to make various dropdowns searchable, for example when adding proposals: 
![screen shot 2018-06-13 at 11 15 53](https://user-images.githubusercontent.com/736583/41341920-409dd58e-6efb-11e8-89a8-758dba87d798.png)
With its absence no JS errors are causes, but usability of the affected forms suffers.

In https://github.com/4teamwork/opengever.core/pull/4397 i have extracted some functionality into its own javascript file and added that file in an upgrade-step in https://github.com/4teamwork/opengever.core/pull/4397/files#diff-733441fdefe984bffebb71c8be1b9ef5R43. Unfortunately the file was not added to the default profile's `jsregistry.xml`. Sorry about that 🙈.
