### PR TITLE
Invalidate cached zip export app.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ---------------------
 
 - Add support for simple language codes in request language negotiation [lgraf]
+- Invalidate cached zip export app. [deiferni]
 - Fix typo in favorite error message. [njohner]
 - Only display .docx files as possible proposal documents. [Rotonen]
 - Fix task revoking permissions on close/reassign. [phgross]

--- a/opengever/meeting/browser/meetings/templates/demand_zip.pt
+++ b/opengever/meeting/browser/meetings/templates/demand_zip.pt
@@ -24,7 +24,7 @@
                            data-meetingurl view/meeting_url;">
       </span>
 
-      <script tal:attributes="src string:${here/portal_url}/++resource++opengever.meeting/zip_export_app.js" />
+      <script tal:attributes="src string:${here/portal_url}/++resource++opengever.meeting/zip_export_app.js?_v=1" />
 
       <hr />
 


### PR DESCRIPTION
The javascript file is being cached for 24h at the moment, we append a query string param to invalidate the cache and force a new download.

Needs backport to `2018.5.x`.

Will be tackled for all `Vue` apps in https://github.com/4teamwork/opengever.core/issues/5180, this is just a temporary fix for the zip_download app.