### PR TITLE
Avoid ObjectModifiedEvents gets fired multiple timeson task transitions

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,7 @@ Changelog
 
 - CSRF logging: Filter list of registered objects so only offending objects are logged in sentry [lgraf]
 - Fix bug where reactivate transition action is not visible for adminsitrators. [phgross]
+- Avoid fireing ObjectModifiedEvents multiple times, on task transitions. [phgross]
 - Make sure widgets properly return persisted missing values for optional fields with default values [lgraf]
 - Mark tasks text field no longer as the primary field. [phgross]
 - Fix oc loading icon since fontawesome update. [Kevin Bieri]

--- a/opengever/inbox/browser/refuse.py
+++ b/opengever/inbox/browser/refuse.py
@@ -64,7 +64,7 @@ class ForwardingRefuseForm(Form):
         add_simple_response(
             self.context,
             text=response_text,
-            transition=u'forwarding-transition-refuse')
+            transition=u'forwarding-transition-refuse', supress_events=True)
 
     def change_workflow_sate(self):
         wf_tool = getToolByName(self.context, 'portal_workflow')

--- a/opengever/task/browser/assign.py
+++ b/opengever/task/browser/assign.py
@@ -128,7 +128,8 @@ class AssignTaskForm(Form):
                 (ITask['responsible'], kwargs.get('responsible')),
                 (ITask['responsible_client'],
                  kwargs.get('responsible_client')),),
-            transition=kwargs.get('transition'))
+            transition=kwargs.get('transition'),
+            supress_events=True)
 
     def sync_remote_task(self, **kwargs):
         sync_task_response(self.context, self.request, 'workflow',
@@ -172,7 +173,8 @@ class RefuseForwardingView(BrowserView):
                 (ITask['responsible'], self.context.responsible),
                 (ITask['responsible_client'],
                  self.context.responsible_client),),
-            transition=u'forwarding-transition-refuse')
+            transition=u'forwarding-transition-refuse',
+            supress_events=True)
 
         notify(ObjectModifiedEvent(self.context))
 

--- a/opengever/task/browser/forms.py
+++ b/opengever/task/browser/forms.py
@@ -170,4 +170,4 @@ class TaskEditForm(DefaultEditForm):
                 (ITask['responsible'], data.get('responsible')),
                 (ITask['responsible_client'],
                  data.get('responsible_client')),),
-            transition=REASSIGN_TRANSITION)
+            transition=REASSIGN_TRANSITION, supress_events=True)

--- a/opengever/task/deadline_modifier.py
+++ b/opengever/task/deadline_modifier.py
@@ -56,8 +56,8 @@ class DeadlineModifier(object):
             field_changes=(
                 (ITask['deadline'], new_deadline),
             ),
-            transition=transition
-        )
+            transition=transition,
+            supress_events=True)
 
         self.context.deadline = new_deadline
         notify(ObjectModifiedEvent(self.context))

--- a/opengever/task/deadline_modifier.py
+++ b/opengever/task/deadline_modifier.py
@@ -33,9 +33,9 @@ class DeadlineModifier(object):
         if not include_agency:
             return checker.current_user.is_issuer
         else:
-            return (checker.current_user.is_issuer or
-                    checker.current_user.in_issuing_orgunits_inbox_group or
-                    checker.current_user.is_administrator)
+            return (checker.current_user.is_issuer
+                    or checker.current_user.in_issuing_orgunits_inbox_group
+                    or checker.current_user.is_administrator)
 
     def modify_deadline(self, new_deadline, text, transition):
         """Handles the whole deadline mofication process:

--- a/opengever/task/tests/test_forms.py
+++ b/opengever/task/tests/test_forms.py
@@ -1,72 +1,51 @@
-from ftw.builder import Builder
-from ftw.builder import create
 from ftw.testbrowser import browsing
+from opengever.activity import notification_center
 from opengever.activity.model import Activity
 from opengever.activity.model import Subscription
-from opengever.core.testing import OPENGEVER_FUNCTIONAL_ACTIVITY_LAYER
-from opengever.testing import FunctionalTestCase
-from plone.app.testing import TEST_USER_ID
+from opengever.testing import IntegrationTestCase
 
 
-class TestTaskEditForm(FunctionalTestCase):
-
-    layer = OPENGEVER_FUNCTIONAL_ACTIVITY_LAYER
-
-    def setUp(self):
-        super(TestTaskEditForm, self).setUp()
-        create(Builder('ogds_user')
-               .id('peter.meier')
-               .assign_to_org_units([self.org_unit])
-               .having(firstname=u'Peter', lastname=u'Meier'))
-        create(Builder('ogds_user')
-               .id('james.meier')
-               .assign_to_org_units([self.org_unit])
-               .having(firstname=u'James', lastname=u'Meier'))
-
-        self.dossier = create(Builder('dossier').titled(u'Dossier'))
+class TestTaskEditForm(IntegrationTestCase):
 
     @browsing
     def test_edit_responsible_adds_reassign_response(self, browser):
-        task = create(Builder('task')
-                      .within(self.dossier)
-                      .having(title=u'Test task',
-                              task_type='comment',
-                              responsible='peter.meier'))
-
-        browser.login().open(task, view='edit')
+        self.login(self.administrator, browser=browser)
+        self.set_workflow_state('task-state-open', self.task)
+        browser.open(self.task, view='edit')
 
         form = browser.find_form_by_field('Responsible')
-        form.find_widget('Responsible').fill('org-unit-1:james.meier')
+        form.find_widget('Responsible').fill('fa:{}'.format(self.secretariat_user.id))
         browser.find('Save').click()
 
-        browser.open(task, view='tabbedview_view-overview')
+        browser.open(self.task, view='tabbedview_view-overview')
         answer = browser.css('.answer')[0]
         self.assertEquals('answer reassign', answer.get('class'))
         self.assertEquals(
-            [u'Reassigned from Meier Peter (peter.meier)'
-             ' to Meier James (james.meier) by Test User (test_user_1_)'],
+            [u'Reassigned from B\xe4rfuss K\xe4thi (kathi.barfuss) to K\xf6nig '
+             u'J\xfcrgen (jurgen.konig) by Kohler Nicole (nicole.kohler)'],
             answer.css('h3').text)
 
     @browsing
     def test_edit_responsible_records_activity(self, browser):
-        browser.login().open(self.dossier, view='++add++opengever.task.task')
-        browser.fill({'Title': u'Abkl\xe4rung Fall Meier',
-                      'Task Type': 'comment',
-                      'Text': 'Lorem ipsum'})
+        self.activate_feature('activity')
+        self.login(self.administrator, browser=browser)
+
+        # register_watchers
+        center = notification_center()
+        center.add_task_responsible(self.task, self.task.responsible)
+        center.add_task_issuer(self.task, self.task.issuer)
+
+        self.set_workflow_state('task-state-open', self.task)
+
+        browser.open(self.task, view='edit')
         form = browser.find_form_by_field('Responsible')
-        form.find_widget('Responsible').fill('org-unit-1:peter.meier')
-
-        browser.find('Save').click()
-
-        browser.open(browser.context.get('task-1'), view='edit')
-        form = browser.find_form_by_field('Responsible')
-        form.find_widget('Responsible').fill('org-unit-1:james.meier')
-
+        form.find_widget('Responsible').fill('fa:{}'.format(self.secretariat_user.id))
         browser.find('Save').click()
 
         activity = Activity.query.order_by(Activity.created.desc()).first()
+
         self.assertEquals(u'task-transition-reassign', activity.kind)
         self.assertEquals(
-            [(TEST_USER_ID, u'task_issuer'),
-             (u'james.meier', u'task_responsible')],
+            [(u'robert.ziegler', u'task_issuer'),
+             (u'jurgen.konig', u'task_responsible')],
             [(sub.watcher.actorid, sub.role) for sub in Subscription.query.all()])

--- a/opengever/task/util.py
+++ b/opengever/task/util.py
@@ -94,7 +94,7 @@ def get_task_type_title(task_type, language):
 
 
 def add_simple_response(task, text='', field_changes=None, added_object=None,
-                        successor_oguid=None, **kwargs):
+                        successor_oguid=None, supress_events=False, **kwargs):
     """Add a simple response which does (not change the task itself).
     `task`: task context
     `text`: fulltext
@@ -139,7 +139,8 @@ def add_simple_response(task, text='', field_changes=None, added_object=None,
     container = opengever.task.adapters.IResponseContainer(task)
     container.add(response)
 
-    notify(ObjectModifiedEvent(task))
+    if not supress_events:
+        notify(ObjectModifiedEvent(task))
 
     TaskTransitionActivity(task, task.REQUEST, response).record()
     return response


### PR DESCRIPTION
This solves or at least temper an existing performance-issue when reassign a task inside a large dossier (see #4683) or other task transition/actions. The following transitions could be optimized:
 - Reassign a task / forwarding via transition
 - Reassign a task via Editform
 - Deadline modification
 - Refusing a task