### PR TITLE
Fix officeconnector issue with urls including view name

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2018.4.0 (unreleased)
 ---------------------
 
+- Fix officeconnector issue when invoked from url with trailing view name. [njohner]
 - Task forms: Drop unnecessary distinction between single/multi org unit setups. [lgraf]
 - Add the document UUID to the OC document payloads. [Rotonen]
 - Fix styling of dossier manager field, when a group is selected.[phgross]

--- a/opengever/document/static/officeconnector.js
+++ b/opengever/document/static/officeconnector.js
@@ -135,7 +135,7 @@ function officeConnectorMultiAttach(url) {
         dossier_config.headers = {};
         dossier_config.headers['Accept'] = 'application/json';
         dossier_config.type = 'GET';
-        dossier_config.url = window.location.pathname + '/attributes';
+        dossier_config.url = document.getElementsByTagName('base')[0].href + '/attributes';
 
         dossier_attributes = $.ajax(dossier_config);
 


### PR DESCRIPTION
Office connector uses the window location as base url for the dossier, but this does not work when called from a url with the trailing view name. Instead we can use the `href` attribute of the `base` tag.
This works as is, we do not need to fix #4672 first as the base url is already correct for folderish objects.

resolves #4665