### PR TITLE
Fix IE bug on the notification settings page.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,7 @@ Changelog
 
 - Pin ftw.table to 1.20.0, to fix a concurrency bug in tables. [njohner]
 - Fix issue when commenting on a not submitted proposal. [phgross]
+- Fix IE bug on the notification settings page. [phgross]
 - Fix sharing view on committecontainer. [phgross]
 - Fix missing favorite-id on toggle-link if toggling favorite from repository-tree. [elioschmutz]
 - Fix broken favorites state if toggling state in the repository-tree. [elioschmutz]

--- a/opengever/activity/browser/resources/settings.js
+++ b/opengever/activity/browser/resources/settings.js
@@ -57,7 +57,7 @@
         });
       }
 
-      var values = Object.values(activities)
+      var values = Object.keys(activities).map(function(e) { return activities[e]});
 
       var tabs = [
         {tabId: 'tasks',


### PR DESCRIPTION
`Object.values` is not supported on IE. See https://stackoverflow.com/questions/42830257/alternative-version-for-object-values