### PR TITLE
Port disposition tests to integration layer

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -514,6 +514,7 @@ Users
 .. <fixture:users>
 
 - ``self.administrator``: ``nicole.kohler``
+- ``self.archivist``: ``jurgen.fischer``
 - ``self.committee_responsible``: ``franzi.muller``
 - ``self.dossier_manager``: ``faivel.fruhling``
 - ``self.dossier_responsible``: ``robert.ziegler``
@@ -568,6 +569,7 @@ Objects
         - self.cancelled_meeting_dossier
         - self.closed_meeting_dossier
         - self.decided_meeting_dossier
+        - self.disposition
         - self.dossier
           - self.document
           - self.draft_proposal
@@ -600,6 +602,8 @@ Objects
           - self.meeting_document
           - self.meeting_task
             - self.meeting_subtask
+        - self.offered_dossier_to_archive
+        - self.offered_dossier_to_destroy
         - self.protected_dossier
           - self.protected_document
         - self.protected_dossier_with_task

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -13,6 +13,7 @@ Changelog
 - Add buttons for managers to get the toc json for meeting periods. [njohner]
 - Add absent members to the meeting protocolData. [njohner]
 - Add description field to paragraph add form. [njohner]
+- Port disposition tests to integration layer. [njohner]
 - Add support for simple language codes in request language negotiation [lgraf]
 - Fixed attaching mails to mail via Office Connector. [Rotonen]
 - Fix typo in favorite error message. [njohner]

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -13,6 +13,7 @@ Changelog
 - Add buttons for managers to get the toc json for meeting periods. [njohner]
 - Add absent members to the meeting protocolData. [njohner]
 - Add description field to paragraph add form. [njohner]
+- Fix bug in disposition ech0160 folder model. [njohner]
 - Port disposition tests to integration layer. [njohner]
 - Add support for simple language codes in request language negotiation [lgraf]
 - Fixed attaching mails to mail via Office Connector. [Rotonen]

--- a/opengever/bundle/sections/constructor.py
+++ b/opengever/bundle/sections/constructor.py
@@ -28,6 +28,7 @@ TYPES_WITHOUT_REFERENCE_NUMBER = (
     'opengever.task.task',
     'opengever.meeting.proposal',
     'opengever.meeting.submittedproposal',
+    'opengever.disposition.disposition',
 )
 
 

--- a/opengever/bundle/tests/test_oggbundle_pipeline.py
+++ b/opengever/bundle/tests/test_oggbundle_pipeline.py
@@ -290,7 +290,7 @@ class TestOggBundlePipeline(IntegrationTestCase):
         return self.assert_dossier_hanspeter_created(parent)
 
     def assert_dossier_peter_schneider_created(self, parent):
-        dossier_peter = parent.get('dossier-16')
+        dossier_peter = parent.get('dossier-18')
         self.assertEqual(
             u'Vreni Meier ist ein Tausendsassa',
             IDossier(dossier_peter).comments)
@@ -308,7 +308,7 @@ class TestOggBundlePipeline(IntegrationTestCase):
             index_data_for(dossier_peter)[GUID_INDEX_NAME])
 
     def assert_dossier_vreni_created(self, parent):
-        dossier = self.leaf_repofolder.get('dossier-18')
+        dossier = self.leaf_repofolder.get('dossier-20')
         self.assertEqual(u'Vreni Meier ist ein Tausendsassa',
                          IDossier(dossier).comments)
         self.assertEqual(tuple(), IDossier(dossier).keywords)
@@ -324,7 +324,7 @@ class TestOggBundlePipeline(IntegrationTestCase):
             index_data_for(dossier)[GUID_INDEX_NAME])
 
     def assert_dossier_hanspeter_created(self, parent):
-        dossier_peter = parent.get('dossier-17')
+        dossier_peter = parent.get('dossier-19')
         self.assertEqual(
             u'archival worthy',
             ILifeCycle(dossier_peter).archival_value)

--- a/opengever/disposition/ech0160/model/folder.py
+++ b/opengever/disposition/ech0160/model/folder.py
@@ -14,8 +14,8 @@ class Folder(object):
         toc.increment_folder_counter()
         self.path = os.path.join(base_path, self.name)
 
-        for dossier in dossier.dossiers.values():
-            self.folders.append(Folder(toc, dossier, self.path))
+        for subdossier in dossier.dossiers.values():
+            self.folders.append(Folder(toc, subdossier, self.path))
 
         for doc in dossier.documents.values():
             if doc.obj.archival_file or doc.obj.file:

--- a/opengever/disposition/tests/test_activities.py
+++ b/opengever/disposition/tests/test_activities.py
@@ -1,52 +1,23 @@
 from ftw.builder import Builder
 from ftw.builder import create
-from opengever.activity import notification_center
 from opengever.activity.model import Activity
 from opengever.activity.model import Resource
 from opengever.activity.roles import DISPOSITION_ARCHIVIST_ROLE
 from opengever.activity.roles import DISPOSITION_RECORDS_MANAGER_ROLE
 from opengever.base.behaviors.lifecycle import ARCHIVAL_VALUE_UNWORTHY
 from opengever.base.behaviors.lifecycle import ARCHIVAL_VALUE_WORTHY
-from opengever.core.testing import OPENGEVER_FUNCTIONAL_ACTIVITY_LAYER
-from opengever.ogds.base.actor import Actor
-from opengever.testing import FunctionalTestCase
+from opengever.base.behaviors.lifecycle import ILifeCycle
+from opengever.ogds.base.actor import ActorLookup
+from opengever.testing import IntegrationTestCase
 from plone import api
-from plone.app.testing import TEST_USER_ID
 
 
-class TestDispositionNotifications(FunctionalTestCase):
+class TestDispositionNotifications(IntegrationTestCase):
 
-    layer = OPENGEVER_FUNCTIONAL_ACTIVITY_LAYER
-
-    def setUp(self):
-        super(TestDispositionNotifications, self).setUp()
-
-        self.hugo = create(Builder('user')
-                           .named('Hugo', 'Boss')
-                           .with_roles('Contributor', 'Archivist'))
-        self.peter = create(Builder('user')
-                            .named('Peter', 'Boss')
-                            .with_roles('Contributor'))
-        self.hans = create(Builder('user')
-                           .named('Hans', 'Boss')
-                           .with_roles('Contributor', 'Archivist'))
-
-        self.center = notification_center()
-        self.actor_link = Actor.lookup(TEST_USER_ID).get_link()
+    features = ('activity', )
 
     def test_creator_and_all_archivist_are_registered_as_watchers(self):
-        acl_users = api.portal.get_tool('acl_users')
-        role_manager = acl_users.get('portal_role_manager')
-        role_manager.assignRoleToPrincipal(
-            'Archivist', self.org_unit.inbox_group.groupid)
-
-        create(Builder('ogds_user')
-               .id('peter.meier')
-               .having(firstname='peter', lastname='meier',
-                       email='meier@example.com')
-               .assign_to_org_units([self.org_unit])
-               .in_group(self.org_unit.inbox_group))
-
+        self.login(self.regular_user)
         create(Builder('disposition'))
 
         resource = Resource.query.one()
@@ -58,25 +29,27 @@ class TestDispositionNotifications(FunctionalTestCase):
             sub.watcher.actorid for sub in resource.subscriptions
             if sub.role == DISPOSITION_RECORDS_MANAGER_ROLE]
 
-        self.assertItemsEqual([TEST_USER_ID], records_manager_watchers)
-        self.assertItemsEqual(
-            [TEST_USER_ID, u'hugo.boss', u'hans.boss', u'peter.meier'],
-            archivist_watchers)
+        self.assertItemsEqual([self.regular_user.getId()], records_manager_watchers)
+        self.assertItemsEqual([self.archivist.getId()], archivist_watchers)
 
     def test_added_activity_is_recorded_when_a_disposition_is_created(self):
+        self.login(self.regular_user)
+        actor = ActorLookup(self.regular_user.getId()).lookup()
         create(Builder('disposition').titled(u'Angebot 13.49'))
 
         activity = Activity.query.one()
         self.assertEquals('disposition-added', activity.kind)
         self.assertEquals(
-            u'New disposition added by Test User on admin unit Admin Unit 1',
+            u'New disposition added by {} on admin unit Hauptmandant'.format(
+                actor.get_label(with_principal=False)),
             activity.summary)
         self.assertEquals(u'Disposition added', activity.label)
         self.assertIsNone(activity.description)
         self.assertEquals(u'Angebot 13.49', activity.title)
 
     def test_appraise_activity_is_recorded(self):
-        self.grant('Archivist')
+        self.login(self.archivist)
+        actor = ActorLookup(self.archivist.getId()).lookup()
         disposition = create(Builder('disposition'))
         api.content.transition(disposition,
                                transition='disposition-transition-appraise')
@@ -84,19 +57,18 @@ class TestDispositionNotifications(FunctionalTestCase):
         activity = Activity.query.all()[-1]
         self.assertEquals('disposition-transition-appraise', activity.kind)
         self.assertEquals(
-            u'Appraisal finalized by {}'.format(self.actor_link),
+            u'Appraisal finalized by {}'.format(actor.get_link()),
             activity.summary)
         self.assertEquals(u'disposition-transition-appraise', activity.label)
         self.assertIsNone(activity.description)
 
     def test_dispose_activity_is_recorded(self):
-        self.grant('Records Manager')
-        dossier = create(Builder('dossier')
-                         .as_expired()
-                         .having(archival_value=ARCHIVAL_VALUE_WORTHY))
+        self.login(self.records_manager)
+        actor = ActorLookup(self.records_manager.getId()).lookup()
+        ILifeCycle(self.expired_dossier).archival_value = ARCHIVAL_VALUE_WORTHY
 
         disposition = create(Builder('disposition')
-                             .having(dossiers=[dossier])
+                             .having(dossiers=[self.expired_dossier])
                              .in_state('disposition-state-appraised'))
         api.content.transition(disposition,
                                transition='disposition-transition-dispose')
@@ -104,18 +76,18 @@ class TestDispositionNotifications(FunctionalTestCase):
         activity = Activity.query.all()[-1]
         self.assertEquals('disposition-transition-dispose', activity.kind)
         self.assertEquals(
-            u'Disposition disposed for the archive by {}'.format(self.actor_link),
+            u'Disposition disposed for the archive by {}'.format(actor.get_link()),
             activity.summary)
         self.assertEquals(u'disposition-transition-dispose', activity.label)
         self.assertIsNone(activity.description)
 
     def test_appraised_to_close_activity_is_recorded(self):
-        self.grant('Records Manager')
-        dossier = create(Builder('dossier')
-                         .as_expired()
-                         .having(archival_value=ARCHIVAL_VALUE_UNWORTHY))
+        self.login(self.records_manager)
+        actor = ActorLookup(self.records_manager.getId()).lookup()
+        ILifeCycle(self.expired_dossier).archival_value = ARCHIVAL_VALUE_UNWORTHY
+
         disposition = create(Builder('disposition')
-                             .having(dossiers=[dossier])
+                             .having(dossiers=[self.expired_dossier])
                              .in_state('disposition-state-appraised'))
         api.content.transition(disposition,
                                transition='disposition-transition-appraised-to-closed')
@@ -124,13 +96,14 @@ class TestDispositionNotifications(FunctionalTestCase):
         self.assertEquals('disposition-transition-appraised-to-closed', activity.kind)
         self.assertEquals(
             u'Disposition closed and all dossiers destroyed by {}'.format(
-                self.actor_link),
+                actor.get_link()),
             activity.summary)
         self.assertEquals(u'disposition-transition-appraised-to-closed', activity.label)
         self.assertIsNone(activity.description)
 
     def test_archive_activity_is_recorded(self):
-        self.grant('Archivist')
+        self.login(self.archivist)
+        actor = ActorLookup(self.archivist.getId()).lookup()
         disposition = create(Builder('disposition')
                              .in_state('disposition-state-disposed'))
         api.content.transition(disposition,
@@ -139,13 +112,14 @@ class TestDispositionNotifications(FunctionalTestCase):
         activity = Activity.query.all()[-1]
         self.assertEquals('disposition-transition-archive', activity.kind)
         self.assertEquals(
-            u'The archiving confirmed by {}'.format(self.actor_link),
+            u'The archiving confirmed by {}'.format(actor.get_link()),
             activity.summary)
         self.assertEquals(u'disposition-transition-archive', activity.label)
         self.assertIsNone(activity.description)
 
     def test_close_activity_is_recorded(self):
-        self.grant('Records Manager')
+        self.login(self.records_manager)
+        actor = ActorLookup(self.records_manager.getId()).lookup()
         disposition = create(Builder('disposition')
                              .in_state('disposition-state-archived'))
         api.content.transition(disposition,
@@ -155,12 +129,13 @@ class TestDispositionNotifications(FunctionalTestCase):
         self.assertEquals('disposition-transition-close', activity.kind)
         self.assertEquals(
             u'Disposition closed and all dossiers '
-            'destroyed by {}'.format(self.actor_link), activity.summary)
+            'destroyed by {}'.format(actor.get_link()), activity.summary)
         self.assertEquals(u'disposition-transition-close', activity.label)
         self.assertIsNone(activity.description)
 
     def test_refuse_activity_is_recorded(self):
-        self.grant('Archivist')
+        self.login(self.archivist)
+        actor = ActorLookup(self.archivist.getId()).lookup()
         disposition = create(Builder('disposition')
                              .in_state('disposition-state-disposed'))
         api.content.transition(disposition,
@@ -169,7 +144,7 @@ class TestDispositionNotifications(FunctionalTestCase):
         activity = Activity.query.all()[-1]
         self.assertEquals('disposition-transition-refuse', activity.kind)
         self.assertEquals(
-            u'Disposition refused by {}'.format(self.actor_link),
+            u'Disposition refused by {}'.format(actor.get_link()),
             activity.summary)
         self.assertEquals(u'disposition-transition-refuse', activity.label)
         self.assertIsNone(activity.description)

--- a/opengever/disposition/tests/test_byline.py
+++ b/opengever/disposition/tests/test_byline.py
@@ -1,34 +1,16 @@
-from DateTime import DateTime
-from ftw.builder import Builder
-from ftw.builder import create
 from ftw.testbrowser import browsing
-from opengever.testing import FunctionalTestCase
+from opengever.testing import IntegrationTestCase
 
 
-class TestDispositionByline(FunctionalTestCase):
-
-    def setUp(self):
-        super(TestDispositionByline, self).setUp()
-        self.root = create(Builder('repository_root'))
-        self.repository = create(Builder('repository').within(self.root))
-        self.dossier1 = create(Builder('dossier')
-                               .as_expired()
-                               .within(self.repository))
-
-        self.grant('Records Manager')
+class TestDispositionByline(IntegrationTestCase):
 
     @browsing
     def test_shows_current_review_state_creation_and_modification_date(self, browser):
-        disposition = create(Builder('disposition')
-                             .having(dossiers=[self.dossier1])
-                             .with_creation_date(DateTime(2016, 4, 10, 7, 25))
-                             .with_modification_date(DateTime(2016, 4, 22, 22))
-                             .within(self.root))
-
-        browser.login().open(disposition)
+        self.login(self.records_manager, browser)
+        browser.open(self.disposition)
 
         self.assertEquals(
-            ['Created: Apr 10, 2016 07:25 AM',
+            ['Created: Aug 31, 2016 09:05 PM',
              'State: disposition-state-in-progress',
-             'Last modified: Apr 22, 2016 10:00 PM'],
+             'Last modified: Aug 31, 2016 09:05 PM'],
             browser.css('#plone-document-byline li').text)

--- a/opengever/disposition/tests/test_destruction.py
+++ b/opengever/disposition/tests/test_destruction.py
@@ -1,187 +1,110 @@
-from ftw.builder import Builder
-from ftw.builder import create
 from opengever.base.behaviors.lifecycle import ARCHIVAL_VALUE_UNWORTHY
 from opengever.base.behaviors.lifecycle import ARCHIVAL_VALUE_WORTHY
-from opengever.testing import FunctionalTestCase
+from opengever.base.behaviors.lifecycle import ILifeCycle
+from opengever.base.security import elevated_privileges
+from opengever.disposition.interfaces import IAppraisal
+from opengever.testing import IntegrationTestCase
 from persistent.list import PersistentList
 from persistent.mapping import PersistentMapping
 from plone import api
+from Products.CMFPlone.utils import safe_unicode
 from zExceptions import Unauthorized
 from zope.component import getUtility
 from zope.intid.interfaces import IIntIds
 
 
-class TestDestruction(FunctionalTestCase):
+class TestDestruction(IntegrationTestCase):
 
-    def setUp(self):
-        super(TestDestruction, self).setUp()
-        self.root = create(Builder('repository_root'))
-        self.repository = create(Builder('repository')
-                                 .titled('Anfragen')
-                                 .within(self.root))
-        self.dossier1 = create(Builder('dossier')
-                               .titled(u'D\xf6ssier 1')
-                               .having(archival_value=ARCHIVAL_VALUE_UNWORTHY)
-                               .as_expired()
-                               .within(self.repository))
-        self.dossier2 = create(Builder('dossier')
-                               .titled(u'D\xf6ssier 2')
-                               .having(archival_value=ARCHIVAL_VALUE_WORTHY)
-                               .as_expired()
-                               .within(self.repository))
-        self.dossier3 = create(Builder('dossier')
-                               .titled(u'D\xf6ssier 3')
-                               .having(archival_value=ARCHIVAL_VALUE_WORTHY)
-                               .as_expired()
-                               .within(self.repository))
-
-        intids = getUtility(IIntIds)
-        self.dossier_intids = [intids.getId(self.dossier1),
-                               intids.getId(self.dossier2),
-                               intids.getId(self.dossier3)]
-
-        self.grant(
-            'Contributor', 'Editor', 'Reader', 'Reviewer', 'Records Manager')
-        self.disposition = create(Builder('disposition')
-                                  .having(dossiers=[self.dossier1,
-                                                    self.dossier2,
-                                                    self.dossier3])
-                                  .in_state('disposition-state-archived')
-                                  .within(self.root))
-
-        self.disposition.mark_dossiers_as_archived()
+    def close_disposition(self):
+        with elevated_privileges():
+            api.content.transition(obj=self.disposition,
+                                   transition='disposition-transition-appraise')
+            api.content.transition(obj=self.disposition,
+                                   transition='disposition-transition-dispose')
+            api.content.transition(obj=self.disposition,
+                                   transition='disposition-transition-archive')
+            api.content.transition(obj=self.disposition,
+                                   transition='disposition-transition-close')
 
     def test_removed_dossiers_are_added_to_destroyed_dossier_list(self):
-        api.content.transition(obj=self.disposition,
-                               transition='disposition-transition-close')
+        self.login(self.regular_user)
+        intids = getUtility(IIntIds)
+        expected = []
+        for dossier in (self.offered_dossier_to_archive, self.offered_dossier_to_destroy):
+            expected.append(
+              {'intid': intids.getId(dossier),
+               'title': dossier.title,
+               'appraisal': ILifeCycle(dossier).archival_value == ARCHIVAL_VALUE_WORTHY,
+               'reference_number': dossier.get_reference_number(),
+               'repository_title': safe_unicode(self.leaf_repofolder.Title()),
+               'former_state': dossier.get_former_state()})
 
-        expected = [
-            {'intid': self.dossier_intids[0],
-             'title': u'D\xf6ssier 1',
-             'appraisal': False,
-             'reference_number': 'Client1 1 / 1',
-             'repository_title': u'1. Anfragen',
-             'former_state': u'dossier-state-resolved'},
-            {'intid': self.dossier_intids[1],
-             'title': u'D\xf6ssier 2',
-             'appraisal': True,
-             'reference_number': 'Client1 1 / 2',
-             'repository_title': u'1. Anfragen',
-             'former_state': u'dossier-state-resolved'},
-            {'intid': self.dossier_intids[2],
-             'title': u'D\xf6ssier 3',
-             'appraisal': True,
-             'reference_number': 'Client1 1 / 3',
-             'repository_title': u'1. Anfragen',
-             'former_state': u'dossier-state-resolved'}]
+        self.close_disposition()
 
         self.assertEquals(expected,
                           list(self.disposition.get_destroyed_dossiers()))
 
     def test_destroyed_dossier_list_is_persistent(self):
-        api.content.transition(obj=self.disposition,
-                               transition='disposition-transition-close')
+        self.login(self.regular_user)
+        self.close_disposition()
 
         self.assertEquals(PersistentList,
                           type(self.disposition.get_destroyed_dossiers()))
         self.assertEquals(PersistentMapping,
                           type(self.disposition.get_destroyed_dossiers()[0]))
 
-    def test_when_closing_all_dossier_gets_removed(self):
-        self.assertEquals(
-            [self.dossier1, self.dossier2, self.dossier3],
-            self.repository.listFolderContents())
+    def test_all_dossiers_get_removed_when_closing_disposition(self):
+        self.login(self.regular_user)
+        expected_difference = [self.offered_dossier_to_archive,
+                               self.offered_dossier_to_destroy]
+        content_before = self.leaf_repofolder.listFolderContents()
+        self.close_disposition()
+        content_after = self.leaf_repofolder.listFolderContents()
+
+        self.assertItemsEqual(expected_difference,
+                              set(content_before).difference(set(content_after)))
+
+    def test_unarchived_dossiers_get_removed_when_closing_disposition(self):
+        self.login(self.manager)
+        expected_difference = [self.offered_dossier_to_archive,
+                               self.offered_dossier_to_destroy]
 
         api.content.transition(obj=self.disposition,
-                               transition='disposition-transition-close')
+                               transition='disposition-transition-appraise')
 
-        self.assertEquals([], self.repository.listFolderContents())
+        content_before = self.leaf_repofolder.listFolderContents()
+
+        ILifeCycle(self.offered_dossier_to_archive).archival_value = ARCHIVAL_VALUE_UNWORTHY
+        IAppraisal(self.disposition).initialize(self.offered_dossier_to_archive)
+
+        api.content.transition(obj=self.disposition,
+                               transition='disposition-transition-appraised-to-closed')
+        content_after = self.leaf_repofolder.listFolderContents()
+        self.assertItemsEqual(expected_difference,
+                              set(content_before).difference(set(content_after)))
 
 
-class TestDestroyPermission(FunctionalTestCase):
+class TestDestroyPermission(IntegrationTestCase):
 
-    def setUp(self):
-        super(TestDestroyPermission, self).setUp()
-        self.root = create(Builder('repository_root'))
-        self.repository = create(Builder('repository')
-                                 .titled('Anfragen')
-                                 .within(self.root))
-        self.grant('Records Manager')
-
-    def test_destruction_raises_unauthorized_when_dossiers_is_not_archived(self):
-        dossier = create(Builder('dossier')
-                         .titled(u'D\xf6ssier 2')
-                         .having(archival_value=ARCHIVAL_VALUE_WORTHY)
-                         .as_expired()
-                         .within(self.repository))
-        disposition = create(Builder('disposition')
-                             .having(dossiers=[dossier])
-                             .within(self.root))
+    def test_destruction_raises_unauthorized_when_dossiers_are_not_archived(self):
+        self.login(self.records_manager)
 
         with self.assertRaises(Unauthorized):
-            disposition.destroy_dossiers()
+            self.disposition.destroy_dossiers()
+
+        for dossier in self.disposition.get_dossiers():
+            api.content.transition(dossier, to_state='dossier-state-archived')
+
+        self.disposition.destroy_dossiers()
 
     def test_destruction_raises_unauthorized_when_user_has_not_destroy_permission(self):
-        dossier = create(Builder('dossier')
-                         .titled(u'D\xf6ssier 2')
-                         .having(archival_value=ARCHIVAL_VALUE_WORTHY)
-                         .as_expired()
-                         .within(self.repository))
-        disposition = create(Builder('disposition')
-                             .having(dossiers=[dossier])
-                             .within(self.root))
+        self.login(self.archivist)
 
-        self.grant('Archivist', 'Records Manager')
-        api.content.transition(obj=disposition,
-                               transition='disposition-transition-appraise')
-        api.content.transition(obj=disposition,
-                               transition='disposition-transition-dispose')
-        api.content.transition(obj=disposition,
-                               transition='disposition-transition-archive')
+        for dossier in self.disposition.get_dossiers():
+            api.content.transition(dossier, to_state='dossier-state-archived')
 
-        self.grant('Archivist')
         with self.assertRaises(Unauthorized):
-            disposition.destroy_dossiers()
+            self.disposition.destroy_dossiers()
 
-        self.grant('Records Manager')
-        disposition.destroy_dossiers()
-
-
-class TestDestructionForNotArchivedDossiers(FunctionalTestCase):
-
-    def setUp(self):
-        super(TestDestructionForNotArchivedDossiers, self).setUp()
-        self.root = create(Builder('repository_root'))
-        self.repository = create(Builder('repository')
-                                 .titled('Anfragen')
-                                 .within(self.root))
-        self.dossier1 = create(Builder('dossier')
-                               .titled(u'D\xf6ssier 1')
-                               .having(archival_value=ARCHIVAL_VALUE_UNWORTHY)
-                               .as_expired()
-                               .within(self.repository))
-        self.dossier2 = create(Builder('dossier')
-                               .titled(u'D\xf6ssier 2')
-                               .having(archival_value=ARCHIVAL_VALUE_UNWORTHY)
-                               .as_expired()
-                               .in_state('dossier-state-inactive')
-                               .within(self.repository))
-
-        self.grant('Records Manager', 'Contributor')
-        self.disposition = create(Builder('disposition')
-                                  .having(dossiers=[self.dossier1, self.dossier2])
-                                  .in_state('disposition-state-appraised')
-                                  .within(self.root))
-
-    def test_dossiers_gets_removed(self):
-        self.assertEquals(
-            [self.dossier1, self.dossier2],
-            self.repository.listFolderContents())
-
-        api.content.transition(
-            obj=self.disposition,
-            transition='disposition-transition-appraised-to-closed')
-
-        self.assertEquals(
-            [],
-            self.repository.listFolderContents())
+        self.login(self.records_manager)
+        self.disposition.destroy_dossiers()

--- a/opengever/disposition/tests/test_disposition.py
+++ b/opengever/disposition/tests/test_disposition.py
@@ -8,90 +8,82 @@ from ftw.testbrowser.pages.statusmessages import info_messages
 from ftw.testbrowser.pages.statusmessages import error_messages
 from ftw.testing import freeze
 from opengever.base.behaviors.lifecycle import ILifeCycle
-from opengever.testing import FunctionalTestCase
+from opengever.dossier.behaviors.dossier import IDossier
+from opengever.testing import IntegrationTestCase
 from opengever.testing import obj2paths
 from plone import api
 from plone.protect import createToken
 
-
 OFFERED_STATE = 'dossier-state-offered'
+RESOLVED_STATE = 'dossier-state-resolved'
+INACTIVE_STATE = 'dossier-state-inactive'
 
 
-class TestDisposition(FunctionalTestCase):
-
-    def setUp(self):
-        super(TestDisposition, self).setUp()
-        self.root = create(Builder('repository_root'))
-        self.repository = create(Builder('repository').within(self.root))
-        self.dossier1 = create(Builder('dossier')
-                               .titled(u'Dossier A')
-                               .as_expired()
-                               .within(self.repository))
-        self.dossier2 = create(Builder('dossier')
-                               .in_state('dossier-state-resolved')
-                               .within(self.repository))
-        self.dossier3 = create(Builder('dossier')
-                               .as_expired()
-                               .within(self.repository))
-
-        self.grant(
-            'Contributor', 'Editor', 'Reader', 'Reviewer', 'Records Manager')
+class TestDisposition(IntegrationTestCase):
 
     def test_id_is_sequence_number_prefixed_with_disposition(self):
-        disposition_1 = create(Builder('disposition'))
-        disposition_2 = create(Builder('disposition'))
-
-        self.assertEquals('disposition-1', disposition_1.getId())
-        self.assertEquals('disposition-2', disposition_2.getId())
+        self.login(self.records_manager)
+        disposition = create(Builder('disposition'))
+        self.assertEquals('disposition-1', self.disposition.getId())
+        self.assertEquals('disposition-2', disposition.getId())
 
     @browsing
     def test_title_is_prefilled_with_default_suggestion(self, browser):
         """Expected format:
         Disposition {adminiunit-abbreviation} {today's date}'.
         """
-
         expected = 'Disposition Client1 Jan 01, 2014'
 
+        self.login(self.archivist, browser)
         with freeze(datetime(2014, 1, 1)):
-            browser.login().open(
-                self.repository,
-                view="++add++opengever.disposition.disposition")
+            browser.open(self.leaf_repofolder,
+                         view="++add++opengever.disposition.disposition")
 
             self.assertEquals(
                 expected, browser.forms.get('form').find_field('Title').value)
 
     @browsing
     def test_can_be_added(self, browser):
-        browser.login().open(self.root)
+        self.login(self.records_manager, browser)
+
+        browser.open(self.repository_root)
         factoriesmenu.add('Disposition')
-        browser.fill({'Dossiers': [self.dossier1, self.dossier3]})
-        browser.find('Save').click()
+        with freeze(datetime(2037, 1, 1)):
+            browser.fill({'Dossiers': [self.inactive_dossier,
+                                       self.expired_dossier]})
+            browser.find('Save').click()
 
         self.assertEquals(['Item created'], info_messages())
 
     @browsing
     def test_selected_dossiers_in_the_list_are_preselected(self, browser):
-        data = {'paths:list': obj2paths([self.dossier1, self.dossier3]),
+        self.login(self.records_manager, browser)
+        self.disposition.dossiers = []
+
+        dossiers_to_add = [self.inactive_dossier, self.expired_dossier]
+        data = {'paths:list': obj2paths(dossiers_to_add),
                 '_authenticator': createToken()}
-        browser.login().open(self.root,
-                             view='++add++opengever.disposition.disposition',
-                             data=data)
 
-        browser.find('Save').click()
+        with freeze(datetime(2037, 1, 1)):
+            browser.open(self.repository_root,
+                         view='++add++opengever.disposition.disposition',
+                         data=data)
 
-        self.assertEquals([self.dossier1, self.dossier3],
+            browser.find('Save').click()
+
+        self.assertEquals(dossiers_to_add,
                           [rel.to_object for rel in browser.context.dossiers])
 
     @browsing
     def test_selected_dossiers_in_active_states_are_skipped(self, browser):
-        dossier4 = create(Builder('dossier')
-                          .within(self.repository))
-        data = {'paths:list': obj2paths([dossier4]),
+        self.login(self.records_manager, browser)
+
+        data = {'paths:list': obj2paths([self.empty_dossier]),
                 '_authenticator': createToken()}
 
-        browser.login().open(self.root,
-                             view='++add++opengever.disposition.disposition',
-                             data=data)
+        browser.open(self.repository_root,
+                     view='++add++opengever.disposition.disposition',
+                     data=data)
         browser.find('Save').click()
 
         self.assertEquals(['There were some errors.'], error_messages())
@@ -100,123 +92,135 @@ class TestDisposition(FunctionalTestCase):
 
     @browsing
     def test_already_offered_dossiers_cant_be_selected(self, browser):
-        data = {'paths:list': obj2paths([self.dossier1]),
-                '_authenticator': createToken()}
-        browser.login().open(self.root,
-                             view='++add++opengever.disposition.disposition',
-                             data=data)
-        browser.find('Save').click()
+        self.login(self.records_manager, browser)
 
-        browser.login().open(self.root,
-                             view='++add++opengever.disposition.disposition',
-                             data=data)
+        data = {'paths:list': obj2paths([self.offered_dossier_to_archive]),
+                '_authenticator': createToken()}
+        browser.open(self.repository_root,
+                     view='++add++opengever.disposition.disposition',
+                     data=data)
         browser.find('Save').click()
 
         self.assertEquals(['There were some errors.'], error_messages())
-        self.assertEquals(['The dossier Dossier A is already offered in '
-                           'a different disposition.'],
+        self.assertEquals(['The dossier {} is already offered in a different '
+                           'disposition.'.format(self.offered_dossier_to_archive.Title())],
                           browser.css('.fieldErrorBox .error').text)
 
     @browsing
     def test_only_expired_dossiers_can_be_added(self, browser):
-        data = {'paths:list': obj2paths([self.dossier2]),
+        self.login(self.records_manager, browser)
+
+        data = {'paths:list': obj2paths([self.expired_dossier]),
                 '_authenticator': createToken()}
-        browser.login().open(self.root,
-                             view='++add++opengever.disposition.disposition',
-                             data=data)
 
-        browser.find('Save').click()
+        self.assertEqual(date(2000, 12, 31), IDossier(self.expired_dossier).end)
 
-        self.assertEquals(['There were some errors.'], error_messages())
-        self.assertEquals(
-            ['The retention period of the selected dossiers is not expired.'],
-            browser.css('.fieldErrorBox .error').text)
+        with freeze(datetime(2001, 1, 1)):
+            browser.open(self.repository_root,
+                         view='++add++opengever.disposition.disposition',
+                         data=data)
+
+            browser.find('Save').click()
+
+            self.assertEquals(['There were some errors.'], error_messages())
+            self.assertEquals(
+                ['The retention period of the selected dossiers is not expired.'],
+                browser.css('.fieldErrorBox .error').text)
+
+        with freeze(datetime(2021, 1, 1)):
+            browser.open(self.repository_root,
+                         view='++add++opengever.disposition.disposition',
+                         data=data)
+
+            browser.find('Save').click()
+
+            self.assertEquals([], error_messages())
+            self.assertEquals(['Item created'], info_messages())
 
     @browsing
     def test_attached_dossier_are_set_to_offered_state(self, browser):
-        data = {'paths:list': obj2paths([self.dossier1, self.dossier3]),
-                '_authenticator': createToken()}
-        browser.login().open(self.root,
-                             view='++add++opengever.disposition.disposition',
-                             data=data)
-        browser.find('Save').click()
+        self.login(self.records_manager, browser)
 
-        self.assertEquals(OFFERED_STATE, api.content.get_state(self.dossier1))
-        self.assertEquals(OFFERED_STATE, api.content.get_state(self.dossier3))
+        with freeze(datetime(2037, 1, 1)):
+            data = {'paths:list': obj2paths([self.expired_dossier, self.inactive_dossier]),
+                    '_authenticator': createToken()}
+            browser.open(self.repository_root,
+                         view='++add++opengever.disposition.disposition',
+                         data=data)
+            browser.find('Save').click()
+
+        self.assertEquals(OFFERED_STATE, api.content.get_state(self.expired_dossier))
+        self.assertEquals(OFFERED_STATE, api.content.get_state(self.inactive_dossier))
 
     @browsing
     def test_date_of_submission_is_set_today_for_attached_dossiers(self, browser):
-        data = {'paths:list': obj2paths([self.dossier1, self.dossier3]),
-                '_authenticator': createToken()}
-        browser.login().open(self.root,
-                             view='++add++opengever.disposition.disposition',
-                             data=data)
-        browser.find('Save').click()
+        self.login(self.records_manager, browser)
 
-        self.assertEquals(date.today(),
-                          ILifeCycle(self.dossier1).date_of_submission)
-        self.assertEquals(date.today(),
-                          ILifeCycle(self.dossier3).date_of_submission)
+        with freeze(datetime(2037, 1, 1)):
+            data = {'paths:list': obj2paths([self.expired_dossier, self.inactive_dossier]),
+                    '_authenticator': createToken()}
+            browser.open(self.repository_root,
+                         view='++add++opengever.disposition.disposition',
+                         data=data)
+            browser.find('Save').click()
+
+            self.assertEquals(date.today(),
+                              ILifeCycle(self.expired_dossier).date_of_submission)
+            self.assertEquals(date.today(),
+                              ILifeCycle(self.inactive_dossier).date_of_submission)
 
 
-class TestDispositionEditForm(FunctionalTestCase):
+class TestDispositionEditForm(IntegrationTestCase):
 
-    def setUp(self):
-        super(TestDispositionEditForm, self).setUp()
-        self.root = create(Builder('repository_root'))
-        self.repository = create(Builder('repository').within(self.root))
-        self.dossier1 = create(Builder('dossier').as_expired()
-                               .within(self.repository))
-        self.dossier2 = create(Builder('dossier')
-                               .as_expired()
-                               .in_state('dossier-state-inactive')
-                               .within(self.repository))
-        self.dossier3 = create(Builder('dossier')
-                               .as_expired()
-                               .within(self.repository))
-
-        self.grant('Contributor', 'Editor', 'Reader', 'Reviewer', 'Records Manager')
+    def test_initial_states(self):
+        self.login(self.regular_user)
+        self.assertEquals(OFFERED_STATE, api.content.get_state(self.offered_dossier_to_archive))
+        self.assertEquals(OFFERED_STATE, api.content.get_state(self.offered_dossier_to_destroy))
+        self.assertEquals(RESOLVED_STATE, api.content.get_state(self.expired_dossier))
+        self.assertEquals(INACTIVE_STATE, api.content.get_state(self.inactive_dossier))
 
     @browsing
     def test_set_added_dossiers_to_offered_state(self, browser):
-        disposition = create(Builder('disposition')
-                             .having(dossiers=[self.dossier1])
-                             .within(self.root))
+        self.login(self.records_manager, browser)
 
-        browser.login().open(disposition, view='edit')
-        browser.fill({'Dossiers': [self.dossier1, self.dossier2, self.dossier3]})
-        browser.find('Save').click()
+        with freeze(datetime(2037, 1, 1)):
+            browser.open(self.disposition, view='edit')
+            browser.fill({'Dossiers': [self.offered_dossier_to_archive,
+                                       self.offered_dossier_to_destroy,
+                                       self.expired_dossier,
+                                       self.inactive_dossier]})
+            browser.find('Save').click()
 
-        self.assertEquals(OFFERED_STATE, api.content.get_state(self.dossier2))
-        self.assertEquals(OFFERED_STATE, api.content.get_state(self.dossier3))
+        self.assertEquals(OFFERED_STATE, api.content.get_state(self.offered_dossier_to_archive))
+        self.assertEquals(OFFERED_STATE, api.content.get_state(self.offered_dossier_to_destroy))
+        self.assertEquals(OFFERED_STATE, api.content.get_state(self.expired_dossier))
+        self.assertEquals(OFFERED_STATE, api.content.get_state(self.inactive_dossier))
 
     @browsing
     def test_set_dropped_dossiers_to_former_state(self, browser):
-        disposition = create(Builder('disposition')
-                             .having(dossiers=[self.dossier1, self.dossier2, self.dossier3])
-                             .within(self.root))
+        self.login(self.records_manager, browser)
 
-        browser.login().open(disposition, view='edit')
-        browser.fill({'Dossiers': [self.dossier3]})
+        browser.open(self.disposition, view='edit')
+        browser.fill({'Dossiers': [self.expired_dossier]})
         browser.find('Save').click()
 
         self.assertEquals('dossier-state-resolved',
-                          api.content.get_state(self.dossier1))
+                          api.content.get_state(self.offered_dossier_to_archive))
         self.assertEquals('dossier-state-inactive',
-                          api.content.get_state(self.dossier2))
-        self.assertEquals(OFFERED_STATE, api.content.get_state(self.dossier3))
+                          api.content.get_state(self.offered_dossier_to_destroy))
+        self.assertEquals(OFFERED_STATE, api.content.get_state(self.expired_dossier))
 
     @browsing
     def test_reset_date_of_submission_for_dropped_dossiers(self, browser):
-        disposition = create(Builder('disposition')
-                             .having(dossiers=[self.dossier1, self.dossier2, self.dossier3])
-                             .within(self.root))
+        self.login(self.records_manager, browser)
 
-        browser.login().open(disposition, view='edit')
-        browser.fill({'Dossiers': [self.dossier3]})
+        browser.open(self.disposition, view='edit')
+        browser.fill({'Dossiers': [self.expired_dossier]})
         browser.find('Save').click()
 
-        self.assertEquals(None, ILifeCycle(self.dossier1).date_of_submission)
-        self.assertEquals(None, ILifeCycle(self.dossier2).date_of_submission)
-        self.assertEquals(date.today(),
-                          ILifeCycle(self.dossier3).date_of_submission)
+        self.assertEquals(
+            None, ILifeCycle(self.offered_dossier_to_archive).date_of_submission)
+        self.assertEquals(
+            None, ILifeCycle(self.offered_dossier_to_destroy).date_of_submission)
+        self.assertEquals(
+            date.today(), ILifeCycle(self.expired_dossier).date_of_submission)

--- a/opengever/disposition/tests/test_ech0160export.py
+++ b/opengever/disposition/tests/test_ech0160export.py
@@ -1,33 +1,19 @@
 from datetime import datetime
-from ftw.builder import Builder
-from ftw.builder import create
 from ftw.testbrowser import browsing
 from ftw.testing import freeze
-from opengever.testing import FunctionalTestCase
+from opengever.testing import IntegrationTestCase
 
 
-class TesteCH0160Deployment(FunctionalTestCase):
-
-    def setUp(self):
-        super(TesteCH0160Deployment, self).setUp()
-        self.root = create(Builder('repository_root')
-                           .having(title_de=u'Ordnungssytem 2000'))
-        self.folder = create(Builder('repository').within(self.root))
-        self.grant('Contributor', 'Editor', 'Reader', 'Records Manager')
+class TesteCH0160Deployment(IntegrationTestCase):
 
     @browsing
     def test_returns_zip_file_stream(self, browser):
-        dossier_a = create(Builder('dossier')
-                           .as_expired()
-                           .within(self.folder))
-        create(Builder('document').with_dummy_content().within(dossier_a))
-        disposition = create(Builder('disposition')
-                             .having(dossiers=[dossier_a],
-                                     transfer_number=u'10xy')
-                             .within(self.root))
+        self.login(self.records_manager)
+
+        self.disposition.transfer_number = "10xy"
 
         with freeze(datetime(2016, 6, 11)):
-            view = disposition.unrestrictedTraverse('ech0160_export')
+            view = self.disposition.unrestrictedTraverse('ech0160_export')
             view()
 
             self.assertEquals(

--- a/opengever/disposition/tests/test_history.py
+++ b/opengever/disposition/tests/test_history.py
@@ -1,7 +1,5 @@
-from ftw.builder import Builder
-from ftw.builder import create
 from ftw.testbrowser import browsing
-from opengever.base.behaviors.lifecycle import ARCHIVAL_VALUE_WORTHY
+from opengever.base.security import elevated_privileges
 from opengever.disposition.history import Added
 from opengever.disposition.history import Appraised
 from opengever.disposition.history import AppraisedToClosed
@@ -12,58 +10,48 @@ from opengever.disposition.history import Edited
 from opengever.disposition.history import Refused
 from opengever.disposition.interfaces import IAppraisal
 from opengever.disposition.interfaces import IHistoryStorage
-from opengever.testing import FunctionalTestCase
+from opengever.ogds.base.actor import ActorLookup
+from opengever.testing import IntegrationTestCase
 from plone import api
 from zope.i18n import translate
-import transaction
 
 
-class TestHistoryEntries(FunctionalTestCase):
+class TestHistoryEntries(IntegrationTestCase):
 
-    user_link = '<a href="http://nohost/plone/@@user-details/test_user_1_">'\
-                'Test User (test_user_1_)</a>'
-
-    def setUp(self):
-        super(TestHistoryEntries, self).setUp()
-        self.root = create(Builder('repository_root'))
-        self.repository = create(Builder('repository').within(self.root))
-        self.dossier1 = create(Builder('dossier')
-                               .as_expired()
-                               .having(archival_value=ARCHIVAL_VALUE_WORTHY)
-                               .within(self.repository))
-        self.dossier2 = create(Builder('dossier')
-                               .as_expired()
-                               .within(self.repository))
-
-        self.grant('Contributor', 'Editor', 'Reader',
-                   'Reviewer', 'Records Manager', 'Archivist')
-
-        self.disposition = create(Builder('disposition')
-                             .having(dossiers=[self.dossier1])
-                             .within(self.root))
+    @property
+    def current_user_link(self):
+        userid = api.user.get_current().getId()
+        actor = ActorLookup(userid).lookup()
+        return actor.get_link()
 
     def test_add_history_entry_when_created_a_disposition(self):
+        self.login(self.records_manager)
+
         entry = IHistoryStorage(self.disposition).get_history()[0]
 
         self.assertTrue(isinstance(entry, Added))
         self.assertEquals('add', entry.css_class)
-        self.assertEquals(u'Added by {}'.format(self.user_link),
+        self.assertEquals(u'Added by {}'.format(self.current_user_link),
                           translate(entry.msg(), context=self.request))
 
     @browsing
     def test_add_history_entry_when_editing_a_disposition(self, browser):
-        browser.login().open(self.disposition, view='edit')
-        browser.fill({'Dossiers': [self.dossier1, self.dossier2]})
+        self.login(self.records_manager, browser)
+        browser.open(self.disposition, view='edit')
+        browser.fill({'Dossiers': [self.expired_dossier,
+                                   self.offered_dossier_to_archive,
+                                   self.offered_dossier_to_destroy]})
         browser.find('Save').click()
 
         entry = IHistoryStorage(self.disposition).get_history()[0]
 
         self.assertTrue(isinstance(entry, Edited))
         self.assertEquals('edit', entry.css_class)
-        self.assertEquals(u'Edited by {}'.format(self.user_link),
+        self.assertEquals(u'Edited by {}'.format(self.current_user_link),
                           translate(entry.msg(), context=self.request))
 
     def test_add_history_entry_when_finalize_appraisal_a_disposition(self):
+        self.login(self.archivist)
         api.content.transition(obj=self.disposition,
                                transition='disposition-transition-appraise')
 
@@ -71,30 +59,34 @@ class TestHistoryEntries(FunctionalTestCase):
 
         self.assertTrue(isinstance(entry, Appraised))
         self.assertEquals('appraise', entry.css_class)
-        self.assertEquals(u'Appraisal finalized by {}'.format(self.user_link),
+        self.assertEquals(u'Appraisal finalized by {}'.format(self.current_user_link),
                           translate(entry.msg(), context=self.request))
 
     def test_add_history_entry_when_dispose_a_disposition(self):
-        api.content.transition(obj=self.disposition,
-                               transition='disposition-transition-appraise')
-        api.content.transition(obj=self.disposition,
-                               transition='disposition-transition-dispose')
+        self.login(self.records_manager)
+        with elevated_privileges():
+            api.content.transition(obj=self.disposition,
+                                   transition='disposition-transition-appraise')
+            api.content.transition(obj=self.disposition,
+                                   transition='disposition-transition-dispose')
 
         entry = IHistoryStorage(self.disposition).get_history()[0]
 
         self.assertTrue(isinstance(entry, Disposed))
         self.assertEquals('dispose', entry.css_class)
         self.assertEquals(
-            u'Disposition disposed for the archive by {}'.format(self.user_link),
+            u'Disposition disposed for the archive by {}'.format(self.current_user_link),
             translate(entry.msg(), context=self.request))
 
     def test_add_history_entry_when_directly_close_a_disposition(self):
-        IAppraisal(self.disposition).update(dossier=self.dossier1,
+        self.login(self.records_manager)
+        IAppraisal(self.disposition).update(dossier=self.offered_dossier_to_archive,
                                             archive=False)
-        api.content.transition(obj=self.disposition,
-                               transition='disposition-transition-appraise')
-        api.content.transition(obj=self.disposition,
-                               transition='disposition-transition-appraised-to-closed')
+        with elevated_privileges():
+            api.content.transition(obj=self.disposition,
+                                   transition='disposition-transition-appraise')
+            api.content.transition(obj=self.disposition,
+                                   transition='disposition-transition-appraised-to-closed')
 
         entry = IHistoryStorage(self.disposition).get_history()[0]
 
@@ -102,34 +94,38 @@ class TestHistoryEntries(FunctionalTestCase):
         self.assertEquals('close', entry.css_class)
         self.assertEquals(
             u'Disposition closed and all dossiers destroyed by {}'.format(
-                self.user_link),
+                self.current_user_link),
             translate(entry.msg(), context=self.request))
 
     def test_add_history_entry_when_archive_a_disposition(self):
-        api.content.transition(obj=self.disposition,
-                               transition='disposition-transition-appraise')
-        api.content.transition(obj=self.disposition,
-                               transition='disposition-transition-dispose')
-        api.content.transition(obj=self.disposition,
-                               transition='disposition-transition-archive')
+        self.login(self.records_manager)
+        with elevated_privileges():
+            api.content.transition(obj=self.disposition,
+                                   transition='disposition-transition-appraise')
+            api.content.transition(obj=self.disposition,
+                                   transition='disposition-transition-dispose')
+            api.content.transition(obj=self.disposition,
+                                   transition='disposition-transition-archive')
 
         entry = IHistoryStorage(self.disposition).get_history()[0]
 
         self.assertTrue(isinstance(entry, Archived))
         self.assertEquals('archive', entry.css_class)
         self.assertEquals(
-            u'The archiving confirmed by {}'.format(self.user_link),
+            u'The archiving confirmed by {}'.format(self.current_user_link),
             translate(entry.msg(), context=self.request))
 
     def test_add_history_entry_when_close_a_disposition(self):
-        api.content.transition(obj=self.disposition,
-                               transition='disposition-transition-appraise')
-        api.content.transition(obj=self.disposition,
-                               transition='disposition-transition-dispose')
-        api.content.transition(obj=self.disposition,
-                               transition='disposition-transition-archive')
-        api.content.transition(obj=self.disposition,
-                               transition='disposition-transition-close')
+        self.login(self.records_manager)
+        with elevated_privileges():
+            api.content.transition(obj=self.disposition,
+                                   transition='disposition-transition-appraise')
+            api.content.transition(obj=self.disposition,
+                                   transition='disposition-transition-dispose')
+            api.content.transition(obj=self.disposition,
+                                   transition='disposition-transition-archive')
+            api.content.transition(obj=self.disposition,
+                                   transition='disposition-transition-close')
 
         entry = IHistoryStorage(self.disposition).get_history()[0]
 
@@ -137,11 +133,11 @@ class TestHistoryEntries(FunctionalTestCase):
         self.assertEquals('close', entry.css_class)
         self.assertEquals(
             u'Disposition closed and all dossiers destroyed by {}'.format(
-                self.user_link),
+                self.current_user_link),
             translate(entry.msg(), context=self.request))
 
     def test_add_history_entry_when_refuse_a_disposition(self):
-        self.grant('Archivist')
+        self.login(self.archivist)
         api.content.transition(obj=self.disposition,
                                transition='disposition-transition-refuse')
 
@@ -150,83 +146,92 @@ class TestHistoryEntries(FunctionalTestCase):
         self.assertTrue(isinstance(entry, Refused))
         self.assertEquals('refuse', entry.css_class)
         self.assertEquals(
-            u'Disposition refused by {}'.format(self.user_link),
+            u'Disposition refused by {}'.format(self.current_user_link),
             translate(entry.msg(), context=self.request))
 
     def test_ignores_modified_events_during_dossier_destruction(self):
-        api.content.transition(obj=self.disposition,
-                               transition='disposition-transition-appraise')
-        IAppraisal(self.disposition).update(dossier=self.dossier1,
-                                            archive=True)
-        api.content.transition(obj=self.disposition,
-                               transition='disposition-transition-dispose')
-        api.content.transition(obj=self.disposition,
-                               transition='disposition-transition-archive')
-        api.content.transition(obj=self.disposition,
-                               transition='disposition-transition-close')
+        self.login(self.records_manager)
+        with elevated_privileges():
+            api.content.transition(obj=self.disposition,
+                                   transition='disposition-transition-appraise')
+            IAppraisal(self.disposition).update(dossier=self.offered_dossier_to_destroy,
+                                                archive=True)
+            api.content.transition(obj=self.disposition,
+                                   transition='disposition-transition-dispose')
+            api.content.transition(obj=self.disposition,
+                                   transition='disposition-transition-archive')
+            api.content.transition(obj=self.disposition,
+                                   transition='disposition-transition-close')
 
-        history = IHistoryStorage(self.disposition).get_history()
         self.assertEquals(
-            'disposition-transition-close', history[0].transition)
-        self.assertEquals(
-            'disposition-transition-archive', history[1].transition)
+            ['disposition-transition-close', 'disposition-transition-archive',
+             'disposition-transition-dispose', 'disposition-transition-appraise',
+             'added'],
+            [item.transition for item in IHistoryStorage(self.disposition).get_history()]
+        )
 
 
-class TestHistoryListingInOverview(FunctionalTestCase):
+class TestHistoryListingInOverview(IntegrationTestCase):
 
-    def setUp(self):
-        super(TestHistoryListingInOverview, self).setUp()
-        self.root = create(Builder('repository_root'))
-        self.repository = create(Builder('repository').within(self.root))
-        self.dossier1 = create(Builder('dossier')
-                               .as_expired()
-                               .having(archival_value=ARCHIVAL_VALUE_WORTHY)
-                               .within(self.repository))
-        self.dossier2 = create(Builder('dossier')
-                               .as_expired()
-                               .having(archival_value=ARCHIVAL_VALUE_WORTHY)
-                               .within(self.repository))
-        self.grant(
-            'Contributor', 'Editor', 'Reader', 'Reviewer',
-            'Records Manager', 'Archivist')
+    @property
+    def records_manager_label(self):
+        userid = self.records_manager.getId()
+        actor = ActorLookup(userid).lookup()
+        return actor.get_label()
 
-        self.disposition = create(Builder('disposition')
-                             .having(dossiers=[self.dossier1, self.dossier2])
-                             .within(self.root))
-
-        IAppraisal(self.disposition).update(
-            dossier=self.dossier2, archive=False)
-
-        api.content.transition(obj=self.disposition,
-                               transition='disposition-transition-appraise')
-        transaction.commit()
+    @property
+    def archivist_label(self):
+        userid = self.archivist.getId()
+        actor = ActorLookup(userid).lookup()
+        return actor.get_label()
 
     @browsing
     def test_is_sorted_chronological(self, browser):
-        browser.login().open(self.disposition, view='overview')
+        self.login(self.archivist, browser)
+
+        api.content.transition(obj=self.disposition,
+                               transition='disposition-transition-appraise')
+
+        browser.open(self.disposition, view='overview')
 
         self.assertEquals(
-            ['Appraisal finalized by Test User (test_user_1_)',
-             'Added by Test User (test_user_1_)'],
+            [u'Appraisal finalized by {}'.format(self.archivist_label),
+             u'Added by {}'.format(self.records_manager_label)],
             browser.css('.progress .answer h3').text)
 
     @browsing
     def test_details_list_dossier_snapshot(self, browser):
-        browser.login().open(self.disposition, view='overview')
+        self.login(self.archivist, browser)
+
+        IAppraisal(self.disposition).update(
+            dossier=self.offered_dossier_to_archive, archive=False)
+
+        api.content.transition(obj=self.disposition,
+                               transition='disposition-transition-appraise')
+
+        browser.open(self.disposition, view='overview')
 
         appraise = browser.css('div.details ul')[0]
         add = browser.css('div.details ul')[1]
 
         self.assertEquals(
-            ['Client1 1 / 1 Archive', "Client1 1 / 2 Don't archive"],
+            ["Client1 1.1 / 11 Hannah Baufrau Don't archive",
+             "Client1 1.1 / 12 Hans Baumann Don't archive"],
             appraise.css('li').text)
+
         self.assertEquals(
-            ['Client1 1 / 1 Archive', 'Client1 1 / 2 Archive'],
+            ['Client1 1.1 / 11 Hannah Baufrau Archive',
+             "Client1 1.1 / 12 Hans Baumann Don't archive"],
             add.css('li').text)
 
     @browsing
     def test_is_marked_with_corresponding_css_class(self, browser):
-        browser.login().open(self.disposition, view='overview')
+        self.login(self.archivist, browser)
+
+        api.content.transition(obj=self.disposition,
+                               transition='disposition-transition-appraise')
+
+        browser.open(self.disposition, view='overview')
 
         self.assertEquals('answer appraise',
                           browser.css('.progress .answer')[0].get('class'))

--- a/opengever/disposition/tests/test_listing.py
+++ b/opengever/disposition/tests/test_listing.py
@@ -3,20 +3,15 @@ from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
 from ftw.testing import freeze
-from opengever.testing import FunctionalTestCase
+from opengever.testing import IntegrationTestCase
 
 
-class TestDispositionListing(FunctionalTestCase):
-
-    def setUp(self):
-        super(TestDispositionListing, self).setUp()
-        self.root = create(Builder('repository_root'))
+class TestDispositionListing(IntegrationTestCase):
 
     @browsing
     def test_disposition_tab_is_available_on_repositoryroots(self, browser):
-        self.grant('Contributor', 'Editor', 'Reader', 'Records Manager')
-
-        browser.login().open(self.root)
+        self.login(self.records_manager, browser)
+        browser.open(self.repository_root)
 
         self.assertEquals(
             ['Overview', 'Dossiers', 'Dispositions', 'Info'],
@@ -24,7 +19,8 @@ class TestDispositionListing(FunctionalTestCase):
 
     @browsing
     def test_disposition_tab_is_not_available_when_user_cant_add_dispositions(self, browser):
-        browser.login().open(self.root)
+        self.login(self.archivist, browser)
+        browser.login().open(self.repository_root)
 
         self.assertEquals(
             ['Overview', 'Dossiers', 'Info'],
@@ -32,81 +28,74 @@ class TestDispositionListing(FunctionalTestCase):
 
     @browsing
     def test_disposition_listing(self, browser):
-        self.grant('Records Manager')
+        self.login(self.records_manager, browser)
 
         with freeze(datetime(2015, 1, 1)):
-            repository = create(Builder('repository').within(self.root))
             self.disposition_a = create(Builder('disposition')
-                                        .titled(u'Angebot FD 23.11.2010')
-                                        .within(repository))
-            self.disposition_b = create(Builder('disposition')
                                         .titled(u'Angebot FD 1.2.2003')
                                         .in_state('disposition-state-appraised')
-                                        .within(repository))
-            self.disposition_c = create(Builder('disposition')
+                                        .within(self.leaf_repofolder))
+            self.disposition_b = create(Builder('disposition')
                                         .titled(u'Angebot FD 1.2.1995')
                                         .in_state('disposition-state-disposed')
-                                        .within(repository))
+                                        .within(self.leaf_repofolder))
 
-        browser.login().open(self.root, view='tabbedview_view-dispositions')
+        browser.open(self.repository_root, view='tabbedview_view-dispositions')
         self.assertEquals(
             [{'': '',
-              'Sequence Number': '1',
-              'Title': 'Angebot FD 23.11.2010',
-              'Review state': 'disposition-state-in-progress'},
-             {'': '',
               'Sequence Number': '2',
               'Title': 'Angebot FD 1.2.2003',
               'Review state': 'disposition-state-appraised'},
              {'': '',
               'Sequence Number': '3',
               'Title': 'Angebot FD 1.2.1995',
-              'Review state': 'disposition-state-disposed'}],
+              'Review state': 'disposition-state-disposed'},
+             {'': '',
+              'Review state': 'disposition-state-in-progress',
+              'Sequence Number': '1',
+              'Title': 'Angebot 31.8.2016'}],
             browser.css('.listing').first.dicts())
 
     @browsing
     def test_no_tabbedview_actions_available(self, browser):
-        self.grant('Records Manager')
+        self.login(self.records_manager, browser)
 
-        repository = create(Builder('repository').within(self.root))
-        self.disposition_a = create(Builder('disposition').within(repository))
-
-        browser.login().open(self.root, view='tabbedview_view-dispositions')
+        browser.open(self.repository_root, view='tabbedview_view-dispositions')
         self.assertEquals([''], browser.css('.tabbedview-action-list').text)
 
     @browsing
     def test_statefilter_hides_closed_by_default(self, browser):
-        self.grant('Records Manager')
+        self.login(self.records_manager, browser)
 
         with freeze(datetime(2015, 1, 1)):
-            repository = create(Builder('repository').within(self.root))
-            create(Builder('disposition')
-                   .titled(u'In Progress')
-                   .within(repository))
             create(Builder('disposition')
                    .titled(u'Appraised')
                    .in_state('disposition-state-appraised')
-                   .within(repository))
+                   .within(self.leaf_repofolder))
             create(Builder('disposition')
                    .titled(u'Disposed')
                    .in_state('disposition-state-disposed')
-                   .within(repository))
+                   .within(self.leaf_repofolder))
             create(Builder('disposition')
                    .titled(u'Disposed')
                    .in_state('disposition-state-archived')
-                   .within(repository))
+                   .within(self.leaf_repofolder))
             create(Builder('disposition')
                    .titled(u'Closed')
                    .in_state('disposition-state-closed')
-                   .within(repository))
+                   .within(self.leaf_repofolder))
 
-        browser.login().open(self.root, view='tabbedview_view-dispositions')
+        self.disposition.setTitle("In Progress")
+        self.disposition.reindexObject()
+
+        browser.open(self.leaf_repofolder, view='tabbedview_view-dispositions')
         rows = browser.css('.listing').first.dicts()
+
         self.assertItemsEqual(
             ['In Progress', 'Appraised', 'Disposed', 'Disposed'],
             [row.get('Title') for row in rows])
 
-        browser.open(self.root, view='tabbedview_view-dispositions',
+        browser.open(self.leaf_repofolder, view='tabbedview_view-dispositions',
                      data={'disposition_state_filter': 'filter_all'})
         rows = browser.css('.listing').first.dicts()
         self.assertItemsEqual(

--- a/opengever/disposition/tests/test_listing.py
+++ b/opengever/disposition/tests/test_listing.py
@@ -3,7 +3,14 @@ from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
 from ftw.testing import freeze
+from lxml.cssselect import CSSSelector
+from opengever.base.security import elevated_privileges
+from opengever.disposition.interfaces import IHistoryStorage
+from opengever.latex.listing import ILaTexListing
 from opengever.testing import IntegrationTestCase
+from plone import api
+from zope.component import getMultiAdapter
+import lxml
 
 
 class TestDispositionListing(IntegrationTestCase):
@@ -101,3 +108,91 @@ class TestDispositionListing(IntegrationTestCase):
         self.assertItemsEqual(
             ['In Progress', 'Appraised', 'Disposed', 'Disposed', 'Closed'],
             [row.get('Title') for row in rows])
+
+
+class BaseLatexListingTest(IntegrationTestCase):
+
+    def assert_row_values(self, expected, row):
+        self.assertEquals(
+            expected,
+            [value.text_content().strip() for value in
+             row.xpath(CSSSelector('td').path)])
+
+    def get_listing_rows(self, obj, listing_name, items):
+        listing = getMultiAdapter(
+            (obj, obj.REQUEST, self),
+            ILaTexListing, name=listing_name)
+        listing.items = items
+
+        table = lxml.html.fromstring(listing.template())
+        rows = table.xpath(CSSSelector('tbody tr').path)
+        return rows
+
+
+class TestDestroyedDossierListing(BaseLatexListingTest):
+
+    def test_listing(self):
+        self.login(self.regular_user)
+        with elevated_privileges():
+            api.content.transition(obj=self.disposition, transition='disposition-transition-appraise')
+            api.content.transition(obj=self.disposition, transition='disposition-transition-dispose')
+            api.content.transition(obj=self.disposition, transition='disposition-transition-archive')
+            api.content.transition(obj=self.disposition, transition='disposition-transition-close')
+
+        rows = self.get_listing_rows(self.disposition,
+                                     'destroyed_dossiers',
+                                     self.disposition.get_dossier_representations())
+
+        self.assert_row_values(
+            ['Client1 1.1 / 11', 'Hannah Baufrau', 'Yes'], rows[0])
+        self.assert_row_values(
+            ['Client1 1.1 / 12', 'Hans Baumann', 'No'], rows[1])
+
+
+class TestDispositionHistoryListing(BaseLatexListingTest):
+
+    def test_listing(self):
+        self.login(self.records_manager)
+
+        with freeze(datetime(2016, 11, 1, 11, 0)):
+            storage = IHistoryStorage(self.disposition)
+            storage.add('edited', api.user.get_current().getId(), [])
+
+        with freeze(datetime(2016, 11, 6, 12, 33)), elevated_privileges():
+            api.content.transition(self.disposition,
+                                   'disposition-transition-appraise')
+            api.content.transition(self.disposition,
+                                   'disposition-transition-dispose')
+
+        with freeze(datetime(2016, 11, 16, 8, 12)), elevated_privileges():
+            api.content.transition(self.disposition,
+                                   'disposition-transition-archive')
+
+        rows = self.get_listing_rows(self.disposition,
+                                     'disposition_history',
+                                     self.disposition.get_history())
+
+        expected_rows = [
+            ['Nov 16, 2016 08:12 AM', 'Flucht Ramon (ramon.flucht)', 'disposition-transition-archive'],
+            ['Nov 06, 2016 12:33 PM', 'Flucht Ramon (ramon.flucht)', 'disposition-transition-dispose'],
+            ['Nov 06, 2016 12:33 PM', 'Flucht Ramon (ramon.flucht)', 'disposition-transition-appraise'],
+            ['Nov 01, 2016 11:00 AM', 'Flucht Ramon (ramon.flucht)', 'Disposition edited'],
+            ['Aug 31, 2016 07:05 PM', 'Flucht Ramon (ramon.flucht)', 'Disposition added']]
+
+        for row, expected_row in zip(rows, expected_rows):
+            self.assert_row_values(expected_row, row)
+
+    def test_transition_label_for_added_and_edited_entries_is_translated_correctly(self):
+        self.login(self.records_manager)
+
+        storage = IHistoryStorage(self.disposition)
+        storage.add('edited', api.user.get_current().getId(), [])
+
+        rows = self.get_listing_rows(self.disposition,
+                                     'disposition_history',
+                                     self.disposition.get_history())
+
+        self.assert_row_values(
+            ['Disposition edited'], rows[0][2])
+        self.assert_row_values(
+            ['Disposition added'], rows[1][2])

--- a/opengever/disposition/tests/test_removal_protocol.py
+++ b/opengever/disposition/tests/test_removal_protocol.py
@@ -1,134 +1,14 @@
-from datetime import datetime
-from ftw.builder import Builder
-from ftw.builder import create
 from ftw.pdfgenerator.builder import Builder as PDFBuilder
 from ftw.pdfgenerator.interfaces import ILaTeXView
 from ftw.pdfgenerator.utils import provide_request_layer
 from ftw.testbrowser import browsing
-from ftw.testing import freeze
-from lxml.cssselect import CSSSelector
-from opengever.base.behaviors.lifecycle import ARCHIVAL_VALUE_UNWORTHY
-from opengever.base.behaviors.lifecycle import ARCHIVAL_VALUE_WORTHY
 from opengever.disposition.browser.removal_protocol import IRemovalProtocolLayer
-from opengever.disposition.interfaces import IHistoryStorage
 from opengever.latex.layouts.default import DefaultLayout
-from opengever.latex.listing import ILaTexListing
-from opengever.latex.tests.test_listing import BaseLatexListingTest
-from opengever.testing import FunctionalTestCase
-from plone import api
+from opengever.testing import IntegrationTestCase
 from zope.component import getMultiAdapter
-import lxml
 
 
-class TestDestroyedDossierListing(BaseLatexListingTest):
-
-    def setUp(self):
-        super(TestDestroyedDossierListing, self).setUp()
-        dossier_a = create(Builder('dossier')
-                           .as_expired()
-                           .having(archival_value=ARCHIVAL_VALUE_WORTHY)
-                           .titled(u'Dossier A'))
-        dossier_b = create(Builder('dossier')
-                           .as_expired()
-                           .having(archival_value=ARCHIVAL_VALUE_UNWORTHY)
-                           .titled(u'Dossier B'))
-
-        self.grant('Records Manager')
-
-        self.disposition = create(Builder('disposition')
-                                  .having(dossiers=[dossier_a, dossier_b])
-                                  .in_state('disposition-state-closed'))
-        self.disposition.set_destroyed_dossiers([dossier_a, dossier_b])
-
-        self.listing = getMultiAdapter(
-            (self.disposition, self.disposition.REQUEST, self),
-            ILaTexListing, name='destroyed_dossiers')
-
-    def test_listing(self):
-        self.listing.items = self.disposition.get_dossier_representations()
-
-        table = lxml.html.fromstring(self.listing.template())
-        rows = table.xpath(CSSSelector('tbody tr').path)
-
-        self.assert_row_values(
-            ['Client1 / 1', 'Dossier A', 'Yes'], rows[0])
-        self.assert_row_values(
-            ['Client1 / 2', 'Dossier B', 'No'], rows[1])
-
-
-class TestDispositionHistoryListing(BaseLatexListingTest):
-
-    def setUp(self):
-        super(TestDispositionHistoryListing, self).setUp()
-        self.dossier = create(Builder('dossier')
-                              .as_expired()
-                              .having(archival_value=ARCHIVAL_VALUE_WORTHY))
-
-    def test_listing(self):
-        self.grant('Records Manager', 'Archivist')
-        disposition = create(Builder('disposition')
-                             .having(dossiers=[self.dossier]))
-
-        with freeze(datetime(2014, 11, 6, 12, 33)):
-            api.content.transition(disposition,
-                                   'disposition-transition-appraise')
-            api.content.transition(disposition,
-                                   'disposition-transition-dispose')
-
-        with freeze(datetime(2014, 11, 16, 8, 12)):
-            api.content.transition(disposition,
-                                   'disposition-transition-archive')
-
-        self.listing = getMultiAdapter(
-            (disposition, disposition.REQUEST, self),
-            ILaTexListing, name='disposition_history')
-        self.listing.items = disposition.get_history()
-
-        table = lxml.html.fromstring(self.listing.template())
-        rows = table.xpath(CSSSelector('tbody tr').path)
-
-        self.assert_row_values(
-            ['Nov 16, 2014 08:12 AM',
-             'Test User (test_user_1_)',
-             'disposition-transition-archive'], rows[0])
-
-        self.assert_row_values(
-            ['Nov 06, 2014 12:33 PM',
-             'Test User (test_user_1_)',
-             'disposition-transition-dispose'], rows[1])
-
-        self.assert_row_values(
-            ['Nov 06, 2014 12:33 PM',
-             'Test User (test_user_1_)',
-             'disposition-transition-appraise'], rows[2])
-
-    def test_transition_label_for_added_and_edited_entries_is_translated_correctly(self):
-        disposition = create(Builder('disposition'))
-
-        storage = IHistoryStorage(disposition)
-        storage.add('added', api.user.get_current().getId(), [])
-        storage.add('edited', api.user.get_current().getId(), [])
-
-        self.listing = getMultiAdapter(
-            (disposition, disposition.REQUEST, self),
-            ILaTexListing, name='disposition_history')
-        self.listing.items = disposition.get_history()
-
-        table = lxml.html.fromstring(self.listing.template())
-        rows = table.xpath(CSSSelector('tbody tr').path)
-
-        self.assert_row_values(
-            ['Disposition edited'], rows[0][2])
-        self.assert_row_values(
-            ['Disposition added'], rows[1][2])
-
-
-class TestRemovalProtocolLaTeXView(FunctionalTestCase):
-
-    def setUp(self):
-        super(TestRemovalProtocolLaTeXView, self).setUp()
-
-        self.grant('Records Manager')
+class TestRemovalProtocolLaTeXView(IntegrationTestCase):
 
     def get_view(self, disposition):
         provide_request_layer(disposition.REQUEST, IRemovalProtocolLayer)
@@ -137,23 +17,19 @@ class TestRemovalProtocolLaTeXView(FunctionalTestCase):
             (disposition, disposition.REQUEST, layout), ILaTeXView)
 
     def test_disposition_metadata(self):
-        disposition = create(Builder('disposition')
-                             .having(title=u'Angebot FD 43929',
-                                     transfer_number='RSX 382'))
+        self.login(self.records_manager)
+        self.disposition.transfer_number = "RSX 382"
 
         self.assertEquals(
-            u'\\bf Title & Angebot FD 43929 \\\\%%\n\\bf '
+            u'\\bf Title & Angebot 31.8.2016 \\\\%%\n\\bf '
             'Transfer number & RSX 382 \\\\%%',
-            self.get_view(disposition).get_disposition_metadata())
+            self.get_view(self.disposition).get_disposition_metadata())
 
     @browsing
     def test_pdf_title_is_removal_protocol_for_disposition_title(self, browser):
-        disposition = create(Builder('disposition')
-                             .having(title=u'Angebot FD 43929',
-                                     transfer_number='RSX 382'))
-
-        browser.login().open(disposition, view='removal_protocol')
+        self.login(self.records_manager, browser)
+        browser.open(self.disposition, view='removal_protocol')
 
         self.assertEquals(
-            'attachment; filename="Removal protocol for Angebot FD 43929.pdf"',
+            'attachment; filename="Removal protocol for {}.pdf"'.format(self.disposition.title),
             browser.headers.get('content-disposition'))

--- a/opengever/disposition/tests/test_sippackage.py
+++ b/opengever/disposition/tests/test_sippackage.py
@@ -52,16 +52,22 @@ class TestSIPPackage(FunctionalTestCase):
         self.folder = create(Builder('repository').within(self.root))
         self.grant('Contributor', 'Editor', 'Reader', 'Records Manager')
 
-    # TODO: should only include all dossiers from the disposition object
     def test_adds_all_dossiers_and_documents(self):
         dossier_a = create(Builder('dossier').within(self.folder).as_expired())
         create(Builder('document').with_dummy_content().within(dossier_a))
         dossier_b = create(Builder('dossier').within(self.folder).as_expired())
+        dossier_c = create(Builder('dossier').within(self.folder).as_expired())
         disposition = create(Builder('disposition')
                              .having(dossiers=[dossier_a, dossier_b])
                              .within(self.folder))
 
         package = SIPPackage(disposition)
+
+        # test that dossier_c is not in package
+        self.assertEquals(2, len(package.dossiers))
+        self.assertItemsEqual([dossier_a, dossier_b],
+                              [dossier.obj for dossier in package.dossiers])
+        self.assertEquals(2, len(package.content_folder.folders))
 
         dossier_a_model, dossier_b_model = package.content_folder.folders
         self.assertEquals(1, len(dossier_a_model.files))

--- a/opengever/disposition/tests/test_sippackage.py
+++ b/opengever/disposition/tests/test_sippackage.py
@@ -4,8 +4,43 @@ from ftw.builder import create
 from ftw.testing import freeze
 from opengever.disposition.ech0160.sippackage import SIPPackage
 from opengever.testing import FunctionalTestCase
+from opengever.testing import IntegrationTestCase
 from tempfile import TemporaryFile
 from zipfile import ZipFile
+
+
+class TestSIPPackageIntegration(IntegrationTestCase):
+
+    def test_sip_folder_name_correspond_to_ech0160_definition(self):
+        """See chapter 5.4 Aufbau eines SIP in eCH-0160 definition.
+
+        SIP_[Ablieferungsdatum]_[Name der ablieferenden Stelle]_[Referenz].
+        """
+        self.login(self.records_manager)
+        package = SIPPackage(self.disposition)
+
+        with freeze(datetime(2016, 11, 6)):
+            self.assertEquals(
+                'SIP_20161106_PLONE', package.get_folder_name())
+
+        self.disposition.transfer_number = u'10\xe434'
+        with freeze(datetime(2016, 11, 6)):
+            self.assertEquals(
+                u'SIP_20161106_PLONE_10\xe434', package.get_folder_name())
+
+    def test_ablieferungs_metadata(self):
+        self.login(self.records_manager)
+        package = SIPPackage(self.disposition)
+
+        self.assertEquals(
+            u'GEVER', package.ablieferung.ablieferungstyp)
+        self.assertEquals(
+            'Hauptmandant, ramon.flucht',
+            package.ablieferung.ablieferndeStelle)
+        self.assertEquals(
+            u'Hauptmandant', package.ablieferung.provenienz.aktenbildnerName)
+        self.assertEquals(
+            u'Ordnungssystem', package.ablieferung.provenienz.registratur)
 
 
 class TestSIPPackage(FunctionalTestCase):
@@ -13,48 +48,9 @@ class TestSIPPackage(FunctionalTestCase):
     def setUp(self):
         super(TestSIPPackage, self).setUp()
         self.root = create(Builder('repository_root')
-                           .having(title_de=u'Ordnungssytem 2000'))
+                           .having(title_de=u'Ordnungssystem 2000'))
         self.folder = create(Builder('repository').within(self.root))
         self.grant('Contributor', 'Editor', 'Reader', 'Records Manager')
-
-    def test_sip_folder_name_correspond_to_ech0160_definition(self):
-        """See chapter 5.4 Aufbau eines SIP in eCH-0160 definition.
-
-        SIP_[Ablieferungsdatum]_[Name der ablieferenden Stelle]_[Referenz].
-        """
-        dossier = create(Builder('dossier').within(self.folder).as_expired())
-        disposition = create(Builder('disposition')
-                             .having(dossiers=[dossier])
-                             .within(self.folder))
-
-        with freeze(datetime(2016, 11, 6)):
-            package = SIPPackage(disposition)
-            self.assertEquals(
-                'SIP_20161106_PLONE', package.get_folder_name())
-
-        disposition.transfer_number = u'10\xe434'
-        with freeze(datetime(2016, 11, 6)):
-            package = SIPPackage(disposition)
-            self.assertEquals(
-                u'SIP_20161106_PLONE_10\xe434', package.get_folder_name())
-
-    def test_ablieferungs_metadata(self):
-        dossier = create(Builder('dossier').within(self.folder).as_expired())
-        disposition = create(Builder('disposition')
-                             .having(dossiers=[dossier])
-                             .within(self.folder))
-
-        package = SIPPackage(disposition)
-
-        self.assertEquals(
-            u'GEVER', package.ablieferung.ablieferungstyp)
-        self.assertEquals(
-            'Admin Unit 1, test_user_1_',
-            package.ablieferung.ablieferndeStelle)
-        self.assertEquals(
-            u'Admin Unit 1', package.ablieferung.provenienz.aktenbildnerName)
-        self.assertEquals(
-            u'Ordnungssytem 2000', package.ablieferung.provenienz.registratur)
 
     # TODO: should only include all dossiers from the disposition object
     def test_adds_all_dossiers_and_documents(self):

--- a/opengever/disposition/tests/test_views.py
+++ b/opengever/disposition/tests/test_views.py
@@ -1,45 +1,19 @@
-from datetime import date
-from ftw.builder import Builder
-from ftw.builder import create
 from ftw.testbrowser import browsing
-from opengever.base.behaviors.lifecycle import ARCHIVAL_VALUE_SAMPLING
 from opengever.disposition.disposition import IDisposition
-from opengever.testing import FunctionalTestCase
+from opengever.testing import IntegrationTestCase
 from plone.protect import createToken
 
 
-class TestUpdateTransferNumber(FunctionalTestCase):
+class TestUpdateTransferNumber(IntegrationTestCase):
     """Test disposition overviews function as intended."""
 
-    def setUp(self):
-        super(TestUpdateTransferNumber, self).setUp()
-        self.grant('Records Manager')
-        self.root = create(Builder('repository_root'))
-        self.repository = create(Builder('repository')
-                                 .titled(u'Repository A')
-                                 .having(
-                                     archival_value=ARCHIVAL_VALUE_SAMPLING)
-                                 .within(self.root))
-        self.dossier1 = create(Builder('dossier')
-                               .as_expired()
-                               .within(self.repository)
-                               .having(title=u'Dossier A',
-                                       start=date(2016, 1, 19),
-                                       end=date(2016, 3, 19),
-                                       public_trial='limited-public',
-                                       archival_value='archival worthy'))
-
-        self.disposition = create(Builder('disposition').having(
-            dossiers=[self.dossier1],
-            transfer_number=u'Ablieferung 2013-44'))
-
     @browsing
-    def test_update_transfer_number(self, browser):
-        self.grant('Archivist')
-        browser.login().open(self.disposition,
-                             {'transfer_number': u'Ablieferung 2018-1',
-                              '_authenticator': createToken()},
-                             view=u'update-transfer-number')
+    def test_update_transfer_number_integration(self, browser):
+        self.login(self.archivist, browser)
+        browser.open(self.disposition,
+                     {'transfer_number': u'Ablieferung 2018-1',
+                      '_authenticator': createToken()},
+                     view=u'update-transfer-number')
 
         self.assertEquals({u'proceed': True}, browser.json)
         self.assertEquals(u'Ablieferung 2018-1',

--- a/opengever/disposition/tests/test_workflow.py
+++ b/opengever/disposition/tests/test_workflow.py
@@ -1,166 +1,159 @@
-from ftw.builder import Builder
-from ftw.builder import create
 from ftw.testbrowser import browsing
 from ftw.testbrowser.exceptions import FormFieldNotFound
 from ftw.testbrowser.pages.statusmessages import error_messages
-from opengever.base.behaviors.lifecycle import ARCHIVAL_VALUE_PROMPT
-from opengever.base.behaviors.lifecycle import ARCHIVAL_VALUE_SAMPLING
 from opengever.base.behaviors.lifecycle import ARCHIVAL_VALUE_UNWORTHY
 from opengever.base.behaviors.lifecycle import ARCHIVAL_VALUE_WORTHY
 from opengever.base.behaviors.lifecycle import ILifeCycle
+from opengever.base.security import elevated_privileges
 from opengever.disposition.interfaces import IAppraisal
-from opengever.testing import FunctionalTestCase
+from opengever.testing import IntegrationTestCase
 from plone import api
 from plone.api.exc import InvalidParameterError
-import transaction
 
 
-class TestDispositionWorkflow(FunctionalTestCase):
-
-    def setUp(self):
-        super(TestDispositionWorkflow, self).setUp()
-        self.root = create(Builder('repository_root'))
-        self.repository = create(Builder('repository').within(self.root))
-        self.dossier1 = create(Builder('dossier')
-                               .as_expired()
-                               .having(archival_value=ARCHIVAL_VALUE_PROMPT)
-                               .within(self.repository))
-        self.dossier2 = create(Builder('dossier')
-                               .as_expired()
-                               .having(archival_value=ARCHIVAL_VALUE_SAMPLING)
-                               .within(self.repository))
-
-        self.grant('Records Manager')
-        self.disposition = create(Builder('disposition')
-                                  .having(dossiers=[self.dossier1, self.dossier2])
-                                  .within(self.root))
+class TestDispositionWorkflowIntegration(IntegrationTestCase):
 
     def test_initial_state_is_in_progress(self):
+        self.login(self.records_manager)
         self.assertEquals('disposition-state-in-progress',
                           api.content.get_state(self.disposition))
 
     def test_dispositon_in_progress_can_be_refused_by_an_archivist(self):
-        self.grant('Archivist')
+        self.login(self.archivist)
         api.content.transition(self.disposition, 'disposition-transition-refuse')
         self.assertEquals('disposition-state-in-progress',
                           api.content.get_state(self.disposition))
 
     def test_dispositon_in_disposed_state_can_be_refused_by_an_archivist(self):
-        disposition = create(Builder('disposition')
-                             .in_state('disposition-state-disposed'))
 
-        self.grant('Archivist')
-        api.content.transition(disposition, 'disposition-transition-refuse')
+        with elevated_privileges():
+            api.content.transition(self.disposition, to_state='disposition-state-disposed')
+
+        self.login(self.archivist)
+        api.content.transition(self.disposition, 'disposition-transition-refuse')
         self.assertEquals('disposition-state-in-progress',
-                          api.content.get_state(disposition))
+                          api.content.get_state(self.disposition))
 
     def test_archivist_is_not_allowed_to_dispose_a_disposition(self):
-        disposition = create(Builder('disposition')
-                             .in_state('disposition-state-appraised'))
-        IAppraisal(disposition).update(dossier=self.dossier1, archive=True)
-        IAppraisal(disposition).update(dossier=self.dossier2, archive=True)
+        self.login(self.archivist)
+        api.content.transition(obj=self.disposition,
+                               transition='disposition-transition-appraise')
 
-        with self.assertRaises(InvalidParameterError):
-            self.grant('Archivist')
-            api.content.transition(disposition,
-                                   'disposition-transition-dispose')
-
-        self.grant('Records Manager')
-        api.content.transition(disposition, 'disposition-transition-dispose')
-
-    def test_dispose_is_only_allowed_when_disposition_contains_dossier_to_archive(self):
-        self.grant('Archivist')
-        appraisal = IAppraisal(self.disposition)
-        appraisal.update(dossier=self.dossier1, archive=False)
-        appraisal.update(dossier=self.dossier2, archive=False)
-        api.content.transition(self.disposition,
-                               'disposition-transition-appraise')
-
-        self.grant('Records Manager')
         with self.assertRaises(InvalidParameterError):
             api.content.transition(self.disposition,
                                    'disposition-transition-dispose')
 
-        appraisal.update(dossier=self.dossier1, archive=True)
+        self.login(self.records_manager)
+        api.content.transition(self.disposition, 'disposition-transition-dispose')
+
+    def test_dispose_is_only_allowed_when_disposition_contains_dossier_to_archive(self):
+        self.login(self.archivist)
+        appraisal = IAppraisal(self.disposition)
+        appraisal.update(dossier=self.offered_dossier_to_archive, archive=False)
+        api.content.transition(obj=self.disposition,
+                               transition='disposition-transition-appraise')
+
+        self.login(self.records_manager)
+        with self.assertRaises(InvalidParameterError):
+            api.content.transition(self.disposition,
+                                   'disposition-transition-dispose')
+
+        appraisal.update(dossier=self.offered_dossier_to_archive, archive=True)
         api.content.transition(self.disposition, 'disposition-transition-dispose')
 
     def test_direct_close_is_not_allowed_when_disposition_contains_dossier_to_archive(self):
-        self.grant('Archivist')
+        self.login(self.archivist)
+        api.content.transition(obj=self.disposition,
+                               transition='disposition-transition-appraise')
+
         appraisal = IAppraisal(self.disposition)
-        appraisal.update(dossier=self.dossier1, archive=True)
-        appraisal.update(dossier=self.dossier2, archive=False)
-        api.content.transition(self.disposition,
-                               'disposition-transition-appraise')
+        self.assertTrue(appraisal.get(self.offered_dossier_to_archive))
 
-        self.grant('Records Manager')
+        self.login(self.records_manager)
         with self.assertRaises(InvalidParameterError):
-            api.content.transition(self.disposition,
-                                   'disposition-transition-appraised-to-closed')
+            api.content.transition(obj=self.disposition,
+                                   transition='disposition-transition-appraised-to-closed')
 
-        appraisal.update(dossier=self.dossier1, archive=False)
-        api.content.transition(self.disposition,
-                               'disposition-transition-appraised-to-closed')
+        appraisal.update(dossier=self.offered_dossier_to_archive, archive=False)
+        api.content.transition(obj=self.disposition,
+                               transition='disposition-transition-appraised-to-closed')
 
     def test_direct_close_is_not_allowed_for_archivists(self):
-        self.grant('Archivist')
+        self.login(self.archivist)
         appraisal = IAppraisal(self.disposition)
-        appraisal.update(dossier=self.dossier1, archive=False)
-        appraisal.update(dossier=self.dossier2, archive=False)
-        api.content.transition(self.disposition,
-                               'disposition-transition-appraise')
+        appraisal.update(dossier=self.offered_dossier_to_archive, archive=False)
+        api.content.transition(obj=self.disposition,
+                               transition='disposition-transition-appraise')
 
         with self.assertRaises(InvalidParameterError):
-            api.content.transition(self.disposition,
-                                   'disposition-transition-appraised-to-closed')
+            api.content.transition(obj=self.disposition,
+                                   transition='disposition-transition-appraised-to-closed')
 
-        self.grant('Records Manager')
+        self.login(self.records_manager)
         api.content.transition(self.disposition,
                                'disposition-transition-appraised-to-closed')
 
     def test_records_manager_is_not_allowed_to_archive_a_disposition(self):
-        disposition = create(Builder('disposition')
-                             .in_state('disposition-state-disposed'))
+        self.login(self.records_manager)
+        with self.login(self.archivist):
+            api.content.transition(obj=self.disposition,
+                                   transition='disposition-transition-appraise')
+
+        api.content.transition(obj=self.disposition,
+                               transition='disposition-transition-dispose')
 
         with self.assertRaises(InvalidParameterError):
-            self.grant('Records Manager')
-            api.content.transition(disposition,
-                                   'disposition-transition-archive')
+            api.content.transition(obj=self.disposition,
+                                   transition='disposition-transition-archive')
 
-        self.grant('Archivist')
-        api.content.transition(disposition, 'disposition-transition-archive')
+        self.login(self.archivist)
+        api.content.transition(obj=self.disposition,
+                               transition='disposition-transition-archive')
 
     def test_archivist_is_not_allowed_to_close_a_disposition(self):
-        disposition = create(Builder('disposition')
-                             .in_state('disposition-state-archived'))
+        with elevated_privileges():
+            api.content.transition(obj=self.disposition,
+                                   to_state='disposition-state-archived')
 
+        self.login(self.archivist)
         with self.assertRaises(InvalidParameterError):
-            self.grant('Archivist')
-            api.content.transition(disposition,
-                                   'disposition-transition-close')
+            api.content.transition(obj=self.disposition,
+                                   transition='disposition-transition-close')
 
-        self.grant('Records Manager')
-        api.content.transition(disposition, 'disposition-transition-close')
+        self.login(self.records_manager)
+        api.content.transition(obj=self.disposition,
+                               transition='disposition-transition-close')
 
     def test_when_appraising_final_archival_value_is_stored_on_dossier(self):
-        self.grant('Archivist')
+        self.login(self.archivist)
 
-        IAppraisal(self.disposition).update(
-            dossier=self.dossier1, archive=False)
-        IAppraisal(self.disposition).update(
-            dossier=self.dossier2, archive=True)
+        appraisal = IAppraisal(self.disposition)
+        self.assertEquals(
+            ARCHIVAL_VALUE_WORTHY,
+            ILifeCycle(self.offered_dossier_to_archive).archival_value)
+        self.assertEquals(
+            ARCHIVAL_VALUE_UNWORTHY,
+            ILifeCycle(self.offered_dossier_to_destroy).archival_value)
 
+        appraisal.update(dossier=self.offered_dossier_to_archive, archive=False)
+        appraisal.update(dossier=self.offered_dossier_to_destroy, archive=True)
         api.content.transition(
             self.disposition, transition='disposition-transition-appraise')
 
         self.assertEquals(
-            ARCHIVAL_VALUE_UNWORTHY, ILifeCycle(self.dossier1).archival_value)
+            ARCHIVAL_VALUE_UNWORTHY,
+            ILifeCycle(self.offered_dossier_to_archive).archival_value)
         self.assertEquals(
-            ARCHIVAL_VALUE_WORTHY, ILifeCycle(self.dossier2).archival_value)
+            ARCHIVAL_VALUE_WORTHY,
+            ILifeCycle(self.offered_dossier_to_destroy).archival_value)
 
     @browsing
     def test_appraising_is_not_possible_if_the_appraisal_is_incomplete(self, browser):
-        self.grant('Archivist')
-        browser.login().open(self.disposition)
+        self.login(self.archivist, browser)
+        appraisal = IAppraisal(self.disposition)
+        appraisal.update(dossier=self.offered_dossier_to_archive, archive=None)
+
+        browser.open(self.disposition)
         browser.click_on('disposition-transition-appraise')
 
         self.assertEquals(
@@ -169,43 +162,47 @@ class TestDispositionWorkflow(FunctionalTestCase):
         self.assertEquals('disposition-state-in-progress',
                           api.content.get_state(self.disposition))
 
-        appraisal = IAppraisal(self.disposition)
-        appraisal.update(dossier=self.dossier1, archive=False)
-        appraisal.update(dossier=self.dossier2, archive=True)
-        transaction.commit()
+        appraisal.update(dossier=self.offered_dossier_to_archive, archive=True)
 
-        browser.login().open(self.disposition)
+        browser.open(self.disposition)
         browser.click_on('disposition-transition-appraise')
         self.assertEquals('disposition-state-appraised',
                           api.content.get_state(self.disposition))
 
-    def test_when_archiving_all_dossiers_moved_to_archived_set_to_archive_state(self):
-        self.grant('Archivist', 'Records Manager')
-        IAppraisal(self.disposition).update(dossier=self.dossier1, archive=True)
-        IAppraisal(self.disposition).update(dossier=self.dossier2, archive=True)
-        api.content.transition(
-            self.disposition, transition='disposition-transition-appraise')
-        api.content.transition(
-            self.disposition, transition='disposition-transition-dispose')
+    def test_set_all_dossiers_to_archived_state_when_archiving_disposition(self):
+        self.login(self.archivist)
+        self.assertEquals('dossier-state-offered',
+                          api.content.get_state(self.offered_dossier_to_archive))
+        self.assertEquals('dossier-state-offered',
+                          api.content.get_state(self.offered_dossier_to_destroy))
 
-        api.content.transition(
-            self.disposition, transition='disposition-transition-archive')
+        api.content.transition(obj=self.disposition,
+                               transition='disposition-transition-appraise')
 
-        self.assertEquals(
-            'dossier-state-archived', api.content.get_state(self.dossier1))
-        self.assertEquals(
-            'dossier-state-archived', api.content.get_state(self.dossier2))
+        with self.login(self.records_manager):
+            api.content.transition(obj=self.disposition,
+                                   transition='disposition-transition-dispose')
+
+        api.content.transition(obj=self.disposition,
+                               transition='disposition-transition-archive')
+
+        self.assertEquals('dossier-state-archived',
+                          api.content.get_state(self.offered_dossier_to_archive))
+        self.assertEquals('dossier-state-archived',
+                          api.content.get_state(self.offered_dossier_to_destroy))
 
     @browsing
     def test_transfer_number_is_only_editable_by_archivist(self, browser):
-        self.grant('Records Manager')
-        browser.login().open(self.disposition, view='edit')
+        self.login(self.records_manager, browser)
+        browser.open(self.disposition, view='edit')
 
         with self.assertRaises(FormFieldNotFound):
             browser.fill({'Transfer number': 'AB 123'})
+        browser.css("#form-buttons-cancel").first.click()
 
-        self.grant('Archivist')
-        browser.login().open(self.disposition, view='edit')
+        self.login(self.archivist, browser)
+        browser.open(self.disposition, view='edit')
+
         browser.fill({'Transfer number': 'AB 123'})
         browser.click_on('Save')
 

--- a/opengever/dossier/tests/test_indexer.py
+++ b/opengever/dossier/tests/test_indexer.py
@@ -152,6 +152,7 @@ class TestDossierIndexers(IntegrationTestCase):
                 u'Subsubkeyword',
                 u'Subsubkeyw\xf6rd',
                 u'Vertr\xe4ge',
+                u'Wichtig',
                 u'secret',
                 u'special',
                 ),

--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -64,7 +64,9 @@ class OpengeverContentFixture(object):
         with self.freeze_at_hour(4):
             self.create_units()
 
-        with self.freeze_at_hour(5):
+        # Create users. Here we can use a 1minute step between creation of two
+        # objects as every second one is a ogds user with no creation date.
+        with self.freeze_at_hour(5, tick_length=1):
             self.create_users()
 
         with self.freeze_at_hour(6):
@@ -253,6 +255,13 @@ class OpengeverContentFixture(object):
             'workspace_guest',
             u'Hans',
             u'Peter',
+            )
+
+        self.archivist = self.create_user(
+            'archivist',
+            u'J\xfcrgen',
+            u'Fischer',
+            ['Archivist']
             )
 
         # This user is intended to be used in situations where you need a user
@@ -1490,7 +1499,7 @@ class OpengeverContentFixture(object):
             )
 
     @contextmanager
-    def freeze_at_hour(self, hour):
+    def freeze_at_hour(self, hour, tick_length=2):
         """Freeze the time when creating content with builders, so that
         we can rely on consistent creation times.
         Since we can sort consistently when all objects have the exact same
@@ -1507,7 +1516,7 @@ class OpengeverContentFixture(object):
         start = datetime(2016, 8, 31, hour, 1, 33, tzinfo=pytz.UTC)
         end = start + timedelta(hours=1)
         with freeze(start) as clock:
-            with ticking_creator(clock, minutes=2):
+            with ticking_creator(clock, minutes=tick_length):
                 with self.ticking_proposal_history(clock, seconds=1):
                     with time_based_intids():
                         yield


### PR DESCRIPTION
* changes to the fixture:
  * Added a new user `archivist` to the fixture
  * Added 2 offered dossiers and a disposition to the fixture
  * Add the clock as attribute of the fixture.
  * Create plone user and ogds user with the same timestamp. Before we were moving the clock 2 minutes between these two, but this leads to necessitating 4 minutes per cerated user, which did not allow to add the `archivist` in the same hour as the other users. 
* Ported almost all disposition tests to the integration layer. 
* Fix bug in disposition ech0160 folder model. See below

Not all tests in `TestSIPPackage` could be ported, as we need documents in the disposition dossier, but these cannot be added properly in an integration test, as we never really write the blobs when in this isolation layer. Of course we could add documents to the fixture, but it's one of the only places where they are necessary.

In the disposition folder model, we had `dossier` as argument of the `__init__` method, but this argument was then overwritten in a for loop and then used again to get the files in the dossier (see snippet below). This led to getting the files from the last subdossier instead of the files of the current dossier, but only if the folder had at least one subdossier, which made it slip through the tests. This error was picked up after porting `TestFolderAndFileModel.test_complete_tree_representation` to the integration layer. This test is more complete now and tests a more complex structure.

```
def __init__(self, toc, dossier, base_path):
    self.folders = []
    self.files = []

    self.name = u'd{0:06d}'.format(toc.next_folder)
    toc.increment_folder_counter()
    self.path = os.path.join(base_path, self.name)

    for dossier in dossier.dossiers.values():
        self.folders.append(Folder(toc, dossier, self.path))

    for doc in dossier.documents.values():
        if doc.obj.archival_file or doc.obj.file:
            self.files.append(File(toc, doc))
```

resolves #5133 