### PR TITLE
Use the same template for default notifiaction email like the daily-digest template.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,7 @@ Changelog
 
 - Fix dispatching notifications while recording a TaskReminderActivity. [elioschmutz]
 - Prefill task-reminder select field on task response form. [elioschmutz]
+- Use the same template for default notifiaction email like the daily-digest template. [elioschmutz]
 - Make sure our Diazo theme doesn't drop data-base-url attribute. [lgraf]
 - Bump Plone version to 4.3.18. [Rotonen, lgraf]
 - Bump ftw.solr to 2.3.0 to get patched (optimized) reindexObjectSecurity(). [lgraf]

--- a/opengever/activity/browser/configure.zcml
+++ b/opengever/activity/browser/configure.zcml
@@ -38,6 +38,14 @@
       allowed_attributes="list save reset"
       />
 
+  <browser:page
+      name="notification_mail_macros"
+      for="*"
+      permission="zope2.View"
+      template="templates/notification_mail_macros.pt"
+      class=".notification_mail_macros.View"
+      />
+
   <adapter factory=".listing.NotificationTableSource" />
 
 </configure>

--- a/opengever/activity/browser/notification_mail_macros.py
+++ b/opengever/activity/browser/notification_mail_macros.py
@@ -1,0 +1,7 @@
+from Products.Five.browser import BrowserView
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+
+
+class View(BrowserView):
+
+    template = ViewPageTemplateFile('templates/notification_mail_macros.pt')

--- a/opengever/activity/browser/templates/notification_mail_macros.pt
+++ b/opengever/activity/browser/templates/notification_mail_macros.pt
@@ -159,6 +159,9 @@
       }
 
     </style>
+
+    <metal:styleslot define-slot="style_slot" />
+
     <!-- Progressive Enhancements : END -->
 
     <!-- What it does: Makes background images in 72ppi Outlook render at correct size. -->
@@ -219,7 +222,7 @@
                   </td>
                 </tr>
                 <tr>
-                  <td style="padding: 40px; font-family: Arial, sans-serif; font-size: 15px; line-height: 140%; color: #555555;">
+                  <td class="email-content" style="padding: 40px; font-family: Arial, sans-serif; font-size: 15px; line-height: 140%; color: #555555;">
                       <metal:content define-slot="content">
                     </metal:content>
                   </td>

--- a/opengever/activity/browser/templates/notification_mail_macros.pt
+++ b/opengever/activity/browser/templates/notification_mail_macros.pt
@@ -1,0 +1,279 @@
+<metal:page define-macro="mail_template">
+
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office"
+      i18n:domain="opengever.activity">
+  <head
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      xmlns:metal="http://xml.zope.org/namespaces/metal">
+    <meta charset="utf-8" /> <!-- utf-8 works for most cases -->
+    <meta name="viewport" content="width=device-width" /> <!-- Forcing initial-scale shouldn't be necessary -->
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" /> <!-- Use the latest (edge) version of IE rendering engine -->
+    <meta name="x-apple-disable-message-reformatting" />  <!-- Disable auto-scale in iOS 10 Mail entirely -->
+    <title></title> <!-- The title tag shows in email notifications, like Android 4.4. -->
+
+    <!-- Web Font / @font-face : BEGIN -->
+    <!-- NOTE: If web fonts are not required, lines 10 - 27 can be safely removed. -->
+
+    <!-- Desktop Outlook chokes on web font references and defaults to Times New Roman, so we force a safe fallback font. -->
+    <!--[if mso]>
+        <style>
+        * {
+        font-family: sans-serif !important;
+        }
+        </style>
+    <![endif]-->
+
+    <!-- All other clients get the webfont reference; some will render the font and others will silently fail to the fallbacks. More on that here: http://stylecampaign.com/blog/2015/02/webfont-support-in-email/ -->
+    <!--[if !mso]><!-->
+    <!--<![endif]-->
+
+    <!-- Web Font / @font-face : END -->
+
+    <!-- CSS Reset : BEGIN -->
+    <style>
+
+      /* What it does: Remove spaces around the email design added by some email clients. */
+      /* Beware: It can remove the padding / margin and add a background color to the compose a reply window. */
+      html,
+      body {
+      margin: 0 auto !important;
+      padding: 0 !important;
+      height: 100% !important;
+      width: 100% !important;
+      }
+
+      /* What it does: Stops email clients resizing small text. */
+      * {
+      -ms-text-size-adjust: 100%;
+      -webkit-text-size-adjust: 100%;
+      }
+
+      /* What it does: Centers email on Android 4.4 */
+      div[style*="margin: 16px 0"] {
+      margin: 0 !important;
+      }
+
+      /* What it does: Stops Outlook from adding extra spacing to tables. */
+      table,
+      td {
+      mso-table-lspace: 0pt !important;
+      mso-table-rspace: 0pt !important;
+      }
+
+      /* What it does: Fixes webkit padding issue. Fix for Yahoo mail table alignment bug. Applies table-layout to the first 2 tables then removes for anything nested deeper. */
+      table {
+      border-spacing: 0 !important;
+      border-collapse: collapse !important;
+      table-layout: fixed !important;
+      margin: 0 auto !important;
+      }
+      table table table {
+      table-layout: auto;
+      }
+
+      /* What it does: Uses a better rendering method when resizing images in IE. */
+      img {
+      -ms-interpolation-mode:bicubic;
+      }
+
+      /* What it does: A work-around for email clients meddling in triggered links. */
+      *[x-apple-data-detectors],  /* iOS */
+      .x-gmail-data-detectors,    /* Gmail */
+      .x-gmail-data-detectors *,
+      .aBn {
+      border-bottom: 0 !important;
+      cursor: default !important;
+      color: inherit !important;
+      text-decoration: none !important;
+      font-size: inherit !important;
+      font-family: inherit !important;
+      font-weight: inherit !important;
+      line-height: inherit !important;
+      }
+
+      /* What it does: Prevents Gmail from displaying an download button on large, non-linked images. */
+      .a6S {
+      display: none !important;
+      opacity: 0.01 !important;
+      }
+      /* If the above doesn't work, add a .g-img class to any image in question. */
+      img.g-img + div {
+      display: none !important;
+      }
+
+      /* What it does: Prevents underlining the button text in Windows 10 */
+      .button-link {
+      text-decoration: none !important;
+      }
+
+      /* What it does: Removes right gutter in Gmail iOS app: https://github.com/TedGoas/Cerberus/issues/89  */
+      /* Create one of these media queries for each additional viewport size you'd like to fix */
+      /* Thanks to Eric Lepetit (@ericlepetitsf) for help troubleshooting */
+      @media only screen and (min-device-width: 375px) and (max-device-width: 413px) { /* iPhone 6 and 6+ */
+      .email-container {
+      min-width: 375px !important;
+      }
+      }
+
+      @media screen and (max-width: 480px) {
+      /* What it does: Forces Gmail app to display email full width */
+      div > u ~ div .gmail {
+      min-width: 100vw;
+      }
+      }
+
+    </style>
+    <!-- CSS Reset : END -->
+
+    <!-- Progressive Enhancements : BEGIN -->
+    <style>
+      a {
+      color: #418195 !important;
+      text-decoration: underline !important;
+      }
+
+      a:visited {
+      color: #418195 !important;
+      text-decoration: underline !important;
+      }
+
+      a:hover {
+      color: #418195 !important;
+      text-decoration: underline !important;
+      }
+
+      a:visited:hover {
+      color: #418195 !important;
+      text-decoration: underline !important;
+      }
+
+      /* Media Queries */
+      @media screen and (max-width: 600px) {
+
+      /* What it does: Adjust typography on small screens to improve readability */
+      .email-container p {
+      font-size: 17px !important;
+      }
+
+      }
+
+    </style>
+    <!-- Progressive Enhancements : END -->
+
+    <!-- What it does: Makes background images in 72ppi Outlook render at correct size. -->
+    <!--[if gte mso 9]>
+        <xml>
+        <o:OfficeDocumentSettings>
+        <o:AllowPNG/>
+        <o:PixelsPerInch>96</o:PixelsPerInch>
+        </o:OfficeDocumentSettings>
+        </xml>
+    <![endif]-->
+
+  </head>
+  <body width="100%" bgcolor="#f5f5f5" style="margin: 0; mso-line-height-rule: exactly;">
+    <center style="width: 100%; background: #f5f5f5; text-align: left;">
+
+      <!-- Visually Hidden Preheader Text : BEGIN -->
+      <div style="display: none; font-size: 1px; line-height: 1px; max-height: 0px; max-width: 0px; opacity: 0; overflow: hidden; mso-hide: all; font-family: Arial, sans-serif;">
+        <metal:preheader define-slot="preheader">
+        </metal:preheader>
+      </div>
+      <!-- Visually Hidden Preheader Text : END -->
+
+      <!--
+          Set the email width. Defined in two places:
+          1. max-width for all clients except Desktop Windows Outlook, allowing the email to squish on narrow but never go wider than 600px.
+          2. MSO tags for Desktop Windows Outlook enforce a 600px width.
+      -->
+      <div style="max-width: 600px; margin: auto;" class="email-container">
+        <!--[if mso]>
+            <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="600" align="center">
+            <tr>
+            <td>
+        <![endif]-->
+
+        <!-- Email Header : BEGIN -->
+        <table role="presentation" cellspacing="0" cellpadding="0" border="0" align="center" width="100%" style="max-width: 600px;">
+          <tr>
+            <td style="padding: 20px 0; text-align: center"></td>
+          </tr>
+        </table>
+        <!-- Email Header : END -->
+
+          <!-- Email Body : BEGIN -->
+        <table role="presentation" cellspacing="0" cellpadding="0" border="0" align="center" width="100%" style="max-width: 600px;">
+          <!-- 1 Column Text + Button : BEGIN -->
+          <tr>
+            <td bgcolor="#ffffff" style="border-top: 5px solid #3387a1;">
+              <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
+                <tr>
+                  <td style="padding: 40px; font-family: Arial, sans-serif; font-size: 15px; line-height: 140%; color: #555555;">
+                    <h1 style="text-align: center; margin: 0 0 10px 0; font-family: Arial, sans-serif; font-size: 24px; line-height: 125%; color: #333333; font-weight: normal;" tal:content="options/title">
+                        <metal:title define-slot="title">
+                        </metal:title>
+                    </h1>
+                    <metal:subtitle define-slot="subtitle">
+                    </metal:subtitle>
+                  </td>
+                </tr>
+                <tr>
+                  <td style="padding: 40px; font-family: Arial, sans-serif; font-size: 15px; line-height: 140%; color: #555555;">
+                      <metal:content define-slot="content">
+                    </metal:content>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+          <!-- 1 Column Text + Button : END -->
+
+          <!-- Clear Spacer : BEGIN -->
+          <tr>
+            <td aria-hidden="true" height="40" style="font-size: 0; line-height: 0; border-bottom: 5px solid #3387a1;">
+              &nbsp;
+            </td>
+          </tr>
+          <!-- Clear Spacer : END -->
+
+          <!-- 1 Column Text : BEGIN -->
+          <tr>
+            <td bgcolor="#ffffff">
+              <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
+                <tr>
+                  <td style="padding: 40px; font-family: sans-serif; font-size: 15px; line-height: 140%; color: #555555;">
+                    <!-- Button : BEGIN -->
+                    <table role="presentation" cellspacing="0" cellpadding="0" border="0" align="center" style="margin: auto;">
+                      <tr>
+                        <td style="border-radius: 3px; text-align: center;">
+                          <a href="#"
+                             class="button-a"
+                             i18n:translate="label_notification_settings"
+                             tal:attributes="href string:${options/public_url}/@@personal-preferences"
+                             style="font-family: Arial, sans-serif; font-size: 13px; line-height: 110%; text-align: center; text-decoration: none; display: block; border-radius: 3px; font-weight: bold; color: #418195;">
+                            Notification settings
+                          </a>
+                        </td>
+                      </tr>
+                    </table>
+                    <!-- Button : END -->
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+          <!-- 1 Column Text : END -->
+        </table>
+        <!-- Email Body : END -->
+
+        <!--[if mso]>
+            </td>
+            </tr>
+            </table>
+        <![endif]-->
+      </div>
+    </center>
+  </body>
+</html>
+</metal:page>

--- a/opengever/activity/locales/de/LC_MESSAGES/opengever.activity.po
+++ b/opengever/activity/locales/de/LC_MESSAGES/opengever.activity.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-10-01 09:34+0000\n"
+"POT-Creation-Date: 2018-10-23 11:27+0000\n"
 "PO-Revision-Date: 2015-02-24 08:40+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -147,11 +147,6 @@ msgstr "GEVER Benachrichtigung"
 msgid "label_daily_digest"
 msgstr "Tageszusammenfassung"
 
-#. Default: "Details:"
-#: ./opengever/activity/templates/notification.pt
-msgid "label_details"
-msgstr "Details:"
-
 #. Default: "Dispositions"
 #: ./opengever/activity/browser/settings.py
 msgid "label_dispositions"
@@ -168,8 +163,8 @@ msgid "label_mail"
 msgstr "Mail"
 
 #. Default: "Notification settings"
+#: ./opengever/activity/browser/templates/notification_mail_macros.pt
 #: ./opengever/activity/browser/templates/settings.pt
-#: ./opengever/activity/templates/digest.pt
 msgid "label_notification_settings"
 msgstr "Benachrichtigungs-Einstellungen"
 

--- a/opengever/activity/locales/fr/LC_MESSAGES/opengever.activity.po
+++ b/opengever/activity/locales/fr/LC_MESSAGES/opengever.activity.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-10-01 09:34+0000\n"
+"POT-Creation-Date: 2018-10-23 11:27+0000\n"
 "PO-Revision-Date: 2017-12-03 16:14+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-activity/fr/>\n"
@@ -149,11 +149,6 @@ msgstr "message GEVER"
 msgid "label_daily_digest"
 msgstr "Résumé quotidien"
 
-#. Default: "Details:"
-#: ./opengever/activity/templates/notification.pt
-msgid "label_details"
-msgstr "Détails:"
-
 #. Default: "Dispositions"
 #: ./opengever/activity/browser/settings.py
 msgid "label_dispositions"
@@ -170,8 +165,8 @@ msgid "label_mail"
 msgstr "e-mail"
 
 #. Default: "Notification settings"
+#: ./opengever/activity/browser/templates/notification_mail_macros.pt
 #: ./opengever/activity/browser/templates/settings.pt
-#: ./opengever/activity/templates/digest.pt
 msgid "label_notification_settings"
 msgstr "paramètres de notification"
 

--- a/opengever/activity/locales/opengever.activity.pot
+++ b/opengever/activity/locales/opengever.activity.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-10-01 09:34+0000\n"
+"POT-Creation-Date: 2018-10-23 11:27+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -147,11 +147,6 @@ msgstr ""
 msgid "label_daily_digest"
 msgstr ""
 
-#. Default: "Details:"
-#: ./opengever/activity/templates/notification.pt
-msgid "label_details"
-msgstr ""
-
 #. Default: "Dispositions"
 #: ./opengever/activity/browser/settings.py
 msgid "label_dispositions"
@@ -168,8 +163,8 @@ msgid "label_mail"
 msgstr ""
 
 #. Default: "Notification settings"
+#: ./opengever/activity/browser/templates/notification_mail_macros.pt
 #: ./opengever/activity/browser/templates/settings.pt
-#: ./opengever/activity/templates/digest.pt
 msgid "label_notification_settings"
 msgstr ""
 

--- a/opengever/activity/mail.py
+++ b/opengever/activity/mail.py
@@ -1,6 +1,7 @@
 from opengever.activity.browser import resolve_notification_url
 from opengever.activity.dispatcher import NotificationDispatcher
 from opengever.activity.mailer import Mailer
+from opengever.ogds.base.utils import get_current_admin_unit
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from zope.i18n import translate
 from zope.i18nmessageid import MessageFactory
@@ -43,5 +44,6 @@ class PloneNotificationMailer(NotificationDispatcher, Mailer):
             'label': notification.activity.translations[language].label,
             'summary': notification.activity.translations[language].summary,
             'description': notification.activity.translations[language].description,
-            'link': resolve_notification_url(notification)
+            'link': resolve_notification_url(notification),
+            'public_url': get_current_admin_unit().public_url,
         }

--- a/opengever/activity/templates/digest.pt
+++ b/opengever/activity/templates/digest.pt
@@ -1,289 +1,42 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html lang="en" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office"
-      i18n:domain="opengever.activity">
-  <head>
-    <meta charset="utf-8" /> <!-- utf-8 works for most cases -->
-    <meta name="viewport" content="width=device-width" /> <!-- Forcing initial-scale shouldn't be necessary -->
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" /> <!-- Use the latest (edge) version of IE rendering engine -->
-    <meta name="x-apple-disable-message-reformatting" />  <!-- Disable auto-scale in iOS 10 Mail entirely -->
-    <title></title> <!-- The title tag shows in email notifications, like Android 4.4. -->
+<html
+    xmlns="http://www.w3.org/1999/xhtml"
+    xmlns:tal="http://xml.zope.org/namespaces/tal"
+    xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+    i18n:domain="opengever.activity"
+    metal:use-macro="context/notification_mail_macros/macros/mail_template">
 
-    <!-- Web Font / @font-face : BEGIN -->
-    <!-- NOTE: If web fonts are not required, lines 10 - 27 can be safely removed. -->
-
-    <!-- Desktop Outlook chokes on web font references and defaults to Times New Roman, so we force a safe fallback font. -->
-    <!--[if mso]>
-        <style>
-        * {
-        font-family: sans-serif !important;
-        }
-        </style>
-    <![endif]-->
-
-    <!-- All other clients get the webfont reference; some will render the font and others will silently fail to the fallbacks. More on that here: http://stylecampaign.com/blog/2015/02/webfont-support-in-email/ -->
-    <!--[if !mso]><!-->
-    <!--<![endif]-->
-
-    <!-- Web Font / @font-face : END -->
-
-    <!-- CSS Reset : BEGIN -->
-    <style>
-
-      /* What it does: Remove spaces around the email design added by some email clients. */
-      /* Beware: It can remove the padding / margin and add a background color to the compose a reply window. */
-      html,
-      body {
-      margin: 0 auto !important;
-      padding: 0 !important;
-      height: 100% !important;
-      width: 100% !important;
-      }
-
-      /* What it does: Stops email clients resizing small text. */
-      * {
-      -ms-text-size-adjust: 100%;
-      -webkit-text-size-adjust: 100%;
-      }
-
-      /* What it does: Centers email on Android 4.4 */
-      div[style*="margin: 16px 0"] {
-      margin: 0 !important;
-      }
-
-      /* What it does: Stops Outlook from adding extra spacing to tables. */
-      table,
-      td {
-      mso-table-lspace: 0pt !important;
-      mso-table-rspace: 0pt !important;
-      }
-
-      /* What it does: Fixes webkit padding issue. Fix for Yahoo mail table alignment bug. Applies table-layout to the first 2 tables then removes for anything nested deeper. */
-      table {
-      border-spacing: 0 !important;
-      border-collapse: collapse !important;
-      table-layout: fixed !important;
-      margin: 0 auto !important;
-      }
-      table table table {
-      table-layout: auto;
-      }
-
-      /* What it does: Uses a better rendering method when resizing images in IE. */
-      img {
-      -ms-interpolation-mode:bicubic;
-      }
-
-      /* What it does: A work-around for email clients meddling in triggered links. */
-      *[x-apple-data-detectors],  /* iOS */
-      .x-gmail-data-detectors,    /* Gmail */
-      .x-gmail-data-detectors *,
-      .aBn {
-      border-bottom: 0 !important;
-      cursor: default !important;
-      color: inherit !important;
-      text-decoration: none !important;
-      font-size: inherit !important;
-      font-family: inherit !important;
-      font-weight: inherit !important;
-      line-height: inherit !important;
-      }
-
-      /* What it does: Prevents Gmail from displaying an download button on large, non-linked images. */
-      .a6S {
-      display: none !important;
-      opacity: 0.01 !important;
-      }
-      /* If the above doesn't work, add a .g-img class to any image in question. */
-      img.g-img + div {
-      display: none !important;
-      }
-
-      /* What it does: Prevents underlining the button text in Windows 10 */
-      .button-link {
-      text-decoration: none !important;
-      }
-
-      /* What it does: Removes right gutter in Gmail iOS app: https://github.com/TedGoas/Cerberus/issues/89  */
-      /* Create one of these media queries for each additional viewport size you'd like to fix */
-      /* Thanks to Eric Lepetit (@ericlepetitsf) for help troubleshooting */
-      @media only screen and (min-device-width: 375px) and (max-device-width: 413px) { /* iPhone 6 and 6+ */
-      .email-container {
-      min-width: 375px !important;
-      }
-      }
-
-      @media screen and (max-width: 480px) {
-      /* What it does: Forces Gmail app to display email full width */
-      div > u ~ div .gmail {
-      min-width: 100vw;
-      }
-      }
-
-    </style>
-    <!-- CSS Reset : END -->
-
-    <!-- Progressive Enhancements : BEGIN -->
-    <style>
-      a {
-      color: #418195 !important;
-      text-decoration: underline !important;
-      }
-
-      a:visited {
-      color: #418195 !important;
-      text-decoration: underline !important;
-      }
-
-      a:hover {
-      color: #418195 !important;
-      text-decoration: underline !important;
-      }
-
-      a:visited:hover {
-      color: #418195 !important;
-      text-decoration: underline !important;
-      }
-
-      /* Media Queries */
-      @media screen and (max-width: 600px) {
-
-      /* What it does: Adjust typography on small screens to improve readability */
-      .email-container p {
-      font-size: 17px !important;
-      }
-
-      }
-
-    </style>
-    <!-- Progressive Enhancements : END -->
-
-    <!-- What it does: Makes background images in 72ppi Outlook render at correct size. -->
-    <!--[if gte mso 9]>
-        <xml>
-        <o:OfficeDocumentSettings>
-        <o:AllowPNG/>
-        <o:PixelsPerInch>96</o:PixelsPerInch>
-        </o:OfficeDocumentSettings>
-        </xml>
-    <![endif]-->
-
-  </head>
-  <body width="100%" bgcolor="#f5f5f5" style="margin: 0; mso-line-height-rule: exactly;">
-    <center style="width: 100%; background: #f5f5f5; text-align: left;">
-
-      <!-- Visually Hidden Preheader Text : BEGIN -->
-      <div style="display: none; font-size: 1px; line-height: 1px; max-height: 0px; max-width: 0px; opacity: 0; overflow: hidden; mso-hide: all; font-family: Arial, sans-serif;">
+    <metal:preheader metal:fill-slot="preheader">
         Digest Mail from
         <span tal:content="options/today" />
-      </div>
-      <!-- Visually Hidden Preheader Text : END -->
+    </metal:preheader>
 
-      <!--
-          Set the email width. Defined in two places:
-          1. max-width for all clients except Desktop Windows Outlook, allowing the email to squish on narrow but never go wider than 600px.
-          2. MSO tags for Desktop Windows Outlook enforce a 600px width.
-      -->
-      <div style="max-width: 600px; margin: auto;" class="email-container">
-        <!--[if mso]>
-            <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="600" align="center">
-            <tr>
-            <td>
-        <![endif]-->
+    <metal:title metal:fill-slot="title">
+        <div tal:replace="options/title"></div>
+    </metal:title>
 
-        <!-- Email Header : BEGIN -->
-        <table role="presentation" cellspacing="0" cellpadding="0" border="0" align="center" width="100%" style="max-width: 600px;">
-          <tr>
-            <td style="padding: 20px 0; text-align: center"></td>
-          </tr>
-        </table>
-        <!-- Email Header : END -->
+    <metal:subtitle metal:fill-slot="subtitle">
+        <p tal:content="options/today" style="text-align: center; margin: 0;">today</p>
+    </metal:subtitle>
 
-          <!-- Email Body : BEGIN -->
-        <table role="presentation" cellspacing="0" cellpadding="0" border="0" align="center" width="100%" style="max-width: 600px;">
-          <!-- 1 Column Text + Button : BEGIN -->
-          <tr>
-            <td bgcolor="#ffffff" style="border-top: 5px solid #3387a1;">
-              <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
-                <tr>
-                  <td style="padding: 40px; font-family: Arial, sans-serif; font-size: 15px; line-height: 140%; color: #555555;">
-                    <h1 style="text-align: center; margin: 0 0 10px 0; font-family: Arial, sans-serif; font-size: 24px; line-height: 125%; color: #333333; font-weight: normal;" tal:content="options/title">
-                    </h1>
-                    <p tal:content="options/today" style="text-align: center; margin: 0;">today</p>
-                  </td>
-                </tr>
-                <tr>
-                  <td style="padding: 40px; font-family: Arial, sans-serif; font-size: 15px; line-height: 140%; color: #555555;">
-                    <dl style="padding: 0; margin: 0;">
-                      <tal:repeat tal:repeat="item options/notifications">
-                        <dt>
-                          <h2 style="margin: 0 0 10px 0; font-family: Arial, sans-serif; font-size: 18px; line-height: 125%; color: #333333; font-weight: bold;">
-                            <a style="color: #418195;"
-                               href="#"
-                               tal:content="item/title"
-                               tal:attributes="href item/url">Item title</a>
-                          </h2>
-                        </dt>
-                        <dd style="margin: 0; padding: 0;">
-                          <ul style="padding: 0; Margin: 0;">
-                            <li style="Margin:0 0 1em; list-style:disc; mso-special-format:bullet;" tal:repeat="activity item/activities">
-                              <p tal:content="structure activity/summary" />
-                            </li>
-                          </ul>
-                        </dd>
-                      </tal:repeat>
-                    </dl>
-                  </td>
-                </tr>
-              </table>
-            </td>
-          </tr>
-          <!-- 1 Column Text + Button : END -->
-
-          <!-- Clear Spacer : BEGIN -->
-          <tr>
-            <td aria-hidden="true" height="40" style="font-size: 0; line-height: 0; border-bottom: 5px solid #3387a1;">
-              &nbsp;
-            </td>
-          </tr>
-          <!-- Clear Spacer : END -->
-
-          <!-- 1 Column Text : BEGIN -->
-          <tr>
-            <td bgcolor="#ffffff">
-              <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
-                <tr>
-                  <td style="padding: 40px; font-family: sans-serif; font-size: 15px; line-height: 140%; color: #555555;">
-                    <!-- Button : BEGIN -->
-                    <table role="presentation" cellspacing="0" cellpadding="0" border="0" align="center" style="margin: auto;">
-                      <tr>
-                        <td style="border-radius: 3px; text-align: center;">
-                          <a href="#"
-                             class="button-a"
-                             i18n:translate="label_notification_settings"
-                             tal:attributes="href string:${options/public_url}/@@personal-preferences"
-                             style="font-family: Arial, sans-serif; font-size: 13px; line-height: 110%; text-align: center; text-decoration: none; display: block; border-radius: 3px; font-weight: bold; color: #418195;">
-                            Notification settings
-                          </a>
-                        </td>
-                      </tr>
-                    </table>
-                    <!-- Button : END -->
-                  </td>
-                </tr>
-              </table>
-            </td>
-          </tr>
-          <!-- 1 Column Text : END -->
-        </table>
-        <!-- Email Body : END -->
-
-        <!--[if mso]>
-            </td>
-            </tr>
-            </table>
-        <![endif]-->
-      </div>
-    </center>
-  </body>
+    <meta:content metal:fill-slot="content">
+      <dl style="padding: 0; margin: 0;">
+        <tal:repeat tal:repeat="item options/notifications">
+          <dt>
+            <h2 style="margin: 0 0 10px 0; font-family: Arial, sans-serif; font-size: 18px; line-height: 125%; color: #333333; font-weight: bold;">
+              <a style="color: #418195;"
+                 href="#"
+                 tal:content="item/title"
+                 tal:attributes="href item/url">Item title</a>
+            </h2>
+          </dt>
+          <dd style="margin: 0; padding: 0;">
+            <ul style="padding: 0; Margin: 0;">
+              <li style="Margin:0 0 1em; list-style:disc; mso-special-format:bullet;" tal:repeat="activity item/activities">
+                <p tal:content="structure activity/summary" />
+              </li>
+            </ul>
+          </dd>
+        </tal:repeat>
+      </dl>
+    </meta:content>
 </html>
-

--- a/opengever/activity/templates/notification.pt
+++ b/opengever/activity/templates/notification.pt
@@ -5,6 +5,14 @@
     i18n:domain="opengever.activity"
     metal:use-macro="context/notification_mail_macros/macros/mail_template">
 
+    <metal:styles metal:fill-slot="style_slot">
+      <style>
+        .email-content table {
+          width: 100%;
+        }
+      </style>
+    </metal:styles>
+
     <metal:title metal:fill-slot="title">
         <div tal:replace="options/title"></div>
     </metal:title>
@@ -15,7 +23,6 @@
       <p><a href="" tal:content="options/title" tal:attributes="href options/link"></a></p>
 
       <tal:block tal:condition="options/description">
-        <p class="details" i18n:translate="label_details">Details:</p>
         <tal:block tal:repeat="paragraph options/description">
           <p tal:content="structure paragraph" />
         </tal:block>

--- a/opengever/activity/templates/notification.pt
+++ b/opengever/activity/templates/notification.pt
@@ -1,49 +1,25 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html
     xmlns="http://www.w3.org/1999/xhtml"
     xmlns:tal="http://xml.zope.org/namespaces/tal"
     xmlns:i18n="http://xml.zope.org/namespaces/i18n"
-    i18n:domain="opengever.activity">
+    i18n:domain="opengever.activity"
+    metal:use-macro="context/notification_mail_macros/macros/mail_template">
 
-  <head>
-    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <metal:title metal:fill-slot="title">
+        <div tal:replace="options/title"></div>
+    </metal:title>
 
-    <title tal:content="structure options/subject"></title>
-    <style>
-      body{
-        font-family: sans-serif;
-        font-size: 85%;
-      }
+    <metal:content metal:fill-slot="content">
+      <p class="notification_label" tal:content="structure options/summary" />
 
-      .notification_label {
-        padding-bottom: 5px;
+      <p><a href="" tal:content="options/title" tal:attributes="href options/link"></a></p>
 
-      }
-      .label {
-        font-weight: bold;
-        text-align: left;
-        padding-right: 1em;
-        }
-
-      .details {
-        padding-top: 15px;
-        }
-    </style>
-
-  </head>
-
-  <body>
-    <p class="notification_label" tal:content="structure options/summary" />
-
-    <p><a href="" tal:content="options/title" tal:attributes="href options/link"></a></p>
-
-    <tal:block tal:condition="options/description">
-      <p class="details" i18n:translate="label_details">Details:</p>
-      <tal:block tal:repeat="paragraph options/description">
-        <p tal:content="structure paragraph" />
+      <tal:block tal:condition="options/description">
+        <p class="details" i18n:translate="label_details">Details:</p>
+        <tal:block tal:repeat="paragraph options/description">
+          <p tal:content="structure paragraph" />
+        </tal:block>
       </tal:block>
-    </tal:block>
-  </body>
 
+    </metal:content>
 </html>

--- a/opengever/activity/tests/test_digest.py
+++ b/opengever/activity/tests/test_digest.py
@@ -67,10 +67,10 @@ class TestDigestMail(IntegrationTestCase):
 
         browser.open_html(str(messages[0].get_payload()[0]))
 
-        self.assertEquals('Oct 16, 201= 7', browser.css('table p').text[0])
+        self.assertEquals('Oct 16, 2017', browser.css('table p').text[0])
         self.assertEquals(['Daily Digest for B=C3=A4rfuss K=C3=A4thi'],
                           browser.css('h1').text)
-        self.assertEquals(['Bitte =C3=84nderungen nachvollzie= hen'],
+        self.assertEquals(['Bitte =C3=84nderungen nachvollziehen'],
                           browser.css('h2 a').text)
 
     def test_send_in_digest_flag_is_enabled_after_send(self):

--- a/opengever/activity/tests/test_mail.py
+++ b/opengever/activity/tests/test_mail.py
@@ -103,7 +103,7 @@ class TestEmailNotification(IntegrationTestCase):
         self.login(self.dossier_responsible, browser)
         self.create_task_via_browser(browser)
         raw_mail = Mailing(self.portal).pop()
-        link = '<p><a href=3D"http://nohost/plone/@@resolve_notification?notification_i=\nd=3D1">Test Task</a></p>'
+        link = '<p><a href=3D"http://nohost/plone/@@resolve_notification?notification=\n_id=3D1">Test Task</a></p>'
         self.assertIn(link, raw_mail.strip())
 
     @browsing


### PR DESCRIPTION
Dieser PR verwendet für die Standard-Benachrichtigung per E-Mail das selbe Template wie für die Tageszusammenfassung.

Tageszusammenfassung:
--------------------------
<img width="729" alt="bildschirmfoto 2018-10-22 um 16 41 05" src="https://user-images.githubusercontent.com/557005/47298902-3ebe8580-d619-11e8-93e8-33a1a26dd441.png">


Standard-Benachrichtigung vorher:
--------------------------
<img width="713" alt="bildschirmfoto 2018-10-22 um 16 41 59" src="https://user-images.githubusercontent.com/557005/47298914-4aaa4780-d619-11e8-810c-136ea32b6748.png">


Standard-Benachrichtigung nachher:
--------------------------
<img width="720" alt="bildschirmfoto 2018-10-22 um 16 41 11" src="https://user-images.githubusercontent.com/557005/47298932-5269ec00-d619-11e8-9d8d-37eeb8957f6d.png">

fixes #4523