### PR TITLE
Mark tasks text field no longer as the primary field.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ---------------------
 
 - Make sure widgets properly return persisted missing values for optional fields with default values [lgraf]
+- Mark tasks text field no longer as the primary field. [phgross]
 - Fix oc loading icon since fontawesome update. [Kevin Bieri]
 - Fix inline-cell-icons since fontawesome update. [Kevin Bieri]
 - Fix response description for older rejected tasks. [phgross]

--- a/opengever/api/tests/test_summary.py
+++ b/opengever/api/tests/test_summary.py
@@ -125,3 +125,20 @@ class TestGeverJSONSummarySerializer(IntegrationTestCase):
                         u'und-vereinbarungen/dossier-1/document-12',
                 u'reference_number': u'Client1 1.1 / 1 / 12',
             })
+
+    @browsing
+    def test_summary_with_filename_on_dossiers_containing_tasks(self, browser):
+        self.login(self.regular_user, browser)
+
+        self.task.text = u'Sample description'
+
+        browser.open(self.dossier.absolute_url() +
+                     '?items.fl=filename,filesize',
+                     headers={'Accept': 'application/json'})
+
+        summary = browser.json['items'][1]
+        self.assertEqual(
+            {u'@id': u'http://nohost/plone/ordnungssystem/fuhrung/'
+             'vertrage-und-vereinbarungen/dossier-1/task-1',
+             u'filename': None,
+             u'filesize': 0}, summary)

--- a/opengever/task/task.py
+++ b/opengever/task/task.py
@@ -175,8 +175,6 @@ class ITask(model.Schema):
         )
 
     dexteritytextindexer.searchable('text')
-    model.primary('text')
-
     text = schema.Text(
         title=_(u"label_text", default=u"Text"),
         description=_(u"help_text", default=u""),


### PR DESCRIPTION
It does not make sense to mark a `text` field   as a primary field.

This solves an issue (closes #4745) where API GET request on dossiers had raised an AttributeError when the dossier contained tasks and the summary fieldlist contained the `filesize` or `filename` attribute.