### PR TITLE
Convert all tests from opengever.base to integration tests. 

### DIFF
--- a/opengever/advancedsearch/tests/test_search.py
+++ b/opengever/advancedsearch/tests/test_search.py
@@ -2,45 +2,43 @@ from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
 from ftw.testbrowser.exceptions import FormFieldNotFound
-from opengever.core.testing import activate_filing_number
-from opengever.core.testing import inactivate_filing_number
-from opengever.testing import FunctionalTestCase
+from opengever.dossier.behaviors.dossier import IDossierMarker
+from opengever.testing import IntegrationTestCase
 import urllib
+import urlparse
 
 
-class TestSearchForm(FunctionalTestCase):
+class TestSearchForm(IntegrationTestCase):
 
     @browsing
     def test_filing_number_fields_is_hidden_in_site_without_filing_number_support(self, browser):
-        browser.login().open(self.portal, view='advanced_search')
+        self.login(self.regular_user, browser=browser)
+        browser.open(self.portal, view='advanced_search')
 
         with self.assertRaises(FormFieldNotFound):
             browser.fill({'Filing number': 'Test'})
 
 
-class TestSearchFormWithFilingNumberSupport(FunctionalTestCase):
+class TestSearchFormWithFilingNumberSupport(IntegrationTestCase):
 
-    def setUp(self):
-        super(TestSearchFormWithFilingNumberSupport, self).setUp()
-        activate_filing_number(self.portal)
-
-    def tearDown(self):
-        super(TestSearchFormWithFilingNumberSupport, self).tearDown()
-        inactivate_filing_number(self.portal)
+    features = ('filing_number', )
 
     @browsing
     def test_filing_number_field_is_displayed_in_a_filing_number_supported_site(self, browser):
-        browser.login().open(view='advanced_search')
-        browser.fill({'Filing number': 'Test'})
+        self.login(self.regular_user, browser=browser)
+        browser.open(self.portal, view='advanced_search')
+
+        browser.fill({'Filing number': u'FD-112'})
 
 
-class TestSearchFormObjectProvidesDescription(FunctionalTestCase):
+class TestSearchFormObjectProvidesDescription(IntegrationTestCase):
 
     @browsing
     def test_contains_special_info_in_a_multi_client_setup(self, browser):
-        create(Builder('admin_unit'))
+        create(Builder('admin_unit').id("additional"))
 
-        browser.login().open(self.portal, view='advanced_search')
+        self.login(self.regular_user, browser=browser)
+        browser.open(self.portal, view='advanced_search')
 
         self.assertEquals(
             ['Select the contenttype to be searched for.It searches '
@@ -49,125 +47,191 @@ class TestSearchFormObjectProvidesDescription(FunctionalTestCase):
 
     @browsing
     def test_not_contains_client_info_in_a_single_client_setup(self, browser):
-        browser.login().open(self.portal, view='advanced_search')
+        self.login(self.regular_user, browser=browser)
+        browser.open(self.portal, view='advanced_search')
 
         self.assertEquals(
             ['Select the contenttype to be searched for.'],
             browser.css('#formfield-form-widgets-object_provides span.formHelp').text)
 
 
-class TestSearchWithContent(FunctionalTestCase):
-
-    def setUp(self):
-        super(TestSearchWithContent, self).setUp()
-
-        self.dossier1 = create(Builder("dossier").titled(u"Dossier1"))
-        self.dossier2 = create(Builder("dossier").titled(u"Dossier2"))
+class TestSearchWithContent(IntegrationTestCase):
 
     @browsing
     def test_search_dossiers(self, browser):
-        browser.login().open(self.dossier1, view='advanced_search')
+        self.login(self.regular_user, browser=browser)
+
+        browser.open(self.portal, view='advanced_search')
         browser.fill({
-            'Text': "dossier1",
+            'Text': "kantonalen Finanzverwaltung",
             'Type': ['opengever.dossier.behaviors.dossier.IDossierMarker']})
         browser.css('#form-buttons-button_search').first.click()
 
         self.assertEquals(['1'], browser.css('#search-results-number').text)
         self.assertEquals(
-            'http://nohost/plone/@@search?object_provides=opengever.dossier.behaviors.dossier.IDossierMarker&SearchableText=dossier1',
-            browser.url)
+            'object_provides=opengever.dossier.behaviors.dossier.IDossierMarker'
+            '&SearchableText=kantonalen+Finanzverwaltung',
+            urlparse.urlparse(browser.url).query)
+        self.assertEquals(
+            [u'Vertr\xe4ge mit der kantonalen Finanzverwaltung'],
+            browser.css('.searchResults .searchItem dt').text)
 
     @browsing
     def test_search_documents(self, browser):
-        create(Builder("document").within(self.dossier1).titled("Document1"))
-        create(Builder("document").within(self.dossier2).titled("Document2"))
+        self.login(self.regular_user, browser=browser)
 
-        # search documents (we can't find the document because we must
-        # change the content-type)
-        browser.login().open(self.dossier1, view='advanced_search')
+        browser.open(self.portal, view='advanced_search')
         browser.fill({
-            'Text': "document1",
-            'Type': ['opengever.dossier.behaviors.dossier.IDossierMarker']})
-        browser.css('#form-buttons-button_search').first.click()
-        self.assertEquals(['0'], browser.css('#search-results-number').text)
-
-        # search documents with the right content-type
-        browser.open(self.dossier1, view='advanced_search')
-        browser.fill({
-            'Text': "document1",
+            'Text': u'Vertr\xe4gsentwurf',
             'Type': ['opengever.document.behaviors.IBaseDocument']})
         browser.css('#form-buttons-button_search').first.click()
 
-        self.assertEquals(['1'], browser.css('#search-results-number').text)
-        self.assertEquals(['Document1'], browser.css('.searchItem dt').text)
+        self.assertEquals(['3'], browser.css('#search-results-number').text)
+        self.assertEquals(
+            [self.document.title, self.taskdocument.title,
+             self.proposaldocument.title],
+            browser.css('.searchResults .searchItem dt').text)
 
     @browsing
     def test_search_tasks(self, browser):
-        create(Builder("task").within(self.dossier1).titled("Task1"))
-        create(Builder("task").within(self.dossier2).titled("Task2"))
-
-        # search tasks (we can't find the task because we must change
-        # the content-type)
-        browser.login().open(self.dossier1, view='advanced_search')
+        self.login(self.regular_user, browser=browser)
+        browser.open(self.portal, view='advanced_search')
         browser.fill({
-            'Text': "task1",
-            'Type': ['opengever.dossier.behaviors.dossier.IDossierMarker']})
-        browser.css('#form-buttons-button_search').first.click()
-        self.assertEquals(['0'], browser.css('#search-results-number').text)
-
-        # search tasks with the right content-type
-        browser.login().open(self.dossier1, view='advanced_search')
-        browser.fill({
-            'Text': "task1",
+            'Text': "Rechtliche Grundlagen",
             'Type': ['opengever.task.task.ITask']})
         browser.css('#form-buttons-button_search').first.click()
+
         self.assertEquals(['1'], browser.css('#search-results-number').text)
-        self.assertEquals(['Task1'], browser.css('.searchItem dt').text)
+        self.assertEquals([self.subtask.title],
+                          browser.css('.searchResults .searchItem dt').text)
+
+    @browsing
+    def test_date_min_queries(self, browser):
+        self.login(self.regular_user, browser=browser)
+        browser.open(self.portal, view='advanced_search')
+
+        browser.fill({
+            'Text': "kantonalen Finanzverwaltung",
+            'form.widgets.object_provides': IDossierMarker.__identifier__,
+            'form.widgets.start_1': "10.10.2015"})
+        browser.css('#form-buttons-button_search').first.click()
+
+        self.assertEquals([self.dossier.title],
+                          browser.css('.searchResults .searchItem dt').text)
+
+        browser.open(self.portal, view='advanced_search')
+        browser.fill({
+            'Text': "kantonalen Finanzverwaltung",
+            'form.widgets.object_provides': IDossierMarker.__identifier__,
+            'form.widgets.start_1': "10.01.2017"})
+        browser.css('#form-buttons-button_search').first.click()
+        self.assertEquals([],
+                          browser.css('.searchResults .searchItem dt').text)
+
+    @browsing
+    def test_date_max_queries(self, browser):
+        self.login(self.regular_user, browser=browser)
+        browser.open(self.portal, view='advanced_search')
+
+        browser.fill({
+            'Text': u'Abgeschlossene Vertr\xe4ge',
+            'form.widgets.object_provides': IDossierMarker.__identifier__,
+            'form.widgets.end_2': "10.10.2002"})
+        browser.css('#form-buttons-button_search').first.click()
+
+        self.assertEquals([self.expired_dossier.title],
+                          browser.css('.searchResults .searchItem dt').text)
+
+        browser.open(self.portal, view='advanced_search')
+        browser.fill({
+            'Text': u'Abgeschlossene Vertr\xe4ge',
+            'form.widgets.object_provides': IDossierMarker.__identifier__,
+            'form.widgets.end_2': "10.10.1998"})
+        browser.css('#form-buttons-button_search').first.click()
+        self.assertEquals([],
+                          browser.css('.searchResults .searchItem dt').text)
+
+    @browsing
+    def test_can_select_dossier_responsible_from_inactive_ou_in_widget(self, browser):
+        self.create_inactive_user()
+        self.login(self.regular_user, browser=browser)
+
+        # We manually do a request on the widget here because
+        # ftw.keywordwidget.tests.widget.AsyncKeywordWidget
+        # doesn't support .query() yet
+        widget_url = '/'.join((
+            self.portal.absolute_url(),
+            'advanced_search',
+            '++widget++form.widgets.responsible'))
+        browser.open(widget_url + '/search?q=without')
+
+        self.assertIn(
+            {'id': 'user.without.orgunit',
+             'text': 'Orgunit Without (user.without.orgunit)',
+             '_resultId': 'user.without.orgunit'},
+            browser.json['results'])
+
+    @browsing
+    def test_can_select_task_issuer_from_inactive_ou_in_widget(self, browser):
+        self.create_inactive_user()
+        self.login(self.regular_user, browser=browser)
+
+        # We manually do a request on the widget here because
+        # ftw.keywordwidget.tests.widget.AsyncKeywordWidget
+        # doesn't support .query() yet
+        widget_url = '/'.join((
+            self.portal.absolute_url(),
+            'advanced_search',
+            '++widget++form.widgets.issuer'))
+        browser.open(widget_url + '/search?q=without')
+
+        self.assertIn(
+            {'id': 'user.without.orgunit',
+             'text': 'Orgunit Without (user.without.orgunit)',
+             '_resultId': 'user.without.orgunit'},
+            browser.json['results'])
+
+    @browsing
+    def test_can_select_doc_checked_out_from_inactive_ou_in_widget(self, browser):
+        self.create_inactive_user()
+        self.login(self.regular_user, browser=browser)
+
+        # We manually do a request on the widget here because
+        # ftw.keywordwidget.tests.widget.AsyncKeywordWidget
+        # doesn't support .query() yet
+        widget_url = '/'.join((
+            self.portal.absolute_url(),
+            'advanced_search',
+            '++widget++form.widgets.checked_out'))
+        browser.open(widget_url + '/search?q=without')
+
+        self.assertIn(
+            {'id': 'user.without.orgunit',
+             'text': 'Orgunit Without (user.without.orgunit)',
+             '_resultId': 'user.without.orgunit'},
+            browser.json['results'])
+
+    @browsing
+    def test_disable_unload_protection(self, browser):
+        self.login(self.regular_user, browser=browser)
+        browser.open(self.portal, view='advanced_search')
+
+        self.assertNotIn('enableUnloadProtection', browser.contents)
 
 
-class TestSearchWithoutContent(FunctionalTestCase):
+class TestQueryStrings(IntegrationTestCase):
 
-    def setUp(self):
-        super(TestSearchWithoutContent, self).setUp()
-
-        activate_filing_number(self.portal)
-
-        self.dossier1 = create(Builder("dossier"))
-
-    def tearDown(self):
-        super(TestSearchWithoutContent, self).tearDown()
-
-        inactivate_filing_number(self.portal)
+    features = ('filing_number', )
 
     def assertBrowserUrlContainsSearchParams(self, browser, params):
         url = "http://nohost/plone/@@search?{}".format(urllib.urlencode(params))
         self.assertEqual(browser.url, url)
 
     @browsing
-    def test_date_min_or_max_range_is_queried(self, browser):
-        browser.login()
-        browser.open(view='advanced_search')
-        browser.fill({'form.widgets.object_provides': 'opengever.dossier.behaviors.dossier.IDossierMarker',
-                      'form.widgets.start_1': "01.01.2010",
-                      'form.widgets.end_2': "01.04.2010"})
-        browser.css('#form-buttons-button_search').first.click()
-
-        self.assertBrowserUrlContainsSearchParams(browser, [
-            ('object_provides', 'opengever.dossier.behaviors.dossier.IDossierMarker'),
-            ('start.range:record', 'min'),
-            ('start.query:record:list:date', '2010-01-01'),
-            ('end.range:record', 'max'),
-            ('end.query:record:list:date', '2010-04-02'),
-        ])
-
-    @browsing
     def test_validate_searchstring_for_dossiers(self, browser):
-        create(Builder('ogds_user')
-               .having(firstname='Foo', lastname='Boss',
-                       userid='foo@example.com')
-               .assign_to_org_units([self.org_unit]))
+        self.login(self.regular_user, browser=browser)
+        browser.open(view='advanced_search')
 
-        browser.login().open(view='advanced_search')
         browser.fill({'form.widgets.searchableText': "dossier1",
                       'form.widgets.object_provides': ['opengever.dossier.behaviors.dossier.IDossierMarker'],
                       'form.widgets.start_1': "01.01.2010",
@@ -180,8 +244,7 @@ class TestSearchWithoutContent(FunctionalTestCase):
                       'form.widgets.dossier_review_state:list': 'dossier-state-active'})
 
         form = browser.find_form_by_field('Responsible')
-        form.find_widget('Responsible').fill('foo@example.com')
-
+        form.find_widget('Responsible').fill(self.regular_user.id)
         browser.css('#form-buttons-button_search').first.click()
 
         self.assertBrowserUrlContainsSearchParams(browser, [
@@ -196,76 +259,15 @@ class TestSearchWithoutContent(FunctionalTestCase):
             ('reference', 'OG 14.2'),
             ('sequence_number:int', '5'),
             ('searchable_filing_no', '14'),
-            ('responsible', 'foo@example.com'),
+            ('responsible', self.regular_user.id),
             ('review_state:list', 'dossier-state-active'),
         ])
 
     @browsing
-    def test_can_select_dossier_responsible_from_inactive_ou_in_widget(self, browser):
-        create(Builder('ogds_user')
-               .having(firstname='Without', lastname='Orgunit',
-                       userid='user.without.orgunit'))
-
-        # We manually do a request on the widget here because
-        # ftw.keywordwidget.tests.widget.AsyncKeywordWidget
-        # doesn't support .query() yet
-        widget_url = '/'.join((
-            self.portal.absolute_url(),
-            'advanced_search',
-            '++widget++form.widgets.responsible'))
-        browser.login().open(widget_url + '/search?q=without')
-
-        self.assertIn(
-            {'id': 'user.without.orgunit',
-             'text': 'Orgunit Without (user.without.orgunit)',
-             '_resultId': 'user.without.orgunit'},
-            browser.json['results'])
-
-    @browsing
-    def test_can_select_task_issuer_from_inactive_ou_in_widget(self, browser):
-        create(Builder('ogds_user')
-               .having(firstname='Without', lastname='Orgunit',
-                       userid='user.without.orgunit'))
-
-        # We manually do a request on the widget here because
-        # ftw.keywordwidget.tests.widget.AsyncKeywordWidget
-        # doesn't support .query() yet
-        widget_url = '/'.join((
-            self.portal.absolute_url(),
-            'advanced_search',
-            '++widget++form.widgets.issuer'))
-        browser.login().open(widget_url + '/search?q=without')
-
-        self.assertIn(
-            {'id': 'user.without.orgunit',
-             'text': 'Orgunit Without (user.without.orgunit)',
-             '_resultId': 'user.without.orgunit'},
-            browser.json['results'])
-
-    @browsing
-    def test_can_select_doc_checked_out_from_inactive_ou_in_widget(self, browser):
-        create(Builder('ogds_user')
-               .having(firstname='Without', lastname='Orgunit',
-                       userid='user.without.orgunit'))
-
-        # We manually do a request on the widget here because
-        # ftw.keywordwidget.tests.widget.AsyncKeywordWidget
-        # doesn't support .query() yet
-        widget_url = '/'.join((
-            self.portal.absolute_url(),
-            'advanced_search',
-            '++widget++form.widgets.checked_out'))
-        browser.login().open(widget_url + '/search?q=without')
-
-        self.assertIn(
-            {'id': 'user.without.orgunit',
-             'text': 'Orgunit Without (user.without.orgunit)',
-             '_resultId': 'user.without.orgunit'},
-            browser.json['results'])
-
-    @browsing
     def test_validate_searchstring_for_documents(self, browser):
-        browser.login().open(view='advanced_search')
+        self.login(self.regular_user, browser=browser)
+        browser.open(view='advanced_search')
+
         browser.fill({'form.widgets.searchableText': "document1",
                       'form.widgets.object_provides': 'opengever.document.behaviors.IBaseDocument',
                       'form.widgets.receipt_date_1': "01.01.2010",
@@ -293,7 +295,9 @@ class TestSearchWithoutContent(FunctionalTestCase):
 
     @browsing
     def test_validate_searchstring_for_tasks(self, browser):
-        browser.login().open(view='advanced_search')
+        self.login(self.regular_user, browser=browser)
+        browser.open(view='advanced_search')
+
         browser.fill({'form.widgets.searchableText': "task1",
                       'form.widgets.object_provides': 'opengever.task.task.ITask',
                       'form.widgets.deadline_1': "01.01.2010",
@@ -310,8 +314,3 @@ class TestSearchWithoutContent(FunctionalTestCase):
             ('deadline.query:record:list:date', '2010-02-02'),
             ('task_type', 'information'),
         ])
-
-    @browsing
-    def test_disable_unload_protection(self, browser):
-        browser.login().open(view='advanced_search')
-        self.assertNotIn('enableUnloadProtection', browser.contents)

--- a/opengever/base/templates/simple_link.pt
+++ b/opengever/base/templates/simple_link.pt
@@ -1,4 +1,4 @@
 <a  href="#" tal:content="context/Title"
     tal:attributes="href context/getURL;
                     class context/ContentTypeClass;
-                    alt python: context.Title().decode('utf-8')" />
+                    alt python: context.Title() and context.Title().decode('utf-8')" />

--- a/opengever/base/tests/byline_base_test.py
+++ b/opengever/base/tests/byline_base_test.py
@@ -1,8 +1,8 @@
-from opengever.testing import FunctionalTestCase
+from opengever.testing import IntegrationTestCase
 from ftw.testbrowser import browser as default_browser
 
 
-class TestBylineBase(FunctionalTestCase):
+class TestBylineBase(IntegrationTestCase):
 
     def get_byline_value_by_label(self, label, browser=default_browser):
         byline_elements = browser.css(".documentByLine li")

--- a/opengever/base/tests/test_archeologist.py
+++ b/opengever/base/tests/test_archeologist.py
@@ -1,42 +1,32 @@
-from ftw.builder import Builder
-from ftw.builder import create
-from ftw.bumblebee.tests.helpers import asset as bumblebee_asset
 from opengever.base.archeologist import Archeologist
-from opengever.testing import FunctionalTestCase
+from opengever.testing import IntegrationTestCase
 from opengever.testing.helpers import create_document_version
 from plone import api
 from zope.annotation.interfaces import IAnnotations
-import transaction
 
 
 TEST_ANNOTATION_KEY = 'test_archeologist'
 
 
-class TestArcheologist(FunctionalTestCase):
+class TestArcheologist(IntegrationTestCase):
 
     def test_archeologist_returns_modifyable_persistent_reference(self):
-        dossier = create(Builder('dossier'))
-        document = create(Builder('document')
-                          .within(dossier)
-                          .attach_file_containing(
-                              bumblebee_asset('example.docx').bytes(),
-                              u'example.docx'))
-        create_document_version(document, version_id=1)
-        create_document_version(document, version_id=2)
+        self.login(self.regular_user)
+
+        create_document_version(self.document, version_id=1)
+        create_document_version(self.document, version_id=2)
 
         repository = api.portal.get_tool('portal_repository')
 
         archived_obj = Archeologist(
-            document, repository.retrieve(document, selector=1)).excavate()
+            self.document, repository.retrieve(self.document, selector=1)).excavate()
         annotations = IAnnotations(archived_obj)
         self.assertNotIn(TEST_ANNOTATION_KEY, annotations)
         annotations[TEST_ANNOTATION_KEY] = 'can touch this!'
         archived_obj.some_attr = 'can touch this!'
 
-        transaction.commit()
-
         archived_obj = Archeologist(
-            document, repository.retrieve(document, selector=1)).excavate()
+            self.document, repository.retrieve(self.document, selector=1)).excavate()
         annotations = IAnnotations(archived_obj)
         self.assertIn(TEST_ANNOTATION_KEY, annotations)
         self.assertEqual('can touch this!', annotations[TEST_ANNOTATION_KEY])

--- a/opengever/base/tests/test_edit_public_trial_form.py
+++ b/opengever/base/tests/test_edit_public_trial_form.py
@@ -1,89 +1,77 @@
-from ftw.builder import Builder
-from ftw.builder import create
 from ftw.testbrowser import browsing
-from opengever.base.browser import edit_public_trial
-from opengever.testing import FunctionalTestCase
 from opengever.base.behaviors.classification import PUBLIC_TRIAL_PRIVATE
+from opengever.base.browser import edit_public_trial
+from opengever.testing import IntegrationTestCase
+from plone import api
+from zExceptions import Unauthorized
 
 
-class TestEditPublicTrialHelperFunction(FunctionalTestCase):
+class TestEditPublicTrialHelperFunction(IntegrationTestCase):
 
     def setUp(self):
         super(TestEditPublicTrialHelperFunction, self).setUp()
-
-        dossier = create(Builder('dossier').in_state('dossier-state-resolved'))
-        self.document = create(Builder('document')
-                               .with_dummy_content()
-                               .within(dossier))
-
         self.can_edit = edit_public_trial.can_access_public_trial_edit_form
 
     def test_parent_of_content_needs_to_be_a_dossier(self):
-        user = self.portal.portal_membership.getAuthenticatedMember()
+        self.login(self.regular_user)
+        self.set_workflow_state('dossier-state-resolved', self.dossier)
 
+        user = api.user.get_current()
         self.assertTrue(self.can_edit(user, self.document))
 
         with self.assertRaises(AssertionError):
             self.can_edit(user, self.document.aq_parent)
 
     def test_one_of_the_parents_needs_to_be_a_dossier(self):
-        user = self.portal.portal_membership.getAuthenticatedMember()
-        dossier = create(Builder('dossier').in_state('dossier-state-resolved'))
-        task = create(Builder('task').within(dossier))
-        document = create(Builder('document')
-                          .with_dummy_content()
-                          .within(task))
+        self.login(self.regular_user)
+        self.set_workflow_state('dossier-state-resolved', self.dossier)
 
-        self.assertTrue(self.can_edit(user, document))
+        self.assertTrue(self.can_edit(api.user.get_current(), self.taskdocument))
 
     def test_user_CANNOT_edit_when_parent_dossier_is_inactive(self):
-        user = self.portal.portal_membership.getAuthenticatedMember()
-        dossier = create(Builder('dossier').in_state('dossier-state-inactive'))
-        document = create(Builder('document')
-                          .with_dummy_content()
-                          .within(dossier))
+        self.login(self.regular_user)
+        self.set_workflow_state('dossier-state-inactive', self.dossier)
 
-        self.assertFalse(self.can_edit(user, document))
+        self.assertFalse(self.can_edit(api.user.get_current(), self.document))
 
     def test_user_WITH_modify_permission_in_open_state_CAN_edit(self):
-        user = self.portal.portal_membership.getAuthenticatedMember()
+        self.login(self.regular_user)
+        self.set_workflow_state('dossier-state-resolved', self.dossier)
 
-        self.assertTrue(self.can_edit(user, self.document))
+        self.assertTrue(self.can_edit(api.user.get_current(), self.document))
 
     def test_user_WITHOUT_modify_permission_in_open_state_CANNOT_edit(self):
-        user = create(Builder('user').with_roles('Contributor'))
-        self.assertFalse(self.can_edit(user, self.document))
+        self.login(self.regular_user)
+        self.set_workflow_state('dossier-state-resolved', self.dossier)
+
+        self.assertFalse(self.can_edit(self.reader_user, self.document))
 
     def test_does_not_work_on_subdossier(self):
-        user = self.portal.portal_membership.getAuthenticatedMember()
-        dossier = create(Builder('dossier'))
-        subdossier = create(Builder('dossier').within(dossier))
+        self.login(self.regular_user)
+        self.set_workflow_state('dossier-state-resolved', self.dossier)
 
         with self.assertRaises(AssertionError):
-            self.can_edit(user, subdossier)
+            self.can_edit(api.user.get_current(), self.subdossier)
 
 
-class TestEditPublicTrialForm(FunctionalTestCase):
-
-    def setUp(self):
-        super(TestEditPublicTrialForm, self).setUp()
-
-        dossier = create(Builder('dossier').in_state('dossier-state-resolved'))
-        self.document = create(Builder('document')
-                               .with_dummy_content()
-                               .within(dossier))
+class TestEditPublicTrialForm(IntegrationTestCase):
 
     @browsing
     def test_raise_aunauthorized_if_the_user_CANNOT_modify(self, browser):
-        user = create(Builder('user').with_roles('Contributor'))
+        self.login(self.regular_user, browser=browser)
+        self.set_workflow_state('dossier-state-resolved', self.dossier)
 
-        with browser.expect_unauthorized():
-            browser.login(user.getId()).visit(self.document,
-                                              view='edit_public_trial')
+        self.login(self.reader_user, browser=browser)
+        with self.assertRaises(Unauthorized):
+            browser.visit(self.document, view='edit_public_trial')
 
     @browsing
     def test_user_CAN_access_edit_form(self, browser):
-        browser.login().visit(self.document, view='edit_public_trial')
+        self.login(self.regular_user, browser=browser)
+        self.login(self.administrator, browser=browser)
+
+        self.set_workflow_state('dossier-state-resolved', self.dossier)
+        browser.visit(self.document, view='edit_public_trial')
 
         self.assertEquals(
             '{0}/edit_public_trial'.format(self.document.absolute_url()),
@@ -94,14 +82,20 @@ class TestEditPublicTrialForm(FunctionalTestCase):
 
     @browsing
     def test_user_CAN_modify_public_trial_information(self, browser):
-        browser.login().visit(self.document, view='edit_public_trial')
+        self.login(self.regular_user, browser=browser)
+        self.set_workflow_state('dossier-state-resolved', self.dossier)
+
+        browser.open(self.document, view='edit_public_trial')
         browser.fill({'Public Trial': PUBLIC_TRIAL_PRIVATE}).submit()
 
         self.assertEquals('private', self.document.public_trial)
 
     @browsing
     def test_user_CAN_modify_public_trial_statement(self, browser):
-        browser.login().visit(self.document, view='edit_public_trial')
+        self.login(self.regular_user, browser=browser)
+        self.set_workflow_state('dossier-state-resolved', self.dossier)
+
+        browser.visit(self.document, view='edit_public_trial')
         browser.fill({'Public trial statement': 'Foo statement'}).submit()
 
         self.assertEquals('Foo statement',
@@ -109,6 +103,9 @@ class TestEditPublicTrialForm(FunctionalTestCase):
 
     @browsing
     def test_user_submit_cancel_button(self, browser):
-        browser.login().visit(self.document, view='edit_public_trial')
+        self.login(self.regular_user, browser=browser)
+        self.set_workflow_state('dossier-state-resolved', self.dossier)
+
+        browser.visit(self.document, view='edit_public_trial')
         browser.find('Cancel').click()
         self.assertEquals(self.document.absolute_url(), browser.url)

--- a/opengever/base/tests/test_folder_delete_confirmation.py
+++ b/opengever/base/tests/test_folder_delete_confirmation.py
@@ -2,81 +2,78 @@ from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
 from ftw.testbrowser.pages import statusmessages
-from opengever.testing import FunctionalTestCase
+from opengever.testing import IntegrationTestCase
 from plone import api
 import transaction
 
 
-class TestFolderDeleteConfirmation(FunctionalTestCase):
-
-    def setUp(self):
-        super(TestFolderDeleteConfirmation, self).setUp()
-        self.templatefolder = create(Builder('templatefolder'))
+class TestFolderDeleteConfirmation(IntegrationTestCase):
 
     def get_path(self, obj):
         return '/'.join(obj.getPhysicalPath())
 
     @browsing
     def test_show_portal_message_if_no_objects_where_selected(self, browser):
-        browser.login().visit(self.templatefolder, view="folder_delete_confirmation")
+        self.login(self.administrator, browser=browser)
+        browser.open(self.templates, view="folder_delete_confirmation")
+
         statusmessages.assert_message('Please select one or more items to delete.')
 
     @browsing
     def test_show_portal_message_if_non_existing_objects_where_selected(self, browser):
-        browser.login().visit(self.templatefolder,
-                              view="folder_delete_confirmation?paths:list=/not/existing")
+        self.login(self.administrator, browser=browser)
+        browser.visit(self.templates,
+                      view="folder_delete_confirmation?paths:list=/not/existing")
         statusmessages.assert_message('Please select one or more items to delete.')
 
     @browsing
     def test_redirect_to_origin_template_if_no_objects_where_selected(self, browser):
-        browser.login().visit(self.templatefolder, view="folder_delete_confirmation")
+        self.login(self.administrator, browser=browser)
+        browser.visit(self.templates, view="folder_delete_confirmation")
 
-        self.assertEqual(self.templatefolder.absolute_url(),
-                         browser.url)
+        self.assertEqual(self.templates.absolute_url(), browser.url)
 
     @browsing
     def test_list_items_to_delete_on_confirmation_form(self, browser):
-        dossiertemplate = create(Builder('dossiertemplate').within(self.templatefolder))
+        self.login(self.administrator, browser=browser)
+        browser.visit(self.templates,
+                      view="folder_delete_confirmation",
+                      data=self.make_path_param(self.dossiertemplate))
 
-        browser.login().visit(self.templatefolder,
-                              view="folder_delete_confirmation",
-                              data={'paths:list': [self.get_path(dossiertemplate)]})
-
-        self.assertEqual([dossiertemplate.pretty_title_or_id()],
+        self.assertEqual([self.dossiertemplate.pretty_title_or_id()],
                          browser.css('#items-to-delete li').text)
 
     @browsing
     def test_confirmation_form_shows_a_warning_if_some_items_have_backrefs(self, browser):
-        dossiertemplate = create(Builder('dossiertemplate').within(self.templatefolder))
-
-        repo_root = create(Builder('repository_root'))
+        self.login(self.administrator, browser=browser)
         leaf_node = create(Builder('repository')
-                           .having(addable_dossier_templates=[dossiertemplate])
-                           .within(repo_root))
+                           .having(addable_dossier_templates=[self.dossiertemplate])
+                           .within(self.repository_root))
 
-        browser.login().visit(self.templatefolder,
-                              view="folder_delete_confirmation",
-                              data={'paths:list': [self.get_path(dossiertemplate)]})
+        browser.visit(self.templates,
+                      view="folder_delete_confirmation",
+                      data=self.make_path_param(self.dossiertemplate))
 
         self.assertEqual([leaf_node.pretty_title_or_id()],
                          browser.css('#items-with-backlinks li').text)
 
     @browsing
     def test_delete_only_items_without_backrefs(self, browser):
-        dossietemplate_without_backref = create(Builder('dossiertemplate').within(self.templatefolder))
-        dossiertemplate_with_backref = create(Builder('dossiertemplate').within(self.templatefolder))
+        self.login(self.administrator, browser=browser)
 
-        repo_root = create(Builder('repository_root'))
+        dossiertemplate_with_backref = create(Builder('dossiertemplate')
+                                              .within(self.templates))
+
         leaf_node = create(Builder('repository')
                            .having(addable_dossier_templates=[dossiertemplate_with_backref])
-                           .within(repo_root))
+                           .within(self.repository_root))
 
-        browser.login().visit(self.templatefolder,
-                              view="folder_delete_confirmation",
-                              data={'paths:list': [self.get_path(dossietemplate_without_backref),
-                                                   self.get_path(dossiertemplate_with_backref)]})
+        browser.visit(self.templates,
+                      view="folder_delete_confirmation",
+                      data=self.make_path_param(self.dossiertemplate,
+                                                dossiertemplate_with_backref))
 
-        self.assertEqual([dossietemplate_without_backref.pretty_title_or_id()],
+        self.assertEqual([self.dossiertemplate.pretty_title_or_id()],
                          browser.css('#items-to-delete li').text)
 
         self.assertEqual([leaf_node.pretty_title_or_id()],
@@ -85,6 +82,8 @@ class TestFolderDeleteConfirmation(FunctionalTestCase):
         browser.css('form#folder_delete_confirmation').first.submit()
 
         statusmessages.assert_message('Items successfully deleted.')
-        self.assertEqual([dossiertemplate_with_backref], self.templatefolder.listFolderContents())
-        self.assertEqual(self.templatefolder.absolute_url(),
-                         browser.url)
+        self.assertIn(dossiertemplate_with_backref, self.templates.objectValues())
+        with self.assertRaises(KeyError):
+            self.dossiertemplate
+
+        self.assertEqual(self.templates.absolute_url(), browser.url)

--- a/opengever/base/tests/test_hooks.py
+++ b/opengever/base/tests/test_hooks.py
@@ -1,9 +1,9 @@
 from opengever.base.hooks import DEFAULT_EXTEDIT_ACTION_IDENTIFIER
-from opengever.testing import FunctionalTestCase
+from opengever.testing import IntegrationTestCase
 from plone import api
 
 
-class TestHooks(FunctionalTestCase):
+class TestHooks(IntegrationTestCase):
 
     def test_default_external_edit_action_removed(self):
         actions_tool = api.portal.get_tool('portal_actions')

--- a/opengever/base/tests/test_json_response.py
+++ b/opengever/base/tests/test_json_response.py
@@ -1,10 +1,10 @@
 from opengever.base import _
 from opengever.base.response import JSONResponse
-from opengever.testing import FunctionalTestCase
+from opengever.testing import IntegrationTestCase
 import json
 
 
-class TestUnitJSONResponse(FunctionalTestCase):
+class TestUnitJSONResponse(IntegrationTestCase):
 
     def setUp(self):
         super(TestUnitJSONResponse, self).setUp()

--- a/opengever/base/tests/test_logout.py
+++ b/opengever/base/tests/test_logout.py
@@ -1,33 +1,33 @@
 from ftw.testbrowser import browsing
 from opengever.setup.casauth import install_cas_auth_plugin
-from opengever.testing import FunctionalTestCase
 from opengever.testing import IntegrationTestCase
 from plone import api
-import transaction
 
 
 class TestLogoutWithoutCASAuth(IntegrationTestCase):
 
     @browsing
     def test_url_is_plone_logout(self, browser):
-        browser.login().open(view='logout_url')
+        self.login(self.regular_user, browser=browser)
+
+        browser.open(view='logout_url')
         self.assertEquals('http://nohost/plone/logout', browser.contents)
 
 
-class TestLogoutWithCASAuth(FunctionalTestCase):
+class TestLogoutWithCASAuth(IntegrationTestCase):
 
     def setUp(self):
         super(TestLogoutWithCASAuth, self).setUp()
         install_cas_auth_plugin()
-        transaction.commit()
 
     def tearDown(self):
         super(TestLogoutWithCASAuth, self).tearDown()
         acl_users = api.portal.get_tool('acl_users')
         acl_users.plugins.removePluginById('cas_auth')
-        transaction.commit()
 
     @browsing
     def test_url_is_cas_server_logout(self, browser):
-        browser.login().open(view='logout_url')
-        self.assertEquals('http://example.com/portal/logout', browser.contents)
+        self.login(self.regular_user, browser=browser)
+
+        browser.open(view='logout_url')
+        self.assertEquals('http://nohost/portal/logout', browser.contents)

--- a/opengever/base/tests/test_ploneform_macros.py
+++ b/opengever/base/tests/test_ploneform_macros.py
@@ -1,38 +1,36 @@
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
+from ftw.testbrowser.pages import factoriesmenu
 from ftw.testbrowser.pages.statusmessages import error_messages
 from ftw.testbrowser.pages.statusmessages import info_messages
-from opengever.testing import FunctionalTestCase
+from opengever.testing import IntegrationTestCase
 
 
-class TestRegressionPloneformMacros(FunctionalTestCase):
+class TestRegressionPloneformMacros(IntegrationTestCase):
 
     def setUp(self):
         super(TestRegressionPloneformMacros, self).setUp()
 
-        self.repository_root, self.repository_folder = create(
-            Builder('repository_tree'))
-
     @browsing
     def test_error_messages_are_displayed_for_form_groups(self, browser):
-        browser.login()
-        self.grant('Manager')
+        self.login(self.regular_user, browser=browser)
 
         # make sure that only title is required
         # ensure that our assumption is correct, otherwise the regression
         # test won't work correctly
-        browser.open(self.repository_folder,
-                     view='++add++opengever.dossier.businesscasedossier')
+        browser.open(self.leaf_repofolder)
+        factoriesmenu.add(u'Business Case Dossier')
         browser.fill({'Title': 'foo'})
         browser.find('Save').click()
         self.assertEqual(['Item created'], info_messages())
 
         # actually test that group-errors are displayed correctly
-        browser.open(self.repository_folder,
-                     view='++add++opengever.dossier.businesscasedossier')
+        browser.open(self.leaf_repofolder)
+        factoriesmenu.add(u'Business Case Dossier')
+
         # fill invalid
-        browser.fill({'Title': 'foo', 'Date of cassation': 'invalid'})
+        browser.fill({'Title': 'foo', 'Opening Date': 'invalid'})
         browser.find('Save').click()
         self.assertEqual([], info_messages())
         self.assertEqual(['There were some errors.'], error_messages())

--- a/opengever/base/tests/test_protect.py
+++ b/opengever/base/tests/test_protect.py
@@ -4,7 +4,7 @@ from ftw.builder import create
 from ftw.testbrowser import browsing
 from itertools import chain
 from opengever.base.protect import get_buckets_for_btree
-from opengever.testing import FunctionalTestCase
+from opengever.testing import IntegrationTestCase
 import transaction
 import unittest
 
@@ -23,22 +23,16 @@ class TestBucketsForBTree(unittest.TestCase):
         self.assertEquals(50, len(list(chain(*keys))))
 
 
-class TestProtect(FunctionalTestCase):
-
-    def setUp(self):
-        super(TestProtect, self).setUp()
-        repo_root = create(Builder('repository_root'))
-        repo_folder = create(Builder('repository').within(repo_root))
-        self.dossier = create(Builder('dossier').within(repo_folder))
-        self.document = create(Builder('document').within(self.dossier))
+class TestProtect(IntegrationTestCase):
 
     @browsing
     def test_initializes_annotations_without_csrf_confirmation(self, browser):
-        browser.login().open(self.document)
+        self.login(self.regular_user, browser=browser)
+        browser.open(self.document)
+
         self.assertEquals(self.document.absolute_url(), browser.url)
 
         del self.document.__annotations__
-        transaction.commit()
 
-        browser.login().open(self.document)
+        browser.open(self.document)
         self.assertEquals(self.document.absolute_url(), browser.url)

--- a/opengever/base/tests/test_quickupload.py
+++ b/opengever/base/tests/test_quickupload.py
@@ -2,15 +2,16 @@ from collective.quickupload.interfaces import IQuickUploadFileFactory
 from ftw.builder import Builder
 from ftw.builder import create
 from opengever.journal.browser import JournalHistory
-from opengever.testing import FunctionalTestCase
+from opengever.testing import IntegrationTestCase
 from zope.i18n import translate
 
 
-class TestOGQuickupload(FunctionalTestCase):
+class TestOGQuickupload(IntegrationTestCase):
 
     def setUp(self):
         super(TestOGQuickupload, self).setUp()
-        self.dossier = create(Builder('dossier'))
+
+        self.login(self.regular_user)
         self.adapter = IQuickUploadFileFactory(self.dossier)
 
     def test_get_mimetype(self):
@@ -39,8 +40,8 @@ class TestOGQuickupload(FunctionalTestCase):
         content = create(Builder('quickuploaded_document')
                          .within(self.dossier)
                          .with_asset_data('text.txt'))
-        history = JournalHistory(content, content.REQUEST)
 
+        history = JournalHistory(content, content.REQUEST)
         self.assertEquals(1,
                           len(history.data()),
                           'Expect exactly one journal entry after upload')

--- a/opengever/base/tests/test_redirector.py
+++ b/opengever/base/tests/test_redirector.py
@@ -4,14 +4,14 @@ from opengever.base.interfaces import IRedirector
 from opengever.base.redirector import REDIRECTOR_COOKIE_NAME
 from opengever.base.redirector import RedirectorCookie
 from opengever.base.redirector import RedirectorViewlet
-from opengever.testing import FunctionalTestCase
+from opengever.testing import IntegrationTestCase
 from plone.app.caching.interfaces import IETagValue
 from zope.component import getMultiAdapter
 import hashlib
 import json
 
 
-class TestRedirectorCookie(FunctionalTestCase):
+class TestRedirectorCookie(IntegrationTestCase):
 
     def test_adding_string_to_cookie(self):
         self.assertEquals([], RedirectorCookie(self.request).read())
@@ -63,12 +63,10 @@ class TestRedirectorCookie(FunctionalTestCase):
         return self.request.response.cookies.get(REDIRECTOR_COOKIE_NAME, None)
 
 
-class TestRedirector(FunctionalTestCase):
+class TestRedirector(IntegrationTestCase):
 
     def setUp(self):
         super(TestRedirector, self).setUp()
-        self.prepareSession()
-
         self.redirector = IRedirector(self.request)
 
     def test_stores_and_retrieves_redirects(self):
@@ -90,11 +88,7 @@ class TestRedirector(FunctionalTestCase):
         self.assertEquals(1, len(self.redirector.get_redirects(remove=False)))
         self.assertEquals(1, len(self.redirector.get_redirects(remove=False)))
 
-class TestRedirectorViewlet(FunctionalTestCase):
-
-    def setUp(self):
-        super(TestRedirectorViewlet, self).setUp()
-        self.prepareSession()
+class TestRedirectorViewlet(IntegrationTestCase):
 
     def test_viewlet_only_redirects_once(self):
         redirector = IRedirector(self.request)

--- a/opengever/base/tests/test_reference_prefix.py
+++ b/opengever/base/tests/test_reference_prefix.py
@@ -2,18 +2,17 @@ from ftw.builder import Builder
 from ftw.builder import create
 from opengever.base.interfaces import IReferenceNumberPrefix
 from opengever.base.interfaces import IReferenceNumberSettings
-from opengever.testing import FunctionalTestCase
+from opengever.testing import IntegrationTestCase
 from plone.registry.interfaces import IRegistry
 from zope.component import getUtility
 
 
-class TestReferencePrefixAdapter(FunctionalTestCase):
+class TestReferencePrefixAdapter(IntegrationTestCase):
 
     def setUp(self):
         super(TestReferencePrefixAdapter, self).setUp()
-
-        self.repository = create(Builder('repository').titled(u'Position'))
-        self.adapter = IReferenceNumberPrefix(self.repository)
+        self.login(self.regular_user)
+        self.adapter = IReferenceNumberPrefix(self.leaf_repofolder)
 
     def test_numbering_starts_at_one_by_default(self):
         self.assertEquals(u'1', self.adapter.get_next_number())
@@ -29,68 +28,51 @@ class TestReferencePrefixAdapter(FunctionalTestCase):
         proxy = registry.forInterface(IReferenceNumberSettings)
         proxy.reference_prefix_starting_point = u'0'
 
-        dossier = create(Builder('dossier').within(self.repository))
-        self.assertEquals(
-            u'1',
-            self.adapter.get_number(dossier))
+        dossier = create(Builder('dossier').within(self.empty_repofolder))
+        adapter = IReferenceNumberPrefix(self.empty_repofolder)
+
+        self.assertEquals(u'1', adapter.get_number(dossier))
 
     def test_numbering_continues_after_nine(self):
-        self.set_numbering_base(u'9')
+        self.adapter.set_number(self.leaf_repofolder, 9)
         self.assertEquals(u'10', self.adapter.get_next_number())
 
     def test_numbering_supports_alphanumeric_numbers(self):
-        self.set_numbering_base(u'A1A15')
+        self.adapter.set_number(self.leaf_repofolder, u'A1A15')
         self.assertEquals(u'A1A16', self.adapter.get_next_number())
 
     def test_set_number_assigns_a_specific_number_to_an_object(self):
-        item = self.create_item()
-        self.assertEquals(u'42', self.adapter.set_number(item, u'42'))
-        self.assertEquals(u'42', self.adapter.get_number(item))
+        self.assertEquals(u'42',
+                          self.adapter.set_number(self.leaf_repofolder, u'42'))
+        self.assertEquals(u'42', self.adapter.get_number(self.leaf_repofolder))
 
     def test_set_number_recycles_old_numbers(self):
-        item = self.create_item()
-        self.assertEquals(u'1', self.adapter.get_number(item))
-        self.assertEquals(u'1', self.adapter.set_number(item))
-        self.assertEquals(u'1', self.adapter.get_number(item))
+        self.adapter.set_number(self.leaf_repofolder, u'42')
 
-    def test_non_assigned_numbers_are_valid(self):
-        self.create_numbered_item(u'3')
+        self.assertEquals(u'42', self.adapter.get_number(self.leaf_repofolder))
+        self.assertEquals(u'42', self.adapter.set_number(self.leaf_repofolder))
+        self.assertEquals(u'42', self.adapter.get_number(self.leaf_repofolder))
+
+    def test_assigned_numbers_are_invalid(self):
+        self.adapter.set_number(self.leaf_repofolder, u'3')
 
         self.assertTrue(self.adapter.is_valid_number(u'2'))
         self.assertTrue(self.adapter.is_valid_number(u'4'))
-
-    def test_assigned_numbers_are_invalid(self):
-        self.create_numbered_item(u'2')
-
-        self.assertFalse(self.adapter.is_valid_number(u'2'))
+        self.assertFalse(self.adapter.is_valid_number(u'3'))
 
     def test_with_object_the_assigned_number_is_valid(self):
-        item = self.create_numbered_item(u'A9')
-
-        self.assertTrue(self.adapter.is_valid_number(u'A9', item))
+        self.adapter.set_number(self.leaf_repofolder, u'A9')
+        self.assertTrue(self.adapter.is_valid_number(u'A9', self.leaf_repofolder))
 
     def test_with_object_numbers_assigned_to_other_objects_are_not_valid(self):
-        item = self.create_numbered_item(u'A9')
-        self.create_numbered_item(u'A10')
-
-        self.assertFalse(self.adapter.is_valid_number(u'A10', item))
+        self.adapter.set_number(self.leaf_repofolder, u'A9')
+        self.assertFalse(self.adapter.is_valid_number(u'A9', self.empty_repofolder))
 
     def test_repository_and_dossier_use_a_seperate_counter(self):
-        self.create_numbered_item(5)
+        self.adapter.set_number(self.leaf_repofolder, u'234')
 
-        dossier = create(Builder('dossier').within(self.repository))
-        repository = create(Builder('repository').within(self.repository))
+        repository = create(Builder('repository').within(self.leaf_repofolder))
+        dossier = create(Builder('dossier').within(self.leaf_repofolder))
 
-        self.assertEquals(u'1', self.adapter.get_number(dossier))
-        self.assertEquals(u'6', self.adapter.get_number(repository))
-
-    def set_numbering_base(self, base):
-        self.create_numbered_item(base)
-
-    def create_numbered_item(self, number):
-        item = self.create_item()
-        self.adapter.set_number(item, number)
-        return item
-
-    def create_item(self):
-        return create(Builder('repository').within(self.repository))
+        self.assertEquals(u'235', self.adapter.get_next_number(repository))
+        self.assertEquals(u'11', self.adapter.get_next_number(dossier))

--- a/opengever/base/tests/test_relations.py
+++ b/opengever/base/tests/test_relations.py
@@ -1,53 +1,45 @@
-from ftw.builder import Builder
-from ftw.builder import create
 from ftw.testbrowser import browsing
-from opengever.testing import FunctionalTestCase
-from plone.app.testing import TEST_USER_ID
+from opengever.testing import IntegrationTestCase
 from zc.relation.interfaces import ICatalog
 from zope.component import getUtility
 from zope.intid.interfaces import IIntIds
 
 
-class TestRelations(FunctionalTestCase):
-
-    def setUp(self):
-        super(TestRelations, self).setUp()
-        self.dossier_a = create(Builder('dossier').titled(u'Dossier A'))
+class TestRelations(IntegrationTestCase):
 
     @browsing
     def test_relation_gets_added_in_zc_catalog_when_dossier_is_added(self, browser):
-        browser.login().open(self.portal,
-                             view='++add++opengever.dossier.businesscasedossier')
+        self.login(self.regular_user, browser=browser)
+
+        browser.open(self.leaf_repofolder,
+                     view='++add++opengever.dossier.businesscasedossier')
         browser.fill({'Title': 'Dossier B with relations',
-                      'Responsible': TEST_USER_ID,
-                      'Related Dossier': [self.dossier_a]})
+                      'Related Dossier': [self.dossier]})
         browser.find('Save').click()
 
         rel_catalog = getUtility(ICatalog)
         intids = getUtility(IIntIds)
         relations = [rel for rel in rel_catalog.findRelations(
-            {'to_id': intids.getId(self.dossier_a)})]
+            {'to_id': intids.getId(self.dossier)})]
 
-        self.assertEqual(1, len(relations))
-        self.assertEqual(intids.getId(self.dossier_a), relations[0].to_id)
-        self.assertEqual(intids.getId(browser.context), relations[0].from_id)
+        self.assertEqual(2, len(relations))
+        self.assertEqual(intids.getId(self.dossier), relations[-1].to_id)
+        self.assertEqual(intids.getId(browser.context), relations[-1].from_id)
 
     @browsing
     def test_relation_catalog_gets_upated_when_dossier_is_updated(self, browser):
-        self.dossier_b = create(Builder('dossier')
-                                .having(responsible=TEST_USER_ID)
-                                .titled(u'Dossier B'))
-        browser.login().open(self.dossier_b, view='edit')
+        self.login(self.regular_user, browser=browser)
+
+        browser.open(self.empty_dossier, view='edit')
         browser.fill({'Title': 'Dossier B with relations',
-                      'Responsible': TEST_USER_ID,
-                      'Related Dossier': [self.dossier_a]})
+                      'Related Dossier': [self.dossier]})
         browser.find('Save').click()
 
         rel_catalog = getUtility(ICatalog)
         intids = getUtility(IIntIds)
         relations = [rel for rel in rel_catalog.findRelations(
-            {'to_id': intids.getId(self.dossier_a)})]
+            {'to_id': intids.getId(self.dossier)})]
 
-        self.assertEqual(1, len(relations))
-        self.assertEqual(intids.getId(self.dossier_a), relations[0].to_id)
-        self.assertEqual(intids.getId(self.dossier_b), relations[0].from_id)
+        self.assertEqual(2, len(relations))
+        self.assertEqual(intids.getId(self.dossier), relations[-1].to_id)
+        self.assertEqual(intids.getId(self.empty_dossier), relations[-1].from_id)

--- a/opengever/base/tests/test_require_login.py
+++ b/opengever/base/tests/test_require_login.py
@@ -1,63 +1,58 @@
-from ftw.builder import Builder
-from ftw.builder import create
 from ftw.testbrowser import browsing
 from ftw.testbrowser.pages import plone
-from opengever.testing import FunctionalTestCase
+from opengever.testing import IntegrationTestCase
 from plone.app.testing import TEST_USER_NAME
 from plone.app.testing import TEST_USER_PASSWORD
 import transaction
 import urllib
 
 
-class TestRequireLoginScript(FunctionalTestCase):
-
-    def setUp(self):
-        super(TestRequireLoginScript, self).setUp()
-
-        self.repo, self.repo_folder = create(Builder('repository_tree'))
-        self.dossier = create(Builder('dossier').within(self.repo_folder))
-        self.document = create(
-            Builder('document')
-            .within(self.dossier)
-            .titled(u'Document1')
-            .with_dummy_content())
+class TestRequireLoginScript(IntegrationTestCase):
 
     @browsing
     def test_require_login_redirects_to_came_from_if_already_logged_in(self, browser):
-        browser.login().open(
-            view='require_login?came_from={}'.format(
-                urllib.quote(self.document.absolute_url())))
-        self.assertEqual(self.document.absolute_url(),
-                         browser.url.split('?')[0])
+        self.login(self.regular_user, browser=browser)
+
+        browser.open(self.portal, view='require_login?came_from={}'.format(
+            urllib.quote(self.document.absolute_url())))
+
+        self.assertEqual(self.document.absolute_url(), browser.url.split('?')[0])
 
     @browsing
     def test_require_login_displays_login_form_and_redirecs_upon_login(self, browser):
+        self.login(self.regular_user, browser=browser)
+        document_url = self.document.absolute_url()
+        self.logout(browser=browser)
+
         # Disable the `cookie only over https flag, activated
         # by `opengever.core.hooks.installed`.
         self.portal.acl_users.session.secure = False
-        transaction.commit()
 
         with browser.expect_unauthorized():
             browser.open(
                 view='require_login?came_from={}'.format(
-                    urllib.quote(self.document.absolute_url())))
+                    urllib.quote(document_url)))
+
         self.assertTrue(
             browser.url.startswith('http://nohost/plone/require_login'),
             'Unexpected URL {}'.format(browser.url))
 
-        browser.fill({'Login Name': TEST_USER_NAME,
+        browser.fill({'Login Name': self.regular_user.id,
                       'Password': TEST_USER_PASSWORD}).submit()
-        self.assertEqual(self.document.absolute_url(), browser.url)
+        self.assertEqual(document_url, browser.url)
 
     @browsing
     def test_unauthorized_visible_when_raised_in_traversal(self, browser):
+        self.login(self.regular_user, browser=browser)
+
         with browser.expect_unauthorized():
-            browser.login().open(view='test-traversal-unauthorized')
+            browser.open(view='test-traversal-unauthorized')
 
     @browsing
     def test_unauthorized_visible_when_raised_in_publishing(self, browser):
+        self.login(self.regular_user, browser=browser)
         with browser.expect_unauthorized():
-            browser.login().open(view='test-publishing-unauthorized')
+            browser.open(view='test-publishing-unauthorized')
         self.assertEquals('Insufficient Privileges', plone.first_heading())
 
     @browsing
@@ -66,6 +61,9 @@ class TestRequireLoginScript(FunctionalTestCase):
         # page to appear when logged in.
         url = ('{0}/acl_users/credentials_cookie_auth/require_login'
                '?came_from={0}/does/not/exist').format(self.portal.absolute_url())
+
+        self.login(self.regular_user, browser=browser)
         with browser.expect_unauthorized():
-            browser.login().open(url)
+            browser.open(url)
+
         self.assertEquals('Insufficient Privileges', plone.first_heading())

--- a/opengever/base/tests/test_schema_defaults.py
+++ b/opengever/base/tests/test_schema_defaults.py
@@ -1,12 +1,12 @@
 from opengever.base.tests.sample_behavior.sample import ISampleSchema
-from opengever.testing import FunctionalTestCase
+from opengever.testing import IntegrationTestCase
 from plone.dexterity.fti import DexterityFTI
 from plone.dexterity.fti import register
 from plone.dexterity.utils import createContentInContainer
 from Products.CMFCore.utils import getToolByName
 
 
-class TestSchemaLevelDefaultsForBehaviors(FunctionalTestCase):
+class TestSchemaLevelDefaultsForBehaviors(IntegrationTestCase):
 
     def setUp(self):
         super(TestSchemaLevelDefaultsForBehaviors, self).setUp()
@@ -20,7 +20,12 @@ class TestSchemaLevelDefaultsForBehaviors(FunctionalTestCase):
         typestool._setObject('SampleItem', fti)
         register(fti)
 
+        site_fti = typestool['Plone Site']
+        site_fti.allowed_content_types = site_fti.allowed_content_types + ('SampleItem', )
+
     def test_defaults_on_behavior_schemata_take_effect(self):
+        self.login(self.manager)
+
         obj = createContentInContainer(self.portal, 'SampleItem')
         obj = ISampleSchema(obj)
         self.assertEquals(ISampleSchema['foobar'].default, obj.foobar)

--- a/opengever/base/tests/test_source_binder.py
+++ b/opengever/base/tests/test_source_binder.py
@@ -1,47 +1,35 @@
-from ftw.builder import Builder
-from ftw.builder import create
 from ftw.testbrowser import browsing
 from opengever.base.source import DossierPathSourceBinder
 from opengever.base.source import RepositoryPathSourceBinder
-from opengever.testing import FunctionalTestCase
 from opengever.testing import IntegrationTestCase
 
 
-class TestRepositoryPathSourceBinder(FunctionalTestCase):
-
-    def setUp(self):
-        super(TestRepositoryPathSourceBinder, self).setUp()
-        self.grant('Administrator', 'Contributor', 'Editor', 'Reader')
-
-        self.reporoot_1 = create(Builder('repository_root')
-                                 .titled(u'Ordnungssystem1'))
-        self.repofolder1 = create(Builder('repository')
-                                  .within(self.reporoot_1))
-        self.repofolder1_1 = create(Builder('repository')
-                                    .within(self.repofolder1))
-
-        self.reporoot2 = create(Builder('repository_root')
-                                 .titled(u'Ordnungssystem2'))
-        self.repofolder2 = create(Builder('repository').within(self.reporoot2))
+class TestRepositoryPathSourceBinder(IntegrationTestCase):
 
     def test_navigation_tree_query_is_limited_to_current_repository(self):
+        self.login(self.regular_user)
+
         source_binder = RepositoryPathSourceBinder()
-        source = source_binder(self.repofolder1_1)
-        self.assertEqual({'query': '/plone/ordnungssystem1'},
+
+        source = source_binder(self.branch_repofolder)
+        self.assertEqual({'query': '/plone/ordnungssystem'},
                          source.navigation_tree_query['path'])
-        source = source_binder(self.repofolder1)
-        self.assertEqual({'query': '/plone/ordnungssystem1'},
+
+        source = source_binder(self.leaf_repofolder)
+        self.assertEqual({'query': '/plone/ordnungssystem'},
                          source.navigation_tree_query['path'])
 
 
-class TestDossierSourceBinder(FunctionalTestCase):
+class TestDossierSourceBinder(IntegrationTestCase):
 
     def test_only_objects_inside_the_maindossier_are_selectable(self):
-        dossier_1 = create(Builder('dossier'))
-        sub = create(Builder('dossier').within(dossier_1))
-        dossier_2 = create(Builder('dossier'))
-        create(Builder('document').titled(u'Test 1').within(dossier_1))
-        create(Builder('document').titled(u'Test 2').within(dossier_2))
+        self.login(self.regular_user)
+
+        self.document.title = 'Test open'
+        self.subdocument.title = 'Test sub'
+        self.inactive_document.title = 'Test inactive'
+        [obj.reindexObject() for obj in
+         (self.document, self.subdocument, self.inactive_document)]
 
         source_binder = DossierPathSourceBinder(
             portal_type=("opengever.document.document", "ftw.mail.mail"),
@@ -53,13 +41,17 @@ class TestDossierSourceBinder(FunctionalTestCase):
                  'ftw.mail.mail.IMail']}
         )
 
-        source = source_binder(dossier_1)
-        self.assertEqual(
-            ['Test 1'], [term.title for term in source.search('Test')])
+        source = source_binder(self.dossier)
+        self.assertEqual(['Test open', 'Test sub'],
+                         [term.title for term in source.search('Test')])
 
-        source = source_binder(sub)
-        self.assertEqual(
-            ['Test 1'], [term.title for term in source.search('Test')])
+        source = source_binder(self.subdossier)
+        self.assertEqual(['Test open', 'Test sub'],
+                         [term.title for term in source.search('Test')])
+
+        source = source_binder(self.inactive_dossier)
+        self.assertEqual(['Test inactive'],
+                         [term.title for term in source.search('Test')])
 
 
 class TestRelatedDossierAutocomplete(IntegrationTestCase):

--- a/opengever/base/tests/test_utils.py
+++ b/opengever/base/tests/test_utils.py
@@ -6,7 +6,7 @@ from opengever.base.behaviors.utils import set_attachment_content_disposition
 from opengever.base.utils import escape_html
 from opengever.base.utils import file_checksum
 from opengever.dossier.utils import find_parent_dossier
-from opengever.testing import FunctionalTestCase
+from opengever.testing import IntegrationTestCase
 from plone.namedfile.file import NamedFile
 from unittest import TestCase
 from urllib import quote
@@ -77,46 +77,45 @@ class TestAttachmentContentDisposition(MockTestCase):
             ['text/plain', 7, 'attachment; filename="Default Name"'])
 
 
-class TestFindParentDossier(FunctionalTestCase):
+class TestFindParentDossier(IntegrationTestCase):
 
     def test_find_parent_dossier(self):
-        dossier = create(Builder('dossier'))
-        document = create(Builder('document').within(dossier))
+        self.login(self.regular_user)
 
-        self.assertEquals(dossier, find_parent_dossier(document))
+        self.assertEquals(self.dossier, find_parent_dossier(self.document))
 
     def test_find_parent_inbox(self):
-        inbox = create(Builder('inbox'))
-        document = create(Builder('document').within(inbox))
+        self.login(self.secretariat_user)
 
-        self.assertEquals(inbox, find_parent_dossier(document))
+        self.assertEquals(self.inbox, find_parent_dossier(self.inbox_document))
 
     def test_find_parent_on_nested_dossiers(self):
-        dossier = create(Builder('dossier'))
-        subdossier = create(Builder('dossier').within(dossier))
-        document = create(Builder('document').within(subdossier))
+        self.login(self.regular_user)
 
-        self.assertEquals(subdossier, find_parent_dossier(document))
+        self.assertEquals(self.subdossier, find_parent_dossier(self.subdocument))
 
     def test_find_first_parent_dossier(self):
-        dossier = create(Builder('dossier'))
-        task = create(Builder('task').within(dossier))
-        document = create(Builder('document').within(task))
+        self.login(self.regular_user)
 
-        self.assertEquals(dossier, find_parent_dossier(document))
+        self.assertEquals(self.dossier, find_parent_dossier(self.taskdocument))
 
     def test_return_itself_if_dossier_is_passed(self):
-        dossier = create(Builder('dossier'))
-        self.assertEquals(dossier, find_parent_dossier(dossier))
+        self.login(self.regular_user)
+
+        self.assertEquals(self.dossier, find_parent_dossier(self.dossier))
 
     def test_raise_valuerror_if_plone_root_is_passed(self):
+        self.login(self.regular_user)
+
         with self.assertRaises(ValueError):
             find_parent_dossier(self.portal)
 
     def test_raise_valuerror_if_plone_root_is_reached(self):
+        self.login(self.regular_user)
+
         document = create(Builder('document'))
         with self.assertRaises(ValueError):
-            find_parent_dossier(document)
+            find_parent_dossier(self.leaf_repofolder)
 
 
 class TestEscapeHTML(TestCase):

--- a/opengever/base/tests/test_widget.py
+++ b/opengever/base/tests/test_widget.py
@@ -1,5 +1,5 @@
 from ftw.testbrowser import browsing
-from opengever.testing import FunctionalTestCase
+from opengever.testing import IntegrationTestCase
 from plone.app.z3cform.interfaces import IPloneFormLayer
 from z3c.form.browser.text import TextWidget
 from zope.component import getMultiAdapter
@@ -7,7 +7,7 @@ from zope.interface import alsoProvides
 from zope.schema._bootstrapfields import TextLine
 
 
-class TestGeverRenderWidget(FunctionalTestCase):
+class TestGeverRenderWidget(IntegrationTestCase):
     def setUp(self):
         super(TestGeverRenderWidget, self).setUp()
         textfield = TextLine()
@@ -54,11 +54,12 @@ class TestGeverRenderWidget(FunctionalTestCase):
             widget_renderer.get_description())
 
 
-class TestRadioTableWidget(FunctionalTestCase):
+class TestRadioTableWidget(IntegrationTestCase):
 
     @browsing
     def test_renders_default_table_columns(self, browser):
-        browser.login().visit(view='test-z3cform-widget')
+        self.login(self.manager, browser=browser)
+        browser.open(view='test-z3cform-widget')
 
         self.assertEqual(
             # checkbox-column title/text is empty and that's ok.
@@ -68,7 +69,9 @@ class TestRadioTableWidget(FunctionalTestCase):
 
     @browsing
     def test_renders_custom_table_columns(self, browser):
-        browser.login().visit(view='test-z3cform-widget')
+        self.login(self.manager, browser=browser)
+        browser.open(view='test-z3cform-widget')
+
         # checkbox-column title/text is empty and that's ok.
         expected_columns = [
             {'': '', 'Description': ''},
@@ -82,7 +85,7 @@ class TestRadioTableWidget(FunctionalTestCase):
 
     @browsing
     def test_does_not_render_none_choice_when_a_required_field(self, browser):
-        browser.login()
+        self.login(self.manager, browser=browser)
         browser.open(view='test-z3cform-required-widget')
         self.assertNotIn(
             {'': '', 'Description': ''},
@@ -91,13 +94,17 @@ class TestRadioTableWidget(FunctionalTestCase):
 
     @browsing
     def test_fill_table_choice_field(self, browser):
-        browser.login().visit(view='test-z3cform-widget')
+        self.login(self.manager, browser=browser)
+        browser.open(view='test-z3cform-widget')
+
         browser.fill({'form.widgets.default_radio_table_field': '2'}).submit()
         self.assertEqual({u'default_radio_table_field': [2, u'bar']}, browser.json)
 
     @browsing
     def test_renders_table_choice_input_fields(self, browser):
-        browser.login().visit(view='test-z3cform-widget')
+        self.login(self.manager, browser=browser)
+        browser.open(view='test-z3cform-widget')
+
         inputs = browser.css(
             '#formfield-form-widgets-default_radio_table_field input')
         expected_inputs = [
@@ -111,7 +118,9 @@ class TestRadioTableWidget(FunctionalTestCase):
 
     @browsing
     def test_renders_empty_message(self, browser):
-        browser.login().visit(view='test-z3cform-widget')
+        self.login(self.manager, browser=browser)
+        browser.open(view='test-z3cform-widget')
+
         self.assertEqual(
             "No items available",
             browser.css('#formfield-form-widgets-empty_radio_table_field .empty_message').first.text

--- a/opengever/document/tests/test_document_byline.py
+++ b/opengever/document/tests/test_document_byline.py
@@ -1,46 +1,38 @@
-from datetime import date
-from ftw.builder import Builder
-from ftw.builder import create
 from ftw.testbrowser import browsing
 from opengever.base.tests.byline_base_test import TestBylineBase
-from opengever.testing import create_ogds_user
+from plone.app.testing import TEST_USER_ID
 
 
 class TestDocumentByline(TestBylineBase):
 
-    def setUp(self):
-        super(TestDocumentByline, self).setUp()
-        create_ogds_user('hugo.boss')
-
-        self.document = create(Builder('document')
-                               .having(start=date(2013, 11, 6),
-                                       document_date=date(2013, 11, 5),
-                                       document_author='hugo.boss'))
-
     @browsing
     def test_document_byline_start_date(self, browser):
-        browser.login().open(self.document)
+        self.login(self.regular_user, browser=browser)
+        browser.open(self.document)
 
         start_date = self.get_byline_value_by_label('from:')
-        self.assertEquals('Nov 05, 2013', start_date.text)
+        self.assertEquals('Jan 03, 2010', start_date.text)
 
     @browsing
     def test_document_byline_sequence_number(self, browser):
-        browser.login().open(self.document)
+        self.login(self.regular_user, browser=browser)
+        browser.open(self.document)
 
         seq_number = self.get_byline_value_by_label('Sequence Number:')
-        self.assertEquals('1', seq_number.text)
+        self.assertEquals('12', seq_number.text)
 
     @browsing
     def test_document_byline_reference_number(self, browser):
-        browser.login().open(self.document)
+        self.login(self.regular_user, browser=browser)
+        browser.open(self.document)
 
         ref_number = self.get_byline_value_by_label('Reference Number:')
-        self.assertEquals('Client1 / 1', ref_number.text)
+        self.assertEquals('Client1 1.1 / 1 / 12', ref_number.text)
 
     @browsing
     def test_document_byline_document_author(self, browser):
-        browser.login().open(self.document)
+        self.login(self.regular_user, browser=browser)
+        browser.open(self.document)
 
         document_author = self.get_byline_value_by_label('by:')
-        self.assertEquals('Boss Hugo', document_author.text)
+        self.assertEquals(TEST_USER_ID, document_author.text)

--- a/opengever/dossier/tests/test_dossier_byline.py
+++ b/opengever/dossier/tests/test_dossier_byline.py
@@ -1,33 +1,16 @@
 from datetime import date
 from ftw.builder import Builder
 from ftw.builder import create
-from ftw.mail.interfaces import IMailSettings
 from ftw.testbrowser import browsing
 from opengever.base.tests.byline_base_test import TestBylineBase
-from opengever.core.testing import activate_filing_number
-from opengever.core.testing import inactivate_filing_number
 from opengever.dossier.behaviors.dossier import IDossier
-from opengever.testing import create_ogds_user
-from plone.registry.interfaces import IRegistry
-from zope.component import getUtility
-from zope.intid.interfaces import IIntIds
+from opengever.dossier.behaviors.filing import IFilingNumber
 import transaction
 
 
 class TestDossierBylineBase(TestBylineBase):
-
-    def setUp(self):
-        super(TestDossierBylineBase, self).setUp()
-
-        self.intids = getUtility(IIntIds)
-
-        create_ogds_user('hugo.boss')
-        self.dossier = self.create_dossier()
-
-        registry = getUtility(IRegistry)
-        mail_settings = registry.forInterface(IMailSettings)
-        mail_settings.mail_domain = u'opengever.4teamwork.ch'
-        transaction.commit()
+    """Base Test for the dossier byline.
+    """
 
 
 class TestDossierByline(TestDossierBylineBase):
@@ -43,71 +26,85 @@ class TestDossierByline(TestDossierBylineBase):
 
     @browsing
     def test_dossier_byline_responsible_display(self, browser):
-        browser.login().open(self.dossier)
+        self.login(self.regular_user, browser=browser)
+        browser.open(self.dossier)
 
         responsible = self.get_byline_value_by_label('Responsible:')
-        self.assertEquals('Boss Hugo (hugo.boss)', responsible.text)
+        self.assertEquals('Ziegler Robert (robert.ziegler)', responsible.text)
 
     @browsing
     def test_dossier_byline_responsible_is_linked_to_user_details(self, browser):
-        browser.login().open(self.dossier)
+        self.login(self.regular_user, browser=browser)
+        browser.open(self.dossier)
 
         responsible = self.get_byline_value_by_label('Responsible:')
-        self.assertEqual('http://nohost/plone/@@user-details/hugo.boss',
-                          responsible.get('href'))
+        self.assertEqual('http://nohost/plone/@@user-details/robert.ziegler',
+                         responsible.get('href'))
 
     @browsing
     def test_dossier_byline_state_display(self, browser):
-        browser.login().open(self.dossier)
+        self.login(self.regular_user, browser=browser)
+        browser.open(self.dossier)
 
         state = self.get_byline_value_by_label('State:')
         self.assertEquals('dossier-state-active', state.text)
 
     @browsing
     def test_dossier_byline_start_date_display(self, browser):
-        browser.login().open(self.dossier)
+        self.login(self.regular_user, browser=browser)
+        browser.open(self.dossier)
 
         start_date = self.get_byline_value_by_label('from:')
-        self.assertEquals('Nov 06, 2013', start_date.text)
+        self.assertEquals('Jan 01, 2016', start_date.text)
 
     @browsing
     def test_dossier_byline_sequence_number_display(self, browser):
-        browser.login().open(self.dossier)
+        self.login(self.regular_user, browser=browser)
+        browser.open(self.dossier)
 
         seq_number = self.get_byline_value_by_label('Sequence Number:')
         self.assertEquals('1', seq_number.text)
 
     @browsing
     def test_dossier_byline_reference_number_display(self, browser):
-        browser.login().open(self.dossier)
+        self.login(self.regular_user, browser=browser)
+        browser.open(self.dossier)
 
         ref_number = self.get_byline_value_by_label('Reference Number:')
-        self.assertEquals('Client1 / 1', ref_number.text)
+        self.assertEquals('Client1 1.1 / 1', ref_number.text)
 
     @browsing
     def test_dossier_byline_email_display(self, browser):
-        browser.login().open(self.dossier)
+        self.login(self.regular_user, browser=browser)
+        browser.open(self.dossier)
 
-        dossier_id = self.intids.getId(self.dossier)
-        mail = self.get_byline_value_by_label('E-Mail:')
-        self.assertEquals('%d@opengever.4teamwork.ch' % dossier_id, mail.text)
+        mail_to_link = self.get_byline_value_by_label('E-Mail:')
+        self.assertEquals('1014013300@example.org', mail_to_link.text)
+        self.assertEquals(
+            'mailto:1014013300@example.org', mail_to_link.get('href'))
 
     @browsing
     def test_dossier_byline_hide_filing_number(self, browser):
-        browser.login().open(self.dossier)
+        self.login(self.regular_user, browser=browser)
+        browser.open(self.dossier)
 
         self.assertEquals(None,
                           self.get_byline_value_by_label('Filing Number:'))
 
     @browsing
     def test_dossier_byline_external_reference_display(self, browser):
-        browser.login().open(self.dossier)
+        self.login(self.regular_user, browser=browser)
+        browser.open(self.dossier)
+
         external_reference = self.get_byline_value_by_label(
                 'External Reference:')
-        self.assertEquals('22900-2017', external_reference.text)
+        self.assertEquals(u'qpr-900-9001-\xf7', external_reference.text)
 
     @browsing
     def test_dossier_byline_external_reference_link_only_for_valid_url(self, browser):
+        self.login(self.regular_user, browser=browser)
+        browser.open(self.dossier)
+
         valid_url = "http://google.ch"
         invalid_url = "google.ch"
 
@@ -128,26 +125,14 @@ class TestDossierByline(TestDossierBylineBase):
 
 class TestFilingBusinessCaseByline(TestBylineBase):
 
-    def setUp(self):
-        super(TestFilingBusinessCaseByline, self).setUp()
-        activate_filing_number(self.portal)
-
-        create_ogds_user('hugo.boss')
-        self.dossier = create(Builder('dossier')
-               .in_state('dossier-state-active')
-               .having(reference_number_prefix='5',
-                       responsible='hugo.boss',
-                       start=date(2013, 11, 6),
-                       end=date(2013, 11, 7),
-                       filing_no='OG-Amt-2013-5'))
-
-    def tearDown(self):
-        inactivate_filing_number(self.portal)
-        super(TestFilingBusinessCaseByline, self).tearDown()
+    features = ('filing_number', )
 
     @browsing
     def test_dossier_byline_filing_number_display(self, browser):
-        browser.login().open(self.dossier)
+        self.login(self.regular_user, browser=browser)
+        IFilingNumber(self.dossier).filing_no = 'OG-Amt-2013-5'
+
+        browser.open(self.dossier)
 
         filing_number = self.get_byline_value_by_label('Filing Number:')
         self.assertEquals('OG-Amt-2013-5', filing_number.text)

--- a/opengever/mail/tests/test_mail_byline.py
+++ b/opengever/mail/tests/test_mail_byline.py
@@ -8,39 +8,35 @@ from opengever.mail.tests import MAIL_DATA
 
 class TestMailByline(TestBylineBase):
 
-    def setUp(self):
-        super(TestMailByline, self).setUp()
-
-        create(Builder('fixture').with_hugo_boss(email='from@example.org'))
-
-        self.mail = create(Builder('mail')
-                           .with_message(MAIL_DATA)
-                           .having(start=date(2013, 11, 6)))
-
     @browsing
     def test_document_byline_start_date(self, browser):
-        browser.login().open(self.mail)
+        self.login(self.regular_user, browser=browser)
+        browser.open(self.mail_eml)
 
         start_date = self.get_byline_value_by_label('from:')
         self.assertEquals('Jan 01, 1999', start_date.text)
 
     @browsing
     def test_document_byline_sequence_number(self, browser):
-        browser.login().open(self.mail)
+        self.login(self.regular_user, browser=browser)
+        browser.open(self.mail_eml)
 
         seq_number = self.get_byline_value_by_label('Sequence Number:')
-        self.assertEquals('1', seq_number.text)
+        self.assertEquals('24', seq_number.text)
 
     @browsing
     def test_document_byline_reference_number(self, browser):
-        browser.login().open(self.mail)
+        self.login(self.regular_user, browser=browser)
+        browser.open(self.mail_eml)
 
         ref_number = self.get_byline_value_by_label('Reference Number:')
-        self.assertEquals('Client1 / 1', ref_number.text)
+        self.assertEquals('Client1 1.1 / 1 / 24', ref_number.text)
 
     @browsing
     def test_document_byline_document_author(self, browser):
-        browser.login().open(self.mail)
+        self.login(self.regular_user, browser=browser)
+        browser.open(self.mail_eml)
 
         document_author = self.get_byline_value_by_label('by:')
-        self.assertEquals('Boss Hugo', document_author.text)
+        self.assertEquals(u'Freddy H\xf6lderlin <from@example.org>',
+                          document_author.text)

--- a/opengever/task/tests/test_task_byline.py
+++ b/opengever/task/tests/test_task_byline.py
@@ -1,93 +1,72 @@
-from DateTime.DateTime import DateTime
-from ftw.builder import Builder
-from ftw.builder import create
 from ftw.testbrowser import browsing
 from opengever.base.tests.byline_base_test import TestBylineBase
-from zope.component import getUtility
-from zope.intid.interfaces import IIntIds
-import transaction
 
 
 class TestTaskByline(TestBylineBase):
 
-    use_default_fixture = False
-
-    def setUp(self):
-        super(TestTaskByline, self).setUp()
-        self.intids = getUtility(IIntIds)
-
-        self.user, self.org_unit, self.admin_unit = create(
-            Builder('fixture')
-            .with_user()
-            .with_org_unit()
-            .with_admin_unit(abbreviation='c1'))
-
-        create(Builder('fixture').with_hugo_boss())
-
-        self.task = create(Builder('task')
-               .in_state('task-state-open')
-               .having(responsible='hugo.boss',
-                       filing_no='OG-Amt-2013-5'))
-
-        self.task.creation_date = DateTime(2011, 8, 10, 20, 10)
-        self.task.setModificationDate(DateTime(2011, 8, 11, 20, 10))
-        transaction.commit()
-
     @browsing
     def test_task_byline_responsible_display(self, browser):
-        browser.login().open(self.task)
+        self.login(self.regular_user, browser=browser)
+        browser.open(self.task)
 
         responsible = self.get_byline_value_by_label('by:')
-        self.assertEquals('Boss Hugo (hugo.boss)', responsible.text)
+        self.assertEquals(u'B\xe4rfuss K\xe4thi (kathi.barfuss)',
+                          responsible.text)
 
     @browsing
     def test_dossier_byline_responsible_is_linked_to_user_details(self, browser):
-        browser.login().open(self.task)
+        self.login(self.regular_user, browser=browser)
+        browser.open(self.task)
 
         responsible = self.get_byline_value_by_label('by:')
-        self.assertEqual('http://nohost/plone/@@user-details/hugo.boss',
+        self.assertEqual('http://nohost/plone/@@user-details/kathi.barfuss',
                          responsible.get('href'))
 
     @browsing
     def test_task_byline_state_display(self, browser):
-        browser.login().open(self.task)
+        self.login(self.regular_user, browser=browser)
+        browser.open(self.task)
 
         state = self.get_byline_value_by_label('State:')
-        self.assertEquals('task-state-open', state.text)
+        self.assertEquals('task-state-in-progress', state.text)
 
     @browsing
     def test_task_byline_start_date_display(self, browser):
-        browser.login().open(self.task)
+        self.login(self.regular_user, browser=browser)
+        browser.open(self.task)
 
         start_date = self.get_byline_value_by_label('created:')
-        self.assertEquals('Aug 10, 2011 08:10 PM', start_date.text)
+        self.assertEquals('Aug 31, 2016 06:01 PM', start_date.text)
 
     @browsing
     def test_task_byline_modification_date_display(self, browser):
-        browser.login().open(self.task)
+        self.login(self.regular_user, browser=browser)
+        browser.open(self.task)
 
         start_date = self.get_byline_value_by_label('last modified:')
-        self.assertEquals('Aug 11, 2011 08:10 PM', start_date.text)
+        self.assertEquals('Aug 31, 2016 06:05 PM', start_date.text)
 
     @browsing
     def test_dossier_byline_sequence_number_display_is_prefixed_with_admin_unit_abbreviation(self, browser):
-        browser.login().open(self.task)
+        self.login(self.regular_user, browser=browser)
+        browser.open(self.task)
 
         seq_number = self.get_byline_value_by_label('Sequence Number:')
-        self.assertEquals('c1 1', seq_number.text)
+        self.assertEquals('Client1 1', seq_number.text)
 
     @browsing
     def test_is_private_attribute_is_displayed_in_byline_for_private_task(self, browser):
-        self.task.is_private = True
-        transaction.commit()
+        self.login(self.regular_user, browser=browser)
 
-        browser.login().open(self.task)
+        self.task.is_private = True
+        browser.open(self.task)
 
         is_private = self.get_byline_value_by_label('Private:')
         self.assertEquals('Yes', is_private.text)
 
     @browsing
     def test_is_private_attribute_is_not_displayed_in_byline_for_default_task(self, browser):
-        browser.login().open(self.task)
+        self.login(self.regular_user, browser=browser)
+        browser.open(self.task)
 
         self.assertIsNone(self.get_byline_value_by_label('Private:'))

--- a/opengever/testing/integration_test_case.py
+++ b/opengever/testing/integration_test_case.py
@@ -682,3 +682,8 @@ class IntegrationTestCase(TestCase):
         wftool = api.portal.get_tool('portal_workflow')
         return [transition['id'] for transition in
                 wftool.listActionInfos(object=obj, check_condition=True)]
+
+    def create_inactive_user(self):
+        create(Builder('ogds_user')
+               .having(firstname='Without', lastname='Orgunit',
+                       userid='user.without.orgunit'))


### PR DESCRIPTION
😅 😅 😅 
- Some skipped "flaky tests" are now enabled again, they should no longer be flaky because of the layer change
- No change on the fixture was needed ! 🎉 
- The default_values and API tests still uses the `FunctionalTestCase`

⚠️ Contains #5228