### PR TITLE
Add proposal notification roles

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2018.4.0 (unreleased)
 ---------------------
 
+- Add new notification roles for proposal activities. [elioschmutz]
 - Open successor task when predecessor is skipped or closed. [njohner]
 - Theme: Remove diazo rule that duplicated some JS scripts. [lgraf]
 - Fix an issue with excerpts title not being unicode. [deiferni]

--- a/opengever/activity/__init__.py
+++ b/opengever/activity/__init__.py
@@ -109,5 +109,19 @@ ACTIVITY_TRANSLATIONS = {
         'forwarding-transition-reassign-refused',
         default=u'Forwarding reassigned and refused'),
     'forwarding-transition-refuse': _(
-        'forwarding-transition-refuse', default=u'Forwarding refused')
+        'forwarding-transition-refuse', default=u'Forwarding refused'),
+    'proposal-transition-reject': _(
+        'proposal-transition-reject', default=u'Proposal rejected'),
+    'proposal-transition-schedule': _(
+        'proposal-transition-schedule', default=u'Proposal scheduled'),
+    'proposal-transition-decide': _(
+        'proposal-transition-decide', default=u'Proposal decided'),
+    'proposal-transition-submit': _(
+        'proposal-transition-submit', default=u'Proposal submitted'),
+    'proposal-commented': _('proposal-commented', default=u'Proposal commented'),
+    'proposal-attachment-updated': _('proposal-attachment-updated',
+                                     default=u'Attachment updated'),
+    'proposal-additional-documents-submitted': _(
+        'proposal-additional-documents-submitted',
+        default=u'Additional documents submitted'),
 }

--- a/opengever/activity/browser/settings.py
+++ b/opengever/activity/browser/settings.py
@@ -3,6 +3,8 @@ from opengever.activity import ACTIVITY_TRANSLATIONS
 from opengever.activity import notification_center
 from opengever.activity.model.settings import NotificationDefault
 from opengever.activity.model.settings import NotificationSetting
+from opengever.activity.roles import COMMITTEE_RESPONSIBLE_ROLE
+from opengever.activity.roles import PROPOSAL_ISSUER_ROLE
 from opengever.activity.roles import TASK_ISSUER_ROLE
 from opengever.activity.roles import TASK_RESPONSIBLE_ROLE
 from opengever.base.handlebars import prepare_handlebars_template
@@ -52,7 +54,20 @@ ACTIVITY_GROUPS = [
          'forwarding-transition-close',
          'forwarding-transition-reassign',
          'forwarding-transition-reassign-refused',
-         'forwarding-transition-refuse']}
+         'forwarding-transition-refuse'
+     ]},
+
+    {'id': 'proposal',
+     'roles': [PROPOSAL_ISSUER_ROLE, COMMITTEE_RESPONSIBLE_ROLE],
+     'activities': [
+         'proposal-transition-submit',
+         'proposal-transition-reject',
+         'proposal-transition-schedule',
+         'proposal-transition-decide',
+         'proposal-commented',
+         'proposal-attachment-updated',
+         'proposal-additional-documents-submitted',
+     ]},
 ]
 
 

--- a/opengever/activity/hooks.py
+++ b/opengever/activity/hooks.py
@@ -1,4 +1,6 @@
 from opengever.activity.model import NotificationDefault
+from opengever.activity.roles import COMMITTEE_RESPONSIBLE_ROLE
+from opengever.activity.roles import PROPOSAL_ISSUER_ROLE
 from opengever.activity.roles import TASK_ISSUER_ROLE
 from opengever.activity.roles import TASK_RESPONSIBLE_ROLE
 from opengever.base.model import create_session
@@ -63,6 +65,21 @@ DEFAULT_SETTINGS = [
      'badge_notification_roles': [TASK_RESPONSIBLE_ROLE, TASK_ISSUER_ROLE]},
     {'kind': 'forwarding-transition-refuse', 'mail_notification': False,
      'badge_notification_roles': [TASK_RESPONSIBLE_ROLE, TASK_ISSUER_ROLE]},
+    {'kind': 'proposal-transition-submit',
+     'badge_notification_roles': [COMMITTEE_RESPONSIBLE_ROLE]},
+    {'kind': 'proposal-transition-reject',
+     'badge_notification_roles': [PROPOSAL_ISSUER_ROLE]},
+    {'kind': 'proposal-transition-schedule',
+     'badge_notification_roles': [PROPOSAL_ISSUER_ROLE]},
+    {'kind': 'proposal-transition-decide',
+     'badge_notification_roles': [PROPOSAL_ISSUER_ROLE]},
+    {'kind': 'proposal-commented',
+     'badge_notification_roles': [PROPOSAL_ISSUER_ROLE,
+                                  COMMITTEE_RESPONSIBLE_ROLE]},
+    {'kind': 'proposal-attachment-updated',
+     'badge_notification_roles': [PROPOSAL_ISSUER_ROLE]},
+    {'kind': 'proposal-additional-documents-submitted',
+     'badge_notification_roles': [COMMITTEE_RESPONSIBLE_ROLE]},
 ]
 
 

--- a/opengever/activity/locales/de/LC_MESSAGES/opengever.activity.po
+++ b/opengever/activity/locales/de/LC_MESSAGES/opengever.activity.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-05-28 08:37+0000\n"
+"POT-Creation-Date: 2018-06-13 12:06+0000\n"
 "PO-Revision-Date: 2015-02-24 08:40+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -51,6 +51,11 @@ msgstr "Typ"
 #: ./opengever/activity/browser/listing.py
 msgid "column_title"
 msgstr "Titel"
+
+#. Default: "Committee responsible"
+#: ./opengever/activity/roles.py
+msgid "committee_responsible"
+msgstr "Gremium verantwortlicher"
 
 #. Default: "Created"
 #: ./opengever/activity/browser/listing.py
@@ -137,6 +142,11 @@ msgstr "Alle Benachrichtigungen"
 #: ./opengever/activity/center.py
 msgid "msg_error_not_notified"
 msgstr "Während dem Erzeugen der Benachrichtigung ist ein Fehler aufgetreten. Die Benachrichtigung wurde deshalb nicht oder nur zum Teil ausgelöst."
+
+#. Default: "Proposal issuer"
+#: ./opengever/activity/roles.py
+msgid "proposal_issuer"
+msgstr "Antragssteller"
 
 #. Default: "Records Manager"
 #: ./opengever/activity/roles.py

--- a/opengever/activity/locales/de/LC_MESSAGES/opengever.activity.po
+++ b/opengever/activity/locales/de/LC_MESSAGES/opengever.activity.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-06-13 12:06+0000\n"
+"POT-Creation-Date: 2018-06-21 09:46+0000\n"
 "PO-Revision-Date: 2015-02-24 08:40+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -142,6 +142,41 @@ msgstr "Alle Benachrichtigungen"
 #: ./opengever/activity/center.py
 msgid "msg_error_not_notified"
 msgstr "Während dem Erzeugen der Benachrichtigung ist ein Fehler aufgetreten. Die Benachrichtigung wurde deshalb nicht oder nur zum Teil ausgelöst."
+
+#. Default: "Additional documents submitted"
+#: ./opengever/activity/__init__.py
+msgid "proposal-additional-documents-submitted"
+msgstr "Zusätzliche Anhänge eingereicht"
+
+#. Default: "Attachment updated"
+#: ./opengever/activity/__init__.py
+msgid "proposal-attachment-updated"
+msgstr "Anhang aktualisiert"
+
+#. Default: "Proposal commented"
+#: ./opengever/activity/__init__.py
+msgid "proposal-commented"
+msgstr "Antrag kommentiert"
+
+#. Default: "Proposal decided"
+#: ./opengever/activity/__init__.py
+msgid "proposal-transition-decide"
+msgstr "Antrag beschlossen"
+
+#. Default: "Proposal rejected"
+#: ./opengever/activity/__init__.py
+msgid "proposal-transition-reject"
+msgstr "Antrag zurückgewiesen"
+
+#. Default: "Proposal scheduled"
+#: ./opengever/activity/__init__.py
+msgid "proposal-transition-schedule"
+msgstr "Antrag traktandiert"
+
+#. Default: "Proposal submitted"
+#: ./opengever/activity/__init__.py
+msgid "proposal-transition-submit"
+msgstr "Antrag eingereicht"
 
 #. Default: "Proposal issuer"
 #: ./opengever/activity/roles.py

--- a/opengever/activity/locales/fr/LC_MESSAGES/opengever.activity.po
+++ b/opengever/activity/locales/fr/LC_MESSAGES/opengever.activity.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-05-28 08:37+0000\n"
+"POT-Creation-Date: 2018-06-13 12:06+0000\n"
 "PO-Revision-Date: 2017-12-03 16:14+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-activity/fr/>\n"
@@ -53,6 +53,11 @@ msgstr "type"
 #: ./opengever/activity/browser/listing.py
 msgid "column_title"
 msgstr "Titre"
+
+#. Default: "Committee responsible"
+#: ./opengever/activity/roles.py
+msgid "committee_responsible"
+msgstr ""
 
 #. Default: "Created"
 #: ./opengever/activity/browser/listing.py
@@ -139,6 +144,11 @@ msgstr "Toutes les notifications"
 #: ./opengever/activity/center.py
 msgid "msg_error_not_notified"
 msgstr "Un problème a apparu pendant la création de la notification. La notification n’a pas pu être produite ou seulement partiellement."
+
+#. Default: "Proposal issuer"
+#: ./opengever/activity/roles.py
+msgid "proposal_issuer"
+msgstr ""
 
 #. Default: "Records Manager"
 #: ./opengever/activity/roles.py

--- a/opengever/activity/locales/fr/LC_MESSAGES/opengever.activity.po
+++ b/opengever/activity/locales/fr/LC_MESSAGES/opengever.activity.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-06-13 12:06+0000\n"
+"POT-Creation-Date: 2018-06-21 09:46+0000\n"
 "PO-Revision-Date: 2017-12-03 16:14+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-activity/fr/>\n"
@@ -144,6 +144,41 @@ msgstr "Toutes les notifications"
 #: ./opengever/activity/center.py
 msgid "msg_error_not_notified"
 msgstr "Un problème a apparu pendant la création de la notification. La notification n’a pas pu être produite ou seulement partiellement."
+
+#. Default: "Additional documents submitted"
+#: ./opengever/activity/__init__.py
+msgid "proposal-additional-documents-submitted"
+msgstr ""
+
+#. Default: "Attachment updated"
+#: ./opengever/activity/__init__.py
+msgid "proposal-attachment-updated"
+msgstr ""
+
+#. Default: "Proposal commented"
+#: ./opengever/activity/__init__.py
+msgid "proposal-commented"
+msgstr ""
+
+#. Default: "Proposal decided"
+#: ./opengever/activity/__init__.py
+msgid "proposal-transition-decide"
+msgstr ""
+
+#. Default: "Proposal rejected"
+#: ./opengever/activity/__init__.py
+msgid "proposal-transition-reject"
+msgstr ""
+
+#. Default: "Proposal scheduled"
+#: ./opengever/activity/__init__.py
+msgid "proposal-transition-schedule"
+msgstr ""
+
+#. Default: "Proposal submitted"
+#: ./opengever/activity/__init__.py
+msgid "proposal-transition-submit"
+msgstr ""
 
 #. Default: "Proposal issuer"
 #: ./opengever/activity/roles.py

--- a/opengever/activity/locales/opengever.activity.pot
+++ b/opengever/activity/locales/opengever.activity.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-06-13 12:06+0000\n"
+"POT-Creation-Date: 2018-06-21 09:46+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -141,6 +141,41 @@ msgstr ""
 #. Default: "A problem has occurred during the notification creation. Notification could not or only partially produced."
 #: ./opengever/activity/center.py
 msgid "msg_error_not_notified"
+msgstr ""
+
+#. Default: "Additional documents submitted"
+#: ./opengever/activity/__init__.py
+msgid "proposal-additional-documents-submitted"
+msgstr ""
+
+#. Default: "Attachment updated"
+#: ./opengever/activity/__init__.py
+msgid "proposal-attachment-updated"
+msgstr ""
+
+#. Default: "Proposal commented"
+#: ./opengever/activity/__init__.py
+msgid "proposal-commented"
+msgstr ""
+
+#. Default: "Proposal decided"
+#: ./opengever/activity/__init__.py
+msgid "proposal-transition-decide"
+msgstr ""
+
+#. Default: "Proposal rejected"
+#: ./opengever/activity/__init__.py
+msgid "proposal-transition-reject"
+msgstr ""
+
+#. Default: "Proposal scheduled"
+#: ./opengever/activity/__init__.py
+msgid "proposal-transition-schedule"
+msgstr ""
+
+#. Default: "Proposal submitted"
+#: ./opengever/activity/__init__.py
+msgid "proposal-transition-submit"
 msgstr ""
 
 #. Default: "Proposal issuer"

--- a/opengever/activity/locales/opengever.activity.pot
+++ b/opengever/activity/locales/opengever.activity.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-05-28 08:37+0000\n"
+"POT-Creation-Date: 2018-06-13 12:06+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -50,6 +50,11 @@ msgstr ""
 #. Default: "Title"
 #: ./opengever/activity/browser/listing.py
 msgid "column_title"
+msgstr ""
+
+#. Default: "Committee responsible"
+#: ./opengever/activity/roles.py
+msgid "committee_responsible"
 msgstr ""
 
 #. Default: "Created"
@@ -136,6 +141,11 @@ msgstr ""
 #. Default: "A problem has occurred during the notification creation. Notification could not or only partially produced."
 #: ./opengever/activity/center.py
 msgid "msg_error_not_notified"
+msgstr ""
+
+#. Default: "Proposal issuer"
+#: ./opengever/activity/roles.py
+msgid "proposal_issuer"
 msgstr ""
 
 #. Default: "Records Manager"

--- a/opengever/activity/roles.py
+++ b/opengever/activity/roles.py
@@ -9,7 +9,8 @@ TASK_OLD_RESPONSIBLE_ROLE = 'task_old_responsible'
 DISPOSITION_RECORDS_MANAGER_ROLE = 'records_manager'
 DISPOSITION_ARCHIVIST_ROLE = 'archivist'
 WATCHER_ROLE = 'regular_watcher'
-
+COMMITTEE_RESPONSIBLE_ROLE = 'committee_responsible'
+PROPOSAL_ISSUER_ROLE = 'proposal_issuer'
 
 _('task_issuer', default=u"Task issuer")
 _('task_responsible', default=u"Task responsible")
@@ -17,3 +18,5 @@ _('task_old_responsible', default=u"Task former responsible")
 _('records_manager', default=u"Records Manager")
 _('archivist', default=u"Archivist")
 _('regular_watcher', default=u"Watcher")
+_('proposal_issuer', default=u"Proposal issuer")
+_('committee_responsible', default=u"Committee responsible")

--- a/opengever/core/upgrades/20180620155648_add_meeting_notification_settings/upgrade.py
+++ b/opengever/core/upgrades/20180620155648_add_meeting_notification_settings/upgrade.py
@@ -1,0 +1,64 @@
+from opengever.activity.roles import COMMITTEE_RESPONSIBLE_ROLE
+from opengever.activity.roles import PROPOSAL_ISSUER_ROLE
+from opengever.core.upgrade import SchemaMigration
+from sqlalchemy.schema import Sequence
+from sqlalchemy.sql.expression import column
+from sqlalchemy.sql.expression import table
+import json
+
+
+DEFAULT_SETTINGS = [
+    {'kind': 'proposal-transition-submit',
+     'badge_notification_roles': [COMMITTEE_RESPONSIBLE_ROLE]},
+
+    {'kind': 'proposal-transition-reject',
+     'badge_notification_roles': [PROPOSAL_ISSUER_ROLE]},
+
+    {'kind': 'proposal-transition-schedule',
+     'badge_notification_roles': [PROPOSAL_ISSUER_ROLE]},
+
+    {'kind': 'proposal-transition-decide',
+     'badge_notification_roles': [PROPOSAL_ISSUER_ROLE]},
+
+    {'kind': 'proposal-commented',
+     'badge_notification_roles': [PROPOSAL_ISSUER_ROLE,
+                                  COMMITTEE_RESPONSIBLE_ROLE]},
+
+    {'kind': 'proposal-attachment-updated',
+     'badge_notification_roles': [PROPOSAL_ISSUER_ROLE]},
+
+    {'kind': 'proposal-additional-documents-submitted',
+     'badge_notification_roles': [COMMITTEE_RESPONSIBLE_ROLE]},
+]
+
+
+defaults_table = table(
+    "notification_defaults",
+    column("id"),
+    column("kind"),
+    column("badge_notification_roles"))
+
+
+class AddMeetingNotificationSettings(SchemaMigration):
+    """Add meeting notification settings.
+    """
+
+    def migrate(self):
+        self.insert_notification_defaults()
+
+    def insert_notification_defaults(self):
+        seq = Sequence('notification_defaults_id_seq')
+        for item in DEFAULT_SETTINGS:
+            setting = self.execute(defaults_table
+                                   .select()
+                                   .where(defaults_table.columns.kind == item.get('kind')))
+
+            if setting.rowcount:
+                # We don't want to reset already inserted settings
+                continue
+
+            self.execute(defaults_table
+                         .insert()
+                         .values(id=self.execute(seq),
+                                 kind=item['kind'],
+                                 badge_notification_roles=json.dumps(item['badge_notification_roles'])))


### PR DESCRIPTION
This PR adds the required roles to setup the proposal notification properly.

I had to already update the activity-settings to fix the tests. This means, the newly introduced activities and its roles are already listed within the personal-settings overview.

Closes #4413 