### PR TITLE
Exclude PreconditionFailed from Error log.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -18,6 +18,7 @@ Changelog
 - Only show create proposal button if meeting feature is enabled. [njohner]
 - Add action to switch to new GEVER UI. [njohner]
 - Add generic view to retrieve the value of a setting. [njohner]
+- Exclude PreconditionFailed from Error log. [njohner]
 - Lock oder of avaialbe roles in sharing endpoint. [phgross]
 - Fix archival_file and public_trial checks on documents overview. [phgross]
 - Add placeful workflow policy for inbox-area. Let inbox users edit and checkout documents but not the inbox itself. [phgross]

--- a/opengever/base/hooks.py
+++ b/opengever/base/hooks.py
@@ -27,6 +27,19 @@ def create_models():
     model.Base.metadata.create_all(model.Session().bind, checkfirst=True)
 
 
+def configure_error_log(site):
+    error_log = getToolByName(site, 'error_log')
+    properties = error_log.getProperties()
+    if 'PreconditionFailed' in properties.get('ignored_exceptions', ()):
+        return
+
+    ignored = tuple(properties['ignored_exceptions'])
+    ignored += ('PreconditionFailed',)
+    properties['ignored_exceptions'] = ignored
+    error_log.setProperties(**properties)
+
+
 def installed(site):
     remove_standard_extedit_action(site)
     create_models()
+    configure_error_log(site)

--- a/opengever/core/upgrades/20180813172307_exclude_precondition_failed_from_error_log/upgrade.py
+++ b/opengever/core/upgrades/20180813172307_exclude_precondition_failed_from_error_log/upgrade.py
@@ -1,0 +1,20 @@
+from ftw.upgrade import UpgradeStep
+
+
+class ExcludePreconditionFailedFromErrorLog(UpgradeStep):
+    """Exclude precondition failed from error log.
+    """
+
+    def __call__(self):
+        self.configure_error_log()
+
+    def configure_error_log(self):
+        error_log = self.getToolByName('error_log')
+        properties = error_log.getProperties()
+        if 'PreconditionFailed' in properties.get('ignored_exceptions', ()):
+            return
+
+        ignored = tuple(properties['ignored_exceptions'])
+        ignored += ('PreconditionFailed',)
+        properties['ignored_exceptions'] = ignored
+        error_log.setProperties(**properties)


### PR DESCRIPTION
`PreconditionFailed` errors should be managed client side and can therefore be ignored on the GEVER side.

resolves #4730 