### PR TITLE
Add placeful workflow policy for inboxes

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2018.4.0 (unreleased)
 ---------------------
 
+- Fix archival_file and public_trial checks on documents overview. [phgross]
 - Add placeful workflow policy for inbox-area. Let inbox users edit and checkout documents but not the inbox itself. [phgross]
 - Fix base URL for contentish objects. [njohner]
 - Bump Chameleon to 3.3 in order to fix edge case in exception handler causing recursion. [lgraf]

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2018.4.0 (unreleased)
 ---------------------
 
+- Add placeful workflow policy for inbox-area. Let inbox users edit and checkout documents but not the inbox itself. [phgross]
 - Fix base URL for contentish objects. [njohner]
 - Bump Chameleon to 3.3 in order to fix edge case in exception handler causing recursion. [lgraf]
 - Move excerpts to the file info box on proposal overviews. [Rotonen]

--- a/opengever/core/profiles/default/portal_placeful_workflow.xml
+++ b/opengever/core/profiles/default/portal_placeful_workflow.xml
@@ -1,3 +1,4 @@
 <object name="portal_placeful_workflow" meta_type="Placeful Workflow Tool">
   <object name="opengever_private_policy" meta_type="WorkflowPolicy" />
+  <object name="opengever_inbox_policy" meta_type="WorkflowPolicy" />
 </object>

--- a/opengever/core/profiles/default/portal_placeful_workflow/opengever_inbox_policy.xml
+++ b/opengever/core/profiles/default/portal_placeful_workflow/opengever_inbox_policy.xml
@@ -1,0 +1,10 @@
+<object name="opengever_inbox" meta_type="WorkflowPolicy">
+  <property name="title">Opengever inbox policy</property>
+  <bindings>
+
+    <type type_id="opengever.document.document">
+      <bound-workflow workflow_id="opengever_inbox_document_workflow" />
+    </type>
+
+  </bindings>
+</object>

--- a/opengever/core/profiles/default/workflows.xml
+++ b/opengever/core/profiles/default/workflows.xml
@@ -9,6 +9,7 @@
   <object name="opengever_dossier_workflow" meta_type="Workflow" />
   <object name="opengever_forwarding_workflow" meta_type="Workflow" />
   <object name="opengever_inbox_workflow" meta_type="Workflow" />
+  <object name="opengever_inbox_document_workflow" meta_type="Workflow" />
   <object name="opengever_mail_workflow" meta_type="Workflow" />
   <object name="opengever_meetingtemplate_workflow" meta_type="Workflow" />
   <object name="opengever_paragraphtemplate_workflow" meta_type="Workflow" />

--- a/opengever/core/profiles/default/workflows/opengever_inbox_document_workflow/definition.xml
+++ b/opengever/core/profiles/default/workflows/opengever_inbox_document_workflow/definition.xml
@@ -1,0 +1,557 @@
+<dc-workflow
+    workflow_id="opengever_inbox_document_workflow"
+    title="Document workflow for documents inside the inbox area"
+    description=""
+    state_variable="review_state"
+    initial_state="document-state-draft"
+    manager_bypass="False">
+  <permission>Access contents information</permission>
+  <permission>CMFEditions: Access previous versions</permission>
+  <permission>CMFEditions: Apply version control</permission>
+  <permission>CMFEditions: Checkout to location</permission>
+  <permission>CMFEditions: Manage versioning policies</permission>
+  <permission>CMFEditions: Purge version</permission>
+  <permission>CMFEditions: Revert to previous versions</permission>
+  <permission>Change portal events</permission>
+  <permission>Content rules: Manage rules</permission>
+  <permission>Copy or Move</permission>
+  <permission>Delete objects</permission>
+  <permission>List folder contents</permission>
+  <permission>Modify portal content</permission>
+  <permission>Request review</permission>
+  <permission>Sharing page: Delegate roles</permission>
+  <permission>View</permission>
+  <permission>WebDAV Lock items</permission>
+  <permission>WebDAV Unlock items</permission>
+  <permission>WebDAV access</permission>
+  <permission>opengever.document: Cancel</permission>
+  <permission>opengever.document: Checkin</permission>
+  <permission>opengever.document: Checkout</permission>
+  <state
+      state_id="document-state-draft"
+      title="document-state-draft">
+    <description>one single state</description>
+    <exit-transition transition_id="document-transition-remove" />
+    <permission-map
+        name="Access contents information"
+        acquired="False">
+      <permission-role>Editor</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>Reader</permission-role>
+      <permission-role>Administrator</permission-role>
+    </permission-map>
+    <permission-map
+        name="CMFEditions: Access previous versions"
+        acquired="False">
+      <permission-role>Editor</permission-role>
+      <permission-role>Reader</permission-role>
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map
+        name="CMFEditions: Apply version control"
+        acquired="False">
+      <permission-role>Editor</permission-role>
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map
+        name="CMFEditions: Checkout to location"
+        acquired="False">
+      <permission-role>Editor</permission-role>
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map
+        name="CMFEditions: Manage versioning policies"
+        acquired="False">
+      <permission-role>Editor</permission-role>
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map
+        name="CMFEditions: Purge version"
+        acquired="False">
+      <permission-role>Editor</permission-role>
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map
+        name="CMFEditions: Revert to previous versions"
+        acquired="False">
+      <permission-role>Editor</permission-role>
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map
+        name="Change portal events"
+        acquired="False">
+      <permission-role>Editor</permission-role>
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map
+        name="Content rules: Manage rules"
+        acquired="False">
+    </permission-map>
+    <permission-map
+        name="Copy or Move"
+        acquired="True">
+    </permission-map>
+    <permission-map
+        name="Delete objects"
+        acquired="True">
+    </permission-map>
+    <permission-map
+        name="List folder contents"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map
+        name="Modify portal content"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>Administrator</permission-role>
+      <permission-role>Editor</permission-role>
+    </permission-map>
+    <permission-map
+        name="Request review"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>Administrator</permission-role>
+      <permission-role>Editor</permission-role>
+    </permission-map>
+    <permission-map
+        name="Sharing page: Delegate roles"
+        acquired="False">
+    </permission-map>
+    <permission-map
+        name="View"
+        acquired="False">
+      <permission-role>Editor</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>Reader</permission-role>
+      <permission-role>Administrator</permission-role>
+    </permission-map>
+    <permission-map
+        name="WebDAV Lock items"
+        acquired="False">
+      <permission-role>Editor</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>Administrator</permission-role>
+    </permission-map>
+    <permission-map
+        name="WebDAV Unlock items"
+        acquired="False">
+      <permission-role>Editor</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>Administrator</permission-role>
+    </permission-map>
+    <permission-map
+        name="WebDAV access"
+        acquired="False">
+      <permission-role>Editor</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>Administrator</permission-role>
+    </permission-map>
+    <permission-map
+        name="opengever.document: Cancel"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>Administrator</permission-role>
+      <permission-role>Editor</permission-role>
+    </permission-map>
+    <permission-map
+        name="opengever.document: Checkin"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>Administrator</permission-role>
+      <permission-role>Editor</permission-role>
+    </permission-map>
+    <permission-map
+        name="opengever.document: Checkout"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>Administrator</permission-role>
+      <permission-role>Editor</permission-role>
+    </permission-map>
+  </state>
+  <state
+      state_id="document-state-removed"
+      title="document-state-removed">
+    <description>document-state-removed</description>
+    <exit-transition transition_id="document-transition-restore" />
+    <permission-map
+        name="Access contents information"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map
+        name="CMFEditions: Access previous versions"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map
+        name="CMFEditions: Apply version control"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map
+        name="CMFEditions: Checkout to location"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map
+        name="CMFEditions: Manage versioning policies"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map
+        name="CMFEditions: Purge version"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map
+        name="CMFEditions: Revert to previous versions"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map
+        name="Change portal events"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map
+        name="Content rules: Manage rules"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map
+        name="Copy or Move"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map
+        name="Delete objects"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map
+        name="List folder contents"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map
+        name="Modify portal content"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map
+        name="Request review"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map
+        name="Sharing page: Delegate roles"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map
+        name="View"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map
+        name="WebDAV Lock items"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map
+        name="WebDAV Unlock items"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map
+        name="WebDAV access"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map
+        name="opengever.document: Cancel"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map
+        name="opengever.document: Checkin"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map
+        name="opengever.document: Checkout"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+  </state>
+  <state
+      state_id="document-state-shadow"
+      title="">
+    <exit-transition transition_id="document-transition-initialize" />
+    <permission-map
+        name="Access contents information"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>Owner</permission-role>
+    </permission-map>
+    <permission-map
+        name="CMFEditions: Access previous versions"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>Owner</permission-role>
+    </permission-map>
+    <permission-map
+        name="CMFEditions: Apply version control"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>Owner</permission-role>
+    </permission-map>
+    <permission-map
+        name="CMFEditions: Checkout to location"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>Owner</permission-role>
+    </permission-map>
+    <permission-map
+        name="CMFEditions: Manage versioning policies"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>Owner</permission-role>
+    </permission-map>
+    <permission-map
+        name="CMFEditions: Purge version"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>Owner</permission-role>
+    </permission-map>
+    <permission-map
+        name="CMFEditions: Revert to previous versions"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>Owner</permission-role>
+    </permission-map>
+    <permission-map
+        name="Change portal events"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>Owner</permission-role>
+    </permission-map>
+    <permission-map
+        name="Content rules: Manage rules"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>Owner</permission-role>
+    </permission-map>
+    <permission-map
+        name="Copy or Move"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>Owner</permission-role>
+    </permission-map>
+    <permission-map
+        name="Delete objects"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>Owner</permission-role>
+    </permission-map>
+    <permission-map
+        name="List folder contents"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>Owner</permission-role>
+    </permission-map>
+    <permission-map
+        name="Modify portal content"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>Owner</permission-role>
+    </permission-map>
+    <permission-map
+        name="Request review"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>Owner</permission-role>
+    </permission-map>
+    <permission-map
+        name="Sharing page: Delegate roles"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>Owner</permission-role>
+    </permission-map>
+    <permission-map
+        name="View"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>Owner</permission-role>
+    </permission-map>
+    <permission-map
+        name="WebDAV Lock items"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>Owner</permission-role>
+    </permission-map>
+    <permission-map
+        name="WebDAV Unlock items"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>Owner</permission-role>
+    </permission-map>
+    <permission-map
+        name="WebDAV access"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>Owner</permission-role>
+    </permission-map>
+    <permission-map
+        name="opengever.document: Cancel"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>Owner</permission-role>
+    </permission-map>
+    <permission-map
+        name="opengever.document: Checkin"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>Owner</permission-role>
+    </permission-map>
+    <permission-map
+        name="opengever.document: Checkout"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>Owner</permission-role>
+    </permission-map>
+  </state>
+
+  <transition
+      transition_id="document-transition-initialize"
+      title="document-transition-initialize"
+      new_state="document-state-draft"
+      trigger="USER"
+      before_script=""
+      after_script="">
+
+    <guard>
+      <guard-permission>Add portal content</guard-permission>
+    </guard>
+  </transition>
+
+  <transition
+      transition_id="document-transition-remove"
+      title="document-transition-remove"
+      new_state="document-state-removed"
+      trigger="USER"
+      before_script=""
+      after_script="">
+    <description />
+    <action
+        url="%(content_url)s/content_status_modify?workflow_action=document-transition-remove"
+        category=""
+        icon="">document-transition-remove</action>
+    <guard>
+      <guard-permission>Remove GEVER content</guard-permission>
+    </guard>
+  </transition>
+
+  <transition
+      transition_id="document-transition-restore"
+      title="document-transition-restore"
+      new_state="document-state-draft"
+      trigger="USER"
+      before_script=""
+      after_script="">
+    <description />
+    <action
+        url="%(content_url)s/content_status_modify?workflow_action=document-transition-restore"
+        category="workflow"
+        icon="">document-transition-restore</action>
+    <guard>
+      <guard-permission>Manage portal</guard-permission>
+    </guard>
+  </transition>
+
+  <worklist
+      worklist_id="reviewer_queue"
+      title="">
+    <description>Reviewer tasks</description>
+    <action
+        url="%(portal_url)s/search?review_state=document-state-pending"
+        category="global"
+        icon="">Pending (%(count)d)</action>
+    <guard>
+      <guard-permission>Review portal content</guard-permission>
+    </guard>
+    <match
+        name="review_state"
+        values="document-state-pending"
+        />
+  </worklist>
+  <variable
+      variable_id="action"
+      for_catalog="False"
+      for_status="True"
+      update_always="True">
+    <description>Previous transition</description>
+    <default>
+
+      <expression>transition/getId|nothing</expression>
+    </default>
+    <guard>
+    </guard>
+  </variable>
+  <variable
+      variable_id="actor"
+      for_catalog="False"
+      for_status="True"
+      update_always="True">
+    <description>The ID of the user who performed the previous transition</description>
+    <default>
+
+      <expression>user/getUserName</expression>
+    </default>
+    <guard>
+    </guard>
+  </variable>
+  <variable
+      variable_id="comments"
+      for_catalog="False"
+      for_status="True"
+      update_always="True">
+    <description>Comment about the last transition</description>
+    <default>
+
+      <expression>python:state_change.kwargs.get('comment', '')</expression>
+    </default>
+    <guard>
+    </guard>
+  </variable>
+  <variable
+      variable_id="review_history"
+      for_catalog="False"
+      for_status="False"
+      update_always="False">
+    <description>Provides access to workflow history</description>
+    <default>
+
+      <expression>state_change/getHistory</expression>
+    </default>
+    <guard>
+      <guard-permission>Request review</guard-permission>
+      <guard-permission>Review portal content</guard-permission>
+    </guard>
+  </variable>
+  <variable
+      variable_id="time"
+      for_catalog="False"
+      for_status="True"
+      update_always="True">
+    <description>When the previous transition was performed</description>
+    <default>
+
+      <expression>state_change/getDateTime</expression>
+    </default>
+    <guard>
+    </guard>
+  </variable>
+</dc-workflow>

--- a/opengever/core/profiles/default/workflows/opengever_inbox_workflow/definition.xml
+++ b/opengever/core/profiles/default/workflows/opengever_inbox_workflow/definition.xml
@@ -1,6 +1,6 @@
 <dc-workflow
     workflow_id="opengever_inbox_workflow"
-    title="Dossier Workflow"
+    title="Inbox Workflow"
     description=""
     state_variable="review_state"
     initial_state="inbox-state-default"
@@ -59,8 +59,6 @@
         name="Modify portal content"
         acquired="False">
       <permission-role>Manager</permission-role>
-      <permission-role>Editor</permission-role>
-      <permission-role>Administrator</permission-role>
     </permission-map>
     <permission-map
         name="Sharing page: Delegate roles"

--- a/opengever/core/upgrades/20180726095934_add_placeful_workflow_for_inbox_area/portal_placeful_workflow.xml
+++ b/opengever/core/upgrades/20180726095934_add_placeful_workflow_for_inbox_area/portal_placeful_workflow.xml
@@ -1,0 +1,3 @@
+<object name="portal_placeful_workflow" meta_type="Placeful Workflow Tool" purge="False">
+  <object name="opengever_inbox_policy" meta_type="WorkflowPolicy" />
+</object>

--- a/opengever/core/upgrades/20180726095934_add_placeful_workflow_for_inbox_area/portal_placeful_workflow/opengever_inbox_policy.xml
+++ b/opengever/core/upgrades/20180726095934_add_placeful_workflow_for_inbox_area/portal_placeful_workflow/opengever_inbox_policy.xml
@@ -1,0 +1,10 @@
+<object name="opengever_inbox" meta_type="WorkflowPolicy">
+  <property name="title">Opengever inbox policy</property>
+  <bindings>
+
+    <type type_id="opengever.document.document">
+      <bound-workflow workflow_id="opengever_inbox_document_workflow" />
+    </type>
+
+  </bindings>
+</object>

--- a/opengever/core/upgrades/20180726095934_add_placeful_workflow_for_inbox_area/upgrade.py
+++ b/opengever/core/upgrades/20180726095934_add_placeful_workflow_for_inbox_area/upgrade.py
@@ -1,0 +1,38 @@
+from ftw.upgrade import UpgradeStep
+from ftw.upgrade.placefulworkflow import PlacefulWorkflowPolicyActivator
+from opengever.inbox.container import IInboxContainer
+from opengever.inbox.inbox import IInbox
+from plone import api
+
+
+class AddPlacefulWorkflowForInboxArea(UpgradeStep):
+    """Add placeful workflow for inbox area.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()
+
+        self.update_inbox_workflow()
+
+    def update_inbox_workflow(self):
+        self.update_workflow_security(
+            ['opengever_inbox_workflow'],
+            reindex_security=False)
+
+        inboxes = api.content.find(
+            context=api.portal.get(),
+            depth=1,
+            object_provides=[IInbox, IInboxContainer])
+
+        for brain in inboxes:
+            inbox = brain.getObject()
+
+            activator = PlacefulWorkflowPolicyActivator(inbox)
+            activator.activate_policy(
+                'opengever_inbox_policy',
+                review_state_mapping={
+                    ('opengever_document_workflow',
+                     'opengever_inbox_document_workflow'): {
+                         'document-state-draft': 'document-state-draft',
+                         'document-state-removed': 'document-state-removed',
+                         'document-state-shadow': 'document-state-shadow'}})

--- a/opengever/core/upgrades/20180726095934_add_placeful_workflow_for_inbox_area/workflows.xml
+++ b/opengever/core/upgrades/20180726095934_add_placeful_workflow_for_inbox_area/workflows.xml
@@ -1,0 +1,5 @@
+<object name="portal_workflow" meta_type="Plone Workflow Tool" purge="False">
+
+  <object name="opengever_inbox_document_workflow" meta_type="Workflow" />
+
+</object>

--- a/opengever/core/upgrades/20180726095934_add_placeful_workflow_for_inbox_area/workflows/opengever_inbox_document_workflow/definition.xml
+++ b/opengever/core/upgrades/20180726095934_add_placeful_workflow_for_inbox_area/workflows/opengever_inbox_document_workflow/definition.xml
@@ -1,0 +1,557 @@
+<dc-workflow
+    workflow_id="opengever_inbox_document_workflow"
+    title="Document workflow for documents inside the inbox area"
+    description=""
+    state_variable="review_state"
+    initial_state="document-state-draft"
+    manager_bypass="False">
+  <permission>Access contents information</permission>
+  <permission>CMFEditions: Access previous versions</permission>
+  <permission>CMFEditions: Apply version control</permission>
+  <permission>CMFEditions: Checkout to location</permission>
+  <permission>CMFEditions: Manage versioning policies</permission>
+  <permission>CMFEditions: Purge version</permission>
+  <permission>CMFEditions: Revert to previous versions</permission>
+  <permission>Change portal events</permission>
+  <permission>Content rules: Manage rules</permission>
+  <permission>Copy or Move</permission>
+  <permission>Delete objects</permission>
+  <permission>List folder contents</permission>
+  <permission>Modify portal content</permission>
+  <permission>Request review</permission>
+  <permission>Sharing page: Delegate roles</permission>
+  <permission>View</permission>
+  <permission>WebDAV Lock items</permission>
+  <permission>WebDAV Unlock items</permission>
+  <permission>WebDAV access</permission>
+  <permission>opengever.document: Cancel</permission>
+  <permission>opengever.document: Checkin</permission>
+  <permission>opengever.document: Checkout</permission>
+  <state
+      state_id="document-state-draft"
+      title="document-state-draft">
+    <description>one single state</description>
+    <exit-transition transition_id="document-transition-remove" />
+    <permission-map
+        name="Access contents information"
+        acquired="False">
+      <permission-role>Editor</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>Reader</permission-role>
+      <permission-role>Administrator</permission-role>
+    </permission-map>
+    <permission-map
+        name="CMFEditions: Access previous versions"
+        acquired="False">
+      <permission-role>Editor</permission-role>
+      <permission-role>Reader</permission-role>
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map
+        name="CMFEditions: Apply version control"
+        acquired="False">
+      <permission-role>Editor</permission-role>
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map
+        name="CMFEditions: Checkout to location"
+        acquired="False">
+      <permission-role>Editor</permission-role>
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map
+        name="CMFEditions: Manage versioning policies"
+        acquired="False">
+      <permission-role>Editor</permission-role>
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map
+        name="CMFEditions: Purge version"
+        acquired="False">
+      <permission-role>Editor</permission-role>
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map
+        name="CMFEditions: Revert to previous versions"
+        acquired="False">
+      <permission-role>Editor</permission-role>
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map
+        name="Change portal events"
+        acquired="False">
+      <permission-role>Editor</permission-role>
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map
+        name="Content rules: Manage rules"
+        acquired="False">
+    </permission-map>
+    <permission-map
+        name="Copy or Move"
+        acquired="True">
+    </permission-map>
+    <permission-map
+        name="Delete objects"
+        acquired="True">
+    </permission-map>
+    <permission-map
+        name="List folder contents"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map
+        name="Modify portal content"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>Administrator</permission-role>
+      <permission-role>Editor</permission-role>
+    </permission-map>
+    <permission-map
+        name="Request review"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>Administrator</permission-role>
+      <permission-role>Editor</permission-role>
+    </permission-map>
+    <permission-map
+        name="Sharing page: Delegate roles"
+        acquired="False">
+    </permission-map>
+    <permission-map
+        name="View"
+        acquired="False">
+      <permission-role>Editor</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>Reader</permission-role>
+      <permission-role>Administrator</permission-role>
+    </permission-map>
+    <permission-map
+        name="WebDAV Lock items"
+        acquired="False">
+      <permission-role>Editor</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>Administrator</permission-role>
+    </permission-map>
+    <permission-map
+        name="WebDAV Unlock items"
+        acquired="False">
+      <permission-role>Editor</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>Administrator</permission-role>
+    </permission-map>
+    <permission-map
+        name="WebDAV access"
+        acquired="False">
+      <permission-role>Editor</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>Administrator</permission-role>
+    </permission-map>
+    <permission-map
+        name="opengever.document: Cancel"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>Administrator</permission-role>
+      <permission-role>Editor</permission-role>
+    </permission-map>
+    <permission-map
+        name="opengever.document: Checkin"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>Administrator</permission-role>
+      <permission-role>Editor</permission-role>
+    </permission-map>
+    <permission-map
+        name="opengever.document: Checkout"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>Administrator</permission-role>
+      <permission-role>Editor</permission-role>
+    </permission-map>
+  </state>
+  <state
+      state_id="document-state-removed"
+      title="document-state-removed">
+    <description>document-state-removed</description>
+    <exit-transition transition_id="document-transition-restore" />
+    <permission-map
+        name="Access contents information"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map
+        name="CMFEditions: Access previous versions"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map
+        name="CMFEditions: Apply version control"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map
+        name="CMFEditions: Checkout to location"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map
+        name="CMFEditions: Manage versioning policies"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map
+        name="CMFEditions: Purge version"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map
+        name="CMFEditions: Revert to previous versions"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map
+        name="Change portal events"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map
+        name="Content rules: Manage rules"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map
+        name="Copy or Move"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map
+        name="Delete objects"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map
+        name="List folder contents"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map
+        name="Modify portal content"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map
+        name="Request review"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map
+        name="Sharing page: Delegate roles"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map
+        name="View"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map
+        name="WebDAV Lock items"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map
+        name="WebDAV Unlock items"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map
+        name="WebDAV access"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map
+        name="opengever.document: Cancel"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map
+        name="opengever.document: Checkin"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map
+        name="opengever.document: Checkout"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+  </state>
+  <state
+      state_id="document-state-shadow"
+      title="">
+    <exit-transition transition_id="document-transition-initialize" />
+    <permission-map
+        name="Access contents information"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>Owner</permission-role>
+    </permission-map>
+    <permission-map
+        name="CMFEditions: Access previous versions"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>Owner</permission-role>
+    </permission-map>
+    <permission-map
+        name="CMFEditions: Apply version control"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>Owner</permission-role>
+    </permission-map>
+    <permission-map
+        name="CMFEditions: Checkout to location"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>Owner</permission-role>
+    </permission-map>
+    <permission-map
+        name="CMFEditions: Manage versioning policies"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>Owner</permission-role>
+    </permission-map>
+    <permission-map
+        name="CMFEditions: Purge version"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>Owner</permission-role>
+    </permission-map>
+    <permission-map
+        name="CMFEditions: Revert to previous versions"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>Owner</permission-role>
+    </permission-map>
+    <permission-map
+        name="Change portal events"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>Owner</permission-role>
+    </permission-map>
+    <permission-map
+        name="Content rules: Manage rules"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>Owner</permission-role>
+    </permission-map>
+    <permission-map
+        name="Copy or Move"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>Owner</permission-role>
+    </permission-map>
+    <permission-map
+        name="Delete objects"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>Owner</permission-role>
+    </permission-map>
+    <permission-map
+        name="List folder contents"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>Owner</permission-role>
+    </permission-map>
+    <permission-map
+        name="Modify portal content"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>Owner</permission-role>
+    </permission-map>
+    <permission-map
+        name="Request review"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>Owner</permission-role>
+    </permission-map>
+    <permission-map
+        name="Sharing page: Delegate roles"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>Owner</permission-role>
+    </permission-map>
+    <permission-map
+        name="View"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>Owner</permission-role>
+    </permission-map>
+    <permission-map
+        name="WebDAV Lock items"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>Owner</permission-role>
+    </permission-map>
+    <permission-map
+        name="WebDAV Unlock items"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>Owner</permission-role>
+    </permission-map>
+    <permission-map
+        name="WebDAV access"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>Owner</permission-role>
+    </permission-map>
+    <permission-map
+        name="opengever.document: Cancel"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>Owner</permission-role>
+    </permission-map>
+    <permission-map
+        name="opengever.document: Checkin"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>Owner</permission-role>
+    </permission-map>
+    <permission-map
+        name="opengever.document: Checkout"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>Owner</permission-role>
+    </permission-map>
+  </state>
+
+  <transition
+      transition_id="document-transition-initialize"
+      title="document-transition-initialize"
+      new_state="document-state-draft"
+      trigger="USER"
+      before_script=""
+      after_script="">
+
+    <guard>
+      <guard-permission>Add portal content</guard-permission>
+    </guard>
+  </transition>
+
+  <transition
+      transition_id="document-transition-remove"
+      title="document-transition-remove"
+      new_state="document-state-removed"
+      trigger="USER"
+      before_script=""
+      after_script="">
+    <description />
+    <action
+        url="%(content_url)s/content_status_modify?workflow_action=document-transition-remove"
+        category=""
+        icon="">document-transition-remove</action>
+    <guard>
+      <guard-permission>Remove GEVER content</guard-permission>
+    </guard>
+  </transition>
+
+  <transition
+      transition_id="document-transition-restore"
+      title="document-transition-restore"
+      new_state="document-state-draft"
+      trigger="USER"
+      before_script=""
+      after_script="">
+    <description />
+    <action
+        url="%(content_url)s/content_status_modify?workflow_action=document-transition-restore"
+        category="workflow"
+        icon="">document-transition-restore</action>
+    <guard>
+      <guard-permission>Manage portal</guard-permission>
+    </guard>
+  </transition>
+
+  <worklist
+      worklist_id="reviewer_queue"
+      title="">
+    <description>Reviewer tasks</description>
+    <action
+        url="%(portal_url)s/search?review_state=document-state-pending"
+        category="global"
+        icon="">Pending (%(count)d)</action>
+    <guard>
+      <guard-permission>Review portal content</guard-permission>
+    </guard>
+    <match
+        name="review_state"
+        values="document-state-pending"
+        />
+  </worklist>
+  <variable
+      variable_id="action"
+      for_catalog="False"
+      for_status="True"
+      update_always="True">
+    <description>Previous transition</description>
+    <default>
+
+      <expression>transition/getId|nothing</expression>
+    </default>
+    <guard>
+    </guard>
+  </variable>
+  <variable
+      variable_id="actor"
+      for_catalog="False"
+      for_status="True"
+      update_always="True">
+    <description>The ID of the user who performed the previous transition</description>
+    <default>
+
+      <expression>user/getUserName</expression>
+    </default>
+    <guard>
+    </guard>
+  </variable>
+  <variable
+      variable_id="comments"
+      for_catalog="False"
+      for_status="True"
+      update_always="True">
+    <description>Comment about the last transition</description>
+    <default>
+
+      <expression>python:state_change.kwargs.get('comment', '')</expression>
+    </default>
+    <guard>
+    </guard>
+  </variable>
+  <variable
+      variable_id="review_history"
+      for_catalog="False"
+      for_status="False"
+      update_always="False">
+    <description>Provides access to workflow history</description>
+    <default>
+
+      <expression>state_change/getHistory</expression>
+    </default>
+    <guard>
+      <guard-permission>Request review</guard-permission>
+      <guard-permission>Review portal content</guard-permission>
+    </guard>
+  </variable>
+  <variable
+      variable_id="time"
+      for_catalog="False"
+      for_status="True"
+      update_always="True">
+    <description>When the previous transition was performed</description>
+    <default>
+
+      <expression>state_change/getDateTime</expression>
+    </default>
+    <guard>
+    </guard>
+  </variable>
+</dc-workflow>

--- a/opengever/core/upgrades/20180726095934_add_placeful_workflow_for_inbox_area/workflows/opengever_inbox_workflow/definition.xml
+++ b/opengever/core/upgrades/20180726095934_add_placeful_workflow_for_inbox_area/workflows/opengever_inbox_workflow/definition.xml
@@ -1,0 +1,232 @@
+<dc-workflow
+    workflow_id="opengever_inbox_workflow"
+    title="Inbox Workflow"
+    description=""
+    state_variable="review_state"
+    initial_state="inbox-state-default"
+    manager_bypass="False">
+  <permission>Access contents information</permission>
+  <permission>Add portal content</permission>
+  <permission>List folder contents</permission>
+  <permission>Manage properties</permission>
+  <permission>Modify portal content</permission>
+  <permission>Sharing page: Delegate roles</permission>
+  <permission>View</permission>
+  <permission>ftw.mail: Add Inbound Mail</permission>
+  <permission>ftw.mail: Add Mail</permission>
+  <permission>opengever.document: Add document</permission>
+  <permission>opengever.dossier: Add businesscasedossier</permission>
+  <permission>opengever.inbox: Add Forwarding</permission>
+  <permission>opengever.task: Add task</permission>
+  <permission>opengever.trash: Trash content</permission>
+  <permission>opengever.trash: Untrash content</permission>
+  <permission>opengever.document: Cancel</permission>
+  <permission>opengever.document: Checkin</permission>
+  <permission>opengever.document: Checkout</permission>
+  <permission>opengever.inbox: Scan In</permission>
+  <state
+      state_id="inbox-state-default"
+      title="inbox-state-default">
+    <exit-transition transition_id="dossier-transition-deactivate" />
+    <exit-transition transition_id="dossier-transition-resolve" />
+    <permission-map
+        name="Access contents information"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>Reader</permission-role>
+      <permission-role>Administrator</permission-role>
+    </permission-map>
+    <permission-map
+        name="Add portal content"
+        acquired="False">
+      <permission-role>Contributor</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>Administrator</permission-role>
+    </permission-map>
+    <permission-map
+        name="List folder contents"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map
+        name="Manage properties"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>Reader</permission-role>
+      <permission-role>Administrator</permission-role>
+    </permission-map>
+    <permission-map
+        name="Modify portal content"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map
+        name="Sharing page: Delegate roles"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>Administrator</permission-role>
+    </permission-map>
+    <permission-map
+        name="View"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>Reader</permission-role>
+      <permission-role>Administrator</permission-role>
+    </permission-map>
+    <permission-map
+        name="ftw.mail: Add Inbound Mail"
+        acquired="False">
+      <permission-role>Contributor</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>Administrator</permission-role>
+    </permission-map>
+    <permission-map
+        name="ftw.mail: Add Mail"
+        acquired="False">
+      <permission-role>Contributor</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>Administrator</permission-role>
+    </permission-map>
+    <permission-map
+        name="opengever.document: Add document"
+        acquired="False">
+      <permission-role>Contributor</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>Administrator</permission-role>
+    </permission-map>
+    <permission-map
+        name="opengever.document: Cancel"
+        acquired="False">
+  </permission-map>
+    <permission-map
+        name="opengever.document: Checkin"
+        acquired="False">
+  </permission-map>
+    <permission-map
+        name="opengever.document: Checkout"
+        acquired="False">
+  </permission-map>
+    <permission-map
+        name="opengever.dossier: Add businesscasedossier"
+        acquired="False">
+      <permission-role>Contributor</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>Administrator</permission-role>
+    </permission-map>
+    <permission-map
+        name="opengever.inbox: Add Forwarding"
+        acquired="False">
+      <permission-role>Contributor</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>Administrator</permission-role>
+    </permission-map>
+    <permission-map
+        name="opengever.inbox: Scan In"
+        acquired="True">
+      <permission-role>Contributor</permission-role>
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map
+        name="opengever.task: Add task"
+        acquired="False">
+  </permission-map>
+    <permission-map
+        name="opengever.trash: Trash content"
+        acquired="False">
+      <permission-role>Contributor</permission-role>
+      <permission-role>Editor</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>Administrator</permission-role>
+    </permission-map>
+    <permission-map
+        name="opengever.trash: Untrash content"
+        acquired="False">
+      <permission-role>Contributor</permission-role>
+      <permission-role>Editor</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>Administrator</permission-role>
+    </permission-map>
+  </state>
+  <worklist
+      worklist_id="reviewer_queue"
+      title="">
+    <description>Reviewer tasks</description>
+    <action
+        url="%(portal_url)s/search?review_state=pending"
+        category="global"
+        icon="">Pending (%(count)d)</action>
+    <guard>
+      <guard-permission>Review portal content</guard-permission>
+    </guard>
+    <match
+        name="review_state"
+        values="pending"
+        />
+  </worklist>
+  <variable
+      variable_id="action"
+      for_catalog="False"
+      for_status="True"
+      update_always="True">
+    <description>The last transition</description>
+    <default>
+
+      <expression>transition/getId|nothing</expression>
+    </default>
+    <guard>
+  </guard>
+  </variable>
+  <variable
+      variable_id="actor"
+      for_catalog="False"
+      for_status="True"
+      update_always="True">
+    <description>The ID of the user who performed the last transition</description>
+    <default>
+
+      <expression>user/getId</expression>
+    </default>
+    <guard>
+  </guard>
+  </variable>
+  <variable
+      variable_id="comments"
+      for_catalog="False"
+      for_status="True"
+      update_always="True">
+    <description>Comments about the last transition</description>
+    <default>
+
+      <expression>python:state_change.kwargs.get('comment', '')</expression>
+    </default>
+    <guard>
+  </guard>
+  </variable>
+  <variable
+      variable_id="review_history"
+      for_catalog="False"
+      for_status="False"
+      update_always="False">
+    <description>Provides access to workflow history</description>
+    <default>
+
+      <expression>state_change/getHistory</expression>
+    </default>
+    <guard>
+      <guard-permission>View</guard-permission>
+    </guard>
+  </variable>
+  <variable
+      variable_id="time"
+      for_catalog="False"
+      for_status="True"
+      update_always="True">
+    <description>Time of the last transition</description>
+    <default>
+
+      <expression>state_change/getDateTime</expression>
+    </default>
+    <guard>
+  </guard>
+  </variable>
+</dc-workflow>

--- a/opengever/document/browser/overview.py
+++ b/opengever/document/browser/overview.py
@@ -276,6 +276,10 @@ class Overview(DefaultView, GeverTabMixin, ActionButtonRendererMixin):
         return get_css_class(context or self.context)
 
     def show_modfiy_public_trial_link(self):
+        parent_dossier = self.context.get_parent_dossier()
+        if not parent_dossier:
+            return False
+
         try:
             can_edit = edit_public_trial.can_access_public_trial_edit_form(
                 getSecurityManager().getUser(),
@@ -283,8 +287,7 @@ class Overview(DefaultView, GeverTabMixin, ActionButtonRendererMixin):
         except (AssertionError, ValueError):
             return False
 
-        state = api.content.get_state(
-            self.context.get_parent_dossier(), default=None)
+        state = api.content.get_state(parent_dossier, default=None)
         return can_edit and state in DOSSIER_STATES_CLOSED
 
     def show_preview(self):

--- a/opengever/document/tests/test_overview.py
+++ b/opengever/document/tests/test_overview.py
@@ -367,6 +367,16 @@ class TestDocumentOverviewVanilla(IntegrationTestCase):
             'Public trial edit link should be visible.')
 
     @browsing
+    def test_modify_public_trial_link_NOT_shown_on_inbox_documents(self, browser):
+        self.login(self.secretariat_user, browser)
+
+        browser.open(self.inbox_document, view='tabbedview_view-overview')
+
+        self.assertFalse(
+            browser.css('#form-widgets-IClassification-public_trial_statement').first.text,
+            'Public trial edit link should not be visible.')
+
+    @browsing
     def test_modify_public_trial_is_visible_on_closed_dossier_inside_a_task(self, browser):  # noqa
         self.login(self.regular_user, browser)
         self.set_workflow_state('dossier-state-resolved', self.dossier)
@@ -440,6 +450,16 @@ class TestDocumentOverviewVanilla(IntegrationTestCase):
             '/edit_archival_file',
             browser.css('#archival_file_edit_link').first.get('href'),
             )
+
+    @browsing
+    def test_edit_archival_file_link_is_disabled_on_inbox_documents(self, browser):  # noqa
+        self.login(self.secretariat_user, browser)
+
+        browser.open(self.inbox_document, view='tabbedview_view-overview')
+
+        self.assertFalse(
+            browser.css('#archival_file_edit_link'),
+            'Archival file edit link should not be visible.')
 
     @browsing
     def test_edit_archival_file_link_is_visible_on_closed_dossier_inside_a_task(self, browser):  # noqa

--- a/opengever/inbox/tests/test_workflow.py
+++ b/opengever/inbox/tests/test_workflow.py
@@ -1,0 +1,82 @@
+from ftw.testbrowser import browsing
+from opengever.testing import IntegrationTestCase
+from plone import api
+
+
+class TestInboxWorkflow(IntegrationTestCase):
+
+    @browsing
+    def test_only_managers_are_able_to_edit_inboxes(self, browser):
+        self.login(self.secretariat_user, browser=browser)
+        with browser.expect_unauthorized():
+            browser.open(self.inbox, view='edit')
+
+        self.login(self.administrator, browser=browser)
+        with browser.expect_unauthorized():
+            browser.open(self.inbox, view='edit')
+
+        self.login(self.manager, browser=browser)
+        browser.open(self.inbox, view='edit')
+        browser.fill({'Title': 'Eingangskorb 1'})
+        browser.click_on('Save')
+
+        self.assertEquals(200, browser.status_code)
+
+    def test_inbox_documents_uses_placeful_workflow(self):
+        self.login(self.secretariat_user)
+
+        wftool = api.portal.get_tool('portal_workflow')
+        self.assertEquals(
+            'opengever_inbox_document_workflow',
+            wftool.getWorkflowsFor(self.inbox_document)[0].id)
+
+    @browsing
+    def test_editors_are_able_to_edit_and_checkout_a_document(self, browser):
+        self.login(self.secretariat_user, browser=browser)
+
+        browser.open(self.inbox_document, view='edit')
+        browser.fill({'Title': 'Document Update'})
+        browser.click_on('Save')
+
+        self.assertEquals(200, browser.status_code)
+
+        browser.open(self.inbox_document, view='tabbedview_view-overview')
+        browser.click_on('Checkout and edit')
+
+        self.assertEquals(200, browser.status_code)
+        self.assertEquals(self.secretariat_user.id,
+                          self.inbox_document.checked_out_by())
+
+    def test_switch_to_regular_workflow_when_moving_a_document_to_repository(self):
+        self.login(self.secretariat_user)
+
+        moved = api.content.move(
+            source=self.inbox_document, target=self.dossier)
+
+        wftool = api.portal.get_tool('portal_workflow')
+        self.assertEquals(
+            'opengever_document_workflow',
+            wftool.getWorkflowsFor(moved)[0].id)
+
+    @browsing
+    def test_switch_to_regular_workflow_when_assign_to_dossier_via_forwarding(self, browser):
+        self.login(self.secretariat_user, browser=browser)
+
+        # step 1
+        browser.open(self.inbox_forwarding, view='tabbedview_view-overview')
+        browser.click_on('forwarding-transition-assign-to-dossier')
+        browser.fill({'Assign to a ...': 'existing_dossier',
+                      'Response': 'Sample response'}).submit()
+        # step 2
+        browser.fill(
+            {'form.widgets.dossier.widgets.query': 'Finanzverwaltung'}).submit()
+        browser.fill(
+            {'form.widgets.dossier':'/'.join(self.dossier.getPhysicalPath())})
+        browser.click_on('Save')
+        # step 3
+        browser.click_on('Save')
+
+        document, = browser.context.objectValues()
+        wftool = api.portal.get_tool('portal_workflow')
+        self.assertEquals('opengever_document_workflow',
+                          wftool.getWorkflowsFor(document)[0].id)

--- a/opengever/setup/profiles/default_content/content_creation/01_default_content.json
+++ b/opengever/setup/profiles/default_content/content_creation/01_default_content.json
@@ -12,7 +12,9 @@
         "_type": "opengever.inbox.inbox",
         "title_de": "Eingangskorb",
         "title_fr": "Boîte de réception",
-        "inbox_group": "og_mandant1_eingangskorb"
+        "inbox_group": "og_mandant1_eingangskorb",
+        "_placefulworkflow": ["opengever_inbox_policy",
+                              "opengever_inbox_policy"]
     },
     {
         "_path": "vorlagen",

--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -683,6 +683,15 @@ class OpengeverContentFixture(object):
                 )
             ))
 
+        # Enable inbox_policy placeful workflow
+        inbox_policy_id = 'opengever_inbox_policy'
+        self.inbox.manage_addProduct[
+            'CMFPlacefulWorkflow'].manage_addWorkflowPolicyConfig()
+        pwf_tool = api.portal.get_tool('portal_placeful_workflow')
+        policy_config = pwf_tool.getWorkflowPolicyConfig(self.inbox)
+        policy_config.setPolicyIn(inbox_policy_id, update_security=False)
+        policy_config.setPolicyBelow(inbox_policy_id, update_security=False)
+
         self.register('inbox_document', create(
             Builder('document')
             .within(self.inbox)


### PR DESCRIPTION
Currently inbox inbox group users are wrongly able to edit the inbox. Because those users should still be able to edit documents inside the inbox, we introduce a separate workflow for inbox_documents and adjust the inbox workflow:
 - Add a separate placeful workflow policy `opengever_inbox_workflow` enabled on inboxes and inbox-containers and below.
 - Separate inbox_document workflow which no longer acquires the permissions `Modify portal_content`, `Request review`, `opengever.document: Cancel`, `opengever.document: Checkin` and `opengever.document: Checkout`
 - Revoke `Modify_portal_content` for `Editors` and `Administrators on inboxes`
 - Upgradestep which enables the placeful_workflow policy for all inboxes or inbox-container and below.

Currently inbox users are not been able to Checkout/Checkin documents, but only edit metadata. This restriction does not make much sense in a functional view and there is also no technical reason  against. So the new inbox_document workflow also allow to checkout/checkin documents. 


Closes #1408

Besides the permissions adjustments, I found a bug in the `archival_file` and `public_trial` checks, and fixes those as well.
