### PR TITLE
Set setup.py version to 2018.5.0.dev0.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 import os
 
 
-version = '2018.4.3.dev0'
+version = '2018.5.0.dev0'
 maintainer = '4teamwork AG'
 
 


### PR DESCRIPTION
This was done already but has been lost due to a bugfix release made from `master` afterwards.