### PR TITLE
Correct table width for SubDossiersLaTeXListing.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2018.5.0 (unreleased)
 ---------------------
 
+- Correct width of subdossier table in dossier details pdf. [njohner]
 - Disallow grouping tasks by the checkbox column in list views. [Rotonen]
 - Add feature to generate a task listing pdf when resolving a dossier. [njohner]
 - Set adhoc agendaitem filename to title without prefixing it. [njohner]

--- a/opengever/latex/listing.py
+++ b/opengever/latex/listing.py
@@ -41,6 +41,11 @@ class Column(object):
 
         return value
 
+    def get_width(self):
+        if not self.width.endswith("%"):
+            raise NotImplementedError("Only implemented for width in percentage")
+        return float(self.width.split("%")[0])
+
 
 class ILaTexListing(Interface):
 
@@ -134,6 +139,16 @@ class LaTexListing(object):
 
         return obj.Title()
 
+    @staticmethod
+    def reset_column_widths(columns):
+        """recalculates the column widths so that they span the whole textwidth.
+        """
+        total_width = reduce(lambda total_width, column: total_width + column.get_width(),
+                             columns.values(), 0)
+        for column in columns.values():
+            column.width = str(column.get_width() / total_width * 100) + "%"
+        return columns
+
 
 @implementer(ILaTexListing)
 @adapter(Interface, Interface, Interface)
@@ -193,6 +208,7 @@ class SubDossiersLaTeXListing(DossiersLaTeXListing):
     def update_column_dict(self, columns):
         del columns['reference']
         del columns['repository_title']
+        self.reset_column_widths(columns)
         return columns
 
 


### PR DESCRIPTION
SubDossiersLaTeXListing inherits from DossiersLaTeXListing by removing two columns, but the column widths were not recalculated afterwards, so that the table would not span the whole textwidth.

We add a new method to reset the column width so that the table spans the whole `textwidth`. The tables are now all the same width:

<img width="900" alt="screen shot 2018-09-03 at 08 45 26" src="https://user-images.githubusercontent.com/7374243/44971445-e1318500-af55-11e8-8cfe-2d9e1333358f.png">

resolves #4623 