### PR TITLE
Extend meeting zip-export with sort_order and gever_id.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,8 +5,7 @@ Changelog
 2018.4.1 (unreleased)
 ---------------------
 
-- Nothing changed yet.
-
+- Extend meeting zip-export with sort_order and gever_id. [phgross]
 
 2018.4.0 (2018-08-20)
 ---------------------

--- a/opengever/meeting/model/agendaitem.py
+++ b/opengever/meeting/model/agendaitem.py
@@ -232,6 +232,7 @@ class AgendaItem(Base):
 
     def get_data_for_zip_export(self):
         agenda_item_data = {
+            'opengever_id': self.agenda_item_id,
             'title': safe_unicode(self.get_title()),
         }
 

--- a/opengever/meeting/model/agendaitem.py
+++ b/opengever/meeting/model/agendaitem.py
@@ -234,6 +234,7 @@ class AgendaItem(Base):
         agenda_item_data = {
             'opengever_id': self.agenda_item_id,
             'title': safe_unicode(self.get_title()),
+            'sort_order': self.sort_order,
         }
 
         if self.has_document:

--- a/opengever/meeting/model/meeting.py
+++ b/opengever/meeting/model/meeting.py
@@ -410,6 +410,7 @@ class Meeting(Base, SQLFormSupport):
 
     def get_data_for_zip_export(self):
         meeting_data = {
+            'opengever_id': self.meeting_id,
             'title': safe_unicode(self.title),
             'start': safe_unicode(self.start.isoformat()),
             'end': safe_unicode(self.end and self.end.isoformat() or ''),

--- a/opengever/meeting/tests/test_meeting_zipexport.py
+++ b/opengever/meeting/tests/test_meeting_zipexport.py
@@ -169,9 +169,11 @@ class TestMeetingZipExportView(IntegrationTestCase):
         self.assertEquals({
             'agenda_items': [{
                 'opengever_id': 2,
+                'sort_order': 1,
                 'title': u'A Gesch\xfcfte',
             }, {
                 'number': '1.',
+                'sort_order': 2,
                 'opengever_id': 3,
                 'proposal': {
                     'checksum': 'e00d6c8fb32c30d3ca3a3f8e5d873565482567561023016d9ca18243ff1cfa14',
@@ -187,6 +189,7 @@ class TestMeetingZipExportView(IntegrationTestCase):
                     'title': u'Vertr\xe4gsentwurf',
                 }],
                 'number': '2.',
+                'sort_order': 3,
                 'opengever_id': 4,
                 'proposal': {
                     'checksum': 'e00d6c8fb32c30d3ca3a3f8e5d873565482567561023016d9ca18243ff1cfa14',
@@ -237,13 +240,15 @@ class TestMeetingZipExportView(IntegrationTestCase):
         self.assert_json_structure_equal({
             'meetings': [
                 {'agenda_items': [
-                    {'title': u'A Gesch\xfcfte'},
+                    {'sort_order': 1,
+                     'title': u'A Gesch\xfcfte'},
                     {'number': '1.',
                      'proposal': {
                          'checksum': 'e00d6c8fb32c30d3ca3a3f8e5d873565482567561023016d9ca18243ff1cfa14',
                          'file': '1. Ad-hoc Traktandthm/Ad hoc agenda item Ad-hoc Traktandthm.docx',
-                         'modified': '2017-12-12T23:00:00+01:00'
+                         'modified': '2017-12-12T23:00:00+01:00',
                      },
+                     'sort_order': 2,
                      'title': u'Ad-hoc Traktand\xfem'},
                     {'attachments': [{
                         'checksum': '51d6317494eccc4a73154625a6820cb6b50dc1455eb4cf26399299d4f9ce77b2',
@@ -251,6 +256,7 @@ class TestMeetingZipExportView(IntegrationTestCase):
                         'modified': '2016-08-31T15:31:46+02:00',
                         'title': u'Vertr\xe4gsentwurf'}],
                      'number': '2.',
+                     'sort_order': 3,
                      'proposal': {
                          'checksum': 'e00d6c8fb32c30d3ca3a3f8e5d873565482567561023016d9ca18243ff1cfa14',
                          'file': '2. Anderungen am Personalreglement/Anderungen am Personalreglement.docx',

--- a/opengever/meeting/tests/test_meeting_zipexport.py
+++ b/opengever/meeting/tests/test_meeting_zipexport.py
@@ -165,11 +165,14 @@ class TestMeetingZipExportView(IntegrationTestCase):
         with freeze(localized_datetime(2017, 12, 13)):
             self.schedule_ad_hoc(self.meeting, u'Ad-hoc Traktand\xfem')
         self.schedule_proposal(self.meeting, self.submitted_word_proposal)
+        data = self.meeting.get_data_for_zip_export()
         self.assertEquals({
             'agenda_items': [{
+                'opengever_id': 2,
                 'title': u'A Gesch\xfcfte',
             }, {
                 'number': '1.',
+                'opengever_id': 3,
                 'proposal': {
                     'checksum': 'e00d6c8fb32c30d3ca3a3f8e5d873565482567561023016d9ca18243ff1cfa14',
                     'file': u'1. Ad-hoc Traktandthm/Ad hoc agenda item Ad-hoc Traktandthm.docx',
@@ -184,6 +187,7 @@ class TestMeetingZipExportView(IntegrationTestCase):
                     'title': u'Vertr\xe4gsentwurf',
                 }],
                 'number': '2.',
+                'opengever_id': 4,
                 'proposal': {
                     'checksum': 'e00d6c8fb32c30d3ca3a3f8e5d873565482567561023016d9ca18243ff1cfa14',
                     'file': u'2. Anderungen am Personalreglement/Anderungen am Personalreglement.docx',
@@ -197,9 +201,10 @@ class TestMeetingZipExportView(IntegrationTestCase):
             },
             'end': u'2016-09-12T17:00:00+00:00',
             'location': u'B\xfcren an der Aare',
+            'opengever_id': 1,
             'start': u'2016-09-12T15:30:00+00:00',
             'title': u'9. Sitzung der Rechnungspr\xfcfungskommission',
-        }, self.meeting.get_data_for_zip_export())
+        }, data)
 
     @browsing
     def test_exported_meeting_json_has_correct_file_names(self, browser):
@@ -225,6 +230,9 @@ class TestMeetingZipExportView(IntegrationTestCase):
         # the protocol is generated during the tests and its checksum cannot
         # be predicted
         meeting_json['meetings'][0]['protocol']['checksum'] = 'unpredictable'
+        meeting_json['meetings'][0].pop('opengever_id')
+        for agenda_item in meeting_json['meetings'][0]['agenda_items']:
+            agenda_item.pop('opengever_id')
 
         self.assert_json_structure_equal({
             'meetings': [


### PR DESCRIPTION
Extend meeting zip-export with sort_order and gever_id, used by grimlock to ensure the sort oder and clean updates of existing meetings.

