### PR TITLE
Add version pinning for plone.schema.

### DIFF
--- a/versions.cfg
+++ b/versions.cfg
@@ -149,6 +149,7 @@ plone.recipe.command = 1.1
 plone.recipe.precompiler = 0.6
 plone.rest = 1.2.0
 plone.restapi = 3.4.1
+plone.schema = 1.2.0
 plonegov.pdflatex = 1.5.1
 plonegov.recipe.pdflatex = 0.5
 plumber = 1.5


### PR DESCRIPTION
Used by the newer version of plone.restapi.