### PR TITLE
Lock oder of avaialbe roles in sharing endpoint.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2018.4.0 (unreleased)
 ---------------------
 
+- Lock oder of avaialbe roles in sharing endpoint. [phgross]
 - Fix archival_file and public_trial checks on documents overview. [phgross]
 - Add placeful workflow policy for inbox-area. Let inbox users edit and checkout documents but not the inbox itself. [phgross]
 - Fix base URL for contentish objects. [njohner]

--- a/opengever/api/sharing.py
+++ b/opengever/api/sharing.py
@@ -1,5 +1,6 @@
 from opengever.base.role_assignments import ASSIGNMENT_VIA_SHARING
 from opengever.base.role_assignments import RoleAssignmentManager
+from opengever.sharing.browser.sharing import ROLES_ORDER
 from opengever.sharing.security import disabled_permission_check
 from plone.restapi.interfaces import ISerializeToJson
 from plone.restapi.services.content.sharing import SharingGet as APISharingGet
@@ -27,6 +28,7 @@ class SharingGet(APISharingGet):
         serializer = queryMultiAdapter((self.context, self.request),
                                        interface=ISerializeToJson,
                                        name='local_roles')
+
         if serializer is None:
             self.request.response.setStatus(501)
             return dict(error=dict(message='No serializer available.'))
@@ -36,6 +38,11 @@ class SharingGet(APISharingGet):
                 data = serializer(search=self.request.form.get('search'))
         else:
             data = serializer(search=self.request.form.get('search'))
+
+        # sort available roles
+        data['available_roles'].sort(
+            lambda a, b: cmp(ROLES_ORDER.index(a['id']),
+                             ROLES_ORDER.index(b['id'])))
 
         return data
 

--- a/opengever/sharing/browser/sharing.py
+++ b/opengever/sharing/browser/sharing.py
@@ -35,6 +35,9 @@ import json
 import re
 
 
+ROLES_ORDER = ['Reader', 'Contributor', 'Editor', 'Reviewer',
+               'Publisher', 'DossierManager']
+
 ROLE_MAPPING = (
     (IDossier, (
         (u'Reader', _('sharing_dossier_reader')),

--- a/opengever/sharing/tests/test_sharing.py
+++ b/opengever/sharing/tests/test_sharing.py
@@ -20,7 +20,7 @@ class TestOpengeverSharingIntegration(IntegrationTestCase):
         browser.open(self.dossier, view='@sharing',
                      method='GET', headers={'Accept': 'application/json'})
 
-        self.assertItemsEqual(
+        self.assertEqual(
             [u'Reader', u'Contributor', u'Editor', u'Reviewer', u'Publisher'],
             [role['id'] for role in browser.json.get('available_roles')])
 
@@ -31,7 +31,7 @@ class TestOpengeverSharingIntegration(IntegrationTestCase):
         browser.open(self.templates, view='@sharing',
                      method='GET', headers={'Accept': 'application/json'})
 
-        self.assertItemsEqual(
+        self.assertEqual(
             [u'Reader', u'Contributor', u'Editor'],
             [role['id'] for role in browser.json.get('available_roles')])
 
@@ -48,11 +48,11 @@ class TestOpengeverSharingIntegration(IntegrationTestCase):
         browser.open(self.dossier, view='@sharing?ignore_permissions=1',
                      method='GET', headers={'Accept': 'application/json'})
 
-        self.assertItemsEqual(
+        self.assertEqual(
             [u'Reader', u'Contributor', u'Editor',
              u'Reviewer', u'Publisher', u'DossierManager'],
             [role['id'] for role in browser.json.get('available_roles')])
-        self.assertItemsEqual(
+        self.assertEqual(
             [u'Publisher', u'DossierManager', u'Editor',
              u'Reader', u'Contributor', u'Reviewer'],
             browser.json['entries'][0]['roles'].keys())


### PR DESCRIPTION
With the plone.restapi version dump, I dropped the order of available roles. Because the user is used to the current role order, we want to lock this.