### PR TITLE
Fix physical_path schema migration for oracle backends.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2018.4.0 (unreleased)
 ---------------------
 
+- Fix physical_path schema migration for oracle backends. [phgross]
 - Indicate change of responsible in response when task is rejected. [njohner]
 - Add MS publisher to the list of OfficeConnector editables. [tarnap]
 - Add csv, wav, wmf and xml to the mimetypes for file icons. [tarnap]

--- a/opengever/core/upgrades/20180517160709_change_physical_path_column_type/upgrade.py
+++ b/opengever/core/upgrades/20180517160709_change_physical_path_column_type/upgrade.py
@@ -1,6 +1,9 @@
 from opengever.core.upgrade import SchemaMigration
-from sqlalchemy import Text
+from sqlalchemy import Column
 from sqlalchemy import String
+from sqlalchemy import Text
+from sqlalchemy.sql.expression import column
+from sqlalchemy.sql.expression import table
 
 
 class ChangePhysicalPathColumnType(SchemaMigration):
@@ -8,30 +11,77 @@ class ChangePhysicalPathColumnType(SchemaMigration):
     """
 
     def migrate(self):
-        self.op.alter_column(
+        self.alter_column(
             'tasks',
             'physical_path',
             type_=Text,
             existing_nullable=True,
             existing_type=String(256))
 
-        self.op.alter_column(
+        self.alter_column(
             'proposals',
             'physical_path',
             type_=Text,
             existing_nullable=False,
             existing_type=String(256))
 
-        self.op.alter_column(
+        self.alter_column(
             'proposals',
             'submitted_physical_path',
             type_=Text,
             existing_nullable=True,
             existing_type=String(256))
 
-        self.op.alter_column(
+        self.alter_column(
             'committees',
             'physical_path',
             type_=Text,
             existing_nullable=False,
             existing_type=String(256))
+
+    def alter_column(self, table_name, column_name, type_, existing_nullable, existing_type):  # noqa
+
+        if self.is_oracle:
+            self.alter_oracle_column(table_name, column_name,
+                                     type_, existing_nullable, existing_type)
+        else:
+            self.op.alter_column(
+                table_name, column_name, type_=type_,
+                existing_nullable=existing_nullable,
+                existing_type=existing_type)
+
+    def alter_oracle_column(self, table_name, column_name, type_, existing_nullable, existing_type):  # noqa
+        tmp_column_name = 'tmp{}'.format(column_name)
+
+        # rename existing column
+        self.op.alter_column(table_name,
+                             column_name,
+                             new_column_name=tmp_column_name,
+                             existing_nullable=existing_nullable,
+                             existing_type=existing_type)
+
+        # add new column with the new type
+        self.op.add_column(
+            table_name, Column(column_name, type_, nullable=True))
+
+        # migrate_data
+        _table = table(table_name,
+            column("id"),
+            column(tmp_column_name),
+            column(column_name),
+        )
+
+        items = self.connection.execute(_table.select()).fetchall()
+        for item in items:
+            self.execute(
+                _table.update()
+                .values(**{column_name: getattr(item, tmp_column_name)})
+                .where(_table.columns.id == item.id)
+            )
+
+        # make column non nullable
+        self.op.alter_column(
+            table_name, column_name, existing_type=type_, nullable=existing_nullable)
+
+        # drop_tmp_column
+        self.op.drop_column(table_name, tmp_column_name)


### PR DESCRIPTION
Changing a VARCHAR2 column to CLOB, as it has been done by the former implementation of the `ChangePhysicalPathColumnType` migration, does not work on oracle and raises an
`DatabaseError: (cx_Oracle.DatabaseError) ORA-22858: invalid 
alteration of datatype` exception (see
https://stackoverflow.com/questions/13402510/oracle-changing-varchar2-column-to-clob).

Therefore I add a special handling for oracle backends: create a new column and move the data from the old column to the new column.

This needs to be backported to `2018.3-stable`.