### PR TITLE
Amend the keywordwidget js template to also list team members

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -26,6 +26,7 @@ Changelog
 - Correctly update containing_dossier and containing_subdossier indexes. [njohner]
 - Also show participants with expired membership in meeting participants-tab. [njohner]
 - Change remaining "zurücksenden" to "ablegen". [njohner]
+- Also expand teams, like groups, on keyword widgets. [Rotonen]
 - Translate z3c.formwidget.query (nothing). [njohner]
 - Add buttons for managers to get the toc json for meeting periods. [njohner]
 - Add absent members to the meeting protocolData. [njohner]

--- a/opengever/base/browser/configure.zcml
+++ b/opengever/base/browser/configure.zcml
@@ -11,6 +11,13 @@
       permission="zope2.View"
       />
 
+  <browser:page
+      name="list_teammembers"
+      for="*"
+      class=".list_teammembers.ListTeamMembers"
+      permission="zope2.View"
+      />
+
   <adapter factory=".navtree.OpengeverNavtreeStrategy" />
 
   <browser:page

--- a/opengever/base/browser/list_groupmembers.py
+++ b/opengever/base/browser/list_groupmembers.py
@@ -2,17 +2,27 @@ from opengever.ogds.base.actor import Actor
 from opengever.ogds.base.utils import ogds_service
 from Products.Five import BrowserView
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+from zExceptions import BadRequest
 
 
 class ListGroupMembers(BrowserView):
+    """Fetch group members by group id."""
+
     template = ViewPageTemplateFile("list_groupmembers.pt")
+
+    def __init__(self, context, request):
+        super(ListGroupMembers, self).__init__(context, request)
+
+        self.active = None
+        self.members = None
+        self.group_id = None
 
     def __call__(self):
         self.group_id = self.context.REQUEST.get('group', None)
         self.members = []
 
         if not self.group_id:
-            return 'no group id'
+            BadRequest('no group id')
 
         group = ogds_service().fetch_group(self.group_id)
         self.active = getattr(group, 'active', None)

--- a/opengever/base/browser/list_teammembers.py
+++ b/opengever/base/browser/list_teammembers.py
@@ -1,0 +1,45 @@
+from opengever.ogds.base.actor import Actor
+from opengever.ogds.models.team import Team
+from Products.Five import BrowserView
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+from sqlalchemy.orm.exc import NoResultFound
+from zExceptions import BadRequest
+
+
+class ListTeamMembers(BrowserView):
+    """Fetch team group and group members by team id."""
+
+    template = ViewPageTemplateFile("list_groupmembers.pt")
+
+    def __init__(self, context, request):
+        super(ListTeamMembers, self).__init__(context, request)
+
+        self.active = None
+        self.members = None
+        self.team_id = None
+        self.group_id = None
+
+    def __call__(self):
+        self.team_id = self.context.REQUEST.get('team', None)
+        self.members = []
+
+        if not self.team_id:
+            raise BadRequest('no team id')
+
+        try:
+            team = Team.query.filter_by(team_id=self.team_id).one()
+            group = getattr(team, 'group', None)
+            self.group_id = getattr(group, 'groupid', None)
+        except NoResultFound:
+            self.group_id = None
+
+        if not self.group_id:
+            raise BadRequest('no group id')
+
+        self.active = getattr(group, 'active', None)
+
+        actors = [Actor.user(user.userid) for user in getattr(group, 'users', [])]
+        actors.sort(key=lambda actor: actor.get_label())
+        self.members = [each.get_link() for each in actors]
+
+        return self.template()

--- a/opengever/base/browser/resources/keywordwidget.js
+++ b/opengever/base/browser/resources/keywordwidget.js
@@ -1,93 +1,93 @@
 (function($) {
-    function usersAndGroupsTemplate(widget) {
-        return function(data) {
-            // This template will mark users and groups with an icon. Additionaly
-            // it links groups with an overlay to see all group-members.
-            if (!data.id) {
-                // Happens while searching
-                return data.text;
-            }
-
-            var isGroup = false;
-            var principalId = "";
-            var principalTitle = "";
-            var baseClass = "keywordWidgetUsersAndGroupsElement";
-            var groupMemberEndpoint = "@@list_groupmembers";
-
-            function init(data) {
-                var principal = data.id.split("group:");
-                if (principal.length > 1) {
-                    isGroup = true;
-                }
-                principalId = principal[principal.length - 1];
-                principalTitle = data.text;
-            }
-
-            function generateUserElement() {
-                var element = $("<span />");
-                element.addClass(baseClass);
-                element.append($("<span class='fa fa-user'></span>"));
-                element.append($("<span />").text(principalTitle));
-                return element;
-            }
-
-            function generateGroupElement() {
-                var element = $("<a />");
-                element.addClass(baseClass);
-                element.attr("href", groupMemberEndpoint + "?group=" + principalId);
-                element.append($("<span class='fa fa-users'></span>"));
-                element.append($("<span />").text(principalTitle));
-                element.prepOverlay({
-                    subtype: "ajax",
-                });
-
-                return element;
-            }
-
-            init(data);
-
-            if (isGroup) {
-                return generateGroupElement();
-            } else {
-                return generateUserElement();
-            }
-        };
-    }
-    function showConsistencyWarning(message) {
-        if ($(".protectDossierConsistencyMessage").length > 0) {
-            // Consistency warning already exists
-            return;
-        }
-
-        var portalMessage = $("<dl />");
-        portalMessage.addClass("portalMessage");
-        portalMessage.addClass(message.messageClass);
-        portalMessage.addClass("protectDossierConsistencyMessage");
-
-        portalMessage.append($("<dt />").text(message.messageTitle));
-        portalMessage.append($("<dd />").text(message.message));
-
-        $("#content").before(portalMessage);
-    }
-
-    $(document).on("ftwKeywordWidgetInit", function() {
-        window.ftwKeywordWidget.registerTemplate("usersAndGroups", usersAndGroupsTemplate);
-    });
-
-    $(document).on("ftwKeywordWidgetInitWidget", function (e, widget) {
-      if (["form-widgets-IProtectDossier-reading",
-           "form-widgets-IProtectDossier-reading_and_writing",
-           "form-widgets-IProtectDossier-dossier_manager"].indexOf(widget.attr("id")) >= 0) {
-          widget.on("change", function(e) {
-              var url = $("base").attr("href") + "@@check_protect_dossier_consistency";
-              $.get(url, function(data) {
-                  if (!data.messages) {
-                      // No consistency error
-                      return;
-                  }
-                  showConsistencyWarning(data.messages[0]);
-              });
-          });
+  function usersAndGroupsTemplate(widget) {
+    return function(data) {
+      // This template will mark users and groups with an icon. Additionaly
+      // it links groups with an overlay to see all group-members.
+      if (!data.id) {
+        // Happens while searching
+        return data.text;
       }
-    });
+
+      var isGroup = false;
+      var principalId = '';
+      var principalTitle = '';
+      var baseClass = 'keywordWidgetUsersAndGroupsElement';
+      var groupMemberEndpoint = '@@list_groupmembers';
+
+      function init(data) {
+        var principal = data.id.split('group:');
+        if (principal.length > 1) {
+          isGroup = true;
+        }
+        principalId = principal[principal.length - 1];
+        principalTitle = data.text;
+      }
+
+      function generateUserElement() {
+        var element = $('<span />');
+        element.addClass(baseClass);
+        element.append($('<span class="fa fa-user"></span>'));
+        element.append($('<span />').text(principalTitle));
+        return element;
+      }
+
+      function generateGroupElement() {
+        var element = $('<a />');
+        element.addClass(baseClass);
+        element.attr('href', groupMemberEndpoint + '?group=' + principalId);
+        element.append($('<span class="fa fa-users"></span>'));
+        element.append($('<span />').text(principalTitle));
+        element.prepOverlay({
+          subtype: 'ajax',
+        });
+
+        return element;
+      }
+
+      init(data);
+
+      if (isGroup) {
+        return generateGroupElement();
+      } else {
+        return generateUserElement();
+      }
+    };
+  }
+  function showConsistencyWarning(message) {
+    if ($('.protectDossierConsistencyMessage').length > 0) {
+      // Consistency warning already exists
+      return;
+    }
+
+    var portalMessage = $('<dl />');
+    portalMessage.addClass('portalMessage');
+    portalMessage.addClass(message.messageClass);
+    portalMessage.addClass('protectDossierConsistencyMessage');
+
+    portalMessage.append($('<dt />').text(message.messageTitle));
+    portalMessage.append($('<dd />').text(message.message));
+
+    $('#content').before(portalMessage);
+  }
+
+  $(document).on('ftwKeywordWidgetInit', function() {
+    window.ftwKeywordWidget.registerTemplate('usersAndGroups', usersAndGroupsTemplate);
+  });
+
+  $(document).on('ftwKeywordWidgetInitWidget', function (e, widget) {
+    if (['form-widgets-IProtectDossier-reading',
+      'form-widgets-IProtectDossier-reading_and_writing',
+      'form-widgets-IProtectDossier-dossier_manager'].indexOf(widget.attr('id')) >= 0) {
+      widget.on('change', function(e) {
+        var url = $('base').attr('href') + '@@check_protect_dossier_consistency';
+        $.get(url, function(data) {
+          if (!data.messages) {
+            // No consistency error
+            return;
+          }
+          showConsistencyWarning(data.messages[0]);
+        });
+      });
+    }
+  });
 })(jQuery);

--- a/opengever/base/browser/resources/keywordwidget.js
+++ b/opengever/base/browser/resources/keywordwidget.js
@@ -9,15 +9,23 @@
       }
 
       var isGroup = false;
+      var isTeam = false;
       var principalId = '';
       var principalTitle = '';
       var baseClass = 'keywordWidgetUsersAndGroupsElement';
       var groupMemberEndpoint = '@@list_groupmembers';
+      var teamMemberEndpoint = '@@list_teammembers';
 
       function init(data) {
         var principal = data.id.split('group:');
         if (principal.length > 1) {
           isGroup = true;
+        }
+        else {
+          principal = data.id.split('team:');
+          if (principal.length > 1) {
+            isTeam = true;
+          }
         }
         principalId = principal[principal.length - 1];
         principalTitle = data.text;
@@ -28,6 +36,18 @@
         element.addClass(baseClass);
         element.append($('<span class="fa fa-user"></span>'));
         element.append($('<span />').text(principalTitle));
+        return element;
+      }
+
+      function generateTeamElement() {
+        var element = $('<a />');
+        element.addClass(baseClass);
+        element.attr('href', teamMemberEndpoint + '?team=' + principalId);
+        element.append($('<span class="fa fa-users"></span>'));
+        element.append($('<span />').text(principalTitle));
+        element.prepOverlay({
+          subtype: 'ajax',
+        });
         return element;
       }
 
@@ -48,6 +68,8 @@
 
       if (isGroup) {
         return generateGroupElement();
+      } else if (isTeam) {
+        return generateTeamElement();
       } else {
         return generateUserElement();
       }

--- a/opengever/base/tests/test_list_teammembers.py
+++ b/opengever/base/tests/test_list_teammembers.py
@@ -1,0 +1,27 @@
+from ftw.testbrowser import browsing
+from opengever.testing import IntegrationTestCase
+
+
+class TestTeamMembersView(IntegrationTestCase):
+
+    @browsing
+    def test_list_teammembers_view(self, browser):
+        self.login(self.regular_user, browser)
+        browser.open(view='list_teammembers', data={'team': 1})
+        self.assertSequenceEqual(
+            [u'B\xe4rfuss K\xe4thi (kathi.barfuss)', u'Ziegler Robert (robert.ziegler)'],
+            browser.css('.member_listing li a').text,
+        )
+
+    @browsing
+    def test_list_teammembers_view_with_nonexisting_group(self, browser):
+        self.login(self.regular_user, browser)
+        with browser.expect_http_error(code=400, reason='Bad Request'):
+            browser.open(view='list_teammembers', data={'team': 0})
+            self.assertEqual(['no group id'], browser.css('p').text)
+
+    @browsing
+    def test_list_teammembers_view_with_empty_group(self, browser):
+        self.login(self.regular_user, browser)
+        browser.open(view='list_teammembers', data={'team': 3})
+        self.assertEqual(['There are no members in this group.'], browser.css('p').text)

--- a/opengever/contact/tests/test_team_listing.py
+++ b/opengever/contact/tests/test_team_listing.py
@@ -27,44 +27,31 @@ class TestTeamListing(IntegrationTestCase):
 
     @browsing
     def test_lists_only_active_teams_by_default(self, browser):
-        self.login(self.regular_user, browser=browser)
+        self.login(self.regular_user, browser)
         browser.open(self.contactfolder, view='tabbedview_view-teams')
-
-        self.assertEquals(
-            [u'Projekt \xdcberbaung Dorfmatte', 'Sekretariat Abteilung XY'],
-            [team.get('Title') for team in
-             browser.css('.listing').first.dicts()])
+        expected_teams = [u'Projekt \xdcberbaung Dorfmatte', 'Sekretariat Abteilung Null', 'Sekretariat Abteilung XY']
+        self.assertEqual(expected_teams, [team.get('Title') for team in browser.css('.listing').first.dicts()])
 
         Team.get('1').active = False
         create_session().flush()
 
         browser.open(self.contactfolder, view='tabbedview_view-teams')
-        self.assertEquals(
-            ['Sekretariat Abteilung XY'],
-            [team.get('Title') for team in
-             browser.css('.listing').first.dicts()])
+        expected_teams = ['Sekretariat Abteilung Null', 'Sekretariat Abteilung XY']
+        self.assertEquals(expected_teams, [team.get('Title') for team in browser.css('.listing').first.dicts()])
 
     @browsing
     def test_lists_also_inactive_teams_with_all_filter(self, browser):
         Team.get('1').active = False
         create_session().flush()
 
-        self.login(self.regular_user, browser=browser)
-        browser.open(self.contactfolder, view='tabbedview_view-teams',
-                     data={'team_state_filter': 'filter_all'})
-
-        self.assertEquals(
-            [u'Projekt \xdcberbaung Dorfmatte', 'Sekretariat Abteilung XY'],
-            [team.get('Title') for team in
-             browser.css('.listing').first.dicts()])
+        self.login(self.regular_user, browser)
+        browser.open(self.contactfolder, view='tabbedview_view-teams', data={'team_state_filter': 'filter_all'})
+        expected_teams = [u'Projekt \xdcberbaung Dorfmatte', 'Sekretariat Abteilung Null', 'Sekretariat Abteilung XY']
+        self.assertEqual(expected_teams, [team.get('Title') for team in browser.css('.listing').first.dicts()])
 
     @browsing
     def test_filtering_on_title(self, browser):
-        self.login(self.regular_user, browser=browser)
-        browser.open(self.contactfolder, view='tabbedview_view-teams',
-                     data={'searchable_text': 'abteilung',})
-
-        self.assertEquals(
-            [u'Sekretariat Abteilung XY'],
-            [team.get('Title') for team in
-             browser.css('.listing').first.dicts()])
+        self.login(self.regular_user, browser)
+        browser.open(self.contactfolder, view='tabbedview_view-teams', data={'searchable_text': 'abteilung'})
+        expected_teams = ['Sekretariat Abteilung Null', 'Sekretariat Abteilung XY']
+        self.assertEqual(expected_teams, [team.get('Title') for team in browser.css('.listing').first.dicts()])

--- a/opengever/examplecontent/hooks.py
+++ b/opengever/examplecontent/hooks.py
@@ -1,5 +1,6 @@
 from opengever.examplecontent.contacts import ContactExampleContentCreator
 from opengever.examplecontent.meeting import MeetingExampleContentCreator
+from opengever.examplecontent.teams import TeamExampleContentCreator
 from opengever.private import enable_opengever_private
 
 
@@ -8,6 +9,9 @@ def municipality_content_profile_installed(site):
     creator.create_content()
 
     creator = ContactExampleContentCreator()
+    creator.create()
+
+    creator = TeamExampleContentCreator()
     creator.create()
 
     enable_opengever_private()

--- a/opengever/examplecontent/teams.py
+++ b/opengever/examplecontent/teams.py
@@ -1,0 +1,24 @@
+from itertools import cycle
+from opengever.base.model import create_session
+from opengever.ogds.models.group import Group
+from opengever.ogds.models.org_unit import OrgUnit
+from opengever.ogds.models.team import Team
+
+
+class TeamExampleContentCreator(object):
+    """Create Teams for example content.
+
+    Creates one team per group.
+
+    Predictably cycles through the existing org units.
+    """
+
+    def __init__(self):
+        self.db_session = create_session()
+
+    def create(self):
+        org_units = cycle(OrgUnit.query.all())
+        groups = Group.query.filter_by(active=True).all()
+        for group in groups:
+            team = Team(title=group.title or group.groupid, group=group, org_unit=next(org_units))
+            self.db_session.add(team)

--- a/opengever/examplecontent/tests/test_hooks.py
+++ b/opengever/examplecontent/tests/test_hooks.py
@@ -23,4 +23,4 @@ class TestHooks(IntegrationTestCase):
         self.assertEqual(4, AgendaItem.query.count())
         self.assertEqual(9, Meeting.query.count())
 
-        self.assertEqual(8, Team.query.count())
+        self.assertEqual(10, Team.query.count())

--- a/opengever/examplecontent/tests/test_hooks.py
+++ b/opengever/examplecontent/tests/test_hooks.py
@@ -1,6 +1,7 @@
 from opengever.meeting.model import AgendaItem
 from opengever.meeting.model import Meeting
 from opengever.meeting.model import Proposal
+from opengever.ogds.models.team import Team
 from opengever.testing import IntegrationTestCase
 from plone import api
 from plone.app.testing import applyProfile
@@ -21,3 +22,5 @@ class TestHooks(IntegrationTestCase):
         self.assertEqual(5, Proposal.query.count())
         self.assertEqual(4, AgendaItem.query.count())
         self.assertEqual(9, Meeting.query.count())
+
+        self.assertEqual(8, Team.query.count())

--- a/opengever/meeting/tests/test_committee_roles.py
+++ b/opengever/meeting/tests/test_committee_roles.py
@@ -64,6 +64,7 @@ class TestCommitteeGroupsVocabulary(IntegrationTestCase):
              u'fa_inbox_users',
              u'projekt_a',
              u'projekt_b',
+             u'projekt_laeaer',
              u'committee_rpk_group',
              u'committee_ver_group'],
             [term.value for term in

--- a/opengever/ogds/base/tests/test_sources.py
+++ b/opengever/ogds/base/tests/test_sources.py
@@ -1002,7 +1002,7 @@ class TestAllUsersAndGroupsSource(IntegrationTestCase):
 class TestAllFilteredGroupsSource(TestAllGroupsSource):
 
     def setUp(self):
-        super(TestAllGroupsSource, self).setUp()
+        super(TestAllFilteredGroupsSource, self).setUp()
         self.source = AllFilteredGroupsSource(self.portal)
 
     def test_search_does_not_find_blacklisted_groups(self):

--- a/opengever/ogds/base/tests/test_sources.py
+++ b/opengever/ogds/base/tests/test_sources.py
@@ -947,21 +947,14 @@ class TestAllGroupsSource(IntegrationTestCase):
 
     def test_search_finds_only_enabled_org_units(self):
         result = self.source.search('projek')
-
-        self.assertEqual(2, len(result), 'Expect two result. Projey A and Projekt B')
-        self.assertEquals(['projekt_a', 'projekt_b'],
-                          [item.value for item in result])
-        self.assertEquals(['Projekt A', 'Projekt B'],
-                          [item.title for item in result])
+        self.assertEqual(3, len(result), 'Expected three results.')
+        self.assertEquals(['projekt_a', 'projekt_b', 'projekt_laeaer'], [item.value for item in result])
+        self.assertEquals(['Projekt A', 'Projekt B', u'Projekt L\xc3\xa4\xc3\xa4r'], [item.title for item in result])
 
         group = Group.query.get('projekt_b')
         group.active = False
-
         result = self.source.search('projek')
-
-        self.assertEqual(
-            1, len(result),
-            'Expect one result, Projekt A - Projekt B is disabled')
+        self.assertEqual(2, len(result), 'Expected two results.')
 
     def test_invalid_token_raises_lookup_error(self):
         with self.assertRaises(LookupError):
@@ -1006,31 +999,34 @@ class TestAllFilteredGroupsSource(TestAllGroupsSource):
         self.source = AllFilteredGroupsSource(self.portal)
 
     def test_search_does_not_find_blacklisted_groups(self):
-        self.assertEqual(
-            [u'fa_users', u'fa_inbox_users', u'projekt_a', u'projekt_b',
-             u'committee_rpk_group', u'committee_ver_group'],
-            [term.value for term in self.source.search('')])
+        expected_groups = [
+            u'fa_users',
+            u'fa_inbox_users',
+            u'projekt_a',
+            u'projekt_b',
+            u'projekt_laeaer',
+            u'committee_rpk_group',
+            u'committee_ver_group',
+        ]
+        self.assertEqual(expected_groups, [term.value for term in self.source.search('')])
 
         # Whitelist no group explicitly
-        api.portal.set_registry_record('white_list_prefix',
-                                       u'^$',
-                                       ISharingConfiguration)
+        api.portal.set_registry_record('white_list_prefix', u'^$', ISharingConfiguration)
 
         # Blacklist all groups beginning with `fa_`
-        api.portal.set_registry_record('black_list_prefix',
-                                       u'^fa_',
-                                       ISharingConfiguration)
+        api.portal.set_registry_record('black_list_prefix', u'^fa_', ISharingConfiguration)
 
-        self.assertEqual(
-            [u'projekt_a', u'projekt_b', u'committee_rpk_group',
-             u'committee_ver_group'],
-            [term.value for term in self.source.search('')])
+        expected_groups = [
+            u'projekt_a',
+            u'projekt_b',
+            u'projekt_laeaer',
+            u'committee_rpk_group',
+            u'committee_ver_group',
+        ]
+        self.assertEqual(expected_groups, [term.value for term in self.source.search('')])
 
         # Blacklist all groups
-        api.portal.set_registry_record('black_list_prefix',
-                                       u'^.',
-                                       ISharingConfiguration)
-
+        api.portal.set_registry_record('black_list_prefix', u'^.', ISharingConfiguration)
         self.assertEqual([], [term.value for term in self.source.search('')])
 
     def test_search_finds_whitelisted_org_groups(self):

--- a/opengever/ogds/base/tests/test_team_forms.py
+++ b/opengever/ogds/base/tests/test_team_forms.py
@@ -29,9 +29,9 @@ class TestTeamAddForm(IntegrationTestCase):
         form.find_widget('Org Unit').fill('fa')
         form.find_widget('Group').fill('projekt_a')
         browser.find('Save').click()
-        self.assertEquals(3, len(Team.query.all()))
+        self.assertEquals(4, len(Team.query.all()))
 
-        team = Team.query.get(3)
+        team = Team.query.get(4)
         self.assertEquals('projekt_a', team.groupid)
         self.assertEquals(u'Projekt \xdcberbaung Dorfmatte', team.title)
         self.assertEquals('fa', team.org_unit_id)

--- a/opengever/task/task.py
+++ b/opengever/task/task.py
@@ -274,6 +274,14 @@ class IAddTaskSchema(ITask):
         fields=[u'tasktemplate_position'],
     )
 
+    form.widget(
+        'responsible',
+        KeywordFieldWidget,
+        async=True,
+        template_selection='usersAndGroups',
+        template_result='usersAndGroups',
+    )
+
     responsible = schema.List(
         title=_(u"label_responsible", default=u"Responsible"),
         description=_(u"help_responsible", default=""),

--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -339,6 +339,24 @@ class OpengeverContentFixture(object):
                 )
             )
 
+        group_empty = create(
+            Builder('ogds_group')
+            .having(
+                groupid=u'projekt_laeaer',
+                title=u'Projekt L\xc3\xa4\xc3\xa4r',
+                users=[],
+            )
+        )
+
+        create(
+            Builder('ogds_team')
+            .having(
+                title=u'Sekretariat Abteilung Null',
+                group=group_empty,
+                org_unit=self.org_unit,
+            )
+        )
+
     @staticuid()
     def create_repository_tree(self):
         self.root = self.register('repository_root', create(


### PR DESCRIPTION
![2018-12-18-team-keywordwidget](https://user-images.githubusercontent.com/935317/50172614-c3661100-02f5-11e9-8c81-94e7ff91271c.gif)

* Added teams to example content
* Added an empty group and a team for it into the fixtures
* Added a view for the keyword widget to use to fetch team members
* Extended the keyword widget js template to also work with teams
* Used the form on the add task form responsible field

Did I miss some other forms where this new template should now be used for the widget?

Closes #5129 