### PR TITLE
Fix bug in document template list.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -14,6 +14,7 @@ Changelog
 - Fix bug with document without file in a dossiertemplate. [njohner]
 - Prevent replacing files on proposal templates with non-.docx files via quickupload. [Rotonen]
 - Add an upgrade step to fix broken-by-broken-protocol-excerpt journal entries on dossiers. [Rotonen]
+- Do not list documents within dossiertemplates when creating a document from template. [njohner]
 - Correct width of subdossier table in dossier details pdf. [njohner]
 - Do not set document date during check-in or cancel. [njohner]
 - Disallow grouping tasks by the checkbox column in list views. [Rotonen]

--- a/opengever/dossier/tests/test_templatefolder.py
+++ b/opengever/dossier/tests/test_templatefolder.py
@@ -51,6 +51,24 @@ class TestDocumentWithTemplateFormPlain(IntegrationTestCase):
         self.assertEquals(expected_listing, browser.css('table.listing').first.dicts())
 
     @browsing
+    def test_form_does_not_list_templates_from_dossiertemplates(self, browser):
+        self.login(self.regular_user, browser)
+        create(Builder('document')
+               .titled(u'T\xc3\xb6mpl\xc3\xb6te in dossiertemplate')
+               .with_dummy_content()
+               .within(self.dossiertemplate))
+
+        browser.open(self.dossier, view='document_with_template')
+        expected_listing = [
+            {'': '', 'Creator': 'nicole.kohler', 'Modified': '28.12.2010', 'Title': u'T\xc3\xb6mpl\xc3\xb6te Mit'},
+            {'': '', 'Creator': 'nicole.kohler', 'Modified': '31.08.2016', 'Title': u'T\xc3\xb6mpl\xc3\xb6te Normal'},
+            {'': '', 'Creator': 'nicole.kohler', 'Modified': '31.08.2016', 'Title': u'T\xc3\xb6mpl\xc3\xb6te Ohne'},
+            {'': '', 'Creator': 'nicole.kohler', 'Modified': '29.02.2020', 'Title': u'T\xc3\xb6mpl\xc3\xb6te Sub'},
+            ]
+
+        self.assertEquals(expected_listing, browser.css('table.listing').first.dicts())
+
+    @browsing
     def test_form_does_not_inlcude_participants_with_disabled_feature(self, browser):
         self.login(self.regular_user, browser)
         browser.open(self.dossier, view='document_with_template')


### PR DESCRIPTION
When creating a document from a template, `document` templates  inside a `dossiertemplate` should not be in the list of templates to choose from.

Documents can be inside the main `templatefolder`, but also in sub-`templatefolder`, `dossiertemplate`, subfolders in `dossiertemplate`, etc.
In the end we want as templates all `document` that are nor contained in a `templatefolder`. This would need to be recursively checked (as they can have dossiers as direct `parent_folder`). It is easier to get all documents that are directly contained in a `templatefolder`, which should be equivalent. This requires several catalog searches, and a custom sorting.

resolves #4657 
Also resolves https://extranet.4teamwork.ch/support/gemeinde-koeniz/tracker/76