### PR TITLE
Record activities

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -27,6 +27,7 @@ Changelog
 - Optionalize 'related document or template' for proposals. [Rotonen]
 - Add a no value option to the table radio widget when it's not required. [Rotonen]
 - Extend activity icons for proposal activities. [elioschmutz]
+- Implement proposal notifications. [elioschmutz]
 - Register watchers for proposals. [elioschmutz]
 - Implement tabs for personal activity-settings view. [elioschmutz]
 - Add new notification roles for proposal activities. [elioschmutz]

--- a/opengever/activity/browser/resolve.py
+++ b/opengever/activity/browser/resolve.py
@@ -36,11 +36,13 @@ class ResolveNotificationView(ResolveOGUIDView):
         """Redirect to the affected resource. If the resource is stored
         in an other admin_unit than the current one, it redirects to the
         resolve_oguid view on this admin_unit."""
-
         oguid = self.notification.activity.resource.oguid
 
         if oguid.is_on_current_admin_unit:
-            url = oguid.resolve_object().absolute_url()
+            try:
+                url = oguid.resolve_object().absolute_url()
+            except KeyError:
+                raise NotFound('Requested object have been deleted')
 
         else:
             admin_unit = ogds_service().fetch_admin_unit(oguid.admin_unit_id)

--- a/opengever/activity/tests/test_resolve.py
+++ b/opengever/activity/tests/test_resolve.py
@@ -4,8 +4,11 @@ from ftw.testbrowser import browsing
 from opengever.activity import notification_center
 from opengever.activity.browser import resolve_notification_url
 from opengever.base.oguid import Oguid
+from opengever.base.security import elevated_privileges
 from opengever.testing import FunctionalTestCase
+from plone import api
 from plone.app.testing import TEST_USER_ID
+import transaction
 
 
 class TestResolveNotificationView(FunctionalTestCase):
@@ -78,6 +81,27 @@ class TestResolveNotificationView(FunctionalTestCase):
                              data={'notification_id': notification.notification_id})
 
         self.assertEquals(task.absolute_url(), browser.url)
+
+    @browsing
+    def test_raises_notfound_when_oguid_does_no_longer_exists(self, browser):
+        task = create(Builder('task'))
+        oguid = Oguid.for_object(task)
+
+        resource = create(Builder('resource').oguid(oguid.id))
+        activity = create(Builder('activity').having(resource=resource))
+        notification = create(Builder('notification')
+                              .having(activity=activity, userid=TEST_USER_ID))
+
+        with elevated_privileges():
+            # This happens on rejecting a submitte proposal within the
+            # opengever.meeting-module. A submtited proposal will be deleted
+            # on rejecting and is no longer resolveable.
+            api.content.delete(task)
+            transaction.commit()
+
+        with browser.expect_http_error(reason='Not Found'):
+            browser.login().open(self.portal, view='resolve_notification',
+                                 data={'notification_id': notification.notification_id})
 
     @browsing
     def test_redirects_to_the_resolveoguid_on_admin_unit_for_foreign_ressources(self, browser):

--- a/opengever/meeting/activity/activities.py
+++ b/opengever/meeting/activity/activities.py
@@ -56,3 +56,13 @@ class ProposalSubmittedActivity(ProposalTransitionActivity):
         return self.translate_to_all_languages(
             _('proposal_history_label_submitted', u'Submitted by ${user}',
               mapping={'user': actor_link()}))
+
+
+class ProposalRejectedActivity(ProposalTransitionActivity):
+    kind = 'proposal-transition-reject'
+
+    @property
+    def summary(self):
+        return self.translate_to_all_languages(
+            _('proposal_history_label_rejected', u'Rejected by ${user}',
+              mapping={'user': actor_link()}))

--- a/opengever/meeting/activity/activities.py
+++ b/opengever/meeting/activity/activities.py
@@ -1,0 +1,32 @@
+from opengever.activity import ACTIVITY_TRANSLATIONS
+from opengever.activity.base import BaseActivity
+from opengever.meeting import _
+from opengever.ogds.base.actor import Actor
+from plone import api
+
+
+def actor_link():
+    return Actor.lookup(api.user.get_current().id).get_link()
+
+
+class ProposalCommentedActivitiy(BaseActivity):
+    """Activity representation for commenting a proposal.
+    """
+    kind = 'proposal-commented'
+
+    def __init__(self, context, request):
+        super(ProposalCommentedActivitiy, self).__init__(context, request)
+
+    @property
+    def summary(self):
+        return self.translate_to_all_languages(
+            _('proposal_history_label_commented', u'Proposal commented by ${user}',
+              mapping={'user': actor_link()}))
+
+    @property
+    def label(self):
+        return self.translate_to_all_languages(ACTIVITY_TRANSLATIONS[self.kind])
+
+    @property
+    def description(self):
+        return {}

--- a/opengever/meeting/activity/activities.py
+++ b/opengever/meeting/activity/activities.py
@@ -30,3 +30,29 @@ class ProposalCommentedActivitiy(BaseActivity):
     @property
     def description(self):
         return {}
+
+
+class ProposalTransitionActivity(BaseActivity):
+    """Activity which represents a proposal transition change.
+    """
+
+    def __init__(self, context, request):
+        super(ProposalTransitionActivity, self).__init__(context, request)
+
+    @property
+    def description(self):
+        return {}
+
+    @property
+    def label(self):
+        return self.translate_to_all_languages(ACTIVITY_TRANSLATIONS[self.kind])
+
+
+class ProposalSubmittedActivity(ProposalTransitionActivity):
+    kind = 'proposal-transition-submit'
+
+    @property
+    def summary(self):
+        return self.translate_to_all_languages(
+            _('proposal_history_label_submitted', u'Submitted by ${user}',
+              mapping={'user': actor_link()}))

--- a/opengever/meeting/activity/activities.py
+++ b/opengever/meeting/activity/activities.py
@@ -1,6 +1,7 @@
 from opengever.activity import ACTIVITY_TRANSLATIONS
 from opengever.activity.base import BaseActivity
 from opengever.meeting import _
+from opengever.meeting.model import Meeting
 from opengever.ogds.base.actor import Actor
 from plone import api
 
@@ -66,3 +67,23 @@ class ProposalRejectedActivity(ProposalTransitionActivity):
         return self.translate_to_all_languages(
             _('proposal_history_label_rejected', u'Rejected by ${user}',
               mapping={'user': actor_link()}))
+
+
+class ProposalScheduledActivity(ProposalTransitionActivity):
+    kind = 'proposal-transition-schedule'
+
+    def __init__(self, context, request, meeting_id):
+        super(ProposalTransitionActivity, self).__init__(context, request)
+        self.meeting_id = meeting_id
+
+    @property
+    def summary(self):
+        return self.translate_to_all_languages(
+            _('proposal_history_label_scheduled',
+              u'Scheduled for meeting ${meeting} by ${user}',
+              mapping={'meeting': self.get_meeting_title(self.meeting_id),
+                       'user': actor_link()}))
+
+    def get_meeting_title(self, meeting_id):
+        meeting = Meeting.query.get(meeting_id)
+        return meeting.get_title() if meeting else u''

--- a/opengever/meeting/activity/activities.py
+++ b/opengever/meeting/activity/activities.py
@@ -124,3 +124,28 @@ class ProposalDocumentUpdatedActivity(BaseActivity):
     @property
     def description(self):
         return {}
+
+
+class ProposalDocumentSubmittedActivity(BaseActivity):
+    """Activity representation for updating a proposals document.
+    """
+    kind = 'proposal-additional-documents-submitted'
+
+    def __init__(self, context, request, document_title):
+        super(ProposalDocumentSubmittedActivity, self).__init__(context, request)
+        self.document_title = document_title
+
+    @property
+    def summary(self):
+        return self.translate_to_all_languages(
+            _(u'proposal_activity_label_document_submitted',
+              u'Document ${title} submitted',
+              mapping={'title': self.document_title or ''}))
+
+    @property
+    def label(self):
+        return self.translate_to_all_languages(ACTIVITY_TRANSLATIONS[self.kind])
+
+    @property
+    def description(self):
+        return {}

--- a/opengever/meeting/activity/activities.py
+++ b/opengever/meeting/activity/activities.py
@@ -97,3 +97,30 @@ class ProposalDecideActivity(ProposalTransitionActivity):
         return self.translate_to_all_languages(
             _('proposal_history_label_decided', u'Proposal decided by ${user}',
               mapping={'user': actor_link()}))
+
+
+class ProposalDocumentUpdatedActivity(BaseActivity):
+    """Activity representation for updating a proposals document.
+    """
+    kind = 'proposal-attachment-updated'
+
+    def __init__(self, context, request, document_title, submitted_version):
+        super(ProposalDocumentUpdatedActivity, self).__init__(context, request)
+        self.document_title = document_title
+        self.submitted_version = submitted_version
+
+    @property
+    def summary(self):
+        return self.translate_to_all_languages(
+            _(u'proposal_activity_label_document_updated',
+              u'Submitted document ${title} updated to version ${version}',
+              mapping={'title': self.document_title or '',
+                       'version': self.submitted_version}))
+
+    @property
+    def label(self):
+        return self.translate_to_all_languages(ACTIVITY_TRANSLATIONS[self.kind])
+
+    @property
+    def description(self):
+        return {}

--- a/opengever/meeting/activity/activities.py
+++ b/opengever/meeting/activity/activities.py
@@ -87,3 +87,13 @@ class ProposalScheduledActivity(ProposalTransitionActivity):
     def get_meeting_title(self, meeting_id):
         meeting = Meeting.query.get(meeting_id)
         return meeting.get_title() if meeting else u''
+
+
+class ProposalDecideActivity(ProposalTransitionActivity):
+    kind = 'proposal-transition-decide'
+
+    @property
+    def summary(self):
+        return self.translate_to_all_languages(
+            _('proposal_history_label_decided', u'Proposal decided by ${user}',
+              mapping={'user': actor_link()}))

--- a/opengever/meeting/browser/configure.zcml
+++ b/opengever/meeting/browser/configure.zcml
@@ -159,6 +159,14 @@
       layer="opengever.ogds.base.interfaces.IInternalOpengeverRequestLayer"
       />
 
+  <browser:page
+      for="opengever.meeting.proposal.IProposal"
+      name="receive-connector-action"
+      class=".receiveconnectoraction.ReceiveConnectorAction"
+      permission="zope2.View"
+      layer="opengever.ogds.base.interfaces.IInternalOpengeverRequestLayer"
+      />
+
   <!-- committee tabs -->
   <browser:page
       name="tabbedview_view-meetings"

--- a/opengever/meeting/browser/receiveconnectoraction.py
+++ b/opengever/meeting/browser/receiveconnectoraction.py
@@ -1,0 +1,17 @@
+from opengever.base.request import tracebackify
+from opengever.base.utils import ok_response
+from opengever.meeting.connector.connector import Connector
+from Products.Five import BrowserView
+
+
+@tracebackify
+class ReceiveConnectorAction(BrowserView):
+    """Receives a connector action and passes the context and the request
+    back to the connector.
+
+    This view is only available for internal requests.
+    """
+
+    def __call__(self):
+        Connector.receive(self.context, self.request)
+        return ok_response(self.request)

--- a/opengever/meeting/command.py
+++ b/opengever/meeting/command.py
@@ -5,7 +5,6 @@ from opengever.base.interfaces import IDataCollector
 from opengever.base.model import create_session
 from opengever.base.oguid import Oguid
 from opengever.base.request import dispatch_json_request
-from opengever.base.request import dispatch_request
 from opengever.base.transport import REQUEST_KEY
 from opengever.base.transport import Transporter
 from opengever.document.versioner import Versioner
@@ -433,25 +432,6 @@ class CreateSubmittedProposalCommand(object):
             self.admin_unit_id, '@@create_submitted_proposal', data=request_data)
 
         self.submitted_proposal_path = response['path']
-
-
-class RejectProposalCommand(object):
-
-    def __init__(self, submitted_proposal):
-        self.submitted_proposal = submitted_proposal
-
-    def execute(self):
-        model = self.submitted_proposal.load_model()
-        response = dispatch_request(
-            model.admin_unit_id,
-            '@@reject-proposal',
-            path=model.physical_path)
-
-        response_body = response.read()
-        if response_body != 'OK':
-            raise ValueError(
-                'Unexpected response {!r} when rejecting proposal.'.format(
-                    response_body))
 
 
 class NullUpdateSubmittedDocumentCommand(object):

--- a/opengever/meeting/connector/actions.py
+++ b/opengever/meeting/connector/actions.py
@@ -1,0 +1,9 @@
+from opengever.meeting.connector.connector import Connector
+from opengever.meeting.connector.connector import ConnectorAction
+
+
+@Connector.register
+class CommentAction(ConnectorAction):
+    def execute(self):
+        text = self.data.get('text')
+        self.context._comment(text)

--- a/opengever/meeting/connector/actions.py
+++ b/opengever/meeting/connector/actions.py
@@ -21,3 +21,10 @@ class RejectAction(ConnectorAction):
     def execute(self):
         text = self.data.get('text')
         self.context._reject(text)
+
+
+@Connector.register
+class ScheduleAction(ConnectorAction):
+    def execute(self):
+        meeting_id = self.data.get('meeting_id')
+        self.context._schedule(meeting_id)

--- a/opengever/meeting/connector/actions.py
+++ b/opengever/meeting/connector/actions.py
@@ -7,3 +7,10 @@ class CommentAction(ConnectorAction):
     def execute(self):
         text = self.data.get('text')
         self.context._comment(text)
+
+
+@Connector.register
+class SubmitAction(ConnectorAction):
+    def execute(self):
+        text = self.data.get('text')
+        self.context._submit(text)

--- a/opengever/meeting/connector/actions.py
+++ b/opengever/meeting/connector/actions.py
@@ -28,3 +28,9 @@ class ScheduleAction(ConnectorAction):
     def execute(self):
         meeting_id = self.data.get('meeting_id')
         self.context._schedule(meeting_id)
+
+
+@Connector.register
+class DecideAction(ConnectorAction):
+    def execute(self):
+        self.context._decide()

--- a/opengever/meeting/connector/actions.py
+++ b/opengever/meeting/connector/actions.py
@@ -34,3 +34,12 @@ class ScheduleAction(ConnectorAction):
 class DecideAction(ConnectorAction):
     def execute(self):
         self.context._decide()
+
+
+@Connector.register
+class UpdateSubmittedDocumentAction(ConnectorAction):
+    def execute(self):
+        document_title = self.data.get('document_title')
+        submitted_version = self.data.get('submitted_version')
+        self.context._update_submitted_document(
+            document_title, submitted_version)

--- a/opengever/meeting/connector/actions.py
+++ b/opengever/meeting/connector/actions.py
@@ -14,3 +14,10 @@ class SubmitAction(ConnectorAction):
     def execute(self):
         text = self.data.get('text')
         self.context._submit(text)
+
+
+@Connector.register
+class RejectAction(ConnectorAction):
+    def execute(self):
+        text = self.data.get('text')
+        self.context._reject(text)

--- a/opengever/meeting/connector/actions.py
+++ b/opengever/meeting/connector/actions.py
@@ -43,3 +43,10 @@ class UpdateSubmittedDocumentAction(ConnectorAction):
         submitted_version = self.data.get('submitted_version')
         self.context._update_submitted_document(
             document_title, submitted_version)
+
+
+@Connector.register
+class SubmitDocumentAction(ConnectorAction):
+    def execute(self):
+        document_title = self.data.get('document_title')
+        self.context._submit_document(document_title)

--- a/opengever/meeting/connector/connector.py
+++ b/opengever/meeting/connector/connector.py
@@ -1,0 +1,90 @@
+from opengever.base import advancedjson
+from opengever.base.request import dispatch_request
+
+
+class Connector(object):
+    """The connector connects two objects and executes a dispatched action
+    for each connected object.
+
+    The use-case of this class is the following:
+
+    We have a Proposal and a Submitted Proposal. They don't know each other but
+    they are related in some kind.
+
+    Another class, the SQL Proposal knows the paths for this objects.
+
+    If we want to change something on the Proposal, we also want to change it
+    on the Submitted Proposal and vice versa.
+
+    The connector does exactly this. It connects the two objects. And later,
+    you can dispatch some actions. The dispatched actions are executed for each
+    connected object.
+    """
+    actions = {}
+
+    @classmethod
+    def register(cls, klass):
+        assert klass.action_id() not in cls.actions
+        cls.actions[klass.action_id()] = klass
+        return klass
+
+    def __init__(self):
+        self.paths = []
+
+    def connect_path(self, path):
+        self.paths.append(path)
+
+    def dispatch(self, action, **data):
+        for connector_path in self.paths:
+            request_data = {'data': advancedjson.dumps({
+                'action': action.action_id(),
+                'data': data
+            })}
+
+            response = dispatch_request(
+                connector_path.admin_unit_id,
+                '@@receive-connector-action',
+                path=connector_path.path,
+                data=request_data,)
+
+            self.validate_response(response)
+
+    @classmethod
+    def receive(cls, context, request):
+        data = advancedjson.loads(request.get('data'))
+        action = cls.actions.get(data.get('action'))
+        return action(context, request, data.get('data')).execute()
+
+    def validate_response(self, response):
+        response_body = response.read()
+        if response_body != 'OK':
+            raise ValueError(
+                'Unexpected response {!r} when validating response.'.format(
+                    response_body))
+
+
+class ConnectorPath(object):
+    """Use ConnectorPaths to connect different objects thorugh the Connector
+    class.
+    """
+    def __init__(self, admin_unit_id, path):
+        self.path = path
+        self.admin_unit_id = admin_unit_id
+
+
+class ConnectorAction(object):
+    """A connector action is something that should be excecuted on every
+    connected object.
+    """
+
+    def __init__(self, context, request, data):
+        self.context = context
+        self.request = request
+        self.data = data
+
+    def execute(self):
+        raise NotImplementedError
+
+    @classmethod
+    def action_id(cls):
+        return cls.__name__.decode('utf-8')

--- a/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-04 09:52+0000\n"
+"POT-Creation-Date: 2018-07-04 09:53+0000\n"
 "PO-Revision-Date: 2017-10-23 18:40+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1442,6 +1442,11 @@ msgstr "In Bearbeitung"
 #: ./opengever/meeting/browser/tabbed.py
 msgid "periods"
 msgstr "Perioden"
+
+#. Default: "Document ${title} submitted"
+#: ./opengever/meeting/activity/activities.py
+msgid "proposal_activity_label_document_submitted"
+msgstr "Dokument ${title} eingereicht"
 
 #. Default: "Submitted document ${title} updated to version ${version}"
 #: ./opengever/meeting/activity/activities.py

--- a/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-04 09:46+0000\n"
+"POT-Creation-Date: 2018-07-04 09:52+0000\n"
 "PO-Revision-Date: 2017-10-23 18:40+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1443,6 +1443,11 @@ msgstr "In Bearbeitung"
 msgid "periods"
 msgstr "Perioden"
 
+#. Default: "Submitted document ${title} updated to version ${version}"
+#: ./opengever/meeting/activity/activities.py
+msgid "proposal_activity_label_document_updated"
+msgstr "Eingereichtes Dokument ${title} aktualisiert zu Version ${version}"
+
 #. Default: "Proposal document"
 #: ./opengever/meeting/proposal.py
 msgid "proposal_document"
@@ -1454,6 +1459,7 @@ msgid "proposal_history_label_cancelled"
 msgstr "Storniert durch ${user}"
 
 #. Default: "Proposal commented by ${user}"
+#: ./opengever/meeting/activity/activities.py
 #: ./opengever/meeting/proposalhistory.py
 msgid "proposal_history_label_commented"
 msgstr "Kommentiert durch ${user}"
@@ -1464,6 +1470,7 @@ msgid "proposal_history_label_created"
 msgstr "Erstellt durch ${user}"
 
 #. Default: "Proposal decided by ${user}"
+#: ./opengever/meeting/activity/activities.py
 #: ./opengever/meeting/proposalhistory.py
 msgid "proposal_history_label_decided"
 msgstr "Antrag beschlossen durch ${user}"
@@ -1484,6 +1491,7 @@ msgid "proposal_history_label_reactivated"
 msgstr "Wieder eröffnet durch ${user}"
 
 #. Default: "Rejected by ${user}"
+#: ./opengever/meeting/activity/activities.py
 #: ./opengever/meeting/proposalhistory.py
 msgid "proposal_history_label_rejected"
 msgstr "Zurückgewiesen von ${user}"
@@ -1504,11 +1512,13 @@ msgid "proposal_history_label_revised"
 msgstr "Antragsbeschluss überarbeitet durch ${user}"
 
 #. Default: "Scheduled for meeting ${meeting} by ${user}"
+#: ./opengever/meeting/activity/activities.py
 #: ./opengever/meeting/proposalhistory.py
 msgid "proposal_history_label_scheduled"
 msgstr "Geplant für die Sitzung ${meeting} durch ${user}"
 
 #. Default: "Submitted by ${user}"
+#: ./opengever/meeting/activity/activities.py
 #: ./opengever/meeting/proposalhistory.py
 msgid "proposal_history_label_submitted"
 msgstr "Eingereicht durch ${user}"

--- a/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-04 09:46+0000\n"
+"POT-Creation-Date: 2018-07-04 09:52+0000\n"
 "PO-Revision-Date: 2018-05-22 10:15+0000\n"
 "Last-Translator: Niklaus Johner <Niklaus.johner@4teamwork.ch>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-meeting/fr/>\n"
@@ -1445,6 +1445,11 @@ msgstr "En modification"
 msgid "periods"
 msgstr "Périodes"
 
+#. Default: "Submitted document ${title} updated to version ${version}"
+#: ./opengever/meeting/activity/activities.py
+msgid "proposal_activity_label_document_updated"
+msgstr ""
+
 #. Default: "Proposal document"
 #: ./opengever/meeting/proposal.py
 msgid "proposal_document"
@@ -1456,6 +1461,7 @@ msgid "proposal_history_label_cancelled"
 msgstr "Annulé par ${user}"
 
 #. Default: "Proposal commented by ${user}"
+#: ./opengever/meeting/activity/activities.py
 #: ./opengever/meeting/proposalhistory.py
 msgid "proposal_history_label_commented"
 msgstr "Commenté par ${user}"
@@ -1466,6 +1472,7 @@ msgid "proposal_history_label_created"
 msgstr "Créé par ${user}"
 
 #. Default: "Proposal decided by ${user}"
+#: ./opengever/meeting/activity/activities.py
 #: ./opengever/meeting/proposalhistory.py
 msgid "proposal_history_label_decided"
 msgstr "Proposition décidée par ${user}"
@@ -1486,6 +1493,7 @@ msgid "proposal_history_label_reactivated"
 msgstr "Réactivé par ${user}"
 
 #. Default: "Rejected by ${user}"
+#: ./opengever/meeting/activity/activities.py
 #: ./opengever/meeting/proposalhistory.py
 msgid "proposal_history_label_rejected"
 msgstr "Rejeté par ${user}"
@@ -1506,11 +1514,13 @@ msgid "proposal_history_label_revised"
 msgstr "Décision de proposition révisée par ${user}"
 
 #. Default: "Scheduled for meeting ${meeting} by ${user}"
+#: ./opengever/meeting/activity/activities.py
 #: ./opengever/meeting/proposalhistory.py
 msgid "proposal_history_label_scheduled"
 msgstr "Prévu pour la séance ${meeting} par ${user}"
 
 #. Default: "Submitted by ${user}"
+#: ./opengever/meeting/activity/activities.py
 #: ./opengever/meeting/proposalhistory.py
 msgid "proposal_history_label_submitted"
 msgstr "Soumis par ${user}"

--- a/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-04 09:52+0000\n"
+"POT-Creation-Date: 2018-07-04 09:53+0000\n"
 "PO-Revision-Date: 2018-05-22 10:15+0000\n"
 "Last-Translator: Niklaus Johner <Niklaus.johner@4teamwork.ch>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-meeting/fr/>\n"
@@ -1444,6 +1444,11 @@ msgstr "En modification"
 #: ./opengever/meeting/browser/tabbed.py
 msgid "periods"
 msgstr "Périodes"
+
+#. Default: "Document ${title} submitted"
+#: ./opengever/meeting/activity/activities.py
+msgid "proposal_activity_label_document_submitted"
+msgstr ""
 
 #. Default: "Submitted document ${title} updated to version ${version}"
 #: ./opengever/meeting/activity/activities.py

--- a/opengever/meeting/locales/opengever.meeting.pot
+++ b/opengever/meeting/locales/opengever.meeting.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-04 09:46+0000\n"
+"POT-Creation-Date: 2018-07-04 09:52+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1442,6 +1442,11 @@ msgstr ""
 msgid "periods"
 msgstr ""
 
+#. Default: "Submitted document ${title} updated to version ${version}"
+#: ./opengever/meeting/activity/activities.py
+msgid "proposal_activity_label_document_updated"
+msgstr ""
+
 #. Default: "Proposal document"
 #: ./opengever/meeting/proposal.py
 msgid "proposal_document"
@@ -1453,6 +1458,7 @@ msgid "proposal_history_label_cancelled"
 msgstr ""
 
 #. Default: "Proposal commented by ${user}"
+#: ./opengever/meeting/activity/activities.py
 #: ./opengever/meeting/proposalhistory.py
 msgid "proposal_history_label_commented"
 msgstr ""
@@ -1463,6 +1469,7 @@ msgid "proposal_history_label_created"
 msgstr ""
 
 #. Default: "Proposal decided by ${user}"
+#: ./opengever/meeting/activity/activities.py
 #: ./opengever/meeting/proposalhistory.py
 msgid "proposal_history_label_decided"
 msgstr ""
@@ -1483,6 +1490,7 @@ msgid "proposal_history_label_reactivated"
 msgstr ""
 
 #. Default: "Rejected by ${user}"
+#: ./opengever/meeting/activity/activities.py
 #: ./opengever/meeting/proposalhistory.py
 msgid "proposal_history_label_rejected"
 msgstr ""
@@ -1503,11 +1511,13 @@ msgid "proposal_history_label_revised"
 msgstr ""
 
 #. Default: "Scheduled for meeting ${meeting} by ${user}"
+#: ./opengever/meeting/activity/activities.py
 #: ./opengever/meeting/proposalhistory.py
 msgid "proposal_history_label_scheduled"
 msgstr ""
 
 #. Default: "Submitted by ${user}"
+#: ./opengever/meeting/activity/activities.py
 #: ./opengever/meeting/proposalhistory.py
 msgid "proposal_history_label_submitted"
 msgstr ""

--- a/opengever/meeting/locales/opengever.meeting.pot
+++ b/opengever/meeting/locales/opengever.meeting.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-04 09:52+0000\n"
+"POT-Creation-Date: 2018-07-04 09:53+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1440,6 +1440,11 @@ msgstr ""
 #. Default: "Periods"
 #: ./opengever/meeting/browser/tabbed.py
 msgid "periods"
+msgstr ""
+
+#. Default: "Document ${title} submitted"
+#: ./opengever/meeting/activity/activities.py
+msgid "proposal_activity_label_document_submitted"
 msgstr ""
 
 #. Default: "Submitted document ${title} updated to version ${version}"

--- a/opengever/meeting/model/proposal.py
+++ b/opengever/meeting/model/proposal.py
@@ -315,6 +315,8 @@ class Proposal(Base):
     def reject(self, text):
         assert self.workflow.can_execute_transition(self, 'submitted-pending')
 
+        self.connector.dispatch(RejectAction, text=text)
+
         self.submitted_physical_path = None
         self.submitted_admin_unit_id = None
         self.submitted_int_id = None
@@ -323,8 +325,6 @@ class Proposal(Base):
         # set workflow state directly for once, the transition is used to
         # redirect to a form.
         self.workflow_state = self.STATE_PENDING.name
-
-        self.connector.dispatch(RejectAction, text=text)
 
     def remove_scheduled(self, meeting):
         self.execute_transition('scheduled-submitted')

--- a/opengever/meeting/model/proposal.py
+++ b/opengever/meeting/model/proposal.py
@@ -9,6 +9,7 @@ from opengever.meeting.connector.actions import DecideAction
 from opengever.meeting.connector.actions import RejectAction
 from opengever.meeting.connector.actions import ScheduleAction
 from opengever.meeting.connector.actions import SubmitAction
+from opengever.meeting.connector.actions import UpdateSubmittedDocumentAction
 from opengever.meeting.connector.connector import Connector
 from opengever.meeting.connector.connector import ConnectorPath
 from opengever.meeting.interfaces import IHistory
@@ -427,6 +428,11 @@ class Proposal(Base):
 
     def submit(self, **kwargs):
         self.connector.dispatch(SubmitAction, **kwargs)
+
+    def update_submitted_document(self, document, submitted_document):
+        self.connector.dispatch(UpdateSubmittedDocumentAction,
+                                document_title=document.title,
+                                submitted_version=document.get_current_version_id())
 
     @property
     def connector(self):

--- a/opengever/meeting/model/proposal.py
+++ b/opengever/meeting/model/proposal.py
@@ -5,6 +5,7 @@ from opengever.document.interfaces import ICheckinCheckoutManager
 from opengever.globalindex.model import WORKFLOW_STATE_LENGTH
 from opengever.meeting import _
 from opengever.meeting.connector.actions import CommentAction
+from opengever.meeting.connector.actions import SubmitAction
 from opengever.meeting.connector.connector import Connector
 from opengever.meeting.connector.connector import ConnectorPath
 from opengever.meeting.interfaces import IHistory
@@ -415,6 +416,9 @@ class Proposal(Base):
 
     def comment(self, **kwargs):
         self.connector.dispatch(CommentAction, **kwargs)
+
+    def submit(self, **kwargs):
+        self.connector.dispatch(SubmitAction, **kwargs)
 
     @property
     def connector(self):

--- a/opengever/meeting/model/proposal.py
+++ b/opengever/meeting/model/proposal.py
@@ -6,6 +6,7 @@ from opengever.globalindex.model import WORKFLOW_STATE_LENGTH
 from opengever.meeting import _
 from opengever.meeting.connector.actions import CommentAction
 from opengever.meeting.connector.actions import RejectAction
+from opengever.meeting.connector.actions import ScheduleAction
 from opengever.meeting.connector.actions import SubmitAction
 from opengever.meeting.connector.connector import Connector
 from opengever.meeting.connector.connector import ConnectorPath
@@ -311,6 +312,8 @@ class Proposal(Base):
 
         IHistory(self.resolve_submitted_proposal()).append_record(
             u'scheduled', meeting_id=meeting.meeting_id)
+
+        self.connector.dispatch(ScheduleAction, meeting_id=meeting.meeting_id)
 
     def reject(self, text):
         assert self.workflow.can_execute_transition(self, 'submitted-pending')

--- a/opengever/meeting/model/proposal.py
+++ b/opengever/meeting/model/proposal.py
@@ -9,6 +9,7 @@ from opengever.meeting.connector.actions import DecideAction
 from opengever.meeting.connector.actions import RejectAction
 from opengever.meeting.connector.actions import ScheduleAction
 from opengever.meeting.connector.actions import SubmitAction
+from opengever.meeting.connector.actions import SubmitDocumentAction
 from opengever.meeting.connector.actions import UpdateSubmittedDocumentAction
 from opengever.meeting.connector.connector import Connector
 from opengever.meeting.connector.connector import ConnectorPath
@@ -433,6 +434,10 @@ class Proposal(Base):
         self.connector.dispatch(UpdateSubmittedDocumentAction,
                                 document_title=document.title,
                                 submitted_version=document.get_current_version_id())
+
+    def copy_proposal_document(self, document):
+        self.connector.dispatch(SubmitDocumentAction,
+                                document_title=document.title)
 
     @property
     def connector(self):

--- a/opengever/meeting/model/proposal.py
+++ b/opengever/meeting/model/proposal.py
@@ -4,6 +4,7 @@ from opengever.base.utils import escape_html
 from opengever.document.interfaces import ICheckinCheckoutManager
 from opengever.globalindex.model import WORKFLOW_STATE_LENGTH
 from opengever.meeting import _
+from opengever.meeting.connector.actions import CommentAction
 from opengever.meeting.connector.connector import Connector
 from opengever.meeting.connector.connector import ConnectorPath
 from opengever.meeting.interfaces import IHistory
@@ -411,6 +412,9 @@ class Proposal(Base):
             return u''
 
         return agenda_item.meeting.get_link()
+
+    def comment(self, **kwargs):
+        self.connector.dispatch(CommentAction, **kwargs)
 
     @property
     def connector(self):

--- a/opengever/meeting/model/proposal.py
+++ b/opengever/meeting/model/proposal.py
@@ -5,6 +5,7 @@ from opengever.document.interfaces import ICheckinCheckoutManager
 from opengever.globalindex.model import WORKFLOW_STATE_LENGTH
 from opengever.meeting import _
 from opengever.meeting.connector.actions import CommentAction
+from opengever.meeting.connector.actions import DecideAction
 from opengever.meeting.connector.actions import RejectAction
 from opengever.meeting.connector.actions import ScheduleAction
 from opengever.meeting.connector.actions import SubmitAction
@@ -369,6 +370,8 @@ class Proposal(Base):
 
         IHistory(self.resolve_submitted_proposal()).append_record(u'decided')
         self.execute_transition('scheduled-decided')
+
+        self.connector.dispatch(DecideAction)
 
     def register_excerpt(self, document_intid):
         """Adds a GeneratedExcerpt database entry and a corresponding

--- a/opengever/meeting/model/proposal.py
+++ b/opengever/meeting/model/proposal.py
@@ -4,6 +4,8 @@ from opengever.base.utils import escape_html
 from opengever.document.interfaces import ICheckinCheckoutManager
 from opengever.globalindex.model import WORKFLOW_STATE_LENGTH
 from opengever.meeting import _
+from opengever.meeting.connector.connector import Connector
+from opengever.meeting.connector.connector import ConnectorPath
 from opengever.meeting.interfaces import IHistory
 from opengever.meeting.model import AgendaItem
 from opengever.meeting.model.generateddocument import GeneratedExcerpt
@@ -409,3 +411,12 @@ class Proposal(Base):
             return u''
 
         return agenda_item.meeting.get_link()
+
+    @property
+    def connector(self):
+        connector = Connector()
+        connector.connect_path(ConnectorPath(self.admin_unit_id, self.physical_path))
+        if self.is_submitted():
+            connector.connect_path(ConnectorPath(self.submitted_admin_unit_id, self.submitted_physical_path))
+
+        return connector

--- a/opengever/meeting/model/proposal.py
+++ b/opengever/meeting/model/proposal.py
@@ -5,6 +5,7 @@ from opengever.document.interfaces import ICheckinCheckoutManager
 from opengever.globalindex.model import WORKFLOW_STATE_LENGTH
 from opengever.meeting import _
 from opengever.meeting.connector.actions import CommentAction
+from opengever.meeting.connector.actions import RejectAction
 from opengever.meeting.connector.actions import SubmitAction
 from opengever.meeting.connector.connector import Connector
 from opengever.meeting.connector.connector import ConnectorPath
@@ -322,7 +323,8 @@ class Proposal(Base):
         # set workflow state directly for once, the transition is used to
         # redirect to a form.
         self.workflow_state = self.STATE_PENDING.name
-        IHistory(self.resolve_proposal()).append_record(u'rejected', text=text)
+
+        self.connector.dispatch(RejectAction, text=text)
 
     def remove_scheduled(self, meeting):
         self.execute_transition('scheduled-submitted')

--- a/opengever/meeting/proposal.py
+++ b/opengever/meeting/proposal.py
@@ -19,6 +19,7 @@ from opengever.meeting import _
 from opengever.meeting.activity.activities import ProposalCommentedActivitiy
 from opengever.meeting.activity.activities import ProposalRejectedActivity
 from opengever.meeting.activity.activities import ProposalSubmittedActivity
+from opengever.meeting.activity.activities import ProposalScheduledActivity
 from opengever.meeting.activity.watchers import remove_watchers_on_submitted_proposal_deleted
 from opengever.meeting.command import CopyProposalDocumentCommand
 from opengever.meeting.command import CreateSubmittedProposalCommand
@@ -343,6 +344,11 @@ class ProposalBase(ModelContainer):
         """
         ProposalRejectedActivity(self, self.REQUEST).record()
         IHistory(self).append_record(u'rejected', text=text)
+
+    def _schedule(self, meeting_id):
+        """Called by the connector-action ScheduleAction
+        """
+        ProposalScheduledActivity(self, self.REQUEST, meeting_id).record()
 
 
 class SubmittedProposal(ProposalBase):

--- a/opengever/meeting/proposal.py
+++ b/opengever/meeting/proposal.py
@@ -16,6 +16,7 @@ from opengever.document.widgets.document_link import DocumentLinkWidget
 from opengever.dossier.behaviors.dossier import IDossierMarker
 from opengever.dossier.utils import get_containing_dossier
 from opengever.meeting import _
+from opengever.meeting.activity.activities import ProposalCommentedActivitiy
 from opengever.meeting.activity.watchers import remove_watchers_on_submitted_proposal_deleted
 from opengever.meeting.command import CopyProposalDocumentCommand
 from opengever.meeting.command import CreateSubmittedProposalCommand
@@ -323,7 +324,13 @@ class ProposalBase(ModelContainer):
         return False
 
     def comment(self, text, uuid=None):
+        self.load_model().comment(text=text)
         return IHistory(self).append_record(u'commented', uuid=uuid, text=text)
+
+    def _comment(self, text):
+        """Called by the connector-action CommentAction
+        """
+        ProposalCommentedActivitiy(self, self.REQUEST).record()
 
 
 class SubmittedProposal(ProposalBase):

--- a/opengever/meeting/proposal.py
+++ b/opengever/meeting/proposal.py
@@ -22,7 +22,6 @@ from opengever.meeting.activity.watchers import remove_watchers_on_submitted_pro
 from opengever.meeting.command import CopyProposalDocumentCommand
 from opengever.meeting.command import CreateSubmittedProposalCommand
 from opengever.meeting.command import NullUpdateSubmittedDocumentCommand
-from opengever.meeting.command import RejectProposalCommand
 from opengever.meeting.command import UpdateSubmittedDocumentCommand
 from opengever.meeting.container import ModelContainer
 from opengever.meeting.interfaces import IHistory
@@ -338,6 +337,11 @@ class ProposalBase(ModelContainer):
         """
         ProposalSubmittedActivity(self, self.REQUEST).record()
 
+    def _reject(self, text):
+        """Called by the connector-action RejectAction
+        """
+        IHistory(self).append_record(u'rejected', text=text)
+
 
 class SubmittedProposal(ProposalBase):
     """Proxy for a proposal in queue with a committee."""
@@ -439,13 +443,14 @@ class SubmittedProposal(ProposalBase):
 
     def reject(self, text):
         """Reject the submitted proposal."""
+        self.load_model().reject(text)
 
-        RejectProposalCommand(self).execute()
-        proposal = self.load_model()
-        proposal.reject(text)
-
+    def _reject(self, text):
+        """Called by the connector-action RejectAction
+        """
+        super(SubmittedProposal, self)._reject(text)
         remove_watchers_on_submitted_proposal_deleted(
-            self, proposal.committee.group_id)
+            self, self.load_model().committee.group_id)
 
         with elevated_privileges():
             api.content.delete(self)
@@ -693,13 +698,11 @@ class Proposal(ProposalBase):
 
         self.load_model().submit(text=text)
 
-    def reject(self):
-        """Reject the proposal.
-
-        Called via remote-request after the proposal has been rejected on the
-        committee side.
+    def _reject(self, text):
+        """Called by the connector-action RejectAction after the proposal has
+        been rejected on the committee side.
         """
-
+        super(Proposal, self)._reject(text)
         self.date_of_submission = None
         api.content.transition(obj=self,
                                transition='proposal-transition-reject')

--- a/opengever/meeting/proposal.py
+++ b/opengever/meeting/proposal.py
@@ -18,6 +18,7 @@ from opengever.dossier.utils import get_containing_dossier
 from opengever.meeting import _
 from opengever.meeting.activity.activities import ProposalCommentedActivitiy
 from opengever.meeting.activity.activities import ProposalDecideActivity
+from opengever.meeting.activity.activities import ProposalDocumentSubmittedActivity
 from opengever.meeting.activity.activities import ProposalDocumentUpdatedActivity
 from opengever.meeting.activity.activities import ProposalRejectedActivity
 from opengever.meeting.activity.activities import ProposalScheduledActivity
@@ -363,6 +364,12 @@ class ProposalBase(ModelContainer):
         ProposalDocumentUpdatedActivity(
             self, self.REQUEST, document_title, submitted_version).record()
 
+    def _submit_document(self, document_title):
+        """Called by the connector-action SubmitDocumentAction
+        """
+        ProposalDocumentSubmittedActivity(
+            self, self.REQUEST, document_title).record()
+
 
 class SubmittedProposal(ProposalBase):
     """Proxy for a proposal in queue with a committee."""
@@ -680,6 +687,8 @@ class Proposal(ProposalBase):
                 document,
                 target_path=proposal_model.submitted_physical_path,
                 target_admin_unit_id=proposal_model.submitted_admin_unit_id)
+
+            proposal_model.copy_proposal_document(document)
 
             if not self.relatedItems:
                 # The missing_value attribute of a z3c-form field is used

--- a/opengever/meeting/proposal.py
+++ b/opengever/meeting/proposal.py
@@ -17,6 +17,7 @@ from opengever.dossier.behaviors.dossier import IDossierMarker
 from opengever.dossier.utils import get_containing_dossier
 from opengever.meeting import _
 from opengever.meeting.activity.activities import ProposalCommentedActivitiy
+from opengever.meeting.activity.activities import ProposalSubmittedActivity
 from opengever.meeting.activity.watchers import remove_watchers_on_submitted_proposal_deleted
 from opengever.meeting.command import CopyProposalDocumentCommand
 from opengever.meeting.command import CreateSubmittedProposalCommand
@@ -331,6 +332,11 @@ class ProposalBase(ModelContainer):
         """Called by the connector-action CommentAction
         """
         ProposalCommentedActivitiy(self, self.REQUEST).record()
+
+    def _submit(self, text):
+        """Called by the connector-action SubmitAction
+        """
+        ProposalSubmittedActivity(self, self.REQUEST).record()
 
 
 class SubmittedProposal(ProposalBase):
@@ -684,6 +690,8 @@ class Proposal(ProposalBase):
         create_command.execute(text)
         for copy_command in copy_commands:
             copy_command.execute()
+
+        self.load_model().submit(text=text)
 
     def reject(self):
         """Reject the proposal.

--- a/opengever/meeting/proposal.py
+++ b/opengever/meeting/proposal.py
@@ -18,6 +18,7 @@ from opengever.dossier.utils import get_containing_dossier
 from opengever.meeting import _
 from opengever.meeting.activity.activities import ProposalCommentedActivitiy
 from opengever.meeting.activity.activities import ProposalDecideActivity
+from opengever.meeting.activity.activities import ProposalDocumentUpdatedActivity
 from opengever.meeting.activity.activities import ProposalRejectedActivity
 from opengever.meeting.activity.activities import ProposalScheduledActivity
 from opengever.meeting.activity.activities import ProposalSubmittedActivity
@@ -356,6 +357,12 @@ class ProposalBase(ModelContainer):
         """
         ProposalDecideActivity(self, self.REQUEST).record()
 
+    def _update_submitted_document(self, document_title, submitted_version):
+        """Called by the connector-action UpdateSubmittedDocumentAction
+        """
+        ProposalDocumentUpdatedActivity(
+            self, self.REQUEST, document_title, submitted_version).record()
+
 
 class SubmittedProposal(ProposalBase):
     """Proxy for a proposal in queue with a committee."""
@@ -665,7 +672,8 @@ class Proposal(ProposalBase):
             else:
                 command = UpdateSubmittedDocumentCommand(
                     self, document, submitted_document)
-
+                proposal_model.update_submitted_document(
+                    document, submitted_document)
         else:
             command = CopyProposalDocumentCommand(
                 self,

--- a/opengever/meeting/proposal.py
+++ b/opengever/meeting/proposal.py
@@ -17,9 +17,10 @@ from opengever.dossier.behaviors.dossier import IDossierMarker
 from opengever.dossier.utils import get_containing_dossier
 from opengever.meeting import _
 from opengever.meeting.activity.activities import ProposalCommentedActivitiy
+from opengever.meeting.activity.activities import ProposalDecideActivity
 from opengever.meeting.activity.activities import ProposalRejectedActivity
-from opengever.meeting.activity.activities import ProposalSubmittedActivity
 from opengever.meeting.activity.activities import ProposalScheduledActivity
+from opengever.meeting.activity.activities import ProposalSubmittedActivity
 from opengever.meeting.activity.watchers import remove_watchers_on_submitted_proposal_deleted
 from opengever.meeting.command import CopyProposalDocumentCommand
 from opengever.meeting.command import CreateSubmittedProposalCommand
@@ -349,6 +350,11 @@ class ProposalBase(ModelContainer):
         """Called by the connector-action ScheduleAction
         """
         ProposalScheduledActivity(self, self.REQUEST, meeting_id).record()
+
+    def _decide(self):
+        """Called by the connector-action DecideAction
+        """
+        ProposalDecideActivity(self, self.REQUEST).record()
 
 
 class SubmittedProposal(ProposalBase):

--- a/opengever/meeting/proposal.py
+++ b/opengever/meeting/proposal.py
@@ -17,6 +17,7 @@ from opengever.dossier.behaviors.dossier import IDossierMarker
 from opengever.dossier.utils import get_containing_dossier
 from opengever.meeting import _
 from opengever.meeting.activity.activities import ProposalCommentedActivitiy
+from opengever.meeting.activity.activities import ProposalRejectedActivity
 from opengever.meeting.activity.activities import ProposalSubmittedActivity
 from opengever.meeting.activity.watchers import remove_watchers_on_submitted_proposal_deleted
 from opengever.meeting.command import CopyProposalDocumentCommand
@@ -340,6 +341,7 @@ class ProposalBase(ModelContainer):
     def _reject(self, text):
         """Called by the connector-action RejectAction
         """
+        ProposalRejectedActivity(self, self.REQUEST).record()
         IHistory(self).append_record(u'rejected', text=text)
 
 

--- a/opengever/meeting/tests/test_activites.py
+++ b/opengever/meeting/tests/test_activites.py
@@ -178,6 +178,35 @@ class TestMeetingActivities(IntegrationTestCase):
                 u'Proposal decided by {}'.format(actor_link()),
                 activity.summary)
 
+    @browsing
+    def test_record_activity_on_update_attachment_for_proposal_and_submitted_proposal(self, browser):
+        self.login(self.committee_responsible, browser)
+        rtool = api.portal.get_tool('portal_repository')
+
+        document = self.subdocument
+
+        self.assertEqual(0, Activity.query.count())
+
+        # create init version
+        rtool.save(document)
+
+        self.proposal.submit_additional_document(document)
+
+        # create version 1
+        rtool.save(document)
+
+        self.proposal.submit_additional_document(document)
+
+        self.assertEqual(2, Activity.query.count())
+
+        for activity in Activity.query.all():
+            self.assertEquals('proposal-attachment-updated', activity.kind)
+            self.assertEquals('Attachment updated', activity.label)
+            self.assertEquals(self.proposal.title, activity.title)
+            self.assertEquals(
+                u'Submitted document {} updated to version 1'.format(document.title),
+                activity.summary)
+
     def assertSubscribersForResource(self, subscribers, resource):
         self.assertItemsEqual(
             [subscriber.id for subscriber in subscribers],

--- a/opengever/meeting/tests/test_activites.py
+++ b/opengever/meeting/tests/test_activites.py
@@ -155,6 +155,29 @@ class TestMeetingActivities(IntegrationTestCase):
                 u'Scheduled for meeting {} by {}'.format(meeting.get_title(), actor_link()),
                 activity.summary)
 
+    @browsing
+    def test_record_activity_on_decide_a_proposal_for_proposal_and_submitted_proposal(self, browser):
+        self.login(self.committee_responsible, browser)
+        meeting = self.meeting.model
+
+        self.assertEqual(0, Activity.query.count())
+
+        self.submitted_proposal.load_model().schedule(meeting)
+
+        self.assertEqual(2, Activity.query.count())
+
+        self.submitted_proposal.load_model().decide(meeting)
+
+        self.assertEqual(4, Activity.query.count())
+
+        for activity in Activity.query.all()[-2:]:
+            self.assertEquals('proposal-transition-decide', activity.kind)
+            self.assertEquals('Proposal decided', activity.label)
+            self.assertEquals(self.proposal.title, activity.title)
+            self.assertEquals(
+                u'Proposal decided by {}'.format(actor_link()),
+                activity.summary)
+
     def assertSubscribersForResource(self, subscribers, resource):
         self.assertItemsEqual(
             [subscriber.id for subscriber in subscribers],

--- a/opengever/meeting/tests/test_activites.py
+++ b/opengever/meeting/tests/test_activites.py
@@ -1,6 +1,8 @@
 from ftw.testbrowser import browsing
 from ftw.testbrowser.pages import factoriesmenu
+from opengever.activity.model import Activity
 from opengever.activity.model.subscription import Subscription
+from opengever.meeting.activity.activities import actor_link
 from opengever.testing import IntegrationTestCase
 from plone import api
 from zope.app.intid.interfaces import IIntIds
@@ -84,6 +86,22 @@ class TestMeetingActivities(IntegrationTestCase):
 
         self.assertSubscribersForResource([self.dossier_responsible], proposal)
         self.assertSubscribersLength(1)
+
+    @browsing
+    def test_record_activity_on_comment_for_proposal_and_submitted_proposal(self, browser):
+        self.login(self.committee_responsible)
+
+        self.assertEqual(0, Activity.query.count())
+
+        self.proposal.comment(u'james b\xc3\xb6nd')
+
+        self.assertEqual(2, Activity.query.count())
+        for activity in Activity.query.all():
+            self.assertEquals('proposal-commented', activity.kind)
+            self.assertEquals(self.proposal.title, activity.title)
+            self.assertEquals(
+                u'Proposal commented by {}'.format(actor_link()),
+                activity.summary)
 
     def assertSubscribersForResource(self, subscribers, resource):
         self.assertItemsEqual(

--- a/opengever/meeting/tests/test_activites.py
+++ b/opengever/meeting/tests/test_activites.py
@@ -120,6 +120,23 @@ class TestMeetingActivities(IntegrationTestCase):
                 u'Submitted by {}'.format(actor_link()),
                 activity.summary)
 
+    @browsing
+    def test_record_activity_on_rejecting_a_proposal_for_proposal_and_submitted_proposal(self, browser):
+        self.login(self.committee_responsible, browser)
+
+        self.assertEqual(0, Activity.query.count())
+
+        self.reject_proposal(self.submitted_proposal, browser, comment=u'james b\xc3\xb6nd')
+
+        self.assertEqual(2, Activity.query.count())
+        for activity in Activity.query.all():
+            self.assertEquals('proposal-transition-reject', activity.kind)
+            self.assertEquals('Proposal rejected', activity.label)
+            self.assertEquals(self.proposal.title, activity.title)
+            self.assertEquals(
+                u'Rejected by {}'.format(actor_link()),
+                activity.summary)
+
     def assertSubscribersForResource(self, subscribers, resource):
         self.assertItemsEqual(
             [subscriber.id for subscriber in subscribers],
@@ -160,8 +177,8 @@ class TestMeetingActivities(IntegrationTestCase):
     def submit_proposal(self, proposal, browser, comment=''):
         self.execute_transition(proposal, 'pending-submitted', browser, comment)
 
-    def reject_proposal(self, proposal, browser):
-        self.execute_transition(proposal, 'submitted-pending', browser)
+    def reject_proposal(self, proposal, browser, comment=''):
+        self.execute_transition(proposal, 'submitted-pending', browser, comment)
 
     def create_proposal_with_issuer(self, issuer, committee, browser):
         browser.open(self.dossier)

--- a/opengever/meeting/tests/test_activites.py
+++ b/opengever/meeting/tests/test_activites.py
@@ -103,6 +103,23 @@ class TestMeetingActivities(IntegrationTestCase):
                 u'Proposal commented by {}'.format(actor_link()),
                 activity.summary)
 
+    @browsing
+    def test_record_activity_on_submtitting_a_proposal_for_proposal_and_submitted_proposal(self, browser):
+        self.login(self.committee_responsible, browser)
+
+        self.assertEqual(0, Activity.query.count())
+
+        self.submit_proposal(self.draft_proposal, browser, comment=u'james b\xc3\xb6nd')
+
+        self.assertEqual(2, Activity.query.count())
+        for activity in Activity.query.all():
+            self.assertEquals('proposal-transition-submit', activity.kind)
+            self.assertEquals('Proposal submitted', activity.label)
+            self.assertEquals(self.draft_proposal.title, activity.title)
+            self.assertEquals(
+                u'Submitted by {}'.format(actor_link()),
+                activity.summary)
+
     def assertSubscribersForResource(self, subscribers, resource):
         self.assertItemsEqual(
             [subscriber.id for subscriber in subscribers],
@@ -132,14 +149,16 @@ class TestMeetingActivities(IntegrationTestCase):
     def get_group_members(self, group_id):
         return api.user.get_users(groupname=group_id)
 
-    def execute_transition(self, obj, transition, browser):
+    def execute_transition(self, obj, transition, browser, comment=''):
         browser.visit(
             obj, view="addtransitioncomment?form.widgets.transition={}".format(
                 transition))
+        if comment:
+            browser.fill({'Comment': comment})
         browser.find('Confirm').click()
 
-    def submit_proposal(self, proposal, browser):
-        self.execute_transition(proposal, 'pending-submitted', browser)
+    def submit_proposal(self, proposal, browser, comment=''):
+        self.execute_transition(proposal, 'pending-submitted', browser, comment)
 
     def reject_proposal(self, proposal, browser):
         self.execute_transition(proposal, 'submitted-pending', browser)

--- a/opengever/meeting/tests/test_activites.py
+++ b/opengever/meeting/tests/test_activites.py
@@ -137,6 +137,24 @@ class TestMeetingActivities(IntegrationTestCase):
                 u'Rejected by {}'.format(actor_link()),
                 activity.summary)
 
+    @browsing
+    def test_record_activity_on_schedule_a_proposal_for_proposal_and_submitted_proposal(self, browser):
+        self.login(self.committee_responsible, browser)
+        meeting = self.meeting.model
+
+        self.assertEqual(0, Activity.query.count())
+
+        self.submitted_proposal.load_model().schedule(meeting)
+
+        self.assertEqual(2, Activity.query.count())
+        for activity in Activity.query.all():
+            self.assertEquals('proposal-transition-schedule', activity.kind)
+            self.assertEquals('Proposal scheduled', activity.label)
+            self.assertEquals(self.proposal.title, activity.title)
+            self.assertEquals(
+                u'Scheduled for meeting {} by {}'.format(meeting.get_title(), actor_link()),
+                activity.summary)
+
     def assertSubscribersForResource(self, subscribers, resource):
         self.assertItemsEqual(
             [subscriber.id for subscriber in subscribers],

--- a/opengever/meeting/tests/test_activites.py
+++ b/opengever/meeting/tests/test_activites.py
@@ -192,19 +192,41 @@ class TestMeetingActivities(IntegrationTestCase):
 
         self.proposal.submit_additional_document(document)
 
+        self.assertEqual(2, Activity.query.count())
+
         # create version 1
         rtool.save(document)
+
+        self.proposal.submit_additional_document(document)
+
+        self.assertEqual(4, Activity.query.count())
+
+        for activity in Activity.query.all()[-2:]:
+            self.assertEquals('proposal-attachment-updated', activity.kind)
+            self.assertEquals('Attachment updated', activity.label)
+            self.assertEquals(self.proposal.title, activity.title)
+            self.assertEquals(
+                u'Submitted document {} updated to version 1'.format(document.title),
+                activity.summary)
+
+    @browsing
+    def test_record_activity_on_submit_attachment_for_proposal_and_submitted_proposal(self, browser):
+        self.login(self.committee_responsible, browser)
+
+        document = self.subdocument
+
+        self.assertEqual(0, Activity.query.count())
 
         self.proposal.submit_additional_document(document)
 
         self.assertEqual(2, Activity.query.count())
 
         for activity in Activity.query.all():
-            self.assertEquals('proposal-attachment-updated', activity.kind)
-            self.assertEquals('Attachment updated', activity.label)
+            self.assertEquals('proposal-additional-documents-submitted', activity.kind)
+            self.assertEquals('Additional documents submitted', activity.label)
             self.assertEquals(self.proposal.title, activity.title)
             self.assertEquals(
-                u'Submitted document {} updated to version 1'.format(document.title),
+                u'Document {} submitted'.format(document.title),
                 activity.summary)
 
     def assertSubscribersForResource(self, subscribers, resource):

--- a/opengever/meeting/tests/test_connector.py
+++ b/opengever/meeting/tests/test_connector.py
@@ -1,0 +1,60 @@
+from opengever.meeting.connector.connector import Connector
+from opengever.meeting.connector.connector import ConnectorAction
+from opengever.meeting.connector.connector import ConnectorPath
+from opengever.testing import IntegrationTestCase
+
+
+@Connector.register
+class DummyConnectorAction(ConnectorAction):
+    recorder = []  # only for testing. records the execution
+
+    def execute(self):
+        self.recorder.append({
+            'id': self.context.getId(),
+            'data': self.data})
+
+
+class TestConnector(IntegrationTestCase):
+    features = ('meeting',)
+
+    def setUp(self):
+        super(TestConnector, self).setUp()
+        DummyConnectorAction.recorder = []
+
+    def test_dispatch_action_executes_action_for_each_connected_path(self):
+        self.login(self.committee_responsible)
+        self.connector.dispatch(DummyConnectorAction)
+
+        recorded = DummyConnectorAction.recorder
+
+        self.assertItemsEqual(
+            [self.proposal.getId(), self.submitted_proposal.getId()],
+            [item.get('id') for item in recorded]
+            )
+
+    def test_dispatch_action_passes_the_data_to_the_action(self):
+        self.login(self.committee_responsible)
+        text = u'james b\xc3\xb6nd'
+        values = [1, 2, 3]
+
+        self.connector.dispatch(DummyConnectorAction, text=text, values=values)
+
+        self.assertDictEqual(
+            {'text': text, 'values': values},
+            DummyConnectorAction.recorder[0].get('data'))
+
+    @property
+    def connector(self):
+        connector = Connector()
+        proposal_path = ConnectorPath(
+            self.proposal.get_sync_admin_unit_id(),
+            self.proposal.get_sync_target_path())
+
+        connector.connect_path(proposal_path)
+
+        submitted_proposal_path = ConnectorPath(
+            self.submitted_proposal.get_sync_admin_unit_id(),
+            self.submitted_proposal.get_sync_target_path())
+
+        connector.connect_path(submitted_proposal_path)
+        return connector

--- a/opengever/meeting/tests/test_connector.py
+++ b/opengever/meeting/tests/test_connector.py
@@ -58,3 +58,24 @@ class TestConnector(IntegrationTestCase):
 
         connector.connect_path(submitted_proposal_path)
         return connector
+
+
+class TestProposalConnector(IntegrationTestCase):
+    features = ('meeting',)
+
+    def setUp(self):
+        super(TestProposalConnector, self).setUp()
+        DummyConnectorAction.recorder = []
+
+    def test_sql_proposal_connector_connects_its_proposal_and_submitted_proposal(self):
+        self.login(self.committee_responsible)
+
+        connector = self.proposal.load_model().connector
+        connector.dispatch(DummyConnectorAction)
+
+        recorded = DummyConnectorAction.recorder
+
+        self.assertItemsEqual(
+            [self.proposal.getId(), self.submitted_proposal.getId()],
+            [item.get('id') for item in recorded]
+            )


### PR DESCRIPTION
This PR triggers the activities:

<img width="440" alt="bildschirmfoto 2018-07-02 um 15 19 45" src="https://user-images.githubusercontent.com/557005/42170351-980d05d6-7e16-11e8-9ba4-3754b0af3c30.png">

The new `connector`-implementation was required to trigger the activities on both sides, the proposal and the submitted proposal. There are already several such implementations (history, commands) but they are not generic. After a refactoring, all the syncing-implementations could be replaced by the new `connector`.

closes #4415 