### PR TITLE
Fix an encoding issue by not using model code.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -17,6 +17,7 @@ Changelog
 - Disallow replacing the file on proposal documents with a non-.docx file. [Rotonen]
 - Disallow removing the file from proposal documents. [Rotonen]
 - Bump lxml to 4.1.1. [Rotonen]
+- Fix an encoding issue in an upgrade by no using model code. [deiferni]
 
 
 2018.4.2 (2018-08-30)

--- a/opengever/core/upgrades/20180619143343_make_sure_excerpt_document_title_is_unicode/upgrade.py
+++ b/opengever/core/upgrades/20180619143343_make_sure_excerpt_document_title_is_unicode/upgrade.py
@@ -89,9 +89,20 @@ class MakeSureExcerptDocumentTitleIsUnicode(SQLUpgradeStep):
         for submitted_proposal in self.objects(
                 {'portal_type': 'opengever.meeting.submittedproposal'},
                 'Fix submitted proposal excerpts title.'):
-            excerpts = submitted_proposal.get_excerpts(unrestricted=True)
+            excerpts = self.get_submitted_proposal_excerpts(submitted_proposal)
             for excerpt_document in excerpts:
                 self.fix_document_title(excerpt_document)
+
+    def get_submitted_proposal_excerpts(self, submitted_proposal):
+        """Copy of SubmittedProposal.get_excerpts but omitting the sorting
+        as that may trigger errors before THIS upgrade is run.
+        """
+        excerpts = []
+        for relation_value in getattr(submitted_proposal, 'excerpts', ()):
+            obj = relation_value.to_object
+            excerpts.append(obj)
+
+        return excerpts
 
     def migrate_excerpts_in_dossiers(self):
         """Migrate excerpts that were returned to dossier of their proposal."""


### PR DESCRIPTION
In 34b711962664 excerpts are now also sorted by title. Unfortunately that code is used in an upgrade (which was introduced before aforementioned change) which attempts to fix encoding issues in the title.

With this PR we copy model code into the upgrade, but without sorting as order is not relevant.