### PR TITLE
Make sure dossier manager field is set when protecting a dossier.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ---------------------
 
 - Only prefill dossier_manager as a form level default (instead of schema level). [lgraf]
+- Make sure dossier manager field is set when protecting a dossier. [njohner]
 - Fix officeconnector issue when invoked from url with trailing view name. [njohner]
 - Task forms: Drop unnecessary distinction between single/multi org unit setups. [lgraf]
 - Add the document UUID to the OC document payloads. [Rotonen]

--- a/opengever/dossier/behaviors/protect_dossier.py
+++ b/opengever/dossier/behaviors/protect_dossier.py
@@ -13,6 +13,8 @@ from plone.supermodel import model
 from zope import schema
 from zope.interface import alsoProvides
 from zope.interface import Interface
+from zope.interface import Invalid
+from zope.interface import invariant
 
 
 class IProtectDossierMarker(Interface):
@@ -126,6 +128,13 @@ class IProtectDossier(model.Schema):
         required=False,
         missing_value=None,
         )
+
+    @invariant
+    def dossier_manager_filled_if_protection(self):
+        if ((self.reading_and_writing or self.reading)
+                and not self.dossier_manager):
+            raise Invalid(_("A dossier manager must be selected "
+                            " when protecting a dossier"))
 
 
 alsoProvides(IProtectDossier, IFormFieldProvider)

--- a/opengever/dossier/locales/de/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/de/LC_MESSAGES/opengever.dossier.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2018-07-13 15:27+0000\n"
+"POT-Creation-Date: 2018-08-07 14:25+0000\n"
 "PO-Revision-Date: 2017-05-23 04:53+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: German <https://translations.onegovgever.ch/projects/onegov-gever/opengever-dossier/de/>\n"
@@ -19,6 +19,10 @@ msgstr ""
 #: ./opengever/dossier/move_items.py
 msgid "${copied_items} Elements were moved successfully"
 msgstr "${copied_items} Elemente wurden erfolgreich verschoben"
+
+#: ./opengever/dossier/behaviors/protect_dossier.py
+msgid "A dossier manager must be selected  when protecting a dossier"
+msgstr "Ein Dossier-Verwalter muss ausgewählt werden um das Dossier schützen zu können."
 
 #. Default: "Geschäftsdossier"
 msgid "Add Business Case Dossier"
@@ -295,7 +299,7 @@ msgid "documents"
 msgstr "Dokumente"
 
 #. Default: "The local roles do not match with the current dossier protection settings. If you save this form, the local roles will be overridden."
-#: ./opengever/dossier/browser/forms.py
+#: ./opengever/dossier/browser/protect_dossier.py
 msgid "dossier_protection_inconsistency_warning"
 msgstr "Die lokalen Berechtigungen stimmen nicht mit den Dossier-Schutz Einstellungen überein. Wenn Sie dieses Formular speichern, werden die aktuellen lokalen Berechtigungen mit den Dossier-Schutz Einstellungen überschrieben."
 
@@ -510,7 +514,6 @@ msgid "label_creator"
 msgstr "Erstellt von"
 
 #. Default: "Description"
-#: ./opengever/dossier/browser/overview.py
 #: ./opengever/dossier/templatefolder/tabs.py
 msgid "label_description"
 msgstr "Beschreibung"

--- a/opengever/dossier/locales/fr/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/fr/LC_MESSAGES/opengever.dossier.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-13 15:27+0000\n"
+"POT-Creation-Date: 2018-08-07 14:25+0000\n"
 "PO-Revision-Date: 2017-12-03 11:16+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-dossier/fr/>\n"
@@ -19,6 +19,10 @@ msgstr ""
 #: ./opengever/dossier/move_items.py
 msgid "${copied_items} Elements were moved successfully"
 msgstr "Les éléments ${copied_items} ont été déplacés avec succès."
+
+#: ./opengever/dossier/behaviors/protect_dossier.py
+msgid "A dossier manager must be selected  when protecting a dossier"
+msgstr "Un administrateur du dossier doit être sélectionné pour pouvoir protéger le dossier."
 
 msgid "Add Business Case Dossier"
 msgstr "Ajouter un dossier d'affaire"
@@ -267,9 +271,7 @@ msgstr "Créer un dossier d'affaire à partir du modèle"
 #. Default: "This user or group will get the dossier manager role after protecting the dossier."
 #: ./opengever/dossier/behaviors/protect_dossier.py
 msgid "description_dossier_manager"
-msgstr ""
-"Choisissez un utilisateur ou un groupe pouvant modifier ou enlever la "
-"protection d'un dossier ayant été protégé. Normalement c'est vous-même."
+msgstr "Choisissez un utilisateur ou un groupe pouvant modifier ou enlever la protection d'un dossier ayant été protégé. Normalement c'est vous-même."
 
 #. Default: "The defined keywords will be preselected for new dossies from template."
 #: ./opengever/dossier/dossiertemplate/behaviors.py
@@ -279,17 +281,12 @@ msgstr "En activant cette option les mots-clés définis seront présélectionn�
 #. Default: "Choose users and groups which have only readable access to the dossier"
 #: ./opengever/dossier/behaviors/protect_dossier.py
 msgid "description_reading"
-msgstr ""
-"Choisissez les utilisateurs ou groupes obtenant accès en lecture seule au "
-"dossier."
+msgstr "Choisissez les utilisateurs ou groupes obtenant accès en lecture seule au dossier."
 
 #. Default: "Choose users and groups which have readable and writing access to the dossier"
 #: ./opengever/dossier/behaviors/protect_dossier.py
 msgid "description_reading_and_writing"
-msgstr ""
-"Choisissez les utilisateurs ou groupes obtenant accès en lecture et écriture "
-"au dossier. Les utilisateurs de ce groupe seront autorisés à traiter le "
-"dossier, ainsi qu'à créer et modifier des contenus."
+msgstr "Choisissez les utilisateurs ou groupes obtenant accès en lecture et écriture au dossier. Les utilisateurs de ce groupe seront autorisés à traiter le dossier, ainsi qu'à créer et modifier des contenus."
 
 #. Default: "The user can choose only from the defined keywords in a new dossier from template. It also prevents the user for creating new keywords"
 #: ./opengever/dossier/dossiertemplate/behaviors.py
@@ -300,13 +297,9 @@ msgid "documents"
 msgstr "Documents"
 
 #. Default: "The local roles do not match with the current dossier protection settings. If you save this form, the local roles will be overridden."
-#: ./opengever/dossier/browser/forms.py
+#: ./opengever/dossier/browser/protect_dossier.py
 msgid "dossier_protection_inconsistency_warning"
-msgstr ""
-"Les autorisations actuelles ne correspondent pas aux paramètres de "
-"protection du dossier. En enregistrant ce formulaire, les autorisations "
-"locales actuelles seront écrasées par les paramètres de protection du "
-"dossier."
+msgstr "Les autorisations actuelles ne correspondent pas aux paramètres de protection du dossier. En enregistrant ce formulaire, les autorisations locales actuelles seront écrasées par les paramètres de protection du dossier."
 
 #. Default: "It isn't allowed to add such items there: ${failed_objects}"
 #: ./opengever/dossier/move_items.py
@@ -519,7 +512,6 @@ msgid "label_creator"
 msgstr "Créé par"
 
 #. Default: "Description"
-#: ./opengever/dossier/browser/overview.py
 #: ./opengever/dossier/templatefolder/tabs.py
 msgid "label_description"
 msgstr "Description"

--- a/opengever/dossier/locales/opengever.dossier.pot
+++ b/opengever/dossier/locales/opengever.dossier.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-13 15:27+0000\n"
+"POT-Creation-Date: 2018-08-07 14:25+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,6 +19,10 @@ msgstr ""
 
 #: ./opengever/dossier/move_items.py
 msgid "${copied_items} Elements were moved successfully"
+msgstr ""
+
+#: ./opengever/dossier/behaviors/protect_dossier.py
+msgid "A dossier manager must be selected  when protecting a dossier"
 msgstr ""
 
 msgid "Add Business Case Dossier"
@@ -294,7 +298,7 @@ msgid "documents"
 msgstr ""
 
 #. Default: "The local roles do not match with the current dossier protection settings. If you save this form, the local roles will be overridden."
-#: ./opengever/dossier/browser/forms.py
+#: ./opengever/dossier/browser/protect_dossier.py
 msgid "dossier_protection_inconsistency_warning"
 msgstr ""
 
@@ -509,7 +513,6 @@ msgid "label_creator"
 msgstr ""
 
 #. Default: "Description"
-#: ./opengever/dossier/browser/overview.py
 #: ./opengever/dossier/templatefolder/tabs.py
 msgid "label_description"
 msgstr ""


### PR DESCRIPTION
We require that the dossier manager field is set when `reading` or `reading_writing` protection is set.
An exception is raised if this is not the case:

![screen shot 2018-08-07 at 16 49 38](https://user-images.githubusercontent.com/7374243/43783396-f134a562-9a61-11e8-8529-a2b97fe5af4f.png)

resolves #4673 