### PR TITLE
Revert "Merge pull request #5000" 

### DIFF
--- a/opengever/base/browser/resources/tooltip.js
+++ b/opengever/base/browser/resources/tooltip.js
@@ -92,9 +92,7 @@
     showBackdrop(event);
   }
 
-  if (!Modernizr.touch) {
-    $(document).on("mouseover", ".tooltip-trigger", initTooltips);
-  }
+  $(document).on("mouseover", ".tooltip-trigger", initTooltips);
 
 }(window, window.jQuery));
 


### PR DESCRIPTION
This reverts commit cb637206b1ed6b8c1ef266ba91e958fdd335c1cd.

The with #5000 introduced solution, leads to problem on hybrid machines (touchable desktops), where the tooltip is now newer showed up on such machines. In my opinion it's more important that the `tooltip` works on hybrids, than the tabled use case is solved. 

I'll reopen the Issue #4809, so we can look for an other solution ... 