### PR TITLE
Only display .docx files as possible proposal documents

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2019.1.0 (unreleased)
 ---------------------
 
-- Nothing changed yet.
+- Only display .docx files as possible proposal documents. [Rotonen]
 
 
 2018.5.4 (2018-12-06)

--- a/opengever/meeting/browser/proposalforms.py
+++ b/opengever/meeting/browser/proposalforms.py
@@ -111,6 +111,7 @@ class IAddProposal(IProposal):
             portal_type=("opengever.document.document", ),
             navigation_tree_query={
                 'review_state': {'not': 'document-state-shadow'},
+                'file_extension': '.docx',
                 'object_provides': [
                     'opengever.document.document.IDocumentSchema',
                     'opengever.dossier.behaviors.dossier.IDossierMarker',

--- a/opengever/meeting/tests/test_proposal.py
+++ b/opengever/meeting/tests/test_proposal.py
@@ -1133,17 +1133,22 @@ class TestProposal(IntegrationTestCase):
             headers={'Content-Type': 'application/x-www-form-urlencoded'},
             data=formdata.urlencode({'href': '/'.join(self.dossier.getPhysicalPath()), 'rel': 0}),
         )
-        expected_documents = [
-            '2015',
-            '2016',
-            u'Antrag f\xfcr Kreiselbau',
-            u'Initialvertrag f\xfcr Bearbeitung',
-            u'Initialvertrag f\xfcr Bearbeitung',
-            u'L\xe4\xe4r',
-            'Personaleintritt',
-            u'Vertr\xe4ge',
-            u'Vertr\xe4gsentwurf',
-            u'Vertragsentwurf \xdcberpr\xfcfen',
-            u'Vertragsentw\xfcrfe 2018',
-        ]
+        expected_documents = [u'Initialvertrag f\xfcr Bearbeitung', u'Vertr\xe4gsentwurf']
+        self.assertEqual(expected_documents, browser.css('li').text)
+
+    @browsing
+    def test_add_form_does_not_list_non_docx_documents_as_proposal_documents(self, browser):
+        self.login(self.regular_user, browser)
+        contenttree_url = '/'.join((
+            self.dossier.absolute_url(),
+            '++add++opengever.meeting.proposal',
+            '++widget++form.widgets.proposal_document',
+            '@@contenttree-fetch',
+        ))
+        browser.open(
+            contenttree_url,
+            headers={'Content-Type': 'application/x-www-form-urlencoded'},
+            data=formdata.urlencode({'href': '/'.join(self.dossier.getPhysicalPath()), 'rel': 0}),
+        )
+        expected_documents = [u'Initialvertrag f\xfcr Bearbeitung', u'Vertr\xe4gsentwurf']
         self.assertEqual(expected_documents, browser.css('li').text)


### PR DESCRIPTION
Simply using the new metadata field does the trick.

Closes #5082 