### PR TITLE
Prevent double registrations in the fixtures

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -577,7 +577,7 @@ Objects
           - self.draft_proposal
           - self.draft_word_proposal
           - self.empty_document
-          - self.mail
+          - self.mail_eml
           - self.mail_msg
           - self.proposal
             - self.proposaldocument

--- a/opengever/api/tests/test_mail.py
+++ b/opengever/api/tests/test_mail.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from ftw.testbrowser import browsing
 from opengever.mail.mail import IOGMail
 from opengever.testing import IntegrationTestCase
@@ -13,25 +12,24 @@ class TestGetMail(IntegrationTestCase):
     @browsing
     def test_contains_also_original_message(self, browser):
         self.login(self.regular_user, browser)
-        IOGMail(self.mail).original_message = NamedBlobFile(
+        IOGMail(self.mail_eml).original_message = NamedBlobFile(
             data='__DATA__', filename=u'testmail.msg')
 
-        browser.open(self.mail.absolute_url(), method='GET',
+        browser.open(self.mail_eml.absolute_url(), method='GET',
                      headers={'Accept': 'application/json',
                               'Content-Type': 'application/json'})
         self.assertEqual(200, browser.status_code)
-        self.assertEqual(
-            {u'content-type': u'application/vnd.ms-outlook',
-             u'download': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/document-29/@@download/original_message',
-             u'filename': u'testmail.msg',
-             u'size': 8},
-            browser.json.get('original_message'))
+        expected_message = {
+            u'content-type': u'application/vnd.ms-outlook',
+            u'download': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/document-29'
+                         u'/@@download/original_message',
+            u'filename': u'testmail.msg',
+            u'size': 8,
+        }
+        self.assertEqual(expected_message, browser.json.get('original_message'))
 
 
 class TestCreateMail(IntegrationTestCase):
-
-    def setUp(self):
-        super(TestCreateMail, self).setUp()
 
     @browsing
     def test_create_mail_from_msg_converts_to_eml(self, browser):
@@ -72,12 +70,11 @@ class TestCreateMail(IntegrationTestCase):
                 headers={'Accept': 'application/json',
                          'Content-Type': 'application/json'})
 
-
         self.assertEqual(browser.status_code, 201)
         self.assertEqual(1, len(children.get('added')))
 
         mail = children['added'].pop()
-        self.assertEqual(mail.Title(), 'Äusseres Testmäil')
+        self.assertEqual(mail.Title(), '\xc3\x84usseres Testm\xc3\xa4il')
         self.assertEqual(mail.message.filename, 'Aeusseres Testmaeil.eml')
         self.assertEqual(mail.original_message, None)
 
@@ -113,26 +110,26 @@ class TestPatchMail(IntegrationTestCase):
     def test_updating_the_title(self, browser):
         self.login(self.regular_user, browser)
         browser.open(
-            self.mail.absolute_url(),
+            self.mail_eml.absolute_url(),
             data=json.dumps({'title': u'New title'}),
             method='PATCH',
             headers={'Accept': 'application/json',
                      'Content-Type': 'application/json'})
 
         self.assertEqual(browser.status_code, 204)
-        self.assertEqual(self.mail.Title(), 'New title')
-        self.assertEqual(self.mail.title, u'New title')
+        self.assertEqual(self.mail_eml.Title(), 'New title')
+        self.assertEqual(self.mail_eml.title, u'New title')
 
     @browsing
     def test_updating_other_metadata(self, browser):
         self.login(self.regular_user, browser)
         browser.open(
-            self.mail.absolute_url(),
+            self.mail_eml.absolute_url(),
             data=json.dumps({'description': u'Lorem ipsum'}),
             method='PATCH',
             headers={'Accept': 'application/json',
                      'Content-Type': 'application/json'})
 
         self.assertEqual(browser.status_code, 204)
-        self.assertEqual(self.mail.title, u'Die B\xfcrgschaft')
-        self.assertEqual(self.mail.description, 'Lorem ipsum')
+        self.assertEqual(self.mail_eml.title, u'Die B\xfcrgschaft')
+        self.assertEqual(self.mail_eml.description, 'Lorem ipsum')

--- a/opengever/api/tests/test_serializer.py
+++ b/opengever/api/tests/test_serializer.py
@@ -66,6 +66,6 @@ class TestDocumentSerializer(IntegrationTestCase):
     @browsing
     def test_mail_serialization_contains_reference_number(self, browser):
         self.login(self.regular_user, browser)
-        browser.open(self.mail, headers={'Accept': 'application/json'})
+        browser.open(self.mail_eml, headers={'Accept': 'application/json'})
         self.assertEqual(browser.status_code, 200)
         self.assertEqual(browser.json.get(u'reference_number'), u'Client1 1.1 / 1 / 29')

--- a/opengever/base/tests/test_contentlisting.py
+++ b/opengever/base/tests/test_contentlisting.py
@@ -126,7 +126,7 @@ class TestOpengeverContentListing(IntegrationTestCase):
             )
 
         self.assertFalse(
-            IContentListingObject(obj2brain(self.mail)).is_document,
+            IContentListingObject(obj2brain(self.mail_eml)).is_document,
             )
 
         self.assertFalse(
@@ -243,7 +243,7 @@ class TestBrainContentListingRenderLink(IntegrationTestCase):
 
         self.assertEquals(
             u'PATCHED LINK Die B\xfcrgschaft'.encode('utf-8'),
-            IContentListingObject(obj2brain(self.mail)).render_link(),
+            IContentListingObject(obj2brain(self.mail_eml)).render_link(),
             )
 
     @browsing

--- a/opengever/base/tests/test_copy_paste.py
+++ b/opengever/base/tests/test_copy_paste.py
@@ -23,7 +23,7 @@ class TestCopyItems(IntegrationTestCase):
     def test_redirects_back_and_show_statusmessage_if_copy_success(self, browser):
         self.login(self.regular_user, browser=browser)
 
-        data = self.make_path_param(self.document, self.mail)
+        data = self.make_path_param(self.document, self.mail_eml)
         browser.open(self.dossier, data=data, view='copy_items')
 
         self.assertEqual(self.dossier.absolute_url(), browser.url)
@@ -56,16 +56,16 @@ class TestCopyItem(IntegrationTestCase):
     @browsing
     def test_statusmessage_if_copy_mail_success(self, browser):
         self.login(self.regular_user, browser=browser)
-        browser.open(self.mail, view='copy_item')
+        browser.open(self.mail_eml, view='copy_item')
 
-        self.assertEqual(self.mail.absolute_url(), browser.url)
+        self.assertEqual(self.mail_eml.absolute_url(), browser.url)
         self.assertEqual(['Selected objects successfully copied.'],
                          info_messages())
 
     @browsing
     def test_statusmessage_if_paste_mail_success(self, browser):
         self.login(self.regular_user, browser=browser)
-        browser.open(self.mail, view='copy_item')
+        browser.open(self.mail_eml, view='copy_item')
 
         browser.open(self.empty_dossier, view='tabbed_view')
         browser.css('#contentActionMenus a#paste').first.click()

--- a/opengever/base/tests/test_default_values_for_types.py
+++ b/opengever/base/tests/test_default_values_for_types.py
@@ -970,7 +970,7 @@ class TestMailDefaults(TestDefaultsBase):
         return message_value
 
     def get_obj_of_own_type(self):
-        return self.mail
+        return self.mail_eml
 
     def test_create_content_in_container(self):
         self.login(self.regular_user)

--- a/opengever/base/tests/test_object_touched_handling.py
+++ b/opengever/base/tests/test_object_touched_handling.py
@@ -66,7 +66,7 @@ class TestObjectTouchedLogging(IntegrationTestCase):
 
         with freeze(FROZEN_NOW):
             notify(ObjectTouchedEvent(self.document))
-            notify(ObjectTouchedEvent(self.mail))
+            notify(ObjectTouchedEvent(self.mail_eml))
 
         recently_touched_log = self._get_log(self.regular_user)
 

--- a/opengever/base/tests/test_object_touched_triggering.py
+++ b/opengever/base/tests/test_object_touched_triggering.py
@@ -51,7 +51,7 @@ class TestObjectTouchedTriggering(IntegrationTestCase):
         self.login(self.regular_user)
 
         register_event_recorder(IObjectTouchedEvent)
-        notify(ObjectAddedEvent(self.mail))
+        notify(ObjectAddedEvent(self.mail_eml))
 
         event = get_last_recorded_event()
         self.assertTrue(IObjectTouchedEvent.providedBy(event))

--- a/opengever/bumblebee/tests/test_overlay_adapter_mail.py
+++ b/opengever/bumblebee/tests/test_overlay_adapter_mail.py
@@ -12,7 +12,7 @@ class TestAdapterRegisteredProperly(IntegrationTestCase):
 
     def test_get_overlay_adapter_for_mails(self):
         self.login(self.regular_user)
-        adapter = getMultiAdapter((self.mail, self.request), IBumblebeeOverlay)
+        adapter = getMultiAdapter((self.mail_eml, self.request), IBumblebeeOverlay)
 
         self.assertIsInstance(adapter, BumblebeeMailOverlay)
 
@@ -26,14 +26,14 @@ class TestHasFile(IntegrationTestCase):
 
     def test_returns_true_if_mail_has_a_file(self):
         self.login(self.regular_user)
-        adapter = getMultiAdapter((self.mail, self.request), IBumblebeeOverlay)
+        adapter = getMultiAdapter((self.mail_eml, self.request), IBumblebeeOverlay)
 
         self.assertTrue(adapter.has_file())
 
     def test_returns_false_if_mail_has_no_file(self):
         self.login(self.regular_user)
-        IMail(self.mail).message = None
-        adapter = getMultiAdapter((self.mail, self.request), IBumblebeeOverlay)
+        IMail(self.mail_eml).message = None
+        adapter = getMultiAdapter((self.mail_eml, self.request), IBumblebeeOverlay)
 
         self.assertFalse(adapter.has_file())
 
@@ -44,16 +44,16 @@ class TestGetFile(IntegrationTestCase):
 
     def test_returns_none_if_document_has_no_file(self):
         self.login(self.regular_user)
-        IMail(self.mail).message = None
-        adapter = getMultiAdapter((self.mail, self.request), IBumblebeeOverlay)
+        IMail(self.mail_eml).message = None
+        adapter = getMultiAdapter((self.mail_eml, self.request), IBumblebeeOverlay)
 
         self.assertIsNone(adapter.get_file())
 
     def test_returns_file_if_document_has_file(self):
         self.login(self.regular_user)
-        adapter = getMultiAdapter((self.mail, self.request), IBumblebeeOverlay)
+        adapter = getMultiAdapter((self.mail_eml, self.request), IBumblebeeOverlay)
 
-        self.assertEqual(self.mail.message, adapter.get_file())
+        self.assertEqual(self.mail_eml.message, adapter.get_file())
 
 
 class TestGetOpenAsPdfLink(IntegrationTestCase):
@@ -62,7 +62,7 @@ class TestGetOpenAsPdfLink(IntegrationTestCase):
 
     def test_returns_none_for_unsupported_mail_conversion(self):
         self.login(self.regular_user)
-        adapter = getMultiAdapter((self.mail, self.request), IBumblebeeOverlay)
+        adapter = getMultiAdapter((self.mail_eml, self.request), IBumblebeeOverlay)
 
         expected_url = (
             'http://nohost/plone/ordnungssystem/fuhrung'
@@ -74,8 +74,8 @@ class TestGetOpenAsPdfLink(IntegrationTestCase):
 
     def test_handles_non_ascii_characters_in_filename(self):
         self.login(self.regular_user)
-        IMail(self.mail).message.filename = u'GEVER - \xdcbernahme.msg'
-        adapter = getMultiAdapter((self.mail, self.request), IBumblebeeOverlay)
+        IMail(self.mail_eml).message.filename = u'GEVER - \xdcbernahme.msg'
+        adapter = getMultiAdapter((self.mail_eml, self.request), IBumblebeeOverlay)
 
         expected_url = (
             u'http://nohost/plone/ordnungssystem/fuhrung'
@@ -92,7 +92,7 @@ class TestGetCheckoutUrl(IntegrationTestCase):
 
     def test_returns_none_because_its_not_possible_to_checkout_emails(self):
         self.login(self.regular_user)
-        adapter = getMultiAdapter((self.mail, self.request), IBumblebeeOverlay)
+        adapter = getMultiAdapter((self.mail_eml, self.request), IBumblebeeOverlay)
 
         self.assertIsNone(adapter.get_checkout_url())
 
@@ -103,7 +103,7 @@ class TestGetCheckinWithoutCommentUrl(IntegrationTestCase):
 
     def test_returns_none_because_its_not_possible_to_checkin_emails(self):
         self.login(self.regular_user)
-        adapter = getMultiAdapter((self.mail, self.request), IBumblebeeOverlay)
+        adapter = getMultiAdapter((self.mail_eml, self.request), IBumblebeeOverlay)
 
         self.assertIsNone(adapter.get_checkin_without_comment_url())
 
@@ -114,6 +114,6 @@ class TestGetCheckinWithCommentUrl(IntegrationTestCase):
 
     def test_returns_none_because_its_not_possible_to_checkin_emails(self):
         self.login(self.regular_user)
-        adapter = getMultiAdapter((self.mail, self.request), IBumblebeeOverlay)
+        adapter = getMultiAdapter((self.mail_eml, self.request), IBumblebeeOverlay)
 
         self.assertIsNone(adapter.get_checkin_with_comment_url())

--- a/opengever/bumblebee/tests/test_overlay_view.py
+++ b/opengever/bumblebee/tests/test_overlay_view.py
@@ -227,7 +227,7 @@ class TestBumblebeeOverlayListing(IntegrationTestCase):
     def test_actions_with_mail(self, browser):
         self.login(self.regular_user, browser)
 
-        browser.open(self.mail, view='bumblebee-overlay-listing')
+        browser.open(self.mail_eml, view='bumblebee-overlay-listing')
 
         self.assertEqual(
             [
@@ -395,7 +395,7 @@ class TestBumblebeeOverlayDocument(IntegrationTestCase):
     def test_actions_with_mail(self, browser):
         self.login(self.regular_user, browser)
 
-        browser.open(self.mail, view="bumblebee-overlay-document")
+        browser.open(self.mail_eml, view="bumblebee-overlay-document")
 
         self.assertEqual(
             [

--- a/opengever/mail/tests/test_mail_previewtab.py
+++ b/opengever/mail/tests/test_mail_previewtab.py
@@ -11,9 +11,9 @@ class TestPreviewTab(IntegrationTestCase):
     @browsing
     def test_mail_preview_tab(self, browser):
         self.login(self.regular_user, browser)
-        self.change_mail_data(self.mail, MAIL_DATA)
+        self.change_mail_data(self.mail_eml, MAIL_DATA)
 
-        browser.open(self.mail, view='tabbedview_view-preview')
+        browser.open(self.mail_eml, view='tabbedview_view-preview')
 
         expect = [['From:', u'Freddy H\xf6lderlin <from@example.org>'],
                   ['Subject:', u'Die B\xfcrgschaft'],
@@ -27,9 +27,9 @@ class TestPreviewTab(IntegrationTestCase):
         self.login(self.regular_user, browser)
         mail_data = resource_string('opengever.mail.tests',
                                     'attachment_with_wrong_mimetype.txt')
-        self.change_mail_data(self.mail, mail_data)
+        self.change_mail_data(self.mail_eml, mail_data)
 
-        browser.open(self.mail, view='tabbedview_view-preview')
+        browser.open(self.mail_eml, view='tabbedview_view-preview')
 
         self.assertEquals([u'B\xfccher.txt'],
                           browser.css('div.mailAttachment a').text)
@@ -37,7 +37,7 @@ class TestPreviewTab(IntegrationTestCase):
     @browsing
     def test_preview_tab_can_be_disabled_by_registry_flag(self, browser):
         self.login(self.regular_user, browser)
-        browser.open(self.mail, view='tabbed_view')
+        browser.open(self.mail_eml, view='tabbed_view')
 
         self.assertEquals(
             ['Overview', 'Preview', 'Journal', 'Sharing'],
@@ -47,7 +47,7 @@ class TestPreviewTab(IntegrationTestCase):
             name='preview_tab_visible', interface=IMailTabbedviewSettings,
             value=False)
 
-        browser.open(self.mail, view='tabbed_view')
+        browser.open(self.mail_eml, view='tabbed_view')
         self.assertEquals(
             ['Overview', 'Journal', 'Sharing'],
             browser.css('.formTab').text)

--- a/opengever/meeting/tests/test_proposal.py
+++ b/opengever/meeting/tests/test_proposal.py
@@ -554,7 +554,7 @@ class TestProposal(IntegrationTestCase):
     @browsing
     def test_regression_proposal_submission_with_mails(self, browser):
         self.login(self.dossier_responsible, browser)
-        self.set_related_items(self.draft_proposal, [self.mail])
+        self.set_related_items(self.draft_proposal, [self.mail_eml])
         browser.open(self.draft_proposal, view='tabbedview_view-overview')
         browser.click_on('Submit')
         browser.click_on("Confirm")
@@ -567,7 +567,7 @@ class TestProposal(IntegrationTestCase):
 
         submitted_mail = submitted_proposal.get_documents()[0]
         self.assertSubmittedDocumentCreated(self.draft_proposal,
-                                            self.mail,
+                                            self.mail_eml,
                                             submitted_mail)
 
     @browsing
@@ -729,7 +729,7 @@ class TestProposal(IntegrationTestCase):
     def test_resubmit_rejected_proposal_with_mail_attachments(self, browser):
         with self.login(self.dossier_responsible, browser):
             self.draft_proposal.relatedItems.append(
-                self.as_relation_value(self.mail))
+                self.as_relation_value(self.mail_eml))
 
             browser.visit(self.draft_proposal, view='tabbedview_view-overview')
             browser.click_on('Submit')

--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -47,6 +47,7 @@ class OpengeverContentFixture(object):
         self._lookup_table = {
             'manager': ('user', SITE_OWNER_NAME),
             }
+        self._registered_paths = set()
 
         # Set up a static secret for the Zope acl_users JWT plugin
         # XXX - the __call__ based _lookup_table cannot be used within __init__
@@ -1442,7 +1443,10 @@ class OpengeverContentFixture(object):
         portal_path = '/'.join(api.portal.get().getPhysicalPath())
         if path.startswith(portal_path):
             path = path[len(portal_path):].lstrip('/')
+        if path in self._registered_paths:
+            raise ValueError('Trying to double register {}!'.format(path))
         self._lookup_table[attrname] = ('object', path)
+        self._registered_paths.add(path)
 
     def register_url(self, attrname, url):
         """Add an object to the lookup table by url.

--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -1142,13 +1142,11 @@ class OpengeverContentFixture(object):
 
     @staticuid()
     def create_emails(self):
-        self.mail_eml = self.register('mail_eml', create(
+        self.register('mail_eml', create(
             Builder("mail")
             .with_message(MAIL_DATA)
             .within(self.dossier)
             ))
-
-        self.register('mail', self.mail_eml)
 
         class MockMsg2MimeTransform(object):
 
@@ -1162,7 +1160,7 @@ class OpengeverContentFixture(object):
             transform=MockMsg2MimeTransform(),
             )
 
-        self.mail_msg = self.register('mail_msg', command.execute())
+        self.register('mail_msg', command.execute())
 
     @staticuid()
     def create_meetings(self):

--- a/opengever/testing/integration_test_case.py
+++ b/opengever/testing/integration_test_case.py
@@ -563,9 +563,8 @@ class IntegrationTestCase(TestCase):
         self.assertTrue(assignable.getBlacklistStatus(CONTEXT_CATEGORY))
 
     def change_mail_data(self, mail, data):
-        old_file = IMail(self.mail).message
-        IMail(self.mail).message = NamedBlobFile(
-            data=data, filename=old_file.filename)
+        old_file = IMail(mail).message
+        IMail(mail).message = NamedBlobFile(data=data, filename=old_file.filename)
 
     def agenda_item_url(self, agenda_item, endpoint):
         return '{}/agenda_items/{}/{}'.format(


### PR DESCRIPTION
Ended up here from https://github.com/4teamwork/opengever.core/pull/4829

* Make everything use explicit `self.mail_eml`
* Add a test for preventing object double registrations

Closes https://github.com/4teamwork/opengever.core/issues/4911