### PR TITLE
Fix data in Task PDF when resolving a dossier.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ---------------------
 
 - Fix issue when returning an excerpt to an already decided proposal. [njohner]
+- Fix data in Task PDF when resolving a dossier. [njohner]
 - Display group label in teamdetails instead of group title. [njohner]
 - Add reference numbers to protected items admin view links. [Rotonen]
 - Sort repository excel exports by reference number. [Rotonen]

--- a/opengever/latex/dossiertasks.py
+++ b/opengever/latex/dossiertasks.py
@@ -78,13 +78,13 @@ class DossierTasksLaTeXView(MakoLaTeXView):
                 deadline = deadline.strftime(self.strftimestring)
 
             task_data_list.append({'title': task.title,
-                                   'description': task.text,
+                                   'description': task.text or "",
                                    'sequence_number': task.get_sequence_number(),
                                    'type': task.get_task_type_label(),
                                    'completion_date': completion_date,
                                    'deadline': deadline,
-                                   'responsible': task.responsible,
-                                   'responsible_client': task.responsible_client,
+                                   'responsible': task.get_responsible_actor().get_label(),
+                                   'issuer': task.get_issuer_actor().get_label(),
                                    'history': task_history.get_listing(response_container)})
 
         return {'task_data_list': task_data_list,

--- a/opengever/latex/templates/dossiertasks.tex
+++ b/opengever/latex/templates/dossiertasks.tex
@@ -7,8 +7,8 @@
 {\bf Beschreibung}: ${task_data.get("description")}\\%%
 {\bf Auftragstyp}: ${task_data.get("type")}\\%%
 {\bf Frist}: ${task_data.get("deadline")}\\%%
-{\bf Auftraggeber}: ${task_data.get("responsible")}\\%%
-{\bf Auftragnehmer}: ${task_data.get("responsible_client")}\\%%
+{\bf Auftraggeber}: ${task_data.get("issuer")}\\%%
+{\bf Auftragnehmer}: ${task_data.get("responsible")}\\%%
 {\bf Erledigungsdatum}: ${task_data.get("completion_date")}\\%%
 
 \small

--- a/opengever/latex/tests/test_dossiertasks.py
+++ b/opengever/latex/tests/test_dossiertasks.py
@@ -4,7 +4,6 @@ from ftw.builder import Builder
 from ftw.builder import create
 from ftw.pdfgenerator.builder import Builder as PDFBuilder
 from ftw.pdfgenerator.interfaces import ILaTeXView
-from ftw.pdfgenerator.utils import provide_request_layer
 from ftw.testbrowser import browsing
 from ftw.testbrowser.pages import factoriesmenu
 from ftw.testing import freeze
@@ -16,6 +15,7 @@ from opengever.latex.testing import LATEX_ZCML_LAYER
 from opengever.testing import FunctionalTestCase
 from plone import api
 from plone.app.testing import TEST_USER_ID
+from plone.app.testing import SITE_OWNER_NAME
 from zope.component import getMultiAdapter
 from zope.publisher.interfaces.browser import IDefaultBrowserLayer
 
@@ -65,13 +65,13 @@ class TestDossierTasksLaTeXView(FunctionalTestCase):
             task1 = create(Builder('task')
                            .within(dossier)
                            .having(responsible=self.user.userid,
-                                   responsible_client=self.org_unit.id(),
+                                   issuer=SITE_OWNER_NAME,
                                    title="task 1"))
 
             task2 = create(Builder('task')
                            .within(subdossier)
                            .having(responsible=self.user.userid,
-                                   responsible_client=self.org_unit.id(),
+                                   issuer=self.user.userid,
                                    title="task 2"))
 
         expected_deadline = datetime(2016, 4, 17, 0, 0)
@@ -89,19 +89,19 @@ class TestDossierTasksLaTeXView(FunctionalTestCase):
             expected = {'label': u'Task list for dossier Anfr\xf6gen 2015 (Client1 / 1)',
                         'task_data_list': [{'completion_date': completion_date.strftime('%d.%m.%Y %H:%M'),
                                             'deadline': expected_deadline.strftime('%d.%m.%Y %H:%M'),
-                                            'description': None,
+                                            'description': '',
                                             'history': None,
-                                            'responsible': u'test_user_1_',
-                                            'responsible_client': u'org-unit-1',
+                                            'responsible': u'Test User (test_user_1_)',
+                                            'issuer': u'admin (admin)',
                                             'sequence_number': 1,
                                             'title': 'task 1',
                                             'type': ''},
                                            {'completion_date': None,
                                             'deadline': expected_deadline.strftime('%d.%m.%Y %H:%M'),
-                                            'description': None,
+                                            'description': '',
                                             'history': None,
-                                            'responsible': u'test_user_1_',
-                                            'responsible_client': u'org-unit-1',
+                                            'responsible': u'Test User (test_user_1_)',
+                                            'issuer': u'Test User (test_user_1_)',
                                             'sequence_number': 2,
                                             'title': 'task 2',
                                             'type': ''}]}


### PR DESCRIPTION
* Make sure that the text passed is an empty string and not "None", as this gets displayed as such in the PDF. 
* Fix the label shown for the task issuer and task responsible.

It seems I got really confused with what `Auftraggeber` and `Auftragnehmer` were. Sorry about that!

I think we do not need to handle the case of `None` for the other fields as they are all mandatory.

**Here a snapshot of the PDF. The task has no description, myself as issuer and Lukas as responsible**
<img width="971" alt="screen shot 2018-11-12 at 16 19 06" src="https://user-images.githubusercontent.com/7374243/48356549-d18d9580-e696-11e8-8e0c-d405a19a5c34.png">

resolves #5065