### PR TITLE
Map gever_admins to the administrator_group in example content.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2018.5.0 (unreleased)
 ---------------------
 
+- Map gever_admins to the administrator_group in example content. [njohner]
 - OGGBundle: Fix encoding issue with UNC filepaths containing non-ASCII characters. [lgraf]
 - Send notification dispatch exceptions to Raven. [Rotonen]
 - Fix sharing-form local_roles inheritance fallback and skip it for administators and managers. [phgross]

--- a/opengever/examplecontent/configure.zcml
+++ b/opengever/examplecontent/configure.zcml
@@ -19,6 +19,7 @@
                            opengever.examplecontent:municipality_content
                            opengever.examplecontent:init"
       admin_unit_id="fd"
+      administrator_group="gever_admins"
       records_manager_group="record_managers"
       archivist_group="archiv"
       />
@@ -32,6 +33,7 @@
                            opengever.examplecontent:municipality_content
                            opengever.examplecontent:init"
       admin_unit_id="ska"
+      administrator_group="gever_admins"
       records_manager_group="record_managers"
       archivist_group="archiv"
       />


### PR DESCRIPTION
The `geveradmin` user is member of the `gever_admins` groups, so we now have at least one Administrator in the example content users.

resolves #4387 