### PR TITLE
Enable the meeting feature for meeting template tests

### DIFF
--- a/opengever/meeting/tests/test_meeting_template.py
+++ b/opengever/meeting/tests/test_meeting_template.py
@@ -8,6 +8,10 @@ import json
 
 class TestMeetingTemplate(IntegrationTestCase):
 
+    features = (
+        'meeting',
+    )
+
     @browsing
     def test_adding_meetingtemplate_works_properly(self, browser):
         self.login(self.dossier_responsible, browser=browser)


### PR DESCRIPTION
My bad, must have misread the test having been green when merging https://github.com/4teamwork/opengever.core/pull/4912

Backport to `2018.4-stable`