### PR TITLE
Do not show lockinfo in mail edit form.

### DIFF
--- a/opengever/locking/info.py
+++ b/opengever/locking/info.py
@@ -55,7 +55,8 @@ class GeverLockInfoViewlet(LockInfoViewlet):
         return "Manager" in api.user.get_roles()
 
     def is_edit_form(self):
-        return IEditForm.providedBy(self.view)
+        return (IEditForm.providedBy(self.view)
+                or IEditForm.providedBy(getattr(self.view, "form_instance", None)))
 
     def get_related_meeting_from_protocol(self):
         oguid = Oguid.for_object(self.context)


### PR DESCRIPTION
Not sure why but when editing an E-mail, the view attribute of the lockinfo viewlet is the form wrapper (`Products.Five.metaclass.MyFormWrapper`) and not the form itself. Hence it does not provide the `IEditForm` interface and we first need to get the form instance in that case.

I'd be happy with a cleaner solution though...

fixes #4662 