### PR TITLE
Handle documents without files in meeting zip export with .

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -8,6 +8,7 @@ Changelog
 - Scrub Bobo Call Interface data out of the HTTP response headers. [Rotonen]
 - Scrub the server version out of the HTTP response headers. [Rotonen]
 - Fix bug in excerpt overview when user has no permissions on meeting. [njohner]
+- Fix bug in meeting zip export with documents without files. [njohner]
 - Change wording of info for inactiv close meeting button. [njohner]
 - Avoid truncating committee responsible group token while normalizing. [deiferni]
 - Prevent tasks from being copied. [lgraf]

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -8,6 +8,7 @@ Changelog
 - Scrub Bobo Call Interface data out of the HTTP response headers. [Rotonen]
 - Scrub the server version out of the HTTP response headers. [Rotonen]
 - Fix bug in excerpt overview when user has no permissions on meeting. [njohner]
+- Avoid naming conflicts in meeting zipexport. [njohner]
 - Fix bug in meeting zip export with documents without files. [njohner]
 - Change wording of info for inactiv close meeting button. [njohner]
 - Avoid truncating committee responsible group token while normalizing. [deiferni]

--- a/opengever/meeting/tests/test_meeting_zipexport.py
+++ b/opengever/meeting/tests/test_meeting_zipexport.py
@@ -42,6 +42,24 @@ class TestMeetingZipExportView(IntegrationTestCase):
             zip_file.namelist())
 
     @browsing
+    def test_zip_export_skips_agenda_items_attachments_without_file(self, browser):
+        browser.append_request_header('Accept-Language', 'de-ch')
+        self.login(self.committee_responsible, browser)
+
+        self.proposal.submit_additional_document(self.empty_document)
+        self.proposal.submit_additional_document(self.subdocument)
+        self.schedule_proposal(self.meeting, self.submitted_proposal)
+
+        browser.open(self.meeting, view='export-meeting-zip')
+        zip_file = ZipFile(StringIO(browser.contents), 'r')
+        self.assertItemsEqual(
+            ['Traktandum 1/Vertraege.docx',
+             'Traktandum 1/Anhang/1_Vertraegsentwurf.docx',
+             'Traktandum 1/Anhang/2_Uebersicht der Vertraege von 2016.xlsx',
+             'meeting.json'],
+            zip_file.namelist())
+
+    @browsing
     def test_export_proposal_word_documents(self, browser):
         browser.append_request_header('Accept-Language', 'de-ch')
         self.login(self.committee_responsible, browser)

--- a/opengever/meeting/tests/test_traverser.py
+++ b/opengever/meeting/tests/test_traverser.py
@@ -1,4 +1,5 @@
 from opengever.testing import IntegrationTestCase
+from opengever.meeting.traverser import MeetingDocumentWithFileTraverser
 from opengever.meeting.traverser import MeetingTraverser
 
 
@@ -66,3 +67,80 @@ class TestMeetingTraverser(IntegrationTestCase):
         self.assertEqual(
              [(i + 1, doc) for i, doc in enumerate(submitted_proposal.get_excerpts())],
              traverser.agenda_item_excerpts)
+
+
+class MeetingDocumentWithFileTraverserTestImplementation(MeetingDocumentWithFileTraverser):
+
+    def __init__(self, meeting):
+        super(MeetingDocumentWithFileTraverserTestImplementation, self).__init__(meeting)
+        self.protocol_document = None
+        self.agenda_item_list_document = None
+        self.agenda_item_documents = []
+        self.agenda_item_attachments = []
+        self.agenda_item_excerpts = []
+
+    def traverse_protocol_document(self, document):
+        self.protocol_document = document
+
+    def traverse_agenda_item_list_document(self, document):
+        self.agenda_item_list_document = document
+
+    def traverse_agenda_item_document(self, document, agenda_item):
+        self.agenda_item_documents.append(document)
+
+    def traverse_agenda_item_attachment(self, document, agenda_item, attachment_number):
+        self.agenda_item_attachments.append(document)
+
+    def traverse_agenda_item_excerpt(self, document, agenda_item, excerpt_number):
+        self.agenda_item_excerpts.append(document)
+
+
+class TestMeetingDocumentWithFileTraverser(IntegrationTestCase):
+
+    features = ('meeting',)
+
+    def test_meeting_traverser_traverses_all_documents_with_file(self):
+        self.login(self.committee_responsible)
+
+        # Add two additional attachments, one without a file
+        self.proposal.submit_additional_document(self.empty_document)
+        self.proposal.submit_additional_document(self.subdocument)
+
+        proposal_agenda_item = self.schedule_proposal(
+            self.meeting, self.submitted_proposal)
+        self.schedule_paragraph(
+            self.meeting, "I'm a paragraph and thus should not be relevant")
+        ad_hoc_agend_item = self.schedule_ad_hoc(
+            self.meeting, "I'm an ad hoc agenda item")
+        submitted_proposal = proposal_agenda_item.proposal.resolve_submitted_proposal()
+
+        self.decide_agendaitem_generate_and_return_excerpt(proposal_agenda_item)
+        self.generate_protocol_document(self.meeting)
+        self.generate_agenda_item_list(self.meeting)
+
+        traverser = MeetingDocumentWithFileTraverserTestImplementation(
+            self.meeting.model).traverse()
+
+        self.assertEqual(
+            self.meeting.model.protocol_document.resolve_document(),
+            traverser.protocol_document)
+        self.assertEqual(
+            self.meeting.model.agendaitem_list_document.resolve_document(),
+            traverser.agenda_item_list_document)
+        self.assertEqual(
+            [proposal_agenda_item.resolve_document(),
+             ad_hoc_agend_item.resolve_document()],
+            traverser.agenda_item_documents)
+        self.assertEqual(
+             submitted_proposal.get_excerpts(),
+             traverser.agenda_item_excerpts)
+
+        documents_without_file = [doc for doc in submitted_proposal.get_documents()
+                                  if not doc.has_file()]
+        documents_with_file = [doc for doc in submitted_proposal.get_documents()
+                               if doc.has_file()]
+        for document in documents_without_file:
+            self.assertNotIn(document, traverser.agenda_item_attachments)
+        self.assertItemsEqual(
+            documents_with_file,
+            traverser.agenda_item_attachments)

--- a/opengever/meeting/traverser.py
+++ b/opengever/meeting/traverser.py
@@ -1,3 +1,6 @@
+from ftw.bumblebee.interfaces import IBumblebeeDocument
+
+
 class MeetingTraverser(object):
     """Traverse the meeting and its documents.
 
@@ -85,3 +88,25 @@ class MeetingTraverser(object):
 
     def traverse_agenda_item_excerpt(self, document, agenda_item, attachment_number):
         pass
+
+
+class MeetingDocumentWithFileTraverser(MeetingTraverser):
+    """Traverse the meeting and its documents, but only if the document
+    has a file.
+
+    There is no need to overwrite _get_agenda_item_document,
+    _get_protocol_document and _get_agenda_item_list_document
+    as these always have a file if they are present.
+    """
+
+    @staticmethod
+    def _document_has_file(document):
+        return IBumblebeeDocument(document).has_file_data()
+
+    def _get_agenda_item_attachments(self, agenda_item):
+        attachments = super(MeetingDocumentWithFileTraverser, self)._get_agenda_item_attachments(agenda_item)
+        return [attachment for attachment in attachments if self._document_has_file(attachment)]
+
+    def _get_agenda_item_excerpts(self, agenda_item):
+        excerpts = super(MeetingDocumentWithFileTraverser, self)._get_agenda_item_excerpts(agenda_item)
+        return [excerpt for excerpt in excerpts if self._document_has_file(excerpt)]

--- a/opengever/meeting/zipexport.py
+++ b/opengever/meeting/zipexport.py
@@ -9,7 +9,7 @@ from logging import getLogger
 from opengever.base.date_time import utcnow_tz_aware
 from opengever.base.security import elevated_privileges
 from opengever.meeting import _
-from opengever.meeting.traverser import MeetingTraverser
+from opengever.meeting.traverser import MeetingDocumentWithFileTraverser
 from persistent.mapping import PersistentMapping
 from plone import api
 from plone.namedfile.file import NamedBlobFile
@@ -39,7 +39,7 @@ def format_modified(modified):
         ).isoformat())
 
 
-class MeetingDocumentZipper(MeetingTraverser):
+class MeetingDocumentZipper(MeetingDocumentWithFileTraverser):
 
     def __init__(self, meeting, generator):
         super(MeetingDocumentZipper, self).__init__(meeting)
@@ -134,7 +134,7 @@ class MeetingPDFDocumentZipper(MeetingDocumentZipper):
         return self.pdfs[document_id]
 
 
-class MeetingJSONSerializer(MeetingTraverser):
+class MeetingJSONSerializer(MeetingDocumentWithFileTraverser):
     """Represents a JSON file with which grimlock can import the meeting."""
 
     def __init__(self, meeting, zipper):
@@ -196,13 +196,14 @@ class MeetingJSONSerializer(MeetingTraverser):
 
         attachment_data.append({
             'checksum': IBumblebeeDocument(document).get_checksum(),
-            'file': self.zipper.get_agenda_item_attachment_filename(document, agenda_item.formatted_number, attachment_number),
+            'file': self.zipper.get_agenda_item_attachment_filename(
+                document, agenda_item.formatted_number, attachment_number),
             'modified': format_modified(document.modified()),
             'title': safe_unicode(document.Title()),
         })
 
 
-class ZipExportDocumentCollector(MeetingTraverser):
+class ZipExportDocumentCollector(MeetingDocumentWithFileTraverser):
     """Collect all documents that will be exported in a zip."""
 
     def __init__(self, meeting):
@@ -226,9 +227,6 @@ class ZipExportDocumentCollector(MeetingTraverser):
         return tuple(self._documents)
 
     def _collect(self, document):
-        if not IBumblebeeDocument(document).has_file_data():
-            return
-
         self._documents.append(document)
 
 


### PR DESCRIPTION
Documents without files were not properly handled in the meeting zip export. They were only handled in the `ZipExportDocumentCollector` but not in `MeetingJSONSerializer` and `MeetingDocumentZipper`. To make sure documents are handled identically in all three classes, we make a new subclass (`MeetingDocumentWithFileTraverser`) of `MeetingTraverser ` and use it as baseclass for the three classes above. Documents with missing files are now directly skipped in the new traverser.

I also added a missing changelog (forgotten in a PR that is already merged, sorry).

resolves #5281 