### PR TITLE
Fix unicode error on edit an agendaitem.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2018.4.0 (unreleased)
 ---------------------
 
+- Fix unicode error on edit an agendaitem. [elioschmutz]
 - Install CustomEvent and Promise polyfill. [Kevin Bieri]
 - Uninstall webcomponents polyfill. [Kevin Bieri]
 - Fix issue where empty version comments caused version tab to fail. [lgraf]

--- a/opengever/meeting/browser/meetings/agendaitem.py
+++ b/opengever/meeting/browser/meetings/agendaitem.py
@@ -337,8 +337,6 @@ class AgendaItemsView(BrowserView):
                 _('agenda_item_update_empty_string',
                   default=u"Agenda Item title must not be empty.")).proceed().dump()
 
-        title = title.decode('utf-8')
-        description = description and description.decode('utf-8')
         if self.agenda_item.has_proposal:
             if len(title) > ISubmittedProposal['title'].max_length:
                 return JSONResponse(self.request).error(

--- a/opengever/meeting/tests/test_agendaitem.py
+++ b/opengever/meeting/tests/test_agendaitem.py
@@ -80,9 +80,11 @@ class TestEditAgendaItems(IntegrationTestCase):
 
         agenda_item = self.schedule_ad_hoc(self.meeting, 'hax')
         browser.open(self.agenda_item_url(agenda_item, 'edit'),
-                     data={'title': 'bar'})
+                     data={'title': u'b\xe4r',
+                           'description': u'f\xf6o'})
 
-        self.assertEqual(agenda_item.title, 'bar')
+        self.assertEqual(agenda_item.title, u'b\xe4r')
+        self.assertEqual(agenda_item.description, u'f\xf6o')
         self.assertEquals([{u'message': u'Agenda Item updated.',
                             u'messageClass': u'info',
                             u'messageTitle': u'Information'}],


### PR DESCRIPTION
Fix unicode error on edit an agendaitem.

The title and description are already in unicode. See https://github.com/4teamwork/opengever.core/blob/master/opengever/meeting/browser/meetings/agendaitem.py#L333. So it's not possible to re-decode it.

Before:
![screen2](https://user-images.githubusercontent.com/557005/42642984-58531716-85f8-11e8-851e-6a57bbffad0e.gif)

After:
![screen1](https://user-images.githubusercontent.com/557005/42642989-5d0d98a8-85f8-11e8-8210-8da05f98a7af.gif)


closes #4582 