### PR TITLE
Fix the bumblebee document overlay date getter to allow for `None`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -576,6 +576,7 @@ Objects
           - self.document
           - self.draft_proposal
           - self.draft_word_proposal
+          - self.empty_document
           - self.mail
           - self.mail_msg
           - self.proposal

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -8,6 +8,7 @@ Changelog
 - Sharing views: Show userdetails also in an overlay. [phgross]
 - Show assignments info button only on rows with automatic roles. [phgross]
 - Fix sharing form for IE 11. [phgross]
+- Fix display of None on the bumblebee document overlay adapter as a document date. [Rotonen]
 - Lock oder of avaialbe roles in sharing endpoint. [phgross]
 - Fix archival_file and public_trial checks on documents overview. [phgross]
 - Add placeful workflow policy for inbox-area. Let inbox users edit and checkout documents but not the inbox itself. [phgross]

--- a/opengever/api/tests/test_mail.py
+++ b/opengever/api/tests/test_mail.py
@@ -22,7 +22,7 @@ class TestGetMail(IntegrationTestCase):
         self.assertEqual(200, browser.status_code)
         self.assertEqual(
             {u'content-type': u'application/vnd.ms-outlook',
-             u'download': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/document-28/@@download/original_message',
+             u'download': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/document-29/@@download/original_message',
              u'filename': u'testmail.msg',
              u'size': 8},
             browser.json.get('original_message'))

--- a/opengever/api/tests/test_serializer.py
+++ b/opengever/api/tests/test_serializer.py
@@ -68,4 +68,4 @@ class TestDocumentSerializer(IntegrationTestCase):
         self.login(self.regular_user, browser)
         browser.open(self.mail, headers={'Accept': 'application/json'})
         self.assertEqual(browser.status_code, 200)
-        self.assertEqual(browser.json.get(u'reference_number'), u'Client1 1.1 / 1 / 28')
+        self.assertEqual(browser.json.get(u'reference_number'), u'Client1 1.1 / 1 / 29')

--- a/opengever/bumblebee/browser/overlay.py
+++ b/opengever/bumblebee/browser/overlay.py
@@ -12,7 +12,6 @@ from opengever.bumblebee.interfaces import IBumblebeeOverlay
 from opengever.bumblebee.interfaces import IGeverBumblebeeSettings
 from opengever.bumblebee.interfaces import IVersionedContextMarker
 from opengever.document.browser.actionbuttons import ActionButtonRendererMixin
-from opengever.document.browser.versions_tab import LazyHistoryMetadataProxy
 from opengever.document.browser.versions_tab import translate_link
 from opengever.document.checkout.viewlets import CheckedOutViewlet
 from opengever.document.document import IDocumentSchema
@@ -79,7 +78,10 @@ class BumblebeeBaseDocumentOverlay(ActionButtonRendererMixin):
         return Actor.user(self.context.Creator()).get_link()
 
     def get_document_date(self):
-        return api.portal.get_localized_time(self.context.document_date)
+        document_date = self.context.document_date
+        if not document_date:
+            return None
+        return api.portal.get_localized_time(document_date)
 
     def get_containing_dossier(self):
         return self.context.get_parent_dossier()

--- a/opengever/bumblebee/tests/test_overlay_adapter_document.py
+++ b/opengever/bumblebee/tests/test_overlay_adapter_document.py
@@ -140,9 +140,15 @@ class TestGetDocumentDate(IntegrationTestCase):
         adapter = getMultiAdapter((self.document, self.request), IBumblebeeOverlay)
         self.assertEqual(u'Jan 03, 2010', adapter.get_document_date())
 
-    def test_returns_none_if_no_document_date_is_set(self):
+    def test_returns_none_if_document_date_is_empty_string(self):
         self.login(self.regular_user)
         self.document.document_date = ''
+        adapter = getMultiAdapter((self.document, self.request), IBumblebeeOverlay)
+        self.assertIsNone(adapter.get_document_date())
+
+    def test_returns_none_if_document_date_is_none(self):
+        self.login(self.regular_user)
+        self.document.document_date = None
         adapter = getMultiAdapter((self.document, self.request), IBumblebeeOverlay)
         self.assertIsNone(adapter.get_document_date())
 

--- a/opengever/bumblebee/tests/test_overlay_adapter_document.py
+++ b/opengever/bumblebee/tests/test_overlay_adapter_document.py
@@ -1,571 +1,417 @@
-from datetime import date
-from ftw.builder import Builder
-from ftw.builder import create
-from ftw.bumblebee.tests.helpers import asset as bumblebee_asset
 from ftw.testbrowser import browsing
+from opengever.base.interfaces import IReferenceNumber
+from opengever.base.interfaces import ISequenceNumber
 from opengever.bumblebee.browser.overlay import BumblebeeBaseDocumentOverlay
 from opengever.bumblebee.interfaces import IBumblebeeOverlay
 from opengever.bumblebee.interfaces import IVersionedContextMarker
-from opengever.core.testing import OPENGEVER_FUNCTIONAL_BUMBLEBEE_LAYER
-from opengever.testing import FunctionalTestCase
-from plone.app.testing import login
+from opengever.testing import IntegrationTestCase
 from plone.locking.interfaces import IRefreshableLockable
+from plone.namedfile.file import NamedBlobFile
 from zope.component import getMultiAdapter
+from zope.component import getUtility
 from zope.interface import alsoProvides
 from zope.interface.verify import verifyClass
 
 
-class TestAdapterRegisteredProperly(FunctionalTestCase):
+class TestAdapterRegisteredProperly(IntegrationTestCase):
     """Test bumblebee overlay adapter registrations."""
 
-    layer = OPENGEVER_FUNCTIONAL_BUMBLEBEE_LAYER
+    features = (
+        'bumblebee',
+        )
 
     def test_get_overlay_adapter_for_documents(self):
-        dossier = create(Builder('dossier'))
-        document = create(Builder('document').within(dossier))
-
-        adapter = getMultiAdapter((document, self.request), IBumblebeeOverlay)
-
+        self.login(self.regular_user)
+        adapter = getMultiAdapter((self.document, self.request), IBumblebeeOverlay)
         self.assertIsInstance(adapter, BumblebeeBaseDocumentOverlay)
 
     def test_verify_implemented_interfaces(self):
         verifyClass(IBumblebeeOverlay, BumblebeeBaseDocumentOverlay)
 
 
-class TestGetPreviewPdfUrl(FunctionalTestCase):
+class TestGetPreviewPdfUrl(IntegrationTestCase):
     """Test generating a link to the bumblebee instance."""
 
-    layer = OPENGEVER_FUNCTIONAL_BUMBLEBEE_LAYER
+    features = (
+        'bumblebee',
+        )
 
     def test_returns_preview_pdf_url_as_string(self):
-        dossier = create(Builder('dossier'))
-        document = create(Builder('document').within(dossier))
+        self.login(self.regular_user)
+        adapter = getMultiAdapter((self.empty_document, self.request), IBumblebeeOverlay)
+        self.assertEqual(
+            'http://nohost/plone/++resource++opengever.bumblebee.resources/fallback_not_digitally_available.svg',
+            adapter.get_preview_pdf_url(),
+            )
 
-        adapter = getMultiAdapter((document, self.request), IBumblebeeOverlay)
 
-        self.assertIn(
-            'not_digitally_available.svg', adapter.get_preview_pdf_url())
-
-
-class TestGetOpenAsPdfLink(FunctionalTestCase):
+class TestGetOpenAsPdfLink(IntegrationTestCase):
     """Test the integrity of generated bumblebee links."""
 
-    layer = OPENGEVER_FUNCTIONAL_BUMBLEBEE_LAYER
+    features = (
+        'bumblebee',
+        )
 
     def test_returns_pdf_url_as_string(self):
-        dossier = create(Builder('dossier'))
-        document = create(Builder('document')
-                          .within(dossier)
-                          .with_dummy_content())
-
-        adapter = getMultiAdapter((document, self.request), IBumblebeeOverlay)
-
+        self.login(self.regular_user)
+        adapter = getMultiAdapter((self.document, self.request), IBumblebeeOverlay)
         self.assertEqual(
-            'http://nohost/plone/dossier-1/document-1/'
-            'bumblebee-open-pdf?filename=Testdokumaent.pdf',
-            adapter.get_open_as_pdf_url())
+            '{}/bumblebee-open-pdf?filename=Vertraegsentwurf.pdf'.format(self.document.absolute_url()),
+            adapter.get_open_as_pdf_url(),
+            )
 
     def test_returns_none_if_no_mimetype_is_available(self):
-        dossier = create(Builder('dossier'))
-        document = create(Builder('document').within(dossier))
-
-        adapter = getMultiAdapter((document, self.request), IBumblebeeOverlay)
-
+        self.login(self.regular_user)
+        adapter = getMultiAdapter((self.empty_document, self.request), IBumblebeeOverlay)
         self.assertIsNone(adapter.get_open_as_pdf_url())
 
     def test_returns_none_if_mimetype_is_not_supported(self):
-        dossier = create(Builder('dossier'))
-        document = create(Builder('document')
-                          .within(dossier)
-                          .attach_file_containing(
-                              "data", name=u"test.notsupported"))
-
-        adapter = getMultiAdapter((document, self.request), IBumblebeeOverlay)
-
+        self.login(self.regular_user)
+        self.document.file = NamedBlobFile(
+            data=u'T\xc3\xa4stfil\xc3\xa9',
+            contentType='test/notsupported',
+            filename=u'test.notsupported',
+            )
+        adapter = getMultiAdapter((self.document, self.request), IBumblebeeOverlay)
         self.assertIsNone(adapter.get_open_as_pdf_url())
 
 
-class TestGetPdfFilename(FunctionalTestCase):
+class TestGetPdfFilename(IntegrationTestCase):
     """Test we generate bumblebee filenames correctly."""
 
-    layer = OPENGEVER_FUNCTIONAL_BUMBLEBEE_LAYER
+    features = (
+        'bumblebee',
+        )
 
     def test_changes_filename_extension_to_pdf_and_returns_filename(self):
-        dossier = create(Builder('dossier'))
-        document = create(Builder('document')
-                          .within(dossier)
-                          .attach_file_containing(
-                              "data", name=u"test.docx"))
-
-        adapter = getMultiAdapter((document, self.request), IBumblebeeOverlay)
-
-        self.assertEqual('Testdokumaent.docx', document.file.filename)
-        self.assertEqual('Testdokumaent.pdf', adapter._get_pdf_filename())
+        self.login(self.regular_user)
+        adapter = getMultiAdapter((self.document, self.request), IBumblebeeOverlay)
+        self.assertEqual('Vertraegsentwurf.docx', self.document.file.filename)
+        self.assertEqual('Vertraegsentwurf.pdf', adapter._get_pdf_filename())
 
     def test_returns_none_if_no_file_is_given(self):
-        dossier = create(Builder('dossier'))
-        document = create(Builder('document')
-                          .within(dossier))
-
-        adapter = getMultiAdapter((document, self.request), IBumblebeeOverlay)
-
+        self.login(self.regular_user)
+        adapter = getMultiAdapter((self.empty_document, self.request), IBumblebeeOverlay)
         self.assertIsNone(adapter._get_pdf_filename())
 
 
-class TestGetFileSize(FunctionalTestCase):
+class TestGetFileSize(IntegrationTestCase):
     """Test we agree about filesize with bumblebee."""
 
-    layer = OPENGEVER_FUNCTIONAL_BUMBLEBEE_LAYER
+    features = (
+        'bumblebee',
+        )
 
     def test_returns_file_size_in_kb_if_file_is_available(self):
-        dossier = create(Builder('dossier'))
-        document = create(Builder('document')
-                          .within(dossier)
-                          .attach_file_containing(
-                              bumblebee_asset('example.docx').bytes(),
-                              u'example.docx'))
-
-        adapter = getMultiAdapter((document, self.request), IBumblebeeOverlay)
-
-        self.assertEqual(26, adapter.get_file_size())
+        self.login(self.regular_user)
+        adapter = getMultiAdapter((self.document, self.request), IBumblebeeOverlay)
+        self.assertEqual(self.document.get_file().getSize() / 1024, adapter.get_file_size())
 
     def test_returns_none_if_no_file_is_available(self):
-        dossier = create(Builder('dossier'))
-        document = create(Builder('document').within(dossier))
-
-        adapter = getMultiAdapter((document, self.request), IBumblebeeOverlay)
-
+        self.login(self.regular_user)
+        adapter = getMultiAdapter((self.empty_document, self.request), IBumblebeeOverlay)
         self.assertIsNone(adapter.get_file_size())
 
 
-class TestGetCreator(FunctionalTestCase):
+class TestGetCreator(IntegrationTestCase):
     """Test we correctly link to the document author."""
 
-    layer = OPENGEVER_FUNCTIONAL_BUMBLEBEE_LAYER
+    features = (
+        'bumblebee',
+        )
 
     def test_returns_link_to_creator(self):
-        dossier = create(Builder('dossier'))
-        document = create(Builder('document').within(dossier))
-
-        adapter = getMultiAdapter((document, self.request), IBumblebeeOverlay)
+        self.login(self.regular_user)
+        adapter = getMultiAdapter((self.document, self.request), IBumblebeeOverlay)
         creator_link = adapter.get_creator_link()
-
-        self.assertIn('Test User (test_user_1_)', creator_link)
-        self.assertIn('http://nohost/plone/@@user-details/test_user_1_',
-                      creator_link)
+        self.assertIn('Ziegler Robert (robert.ziegler)', creator_link)
+        self.assertIn('http://nohost/plone/@@user-details/robert.ziegler', creator_link)
 
 
-class TestGetDocumentDate(FunctionalTestCase):
+class TestGetDocumentDate(IntegrationTestCase):
     """Test we correctly fetch the document date."""
 
-    layer = OPENGEVER_FUNCTIONAL_BUMBLEBEE_LAYER
+    features = (
+        'bumblebee',
+        )
 
     def test_returns_localized_document_date(self):
-        dossier = create(Builder('dossier'))
-        document = create(Builder('document')
-                          .within(dossier)
-                          .having(document_date=date(2014, 1, 1)))
-
-        adapter = getMultiAdapter((document, self.request), IBumblebeeOverlay)
-
-        self.assertEqual(u'Jan 01, 2014', adapter.get_document_date())
+        self.login(self.regular_user)
+        adapter = getMultiAdapter((self.document, self.request), IBumblebeeOverlay)
+        self.assertEqual(u'Jan 03, 2010', adapter.get_document_date())
 
     def test_returns_none_if_no_document_date_is_set(self):
-        dossier = create(Builder('dossier'))
-        document = create(Builder('document')
-                          .within(dossier)
-                          .having(document_date=''))
-
-        adapter = getMultiAdapter((document, self.request), IBumblebeeOverlay)
-
+        self.login(self.regular_user)
+        self.document.document_date = ''
+        adapter = getMultiAdapter((self.document, self.request), IBumblebeeOverlay)
         self.assertIsNone(adapter.get_document_date())
 
 
-class TestGetContainingDossier(FunctionalTestCase):
+class TestGetContainingDossier(IntegrationTestCase):
     """Test we correctly fetch the immediate parent dossier."""
 
-    layer = OPENGEVER_FUNCTIONAL_BUMBLEBEE_LAYER
+    features = (
+        'bumblebee',
+        )
 
     def test_returns_the_containing_dossier(self):
-        dossier = create(Builder('dossier'))
-        document = create(Builder('document')
-                          .within(dossier)
-                          .having(document_date=date(2014, 1, 1)))
-
-        adapter = getMultiAdapter((document, self.request), IBumblebeeOverlay)
-
-        self.assertEqual(dossier, adapter.get_containing_dossier())
+        self.login(self.regular_user)
+        adapter = getMultiAdapter((self.document, self.request), IBumblebeeOverlay)
+        self.assertEqual(self.dossier, adapter.get_containing_dossier())
 
 
-class TestGetSequenceNumber(FunctionalTestCase):
+class TestGetSequenceNumber(IntegrationTestCase):
     """Test we correctly fetch the document sequence number."""
 
-    layer = OPENGEVER_FUNCTIONAL_BUMBLEBEE_LAYER
+    features = (
+        'bumblebee',
+        )
 
     def test_returns_sequence_number(self):
-        dossier = create(Builder('dossier'))
-        document = create(Builder('document').within(dossier))
-
-        adapter = getMultiAdapter((document, self.request), IBumblebeeOverlay)
-
-        self.assertEqual(1, adapter.get_sequence_number())
+        self.login(self.regular_user)
+        adapter = getMultiAdapter((self.document, self.request), IBumblebeeOverlay)
+        self.assertEqual(getUtility(ISequenceNumber).get_number(self.document), adapter.get_sequence_number())
 
 
-class TestGetReferenceNumber(FunctionalTestCase):
+class TestGetReferenceNumber(IntegrationTestCase):
     """Test we correctly fetch the document reference number."""
 
-    layer = OPENGEVER_FUNCTIONAL_BUMBLEBEE_LAYER
+    features = (
+        'bumblebee',
+        )
 
     def test_returns_reference_number(self):
-        dossier = create(Builder('dossier'))
-        document = create(Builder('document').within(dossier))
-
-        adapter = getMultiAdapter((document, self.request), IBumblebeeOverlay)
-
-        self.assertEqual('Client1 / 1 / 1', adapter.get_reference_number())
+        self.login(self.regular_user)
+        adapter = getMultiAdapter((self.document, self.request), IBumblebeeOverlay)
+        self.assertEqual(IReferenceNumber(self.document).get_number(), adapter.get_reference_number())
 
 
-class TestGetCheckoutLink(FunctionalTestCase):
+class TestGetCheckoutLink(IntegrationTestCase):
     """Test we correctly generate the document checkout link."""
 
-    layer = OPENGEVER_FUNCTIONAL_BUMBLEBEE_LAYER
+    features = (
+        'bumblebee',
+        )
 
     def test_returns_checkout_and_edit_url(self):
-        dossier = create(Builder('dossier'))
-        document = create(Builder('document')
-                          .within(dossier)
-                          .attach_file_containing(
-                              bumblebee_asset('example.docx').bytes(),
-                              u'example.docx'))
-
-        adapter = getMultiAdapter((document, self.request), IBumblebeeOverlay)
-
-        self.assertIn(
-            'http://nohost/plone/dossier-1/document-1/editing_document',
-            adapter.get_checkout_url())
+        self.login(self.regular_user)
+        adapter = getMultiAdapter((self.document, self.request), IBumblebeeOverlay)
+        expected_url = '{}/editing_document?_authenticator='.format(self.document.absolute_url())
+        self.assertTrue(adapter.get_checkout_url().startswith(expected_url))
 
     def test_returns_none_if_no_document_is_available_to_checkout(self):
-        dossier = create(Builder('dossier'))
-        document = create(Builder('document').within(dossier))
-
-        adapter = getMultiAdapter((document, self.request), IBumblebeeOverlay)
-
-        self.assertIsNone(None, adapter.get_checkout_url())
+        self.login(self.regular_user)
+        adapter = getMultiAdapter((self.empty_document, self.request), IBumblebeeOverlay)
+        self.assertIsNone(adapter.get_checkout_url())
 
     def test_returns_none_if_user_is_not_allowed_to_edit(self):
-        dossier = create(Builder('dossier'))
-        document = create(Builder('document')
-                          .within(dossier)
-                          .attach_file_containing(
-                              bumblebee_asset('example.docx').bytes(),
-                              u'example.docx'))
-        create(Builder('user')
-               .with_userid('bond')
-               .with_roles('Member', 'Reader'))
-
-        adapter = getMultiAdapter((document, self.request), IBumblebeeOverlay)
-
-        self.assertIn(
-            'http://nohost/plone/dossier-1/document-1/editing_document',
-            adapter.get_checkout_url())
-
-        login(self.portal, 'bond')
-        self.assertIsNone(None, adapter.get_checkout_url())
+        self.login(self.regular_user)
+        adapter = getMultiAdapter((self.proposaldocument, self.request), IBumblebeeOverlay)
+        self.assertIsNone(adapter.get_checkout_url())
 
 
-class TestGetDownloadCopyLink(FunctionalTestCase):
+class TestGetDownloadCopyLink(IntegrationTestCase):
     """Test we correctly generate the document download link."""
 
-    layer = OPENGEVER_FUNCTIONAL_BUMBLEBEE_LAYER
+    features = (
+        'bumblebee',
+        )
 
     @browsing
     def test_returns_download_copy_link_as_html_link(self, browser):
-        dossier = create(Builder('dossier'))
-        document = create(Builder('document')
-                          .within(dossier)
-                          .attach_file_containing(
-                              bumblebee_asset('example.docx').bytes(),
-                              u'example.docx'))
-
-        adapter = getMultiAdapter((document, self.request), IBumblebeeOverlay)
-
+        self.login(self.regular_user)
+        adapter = getMultiAdapter((self.document, self.request), IBumblebeeOverlay)
         browser.open_html(adapter.get_download_copy_link())
-
         self.assertEqual('Download copy', browser.css('a').first.text)
 
     def test_returns_none_if_no_document_is_available(self):
-        dossier = create(Builder('dossier'))
-        document = create(Builder('document').within(dossier))
-
-        adapter = getMultiAdapter((document, self.request), IBumblebeeOverlay)
+        self.login(self.regular_user)
+        adapter = getMultiAdapter((self.empty_document, self.request), IBumblebeeOverlay)
         self.assertIsNone(adapter.get_download_copy_link())
 
 
-class TestGetEditMetadataLink(FunctionalTestCase):
+class TestGetEditMetadataLink(IntegrationTestCase):
     """Test we correctly generate the document edit metadata link."""
 
-    layer = OPENGEVER_FUNCTIONAL_BUMBLEBEE_LAYER
+    features = (
+        'bumblebee',
+        )
 
     def test_returns_edit_metadata_url(self):
-        dossier = create(Builder('dossier'))
-        document = create(Builder('document').within(dossier))
-
-        adapter = getMultiAdapter((document, self.request), IBumblebeeOverlay)
-        self.assertEqual(
-            'http://nohost/plone/dossier-1/document-1/edit',
-            adapter.get_edit_metadata_url())
+        self.login(self.regular_user)
+        adapter = getMultiAdapter((self.document, self.request), IBumblebeeOverlay)
+        self.assertEqual('{}/edit'.format(self.document.absolute_url()), adapter.get_edit_metadata_url())
 
     def test_returns_none_if_user_is_not_allowed_to_edit(self):
-        dossier = create(Builder('dossier'))
-        document = create(Builder('document').within(dossier))
-        create(Builder('user')
-               .with_userid('bond')
-               .with_roles('Member', 'Reader'))
-
-        adapter = getMultiAdapter((document, self.request), IBumblebeeOverlay)
-
-        self.assertEqual(
-            'http://nohost/plone/dossier-1/document-1/edit',
-            adapter.get_edit_metadata_url())
-
-        login(self.portal, 'bond')
+        self.login(self.regular_user)
+        adapter = getMultiAdapter((self.proposaldocument, self.request), IBumblebeeOverlay)
         self.assertIsNone(adapter.get_edit_metadata_url())
 
 
-class TestHasFile(FunctionalTestCase):
+class TestHasFile(IntegrationTestCase):
     """Test we correctly detect if a document has a file."""
 
-    layer = OPENGEVER_FUNCTIONAL_BUMBLEBEE_LAYER
+    features = (
+        'bumblebee',
+        )
 
     def test_returns_true_if_document_has_a_file(self):
-        dossier = create(Builder('dossier'))
-        document = create(Builder('document')
-                          .within(dossier)
-                          .attach_file_containing(
-                              bumblebee_asset('example.docx').bytes(),
-                              u'example.docx'))
-
-        adapter = getMultiAdapter((document, self.request), IBumblebeeOverlay)
-
+        self.login(self.regular_user)
+        adapter = getMultiAdapter((self.document, self.request), IBumblebeeOverlay)
         self.assertTrue(adapter.has_file())
 
     def test_returns_false_if_document_has_no_file(self):
-        dossier = create(Builder('dossier'))
-        document = create(Builder('document').within(dossier))
-
-        adapter = getMultiAdapter((document, self.request), IBumblebeeOverlay)
-
+        self.login(self.regular_user)
+        adapter = getMultiAdapter((self.empty_document, self.request), IBumblebeeOverlay)
         self.assertFalse(adapter.has_file())
 
 
-class TestGetFile(FunctionalTestCase):
+class TestGetFile(IntegrationTestCase):
     """Test we correctly fetch the file of the document."""
 
-    layer = OPENGEVER_FUNCTIONAL_BUMBLEBEE_LAYER
+    features = (
+        'bumblebee',
+        )
 
     def test_returns_none_if_document_has_no_file(self):
-        dossier = create(Builder('dossier'))
-        document = create(Builder('document').within(dossier))
-
-        adapter = getMultiAdapter((document, self.request), IBumblebeeOverlay)
-
+        self.login(self.regular_user)
+        adapter = getMultiAdapter((self.empty_document, self.request), IBumblebeeOverlay)
         self.assertIsNone(adapter.get_file())
 
     def test_returns_file_if_document_has_file(self):
-        dossier = create(Builder('dossier'))
-        document = create(Builder('document')
-                          .within(dossier)
-                          .attach_file_containing(
-                              bumblebee_asset('example.docx').bytes(),
-                              u'example.docx'))
-
-        adapter = getMultiAdapter((document, self.request), IBumblebeeOverlay)
-
-        self.assertEqual(document.file, adapter.get_file())
+        self.login(self.regular_user)
+        adapter = getMultiAdapter((self.document, self.request), IBumblebeeOverlay)
+        self.assertEqual(self.document.file, adapter.get_file())
 
 
-class TestGetCheckinWithoutCommentUrl(FunctionalTestCase):
+class TestGetCheckinWithoutCommentUrl(IntegrationTestCase):
     """Test we correctly generate a checkin without comment link."""
 
-    layer = OPENGEVER_FUNCTIONAL_BUMBLEBEE_LAYER
+    features = (
+        'bumblebee',
+        )
 
     def test_returns_none_when_document_is_not_checked_out(self):
-        dossier = create(Builder('dossier'))
-        document = create(Builder('document')
-                          .within(dossier)
-                          .with_dummy_content())
-
-        adapter = getMultiAdapter((document, self.request), IBumblebeeOverlay)
-
+        self.login(self.regular_user)
+        adapter = getMultiAdapter((self.document, self.request), IBumblebeeOverlay)
         self.assertIsNone(adapter.get_checkin_without_comment_url())
 
     def test_returns_checkin_without_comment_url_as_string(self):
-        dossier = create(Builder('dossier'))
-        document = create(Builder('document')
-                          .within(dossier)
-                          .with_dummy_content()
-                          .checked_out())
-
-        adapter = getMultiAdapter((document, self.request), IBumblebeeOverlay)
-        self.assertIn(
-            'http://nohost/plone/dossier-1/document-1/'
-            '@@checkin_without_comment',
-            adapter.get_checkin_without_comment_url())
+        self.login(self.regular_user)
+        self.checkout_document(self.document)
+        adapter = getMultiAdapter((self.document, self.request), IBumblebeeOverlay)
+        expected_url = '{}/@@checkin_without_comment?_authenticator='.format(self.document.absolute_url())
+        self.assertTrue(adapter.get_checkin_without_comment_url().startswith(expected_url))
 
 
-class TestGetCheckinWithCommentUrl(FunctionalTestCase):
+class TestGetCheckinWithCommentUrl(IntegrationTestCase):
     """Test we correctly generate a checkin with comment link."""
 
-    layer = OPENGEVER_FUNCTIONAL_BUMBLEBEE_LAYER
+    features = (
+        'bumblebee',
+        )
 
     def test_returns_none_when_document_is_not_checked_out(self):
-        dossier = create(Builder('dossier'))
-        document = create(Builder('document')
-                          .within(dossier)
-                          .with_dummy_content())
-
-        adapter = getMultiAdapter((document, self.request), IBumblebeeOverlay)
-
+        self.login(self.regular_user)
+        adapter = getMultiAdapter((self.document, self.request), IBumblebeeOverlay)
         self.assertIsNone(adapter.get_checkin_with_comment_url())
 
     def test_returns_checkin_with_comment_url_as_string(self):
-        dossier = create(Builder('dossier'))
-        document = create(Builder('document')
-                          .within(dossier)
-                          .with_dummy_content()
-                          .checked_out())
-
-        adapter = getMultiAdapter((document, self.request), IBumblebeeOverlay)
-        self.assertIn(
-            'http://nohost/plone/dossier-1/document-1/@@checkin_document',
-            adapter.get_checkin_with_comment_url())
+        self.login(self.regular_user)
+        self.checkout_document(self.document)
+        adapter = getMultiAdapter((self.document, self.request), IBumblebeeOverlay)
+        expected_url = '{}/@@checkin_document?_authenticator='.format(self.document.absolute_url())
+        self.assertTrue(adapter.get_checkin_with_comment_url().startswith(expected_url))
 
 
-class TestRenderLockInfoViewlet(FunctionalTestCase):
+class TestRenderLockInfoViewlet(IntegrationTestCase):
     """Test we correctly render the document locking status."""
 
-    layer = OPENGEVER_FUNCTIONAL_BUMBLEBEE_LAYER
+    features = (
+        'bumblebee',
+        )
 
     @browsing
     def test_returns_empty_html_if_not_locked(self, browser):
-        dossier = create(Builder('dossier'))
-        document = create(Builder('document')
-                          .within(dossier)
-                          .with_dummy_content())
-
-        adapter = getMultiAdapter((document, self.request), IBumblebeeOverlay)
+        self.login(self.regular_user)
+        adapter = getMultiAdapter((self.document, self.request), IBumblebeeOverlay)
         browser.open_html(adapter.render_lock_info_viewlet())
-
         self.assertEqual(0, len(browser.css('.portalMessage')))
 
     @browsing
     def test_returns_lock_info_viewlet_if_locked(self, browser):
-        create(Builder('user')
-               .with_userid('bond')
-               .with_roles('Member', 'Reader'))
-
-        dossier = create(Builder('dossier'))
-        document = create(Builder('document')
-                          .within(dossier)
-                          .with_dummy_content())
-
-        IRefreshableLockable(document).lock()
-
-        login(self.portal, 'bond')
-
-        adapter = getMultiAdapter((document, self.request), IBumblebeeOverlay)
+        self.login(self.regular_user)
+        IRefreshableLockable(self.document).lock()
+        adapter = getMultiAdapter((self.document, self.request), IBumblebeeOverlay)
         browser.open_html(adapter.render_lock_info_viewlet())
-
         self.assertEqual(1, len(browser.css('.portalMessage')))
 
 
-class TestRenderCheckedOutViewlet(FunctionalTestCase):
+class TestRenderCheckedOutViewlet(IntegrationTestCase):
     """Test we correctly render the document checkout info viewlet."""
 
-    layer = OPENGEVER_FUNCTIONAL_BUMBLEBEE_LAYER
+    features = (
+        'bumblebee',
+        )
 
     @browsing
     def test_returns_empty_html_if_not_checked_out(self, browser):
-        dossier = create(Builder('dossier'))
-        document = create(Builder('document')
-                          .within(dossier)
-                          .with_dummy_content())
-
-        adapter = getMultiAdapter((document, self.request), IBumblebeeOverlay)
+        self.login(self.regular_user)
+        adapter = getMultiAdapter((self.document, self.request), IBumblebeeOverlay)
         self.assertEqual(u'\n', adapter.render_checked_out_viewlet())
 
     @browsing
     def test_returns_lock_info_viewlet_if_checked_out(self, browser):
-        dossier = create(Builder('dossier'))
-        document = create(Builder('document')
-                          .within(dossier)
-                          .with_dummy_content()
-                          .checked_out())
-
-        adapter = getMultiAdapter((document, self.request), IBumblebeeOverlay)
+        self.login(self.regular_user)
+        self.checkout_document(self.document)
+        adapter = getMultiAdapter((self.document, self.request), IBumblebeeOverlay)
         browser.open_html(adapter.render_checked_out_viewlet())
-
         self.assertEqual(1, len(browser.css('.portalMessage')))
 
 
-class TestIsVersionedContext(FunctionalTestCase):
+class TestIsVersionedContext(IntegrationTestCase):
     """Test if we correctly detect if we're on a versioned document or not."""
 
-    layer = OPENGEVER_FUNCTIONAL_BUMBLEBEE_LAYER
+    features = (
+        'bumblebee',
+        )
 
     def test_returns_false_if_no_version_id_is_given(self):
-        dossier = create(Builder('dossier'))
-        document = create(Builder('document').within(dossier))
-
-        adapter = getMultiAdapter((document, self.request), IBumblebeeOverlay)
-
+        self.login(self.regular_user)
+        adapter = getMultiAdapter((self.document, self.request), IBumblebeeOverlay)
         self.assertFalse(adapter.is_versioned())
 
-    def test_returns_true_if_version_id_is_0(self):
-        dossier = create(Builder('dossier'))
-        document = create(Builder('document').within(dossier))
-
-        self.request['version_id'] = 0
-        adapter = getMultiAdapter((document, self.request), IBumblebeeOverlay)
-
+    def test_returns_true_if_version_id_is_a_string(self):
+        self.login(self.regular_user)
+        self.request['version_id'] = '0'
+        adapter = getMultiAdapter((self.document, self.request), IBumblebeeOverlay)
         self.assertTrue(adapter.is_versioned())
 
     def test_returns_true_if_version_id_is_a_number(self):
-        dossier = create(Builder('dossier'))
-        document = create(Builder('document').within(dossier))
-
+        self.login(self.regular_user)
         self.request['version_id'] = 123
-        adapter = getMultiAdapter((document, self.request), IBumblebeeOverlay)
-
+        adapter = getMultiAdapter((self.document, self.request), IBumblebeeOverlay)
         self.assertTrue(adapter.is_versioned())
 
 
-class TestGetRevertUrl(FunctionalTestCase):
+class TestGetRevertUrl(IntegrationTestCase):
     """Test we generate proper document version revert links."""
 
-    layer = OPENGEVER_FUNCTIONAL_BUMBLEBEE_LAYER
+    features = (
+        'bumblebee',
+        )
 
     def test_returns_revert_url_as_string(self):
-        dossier = create(Builder('dossier'))
-        document = create(Builder('document').within(dossier))
-
+        self.login(self.regular_user)
         alsoProvides(self.request, IVersionedContextMarker)
-
         # We need to do both in order to fake a real request here
         self.request['version_id'] = 3
-        adapter = getMultiAdapter((document, self.request), IBumblebeeOverlay)
+        adapter = getMultiAdapter((self.document, self.request), IBumblebeeOverlay)
         adapter.version_id = 3
-
-        self.assertIn(
-            'revert-file-to-version?version_id=3',
-            adapter.get_revert_link())
+        self.assertIn('revert-file-to-version?version_id=3', adapter.get_revert_link())
 
     def test_returns_none_if_context_is_not_a_versioned_context(self):
-        dossier = create(Builder('dossier'))
-        document = create(Builder('document').within(dossier))
-
+        self.login(self.regular_user)
         alsoProvides(self.request, IVersionedContextMarker)
-
-        adapter = getMultiAdapter((document, self.request), IBumblebeeOverlay)
-
+        adapter = getMultiAdapter((self.document, self.request), IBumblebeeOverlay)
         self.assertIsNone(adapter.get_revert_link())

--- a/opengever/bumblebee/tests/test_overlay_adapter_document_version.py
+++ b/opengever/bumblebee/tests/test_overlay_adapter_document_version.py
@@ -1,27 +1,22 @@
-from ftw.builder import Builder
-from ftw.builder import create
 from opengever.bumblebee.browser.overlay import BumblebeeDocumentVersionOverlay
 from opengever.bumblebee.interfaces import IBumblebeeOverlay
 from opengever.bumblebee.interfaces import IVersionedContextMarker
-from opengever.core.testing import OPENGEVER_FUNCTIONAL_BUMBLEBEE_LAYER
-from opengever.testing import FunctionalTestCase
+from opengever.testing import IntegrationTestCase
 from zope.component import getMultiAdapter
 from zope.interface import alsoProvides
 from zope.interface.verify import verifyClass
 
 
-class TestAdapterRegisteredProperly(FunctionalTestCase):
+class TestAdapterRegisteredProperly(IntegrationTestCase):
 
-    layer = OPENGEVER_FUNCTIONAL_BUMBLEBEE_LAYER
+    features = (
+        'bumblebee',
+        )
 
     def test_get_overlay_adapter_for_documents(self):
-        dossier = create(Builder('dossier'))
-        document = create(Builder('document').within(dossier))
-
+        self.login(self.regular_user)
         alsoProvides(self.request, IVersionedContextMarker)
-
-        adapter = getMultiAdapter((document, self.request), IBumblebeeOverlay)
-
+        adapter = getMultiAdapter((self.document, self.request), IBumblebeeOverlay)
         self.assertIsInstance(adapter, BumblebeeDocumentVersionOverlay)
 
     def test_verify_implemented_interfaces(self):

--- a/opengever/bumblebee/tests/test_overlay_adapter_mail.py
+++ b/opengever/bumblebee/tests/test_overlay_adapter_mail.py
@@ -66,7 +66,7 @@ class TestGetOpenAsPdfLink(IntegrationTestCase):
 
         expected_url = (
             'http://nohost/plone/ordnungssystem/fuhrung'
-            '/vertrage-und-vereinbarungen/dossier-1/document-28'
+            '/vertrage-und-vereinbarungen/dossier-1/document-29'
             '/bumblebee-open-pdf?filename=Die%20Buergschaft.pdf'
             )
 
@@ -79,7 +79,7 @@ class TestGetOpenAsPdfLink(IntegrationTestCase):
 
         expected_url = (
             u'http://nohost/plone/ordnungssystem/fuhrung'
-            u'/vertrage-und-vereinbarungen/dossier-1/document-28'
+            u'/vertrage-und-vereinbarungen/dossier-1/document-29'
             u'/bumblebee-open-pdf?filename=GEVER%20-%20%C3%9Cbernahme.pdf'
             )
 

--- a/opengever/dossier/tests/test_overview.py
+++ b/opengever/dossier/tests/test_overview.py
@@ -26,7 +26,8 @@ class TestOverview(IntegrationTestCase):
 
     @property
     def tested_document(self):
-        return self.taskdocument
+        # XXX - this needs to be within the 10 latest documents
+        return self.empty_document
 
     @property
     def tested_task(self):
@@ -168,15 +169,12 @@ class TestOverview(IntegrationTestCase):
     @browsing
     def test_documents_in_overview_are_linked(self, browser):
         self.login(self.regular_user, browser=browser)
-
-        browser.open(self.tested_dossier,
-                     view='tabbedview_view-overview')
-
-        link = browser.css(
-            '#newest_documentsBox li:not(.moreLink) a.document_link')[-1]
-        self.assertEquals(self.tested_document.title, link.text)
-        self.assertEqual(
-            self.tested_document.absolute_url(), link.get('href'))
+        browser.open(self.tested_dossier, view='tabbedview_view-overview')
+        links = browser.css('#newest_documentsBox li:not(.moreLink) a.document_link')
+        titles = links.text
+        anchors = [link.get('href') for link in links]
+        self.assertIn(self.tested_document.title, titles)
+        self.assertIn(self.tested_document.absolute_url(), anchors)
 
     @browsing
     def test_document_box_items_are_limited_to_ten_and_sorted_by_modified(self, browser):

--- a/opengever/dossier/tests/test_templatefolder.py
+++ b/opengever/dossier/tests/test_templatefolder.py
@@ -196,15 +196,15 @@ class TestDocumentWithTemplateFormWithDocProperties(IntegrationTestCase):
         self.assertEquals(u'Test Docx.docx', document.file.filename)
 
         expected_doc_properties = {
-            'Document.ReferenceNumber': 'Client1 1.1 / 1 / 34',
-            'Document.SequenceNumber': '34',
+            'Document.ReferenceNumber': 'Client1 1.1 / 1 / 35',
+            'Document.SequenceNumber': '35',
             'Dossier.ReferenceNumber': 'Client1 1.1 / 1',
             'Dossier.Title': u'Vertr\xe4ge mit der kantonalen Finanzverwaltung',
             'User.FullName': u'B\xe4rfuss K\xe4thi',
             'User.ID': 'kathi.barfuss',
             'ogg.document.document_date': datetime(2020, 9, 28, 0, 0),
-            'ogg.document.reference_number': 'Client1 1.1 / 1 / 34',
-            'ogg.document.sequence_number': '34',
+            'ogg.document.reference_number': 'Client1 1.1 / 1 / 35',
+            'ogg.document.sequence_number': '35',
             'ogg.document.title': 'Test Docx',
             'ogg.document.version_number': 0,
             'ogg.dossier.reference_number': 'Client1 1.1 / 1',
@@ -254,15 +254,15 @@ class TestDocumentWithTemplateFormWithDocProperties(IntegrationTestCase):
         self.assertEquals(u'Test Docx.docx', document.file.filename)
 
         expected_doc_properties = {
-            'Document.ReferenceNumber': 'Client1 1.1 / 1 / 34',
-            'Document.SequenceNumber': '34',
+            'Document.ReferenceNumber': 'Client1 1.1 / 1 / 35',
+            'Document.SequenceNumber': '35',
             'Dossier.ReferenceNumber': 'Client1 1.1 / 1',
             'Dossier.Title': u'Vertr\xe4ge mit der kantonalen Finanzverwaltung',
             'User.FullName': u'B\xe4rfuss K\xe4thi',
             'User.ID': 'kathi.barfuss',
             'ogg.document.document_date': datetime(2020, 10, 28, 0, 0),
-            'ogg.document.reference_number': 'Client1 1.1 / 1 / 34',
-            'ogg.document.sequence_number': '34',
+            'ogg.document.reference_number': 'Client1 1.1 / 1 / 35',
+            'ogg.document.sequence_number': '35',
             'ogg.document.title': 'Test Docx',
             'ogg.document.version_number': 0,
             'ogg.dossier.reference_number': 'Client1 1.1 / 1',

--- a/opengever/ech0147/tests/test_model.py
+++ b/opengever/ech0147/tests/test_model.py
@@ -108,12 +108,19 @@ class TestDossierModel(IntegrationTestCase):
             base_path + '/' + self.dossier.getId(), dossier.path)
 
     def test_dossier_contains_documents_and_mails(self):
-        documentish_types = ['opengever.document.document', 'ftw.mail.mail']
         dossier = Dossier(self.dossier, u'files')
-        self.assertItemsEqual(
-            [d for d in self.dossier.objectValues()
-             if d.portal_type in documentish_types],
-            [d.obj for d in dossier.documents])
+        dossier_objects = self.dossier.objectValues()
+        expected_mails = [
+            d for d
+            in dossier_objects
+            if d.portal_type == 'ftw.mail.mail'
+            ]
+        expected_documents = [
+            d for d
+            in dossier_objects
+            if d.portal_type == 'opengever.document.document' and d.file
+            ]
+        self.assertItemsEqual(expected_mails + expected_documents, [d.obj for d in dossier.documents])
 
     def test_documents_without_a_file_are_skipped(self):
         self.document.file = None

--- a/opengever/mail/tests/test_indexers.py
+++ b/opengever/mail/tests/test_indexers.py
@@ -47,4 +47,4 @@ class TestMailIndexers(IntegrationTestCase):
             u'IDocumentSchema',
             )
 
-        self.assertEquals('Client1 1.1 / 1 / 28 28', extender())
+        self.assertEquals('Client1 1.1 / 1 / 29 29', extender())

--- a/opengever/officeconnector/tests/test_api_dossier_attach.py
+++ b/opengever/officeconnector/tests/test_api_dossier_attach.py
@@ -93,7 +93,7 @@ class TestOfficeconnectorDossierAPIWithAttach(OCIntegrationTestCase):
         expected_payloads = [{
             u'content-type': u'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
             u'csrf-token': u'86ecf9b4135514f8c94c61ce336a4b98b4aaed8a',
-            u'document-url': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-5/document-27',
+            u'document-url': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-5/document-28',
             u'download': u'download',
             u'filename': u'Uebersicht der Inaktiven Vertraege von 2016.xlsx',
             u'title': u'\xdcbersicht der Inaktiven Vertr\xe4ge von 2016',
@@ -140,7 +140,7 @@ class TestOfficeconnectorDossierAPIWithAttach(OCIntegrationTestCase):
         expected_payloads = [{
             u'content-type': u'application/msword',
             u'csrf-token': u'86ecf9b4135514f8c94c61ce336a4b98b4aaed8a',
-            u'document-url': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-4/document-26',
+            u'document-url': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-4/document-27',
             u'download': u'download',
             u'filename': u'Uebersicht der Vertraege vor 2000.doc',
             u'title': u'\xdcbersicht der Vertr\xe4ge vor 2000',

--- a/opengever/oneoffixx/tests/assets/oneoffixx_connect_xml.txt
+++ b/opengever/oneoffixx/tests/assets/oneoffixx_connect_xml.txt
@@ -14,15 +14,15 @@
         <Arguments>
           <Interface Name="OneGovGEVER">
             <Node Id="ogg.document.title">A doc</Node>
-            <Node Id="ogg.document.reference_number">Client1 1.1 / 1 / 34</Node>
-            <Node Id="ogg.document.sequence_number">34</Node>
+            <Node Id="ogg.document.reference_number">Client1 1.1 / 1 / 35</Node>
+            <Node Id="ogg.document.sequence_number">35</Node>
           </Interface>
         </Arguments>
       </Function>
       <Function name="MetaData" id="c364b495-7176-4ce2-9f7c-e71f302b8096">
         <Value key="ogg.document.title" type="string">A doc</Value>
-        <Value key="ogg.document.reference_number" type="string">Client1 1.1 / 1 / 34</Value>
-        <Value key="ogg.document.sequence_number" type="string">34</Value>
+        <Value key="ogg.document.reference_number" type="string">Client1 1.1 / 1 / 35</Value>
+        <Value key="ogg.document.sequence_number" type="string">35</Value>
       </Function>
       <Commands>
         <Command Name="DefaultProcess">

--- a/opengever/private/tests/test_reference_number.py
+++ b/opengever/private/tests/test_reference_number.py
@@ -138,7 +138,7 @@ class TestPrivateReferenceNumber(IntegrationTestCase):
         self.login(self.regular_user, browser)
         browser.open(self.private_document)
 
-        expected_reference_number = 'P Client1 kathi-barfuss / 1 / 32'
+        expected_reference_number = 'P Client1 kathi-barfuss / 1 / 33'
         found_reference_number = browser.css('.referenceNumber .value').text[0]
 
         self.assertEqual(found_reference_number, expected_reference_number)

--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -1042,6 +1042,15 @@ class OpengeverContentFixture(object):
                 )
             ))
 
+        self.register('empty_document', create(
+            Builder('document')
+            .within(self.dossier)
+            .titled(u'L\xe4\xe4r')
+            .having(
+                preserved_as_paper=True,
+                )
+            ))
+
     @staticuid()
     def create_expired_dossier(self):
         expired_dossier = self.register('expired_dossier', create(


### PR DESCRIPTION
* Added an empty document into the fixtures
* Ported the bumblebee overlay tests to integration tests
* Fixed the bumblebee document overlay date getter to allow for `None`

Closes #4723