### PR TITLE
Include bumblebee checksum to restapi calls

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -12,6 +12,7 @@ Changelog
 - Make the changed field a python datetime. [njohner]
 - Fix Officeconnector permission checks for task documents tab actions. [Rotonen]
 - Ensure clamped down enough permissions on shadow documents. [Rotonen]
+- Include bumblebee-checksum into @listing endpoint [elioschmutz]
 - Drop verbose logging for ObjectTouched events. [lgraf]
 - Bump ftw.solr to 2.3.1 to get reindexObjectSecurity fix. [lgraf]
 - Fix an issue when creating meetings from a template. [deiferni]

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -12,6 +12,7 @@ Changelog
 - Make the changed field a python datetime. [njohner]
 - Fix Officeconnector permission checks for task documents tab actions. [Rotonen]
 - Ensure clamped down enough permissions on shadow documents. [Rotonen]
+- Include bumblebee_checksum to dexterity item serialization [elioschmutz]
 - Include bumblebee-checksum into @listing endpoint [elioschmutz]
 - Drop verbose logging for ObjectTouched events. [lgraf]
 - Bump ftw.solr to 2.3.1 to get reindexObjectSecurity fix. [lgraf]

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -9,6 +9,9 @@
   <include package="opengever.document" file="permissions.zcml" />
   <include package="opengever.trash" file="permissions.zcml" />
 
+  <adapter factory=".serializer.GeverSerializeToJson" />
+  <adapter factory=".serializer.GeverSerializeFolderToJson" />
+
   <adapter factory=".summary.GeverJSONSummarySerializer" />
   <adapter factory=".fields.ChoiceFieldDeserializer" />
 

--- a/opengever/api/document.py
+++ b/opengever/api/document.py
@@ -3,7 +3,7 @@ from opengever.document.behaviors import IBaseDocument
 from opengever.document.interfaces import ICheckinCheckoutManager
 from plone.restapi.deserializer import json_body
 from plone.restapi.interfaces import ISerializeToJson
-from plone.restapi.serializer.dxcontent import SerializeToJson
+from opengever.api.serializer import GeverSerializeToJson
 from plone.restapi.services.content.update import ContentPatch
 from zope.component import adapter
 from zope.component import getMultiAdapter
@@ -13,7 +13,7 @@ from zope.interface import Interface
 
 @implementer(ISerializeToJson)
 @adapter(IBaseDocument, Interface)
-class SerializeDocumentToJson(SerializeToJson):
+class SerializeDocumentToJson(GeverSerializeToJson):
 
     def __call__(self, *args, **kwargs):
         result = super(SerializeDocumentToJson, self).__call__(*args, **kwargs)

--- a/opengever/api/dossier.py
+++ b/opengever/api/dossier.py
@@ -1,7 +1,7 @@
 from ftw.mail.interfaces import IEmailAddress
+from opengever.api.serializer import GeverSerializeFolderToJson
 from opengever.dossier.behaviors.dossier import IDossierMarker
 from plone.restapi.interfaces import ISerializeToJson
-from plone.restapi.serializer.dxcontent import SerializeFolderToJson
 from zope.component import adapter
 from zope.interface import implementer
 from zope.interface import Interface
@@ -9,7 +9,7 @@ from zope.interface import Interface
 
 @implementer(ISerializeToJson)
 @adapter(IDossierMarker, Interface)
-class SerializeDossierToJson(SerializeFolderToJson):
+class SerializeDossierToJson(GeverSerializeFolderToJson):
 
     def __call__(self, *args, **kwargs):
         result = super(SerializeDossierToJson, self).__call__(*args, **kwargs)

--- a/opengever/api/listing.py
+++ b/opengever/api/listing.py
@@ -68,6 +68,7 @@ def filename(obj):
 # Mapping of field name -> (index, accessor, sort index)
 FIELDS = {
     '@type': ('portal_type', 'PortalType', 'portal_type'),
+    'bumblebee_checksum': (None, 'bumblebee_checksum', DEFAULT_SORT_INDEX),
     'checked_out': ('checked_out', 'checked_out', 'checked_out'),
     'checked_out_fullname': ('checked_out', 'checked_out_fullname', 'checked_out'),
     'containing_dossier': ('containing_dossier', 'containing_dossier', 'containing_dossier'),

--- a/opengever/api/repositoryfolder.py
+++ b/opengever/api/repositoryfolder.py
@@ -1,7 +1,7 @@
+from opengever.api.serializer import GeverSerializeFolderToJson
 from opengever.base.interfaces import IReferenceNumber
 from opengever.repository.interfaces import IRepositoryFolder
 from plone.restapi.interfaces import ISerializeToJson
-from plone.restapi.serializer.dxcontent import SerializeFolderToJson
 from zope.component import adapter
 from zope.interface import implementer
 from zope.interface import Interface
@@ -9,7 +9,7 @@ from zope.interface import Interface
 
 @implementer(ISerializeToJson)
 @adapter(IRepositoryFolder, Interface)
-class SerializeRepositoryFolderToJson(SerializeFolderToJson):
+class SerializeRepositoryFolderToJson(GeverSerializeFolderToJson):
 
     def __call__(self, *args, **kwargs):
         result = super(SerializeRepositoryFolderToJson, self).__call__(*args, **kwargs)

--- a/opengever/api/serializer.py
+++ b/opengever/api/serializer.py
@@ -1,0 +1,18 @@
+from opengever.base.interfaces import IOpengeverBaseLayer
+from plone.dexterity.interfaces import IDexterityContainer
+from plone.dexterity.interfaces import IDexterityContent
+from plone.restapi.serializer.dxcontent import SerializeFolderToJson
+from plone.restapi.serializer.dxcontent import SerializeToJson
+from zope.component import adapter
+
+
+@adapter(IDexterityContent, IOpengeverBaseLayer)
+class GeverSerializeToJson(SerializeToJson):
+    """
+    """
+
+
+@adapter(IDexterityContainer, IOpengeverBaseLayer)
+class GeverSerializeFolderToJson(SerializeFolderToJson):
+    """
+    """

--- a/opengever/api/serializer.py
+++ b/opengever/api/serializer.py
@@ -1,3 +1,5 @@
+from ftw.bumblebee.interfaces import IBumblebeeable
+from ftw.bumblebee.interfaces import IBumblebeeDocument
 from opengever.base.interfaces import IOpengeverBaseLayer
 from plone.dexterity.interfaces import IDexterityContainer
 from plone.dexterity.interfaces import IDexterityContent
@@ -6,10 +8,20 @@ from plone.restapi.serializer.dxcontent import SerializeToJson
 from zope.component import adapter
 
 
+def extend_with_bumblebee_checksum(result, context):
+    if IBumblebeeable.providedBy(context):
+        result['bumblebee_checksum'] = IBumblebeeDocument(context).get_checksum()
+
+
 @adapter(IDexterityContent, IOpengeverBaseLayer)
 class GeverSerializeToJson(SerializeToJson):
-    """
-    """
+
+    def __call__(self, *args, **kwargs):
+        result = super(GeverSerializeToJson, self).__call__(*args, **kwargs)
+
+        extend_with_bumblebee_checksum(result, self.context)
+
+        return result
 
 
 @adapter(IDexterityContainer, IOpengeverBaseLayer)

--- a/opengever/api/tests/test_listing.py
+++ b/opengever/api/tests/test_listing.py
@@ -1,5 +1,6 @@
-from opengever.testing import IntegrationTestCase
+from ftw.bumblebee.tests.helpers import DOCX_CHECKSUM
 from ftw.testbrowser import browsing
+from opengever.testing import IntegrationTestCase
 
 
 class TestListingEndpoint(IntegrationTestCase):
@@ -23,7 +24,7 @@ class TestListingEndpoint(IntegrationTestCase):
     def test_document_listing(self, browser):
         self.login(self.regular_user, browser=browser)
 
-        view = '@listing?name=documents&columns=reference&columns=title&columns=modified&columns=document_author&columns=containing_dossier&sort_on=created'
+        view = '@listing?name=documents&columns=reference&columns=title&columns=modified&columns=document_author&columns=containing_dossier&columns=bumblebee_checksum&sort_on=created'
         browser.open(self.dossier, view=view, headers={'Accept': 'application/json'})
 
         self.assertEqual(
@@ -32,7 +33,8 @@ class TestListingEndpoint(IntegrationTestCase):
              u'document_author': u'test_user_1_',
              u'@id': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/document-12',
              u'modified': u'2016-08-31T14:07:33+00:00',
-             u'containing_dossier': u'Vertr\xe4ge mit der kantonalen Finanzverwaltung'},
+             u'containing_dossier': u'Vertr\xe4ge mit der kantonalen Finanzverwaltung',
+             u'bumblebee_checksum': DOCX_CHECKSUM},
             browser.json['items'][-1])
 
     @browsing

--- a/opengever/api/tests/test_serializer.py
+++ b/opengever/api/tests/test_serializer.py
@@ -1,3 +1,5 @@
+from ftw.bumblebee.interfaces import IBumblebeeDocument
+from ftw.bumblebee.tests.helpers import DOCX_CHECKSUM
 from ftw.testbrowser import browsing
 from opengever.testing import IntegrationTestCase
 from plone import api
@@ -72,8 +74,24 @@ class TestDocumentSerializer(IntegrationTestCase):
         self.assertEqual(browser.json.get(u'reference_number'), u'Client1 1.1 / 1 / 12')
 
     @browsing
+    def test_document_serialization_contains_bumblebee_checksum(self, browser):
+        self.login(self.regular_user, browser)
+        browser.open(self.document, headers={'Accept': 'application/json'})
+        self.assertEqual(browser.status_code, 200)
+        self.assertEqual(browser.json.get(u'bumblebee_checksum'), DOCX_CHECKSUM)
+
+    @browsing
     def test_mail_serialization_contains_reference_number(self, browser):
         self.login(self.regular_user, browser)
         browser.open(self.mail_eml, headers={'Accept': 'application/json'})
         self.assertEqual(browser.status_code, 200)
         self.assertEqual(browser.json.get(u'reference_number'), u'Client1 1.1 / 1 / 28')
+
+    @browsing
+    def test_mail_serialization_contains_bumblebee_checksum(self, browser):
+        self.login(self.regular_user, browser)
+        browser.open(self.mail_eml, headers={'Accept': 'application/json'})
+        self.assertEqual(browser.status_code, 200)
+
+        checksum = IBumblebeeDocument(self.mail_eml).get_checksum()
+        self.assertEqual(browser.json.get(u'bumblebee_checksum'), checksum)


### PR DESCRIPTION
This PR provides the bumblebee-checksum in the `@listing` restapi endpoint and for serialized IBumblebeeable objects.

fixes #5009 