### PR TITLE
Also hide re-risen Unauthorized tracebacks for non-manager users.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -18,6 +18,7 @@ Changelog
 - Include portal_type in @favorites endpoint response. [lgraf]
 - Supply date format locale settings for fr-ch. [lgraf]
 - Add meeting error view displayed when user has permission issues. [njohner]
+- Also hide re-risen Unauthorized tracebacks for non-manager users. [Rotonen]
 - Kill the theme functional test layer. [Rotonen]
 - Kill the theme integration test layer. [Rotonen]
 - Merge the plonetheme.teamraum gever profile into opengever.core. [Rotonen]

--- a/opengever/base/monkey/patches/__init__.py
+++ b/opengever/base/monkey/patches/__init__.py
@@ -1,6 +1,7 @@
 from .cmf_catalog_aware import PatchCMFCatalogAware
 from .cmf_catalog_aware import PatchCMFCatalogAwareHandlers
 from .default_values import PatchBuilderCreate
+from .default_values import PatchDeserializeFromJson
 from .default_values import PatchDexterityContentGetattr
 from .default_values import PatchDexterityDefaultAddForm
 from .default_values import PatchDXCreateContentInContainer
@@ -8,7 +9,7 @@ from .default_values import PatchInvokeFactory
 from .default_values import PatchTransmogrifyDXSchemaUpdater
 from .default_values import PatchZ3CFormChangedField
 from .default_values import PatchZ3CFormWidgetUpdate
-from .default_values import PatchDeserializeFromJson
+from .exception_formatter import PatchExceptionFormatter
 from .filter_trashed_from_catalog import PatchCatalogToFilterTrashedDocs
 from .history_handler_tool import PatchCMFEditonsHistoryHandlerTool
 from .ldap_userfolder_encoding import PatchLDAPUserFolderEncoding
@@ -17,8 +18,8 @@ from .paste_permission import PatchDXContainerPastePermission
 from .plone_43rc1_upgrade import PatchPlone43RC1Upgrade
 from .resource_registries_url_regex import PatchResourceRegistriesURLRegex
 from .rolemanager import PatchOFSRoleManager
-from .uuidindex import PatchUUIDIndex
 from .tz_for_log import PatchZ2LogTimezone
+from .uuidindex import PatchUUIDIndex
 from .verify_object_paste import PatchCopyContainerVerifyObjectPaste
 from .webdav_lock_timeout import PatchWebDAVLockTimeout
 
@@ -46,3 +47,4 @@ PatchDeserializeFromJson()()
 PatchCMFCatalogAware()()
 PatchOFSRoleManager()()
 PatchCMFCatalogAwareHandlers()()
+PatchExceptionFormatter()()

--- a/opengever/base/monkey/patches/exception_formatter.py
+++ b/opengever/base/monkey/patches/exception_formatter.py
@@ -1,0 +1,41 @@
+from opengever.base.monkey.patching import MonkeyPatch
+
+
+class PatchExceptionFormatter(MonkeyPatch):
+    """Return an empty user-facing traceback for non-manager users.
+
+    This is done as ``Unauthorized`` is explicitly rerisen for PAS plugins and
+    this ends up bypassing the ``opengever.base`` exception template and
+    falling back to normal exception rendering mechanisms.
+    """
+
+    def __call__(self):
+        from plone import api
+
+        def formatException(self, etype, value, tb, limit=None):
+            # The block within this if is the original implementation
+            if api.user.has_permission("Manage Portal", obj=api.portal.get()):
+                # The next line provides a way to detect recursion.
+                __exception_formatter__ = 1
+                result = [self.getPrefix() + "\n"]
+                if limit is None:
+                    limit = self.getLimit()
+                n = 0
+                while tb is not None and (limit is None or n < limit):
+                    if tb.tb_frame.f_locals.get("__exception_formatter__"):
+                        # Stop recursion.
+                        result.append("(Recursive formatException() stopped)\n")
+                        break
+                    line = self.formatLine(tb)
+                    result.append(line + "\n")
+                    tb = tb.tb_next
+                    n = n + 1
+                exc_line = self.formatExceptionOnly(etype, value)
+                result.append(self.formatLastLine(exc_line))
+                return result
+
+            # We fall through in our patch with a notification of a suppression
+            return ["Exception suppressed."]
+
+        from zExceptions.ExceptionFormatter import TextExceptionFormatter
+        self.patch_refs(TextExceptionFormatter, "formatException", formatException)


### PR DESCRIPTION
Return an empty user-facing traceback for non-manager users.
This is done as `Unauthorized` is explicitly rerisen for PAS plugins and this ends up bypassing the `opengever.base` exception template and falling back to normal exception rendering mechanisms.

Additionally we always display the tracebacks in debug mode or with verbose security enabled.

Adding tests for this one would be quite a chore as one would have to create a new testing layer per combination of ZServer settings and the traversal driver on the testbrowser always follows redirects and the issue we have is on the body of the redirect response. Thus I'm requesting manual validation.

We're hitting this logic (relevant for PAS challenge plugins) in https://github.com/zopefoundation/Zope/commit/7b65910f826130e456c32fd33a0ccec26687e324 and monkey patching the exception formatting logic was the least impactful route I found of addressing this.

An alternative would be to try to muck around with the exception hook itself, but that'd be potentially a lot more dangerous.

https://github.com/zopefoundation/Zope/blob/d916c812bdaf518053b0c3cb2cb3545ff73bc288/src/ZPublisher/Publish.py#L336

Also the exception rendering code is peppered a bit all around the place, depending on exact circumstance, but all of them I've managed to find use the `zExceptions.ExceptionFormatter`.

Original implementation:
https://github.com/zopefoundation/zExceptions/blob/85343157fa49f04b5304f8394d27400804b292df/src/zExceptions/ExceptionFormatter.py#L178-L196

Closes #5191 