### PR TITLE
gitignore: Make _build match recursively instead of just in the root directory.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.mo
 *.pyc
 .DS_Store
+_build/
 /.installed.cfg
 /.mr.developer.cfg
 /.python-version
@@ -9,7 +10,6 @@
 /.ruby-version
 /.sass-cache
 /README.html
-/_build/
 /build/
 /buildout.cfg
 /coverage/


### PR DESCRIPTION
This directory gets created by Sphinx documentation builds, and may appear at any depth.

Fixes the underlying issue for the mess in #5188