### PR TITLE
Support adding task via REST API

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2018.5.0 (unreleased)
 ---------------------
 
+- Support adding tasks via REST API. [phgross]
 - Correct info messages in meetings. [njohner]
 - Add proposal tabs to repository folders. [Rotonen]
 - Fix global scoped "show more" links for SOLR livesearch [Rotonen]

--- a/opengever/activity/tests/test_handlers.py
+++ b/opengever/activity/tests/test_handlers.py
@@ -6,6 +6,7 @@ from opengever.core.testing import OPENGEVER_FUNCTIONAL_ACTIVITY_LAYER
 from opengever.testing import FunctionalTestCase
 from plone import api
 from plone.app.testing import TEST_USER_ID
+from sqlalchemy import desc
 from zope.event import notify
 
 
@@ -23,7 +24,7 @@ class TestNotificationEventHandler(FunctionalTestCase):
                                   {'en': 'Lorem ipsum'})
         notify(event)
 
-        activity = Activity.query.first()
+        activity = Activity.query.order_by(desc(Activity.id)).first()
         self.assertEquals(task, activity.resource.oguid.resolve_object())
         self.assertEquals('task-transition-open-in-progress', activity.kind)
         self.assertEquals('Task accepted by Test user.', activity.summary)

--- a/opengever/inbox/forwarding.py
+++ b/opengever/inbox/forwarding.py
@@ -3,7 +3,6 @@ from Acquisition import aq_parent
 from datetime import datetime
 from ftw.keywordwidget.widget import KeywordFieldWidget
 from opengever.inbox import _
-from opengever.inbox.activities import ForwardingAddedActivity
 from opengever.ogds.base.sources import AllUsersInboxesAndTeamsSourceBinder
 from opengever.ogds.base.utils import get_current_org_unit
 from opengever.ogds.base.utils import get_ou_selector
@@ -174,15 +173,7 @@ class ForwardingAddForm(add.DefaultAddForm):
     def createAndAdd(self, data):
         update_reponsible_field_data(data)
 
-        forwarding = super(ForwardingAddForm, self).createAndAdd(data=data)
-
-        ForwardingAddedActivity(
-            forwarding,
-            self.request,
-            self.context,
-            ).record()
-
-        return forwarding
+        return super(ForwardingAddForm, self).createAndAdd(data=data)
 
 
 class ForwardingAddView(add.DefaultAddView):

--- a/opengever/inbox/tests/test_activities.py
+++ b/opengever/inbox/tests/test_activities.py
@@ -79,8 +79,6 @@ class TestForwardingActivites(FunctionalTestCase):
                             .having(responsible=TEST_USER_ID,
                                     issuer='hugo.boss')
                             .within(inbox))
-        self.center.add_task_responsible(forwarding, TEST_USER_ID)
-        self.center.add_task_issuer(forwarding, 'hugo.boss')
 
         successor = accept_forwarding_with_successor(
             self.portal, forwarding.oguid.id,
@@ -97,8 +95,7 @@ class TestForwardingActivites(FunctionalTestCase):
         self.assertItemsEqual(
             [(u'test_user_1_', u'task_responsible'),
              (u'inbox:org-unit-1', u'task_issuer')],
-            [(subscription.watcher.actorid, subscription.role)
-             for subscription in successor_resource.subscriptions])
+            [(subscription.watcher.actorid, subscription.role) for subscription in successor_resource.subscriptions])
 
     @browsing
     def test_accepting_and_assign_forwarding_with_successor_and__updated_responsibles(self, browser):

--- a/opengever/inbox/tests/test_inbox_assign.py
+++ b/opengever/inbox/tests/test_inbox_assign.py
@@ -7,6 +7,7 @@ from opengever.core.testing import OPENGEVER_FUNCTIONAL_ACTIVITY_LAYER
 from opengever.task.adapters import IResponseContainer
 from opengever.testing import FunctionalTestCase
 from Products.CMFCore.utils import getToolByName
+from sqlalchemy import desc
 
 
 class TestAssingForwarding(FunctionalTestCase):
@@ -83,9 +84,9 @@ class TestAssingForwarding(FunctionalTestCase):
         self.assertEquals('inbox:org-unit-2',
                           self.forwarding.get_sql_object().responsible)
 
-        self.assertEquals(1, len(Activity.query.all()))
-        self.assertEquals('forwarding-transition-reassign-refused',
-                          Activity.query.all()[0].kind)
+        self.assertEquals(
+            'forwarding-transition-reassign-refused',
+            Activity.query.order_by(desc(Activity.id)).first().kind)
 
     def assign_forwarding(self, new_client, response, browser=default_browser):
         browser.login().open(self.forwarding)

--- a/opengever/ogds/base/sources.py
+++ b/opengever/ogds/base/sources.py
@@ -226,19 +226,13 @@ class AllUsersInboxesAndTeamsSource(BaseQuerySoure):
         return SimpleTerm(value, token, title)
 
     def getTermByToken(self, token):
-        """ Should raise LookupError if term could not be found.
+        """Should raise LookupError if term could not be found.
         Check zope.schema.interfaces.IVocabularyTokenized
         """
         orgunit_id, userid = (None, None)
 
         if not token:
             raise LookupError('A token "unit_id:userid" is required.')
-
-        try:
-            orgunit_id, userid = token.split(':', 1)
-        except ValueError:
-            raise LookupError('A token "unit_id:userid" is required.')
-
         try:
             value = token
             return self.getTerm(value)

--- a/opengever/task/browser/forms.py
+++ b/opengever/task/browser/forms.py
@@ -99,8 +99,6 @@ class TaskAddForm(DefaultAddForm):
         notify(ObjectCreatedEvent(task))
         task_form.add(task)
 
-        activity = TaskAddedActivity(task, self.request, self.context)
-        activity.record()
         return task
 
     def _set_immediate_view(self, created):

--- a/opengever/task/configure.zcml
+++ b/opengever/task/configure.zcml
@@ -185,6 +185,12 @@
       handler=".localroles.set_roles_after_modifying"
       />
 
+  <subscriber
+      for="opengever.task.task.ITask
+           zope.lifecycleevent.interfaces.IObjectAddedEvent"
+      handler=".handlers.record_added_activity"
+      />
+
   <adapter
       for="opengever.task.task.ITask"
       factory=".yearfolderstorer.YearfolderStorer"

--- a/opengever/task/tests/test_activities.py
+++ b/opengever/task/tests/test_activities.py
@@ -14,6 +14,7 @@ from opengever.core.testing import OPENGEVER_FUNCTIONAL_ACTIVITY_LAYER
 from opengever.task.browser.accept.utils import accept_task_with_successor
 from opengever.testing import FunctionalTestCase
 from plone.app.testing import TEST_USER_ID
+from sqlalchemy import desc
 import email
 
 
@@ -44,7 +45,7 @@ class TestTaskActivites(FunctionalTestCase):
 
         browser.css('#form-buttons-save').first.click()
 
-        activity = Activity.query.one()
+        activity =  Activity.query.one()
         self.assertEquals('task-added', activity.kind)
         self.assertEquals(u'Abkl\xe4rung Fall Meier', activity.title)
         self.assertEquals(u'New task opened by Test User', activity.summary)
@@ -94,7 +95,7 @@ class TestTaskActivites(FunctionalTestCase):
         browser.fill({'Response': u'Wird n\xe4chste Woche erledigt.'})
         browser.css('#form-buttons-save').first.click()
 
-        activity = Activity.query.one()
+        activity = Activity.query.order_by(desc(Activity.id)).first()
         self.assertEquals(u'task-transition-open-in-progress', activity.kind)
         self.assertEquals(u'Abkl\xe4rung Fall Meier', activity.title)
         self.assertEquals(
@@ -114,7 +115,7 @@ class TestTaskActivites(FunctionalTestCase):
         browser.fill({'Response': u'Wird n\xe4chste Woche erledigt.'})
         browser.find('Save').click()
 
-        activity = Activity.query.one()
+        activity = Activity.query.order_by(desc(Activity.id)).first()
         self.assertEquals(u'task-commented', activity.kind)
         self.assertEquals(u'Abkl\xe4rung Fall Meier', activity.title)
         self.assertEquals(
@@ -136,7 +137,7 @@ class TestTaskActivites(FunctionalTestCase):
         browser.fill({'Response': u'Wird n\xe4chste Woche erledigt.'})
         browser.css('#form-buttons-save').first.click()
 
-        activity = Activity.query.one()
+        activity = Activity.query.order_by(desc(Activity.id)).first()
         self.assertEquals(u'task-transition-open-in-progress', activity.kind)
         self.assertEquals('hugo.boss', activity.actor_id)
 
@@ -152,7 +153,7 @@ class TestTaskActivites(FunctionalTestCase):
         browser.fill({'Response': u'Ist erledigt.'})
         browser.css('#form-buttons-save').first.click()
 
-        activity = Activity.query.one()
+        activity = Activity.query.order_by(desc(Activity.id)).first()
         self.assertEquals(u'task-transition-in-progress-resolved', activity.kind)
         self.assertEquals(u'Abkl\xe4rung Fall Meier', activity.title)
         self.assertEquals(
@@ -171,7 +172,7 @@ class TestTaskActivites(FunctionalTestCase):
         browser.fill({'Response': u'Wird \xfcbersprungen.'})
         browser.css('#form-buttons-save').first.click()
 
-        activity = Activity.query.one()
+        activity = Activity.query.order_by(desc(Activity.id)).first()
         self.assertEquals(u'task-transition-rejected-skipped', activity.kind)
         self.assertEquals(u'Abkl\xe4rung Fall Meier', activity.title)
         self.assertEquals(
@@ -195,7 +196,7 @@ class TestTaskActivites(FunctionalTestCase):
             'New Deadline': '20.03.2016',
             'Response': u'nicht dring\xe4nd'}).save()
 
-        activity = Activity.query.one()
+        activity = Activity.query.order_by(desc(Activity.id)).first()
         self.assertEquals(u'task-transition-modify-deadline', activity.kind)
         self.assertEquals(u'Abkl\xe4rung Fall Meier', activity.title)
         self.assertEquals(
@@ -224,7 +225,7 @@ class TestTaskActivites(FunctionalTestCase):
 
         browser.css('#form-buttons-save').first.click()
 
-        activity = Activity.query.one()
+        activity = Activity.query.order_by(desc(Activity.id)).first()
         self.assertEquals('task-added', activity.kind)
         self.assertEquals(u'Abkl\xe4rung Fall Meier', activity.title)
         self.assertEquals(u'New task opened by Test User', activity.summary)
@@ -241,7 +242,7 @@ class TestTaskActivites(FunctionalTestCase):
         browser.fill({'Title': u'Letter to peter'})
         browser.css('#form-buttons-save').first.click()
 
-        activity = Activity.query.one()
+        activity = Activity.query.order_by(desc(Activity.id)).first()
         self.assertEquals(u'transition-add-document', activity.kind)
 
     @browsing
@@ -262,7 +263,7 @@ class TestTaskActivites(FunctionalTestCase):
         # fill medatata step and submit
         browser.find('Save').click()
 
-        activity = Activity.query.one()
+        activity = Activity.query.order_by(desc(Activity.id)).first()
         self.assertEquals('task-added', activity.kind)
         self.assertEquals(u'Abkl\xe4rung Fall Huber', activity.title)
         self.assertEquals(u'New task opened by Test User', activity.summary)

--- a/opengever/task/tests/test_api_support.py
+++ b/opengever/task/tests/test_api_support.py
@@ -1,4 +1,5 @@
 from ftw.testbrowser import browsing
+from opengever.activity import notification_center
 from opengever.testing import IntegrationTestCase
 import json
 
@@ -61,3 +62,29 @@ class TestAPISupport(IntegrationTestCase):
         self.assertEqual('fa', sql_task.assigned_org_unit)
         self.assertEqual(self.regular_user.id, sql_task.responsible)
         self.assertEqual(self.secretariat_user.id, sql_task.issuer)
+
+    @browsing
+    def test_watchers_are_correclty_registered(self, browser):
+        self.activate_feature('activity')
+
+        self.login(self.regular_user, browser=browser)
+
+        data = {
+            "@type": "opengever.task.task",
+            "title": "Task",
+            "task_type": "correction",
+            "text": "Anweisungen etc.",
+            "responsible": self.regular_user.id,
+            "issuer": self.secretariat_user.id,
+            "responsible_client": "fa"}
+
+        with self.observe_children(self.dossier) as children:
+            browser.open(self.dossier.absolute_url(),
+                         method='POST', data=json.dumps(data),
+                         headers=self.api_headers)
+
+        task = children['added'].pop()
+        watchers = notification_center().get_watchers(task)
+
+        self.assertEqual([u'kathi.barfuss', u'jurgen.konig'],
+                         [watcher.actorid for watcher in watchers])

--- a/opengever/task/tests/test_api_support.py
+++ b/opengever/task/tests/test_api_support.py
@@ -1,0 +1,63 @@
+from ftw.testbrowser import browsing
+from opengever.testing import IntegrationTestCase
+import json
+
+
+class TestAPISupport(IntegrationTestCase):
+
+    api_headers = {
+        'Accept': 'application/json',
+        'Content-Type': 'application/json',
+    }
+
+    @browsing
+    def test_adding_a_task(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        data = {
+            "@type": "opengever.task.task",
+            "title": "Task",
+            "task_type": "correction",
+            "text": "Anweisungen etc.",
+            "responsible": self.regular_user.id,
+            "issuer": self.secretariat_user.id,
+            "responsible_client": "fa"}
+
+        with self.observe_children(self.dossier) as children:
+            browser.open(self.dossier.absolute_url(),
+                         method='POST', data=json.dumps(data),
+                         headers=self.api_headers)
+
+        task = children['added'].pop()
+
+        self.assertEqual('Task', task.title)
+        self.assertEqual('correction', task.task_type)
+        self.assertEqual('fa', task.responsible_client)
+        self.assertEqual(self.regular_user.id, task.responsible)
+        self.assertEqual(self.secretariat_user.id, task.issuer)
+
+    @browsing
+    def test_added_task_is_indexed_in_globalindex(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        data = {
+            "@type": "opengever.task.task",
+            "title": "Task",
+            "task_type": "correction",
+            "text": "Anweisungen etc.",
+            "responsible": self.regular_user.id,
+            "issuer": self.secretariat_user.id,
+            "responsible_client": "fa"}
+
+        with self.observe_children(self.dossier) as children:
+            browser.open(self.dossier.absolute_url(),
+                         method='POST', data=json.dumps(data),
+                         headers=self.api_headers)
+
+        sql_task = children['added'].pop().get_sql_object()
+
+        self.assertEqual('Task', sql_task.title)
+        self.assertEqual('correction', sql_task.task_type)
+        self.assertEqual('fa', sql_task.assigned_org_unit)
+        self.assertEqual(self.regular_user.id, sql_task.responsible)
+        self.assertEqual(self.secretariat_user.id, sql_task.issuer)

--- a/opengever/task/tests/test_comment_response.py
+++ b/opengever/task/tests/test_comment_response.py
@@ -8,6 +8,7 @@ from opengever.task.adapters import IResponseContainer
 from opengever.task.comment_response import CommentResponseHandler
 from opengever.task.interfaces import ICommentResponseHandler
 from opengever.testing import FunctionalTestCase
+from sqlalchemy import desc
 from zope.interface.verify import verifyClass
 
 
@@ -31,7 +32,7 @@ class TestCommentResponseHandler(FunctionalTestCase):
 
         ICommentResponseHandler(task).add_response("My response")
 
-        activity = Activity.query.one()
+        activity = Activity.query.order_by(desc(Activity.id)).first()
         self.assertEquals('task-commented', activity.kind)
 
     def test_add_response_appends_a_new_response_obj_to_the_context_response_container(self):


### PR DESCRIPTION
With the latest plone.restapi update, there was nothing big to support adding tasks via API:
- Remove unnecessary split ups of `ddd:ddd` tokens. There was never the case.
- Fix activity and watcher registration, by moving the activity recording from the form in to an event handler.

Example request body:
``` js
{
  "@type": "opengever.task.task",
  "title": "Anfrage prüfen auf Vollständigkeit",
  "task_type": "correction",
  "text": "Könntest du bitte die Anfrage (siehe Anhang) prüfen und gegebenenfalls ergänzen",
  "responsible": "peter.muster",
  "issuer": "hans.peter",
  "responsible_client": "afi"
}
```
