### PR TITLE
Avoid naming conflicts in meeting zipexport

### DIFF
--- a/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-12-17 15:41+0000\n"
+"POT-Creation-Date: 2019-01-24 15:53+0000\n"
 "PO-Revision-Date: 2017-10-23 18:40+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -404,6 +404,11 @@ msgstr "Traktandum erfolgreich aktualisiert."
 #: ./opengever/meeting/tabs/membershiplisting.py
 msgid "all"
 msgstr "Alle"
+
+#. Default: "Attachments"
+#: ./opengever/meeting/zipexport.py
+msgid "attachments"
+msgstr "Anhang"
 
 #. Default: "Cancel"
 #: ./opengever/meeting/browser/committeeforms.py

--- a/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-12-17 15:41+0000\n"
+"POT-Creation-Date: 2019-01-24 15:53+0000\n"
 "PO-Revision-Date: 2018-05-22 10:15+0000\n"
 "Last-Translator: Niklaus Johner <Niklaus.johner@4teamwork.ch>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-meeting/fr/>\n"
@@ -406,6 +406,11 @@ msgstr "Le point de l'ordre du jour a été mis à jour avec succès."
 #: ./opengever/meeting/tabs/membershiplisting.py
 msgid "all"
 msgstr "Tous"
+
+#. Default: "Attachments"
+#: ./opengever/meeting/zipexport.py
+msgid "attachments"
+msgstr "Annexes"
 
 #. Default: "Cancel"
 #: ./opengever/meeting/browser/committeeforms.py

--- a/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
@@ -1793,7 +1793,7 @@ msgstr "Texte libre ajouté à l'ordre du jour avec succès."
 #. Default: "Agenda item ${agenda_item_number}"
 #: ./opengever/meeting/zipexport.py
 msgid "title_agenda_item"
-msgstr "Point de l'ordre du jour ${agenda_item_number}"
+msgstr "Point de l'ordre du jour ${number}"
 
 #. Default: "Delete proposal"
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt

--- a/opengever/meeting/locales/opengever.meeting.pot
+++ b/opengever/meeting/locales/opengever.meeting.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-12-17 15:41+0000\n"
+"POT-Creation-Date: 2019-01-24 15:53+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -402,6 +402,11 @@ msgstr ""
 #: ./opengever/meeting/tabs/meetinglisting.py
 #: ./opengever/meeting/tabs/membershiplisting.py
 msgid "all"
+msgstr ""
+
+#. Default: "Attachments"
+#: ./opengever/meeting/zipexport.py
+msgid "attachments"
 msgstr ""
 
 #. Default: "Cancel"

--- a/opengever/meeting/tests/test_traverser.py
+++ b/opengever/meeting/tests/test_traverser.py
@@ -21,11 +21,11 @@ class MeetingTraverserTestImplementation(MeetingTraverser):
     def traverse_agenda_item_document(self, document, agenda_item):
         self.agenda_item_documents.append(document)
 
-    def traverse_agenda_item_attachment(self, document, agenda_item):
-        self.agenda_item_attachments.append(document)
+    def traverse_agenda_item_attachment(self, document, agenda_item, attachment_number):
+        self.agenda_item_attachments.append((attachment_number, document))
 
-    def traverse_agenda_item_excerpt(self, document, agenda_item):
-        self.agenda_item_excerpts.append(document)
+    def traverse_agenda_item_excerpt(self, document, agenda_item, excerpt_number):
+        self.agenda_item_excerpts.append((excerpt_number, document))
 
 
 class TestMeetingTraverser(IntegrationTestCase):
@@ -61,8 +61,8 @@ class TestMeetingTraverser(IntegrationTestCase):
              ad_hoc_agend_item.resolve_document()],
             traverser.agenda_item_documents)
         self.assertEqual(
-            submitted_proposal.get_documents(),
+            [(i + 1, doc) for i, doc in enumerate(submitted_proposal.get_documents())],
             traverser.agenda_item_attachments)
         self.assertEqual(
-             submitted_proposal.get_excerpts(),
+             [(i + 1, doc) for i, doc in enumerate(submitted_proposal.get_excerpts())],
              traverser.agenda_item_excerpts)

--- a/opengever/meeting/traverser.py
+++ b/opengever/meeting/traverser.py
@@ -36,14 +36,19 @@ class MeetingTraverser(object):
             self.traverse_agenda_item_document(
                 agenda_item_doc, agenda_item)
 
+        attachment_number = 0
         for attachment in self._get_agenda_item_attachments(agenda_item):
             if attachment:
+                attachment_number += 1
                 self.traverse_agenda_item_attachment(
-                    attachment, agenda_item)
+                    attachment, agenda_item, attachment_number)
 
+        excerpt_number = 0
         for excerpt in self._get_agenda_item_excerpts(agenda_item):
             if excerpt:
-                self.traverse_agenda_item_excerpt(excerpt, agenda_item)
+                excerpt_number += 1
+                self.traverse_agenda_item_excerpt(
+                    excerpt, agenda_item, excerpt_number)
 
     def _get_protocol_document(self):
         if not self.meeting.has_protocol_document():
@@ -75,8 +80,8 @@ class MeetingTraverser(object):
     def traverse_agenda_item_document(self, document, agenda_item):
         pass
 
-    def traverse_agenda_item_attachment(self, document, agenda_item):
+    def traverse_agenda_item_attachment(self, document, agenda_item, attachment_number):
         pass
 
-    def traverse_agenda_item_excerpt(self, document, agenda_item):
+    def traverse_agenda_item_excerpt(self, document, agenda_item, attachment_number):
         pass

--- a/opengever/meeting/traverser.py
+++ b/opengever/meeting/traverser.py
@@ -58,9 +58,6 @@ class MeetingTraverser(object):
         return self.meeting.agendaitem_list_document.resolve_document()
 
     def _get_agenda_item_document(self, agenda_item):
-        if not agenda_item.has_document:
-            return None
-
         return agenda_item.resolve_document()
 
     def _get_agenda_item_attachments(self, agenda_item):

--- a/opengever/meeting/zipexport.py
+++ b/opengever/meeting/zipexport.py
@@ -67,6 +67,21 @@ class MeetingDocumentZipper(MeetingTraverser):
             safe_unicode(self.get_filename(document)))
         )
 
+    def get_agenda_item_attachment_filename(self, document, agenda_item_number, attachment_number):
+        return normalize_path(u'{}/{}/{}_{}'.format(
+            translate(
+                _(u'title_agenda_item', default=u'Agenda item ${agenda_item_number}',
+                  mapping={u'number': agenda_item_number}),
+                context=getRequest(),
+                ),
+            translate(
+                _(u'attachments', default=u'Attachments'),
+                context=getRequest(),
+                ),
+            str(attachment_number),
+            safe_unicode(self.get_filename(document)))
+        )
+
     def traverse_protocol_document(self, document):
         self.generator.add_file(
             self.get_filename(document), self.get_file(document).open()
@@ -83,9 +98,9 @@ class MeetingDocumentZipper(MeetingTraverser):
             self.get_file(document).open()
         )
 
-    def traverse_agenda_item_attachment(self, document, agenda_item):
+    def traverse_agenda_item_attachment(self, document, agenda_item, attachment_number):
         self.generator.add_file(
-            self.get_agenda_item_filename(document, agenda_item.formatted_number),
+            self.get_agenda_item_attachment_filename(document, agenda_item.formatted_number, attachment_number),
             self.get_file(document).open()
         )
 
@@ -175,13 +190,13 @@ class MeetingJSONSerializer(MeetingTraverser):
             'modified': format_modified(document.modified()),
         }
 
-    def traverse_agenda_item_attachment(self, document, agenda_item):
+    def traverse_agenda_item_attachment(self, document, agenda_item, attachment_number):
         attachment_data = self.current_agenda_item_data.setdefault(
             'attachments', [])
 
         attachment_data.append({
             'checksum': IBumblebeeDocument(document).get_checksum(),
-            'file': self.zipper.get_agenda_item_filename(document, agenda_item.formatted_number),
+            'file': self.zipper.get_agenda_item_attachment_filename(document, agenda_item.formatted_number, attachment_number),
             'modified': format_modified(document.modified()),
             'title': safe_unicode(document.Title()),
         })
@@ -203,7 +218,7 @@ class ZipExportDocumentCollector(MeetingTraverser):
     def traverse_agenda_item_document(self, document, agenda_item):
         self._collect(document)
 
-    def traverse_agenda_item_attachment(self, document, agenda_item):
+    def traverse_agenda_item_attachment(self, document, agenda_item, attachment_number):
         self._collect(document)
 
     def get_documents(self):


### PR DESCRIPTION
When a proposal has several attachments with the same title/filename, or if the proposal document has the same title/filename as an attachment, this leads to a naming conflict in the zip file and in the grimlock zip-import. To avoid that, we add a new folder `attachments` for each proposal, and within that folder we prefix the attachments with a number.

Also note that in the first commit I removed an unnecessary check in the `MeetingTraverser`. Indeed in `_get_agenda_item_document` we do not need to check whether the agendaitem has a document, as `AgendaItem.resolve_document` already returns `None` when if the agenda_item does not have a document.

resolves #5192 