### PR TITLE
Add MS Publisher to the list of OC editables

### DIFF
--- a/opengever/core/profiles/default/registry.xml
+++ b/opengever/core/profiles/default/registry.xml
@@ -158,6 +158,9 @@
       <element>application/vnd.openxmlformats-officedocument.presentationml.template</element>
       <element>application/vnd.openxmlformats-officedocument.presentationml.slideshow</element>
 
+      <!-- MS Publisher -->
+      <element>application/x-mspublisher</element>
+
       <!-- MS Word -->
       <element>application/msword</element>
       <element>application/vnd.ms-word.document.macroEnabled.12</element>

--- a/opengever/core/upgrades/20180628133742_add_ms_publisher_to_oc_editables/registry.xml
+++ b/opengever/core/upgrades/20180628133742_add_ms_publisher_to_oc_editables/registry.xml
@@ -1,0 +1,12 @@
+<registry>
+
+  <record
+      interface="opengever.officeconnector.interfaces.IOfficeConnectorSettings"
+      field="officeconnector_editable_types">
+    <value purge="False">
+      <!-- MS Publisher -->
+      <element>application/x-mspublisher</element>
+    </value>
+  </record>
+
+</registry>

--- a/opengever/core/upgrades/20180628133742_add_ms_publisher_to_oc_editables/upgrade.py
+++ b/opengever/core/upgrades/20180628133742_add_ms_publisher_to_oc_editables/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddMSPublisherToOCEditables(UpgradeStep):
+    """Add MS Publisher to OC editables.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()


### PR DESCRIPTION
Make sure the registry is not purged when the entry for the
IOfficeConnectorSettings added by setting the attribute "purge".

Resolves #4481 