### PR TITLE
Fix double escaping of agendaitem title in meeting overview.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2018.5.0 (unreleased)
 ---------------------
 
+- Fix double escaping of agendaitem title in meeting overview. [njohner]
 - Correct width of subdossier table in dossier details pdf. [njohner]
 - Disallow grouping tasks by the checkbox column in list views. [Rotonen]
 - Add feature to generate a task listing pdf when resolving a dossier. [njohner]

--- a/opengever/meeting/browser/meetings/templates/navigation.html
+++ b/opengever/meeting/browser/meetings/templates/navigation.html
@@ -4,7 +4,7 @@
     <li>
       <a href="#ai{{id}}" class="{{css_class}}">
         <span class="number">{{number}}</span>
-        <span class="title">{{title}}</span>
+        <span class="title">{{{title}}}</span>
       </a>
     </li>
     {{/each}}


### PR DESCRIPTION
This should be back-ported to 2018.4.

<img width="1185" alt="screen shot 2018-09-03 at 13 44 33" src="https://user-images.githubusercontent.com/7374243/44985272-03d89380-af80-11e8-83f7-18519a4178be.png">

resolves #4814 
