### PR TITLE
Improve proposal activity tests

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -8,6 +8,7 @@ Changelog
 - Fix issue where empty version comments caused version tab to fail. [lgraf]
 - Add webcomponents-bundle which contains ie11 polyfills. The polyfills where included in trix.js. This file have been removed in commit c40bf4e. [elioschmutz]
 - Add skipped task icon. [Kevin Bieri]
+- Trigger proposal rejected activity before unregister watchers. [elioschmutz]
 - Correct info message showed when regenerating agendaitem list. [njohner]
 - Make remove button unavailable for private dossier. [njohner]
 - Build missing french translations for opengever.meeting. [elioschmutz]

--- a/opengever/meeting/proposal.py
+++ b/opengever/meeting/proposal.py
@@ -435,10 +435,10 @@ class SubmittedProposal(ProposalBase):
         proposal = self.load_model()
         proposal.reject(text)
 
+        ProposalRejectedActivity(self, self.REQUEST).record()
+
         remove_watchers_on_submitted_proposal_deleted(
             self, proposal.committee.group_id)
-
-        ProposalRejectedActivity(self, self.REQUEST).record()
 
         with elevated_privileges():
             api.content.delete(self)


### PR DESCRIPTION
This PR improves the tests of proposal activities.

It tests the badge-notifications for the notification-settings for each activity.

This is a follow-up pr of https://github.com/4teamwork/opengever.core/pull/4548