### PR TITLE
Ensure creator gets set to the paster upon pasting content

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ---------------------
 
 - Fix physical_path schema migration for oracle backends. [phgross]
+- Ensure creator sets get to the paster upon pasting content. [Rotonen]
 - Indicate change of responsible in response when task is rejected. [njohner]
 - Add MS publisher to the list of OfficeConnector editables. [tarnap]
 - Add csv, wav, wmf and xml to the mimetypes for file icons. [tarnap]

--- a/opengever/base/browser/paste.py
+++ b/opengever/base/browser/paste.py
@@ -79,10 +79,12 @@ class PasteClipboardView(BrowserView):
             # https://github.com/plone/plone.api/commit/79bec69932ca87a4a5cd675db8b0bd9437dddcdf
             # the following code should be replaced with plone.api after the
             # plone update.
-            copy_info = self.context.manage_pasteObjects(
-                obj.aq_parent.manage_copyObjects(obj.getId()))
+            copy_info = self.context.manage_pasteObjects(obj.aq_parent.manage_copyObjects(obj.getId()))
             new_id = copy_info[0]['new_id']
-            self.rename_object(self.context[new_id])
+            copied_obj = self.context[new_id]
+            # XXX - ensure the new object is listed as created by the paster
+            copied_obj.creators = (api.user.get_current().id, )
+            self.rename_object(copied_obj)
 
     def rename_object(self, copy):
         return self._recursive_rename(copy)

--- a/opengever/base/tests/test_copy_paste.py
+++ b/opengever/base/tests/test_copy_paste.py
@@ -98,6 +98,17 @@ class TestCopyPaste(IntegrationTestCase):
         self.assertEquals('document-{}'.format(sequence_number), copy.getId())
 
     @browsing
+    def test_creates_objects_with_correct_creator(self, browser):
+        self.login(self.regular_user, browser=browser)
+        self.assertNotEqual(self.document.Creator(), self.regular_user.id)
+        data = self.make_path_param(self.document)
+        browser.open(self.empty_dossier, view="copy_items", data=data)
+        browser.css('#contentActionMenus a#paste').first.click()
+        copy = self.empty_dossier.objectValues()[-1]
+        self.assertEqual(copy.Creator(), self.regular_user.id)
+        self.assertEqual(len(copy.creators), 1)
+
+    @browsing
     def test_pasting_handles_multiple_items_in_clipboard(self, browser):
         self.login(self.regular_user, browser=browser)
 


### PR DESCRIPTION
We're potentially mucking with DC metadata assumptions here:

https://github.com/zopefoundation/Products.CMFCore/blob/e235f04aea5678f56693fdbaca152da0685e8fc7/Products/CMFCore/interfaces/_content.py#L235-L248

Closes #4386 