### PR TITLE
Translate status message type in forms.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2018.5.0 (unreleased)
 ---------------------
 
+- Translate status message type in forms. [njohner]
 - Add Open XML Visio mimetypes. [deiferni]
 - Fix issue when returning an excerpt to an already decided proposal. [njohner]
 - Fix data in Task PDF when resolving a dossier. [njohner]

--- a/opengever/base/browser/templates/macros.pt
+++ b/opengever/base/browser/templates/macros.pt
@@ -16,7 +16,7 @@
 
               <tal:status condition="python: hasattr(view, 'rendered_error_message') and view.rendered_error_message">
                     <dl class="portalMessage error">
-                        <dt i18n:translate="">
+                        <dt i18n:domain="plone" i18n:translate="">
                             Error
                         </dt>
                         <dd tal:content="structure view/rendered_error_message" />
@@ -27,13 +27,13 @@
                                     groupErrors python: [e for e in [g.widgets.errors for g in getattr(view, 'groups', [])] if e]"
                             condition="status">
                     <dl class="portalMessage error" tal:condition="python: view.widgets.errors or groupErrors">
-                        <dt i18n:translate="">
+                        <dt i18n:domain="plone" i18n:translate="">
                             Error
                         </dt>
                         <dd tal:content="status" />
                     </dl>
                     <dl class="portalMessage info" tal:condition="python: not(view.widgets.errors or groupErrors)">
-                        <dt i18n:translate="">
+                        <dt i18n:domain="plone" i18n:translate="">
                             Info
                         </dt>
                         <dd tal:content="status" />


### PR DESCRIPTION
Because the status message is defined in a `metal` macro, it seems that we need to pass the translation domain in each translated tag.

This led to message type not being translated in various forms, notably when adding a document from a template, but also when adding a proposal, a task, and probably any add form in which an error could be raised.

**Before the status message type was not translated**
<img width="1359" alt="screen shot 2018-11-14 at 08 03 35" src="https://user-images.githubusercontent.com/7374243/48471453-36123700-e7f4-11e8-9372-16a7649099dc.png">

**Now the translation works correctly, shown here for adding a document from a template, or adding a proposal**

<img width="1359" alt="screen shot 2018-11-14 at 10 01 45" src="https://user-images.githubusercontent.com/7374243/48471580-812c4a00-e7f4-11e8-9e58-de7734fcae2e.png">

<img width="1359" alt="screen shot 2018-11-14 at 10 01 54" src="https://user-images.githubusercontent.com/7374243/48471581-812c4a00-e7f4-11e8-968d-bdc887415304.png">

resolves #5064 

