### PR TITLE
Fix resolved subdossier invalid end dates when resolving main dossier.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,7 @@ Changelog
 
 - Fix an improper super call in meeting activities. [Rotonen]
 - Move meeting activity actor_link fetching to meeting activity helpers. [Rotonen]
+- Fix invalid end dates of resolved subdossiers when resolving main dossier. [njohner]
 - Fix flaky loading of document preview with tooltip. [Kevin Bieri]
 - Remove unused get_conversion_status view. [njohner]
 - Remove plonetheme.teamraum upgradesteps. [phgross]

--- a/opengever/dossier/base.py
+++ b/opengever/dossier/base.py
@@ -48,6 +48,7 @@ DOSSIER_STATES_CLOSED = [
     'dossier-state-resolved',
 ]
 
+DOSSIER_STATE_RESOLVED = 'dossier-state-resolved'
 
 DOSSIER_STATES_OFFERABLE = DOSSIER_STATES_CLOSED + ['dossier-state-offered']
 
@@ -140,6 +141,9 @@ class DossierContainer(Container):
     def is_open(self):
         wf_state = api.content.get_state(obj=self)
         return wf_state in DOSSIER_STATES_OPEN
+
+    def is_resolved(self):
+        return api.content.get_state(obj=self) == DOSSIER_STATE_RESOLVED
 
     def get_main_dossier(self):
         """Return the root dossier for the current dossier.


### PR DESCRIPTION
Invalid end dates for resolved dossiers can happen for several reasons, recently because of the switch from document_date to changed for the calculation of the earliest_possible_end_date. These are always due to software bugs and not user input and should hence be fixed automatically.

We need to be careful because open subdossiers with invalid end dates are due to user input and should still lead to an error message and let the user fix it himself. The approach implemented here works as follows:

* when checking the validity of subdossier end dates (in `ResolveConditions.check_end_dates`), we consider as invalid only dossiers that are not resolved and have an invalid end date. These will prevent dossier resolution and the user will receive an error message
* When resolving the dossier in `Resolver._recursive_resolve`, we set the end date of subdossiers:
  * to the end date of the main dossier if the subdossier has no end date or is not `resolved` and has an invalid end date (This should never happen in my opinion, but the condition was already there, so I left it for safety for now)
  * to the `earliest_possible_end_date` of the subdossier if it is resolved and has an invalid end date.

With this, invalid end dates of resolved dossier will no longer prevent dossier resolution and get corrected.

Note that the end date of inactive dossiers can also get set automatically by the software, to the day of inactivation. While before such dossiers could have an invalid end date (if a document had a `document_date` posterior to the inactivation date), this should not be possible anymore (all `changed` dates will be prior to the inactivation date, as nothing can be modified once the dossier is inactive). Of course they can have an invalid end date if the user set it himself, but then it is his responsibility to reset the end date correctly.

resolves #5204 