### PR TITLE
Move the favorite action just after the documentFirstHeading.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,7 @@ Changelog
 
 - Add trashing of protocol excerpts. [njohner]
 - Display title for NullObject in meeting template selection. [njohner]
+- Fix styling of favorite button. [njohner]
 - Exclude searchroots from subdossier listings. [Rotonen, lgraf]
 - Add filters (active and all) to membership listing. [njohner]
 - Do not add a task-reminder activity if task is finished. [elioschmutz]

--- a/plonetheme/teamraum/resources/rules.xml
+++ b/plonetheme/teamraum/resources/rules.xml
@@ -200,6 +200,13 @@
       <after content="//*[@id='portal-footer-wrapper']/div/script" css:theme="#container" />
       <after content="//*[@id='portal-footer-wrapper']/div/noscript" css:theme="#container" />
 
+      <!-- Move div#favorites-action out of the IBelowContentTitle viewlet and
+           place it after the title so we can style it as display:inline-block -->
+      <after content="//div[@id='content']//h1[@class='documentFirstHeading']">
+        <xsl:copy-of select="//div[@id='content']//div[@id='favorite-action']" />
+      </after>
+      <drop content="//div[@id='content']//div[@id='favorite-action']" />
+
     </rules>
   </rules>
 </rules>


### PR DESCRIPTION
The favorite-action is rendered by the below-content-title viewlet, but we actually want it on the same line as the title. This viewlet is rendered as a block in the default template, below the title. We use diazo here to move it outside of that viewlet and just after the document title.

This seems to fix the problem in all the mentioned cases:

**Dossier "view metadata"**
![screen shot 2018-10-08 at 14 42 29](https://user-images.githubusercontent.com/7374243/46609691-07c07e00-cb09-11e8-8083-eb812500c3e1.png)

**Paragraph template view**
![screen shot 2018-10-08 at 14 45 21](https://user-images.githubusercontent.com/7374243/46609692-07c07e00-cb09-11e8-88d9-187b6484970f.png)

And it did not break any of the other views, for example:
**Normal document with title spannign more than one line**
![screen shot 2018-10-08 at 14 42 24](https://user-images.githubusercontent.com/7374243/46609690-0727e780-cb09-11e8-9c6b-680298b5ae33.png)

resolves #4747 