### PR TITLE
Fix task revoking permissions on close/reassign

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,7 @@ Changelog
 
 - Fix typo in favorite error message. [njohner]
 - Only display .docx files as possible proposal documents. [Rotonen]
+- Fix task revoking permissions on close/reassign. [phgross]
 
 
 2018.5.4 (2018-12-06)

--- a/opengever/task/locales/de/LC_MESSAGES/opengever.task.po
+++ b/opengever/task/locales/de/LC_MESSAGES/opengever.task.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2018-10-16 07:48+0000\n"
+"POT-Creation-Date: 2018-12-10 07:42+0000\n"
 "PO-Revision-Date: 2015-02-17 18:41+0100\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -704,6 +704,16 @@ msgstr "Aufgabe erfolgreich neu zugewiesen. Sie sind nicht länger berechtigt au
 #: ./opengever/task/response_description.py
 msgid "msg_task_commented"
 msgstr "Kommentiert von ${user}"
+
+#. Default: "Review state successfully changed."
+#: ./opengever/task/response.py
+msgid "msg_transition_successful"
+msgstr "Status erfolgreich geändert."
+
+#. Default: "Review state successfully changed, you are no longer permitted to access the task."
+#: ./opengever/task/response.py
+msgid "msg_transition_successful_no_longer_permission_to_access"
+msgstr "Status erfolgreich geändert, Sie sind nicht länger berechtigt auf die Aufgabe zuzugreifen."
 
 msgid "mytasks"
 msgstr "Meine Aufgaben"

--- a/opengever/task/locales/fr/LC_MESSAGES/opengever.task.po
+++ b/opengever/task/locales/fr/LC_MESSAGES/opengever.task.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-10-16 07:48+0000\n"
+"POT-Creation-Date: 2018-12-10 07:42+0000\n"
 "PO-Revision-Date: 2017-12-03 11:47+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-task/fr/>\n"
@@ -706,6 +706,16 @@ msgstr "Tâche réassignée avec succès. Vous n’avez désormais plus accès �
 #: ./opengever/task/response_description.py
 msgid "msg_task_commented"
 msgstr "Commenté par ${user}"
+
+#. Default: "Review state successfully changed."
+#: ./opengever/task/response.py
+msgid "msg_transition_successful"
+msgstr "Statut modifié avec succès."
+
+#. Default: "Review state successfully changed, you are no longer permitted to access the task."
+#: ./opengever/task/response.py
+msgid "msg_transition_successful_no_longer_permission_to_access"
+msgstr "Statut modifié avec succès, vos droits d'accès à la tâche ont été révoqués."
 
 msgid "mytasks"
 msgstr "Mes tâches"

--- a/opengever/task/locales/opengever.task.pot
+++ b/opengever/task/locales/opengever.task.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2018-10-16 07:48+0000\n"
+"POT-Creation-Date: 2018-12-10 07:42+0000\n"
 "PO-Revision-Date: 2009-02-25 14:39+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -701,6 +701,16 @@ msgstr ""
 #. Default: "Commented by ${user}"
 #: ./opengever/task/response_description.py
 msgid "msg_task_commented"
+msgstr ""
+
+#. Default: "Review state successfully changed."
+#: ./opengever/task/response.py
+msgid "msg_transition_successful"
+msgstr ""
+
+#. Default: "Review state successfully changed, you are no longer permitted to access the task."
+#: ./opengever/task/response.py
+msgid "msg_transition_successful_no_longer_permission_to_access"
 msgstr ""
 
 msgid "mytasks"

--- a/opengever/task/localroles.py
+++ b/opengever/task/localroles.py
@@ -174,12 +174,6 @@ class LocalRolesSetter(object):
 
     def revoke_on_distinct_parent(self):
         distinct_parent = self.get_distinct_parent()
-        manager = RoleAssignmentManager(self.get_distinct_parent())
-        manager.clear(
-            ASSIGNMENT_VIA_TASK,
-            self.responsible_permission_identfier, self.task, reindex=False)
-        manager.clear(ASSIGNMENT_VIA_TASK_AGENCY,
-                      self.inbox_group_id, self.task, reindex=False)
 
         # We disabled reindexObjectSecurity and reindex the security manually
         # instead, to avoid reindexing all objects including all documents.
@@ -190,6 +184,13 @@ class LocalRolesSetter(object):
             object_provides=[IDossierMarker.__identifier__,
                              IProposal.__identifier__],
             path='/'.join(distinct_parent.getPhysicalPath()))]
+
+        manager = RoleAssignmentManager(distinct_parent)
+        manager.clear(
+            ASSIGNMENT_VIA_TASK,
+            self.responsible_permission_identfier, self.task, reindex=False)
+        manager.clear(ASSIGNMENT_VIA_TASK_AGENCY,
+                      self.inbox_group_id, self.task, reindex=False)
 
         for dossier in subdossiers:
             dossier.reindexObject(idxs=CatalogAware._cmf_security_indexes)

--- a/opengever/task/tests/test_response.py
+++ b/opengever/task/tests/test_response.py
@@ -5,6 +5,7 @@ from opengever.testing import IntegrationTestCase
 from persistent import Persistent
 from persistent.list import PersistentList
 from persistent.mapping import PersistentMapping
+from plone import api
 
 
 class TestTaskResponses(IntegrationTestCase):
@@ -45,3 +46,33 @@ class TestTaskResponseForm(IntegrationTestCase):
         browser.click_on('task-transition-in-progress-resolved')
 
         self.assertEquals([], info_messages())
+
+    @browsing
+    def test_redirects_to_task_if_user_has_access_rights(self, browser):
+        self.login(self.dossier_responsible, browser=browser)
+        browser.open(self.subtask, view='tabbedview_view-overview')
+        browser.click_on('task-transition-resolved-tested-and-closed')
+        browser.click_on('Save')
+
+        self.assertEquals(['Review state successfully changed.'],
+                          info_messages())
+        self.assertEquals(self.subtask, browser.context)
+
+    @browsing
+    def test_redirects_to_portal_if_user_has_no_longer_access_rights(self, browser):
+        self.login(self.administrator)
+
+        self.set_workflow_state('task-state-open', self.task_in_protected_dossier)
+        self.task_in_protected_dossier.task_type = 'information'
+        self.task_in_protected_dossier.sync()
+
+        self.login(self.regular_user, browser=browser)
+        browser.open(self.task_in_protected_dossier, view='tabbedview_view-overview')
+        browser.click_on('task-transition-open-tested-and-closed')
+        browser.click_on('Save')
+
+        self.assertEquals(
+            ['Review state successfully changed, you are no longer permitted '
+             'to access the task.'],
+            info_messages())
+        self.assertEquals(api.portal.get(), browser.context)


### PR DESCRIPTION
Avoid unauthorized raises, when current user loses the access rights on the dossier during task closing. The Unauthorized has been raised, because we revoked the permission and fetch the subdossiers afterwards, so the getObject on the brain raised the `Unauthorized`. I've fixed this by changing the order, first fetch all subdossiers and than revoke the permission on the main dossier.

Besides that I also implemented a fallback to the add response form, when the current users loses access rights. If that's the case we now redirect to the personal overview and show a corresponding statusmessage.

Backport needed: `2018.5`