### PR TITLE
Update filename normalisation

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -21,6 +21,7 @@ Changelog
 - Fix unicode error on edit an agendaitem. [elioschmutz]
 - Adjust activity mail subject to a more generic text. [elioschmutz]
 - Do no longer record `document submitted` activity while submitting a proposal with attachments. [elioschmutz]
+- New filename normalizer to more closely match document and E-mail titles. [njohner]
 - Install CustomEvent and Promise polyfill. [Kevin Bieri]
 - Uninstall webcomponents polyfill. [Kevin Bieri]
 - Update favorite-icon after checking-out or checking-in a document. [elioschmutz]

--- a/opengever/api/tests/test_content_creation.py
+++ b/opengever/api/tests/test_content_creation.py
@@ -73,7 +73,7 @@ class TestContentCreation(IntegrationTestCase):
         new_object_id = str(response.json['id'])
         doc = self.dossier.restrictedTraverse(new_object_id)
         self.assertEqual(u'Sanierung B\xe4rengraben 2016', doc.title)
-        self.assertEqual(u'sanierung-barengraben-2016.txt', doc.file.filename)
+        self.assertEqual(u'Sanierung Baerengraben 2016.txt', doc.file.filename)
 
         checksum = IBumblebeeDocument(doc).get_checksum()
         self.assertIsNotNone(checksum)

--- a/opengever/api/tests/test_mail.py
+++ b/opengever/api/tests/test_mail.py
@@ -78,7 +78,7 @@ class TestCreateMail(IntegrationTestCase):
 
         mail = children['added'].pop()
         self.assertEqual(mail.Title(), 'Äusseres Testmäil')
-        self.assertEqual(mail.message.filename, 'ausseres-testmail.eml')
+        self.assertEqual(mail.message.filename, 'Aeusseres Testmaeil.eml')
         self.assertEqual(mail.original_message, None)
 
     @browsing
@@ -103,7 +103,7 @@ class TestCreateMail(IntegrationTestCase):
 
         mail = children['added'].pop()
         self.assertEqual(mail.Title(), 'Separate title')
-        self.assertEqual(mail.message.filename, 'separate-title.eml')
+        self.assertEqual(mail.message.filename, 'Separate title.eml')
         self.assertEqual(mail.original_message, None)
 
 

--- a/opengever/api/tests/test_summary.py
+++ b/opengever/api/tests/test_summary.py
@@ -103,7 +103,7 @@ class TestGeverJSONSummarySerializer(IntegrationTestCase):
                         u'und-vereinbarungen/dossier-1/document-12',
                 u'created': u'2016-08-31T15:07:33+02:00',
                 u'creator': u'robert.ziegler',
-                u'filename': u'vertragsentwurf.docx',
+                u'filename': u'Vertraegsentwurf.docx',
                 u'filesize': 27413,
                 u'mimetype': u'application/vnd.openxmlformats-officedocument.'
                              u'wordprocessingml.document',

--- a/opengever/base/configure.zcml
+++ b/opengever/base/configure.zcml
@@ -313,4 +313,11 @@
       permission="zope2.View"
       />
 
+  <utility
+      name="gever_filename_normalizer"
+      provides="plone.i18n.normalizer.interfaces.IFileNameNormalizer"
+      component=".filename.filenamenormalizer"
+      permission="zope.Public"
+      />
+
 </configure>

--- a/opengever/base/filename.py
+++ b/opengever/base/filename.py
@@ -1,0 +1,191 @@
+from plone.i18n.normalizer.base import CHAR as base_cache
+from plone.i18n.normalizer.interfaces import IFileNameNormalizer
+from Products.CMFPlone.utils import safe_unicode
+from zope.interface import implements
+import re
+import string
+import unicodedata
+
+# We share the cache with the plone basenormalizer as there seems
+# to be little reason to cache the unicode tables twice.
+unicode_cache = base_cache
+
+# On OpenBSD string.whitespace has a non-standard implementation
+# See http://dev.plone.org/plone/ticket/4704 for details
+whitespace = ''.join([c for c in string.whitespace if ord(c) < 128])
+allowed_characters = string.ascii_letters + string.digits + string.punctuation + whitespace
+
+
+def unidecode(string):
+    """This function is taken and adapted from the unidecode module.
+    It replaces unicode characters with their closest ASCII counterpart
+    or with a whitespace.
+    """
+    retval = []
+
+    for char in string:
+        codepoint = ord(char)
+
+        if codepoint < 0x80:  # Basic ASCII
+            retval.append(str(char))
+            continue
+
+        if codepoint > 0xeffff:
+            retval.append(' ')
+            continue  # Characters in Private Use Area and above are ignored
+
+        section = codepoint >> 8   # Chop off the last two hex digits
+        position = codepoint % 256  # Last two hex digits
+        try:
+            table = unicode_cache[section]
+        except KeyError:
+            try:
+                mod = __import__('unidecode.x%02x' % (section), [], [], ['data'])
+            except ImportError:
+                unicode_cache[section] = None
+                retval.append(' ')
+                continue   # No match: ignore this character and carry on.
+
+            unicode_cache[section] = table = mod.data
+
+        if table and len(table) > position:
+            retval.append(table[position])
+
+        elif unicodedata.decomposition(char):
+            normalized = unicodedata.normalize('NFKD', char).strip()
+            normalized = ''.join([c for c in normalized if c in allowed_characters])
+            retval.append(normalized or ' ')
+
+        else:
+            retval.append(' ')
+
+    return ''.join(retval)
+
+
+class GeverBaseStringNormalizer(object):
+    """This normalizer is meant as a flexible baseclass for
+    string normalizers in opengever. Its normalize method will:
+    * make the string NFKC encoded unicode
+    * apply the character mapping defined in self.unicode_mapping
+    * transliterate unicode characters, inserting spaces for characters
+      that cannot be transliterated
+    * apply regular expression substitutions defined in self.regex_substitution_list
+    * strip leading spaces
+    * crop the resulting string to self.max_length (if None, do not crop)
+    * strip trailing spaces
+    """
+
+    def __init__(self):
+        self.unicode_mapping = {}
+        self.regex_substitution_list = tuple()
+        self.max_length = 50
+
+    def normalize(self, text):
+        text = safe_unicode(text)
+        text = unicodedata.normalize('NFKC', text)
+        text = self.map_unicode(text)
+        text = unidecode(text)
+        text = self.apply_regex_substitutions(text)
+        text = text.lstrip()
+        text = self.crop_length(text)
+        text = text.rstrip()
+        return safe_unicode(text)
+
+    def map_unicode(self, text):
+        """
+        This method is used to replace special characters found in a mapping.
+        """
+        res = u''
+        for ch in text:
+            ordinal = ord(ch)
+            if ordinal in self.unicode_mapping:
+                res += self.unicode_mapping.get(ordinal)
+            else:
+                res += ch
+        return res
+
+    def apply_regex_substitutions(self, text):
+        for regex, substitution_string in self.regex_substitution_list:
+            text = regex.sub(substitution_string, text)
+        return text
+
+    def crop_length(self, text):
+        if self.max_length is None:
+            return text
+        return text[:self.max_length]
+
+
+class GeverFileNameNormalizer(GeverBaseStringNormalizer):
+    """This normalizer is used to generate normalized filenames
+    typically from the title of an object, making the filename safe
+    but as close as possible to the original title.
+    Specifically it will:
+    * Use a custom map for transliterating German characters as
+      well as map & to +
+    * Transliterate other unicode characters using unidecode
+    * Only keep safe characters (letters, digits, whitespace and _.,=()+-)
+    * Replace all other characters with whitespace
+    * Replace consecutive spaces with a single space
+    * Truncate the length of the filename to 100 characters, not including the extension
+
+    In addition to the above, the filename extension normalization includes:
+    * make the string lowercase
+    * map jpeg to jpg and tiff to tif
+    """
+    implements(IFileNameNormalizer)
+
+    def __init__(self):
+        super(GeverFileNameNormalizer, self).__init__()
+        self.max_length = 100
+
+        self.unicode_mapping = {196: u'Ae', 198: u'Ae', 214: u'Oe', 220: u'Ue',
+                                228: u'ae', 230: u'ae', 246: u'oe', 252: u'ue',
+                                223: u'ss', 224: u'a', 339: u'oe', 38: u'+'}
+
+        self.extension_mapping = {u'tiff': u'tif', u'jpeg': u'jpg'}
+
+        self.allowed_characters = string.ascii_letters + string.digits + ' _.,=()+-'
+
+        forbidden_chars_regex = re.compile(r"[^{}]+".format(self.allowed_characters))
+        multiple_spaces_regex = re.compile(r" +")
+
+        self.regex_substitution_list = ((forbidden_chars_regex, ' '),
+                                        (multiple_spaces_regex, ' '))
+
+        self.filename_extension_regex = re.compile(r"^(.+)\.(\w{,4})$")
+
+    def split_filename_extension(self, filename):
+        match = self.filename_extension_regex.search(filename)
+        if match is not None:
+            filename = match.groups()[0]
+            extension = match.groups()[1]
+            return filename, extension
+        return filename, ''
+
+    def normalize_name(self, text):
+        text = super(GeverFileNameNormalizer, self).normalize(text)
+        text = self.crop_length(text)
+        return text
+
+    def normalize_extension(self, extension):
+        extension = self.extension_mapping.get(extension, extension)
+        extension = super(GeverFileNameNormalizer, self).normalize(extension)
+        extension = extension.lower()
+        return extension
+
+    def normalize(self, filename, extension=None):
+        """if the extension is not passed separately, it will
+        be determined from the filename (if possible).
+        """
+        if extension is None:
+            filename, extension = self.split_filename_extension(filename)
+        filename = self.normalize_name(filename)
+        if extension:
+            if extension.startswith("."):
+                extension = extension[1:]
+            extension = self.normalize_extension(extension)
+            return ".".join((filename, extension))
+        return filename
+
+
+filenamenormalizer = GeverFileNameNormalizer()

--- a/opengever/base/tests/test_command.py
+++ b/opengever/base/tests/test_command.py
@@ -19,7 +19,7 @@ class TestCreateEmailCommand(IntegrationTestCase):
         mail = command.execute()
 
         self.assertEqual('message/rfc822', mail.message.contentType)
-        self.assertEqual('no-subject.eml', mail.message.filename)
+        self.assertEqual('No Subject.eml', mail.message.filename)
 
         self.assertEqual(u'testm\xe4il.msg', mail.original_message.filename)
         self.assertEqual('mock-msg-body', mail.original_message.data)

--- a/opengever/base/tests/test_filename_normalizer.py
+++ b/opengever/base/tests/test_filename_normalizer.py
@@ -1,0 +1,124 @@
+from unittest import TestCase
+from opengever.base.filename import GeverFileNameNormalizer
+import string
+import sys
+import unicodedata
+
+
+class TestFilenameNormalizer(TestCase):
+
+    normalizer = GeverFileNameNormalizer()
+    allowed_characters = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789 _.,=()+-'
+    max_length = 100
+
+    def test_character_cases_are_retained(self):
+        self.assertEqual(string.ascii_letters,
+                         self.normalizer.normalize_name(unicode(string.ascii_letters)))
+
+    def test_maximal_filename_length(self):
+        filename = u''.join('a' for i in range(2*self.max_length))
+        self.assertEqual(self.max_length, len(self.normalizer.normalize_name(filename)))
+
+    def test_filename_cropping_happens_after_character_mapping(self):
+        filename = u''.join(u'\xe4' for i in range(2*self.max_length))
+        self.assertEqual(self.max_length, len(self.normalizer.normalize_name(filename)))
+
+    def test_filename_cropping_happens_after_character_decoding(self):
+        filename = u''.join(u'\xe6' for i in range(2*self.max_length))
+        self.assertEqual(self.max_length, len(self.normalizer.normalize_name(filename)))
+
+    def test_filename_cropping_happens_after_consecutive_spaces_elimination(self):
+        filename = u''.join(u'  aa' for i in range(2*self.max_length))
+        self.assertEqual(self.max_length, len(self.normalizer.normalize_name(filename)))
+
+    def test_filename_cropped_length_does_not_include_file_extension(self):
+        filename = u''.join(u'\xe4' for i in range(2*self.max_length))
+        extension = '.txt'
+        expected_length = self.max_length + len(extension)
+        self.assertEqual(expected_length, len(self.normalizer.normalize(filename+extension)))
+
+    def test_normalizer_handles_non_unicode_strings(self):
+        self.assertTrue(isinstance(self.normalizer.normalize("a non unicode string"), unicode))
+
+    def test_only_allowed_characters_are_output(self):
+        for i in range(sys.maxunicode):
+            normalized = self.normalizer.normalize_name(unichr(i))
+            for character in normalized:
+                self.assertTrue(character in self.allowed_characters,
+                                u"unichr({}): {} was normalized to {}".format(i, unichr(i), normalized))
+
+    def test_consecutive_spaces_are_cleaned_up(self):
+        self.assertEqual(u'a test name with spaces',
+                         self.normalizer.normalize_name(u'a test  name with   spaces'))
+        self.assertEqual(u'a test name with spaces',
+                         self.normalizer.normalize_name(u'a test \t name with ;  spaces'))
+
+    def test_german_umlaut_mapping(self):
+        mapping = ((u'\xe4', 'ae'), (u'\xfc', 'ue'), (u'\xf6', 'oe'),
+                   (u'\xc4', 'Ae'), (u'\xdc', 'Ue'), (u'\xd6', 'Oe'),
+                   (u'\xdf', 'ss'))
+        for special, normalized in mapping:
+            self.assertEqual(normalized,
+                             self.normalizer.normalize_name(special))
+
+    def test_german_umlaut_mapping_also_works_for_decomposed_characters(self):
+        mapping = ((u'\xe4', 'ae'), (u'\xfc', 'ue'), (u'\xf6', 'oe'),
+                   (u'\xc4', 'Ae'), (u'\xdc', 'Ue'), (u'\xd6', 'Oe'),
+                   (u'\xdf', 'ss'))
+        for special, normalized in mapping:
+            decomposed = unicodedata.normalize('NFKD', special)
+            self.assertEqual(normalized,
+                             self.normalizer.normalize_name(decomposed))
+
+    def test_french_accent_mapping(self):
+        mapping = ((u'\xe9', 'e'), (u'\xe8', 'e'), (u'\xea', 'e'),
+                   (u'\xc9', 'E'), (u'\xc8', 'E'), (u'\xca', 'E'),
+                   (u'\xe0', 'a'), (u'\xe2', 'a'),
+                   (u'\xc0', 'A'), (u'\xc2', 'A'),
+                   (u'\xf4', 'o'), (u'\u0153', 'oe'),
+                   (u'\xd4', 'O'), (u'\u0152', 'OE'),
+                   (u'\xfb', 'u'), (u'\xf9', 'u'),
+                   (u'\xdb', 'U'), (u'\xd9', 'U'),
+                   (u'\xee', 'i'), (u'\xef', 'i'),
+                   (u'\xce', 'I'), (u'\xcf', 'I'),
+                   (u'\xe7', 'c'), (u'\xc7', 'C'))
+        for special, normalized in mapping:
+            self.assertEqual(normalized,
+                             self.normalizer.normalize_name(special))
+
+    def test_special_character_mapping(self):
+        mapping = ((u'&', u'+'),)
+        for special, normalized in mapping:
+            self.assertEqual(normalized,
+                             self.normalizer.normalize_name(special))
+
+    def test_extension_mapping(self):
+        mapping = ((u'tiff', u'tif'), (u'jpeg', u'jpg'))
+        for original, mapped in mapping:
+            self.assertEqual(mapped,
+                             self.normalizer.normalize_extension(original))
+
+    def test_unmapped_extensions_remain_unchanged(self):
+        extension_list = [u'docx', u'doc', u'txt', u'png', u'xls', u'xlsx', u'ppt', u'pptx']
+        for extension in extension_list:
+            self.assertEqual(extension,
+                             self.normalizer.normalize_extension(extension))
+
+    def test_split_filename_extension(self):
+        self.assertEqual((u'filename', u'txt'),
+                         self.normalizer.split_filename_extension(u'filename.txt'))
+        self.assertEqual((u'filename', u'jpeg'),
+                         self.normalizer.split_filename_extension(u'filename.jpeg'))
+        self.assertEqual((u'my.filename', ''),
+                         self.normalizer.split_filename_extension(u'my.filename'))
+
+    def test_filename_normalization(self):
+        self.assertEqual(u'Uebersicht.txt', self.normalizer.normalize(u'\xdcbersicht.txt'))
+        self.assertEqual(u'Uebersicht.txt', self.normalizer.normalize(u'\xdcbersicht', extension=u'txt'))
+        self.assertEqual(u'Filename.tif', self.normalizer.normalize(u'Filename.tiff'))
+        self.assertEqual(u'Filename.tif', self.normalizer.normalize(u'Filename', extension=u'tiff'))
+
+    def test_leading_and_trailing_whitespaces_are_removed(self):
+        self.assertEqual("filename.txt", self.normalizer.normalize("  filename  .txt"))
+        self.assertEqual("filename.txt", self.normalizer.normalize("[filename].txt"))
+        self.assertEqual("filename.txt", self.normalizer.normalize("[filename]", extension="txt"))

--- a/opengever/bumblebee/tests/test_callback.py
+++ b/opengever/bumblebee/tests/test_callback.py
@@ -31,7 +31,7 @@ class TestStoreArchivalFile(FunctionalTestCase):
             view()
 
         archival_file = IDocumentMetadata(self.document).archival_file
-        self.assertEquals('uberprufung-xy.pdf', archival_file.filename)
+        self.assertEquals('Ueberpruefung XY.pdf', archival_file.filename)
         self.assertTrue(isinstance(archival_file, NamedBlobFile))
         self.assertEquals('application/pdf', archival_file.contentType)
         self.assertEquals('Test String', archival_file.data)

--- a/opengever/bumblebee/tests/test_document_adapter.py
+++ b/opengever/bumblebee/tests/test_document_adapter.py
@@ -38,5 +38,5 @@ class TestMailDocumentAdapter(FunctionalTestCase):
 
         bumblebee_document = IBumblebeeDocument(mail_with_original_message)
         self.assertEqual(
-            'no-subject.eml',
+            'No Subject.eml',
             bumblebee_document.get_primary_field().filename)

--- a/opengever/bumblebee/tests/test_overlay_adapter_document.py
+++ b/opengever/bumblebee/tests/test_overlay_adapter_document.py
@@ -62,7 +62,7 @@ class TestGetOpenAsPdfLink(FunctionalTestCase):
 
         self.assertEqual(
             'http://nohost/plone/dossier-1/document-1/'
-            'bumblebee-open-pdf?filename=testdokumant.pdf',
+            'bumblebee-open-pdf?filename=Testdokumaent.pdf',
             adapter.get_open_as_pdf_url())
 
     def test_returns_none_if_no_mimetype_is_available(self):
@@ -99,8 +99,8 @@ class TestGetPdfFilename(FunctionalTestCase):
 
         adapter = getMultiAdapter((document, self.request), IBumblebeeOverlay)
 
-        self.assertEqual('testdokumant.docx', document.file.filename)
-        self.assertEqual('testdokumant.pdf', adapter._get_pdf_filename())
+        self.assertEqual('Testdokumaent.docx', document.file.filename)
+        self.assertEqual('Testdokumaent.pdf', adapter._get_pdf_filename())
 
     def test_returns_none_if_no_file_is_given(self):
         dossier = create(Builder('dossier'))

--- a/opengever/bumblebee/tests/test_overlay_adapter_mail.py
+++ b/opengever/bumblebee/tests/test_overlay_adapter_mail.py
@@ -67,7 +67,7 @@ class TestGetOpenAsPdfLink(IntegrationTestCase):
         expected_url = (
             'http://nohost/plone/ordnungssystem/fuhrung'
             '/vertrage-und-vereinbarungen/dossier-1/document-28'
-            '/bumblebee-open-pdf?filename=die-burgschaft.pdf'
+            '/bumblebee-open-pdf?filename=Die%20Buergschaft.pdf'
             )
 
         self.assertEqual(expected_url, adapter.get_open_as_pdf_url())

--- a/opengever/bundle/tests/test_section_fileloader.py
+++ b/opengever/bundle/tests/test_section_fileloader.py
@@ -54,7 +54,7 @@ class TestFileLoader(FunctionalTestCase):
 
         self.assertEqual('Lorem Ipsum\n', doc.file.data)
         self.assertEqual('application/pdf', doc.file.contentType)
-        self.assertEqual('foo-bar.pdf', doc.file.filename)
+        self.assertEqual('Foo Bar.pdf', doc.file.filename)
 
     def test_syncs_title_from_filename_if_untitled(self):
         doc = create(Builder('document').titled(None))

--- a/opengever/bundle/tests/test_section_fileloader.py
+++ b/opengever/bundle/tests/test_section_fileloader.py
@@ -123,7 +123,7 @@ class TestFileLoader(FunctionalTestCase):
         self.assertEqual(u'Lorem Ipsum', mail.title)
         self.assertEqual(920, len(mail.message.data))
         self.assertEqual('message/rfc822', mail.message.contentType)
-        self.assertEqual('lorem-ipsum.eml', mail.message.filename)
+        self.assertEqual('Lorem Ipsum.eml', mail.message.filename)
         self.assertEqual(True, mail.digitally_available)
 
     def test_handles_msg_mails(self):

--- a/opengever/core/upgrades/20180713145257_update_file_names/upgrade.py
+++ b/opengever/core/upgrades/20180713145257_update_file_names/upgrade.py
@@ -1,0 +1,18 @@
+from ftw.upgrade import UpgradeStep
+from opengever.document.subscribers import sync_title_and_filename_handler
+
+
+class UpdateFileNames(UpgradeStep):
+    """Update file names for documents and E-mails
+    """
+
+    def __call__(self):
+        # Sync document filenames with title
+        for obj in self.objects({'portal_type': 'opengever.document.document'},
+                                'Synchronize document filenames with title'):
+            sync_title_and_filename_handler(obj, None)
+
+        # Sync E-mail filenames with title
+        for obj in self.objects({'portal_type': 'ftw.mail.mail'},
+                                'Synchronize E-mail filenames with title'):
+            obj.update_filename()

--- a/opengever/disposition/tests/test_model.py
+++ b/opengever/disposition/tests/test_model.py
@@ -337,14 +337,14 @@ class TestFolderAndFileModel(FunctionalTestCase):
         subdossier_model = dossier_model_a.folders[0]
         self.assertEquals(1, len(subdossier_model.files))
         file_model_a = subdossier_model.files[0]
-        self.assertEquals(u'testdokumant.doc', file_model_a.filename)
+        self.assertEquals(u'Testdokumaent.doc', file_model_a.filename)
         self.assertEquals(document_a.file._blob.committed(), file_model_a.filepath)
 
         # dossier b
         self.assertEquals([], dossier_model_b.folders)
         self.assertEquals(1, len(dossier_model_b.files))
         file_model_b = dossier_model_b.files[0]
-        self.assertEquals(u'testdokumant.doc', file_model_b.filename)
+        self.assertEquals(u'Testdokumaent.doc', file_model_b.filename)
         self.assertEquals(document_b.file._blob.committed(), file_model_b.filepath)
 
 
@@ -369,7 +369,7 @@ class TestFileModel(FunctionalTestCase):
         document = create(Builder('document').with_dummy_content())
         model = File(self.toc, Document(document))
 
-        self.assertEquals(u'testdokumant.doc', model.filename)
+        self.assertEquals(u'Testdokumaent.doc', model.filename)
         self.assertEquals(document.file._blob.committed(), model.filepath)
 
     def test_named_next_file_number_prefixed_with_p(self):

--- a/opengever/document/subscribers.py
+++ b/opengever/document/subscribers.py
@@ -1,6 +1,6 @@
 from opengever.document import _
 from opengever.ogds.base.utils import ogds_service
-from plone.i18n.normalizer.interfaces import IIDNormalizer
+from plone.i18n.normalizer.interfaces import IFileNameNormalizer
 from zope.component import getUtility
 from zope.globalrequest import getRequest
 from zope.i18n import translate
@@ -33,7 +33,8 @@ def sync_title_and_filename_handler(doc, event):
     - If there is a title and a file, use the normalized title as filename
 
     """
-    normalizer = getUtility(IIDNormalizer)
+    normalizer = getUtility(IFileNameNormalizer, name='gever_filename_normalizer')
+
     if not doc.file:
         return
 
@@ -41,12 +42,10 @@ def sync_title_and_filename_handler(doc, event):
     if not doc.title:
         # use the filename without extension as title
         doc.title = basename
-        doc.file.filename = u''.join(
-            [normalizer.normalize(basename), ext])
+        doc.file.filename = normalizer.normalize(basename, extension=ext)
     elif doc.title:
         # use the title as filename
-        doc.file.filename = u''.join(
-            [normalizer.normalize(doc.title), ext])
+        doc.file.filename = normalizer.normalize(doc.title, extension=ext)
 
 
 def set_copyname(doc, event):

--- a/opengever/document/tests/test_archival_file.py
+++ b/opengever/document/tests/test_archival_file.py
@@ -43,7 +43,7 @@ class TestArchivalFile(FunctionalTestCase):
 
     def test_file_name_is_file_filename_with_pdf_extension(self):
         self.assertEquals(
-            'uberprufung-xy.pdf',
+            'Ueberpruefung XY.pdf',
             ArchivalFileConverter(self.document).get_file_name())
 
     def test_trigger_conversion_sets_state_to_converting(self):

--- a/opengever/document/tests/test_checkout.py
+++ b/opengever/document/tests/test_checkout.py
@@ -820,7 +820,7 @@ class TestCheckinCheckoutManagerAPI(FunctionalTestCase):
         # document isn't checked out and the old object is in the history
         self.assertIsNone(manager.get_checked_out_by())
 
-        self.assertEquals(u'document1.doc',
+        self.assertEquals(u'Document1.doc',
                           pr.retrieve(self.doc1, 0).object.file.filename)
         self.assertEquals(u'blubb.txt', self.doc1.file.filename)
 

--- a/opengever/document/tests/test_document.py
+++ b/opengever/document/tests/test_document.py
@@ -85,7 +85,7 @@ class TestDocument(FunctionalTestCase):
         document = create(Builder('document')
                           .titled('Foo')
                           .attach_file_containing('foo', name=u'foo.txt'))
-        self.assertEqual(u'foo.txt', document.get_filename())
+        self.assertEqual(u'Foo.txt', document.get_filename())
 
     def test_filename_getter_return_none_if_no_file_is_available(self):
         document = create(Builder('document'))

--- a/opengever/document/tests/test_forms.py
+++ b/opengever/document/tests/test_forms.py
@@ -33,7 +33,7 @@ class TestDocumentIntegration(FunctionalTestCase):
         browser.login().open(self.document, view='edit')
 
         self.assertEqual(
-            u'document1.doc \u2014 1 KB',
+            u'Document1.doc \u2014 1 KB',
             browser.css('.named-file-widget.namedblobfile-field').first.text)
 
         # edit should not be posssible

--- a/opengever/document/tests/test_quickupload.py
+++ b/opengever/document/tests/test_quickupload.py
@@ -43,5 +43,5 @@ class TestDocumentQuickupload(FunctionalTestCase):
                .within(self.document)
                .with_data('NEW DATA', filename='test.pdf'))
 
-        self.assertEquals('anfrage-herr-meier.pdf',
+        self.assertEquals('Anfrage Herr Meier.pdf',
                           self.document.file.filename)

--- a/opengever/document/tests/test_title_filename_syncer.py
+++ b/opengever/document/tests/test_title_filename_syncer.py
@@ -3,23 +3,26 @@ from ftw.builder import create
 from opengever.testing import FunctionalTestCase
 from zope.event import notify
 from zope.lifecycleevent import ObjectModifiedEvent
+import os
 
 
 class TestTitleFilenameSyncer(FunctionalTestCase):
+
+    max_filename_length = 100
 
     def test_infer_title_from_filename(self):
         document = create(Builder("document")
                           .without_default_title()
                           .attach_file_containing(u"blup", name=u'T\xf6st.txt'))
-        self.assertEqual(document.title, u'T\xf6st')
-        self.assertEqual(document.file.filename, u'tost.txt')
+        self.assertEqual(u'T\xf6st', document.title)
+        self.assertEqual(u'Toest.txt', document.file.filename)
 
     def test_infer_filename_from_title(self):
         document = create(Builder("document")
                           .titled("My Title") \
                           .attach_file_containing(u"blup", name=u"wrong.txt"))
-        self.assertEqual(document.title, u'My Title')
-        self.assertEqual(document.file.filename, u'my-title.txt')
+        self.assertEqual(u'My Title', document.title)
+        self.assertEqual(u'My Title.txt', document.file.filename)
 
     def test_filename_is_unicode(self):
         document = create(Builder("document")
@@ -28,4 +31,62 @@ class TestTitleFilenameSyncer(FunctionalTestCase):
         document.title = 'Ohh'
         notify(ObjectModifiedEvent(document))
 
-        self.assertEqual(document.file.filename, u'ohh.txt')
+        self.assertEqual(u'Ohh.txt', document.file.filename)
+
+    def test_filename_maximum_length_from_title(self):
+        title = u''.join('a' for i in range(2*self.max_filename_length))
+        expected_filename = title[:self.max_filename_length]+'.txt'
+
+        document = create(Builder("document")
+                          .titled(title)
+                          .attach_file_containing(u"12", name=u"hmm.txt"))
+        self.assertEqual(title, document.title)
+        self.assertEqual(expected_filename, document.file.filename)
+
+    def test_filename_maximum_length_from_filename(self):
+        filename = u''.join('a' for i in range(2*self.max_filename_length))+'.txt'
+        expected_title = os.path.splitext(filename)[0]
+        expected_filename = expected_title[:self.max_filename_length]+'.txt'
+
+        document = create(Builder("document")
+                          .without_default_title()
+                          .attach_file_containing(u"12", name=filename))
+        self.assertEqual(expected_title, document.title)
+        self.assertEqual(expected_filename, document.file.filename)
+
+    def test_filename_maximum_length_respected_by_umlaut_transform(self):
+        title = u''.join(u'\xe4' for i in range(2*self.max_filename_length))
+        expected_filename = title.replace(u'\xe4', 'ae')[:self.max_filename_length]+'.txt'
+
+        document = create(Builder("document")
+                          .titled(title)
+                          .attach_file_containing(u"12", name=u"hmm.txt"))
+        self.assertEqual(title, document.title)
+        self.assertEqual(expected_filename, document.file.filename)
+
+    def test_filename_transform_from_title(self):
+        """ Test that the filename transform preserves spaces and case,
+        transforms umlauts and replaces dangerous special characters.
+        """
+        title = u'\xe4\xd6\xe9 / \\ . *'
+        expected_filename = "aeOee ..txt"
+        document = create(Builder("document")
+                          .titled(title)
+                          .attach_file_containing(u"12", name=u"hmm.txt"))
+
+        self.assertEqual(title, document.title)
+        self.assertEqual(expected_filename, document.file.filename)
+
+    def test_filename_transform_from_filename(self):
+        """ Test that the filename transform preserves spaces and case,
+        transforms umlauts and replaces dangerous special characters.
+        """
+        filename = u'\xe4\xd6\xe9 / \\ . *.txt'
+        expected_title = os.path.splitext(filename)[0]
+        expected_filename = "aeOee ..txt"
+        document = create(Builder("document")
+                          .without_default_title()
+                          .attach_file_containing(u"12", name=filename))
+
+        self.assertEqual(expected_title, document.title)
+        self.assertEqual(expected_filename, document.file.filename)

--- a/opengever/dossier/tests/test_resolve.py
+++ b/opengever/dossier/tests/test_resolve.py
@@ -144,7 +144,7 @@ class TestResolveJobs(IntegrationTestCase):
         main_journal_pdf, = main_children['added']
         self.assertEquals(u'Journal of dossier An empty dossier, Apr 25, 2016 12:00 AM',
                           main_journal_pdf.title)
-        self.assertEquals(u'journal-of-dossier-an-empty-dossier-apr-25-2016-12.pdf',
+        self.assertEquals(u'Journal of dossier An empty dossier, Apr 25, 2016 12 00 AM.pdf',
                           main_journal_pdf.file.filename)
         self.assertEquals(u'application/pdf',
                           main_journal_pdf.file.contentType)
@@ -154,7 +154,7 @@ class TestResolveJobs(IntegrationTestCase):
         sub_journal_pdf, = sub_children['added']
         self.assertEquals(u'Journal of dossier Sub, Apr 25, 2016 12:00 AM',
                           sub_journal_pdf.title)
-        self.assertEquals(u'journal-of-dossier-sub-apr-25-2016-12-00-am.pdf',
+        self.assertEquals(u'Journal of dossier Sub, Apr 25, 2016 12 00 AM.pdf',
                           sub_journal_pdf.file.filename)
         self.assertEquals(u'application/pdf',
                           sub_journal_pdf.file.contentType)

--- a/opengever/dossier/tests/test_templatefolder.py
+++ b/opengever/dossier/tests/test_templatefolder.py
@@ -143,7 +143,7 @@ class TestDocumentWithTemplateFormPlain(IntegrationTestCase):
                 }).save()
 
         document = self.dossier.listFolderContents()[-1]
-        self.assertEquals(u'test-docx.docx', document.file.filename)
+        self.assertEquals(u'Test Docx.docx', document.file.filename)
 
         with TemporaryDocFile(document.file) as tmpfile:
             self.assertItemsEqual([], read_properties(tmpfile.path))
@@ -193,7 +193,7 @@ class TestDocumentWithTemplateFormWithDocProperties(IntegrationTestCase):
                 }).save()
 
         document = self.dossier.listFolderContents()[-1]
-        self.assertEquals(u'test-docx.docx', document.file.filename)
+        self.assertEquals(u'Test Docx.docx', document.file.filename)
 
         expected_doc_properties = {
             'Document.ReferenceNumber': 'Client1 1.1 / 1 / 34',
@@ -251,7 +251,7 @@ class TestDocumentWithTemplateFormWithDocProperties(IntegrationTestCase):
                 }).save()
 
         document = self.dossier.listFolderContents()[-1]
-        self.assertEquals(u'test-docx.docx', document.file.filename)
+        self.assertEquals(u'Test Docx.docx', document.file.filename)
 
         expected_doc_properties = {
             'Document.ReferenceNumber': 'Client1 1.1 / 1 / 34',
@@ -415,7 +415,7 @@ class TestDocumentWithTemplateFormWithContacts(FunctionalTestCase):
                 }).save()
 
         document = self.dossier.listFolderContents()[0]
-        self.assertEquals(u'test-docx.docx', document.file.filename)
+        self.assertEquals(u'Test Docx.docx', document.file.filename)
 
         expected_person_properties = {
             'ogg.recipient.contact.title': u'M\xfcller Peter',
@@ -502,7 +502,7 @@ class TestDocumentWithTemplateFormWithContacts(FunctionalTestCase):
                 }).save()
 
         document = self.dossier.listFolderContents()[0]
-        self.assertEquals(u'test-docx.docx', document.file.filename)
+        self.assertEquals(u'Test Docx.docx', document.file.filename)
         expected_org_role_properties = {
             'ogg.recipient.contact.title': u'M\xfcller Peter',
             'ogg.recipient.person.firstname': 'Peter',
@@ -551,7 +551,7 @@ class TestDocumentWithTemplateFormWithContacts(FunctionalTestCase):
                 }).save()
 
         document = self.dossier.listFolderContents()[0]
-        self.assertEquals(u'test-docx.docx', document.file.filename)
+        self.assertEquals(u'Test Docx.docx', document.file.filename)
 
         expected_org_role_properties = {
             'ogg.recipient.contact.title': u'M\xfcller Peter',

--- a/opengever/ech0147/tests/test_model.py
+++ b/opengever/ech0147/tests/test_model.py
@@ -71,7 +71,7 @@ class TestMessageModel(IntegrationTestCase):
         self.assertEqual(
             [u'files/dossier-1/dossier-2/Uebersicht der Vertraege von 2016.xlsx',
              u'files/dossier-1/Vertraegsentwurf.docx',
-             u'files/dossier-1/die-burgschaft.eml',
+             u'files/dossier-1/Die Buergschaft.eml',
              u'files/dossier-1/testm\xe4il.msg',
              u'files/Vertraegsentwurf.docx'],
             zipfile.arcnames)

--- a/opengever/ech0147/tests/test_model.py
+++ b/opengever/ech0147/tests/test_model.py
@@ -69,11 +69,11 @@ class TestMessageModel(IntegrationTestCase):
         msg.add_to_zip(zipfile)
 
         self.assertEqual(
-            [u'files/dossier-1/dossier-2/ubersicht-der-vertrage-von-2016.xlsx',
-             u'files/dossier-1/vertragsentwurf.docx',
+            [u'files/dossier-1/dossier-2/Uebersicht der Vertraege von 2016.xlsx',
+             u'files/dossier-1/Vertraegsentwurf.docx',
              u'files/dossier-1/die-burgschaft.eml',
              u'files/dossier-1/testm\xe4il.msg',
-             u'files/vertragsentwurf.docx'],
+             u'files/Vertraegsentwurf.docx'],
             zipfile.arcnames)
 
     def test_message_with_subjects(self):

--- a/opengever/mail/mail.py
+++ b/opengever/mail/mail.py
@@ -22,7 +22,7 @@ from opengever.ogds.models.user import User
 from plone.app.dexterity.behaviors import metadata
 from plone.autoform import directives as form
 from plone.autoform.interfaces import IFormFieldProvider
-from plone.i18n.normalizer.interfaces import IIDNormalizer
+from plone.i18n.normalizer.interfaces import IFileNameNormalizer
 from plone.namedfile import field
 from plone.namedfile import NamedBlobFile
 from plone.supermodel import model
@@ -277,7 +277,7 @@ class OGMail(Mail, BaseDocumentMixin):
         if not isinstance(filename, unicode):
             filename = filename.decode('utf-8')
         # remove line breaks from the filename
-        filename = re.sub('\s{1,}', ' ', filename)
+        filename = re.sub(r'\s{1,}', ' ', filename)
 
         content_type = attachment.get_content_type()
         if content_type == 'message/rfc822':
@@ -323,8 +323,8 @@ class OGMail(Mail, BaseDocumentMixin):
         if not self.message:
             return
 
-        normalizer = getUtility(IIDNormalizer)
-        normalized_subject = normalizer.normalize(self.title)
+        normalizer = getUtility(IFileNameNormalizer, name='gever_filename_normalizer')
+        normalized_subject = normalizer.normalize_name(self.title)
         self.message.filename = u'{}.eml'.format(normalized_subject)
 
     def get_file(self):
@@ -398,9 +398,9 @@ def initalize_title(mail, event):
 # belongs.
 
 EMAILPATTERN = re.compile(
-    ("([a-z0-9!#$%&'*+\/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+\/=?^_`"
-     "{|}~-]+)*(@|\sat\s)(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?(\.|"
-     "\sdot\s))+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?)"))
+    (r"([a-z0-9!#$%&'*+\/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+\/=?^_`"
+     r"{|}~-]+)*(@|\sat\s)(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?(\.|"
+     r"\sdot\s))+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?)"))
 
 
 def extract_email(header_from):

--- a/opengever/mail/tests/test_mail_download_copy.py
+++ b/opengever/mail/tests/test_mail_download_copy.py
@@ -31,7 +31,7 @@ class TestMailDownloadCopy(FunctionalTestCase):
             'status': '200 Ok',
             'content-length': str(len(browser.contents)),
             'content-type': 'message/rfc822',
-            'content-disposition': 'attachment; filename="die-burgschaft.eml"',
+            'content-disposition': 'attachment; filename="Die Buergschaft.eml"',
             },
             browser.headers)
 

--- a/opengever/mail/tests/test_mail_overviewtab.py
+++ b/opengever/mail/tests/test_mail_overviewtab.py
@@ -33,7 +33,7 @@ class TestOverview(FunctionalTestCase):
                   ['Description', ''],
                   ['Foreign Reference', ''],
                   ['Message',
-                   u'mehrere-anhange.eml \u2014 32 KB '
+                   u'Mehrere Anhaenge.eml \u2014 32 KB '
                    u'Checkout and edit Download copy'],
                   ['Attachments',
                    'Inneres Testma?il ohne Attachments.eml 1 KB '

--- a/opengever/mail/tests/test_message_filename_initialized.py
+++ b/opengever/mail/tests/test_message_filename_initialized.py
@@ -11,8 +11,8 @@ class TestMessageFilenameInitialized(FunctionalTestCase):
 
     def test_message_filename_initialized_with_builder(self):
         mail = create(Builder("mail").with_message(MAIL_DATA))
-        self.assertEquals('die-burgschaft.eml', mail.get_filename())
-        self.assertEquals('die-burgschaft.eml', mail.message.filename)
+        self.assertEquals('Die Buergschaft.eml', mail.get_filename())
+        self.assertEquals('Die Buergschaft.eml', mail.message.filename)
 
     def test_filename_is_none_when_no_file_is_present(self):
         mail = create(Builder("mail"))
@@ -29,12 +29,12 @@ class TestMessageFilenameInitialized(FunctionalTestCase):
                          data=MAIL_DATA,
                          portal_type='ftw.mail.mail')
         mail = result['success']
-        self.assertEquals('die-burgschaft.eml', mail.message.filename)
+        self.assertEquals('Die Buergschaft.eml', mail.message.filename)
 
     def test_message_filename_initialzed_with_inboud_mail(self):
         dossier = create(Builder("dossier"))
         mail = inbound.createMailInContainer(dossier, MAIL_DATA)
-        self.assertEquals('die-burgschaft.eml', mail.message.filename)
+        self.assertEquals('Die Buergschaft.eml', mail.message.filename)
 
     @browsing
     def test_message_filename_initialized_on_addview(self, browser):
@@ -45,4 +45,4 @@ class TestMessageFilenameInitialized(FunctionalTestCase):
         }).submit()
 
         mail = browser.context
-        self.assertEquals('die-burgschaft.eml', mail.message.filename)
+        self.assertEquals('Die Buergschaft.eml', mail.message.filename)

--- a/opengever/mail/tests/test_ogmail.py
+++ b/opengever/mail/tests/test_ogmail.py
@@ -118,7 +118,7 @@ class TestOGMailAddition(FunctionalTestCase):
         mail = create(Builder('mail').with_dummy_message())
         mail.title = u'Foo B\xe4r'
         mail.update_filename()
-        self.assertEqual(u'foo-bar.eml', mail.message.filename)
+        self.assertEqual(u'Foo Baer.eml', mail.message.filename)
 
     def test_get_attachments_returns_correct_descriptor_dict(self):
         mail = create(Builder('mail')

--- a/opengever/mail/tests/test_senddocument.py
+++ b/opengever/mail/tests/test_senddocument.py
@@ -136,7 +136,7 @@ f\xc3\xbcr Ernst Franz\r\n\r\nBesten Dank im Voraus"""
         mails = [create(Builder("mail").within(dossier).with_dummy_message()), ]
 
         mail = self.send_documents(dossier, mails)
-        self.assert_attachment(mail, 'no-subject.eml', 'message/rfc822')
+        self.assert_attachment(mail, 'No Subject.eml', 'message/rfc822')
 
         attachment = mail.get_payload()[1].get_payload()[0]
         self.assertIn(

--- a/opengever/mail/tests/test_subscribers.py
+++ b/opengever/mail/tests/test_subscribers.py
@@ -22,4 +22,4 @@ class TestSubscribers(FunctionalTestCase):
         browser.login().open(mail, view='edit')
         browser.fill({'Title': 'My new mail Title'}).submit()
 
-        self.assertEqual(u'my-new-mail-title.eml', mail.message.filename)
+        self.assertEqual(u'My new mail Title.eml', mail.message.filename)

--- a/opengever/mail/tests/test_zip_export.py
+++ b/opengever/mail/tests/test_zip_export.py
@@ -10,7 +10,7 @@ class TestMailZipExport(IntegrationTestCase):
                                          interface=IZipRepresentation)
 
         path, file_ = tuple(representation.get_files())[0]
-        self.assertEquals(u'/die-burgschaft.eml', path)
+        self.assertEquals(u'/Die Buergschaft.eml', path)
         self.assertEquals(self.mail_eml.message.open().read(),
                           file_.read())
 

--- a/opengever/meeting/browser/sablontemplate.py
+++ b/opengever/meeting/browser/sablontemplate.py
@@ -16,7 +16,7 @@ SAMPLE_MEETING_DATA = {
         'decision_number': 1,
         'attachments': [{
             "title": u'Beweisaufn\xe4hme',
-            "filename": u"beweisaufnahme.txt"
+            "filename": u"Beweisaufnaehme.txt"
             }, {
             "title": u"L\xf6rem",
             "filename": u"lorem.eml"

--- a/opengever/meeting/browser/sablontemplate.py
+++ b/opengever/meeting/browser/sablontemplate.py
@@ -19,7 +19,7 @@ SAMPLE_MEETING_DATA = {
             "filename": u"Beweisaufnaehme.txt"
             }, {
             "title": u"L\xf6rem",
-            "filename": u"lorem.eml"
+            "filename": u"Loerem.eml"
             }, {
             "title": "Strafbefehl"
             }]

--- a/opengever/meeting/model/meeting.py
+++ b/opengever/meeting/model/meeting.py
@@ -25,7 +25,7 @@ from opengever.ogds.models.types import UnicodeCoercingText
 from opengever.ogds.models.user import User
 from operator import methodcaller
 from plone import api
-from plone.i18n.normalizer.interfaces import IIDNormalizer
+from plone.i18n.normalizer.interfaces import IFileNameNormalizer
 from Products.CMFPlone.utils import safe_unicode
 from sqlalchemy import Column
 from sqlalchemy import ForeignKey
@@ -295,7 +295,7 @@ class Meeting(Base, SQLFormSupport):
             translate(prefix, context=getRequest()), self.get_title())
 
     def _get_filename(self, prefix):
-        normalizer = getUtility(IIDNormalizer)
+        normalizer = getUtility(IFileNameNormalizer, name='gever_filename_normalizer')
         return u"{}-{}.docx".format(
             translate(prefix, context=getRequest()),
             normalizer.normalize(self.get_title()))

--- a/opengever/meeting/tests/test_agendaitem_list.py
+++ b/opengever/meeting/tests/test_agendaitem_list.py
@@ -60,7 +60,7 @@ class TestAgendaItemList(IntegrationTestCase):
 
         self.assertEqual(200, browser.status_code)
         self.assertDictContainsSubset(
-            {'content-disposition': 'attachment; filename="agendaitem-list-9-sitzung-der.docx"',
+            {'content-disposition': 'attachment; filename="Agendaitem list-9. Sitzung der Rechnungspruefungskommission.docx"',
              'content-type': MIME_DOCX},
             browser.headers)
 
@@ -74,7 +74,7 @@ class TestAgendaItemList(IntegrationTestCase):
             browser.open(self.meeting, view='agenda_item_list/as_json')
 
         expected_agenda_items = [
-            {u'attachments': [{u'filename': u'vertragsentwurf.docx',
+            {u'attachments': [{u'filename': u'Vertraegsentwurf.docx',
                               u'title': u'Vertr\xe4gsentwurf'}],
              u'decision_number': None,
              u'dossier_reference_number': u'Client1 1.1 / 1',

--- a/opengever/meeting/tests/test_agendaitem_proposal.py
+++ b/opengever/meeting/tests/test_agendaitem_proposal.py
@@ -283,9 +283,10 @@ class TestProposalAgendaItem(IntegrationTestCase):
         excerpt_document, = children['added']
         self.assertEquals('Excerption \xc3\x84nderungen',
                           excerpt_document.Title())
-        self.assertEquals('Excerption \xc3\x84nderungen', excerpt_document.Title())
         self.assertIsInstance(excerpt_document.title, unicode)
         self.assertIsNotNone(excerpt_document.file.data)
+        self.assertEquals(u'Excerption Aenderungen.docx',
+                          excerpt_document.file.filename)
 
     @browsing
     def test_cannot_create_excerpt_when_meeting_closed(self, browser):

--- a/opengever/meeting/tests/test_download_sablon_template.py
+++ b/opengever/meeting/tests/test_download_sablon_template.py
@@ -22,6 +22,6 @@ class TestSablonTemplateDownloadView(FunctionalTestCase):
         browser.find('Download copy').click()
         browser.find('label_download').click()
 
-        self.assertEqual('attachment; filename="tost.txt"',
+        self.assertEqual('attachment; filename="toest.txt"',
                          browser.headers['content-disposition'])
         self.assertEqual("blub blub", browser.contents)

--- a/opengever/meeting/tests/test_proposal.py
+++ b/opengever/meeting/tests/test_proposal.py
@@ -792,7 +792,7 @@ class TestProposal(IntegrationTestCase):
         excerpt_document, = children['added']
         self.assertEquals('Excerpt \xc3\x84nderungen',
                           excerpt_document.Title())
-        self.assertEquals(u'excerpt-anderungen.docx',
+        self.assertEquals(u'Excerpt Aenderungen.docx',
                           excerpt_document.file.filename)
         self.assertEquals(MIME_DOCX, excerpt_document.file.contentType)
         self.assertIsNotNone(excerpt_document.file.data)

--- a/opengever/meeting/tests/test_proposal_template.py
+++ b/opengever/meeting/tests/test_proposal_template.py
@@ -24,7 +24,7 @@ class TestProposalTemplate(IntegrationTestCase):
         baugesuch = self.templates.objectValues()[-1]
         browser.open(baugesuch, view='tabbedview_view-overview')
         self.assertDictContainsSubset({'Title': 'Baugesuch'}, dict(browser.css('.documentMetadata table').first.lists()))
-        self.assertEquals('baugesuch.docx', browser.css('.documentMetadata span.filename').first.text)
+        self.assertEquals('Baugesuch.docx', browser.css('.documentMetadata span.filename').first.text)
 
     @browsing
     def test_uploading_non_docx_files_is_not_allowed(self, browser):

--- a/opengever/meeting/tests/test_protocol.py
+++ b/opengever/meeting/tests/test_protocol.py
@@ -26,6 +26,8 @@ class TestProtocol(IntegrationTestCase):
             u'Rechnungspr\xfcfungskommission has been generated '
             u'successfully.')
         self.assertIsNotNone(meeting.protocol_document)
+        self.assertEqual(u'Protocol-9. Sitzung der Rechnungspruefungskommission.docx',
+                         meeting.protocol_document.resolve_document().file.filename)
         self.assertEqual(0, meeting.protocol_document.generated_version)
 
         # update already generated protocol

--- a/opengever/task/tests/test_overview.py
+++ b/opengever/task/tests/test_overview.py
@@ -85,7 +85,7 @@ class TestTaskOverview(IntegrationTestCase):
 
         self.assertEquals(
             [u'Task - Rechtliche Grundlagen in Vertragsentwurf \xdcberpr\xfcfen/',
-             'feedback-zum-vertragsentwurf.docx'],
+             'Feedback zum Vertragsentwurf.docx'],
             zipfile.namelist())
 
         data = {'zip_selected:method': 1,

--- a/opengever/task/tests/test_zipexport.py
+++ b/opengever/task/tests/test_zipexport.py
@@ -16,7 +16,7 @@ class TestTaskZipExport(IntegrationTestCase):
             ]
         expected_paths = [
             u'/Aufgabe - Rechtliche Grundlagen in Vertragsentwurf \xdcberpr\xfcfen',
-            u'/feedback-zum-vertragsentwurf.docx',
+            u'/Feedback zum Vertragsentwurf.docx',
             ]
         self.assertEqual(paths, expected_paths)
 
@@ -30,6 +30,6 @@ class TestTaskZipExport(IntegrationTestCase):
             ]
         expected_paths = [
             u'/T\xe2che - Rechtliche Grundlagen in Vertragsentwurf \xdcberpr\xfcfen',
-            u'/feedback-zum-vertragsentwurf.docx',
+            u'/Feedback zum Vertragsentwurf.docx',
             ]
         self.assertEqual(paths, expected_paths)


### PR DESCRIPTION
In order to have filenames as close as possible to document titles, we change the filename normalisation method. We now notably allow:
* white spaces
* capital letters
* We use a German locale to transform umlauts, e.g. "ü -> ue"
* Maximal filename length is extended to 100 characters

resolves #4217