### PR TITLE
Make sure a failure to update DocProperties doesn't prevent checkin/checkout or moving of documents

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2019.1.0 (unreleased)
 ---------------------
 
+- Make sure a failure to update DocProperties doesn't prevent checkin/checkout or moving of documents. [lgraf]
 - Bump ftw.pdfgenerator to version 1.6.3. [njohner]
 - Fix an improper super call in meeting activities. [Rotonen]
 - Move meeting activity actor_link fetching to meeting activity helpers. [Rotonen]


### PR DESCRIPTION
This changes the updating of DocProperties for `*.docx` documents in a way here it doesn't block **moving** or **checkin/checkout** of documents if the DocProperties update fails for some reason.

One reason this can happen is corrupted / invalid Word-Documents: These cause a `BadZipfile` exception that would otherwise kill the entire (possibly long running) move operation, or prevent this document from ever getting checked out again and fixed.

The behavior for **adding new documents** is still the same though - it will fail hard, and therefore prevent that broken documents even make it into GEVER. But for documents that are already in GEVER, we're being more defensive.

So, to summarize, this is how DocProperties update errors for the different document-related events will be handled now:

| Event/Action       | Handling of DocProperties error |
|-----------|-----------|
| Add       | Fail Hard |
| Paste     | Fail Hard |
| Move      | Skip      |
| Check out | Skip      |
| Check in  | Skip      |

Needs to be backported to `2018.5-stable`