### PR TITLE
Reindex and store additionally supported bumblebee documents.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ---------------------
 
 - Testserver: add support for custom fixtures. [jone]
+- Reindex and store additionally supported bumblebee documents. [elioschmutz]
 - Make sure docproperties gets updated when updating an agendaitem list or a protocol. [phgross]
 - Fix logo upload in the theme control-panel. [phgross]
 - Solr TabbedView filters: Also include non-wildcarded terms in query. [lgraf]

--- a/opengever/core/upgrades/20181116121240_reindex_new_supported_bumblebee_documents/upgrade.py
+++ b/opengever/core/upgrades/20181116121240_reindex_new_supported_bumblebee_documents/upgrade.py
@@ -1,0 +1,36 @@
+from ftw.bumblebee import get_service_v3
+from ftw.bumblebee.interfaces import IBumblebeeable
+from ftw.bumblebee.interfaces import IBumblebeeDocument
+from ftw.bumblebee.mimetypes import get_extensions_by_mimetype
+from ftw.upgrade import UpgradeStep
+from ftw.upgrade.progresslogger import ProgressLogger
+
+
+class ReindexNewSupportedBumblebeeDocuments(UpgradeStep):
+    """Reindex new supported bumblebee documents.
+    """
+    additional_mimetypes = ('indd', 'vsdx', 'vstx', 'vssx')
+    deferrable = True
+
+    def __call__(self):
+        self.install_upgrade_profile()
+        service = get_service_v3()
+
+        msg = 'Reindex checksum for documents having one of the following ' \
+              'file-extensions: {}.'.format(', '.join(self.additional_mimetypes))
+
+        for obj in ProgressLogger(msg, self.objs_to_perform()):
+            IBumblebeeDocument(obj).update_checksum()
+            service.trigger_storing(obj, deferred=True)
+
+    def objs_to_perform(self):
+        objs = []
+        for brain in self.catalog_unrestricted_search(
+                {'object_provides': IBumblebeeable.__identifier__}):
+
+            extension = get_extensions_by_mimetype(brain.getContentType)
+
+            if bool(extension & set(self.additional_mimetypes)):
+                objs.append(brain.getObject())
+
+        return objs


### PR DESCRIPTION
This PR calculates the checksum for documents having the newly supported mimetypes and stores the im bubmelbee.

~⚠️ use `ftw.bumblebee` release instead from source~ (Required bumblebee-version have already been pinned by the following commit https://github.com/4teamwork/opengever.core/commit/210cb77804)
