### PR TITLE
 Show error view when user has permission issues on a meeting.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2019.1.0 (unreleased)
 ---------------------
 
+- Add meeting error view displayed when user has permission issues. [njohner]
 - Kill the theme functional test layer. [Rotonen]
 - Kill the theme integration test layer. [Rotonen]
 - Merge the plonetheme.teamraum gever profile into opengever.core. [Rotonen]

--- a/opengever/meeting/browser/meetings/byline.py
+++ b/opengever/meeting/browser/meetings/byline.py
@@ -1,11 +1,8 @@
-from opengever.base.browser.helper import get_css_class
-from opengever.base.utils import escape_html
 from opengever.base.viewlets.byline import BylineBase
 from opengever.meeting import _
 from opengever.tabbedview.helper import linked
 from plone import api
 from Products.CMFPlone.utils import safe_unicode
-from zope.i18n import translate
 
 
 class MeetingByline(BylineBase):
@@ -37,19 +34,11 @@ class MeetingByline(BylineBase):
                    'content': meeting.location}
 
         dossier = meeting.get_dossier()
+        with_tooltip = False
         if api.user.has_permission('View', obj=dossier):
-            dossier_html = linked(dossier, dossier.Title())
-        else:
-            no_access_tooltip = safe_unicode(translate(
-                _(u'You are not allowed to view the meeting dossier.'),
-                context=self.request))
-            dossier_html = (
-                u'<span class="{classes}">'
-                u'<span class="no_access" title="{no_access_tooltip}">'
-                u'{title}</span></span>').format(
-                    classes=safe_unicode(get_css_class(dossier)),
-                    no_access_tooltip=escape_html(no_access_tooltip),
-                    title=escape_html(safe_unicode(dossier.Title())))
+            with_tooltip = True
+
+        dossier_html = linked(dossier, dossier.Title(), with_tooltip=with_tooltip)
 
         yield {'label': _('meeting_byline_meetin_dossier', default='Meeting dossier'),
                'content': dossier_html,

--- a/opengever/meeting/browser/meetings/templates/meeting_error.pt
+++ b/opengever/meeting/browser/meetings/templates/meeting_error.pt
@@ -1,0 +1,36 @@
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en"
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      xmlns:metal="http://xml.zope.org/namespaces/metal"
+      xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+      lang="en"
+      metal:use-macro="here/main_template/macros/master"
+      i18n:domain="opengever.meeting">
+
+  <metal:title metal:fill-slot="content-title">
+    <metal:use use-macro="context/@@gever-macros/js_default_error_messages" />
+    <div id="tabbedview-header">
+      <h1 class="memberHeading meeting-view-heading documentFirstHeading">
+        <span tal:content="view/model/get_title" />
+        <span class="meeting-number"
+              tal:define="meeting view/model"
+              tal:condition="meeting/meeting_number"
+              i18n:attributes="title"
+              title="Meeting number">
+          #
+          <tal:YEAR replace="meeting/start/year" />
+          /
+          <tal:MEETING_NUMBER replace="meeting/meeting_number" />
+        </span>
+      </h1>
+    </div>
+  </metal:title>
+
+  <metal:content-core fill-slot="content-core">
+    <h2 class="meeting-permission-error-title" i18n:translate="">Insufficient privileges on meeting dossier</h2>
+    <div class="meeting-permission-error-message" tal:content="view/error_message">
+      Error message
+    </div>
+    <span tal:replace="structure view/meeting_dossier_link"></span>
+  </metal:content-core>
+
+</html>

--- a/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-11-22 08:07+0000\n"
+"POT-Creation-Date: 2019-01-11 09:17+0000\n"
 "PO-Revision-Date: 2017-10-23 18:40+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -152,6 +152,10 @@ msgstr "Ab Vorlage"
 msgid "History"
 msgstr "Verlauf"
 
+#: ./opengever/meeting/browser/meetings/templates/meeting_error.pt
+msgid "Insufficient privileges on meeting dossier"
+msgstr "Unzureichende Berechtigungen auf dem Sitzungsdossier"
+
 #: ./opengever/meeting/committee.py
 msgid "Linked repository folder"
 msgstr "Ablageposition"
@@ -161,6 +165,7 @@ msgid "Meeting Dossier"
 msgstr "Sitzungsdossier"
 
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt
+#: ./opengever/meeting/browser/meetings/templates/meeting_error.pt
 msgid "Meeting number"
 msgstr "Sitzungsnummer"
 
@@ -257,10 +262,6 @@ msgstr "Alle anzeigen"
 #: ./opengever/meeting/browser/meetings/participants.py
 msgid "You are not allowed to change the meeting details."
 msgstr "Sie haben nicht die nötigen Rechte, um Änderungen vorzunehmen."
-
-#: ./opengever/meeting/browser/meetings/byline.py
-msgid "You are not allowed to view the meeting dossier."
-msgstr "Sie haben nicht die nötigen Rechte, um das Sitzungsdossier anzusehen."
 
 #. Default: "Cancel meeting"
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt
@@ -1558,6 +1559,16 @@ msgstr "Das Erstellen der Zip-Datei hat zu lange gedauert."
 #: ./opengever/meeting/browser/templates/committee.pt
 msgid "new_unscheduled_proposals"
 msgstr "Neu eingereichte Anträge"
+
+#. Default: "User does not have permission to edit the meeting dossier:"
+#: ./opengever/meeting/browser/meetings/meeting.py
+msgid "no_edit_permissions_on_meeting_dossier"
+msgstr "Sie haben keine Rechte das Sitzungsdossier zu bearbeiten und Inhalte hinzuzufügen:"
+
+#. Default: "User does not have permission to view the meeting dossier:"
+#: ./opengever/meeting/browser/meetings/meeting.py
+msgid "no_view_permissions_on_meeting_dossier"
+msgstr "Sie haben keine Rechte das Sitzungsdossier anzusehen:"
 
 #. Default: "Overview"
 #: ./opengever/meeting/browser/tabbed.py

--- a/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-11-22 08:07+0000\n"
+"POT-Creation-Date: 2019-01-11 09:17+0000\n"
 "PO-Revision-Date: 2018-05-22 10:15+0000\n"
 "Last-Translator: Niklaus Johner <Niklaus.johner@4teamwork.ch>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-meeting/fr/>\n"
@@ -154,6 +154,10 @@ msgstr "A partir d'un modèle"
 msgid "History"
 msgstr "Historique"
 
+#: ./opengever/meeting/browser/meetings/templates/meeting_error.pt
+msgid "Insufficient privileges on meeting dossier"
+msgstr "Privilèges insuffisants sur le dossier de séance"
+
 #: ./opengever/meeting/committee.py
 msgid "Linked repository folder"
 msgstr "Répertoire d'archivage"
@@ -163,6 +167,7 @@ msgid "Meeting Dossier"
 msgstr "Dossier de séance"
 
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt
+#: ./opengever/meeting/browser/meetings/templates/meeting_error.pt
 msgid "Meeting number"
 msgstr "Numéro de la séance"
 
@@ -259,10 +264,6 @@ msgstr "afficher tous"
 #: ./opengever/meeting/browser/meetings/participants.py
 msgid "You are not allowed to change the meeting details."
 msgstr "Vous ne disposez pas des droits nécessaires pour faire des modifications."
-
-#: ./opengever/meeting/browser/meetings/byline.py
-msgid "You are not allowed to view the meeting dossier."
-msgstr "Vous ne disposez pas des droits nécessaires pour accéder au dossier."
 
 #. Default: "Cancel meeting"
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt
@@ -1560,6 +1561,16 @@ msgstr "La génération du fichier Zip a duré trop longtemps"
 #: ./opengever/meeting/browser/templates/committee.pt
 msgid "new_unscheduled_proposals"
 msgstr "Nouvelles propositions soumises"
+
+#. Default: "User does not have permission to edit the meeting dossier:"
+#: ./opengever/meeting/browser/meetings/meeting.py
+msgid "no_edit_permissions_on_meeting_dossier"
+msgstr "Vous n'avez pas les privilèges suffisants pour modifier le dossier de séance ou y ajouter du contenu:"
+
+#. Default: "User does not have permission to view the meeting dossier:"
+#: ./opengever/meeting/browser/meetings/meeting.py
+msgid "no_view_permissions_on_meeting_dossier"
+msgstr "Vous n'avez pas les privilèges suffisants pour voir le dossier de séance:"
 
 #. Default: "Overview"
 #: ./opengever/meeting/browser/tabbed.py

--- a/opengever/meeting/locales/opengever.meeting.pot
+++ b/opengever/meeting/locales/opengever.meeting.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-11-22 08:07+0000\n"
+"POT-Creation-Date: 2019-01-11 09:17+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -151,6 +151,10 @@ msgstr ""
 msgid "History"
 msgstr ""
 
+#: ./opengever/meeting/browser/meetings/templates/meeting_error.pt
+msgid "Insufficient privileges on meeting dossier"
+msgstr ""
+
 #: ./opengever/meeting/committee.py
 msgid "Linked repository folder"
 msgstr ""
@@ -160,6 +164,7 @@ msgid "Meeting Dossier"
 msgstr ""
 
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt
+#: ./opengever/meeting/browser/meetings/templates/meeting_error.pt
 msgid "Meeting number"
 msgstr ""
 
@@ -255,10 +260,6 @@ msgstr ""
 
 #: ./opengever/meeting/browser/meetings/participants.py
 msgid "You are not allowed to change the meeting details."
-msgstr ""
-
-#: ./opengever/meeting/browser/meetings/byline.py
-msgid "You are not allowed to view the meeting dossier."
 msgstr ""
 
 #. Default: "Cancel meeting"
@@ -1556,6 +1557,16 @@ msgstr ""
 #. Default: "New unscheduled proposals:"
 #: ./opengever/meeting/browser/templates/committee.pt
 msgid "new_unscheduled_proposals"
+msgstr ""
+
+#. Default: "User does not have permission to edit the meeting dossier:"
+#: ./opengever/meeting/browser/meetings/meeting.py
+msgid "no_edit_permissions_on_meeting_dossier"
+msgstr ""
+
+#. Default: "User does not have permission to view the meeting dossier:"
+#: ./opengever/meeting/browser/meetings/meeting.py
+msgid "no_view_permissions_on_meeting_dossier"
 msgstr ""
 
 #. Default: "Overview"

--- a/opengever/meeting/tests/test_meeting_byline.py
+++ b/opengever/meeting/tests/test_meeting_byline.py
@@ -28,10 +28,16 @@ class TestMeetingByline(IntegrationTestCase):
         self.assertEquals(self.meeting_dossier, browser.context)
 
     @browsing
-    def test_dossier_not_linked_when_unauthorized(self, browser):
+    def test_dossier_linked_but_no_breadcrumbs_when_unauthorized(self, browser):
         self.login(self.meeting_user, browser)
+
+        browser.open(self.meeting)
+        item = byline.by_label()['Meeting dossier:']
+        self.assertTrue(item.css('a').first)
+        self.assertTrue(item.css('.rollover-breadcrumb').first)
+
         self.meeting_dossier.__ac_local_roles_block__ = True
         browser.open(self.meeting)
         item = byline.by_label()['Meeting dossier:']
-        self.assertFalse(item.css('a'))
-        self.assertTrue(item.css('span.no_access').first)
+        self.assertTrue(item.css('a').first)
+        self.assertFalse(item.css('.rollover-breadcrumb'))

--- a/opengever/meeting/tests/test_meeting_view.py
+++ b/opengever/meeting/tests/test_meeting_view.py
@@ -6,6 +6,7 @@ from ftw.testing import freeze
 from opengever.meeting.tests.pages import meeting_view
 from opengever.testing import IntegrationTestCase
 from opengever.testing.pages import byline
+from plone import api
 import pytz
 
 
@@ -247,3 +248,35 @@ class TestMeetingView(IntegrationTestCase):
         self.assertEquals(
             0,
             len(browser.css('#ad-hoc-agenda-item-proposal-templates')))
+
+    @browsing
+    def test_displays_error_view_when_no_view_permissions_on_meeting_dossier(self, browser):
+        self.login(self.meeting_user, browser=browser)
+
+        browser.open(self.meeting)
+        self.assertEqual(0, len(browser.css(".meeting-permission-error-title")))
+        self.assertFalse(0, len(browser.css(".meeting-permission-error-error")))
+
+        api.content.disable_roles_acquisition(self.meeting_dossier)
+
+        browser.open(self.meeting)
+        self.assertEqual(browser.css(".meeting-permission-error-title").first.text,
+                         'Insufficient privileges on meeting dossier')
+        self.assertEqual(browser.css(".meeting-permission-error-message").first.text,
+                         'User does not have permission to view the meeting dossier:')
+
+    @browsing
+    def test_displays_error_view_when_no_edit_permissions_on_meeting_dossier(self, browser):
+        self.login(self.committee_responsible, browser=browser)
+
+        browser.open(self.meeting)
+        self.assertEqual(0, len(browser.css(".meeting-permission-error-title")))
+        self.assertFalse(0, len(browser.css(".meeting-permission-error-error")))
+
+        api.content.disable_roles_acquisition(self.meeting_dossier)
+
+        browser.open(self.meeting)
+        self.assertEqual(browser.css(".meeting-permission-error-title").first.text,
+                         'Insufficient privileges on meeting dossier')
+        self.assertEqual(browser.css(".meeting-permission-error-message").first.text,
+                         'User does not have permission to edit the meeting dossier:')

--- a/opengever/tabbedview/helper.py
+++ b/opengever/tabbedview/helper.py
@@ -15,7 +15,6 @@ from plone.memoize import ram
 from plone.uuid.interfaces import IUUID
 from Products.CMFCore.interfaces._tools import IMemberData
 from Products.CMFPlone.utils import safe_unicode
-from Products.CMFPlone.utils import safe_unicode
 from Products.PluggableAuthService.interfaces.authservice import IPropertiedUser
 from Products.ZCatalog.interfaces import ICatalogBrain
 from zope.component import getUtility
@@ -150,7 +149,7 @@ def linked_containing_maindossier(item, value):
     return link
 
 
-def linked(item, value):
+def linked(item, value, with_tooltip=True):
     """Takes an item (object or brain) and returns a HTML snippet that
     contains a link to the item, it's icon and breadcrumbs in the tooltip.
     """
@@ -171,7 +170,10 @@ def linked(item, value):
     # Make sure all data used in the HTML snippet is properly escaped
     value = escape_html(value)
 
-    link = '<a class="rollover-breadcrumb %s" href="%s" data-uid="%s"><span>%s</span></a>' % (
+    if with_tooltip:
+        css_class = "rollover-breadcrumb " + css_class
+
+    link = '<a class="%s" href="%s" data-uid="%s"><span>%s</span></a>' % (
         css_class, url, uid, value)
 
     wrapper = '<span class="linkWrapper">%s</span>' % link


### PR DESCRIPTION
We add a new view, which is displayed instead of the meeting view when a user has a permission mismatch between the `committee` and the `meeting_dossier`, as several elements of the meeting view are broken in that case. More specifically, when a user has `View` permission on the `committee` but not on the `meeting_dossier` or when a user has `Edit` permission on the `committee` but not on the `meeting_dossier`. The new view informs the user of the situation by displaying an error message (see screenshots below).

Note that I display a link to the `meeting_dossier` in these cases, which means that a user with no view permissions of the `meeting_dossier` will still see it's title and the link to the dossier.

**User has edit on the committee but not on the meeting_dossier**
<img width="1116" alt="screen shot 2019-01-11 at 11 01 46" src="https://user-images.githubusercontent.com/7374243/51033824-e908d200-15a4-11e9-918a-39bbb1f7e5da.png">

**User has view on the committee but not on the meeting_dossier**
<img width="1247" alt="screen shot 2019-01-11 at 11 21 29" src="https://user-images.githubusercontent.com/7374243/51033825-e908d200-15a4-11e9-9ced-e3a332f0bf09.png">

resolves #5107 