### PR TITLE
Add new meeting toc options sorted by reference number and only ad hoc agendaitems

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -42,6 +42,7 @@ Changelog
 - Bump ftw.testbrowser to 1.30.0 to respect content encodings in tests. [Rotonen]
 - Use the correct message factory in the Oneoffixx form. [Rotonen]
 - Add choice fields as possible first form elements for the autofocus seek. [Rotonen]
+- Add two new TOC types for periods. [njohner]
 - Bump ftw.pdfgenerator to version 1.6.3. [njohner]
 - Provide solr for local development. [njohner]
 - Fix an improper super call in meeting activities. [Rotonen]

--- a/opengever/meeting/browser/configure.zcml
+++ b/opengever/meeting/browser/configure.zcml
@@ -152,6 +152,22 @@
       />
 
   <browser:page
+      for="opengever.meeting.interfaces.IPeriodWrapper"
+      name="dossier_refnum_toc"
+      class=".toc.DownloadDossierReferenceNumberTOC"
+      permission="zope2.View"
+      allowed_attributes="as_json"
+      />
+
+  <browser:page
+      for="opengever.meeting.interfaces.IPeriodWrapper"
+      name="repository_refnum_toc"
+      class=".toc.DownloadRepositoryReferenceNumberTOC"
+      permission="zope2.View"
+      allowed_attributes="as_json"
+      />
+
+  <browser:page
       name="tabbedview_view-periods"
       for="opengever.meeting.committee.ICommittee"
       class=".periods.PeriodsTab"

--- a/opengever/meeting/browser/templates/periods.pt
+++ b/opengever/meeting/browser/templates/periods.pt
@@ -21,6 +21,20 @@
             download TOC by repository
           </a>
         </li>
+        <li>
+          <a class="download_toc"
+             tal:attributes="href string:${context/absolute_url}/${period/wrapper_id}/dossier_refnum_toc"
+             i18n:translate="label_download_dossier_refnum_toc">
+            download TOC by dossier reference number
+          </a>
+        </li>
+        <li>
+          <a class="download_toc"
+             tal:attributes="href string:${context/absolute_url}/${period/wrapper_id}/repository_refnum_toc"
+             i18n:translate="label_download_repository_refnum_toc">
+            download TOC by repository reference number
+          </a>
+        </li>
       </ul>
       <ul class="actions" tal:condition="view/is_editable_by_current_user">
         <li>
@@ -44,6 +58,20 @@
              tal:attributes="href string:${context/absolute_url}/${period/wrapper_id}/repository_toc/as_json"
              i18n:translate="label_download_repository_toc_json">
             download TOC json repository
+          </a>
+        </li>
+        <li>
+          <a class="download_toc_json"
+             tal:attributes="href string:${context/absolute_url}/${period/wrapper_id}/dossier_refnum_toc/as_json"
+             i18n:translate="label_download_dossier_refnum_toc_json">
+            download TOC json by dossier reference number
+          </a>
+        </li>
+        <li>
+          <a class="download_toc_json"
+             tal:attributes="href string:${context/absolute_url}/${period/wrapper_id}/repository_refnum_toc/as_json"
+             i18n:translate="label_download_repository_refnum_toc_json">
+            download TOC json by repository reference number
           </a>
         </li>
       </ul>

--- a/opengever/meeting/browser/toc.py
+++ b/opengever/meeting/browser/toc.py
@@ -3,6 +3,8 @@ from opengever.meeting.command import MIME_DOCX
 from opengever.meeting.exceptions import SablonProcessingFailed
 from opengever.meeting.sablon import Sablon
 from opengever.meeting.toc.alphabetical import AlphabeticalToc
+from opengever.meeting.toc.dossier_refnum import DossierReferenceNumberBasedTOC
+from opengever.meeting.toc.repository_refnum import RepositoryReferenceNumberBasedTOC
 from opengever.meeting.toc.repository import RepositoryBasedTOC
 from plone import api
 from plone.i18n.normalizer.interfaces import IIDNormalizer
@@ -98,6 +100,46 @@ class DownloadRepositoryTOC(DownloadAlphabeticalTOC):
         return u"{}.docx".format(
             translate(_(u'filename_repository_toc',
                         default=u'Repository Toc ${period} ${committee}',
+                        mapping={
+                          'period': period_title,
+                          'committee': committee_title,
+                        }),
+                      context=getRequest()))
+
+
+class DownloadDossierReferenceNumberTOC(DownloadAlphabeticalTOC):
+
+    def get_data(self):
+        return DossierReferenceNumberBasedTOC(self.model).get_json()
+
+    def get_filename(self):
+        normalizer = getUtility(IIDNormalizer)
+        period_title = normalizer.normalize(self.model.title)
+        committee_title = normalizer.normalize(self.model.committee.title)
+
+        return u"{}.docx".format(
+            translate(_(u'filename_dossier_reference_number_toc',
+                        default=u'Dossier Reference Number Toc ${period} ${committee}',
+                        mapping={
+                          'period': period_title,
+                          'committee': committee_title,
+                        }),
+                      context=getRequest()))
+
+
+class DownloadRepositoryReferenceNumberTOC(DownloadAlphabeticalTOC):
+
+    def get_data(self):
+        return RepositoryReferenceNumberBasedTOC(self.model).get_json()
+
+    def get_filename(self):
+        normalizer = getUtility(IIDNormalizer)
+        period_title = normalizer.normalize(self.model.title)
+        committee_title = normalizer.normalize(self.model.committee.title)
+
+        return u"{}.docx".format(
+            translate(_(u'filename_repository_reference_number_toc',
+                        default=u'Repository Reference Number Toc ${period} ${committee}',
                         mapping={
                           'period': period_title,
                           'committee': committee_title,

--- a/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
@@ -348,6 +348,11 @@ msgstr "Protokollauszug ablegen"
 msgid "active"
 msgstr "Aktiv"
 
+#. Default: "Ad hoc agendaitems"
+#: ./opengever/meeting/toc/dossier_refnum.py
+msgid "ad_hoc_toc_group_title"
+msgstr "Traktanden ohne Antrag"
+
 #. Default: "Cannot decide agenda item: someone else has checked out the document."
 #: ./opengever/meeting/browser/meetings/agendaitem.py
 msgid "agenda_item_cannot_decide_document_checked_out"
@@ -715,6 +720,16 @@ msgstr "Vorlagen Protokoll"
 msgid "filename_alphabetical_toc"
 msgstr "Inhaltsverzeichnis ${period} ${committee} alphabetisch"
 
+#. Default: "Dossier Reference Number Toc ${period} ${committee}"
+#: ./opengever/meeting/browser/toc.py
+msgid "filename_dossier_reference_number_toc"
+msgstr "Inhaltsverzeichnis ${period} ${committee} nach Aktenzeichen"
+
+#. Default: "Repository Reference Number Toc ${period} ${committee}"
+#: ./opengever/meeting/browser/toc.py
+msgid "filename_repository_reference_number_toc"
+msgstr "Inhaltsverzeichnis ${period} ${committee} nach Positionsnummer"
+
 #. Default: "Repository Toc ${period} ${committee}"
 #: ./opengever/meeting/browser/toc.py
 msgid "filename_repository_toc"
@@ -991,6 +1006,26 @@ msgstr "Inhaltsverzeichnis alphabetisch"
 #: ./opengever/meeting/browser/templates/periods.pt
 msgid "label_download_alphabetical_toc_json"
 msgstr "Inhaltsverzeichnis alphabetisch JSON"
+
+#. Default: "download TOC by dossier reference number"
+#: ./opengever/meeting/browser/templates/periods.pt
+msgid "label_download_dossier_refnum_toc"
+msgstr "Inhaltsverzeichnis nach Aktenzeichen"
+
+#. Default: "download TOC json by dossier reference number"
+#: ./opengever/meeting/browser/templates/periods.pt
+msgid "label_download_dossier_refnum_toc_json"
+msgstr "Inhaltsverzeichnis nach Aktenzeichen JSON"
+
+#. Default: "download TOC by repository reference number"
+#: ./opengever/meeting/browser/templates/periods.pt
+msgid "label_download_repository_refnum_toc"
+msgstr "Inhaltsverzeichnis nach Positionsnummer"
+
+#. Default: "download TOC json by repository reference number"
+#: ./opengever/meeting/browser/templates/periods.pt
+msgid "label_download_repository_refnum_toc_json"
+msgstr "Inhaltsverzeichnis nach Positionsnummer JSON"
 
 #. Default: "download TOC by repository"
 #: ./opengever/meeting/browser/templates/periods.pt

--- a/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
@@ -350,6 +350,11 @@ msgstr "Déposer l'extrait de protocole"
 msgid "active"
 msgstr "Actif"
 
+#. Default: "Ad hoc agendaitems"
+#: ./opengever/meeting/toc/dossier_refnum.py
+msgid "ad_hoc_toc_group_title"
+msgstr "Points de l'ordre du jour sans demande"
+
 #. Default: "Cannot decide agenda item: someone else has checked out the document."
 #: ./opengever/meeting/browser/meetings/agendaitem.py
 msgid "agenda_item_cannot_decide_document_checked_out"
@@ -717,6 +722,16 @@ msgstr "Modèles protocole"
 msgid "filename_alphabetical_toc"
 msgstr "Table de matière ${period} ${committee} alphabétique"
 
+#. Default: "Dossier Reference Number Toc ${period} ${committee}"
+#: ./opengever/meeting/browser/toc.py
+msgid "filename_dossier_reference_number_toc"
+msgstr "Table de matière ${period} ${committee} selon Numéro de référence"
+
+#. Default: "Repository Reference Number Toc ${period} ${committee}"
+#: ./opengever/meeting/browser/toc.py
+msgid "filename_repository_reference_number_toc"
+msgstr "Table de matière ${period} ${committee} selon Numéro de classement"
+
 #. Default: "Repository Toc ${period} ${committee}"
 #: ./opengever/meeting/browser/toc.py
 msgid "filename_repository_toc"
@@ -993,6 +1008,26 @@ msgstr "Table de matière alphabétique"
 #: ./opengever/meeting/browser/templates/periods.pt
 msgid "label_download_alphabetical_toc_json"
 msgstr "Table de matière alphabétique JSON"
+
+#. Default: "download TOC by dossier reference number"
+#: ./opengever/meeting/browser/templates/periods.pt
+msgid "label_download_dossier_refnum_toc"
+msgstr "Table de matière selon le Numéro de référence"
+
+#. Default: "download TOC json by dossier reference number"
+#: ./opengever/meeting/browser/templates/periods.pt
+msgid "label_download_dossier_refnum_toc_json"
+msgstr "Table de matière selon le Numéro de référence JSON"
+
+#. Default: "download TOC by repository reference number"
+#: ./opengever/meeting/browser/templates/periods.pt
+msgid "label_download_repository_refnum_toc"
+msgstr "Table de matière selon le Numéro de classement"
+
+#. Default: "download TOC json by repository reference number"
+#: ./opengever/meeting/browser/templates/periods.pt
+msgid "label_download_repository_refnum_toc_json"
+msgstr "Table de matière selon le Numéro de classement JSON"
 
 #. Default: "download TOC by repository"
 #: ./opengever/meeting/browser/templates/periods.pt

--- a/opengever/meeting/locales/opengever.meeting.pot
+++ b/opengever/meeting/locales/opengever.meeting.pot
@@ -347,6 +347,11 @@ msgstr ""
 msgid "active"
 msgstr ""
 
+#. Default: "Ad hoc agendaitems"
+#: ./opengever/meeting/toc/dossier_refnum.py
+msgid "ad_hoc_toc_group_title"
+msgstr ""
+
 #. Default: "Cannot decide agenda item: someone else has checked out the document."
 #: ./opengever/meeting/browser/meetings/agendaitem.py
 msgid "agenda_item_cannot_decide_document_checked_out"
@@ -714,6 +719,16 @@ msgstr ""
 msgid "filename_alphabetical_toc"
 msgstr ""
 
+#. Default: "Dossier Reference Number Toc ${period} ${committee}"
+#: ./opengever/meeting/browser/toc.py
+msgid "filename_dossier_reference_number_toc"
+msgstr ""
+
+#. Default: "Repository Reference Number Toc ${period} ${committee}"
+#: ./opengever/meeting/browser/toc.py
+msgid "filename_repository_reference_number_toc"
+msgstr ""
+
 #. Default: "Repository Toc ${period} ${committee}"
 #: ./opengever/meeting/browser/toc.py
 msgid "filename_repository_toc"
@@ -989,6 +1004,26 @@ msgstr ""
 #. Default: "download TOC json alphabetical"
 #: ./opengever/meeting/browser/templates/periods.pt
 msgid "label_download_alphabetical_toc_json"
+msgstr ""
+
+#. Default: "download TOC by dossier reference number"
+#: ./opengever/meeting/browser/templates/periods.pt
+msgid "label_download_dossier_refnum_toc"
+msgstr ""
+
+#. Default: "download TOC json by dossier reference number"
+#: ./opengever/meeting/browser/templates/periods.pt
+msgid "label_download_dossier_refnum_toc_json"
+msgstr ""
+
+#. Default: "download TOC by repository reference number"
+#: ./opengever/meeting/browser/templates/periods.pt
+msgid "label_download_repository_refnum_toc"
+msgstr ""
+
+#. Default: "download TOC json by repository reference number"
+#: ./opengever/meeting/browser/templates/periods.pt
+msgid "label_download_repository_refnum_toc_json"
 msgstr ""
 
 #. Default: "download TOC by repository"

--- a/opengever/meeting/tests/test_periods.py
+++ b/opengever/meeting/tests/test_periods.py
@@ -21,7 +21,9 @@ class TestPathBar(IntegrationTestCase):
         self.assertEqual(
             '2016 (Jan 01, 2016 - Dec 31, 2016) '
             'download TOC alphabetical '
-            'download TOC by repository',
+            'download TOC by repository '
+            'download TOC by dossier reference number '
+            'download TOC by repository reference number',
             listing.text
             )
 
@@ -50,13 +52,16 @@ class TestPeriod(IntegrationTestCase):
         text_by_period = [row.css('> *').text for row in period_rows]
         self.assertEqual([
             ['2016 (Jan 01, 2016 - Dec 31, 2016)',
-             'download TOC alphabetical download TOC by repository',
+             'download TOC alphabetical download TOC by repository '
+             'download TOC by dossier reference number download TOC by repository reference number',
              'Edit'],
             ['2011 (Jan 01, 2011 - Dec 31, 2011)',
-             'download TOC alphabetical download TOC by repository',
+             'download TOC alphabetical download TOC by repository '
+             'download TOC by dossier reference number download TOC by repository reference number',
              'Edit'],
             ['2010 (Jan 01, 2010 - Dec 31, 2010)',
-             'download TOC alphabetical download TOC by repository',
+             'download TOC alphabetical download TOC by repository '
+             'download TOC by dossier reference number download TOC by repository reference number',
              'Edit']
         ], text_by_period)
 
@@ -117,7 +122,8 @@ class TestPeriod(IntegrationTestCase):
         text_by_period = [row.css('> *').text for row in period_rows]
         self.assertEqual([
             ['2016 (Jan 01, 2016 - Dec 31, 2016)',
-             'download TOC alphabetical download TOC by repository',
+             'download TOC alphabetical download TOC by repository '
+             'download TOC by dossier reference number download TOC by repository reference number',
              'Edit'],
         ], text_by_period)
 
@@ -127,9 +133,11 @@ class TestPeriod(IntegrationTestCase):
         text_by_period = [row.css('> *').text for row in period_rows]
         self.assertEqual([
             ['2016 (Jan 01, 2016 - Dec 31, 2016)',
-             'download TOC alphabetical download TOC by repository',
+             'download TOC alphabetical download TOC by repository '
+             'download TOC by dossier reference number download TOC by repository reference number',
              'Edit',
-             'download TOC json alphabetical download TOC json repository'],
+             'download TOC json alphabetical download TOC json repository '
+             'download TOC json by dossier reference number download TOC json by repository reference number'],
         ], text_by_period)
 
     @browsing
@@ -140,7 +148,7 @@ class TestPeriod(IntegrationTestCase):
         button = browser.find('download TOC json alphabetical')
 
         period = self.committee.load_model().periods[0]
-        expected_url = os.path.join(period.get_url(self.committee),'alphabetical_toc/as_json')
+        expected_url = os.path.join(period.get_url(self.committee), 'alphabetical_toc/as_json')
         self.assertEqual(expected_url, button.get("href"))
 
         button.click()
@@ -162,11 +170,59 @@ class TestPeriod(IntegrationTestCase):
         button = browser.find('download TOC json repository')
 
         period = self.committee.load_model().periods[0]
-        expected_url = os.path.join(period.get_url(self.committee),'repository_toc/as_json')
+        expected_url = os.path.join(period.get_url(self.committee), 'repository_toc/as_json')
         self.assertEqual(expected_url, button.get("href"))
 
         button.click()
         toc_content = {u'toc': [{u'group_title': u'Vertr\xe4ge und Vereinbarungen',
+                                 u'contents': [{u'decision_number': 1,
+                                                u'dossier_reference_number': u'Client1 1.1 / 1',
+                                                u'has_proposal': True,
+                                                u'meeting_date': u'17.07.2016',
+                                                u'meeting_start_page_number': None,
+                                                u'repository_folder_title': u'Vertr\xe4ge und Vereinbarungen',
+                                                u'title': u'Initialvertrag f\xfcr Bearbeitung'}],
+                                 }]}
+
+        self.assertEqual(toc_content, browser.json)
+
+    @browsing
+    def test_toc_json_dossier_reference_number_button(self, browser):
+        self.login(self.manager, browser)
+        browser.open(self.committee, view='tabbedview_view-periods')
+        button = browser.find('download TOC json by dossier reference number')
+
+        period = self.committee.load_model().periods[0]
+        expected_url = os.path.join(period.get_url(self.committee), 'dossier_refnum_toc/as_json')
+        self.assertEqual(expected_url, button.get("href"))
+
+        button.click()
+        toc_content = {u'toc': [{u'group_title': u'Client1 1.1 / 1',
+                                 u'contents': [{u'decision_number': 1,
+                                                u'dossier_reference_number': u'Client1 1.1 / 1',
+                                                u'has_proposal': True,
+                                                u'meeting_date': u'17.07.2016',
+                                                u'meeting_start_page_number': None,
+                                                u'repository_folder_title': u'Vertr\xe4ge und Vereinbarungen',
+                                                u'title': u'Initialvertrag f\xfcr Bearbeitung'}],
+                                 }]}
+
+        self.assertEqual(toc_content, browser.json)
+
+    @browsing
+    def test_toc_json_repository_reference_number_button(self, browser):
+        self.login(self.manager, browser)
+
+        browser.open(self.committee, view='tabbedview_view-periods')
+        button = browser.find('download TOC json by repository reference number')
+
+        period = self.committee.load_model().periods[0]
+        expected_url = os.path.join(period.get_url(self.committee), 'repository_refnum_toc/as_json')
+        self.assertEqual(expected_url, button.get("href"))
+
+        button.click()
+
+        toc_content = {u'toc': [{u'group_title': u'Client1 1.1',
                                  u'contents': [{u'decision_number': 1,
                                                 u'dossier_reference_number': u'Client1 1.1 / 1',
                                                 u'has_proposal': True,

--- a/opengever/meeting/tests/test_toc.py
+++ b/opengever/meeting/tests/test_toc.py
@@ -410,7 +410,7 @@ class TestTOCByRepository(TestAlphabeticalTOC):
     download_button_label = 'download TOC by repository'
 
     expected_toc_json = {'toc': [{
-        'group_title': None,
+        'group_title': u'Ad hoc agendaitems',
         'contents': [{
                 'title': u'Nahhh not here either',
                 'dossier_reference_number': None,

--- a/opengever/meeting/toc/alphabetical.py
+++ b/opengever/meeting/toc/alphabetical.py
@@ -4,27 +4,13 @@ from datetime import timedelta
 from itertools import groupby
 from opengever.meeting.model import AgendaItem
 from opengever.meeting.model import Meeting
+from opengever.meeting.toc.utils import first_title_char
 from opengever.meeting.utils import format_date
 from opengever.meeting.utils import JsonDataProcessor
-from operator import itemgetter
 from sqlalchemy.orm import contains_eager
 from sqlalchemy.orm import joinedload
 from sqlalchemy.sql.expression import false
 import pytz
-
-
-def first_title_char(value):
-    return value['title'][:1].upper()
-
-
-def group_by_sort_key(item):
-    return (first_title_char(item), item['decision_number'])
-
-
-def item_sort_key(item):
-    return (item['title'].lower(),
-            item['repository_folder_title'],
-            item['decision_number'])
 
 
 class AlphabeticalToc(object):
@@ -32,26 +18,36 @@ class AlphabeticalToc(object):
     def __init__(self, period):
         self.period = period
 
+    @staticmethod
+    def group_by_key(item):
+        return first_title_char(item)
+
+    @staticmethod
+    def item_sort_key(item):
+        return (item['title'].lower(),
+                item['repository_folder_title'],
+                item['decision_number'])
+
     def sort_items(self, unordered_items):
         """We currently sort on the client side since title can be either in
         the agenda_items table or in the proposals table.
         """
-        return sorted(unordered_items, key=group_by_sort_key)
+        return sorted(unordered_items, key=self.item_sort_key)
 
     def group_items(self, sorted_items):
         """Input items must be sorted since groupby depends on input order.
         """
         results = []
         for character, contents in groupby(sorted_items,
-                                           key=first_title_char):
+                                           key=self.group_by_key):
             results.append({
                 'group_title': character,
-                'contents': list(sorted(contents, key=item_sort_key))
+                'contents': list(contents)
             })
         return results
 
     def sort_groups(self, groups):
-        return sorted(groups, key=itemgetter('group_title'))
+        return groups
 
     def build_query(self):
         datetime_from = pytz.UTC.localize(

--- a/opengever/meeting/toc/alphabetical.py
+++ b/opengever/meeting/toc/alphabetical.py
@@ -31,7 +31,7 @@ class AlphabeticalToc(object):
                 item['decision_number'])
 
     @staticmethod
-    def group_key_to_title(group_key):
+    def get_group_title(group_key, contents):
         return group_key.upper()
 
     def sort_items(self, unordered_items):
@@ -46,9 +46,10 @@ class AlphabeticalToc(object):
         results = []
         for group_key, contents in groupby(sorted_items,
                                            key=self.group_by_key):
+            contents = list(contents)
             results.append({
-                'group_title': self.group_key_to_title(group_key),
-                'contents': list(contents)
+                'group_title': self.get_group_title(group_key, contents),
+                'contents': contents
             })
         return results
 

--- a/opengever/meeting/toc/alphabetical.py
+++ b/opengever/meeting/toc/alphabetical.py
@@ -5,6 +5,7 @@ from itertools import groupby
 from opengever.meeting.model import AgendaItem
 from opengever.meeting.model import Meeting
 from opengever.meeting.toc.utils import first_title_char
+from opengever.meeting.toc.utils import normalise_string
 from opengever.meeting.utils import format_date
 from opengever.meeting.utils import JsonDataProcessor
 from sqlalchemy.orm import contains_eager
@@ -24,9 +25,14 @@ class AlphabeticalToc(object):
 
     @staticmethod
     def item_sort_key(item):
-        return (item['title'].lower(),
-                item['repository_folder_title'],
+        return (normalise_string(item['title']),
+                item['title'],
+                normalise_string(item['repository_folder_title']),
                 item['decision_number'])
+
+    @staticmethod
+    def group_key_to_title(group_key):
+        return group_key.upper()
 
     def sort_items(self, unordered_items):
         """We currently sort on the client side since title can be either in
@@ -38,10 +44,10 @@ class AlphabeticalToc(object):
         """Input items must be sorted since groupby depends on input order.
         """
         results = []
-        for character, contents in groupby(sorted_items,
+        for group_key, contents in groupby(sorted_items,
                                            key=self.group_by_key):
             results.append({
-                'group_title': character,
+                'group_title': self.group_key_to_title(group_key),
                 'contents': list(contents)
             })
         return results

--- a/opengever/meeting/toc/dossier_refnum.py
+++ b/opengever/meeting/toc/dossier_refnum.py
@@ -1,0 +1,29 @@
+from opengever.meeting import _
+from opengever.meeting.toc.alphabetical import AlphabeticalToc
+from opengever.meeting.toc.utils import to_human_sortable_key
+from opengever.meeting.toc.utils import normalise_string
+from zope.globalrequest import getRequest
+from zope.i18n import translate
+
+
+class DossierReferenceNumberBasedTOC(AlphabeticalToc):
+
+    @staticmethod
+    def group_by_key(item):
+        return (to_human_sortable_key(item['dossier_reference_number']))
+
+    @staticmethod
+    def item_sort_key(item):
+        return (to_human_sortable_key(item['dossier_reference_number']),
+                normalise_string(item['title']),
+                item['title'],
+                item['decision_number'])
+
+    def get_group_title(self, group_key, contents):
+        if group_key:
+            return contents[0]['dossier_reference_number']
+
+        ad_hoc_title = translate(_(u'ad_hoc_toc_group_title',
+                                   default=u'Ad hoc agendaitems'),
+                                 context=getRequest())
+        return ad_hoc_title

--- a/opengever/meeting/toc/repository.py
+++ b/opengever/meeting/toc/repository.py
@@ -1,5 +1,8 @@
+from opengever.meeting import _
 from opengever.meeting.toc.alphabetical import AlphabeticalToc
 from opengever.meeting.toc.utils import normalise_string
+from zope.globalrequest import getRequest
+from zope.i18n import translate
 
 
 class RepositoryBasedTOC(AlphabeticalToc):
@@ -18,4 +21,10 @@ class RepositoryBasedTOC(AlphabeticalToc):
 
     @staticmethod
     def get_group_title(group_key, contents):
-        return group_key
+        if group_key:
+            return group_key
+
+        ad_hoc_title = translate(_(u'ad_hoc_toc_group_title',
+                                   default=u'Ad hoc agendaitems'),
+                                 context=getRequest())
+        return ad_hoc_title

--- a/opengever/meeting/toc/repository.py
+++ b/opengever/meeting/toc/repository.py
@@ -1,22 +1,14 @@
-from itertools import groupby
 from opengever.meeting.toc.alphabetical import AlphabeticalToc
-from operator import itemgetter
 
 
 class RepositoryBasedTOC(AlphabeticalToc):
 
-    def sort_items(self, unordered_items):
-        return sorted(unordered_items,
-                      key=itemgetter('repository_folder_title',
-                                     'title',
-                                     'decision_number'))
+    @staticmethod
+    def group_by_key(item):
+        return item['repository_folder_title']
 
-    def group_items(self, sorted_items):
-        results = []
-        for repo_folder_title, contents in groupby(
-                    sorted_items, key=itemgetter('repository_folder_title')):
-            results.append({
-                'group_title': repo_folder_title,
-                'contents': list(contents)
-            })
-        return results
+    @staticmethod
+    def item_sort_key(item):
+        return (item['repository_folder_title'],
+                item['title'],
+                item['decision_number'])

--- a/opengever/meeting/toc/repository.py
+++ b/opengever/meeting/toc/repository.py
@@ -17,5 +17,5 @@ class RepositoryBasedTOC(AlphabeticalToc):
                 item['decision_number'])
 
     @staticmethod
-    def group_key_to_title(group_key):
+    def get_group_title(group_key, contents):
         return group_key

--- a/opengever/meeting/toc/repository.py
+++ b/opengever/meeting/toc/repository.py
@@ -1,4 +1,5 @@
 from opengever.meeting.toc.alphabetical import AlphabeticalToc
+from opengever.meeting.toc.utils import normalise_string
 
 
 class RepositoryBasedTOC(AlphabeticalToc):
@@ -9,6 +10,12 @@ class RepositoryBasedTOC(AlphabeticalToc):
 
     @staticmethod
     def item_sort_key(item):
-        return (item['repository_folder_title'],
+        return (normalise_string(item['repository_folder_title']),
+                item['repository_folder_title'],
+                normalise_string(item['title']),
                 item['title'],
                 item['decision_number'])
+
+    @staticmethod
+    def group_key_to_title(group_key):
+        return group_key

--- a/opengever/meeting/toc/repository_refnum.py
+++ b/opengever/meeting/toc/repository_refnum.py
@@ -1,0 +1,30 @@
+from opengever.meeting import _
+from opengever.meeting.toc.dossier_refnum import to_human_sortable_key
+from opengever.meeting.toc.dossier_refnum import DossierReferenceNumberBasedTOC
+from opengever.meeting.toc.utils import normalise_string
+from opengever.meeting.toc.utils import repo_refnum
+from zope.globalrequest import getRequest
+from zope.i18n import translate
+
+
+class RepositoryReferenceNumberBasedTOC(DossierReferenceNumberBasedTOC):
+
+    @staticmethod
+    def item_sort_key(item):
+        return (to_human_sortable_key(repo_refnum(item)),
+                normalise_string(item['title']),
+                item['title'],
+                item['decision_number'])
+
+    @staticmethod
+    def group_by_key(item):
+        return (to_human_sortable_key(repo_refnum(item)))
+
+    def get_group_title(self, group_key, contents):
+        if group_key:
+            return repo_refnum(contents[0])
+
+        ad_hoc_title = translate(_(u'ad_hoc_toc_group_title',
+                                   default=u'Ad hoc agendaitems'),
+                                 context=getRequest())
+        return ad_hoc_title

--- a/opengever/meeting/toc/utils.py
+++ b/opengever/meeting/toc/utils.py
@@ -1,5 +1,10 @@
 from opengever.base.filename import unidecode
+from opengever.base.interfaces import IReferenceNumberFormatter
+from opengever.base.interfaces import IReferenceNumberSettings
 from Products.CMFPlone.utils import safe_unicode
+from plone.registry.interfaces import IRegistry
+from zope.component import getUtility
+from zope.component import queryAdapter
 import unicodedata
 
 
@@ -15,3 +20,28 @@ def normalise_string(string):
 
 def first_title_char(item):
     return normalise_string(item["title"])[:1]
+
+
+def to_human_sortable_key(string):
+    """To correctly sort reference number strings such as 'ab 10.2' after 'ab 1.2'
+    we need to separate numbers from other characters and cast them.
+    """
+    if string is None:
+        return []
+    registry = getUtility(IRegistry)
+    proxy = registry.forInterface(IReferenceNumberSettings)
+    formatter = queryAdapter(IReferenceNumberFormatter, name=proxy.formatter)
+    return formatter.sorter(string)
+
+
+def repo_refnum(item):
+    registry = getUtility(IRegistry)
+    proxy = registry.forInterface(IReferenceNumberSettings)
+    formatter = queryAdapter(IReferenceNumberFormatter, name=proxy.formatter)
+
+    refnum = item['dossier_reference_number']
+    if refnum is None:
+        return None
+    elif formatter.repository_dossier_seperator in refnum:
+        repo_refnum, remainder = refnum.split(formatter.repository_dossier_seperator, 1)
+        return repo_refnum

--- a/opengever/meeting/toc/utils.py
+++ b/opengever/meeting/toc/utils.py
@@ -1,0 +1,3 @@
+
+def first_title_char(item):
+    return item['title'][:1].upper()

--- a/opengever/meeting/toc/utils.py
+++ b/opengever/meeting/toc/utils.py
@@ -1,3 +1,17 @@
+from opengever.base.filename import unidecode
+from Products.CMFPlone.utils import safe_unicode
+import unicodedata
+
+
+def normalise_unicode(string):
+    return unicodedata.normalize('NFKC', safe_unicode(string))
+
+
+def normalise_string(string):
+    if string is None:
+        return
+    return unidecode(normalise_unicode(string)).lower()
+
 
 def first_title_char(item):
-    return item['title'][:1].upper()
+    return normalise_string(item["title"])[:1]


### PR DESCRIPTION
We add two new toc types for meeting periods:
* only agendaitems with proposals, ordered by dossier reference number
* only ad hoc agendaitems, ordered by titles

I'm not quite sure whether this is what was wanted here? The proposed solution is only partially satisfactory as it relies on a second entry in the TOC json `toc_adhoc`, which can be used in the sablon template to have a different listing type (without displaying the reference number) for adhoc agendaitem elements. I modified the template accordingly, see below for example TOCs:

**Only agendaitems with proposals, ordered by reference number**
<img width="950" alt="screen shot 2019-01-09 at 13 36 22" src="https://user-images.githubusercontent.com/7374243/50899868-ab287400-1413-11e9-867b-028a57a1a2c7.png">

**Only ad hoc agendaitems, ordered by title**
<img width="949" alt="screen shot 2019-01-09 at 13 36 34" src="https://user-images.githubusercontent.com/7374243/50899866-ab287400-1413-11e9-98ac-b4e983ea5057.png">

Another solution could be to have two different templates. Or maybe only one new TOC type, with two listings, one for agendaitems with proposal and one for ad hoc?

resolves #5176 