### PR TITLE
Create initial version with the original document creator as the principal

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2018.4.0 (unreleased)
 ---------------------
 
+- Create initial version with the original document creator as the principal. [lgraf]
 - Add REST API endpoint for creating bumblebee sessions. [buchi]
 - Bump ftw.casauth to 1.2.0 which provides a `@caslogin` endpoint. [buchi]
 - Customize `@navigation` endpoint to return repository tree. [buchi]

--- a/opengever/base/security.py
+++ b/opengever/base/security.py
@@ -21,8 +21,12 @@ class UnrestrictedUser(BaseUnrestrictedUser):
 
 
 @contextmanager
-def elevated_privileges():
+def elevated_privileges(user_id=None):
     """Temporarily elevate current user's privileges.
+
+    If the `user_id` argument is set, it will be user as the ID of the
+    temporary user with elevated_privileges, otherwise the current user's ID
+    will be used.
 
     See http://docs.plone.org/develop/plone/security/permissions.html#bypassing-permission-checks
     for more documentation on this code.
@@ -34,9 +38,10 @@ def elevated_privileges():
         # Note that the username (getId()) is left in exception
         # tracebacks in the error_log,
         # so it is an important thing to store.
-        tmp_user = UnrestrictedUser(
-            api.user.get_current().getId(), '', ('manage', 'Manager'), ''
-            )
+        if user_id is None:
+            user_id = api.user.get_current().getId()
+
+        tmp_user = UnrestrictedUser(user_id, '', ('manage', 'Manager'), '')
 
         # Wrap the user in the acquisition context of the portal
         tmp_user = tmp_user.__of__(api.portal.get().acl_users)

--- a/opengever/base/tests/test_security.py
+++ b/opengever/base/tests/test_security.py
@@ -15,9 +15,8 @@ class TestSecurity(FunctionalTestCase):
         self.assertNotIn('manage', api.user.get_current().getRoles())
 
         with elevated_privileges():
-            current_user = api.user.get_current()
-            self.assertEqual(TEST_USER_ID, current_user.getId())
-            self.assertIn('manage', current_user.getRoles())
+            self.assertEqual(TEST_USER_ID, api.user.get_current().getId())
+            self.assertIn('manage', api.user.get_current().getRoles())
 
         self.assertNotIn('manage', api.user.get_current().getRoles())
-        self.assertEqual(TEST_USER_ID, current_user.getId())
+        self.assertEqual(TEST_USER_ID, api.user.get_current().getId())

--- a/opengever/base/tests/test_security.py
+++ b/opengever/base/tests/test_security.py
@@ -1,22 +1,19 @@
 from opengever.base.security import elevated_privileges
-from opengever.testing import FunctionalTestCase
+from opengever.testing import IntegrationTestCase
 from plone import api
-from plone.app.testing import TEST_USER_ID
 
 
-class TestSecurity(FunctionalTestCase):
-
-    def setUp(self):
-        super(TestSecurity, self).setUp()
-        self.test_user = api.user.get(userid=TEST_USER_ID)
+class TestSecurity(IntegrationTestCase):
 
     def test_elevated_privileges_sets_priviledged_user_and_restores_old(self):
-        self.assertEqual(TEST_USER_ID, api.user.get_current().getId())
+        self.login(self.regular_user)
+
+        self.assertEqual('kathi.barfuss', api.user.get_current().getId())
         self.assertNotIn('manage', api.user.get_current().getRoles())
 
         with elevated_privileges():
-            self.assertEqual(TEST_USER_ID, api.user.get_current().getId())
+            self.assertEqual('kathi.barfuss', api.user.get_current().getId())
             self.assertIn('manage', api.user.get_current().getRoles())
 
         self.assertNotIn('manage', api.user.get_current().getRoles())
-        self.assertEqual(TEST_USER_ID, api.user.get_current().getId())
+        self.assertEqual('kathi.barfuss', api.user.get_current().getId())

--- a/opengever/base/tests/test_security.py
+++ b/opengever/base/tests/test_security.py
@@ -17,3 +17,16 @@ class TestSecurity(IntegrationTestCase):
 
         self.assertNotIn('manage', api.user.get_current().getRoles())
         self.assertEqual('kathi.barfuss', api.user.get_current().getId())
+
+    def test_elevated_privileges_allows_custom_user_id(self):
+        self.login(self.regular_user)
+
+        self.assertEqual('kathi.barfuss', api.user.get_current().getId())
+        self.assertNotIn('manage', api.user.get_current().getRoles())
+
+        with elevated_privileges(user_id='peter'):
+            self.assertEqual('peter', api.user.get_current().getId())
+            self.assertIn('manage', api.user.get_current().getRoles())
+
+        self.assertNotIn('manage', api.user.get_current().getRoles())
+        self.assertEqual('kathi.barfuss', api.user.get_current().getId())

--- a/opengever/document/browser/versions_tab.py
+++ b/opengever/document/browser/versions_tab.py
@@ -101,6 +101,10 @@ class VersionDataProxy(object):
     def actor(self):
         """Returns a formatted link to the actor that created this version.
         """
+        if self.version == 0:
+            # Always return document's original creator for initial version
+            return Actor.user(self._context.Creator()).get_link()
+
         principal = self.sys_metadata['principal']
         actor = Actor.user(principal)
         return actor.get_link()

--- a/opengever/document/tests/test_versioner.py
+++ b/opengever/document/tests/test_versioner.py
@@ -53,6 +53,30 @@ class TestInitialVersionCreation(IntegrationTestCase):
             datetime.fromtimestamp(version.sys_metadata.get('timestamp')))
 
     @browsing
+    def test_initial_version_principal_is_documents_original_creator(self, browser):
+        self.login(self.regular_user)
+
+        # Guard assertion to make sure creatore of the fixture-document is
+        # what we expect it to be.
+        self.assertEqual('robert.ziegler', self.document.Creator())
+
+        self.document.file = NamedBlobFile(data='New', filename=u'test.txt')
+
+        versioner = Versioner(self.document)
+        versioner.create_version(comment='')
+
+        initial_version_md = versioner.get_version_metadata(0)
+        first_version_md = versioner.get_version_metadata(1)
+
+        self.assertEqual(
+            'robert.ziegler',
+            initial_version_md['sys_metadata']['principal'])
+
+        self.assertEqual(
+            'kathi.barfuss',
+            first_version_md['sys_metadata']['principal'])
+
+    @browsing
     def test_updating_a_document_via_webdav_creates_initial_version_too(self, browser):
         self.login(self.regular_user)
 
@@ -89,5 +113,5 @@ class TestInitialVersionCreation(IntegrationTestCase):
         self.document.file = NamedBlobFile(data='New', filename=u'test.txt')
         sys_metadata = versioner.get_version_metadata(0).get('sys_metadata')
         self.assertEqual(u'custom initial version', sys_metadata.get('comment'))
-        self.assertEqual('kathi.barfuss', sys_metadata.get('principal'))
+        self.assertEqual('robert.ziegler', sys_metadata.get('principal'))
         self.assertEqual('document-state-draft', sys_metadata.get('review_state'))

--- a/opengever/document/tests/test_versions_tab.py
+++ b/opengever/document/tests/test_versions_tab.py
@@ -111,6 +111,22 @@ class TestVersionsTab(BaseVersionsTab):
                           actor_link.attrib['href'])
 
     @browsing
+    def test_lists_original_creator_as_actor_for_initial_version(self, browser):
+        create(Builder('ogds_user')
+               .id('original-document-creator')
+               .having(firstname=u'Firstname', lastname=u'Lastname'))
+        self.document.creators = ('original-document-creator', )
+        transaction.commit()
+
+        browser.login().open(self.document, view='tabbedview_view-versions')
+        listing = browser.css('.listing').first
+        last_row = listing.css('tr')[-1]
+        actor_link = last_row.css('td a').first
+
+        self.assertEquals(
+            'Lastname Firstname (original-document-creator)', actor_link.text)
+
+    @browsing
     def test_revert_link_is_properly_constructed(self, browser):
         browser.login().open(self.document,
                              view='tabbedview_view-versions')


### PR DESCRIPTION
With the **deferred creation of the initial version** (introduced in #3467), the initial version will only be created once a second version is actually created. That may happen in the security context of a different user that initially created the document.

Because CMFEditions always sets the ID of the currently logged in user as `sys_metadata['principal']`, this leads to incorrect authorship attribution for this case.

We therefore create the initial version with a security context that assumes the user ID of the document's initial creator to make sure the 'principal' in the initial version's authorship metadata is correct.

I also changed the version tab so it always lists the document's original creator for version 0 - irrespective of whether that's an actual initial version (case described above) or a fake initial version (one that hasn't been created yet), for which we already did this anyway.

This means that for existing documents with incorrect principal for version 0, we solve the problem on the display layer - so it's not necessary to migrate existing version metadata via ZVC storage internals, which would be convoluted and pretty risky.