### PR TITLE
Hide create proposal action on inboxes document listing tab.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -9,6 +9,7 @@ Changelog
 - Revoke local roles for responsible and agency when finishing a task. [phgross]
 - Allow administrators to export the repository as excel file. [njohner]
 - Document generated meeting documents. [tarnap]
+- Hide create proposal action on inboxes document listing tab. [phgross]
 - Add RoleAssignment manager layer including a new sharing form. [phgross]
 - Fix teamraum styles import / export for right logo. [tarnap]
 - Bump ftw.upgrade for deferrable upgrade support. [deiferni]

--- a/opengever/inbox/browser/tabs.py
+++ b/opengever/inbox/browser/tabs.py
@@ -78,7 +78,8 @@ class InboxDocuments(Documents):
     # do not list documents in forwardings
     depth = 1
 
-    disabled_actions = ['create_task',
+    disabled_actions = ['create_proposal',
+                        'create_task',
                         'submit_additional_documents']
 
     @property

--- a/opengever/inbox/tests/test_tabs.py
+++ b/opengever/inbox/tests/test_tabs.py
@@ -33,6 +33,17 @@ class TestInboxTabbedview(IntegrationTestCase):
              'Public Trial'],
             browser.css('.listing th').text)
 
+    @browsing
+    def test_add_task_and_proposal_action_are_hidden(self, browser):
+        self.login(self.secretariat_user, browser=browser)
+
+        browser.open(self.inbox, view='tabbedview_view-documents')
+
+        self.assertNotIn(
+            'Create Proposal', browser.css('#tabbedview-menu a').text)
+        self.assertNotIn(
+            'Create Task', browser.css('#tabbedview-menu a').text)
+
 
 class TestAssignedInboxTaskTab(IntegrationTestCase):
 


### PR DESCRIPTION
It's not possible to add a proposal to an inbox, therefore the create proposal action does not make sense.

I also convert the inbox tab tests to integration tests.

Closes #4646 