### PR TITLE
Fix normalizing filename for zip export.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2018.5.0 (unreleased)
 ---------------------
 
+- Fix normalizing filename for zip export. [deiferni]
 - Fix rendering issue in livesearch reply view. [deiferni]
 - Fix JS ordering issue: define modernizr.js position. [phgross]
 - Disable buttons during save request in sharing form and improve error handling. [phgross]

--- a/opengever/meeting/tests/test_meeting_zipexport.py
+++ b/opengever/meeting/tests/test_meeting_zipexport.py
@@ -181,6 +181,9 @@ class TestMeetingZipExportView(IntegrationTestCase):
         set_preferred_language(self.portal.REQUEST, 'de-ch')
         browser.append_request_header('Accept-Language', 'de-ch')
         self.login(self.committee_responsible, browser)
+
+        self.meeting.model.title = u'9. Sitzung der Rechnungspr\xfcfungs' \
+                                   u'kommission, ordentlich'
         self.schedule_paragraph(self.meeting, u'A Gesch\xfcfte')
         with freeze(localized_datetime(2017, 12, 13)):
             self.schedule_ad_hoc(
@@ -238,17 +241,17 @@ class TestMeetingZipExportView(IntegrationTestCase):
                  'location': u'B\xfcren an der Aare',
                  'protocol': {
                      'checksum': 'unpredictable',
-                     'file': 'Protokoll-9. Sitzung der Rechnungspruefungskommission.docx',
+                     'file': 'Protokoll-9. Sitzung der Rechnungspruefungskommission- ordentlich.docx',
                      'modified': '2017-12-13T23:00:00+01:00'
                  },
                  'start': '2016-09-12T15:30:00+00:00',
-                 'title': u'9. Sitzung der Rechnungspr\xfcfungskommission'}
+                 'title': u'9. Sitzung der Rechnungspr\xfcfungskommission, ordentlich'}
                 ],
             'version': '1.0.0'
             }, meeting_json)
 
         expected_file_names = [
-            'Protokoll-9. Sitzung der Rechnungspruefungskommission.docx',
+            'Protokoll-9. Sitzung der Rechnungspruefungskommission- ordentlich.docx',
             'Traktandum 1/Ad-hoc Traktandthm.docx',
             'Traktandum 2/Aenderungen am Personalreglement.docx',
             'Traktandum 2/Vertraegsentwurf.docx',

--- a/opengever/meeting/zipexport.py
+++ b/opengever/meeting/zipexport.py
@@ -52,7 +52,7 @@ class MeetingDocumentZipper(MeetingTraverser):
         return self.generator.generate()
 
     def get_filename(self, document):
-        return document.get_filename()
+        return normalize_path(document.get_filename())
 
     def get_file(self, document):
         return document.get_file()


### PR DESCRIPTION
For certain special characters normalization for the actual file names and for the JSON-file with metadata were different. We make sure to use the same normalization in all cases.

Fixes #5023.