### PR TITLE
Sharing views: Show userdetails also in an overlay. 

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2018.4.0 (unreleased)
 ---------------------
 
+- Sharing views: Show userdetails also in an overlay. [phgross]
 - Lock oder of avaialbe roles in sharing endpoint. [phgross]
 - Fix archival_file and public_trial checks on documents overview. [phgross]
 - Add placeful workflow policy for inbox-area. Let inbox users edit and checkout documents but not the inbox itself. [phgross]

--- a/opengever/base/browser/resources/prepoverlay.js
+++ b/opengever/base/browser/resources/prepoverlay.js
@@ -20,6 +20,10 @@ $(function() {
 
     var events = $(this).data('events');
 
+    if ($(this).parents('.overlay-ajax').length) {
+      $(this).parents('.overlay-ajax').overlay().close();
+    };
+
     if (!events || !events.click) {
       $(this).prepOverlay(config);
 

--- a/opengever/ogds/base/browser/configure.zcml
+++ b/opengever/ogds/base/browser/configure.zcml
@@ -55,6 +55,14 @@
       />
 
   <browser:page
+      for="*"
+      name="user-details-plain"
+      class=".userdetails.UserDetails"
+      permission="zope2.View"
+      template="templates/userdetails_table.pt"
+      />
+
+  <browser:page
       for="opengever.ogds.base.interfaces.ITeam"
       name="view"
       class=".teamdetails.TeamDetails"

--- a/opengever/ogds/base/browser/templates/userdetails.pt
+++ b/opengever/ogds/base/browser/templates/userdetails.pt
@@ -16,7 +16,6 @@
 
         <div tal:replace="structure provider:plone.abovecontenttitle" />
         <h1 class="documentFirstHeading" tal:content="user/label"/>
-        <!--         <div tal:replace="structure provider:plone.belowcontenttitle" /> -->
 
         <div tal:replace="structure provider:plone.abovecontentbody" />
 
@@ -24,123 +23,8 @@
            tal:attributes="href string:${here/absolute_url}/kontakte/#users"
            i18n:translate="link_all_users">Show all users</a>
 
-        <table class="vertical listing">
-          <tr>
-            <th i18n:translate="label_fullname">Name</th>
-            <td tal:content="user/label"></td>
-          </tr>
+        <div tal:replace="structure view/user_details_table" />
 
-          <tr>
-            <th i18n:translate="label_active">Active</th>
-            <td i18n:translate="active_yes" tal:condition="user/active">Yes</td>
-            <td i18n:translate="active_no" tal:condition="not:user/active">No</td>
-          </tr>
-
-          <tr tal:condition="user/salutation">
-            <th i18n:translate="label_salutation">Salutation</th>
-            <td tal:content="user/salutation"></td>
-          </tr>
-
-          <tr tal:condition="user/description">
-            <th i18n:translate="label_description">Description</th>
-            <td tal:content="user/description"></td>
-          </tr>
-
-          <tr tal:condition="user/directorate">
-            <th i18n:translate="label_directorate">Directorate</th>
-            <td>
-              <tal:title tal:replace="user/directorate" />
-              <span class="discreet" tal:condition="user/directorate_abbr">
-                (<tal:abbr tal:replace="user/directorate_abbr" />)
-              </span>
-            </td>
-          </tr>
-
-          <tr tal:condition="user/department">
-            <th i18n:translate="label_department">Department</th>
-            <td>
-              <tal:title tal:replace="user/department" />
-              <span class="discreet" tal:condition="user/department_abbr">
-                (<tal:abbr tal:replace="user/department_abbr" />)
-              </span>
-            </td>
-          </tr>
-
-          <tr tal:condition="user/email">
-            <th i18n:translate="label_email">Email</th>
-            <td><a tal:content="user/email"
-                   tal:attributes="href string:mailto:${user/email}" /></td>
-          </tr>
-
-          <tr tal:condition="user/email2">
-            <th i18n:translate="label_email2">Email 2</th>
-            <td><a tal:content="user/email2"
-                   tal:attributes="href string:mailto:${user/email2}" /></td>
-          </tr>
-
-          <tr tal:condition="user/url">
-            <th i18n:translate="label_url">URL</th>
-            <td><a tal:content="user/url"
-                   tal:attributes="href user/url"
-                   target="_blank" /></td>
-          </tr>
-
-          <tr tal:condition="user/phone_office">
-            <th i18n:translate="label_phone_office">Office phone</th>
-            <td tal:content="user/phone_office"></td>
-          </tr>
-
-          <tr tal:condition="user/phone_fax">
-            <th i18n:translate="label_phone_fax">Fax</th>
-            <td tal:content="user/phone_fax"></td>
-          </tr>
-
-          <tr tal:condition="user/phone_mobile">
-            <th i18n:translate="label_phone_mobile">Mobile phone</th>
-            <td tal:content="user/phone_mobile"></td>
-          </tr>
-
-          <tr tal:condition="python:user.address1 or user.address2 or user.zip_code or user.city or user.country">
-            <th i18n:translate="label_address">Address</th>
-            <td>
-              <div tal:content="user/address1" tal:condition="user/address1" />
-              <div tal:content="user/address2" tal:condition="user/address2" />
-              <div tal:condition="python:user.zip_code or user.city">
-                <span tal:replace="user/zip_code" />
-                <span tal:content="user/city" />
-              </div>
-              <div tal:content="user/country" tal:condition="user/country" />
-            </td>
-          </tr>
-
-          <tr tal:condition="python:len(groups) > 0">
-              <th i18n:translate="label_groups">Groups</th>
-              <td>
-                  <ul class="groups">
-                      <li tal:repeat="group groups">
-                        <a class="group link-overlay"
-                           tal:define="groupmembers_url python:view.groupmembers_url(group.groupid)"
-                           tal:attributes="href groupmembers_url"
-                           tal:content="python: group.title or group.groupid"></a>
-                      </li>
-                  </ul>
-              </td>
-          </tr>
-
-          <tr tal:condition="python:len(teams) > 0">
-              <th i18n:translate="label_teams">Teams</th>
-              <td>
-                  <ul class="teams">
-                      <li tal:repeat="team teams">
-                        <a class="team"
-                           tal:attributes="href string:${view/contactfolder_url}/team-${team/team_id}/view"
-                           tal:content="team/title"></a>
-                      </li>
-                  </ul>
-              </td>
-          </tr>
-
-        </table>
 
         <div tal:replace="structure provider:plone.belowcontentbody" />
       </tal:main-macro>

--- a/opengever/ogds/base/browser/templates/userdetails_table.pt
+++ b/opengever/ogds/base/browser/templates/userdetails_table.pt
@@ -1,0 +1,124 @@
+<tal:define tal:define="data view/get_userdata;
+                        user data/user;
+                        groups data/groups;
+                        teams data/teams">
+
+  <table class="vertical listing">
+    <tr>
+      <th i18n:translate="label_fullname">Name</th>
+      <td tal:content="user/label"></td>
+    </tr>
+
+    <tr>
+      <th i18n:translate="label_active">Active</th>
+      <td i18n:translate="active_yes" tal:condition="user/active">Yes</td>
+      <td i18n:translate="active_no" tal:condition="not:user/active">No</td>
+    </tr>
+
+    <tr tal:condition="user/salutation">
+      <th i18n:translate="label_salutation">Salutation</th>
+      <td tal:content="user/salutation"></td>
+    </tr>
+
+    <tr tal:condition="user/description">
+      <th i18n:translate="label_description">Description</th>
+      <td tal:content="user/description"></td>
+    </tr>
+
+    <tr tal:condition="user/directorate">
+      <th i18n:translate="label_directorate">Directorate</th>
+      <td>
+        <tal:title tal:replace="user/directorate" />
+        <span class="discreet" tal:condition="user/directorate_abbr">
+          (<tal:abbr tal:replace="user/directorate_abbr" />)
+        </span>
+      </td>
+    </tr>
+
+    <tr tal:condition="user/department">
+      <th i18n:translate="label_department">Department</th>
+      <td>
+        <tal:title tal:replace="user/department" />
+        <span class="discreet" tal:condition="user/department_abbr">
+          (<tal:abbr tal:replace="user/department_abbr" />)
+        </span>
+      </td>
+    </tr>
+
+    <tr tal:condition="user/email">
+      <th i18n:translate="label_email">Email</th>
+      <td><a tal:content="user/email"
+      tal:attributes="href string:mailto:${user/email}" /></td>
+    </tr>
+
+    <tr tal:condition="user/email2">
+      <th i18n:translate="label_email2">Email 2</th>
+      <td><a tal:content="user/email2"
+      tal:attributes="href string:mailto:${user/email2}" /></td>
+    </tr>
+
+    <tr tal:condition="user/url">
+      <th i18n:translate="label_url">URL</th>
+      <td><a tal:content="user/url"
+      tal:attributes="href user/url"
+      target="_blank" /></td>
+    </tr>
+
+    <tr tal:condition="user/phone_office">
+      <th i18n:translate="label_phone_office">Office phone</th>
+      <td tal:content="user/phone_office"></td>
+    </tr>
+
+    <tr tal:condition="user/phone_fax">
+      <th i18n:translate="label_phone_fax">Fax</th>
+      <td tal:content="user/phone_fax"></td>
+    </tr>
+
+    <tr tal:condition="user/phone_mobile">
+      <th i18n:translate="label_phone_mobile">Mobile phone</th>
+      <td tal:content="user/phone_mobile"></td>
+    </tr>
+
+    <tr tal:condition="python:user.address1 or user.address2 or user.zip_code or user.city or user.country">
+      <th i18n:translate="label_address">Address</th>
+      <td>
+        <div tal:content="user/address1" tal:condition="user/address1" />
+        <div tal:content="user/address2" tal:condition="user/address2" />
+        <div tal:condition="python:user.zip_code or user.city">
+          <span tal:replace="user/zip_code" />
+          <span tal:content="user/city" />
+        </div>
+        <div tal:content="user/country" tal:condition="user/country" />
+      </td>
+    </tr>
+
+    <tr tal:condition="python:len(groups) > 0">
+      <th i18n:translate="label_groups">Groups</th>
+      <td>
+        <ul class="groups">
+          <li tal:repeat="group groups">
+            <a class="group link-overlay"
+               tal:define="groupmembers_url python:view.groupmembers_url(group.groupid)"
+               tal:attributes="href groupmembers_url"
+               tal:content="python: group.title or group.groupid"></a>
+          </li>
+        </ul>
+      </td>
+    </tr>
+
+    <tr tal:condition="python:len(teams) > 0">
+      <th i18n:translate="label_teams">Teams</th>
+      <td>
+        <ul class="teams">
+          <li tal:repeat="team teams">
+            <a class="team"
+               tal:attributes="href string:${view/contactfolder_url}/team-${team/team_id}/view"
+               tal:content="team/title"></a>
+          </li>
+        </ul>
+      </td>
+    </tr>
+
+  </table>
+
+</tal:define>

--- a/opengever/ogds/base/browser/userdetails.py
+++ b/opengever/ogds/base/browser/userdetails.py
@@ -2,6 +2,7 @@ from opengever.contact.utils import get_contactfolder_url
 from opengever.ogds.base.utils import ogds_service
 from opengever.ogds.models.exceptions import RecordNotFound
 from Products.Five import BrowserView
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from urllib import urlencode
 from zExceptions import NotFound
 from zope.component.hooks import getSite
@@ -19,6 +20,10 @@ class UserDetails(BrowserView):
         portal = getSite()
         return '/'.join((portal.portal_url(), '@@user-details',
                          userid))
+
+    def user_details_table(self):
+        template = ViewPageTemplateFile('templates/userdetails_table.pt')
+        return template(self, self.request)
 
     def get_userdata(self):
         """Returns a dict of information about a specific user

--- a/opengever/ogds/base/tests/test_userdetails.py
+++ b/opengever/ogds/base/tests/test_userdetails.py
@@ -97,3 +97,31 @@ class TestUserDetails(IntegrationTestCase):
              'http://nohost/plone/@@list_groupmembers?group=projekt_a',
              'http://nohost/plone/@@list_groupmembers?group=with+spaces'],
             group_links)
+
+
+class TestUserDetailsPlain(IntegrationTestCase):
+
+    @browsing
+    def test_contains_only_metadata_table(self, browser):
+        self.login(self.regular_user, browser)
+
+        browser.open(self.portal, view='@@user-details-plain/kathi.barfuss')
+
+        metadata = dict(browser.css('.vertical').first.lists())
+        self.assertDictContainsSubset({
+            'Address': 'Kappelenweg 13 Postfach 1234 1234 Vorkappelen Schweiz',
+            'Department': 'Staatskanzlei (SK)',
+            'Description': 'nix',
+            'Directorate': 'Staatsarchiv (Arch)',
+            'Email': 'foo@example.com',
+            'Email 2': 'bar@example.com',
+            'Fax': '012 34 56 77',
+            'Mobile phone': '012 34 56 76',
+            'Name': u'B\xe4rfuss K\xe4thi (kathi.barfuss)',
+            'Office phone': '012 34 56 78',
+            'Salutation': 'Prof. Dr.',
+            'Teams': u'Projekt \xdcberbaung Dorfmatte',
+            'URL': 'http://www.example.com',
+        }, metadata)
+
+        self.assertEquals([], browser.css('h1'))

--- a/opengever/sharing/browser/sharing.py
+++ b/opengever/sharing/browser/sharing.py
@@ -212,7 +212,7 @@ class OpengeverSharingView(SharingView):
             return '{}/@@list_groupmembers?group={}'.format(
                 api.portal.get().absolute_url(), item['id'])
         else:
-            return '{}/@@user-details/{}'.format(
+            return '{}/@@user-details-plain/{}'.format(
                 api.portal.get().absolute_url(), item['id'])
 
     def extend_with_assignment_infos(self, item, manager):

--- a/opengever/sharing/tests/test_sharing.py
+++ b/opengever/sharing/tests/test_sharing.py
@@ -146,7 +146,7 @@ class TestOpengeverSharingIntegration(IntegrationTestCase):
                   u'computed_roles': {},
                   u'automatic_roles': {},
                   u'title': u'Ziegler Robert',
-                  u'url': u'http://nohost/plone/@@user-details/robert.ziegler',
+                  u'url': u'http://nohost/plone/@@user-details-plain/robert.ziegler',
                   u'login': u'robert.ziegler',
                   u'type': u'user',
                   u'id': u'robert.ziegler'}]},
@@ -190,7 +190,7 @@ class TestOpengeverSharingIntegration(IntegrationTestCase):
                         u'Reviewer': False},
              u'title': u'B\xe4rfuss K\xe4thi',
              u'type': u'user',
-             u'url': u'http://nohost/plone/@@user-details/kathi.barfuss'},
+             u'url': u'http://nohost/plone/@@user-details-plain/kathi.barfuss'},
             [item for item in entries if item['id'] == self.regular_user.id][0])
 
 


### PR DESCRIPTION
Extract user details table in to a separate template and add a plain view, which can be displayed in a overlay. So we can show the user details in a overlay in the sharing view, in the same manner we display the group details.

I've also adjust the prepOverlay JS to not stack overlays when clicking on a overlay-link inside an overlay.