### PR TITLE
Include Dossier Doc-Properties for Documents inside Proposals and Tasks

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -591,6 +591,7 @@ Objects
           - self.mail
           - self.mail_msg
           - self.proposal
+            - self.proposaldocument
           - self.subdossier
             - self.subdocument
           - self.subdossier2

--- a/opengever/api/tests/test_serializer.py
+++ b/opengever/api/tests/test_serializer.py
@@ -68,4 +68,4 @@ class TestDocumentSerializer(IntegrationTestCase):
         self.login(self.regular_user, browser)
         browser.open(self.mail, headers={'Accept': 'application/json'})
         self.assertEqual(browser.status_code, 200)
-        self.assertEqual(browser.json.get(u'reference_number'), u'Client1 1.1 / 1 / 25')
+        self.assertEqual(browser.json.get(u'reference_number'), u'Client1 1.1 / 1 / 26')

--- a/opengever/bumblebee/tests/test_overlay_adapter_mail.py
+++ b/opengever/bumblebee/tests/test_overlay_adapter_mail.py
@@ -66,7 +66,7 @@ class TestGetOpenAsPdfLink(IntegrationTestCase):
 
         expected_url = (
             'http://nohost/plone/ordnungssystem/fuhrung'
-            '/vertrage-und-vereinbarungen/dossier-1/document-25'
+            '/vertrage-und-vereinbarungen/dossier-1/document-26'
             '/bumblebee-open-pdf?filename=die-burgschaft.pdf'
             )
 
@@ -79,7 +79,7 @@ class TestGetOpenAsPdfLink(IntegrationTestCase):
 
         expected_url = (
             u'http://nohost/plone/ordnungssystem/fuhrung'
-            u'/vertrage-und-vereinbarungen/dossier-1/document-25'
+            u'/vertrage-und-vereinbarungen/dossier-1/document-26'
             u'/bumblebee-open-pdf?filename=GEVER%20-%20%C3%9Cbernahme.pdf'
             )
 

--- a/opengever/document/tests/test_bumblebee.py
+++ b/opengever/document/tests/test_bumblebee.py
@@ -119,7 +119,7 @@ class TestBumblebeeIntegrationWithEnabledFeature(IntegrationTestCase):
             'deferred': False,
             'url': (
                 '/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen'
-                '/dossier-1/dossier-2/document-22/bumblebee_trigger_storing'
+                '/dossier-1/dossier-2/document-23/bumblebee_trigger_storing'
                 ),
             }
 
@@ -163,7 +163,7 @@ class TestBumblebeeIntegrationWithEnabledFeature(IntegrationTestCase):
             'deferred': False,
             'url': (
                 '/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen'
-                '/dossier-1/dossier-2/document-22/bumblebee_trigger_storing'
+                '/dossier-1/dossier-2/document-23/bumblebee_trigger_storing'
                 ),
             }
 

--- a/opengever/dossier/docprops.py
+++ b/opengever/dossier/docprops.py
@@ -1,4 +1,3 @@
-from Acquisition import aq_parent
 from datetime import datetime
 from datetime import time
 from ooxml_docprops import is_supported_mimetype
@@ -327,7 +326,7 @@ class DefaultDocProperties(object):
 
     def get_properties(self, recipient_data=tuple()):
         document = self.context
-        dossier = aq_parent(document)
+        dossier = document.get_parent_dossier()
         repofolder = self.get_repofolder(dossier)
         repo = self.get_repo(dossier)
         site = self.get_site(dossier)

--- a/opengever/dossier/tests/__init__.py
+++ b/opengever/dossier/tests/__init__.py
@@ -28,6 +28,7 @@ EXPECTED_USER_DOC_PROPERTIES = {
     'ogg.user.country': u'Schweiz',
 }
 
+
 OGDS_USER_ATTRIBUTES = {
     'firstname': u'Peter',
     'lastname': u'M\xfcller',
@@ -58,6 +59,7 @@ EXPECTED_DOSSIER_PROPERTIES = {
     'ogg.dossier.sequence_number': '1',
 }
 
+
 EXPECTED_DOCUMENT_PROPERTIES = {
     'Document.ReferenceNumber': 'Client1 1.1 / 1 / 10',
     'Document.SequenceNumber': '10',
@@ -72,9 +74,48 @@ EXPECTED_DOCUMENT_PROPERTIES = {
     'ogg.document.version_number': 0,
 }
 
+EXPECTED_TASKDOCUMENT_PROPERTIES = {
+    'Document.ReferenceNumber': 'Client1 1.1 / 1 / 11',
+    'Document.SequenceNumber': '11',
+    'ogg.document.title': u'Feedback zum Vertragsentwurf',
+    'ogg.document.reference_number': 'Client1 1.1 / 1 / 11',
+    'ogg.document.document_date': datetime(2016, 8, 31, 0, 0),
+    'ogg.document.sequence_number': '11',
+    'ogg.document.version_number': 0
+}
+
+EXPECTED_PROPOSALDOCUMENT_PROPERTIES = {
+    'Document.ReferenceNumber': 'Client1 1.1 / 1 / 15',
+    'Document.SequenceNumber': '15',
+    'ogg.document.title': u'Kommentar zum Vertragsentwurf',
+    'ogg.document.reference_number': 'Client1 1.1 / 1 / 15',
+    'ogg.document.document_date': datetime(2016, 8, 31, 0, 0),
+    'ogg.document.sequence_number': '15',
+    'ogg.document.version_number': 0
+}
+
+EXPECTED_MEETING_PROPERTIES = {
+    'ogg.meeting.agenda_item_number': '',
+    'ogg.meeting.decision_number': '',
+    'ogg.meeting.proposal_state': 'Submitted',
+    'ogg.meeting.proposal_title': 'Vertragsentwurf f\xc3\xbcr weitere Bearbeitung bewilligen'
+}
 
 EXPECTED_DOC_PROPERTIES = dict(
     EXPECTED_USER_DOC_PROPERTIES.items() +
     EXPECTED_DOSSIER_PROPERTIES.items() +
     EXPECTED_DOCUMENT_PROPERTIES.items()
+)
+
+EXPECTED_TASKDOC_PROPERTIES = dict(
+    EXPECTED_USER_DOC_PROPERTIES.items() +
+    EXPECTED_DOSSIER_PROPERTIES.items() +
+    EXPECTED_TASKDOCUMENT_PROPERTIES.items()
+)
+
+EXPECTED_PROPOSALDOC_PROPERTIES = dict(
+    EXPECTED_USER_DOC_PROPERTIES.items() +
+    EXPECTED_DOSSIER_PROPERTIES.items() +
+    EXPECTED_MEETING_PROPERTIES.items() +
+    EXPECTED_PROPOSALDOCUMENT_PROPERTIES.items()
 )

--- a/opengever/dossier/tests/test_default_doc_property_adapters.py
+++ b/opengever/dossier/tests/test_default_doc_property_adapters.py
@@ -3,6 +3,8 @@ from opengever.dossier.interfaces import IDocPropertyProvider
 from opengever.dossier.tests import EXPECTED_DOC_PROPERTIES
 from opengever.dossier.tests import EXPECTED_DOCUMENT_PROPERTIES
 from opengever.dossier.tests import EXPECTED_DOSSIER_PROPERTIES
+from opengever.dossier.tests import EXPECTED_PROPOSALDOC_PROPERTIES
+from opengever.dossier.tests import EXPECTED_TASKDOC_PROPERTIES
 from opengever.dossier.tests import EXPECTED_USER_DOC_PROPERTIES
 from opengever.testing import IntegrationTestCase
 from zope.component import getAdapter
@@ -20,6 +22,24 @@ class TestDocProperties(IntegrationTestCase):
             (self.document, self.portal.REQUEST), IDocProperties)
         all_properties = docprops.get_properties()
         self.assertEqual(EXPECTED_DOC_PROPERTIES, all_properties)
+
+    def test_default_doc_properties_adapter_for_taskdocument(self):
+        self.login(self.regular_user)
+
+        docprops = getMultiAdapter(
+            (self.taskdocument, self.portal.REQUEST), IDocProperties)
+
+        all_properties = docprops.get_properties()
+        self.assertEqual(EXPECTED_TASKDOC_PROPERTIES, all_properties)
+
+    def test_default_doc_properties_adapter_for_proposaldocument(self):
+        self.login(self.regular_user)
+
+        docprops = getMultiAdapter(
+            (self.proposaldocument, self.portal.REQUEST), IDocProperties)
+
+        all_properties = docprops.get_properties()
+        self.assertEqual(EXPECTED_PROPOSALDOC_PROPERTIES, all_properties)
 
     def test_default_document_doc_properties_provider(self):
         self.login(self.regular_user)

--- a/opengever/dossier/tests/test_documents_tab.py
+++ b/opengever/dossier/tests/test_documents_tab.py
@@ -32,7 +32,7 @@ class TestDocumentsTab(IntegrationTestCase):
 
         expected_url = (
             'http://nohost/plone/ordnungssystem/fuhrung'
-            '/vertrage-und-vereinbarungen/dossier-1/dossier-2/document-22'
+            '/vertrage-und-vereinbarungen/dossier-1/dossier-2/document-23'
             )
 
         self.assertEqual(expected_url, items.first.get('href'))

--- a/opengever/dossier/tests/test_overview.py
+++ b/opengever/dossier/tests/test_overview.py
@@ -26,7 +26,7 @@ class TestOverview(IntegrationTestCase):
 
     @property
     def tested_document(self):
-        return self.document
+        return self.taskdocument
 
     @property
     def tested_task(self):

--- a/opengever/dossier/tests/test_templatefolder.py
+++ b/opengever/dossier/tests/test_templatefolder.py
@@ -196,15 +196,15 @@ class TestDocumentWithTemplateFormWithDocProperties(IntegrationTestCase):
         self.assertEquals(u'test-docx.docx', document.file.filename)
 
         expected_doc_properties = {
-            'Document.ReferenceNumber': 'Client1 1.1 / 1 / 31',
-            'Document.SequenceNumber': '31',
+            'Document.ReferenceNumber': 'Client1 1.1 / 1 / 32',
+            'Document.SequenceNumber': '32',
             'Dossier.ReferenceNumber': 'Client1 1.1 / 1',
             'Dossier.Title': u'Vertr\xe4ge mit der kantonalen Finanzverwaltung',
             'User.FullName': u'B\xe4rfuss K\xe4thi',
             'User.ID': 'kathi.barfuss',
             'ogg.document.document_date': datetime(2020, 9, 28, 0, 0),
-            'ogg.document.reference_number': 'Client1 1.1 / 1 / 31',
-            'ogg.document.sequence_number': '31',
+            'ogg.document.reference_number': 'Client1 1.1 / 1 / 32',
+            'ogg.document.sequence_number': '32',
             'ogg.document.title': 'Test Docx',
             'ogg.document.version_number': 0,
             'ogg.dossier.reference_number': 'Client1 1.1 / 1',
@@ -254,15 +254,15 @@ class TestDocumentWithTemplateFormWithDocProperties(IntegrationTestCase):
         self.assertEquals(u'test-docx.docx', document.file.filename)
 
         expected_doc_properties = {
-            'Document.ReferenceNumber': 'Client1 1.1 / 1 / 31',
-            'Document.SequenceNumber': '31',
+            'Document.ReferenceNumber': 'Client1 1.1 / 1 / 32',
+            'Document.SequenceNumber': '32',
             'Dossier.ReferenceNumber': 'Client1 1.1 / 1',
             'Dossier.Title': u'Vertr\xe4ge mit der kantonalen Finanzverwaltung',
             'User.FullName': u'B\xe4rfuss K\xe4thi',
             'User.ID': 'kathi.barfuss',
             'ogg.document.document_date': datetime(2020, 10, 28, 0, 0),
-            'ogg.document.reference_number': 'Client1 1.1 / 1 / 31',
-            'ogg.document.sequence_number': '31',
+            'ogg.document.reference_number': 'Client1 1.1 / 1 / 32',
+            'ogg.document.sequence_number': '32',
             'ogg.document.title': 'Test Docx',
             'ogg.document.version_number': 0,
             'ogg.dossier.reference_number': 'Client1 1.1 / 1',

--- a/opengever/mail/tests/test_indexers.py
+++ b/opengever/mail/tests/test_indexers.py
@@ -47,4 +47,4 @@ class TestMailIndexers(IntegrationTestCase):
             u'IDocumentSchema',
             )
 
-        self.assertEquals('Client1 1.1 / 1 / 25 25', extender())
+        self.assertEquals('Client1 1.1 / 1 / 26 26', extender())

--- a/opengever/meeting/tests/test_meeting_zipexport.py
+++ b/opengever/meeting/tests/test_meeting_zipexport.py
@@ -156,14 +156,14 @@ class TestMeetingZipExportView(IntegrationTestCase):
                 'attachments': [{
                     'checksum': '51d6317494eccc4a73154625a6820cb6b50dc1455eb4cf26399299d4f9ce77b2',
                     'file': u'2. Anderungen am Personalreglement/Vertragsentwurf.docx',
-                    'modified': u'2016-08-31T15:21:46+02:00',
+                    'modified': u'2016-08-31T15:23:46+02:00',
                     'title': u'Vertr\xe4gsentwurf',
                 }],
                 'number': '2.',
                 'proposal': {
                     'checksum': 'e00d6c8fb32c30d3ca3a3f8e5d873565482567561023016d9ca18243ff1cfa14',
                     'file': u'2. Anderungen am Personalreglement/Anderungen am Personalreglement.docx',
-                    'modified': u'2016-08-31T15:21:44+02:00',
+                    'modified': u'2016-08-31T15:23:44+02:00',
                 },
                 'title': u'\xc4nderungen am Personalreglement',
             }],
@@ -216,13 +216,13 @@ class TestMeetingZipExportView(IntegrationTestCase):
                     {'attachments': [{
                         'checksum': '51d6317494eccc4a73154625a6820cb6b50dc1455eb4cf26399299d4f9ce77b2',
                         'file': '2. Anderungen am Personalreglement/Vertragsentwurf.docx',
-                        'modified': '2016-08-31T15:21:46+02:00',
+                        'modified': '2016-08-31T15:23:46+02:00',
                         'title': u'Vertr\xe4gsentwurf'}],
                      'number': '2.',
                      'proposal': {
                          'checksum': 'e00d6c8fb32c30d3ca3a3f8e5d873565482567561023016d9ca18243ff1cfa14',
                          'file': '2. Anderungen am Personalreglement/Anderungen am Personalreglement.docx',
-                         'modified': '2016-08-31T15:21:44+02:00'
+                         'modified': '2016-08-31T15:23:44+02:00'
                      },
                      'title': u'\xc4nderungen am Personalreglement'}
                  ],

--- a/opengever/oneoffixx/tests/assets/oneoffixx_connect_xml.txt
+++ b/opengever/oneoffixx/tests/assets/oneoffixx_connect_xml.txt
@@ -14,15 +14,15 @@
         <Arguments>
           <Interface Name="OneGovGEVER">
             <Node Id="ogg.document.title">A doc</Node>
-            <Node Id="ogg.document.reference_number">Client1 1.1 / 1 / 31</Node>
-            <Node Id="ogg.document.sequence_number">31</Node>
+            <Node Id="ogg.document.reference_number">Client1 1.1 / 1 / 32</Node>
+            <Node Id="ogg.document.sequence_number">32</Node>
           </Interface>
         </Arguments>
       </Function>
       <Function name="MetaData" id="c364b495-7176-4ce2-9f7c-e71f302b8096">
         <Value key="ogg.document.title" type="string">A doc</Value>
-        <Value key="ogg.document.reference_number" type="string">Client1 1.1 / 1 / 31</Value>
-        <Value key="ogg.document.sequence_number" type="string">31</Value>
+        <Value key="ogg.document.reference_number" type="string">Client1 1.1 / 1 / 32</Value>
+        <Value key="ogg.document.sequence_number" type="string">32</Value>
       </Function>
       <Commands>
         <Command Name="DefaultProcess">

--- a/opengever/private/tests/test_reference_number.py
+++ b/opengever/private/tests/test_reference_number.py
@@ -138,7 +138,7 @@ class TestPrivateReferenceNumber(IntegrationTestCase):
         self.login(self.regular_user, browser)
         browser.open(self.private_document)
 
-        expected_reference_number = 'P Client1 kathi-barfuss / 1 / 29'
+        expected_reference_number = 'P Client1 kathi-barfuss / 1 / 30'
         found_reference_number = browser.css('.referenceNumber .value').text[0]
 
         self.assertEqual(found_reference_number, expected_reference_number)

--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -836,6 +836,16 @@ class OpengeverContentFixture(object):
                 proposal.load_model().submitted_physical_path.encode('utf-8'),
                 )
 
+            self.register('proposaldocument', create(
+                Builder('document')
+                .within(proposal)
+                .titled(u'Kommentar zum Vertragsentwurf')
+                .attach_file_containing(
+                    'Komentar text',
+                    u'vertr\xe4g sentwurf.docx',
+                    )
+                ))
+
             self.register('draft_proposal', create(
                 Builder('proposal')
                 .within(self.dossier)


### PR DESCRIPTION
properties from the `Dossier` were missing in the docproperties of documents inside `Task` and `Proposal` because we were getting the dossier with `aq_parent` instead of using `get_parent_dossier`.

I also added tests to make sure such documents contain the expected docproperties.

resolves #4410 