### PR TITLE
Fix rendering issue in search view.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ---------------------
 
 - Fix normalizing filename for zip export. [deiferni]
+- Fix rendering issue in search view. [deiferni]
 - Fix rendering issue in livesearch reply view. [deiferni]
 - Fix JS ordering issue: define modernizr.js position. [phgross]
 - Disable buttons during save request in sharing form and improve error handling. [phgross]

--- a/opengever/base/browser/search.pt
+++ b/opengever/base/browser/search.pt
@@ -336,7 +336,7 @@
 
                             </div>
 
-                            <div class="description" tal:content="structure item/CroppedDescription">
+                            <div class="description" tal:content="structure python: view.escaped_description(item)">
                               Cropped description
                             </div>
 

--- a/opengever/base/tests/test_search.py
+++ b/opengever/base/tests/test_search.py
@@ -291,6 +291,7 @@ class TestSolrSearch(IntegrationTestCase):
                 ],
                 'hl': 'on',
                 'hl.fl': 'SearchableText',
+                'hl.encoder': 'html',
                 'hl.snippets': 3,
             })
 
@@ -312,6 +313,7 @@ class TestSolrSearch(IntegrationTestCase):
                 ],
                 'hl': 'on',
                 'hl.fl': 'SearchableText',
+                'hl.encoder': 'html',
                 'hl.snippets': 3,
             })
 


### PR DESCRIPTION
This PR fixes a rendering issue in search view. We fix it for SOLR and for the skins folder search results. The description was inserted as structure which would not render correctly due to missing escaping for catalog results.

SOLR search is configured by the view to return markup with highlighting using `<em>` tags. SOLR is now also configured to already escape its results before inserting those `<em>` tags so that the returned description can be safely inserted in the template using a `tal:structure`. 

For catalog results the view now escapes the description before it is being rendered in the template.

Fixes https://github.com/4teamwork/opengever.ftw/issues/77 https://github.com/4teamwork/opengever.core/issues/5017