### PR TITLE
Fix base URL tag for contentish objects.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2018.4.0 (unreleased)
 ---------------------
 
+- Fix base URL for contentish objects. [njohner]
 - Bump Chameleon to 3.3 in order to fix edge case in exception handler causing recursion. [lgraf]
 - Move excerpts to the file info box on proposal overviews. [Rotonen]
 - Bump plone.restapi to 3.4.1 version. [phgross]

--- a/opengever/base/browser/layout.py
+++ b/opengever/base/browser/layout.py
@@ -1,3 +1,4 @@
+from AccessControl import Unauthorized
 from opengever.base.interfaces import ISQLObjectWrapper
 from opengever.bumblebee import is_bumblebee_feature_enabled
 from opengever.meeting import is_meeting_feature_enabled
@@ -28,3 +29,22 @@ class GeverLayoutPolicy(LayoutPolicy):
                 normalize(type(self.context.model).__name__)))
 
         return ' '.join(classes)
+
+    def renderBase(self):
+        """Fixes the base url in the case of contentish objects.
+        LayoutPolicy incorrectly returns the request URL for contentish
+        objects, including the view name.
+        This is fixed in Plone 4.3.16 by introducing a new data attribute
+        on the body tag, data-base-url, which should contain the correct
+        base url, but actually also has a bug in a fallback setting the
+        url to the referer.
+        Moreover we make sure that the base url ends with a slash as
+        the browser will cut it to the last slash
+        """
+        context = self.context
+
+        # when accessing via WEBDAV you're not allowed to access aq_base
+        try:
+            return context.absolute_url().rstrip('/') + '/'
+        except Unauthorized:
+            pass

--- a/opengever/base/tests/test_layout.py
+++ b/opengever/base/tests/test_layout.py
@@ -1,5 +1,7 @@
 from ftw.testbrowser import browsing
 from opengever.testing import IntegrationTestCase
+from plone import api
+from zope.component import getMultiAdapter
 
 
 class TestGeverLayoutPolicy(IntegrationTestCase):
@@ -45,3 +47,14 @@ class TestGeverLayoutPolicy(IntegrationTestCase):
         self.activate_feature('meeting')
         browser.open(self.meeting)
         self.assertIn('model-meeting', browser.css('body').first.classes)
+
+    def test_render_base_returns_correct_url(self):
+        self.login(self.manager)
+        portal = api.portal.get()
+        contents = api.content.find(context=portal)
+        portal_types = set(el.portal_type for el in contents)
+        for portal_type in portal_types:
+            brains = api.content.find(portal_type=portal_type)
+            obj = brains[0].getObject()
+            layout = getMultiAdapter((obj, self.request), name=u'plone_layout')
+            self.assertEqual(layout.renderBase(), obj.absolute_url().rstrip("/") + "/")


### PR DESCRIPTION
We fix the base URL for contentish objects, which was incorrectly set to the request URL, hence including the view name.
This is for issue #4672, fixing the problem for the 2018.4 release, but the issue should not be closed as we will implement a better solution for 2018.5.

In the meantime, this resolves #4671