### PR TITLE
Add role assignments management view.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -9,6 +9,7 @@ Changelog
 - Bump ftw.upgrade for deferrable upgrade support. [deiferni]
 - Create initial version with the original document creator as the principal. [lgraf]
 - Improve usability of proposal add form. [elioschmutz]
+- Add role assignments management view. [phgross]
 - Add REST API endpoint for creating bumblebee sessions. [buchi]
 - Bump ftw.casauth to 1.2.0 which provides a `@caslogin` endpoint. [buchi]
 - Customize `@navigation` endpoint to return repository tree. [buchi]

--- a/opengever/base/browser/configure.zcml
+++ b/opengever/base/browser/configure.zcml
@@ -217,4 +217,11 @@
       permission="cmf.ManagePortal"
       />
 
+  <browser:page
+      for="*"
+      name="manage-role-assignments"
+      class=".manage_role_assignments.ManageRoleAssignmentsView"
+      permission="cmf.ManagePortal"
+      />
+
 </configure>

--- a/opengever/base/browser/manage_role_assignments.py
+++ b/opengever/base/browser/manage_role_assignments.py
@@ -1,0 +1,19 @@
+from opengever.base.role_assignments import RoleAssignment
+from opengever.base.role_assignments import RoleAssignmentManager
+from Products.Five.browser import BrowserView
+import json
+
+
+class ManageRoleAssignmentsView(BrowserView):
+
+    def __call__(self):
+        response = self.request.response
+        response.setHeader('Content-Type', 'application/json')
+        response.setHeader('X-Theme-Disabled', 'True')
+
+        manager = RoleAssignmentManager(self.context)
+        assignments = [RoleAssignment.get(**data)
+                       for data in manager.storage._storage()]
+
+        return json.dumps(
+            [assignment.serialize() for assignment in assignments])


### PR DESCRIPTION
Because the ZMI's manage_access view, is no longer the alone source of
truth, I added a management view which returns all the existing
assignments for the current context. The view is only accessible for managers.