### PR TITLE
Fix issue where empty version comments caused version tab to fail

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2018.4.0 (unreleased)
 ---------------------
 
+- Fix issue where empty version comments caused version tab to fail. [lgraf]
 - Correct info message showed when regenerating agendaitem list. [njohner]
 - Build missing french translations for opengever.meeting. [elioschmutz]
 - Hide Excerpts field in SubmittedProposal edit form. [njohner]

--- a/opengever/document/tests/test_versions_tab.py
+++ b/opengever/document/tests/test_versions_tab.py
@@ -67,6 +67,21 @@ class TestVersionsTabWithoutPDFConverter(TestVersionsTab):
             self.assertEquals(['28.01.2015 18:30', '28.01.2015 12:00'], dates)
 
     @browsing
+    def test_handles_version_comments_that_are_none(self, browser):
+        with PDFConverterAvailability(False):
+            doc = self._create_doc()
+
+            repository = api.portal.get_tool('portal_repository')
+            repository.save(obj=doc, comment=None)
+            transaction.commit()
+
+            browser.login().open(doc, view='tabbedview_view-versions')
+            listing = browser.css('.listing').first
+            comments = [d['Kommentar'] for d in listing.dicts()]
+            self.assertEquals(
+                ['', 'Dokument erstellt (Initialversion)'], comments)
+
+    @browsing
     def test_is_sorted_by_descending_version_id(self, browser):
         with PDFConverterAvailability(False):
             browser.login().open(self.document, view='tabbedview_view-versions')

--- a/opengever/tabbedview/helper.py
+++ b/opengever/tabbedview/helper.py
@@ -25,10 +25,19 @@ from zope.i18n import translate
 
 
 def tooltip_helper(item, value):
+    """Turn some simple text into a <span/> element with a title.
+
+    While this function accepts both unicode and bytestring for `value`, it
+    always returns an utf-8 encoded bytestring.
+    """
+    if value is None:
+        value = u''
+
     value = safe_unicode(value)
     text = u''.join(
         BeautifulSoup(value, fromEncoding='utf8').findAll(text=True))
-    return (u'<span title="%s">%s</span>' % (text, value)).encode('utf-8')
+    tooltip = (u'<span title="%s">%s</span>' % (text, value)).encode('utf-8')
+    return tooltip
 
 
 def org_unit_title_helper(item, value):

--- a/opengever/tabbedview/tests/test_helpers.py
+++ b/opengever/tabbedview/tests/test_helpers.py
@@ -1,23 +1,20 @@
 from datetime import date
 from ftw.testing import MockTestCase
-from opengever.tabbedview.helper import task_id_checkbox_helper
 from opengever.tabbedview.helper import readable_date
+from opengever.tabbedview.helper import task_id_checkbox_helper
+from opengever.testing import IntegrationTestCase
 
 
-class TestHelpers(MockTestCase):
+class TestHelpers(IntegrationTestCase):
 
     def test_task_id_checkbox_helper(self):
-
-        brain = self.stub()
-        self.expect(brain.title).result('The brain of a task')
-        self.expect(brain.task_id).result('123')
-
-        self.replay()
+        self.login(self.regular_user)
+        sql_task = self.task.get_sql_object()
 
         self.assertEquals(
-            task_id_checkbox_helper(brain, ''),
-            '<input class="noborder selectable" id="123" name="task_ids:list" '
-            'title="Select The brain of a task" type="checkbox" value="123" />')
+            task_id_checkbox_helper(sql_task, ''),
+            u'<input class="noborder selectable" id="2" name="task_ids:list" '
+            u'title="Select Vertragsentwurf \xdcberpr\xfcfen" type="checkbox" value="2" />')
 
     def test_readable_date_from_datetime_string(self):
         self.assertEqual(
@@ -30,3 +27,5 @@ class TestHelpers(MockTestCase):
     def test_readable_date_from_date_object(self):
         self.assertEqual(
             readable_date({}, date(2017, 12, 31)), '31.12.2017')
+
+

--- a/opengever/tabbedview/tests/test_helpers.py
+++ b/opengever/tabbedview/tests/test_helpers.py
@@ -2,6 +2,7 @@ from datetime import date
 from ftw.testing import MockTestCase
 from opengever.tabbedview.helper import readable_date
 from opengever.tabbedview.helper import task_id_checkbox_helper
+from opengever.tabbedview.helper import tooltip_helper
 from opengever.testing import IntegrationTestCase
 
 
@@ -28,4 +29,21 @@ class TestHelpers(IntegrationTestCase):
         self.assertEqual(
             readable_date({}, date(2017, 12, 31)), '31.12.2017')
 
+    def test_tooltip_helper_accepts_unicode(self):
+        tooltip = tooltip_helper({}, u'B\xe4rengraben')
+        self.assertIsInstance(tooltip, str)
+        self.assertEqual(
+            '<span title="B\xc3\xa4rengraben">B\xc3\xa4rengraben</span>',
+            tooltip)
 
+    def test_tooltip_helper_accepts_bytestring(self):
+        tooltip = tooltip_helper({}, 'B\xc3\xa4rengraben')
+        self.assertIsInstance(tooltip, str)
+        self.assertEqual(
+            '<span title="B\xc3\xa4rengraben">B\xc3\xa4rengraben</span>',
+            tooltip)
+
+    def test_tooltip_helper_deals_with_none(self):
+        tooltip = tooltip_helper({}, None)
+        self.assertIsInstance(tooltip, str)
+        self.assertEqual('<span title=""></span>', tooltip)


### PR DESCRIPTION
The `comment` in the `sys_metadata` section of version metadata may be `None` as well as empty string. This fixes the `tooltip_helper` so it also deals with this case, and adds regression tests for both the helper as well as the higher level use case of the version tab.

First I changed `Versioner.create_version()` in a way where it never sets `None` as a comment - but I think that's misleading:
1) There's no upgrade step that fixes existing version metadata, so `None` can still appear -> nothing gained
2) That's just the way CMFEditions works, we have to expect `None` in this kind of metadata.  

Fixes #4515
