### PR TITLE
Fix global scoped "show more" links for SOLR livesearch

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2018.5.0 (unreleased)
 ---------------------
 
+- Fix global scoped "show more" links for SOLR livesearch [Rotonen]
 - Correct width of subdossier table in dossier details pdf. [njohner]
 - Do not set document date during check-in or cancel. [njohner]
 - Disallow grouping tasks by the checkbox column in list views. [Rotonen]

--- a/opengever/base/browser/livesearch.py
+++ b/opengever/base/browser/livesearch.py
@@ -5,6 +5,7 @@ from ftw.solr.query import make_query
 from opengever.base.solr import OGSolrContentListing
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone import PloneMessageFactory as pmf
+from Products.CMFPlone.browser.navtree import getNavigationRoot
 from Products.CMFPlone.utils import normalizeString
 from Products.CMFPlone.utils import safe_unicode
 from Products.Five.browser import BrowserView
@@ -44,7 +45,7 @@ class LiveSearchReplyView(BrowserView):
             self.search_term = self.search_term.decode('utf-8')
 
         self.limit = int(self.request.form.get('limit', 10))
-        self.path = self.request.form.get('path', None)
+        self.path = self.request.form.get('path', getNavigationRoot(self.context))
         results = self.results()
         return self.render_results(results)
 

--- a/opengever/base/browser/livesearch.py
+++ b/opengever/base/browser/livesearch.py
@@ -43,7 +43,7 @@ class LiveSearchReplyView(BrowserView):
         if not isinstance(self.search_term, unicode):
             self.search_term = self.search_term.decode('utf-8')
 
-        self.limit = self.request.form.get('limit', 10)
+        self.limit = int(self.request.form.get('limit', 10))
         self.path = self.request.form.get('path', None)
         results = self.results()
         return self.render_results(results)

--- a/opengever/base/tests/test_search.py
+++ b/opengever/base/tests/test_search.py
@@ -329,3 +329,20 @@ class TestSolrSearch(IntegrationTestCase):
         self.request.processInputs()
         self.search.results()
         self.assertFalse(self.solr.search.called)
+
+    @browsing
+    def test_show_more_is_not_rendered_per_default(self, browser):
+        self.login(self.regular_user, browser)
+        browser.open(self.portal, view='@@livesearch_reply?q=test')
+        self.assertIsNone(browser.find('Show all items'))
+
+    @browsing
+    def test_path_for_show_more_is_not_none(self, browser):
+        self.login(self.regular_user, browser)
+        browser.open(self.portal, view='@@livesearch_reply?q=test&limit=2')
+        all_items_link = browser.find('Show all items')
+        self.assertIsNotNone(all_items_link)
+        self.assertEqual(
+            '<a href="@@search?SearchableText=test&amp;path=/plone" style="font-weight:normal">Show all items</a>',
+            all_items_link.outerHTML,
+            )


### PR DESCRIPTION
* Fixed result limits for SOLR livesearch
* Fixed paths for global scoped SOLR livesearch 'show more' links

/cc @phgross we'll backport this as well?

Closes #4838

Backport to `2018.4-stable` needed