### PR TITLE
Improve "checkout and edit" buttons

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -11,6 +11,7 @@ Changelog
 - Fix a bug with modern emojis while rendering task responses. [deiferni]
 - Fix physical_path schema migration for oracle backends. [phgross]
 - Ensure creator sets get to the paster upon pasting content. [Rotonen]
+- Improve Checkout/Edit button labels. [njohner]
 - Indicate change of responsible in response when task is rejected. [njohner]
 - Also make active committee vocabularies sorted by title. [Rotonen]
 - Sort user groups. [Rotonen]

--- a/opengever/bumblebee/tests/test_overlay_view.py
+++ b/opengever/bumblebee/tests/test_overlay_view.py
@@ -191,7 +191,7 @@ class TestBumblebeeOverlayListing(IntegrationTestCase):
         self.assertEqual(
             [
                 'Edit metadata',
-                'Checkout and edit',
+                'Edit',
                 'Checkin without comment',
                 'Checkin with comment',
                 'Cancel checkout',
@@ -357,7 +357,7 @@ class TestBumblebeeOverlayDocument(IntegrationTestCase):
         self.assertEqual(
             [
                 'Edit metadata',
-                'Checkout and edit',
+                'Edit',
                 'Checkin without comment',
                 'Checkin with comment',
                 'Cancel checkout',

--- a/opengever/document/browser/actionbuttons.py
+++ b/opengever/document/browser/actionbuttons.py
@@ -119,6 +119,9 @@ class ActionButtonRendererMixin(object):
 
         return not self.is_checked_out_by_another_user()
 
+    def is_checked_out(self):
+        return self.context.is_checked_out()
+
     def is_checked_out_by_another_user(self):
         manager = queryMultiAdapter(
             (self.context, self.request), ICheckinCheckoutManager)

--- a/opengever/document/browser/templates/macros.pt
+++ b/opengever/document/browser/templates/macros.pt
@@ -24,6 +24,7 @@
 
         <tal:file tal:condition="context/has_file"
             tal:define="preview_supported view/is_preview_supported;
+            checked_out view/is_checked_out;
             checkout_and_edit_available view/is_checkout_and_edit_available;
             office_connector_editable view/is_office_connector_editable;
             copy_download_available view/is_download_copy_available;
@@ -35,37 +36,65 @@
             <tal:checkout_and_edit_enabled tal:condition="checkout_and_edit_available">
                 <tal:oc_editable tal:condition="office_connector_editable">
                     <tal:oc_checkout tal:condition="new_external_edit_enabled">
-                        <a tal:attributes="href string:javascript:officeConnectorCheckout('${context/absolute_url}/officeconnector_checkout_url');;;
-                                           data-document-url context/absolute_url"
-                            class="function-edit oc-checkout"
-                            href="#"
-                            i18n:translate="label_checkout_and_edit">
-                            Checkout and edit
-                        </a>
+                        <tal:checkedout tal:condition="checked_out">
+                            <a tal:attributes="href string:javascript:officeConnectorCheckout('${context/absolute_url}/officeconnector_checkout_url');;;
+                                               data-document-url context/absolute_url"
+                                class="function-edit oc-checkout"
+                                href="#"
+                                i18n:translate="label_edit">
+                                Edit
+                            </a>
+                        </tal:checkedout>
+                        <tal:notcheckedout tal:condition="not: checked_out">
+                            <a tal:attributes="href string:javascript:officeConnectorCheckout('${context/absolute_url}/officeconnector_checkout_url');;;
+                                               data-document-url context/absolute_url"
+                                class="function-edit oc-checkout"
+                                href="#"
+                                i18n:translate="label_checkout_and_edit">
+                                Checkout and edit
+                            </a>
+                        </tal:notcheckedout>
                     </tal:oc_checkout>
 
                     <tal:zem_checkout tal:condition="not: new_external_edit_enabled">
-                        <a tal:attributes="href string:${context/absolute_url}/editing_document?_authenticator=${context/@@authenticator/token}"
-                            class="function-edit"
-                            href="#"
-                            i18n:translate="label_checkout_and_edit">
-                            Checkout and edit
-                        </a>
+                        <tal:checkedout tal:condition="checked_out">
+                            <a tal:attributes="href string:${context/absolute_url}/editing_document?_authenticator=${context/@@authenticator/token}"
+                                class="function-edit"
+                                href="#"
+                                i18n:translate="label_edit">
+                                Edit
+                            </a>
+                        </tal:checkedout>
+                        <tal:notcheckedout tal:condition="not: checked_out">
+                            <a tal:attributes="href string:${context/absolute_url}/editing_document?_authenticator=${context/@@authenticator/token}"
+                                class="function-edit"
+                                href="#"
+                                i18n:translate="label_checkout_and_edit">
+                                Checkout and edit
+                            </a>
+                        </tal:notcheckedout>
                     </tal:zem_checkout>
                 </tal:oc_editable>
 
                 <tal:oc_uneditable tal:condition="not: office_connector_editable">
-                    <span class="fa-exclamation-triangle-after function-edit-inactive discreet" title="Office connector unsupported type" value="Checkout and edit"
-                    i18n:attributes="title oc_unsupported_message" i18n:translate="label_checkout_and_edit">
-                        Checkout and edit
-                    </span>
-
-                    <a tal:attributes="href string:${context/absolute_url}/@@checkout_documents?_authenticator=${context/@@authenticator/token}"
-                        class="function-edit"
-                        href="#"
-                        i18n:translate="label_checkout">
-                        Checkout
-                    </a>
+                    <tal:checkedout tal:condition="checked_out">
+                        <span class="fa-exclamation-triangle-after function-edit-inactive discreet" title="Office connector unsupported type" value="Edit"
+                        i18n:attributes="title oc_unsupported_message" i18n:translate="label_edit">
+                            Edit
+                        </span>
+                    </tal:checkedout>
+                    <tal:notcheckedout tal:condition="not: checked_out">
+                        <span class="fa-exclamation-triangle-after function-edit-inactive discreet" title="Office connector unsupported type" value="Checkout and edit"
+                        i18n:attributes="title oc_unsupported_message" i18n:translate="label_checkout_and_edit">
+                            Checkout and edit
+                        </span>
+                        <a tal:attributes="href string:${context/absolute_url}/@@checkout_documents?_authenticator=${context/@@authenticator/token}"
+                            class="function-edit"
+                            href="#"
+                            i18n:translate="label_checkout">
+                            Checkout
+                        </a>
+                    </tal:notcheckedout>
                 </tal:oc_uneditable>
             </tal:checkout_and_edit_enabled>
 

--- a/opengever/document/locales/de/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/de/LC_MESSAGES/opengever.document.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2018-04-06 06:16+0000\n"
+"POT-Creation-Date: 2018-06-27 08:29+0000\n"
 "PO-Revision-Date: 2017-10-13 14:27+0200\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -433,6 +433,11 @@ msgstr "Herunterladen"
 msgid "label_download_copy"
 msgstr "Kopie herunterladen"
 
+#. Default: "Edit"
+#: ./opengever/document/browser/templates/macros.pt
+msgid "label_edit"
+msgstr "Erneut Bearbeiten"
+
 #. Default: "File"
 #: ./opengever/document/browser/overview.py
 #: ./opengever/document/document.py
@@ -446,6 +451,7 @@ msgstr "Fremdzeichen"
 
 #. Default: "Keywords"
 #: ./opengever/document/behaviors/metadata.py
+#: ./opengever/document/browser/overview.py
 msgid "label_keywords"
 msgstr "Schlagwörter"
 

--- a/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-04-06 06:16+0000\n"
+"POT-Creation-Date: 2018-06-27 08:29+0000\n"
 "PO-Revision-Date: 2017-09-03 08:50+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-document/fr/>\n"
@@ -430,6 +430,11 @@ msgstr "Télécharger"
 msgid "label_download_copy"
 msgstr "Télécharger une copie"
 
+#. Default: "Edit"
+#: ./opengever/document/browser/templates/macros.pt
+msgid "label_edit"
+msgstr "Editer à nouveau"
+
 #. Default: "File"
 #: ./opengever/document/browser/overview.py
 #: ./opengever/document/document.py
@@ -443,6 +448,7 @@ msgstr "Code externe"
 
 #. Default: "Keywords"
 #: ./opengever/document/behaviors/metadata.py
+#: ./opengever/document/browser/overview.py
 msgid "label_keywords"
 msgstr "Mots-clés"
 

--- a/opengever/document/locales/opengever.document.pot
+++ b/opengever/document/locales/opengever.document.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-04-06 06:16+0000\n"
+"POT-Creation-Date: 2018-06-27 08:29+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -430,6 +430,11 @@ msgstr ""
 msgid "label_download_copy"
 msgstr ""
 
+#. Default: "Edit"
+#: ./opengever/document/browser/templates/macros.pt
+msgid "label_edit"
+msgstr ""
+
 #. Default: "File"
 #: ./opengever/document/browser/overview.py
 #: ./opengever/document/document.py
@@ -443,6 +448,7 @@ msgstr ""
 
 #. Default: "Keywords"
 #: ./opengever/document/behaviors/metadata.py
+#: ./opengever/document/browser/overview.py
 msgid "label_keywords"
 msgstr ""
 

--- a/opengever/document/tests/test_overview.py
+++ b/opengever/document/tests/test_overview.py
@@ -167,7 +167,7 @@ class TestDocumentOverviewVanilla(IntegrationTestCase):
         file_actions = browser.css('.file-action-buttons a').text
 
         self.assertIn(
-            'Checkout and edit',
+            'Edit',
             file_actions,
             )
 
@@ -496,7 +496,7 @@ class TestDocumentOverviewVanilla(IntegrationTestCase):
         browser.open(self.document, view='tabbedview_view-overview')
 
         file_actions = [
-            'Checkout and edit',
+            'Edit',
             'Checkin with comment',
             'Download copy',
             'PDF Preview',


### PR DESCRIPTION
When document is already checked-out we now show an `Edit` button instead of `Checkout and edit`. 

**Normal 'checkout and edit' of a file**
![screen shot 2018-06-27 at 10 36 10](https://user-images.githubusercontent.com/7374243/41963154-261d7546-79f7-11e8-9b29-8d4691ce7136.png)

**Once checked-out, we now show an `Edit` button**
![screen shot 2018-06-27 at 10 36 36](https://user-images.githubusercontent.com/7374243/41963153-2600cfb8-79f7-11e8-90dd-e6da310e5a17.png)

**For a file that cannot be edit in office connector (unsupported file type), we show an `checkout` button**
![screen shot 2018-06-27 at 10 36 59](https://user-images.githubusercontent.com/7374243/41963148-25c23a00-79f7-11e8-9e68-443b75093002.png)

**If the file is already checked-out and is of unsupported type, we don't show any button (before we showed the checkout button here, but that does not make sense)**
![screen shot 2018-06-27 at 10 37 26](https://user-images.githubusercontent.com/7374243/41963152-25e20498-79f7-11e8-918e-7e48225bb38a.png)

resolves #1812 