### PR TITLE
Fix bug with document without file in a dossiertemplate.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -9,6 +9,7 @@ Changelog
 - Fix global scoped "show more" links for SOLR livesearch [Rotonen]
 - Only set proposal to decided when excerpt has been generated and returned. [njohner]
 - Add actions pointing to the meeting and protocol debug views. [njohner]
+- Fix bug with document without file in a dossiertemplate. [njohner]
 - Correct width of subdossier table in dossier details pdf. [njohner]
 - Do not set document date during check-in or cancel. [njohner]
 - Disallow grouping tasks by the checkbox column in list views. [Rotonen]

--- a/opengever/dossier/command.py
+++ b/opengever/dossier/command.py
@@ -10,8 +10,9 @@ class CreateDocumentFromTemplateCommand(CreateDocumentCommand):
     """
 
     def __init__(self, context, template_doc, title, recipient_data=tuple()):
+        data = getattr(template_doc.get_file(), "data", None)
         super(CreateDocumentFromTemplateCommand, self).__init__(
-            context, template_doc.file.filename, template_doc.file.data,
+            context, template_doc.get_filename(), data,
             title=title)
         self.recipient_data = recipient_data
 

--- a/opengever/dossier/tests/test_command.py
+++ b/opengever/dossier/tests/test_command.py
@@ -1,0 +1,26 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from opengever.testing import IntegrationTestCase
+from opengever.dossier.command import CreateDocumentFromTemplateCommand
+
+
+class TestCreateDocumentFromTemplateCommand(IntegrationTestCase):
+
+    def test_create_document_from_template(self):
+        expected_title = 'My title'
+        expected_data = 'Test data'
+        self.login(self.regular_user)
+        template = create(Builder('document').within(self.dossiertemplate).with_dummy_content())
+        command = CreateDocumentFromTemplateCommand(self.dossier, template, expected_title)
+        document = command.execute()
+        self.assertEqual(expected_title, document.title)
+        self.assertEqual(expected_data, document.file.data)
+
+    def test_create_document_from_template_without_file(self):
+        expected_title = 'My title'
+        self.login(self.regular_user)
+        template = create(Builder('document').within(self.dossiertemplate))
+        command = CreateDocumentFromTemplateCommand(self.dossier, template, expected_title)
+        document = command.execute()
+        self.assertEqual(expected_title, document.title)
+        self.assertIsNone(document.file)

--- a/opengever/dossier/tests/test_command.py
+++ b/opengever/dossier/tests/test_command.py
@@ -1,6 +1,8 @@
 from ftw.builder import Builder
 from ftw.builder import create
 from opengever.testing import IntegrationTestCase
+from opengever.dossier.behaviors.dossier import IDossierMarker
+from opengever.dossier.command import CreateDossierFromTemplateCommand
 from opengever.dossier.command import CreateDocumentFromTemplateCommand
 
 
@@ -24,3 +26,13 @@ class TestCreateDocumentFromTemplateCommand(IntegrationTestCase):
         document = command.execute()
         self.assertEqual(expected_title, document.title)
         self.assertIsNone(document.file)
+
+
+class TestCreateDossierFromTemplateCommand(IntegrationTestCase):
+
+    def test_create_dossier_from_template(self):
+        self.login(self.regular_user)
+        command = CreateDossierFromTemplateCommand(self.dossier, self.dossiertemplate)
+        dossier = command.execute()
+        self.assertEqual(self.dossiertemplate.title, dossier.title)
+        self.assertTrue(IDossierMarker.providedBy(dossier))


### PR DESCRIPTION
Creating a dossier from a dossiertemplate would fail when there was a document without a file in the dossiertemplate.

resolves #4828 
