### PR TITLE
Docs: Check whether git-lfs is enabled before building.

### DIFF
--- a/bin/enable-lfs
+++ b/bin/enable-lfs
@@ -1,6 +1,55 @@
 #!/bin/bash
 set -euo pipefail
 
+function red {
+    RED=$(tput setaf 1)
+    RESET=$(tput sgr0)
+    echo "$RED $1 $RESET"
+}
+
+# Parse options
+WARN_ONLY=0
+
+for i in "$@"
+do
+case $i in
+    --warn-only)
+    WARN_ONLY=1
+    shift
+    ;;
+    *)
+          # unknown option
+    ;;
+esac
+done
+
+# ----------------------------------------------------------------------
+
+if [[ $WARN_ONLY = 1 ]]; then
+
+    # Check whether git-lfs is enabled for this repo
+    REPO_ROOT=$(git rev-parse --show-toplevel)
+    set +e
+    grep -q '\[lfs\]' $REPO_ROOT/.git/config
+    LFS_DISABLED=$?
+    set -e
+
+    if [[ $LFS_DISABLED = 1 ]]; then
+        red "ERROR: git-lfs isn't enabled for this repository."
+        red ""
+        red "Please make sure you're in the correct repository, and if so,"
+        red "enable git-lfs support for this repo by running"
+        red ""
+        red "  bin/enable-lfs"
+        red ""
+        red "from the root of this repository."
+        exit 1
+    else
+        # LFS is enabled
+        exit 0
+    fi
+fi
+
 echo "Enabling automatic fetching of LFS resources for $(pwd)"
 git config --local lfs.fetchexclude ''
 echo "Success."

--- a/sphinx.cfg
+++ b/sphinx.cfg
@@ -28,6 +28,7 @@ inline =
     # otherwise defaults to 'html'.
 
     if [ -z $1 ]; then FORMAT='html'; else FORMAT=$1; fi
+    if [ -z $CI ]; then CI='false'; fi
 
     set -euo pipefail
 
@@ -38,6 +39,10 @@ inline =
     export SPHINXBUILD="${buildout:bin-directory}/sphinx-build"
 
     echo -e "Building 'public' docs...\n"
+
+    if [[ $CI != "true" ]]; then
+        ${buildout:bin-directory}/enable-lfs --warn-only
+    fi
 
     if [ -f $ZOPE_PY ]; then
         # Update ReStructuredText .inc files based on JSON schema dumps
@@ -76,6 +81,7 @@ inline =
     # otherwise defaults to 'html'.
 
     if [ -z $1 ]; then FORMAT='html'; else FORMAT=$1; fi
+    if [ -z $CI ]; then CI='false'; fi
 
     set -euo pipefail
 
@@ -86,6 +92,10 @@ inline =
     export SPHINXBUILD="${buildout:bin-directory}/sphinx-build"
 
     echo -e "Building 'public-fr' docs...\n"
+
+    if [[ $CI != "true" ]]; then
+        ${buildout:bin-directory}/enable-lfs --warn-only
+    fi
 
     if [ -f $ZOPE_PY ]; then
         # Update ReStructuredText .inc files based on JSON schema dumps
@@ -124,6 +134,7 @@ inline =
     # otherwise defaults to 'html'.
 
     if [ -z $1 ]; then FORMAT='html'; else FORMAT=$1; fi
+    if [ -z $CI ]; then CI='false'; fi
 
     set -euo pipefail
 
@@ -131,6 +142,10 @@ inline =
     export SPHINXBUILD="${buildout:bin-directory}/sphinx-build"
 
     echo -e "Building 'intern' docs...\n"
+
+    if [[ $CI != "true" ]]; then
+        ${buildout:bin-directory}/enable-lfs --warn-only
+    fi
 
     # Build the Sphinx documentation
     cd docs/intern


### PR DESCRIPTION
When attempting to build docs using on of the `bin/docs-build-<project>` scripts, this will now **print a warning and abort if `git-lfs` support hasn't been enabled** for the current repo *(because that would result in a build with missing images)*.

On CI (Jenkins) this check is skipped, because we explicitely don't want to enable LFS on Jenkins, and the missing images otherwise don't negatively affect the docs build.

*(No changelog entry because internal change)*