### PR TITLE
Whitelist registry records proxies for non-persistency

### DIFF
--- a/opengever/base/monkey/patches/default_values.py
+++ b/opengever/base/monkey/patches/default_values.py
@@ -2,11 +2,11 @@ from copy import deepcopy
 from opengever.base.interfaces import IDuringContentCreation
 from opengever.base.monkey.patching import MonkeyPatch
 from plone.dexterity.content import _marker
+from plone.registry.recordsproxy import RecordsProxy
 from zope.globalrequest import getRequest
 from zope.interface import alsoProvides
 from zope.interface import noLongerProvides
 from zope.schema.interfaces import IContextAwareDefaultFactory
-
 
 def _default_from_schema(context, schema, fieldname):
     """Helper to look up default value of a field
@@ -224,6 +224,7 @@ class PatchZ3CFormChangedField(MonkeyPatch):
                 # instance from Plone's TTW registry editor.
                 assert any((
                     isinstance(context, QueryContext),
+                    isinstance(context, RecordsProxy),
                     isinstance(context, ImplicitAcquisitionWrapper) and
                     isinstance(aq_base(context), dict),
                 ))


### PR DESCRIPTION
I'm pretty sure this is fine.
https://github.com/plone/plone.registry/blob/d77dec32cb25d604cc48ac6c8ab92a5a10af26e9/plone/registry/interfaces.py#L185-L190

Closes https://github.com/4teamwork/opengever.core/issues/4340