### PR TITLE
Fix groubmembers overlay for groupids with spaces.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2018.5.0 (unreleased)
 ---------------------
 
+- Fix groubmembers overlay for groupids with spaces. [phgross]
 - Add missing mimetype for wmf files. [phgross]
 - Fix tree portlet header styling for IE11. [Kevin Bieri]
 - Register bmp as editable by officeconnector. [phgross]

--- a/opengever/sharing/browser/sharing.py
+++ b/opengever/sharing/browser/sharing.py
@@ -214,8 +214,9 @@ class OpengeverSharingView(SharingView):
         """Returns the url to the detail view for users or group.
         """
         if item.get('type') == 'group':
-            return '{}/@@list_groupmembers?group={}'.format(
-                api.portal.get().absolute_url(), item['id'])
+            return '{}/@@list_groupmembers?{}'.format(
+                api.portal.get().absolute_url(),
+                urlencode({'group': item['id']}))
         else:
             return '{}/@@user-details-plain/{}'.format(
                 api.portal.get().absolute_url(), item['id'])

--- a/opengever/sharing/tests/test_sharing.py
+++ b/opengever/sharing/tests/test_sharing.py
@@ -204,6 +204,28 @@ class TestOpengeverSharingIntegration(IntegrationTestCase):
              u'url': u'http://nohost/plone/@@user-details-plain/kathi.barfuss'},
             [item for item in entries if item['id'] == self.regular_user.id][0])
 
+    @browsing
+    def test_sharing_view_handles_groupids_with_spaces(self, browser):
+        self.login(self.administrator, browser=browser)
+
+        group_id = 'group with spaces'
+        create(Builder('group')
+               .with_groupid(group_id)
+               .having(title='Group with sapces'))
+
+        manager = RoleAssignmentManager(self.empty_dossier)
+        manager.add_or_update_assignment(
+            TaskRoleAssignment(group_id, ['Reader'], self.task))
+
+        browser.open(self.empty_dossier, view='@sharing',
+                     method='Get', headers={'Accept': 'application/json'})
+
+        entry = [entry for entry in browser.json['entries']
+                 if entry['id'] == u'group with spaces'][0]
+        self.assertEquals(
+            u'http://nohost/plone/@@list_groupmembers?group=group+with+spaces',
+            entry['url'])
+
 
 class TestRoleAssignmentsGet(IntegrationTestCase):
 


### PR DESCRIPTION
Urlencode the `groupid` parameter when creating the list-groupmembers overlay link. This fixes an issue with groups where the id contains spaces. (Fixes #4873)

Backport to `2018.4-stable`