### PR TITLE
Do not include paragraphs in AlphabeticalToc.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ---------------------
 
 - Remove leftover checkout and edit, and cancel actions for sablon and proposal templates. [njohner]
+- Do not include paragraphs in comittee table of contents. [njohner]
 - Add TaskReminderActivity object. [elioschmutz]
 - Make paragraph templates deletable. [Rotonen]
 - Add ReminderSetting SQL Model. [elioschmutz]

--- a/opengever/meeting/tests/test_toc.py
+++ b/opengever/meeting/tests/test_toc.py
@@ -183,6 +183,11 @@ class TestAlphabeticalTOC(FunctionalTestCase):
         ))
 
         create(Builder('agenda_item').having(
+            meeting=self.meeting2,
+            is_paragraph=True,
+            title=u'I am a paragraph'))
+
+        create(Builder('agenda_item').having(
             meeting=self.meeting_after,
             title=u'I am after period end',
             decision_number=1,

--- a/opengever/meeting/toc/alphabetical.py
+++ b/opengever/meeting/toc/alphabetical.py
@@ -9,6 +9,7 @@ from opengever.meeting.utils import JsonDataProcessor
 from operator import itemgetter
 from sqlalchemy.orm import contains_eager
 from sqlalchemy.orm import joinedload
+from sqlalchemy.sql.expression import false
 import pytz
 
 
@@ -67,7 +68,8 @@ class AlphabeticalToc(object):
         # relevant day for the toc
         query = query.filter(Meeting.start >= datetime_from,
                              Meeting.start < datetime_to,
-                             Meeting.committee == self.period.committee
+                             Meeting.committee == self.period.committee,
+                             AgendaItem.is_paragraph == false()
                              )
         return query
 


### PR DESCRIPTION
We do not want paragraphs (intertitles) included in the table of contents (alphabetical or repository based).
I also updated the tests to make sure the intertitles are excluded from the tocs.

resolves #4907 

Sidenote: `description` of the agendaitems is not in the generated json, but as @deiferni pointed out, there is probably no one out there who wants the descriptions in the Toc. So I left it as is for now.