### PR TITLE
Fix a typo in the code of repository root reference number adapter

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ---------------------
 
 - Map gever_admins to the administrator_group in example content. [njohner]
+- Fix parent reference number fetching for repository roots. [Rotonen]
 - OGGBundle: Fix encoding issue with UNC filepaths containing non-ASCII characters. [lgraf]
 - Send notification dispatch exceptions to Raven. [Rotonen]
 - Fix sharing-form local_roles inheritance fallback and skip it for administators and managers. [phgross]

--- a/opengever/api/tests/test_repository.py
+++ b/opengever/api/tests/test_repository.py
@@ -1,0 +1,57 @@
+from ftw.testbrowser import browsing
+from opengever.testing import IntegrationTestCase
+
+
+class TestRepositoryAPI(IntegrationTestCase):
+    @browsing
+    def test_can_get_repository_root(self, browser):
+        self.login(self.regular_user, browser=browser)
+        browser.open(self.repository_root, method="GET", headers={"Accept": "application/json"})
+        self.assertEqual(200, browser.status_code)
+        expected_repository_root = {
+            u"title_de": u"Ordnungssystem",
+            u"valid_until": None,
+            u"title_fr": u"Syst\xe8me de classement",
+            u"layout": u"tabbed_view",
+            u"UID": u"createrepositorytree000000000001",
+            u"parent": {
+                u"title": u"Plone site",
+                u"@id": u"http://nohost/plone",
+                u"@type": u"Plone Site",
+                u"description": u"",
+            },
+            u"created": u"2016-08-31T06:01:33+00:00",
+            u"is_folderish": True,
+            u"modified": u"2016-08-31T06:07:33+00:00",
+            u"allow_discussion": False,
+            u"id": u"ordnungssystem",
+            u"items_total": 2,
+            u"valid_from": None,
+            u"version": None,
+            u"@components": {
+                u"breadcrumbs": {u"@id": u"http://nohost/plone/ordnungssystem/@breadcrumbs"},
+                u"navigation": {u"@id": u"http://nohost/plone/ordnungssystem/@navigation"},
+                u"actions": {u"@id": u"http://nohost/plone/ordnungssystem/@actions"},
+                u"workflow": {u"@id": u"http://nohost/plone/ordnungssystem/@workflow"},
+            },
+            u"review_state": u"repositoryroot-state-active",
+            u"items": [
+                {
+                    u"review_state": u"repositoryfolder-state-active",
+                    u"title": None,
+                    u"@id": u"http://nohost/plone/ordnungssystem/fuhrung",
+                    u"@type": u"opengever.repository.repositoryfolder",
+                    u"description": u"Alles zum Thema F\xfchrung.",
+                },
+                {
+                    u"review_state": u"repositoryfolder-state-active",
+                    u"title": None,
+                    u"@id": u"http://nohost/plone/ordnungssystem/rechnungsprufungskommission",
+                    u"@type": u"opengever.repository.repositoryfolder",
+                    u"description": u"",
+                },
+            ],
+            u"@id": u"http://nohost/plone/ordnungssystem",
+            u"@type": u"opengever.repository.repositoryroot",
+        }
+        self.assertEqual(expected_repository_root, browser.json)

--- a/opengever/repository/reference.py
+++ b/opengever/repository/reference.py
@@ -14,7 +14,7 @@ class RepositoryRootNumber(BasicReferenceNumber):
     ref_type = 'repositoryroot'
 
     def get_number(self):
-        parent_num = self.get_parent_number()
+        parent_num = self.get_parent_numbers()
         if parent_num:
             return str(parent_num) + ' '
         return ''


### PR DESCRIPTION
Huh, this adapter has been broken since August 2010 as far as I can tell?

https://github.com/4teamwork/opengever.core/blame/dd62ab3f037fff23feb25ebb933a404012c64661/opengever/repository/reference.py#L18

Closes #4967 