### PR TITLE
Drop verbose logging for ObjectTouched events.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2018.5.0 (unreleased)
 ---------------------
 
+- Drop verbose logging for ObjectTouched events. [lgraf]
 - Bump ftw.solr to 2.3.1 to get reindexObjectSecurity fix. [lgraf]
 - Fix an issue when creating meetings from a template. [deiferni]
 - Fix normalizing filename for zip export. [deiferni]

--- a/opengever/base/touched.py
+++ b/opengever/base/touched.py
@@ -68,9 +68,7 @@ class ObjectTouchedHandler(object):
         if not should_track_touches(context):
             return
 
-        logger.info("Object touched: %r (UID: %s)" % (context, IUUID(context)))
         current_user_id = api.user.get_current().id
-
         self.ensure_log_initialized(current_user_id)
         recently_touched_log = self.get_recently_touched_log(current_user_id)
 


### PR DESCRIPTION
Drop verbose logging for `ObjectTouched` events. Logging was initially added to aid debugging of potential issues with the "recently touched" feature, but it turns out to be too verbose and leads to spam in the instance logs.