### PR TITLE
Add Impersonator role and "ftw.tokenauth: Impersonate user" permission.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ---------------------
 
 - Remove deprecated docprops from templates and tests. [njohner]
+- Add Impersonator role and "ftw.tokenauth: Impersonate user" permission. [njohner]
 - Bump ftw.structlog to get new client_ip field and referrer logging fixes. [lgraf]
 - Skip sablon template validation during setup of development system. [njohner]
 - Include portal_type in @favorites endpoint response. [lgraf]

--- a/opengever/core/profiles/default/rolemap.xml
+++ b/opengever/core/profiles/default/rolemap.xml
@@ -7,6 +7,7 @@
     <role name="CommitteeMember" />
     <role name="CommitteeResponsible" />
     <role name="DossierManager" />
+    <role name="Impersonator" />
     <role name="MeetingUser" />
     <role name="Publisher" />
     <role name="Records Manager" />
@@ -270,6 +271,10 @@
     <!-- TOKENAUTH -->
     <permission name="ftw.tokenauth: Manage own Service Keys" acquire="False">
       <role name="ServiceKeyUser" />
+    </permission>
+
+    <permission name="ftw.tokenauth: Impersonate user" acquire="False">
+      <role name="Impersonator" />
     </permission>
 
     <!-- TRASH -->

--- a/opengever/core/upgrades/20190116081139_add_impersonator_role_for_ftw_tokenauth_impersonate_feature/rolemap.xml
+++ b/opengever/core/upgrades/20190116081139_add_impersonator_role_for_ftw_tokenauth_impersonate_feature/rolemap.xml
@@ -1,0 +1,10 @@
+<rolemap>
+  <roles>
+    <role name="Impersonator" />
+  </roles>
+  <permissions>
+    <permission name="ftw.tokenauth: Impersonate user" acquire="False">
+      <role name="Impersonator" />
+    </permission>
+  </permissions>
+</rolemap>

--- a/opengever/core/upgrades/20190116081139_add_impersonator_role_for_ftw_tokenauth_impersonate_feature/upgrade.py
+++ b/opengever/core/upgrades/20190116081139_add_impersonator_role_for_ftw_tokenauth_impersonate_feature/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddImpersonatorRoleForFtwTokenauthImpersonateFeature(UpgradeStep):
+    """Add impersonator role for ftw tokenauth impersonate feature.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()


### PR DESCRIPTION
We add a new permission `ftw.tokenauth: Impersonate user` and a new role `Impersonator`, having that permission. This role will be given to service users that should be allowed to use the `impoersonate` feature of `ftw.tokenauth`

resolves #5142 