### PR TITLE
Register MS publisher mimetype to python mimetypes registry.

### DIFF
--- a/opengever/core/upgrades/20180813122830_fix_contenttype_for_ms_publisher_files/upgrade.py
+++ b/opengever/core/upgrades/20180813122830_fix_contenttype_for_ms_publisher_files/upgrade.py
@@ -1,0 +1,33 @@
+from ftw.upgrade import UpgradeStep
+from ftw.upgrade.progresslogger import ProgressLogger
+from opengever.document.document import IDocumentSchema
+from os.path import splitext
+from plone import api
+
+
+MS_PUBLISHER_EXTENSION = '.pub'
+MS_PUBLISHER_MIMETYPE = 'application/x-mspublisher'
+
+
+class FixContenttypeForMSPublisherFiles(UpgradeStep):
+    """Fix contenttype for MS Publisher files.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()
+
+        catalog = api.portal.get_tool('portal_catalog')
+        brains = catalog.unrestrictedSearchResults(
+            {'object_provides': IDocumentSchema.__identifier__})
+
+        for brain in ProgressLogger('Fix contettype for MS Publisher files',
+                                    brains):
+            if brain.getContentType == 'application/octet-stream':
+                obj = brain.getObject()
+                if not obj.file:
+                    continue
+
+                filename, ext = splitext(obj.file.filename)
+                if ext == MS_PUBLISHER_EXTENSION:
+                    obj.file.contentType = MS_PUBLISHER_MIMETYPE
+                    obj.reindexObject()

--- a/opengever/document/extra_mimetypes.py
+++ b/opengever/document/extra_mimetypes.py
@@ -39,6 +39,9 @@ ADDITIONAL_TYPES = [
     # MS Project
     ('application/vnd.ms-project', '.mpp'),
 
+    # MS Publisher
+    ('application/x-mspublisher', '.pub'),
+
     # MS OneNote
     ('application/onenote', '.one'),
 


### PR DESCRIPTION
Including an upgradestep which fix the contenttype for existing MS Publisher documents.

Note: Changelog entry not necessary, feature already mentioned in the changelog.