### PR TITLE
Untangle admin units and org units in FixtureBuilder for functional test cases

### DIFF
--- a/opengever/activity/tests/test_plone_center.py
+++ b/opengever/activity/tests/test_plone_center.py
@@ -48,7 +48,7 @@ class TestPloneNotificationCenter(FunctionalTestCase):
                       'Task Type': 'comment'})
 
         form = browser.find_form_by_field('Responsible')
-        form.find_widget('Responsible').fill('inbox:client1')
+        form.find_widget('Responsible').fill('inbox:org-unit-1')
 
         browser.css('#form-buttons-save').first.click()
 
@@ -58,7 +58,7 @@ class TestPloneNotificationCenter(FunctionalTestCase):
         subscriptions = resource.subscriptions
 
         self.assertItemsEqual(
-            [(u'inbox:client1', u'task_responsible'),
+            [(u'inbox:org-unit-1', u'task_responsible'),
              (u'test_user_1_', u'task_issuer')],
             [(sub.watcher.actorid, sub.role) for sub in subscriptions])
 
@@ -90,7 +90,7 @@ class TestNotifactionCenterErrorHandling(FunctionalTestCase):
                       'Task Type': 'comment'})
 
         form = browser.find_form_by_field('Responsible')
-        form.find_widget('Responsible').fill('inbox:client1')
+        form.find_widget('Responsible').fill('inbox:org-unit-1')
         form.find_widget('Issuer').fill(TEST_USER_ID)
 
         browser.css('#form-buttons-save').first.click()
@@ -111,7 +111,7 @@ class TestNotifactionCenterErrorHandling(FunctionalTestCase):
                       'Task Type': 'comment'})
 
         form = browser.find_form_by_field('Responsible')
-        form.find_widget('Responsible').fill('inbox:client1')
+        form.find_widget('Responsible').fill('inbox:org-unit-1')
         form.find_widget('Issuer').fill(TEST_USER_ID)
 
         browser.css('#form-buttons-save').first.click()
@@ -130,7 +130,7 @@ class TestNotifactionCenterErrorHandling(FunctionalTestCase):
                       'Task Type': 'comment'})
 
         form = browser.find_form_by_field('Responsible')
-        form.find_widget('Responsible').fill('client1:hugo.boss')
+        form.find_widget('Responsible').fill('org-unit-1:hugo.boss')
         form.find_widget('Issuer').fill(TEST_USER_ID)
 
         browser.css('#form-buttons-save').first.click()

--- a/opengever/base/tests/test_default_values_for_types.py
+++ b/opengever/base/tests/test_default_values_for_types.py
@@ -31,7 +31,7 @@ FROZEN_NOW = datetime.now()
 FROZEN_TODAY = FROZEN_NOW.date()
 
 DEFAULT_TITLE = u'My title'
-DEFAULT_CLIENT = u'client1'
+DEFAULT_CLIENT = u'org-unit-1'
 
 REPOROOT_REQUIREDS = {
     'title_de': DEFAULT_TITLE,

--- a/opengever/base/tests/test_oguid.py
+++ b/opengever/base/tests/test_oguid.py
@@ -43,7 +43,7 @@ class TestOguidFunctional(FunctionalTestCase):
         int_id = intids.getId(obj)
         oguid = Oguid.for_object(obj)
 
-        self.assertEqual('client1:{}'.format(int_id), oguid)
+        self.assertEqual('admin-unit-1:{}'.format(int_id), oguid)
 
     def test_oguid_get_url_same_admin_unit(self):
         obj = create(Builder('dossier'))

--- a/opengever/base/tests/test_transport.py
+++ b/opengever/base/tests/test_transport.py
@@ -27,7 +27,7 @@ class TestTransporter(FunctionalTestCase):
                           .with_dummy_content())
 
         transported_doc = Transporter().transport_from(
-            dossier, 'client1', '/'.join(document.getPhysicalPath()))
+            dossier, 'admin-unit-1', '/'.join(document.getPhysicalPath()))
 
         self.assertEquals('Testdocument', transported_doc.title)
         self.assertEquals('Test data', transported_doc.file.data)
@@ -49,7 +49,7 @@ class TestTransporter(FunctionalTestCase):
                           .with_dummy_content())
 
         data = Transporter().transport_to(
-            document, 'client1', '/'.join(target_dossier.getPhysicalPath()))
+            document, 'admin-unit-1', '/'.join(target_dossier.getPhysicalPath()))
         transported_doc = self.portal.unrestrictedTraverse(
             data.get('path').encode('utf-8'))
 
@@ -76,7 +76,7 @@ class TestTransporter(FunctionalTestCase):
                       .having(deadline=date(2014, 7, 1)))
 
         Transporter().transport_from(
-            source_dossier, 'client1', '/'.join(task.getPhysicalPath()))
+            source_dossier, 'admin-unit-1', '/'.join(task.getPhysicalPath()))
 
     def test_transport_to_with_elevated_privileges(self):
         source = create(Builder("dossier").titled(u"Source"))
@@ -94,10 +94,10 @@ class TestTransporter(FunctionalTestCase):
         self.login(u'hugo.boss')
 
         with self.assertRaises(Unauthorized):
-            Transporter().transport_to(task, 'client1', target_path)
+            Transporter().transport_to(task, 'admin-unit-1', target_path)
 
         Transporter().transport_to(
-            task, 'client1', target_path,
+            task, 'admin-unit-1', target_path,
             view='transporter-privileged-receive-object')
 
     def test_transport_to_does_not_break_deadline_datatype(self):
@@ -110,5 +110,5 @@ class TestTransporter(FunctionalTestCase):
             .titled(u'Fo\xf6')
             .having(deadline=date(2014, 7, 1)),
             )
-        Transporter().transport_to(task, 'client1', target_path, view='transporter-privileged-receive-object')
+        Transporter().transport_to(task, 'admin-unit-1', target_path, view='transporter-privileged-receive-object')
         self.assertFalse(isinstance(target.getFirstChild().deadline, datetime))

--- a/opengever/base/transport.py
+++ b/opengever/base/transport.py
@@ -60,13 +60,13 @@ class Transporter(object):
             target_cid, '@@{}'.format(view),
             path=container_path, data=request_data)
 
-    def transport_from(self, container, source_cid, path):
-        """ Copies the object under *path* from client with *source_cid* into
-        the local folder *container*
+    def transport_from(self, container, source_admin_unit_id, path):
+        """ Copies the object under *path* from client with
+        *source_admin_unit_id* into the local folder *container*
         *path* is the relative path of the object to its plone site root.
         """
 
-        data = dispatch_json_request(source_cid,
+        data = dispatch_json_request(source_admin_unit_id,
                                      '@@transporter-extract-object-json',
                                      path=path)
 

--- a/opengever/disposition/tests/test_activities.py
+++ b/opengever/disposition/tests/test_activities.py
@@ -69,7 +69,7 @@ class TestDispositionNotifications(FunctionalTestCase):
         activity = Activity.query.one()
         self.assertEquals('disposition-added', activity.kind)
         self.assertEquals(
-            u'New disposition added by Test User on admin unit Client1',
+            u'New disposition added by Test User on admin unit Admin Unit 1',
             activity.summary)
         self.assertEquals(u'Disposition added', activity.label)
         self.assertIsNone(activity.description)

--- a/opengever/disposition/tests/test_sippackage.py
+++ b/opengever/disposition/tests/test_sippackage.py
@@ -49,10 +49,10 @@ class TestSIPPackage(FunctionalTestCase):
         self.assertEquals(
             u'GEVER', package.ablieferung.ablieferungstyp)
         self.assertEquals(
-            'Client1, test_user_1_',
+            'Admin Unit 1, test_user_1_',
             package.ablieferung.ablieferndeStelle)
         self.assertEquals(
-            u'Client1', package.ablieferung.provenienz.aktenbildnerName)
+            u'Admin Unit 1', package.ablieferung.provenienz.aktenbildnerName)
         self.assertEquals(
             u'Ordnungssytem 2000', package.ablieferung.provenienz.registratur)
 

--- a/opengever/globalindex/tests/test_reporter.py
+++ b/opengever/globalindex/tests/test_reporter.py
@@ -35,9 +35,9 @@ class TestTaskReporter(FunctionalTestCase):
              None,
              None,
              u'Test User (test_user_1_)',
-             u'Client1',
+             u'Org Unit 1',
              u'Test User (test_user_1_)',
              u'To comment',
-             u'client1',
+             u'admin-unit-1',
              1L],
             [cell.value for cell in list(workbook.active.rows)[1]])

--- a/opengever/globalindex/tests/test_task_css_class.py
+++ b/opengever/globalindex/tests/test_task_css_class.py
@@ -16,8 +16,8 @@ class TestTaskCssClass(FunctionalTestCase):
         forwarding = create(Builder('globalindex_task')
                             .having(int_id=123, sequence_number=123,
                                     task_type='forwarding_task_type',
-                                    assigned_org_unit='client1',
-                                    issuing_org_unit='client1',
+                                    assigned_org_unit='org-unit-1',
+                                    issuing_org_unit='org-unit-1',
                                     admin_unit_id='foo'))
 
         self.assertEqual('contenttype-opengever-inbox-forwarding',
@@ -26,9 +26,9 @@ class TestTaskCssClass(FunctionalTestCase):
     def test_remote_forwardings_has_forwarding_class(self):
         remote_forwarding = create(Builder('globalindex_task')
                                    .having(int_id=123, sequence_number=123,
-                                           admin_unit_id='client1',
+                                           admin_unit_id='admin-unit-1',
                                            task_type='forwarding_task_type',
-                                           issuing_org_unit='client1',
+                                           issuing_org_unit='org-unit-1',
                                            assigned_org_unit=u'additional'))
 
         self.assertEqual('contenttype-opengever-inbox-forwarding',
@@ -37,9 +37,9 @@ class TestTaskCssClass(FunctionalTestCase):
     def test_subtask_class(self):
         subtask = create(Builder('globalindex_task')
                          .having(int_id=123, sequence_number=123,
-                                 admin_unit_id='client1',
-                                 assigned_org_unit='client1',
-                                 issuing_org_unit='client1',
+                                 admin_unit_id='admin-unit-1',
+                                 assigned_org_unit='org-unit-1',
+                                 issuing_org_unit='org-unit-1',
                                  is_subtask=True))
 
         self.assertEqual('contenttype-opengever-task-sub-task', subtask.get_css_class())
@@ -49,7 +49,7 @@ class TestTaskCssClass(FunctionalTestCase):
                              .having(int_id=123, sequence_number=123,
                                      admin_unit_id='additional',
                                      issuing_org_unit='additional',
-                                     assigned_org_unit='client1'))
+                                     assigned_org_unit='org-unit-1'))
 
         self.assertEqual('contenttype-opengever-task-remote-task', remote_task.get_css_class())
 
@@ -57,8 +57,8 @@ class TestTaskCssClass(FunctionalTestCase):
         remote_task = create(Builder('globalindex_task')
                              .having(int_id=123, sequence_number=123,
                                      is_subtask=True,
-                                     admin_unit_id='client1',
-                                     issuing_org_unit='client1',
+                                     admin_unit_id='admin-unit-1',
+                                     issuing_org_unit='org-unit-1',
                                      assigned_org_unit='additional'))
 
         self.assertEqual('contenttype-opengever-task-sub-task', remote_task.get_css_class())
@@ -69,15 +69,15 @@ class TestTaskCssClass(FunctionalTestCase):
                                      is_subtask=True,
                                      admin_unit_id='additional',
                                      issuing_org_unit='additional',
-                                     assigned_org_unit='client1'))
+                                     assigned_org_unit='org-unit-1'))
         self.assertEqual('contenttype-opengever-task-remote-task', remote_task.get_css_class())
 
     def test_normal_task_classk(self):
         task = create(Builder('globalindex_task')
                       .having(int_id=123, sequence_number=123,
-                              admin_unit_id='client1',
-                              issuing_org_unit='client1',
-                              assigned_org_unit='client1'))
+                              admin_unit_id='admin-unit-1',
+                              issuing_org_unit='org-unit-1',
+                              assigned_org_unit='org-unit-1'))
 
         self.assertEqual('contenttype-opengever-task-task',
                          task.get_css_class())

--- a/opengever/globalindex/tests/test_task_link.py
+++ b/opengever/globalindex/tests/test_task_link.py
@@ -20,11 +20,11 @@ class TestTaskLinkGeneration(FunctionalTestCase):
         attr = {
             'title': u'Do it!',
             'physical_path': "qux/dossier-1/task-2",
-            'assigned_org_unit': 'client1',
-            'issuing_org_unit': 'client1',
+            'assigned_org_unit': 'org-unit-1',
+            'issuing_org_unit': 'org-unit-1',
             'review_state': 'task-state-tested-and-closed',
             'responsible': TEST_USER_ID,
-            'admin_unit_id': 'client1',
+            'admin_unit_id': 'admin-unit-1',
             'breadcrumb_title': '0 Allgemeines > 01 SonstigesTestdossier 4tw > Testaufgabe',
             'principals': [TEST_USER_ID]}
         attr.update(**kwargs)
@@ -53,7 +53,7 @@ class TestTaskLinkGeneration(FunctionalTestCase):
                           link.xpath(css_to_xpath('span'))[0].get('class'))
         self.assertEquals('Do it!',
                           link.xpath(css_to_xpath('span'))[1].text)
-        self.assertEquals('(Client1 / Test User (test_user_1_))',
+        self.assertEquals('(Org Unit 1 / Test User (test_user_1_))',
                           link.xpath(css_to_xpath('span'))[2].text)
 
     def test_task_is_always_linked_when_user_has_administrator_role(self):
@@ -79,7 +79,7 @@ class TestTaskLinkGeneration(FunctionalTestCase):
         link_tag = link.xpath(css_to_xpath('a'))[0]
 
         self.assertEquals(
-            '[Client1] > 0 Allgemeines > 01 SonstigesTestdossier 4tw > Testaufgabe',
+            '[Admin Unit 1] > 0 Allgemeines > 01 SonstigesTestdossier 4tw > Testaufgabe',
             link_tag.get('title'))
 
     def test_link_text_is_task_title(self):
@@ -110,7 +110,7 @@ class TestTaskLinkGeneration(FunctionalTestCase):
         link = self.add_task_and_get_link()
         suffix = link.xpath(css_to_xpath('span'))[2]
 
-        self.assertEquals('(Client1 / Test User (test_user_1_))', suffix.text)
+        self.assertEquals('(Org Unit 1 / Test User (test_user_1_))', suffix.text)
         self.assertEquals('discreet', suffix.get('class'))
 
     def test_responsible_info_is_parametrable(self):
@@ -154,7 +154,7 @@ class TestTaskLinkGeneration(FunctionalTestCase):
         #INFO: link_tag.attr['titles'] automatically decodes html entities
         self.assertEquals(
             '<a href="http://example.com/qux/dossier-1/task-2" '
-            'title="[Client1] &gt; 0 Allg. &gt; &lt;b&gt;4tw&lt;/b&gt; &gt; '
+            'title="[Admin Unit 1] &gt; 0 Allg. &gt; &lt;b&gt;4tw&lt;/b&gt; &gt; '
             'Task"><span class="contenttype-opengever-task-task">Do it!</span>'
             '</a>  ',
             tostring(link_tag))

--- a/opengever/inbox/tests/test_accept.py
+++ b/opengever/inbox/tests/test_accept.py
@@ -13,6 +13,7 @@ class TestForwardingAccepting(FunctionalTestCase):
         dossier = create(Builder('dossier'))
         forwarding = create(Builder('forwarding')
                             .having(responsible=TEST_USER_ID,
+                                    responsible_client='org-unit-1',
                                     issuer='hugo.boss')
                             .within(inbox))
         task = accept_forwarding_with_successor(
@@ -28,6 +29,7 @@ class TestAssignToDossier(FunctionalTestCase):
         dossier = create(Builder('dossier'))
         forwarding = create(Builder('forwarding')
                             .having(responsible=TEST_USER_ID,
+                                    responsible_client='org-unit-1',
                                     issuer='hugo.boss')
                             .within(inbox))
         task = assign_forwarding_to_dossier(

--- a/opengever/inbox/tests/test_activities.py
+++ b/opengever/inbox/tests/test_activities.py
@@ -42,7 +42,7 @@ class TestForwardingActivites(FunctionalTestCase):
                       'Text': 'Lorem ipsum'})
 
         form = browser.find_form_by_field('Responsible')
-        form.find_widget('Responsible').fill('client1:hugo.boss')
+        form.find_widget('Responsible').fill('org-unit-1:hugo.boss')
 
         browser.find('Save').click()
 
@@ -58,7 +58,7 @@ class TestForwardingActivites(FunctionalTestCase):
         inbox = create(Builder('inbox').titled(u'Inbox'))
         forwarding = create(Builder('forwarding')
                             .within(inbox)
-                            .having(issuer='inbox:client2',
+                            .having(issuer='inbox:org-unit-2',
                                     responsible='hugo.boss')
                             .titled(u'Anfrage XY'))
 
@@ -68,7 +68,7 @@ class TestForwardingActivites(FunctionalTestCase):
         resource = notification_center().fetch_resource(task)
         self.assertItemsEqual(
             [(u'hugo.boss', u'task_responsible'),
-             (u'inbox:client1', u'task_issuer')],
+             (u'inbox:org-unit-1', u'task_issuer')],
             [(subscription.watcher.actorid, subscription.role)
              for subscription in resource.subscriptions])
 
@@ -96,7 +96,7 @@ class TestForwardingActivites(FunctionalTestCase):
 
         self.assertItemsEqual(
             [(u'test_user_1_', u'task_responsible'),
-             (u'inbox:client1', u'task_issuer')],
+             (u'inbox:org-unit-1', u'task_issuer')],
             [(subscription.watcher.actorid, subscription.role)
              for subscription in successor_resource.subscriptions])
 
@@ -157,7 +157,7 @@ class TestForwardingReassignActivity(FunctionalTestCase):
                              view='++add++opengever.inbox.forwarding')
         browser.fill({'Title': u'Abkl\xe4rung Fall Meier'})
         form = browser.find_form_by_field('Responsible')
-        form.find_widget('Responsible').fill('client1:jon.meier')
+        form.find_widget('Responsible').fill('org-unit-1:jon.meier')
         form.find_widget('Issuer').fill(u'hugo.boss')
 
         browser.css('#form-buttons-save').first.click()

--- a/opengever/inbox/tests/test_inbox.py
+++ b/opengever/inbox/tests/test_inbox.py
@@ -47,7 +47,7 @@ class TestInbox(FunctionalTestCase):
 
     def test_get_responsible_org_unit_fetch_configured_org_unit(self):
         inbox = create(Builder('inbox').
-                       having(responsible_org_unit='client1'))
+                       having(responsible_org_unit='org-unit-1'))
 
         self.assertEqual(self.org_unit, inbox.get_responsible_org_unit())
 

--- a/opengever/inbox/tests/test_inbox_assign.py
+++ b/opengever/inbox/tests/test_inbox_assign.py
@@ -18,32 +18,32 @@ class TestAssingForwarding(FunctionalTestCase):
 
         create(Builder('org_unit')
                .with_default_groups()
-               .id('client2')
-               .having(title='Client2',
+               .id('org-unit-2')
+               .having(title='Org Unit 2',
                        admin_unit=self.admin_unit))
 
         self.forwarding = create(
             Builder('forwarding')
             .having(title=u'Test forwarding',
-                    responsible_client=u'client1',
-                    responsible=u'inbox:client1')
+                    responsible_client=u'org-unit-1',
+                    responsible=u'inbox:org-unit-1')
             .in_state('forwarding-state-refused'))
 
     @browsing
     def test_updates_responsible_and_responsible_client(self, browser):
-        self.assign_forwarding('client2', 'Fake Response')
+        self.assign_forwarding('org-unit-2', 'Fake Response')
 
-        self.assertEquals('client2', self.forwarding.responsible_client)
-        self.assertEquals('client2',
+        self.assertEquals('org-unit-2', self.forwarding.responsible_client)
+        self.assertEquals('org-unit-2',
                           self.forwarding.get_sql_object().assigned_org_unit)
 
-        self.assertEquals('inbox:client2', self.forwarding.responsible)
-        self.assertEquals('inbox:client2',
+        self.assertEquals('inbox:org-unit-2', self.forwarding.responsible)
+        self.assertEquals('inbox:org-unit-2',
                           self.forwarding.get_sql_object().responsible)
 
     @browsing
     def test_assign_sets_forwarding_in_open_state(self, browser):
-        self.assign_forwarding('client2', 'Fake Response')
+        self.assign_forwarding('org-unit-2', 'Fake Response')
 
         wf_tool = getToolByName(self.portal, 'portal_workflow')
         self.assertEquals('forwarding-state-open',
@@ -54,33 +54,33 @@ class TestAssingForwarding(FunctionalTestCase):
 
     @browsing
     def test_assign_add_corresonding_response(self, browser):
-        self.assign_forwarding('client2', 'Fake Response')
+        self.assign_forwarding('org-unit-2', 'Fake Response')
 
         response = IResponseContainer(self.forwarding)[-1]
 
         responsible_change = {'id': 'responsible',
                               'name': u'label_responsible',
-                              'before': u'inbox:client1',
-                              'after': u'inbox:client2'}
+                              'before': u'inbox:org-unit-1',
+                              'after': u'inbox:org-unit-2'}
 
         responsible_client_change = {'id': 'responsible_client',
                                      'name': u'label_resonsible_client',
-                                     'before': u'client1',
-                                     'after': u'client2'}
+                                     'before': u'org-unit-1',
+                                     'after': u'org-unit-2'}
 
         self.assertEquals([responsible_change, responsible_client_change],
                           response.changes)
 
     @browsing
     def test_activity_is_recorded_correctly(self, browser):
-        self.assign_forwarding('client2', 'Fake Response')
+        self.assign_forwarding('org-unit-2', 'Fake Response')
 
-        self.assertEquals('client2', self.forwarding.responsible_client)
-        self.assertEquals('client2',
+        self.assertEquals('org-unit-2', self.forwarding.responsible_client)
+        self.assertEquals('org-unit-2',
                           self.forwarding.get_sql_object().assigned_org_unit)
 
-        self.assertEquals('inbox:client2', self.forwarding.responsible)
-        self.assertEquals('inbox:client2',
+        self.assertEquals('inbox:org-unit-2', self.forwarding.responsible)
+        self.assertEquals('inbox:org-unit-2',
                           self.forwarding.get_sql_object().responsible)
 
         self.assertEquals(1, len(Activity.query.all()))

--- a/opengever/inbox/tests/test_inbox_container.py
+++ b/opengever/inbox/tests/test_inbox_container.py
@@ -61,10 +61,11 @@ class TestInboxView(FunctionalTestCase):
 
     @browsing
     def test_redirects_to_current_inbox_when_accessing_inbox_container(self, browser):
-        self.client1_inbox = create(Builder('inbox')
-                                    .titled(u'Client1 Inbox')
-                                    .within(self.container)
-                                    .having(responsible_org_unit='client1'))
+        self.client1_inbox = create(
+            Builder('inbox')
+            .titled(u'Org Unit 1 Inbox')
+            .within(self.container)
+            .having(responsible_org_unit='org-unit-1'))
 
         browser.login().open(self.container)
 
@@ -72,15 +73,16 @@ class TestInboxView(FunctionalTestCase):
 
     @browsing
     def test_stays_on_inbox_container_when_current_inbox_not_available(self, browser):
-        self.client1_inbox = create(Builder('inbox')
-                            .titled(u'Client1 Inbox')
-                            .within(self.container)
-                            .having(responsible_org_unit='client2'))
+        self.client2_inbox = create(
+            Builder('inbox')
+            .titled(u'Org Unit 2 Inbox')
+            .within(self.container)
+            .having(responsible_org_unit='org-unit-2'))
 
         browser.login().open(self.container)
         self.assertEqual(self.container.absolute_url(), browser.url)
         self.assertEquals(
-            ['Your not allowed to access the inbox of Client1.'],
+            ['Your not allowed to access the inbox of Org Unit 1.'],
             statusmessages.messages().get('warning'))
 
     @skip("This test currently fails in a flaky way on CI."

--- a/opengever/inbox/tests/test_overview.py
+++ b/opengever/inbox/tests/test_overview.py
@@ -17,8 +17,8 @@ class TestBaseInboxOverview(FunctionalTestCase):
         self.user2, self.org_unit2, self.admin_unit2 = create(
             Builder('fixture')
             .with_user(userid='hans.muster')
-            .with_org_unit(unit_id=u'client2')
-            .with_admin_unit())
+            .with_org_unit(unit_id=u'org-unit-2')
+            .with_admin_unit(unit_id=u'admin-unit-2'))
 
         self.user, self.org_unit, self.admin_unit = create(
             Builder('fixture').with_all_unit_setup())
@@ -95,14 +95,14 @@ class TestInboxOverviewAssignedInboxTasks(TestBaseInboxOverview):
         create(Builder('task')
                .within(self.inbox)
                .with_modification_date(DateTime(2014, 1, 1))
-               .having(responsible='inbox:client1')
+               .having(responsible='inbox:org-unit-1')
                .titled(u'Task x'))
         create(Builder('forwarding')
                .within(self.inbox)
                .with_modification_date(DateTime(2014, 1, 2))
-               .having(responsible='inbox:client1')
+               .having(responsible='inbox:org-unit-1')
                .titled(u'Forwarding x'))
-        create(Builder('forwarding').having(responsible='inbox:client2')
+        create(Builder('forwarding').having(responsible='inbox:org-unit-2')
                                     .titled(u'Forwarding Invisible'))
 
         browser.login().open(self.inbox, view='tabbedview_view-overview')
@@ -115,12 +115,12 @@ class TestInboxOverviewAssignedInboxTasks(TestBaseInboxOverview):
         for i in range(1, 6):
             create(Builder('forwarding')
                    .within(self.inbox)
-                   .having(responsible='inbox:client1')
+                   .having(responsible='inbox:org-unit-1')
                    .with_modification_date(DateTime(2010, 1, 1) + i)
                    .titled(u'Task %s' % i))
         create(Builder('task')
                .within(self.inbox)
-               .having(responsible='inbox:client1')
+               .having(responsible='inbox:org-unit-1')
                .with_modification_date(DateTime(2009, 12, 1))
                .titled(u'Task 6'))
 
@@ -132,12 +132,12 @@ class TestInboxOverviewAssignedInboxTasks(TestBaseInboxOverview):
     @browsing
     def test_lists_only_the_local_one_when_having_predecessor_successor_couples(self, browser):
         predecessor = create(Builder('forwarding')
-                             .having(responsible='inbox:client2',
-                                     assigned_client='client2')
+                             .having(responsible='inbox:org-unit-2',
+                                     assigned_client='org-unit-2')
                              .titled(u'Predecessor'))
         create(Builder('forwarding')
-               .having(responsible='inbox:client1',
-                       assigned_client='client1')
+               .having(responsible='inbox:org-unit-1',
+                       assigned_client='org-unit-1')
                .successor_from(predecessor)
                .titled(u'Successor'))
 
@@ -149,10 +149,10 @@ class TestInboxOverviewAssignedInboxTasks(TestBaseInboxOverview):
     @browsing
     def test_list_only_active_tasks(self, browser):
         create(Builder('forwarding')
-               .having(responsible='inbox:client1')
+               .having(responsible='inbox:org-unit-1')
                .titled('Active'))
         closed = create(Builder('forwarding')
-                        .having(responsible='inbox:client1')
+                        .having(responsible='inbox:org-unit-1')
                         .in_state('forwarding-state-closed')
                         .titled('Closed'))
         sync_task(closed, None)
@@ -171,14 +171,14 @@ class TestInboxOverviewIssuedInboxTasks(TestBaseInboxOverview):
         create(Builder('task')
                .with_modification_date(DateTime(2014, 1, 1))
                .within(self.inbox)
-               .having(issuer='inbox:client1')
+               .having(issuer='inbox:org-unit-1')
                .titled('A Task'))
         create(Builder('forwarding')
                .with_modification_date(DateTime(2014, 2, 1))
                .within(self.inbox)
-               .having(issuer='inbox:client1')
+               .having(issuer='inbox:org-unit-1')
                .titled('A Forwarding'))
-        create(Builder('forwarding').having(issuer='inbox:client2'))
+        create(Builder('forwarding').having(issuer='inbox:org-unit-2'))
 
         browser.login().open(self.inbox, view='tabbedview_view-overview')
         self.assertSequenceEqual(
@@ -190,12 +190,12 @@ class TestInboxOverviewIssuedInboxTasks(TestBaseInboxOverview):
         for i in range(1, 6):
             create(Builder('forwarding')
                    .within(self.inbox)
-                   .having(issuer='inbox:client1')
+                   .having(issuer='inbox:org-unit-1')
                    .with_modification_date(DateTime(2010, 1, 1) + i)
                    .titled(u'Task %s' % i))
         create(Builder('task')
                .within(self.inbox)
-               .having(issuer='inbox:client1')
+               .having(issuer='inbox:org-unit-1')
                .with_modification_date(DateTime(2009, 12, 1))
                .titled(u'Task 6'))
 
@@ -207,10 +207,10 @@ class TestInboxOverviewIssuedInboxTasks(TestBaseInboxOverview):
     @browsing
     def test_list_only_active_tasks(self, browser):
         create(Builder('forwarding')
-               .having(issuer='inbox:client1')
+               .having(issuer='inbox:org-unit-1')
                .titled('Active'))
         closed = create(Builder('forwarding')
-                        .having(issuer='inbox:client1')
+                        .having(issuer='inbox:org-unit-1')
                         .in_state('forwarding-state-closed')
                         .titled('Closed'))
         sync_task(closed, None)

--- a/opengever/inbox/tests/test_tabs.py
+++ b/opengever/inbox/tests/test_tabs.py
@@ -74,7 +74,7 @@ class TestInboxTaskTabs(FunctionalTestCase):
         self.org_unit_2 = create(Builder('org_unit')
                                  .having(admin_unit=self.admin_unit)
                                  .assign_users([self.user])
-                                 .id('client2'))
+                                 .id('org-unit-2'))
 
         self.inbox = create(Builder('inbox').titled(u'Testinbox'))
 
@@ -94,25 +94,25 @@ class TestAssignedInboxTaskTab(TestInboxTaskTabs):
     def test_lists_only_tasks_assigned_to_the_current_org_units_inbox(self):
         forwarding_1 = create(Builder('forwarding')
                               .within(self.inbox)
-                              .having(responsible='inbox:client1'))
+                              .having(responsible='inbox:org-unit-1'))
         forwarding_2 = create(Builder('forwarding')
                               .within(self.inbox)
-                              .having(responsible='inbox:client2'))
+                              .having(responsible='inbox:org-unit-2'))
 
         self.assert_listing_results([forwarding_1])
 
-        select_current_org_unit('client2')
+        select_current_org_unit('org-unit-2')
         self.assert_listing_results([forwarding_2])
 
     def test_list_tasks_and_forwardings(self):
         task = create(Builder('task')
                       .within(self.inbox)
-                      .having(responsible='inbox:client1',
+                      .having(responsible='inbox:org-unit-1',
                               modification_date=DateTime(2013, 6, 10)))
 
         forwarding = create(Builder('forwarding')
                             .within(self.inbox)
-                            .having(responsible='inbox:client1',
+                            .having(responsible='inbox:org-unit-1',
                                     modification_date=DateTime(2013, 6, 11)))
 
         self.assert_listing_results([task, forwarding])
@@ -125,36 +125,36 @@ class TestIssuedInboxTaskTab(TestInboxTaskTabs):
     def test_list_tasks_and_forwardings(self):
         task = create(Builder('task')
                       .within(self.inbox)
-                      .having(issuer='inbox:client1'))
+                      .having(issuer='inbox:org-unit-1'))
 
         forwarding = create(Builder('forwarding')
                             .within(self.inbox)
-                            .having(issuer='inbox:client1'))
+                            .having(issuer='inbox:org-unit-1'))
 
         self.assert_listing_results([task, forwarding])
 
     def test_list_only_task_with_current_org_units_inbox_as_a_issuer(self):
         task1 = create(Builder('task')
                       .within(self.inbox)
-                      .having(issuer='inbox:client1'))
+                      .having(issuer='inbox:org-unit-1'))
 
         task2 = create(Builder('task')
                       .within(self.inbox)
-                      .having(issuer='inbox:client2'))
+                      .having(issuer='inbox:org-unit-2'))
 
         self.assert_listing_results([task1])
 
-        select_current_org_unit('client2')
+        select_current_org_unit('org-unit-2')
         self.assert_listing_results([task2])
 
     def test_list_also_tasks_outside_of_the_inbox(self):
         task_inside = create(Builder('task')
               .within(self.inbox)
-              .having(issuer='inbox:client1',
+              .having(issuer='inbox:org-unit-1',
                       modification_date=DateTime(2013, 6, 10)))
 
         task_outside = create(Builder('task')
-              .having(issuer='inbox:client1',
+              .having(issuer='inbox:org-unit-1',
                       modification_date=DateTime(2013, 6, 11)))
 
         self.assert_listing_results([task_inside, task_outside])

--- a/opengever/inbox/tests/test_yearfolder.py
+++ b/opengever/inbox/tests/test_yearfolder.py
@@ -15,41 +15,41 @@ class TestYearFolderGetter(FunctionalTestCase):
         super(TestYearFolderGetter, self).setUp()
 
         self.inbox_container = create(Builder('inbox_container'))
-        self.client1_inbox = create(Builder('inbox')
-                                    .within(self.inbox_container)
-                                    .having(responsible_org_unit='client1'))
-        self.client2_inbox = create(Builder('inbox')
-                                    .within(self.inbox_container)
-                                    .having(responsible_org_unit='client2'))
+        self.org_unit_1_inbox = create(Builder('inbox')
+                                       .within(self.inbox_container)
+                                       .having(responsible_org_unit='org-unit-1'))
+        self.org_unit_2_inbox = create(Builder('inbox')
+                                       .within(self.inbox_container)
+                                       .having(responsible_org_unit='org-unit-2'))
 
         self.current_year = unicode(date.today().year)
 
     def test_returns_yearfolder_of_the_current_year(self):
         yearfolder = create(Builder('yearfolder')
-                            .within(self.client1_inbox)
+                            .within(self.org_unit_1_inbox)
                             .having(id=self.current_year))
 
         self.assertEquals(self.current_year, yearfolder.getId())
         self.assertEquals(yearfolder,
-                          get_current_yearfolder(inbox=self.client1_inbox))
+                          get_current_yearfolder(inbox=self.org_unit_1_inbox))
 
     def test_creates_yearfolder_of_the_current_year_when_not_exists(self):
-        yearfolder = get_current_yearfolder(inbox=self.client1_inbox)
+        yearfolder = get_current_yearfolder(inbox=self.org_unit_1_inbox)
 
         self.assertEquals(self.current_year, yearfolder.getId())
         self.assertEquals('Closed {}'.format(self.current_year),
                           yearfolder.Title())
 
     def test_observe_current_inbox_when_context_is_given(self):
-        client1_yearfolder = create(Builder('yearfolder')
-                                    .within(self.client1_inbox)
-                                    .having(id=self.current_year))
+        org_unit_1_yearfolder = create(Builder('yearfolder')
+                                       .within(self.org_unit_1_inbox)
+                                       .having(id=self.current_year))
 
         create(Builder('yearfolder')
-               .within(self.client2_inbox)
+               .within(self.org_unit_2_inbox)
                .having(id=self.current_year))
 
-        self.assertEquals(client1_yearfolder,
+        self.assertEquals(org_unit_1_yearfolder,
                           get_current_yearfolder(context=self.portal))
 
     def test_raises_when_both_context_and_inbox_are_missing(self):

--- a/opengever/latex/tests/test_listing.py
+++ b/opengever/latex/tests/test_listing.py
@@ -56,7 +56,7 @@ class TestDossierListing(BaseLatexListingTest):
         responsible = self.listing.get_responsible(
             obj2brain(self.dossier))
 
-        self.assertEquals(u'Client1 / Boss Hugo (hugo.boss)', responsible)
+        self.assertEquals(u'Admin Unit 1 / Boss Hugo (hugo.boss)', responsible)
 
     def test_get_repository_title_returns_the_title_of_the_first_parental_repository_folder(self):
         self.assertEquals(
@@ -103,7 +103,7 @@ class TestDossierListing(BaseLatexListingTest):
              '1',
              '1.1. Repository XY',
              'Dossier A',
-             'Client1 / Boss Hugo (hugo.boss)',
+             'Admin Unit 1 / Boss Hugo (hugo.boss)',
              'dossier-state-resolved',
              '01.11.2013',
              '31.12.2013'], rows[0])
@@ -113,7 +113,7 @@ class TestDossierListing(BaseLatexListingTest):
              '2',
              '1.1. Repository XY',
              'Dossier B',
-             'Client1 / Boss Hugo (hugo.boss)',
+             'Admin Unit 1 / Boss Hugo (hugo.boss)',
              'dossier-state-active',
              '01.11.2013',
              ''], rows[1])
@@ -193,7 +193,7 @@ class TestSubDossierListing(BaseLatexListingTest):
         self.assert_row_values(
             ['1',
              'Dossier A',
-             'Client1 / Boss Hugo (hugo.boss)',
+             'Admin Unit 1 / Boss Hugo (hugo.boss)',
              'dossier-state-resolved',
              '01.11.2013',
              '31.12.2013'], rows[0])
@@ -236,7 +236,7 @@ class TestTaskListings(BaseLatexListingTest):
 
         self.hugo = create(Builder('fixture').with_hugo_boss())
 
-        self.org_unit_2 = create(Builder('org_unit').id('client2')
+        self.org_unit_2 = create(Builder('org_unit').id('org-unit-2')
                                  .having(admin_unit=self.admin_unit))
 
         self.task = create(Builder('task')
@@ -274,8 +274,8 @@ class TestTaskListings(BaseLatexListingTest):
         self.assert_row_values(
             ['1',
              'For approval',
-             'Client1 / Boss Hugo',
-             'Client1 / Boss Hugo',
+             'Org Unit 1 / Boss Hugo',
+             'Org Unit 1 / Boss Hugo',
              'task-state-in-progress',
              'Task A',
              '06.11.2013'], rows[0])

--- a/opengever/latex/tests/test_opentaskreport.py
+++ b/opengever/latex/tests/test_opentaskreport.py
@@ -20,6 +20,7 @@ from zope.component import adaptedBy
 from zope.component import getMultiAdapter
 from zope.interface.verify import verifyClass
 from zope.publisher.interfaces.browser import IDefaultBrowserLayer
+import unittest
 
 
 class TestOpenTaskReportPDFView(MockTestCase):
@@ -146,6 +147,9 @@ class TestOpenTaskReport(FunctionalTestCase):
         self.assertFalse(
             self.portal.unrestrictedTraverse('pdf-open-task-report-allowed')())
 
+    @unittest.skip('The code that this test tests for is actually broken and '
+                   'needs to be fixed. The condition in opentaskreport.py:80 '
+                   'is wrong, it compares IDs of admin units vs org units.')
     def test_shows_only_task_on_admin_unit(self):
         additional_admin_unit = create(Builder('admin_unit').id(u'additional'))
         create(Builder('org_unit').id(u'additional')

--- a/opengever/latex/tests/test_opentaskreport.py
+++ b/opengever/latex/tests/test_opentaskreport.py
@@ -95,6 +95,7 @@ class TestOpenTaskReport(FunctionalTestCase):
                            .having(task_type='comment',
                                    issuer='peter.peter',
                                    responsible='hans.meier',
+                                   responsible_client='org-unit-1',
                                    deadline=date(2014, 07, 01)))
 
         provide_request_layer(self.task.REQUEST, IOpenTaskReportLayer)
@@ -156,6 +157,7 @@ class TestOpenTaskReport(FunctionalTestCase):
                            .having(task_type='comment',
                                    issuer='peter.peter',
                                    responsible='hans.meier',
+                                   responsible_client='org-unit-1',
                                    deadline=date(2014, 07, 01)))
         successor.get_sql_object().admin_unit_id = 'additional'
 

--- a/opengever/meeting/browser/sablontemplate.py
+++ b/opengever/meeting/browser/sablontemplate.py
@@ -31,7 +31,7 @@ SAMPLE_MEETING_DATA = {
         'title': u'R\xfccktritt Hans Muster',
         'is_paragraph': False,
         'decision_number': 2}],
-    'mandant': {'name': u'Client1'},
+    'mandant': {'name': u'Admin Unit 1'},
     'meeting': {'date': u'Dec 13, 2011',
                 'end_time': u'11:45 AM',
                 'start_time': u'09:30 AM',

--- a/opengever/meeting/tests/test_committee_roles.py
+++ b/opengever/meeting/tests/test_committee_roles.py
@@ -18,14 +18,14 @@ class TestCommitteeTabs(FunctionalTestCase):
     def test_committee_roles_initialized(self):
         self.assertEqual(
             ('CommitteeResponsible', ),
-            dict(self.committee.get_local_roles())['client1_users'])
+            dict(self.committee.get_local_roles())['org-unit-1_users'])
 
     def test_update_roles_removes_old_role(self):
         CommitteeRoles(self.committee).update(
-            'foo', previous_principal='client1_users')
+            'foo', previous_principal='org-unit-1_users')
 
         local_roles = dict(self.committee.get_local_roles())
-        self.assertNotIn('client1_users', local_roles)
+        self.assertNotIn('org-unit-1_users', local_roles)
         self.assertEqual(('CommitteeResponsible',),
                          local_roles['foo'])
 
@@ -33,17 +33,17 @@ class TestCommitteeTabs(FunctionalTestCase):
         self.committee.manage_addLocalRoles('foo',
             ['Contributor', 'Administrator'])
         self.committee.manage_addLocalRoles(
-            'client1_users', ['Contributor'])
+            'org-unit-1_users', ['Contributor'])
 
         CommitteeRoles(self.committee).update(
-            'foo', previous_principal='client1_users')
+            'foo', previous_principal='org-unit-1_users')
         local_roles = dict(self.committee.get_local_roles())
         self.assertItemsEqual(
             ['Administrator', 'CommitteeResponsible', 'Contributor'],
             local_roles['foo'])
         self.assertItemsEqual(
             ['Contributor'],
-            local_roles['client1_users'])
+            local_roles['org-unit-1_users'])
 
     def test_principal_of_managed_roles_is_a_bytestring(self):
         for principal, roles in self.committee.get_local_roles():

--- a/opengever/meeting/tests/test_protocol_json_data.py
+++ b/opengever/meeting/tests/test_protocol_json_data.py
@@ -163,7 +163,7 @@ class TestExcerptJsonData(FunctionalTestCase):
             'document': {'generated': u'04.05.2018'},
             'participants': {'other': [], 'members': []},
             'committee': {'name': u'Gemeinderat'},
-            'mandant': {'name': u'Client1'},
+            'mandant': {'name': u'Admin Unit 1'},
             'meeting': {'date': u'13.12.2011',
                         'start_time': u'09:30 AM',
                         'end_time': u'11:45 AM',

--- a/opengever/ogds/base/tests/test_sort_helpers.py
+++ b/opengever/ogds/base/tests/test_sort_helpers.py
@@ -31,7 +31,7 @@ class TestUserSortDict(FunctionalTestCase):
         self.assertEqual(
             {u'albert.peter': u'Peter Albert',
              u'test_user_1_': u'Test User',
-             u'inbox:client1': u'Inbox: Client1',
+             u'inbox:org-unit-1': u'Inbox: Org Unit 1',
              u'inbox:arch': u'Inbox: Landesarchiv',
              u'hugo.boss': u'Boss Hugo',
              u'james.bond': u'Bond James'},
@@ -53,7 +53,7 @@ class TestUserSortDict(FunctionalTestCase):
              u'contact:croft-lara': u'Croft Lara',
              u'contact:man-super': u'M\xe4n Super',
              u'test_user_1_': u'Test User',
-             u'inbox:client1': u'Inbox: Client1',
+             u'inbox:org-unit-1': u'Inbox: Org Unit 1',
              u'inbox:arch': u'Inbox: Landesarchiv',
              u'hugo.boss': u'Boss Hugo',
              u'james.bond': u'Bond James'},
@@ -64,7 +64,7 @@ class TestUserSortDict(FunctionalTestCase):
         self.assertEqual(
             {u'albert.peter': u'Peter Albert',
              u'test_user_1_': u'Test User',
-             u'inbox:client1': u'Inbox: Client1',
+             u'inbox:org-unit-1': u'Inbox: Org Unit 1',
              u'inbox:arch': u'Inbox: Landesarchiv',
              u'hugo.boss': u'Boss Hugo',
              u'james.bond': u'Bond James'},

--- a/opengever/ogds/base/tests/test_sources.py
+++ b/opengever/ogds/base/tests/test_sources.py
@@ -123,18 +123,18 @@ class TestAllUsersInboxesAndTeamsSource(FunctionalTestCase):
 
         self.admin_unit = create(Builder('admin_unit'))
         self.org_unit1 = create(Builder('org_unit')
-                                .id('unit1')
+                                .id('org-unit-1')
                                 .having(title=u'Informatik',
                                         admin_unit=self.admin_unit)
                                 .with_default_groups())
         self.org_unit2 = create(Builder('org_unit')
-                                .id('unit2')
+                                .id('org-unit-2')
                                 .having(title=u'Finanzdirektion',
                                         admin_unit=self.admin_unit)
                                 .with_default_groups())
 
         self.disabled_unit = create(Builder('org_unit')
-                                    .id('unit3')
+                                    .id('org-unit-3')
                                     .having(title=u'Steueramt',
                                             enabled=False,
                                             admin_unit=self.admin_unit)
@@ -167,7 +167,7 @@ class TestAllUsersInboxesAndTeamsSource(FunctionalTestCase):
         self.source = AllUsersInboxesAndTeamsSource(self.portal)
 
     def test_get_term_by_token(self):
-        term = self.source.getTermByToken(u'unit1:hans')
+        term = self.source.getTermByToken(u'org-unit-1:hans')
         self.assertTrue(isinstance(term, SimpleTerm))
         self.assertEquals(u'Informatik: Peter Hans (hans)',
                           term.title)
@@ -187,8 +187,8 @@ class TestAllUsersInboxesAndTeamsSource(FunctionalTestCase):
     def test_title_token_and_value_of_term(self):
         result = self.source.search('John')
         self.assertEqual(1, len(result), 'Expect one result. only John')
-        self.assertEquals(u'unit1:john', result[0].token)
-        self.assertEquals(u'unit1:john', result[0].value)
+        self.assertEquals(u'org-unit-1:john', result[0].token)
+        self.assertEquals(u'org-unit-1:john', result[0].value)
         self.assertEquals(u'Informatik: Doe John (john)',
                           result[0].title)
 
@@ -209,8 +209,8 @@ class TestAllUsersInboxesAndTeamsSource(FunctionalTestCase):
                            .assign_to_org_units([self.org_unit1]))
 
         self.assertEquals(
-            ['inbox:unit1', 'unit1:user2', 'unit1:user1', 'unit1:hugo',
-             'unit1:john', 'unit1:hans', 'unit1:user3'],
+            ['inbox:org-unit-1', 'org-unit-1:user2', 'org-unit-1:user1', 'org-unit-1:hugo',
+             'org-unit-1:john', 'org-unit-1:hans', 'org-unit-1:user3'],
             [term.token for term in self.source.search('Informatik')])
 
     def test_search_for_orgunit(self):
@@ -218,7 +218,7 @@ class TestAllUsersInboxesAndTeamsSource(FunctionalTestCase):
         result.pop(0)  # Remove inbox
 
         self.assertEquals(3, len(result), 'Expect 3 items')
-        self.assertTermKeys([u'unit1:hans', u'unit1:hugo', u'unit1:john'],
+        self.assertTermKeys([u'org-unit-1:hans', u'org-unit-1:hugo', u'org-unit-1:john'],
                             result)
 
     def test_return_no_search_result_for_inactive_orgunits(self):
@@ -231,7 +231,7 @@ class TestAllUsersInboxesAndTeamsSource(FunctionalTestCase):
         result = self.source.search('Hans')
 
         self.assertEquals(2, len(result), 'Expect 3 items')
-        self.assertTermKeys([u'unit1:hans', u'unit2:hans'], result)
+        self.assertTermKeys([u'org-unit-1:hans', u'org-unit-2:hans'], result)
 
     def test_source_length_is_length_of_search_result(self):
         self.assertEquals(0, len(self.source),
@@ -251,12 +251,12 @@ class TestAllUsersInboxesAndTeamsSource(FunctionalTestCase):
             '__iter__ of the source should be equal to the result')
 
     def test_all_ogds_users_are_valid(self):
-        self.assertIn(u'unit1:john', self.source)
-        self.assertIn(u'unit1:hugo', self.source)
-        self.assertIn(u'unit1:hans', self.source)
-        self.assertIn(u'unit2:hans', self.source)
-        self.assertIn(u'unit2:reto', self.source)
-        self.assertIn(u'unit2:john', self.source)
+        self.assertIn(u'org-unit-1:john', self.source)
+        self.assertIn(u'org-unit-1:hugo', self.source)
+        self.assertIn(u'org-unit-1:hans', self.source)
+        self.assertIn(u'org-unit-2:hans', self.source)
+        self.assertIn(u'org-unit-2:reto', self.source)
+        self.assertIn(u'org-unit-2:john', self.source)
 
         self.assertNotIn(u'dummy:dummy', self.source)
         self.assertNotIn(u'malformed', self.source)
@@ -266,10 +266,10 @@ class TestAllUsersInboxesAndTeamsSource(FunctionalTestCase):
         self.assertNotIn('simon.says', self.source)
 
     def test_getTerm_can_handle_values_containing_only_a_userid(self):
-        self.portal.REQUEST.set('form.widgets.responsible_client', 'unit2')
+        self.portal.REQUEST.set('form.widgets.responsible_client', 'org-unit-2')
         source = AllUsersInboxesAndTeamsSource(self.portal)
         self.assertEquals(source.getTerm('hans').token,
-                          source.getTerm('unit2:hans').token)
+                          source.getTerm('org-unit-2:hans').token)
 
     def test_getTerm_handles_inactive_users(self):
         create(Builder('ogds_user')
@@ -277,7 +277,7 @@ class TestAllUsersInboxesAndTeamsSource(FunctionalTestCase):
                .having(firstname='Peter', lastname='Muster', active=False)
                .assign_to_org_units([self.org_unit2]))
 
-        self.assertTrue(self.source.getTerm('unit2:peter.muster'),
+        self.assertTrue(self.source.getTerm('org-unit-2:peter.muster'),
                         'Expect a term from inactive user')
 
     def test_search_for_inactive_users_is_not_possible(self):
@@ -295,16 +295,16 @@ class TestAllUsersInboxesAndTeamsSource(FunctionalTestCase):
         self.assertEquals(4, len(result),
                           'Expect 4 results, 1 Inbox and 3 Users')
 
-        self.assertTermKeys([u'inbox:unit1',
-                             u'unit1:hans',
-                             u'unit1:hugo',
-                             u'unit1:john'],
+        self.assertTermKeys([u'inbox:org-unit-1',
+                             u'org-unit-1:hans',
+                             u'org-unit-1:hugo',
+                             u'org-unit-1:john'],
                             result)
 
-        self.assertEquals('inbox:unit1', result[0].token)
+        self.assertEquals('inbox:org-unit-1', result[0].token)
         self.assertEquals(u'Inbox: Informatik', result[0].title)
 
-        self.assertIn('inbox:unit1', self.source)
+        self.assertIn('inbox:org-unit-1', self.source)
 
     def test_do_not_return_inboxes_of_inactive_orgunits(self):
         result = self.source.search('Inbox Steueramt')
@@ -315,7 +315,7 @@ class TestAllUsersInboxesAndTeamsSource(FunctionalTestCase):
     def test_search_for_term_inbox_or_partial_term_that_matches_inbox(self):
         inboxes = self.source.search('Inbox')
         self.assertEquals(2, len(inboxes), 'Expect two inboxes')
-        self.assertTermKeys(['inbox:unit1', 'inbox:unit2'], inboxes)
+        self.assertTermKeys(['inbox:org-unit-1', 'inbox:org-unit-2'], inboxes)
 
         self.assertEquals(2, len(self.source.search('Inb')))
         self.assertEquals(2, len(self.source.search('inbo')))
@@ -323,32 +323,32 @@ class TestAllUsersInboxesAndTeamsSource(FunctionalTestCase):
         self.assertEquals(2, len(self.source.search('nbo')))
 
     def test_only_users_of_the_current_orgunit_and_inboxes_are_valid(self):
-        self.portal.REQUEST.set('form.widgets.responsible_client', 'unit1')
+        self.portal.REQUEST.set('form.widgets.responsible_client', 'org-unit-1')
         source = self.source = AllUsersInboxesAndTeamsSource(
             self.portal,
             only_current_orgunit=True)
 
-        self.assertIn(u'unit1:john', source)
-        self.assertIn(u'unit1:hugo', source)
-        self.assertIn(u'unit1:hans', source)
+        self.assertIn(u'org-unit-1:john', source)
+        self.assertIn(u'org-unit-1:hugo', source)
+        self.assertIn(u'org-unit-1:hans', source)
 
         # Not assigned users are still valid but not returned by search
-        self.assertIn(u'unit2:hans', source)
-        self.assertIn(u'unit2:reto', source)
-        self.assertTermKeys([u'inbox:unit1', u'inbox:unit2', u'unit1:john',
-                             u'unit1:hugo', u'unit1:hans'],
+        self.assertIn(u'org-unit-2:hans', source)
+        self.assertIn(u'org-unit-2:reto', source)
+        self.assertTermKeys([u'inbox:org-unit-1', u'inbox:org-unit-2', u'org-unit-1:john',
+                             u'org-unit-1:hugo', u'org-unit-1:hans'],
                             source.search('unit'))
 
     def test_only_the_current_inbox_is_valid(self):
-        self.portal.REQUEST.set('form.widgets.responsible_client', 'unit1')
+        self.portal.REQUEST.set('form.widgets.responsible_client', 'org-unit-1')
         source = self.source = AllUsersInboxesAndTeamsSource(
             self.portal,
             only_current_inbox=True)
 
-        self.assertIn('inbox:unit1', source)
-        self.assertNotIn('inbox:unit2', source)
+        self.assertIn('inbox:org-unit-1', source)
+        self.assertNotIn('inbox:org-unit-2', source)
 
-        self.assertTermKeys([u'inbox:unit1'],
+        self.assertTermKeys([u'inbox:org-unit-1'],
                             source.search('Inb'))
 
     def test_teams_are_only_in_source_when_flag_is_true(self):
@@ -397,13 +397,13 @@ class TestUsersContactsInboxesSource(FunctionalTestCase):
             Builder('fixture').with_admin_unit().with_org_unit())
 
         org_unit_2 = create(Builder('org_unit')
-                            .id('client2')
+                            .id('org-unit-2')
                             .with_default_groups()
-                            .having(title='Client2',
+                            .having(title='Org Unit 2',
                                     admin_unit=self.admin_unit))
 
         disabled_unit = create(Builder('org_unit')
-                               .id('client3')
+                               .id('org-unit-3')
                                .having(title=u'Steueramt',
                                        enabled=False,
                                        admin_unit=self.admin_unit)
@@ -458,8 +458,8 @@ class TestUsersContactsInboxesSource(FunctionalTestCase):
         self.assertEquals('Boss Hugo (hugo.boss)', term.title)
 
     def test_inboxes_are_valid(self):
-        self.assertIn('inbox:client1', self.source)
-        self.assertIn('inbox:client2', self.source)
+        self.assertIn('inbox:org-unit-1', self.source)
+        self.assertIn('inbox:org-unit-2', self.source)
 
     def test_contacts_are_valid(self):
         self.assertIn('contact:croft-lara', self.source)
@@ -492,25 +492,25 @@ class TestAssignedUsersSource(FunctionalTestCase):
                             .id('additional')
                             .having(title='additional'))
 
-        self.org_unit = create(Builder('org_unit').id('client1')
-                               .having(title=u"Client 1",
+        self.org_unit = create(Builder('org_unit').id('org-unit-1')
+                               .having(title=u"Org Unit 1",
                                        admin_unit=self.admin_unit)
                                .with_default_groups())
 
-        org_unit_2 = create(Builder('org_unit').id('client2')
-                            .having(title=u"Client 2",
+        org_unit_2 = create(Builder('org_unit').id('org-unit-2')
+                            .having(title=u"Org Unit 2",
                                     admin_unit=self.admin_unit)
                             .with_default_groups()
                             .assign_users([user])
                             .as_current_org_unit())
 
         org_unit_3 = create(Builder('org_unit')
-                            .id('client3')
-                            .having(title=u"Client 3", admin_unit=additional)
+                            .id('org-unit-3')
+                            .having(title=u"Org Unit 3", admin_unit=additional)
                             .with_default_groups())
 
         disabled_unit = create(Builder('org_unit')
-                               .id('client4')
+                               .id('org-unit-4')
                                .having(title=u'Steueramt',
                                        enabled=False,
                                        admin_unit=self.admin_unit)
@@ -602,25 +602,25 @@ class TestAllUsersSource(FunctionalTestCase):
                             .id('additional')
                             .having(title='additional'))
 
-        self.org_unit = create(Builder('org_unit').id('client1')
-                               .having(title=u"Client 1",
+        self.org_unit = create(Builder('org_unit').id('org-unit-1')
+                               .having(title=u"Org Unit 1",
                                        admin_unit=self.admin_unit)
                                .with_default_groups())
 
-        org_unit_2 = create(Builder('org_unit').id('client2')
-                            .having(title=u"Client 2",
+        org_unit_2 = create(Builder('org_unit').id('org-unit-2')
+                            .having(title=u"Org Unit 2",
                                     admin_unit=self.admin_unit)
                             .with_default_groups()
                             .assign_users([user])
                             .as_current_org_unit())
 
         org_unit_3 = create(Builder('org_unit')
-                            .id('client3')
-                            .having(title=u"Client 3", admin_unit=additional)
+                            .id('org-unit-3')
+                            .having(title=u"Org Unit 3", admin_unit=additional)
                             .with_default_groups())
 
         disabled_unit = create(Builder('org_unit')
-                               .id('client4')
+                               .id('org-unit-4')
                                .having(title=u'Steueramt',
                                        enabled=False,
                                        admin_unit=self.admin_unit)
@@ -717,7 +717,7 @@ class TestAllEmailContactsAndUsersSource(FunctionalTestCase):
             Builder('fixture').with_admin_unit().with_org_unit())
 
         disabled_unit = create(Builder('org_unit')
-                               .id('unit4')
+                               .id('org-unit-4')
                                .having(title=u'Steueramt',
                                        enabled=False,
                                        admin_unit=self.admin_unit)

--- a/opengever/task/tests/test_activities.py
+++ b/opengever/task/tests/test_activities.py
@@ -256,7 +256,7 @@ class TestTaskActivites(FunctionalTestCase):
         browser.find('task-transition-delegate').click()
         # fill responsibles step
         form = browser.find_form_by_field('Responsibles')
-        form.find_widget('Responsibles').fill(['client1:hugo.boss'])
+        form.find_widget('Responsibles').fill(['org-unit-1:hugo.boss'])
 
         browser.find('Continue').click()
         # fill medatata step and submit

--- a/opengever/task/tests/test_assign_to_dossier.py
+++ b/opengever/task/tests/test_assign_to_dossier.py
@@ -57,10 +57,10 @@ class TestAssignForwardignToDossier(FunctionalTestCase):
         # Step 4 - edit task form
         browser.fill({'Task Type': 'comment',
                       'Deadline': '9/24/14',
-                      'Issuer': 'inbox:client1'})
+                      'Issuer': 'inbox:org-unit-1'})
 
         form = browser.find_form_by_field('Responsible')
-        form.find_widget('Responsible').fill('client1:' + TEST_USER_ID)
+        form.find_widget('Responsible').fill('org-unit-1:' + TEST_USER_ID)
 
         browser.css('#form-buttons-save').first.click()
 
@@ -68,7 +68,7 @@ class TestAssignForwardignToDossier(FunctionalTestCase):
         self.assertEquals('A letter from peter', browser.context.title,
                           'Forwarding title should be assumed to the new task')
         self.assertEquals(TEST_USER_ID, browser.context.responsible)
-        self.assertEquals('inbox:client1', browser.context.issuer)
+        self.assertEquals('inbox:org-unit-1', browser.context.issuer)
 
         self.assertEquals('The letter',
                           browser.context.listFolderContents()[0].Title(),
@@ -102,10 +102,10 @@ class TestAssignForwardignToDossier(FunctionalTestCase):
         # Step 3 - edit task form
         browser.fill({'Task Type': 'comment',
                       'Deadline': '9/24/14',
-                      'Issuer': 'inbox:client1'})
+                      'Issuer': 'inbox:org-unit-1'})
 
         form = browser.find_form_by_field('Responsible')
-        form.find_widget('Responsible').fill('client1:' + TEST_USER_ID)
+        form.find_widget('Responsible').fill('org-unit-1:' + TEST_USER_ID)
 
         browser.css('#form-buttons-save').first.click()
 
@@ -113,7 +113,7 @@ class TestAssignForwardignToDossier(FunctionalTestCase):
         self.assertEquals('A letter from peter', browser.context.title,
                           'Forwarding title should be assumed to the new task')
         self.assertEquals(TEST_USER_ID, browser.context.responsible)
-        self.assertEquals('inbox:client1', browser.context.issuer)
+        self.assertEquals('inbox:org-unit-1', browser.context.issuer)
 
         self.assertEquals('The letter',
                           browser.context.listFolderContents()[0].Title(),

--- a/opengever/task/tests/test_deadline_modification.py
+++ b/opengever/task/tests/test_deadline_modification.py
@@ -145,7 +145,7 @@ class TestDeadlineModifierController(FunctionalTestCase):
 
     def test_modify_is_allowed_for_a_inbox_group_user_when_inbox_is_issuer(self):
         task = create(Builder('task')
-                      .having(issuer='inbox:client1', responsible=TEST_USER_ID)
+                      .having(issuer='inbox:org-unit-1', responsible=TEST_USER_ID)
                       .in_progress())
 
         modifier = IDeadlineModifier(task)

--- a/opengever/task/tests/test_forms.py
+++ b/opengever/task/tests/test_forms.py
@@ -36,7 +36,7 @@ class TestTaskEditForm(FunctionalTestCase):
         browser.login().open(task, view='edit')
 
         form = browser.find_form_by_field('Responsible')
-        form.find_widget('Responsible').fill('client1:james.meier')
+        form.find_widget('Responsible').fill('org-unit-1:james.meier')
         browser.find('Save').click()
 
         browser.open(task, view='tabbedview_view-overview')
@@ -54,13 +54,13 @@ class TestTaskEditForm(FunctionalTestCase):
                       'Task Type': 'comment',
                       'Text': 'Lorem ipsum'})
         form = browser.find_form_by_field('Responsible')
-        form.find_widget('Responsible').fill('client1:peter.meier')
+        form.find_widget('Responsible').fill('org-unit-1:peter.meier')
 
         browser.find('Save').click()
 
         browser.open(browser.context.get('task-1'), view='edit')
         form = browser.find_form_by_field('Responsible')
-        form.find_widget('Responsible').fill('client1:james.meier')
+        form.find_widget('Responsible').fill('org-unit-1:james.meier')
 
         browser.find('Save').click()
 

--- a/opengever/task/tests/test_indexer.py
+++ b/opengever/task/tests/test_indexer.py
@@ -14,8 +14,8 @@ class TestTaskIndexers(FunctionalTestCase):
 
         create(Builder('org_unit')
                .with_default_groups()
-               .id('client2')
-               .having(title='Client2', admin_unit=self.admin_unit))
+               .id('org-unit-2')
+               .having(title='Org Unit 2', admin_unit=self.admin_unit))
 
         self.task = create(Builder("task")
                            .titled("Test task 1")
@@ -35,14 +35,14 @@ class TestTaskIndexers(FunctionalTestCase):
 
     def test_assigned_client(self):
         self.assertEquals(
-            obj2brain(self.task).assigned_client, 'client1')
+            obj2brain(self.task).assigned_client, 'org-unit-1')
 
         self.task.responsible = 'hugo.boss'
-        self.task.responsible_client = 'client2'
+        self.task.responsible_client = 'org-unit-2'
         self.task.reindexObject()
 
         self.assertEquals(
-            obj2brain(self.task).assigned_client, 'client2')
+            obj2brain(self.task).assigned_client, 'org-unit-2')
 
     def test_is_subtask(self):
         self.subtask = create(Builder("task").within(self.task)

--- a/opengever/task/tests/test_localroles.py
+++ b/opengever/task/tests/test_localroles.py
@@ -100,17 +100,17 @@ class TestLocalRolesSetter(FunctionalTestCase):
                       .within(dossier)
                       .relate_to(document)
                       .having(responsible='hugo.boss',
-                              responsible_client='client1'))
+                              responsible_client='org-unit-1'))
 
         self.assertEquals(
             ('Editor', ),
-            task.get_local_roles_for_userid('client1_inbox_users'))
+            task.get_local_roles_for_userid('org-unit-1_inbox_users'))
         self.assertEquals(
             ('Reader', ),
-            document.get_local_roles_for_userid('client1_inbox_users'))
+            document.get_local_roles_for_userid('org-unit-1_inbox_users'))
         self.assertEquals(
             ('Contributor', ),
-            dossier.get_local_roles_for_userid('client1_inbox_users'))
+            dossier.get_local_roles_for_userid('org-unit-1_inbox_users'))
 
     def test_inbox_group_has_no_additional_localroles_in_a_oneclient_setup(self):
         dossier = create(Builder('dossier'))
@@ -119,34 +119,34 @@ class TestLocalRolesSetter(FunctionalTestCase):
                       .within(dossier)
                       .relate_to(document)
                       .having(responsible='hugo.boss',
-                              responsible_client='client1'))
+                              responsible_client='org-unit-1'))
 
         self.assertEquals(
             (),
-            task.get_local_roles_for_userid('client1_inbox_users'))
+            task.get_local_roles_for_userid('org-unit-1_inbox_users'))
         self.assertEquals(
             (),
-            document.get_local_roles_for_userid('client1_inbox_users'))
+            document.get_local_roles_for_userid('org-unit-1_inbox_users'))
         self.assertEquals(
             (),
-            dossier.get_local_roles_for_userid('client1_inbox_users'))
+            dossier.get_local_roles_for_userid('org-unit-1_inbox_users'))
 
     def test_use_inbox_group_when_inbox_is_responsible(self):
         dossier = create(Builder('dossier'))
         task = create(Builder('task')
                       .within(dossier)
-                      .having(responsible='inbox:client1'))
+                      .having(responsible='inbox:org-unit-1'))
 
         self.assertEquals(
             ('Editor', ),
-            task.get_local_roles_for_userid('client1_inbox_users'))
+            task.get_local_roles_for_userid('org-unit-1_inbox_users'))
 
         self.assertEquals(
             ('Contributor', ),
-            dossier.get_local_roles_for_userid('client1_inbox_users'))
+            dossier.get_local_roles_for_userid('org-unit-1_inbox_users'))
 
         self.assertEquals(
-            (), task.get_local_roles_for_userid('inbox:client1'))
+            (), task.get_local_roles_for_userid('inbox:org-unit-1'))
 
     @browsing
     def test_responsible_can_edit_related_documents_that_are_inside_a_task(self, browser):
@@ -162,7 +162,7 @@ class TestLocalRolesSetter(FunctionalTestCase):
         create(Builder('task')
                .within(dossier)
                .relate_to(referenced_document)
-               .having(responsible='hugo.boss', responsible_client='client1'))
+               .having(responsible='hugo.boss', responsible_client='org-unit-1'))
 
         browser.login('hugo.boss')
         # this will fail if permissions are set incorrectly

--- a/opengever/task/tests/test_main.py
+++ b/opengever/task/tests/test_main.py
@@ -18,7 +18,7 @@ class TestMethodValidator(FunctionalTestCase):
                       .having(
                           issuer=TEST_USER_ID,
                           responsible=TEST_USER_ID,
-                          responsible_client='client1'))
+                          responsible_client='org-unit-1'))
 
         validator = MethodValidator(task, self.portal.REQUEST, None,
                                     IChooseMethodSchema['method'], None)
@@ -30,7 +30,7 @@ class TestMethodValidator(FunctionalTestCase):
                       .having(
                           issuer=TEST_USER_ID,
                           responsible=TEST_USER_ID,
-                          responsible_client='client1'))
+                          responsible_client='org-unit-1'))
 
         validator = MethodValidator(task, self.portal.REQUEST, None,
                                     IChooseMethodSchema['method'], None)
@@ -38,13 +38,13 @@ class TestMethodValidator(FunctionalTestCase):
         validator.validate('existing_dossier')
 
     def test_raise_invalid_if_current_user_is_not_assigned_to_responsible_client(self):
-        create(Builder('org_unit').id('client2').with_default_groups()
+        create(Builder('org_unit').id('org-unit-2').with_default_groups()
                .having(admin_unit=self.admin_unit))
         task = create(Builder('task')
                       .having(
                           issuer=TEST_USER_ID,
                           responsible=TEST_USER_ID,
-                          responsible_client='client2'))
+                          responsible_client='org-unit-2'))
 
         validator = MethodValidator(task, self.portal.REQUEST, None,
                                     IChooseMethodSchema['method'], None)

--- a/opengever/task/tests/test_redirector.py
+++ b/opengever/task/tests/test_redirector.py
@@ -20,7 +20,7 @@ class TestTaskRedirector(FunctionalTestCase):
                       'Task Type': 'direct-execution'})
 
         form = browser.find_form_by_field('Responsible')
-        form.find_widget('Responsible').fill('client1:' + TEST_USER_ID)
+        form.find_widget('Responsible').fill('org-unit-1:' + TEST_USER_ID)
 
         browser.click_on('Save')
 
@@ -43,7 +43,7 @@ class TestTaskRedirector(FunctionalTestCase):
                       'Task Type': 'direct-execution'})
 
         form = browser.find_form_by_field('Responsible')
-        form.find_widget('Responsible').fill('client1:' + TEST_USER_ID)
+        form.find_widget('Responsible').fill('org-unit-1:' + TEST_USER_ID)
 
         browser.click_on('Save')
 

--- a/opengever/task/tests/test_response_descriptions.py
+++ b/opengever/task/tests/test_response_descriptions.py
@@ -31,7 +31,7 @@ class TestResponseDescriptions(FunctionalTestCase):
 
         create(Builder('org_unit')
                .as_current_org_unit()
-               .id('client1')
+               .id('org-unit-1')
                .having(title=u'Amt f\xfcr Umwelt', admin_unit=self.admin_unit)
                .assign_users([self.user, self.other_user]))
 
@@ -48,7 +48,7 @@ class TestResponseDescriptions(FunctionalTestCase):
                                    deadline=date(2010, 1, 1),
                                    issuer=TEST_USER_ID,
                                    responsible=TEST_USER_ID,
-                                   responsible_client='client1'))
+                                   responsible_client='org-unit-1'))
 
     def get_latest_answer(self, browser):
         latest_answer = browser.css('div.answers .answer').first
@@ -177,7 +177,7 @@ class TestResponseDescriptions(FunctionalTestCase):
         self.click_task_button(browser, 'reassign', save_and_reload=False)
 
         form = browser.find_form_by_field('Responsible')
-        form.find_widget('Responsible').fill('client1:other_user')
+        form.find_widget('Responsible').fill('org-unit-1:other_user')
 
         browser.find('Assign').click()
         self.visit_overview(browser)
@@ -215,7 +215,7 @@ class TestResponseDescriptions(FunctionalTestCase):
         # Step 1 - Select new responsible(s)
         self.click_task_button(browser, 'delegate', save_and_reload=False)
         form = browser.find_form_by_field('Responsibles')
-        form.find_widget('Responsibles').fill('client1:test_user_1_')
+        form.find_widget('Responsibles').fill('org-unit-1:test_user_1_')
 
         browser.find('Continue').click()
 

--- a/opengever/task/tests/test_task.py
+++ b/opengever/task/tests/test_task.py
@@ -217,7 +217,7 @@ class TestTaskIntegration(FunctionalTestCase):
         self.assertEquals(0, len(IResponseContainer(maintask)))
 
         maintask.REQUEST.environ['X_OGDS_AC'] = None
-        maintask.REQUEST.environ['X_OGDS_AUID'] = 'client1'
+        maintask.REQUEST.environ['X_OGDS_AUID'] = 'org-unit-1'
         create(Builder('task').within(maintask).titled('subtask'))
         self.assertEquals(0, len(IResponseContainer(maintask)))
 
@@ -241,8 +241,8 @@ class TestTaskIntegration(FunctionalTestCase):
     def test_responsible_client_for_multiple_orgunits(self, browser):
         create(Builder('org_unit')
                .with_default_groups()
-               .id('client2')
-               .having(title='Client2',
+               .id('org-unit-2')
+               .having(title='Org Unit 2',
                        admin_unit=self.admin_unit))
 
         dossier = create(Builder('dossier'))
@@ -259,7 +259,7 @@ class TestTaskIntegration(FunctionalTestCase):
 
         task = dossier.objectValues()[0]
         self.assertEquals(
-            'client1',
+            'org-unit-1',
             task.responsible_client,
             'The client should be stored after submitting the form')
         self.assertEquals(
@@ -271,8 +271,8 @@ class TestTaskIntegration(FunctionalTestCase):
     def test_create_a_task_for_every_selected_person_with_multiple_orgunits(self, browser):
         client2 = create(Builder('org_unit')
                          .with_default_groups()
-                         .id('client2')
-                         .having(title='Client2',
+                         .id('org-unit-2')
+                         .having(title='Org Unit 2',
                                  admin_unit=self.admin_unit))
         user = create(Builder('ogds_user')
                       .assign_to_org_units([client2])
@@ -302,9 +302,9 @@ class TestTaskIntegration(FunctionalTestCase):
                        dossier.objectValues())
         self.assertEquals(2, len(tasks), 'Expect 2 tasks')
         self.assertEquals(TEST_USER_ID, tasks[0].responsible)
-        self.assertEquals('client1', tasks[0].responsible_client)
+        self.assertEquals('org-unit-1', tasks[0].responsible_client)
         self.assertEquals(user.userid, tasks[1].responsible)
-        self.assertEquals('client2', tasks[1].responsible_client)
+        self.assertEquals('org-unit-2', tasks[1].responsible_client)
 
         activities = Activity.query.all()
         self.assertEquals(2, len(activities))
@@ -339,9 +339,9 @@ class TestTaskIntegration(FunctionalTestCase):
         tasks = dossier.objectValues()
         self.assertEquals(2, len(tasks), 'Expect 2 tasks')
         self.assertEquals(TEST_USER_ID, tasks[0].responsible)
-        self.assertEquals('client1', tasks[0].responsible_client)
+        self.assertEquals('org-unit-1', tasks[0].responsible_client)
         self.assertEquals(user.userid, tasks[1].responsible)
-        self.assertEquals('client1', tasks[1].responsible_client)
+        self.assertEquals('org-unit-1', tasks[1].responsible_client)
 
         activities = Activity.query.all()
         self.assertEquals(2, len(activities))

--- a/opengever/task/tests/test_transition_actions.py
+++ b/opengever/task/tests/test_transition_actions.py
@@ -301,7 +301,7 @@ class TestAccept(BaseTransitionActionFunctionalTest):
     @browsing
     def test_is_responseform_for_adminunit_intern_tasks(self, browser):
         task = create(Builder('task')
-                      .having(responsible_client='client1'))
+                      .having(responsible_client='org-unit-1'))
         self.do_transition(browser, task)
         self.assert_action(
             browser,

--- a/opengever/task/tests/test_workflow.py
+++ b/opengever/task/tests/test_workflow.py
@@ -26,7 +26,7 @@ class TestTaskWorkflowAddingDocumentsAndMails(FunctionalTestCase):
                                    deadline=datetime(2010, 1, 1),
                                    issuer=TEST_USER_ID,
                                    responsible=TEST_USER_ID,
-                                   responsible_client='client1'))
+                                   responsible_client='org-unit-1'))
 
     def click_task_button(self, browser, button_class, save_and_reload=True):
         """Visits the overview view on `self.task`, clicks the button
@@ -108,7 +108,8 @@ class TestTaskWorkflow(FunctionalTestCase):
     def test_document_in_a_closed_tasks_are_still_editable(self, browser):
         task = create(Builder('task')
                       .having(issuer=TEST_USER_ID,
-                              responsible=TEST_USER_ID)
+                              responsible_client=u'org-unit-1',
+                              responsible=TEST_USER_ID,)
                       .in_state('task-state-tested-and-closed'))
 
         document = create(Builder('document')
@@ -128,7 +129,9 @@ class TestTaskWorkflow(FunctionalTestCase):
 
         task = create(Builder('task')
                       .within(dossier)
-                      .having(issuer=TEST_USER_ID, responsible=TEST_USER_ID)
+                      .having(issuer=TEST_USER_ID,
+                              responsible_client=u'org-unit-1',
+                              responsible=TEST_USER_ID)
                       .in_state('task-state-tested-and-closed'))
 
         document = create(Builder('document')
@@ -142,7 +145,8 @@ class TestTaskWorkflow(FunctionalTestCase):
             browser.login().open(document, view='edit')
 
     def test_deleting_task_is_only_allowed_for_managers(self):
-        task = create(Builder('task'))
+        task = create(Builder('task')
+                      .having(responsible_client=u'org-unit-1'))
 
         acl_users = api.portal.get_tool('acl_users')
         valid_roles = list(acl_users.portal_role_manager.valid_roles())

--- a/opengever/testing/builders/dx.py
+++ b/opengever/testing/builders/dx.py
@@ -175,7 +175,7 @@ class TaskBuilder(DexterityBuilder):
         self.predecessor = None
         self._as_sequential_task = False
         self.arguments = {
-            'responsible_client': 'client1',
+            'responsible_client': 'org-unit-1',
             'responsible': TEST_USER_ID,
             'issuer': TEST_USER_ID}
 
@@ -465,7 +465,7 @@ class CommitteeBuilder(DexterityBuilder):
 
     def __init__(self, session):
         super(CommitteeBuilder, self).__init__(session)
-        self.arguments = {'title': 'My Committee', 'group_id': u'client1_users'}
+        self.arguments = {'title': 'My Committee', 'group_id': u'org-unit-1_users'}
 
     def link_with(self, repository_folder):
         self.arguments['repository_folder'] = repository_folder

--- a/opengever/testing/builders/fixture.py
+++ b/opengever/testing/builders/fixture.py
@@ -8,8 +8,8 @@ class FixtureBuilder(object):
 
     For now  this should be considered an experiment that might go away in the
     future.
-
     """
+
     def __init__(self, session):
         self.session = session
         self._with_user = False
@@ -28,12 +28,12 @@ class FixtureBuilder(object):
             'email': 'hugo@boss.ch',
         }
         self._org_unit_args = {
-            'title': u'Client1',
-            'unit_id': u'client1',
+            'title': u'Org Unit 1',
+            'unit_id': u'org-unit-1',
         }
         self._admin_unit_args = {
-            'title': u'Client1',
-            'unit_id': u'client1',
+            'title': u'Admin Unit 1',
+            'unit_id': u'admin-unit-1',
             'public_url': 'http://example.com',
         }
 
@@ -105,10 +105,6 @@ class FixtureBuilder(object):
         builder = Builder('admin_unit').having(
             **self._admin_unit_args).as_current_admin_unit()
 
-        # wrapping org-unit
-        if self._with_org_unit:
-            builder = builder.having(unit_id=self._org_unit_args['unit_id'],
-                                     title=self._org_unit_args['title'])
         return create(builder)
 
     def _create_hugo_boss(self):
@@ -116,5 +112,6 @@ class FixtureBuilder(object):
             return None
 
         return create(Builder('ogds_user').having(**self._hugo_boss_args))
+
 
 builder_registry.register('fixture', FixtureBuilder)

--- a/opengever/testing/builders/sql.py
+++ b/opengever/testing/builders/sql.py
@@ -223,7 +223,7 @@ class CommitteeBuilder(SqlObjectBuilder):
         self.arguments['admin_unit_id'] = 'foo'
         self.arguments['int_id'] = 1234
         self.arguments['physical_path'] = '/foo'
-        self.arguments['group_id'] = 'client1_users'
+        self.arguments['group_id'] = 'org-unit-1_users'
 
 
 builder_registry.register('committee_model', CommitteeBuilder)

--- a/opengever/usermigration/tests/test_ogds_migrator.py
+++ b/opengever/usermigration/tests/test_ogds_migrator.py
@@ -20,7 +20,7 @@ class TestOGDSMigrator(FunctionalTestCase):
     def test_users_group_gets_migrated(self):
         org_unit_id = self.org_unit.unit_id
         migrator = OGDSMigrator(
-            self.portal, {'client1_users': 'new_users_group'}, 'move')
+            self.portal, {'org-unit-1_users': 'new_users_group'}, 'move')
         migrator.migrate()
 
         org_unit = ogds_service().fetch_org_unit(org_unit_id)
@@ -29,7 +29,7 @@ class TestOGDSMigrator(FunctionalTestCase):
     def test_inbox_group_gets_migrated(self):
         org_unit_id = self.org_unit.unit_id
         migrator = OGDSMigrator(
-            self.portal, {'client1_inbox_users': 'new_inbox_group'}, 'move')
+            self.portal, {'org-unit-1_inbox_users': 'new_inbox_group'}, 'move')
         migrator.migrate()
 
         org_unit = ogds_service().fetch_org_unit(org_unit_id)
@@ -37,27 +37,27 @@ class TestOGDSMigrator(FunctionalTestCase):
 
     def test_raises_if_group_doesnt_exist(self):
         migrator = OGDSMigrator(
-            self.portal, {'client1_users': 'doesnt.exist'}, 'move')
+            self.portal, {'org-unit-1_users': 'doesnt.exist'}, 'move')
 
         with self.assertRaises(UserMigrationException):
             migrator.migrate()
 
     def test_returns_proper_results_for_moving_users_group(self):
         migrator = OGDSMigrator(
-            self.portal, {'client1_users': 'new_users_group'}, 'move')
+            self.portal, {'org-unit-1_users': 'new_users_group'}, 'move')
         results = migrator.migrate()
 
         self.assertEquals(
-            [('<OrgUnit client1>', 'client1_users', 'new_users_group')],
+            [('<OrgUnit org-unit-1>', 'org-unit-1_users', 'new_users_group')],
             results['users_groups']['moved']
         )
 
     def test_returns_proper_results_for_moving_inbox_group(self):
         migrator = OGDSMigrator(
-            self.portal, {'client1_inbox_users': 'new_inbox_group'}, 'move')
+            self.portal, {'org-unit-1_inbox_users': 'new_inbox_group'}, 'move')
         results = migrator.migrate()
 
         self.assertEquals(
-            [('<OrgUnit client1>', 'client1_inbox_users', 'new_inbox_group')],
+            [('<OrgUnit org-unit-1>', 'org-unit-1_inbox_users', 'new_inbox_group')],
             results['inbox_groups']['moved']
         )


### PR DESCRIPTION
Both the admin unit as well as the org unit in the Fixture builder were created with the ID `client1`.

In addition, there was some code that attempted to link the org unit to the admin unit, but all it really did was *set the ID of the admin unit to the ID of the org unit*.

Because both they're IDs were 'client1' by default, that didn't cause any harm in cases where the admin unit ID wasn't customized.

This change untangles their IDs, setting them to `org-unit-1` and `admin-unit-1` respectively.

---

**Notes**:

- The viewlet failures on STDERR are not introduced by this change - they already exist in the STDERR of a [green build from a few days ago](https://ci.4teamwork.ch/builds/169194/tasks/269956). One culprit seems to be `test_toc.py` in `opengever.meeting`, where two periods (2016 and 2018) are present, but only one is expected to be active.
