### PR TITLE
Custom Sablon Exceptions

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -13,6 +13,7 @@ Changelog
 - Escape description of document_added description object. [elioschmutz]
 - Use plone.protect class of confirm-action view. [elioschmutz]
 - Don't html-escape description for JSON data. [deiferni]
+- Introduce custom exception for errors in processing sablon templates. [njohner]
 - Assign correct roles in development content. [deiferni]
 - Place successor proposal button next to workflow buttons. [Kevin Bieri]
 - Remove document tooltip on touch devices. [Kevin Bieri]

--- a/opengever/base/browser/resources/generateToc.js
+++ b/opengever/base/browser/resources/generateToc.js
@@ -11,6 +11,9 @@
     request.responseType = "arraybuffer";
     request.onload = function() {
       loaded.resolve();
+      if (this.getResponseHeader('X-ogg-reload-page')) {
+        window.location.reload();
+      }
       var contentDisposition = this.getResponseHeader('content-disposition');
       var contentType = this.getResponseHeader('content-type');
       var filename = contentDisposition.match(/filename="(.+)"/)[1];

--- a/opengever/meeting/browser/meetings/agendaitem.py
+++ b/opengever/meeting/browser/meetings/agendaitem.py
@@ -7,6 +7,7 @@ from opengever.meeting import _
 from opengever.meeting.exceptions import CannotExecuteTransition
 from opengever.meeting.exceptions import MissingAdHocTemplate
 from opengever.meeting.exceptions import MissingMeetingDossierPermissions
+from opengever.meeting.exceptions import SablonProcessingFailed
 from opengever.meeting.exceptions import WrongAgendaItemState
 from opengever.meeting.proposal import ISubmittedProposal
 from opengever.meeting.protocol import ExcerptProtocolData
@@ -138,6 +139,11 @@ def return_jsonified_exceptions(func):
                   default=u"No ad-hoc agenda-item template has been "
                           u"configured."),
                 status=501).dump()
+
+        except SablonProcessingFailed:
+            return JSONResponse(getRequest()).error(
+                _('Error while processing Sablon template'),
+                status=500).dump()
 
     return wrapper
 

--- a/opengever/meeting/browser/meetings/agendaitem_list.py
+++ b/opengever/meeting/browser/meetings/agendaitem_list.py
@@ -4,6 +4,7 @@ from opengever.meeting.command import CreateGeneratedDocumentCommand
 from opengever.meeting.command import UpdateGeneratedDocumentCommand
 from opengever.meeting.exceptions import AgendaItemListAlreadyGenerated
 from opengever.meeting.exceptions import AgendaItemListMissingTemplate
+from opengever.meeting.exceptions import SablonProcessingFailed
 from opengever.meeting.model import Meeting
 from opengever.meeting.model.generateddocument import GeneratedAgendaItemList
 from plone import api
@@ -51,6 +52,10 @@ class GenerateAgendaItemList(BrowserView):
                 )
             api.portal.show_message(msg, self.request, type='error')
 
+        except SablonProcessingFailed:
+            msg = _(u'Error while processing Sablon template')
+            api.portal.show_message(msg, self.request, type='error')
+
         return self.request.RESPONSE.redirect(meeting.get_url())
 
     @classmethod
@@ -88,8 +93,14 @@ class UpdateAgendaItemList(BrowserView):
 
         command = UpdateGeneratedDocumentCommand(
             generated_doc, meeting, self.operations)
-        command.execute()
-        command.show_message()
+
+        try:
+            command.execute()
+            command.show_message()
+
+        except SablonProcessingFailed:
+            msg = _(u'Error while processing Sablon template')
+            api.portal.show_message(msg, self.request, type='error')
 
         return self.request.RESPONSE.redirect(meeting.get_url())
 

--- a/opengever/meeting/browser/protocol.py
+++ b/opengever/meeting/browser/protocol.py
@@ -1,3 +1,6 @@
+from opengever.meeting import _
+from opengever.meeting.exceptions import SablonProcessingFailed
+from plone import api
 from plone.protect.utils import addTokenToUrl
 from Products.Five.browser import BrowserView
 
@@ -16,8 +19,12 @@ class MergeDocxProtocol(BrowserView):
     def __call__(self):
         meeting = self.context.get_meeting()
 
-        command = meeting.update_protocol_document(
-            overwrite=self.request.get("overwrite") == "True")
-        command.show_message()
+        try:
+            command = meeting.update_protocol_document(
+                overwrite=self.request.get("overwrite") == "True")
+            command.show_message()
+        except SablonProcessingFailed:
+            msg = _(u'Error while processing Sablon template')
+            api.portal.show_message(msg, self.request, type='error')
 
         return self.request.RESPONSE.redirect(meeting.get_url())

--- a/opengever/meeting/browser/resources/meeting.js
+++ b/opengever/meeting/browser/resources/meeting.js
@@ -518,6 +518,7 @@
       }
       if (typeof(createExcerptDialog) !== 'undefined') {
         createExcerptDialog.close();
+        $('#confirm_create_excerpt .confirm').removeClass("loading");
       }
       renameAgendaItemDialog.cancel();
     };

--- a/opengever/meeting/browser/sablontemplate.py
+++ b/opengever/meeting/browser/sablontemplate.py
@@ -1,5 +1,7 @@
 from opengever.meeting.command import MIME_DOCX
+from opengever.meeting.exceptions import SablonProcessingFailed
 from opengever.meeting.sablon import Sablon
+from Products.CMFPlone.utils import safe_unicode
 from Products.Five.browser import BrowserView
 import json
 
@@ -69,8 +71,10 @@ class FillMeetingTemplate(BrowserView):
 
     def __call__(self):
         sablon = Sablon(self.context)
-        sablon.process(json.dumps(SAMPLE_MEETING_DATA))
-        assert sablon.is_processed_successfully(), sablon.stderr
+        try:
+            sablon.process(json.dumps(SAMPLE_MEETING_DATA))
+        except SablonProcessingFailed as err:
+            return safe_unicode(err.message)
 
         response = self.request.response
         response.setHeader('X-Theme-Disabled', 'True')

--- a/opengever/meeting/browser/toc.py
+++ b/opengever/meeting/browser/toc.py
@@ -29,9 +29,8 @@ class DownloadAlphabeticalTOC(BrowserView):
                           'not be generated.'),
                 request=self.request,
                 type='error')
-
-            return self.request.RESPONSE.redirect(
-                "{}/#periods".format(self.context.parent.absolute_url()))
+            response.setHeader('X-ogg-reload-page', "True")
+            return
 
         sablon = Sablon(template)
         try:

--- a/opengever/meeting/command.py
+++ b/opengever/meeting/command.py
@@ -195,7 +195,6 @@ class CreateGeneratedDocumentCommand(CreateDocumentCommand):
         template = self.document_operations.get_sablon_template(self.meeting)
         sablon = Sablon(template)
         sablon.process(self.document_operations.get_meeting_data(self.meeting).as_json())
-        assert sablon.is_processed_successfully(), sablon.stderr
         return sablon.file_data
 
     def execute(self):
@@ -333,8 +332,7 @@ class MergeDocxProtocolCommand(CreateGeneratedDocumentCommand):
         template = self._get_paragraph_template()
         if template is None:
             return
-
-        return Sablon(self._get_paragraph_template()).process(
+        return Sablon(template).process(
             ProtocolData(self.meeting, [agenda_item]).as_json())
 
     @instance.memoize
@@ -352,11 +350,8 @@ class UpdateGeneratedDocumentCommand(object):
 
     def generate_file_data(self):
         template = self.document_operations.get_sablon_template(self.meeting)
-        sablon = Sablon(template)
-        sablon.process(
-            self.document_operations.get_meeting_data(self.meeting).as_json())
-
-        assert sablon.is_processed_successfully(), sablon.stderr
+        data = self.document_operations.get_meeting_data(self.meeting).as_json()
+        sablon = Sablon(template).process(data)
         return sablon.file_data
 
     def execute(self):

--- a/opengever/meeting/exceptions.py
+++ b/opengever/meeting/exceptions.py
@@ -41,3 +41,7 @@ class WrongAgendaItemState(Exception):
 
 class CannotExecuteTransition(Exception):
     """The workflow transition cannot be executed."""
+
+
+class SablonProcessingFailed(Exception):
+    """Processing of the sablon template failed."""

--- a/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-10-24 12:57+0000\n"
+"POT-Creation-Date: 2018-10-26 07:04+0000\n"
 "PO-Revision-Date: 2017-10-23 18:40+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -125,6 +125,12 @@ msgstr "Löschen"
 #: ./opengever/meeting/command.py
 msgid "Document ${title} has already been submitted in that version."
 msgstr "Das Dokument ${title} wurde bereits in dieser Version eingereicht."
+
+#: ./opengever/meeting/browser/meetings/agendaitem.py
+#: ./opengever/meeting/browser/meetings/agendaitem_list.py
+#: ./opengever/meeting/browser/protocol.py
+msgid "Error while processing Sablon template"
+msgstr "Die Sablonvorlage konnte nicht verarbeitet werden"
 
 #: ./opengever/meeting/browser/proposalforms.py
 msgid "Existing document"

--- a/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-10-24 12:57+0000\n"
+"POT-Creation-Date: 2018-10-26 07:04+0000\n"
 "PO-Revision-Date: 2018-05-22 10:15+0000\n"
 "Last-Translator: Niklaus Johner <Niklaus.johner@4teamwork.ch>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-meeting/fr/>\n"
@@ -127,6 +127,12 @@ msgstr "Supprimer"
 #: ./opengever/meeting/command.py
 msgid "Document ${title} has already been submitted in that version."
 msgstr "Le document ${title} a déjà été soumis dans cette version."
+
+#: ./opengever/meeting/browser/meetings/agendaitem.py
+#: ./opengever/meeting/browser/meetings/agendaitem_list.py
+#: ./opengever/meeting/browser/protocol.py
+msgid "Error while processing Sablon template"
+msgstr "Le Modèle Sablon n'a pas pu être utilisé"
 
 #: ./opengever/meeting/browser/proposalforms.py
 msgid "Existing document"

--- a/opengever/meeting/locales/opengever.meeting.pot
+++ b/opengever/meeting/locales/opengever.meeting.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-10-24 12:57+0000\n"
+"POT-Creation-Date: 2018-10-26 07:04+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -123,6 +123,12 @@ msgstr ""
 
 #: ./opengever/meeting/command.py
 msgid "Document ${title} has already been submitted in that version."
+msgstr ""
+
+#: ./opengever/meeting/browser/meetings/agendaitem.py
+#: ./opengever/meeting/browser/meetings/agendaitem_list.py
+#: ./opengever/meeting/browser/protocol.py
+msgid "Error while processing Sablon template"
 msgstr ""
 
 #: ./opengever/meeting/browser/proposalforms.py

--- a/opengever/meeting/sablon.py
+++ b/opengever/meeting/sablon.py
@@ -1,3 +1,4 @@
+from opengever.meeting.exceptions import SablonProcessingFailed
 from os import environ
 from os.path import join
 from subprocess32 import PIPE
@@ -38,9 +39,10 @@ class Sablon(object):
                 stdin=PIPE, stdout=PIPE, stderr=PIPE)
             self.stdout, self.stderr = subprocess.communicate(input=json_data)
             self.returncode = subprocess.returncode
-            if self.is_processed_successfully():
-                with open(output_path, 'rb') as outfile:
-                    self.file_data = outfile.read()
+            if not self.is_processed_successfully():
+                raise SablonProcessingFailed(self.stderr)
+            with open(output_path, 'rb') as outfile:
+                self.file_data = outfile.read()
         finally:
             shutil.rmtree(tmpdir_path)
 

--- a/opengever/meeting/sablontemplate.py
+++ b/opengever/meeting/sablontemplate.py
@@ -2,6 +2,7 @@ from opengever.document.document import Document
 from opengever.document.document import IDocumentSchema
 from opengever.meeting import _
 from opengever.meeting.browser.sablontemplate import SAMPLE_MEETING_DATA
+from opengever.meeting.exceptions import SablonProcessingFailed
 from opengever.meeting.sablon import Sablon
 from os.path import join
 from plone.namedfile.field import NamedBlobFile
@@ -20,10 +21,11 @@ def sablon_template_is_valid(value):
     sablon = Sablon(None)
 
     for template_type, data in VALIDATION_DATA.items():
-        sablon.process(json.dumps(data), namedblobfile=value)
-        if sablon.is_processed_successfully():
+        try:
+            sablon.process(json.dumps(data), namedblobfile=value)
             return True
-
+        except SablonProcessingFailed:
+            continue
     return False
 
 

--- a/opengever/meeting/tests/test_toc.py
+++ b/opengever/meeting/tests/test_toc.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
+from ftw.testbrowser.exceptions import HTTPServerError
 from ftw.testbrowser.pages.statusmessages import error_messages
 from ftw.testing import freeze
 from opengever.core.testing import OPENGEVER_FUNCTIONAL_MEETING_LAYER
@@ -222,6 +223,9 @@ class TestAlphabeticalTOC(FunctionalTestCase):
     def test_shows_statusmessage_when_no_template_is_configured(self, browser):
         url = self.period.get_url(self.committee)
         browser.login().open(url, view='alphabetical_toc')
+        # when an error happens here, the view returns an error
+        # and the page is reloaded in Javascript. Here we reload manually
+        browser.open(url)
         self.assertEqual(u'There is no toc template configured, toc could '
                          'not be generated.',
                          error_messages()[0])
@@ -333,6 +337,9 @@ class TestTOCByRepository(TestAlphabeticalTOC):
     def test_shows_statusmessage_when_no_template_is_configured(self, browser):
         url = self.period.get_url(self.committee)
         browser.login().open(url, view='repository_toc')
+        # when an error happens here, the view returns an error
+        # and the page is reloaded in Javascript. Here we reload manually
+        browser.open(url)
         self.assertEqual(u'There is no toc template configured, toc could '
                          'not be generated.',
                          error_messages()[0])


### PR DESCRIPTION
We introduce a custom exception to handle failures when processing sablon templates.
Some of the sablons are requests issued from JavaScript, which are handled separately.
* We add a custom exception `SablonProcessingFailed` raised when processing fails. This exception adds an error message and reloads the page.
* For requests from JavaScript:
  * For agendaitems, we return the error in the JSON response
  * For TOC download, the response is not JSON, but an `arraybuffer`. We therefore cannot use the machinery of the `Controller` to handle the error. Instead we simply add an error message in Plone and then reload the page in JavaScript.
* Error handling of the TOC download was already present in the case of missing template, but it was broken. I fixed it as described above.

Here are snapshots of the different places the sablon errors are handled:
**Protocol generation**
![protocol](https://user-images.githubusercontent.com/7374243/46472426-6c17d080-c7dd-11e8-8baa-3f04783df2f3.png)
**TOC download**
![toc](https://user-images.githubusercontent.com/7374243/46472427-6c17d080-c7dd-11e8-9fed-1a135751773b.png)
**Agendaitem excerpts**
![excerpt](https://user-images.githubusercontent.com/7374243/46472428-6c17d080-c7dd-11e8-9776-062593e8e7b1.png)
**FillMeetingTemplateView**
![fill_meeting_template](https://user-images.githubusercontent.com/7374243/46472429-6c17d080-c7dd-11e8-83e2-e35ec5f724ef.png)

resolves #3792 