### PR TITLE
Fix Officeconnector permission checks for task documents tab actions

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -8,6 +8,7 @@ Changelog
 - Bump docxcompose to 1.0.0a13 to get a numberig restart bugfix. [deiferni]
 - Fix favourite edit action and display pencil. [deiferni]
 - Make the changed field a python datetime. [njohner]
+- Fix Officeconnector permission checks for task documents tab actions. [Rotonen]
 - Drop verbose logging for ObjectTouched events. [lgraf]
 - Bump ftw.solr to 2.3.1 to get reindexObjectSecurity fix. [lgraf]
 - Fix an issue when creating meetings from a template. [deiferni]

--- a/opengever/task/browser/related_documents.py
+++ b/opengever/task/browser/related_documents.py
@@ -1,6 +1,7 @@
 from ftw.table.catalog_source import default_custom_sort
 from ftw.table.interfaces import ICatalogTableSourceConfig
 from ftw.table.interfaces import ITableSource
+from opengever.officeconnector.helpers import is_officeconnector_attach_feature_enabled
 from opengever.tabbedview import GeverCatalogTableSource
 from opengever.tabbedview.browser.tabs import BaseTabProxy
 from opengever.tabbedview.browser.tabs import Documents
@@ -230,22 +231,30 @@ class RelatedDocuments(Documents):
 
     implements(IRelatedDocumentsCatalogTableSourceConfig)
 
-    enabled_actions = [
-        'send_as_email',
-        'checkout',
-        'checkin',
-        'cancel',
-        'create_task',
-        'trashed',
-        'send_documents',
-        'copy_documents_to_remote_client',
-        'move_items',
-        'copy_items',
-        'zip_selected',
-        'export_documents',
+    sort_on = 'sortable_title'
+
+    @property
+    def enabled_actions(self):
+        actions = [
+            'send_as_email',
+            'checkout',
+            'checkin',
+            'cancel',
+            'create_task',
+            'trashed',
+            'send_documents',
+            'copy_documents_to_remote_client',
+            'move_items',
+            'copy_items',
+            'zip_selected',
+            'export_documents',
         ]
 
-    sort_on = 'sortable_title'
+        if is_officeconnector_attach_feature_enabled():
+            actions.append('attach_documents')
+            actions.remove('send_as_email')
+
+        return actions
 
     def get_base_query(self):
         return {

--- a/opengever/task/tests/test_related_documents_tab.py
+++ b/opengever/task/tests/test_related_documents_tab.py
@@ -1,0 +1,46 @@
+from ftw.testbrowser import browsing
+from opengever.testing import IntegrationTestCase
+
+
+class TestTaskRelatedDocumentsTabWithoutOfficeconnector(IntegrationTestCase):
+
+    features = ("!officeconnector-attach",)
+
+    @browsing
+    def test_attach_action_on_related_documents_tab(self, browser):
+        self.login(self.regular_user, browser)
+        browser.open(self.task, view="tabbedview_view-relateddocuments-proxy")
+        expected_actions = [
+            u"More actions \u25bc",
+            "Export as Zip",
+            "Copy Items",
+            "Send as email",
+            "Checkout",
+            "Cancel",
+            "Export selection",
+            "Move Items",
+            "trashed",
+        ]
+        self.assertEqual(expected_actions, browser.css(".actionMenu a").text)
+
+
+class TestTaskRelatedDocumentsTabWithOfficeconnector(IntegrationTestCase):
+
+    features = ("officeconnector-attach",)
+
+    @browsing
+    def test_attach_action_on_related_documents_tab(self, browser):
+        self.login(self.regular_user, browser)
+        browser.open(self.task, view="tabbedview_view-relateddocuments-proxy")
+        expected_actions = [
+            u"More actions \u25bc",
+            "Export as Zip",
+            "Copy Items",
+            "Attach selection",
+            "Checkout",
+            "Cancel",
+            "Export selection",
+            "Move Items",
+            "trashed",
+        ]
+        self.assertEqual(expected_actions, browser.css(".actionMenu a").text)


### PR DESCRIPTION
This was simply missed upon initial implementation.

Closes #5006 