### PR TITLE
Display the checkin comment on bumblebee overlays

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ---------------------
 
 - Increase size of the favorites plone_uid column. [phgross]
+- Display the checkin comment on bumblebee overlays. [Rotonen]
 - Fix physical_path schema migration for oracle backends. [phgross]
 - Indicate change of responsible in response when task is rejected. [njohner]
 - Also make active committee vocabularies sorted by title. [Rotonen]

--- a/opengever/bumblebee/browser/overlay.py
+++ b/opengever/bumblebee/browser/overlay.py
@@ -1,7 +1,7 @@
 from Acquisition import aq_parent
 from ftw import bumblebee
-from ftw.bumblebee.mimetypes import is_mimetype_supported
 from ftw.bumblebee.interfaces import IBumblebeeDocument
+from ftw.bumblebee.mimetypes import is_mimetype_supported
 from opengever.base.browser.helper import get_css_class
 from opengever.base.interfaces import IReferenceNumber
 from opengever.base.interfaces import ISequenceNumber
@@ -12,6 +12,7 @@ from opengever.bumblebee.interfaces import IBumblebeeOverlay
 from opengever.bumblebee.interfaces import IGeverBumblebeeSettings
 from opengever.bumblebee.interfaces import IVersionedContextMarker
 from opengever.document.browser.actionbuttons import ActionButtonRendererMixin
+from opengever.document.browser.versions_tab import LazyHistoryMetadataProxy
 from opengever.document.browser.versions_tab import translate_link
 from opengever.document.checkout.viewlets import CheckedOutViewlet
 from opengever.document.document import IDocumentSchema
@@ -50,6 +51,15 @@ class BumblebeeBaseDocumentOverlay(ActionButtonRendererMixin):
     def __init__(self, context, request):
         self.context = context
         self.request = request
+
+    def get_checkin_comment(self):
+        version_id = self.version_id
+        if version_id is None:
+            version_id = getattr(self.context, 'version_id', None)
+        if version_id is not None:
+            version_metadata = Versioner(self.context).get_version_metadata(version_id)
+            return version_metadata['sys_metadata']['comment']
+        return u''
 
     def is_latest_version(self):
         """A documentish without versions is always the latest version."""

--- a/opengever/bumblebee/browser/templates/bumblebeeoverlay.pt
+++ b/opengever/bumblebee/browser/templates/bumblebeeoverlay.pt
@@ -29,6 +29,12 @@
           </span>
         </td>
       </tr>
+      <tr tal:define="checkin_comment view/overlay/get_checkin_comment" tal:condition="nocall: checkin_comment">
+        <td class="title" i18n:translate="">Checkin comment:</td>
+        <td class="value">
+          <div tal:content="checkin_comment" />
+        </td>
+      </tr>
       <tr tal:condition="view/overlay/get_description">
         <td class="title" i18n:translate="">Description:</td>
         <td class="value">

--- a/opengever/bumblebee/locales/de/LC_MESSAGES/opengever.bumblebee.po
+++ b/opengever/bumblebee/locales/de/LC_MESSAGES/opengever.bumblebee.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-01-22 08:05+0000\n"
+"POT-Creation-Date: 2018-06-28 13:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -13,6 +13,10 @@ msgstr ""
 "Language-Name: English\n"
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
+
+#: ./opengever/bumblebee/browser/templates/bumblebeeoverlay.pt
+msgid "Checkin comment:"
+msgstr "Bearbeitungskommentar"
 
 #: ./opengever/bumblebee/browser/templates/bumblebeeoverlay.pt
 msgid "Creator:"

--- a/opengever/bumblebee/locales/fr/LC_MESSAGES/opengever.bumblebee.po
+++ b/opengever/bumblebee/locales/fr/LC_MESSAGES/opengever.bumblebee.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-01-22 08:05+0000\n"
+"POT-Creation-Date: 2018-06-28 13:31+0000\n"
 "PO-Revision-Date: 2017-10-16 16:28+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -13,6 +13,10 @@ msgstr ""
 "Language-Name: English\n"
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
+
+#: ./opengever/bumblebee/browser/templates/bumblebeeoverlay.pt
+msgid "Checkin comment:"
+msgstr ""
 
 #: ./opengever/bumblebee/browser/templates/bumblebeeoverlay.pt
 msgid "Creator:"

--- a/opengever/bumblebee/locales/opengever.bumblebee.pot
+++ b/opengever/bumblebee/locales/opengever.bumblebee.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-01-22 08:05+0000\n"
+"POT-Creation-Date: 2018-06-28 13:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,6 +16,10 @@ msgstr ""
 "Language-Name: English\n"
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: opengever.bumblebee\n"
+
+#: ./opengever/bumblebee/browser/templates/bumblebeeoverlay.pt
+msgid "Checkin comment:"
+msgstr ""
 
 #: ./opengever/bumblebee/browser/templates/bumblebeeoverlay.pt
 msgid "Creator:"

--- a/opengever/document/tests/test_versioner.py
+++ b/opengever/document/tests/test_versioner.py
@@ -81,3 +81,13 @@ class TestInitialVersionCreation(IntegrationTestCase):
             u'custom initial version', version.sys_metadata['comment'])
 
         self.assertIsNone(versioner.get_custom_initial_version_comment())
+
+    def test_fetching_version_metadata(self):
+        self.login(self.regular_user)
+        versioner = Versioner(self.document)
+        versioner.set_custom_initial_version_comment(u'custom initial version')
+        self.document.file = NamedBlobFile(data='New', filename=u'test.txt')
+        sys_metadata = versioner.get_version_metadata(0).get('sys_metadata')
+        self.assertEqual(u'custom initial version', sys_metadata.get('comment'))
+        self.assertEqual('kathi.barfuss', sys_metadata.get('principal'))
+        self.assertEqual('document-state-draft', sys_metadata.get('review_state'))

--- a/opengever/document/versioner.py
+++ b/opengever/document/versioner.py
@@ -27,6 +27,9 @@ class Versioner(object):
     def get_history_metadata(self):
         return self.repository.getHistoryMetadata(self.document)
 
+    def get_version_metadata(self, version_id):
+            return self.get_history_metadata().retrieve(version_id)['metadata']
+
     def create_version(self, comment):
         """Creates a new version in CMFEditions.
         """


### PR DESCRIPTION
* Uses the versioner to pull in the metadata history
* Uses the lazy history proxy to fetch the correct comment for the document version in question

Closes https://github.com/4teamwork/opengever.core/issues/4381