### PR TITLE
Fix a bug with modern emojis in task responses.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -8,6 +8,7 @@ Changelog
 - Fix unicode error in versions tab comments. [lgraf]
 - Increase size of the favorites plone_uid column. [phgross]
 - Display the checkin comment on bumblebee overlays. [Rotonen]
+- Fix a bug with modern emojis while rendering task responses. [deiferni]
 - Fix physical_path schema migration for oracle backends. [phgross]
 - Ensure creator sets get to the paster upon pasting content. [Rotonen]
 - Indicate change of responsible in response when task is rejected. [njohner]

--- a/opengever/task/browser/overview.py
+++ b/opengever/task/browser/overview.py
@@ -11,9 +11,10 @@ from plone import api
 from plone.app.contentlisting.interfaces import IContentListing
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.utils import safe_unicode
+from Products.Five.browser import BrowserView
 
 
-class Overview(GeverTabMixin):
+class Overview(BrowserView, GeverTabMixin):
     """Provide / override tabbedview methods for task overviews."""
 
     def documents(self):

--- a/opengever/task/viewlets/response.py
+++ b/opengever/task/viewlets/response.py
@@ -30,9 +30,10 @@ class ResponseView(ViewletBase, Base):
                 response=response,
                 text=transforms.convertTo(
                     'text/html', response.text,
-                    mimetype='text/x-web-intelligent'),
+                    mimetype='text/x-web-intelligent').getData(),
                 edit_link=self.edit_link(id),
-                delete_link=self.delete_link(id))
+                delete_link=self.delete_link(id)
+            )
 
             responses.append(info)
 


### PR DESCRIPTION
Fix a bug with modern emojis while rendering task responses. The source of the
problem was not calling `getData` on a transform  which will return a stream
instead of the result.

Testing seems a bit difficult at the moment as our tooling does not seem to
support these characters either 😂.

But, task-responses are now rendered correctly, even if they contain emojis:
![screen shot 2018-06-28 at 18 25 11](https://user-images.githubusercontent.com/736583/42047477-a115d482-7b00-11e8-9b64-c63aff1568b8.png)
