### PR TITLE
Set \emergencystretch to 3em in latex templates.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,7 @@ Changelog
 
 - Fix bug in Windows8/10 and IE11/Edge: Select a task-reminder option will now properly stop spinning. [elioschmutz]
 - Show the task-reminder selector spinner directly and not only on long-requests to remove complexity. [elioschmutz]
+- Set \emergencystretch to 3em in latex templates. [njohner]
 - Update schemas in API documentation to include "changed". [njohner]
 - Ignore unauthorized traversal request in the response forms. [phgross]
 - Don't display the reminder selector on tasks where it would not work. [Rotonen]

--- a/opengever/latex/layouts/resources/default_layout.tex
+++ b/opengever/latex/layouts/resources/default_layout.tex
@@ -9,6 +9,12 @@
 <%block name="beneath_packages">
 </%block>
 
+%% TYPESETTING
+%%%% This allows latex to distribute 3em more of white space on a line
+%%%% when it cannot split it in a satisfying way, this is notably
+%%%% usefull as titles often contain long numbers
+\setlength\emergencystretch{3em}
+
 %% TEXT / PARAGRAPHS
 \renewcommand{\familydefault}{ma1}
 \parindent=0pt


### PR DESCRIPTION
This change allows latex to distribute 3em more of white space on a line when it cannot split it in a satisfying way, this is notably useful as titles often contain long numbers.

According to my tests the current setting should always work for numbers up to 10 digits. For longer numbers we can lines that extend over the margin or sheet. I feel like that is pretty reasonable, though we could obviously crank that up to some larger value, but then there is the risk of obtaining lines typeset with a lot of space.

Another possibility would be to redefine the titles to be `raggedright`, in the case of a section title as in the issue (#5123 ):
```
\titleformat*{\section}{\bf\Large\filright}
```
I think the generic solution should do though.

resolves #5123 