### PR TITLE
No longer use catalog.reindexObject.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ---------------------
 
 - Add missing mimetype for wmf files. [phgross]
+- Fix solr checked-in indexing problems. [phgross]
 - Fix tree portlet header styling for IE11. [Kevin Bieri]
 - Register bmp as editable by officeconnector. [phgross]
 - Fix batching links on the solr search. [phgross]

--- a/opengever/core/upgrades/20180912160954_reindex_checked_out_and_allowed_roles_and_users_on_solr/upgrade.py
+++ b/opengever/core/upgrades/20180912160954_reindex_checked_out_and_allowed_roles_and_users_on_solr/upgrade.py
@@ -1,0 +1,24 @@
+from ftw.upgrade import UpgradeStep
+from opengever.base.interfaces import ISearchSettings
+from plone import api
+from zope.component import queryMultiAdapter
+
+
+class ReindexCheckedOutAndAllowedRolesAndUsersOnSolr(UpgradeStep):
+    """Reindex checked_out and allowedRolesAndUsers on solr.
+    """
+
+    deferrable = True
+
+    def __call__(self):
+        solr_enabled = api.portal.get_registry_record(
+            name='use_solr', interface=ISearchSettings)
+        if not solr_enabled:
+            return
+
+        portal = api.portal.get()
+        solr_maintenance = queryMultiAdapter(
+            (portal, portal.REQUEST), name=u'solr-maintenance')
+
+        solr_maintenance.reindex(
+            idxs=['checked_out', 'allowedRolesAndUsers'], doom=False)

--- a/opengever/document/checkout/manager.py
+++ b/opengever/document/checkout/manager.py
@@ -83,18 +83,10 @@ class CheckinCheckoutManager(object):
         user_id = getSecurityManager().getUser().getId()
         self.annotations[CHECKIN_CHECKOUT_ANNOTATIONS_KEY] = user_id
 
-        # finally, reindex the object
-        catalog = api.portal.get_tool('portal_catalog')
         # update last modified timestamp for recently modified menu
         self.context.setModificationDate()
-        catalog.reindexObject(
-            self.context,
-            idxs=(
-                'checked_out',
-                'modified',
-                ),
-            update_metadata=True,
-            )
+
+        self.context.reindexObject(idxs=['checked_out', 'modified'])
 
         # fire the event
         notify(ObjectCheckedOutEvent(self.context, ''))
@@ -156,18 +148,10 @@ class CheckinCheckoutManager(object):
         # create new version in CMFEditions
         self.versioner.create_version(comment)
 
-        # finally, reindex the object
-        catalog = api.portal.get_tool('portal_catalog')
         # update last modified timestamp for recently modified menu
         self.context.setModificationDate()
-        catalog.reindexObject(
-            self.context,
-            idxs=(
-                'checked_out',
-                'modified',
-                ),
-            update_metadata=True,
-            )
+
+        self.context.reindexObject(idxs=['checked_out', 'modified'])
 
         # fire the event
         notify(ObjectCheckedInEvent(self.context, comment))
@@ -213,14 +197,7 @@ class CheckinCheckoutManager(object):
         self.annotations[CHECKIN_CHECKOUT_ANNOTATIONS_KEY] = None
 
         # finally, reindex the object
-        catalog = api.portal.get_tool('portal_catalog')
-        catalog.reindexObject(
-            self.context,
-            idxs=(
-                'checked_out',
-                ),
-            update_metadata=True,
-            )
+        self.context.reindexObject(idxs=['checked_out'])
 
         # Clear any WebDAV locks left over by ExternalEditor if necessary
         self.clear_locks()

--- a/opengever/setup/overrides.zcml
+++ b/opengever/setup/overrides.zcml
@@ -9,4 +9,9 @@
       name="collective.blueprint.jsonmigrator.ac_local_roles"
       />
 
+  <utility
+      component=".sections.reindexobject.GeverReindexObjectSection"
+      name="plone.app.transmogrifier.reindexobject"
+      />
+
 </configure>

--- a/opengever/setup/sections/reindexobject.py
+++ b/opengever/setup/sections/reindexobject.py
@@ -1,0 +1,88 @@
+from collective.indexing.interfaces import IIndexQueueProcessor
+from collective.indexing.queue import getQueue
+from collective.transmogrifier.interfaces import ISection
+from collective.transmogrifier.interfaces import ISectionBlueprint
+from collective.transmogrifier.utils import traverse
+from plone import api
+from plone.app.transmogrifier.reindexobject import ReindexObjectSection
+from zope.annotation import IAnnotations
+from zope.component import getUtility
+from zope.interface import classProvides, implements
+import logging
+
+
+try:
+    from Products.CMFCore.CMFCatalogAware import CatalogAware  # Plone 4
+except ImportError:
+    from Products.CMFCore.CMFCatalogAware import CMFCatalogAware as CatalogAware  # noqa
+
+
+logger = logging.getLogger('opengever.setup.reindexobject')
+
+SKIP_SOLR_KEY = 'skip_solr'
+
+
+class GeverReindexObjectSection(ReindexObjectSection):
+    classProvides(ISectionBlueprint)
+    implements(ISection)
+
+    _solr_enabled = None
+
+    def __init__(self, transmogrifier, name, options, previous):
+        super(GeverReindexObjectSection, self).__init__(
+            transmogrifier, name, options, previous)
+
+        self.skip_solr = IAnnotations(transmogrifier).get(
+            SKIP_SOLR_KEY, True)
+
+    @property
+    def solr_enabled(self):
+        """Boolean from registry to indicate whether Solr is enabled (memoized).
+        """
+        if self._solr_enabled is None:
+            self._solr_enabled = api.portal.get_registry_record(
+                'opengever.base.interfaces.ISearchSettings.use_solr',
+                default=False)
+        return self._solr_enabled
+
+    def __iter__(self):
+
+        for item in self.previous:
+            pathkey = self.pathkey(*item.keys())[0]
+            if not pathkey:  # not enough info
+                yield item
+                continue
+            path = item[pathkey]
+
+            ob = traverse(self.context, str(path).lstrip('/'), None)
+            if ob is None:
+                yield item
+                continue  # object not found
+
+            if not isinstance(ob, CatalogAware):
+                yield item
+                continue  # can't notify portal_catalog
+
+            if self.verbose:  # add a log to display reindexation progess
+                self.counter += 1
+                logger.info('Reindex object %s (%s)', path, self.counter)
+
+            # update catalog
+            if self.indexes:
+                self.portal_catalog.reindexObject(ob, idxs=self.indexes)
+            else:
+                self.portal_catalog.reindexObject(ob)
+
+            # solr reindexing
+            if not self.skip_solr and self.solr_enabled:
+                # Register collective.indexing hook, to make sure solr changes
+                # are realy send to solr. See
+                # collective.indexing.queue.IndexQueue.hook.
+                getQueue().hook()
+
+                # Using catalogs reindexObject does not trigger corresponding solr
+                # reindexing, so we do it manually.
+                processor = getUtility(IIndexQueueProcessor, name='ftw.solr')
+                processor.index(ob)
+
+            yield item

--- a/opengever/usermigration/creator.py
+++ b/opengever/usermigration/creator.py
@@ -81,7 +81,7 @@ class CreatorMigrator(object):
             modified_idxs.extend(idxs)
             creators_moved.extend(moved)
             if modified_idxs:
-                self.catalog.reindexObject(obj, idxs=modified_idxs)
+                obj.reindexObject(idxs=modified_idxs)
 
         results = {
             'creators': {


### PR DESCRIPTION
Because using `catalog_tool.reindexObject` updates Portal Catalog only, but it doesn't in Solr.
This leads to an inconsistent Solr index and confusing search results for the user. 

Discussed to day with buchi, if ftw.solr should also handle `catalog.reindexObject` calls: 
He is of opinion  that  catalog's `reindexObject`, is an internal API which only updates the portal_catalog, it also skip other catalogs (UID ...) and therefore should not do anything with solr. This makes sense.

The PR contains an upgradestep which reindexes checked_out and allowedRolesAndUsers on solr. Because those could be affected by the reindexing problem. The upgradestep is marked as deferrable, because its not urgent.

I also overwrite the `plone.app.transmogrifiert` ReindexObject section, to include a manual SOLR reindex there.

Notes:
 - Upgradesteps before the SOLR integration (09.02.2018) are not fixed/adjusted.
 - ftw.upgrade does not use `catalog.reindexObject`

Resolves #4861 


Backport to `2018.4-stable`
