### PR TITLE
Reorder conditions in dossier resolve.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ---------------------
 
 - Translate status message type in forms. [njohner]
+- Skip check that tasks and documents are in a subdossier when resolving a subdossier. [njohner]
 - Add Open XML Visio mimetypes. [deiferni]
 - Bump ftw.bumblebee to 3.7.0 for new derived secrets for the demand endpoint. [deiferni]
 - Fix issue when returning an excerpt to an already decided proposal. [njohner]

--- a/opengever/dossier/resolve.py
+++ b/opengever/dossier/resolve.py
@@ -421,8 +421,8 @@ class ResolveConditions(object):
         errors = []
 
         if (self.strict
-                and not self.context.is_all_supplied()
-                and not self.context.is_subdossier()):
+                and not self.context.is_subdossier()
+                and not self.context.is_all_supplied()):
             errors.append(NOT_SUPPLIED_OBJECTS)
         if not self.context.is_all_checked_in():
             errors.append(NOT_CHECKED_IN_DOCS)


### PR DESCRIPTION
This should have a positive performance impact when resolving a subdossier as we will not have to check whether all tasks and documents are in a subdossier (`and` condition will evaluate from left to right until it hits its first `False`).