### PR TITLE
Prevent tasks from being copied

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2019.1.0 (unreleased)
 ---------------------
 
+- Prevent tasks from being copied. [lgraf]
 - ResolveOGUIDView: Preserve query string. [lgraf]
 - Bump docxcompose to 1.0.0a16 to fix updating docproperties. [deiferni]
 - Remove deprecated docprops from templates and tests. [njohner]

--- a/opengever/dossier/tests/test_copy_dossier.py
+++ b/opengever/dossier/tests/test_copy_dossier.py
@@ -3,7 +3,6 @@ from ftw.builder import create
 from opengever.base.interfaces import IReferenceNumberPrefix
 from opengever.testing import IntegrationTestCase
 from plone import api
-from plone.uuid.interfaces import IUUID
 from zope.app.intid.interfaces import IIntIds
 from zope.component import getUtility
 
@@ -73,3 +72,16 @@ class TestCopyDossiers(IntegrationTestCase):
                                        'containing_dossier', subdocument_copy)
         self.assert_index_and_metadata('', 'containing_subdossier',
                                        subdocument_copy)
+
+    def test_copying_tasks_is_prevented(self):
+        self.login(self.dossier_responsible)
+
+        create(Builder('task')
+               .within(self.empty_dossier)
+               .having(responsible_client='fa',
+                       responsible=self.regular_user.getId(),
+                       issuer=self.dossier_responsible.getId()))
+
+        copied_dossier = api.content.copy(
+            source=self.empty_dossier, target=self.empty_repofolder)
+        self.assertItemsEqual([], copied_dossier.getFolderContents())

--- a/opengever/task/configure.zcml
+++ b/opengever/task/configure.zcml
@@ -148,6 +148,12 @@
       handler=".handlers.set_initial_state"
       />
 
+  <subscriber
+      for="opengever.task.task.ITask
+           zope.lifecycleevent.interfaces.IObjectCopiedEvent"
+      handler=".handlers.delete_copied_task"
+      />
+
   <adapter
       factory=".indexers.date_of_completion"
       name="date_of_completion"

--- a/opengever/task/handlers.py
+++ b/opengever/task/handlers.py
@@ -3,6 +3,7 @@ from datetime import date
 from opengever.activity import notification_center
 from opengever.activity.roles import TASK_ISSUER_ROLE
 from opengever.activity.roles import TASK_RESPONSIBLE_ROLE
+from opengever.base.security import elevated_privileges
 from opengever.document.behaviors import IBaseDocument
 from opengever.globalindex.handlers.task import TaskSqlSyncer
 from opengever.inbox.activities import ForwardingAddedActivity
@@ -18,6 +19,16 @@ from opengever.tasktemplates.interfaces import IDuringTaskTemplateFolderTriggeri
 from opengever.tasktemplates.interfaces import IFromSequentialTasktemplate
 from plone import api
 from zope.globalrequest import getRequest
+
+
+def delete_copied_task(copied_task, event):
+    """Prevent tasks from being copied.
+
+    This deletes the task from the copied subtree (a ZEXP) before the subtree
+    gets inserted into the destination location.
+    """
+    with elevated_privileges():
+        api.content.delete(copied_task)
 
 
 def create_subtask_response(context, event):


### PR DESCRIPTION
When copying a dossier, contained tasks should not be copied with it. This may have previously worked occasionally, but was fraught with issues around IntId generation and syncing to SQL, sometimes preventing dossiers with tasks in them from being copied.

This implementation works [exactly the same as what we already have for proposals](https://github.com/4teamwork/opengever.core/blob/505111c4e850191a8ac75702e989cb228135a490/opengever/meeting/handlers.py#L90-L97).

This means there is an eventhandler on `IObjectCopiedEvent` for *the object itself*, and the object (the task) then *deletes itself*.

The advantage of this implementation is that **copying tasks anywhere will always reliably be prevented**. A possible risk however is if we were to rely on tasks getting copied anywhere, this implementation would break that functionality. I couldn't find anything however. What I've checked:
- Tasks can't be copied directly (via checkboxes)
- Tasks can't be added to dossier templates
- Task templates don't rely on copy & paste when being instantiated (instead actual object creation is performed) 

Relevant discussion in feedback forum: https://feedback.onegovgever.ch/t/kopie-dossier-mit-ohne-aufgaben-und-antraegen/1262/