### PR TITLE
Fix unicode error in versions tab comments.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2018.4.0 (unreleased)
 ---------------------
 
+- Fix unicode error in versions tab comments. [lgraf]
 - Increase size of the favorites plone_uid column. [phgross]
 - Display the checkin comment on bumblebee overlays. [Rotonen]
 - Fix physical_path schema migration for oracle backends. [phgross]

--- a/opengever/document/browser/versions_tab.py
+++ b/opengever/document/browser/versions_tab.py
@@ -10,11 +10,11 @@ from opengever.document import _
 from opengever.document.browser.download import DownloadConfirmationHelper
 from opengever.document.interfaces import ICheckinCheckoutManager
 from opengever.document.versioner import Versioner
-from opengever.journal.tab import tooltip_helper
 from opengever.ogds.base.actor import Actor
 from opengever.tabbedview import BaseListingTab
 from opengever.tabbedview import GeverTableSource
 from opengever.tabbedview.helper import linked_version_preview
+from opengever.tabbedview.helper import tooltip_helper
 from plone import api
 from plone.protect.utils import addTokenToUrl
 from Products.CMFPlone.utils import safe_unicode

--- a/opengever/document/tests/test_versions_tab.py
+++ b/opengever/document/tests/test_versions_tab.py
@@ -35,7 +35,8 @@ class TestVersionsTab(FunctionalTestCase):
     def _create_doc_with_versions(self, n=3):
         doc = self._create_doc()
         for version_id in range(1, n + 1):
-            create_document_version(doc, version_id)
+            create_document_version(doc, version_id,
+                                    comment=u'Kommentar mit Uml\xe4ut')
         return doc
 
     def _create_doc(self):

--- a/opengever/journal/tab.py
+++ b/opengever/journal/tab.py
@@ -1,4 +1,3 @@
-from BeautifulSoup import BeautifulSoup
 from ftw.journal.config import JOURNAL_ENTRIES_ANNOTATIONS_KEY
 from ftw.journal.interfaces import IAnnotationsJournalizable
 from ftw.journal.interfaces import IWorkflowHistoryJournalizable
@@ -11,6 +10,7 @@ from opengever.tabbedview import BaseListingTab
 from opengever.tabbedview import GeverTableSource
 from opengever.tabbedview.helper import linked_ogds_author
 from opengever.tabbedview.helper import readable_ogds_user
+from opengever.tabbedview.helper import tooltip_helper
 from plone import api
 from zope.annotation.interfaces import IAnnotations
 from zope.browserpage.viewpagetemplatefile import ViewPageTemplateFile
@@ -21,12 +21,6 @@ from zope.interface import implementer
 from zope.interface import implements
 from zope.interface import Interface
 import cPickle
-
-
-def tooltip_helper(item, value):
-    text = ''.join(
-        BeautifulSoup(value, fromEncoding='utf8').findAll(text=True))
-    return '<span title="%s">%s</span>' % (text.encode('utf-8'), value)
 
 
 def title_helper(item, value):

--- a/opengever/journal/tests/test_journal_tab.py
+++ b/opengever/journal/tests/test_journal_tab.py
@@ -144,7 +144,7 @@ class TestJournalTabSorting(FunctionalTestCase):
             {'action': {'visible': True,
                         'type': 'Dossier changed',
                         'title': title},
-             'comments': '',
+             'comments': 'Kommentar mit Uml\xc3\xa4ut',
              'actor': actor,
              'time': time})
 

--- a/opengever/tabbedview/helper.py
+++ b/opengever/tabbedview/helper.py
@@ -15,6 +15,7 @@ from plone.memoize import ram
 from plone.uuid.interfaces import IUUID
 from Products.CMFCore.interfaces._tools import IMemberData
 from Products.CMFPlone.utils import safe_unicode
+from Products.CMFPlone.utils import safe_unicode
 from Products.PluggableAuthService.interfaces.authservice import IPropertiedUser
 from Products.ZCatalog.interfaces import ICatalogBrain
 from zope.component import getUtility
@@ -24,9 +25,10 @@ from zope.i18n import translate
 
 
 def tooltip_helper(item, value):
-    text = ''.join(
+    value = safe_unicode(value)
+    text = u''.join(
         BeautifulSoup(value, fromEncoding='utf8').findAll(text=True))
-    return '<span title="%s">%s</span>' % (text.encode('utf-8'), value)
+    return (u'<span title="%s">%s</span>' % (text, value)).encode('utf-8')
 
 
 def org_unit_title_helper(item, value):

--- a/opengever/tabbedview/helper.py
+++ b/opengever/tabbedview/helper.py
@@ -1,3 +1,4 @@
+from BeautifulSoup import BeautifulSoup
 from datetime import datetime
 from ftw.mail.utils import get_header
 from ftw.solr.document import SolrDocument
@@ -20,6 +21,12 @@ from zope.component import getUtility
 from zope.component.hooks import getSite
 from zope.globalrequest import getRequest
 from zope.i18n import translate
+
+
+def tooltip_helper(item, value):
+    text = ''.join(
+        BeautifulSoup(value, fromEncoding='utf8').findAll(text=True))
+    return '<span title="%s">%s</span>' % (text.encode('utf-8'), value)
 
 
 def org_unit_title_helper(item, value):

--- a/opengever/testing/helpers.py
+++ b/opengever/testing/helpers.py
@@ -98,11 +98,14 @@ def add_languages(codes, support_combined=True):
     transaction.commit()
 
 
-def create_document_version(doc, version_id, data=None):
+def create_document_version(doc, version_id, data=None, comment=None):
     vdata = data or 'VERSION {} DATA'.format(version_id)
     doc.file.data = vdata
 
-    Versioner(doc).create_version("This is Version %s" % version_id)
+    if comment is None:
+        comment = u'This is Version %s' % version_id
+
+    Versioner(doc).create_version(comment)
 
 
 def css_to_xpath(css):


### PR DESCRIPTION
Fixes unicode issue with `tooltip_helper` for versions tab comments that contain non-ASCII characters:

The tooltip_helper is currently used by two tabs, version and journal tabs. They don't both pass it the same type of value, one uses unicode and the other bytestrings. The `tooltip_helper` therefore needs to be able to accept both, work with unicode internally, and finally return a bytestring.