### PR TITLE
Exclude shadow documents from being relatable

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,7 @@ Changelog
 
 - Fix issue when returning an excerpt to an already decided proposal. [njohner]
 - Display group label in teamdetails instead of group title. [njohner]
+- Prevent shadow documents from being relatable. [Rotonen]
 - Add reference numbers to protected items admin view links. [Rotonen]
 - Sort repository excel exports by reference number. [Rotonen]
 - Allow managers to deactivate a dossier. [njohner]

--- a/opengever/document/behaviors/related_docs.py
+++ b/opengever/document/behaviors/related_docs.py
@@ -23,10 +23,10 @@ class IRelatedDocuments(model.Schema):
             source=RepositoryPathSourceBinder(
                 portal_type=("opengever.document.document", "ftw.mail.mail"),
                 navigation_tree_query={
+                    'review_state': {'not': 'document-state-shadow'},
                     'object_provides':
                         ['opengever.repository.repositoryroot.IRepositoryRoot',
-                         'opengever.repository.repositoryfolder.' +
-                            'IRepositoryFolderSchema',
+                         'opengever.repository.repositoryfolder.IRepositoryFolderSchema',
                          'opengever.dossier.behaviors.dossier.IDossierMarker',
                          'opengever.document.document.IDocumentSchema',
                          'ftw.mail.mail.IMail', ]

--- a/opengever/meeting/browser/proposalforms.py
+++ b/opengever/meeting/browser/proposalforms.py
@@ -110,6 +110,7 @@ class IAddProposal(IProposal):
         source=DossierPathSourceBinder(
             portal_type=("opengever.document.document", ),
             navigation_tree_query={
+                'review_state': {'not': 'document-state-shadow'},
                 'object_provides': [
                     'opengever.document.document.IDocumentSchema',
                     'opengever.dossier.behaviors.dossier.IDossierMarker',

--- a/opengever/meeting/proposal.py
+++ b/opengever/meeting/proposal.py
@@ -115,6 +115,7 @@ class IProposal(model.Schema):
             source=DossierPathSourceBinder(
                 portal_type=("opengever.document.document", "ftw.mail.mail"),
                 navigation_tree_query={
+                    'review_state': {'not': 'document-state-shadow'},
                     'object_provides': [
                         'opengever.dossier.behaviors.dossier.IDossierMarker',
                         'opengever.document.document.IDocumentSchema',

--- a/opengever/meeting/tests/test_proposal.py
+++ b/opengever/meeting/tests/test_proposal.py
@@ -1077,3 +1077,39 @@ class TestProposal(IntegrationTestCase):
         factoriesmenu.add('Proposal')
         expected_languages = ['Deutsch', 'English']
         self.assertEqual(expected_languages, browser.css('#form-widgets-language option').text)
+
+    @browsing
+    def test_add_form_does_not_list_shadow_documents_as_relatable(self, browser):
+        """Dossier responsible has created the shadow document.
+
+        This test ensures he does not get it offered as a relatable document on
+        proposals.
+        """
+        self.login(self.dossier_responsible, browser)
+        contenttree_url = '/'.join((
+            self.dossier.absolute_url(),
+            '++add++opengever.meeting.proposal',
+            '++widget++form.widgets.relatedItems',
+            '@@contenttree-fetch',
+        ))
+        browser.open(
+            contenttree_url,
+            headers={'Content-Type': 'application/x-www-form-urlencoded'},
+            data=formdata.urlencode({'href': '/'.join(self.dossier.getPhysicalPath()), 'rel': 0}),
+        )
+        expected_documents = [
+            '2015',
+            '2016',
+            '[No Subject]',
+            u'Antrag f\xfcr Kreiselbau',
+            u'Die B\xfcrgschaft',
+            u'Initialvertrag f\xfcr Bearbeitung',
+            u'Initialvertrag f\xfcr Bearbeitung',
+            u'L\xe4\xe4r',
+            'Personaleintritt',
+            u'Vertr\xe4ge',
+            u'Vertr\xe4gsentwurf',
+            u'Vertragsentwurf \xdcberpr\xfcfen',
+            u'Vertragsentw\xfcrfe 2018',
+        ]
+        self.assertEqual(expected_documents, browser.css('li').text)

--- a/opengever/meeting/tests/test_proposal.py
+++ b/opengever/meeting/tests/test_proposal.py
@@ -1113,3 +1113,37 @@ class TestProposal(IntegrationTestCase):
             u'Vertragsentw\xfcrfe 2018',
         ]
         self.assertEqual(expected_documents, browser.css('li').text)
+
+    @browsing
+    def test_add_form_does_not_list_shadow_documents_as_proposal_documents(self, browser):
+        """Dossier responsible has created the shadow document.
+
+        This test ensures he does not get it offered as a proposal document on
+        proposals.
+        """
+        self.login(self.dossier_responsible, browser)
+        contenttree_url = '/'.join((
+            self.dossier.absolute_url(),
+            '++add++opengever.meeting.proposal',
+            '++widget++form.widgets.proposal_document',
+            '@@contenttree-fetch',
+        ))
+        browser.open(
+            contenttree_url,
+            headers={'Content-Type': 'application/x-www-form-urlencoded'},
+            data=formdata.urlencode({'href': '/'.join(self.dossier.getPhysicalPath()), 'rel': 0}),
+        )
+        expected_documents = [
+            '2015',
+            '2016',
+            u'Antrag f\xfcr Kreiselbau',
+            u'Initialvertrag f\xfcr Bearbeitung',
+            u'Initialvertrag f\xfcr Bearbeitung',
+            u'L\xe4\xe4r',
+            'Personaleintritt',
+            u'Vertr\xe4ge',
+            u'Vertr\xe4gsentwurf',
+            u'Vertragsentwurf \xdcberpr\xfcfen',
+            u'Vertragsentw\xfcrfe 2018',
+        ]
+        self.assertEqual(expected_documents, browser.css('li').text)

--- a/opengever/task/task.py
+++ b/opengever/task/task.py
@@ -202,6 +202,7 @@ class ITask(model.Schema):
             source=DossierPathSourceBinder(
                 portal_type=("opengever.document.document", "ftw.mail.mail"),
                 navigation_tree_query={
+                    'review_state': {'not': 'document-state-shadow'},
                     'object_provides': [
                         'opengever.dossier.behaviors.dossier.IDossierMarker',
                         'opengever.document.document.IDocumentSchema',

--- a/opengever/tasktemplates/browser/trigger.py
+++ b/opengever/tasktemplates/browser/trigger.py
@@ -79,6 +79,7 @@ class ISelectTaskTemplateFolder(model.Schema):
             source=DossierPathSourceBinder(
                 portal_type=("opengever.document.document", "ftw.mail.mail"),
                 navigation_tree_query={
+                    'review_state': {'not': 'document-state-shadow'},
                     'object_provides':
                     ['opengever.dossier.behaviors.dossier.IDossierMarker',
                      'opengever.document.document.IDocumentSchema',


### PR DESCRIPTION
As we use a new enough `ZCatalog`, we can append a not query of the `review_state` to the path queries.

Put this PR to 2018.5 milestone as this is essentially an Oneoffixx thing.

Closes #3385 