### PR TITLE
Refactor solr livesearch reply

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -8,6 +8,7 @@ Changelog
 - Remove deprecated docprops from templates and tests. [njohner]
 - Bump ftw.structlog to get new client_ip field and referrer logging fixes. [lgraf]
 - Skip sablon template validation during setup of development system. [njohner]
+- Refactor solr LiveSearchReplyView to use a template. [njohner]
 - Include portal_type in @favorites endpoint response. [lgraf]
 - Supply date format locale settings for fr-ch. [lgraf]
 - Add meeting error view displayed when user has permission issues. [njohner]

--- a/opengever/advancedsearch/skins/advancedsearch_resources/livesearch_reply.py
+++ b/opengever/advancedsearch/skins/advancedsearch_resources/livesearch_reply.py
@@ -151,7 +151,7 @@ if not results:
               (ts.translate(pmf('Error'), context=REQUEST),
                ts.translate(label_has_parse_errors, context=REQUEST)))
     else:
-        write('''<ul class=dropdown-list><li id="LSNothingFound" class="dropdown-list-item">%s</li></ul>'''
+        write('''<ul class="dropdown-list"><li id="LSNothingFound" class="dropdown-list-item">%s</li></ul>'''
               % ts.translate(label_no_results_found, context=REQUEST))
     write('''<div class="dropdown-list-footer LSRow">''')
     write('<a href="%s" class="dropdown-list-item">%s</a>' %
@@ -191,6 +191,7 @@ else:
     write('''</ul>''')
 
     write('''<div class="dropdown-list-footer LSRow">''')
+
     write('<a href="%s" class="dropdown-list-item">%s</a>' %
           (portal_url + '/advanced_search?SearchableText=%s' % searchurlparameter,
            ts.translate(label_advanced_search, context=REQUEST)))

--- a/opengever/advancedsearch/tests/test_livesearch_reply.py
+++ b/opengever/advancedsearch/tests/test_livesearch_reply.py
@@ -12,6 +12,7 @@ class TestLivesearchReply(IntegrationTestCase):
         self.dossier.reindexObject()
 
         browser.open(view='livesearch_reply?q=evil')
+
         link_node = browser.css('.LSRow').first
         # lxml unescapes attributes for us. we want to test that the title
         # has been escaped correctly and thus use browser.contents only.
@@ -20,3 +21,12 @@ class TestLivesearchReply(IntegrationTestCase):
         # also test title that is displayed
         self.assertIn('&lt;script&gt;alert(\'evil\');&lt;',
                       link_node.innerHTML)
+
+    @browsing
+    def test_livesearch_empty_result(self, browser):
+        self.login(self.regular_user, browser=browser)
+        browser.open(view='livesearch_reply?q=blablabla')
+
+        link_node = browser.css('.dropdown-list-item').first
+        self.assertEqual('LSNothingFound', link_node.get("id"))
+        self.assertEqual('No matching results found.', link_node.text)

--- a/opengever/base/browser/templates/livesearch.pt
+++ b/opengever/base/browser/templates/livesearch.pt
@@ -1,0 +1,38 @@
+<tal:block tal:condition="not: view/result_items">
+    <fieldset class="livesearchContainer solr">
+        <legend id="livesearchLegend" tal:content="view/legend"></legend>
+        <div class="LSIEFix">
+            <ul class=dropdown-list>
+                <li id="LSNothingFound" class="dropdown-list-item" tal:content="view/nothing_found"></li>
+            </ul>
+            <div class="dropdown-list-footer LSRow">
+                <a tal:attributes="href view/advanced_search_url" class="dropdown-list-item" tal:content="view/advanced_search_label"></a>
+            </div>
+        </div>
+    </fieldset>
+</tal:block>
+
+<tal:block tal:condition="view/result_items">
+    <fieldset class="livesearchContainer solr">
+        <legend id="livesearchLegend" tal:content="view/legend"></legend>
+        <div class="LSIEFix">
+            <ul class="dropdown-list LSTable">
+                <tal:repeat tal:repeat="item view/result_items">
+                    <a tal:attributes="href item/url; title item/title" class="dropdown-list-item LSRow">
+                        <span tal:attributes="class item/css_klass"/>
+                        <span class="dropdown-list-item-content">
+                            <div class="LSTitle" tal:content="item/title"></div>
+                            <div class="LSDescr" tal:content="item/description"></div>
+                        </span>
+                    </a>
+                </tal:repeat>
+            </ul>
+            <div class="dropdown-list-footer LSRow">
+                <a tal:attributes="href view/advanced_search_url" class="dropdown-list-item" tal:content="view/advanced_search_label"></a>
+                <tal:block tal:condition="view/show_more">
+                    <a tal:attributes="href view/show_more/url" class="dropdown-list-item LSRow" tal:content="view/show_more/title"></a>
+                </tal:block>
+            </div>
+        </div>
+    </fieldset>
+</tal:block>

--- a/opengever/base/tests/test_search.py
+++ b/opengever/base/tests/test_search.py
@@ -313,6 +313,6 @@ class TestSolrSearch(IntegrationTestCase):
         all_items_link = browser.find('Show all items')
         self.assertIsNotNone(all_items_link)
         self.assertEqual(
-            '<a href="@@search?SearchableText=test&amp;path=/plone" class="dropdown-list-item LSRow">Show all items</a>',
+            '<a class="dropdown-list-item LSRow" href="@@search?SearchableText=test&amp;path=/plone">Show all items</a>',
             all_items_link.outerHTML,
             )

--- a/opengever/base/tests/test_solr_livesearch.py
+++ b/opengever/base/tests/test_solr_livesearch.py
@@ -1,0 +1,126 @@
+from ftw.solr.interfaces import IFtwSolrLayer
+from ftw.testbrowser import browsing
+from opengever.testing import IntegrationTestCase
+from zope.interface import alsoProvides
+
+
+class TestSolrLivesearchReply(IntegrationTestCase):
+
+    features = ('solr', )
+
+    def setUp(self):
+        super(TestSolrLivesearchReply, self).setUp()
+        alsoProvides(self.request, IFtwSolrLayer)
+        self.livesearch = self.portal.unrestrictedTraverse('@@livesearch_reply')
+        self.request.form.update({'q': 'foo'})
+        self.solr_search_response = {
+            "responseHeader": {
+                "status": 0,
+                "QTime": 3,
+                "limit": 10,
+                "params": {
+                    "json": "{\n  \"query\": \":\"\n}"
+                    }
+                },
+            "response": {
+                "numFound": 3,
+                "start": 0,
+                "docs": [
+                    {
+                        "UID": "85bed8c49f6d4f8b841693c6a7c6cff1",
+                        "Title": "My Folder 1",
+                        "Description": "",
+                        "getIcon": "",
+                        "id": "my-folder-1",
+                        "path": "/my-folder-1",
+                        "portal_type": "opengever.dossier.businesscasedossier"
+                    },
+                    {
+                        "UID": "85a29144758f494c88df19182f749ed6",
+                        "Title": "My Folder 2",
+                        "Description": "",
+                        "getIcon": "",
+                        "path": "/my-folder-2",
+                        "id": "my-folder-2",
+                        "portal_type": "opengever.dossier.businesscasedossier",
+                    },
+                    {
+                        "UID": "9398dad21bcd49f8a197cd50d10ea778",
+                        "Title": "My Document",
+                        "Description": "",
+                        "getIcon": "icon_dokument_word.gif",
+                        "path": "/my-folder-1/my-document",
+                        "id": "my-document",
+                        "portal_type": "opengever.document.document",
+                    }
+                        ]
+                }
+            }
+
+    @browsing
+    def test_testing_solr_livesearch(self, browser):
+        """Make sure we are testing the solr livesearch reply"""
+        self.solr = self.mock_solr(response_json=self.solr_search_response)
+        browser.open_html(self.livesearch())
+        self.assertIn("solr", browser.css(".livesearchContainer").first.classes)
+
+    @browsing
+    def test_livesearch_reply_listing(self, browser):
+        self.solr = self.mock_solr(response_json=self.solr_search_response)
+        browser.open_html(self.livesearch())
+
+        link_nodes = browser.css('.dropdown-list-item')
+        self.assertEqual(4, len(link_nodes))
+
+        expected_titles = ['My Folder 1', 'My Folder 2',
+                           'My Document', 'Advanced Search&#8230;']
+        self.assertEqual(expected_titles, [node.text for node in link_nodes])
+
+    @browsing
+    def test_livesearch_reply_escapes_title(self, browser):
+        self.solr_search_response["response"]["docs"][0]["Title"] = u"<script>alert('evil');</script>"
+        self.solr = self.mock_solr(response_json=self.solr_search_response)
+        browser.open_html(self.livesearch())
+
+        link_node = browser.css('.dropdown-list-item').first
+        # lxml unescapes attributes for us. we want to test that the title
+        # has been escaped correctly and thus use browser.contents only.
+        self.assertIn('title="&lt;script&gt;alert(\'evil\');&lt;/script&gt;"',
+                      link_node.outerHTML)
+        # also test title that is displayed
+        self.assertIn('&lt;script&gt;alert(\'evil\');&lt;',
+                      link_node.innerHTML)
+
+    @browsing
+    def test_livesearch_reply_show_more(self, browser):
+        self.solr_search_response["response"]["numFound"] = 4
+        self.request.form.update({'limit': '3'})
+        self.solr = self.mock_solr(response_json=self.solr_search_response)
+        browser.open_html(self.livesearch())
+
+        link_nodes = browser.css('.dropdown-list-item')
+        self.assertEqual(5, len(link_nodes))
+
+        expected_titles = ['My Folder 1', 'My Folder 2', 'My Document',
+                           'Advanced Search&#8230;', 'Show all items']
+        self.assertEqual(expected_titles, [node.text for node in link_nodes])
+
+        self.assertEqual('@@search?SearchableText=foo&path=/plone',
+                         link_nodes[-1].get("href"))
+
+    @browsing
+    def test_livesearch_reply_empty_result(self, browser):
+        self.solr_search_response["response"]["docs"] = []
+        self.solr_search_response["response"]["numFound"] = 0
+        self.solr = self.mock_solr(response_json=self.solr_search_response)
+        browser.open_html(self.livesearch())
+
+        link_nodes = browser.css('.dropdown-list-item')
+        self.assertEqual(2, len(link_nodes))
+
+        expected_titles = ['No matching results found.',
+                           'Advanced Search&#8230;']
+        self.assertEqual(expected_titles, [node.text for node in link_nodes])
+
+        link_node = browser.css('.dropdown-list-item').first
+        self.assertEqual('LSNothingFound', link_node.get("id"))


### PR DESCRIPTION
Livesearch reply with activated solr was overwritten by a browser view, but copying the rendering from the `livesearch_reply.py` from the skins folder, so that no template was used for the view. Instead html was generated from the python code by concatenating strings, making the code hard to read and modify. 
* We refactor the `LiveSearchReplyView` to use a template
* We add tests for the `LiveSearchReplyView` (which was untested until now)
* We correct a small xml bug in the standard `livesearch_reply` (no solr)
* We add a test for when the standard `livesearch_reply` returns no results.

To allow more flexible testing we modify the `IntegrationTestCase.mock_solr` method to also accept a response dictionary as argument instead  of an asset filename. This allows to more easily modify the response in the tests.

resolves #5018 