### PR TITLE
Remove deprecated sablon fields from documentation

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ---------------------
 
 - Hide Excerpts field in SubmittedProposal edit form. [njohner]
+- Remove deprecated sablon fields from documenation. [tarnap]
 - Fix unicode error in versions tab comments. [lgraf]
 - Increase size of the favorites plone_uid column. [phgross]
 - Display the checkin comment on bumblebee overlays. [Rotonen]

--- a/docs/public/admin-manual/meeting/mergefields.rst
+++ b/docs/public/admin-manual/meeting/mergefields.rst
@@ -149,42 +149,6 @@ Metadaten zu einem Traktandum (AgendaItem):
 
   Gibt an, ob es sich um einen Abschnitt handelt oder nicht (Boolean).
 
-- ``legal_basis``
-
-  Rechtsgrundlage des Antrags (Text).
-
-- ``initial_position``
-
-  Ausgangslage des Antrags (Text).
-
-- ``considerations``
-
-  Erwägungen zum Antrag (Text).
-
-- ``proposed_action``
-
-  Text des Antrags (Text).
-
-- ``discussion``
-
-  Diskussion während der Sitzung zum Antrag (Text).
-
-- ``decision``
-
-  Beschluss zum Antrag gemäss Sitzung (Text).
-
-- ``disclose_to``
-
-  Zu eröffnen an (Text).
-
-- ``copy_for_attention``
-
-  Kopie geht an (Text).
-
-- ``publish_in``
-
-  Zu veröffentlichen in (Text).
-
 - ``attachments``
 
   Liste von Anhängen des Antrags (Liste von Attachment).


### PR DESCRIPTION
Remove the unsupported fields from the documentation.

These fields are part of the old SPV version and can therefore be removed.
All customers of the old SPV were migrated to the new version.

Resolves #4530