### PR TITLE
 Fix bumblebee overlay link for not yet created initial version.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2018.5.0 (unreleased)
 ---------------------
 
+- Fix bumblebee overlay link for not yet created initial version. [phgross]
 - Only allow adding meeting templates, when meeting feature is enabled. [phgross]
 - Add TaskReminderActivity object. [elioschmutz]
 - Make paragraph templates deletable. [Rotonen]

--- a/opengever/document/browser/versions_tab.py
+++ b/opengever/document/browser/versions_tab.py
@@ -154,6 +154,11 @@ class VersionDataProxy(object):
             label = translate_text(_(u'label_revert', default=u'Revert'))
             return u'<span class="discreet">{}</span>'.format(label)
 
+    @property
+    def _bumblebee_url(self):
+        return "{}/@@bumblebee-overlay-listing?version_id={}".format(
+            self.url, self.version)
+
 
 class LazyHistoryMetadataProxy(object):
     """A proxy for CMFEditions `ShadowHistory` objects as returned by
@@ -298,6 +303,11 @@ class InitialVersionDataProxy(object):
             additional_classes=['standalone', 'function-download-copy'],
             viewname='download', include_token=True)
         return link
+
+    @property
+    def _bumblebee_url(self):
+        return "{}/@@bumblebee-overlay-listing".format(
+            self.url, self.version)
 
 
 class IVersionsSourceConfig(ITableSourceConfig):

--- a/opengever/document/tests/test_versions_tab.py
+++ b/opengever/document/tests/test_versions_tab.py
@@ -193,6 +193,8 @@ class TestVersionsTabWithBubmelbeeActivated(BaseVersionsTab):
 
 class TestVersionsTabForDocumentWithoutInitialVersion(FunctionalTestCase):
 
+    layer = OPENGEVER_FUNCTIONAL_BUMBLEBEE_LAYER
+
     def setUp(self):
         super(TestVersionsTabForDocumentWithoutInitialVersion, self).setUp()
 
@@ -209,6 +211,7 @@ class TestVersionsTabForDocumentWithoutInitialVersion(FunctionalTestCase):
         self.assertEquals(
             [{'Comment': 'Initial version',
               'Download copy': 'Download copy',
+              'Preview': 'Preview',
               'Revert': '',
               'Version': '0',
               'Date': 'Nov 06, 2016 12:00 AM',
@@ -227,3 +230,11 @@ class TestVersionsTabForDocumentWithoutInitialVersion(FunctionalTestCase):
         self.assertEquals(
             u'Document copied from task (task closed)',
             listing.dicts()[0].get('Comment'))
+
+    @browsing
+    def test_uses_working_copy_for_bumblebee_link(self, browser):
+        browser.login().open(self.document, view='tabbedview_view-versions')
+
+        self.assertEquals(
+            'http://nohost/plone/document-1/@@bumblebee-overlay-listing',
+            browser.find_link_by_text('Preview').get('href'))

--- a/opengever/tabbedview/helper.py
+++ b/opengever/tabbedview/helper.py
@@ -203,9 +203,7 @@ def linked_document(item, value):
 
 
 def linked_version_preview(item, value):
-    url = "{}/@@bumblebee-overlay-listing?version_id={}".format(
-        item.url, item.version)
-
+    url = item._bumblebee_url
     showroom_title = translate(
         _('label_showroom_version_title',
             default='Version ${version} of ${timestamp}',


### PR DESCRIPTION
Since 2017.6 (PR #3467) the initial version of a document is only created when really used. Which leads to a not working bumblebee overlay link, when the initial version does not exist yet. Closes #4917

I add a special handling to the `InitialVersionDataProxy`, which uses the working copy to fetch the document.

Backport to `2018.4.-stable`