### PR TITLE
Open successor task when predecessor is skipped or closed.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2018.4.0 (unreleased)
 ---------------------
 
+- Open successor task when predecessor is skipped or closed. [njohner]
 - Make protocol editable even if meeting is open. [njohner]
 - Include Dossier Doc-Properties for Documents inside Proposals and Tasks. [njohner]
 - Make sure members folders (private roots) get persisted default values. [lgraf]

--- a/opengever/task/handlers.py
+++ b/opengever/task/handlers.py
@@ -95,7 +95,9 @@ def start_next_task(task, event):
     # todo also handle skipped tasks
     if event.action not in ['task-transition-open-resolved',
                             'task-transition-in-progress-resolved',
-                            'task-transition-in-progress-tested-and-closed']:
+                            'task-transition-in-progress-tested-and-closed',
+                            'task-transition-rejected-skipped',
+                            'task-transition-planned-skipped']:
         return
 
     if task.is_from_sequential_tasktemplate:

--- a/opengever/task/handlers.py
+++ b/opengever/task/handlers.py
@@ -94,7 +94,8 @@ def cancel_subtasks(task, event):
 def start_next_task(task, event):
     # todo also handle skipped tasks
     if event.action not in ['task-transition-open-resolved',
-                            'task-transition-in-progress-resolved']:
+                            'task-transition-in-progress-resolved',
+                            'task-transition-in-progress-tested-and-closed']:
         return
 
     if task.is_from_sequential_tasktemplate:

--- a/opengever/task/tests/test_sequential_task_process.py
+++ b/opengever/task/tests/test_sequential_task_process.py
@@ -39,6 +39,32 @@ class TestSequentialTaskProcess(IntegrationTestCase):
         self.assertEquals(
             'task-state-open', api.content.get_state(subtask2))
 
+    def test_starts_next_task_when_task_gets_closed(self):
+        self.login(self.regular_user)
+
+        # create subtask
+        subtask2 = create(Builder('task')
+                          .within(self.task)
+                          .having(responsible_client='fa',
+                                  responsible=self.regular_user.getId(),
+                                  issuer=self.dossier_responsible.getId(),
+                                  task_type='correction',
+                                  deadline=date(2016, 11, 1))
+                          .in_state('task-state-planned'))
+
+        self.set_workflow_state('task-state-in-progress', self.subtask)
+        alsoProvides(self.subtask, IFromSequentialTasktemplate)
+        alsoProvides(subtask2, IFromSequentialTasktemplate)
+        self.task.set_tasktemplate_order([self.subtask, subtask2])
+        self.subtask.task_type = 'direct-execution'
+        api.content.transition(
+            obj=self.subtask, transition='task-transition-in-progress-tested-and-closed')
+
+        self.assertEquals(
+            'task-state-tested-and-closed', api.content.get_state(self.subtask))
+        self.assertEquals(
+            'task-state-open', api.content.get_state(subtask2))
+
     def test_handles_already_opened_tasks(self):
         self.login(self.regular_user)
 


### PR DESCRIPTION
When a `Task` from a sequential task template gets closed or skipped, its successor is opened.

resolves #4459 