### PR TITLE
Don't html-escape description for JSON data.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -8,6 +8,7 @@ Changelog
 - Extend example-content with evil objects containing javascript. [elioschmutz]
 - Escape description of document_added description object. [elioschmutz]
 - Use plone.protect class of confirm-action view. [elioschmutz]
+- Don't html-escape description for JSON data. [deiferni]
 - Assign correct roles in development content. [deiferni]
 - Place successor proposal button next to workflow buttons. [Kevin Bieri]
 - Remove document tooltip on touch devices. [Kevin Bieri]

--- a/opengever/meeting/browser/sablontemplate.py
+++ b/opengever/meeting/browser/sablontemplate.py
@@ -24,7 +24,7 @@ SAMPLE_MEETING_DATA = {
             "title": "Strafbefehl"
             }]
     }, {
-        'description': 'R&uuml;cktritt Grund',
+        'description': u'R\xfccktritt Grund',
         'dossier_reference_number': None,
         'repository_folder_title': None,
         'number': '2.',

--- a/opengever/meeting/model/agendaitem.py
+++ b/opengever/meeting/model/agendaitem.py
@@ -142,9 +142,11 @@ class AgendaItem(Base):
             self.title = title
 
     def get_description(self):
-        description = (self.submitted_proposal.description if self.has_proposal
-                       else self.description)
-        return to_html_xweb_intelligent(description) or None
+        return (self.submitted_proposal.description if self.has_proposal
+                else self.description)
+
+    def get_description_html(self):
+        return to_html_xweb_intelligent(self.get_description()) or None
 
     def set_description(self, description):
         if self.has_proposal:
@@ -224,7 +226,7 @@ class AgendaItem(Base):
             'id': self.agenda_item_id,
             'css_class': self.get_css_class(),
             'title': self.get_title_html(),
-            'description': self.get_description(),
+            'description': self.get_description_html(),
             'number': self.number,
             'has_proposal': self.has_proposal,
             'link': self.get_proposal_link(include_icon=False),

--- a/opengever/meeting/tests/test_agendaitem_list.py
+++ b/opengever/meeting/tests/test_agendaitem_list.py
@@ -111,7 +111,7 @@ class TestAgendaItemList(IntegrationTestCase):
              u'number': u'1.',
              u'repository_folder_title': u'Vertr\xe4ge und Vereinbarungen',
              u'title': u'Vertr\xe4ge',
-             u'description': u'F&uuml;r weitere Bearbeitung bewilligen'},
+             u'description': u'F\xfcr weitere Bearbeitung bewilligen'},
             {u'decision_number': None,
              u'description': None,
              u'dossier_reference_number': None,

--- a/opengever/meeting/tests/test_unit_agenda_item.py
+++ b/opengever/meeting/tests/test_unit_agenda_item.py
@@ -2,8 +2,6 @@ from ftw.builder import Builder
 from ftw.builder import create
 from opengever.core.testing import OPENGEVER_FUNCTIONAL_MEETING_LAYER
 from opengever.testing import FunctionalTestCase
-from opengever.testing import MEMORY_DB_LAYER
-from unittest import TestCase
 
 
 class TestProposalAgendaItem(FunctionalTestCase):
@@ -36,7 +34,7 @@ class TestProposalAgendaItem(FunctionalTestCase):
         self.proposal, self.submitted_proposal = create(Builder('proposal')
                                .within(self.dossier)
                                .having(title=u'Pr\xf6posal',
-                                       description='Description',
+                                       description=u'F\xfc\xfc',
                                        committee=self.committee.load_model())
                                .with_submitted())
         self.agenda_item = create(
@@ -60,10 +58,21 @@ class TestProposalAgendaItem(FunctionalTestCase):
              'number': '1.',
              'id': 1,
              'title': 'Pr&ouml;posal',
-             'description': 'Description',
+             'description': 'F&uuml;&uuml;',
              'has_proposal': True,
              'link': u'<a href="http://nohost/plone/opengever-meeting-committeecontainer/committee-1/submitted-proposal-1" title="Pr\xf6posal">Pr\xf6posal</a>'},  # noqa
             self.agenda_item.serialize())
+
+    def test_agenda_item_json_data_part(self):
+        self.assertEqual(
+            {'decision_number': None,
+             'description': u'F\xfc\xfc',
+             'dossier_reference_number': u'Client1 1 / 1',
+             'is_paragraph': False,
+             'number': u'1.',
+             'repository_folder_title': u'',
+             'title': u'Pr\xf6posal'},
+            self.agenda_item.get_agenda_item_data())
 
 
 class TestSimpleAgendaItem(FunctionalTestCase):


### PR DESCRIPTION
The description is passed on to sablon which no longer treats the input as html which needs to be converted to word. So html-escapes will be treated literally which is wrong.

Fixes #5012.