### PR TITLE
Remove checkout and edit, and cancel button.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2018.5.0 (unreleased)
 ---------------------
 
+- Remove leftover checkout and edit, and cancel actions for sablon and proposal templates. [njohner]
 - Fix bumblebee overlay link for not yet created initial version. [phgross]
 - Only allow adding meeting templates, when meeting feature is enabled. [phgross]
 - Add TaskReminderActivity object. [elioschmutz]

--- a/opengever/core/profiles/default/types/opengever.meeting.proposaltemplate.xml
+++ b/opengever/core/profiles/default/types/opengever.meeting.proposaltemplate.xml
@@ -109,24 +109,4 @@
     <permission value="opengever.document: Checkout" />
   </action>
 
-  <action
-      action_id="checkout_edit_document"
-      visible="True"
-      title="Checkout and edit"
-      url_expr="string:${object_url}/@@checkout_documents?mode=external&amp;_authenticator=${object/@@authenticator/token}"
-      condition_expr="python:path('object/@@checkout_control').is_checkout_allowed() and context.file != None"
-      category="object">
-    <permission value="opengever.document: Checkout" />
-  </action>
-
-  <action
-      action_id="cancel_document_checkout"
-      visible="True"
-      title="Cancel Checkout"
-      url_expr="string:${object_url}/@@cancel_document_checkouts?_authenticator=${object/@@authenticator/token}"
-      condition_expr="python:path('object/@@checkout_control').is_cancel_allowed()"
-      category="object">
-    <permission value="opengever.document: Cancel" />
-  </action>
-
 </object>

--- a/opengever/core/profiles/default/types/opengever.meeting.sablontemplate.xml
+++ b/opengever/core/profiles/default/types/opengever.meeting.sablontemplate.xml
@@ -128,26 +128,6 @@
     <permission value="opengever.document: Checkout" />
   </action>
 
-  <action
-      action_id="checkout_edit_document"
-      visible="True"
-      title="Checkout and edit"
-      url_expr="string:${object_url}/@@checkout_documents?mode=external&amp;_authenticator=${object/@@authenticator/token}"
-      condition_expr="python:path('object/@@checkout_control').is_checkout_allowed() and context.file != None"
-      category="object">
-    <permission value="opengever.document: Checkout" />
-  </action>
-
-  <action
-      action_id="cancel_document_checkout"
-      visible="True"
-      title="Cancel Checkout"
-      url_expr="string:${object_url}/@@cancel_document_checkouts?_authenticator=${object/@@authenticator/token}"
-      condition_expr="python:path('object/@@checkout_control').is_cancel_allowed()"
-      category="object">
-    <permission value="opengever.document: Cancel" />
-  </action>
-
   <!-- Menu Actions -->
   <action
       title="Fill meeting template"

--- a/opengever/core/upgrades/20181002134456_remove_checkout_edit_and_cancel_actions/upgrade.py
+++ b/opengever/core/upgrades/20181002134456_remove_checkout_edit_and_cancel_actions/upgrade.py
@@ -1,0 +1,17 @@
+from ftw.upgrade import UpgradeStep
+
+
+class RemoveCheckoutEditAndCancelActions(UpgradeStep):
+    """Remove checkout edit and cancel actions.
+    """
+
+    def __call__(self):
+        self.actions_remove_type_action(
+            'opengever.meeting.sablontemplate', "checkout_edit_document")
+        self.actions_remove_type_action(
+            'opengever.meeting.sablontemplate', "cancel_document_checkout")
+
+        self.actions_remove_type_action(
+            'opengever.meeting.proposaltemplate', "checkout_edit_document")
+        self.actions_remove_type_action(
+            'opengever.meeting.proposaltemplate', "cancel_document_checkout")


### PR DESCRIPTION
Remove the leftover `checkout and edit` and `cancel` buttons from 'proposaltemplate' and 'sablontemplate'.

These were forgotten when we removed these actions from the `opengever.document.document`

resolves #4824 