### PR TITLE
Reindex issuer of all proposals.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ---------------------
 
 - Support adding tasks via REST API. [phgross]
+- Reindex issuer of all proposals. [phgross]
 - Correct info messages in meetings. [njohner]
 - Add proposal tabs to repository folders. [Rotonen]
 - Fix global scoped "show more" links for SOLR livesearch [Rotonen]

--- a/opengever/core/upgrades/20180919125535_reindex_issuer_for_proposals/upgrade.py
+++ b/opengever/core/upgrades/20180919125535_reindex_issuer_for_proposals/upgrade.py
@@ -1,0 +1,14 @@
+from ftw.upgrade import UpgradeStep
+
+
+class ReindexIssuerForProposals(UpgradeStep):
+    """Reindex issuer for proposals.
+    """
+
+    def __call__(self):
+        for proposal in self.objects(
+                {'portal_type': ['opengever.meeting.proposal',
+                                 'opengever.meeting.submittedproposal']},
+                'Reindex proposal issuer'):
+
+            proposal.reindexObject(idxs=['issuer'])


### PR DESCRIPTION
In 4teamwork/opengever.core#4442 a new issuer field was introduced on Proposals. This field is now picked up for the issuer indexes and metadata - but existing proposals hasn't been reindex.

Closes #4855