### PR TITLE
Format task template comments

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,7 @@ Changelog
 
 - Hide Excerpts field in SubmittedProposal edit form. [njohner]
 - Remove deprecated sablon fields from documenation. [tarnap]
+- Format task template comments in detail view. [tarnap]
 - Fix unicode error in versions tab comments. [lgraf]
 - Increase size of the favorites plone_uid column. [phgross]
 - Display the checkin comment on bumblebee overlays. [Rotonen]

--- a/opengever/tasktemplates/browser/tasktemplates.py
+++ b/opengever/tasktemplates/browser/tasktemplates.py
@@ -6,7 +6,9 @@ from opengever.task.helper import task_type_helper
 from opengever.tasktemplates import _
 from opengever.tasktemplates.browser.helper import interactive_user_helper
 from opengever.tasktemplates.content.tasktemplate import ITaskTemplate
+from plone import api
 from plone.dexterity.browser.view import DefaultView
+from Products.CMFPlone.utils import safe_unicode
 from zope.component.hooks import getSite
 from zope.i18n import translate
 
@@ -75,6 +77,14 @@ class TaskTemplates(BaseCatalogListingTab):
 
 
 class View(DefaultView):
+
+    def comments(self):
+        text = ITaskTemplate(self.context).text
+        if text:
+            transformer = api.portal.get_tool(name='portal_transforms')
+            converted = transformer.convertTo(
+                'text/html', safe_unicode(text), mimetype='text/x-web-intelligent')
+            return converted.getData()
 
     def responsible_link(self):
         task = ITaskTemplate(self.context)

--- a/opengever/tasktemplates/browser/templates/view.pt
+++ b/opengever/tasktemplates/browser/templates/view.pt
@@ -21,7 +21,7 @@
             <tr tal:repeat="widget group/widgets/values">
             <span tal:define="index repeat/widget/index"/>
 
-              <tal:block condition="python: widget.__name__ not in ('preselected','title','responsible','issuer') and widget.value">
+              <tal:block condition="python: widget.__name__ not in ('preselected','title','responsible','issuer', 'text') and widget.value">
 
                 <th tal:content="widget/label" ></th>
                 <td tal:content="structure widget/render" />
@@ -33,6 +33,10 @@
               <tal:block condition="python:widget.__name__  == 'issuer' and widget.value">
                 <th tal:content="widget/label"></th>
                 <td tal:content="structure view/issuer_link" />
+              </tal:block>
+              <tal:block condition="python:widget.__name__  == 'text' and widget.value">
+                <th tal:content="widget/label"></th>
+                <td tal:content="structure view/comments" />
               </tal:block>
               <tal:block condition="python:widget.__name__  == 'preselected' and widget.value==['selected']">
                 <th tal:content="widget/field/title"></th>

--- a/opengever/tasktemplates/content/tasktemplate.py
+++ b/opengever/tasktemplates/content/tasktemplate.py
@@ -82,6 +82,7 @@ class ITaskTemplate(model.Schema):
         required=True,
     )
 
+    # Bad naming: comments is more appropriated
     model.primary('text')
     text = schema.Text(
         title=_(u"label_text", default=u"Text"),

--- a/opengever/tasktemplates/tests/test_tasktemplate.py
+++ b/opengever/tasktemplates/tests/test_tasktemplate.py
@@ -47,6 +47,26 @@ class TestTaskTemplates(IntegrationTestCase):
                           browser.css('.documentFirstHeading').text)
 
     @browsing
+    def test_view_displays_formatted_comments(self, browser):
+        self.login(self.administrator, browser=browser)
+
+        self.tasktemplate.text = (u'- T\xfcsteintrag' '\n'
+                                  u'- m\xfet' '\n'
+                                  u'- F\xfdrmat')
+
+        browser.open(self.tasktemplate)
+
+        # Get the cell of the comments
+        cells = [row.css('td').first
+                 for row in browser.css('.task-listing tr')
+                 if len(row.css('th')) and row.css('th').first.text == 'Text']
+
+        self.assertEquals(1, len(cells))
+
+        self.assertEquals(u'- T\xfcsteintrag<br>- m\xfet<br>- F\xfdrmat',
+                          cells[0].normalized_innerHTML)
+
+    @browsing
     def test_tasktemplatefolder_can_be_edited_when_activated(self, browser):
         self.login(self.administrator, browser=browser)
 

--- a/opengever/tasktemplates/tests/test_tasktemplate.py
+++ b/opengever/tasktemplates/tests/test_tasktemplate.py
@@ -52,7 +52,8 @@ class TestTaskTemplates(IntegrationTestCase):
 
         self.tasktemplate.text = (u'- T\xfcsteintrag' '\n'
                                   u'- m\xfet' '\n'
-                                  u'- F\xfdrmat')
+                                  u'- F\xfdrmat'
+                                  '<script>alert("XSS!");</script>')
 
         browser.open(self.tasktemplate)
 
@@ -63,7 +64,10 @@ class TestTaskTemplates(IntegrationTestCase):
 
         self.assertEquals(1, len(cells))
 
-        self.assertEquals(u'- T\xfcsteintrag<br>- m\xfet<br>- F\xfdrmat',
+        self.assertEquals(u'- T\xfcsteintrag<br>'
+                          u'- m\xfet<br>'
+                          u'- F\xfdrmat'
+                          u'&lt;script&gt;alert("XSS!");&lt;/script&gt;',
                           cells[0].normalized_innerHTML)
 
     @browsing


### PR DESCRIPTION
# Previously

![bildschirmfoto 2018-07-02 um 14 29 31](https://user-images.githubusercontent.com/485755/42163980-dd88d7fa-7e04-11e8-9810-77f59ca69048.png)

When the text contains line breaks and similar, they were not displayed in the detail view.

![bildschirmfoto 2018-07-02 um 14 29 25](https://user-images.githubusercontent.com/485755/42163981-ddab5334-7e04-11e8-868c-24307256d629.png)

# Changes with this PR

<img width="1072" alt="screen shot 2018-07-03 at 09 24 45" src="https://user-images.githubusercontent.com/194114/42212997-ecab7824-7eb7-11e8-80cf-34426195daf0.png">

Resolves #4526 