### PR TITLE
Include portal_type in @favorites endpoint responses.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2019.1.0 (unreleased)
 ---------------------
 
+- Include portal_type in @favorites endpoint response. [lgraf]
 - Supply date format locale settings for fr-ch. [lgraf]
 - Add meeting error view displayed when user has permission issues. [njohner]
 - Kill the theme functional test layer. [Rotonen]

--- a/docs/public/dev-manual/api/favorite.rst
+++ b/docs/public/dev-manual/api/favorite.rst
@@ -35,6 +35,7 @@ Mittels eines GET Request können Favoriten des Benutzers abgefragt werden. Dabe
               "icon_class": "icon-dokument_word",
               "oguid": "fd:68398212",
               "title": "Richtlinien Gesetzesentwürfe",
+              "portal_type": "opengever.document.document",
               "position": 1,
               "target_url": "http://localhost:8080/fd/resolve_oguid/fd:68398212"
           }
@@ -45,6 +46,7 @@ Mittels eines GET Request können Favoriten des Benutzers abgefragt werden. Dabe
               "icon_class": "contenttype-opengever-dossier-businesscasedossier",
               "oguid": "fd:68336212",
               "title": "Anfragen 2018",
+              "portal_type": "opengever.dossier.businesscasedossier",
               "position": 2,
               "target_url": "http://localhost:8080/fd/resolve_oguid/fd:68336212"
           }
@@ -81,6 +83,7 @@ Ein Favorit für ein beliebiges Objekt kann mittels POST Request hinzugefügt we
           "icon_class": "icon-dokument_word",
           "oguid": "fd:68398212",
           "title": "Anfrage 2018",
+          "portal_type": "opengever.document.document",
           "position": 1,
           "target_url": "http://localhost:8080/fd/resolve_oguid/fd:68398212"
       }
@@ -132,6 +135,7 @@ Es ist aber möglich bei einem PATCH request die Objekt-Repräsentation als Resp
           "icon_class": "icon-dokument_word",
           "oguid": "fd:68398212",
           "title": "Weekly Document",
+          "portal_type": "opengever.document.document",
           "position": 35,
           "target_url": "http://localhost:8080/fd/resolve_oguid/fd:68398212"
       }

--- a/opengever/api/tests/test_favorites.py
+++ b/opengever/api/tests/test_favorites.py
@@ -34,6 +34,7 @@ class TestFavoritesGet(IntegrationTestCase):
         self.assertEqual(200, browser.status_code)
         self.assertEquals(
             [{u'@id': u'http://nohost/plone/@favorites/kathi.barfuss/1',
+              u'portal_type': u'opengever.dossier.businesscasedossier',
               u'favorite_id': 1,
               u'position': 23,
               u'oguid': u'plone:1014013300',
@@ -43,6 +44,7 @@ class TestFavoritesGet(IntegrationTestCase):
               u'icon_class': u'contenttype-opengever-dossier-businesscasedossier',
               u'title': u'Vertr\xe4ge mit der kantonalen Finanzverwaltung'},
              {u'@id': u'http://nohost/plone/@favorites/kathi.barfuss/2',
+              u'portal_type': u'opengever.document.document',
               u'favorite_id': 2,
               u'position': 21,
               u'oguid': u'plone:1014073300',
@@ -69,6 +71,7 @@ class TestFavoritesGet(IntegrationTestCase):
         self.assertEqual(200, browser.status_code)
         self.assertEquals(
             {u'@id': u'http://nohost/plone/@favorites/kathi.barfuss/1',
+             u'portal_type': u'opengever.dossier.businesscasedossier',
              u'favorite_id': 1,
              u'position': 23,
              u'oguid': u'plone:1014013300',
@@ -136,6 +139,7 @@ class TestFavoritesPost(IntegrationTestCase):
 
         self.assertEquals(
             {u'@id': u'http://nohost/plone/@favorites/kathi.barfuss/1',
+             u'portal_type': u'opengever.document.document',
              u'favorite_id': 1,
              u'oguid': u'plone:1014073300',
              u'position': 0,
@@ -205,6 +209,7 @@ class TestFavoritesPost(IntegrationTestCase):
 
         self.assertEqual(
             {u'@id': u'http://nohost/plone/@favorites/nicole.kohler/1',
+             u'portal_type': u'opengever.document.document',
              u'admin_unit': u'Hauptmandant',
              u'favorite_id': 1,
              u'icon_class': u'icon-docx',
@@ -448,6 +453,7 @@ class TestFavoritesPatch(IntegrationTestCase):
         self.assertEqual(200, browser.status_code)
         self.assertEqual(
             {u'@id': u'http://nohost/plone/@favorites/kathi.barfuss/1',
+             u'portal_type': u'opengever.dossier.businesscasedossier',
              u'favorite_id': 1,
              u'title': u'\xdcbersicht OGIPs',
              u'target_url': u'http://nohost/plone/resolve_oguid/plone:1014013300',

--- a/opengever/api/tests/test_repository_favorites.py
+++ b/opengever/api/tests/test_repository_favorites.py
@@ -193,6 +193,7 @@ class TestRepositoryFavoritesPost(IntegrationTestCase):
              u'favorite_id': 1,
              u'icon_class': u'icon-docx',
              u'oguid': u'plone:1014073300',
+             u'portal_type': u'opengever.document.document',
              u'position': None,
              u'target_url': u'http://nohost/plone/resolve_oguid/plone:1014073300',
              u'title': u'Vertr\xe4gsentwurf',

--- a/opengever/base/model/favorite.py
+++ b/opengever/base/model/favorite.py
@@ -55,6 +55,7 @@ class Favorite(Base):
     def serialize(self, portal_url):
         return {
             '@id': self.api_url(portal_url),
+            'portal_type': self.portal_type,
             'favorite_id': self.favorite_id,
             'oguid': self.oguid.id,
             'title': self.title,


### PR DESCRIPTION
This adds a `portal_type` field to the items in the `@favorite` endpoint's responses. The field indicates the type of the target object referenced by the favorite.

A new response will look like this:

```json
      [
          {
              "@id": "http://localhost:8080/fd/@favorites/peter.mueller/3",
              "favorite_id": 3,
              "icon_class": "icon-dokument_word",
              "oguid": "fd:68398212",
              "title": "Richtlinien Gesetzesentwürfe",
              "portal_type": "opengever.document.document",
              "position": 1,
              "target_url": "http://localhost:8080/fd/resolve_oguid/fd:68398212"
          }
          ,
          {
              "@id": "http://localhost:8080/fd/@favorites/peter.mueller/57",
              "favorite_id": 57,
              "icon_class": "contenttype-opengever-dossier-businesscasedossier",
              "oguid": "fd:68336212",
              "title": "Anfragen 2018",
              "portal_type": "opengever.dossier.businesscasedossier",
              "position": 2,
              "target_url": "http://localhost:8080/fd/resolve_oguid/fd:68336212"
          }
      ]
```

Closes #5258 