### PR TITLE
Meeting zip export shall hande mails

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -9,6 +9,7 @@ Changelog
 - Theme: Remove diazo rule that duplicated some JS scripts. [lgraf]
 - Fix an issue with excerpts title not being unicode. [deiferni]
 - Fix updating mail title via API. [phgross]
+- Fix exporting meetings with proposals with related mails. [tarnap]
 - Make protocol editable even if meeting is open. [njohner]
 - Include Dossier Doc-Properties for Documents inside Proposals and Tasks. [njohner]
 - Make sure members folders (private roots) get persisted default values. [lgraf]

--- a/opengever/meeting/browser/meetings/zipexport.py
+++ b/opengever/meeting/browser/meetings/zipexport.py
@@ -98,7 +98,7 @@ class MeetingZipExport(BrowserView):
                 continue
 
             path = agenda_item.get_document_filename_for_zip(document)
-            generator.add_file(path, document.file.open())
+            generator.add_file(path, document.get_file().open())
 
     def add_agenda_items_attachments(self, generator):
         for agenda_item in self.model.agenda_items:
@@ -107,7 +107,7 @@ class MeetingZipExport(BrowserView):
 
             for document in agenda_item.proposal.resolve_submitted_documents():
                 path = agenda_item.get_document_filename_for_zip(document)
-                generator.add_file(path, document.file.open())
+                generator.add_file(path, document.get_file().open())
 
     def get_agendaitem_list(self):
         if self.model.has_agendaitem_list_document():

--- a/opengever/meeting/model/agendaitem.py
+++ b/opengever/meeting/model/agendaitem.py
@@ -205,7 +205,7 @@ class AgendaItem(Base):
             self.number,
             safe_unicode(self.get_title()),
             safe_unicode(document.Title()),
-            os.path.splitext(document.file.filename)[1]))
+            os.path.splitext(document.get_file().filename)[1]))
 
     def get_proposal_link(self, include_icon=True):
         if not self.has_proposal:
@@ -392,7 +392,7 @@ class AgendaItem(Base):
         excerpt_document = MergeDocxExcerptCommand(
             context=meeting_dossier,
             agenda_item=self,
-            filename=source_document.file.filename,
+            filename=source_document.get_file().filename,
             title=title,
         ).execute()
 


### PR DESCRIPTION
`document.file` is not available in `OGMail`

Use `document.get_file()`, which is available on documents and mails.

@lukasgraf: I will squash the commits together after review.
I left the commit where I remove the test unsquashed to remind why the test didn't work as expected.

Resolves #4453 

Backport needed to: `2018.3-stable`