### PR TITLE
Fix rendering issue in livesearch reply view.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2018.5.0 (unreleased)
 ---------------------
 
+- Fix rendering issue in livesearch reply view. [deiferni]
 - Disable buttons during save request in sharing form and improve error handling. [phgross]
 - Bump docxcompose to 1.0.0a12 to get a bugfix for sections in word. [deiferni]
 - Extend example-content with evil objects containing javascript. [elioschmutz]

--- a/opengever/advancedsearch/skins/advancedsearch_resources/livesearch_reply.py
+++ b/opengever/advancedsearch/skins/advancedsearch_resources/livesearch_reply.py
@@ -181,7 +181,8 @@ else:
         else:
             display_title = full_title
 
-        full_title = full_title.replace('"', '&quot;')
+        full_title = html_quote(full_title)
+        display_title = html_quote(display_title)
 
         css_klass = 'contenttype-%s' % ploneUtils.normalizeString(result.portal_type)
         mime_type_klass = get_mimetype_icon_klass(result)

--- a/opengever/advancedsearch/tests/test_livesearch_reply.py
+++ b/opengever/advancedsearch/tests/test_livesearch_reply.py
@@ -1,0 +1,22 @@
+from ftw.testbrowser import browsing
+from opengever.testing import IntegrationTestCase
+
+
+class TestLivesearchReply(IntegrationTestCase):
+
+    @browsing
+    def test_livesearch_reply_escapes_title(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        self.dossier.title = u"<script>alert('evil');</script>"
+        self.dossier.reindexObject()
+
+        browser.open(view='livesearch_reply?q=evil')
+        link_node = browser.css('.LSRow').first
+        # lxml unescapes attributes for us. we want to test that the title
+        # has been escaped correctly and thus use browser.contents only.
+        self.assertIn('title="&lt;script&gt;alert(\'evil\');&lt;/script&gt;"',
+                      link_node.outerHTML)
+        # also test title that is displayed
+        self.assertIn('&lt;script&gt;alert(\'evil\');&lt;',
+                      link_node.innerHTML)

--- a/opengever/base/browser/livesearch.py
+++ b/opengever/base/browser/livesearch.py
@@ -117,7 +117,8 @@ class LiveSearchReplyView(BrowserView):
                 else:
                     display_title = full_title
 
-                full_title = full_title.replace('"', '&quot;')
+                full_title = html_quote(full_title)
+                display_title = html_quote(display_title)
 
                 css_klass = get_mimetype_icon_klass(result.doc)
 


### PR DESCRIPTION
Fix it for solr and for the skins folder livesearch. The title was not escaped at all which lead to markup not being rendered correctly in some cases.

Fixes https://github.com/4teamwork/opengever.core/issues/5016.