### PR TITLE
Register bmp as editable by officeconnector type.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ---------------------
 
 - Fix tree portlet header styling for IE11. [Kevin Bieri]
+- Register bmp as editable by officeconnector. [phgross]
 - Correct info messages in meetings. [njohner]
 - Fix global scoped "show more" links for SOLR livesearch [Rotonen]
 - Only set proposal to decided when excerpt has been generated and returned. [njohner]

--- a/opengever/core/profiles/default/registry.xml
+++ b/opengever/core/profiles/default/registry.xml
@@ -122,6 +122,7 @@
       <element>image/tiff</element>
       <element>image/gif</element>
       <element>image/png</element>
+      <element>image/bmp</element>
 
       <!-- MS Visio -->
       <element>application/vnd.visio</element>

--- a/opengever/core/upgrades/20180907161827_extend_officeconnector_editable_file_types/registry.xml
+++ b/opengever/core/upgrades/20180907161827_extend_officeconnector_editable_file_types/registry.xml
@@ -1,0 +1,15 @@
+<registry>
+
+  <!-- OFFICECONNECTOR -->
+  <records interface="opengever.officeconnector.interfaces.IOfficeConnectorSettings" />
+  <record
+      interface="opengever.officeconnector.interfaces.IOfficeConnectorSettings"
+      field="officeconnector_editable_types">
+    <value purge="False">
+
+      <element>image/bmp</element>
+
+    </value>
+  </record>
+
+</registry>

--- a/opengever/core/upgrades/20180907161827_extend_officeconnector_editable_file_types/upgrade.py
+++ b/opengever/core/upgrades/20180907161827_extend_officeconnector_editable_file_types/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class ExtendOfficeconnectorEditableFileTypes(UpgradeStep):
+    """Extend officeconnector editable file types.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()


### PR DESCRIPTION
See https://github.com/4teamwork/OfficeConnector/pull/296

Backport to `2018.4-stable` 