### PR TITLE
Improve view for additional submitted documents

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -10,6 +10,7 @@ Changelog
 - Make lock info visible even when a document can be safely unlocked. [njohner]
 - Make `@config` endpoint accessible for anonymous on every context. [buchi]
 - Return root and CAS URL in `@config` endpoint. [buchi]
+- Improve form for submitting and updating additional documents. [tarnap]
 - Bump ftw.tokenauth to 1.1.0 which provides support for impersonation. [buchi]
 - Adjust table styling for small screens for the activity-settings view. [elioschmutz]
 - Update german translation for "committeee responsible" used within the activity settings tab. [elioschmutz]

--- a/opengever/meeting/browser/documents/submit.py
+++ b/opengever/meeting/browser/documents/submit.py
@@ -48,9 +48,20 @@ class SubmitAdditionalDocument(AutoExtensibleForm, Form):
     """
     ignoreContext = True
     allow_prefill_from_GET_request = True  # XXX
-    label = _(u'label_submit_additional_documents', default=u'Submit Updated Documents')
 
     schema = ISubmitAdditionalDocument
+
+    @property
+    def label(self):
+        proposal = self.extractData()[0]['proposal']
+        document = self.context
+
+        if SubmittedDocument.query.get_by_source(proposal, document).is_up_to_date(document):
+            label = _(u'label_submit_additional_documents', default=u'Submit Additional Documents')
+        else:
+            label = _(u'label_submit_updated_documents', default=u'Submit Updated Documents')
+
+        return label
 
     def update(self):
         self._preselect_proposal()

--- a/opengever/meeting/browser/documents/submit.py
+++ b/opengever/meeting/browser/documents/submit.py
@@ -48,6 +48,7 @@ class SubmitAdditionalDocument(AutoExtensibleForm, Form):
     """
     ignoreContext = True
     allow_prefill_from_GET_request = True  # XXX
+    label = _(u'label_submit_additional_documents', default=u'Submit Updated Documents')
 
     schema = ISubmitAdditionalDocument
 
@@ -80,7 +81,8 @@ class SubmitAdditionalDocument(AutoExtensibleForm, Form):
         return super(SubmitAdditionalDocument, self).__call__()
 
     @buttonAndHandler(_(u'button_submit_attachments',
-                        default=u'Submit Attachments'))
+                        default=u'Submit Attachments'),
+                      name='save')
     def submit_documents(self, action):
         data, errors = self.extractData()
         if errors:

--- a/opengever/meeting/browser/submitdocuments.py
+++ b/opengever/meeting/browser/submitdocuments.py
@@ -66,6 +66,7 @@ class SubmitAdditionalDocuments(AutoExtensibleForm, Form):
     """
     ignoreContext = True
     allow_prefill_from_GET_request = True  # XXX
+    label = _(u'label_submit_additional_documents', default=u'Submit Additional Documents')
 
     schema = ISubmitAdditionalDocuments
 
@@ -82,7 +83,8 @@ class SubmitAdditionalDocuments(AutoExtensibleForm, Form):
             self.context.is_submit_additional_documents_allowed()
 
     @buttonAndHandler(_(u'button_submit_attachments',
-                        default=u'Submit Attachments'))
+                        default=u'Submit Attachments'),
+                      name='save')
     def submit_documents(self, action):
         data, errors = self.extractData()
         if errors:

--- a/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-09 08:29+0000\n"
+"POT-Creation-Date: 2018-07-17 09:06+0000\n"
 "PO-Revision-Date: 2017-10-23 18:40+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1200,6 +1200,16 @@ msgstr "Protokollführung"
 #: ./opengever/meeting/browser/meetings/protocol.py
 msgid "label_start"
 msgstr "Start"
+
+#. Default: "Submit Additional Documents"
+#: ./opengever/meeting/browser/submitdocuments.py
+msgid "label_submit_additional_documents"
+msgstr "Zusätzliche Dokumente einreichen"
+
+#. Default: "Submit Updated Documents"
+#: ./opengever/meeting/browser/documents/submit.py
+msgid "label_submit_updated_documents"
+msgstr "Nachreichen einer neuen Version"
 
 #. Default: "Successors"
 #: ./opengever/meeting/proposal.py

--- a/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-09 08:29+0000\n"
+"POT-Creation-Date: 2018-07-17 09:06+0000\n"
 "PO-Revision-Date: 2018-05-22 10:15+0000\n"
 "Last-Translator: Niklaus Johner <Niklaus.johner@4teamwork.ch>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-meeting/fr/>\n"
@@ -1202,6 +1202,16 @@ msgstr "Secrétaire"
 #: ./opengever/meeting/browser/meetings/protocol.py
 msgid "label_start"
 msgstr "Début"
+
+#. Default: "Submit Additional Documents"
+#: ./opengever/meeting/browser/submitdocuments.py
+msgid "label_submit_additional_documents"
+msgstr ""
+
+#. Default: "Submit Updated Documents"
+#: ./opengever/meeting/browser/documents/submit.py
+msgid "label_submit_updated_documents"
+msgstr ""
 
 #. Default: "Successors"
 #: ./opengever/meeting/proposal.py

--- a/opengever/meeting/locales/opengever.meeting.pot
+++ b/opengever/meeting/locales/opengever.meeting.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-09 08:29+0000\n"
+"POT-Creation-Date: 2018-07-17 09:06+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1198,6 +1198,16 @@ msgstr ""
 #: ./opengever/meeting/browser/meetings/meeting.py
 #: ./opengever/meeting/browser/meetings/protocol.py
 msgid "label_start"
+msgstr ""
+
+#. Default: "Submit Additional Documents"
+#: ./opengever/meeting/browser/submitdocuments.py
+msgid "label_submit_additional_documents"
+msgstr ""
+
+#. Default: "Submit Updated Documents"
+#: ./opengever/meeting/browser/documents/submit.py
+msgid "label_submit_updated_documents"
 msgstr ""
 
 #. Default: "Successors"


### PR DESCRIPTION
There are several views for submitting additional documents.

One is used to submit additional documents and for updating these documents.
This view got a dynamic label, such that the label matches the action (update submitted documents or submit new documents).

# Submit additional documents
<img width="1072" alt="screen shot 2018-07-18 at 17 52 43" src="https://user-images.githubusercontent.com/194114/42893172-ede3b33e-8ab3-11e8-849c-ca6837752b51.png">

# Update submitted documents
<img width="1072" alt="screen shot 2018-07-18 at 17 53 30" src="https://user-images.githubusercontent.com/194114/42893180-f3dde674-8ab3-11e8-814f-4223a56e98d8.png">

Resolves #4584 