### PR TITLE
Make ReindexTaskPrincipalsInGlobalindex upgradestep more robust.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,7 @@ Changelog
 
 - Return review_state ID in API summaries and introduce a new review_state_label attribute instead. [phgross]
 - Fix quotation error and missing translations for task and dossier PDFs. [njohner]
+- Make ReindexTaskPrincipalsInGlobalindex upgradestep more robust. [phgross]
 
 
 2018.5.1 (2018-11-23)

--- a/opengever/core/upgrades/20181022104232_reindex_task_principals_in_globalindex/upgrade.py
+++ b/opengever/core/upgrades/20181022104232_reindex_task_principals_in_globalindex/upgrade.py
@@ -1,5 +1,8 @@
 from ftw.upgrade import UpgradeStep
 from opengever.task.task import ITask
+import logging
+
+logger = logging.getLogger('opengever.core')
 
 
 class ReindexTaskPrincipalsInGlobalindex(UpgradeStep):
@@ -10,4 +13,9 @@ class ReindexTaskPrincipalsInGlobalindex(UpgradeStep):
         query = {'object_provides': ITask.__identifier__}
         for task in self.objects(query, 'Reindex task principals'):
             sql_task = task.get_sql_object()
+            if not sql_task:
+                logger.warning(u'Reindexing of task {} has been skipped, SQL '
+                               u'representation is missing'.format(task))
+                continue
+
             sql_task.principals = task.get_principals()


### PR DESCRIPTION
Skip tasks where no representing sql task is stored in the globalindex. This situation should never happen and is something which should be visible in the validation scripts (https://github.com/4teamwork/opengever.maintenance/pull/149), but should not let the
upgrade fail.

So we skip and log a warning instead if a corresponding sql task is missing.