### PR TITLE
Use the correct message factory in the Oneoffixx form

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -14,6 +14,7 @@ Changelog
 - Merge the plonetheme.teamraum bumblebee profile to opengever.core. [Rotonen]
 - Set the default publisher encoding to UTF-8 to match production in tests. [Rotonen]
 - Bump ftw.testbrowser to 1.30.0 to respect content encodings in tests. [Rotonen]
+- Use the correct message factory in the Oneoffixx form. [Rotonen]
 - Bump ftw.pdfgenerator to version 1.6.3. [njohner]
 - Fix an improper super call in meeting activities. [Rotonen]
 - Move meeting activity actor_link fetching to meeting activity helpers. [Rotonen]

--- a/opengever/oneoffixx/browser/form.py
+++ b/opengever/oneoffixx/browser/form.py
@@ -1,5 +1,5 @@
 from opengever.base.schema import TableChoice
-from opengever.dossier import _
+from opengever.oneoffixx import _
 from opengever.oneoffixx.api_client import OneoffixxAPIClient
 from opengever.oneoffixx.command import CreateDocumentFromOneOffixxTemplateCommand
 from opengever.oneoffixx.utils import whitelisted_template_types


### PR DESCRIPTION
The form previously mistakenly used the message factory from Dossier.

Closes #5244