### PR TITLE
Improve task listing formatting.

### DIFF
--- a/opengever/latex/dossiertasks.py
+++ b/opengever/latex/dossiertasks.py
@@ -58,7 +58,7 @@ class DossierTasksLaTeXView(MakoLaTeXView):
         tasks = self.get_tasks()
         task_data_list = []
         title = translate(_('label_dossier_tasks',
-                            default=u'Task list for dossier ${title} (${reference_number})',
+                            default=u'Task list for dossier "${title} (${reference_number})"',
                           mapping={'title': self.context.title,
                                    'reference_number': self.context.get_reference_number()}),
                           context=self.request)

--- a/opengever/latex/listing.py
+++ b/opengever/latex/listing.py
@@ -21,10 +21,11 @@ from zope.interface import Interface
 
 class Column(object):
 
-    def __init__(self, id, label, width, getter=None):
+    def __init__(self, id, label, width, getter=None, alignment=None):
         self.id = id
         self.label = label
         self.width = width
+        self.alignment = alignment or "justify"
 
         if getter is None:
             getter = id
@@ -294,21 +295,28 @@ class TasksLaTeXListing(DossiersLaTeXListing):
 @adapter(Interface, Interface, Interface)
 class TaskHistoryLaTeXListing(LaTexListing):
 
+    def get_actor_label(self, item):
+        return Actor.lookup(item.creator).get_label()
+
     def get_columns(self):
         return [
             Column('date',
                    _('label_time', default=u'Time'),
                    '10%',
-                   lambda item: helper.readable_date_time(item, item.date)),
+                   lambda item: helper.readable_date_time(item, item.date),
+                   "left"),
 
             Column('creator',
                    _('label_creator', default='Changed by'),
-                   '20%'),
+                   '20%',
+                   self.get_actor_label,
+                   "left"),
 
             Column('transition',
                    _('label_transition', default='Transition'),
                    '20%',
-                   lambda item: activity_mf(item.transition)),
+                   lambda item: activity_mf(item.transition),
+                   "left"),
 
             Column('text',
                    _('label_description', default='Description'),

--- a/opengever/latex/locales/de/LC_MESSAGES/opengever.latex.po
+++ b/opengever/latex/locales/de/LC_MESSAGES/opengever.latex.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-30 13:38+0000\n"
+"POT-Creation-Date: 2018-11-14 15:33+0000\n"
 "PO-Revision-Date: 2013-11-19 16:25+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -54,10 +54,10 @@ msgstr "Dokumente"
 msgid "label_dossier_journal"
 msgstr "Journal zu Dossier ${title} (${reference_number})"
 
-#. Default: "Task list for dossier ${title} (${reference_number})"
+#. Default: "Task list for dossier \"${title} (${reference_number})\""
 #: ./opengever/latex/dossiertasks.py
 msgid "label_dossier_tasks"
-msgstr "Aufgabenliste zu Dossier ${title} (${reference_number})"
+msgstr "Aufgabenliste zu Dossier \"${title} (${reference_number})\""
 
 #. Default: "End"
 #: ./opengever/latex/dossierdetails.py

--- a/opengever/latex/locales/fr/LC_MESSAGES/opengever.latex.po
+++ b/opengever/latex/locales/fr/LC_MESSAGES/opengever.latex.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-30 13:38+0000\n"
+"POT-Creation-Date: 2018-11-14 15:33+0000\n"
 "PO-Revision-Date: 2017-12-03 09:48+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-latex/fr/>\n"
@@ -56,10 +56,10 @@ msgstr "Documents"
 msgid "label_dossier_journal"
 msgstr "Journal du dossier ${title} (${reference_number})"
 
-#. Default: "Task list for dossier ${title} (${reference_number})"
+#. Default: "Task list for dossier \"${title} (${reference_number})\""
 #: ./opengever/latex/dossiertasks.py
 msgid "label_dossier_tasks"
-msgstr "Liste des tâches du dossier ${title} (${reference_number})"
+msgstr "Liste des tâches du dossier \"${title} (${reference_number})\""
 
 #. Default: "End"
 #: ./opengever/latex/dossierdetails.py

--- a/opengever/latex/locales/opengever.latex.pot
+++ b/opengever/latex/locales/opengever.latex.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-07-30 13:38+0000\n"
+"POT-Creation-Date: 2018-11-14 15:33+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -57,7 +57,7 @@ msgstr ""
 msgid "label_dossier_journal"
 msgstr ""
 
-#. Default: "Task list for dossier ${title} (${reference_number})"
+#. Default: "Task list for dossier \"${title} (${reference_number})\""
 #: ./opengever/latex/dossiertasks.py
 msgid "label_dossier_tasks"
 msgstr ""

--- a/opengever/latex/templates/listing.pt
+++ b/opengever/latex/templates/listing.pt
@@ -7,8 +7,8 @@
 
   <table>
     <colgroup>
-      <col tal:repeat="value view/get_widths"
-           tal:attributes="width value" width="1%" />
+      <col tal:repeat="column view/get_columns"
+           tal:attributes="width column/width; align column/alignment" width="1%" align="justify"/>
     </colgroup>
 
     <thead>

--- a/opengever/latex/tests/test_dossiertasks.py
+++ b/opengever/latex/tests/test_dossiertasks.py
@@ -45,7 +45,7 @@ class TestDossierTasksLaTeXView(FunctionalTestCase):
                 (dossier, dossier.REQUEST, layout), ILaTeXView)
 
             self.assertEquals(
-                u'Task list for dossier Anfr\xf6gen 2015 (Client1 / 1)',
+                u'Task list for dossier "Anfr\xf6gen 2015 (Client1 / 1)"',
                 dossier_tasks.get_render_arguments().get('label'))
 
     @browsing
@@ -86,7 +86,7 @@ class TestDossierTasksLaTeXView(FunctionalTestCase):
                                            ILaTeXView)
             self.assertEquals([task1, task2], dossiertasks.get_tasks())
 
-            expected = {'label': u'Task list for dossier Anfr\xf6gen 2015 (Client1 / 1)',
+            expected = {'label': u'Task list for dossier "Anfr\xf6gen 2015 (Client1 / 1)"',
                         'task_data_list': [{'completion_date': completion_date.strftime('%d.%m.%Y %H:%M'),
                                             'deadline': expected_deadline.strftime('%d.%m.%Y %H:%M'),
                                             'description': '',


### PR DESCRIPTION
We improve the format of the task listing PDF:

* We add the possibility to set the text alignment in the `LaTexListing`. `Column`s now have a new `alignment` attribute.
* To avoid stretching of text and hyphenation, we set the first three columns (date, creator and transition) to left-aligned. The last column, `description`, is justified.
* For the creator we now show the full label (full name and userid)
* In the title of the document, we quote the dossier title.

**Old formatting**
<img width="913" alt="screen shot 2018-11-15 at 08 26 05" src="https://user-images.githubusercontent.com/7374243/48537082-bbf3b800-e8b0-11e8-9405-17dfc175e97f.png">

**New formatting**
<img width="902" alt="screen shot 2018-11-15 at 08 28 49" src="https://user-images.githubusercontent.com/7374243/48537088-c01fd580-e8b0-11e8-9e05-fa16926a6532.png">

This should not change the formatting of other listings, as we use `justified` as default, which seems to be the default when no alignment is specified. The generated latex probably depends on the browser used though, as we go through HTML, and then from HTML to Latex.

