### PR TITLE
Fix issue when returning an excerpt to an already decided proposal.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2018.5.0 (unreleased)
 ---------------------
 
+- Fix issue when returning an excerpt to an already decided proposal. [njohner]
 - Display group label in teamdetails instead of group title. [njohner]
 - Add reference numbers to protected items admin view links. [Rotonen]
 - Sort repository excel exports by reference number. [Rotonen]

--- a/opengever/meeting/model/agendaitem.py
+++ b/opengever/meeting/model/agendaitem.py
@@ -353,7 +353,11 @@ class AgendaItem(Base):
         return False
 
     def return_excerpt(self, document):
-        self.proposal.decide(self)
+        # Agendaitems that were decided before we introduced that
+        # proposals get decided only when the excerpt is returned
+        # can be already decided even if the proposal has not been returned.
+        if not self.is_proposal_decided():
+            self.proposal.decide(self)
         self.proposal.return_excerpt(document)
 
     def generate_excerpt(self, title):


### PR DESCRIPTION
This will not happen in the long run, but agendaitems that were decided before we introduced that proposals get decided only when the excerpt is returned can be already decided even if the proposal has not been returned. This lead to an error when returning the excerpt and trying to decided an already decided proposal.
We fix this by only closing the proposal if it has not been closed already.

**returning the excerpt of a closed agendaitem could lead to an error**
<img width="1294" alt="screen shot 2018-11-07 at 10 28 06" src="https://user-images.githubusercontent.com/7374243/48123532-79135e00-e27a-11e8-9513-a77991ed74d8.png">

**With the fix, we can return the excerpt without trying to close the proposal a second time**
<img width="1294" alt="screen shot 2018-11-07 at 10 30 01" src="https://user-images.githubusercontent.com/7374243/48123539-7d3f7b80-e27a-11e8-9926-3950846a68d4.png">

resolves #5055 