### PR TITLE
Make sure widgets properly return persisted missing values

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2018.4.0 (unreleased)
 ---------------------
 
+- Make sure widgets properly return persisted missing values for optional fields with default values [lgraf]
 - Fix oc loading icon since fontawesome update. [Kevin Bieri]
 - Sharing views: Show userdetails also in an overlay. [phgross]
 - Show assignments info button only on rows with automatic roles. [phgross]

--- a/opengever/base/monkey/patches/__init__.py
+++ b/opengever/base/monkey/patches/__init__.py
@@ -7,6 +7,7 @@ from .default_values import PatchDXCreateContentInContainer
 from .default_values import PatchInvokeFactory
 from .default_values import PatchTransmogrifyDXSchemaUpdater
 from .default_values import PatchZ3CFormChangedField
+from .default_values import PatchZ3CFormWidgetUpdate
 from .default_values import PatchDeserializeFromJson
 from .filter_trashed_from_catalog import PatchCatalogToFilterTrashedDocs
 from .history_handler_tool import PatchCMFEditonsHistoryHandlerTool
@@ -38,6 +39,7 @@ PatchTransmogrifyDXSchemaUpdater()()
 PatchWebDAVLockTimeout()()
 PatchZ2LogTimezone()()
 PatchZ3CFormChangedField()()
+PatchZ3CFormWidgetUpdate()()
 PatchDeserializeFromJson()()
 PatchCMFCatalogAware()()
 PatchOFSRoleManager()()

--- a/opengever/testing/helpers.py
+++ b/opengever/testing/helpers.py
@@ -10,6 +10,8 @@ from Products.PloneLanguageTool.LanguageTool import LanguageBinding
 from zope.component import getUtility
 from zope.component.hooks import getSite
 from zope.intid.interfaces import IIntIds
+from zope.security.management import endInteraction
+from zope.security.management import newInteraction
 import pytz
 import transaction
 
@@ -124,3 +126,25 @@ def obj2paths(objs):
     """Returns a list of paths (string) for the given objects.
     """
     return ['/'.join(obj.getPhysicalPath()) for obj in objs]
+
+
+@contextmanager
+def fake_interaction():
+    """Context manager that temporarily sets up a fake IInteraction.
+
+    This may be needed in cases where no real request is being processed
+    (there's no actual publishing going on), but still a call to
+    checkPermission() is necessary.
+
+    That call would otherwise fail with zope.security.interfaces.NoInteraction.
+
+    Initially needed for standalone testing of z3c.forms, inspired by
+    from z3c/formwidget//query/README.txt.
+
+    For more details see zope.security.management and ZPublisher.Publish.
+    """
+    newInteraction()
+    try:
+        yield
+    finally:
+        endInteraction()


### PR DESCRIPTION
Make sure widgets properly return persisted missing values for optional fields with default values:

In `z3c.form.widget.Widget.update` there is a [misguided check](https://github.com/zopefoundation/z3c.form/blob/3.2.11/src/z3c/form/widget.py#L114) that falls back to using a **default value** if a fields actual value is **equal to missing value**.

This leads to a bug where for fields that are

1) optional (not required)
2) have a default of some sort (field.default or field.defaultFactory)
3) have a legitimate missing value persisted
4) have a MV that is different from the default

an incorrect value is returned by the widget (the default value instead of the legitimate missing value).

This will result in display views that render an object and use the widget's display mode for that to render an incorrect field value (even though underneath, on the persistent object, the MV is properly persisted).

In addition, in an edit form the widget will incorrectly cause the default to be filled in instead of leaving the field at its legitimate MV. This will then result in the persisted MV being overriden by the default.

This change monkey patches `z3c.form.widget.Widget.update` in a way where this strategy is only applied for REQUIRED fields:

Only if the field is required AND the persisted value is equal to MV will it return the default - otherwise, the persisted value is used.

Fixes #4727 