### PR TITLE
Only prefill dossier_manager as a form level default (instead of schema level)

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2018.4.0 (unreleased)
 ---------------------
 
+- Only prefill dossier_manager as a form level default (instead of schema level). [lgraf]
 - Fix officeconnector issue when invoked from url with trailing view name. [njohner]
 - Task forms: Drop unnecessary distinction between single/multi org unit setups. [lgraf]
 - Add the document UUID to the OC document payloads. [Rotonen]

--- a/opengever/base/tests/test_default_values_for_types.py
+++ b/opengever/base/tests/test_default_values_for_types.py
@@ -88,7 +88,7 @@ DOSSIER_DEFAULTS = {
     'start': FROZEN_TODAY,
     'reading': [],
     'reading_and_writing': [],
-    'dossier_manager': 'kathi.barfuss',
+    'dossier_manager': None,
 }
 DOSSIER_FORM_DEFAULTS = {
     'responsible': 'kathi.barfuss',

--- a/opengever/dossier/behaviors/protect_dossier.py
+++ b/opengever/dossier/behaviors/protect_dossier.py
@@ -10,33 +10,9 @@ from plone.behavior.annotation import AnnotationsFactoryImpl
 from plone.behavior.annotation import AnnotationStorage
 from plone.behavior.interfaces import ISchemaAwareFactory
 from plone.supermodel import model
-from Products.CMFPlone.utils import safe_unicode
 from zope import schema
 from zope.interface import alsoProvides
 from zope.interface import Interface
-from zope.interface import provider
-from zope.schema.interfaces import IContextAwareDefaultFactory
-
-
-@provider(IContextAwareDefaultFactory)
-def current_user(context):
-    userid = api.user.get_current().getId()
-
-    if not userid:
-        return None
-
-    try:
-        AllUsersAndGroupsSourceBinder()(context).getTerm(userid)
-    except LookupError:
-        # The current logged in user does not exist in the
-        # field-source.
-        return None
-
-    if 'Manager' in api.user.get_roles():
-        # We don't want to prefill managers.
-        return None
-
-    return safe_unicode(userid)
 
 
 class IProtectDossierMarker(Interface):
@@ -147,7 +123,6 @@ class IProtectDossier(model.Schema):
                 )
             ),
         source=AllUsersAndGroupsSourceBinder(),
-        defaultFactory=current_user,
         required=False,
         missing_value=None,
         )


### PR DESCRIPTION
The `dossier_manager` must not be a schema default, because otherwise the current user gets set as a default in situations other than user-created content via forms (programmatic content creation via OGGbundle import, REST API, etc...).

This changes the `dossier_manager` to be **just a form level default** instead of a schema level default.

*@phgross As discussed, I will refactor the form widget prefilling by introducing a common helper method to easily access `z3c.form` group widgets (in a later PR).* 

Fixes #4653