### PR TITLE
Set ad-hoc AgendaItem filename to title.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2018.5.0 (unreleased)
 ---------------------
 
+- Set adhoc agendaitem filename to title without prefixing it. [njohner]
 - Disallow dossier from template when adding businesscasedossier is disallowed. [njohner]
 - Change wording for "Return Excerpt" from "zurücksenden" to "ablegen". [njohner]
 

--- a/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-24 11:50+0000\n"
+"POT-Creation-Date: 2018-08-21 10:45+0000\n"
 "PO-Revision-Date: 2017-10-23 18:40+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -652,11 +652,6 @@ msgstr "Nur .docx Dateien sind als Antragsdokumente erlaubt."
 msgid "error_prosal_template_not_docx"
 msgstr "Nur Word-Dateien (.docx) sind erlaubt."
 
-#. Default: "Either a proposal template or a proposal document, but not both, is required."
-#: ./opengever/meeting/browser/proposalforms.py
-msgid "error_template_or_document_but_not_both_required_for_creation"
-msgstr "Bitte wählen sie entweder eine Antragsvorlage oder ein Antragsdokument aus."
-
 #. Default: "Either a proposal template or a proposal document is required."
 #: ./opengever/meeting/browser/proposalforms.py
 msgid "error_template_or_document_required_for_creation"
@@ -856,6 +851,7 @@ msgid "label_create_excerpt"
 msgstr "Protokollauszug generieren"
 
 #. Default: "Creator"
+#: ./opengever/meeting/browser/meetings/meeting.py
 #: ./opengever/meeting/browser/proposalforms.py
 msgid "label_creator"
 msgstr "Ersteller"
@@ -1093,6 +1089,7 @@ msgid "label_member"
 msgstr "Mitglied"
 
 #. Default: "Modified"
+#: ./opengever/meeting/browser/meetings/meeting.py
 #: ./opengever/meeting/browser/proposalforms.py
 msgid "label_modified"
 msgstr "Zuletzt bearbeitet"
@@ -1665,11 +1662,6 @@ msgstr "${count} Teilnehmende"
 #: ./opengever/meeting/browser/meetings/agendaitem.py
 msgid "text_added"
 msgstr "Traktandum erfolgreich hinzugefügt"
-
-#. Default: "Ad hoc agenda item ${title}"
-#: ./opengever/meeting/model/meeting.py
-msgid "title_ad_hoc_document"
-msgstr "Traktandum ${title}"
 
 #. Default: "Delete proposal"
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt

--- a/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-24 11:50+0000\n"
+"POT-Creation-Date: 2018-08-21 10:45+0000\n"
 "PO-Revision-Date: 2018-05-22 10:15+0000\n"
 "Last-Translator: Niklaus Johner <Niklaus.johner@4teamwork.ch>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-meeting/fr/>\n"
@@ -654,11 +654,6 @@ msgstr "Seuls les fichiers .docx sont autorisés comme documents de proposition.
 msgid "error_prosal_template_not_docx"
 msgstr "Seuls les fichiers Word (.docx) sont acceptés."
 
-#. Default: "Either a proposal template or a proposal document, but not both, is required."
-#: ./opengever/meeting/browser/proposalforms.py
-msgid "error_template_or_document_but_not_both_required_for_creation"
-msgstr "Veuillez choisir soit un modèle de proposition, soit un document de proposition."
-
 #. Default: "Either a proposal template or a proposal document is required."
 #: ./opengever/meeting/browser/proposalforms.py
 msgid "error_template_or_document_required_for_creation"
@@ -858,6 +853,7 @@ msgid "label_create_excerpt"
 msgstr "Générer un extrait de protocole"
 
 #. Default: "Creator"
+#: ./opengever/meeting/browser/meetings/meeting.py
 #: ./opengever/meeting/browser/proposalforms.py
 msgid "label_creator"
 msgstr "Créé par"
@@ -1095,6 +1091,7 @@ msgid "label_member"
 msgstr "Membre"
 
 #. Default: "Modified"
+#: ./opengever/meeting/browser/meetings/meeting.py
 #: ./opengever/meeting/browser/proposalforms.py
 msgid "label_modified"
 msgstr "Dernière modification"
@@ -1667,11 +1664,6 @@ msgstr "${count} participants"
 #: ./opengever/meeting/browser/meetings/agendaitem.py
 msgid "text_added"
 msgstr "Texte libre ajouté à l'ordre du jour avec succès."
-
-#. Default: "Ad hoc agenda item ${title}"
-#: ./opengever/meeting/model/meeting.py
-msgid "title_ad_hoc_document"
-msgstr "Point ${title} de l'ordre du jour"
 
 #. Default: "Delete proposal"
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt

--- a/opengever/meeting/locales/opengever.meeting.pot
+++ b/opengever/meeting/locales/opengever.meeting.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-24 11:50+0000\n"
+"POT-Creation-Date: 2018-08-21 10:45+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -651,11 +651,6 @@ msgstr ""
 msgid "error_prosal_template_not_docx"
 msgstr ""
 
-#. Default: "Either a proposal template or a proposal document, but not both, is required."
-#: ./opengever/meeting/browser/proposalforms.py
-msgid "error_template_or_document_but_not_both_required_for_creation"
-msgstr ""
-
 #. Default: "Either a proposal template or a proposal document is required."
 #: ./opengever/meeting/browser/proposalforms.py
 msgid "error_template_or_document_required_for_creation"
@@ -855,6 +850,7 @@ msgid "label_create_excerpt"
 msgstr ""
 
 #. Default: "Creator"
+#: ./opengever/meeting/browser/meetings/meeting.py
 #: ./opengever/meeting/browser/proposalforms.py
 msgid "label_creator"
 msgstr ""
@@ -1092,6 +1088,7 @@ msgid "label_member"
 msgstr ""
 
 #. Default: "Modified"
+#: ./opengever/meeting/browser/meetings/meeting.py
 #: ./opengever/meeting/browser/proposalforms.py
 msgid "label_modified"
 msgstr ""
@@ -1663,11 +1660,6 @@ msgstr ""
 #. Default: "Text successfully added."
 #: ./opengever/meeting/browser/meetings/agendaitem.py
 msgid "text_added"
-msgstr ""
-
-#. Default: "Ad hoc agenda item ${title}"
-#: ./opengever/meeting/model/meeting.py
-msgid "title_ad_hoc_document"
 msgstr ""
 
 #. Default: "Delete proposal"

--- a/opengever/meeting/model/meeting.py
+++ b/opengever/meeting/model/meeting.py
@@ -473,16 +473,12 @@ class Meeting(Base, SQLFormSupport):
             'opengever.document: Add document', meeting_dossier):
             raise MissingMeetingDossierPermissions
 
-        document_title = _(u'title_ad_hoc_document',
-                           default=u'Ad hoc agenda item ${title}',
-                           mapping={u'title': title})
-
         ad_hoc_document = CreateDocumentCommand(
             context=meeting_dossier,
             filename=ad_hoc_template.file.filename,
             data=ad_hoc_template.file.data,
             content_type=ad_hoc_template.file.contentType,
-            title=translate(document_title, context=getRequest())).execute()
+            title=title).execute()
         agenda_item = AgendaItem(
             title=title, description=description,
             document=ad_hoc_document, is_paragraph=False)

--- a/opengever/meeting/tests/test_agendaitem_adhoc.py
+++ b/opengever/meeting/tests/test_agendaitem_adhoc.py
@@ -56,7 +56,7 @@ class TestAdHocAgendaItem(IntegrationTestCase):
 
         document_link_html = item_data.get('document_link')
         self.assertIn(
-            u'Ad hoc agenda item R\xfccktritt',
+            u'R\xfccktritt',
             document_link_html)
         self.assertIn(
             ad_hoc_document.absolute_url() + '/tooltip',

--- a/opengever/meeting/tests/test_meeting_zipexport.py
+++ b/opengever/meeting/tests/test_meeting_zipexport.py
@@ -177,7 +177,7 @@ class TestMeetingZipExportView(IntegrationTestCase):
                 'opengever_id': 3,
                 'proposal': {
                     'checksum': 'e00d6c8fb32c30d3ca3a3f8e5d873565482567561023016d9ca18243ff1cfa14',
-                    'file': u'1. Ad-hoc Traktandthm/Ad hoc agenda item Ad-hoc Traktandthm.docx',
+                    'file': u'1. Ad-hoc Traktandthm/Ad-hoc Traktandthm.docx',
                     'modified': u'2017-12-12T23:00:00+01:00',
                 },
                 'title': u'Ad-hoc Traktand\xfem',
@@ -245,7 +245,7 @@ class TestMeetingZipExportView(IntegrationTestCase):
                     {'number': '1.',
                      'proposal': {
                          'checksum': 'e00d6c8fb32c30d3ca3a3f8e5d873565482567561023016d9ca18243ff1cfa14',
-                         'file': '1. Ad-hoc Traktandthm/Ad hoc agenda item Ad-hoc Traktandthm.docx',
+                         'file': '1. Ad-hoc Traktandthm/Ad-hoc Traktandthm.docx',
                          'modified': '2017-12-12T23:00:00+01:00',
                      },
                      'sort_order': 2,
@@ -281,7 +281,7 @@ class TestMeetingZipExportView(IntegrationTestCase):
 
         file_names = zip_file.namelist()
         for file_name in [
-                '1. Ad-hoc Traktandthm/Ad hoc agenda item Ad-hoc Traktandthm.docx',
+                '1. Ad-hoc Traktandthm/Ad-hoc Traktandthm.docx',
                 '2. Anderungen am Personalreglement/Vertragsentwurf.docx',
                 '2. Anderungen am Personalreglement/Anderungen am Personalreglement.docx',
                 'Protocol-9. Sitzung der Rechnungsprufungskommission.docx']:


### PR DESCRIPTION
Ad-hoc `AgendaItem` filename was prefixed with "Ad hoc agenda item". It is now simply set to the title of the `AgendaItem`, as entered by the user.

resolves #4409 