### PR TITLE
Do not open keywordwidget when autofocusing the first form field,

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -20,6 +20,7 @@ Changelog
 - Task performance improvements: avoid reindexObjectSecurity for not affected documents. [phgross]
 - Display group label in teamdetails instead of group title. [njohner]
 - Prevent shadow documents from being relatable. [Rotonen]
+- Do not open keywordwidget when autofocusing the first form field. [phgross]
 - Add reference numbers to protected items admin view links. [Rotonen]
 - Sort repository excel exports by reference number. [Rotonen]
 - Allow managers to deactivate a dossier. [njohner]

--- a/opengever/base/browser/resources/base.js
+++ b/opengever/base/browser/resources/base.js
@@ -3,7 +3,8 @@ $(window).load(function(){
   var firstFormElement = $("form#form input:text:visible, form#form textarea:visible, .keyword-widget").first();
   // Check if element is select2 widget
   if (firstFormElement.data('select2')) {
-    firstFormElement.select2('open');
+    firstFormElement.focus();
+    firstFormElement.select2('focus');
   } else {
     firstFormElement.focus();
   }


### PR DESCRIPTION
but only focus instead. 

The fix (#3837) for the send document form still works but also closes #5067.

![kapture 2018-11-09 at 11 01 51](https://user-images.githubusercontent.com/485755/48256287-6e3e0200-e40f-11e8-8ad5-c1a1eec82fae.gif)
