### PR TITLE
Correctly handle containing_dossier, containing_subdossier and is_subdossier indices.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ---------------------
 
 - Remove plonetheme.teamraum upgradesteps. [phgross]
+- Correctly update containing_dossier and containing_subdossier indexes. [njohner]
 - Bump docxcompose to 1.0.0a15 for bugfixes. [deiferni]
 - Set changed date on ObjectAdded instead of ObjectCreatedEvent. [phgross]
 - Translate z3c.formwidget.query (nothing). [njohner]

--- a/opengever/core/upgrades/20181219103543_reindex_containing_dossier_or_subdossier_indices/upgrade.py
+++ b/opengever/core/upgrades/20181219103543_reindex_containing_dossier_or_subdossier_indices/upgrade.py
@@ -1,0 +1,39 @@
+from ftw.upgrade import UpgradeStep
+from opengever.dossier.interfaces import IDossierMarker
+
+
+TYPES_WITH_CONTAINING_DOSSIER_INDEX = ('opengever.dossier.businesscasedossier',
+                                       'opengever.meeting.proposal',
+                                       'opengever.workspace.folder',
+                                       'opengever.document.document',
+                                       'opengever.task.task',
+                                       'opengever.private.dossier',
+                                       'ftw.mail.mail',
+                                       'opengever.meeting.meetingdossier',
+                                       'opengever.workspace.workspace')
+
+TYPES_WITH_CONTAINING_SUBDOSSIER_INDEX = ('opengever.document.document',
+                                          'opengever.task.task',
+                                          'ftw.mail.mail')
+
+
+class ReindexContainingDossierOrSubdossierIndices(UpgradeStep):
+    """Reindex containing_dossier, containing_subdossier and
+    is_subdossier indices.
+    """
+
+    deferrable = True
+
+    def __call__(self):
+        message = "Ensure containing_dossier, containing_subdossier and "
+        message += "is_subdossier are properly indexed on all objects"
+
+        for obj in self.objects({'portal_type': TYPES_WITH_CONTAINING_DOSSIER_INDEX}, message):
+            if IDossierMarker.providedBy(obj):
+                obj.reindexObject(idxs=["is_subdossier", "containing_dossier"])
+
+            elif obj.portal_type in TYPES_WITH_CONTAINING_SUBDOSSIER_INDEX:
+                obj.reindexObject(idxs=["is_subdossier", "containing_dossier",
+                                        "containing_subdossier"])
+            else:
+                obj.reindexObject(idxs=["containing_dossier"])

--- a/opengever/dossier/configure.zcml
+++ b/opengever/dossier/configure.zcml
@@ -145,16 +145,6 @@
       />
 
   <adapter
-      factory=".indexers.isSubdossierIndexer"
-      name="is_subdossier"
-      />
-
-  <adapter
-      factory=".indexers.is_subdossier_dossiertemplate"
-      name="is_subdossier"
-      />
-
-  <adapter
       factory=".indexers.external_reference"
       name="external_reference"
       />

--- a/opengever/dossier/configure.zcml
+++ b/opengever/dossier/configure.zcml
@@ -216,12 +216,6 @@
 
   <subscriber
       for="opengever.dossier.behaviors.dossier.IDossierMarker
-           zope.lifecycleevent.interfaces.IObjectMovedEvent"
-      handler=".handlers.reindex_is_subdossier"
-      />
-
-  <subscriber
-      for="opengever.dossier.behaviors.dossier.IDossierMarker
            opengever.sharing.interfaces.ILocalRolesAcquisitionBlocked"
       handler=".handlers.reindex_blocked_local_roles"
       />

--- a/opengever/dossier/configure.zcml
+++ b/opengever/dossier/configure.zcml
@@ -210,12 +210,6 @@
 
   <subscriber
       for="opengever.dossier.behaviors.dossier.IDossierMarker
-           zope.lifecycleevent.interfaces.IObjectModifiedEvent"
-      handler=".handlers.reindex_containing_dossier"
-      />
-
-  <subscriber
-      for="opengever.dossier.behaviors.dossier.IDossierMarker
            opengever.sharing.interfaces.ILocalRolesAcquisitionBlocked"
       handler=".handlers.reindex_blocked_local_roles"
       />

--- a/opengever/dossier/handlers.py
+++ b/opengever/dossier/handlers.py
@@ -131,12 +131,6 @@ def reindex_containing_dossier(dossier, event):
                     sync_task(brain.getObject(), event)
 
 
-def reindex_is_subdossier(dossier, event):
-    """Reindex the is_subdossier index after the dossier have been moved.
-    """
-    dossier.reindexObject(idxs=['is_subdossier'])
-
-
 def reindex_blocked_local_roles(dossier, event):
     """Reindex blocked_local_roles upon the acquisition blockedness changing."""
     dossier.reindexObject(idxs=['blocked_local_roles'])

--- a/opengever/dossier/indexers.py
+++ b/opengever/dossier/indexers.py
@@ -125,7 +125,7 @@ def containing_subdossier(obj):
     case an empty string is returned.
     """
     context = aq_inner(obj)
-    # Only compute for types that actually can be contained in a dossier
+    # Only compute for types for which we use the containing subdossier index
     if context.portal_type not in ['opengever.document.document',
                                    'opengever.task.task',
                                    'ftw.mail.mail']:

--- a/opengever/dossier/indexers.py
+++ b/opengever/dossier/indexers.py
@@ -78,9 +78,23 @@ def blocked_local_roles(obj):
     return bool(getattr(aq_inner(obj), '__ac_local_roles_block__', False))
 
 
+TYPES_WITH_CONTAINING_DOSSIER_INDEX = set(('opengever.dossier.businesscasedossier',
+                                           'opengever.meeting.proposal',
+                                           'opengever.workspace.folder',
+                                           'opengever.document.document',
+                                           'opengever.task.task',
+                                           'opengever.private.dossier',
+                                           'ftw.mail.mail',
+                                           'opengever.meeting.meetingdossier',
+                                           'opengever.workspace.workspace'))
+
+
 @indexer(IDexterityContent)
 def main_dossier_title(obj):
     """Return the title of the main dossier."""
+    if obj.portal_type not in TYPES_WITH_CONTAINING_DOSSIER_INDEX:
+        return None
+
     dossier = get_main_dossier(obj)
     if not dossier:
         return None
@@ -103,18 +117,21 @@ def main_dossier_title(obj):
     return title
 
 
+TYPES_WITH_CONTAINING_SUBDOSSIER_INDEX = ('opengever.document.document',
+                                          'opengever.task.task',
+                                          'ftw.mail.mail')
+
+
 @indexer(IDexterityContent)
 def containing_subdossier(obj):
     """Returns the title of the subdossier the object is contained in,
     unless it's contained directly in the root of a dossier, in which
     case an empty string is returned.
     """
-    context = aq_inner(obj)
-    # Only compute for types for which we use the containing subdossier index
-    if context.portal_type not in ['opengever.document.document',
-                                   'opengever.task.task',
-                                   'ftw.mail.mail']:
+    if obj.portal_type not in TYPES_WITH_CONTAINING_SUBDOSSIER_INDEX:
         return ''
+
+    context = aq_inner(obj)
 
     parent = context
     parent_dossier = None

--- a/opengever/dossier/indexers.py
+++ b/opengever/dossier/indexers.py
@@ -66,21 +66,6 @@ def responsibleIndexer(obj):
 
 
 @indexer(IDossierMarker)
-def isSubdossierIndexer(obj):
-    # TODO: should be replaced with the is_subdossier method
-    # from og.dossier.base.py
-    parent = aq_parent(aq_inner(obj))
-    if IDossierMarker.providedBy(parent):
-        return True
-    return False
-
-
-@indexer(IDossierTemplateMarker)
-def is_subdossier_dossiertemplate(obj):
-    return obj.is_subdossier()
-
-
-@indexer(IDossierMarker)
 def external_reference(obj):
     """Return the external reference of a dossier."""
     context = aq_inner(obj)


### PR DESCRIPTION
The `containing_dossier` and `containing_subdossier` indices were not updated when an object was copied or moved. As an `ObjectModifiedEvent` is fired for every object that is moved, i.e. when moving a container an event is fired for every contained object as well, we can simply handle this in an event registered for `IDexterityContent`.

We also move the reindexing of `is_subdossier` to this handler, to have everything at the same place.

The `containing_subdossier` index was updated when an object was modified, event when it's title was not changed, although `containing_dossier` was only updated when the title gets modified. We now update the indexes only when necessary.

This should fix the sorting issues on subdossiers, which seemed to stem from inconsistent data between the metadata and the index:
https://extranet.4teamwork.ch/support/gever-st-gallen/tracker/332
