### PR TITLE
Fix issue when commenting on a not submitted proposal

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ---------------------
 
 - Pin ftw.table to 1.20.0, to fix a concurrency bug in tables. [njohner]
+- Fix issue when commenting on a not submitted proposal. [phgross]
 - Fix sharing view on committecontainer. [phgross]
 - Fix missing favorite-id on toggle-link if toggling favorite from repository-tree. [elioschmutz]
 - Fix broken favorites state if toggling state in the repository-tree. [elioschmutz]

--- a/opengever/meeting/proposal.py
+++ b/opengever/meeting/proposal.py
@@ -329,6 +329,10 @@ class ProposalBase(ModelContainer):
         ProposalCommentedActivitiy(self, self.REQUEST).record()
         return IHistory(self).append_record(u'commented', uuid=uuid, text=text)
 
+    def is_submitted(self):
+        model = self.load_model()
+        return model.is_submitted()
+
 
 class SubmittedProposal(ProposalBase):
     """Proxy for a proposal in queue with a committee."""
@@ -701,7 +705,3 @@ class Proposal(ProposalBase):
         self.date_of_submission = None
         api.content.transition(obj=self,
                                transition='proposal-transition-reject')
-
-    def is_submitted(self):
-        model = self.load_model()
-        return model.is_submitted()

--- a/opengever/meeting/proposalhistory.py
+++ b/opengever/meeting/proposalhistory.py
@@ -10,8 +10,6 @@ from opengever.meeting.activity.activities import ProposalCommentedActivitiy
 from opengever.meeting.activity.activities import ProposalDecideActivity
 from opengever.meeting.activity.activities import ProposalScheduledActivity
 from opengever.meeting.model import Meeting
-from opengever.meeting.proposal import Proposal
-from opengever.meeting.proposal import SubmittedProposal
 from opengever.ogds.base.actor import Actor
 from persistent.mapping import PersistentMapping
 from plone import api

--- a/opengever/meeting/proposalhistory.py
+++ b/opengever/meeting/proposalhistory.py
@@ -120,9 +120,8 @@ class BaseHistoryRecord(object):
     Each record must have a unique `history_type` from which it can be built
     with IHistory.append_record.
 
-    If `needs_syncing` is `True` a records that is created on the
-    `SubmittedProposal` side is automatically added to its corresponding
-    `Proposal`.
+    If `needs_syncing` is `True` a records is created on one side is
+    automatically added to its corresponding `Proposal` or `SubmittedProposal`.
     """
 
     history_type = None

--- a/opengever/meeting/proposalhistory.py
+++ b/opengever/meeting/proposalhistory.py
@@ -68,7 +68,7 @@ class ProposalHistory(object):
         record = clazz(self.context, timestamp=timestamp, **kwargs)
         record.append_to(history)
 
-        if record.needs_syncing:
+        if record.needs_syncing and self.context.is_submitted():
             path = self.context.get_sync_target_path()
             admin_unit_id = self.context.get_sync_admin_unit_id()
 

--- a/opengever/meeting/tests/test_proposalhistory.py
+++ b/opengever/meeting/tests/test_proposalhistory.py
@@ -331,3 +331,23 @@ class TestIntegrationProposalHistory(IntegrationTestCase):
             browser,
             with_submitted=True,
             )
+
+    @browsing
+    def test_comment_on_unsubmitted_proposal_does_not_try_to_sync(self, browser):
+        self.login(self.meeting_user, browser)
+
+        proposal = create(Builder('proposal')
+                          .within(self.dossier)
+                          .having(title=u'Vertr\xe4ge',
+                                  committee=self.committee.load_model(),
+                                  issuer=self.dossier_responsible.getId())
+                          .relate_to(self.document))
+
+        # Add comment
+        browser.open(proposal, view='addcomment')
+        browser.fill({'Comment': u'Vorgezogener Kommentar'})
+        browser.click_on('Confirm')
+
+        browser.open(proposal, view='tabbedview_view-overview')
+        self.assertEqual(
+            'Vorgezogener Kommentar', browser.css('.answer .text')[0].text)


### PR DESCRIPTION
Do not try to sync proposalhistory entries on not sumitted propsoal, because there is no "other side".

Closes #4795 