### PR TITLE
Doku Anpassungen durch OGIP 36

### DIFF
--- a/docs/public/user-manual/benachrichtigung.rst
+++ b/docs/public/user-manual/benachrichtigung.rst
@@ -1,3 +1,5 @@
+.. _label-benachrichtigungen:
+
 Benachrichtigungs-Einstellungen
 ===============================
 
@@ -29,10 +31,18 @@ Individualisierte Einstellungen können mit der Aktion *Auf Standard zurücksetz
 
 |img-benachrichtigungs-einstellungen-4|
 
+Benachrichtigungen für Weiterleitungen und Anträge
+--------------------------------------------------
+Analog den Benachrichtigungen für Aufgaben, kann in den Tabs *Weiterleitungen*
+sowie *Anträge* die Benachrichtigungen für diese Aktivitäten eingestellt werden.
+
+|img-benachrichtigungs-einstellungen-5|
+
 .. |img-benachrichtigungs-einstellungen-1| image:: img/media/img-benachrichtigungs-einstellungen-1.png
 .. |img-benachrichtigungs-einstellungen-2| image:: img/media/img-benachrichtigungs-einstellungen-2.png
 .. |img-benachrichtigungs-einstellungen-3| image:: img/media/img-benachrichtigungs-einstellungen-3.png
 .. |img-benachrichtigungs-einstellungen-4| image:: img/media/img-benachrichtigungs-einstellungen-4.png
+.. |img-benachrichtigungs-einstellungen-5| image:: img/media/img-benachrichtigungs-einstellungen-5.png
 
 
 .. disqus::

--- a/docs/public/user-manual/img/media/img-benachrichtigungs-einstellungen-5.png
+++ b/docs/public/user-manual/img/media/img-benachrichtigungs-einstellungen-5.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c9a6862d06017004aa3a60a2926ae0e4eb3adb9e692c22c655e328f21e6c7750
+size 70088

--- a/docs/public/user-manual/spv/antrag-erfassen.rst
+++ b/docs/public/user-manual/spv/antrag-erfassen.rst
@@ -25,7 +25,7 @@ Das Feld „Antragssteller“ enthält standardmässig den aktuellen Benutzenden
 Es besteht auch die Möglichkeit, einen anderen Benutzenden des aktuellen
 Mandantden auszuwählen. Damit ist es möglich, Anträge im Namen anderer
 Benutzenden zu erstellen. Dabei ist zu beachten, dass nur jener Benutzende,
-welcher im Feld „Antragssteller“ hinterleget ist, die :ref:`label-antrags-benachrichtigungen` erhält.
+welcher im Feld „Antragssteller“ hinterlegt ist, die :ref:`label-antrags-benachrichtigungen` erhält.
 
 Wenn die Option «Nach dem Hinzufügen bearbeiten» angewählt bleibt
 (Standardeinstellung), wird das Dokument zur weiteren Bearbeitung in Word

--- a/docs/public/user-manual/spv/antrag-erfassen.rst
+++ b/docs/public/user-manual/spv/antrag-erfassen.rst
@@ -21,6 +21,12 @@ bzw. ausgewählt.
 
 |img-spvupdate-10|
 
+Das Feld „Antragssteller“ enthält standardmässig den aktuellen Benutzenden.
+Es besteht auch die Möglichkeit, einen anderen Benutzenden des aktuellen
+Mandantden auszuwählen. Damit ist es möglich, Anträge im Namen anderer
+Benutzenden zu erstellen. Dabei ist zu beachten, dass nur jener Benutzende,
+welcher im Feld „Antragssteller“ hinterleget ist, die :ref:`label-antrags-benachrichtigungen` erhält.
+
 Wenn die Option «Nach dem Hinzufügen bearbeiten» angewählt bleibt
 (Standardeinstellung), wird das Dokument zur weiteren Bearbeitung in Word
 geöffnet.
@@ -40,38 +46,6 @@ eingecheckt werden.
 |img-spvupdate-13|
 |img-spvupdate-14|
 
-Nun wird der Antrag traktandiert über «Einreichen». Der Status des Antrags
-ändert sich von «in Bearbeitung in «Eingereicht».
-
-|img-spvupdate-15|
-
-Mit diesem Vorgehen werden die ordentlichen, vorgängig bekannten Geschäfte für
-die betreffende Sitzung traktandiert oder storniert. Merke: Vor dem Einreichen
-alle Dokumente einchecken.
-
-Wenn alle vorgängig bekannten Anträge traktandiert sind, wird die Sitzung im
-Bereich «Sitzungen» weiterbearbeitet. Konkret liegen drei eingereichte Anträge
-für den Gemeinderat Musterhausen vor.
-
-|img-spvupdate-16|
-
-Die anstehende Sitzung muss nun geöffnet und die Traktanden hinzugefügt werden.
-Eingereichte Anträge werden nicht automatisch auf eine konkrete Sitzung
-traktandiert. Die eingereichten Anträge werden in der konkreten Sitzung
-traktandiert.
-
-|img-spvupdate-17|
-
-Sobald die Anträge traktandiert sind, sind diese in der Übersicht des Gremiums
-nicht mehr ersichtlich.
-
-|img-spvupdate-18|
-
-Anträge, welche nicht den Vorgaben entsprechen können zurückgewiesen werden.
-Sie können die Rückweisung in einem separaten Feld kommentieren.
-
-|img-spvupdate-19|
-
 
 .. |img-spvupdate-8| image:: ../img/media/img-spvupdate-8.png
 .. |img-spvupdate-9| image:: ../img/media/img-spvupdate-9.png
@@ -80,10 +54,6 @@ Sie können die Rückweisung in einem separaten Feld kommentieren.
 .. |img-spvupdate-12| image:: ../img/media/img-spvupdate-12.png
 .. |img-spvupdate-13| image:: ../img/media/img-spvupdate-13.png
 .. |img-spvupdate-14| image:: ../img/media/img-spvupdate-14.png
-.. |img-spvupdate-15| image:: ../img/media/img-spvupdate-15.png
-.. |img-spvupdate-16| image:: ../img/media/img-spvupdate-16.png
-.. |img-spvupdate-17| image:: ../img/media/img-spvupdate-17.png
-.. |img-spvupdate-18| image:: ../img/media/img-spvupdate-18.png
-.. |img-spvupdate-19| image:: ../img/media/img-spvupdate-19.png
+
 
 .. disqus::

--- a/docs/public/user-manual/spv/antrag-traktandieren.rst
+++ b/docs/public/user-manual/spv/antrag-traktandieren.rst
@@ -2,7 +2,7 @@ Antrag traktandieren
 --------------------
 
 Nach der Erfassung des Antrags wird dieser über «Einreichen» ins Gremium
-eingereicht. Der Status des Antrags ändert sich von «in Bearbeitung» in
+eingereicht. Der Status des Antrags ändert sich von «in Bearbeitung» zu
 «Eingereicht».
 
 |img-spvupdate-15|

--- a/docs/public/user-manual/spv/antrag-traktandieren.rst
+++ b/docs/public/user-manual/spv/antrag-traktandieren.rst
@@ -1,0 +1,43 @@
+Antrag traktandieren
+--------------------
+
+Nach der Erfassung des Antrags wird dieser über «Einreichen» ins Gremium
+eingereicht. Der Status des Antrags ändert sich von «in Bearbeitung» in
+«Eingereicht».
+
+|img-spvupdate-15|
+
+Mit diesem Vorgehen werden die ordentlichen, vorgängig bekannten Geschäfte für
+die betreffende Sitzung traktandiert oder storniert. Merke: Vor dem Einreichen
+alle Dokumente einchecken.
+
+Wenn alle vorgängig bekannten Anträge traktandiert sind, wird die Sitzung im
+Bereich «Sitzungen» weiterbearbeitet. Konkret liegen drei eingereichte Anträge
+für den Gemeinderat Musterhausen vor.
+
+|img-spvupdate-16|
+
+Die anstehende Sitzung muss nun geöffnet und die Traktanden hinzugefügt werden.
+Eingereichte Anträge werden nicht automatisch auf eine konkrete Sitzung
+traktandiert. Die eingereichten Anträge werden in der konkreten Sitzung
+traktandiert.
+
+|img-spvupdate-17|
+
+Sobald die Anträge traktandiert sind, sind diese in der Übersicht des Gremiums
+nicht mehr ersichtlich.
+
+|img-spvupdate-18|
+
+Anträge, welche nicht den Vorgaben entsprechen können zurückgewiesen werden.
+Sie können die Rückweisung in einem separaten Feld kommentieren.
+
+|img-spvupdate-19|
+
+.. |img-spvupdate-15| image:: ../img/media/img-spvupdate-15.png
+.. |img-spvupdate-16| image:: ../img/media/img-spvupdate-16.png
+.. |img-spvupdate-17| image:: ../img/media/img-spvupdate-17.png
+.. |img-spvupdate-18| image:: ../img/media/img-spvupdate-18.png
+.. |img-spvupdate-19| image:: ../img/media/img-spvupdate-19.png
+
+.. disqus::

--- a/docs/public/user-manual/spv/antrags-benachrichtigungen.rst
+++ b/docs/public/user-manual/spv/antrags-benachrichtigungen.rst
@@ -27,6 +27,6 @@ Verantwortlichen eines Gremiums ausgelöst:
 
 Diese oben erwähnten Aktionen werden auch in den Benachrichtigungs-Einstellungen
 sichtbar und können von den Benutzern einzeln konfiguriert werden. Mehr
-dazu können Sie unter :ref:`label-benachrichtigungen`nachlesen .
+dazu können Sie unter :ref:`label-benachrichtigungen` nachlesen .
 
 .. disqus::

--- a/docs/public/user-manual/spv/antrags-benachrichtigungen.rst
+++ b/docs/public/user-manual/spv/antrags-benachrichtigungen.rst
@@ -22,10 +22,11 @@ Verantwortlichen eines Gremiums ausgelöst:
 
 -   Neuer Antrag eingereicht
 -   Eingereichter Antrag kommentiert
--   Anhänge eingereichter Antrag aktualisiert
+-   Neue Anhänge eingereicht
+-   Bestehende Anhänge aktualisiert
 
 Diese oben erwähnten Aktionen werden auch in den Benachrichtigungs-Einstellungen
 sichtbar und können von den Benutzern einzeln konfiguriert werden. Mehr
-dazu können Sie hier nachlesen: :ref:`label-benachrichtigungen`.
+dazu können Sie unter :ref:`label-benachrichtigungen`nachlesen .
 
 .. disqus::

--- a/docs/public/user-manual/spv/antrags-benachrichtigungen.rst
+++ b/docs/public/user-manual/spv/antrags-benachrichtigungen.rst
@@ -1,0 +1,31 @@
+.. _label-antrags-benachrichtigungen:
+
+Antrags-Benachrichtigungen
+--------------------------
+
+Die im Feld "Antragssteller" hinterlegte Person erhält bei folgenden Aktionen
+eine Benachrichtigung:
+
+- 	Antrag zurückgewiesen
+- 	Antrag traktandiert
+- 	Protokollauszug an Antragssteller/Antragsdossier zurückgesendet
+- 	Antrag kommentiert
+
+Weiter gilt es zu beachten, dass zur Erstellung von Anträgen zwischen
+Antragssteller und Gremienverantwortlichen unterschieden wird.
+Gremienverantwortliche werden durch eine LDAP-Gruppe definiert. Diese kann auf
+jedem Gremium über das Feld Gremien-Verantwortlich festgelegt werden. Der
+Antragssteller entsprich dem Benutzenden, der den Antrag erstellt hat.
+
+Bei folgenden Aktionen wird eine Benachrichtigung an die
+Verantwortlichen eines Gremiums ausgelöst:
+
+-   Neuer Antrag eingereicht
+-   Eingereichter Antrag kommentiert
+-   Anhänge eingereichter Antrag aktualisiert
+
+Diese oben erwähnten Aktionen werden auch in den Benachrichtigungs-Einstellungen
+sichtbar und können von den Benutzern einzeln konfiguriert werden. Mehr
+dazu können Sie hier nachlesen: :ref:`label-benachrichtigungen`.
+
+.. disqus::

--- a/docs/public/user-manual/spv/index.rst
+++ b/docs/public/user-manual/spv/index.rst
@@ -16,6 +16,8 @@ können Sie in den untenstehenden Kapiteln nachlesen.
    :maxdepth: 2
 
    antrag-erfassen
+   antrag-traktandieren
+   antrags-benachrichtigungen
    kommission_gremium_erfassen
    sitzung-vorbereiten
    sitzung-durchfuehren


### PR DESCRIPTION
@phgross  ein Printscreen mit dem Feld "Antragssteller" fehlt noch. Möchte diesen dann auf spv.onegovgever machen, damit es zu den restlichen Screens passt. 