### PR TITLE
Overwrite showEditableBorder from ploneview

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ---------------------
 
 - CSRF logging: Filter list of registered objects so only offending objects are logged in sentry [lgraf]
+- Fix bug where reactivate transition action is not visible for adminsitrators. [phgross]
 - Make sure widgets properly return persisted missing values for optional fields with default values [lgraf]
 - Mark tasks text field no longer as the primary field. [phgross]
 - Fix oc loading icon since fontawesome update. [Kevin Bieri]

--- a/opengever/base/browser/configure.zcml
+++ b/opengever/base/browser/configure.zcml
@@ -238,4 +238,13 @@
       permission="zope2.View"
       />
 
+  <browser:page
+      for="*"
+      name="plone"
+      class=".ploneview.GeverPloneView"
+      permission="zope.Public"
+      allowed_interface="Products.CMFPlone.browser.interfaces.IPlone"
+      layer="opengever.base.interfaces.IOpengeverBaseLayer"
+      />
+
 </configure>

--- a/opengever/base/browser/ploneview.py
+++ b/opengever/base/browser/ploneview.py
@@ -1,0 +1,24 @@
+from plone import api
+from Products.CMFPlone.browser.ploneview import Plone
+
+
+class GeverPloneView(Plone):
+    """Customize Ploneview's showEditableBorder, to include checks
+    for workflow actions.
+    """
+
+    def showEditableBorder(self):
+        request = self.request
+        if 'disable_border' in request:
+            return False
+
+        value = super(GeverPloneView, self).showEditableBorder()
+
+        # Also check for workflow actions, when the editable
+        # border would be False
+        if value is False:
+            wftool = api.portal.get_tool('portal_workflow')
+            if len(wftool.listActionInfos(object=self.context)):
+                return True
+
+        return value

--- a/opengever/base/tests/test_ploneview.py
+++ b/opengever/base/tests/test_ploneview.py
@@ -1,0 +1,14 @@
+from opengever.testing import IntegrationTestCase
+
+
+class TestGeverPloneView(IntegrationTestCase):
+
+    def test_show_editableborder_is_true_when_only_workflow_transitions_are_visible(self):
+        self.login(self.administrator)
+
+        self.set_workflow_state('dossier-state-inactive', self.empty_dossier)
+        self.empty_dossier.__ac_local_roles_block__ = True
+        self.empty_dossier.reindexObjectSecurity()
+
+        self.assertTrue(
+            self.empty_dossier.unrestrictedTraverse('plone').showEditableBorder())

--- a/opengever/core/tests/test_view_security.py
+++ b/opengever/core/tests/test_view_security.py
@@ -24,6 +24,7 @@ WHITELIST = (
     'opengever.base.browser.ploneform_macros.Macros',
     'opengever.base.widgets.GeverRenderWidget',
     'opengever.base.browser.jsvariables.GeverJSVariables',
+    'opengever.base.browser.ploneview.GeverPloneView',
 
     # The bumblebee token is verified in these views:
     'opengever.bumblebee.browser.callback.StoreArchivalFile',


### PR DESCRIPTION
to respect also workflow transitions.

This solves an issue, where the contentmenu was wrongly not visible, in some cases where the user is able to trigger a transition, but does not have Modify oder Add portal content permission. For example an administrator is allowed to reactivate a inactive dossier, but did not see the menu. Closes #4621 