### PR TITLE
Add eTag adapter for the clipboard

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -11,6 +11,7 @@ Changelog
 - Sort excerpts by title. [Rotonen]
 - Task forms: Drop unnecessary distinction between single/multi org unit setups. [lgraf]
 - Add the document UUID to the OC document payloads. [Rotonen]
+- Add eTag adapter for the clipboard. [phgross]
 - Fix styling of dossier manager field, when a group is selected.[phgross]
 - Update fontawesome to version 5.2. [Kevin Bieri]
 - Add missing icon in Activity settings. [njohner]

--- a/opengever/base/clipboard.py
+++ b/opengever/base/clipboard.py
@@ -1,6 +1,10 @@
 from OFS.CopySupport import cookie_path
+from plone.app.caching.interfaces import IETagValue
 from plone.app.uuid.utils import uuidToObject
 from plone.uuid.interfaces import IUUID
+from zope.component import adapts
+from zope.interface import implements
+from zope.interface import Interface
 import json
 
 
@@ -17,8 +21,11 @@ class Clipboard(object):
         self.request.RESPONSE.setCookie(
             self.key, value, path=str(cookie_path(self.request)))
 
+    def get_request_value(self):
+        return self.request.cookies.get(self.key)
+
     def get_objs(self):
-        value = self.request.cookies.get(self.key)
+        value = self.get_request_value()
         if value:
             uuids = json.loads(value.decode('base64'))
             return [uuidToObject(uuid) for uuid in uuids]
@@ -29,3 +36,15 @@ class Clipboard(object):
         # Return a "path" value for use in a cookie that refers
         # to the root of the Zope object space.
         return self.request['BASEPATH1'] or "/"
+
+
+class ClipboardETagValue(object):
+    implements(IETagValue)
+    adapts(Interface, Interface)
+
+    def __init__(self, published, request):
+        self.published = published
+        self.request = request
+
+    def __call__(self):
+        return Clipboard(self.request).get_request_value()

--- a/opengever/base/configure.zcml
+++ b/opengever/base/configure.zcml
@@ -63,6 +63,11 @@
       name="favorite"
       />
 
+  <adapter
+      factory=".clipboard.ClipboardETagValue"
+      name="clipboard"
+      />
+
   <configure package="collective.quickupload.browser">
     <browser:page
         class="opengever.base.quickupload.OGQuickUploadView"

--- a/opengever/base/tests/test_copy_paste.py
+++ b/opengever/base/tests/test_copy_paste.py
@@ -5,6 +5,7 @@ from ftw.testbrowser.pages.statusmessages import error_messages
 from ftw.testbrowser.pages.statusmessages import info_messages
 from opengever.base.interfaces import ISequenceNumber
 from opengever.testing import IntegrationTestCase
+from plone.protect import createToken
 from zope.component import getUtility
 
 
@@ -213,3 +214,19 @@ class TestCopyPaste(IntegrationTestCase):
         self.assertEqual(
             ["Can't paste items, the context does not allow pasting items."],
             error_messages())
+
+
+class TestClipboardCaching(IntegrationTestCase):
+
+    @browsing
+    def test_paste_action_occurance_is_not_cached(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        browser.open(self.dossier)
+        browser.open(self.document, view='copy_item',
+                     data={'_authenticator': createToken()})
+
+        browser.open(self.dossier)
+        self.assertIn(
+            'Paste',
+            browser.css('#plone-contentmenu-actions .actionMenuContent a').text)

--- a/opengever/core/profiles/default/registry.xml
+++ b/opengever/core/profiles/default/registry.xml
@@ -48,6 +48,7 @@
       <element>redirector</element>
       <element>repository-favorites</element>
       <element>favorite</element>
+      <element>clipboard</element>
     </value>
   </record>
 

--- a/opengever/core/upgrades/20180806174312_add_clipboard_e_tag/registry.xml
+++ b/opengever/core/upgrades/20180806174312_add_clipboard_e_tag/registry.xml
@@ -1,0 +1,9 @@
+<registry>
+
+  <record name="plone.app.caching.weakCaching.plone.content.folderView.etags">
+    <value purge="False">
+      <element>clipboard</element>
+    </value>
+  </record>
+
+</registry>

--- a/opengever/core/upgrades/20180806174312_add_clipboard_e_tag/upgrade.py
+++ b/opengever/core/upgrades/20180806174312_add_clipboard_e_tag/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddClipboardETag(UpgradeStep):
+    """Add clipboard eTag.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()


### PR DESCRIPTION
to make sure that the paste action occurrence is not cached. Closes #4647.