### PR TITLE
 Show one line of each of title and description in livesearch result

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -8,6 +8,7 @@ Changelog
 - Return review_state ID in API summaries and introduce a new review_state_label attribute instead. [phgross]
 - Fix quotation error and missing translations for task and dossier PDFs. [njohner]
 - Make ReindexTaskPrincipalsInGlobalindex upgradestep more robust. [phgross]
+- Show one line of each title and description in livesearch result. [njohner]
 
 
 2018.5.1 (2018-11-23)

--- a/opengever/advancedsearch/skins/advancedsearch_resources/livesearch_reply.py
+++ b/opengever/advancedsearch/skins/advancedsearch_resources/livesearch_reply.py
@@ -180,19 +180,20 @@ else:
         if mime_type_klass:
             css_klass = mime_type_klass
 
-        write('''<a href="%s" title="%s" class="dropdown-list-item LSRow"><span class="%s"/><div>%s</div>'''
-              % (itemUrl, title, css_klass, title))
-        description = html_quote(safe_unicode(result.Description))
+        write('''<a href="%s" title="%s" class="dropdown-list-item LSRow">''' % (itemUrl, title))
+        write('''<span class="%s"/><span class="dropdown-list-item-content">''' % (css_klass))
+        write('''<div class="LSTitle">%s</div>''' % (title))
 
+        description = html_quote(safe_unicode(result.Description))
         write('''<div class="LSDescr">%s</div>''' % (description))
-        write('''</a>''')
+        write('''</span></a>''')
         title, description = None, None
     write('''</ul>''')
 
     write('''<div class="dropdown-list-footer LSRow">''')
     write('<a href="%s" class="dropdown-list-item">%s</a>' %
-         (portal_url + '/advanced_search?SearchableText=%s' % searchurlparameter,
-          ts.translate(label_advanced_search, context=REQUEST)))
+          (portal_url + '/advanced_search?SearchableText=%s' % searchurlparameter,
+           ts.translate(label_advanced_search, context=REQUEST)))
 
     if len(results) > limit:
         # add a more... row

--- a/opengever/advancedsearch/skins/advancedsearch_resources/livesearch_reply.py
+++ b/opengever/advancedsearch/skins/advancedsearch_resources/livesearch_reply.py
@@ -30,8 +30,6 @@ if siteProperties is not None:
 
 # SIMPLE CONFIGURATION
 USE_ICON = True
-MAX_TITLE = 29
-MAX_DESCRIPTION = 93
 
 # generate a result set for the query
 catalog = context.portal_catalog
@@ -175,14 +173,7 @@ else:
 
         itemUrl = itemUrl + searchterm_query
 
-        full_title = safe_unicode(pretty_title_or_id(result))
-        if len(full_title) > MAX_TITLE:
-            display_title = ''.join((full_title[:MAX_TITLE], '...'))
-        else:
-            display_title = full_title
-
-        full_title = html_quote(full_title)
-        display_title = html_quote(display_title)
+        title = html_quote(safe_unicode(pretty_title_or_id(result)))
 
         css_klass = 'contenttype-%s' % ploneUtils.normalizeString(result.portal_type)
         mime_type_klass = get_mimetype_icon_klass(result)
@@ -190,16 +181,12 @@ else:
             css_klass = mime_type_klass
 
         write('''<a href="%s" title="%s" class="dropdown-list-item LSRow"><span class="%s"/><div>%s</div>'''
-              % (itemUrl, full_title, css_klass, display_title))
-        display_description = safe_unicode(result.Description)
-        if len(display_description) > MAX_DESCRIPTION:
-            display_description = ''.join((display_description[:MAX_DESCRIPTION], '...'))
+              % (itemUrl, title, css_klass, title))
+        description = html_quote(safe_unicode(result.Description))
 
-        # need to quote it, to avoid injection of html containing javascript and other evil stuff
-        display_description = html_quote(display_description)
-        write('''<div class="LSDescr">%s</div>''' % (display_description))
+        write('''<div class="LSDescr">%s</div>''' % (description))
         write('''</a>''')
-        full_title, display_title, display_description = None, None, None
+        title, description = None, None
     write('''</ul>''')
 
     write('''<div class="dropdown-list-footer LSRow">''')

--- a/opengever/base/browser/livesearch.py
+++ b/opengever/base/browser/livesearch.py
@@ -113,12 +113,14 @@ class LiveSearchReplyView(BrowserView):
 
                 css_klass = get_mimetype_icon_klass(result.doc)
 
-                write('''<a href="%s" title="%s" class="dropdown-list-item LSRow">
-                         <span class="%s"/><div>%s</div></a>''' % (itemUrl, title, css_klass, title))
+                write('''<a href="%s" title="%s" class="dropdown-list-item LSRow">''' % (itemUrl, title))
+                write('''<span class="%s"/><span class="dropdown-list-item-content">''' % (css_klass))
+                write('''<div class="LSTitle">%s</div>''' % (title))
+
                 description = html_quote(safe_unicode(result.Description()) or u'')
 
                 write('''<div class="LSDescr">%s</div>''' % (description))
-                write('''</a>''')
+                write('''</span></a>''')
                 title, description = None, None
             write('''</ul>''')
 

--- a/opengever/base/browser/livesearch.py
+++ b/opengever/base/browser/livesearch.py
@@ -58,10 +58,11 @@ class LiveSearchReplyView(BrowserView):
             filters.append(u'path_parent:%s' % escape(self.path))
         params = {
             'fl': [
-                'UID', 'id', 'Title', 'getIcon', 'portal_type', 'path',
+                'UID', 'id', 'Title', 'getIcon', 'portal_type', 'path', 'Description'
             ],
 
         }
+
         resp = solr.search(
             query=query, filters=filters, rows=self.limit, **params)
         return resp

--- a/opengever/base/browser/livesearch.py
+++ b/opengever/base/browser/livesearch.py
@@ -15,8 +15,6 @@ from zope.component import getUtility
 
 
 USE_ICON = True
-MAX_TITLE = 29
-MAX_DESCRIPTION = 93
 
 
 # https://github.com/4teamwork/opengever.core/blob/master/opengever/base/browser/helper.py#L20
@@ -111,28 +109,17 @@ class LiveSearchReplyView(BrowserView):
 
                 itemUrl = itemUrl + u'?SearchableText=%s' % url_quote_plus(self.search_term)
 
-                full_title = safe_unicode(result.Title())
-                if len(full_title) > MAX_TITLE:
-                    display_title = ''.join((full_title[:MAX_TITLE], '...'))
-                else:
-                    display_title = full_title
-
-                full_title = html_quote(full_title)
-                display_title = html_quote(display_title)
+                title = html_quote(safe_unicode(result.Title()))
 
                 css_klass = get_mimetype_icon_klass(result.doc)
 
                 write('''<a href="%s" title="%s" class="dropdown-list-item LSRow">
-                         <span class="%s"/><div>%s</div></a>''' % (itemUrl, full_title, css_klass, display_title))
-                display_description = safe_unicode(result.Description()) or u''
-                if len(display_description) > MAX_DESCRIPTION:
-                    display_description = ''.join((display_description[:MAX_DESCRIPTION], '...'))
+                         <span class="%s"/><div>%s</div></a>''' % (itemUrl, title, css_klass, title))
+                description = html_quote(safe_unicode(result.Description()) or u'')
 
-                # need to quote it, to avoid injection of html containing javascript and other evil stuff
-                display_description = html_quote(display_description)
-                write('''<div class="LSDescr">%s</div>''' % (display_description))
+                write('''<div class="LSDescr">%s</div>''' % (description))
                 write('''</a>''')
-                full_title, display_title, display_description = None, None, None
+                title, description = None, None
             write('''</ul>''')
 
             write('''<div class="dropdown-list-footer LSRow">''')

--- a/plonetheme/teamraum/resources/css/main.css
+++ b/plonetheme/teamraum/resources/css/main.css
@@ -465,10 +465,21 @@ fieldset.livesearchContainer {
   display: none;
 }
 
+#LSResult .dropdown-list-item-content {
+  width: 410px;
+  flex-flow: row wrap;
+  flex-grow: unset;
+}
 
 #LSResult .LSDescr {
   font-size: 91.6667%;
   color: #666;
+}
+
+#LSResult .LSDescr,
+#LSResult .LSTitle {
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 #LSParseErrors {


### PR DESCRIPTION
* We improve the livesearch result display. We now show one line of the title and one line of the description. Both are truncated if necessary and an ellipsis is added if they are truncated.
* Instead of truncating them in the python code, we now do this in css.
* There was also an issue with solr, where the description would not be displayed. This has now been fixed (we forgot to get the description field in the request to solr).

Here a snapshot on IE.

<img width="1284" alt="screen shot 2018-11-27 at 16 50 54" src="https://user-images.githubusercontent.com/7374243/49102161-5e7c4580-f278-11e8-9e0b-750b165e6a9d.png">
