### PR TITLE
Remove document tooltip on touch devices

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -10,6 +10,7 @@ Changelog
 - Use plone.protect class of confirm-action view. [elioschmutz]
 - Assign correct roles in development content. [deiferni]
 - Place successor proposal button next to workflow buttons. [Kevin Bieri]
+- Remove document tooltip on touch devices. [Kevin Bieri]
 - Fix dispatching notifications while recording a TaskReminderActivity. [elioschmutz]
 - Prefill task-reminder select field on task response form. [elioschmutz]
 - Use the same template for default notifiaction email like the daily-digest template. [elioschmutz]

--- a/opengever/base/browser/resources/tooltip.js
+++ b/opengever/base/browser/resources/tooltip.js
@@ -92,7 +92,9 @@
     showBackdrop(event);
   }
 
-  $(document).on("mouseover", ".tooltip-trigger", initTooltips);
+  if (!Modernizr.touch) {
+    $(document).on("mouseover", ".tooltip-trigger", initTooltips);
+  }
 
 }(window, window.jQuery));
 


### PR DESCRIPTION
Closes https://github.com/4teamwork/opengever.core/issues/4809

On one hand the mouseover event somehow breaks the click event on touch devices such as the iPad.
On the other hand a mouseover event is not possible on touch devices anyway. So just initialize the qtip tooltips on non touch devices.