### PR TITLE
Set changed date on ObjectAdded instead of ObjectCreatedEvent.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ---------------------
 
 - Bump docxcompose to 1.0.0a15 for bugfixes. [deiferni]
+- Set changed date on ObjectAdded instead of ObjectCreatedEvent. [phgross]
 - Add description field to paragraph add form. [njohner]
 - Add support for simple language codes in request language negotiation [lgraf]
 - Invalidate cached zip export app. [deiferni]

--- a/opengever/base/configure.zcml
+++ b/opengever/base/configure.zcml
@@ -293,7 +293,7 @@
 
   <subscriber
       for="opengever.base.behaviors.changed.IChangedMarker
-           zope.lifecycleevent.interfaces.IObjectCreatedEvent"
+           zope.lifecycleevent.interfaces.IObjectAddedEvent"
       handler=".handlers.update_changed_date"
       />
 

--- a/opengever/base/handlers.py
+++ b/opengever/base/handlers.py
@@ -114,7 +114,7 @@ def update_favorites_title(context, event):
 
 """
 The 'changed' field is updated when an object is created
-(IObjectCreatedEvent) and generally when modified by a user
+(IObjectAddedEvent) and generally when modified by a user
 (IObjectModifiedEvent except when the object is simply reindexed).
 The field is also updated for workflow status changes and when a document
 is checked-in or reverted to an older version. See opengever/base/configure.zcml

--- a/opengever/base/tests/test_changed_date.py
+++ b/opengever/base/tests/test_changed_date.py
@@ -156,6 +156,17 @@ class TestChangedUpdateForDossier(TestChangedUpdateBase):
         self.assert_changed_value(self.subdossier, FREEZING_TIME)
         self.assert_changed_value(self.dossier, self.dossier_initial_changed)
 
+    def test_changed_is_set_when_copy_paste_an_dossier(self):
+        self.login(self.regular_user)
+
+        with freeze(FREEZING_TIME):
+            new_dossier = api.content.copy(
+                source=self.subdossier, target=self.leaf_repofolder)
+
+        self.assert_changed_value(new_dossier, FREEZING_TIME)
+        for obj in new_dossier.objectValues():
+            self.assert_changed_value(obj, FREEZING_TIME)
+
 
 class TestChangedUpdateForTask(TestChangedUpdateBase):
 


### PR DESCRIPTION
This fixes an issue when copy & pasting a dossier containing documents. The reason is, that object which raises the CreatedEvent or CopiedEvent (inherits from the CreatedEvent) aren't acquisition wrapped. This can lead to several issues, as example the copy & paste bug. Closes #5182 

IMHO the ObjectAdded which is fired when the object is added to the context, is the right thing to initialize the changed date.

Needs backport to `2018.5`