### PR TITLE
Sanitize eCH-0147 imports via a JSON cycle

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -38,6 +38,7 @@ Changelog
 - Respect ISharingConfiguration black- and white_list_prefix for selectable groups in add-team form. [elioschmutz]
 - Restrict selectable orgunits on add-team form to orgunits of the current adminunit only. [elioschmutz]
 - Update ftw.tabbedview to 4.1.2. [Kevin Bieri]
+- Sanitize eCH-0147 imports. [Rotonen]
 - Fix dispatching notifications while recording a TaskReminderActivity. [elioschmutz]
 - Prefill task-reminder select field on task response form. [elioschmutz]
 - Use the same template for default notifiaction email like the daily-digest template. [elioschmutz]

--- a/opengever/core/upgrades/20181109105732_ensure_all_fields_of_e_ch_0147_imported_objects_are_properly_typed/upgrade.py
+++ b/opengever/core/upgrades/20181109105732_ensure_all_fields_of_e_ch_0147_imported_objects_are_properly_typed/upgrade.py
@@ -1,0 +1,87 @@
+from contextlib import contextmanager
+from datetime import date
+from datetime import datetime
+from dateutil.parser import parse as date_parser
+from ftw.upgrade import UpgradeStep
+from opengever.bundle.sections.constructor import BUNDLE_GUID_KEY
+from opengever.ech0147.interfaces import IECH0147Settings
+from plone import api
+from plone.dexterity.utils import iterSchemata
+from pyxb.binding.datatypes import boolean as pyxb_boolean
+from pyxb.binding.datatypes import date as pyxb_date
+from pyxb.binding.datatypes import dateTime as pyxb_datetime
+from pyxb.binding.datatypes import int as pyxb_int
+from pyxb.binding.datatypes import string as pyxb_string
+from zope.annotation import IAnnotations
+from zope.schema import getFieldsInOrder
+import logging
+import pyxb.binding.datatypes
+
+
+logger = logging.getLogger("opengever.core")
+
+
+@contextmanager
+def writable(field):
+    try:
+        original_readonly = field.readonly
+        field.readonly = False
+        yield field
+    finally:
+        field.readonly = original_readonly
+
+
+class EnsureAllFieldsOfECH0147ImportedObjectsAreProperlyTyped(UpgradeStep):
+    """Ensure all fields of eCH-0147 imported objects are properly typed.
+    """
+    deferrable = True
+
+    def __call__(self):
+        self.install_upgrade_profile()
+
+        # Skip if eCH-0147 imports are not enabled
+        if not api.portal.get_registry_record("ech0147_import_enabled", interface=IECH0147Settings):
+            return
+
+        # Only query non-imported-from-bundle documents and dossiers
+        affected_types = ("opengever.dossier.businesscasedossier", "opengever.document.document")
+        query = {"portal_type": affected_types, "bundle_guid": None}
+        primitive_pyxb_types = pyxb.binding.datatypes.__dict__.get("_PrimitiveDatatypes")
+        trivial_pyxb_types = (pyxb_int, pyxb_boolean, pyxb_string)
+        trivial_types = (int, basestring)
+
+        for obj in self.objects(query, "Ensure all fields of eCH-0147 imported objects are properly typed."):
+            # Skip imported-from-bundle objects not on the index
+            if IAnnotations(obj).get(BUNDLE_GUID_KEY):
+                continue
+            for schema in iterSchemata(obj):
+                for name, field in getFieldsInOrder(schema):
+                    value = getattr(field.interface(obj), name, None)
+                    value_type = type(value)
+                    # Only touch pyxb typed values
+                    if field._type and value is not None and isinstance(value_type, primitive_pyxb_types):
+                        object_path = "/".join(obj.getPhysicalPath())
+                        logger.info(
+                            "Found PyXB values in object %s field %s field type %s value type %s.",
+                            object_path,
+                            name,
+                            repr(field._type),
+                            repr(value_type),
+                        )
+                        if isinstance(value_type, trivial_pyxb_types) and field._type in trivial_types:
+                            with writable(field) as wfield:
+                                wfield.set(wfield.interface(obj), wfield._type(value))
+                        elif isinstance(value_type, pyxb_date) and field._type is date:
+                            with writable(field) as wfield:
+                                wfield.set(wfield.interface(obj), wfield._type.fromordinal(wfield.toordinal()))
+                        elif isinstance(value_type, pyxb_datetime) and field._type is datetime:
+                            with writable(field) as wfield:
+                                wfield.set(wfield.interface(obj), date_parser(value.ISO()))
+                        else:
+                            logger.warn(
+                                "PyXB values in object %s field %s field type %s value type %s fell through!",
+                                object_path,
+                                name,
+                                repr(field._type),
+                                repr(value_type),
+                            )

--- a/opengever/dossier/handlers.py
+++ b/opengever/dossier/handlers.py
@@ -41,9 +41,9 @@ def set_former_reference_after_moving(obj, event):
 
     dossier_repr = IDossier(obj)
     former_ref_no = dossier_repr.temporary_former_reference_number
-    IDossier['former_reference_number'].set(dossier_repr, former_ref_no)
+    IDossier['former_reference_number'].set(dossier_repr, unicode(former_ref_no))
     # reset temporary former reference number
-    IDossier['temporary_former_reference_number'].set(dossier_repr, '')
+    IDossier['temporary_former_reference_number'].set(dossier_repr, u'')
 
     # setting the new number
     parent = aq_parent(aq_inner(obj))

--- a/opengever/ech0147/serializer.py
+++ b/opengever/ech0147/serializer.py
@@ -1,0 +1,31 @@
+from pyxb.binding.datatypes import date as pyxb_date
+import dateutil.parser
+import json
+
+
+ECH_0147_DATE_FIELDS = ('start', 'document_date')
+ECH_0147_DATETIME_FIELDS = ()
+
+
+class ECH0147Serializer(json.JSONEncoder):
+    """Sanitize inputs for eCH-0147 imports via JSON serialization."""
+
+    def default(self, obj):
+        if isinstance(obj, pyxb_date):
+            return obj.isoformat()
+        return obj
+
+    def decode(self, string):
+        """We only get flat enough dicts to know dates are on the top level."""
+        obj = json.loads(string)
+
+        for key, value in obj.items():
+            if isinstance(value, basestring):
+                if key in ECH_0147_DATE_FIELDS:
+                    obj[key] = dateutil.parser.parse(value).date()
+                elif key in ECH_0147_DATETIME_FIELDS:
+                    obj[key] = dateutil.parser.parse(value)
+                else:
+                    pass
+
+        return obj

--- a/opengever/ech0147/tests/test_import.py
+++ b/opengever/ech0147/tests/test_import.py
@@ -6,6 +6,8 @@ from opengever.testing import FunctionalTestCase
 from opengever.testing import IntegrationTestCase
 from opengever.testing.helpers import obj2brain
 from plone import api
+from plone.dexterity.utils import iterSchemata
+from zope.schema import getFieldsInOrder
 import os.path
 
 
@@ -88,6 +90,24 @@ class TestImport(IntegrationTestCase):
         self.assertEqual(dossier.Title(), 'Neubau Schwimmbad 50m')
 
     @browsing
+    def test_import_dossier_with_full_set_of_metadata_contains_valid_data_after_import(self, browser):
+        self.activate_feature('ech0147-import')
+        self.login(self.regular_user, browser)
+        browser.open(self.leaf_repofolder, view='ech0147_import')
+        with open(get_path('message_full.zip')) as file_:
+            browser.forms['form'].fill({
+                'File': file_,
+            }).submit()
+        dossier = self.leaf_repofolder.objectValues()[-1]
+
+        for schema in iterSchemata(dossier):
+            for name, field in getFieldsInOrder(schema):
+                value = getattr(field.interface(dossier), name, None)
+                # Allow empty values on non-required fields
+                if not field.required and value is not None:
+                    self.assertEqual(field._type, type(value), 'Wrong type for value of field: {}'.format(name))
+
+    @browsing
     def test_import_toplevel_documents_in_dossier(self, browser):
         self.activate_feature('ech0147-import')
         self.login(self.regular_user, browser)
@@ -101,6 +121,27 @@ class TestImport(IntegrationTestCase):
         self.assertEqual(docs[1].Title(), 'Grundrissplan')
 
         self.assertIsNotNone(obj2brain(docs[0]).bumblebee_checksum)
+
+    @browsing
+    def test_import_toplevel_documents_in_dossier_contain_valid_data_after_import(self, browser):
+        self.activate_feature('ech0147-import')
+        self.login(self.regular_user, browser)
+        browser.open(self.dossier, view='ech0147_import')
+        with open(get_path('message_docs_only.zip')) as file_:
+            browser.forms['form'].fill({
+                'File': file_,
+            }).submit()
+
+        for doc in self.dossier.objectValues()[-2:]:
+            for schema in iterSchemata(doc):
+                for name, field in getFieldsInOrder(schema):
+                    # We skip Versionable.changeNote as that's not actually persisted on the object
+                    if name == 'changeNote':
+                        continue
+                    value = getattr(field.interface(doc), name, None)
+                    # Allow empty values on non-required fields
+                    if not field.required and value is not None:
+                        self.assertEqual(field._type, type(value), 'Wrong type for value of field: {}'.format(name))
 
     @browsing
     def test_import_toplevel_documents_in_repofolder_displays_error(self, browser):


### PR DESCRIPTION
Made a custom JSON (de)serializer for eCH-0147  imports as we feed these to the `plone.restapi` JSON deserializer. This way everything is guaranteedly just a string unless it's whitelisted as a date field and we can easily amend any future additions to the field types.

There are also tests for importing data via eCH-0147 and a deferrable upgrade step for going through all of the fields on all of the schemata on all of the non-bundle-imported objects for PyXB data types and casting the strings, ints, booleans, dates and datetimes thereof into their appropriate field types.

Closes #4376