### PR TITLE
Only allow adding meeting templates, when meeting feature is enabled.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2018.5.0 (unreleased)
 ---------------------
 
+- Only allow adding meeting templates, when meeting feature is enabled. [phgross]
 - Add TaskReminderActivity object. [elioschmutz]
 - Make paragraph templates deletable. [Rotonen]
 - Add ReminderSetting SQL Model. [elioschmutz]

--- a/opengever/dossier/templatefolder/templatefolder.py
+++ b/opengever/dossier/templatefolder/templatefolder.py
@@ -43,10 +43,9 @@ class TemplateFolder(Container, TranslatedTitleMixin):
 
         def filter_type(fti):
             factory_type = fti.id
-            if factory_type in [u'opengever.meeting.sablontemplate']:
-                return is_meeting_feature_enabled()
-
-            if factory_type in [u'opengever.meeting.proposaltemplate']:
+            if factory_type in [u'opengever.meeting.sablontemplate',
+                                u'opengever.meeting.proposaltemplate',
+                                u'opengever.meeting.meetingtemplate']:
                 return is_meeting_feature_enabled()
 
             if factory_type in [u'opengever.dossier.dossiertemplate']:

--- a/opengever/dossier/tests/test_templatefolder.py
+++ b/opengever/dossier/tests/test_templatefolder.py
@@ -649,7 +649,7 @@ class TestTemplateFolder(FunctionalTestCase):
         browser.login().open(templatefolder)
 
         self.assertEquals(
-            ['Document', 'Meeting Template', 'TaskTemplateFolder', 'Template Folder'],
+            ['Document', 'TaskTemplateFolder', 'Template Folder'],
             factoriesmenu.addable_types())
 
     @skip("This test currently fails in a flaky way on CI."
@@ -1037,7 +1037,6 @@ class TestDossierTemplateFeature(IntegrationTestCase):
 
         expected_addable_types = ['Document',
                                   'Dossier template',
-                                  'Meeting Template',
                                   'TaskTemplateFolder',
                                   'Template Folder']
         self.assertEqual(expected_addable_types, factoriesmenu.addable_types())


### PR DESCRIPTION
This works for the action, as well for the API

Closes #4905 

Backport to: `2018.4-stable`