### PR TITLE
Fix logo upload in the theme control-panel.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2019.1.0 (unreleased)
 ---------------------
 
+- Fix logo upload in the theme control-panel. [phgross]
 - Solr TabbedView filters: Also include non-wildcarded terms in query. [lgraf]
 - Better label the Oneoffixx template selection dropdown default value. [Rotonen]
 - Notifications: Defer sending mails until end of transaction. [lgraf]

--- a/plonetheme/teamraum/importexport.py
+++ b/plonetheme/teamraum/importexport.py
@@ -94,7 +94,7 @@ class CustomStylesUtility(object):
         a blob from it, or resuse the existing one if none has been uploaded.
         """
         logo, blob = None, None
-        data = logo_file.read()
+        data = logo_file.read() if logo_file else None
         if data:
             blob = BlobWrapper('image/png')
             if isinstance(data, basestring):
@@ -145,9 +145,10 @@ class CustomStylesUtility(object):
             if key == LOGO_KEY:
                 logo = self.get_logo(value)
                 styles[LOGO_KEY] = logo
-            elif key == LOGO_RIGHT_KEY and value:
+            elif key == LOGO_RIGHT_KEY:
                 logo_right = self.get_logo_right(value)
-                styles[LOGO_RIGHT_KEY] = logo_right
+                if logo_right:
+                    styles[LOGO_RIGHT_KEY] = logo_right
             elif key == LOGO_TITLE_KEY:
                 if isinstance(value, unicode):
                     value = value.encode('utf8')

--- a/plonetheme/teamraum/tests/test_importexport.py
+++ b/plonetheme/teamraum/tests/test_importexport.py
@@ -4,6 +4,7 @@ from io import StringIO
 from opengever.testing import IntegrationTestCase
 from plonetheme.teamraum.importexport import CustomStylesUtility
 from plonetheme.teamraum.importexport import LOGO_RIGHT_KEY
+from plonetheme.teamraum.importexport import LOGO_KEY
 import json
 
 
@@ -79,7 +80,7 @@ class TestCustomStylesImportExport(IntegrationTestCase):
         self.login(self.manager, browser)
 
         data = self.get_dict()
-        data[LOGO_RIGHT_KEY] = None
+        data.pop(LOGO_RIGHT_KEY)
 
         browser.open(self.portal, view='@@teamraumtheme-controlpanel')
         browser.fill({'import_styles': self.file_from_dict(data)})
@@ -102,7 +103,7 @@ class TestCustomStylesImportExport(IntegrationTestCase):
         self.login(self.manager, browser)
 
         data = self.get_dict()
-        data[LOGO_RIGHT_KEY] = ''
+        data.pop(LOGO_RIGHT_KEY)
 
         browser.open(self.portal, view='@@teamraumtheme-controlpanel')
         browser.fill({'import_styles': self.file_from_dict(data)})
@@ -111,11 +112,24 @@ class TestCustomStylesImportExport(IntegrationTestCase):
         statusmessages.assert_no_error_messages()
 
         custom_styles = CustomStylesUtility(self.portal)
-        self.assertEquals(
-            '',
+        self.assertIsNone(
             custom_styles.annotations['customstyles'].get(LOGO_RIGHT_KEY))
 
         browser.find('export styles').click()
         self.assertEquals(
             data,
             json.loads(browser.contents))
+
+    @browsing
+    def test_safe_logo_without_a_right_logo(self, browser):
+        self.login(self.manager, browser)
+
+        browser.open(self.portal, view='@@teamraumtheme-controlpanel')
+        browser.fill({'Logo': ('Raw file data', 'logo.png', 'image/png')})
+        browser.click_on('save')
+
+        self.assertEqual(['Changes saved'], statusmessages.info_messages())
+
+        custom_styles = CustomStylesUtility(self.portal)
+        logo = custom_styles.annotations['customstyles'].get(LOGO_KEY)
+        self.assertEqual('Raw file data', logo.data)


### PR DESCRIPTION
The upload was broken and ended up in an AttributeError and a cryptic error message gets
displayed in browser.