### PR TITLE
Bump Ruby version to 2.4.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-ruby '2.4.2'
+ruby '2.4.5'
 gem 'sass', '~> 3.4'
 
 install_if -> { RUBY_PLATFORM =~ /darwin|bsd|dragonfly/ } do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,7 +23,7 @@ DEPENDENCIES
   wdm (>= 0.1.0)
 
 RUBY VERSION
-   ruby 2.4.2p198
+   ruby 2.4.5p335
 
 BUNDLED WITH
    1.16.0

--- a/README.rst
+++ b/README.rst
@@ -165,7 +165,7 @@ and the `ruby-build <https://github.com/sstephenson/ruby-build>`_ plugin:
     echo 'export PATH="$HOME/.rbenv/bin:$PATH"' >> ~/.bash_profile
     echo 'eval "$(rbenv init -)"' >> ~/.bash_profile
     source ~/.bash_profile
-    rbenv install 2.3.3
+    rbenv install 2.4.5
     gem install bundler
 
 The installation of the ``Sablon`` gem can then be performed by buildout (by

--- a/versions.cfg
+++ b/versions.cfg
@@ -8,7 +8,7 @@ extends =
 
 [ruby-versions]
 nokogiri = 1.8.1
-ruby = 2.4.2
+ruby = 2.4.5
 sablon = 0.0.21
 
 


### PR DESCRIPTION
While installing gever on my machine today, I stumbled upon the wrong Ruby version in the documentation. Also, I had to activate the correct Ruby version after installing it.

The ruby version in the documentation now matches the one specified in the `Gemfile`.

On a side note: I also had to use `rbenv exec gem install bundler` instead of only `gem install bundler`, but maybe that is only because of my setup and does not need to be documented?