### PR TITLE
Use opaque_id instead of get parameter in SavePDFDocumentUnder.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -9,6 +9,7 @@ Changelog
 - Fix data in Task PDF when resolving a dossier. [njohner]
 - Make save as pdf button colored green. [deiferni]
 - Only show proposal notification settings when meeting feature is enabled. [deiferni]
+- Use opaque_id instead of get parameter in SavePDFDocumentUnder. [njohner]
 - Display group label in teamdetails instead of group title. [njohner]
 - Prevent shadow documents from being relatable. [Rotonen]
 - Add reference numbers to protected items admin view links. [Rotonen]

--- a/opengever/bumblebee/browser/callback.py
+++ b/opengever/bumblebee/browser/callback.py
@@ -34,7 +34,7 @@ class ReceiveDocumentPDF(BaseDemandCallbackView):
     def __call__(self):
         if self.request.method != 'POST':
             raise MethodNotAllowed()
-        if not IAnnotations(self.context)[PDF_SAVE_TOKEN_KEY] == self.request.form.get("pdf_save_under_token"):
+        if not IAnnotations(self.context)[PDF_SAVE_TOKEN_KEY] == self.get_opaque_id():
             raise Unauthorized
         return super(ReceiveDocumentPDF, self).__call__()
 

--- a/opengever/bumblebee/tests/test_callback.py
+++ b/opengever/bumblebee/tests/test_callback.py
@@ -92,7 +92,7 @@ class TestReceiveDocumentPDF(FunctionalTestCase):
         self.request.set('status', "success")
         self.request.set('pdf', file)
         self.request.set('token', get_download_token())
-        self.request.form['pdf_save_under_token'] = self.save_token
+        self.request.set('opaque_id', self.save_token)
         self.request.method = "POST"
 
     def test_raises_unathorized_when_pdf_save_token_is_wrong(self):

--- a/opengever/document/browser/save_pdf_document_under.py
+++ b/opengever/document/browser/save_pdf_document_under.py
@@ -43,12 +43,12 @@ class SavePDFDocumentUnder(BrowserView):
         self.trigger_conversion()
         return self.template()
 
-    def get_callback_url(self, token):
-        return "{}/save_pdf_under_callback?pdf_save_under_token={}".format(
-            self.destination_document.absolute_url(), token)
+    def get_callback_url(self):
+        return "{}/save_pdf_under_callback".format(
+            self.destination_document.absolute_url())
 
     def trigger_conversion(self):
-        token = uuid4().hex
+        token = str(uuid4())
         annotations = IAnnotations(self.destination_document)
         annotations[PDF_SAVE_TOKEN_KEY] = token
 
@@ -58,7 +58,7 @@ class SavePDFDocumentUnder(BrowserView):
             document = self.source_document
 
         if IBumblebeeServiceV3(getRequest()).queue_demand(
-                document, PROCESSING_QUEUE, self.get_callback_url(token)):
+                document, PROCESSING_QUEUE, self.get_callback_url(), opaque_id=token):
             annotations[PDF_SAVE_STATUS_KEY] = "conversion-demanded"
         else:
             raise BadRequest("This document is not convertable.")

--- a/opengever/document/tests/test_save_pdf_under.py
+++ b/opengever/document/tests/test_save_pdf_under.py
@@ -254,8 +254,7 @@ class TestSavePDFDocumentUnder(IntegrationTestCase):
         self.assertEqual(created_document.absolute_url(), view.destination_document_url())
 
         expected_callback_url = "/".join([created_document.absolute_url(), "save_pdf_under_callback"])
-        expected_callback_url += "?pdf_save_under_token=test_token"
-        self.assertEqual(expected_callback_url, view.get_callback_url("test_token"))
+        self.assertEqual(expected_callback_url, view.get_callback_url())
 
     @browsing
     def test_demand_document_pdf_conversion_status_is_traversable(self, browser):


### PR DESCRIPTION
After discussing with @jone and @deiferni, we should use the `opaque_id` of `bumblebee` instead of a get parameter for the verification token in the `SavePDFUnder` views. 