### PR TITLE
Open task report: Fix condition to report admin-unit local tasks only

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -9,6 +9,7 @@ Changelog
 - Hide Excerpts field in SubmittedProposal edit form. [njohner]
 - Remove deprecated sablon fields from documenation. [tarnap]
 - Format task template comments in detail view. [tarnap]
+- Open task report: Fix condition to report admin-unit local tasks only. [lgraf]
 - Fix unicode error in versions tab comments. [lgraf]
 - Restrict availability of the delete button. [njohner]
 - Increase size of the favorites plone_uid column. [phgross]

--- a/opengever/latex/opentaskreport.py
+++ b/opengever/latex/opentaskreport.py
@@ -28,7 +28,7 @@ OPEN_TASK_STATES = [
     'task-state-resolved',
     'task-state-rejected',
     'forwarding-state-open',
-    ]
+]
 
 
 class IOpenTaskReportLayer(ILandscapeLayer):
@@ -66,7 +66,6 @@ class OpenTaskReportLaTeXView(MakoLaTeXView):
     def _extend_task_query(self, query):
         """Extends a globalindex task query.
         """
-
         # sort by deadline
         query = query.order_by(asc(Task.deadline))
 
@@ -77,7 +76,7 @@ class OpenTaskReportLaTeXView(MakoLaTeXView):
         # List only the one which is assigned to this client.
         query = query.filter(
             or_(
-                and_(Task.predecessor == None, Task.successors == None),
+                and_(Task.predecessor == None, Task.successors == None),  # noqa: comparison to None is correct for SQLAlchemy
                 Task.admin_unit_id == get_current_admin_unit().id()))
 
         return query
@@ -89,7 +88,6 @@ class OpenTaskReportLaTeXView(MakoLaTeXView):
         incoming -- open tasks assigned to the current client
         outgoing -- open tasks assigned to another client
         """
-
         org_unit_id = get_current_org_unit().id()
 
         incoming_query = Session().query(Task)
@@ -163,7 +161,7 @@ class OpenTaskReportLaTeXView(MakoLaTeXView):
             responsible,
             deadline,
             review_state,
-            ]
+        ]
 
     def convert_list_to_row(self, row):
         return ' & '.join([self.convert_plain(cell) for cell in row])

--- a/opengever/latex/opentaskreport.py
+++ b/opengever/latex/opentaskreport.py
@@ -9,6 +9,7 @@ from opengever.latex.interfaces import ILandscapeLayer
 from opengever.latex.utils import get_issuer_of_task
 from opengever.latex.utils import workflow_state
 from opengever.ogds.base.actor import Actor
+from opengever.ogds.base.utils import get_current_admin_unit
 from opengever.ogds.base.utils import get_current_org_unit
 from opengever.ogds.base.utils import ogds_service
 from opengever.task.helper import task_type_helper
@@ -77,7 +78,7 @@ class OpenTaskReportLaTeXView(MakoLaTeXView):
         query = query.filter(
             or_(
                 and_(Task.predecessor == None, Task.successors == None),
-                Task.admin_unit_id == get_current_org_unit().id()))
+                Task.admin_unit_id == get_current_admin_unit().id()))
 
         return query
 

--- a/opengever/latex/tests/test_opentaskreport.py
+++ b/opengever/latex/tests/test_opentaskreport.py
@@ -147,9 +147,6 @@ class TestOpenTaskReport(FunctionalTestCase):
         self.assertFalse(
             self.portal.unrestrictedTraverse('pdf-open-task-report-allowed')())
 
-    @unittest.skip('The code that this test tests for is actually broken and '
-                   'needs to be fixed. The condition in opentaskreport.py:80 '
-                   'is wrong, it compares IDs of admin units vs org units.')
     def test_shows_only_task_on_admin_unit(self):
         additional_admin_unit = create(Builder('admin_unit').id(u'additional'))
         create(Builder('org_unit').id(u'additional')
@@ -171,10 +168,10 @@ class TestOpenTaskReport(FunctionalTestCase):
 
         self.assertEqual(
             ['1 & Task 1 & To comment &  & Client1 & Peter Peter & '
-             'Client1 / Meier Hans & 01.07.2014 & task"=state"=open'],
+             'Org Unit 1 / Meier Hans & 01.07.2014 & task"=state"=open'],
             arguments['outgoing'])
 
         self.assertEqual(
-            ['1 & Task 1 & To comment &  & Client1 & Client1 / Peter '
+            ['1 & Task 1 & To comment &  & Client1 & Org Unit 1 / Peter '
              'Peter & Meier Hans & 01.07.2014 & task"=state"=open'],
             arguments['incoming'], )


### PR DESCRIPTION
This is a follow up to #4529 - the condition for checking admin-unit local tasks *(local side of inter-admin-unit task-pairs)* in the open task report was wrong.