### PR TITLE
Add action to switch to new UI

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -10,6 +10,8 @@ Changelog
 - Fix sharing form for IE 11. [phgross]
 - Fix display of None on the bumblebee document overlay adapter as a document date. [Rotonen]
 - Fix pdf conversion for mails when resolving a dossier (ArchivalFileConverter). [njohner]
+- Add action to switch to new GEVER UI. [njohner]
+- Add generic view to retrieve the value of a setting. [njohner]
 - Lock oder of avaialbe roles in sharing endpoint. [phgross]
 - Fix archival_file and public_trial checks on documents overview. [phgross]
 - Add placeful workflow policy for inbox-area. Let inbox users edit and checkout documents but not the inbox itself. [phgross]

--- a/opengever/api/tests/test_config.py
+++ b/opengever/api/tests/test_config.py
@@ -42,6 +42,8 @@ class TestConfig(IntegrationTestCase):
                 u'ech0147_export': False,
                 u'ech0147_import': False,
                 u'favorites': True,
+                u'gever_ui_enabled': False,
+                u'gever_ui_path': u'http://localhost:8081/#/',
                 u'journal_pdf': False,
                 u'meetings': False,
                 u'officeatwork': False,

--- a/opengever/base/browser/config.py
+++ b/opengever/base/browser/config.py
@@ -1,6 +1,9 @@
 from opengever.base.handlebars import prepare_handlebars_template
 from path import Path
 from Products.Five.browser import BrowserView
+from opengever.base.interfaces import IGeverSettings
+from zope.interface import implementer
+from zope.publisher.interfaces import IPublishTraverse
 
 
 TEMPLATES_DIR = Path(__file__).joinpath('..', 'templates').abspath()
@@ -14,3 +17,34 @@ class ConfigView(BrowserView):
 
     def render_form_template(self):
         return prepare_handlebars_template(TEMPLATES_DIR.joinpath('config.html'))
+
+
+@implementer(IPublishTraverse)
+class GetSettingView(BrowserView):
+    """View to get values of configuration settings.
+    To allow us to traverse to a particular setting,
+    we overwrite __getitem__, which is called by traversals
+    (for example unrestrictedTraverse), and publishTraverse, which is
+    used for traversing to a published item (e.g. url entered in a browser)
+    """
+
+    def __call__(self):
+        if hasattr(self, "key"):
+            return self.__getitem__(self.key)
+
+    def __getitem__(self, key):
+        """We overwrite __getitem__ as it is called by the traversal
+        method, allowing us to traverse to settings.
+        """
+        configuration = IGeverSettings(self.context)
+        if key in configuration.get_features():
+            return configuration.get_features().get(key)
+        elif key in configuration.get_settings():
+            return configuration.get_settings().get(key)
+        raise(KeyError("{} not in gever settings".format(key)))
+
+    def publishTraverse(self, request, name):  # noqa
+        """name is the key  of the setting we want to retrieve
+        """
+        self.key = name
+        return self

--- a/opengever/base/browser/configure.zcml
+++ b/opengever/base/browser/configure.zcml
@@ -231,4 +231,11 @@
       permission="zope2.View"
       />
 
+  <browser:page
+      for="*"
+      name="get_setting"
+      class=".config.GetSettingView"
+      permission="zope2.View"
+      />
+
 </configure>

--- a/opengever/base/configuration.py
+++ b/opengever/base/configuration.py
@@ -5,6 +5,7 @@ from opengever.activity.interfaces import IActivitySettings
 from opengever.base.casauth import get_cas_server_url
 from opengever.base.interfaces import IFavoritesSettings
 from opengever.base.interfaces import IGeverSettings
+from opengever.base.interfaces import IGeverUI
 from opengever.base.interfaces import IRecentlyTouchedSettings
 from opengever.base.interfaces import ISearchSettings
 from opengever.bumblebee.interfaces import IGeverBumblebeeSettings
@@ -62,13 +63,15 @@ class GeverSettingsAdpaterV1(object):
     def get_features(self):
         features = OrderedDict()
         features['activity'] = api.portal.get_registry_record('is_feature_enabled', interface=IActivitySettings)
-        features['archival_file_conversion'] = api.portal.get_registry_record('archival_file_conversion_enabled', interface=IDossierResolveProperties)
+        features['archival_file_conversion'] = api.portal.get_registry_record('archival_file_conversion_enabled', interface=IDossierResolveProperties)  # noqa
         features['contacts'] = api.portal.get_registry_record('is_feature_enabled', interface=IContactSettings)
         features['doc_properties'] = api.portal.get_registry_record('create_doc_properties', interface=ITemplateFolderProperties)  # noqa
         features['dossier_templates'] = api.portal.get_registry_record('is_feature_enabled', interface=IDossierTemplateSettings)  # noqa
         features['ech0147_export'] = api.portal.get_registry_record('ech0147_export_enabled', interface=IECH0147Settings)
         features['ech0147_import'] = api.portal.get_registry_record('ech0147_import_enabled', interface=IECH0147Settings)
         features['favorites'] = api.portal.get_registry_record('is_feature_enabled', interface=IFavoritesSettings)
+        features['gever_ui_enabled'] = api.portal.get_registry_record('is_feature_enabled', interface=IGeverUI)
+        features['gever_ui_path'] = api.portal.get_registry_record('path', interface=IGeverUI)
         features['journal_pdf'] = api.portal.get_registry_record('journal_pdf_enabled', interface=IDossierResolveProperties)
         features['meetings'] = api.portal.get_registry_record('is_feature_enabled', interface=IMeetingSettings)
         features['officeatwork'] = api.portal.get_registry_record('is_feature_enabled', interface=IOfficeatworkSettings)
@@ -82,7 +85,7 @@ class GeverSettingsAdpaterV1(object):
         features['repositoryfolder_documents_tab'] = api.portal.get_registry_record('show_documents_tab', interface=IRepositoryFolderRecords)  # noqa
         features['repositoryfolder_tasks_tab'] = api.portal.get_registry_record('show_tasks_tab', interface=IRepositoryFolderRecords)  # noqa
         features['resolver_name'] = api.portal.get_registry_record('resolver_name', interface=IDossierResolveProperties)
-        features['sablon_date_format'] = api.portal.get_registry_record('sablon_date_format_string', interface=IMeetingSettings)
+        features['sablon_date_format'] = api.portal.get_registry_record('sablon_date_format_string', interface=IMeetingSettings)  # noqa
         features['solr'] = api.portal.get_registry_record('use_solr', interface=ISearchSettings)
         features['workspace'] = api.portal.get_registry_record('is_feature_enabled', interface=IWorkspaceSettings)
         return features

--- a/opengever/base/interfaces.py
+++ b/opengever/base/interfaces.py
@@ -350,3 +350,16 @@ class IRecentlyTouchedSettings(Interface):
         description=u'How many entries to keep for a users recently touched '
                     u'items list.',
         default=10)
+
+
+class IGeverUI(Interface):
+
+    is_feature_enabled = schema.Bool(
+        title=u'Enable new GEVER UI',
+        description=u'Whether new GEVER UI is enabled',
+        default=False)
+
+    path = schema.URI(
+        title=u"Base URL of the GEVER UI",
+        description=u"Used as base URL to reach an object on the GEVER UI",
+        default="http://localhost:8081/#/")

--- a/opengever/base/tests/test_configuration_adapter.py
+++ b/opengever/base/tests/test_configuration_adapter.py
@@ -21,6 +21,8 @@ class TestConfigurationAdapter(IntegrationTestCase):
                 ('ech0147_export', False),
                 ('ech0147_import', False),
                 ('favorites', True),
+                ('gever_ui_enabled', False),
+                ('gever_ui_path', 'http://localhost:8081/#/'),
                 ('journal_pdf', False),
                 ('meetings', False),
                 ('officeatwork', False),

--- a/opengever/base/tests/test_get_setting_view.py
+++ b/opengever/base/tests/test_get_setting_view.py
@@ -1,0 +1,29 @@
+from ftw.testbrowser import browsing
+from opengever.base.interfaces import IGeverSettings
+from opengever.testing import IntegrationTestCase
+
+
+class TestGetSettingView(IntegrationTestCase):
+
+    @browsing
+    def test_get_setting_view_returns_feature_values(self, browser):
+        self.login(self.regular_user)
+        features = IGeverSettings(self.portal).get_features()
+        self.assertTrue(len(features) > 0)
+        for feature, value in features.items():
+            self.assertEqual(value,
+                             self.portal.unrestrictedTraverse("get_setting/{}".format(feature)))
+
+    @browsing
+    def test_get_setting_view_returns_setting_values(self, browser):
+        self.login(self.regular_user)
+        settings = IGeverSettings(self.portal).get_settings()
+        self.assertTrue(len(settings) > 0)
+        for setting, value in settings.items():
+            self.assertEqual(value,
+                             self.portal.unrestrictedTraverse("get_setting/{}".format(setting)))
+
+    def test_get_setting_view_raises_key_Error(self):
+        self.login(self.regular_user)
+        with self.assertRaises(KeyError):
+            self.portal.unrestrictedTraverse("get_setting/foo")

--- a/opengever/base/tests/test_gever_ui_action.py
+++ b/opengever/base/tests/test_gever_ui_action.py
@@ -1,0 +1,58 @@
+from ftw.testbrowser import browsing
+from ftw.testbrowser.pages import editbar
+from opengever.base.interfaces import IGeverSettings
+from opengever.testing import IntegrationTestCase
+from plone import api
+import os
+
+
+class TestGeverUIAction(IntegrationTestCase):
+
+    def test_feature_disabled_by_default(self):
+        self.login(self.regular_user)
+        settings = IGeverSettings(self.portal).get_features()
+        self.assertIn("gever_ui_enabled", settings)
+        self.assertFalse(settings.get("gever_ui_enabled"))
+
+    @browsing
+    def test_action_is_visible_when_feature_enabled(self, browser):
+        self.login(self.regular_user, browser)
+        browser.open(self.repository_root)
+        self.assertEqual(['Properties'], editbar.menu_options("Actions"))
+
+        self.activate_feature("gever_ui")
+        browser.open(self.repository_root)
+        self.assertEqual(['Properties', 'Switch to new UI'], editbar.menu_options("Actions"))
+
+    @browsing
+    def test_action_redirects_to_correct_url_for_repo(self, browser):
+        self.activate_feature("gever_ui")
+        self.login(self.regular_user, browser)
+        obj = self.repository_root
+        browser.open(obj)
+        new_ui_base = api.portal.get_registry_record("opengever.base.interfaces.IGeverUI.path")
+        url = browser.find("Switch to new UI").get("href")
+        expected_url = os.path.join(new_ui_base, obj.virtual_url_path())
+        self.assertEqual(expected_url, url)
+
+    @browsing
+    def test_action_redirects_to_correct_url_for_dossier(self, browser):
+        self.activate_feature("gever_ui")
+        self.login(self.regular_user, browser)
+        obj = self.dossier
+        browser.open(obj)
+        new_ui_base = api.portal.get_registry_record("opengever.base.interfaces.IGeverUI.path")
+        url = browser.find("Switch to new UI").get("href")
+        expected_url = os.path.join(new_ui_base, obj.virtual_url_path())
+        self.assertEqual(expected_url, url)
+
+    @browsing
+    def test_action_redirects_to_correct_url_for_document(self, browser):
+        self.activate_feature("gever_ui")
+        self.login(self.regular_user, browser)
+        obj = self.document
+        browser.open(obj)
+        new_ui_base = api.portal.get_registry_record("opengever.base.interfaces.IGeverUI.path")
+        url = browser.find("Switch to new UI").get("href")
+        expected_url = os.path.join(new_ui_base, obj.virtual_url_path())
+        self.assertEqual(expected_url, url)

--- a/opengever/core/locales/de/LC_MESSAGES/opengever.core.po
+++ b/opengever/core/locales/de/LC_MESSAGES/opengever.core.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2018-07-13 15:30+0000\n"
+"POT-Creation-Date: 2018-08-13 06:07+0000\n"
 "PO-Revision-Date: 2017-09-18 15:21+0200\n"
 "Last-Translator: Philippe Gross <p.gross@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -138,6 +138,7 @@ msgid "Meeting Dossier"
 msgstr "Sitzungsdossier"
 
 #: ./opengever/core/profiles/default/types/opengever.meeting.meetingtemplate.xml
+#: ./opengever/core/upgrades/20180716085827_meeting_templates/types/opengever.meeting.meetingtemplate.xml
 msgid "Meeting Template"
 msgstr "Sitzungsvorlage"
 
@@ -155,6 +156,7 @@ msgid "My repository"
 msgstr "Meine Ablage"
 
 #: ./opengever/core/profiles/default/types/opengever.meeting.paragraphtemplate.xml
+#: ./opengever/core/upgrades/20180716085827_meeting_templates/types/opengever.meeting.paragraphtemplate.xml
 msgid "Paragraph Template"
 msgstr "Zwischentitelvorlage"
 
@@ -236,6 +238,11 @@ msgstr "Zusätzliche Anhänge einreichen"
 #: ./opengever/core/profiles/default/types/opengever.meeting.submittedproposal.xml
 msgid "Submitted Proposal"
 msgstr "Eingereichter Antrag"
+
+#: ./opengever/core/profiles/default/actions.xml
+#: ./opengever/core/upgrades/20180809152739_add_gever_ui_action/actions.xml
+msgid "Switch to new UI"
+msgstr "Neue Bedienoberfläche"
 
 #: ./opengever/core/profiles/default/types/opengever.task.task.xml
 msgid "Task"

--- a/opengever/core/locales/fr/LC_MESSAGES/opengever.core.po
+++ b/opengever/core/locales/fr/LC_MESSAGES/opengever.core.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2018-07-13 15:30+0000\n"
+"POT-Creation-Date: 2018-08-13 06:07+0000\n"
 "PO-Revision-Date: 2013-03-27 10:44+0100\n"
 "Last-Translator: Philippe Gross <p.gross@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -135,6 +135,7 @@ msgid "Meeting Dossier"
 msgstr "Dossier de réunion"
 
 #: ./opengever/core/profiles/default/types/opengever.meeting.meetingtemplate.xml
+#: ./opengever/core/upgrades/20180716085827_meeting_templates/types/opengever.meeting.meetingtemplate.xml
 msgid "Meeting Template"
 msgstr ""
 
@@ -152,6 +153,7 @@ msgid "My repository"
 msgstr "Mon référentiel"
 
 #: ./opengever/core/profiles/default/types/opengever.meeting.paragraphtemplate.xml
+#: ./opengever/core/upgrades/20180716085827_meeting_templates/types/opengever.meeting.paragraphtemplate.xml
 msgid "Paragraph Template"
 msgstr ""
 
@@ -231,6 +233,11 @@ msgstr "Soumettre des documents additionnels"
 #: ./opengever/core/profiles/default/types/opengever.meeting.submittedproposal.xml
 msgid "Submitted Proposal"
 msgstr "Proposition soumise"
+
+#: ./opengever/core/profiles/default/actions.xml
+#: ./opengever/core/upgrades/20180809152739_add_gever_ui_action/actions.xml
+msgid "Switch to new UI"
+msgstr "Nouvelle interface graphique"
 
 #: ./opengever/core/profiles/default/types/opengever.task.task.xml
 msgid "Task"

--- a/opengever/core/locales/opengever.core.pot
+++ b/opengever/core/locales/opengever.core.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-13 15:30+0000\n"
+"POT-Creation-Date: 2018-08-13 06:07+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -138,6 +138,7 @@ msgid "Meeting Dossier"
 msgstr ""
 
 #: ./opengever/core/profiles/default/types/opengever.meeting.meetingtemplate.xml
+#: ./opengever/core/upgrades/20180716085827_meeting_templates/types/opengever.meeting.meetingtemplate.xml
 msgid "Meeting Template"
 msgstr ""
 
@@ -155,6 +156,7 @@ msgid "My repository"
 msgstr ""
 
 #: ./opengever/core/profiles/default/types/opengever.meeting.paragraphtemplate.xml
+#: ./opengever/core/upgrades/20180716085827_meeting_templates/types/opengever.meeting.paragraphtemplate.xml
 msgid "Paragraph Template"
 msgstr ""
 
@@ -233,6 +235,11 @@ msgstr ""
 
 #: ./opengever/core/profiles/default/types/opengever.meeting.submittedproposal.xml
 msgid "Submitted Proposal"
+msgstr ""
+
+#: ./opengever/core/profiles/default/actions.xml
+#: ./opengever/core/upgrades/20180809152739_add_gever_ui_action/actions.xml
+msgid "Switch to new UI"
 msgstr ""
 
 #: ./opengever/core/profiles/default/types/opengever.task.task.xml

--- a/opengever/core/profiles/default/actions.xml
+++ b/opengever/core/profiles/default/actions.xml
@@ -643,6 +643,18 @@
       <property name="visible">True</property>
     </object>
 
+    <object name="gever_ui" meta_type="CMF Action" i18n:domain="opengever.core">
+      <property name="title" i18n:translate="">Switch to new UI</property>
+      <property name="description" i18n:translate="" />
+      <property name="url_expr">python:path("object/get_setting/gever_ui_path") + object.virtual_url_path()</property>
+      <property name="icon_expr" />
+      <property name="permissions">
+        <element value="View" />
+      </property>
+      <property name="available_expr">object/get_setting/gever_ui_enabled</property>
+      <property name="visible">True</property>
+    </object>
+
   </object>
 
 

--- a/opengever/core/profiles/default/registry.xml
+++ b/opengever/core/profiles/default/registry.xml
@@ -74,6 +74,9 @@
   <!-- ECH-0147 -->
   <records interface="opengever.ech0147.interfaces.IECH0147Settings" />
 
+  <!-- Gever-UI -->
+  <records interface="opengever.base.interfaces.IGeverUI" />
+
   <!-- LATEX -->
   <records interface="opengever.latex.interfaces.ILaTeXSettings" />
 

--- a/opengever/core/upgrades/20180809152739_add_gever_ui_action/actions.xml
+++ b/opengever/core/upgrades/20180809152739_add_gever_ui_action/actions.xml
@@ -1,0 +1,19 @@
+<object xmlns:i18n="http://xml.zope.org/namespaces/i18n" name="portal_actions" meta_type="Plone Actions Tool">
+
+  <!-- OBJECT BUTTONS -->
+  <object name="object_buttons" meta_type="CMF Action Category">
+
+    <object name="gever_ui" meta_type="CMF Action" i18n:domain="opengever.core">
+      <property name="title" i18n:translate="">Switch to new UI</property>
+      <property name="description" i18n:translate="" />
+      <property name="url_expr">python:path("object/get_setting/gever_ui_path") + object.virtual_url_path()</property>
+      <property name="icon_expr" />
+      <property name="permissions">
+        <element value="View" />
+      </property>
+      <property name="available_expr">object/get_setting/gever_ui_enabled</property>
+      <property name="visible">True</property>
+    </object>
+
+  </object>
+</object>

--- a/opengever/core/upgrades/20180809152739_add_gever_ui_action/registry.xml
+++ b/opengever/core/upgrades/20180809152739_add_gever_ui_action/registry.xml
@@ -1,0 +1,4 @@
+<registry>
+  <!-- Gever-UI -->
+  <records interface="opengever.base.interfaces.IGeverUI" />
+</registry>

--- a/opengever/core/upgrades/20180809152739_add_gever_ui_action/upgrade.py
+++ b/opengever/core/upgrades/20180809152739_add_gever_ui_action/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddGeverUIAction(UpgradeStep):
+    """Add gever ui action.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/testing/integration_test_case.py
+++ b/opengever/testing/integration_test_case.py
@@ -58,6 +58,7 @@ FEATURE_FLAGS = {
     'ech0147-export': 'opengever.ech0147.interfaces.IECH0147Settings.ech0147_export_enabled',
     'ech0147-import': 'opengever.ech0147.interfaces.IECH0147Settings.ech0147_import_enabled',
     'extjs': 'ftw.tabbedview.interfaces.ITabbedView.extjs_enabled',
+    'gever_ui': 'opengever.base.interfaces.IGeverUI.is_feature_enabled',
     'meeting': 'opengever.meeting.interfaces.IMeetingSettings.is_feature_enabled',
     'officeconnector-attach': 'opengever.officeconnector.interfaces.IOfficeConnectorSettings.attach_to_outlook_enabled',
     'officeconnector-checkout': 'opengever.officeconnector.interfaces.IOfficeConnectorSettings.direct_checkout_and_edit_enabled',  # noqa


### PR DESCRIPTION
We add an action to switch to the new GEVER UI. The action is controlled by two registry settings:
1. boolean to activate the feature (disabled by default)
2. a URI to control the basepath used to redirect to the new UI.

We also introduce a new view to retrieve registry settings (from a traversal to the view followed by the setting name for example `get_setting/gever_ui_enabled`)

resolves #4688 