### PR TITLE
Add missing mimetype for wmf files.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2018.5.0 (unreleased)
 ---------------------
 
+- Add missing mimetype for wmf files. [phgross]
 - Fix tree portlet header styling for IE11. [Kevin Bieri]
 - Register bmp as editable by officeconnector. [phgross]
 - Fix batching links on the solr search. [phgross]

--- a/opengever/core/upgrades/20180911140637_fix_contenttype_for_ms_publisher_files/upgrade.py
+++ b/opengever/core/upgrades/20180911140637_fix_contenttype_for_ms_publisher_files/upgrade.py
@@ -8,9 +8,12 @@ from plone import api
 MS_PUBLISHER_EXTENSION = '.pub'
 MS_PUBLISHER_MIMETYPE = 'application/x-mspublisher'
 
+WMF_EXTENSION = '.wmf'
+WMF_MIMETYPE = 'image/x-wmf'
+
 
 class FixContenttypeForMSPublisherFiles(UpgradeStep):
-    """Fix contenttype for MS Publisher files.
+    """Fix contenttype for MS Publisher and WMF files.
     """
 
     def __call__(self):
@@ -20,8 +23,8 @@ class FixContenttypeForMSPublisherFiles(UpgradeStep):
         brains = catalog.unrestrictedSearchResults(
             {'object_provides': IDocumentSchema.__identifier__})
 
-        for brain in ProgressLogger('Fix contettype for MS Publisher files',
-                                    brains):
+        for brain in ProgressLogger(
+                'Fix contettype for MS Publisher and wmf files', brains):
             if brain.getContentType == 'application/octet-stream':
                 obj = brain.getObject()
                 if not obj.file:
@@ -30,4 +33,8 @@ class FixContenttypeForMSPublisherFiles(UpgradeStep):
                 filename, ext = splitext(obj.file.filename)
                 if ext == MS_PUBLISHER_EXTENSION:
                     obj.file.contentType = MS_PUBLISHER_MIMETYPE
+                    obj.reindexObject()
+
+                if ext == WMF_EXTENSION:
+                    obj.file.contentType = WMF_MIMETYPE
                     obj.reindexObject()

--- a/opengever/document/extra_mimetypes.py
+++ b/opengever/document/extra_mimetypes.py
@@ -128,6 +128,9 @@ ADDITIONAL_TYPES = [
     # MS Powerpoint Slideshow (Macro Enabled)
     ('application/vnd.ms-powerpoint.slideshow.macroEnabled.12', '.ppsm'),
 
+    # Windows Metafile
+    ('image/x-wmf', '.wmf'),
+
     # Apple Keynote
     ('application/x-iwork-keynote-sffkey', '.key'),
 


### PR DESCRIPTION
This fixes the icon for wmf files (introduced by 94f1ba126651d7ea8f428675e6126ae6075f4fbc).

Instead of writing a new upgradestep, i touched an existing one which does the same for MS Publisher files, to avoid doubled run time.

Backport to `2018.4-stable` 