### PR TITLE
Resolve mail author to fullname when it is a userid.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -8,6 +8,7 @@ Changelog
 - Prevent tasks from being copied. [lgraf]
 - ResolveOGUIDView: Preserve query string. [lgraf]
 - Bump docxcompose to 1.0.0a16 to fix updating docproperties. [deiferni]
+- Resolve mail author to fullname when it is a userid. [njohner]
 - Remove deprecated docprops from templates and tests. [njohner]
 - Add Impersonator role and "ftw.tokenauth: Impersonate user" permission. [njohner]
 - Bump ftw.structlog to get new client_ip field and referrer logging fixes. [lgraf]

--- a/opengever/mail/configure.zcml
+++ b/opengever/mail/configure.zcml
@@ -84,4 +84,10 @@
            zope.lifecycleevent.interfaces.IObjectCreatedEvent"
       handler=".mail.initialize_metadata"
       />
+
+  <subscriber
+      for="opengever.mail.mail.IOGMailMarker
+           zope.lifecycleevent.interfaces.IObjectModifiedEvent"
+      handler=".subscribers.resolve_mail_author"
+      />
 </configure>

--- a/opengever/mail/subscribers.py
+++ b/opengever/mail/subscribers.py
@@ -1,5 +1,15 @@
+from opengever.document.subscribers import resolve_document_author
+
+
 def set_digitally_available(mail, event):
     """Set the `digitally_available` field upon creation
     (always True for mails by definition).
     """
     mail.digitally_available = True
+
+
+def resolve_mail_author(mail, event):
+    """When mail edited, the author can be specified by userid and should
+    be mapped to user fullname. This is not fired upon mail creation,
+    as the author is taken from the sender E-mail address in that case."""
+    resolve_document_author(mail, event)

--- a/opengever/mail/tests/test_mail.py
+++ b/opengever/mail/tests/test_mail.py
@@ -1,26 +1,22 @@
-from ftw.builder import Builder
-from ftw.builder import create
 from ftw.testbrowser import browsing
-from opengever.testing import FunctionalTestCase
+from opengever.testing import IntegrationTestCase
 
 
-class TestMail(FunctionalTestCase):
+class TestMail(IntegrationTestCase):
 
     @browsing
     def test_regular_user_can_add_new_keywords_in_mail(self, browser):
-        dossier = create(Builder('dossier'))
-        mail = create(Builder('mail').within(dossier))
+        self.login(self.regular_user, browser)
 
-        self.grant('Reader', 'Contributor', 'Editor')
-
-        browser.login().visit(mail, view='@@edit')
-
+        browser.visit(self.mail_eml, view='@@edit')
         keywords = browser.find_field_by_text(u'Keywords')
+        self.assertTupleEqual(tuple(), tuple(keywords.value))
+
         new = browser.css('#' + keywords.attrib['id'] + '_new').first
         new.text = u'NewItem1\nNew Item 2\nN\xf6i 3'
         browser.find_button_by_label('Save').click()
 
-        browser.visit(mail, view='edit')
+        browser.visit(self.mail_eml, view='edit')
         keywords = browser.find_field_by_text(u'Keywords')
         self.assertTupleEqual(('New Item 2', 'NewItem1', 'N=C3=B6i 3'),
                               tuple(keywords.value))

--- a/opengever/mail/tests/test_mail_metadata.py
+++ b/opengever/mail/tests/test_mail_metadata.py
@@ -3,6 +3,7 @@ from ftw.builder import Builder
 from ftw.builder import create
 from ftw.mail import inbound
 from ftw.testbrowser import browser
+from ftw.testbrowser import browsing
 from opengever.document.interfaces import IDocumentSettings
 from opengever.mail.mail import extract_email
 from opengever.mail.mail import get_author_by_email
@@ -10,6 +11,8 @@ from opengever.mail.mail import MESSAGE_SOURCE_DRAG_DROP_UPLOAD
 from opengever.mail.tests import MAIL_DATA
 from opengever.mail.tests.utils import get_header_date
 from opengever.testing import FunctionalTestCase
+from opengever.testing import IntegrationTestCase
+from opengever.testing import obj2brain
 from opengever.testing.sql import create_ogds_user
 from plone.registry.interfaces import IRegistry
 from unittest import TestCase
@@ -147,6 +150,28 @@ class TestMailMetadataWithAddView(TestMailMetadataWithBuilder):
 
             mail = browser.context
             return mail
+
+
+class TestMailAuthorResolving(IntegrationTestCase):
+
+    @browsing
+    def test_editing_mail_with_a_userid_as_author_resolves_to_fullname(self, browser):
+        self.login(self.regular_user, browser)
+        browser.open(self.mail_eml, view='edit')
+        browser.fill({'Author': u'kathi.barfuss'})
+        browser.click_on('Save')
+
+        self.assertEquals(u'B\xe4rfuss K\xe4thi', self.mail_eml.document_author)
+        self.assertEquals(u'B\xe4rfuss K\xe4thi', obj2brain(self.mail_eml).document_author)
+
+    @browsing
+    def test_editing_mail_with_a_real_name_as_author_dont_change_author_name(self, browser):
+        self.login(self.regular_user, browser)
+        browser.open(self.mail_eml, view='edit')
+        browser.fill({'Author': u'Muster Peter'})
+        browser.click_on('Save')
+
+        self.assertEquals('Muster Peter', self.mail_eml.document_author)
 
 
 class TestMailPreservedAsPaperDefault(FunctionalTestCase):


### PR DESCRIPTION
When editing an E-mail and setting the `document_author` to an existing userid, we now set the `document_author` to the corresponding user `fullname`.

Should we write an upgrade step to correct existing E-mails? Note that upon E-mail creation, the `document_author` is taken from the e-mail sender, and if the E-mail address corresponds to a GEVER user, the `document_author` is set to that user's `fullname`. So my guess is that this issue affects only a few E-mails

As I copied the tests from `test_document.TestDocumentAuthorResolving`, which were functional tests, I ported those to the integration layer. I also ported `test_mail.py` to integration layer, just because I had at first added my new tests in that file and having functional tests in there hurt my eyes.

resolves #5226 