### PR TITLE
Skip sablon template validation during setup of development system.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2019.1.0 (unreleased)
 ---------------------
 
+- Skip sablon template validation during setup of development system. [njohner]
 - Include portal_type in @favorites endpoint response. [lgraf]
 - Supply date format locale settings for fr-ch. [lgraf]
 - Add meeting error view displayed when user has permission issues. [njohner]

--- a/opengever/meeting/handlers.py
+++ b/opengever/meeting/handlers.py
@@ -12,6 +12,7 @@ from opengever.meeting.model import SubmittedDocument
 from opengever.meeting.model.excerpt import Excerpt
 from opengever.meeting.proposal import ISubmittedProposal
 from opengever.meeting.sablontemplate import sablon_template_is_valid
+from opengever.setup.interfaces import IDuringSetup
 from plone import api
 from zc.relation.interfaces import ICatalog
 from zope.annotation.interfaces import IAnnotations
@@ -20,6 +21,7 @@ from zope.component.interfaces import ComponentLookupError
 from zope.container.interfaces import IContainerModifiedEvent
 from zope.globalrequest import getRequest
 from zope.intid.interfaces import IIntIds
+import os
 
 
 def document_deleted(context, event):
@@ -127,6 +129,10 @@ def configure_committee_container_portlets(container, event):
 
 
 def validate_template_file(obj, event):
+    # skip validation during setup of development system. This allows to setup
+    # in development mode without the need of a working sablon installation.
+    if IDuringSetup.providedBy(getRequest()) and os.environ.get('IS_DEVELOPMENT_MODE', False):
+        return
     if obj.file is not None:
         IAnnotations(obj)[
             'opengever.meeting.sablon_template_is_valid'

--- a/opengever/meeting/tests/test_sablon_template_validation.py
+++ b/opengever/meeting/tests/test_sablon_template_validation.py
@@ -1,7 +1,12 @@
 from ftw.testbrowser import browsing
 from ftw.testbrowser.pages import statusmessages
+from opengever.meeting.handlers import validate_template_file
+from opengever.setup.interfaces import IDuringSetup
 from opengever.testing import assets
 from opengever.testing import IntegrationTestCase
+from zope.annotation.interfaces import IAnnotations
+from zope.interface import alsoProvides
+import os
 
 
 class TestSablonTemplateValidation(IntegrationTestCase):
@@ -41,3 +46,45 @@ class TestSablonTemplateValidation(IntegrationTestCase):
             'File': (sablon_template, 'valid_sablon_template.docx', 'text/plain'),
         }).save()
         statusmessages.assert_no_error_messages()
+
+        # Go to the created template's detail view
+        browser.open(browser.context.listFolderContents()[-1])
+
+        self.assertEquals([], statusmessages.error_messages())
+
+    @browsing
+    def test_validation_is_skipped_during_setup_in_development_mode(self, browser):
+        """ During setup in development mode the validation of sablon template
+        should be skipped."""
+        self.login(self.meeting_user, browser)
+
+        self.assertTrue(self.sablon_template.is_valid_sablon_template())
+
+        IAnnotations(self.sablon_template)['opengever.meeting.sablon_template_is_valid'] = False
+        self.assertFalse(self.sablon_template.is_valid_sablon_template())
+
+        # validation is executed and sablon template is marked as valid
+        validate_template_file(self.sablon_template, "foo")
+        self.assertTrue(self.sablon_template.is_valid_sablon_template())
+
+        IAnnotations(self.sablon_template)['opengever.meeting.sablon_template_is_valid'] = False
+        self.assertFalse(self.sablon_template.is_valid_sablon_template())
+
+        # validation is skipped in development mode during setup
+        with DevelopmentModeEnvironEnabled():
+            alsoProvides(self.request, IDuringSetup)
+            validate_template_file(self.sablon_template, "foo")
+            self.assertFalse(self.sablon_template.is_valid_sablon_template())
+
+
+class DevelopmentModeEnvironEnabled():
+
+    def __enter__(self):
+        self.development_var = os.environ.get('IS_DEVELOPMENT_MODE')
+        os.environ['IS_DEVELOPMENT_MODE'] = "True"
+
+    def __exit__(self, type, value, traceback):
+        if 'IS_DEVELOPMENT_MODE' in os.environ:
+            os.environ.pop('IS_DEVELOPMENT_MODE')
+        if self.development_var is not None:
+            os.environ['IS_DEVELOPMENT_MODE'] = self.development_var


### PR DESCRIPTION
To allow to setup a development GEVER without a functional Sablon installation, we skip template validation during setup in development mode.

Note that after the setup of the example content, the sablon templates are marked as invalid. And without a working installation of sablon, sablon templates cannot be checked-in (they can be checked out).

Fixes #4852