### PR TITLE
Open notifications for resources on a foreign admin_unit in a new tab/window.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2018.5.0 (unreleased)
 ---------------------
 
+- Open notifications for resources on a foreign admin_unit in a new tab/window. [phgross]
 - Fix bug in Windows8/10 and IE11/Edge: Select a task-reminder option will now properly stop spinning. [elioschmutz]
 - Show the task-reminder selector spinner directly and not only on long-requests to remove complexity. [elioschmutz]
 - Set \emergencystretch to 3em in latex templates. [njohner]

--- a/opengever/activity/browser/views.py
+++ b/opengever/activity/browser/views.py
@@ -62,6 +62,13 @@ class NotificationView(BrowserView):
         response.setHeader('X-Theme-Disabled', 'True')
         return json.dumps(data)
 
+    def get_link_target(self, notification):
+        oguid =  notification.activity.resource.oguid
+        if oguid.is_on_current_admin_unit:
+            return '_self'
+
+        return '_blank'
+
     def dump_notifications(self, notifications):
         data = []
         for notification in notifications:
@@ -72,6 +79,7 @@ class NotificationView(BrowserView):
                 'created': notification.activity.created.astimezone(
                     pytz.UTC).isoformat(),
                 'link': resolve_notification_url(notification),
+                'target': self.get_link_target(notification),
                 'read': notification.is_read,
                 'id': notification.notification_id})
 

--- a/opengever/activity/browser/views.py
+++ b/opengever/activity/browser/views.py
@@ -63,7 +63,7 @@ class NotificationView(BrowserView):
         return json.dumps(data)
 
     def get_link_target(self, notification):
-        oguid =  notification.activity.resource.oguid
+        oguid = notification.activity.resource.oguid
         if oguid.is_on_current_admin_unit:
             return '_self'
 

--- a/opengever/activity/tests/test_views.py
+++ b/opengever/activity/tests/test_views.py
@@ -232,14 +232,14 @@ class TestListNotifications(FunctionalTestCase):
 
         browser.login().open(self.portal,
                              view="notifications/list",
-                             data={'batch_size': 7, 'page':2})
+                             data={'batch_size': 7, 'page': 2})
         self.assertEquals(
             u'http://nohost/plone/notifications/list?page=3&batch_size=7',
             browser.json.get('next_page'))
 
         browser.login().open(self.portal,
                              view="notifications/list",
-                             data={'batch_size': 7, 'page':3})
+                             data={'batch_size': 7, 'page': 3})
         self.assertEquals(None, browser.json.get('next_page'))
 
     @browsing

--- a/opengever/activity/viewlets/notification.pt
+++ b/opengever/activity/viewlets/notification.pt
@@ -23,7 +23,7 @@
                     <span>{{label}}</span>
                     <span class="timeago relativetime" title="{{created}}">{{created}}</span>
                   </div>
-                  <a class="notification-list-item-title" href="{{link}}">{{title}}</a>
+                  <a class="notification-list-item-title" target="{{target}}" href="{{link}}">{{title}}</a>
                   <div class="notification-list-item-summary">{{{summary}}}</div>
                 </span>
               </li>


### PR DESCRIPTION
In the same manner we do that for for all switching admin_unit links (tasks etc.) we open notification links for foreign resources in the notification viewlet in a new tab/window.