### PR TITLE
Fix loading of document preview with tooltip

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2019.1.0 (unreleased)
 ---------------------
 
+- Fix flaky loading of document preview with tooltip. [Kevin Bieri]
 - Remove plonetheme.teamraum upgradesteps. [phgross]
 - Correctly update containing_dossier and containing_subdossier indexes. [njohner]
 - Also show participants with expired membership in meeting participants-tab. [njohner]

--- a/opengever/base/browser/resources/tooltip.js
+++ b/opengever/base/browser/resources/tooltip.js
@@ -3,6 +3,7 @@
   "use strict";
 
   var tooltipHideTimer = null;
+  var viewingDocument = false;
 
   var settings = {
     overwrite: false, // Do not reload the tooltip when it's already created
@@ -40,7 +41,7 @@
 
   function isTooltipResponse(data, status, jqXHR) {
     if(jqXHR.getResponseHeader('X-Tooltip-Response') !== "True") {
-      return $.Deferred().reject(jqXHR, "error");
+      return $.Deferred().reject(jqXHR, "X-Tooltip-Response missing on tooltip response.");
     }
     return $.Deferred().resolve(data, status, jqXHR);
   }
@@ -54,7 +55,10 @@
         $(".showroom-reference").on("click", function() { api.hide(); });
       })
       .fail(function() {
-        location.reload();
+        // Avoid cancelling a pending navigation request initiated by the user
+        if (!viewingDocument) {
+          location.reload();
+        }
       });
     return spinner();
   }
@@ -86,6 +90,7 @@
   function closeTooltips(event, api) {
     var target = event.originalEvent.target;
     $(target).on("click", function() {
+      viewingDocument = true;
       api.hide();
       hideBackdrop(event);
     });


### PR DESCRIPTION
As documented in https://extranet.4teamwork.ch/support/stadt-nidau/tracker-gever/95 it may be possible that the documents overview page reloads when loading a tooltip of a document and the document detail view simultaneously.
So when user clicks on the document link in the overview while the browser awaits the response from the tooltip, the tooltip request is aborted. The javascript code checks the response of the tooltip request, which has been aborted, for a `X-Tooltip-Response` header. But because the request has been canceled the header is not present. As a result the javascript code triggers a reload of the documents overview page because it is treated as an error.
Using a flag setting to true when the user clicks on the documents links solved the problem. The flag is checked before reloading the page.
Also adjust the error message when the `X-Tooltip-Response` header is missing.