### PR TITLE
Add missing changed index to solr and fix tabbedview helper fallback.

### DIFF
--- a/opengever/tabbedview/catalog_source.py
+++ b/opengever/tabbedview/catalog_source.py
@@ -63,8 +63,11 @@ class GeverCatalogTableSource(FilteredTableSourceMixin, CatalogTableSource):
             else:
                 sort += ' asc'
 
+        # Todo: modified be removed once the changed metadata is filled on
+        # all deployments.
+        # https://github.com/4teamwork/opengever.core/issues/4988
         fl = ['UID', 'getIcon', 'portal_type', 'path', 'id',
-              'bumblebee_checksum']
+              'bumblebee_checksum', 'modified']
         fl = fl + [c['column'] for c in self.config.columns if c['column']]
         params = {
             'fl': fl,

--- a/opengever/tabbedview/tests/test_catalog_source.py
+++ b/opengever/tabbedview/tests/test_catalog_source.py
@@ -85,7 +85,7 @@ class TestSolrSearch(IntegrationTestCase):
         self.assertEqual(
             self.solr.search.call_args[1]['fl'],
             ['UID', 'getIcon', 'portal_type', 'path', 'id',
-             'bumblebee_checksum', 'reference', 'Title']
+             'bumblebee_checksum', 'modified', 'reference', 'Title']
             )
 
     def test_solr_is_used_if_enabled_and_searchable_text(self):

--- a/solr-conf/managed-schema
+++ b/solr-conf/managed-schema
@@ -126,6 +126,7 @@
 
     <!-- GEVER specific fields -->
     <field name="bumblebee_checksum" type="string" indexed="false" stored="false" />
+    <field name="changed" type="pdate" indexed="true" stored="false" />
     <field name="checked_out" type="string" indexed="true" stored="false" />
     <field name="completed" type="pdate" indexed="true" stored="false" />
     <field name="containing_dossier" type="string" indexed="false" stored="false" />


### PR DESCRIPTION
-  Fix changed fallback in documents listings for solr documents. This fixes an Bug on document listings when filtering and solr is enabled (see https://sentry.4teamwork.ch/sentry/onegov-gever/issues/9683/).
- Added missing `changed` field to the solr schema 
-  Added tests which checks if solr conf contains all catlaog indexes, and metadata or are marked as catalog only. This should help to not forget the solr-conf when adding a new index/metadata



There is no upgradestep needed, we'll need to fix/reindex the existing solr installations manually.