### PR TITLE
Add TaskReminder to handle reminders in annotations and sql.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,7 @@ Changelog
 
 - Remove leftover checkout and edit, and cancel actions for sablon and proposal templates. [njohner]
 - Do not include paragraphs in comittee table of contents. [njohner]
+- Add TaskReminder to handle reminders in annotations and sql. [elioschmutz]
 - Add TaskReminderActivity object. [elioschmutz]
 - Make paragraph templates deletable. [Rotonen]
 - Add ReminderSetting SQL Model. [elioschmutz]

--- a/opengever/activity/base.py
+++ b/opengever/activity/base.py
@@ -70,7 +70,7 @@ class BaseActivity(object):
         return translate(msg, context=self.request, target_language=language)
 
     def add_activity(self):
-        self.center.add_activity(
+        return self.center.add_activity(
             self.context,
             self.kind,
             self.title,

--- a/opengever/activity/browser/settings.py
+++ b/opengever/activity/browser/settings.py
@@ -10,7 +10,7 @@ from opengever.activity.roles import DISPOSITION_RECORDS_MANAGER_ROLE
 from opengever.activity.roles import PROPOSAL_ISSUER_ROLE
 from opengever.activity.roles import TASK_ISSUER_ROLE
 from opengever.activity.roles import TASK_RESPONSIBLE_ROLE
-from opengever.activity.roles import WATCHER_ROLE
+from opengever.activity.roles import TASK_REMINDER_WATCHER_ROLE
 from opengever.base.handlebars import prepare_handlebars_template
 from opengever.base.model import create_session
 from Products.Five import BrowserView
@@ -73,7 +73,7 @@ ACTIVITY_GROUPS = [
      ]},
 
     {'id': 'reminder',
-     'roles': [WATCHER_ROLE],
+     'roles': [TASK_REMINDER_WATCHER_ROLE],
      'activities': [
          'task-reminder',
      ]},

--- a/opengever/activity/center.py
+++ b/opengever/activity/center.py
@@ -93,29 +93,10 @@ class NotificationCenter(object):
         return tuple(resource.watchers)
 
     def add_activity(self, oguid, kind, title, label, summary, actor_id, description):
-        if description is None:
-            description = {}
-
-        resource = self.fetch_resource(oguid)
-        if not resource:
-            resource = self.add_resource(oguid)
-
-        activity = Activity(resource=resource, kind=kind, actor_id=actor_id)
-
-        # language dependent attributes
-        for language, value in label.items():
-            activity.translations[language].label = value
-
-        for language, value in summary.items():
-            activity.translations[language].summary = value
-
-        for language, value in description.items():
-            activity.translations[language].description = value
-
-        for language, value in title.items():
-            activity.translations[language].title = value
-
-        self.session.add(activity)
+        """Creates an activity and the related notifications..
+        """
+        activity = self._add_activity(
+            oguid, kind, title, label, summary, actor_id, description)
 
         errors = self.create_notifications(activity)
         return {'activity': activity, 'errors': errors}
@@ -180,6 +161,35 @@ class NotificationCenter(object):
 
         query = query.join(Notification.activity)
         return query.count()
+
+    def _add_activity(self, oguid, kind, title, label, summary, actor_id, description):
+        """Creates an activity instance and add it to the database.
+        """
+        if description is None:
+            description = {}
+
+        resource = self.fetch_resource(oguid)
+        if not resource:
+            resource = self.add_resource(oguid)
+
+        activity = Activity(resource=resource, kind=kind, actor_id=actor_id)
+
+        # language dependent attributes
+        for language, value in label.items():
+            activity.translations[language].label = value
+
+        for language, value in summary.items():
+            activity.translations[language].summary = value
+
+        for language, value in description.items():
+            activity.translations[language].description = value
+
+        for language, value in title.items():
+            activity.translations[language].title = value
+
+        self.session.add(activity)
+
+        return activity
 
 
 class PloneNotificationCenter(NotificationCenter):

--- a/opengever/activity/hooks.py
+++ b/opengever/activity/hooks.py
@@ -5,7 +5,7 @@ from opengever.activity.roles import DISPOSITION_RECORDS_MANAGER_ROLE
 from opengever.activity.roles import PROPOSAL_ISSUER_ROLE
 from opengever.activity.roles import TASK_ISSUER_ROLE
 from opengever.activity.roles import TASK_RESPONSIBLE_ROLE
-from opengever.activity.roles import WATCHER_ROLE
+from opengever.activity.roles import TASK_REMINDER_WATCHER_ROLE
 from opengever.base.model import create_session
 from sqlalchemy.orm.exc import NoResultFound
 
@@ -52,7 +52,7 @@ DEFAULT_SETTINGS = [
     {'kind': 'task-transition-planned-skipped',
      'badge_notification_roles': [TASK_RESPONSIBLE_ROLE, TASK_ISSUER_ROLE]},
     {'kind': 'task-reminder',
-     'badge_notification_roles': [WATCHER_ROLE]},
+     'badge_notification_roles': [TASK_REMINDER_WATCHER_ROLE]},
     {'kind': 'forwarding-added',
      'mail_notification_roles': [TASK_RESPONSIBLE_ROLE],
      'badge_notification_roles': [TASK_RESPONSIBLE_ROLE, TASK_ISSUER_ROLE]},

--- a/opengever/activity/locales/de/LC_MESSAGES/opengever.activity.po
+++ b/opengever/activity/locales/de/LC_MESSAGES/opengever.activity.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-09-20 08:57+0000\n"
+"POT-Creation-Date: 2018-10-01 09:34+0000\n"
 "PO-Revision-Date: 2015-02-24 08:40+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -377,6 +377,11 @@ msgstr "Auftraggeber"
 #: ./opengever/activity/roles.py
 msgid "task_old_responsible"
 msgstr "Früherer Auftragnehmer"
+
+#. Default: "Watcher"
+#: ./opengever/activity/roles.py
+msgid "task_reminder_watcher_role"
+msgstr "Beobachter"
 
 #. Default: "Task responsible"
 #: ./opengever/activity/roles.py

--- a/opengever/activity/locales/fr/LC_MESSAGES/opengever.activity.po
+++ b/opengever/activity/locales/fr/LC_MESSAGES/opengever.activity.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-09-20 08:57+0000\n"
+"POT-Creation-Date: 2018-10-01 09:34+0000\n"
 "PO-Revision-Date: 2017-12-03 16:14+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-activity/fr/>\n"
@@ -379,6 +379,11 @@ msgstr "mandant"
 #: ./opengever/activity/roles.py
 msgid "task_old_responsible"
 msgstr "Mandataire précédent"
+
+#. Default: "Watcher"
+#: ./opengever/activity/roles.py
+msgid "task_reminder_watcher_role"
+msgstr ""
 
 #. Default: "Task responsible"
 #: ./opengever/activity/roles.py

--- a/opengever/activity/locales/opengever.activity.pot
+++ b/opengever/activity/locales/opengever.activity.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-09-20 08:57+0000\n"
+"POT-Creation-Date: 2018-10-01 09:34+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -376,6 +376,11 @@ msgstr ""
 #. Default: "Task former responsible"
 #: ./opengever/activity/roles.py
 msgid "task_old_responsible"
+msgstr ""
+
+#. Default: "Watcher"
+#: ./opengever/activity/roles.py
+msgid "task_reminder_watcher_role"
 msgstr ""
 
 #. Default: "Task responsible"

--- a/opengever/activity/roles.py
+++ b/opengever/activity/roles.py
@@ -11,6 +11,7 @@ DISPOSITION_ARCHIVIST_ROLE = 'archivist'
 WATCHER_ROLE = 'regular_watcher'
 COMMITTEE_RESPONSIBLE_ROLE = 'committee_responsible'
 PROPOSAL_ISSUER_ROLE = 'proposal_issuer'
+TASK_REMINDER_WATCHER_ROLE = 'task_reminder_watcher_role'
 
 _('task_issuer', default=u"Task issuer")
 _('task_responsible', default=u"Task responsible")
@@ -20,3 +21,4 @@ _('archivist', default=u"Archivist")
 _('regular_watcher', default=u"Watcher")
 _('proposal_issuer', default=u"Proposal issuer")
 _('committee_responsible', default=u"Committee responsible")
+_('task_reminder_watcher_role', default=u"Watcher")

--- a/opengever/core/upgrades/20181001113227_change_task_reminder_notification_setting_role/upgrade.py
+++ b/opengever/core/upgrades/20181001113227_change_task_reminder_notification_setting_role/upgrade.py
@@ -1,0 +1,24 @@
+from opengever.activity.roles import TASK_REMINDER_WATCHER_ROLE
+from opengever.core.upgrade import SchemaMigration
+from sqlalchemy.sql.expression import column
+from sqlalchemy.sql.expression import table
+import json
+
+
+defaults_table = table(
+    "notification_defaults",
+    column("id"),
+    column("kind"),
+    column("badge_notification_roles"))
+
+
+class ChangeTaskReminderNotificationSettingRole(SchemaMigration):
+    """Change task reminder notification setting role.
+    """
+
+    def migrate(self):
+        self.execute(
+            defaults_table.update()
+            .values(badge_notification_roles=json.dumps([TASK_REMINDER_WATCHER_ROLE]))
+            .where(defaults_table.columns.kind == 'task-reminder')
+            )

--- a/opengever/globalindex/model/reminder_settings.py
+++ b/opengever/globalindex/model/reminder_settings.py
@@ -3,6 +3,7 @@ from opengever.base.model import Base
 from opengever.base.model import UTCDateTime
 from opengever.globalindex.model.task import Task
 from opengever.ogds.models import USER_ID_LENGTH
+from opengever.task.reminder import TASK_REMINDER_OPTIONS
 from sqlalchemy import Column
 from sqlalchemy import Date
 from sqlalchemy import ForeignKey
@@ -35,3 +36,7 @@ class ReminderSetting(Base):
             self.actor_id,
             repr(self.task),
             self.remind_day)
+
+    def update_remind_day(self):
+        option = TASK_REMINDER_OPTIONS[self.option_type]
+        self.remind_day = option.calculate_remind_on(self.task.deadline)

--- a/opengever/task/reminder/reminder.py
+++ b/opengever/task/reminder/reminder.py
@@ -1,0 +1,99 @@
+from opengever.base.model import create_session
+from opengever.globalindex.model.reminder_settings import ReminderSetting
+from opengever.task.reminder import TASK_REMINDER_OPTIONS
+from persistent.dict import PersistentDict
+from plone import api
+from zope.annotation import IAnnotations
+
+
+TASK_REMINDER_ANNOTATIONS_KEY = 'opengever.task.task_reminder'
+
+
+def get_task_reminder():
+    return TaskReminder()
+
+
+class TaskReminder(object):
+
+    def __init__(self):
+        self.session = create_session()
+
+    def set_reminder(self, obj, option, user_id=None):
+        """Sets a reminder for the given object for a specific user or for the
+        current logged in user.
+
+        A previously set reminder for the given user for the given object will
+        be overridden by the new reminder-setting.
+
+        arguments:
+        obj -- the object for which the reminder should be set
+        option -- a TASK_REMINDER_OPTIONS option
+        """
+        user_id = user_id or api.user.get_current().getId()
+        self._set_reminder_setting_in_annotation(obj, user_id, option)
+        self._set_reminder_setting_in_globalindex(obj, user_id, option)
+
+    def get_reminder(self, obj, user_id=None):
+        """Get the reminder-option object for the given object for a specific
+        user or for the current logged in user.
+
+        Returns None, if no reminder is set.
+        """
+        user_id = user_id or api.user.get_current().getId()
+        return TASK_REMINDER_OPTIONS.get(
+            self._get_user_annotation(obj, user_id))
+
+    def get_sql_reminder(self, obj, user_id=None):
+        """Get the sql-reminder for the given object for a specific user or
+        for the current logged in user.
+
+        Returns None, if no reminder is set.
+        """
+        user_id = user_id or api.user.get_current().getId()
+        return ReminderSetting.query.filter(
+            ReminderSetting.actor_id == user_id,
+            ReminderSetting.task.has(task_id=obj.get_sql_object().task_id)).first()
+
+    def clear_reminder(self, obj, user_id=None):
+        """Removes a registered reminder for the given object for a specific
+        user or for the current logged in user.
+        """
+        user_id = user_id or api.user.get_current().getId()
+        self._clear_reminder_setting_in_annotation(obj, user_id)
+        self._clear_reminder_setting_in_sql(obj, user_id)
+
+    def _set_reminder_setting_in_annotation(self, obj, user_id, option):
+        self._set_user_annotation(obj, user_id, option.option_type)
+
+    def _set_reminder_setting_in_globalindex(self, obj, user_id, option):
+        self._clear_reminder_setting_in_sql(obj, user_id)
+        self.session.add(ReminderSetting(
+            task_id=obj.get_sql_object().task_id,
+            actor_id=user_id,
+            option_type=option.option_type,
+            remind_day=option.calculate_remind_on(obj.deadline)
+            ))
+
+    def _clear_reminder_setting_in_annotation(self, obj, user_id):
+        storage = self._annotation_storage(obj)
+        if user_id in storage:
+            del storage[user_id]
+
+    def _clear_reminder_setting_in_sql(self, obj, user_id):
+        current_reminder = self.get_sql_reminder(obj, user_id)
+        if current_reminder:
+            self.session.delete(current_reminder)
+
+    def _annotation_storage(self, obj):
+        annotations = IAnnotations(obj)
+        if TASK_REMINDER_ANNOTATIONS_KEY not in annotations:
+            annotations[TASK_REMINDER_ANNOTATIONS_KEY] = PersistentDict()
+
+        return annotations.get(TASK_REMINDER_ANNOTATIONS_KEY)
+
+    def _set_user_annotation(self, obj, user_id, value):
+        storage = self._annotation_storage(obj)
+        storage[user_id] = value
+
+    def _get_user_annotation(self, obj, user_id):
+        return self._annotation_storage(obj).get(user_id)

--- a/opengever/task/reminder/reminder.py
+++ b/opengever/task/reminder/reminder.py
@@ -71,6 +71,13 @@ class TaskReminder(object):
                 ReminderSetting.remind_day == date.today()).all():
             TaskReminderActivity(reminder.task, getRequest()).record(reminder.actor_id)
 
+    def recalculate_remind_day_for_obj(self, obj):
+        """If the duedate of a task will change, we have to update the
+        reminde-day of all reminders set for this object.
+        """
+        map(lambda reminder: reminder.update_remind_day(),
+            obj.get_sql_object().reminder_settings)
+
     def _set_reminder_setting_in_annotation(self, obj, user_id, option):
         self._set_user_annotation(obj, user_id, option.option_type)
 

--- a/opengever/task/tests/test_activities.py
+++ b/opengever/task/tests/test_activities.py
@@ -5,6 +5,7 @@ from ftw.mail.utils import get_header
 from ftw.testbrowser import browsing
 from ftw.testing.mailing import Mailing
 from opengever.activity import notification_center
+from opengever.activity import SYSTEM_ACTOR_ID
 from opengever.activity.hooks import insert_notification_defaults
 from opengever.activity.model import Activity
 from opengever.activity.roles import TASK_ISSUER_ROLE
@@ -439,10 +440,13 @@ class TestTaskReminderActivity(IntegrationTestCase):
 
     def test_activity_attributes(self):
         self.login(self.regular_user)
-        TaskReminderActivity(self.task.get_sql_object(), self.request).record()
+        TaskReminderActivity(self.task.get_sql_object(), self.request).record(
+            self.dossier_responsible.getId())
+
         activity = Activity.query.first()
 
         self.assertEquals('task-reminder', activity.kind)
         self.assertEquals('Task reminder', activity.label)
         self.assertEquals(self.task.title, activity.title)
+        self.assertEqual(SYSTEM_ACTOR_ID, activity.actor_id)
         self.assertEquals(u'Deadline is on Nov 01, 2016', activity.summary)

--- a/opengever/task/tests/test_reminder.py
+++ b/opengever/task/tests/test_reminder.py
@@ -1,10 +1,19 @@
 from datetime import date
-from opengever.task.reminder import TASK_REMINDER_SAME_DAY
+from datetime import datetime
+from datetime import timedelta
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.testing import freeze
+from opengever.activity.model import Activity
+from opengever.activity.model import Notification
+from opengever.task.activities import TaskReminderActivity
+from opengever.task.reminder import TASK_REMINDER_BEGINNING_OF_WEEK
 from opengever.task.reminder import TASK_REMINDER_ONE_DAY_BEFORE
 from opengever.task.reminder import TASK_REMINDER_ONE_WEEK_BEFORE
-from opengever.task.reminder import TASK_REMINDER_BEGINNING_OF_WEEK
+from opengever.task.reminder import TASK_REMINDER_SAME_DAY
 from opengever.task.reminder.reminder import TaskReminder
 from opengever.testing import IntegrationTestCase
+import pytz
 
 
 class TestTaskReminderOptions(IntegrationTestCase):
@@ -34,6 +43,8 @@ class TestTaskReminderOptions(IntegrationTestCase):
 
 
 class TestTaskReminder(IntegrationTestCase):
+
+    features = ('activity', )
 
     def test_set_reminder_creates_annotation_entry_for_current_user(self):
         self.login(self.regular_user)
@@ -120,3 +131,52 @@ class TestTaskReminder(IntegrationTestCase):
             TASK_REMINDER_ONE_DAY_BEFORE.option_type,
             task_reminder.get_sql_reminder(
                 self.task, user_id=self.dossier_responsible.getId()).option_type)
+
+    def test_create_reminder_notifications_does_nothing_if_there_are_no_reminder_settings(self):
+        self.login(self.regular_user)
+
+        TaskReminder().create_reminder_notifications()
+
+        self.assertEqual(0, Activity.query.count())
+        self.assertEqual(0, Notification.query.count())
+
+    def test_create_reminder_notifications_adds_notifications_for_each_reminder_if_reaching_remind_day(self):
+        self.login(self.administrator)
+        today = date.today()
+
+        self.task.responsible = self.dossier_responsible.getId()
+        self.task.issuer = self.regular_user.getId()
+        self.task.deadline = today
+
+        self.subtask.responsible = self.dossier_responsible.getId()
+        self.subtask.issuer = self.regular_user.getId()
+        self.subtask.deadline = today + timedelta(days=1)
+
+        self.sequential_task.responsible = self.dossier_responsible.getId()
+        self.sequential_task.issuer = self.regular_user.getId()
+        self.sequential_task.deadline = today + timedelta(days=5)
+
+        task_reminder = TaskReminder()
+
+        with self.login(self.regular_user):
+            task_reminder.set_reminder(self.task, TASK_REMINDER_SAME_DAY)
+            task_reminder.set_reminder(self.sequential_task, TASK_REMINDER_SAME_DAY)
+
+        with self.login(self.dossier_responsible):
+            task_reminder.set_reminder(self.subtask, TASK_REMINDER_ONE_DAY_BEFORE)
+
+        with freeze(pytz.UTC.localize(datetime.combine(today, datetime.min.time()))):
+            task_reminder.create_reminder_notifications()
+
+        task_reminder_activities = Activity.query.filter(
+            Activity.kind == TaskReminderActivity.kind)
+
+        self.assertEqual(2, task_reminder_activities.count())
+
+        notifications = []
+        [notifications.extend(activity.notifications) for activity in task_reminder_activities]
+
+        self.assertEqual(2, len(notifications))
+        self.assertItemsEqual(
+            [self.regular_user.getId(), self.dossier_responsible.getId()],
+            [notification.userid for notification in notifications])

--- a/opengever/task/tests/test_reminder.py
+++ b/opengever/task/tests/test_reminder.py
@@ -3,6 +3,7 @@ from opengever.task.reminder import TASK_REMINDER_SAME_DAY
 from opengever.task.reminder import TASK_REMINDER_ONE_DAY_BEFORE
 from opengever.task.reminder import TASK_REMINDER_ONE_WEEK_BEFORE
 from opengever.task.reminder import TASK_REMINDER_BEGINNING_OF_WEEK
+from opengever.task.reminder.reminder import TaskReminder
 from opengever.testing import IntegrationTestCase
 
 
@@ -30,3 +31,92 @@ class TestTaskReminderOptions(IntegrationTestCase):
         self.assertEqual(
             date(2018, 7, 2),  # Monday
             TASK_REMINDER_BEGINNING_OF_WEEK.calculate_remind_on(deadline))
+
+
+class TestTaskReminder(IntegrationTestCase):
+
+    def test_set_reminder_creates_annotation_entry_for_current_user(self):
+        self.login(self.regular_user)
+        task_reminder = TaskReminder()
+        task_reminder.set_reminder(self.task, TASK_REMINDER_ONE_DAY_BEFORE)
+
+        self.assertEqual(
+            TASK_REMINDER_ONE_DAY_BEFORE.option_type,
+            task_reminder.get_reminder(self.task).option_type)
+
+        self.assertIsNone(task_reminder.get_reminder(
+            self.task, user_id=self.dossier_responsible.getId()))
+
+    def test_set_reminder_updates_annotations_entry_if_already_exists(self):
+        self.login(self.regular_user)
+        task_reminder = TaskReminder()
+        task_reminder.set_reminder(self.task, TASK_REMINDER_ONE_DAY_BEFORE)
+        task_reminder.set_reminder(self.task, TASK_REMINDER_ONE_WEEK_BEFORE)
+
+        self.assertEqual(
+            TASK_REMINDER_ONE_WEEK_BEFORE.option_type,
+            task_reminder.get_reminder(self.task).option_type)
+
+    def test_set_reminder_creates_sql_entry_for_current_user(self):
+        self.login(self.regular_user)
+        task_reminder = TaskReminder()
+        task_reminder.set_reminder(self.task, TASK_REMINDER_ONE_DAY_BEFORE)
+
+        reminder = task_reminder.get_sql_reminder(self.task)
+
+        self.assertEqual(
+            TASK_REMINDER_ONE_DAY_BEFORE.option_type,
+            reminder.option_type
+            )
+
+        self.assertEqual(
+            TASK_REMINDER_ONE_DAY_BEFORE.calculate_remind_on(self.task.deadline),
+            reminder.remind_day
+            )
+
+        self.assertIsNone(task_reminder.get_sql_reminder(
+            self.task, user_id=self.dossier_responsible.getId()))
+
+    def test_set_reminder_updates_sql_entry_if_already_exists(self):
+        self.login(self.regular_user)
+        task_reminder = TaskReminder()
+        task_reminder.set_reminder(self.task, TASK_REMINDER_ONE_DAY_BEFORE)
+        task_reminder.set_reminder(self.task, TASK_REMINDER_ONE_WEEK_BEFORE)
+
+        self.assertEqual(
+            TASK_REMINDER_ONE_WEEK_BEFORE.option_type,
+            task_reminder.get_sql_reminder(self.task).option_type)
+
+    def test_clear_reminder_removes_annotation_reminder_for_current_user(self):
+        self.login(self.regular_user)
+        task_reminder = TaskReminder()
+
+        task_reminder.set_reminder(self.task, TASK_REMINDER_ONE_DAY_BEFORE)
+        task_reminder.set_reminder(
+            self.task, TASK_REMINDER_ONE_DAY_BEFORE,
+            user_id=self.dossier_responsible.getId())
+
+        task_reminder.clear_reminder(self.task)
+        self.assertIsNone(task_reminder.get_reminder(self.task))
+
+        self.assertEqual(
+            TASK_REMINDER_ONE_DAY_BEFORE.option_type,
+            task_reminder.get_reminder(
+                self.task, user_id=self.dossier_responsible.getId()).option_type)
+
+    def test_clear_reminder_removes_sql_reminder_for_current_user(self):
+        self.login(self.regular_user)
+        task_reminder = TaskReminder()
+
+        task_reminder.set_reminder(self.task, TASK_REMINDER_ONE_DAY_BEFORE)
+        task_reminder.set_reminder(
+            self.task, TASK_REMINDER_ONE_DAY_BEFORE,
+            user_id=self.dossier_responsible.getId())
+
+        task_reminder.clear_reminder(self.task)
+        self.assertIsNone(task_reminder.get_sql_reminder(self.task))
+
+        self.assertEqual(
+            TASK_REMINDER_ONE_DAY_BEFORE.option_type,
+            task_reminder.get_sql_reminder(
+                self.task, user_id=self.dossier_responsible.getId()).option_type)


### PR DESCRIPTION
Dieser PR implementiert das Objekt `TaskReminder`.

Das Objekt ist verantwortlich für alles, was mit Reminders gemacht wird.

Das ist:

- Hinzufügen eines Reminders für ein Objekt
- Entfernen eines Reminders für ein Objekt
- Aktuellen Reminder für das Ploneobjekt abholen
- Aktuellen Reminder für das SQL Objekt abholen
- Activities und Notifications für Objekte erstellen
- remind_day von allen gesetzten Reminders eines Objektes aktualisieren

issuer: #4205 
based on: https://github.com/4teamwork/opengever.core/pull/4620