### PR TITLE
Restrict TaskQueries according to the task principals.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -21,6 +21,7 @@ Changelog
 - Make sure our Diazo theme doesn't drop data-base-url attribute. [lgraf]
 - Bump Plone version to 4.3.18. [Rotonen, lgraf]
 - Fix bug with document showroom for sablon and proposal templates. [njohner]
+- Restrict TaskQueries according to the task principals. [phgross]
 - Bump ftw.solr to 2.3.0 to get patched (optimized) reindexObjectSecurity(). [lgraf]
 - Implement asynchronous meeting zip generation, with PDFs from the new demand endpoint. [deiferni, lgraf]
 - Add new icon for private folder. [njohner]

--- a/opengever/core/upgrades/20181022104232_reindex_task_principals_in_globalindex/upgrade.py
+++ b/opengever/core/upgrades/20181022104232_reindex_task_principals_in_globalindex/upgrade.py
@@ -1,0 +1,13 @@
+from ftw.upgrade import UpgradeStep
+from opengever.task.task import ITask
+
+
+class ReindexTaskPrincipalsInGlobalindex(UpgradeStep):
+    """Reindex task principals in globalindex.
+    """
+
+    def __call__(self):
+        query = {'object_provides': ITask.__identifier__}
+        for task in self.objects(query, 'Reindex task principals'):
+            sql_task = task.get_sql_object()
+            sql_task.principals = task.get_principals()

--- a/opengever/globalindex/tests/test_query.py
+++ b/opengever/globalindex/tests/test_query.py
@@ -129,6 +129,22 @@ class TestTaskQueries(IntegrationTestCase):
         self.assertItemsEqual(
             tasks, Task.query.all_issued_tasks(additional).all())
 
+    def test_restrict_checks_principals(self):
+        # Responsible user is able to see
+        self.login(self.regular_user)
+        sql_task = self.task_in_protected_dossier.get_sql_object()
+        self.assertIn(sql_task, Task.query.restrict().all())
+
+        # Secretariat user is not able to see the task
+        self.login(self.secretariat_user)
+        self.assertNotIn(sql_task, Task.query.restrict().all())
+
+    def test_restrict_checks_is_skipped_for_admins(self):
+        # Responsible user is able to see
+        self.login(self.administrator)
+        sql_task = self.task_in_protected_dossier.get_sql_object()
+        self.assertIn(sql_task, Task.query.restrict().all())
+
     def test_by_container_list_recursive_all_tasks_inside_the_given_container(self):
         self.login(self.regular_user)
 

--- a/opengever/tabbedview/tests/test_personaloverview.py
+++ b/opengever/tabbedview/tests/test_personaloverview.py
@@ -250,27 +250,23 @@ class TestGlobalTaskListings(IntegrationTestCase):
         self.login(self.dossier_responsible, browser=browser)
         browser.open(view='tabbedview_view-myissuedtasks')
         expected_tasks = [
-            u'F\xf6rw\xe4rding',
             u'Rechtliche Grundlagen in Vertragsentwurf \xdcberpr\xfcfen',
             u'Vertragsentwurf \xdcberpr\xfcfen',
             u'Vertr\xe4ge abschliessen',
             u'Status \xdcberpr\xfcfen',
             u'Programm \xdcberpr\xfcfen',
             u'H\xf6rsaal reservieren',
-            u'Ein notwendiges \xdcbel',
             ]
         found_tasks = [row.get('Title') for row in browser.css('.listing').first.dicts()]
         self.assertEquals(expected_tasks, found_tasks)
         self.task.get_sql_object().issuer = 'kathi.barfuss'
         browser.open(view='tabbedview_view-myissuedtasks')
         expected_tasks = [
-            u'F\xf6rw\xe4rding',
             u'Rechtliche Grundlagen in Vertragsentwurf \xdcberpr\xfcfen',
             u'Vertr\xe4ge abschliessen',
             u'Status \xdcberpr\xfcfen',
             u'Programm \xdcberpr\xfcfen',
             u'H\xf6rsaal reservieren',
-            u'Ein notwendiges \xdcbel',
             ]
         found_tasks = [row.get('Title') for row in browser.css('.listing').first.dicts()]
         self.assertEquals(expected_tasks, found_tasks)
@@ -290,8 +286,7 @@ class TestGlobalTaskListings(IntegrationTestCase):
             u'Status \xdcberpr\xfcfen',
             u'Programm \xdcberpr\xfcfen',
             u'H\xf6rsaal reservieren',
-            u'Ein notwendiges \xdcbel',
-        ]
+            ]
         found_tasks = [row.get('Title') for row in browser.css('.listing').first.dicts()]
         self.assertItemsEqual(expected_tasks, found_tasks)
         self.task.get_sql_object().assigned_org_unit = 'additional'
@@ -306,8 +301,7 @@ class TestGlobalTaskListings(IntegrationTestCase):
             u'Status \xdcberpr\xfcfen',
             u'Programm \xdcberpr\xfcfen',
             u'H\xf6rsaal reservieren',
-            u'Ein notwendiges \xdcbel',
-        ]
+            ]
         found_tasks = [row.get('Title') for row in browser.css('.listing').first.dicts()]
         self.assertItemsEqual(expected_tasks, found_tasks)
 
@@ -326,8 +320,7 @@ class TestGlobalTaskListings(IntegrationTestCase):
             u'Status \xdcberpr\xfcfen',
             u'Programm \xdcberpr\xfcfen',
             u'H\xf6rsaal reservieren',
-            u'Ein notwendiges \xdcbel',
-        ]
+            ]
         found_tasks = [row.get('Title') for row in browser.css('.listing').first.dicts()]
         self.assertItemsEqual(expected_tasks, found_tasks)
         create(
@@ -351,7 +344,6 @@ class TestGlobalTaskListings(IntegrationTestCase):
             u'Status \xdcberpr\xfcfen',
             u'Programm \xdcberpr\xfcfen',
             u'H\xf6rsaal reservieren',
-            u'Ein notwendiges \xdcbel',
         ]
         found_tasks = [row.get('Title') for row in browser.css('.listing').first.dicts()]
         self.assertItemsEqual(expected_tasks, found_tasks)

--- a/opengever/task/tests/test_principals.py
+++ b/opengever/task/tests/test_principals.py
@@ -1,0 +1,16 @@
+from opengever.testing import IntegrationTestCase
+
+
+class TestTaskPrincipals(IntegrationTestCase):
+
+    def test_return_a_list_of_all_users_and_groups_which_are_able_to_see_the_task(self):
+        self.login(self.regular_user)
+
+        self.assertEqual(
+            [u'kathi.barfuss', u'fa_users'], self.task.get_principals())
+
+    def test_does_respect_blocked_role_inheritance(self):
+        self.login(self.regular_user)
+
+        self.assertEqual(
+            [u'kathi.barfuss'], self.task_in_protected_dossier.get_principals())

--- a/opengever/testing/integration_test_case.py
+++ b/opengever/testing/integration_test_case.py
@@ -21,6 +21,7 @@ from opengever.meeting.wrapper import MeetingWrapper
 from opengever.ogds.base.utils import get_current_admin_unit
 from opengever.ogds.base.utils import get_current_org_unit
 from opengever.ogds.base.utils import ogds_service
+from opengever.ogds.models.org_unit import OrgUnit
 from opengever.private import enable_opengever_private
 from opengever.task.interfaces import ISuccessorTaskController
 from opengever.task.task import ITask
@@ -654,11 +655,12 @@ class IntegrationTestCase(TestCase):
         return solr
 
     def add_additional_org_unit(self):
-        create(Builder('org_unit').id("additional")
+        org_unit = create(Builder('org_unit').id("additional")
                .having(admin_unit=get_current_admin_unit()))
 
         # Reset org_unit strategy, we need now a MultipleOrgUnitsStrategy
         get_current_org_unit()._chosen_strategy = None
+        return OrgUnit.get('additional')
 
     def assert_solr_called(self, solr, text, **kwargs):
         query = (


### PR DESCRIPTION
With the `TaskPrincipals` we already sync principals allowed to see a Task in to the globalindex. But currently the task queries has not been restricted and therefore a task was always visible, for all accessors of a Dossier and for inbox-users all tasks of a current admin_unit has been visible.

With "OGIP 46 - personal task", we now introduced a possibility to disable the `inbox-user` agency permission and have to restrict the task listings etc. I decided to restrict all TaskQueries, which also solves an [Issue](https://extranet.4teamwork.ch/support/gever-st-gallen/tracker/365) wich allowed including tasks in to pdf_task_listing, where the user was not allowed to access.

During implementation I've also realized that the current implementation of the principals getter was wrong and did not respect the block_local_roles flag. 

Maybe backported to `2018.4-stable` 

Closes #4765 