### PR TITLE
Decide proposal only when excerpt is returned

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ---------------------
 
 - Fix global scoped "show more" links for SOLR livesearch [Rotonen]
+- Only set proposal to decided when excerpt has been generated and returned. [njohner]
 - Correct width of subdossier table in dossier details pdf. [njohner]
 - Do not set document date during check-in or cancel. [njohner]
 - Disallow grouping tasks by the checkbox column in list views. [Rotonen]

--- a/opengever/dossier/tests/test_templatefolder.py
+++ b/opengever/dossier/tests/test_templatefolder.py
@@ -196,15 +196,15 @@ class TestDocumentWithTemplateFormWithDocProperties(IntegrationTestCase):
         self.assertEquals(u'Test Docx.docx', document.file.filename)
 
         expected_doc_properties = {
-            'Document.ReferenceNumber': 'Client1 1.1 / 1 / 35',
-            'Document.SequenceNumber': '35',
+            'Document.ReferenceNumber': 'Client1 1.1 / 1 / 37',
+            'Document.SequenceNumber': '37',
             'Dossier.ReferenceNumber': 'Client1 1.1 / 1',
             'Dossier.Title': u'Vertr\xe4ge mit der kantonalen Finanzverwaltung',
             'User.FullName': u'B\xe4rfuss K\xe4thi',
             'User.ID': 'kathi.barfuss',
             'ogg.document.document_date': datetime(2020, 9, 28, 0, 0),
-            'ogg.document.reference_number': 'Client1 1.1 / 1 / 35',
-            'ogg.document.sequence_number': '35',
+            'ogg.document.reference_number': 'Client1 1.1 / 1 / 37',
+            'ogg.document.sequence_number': '37',
             'ogg.document.title': 'Test Docx',
             'ogg.document.version_number': 0,
             'ogg.dossier.reference_number': 'Client1 1.1 / 1',
@@ -254,15 +254,15 @@ class TestDocumentWithTemplateFormWithDocProperties(IntegrationTestCase):
         self.assertEquals(u'Test Docx.docx', document.file.filename)
 
         expected_doc_properties = {
-            'Document.ReferenceNumber': 'Client1 1.1 / 1 / 35',
-            'Document.SequenceNumber': '35',
+            'Document.ReferenceNumber': 'Client1 1.1 / 1 / 37',
+            'Document.SequenceNumber': '37',
             'Dossier.ReferenceNumber': 'Client1 1.1 / 1',
             'Dossier.Title': u'Vertr\xe4ge mit der kantonalen Finanzverwaltung',
             'User.FullName': u'B\xe4rfuss K\xe4thi',
             'User.ID': 'kathi.barfuss',
             'ogg.document.document_date': datetime(2020, 10, 28, 0, 0),
-            'ogg.document.reference_number': 'Client1 1.1 / 1 / 35',
-            'ogg.document.sequence_number': '35',
+            'ogg.document.reference_number': 'Client1 1.1 / 1 / 37',
+            'ogg.document.sequence_number': '37',
             'ogg.document.title': 'Test Docx',
             'ogg.document.version_number': 0,
             'ogg.dossier.reference_number': 'Client1 1.1 / 1',

--- a/opengever/ech0147/tests/test_model.py
+++ b/opengever/ech0147/tests/test_model.py
@@ -73,6 +73,7 @@ class TestMessageModel(IntegrationTestCase):
              u'files/dossier-1/Vertraegsentwurf.docx',
              u'files/dossier-1/Die Buergschaft.eml',
              u'files/dossier-1/testm\xe4il.msg',
+             u'files/dossier-1/Initialvertrag fuer Bearbeitung.docx',
              u'files/Vertraegsentwurf.docx'],
             zipfile.arcnames)
 

--- a/opengever/meeting/browser/meetings/agendaitem.py
+++ b/opengever/meeting/browser/meetings/agendaitem.py
@@ -262,6 +262,7 @@ class AgendaItemsView(BrowserView):
                 view='agenda_items/{}/edit'.format(item.agenda_item_id))
             data['decision_number'] = item.get_decision_number()
             data['is_decided'] = item.is_decided()
+            data['is_completed'] = item.is_completed()
             if item.is_decide_possible():
                 data['decide_link'] = meeting.get_url(
                     view='agenda_items/{}/decide'.format(item.agenda_item_id))

--- a/opengever/meeting/browser/meetings/templates/agendaitems.html
+++ b/opengever/meeting/browser/meetings/templates/agendaitems.html
@@ -1,6 +1,6 @@
 <script id="agendaitemsTemplate" type="text/x-handlebars-template">
   {{#each agendaitems}}
-  <tr class="{{css_class}} word-feature agenda_item" data-uid="{{id}}" id="ai{{id}}">
+  <tr class="{{css_class}} word-feature agenda_item" data-uid="{{id}}" id="ai{{id}}" completed="{{is_completed}}">
     {{#if ../agendalist_editable}}<td class="sortable-handle"></td>{{/if}}
     <td class="title">
 

--- a/opengever/meeting/browser/resources/meeting.js
+++ b/opengever/meeting/browser/resources/meeting.js
@@ -639,7 +639,7 @@
     };
 
     this.updateCloseTransitionActionState = function() {
-      if($('.decide-agenda-item, .revise-agenda-item').length > 0) {
+      if($("[completed='false']").length > 0) {
         $('.close-meeting').addClass('disabled');
         $('.cancel-meeting').hide();
       } else {

--- a/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
@@ -806,7 +806,7 @@ msgstr "Sitzung stornieren"
 #. Default: "The meeting cannot be closed because it has undecided agenda items."
 #: ./opengever/meeting/model/meeting.py
 msgid "label_close_error_has_undecided_agenda_items"
-msgstr "Die Sitzung kann nicht abgeschlossen werden solange noch nicht alle Traktanden abgeschlossen sind."
+msgstr "Die Sitzung kann nicht abgeschlossen werden solange noch nicht alle Traktanden abgeschlossen sind und die Protokollauszüge generiert und zurückgesendet wurden."
 
 #. Default: "Closed meetings"
 #: ./opengever/meeting/browser/committee.py
@@ -1439,7 +1439,7 @@ msgstr "Antrag erfolgreich eingereicht."
 #. Default: "The meeting can only be closed when all agenda items are decided."
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt
 msgid "msg_require_all_agenda_items_decided_for_closing"
-msgstr "Die Sitzung kann erst abgeschlossen werden wenn alle Traktanden abgeschlossen sind."
+msgstr "Die Sitzung kann erst abgeschlossen werden wenn alle Traktanden abgeschlossen sind und die Protokollauszüge generiert und zurückgesendet wurden."
 
 #. Default: "The object was deleted successfully."
 #: ./opengever/meeting/browser/views.py

--- a/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
@@ -808,7 +808,7 @@ msgstr "Annuler la réunion"
 #. Default: "The meeting cannot be closed because it has undecided agenda items."
 #: ./opengever/meeting/model/meeting.py
 msgid "label_close_error_has_undecided_agenda_items"
-msgstr "La réunion ne peut pas être clôturée avant que tous les points de l'ordre du jour ne soient clôturés."
+msgstr "La réunion ne peut pas être clôturée avant que tous les points de l'ordre du jour ne soient clôturés et les extraits de protocol générés et renvoyés comme réponse."
 
 #. Default: "Closed meetings"
 #: ./opengever/meeting/browser/committee.py
@@ -1441,7 +1441,7 @@ msgstr "Proposition soumise avec succès."
 #. Default: "The meeting can only be closed when all agenda items are decided."
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt
 msgid "msg_require_all_agenda_items_decided_for_closing"
-msgstr "La réunion pourra seulement être clôturée quand tous les points de l'ordre du jour seront clôturés."
+msgstr "La réunion pourra seulement être clôturée quand tous les points de l'ordre du jour seront clôturés et les extraits de protocol générés et renvoyés comme réponse."
 
 #. Default: "The object was deleted successfully."
 #: ./opengever/meeting/browser/views.py

--- a/opengever/meeting/model/agendaitem.py
+++ b/opengever/meeting/model/agendaitem.py
@@ -374,6 +374,17 @@ class AgendaItem(Base):
             return False
         return self.proposal.is_decided()
 
+    def is_completed(self):
+        """An ad-hoc agendaitem is completed when it is decided, whereas an
+        agendaitem with proposal needs to be decided, the excerpt generated
+        and returned to the proposal. A paragraph is always considered completed.
+        """
+        if self.is_paragraph:
+            return True
+        if self.has_proposal:
+            return self.is_decided() and self.is_proposal_decided()
+        return self.is_decided()
+
     def revise(self):
         """If the excerpt has been sent back so that the proposal is
         decided, we also have to revise the proposal"""

--- a/opengever/meeting/model/meeting.py
+++ b/opengever/meeting/model/meeting.py
@@ -398,7 +398,7 @@ class Meeting(Base, SQLFormSupport):
             return not agenda_item.is_paragraph
 
         def is_not_decided(agenda_item):
-            return agenda_item.workflow_state != 'decided'
+            return not agenda_item.is_completed()
 
         return filter(is_not_decided, filter(is_not_paragraph, self.agenda_items))
 

--- a/opengever/meeting/model/proposal.py
+++ b/opengever/meeting/model/proposal.py
@@ -345,8 +345,11 @@ class Proposal(Base):
 
         IHistory(self.resolve_submitted_proposal()).append_record(u'revised')
 
+    def is_decided(self):
+        return self.get_state() == self.STATE_DECIDED
+
     def reopen(self, agenda_item):
-        assert self.get_state() == self.STATE_DECIDED
+        assert self.is_decided()
         IHistory(self.resolve_submitted_proposal()).append_record(u'reopened')
 
     def cancel(self, text=None):

--- a/opengever/meeting/tests/test_agendaitem.py
+++ b/opengever/meeting/tests/test_agendaitem.py
@@ -152,7 +152,7 @@ class TestEditAgendaItems(IntegrationTestCase):
 
         agenda_item = self.schedule_proposal(
             self.meeting, self.submitted_proposal)
-        agenda_item.decide()
+        self.decide_agendaitem_generate_and_return_excerpt(agenda_item)
         self.meeting.model.close()
 
         with browser.expect_http_error(code=403):
@@ -294,7 +294,7 @@ class TestReopenAgendaItem(IntegrationTestCase):
         self.login(self.committee_responsible, browser)
         agenda_item = self.schedule_proposal(
             self.meeting, self.submitted_proposal)
-        agenda_item.decide()
+        self.decide_agendaitem_generate_and_return_excerpt(agenda_item)
         self.meeting.model.close()
 
         with browser.expect_http_error(code=403):
@@ -339,7 +339,7 @@ class TestReviseAgendaItem(IntegrationTestCase):
         self.login(self.committee_responsible, browser)
         agenda_item = self.schedule_proposal(
             self.meeting, self.submitted_proposal)
-        agenda_item.decide()
+        self.decide_agendaitem_generate_and_return_excerpt(agenda_item)
         self.meeting.model.close()
 
         with browser.expect_http_error(code=403):

--- a/opengever/meeting/tests/test_agendaitem.py
+++ b/opengever/meeting/tests/test_agendaitem.py
@@ -257,20 +257,6 @@ class TestDecideAgendaItem(IntegrationTestCase):
                      data={'_authenticator': createToken()})
         self.assertEquals(None, browser.json.get('redirectUrl'))
 
-    @browsing
-    def test_closing_proposal_adds_proposalhistory(self, browser):
-        self.login(self.committee_responsible, browser)
-        agenda_item = self.schedule_proposal(
-            self.meeting, self.submitted_word_proposal)
-        agenda_item.close()
-
-        browser.open(self.submitted_word_proposal, view=u'tabbedview_view-overview')
-        entry = browser.css('.answer').first
-
-        self.assertEquals(u'Proposal decided by M\xfcller Fr\xe4nzi (franzi.muller)',
-                          entry.css('h3').first.text)
-        self.assertEquals('answer decided', entry.get('class'))
-
 
 class TestReopenAgendaItem(IntegrationTestCase):
 
@@ -281,7 +267,7 @@ class TestReopenAgendaItem(IntegrationTestCase):
         self.login(self.committee_responsible, browser)
         agenda_item = self.schedule_proposal(
             self.meeting, self.submitted_proposal)
-        agenda_item.decide()
+        self.decide_agendaitem_generate_and_return_excerpt(agenda_item)
 
         browser.open(self.agenda_item_url(agenda_item, 'reopen'),
                      data={'_authenticator': createToken()})
@@ -325,7 +311,7 @@ class TestReviseAgendaItem(IntegrationTestCase):
         self.login(self.committee_responsible, browser)
         agenda_item = self.schedule_proposal(
             self.meeting, self.submitted_proposal)
-        agenda_item.decide()
+        self.decide_agendaitem_generate_and_return_excerpt(agenda_item)
         agenda_item.reopen()
 
         browser.open(self.agenda_item_url(agenda_item, 'revise'),

--- a/opengever/meeting/tests/test_agendaitem_proposal.py
+++ b/opengever/meeting/tests/test_agendaitem_proposal.py
@@ -320,7 +320,7 @@ class TestProposalAgendaItem(IntegrationTestCase):
         self.login(self.committee_responsible, browser)
         agenda_item = self.schedule_proposal(self.meeting,
                                              self.submitted_word_proposal)
-        agenda_item.decide()
+        self.decide_agendaitem_generate_and_return_excerpt(agenda_item)
         self.meeting.model.execute_transition('held-closed')
         self.assertEquals(self.meeting.model.STATE_CLOSED,
                           self.meeting.model.get_state())

--- a/opengever/meeting/tests/test_agendaitem_proposal.py
+++ b/opengever/meeting/tests/test_agendaitem_proposal.py
@@ -1,6 +1,7 @@
 from ftw.testbrowser import browsing
 from opengever.base.role_assignments import RoleAssignmentManager
 from opengever.base.role_assignments import SharingRoleAssignment
+from opengever.meeting.model.proposal import Proposal
 from opengever.testing import IntegrationTestCase
 from opengever.trash.trash import ITrashed
 from plone import api
@@ -40,6 +41,30 @@ class TestProposalAgendaItem(IntegrationTestCase):
 
         self.assertEqual(2, agenda_item.decision_number)
         self.assertEqual(2, self.meeting.model.meeting_number)
+
+    @browsing
+    def test_proposal_is_decided_only_when_excerpt_is_returned(self, browser):
+        self.login(self.committee_responsible, browser)
+        self.assertEqual(Proposal.STATE_SUBMITTED, self.submitted_proposal.get_state())
+
+        agenda_item = self.schedule_proposal(
+            self.meeting, self.submitted_proposal)
+        self.assertEqual(Proposal.STATE_SCHEDULED, self.submitted_proposal.get_state())
+
+        browser.open(self.agenda_item_url(agenda_item, 'decide'),
+                     data={'_authenticator': createToken()})
+        self.assertEqual(Proposal.STATE_SCHEDULED, self.submitted_proposal.get_state())
+
+        browser.open(self.meeting, view='agenda_items/list')
+        generate_excerpt_link = browser.json['items'][0]['generate_excerpt_link']
+        browser.open(generate_excerpt_link, send_authenticator=True,
+                     data={'excerpt_title': 'Excerption \xc3\x84nderungen'})
+        self.assertEqual(Proposal.STATE_SCHEDULED, self.submitted_proposal.get_state())
+
+        browser.open(self.meeting, view='agenda_items/list')
+        return_excerpt_link = browser.json[u"items"][0]['excerpts'][0]['return_link']
+        browser.open(return_excerpt_link, send_authenticator=True)
+        self.assertEqual(Proposal.STATE_DECIDED, self.submitted_proposal.get_state())
 
     @browsing
     def test_delete_agenda_item_does_not_trash_proposal_document(self, browser):
@@ -202,7 +227,7 @@ class TestProposalAgendaItem(IntegrationTestCase):
                   u'messageClass': u'info'}]},
             browser.json)
 
-        self.assertEquals(proposal_model.STATE_DECIDED, proposal_model.get_state())
+        self.assertEquals(proposal_model.STATE_SCHEDULED, proposal_model.get_state())
         self.assertIsNone(self.get_checkout_manager(document).get_checked_out_by())
 
     @browsing

--- a/opengever/meeting/tests/test_docproperties.py
+++ b/opengever/meeting/tests/test_docproperties.py
@@ -72,7 +72,8 @@ class TestMeetingDocxProperties(IntegrationTestCase):
 
     def test_decided_proposal_document(self):
         with self.login(self.committee_responsible):
-            self.schedule_proposal(self.meeting, self.submitted_word_proposal).decide()
+            agendaitem = self.schedule_proposal(self.meeting, self.submitted_word_proposal)
+            self.decide_agendaitem_generate_and_return_excerpt(agendaitem)
 
         with self.login(self.dossier_responsible):
             self.assertEquals(
@@ -107,12 +108,11 @@ class TestMeetingDocxProperties(IntegrationTestCase):
                  'ogg.meeting.agenda_item_number': '1.',
                  'ogg.meeting.proposal_title': '\xc3\x84nderungen am Personalreglement',
                  'ogg.meeting.proposal_description': '',
-                 'ogg.meeting.proposal_state': 'Decided'},
+                 'ogg.meeting.proposal_state': 'Scheduled'},
                 get_doc_properties(meeting_dossier_excerpt))
 
             with self.observe_children(self.dossier) as children:
-                self.submitted_word_proposal.load_model().return_excerpt(
-                    meeting_dossier_excerpt)
+                agenda_item.return_excerpt(meeting_dossier_excerpt)
 
             case_dossier_excerpt, = children['added']
 

--- a/opengever/meeting/tests/test_meeting_zipexport.py
+++ b/opengever/meeting/tests/test_meeting_zipexport.py
@@ -224,9 +224,8 @@ class TestMeetingZipExportView(IntegrationTestCase):
             self.schedule_ad_hoc(
                 self.meeting, u'Ad-hoc Traktand\xfem'
             ).decide()
-        self.schedule_proposal(
-            self.meeting, self.submitted_word_proposal
-        ).decide()
+        agenda_item = self.schedule_proposal(self.meeting, self.submitted_word_proposal)
+        self.decide_agendaitem_generate_and_return_excerpt(agenda_item)
         with freeze(localized_datetime(2017, 12, 14)):
             self.meeting.model.close()
 

--- a/opengever/meeting/tests/test_proposal.py
+++ b/opengever/meeting/tests/test_proposal.py
@@ -930,7 +930,7 @@ class TestProposal(IntegrationTestCase):
         self.assertFalse(browser.reload().find(button_label))
 
         with self.login(self.committee_responsible):
-            agenda_item.decide()
+            self.decide_agendaitem_generate_and_return_excerpt(agenda_item, 'Excerpt')
             self.assertEquals('decided', self.submitted_word_proposal.get_state().title)
 
         self.assertEquals('decided', self.word_proposal.get_state().title)
@@ -944,10 +944,12 @@ class TestProposal(IntegrationTestCase):
         self.assertEquals(
             str(self.word_proposal.get_committee().load_model().committee_id),
             browser.find('Committee').value)
-        self.assertEquals(
-            [rel.to_path for rel in self.word_proposal.relatedItems],
-            [node.value for node
-             in browser.find('Attachments').css('input[type=checkbox]')])
+
+        expected_attachements = [rel.to_path for rel in self.word_proposal.relatedItems]
+        expected_attachements.append(self.word_proposal.get_excerpt().absolute_url_path())
+        self.assertItemsEqual(
+            expected_attachements,
+            [node.value for node in browser.find('Attachments').css('input[type=checkbox]')])
 
         self.assertIn(
             self.word_proposal.get_proposal_document().UID(),
@@ -974,7 +976,7 @@ class TestProposal(IntegrationTestCase):
              ['State', 'Pending'],
              ['Decision number', ''],
              ['Predecessor', u'\xc4nderungen am Personalreglement'],
-             ['Attachments', u'Vertr\xe4gsentwurf'],
+             ['Attachments', u'Excerpt Vertr\xe4gsentwurf'],
              ['Excerpt', '']],
             browser.css('table.listing').first.lists())
 
@@ -994,7 +996,7 @@ class TestProposal(IntegrationTestCase):
              ['Decision number', '2016 / 2'],
              ['Successors', u'\xc4nderungen am Personalreglement zur Nachpr\xfcfung'],
              ['Attachments', u'Vertr\xe4gsentwurf'],
-             ['Excerpt', '']],
+             ['Excerpt', 'Excerpt']],
             browser.css('table.listing').first.lists())
 
     @browsing

--- a/opengever/meeting/tests/test_proposalhistory.py
+++ b/opengever/meeting/tests/test_proposalhistory.py
@@ -2,12 +2,12 @@ from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browser as default_browser
 from ftw.testbrowser import browsing
-from opengever.dossier.interfaces import IDossierResolveProperties
 from opengever.meeting.interfaces import IHistory
 from opengever.testing import IntegrationTestCase
 from plone import api
 from plone.namedfile.file import NamedBlobFile
 from plone.protect import createToken
+from plone.uuid.interfaces import IUUID
 
 
 class TestIntegrationProposalHistory(IntegrationTestCase):
@@ -286,11 +286,19 @@ class TestIntegrationProposalHistory(IntegrationTestCase):
         self.login(self.meeting_user, browser)
         scheduling_url = self.meeting.model.get_url(view='unscheduled_proposals/1/schedule')
         deciding_url = self.meeting.model.get_url(view='agenda_items/2/decide')
+        generate_excerpt_url = self.meeting.model.get_url(view='agenda_items/2/generate_excerpt?excerpt_title=bla')
+        return_excerpt_url = self.meeting.model.get_url(view='agenda_items/2/return_excerpt?document={}')
         reopening_url = self.meeting.model.get_url(view='agenda_items/2/reopen')
         with self.login(self.committee_responsible, browser):
             browser.open(scheduling_url)
             browser.open(deciding_url, data={'_authenticator': createToken()})
+            browser.open(generate_excerpt_url, data={'_authenticator': createToken()})
+            agenda_item = self.meeting.model.agenda_items[0]
+            excerpt_document = agenda_item.get_excerpt_documents()[0]
+            browser.open(return_excerpt_url.format(IUUID(excerpt_document)), data={'_authenticator': createToken()})
+
             browser.open(reopening_url, data={'_authenticator': createToken()})
+
         self.assert_proposal_history_records(
             u'Proposal reopened by M\xfcller Fr\xe4nzi (franzi.muller)',
             self.proposal,
@@ -303,9 +311,16 @@ class TestIntegrationProposalHistory(IntegrationTestCase):
         self.login(self.meeting_user, browser)
         scheduling_url = self.meeting.model.get_url(view='unscheduled_proposals/1/schedule')
         deciding_url = self.meeting.model.get_url(view='agenda_items/2/decide')
+        generate_excerpt_url = self.meeting.model.get_url(view='agenda_items/2/generate_excerpt?excerpt_title=bla')
+        return_excerpt_url = self.meeting.model.get_url(view='agenda_items/2/return_excerpt?document={}')
         with self.login(self.committee_responsible, browser):
             browser.open(scheduling_url)
             browser.open(deciding_url, data={'_authenticator': createToken()})
+            browser.open(generate_excerpt_url, data={'_authenticator': createToken()})
+            agenda_item = self.meeting.model.agenda_items[0]
+            excerpt_document = agenda_item.get_excerpt_documents()[0]
+            browser.open(return_excerpt_url.format(IUUID(excerpt_document)), data={'_authenticator': createToken()})
+
         self.assert_proposal_history_records(
             u'Proposal decided by M\xfcller Fr\xe4nzi (franzi.muller)',
             self.proposal,
@@ -318,13 +333,20 @@ class TestIntegrationProposalHistory(IntegrationTestCase):
         self.login(self.meeting_user, browser)
         scheduling_url = self.meeting.model.get_url(view='unscheduled_proposals/1/schedule')
         deciding_url = self.meeting.model.get_url(view='agenda_items/2/decide')
+        generate_excerpt_url = self.meeting.model.get_url(view='agenda_items/2/generate_excerpt?excerpt_title=bla')
+        return_excerpt_url = self.meeting.model.get_url(view='agenda_items/2/return_excerpt?document={}')
         reopening_url = self.meeting.model.get_url(view='agenda_items/2/reopen')
         revising_url = self.meeting.model.get_url(view='agenda_items/2/revise')
         with self.login(self.committee_responsible, browser):
             browser.open(scheduling_url)
             browser.open(deciding_url, data={'_authenticator': createToken()})
+            browser.open(generate_excerpt_url, data={'_authenticator': createToken()})
+            agenda_item = self.meeting.model.agenda_items[0]
+            excerpt_document = agenda_item.get_excerpt_documents()[0]
+            browser.open(return_excerpt_url.format(IUUID(excerpt_document)), data={'_authenticator': createToken()})
             browser.open(reopening_url, data={'_authenticator': createToken()})
             browser.open(revising_url, data={'_authenticator': createToken()})
+
         self.assert_proposal_history_records(
             u'Proposal revised by M\xfcller Fr\xe4nzi (franzi.muller)',
             self.proposal,

--- a/opengever/meeting/tests/test_protocol.py
+++ b/opengever/meeting/tests/test_protocol.py
@@ -127,7 +127,9 @@ class TestProtocol(IntegrationTestCase):
     @browsing
     def test_protocol_is_generated_when_closing_meetings(self, browser):
         self.login(self.committee_responsible, browser)
-        self.schedule_proposal(self.meeting, self.submitted_word_proposal).decide()
+        agenda_item = self.schedule_proposal(self.meeting, self.submitted_word_proposal)
+        self.decide_agendaitem_generate_and_return_excerpt(agenda_item)
+
         meeting = self.meeting.model
 
         self.assertIsNone(meeting.protocol_document)

--- a/opengever/oneoffixx/tests/assets/oneoffixx_connect_xml.txt
+++ b/opengever/oneoffixx/tests/assets/oneoffixx_connect_xml.txt
@@ -14,15 +14,15 @@
         <Arguments>
           <Interface Name="OneGovGEVER">
             <Node Id="ogg.document.title">A doc</Node>
-            <Node Id="ogg.document.reference_number">Client1 1.1 / 1 / 35</Node>
-            <Node Id="ogg.document.sequence_number">35</Node>
+            <Node Id="ogg.document.reference_number">Client1 1.1 / 1 / 37</Node>
+            <Node Id="ogg.document.sequence_number">37</Node>
           </Interface>
         </Arguments>
       </Function>
       <Function name="MetaData" id="c364b495-7176-4ce2-9f7c-e71f302b8096">
         <Value key="ogg.document.title" type="string">A doc</Value>
-        <Value key="ogg.document.reference_number" type="string">Client1 1.1 / 1 / 35</Value>
-        <Value key="ogg.document.sequence_number" type="string">35</Value>
+        <Value key="ogg.document.reference_number" type="string">Client1 1.1 / 1 / 37</Value>
+        <Value key="ogg.document.sequence_number" type="string">37</Value>
       </Function>
       <Commands>
         <Command Name="DefaultProcess">

--- a/opengever/private/tests/test_reference_number.py
+++ b/opengever/private/tests/test_reference_number.py
@@ -138,7 +138,7 @@ class TestPrivateReferenceNumber(IntegrationTestCase):
         self.login(self.regular_user, browser)
         browser.open(self.private_document)
 
-        expected_reference_number = 'P Client1 kathi-barfuss / 1 / 33'
+        expected_reference_number = 'P Client1 kathi-barfuss / 1 / 35'
         found_reference_number = browser.css('.referenceNumber .value').text[0]
 
         self.assertEqual(found_reference_number, expected_reference_number)

--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -1297,6 +1297,10 @@ class OpengeverContentFixture(object):
             )
         for agenda_item in self.decided_meeting.agenda_items:
             agenda_item.close()
+            if agenda_item.has_proposal:
+                excerpt = agenda_item.generate_excerpt(agenda_item.get_title())
+                agenda_item.return_excerpt(excerpt)
+
         self.decided_meeting.close()
 
         closed_meeting_dossier = self.register(

--- a/opengever/testing/integration_test_case.py
+++ b/opengever/testing/integration_test_case.py
@@ -568,6 +568,14 @@ class IntegrationTestCase(TestCase):
         agenda_item = AgendaItem.query.order_by(desc('id')).first()
         return agenda_item
 
+    def decide_agendaitem_generate_and_return_excerpt(self, agendaitem, excerpt_title=None):
+        """Meeting: decide an agendaitem, then generate the excerpt and
+        return it to the dossier. This will set the proposal to decided.
+        """
+        agendaitem.decide()
+        excerpt = agendaitem.generate_excerpt(excerpt_title or agendaitem.get_title())
+        agendaitem.return_excerpt(excerpt)
+
     def as_relation_value(self, obj):
         return RelationValue(getUtility(IIntIds).getId(obj))
 


### PR DESCRIPTION
When an agendaitem is decided, the proposal should not be set to decided yet, as the decision has not been communicated yet (excerpt returned). We now only set the proposal to decided when the excerpt has been generated and returned.

Closing a meeting now requires that not only all agendaitems are decided, but also that the excerpts have been generated and returned for the agentaitems with proposals.

resolves #4331 