### PR TITLE
Sharing form fixes

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -8,6 +8,7 @@ Changelog
 - Bump ftw.solr to 2.3.0 to get patched (optimized) reindexObjectSecurity(). [lgraf]
 - Implement asynchronous meeting zip generation, with PDFs from the new demand endpoint. [deiferni, lgraf]
 - Add new icon for private folder. [njohner]
+- Sharing form: fix removal of all role assignments. [phgross]
 - Allow pasting templates into template folders. [Rotonen]
 - Map gever_admins to the administrator_group in example content. [njohner]
 - Fix parent reference number fetching for repository roots. [Rotonen]

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -8,6 +8,7 @@ Changelog
 - Bump ftw.solr to 2.3.0 to get patched (optimized) reindexObjectSecurity(). [lgraf]
 - Implement asynchronous meeting zip generation, with PDFs from the new demand endpoint. [deiferni, lgraf]
 - Add new icon for private folder. [njohner]
+- Sharing form: do not show search results multiple times. [phgross]
 - Sharing form: fix removal of all role assignments. [phgross]
 - Allow pasting templates into template folders. [Rotonen]
 - Map gever_admins to the administrator_group in example content. [njohner]

--- a/opengever/base/role_assignments.py
+++ b/opengever/base/role_assignments.py
@@ -187,7 +187,8 @@ class RoleAssignmentStorage(object):
 
     def clear_by_cause_and_principal(self, cause, principal):
         item = self.get_by_cause_and_principal(cause, principal)
-        self._storage().remove(item)
+        if item:
+            self._storage().remove(item)
 
     def clear_by_cause(self, cause):
         for item in self.get_by_cause(cause):
@@ -283,6 +284,14 @@ class RoleAssignmentManager(object):
         """Remove all assignments.
         """
         self.storage.clear_all()
+        self._update_local_roles()
+
+    def clear_by_cause_and_principals(self, cause, principals):
+        """Remove all assignments of the given cause and for all principals.
+        """
+        for principal in principals:
+            self.storage.clear_by_cause_and_principal(cause, principal)
+
         self._update_local_roles()
 
     def clear_by_cause_and_principal(self, cause, principal):

--- a/opengever/sharing/browser/resources/sharing.js
+++ b/opengever/sharing/browser/resources/sharing.js
@@ -98,9 +98,14 @@ var sharingApp = {
 
       this.requester.get(this.endpoint, { params: params }).then(function (response) {
 
-        this.entries = this.entries.filter(function(i) { return !i.disabled; });
+        // Drop former search results, which has not been changed.
+        this.entries = this.entries.filter(function(i) { return i.disabled === false; });
+
+        var current_ids = this.entries.map( function(i) { return i.id})
         this.entries = this.entries.concat(
-          response.data['entries'].filter(function(i) { return i.disabled != false; }));
+          response.data['entries'].filter(function(i) {
+            return i.disabled !== false && current_ids.indexOf(i.id) === -1;
+          }));
         this.inherit = response.data['inherit'];
 
       }.bind(this));


### PR DESCRIPTION
- **Fix removal of all role assignments**: Currently the removal of all local roleassignments has been skipped by mistake in the sharing endpoint. We fix that, by making sure that all
RoleAssignments are cleared, when no assignments exists.

- Do not show search results multiple times.


Backport to `2018.4-stable`