### PR TITLE
Make lock info visible even when it can be safely unlocked.

### DIFF
--- a/opengever/locking/info.py
+++ b/opengever/locking/info.py
@@ -1,7 +1,6 @@
 from opengever.base.oguid import Oguid
 from opengever.locking.lock import LOCK_TYPE_MEETING_EXCERPT_LOCK
 from opengever.locking.lock import LOCK_TYPE_MEETING_SUBMITTED_LOCK
-from opengever.locking.lock import LOCK_TYPE_SYS_LOCK
 from opengever.meeting.model import GeneratedExcerpt
 from opengever.meeting.model import GeneratedProtocol
 from opengever.meeting.model import SubmittedDocument
@@ -20,6 +19,7 @@ class GeverLockInfoViewlet(LockInfoViewlet):
         'templates/excerpt_document_lock_template.pt')
     oc_document_lock_template = ViewPageTemplateFile(
         'templates/oc_document_lock_template.pt')
+    default_template = ViewPageTemplateFile('templates/info.pt')
 
     # templates seem to be converted to BoundPageTemplate with acquisition
     # magic, thus we cannot put the ViewPageTemplateFile instances directly
@@ -27,16 +27,18 @@ class GeverLockInfoViewlet(LockInfoViewlet):
     custom_templates = {
         LOCK_TYPE_MEETING_SUBMITTED_LOCK: 'submitted_document_lock_template',
         LOCK_TYPE_MEETING_EXCERPT_LOCK: 'excerpt_document_lock_template',
-        "office_connector_lock": 'oc_document_lock_template'
+        "office_connector_lock": 'oc_document_lock_template',
+        'default': 'default_template'
     }
 
     def render(self):
-        custom_template_name = self.custom_templates.get(
-            self.get_lock_type_name())
-        if custom_template_name:
-            return getattr(self, custom_template_name)()
+        custom_template_name = self.get_template_name()
+        return getattr(self, custom_template_name)()
 
-        return super(GeverLockInfoViewlet, self).render()
+    def get_template_name(self):
+        custom_template_name = self.custom_templates.get(
+            self.get_lock_type_name(), self.custom_templates.get('default'))
+        return custom_template_name
 
     def get_lock_type_name(self):
         lock_info = self.lock_info()

--- a/opengever/locking/templates/info.pt
+++ b/opengever/locking/templates/info.pt
@@ -1,0 +1,45 @@
+<div id="plone-lock-status"
+     i18n:domain="plone"
+     tal:define="locked view/info/is_locked;
+                 stealable view/lock_is_stealable;
+                 lock_details view/lock_info;">
+  <tal:block condition="locked">
+    <dl class="portalMessage info">
+      <dt i18n:translate="label_locked">Locked</dt>
+      <dd>
+        <tal:author-page
+            tal:condition="lock_details/author_page"
+            i18n:translate="description_webdav_locked_by_author_on_time">
+          This item was locked by
+          <a i18n:name="author"
+             tal:content="lock_details/fullname"
+             tal:attributes="href lock_details/author_page" />
+          <span i18n:name="time"
+                tal:content="lock_details/time_difference" /> ago.
+        </tal:author-page>
+        <tal:no-author-page
+            tal:condition="not:lock_details/author_page"
+            i18n:translate="description_webdav_locked_by_author_on_time">
+          This item was locked by
+          <span i18n:name="author"
+                tal:content="lock_details/fullname" />
+          <span i18n:name="time"
+                tal:content="lock_details/time_difference" /> ago.
+        </tal:no-author-page>
+        <form tal:condition="view/current_user_can_unlock_document"
+              tal:attributes="action string:${context/absolute_url}/@@plone_lock_operations/force_unlock"
+              method="POST">
+          <span i18n:translate="description_webdav_locked_steal">
+            If you are certain this user has abandoned the object,
+            you may
+            <input type="submit"
+                   value="Unlock"
+                   i18n:name="unlock_button"
+                   i18n:attributes="value" />
+            the object. You will then be able to edit it.
+          </span>
+        </form>
+      </dd>
+    </dl>
+  </tal:block>
+</div>


### PR DESCRIPTION
Lock info is visible now even if the lock belongs to the current user.
Only managers will see the unlock button though.

**User see own lock**
![screen shot 2018-07-03 at 12 24 17](https://user-images.githubusercontent.com/7374243/42214512-08f62b9c-7ebc-11e8-9db9-dd2515e4a491.png)

**managers can unlock**
<img width="1195" alt="screen shot 2018-07-03 at 13 06 58" src="https://user-images.githubusercontent.com/7374243/42216402-fcf64056-7ec1-11e8-9284-38b99bedaee6.png">

resolves #4454 