### PR TITLE
Use MetaData.reflect instead of reflect parmeter.

### DIFF
--- a/opengever/core/upgrade.py
+++ b/opengever/core/upgrade.py
@@ -387,7 +387,8 @@ class SchemaMigration(SQLUpgradeStep):
         super(SchemaMigration, self)._setup_db_connection()
 
         self.dialect_name = self.connection.dialect.name
-        self.metadata = MetaData(self.connection, reflect=True)
+        self.metadata = MetaData(self.connection)
+        self.metadata.reflect()
         self.op = get_operations(self.connection)
 
 
@@ -451,7 +452,9 @@ class GeverUpgradeStepRecorder(UpgradeStepRecorder):
         """Fetches the tracking table from the DB schema metadata if present,
         or creates it if necessary.
         """
-        table = MetaData(self.connection, reflect=True).tables.get(TRACKING_TABLE_NAME)
+        metadata = MetaData(self.connection)
+        metadata.reflect()
+        table = metadata.tables.get(TRACKING_TABLE_NAME)
         if table is not None:
             self._migrate_tracking_table(table)
             return table

--- a/opengever/setup/deploy.py
+++ b/opengever/setup/deploy.py
@@ -228,5 +228,6 @@ class GeverDeployment(object):
     def drop_sql_tables(self, session):
         """Drops all sql tables, usually for a dev-setup.
         """
-        temp_metadata = MetaData(bind=session.bind, reflect=True)
+        temp_metadata = MetaData(bind=session.bind)
+        temp_metadata.reflect()
         temp_metadata.drop_all()


### PR DESCRIPTION
This suppresses an sqlalchemy deprecation warning. I've set up new gever (with the purge sql option enabled) to test it works. All code paths that are modified are taken when setting up a new gever with `@@gever-add-deployment`.