### PR TITLE
Display title for NullObject in meeting template selection.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ---------------------
 
 - Add trashing of protocol excerpts. [njohner]
+- Display title for NullObject in meeting template selection. [njohner]
 - Exclude searchroots from subdossier listings. [Rotonen, lgraf]
 - Add filters (active and all) to membership listing. [njohner]
 - Do not add a task-reminder activity if task is finished. [elioschmutz]

--- a/opengever/base/helper.py
+++ b/opengever/base/helper.py
@@ -1,0 +1,9 @@
+from opengever.base import _
+from opengever.base.utils import NullObject
+
+
+def title_helper(item, title):
+    if isinstance(item, NullObject):
+        return _(u'label_null', default=u'Null')
+    else:
+        return title

--- a/opengever/base/locales/de/LC_MESSAGES/opengever.base.po
+++ b/opengever/base/locales/de/LC_MESSAGES/opengever.base.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-10-01 07:46+0000\n"
+"POT-Creation-Date: 2018-10-04 14:07+0000\n"
 "PO-Revision-Date: 2014-09-04 01:03+0200\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: Jonas Baumann <j.baumann@4teamwork.ch>\n"
@@ -301,6 +301,11 @@ msgstr "Keine kürzlich bearbeiteten Dokumente"
 #: ./opengever/base/widgets.py
 msgid "label_none"
 msgstr "Keine Werte"
+
+#. Default: "Null"
+#: ./opengever/base/helper.py
+msgid "label_null"
+msgstr "Kein Wert"
 
 #. Default: "Overview"
 #: ./opengever/base/viewlets/favorites_menu.py

--- a/opengever/base/locales/fr/LC_MESSAGES/opengever.base.po
+++ b/opengever/base/locales/fr/LC_MESSAGES/opengever.base.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-10-01 07:46+0000\n"
+"POT-Creation-Date: 2018-10-04 14:07+0000\n"
 "PO-Revision-Date: 2017-11-29 10:53+0000\n"
 "Last-Translator: Philippe Gross <gross.philippe@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-base/fr/>\n"
@@ -299,6 +299,11 @@ msgstr "Aucun document modifié récemment"
 #. Default: "None"
 #: ./opengever/base/widgets.py
 msgid "label_none"
+msgstr "Aucune valeur"
+
+#. Default: "Null"
+#: ./opengever/base/helper.py
+msgid "label_null"
 msgstr "Aucune valeur"
 
 #. Default: "Overview"

--- a/opengever/base/locales/opengever.base.pot
+++ b/opengever/base/locales/opengever.base.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-10-01 07:46+0000\n"
+"POT-Creation-Date: 2018-10-04 14:07+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -297,6 +297,11 @@ msgstr ""
 #. Default: "None"
 #: ./opengever/base/widgets.py
 msgid "label_none"
+msgstr ""
+
+#. Default: "Null"
+#: ./opengever/base/helper.py
+msgid "label_null"
 msgstr ""
 
 #. Default: "Overview"

--- a/opengever/meeting/browser/meetings/meeting.py
+++ b/opengever/meeting/browser/meetings/meeting.py
@@ -5,6 +5,7 @@ from opengever.base.browser.wizard import BaseWizardStepForm
 from opengever.base.browser.wizard.interfaces import IWizardDataStorage
 from opengever.base.form import WizzardWrappedAddForm
 from opengever.base.handlebars import prepare_handlebars_template
+from opengever.base.helper import title_helper
 from opengever.base.model import create_session
 from opengever.base.oguid import Oguid
 from opengever.base.schema import TableChoice
@@ -62,7 +63,8 @@ class IMeetingModel(model.Schema):
         columns=(
             {'column': 'title',
              'column_title': _(u'label_title', default=u'Title'),
-             'sort_index': 'sortable_title'},
+             'sort_index': 'sortable_title',
+             'transform': title_helper},
             {'column': 'Creator',
              'column_title': _(u'label_creator', default=u'Creator'),
              'sort_index': 'document_author'},


### PR DESCRIPTION
The `TableRadioWidget` automatically adds the NullObject if the field is not required. A label is added for this element in the default columns, but for custom columns this element will not have a title. We add a helper that can be used as transform to handle this in a custom title column.

It seems likely that we will have the same issue in other `TableRadioWidget`. So I put the transform in `opengever.base` with a generic translation for the Null label.

![screen shot 2018-10-04 at 16 31 44](https://user-images.githubusercontent.com/7374243/46481180-1cdc9a80-c7f3-11e8-8c7a-2e5d0305429b.png)

resolves #4849