### PR TITLE
Correct info message when agendaitem list is regenerated.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2018.4.0 (unreleased)
 ---------------------
 
+- Correct info message showed when regenerating agendaitem list. [njohner]
 - Build missing french translations for opengever.meeting. [elioschmutz]
 - Hide Excerpts field in SubmittedProposal edit form. [njohner]
 - Remove deprecated sablon fields from documenation. [tarnap]

--- a/opengever/meeting/command.py
+++ b/opengever/meeting/command.py
@@ -164,10 +164,12 @@ class AgendaItemListOperations(object):
         return agendaitem_list_document
 
     def get_generated_message(self, meeting):
-        return _(u'Agenda item list for meeting ${title} has been generated successfully.', mapping=dict(title=meeting.get_title()))
+        return _(u'Agenda item list for meeting ${title} has been generated '
+                 'successfully.',
+                 mapping=dict(title=meeting.get_title()))
 
     def get_updated_message(self, meeting):
-        return _(u'Protocol for meeting ${title} has been updated '
+        return _(u'Agenda item list for meeting ${title} has been updated '
                  'successfully.',
                  mapping=dict(title=meeting.get_title()))
 

--- a/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-04 09:46+0000\n"
+"POT-Creation-Date: 2018-07-06 06:12+0000\n"
 "PO-Revision-Date: 2017-10-23 18:40+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -60,6 +60,10 @@ msgstr "Das zusätzliche Dokument ${title} wurde erfolgreich eingereicht."
 #: ./opengever/meeting/command.py
 msgid "Agenda item list for meeting ${title} has been generated successfully."
 msgstr "Traktandenliste für die Sitzung ${title} wurde erfolgreich erstellt."
+
+#: ./opengever/meeting/command.py
+msgid "Agenda item list for meeting ${title} has been updated successfully."
+msgstr "Traktandenliste für die Sitzung ${title} wurde erfolgreich aktualisiert."
 
 #. Default: "An unexpected error has occurred"
 #: ./opengever/meeting/browser/meetings/meeting.py

--- a/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-04 09:46+0000\n"
+"POT-Creation-Date: 2018-07-06 06:12+0000\n"
 "PO-Revision-Date: 2018-05-22 10:15+0000\n"
 "Last-Translator: Niklaus Johner <Niklaus.johner@4teamwork.ch>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-meeting/fr/>\n"
@@ -62,6 +62,10 @@ msgstr "Le document supplémentaire ${title} a été soumis avec succès."
 #: ./opengever/meeting/command.py
 msgid "Agenda item list for meeting ${title} has been generated successfully."
 msgstr "L'ordre du jour pour la séance ${title} a été créé avec succès."
+
+#: ./opengever/meeting/command.py
+msgid "Agenda item list for meeting ${title} has been updated successfully."
+msgstr "L'ordre du jour pour la séance ${title} a été actualisé avec succès."
 
 #. Default: "An unexpected error has occurred"
 #: ./opengever/meeting/browser/meetings/meeting.py

--- a/opengever/meeting/locales/opengever.meeting.pot
+++ b/opengever/meeting/locales/opengever.meeting.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-04 09:46+0000\n"
+"POT-Creation-Date: 2018-07-06 06:12+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -58,6 +58,10 @@ msgstr ""
 
 #: ./opengever/meeting/command.py
 msgid "Agenda item list for meeting ${title} has been generated successfully."
+msgstr ""
+
+#: ./opengever/meeting/command.py
+msgid "Agenda item list for meeting ${title} has been updated successfully."
 msgstr ""
 
 #. Default: "An unexpected error has occurred"


### PR DESCRIPTION
The message displayed when regenerating the agendaitem list was wrongly saying that the protocol has been regenerated.