### PR TITLE
 Define solr version in versions.cfg

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -222,10 +222,6 @@ Extend the Solr configuration in your `buildout.cfg` and add the Solr directive:
         https://raw.githubusercontent.com/4teamwork/gever-buildouts/master/solr.cfg
     solr-port = 8983
 
-    [solr]
-    url = http://archive.apache.org/dist/lucene/solr/7.3.0/solr-7.3.0.tgz
-    md5sum = dfb6893fc656e14919df48ff654d38f2
-
 
 Buildout
 

--- a/versions.cfg
+++ b/versions.cfg
@@ -215,3 +215,7 @@ zc.buildout = 2.9.4
 zope.sqlalchemy = 0.7.7
 zope.testrunner = 4.8.1
 zptlint = 0.2.4
+
+[solr]
+url = http://archive.apache.org/dist/lucene/solr/7.3.1/solr-7.3.1.tgz
+md5sum = 042a6c0d579375be1a8886428f13755f


### PR DESCRIPTION
We want to define a specific SOLR version, which is tested and should be used for each specific GEVER versions. So I moved the definition in to the versions.cfg. 

It's still possible to change to solr version for a specific deployment, but it's no longer necessary to define the version in each buildout.