### PR TITLE
Make upgrade step 20180619143343 deferrable:

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2018.5.0 (unreleased)
 ---------------------
 
-- Nothing changed yet.
+- Make upgrade step 20180619143343 deferrable: Use of CMFEditions getHistory causes massive amounts of savepoints. [lgraf]
 
 
 2018.4.1 (2018-08-30)

--- a/opengever/core/upgrades/20180619143343_make_sure_excerpt_document_title_is_unicode/upgrade.py
+++ b/opengever/core/upgrades/20180619143343_make_sure_excerpt_document_title_is_unicode/upgrade.py
@@ -36,6 +36,9 @@ class MakeSureExcerptDocumentTitleIsUnicode(SQLUpgradeStep):
     - persisted title in i18n messages of the journal
 
     """
+
+    deferrable = True
+
     def migrate(self):
         has_meeting_feature = api.portal.get_registry_record(
             'opengever.meeting.interfaces.IMeetingSettings.is_feature_enabled')


### PR DESCRIPTION
The use of CMFEditions' [`CopyModifyMergeRepositoryTool.getHistory()`](https://github.com/plone/Products.CMFEditions/blob/2.2.23/Products/CMFEditions/CopyModifyMergeRepositoryTool.py#L497-L506) causes massive amounts of savepoints (one per version history retrieve).

When this is done for lots of documents, this leads to thousands of savepoints being created and rolled back to in the same transaction.

This has the side effect of creating just as many nested SQLAlchemy transactions.

When the SQLAlchemy connection then is used in a subsequent upgrade step, the attempt to fetch the outermost connection in `sqlalchemy.orm.session.connection_for_bind()` then fails, because it's [recursive](https://github.com/zzzeek/sqlalchemy/blob/master/lib/sqlalchemy/orm/session.py#L398) and exceeds Python's maximum recursion depth (1000 by default) because of the many nested transactions.

We therefore mark this upgrade step as deferrable, so that it can be run seperately from other upgrades, hopefully sidestepping this issue.

**Note**: Needs to be backported to `2018.4.2`