### PR TITLE
Add file related metadata and indices, without yet actually using them

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -8,6 +8,7 @@ Changelog
 - Drop verbose logging for ObjectTouched events. [lgraf]
 - Bump ftw.solr to 2.3.1 to get reindexObjectSecurity fix. [lgraf]
 - Fix an issue when creating meetings from a template. [deiferni]
+- Added indices and metadata for filesize, filename and file extension. [Rotonen]
 - Fix normalizing filename for zip export. [deiferni]
 - Fix rendering issue in search view. [deiferni]
 - Fix rendering issue in livesearch reply view. [deiferni]

--- a/opengever/core/profiles/default/catalog.xml
+++ b/opengever/core/profiles/default/catalog.xml
@@ -30,6 +30,9 @@
   <column value="delivery_date" />
   <column value="checked_out" />
   <column value="public_trial" />
+  <column value="filesize" />
+  <column value="filename" />
+  <column value="file_extension" />
 
   <!-- DOSSIER -->
   <column value="containing_subdossier" />

--- a/opengever/core/upgrades/20181101150743_add_document_filesize__filename_and_file_extension_to_document_metadata/catalog.xml
+++ b/opengever/core/upgrades/20181101150743_add_document_filesize__filename_and_file_extension_to_document_metadata/catalog.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<object name="portal_catalog">
+    <column value="filesize" />
+    <column value="filename" />
+    <column value="file_extension" />
+</object>

--- a/opengever/core/upgrades/20181101150743_add_document_filesize__filename_and_file_extension_to_document_metadata/upgrade.py
+++ b/opengever/core/upgrades/20181101150743_add_document_filesize__filename_and_file_extension_to_document_metadata/upgrade.py
@@ -1,0 +1,21 @@
+from ftw.upgrade import UpgradeStep
+from opengever.document.behaviors import IBaseDocument
+
+
+class AddDocumentFilesize_filenameAndFileExtensionToDocumentMetadata(UpgradeStep):
+    """Add document filesize, filename and file extension to document metadata.
+    """
+
+    deferrable = True
+
+    def __call__(self):
+        self.install_upgrade_profile()
+        self.catalog_add_index('filesize', 'FieldIndex')
+        self.catalog_add_index('file_extension', 'FieldIndex')
+
+        query = {
+            'object_provides': IBaseDocument.__identifier__,
+            }
+
+        for basedocument in self.objects(query, 'Index filesize, filename and file extension of IBaseDocument objects.'):
+            basedocument.reindexObject(idxs=['filesize', 'file_extension'])

--- a/opengever/document/behaviors/metadata.py
+++ b/opengever/document/behaviors/metadata.py
@@ -7,7 +7,6 @@ from ftw.keywordwidget.widget import KeywordFieldWidget
 from ftw.mail.mail import IMail
 from opengever.document import _
 from opengever.document.interfaces import IDocumentSettings
-from opengever.document.behaviors.related_docs import IRelatedDocuments
 from plone import api
 from plone.autoform import directives as form
 from plone.autoform.interfaces import IFormFieldProvider

--- a/opengever/document/config.py
+++ b/opengever/document/config.py
@@ -9,4 +9,5 @@ INDEXES = (
     ('sortable_author', 'FieldIndex'),
     ('public_trial', 'FieldIndex'),
     ('filesize', 'FieldIndex'),
+    ('file_extension', 'FieldIndex'),
 )

--- a/opengever/document/config.py
+++ b/opengever/document/config.py
@@ -8,4 +8,5 @@ INDEXES = (
     ('receipt_date', 'DateIndex'),
     ('sortable_author', 'FieldIndex'),
     ('public_trial', 'FieldIndex'),
+    ('filesize', 'FieldIndex'),
 )

--- a/opengever/document/configure.zcml
+++ b/opengever/document/configure.zcml
@@ -271,6 +271,11 @@
       name="metadata"
       />
 
+  <adapter
+      factory=".indexers.filesize"
+      name="filesize"
+      />
+
   <adapter factory=".document.UploadValidator" />
 
 </configure>

--- a/opengever/document/configure.zcml
+++ b/opengever/document/configure.zcml
@@ -276,6 +276,11 @@
       name="filesize"
       />
 
+  <adapter
+      factory=".indexers.filename"
+      name="filename"
+      />
+
   <adapter factory=".document.UploadValidator" />
 
 </configure>

--- a/opengever/document/configure.zcml
+++ b/opengever/document/configure.zcml
@@ -281,6 +281,11 @@
       name="filename"
       />
 
+  <adapter
+      factory=".indexers.file_extension"
+      name="file_extension"
+      />
+
   <adapter factory=".document.UploadValidator" />
 
 </configure>

--- a/opengever/document/indexers.py
+++ b/opengever/document/indexers.py
@@ -21,6 +21,7 @@ from zope.component import queryMultiAdapter
 from zope.interface import implementer
 from zope.interface import Interface
 import logging
+import os.path
 
 
 logger = logging.getLogger('opengever.document')
@@ -210,4 +211,13 @@ def filename(obj):
     filename = obj.get_filename()
     if filename:
         return filename
+    return u''
+
+
+@indexer(IDocumentSchema)
+def file_extension(obj):
+    filename = obj.get_filename()
+    if filename:
+        # We should not rely on the normalization to have happened
+        return os.path.splitext(filename)[-1].lower()
     return u''

--- a/opengever/document/indexers.py
+++ b/opengever/document/indexers.py
@@ -203,3 +203,11 @@ def filesize(obj):
     if file_:
         return file_.getSize()
     return 0
+
+
+@indexer(IBaseDocument)
+def filename(obj):
+    filename = obj.get_filename()
+    if filename:
+        return filename
+    return u''

--- a/opengever/document/indexers.py
+++ b/opengever/document/indexers.py
@@ -195,3 +195,11 @@ def metadata(obj):
         metadata.append(doc_metadata.foreign_reference.encode('utf8'))
 
     return ' '.join(metadata)
+
+
+@indexer(IBaseDocument)
+def filesize(obj):
+    file_ = obj.get_file()
+    if file_:
+        return file_.getSize()
+    return 0

--- a/opengever/document/locales/de/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/de/LC_MESSAGES/opengever.document.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2018-08-23 09:19+0000\n"
+"POT-Creation-Date: 2018-10-30 20:51+0000\n"
 "PO-Revision-Date: 2017-10-13 14:27+0200\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"

--- a/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-08-23 09:19+0000\n"
+"POT-Creation-Date: 2018-10-30 20:51+0000\n"
 "PO-Revision-Date: 2017-09-03 08:50+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-document/fr/>\n"

--- a/opengever/document/locales/opengever.document.pot
+++ b/opengever/document/locales/opengever.document.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-08-23 09:19+0000\n"
+"POT-Creation-Date: 2018-10-30 20:51+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"

--- a/opengever/document/tests/test_indexers.py
+++ b/opengever/document/tests/test_indexers.py
@@ -6,6 +6,7 @@ from ftw.testing import MockTestCase
 from opengever.core.testing import COMPONENT_UNIT_TESTING
 from opengever.document.checkout.manager import CHECKIN_CHECKOUT_ANNOTATIONS_KEY
 from opengever.document.indexers import DefaultDocumentIndexer
+from opengever.document.indexers import filename as filename_indexer
 from opengever.document.indexers import metadata
 from opengever.document.interfaces import IDocumentIndexer
 from opengever.testing import FunctionalTestCase
@@ -64,6 +65,19 @@ class TestDocumentIndexers(FunctionalTestCase):
         document.file = None
         document.reindexObject()
         self.assertEqual(0, index_data_for(document).get('filesize'))
+
+    def test_filename_indexers(self):
+        document = create(
+            Builder("document")
+            .titled(u'D\xf6k\xfcm\xe4nt')
+            .attach_file_containing(u"content", name=u"file.txt")
+        )
+        document.reindexObject()
+        self.assertEqual(u'Doekuemaent.txt', filename_indexer(document)())
+
+        document.file = None
+        document.reindexObject()
+        self.assertEqual(u'', filename_indexer(document)())
 
     def test_date_indexers(self):
         with freeze(datetime.datetime(2016, 1, 1, 0, 0)):

--- a/opengever/document/tests/test_indexers.py
+++ b/opengever/document/tests/test_indexers.py
@@ -61,10 +61,12 @@ class TestDocumentIndexers(FunctionalTestCase):
         )
         document.reindexObject()
         self.assertEqual(7, index_data_for(document).get('filesize'))
+        self.assertEqual(7, obj2brain(document).filesize)
 
         document.file = None
         document.reindexObject()
         self.assertEqual(0, index_data_for(document).get('filesize'))
+        self.assertEqual(0, obj2brain(document).filesize)
 
     def test_filename_indexers(self):
         document = create(
@@ -74,10 +76,12 @@ class TestDocumentIndexers(FunctionalTestCase):
         )
         document.reindexObject()
         self.assertEqual(u'Doekuemaent.txt', filename_indexer(document)())
+        self.assertEqual(u'Doekuemaent.txt', obj2brain(document).filename)
 
         document.file = None
         document.reindexObject()
         self.assertEqual(u'', filename_indexer(document)())
+        self.assertEqual(u'', obj2brain(document).filename)
 
     def test_file_extension_indexers(self):
         document = create(
@@ -87,10 +91,12 @@ class TestDocumentIndexers(FunctionalTestCase):
         )
         document.reindexObject()
         self.assertEqual(u'.txt', index_data_for(document).get('file_extension'))
+        self.assertEqual(u'.txt', obj2brain(document).file_extension)
 
         document.file = None
         document.reindexObject()
         self.assertEqual(u'', index_data_for(document).get('file_extension'))
+        self.assertEqual(u'', obj2brain(document).file_extension)
 
     def test_date_indexers(self):
         with freeze(datetime.datetime(2016, 1, 1, 0, 0)):

--- a/opengever/document/tests/test_indexers.py
+++ b/opengever/document/tests/test_indexers.py
@@ -79,6 +79,19 @@ class TestDocumentIndexers(FunctionalTestCase):
         document.reindexObject()
         self.assertEqual(u'', filename_indexer(document)())
 
+    def test_file_extension_indexers(self):
+        document = create(
+            Builder("document")
+            .titled(u'D\xf6k\xfcm\xe4nt')
+            .attach_file_containing(u"content", name=u"file.txt")
+        )
+        document.reindexObject()
+        self.assertEqual(u'.txt', index_data_for(document).get('file_extension'))
+
+        document.file = None
+        document.reindexObject()
+        self.assertEqual(u'', index_data_for(document).get('file_extension'))
+
     def test_date_indexers(self):
         with freeze(datetime.datetime(2016, 1, 1, 0, 0)):
             doc1 = create(Builder('document').having(

--- a/opengever/document/tests/test_indexers.py
+++ b/opengever/document/tests/test_indexers.py
@@ -53,6 +53,18 @@ class TestDocumentIndexers(FunctionalTestCase):
         self.assertEquals(
             index_data_for(doc1).get('sortable_author'), u'H\xfcgo B\xf6ss')
 
+    def test_filesize_indexers(self):
+        document = create(
+            Builder("document")
+            .attach_file_containing(u"content", name=u"file.txt")
+        )
+        document.reindexObject()
+        self.assertEqual(7, index_data_for(document).get('filesize'))
+
+        document.file = None
+        document.reindexObject()
+        self.assertEqual(0, index_data_for(document).get('filesize'))
+
     def test_date_indexers(self):
         with freeze(datetime.datetime(2016, 1, 1, 0, 0)):
             doc1 = create(Builder('document').having(


### PR DESCRIPTION
Did I get the addition of yet-unused metadata bit right here?

The translations on the schema items also probably need some love.

I'm also assuming we want to craft the deferrable upgrade step for rolling out this and the new `changed` timesteamp sometime later when the dust has settled on both.

Closes #4966 