### PR TITLE
Restrict availability of Delete action button

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ---------------------
 
 - Fix unicode error in versions tab comments. [lgraf]
+- Restrict availability of the delete button. [njohner]
 - Increase size of the favorites plone_uid column. [phgross]
 - Display the checkin comment on bumblebee overlays. [Rotonen]
 - Fix a bug with modern emojis while rendering task responses. [deiferni]

--- a/opengever/base/browser/configure.zcml
+++ b/opengever/base/browser/configure.zcml
@@ -137,6 +137,13 @@
       />
 
   <browser:page
+      for="*"
+      name="is_delete_available"
+      class=".is_delete_available.IsDeleteAvailable"
+      permission="zope2.View"
+      />
+
+  <browser:page
       name="folder_delete_confirmation"
       for="*"
       permission="zope2.DeleteObjects"

--- a/opengever/base/browser/is_delete_available.py
+++ b/opengever/base/browser/is_delete_available.py
@@ -1,0 +1,27 @@
+from Acquisition import aq_parent
+from opengever.private.interfaces import IPrivateContainer
+from opengever.tasktemplates.content.tasktemplate import ITaskTemplate
+from opengever.tasktemplates.content.templatefoldersschema import ITaskTemplateFolderSchema
+from Products.Five.browser import BrowserView
+
+
+class IsDeleteAvailable(BrowserView):
+    """This view is used to check whether to display the delete
+    button for a given object or not. This is notably usefull
+    as we have our own delete actions for certain portal types.
+    """
+
+    authorized_interfaces = (IPrivateContainer,
+                             ITaskTemplate,
+                             ITaskTemplateFolderSchema)
+
+    authorized_parent_interfaces = (IPrivateContainer,
+                                    )
+
+    def __call__(self):
+        parent = aq_parent(self.context)
+        return (any(interface.providedBy(self.context)
+                for interface in self.authorized_interfaces)
+                or any(interface.providedBy(parent)
+                for interface in self.authorized_parent_interfaces)
+                )

--- a/opengever/core/profiles/default/actions.xml
+++ b/opengever/core/profiles/default/actions.xml
@@ -452,7 +452,7 @@
       <property name="description" i18n:translate="" />
       <property name="url_expr">string:${globals_view/getCurrentObjectUrl}/delete_confirmation</property>
       <property name="icon_expr" />
-      <property name="available_expr">python:checkPermission("Delete objects", globals_view.getParentObject()) and not globals_view.isPortalOrPortalDefaultPage()</property>
+      <property name="available_expr">python:checkPermission("Delete objects", globals_view.getParentObject()) and here.restrictedTraverse('is_delete_available')()</property>
       <property name="permissions">
         <element value="Delete objects" />
       </property>

--- a/opengever/core/upgrades/20180629085145_restrict_delete_action_availability/actions.xml
+++ b/opengever/core/upgrades/20180629085145_restrict_delete_action_availability/actions.xml
@@ -1,0 +1,12 @@
+<object xmlns:i18n="http://xml.zope.org/namespaces/i18n" name="portal_actions" meta_type="Plone Actions Tool">
+
+  <!-- OBJECT BUTTONS -->
+  <object name="object_buttons" meta_type="CMF Action Category">
+
+    <object name="delete" meta_type="CMF Action" i18n:domain="plone">
+      <property name="available_expr">python:checkPermission("Delete objects", globals_view.getParentObject()) and here.restrictedTraverse('is_delete_available')()</property>
+    </object>
+
+  </object>
+
+</object>

--- a/opengever/core/upgrades/20180629085145_restrict_delete_action_availability/upgrade.py
+++ b/opengever/core/upgrades/20180629085145_restrict_delete_action_availability/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class RestrictDeleteActionAvailability(UpgradeStep):
+    """Restrict delete action availability.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/dossier/tests/test_dossier_workflow.py
+++ b/opengever/dossier/tests/test_dossier_workflow.py
@@ -25,7 +25,7 @@ class TestDossierWorkflow(IntegrationTestCase):
     def test_offer_transition_is_hidden_in_action_menu(self, browser):
         self.login(self.manager, browser)
         browser.visit(self.archive_dossier)
-        expected = ['Cover (PDF)', 'Delete', 'Export as Zip',
+        expected = ['Cover (PDF)', 'Export as Zip',
                     'Print details (PDF)', 'Properties', 'Sharing',
                     'Policy...']
         self.assertItemsEqual(expected, self.get_action_menu_content())

--- a/opengever/repository/tests/test_deletion.py
+++ b/opengever/repository/tests/test_deletion.py
@@ -3,6 +3,7 @@ from Acquisition import aq_parent
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
+from ftw.testbrowser.pages import editbar
 from ftw.testbrowser.pages import statusmessages
 from opengever.repository.deleter import RepositoryDeleter
 from opengever.testing import IntegrationTestCase
@@ -50,18 +51,50 @@ class TestRepositoryDeleter(IntegrationTestCase):
     def test_delete_action_is_only_available_when_preconditions_satisfied(
             self, browser):
         self.login(self.administrator, browser)
-
         browser.open(self.empty_repofolder)
         self.assertIn(
             'Delete',
-            browser.css('#plone-contentmenu-actions .actionMenuContent a').text,
+            editbar.menu_options("Actions"),
             'Expected "Delete" action to be visible on {!r}.'.format(
                 self.empty_repofolder))
 
         browser.open(self.branch_repofolder)
         self.assertNotIn(
             'Delete',
-            browser.css('#plone-contentmenu-actions .actionMenuContent a').text,
+            editbar.menu_options("Actions"),
+            'Expected "Delete" action to be invisible on {!r}.'.format(
+                self.branch_repofolder))
+
+        browser.open(self.leaf_repofolder)
+        self.assertNotIn(
+            'Delete',
+            editbar.menu_options("Actions"),
+            'Expected "Delete" action to be invisible on {!r}.'.format(
+                self.branch_repofolder))
+
+    @browsing
+    def test_delete_action_is_only_available_when_preconditions_satisfied_also_for_managers(
+            self, browser):
+        self.login(self.manager, browser)
+
+        browser.open(self.empty_repofolder)
+        self.assertIn(
+            'Delete',
+            editbar.menu_options("Actions"),
+            'Expected "Delete" action to be visible on {!r}.'.format(
+                self.empty_repofolder))
+
+        browser.open(self.branch_repofolder)
+        self.assertNotIn(
+            'Delete',
+            editbar.menu_options("Actions"),
+            'Expected "Delete" action to be invisible on {!r}.'.format(
+                self.branch_repofolder))
+
+        browser.open(self.leaf_repofolder)
+        self.assertNotIn(
+            'Delete',
+            editbar.menu_options("Actions"),
             'Expected "Delete" action to be invisible on {!r}.'.format(
                 self.branch_repofolder))
 

--- a/opengever/tasktemplates/tests/test_tasktemplate.py
+++ b/opengever/tasktemplates/tests/test_tasktemplate.py
@@ -84,13 +84,54 @@ class TestTaskTemplates(IntegrationTestCase):
         self.assertEquals(10, tasktemplate.deadline)
 
     @browsing
-    def test_deleting_a_tasktemplate_is_possible(self, browser):
+    def test_deleting_a_tasktemplatefolder_is_possible(self, browser):
         self.login(self.dossier_responsible, browser=browser)
+
+        title = self.tasktemplatefolder.title
+        self.assertIn(title, [template.title for template in
+                              self.templates.listFolderContents()])
 
         browser.open(self.tasktemplatefolder)
         self.assertIn(
             'Delete',
             browser.css('#plone-contentmenu-actions .actionMenuContent a').text)
+
+        browser.click_on('Delete')
+        browser.click_on('Delete')
+
+        self.assertEquals(['Verfahren Neuanstellung has been deleted.'], info_messages())
+        self.assertNotIn(title, [template.title for template in
+                                 self.templates.listFolderContents()])
+
+    @browsing
+    def test_deleting_a_tasktemplate_is_possible(self, browser):
+        self.login(self.dossier_responsible, browser=browser)
+
+        title = self.tasktemplate.title
+        self.assertIn(title, [template.title for template in
+                              self.tasktemplatefolder.listFolderContents()])
+
+        browser.open(self.tasktemplate)
+        self.assertIn(
+            'Delete',
+            browser.css('#plone-contentmenu-actions .actionMenuContent a').text)
+
+        browser.click_on('Delete')
+        browser.click_on('Delete')
+
+        self.assertEquals(['Arbeitsplatz einrichten. has been deleted.'], info_messages())
+        self.assertNotIn(title, [template.title for template in
+                                 self.tasktemplatefolder.listFolderContents()])
+
+    @browsing
+    def test_deleting_tasktemplates_is_possible(self, browser):
+        self.login(self.dossier_responsible, browser=browser)
+
+        browser.open(self.tasktemplatefolder, view="tabbed_view/listing?view_name=tasktemplates")
+
+        self.assertIn(
+            'Delete',
+            browser.css('#tabbedview-menu .tabbedview-action-list a').text)
 
         data = self.make_path_param(self.tasktemplate)
         browser.open(self.tasktemplatefolder, data,


### PR DESCRIPTION
Since #3598, a delete action button was available everywhere for managers, and on third level of the repository it was available for admins even when the node was not empty, or twice when the node was empty. This was an unintended side effect of making the delete action available for the private folder, it became instead available everywhere where a user had delete rights on the parent. As we also have our own delete action for repos, this could lead to two available buttons.

The tests did not catch this error because we were testing on a branch repository folder, where the administrator does not have delete rights on the parent. Testing on a leaf made the error apparent.

I added a new view used to control where the delete button should be available and improved the tests for deleting repository nodes and tasktemplates and tasktemplatefolders.

resolves #4334 