### PR TITLE
Conditionally show proposal notification settings.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -8,6 +8,7 @@ Changelog
 - Fix issue when returning an excerpt to an already decided proposal. [njohner]
 - Fix data in Task PDF when resolving a dossier. [njohner]
 - Make save as pdf button colored green. [deiferni]
+- Only show proposal notification settings when meeting feature is enabled. [deiferni]
 - Display group label in teamdetails instead of group title. [njohner]
 - Add reference numbers to protected items admin view links. [Rotonen]
 - Sort repository excel exports by reference number. [Rotonen]

--- a/opengever/activity/browser/resources/settings.js
+++ b/opengever/activity/browser/resources/settings.js
@@ -66,18 +66,22 @@
         {tabId: 'forwardings',
          tabTitle: this.getDataAttribute('tab-title-forwardings'),
          activities: this.filterActivitiesByType(values, 'forwarding')},
-        {tabId: 'proposals',
-         tabTitle: this.getDataAttribute('tab-title-proposals'),
-         activities: this.filterActivitiesByType(values, 'proposal')},
         {tabId: 'reminders',
          tabTitle: this.getDataAttribute('tab-title-reminders'),
          activities: this.filterActivitiesByType(values, 'reminder')},
       ];
-      if (this.getDataAttribute('show-disposition') == 'True'){
+      if (this.getDataAttribute('show-proposals') == 'True') {
+        tabs.push({tabId: 'proposals',
+           tabTitle: this.getDataAttribute('tab-title-proposals'),
+           activities: this.filterActivitiesByType(values, 'proposal')
+        });
+      }
+      if (this.getDataAttribute('show-disposition') == 'True') {
         tabs.push({tabId: 'dispositions',
            tabTitle: this.getDataAttribute('tab-title-dispositions'),
-           activities: this.filterActivitiesByType(values, 'disposition')});
-        }
+           activities: this.filterActivitiesByType(values, 'disposition')
+        });
+      }
       return this.template({
         tabs: tabs,
         translations: data.translations,

--- a/opengever/activity/browser/settings.py
+++ b/opengever/activity/browser/settings.py
@@ -9,15 +9,15 @@ from opengever.activity.roles import DISPOSITION_ARCHIVIST_ROLE
 from opengever.activity.roles import DISPOSITION_RECORDS_MANAGER_ROLE
 from opengever.activity.roles import PROPOSAL_ISSUER_ROLE
 from opengever.activity.roles import TASK_ISSUER_ROLE
-from opengever.activity.roles import TASK_RESPONSIBLE_ROLE
 from opengever.activity.roles import TASK_REMINDER_WATCHER_ROLE
+from opengever.activity.roles import TASK_RESPONSIBLE_ROLE
 from opengever.base.handlebars import prepare_handlebars_template
 from opengever.base.model import create_session
-from Products.Five import BrowserView
 from opengever.base.response import JSONResponse
 from opengever.task.response_description import ResponseDescription
 from path import Path
 from plone import api
+from Products.Five import BrowserView
 from zope.browserpage.viewpagetemplatefile import ViewPageTemplateFile
 from zope.i18n import translate
 import json

--- a/opengever/activity/browser/settings.py
+++ b/opengever/activity/browser/settings.py
@@ -14,6 +14,7 @@ from opengever.activity.roles import TASK_RESPONSIBLE_ROLE
 from opengever.base.handlebars import prepare_handlebars_template
 from opengever.base.model import create_session
 from opengever.base.response import JSONResponse
+from opengever.meeting import is_meeting_feature_enabled
 from opengever.task.response_description import ResponseDescription
 from path import Path
 from plone import api
@@ -302,3 +303,6 @@ class NotificationSettingsForm(BrowserView):
 
     def show_disposition_tab(self):
         return api.user.has_permission('opengever.disposition: Add disposition')
+
+    def show_proposals_tab(self):
+        return is_meeting_feature_enabled()

--- a/opengever/activity/browser/templates/settings.pt
+++ b/opengever/activity/browser/templates/settings.pt
@@ -32,7 +32,8 @@
                            data-tab-title-proposals view/tab_title_proposals;
                            data-tab-title-reminders view/tab_title_reminders;
                            data-tab-title-dispositions view/tab_title_dispositions;
-                           data-show-disposition view/show_disposition_tab">
+                           data-show-disposition view/show_disposition_tab;
+                           data-show-proposals view/show_proposals_tab;">
 
         <tbody>
           <tal:block tal:replace="structure view/render_form_template"></tal:block>


### PR DESCRIPTION
Conditionally show proposal notification settings.

The settings should only be visible when the meeting feature is enabled. If the feature is disabled the tab is omitted from the form as follows:

![screenshot 2018-11-12 at 13 41 58](https://user-images.githubusercontent.com/736583/48348265-23c3bc00-e681-11e8-83f3-378511dc511a.png)

The changes in this PR lead to the tab order changing slightly. The proposals tab will move by one tab, to the right of the notifications tab. I did not address this issue as i do not expect this to be a breaking change for our users (the form is most certainly not used on a daily basis).

Fixes #5066.

_The form is rendered in javascript only, so unfortunately i cannot test this automatically._

