### PR TITLE
Make sure members folders (private roots) get persisted default values.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2018.4.0 (unreleased)
 ---------------------
 
+- Make sure members folders (private roots) get persisted default values. [lgraf]
 - Make proposal title defaultFactory more robust. [lgraf]
 - Fix default value persistence for title and description fields. [lgraf]
 - Ensure default values get set by patching DX DefaultAddForm.create(). [lgraf]

--- a/opengever/private/folder.py
+++ b/opengever/private/folder.py
@@ -1,3 +1,4 @@
+from opengever.base.default_values import set_default_values
 from opengever.ogds.base.actor import Actor
 from opengever.private.interfaces import IPrivateContainer
 from opengever.repository.repositoryfolder import IRepositoryFolderSchema
@@ -32,3 +33,8 @@ class PrivateFolder(Container):
         """
         api.user.grant_roles(username=self.getOwner().getId(), obj=self,
                              roles=PRIVATE_FOLDER_DEFAULT_ROLES)
+
+        # MembershipTool.createMemberarea() uses yet another way for content
+        # creation, that doesn't properly set default values. We therefore
+        # apply them here after creation.
+        set_default_values(self, self.aq_parent, {})


### PR DESCRIPTION
Make sure members folders (private roots) get persisted default values.

*(Discovered by running the script that checks for default value persistence)*