### PR TITLE
Put comments as well in the title attribute

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -8,6 +8,7 @@ Changelog
 - Indicate change of responsible in response when task is rejected. [njohner]
 - Add MS publisher to the list of OfficeConnector editables. [tarnap]
 - Add csv, wav, wmf and xml to the mimetypes for file icons. [tarnap]
+- Display the comment in a title attribute in case it gets truncated. [tarnap]
 - Add new notification roles for proposal activities. [elioschmutz]
 - Open successor task when predecessor is skipped or closed. [njohner]
 - Theme: Remove diazo rule that duplicated some JS scripts. [lgraf]

--- a/opengever/document/browser/versions_tab.py
+++ b/opengever/document/browser/versions_tab.py
@@ -10,6 +10,7 @@ from opengever.document import _
 from opengever.document.browser.download import DownloadConfirmationHelper
 from opengever.document.interfaces import ICheckinCheckoutManager
 from opengever.document.versioner import Versioner
+from opengever.journal.tab import tooltip_helper
 from opengever.ogds.base.actor import Actor
 from opengever.tabbedview import BaseListingTab
 from opengever.tabbedview import GeverTableSource
@@ -373,6 +374,7 @@ class VersionsTab(BaseListingTab):
 
         {'column': 'comment',
          'column_title': _(u'label_comment', default=u'Comment'),
+         'transform': tooltip_helper,
          },
 
         {'column': 'download_link',

--- a/opengever/document/browser/versions_tab.py
+++ b/opengever/document/browser/versions_tab.py
@@ -375,6 +375,7 @@ class VersionsTab(BaseListingTab):
         {'column': 'comment',
          'column_title': _(u'label_comment', default=u'Comment'),
          'transform': tooltip_helper,
+         'sortable': False,
          },
 
         {'column': 'download_link',


### PR DESCRIPTION
Comments are truncated when they are too long.
A simple way to solve this without breaking the UI is to put the comment
as well in the title attribute of the DOM element containing the
truncated text.

This is already solved in the Journal tab.
The tooltip helper just strips all html tags from the text, probably to
prevent XSS.

I also removed the sortable option on the comment (shall I put this into its own commit or shall I keep the sort option?)

Resolves #4323 