### PR TITLE
Fix sharing form local_roles inheritance fallback.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,7 @@ Changelog
 
 - OGGBundle: Fix encoding issue with UNC filepaths containing non-ASCII characters. [lgraf]
 - Send notification dispatch exceptions to Raven. [Rotonen]
+- Fix sharing-form local_roles inheritance fallback and skip it for administators and managers. [phgross]
 - Do not present the paste UI to users without 'Copy or Move' on the target. [Rotonen]
 - Add is_private field for tasks. [elioschmutz]
 - Add trashing of protocol excerpts. [njohner]

--- a/opengever/sharing/browser/sharing.py
+++ b/opengever/sharing/browser/sharing.py
@@ -288,7 +288,8 @@ class OpengeverSharingView(SharingView):
             global_roles = user.getRoles()
             local_roles = [r for r in context_roles if r not in global_roles]
             if local_roles:
-                context.manage_setLocalRoles(user.getId(), local_roles)
+                assignment = SharingRoleAssignment(user.getId(), local_roles)
+                RoleAssignmentManager(self.context).add_or_update_assignment(assignment)
 
         context.__ac_local_roles_block__ = True if block else None
 

--- a/opengever/sharing/browser/sharing.py
+++ b/opengever/sharing/browser/sharing.py
@@ -254,6 +254,9 @@ class OpengeverSharingView(SharingView):
         corresponding event. Needed for adding a Journalentry after a
         change of the inheritance
         """
+        user = api.user.get_current()
+        is_administrator = user.has_role('Administrator') or user.has_role('Manager')
+
         # Modifying local roles needs the "Sharing page: Delegate roles"
         # permission as well as "Modify portal content". However, we don't
         # want to give the "Role Manager" Role "Modify portal content",
@@ -280,10 +283,16 @@ class OpengeverSharingView(SharingView):
             context, 'portal_url').getPortalObject().getWrappedOwner()
         newSecurityManager(self.context, owner)
 
-        if block:
+        if block and not is_administrator:
             # If user has inherited local roles and removes inheritance,
             # locally set roles he inherited before
             # to avoid definitive lose of access (refs #11945)
+
+            # For administrators and managers we skip those fallback, because
+            # the access for those users is ensured by the global roles. So we
+            # can avoid local_roles assigned to a specific users, which we say
+            # should not be used usually.
+
             context_roles = user.getRolesInContext(context)
             global_roles = user.getRoles()
             local_roles = [r for r in context_roles if r not in global_roles]

--- a/opengever/sharing/tests/test_sharing.py
+++ b/opengever/sharing/tests/test_sharing.py
@@ -125,6 +125,30 @@ class TestOpengeverSharingIntegration(IntegrationTestCase):
         self.assertTrue(self.empty_dossier.__ac_local_roles_block__)
 
     @browsing
+    def test_stop_inheritance_fallback(self, browser):
+        self.login(self.dossier_responsible, browser=browser)
+
+        acl_users = api.portal.get_tool('acl_users')
+
+        roles =['Member', 'Role Manager']
+        acl_users.userFolderEditUser(self.dossier_responsible.id, None, list(roles), [])
+
+        data = json.dumps({"entries": [], "inherit": False})
+        browser.open(self.empty_dossier, data, view='@sharing', method='POST',headers={'Accept': 'application/json','Content-Type': 'application/json'})
+
+        self.assertTrue(self.empty_dossier.__ac_local_roles_block__)
+        self.assertEquals(
+            ((self.dossier_responsible.id,
+              ('Contributor', 'Owner', 'Editor', 'Reader')),),
+            self.empty_dossier.get_local_roles())
+
+        self.assertEquals(
+            [{'cause': 3,
+              'roles': ['Contributor', 'Editor', 'Reader', 'Owner'],
+              'reference': None, 'principal': 'robert.ziegler'}],
+            RoleAssignmentManager(self.empty_dossier).storage._storage())
+
+    @browsing
     def test_sharing_view_only_returns_users_from_current_admin_unit(self, browser):
         self.login(self.regular_user, browser=browser)
 

--- a/opengever/sharing/tests/test_sharing.py
+++ b/opengever/sharing/tests/test_sharing.py
@@ -8,6 +8,7 @@ from opengever.base.role_assignments import RoleAssignmentManager
 from opengever.base.role_assignments import SharingRoleAssignment
 from opengever.base.role_assignments import TaskRoleAssignment
 from opengever.testing import IntegrationTestCase
+from plone import api
 import json
 
 
@@ -147,6 +148,18 @@ class TestOpengeverSharingIntegration(IntegrationTestCase):
               'roles': ['Contributor', 'Editor', 'Reader', 'Owner'],
               'reference': None, 'principal': 'robert.ziegler'}],
             RoleAssignmentManager(self.empty_dossier).storage._storage())
+
+    @browsing
+    def test_stop_inheritance_fallback_is_skipped_for_administrators(self, browser):
+        self.login(self.administrator, browser=browser)
+
+        data = json.dumps({"entries": [], "inherit": False})
+        browser.open(self.empty_dossier, data, view='@sharing', method='POST',
+                     headers={'Accept': 'application/json',
+                              'Content-Type': 'application/json'})
+
+        self.assertTrue(self.empty_dossier.__ac_local_roles_block__)
+        self.assertEquals([], RoleAssignmentManager(self.empty_dossier).storage._storage())
 
     @browsing
     def test_sharing_view_only_returns_users_from_current_admin_unit(self, browser):


### PR DESCRIPTION
The sharing view's `update_inheritance` contains a fallback wich re adds the current local roles, if the current user would lock him out. Those currently did not used the RoleAssignmentManager and therefore raised a `ValueError`. It now uses the `RoleAssignmentManager` which closes #4963

Additionally we decided to skip the `inheritance fallback` for administrators and managers, because the access for those users is ensured by the global roles. So we can avoid local_roles assigned to a specific users, which we say should not be used usually.

Backport to `2018.4-stable`