### PR TITLE
Migrating docs and translation to other server

### DIFF
--- a/docs/intern/kurzreferenzen/ubersetzungen.rst
+++ b/docs/intern/kurzreferenzen/ubersetzungen.rst
@@ -14,6 +14,7 @@ Login: via GitHub
 
 Deployment: /apps/02-django-translations.onegovgever.ch auf seth.4teamwork.ch
 
+
 Aktualisierung der Übersetzungen:
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/intern/kurzreferenzen/ubersetzungen.rst
+++ b/docs/intern/kurzreferenzen/ubersetzungen.rst
@@ -12,7 +12,7 @@ Für das Aktualisieren und Bearbeiten der Übersetzungen verwenden wir die Softw
 
 Login: via GitHub
 
-Deployment: theta.4teamwork.ch/37-translations.onegovgever.ch-django
+Deployment: /apps/02-django-translations.onegovgever.ch auf seth.4teamwork.ch
 
 Aktualisierung der Übersetzungen:
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/intern/meta.rst
+++ b/docs/intern/meta.rst
@@ -126,6 +126,16 @@ Für das Publizieren der Dokumentation gibt es pro Projekt ein
 builder baut der für die Publizierung auf einem Webserver geeignet ist, und
 mit ``rsync`` auf den entsprechenden Webserver publiziert.
 
+
+Damit das Publizieren mit ``rsync`` funktioniert, muss der persönliche Benutzer
+für den entsprechenden Server in der  ``~/.ssh/config`` hinterlegt werden.
+
+.. code-block:: bash
+
+   Host seth.4teamwork.ch
+     User <user>
+
+
 Um z.B. die interne Doku zu publizieren:
 
 .. code-block:: bash

--- a/sphinx.cfg
+++ b/sphinx.cfg
@@ -59,7 +59,7 @@ recipe = collective.recipe.template
 inline =
     #!/bin/bash
     bin/docs-build-public dirhtml
-    rsync -v -a docs/public/_build/dirhtml/* zope@theta.4teamwork.ch:/var/www/docs.onegovgever.ch/
+    rsync -v -a docs/public/_build/dirhtml/* seth.4teamwork.ch:/var/www/docs.onegovgever.ch/
 
 output = ${buildout:bin-directory}/docs-build-and-publish-public
 mode = 755
@@ -107,7 +107,7 @@ recipe = collective.recipe.template
 inline =
     #!/bin/bash
     bin/docs-build-public-fr dirhtml
-    rsync -v -a docs/public-fr/_build/dirhtml/* zope@theta.4teamwork.ch:/var/www/docs-fr.onegovgever.ch/
+    rsync -v -a docs/public-fr/_build/dirhtml/* seth.4teamwork.ch:/var/www/docs-fr.onegovgever.ch/
 
 output = ${buildout:bin-directory}/docs-build-and-publish-public-fr
 mode = 755
@@ -145,7 +145,7 @@ recipe = collective.recipe.template
 inline =
     #!/bin/bash
     bin/docs-build-intern dirhtml
-    rsync -v -a docs/intern/_build/dirhtml/* zope@theta.4teamwork.ch:/var/www/intern.onegovgever.ch/
+    rsync -v -a docs/intern/_build/dirhtml/* seth.4teamwork.ch:/var/www/intern.onegovgever.ch/
 
 output = ${buildout:bin-directory}/docs-build-and-publish-intern
 mode = 755

--- a/sphinx.cfg
+++ b/sphinx.cfg
@@ -59,7 +59,7 @@ recipe = collective.recipe.template
 inline =
     #!/bin/bash
     bin/docs-build-public dirhtml
-    rsync -v -a docs/public/_build/dirhtml/* seth.4teamwork.ch:/var/www/docs.onegovgever.ch/
+    rsync -O --chmod=ug+rw,Dg+s -v -a --delete docs/public/_build/dirhtml/* seth.4teamwork.ch:/var/www/docs.onegovgever.ch/
 
 output = ${buildout:bin-directory}/docs-build-and-publish-public
 mode = 755
@@ -107,7 +107,7 @@ recipe = collective.recipe.template
 inline =
     #!/bin/bash
     bin/docs-build-public-fr dirhtml
-    rsync -v -a docs/public-fr/_build/dirhtml/* seth.4teamwork.ch:/var/www/docs-fr.onegovgever.ch/
+    rsync -O --chmod=ug+rw,Dg+s -v -a --delete docs/public-fr/_build/dirhtml/* seth.4teamwork.ch:/var/www/docs-fr.onegovgever.ch/
 
 output = ${buildout:bin-directory}/docs-build-and-publish-public-fr
 mode = 755
@@ -145,7 +145,7 @@ recipe = collective.recipe.template
 inline =
     #!/bin/bash
     bin/docs-build-intern dirhtml
-    rsync -v -a docs/intern/_build/dirhtml/* seth.4teamwork.ch:/var/www/intern.onegovgever.ch/
+    rsync -O --chmod=ug+rw,Dg+s -v -a --delete docs/intern/_build/dirhtml/* seth.4teamwork.ch:/var/www/intern.onegovgever.ch/
 
 output = ${buildout:bin-directory}/docs-build-and-publish-intern
 mode = 755


### PR DESCRIPTION
The docs are now on seth.4teamwork.ch instead of theta.4teamwork.ch

Due the use of personal users, every user who updates the documentation must customize their .ssh/config configuration.

Please add the following in your local ~/.ssh/config

```
Host seth.4teamwork.ch
  User <user>
```