### PR TITLE
Bump zope.testrunner to 4.8.1.

### DIFF
--- a/versions.cfg
+++ b/versions.cfg
@@ -217,4 +217,5 @@ z3c.saconfig = 0.14
 z3c.unconfigure = 1.0.1
 zc.buildout = 2.9.4
 zope.sqlalchemy = 0.7.7
+zope.testrunner = 4.8.1
 zptlint = 0.2.4


### PR DESCRIPTION
We were previously on `4.4.4`.

Rationales / changes:

* We can now do this as we're not running anything in a way which depends on clean layer teardowns
  * /cc @jone
  * We still cannot do sequential runs of the full stack or certain modules
  * `4.4.5` sorts sequential runs to reuse layer setups better, which flares this up further
* `4.4.8` improves the use of multiple test filters - knocks a full minute of wallclock time off all `bin/mtest` runs
* `4.4.9` parallelises `bin/test -j` runs starting from the first layer by introducing an implicit `.EmptyLayer` to run first
* `4.5.0` using `-x` will actually stop the whole test run when the first error is encountered, instead of just stopping the current layer
* `4.8.0` and `4.8.1` bleed through more categories of deprecation warnings, which can be a bit noisy, but some of them seem currently relevant for us, so I'd rather see them there
  * If people dislike this, we can pin this to `4.5.0` for now to get a balance of the usability improvements