### PR TITLE
Fix a new integration test which got merged after a fixture amend merge

### DIFF
--- a/opengever/base/tests/test_reference_prefix.py
+++ b/opengever/base/tests/test_reference_prefix.py
@@ -75,4 +75,4 @@ class TestReferencePrefixAdapter(IntegrationTestCase):
         dossier = create(Builder('dossier').within(self.leaf_repofolder))
 
         self.assertEquals(u'235', self.adapter.get_next_number(repository))
-        self.assertEquals(u'11', self.adapter.get_next_number(dossier))
+        self.assertEquals(u'13', self.adapter.get_next_number(dossier))


### PR DESCRIPTION
Did not realise there was a new integration test in `opengever.base` relying on the dossier count.

My bad.