### PR TITLE
Display native language of each language on proposal edit forms

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -22,6 +22,7 @@ Changelog
 
 - Make upgrade step 20180619143343 deferrable: Use of CMFEditions getHistory causes massive amounts of savepoints. [lgraf]
 - Simplify agenda item titles for folder names for meeting zip exports. [Rotonen]
+- Display native language of each language on proposal edit forms. [Rotonen]
 
 
 2018.4.1 (2018-08-30)

--- a/opengever/meeting/tests/test_proposal.py
+++ b/opengever/meeting/tests/test_proposal.py
@@ -1049,3 +1049,11 @@ class TestProposal(IntegrationTestCase):
         self.assertEqual(0, submitted_document_model.submitted_version)
         self.assertEqual(proposal.load_model(),
                          submitted_document_model.proposal)
+
+    @browsing
+    def test_proposal_shows_native_language_names_on_form(self, browser):
+        self.login(self.committee_responsible, browser)
+        browser.open(self.dossier)
+        factoriesmenu.add('Proposal')
+        expected_languages = ['Deutsch', 'English']
+        self.assertEqual(expected_languages, browser.css('#form-widgets-language option').text)

--- a/opengever/meeting/vocabulary.py
+++ b/opengever/meeting/vocabulary.py
@@ -235,11 +235,18 @@ class LanguagesVocabulary(object):
 
     def __call__(self, context):
         ltool = api.portal.get_tool('portal_languages')
-        languages = [code.split('-')[0]
-                     for code in ltool.getSupportedLanguages()]
+        supported_language_codes = [language[0].split('-')[0] for language in ltool.listSupportedLanguages()]
+        return SimpleVocabulary([
+            SimpleVocabulary.createTerm(*LanguagesVocabulary.parse_language_to_term(language))
+            for language in ltool.listAvailableLanguageInformation()
+            if language.get('code') in supported_language_codes
+            ])
 
-        return SimpleVocabulary(
-            [SimpleTerm(language) for language in languages])
+    @staticmethod
+    def parse_language_to_term(language):
+        code = language.get('code')
+        name = language.get('native')
+        return code, code, name
 
 
 @implementer(IVocabularyFactory)


### PR DESCRIPTION
I also considered translating each language to the user-native language, as `zope.i18n` does have all the mappings to achieve this, but as this only happens in multilingual organisations, always grabbing the language-native title, as specified int he ticket, should be fine.

Closes #4335