### PR TITLE
Add feature to generate a pdf listing the tasks when resolving a dossier.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2018.5.0 (unreleased)
 ---------------------
 
+- Add feature to generate a task listing pdf when resolving a dossier. [njohner]
 - Set adhoc agendaitem filename to title without prefixing it. [njohner]
 - Disallow dossier from template when adding businesscasedossier is disallowed. [njohner]
 - Change wording for "Return Excerpt" from "zurücksenden" to "ablegen". [njohner]

--- a/docs/public/dev-manual/api/config.rst
+++ b/docs/public/dev-manual/api/config.rst
@@ -33,6 +33,7 @@ GEVER-Mandanten abgefragt werden.
               "ech0147_import": true,
               "favorites": true,
               "journal_pdf": false,
+              "tasks_pdf": false,
               "meetings": true,
               "officeatwork": true,
               "officeconnector_attach": true,

--- a/opengever/api/tests/test_config.py
+++ b/opengever/api/tests/test_config.py
@@ -59,6 +59,7 @@ class TestConfig(IntegrationTestCase):
                 u'resolver_name': u'strict',
                 u'sablon_date_format': u'%d.%m.%Y',
                 u'solr': False,
+                u'tasks_pdf': False,
                 u'workspace': False,
             })
 

--- a/opengever/base/configuration.py
+++ b/opengever/base/configuration.py
@@ -73,6 +73,7 @@ class GeverSettingsAdpaterV1(object):
         features['gever_ui_enabled'] = api.portal.get_registry_record('is_feature_enabled', interface=IGeverUI)
         features['gever_ui_path'] = api.portal.get_registry_record('path', interface=IGeverUI)
         features['journal_pdf'] = api.portal.get_registry_record('journal_pdf_enabled', interface=IDossierResolveProperties)
+        features['tasks_pdf'] = api.portal.get_registry_record('tasks_pdf_enabled', interface=IDossierResolveProperties)
         features['meetings'] = api.portal.get_registry_record('is_feature_enabled', interface=IMeetingSettings)
         features['officeatwork'] = api.portal.get_registry_record('is_feature_enabled', interface=IOfficeatworkSettings)
         features['officeconnector_attach'] = api.portal.get_registry_record('attach_to_outlook_enabled', interface=IOfficeConnectorSettings)  # noqa

--- a/opengever/base/tests/test_configuration_adapter.py
+++ b/opengever/base/tests/test_configuration_adapter.py
@@ -24,6 +24,7 @@ class TestConfigurationAdapter(IntegrationTestCase):
                 ('gever_ui_enabled', False),
                 ('gever_ui_path', 'http://localhost:8081/#/'),
                 ('journal_pdf', False),
+                ('tasks_pdf', False),
                 ('meetings', False),
                 ('officeatwork', False),
                 ('officeconnector_attach', False),

--- a/opengever/core/upgrades/20180720162842_add_task_pdf_enabled_dossier_resolve_property/registry.xml
+++ b/opengever/core/upgrades/20180720162842_add_task_pdf_enabled_dossier_resolve_property/registry.xml
@@ -1,0 +1,3 @@
+<registry purge="False">
+  <records interface="opengever.dossier.interfaces.IDossierResolveProperties" />
+</registry>

--- a/opengever/core/upgrades/20180720162842_add_task_pdf_enabled_dossier_resolve_property/upgrade.py
+++ b/opengever/core/upgrades/20180720162842_add_task_pdf_enabled_dossier_resolve_property/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddTaskPdfEnabledDossierResolveProperty(UpgradeStep):
+    """Add task pdf enabled dossier resolve property.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/document/document.py
+++ b/opengever/document/document.py
@@ -306,7 +306,8 @@ class Document(Item, BaseDocumentMixin):
         """Return the current document history version."""
         return Versioner(self).get_current_version_id(missing_as_zero)
 
-    def update_file(self, data, content_type=None, filename=None):
+    def update_file(self, data, content_type=None, filename=None,
+                    create_version=False, comment=''):
         content_type = content_type or self.file.contentType
         filename = filename or self.file.filename
 
@@ -314,6 +315,9 @@ class Document(Item, BaseDocumentMixin):
             data=data,
             filename=filename,
             contentType=content_type)
+        if create_version:
+            Versioner(self).create_version(comment)
+        self.setModificationDate()
         self.reindexObject()
 
     def has_file(self):

--- a/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
@@ -288,7 +288,7 @@ msgstr "Document créé (version initiale)"
 #. Default: "Changed by"
 #: ./opengever/document/browser/versions_tab.py
 msgid "label_actor"
-msgstr "Modifier par"
+msgstr "Modifié par"
 
 #. Default: "Archival File"
 #: ./opengever/document/behaviors/metadata.py

--- a/opengever/dossier/interfaces.py
+++ b/opengever/dossier/interfaces.py
@@ -228,3 +228,11 @@ class IDossierResolveProperties(Interface):
         vocabulary=u'opengever.dossier.ValidResolverNamesVocabulary',
         default='strict'
     )
+
+
+class IDossierTasksPdfMarker(Interface):
+    """Marker Interface for dossier tasks list document."""
+
+
+class IDossierJournalPdfMarker(Interface):
+    """Marker Interface for dossier journal document."""

--- a/opengever/dossier/interfaces.py
+++ b/opengever/dossier/interfaces.py
@@ -211,6 +211,12 @@ class IDossierResolveProperties(Interface):
         'should be added automatically to the dossier when it gets resolved.',
         default=False)
 
+    tasks_pdf_enabled = schema.Bool(
+        title=u'Enable `tasks pdf` option.',
+        description=u'Select if a pdf representation of the tasks in the dossier '
+        'should be added automatically to the dossier when it gets resolved.',
+        default=False)
+
     archival_file_conversion_enabled = schema.Bool(
         title=u'Enable automatic archival file conversion with bumblebee.',
         description=u'Select if GEVER should trigger the archival file '

--- a/opengever/dossier/locales/de/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/de/LC_MESSAGES/opengever.dossier.po
@@ -909,6 +909,11 @@ msgstr "abgelaufen"
 msgid "title_dossier_journal"
 msgstr "Dossier Journal ${title}, ${timestamp}"
 
+#. Default: "Task list of dossier ${title}, ${timestamp}"
+#: ./opengever/dossier/resolve.py
+msgid "title_dossier_tasks"
+msgstr "Aufgabenliste des Dossiers ${title}, ${timestamp}"
+
 #. Default: "You didn't select any participants."
 #: ./opengever/dossier/browser/forms.py
 msgid "warning_no_participants_selected"

--- a/opengever/dossier/locales/de/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/de/LC_MESSAGES/opengever.dossier.po
@@ -207,6 +207,10 @@ msgstr "Das Subdossier wurde erfolgreich abgeschlossen."
 msgid "This subdossier can't be activated,because the main dossiers is inactive"
 msgstr "Dieses Subdossier kann nicht wieder aktiviert werden, da das Hauptdossier storniert ist."
 
+#: ./opengever/dossier/resolve.py
+msgid "Updated with a newer generated version from dossier ${title}."
+msgstr "Mit einer neuen Version des Dossiers ${title} aktualisiert."
+
 #: ./opengever/dossier/archive.py
 msgid "When the Action give filing number is selected,                         all fields are required."
 msgstr "Für die Vergabe der Ablagenummer, werden alle Felder benötigt."

--- a/opengever/dossier/locales/fr/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/fr/LC_MESSAGES/opengever.dossier.po
@@ -205,6 +205,10 @@ msgstr "Le sous-dossier a été clôturé avec succès."
 msgid "This subdossier can't be activated,because the main dossiers is inactive"
 msgstr "Ce sous-dossier ne peut pas être réactivé, parce que le dossier principal a été annulé."
 
+#: ./opengever/dossier/resolve.py
+msgid "Updated with a newer generated version from dossier ${title}."
+msgstr "Actualisé par une nouvelle version du dossier ${title}."
+
 #: ./opengever/dossier/archive.py
 msgid "When the Action give filing number is selected,                         all fields are required."
 msgstr "Pour l'attribution du numéro d'inventaire, tous les champs sont obligatoires."

--- a/opengever/dossier/locales/fr/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/fr/LC_MESSAGES/opengever.dossier.po
@@ -907,6 +907,11 @@ msgstr "Périmé"
 msgid "title_dossier_journal"
 msgstr "Journal du dossier ${title}, ${timestamp}"
 
+#. Default: "Task list of dossier ${title}, ${timestamp}"
+#: ./opengever/dossier/resolve.py
+msgid "title_dossier_tasks"
+msgstr "Liste des tâches du dossier ${title}, ${timestamp}"
+
 #. Default: "You didn't select any participants."
 #: ./opengever/dossier/browser/forms.py
 msgid "warning_no_participants_selected"

--- a/opengever/dossier/locales/opengever.dossier.pot
+++ b/opengever/dossier/locales/opengever.dossier.pot
@@ -908,6 +908,11 @@ msgstr ""
 msgid "title_dossier_journal"
 msgstr ""
 
+#. Default: "Task list of dossier ${title}, ${timestamp}"
+#: ./opengever/dossier/resolve.py
+msgid "title_dossier_tasks"
+msgstr ""
+
 #. Default: "You didn't select any participants."
 #: ./opengever/dossier/browser/forms.py
 msgid "warning_no_participants_selected"

--- a/opengever/dossier/locales/opengever.dossier.pot
+++ b/opengever/dossier/locales/opengever.dossier.pot
@@ -206,6 +206,10 @@ msgstr ""
 msgid "This subdossier can't be activated,because the main dossiers is inactive"
 msgstr ""
 
+#: ./opengever/dossier/resolve.py
+msgid "Updated with a newer generated version from dossier ${title}."
+msgstr ""
+
 #: ./opengever/dossier/archive.py
 msgid "When the Action give filing number is selected,                         all fields are required."
 msgstr ""

--- a/opengever/dossier/resolve.py
+++ b/opengever/dossier/resolve.py
@@ -3,6 +3,7 @@ from opengever.base.command import CreateDocumentCommand
 from opengever.base.security import elevated_privileges
 from opengever.document.archival_file import ArchivalFileConverter
 from opengever.document.behaviors import IBaseDocument
+from opengever.document.versioner import Versioner
 from opengever.dossier import _
 from opengever.dossier.base import DOSSIER_STATES_OPEN
 from opengever.dossier.behaviors.dossier import IDossier
@@ -10,6 +11,8 @@ from opengever.dossier.behaviors.dossier import IDossierMarker
 from opengever.dossier.behaviors.filing import IFilingNumberMarker
 from opengever.dossier.interfaces import IDossierResolveProperties
 from opengever.dossier.interfaces import IDossierResolver
+from opengever.dossier.interfaces import IDossierJournalPdfMarker
+from opengever.dossier.interfaces import IDossierTasksPdfMarker
 from plone import api
 from Products.CMFCore.utils import getToolByName
 from Products.Five.browser import BrowserView
@@ -17,6 +20,7 @@ from zope.component import adapter
 from zope.component import getAdapter
 from zope.component import getSiteManager
 from zope.i18n import translate
+from zope.interface import alsoProvides
 from zope.interface import implementer
 from zope.interface import implements
 from zope.schema.interfaces import IVocabularyFactory
@@ -247,12 +251,26 @@ class StrictDossierResolver(object):
         if dossier and dossier.end:
             kwargs['document_date'] = dossier.end
 
+        results = api.content.find(object_provides=IDossierJournalPdfMarker,
+                                   depth=1,
+                                   context=self.context)
+
         with elevated_privileges():
-            CreateDocumentCommand(
-                self.context, filename, view.get_data(),
-                title=translate(title, context=self.context.REQUEST),
-                content_type='application/pdf',
-                **kwargs).execute()
+            if len(results) > 0:
+                document = results[0].getObject()
+                document.title = translate(title, context=self.context.REQUEST)
+                comment = _(u'Updated with a newer generated version from dossier ${title}.',
+                            mapping=dict(title=self.context.title))
+                document.update_file(view.get_data(), create_version=True,
+                                     comment=comment)
+                return
+
+            document = CreateDocumentCommand(
+                        self.context, filename, view.get_data(),
+                        title=translate(title, context=self.context.REQUEST),
+                        content_type='application/pdf',
+                        **kwargs).execute()
+            alsoProvides(document, IDossierJournalPdfMarker)
 
     def create_tasks_listing_pdf(self):
         """Creates a pdf representation of the dossier tasks, and add it to
@@ -266,6 +284,7 @@ class StrictDossierResolver(object):
             return
 
         view = self.context.unrestrictedTraverse('pdf-dossier-tasks')
+
         today = api.portal.get_localized_time(
             datetime=datetime.today(), long_format=True)
         filename = u'Tasks {}.pdf'.format(today)
@@ -280,12 +299,26 @@ class StrictDossierResolver(object):
         if dossier and dossier.end:
             kwargs['document_date'] = dossier.end
 
+        results = api.content.find(object_provides=IDossierTasksPdfMarker,
+                                   depth=1,
+                                   context=self.context)
+
         with elevated_privileges():
-            CreateDocumentCommand(
-                self.context, filename, view.get_data(),
-                title=translate(title, context=self.context.REQUEST),
-                content_type='application/pdf',
-                **kwargs).execute()
+            if len(results) > 0:
+                document = results[0].getObject()
+                document.title = translate(title, context=self.context.REQUEST)
+                comment = _(u'Updated with a newer generated version from dossier ${title}.',
+                            mapping=dict(title=self.context.title))
+                document.update_file(view.get_data(), create_version=True,
+                                     comment=comment)
+                return
+
+            document = CreateDocumentCommand(
+                        self.context, filename, view.get_data(),
+                        title=translate(title, context=self.context.REQUEST),
+                        content_type='application/pdf',
+                        **kwargs).execute()
+            alsoProvides(document, IDossierTasksPdfMarker)
 
     def trigger_pdf_conversion(self):
         if not self.get_property('archival_file_conversion_enabled'):

--- a/opengever/dossier/tests/test_resolve.py
+++ b/opengever/dossier/tests/test_resolve.py
@@ -197,7 +197,66 @@ class TestResolveJobs(IntegrationTestCase):
                          "Document date should be earliest possible date")
 
     @browsing
-    def test_journal_pdf_is_disabled_by_default(self, browser):
+    def test_adds_tasks_pdf_only_to_main_dossier(self, browser):
+        self.activate_feature('tasks-pdf')
+        self.login(self.secretariat_user, browser)
+
+        subdossier = create(Builder('dossier')
+                            .within(self.empty_dossier)
+                            .titled(u'Sub'))
+
+        with self.observe_children(self.empty_dossier) as main_children:
+            with self.observe_children(subdossier) as sub_children:
+                with freeze(datetime(2016, 4, 25)):
+                    resolve_dossier(self.empty_dossier, browser)
+
+        self.assertEquals(1, len(main_children['added']))
+        main_tasks_pdf, = main_children['added']
+        self.assertEquals(u'Task list of dossier An empty dossier, Apr 25, 2016 12:00 AM',
+                          main_tasks_pdf.title)
+        self.assertEquals(u'Task list of dossier An empty dossier, Apr 25, 2016 12 00 AM.pdf',
+                          main_tasks_pdf.file.filename)
+        self.assertEquals(u'application/pdf',
+                          main_tasks_pdf.file.contentType)
+        self.assertFalse(main_tasks_pdf.preserved_as_paper)
+
+        self.assertEquals(0, len(sub_children['added']))
+
+    @browsing
+    def test_sets_tasks_pdf_document_date_to_dossier_end_date(self, browser):
+        """When the document date is not set to the dossiers end date the
+        subdossier will be left in an inconsistent state. this will make
+        resolving the main dossier impossible.
+        """
+        self.activate_feature('tasks-pdf')
+        self.login(self.secretariat_user, browser)
+
+        subdossier = create(Builder('dossier')
+                            .within(self.empty_dossier)
+                            .having(
+                                start=date(2016, 1, 1),
+                                end=date(2016, 3, 15))
+                            .titled(u'Sub'))
+
+        with self.observe_children(subdossier) as sub_children:
+            with freeze(datetime(2016, 4, 25)):
+                resolve_dossier(subdossier, browser)
+
+        self.assertEquals(0, len(sub_children['added']))
+
+        with self.observe_children(self.empty_dossier) as main_children:
+            with freeze(datetime(2016, 9, 1)):
+                resolve_dossier(self.empty_dossier, browser)
+
+        self.assertEquals(1, len(main_children['added']))
+        main_tasks_pdf, = main_children['added']
+        self.assertEqual(date(2016, 3, 15), IDossier(self.empty_dossier).end,
+                         "End should be earliest possible date")
+        self.assertEqual(date(2016, 3, 15), main_tasks_pdf.document_date,
+                         "Document date should be earliest possible date")
+
+    @browsing
+    def test_tasks_and_journal_pdf_are_disabled_by_default(self, browser):
         self.login(self.secretariat_user, browser)
 
         with self.observe_children(self.empty_dossier) as children:

--- a/opengever/dossier/tests/test_resolve.py
+++ b/opengever/dossier/tests/test_resolve.py
@@ -197,6 +197,24 @@ class TestResolveJobs(IntegrationTestCase):
                          "Document date should be earliest possible date")
 
     @browsing
+    def test_journal_pdf_gets_updated_when_dossier_is_closed_again(self, browser):
+        self.activate_feature('journal-pdf')
+        self.login(self.secretariat_user, browser)
+
+        with self.observe_children(self.empty_dossier) as children:
+            resolve_dossier(self.empty_dossier, browser)
+        self.assertEquals(1, len(children['added']))
+        journal_pdf, = children['added']
+        journal_pdf.reindexObject()
+        self.assertEquals(0, journal_pdf.get_current_version_id(missing_as_zero=True))
+
+        browser.open(self.empty_dossier, view='transition-reactivate', data={'_authenticator': createToken()})
+        with self.observe_children(self.empty_dossier) as children:
+            resolve_dossier(self.empty_dossier, browser)
+        self.assertEquals(0, len(children['added']))
+        self.assertEquals(1, journal_pdf.get_current_version_id(missing_as_zero=True))
+
+    @browsing
     def test_adds_tasks_pdf_only_to_main_dossier(self, browser):
         self.activate_feature('tasks-pdf')
         self.login(self.secretariat_user, browser)
@@ -254,6 +272,24 @@ class TestResolveJobs(IntegrationTestCase):
                          "End should be earliest possible date")
         self.assertEqual(date(2016, 3, 15), main_tasks_pdf.document_date,
                          "Document date should be earliest possible date")
+
+    @browsing
+    def test_tasks_pdf_gets_updated_when_dossier_is_closed_again(self, browser):
+        self.activate_feature('tasks-pdf')
+        self.login(self.secretariat_user, browser)
+
+        with self.observe_children(self.empty_dossier) as children:
+            resolve_dossier(self.empty_dossier, browser)
+        self.assertEquals(1, len(children['added']))
+        tasks_pdf, = children['added']
+        tasks_pdf.reindexObject()
+        self.assertEquals(0, tasks_pdf.get_current_version_id(missing_as_zero=True))
+
+        browser.open(self.empty_dossier, view='transition-reactivate', data={'_authenticator': createToken()})
+        with self.observe_children(self.empty_dossier) as children:
+            resolve_dossier(self.empty_dossier, browser)
+        self.assertEquals(0, len(children['added']))
+        self.assertEquals(1, tasks_pdf.get_current_version_id(missing_as_zero=True))
 
     @browsing
     def test_tasks_and_journal_pdf_are_disabled_by_default(self, browser):

--- a/opengever/latex/configure.zcml
+++ b/opengever/latex/configure.zcml
@@ -41,6 +41,11 @@
       />
 
   <adapter
+      factory=".listing.TaskHistoryLaTeXListing"
+      name="task-history"
+      />
+
+  <adapter
       factory=".listing.JournalLaTeXListing"
       name="journal"
       />
@@ -78,6 +83,18 @@
       for="*"
       name="pdf-dossier-journal"
       class=".dossierjournal.DossierJournalPDFView"
+      permission="zope2.View"
+      />
+
+  <adapter
+      factory=".dossiertasks.DossierTasksLaTeXView"
+      provides="ftw.pdfgenerator.interfaces.ILaTeXView"
+      />
+
+  <browser:page
+      for="*"
+      name="pdf-dossier-tasks"
+      class=".dossiertasks.DossierTasksPDFView"
       permission="zope2.View"
       />
 

--- a/opengever/latex/dossierdetails.py
+++ b/opengever/latex/dossierdetails.py
@@ -264,7 +264,7 @@ class DossierDetailsLaTeXView(MakoLaTeXView):
         return sort_on, sort_order
 
     def convert_list(self, items):
-        """Returns a new list, containing all values in `items` convertend
+        """Returns a new list, containing all values in `items` converted
         into LaTeX.
         """
         data = []

--- a/opengever/latex/dossiertasks.py
+++ b/opengever/latex/dossiertasks.py
@@ -1,0 +1,97 @@
+from contextlib import contextmanager
+from ftw.pdfgenerator.browser.views import ExportPDFView
+from ftw.pdfgenerator.interfaces import ILaTeXLayout
+from ftw.pdfgenerator.interfaces import IPDFAssembler
+from ftw.pdfgenerator.utils import provide_request_layer
+from ftw.pdfgenerator.view import MakoLaTeXView
+from opengever.latex import _
+from opengever.latex.listing import ILaTexListing
+from opengever.task.adapters import IResponseContainer
+from opengever.task.task import ITask
+from plone import api
+from zope.component import adapter
+from zope.component import getMultiAdapter
+from zope.i18n import translate
+from zope.interface import Interface
+from zope.interface import noLongerProvides
+
+
+class IDossierTasksLayer(Interface):
+    """Request layer for selecting the dossier tasks view.
+    """
+
+
+@contextmanager
+def provide_dossier_task_layer(request):
+    try:
+        provide_request_layer(request, IDossierTasksLayer)
+        yield
+    finally:
+        noLongerProvides(request, IDossierTasksLayer)
+
+
+class DossierTasksPDFView(ExportPDFView):
+
+    def __call__(self):
+        # Enable IDossierTasksLayer
+        with provide_dossier_task_layer(self.request):
+            return super(DossierTasksPDFView, self).__call__()
+
+    def get_data(self):
+        # let the request provide IDossierTasksLayer
+        with provide_dossier_task_layer(self.request):
+            assembler = getMultiAdapter((self.context, self.request),
+                                        IPDFAssembler)
+            return assembler.build_pdf()
+
+
+@adapter(Interface, IDossierTasksLayer, ILaTeXLayout)
+class DossierTasksLaTeXView(MakoLaTeXView):
+
+    template_directories = ['templates']
+    template_name = 'dossiertasks.tex'
+    strftimestring = '%d.%m.%Y %H:%M'
+
+    def get_render_arguments(self):
+        self.layout.show_organisation = True
+
+        tasks = self.get_tasks()
+        task_data_list = []
+        title = translate(_('label_dossier_tasks',
+                            default=u'Task list for dossier ${title} (${reference_number})',
+                          mapping={'title': self.context.title,
+                                   'reference_number': self.context.get_reference_number()}),
+                          context=self.request)
+
+        for task in tasks:
+            task_history = getMultiAdapter((task, self.request, self),
+                                           ILaTexListing, name='task-history')
+
+            response_container = IResponseContainer(task)
+
+            completion_date = task.date_of_completion
+            if completion_date:
+                completion_date = completion_date.strftime(self.strftimestring)
+
+            deadline = task.deadline
+            if deadline:
+                deadline = deadline.strftime(self.strftimestring)
+
+            task_data_list.append({'title': task.title,
+                                   'description': task.text,
+                                   'sequence_number': task.get_sequence_number(),
+                                   'type': task.get_task_type_label(),
+                                   'completion_date': completion_date,
+                                   'deadline': deadline,
+                                   'responsible': task.responsible,
+                                   'responsible_client': task.responsible_client,
+                                   'history': task_history.get_listing(response_container)})
+
+        return {'task_data_list': task_data_list,
+                'label': title}
+
+    def get_tasks(self):
+        task_brains = api.content.find(context=self.context, object_provides=ITask)
+        tasks = [el.getObject() for el in task_brains]
+        tasks.sort(key=lambda task: task.get_sequence_number())
+        return tasks

--- a/opengever/latex/listing.py
+++ b/opengever/latex/listing.py
@@ -1,5 +1,6 @@
 from collections import OrderedDict
 from ftw.table import helper
+from opengever.activity import _ as activity_mf
 from opengever.journal import _ as journal_mf
 from opengever.journal.handlers import DOCUMENT_SENT
 from opengever.journal.tab import title_helper
@@ -47,7 +48,7 @@ class ILaTexListing(Interface):
         """"Returns a LaTEx string with the labels of the listing"""
 
     def get_widths():
-        """"Returns a LaTEx string with the labels of the listing,
+        """"Returns a LaTEx string with the widths of the listing,
         which are calculated."""
 
     def get_rows():
@@ -86,20 +87,20 @@ class LaTexListing(object):
         return columns
 
     def get_widths(self):
-        """"Returns a LaTEx string with the labels of the listing,
-        which are calculated."""
+        """"Returns a list of the column widths as strings"""
         return [col.width for col in self.columns.values()]
 
     def get_labels(self):
-        """"Returns a LaTEx string with the labels of the listing"""
+        """"Returns a list of the column labels of the listing"""
         return [col.label for col in self.columns.values()]
 
     def get_rows(self):
-        """"Returns a LaTEx string with all the rows of the listing"""
+        """"Returns a list of the data for each row of the listing"""
         return [self.get_row_for_item(item) for item in self.items]
 
-    def get_listing(self, items=[]):
-        self.items += items
+    def get_listing(self, items=None):
+        if items is not None:
+            self.items += items
 
         if len(self.items) == 0:
             return None
@@ -270,6 +271,32 @@ class TasksLaTeXListing(DossiersLaTeXListing):
                    _('label_deadline', default='Deadline'),
                    '15%',
                    lambda item: helper.readable_date(item, item.deadline))
+        ]
+
+
+@implementer(ILaTexListing)
+@adapter(Interface, Interface, Interface)
+class TaskHistoryLaTeXListing(LaTexListing):
+
+    def get_columns(self):
+        return [
+            Column('date',
+                   _('label_time', default=u'Time'),
+                   '10%',
+                   lambda item: helper.readable_date_time(item, item.date)),
+
+            Column('creator',
+                   _('label_creator', default='Changed by'),
+                   '20%'),
+
+            Column('transition',
+                   _('label_transition', default='Transition'),
+                   '20%',
+                   lambda item: activity_mf(item.transition)),
+
+            Column('text',
+                   _('label_description', default='Description'),
+                   '50%'),
         ]
 
 

--- a/opengever/latex/locales/de/LC_MESSAGES/opengever.latex.po
+++ b/opengever/latex/locales/de/LC_MESSAGES/opengever.latex.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-10-02 12:51+0000\n"
+"POT-Creation-Date: 2018-07-30 13:38+0000\n"
 "PO-Revision-Date: 2013-11-19 16:25+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -14,6 +14,11 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
 
+#. Default: "Changed by"
+#: ./opengever/latex/listing.py
+msgid "label_creator"
+msgstr "Geändert von"
+
 #. Default: "Deadline"
 #: ./opengever/latex/listing.py
 msgid "label_deadline"
@@ -23,6 +28,11 @@ msgstr "Zu erledigen bis"
 #: ./opengever/latex/listing.py
 msgid "label_delivery_date"
 msgstr "Ausgangsdatum"
+
+#. Default: "Description"
+#: ./opengever/latex/listing.py
+msgid "label_description"
+msgstr "Beschreibung"
 
 #. Default: "Document author"
 #: ./opengever/latex/listing.py
@@ -43,6 +53,11 @@ msgstr "Dokumente"
 #: ./opengever/latex/dossierjournal.py
 msgid "label_dossier_journal"
 msgstr "Journal zu Dossier ${title} (${reference_number})"
+
+#. Default: "Task list for dossier ${title} (${reference_number})"
+#: ./opengever/latex/dossiertasks.py
+msgid "label_dossier_tasks"
+msgstr "Aufgabenliste zu Dossier ${title} (${reference_number})"
 
 #. Default: "End"
 #: ./opengever/latex/dossierdetails.py
@@ -129,14 +144,23 @@ msgstr "Art"
 msgid "label_tasks"
 msgstr "Aufgaben"
 
+#. Default: "Time"
+#: ./opengever/latex/listing.py
+msgid "label_time"
+msgstr "Zeitpunkt"
+
 #. Default: "Title"
 #: ./opengever/latex/dossierdetails.py
 #: ./opengever/latex/listing.py
 msgid "label_title"
 msgstr "Titel"
 
+#. Default: "Transition"
+#: ./opengever/latex/listing.py
+msgid "label_transition"
+msgstr "Aktion"
+
 #. Default: "No."
 #: ./opengever/latex/listing.py
 msgid "short_label_sequence_number"
 msgstr "Nr."
-

--- a/opengever/latex/locales/fr/LC_MESSAGES/opengever.latex.po
+++ b/opengever/latex/locales/fr/LC_MESSAGES/opengever.latex.po
@@ -1,21 +1,25 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-10-02 12:51+0000\n"
+"POT-Creation-Date: 2018-07-30 13:38+0000\n"
 "PO-Revision-Date: 2017-12-03 09:48+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
-"Language-Team: French <https://translations.onegovgever.ch/projects/onegov-"
-"gever/opengever-latex/fr/>\n"
-"Language: fr\n"
+"Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-latex/fr/>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
-"X-Generator: Weblate 2.13.1\n"
 "Language-Code: en\n"
 "Language-Name: English\n"
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
+"Language: fr\n"
+"X-Generator: Weblate 2.13.1\n"
+
+#. Default: "Changed by"
+#: ./opengever/latex/listing.py
+msgid "label_creator"
+msgstr "Modifié par"
 
 #. Default: "Deadline"
 #: ./opengever/latex/listing.py
@@ -26,6 +30,11 @@ msgstr "A réaliser jusqu'au"
 #: ./opengever/latex/listing.py
 msgid "label_delivery_date"
 msgstr "Date de remise"
+
+#. Default: "Description"
+#: ./opengever/latex/listing.py
+msgid "label_description"
+msgstr "Description"
 
 #. Default: "Document author"
 #: ./opengever/latex/listing.py
@@ -46,6 +55,11 @@ msgstr "Documents"
 #: ./opengever/latex/dossierjournal.py
 msgid "label_dossier_journal"
 msgstr "Journal du dossier ${title} (${reference_number})"
+
+#. Default: "Task list for dossier ${title} (${reference_number})"
+#: ./opengever/latex/dossiertasks.py
+msgid "label_dossier_tasks"
+msgstr "Liste des tâches du dossier ${title} (${reference_number})"
 
 #. Default: "End"
 #: ./opengever/latex/dossierdetails.py
@@ -132,11 +146,21 @@ msgstr "Type de mandat"
 msgid "label_tasks"
 msgstr "Tâches"
 
+#. Default: "Time"
+#: ./opengever/latex/listing.py
+msgid "label_time"
+msgstr "Date"
+
 #. Default: "Title"
 #: ./opengever/latex/dossierdetails.py
 #: ./opengever/latex/listing.py
 msgid "label_title"
 msgstr "Titre"
+
+#. Default: "Transition"
+#: ./opengever/latex/listing.py
+msgid "label_transition"
+msgstr "Action"
 
 #. Default: "No."
 #: ./opengever/latex/listing.py

--- a/opengever/latex/locales/opengever.latex.pot
+++ b/opengever/latex/locales/opengever.latex.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-10-02 12:51+0000\n"
+"POT-Creation-Date: 2018-07-30 13:38+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,6 +17,11 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: opengever.latex\n"
 
+#. Default: "Changed by"
+#: ./opengever/latex/listing.py
+msgid "label_creator"
+msgstr ""
+
 #. Default: "Deadline"
 #: ./opengever/latex/listing.py
 msgid "label_deadline"
@@ -25,6 +30,11 @@ msgstr ""
 #. Default: "Delivery date"
 #: ./opengever/latex/listing.py
 msgid "label_delivery_date"
+msgstr ""
+
+#. Default: "Description"
+#: ./opengever/latex/listing.py
+msgid "label_description"
 msgstr ""
 
 #. Default: "Document author"
@@ -45,6 +55,11 @@ msgstr ""
 #. Default: "Journal of dossier ${title} (${reference_number})"
 #: ./opengever/latex/dossierjournal.py
 msgid "label_dossier_journal"
+msgstr ""
+
+#. Default: "Task list for dossier ${title} (${reference_number})"
+#: ./opengever/latex/dossiertasks.py
+msgid "label_dossier_tasks"
 msgstr ""
 
 #. Default: "End"
@@ -132,14 +147,23 @@ msgstr ""
 msgid "label_tasks"
 msgstr ""
 
+#. Default: "Time"
+#: ./opengever/latex/listing.py
+msgid "label_time"
+msgstr ""
+
 #. Default: "Title"
 #: ./opengever/latex/dossierdetails.py
 #: ./opengever/latex/listing.py
 msgid "label_title"
 msgstr ""
 
+#. Default: "Transition"
+#: ./opengever/latex/listing.py
+msgid "label_transition"
+msgstr ""
+
 #. Default: "No."
 #: ./opengever/latex/listing.py
 msgid "short_label_sequence_number"
 msgstr ""
-

--- a/opengever/latex/templates/dossiertasks.tex
+++ b/opengever/latex/templates/dossiertasks.tex
@@ -1,0 +1,18 @@
+\section*{${label}}\\%%
+\vspace{\baselineskip}
+%for task_data in task_data_list:
+\vspace{2\baselineskip}
+\normalsize
+{\bf Title: ${task_data.get("title")} }\\%%
+{\bf Beschreibung}: ${task_data.get("description")}\\%%
+{\bf Auftragstyp}: ${task_data.get("type")}\\%%
+{\bf Frist}: ${task_data.get("deadline")}\\%%
+{\bf Auftraggeber}: ${task_data.get("responsible")}\\%%
+{\bf Auftragnehmer}: ${task_data.get("responsible_client")}\\%%
+{\bf Erledigungsdatum}: ${task_data.get("completion_date")}\\%%
+
+\small
+\vspace{\baselineskip}
+${task_data.get("history")}
+%endfor
+

--- a/opengever/latex/tests/test_dossierjournal.py
+++ b/opengever/latex/tests/test_dossierjournal.py
@@ -30,21 +30,6 @@ class TestDossierJournalPDFView(MockTestCase):
         view = getMultiAdapter((context, request), name='pdf-dossier-journal')
         self.assertTrue(isinstance(view, dossierjournal.DossierJournalPDFView))
 
-    def test_render_adds_browser_layer(self):
-        context = request = self.create_dummy()
-
-        view = self.mocker.patch(
-            dossierjournal.DossierJournalPDFView(context, request))
-
-        self.expect(view.allow_alternate_output()).result(False)
-        self.expect(view.export())
-
-        self.replay()
-
-        view()
-        self.assertTrue(
-            dossierjournal.IDossierJournalLayer.providedBy(request))
-
 
 class TestJournalListingLaTeXView(FunctionalTestCase):
 

--- a/opengever/latex/tests/test_dossiertasks.py
+++ b/opengever/latex/tests/test_dossiertasks.py
@@ -1,0 +1,140 @@
+from datetime import datetime
+from datetime import date
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.pdfgenerator.builder import Builder as PDFBuilder
+from ftw.pdfgenerator.interfaces import ILaTeXView
+from ftw.pdfgenerator.utils import provide_request_layer
+from ftw.testbrowser import browsing
+from ftw.testbrowser.pages import factoriesmenu
+from ftw.testing import freeze
+from ftw.testing import MockTestCase
+from opengever.latex import dossiertasks
+from opengever.latex.dossiertasks import provide_dossier_task_layer
+from opengever.latex.layouts.default import DefaultLayout
+from opengever.latex.testing import LATEX_ZCML_LAYER
+from opengever.testing import FunctionalTestCase
+from plone import api
+from plone.app.testing import TEST_USER_ID
+from zope.component import getMultiAdapter
+from zope.publisher.interfaces.browser import IDefaultBrowserLayer
+
+
+class TestDossierTasksPDFView(MockTestCase):
+
+    layer = LATEX_ZCML_LAYER
+
+    def test_is_registered(self):
+        context = self.create_dummy()
+        request = self.providing_stub([IDefaultBrowserLayer])
+
+        self.replay()
+        view = getMultiAdapter((context, request), name='pdf-dossier-tasks')
+        self.assertTrue(isinstance(view, dossiertasks.DossierTasksPDFView))
+
+
+class TestDossierTasksLaTeXView(FunctionalTestCase):
+
+    @browsing
+    def test_dossier_tasks_label(self, browser):
+        dossier = create(Builder('dossier').titled(u'Anfr\xf6gen 2015'))
+
+        with provide_dossier_task_layer(dossier.REQUEST):
+            layout = DefaultLayout(dossier, dossier.REQUEST, PDFBuilder())
+            dossier_tasks = getMultiAdapter(
+                (dossier, dossier.REQUEST, layout), ILaTeXView)
+
+            self.assertEquals(
+                u'Task list for dossier Anfr\xf6gen 2015 (Client1 / 1)',
+                dossier_tasks.get_render_arguments().get('label'))
+
+    @browsing
+    def test_dossier_tasks_data(self, browser):
+        repository = create(Builder('repository_root')
+                            .titled(u'Repository'))
+        dossier = create(Builder('dossier')
+                         .titled(u'Anfr\xf6gen 2015')
+                         .within(repository)
+                         .having(responsible=self.user.userid))
+
+        subdossier = create(Builder('dossier')
+                            .within(dossier)
+                            .titled(u'Subdossier'))
+
+        with freeze(datetime(2016, 4, 12, 10, 35)):
+            task1 = create(Builder('task')
+                           .within(dossier)
+                           .having(responsible=self.user.userid,
+                                   responsible_client=self.org_unit.id(),
+                                   title="task 1"))
+
+            task2 = create(Builder('task')
+                           .within(subdossier)
+                           .having(responsible=self.user.userid,
+                                   responsible_client=self.org_unit.id(),
+                                   title="task 2"))
+
+        expected_deadline = datetime(2016, 4, 17, 0, 0)
+
+        with freeze(datetime(2016, 10, 12, 13, 20)):
+            api.content.transition(task1, to_state='task-state-resolved')
+            completion_date = date.today()
+
+        with provide_dossier_task_layer(dossier.REQUEST):
+            layout = DefaultLayout(dossier, dossier.REQUEST, PDFBuilder())
+            dossiertasks = getMultiAdapter((dossier, dossier.REQUEST, layout),
+                                           ILaTeXView)
+            self.assertEquals([task1, task2], dossiertasks.get_tasks())
+
+            expected = {'label': u'Task list for dossier Anfr\xf6gen 2015 (Client1 / 1)',
+                        'task_data_list': [{'completion_date': completion_date.strftime('%d.%m.%Y %H:%M'),
+                                            'deadline': expected_deadline.strftime('%d.%m.%Y %H:%M'),
+                                            'description': None,
+                                            'history': None,
+                                            'responsible': u'test_user_1_',
+                                            'responsible_client': u'org-unit-1',
+                                            'sequence_number': 1,
+                                            'title': 'task 1',
+                                            'type': ''},
+                                           {'completion_date': None,
+                                            'deadline': expected_deadline.strftime('%d.%m.%Y %H:%M'),
+                                            'description': None,
+                                            'history': None,
+                                            'responsible': u'test_user_1_',
+                                            'responsible_client': u'org-unit-1',
+                                            'sequence_number': 2,
+                                            'title': 'task 2',
+                                            'type': ''}]}
+
+            self.assertEquals(expected, dossiertasks.get_render_arguments())
+
+    @browsing
+    def test_dossier_tasks_history(self, browser):
+        repository = create(Builder('repository_root')
+                            .titled(u'Repository'))
+        dossier = create(Builder('dossier')
+                         .titled(u'Anfr\xf6gen 2015')
+                         .within(repository)
+                         .having(responsible=self.user.userid))
+
+        browser.login().visit(dossier)
+        factoriesmenu.add('Task')
+        browser.fill({'Title': 'Task title',
+                      'Task Type': 'To comment'})
+
+        form = browser.find_form_by_field('Responsible')
+        form.find_widget('Responsible').fill(self.get_org_unit().id() + ':' + TEST_USER_ID)
+        browser.find('Save').click()
+
+        browser.open('http://nohost/plone/repository/dossier-1/task-1')
+        browser.click_on("task-transition-open-resolved")
+        browser.fill({'Response': 'response text'})
+        browser.click_on("Save")
+
+        with provide_dossier_task_layer(dossier.REQUEST):
+            layout = DefaultLayout(dossier, dossier.REQUEST, PDFBuilder())
+            dossiertasks = getMultiAdapter((dossier, dossier.REQUEST, layout),
+                                           ILaTeXView)
+            tasks_data = dossiertasks.get_render_arguments()['task_data_list']
+            self.assertEqual(1, len(tasks_data))
+            self.assertIn("response text", tasks_data[0]['history'])

--- a/opengever/testing/integration_test_case.py
+++ b/opengever/testing/integration_test_case.py
@@ -60,8 +60,10 @@ FEATURE_FLAGS = {
     'extjs': 'ftw.tabbedview.interfaces.ITabbedView.extjs_enabled',
     'gever_ui': 'opengever.base.interfaces.IGeverUI.is_feature_enabled',
     'meeting': 'opengever.meeting.interfaces.IMeetingSettings.is_feature_enabled',
-    'officeconnector-attach': 'opengever.officeconnector.interfaces.IOfficeConnectorSettings.attach_to_outlook_enabled',
-    'officeconnector-checkout': 'opengever.officeconnector.interfaces.IOfficeConnectorSettings.direct_checkout_and_edit_enabled',  # noqa
+    'officeconnector-attach': 'opengever.officeconnector.interfaces.'
+                              'IOfficeConnectorSettings.attach_to_outlook_enabled',
+    'officeconnector-checkout': 'opengever.officeconnector.interfaces.'
+                                'IOfficeConnectorSettings.direct_checkout_and_edit_enabled',
     'oneoffixx': 'opengever.oneoffixx.interfaces.IOneoffixxSettings.is_feature_enabled',
     'repositoryfolder-documents-tab': 'opengever.repository.interfaces.IRepositoryFolderRecords.show_documents_tab',
     'repositoryfolder-tasks-tab': 'opengever.repository.interfaces.IRepositoryFolderRecords.show_tasks_tab',
@@ -70,6 +72,7 @@ FEATURE_FLAGS = {
     'solr': 'opengever.base.interfaces.ISearchSettings.use_solr',
     'purge-trash': 'opengever.dossier.interfaces.IDossierResolveProperties.purge_trash_enabled',
     'journal-pdf': 'opengever.dossier.interfaces.IDossierResolveProperties.journal_pdf_enabled',
+    'tasks-pdf': 'opengever.dossier.interfaces.IDossierResolveProperties.tasks_pdf_enabled',
     }
 
 FEATURE_PROFILES = {


### PR DESCRIPTION
We add a new feature to create a document of the tasks of a dossier when it gets resolved.
The document is a pdf containing a list of the tasks. For each task we show the metadata followed by a table presenting its history.
This feature is controlled by a configuration entry `tasks_pdf_enabled` in `IDossierResolveProperties` and is deactivated by default.

Finally we introduce an interface to mark the generated document to allow updating it instead of generating a new one when the dossier is reactivated and then closed again. We also adapt the journal pdf to follow that same behaviour.

Here an example of a generated pdf:
[Aufgabenliste des Dossier grege, 25.07.2018 10 05 (8).pdf](https://github.com/4teamwork/opengever.core/files/2228165/Aufgabenliste.des.Dossier.grege.25.07.2018.10.05.8.pdf)

resolves #4184 