### PR TITLE
Task-Reminder Restapi-Endpoints to add and delete reminders

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,7 @@ Changelog
 
 - Exclude searchroots from subdossier listings. [Rotonen, lgraf]
 - Add filters (active and all) to membership listing. [njohner]
+- Add restapi endpoints to add and delete task-reminders. [elioschmutz]
 - Remove leftover checkout and edit, and cancel actions for sablon and proposal templates. [njohner]
 - Do not include paragraphs in comittee table of contents. [njohner]
 - Add TaskReminder to handle reminders in annotations and sql. [elioschmutz]

--- a/docs/public/dev-manual/api/index.rst
+++ b/docs/public/dev-manual/api/index.rst
@@ -22,6 +22,7 @@ Inhalt:
    metadata.rst
    config.rst
    favorite.rst
+   reminder.rst
    recently_touched.rst
    preview.rst
    examples/index.rst

--- a/docs/public/dev-manual/api/reminder.rst
+++ b/docs/public/dev-manual/api/reminder.rst
@@ -1,0 +1,75 @@
+.. _reminders:
+
+Aufgaben-Erinnerungen
+=====================
+
+Der ``@reminder`` Endpoint behandelt Erinnerungen für Aufgabe. Jeder Benutzer kann für jede Aufgabe eine eigene Erinnerung setzten.
+
+
+Erinnerung setzten:
+-------------------
+Mit einem POST Request wird eine neue Erinnerung gesetzt. Als Body wird das Attribut ``option_type`` erwartet.
+Wenn das Attribut einen Wert enthält, welcher nicht zulässig ist, wird eine Liste mit gültigen Werten zurückgegeben.
+
+
+**Beispiel-Request**:
+
+   .. sourcecode:: http
+
+       POST /task-1/@reminder HTTP/1.1
+       Accept: application/json
+
+       {
+        "option_type": "one_day_before"
+       }
+
+
+**Beispiel-Response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 204 No content
+
+
+Erinnerung aktualisieren:
+-------------------------
+Eine bestehende Erinnerung kann durch einen PATCH Request aktualisiert werden.
+
+
+**Beispiel-Request**:
+
+   .. sourcecode:: http
+
+       PATCH /task-1/@reminder HTTP/1.1
+       Accept: application/json
+
+       {
+        "option_type": "same_day"
+       }
+
+
+**Beispiel-Response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 204 No content
+
+
+Erinnerung entfernen:
+---------------------
+Eine bestehende Erinnerung kann durch einen DELETE Request gelöscht werden:
+
+
+**Beispiel-Request**:
+
+   .. sourcecode:: http
+
+       DELETE /task-1/@reminder HTTP/1.1
+       Accept: application/json
+
+
+**Beispiel-Response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 204 No Content

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -203,4 +203,28 @@
       permission="zope2.View"
       />
 
+  <plone:service
+      method="POST"
+      name="@reminder"
+      for="opengever.task.task.ITask"
+      factory=".reminder.TaskReminderPost"
+      permission="zope2.View"
+      />
+
+  <plone:service
+      method="PATCH"
+      name="@reminder"
+      for="opengever.task.task.ITask"
+      factory=".reminder.TaskReminderPatch"
+      permission="zope2.View"
+      />
+
+  <plone:service
+      method="DELETE"
+      name="@reminder"
+      for="opengever.task.task.ITask"
+      factory=".reminder.TaskReminderDelete"
+      permission="zope2.View"
+      />
+
 </configure>

--- a/opengever/api/reminder.py
+++ b/opengever/api/reminder.py
@@ -1,0 +1,99 @@
+from opengever.task.reminder import TASK_REMINDER_OPTIONS
+from opengever.task.reminder.reminder import TaskReminder
+from plone.restapi.deserializer import json_body
+from plone.restapi.services import Service
+from zExceptions import BadRequest
+
+
+error_msgs = {
+    'missing_option_type': "The request body requires the 'option_type' attribute.",
+    'non_existing_option_type': "The provided 'option_type' does not exists. "
+                                "Use one of the following options: {}".format(
+                                    ', '.join(TASK_REMINDER_OPTIONS.keys())),
+}
+
+
+class TaskReminderPost(Service):
+    """API endpoint to set a task-reminder for the current user.
+
+    POST /task/@reminder
+
+    Payload: {
+        "option_type": option_type
+         (see opengever.task.reminder.TASK_REMINDER_OPTIONS for possible option_types)
+    }
+
+    """
+    def reply(self):
+        data = json_body(self.request)
+        option_type = data.get('option_type')
+
+        if not option_type:
+            raise BadRequest(error_msgs.get('missing_option_type'))
+
+        reminder_option = TASK_REMINDER_OPTIONS.get(option_type)
+
+        if not reminder_option:
+            raise BadRequest(error_msgs.get('non_existing_option_type'))
+
+        task_reminder = TaskReminder()
+
+        if task_reminder.get_reminder(self.context):
+            self.request.response.setStatus(409)
+            return super(TaskReminderPost, self).reply()
+
+        task_reminder.set_reminder(self.context, reminder_option)
+
+        self.request.response.setStatus(204)
+        return super(TaskReminderPost, self).reply()
+
+
+class TaskReminderPatch(Service):
+    """API endpoint to reset a task-reminder for the current user.
+
+    PATCH /task/@reminder
+
+    Payload: {
+        "option_type": option_type
+         (see opengever.task.reminder.TASK_REMINDER_OPTIONS for possible option_types)
+    }
+
+    """
+    def reply(self):
+        data = json_body(self.request)
+        option_type = data.get('option_type')
+
+        reminder_option = TASK_REMINDER_OPTIONS.get(option_type)
+
+        if option_type and not reminder_option:
+            raise BadRequest(error_msgs.get('non_existing_option_type'))
+
+        if reminder_option:
+            task_reminder = TaskReminder()
+
+            if not task_reminder.get_reminder(self.context):
+                self.request.response.setStatus(404)
+                return super(TaskReminderPatch, self).reply()
+
+            task_reminder.set_reminder(self.context, reminder_option)
+
+        self.request.response.setStatus(204)
+        return super(TaskReminderPatch, self).reply()
+
+
+class TaskReminderDelete(Service):
+    """API endpoint to remove a task-reminder for the current user.
+
+    DELETE /task/@reminder
+    """
+
+    def reply(self):
+        task_reminder = TaskReminder()
+
+        if not task_reminder.get_reminder(self.context):
+            self.request.response.setStatus(404)
+            return super(TaskReminderDelete, self).reply()
+
+        task_reminder.clear_reminder(self.context)
+        self.request.response.setStatus(204)
+        return super(TaskReminderDelete, self).reply()

--- a/opengever/api/tests/test_reminder.py
+++ b/opengever/api/tests/test_reminder.py
@@ -1,0 +1,165 @@
+from ftw.testbrowser import browsing
+from opengever.api.reminder import error_msgs
+from opengever.task.reminder import TASK_REMINDER_ONE_DAY_BEFORE
+from opengever.task.reminder import TASK_REMINDER_ONE_WEEK_BEFORE
+from opengever.task.reminder.reminder import TaskReminder
+from opengever.testing import IntegrationTestCase
+import json
+
+
+class TestTaskReminderAPI(IntegrationTestCase):
+
+    def setUp(self):
+        super(TestTaskReminderAPI, self).setUp()
+        self.task_reminder = TaskReminder()
+        self.http_headers = {
+            'Accept': 'application/json',
+            'Content-Type': 'application/json'
+        }
+
+    @browsing
+    def test_post_adds_task_reminder(self, browser):
+        self.login(self.regular_user, browser)
+        payload = {'option_type': TASK_REMINDER_ONE_DAY_BEFORE.option_type}
+
+        self.assertIsNone(
+            self.task_reminder.get_reminder(self.task))
+
+        browser.open(
+            self.task.absolute_url() + '/@reminder',
+            data=json.dumps(payload),
+            method='POST',
+            headers=self.http_headers,
+        )
+
+        self.assertEqual(204, browser.status_code)
+        self.assertEqual(
+            TASK_REMINDER_ONE_DAY_BEFORE.option_type,
+            self.task_reminder.get_reminder(self.task).option_type)
+
+    @browsing
+    def test_post_raises_when_option_type_is_missing(self, browser):
+        self.login(self.regular_user, browser)
+        payload = {}
+
+        with browser.expect_http_error(400):
+            browser.open(
+                self.task.absolute_url() + '/@reminder',
+                data=json.dumps(payload),
+                method='POST',
+                headers=self.http_headers,
+            )
+
+        self.assertEqual(
+            {"message": error_msgs.get('missing_option_type'),
+             "type": "BadRequest"},
+            browser.json)
+
+    @browsing
+    def test_post_raises_409_when_adding_already_set_reminder(self, browser):
+        self.login(self.regular_user, browser)
+        self.task_reminder.set_reminder(self.task, TASK_REMINDER_ONE_DAY_BEFORE)
+
+        payload = {'option_type': TASK_REMINDER_ONE_WEEK_BEFORE.option_type}
+
+        with browser.expect_http_error(409):
+            browser.open(
+                self.task.absolute_url() + '/@reminder',
+                data=json.dumps(payload),
+                method='POST',
+                headers=self.http_headers,
+            )
+
+        self.assertEqual(
+            TASK_REMINDER_ONE_DAY_BEFORE.option_type,
+            self.task_reminder.get_reminder(self.task).option_type)
+
+    @browsing
+    def test_post_shows_possible_reminder_options_if_option_does_not_exists(self, browser):
+        self.login(self.regular_user, browser)
+        payload = {'option_type': 'not_existing_option_type'}
+
+        with browser.expect_http_error(400):
+            browser.open(
+                self.task.absolute_url() + '/@reminder',
+                data=json.dumps(payload),
+                method='POST',
+                headers=self.http_headers,
+            )
+
+        self.assertEqual(
+            {"message": error_msgs.get('non_existing_option_type'),
+             "type": "BadRequest"},
+            browser.json)
+
+    @browsing
+    def test_patch_updates_set_reminder(self, browser):
+        self.login(self.regular_user, browser)
+        self.task_reminder.set_reminder(self.task, TASK_REMINDER_ONE_DAY_BEFORE)
+
+        payload = {'option_type': TASK_REMINDER_ONE_WEEK_BEFORE.option_type}
+
+        browser.open(
+            self.task.absolute_url() + '/@reminder',
+            data=json.dumps(payload),
+            method='PATCH',
+            headers=self.http_headers,
+        )
+
+        self.assertEqual(204, browser.status_code)
+        self.assertEqual(
+            TASK_REMINDER_ONE_WEEK_BEFORE.option_type,
+            self.task_reminder.get_reminder(self.task).option_type)
+
+    @browsing
+    def test_patch_raises_404_when_updating_not_yet_set_reminder(self, browser):
+        self.login(self.regular_user, browser)
+
+        payload = {'option_type': TASK_REMINDER_ONE_WEEK_BEFORE.option_type}
+
+        with browser.expect_http_error(404):
+            browser.open(
+                self.task.absolute_url() + '/@reminder',
+                data=json.dumps(payload),
+                method='PATCH',
+                headers=self.http_headers,
+            )
+
+        self.assertIsNone(
+            self.task_reminder.get_reminder(self.task))
+
+    @browsing
+    def test_delete_removes_task_reminder(self, browser):
+        self.login(self.regular_user, browser)
+        self.task_reminder.set_reminder(self.task, TASK_REMINDER_ONE_DAY_BEFORE)
+
+        self.assertEqual(
+            TASK_REMINDER_ONE_DAY_BEFORE.option_type,
+            self.task_reminder.get_reminder(self.task).option_type)
+
+        browser.open(
+            self.task.absolute_url() + '/@reminder',
+            method='DELETE',
+            headers=self.http_headers,
+        )
+
+        self.assertEqual(204, browser.status_code)
+        self.assertIsNone(
+            self.task_reminder.get_reminder(self.task))
+
+    @browsing
+    def test_delete_raises_404_if_removing_non_existing_task_reminder(self, browser):
+        self.login(self.regular_user, browser)
+
+        self.assertIsNone(
+            self.task_reminder.get_reminder(self.task))
+
+        with browser.expect_http_error(404):
+            browser.open(
+                self.task.absolute_url() + '/@reminder',
+                method='DELETE',
+                headers={'Accept': 'application/json'},
+            )
+
+        self.assertIsNone(
+            self.task_reminder.get_reminder(self.task))


### PR DESCRIPTION
Dieser PR fügt die Task-Reminder Endpoints zu hinzufügen und löschen von Task-Reminders hinzu: `@reminder`.

Issuer: #4205 
Based on: #4736