### PR TITLE
Prevent replacing files on proposal templates with non-.docx files via quickupload

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -10,6 +10,7 @@ Changelog
 - Only set proposal to decided when excerpt has been generated and returned. [njohner]
 - Add actions pointing to the meeting and protocol debug views. [njohner]
 - Fix bug with document without file in a dossiertemplate. [njohner]
+- Prevent replacing files on proposal templates with non-.docx files via quickupload. [Rotonen]
 - Correct width of subdossier table in dossier details pdf. [njohner]
 - Do not set document date during check-in or cancel. [njohner]
 - Disallow grouping tasks by the checkbox column in list views. [Rotonen]

--- a/opengever/document/quick_upload.py
+++ b/opengever/document/quick_upload.py
@@ -3,6 +3,7 @@ from collective.quickupload.interfaces import IQuickUploadFileFactory
 from opengever.document import _
 from opengever.document.document import IDocumentSchema
 from opengever.document.interfaces import ICheckinCheckoutManager
+from opengever.meeting.proposaltemplate import IProposalTemplate
 from zExceptions import Unauthorized
 from zope.component import adapter
 from zope.component import getMultiAdapter
@@ -28,7 +29,7 @@ class QuickUploadFileUpdater(object):
         if not self.is_upload_allowed():
             raise Unauthorized
 
-        if self.is_proposal_upload():
+        if self.is_proposal_upload() or self.is_proposal_template_upload():
             if not os.path.splitext(self.get_file_name(filename))[1].lower() == '.docx':
                 return {
                     'error': translate(_(
@@ -54,6 +55,9 @@ class QuickUploadFileUpdater(object):
     def is_proposal_upload(self):
         """The upload form context can be, for example, a Dossier."""
         return getattr(self.context, 'is_inside_a_proposal', lambda: False)()
+
+    def is_proposal_template_upload(self):
+        return IProposalTemplate.providedBy(self.context)
 
     def get_file_name(self, org_filename):
         filename, ext = os.path.splitext(org_filename)

--- a/opengever/meeting/tests/test_proposal_template.py
+++ b/opengever/meeting/tests/test_proposal_template.py
@@ -3,6 +3,7 @@ from ftw.testbrowser.pages import factoriesmenu
 from ftw.testbrowser.pages import statusmessages
 from opengever.meeting.command import MIME_DOCX
 from opengever.testing import IntegrationTestCase
+from StringIO import StringIO
 
 
 class TestProposalTemplate(IntegrationTestCase):
@@ -37,3 +38,24 @@ class TestProposalTemplate(IntegrationTestCase):
         self.assertEquals(
             ['Only word files (.docx) can be added here.'],
             browser.css('#formfield-form-widgets-file .error').text)
+
+    @browsing
+    def test_proposal_template_document_must_be_docx_via_quickupload(self, browser):
+        self.login(self.administrator, browser)
+        filename = 'foo.xlsx'
+        headers = {
+            'X-File-Name': filename,
+            'Content-Type': 'application/octet-stream',
+            'X-Requested-With': 'XMLHttpRequest',
+            }
+        fileish = StringIO('foobar')
+        self.checkout_document(self.proposal_template)
+        expected_error = {u'error': u"It's not possible to have non-.docx documents as proposal documents."}
+        browser.open(
+            self.proposal_template,
+            data={'file': fileish},
+            headers=headers,
+            view='@@quick_upload_file?qqfile={}'.format(filename),
+            )
+        fileish.close()
+        self.assertEqual(browser.json, expected_error)


### PR DESCRIPTION
* It does not seem to be possible to remove a file from a proposal template
* The form upload check was already in place
* Added a check to the file quickuploads for checking if the context is a proposal template

Closes #4642