### PR TITLE
Add choice fields as possible first form elements for the autofocus seek

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -15,6 +15,7 @@ Changelog
 - Set the default publisher encoding to UTF-8 to match production in tests. [Rotonen]
 - Bump ftw.testbrowser to 1.30.0 to respect content encodings in tests. [Rotonen]
 - Use the correct message factory in the Oneoffixx form. [Rotonen]
+- Add choice fields as possible first form elements for the autofocus seek. [Rotonen]
 - Bump ftw.pdfgenerator to version 1.6.3. [njohner]
 - Fix an improper super call in meeting activities. [Rotonen]
 - Move meeting activity actor_link fetching to meeting activity helpers. [Rotonen]

--- a/opengever/base/browser/resources/base.js
+++ b/opengever/base/browser/resources/base.js
@@ -1,6 +1,6 @@
 $(window).load(function(){
   // set focus on first form field
-  var firstFormElement = $("form#form input:text:visible, form#form textarea:visible, .keyword-widget").first();
+  var firstFormElement = $('form#form input:text:visible, form#form textarea:visible, .keyword-widget, .choice-field').first();
   // Check if element is select2 widget
   if (firstFormElement.data('select2')) {
     firstFormElement.focus();


### PR DESCRIPTION
On a quick clickaround did not notice any legacy reason why choice fields were not included in the seek of which field to focus on as the first field of the form.

Closes #5245