### PR TITLE
Fixup for #4506 (oracle fix).

### DIFF
--- a/opengever/core/upgrades/20180517160709_change_physical_path_column_type/upgrade.py
+++ b/opengever/core/upgrades/20180517160709_change_physical_path_column_type/upgrade.py
@@ -80,8 +80,9 @@ class ChangePhysicalPathColumnType(SchemaMigration):
             )
 
         # make column non nullable
-        self.op.alter_column(
-            table_name, column_name, existing_type=type_, nullable=existing_nullable)
+        if not existing_nullable:
+            self.op.alter_column(
+                table_name, column_name, existing_type=type_, nullable=False)
 
         # drop_tmp_column
         self.op.drop_column(table_name, tmp_column_name)


### PR DESCRIPTION
Altering an oracle column to nullable-allowed where nullable was already allowed, is not possible and ends in an Oracle Exception (`ORA-01451: column to be modified to NULL cannot be
modified to NULL`), therefore I add an additional check and only handle non-nullable columns.

I've tested the upgradestep on oracle, works now 😅 

Needs backport: `2018.3-stable`