### PR TITLE
Fix bug when triggering a tasktemplatefolder with inbox as responsible.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ---------------------
 
 - Add new notification roles for proposal activities. [elioschmutz]
+- Fix triggering TaskTemplateFolders with inboxes as task responsibles. [njohner]
 - Open successor task when predecessor is skipped or closed. [njohner]
 - Theme: Remove diazo rule that duplicated some JS scripts. [lgraf]
 - Fix an issue with excerpts title not being unicode. [deiferni]


### PR DESCRIPTION
The problem is in how the string representing the user is treated in the forms used to choose a task responsible (`SelectResponsiblesWizardStep`). When representing a user it has the form `orgunit:user_id` and for the inbox `inbox:orgunit`.

This is fixed here with conditionals, as it is in several other places in the code. In the future, this should all be delegated to the actor. 
resolves #4458