### PR TITLE
Trash/remove Protocol Excerpts

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2018.5.0 (unreleased)
 ---------------------
 
+- Add trashing of protocol excerpts. [njohner]
 - Exclude searchroots from subdossier listings. [Rotonen, lgraf]
 - Add filters (active and all) to membership listing. [njohner]
 - Do not add a task-reminder activity if task is finished. [elioschmutz]

--- a/opengever/document/base.py
+++ b/opengever/document/base.py
@@ -8,6 +8,7 @@ from opengever.dossier.templatefolder.interfaces import ITemplateFolder
 from opengever.inbox.inbox import IInbox
 from opengever.meeting.model.generateddocument import GeneratedExcerpt
 from opengever.meeting.proposal import IProposal
+from opengever.meeting.proposal import ISubmittedProposal
 from opengever.task.task import ITask
 from plone import api
 from plone.dexterity.content import Item
@@ -81,6 +82,7 @@ class BaseDocumentMixin(object):
             # We expect that there are 0 or 1 relation, because this document
             # cannot be the excerpt of multiple proposals.
             submitted_proposal = relation.from_object
+            assert(ISubmittedProposal.providedBy(submitted_proposal))
             if api.user.has_permission('View', obj=submitted_proposal):
                 return submitted_proposal
 

--- a/opengever/meeting/browser/meetings/agendaitem.py
+++ b/opengever/meeting/browser/meetings/agendaitem.py
@@ -197,7 +197,7 @@ class AgendaItemsView(BrowserView):
     def _serialize_excerpts(self, meeting, item):
         excerpt_data = []
 
-        docs = IContentListing(item.get_excerpt_documents(unrestricted=True))
+        docs = IContentListing(item.get_excerpt_documents(unrestricted=True, include_trashed=False))
         source_dossier_excerpt = item.get_source_dossier_excerpt()
         meeting_dossier = self.meeting.get_dossier()
 

--- a/opengever/meeting/configure.zcml
+++ b/opengever/meeting/configure.zcml
@@ -153,6 +153,12 @@
       />
 
   <subscriber
+      for="opengever.document.behaviors.IBaseDocument
+           opengever.trash.remover.IObjectWillBeRemovedFromTrashEvent"
+      handler=".handlers.excerpt_delete"
+      />
+
+  <subscriber
       for="opengever.document.document.IDocumentSchema
            zope.lifecycleevent.interfaces.IObjectModifiedEvent"
       handler=".handlers.on_document_modified"

--- a/opengever/meeting/model/query.py
+++ b/opengever/meeting/model/query.py
@@ -2,6 +2,7 @@ from datetime import date
 from opengever.base.date_time import utcnow_tz_aware
 from opengever.base.oguid import Oguid
 from opengever.meeting.model.committee import Committee
+from opengever.meeting.model.excerpt import Excerpt
 from opengever.meeting.model.generateddocument import GeneratedDocument
 from opengever.meeting.model.meeting import Meeting
 from opengever.meeting.model.membership import Membership
@@ -65,6 +66,17 @@ class ProposalQuery(BaseQuery):
 
 
 Proposal.query_cls = ProposalQuery
+
+
+class ExcerptQuery(BaseQuery):
+
+    def by_oguid(self, oguid):
+        """Return the query for the given oguid
+        """
+        return self.filter(Excerpt.excerpt_oguid == oguid)
+
+
+Excerpt.query_cls = ExcerptQuery
 
 
 class CommitteeQuery(BaseQuery):

--- a/opengever/meeting/proposal.py
+++ b/opengever/meeting/proposal.py
@@ -508,6 +508,11 @@ class SubmittedProposal(ProposalBase):
         self.excerpts = excerpts
         addRelations(self, None)
 
+    def remove_excerpt(self, excerpt_document):
+        if excerpt_document not in self.get_excerpts(include_trashed=True):
+            raise ValueError("Excerpt not found in excerpts.")
+        self.excerpts = filter(lambda excerpt: excerpt.to_object != excerpt_document, self.excerpts)
+
     def get_edit_values(self, fieldnames):
         """
         This is used by the 'inject_initial_data' method to prefill the edit

--- a/opengever/meeting/proposal.py
+++ b/opengever/meeting/proposal.py
@@ -33,6 +33,7 @@ from opengever.ogds.base.actor import Actor
 from opengever.ogds.base.sources import AssignedUsersSourceBinder
 from opengever.ogds.base.utils import get_current_admin_unit
 from opengever.ogds.base.utils import ogds_service
+from opengever.trash.trash import ITrashed
 from plone import api
 from plone.app.uuid.utils import uuidToObject
 from plone.autoform.directives import mode
@@ -465,7 +466,7 @@ class SubmittedProposal(ProposalBase):
             dossier.absolute_url(),
             dossier.title)
 
-    def get_excerpts(self, unrestricted=False):
+    def get_excerpts(self, unrestricted=False, include_trashed=False):
         """Return a restricted list of document objects which are excerpts
         of the current proposal.
 
@@ -477,7 +478,8 @@ class SubmittedProposal(ProposalBase):
             obj = relation_value.to_object
             if unrestricted or checkPermission('View', obj):
                 excerpts.append(obj)
-
+        if not include_trashed:
+            excerpts = filter(lambda obj: not ITrashed.providedBy(obj), excerpts)
         return sorted(excerpts, key=lambda excerpt: excerpt.title_or_id())
 
     def append_excerpt(self, excerpt_document):

--- a/opengever/meeting/tests/test_excerpt.py
+++ b/opengever/meeting/tests/test_excerpt.py
@@ -7,10 +7,29 @@ from opengever.meeting.model import Excerpt
 from opengever.testing import IntegrationTestCase
 from opengever.trash.remover import Remover
 from opengever.trash.trash import ITrashable
+from opengever.trash.trash import TrashError
 from zope.component import getMultiAdapter
 from zope.event import notify
 from zope.lifecycleevent import ObjectModifiedEvent
 from z3c.relationfield.event import _relations
+
+
+class TestTrashReturnedExcerpt(IntegrationTestCase):
+
+    @browsing
+    def test_trash_excerpt_is_forbidden_when_it_has_been_returned_to_proposal(self, browser):
+        self.login(self.committee_responsible, browser)
+        agenda_item = self.schedule_proposal(self.meeting, self.submitted_proposal)
+        agenda_item.decide()
+        excerpt1 = agenda_item.generate_excerpt('excerpt 1')
+
+        ITrashable(excerpt1).trash()
+
+        ITrashable(excerpt1).untrash()
+        agenda_item.return_excerpt(excerpt1)
+
+        with self.assertRaises(TrashError):
+            ITrashable(excerpt1).trash()
 
 
 class TestRemoveTrashedExcerpt(IntegrationTestCase):

--- a/opengever/trash/browser/trash.py
+++ b/opengever/trash/browser/trash.py
@@ -32,6 +32,11 @@ class TrashView(BrowserView):
                             u'could not trash the object ${obj}, it is checked'
                             ' out.',
                             mapping={'obj': obj.Title().decode('utf-8')})
+                    elif exc.message == 'The document has been returned as excerpt':
+                        msg = _(
+                            u'could not trash the object ${obj}, it is an excerpt'
+                            ' that has been returned to the proposal.',
+                            mapping={'obj': obj.Title().decode('utf-8')})
                     IStatusMessage(self.request).addStatusMessage(
                         msg, type='error')
                 except Unauthorized:

--- a/opengever/trash/locales/de/LC_MESSAGES/opengever.trash.po
+++ b/opengever/trash/locales/de/LC_MESSAGES/opengever.trash.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: opengever.trash 1.0\n"
-"POT-Creation-Date: 2018-05-24 07:27+0000\n"
+"POT-Creation-Date: 2018-09-04 12:38+0000\n"
 "PO-Revision-Date: 2017-05-03 09:38+0200\n"
 "Last-Translator: Julian Infanger <julian.infangner.@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -30,6 +30,10 @@ msgstr "Sie haben keine Objekte ausgewählt"
 #: ./opengever/trash/browser/trash.py
 msgid "could not trash the object ${obj}, it is already trashed"
 msgstr "Das Objekt ${obj} wurde bereits in den Papierkorb verschoben"
+
+#: ./opengever/trash/browser/trash.py
+msgid "could not trash the object ${obj}, it is an excerpt that has been returned to the proposal."
+msgstr "Das Objekt ${obj} konnte nicht in den Papierkorb verschoben werden, es ist ein Protokollauszug, welcher als Antwort an einen Antrag zurückgesendet wurde."
 
 #: ./opengever/trash/browser/trash.py
 msgid "could not trash the object ${obj}, it is checked out."

--- a/opengever/trash/locales/fr/LC_MESSAGES/opengever.trash.po
+++ b/opengever/trash/locales/fr/LC_MESSAGES/opengever.trash.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-05-24 07:27+0000\n"
+"POT-Creation-Date: 2018-09-04 12:38+0000\n"
 "PO-Revision-Date: 2017-12-03 12:24+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-trash/fr/>\n"
@@ -31,6 +31,10 @@ msgstr "Vous n'avez choisi aucun objet."
 #: ./opengever/trash/browser/trash.py
 msgid "could not trash the object ${obj}, it is already trashed"
 msgstr "L'objet a été déplacé vers la corbeille"
+
+#: ./opengever/trash/browser/trash.py
+msgid "could not trash the object ${obj}, it is an excerpt that has been returned to the proposal."
+msgstr "L'objet n'a pas pu être supprimé, il s'agit d'un extrait de protocol renvoyé comme réponse à une proposition"
 
 #: ./opengever/trash/browser/trash.py
 msgid "could not trash the object ${obj}, it is checked out."

--- a/opengever/trash/locales/opengever.trash.pot
+++ b/opengever/trash/locales/opengever.trash.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-05-24 07:27+0000\n"
+"POT-Creation-Date: 2018-09-04 12:38+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -31,6 +31,10 @@ msgstr ""
 
 #: ./opengever/trash/browser/trash.py
 msgid "could not trash the object ${obj}, it is already trashed"
+msgstr ""
+
+#: ./opengever/trash/browser/trash.py
+msgid "could not trash the object ${obj}, it is an excerpt that has been returned to the proposal."
 msgstr ""
 
 #: ./opengever/trash/browser/trash.py

--- a/opengever/trash/remover.py
+++ b/opengever/trash/remover.py
@@ -4,7 +4,23 @@ from opengever.trash.trash import ITrashed
 from plone import api
 from zc.relation.interfaces import ICatalog
 from zope.component import getUtility
+from zope.component.interfaces import IObjectEvent
+from zope.component.interfaces import ObjectEvent
+from zope.event import notify
+from zope.interface import implements
 from zope.intid.interfaces import IIntIds
+
+
+class IObjectWillBeRemovedFromTrashEvent(IObjectEvent):
+    """Interface of an event which gets fired when removing a document from trash.
+    """
+
+
+class ObjectWillBeRemovedFromTrashEvent(ObjectEvent):
+    """The event which gets fired when removing a document from trash.
+    """
+
+    implements(IObjectWillBeRemovedFromTrashEvent)
 
 
 class Remover(object):
@@ -15,6 +31,7 @@ class Remover(object):
         self.verify_is_allowed()
 
         for document in self.documents:
+            notify(ObjectWillBeRemovedFromTrashEvent(document))
             api.content.transition(obj=document,
                                    transition=document.remove_transition)
 


### PR DESCRIPTION
Trashing and/or removing protocol excerpts was not handled properly. Here we add the following features:
* Hide trashed excerpts from the meeting view
* when an excerpt is removed from trash, cleanup relations to proposal/agendaitem:
    * If the excerpt is from an ad-hoc agendaitem, remove its relation to the agendaitem from the sql database
    * If the excerpt is from an agendaitem with a proposal, remove the relation from the submitted proposal
* Forbid to trash an excerpt if it has been returned to the proposal.

![screen shot 2018-09-04 at 14 48 57](https://user-images.githubusercontent.com/7374243/45033103-d0673900-b053-11e8-919d-7ef618454f68.png)

resolves #4486 