### PR TITLE
 Fix bug in favorites to support objects with long titles.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2018.5.2 (unreleased)
 ---------------------
 
+- Fix bug in favorites to support objects with long titles. [njohner]
 - Return review_state ID in API summaries and introduce a new review_state_label attribute instead. [phgross]
 - Fix quotation error and missing translations for task and dossier PDFs. [njohner]
 - Make ReindexTaskPrincipalsInGlobalindex upgradestep more robust. [phgross]

--- a/opengever/base/favorite.py
+++ b/opengever/base/favorite.py
@@ -27,10 +27,11 @@ class FavoriteManager(object):
         create_session().delete(favorite)
 
     def add(self, userid, obj):
+        truncated_title = Favorite.truncate_title(obj.Title().decode('utf-8'))
         favorite = Favorite(
             userid=userid,
             oguid=Oguid.for_object(obj),
-            title=obj.Title().decode('utf-8'),
+            title=truncated_title,
             portal_type=obj.portal_type,
             icon_class=get_css_class(obj),
             plone_uid=IUUID(obj),

--- a/opengever/base/handlers.py
+++ b/opengever/base/handlers.py
@@ -107,7 +107,7 @@ def update_favorites_title(context, event):
         query = Favorite.query.filter(
             and_(Favorite.oguid == Oguid.for_object(context),
                  Favorite.is_title_personalized == False))  # noqa
-        query.update({'title': context.title})
+        query.update_title(context.title)
 
         mark_changed(create_session())
 

--- a/opengever/base/model/favorite.py
+++ b/opengever/base/model/favorite.py
@@ -11,6 +11,7 @@ from opengever.ogds.models import UNIT_ID_LENGTH
 from opengever.ogds.models import USER_ID_LENGTH
 from opengever.ogds.models.admin_unit import AdminUnit
 from opengever.ogds.models.query import BaseQuery
+from Products.CMFPlone.utils import safe_unicode
 from sqlalchemy import and_
 from sqlalchemy import Boolean
 from sqlalchemy import Column
@@ -83,6 +84,10 @@ class Favorite(Base):
         admin_unit = AdminUnit.query.get(self.admin_unit_id)
         return u'{}/resolve_oguid/{}'.format(admin_unit.public_url, self.oguid)
 
+    @staticmethod
+    def truncate_title(title):
+        return safe_unicode(title)[:CONTENT_TITLE_LENGTH]
+
 
 class FavoriteQuery(BaseQuery):
 
@@ -110,6 +115,10 @@ class FavoriteQuery(BaseQuery):
         query = query.filter_by(
             portal_type='opengever.repository.repositoryfolder')
         return query.filter_by(admin_unit_id=admin_unit_id)
+
+    def update_title(self, new_title):
+        truncated_title = Favorite.truncate_title(new_title)
+        self.update({'title': truncated_title})
 
 
 Favorite.query_cls = FavoriteQuery

--- a/opengever/base/tests/test_favorite.py
+++ b/opengever/base/tests/test_favorite.py
@@ -1,6 +1,8 @@
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
+from opengever.base.favorite import FavoriteManager
+from opengever.base.model import CONTENT_TITLE_LENGTH
 from opengever.base.model import create_session
 from opengever.base.model.favorite import Favorite
 from opengever.base.oguid import Oguid
@@ -65,6 +67,24 @@ class TestFavoriteModel(IntegrationTestCase):
             Favorite.query.is_marked_as_favorite(self.dossier, self.regular_user))
 
 
+class TestManager(IntegrationTestCase):
+
+    @browsing
+    def test_titles_of_favorites_get_truncated_on_creation(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        browser.open(self.dossier, view='edit')
+        long_title = u''.join(u"\xe4" for i in range(400))
+        browser.fill({u'Title': long_title})
+        browser.click_on('Save')
+
+        manager = FavoriteManager()
+        fav = manager.add(self.regular_user.getId(), self.dossier)
+
+        self.assertEquals(long_title[:CONTENT_TITLE_LENGTH],
+                          Favorite.query.get(fav.favorite_id).title)
+
+
 class TestHandlers(IntegrationTestCase):
 
     def test_all_favorites_are_deleted_when_removing_object(self):
@@ -102,7 +122,7 @@ class TestHandlers(IntegrationTestCase):
         self.assertEquals(1, Favorite.query.count())
 
     @browsing
-    def test_titled_of_favorites_get_updated(self, browser):
+    def test_titles_of_favorites_get_updated(self, browser):
         self.login(self.regular_user, browser=browser)
 
         fav1 = create(Builder('favorite')
@@ -126,6 +146,25 @@ class TestHandlers(IntegrationTestCase):
         self.assertEquals('GEVER Weeklies',
                           Favorite.query.get(fav1.favorite_id).title)
         self.assertEquals(u'Anfragen 2018', Favorite.query.get(fav2.favorite_id).title)
+
+    @browsing
+    def test_titles_of_favorites_get_truncated_on_update(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        fav = create(Builder('favorite')
+                     .for_object(self.dossier)
+                     .for_user(self.regular_user))
+
+        self.assertEquals(
+            u'Vertr\xe4ge mit der kantonalen Finanzverwaltung', fav.title)
+
+        browser.open(self.dossier, view='edit')
+        long_title = u''.join(u"\xe4" for i in range(400))
+        browser.fill({u'Title': long_title})
+        browser.click_on('Save')
+
+        self.assertEquals(long_title[:CONTENT_TITLE_LENGTH],
+                          Favorite.query.get(fav.favorite_id).title)
 
     def test_icon_class_of_favorites_get_updated_on_checkin_checkout_document(self):
         self.login(self.administrator)

--- a/opengever/base/tests/test_favorite_action.py
+++ b/opengever/base/tests/test_favorite_action.py
@@ -1,8 +1,6 @@
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
-from opengever.base.model import create_session
-from opengever.base.model.favorite import Favorite
 from opengever.base.oguid import Oguid
 from opengever.base.viewlets.favorite_action import FavoriteETagValue
 from opengever.document.browser.tabbed import DocumentTabbedView
@@ -24,7 +22,6 @@ class TestFavoriteAction(IntegrationTestCase):
                           viewlet.get('data-oguid'))
         self.assertEquals('http://nohost/plone/@favorites/kathi.barfuss',
                           viewlet.get('data-url'))
-
 
     @browsing
     def test_favorite_action_respects_feature_flag(self, browser):

--- a/opengever/base/tests/test_favorite_menu.py
+++ b/opengever/base/tests/test_favorite_menu.py
@@ -1,11 +1,5 @@
-from ftw.builder import Builder
-from ftw.builder import create
 from ftw.testbrowser import browsing
-from opengever.base.model import create_session
-from opengever.base.model.favorite import Favorite
-from opengever.base.oguid import Oguid
 from opengever.testing import IntegrationTestCase
-from plone import api
 
 
 class TestFavoriteMenu(IntegrationTestCase):


### PR DESCRIPTION
Favorites only supported objects with titles shorter than 255 characters. This led to errors when trying to edit the title of such an object, or setting it as favorite. We now truncate the title to 255 characters in the favorites.

We could have added a validator in the model to truncate the title automatically when creating or modifying an `opengever.base.model.favorite.Favorite` object. But this would lead to silently truncating the title when a user sets a personalised title. 

Note that there is now some inconsistency in the `FavoriteManager` as the `add` method truncates the title of the object in the favorite, whereas the `update` methods throws an error when the passed title is too long. For now I think this behavior is ok, when the user sets the title for one of his favorites and the title is too long, he will get an error message. When creating a favorite, we do not choose its title, and it gets set properly by the manager (or the api).

I think we can make another issue to have another look at whether we want to handle this more cleanly.

resolves #5149