### PR TITLE
Sharing view improvements and IE 11 fixes

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ---------------------
 
 - Sharing views: Show userdetails also in an overlay. [phgross]
+- Fix sharing form for IE 11. [phgross]
 - Lock oder of avaialbe roles in sharing endpoint. [phgross]
 - Fix archival_file and public_trial checks on documents overview. [phgross]
 - Add placeful workflow policy for inbox-area. Let inbox users edit and checkout documents but not the inbox itself. [phgross]

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ---------------------
 
 - Sharing views: Show userdetails also in an overlay. [phgross]
+- Show assignments info button only on rows with automatic roles. [phgross]
 - Fix sharing form for IE 11. [phgross]
 - Lock oder of avaialbe roles in sharing endpoint. [phgross]
 - Fix archival_file and public_trial checks on documents overview. [phgross]

--- a/opengever/sharing/browser/resources/sharing.js
+++ b/opengever/sharing/browser/resources/sharing.js
@@ -62,7 +62,7 @@ var sharingApp = {
       entry.disabled = false;
     },
 
-    toggle_assignments: function (event, entry) {
+    toggle_assignments: function (entry) {
       if (!entry.assignments){
         var params = { _t: Date.now().toString()};
         var url = this.context_url + '/@role-assignments/' + entry.id;
@@ -96,9 +96,9 @@ var sharingApp = {
 
       this.requester.get(this.endpoint, { params: params }).then(function (response) {
 
-        this.entries = Object.values(this.entries).filter(i => i.disabled == false);
+        this.entries = this.entries.filter(function(i) { return !i.disabled; });
         this.entries = this.entries.concat(
-          response.data['entries'].filter(i => i.disabled != false));
+          response.data['entries'].filter(function(i) { return i.disabled != false; }));
         this.inherit = response.data['inherit'];
 
       }.bind(this));
@@ -107,7 +107,7 @@ var sharingApp = {
 
     save: function(event){
       payload = {
-        entries: Object.values(this.entries),
+        entries: this.entries,
         inherit: this.inherit };
 
       this.requester.post(this.endpoint, payload).then(function (response) {

--- a/opengever/sharing/browser/resources/sharing.js
+++ b/opengever/sharing/browser/resources/sharing.js
@@ -87,6 +87,14 @@ var sharingApp = {
       });
     },
 
+    show_info_assignment_button: function (entry) {
+      return Object.keys(entry.automatic_roles)
+        .map(function(key) { return entry.automatic_roles[key]; })
+        .reduce(function(a, b) {
+          return a || b;
+        }, false);
+    },
+
     search: function() {
       // make sure IE 11 does not cache the fetch request
       var params = { _t: Date.now().toString(), search: this.principal_search };

--- a/opengever/sharing/browser/templates/sharing.html
+++ b/opengever/sharing/browser/templates/sharing.html
@@ -19,7 +19,8 @@
              :href="entry.url">{{entry.title}}</a>
           <a class="assignments_info_button"
              v-bind:class="{ folded: entry.assignments}"
-             @click="(event) => {toggle_assignments(event, entry, )}"/>
+             @click="toggle_assignments(entry)"/>
+
           <div v-show="entry.assignments" class="assignments_info">
             <ul class="assignments_listing">
               <li v-for="assignment in entry.assignments"
@@ -48,7 +49,7 @@
             <input type="checkbox" v-if="entry.computed_roles[role.id] != 'acquired'"
                    :checked="entry.roles[role.id]"
                    :class="role.id"
-                   @click="(event) => {toggle_checkbox(event, entry, role.id)}"/>
+                   @click="toggle_checkbox($event, entry, role.id)"/>
 
             <!-- automatic roles -->
             <div class="automatic"

--- a/opengever/sharing/browser/templates/sharing.html
+++ b/opengever/sharing/browser/templates/sharing.html
@@ -19,7 +19,8 @@
              :href="entry.url">{{entry.title}}</a>
           <a class="assignments_info_button"
              v-bind:class="{ folded: entry.assignments}"
-             @click="toggle_assignments(entry)"/>
+             @click="toggle_assignments(entry)"
+             v-show="show_info_assignment_button(entry)" />
 
           <div v-show="entry.assignments" class="assignments_info">
             <ul class="assignments_listing">

--- a/opengever/sharing/browser/templates/sharing.pt
+++ b/opengever/sharing/browser/templates/sharing.pt
@@ -28,8 +28,6 @@
                              data-is-editable string:true;
                              data-authtoken context/@@authenticator/token"></div>
 
-        <script tal:attributes="src string:${here/portal_url}/++resource++opengever.sharing/sharing.js"></script>
-
       </metal:core-macro>
     </div>
   </body>


### PR DESCRIPTION
- No longer use arrow functions and Object.values, there are not supported by IE 11.
- Drop sharing.js from the sharing template. The sharing.js is included globally (registered in the js registry), so no need to include them in the template.
- Show assignments_info button (?) only on rows with automatic roles