### PR TITLE
 Fix acquisition issue with meeting templates.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2018.5.0 (unreleased)
 ---------------------
 
+- Fix an issue when creating meetings from a template. [deiferni]
 - Fix normalizing filename for zip export. [deiferni]
 - Fix rendering issue in livesearch reply view. [deiferni]
 - Fix JS ordering issue: define modernizr.js position. [phgross]

--- a/opengever/meeting/browser/meetings/meeting.py
+++ b/opengever/meeting/browser/meetings/meeting.py
@@ -212,10 +212,14 @@ class AddMeetingDossierView(WizzardWrappedAddForm):
                 dm = getUtility(IWizardDataStorage)
                 data = dm.get_data(get_dm_key())
                 data['dossier_oguid'] = Oguid.for_object(dossier)
-                meeting_template = data.pop('meeting_template', None)
+                meeting_template_uid = data.pop('meeting_template', None)
+
                 meeting = Meeting(**data)
-                if meeting_template is not None:
+                if meeting_template_uid is not None:
+                    meeting_template = api.content.get(
+                        UID=meeting_template_uid)
                     meeting_template.apply(meeting)
+
                 meeting.initialize_participants()
                 session = create_session()
                 session.add(meeting)

--- a/opengever/meeting/meetingtemplate.py
+++ b/opengever/meeting/meetingtemplate.py
@@ -1,4 +1,3 @@
-from opengever.meeting.paragraphtemplate import ParagraphTemplate
 from plone.dexterity.content import Container
 from Products.CMFPlone.utils import safe_unicode
 

--- a/opengever/meeting/vocabulary.py
+++ b/opengever/meeting/vocabulary.py
@@ -48,7 +48,7 @@ class MeetingTemplateVocabulary(object):
         for brain in meeting_templates:
             template = brain.getObject()
             terms.append(SimpleTerm(
-                value=template,
+                value=IUUID(template),
                 token=template.id,
                 title=safe_unicode(template.title)))
 


### PR DESCRIPTION
When creating meetings from a template the template content object was stored in the wizard storage. This causes issues as the object retrieved from storage can loose its acquisition context. We switch to only storing the objects UID and then retrieving the object again when it is needed.

Fixes #5031 

The existing test in https://github.com/4teamwork/opengever.core/blob/253524907bcaed57e2b5c46d74b972f8c775dbaa/opengever/meeting/tests/test_meeting_template.py#L66-L123 still works, no need for further testing IMO.