### PR TITLE
Prevent pasting without `Copy or Move` on the target container

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -607,6 +607,9 @@ Objects
             - self.meeting_subtask
         - self.protected_dossier
           - self.protected_document
+        - self.protected_dossier_with_task
+          - self.protected_document_with_task
+          - self.task_in_protected_dossier
     - self.empty_repofolder
   - self.templates
     - self.ad_hoc_agenda_item_template

--- a/README.rst
+++ b/README.rst
@@ -605,6 +605,8 @@ Objects
           - self.meeting_document
           - self.meeting_task
             - self.meeting_subtask
+        - self.protected_dossier
+          - self.protected_document
     - self.empty_repofolder
   - self.templates
     - self.ad_hoc_agenda_item_template

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2018.5.0 (unreleased)
 ---------------------
 
+- Do not present the paste UI to users without 'Copy or Move' on the target. [Rotonen]
 - Add trashing of protocol excerpts. [njohner]
 - Display title for NullObject in meeting template selection. [njohner]
 - Fix styling of favorite button. [njohner]

--- a/opengever/base/browser/pasting_allowed.py
+++ b/opengever/base/browser/pasting_allowed.py
@@ -3,6 +3,7 @@ from Acquisition import aq_parent
 from opengever.base.clipboard import Clipboard
 from opengever.dossier.behaviors.dossier import IDossierMarker
 from opengever.private.interfaces import IPrivateContainer
+from plone import api
 from Products.Five import BrowserView
 from ZODB.POSException import ConflictError
 
@@ -34,6 +35,10 @@ class IsPastingAllowedView(BrowserView):
         """Perform the necessary checks to determine whether pasting is
         allowed / possible on the current context.
         """
+        # Check whether the user has Copy or Move on the context
+        if not api.user.has_permission('Copy or Move', obj=self.context):
+            return False
+
         # Check whether pasting is allowed at all for the container type
         if self.context.portal_type in self.disabled_types:
             return False

--- a/opengever/base/monkey/patches/paste_permission.py
+++ b/opengever/base/monkey/patches/paste_permission.py
@@ -5,6 +5,8 @@ class PatchDXContainerPastePermission(MonkeyPatch):
     """Change permission for manage_pasteObjects to "Add portal content"
 
     See https://dev.plone.org/ticket/9177
+    See also https://web.archive.org/web/20151023012935/https://dev.plone.org/ticket/13820
+    See also https://community.plone.org/t/plone-paste-permissions/7155
     XXX: Find a way to do this without patching __ac_permissions__ directly
     """
 

--- a/opengever/base/tests/test_copy_paste.py
+++ b/opengever/base/tests/test_copy_paste.py
@@ -215,6 +215,28 @@ class TestCopyPaste(IntegrationTestCase):
             ["Can't paste items, the context does not allow pasting items."],
             error_messages())
 
+    @browsing
+    def test_paste_not_available_without_copy_or_move_on_target(self, browser):
+        self.login(self.regular_user, browser)
+        browser.open(self.dossier, view="copy_items", data=self.make_path_param(self.document))
+        # A task grants us 'Contributor' on the otherwise inaccessible dossier
+        browser.open(self.protected_dossier_with_task)
+        expected_actions = [
+            u'Add new\u2026 \u25bc',
+            'Document',
+            'document_with_template',
+            'Task',
+            'Add task from template',
+            'Subdossier',
+            'Participant',
+            u'Actions \u25bc',
+            'Cover (PDF)',
+            'Export as Zip',
+            'Print details (PDF)',
+            'Properties',
+            ]
+        self.assertEqual(expected_actions, browser.css('#contentActionMenus a').text)
+
 
 class TestClipboardCaching(IntegrationTestCase):
 

--- a/opengever/bundle/tests/test_oggbundle_pipeline.py
+++ b/opengever/bundle/tests/test_oggbundle_pipeline.py
@@ -280,7 +280,7 @@ class TestOggBundlePipeline(IntegrationTestCase):
         return self.assert_dossier_hanspeter_created(parent)
 
     def assert_dossier_peter_schneider_created(self, parent):
-        dossier_peter = parent.get('dossier-14')
+        dossier_peter = parent.get('dossier-16')
         self.assertEqual(
             u'Vreni Meier ist ein Tausendsassa',
             IDossier(dossier_peter).comments)
@@ -298,7 +298,7 @@ class TestOggBundlePipeline(IntegrationTestCase):
             index_data_for(dossier_peter)[GUID_INDEX_NAME])
 
     def assert_dossier_vreni_created(self, parent):
-        dossier = self.leaf_repofolder.get('dossier-16')
+        dossier = self.leaf_repofolder.get('dossier-18')
         self.assertEqual(u'Vreni Meier ist ein Tausendsassa',
                          IDossier(dossier).comments)
         self.assertEqual(tuple(), IDossier(dossier).keywords)
@@ -314,7 +314,7 @@ class TestOggBundlePipeline(IntegrationTestCase):
             index_data_for(dossier)[GUID_INDEX_NAME])
 
     def assert_dossier_hanspeter_created(self, parent):
-        dossier_peter = parent.get('dossier-15')
+        dossier_peter = parent.get('dossier-17')
         self.assertEqual(
             u'archival worthy',
             ILifeCycle(dossier_peter).archival_value)

--- a/opengever/dossier/tests/test_templatefolder.py
+++ b/opengever/dossier/tests/test_templatefolder.py
@@ -212,15 +212,15 @@ class TestDocumentWithTemplateFormWithDocProperties(IntegrationTestCase):
         self.assertEquals(u'Test Docx.docx', document.file.filename)
 
         expected_doc_properties = {
-            'Document.ReferenceNumber': 'Client1 1.1 / 1 / 38',
-            'Document.SequenceNumber': '38',
+            'Document.ReferenceNumber': 'Client1 1.1 / 1 / 40',
+            'Document.SequenceNumber': '40',
             'Dossier.ReferenceNumber': 'Client1 1.1 / 1',
             'Dossier.Title': u'Vertr\xe4ge mit der kantonalen Finanzverwaltung',
             'User.FullName': u'B\xe4rfuss K\xe4thi',
             'User.ID': 'kathi.barfuss',
             'ogg.document.document_date': datetime(2020, 9, 28, 0, 0),
-            'ogg.document.reference_number': 'Client1 1.1 / 1 / 38',
-            'ogg.document.sequence_number': '38',
+            'ogg.document.reference_number': 'Client1 1.1 / 1 / 40',
+            'ogg.document.sequence_number': '40',
             'ogg.document.title': 'Test Docx',
             'ogg.document.version_number': 0,
             'ogg.dossier.reference_number': 'Client1 1.1 / 1',
@@ -270,15 +270,15 @@ class TestDocumentWithTemplateFormWithDocProperties(IntegrationTestCase):
         self.assertEquals(u'Test Docx.docx', document.file.filename)
 
         expected_doc_properties = {
-            'Document.ReferenceNumber': 'Client1 1.1 / 1 / 38',
-            'Document.SequenceNumber': '38',
+            'Document.ReferenceNumber': 'Client1 1.1 / 1 / 40',
+            'Document.SequenceNumber': '40',
             'Dossier.ReferenceNumber': 'Client1 1.1 / 1',
             'Dossier.Title': u'Vertr\xe4ge mit der kantonalen Finanzverwaltung',
             'User.FullName': u'B\xe4rfuss K\xe4thi',
             'User.ID': 'kathi.barfuss',
             'ogg.document.document_date': datetime(2020, 10, 28, 0, 0),
-            'ogg.document.reference_number': 'Client1 1.1 / 1 / 38',
-            'ogg.document.sequence_number': '38',
+            'ogg.document.reference_number': 'Client1 1.1 / 1 / 40',
+            'ogg.document.sequence_number': '40',
             'ogg.document.title': 'Test Docx',
             'ogg.document.version_number': 0,
             'ogg.dossier.reference_number': 'Client1 1.1 / 1',

--- a/opengever/oneoffixx/tests/assets/oneoffixx_connect_xml.txt
+++ b/opengever/oneoffixx/tests/assets/oneoffixx_connect_xml.txt
@@ -14,14 +14,14 @@
         <Arguments>
           <Interface Name="OneGovGEVER">
             <Node Id="ogg.document.title">Sch&#228;ttengarten</Node>
-            <Node Id="ogg.document.reference_number">Client1 1.1 / 1 / 38</Node>
+            <Node Id="ogg.document.reference_number">Client1 1.1 / 1 / 37</Node>
             <Node Id="ogg.document.sequence_number">37</Node>
           </Interface>
         </Arguments>
       </Function>
       <Function name="MetaData" id="c364b495-7176-4ce2-9f7c-e71f302b8096">
         <Value key="ogg.document.title" type="string">Sch&#228;ttengarten</Value>
-        <Value key="ogg.document.reference_number" type="string">Client1 1.1 / 1 / 38</Value>
+        <Value key="ogg.document.reference_number" type="string">Client1 1.1 / 1 / 37</Value>
         <Value key="ogg.document.sequence_number" type="string">37</Value>
       </Function>
       <Commands>

--- a/opengever/oneoffixx/tests/assets/oneoffixx_connect_xml.txt
+++ b/opengever/oneoffixx/tests/assets/oneoffixx_connect_xml.txt
@@ -14,14 +14,14 @@
         <Arguments>
           <Interface Name="OneGovGEVER">
             <Node Id="ogg.document.title">Sch&#228;ttengarten</Node>
-            <Node Id="ogg.document.reference_number">Client1 1.1 / 1 / 37</Node>
+            <Node Id="ogg.document.reference_number">Client1 1.1 / 1 / 38</Node>
             <Node Id="ogg.document.sequence_number">37</Node>
           </Interface>
         </Arguments>
       </Function>
       <Function name="MetaData" id="c364b495-7176-4ce2-9f7c-e71f302b8096">
         <Value key="ogg.document.title" type="string">Sch&#228;ttengarten</Value>
-        <Value key="ogg.document.reference_number" type="string">Client1 1.1 / 1 / 37</Value>
+        <Value key="ogg.document.reference_number" type="string">Client1 1.1 / 1 / 38</Value>
         <Value key="ogg.document.sequence_number" type="string">37</Value>
       </Function>
       <Commands>

--- a/opengever/sharing/tests/test_blocked_local_roles_listing.py
+++ b/opengever/sharing/tests/test_blocked_local_roles_listing.py
@@ -167,11 +167,20 @@ class TestBlockedLocalRolesListing(IntegrationTestCase):
         browser.append_request_header('Accept-Language', 'de-ch')
         self.login(self.administrator, browser)
         browser.open(self.repository_root, view="tabbedview_view-blocked-local-roles")
-        expected_titles = [u'1. F\xfchrung', u'1.1. Vertr\xe4ge und Vereinbarungen', u'Luftsch\xfctze']
+        expected_titles = [
+            u'1. F\xfchrung',
+            u'1.1. Vertr\xe4ge und Vereinbarungen',
+            u'Luftsch\xfctze',
+            u'Zu allem \xdcbel',
+            ]
         self.assertEquals(expected_titles, browser.css('.blocked-local-roles-link').text)
-        expected_titles = [u'1.1. Vertr\xe4ge und Vereinbarungen', u'Luftsch\xfctze']
+        expected_titles = [
+            u'1.1. Vertr\xe4ge und Vereinbarungen',
+            u'Luftsch\xfctze',
+            u'Zu allem \xdcbel',
+            ]
         self.assertEquals(expected_titles, browser.css('.level1 a').text)
-        expected_titles = [u'Luftsch\xfctze']
+        expected_titles = [u'Luftsch\xfctze', u'Zu allem \xdcbel']
         self.assertEquals(expected_titles, browser.css('.level2 a').text)
         self.assertFalse(browser.css('.level3 a').text)
         nodes = browser.css('.blocked-local-roles-link')

--- a/opengever/sharing/tests/test_blocked_local_roles_listing.py
+++ b/opengever/sharing/tests/test_blocked_local_roles_listing.py
@@ -108,11 +108,7 @@ class TestBlockedLocalRolesListing(IntegrationTestCase):
     def test_blocked_role_tab_does_not_render_tree_when_nothing_found(self, browser):  # noqa
         browser.append_request_header('Accept-Language', 'de-ch')
         self.login(self.administrator, browser)
-
-        browser.open(
-            self.repository_root,
-            view="tabbedview_view-blocked-local-roles",
-            )
+        browser.open(self.empty_repofolder, view="tabbedview_view-blocked-local-roles")
         self.assertEquals(
             browser.css('.blocked-local-roles-listing').first.text,
             u'Keine gesch\xfctzte Objekte in diesem Bereich gefunden.',
@@ -167,44 +163,17 @@ class TestBlockedLocalRolesListing(IntegrationTestCase):
             )
 
     @browsing
-    def test_blocked_role_tab_tree_rendering_of_dossier(self, browser):
+    def test_blocked_role_tab_tree_rendering(self, browser):
         browser.append_request_header('Accept-Language', 'de-ch')
         self.login(self.administrator, browser)
-
-        self.dossier.__ac_local_roles_block__ = True
-        self.dossier.reindexObject(idxs=['blocked_local_roles'])
-
-        browser.open(
-            self.repository_root,
-            view="tabbedview_view-blocked-local-roles",
-            )
-
-        self.assertEquals(
-            browser.css('.blocked-local-roles-link').text,
-            [
-                u'1. F\xfchrung',
-                u'1.1. Vertr\xe4ge und Vereinbarungen',
-                u'Vertr\xe4ge mit der kantonalen Finanzverwaltung',
-                ],
-            )
-
-        self.assertEquals(
-            browser.css('.level1 a').text,
-            [
-                u'1.1. Vertr\xe4ge und Vereinbarungen',
-                u'Vertr\xe4ge mit der kantonalen Finanzverwaltung',
-                ],
-            )
-
-        self.assertEquals(
-            browser.css('.level2 a').text,
-            [
-                u'Vertr\xe4ge mit der kantonalen Finanzverwaltung',
-                ],
-            )
-
+        browser.open(self.repository_root, view="tabbedview_view-blocked-local-roles")
+        expected_titles = [u'1. F\xfchrung', u'1.1. Vertr\xe4ge und Vereinbarungen', u'Luftsch\xfctze']
+        self.assertEquals(expected_titles, browser.css('.blocked-local-roles-link').text)
+        expected_titles = [u'1.1. Vertr\xe4ge und Vereinbarungen', u'Luftsch\xfctze']
+        self.assertEquals(expected_titles, browser.css('.level1 a').text)
+        expected_titles = [u'Luftsch\xfctze']
+        self.assertEquals(expected_titles, browser.css('.level2 a').text)
         self.assertFalse(browser.css('.level3 a').text)
-
         nodes = browser.css('.blocked-local-roles-link')
         repo = 'contenttype-opengever-repository-repositoryfolder'
         dossier = 'contenttype-opengever-dossier-businesscasedossier'
@@ -213,125 +182,21 @@ class TestBlockedLocalRolesListing(IntegrationTestCase):
         self.assertIn(dossier, nodes[2].classes)
 
     @browsing
-    def test_blocked_role_tab_tree_rendering_of_repofolder(self, browser):
-        browser.append_request_header('Accept-Language', 'de-ch')
-        self.login(self.administrator, browser)
-
-        self.leaf_repofolder.__ac_local_roles_block__ = True
-        self.leaf_repofolder.reindexObject(idxs=['blocked_local_roles'])
-
-        browser.open(
-            self.repository_root,
-            view="tabbedview_view-blocked-local-roles",
-            )
-
-        self.assertEquals(
-            browser.css('.blocked-local-roles-link').text,
-            [
-                u'1. F\xfchrung',
-                u'1.1. Vertr\xe4ge und Vereinbarungen',
-                ],
-            )
-
-        self.assertEquals(
-            browser.css('.level1 a').text,
-            [
-                u'1.1. Vertr\xe4ge und Vereinbarungen',
-                ],
-            )
-
-        self.assertFalse(browser.css('.level2 a').text)
-
-        nodes = browser.css('.blocked-local-roles-link')
-        repo = 'contenttype-opengever-repository-repositoryfolder'
-        self.assertIn(repo, nodes[0].classes)
-        self.assertIn(repo, nodes[1].classes)
-
-    @browsing
     def test_blocked_role_tab_can_drill_down_to_dossier(self, browser):
         browser.append_request_header('Accept-Language', 'de-ch')
         self.login(self.administrator, browser)
-
-        self.dossier.__ac_local_roles_block__ = True
-        self.dossier.reindexObject(idxs=['blocked_local_roles'])
-
-        browser.open(
-            self.repository_root,
-            view="tabbedview_view-blocked-local-roles",
-            )
+        browser.open(self.repository_root, view="tabbedview_view-blocked-local-roles")
         browser.css('.blocked-local-roles-link').first.click()
-        expected_url = ''.join((
-            self.branch_repofolder.absolute_url(),
-            '#blocked-local-roles',
-            ))
-        self.assertEquals(
-            expected_url,
-            browser.url,
-            )
-
-        browser.open(
-            self.branch_repofolder,
-            view="tabbedview_view-blocked-local-roles",
-            )
+        expected_url = ''.join((self.branch_repofolder.absolute_url(), '#blocked-local-roles', ))
+        self.assertEquals(expected_url, browser.url)
+        browser.open(self.branch_repofolder, view="tabbedview_view-blocked-local-roles")
         browser.css('.blocked-local-roles-link').first.click()
-        expected_url = ''.join((
-            self.leaf_repofolder.absolute_url(),
-            '#blocked-local-roles',
-            ))
-        self.assertEquals(
-            expected_url,
-            browser.url,
-            )
-
-        browser.open(
-            self.leaf_repofolder,
-            view="tabbedview_view-blocked-local-roles",
-            )
+        expected_url = ''.join((self.leaf_repofolder.absolute_url(), '#blocked-local-roles', ))
+        self.assertEquals(expected_url, browser.url)
+        browser.open(self.leaf_repofolder, view="tabbedview_view-blocked-local-roles")
         browser.css('.blocked-local-roles-link').first.click()
-        expected_url = ''.join((
-            self.dossier.absolute_url(),
-            '#sharing',
-            ))
-        self.assertEquals(
-            expected_url,
-            browser.url,
-            )
-
-    @browsing
-    def test_blocked_role_tab_can_drill_down_to_repofolder(self, browser):
-        browser.append_request_header('Accept-Language', 'de-ch')
-        self.login(self.administrator, browser)
-
-        self.leaf_repofolder.__ac_local_roles_block__ = True
-        self.leaf_repofolder.reindexObject(idxs=['blocked_local_roles'])
-
-        browser.open(
-            self.repository_root,
-            view="tabbedview_view-blocked-local-roles",
-            )
-        browser.css('.blocked-local-roles-link').first.click()
-        expected_url = ''.join((
-            self.branch_repofolder.absolute_url(),
-            '#blocked-local-roles',
-            ))
-        self.assertEquals(
-            expected_url,
-            browser.url,
-            )
-
-        browser.open(
-            self.branch_repofolder,
-            view="tabbedview_view-blocked-local-roles",
-            )
-        browser.css('.blocked-local-roles-link').first.click()
-        expected_url = ''.join((
-            self.leaf_repofolder.absolute_url(),
-            '#sharing',
-            ))
-        self.assertEquals(
-            expected_url,
-            browser.url,
-            )
+        expected_url = ''.join((self.protected_dossier.absolute_url(), '#sharing', ))
+        self.assertEquals(expected_url, browser.url)
 
     @browsing
     def test_protected_dossiers_are_listed_for_manager(self, browser):

--- a/opengever/tabbedview/tests/test_dossier_listing.py
+++ b/opengever/tabbedview/tests/test_dossier_listing.py
@@ -23,7 +23,12 @@ class TestDossierListing(IntegrationTestCase):
     @staticmethod
     def get_contained_folders(folder):
         children = folder.getChildNodes()
-        return [child for child in children if IDossierMarker.providedBy(child)]
+        return [
+            child
+            for child in children
+            if IDossierMarker.providedBy(child)
+            if api.user.has_permission('View', obj=child)
+            ]
 
     @staticmethod
     def get_folder_data(dossier):

--- a/opengever/tabbedview/tests/test_personaloverview.py
+++ b/opengever/tabbedview/tests/test_personaloverview.py
@@ -173,7 +173,6 @@ class TestGlobalTaskListings(IntegrationTestCase):
     def test_my_tasks_list_task_assigned_to_current_user(self, browser):
         self.login(self.regular_user, browser=browser)
         browser.open(view='tabbedview_view-mytasks')
-
         expected_tasks = [
             u'F\xf6rw\xe4rding',
             u'Rechtliche Grundlagen in Vertragsentwurf \xdcberpr\xfcfen',
@@ -182,18 +181,12 @@ class TestGlobalTaskListings(IntegrationTestCase):
             u'Personaleintritt',
             u'Vertr\xe4ge abschliessen',
             u'Status \xdcberpr\xfcfen',
-        ]
-
-        found_tasks = [
-            row.get('Title')
-            for row in browser.css('.listing').first.dicts()
+            u'Ein notwendiges \xdcbel',
             ]
-
+        found_tasks = [row.get('Title') for row in browser.css('.listing').first.dicts()]
         self.assertEquals(expected_tasks, found_tasks)
-
         self.task.get_sql_object().responsible = 'robert.ziegler'
         browser.open(view='tabbedview_view-mytasks')
-
         expected_tasks = [
             u'F\xf6rw\xe4rding',
             u'Rechtliche Grundlagen in Vertragsentwurf \xdcberpr\xfcfen',
@@ -201,12 +194,9 @@ class TestGlobalTaskListings(IntegrationTestCase):
             u'Personaleintritt',
             u'Vertr\xe4ge abschliessen',
             u'Status \xdcberpr\xfcfen',
-        ]
-
-        found_tasks = [
-            row.get('Title')
-            for row in browser.css('.listing').first.dicts()
+            u'Ein notwendiges \xdcbel',
             ]
+        found_tasks = [row.get('Title') for row in browser.css('.listing').first.dicts()]
 
         self.assertEquals(expected_tasks, found_tasks)
 
@@ -257,7 +247,6 @@ class TestGlobalTaskListings(IntegrationTestCase):
     def test_my_tasks_list_task_issued_by_the_current_user(self, browser):
         self.login(self.dossier_responsible, browser=browser)
         browser.open(view='tabbedview_view-myissuedtasks')
-
         expected_tasks = [
             u'F\xf6rw\xe4rding',
             u'Rechtliche Grundlagen in Vertragsentwurf \xdcberpr\xfcfen',
@@ -266,19 +255,12 @@ class TestGlobalTaskListings(IntegrationTestCase):
             u'Status \xdcberpr\xfcfen',
             u'Programm \xdcberpr\xfcfen',
             u'H\xf6rsaal reservieren',
+            u'Ein notwendiges \xdcbel',
             ]
-
-        found_tasks = [
-            row.get('Title')
-            for row in browser.css('.listing').first.dicts()
-            ]
-
+        found_tasks = [row.get('Title') for row in browser.css('.listing').first.dicts()]
         self.assertEquals(expected_tasks, found_tasks)
-
         self.task.get_sql_object().issuer = 'kathi.barfuss'
-
         browser.open(view='tabbedview_view-myissuedtasks')
-
         expected_tasks = [
             u'F\xf6rw\xe4rding',
             u'Rechtliche Grundlagen in Vertragsentwurf \xdcberpr\xfcfen',
@@ -286,23 +268,15 @@ class TestGlobalTaskListings(IntegrationTestCase):
             u'Status \xdcberpr\xfcfen',
             u'Programm \xdcberpr\xfcfen',
             u'H\xf6rsaal reservieren',
+            u'Ein notwendiges \xdcbel',
             ]
-
-        found_tasks = [
-            row.get('Title')
-            for row in browser.css('.listing').first.dicts()
-            ]
-
+        found_tasks = [row.get('Title') for row in browser.css('.listing').first.dicts()]
         self.assertEquals(expected_tasks, found_tasks)
 
     @browsing
-    def test_all_task_list_all_task_assigned_to_current_org_unit(
-            self,
-            browser,
-        ):
+    def test_all_task_list_all_task_assigned_to_current_org_unit(self, browser):
         self.login(self.secretariat_user, browser=browser)
         browser.open(view='tabbedview_view-alltasks')
-
         expected_tasks = [
             u'F\xf6rw\xe4rding',
             u'Rechtliche Grundlagen in Vertragsentwurf \xdcberpr\xfcfen',
@@ -313,19 +287,12 @@ class TestGlobalTaskListings(IntegrationTestCase):
             u'Status \xdcberpr\xfcfen',
             u'Programm \xdcberpr\xfcfen',
             u'H\xf6rsaal reservieren',
-        ]
-
-        found_tasks = [
-            row.get('Title')
-            for row in browser.css('.listing').first.dicts()
+            u'Ein notwendiges \xdcbel',
             ]
-
+        found_tasks = [row.get('Title') for row in browser.css('.listing').first.dicts()]
         self.assertEquals(expected_tasks, found_tasks)
-
         self.task.get_sql_object().assigned_org_unit = 'additional'
-
         browser.open(view='tabbedview_view-alltasks')
-
         expected_tasks = [
             u'F\xf6rw\xe4rding',
             u'Rechtliche Grundlagen in Vertragsentwurf \xdcberpr\xfcfen',
@@ -335,23 +302,15 @@ class TestGlobalTaskListings(IntegrationTestCase):
             u'Status \xdcberpr\xfcfen',
             u'Programm \xdcberpr\xfcfen',
             u'H\xf6rsaal reservieren',
-        ]
-
-        found_tasks = [
-            row.get('Title')
-            for row in browser.css('.listing').first.dicts()
+            u'Ein notwendiges \xdcbel',
             ]
-
+        found_tasks = [row.get('Title') for row in browser.css('.listing').first.dicts()]
         self.assertEquals(expected_tasks, found_tasks)
 
     @browsing
-    def test_all_issued_tasks_list_all_task_issued_by_the_current_org_unit(
-            self,
-            browser,
-        ):
+    def test_all_issued_tasks_list_all_task_issued_by_the_current_org_unit(self, browser):
         self.login(self.secretariat_user, browser=browser)
         browser.open(view='tabbedview_view-allissuedtasks')
-
         expected_tasks = [
             u'F\xf6rw\xe4rding',
             u'Rechtliche Grundlagen in Vertragsentwurf \xdcberpr\xfcfen',
@@ -362,28 +321,13 @@ class TestGlobalTaskListings(IntegrationTestCase):
             u'Status \xdcberpr\xfcfen',
             u'Programm \xdcberpr\xfcfen',
             u'H\xf6rsaal reservieren',
-        ]
-
-        found_tasks = [
-            row.get('Title')
-            for row in browser.css('.listing').first.dicts()
+            u'Ein notwendiges \xdcbel',
             ]
-
+        found_tasks = [row.get('Title') for row in browser.css('.listing').first.dicts()]
         self.assertEquals(expected_tasks, found_tasks)
-
-        create(
-            Builder('org_unit')
-            .id('stv')
-            .having(
-                title=u'Steuerverwaltung',
-                admin_unit_id='plone',
-                )
-            )
-
+        create(Builder('org_unit').id('stv').having(title=u'Steuerverwaltung', admin_unit_id='plone'))
         self.task.get_sql_object().issuing_org_unit = 'stv'
-
         browser.open(view='tabbedview_view-allissuedtasks')
-
         expected_tasks = [
             u'F\xf6rw\xe4rding',
             u'Rechtliche Grundlagen in Vertragsentwurf \xdcberpr\xfcfen',
@@ -393,11 +337,7 @@ class TestGlobalTaskListings(IntegrationTestCase):
             u'Status \xdcberpr\xfcfen',
             u'Programm \xdcberpr\xfcfen',
             u'H\xf6rsaal reservieren',
-        ]
-
-        found_tasks = [
-            row.get('Title')
-            for row in browser.css('.listing').first.dicts()
+            u'Ein notwendiges \xdcbel',
             ]
-
+        found_tasks = [row.get('Title') for row in browser.css('.listing').first.dicts()]
         self.assertEquals(expected_tasks, found_tasks)

--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -120,7 +120,7 @@ class OpengeverContentFixture(object):
                 self.create_workspace()
             with self.login(self.dossier_responsible):
                 self.create_shadow_document()
-                self.create_protected_dossier()
+                self.create_protected_dossiers()
 
         logger.info('(fixture setup in %ds) ', round(time() - start, 3))
 
@@ -1168,7 +1168,7 @@ class OpengeverContentFixture(object):
             ))
 
     @staticuid()
-    def create_protected_dossier(self):
+    def create_protected_dossiers(self):
         protected_dossier = self.register('protected_dossier', create(
             Builder('dossier')
             .within(self.repofolder00)
@@ -1183,7 +1183,7 @@ class OpengeverContentFixture(object):
         protected_dossier.reindexObjectSecurity()
         protected_dossier.reindexObject(idxs=['blocked_local_roles'])
 
-        protected_document = self.register('protected_document', create(
+        self.register('protected_document', create(
             Builder('document')
             .within(protected_dossier)
             .titled(u'T\xfcrmli')
@@ -1194,6 +1194,48 @@ class OpengeverContentFixture(object):
             .attach_file_containing(
                 bumblebee_asset('example.docx').bytes(),
                 u'bauplan.docx')
+            ))
+
+        protected_dossier_with_task = self.register('protected_dossier_with_task', create(
+            Builder('dossier')
+            .within(self.repofolder00)
+            .titled(u'Zu allem \xdcbel')
+            .having(
+                description=u'Schl\xe4cht',
+                responsible=self.dossier_responsible.getId(),
+                start=date(2016, 1, 1),
+                )
+            ))
+        protected_dossier_with_task.__ac_local_roles_block__ = True
+        protected_dossier_with_task.reindexObjectSecurity()
+        protected_dossier_with_task.reindexObject(idxs=['blocked_local_roles'])
+
+        protected_document_with_task = self.register('protected_document_with_task', create(
+            Builder('document')
+            .within(protected_dossier_with_task)
+            .titled(u'Das kleinere \xdcbel')
+            .having(
+                document_date=datetime(2010, 1, 3),
+                document_author=TEST_USER_ID,
+                )
+            .attach_file_containing(
+                bumblebee_asset('example.docx').bytes(),
+                u'kunststuck.docx')
+            ))
+
+        self.register('task_in_protected_dossier', create(
+            Builder('task')
+            .within(protected_dossier_with_task)
+            .titled(u'Ein notwendiges \xdcbel')
+            .having(
+                responsible_client=self.org_unit.id(),
+                responsible=self.regular_user.getId(),
+                issuer=self.dossier_responsible.getId(),
+                task_type='correction',
+                deadline=date(2016, 11, 1),
+                )
+            .in_state('task-state-in-progress')
+            .relate_to(protected_document_with_task)
             ))
 
     @staticuid()

--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -120,6 +120,7 @@ class OpengeverContentFixture(object):
                 self.create_workspace()
             with self.login(self.dossier_responsible):
                 self.create_shadow_document()
+                self.create_protected_dossier()
 
         logger.info('(fixture setup in %ds) ', round(time() - start, 3))
 
@@ -1164,6 +1165,35 @@ class OpengeverContentFixture(object):
                 start=date(2016, 1, 1),
                 responsible=self.dossier_responsible.getId(),
                 )
+            ))
+
+    @staticuid()
+    def create_protected_dossier(self):
+        protected_dossier = self.register('protected_dossier', create(
+            Builder('dossier')
+            .within(self.repofolder00)
+            .titled(u'Luftsch\xfctze')
+            .having(
+                description=u'Lichtbogen-L\xf6schkammern usw.',
+                responsible=self.dossier_responsible.getId(),
+                start=date(2016, 1, 1),
+                )
+            ))
+        protected_dossier.__ac_local_roles_block__ = True
+        protected_dossier.reindexObjectSecurity()
+        protected_dossier.reindexObject(idxs=['blocked_local_roles'])
+
+        protected_document = self.register('protected_document', create(
+            Builder('document')
+            .within(protected_dossier)
+            .titled(u'T\xfcrmli')
+            .having(
+                document_date=datetime(2010, 1, 3),
+                document_author=TEST_USER_ID,
+                )
+            .attach_file_containing(
+                bumblebee_asset('example.docx').bytes(),
+                u'bauplan.docx')
             ))
 
     @staticuid()


### PR DESCRIPTION
* Amend the fixtures to have suitable data types
* Prevent pasting without `Copy or Move` on the target container as otherwise the freshly created object cannot be renamed

Closes #4589