### PR TITLE
Correct info messages in meetings

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2018.5.0 (unreleased)
 ---------------------
 
+- Correct info messages in meetings. [njohner]
 - Fix global scoped "show more" links for SOLR livesearch [Rotonen]
 - Correct width of subdossier table in dossier details pdf. [njohner]
 - Do not set document date during check-in or cancel. [njohner]

--- a/opengever/meeting/browser/meetings/agendaitem.py
+++ b/opengever/meeting/browser/meetings/agendaitem.py
@@ -379,13 +379,8 @@ class AgendaItemsView(BrowserView):
         self.agenda_item.decide()
 
         response = JSONResponse(self.request)
-        if self.agenda_item.has_proposal:
-            response.info(
-                _(u'agenda_item_proposal_decided',
-                  default=u'Agenda Item decided and excerpt generated.'))
-        else:
-            response.info(_(u'agenda_item_decided',
-                            default=u'Agenda Item decided.'))
+        response.info(_(u'agenda_item_decided',
+                        default=u'Agenda Item decided.'))
 
         if meeting_state != self.meeting.get_state():
             response.redirect(self.context.absolute_url())

--- a/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
@@ -1464,7 +1464,7 @@ msgstr "Übersicht"
 #. Default: "Paragraph successfully added."
 #: ./opengever/meeting/browser/meetings/agendaitem.py
 msgid "paragraph_added"
-msgstr "Paragraph erfolgreich hinzugefügt."
+msgstr "Zwischentitel erfolgreich hinzugefügt."
 
 #. Default: "Pending"
 #: ./opengever/meeting/model/agendaitem.py

--- a/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-08-07 11:01+0000\n"
+"POT-Creation-Date: 2018-09-06 07:57+0000\n"
 "PO-Revision-Date: 2017-10-23 18:40+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -360,11 +360,6 @@ msgstr "Das Traktandum wurde abgeschlossen und die Sitzung wurde durchgeführt."
 #: ./opengever/meeting/browser/meetings/agendaitem.py
 msgid "agenda_item_order_updated"
 msgstr "Die Reihenfolge der Traktanden wurde aktualisiert."
-
-#. Default: "Agenda Item decided and excerpt generated."
-#: ./opengever/meeting/browser/meetings/agendaitem.py
-msgid "agenda_item_proposal_decided"
-msgstr "Traktandum wurde abgeschlossen, der Protokollauszug generiert und zurückgespielt."
 
 #. Default: "Agenda Item successfully reopened."
 #: ./opengever/meeting/browser/meetings/agendaitem.py
@@ -1537,6 +1532,7 @@ msgid "proposal_history_label_rejected"
 msgstr "Zurückgewiesen von ${user}"
 
 #. Default: "Removed from schedule of meeting ${meeting} by ${user}"
+#: ./opengever/meeting/activity/activities.py
 #: ./opengever/meeting/proposalhistory.py
 msgid "proposal_history_label_remove_scheduled"
 msgstr "Von der Traktandenliste der Sitzung ${meeting} entfernt durch ${user}"

--- a/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-08-07 11:01+0000\n"
+"POT-Creation-Date: 2018-09-06 07:57+0000\n"
 "PO-Revision-Date: 2018-05-22 10:15+0000\n"
 "Last-Translator: Niklaus Johner <Niklaus.johner@4teamwork.ch>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-meeting/fr/>\n"
@@ -362,11 +362,6 @@ msgstr "Le point de l'ordre du jour a été clôturé et la réunion a eu lieu."
 #: ./opengever/meeting/browser/meetings/agendaitem.py
 msgid "agenda_item_order_updated"
 msgstr "Les points de l'ordre du jour ont été réarrangés."
-
-#. Default: "Agenda Item decided and excerpt generated."
-#: ./opengever/meeting/browser/meetings/agendaitem.py
-msgid "agenda_item_proposal_decided"
-msgstr "Le point de l'ordre du jour a été clôturé, l'extrait de protocole a été généré et renvoyé."
 
 #. Default: "Agenda Item successfully reopened."
 #: ./opengever/meeting/browser/meetings/agendaitem.py
@@ -1539,6 +1534,7 @@ msgid "proposal_history_label_rejected"
 msgstr "Rejeté par ${user}"
 
 #. Default: "Removed from schedule of meeting ${meeting} by ${user}"
+#: ./opengever/meeting/activity/activities.py
 #: ./opengever/meeting/proposalhistory.py
 msgid "proposal_history_label_remove_scheduled"
 msgstr "Enlevé de l'ordre du jour de la réunion ${meeting} par ${user}"

--- a/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
@@ -1466,7 +1466,7 @@ msgstr "Sommaire"
 #. Default: "Paragraph successfully added."
 #: ./opengever/meeting/browser/meetings/agendaitem.py
 msgid "paragraph_added"
-msgstr "Paragraphe ajouté avec succès."
+msgstr "Intertitre ajouté avec succès."
 
 #. Default: "Pending"
 #: ./opengever/meeting/model/agendaitem.py

--- a/opengever/meeting/locales/opengever.meeting.pot
+++ b/opengever/meeting/locales/opengever.meeting.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-08-07 11:01+0000\n"
+"POT-Creation-Date: 2018-09-06 07:57+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -358,11 +358,6 @@ msgstr ""
 #. Default: "Agenda Item order updated."
 #: ./opengever/meeting/browser/meetings/agendaitem.py
 msgid "agenda_item_order_updated"
-msgstr ""
-
-#. Default: "Agenda Item decided and excerpt generated."
-#: ./opengever/meeting/browser/meetings/agendaitem.py
-msgid "agenda_item_proposal_decided"
 msgstr ""
 
 #. Default: "Agenda Item successfully reopened."
@@ -1536,6 +1531,7 @@ msgid "proposal_history_label_rejected"
 msgstr ""
 
 #. Default: "Removed from schedule of meeting ${meeting} by ${user}"
+#: ./opengever/meeting/activity/activities.py
 #: ./opengever/meeting/proposalhistory.py
 msgid "proposal_history_label_remove_scheduled"
 msgstr ""

--- a/opengever/meeting/tests/test_agendaitem_proposal.py
+++ b/opengever/meeting/tests/test_agendaitem_proposal.py
@@ -23,8 +23,7 @@ class TestProposalAgendaItem(IntegrationTestCase):
                      data={'_authenticator': createToken()})
 
         self.assertEquals('decided', agenda_item.workflow_state)
-        self.assertEquals([{u'message': u'Agenda Item decided and excerpt '
-                                        u'generated.',
+        self.assertEquals([{u'message': u'Agenda Item decided.',
                             u'messageClass': u'info',
                             u'messageTitle': u'Information'}],
                           browser.json.get('messages'))
@@ -198,7 +197,7 @@ class TestProposalAgendaItem(IntegrationTestCase):
              '/opengever-meeting-committeecontainer/committee-1/meeting-1',
              u'messages': [
                  {u'messageTitle': u'Information',
-                  u'message': u'Agenda Item decided and excerpt generated.',
+                  u'message': u'Agenda Item decided.',
                   u'messageClass': u'info'}]},
             browser.json)
 


### PR DESCRIPTION
* The info message when scheduling a paragraph was wrongfully saying "Paragraph erfolgreich hinzugefügt" instead of "Zwischentitel erfolgreich hinzugefügt"

* When deciding an agendaitem with a proposal, the info message was wrongfully saying that the protocol excerpt was generated and sent back. I propose to change that to "not yet generated and sent back", as we will enforce that the user generates and sends back all excerpts before closing a meeting.

resolves #4771 