### PR TITLE
Task forms: Drop unnecessary distinction between single/multi org unit setups

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2018.4.0 (unreleased)
 ---------------------
 
+- Task forms: Drop unnecessary distinction between single/multi org unit setups. [lgraf]
 - Fix styling of dossier manager field, when a group is selected.[phgross]
 - Update fontawesome to version 5.2. [Kevin Bieri]
 - Revoke local roles for responsible and agency when finishing a task. [phgross]

--- a/opengever/task/browser/assign.py
+++ b/opengever/task/browser/assign.py
@@ -39,7 +39,7 @@ class IAssignSchema(Schema):
 
     responsible = schema.Choice(
         title=_(u"label_responsible", default=u"Responsible"),
-        description=_(u"help_responsible_single_client_setup", default=""),
+        description=_(u"help_responsible", default=""),
         source=AllUsersInboxesAndTeamsSourceBinder(
             only_current_inbox=True,
             only_current_orgunit=True,

--- a/opengever/task/browser/forms.py
+++ b/opengever/task/browser/forms.py
@@ -1,5 +1,3 @@
-from opengever.ogds.base.utils import ogds_service
-from opengever.task import _
 from opengever.task.activities import TaskAddedActivity
 from opengever.task.activities import TaskReassignActivity
 from opengever.task.task import IAddTaskSchema
@@ -139,20 +137,8 @@ class TaskEditForm(DefaultEditForm):
     """The standard dexterity EditForm with the following customizations:
 
      - Require the Edit Task permission
-     - Omit `responsible` and `responsible_client` fields and adjust field
-       description for single orgunit deployments
      - Records reassign activity when the responsible has changed.
     """
-
-    def update(self):
-        super(TaskEditForm, self).update()
-
-        # omit the responsible_client field and adjust the field description
-        # of the responsible field if there is only one client configured.
-        if not ogds_service().has_multiple_org_units():
-            self.groups[0].widgets['responsible_client'].mode = HIDDEN_MODE
-            self.groups[0].widgets['responsible'].field.description = _(
-                u"help_responsible_single_client_setup", default=u"")
 
     def applyChanges(self, data):
         """Records reassign activity when the responsible has changed.

--- a/opengever/task/locales/de/LC_MESSAGES/opengever.task.po
+++ b/opengever/task/locales/de/LC_MESSAGES/opengever.task.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2018-07-24 15:03+0000\n"
+"POT-Creation-Date: 2018-08-06 15:59+0000\n"
 "PO-Revision-Date: 2015-02-17 18:41+0100\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -323,22 +323,14 @@ msgstr "Kosten in CHF"
 msgid "help_expectedDuration"
 msgstr "Dauer in h"
 
+#: ./opengever/task/browser/assign.py
 #: ./opengever/task/task.py
 msgid "help_responsible"
-msgstr "Wählen Sie die verantwortliche Person aus."
+msgstr "Wählen Sie die verantwortlichen Personen aus."
 
 #: ./opengever/task/task.py
 msgid "help_responsible_client"
 msgstr "Wählen Sie zuerst den Mandanten des Auftragnehmers, anschliessend den Auftragnehmer."
-
-#: ./opengever/task/task.py
-msgid "help_responsible_multiple"
-msgstr "Wählen Sie die verantwortlichen Personen aus."
-
-#: ./opengever/task/browser/assign.py
-#: ./opengever/task/browser/forms.py
-msgid "help_responsible_single_client_setup"
-msgstr "Wählen Sie die verantwortliche Person aus"
 
 #: ./opengever/task/task.py
 msgid "help_task_type"

--- a/opengever/task/locales/fr/LC_MESSAGES/opengever.task.po
+++ b/opengever/task/locales/fr/LC_MESSAGES/opengever.task.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-24 15:03+0000\n"
+"POT-Creation-Date: 2018-08-06 15:59+0000\n"
 "PO-Revision-Date: 2017-12-03 11:47+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-task/fr/>\n"
@@ -325,22 +325,14 @@ msgid "help_expectedDuration"
 msgstr "Durée effective en h"
 
 #. Default: "Select the responsible user from the client chosen above, or the corresponding inbox."
+#: ./opengever/task/browser/assign.py
 #: ./opengever/task/task.py
 msgid "help_responsible"
-msgstr "Sélectionnez la personne responsable."
+msgstr "Sélectionnez les personnes responsables."
 
 #: ./opengever/task/task.py
 msgid "help_responsible_client"
 msgstr "Sélectionner d'abord le client du mandataire et ensuite le mandataire."
-
-#: ./opengever/task/task.py
-msgid "help_responsible_multiple"
-msgstr "Sélectionnez les personnes responsables."
-
-#: ./opengever/task/browser/assign.py
-#: ./opengever/task/browser/forms.py
-msgid "help_responsible_single_client_setup"
-msgstr "Choix de la personne responsable"
 
 #: ./opengever/task/task.py
 msgid "help_task_type"

--- a/opengever/task/locales/opengever.task.pot
+++ b/opengever/task/locales/opengever.task.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2018-07-24 15:03+0000\n"
+"POT-Creation-Date: 2018-08-06 15:59+0000\n"
 "PO-Revision-Date: 2009-02-25 14:39+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -323,21 +323,13 @@ msgstr ""
 msgid "help_expectedDuration"
 msgstr ""
 
+#: ./opengever/task/browser/assign.py
 #: ./opengever/task/task.py
 msgid "help_responsible"
 msgstr ""
 
 #: ./opengever/task/task.py
 msgid "help_responsible_client"
-msgstr ""
-
-#: ./opengever/task/task.py
-msgid "help_responsible_multiple"
-msgstr ""
-
-#: ./opengever/task/browser/assign.py
-#: ./opengever/task/browser/forms.py
-msgid "help_responsible_single_client_setup"
 msgstr ""
 
 #: ./opengever/task/task.py

--- a/opengever/task/task.py
+++ b/opengever/task/task.py
@@ -265,7 +265,7 @@ class IAddTaskSchema(ITask):
 
     responsible = schema.List(
         title=_(u"label_responsible", default=u"Responsible"),
-        description=_(u"help_responsible_multiple", default=""),
+        description=_(u"help_responsible", default=""),
         value_type=schema.Choice(
             source=AllUsersInboxesAndTeamsSourceBinder(include_teams=True),
             ),


### PR DESCRIPTION
This is not necessary any mode, since the `responsible_client` field is now purely internal and is [always hidden](https://github.com/4teamwork/opengever.core/blob/871272d901bcce701e4bce01180f392bcdf82a35/opengever/task/task.py#L135). Also the description for the `responsible` field should be the same for both single and multi org unit deployments, so the translations can be homogenized.