### PR TITLE
Allow pasting documents and templates into a template folder

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2018.5.0 (unreleased)
 ---------------------
 
+- Allow pasting templates into template folders. [Rotonen]
 - Map gever_admins to the administrator_group in example content. [njohner]
 - Fix parent reference number fetching for repository roots. [Rotonen]
 - OGGBundle: Fix encoding issue with UNC filepaths containing non-ASCII characters. [lgraf]

--- a/opengever/base/browser/pasting_allowed.py
+++ b/opengever/base/browser/pasting_allowed.py
@@ -14,9 +14,10 @@ class IsPastingAllowedView(BrowserView):
     Used in the available expression of the object_buttons 'paste' action.
     """
 
-    disabled_types = ('opengever.dossier.templatefolder',
-                      'opengever.contact.contactfolder',
-                      'ftw.mail.mail')
+    disabled_types = (
+        'opengever.contact.contactfolder',
+        'ftw.mail.mail',
+    )
 
     @property
     def allowed_content_types(self):

--- a/opengever/base/tests/test_pasting_allowed.py
+++ b/opengever/base/tests/test_pasting_allowed.py
@@ -1,98 +1,53 @@
-from ftw.builder import Builder
-from ftw.builder import create
 from ftw.testbrowser import browsing
-from opengever.testing import FunctionalTestCase
+from opengever.testing import IntegrationTestCase
 
 
-class TestPastingAllowed(FunctionalTestCase):
+class TestPastingAllowed(IntegrationTestCase):
 
     @browsing
     def test_paste_action_not_displayed_for_contactfolder(self, browser):
-        contactfolder = create(Builder('contactfolder'))
-        contact = create(Builder('contact')
-                         .within(contactfolder))
-
-        paths = ['/'.join(contact.getPhysicalPath())]
-        browser.login().open(contactfolder, {'paths:list': paths},
-                             view='copy_items')
-
-        browser.open(contactfolder)
+        self.login(self.regular_user, browser)
+        paths = ['/'.join(self.hanspeter_duerr.getPhysicalPath())]
+        browser.open(self.contactfolder, data={'paths:list': paths}, view='copy_items')
+        browser.open(self.contactfolder)
         actions = browser.css('#plone-contentmenu-actions li').text
         self.assertSequenceEqual([], actions)
 
     @browsing
-    def test_paste_action_not_displayed_for_templatefolder(self, browser):
-        templatefolder = create(Builder('templatefolder'))
-        document = create(Builder('document')
-                          .within(templatefolder))
-
-        paths = ['/'.join(document.getPhysicalPath())]
-        browser.login().open(templatefolder, {'paths:list': paths},
-                             view='copy_items')
-
-        browser.open(templatefolder)
+    def test_paste_action_not_displayed_for_templates(self, browser):
+        self.login(self.administrator, browser)
+        paths = ['/'.join(self.normal_template.getPhysicalPath())]
+        browser.open(self.templates, data={'paths:list': paths}, view='copy_items')
+        browser.open(self.templates)
         actions = browser.css('#plone-contentmenu-actions li').text
-        self.assertSequenceEqual(
-            ['Export as Zip', 'Properties'], actions)
+        self.assertSequenceEqual(['Export as Zip', 'Properties', 'Sharing'], actions)
 
     @browsing
     def test_paste_action_not_displayed_for_mails(self, browser):
-        dossier = create(Builder('dossier'))
-        document = create(Builder('document').within(dossier))
-        mail = create(Builder('mail').within(dossier))
-
-        paths = ['/'.join(document.getPhysicalPath())]
-        browser.login().open(dossier, {'paths:list': paths}, view='copy_items')
-
-        browser.open(mail)
+        self.login(self.regular_user, browser)
+        browser.open(self.dossier, {'paths:list': ['/'.join(self.document.getPhysicalPath())]}, view='copy_items')
+        browser.open(self.mail_eml)
         actions = browser.css('#plone-contentmenu-actions li').text
-        self.assertSequenceEqual(
-            ['Copy Item', 'Properties', 'save attachments'], actions)
+        self.assertSequenceEqual(['Copy Item', 'Properties', 'save attachments'], actions)
 
     @browsing
     def test_pasting_not_allowed_if_disallowed_subobject_type(self, browser):
-        repofolder = create(Builder('repository'))
-        dossier = create(Builder('dossier').within(repofolder))
-        document = create(Builder('document').within(dossier))
-
-        browser.login().open(
-            dossier,
-            view='copy_items',
-            data={'paths:list': ['/'.join(document.getPhysicalPath())]})
-
-        browser.open(repofolder, view='is_pasting_allowed')
+        self.login(self.regular_user, browser)
+        browser.open(self.dossier, data={'paths:list': ['/'.join(self.document.getPhysicalPath())]}, view='copy_items',)
+        browser.open(self.leaf_repofolder, view='is_pasting_allowed')
         self.assertFalse(browser.contents)
 
     @browsing
     def test_pasting_public_content_into_private_container_is_disallowed(self, browser):
-        repo = create(Builder('repository'))
-        dossier = create(Builder('dossier').within(repo))
-        document = create(Builder('document').within(dossier))
-
-        private_root = create(Builder('private_root'))
-        private_folder = create(Builder('private_folder').within(private_root))
-        private_dossier = create(Builder('private_dossier').within(private_folder))
-
-        browser.login().open(
-            dossier,
-            view='copy_items',
-            data={'paths:list': ['/'.join(document.getPhysicalPath())]})
-
-        browser.open(private_dossier, view='is_pasting_allowed')
+        self.login(self.regular_user, browser)
+        browser.open(self.dossier, data={'paths:list': ['/'.join(self.document.getPhysicalPath())]}, view='copy_items')
+        browser.open(self.private_dossier, view='is_pasting_allowed')
         self.assertFalse(browser.contents)
 
     @browsing
     def test_pasting_private_content_into_private_container_is_allowed(self, browser):
-        private_root = create(Builder('private_root'))
-        private_folder = create(Builder('private_folder').within(private_root))
-        dossier_1 = create(Builder('private_dossier').within(private_folder))
-        document = create(Builder('document').within(dossier_1))
-        dossier_2 = create(Builder('private_dossier').within(private_folder))
-
-        browser.login().open(
-            dossier_1,
-            view='copy_items',
-            data={'paths:list': ['/'.join(document.getPhysicalPath())]})
-
-        browser.open(dossier_2, view='is_pasting_allowed')
+        self.login(self.regular_user, browser)
+        paths = ['/'.join(self.private_document.getPhysicalPath())]
+        browser.open(self.private_dossier, data={'paths:list': paths}, view='copy_items')
+        browser.open(self.private_dossier, view='is_pasting_allowed')
         self.assertTrue(browser.contents)

--- a/opengever/base/tests/test_pasting_allowed.py
+++ b/opengever/base/tests/test_pasting_allowed.py
@@ -14,13 +14,21 @@ class TestPastingAllowed(IntegrationTestCase):
         self.assertSequenceEqual([], actions)
 
     @browsing
-    def test_paste_action_not_displayed_for_templates(self, browser):
+    def test_paste_action_displayed_for_templates(self, browser):
         self.login(self.administrator, browser)
         paths = ['/'.join(self.normal_template.getPhysicalPath())]
         browser.open(self.templates, data={'paths:list': paths}, view='copy_items')
         browser.open(self.templates)
         actions = browser.css('#plone-contentmenu-actions li').text
-        self.assertSequenceEqual(['Export as Zip', 'Properties', 'Sharing'], actions)
+        self.assertSequenceEqual(['Export as Zip', 'Paste', 'Properties', 'Sharing'], actions)
+
+    @browsing
+    def test_pasting_template_into_template_folder_is_allowed(self, browser):
+        self.login(self.administrator, browser)
+        paths = ['/'.join(self.normal_template.getPhysicalPath())]
+        browser.open(self.templates, data={'paths:list': paths}, view='copy_items')
+        browser.open(self.templates, view='is_pasting_allowed')
+        self.assertTrue(browser.contents)
 
     @browsing
     def test_paste_action_not_displayed_for_mails(self, browser):


### PR DESCRIPTION
Fixture setup failures took me down a few wrong paths, but this was rather simple in the end.

We already had filtering of what can be pasted into a template folder.

https://github.com/4teamwork/opengever.core/blob/810674f4186126b85d4d1e8d32d7d91ee4841aae/opengever/dossier/templatefolder/templatefolder.py#L41-L56

So we just needed to allow pasting into a template folder.

Closes #4776