### PR TITLE
Fix updating mail title via API.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -8,6 +8,7 @@ Changelog
 - Open successor task when predecessor is skipped or closed. [njohner]
 - Theme: Remove diazo rule that duplicated some JS scripts. [lgraf]
 - Fix an issue with excerpts title not being unicode. [deiferni]
+- Fix updating mail title via API. [phgross]
 - Make protocol editable even if meeting is open. [njohner]
 - Include Dossier Doc-Properties for Documents inside Proposals and Tasks. [njohner]
 - Make sure members folders (private roots) get persisted default values. [lgraf]

--- a/opengever/api/mail.py
+++ b/opengever/api/mail.py
@@ -41,7 +41,11 @@ class DeserializeMailFromJson(DeserializeFromJson):
         context = super(DeserializeMailFromJson, self).__call__(
             validate_all=validate_all, data=data)
 
-        context._update_title_from_message_subject()
-        initialize_metadata(context, None)
-        initalize_title(context, None)
+        if 'message' in data:
+            if not data.get('title'):
+                context._update_title_from_message_subject()
+                initalize_title(context, None)
+
+            initialize_metadata(context, None)
+
         return context

--- a/opengever/api/tests/test_mail.py
+++ b/opengever/api/tests/test_mail.py
@@ -3,6 +3,7 @@ from ftw.testbrowser import browsing
 from opengever.testing import IntegrationTestCase
 from opengever.testing.assets import load
 import base64
+import json
 
 
 class TestCreateMail(IntegrationTestCase):
@@ -14,16 +15,21 @@ class TestCreateMail(IntegrationTestCase):
     def test_create_mail_from_msg_converts_to_eml(self, browser):
         self.login(self.regular_user, browser)
         msg = base64.b64encode(load('testmail.msg'))
-        browser.open(
-            self.dossier.absolute_url(),
-            data='{"@type": "ftw.mail.mail",'
-                 '"message": {"data": "%s", "encoding": "base64", '
-                 '"filename": "testmail.msg"}}' % msg,
-            method='POST',
-            headers={'Accept': 'application/json',
-                     'Content-Type': 'application/json'})
+
+        with self.observe_children(self.dossier) as children:
+            browser.open(
+                self.dossier.absolute_url(),
+                data='{"@type": "ftw.mail.mail",'
+                     '"message": {"data": "%s", "encoding": "base64", '
+                     '"filename": "testmail.msg"}}' % msg,
+                method='POST',
+                headers={'Accept': 'application/json',
+                         'Content-Type': 'application/json'})
+
         self.assertEqual(browser.status_code, 201)
-        mail = self.dossier.objectValues()[-1]
+        self.assertEqual(1, len(children.get('added')))
+
+        mail = children['added'].pop()
         self.assertEqual(mail.Title(), 'testmail')
         self.assertEqual(mail.message.filename, 'testmail.eml')
         self.assertIn('MIME-Version: 1.0', mail.message.data)
@@ -33,16 +39,78 @@ class TestCreateMail(IntegrationTestCase):
     def test_create_mail_from_eml(self, browser):
         self.login(self.regular_user, browser)
         msg = base64.b64encode(load('mail_with_one_mail_attachment.eml'))
-        browser.open(
-            self.dossier.absolute_url(),
-            data='{"@type": "ftw.mail.mail",'
-                 '"message": {"data": "%s", "encoding": "base64", '
-                 '"filename": "testmail.eml"}}' % msg,
-            method='POST',
-            headers={'Accept': 'application/json',
-                     'Content-Type': 'application/json'})
+
+        with self.observe_children(self.dossier) as children:
+            browser.open(
+                self.dossier.absolute_url(),
+                data='{"@type": "ftw.mail.mail",'
+                     '"message": {"data": "%s", "encoding": "base64", '
+                     '"filename": "testmail.eml"}}' % msg,
+                method='POST',
+                headers={'Accept': 'application/json',
+                         'Content-Type': 'application/json'})
+
+
         self.assertEqual(browser.status_code, 201)
-        mail = self.dossier.objectValues()[-1]
+        self.assertEqual(1, len(children.get('added')))
+
+        mail = children['added'].pop()
         self.assertEqual(mail.Title(), 'Äusseres Testmäil')
         self.assertEqual(mail.message.filename, 'ausseres-testmail.eml')
         self.assertEqual(mail.original_message, None)
+
+    @browsing
+    def test_uses_title_if_given(self, browser):
+        self.login(self.regular_user, browser)
+        msg = base64.b64encode(load('mail_with_one_mail_attachment.eml'))
+
+        with self.observe_children(self.dossier) as children:
+            browser.open(
+                self.dossier.absolute_url(),
+                data=json.dumps({"@type": "ftw.mail.mail",
+                                 "message": {"data": msg,
+                                             "encoding": "base64",
+                                             "filename": "testmail.eml"},
+                                 "title": "Separate title"}),
+                method='POST',
+                headers={'Accept': 'application/json',
+                         'Content-Type': 'application/json'})
+
+        self.assertEqual(browser.status_code, 201)
+        self.assertEqual(1, len(children.get('added')))
+
+        mail = children['added'].pop()
+        self.assertEqual(mail.Title(), 'Separate title')
+        self.assertEqual(mail.message.filename, 'separate-title.eml')
+        self.assertEqual(mail.original_message, None)
+
+
+class TestPatchMail(IntegrationTestCase):
+
+    @browsing
+    def test_updating_the_title(self, browser):
+        self.login(self.regular_user, browser)
+        browser.open(
+            self.mail.absolute_url(),
+            data=json.dumps({'title': u'New title'}),
+            method='PATCH',
+            headers={'Accept': 'application/json',
+                     'Content-Type': 'application/json'})
+
+        self.assertEqual(browser.status_code, 204)
+        self.assertEqual(self.mail.Title(), 'New title')
+        self.assertEqual(self.mail.title, u'New title')
+
+    @browsing
+    def test_updating_other_metadata(self, browser):
+        self.login(self.regular_user, browser)
+        browser.open(
+            self.mail.absolute_url(),
+            data=json.dumps({'description': u'Lorem ipsum'}),
+            method='PATCH',
+            headers={'Accept': 'application/json',
+                     'Content-Type': 'application/json'})
+
+        self.assertEqual(browser.status_code, 204)
+        self.assertEqual(self.mail.title, u'Die B\xfcrgschaft')
+        self.assertEqual(self.mail.description, 'Lorem ipsum')


### PR DESCRIPTION
Currently mail titles gets resetted to subject, when trying to update a mail via REST-API PATCH requests. It now only syncs the title from subject if a message object is part of the
parameters.

This fix makes it also possible to create a mail with a different title than the subject.

Closes #4456

Backport needed to: `2018.3-stable`