### PR TITLE
Remove unused get_conversion_status view.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ---------------------
 
 - Fix flaky loading of document preview with tooltip. [Kevin Bieri]
+- Remove unused get_conversion_status view. [njohner]
 - Remove plonetheme.teamraum upgradesteps. [phgross]
 - Correctly update containing_dossier and containing_subdossier indexes. [njohner]
 - Also show participants with expired membership in meeting participants-tab. [njohner]

--- a/opengever/document/browser/configure.zcml
+++ b/opengever/document/browser/configure.zcml
@@ -57,7 +57,6 @@
       name="demand_document_pdf"
       class=".save_pdf_document_under.SavePDFDocumentUnder"
       permission="zope2.View"
-      allowed_attributes="get_conversion_status"
       />
 
   <browser:page


### PR DESCRIPTION
Not much else to say. I tested it locally with bumblebee to make sure the save_pdf_under still worked.

resolves #5134 