### PR TITLE
Fix create zip for concurrent callback requests.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -8,6 +8,7 @@ Changelog
 - Fix typo in favorite error message. [njohner]
 - Only display .docx files as possible proposal documents. [Rotonen]
 - Fix task revoking permissions on close/reassign. [phgross]
+- Fix an issue with missing zip after concurrent demand callback requests. [deiferni]
 
 
 2018.5.4 (2018-12-06)

--- a/opengever/meeting/browser/resources/zip_export_app.js
+++ b/opengever/meeting/browser/resources/zip_export_app.js
@@ -52,7 +52,7 @@ function init() {
         }
 
         // poll for status
-        return this.requester.get(url)
+        return this.requester.post(url)
           .then(function (response) {
             if (response.data['is_finished']) {
               this.isFinished = true;


### PR DESCRIPTION
When callback requests arrive concurrently the they may not correctly see the amount of finished documents, so zip creation was not triggered all the time.

Thus we move triggering creating the zip file to the polling view. The polling view now uses `POST` as it will create content (the Zip).

The polling view should only be called once as the polling interval is quite long. It can also deal with two concurrent zip creations though and also does not create the zip again when a zip is already present.

Needs backport to `2018.5`.