### PR TITLE
Fix file indexes upgradestep for deployments using solr.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ---------------------
 
 - Bump docxcompose to 1.0.0a14 for better handling of referenced parts. [deiferni]
+- Fix filesize, filename and file extension upgradestep for deployments using solr. [phgross]
 - Fix an issue with meeting template titles. [deiferni]
 
 

--- a/opengever/core/upgrades/20181101150743_add_document_filesize__filename_and_file_extension_to_document_metadata/upgrade.py
+++ b/opengever/core/upgrades/20181101150743_add_document_filesize__filename_and_file_extension_to_document_metadata/upgrade.py
@@ -10,12 +10,21 @@ class AddDocumentFilesize_filenameAndFileExtensionToDocumentMetadata(UpgradeStep
 
     def __call__(self):
         self.install_upgrade_profile()
-        self.catalog_add_index('filesize', 'FieldIndex')
-        self.catalog_add_index('file_extension', 'FieldIndex')
+
+        if not self.catalog_has_index('filesize'):
+            self.catalog_add_index('filesize', 'FieldIndex')
+
+        if not self.catalog_has_index('file_extension'):
+            self.catalog_add_index('file_extension', 'FieldIndex')
 
         query = {
             'object_provides': IBaseDocument.__identifier__,
             }
 
         for basedocument in self.objects(query, 'Index filesize, filename and file extension of IBaseDocument objects.'):
-            basedocument.reindexObject(idxs=['filesize', 'file_extension'])
+
+            # There is no index called filename, but we need to add it to the
+            # idxs list, to make sure that solr's filename index is indexed
+            # as well.
+            basedocument.reindexObject(
+                idxs=['filesize', 'file_extension', 'filename'])

--- a/solr-conf/managed-schema
+++ b/solr-conf/managed-schema
@@ -137,6 +137,9 @@
     <field name="dossier_review_state" type="string" indexed="true" stored="false" />
     <field name="email" type="string" indexed="true" stored="false" />
     <field name="end" type="pdate" indexed="true" stored="false" />
+    <field name="file_extension" type="string" indexed="true" stored="false" />
+    <field name="filename" type="string" indexed="true" stored="false" />
+    <field name="filesize" type="pint" indexed="true" stored="false" />
     <field name="firstname" type="string" indexed="true" stored="false" />
     <field name="is_subdossier" type="boolean" indexed="true" stored="false" />
     <field name="issuer" type="string" indexed="true" stored="false" />


### PR DESCRIPTION
The change from PR #5024 only added catalog indexes, but did not add corresponding indexes to the solr schema. So the upgradestep was useless for deployments with an enabled solr search or even worse it almost removed all solr data because of a curios behave of solr or ftw.solr (I'll investigate this behavior in a separate issue).

So I added the new indexes to the schema and fix the current upgradestep.

