### PR TITLE
OGGBundle: Fix encoding issue with UNC filepaths containing non-ASCII characters

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2018.5.0 (unreleased)
 ---------------------
 
+- OGGBundle: Fix encoding issue with UNC filepaths containing non-ASCII characters. [lgraf]
 - Send notification dispatch exceptions to Raven. [Rotonen]
 - Do not present the paste UI to users without 'Copy or Move' on the target. [Rotonen]
 - Add is_private field for tasks. [elioschmutz]

--- a/opengever/bundle/sections/fileloader.py
+++ b/opengever/bundle/sections/fileloader.py
@@ -134,6 +134,10 @@ class FileLoaderSection(object):
         # posix_mountpoint is the location where the fileshare has been
         # mounted on the POSIX system (Linux / OS X)
         posix_mountpoint = unc_mount_mapping[mount]
+
+        # Ingestion settings are loaded via JSON, so they are in unicode
+        posix_mountpoint = posix_mountpoint.encode('utf-8')
+
         relative_path = rest.replace('\\', '/').lstrip('/')
         abs_filepath = os.path.join(posix_mountpoint, relative_path)
         return abs_filepath

--- a/opengever/bundle/tests/assets/basic.oggbundle/documents.json
+++ b/opengever/bundle/tests/assets/basic.oggbundle/documents.json
@@ -45,6 +45,12 @@
     "review_state": "document-state-draft",
     "title": "Document referenced via UNC-Path"
   },  {
+    "guid": "173a585aea782074a2758d738772e8d7",
+    "parent_guid": "659645aec58d48a9b9663399ea2ec069",
+    "filepath": "\\\\host\\mount\\subdir\\wörd.docx",
+    "review_state": "document-state-draft",
+    "title": "Nonexistent document referenced via UNC-Path with Umlaut"
+  },  {
     "guid": "d65317ece1cb4dc797de1fc1e21bb4eb",
     "parent_reference": [
       [1, 1],

--- a/opengever/bundle/tests/test_bundle_loader.py
+++ b/opengever/bundle/tests/test_bundle_loader.py
@@ -30,7 +30,7 @@ class TestBundleLoader(TestCase):
 
     def test_loads_correct_number_of_items(self):
         bundle = self.load_bundle()
-        self.assertEqual(14, len(list(bundle)))
+        self.assertEqual(15, len(list(bundle)))
 
     def test_loads_items_in_correct_order(self):
         bundle = self.load_bundle()
@@ -48,6 +48,7 @@ class TestBundleLoader(TestCase):
              ('mail', 'Ein Mail'),
              ('mail', ''),
              ('document', 'Document referenced via UNC-Path'),
+             ('document', 'Nonexistent document referenced via UNC-Path with Umlaut'),
              ('document', 'Dokument in bestehendem Examplecontent Dossier'),
              ('mail', 'Mail in bestehendem Examplecontent Dossier')],
             [(get_portal_type(i), get_title(i)) for i in list(bundle)])
@@ -77,6 +78,7 @@ class TestBundleLoader(TestCase):
             ('document', 'Document referenced via UNC-Path'),
             ('document', 'Dokument in bestehendem Examplecontent Dossier'),
             ('document', 'Entlassung Hanspeter M\xc3\xbcller'),
+            ('document', 'Nonexistent document referenced via UNC-Path with Umlaut'),
             ('mail', ''),
             ('mail', 'Ein Mail'),
             ('mail', 'Mail in bestehendem Examplecontent Dossier'),

--- a/opengever/bundle/tests/test_section_bundlesource.py
+++ b/opengever/bundle/tests/test_section_bundlesource.py
@@ -34,7 +34,7 @@ class TestBundleSource(FunctionalTestCase):
 
     def test_yields_items_from_bundle(self):
         source = self.setup_source({})
-        self.assertEqual(14, len(list(source)))
+        self.assertEqual(15, len(list(source)))
 
     def test_raises_if_bundle_path_missing(self):
         transmogrifier = MockTransmogrifier()


### PR DESCRIPTION
This fixes an `UnicodeDecodeError` with UNC filepaths containing non-ASCII characters that wasn't previously covered by tests.

Fixes #4670