### PR TITLE
Fix viewlet rendering error in toc tests.

### DIFF
--- a/opengever/base/tests/test_default_values_for_types.py
+++ b/opengever/base/tests/test_default_values_for_types.py
@@ -1037,7 +1037,9 @@ class TestProposalDefaults(TestDefaultsBase):
             True)
 
         self.container = create(Builder('committee_container'))
-        self.committee = create(Builder('committee').within(self.container))
+        self.committee = create(Builder('committee')
+                                .with_default_period()
+                                .within(self.container))
         self.repofolder = create(Builder('repository'))
 
         self.dossier = create(Builder('dossier')

--- a/opengever/core/tests/test_relations.py
+++ b/opengever/core/tests/test_relations.py
@@ -209,6 +209,7 @@ class TestRelationCatalogInterfaces(FunctionalTestCase):
         create(Builder('committee_container')
                .having(protocol_header_template=sablontemplate_b))
         committee = create(Builder('committee')
+                           .with_default_period()
                            .having(protocol_header_template=sablontemplate_b))
 
         proposal, submittedproposal = create(

--- a/opengever/document/tests/test_document.py
+++ b/opengever/document/tests/test_document.py
@@ -224,7 +224,7 @@ class TestDocument(FunctionalTestCase):
         repo, repo_folder = create(Builder('repository_tree'))
         dossier = create(Builder('dossier').within(repo_folder))
         document = create(Builder('document').within(dossier))
-        committee = create(Builder('committee'))
+        committee = create(Builder('committee').with_default_period())
         self.grant('CommitteeResponsible', on=committee)
         proposal, submitted_proposal = create(
             Builder('proposal').within(dossier)

--- a/opengever/locking/tests/test_lockable.py
+++ b/opengever/locking/tests/test_lockable.py
@@ -20,7 +20,9 @@ class TestSQLLockable(FunctionalTestCase):
         super(TestSQLLockable, self).setUp()
         self.session = create_session()
         self.container = create(Builder('committee_container'))
-        self.committee = create(Builder('committee').within(self.container))
+        self.committee = create(Builder('committee')
+                                .with_default_period()
+                                .within(self.container))
         self.meeting = create(Builder('meeting').having(
             committee=self.committee.load_model()))
 

--- a/opengever/meeting/tests/test_committee_container_tabs.py
+++ b/opengever/meeting/tests/test_committee_container_tabs.py
@@ -27,6 +27,7 @@ class TestCommitteeContainerCommitteeTab(IntegrationTestCase):
         with self.login(self.administrator):
             create(Builder('committee')
                    .within(self.committee_container)
+                   .with_default_period()
                    .titled(u'Invisible'))
 
         self.login(self.meeting_user, browser)

--- a/opengever/meeting/tests/test_committee_roles.py
+++ b/opengever/meeting/tests/test_committee_roles.py
@@ -13,6 +13,7 @@ class TestCommitteeTabs(FunctionalTestCase):
 
         self.container = create(Builder('committee_container'))
         self.committee = create(Builder('committee')
+                                .with_default_period()
                                 .within(self.container))
 
     def test_committee_roles_initialized(self):

--- a/opengever/meeting/tests/test_committee_tabs.py
+++ b/opengever/meeting/tests/test_committee_tabs.py
@@ -13,6 +13,7 @@ class TestCommitteeTabs(FunctionalTestCase):
         self.container = create(Builder('committee_container'))
         self.committee = create(Builder('committee')
                                 .within(self.container)
+                                .with_default_period()
                                 .titled(u'Kleiner Burgerrat'))
         self.committee_model = self.committee.load_model()
 

--- a/opengever/meeting/tests/test_members.py
+++ b/opengever/meeting/tests/test_members.py
@@ -123,7 +123,9 @@ class TestMemberView(FunctionalTestCase):
         self.member = create(Builder('member')
                              .having(email='p.meier@example.com'))
         self.member_wrapper = MemberWrapper.wrap(self.container, self.member)
-        self.committee = create(Builder('committee').within(self.container))
+        self.committee = create(Builder('committee')
+                                .with_default_period()
+                                .within(self.container))
 
         self.membership_1 = create(Builder('membership')
                                    .having(member=self.member,

--- a/opengever/meeting/tests/test_memberships.py
+++ b/opengever/meeting/tests/test_memberships.py
@@ -36,7 +36,9 @@ class TestMemberships(FunctionalTestCase):
     def setUp(self):
         super(TestMemberships, self).setUp()
         self.container = create(Builder('committee_container'))
-        self.committee = create(Builder('committee').within(self.container))
+        self.committee = create(Builder('committee')
+                                .with_default_period()
+                                .within(self.container))
         self.member = create(Builder('member'))
         self.member_wrapper = MemberWrapper.wrap(self.container, self.member)
 

--- a/opengever/meeting/tests/test_periods.py
+++ b/opengever/meeting/tests/test_periods.py
@@ -43,7 +43,9 @@ class TestPeriod(FunctionalTestCase):
 
         # freeze date to make sure the default period is 2016
         with freeze(datetime(2016, 12, 26)):
-            self.committee = create(Builder('committee').within(self.container))
+            self.committee = create(Builder('committee')
+                                    .with_default_period()
+                                    .within(self.container))
 
         self.committee_model = self.committee.load_model()
 

--- a/opengever/meeting/tests/test_protocol_json_data.py
+++ b/opengever/meeting/tests/test_protocol_json_data.py
@@ -36,6 +36,7 @@ class TestProtocolJsonData(FunctionalTestCase):
                             .with_message("lorem", filename=u"lorem.eml")
                             .within(self.dossier))
         self.committee = create(Builder('committee')
+                                .with_default_period()
                                 .having(title=u'Gemeinderat'))
         self.proposal = create(
             Builder('proposal')

--- a/opengever/meeting/tests/test_submit_additional_documents.py
+++ b/opengever/meeting/tests/test_submit_additional_documents.py
@@ -46,7 +46,9 @@ class TestSubmitAdditionalDocuments(FunctionalTestCase):
 
         self.repo, self.repo_folder = create(Builder('repository_tree'))
         self.dossier = create(Builder('dossier').within(self.repo_folder))
-        self.committee = create(Builder('committee').titled('My committee'))
+        self.committee = create(Builder('committee')
+                                .with_default_period()
+                                .titled('My committee'))
         self.document = create(Builder('document')
                                .within(self.dossier)
                                .titled(u'A Document')

--- a/opengever/meeting/tests/test_toc.py
+++ b/opengever/meeting/tests/test_toc.py
@@ -99,6 +99,7 @@ class TestAlphabeticalTOC(FunctionalTestCase):
                                     .within(self.container))
         self.committee_model = self.committee.load_model()
         self.period = create(Builder('period').having(
+            title=u'2010',
             date_from=date(2010, 1, 1),
             date_to=date(2010, 12, 31),
             committee=self.committee_model))
@@ -193,6 +194,7 @@ class TestAlphabeticalTOC(FunctionalTestCase):
                                           .within(self.container))
         self.other_committee_model = self.other_committee.load_model()
         self.other_period = create(Builder('period').having(
+            title=u'2010',
             date_from=date(2010, 1, 1),
             date_to=date(2010, 12, 31),
             committee=self.other_committee_model))
@@ -242,7 +244,7 @@ class TestAlphabeticalTOC(FunctionalTestCase):
         self.assertDictContainsSubset(
             {'status': '200 Ok',
              'content-disposition': 'attachment; '
-                'filename="Alphabetical Toc 2016 my-committee.docx"',
+                'filename="Alphabetical Toc 2010 my-committee.docx"',
              'x-frame-options': 'SAMEORIGIN',
              'content-type': MIME_DOCX,
              'x-theme-disabled': 'True'},
@@ -353,7 +355,7 @@ class TestTOCByRepository(TestAlphabeticalTOC):
         self.assertDictContainsSubset(
             {'status': '200 Ok',
              'content-disposition': 'attachment; '
-                'filename="Repository Toc 2016 my-committee.docx"',
+                'filename="Repository Toc 2010 my-committee.docx"',
              'x-frame-options': 'SAMEORIGIN',
              'content-type': MIME_DOCX,
              'x-theme-disabled': 'True'},

--- a/opengever/meeting/tests/test_unit_agenda_item.py
+++ b/opengever/meeting/tests/test_unit_agenda_item.py
@@ -27,7 +27,9 @@ class TestProposalAgendaItem(FunctionalTestCase):
         self.meeting_dossier = create(
             Builder('meeting_dossier').within(self.repository_folder))
         self.container = create(Builder('committee_container'))
-        self.committee = create(Builder('committee').within(self.container))
+        self.committee = create(Builder('committee')
+                                .with_default_period()
+                                .within(self.container))
         self.meeting = create(Builder('meeting')
                               .having(committee=self.committee.load_model())
                               .link_with(self.meeting_dossier))

--- a/opengever/testing/builders/dx.py
+++ b/opengever/testing/builders/dx.py
@@ -465,7 +465,9 @@ class CommitteeBuilder(DexterityBuilder):
 
     def __init__(self, session):
         super(CommitteeBuilder, self).__init__(session)
-        self.arguments = {'title': 'My Committee', 'group_id': u'org-unit-1_users'}
+        self.arguments = {'title': 'My Committee',
+                          'group_id': u'org-unit-1_users'}
+        self._with_default_period = False
 
     def link_with(self, repository_folder):
         self.arguments['repository_folder'] = repository_folder
@@ -489,7 +491,14 @@ class CommitteeBuilder(DexterityBuilder):
 
         super(CommitteeBuilder, self).after_create(obj)
 
+    def with_default_period(self):
+        self._with_default_period = True
+        return self
+
     def create_default_period(self, obj):
+        if not self._with_default_period:
+            return
+
         committee_model = obj.load_model()
         today = date.today()
         db_session = self.session.session

--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -1513,6 +1513,7 @@ class OpengeverContentFixture(object):
             Builder('committee')
             .titled(title)
             .within(self.committee_container)
+            .with_default_period()
             .having(
                 ad_hoc_template=self.proposal_template,
                 repository_folder=repository_folder,


### PR DESCRIPTION
This PR fixes a viewlet rendering error that appeared during toc tests. The test fixture contained two active periods, which is an invalid state.