### PR TITLE
 Fix re-submitting previously rejected proposals.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -27,6 +27,7 @@ Changelog
 - Add webcomponents-bundle which contains ie11 polyfills. The polyfills where included in trix.js. This file have been removed in commit c40bf4e. [elioschmutz]
 - Add skipped task icon. [Kevin Bieri]
 - Trigger proposal rejected activity before unregister watchers. [elioschmutz]
+- Fix an issue when submitting previously rejected proposals with mail attachments. [deiferni]
 - Correct info message showed when regenerating agendaitem list. [njohner]
 - Make remove button unavailable for private dossier. [njohner]
 - Introduce generic header dropdown button. [Kevin Bieri]

--- a/opengever/meeting/configure.zcml
+++ b/opengever/meeting/configure.zcml
@@ -142,7 +142,7 @@
       />
 
   <subscriber
-      for="opengever.document.document.IDocumentSchema
+      for="opengever.document.behaviors.IBaseDocument
            OFS.interfaces.IObjectWillBeRemovedEvent"
       handler=".handlers.document_deleted"
       />

--- a/opengever/meeting/handlers.py
+++ b/opengever/meeting/handlers.py
@@ -19,9 +19,15 @@ from zope.intid.interfaces import IIntIds
 
 
 def document_deleted(context, event):
-    # this event is also fired when deleting a plone site. Unfortunately
-    # no deletion-order seems to be guaranteed, so it might happen that the
-    # IntId utility is removed before removing content.
+    """Fired when a document or a mail is deleted.
+
+    This happens while rejecting proposals. The entry that tracks the submitted
+    documents must also be removed to avoid issues when re-submitting.
+
+    this event is also fired when deleting a plone site. Unfortunately
+    no deletion-order seems to be guaranteed, so it might happen that the
+    IntId utility is removed before removing content.
+    """
     try:
         getUtility(IIntIds)
     except ComponentLookupError:

--- a/opengever/meeting/handlers.py
+++ b/opengever/meeting/handlers.py
@@ -8,7 +8,6 @@ from opengever.meeting.command import UpdateExcerptInDossierCommand
 from opengever.meeting.model import GeneratedExcerpt
 from opengever.meeting.model import Proposal
 from opengever.meeting.model import SubmittedDocument
-from opengever.meeting.sablontemplate import ISablonTemplate
 from opengever.meeting.sablontemplate import sablon_template_is_valid
 from plone import api
 from zope.annotation.interfaces import IAnnotations

--- a/opengever/meeting/tests/test_proposal.py
+++ b/opengever/meeting/tests/test_proposal.py
@@ -603,6 +603,30 @@ class TestProposal(IntegrationTestCase):
         self.assertEqual(Proposal.STATE_PENDING, self.draft_proposal.get_state())
 
     @browsing
+    def test_resubmit_rejected_proposal_with_mail_attachments(self, browser):
+        with self.login(self.dossier_responsible, browser):
+            self.draft_proposal.relatedItems.append(
+                self.as_relation_value(self.mail))
+
+            browser.visit(self.draft_proposal, view='tabbedview_view-overview')
+            browser.click_on('Submit')
+            browser.click_on('Confirm')
+
+            submitted_proposal = self.draft_proposal.load_model().resolve_submitted_proposal()
+
+        with self.login(self.committee_responsible, browser):
+            browser.visit(submitted_proposal, view='tabbedview_view-overview')
+            browser.click_on('Reject')
+            browser.click_on('Confirm')
+
+        with self.login(self.dossier_responsible, browser):
+            browser.visit(self.draft_proposal, view='tabbedview_view-overview')
+            browser.click_on('Submit')
+            browser.click_on('Confirm')
+
+            statusmessages.assert_message('Proposal successfully submitted.')
+
+    @browsing
     def test_proposal_can_be_submitted_without_permission_on_commitee(self, browser):
         self.login(self.dossier_responsible, browser)
         # https://github.com/4teamwork/opengever.ftw/issues/41


### PR DESCRIPTION
There is an issue with `ftw.mail.mail` attachments as the event handler was only registered for documents, and not for mails. Thus rows in the `submitteddocuments` table were not removed correctly which led to an `IntegrityError` for a duplicate key value upon re-submitting.

Fixes #4565.