### PR TITLE
Indicate responsible change when task is rejected.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2018.4.0 (unreleased)
 ---------------------
 
+- Indicate change of responsible in response when task is rejected. [njohner]
 - Add MS publisher to the list of OfficeConnector editables. [tarnap]
 - Add csv, wav, wmf and xml to the mimetypes for file icons. [tarnap]
 - Add new notification roles for proposal activities. [elioschmutz]

--- a/opengever/task/handlers.py
+++ b/opengever/task/handlers.py
@@ -79,7 +79,12 @@ def set_responsible_to_issuer_on_reject(task, event):
         notification_center().remove_watcher_from_resource(task.oguid, task.responsible, TASK_RESPONSIBLE_ROLE)
         notification_center().add_watcher_to_resource(task.oguid, task.issuer, TASK_ISSUER_ROLE)
         notification_center().add_watcher_to_resource(task.oguid, task.issuer, TASK_RESPONSIBLE_ROLE)
+        old_responsible = ITask(task).responsible
         task.responsible = task.issuer
+        IResponseContainer(task)[-1].add_change(
+            'responsible',
+            _(u"label_responsible", default=u"Responsible"),
+            old_responsible, ITask(task).responsible)
 
 
 def cancel_subtasks(task, event):

--- a/opengever/task/locales/de/LC_MESSAGES/opengever.task.po
+++ b/opengever/task/locales/de/LC_MESSAGES/opengever.task.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2018-05-28 06:31+0000\n"
+"POT-Creation-Date: 2018-06-26 14:31+0000\n"
 "PO-Revision-Date: 2015-02-17 18:41+0100\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -900,10 +900,10 @@ msgstr "Neu zugewiesen von ${responsible_old} an ${responsible_new} durch ${user
 msgid "transition_msg_refuse"
 msgstr "Abgelehnt durch ${user}"
 
-#. Default: "Rejected by ${user}"
+#. Default: "Rejected by ${old_responsible}. Task assigned to responsible ${new_responsible}"
 #: ./opengever/task/response_description.py
 msgid "transition_msg_reject"
-msgstr "Abgelehnt durch ${user}"
+msgstr "Abgelehnt durch ${old_responsible}. Aufgabe an Auftragnehmer ${new_responsible} zugewiesen."
 
 #. Default: "Reopened by ${user}"
 #: ./opengever/task/response_description.py

--- a/opengever/task/locales/fr/LC_MESSAGES/opengever.task.po
+++ b/opengever/task/locales/fr/LC_MESSAGES/opengever.task.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-05-28 06:31+0000\n"
+"POT-Creation-Date: 2018-06-26 14:31+0000\n"
 "PO-Revision-Date: 2017-12-03 11:47+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-task/fr/>\n"
@@ -902,10 +902,10 @@ msgstr "Attribué à nouveau de ${responsible_old} à ${responsible_new} par ${u
 msgid "transition_msg_refuse"
 msgstr "Refusé par ${user}"
 
-#. Default: "Rejected by ${user}"
+#. Default: "Rejected by ${old_responsible}. Task assigned to responsible ${new_responsible}"
 #: ./opengever/task/response_description.py
 msgid "transition_msg_reject"
-msgstr "Refusé par ${user}"
+msgstr "Refusé par ${old_responsible}. La tâche a été réattribuée au responsable ${new_responsible}"
 
 #. Default: "Reopened by ${user}"
 #: ./opengever/task/response_description.py

--- a/opengever/task/locales/opengever.task.pot
+++ b/opengever/task/locales/opengever.task.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2018-05-28 06:31+0000\n"
+"POT-Creation-Date: 2018-06-26 14:31+0000\n"
 "PO-Revision-Date: 2009-02-25 14:39+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -898,7 +898,7 @@ msgstr ""
 msgid "transition_msg_refuse"
 msgstr ""
 
-#. Default: "Rejected by ${user}"
+#. Default: "Rejected by ${old_responsible}. Task assigned to responsible ${new_responsible}"
 #: ./opengever/task/response_description.py
 msgid "transition_msg_reject"
 msgstr ""

--- a/opengever/task/response_description.py
+++ b/opengever/task/response_description.py
@@ -76,11 +76,21 @@ class Reject(ResponseDescription):
     css_class = 'refuse'
 
     def msg(self):
-        return _('transition_msg_reject', u'Rejected by ${user}',
+        return _('transition_msg_reject',
+                 u'Rejected by ${old_responsible}. Task assigned to responsible ${new_responsible}',
                  mapping=self._msg_mapping)
 
     def label(self):
         return _('transition_label_reject', u'Task rejected')
+
+    @property
+    def _msg_mapping(self):
+        mapping = super(Reject, self)._msg_mapping
+        change = self.response.get_change('responsible')
+        if change:
+            mapping['old_responsible'] = Actor.lookup(change.get('before')).get_link()
+            mapping['new_responsible'] = Actor.lookup(change.get('after')).get_link()
+        return mapping
 
 
 ResponseDescription.add_description(Reject)

--- a/opengever/task/tests/test_response_descriptions.py
+++ b/opengever/task/tests/test_response_descriptions.py
@@ -95,7 +95,7 @@ class TestResponseDescriptions(FunctionalTestCase):
         self.click_task_button(browser, 'refuse')
 
         self.assertEqual(
-            u'Rejected by M\xfcller Hans (test_user_1_)',
+            u'Rejected by M\xfcller Hans (test_user_1_). Task assigned to responsible M\xfcller Hans (test_user_1_)',
             self.get_latest_answer(browser))
 
     @browsing


### PR DESCRIPTION
In response message, we indicate the new task responsible when the task is rejected.

resolves #4460 