### PR TITLE
Gever-UI Config Enhancements

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,8 @@ Changelog
 
 - Bump ftw.casauth to 1.2.0 which provides a `@caslogin` endpoint. [buchi] 
 - Make lock info visible even when a document can be safely unlocked. [njohner]
+- Make `@config` endpoint accessible for anonymous on every context. [buchi]
+- Return root and CAS URL in `@config` endpoint. [buchi]
 - Bump ftw.tokenauth to 1.1.0 which provides support for impersonation. [buchi]
 - Adjust table styling for small screens for the activity-settings view. [elioschmutz]
 - Update german translation for "committeee responsible" used within the activity settings tab. [elioschmutz]

--- a/docs/public/dev-manual/api/config.rst
+++ b/docs/public/dev-manual/api/config.rst
@@ -22,27 +22,38 @@ GEVER-Mandanten abgefragt werden.
 
       {
           "@id": "http://localhost:8080/fd/@config",
+          "cas_url": "https://cas.server.net/",
           "features": {
               "activity": true,
+              "archival_file_conversion": false,
               "contacts": false,
               "doc_properties": true,
               "dossier_templates": true,
               "ech0147_export": true,
               "ech0147_import": true,
+              "favorites": true,
+              "journal_pdf": false,
               "meetings": true,
               "officeatwork": true,
-              "officeconnector_attach": false,
+              "officeconnector_attach": true,
               "officeconnector_checkout": true,
+              "oneoffixx": false,
               "preview": false,
+              "preview_auto_refresh": false,
               "preview_open_pdf_in_new_window": false,
+              "purge_trash": false,
               "repositoryfolder_documents_tab": true,
               "repositoryfolder_tasks_tab": true,
+              "resolver_name": "strict",
+              "sablon_date_format": "%d.%m.%Y",
               "solr": true,
-              "word_meetings": false,
               "workspace": false
           },
-          "max_dossier_levels": 2,
-          "max_repositoryfolder_levels": 3
+          "max_dossier_levels": 5,
+          "max_repositoryfolder_levels": 3,
+          "recently_touched_limit": 10,
+          "root_url": "http://localhost:8080/fd",
+          "version": "2018.4.0.dev0"
       }
 
 

--- a/opengever/api/config.py
+++ b/opengever/api/config.py
@@ -7,3 +7,6 @@ class Config(Service):
 
     def reply(self):
         return IGeverSettings(self.context).get_config()
+
+    def check_permission(self):
+        return

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -87,7 +87,7 @@
       name="@config"
       for="*"
       factory=".config.Config"
-      permission="zope2.View"
+      permission="zope.Public"
       />
 
   <plone:service

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -85,7 +85,7 @@
   <plone:service
       method="GET"
       name="@config"
-      for="Products.CMFPlone.interfaces.IPloneSiteRoot"
+      for="*"
       factory=".config.Config"
       permission="zope2.View"
       />

--- a/opengever/base/casauth.py
+++ b/opengever/base/casauth.py
@@ -46,6 +46,8 @@ def get_cas_server_url():
     """Get the CAS server URL from the ftw.casauth plugin.
     """
     acl_users = api.portal.get_tool('acl_users')
+    if 'cas_auth' not in acl_users:
+        return None
     cas_auth = acl_users.cas_auth
     url = getattr(cas_auth, 'cas_server_url', None)
     return url

--- a/opengever/base/configuration.py
+++ b/opengever/base/configuration.py
@@ -1,3 +1,5 @@
+from AccessControl import getSecurityManager
+from AccessControl.users import nobody
 from collections import OrderedDict
 from opengever.activity.interfaces import IActivitySettings
 from opengever.base.casauth import get_cas_server_url
@@ -36,10 +38,12 @@ class GeverSettingsAdpaterV1(object):
 
     def get_config(self):
         config = self.get_info()
-        config.update(self.get_settings())
+        # Only expose essential configuration for unauthenticated requests
+        if getSecurityManager().getUser() != nobody:
+            config.update(self.get_settings())
+            config['features'] = self.get_features()
         config['root_url'] = api.portal.get().absolute_url()
         config['cas_url'] = get_cas_server_url()
-        config['features'] = self.get_features()
         return config
 
     def get_info(self):

--- a/opengever/base/configuration.py
+++ b/opengever/base/configuration.py
@@ -19,13 +19,13 @@ from opengever.repository.interfaces import IRepositoryFolderRecords
 from opengever.workspace.interfaces import IWorkspaceSettings
 from pkg_resources import get_distribution
 from plone import api
-from Products.CMFCore.interfaces import ISiteRoot
 from zope.component import adapter
 from zope.interface import implementer
+from zope.interface import Interface
 
 
 @implementer(IGeverSettings)
-@adapter(ISiteRoot)
+@adapter(Interface)
 class GeverSettingsAdpaterV1(object):
     """Returns the current site configuration in the API v1 format."""
 
@@ -37,6 +37,7 @@ class GeverSettingsAdpaterV1(object):
         config = self.get_info()
         config.update(self.get_settings())
         config['features'] = self.get_features()
+        config['root'] = api.portal.get().absolute_url()
         return config
 
     def get_info(self):

--- a/opengever/base/configuration.py
+++ b/opengever/base/configuration.py
@@ -1,5 +1,6 @@
 from collections import OrderedDict
 from opengever.activity.interfaces import IActivitySettings
+from opengever.base.casauth import get_cas_server_url
 from opengever.base.interfaces import IFavoritesSettings
 from opengever.base.interfaces import IGeverSettings
 from opengever.base.interfaces import IRecentlyTouchedSettings
@@ -36,8 +37,9 @@ class GeverSettingsAdpaterV1(object):
     def get_config(self):
         config = self.get_info()
         config.update(self.get_settings())
+        config['root_url'] = api.portal.get().absolute_url()
+        config['cas_url'] = get_cas_server_url()
         config['features'] = self.get_features()
-        config['root'] = api.portal.get().absolute_url()
         return config
 
     def get_info(self):

--- a/opengever/base/subscribers.py
+++ b/opengever/base/subscribers.py
@@ -12,6 +12,7 @@ from zope.publisher.interfaces.browser import IBrowserView
 
 
 ALLOWED_ENDPOINTS = set([
+    'GET_application_json_@config',
     'POST_application_json_@caslogin',
     'POST_application_json_@login',
     'POST_application_json_@logout',

--- a/opengever/base/tests/test_casauth.py
+++ b/opengever/base/tests/test_casauth.py
@@ -57,6 +57,9 @@ class TestCASServerURL(IntegrationTestCase):
         applyProfile(self.layer['portal'], 'opengever.setup:casauth')
         self.assertEquals('http://example.com/portal', get_cas_server_url())
 
+    def test_cas_server_url_is_none_if_cas_plugin_is_missing(self):
+        self.assertEquals(None, get_cas_server_url())
+
 
 class TestGEVERPortalURL(IntegrationTestCase):
 

--- a/opengever/base/tests/test_configuration_adapter.py
+++ b/opengever/base/tests/test_configuration_adapter.py
@@ -38,6 +38,19 @@ class TestConfigurationAdapter(IntegrationTestCase):
                 ('solr', False),
                 ('workspace', False),
                 ])),
+            ('root_url', 'http://nohost/plone'),
+            ('cas_url', None),
+            ])
+        with self.login(self.regular_user):
+            configuration = IGeverSettings(self.portal).get_config()
+        self.assertEqual(configuration, expected_configuration)
+
+    def test_configuration_for_anonymous(self):
+        expected_configuration = OrderedDict([
+            ('@id', 'http://nohost/plone/@config'),
+            ('version', get_distribution('opengever.core').version),
+            ('root_url', 'http://nohost/plone'),
+            ('cas_url', None),
             ])
         configuration = IGeverSettings(self.portal).get_config()
         self.assertEqual(configuration, expected_configuration)


### PR DESCRIPTION
Enhancements needed for new UI:
- Makes `@config` endpoint accessible for anonymous on every context
- Return CAS server URL
- Return root URL