### PR TITLE
Make sure to sort tasktemplates on the draggable column.

### DIFF
--- a/opengever/core/upgrades/20180716102547_reset_task_templates_listing_cache/upgrade.py
+++ b/opengever/core/upgrades/20180716102547_reset_task_templates_listing_cache/upgrade.py
@@ -33,6 +33,8 @@ class ResetTaskTemplatesListingCache(UpgradeStep):
                          "- skipping record!" % record.key)
                 continue
 
+            data[u'sort'] = {u'field': u'draggable', u'direction': u'ASC'}
+
             columns = data.get('columns')
             for column in columns:
                 column["sortable"] = False

--- a/opengever/tasktemplates/browser/tasktemplates.py
+++ b/opengever/tasktemplates/browser/tasktemplates.py
@@ -69,6 +69,8 @@ class TaskTemplates(BaseCatalogListingTab):
          'transform': preselected_helper},
         )
 
+    sort_on = 'draggable'
+
     types = ['opengever.tasktemplates.tasktemplate', ]
 
     enabled_actions = ['folder_delete_confirmation']


### PR DESCRIPTION
Fix the upgrade step to set the sorting on the `draggable` column and also make sure that it is set to `draggable` column per default.

I did not add a CL entry here, as this fixes a change that is not released yet and has a CL entry.

resolves #4596 