### PR TITLE
Split search terms at non-alphanumeric characters

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -31,6 +31,7 @@ Changelog
 - Disallow replacing the file on proposal documents with a non-.docx file. [Rotonen]
 - Disallow removing the file from proposal documents. [Rotonen]
 - Bump lxml to 4.1.1. [Rotonen]
+- Split search terms at non-alphanumeric characters. [buchi]
 
 
 2018.4.4 (2018-09-17)

--- a/solr-conf/managed-schema
+++ b/solr-conf/managed-schema
@@ -271,6 +271,16 @@
         <tokenizer class="solr.WhitespaceTokenizerFactory"/>
         <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" />
+        <filter class="solr.WordDelimiterGraphFilterFactory"
+              splitOnCaseChange="0"
+              splitOnNumerics="0"
+              stemEnglishPossessive="0"
+              generateWordParts="1"
+              generateNumberParts="1"
+              catenateWords="0"
+              catenateNumbers="0"
+              catenateAll="0"
+              preserveOriginal="1"/>
         <filter class="solr.LowerCaseFilterFactory"/>
       </analyzer>
     </fieldType>


### PR DESCRIPTION
Fixes:
https://extranet.4teamwork.ch/support/gever-st-gallen/tracker/341

Backport to `2018.4-stable`