### PR TITLE
Fix dossier task and journal PDF latex conversion issues

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2018.5.2 (unreleased)
 ---------------------
 
-- Nothing changed yet.
+- Fix quotation error and missing translations for task and dossier PDFs. [njohner]
 
 
 2018.5.1 (2018-11-23)

--- a/opengever/activity/__init__.py
+++ b/opengever/activity/__init__.py
@@ -107,6 +107,8 @@ ACTIVITY_TRANSLATIONS = {
         'task-transition-planned-skipped', default=u'Task skipped'),
     'task-reminder': _(
         'task-reminder', default=u'Task reminder'),
+    'transition-add-subtask': _('transition-add-subtask', 'Subtask added'),
+    'transition-add-document': _('transition-add-document', 'Document added'),
     'forwarding-added': _(
         'forwarding-added', default=u'Forwarding added'),
     'forwarding-transition-accept': _(

--- a/opengever/activity/locales/de/LC_MESSAGES/opengever.activity.po
+++ b/opengever/activity/locales/de/LC_MESSAGES/opengever.activity.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-10-23 11:27+0000\n"
+"POT-Creation-Date: 2018-11-27 11:51+0000\n"
 "PO-Revision-Date: 2015-02-24 08:40+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -387,3 +387,13 @@ msgstr "Auftragnehmer"
 #: ./opengever/activity/digest.py
 msgid "title_daily_digest"
 msgstr "Tageszusammenfassung für ${username}"
+
+#. Default: "Document added"
+#: ./opengever/activity/__init__.py
+msgid "transition-add-document"
+msgstr "Dokument hinzugefügt"
+
+#. Default: "Subtask added"
+#: ./opengever/activity/__init__.py
+msgid "transition-add-subtask"
+msgstr "Unteraufgabe erstellt"

--- a/opengever/activity/locales/fr/LC_MESSAGES/opengever.activity.po
+++ b/opengever/activity/locales/fr/LC_MESSAGES/opengever.activity.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-10-23 11:27+0000\n"
+"POT-Creation-Date: 2018-11-27 11:51+0000\n"
 "PO-Revision-Date: 2017-12-03 16:14+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-activity/fr/>\n"
@@ -389,3 +389,13 @@ msgstr "mandataire"
 #: ./opengever/activity/digest.py
 msgid "title_daily_digest"
 msgstr "Résumé quotidien pour ${username}"
+
+#. Default: "Document added"
+#: ./opengever/activity/__init__.py
+msgid "transition-add-document"
+msgstr "Document ajouté"
+
+#. Default: "Subtask added"
+#: ./opengever/activity/__init__.py
+msgid "transition-add-subtask"
+msgstr "Sous-tâche ajoutée"

--- a/opengever/activity/locales/opengever.activity.pot
+++ b/opengever/activity/locales/opengever.activity.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-10-23 11:27+0000\n"
+"POT-Creation-Date: 2018-11-27 11:51+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -386,4 +386,14 @@ msgstr ""
 #. Default: "Daily Digest for ${username}"
 #: ./opengever/activity/digest.py
 msgid "title_daily_digest"
+msgstr ""
+
+#. Default: "Document added"
+#: ./opengever/activity/__init__.py
+msgid "transition-add-document"
+msgstr ""
+
+#. Default: "Subtask added"
+#: ./opengever/activity/__init__.py
+msgid "transition-add-subtask"
 msgstr ""

--- a/opengever/latex/dossierjournal.py
+++ b/opengever/latex/dossierjournal.py
@@ -68,6 +68,7 @@ class DossierJorunalLaTeXView(MakoLaTeXView):
                       mapping={'title': self.context.title,
                                'reference_number': self.context.get_reference_number()}),
                     context=self.request)
+        title = self.convert_plain(title)
 
         return {
             'label': title,

--- a/opengever/latex/dossierjournal.py
+++ b/opengever/latex/dossierjournal.py
@@ -62,13 +62,15 @@ class DossierJorunalLaTeXView(MakoLaTeXView):
         journal_listing = getMultiAdapter((self.context, self.request, self),
                                           ILaTexListing, name='journal')
 
+        title = translate(
+                    _('label_dossier_journal',
+                      default=u'Journal of dossier "${title} (${reference_number})"',
+                      mapping={'title': self.context.title,
+                               'reference_number': self.context.get_reference_number()}),
+                    context=self.request)
+
         return {
-            'label': translate(
-                _('label_dossier_journal',
-                  default=u'Journal of dossier ${title} (${reference_number})',
-                  mapping={'title': self.context.title,
-                           'reference_number': self.context.get_reference_number()}),
-                context=self.request),
+            'label': title,
             'listing': journal_listing.get_listing(self.get_journal_data())}
 
     def get_journal_data(self):

--- a/opengever/latex/dossiertasks.py
+++ b/opengever/latex/dossiertasks.py
@@ -50,7 +50,7 @@ class DossierTasksLaTeXView(MakoLaTeXView):
 
     template_directories = ['templates']
     template_name = 'dossiertasks.tex'
-    strftimestring = '%d.%m.%Y %H:%M'
+    strftimestring = '%d.%m.%Y'
 
     def get_render_arguments(self):
         self.layout.show_organisation = True

--- a/opengever/latex/dossiertasks.py
+++ b/opengever/latex/dossiertasks.py
@@ -63,6 +63,8 @@ class DossierTasksLaTeXView(MakoLaTeXView):
                                    'reference_number': self.context.get_reference_number()}),
                           context=self.request)
 
+        title = self.convert_plain(title)
+
         for task in tasks:
             task_history = getMultiAdapter((task, self.request, self),
                                            ILaTexListing, name='task-history')
@@ -77,15 +79,16 @@ class DossierTasksLaTeXView(MakoLaTeXView):
             if deadline:
                 deadline = deadline.strftime(self.strftimestring)
 
-            task_data_list.append({'title': task.title,
-                                   'description': task.text or "",
-                                   'sequence_number': task.get_sequence_number(),
-                                   'type': task.get_task_type_label(),
-                                   'completion_date': completion_date,
-                                   'deadline': deadline,
-                                   'responsible': task.get_responsible_actor().get_label(),
-                                   'issuer': task.get_issuer_actor().get_label(),
-                                   'history': task_history.get_listing(response_container)})
+            task_data_list.append(
+              {'title': self.convert_plain(task.title),
+               'description': self.convert_plain(task.text or ""),
+               'sequence_number': task.get_sequence_number(),
+               'type': self.convert_plain(task.get_task_type_label()),
+               'completion_date': completion_date,
+               'deadline': deadline,
+               'responsible': self.convert_plain(task.get_responsible_actor().get_label()),
+               'issuer': self.convert_plain(task.get_issuer_actor().get_label()),
+               'history': task_history.get_listing(response_container)})
 
         return {'task_data_list': task_data_list,
                 'label': title}

--- a/opengever/latex/locales/de/LC_MESSAGES/opengever.latex.po
+++ b/opengever/latex/locales/de/LC_MESSAGES/opengever.latex.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-11-14 15:33+0000\n"
+"POT-Creation-Date: 2018-11-27 12:37+0000\n"
 "PO-Revision-Date: 2013-11-19 16:25+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -49,10 +49,10 @@ msgstr "Dokumentdatum"
 msgid "label_documents"
 msgstr "Dokumente"
 
-#. Default: "Journal of dossier ${title} (${reference_number})"
+#. Default: "Journal of dossier \"${title} (${reference_number})\""
 #: ./opengever/latex/dossierjournal.py
 msgid "label_dossier_journal"
-msgstr "Journal zu Dossier ${title} (${reference_number})"
+msgstr "Journal zu Dossier \"${title} (${reference_number})\""
 
 #. Default: "Task list for dossier \"${title} (${reference_number})\""
 #: ./opengever/latex/dossiertasks.py

--- a/opengever/latex/locales/fr/LC_MESSAGES/opengever.latex.po
+++ b/opengever/latex/locales/fr/LC_MESSAGES/opengever.latex.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-11-14 15:33+0000\n"
+"POT-Creation-Date: 2018-11-27 12:37+0000\n"
 "PO-Revision-Date: 2017-12-03 09:48+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-latex/fr/>\n"
@@ -51,10 +51,10 @@ msgstr "Date du document"
 msgid "label_documents"
 msgstr "Documents"
 
-#. Default: "Journal of dossier ${title} (${reference_number})"
+#. Default: "Journal of dossier \"${title} (${reference_number})\""
 #: ./opengever/latex/dossierjournal.py
 msgid "label_dossier_journal"
-msgstr "Journal du dossier ${title} (${reference_number})"
+msgstr "Journal du dossier \"${title} (${reference_number})\""
 
 #. Default: "Task list for dossier \"${title} (${reference_number})\""
 #: ./opengever/latex/dossiertasks.py

--- a/opengever/latex/locales/opengever.latex.pot
+++ b/opengever/latex/locales/opengever.latex.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-11-14 15:33+0000\n"
+"POT-Creation-Date: 2018-11-27 12:37+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -52,7 +52,7 @@ msgstr ""
 msgid "label_documents"
 msgstr ""
 
-#. Default: "Journal of dossier ${title} (${reference_number})"
+#. Default: "Journal of dossier \"${title} (${reference_number})\""
 #: ./opengever/latex/dossierjournal.py
 msgid "label_dossier_journal"
 msgstr ""

--- a/opengever/latex/tests/test_dossierjournal.py
+++ b/opengever/latex/tests/test_dossierjournal.py
@@ -43,7 +43,7 @@ class TestJournalListingLaTeXView(FunctionalTestCase):
             (dossier, dossier.REQUEST, layout), ILaTeXView)
 
         self.assertEquals(
-            u'Journal of dossier Anfr\xf6gen 2015 (Client1 / 1)',
+            'Journal of dossier "`Anfr\xc3\xb6gen 2015 (Client1 / 1)"\'',
             dossier_journal.get_render_arguments().get('label'))
 
     @browsing

--- a/opengever/latex/tests/test_dossiertasks.py
+++ b/opengever/latex/tests/test_dossiertasks.py
@@ -45,7 +45,7 @@ class TestDossierTasksLaTeXView(FunctionalTestCase):
                 (dossier, dossier.REQUEST, layout), ILaTeXView)
 
             self.assertEquals(
-                u'Task list for dossier "Anfr\xf6gen 2015 (Client1 / 1)"',
+                'Task list for dossier "`Anfr\xc3\xb6gen 2015 (Client1 / 1)"\'',
                 dossier_tasks.get_render_arguments().get('label'))
 
     @browsing
@@ -86,22 +86,22 @@ class TestDossierTasksLaTeXView(FunctionalTestCase):
                                            ILaTeXView)
             self.assertEquals([task1, task2], dossiertasks.get_tasks())
 
-            expected = {'label': u'Task list for dossier "Anfr\xf6gen 2015 (Client1 / 1)"',
-                        'task_data_list': [{'completion_date': completion_date.strftime('%d.%m.%Y %H:%M'),
-                                            'deadline': expected_deadline.strftime('%d.%m.%Y %H:%M'),
+            expected = {'label': 'Task list for dossier "`Anfr\xc3\xb6gen 2015 (Client1 / 1)"\'',
+                        'task_data_list': [{'completion_date': completion_date.strftime('%d.%m.%Y'),
+                                            'deadline': expected_deadline.strftime('%d.%m.%Y'),
                                             'description': '',
                                             'history': None,
-                                            'responsible': u'Test User (test_user_1_)',
-                                            'issuer': u'admin (admin)',
+                                            'responsible': 'Test User (test\\_user\\_1\\_)',
+                                            'issuer': 'admin (admin)',
                                             'sequence_number': 1,
                                             'title': 'task 1',
                                             'type': ''},
                                            {'completion_date': None,
-                                            'deadline': expected_deadline.strftime('%d.%m.%Y %H:%M'),
+                                            'deadline': expected_deadline.strftime('%d.%m.%Y'),
                                             'description': '',
                                             'history': None,
-                                            'responsible': u'Test User (test_user_1_)',
-                                            'issuer': u'Test User (test_user_1_)',
+                                            'responsible': 'Test User (test\\_user\\_1\\_)',
+                                            'issuer': 'Test User (test\\_user\\_1\\_)',
                                             'sequence_number': 2,
                                             'title': 'task 2',
                                             'type': ''}]}


### PR DESCRIPTION
* For both the dossier task PDF and the dossier journal PDF, only the listings were processed by the `ftw.pdfgenerator.html2latex.converter.HTML2LatexConverter`, the other rendered arguments, such as the title of the generated file, were not being processed. This could lead to issues, notably with quotes (Latex uses special opening and closing quotes). This is now corrected.
* I also adapted the title of the dossier journal, to match the one of the dossier task pdf, quoting the dossier title in the title of the PDF.
* There were missing translations for `transition-add-subtask` and `transition-add-document`
* I changed the dateformat for the `deadline` and `completion_date`, not displaying the time anymore, as these are `date` and not `datetime` fields.

**Before we dossier or task titles starting with an `S` would lead to problems because of how latex interpreted `"S`. Moreover we showed the time for the different dates.**
<img width="917" alt="screen shot 2018-11-27 at 14 35 16" src="https://user-images.githubusercontent.com/7374243/49085411-3e399000-f252-11e8-87e0-1339dfbfa84d.png">


**Now quotation works as expected in the document title and task titles, and we do not show times anymore for the date fields.**
<img width="919" alt="screen shot 2018-11-27 at 14 30 05" src="https://user-images.githubusercontent.com/7374243/49085418-41348080-f252-11e8-9a04-8676f63f1095.png">

**Conversion was also forgotten for dossier journal PDF title, but this was not apparent as we did not have the quotes around the title there. It could nevertheless lead to issues for example for a title containing quotes. This now works as expected**
<img width="916" alt="screen shot 2018-11-27 at 14 31 59" src="https://user-images.githubusercontent.com/7374243/49085577-9d97a000-f252-11e8-975a-ee142908248c.png">

**Missing translations led to `transition-add-document` and `transition-add-subtask`. These now appear correctly.**
<img width="919" alt="screen shot 2018-11-27 at 14 30 30" src="https://user-images.githubusercontent.com/7374243/49085620-b607ba80-f252-11e8-93af-664ec3a98f83.png">

<img width="919" alt="screen shot 2018-11-27 at 14 30 19" src="https://user-images.githubusercontent.com/7374243/49085633-bc963200-f252-11e8-9c6f-9a4eead1f760.png">

This resolves https://basecamp.com/2768704/projects/12554551/todos/372453117
