### PR TITLE
Scale down size for logo wrapper, to have more space for personal menues

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2018.5.0 (unreleased)
 ---------------------
 
+- Scale down size for logo wrapper, to have more space for personal menues. [phgross]
 - Fix double escaping of agendaitem title in meeting overview. [njohner]
 - Correct width of subdossier table in dossier details pdf. [njohner]
 - Do not set document date during check-in or cancel. [njohner]

--- a/plonetheme/teamraum/resources/index.html
+++ b/plonetheme/teamraum/resources/index.html
@@ -20,7 +20,7 @@
           <div id="header" class="fixedWidth">
             <div id="banner-image" class="cell position-0 width-16"></div>
             <div class="headerTop row">
-              <div class="cell position-0 width-6 logo-wrapper">
+              <div class="cell position-0 width-3 logo-wrapper">
                 <a href="#" id="portal-logo">
                   <img id="logo-teamraum"
                        title="Startseite"
@@ -28,7 +28,7 @@
                        src="images/logo_teamraum.png" />
                 </a>
               </div>
-              <div class="cell position-6 width-10 controls">
+              <div class="cell position-3 width-13 controls">
                 <a href="#" id="portal-logo-right">
                   <img id="logo-teamraum-right"
                        title="Startseite"


### PR DESCRIPTION
Currently the the logo column uses more than 35% of the total width, which is much more than needed by the logos. This fixes #4818 an UI Issue on small screens.

Before:
![image](https://user-images.githubusercontent.com/485755/45020735-17433780-b030-11e8-8044-64ed593a7774.png)

After:
![bildschirmfoto 2018-09-04 um 10 52 23](https://user-images.githubusercontent.com/485755/45020969-a0f30500-b030-11e8-8053-472961559510.png)

Works also for installations with a right logo:
![bildschirmfoto 2018-09-04 um 10 39 06](https://user-images.githubusercontent.com/485755/45020803-3fcb3180-b030-11e8-97a6-b53cbe850710.png)


Needs backport to: `2018.4-stable`