### PR TITLE
Prevent breaking proposal documents with file replacements

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -13,6 +13,7 @@ Changelog
 - Change wording for "Return Excerpt" from "zurücksenden" to "ablegen". [njohner]
 - Add modification and creation date column to document listings. [njohner]
 - Fix handling of unidirectional by reference tasks in a sequential process. [phgross]
+- Disallow replacing the file on proposal documents with a non-.docx file. [Rotonen]
 - Disallow removing the file from proposal documents. [Rotonen]
 
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -13,6 +13,7 @@ Changelog
 - Change wording for "Return Excerpt" from "zurücksenden" to "ablegen". [njohner]
 - Add modification and creation date column to document listings. [njohner]
 - Fix handling of unidirectional by reference tasks in a sequential process. [phgross]
+- Disallow removing the file from proposal documents. [Rotonen]
 
 
 2018.4.2 (2018-08-30)

--- a/opengever/document/base.py
+++ b/opengever/document/base.py
@@ -52,7 +52,7 @@ class BaseDocumentMixin(object):
             return parent
         if ITask.providedBy(parent):
             return parent.get_containing_dossier()
-        if IProposal.providedBy(parent):
+        if self.is_inside_a_proposal():
             return parent.get_containing_dossier()
 
         return None
@@ -70,9 +70,8 @@ class BaseDocumentMixin(object):
 
         This may return a "proposal" or a "submitted proposal".
         """
-        parent = aq_parent(aq_inner(self))
-        if IProposal.providedBy(parent):
-            return parent
+        if self.is_inside_a_proposal():
+            return aq_parent(aq_inner(self))
 
         # Find submitted proposal when self is an excerpt document in the
         # meeting dossier.
@@ -101,6 +100,10 @@ class BaseDocumentMixin(object):
     @property
     def is_mail(self):
         return False
+
+    def is_inside_a_proposal(self):
+        parent = aq_parent(aq_inner(self))
+        return IProposal.providedBy(parent)
 
     def related_items(self):
         raise NotImplementedError

--- a/opengever/document/document.py
+++ b/opengever/document/document.py
@@ -109,6 +109,8 @@ class UploadValidator(validator.SimpleFieldValidator):
         it should be added as Mail object (see opengever.mail).
 
         Only .docx files are accepted into proposal documents.
+
+        Removing a file is not an option for proposal documents.
         """
         if self.request.form.get('form.widgets.file.action') == 'remove':
             if self.is_proposal_upload():

--- a/opengever/document/document.py
+++ b/opengever/document/document.py
@@ -15,7 +15,6 @@ from opengever.document.behaviors.related_docs import IRelatedDocuments
 from opengever.document.interfaces import ICheckinCheckoutManager
 from opengever.document.versioner import Versioner
 from opengever.dossier.behaviors.dossier import IDossierMarker
-from opengever.meeting.proposal import IProposal
 from opengever.meeting.proposal import ISubmittedProposal
 from opengever.officeconnector.helpers import create_oc_url
 from opengever.officeconnector.helpers import is_officeconnector_checkout_feature_enabled  # noqa
@@ -108,7 +107,15 @@ class UploadValidator(validator.SimpleFieldValidator):
     def validate(self, value):
         """An mail upload as og.document should't be possible,
         it should be added as Mail object (see opengever.mail).
+
+        Only .docx files are accepted into proposal documents.
         """
+        if self.request.form.get('form.widgets.file.action') == 'remove':
+            if self.is_proposal_upload():
+                raise Invalid(_(
+                    u'error_proposal_no_document',
+                    default=(u"It's not possible to have no file in proposal documents.")
+                    ))
         if not value:
             return
 
@@ -116,8 +123,18 @@ class UploadValidator(validator.SimpleFieldValidator):
             return
 
         if self.is_email_upload(value.filename):
-
             self.raise_invalid()
+
+        if self.is_proposal_upload():
+            if not os.path.splitext(value.filename)[1].lower() == '.docx':
+                raise Invalid(_(
+                    u'error_proposal_document_type',
+                    default=(u"It's not possible to have non-.docx documents as proposal documents.")
+                    ))
+
+    def is_proposal_upload(self):
+        """The upload form context can be, for example, a Dossier."""
+        return getattr(self.context, 'is_inside_a_proposal', lambda: False)()
 
     def is_email_upload(self, filename):
         basename, extension = os.path.splitext(filename)
@@ -289,10 +306,6 @@ class Document(Item, BaseDocumentMixin):
     def is_inside_a_task(self):
         parent = aq_parent(aq_inner(self))
         return ITask.providedBy(parent)
-
-    def is_inside_a_proposal(self):
-        parent = aq_parent(aq_inner(self))
-        return IProposal.providedBy(parent)
 
     def is_submitted_document(self):
         parent = aq_parent(aq_inner(self))

--- a/opengever/document/locales/de/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/de/LC_MESSAGES/opengever.document.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2018-07-12 15:47+0000\n"
+"POT-Creation-Date: 2018-08-10 12:09+0000\n"
 "PO-Revision-Date: 2017-10-13 14:27+0200\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -196,6 +196,7 @@ msgstr "Sie haben keine Objekte ausgewählt."
 
 #. Default: "It's not possible to have non-.docx documents as proposal documents."
 #: ./opengever/document/document.py
+#: ./opengever/document/quick_upload.py
 msgid "error_proposal_document_type"
 msgstr "Antragsdokumente müssen immer eine Word-Datei sein, andere Dateiformate sind nicht erlaubt."
 

--- a/opengever/document/locales/de/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/de/LC_MESSAGES/opengever.document.po
@@ -199,6 +199,11 @@ msgstr "Sie haben keine Objekte ausgewählt."
 msgid "error_proposal_document_type"
 msgstr "Antragsdokumente müssen immer eine Word-Datei sein, andere Dateiformate sind nicht erlaubt."
 
+#. Default: "It's not possible to have no file in proposal documents."
+#: ./opengever/document/document.py
+msgid "error_proposal_no_document"
+msgstr "Antragsdokumente ohne Datei sind nicht erlaubt."
+
 #. Default: "Either the title or the file is required."
 #: ./opengever/document/document.py
 msgid "error_title_or_file_required"

--- a/opengever/document/locales/de/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/de/LC_MESSAGES/opengever.document.po
@@ -194,6 +194,11 @@ msgstr "Es ist nicht erlaubt hier E-Mails anzufügen. Bitte senden Sie das E-Mai
 msgid "error_no_items"
 msgstr "Sie haben keine Objekte ausgewählt."
 
+#. Default: "It's not possible to have non-.docx documents as proposal documents."
+#: ./opengever/document/document.py
+msgid "error_proposal_document_type"
+msgstr "Antragsdokumente müssen immer eine Word-Datei sein, andere Dateiformate sind nicht erlaubt."
+
 #. Default: "Either the title or the file is required."
 #: ./opengever/document/document.py
 msgid "error_title_or_file_required"

--- a/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
@@ -196,6 +196,11 @@ msgstr "Il n'est pas possible d'insérer des Email à cet endroit. Pour le faire
 msgid "error_no_items"
 msgstr "Vous n'avez sélectionné aucun élément."
 
+#. Default: "It's not possible to have non-.docx documents as proposal documents."
+#: ./opengever/document/document.py
+msgid "error_proposal_document_type"
+msgstr ""
+
 #. Default: "Either the title or the file is required."
 #: ./opengever/document/document.py
 msgid "error_title_or_file_required"

--- a/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-12 15:47+0000\n"
+"POT-Creation-Date: 2018-08-10 12:09+0000\n"
 "PO-Revision-Date: 2017-09-03 08:50+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-document/fr/>\n"
@@ -198,6 +198,7 @@ msgstr "Vous n'avez sélectionné aucun élément."
 
 #. Default: "It's not possible to have non-.docx documents as proposal documents."
 #: ./opengever/document/document.py
+#: ./opengever/document/quick_upload.py
 msgid "error_proposal_document_type"
 msgstr ""
 

--- a/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
@@ -201,6 +201,11 @@ msgstr "Vous n'avez sélectionné aucun élément."
 msgid "error_proposal_document_type"
 msgstr ""
 
+#. Default: "It's not possible to have no file in proposal documents."
+#: ./opengever/document/document.py
+msgid "error_proposal_no_document"
+msgstr ""
+
 #. Default: "Either the title or the file is required."
 #: ./opengever/document/document.py
 msgid "error_title_or_file_required"

--- a/opengever/document/locales/opengever.document.pot
+++ b/opengever/document/locales/opengever.document.pot
@@ -201,6 +201,11 @@ msgstr ""
 msgid "error_proposal_document_type"
 msgstr ""
 
+#. Default: "It's not possible to have no file in proposal documents."
+#: ./opengever/document/document.py
+msgid "error_proposal_no_document"
+msgstr ""
+
 #. Default: "Either the title or the file is required."
 #: ./opengever/document/document.py
 msgid "error_title_or_file_required"

--- a/opengever/document/locales/opengever.document.pot
+++ b/opengever/document/locales/opengever.document.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-12 15:47+0000\n"
+"POT-Creation-Date: 2018-08-10 12:09+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -198,6 +198,7 @@ msgstr ""
 
 #. Default: "It's not possible to have non-.docx documents as proposal documents."
 #: ./opengever/document/document.py
+#: ./opengever/document/quick_upload.py
 msgid "error_proposal_document_type"
 msgstr ""
 

--- a/opengever/document/locales/opengever.document.pot
+++ b/opengever/document/locales/opengever.document.pot
@@ -196,6 +196,11 @@ msgstr ""
 msgid "error_no_items"
 msgstr ""
 
+#. Default: "It's not possible to have non-.docx documents as proposal documents."
+#: ./opengever/document/document.py
+msgid "error_proposal_document_type"
+msgstr ""
+
 #. Default: "Either the title or the file is required."
 #: ./opengever/document/document.py
 msgid "error_title_or_file_required"

--- a/opengever/document/quick_upload.py
+++ b/opengever/document/quick_upload.py
@@ -1,10 +1,13 @@
 from Acquisition import aq_inner
 from collective.quickupload.interfaces import IQuickUploadFileFactory
+from opengever.document import _
 from opengever.document.document import IDocumentSchema
 from opengever.document.interfaces import ICheckinCheckoutManager
 from zExceptions import Unauthorized
 from zope.component import adapter
 from zope.component import getMultiAdapter
+from zope.globalrequest import getRequest
+from zope.i18n import translate
 from zope.interface import implementer
 import os
 
@@ -13,7 +16,10 @@ import os
 @adapter(IDocumentSchema)
 class QuickUploadFileUpdater(object):
     """Specific quick_upload adapter for documents, which only replace the file
-    with the uploaded one."""
+    with the uploaded one.
+
+    Disallows non-.docx files for proposal documents.
+    """
 
     def __init__(self, context):
         self.context = aq_inner(context)
@@ -21,6 +27,18 @@ class QuickUploadFileUpdater(object):
     def __call__(self, filename, title, description, content_type, data, portal_type):
         if not self.is_upload_allowed():
             raise Unauthorized
+
+        if self.is_proposal_upload():
+            if not os.path.splitext(self.get_file_name(filename))[1].lower() == '.docx':
+                return {
+                    'error': translate(_(
+                        u'error_proposal_document_type',
+                        default=u"It's not possible to have non-.docx documents as proposal documents.",
+                        ),
+                    context=getRequest(),
+                    ),
+                    'success': None,
+                    }
 
         self.context.update_file(data,
                                  content_type=content_type,
@@ -32,6 +50,10 @@ class QuickUploadFileUpdater(object):
         manager = getMultiAdapter((self.context, self.context.REQUEST),
                                   ICheckinCheckoutManager)
         return manager.is_file_upload_allowed()
+
+    def is_proposal_upload(self):
+        """The upload form context can be, for example, a Dossier."""
+        return getattr(self.context, 'is_inside_a_proposal', lambda: False)()
 
     def get_file_name(self, org_filename):
         filename, ext = os.path.splitext(org_filename)

--- a/opengever/meeting/tests/test_proposal.py
+++ b/opengever/meeting/tests/test_proposal.py
@@ -17,7 +17,7 @@ from opengever.meeting.model import Proposal
 from opengever.meeting.model import SubmittedDocument
 from opengever.meeting.proposal import IProposal
 from opengever.meeting.proposal import ISubmittedProposal
-from opengever.officeconnector.helpers import is_officeconnector_checkout_feature_enabled  # noqa
+from opengever.officeconnector.helpers import is_officeconnector_checkout_feature_enabled
 from opengever.testing import index_data_for
 from opengever.testing import IntegrationTestCase
 from plone import api
@@ -447,6 +447,18 @@ class TestProposal(IntegrationTestCase):
         browser.open(document, view='edit')
         self.assertEquals('Edit Document', plone.first_heading(),
                           'Document should be editable.')
+
+    @browsing
+    def test_proposal_document_must_be_docx(self, browser):
+        self.login(self.dossier_responsible, browser)
+        document = self.draft_word_proposal.get_proposal_document()
+        self.checkout_document(document)
+        browser.open(document, view='edit')
+        browser.fill({'form.widgets.file.action': 'replace', 'File': ('asdf', 'foo.xlsx' 'application/fake')})
+        browser.find('Save').click()
+        expected_error = ["It's not possible to have non-.docx documents as proposal documents."]
+        error = browser.css('#formfield-form-widgets-file .fieldErrorBox').text
+        self.assertEqual(error, expected_error)
 
     @browsing
     def test_document_of_proposal_cannot_be_edited_when_submitted(self, browser):

--- a/opengever/meeting/tests/test_proposal.py
+++ b/opengever/meeting/tests/test_proposal.py
@@ -461,6 +461,18 @@ class TestProposal(IntegrationTestCase):
         self.assertEqual(error, expected_error)
 
     @browsing
+    def test_proposal_document_cannot_be_removed(self, browser):
+        self.login(self.dossier_responsible, browser)
+        document = self.draft_word_proposal.get_proposal_document()
+        self.checkout_document(document)
+        browser.open(document, view='edit')
+        browser.fill({'form.widgets.file.action': 'remove'})
+        browser.find('Save').click()
+        expected_error = ["It's not possible to have no file in proposal documents."]
+        error = browser.css('#formfield-form-widgets-file .fieldErrorBox').text
+        self.assertEqual(error, expected_error)
+
+    @browsing
     def test_document_of_proposal_cannot_be_edited_when_submitted(self, browser):
         self.login(self.dossier_responsible, browser)
         document = self.word_proposal.get_proposal_document()


### PR DESCRIPTION
For proposal documents:
* Disallow non-.docx uploads via metadata edits
* Disallow file removals via metadata edits
* Disallow replacing the file with a non-.docx file via D&D

Should also take care of the API and OC upload routes as per the schema field validation.

Closes #4333