### PR TITLE
Render documentish descriptions as intelligent text

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -10,6 +10,7 @@ Changelog
 - Only display .docx files as possible proposal documents. [Rotonen]
 - Fix task revoking permissions on close/reassign. [phgross]
 - Fix an issue with missing zip after concurrent demand callback requests. [deiferni]
+- Render document descriptions as intelligent text on the Bumblebee overlay. [Rotonen]
 - Render document descriptions as intelligent text on the document overview. [Rotonen]
 
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -10,6 +10,7 @@ Changelog
 - Only display .docx files as possible proposal documents. [Rotonen]
 - Fix task revoking permissions on close/reassign. [phgross]
 - Fix an issue with missing zip after concurrent demand callback requests. [deiferni]
+- Render mail descriptions as intelligent text on the mail overview. [Rotonen]
 - Render document descriptions as intelligent text on the Bumblebee overlay. [Rotonen]
 - Render document descriptions as intelligent text on the document overview. [Rotonen]
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -10,6 +10,7 @@ Changelog
 - Only display .docx files as possible proposal documents. [Rotonen]
 - Fix task revoking permissions on close/reassign. [phgross]
 - Fix an issue with missing zip after concurrent demand callback requests. [deiferni]
+- Render document descriptions as intelligent text on the document overview. [Rotonen]
 
 
 2018.5.4 (2018-12-06)

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -10,6 +10,7 @@ Changelog
 - Only display .docx files as possible proposal documents. [Rotonen]
 - Fix task revoking permissions on close/reassign. [phgross]
 - Fix an issue with missing zip after concurrent demand callback requests. [deiferni]
+- Render mail descriptions as intelligent text on the Bumblebee overlay. [Rotonen]
 - Render mail descriptions as intelligent text on the mail overview. [Rotonen]
 - Render document descriptions as intelligent text on the Bumblebee overlay. [Rotonen]
 - Render document descriptions as intelligent text on the document overview. [Rotonen]

--- a/opengever/base/utils.py
+++ b/opengever/base/utils.py
@@ -135,9 +135,12 @@ def to_safe_html(markup):
 
 
 def to_html_xweb_intelligent(text):
-    return api.portal.get_tool(name='portal_transforms').convertTo(
-                    'text/html', text,
-                    mimetype='text/x-web-intelligent').getData()
+    """Transform input text to `text/x-web-intelligent`."""
+    return (
+        api.portal.get_tool(name='portal_transforms')
+        .convertTo('text/html', text, mimetype='text/x-web-intelligent')
+        .getData()
+    )
 
 
 def file_checksum(filename, chunksize=65536, algorithm=u'MD5'):

--- a/opengever/bumblebee/browser/overlay.py
+++ b/opengever/bumblebee/browser/overlay.py
@@ -6,6 +6,7 @@ from opengever.base.browser.helper import get_css_class
 from opengever.base.interfaces import IReferenceNumber
 from opengever.base.interfaces import ISequenceNumber
 from opengever.base.protect import unprotected_write
+from opengever.base.utils import to_html_xweb_intelligent
 from opengever.bumblebee import _
 from opengever.bumblebee import is_bumblebee_feature_enabled
 from opengever.bumblebee.interfaces import IBumblebeeOverlay
@@ -106,7 +107,7 @@ class BumblebeeBaseDocumentOverlay(ActionButtonRendererMixin):
         return self.context.title
 
     def get_description(self):
-        return self.context.description
+        return to_html_xweb_intelligent(self.context.description)
 
     def get_file_size(self):
         """Return the filesize in KB."""

--- a/opengever/bumblebee/browser/templates/bumblebeeoverlay.pt
+++ b/opengever/bumblebee/browser/templates/bumblebeeoverlay.pt
@@ -37,7 +37,7 @@
       </tr>
       <tr tal:condition="view/overlay/get_description">
         <td class="title" i18n:translate="">Description:</td>
-        <td class="value">
+        <td class="value description">
           <div tal:content="structure view/overlay/get_description" />
         </td>
       </tr>

--- a/opengever/bumblebee/tests/test_overlay_view.py
+++ b/opengever/bumblebee/tests/test_overlay_view.py
@@ -422,6 +422,17 @@ class TestBumblebeeOverlayDocument(IntegrationTestCase):
             browser.css('.file-action-buttons a').text,
             )
 
+    @browsing
+    def test_description_is_intelligently_formatted(self, browser):
+        self.login(self.regular_user, browser)
+        self.document.description = u'\n\n Foo\n    Bar\n'
+        browser.open(self.document, view="bumblebee-overlay-document")
+        # Somehow what is `&nbsp;` in a browser is `\xa0` in ftw.testbrowser
+        self.assertEqual(
+            u'<br><br>\xa0Foo<br>\xa0\xa0\xa0\xa0Bar<br>',
+            browser.css('.value.description div')[0].innerHTML,
+        )
+
 
 class TestBumblebeeOverlayViewsWithoutBumblebeeFeature(IntegrationTestCase):
     """Test we can disable Bumblebee."""

--- a/opengever/bumblebee/tests/test_overlay_view.py
+++ b/opengever/bumblebee/tests/test_overlay_view.py
@@ -433,6 +433,17 @@ class TestBumblebeeOverlayDocument(IntegrationTestCase):
             browser.css('.value.description div')[0].innerHTML,
         )
 
+    @browsing
+    def test_description_is_intelligently_formatted_on_mail(self, browser):
+        self.login(self.regular_user, browser)
+        self.mail_eml.description = u'\n\n Foo\n    Bar\n'
+        browser.open(self.mail_eml, view="bumblebee-overlay-document")
+        # Somehow what is `&nbsp;` in a browser is `\xa0` in ftw.testbrowser
+        self.assertEqual(
+            u'<br><br>\xa0Foo<br>\xa0\xa0\xa0\xa0Bar<br>',
+            browser.css('.value.description div')[0].innerHTML,
+        )
+
 
 class TestBumblebeeOverlayViewsWithoutBumblebeeFeature(IntegrationTestCase):
     """Test we can disable Bumblebee."""

--- a/opengever/document/browser/overview.py
+++ b/opengever/document/browser/overview.py
@@ -2,9 +2,10 @@ from AccessControl import getSecurityManager
 from ftw import bumblebee
 from ftw.bumblebee.interfaces import IBumblebeeDocument
 from opengever.base import _ as ogbmf
+from opengever.base.behaviors.changed import IChanged
 from opengever.base.browser import edit_public_trial
 from opengever.base.browser.helper import get_css_class
-from opengever.base.behaviors.changed import IChanged
+from opengever.base.utils import to_html_xweb_intelligent
 from opengever.bumblebee import is_bumblebee_feature_enabled
 from opengever.document import _
 from opengever.document.behaviors.metadata import IDocumentMetadata
@@ -87,6 +88,18 @@ class FieldRow(BaseRow):
         return yes if bool(value) else no
 
 
+class WebIntelligentFieldRow(FieldRow):
+    """Transform the widget value to x-web-intelligent.
+
+    This should only be used for well known fields.
+    """
+
+    def get_content(self):
+        widget = self.view.w[self.field]
+        content = to_html_xweb_intelligent(widget.value)
+        return '<div id="{}" class="{}">{}</div>'.format(widget.id, widget.klass, content)
+
+
 class CustomRow(BaseRow):
     """A custom metadata row type that uses a callable `renderer` to
     fetch the row's content.
@@ -153,7 +166,7 @@ class Overview(DefaultView, GeverTabMixin, ActionButtonRendererMixin):
             FieldRow('IDocumentMetadata.document_author'),
             CustomRow(self.render_creator_link,
                       label=_('label_creator', default='creator')),
-            FieldRow('IDocumentMetadata.description'),
+            WebIntelligentFieldRow('IDocumentMetadata.description'),
             TemplateRow(self.keywords_template,
                         label=_(u'label_keywords', default=u'Keywords')),
             FieldRow('IDocumentMetadata.foreign_reference'),

--- a/opengever/document/tests/test_overview.py
+++ b/opengever/document/tests/test_overview.py
@@ -572,6 +572,17 @@ class TestDocumentOverviewVanilla(IntegrationTestCase):
             browser.css('#edit-bar a').text
             )
 
+    @browsing
+    def test_description_is_intelligently_formatted(self, browser):
+        self.login(self.regular_user, browser)
+        self.document.description = u'\n\n Foo\n    Bar\n'
+        browser.open(self.document, view='tabbedview_view-overview')
+        # Somehow what is `&nbsp;` in a browser is `\xa0` in ftw.testbrowser
+        self.assertEqual(
+            u'<br><br>\xa0Foo<br>\xa0\xa0\xa0\xa0Bar<br>',
+            browser.css('#form-widgets-IDocumentMetadata-description')[0].innerHTML,
+        )
+
 
 class TestDocumentOverviewWithMeeting(IntegrationTestCase):
 

--- a/opengever/mail/browser/mail.py
+++ b/opengever/mail/browser/mail.py
@@ -7,6 +7,7 @@ from opengever.document.browser.overview import CustomRow
 from opengever.document.browser.overview import FieldRow
 from opengever.document.browser.overview import Overview
 from opengever.document.browser.overview import TemplateRow
+from opengever.document.browser.overview import WebIntelligentFieldRow
 from opengever.mail import _
 from plone import api
 from plone.i18n.normalizer.interfaces import IIDNormalizer
@@ -91,7 +92,7 @@ class OverviewTab(MailAttachmentsMixin, Overview):
             FieldRow('IDocumentMetadata.document_author'),
             CustomRow(self.render_creator_link,
                       label=ogdmf('label_creator', default='creator')),
-            FieldRow('IDocumentMetadata.description'),
+            WebIntelligentFieldRow('IDocumentMetadata.description'),
             FieldRow('IDocumentMetadata.foreign_reference'),
             TemplateRow(self.file_template,
                         label=_('label_org_message', default='Message')),

--- a/opengever/mail/tests/test_overview.py
+++ b/opengever/mail/tests/test_overview.py
@@ -1,0 +1,16 @@
+from ftw.testbrowser import browsing
+from opengever.testing import IntegrationTestCase
+
+
+class TestMailOverview(IntegrationTestCase):
+
+    @browsing
+    def test_description_is_intelligently_formatted(self, browser):
+        self.login(self.regular_user, browser)
+        self.mail_eml.description = u'\n\n Foo\n    Bar\n'
+        browser.open(self.mail_eml, view='tabbedview_view-overview')
+        # Somehow what is `&nbsp;` in a browser is `\xa0` in ftw.testbrowser
+        self.assertEqual(
+            u'<br><br>\xa0Foo<br>\xa0\xa0\xa0\xa0Bar<br>',
+            browser.css('#form-widgets-IDocumentMetadata-description')[0].innerHTML,
+        )


### PR DESCRIPTION
Introduced a new row type for the document and mail overviews and used the transform in the Bumblebee overlay.

Closes #5063 