### PR TITLE
Make save as pdf button colored green.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,7 @@ Changelog
 
 - Fix issue when returning an excerpt to an already decided proposal. [njohner]
 - Fix data in Task PDF when resolving a dossier. [njohner]
+- Make save as pdf button colored green. [deiferni]
 - Display group label in teamdetails instead of group title. [njohner]
 - Add reference numbers to protected items admin view links. [Rotonen]
 - Sort repository excel exports by reference number. [Rotonen]

--- a/opengever/document/forms.py
+++ b/opengever/document/forms.py
@@ -218,6 +218,11 @@ class SavePDFUnderForm(form.Form):
     def handle_cancel(self, action):
         return self.request.RESPONSE.redirect(self.context.absolute_url())
 
+    def updateActions(self):
+        super(SavePDFUnderForm, self).updateActions()
+        # make sure button appears colored (green)
+        self.actions['button_submit'].addClass("context")
+
     def get_save_pdf_under_url(self):
         save_pdf_under_url = '{}/demand_document_pdf'.format(self.destination_document.absolute_url())
         return save_pdf_under_url


### PR DESCRIPTION
By adding the context class to the button we can re-use existing css.

![screenshot 2018-11-12 at 12 26 30](https://user-images.githubusercontent.com/736583/48344845-895e7b00-e676-11e8-89a5-a8b5ac69883a.png)

Fixes #5069.