### PR TITLE
Do not set document date during checkin or cancel.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ---------------------
 
 - Correct width of subdossier table in dossier details pdf. [njohner]
+- Do not set document date during check-in or cancel. [njohner]
 - Disallow grouping tasks by the checkbox column in list views. [Rotonen]
 - Add feature to generate a task listing pdf when resolving a dossier. [njohner]
 - Set adhoc agendaitem filename to title without prefixing it. [njohner]

--- a/opengever/document/checkout/manager.py
+++ b/opengever/document/checkout/manager.py
@@ -147,9 +147,6 @@ class CheckinCheckoutManager(object):
         if not self.is_checkin_allowed():
             raise Unauthorized
 
-        # update document_date to current date
-        self.context.document_date = date.today()
-
         # remember that we checked in
         self.annotations[CHECKIN_CHECKOUT_ANNOTATIONS_KEY] = None
 
@@ -307,10 +304,6 @@ class CheckinCheckoutManager(object):
             self.context.file = old_file_copy
         else:
             self.context.file = None
-
-        # update document_date to specific version creation date
-        ts = version.sys_metadata['timestamp']
-        self.context.document_date = datetime.fromtimestamp(ts).date()
 
         if create_version:
             # let's create a version


### PR DESCRIPTION
Document date should not be set by the system anymore, but only by the user. The modification date is already available in the `modified` attribute.

resolves #4560 