### PR TITLE
Fix revoke local roles performance improvement

### DIFF
--- a/opengever/base/role_assignments.py
+++ b/opengever/base/role_assignments.py
@@ -315,8 +315,7 @@ class RoleAssignmentManager(object):
             return
 
         self.storage.clear(item)
-        if reindex:
-            self._update_local_roles()
+        self._update_local_roles(reindex=reindex)
 
     def _update_local_roles(self, reindex=True):
         current_principals = []

--- a/opengever/task/tests/test_localroles.py
+++ b/opengever/task/tests/test_localroles.py
@@ -242,23 +242,33 @@ class TestLocalRolesRevoking(IntegrationTestCase):
     @browsing
     def test_closing_a_task_revokes_responsible_roles_on_distinct_parent(self, browser):
         self.login(self.dossier_responsible, browser=browser)
-        self.set_workflow_state('task-state-tested-and-closed', self.subtask)
-        self.set_workflow_state('task-state-resolved', self.task)
+        self.set_workflow_state('task-state-resolved', self.meeting_task)
 
-        storage = RoleAssignmentManager(self.dossier).storage
-        self.assertIn(
-            Oguid.for_object(self.task).id,
-            [aa.get('reference') for aa in storage._storage()])
+        storage = RoleAssignmentManager(self.meeting_dossier).storage
+        self.assertEquals(
+            [{'cause': 1,
+              'roles': ['Contributor'],
+              'reference': Oguid.for_object(self.meeting_task),
+              'principal': self.dossier_responsible.id},
+             {'cause': 1,
+              'roles': ['Contributor'],
+              'reference': Oguid.for_object(self.meeting_subtask),
+              'principal': self.dossier_responsible.id}],
+            storage._storage())
 
-        # close
-        browser.open(self.task, view='tabbedview_view-overview')
+        # close subtask
+        browser.open(self.meeting_subtask, view='tabbedview_view-overview')
         browser.click_on('task-transition-resolved-tested-and-closed')
-        browser.fill({'Response': 'Done!'})
         browser.click_on('Save')
 
-        self.assertNotIn(
-            Oguid.for_object(self.task).id,
-            [aa.get('reference') for aa in storage._storage()])
+        browser.open(self.meeting_task, view='tabbedview_view-overview')
+        browser.click_on('task-transition-resolved-tested-and-closed')
+        browser.click_on('Save')
+
+        self.assertEquals([], storage._storage())
+        self.assertEquals(
+            (('franzi.muller', ('Owner',)),),
+            self.meeting_dossier.get_local_roles())
 
     @browsing
     def test_cancelling_a_task_revokes_roles(self, browser):


### PR DESCRIPTION
The performance improvement recently introduced by #5079, had a bug on
revoking roles on distinct parent. I've fixed it and improved the
according test.

Needs backport 