### PR TITLE
Revoke temporary roles also when closing direct-execution tasks.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2018.5.0 (unreleased)
 ---------------------
 
+- Revoke temporary roles also when closing direct-execution tasks. [phgross]
 - Exclude searchroots from subdossier listings. [Rotonen, lgraf]
 - Add filters (active and all) to membership listing. [njohner]
 - Do not add a task-reminder activity if task is finished. [elioschmutz]

--- a/opengever/task/__init__.py
+++ b/opengever/task/__init__.py
@@ -34,5 +34,6 @@ FINAL_TASK_STATES = [
 FINAL_TRANSITIONS = [
     'task-transition-open-cancelled',
     'task-transition-open-tested-and-closed',
+    'task-transition-in-progress-tested-and-closed',
     'task-transition-resolved-tested-and-closed',
     'task-transition-planned-skipped']

--- a/opengever/task/tests/test_localroles.py
+++ b/opengever/task/tests/test_localroles.py
@@ -230,6 +230,21 @@ class TestLocalRolesRevoking(IntegrationTestCase):
         self.assertEquals([], storage._storage())
 
     @browsing
+    def test_closing_a_direct_execution_task_revokes_roles(self, browser):
+        self.login(self.regular_user, browser=browser)
+        self.subtask.task_type = 'direct-execution'
+        self.subtask.sync()
+        self.set_workflow_state('task-state-in-progress', self.subtask)
+
+        # close
+        browser.open(self.subtask, view='tabbedview_view-overview')
+        browser.click_on('task-transition-in-progress-tested-and-closed')
+        browser.click_on('Save')
+
+        storage = RoleAssignmentManager(self.subtask).storage
+        self.assertEquals([], storage._storage())
+
+    @browsing
     def test_skip_a_task_revokes_roles(self, browser):
         self.login(self.secretariat_user, browser=browser)
 


### PR DESCRIPTION
The transition from in-progress to closed, was not handled when introduced the role revoking on task finish (see #4656).

Backport to `2018.4-stable`