### PR TITLE
Provide solr for local development.

### DIFF
--- a/development.cfg
+++ b/development.cfg
@@ -6,6 +6,8 @@ extends =
     https://raw.github.com/4teamwork/ftw-buildouts/master/bumblebee.cfg
     sphinx.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/format-xml.cfg
+    https://raw.githubusercontent.com/4teamwork/gever-buildouts/master/solr.cfg
+    start_all.cfg
 
 always-checkout = false
 
@@ -14,8 +16,12 @@ ogds-db-name = opengever
 tool-parts +=
     docxcompose
 
+solr-core-name = development
+solr-port = 8983
+
 development-parts +=
     ${buildout:sphinx-parts}
+    ${buildout:start-all-parts}
 
 development-parts -=
 # Disable generating a bin/i18n-build script (from plone-development.cfg),

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -13,6 +13,7 @@ Changelog
 - Set the default publisher encoding to UTF-8 to match production in tests. [Rotonen]
 - Bump ftw.testbrowser to 1.30.0 to respect content encodings in tests. [Rotonen]
 - Bump ftw.pdfgenerator to version 1.6.3. [njohner]
+- Provide solr for local development. [njohner]
 - Fix an improper super call in meeting activities. [Rotonen]
 - Move meeting activity actor_link fetching to meeting activity helpers. [Rotonen]
 - Fix flaky loading of document preview with tooltip. [Kevin Bieri]

--- a/opengever/examplecontent/profiles/default/registry.xml
+++ b/opengever/examplecontent/profiles/default/registry.xml
@@ -41,4 +41,8 @@
     <value key="group_title_ldap_attribute">description</value>
   </records>
 
+  <records interface="opengever.base.interfaces.ISearchSettings">
+    <value key="use_solr">False</value>
+  </records>
+
 </registry>

--- a/start_all.cfg
+++ b/start_all.cfg
@@ -1,0 +1,26 @@
+[buildout]
+start-all-parts =
+    start-all-script
+
+[start-all-script]
+recipe = collective.recipe.template
+inline =
+
+    #!/bin/bash
+    if [ "$(uname -s)" != "Darwin" ]
+    then
+    echo "start_all.sh is only meant for development on MacOS."
+    exit 1
+    fi
+
+    if [ -z "$(lsof -t -i:${buildout:solr-port})" ]
+    then
+          bin/solr start
+          bin/instance fg
+          bin/solr stop
+    else
+          echo "Cannot start solr, port ${buildout:solr-port} already used by process $(lsof -t -i:${buildout:solr-port})"
+    fi
+
+output = ${buildout:bin-directory}/start_all
+mode = 755


### PR DESCRIPTION
We include solr in `development.cfg`, making it available for local development, but we do not activate it by default. To activate run `bin/instance run src/opengever.maintenance/opengever/maintenance/scripts/activate_solr.py`

To facilitate the starting and stopping of solr and making sure the correct instance of solr is running for a given instance of gever, we provide a script which checks if the port used by solr is already in use and only starts solr and the gever instance if it isn't. When exiting gever, solr will also be stopped.

After installing a fresh GEVER, everything works fine without using solr. But strangely during deployment of the example content, errors of the type
```
2019-01-09 14:03:51 ERROR ftw.solr.connection Update command failed. An exception occured: [Errno 61] Connection refused
2019-01-09 14:03:51 ERROR ftw.solr.connection Solr response error. An exception occured: [Errno 61] Connection refused
``` 
are thrown, although solr should not be active at that point. Not sure what to do about this (although as said, it does not prevent the deployment and does not seem to lead to any problems afterwards).

resolves #5168 