### PR TITLE
Speedup OfficeConnector tests by better using the fixture

### DIFF
--- a/opengever/officeconnector/tests/test_api_dossier_attach.py
+++ b/opengever/officeconnector/tests/test_api_dossier_attach.py
@@ -87,20 +87,18 @@ class TestOfficeconnectorDossierAPIWithAttach(OCIntegrationTestCase):
     @browsing
     def test_attach_to_email_resolved_without_file(self, browser):
         self.login(self.regular_user, browser)
-        self.set_workflow_state('dossier-state-resolved', self.dossier)
-        self.document.file = None
+        self.archive_document.file = None
 
         with browser.expect_http_error(404):
-            oc_url = self.fetch_document_attach_oc_url(browser, self.document)
+            oc_url = self.fetch_document_attach_oc_url(browser, self.archive_document)
 
             self.assertIsNone(oc_url)
 
     @browsing
     def test_attach_to_email_resolved_with_file(self, browser):
         self.login(self.regular_user, browser)
-        self.set_workflow_state('dossier-state-resolved', self.dossier)
 
-        oc_url = self.fetch_document_attach_oc_url(browser, self.document)
+        oc_url = self.fetch_document_attach_oc_url(browser, self.archive_document)
 
         self.assertIsNotNone(oc_url)
         self.assertEquals(200, browser.status_code)
@@ -108,13 +106,13 @@ class TestOfficeconnectorDossierAPIWithAttach(OCIntegrationTestCase):
         tokens = self.validate_attach_token(
             self.regular_user,
             oc_url,
-            (self.document, ),
+            (self.archive_document, ),
             )
 
         payloads = self.fetch_document_attach_payloads(browser, tokens)
 
         self.assertEquals(200, browser.status_code)
-        self.validate_attach_payload(payloads[0], self.document)
+        self.validate_attach_payload(payloads[0], self.archive_document)
 
         file_contents = self.download_document(
             browser,
@@ -122,7 +120,7 @@ class TestOfficeconnectorDossierAPIWithAttach(OCIntegrationTestCase):
             payloads[0],
             )
 
-        self.assertEquals(file_contents, self.document.file.data)
+        self.assertEquals(file_contents, self.archive_document.file.data)
 
     @browsing
     def test_attach_many_to_email_open(self, browser):
@@ -290,13 +288,12 @@ class TestOfficeconnectorDossierAPIWithAttach(OCIntegrationTestCase):
     @browsing
     def test_checkout_checkin_resolved_without_file(self, browser):
         self.login(self.regular_user, browser)
-        self.set_workflow_state('dossier-state-resolved', self.dossier)
-        self.document.file = None
+        self.archive_document.file = None
 
         with browser.expect_http_error(401):
             oc_url = self.fetch_document_checkout_oc_url(
                 browser,
-                self.document,
+                self.archive_document,
                 )
 
             self.assertIsNone(oc_url)
@@ -304,12 +301,11 @@ class TestOfficeconnectorDossierAPIWithAttach(OCIntegrationTestCase):
     @browsing
     def test_checkout_checkin_resolved_with_file(self, browser):
         self.login(self.regular_user, browser)
-        self.set_workflow_state('dossier-state-resolved', self.dossier)
 
         with browser.expect_http_error(401):
             oc_url = self.fetch_document_checkout_oc_url(
                 browser,
-                self.document,
+                self.archive_document,
                 )
 
             self.assertIsNone(oc_url)

--- a/opengever/officeconnector/tests/test_api_dossier_attach.py
+++ b/opengever/officeconnector/tests/test_api_dossier_attach.py
@@ -49,20 +49,18 @@ class TestOfficeconnectorDossierAPIWithAttach(OCIntegrationTestCase):
     @browsing
     def test_attach_to_email_inactive_without_file(self, browser):
         self.login(self.regular_user, browser)
-        self.set_workflow_state('dossier-state-inactive', self.dossier)
-        self.document.file = None
+        self.inactive_document.file = None
 
         with browser.expect_http_error(404):
-            oc_url = self.fetch_document_attach_oc_url(browser, self.document)
+            oc_url = self.fetch_document_attach_oc_url(browser, self.inactive_document)
 
             self.assertIsNone(oc_url)
 
     @browsing
     def test_attach_to_email_inactive_with_file(self, browser):
         self.login(self.regular_user, browser)
-        self.set_workflow_state('dossier-state-inactive', self.dossier)
 
-        oc_url = self.fetch_document_attach_oc_url(browser, self.document)
+        oc_url = self.fetch_document_attach_oc_url(browser, self.inactive_document)
 
         self.assertIsNotNone(oc_url)
         self.assertEquals(200, browser.status_code)
@@ -70,13 +68,13 @@ class TestOfficeconnectorDossierAPIWithAttach(OCIntegrationTestCase):
         tokens = self.validate_attach_token(
             self.regular_user,
             oc_url,
-            (self.document, ),
+            (self.inactive_document, ),
             )
 
         payloads = self.fetch_document_attach_payloads(browser, tokens)
 
         self.assertEquals(200, browser.status_code)
-        self.validate_attach_payload(payloads[0], self.document)
+        self.validate_attach_payload(payloads[0], self.inactive_document)
 
         file_contents = self.download_document(
             browser,
@@ -84,7 +82,7 @@ class TestOfficeconnectorDossierAPIWithAttach(OCIntegrationTestCase):
             payloads[0],
             )
 
-        self.assertEquals(file_contents, self.document.file.data)
+        self.assertEquals(file_contents, self.inactive_document.file.data)
 
     @browsing
     def test_attach_to_email_resolved_without_file(self, browser):
@@ -267,13 +265,12 @@ class TestOfficeconnectorDossierAPIWithAttach(OCIntegrationTestCase):
     @browsing
     def test_checkout_checkin_inactive_without_file(self, browser):
         self.login(self.regular_user, browser)
-        self.set_workflow_state('dossier-state-inactive', self.dossier)
-        self.document.file = None
+        self.inactive_document.file = None
 
         with browser.expect_http_error(401):
             oc_url = self.fetch_document_checkout_oc_url(
                 browser,
-                self.document,
+                self.inactive_document,
                 )
 
             self.assertIsNone(oc_url)
@@ -281,12 +278,11 @@ class TestOfficeconnectorDossierAPIWithAttach(OCIntegrationTestCase):
     @browsing
     def test_checkout_checkin_inactive_with_file(self, browser):
         self.login(self.regular_user, browser)
-        self.set_workflow_state('dossier-state-inactive', self.dossier)
 
         with browser.expect_http_error(401):
             oc_url = self.fetch_document_checkout_oc_url(
                 browser,
-                self.document,
+                self.inactive_document,
                 )
 
             self.assertIsNone(oc_url)

--- a/opengever/officeconnector/tests/test_api_dossier_checkout.py
+++ b/opengever/officeconnector/tests/test_api_dossier_checkout.py
@@ -51,21 +51,19 @@ class TestOfficeconnectorDossierAPIWithCheckout(OCIntegrationTestCase):
     @browsing
     def test_attach_to_email_resolved_without_file(self, browser):
         self.login(self.regular_user, browser)
-        self.set_workflow_state('dossier-state-resolved', self.dossier)
-        self.document.file = None
+        self.archive_document.file = None
 
         with browser.expect_http_error(404):
-            oc_url = self.fetch_document_attach_oc_url(browser, self.document)
+            oc_url = self.fetch_document_attach_oc_url(browser, self.archive_document)
 
             self.assertIsNone(oc_url)
 
     @browsing
     def test_attach_to_email_resolved_with_file(self, browser):
         self.login(self.regular_user, browser)
-        self.set_workflow_state('dossier-state-resolved', self.dossier)
 
         with browser.expect_http_error(404):
-            oc_url = self.fetch_document_attach_oc_url(browser, self.document)
+            oc_url = self.fetch_document_attach_oc_url(browser, self.archive_document)
 
             self.assertIsNone(oc_url)
 
@@ -266,13 +264,12 @@ class TestOfficeconnectorDossierAPIWithCheckout(OCIntegrationTestCase):
     @browsing
     def test_checkout_checkin_resolved_without_file(self, browser):
         self.login(self.regular_user, browser)
-        self.set_workflow_state('dossier-state-resolved', self.dossier)
-        self.document.file = None
+        self.archive_document.file = None
 
         with browser.expect_http_error(401):
             oc_url = self.fetch_document_checkout_oc_url(
                 browser,
-                self.document,
+                self.archive_document,
                 )
 
             self.assertIsNone(oc_url)
@@ -280,12 +277,11 @@ class TestOfficeconnectorDossierAPIWithCheckout(OCIntegrationTestCase):
     @browsing
     def test_checkout_checkin_resolved_with_file(self, browser):
         self.login(self.regular_user, browser)
-        self.set_workflow_state('dossier-state-resolved', self.dossier)
 
         with browser.expect_http_error(401):
             oc_url = self.fetch_document_checkout_oc_url(
                 browser,
-                self.document,
+                self.archive_document,
                 )
 
             self.assertIsNone(oc_url)

--- a/opengever/officeconnector/tests/test_api_dossier_checkout.py
+++ b/opengever/officeconnector/tests/test_api_dossier_checkout.py
@@ -32,21 +32,19 @@ class TestOfficeconnectorDossierAPIWithCheckout(OCIntegrationTestCase):
     @browsing
     def test_attach_to_email_inactive_without_file(self, browser):
         self.login(self.regular_user, browser)
-        self.set_workflow_state('dossier-state-inactive', self.dossier)
-        self.document.file = None
+        self.inactive_document.file = None
 
         with browser.expect_http_error(404):
-            oc_url = self.fetch_document_attach_oc_url(browser, self.document)
+            oc_url = self.fetch_document_attach_oc_url(browser, self.inactive_document)
 
             self.assertIsNone(oc_url)
 
     @browsing
     def test_attach_to_email_inactive_with_file(self, browser):
         self.login(self.regular_user, browser)
-        self.set_workflow_state('dossier-state-inactive', self.dossier)
 
         with browser.expect_http_error(404):
-            oc_url = self.fetch_document_attach_oc_url(browser, self.document)
+            oc_url = self.fetch_document_attach_oc_url(browser, self.inactive_document)
 
             self.assertIsNone(oc_url)
 
@@ -243,13 +241,12 @@ class TestOfficeconnectorDossierAPIWithCheckout(OCIntegrationTestCase):
     @browsing
     def test_checkout_checkin_inactive_without_file(self, browser):
         self.login(self.regular_user, browser)
-        self.set_workflow_state('dossier-state-inactive', self.dossier)
-        self.document.file = None
+        self.inactive_document.file = None
 
         with browser.expect_http_error(401):
             oc_url = self.fetch_document_checkout_oc_url(
                 browser,
-                self.document,
+                self.inactive_document,
                 )
 
             self.assertIsNone(oc_url)
@@ -257,12 +254,11 @@ class TestOfficeconnectorDossierAPIWithCheckout(OCIntegrationTestCase):
     @browsing
     def test_checkout_checkin_inactive_with_file(self, browser):
         self.login(self.regular_user, browser)
-        self.set_workflow_state('dossier-state-inactive', self.dossier)
 
         with browser.expect_http_error(401):
             oc_url = self.fetch_document_checkout_oc_url(
                 browser,
-                self.document,
+                self.inactive_document,
                 )
 
             self.assertIsNone(oc_url)

--- a/opengever/officeconnector/tests/test_api_dossier_disabled.py
+++ b/opengever/officeconnector/tests/test_api_dossier_disabled.py
@@ -26,28 +26,26 @@ class TestOfficeconnectorDossierAPIDisabled(OCIntegrationTestCase):
     @browsing
     def test_attach_to_email_inactive_without_file(self, browser):
         self.login(self.regular_user, browser)
-        self.set_workflow_state('dossier-state-inactive', self.dossier)
-        self.document.file = None
+        self.inactive_document.file = None
 
         with browser.expect_http_error(404):
-            oc_url = self.fetch_document_attach_oc_url(browser, self.document)
+            oc_url = self.fetch_document_attach_oc_url(browser, self.inactive_document)
 
             self.assertIsNone(oc_url)
 
     @browsing
     def test_attach_to_email_inactive_with_file(self, browser):
         self.login(self.regular_user, browser)
-        self.set_workflow_state('dossier-state-inactive', self.dossier)
 
         with browser.expect_http_error(404):
-            oc_url = self.fetch_document_attach_oc_url(browser, self.document)
+            oc_url = self.fetch_document_attach_oc_url(browser, self.inactive_document)
 
             self.assertIsNone(oc_url)
 
     @browsing
     def test_attach_to_email_resolved_without_file(self, browser):
         self.login(self.regular_user, browser)
-        self.set_workflow_state('dossier-state-resolved', self.dossier)
+        self.set_workflow_state('dossier-state-inactive', self.dossier)
         self.document.file = None
 
         with browser.expect_http_error(404):
@@ -173,13 +171,12 @@ class TestOfficeconnectorDossierAPIDisabled(OCIntegrationTestCase):
     @browsing
     def test_checkout_checkin_inactive_without_file(self, browser):
         self.login(self.regular_user, browser)
-        self.set_workflow_state('dossier-state-inactive', self.dossier)
-        self.document.file = None
+        self.inactive_document.file = None
 
         with browser.expect_http_error(401):
             oc_url = self.fetch_document_checkout_oc_url(
                 browser,
-                self.document,
+                self.inactive_document,
                 )
 
             self.assertIsNone(oc_url)
@@ -187,12 +184,11 @@ class TestOfficeconnectorDossierAPIDisabled(OCIntegrationTestCase):
     @browsing
     def test_checkout_checkin_inactive_with_file(self, browser):
         self.login(self.regular_user, browser)
-        self.set_workflow_state('dossier-state-inactive', self.dossier)
 
         with browser.expect_http_error(401):
             oc_url = self.fetch_document_checkout_oc_url(
                 browser,
-                self.document,
+                self.inactive_document,
                 )
 
             self.assertIsNone(oc_url)

--- a/opengever/officeconnector/tests/test_api_dossier_disabled.py
+++ b/opengever/officeconnector/tests/test_api_dossier_disabled.py
@@ -45,21 +45,19 @@ class TestOfficeconnectorDossierAPIDisabled(OCIntegrationTestCase):
     @browsing
     def test_attach_to_email_resolved_without_file(self, browser):
         self.login(self.regular_user, browser)
-        self.set_workflow_state('dossier-state-inactive', self.dossier)
-        self.document.file = None
+        self.archive_document.file = None
 
         with browser.expect_http_error(404):
-            oc_url = self.fetch_document_attach_oc_url(browser, self.document)
+            oc_url = self.fetch_document_attach_oc_url(browser, self.archive_document)
 
             self.assertIsNone(oc_url)
 
     @browsing
     def test_attach_to_email_resolved_with_file(self, browser):
         self.login(self.regular_user, browser)
-        self.set_workflow_state('dossier-state-resolved', self.dossier)
 
         with browser.expect_http_error(404):
-            oc_url = self.fetch_document_attach_oc_url(browser, self.document)
+            oc_url = self.fetch_document_attach_oc_url(browser, self.archive_document)
 
             self.assertIsNone(oc_url)
 
@@ -196,13 +194,12 @@ class TestOfficeconnectorDossierAPIDisabled(OCIntegrationTestCase):
     @browsing
     def test_checkout_checkin_resolved_without_file(self, browser):
         self.login(self.regular_user, browser)
-        self.set_workflow_state('dossier-state-resolved', self.dossier)
-        self.document.file = None
+        self.archive_document.file = None
 
         with browser.expect_http_error(401):
             oc_url = self.fetch_document_checkout_oc_url(
                 browser,
-                self.document,
+                self.archive_document,
                 )
 
             self.assertIsNone(oc_url)
@@ -210,12 +207,11 @@ class TestOfficeconnectorDossierAPIDisabled(OCIntegrationTestCase):
     @browsing
     def test_checkout_checkin_resolved_with_file(self, browser):
         self.login(self.regular_user, browser)
-        self.set_workflow_state('dossier-state-resolved', self.dossier)
 
         with browser.expect_http_error(401):
             oc_url = self.fetch_document_checkout_oc_url(
                 browser,
-                self.document,
+                self.archive_document,
                 )
 
             self.assertIsNone(oc_url)

--- a/opengever/officeconnector/tests/test_templates.py
+++ b/opengever/officeconnector/tests/test_templates.py
@@ -118,23 +118,21 @@ class TestFileActionButtonTemplates(IntegrationTestCase):
         self.assertNotIn('Checkout and edit', actions)
 
     @browsing
-    def test_tooltip_inactive_without_file(self, browser):
+    def test_tooltip_resolved_without_file(self, browser):
         self.login(self.regular_user, browser)
-        self.set_workflow_state('dossier-state-resolved', self.dossier)
-        self.document.file = None
+        self.archive_document.file = None
 
-        browser.open(self.document, view='tooltip')
+        browser.open(self.archive_document, view='tooltip')
 
         actions = browser.css('.file-action-buttons a').text
         self.assertNotIn('Attach to email', actions)
         self.assertNotIn('Checkout and edit', actions)
 
     @browsing
-    def test_tooltip_inactive_with_file(self, browser):
+    def test_tooltip_resolved_with_file(self, browser):
         self.login(self.regular_user, browser)
-        self.set_workflow_state('dossier-state-resolved', self.dossier)
 
-        browser.open(self.document, view='tooltip')
+        browser.open(self.archive_document, view='tooltip')
 
         actions = browser.css('.file-action-buttons a').text
         self.assertNotIn('Attach to email', actions)
@@ -165,9 +163,8 @@ class TestFileActionButtonTemplates(IntegrationTestCase):
     @browsing
     def test_dossier_documents_view_resolved(self, browser):
         self.login(self.regular_user, browser)
-        self.set_workflow_state('dossier-state-resolved', self.dossier)
 
-        browser.open(self.dossier, view='tabbedview_view-documents')
+        browser.open(self.archive_dossier, view='tabbedview_view-documents')
 
         actions = browser.css('.tabbedview-action-list a').text
         self.assertNotIn('Attach selection', actions)
@@ -228,10 +225,9 @@ class TestFileActionButtonTemplatesWithBumblebee(IntegrationTestCase):
     @browsing
     def test_overview_resolved_without_file(self, browser):
         self.login(self.regular_user, browser)
-        self.set_workflow_state('dossier-state-resolved', self.dossier)
-        self.document.file = None
+        self.archive_document.file = None
 
-        browser.open(self.document, view='tabbedview_view-overview')
+        browser.open(self.archive_document, view='tabbedview_view-overview')
 
         actions = browser.css('.file-action-buttons a').text
         self.assertNotIn('Attach to email', actions)
@@ -240,9 +236,8 @@ class TestFileActionButtonTemplatesWithBumblebee(IntegrationTestCase):
     @browsing
     def test_overview_resolved_with_file(self, browser):
         self.login(self.regular_user, browser)
-        self.set_workflow_state('dossier-state-resolved', self.dossier)
 
-        browser.open(self.document, view='tabbedview_view-overview')
+        browser.open(self.archive_document, view='tabbedview_view-overview')
 
         actions = browser.css('.file-action-buttons a').text
         self.assertNotIn('Attach to email', actions)
@@ -296,10 +291,9 @@ class TestFileActionButtonTemplatesWithBumblebee(IntegrationTestCase):
     @browsing
     def test_tooltip_resolved_without_file(self, browser):
         self.login(self.regular_user, browser)
-        self.set_workflow_state('dossier-state-resolved', self.dossier)
-        self.document.file = None
+        self.archive_document.file = None
 
-        browser.open(self.document, view='tooltip')
+        browser.open(self.archive_document, view='tooltip')
 
         actions = browser.css('.file-action-buttons a').text
         self.assertNotIn('Attach to email', actions)
@@ -308,9 +302,8 @@ class TestFileActionButtonTemplatesWithBumblebee(IntegrationTestCase):
     @browsing
     def test_tooltip_resolved_with_file(self, browser):
         self.login(self.regular_user, browser)
-        self.set_workflow_state('dossier-state-resolved', self.dossier)
 
-        browser.open(self.document, view='tooltip')
+        browser.open(self.archive_document, view='tooltip')
 
         actions = browser.css('.file-action-buttons a').text
         self.assertNotIn('Attach to email', actions)
@@ -341,9 +334,8 @@ class TestFileActionButtonTemplatesWithBumblebee(IntegrationTestCase):
     @browsing
     def test_dossier_documents_view_resolved(self, browser):
         self.login(self.regular_user, browser)
-        self.set_workflow_state('dossier-state-resolved', self.dossier)
 
-        browser.open(self.dossier, view='tabbedview_view-documents')
+        browser.open(self.archive_dossier, view='tabbedview_view-documents')
 
         actions = browser.css('.tabbedview-action-list a').text
         self.assertNotIn('Attach selection', actions)
@@ -398,10 +390,9 @@ class TestFileActionButtonTemplatesWithBumblebee(IntegrationTestCase):
     @browsing
     def test_bumblebee_resolved_without_file(self, browser):
         self.login(self.regular_user, browser)
-        self.set_workflow_state('dossier-state-resolved', self.dossier)
-        self.document.file = None
+        self.archive_document.file = None
 
-        browser.open(self.document, view='bumblebee-overlay-listing')
+        browser.open(self.archive_document, view='bumblebee-overlay-listing')
 
         actions = browser.css('.file-action-buttons a').text
         self.assertNotIn('Attach to email', actions)
@@ -410,9 +401,8 @@ class TestFileActionButtonTemplatesWithBumblebee(IntegrationTestCase):
     @browsing
     def test_bumblebee_resolved_with_file(self, browser):
         self.login(self.regular_user, browser)
-        self.set_workflow_state('dossier-state-resolved', self.dossier)
 
-        browser.open(self.document, view='bumblebee-overlay-listing')
+        browser.open(self.archive_document, view='bumblebee-overlay-listing')
 
         actions = browser.css('.file-action-buttons a').text
         self.assertNotIn('Attach to email', actions)
@@ -478,10 +468,9 @@ class TestFileActionButtonTemplatesWithOCAttach(IntegrationTestCase):
     @browsing
     def test_overview_resolved_without_file(self, browser):
         self.login(self.regular_user, browser)
-        self.set_workflow_state('dossier-state-resolved', self.dossier)
-        self.document.file = None
+        self.archive_document.file = None
 
-        browser.open(self.document, view='tabbedview_view-overview')
+        browser.open(self.archive_document, view='tabbedview_view-overview')
 
         actions = browser.css('.file-action-buttons a').text
         self.assertNotIn('Attach to email', actions)
@@ -490,9 +479,8 @@ class TestFileActionButtonTemplatesWithOCAttach(IntegrationTestCase):
     @browsing
     def test_overview_resolved_with_file(self, browser):
         self.login(self.regular_user, browser)
-        self.set_workflow_state('dossier-state-resolved', self.dossier)
 
-        browser.open(self.document, view='tabbedview_view-overview')
+        browser.open(self.archive_document, view='tabbedview_view-overview')
 
         actions = browser.css('.file-action-buttons a').text
         self.assertIn('Attach to email', actions)
@@ -555,10 +543,9 @@ class TestFileActionButtonTemplatesWithOCAttach(IntegrationTestCase):
     @browsing
     def test_tooltip_resolved_without_file(self, browser):
         self.login(self.regular_user, browser)
-        self.set_workflow_state('dossier-state-resolved', self.dossier)
-        self.document.file = None
+        self.archive_document.file = None
 
-        browser.open(self.document, view='tooltip')
+        browser.open(self.archive_document, view='tooltip')
 
         actions = browser.css('.file-action-buttons a').text
         self.assertNotIn('Attach to email', actions)
@@ -567,9 +554,8 @@ class TestFileActionButtonTemplatesWithOCAttach(IntegrationTestCase):
     @browsing
     def test_tooltip_resolved_with_file(self, browser):
         self.login(self.regular_user, browser)
-        self.set_workflow_state('dossier-state-resolved', self.dossier)
 
-        browser.open(self.document, view='tooltip')
+        browser.open(self.archive_document, view='tooltip')
 
         actions = browser.css('.file-action-buttons a').text
         self.assertIn('Attach to email', actions)
@@ -603,9 +589,8 @@ class TestFileActionButtonTemplatesWithOCAttach(IntegrationTestCase):
     @browsing
     def test_dossier_documents_view_resolved(self, browser):
         self.login(self.regular_user, browser)
-        self.set_workflow_state('dossier-state-resolved', self.dossier)
 
-        browser.open(self.dossier, view='tabbedview_view-documents')
+        browser.open(self.archive_dossier, view='tabbedview_view-documents')
 
         actions = browser.css('.tabbedview-action-list a').text
         self.assertIn('Attach selection', actions)
@@ -673,10 +658,9 @@ class TestFileActionButtonTemplatesWithOCAttachAndBumblebee(IntegrationTestCase)
     @browsing
     def test_overview_resolved_without_file(self, browser):
         self.login(self.regular_user, browser)
-        self.set_workflow_state('dossier-state-resolved', self.dossier)
-        self.document.file = None
+        self.archive_document.file = None
 
-        browser.open(self.document, view='tabbedview_view-overview')
+        browser.open(self.archive_document, view='tabbedview_view-overview')
 
         actions = browser.css('.file-action-buttons a').text
         self.assertNotIn('Attach to email', actions)
@@ -685,9 +669,8 @@ class TestFileActionButtonTemplatesWithOCAttachAndBumblebee(IntegrationTestCase)
     @browsing
     def test_overview_resolved_with_file(self, browser):
         self.login(self.regular_user, browser)
-        self.set_workflow_state('dossier-state-resolved', self.dossier)
 
-        browser.open(self.document, view='tabbedview_view-overview')
+        browser.open(self.archive_document, view='tabbedview_view-overview')
 
         actions = browser.css('.file-action-buttons a').text
         self.assertIn('Attach to email', actions)
@@ -750,10 +733,9 @@ class TestFileActionButtonTemplatesWithOCAttachAndBumblebee(IntegrationTestCase)
     @browsing
     def test_tooltip_resolved_without_file(self, browser):
         self.login(self.regular_user, browser)
-        self.set_workflow_state('dossier-state-resolved', self.dossier)
-        self.document.file = None
+        self.archive_document.file = None
 
-        browser.open(self.document, view='tooltip')
+        browser.open(self.archive_document, view='tooltip')
 
         actions = browser.css('.file-action-buttons a').text
         self.assertNotIn('Attach to email', actions)
@@ -762,9 +744,8 @@ class TestFileActionButtonTemplatesWithOCAttachAndBumblebee(IntegrationTestCase)
     @browsing
     def test_tooltip_resolved_with_file(self, browser):
         self.login(self.regular_user, browser)
-        self.set_workflow_state('dossier-state-resolved', self.dossier)
 
-        browser.open(self.document, view='tooltip')
+        browser.open(self.archive_document, view='tooltip')
 
         actions = browser.css('.file-action-buttons a').text
         self.assertIn('Attach to email', actions)
@@ -798,9 +779,8 @@ class TestFileActionButtonTemplatesWithOCAttachAndBumblebee(IntegrationTestCase)
     @browsing
     def test_dossier_documents_view_resolved(self, browser):
         self.login(self.regular_user, browser)
-        self.set_workflow_state('dossier-state-resolved', self.dossier)
 
-        browser.open(self.dossier, view='tabbedview_view-documents')
+        browser.open(self.archive_dossier, view='tabbedview_view-documents')
 
         actions = browser.css('.tabbedview-action-list a').text
         self.assertIn('Attach selection', actions)
@@ -861,10 +841,9 @@ class TestFileActionButtonTemplatesWithOCAttachAndBumblebee(IntegrationTestCase)
     @browsing
     def test_bumblebee_resolved_without_file(self, browser):
         self.login(self.regular_user, browser)
-        self.set_workflow_state('dossier-state-resolved', self.dossier)
-        self.document.file = None
+        self.archive_document.file = None
 
-        browser.open(self.document, view='bumblebee-overlay-listing')
+        browser.open(self.archive_document, view='bumblebee-overlay-listing')
 
         actions = browser.css('.file-action-buttons a').text
         self.assertNotIn('Attach to email', actions)
@@ -873,9 +852,8 @@ class TestFileActionButtonTemplatesWithOCAttachAndBumblebee(IntegrationTestCase)
     @browsing
     def test_bumblebee_resolved_with_file(self, browser):
         self.login(self.regular_user, browser)
-        self.set_workflow_state('dossier-state-resolved', self.dossier)
 
-        browser.open(self.document, view='bumblebee-overlay-listing')
+        browser.open(self.archive_document, view='bumblebee-overlay-listing')
 
         actions = browser.css('.file-action-buttons a').text
         self.assertIn('Attach to email', actions)
@@ -938,10 +916,9 @@ class TestFileActionButtonTemplatesWithOCCheckout(IntegrationTestCase):
     @browsing
     def test_overview_resolved_without_file(self, browser):
         self.login(self.regular_user, browser)
-        self.set_workflow_state('dossier-state-resolved', self.dossier)
-        self.document.file = None
+        self.archive_document.file = None
 
-        browser.open(self.document, view='tabbedview_view-overview')
+        browser.open(self.archive_document, view='tabbedview_view-overview')
 
         actions = browser.css('.file-action-buttons a').text
         self.assertNotIn('Attach to email', actions)
@@ -950,9 +927,8 @@ class TestFileActionButtonTemplatesWithOCCheckout(IntegrationTestCase):
     @browsing
     def test_overview_resolved_with_file(self, browser):
         self.login(self.regular_user, browser)
-        self.set_workflow_state('dossier-state-resolved', self.dossier)
 
-        browser.open(self.document, view='tabbedview_view-overview')
+        browser.open(self.archive_document, view='tabbedview_view-overview')
 
         actions = browser.css('.file-action-buttons a').text
         self.assertNotIn('Attach to email', actions)
@@ -1006,10 +982,9 @@ class TestFileActionButtonTemplatesWithOCCheckout(IntegrationTestCase):
     @browsing
     def test_tooltip_resolved_without_file(self, browser):
         self.login(self.regular_user, browser)
-        self.set_workflow_state('dossier-state-resolved', self.dossier)
-        self.document.file = None
+        self.archive_document.file = None
 
-        browser.open(self.document, view='tooltip')
+        browser.open(self.archive_document, view='tooltip')
 
         actions = browser.css('.file-action-buttons a').text
         self.assertNotIn('Attach to email', actions)
@@ -1018,9 +993,8 @@ class TestFileActionButtonTemplatesWithOCCheckout(IntegrationTestCase):
     @browsing
     def test_tooltip_resolved_with_file(self, browser):
         self.login(self.regular_user, browser)
-        self.set_workflow_state('dossier-state-resolved', self.dossier)
 
-        browser.open(self.document, view='tooltip')
+        browser.open(self.archive_document, view='tooltip')
 
         actions = browser.css('.file-action-buttons a').text
         self.assertNotIn('Attach to email', actions)
@@ -1052,9 +1026,8 @@ class TestFileActionButtonTemplatesWithOCCheckout(IntegrationTestCase):
     @browsing
     def test_dossier_documents_view_resolved(self, browser):
         self.login(self.regular_user, browser)
-        self.set_workflow_state('dossier-state-resolved', self.dossier)
 
-        browser.open(self.dossier, view='tabbedview_view-documents')
+        browser.open(self.archive_dossier, view='tabbedview_view-documents')
 
         actions = browser.css('.tabbedview-action-list a').text
         self.assertNotIn('Attach selection', actions)
@@ -1116,10 +1089,9 @@ class TestFileActionButtonTemplatesWithOCCheckoutAndBumblebee(IntegrationTestCas
     @browsing
     def test_overview_resolved_without_file(self, browser):
         self.login(self.regular_user, browser)
-        self.set_workflow_state('dossier-state-resolved', self.dossier)
-        self.document.file = None
+        self.archive_document.file = None
 
-        browser.open(self.document, view='tabbedview_view-overview')
+        browser.open(self.archive_document, view='tabbedview_view-overview')
 
         actions = browser.css('.file-action-buttons a').text
         self.assertNotIn('Attach to email', actions)
@@ -1128,9 +1100,8 @@ class TestFileActionButtonTemplatesWithOCCheckoutAndBumblebee(IntegrationTestCas
     @browsing
     def test_overview_resolved_with_file(self, browser):
         self.login(self.regular_user, browser)
-        self.set_workflow_state('dossier-state-resolved', self.dossier)
 
-        browser.open(self.document, view='tabbedview_view-overview')
+        browser.open(self.archive_document, view='tabbedview_view-overview')
 
         actions = browser.css('.file-action-buttons a').text
         self.assertNotIn('Attach to email', actions)
@@ -1184,10 +1155,9 @@ class TestFileActionButtonTemplatesWithOCCheckoutAndBumblebee(IntegrationTestCas
     @browsing
     def test_tooltip_resolved_without_file(self, browser):
         self.login(self.regular_user, browser)
-        self.set_workflow_state('dossier-state-resolved', self.dossier)
-        self.document.file = None
+        self.archive_document.file = None
 
-        browser.open(self.document, view='tooltip')
+        browser.open(self.archive_document, view='tooltip')
 
         actions = browser.css('.file-action-buttons a').text
         self.assertNotIn('Attach to email', actions)
@@ -1196,9 +1166,8 @@ class TestFileActionButtonTemplatesWithOCCheckoutAndBumblebee(IntegrationTestCas
     @browsing
     def test_tooltip_resolved_with_file(self, browser):
         self.login(self.regular_user, browser)
-        self.set_workflow_state('dossier-state-resolved', self.dossier)
 
-        browser.open(self.document, view='tooltip')
+        browser.open(self.archive_document, view='tooltip')
 
         actions = browser.css('.file-action-buttons a').text
         self.assertNotIn('Attach to email', actions)
@@ -1229,9 +1198,8 @@ class TestFileActionButtonTemplatesWithOCCheckoutAndBumblebee(IntegrationTestCas
     @browsing
     def test_dossier_documents_view_resolved(self, browser):
         self.login(self.regular_user, browser)
-        self.set_workflow_state('dossier-state-resolved', self.dossier)
 
-        browser.open(self.dossier, view='tabbedview_view-documents')
+        browser.open(self.archive_dossier, view='tabbedview_view-documents')
 
         actions = browser.css('.tabbedview-action-list a').text
         self.assertNotIn('Attach selection', actions)
@@ -1286,10 +1254,9 @@ class TestFileActionButtonTemplatesWithOCCheckoutAndBumblebee(IntegrationTestCas
     @browsing
     def test_bumblebee_resolved_without_file(self, browser):
         self.login(self.regular_user, browser)
-        self.set_workflow_state('dossier-state-resolved', self.dossier)
-        self.document.file = None
+        self.archive_document.file = None
 
-        browser.open(self.document, view='bumblebee-overlay-listing')
+        browser.open(self.archive_document, view='bumblebee-overlay-listing')
 
         actions = browser.css('.file-action-buttons a').text
         self.assertNotIn('Attach to email', actions)
@@ -1298,9 +1265,8 @@ class TestFileActionButtonTemplatesWithOCCheckoutAndBumblebee(IntegrationTestCas
     @browsing
     def test_bumblebee_resolved_with_file(self, browser):
         self.login(self.regular_user, browser)
-        self.set_workflow_state('dossier-state-resolved', self.dossier)
 
-        browser.open(self.document, view='bumblebee-overlay-listing')
+        browser.open(self.archive_document, view='bumblebee-overlay-listing')
 
         actions = browser.css('.file-action-buttons a').text
         self.assertNotIn('Attach to email', actions)

--- a/opengever/officeconnector/tests/test_templates.py
+++ b/opengever/officeconnector/tests/test_templates.py
@@ -31,10 +31,9 @@ class TestFileActionButtonTemplates(IntegrationTestCase):
     @browsing
     def test_overview_inactive_without_file(self, browser):
         self.login(self.regular_user, browser)
-        self.set_workflow_state('dossier-state-inactive', self.dossier)
-        self.document.file = None
+        self.inactive_document.file = None
 
-        browser.open(self.document, view='tabbedview_view-overview')
+        browser.open(self.inactive_document, view='tabbedview_view-overview')
 
         actions = browser.css('.file-action-buttons a').text
         self.assertNotIn('Attach to email', actions)
@@ -43,9 +42,8 @@ class TestFileActionButtonTemplates(IntegrationTestCase):
     @browsing
     def test_overview_inactive_with_file(self, browser):
         self.login(self.regular_user, browser)
-        self.set_workflow_state('dossier-state-inactive', self.dossier)
 
-        browser.open(self.document, view='tabbedview_view-overview')
+        browser.open(self.inactive_document, view='tabbedview_view-overview')
 
         actions = browser.css('.file-action-buttons a').text
         self.assertNotIn('Attach to email', actions)
@@ -101,10 +99,9 @@ class TestFileActionButtonTemplates(IntegrationTestCase):
     @browsing
     def test_tooltip_inactive_without_file(self, browser):
         self.login(self.regular_user, browser)
-        self.set_workflow_state('dossier-state-inactive', self.dossier)
-        self.document.file = None
+        self.inactive_document.file = None
 
-        browser.open(self.document, view='tooltip')
+        browser.open(self.inactive_document, view='tooltip')
 
         actions = browser.css('.file-action-buttons a').text
         self.assertNotIn('Attach to email', actions)
@@ -113,9 +110,8 @@ class TestFileActionButtonTemplates(IntegrationTestCase):
     @browsing
     def test_tooltip_inactive_with_file(self, browser):
         self.login(self.regular_user, browser)
-        self.set_workflow_state('dossier-state-inactive', self.dossier)
 
-        browser.open(self.document, view='tooltip')
+        browser.open(self.inactive_document, view='tooltip')
 
         actions = browser.css('.file-action-buttons a').text
         self.assertNotIn('Attach to email', actions)
@@ -158,9 +154,8 @@ class TestFileActionButtonTemplates(IntegrationTestCase):
     @browsing
     def test_dossier_documents_view_inactive(self, browser):
         self.login(self.regular_user, browser)
-        self.set_workflow_state('dossier-state-inactive', self.dossier)
 
-        browser.open(self.dossier, view='tabbedview_view-documents')
+        browser.open(self.inactive_dossier, view='tabbedview_view-documents')
 
         actions = browser.css('.tabbedview-action-list a').text
         self.assertNotIn('Attach selection', actions)
@@ -212,10 +207,9 @@ class TestFileActionButtonTemplatesWithBumblebee(IntegrationTestCase):
     @browsing
     def test_overview_inactive_without_file(self, browser):
         self.login(self.regular_user, browser)
-        self.set_workflow_state('dossier-state-inactive', self.dossier)
-        self.document.file = None
+        self.inactive_document.file = None
 
-        browser.open(self.document, view='tabbedview_view-overview')
+        browser.open(self.inactive_document, view='tabbedview_view-overview')
 
         actions = browser.css('.file-action-buttons a').text
         self.assertNotIn('Attach to email', actions)
@@ -224,9 +218,8 @@ class TestFileActionButtonTemplatesWithBumblebee(IntegrationTestCase):
     @browsing
     def test_overview_inactive_with_file(self, browser):
         self.login(self.regular_user, browser)
-        self.set_workflow_state('dossier-state-inactive', self.dossier)
 
-        browser.open(self.document, view='tabbedview_view-overview')
+        browser.open(self.inactive_document, view='tabbedview_view-overview')
 
         actions = browser.css('.file-action-buttons a').text
         self.assertNotIn('Attach to email', actions)
@@ -282,10 +275,9 @@ class TestFileActionButtonTemplatesWithBumblebee(IntegrationTestCase):
     @browsing
     def test_tooltip_inactive_without_file(self, browser):
         self.login(self.regular_user, browser)
-        self.set_workflow_state('dossier-state-inactive', self.dossier)
-        self.document.file = None
+        self.inactive_document.file = None
 
-        browser.open(self.document, view='tooltip')
+        browser.open(self.inactive_document, view='tooltip')
 
         actions = browser.css('.file-action-buttons a').text
         self.assertNotIn('Attach to email', actions)
@@ -294,9 +286,8 @@ class TestFileActionButtonTemplatesWithBumblebee(IntegrationTestCase):
     @browsing
     def test_tooltip_inactive_with_file(self, browser):
         self.login(self.regular_user, browser)
-        self.set_workflow_state('dossier-state-inactive', self.dossier)
 
-        browser.open(self.document, view='tooltip')
+        browser.open(self.inactive_document, view='tooltip')
 
         actions = browser.css('.file-action-buttons a').text
         self.assertNotIn('Attach to email', actions)
@@ -339,9 +330,8 @@ class TestFileActionButtonTemplatesWithBumblebee(IntegrationTestCase):
     @browsing
     def test_dossier_documents_view_inactive(self, browser):
         self.login(self.regular_user, browser)
-        self.set_workflow_state('dossier-state-inactive', self.dossier)
 
-        browser.open(self.dossier, view='tabbedview_view-documents')
+        browser.open(self.inactive_dossier, view='tabbedview_view-documents')
 
         actions = browser.css('.tabbedview-action-list a').text
         self.assertNotIn('Attach selection', actions)
@@ -387,10 +377,9 @@ class TestFileActionButtonTemplatesWithBumblebee(IntegrationTestCase):
     @browsing
     def test_bumblebee_inactive_without_file(self, browser):
         self.login(self.regular_user, browser)
-        self.set_workflow_state('dossier-state-inactive', self.dossier)
-        self.document.file = None
+        self.inactive_document.file = None
 
-        browser.open(self.document, view='bumblebee-overlay-listing')
+        browser.open(self.inactive_document, view='bumblebee-overlay-listing')
 
         actions = browser.css('.file-action-buttons a').text
         self.assertNotIn('Attach to email', actions)
@@ -399,9 +388,8 @@ class TestFileActionButtonTemplatesWithBumblebee(IntegrationTestCase):
     @browsing
     def test_bumblebee_inactive_with_file(self, browser):
         self.login(self.regular_user, browser)
-        self.set_workflow_state('dossier-state-inactive', self.dossier)
 
-        browser.open(self.document, view='bumblebee-overlay-listing')
+        browser.open(self.inactive_document, view='bumblebee-overlay-listing')
 
         actions = browser.css('.file-action-buttons a').text
         self.assertNotIn('Attach to email', actions)
@@ -466,10 +454,9 @@ class TestFileActionButtonTemplatesWithOCAttach(IntegrationTestCase):
     @browsing
     def test_overview_inactive_without_file(self, browser):
         self.login(self.regular_user, browser)
-        self.set_workflow_state('dossier-state-inactive', self.dossier)
-        self.document.file = None
+        self.inactive_document.file = None
 
-        browser.open(self.document, view='tabbedview_view-overview')
+        browser.open(self.inactive_document, view='tabbedview_view-overview')
 
         actions = browser.css('.file-action-buttons a').text
         self.assertNotIn('Attach to email', actions)
@@ -478,9 +465,8 @@ class TestFileActionButtonTemplatesWithOCAttach(IntegrationTestCase):
     @browsing
     def test_overview_inactive_with_file(self, browser):
         self.login(self.regular_user, browser)
-        self.set_workflow_state('dossier-state-inactive', self.dossier)
 
-        browser.open(self.document, view='tabbedview_view-overview')
+        browser.open(self.inactive_document, view='tabbedview_view-overview')
 
         actions = browser.css('.file-action-buttons a').text
         self.assertIn('Attach to email', actions)
@@ -545,10 +531,9 @@ class TestFileActionButtonTemplatesWithOCAttach(IntegrationTestCase):
     @browsing
     def test_tooltip_inactive_without_file(self, browser):
         self.login(self.regular_user, browser)
-        self.set_workflow_state('dossier-state-inactive', self.dossier)
-        self.document.file = None
+        self.inactive_document.file = None
 
-        browser.open(self.document, view='tooltip')
+        browser.open(self.inactive_document, view='tooltip')
 
         actions = browser.css('.file-action-buttons a').text
         self.assertNotIn('Attach to email', actions)
@@ -557,9 +542,8 @@ class TestFileActionButtonTemplatesWithOCAttach(IntegrationTestCase):
     @browsing
     def test_tooltip_inactive_with_file(self, browser):
         self.login(self.regular_user, browser)
-        self.set_workflow_state('dossier-state-inactive', self.dossier)
 
-        browser.open(self.document, view='tooltip')
+        browser.open(self.inactive_document, view='tooltip')
 
         actions = browser.css('.file-action-buttons a').text
         self.assertIn('Attach to email', actions)
@@ -583,7 +567,7 @@ class TestFileActionButtonTemplatesWithOCAttach(IntegrationTestCase):
     @browsing
     def test_tooltip_resolved_with_file(self, browser):
         self.login(self.regular_user, browser)
-        self.set_workflow_state('dossier-state-inactive', self.dossier)
+        self.set_workflow_state('dossier-state-resolved', self.dossier)
 
         browser.open(self.document, view='tooltip')
 
@@ -608,9 +592,8 @@ class TestFileActionButtonTemplatesWithOCAttach(IntegrationTestCase):
     @browsing
     def test_dossier_documents_view_inactive(self, browser):
         self.login(self.regular_user, browser)
-        self.set_workflow_state('dossier-state-inactive', self.dossier)
 
-        browser.open(self.dossier, view='tabbedview_view-documents')
+        browser.open(self.inactive_dossier, view='tabbedview_view-documents')
 
         actions = browser.css('.tabbedview-action-list a').text
         self.assertIn('Attach selection', actions)
@@ -666,10 +649,9 @@ class TestFileActionButtonTemplatesWithOCAttachAndBumblebee(IntegrationTestCase)
     @browsing
     def test_overview_inactive_without_file(self, browser):
         self.login(self.regular_user, browser)
-        self.set_workflow_state('dossier-state-inactive', self.dossier)
-        self.document.file = None
+        self.inactive_document.file = None
 
-        browser.open(self.document, view='tabbedview_view-overview')
+        browser.open(self.inactive_document, view='tabbedview_view-overview')
 
         actions = browser.css('.file-action-buttons a').text
         self.assertNotIn('Attach to email', actions)
@@ -678,9 +660,8 @@ class TestFileActionButtonTemplatesWithOCAttachAndBumblebee(IntegrationTestCase)
     @browsing
     def test_overview_inactive_with_file(self, browser):
         self.login(self.regular_user, browser)
-        self.set_workflow_state('dossier-state-inactive', self.dossier)
 
-        browser.open(self.document, view='tabbedview_view-overview')
+        browser.open(self.inactive_document, view='tabbedview_view-overview')
 
         actions = browser.css('.file-action-buttons a').text
         self.assertIn('Attach to email', actions)
@@ -745,10 +726,9 @@ class TestFileActionButtonTemplatesWithOCAttachAndBumblebee(IntegrationTestCase)
     @browsing
     def test_tooltip_inactive_without_file(self, browser):
         self.login(self.regular_user, browser)
-        self.set_workflow_state('dossier-state-inactive', self.dossier)
-        self.document.file = None
+        self.inactive_document.file = None
 
-        browser.open(self.document, view='tooltip')
+        browser.open(self.inactive_document, view='tooltip')
 
         actions = browser.css('.file-action-buttons a').text
         self.assertNotIn('Attach to email', actions)
@@ -757,9 +737,8 @@ class TestFileActionButtonTemplatesWithOCAttachAndBumblebee(IntegrationTestCase)
     @browsing
     def test_tooltip_inactive_with_file(self, browser):
         self.login(self.regular_user, browser)
-        self.set_workflow_state('dossier-state-inactive', self.dossier)
 
-        browser.open(self.document, view='tooltip')
+        browser.open(self.inactive_document, view='tooltip')
 
         actions = browser.css('.file-action-buttons a').text
         self.assertIn('Attach to email', actions)
@@ -808,9 +787,8 @@ class TestFileActionButtonTemplatesWithOCAttachAndBumblebee(IntegrationTestCase)
     @browsing
     def test_dossier_documents_view_inactive(self, browser):
         self.login(self.regular_user, browser)
-        self.set_workflow_state('dossier-state-inactive', self.dossier)
 
-        browser.open(self.dossier, view='tabbedview_view-documents')
+        browser.open(self.inactive_dossier, view='tabbedview_view-documents')
 
         actions = browser.css('.tabbedview-action-list a').text
         self.assertIn('Attach selection', actions)
@@ -859,10 +837,9 @@ class TestFileActionButtonTemplatesWithOCAttachAndBumblebee(IntegrationTestCase)
     @browsing
     def test_bumblebee_inactive_without_file(self, browser):
         self.login(self.regular_user, browser)
-        self.set_workflow_state('dossier-state-inactive', self.dossier)
-        self.document.file = None
+        self.inactive_document.file = None
 
-        browser.open(self.document, view='bumblebee-overlay-listing')
+        browser.open(self.inactive_document, view='bumblebee-overlay-listing')
 
         actions = browser.css('.file-action-buttons a').text
         self.assertNotIn('Attach to email', actions)
@@ -871,9 +848,8 @@ class TestFileActionButtonTemplatesWithOCAttachAndBumblebee(IntegrationTestCase)
     @browsing
     def test_bumblebee_inactive_with_file(self, browser):
         self.login(self.regular_user, browser)
-        self.set_workflow_state('dossier-state-inactive', self.dossier)
 
-        browser.open(self.document, view='bumblebee-overlay-listing')
+        browser.open(self.inactive_document, view='bumblebee-overlay-listing')
 
         actions = browser.css('.file-action-buttons a').text
         self.assertIn('Attach to email', actions)
@@ -941,10 +917,9 @@ class TestFileActionButtonTemplatesWithOCCheckout(IntegrationTestCase):
     @browsing
     def test_overview_inactive_without_file(self, browser):
         self.login(self.regular_user, browser)
-        self.set_workflow_state('dossier-state-inactive', self.dossier)
-        self.document.file = None
+        self.inactive_document.file = None
 
-        browser.open(self.document, view='tabbedview_view-overview')
+        browser.open(self.inactive_document, view='tabbedview_view-overview')
 
         actions = browser.css('.file-action-buttons a').text
         self.assertNotIn('Attach to email', actions)
@@ -953,9 +928,8 @@ class TestFileActionButtonTemplatesWithOCCheckout(IntegrationTestCase):
     @browsing
     def test_overview_inactive_with_file(self, browser):
         self.login(self.regular_user, browser)
-        self.set_workflow_state('dossier-state-inactive', self.dossier)
 
-        browser.open(self.document, view='tabbedview_view-overview')
+        browser.open(self.inactive_document, view='tabbedview_view-overview')
 
         actions = browser.css('.file-action-buttons a').text
         self.assertNotIn('Attach to email', actions)
@@ -1011,10 +985,9 @@ class TestFileActionButtonTemplatesWithOCCheckout(IntegrationTestCase):
     @browsing
     def test_tooltip_inactive_without_file(self, browser):
         self.login(self.regular_user, browser)
-        self.set_workflow_state('dossier-state-inactive', self.dossier)
-        self.document.file = None
+        self.inactive_document.file = None
 
-        browser.open(self.document, view='tooltip')
+        browser.open(self.inactive_document, view='tooltip')
 
         actions = browser.css('.file-action-buttons a').text
         self.assertNotIn('Attach to email', actions)
@@ -1023,9 +996,8 @@ class TestFileActionButtonTemplatesWithOCCheckout(IntegrationTestCase):
     @browsing
     def test_tooltip_inactive_with_file(self, browser):
         self.login(self.regular_user, browser)
-        self.set_workflow_state('dossier-state-inactive', self.dossier)
 
-        browser.open(self.document, view='tooltip')
+        browser.open(self.inactive_document, view='tooltip')
 
         actions = browser.css('.file-action-buttons a').text
         self.assertNotIn('Attach to email', actions)
@@ -1069,9 +1041,8 @@ class TestFileActionButtonTemplatesWithOCCheckout(IntegrationTestCase):
     @browsing
     def test_dossier_documents_view_inactive(self, browser):
         self.login(self.regular_user, browser)
-        self.set_workflow_state('dossier-state-inactive', self.dossier)
 
-        browser.open(self.dossier, view='tabbedview_view-documents')
+        browser.open(self.inactive_dossier, view='tabbedview_view-documents')
 
         actions = browser.css('.tabbedview-action-list a').text
         self.assertNotIn('Attach selection', actions)
@@ -1124,10 +1095,9 @@ class TestFileActionButtonTemplatesWithOCCheckoutAndBumblebee(IntegrationTestCas
     @browsing
     def test_overview_inactive_without_file(self, browser):
         self.login(self.regular_user, browser)
-        self.set_workflow_state('dossier-state-inactive', self.dossier)
-        self.document.file = None
+        self.inactive_document.file = None
 
-        browser.open(self.document, view='tabbedview_view-overview')
+        browser.open(self.inactive_document, view='tabbedview_view-overview')
 
         actions = browser.css('.file-action-buttons a').text
         self.assertNotIn('Attach to email', actions)
@@ -1136,9 +1106,8 @@ class TestFileActionButtonTemplatesWithOCCheckoutAndBumblebee(IntegrationTestCas
     @browsing
     def test_overview_inactive_with_file(self, browser):
         self.login(self.regular_user, browser)
-        self.set_workflow_state('dossier-state-inactive', self.dossier)
 
-        browser.open(self.document, view='tabbedview_view-overview')
+        browser.open(self.inactive_document, view='tabbedview_view-overview')
 
         actions = browser.css('.file-action-buttons a').text
         self.assertNotIn('Attach to email', actions)
@@ -1194,10 +1163,9 @@ class TestFileActionButtonTemplatesWithOCCheckoutAndBumblebee(IntegrationTestCas
     @browsing
     def test_tooltip_inactive_without_file(self, browser):
         self.login(self.regular_user, browser)
-        self.set_workflow_state('dossier-state-inactive', self.dossier)
-        self.document.file = None
+        self.inactive_document.file = None
 
-        browser.open(self.document, view='tooltip')
+        browser.open(self.inactive_document, view='tooltip')
 
         actions = browser.css('.file-action-buttons a').text
         self.assertNotIn('Attach to email', actions)
@@ -1206,9 +1174,8 @@ class TestFileActionButtonTemplatesWithOCCheckoutAndBumblebee(IntegrationTestCas
     @browsing
     def test_tooltip_inactive_with_file(self, browser):
         self.login(self.regular_user, browser)
-        self.set_workflow_state('dossier-state-inactive', self.dossier)
 
-        browser.open(self.document, view='tooltip')
+        browser.open(self.inactive_document, view='tooltip')
 
         actions = browser.css('.file-action-buttons a').text
         self.assertNotIn('Attach to email', actions)
@@ -1251,9 +1218,8 @@ class TestFileActionButtonTemplatesWithOCCheckoutAndBumblebee(IntegrationTestCas
     @browsing
     def test_dossier_documents_view_inactive(self, browser):
         self.login(self.regular_user, browser)
-        self.set_workflow_state('dossier-state-inactive', self.dossier)
 
-        browser.open(self.dossier, view='tabbedview_view-documents')
+        browser.open(self.inactive_dossier, view='tabbedview_view-documents')
 
         actions = browser.css('.tabbedview-action-list a').text
         self.assertNotIn('Attach selection', actions)
@@ -1299,10 +1265,9 @@ class TestFileActionButtonTemplatesWithOCCheckoutAndBumblebee(IntegrationTestCas
     @browsing
     def test_bumblebee_inactive_without_file(self, browser):
         self.login(self.regular_user, browser)
-        self.set_workflow_state('dossier-state-inactive', self.dossier)
-        self.document.file = None
+        self.inactive_document.file = None
 
-        browser.open(self.document, view='bumblebee-overlay-listing')
+        browser.open(self.inactive_document, view='bumblebee-overlay-listing')
 
         actions = browser.css('.file-action-buttons a').text
         self.assertNotIn('Attach to email', actions)
@@ -1311,9 +1276,8 @@ class TestFileActionButtonTemplatesWithOCCheckoutAndBumblebee(IntegrationTestCas
     @browsing
     def test_bumblebee_inactive_with_file(self, browser):
         self.login(self.regular_user, browser)
-        self.set_workflow_state('dossier-state-inactive', self.dossier)
 
-        browser.open(self.document, view='bumblebee-overlay-listing')
+        browser.open(self.inactive_document, view='bumblebee-overlay-listing')
 
         actions = browser.css('.file-action-buttons a').text
         self.assertNotIn('Attach to email', actions)


### PR DESCRIPTION
In an effort to make use of newly added elements in the fixture we update the OfficeConnector tests.

Using the inactive and archive dossiers from the fixture instead of setting the workflow state in the office connector tests made for an easy speedup (from 1:50 to 1:15 on my machine).

This is part of issue #3857