### PR TITLE
Fix zope.testrunner.layer.UnitTests deprecation warnings

### DIFF
--- a/opengever/base/tests/test_utils.py
+++ b/opengever/base/tests/test_utils.py
@@ -32,7 +32,7 @@ class TestAttachmentContentDisposition(MockTestCase):
 
         set_attachment_content_disposition(self.request, '')
 
-        self.assertTrue(len(self.header) == 0)
+        self.assertEqual(len(self.header), 0)
 
     def test_set_ms_filename(self):
         """ In Ms we must remove the quotes.

--- a/opengever/tasktemplates/tests/test_functional_helper.py
+++ b/opengever/tasktemplates/tests/test_functional_helper.py
@@ -16,7 +16,7 @@ class TestFunctionalHelper(MockTestCase):
         self.replay()
         user = interactive_user_helper(mock_context, 'current_user')
 
-        self.assertTrue('Current user' == user)
+        self.assertEqual('Current user', user)
 
     def test_interactive_user_helper_ogds(self):
         """ Test interactive_user_helper-method
@@ -33,4 +33,4 @@ class TestFunctionalHelper(MockTestCase):
 
         user = interactive_user_helper(mock_context, '')
 
-        self.assertTrue('OGDS User' == user)
+        self.assertEqual('OGDS User', user)


### PR DESCRIPTION
Addressed the few deprecation warnings in our `UnitTests` layer to make the early test run cleaner.