### PR TITLE
Allow users to retry creating a file from a Oneoffixx template

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -12,6 +12,7 @@ Changelog
 - Remove leftover checkout and edit, and cancel actions for sablon and proposal templates. [njohner]
 - Do not include paragraphs in comittee table of contents. [njohner]
 - Add TaskReminder to handle reminders in annotations and sql. [elioschmutz]
+- Allow users to retry creating a file from a Oneoffixx template. [Rotonen]
 - Add TaskReminderActivity object. [elioschmutz]
 - Make paragraph templates deletable. [Rotonen]
 - Add ReminderSetting SQL Model. [elioschmutz]

--- a/opengever/document/browser/actionbuttons.py
+++ b/opengever/document/browser/actionbuttons.py
@@ -1,5 +1,6 @@
-from opengever.document.browser.download import DownloadConfirmationHelper
 from opengever.document import _
+from opengever.document.browser.download import DownloadConfirmationHelper
+from opengever.document.document import IDocumentSchema
 from opengever.document.interfaces import ICheckinCheckoutManager
 from opengever.officeconnector.helpers import is_officeconnector_attach_feature_enabled  # noqa
 from plone import api
@@ -90,6 +91,12 @@ class ActionButtonRendererMixin(object):
                     )
 
         return dc_helper.get_html_tag(**kwargs)
+
+    def is_document(self):
+        return IDocumentSchema.providedBy(self.context)
+
+    def is_oneoffixx_creatable(self):
+        return self.is_document() and self.context.is_oneoffixx_creatable()
 
     def is_attach_to_email_available(self):
         if not is_officeconnector_attach_feature_enabled():

--- a/opengever/document/browser/templates/macros.pt
+++ b/opengever/document/browser/templates/macros.pt
@@ -175,6 +175,16 @@
             </a>
         </tal:details_view>
 
+        <tal:oneoffixx tal:define="link context/absolute_url" tal:condition="view/is_oneoffixx_creatable">
+          <a tal:attributes="href string:javascript:officeConnectorCheckout('${context/absolute_url}/officeconnector_oneoffixx_url');
+                             data-document-url context/absolute_url"
+              class="function-revert oc-checkout"
+              href="#"
+              i18n:translate="label_retry_oneoffixx">
+              Oneoffixx retry
+          </a>
+        </tal:oneoffixx>
+
     </div>
 
     <tal:nofile tal:condition="not:context/has_file">

--- a/opengever/document/document.py
+++ b/opengever/document/document.py
@@ -6,7 +6,6 @@ from Acquisition import aq_parent
 from collective import dexteritytextindexer
 from ftw.mail.interfaces import IEmailAddress
 from ftw.tabbedview.interfaces import ITabbedviewUploadable
-from opengever.oneoffixx import is_oneoffixx_feature_enabled
 from opengever.base.interfaces import IRedirector
 from opengever.document import _
 from opengever.document.base import BaseDocumentMixin
@@ -18,6 +17,7 @@ from opengever.dossier.behaviors.dossier import IDossierMarker
 from opengever.meeting.proposal import ISubmittedProposal
 from opengever.officeconnector.helpers import create_oc_url
 from opengever.officeconnector.helpers import is_officeconnector_checkout_feature_enabled  # noqa
+from opengever.oneoffixx import is_oneoffixx_feature_enabled
 from opengever.task.task import ITask
 from plone import api
 from plone.app.versioningbehavior.behaviors import IVersionable
@@ -298,6 +298,9 @@ class Document(Item, BaseDocumentMixin):
 
     def is_shadow_document(self):
         return api.content.get_state(self) == self.shadow_state
+
+    def is_oneoffixx_creatable(self):
+        return is_oneoffixx_feature_enabled() and self.is_shadow_document()
 
     def is_checked_out(self):
         return self.checked_out_by() is not None

--- a/opengever/document/locales/de/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/de/LC_MESSAGES/opengever.document.po
@@ -526,6 +526,11 @@ msgstr "Aktenzeichen"
 msgid "label_related_documents"
 msgstr "Verwandte Dokumente"
 
+#. Default: "Oneoffixx retry"
+#: ./opengever/document/browser/templates/macros.pt
+msgid "label_retry_oneoffixx"
+msgstr "Mit Oneoffixx wiederholen"
+
 #. Default: "Revert"
 #: ./opengever/document/browser/versions_tab.py
 msgid "label_revert"

--- a/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
@@ -523,6 +523,11 @@ msgstr "Numéro de référence"
 msgid "label_related_documents"
 msgstr "Documents liés"
 
+#. Default: "Oneoffixx retry"
+#: ./opengever/document/browser/templates/macros.pt
+msgid "label_retry_oneoffixx"
+msgstr ""
+
 #. Default: "Revert"
 #: ./opengever/document/browser/versions_tab.py
 msgid "label_revert"

--- a/opengever/document/locales/opengever.document.pot
+++ b/opengever/document/locales/opengever.document.pot
@@ -523,6 +523,11 @@ msgstr ""
 msgid "label_related_documents"
 msgstr ""
 
+#. Default: "Oneoffixx retry"
+#: ./opengever/document/browser/templates/macros.pt
+msgid "label_retry_oneoffixx"
+msgstr ""
+
 #. Default: "Revert"
 #: ./opengever/document/browser/versions_tab.py
 msgid "label_revert"

--- a/opengever/document/static/officeconnector.js
+++ b/opengever/document/static/officeconnector.js
@@ -41,13 +41,13 @@
 
     function isDocumentLocked(documentURL) {
         return requestJSON(documentURL + "/status").pipe(function(data) {
-            return JSON.parse(data)["locked"];
+            return JSON.parse(data).locked;
         });
     }
 
     function checkout(documentURL) {
         return poll(function() {
-            return isDocumentLocked(documentURL)
+            return isDocumentLocked(documentURL);
         });
     }
 
@@ -83,41 +83,41 @@
 
 function openOfficeconnector(data) {
     // URLs the browser does not handle get passed onto the OS
-    window.location = data['url'];
+    window.location = data.url;
 }
 
 function alertUser(data) {
-    alert(JSON.parse(data["responseText"])["error"]["message"]);
+    alert(JSON.parse(data.responseText).error.message);
 }
 
 function officeConnectorCheckout(url) {
-    var officeconnector_config = {}
+    var officeconnector_config = {};
 
     officeconnector_config.url = url;
     officeconnector_config.headers = {};
-    officeconnector_config.headers['Accept'] = 'application/json';
+    officeconnector_config.headers.Accept = 'application/json';
 
     $.ajax(officeconnector_config).error(alertUser).done(openOfficeconnector);
 }
 
 function officeConnectorAttach(url) {
-    var officeconnector_config = {}
+    var officeconnector_config = {};
 
     officeconnector_config.url = url;
     officeconnector_config.headers = {};
-    officeconnector_config.headers['Accept'] = 'application/json';
+    officeconnector_config.headers.Accept = 'application/json';
 
     $.ajax(officeconnector_config).error(alertUser).done(openOfficeconnector);
 }
 
 function officeConnectorMultiAttach(url) {
-    var officeconnector_config = {}
+    var officeconnector_config = {};
 
     officeconnector_config.data = {};
     officeconnector_config.data.documents = [];
     officeconnector_config.dataType = 'json';
     officeconnector_config.headers = {};
-    officeconnector_config.headers['Accept'] = 'application/json';
+    officeconnector_config.headers.Accept = 'application/json';
     officeconnector_config.headers['Content-Type'] = 'application/json';
     officeconnector_config.type = 'POST';
     officeconnector_config.url = url;
@@ -129,11 +129,11 @@ function officeConnectorMultiAttach(url) {
     });
 
     if (officeconnector_config.data.documents.length > 0) {
-        var dossier_config = {}
+        var dossier_config = {};
 
         dossier_config.dataType = 'json';
         dossier_config.headers = {};
-        dossier_config.headers['Accept'] = 'application/json';
+        dossier_config.headers.Accept = 'application/json';
         dossier_config.type = 'GET';
         dossier_config.url = document.getElementsByTagName('base')[0].href + '/attributes';
 

--- a/opengever/oneoffixx/tests/test_oneoffixx.py
+++ b/opengever/oneoffixx/tests/test_oneoffixx.py
@@ -29,6 +29,18 @@ class TestCreateDocFromOneoffixxTemplate(IntegrationTestCase):
         self.assertTrue(browser.context.is_shadow_document())
 
     @browsing
+    def test_retry_button_visible_on_shadow_doc(self, browser):
+        self.login(self.regular_user, browser)
+        browser.open(self.dossier)
+        factoriesmenu.add('document_with_oneoffixx_template')
+        node = browser.css("#form-widgets-template-2574d08d-95ea-4639-beab-3103fe4c3bc7").first
+        browser.fill({'Title': 'A doc'})
+        browser.fill({'Template': node.get("title")})
+        browser.find('Save').click()
+        browser.open(browser.context, view='tabbedview_view-overview')
+        self.assertEqual(['Oneoffixx retry'], browser.css('a.oc-checkout').text)
+
+    @browsing
     def test_template_id_stored_in_annotations(self, browser):
         self.login(self.regular_user, browser)
         browser.open(self.dossier)


### PR DESCRIPTION
Split off from https://github.com/4teamwork/opengever.core/pull/4282

In case anything goes wrong, this is enabling us to let users retry, and for development and trying things out, this is undispensable.