### PR TITLE
Fix task and activity queries for oracle backends

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -14,6 +14,7 @@ Changelog
 - Prevent replacing files on proposal templates with non-.docx files via quickupload. [Rotonen]
 - Add an upgrade step to fix broken-by-broken-protocol-excerpt journal entries on dossiers. [Rotonen]
 - Do not list documents within dossiertemplates when creating a document from template. [njohner]
+- Fix activity queries for oracle backends. [phgross]
 - Correct width of subdossier table in dossier details pdf. [njohner]
 - Do not set document date during check-in or cancel. [njohner]
 - Disallow grouping tasks by the checkbox column in list views. [Rotonen]

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -14,6 +14,7 @@ Changelog
 - Prevent replacing files on proposal templates with non-.docx files via quickupload. [Rotonen]
 - Add an upgrade step to fix broken-by-broken-protocol-excerpt journal entries on dossiers. [Rotonen]
 - Do not list documents within dossiertemplates when creating a document from template. [njohner]
+- Fix task path queries for oracle backends. [phgross]
 - Fix activity queries for oracle backends. [phgross]
 - Correct width of subdossier table in dossier details pdf. [njohner]
 - Do not set document date during check-in or cancel. [njohner]

--- a/opengever/activity/center.py
+++ b/opengever/activity/center.py
@@ -12,13 +12,14 @@ from plone import api
 from sqlalchemy.orm import contains_eager
 from sqlalchemy.sql.expression import asc
 from sqlalchemy.sql.expression import desc
+from sqlalchemy.sql.expression import false
+from sqlalchemy.sql.expression import true
 from ZODB.POSException import ConflictError
 from zope.globalrequest import getRequest
 from zope.i18nmessageid import MessageFactory
 import logging
 import sys
 import traceback
-
 
 _ = MessageFactory("opengever.activity")
 logger = logging.getLogger('opengever.activity')
@@ -131,7 +132,7 @@ class NotificationCenter(object):
     def get_users_notifications(self, userid, only_unread=False, limit=None):
         query = Notification.query.by_user(userid)
         if only_unread:
-            query = query.filter(Notification.is_read.is_(False))
+            query = query.filter(Notification.is_read == false())
 
         query = query.join(
             Notification.activity).order_by(desc(Activity.created))
@@ -140,8 +141,8 @@ class NotificationCenter(object):
     def count_users_unread_notifications(self, userid, badge_only=False):
         query = Notification.query.by_user(userid)
         if badge_only:
-            query = query.filter(Notification.is_badge.is_(True))
-        return query.filter(Notification.is_read.is_(False)).count()
+            query = query.filter(Notification.is_badge == true())
+        return query.filter(Notification.is_read == false()).count()
 
     def mark_notification_as_read(self, notification_id):
         notification = self.get_notification(notification_id)
@@ -167,7 +168,7 @@ class NotificationCenter(object):
 
         query = query.join(Notification.activity)
         if badge_only:
-            query = query.filter(Notification.is_badge.is_(True))
+            query = query.filter(Notification.is_badge == true())
         query = query.order_by(order(sort_on))
         query = query.offset(offset).limit(limit)
         return query.options(contains_eager(Notification.activity)).all()

--- a/opengever/activity/model/query.py
+++ b/opengever/activity/model/query.py
@@ -7,6 +7,8 @@ from opengever.activity.model import Subscription
 from opengever.activity.model import Watcher
 from opengever.ogds.models.query import BaseQuery
 from sqlalchemy import and_
+from sqlalchemy.sql.expression import false
+from sqlalchemy.sql.expression import true
 
 
 class ActivityQuery(BaseQuery):
@@ -32,8 +34,8 @@ class NotificationQuery(BaseQuery):
         return self.filter_by(activity_id=activity.id).filter(Notification.userid.is_(None))
 
     def unsent_digest_notifications(self):
-        return self.filter(and_(Notification.is_digest.is_(True),
-                                Notification.sent_in_digest.is_(False)))
+        return self.filter(and_(Notification.is_digest == true(),
+                                Notification.sent_in_digest == false()))
 
 
 Notification.query_cls = NotificationQuery


### PR DESCRIPTION
**Activities**
Do not use `is_(True)` for sqlalchemy filter statements, because this leads to an `ORA-00908: missing NULL keyword` exception on oracle backends. So i use filter(== true()) instead.
 - https://stackoverflow.com/questions/15143827/missing-null-keyword-error-when-trying-to-avoid-duplicates
 - https://stackoverflow.com/questions/18998010/flake8-complains-on-boolean-comparison-in-filter-clause for more information.

**Task**
With #4318 the physical_path column has been switched from a string to a text column. On oracle backends this leads to errors when filtering on physicalpath (`DatabaseError: (cx_Oracle.DatabaseError) ORA-00932: inconsistent datatypes: expected - got CLOB`).

Therefore I implemented a fallback for oracle backends, which first cast to string before filtering.
 - https://stackoverflow.com/questions/12980038/ora-00932-inconsistent-datatypes-expected-got-clob

Note: The path helper could be moved to the basequery, as soon ogds.models is merged into opengever.core. I added  a note in the issue there.


Backport needed for `2018.4`