### PR TITLE
Unsplit the meeting layer in mtest

### DIFF
--- a/bin/mtest
+++ b/bin/mtest
@@ -162,7 +162,6 @@ def split(batch):
     minsize_mapping = {
         'opengever.core.testing.opengever.core:integration': 200,
         'opengever.core.testing.opengever.core:functional': 100,
-        'opengever.core.testing.MeetingLayer': 25,
         }
 
     layer = batch.get('layer')


### PR DESCRIPTION
The meeting layer tests do not stick out runtime-wise like a sore thumb anymore thanks to @deiferni, so we can stop splitting them within-layer and not duplicate the layer setup in mtest.