### PR TITLE
Update favorite-icon after checking-out or checking-in a document.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,7 @@ Changelog
 
 - Install CustomEvent and Promise polyfill. [Kevin Bieri]
 - Uninstall webcomponents polyfill. [Kevin Bieri]
+- Update favorite-icon after checking-out or checking-in a document. [elioschmutz]
 - Fix issue where empty version comments caused version tab to fail. [lgraf]
 - Add webcomponents-bundle which contains ie11 polyfills. The polyfills where included in trix.js. This file have been removed in commit c40bf4e. [elioschmutz]
 - Add skipped task icon. [Kevin Bieri]

--- a/opengever/base/browser/helper.py
+++ b/opengever/base/browser/helper.py
@@ -35,7 +35,7 @@ def checked_out_by(item):
 
 
 # XXX object orient me!
-def get_css_class(item, type_icon_only=False):
+def get_css_class(item, type_icon_only=False, for_user=None):
     """Returns the content-type icon css class for `item`.
 
     Arguments:
@@ -43,6 +43,9 @@ def get_css_class(item, type_icon_only=False):
     `type_icon_only` -- bool if it should only return the simple object
     type icon or the detailed content icon(mimetypes for document etc.).
     """
+    if for_user is None:
+        for_user = api.user.get_current().id
+
     css_class = None
 
     normalize = getUtility(IIDNormalizer).normalize
@@ -84,7 +87,7 @@ def get_css_class(item, type_icon_only=False):
         # is checked out by current user or someone else (or nobody at all)
         checked_out_userid = checked_out_by(item)
         if checked_out_userid:
-            if checked_out_userid == api.user.get_current().id:
+            if checked_out_userid == for_user:
                 css_class += " is-checked-out-by-current-user"
             else:
                 css_class += " is-checked-out"

--- a/opengever/base/tests/test_helper.py
+++ b/opengever/base/tests/test_helper.py
@@ -62,6 +62,20 @@ class TestCssClassHelpers(IntegrationTestCase):
         self.assertEquals('icon-docx is-checked-out-by-current-user',
                           get_css_class(self.document))
 
+    def test_document_obj_checked_out_in_context_of_another_users_id(self):
+        self.login(self.dossier_responsible)
+
+        self.assertEquals('icon-docx', get_css_class(self.document))
+
+        self.checkout_document(self.document)
+        self.assertEquals(
+            'icon-docx is-checked-out-by-current-user',
+            get_css_class(self.document, for_user=self.dossier_responsible.id))
+
+        self.assertEquals(
+            'icon-docx is-checked-out',
+            get_css_class(self.document, for_user=self.regular_user.id))
+
     def test_document_brain_checked_out_suffix(self):
         self.login(self.dossier_responsible)
 

--- a/opengever/document/configure.zcml
+++ b/opengever/document/configure.zcml
@@ -134,6 +134,12 @@
 
   <subscriber
       for="opengever.document.document.IDocumentSchema
+           opengever.document.interfaces.IObjectCheckedInEvent"
+      handler=".handlers.checked_in"
+      />
+
+  <subscriber
+      for="opengever.document.document.IDocumentSchema
            opengever.document.interfaces.IObjectBeforeCheckInEvent"
       handler=".handlers.before_documend_checked_in"
       />

--- a/opengever/document/handlers.py
+++ b/opengever/document/handlers.py
@@ -1,3 +1,6 @@
+from opengever.base.browser.helper import get_css_class
+from opengever.base.model.favorite import Favorite
+from opengever.base.oguid import Oguid
 from opengever.document.archival_file import ArchivalFileConverter
 from opengever.dossier.docprops import DocPropertyWriter
 from zope.lifecycleevent import IObjectRemovedEvent
@@ -8,6 +11,11 @@ DISABLE_DOCPROPERTY_UPDATE_FLAG = 'disable_docproperty_update'
 
 def checked_out(context, event):
     _update_docproperties(context)
+    _update_favorites_icon_class(context)
+
+
+def checked_in(context, event):
+    _update_favorites_icon_class(context)
 
 
 def before_documend_checked_in(context, event):
@@ -49,3 +57,14 @@ def set_archival_file_state(context, event):
 
     if file_removed or file_removed_in_archival_form:
         ArchivalFileConverter(context).remove_state()
+
+
+def _update_favorites_icon_class(context):
+    """Event handler which updates the icon_class of all existing favorites for
+    the current context.
+    """
+    favorites_query = Favorite.query.filter(
+        Favorite.oguid == Oguid.for_object(context))
+
+    for favorite in favorites_query.all():
+        favorite.icon_class = get_css_class(context, for_user=favorite.userid)


### PR DESCRIPTION
Updates the favorite-icon for checked-out documents:

Favorites for user who checked-out the document:
---------------------------------------------------
<img width="394" alt="bildschirmfoto 2018-07-12 um 11 44 51" src="https://user-images.githubusercontent.com/557005/42625893-38977ed2-85c9-11e8-8956-d9cc68ba1caf.png">

Favorites for user marked a checkedout document as a favorite:
---------------------------------------------------
<img width="387" alt="bildschirmfoto 2018-07-12 um 11 44 38" src="https://user-images.githubusercontent.com/557005/42625895-38af7906-85c9-11e8-98dd-7ff80fea6b2c.png">

@lukasgraf ❓ to get the different icon-classes (see method `_update_favorites_icon_class`, we have to lookup the icon for the current user and for all the other users (as already mentioned by @jone within the issue itself). I see three different approaches to reach the same result:

1. Manually manipulating the css-class (this is what I've implemented) 
We get the css-class for the current user and remove the unnecessary part of class for other users.

=> I've chosen this solution because it was fast to implement and i have nothing to refactor. But there are pro's to implement the other solutions, too...

pro: nothing to refactor, fast to implement
con: string-duplication and not object oriented

2. Using something like the `elevated_privileges` contextmanager to get the class with a not existing user. I.e. something like this:

```python
@contextmanager
def unrestricted_user(userid):
    old_manager = getSecurityManager()
    try:
        tmp_user = UnrestrictedUser(userid, '', ('manage', 'Manager'), '')
        tmp_user = tmp_user.__of__(api.portal.get().acl_users)
        newSecurityManager(getRequest(), tmp_user)
        yield
    finally:
        setSecurityManager(old_manager)

css_class_current_user = get_css_class(context)
with unrestricted_user('not_existing_user'):
  css_class_all_users = get_css_class(context)
  
```

pro: easy to understand and read
con: perhaps overkill and the problem is not really solved in the root (see 3rd case)

3. Refactoring the `get_css_class` (https://github.com/4teamwork/opengever.core/blob/master/opengever/base/browser/helper.py#L37) which is already marked to refactor it.
This is my favorite case. But to do this, we need more time for refactoring.

pro: we can use the required methods of the refactored class to get the icon-classes
con: we need more time for refactoring

@lukasgraf what do you think? Is the 1th case what you expected? Or do you prefer the 2nd or 3rd solution? or do you have another approach?

closes #4567 