### PR TITLE
Test no settings or features share a name

### DIFF
--- a/opengever/base/tests/test_get_setting_view.py
+++ b/opengever/base/tests/test_get_setting_view.py
@@ -27,3 +27,9 @@ class TestGetSettingView(IntegrationTestCase):
         self.login(self.regular_user)
         with self.assertRaises(KeyError):
             self.portal.unrestrictedTraverse("get_setting/foo")
+
+    def test_no_features_and_settings_share_names(self):
+        self.login(self.regular_user)
+        feature_names = IGeverSettings(self.portal).get_features().keys()
+        setting_names = IGeverSettings(self.portal).get_settings().keys()
+        self.assertFalse(set(feature_names) & set(setting_names))


### PR DESCRIPTION
When playing around with how to build the per instance configurability of Oneoffixx, I ended up noticing a fetch collision for the API endpoints for feature flags and settings. Asserting on no collisions sidesteps the issue.