### PR TITLE
Various REST API fixes

### DIFF
--- a/opengever/api/dossier.py
+++ b/opengever/api/dossier.py
@@ -14,7 +14,8 @@ class SerializeDossierToJson(SerializeFolderToJson):
     def __call__(self, *args, **kwargs):
         result = super(SerializeDossierToJson, self).__call__(*args, **kwargs)
 
-        result["responsible"] = self.context.get_responsible_actor().get_label(with_principal=False)
+        result[u"responsible_fullname"] = self.context.get_responsible_actor(
+            ).get_label(with_principal=False)
         result[u'reference_number'] = self.context.get_reference_number()
         result[u'email'] = IEmailAddress(self.request).get_email_for_object(
             self.context)

--- a/opengever/api/listing.py
+++ b/opengever/api/listing.py
@@ -68,7 +68,8 @@ def filename(obj):
 # Mapping of field name -> (index, accessor, sort index)
 FIELDS = {
     '@type': ('portal_type', 'PortalType', 'portal_type'),
-    'checked_out': ('checked_out', 'checked_out_fullname', 'checked_out'),
+    'checked_out': ('checked_out', 'checked_out', 'checked_out'),
+    'checked_out_fullname': ('checked_out', 'checked_out_fullname', 'checked_out'),
     'containing_dossier': ('containing_dossier', 'containing_dossier', 'containing_dossier'),
     'containing_subdossier': ('containing_subdossier', 'containing_subdossier', 'containing_subdossier'),  # noqa
     'created': ('created', 'created', 'created'),
@@ -84,7 +85,8 @@ FIELDS = {
     'receipt_date': ('receipt_date', 'receipt_date', 'receipt_date'),
     'reference': ('reference', 'reference', 'reference'),
     'reference_number': ('reference', 'reference', 'reference'),
-    'responsible': ('responsible', 'responsible_fullname', 'responsible'),
+    'responsible': ('responsible', 'responsible', 'responsible'),
+    'responsible_fullname': ('responsible', 'responsible_fullname', 'responsible'),
     'review_state': ('review_state', 'translated_review_state', 'review_state'),
     'sequence_number': ('sequence_number', 'sequence_number', 'sequence_number'),
     'start': ('start', 'start', 'start'),

--- a/opengever/api/listing.py
+++ b/opengever/api/listing.py
@@ -89,6 +89,7 @@ FIELDS = {
     'sequence_number': ('sequence_number', 'sequence_number', 'sequence_number'),
     'start': ('start', 'start', 'start'),
     'thumbnail': (None, 'get_preview_image_url', DEFAULT_SORT_INDEX),
+    'preview': (None, 'get_preview_pdf_url', DEFAULT_SORT_INDEX),
     'title': ('Title', translated_title, 'sortable_title'),
     'type': ('portal_type', 'PortalType', 'portal_type'),
     'filesize': (None, filesize, 'filesize'),

--- a/opengever/api/livesearch.py
+++ b/opengever/api/livesearch.py
@@ -16,6 +16,15 @@ class GeverLiveSearchGet(SearchGet):
             self.request.form.get('path', '/').lstrip('/'),
         ).rstrip('/')
 
+        # Strip VHM path because plone.restapi SearchHandler will add it
+        vhm_physical_path = '/'.join(
+            self.request.get('VirtualRootPhysicalPath', ''))
+        if vhm_physical_path:
+            if path.startswith(vhm_physical_path):
+                path = path[len(vhm_physical_path):]
+                if not path:
+                    path = '/'
+
         if not search_term:
             return []
 

--- a/opengever/api/tests/test_listing.py
+++ b/opengever/api/tests/test_listing.py
@@ -8,12 +8,12 @@ class TestListingEndpoint(IntegrationTestCase):
     def test_dossier_listing(self, browser):
         self.login(self.regular_user, browser=browser)
 
-        view = '@listing?name=dossiers&columns=reference&columns=title&columns=review_state&columns=responsible&sort_on=created'
+        view = '@listing?name=dossiers&columns=reference&columns=title&columns=review_state&columns=responsible_fullname&sort_on=created'
         browser.open(self.repository_root, view=view, headers={'Accept': 'application/json'})
 
         self.assertEqual(
             {u'review_state': u'dossier-state-active',
-             u'responsible': u'Ziegler Robert (robert.ziegler)',
+             u'responsible_fullname': u'Ziegler Robert',
              u'@id': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1',
              u'reference': u'Client1 1.1 / 1',
              u'title': u'Vertr\xe4ge mit der kantonalen Finanzverwaltung'},

--- a/opengever/api/tests/test_serializer.py
+++ b/opengever/api/tests/test_serializer.py
@@ -53,7 +53,8 @@ class TestDossierSerializer(IntegrationTestCase):
         self.login(self.regular_user, browser)
         browser.open(self.dossier, headers={'Accept': 'application/json'})
         self.assertEqual(browser.status_code, 200)
-        self.assertEqual(browser.json.get(u'responsible'), u'Ziegler Robert')
+        self.assertEqual(
+            browser.json.get(u'responsible_fullname'), u'Ziegler Robert')
 
 
 class TestDocumentSerializer(IntegrationTestCase):

--- a/opengever/base/contentlisting.py
+++ b/opengever/base/contentlisting.py
@@ -129,8 +129,10 @@ class OpengeverCatalogContentListingObject(CatalogContentListingObject):
         return self._render_simplelink()
 
     def translated_review_state(self):
-        return translate(
-            self.review_state(), domain='plone', context=self.request)
+        review_state = self.review_state()
+        if review_state:
+            return translate(
+                review_state, domain='plone', context=self.request)
 
     def responsible_fullname(self):
         return display_name(self._brain.responsible)

--- a/opengever/base/contentlisting.py
+++ b/opengever/base/contentlisting.py
@@ -101,6 +101,14 @@ class OpengeverCatalogContentListingObject(CatalogContentListingObject):
         return bumblebee.get_service_v3().get_representation_url(
             self.getDataOrigin(), 'thumbnail')
 
+    def get_preview_pdf_url(self):
+        """Return the url to fetch the bumblebee preview pdf."""
+        if not self.is_bumblebeeable():
+            return None
+
+        return bumblebee.get_service_v3().get_representation_url(
+            self.getDataOrigin(), 'pdf')
+
     def get_overlay_title(self):
         """Return the title for the bumblebee overlay."""
 

--- a/opengever/base/helpers.py
+++ b/opengever/base/helpers.py
@@ -14,4 +14,4 @@ def display_name(userid):
         else:
             userid = ''
 
-    return Actor.user(userid).get_label()
+    return Actor.user(userid).get_label(with_principal=False)

--- a/opengever/base/tests/test_contentlisting.py
+++ b/opengever/base/tests/test_contentlisting.py
@@ -211,6 +211,13 @@ class TestOpengeverContentListing(IntegrationTestCase):
             IContentListingObject(obj2brain(self.document)).get_breadcrumbs(),
             )
 
+    def test_responsible_fullname(self):
+        self.login(self.regular_user)
+        self.assertEqual(
+            IContentListingObject(obj2brain(
+                self.dossier)).responsible_fullname(),
+            u'Ziegler Robert')
+
 
 class TestBrainContentListingRenderLink(IntegrationTestCase):
     """Test we render appropriate content listing links per content type."""

--- a/opengever/base/tests/test_contentlisting.py
+++ b/opengever/base/tests/test_contentlisting.py
@@ -287,6 +287,9 @@ class TestOpengeverContentListingWithDisabledBumblebee(IntegrationTestCase):
     def test_get_preview_image_url(self):
         self.assertIsNone(self.obj.get_preview_image_url())
 
+    def test_get_preview_pdf_url(self):
+        self.assertIsNone(self.obj.get_preview_pdf_url())
+
     def test_get_overlay_title(self):
         self.assertIsNone(self.obj.get_overlay_title())
 
@@ -313,6 +316,9 @@ class TestOpengeverContentListingWithEnabledBumblebee(IntegrationTestCase):
 
     def test_get_preview_image_url(self):
         self.assertIsNotNone(self.obj.get_preview_image_url())
+
+    def test_get_preview_pdf_url(self):
+        self.assertRegexpMatches(self.obj.get_preview_pdf_url(), r'/pdf\?')
 
     def test_get_overlay_title(self):
         self.assertEqual(u'Vertr\xe4gsentwurf', self.obj.get_overlay_title())


### PR DESCRIPTION
- Handle items without review_state in listings
- Keep value of responsible field in GET and return responsible's fullname as it's own property
- Return responsible and checked_out fullnames separately in listings
- Strip VHM path from path in livesearch
- Include PDF preview URL in listings