### PR TITLE
Fix bug with document preview for sablon and proposal templates.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -9,6 +9,7 @@ Changelog
 - Prefill task-reminder select field on task response form. [elioschmutz]
 - Make sure our Diazo theme doesn't drop data-base-url attribute. [lgraf]
 - Bump Plone version to 4.3.18. [Rotonen, lgraf]
+- Fix bug with document showroom for sablon and proposal templates. [njohner]
 - Bump ftw.solr to 2.3.0 to get patched (optimized) reindexObjectSecurity(). [lgraf]
 - Implement asynchronous meeting zip generation, with PDFs from the new demand endpoint. [deiferni, lgraf]
 - Add new icon for private folder. [njohner]

--- a/opengever/bumblebee/__init__.py
+++ b/opengever/bumblebee/__init__.py
@@ -8,7 +8,10 @@ _ = MessageFactory('opengever.bumblebee')
 
 
 BUMBLEBEE_VIEW_COOKIE_NAME = 'bumblebee-view'
-SUPPORTED_CONTENT_TYPES = ['opengever.document.document', 'ftw.mail.mail']
+SUPPORTED_CONTENT_TYPES = ['opengever.document.document',
+                           'ftw.mail.mail',
+                           'opengever.meeting.sablontemplate',
+                           'opengever.meeting.proposaltemplate']
 
 
 def is_bumblebee_feature_enabled():

--- a/opengever/dossier/tests/test_templatefolder.py
+++ b/opengever/dossier/tests/test_templatefolder.py
@@ -30,6 +30,7 @@ from unittest import skip
 from zope.app.intid.interfaces import IIntIds
 from zope.component import getMultiAdapter
 from zope.component import getUtility
+import os
 
 
 class TestDocumentWithTemplateFormPlain(IntegrationTestCase):
@@ -1049,3 +1050,46 @@ class TestDossierTemplateFeature(IntegrationTestCase):
         browser.open(self.templates)
 
         self.assertEqual('Dossier templates', browser.css('.formTab #tab-dossiertemplates').first.text)
+
+
+class TestTemplateFolderShowroomPreviews(IntegrationTestCase):
+
+    features = ('meeting', 'bumblebee',)
+
+    @staticmethod
+    def get_expected_urls_from_documents(document_list):
+        return [os.path.join(document.absolute_url(), "@@bumblebee-overlay-listing")
+                for document in document_list]
+
+    @browsing
+    def test_document_tab_contains_showroom_preview_links(self, browser):
+        self.login(self.regular_user, browser)
+        browser.open(self.templates, view='tabbedview_view-documents')
+        expected_documents = [self.docprops_template, self.asset_template,
+                              self.normal_template, self.empty_template]
+
+        expected_urls = self.get_expected_urls_from_documents(expected_documents)
+        actual_urls = [element.get("data-showroom-target") for element in browser.css(".showroom-item")]
+        self.assertEqual(expected_urls, actual_urls)
+
+    @browsing
+    def test_sablontemplates_tab_contains_showroom_preview_links(self, browser):
+        self.login(self.regular_user, browser)
+        browser.open(self.templates, view='tabbedview_view-sablontemplates')
+        expected_documents = [self.sablon_template]
+
+        expected_urls = self.get_expected_urls_from_documents(expected_documents)
+        actual_urls = [element.get("data-showroom-target") for element in browser.css(".showroom-item")]
+        self.assertEqual(expected_urls, actual_urls)
+
+    @browsing
+    def test_proposaltemplates_tab_contains_showroom_preview_links(self, browser):
+        self.login(self.regular_user, browser)
+        browser.open(self.templates, view='tabbedview_view-proposaltemplates')
+        expected_documents = [self.proposal_template,
+                              self.ad_hoc_agenda_item_template,
+                              self.recurring_agenda_item_template]
+
+        expected_urls = self.get_expected_urls_from_documents(expected_documents)
+        actual_urls = [element.get("data-showroom-target") for element in browser.css(".showroom-item")]
+        self.assertEqual(expected_urls, actual_urls)


### PR DESCRIPTION
I'm still a bit surprised that the tooltip would show the link for the preview, with attributes pointing to the bumblebee data, for content that is not bumblebeeable. Showroom does not find that information as it looks in the listing tab, for a hidden link with the `showroom-item` attribute...

resolves #4826 