### PR TITLE
Fix Reject response description for old tasks

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,7 @@ Changelog
 
 - Fix oc loading icon since fontawesome update. [Kevin Bieri]
 - Fix inline-cell-icons since fontawesome update. [Kevin Bieri]
+- Fix response description for older rejected tasks. [phgross]
 - Sharing views: Show userdetails also in an overlay. [phgross]
 - Show assignments info button only on rows with automatic roles. [phgross]
 - Fix sharing form for IE 11. [phgross]

--- a/opengever/task/locales/de/LC_MESSAGES/opengever.task.po
+++ b/opengever/task/locales/de/LC_MESSAGES/opengever.task.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2018-08-06 15:59+0000\n"
+"POT-Creation-Date: 2018-08-15 08:06+0000\n"
 "PO-Revision-Date: 2015-02-17 18:41+0100\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -666,6 +666,11 @@ msgstr "Meine Aufgaben"
 #: ./opengever/task/browser/assign_dossier.py
 msgid "new_dossier"
 msgstr "neues Dossier"
+
+#. Default: "Rejected by ${user}."
+#: ./opengever/task/response_description.py
+msgid "old_transition_msg_reject"
+msgstr "Abgelehnt durch ${user}."
 
 #. Default: "Progress:"
 #: ./opengever/task/viewlets/templates/responseview.pt

--- a/opengever/task/locales/fr/LC_MESSAGES/opengever.task.po
+++ b/opengever/task/locales/fr/LC_MESSAGES/opengever.task.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-08-06 15:59+0000\n"
+"POT-Creation-Date: 2018-08-15 08:06+0000\n"
 "PO-Revision-Date: 2017-12-03 11:47+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-task/fr/>\n"
@@ -668,6 +668,11 @@ msgstr "Mes tâches"
 #: ./opengever/task/browser/assign_dossier.py
 msgid "new_dossier"
 msgstr "Nouveau Dossier"
+
+#. Default: "Rejected by ${user}."
+#: ./opengever/task/response_description.py
+msgid "old_transition_msg_reject"
+msgstr "Refusé par ${user}."
 
 #. Default: "Progress:"
 #: ./opengever/task/viewlets/templates/responseview.pt

--- a/opengever/task/locales/opengever.task.pot
+++ b/opengever/task/locales/opengever.task.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2018-08-06 15:59+0000\n"
+"POT-Creation-Date: 2018-08-15 08:06+0000\n"
 "PO-Revision-Date: 2009-02-25 14:39+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -663,6 +663,11 @@ msgstr ""
 #. Default: "new dossier"
 #: ./opengever/task/browser/assign_dossier.py
 msgid "new_dossier"
+msgstr ""
+
+#. Default: "Rejected by ${user}."
+#: ./opengever/task/response_description.py
+msgid "old_transition_msg_reject"
 msgstr ""
 
 #. Default: "Progress:"

--- a/opengever/task/response_description.py
+++ b/opengever/task/response_description.py
@@ -76,8 +76,14 @@ class Reject(ResponseDescription):
     css_class = 'refuse'
 
     def msg(self):
+        if not self.response.get_change('responsible'):
+            return _('old_transition_msg_reject',
+                     default=u'Rejected by ${user}.',
+                     mapping=self._msg_mapping)
+
         return _('transition_msg_reject',
-                 u'Rejected by ${old_responsible}. Task assigned to responsible ${new_responsible}',
+                 u'Rejected by ${old_responsible}. Task assigned to '
+                 'responsible ${new_responsible}',
                  mapping=self._msg_mapping)
 
     def label(self):


### PR DESCRIPTION
With #4502 the automated responsible change when rejecting a task is now also visible in the response. But that leads to confusing response description for older tasks, where the responsible change took not place. Like 
> Abgelehnt durch ${old_responsible}. Aufgabe an Auftragnehmer ${new_responsible} zugewiesen.

Therefore I re add the former message for task where no responsible change has been made.