### PR TITLE
Make paragraph templates deletable again

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -612,6 +612,7 @@ Objects
       - self.subdossiertemplate
     - self.empty_template
     - self.meeting_template
+      - self.paragraph_template
     - self.normal_template
     - self.proposal_template
     - self.recurring_agenda_item_template

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ---------------------
 
 - Add TaskReminderActivity object. [elioschmutz]
+- Make paragraph templates deletable. [Rotonen]
 - Add ReminderSetting SQL Model. [elioschmutz]
 - Add task-reminder activity settings. [elioschmutz]
 - Preserve proposal document title for proposal documents of submitted proposals. [Rotonen]

--- a/opengever/base/browser/is_delete_available.py
+++ b/opengever/base/browser/is_delete_available.py
@@ -1,4 +1,5 @@
 from Acquisition import aq_parent
+from opengever.meeting.interfaces import IParagraphTemplate
 from opengever.private.interfaces import IPrivateContainer
 from opengever.tasktemplates.content.tasktemplate import ITaskTemplate
 from opengever.tasktemplates.content.templatefoldersschema import ITaskTemplateFolderSchema
@@ -11,17 +12,23 @@ class IsDeleteAvailable(BrowserView):
     as we have our own delete actions for certain portal types.
     """
 
-    authorized_interfaces = (IPrivateContainer,
-                             ITaskTemplate,
-                             ITaskTemplateFolderSchema)
+    authorized_interfaces = (
+        IParagraphTemplate,
+        IPrivateContainer,
+        ITaskTemplate,
+        ITaskTemplateFolderSchema,
+    )
 
-    authorized_parent_interfaces = (IPrivateContainer,
-                                    )
+    authorized_parent_interfaces = (
+        IPrivateContainer,
+    )
 
     def __call__(self):
         parent = aq_parent(self.context)
-        return (any(interface.providedBy(self.context)
-                for interface in self.authorized_interfaces)
-                or any(interface.providedBy(parent)
-                for interface in self.authorized_parent_interfaces)
-                )
+        allowed = (
+            # Whitelisted by interface provided by context
+            any(interface.providedBy(self.context) for interface in self.authorized_interfaces),
+            # Whitelisted by interface provided by the acquired parent
+            any(interface.providedBy(parent) for interface in self.authorized_parent_interfaces),
+        )
+        return any(allowed)

--- a/opengever/meeting/tests/test_meeting_template.py
+++ b/opengever/meeting/tests/test_meeting_template.py
@@ -47,6 +47,19 @@ class TestMeetingTemplate(IntegrationTestCase):
         self.assertEquals([u'Meeting T\xc3\xb6mpl\xc3\xb6te'], browser.css('h1').text)
 
     @browsing
+    def test_deleting_paragraphtemplates_works_properly(self, browser):
+        self.login(self.administrator, browser)
+        browser.open(self.paragraph_template)
+        self.assertEqual(3, len(self.meeting_template.objectValues()))
+        expected_actions = ['Delete', 'Sharing']
+        available_actions = browser.css('#plone-contentmenu-actions .actionMenuContent a').text
+        self.assertEqual(expected_actions, available_actions)
+        browser.find('Delete').click()
+        # Confirmation
+        browser.find('Delete').click()
+        self.assertEqual(2, len(self.meeting_template.objectValues()))
+
+    @browsing
     def test_add_meeting_from_template(self, browser):
         self.login(self.committee_responsible, browser)
         committee_model = self.committee.load_model()

--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -445,12 +445,12 @@ class OpengeverContentFixture(object):
                 .titled(u'Meeting T\xc3\xb6mpl\xc3\xb6te')
                 .within(self.templates)
                 ))
-            create(
+            self.register('paragraph_template', create(
                 Builder('paragraphtemplate')
                 .titled(u'Begr\xfcssung')
                 .having(position=1)
                 .within(self.meeting_template)
-                )
+                ))
             create(
                 Builder('paragraphtemplate')
                 .titled(u'Gesch\xf0fte')


### PR DESCRIPTION
As the newly introduced deletability block is a bit of a handful, I've introduced an easy to cleanup mixin for flagging things as deletable for now.

Closes #4848