### PR TITLE
Rename the theme integration test layer to preserve unique matchability

### DIFF
--- a/opengever/core/testing.py
+++ b/opengever/core/testing.py
@@ -513,7 +513,7 @@ OPENGEVER_INTEGRATION_TESTING_THEME = GEVERIntegrationTesting(
     # Warning: do not try to base other layers on ContentFixtureLayer.
     # See docstring of ContentFixtureLayer.
     bases=(ThemeContentFixtureLayer(), TRAVERSAL_BROWSER_FIXTURE),
-    name="opengever.core:integration:theme")
+    name="opengever.core:theme:integration")
 
 
 OPENGEVER_INTEGRATION_TESTING = GEVERIntegrationTesting(


### PR DESCRIPTION
If we want to preserve unique testrunner matchability for our main integration test layers, do we do it this way, or do we rename the bulk one as `integration:base` or equivalent?