### PR TITLE
Fix handling of unidirectional by ref tasks in a sequential process.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -10,6 +10,7 @@ Changelog
 - Disallow dossier from template when adding businesscasedossier is disallowed. [njohner]
 - Change wording for "Return Excerpt" from "zurücksenden" to "ablegen". [njohner]
 - Add modification and creation date column to document listings. [njohner]
+- Fix handling of unidirectional by reference tasks in a sequential process. [phgross]
 
 
 2018.4.2 (2018-08-30)

--- a/opengever/task/handlers.py
+++ b/opengever/task/handlers.py
@@ -104,6 +104,7 @@ def cancel_subtasks(task, event):
 def start_next_task(task, event):
     # todo also handle skipped tasks
     if event.action not in ['task-transition-open-resolved',
+                            'task-transition-open-tested-and-closed',
                             'task-transition-in-progress-resolved',
                             'task-transition-in-progress-tested-and-closed',
                             'task-transition-rejected-skipped',

--- a/opengever/task/tests/test_sequential_task_process.py
+++ b/opengever/task/tests/test_sequential_task_process.py
@@ -66,6 +66,21 @@ class TestSequentialTaskProcess(IntegrationTestCase):
         self.assertEquals(
             'task-state-open', api.content.get_state(subtask2))
 
+    def test_starts_next_task_when_open_task_gets_closed(self):
+        self.login(self.regular_user)
+
+        self.seq_subtask_1.task_type = 'information'
+        self.seq_subtask_1.sync()
+
+        api.content.transition(
+            obj=self.seq_subtask_1,
+            transition='task-transition-open-tested-and-closed')
+
+        self.assertEquals(
+            'task-state-tested-and-closed', api.content.get_state(self.seq_subtask_1))
+        self.assertEquals(
+            'task-state-open', api.content.get_state(self.seq_subtask_2))
+
     def test_starts_next_task_when_task_gets_skipped(self):
         self.login(self.dossier_responsible)
 


### PR DESCRIPTION
Unidirectional by reference tasks (`Zur Kenntnisnahme`) can directly been closed from the open state. This transition wasn't handled by the open_next_task handler, which opens the next planned state from the sequential process.


Should be backported to: `2018.4-stable`