### PR TITLE
Login as document owner in the ReceiveDocumentPDF callback.

### DIFF
--- a/opengever/bumblebee/tests/test_callback.py
+++ b/opengever/bumblebee/tests/test_callback.py
@@ -9,6 +9,7 @@ from opengever.bumblebee.browser.callback import ReceiveDocumentPDF
 from opengever.document.archival_file import STATE_FAILED_TEMPORARILY
 from opengever.document.archival_file import STATE_FAILED_PERMANENTLY
 from opengever.document.behaviors.metadata import IDocumentMetadata
+from opengever.document.browser.save_pdf_document_under import PDF_SAVE_OWNER_ID_KEY
 from opengever.document.browser.save_pdf_document_under import PDF_SAVE_TOKEN_KEY
 from opengever.document.browser.save_pdf_document_under import PDF_SAVE_STATUS_KEY
 from opengever.testing import FunctionalTestCase
@@ -83,6 +84,7 @@ class TestReceiveDocumentPDF(FunctionalTestCase):
         self.document = create(Builder('document')
                                .titled(u'\xdcberpr\xfcfung XY')).as_shadow_document()
         IAnnotations(self.document)[PDF_SAVE_TOKEN_KEY] = self.save_token
+        IAnnotations(self.document)[PDF_SAVE_OWNER_ID_KEY] = self.user.userid
 
     def prepare_request(self):
         fieldstorage = cgi.FieldStorage()

--- a/opengever/document/browser/save_pdf_document_under.py
+++ b/opengever/document/browser/save_pdf_document_under.py
@@ -6,6 +6,7 @@ from opengever.base.utils import disable_edit_bar
 from opengever.document.versioner import Versioner
 from opengever.document import _
 from pkg_resources import resource_filename
+from plone import api
 from plone.app.uuid.utils import uuidToObject
 from Products.Five.browser import BrowserView
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
@@ -22,6 +23,7 @@ PDF_SAVE_TOKEN_KEY = 'opengever.document.save_pdf_under_token'
 PDF_SAVE_SOURCE_UUID_KEY = 'opengever.document.save_pdf_under_source_uuid'
 PDF_SAVE_SOURCE_VERSION_KEY = 'opengever.document.save_pdf_under_source_version'
 PDF_SAVE_STATUS_KEY = 'opengever.document.save_pdf_under_status'
+PDF_SAVE_OWNER_ID_KEY = 'opengever.document.save_pdf_document_owner_id'
 
 
 class SavePDFDocumentUnder(BrowserView):
@@ -51,6 +53,7 @@ class SavePDFDocumentUnder(BrowserView):
         token = uuid4().hex
         annotations = IAnnotations(self.destination_document)
         annotations[PDF_SAVE_TOKEN_KEY] = token
+        annotations[PDF_SAVE_OWNER_ID_KEY] = api.user.get_current().getId()
 
         if self.version_id is not None:
             document = Versioner(self.source_document).retrieve(self.version_id)

--- a/opengever/document/tests/test_save_pdf_under.py
+++ b/opengever/document/tests/test_save_pdf_under.py
@@ -6,7 +6,10 @@ from opengever.document.archival_file import STATE_CONVERTED
 from opengever.document.behaviors.related_docs import IRelatedDocuments
 from opengever.document.behaviors.metadata import IDocumentMetadata
 from opengever.document.versioner import Versioner
+from opengever.document.browser.save_pdf_document_under import PDF_SAVE_OWNER_ID_KEY
+from opengever.document.browser.save_pdf_document_under import PDF_SAVE_SOURCE_UUID_KEY
 from opengever.document.browser.save_pdf_document_under import PDF_SAVE_STATUS_KEY
+from opengever.document.browser.save_pdf_document_under import PDF_SAVE_TOKEN_KEY
 from opengever.document.browser.save_pdf_document_under import SavePDFDocumentUnder
 from opengever.testing import IntegrationTestCase
 from plone.uuid.interfaces import IUUID
@@ -206,10 +209,12 @@ class TestSavePDFUnderForm(IntegrationTestCase):
 
         annotations = IAnnotations(created_document)
         self.assertEqual(IUUID(self.document),
-                         annotations.get('opengever.document.save_pdf_under_source_uuid'))
+                         annotations.get(PDF_SAVE_SOURCE_UUID_KEY))
         self.assertEqual('conversion-demanded',
-                         annotations.get('opengever.document.save_pdf_under_status'))
-        self.assertIsNotNone(annotations.get('opengever.document.save_pdf_under_token'))
+                         annotations.get(PDF_SAVE_STATUS_KEY))
+        self.assertIsNotNone(annotations.get(PDF_SAVE_TOKEN_KEY))
+        self.assertEqual(self.regular_user.getId(),
+                         annotations.get(PDF_SAVE_OWNER_ID_KEY))
 
     @browsing
     def test_save_pdf_under_form_redirects_to_demand_document_pdf(self, browser):


### PR DESCRIPTION
The ReceiveDocumentPDF callback view is called from bumblebee hence by an anonymous user. Because of that the preview is not generated by bumblebee as the anonymous user does not have view permissions on the document.