### PR TITLE
CSRF logging: Filter list of registered objects

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2018.4.0 (unreleased)
 ---------------------
 
+- CSRF logging: Filter list of registered objects so only offending objects are logged in sentry [lgraf]
 - Make sure widgets properly return persisted missing values for optional fields with default values [lgraf]
 - Mark tasks text field no longer as the primary field. [phgross]
 - Fix oc loading icon since fontawesome update. [Kevin Bieri]

--- a/opengever/base/protect.py
+++ b/opengever/base/protect.py
@@ -90,8 +90,8 @@ class OGProtectTransform(ProtectTransform):
         # If this happened, the _abort_txn_on_confirm_action_view() safeguard
         # above must have failed.
         redirect_url = self.request.form.get('original_url', '')
-        return (self._get_current_view() == '@@confirm-action' and
-                '@@confirm-action' in redirect_url)
+        return (self._get_current_view() == '@@confirm-action'
+                and '@@confirm-action' in redirect_url)
 
     def _check(self):
         should_log_csrf = bool(os.environ.get('CSRF_LOG_ENABLED', True))

--- a/opengever/base/sentry.py
+++ b/opengever/base/sentry.py
@@ -29,7 +29,7 @@ def context_from_request(request):
     if context is None:
         try:
             context = request.get('PARENTS', [])[0]
-        except:
+        except:  # noqa
             pass
     return context
 
@@ -97,7 +97,7 @@ def log_msg_to_sentry(message, context=None, request=None, url=None,
             if data is not None:
                 data_dict.update(data)
 
-        except:
+        except:  # noqa
             log.error('Error while preparing sentry data.')
             raise
 
@@ -115,17 +115,17 @@ def log_msg_to_sentry(message, context=None, request=None, url=None,
             with custom_string_max_length(client, string_max_length):
                 client.captureMessage(**kwargs)
 
-        except:
+        except:  # noqa
             log.error('Error while reporting to sentry.')
             raise
 
-    except:
+    except:  # noqa
         try:
             get_raven_client().captureException(
                 data={'extra': {
                     'raven_meta_error': 'Error occured while reporting'
                     ' another error.'}})
-        except:
+        except:  # noqa
             log.error(
                 'Failed to report error occured while reporting error.')
             return False

--- a/opengever/base/sentry.py
+++ b/opengever/base/sentry.py
@@ -43,7 +43,7 @@ _marker = object()
 
 def log_msg_to_sentry(message, context=None, request=None, url=None,
                       data=None, extra=None, fingerprint=None,
-                      string_max_length=_marker):
+                      level='error', string_max_length=_marker):
     """A (hopefully) fail-safe function to log a message to Sentry.
 
     This is loosely based on ftw.raven's maybe_report_exception(), except that
@@ -87,6 +87,7 @@ def log_msg_to_sentry(message, context=None, request=None, url=None,
                 'extra': prepare_extra_infos(context, request),
                 'modules': prepare_modules_infos(),
                 'tags': get_default_tags(),
+                'level': level,
             }
 
             release = get_release()


### PR DESCRIPTION
Filter list of registered objects so only **offending** objects are logged in sentry - whitelisted (safe) objects get removed from the list.

This should make it much easier to determine the culprit (object unexpectedly being written to) from the Sentry event.

The extra data attribute in Sentry was renamed from `_registered_object` to `filtered_registered_objects` to be able to distinguish what the semantics of the reported data in a Sentry event are (filtered or not):

![csrf_filtered_registered_objects](https://user-images.githubusercontent.com/405124/44213660-7d921400-a16e-11e8-8940-af112d22a6ad.png)

---


Also, this changes the **log level** of CSRF events to `warning`:

![csrf_warning](https://user-images.githubusercontent.com/405124/44215248-59d0cd00-a172-11e8-9714-99f30a7fcfac.png)


Closes #4676