### PR TITLE
Change wording of info for inactive close meeting button.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2019.1.0 (unreleased)
 ---------------------
 
+- Change wording of info for inactiv close meeting button. [njohner]
 - Prevent tasks from being copied. [lgraf]
 - ResolveOGUIDView: Preserve query string. [lgraf]
 - Bump docxcompose to 1.0.0a16 to fix updating docproperties. [deiferni]

--- a/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
@@ -1523,7 +1523,7 @@ msgstr "Antrag erfolgreich eingereicht."
 #. Default: "The meeting can only be closed when all agenda items are decided."
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt
 msgid "msg_require_all_agenda_items_decided_for_closing"
-msgstr "Die Sitzung kann erst abgeschlossen werden wenn alle Traktanden abgeschlossen sind und die Protokollauszüge generiert und abgelegt wurden."
+msgstr "Die Sitzung kann erst abgeschlossen werden, wenn alle Traktanden abgeschlossen sind und bei allen eingereichten Anträgen die Protokollauszüge abgelegt sind."
 
 #. Default: "Some documents could not be converted to PDF, their original files will be included in the Zip."
 #: ./opengever/meeting/browser/meetings/zipexport.py

--- a/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
@@ -245,7 +245,7 @@ msgstr "Traktandum entfernen"
 
 #: ./opengever/meeting/browser/submitdocuments.py
 msgid "Updated with a newer docment version from proposal's dossier."
-msgstr "Das Dokument wurde durch eine neuere Version aus dem Antragsdossier überschrieben."
+msgstr "Das Dokument wurde durch eine neuere Version aus dem Ursprungsdossier überschrieben."
 
 #: ./opengever/meeting/browser/excerpt.py
 msgid "Updated with a newer excerpt version."

--- a/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
@@ -247,7 +247,7 @@ msgstr "Enlever le point de l'ordre du jour"
 
 #: ./opengever/meeting/browser/submitdocuments.py
 msgid "Updated with a newer docment version from proposal's dossier."
-msgstr "Le document a été écrasé par une version plus récente du dossier proposé."
+msgstr "Le document a été écrasé par une version plus récente provenant du dossier d'origine de la demande."
 
 #: ./opengever/meeting/browser/excerpt.py
 msgid "Updated with a newer excerpt version."


### PR DESCRIPTION
As I wrote in the ticket:

This was already modified in a previous release. Currently we have:

**Protokollauszug ablegen (Overlay):**
Der Protokollauszug wird im Ursprungsdossier des Antrags abgelegt. Es können keine weiteren Protokollauszüge abgelegt werden.
Wollen Sie diesen Protokollauszug wirklich im Ursprungsdossier ablegen?

So the difference here is using `Ursprungsdossier` instead of `Antragsdossier`. Should that be corrected? `Antragsdossier` is used in only one place in the whole GEVER for now...

**Sitzung abschliessen (inaktiv):**
I'd leave the part about closing all agendaitems, which is still a condition to close the meeting. I adapted the text accordingly

resolves #5205 