### PR TITLE
Use correct class for pencil.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2018.5.0 (unreleased)
 ---------------------
 
+- Fix favourite edit action and display pencil. [deiferni]
 - Make the changed field a python datetime. [njohner]
 - Drop verbose logging for ObjectTouched events. [lgraf]
 - Bump ftw.solr to 2.3.1 to get reindexObjectSecurity fix. [lgraf]

--- a/opengever/base/browser/templates/favorites_list.html
+++ b/opengever/base/browser/templates/favorites_list.html
@@ -23,7 +23,7 @@
                 </td>
                 <td class="admin_unit">{{entry.admin_unit}}</td>
                 <td class="edit-controls">
-                    <a href="#" class="editAction fa fa-pencil" @click.prevent="openOverlay(entry)" />
+                    <a href="#" class="editAction fa fa-pencil-alt" @click.prevent="openOverlay(entry)" />
                     <a href="#" class="deleteAction fa fa-times" @click.prevent="deleteAction(entry)"  />
                 </td>
             </tr>


### PR DESCRIPTION
We seem to have renamed the pencil class at some point, somehow this view was omitted. There it is again:

![screen shot 2018-11-05 at 16 47 08](https://user-images.githubusercontent.com/736583/48008974-0a6bbe80-e11b-11e8-92fd-4469d8e6a863.png)

Fixes #5045 