### PR TITLE
return fullname of responsible in dossier GET.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -9,6 +9,7 @@ Changelog
 - Display title for NullObject in meeting template selection. [njohner]
 - Fix styling of favorite button. [njohner]
 - Update the checksum when deleting attachments from E-mails. [njohner]
+- return fullname of responsible in dossier GET. [njohner]
 - Exclude searchroots from subdossier listings. [Rotonen, lgraf]
 - Add filters (active and all) to membership listing. [njohner]
 - Do not add a task-reminder activity if task is finished. [elioschmutz]

--- a/opengever/api/dossier.py
+++ b/opengever/api/dossier.py
@@ -14,6 +14,7 @@ class SerializeDossierToJson(SerializeFolderToJson):
     def __call__(self, *args, **kwargs):
         result = super(SerializeDossierToJson, self).__call__(*args, **kwargs)
 
+        result["responsible"] = self.context.get_responsible_actor().get_label(with_principal=False)
         result[u'reference_number'] = self.context.get_reference_number()
         result[u'email'] = IEmailAddress(self.request).get_email_for_object(
             self.context)

--- a/opengever/api/tests/test_serializer.py
+++ b/opengever/api/tests/test_serializer.py
@@ -48,6 +48,13 @@ class TestDossierSerializer(IntegrationTestCase):
         self.assertEqual(browser.status_code, 200)
         self.assertEqual(browser.json.get(u'email'), u'1014013300@example.org')
 
+    @browsing
+    def test_dossier_serialization_contains_responsible_fullname(self, browser):
+        self.login(self.regular_user, browser)
+        browser.open(self.dossier, headers={'Accept': 'application/json'})
+        self.assertEqual(browser.status_code, 200)
+        self.assertEqual(browser.json.get(u'responsible'), u'Ziegler Robert')
+
 
 class TestDocumentSerializer(IntegrationTestCase):
 


### PR DESCRIPTION
Instead of user identifier, we return the fullname of the dossier responsible in a REST API dossier GET.

We could also return the label with principal: `fullname  (identifier)`

resolves #4820 