### PR TITLE
Sort repository excel exports by reference number

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ---------------------
 
 - Add reference numbers to protected items admin view links. [Rotonen]
+- Sort repository excel exports by reference number. [Rotonen]
 - Bump ftw.contentstats to get disk usage logging. [lgraf]
 - Whitelist "recently touched" data structures from CSRF write protection. [lgraf]
 - Bump docxcompose to 1.0.0a13 to get a numberig restart bugfix. [deiferni]


### PR DESCRIPTION
Fetching the correct reference number adapter and sorting with the sorter from there.

Building a test case where the catalog query result would be guaranteedly out of order or a weird reference formatter just for the tests would be a bit excessive.

Closes #5061 