### PR TITLE
Bump integration test split count to 4

### DIFF
--- a/.ci_governor.yml
+++ b/.ci_governor.yml
@@ -2,4 +2,4 @@
 job_template: python
 weight:
   test-plone-4.3.x-functional.cfg: 3
-  test-plone-4.3.x-integration.cfg: 3
+  test-plone-4.3.x-integration.cfg: 4

--- a/test-plone-4.3.x-integration.cfg
+++ b/test-plone-4.3.x-integration.cfg
@@ -9,7 +9,7 @@ parts =
 jenkins_python = $PYTHON27
 
 [test-jenkins]
-test-command-no-coverage = bin/mtest --layer 'opengever.core.testing.opengever.core:integration' -j 3 $@
+test-command-no-coverage = bin/mtest --layer 'opengever.core.testing.opengever.core:integration' -j 4 $@
 input = inline:
     #!/bin/sh
     ${test-jenkins:pre-test}


### PR DESCRIPTION
We've arrived at a point we need to choose between congestion avoidance and porting tests to integration landing us any wallclock savings. I'm for the latter, thus the PR.

This is sparked by noticing the longest running tests can have been the integration tests on some branches pushed recently.