### PR TITLE
Hide unlock button in the DocumentEditForm.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2018.4.0 (unreleased)
 ---------------------
 
+- Make lock info visible even when a document can be safely unlocked. [njohner]
 - Bump ftw.tokenauth to 1.1.0 which provides support for impersonation. [buchi]
 - Remove opengever.pdfconverter. [elioschmutz]
 - Fix unicode error on edit an agendaitem. [elioschmutz]

--- a/opengever/locking/info.py
+++ b/opengever/locking/info.py
@@ -7,6 +7,7 @@ from opengever.meeting.model import SubmittedDocument
 from plone import api
 from plone.locking.browser.info import LockInfoViewlet
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+from z3c.form.interfaces import IEditForm
 
 
 class GeverLockInfoViewlet(LockInfoViewlet):
@@ -52,6 +53,9 @@ class GeverLockInfoViewlet(LockInfoViewlet):
 
     def current_user_can_unlock_document(self):
         return "Manager" in api.user.get_roles()
+
+    def is_edit_form(self):
+        return IEditForm.providedBy(self.view)
 
     def get_related_meeting_from_protocol(self):
         oguid = Oguid.for_object(self.context)

--- a/opengever/locking/templates/info.pt
+++ b/opengever/locking/templates/info.pt
@@ -1,9 +1,7 @@
 <div id="plone-lock-status"
      i18n:domain="plone"
-     tal:define="locked view/info/is_locked;
-                 stealable view/lock_is_stealable;
-                 lock_details view/lock_info;">
-  <tal:block condition="locked">
+     tal:define="lock_details view/lock_info">
+  <tal:block condition="python: view.info.is_locked() and not view.is_edit_form()">
     <dl class="portalMessage info">
       <dt i18n:translate="label_locked">Locked</dt>
       <dd>


### PR DESCRIPTION
We now show hide the unlock button when editing the document metadata.

I decided to leave the info that the document is locked when editing the metadata, as I think it is relevant for the user to know that while he is editing the metadata, the document is locked. Obviously we can also remove that info, if you think this is irrelevant/confusing for the user.

I also updated the changelog, as I had forgotten to add an entry in #4539 

resolves #4598 

![screen shot 2018-07-16 at 18 22 08](https://user-images.githubusercontent.com/7374243/42770557-340a89d6-8925-11e8-8539-922d22cda505.png)
