### PR TITLE
Fix JS ordering issue: define modernizr.js position.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ---------------------
 
 - Fix rendering issue in livesearch reply view. [deiferni]
+- Fix JS ordering issue: define modernizr.js position. [phgross]
 - Disable buttons during save request in sharing form and improve error handling. [phgross]
 - Bump docxcompose to 1.0.0a12 to get a bugfix for sections in word. [deiferni]
 - Extend example-content with evil objects containing javascript. [elioschmutz]

--- a/opengever/core/profiles/default/jsregistry.xml
+++ b/opengever/core/profiles/default/jsregistry.xml
@@ -415,6 +415,11 @@
       insert-after="collective.js.jqueryui.custom.min.js"
       />
 
+  <javascript
+      id="modernizr.js"
+      insert-after="collective.js.jqueryui.custom.min.js"
+      />
+
   <!-- Required for the jquery 1.11.2 version. -->
   <javascript
       cacheable="True"

--- a/opengever/core/upgrades/20181031131112_define_modernizr_js_position/jsregistry.xml
+++ b/opengever/core/upgrades/20181031131112_define_modernizr_js_position/jsregistry.xml
@@ -1,0 +1,8 @@
+<object name="portal_javascripts" meta_type="JavaScripts Registry">
+
+  <javascript
+      id="modernizr.js"
+      insert-after="collective.js.jqueryui.custom.min.js"
+      />
+
+</object>

--- a/opengever/core/upgrades/20181031131112_define_modernizr_js_position/upgrade.py
+++ b/opengever/core/upgrades/20181031131112_define_modernizr_js_position/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class DefineModernizrJsPosition(UpgradeStep):
+    """Define modernizr.js position.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()


### PR DESCRIPTION
Register modernizr.js as one of the top JS.

Fixes the current js-issue on dev.onegovgever.ch.