### PR TITLE
Add filters (active and all) to membership listing.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2018.5.0 (unreleased)
 ---------------------
 
+- Add filters (active and all) to membership listing. [njohner]
 - Remove leftover checkout and edit, and cancel actions for sablon and proposal templates. [njohner]
 - Do not include paragraphs in comittee table of contents. [njohner]
 - Add TaskReminderActivity object. [elioschmutz]

--- a/opengever/meeting/browser/committeetabs.py
+++ b/opengever/meeting/browser/committeetabs.py
@@ -1,5 +1,3 @@
-from Acquisition import aq_inner
-from Acquisition import aq_parent
 from ftw.table.interfaces import ITableSource
 from ftw.table.interfaces import ITableSourceConfig
 from opengever.meeting.browser.documents.proposalstab import ProposalListingTab
@@ -7,7 +5,6 @@ from opengever.meeting.model import Proposal
 from opengever.meeting.tabs.meetinglisting import MeetingListingTab
 from opengever.meeting.tabs.membershiplisting import MembershipListingTab
 from opengever.tabbedview import SqlTableSource
-from zope.browserpage.viewpagetemplatefile import ViewPageTemplateFile
 from zope.component import adapter
 from zope.interface import implementer
 from zope.interface import implements
@@ -19,16 +16,7 @@ class Meetings(MeetingListingTab):
 
 
 class Memberships(MembershipListingTab):
-
-    selection = ViewPageTemplateFile("templates/no_selection.pt")
-
-    sort_on = 'member_id'
-
-    enabled_actions = []
-    major_actions = []
-
-    def get_member_link(self, item, value):
-        return item.member.get_link(aq_parent(aq_inner(self.context)))
+    pass
 
 
 class ISubmittedProposalTableSourceConfig(ITableSourceConfig):

--- a/opengever/meeting/tests/test_membershiplisting.py
+++ b/opengever/meeting/tests/test_membershiplisting.py
@@ -1,0 +1,71 @@
+from datetime import datetime
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.testbrowser import browsing
+from ftw.testing import freeze
+from opengever.testing import IntegrationTestCase
+
+
+class TestMembershipListing(IntegrationTestCase):
+    features = ('meeting',)
+
+    maxDiff = None
+
+    @browsing
+    def test_filters(self, browser):
+        self.login(self.meeting_user, browser)
+
+        with freeze(datetime(2011, 6, 1)):
+            browser.open(self.committee,
+                         view='tabbedview_view-memberships',
+                         data={'membership_state_filter': 'filter_membership_all'})
+            self.assertItemsEqual(
+                ['Neruda Pablo', u'Sch\xf6ller Heidrun', 'Wendler Jens', u'W\xf6lfl Gerda'],
+                browser.css('#listing_container tbody tr td:first-child').text)
+
+            browser.open(self.committee,
+                         view='tabbedview_view-memberships',
+                         data={'membership_state_filter': 'filter_membership_active'})
+            self.assertItemsEqual(
+                ['Neruda Pablo'],
+                browser.css('#listing_container tbody tr td:first-child').text)
+
+        with freeze(datetime(2015, 6, 1)):
+            browser.open(self.committee,
+                         view='tabbedview_view-memberships',
+                         data={'membership_state_filter': 'filter_membership_active'})
+            self.assertItemsEqual(
+                [u'Sch\xf6ller Heidrun', 'Wendler Jens', u'W\xf6lfl Gerda'],
+                browser.css('#listing_container tbody tr td:first-child').text)
+
+    @browsing
+    def test_entries_are_sorted_by_membership_id(self, browser):
+        self.login(self.meeting_user, browser)
+        browser.open(self.committee,
+                     view='tabbedview_view-memberships',
+                     data={'membership_state_filter': 'filter_membership_all'})
+        self.assertEqual(
+            ['Neruda Pablo', u'Sch\xf6ller Heidrun', 'Wendler Jens', u'W\xf6lfl Gerda'],
+            browser.css('#listing_container tbody tr td:first-child').text)
+
+        member = create(
+            Builder('member')
+            .having(firstname="Hans", lastname="Schmidt")
+            )
+
+        create(
+            Builder('membership')
+            .having(
+                committee=self.committee,
+                member=member,
+                date_from=datetime(2013, 1, 1),
+                date_to=datetime(2018, 1, 1),
+                )
+            )
+
+        browser.open(self.committee,
+                     view='tabbedview_view-memberships',
+                     data={'membership_state_filter': 'filter_membership_all'})
+        self.assertEqual(
+            ['Neruda Pablo', 'Schmidt Hans', u'Sch\xf6ller Heidrun', 'Wendler Jens', u'W\xf6lfl Gerda'],
+            browser.css('#listing_container tbody tr td:first-child').text)


### PR DESCRIPTION
* Added filter for displaying only active memberships in the listing
* Added tests for the membership listing
* Clean up `Memberships` class

for the cleanup, I moved some code from `Memberships` to the parent class `MembershipListingTab`. This is more consistent with how the other ListingTabs are defined. I also removed some superfluous code:
```
enabled_actions = []
major_actions = []
```
are the defaults in `BaseListingTab`, so can be removed.  `get_member_link` was defined twice, but the definition in `MembershipListingTab` seemed to be unused.

![screen shot 2018-10-04 at 09 13 13](https://user-images.githubusercontent.com/7374243/46458394-ed5b6d00-c7b5-11e8-974c-a5eb63501f74.png)

![screen shot 2018-10-04 at 09 13 17](https://user-images.githubusercontent.com/7374243/46458396-ed5b6d00-c7b5-11e8-9884-0c7c04b134a8.png)

resolves #4244 