### PR TITLE
Ignore Tika exceptions during indexing in Solr

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -37,6 +37,7 @@ Changelog
 - Bump lxml to 4.1.1. [Rotonen]
 - Split search terms at non-alphanumeric characters. [buchi]
 - Bump Lucene version used in Solr to 7.3.1. [buchi]
+- Ignore Tika exceptions during indexing in Solr. [buchi]
 
 
 2018.4.4 (2018-09-17)

--- a/solr-conf/solrconfig.xml
+++ b/solr-conf/solrconfig.xml
@@ -803,6 +803,7 @@
       <str name="lowernames">false</str>
       <str name="xpath">/xhtml:html/xhtml:body//text()</str>
       <str name="fmap.content">SearchableText</str>
+      <bool name="ignoreTikaException">true</bool>
       <str name="uprefix">ignored_</str>
     </lst>
   </requestHandler>


### PR DESCRIPTION
Makes sure that the metadata of a document gets indexed if an error occurs
during text extraction with Tika, e.g. because of an encrypted document.

It seems that the behavior has changed in newer Solr versions. With previous versions the metadata got indexed even though a Tika exception occured. With Solr 7.3.1 the document gets not indexed at all if Tika exception aren't ignored.