### PR TITLE
Adjust team queries

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -11,6 +11,7 @@ Changelog
 - Assign correct roles in development content. [deiferni]
 - Place successor proposal button next to workflow buttons. [Kevin Bieri]
 - Remove document tooltip on touch devices. [Kevin Bieri]
+- Restrict selectable orgunits on add-team form to orgunits of the current adminunit only. [elioschmutz]
 - Fix dispatching notifications while recording a TaskReminderActivity. [elioschmutz]
 - Prefill task-reminder select field on task response form. [elioschmutz]
 - Use the same template for default notifiaction email like the daily-digest template. [elioschmutz]

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -11,6 +11,7 @@ Changelog
 - Assign correct roles in development content. [deiferni]
 - Place successor proposal button next to workflow buttons. [Kevin Bieri]
 - Remove document tooltip on touch devices. [Kevin Bieri]
+- Respect ISharingConfiguration black- and white_list_prefix for selectable groups in add-team form. [elioschmutz]
 - Restrict selectable orgunits on add-team form to orgunits of the current adminunit only. [elioschmutz]
 - Fix dispatching notifications while recording a TaskReminderActivity. [elioschmutz]
 - Prefill task-reminder select field on task response form. [elioschmutz]

--- a/opengever/ogds/base/browser/team_forms.py
+++ b/opengever/ogds/base/browser/team_forms.py
@@ -4,8 +4,7 @@ from opengever.base.browser.modelforms import ModelAddForm
 from opengever.base.browser.modelforms import ModelEditForm
 from opengever.contact.utils import get_contactfolder_url
 from opengever.ogds.base import _
-from opengever.ogds.base.sources import AllGroupsSourceBinder
-from opengever.ogds.base.sources import AllOrgUnitsSourceBinder
+from opengever.ogds.base.sources import CurrentAdminUnitOrgUnitsSourceBinder
 from opengever.ogds.models import UNIT_TITLE_LENGTH
 from opengever.ogds.models.team import Team
 from plone.autoform import directives as form
@@ -36,7 +35,7 @@ class ITeam(model.Schema):
     form.widget('org_unit_id', KeywordFieldWidget, async=True)
     org_unit_id = schema.Choice(
         title=_('label_org_unit', default=u'Org Unit'),
-        source=AllOrgUnitsSourceBinder(),
+        source=CurrentAdminUnitOrgUnitsSourceBinder(),
         required=True)
 
 

--- a/opengever/ogds/base/browser/team_forms.py
+++ b/opengever/ogds/base/browser/team_forms.py
@@ -5,6 +5,7 @@ from opengever.base.browser.modelforms import ModelEditForm
 from opengever.contact.utils import get_contactfolder_url
 from opengever.ogds.base import _
 from opengever.ogds.base.sources import CurrentAdminUnitOrgUnitsSourceBinder
+from opengever.ogds.base.sources import AllFilteredGroupsSourceBinder
 from opengever.ogds.models import UNIT_TITLE_LENGTH
 from opengever.ogds.models.team import Team
 from plone.autoform import directives as form
@@ -29,7 +30,7 @@ class ITeam(model.Schema):
     form.widget('groupid', KeywordFieldWidget, async=True)
     groupid = schema.Choice(
         title=_('label_group', default=u'Group'),
-        source=AllGroupsSourceBinder(),
+        source=AllFilteredGroupsSourceBinder(),
         required=True)
 
     form.widget('org_unit_id', KeywordFieldWidget, async=True)

--- a/opengever/ogds/base/sources.py
+++ b/opengever/ogds/base/sources.py
@@ -777,13 +777,15 @@ class BaseSQLModelSource(BaseQuerySoure):
         return self.terms
 
 
-class AllOrgUnitsSource(BaseSQLModelSource):
+class CurrentAdminUnitOrgUnitsSource(BaseSQLModelSource):
 
     model_class = OrgUnit
 
     @property
     def base_query(self):
-        return OrgUnit.query.filter(OrgUnit.enabled == True)  # noqa
+        admin_unit = get_current_admin_unit()
+        return OrgUnit.query.filter(OrgUnit.admin_unit_id == admin_unit.unit_id) \
+                            .filter(OrgUnit.enabled == True)  # noqa
 
     @property
     def search_query(self):
@@ -791,10 +793,10 @@ class AllOrgUnitsSource(BaseSQLModelSource):
 
 
 @implementer(IContextSourceBinder)
-class AllOrgUnitsSourceBinder(object):
+class CurrentAdminUnitOrgUnitsSourceBinder(object):
 
     def __call__(self, context):
-        return AllOrgUnitsSource(context)
+        return CurrentAdminUnitOrgUnitsSource(context)
 
 
 class AllGroupsSource(BaseSQLModelSource):

--- a/opengever/ogds/base/tests/test_sources.py
+++ b/opengever/ogds/base/tests/test_sources.py
@@ -4,9 +4,10 @@ from ftw.solr.connection import SolrResponse
 from ftw.solr.interfaces import ISolrSearch
 from ftw.solr.schema import SolrSchema
 from mock import MagicMock
+from opengever.ogds.base.interfaces import IAdminUnitConfiguration
+from opengever.ogds.base.sources import CurrentAdminUnitOrgUnitsSource
 from opengever.ogds.base.sources import AllEmailContactsAndUsersSource
 from opengever.ogds.base.sources import AllGroupsSource
-from opengever.ogds.base.sources import AllOrgUnitsSource
 from opengever.ogds.base.sources import AllUsersAndGroupsSource
 from opengever.ogds.base.sources import AllUsersInboxesAndTeamsSource
 from opengever.ogds.base.sources import AllUsersSource
@@ -17,6 +18,7 @@ from opengever.ogds.models.group import Group
 from opengever.testing import FunctionalTestCase
 from opengever.testing import IntegrationTestCase
 from pkg_resources import resource_string
+from plone import api
 from plone.app.testing import TEST_USER_ID
 from zope.component import getUtility
 from zope.schema.vocabulary import SimpleTerm
@@ -866,20 +868,31 @@ class TestContactsSource(FunctionalTestCase):
         self.assertEquals([], self.source.search('Hugo'))
 
 
-class TestAllOrgUnitsSource(IntegrationTestCase):
+class TestCurrentAdminUnitOrgUnitsSource(IntegrationTestCase):
 
     def setUp(self):
-        super(TestAllOrgUnitsSource, self).setUp()
-        self.source = AllOrgUnitsSource(self.portal)
+        super(TestCurrentAdminUnitOrgUnitsSource, self).setUp()
+        self.source = CurrentAdminUnitOrgUnitsSource(self.portal)
+
         create(Builder('org_unit')
                .id('afi')
                .having(title=u'Amt f\xfcr Informatik',
                        admin_unit_id='plone',
                        enabled=False))
 
+        self.additional = create(Builder('admin_unit')
+                                 .id('additional'))
+        self.org_unit = create(Builder('org_unit')
+                               .id('ska')
+                               .having(title=u'Staatskanzlei',
+                                       admin_unit=self.additional,
+                                       enabled=True)
+                               .with_default_groups())
+
     def test_all_org_unit_ids_are_valid(self):
         self.assertIn('fa', self.source)
         self.assertIn('afi', self.source)
+        self.assertIn('ska', self.source)
 
     def test_not_existing_org_unit_ids(self):
         self.assertNotIn('not', self.source)
@@ -899,6 +912,17 @@ class TestAllOrgUnitsSource(IntegrationTestCase):
     def test_invalid_token_raises_lookup_error(self):
         with self.assertRaises(LookupError):
             self.source.getTermByToken('invalid-id')
+
+    def test_do_not_find_org_units_of_other_admin_units(self):
+        self.assertEqual(1, len(self.source.search('Finanzamt')))
+        self.assertEqual(0, len(self.source.search('Staatskanzlei')))
+
+        api.portal.set_registry_record('current_unit_id',
+                                       self.additional.id().decode('utf-8'),
+                                       IAdminUnitConfiguration)
+
+        self.assertEqual(0, len(self.source.search('Finanzamt')))
+        self.assertEqual(1, len(self.source.search('Staatskanzlei')))
 
 
 class TestAllGroupsSource(IntegrationTestCase):


### PR DESCRIPTION
Dieser PR lässt den Benutzer beim Hinzufügen eines Teams nur noch Orgunits der aktuellen AdminUnit auswählen.

Zudem wird eine neue Vocabulary-Source für die Gruppen verwendet. Neu werden die Black-White-List prefixes welche im ISharingConfiguration konfiguriert werden bei der Gruppenauswahl miteinbezogen.