### PR TITLE
Display group label in teamdetails instead of group title.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2018.5.0 (unreleased)
 ---------------------
 
+- Display group label in teamdetails instead of group title. [njohner]
 - Add reference numbers to protected items admin view links. [Rotonen]
 - Sort repository excel exports by reference number. [Rotonen]
 - Allow managers to deactivate a dossier. [njohner]

--- a/opengever/ogds/base/browser/templates/teamdetails.pt
+++ b/opengever/ogds/base/browser/templates/teamdetails.pt
@@ -25,7 +25,7 @@
 
           <tr>
             <th i18n:translate="label_group">Group</th>
-            <td class="group" tal:content="team/group/title" />
+            <td class="group" tal:content="team/group/label" />
           </tr>
 
           <tr>

--- a/opengever/ogds/base/tests/test_team_details.py
+++ b/opengever/ogds/base/tests/test_team_details.py
@@ -1,3 +1,4 @@
+from opengever.ogds.models.team import Team
 from opengever.testing import IntegrationTestCase
 from ftw.testbrowser import browsing
 
@@ -30,6 +31,22 @@ class TestTeamDetails(IntegrationTestCase):
             ['Assigned org unit', 'Finanzamt'], items[0])
         self.assertEquals(
             ['Group', 'Projekt A'], items[1])
+
+    @browsing
+    def test_metadata_table_shows_groupid_if_group_has_no_title(self, browser):
+        self.login(self.administrator, browser=browser)
+        browser.raise_http_errors = False
+
+        team = Team.get(1)
+        group = Team.get(1).group
+        group.title = ""
+
+        browser.open(self.contactfolder, view='team-1/view')
+        items = browser.css('.listing').first.lists()
+        self.assertEquals(
+            ['Assigned org unit', team.org_unit.title], items[0])
+        self.assertEquals(
+            ['Group', group.groupid], items[1])
 
     @browsing
     def test_list_and_link_team_members(self, browser):


### PR DESCRIPTION
Using `label` we will display the `groupid` if the group does not have a `title`, instead of having an empty field.

resolves #5054 