### PR TITLE
Add @listing API endpoint 

### DIFF
--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -243,12 +243,12 @@
       permission="zope2.View"
       />
 
-   <plone:service
+  <plone:service
       method="GET"
       for="zope.interface.Interface"
       factory=".listing.Listing"
       name="@listing"
       permission="zope2.View"
-    />
+      />
 
 </configure>

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -243,4 +243,12 @@
       permission="zope2.View"
       />
 
+   <plone:service
+      method="GET"
+      for="zope.interface.Interface"
+      factory=".listing.Listing"
+      name="@listing"
+      permission="zope2.View"
+    />
+
 </configure>

--- a/opengever/api/listing.py
+++ b/opengever/api/listing.py
@@ -10,6 +10,7 @@ from plone.restapi.batching import HypermediaBatch
 from plone.restapi.serializer.converters import json_compatible
 from plone.restapi.services import Service
 from plone.rfc822.interfaces import IPrimaryFieldInfo
+from plone.uuid.interfaces import IUUID
 from Products.CMFCore.utils import getToolByName
 from Products.ZCatalog.Lazy import LazyMap
 from Products.ZCTextIndex.ParseTree import ParseError
@@ -170,9 +171,7 @@ class Listing(Service):
         })
 
         # Exclude context from results, which also matches the path query.
-        # Unfortunately UUIDIndex does not support 'not' queries.
-        # getId should be unique enough for our use-case, though.
-        query['getId'] = {'not': self.context.getId()}
+        query['UID'] = {'not': IUUID(self.context)}
 
         if term:
             query['SearchableText'] = term + '*'

--- a/opengever/api/listing.py
+++ b/opengever/api/listing.py
@@ -137,8 +137,8 @@ class Listing(Service):
             items = self.solr_results(
                 name, term, columns, start, rows, sort_on, sort_order)
         else:
-            items = self.catalog_results(name, term, rows, sort_on, sort_order)
-
+            items = self.catalog_results(
+                name, term, start, rows, sort_on, sort_order)
         if not items:
             return {}
 
@@ -151,7 +151,7 @@ class Listing(Service):
 
         return res
 
-    def catalog_results(self, name, term, rows, sort_on, sort_order):
+    def catalog_results(self, name, term, start, rows, sort_on, sort_order):
         if name not in CATALOG_QUERIES:
             return []
 
@@ -160,7 +160,7 @@ class Listing(Service):
             'path': '/'.join(self.context.getPhysicalPath()),
             'sort_on': sort_on,
             'sort_order': sort_order,
-            'sort_limit': rows,
+            'sort_limit': start + rows,
         })
 
         # Exclude context from results, which also matches the path query.

--- a/opengever/api/listing.py
+++ b/opengever/api/listing.py
@@ -1,21 +1,19 @@
+from ftw.solr.interfaces import ISolrSearch
+from ftw.solr.query import escape
+from opengever.base.behaviors.translated_title import ITranslatedTitleSupport
 from opengever.base.helpers import display_name
-from plone import api
+from opengever.base.interfaces import ISearchSettings
+from opengever.base.solr import OGSolrDocument
+from opengever.base.utils import get_preferred_language_code
 from plone.app.contentlisting.interfaces import IContentListingObject
+from plone.registry.interfaces import IRegistry
 from plone.restapi.serializer.converters import json_compatible
 from plone.restapi.services import Service
 from plone.rfc822.interfaces import IPrimaryFieldInfo
+from Products.CMFCore.utils import getToolByName
 from Products.ZCTextIndex.ParseTree import ParseError
+from zope.component import getUtility
 from zope.i18n import translate
-
-
-QUERIES = {
-    'dossiers': {
-        'object_provides': 'opengever.dossier.behaviors.dossier.IDossierMarker',
-    },
-    'documents': {
-        'object_provides': 'opengever.document.behaviors.IBaseDocument',
-    }
-}
 
 
 class Listing(Service):
@@ -23,15 +21,6 @@ class Listing(Service):
 
     def reply(self):
         name = self.request.form.get('name')
-        if name not in QUERIES:
-            return {}
-
-        query = QUERIES[name].copy()
-        query['path'] = '/'.join(self.context.getPhysicalPath())
-        # Exclude context from results, which also matches the path query.
-        # Unfortunately UUIDIndex does not support 'not' queries.
-        # getId should be unique enough for our use-case, though.
-        query['getId'] = {'not': self.context.getId()}
 
         start = self.request.form.get('start', '0')
         rows = self.request.form.get('rows', '25')
@@ -43,46 +32,113 @@ class Listing(Service):
             rows = 25
 
         sort_on = self.request.form.get('sort_on', DEFAULT_SORT_INDEX)
-        query['sort_on'] = COLUMNS.get(sort_on, (None, DEFAULT_SORT_INDEX))[1]
-        query['sort_order'] = self.request.form.get('sort_order', 'descending')
+        sort_on = FIELDS.get(sort_on, (None, DEFAULT_SORT_INDEX))[1]
+        sort_order = self.request.form.get('sort_order', 'descending')
+        term = self.request.form.get('search', '').strip()
+        columns = self.request.form.get('columns', [])
 
-        searchable_text = self.request.form.get('search', '').strip()
-        if searchable_text:
-            query['SearchableText'] = searchable_text + '*'
-
-        try:
-            items = api.content.find(**query)
-        except ParseError:
-            items = []
+        registry = getUtility(IRegistry)
+        settings = registry.forInterface(ISearchSettings)
+        if settings.use_solr:
+            items = self.solr_results(
+                name, term, columns, start, rows, sort_on, sort_order)
+        else:
+            items = self.catalog_results(name, term, rows, sort_on, sort_order)
 
         if not items:
             return {}
 
-        columns = self.request.form.get('columns', [])
         res = {'items': []}
         for item in items[start:start + rows]:
-            obj = IContentListingObject(item)
-            data = {}
-            for column in columns:
-                if column not in COLUMNS:
-                    continue
-                accessor = COLUMNS[column][0]
-                if isinstance(accessor, str):
-                    value = getattr(obj, accessor, None)
-                    if callable(value):
-                        value = value()
-                else:
-                    value = accessor(obj)
-                data[column] = json_compatible(value)
-
-            data['@id'] = item.getURL()
-            res['items'].append(data)
-
+            res['items'].append(create_list_item(item, columns))
         res['total'] = len(items)
         res['start'] = start
         res['rows'] = rows
 
         return res
+
+    def catalog_results(self, name, term, rows, sort_on, sort_order):
+        if name not in CATALOG_QUERIES:
+            return []
+
+        query = CATALOG_QUERIES[name].copy()
+        query.update({
+            'path': '/'.join(self.context.getPhysicalPath()),
+            'sort_on': sort_on,
+            'sort_order': sort_order,
+            'sort_limit': rows,
+        })
+
+        # Exclude context from results, which also matches the path query.
+        # Unfortunately UUIDIndex does not support 'not' queries.
+        # getId should be unique enough for our use-case, though.
+        query['getId'] = {'not': self.context.getId()}
+
+        if term:
+            query['SearchableText'] = term + '*'
+
+        catalog = getToolByName(self.context, 'portal_catalog')
+        try:
+            return catalog(**query)
+        except ParseError:
+            return []
+
+    def solr_results(self, name, term, columns, start, rows, sort_on,
+                     sort_order):
+
+        if name not in SOLR_FILTERS:
+            return []
+
+        query = '*:*'
+        if term:
+            pattern = (
+                u'(Title:{term}* OR SearchableText:{term}*'
+                u' OR metadata:{term}*)')
+            term_queries = [
+                pattern.format(term=escape(t)) for t in term.split()]
+            query = u' AND '.join(term_queries)
+
+        filters = [u'trashed:false']
+        filters.extend(SOLR_FILTERS[name])
+
+        sort = sort_on
+        if sort:
+            if sort_order in ['descending', 'reverse']:
+                sort += ' desc'
+            else:
+                sort += ' asc'
+
+        fl = ['UID', 'getIcon', 'portal_type', 'path', 'id',
+              'bumblebee_checksum']
+        fl = fl + [c['column'] for c in self.config.columns if c['column']]
+        params = {
+            'fl': fl,
+            'q.op': 'AND',
+        }
+
+        solr = getUtility(ISolrSearch)
+        resp = solr.search(
+            query=query, filters=filters, start=start, rows=rows, sort=sort,
+            **params)
+
+        return [OGSolrDocument(doc) for doc in resp.docs]
+
+
+def create_list_item(item, fields):
+    obj = IContentListingObject(item)
+    data = {'@id': obj.getURL()}
+    for field in fields:
+        if field not in FIELDS:
+            continue
+        accessor = FIELDS[field][0]
+        if isinstance(accessor, str):
+            value = getattr(obj, accessor, None)
+            if callable(value):
+                value = value()
+        else:
+            value = accessor(obj)
+        data[field] = json_compatible(value)
+    return data
 
 
 def responsible_name(obj):
@@ -95,6 +151,14 @@ def checked_out(obj):
 
 def translated_review_state(obj):
     return translate(obj.review_state(), domain='plone', context=obj.request)
+
+
+def translated_title(obj):
+    if ITranslatedTitleSupport.providedBy(obj):
+        attr = 'title_{}'.format(get_preferred_language_code())
+        return getattr(obj, attr, obj.Title())
+    else:
+        return obj.Title()
 
 
 def filesize(obj):
@@ -118,12 +182,16 @@ def filename(obj):
 
 
 DEFAULT_SORT_INDEX = 'modified'
-COLUMNS = {
+
+# Mapping of field name -> (field accessor, sort index)
+FIELDS = {
+    '@type': ('PortalType', 'portal_type'),
     'checked_out': (checked_out, 'checked_out'),
     'containing_dossier': ('containing_dossier', 'containing_dossier'),
-    'containing_subdossier': ('containing_subdossier', 'containing_subdossier'),
+    'containing_subdossier': ('containing_subdossier', 'containing_subdossier'),  # noqa
     'created': ('created', 'created'),
     'creator': ('Creator', 'Creator'),
+    'description': ('Description', 'Description'),
     'delivery_date': ('delivery_date', 'delivery_date'),
     'document_author': ('document_author', 'document_author'),
     'document_date': ('document_date', 'document_date'),
@@ -132,13 +200,32 @@ COLUMNS = {
     'modified': ('modified', 'modified'),
     'receipt_date': ('receipt_date', 'receipt_date'),
     'reference': ('reference', 'reference'),
+    'reference_number': ('reference', 'reference'),
     'responsible': (responsible_name, 'responsible'),
     'review_state': (translated_review_state, 'review_state'),
     'sequence_number': ('sequence_number', 'sequence_number'),
     'start': ('start', 'start'),
     'thumbnail': ('get_preview_image_url', DEFAULT_SORT_INDEX),
-    'title': ('Title', 'sortable_title'),
+    'title': (translated_title, 'sortable_title'),
     'type': ('PortalType', 'portal_type'),
     'filesize': (filesize, 'filesize'),
     'filename': (filename, 'filename'),
+}
+
+SOLR_FILTERS = {
+    'dossiers': [
+        'object_provides:opengever.dossier.behaviors.dossier.IDossierMarker',
+    ],
+    'documents': [
+        'object_provides:opengever.document.behaviors.IBaseDocument',
+    ]
+}
+
+CATALOG_QUERIES = {
+    'dossiers': {
+        'object_provides': 'opengever.dossier.behaviors.dossier.IDossierMarker',  # noqa
+    },
+    'documents': {
+        'object_provides': 'opengever.document.behaviors.IBaseDocument',
+    }
 }

--- a/opengever/api/listing.py
+++ b/opengever/api/listing.py
@@ -1,0 +1,95 @@
+from plone import api
+from plone.app.contentlisting.interfaces import IContentListingObject
+from plone.restapi.serializer.converters import json_compatible
+from plone.restapi.services import Service
+from Products.ZCTextIndex.ParseTree import ParseError
+
+
+QUERIES = {
+    'dossiers': {
+        'object_provides': 'opengever.dossier.behaviors.dossier.IDossierMarker',
+    },
+    'documents': {
+        'object_provides': 'opengever.document.behaviors.IBaseDocument',
+    }
+}
+
+
+class Listing(Service):
+    """List of content items"""
+
+    def reply(self):
+        name = self.request.form.get('name')
+        if name not in QUERIES:
+            return {}
+
+        query = QUERIES[name].copy()
+        query['path'] = '/'.join(self.context.getPhysicalPath())
+        # Exclude context from results, which also matches the path query.
+        # Unfortunately UUIDIndex does not support 'not' queries.
+        # getId should be unique enough for our use-case, though.
+        query['getId'] = {'not': self.context.getId()}
+
+        start = self.request.form.get('start', '0')
+        rows = self.request.form.get('rows', '25')
+        try:
+            start = int(start)
+            rows = int(rows)
+        except ValueError:
+            start = 0
+            rows = 25
+
+        query['sort_on'] = self.request.form.get('sort_on', 'modified')
+        query['sort_order'] = self.request.form.get('sort_order', 'descending')
+
+        searchable_text = self.request.form.get('search', '').strip()
+        if searchable_text:
+            query['SearchableText'] = searchable_text + '*'
+
+        try:
+            items = api.content.find(**query)
+        except ParseError:
+            items = []
+
+        if not items:
+            return {}
+
+        headers = self.request.form.get('headers')
+        res = {'items': []}
+        for item in items[start:start + rows]:
+            obj = IContentListingObject(item)
+            data = {}
+            for header in headers:
+                accessor = FIELD_ACCESSORS.get(header, header)
+                if isinstance(accessor, str):
+                    value = getattr(obj, accessor, None)
+                    if callable(value):
+                        value = value()
+                else:
+                    value = accessor(obj)
+                data[header] = json_compatible(value)
+
+            data['@id'] = item.getURL()
+            res['items'].append(data)
+
+        res['total'] = len(items)
+        res['start'] = start
+        res['rows'] = rows
+
+        return res
+
+
+FIELD_ACCESSORS = {
+    '@type': 'PortalType',
+    'created': 'created',
+    'creator': 'Creator',
+    'description': 'Description',
+    # 'filename': filename,
+    # 'filesize': filesize,
+    'mimetype': 'getContentType',
+    'modified': 'modified',
+    # 'reference_number': reference_number,
+    'review_state': 'review_state',
+    'title': 'Title',
+    'thumbnail': 'get_preview_image_url',
+}

--- a/opengever/api/listing.py
+++ b/opengever/api/listing.py
@@ -1,7 +1,6 @@
 from ftw.solr.interfaces import ISolrSearch
 from ftw.solr.query import escape
 from opengever.base.behaviors.translated_title import ITranslatedTitleSupport
-from opengever.base.helpers import display_name
 from opengever.base.interfaces import ISearchSettings
 from opengever.base.solr import OGSolrDocument
 from opengever.base.utils import get_preferred_language_code
@@ -13,7 +12,6 @@ from plone.rfc822.interfaces import IPrimaryFieldInfo
 from Products.CMFCore.utils import getToolByName
 from Products.ZCTextIndex.ParseTree import ParseError
 from zope.component import getUtility
-from zope.i18n import translate
 
 
 class Listing(Service):
@@ -141,18 +139,6 @@ def create_list_item(item, fields):
     return data
 
 
-def responsible_name(obj):
-    return display_name(obj.responsible)
-
-
-def checked_out(obj):
-    return display_name(obj.checked_out)
-
-
-def translated_review_state(obj):
-    return translate(obj.review_state(), domain='plone', context=obj.request)
-
-
 def translated_title(obj):
     if ITranslatedTitleSupport.providedBy(obj):
         attr = 'title_{}'.format(get_preferred_language_code())
@@ -186,7 +172,7 @@ DEFAULT_SORT_INDEX = 'modified'
 # Mapping of field name -> (field accessor, sort index)
 FIELDS = {
     '@type': ('PortalType', 'portal_type'),
-    'checked_out': (checked_out, 'checked_out'),
+    'checked_out': ('checked_out_fullname', 'checked_out'),
     'containing_dossier': ('containing_dossier', 'containing_dossier'),
     'containing_subdossier': ('containing_subdossier', 'containing_subdossier'),  # noqa
     'created': ('created', 'created'),
@@ -201,8 +187,8 @@ FIELDS = {
     'receipt_date': ('receipt_date', 'receipt_date'),
     'reference': ('reference', 'reference'),
     'reference_number': ('reference', 'reference'),
-    'responsible': (responsible_name, 'responsible'),
-    'review_state': (translated_review_state, 'review_state'),
+    'responsible': ('responsible_fullname', 'responsible'),
+    'review_state': ('translated_review_state', 'review_state'),
     'sequence_number': ('sequence_number', 'sequence_number'),
     'start': ('start', 'start'),
     'thumbnail': ('get_preview_image_url', DEFAULT_SORT_INDEX),

--- a/opengever/api/tests/test_listing.py
+++ b/opengever/api/tests/test_listing.py
@@ -81,3 +81,16 @@ class TestListingEndpoint(IntegrationTestCase):
         self.assertEquals(
             [self.taskdocument.absolute_url()],
             [item['@id'] for item in browser.json['items']])
+
+    @browsing
+    def test_current_context_is_excluded(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        view = '@listing?name=dossiers&columns:list=title&sort_on=created'
+        browser.open(
+            self.dossier, view=view, headers={'Accept': 'application/json'})
+
+        self.assertNotIn(
+            self.dossier.Title().decode('utf8'),
+            [d['title'] for d in browser.json['items']],
+        )

--- a/opengever/api/tests/test_listing.py
+++ b/opengever/api/tests/test_listing.py
@@ -1,0 +1,50 @@
+from opengever.testing import IntegrationTestCase
+from ftw.testbrowser import browsing
+import requests
+
+
+class TestListingEndpoint(IntegrationTestCase):
+
+    @browsing
+    def test_dossier_listing(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        view = '@listing?name=dossiers&columns=reference&columns=title&columns=review_state&columns=responsible&sort_on=created'
+        browser.open(self.repository_root, view=view, headers={'Accept': 'application/json'})
+
+        self.assertEquals(
+            {u'review_state': u'dossier-state-active',
+             u'responsible': u'Ziegler Robert (robert.ziegler)',
+             u'@id': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1',
+             u'reference': u'Client1 1.1 / 1',
+             u'title': u'Vertr\xe4ge mit der kantonalen Finanzverwaltung'},
+            browser.json['items'][-1])
+
+    @browsing
+    def test_document_listing(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        view = '@listing?name=documents&columns=reference&columns=title&columns=modified&columns=document_author&columns=containing_dossier&sort_on=created'
+        browser.open(self.dossier, view=view, headers={'Accept': 'application/json'})
+
+        self.assertEquals(
+            {u'reference': u'Client1 1.1 / 1 / 12',
+             u'title': u'Vertr\xe4gsentwurf',
+             u'document_author': u'test_user_1_',
+             u'@id': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/document-12',
+             u'modified': u'2016-08-31T13:07:33+00:00',
+             u'containing_dossier': u'Vertr\xe4ge mit der kantonalen Finanzverwaltung'},
+            browser.json['items'][-1])
+
+    @browsing
+    def test_file_information(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        view = '@listing?name=documents&columns=filename&columns=filesize&sort_on=created'
+        browser.open(self.dossier, view=view, headers={'Accept': 'application/json'})
+
+        self.assertEquals(
+            {u'@id': self.document.absolute_url(),
+             u'filesize': self.document.file.size,
+             u'filename': u'Vertraegsentwurf.docx'},
+            browser.json['items'][-1])

--- a/opengever/api/tests/test_listing.py
+++ b/opengever/api/tests/test_listing.py
@@ -11,7 +11,7 @@ class TestListingEndpoint(IntegrationTestCase):
         view = '@listing?name=dossiers&columns=reference&columns=title&columns=review_state&columns=responsible&sort_on=created'
         browser.open(self.repository_root, view=view, headers={'Accept': 'application/json'})
 
-        self.assertEquals(
+        self.assertEqual(
             {u'review_state': u'dossier-state-active',
              u'responsible': u'Ziegler Robert (robert.ziegler)',
              u'@id': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1',
@@ -26,7 +26,7 @@ class TestListingEndpoint(IntegrationTestCase):
         view = '@listing?name=documents&columns=reference&columns=title&columns=modified&columns=document_author&columns=containing_dossier&sort_on=created'
         browser.open(self.dossier, view=view, headers={'Accept': 'application/json'})
 
-        self.assertEquals(
+        self.assertEqual(
             {u'reference': u'Client1 1.1 / 1 / 12',
              u'title': u'Vertr\xe4gsentwurf',
              u'document_author': u'test_user_1_',
@@ -42,7 +42,7 @@ class TestListingEndpoint(IntegrationTestCase):
         view = '@listing?name=documents&columns=filename&columns=filesize&sort_on=created'
         browser.open(self.dossier, view=view, headers={'Accept': 'application/json'})
 
-        self.assertEquals(
+        self.assertEqual(
             {u'@id': self.document.absolute_url(),
              u'filesize': self.document.file.size,
              u'filename': u'Vertraegsentwurf.docx'},
@@ -61,15 +61,15 @@ class TestListingEndpoint(IntegrationTestCase):
         view = '@listing?name=dossiers&b_size=3'
         browser.open(
             self.repository_root, view=view, headers={'Accept': 'application/json'})
-        self.assertEquals(3, len(browser.json['items']))
-        self.assertEquals(all_dossiers[0:3], browser.json['items'])
+        self.assertEqual(3, len(browser.json['items']))
+        self.assertEqual(all_dossiers[0:3], browser.json['items'])
 
         # batched with start point
         view = '@listing?name=dossiers&b_size=2&b_start=4'
         browser.open(
             self.repository_root, view=view, headers={'Accept': 'application/json'})
-        self.assertEquals(2, len(browser.json['items']))
-        self.assertEquals(all_dossiers[4:6], browser.json['items'])
+        self.assertEqual(2, len(browser.json['items']))
+        self.assertEqual(all_dossiers[4:6], browser.json['items'])
 
     @browsing
     def test_search_filter(self, browser):
@@ -78,7 +78,7 @@ class TestListingEndpoint(IntegrationTestCase):
         view = '@listing?name=documents&search=feedback&columns=title'
         browser.open(self.repository_root, view=view,
                      headers={'Accept': 'application/json'})
-        self.assertEquals(
+        self.assertEqual(
             [self.taskdocument.absolute_url()],
             [item['@id'] for item in browser.json['items']])
 

--- a/opengever/api/tests/test_listing.py
+++ b/opengever/api/tests/test_listing.py
@@ -58,14 +58,14 @@ class TestListingEndpoint(IntegrationTestCase):
         all_dossiers = browser.json['items']
 
         # batched no start point
-        view = '@listing?name=dossiers&rows=3'
+        view = '@listing?name=dossiers&b_size=3'
         browser.open(
             self.repository_root, view=view, headers={'Accept': 'application/json'})
         self.assertEquals(3, len(browser.json['items']))
         self.assertEquals(all_dossiers[0:3], browser.json['items'])
 
         # batched with start point
-        view = '@listing?name=dossiers&rows=6&start=4'
+        view = '@listing?name=dossiers&b_size=2&b_start=4'
         browser.open(
             self.repository_root, view=view, headers={'Accept': 'application/json'})
         self.assertEquals(2, len(browser.json['items']))

--- a/opengever/base/contentlisting.py
+++ b/opengever/base/contentlisting.py
@@ -117,8 +117,9 @@ class OpengeverCatalogContentListingObject(CatalogContentListingObject):
 
     def is_bumblebeeable(self):
         if not hasattr(self, '_is_bumblebeeable'):
-            self._is_bumblebeeable = (is_bumblebee_feature_enabled() and
-                                      is_bumblebeeable(self))
+            self._is_bumblebeeable = (
+                is_bumblebee_feature_enabled() and is_bumblebeeable(self))
+
         return self._is_bumblebeeable
 
     def render_link(self):

--- a/opengever/base/contentlisting.py
+++ b/opengever/base/contentlisting.py
@@ -2,6 +2,7 @@ from Acquisition import aq_base
 from ftw import bumblebee
 from Missing import Value as MissingValue
 from opengever.base.browser.helper import get_css_class
+from opengever.base.helpers import display_name
 from opengever.bumblebee import is_bumblebee_feature_enabled
 from opengever.bumblebee import is_bumblebeeable
 from opengever.document.document import Document
@@ -11,6 +12,7 @@ from plone.app.contentlisting.catalog import CatalogContentListingObject
 from plone.app.contentlisting.realobject import RealContentListingObject
 from zope.browserpage.viewpagetemplatefile import ViewPageTemplateFile
 from zope.component import getMultiAdapter
+from zope.i18n import translate
 
 
 class OpengeverCatalogContentListingObject(CatalogContentListingObject):
@@ -125,6 +127,16 @@ class OpengeverCatalogContentListingObject(CatalogContentListingObject):
 
         return self._render_simplelink()
 
+    def translated_review_state(self):
+        return translate(
+            self.review_state(), domain='plone', context=self.request)
+
+    def responsible_fullname(self):
+        return display_name(self._brain.responsible)
+
+    def checked_out_fullname(self):
+        return display_name(self._brain.checked_out)
+
     def _render_simplelink(self):
         self.context = self
         return self.simple_link_template(self, self.request)
@@ -147,3 +159,7 @@ class OpengeverRealContentListingObject(RealContentListingObject):
             return getattr(obj, name)
         else:
             raise AttributeError(name)
+
+    def translated_review_state(self):
+        return translate(
+            self.review_state(), domain='plone', context=self.request)

--- a/opengever/base/helpers.py
+++ b/opengever/base/helpers.py
@@ -1,0 +1,17 @@
+from opengever.ogds.base.actor import Actor
+from plone.memoize import ram
+
+
+def display_name_cache_key(func, userid):
+    return userid
+
+
+@ram.cache(display_name_cache_key)
+def display_name(userid):
+    if not isinstance(userid, unicode):
+        if userid is not None:
+            userid = userid.decode('utf-8')
+        else:
+            userid = ''
+
+    return Actor.user(userid).get_label()

--- a/opengever/base/monkey/patches/__init__.py
+++ b/opengever/base/monkey/patches/__init__.py
@@ -17,12 +17,14 @@ from .paste_permission import PatchDXContainerPastePermission
 from .plone_43rc1_upgrade import PatchPlone43RC1Upgrade
 from .resource_registries_url_regex import PatchResourceRegistriesURLRegex
 from .rolemanager import PatchOFSRoleManager
+from .uuidindex import PatchUUIDIndex
 from .tz_for_log import PatchZ2LogTimezone
 from .verify_object_paste import PatchCopyContainerVerifyObjectPaste
 from .webdav_lock_timeout import PatchWebDAVLockTimeout
 
 
 PatchBuilderCreate()()
+PatchUUIDIndex()()
 PatchCatalogToFilterTrashedDocs()()
 PatchCMFEditonsHistoryHandlerTool()()
 PatchCopyContainerVerifyObjectPaste()()

--- a/opengever/base/monkey/patches/uuidindex.py
+++ b/opengever/base/monkey/patches/uuidindex.py
@@ -1,0 +1,9 @@
+from opengever.base.monkey.patching import MonkeyPatch
+
+
+class PatchUUIDIndex(MonkeyPatch):
+    """Enable support for not queries."""
+
+    def __call__(self):
+        from Products.PluginIndexes.UUIDIndex.UUIDIndex import UUIDIndex
+        self.patch_value(UUIDIndex, 'query_options', ["query", "range", "not"])


### PR DESCRIPTION
The listing endpoint currently supports two "modes" a `dossier` and a `document` listing, and knows the following parameters:
 - `name`: mode  (`dossier` or `document`)
 - `start`: starting point for the listing
 - `rows`: number of items wich should be returned
 - `sort_on`: sort index, default sorting is modified
 - `sort_order`:  ascending or descending, default is descending
 - `search`: filter text
 - `columns`: list of columns which should be returned. Currently supported are ['reference', 'creator', 'containing_dossier', 'document_date', 'receipt_date', 'end', 'title', 'document_author', 'responsible', 'filename', 'start', 'filesize', 'review_state', 'type', 'thumbnail', 'description', 'checked_out', 'mimetype', 'reference_number', 'created', 'containing_subdossier', 'modified', 'delivery_date', '@type', 'sequence_number'] 

Endpoint uses Solr to query when solr feature is enabled.

This endpoint is currently only used by the gever-ui and not part of the public API. Therefore i did not add an documentation to the api-docu. As soon the listing endpoint is open for public, as example for the ogg-laufwerk, we'll add documentation for it.

Closes #4766 
