### PR TITLE
Port archival file form tests to integration layer

### DIFF
--- a/opengever/base/browser/edit_public_trial.py
+++ b/opengever/base/browser/edit_public_trial.py
@@ -4,6 +4,7 @@ from opengever.document.behaviors import IBaseDocument
 from opengever.dossier.base import DOSSIER_STATES_OPEN
 from opengever.dossier.templatefolder.interfaces import ITemplateFolder
 from opengever.dossier.utils import find_parent_dossier
+from opengever.inbox.inbox import IInbox
 from plone.dexterity.browser.edit import DefaultEditForm
 from Products.CMFCore.utils import getToolByName
 from z3c.form.field import Fields
@@ -15,6 +16,7 @@ def can_access_public_trial_edit_form(user, content):
     open dossier state. And the containing dossier is
      - not a templatefolder
      - not inactive
+     - not an inbox
     """
 
     assert IBaseDocument.providedBy(
@@ -25,7 +27,8 @@ def can_access_public_trial_edit_form(user, content):
 
     if ITemplateFolder.providedBy(dossier):
         return False
-
+    if IInbox.providedBy(dossier):
+        return False
     if wftool.getInfoFor(dossier, 'review_state') == 'dossier-state-inactive':
         return False
 

--- a/opengever/base/tests/test_utils.py
+++ b/opengever/base/tests/test_utils.py
@@ -85,7 +85,13 @@ class TestFindParentDossier(FunctionalTestCase):
 
         self.assertEquals(dossier, find_parent_dossier(document))
 
-    def test_find_parent_on_nested_dossierts(self):
+    def test_find_parent_inbox(self):
+        inbox = create(Builder('inbox'))
+        document = create(Builder('document').within(inbox))
+
+        self.assertEquals(inbox, find_parent_dossier(document))
+
+    def test_find_parent_on_nested_dossiers(self):
         dossier = create(Builder('dossier'))
         subdossier = create(Builder('dossier').within(dossier))
         document = create(Builder('document').within(subdossier))

--- a/opengever/dossier/utils.py
+++ b/opengever/dossier/utils.py
@@ -19,13 +19,13 @@ def get_containing_dossier(obj):
 
 
 def find_parent_dossier(content):
-    """Returns the first parent dossier relative to the current context.
+    """Returns the first parent dossier (or inbox) relative to the current context.
     """
 
     if IPloneSiteRoot.providedBy(content):
         raise ValueError('Site root passed as argument.')
 
-    while content and not IDossierMarker.providedBy(content):
+    while content and not (IDossierMarker.providedBy(content) or IInbox.providedBy(content)):
         content = aq_parent(aq_inner(content))
         if IPloneSiteRoot.providedBy(content):
             raise ValueError('Site root reached while searching '


### PR DESCRIPTION
We make use of the new elements in the fixture to port the archival file form tests to the integration layer. This is part of issue #3857.

Note that:
1. There was a harmless bug in the `can_access_archival_file_form` function. While iterating over the `DOSSIER_STATES_OPEN` to check whether the user has `Modify portal content` rights on any of these states, we would return whether the user has these rights on the first of the states in the list.
2. The test `test_parent_of_content_needs_to_be_a_dossier` did not actually test what was advertised in the title, instead the second part
    ```
    with self.assertRaises(AssertionError):
        can_access_archival_file_form(user, self.document.aq_parent)
    ``` 
    actually tests that the form cannot be accessed for an object that is not `documentish`. This is already tested in a further test `test_not_accessible_on_not_basedocumentish_objects`. The new test fails instead with a `ValueError` which is raised when reaching the `PloneSiteRoot` in `find_parent_dossier`: https://github.com/4teamwork/opengever.core/blob/master/opengever/dossier/utils.py#L31