### PR TITLE
Copy local roles depending on assignment cause during copy/paste.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -13,6 +13,7 @@ Changelog
 - Avoid naming conflicts in meeting zipexport. [njohner]
 - Fix bug in meeting zip export with documents without files. [njohner]
 - Do not show closed dossiers in the move target autocomplete widget. [Rotonen]
+- Copy local roles depending on assignment cause during copy/paste. [njohner]
 - Change wording of info for inactiv close meeting button. [njohner]
 - Avoid truncating committee responsible group token while normalizing. [deiferni]
 - Provide a testserver for GEVER. [jone]

--- a/opengever/base/locales/de/LC_MESSAGES/opengever.base.po
+++ b/opengever/base/locales/de/LC_MESSAGES/opengever.base.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-10-12 11:55+0000\n"
+"POT-Creation-Date: 2019-01-28 15:39+0000\n"
 "PO-Revision-Date: 2014-09-04 01:03+0200\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: Jonas Baumann <j.baumann@4teamwork.ch>\n"
@@ -378,6 +378,11 @@ msgstr "Titel (französisch)"
 #: opengever/repository/classification.py
 msgid "limited-public"
 msgstr "Eingeschränkt öffentlich"
+
+#. Default: "Some local roles were copied with the objects"
+#: ./opengever/base/monkey/patches/cmf_catalog_aware.py
+msgid "local_roles_copied"
+msgstr "Lokale Berechtigungen wurden auch mitkopiert"
 
 #. Default: "Changes saved"
 #: ./opengever/base/browser/modelforms.py

--- a/opengever/base/locales/fr/LC_MESSAGES/opengever.base.po
+++ b/opengever/base/locales/fr/LC_MESSAGES/opengever.base.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-10-12 11:55+0000\n"
+"POT-Creation-Date: 2019-01-28 15:39+0000\n"
 "PO-Revision-Date: 2017-11-29 10:53+0000\n"
 "Last-Translator: Philippe Gross <gross.philippe@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-base/fr/>\n"
@@ -377,6 +377,11 @@ msgstr "Titre (français)"
 #: opengever/repository/classification.py
 msgid "limited-public"
 msgstr "Accès public restreint"
+
+#. Default: "Some local roles were copied with the objects"
+#: ./opengever/base/monkey/patches/cmf_catalog_aware.py
+msgid "local_roles_copied"
+msgstr "Des autorisations locales ont également été copiées"
 
 #. Default: "Changes saved"
 #: ./opengever/base/browser/modelforms.py

--- a/opengever/base/locales/opengever.base.pot
+++ b/opengever/base/locales/opengever.base.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-10-12 11:55+0000\n"
+"POT-Creation-Date: 2019-01-28 15:39+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -373,6 +373,11 @@ msgstr ""
 
 #: opengever/repository/classification.py
 msgid "limited-public"
+msgstr ""
+
+#. Default: "Some local roles were copied with the objects"
+#: ./opengever/base/monkey/patches/cmf_catalog_aware.py
+msgid "local_roles_copied"
 msgstr ""
 
 #. Default: "Changes saved"

--- a/opengever/base/monkey/patches/cmf_catalog_aware.py
+++ b/opengever/base/monkey/patches/cmf_catalog_aware.py
@@ -108,15 +108,12 @@ class PatchCMFCatalogAwareHandlers(MonkeyPatch):
             current_user_id = current_user.getId()
             if current_user_id is not None:
                 # Customization
-                # Instead of deleting all local roles when copying an object
-                # we keep or delete them depending on their assignment cause.
-                # We also set the current user as owner
-                copied = RoleAssignmentManager(ob).update_local_roles_for_copy(current_user_id)
-                if copied:
-                    message = translate(
-                        _('local_roles_copied',
-                          default=u"Some local roles were copied with the objects"),
-                        context=getRequest())
+                are_all_local_roles_deleted = RoleAssignmentManager(ob)\
+                    .update_local_roles_after_copying(current_user_id)
+                if not are_all_local_roles_deleted:
+                    message = _(
+                        'local_roles_copied',
+                         default=u"Some local roles were copied with the objects")
                     api.portal.show_message(message=message,
                                             request=getRequest(),
                                             type='info')

--- a/opengever/base/role_assignments.py
+++ b/opengever/base/role_assignments.py
@@ -339,21 +339,21 @@ class RoleAssignmentManager(object):
         if reindex:
             self.context.reindexObjectSecurity()
 
-    def update_local_roles_for_copy(self, new_owner):
+    def update_local_roles_after_copying(self, new_owner):
         """ We only delete certain local roles when copying an object
         depending on their assignment cause. We also set a new owner
         on the copied object.
         """
-        are_roles_copied = False
+        are_all_local_roles_deleted = True
         for assignment in RoleAssignment.registry.values():
             if assignment.cause not in assignments_kept_when_copying:
                 self.storage.clear_by_cause(assignment.cause)
             elif self.get_assignments_by_cause(assignment.cause):
-                are_roles_copied = True
+                are_all_local_roles_deleted = False
 
         self.set_new_owner(new_owner, reindex=False)
         self._update_local_roles()
-        return are_roles_copied
+        return are_all_local_roles_deleted
 
     def _update_local_roles(self, reindex=True):
         current_principals = []

--- a/opengever/base/role_assignments.py
+++ b/opengever/base/role_assignments.py
@@ -16,6 +16,12 @@ ASSIGNMENT_VIA_PROTECT_DOSSIER = 4
 ASSIGNMENT_VIA_INVITATION = 5
 ASSIGNMENT_VIA_COMMITTEE_GROUP = 6
 
+# When copying a dossier, we keep or drop local roles depending on
+# their assignment cause.
+assignments_kept_when_copying = (ASSIGNMENT_VIA_SHARING,
+                                 ASSIGNMENT_VIA_PROTECT_DOSSIER,
+                                 ASSIGNMENT_VIA_INVITATION)
+
 
 class RoleAssignment(object):
 
@@ -296,7 +302,7 @@ class RoleAssignmentManager(object):
         self._update_local_roles()
 
     def clear_by_cause_and_principals(self, cause, principals):
-        """Remove all assignments of the given cause and for all principals.
+        """Remove all assignments of the given cause and principals.
         """
         for principal in principals:
             self.storage.clear_by_cause_and_principal(cause, principal)
@@ -316,6 +322,38 @@ class RoleAssignmentManager(object):
 
         self.storage.clear(item)
         self._update_local_roles(reindex=reindex)
+
+    def set_new_owner(self, userid, reindex=True):
+        """ Remove all current owners and set Owner for userid.
+        """
+        for principal, roles in self.context.get_local_roles():
+            if 'Owner' not in roles:
+                continue
+            new_roles = (role for role in roles if not role == "Owner")
+            self.context.manage_setLocalRoles(
+                principal, new_roles, verified=True)
+
+        self.context.manage_addLocalRoles(
+                userid, ['Owner'], verified=True)
+
+        if reindex:
+            self.context.reindexObjectSecurity()
+
+    def update_local_roles_for_copy(self, new_owner):
+        """ We only delete certain local roles when copying an object
+        depending on their assignment cause. We also set a new owner
+        on the copied object.
+        """
+        are_roles_copied = False
+        for assignment in RoleAssignment.registry.values():
+            if assignment.cause not in assignments_kept_when_copying:
+                self.storage.clear_by_cause(assignment.cause)
+            elif self.get_assignments_by_cause(assignment.cause):
+                are_roles_copied = True
+
+        self.set_new_owner(new_owner, reindex=False)
+        self._update_local_roles()
+        return are_roles_copied
 
     def _update_local_roles(self, reindex=True):
         current_principals = []

--- a/opengever/base/tests/test_copy_paste.py
+++ b/opengever/base/tests/test_copy_paste.py
@@ -4,6 +4,16 @@ from ftw.testbrowser import browsing
 from ftw.testbrowser.pages.statusmessages import error_messages
 from ftw.testbrowser.pages.statusmessages import info_messages
 from opengever.base.interfaces import ISequenceNumber
+from opengever.base.oguid import Oguid
+from opengever.base.role_assignments import assignments_kept_when_copying
+from opengever.base.role_assignments import ASSIGNMENT_VIA_COMMITTEE_GROUP
+from opengever.base.role_assignments import ASSIGNMENT_VIA_INVITATION
+from opengever.base.role_assignments import ASSIGNMENT_VIA_PROTECT_DOSSIER
+from opengever.base.role_assignments import ASSIGNMENT_VIA_SHARING
+from opengever.base.role_assignments import ASSIGNMENT_VIA_TASK
+from opengever.base.role_assignments import ASSIGNMENT_VIA_TASK_AGENCY
+from opengever.base.role_assignments import RoleAssignment
+from opengever.base.role_assignments import RoleAssignmentManager
 from opengever.testing import IntegrationTestCase
 from plone.protect import createToken
 from zope.component import getUtility
@@ -236,6 +246,315 @@ class TestCopyPaste(IntegrationTestCase):
             'Properties',
             ]
         self.assertEqual(expected_actions, browser.css('#contentActionMenus a').text)
+
+
+class TestCopyPastePermissionHandling(IntegrationTestCase):
+
+    @browsing
+    def test_preserves_role_inheritance_block_on_dossier(self, browser):
+        self.login(self.administrator, browser=browser)
+
+        self.subdossier.__ac_local_roles_block__ = True
+
+        browser.open(self.dossier,
+                     data=self.make_path_param(self.subdossier), view="copy_items")
+
+        browser.open(self.empty_repofolder)
+        browser.click_on('Paste')
+
+        subdossier_copy = self.empty_repofolder.objectValues()[0]
+        subsubdossier_copy = subdossier_copy.get_subdossiers()[0].getObject()
+        self.assertTrue(getattr(subdossier_copy, '__ac_local_roles_block__', False))
+        self.assertFalse(getattr(subsubdossier_copy, '__ac_local_roles_block__', False))
+
+    @browsing
+    def test_preserves_role_inheritance_block_on_subdossier(self, browser):
+        self.login(self.administrator, browser=browser)
+
+        self.subsubdossier.__ac_local_roles_block__ = True
+
+        browser.open(self.dossier,
+                     data=self.make_path_param(self.subdossier), view="copy_items")
+
+        browser.open(self.empty_repofolder)
+        browser.click_on('Paste')
+
+        subdossier_copy = self.empty_repofolder.objectValues()[0]
+        subsubdossier_copy = subdossier_copy.get_subdossiers()[0].getObject()
+
+        self.assertFalse(getattr(subdossier_copy, '__ac_local_roles_block__', False))
+        self.assertTrue(getattr(subsubdossier_copy, '__ac_local_roles_block__', False))
+
+    @browsing
+    def test_preserves_local_roles_from_sharing(self, browser):
+        assignment_type = ASSIGNMENT_VIA_SHARING
+        assignment_class = RoleAssignment.registry[assignment_type]
+
+        self.login(self.administrator, browser=browser)
+
+        manager = RoleAssignmentManager(self.subdossier)
+        manager.add_or_update_assignment(
+            assignment_class(self.regular_user.id,
+                             ['Reader', 'Editor', 'Contributor']))
+        manager = RoleAssignmentManager(self.subdossier)
+        assignments = manager.get_assignments_by_cause(assignment_type)
+        self.assertEqual(1, len(assignments))
+
+        browser.open(self.dossier,
+                     data=self.make_path_param(self.subdossier), view="copy_items")
+
+        browser.open(self.empty_repofolder)
+        browser.click_on('Paste')
+
+        subdossier_copy = self.empty_repofolder.objectValues()[0]
+        manager = RoleAssignmentManager(subdossier_copy)
+        assignments = manager.get_assignments_by_cause(assignment_type)
+
+        self.assertEqual(1, len(assignments), "{} should get copied".format(assignment_class))
+        assignment = assignments[0]
+        expected_assignment = {'cause': assignment_type,
+                               'roles': ['Reader', 'Editor', 'Contributor'],
+                               'reference': None,
+                               'principal': self.regular_user.id}
+        self.assertEqual(expected_assignment, assignment)
+
+    @browsing
+    def test_preserves_local_roles_from_protect_dossier(self, browser):
+        assignment_type = ASSIGNMENT_VIA_PROTECT_DOSSIER
+        assignment_class = RoleAssignment.registry[assignment_type]
+
+        self.login(self.administrator, browser=browser)
+
+        manager = RoleAssignmentManager(self.subdossier)
+        manager.add_or_update_assignment(
+            assignment_class(self.regular_user.id,
+                             ['Reader', 'Editor', 'Contributor']))
+        manager = RoleAssignmentManager(self.subdossier)
+        assignments = manager.get_assignments_by_cause(assignment_type)
+        self.assertEqual(1, len(assignments))
+
+        browser.open(self.dossier,
+                     data=self.make_path_param(self.subdossier), view="copy_items")
+
+        browser.open(self.empty_repofolder)
+        browser.click_on('Paste')
+
+        subdossier_copy = self.empty_repofolder.objectValues()[0]
+        manager = RoleAssignmentManager(subdossier_copy)
+        assignments = manager.get_assignments_by_cause(assignment_type)
+
+        self.assertEqual(1, len(assignments), "{} should get copied".format(assignment_class))
+        assignment = assignments[0]
+        expected_assignment = {'cause': assignment_type,
+                               'roles': ['Reader', 'Editor', 'Contributor'],
+                               'reference': None,
+                               'principal': self.regular_user.id}
+        self.assertEqual(expected_assignment, assignment)
+
+    @browsing
+    def test_preserves_local_roles_from_invitation(self, browser):
+        assignment_type = ASSIGNMENT_VIA_INVITATION
+        assignment_class = RoleAssignment.registry[assignment_type]
+
+        self.login(self.administrator, browser=browser)
+
+        manager = RoleAssignmentManager(self.subdossier)
+        manager.add_or_update_assignment(
+            assignment_class(self.regular_user.id,
+                             ['Reader', 'Editor', 'Contributor'],
+                             self.workspace))
+        manager = RoleAssignmentManager(self.subdossier)
+        assignments = manager.get_assignments_by_cause(assignment_type)
+        self.assertEqual(1, len(assignments))
+
+        browser.open(self.dossier,
+                     data=self.make_path_param(self.subdossier), view="copy_items")
+
+        browser.open(self.empty_repofolder)
+        browser.click_on('Paste')
+
+        subdossier_copy = self.empty_repofolder.objectValues()[0]
+        manager = RoleAssignmentManager(subdossier_copy)
+        assignments = manager.get_assignments_by_cause(assignment_type)
+
+        self.assertEqual(1, len(assignments), "{} should get copied".format(assignment_class))
+        assignment = assignments[0]
+        expected_assignment = {'cause': assignment_type,
+                               'roles': ['Reader', 'Editor', 'Contributor'],
+                               'reference': Oguid.for_object(self.workspace).id,
+                               'principal': self.regular_user.id}
+        self.assertEqual(expected_assignment, assignment)
+
+    @browsing
+    def test_does_not_preserve_local_roles_from_tasks(self, browser):
+        assignment_type = ASSIGNMENT_VIA_TASK
+        assignment_class = RoleAssignment.registry[assignment_type]
+
+        self.login(self.administrator, browser=browser)
+
+        manager = RoleAssignmentManager(self.subdossier)
+        manager.add_or_update_assignment(
+            assignment_class(self.regular_user.id,
+                             ['Reader', 'Editor', 'Contributor'],
+                             self.task))
+        manager = RoleAssignmentManager(self.subdossier)
+        assignments = manager.get_assignments_by_cause(assignment_type)
+        self.assertEqual(1, len(assignments))
+
+        browser.open(self.dossier,
+                     data=self.make_path_param(self.subdossier), view="copy_items")
+
+        browser.open(self.empty_repofolder)
+        browser.click_on('Paste')
+
+        subdossier_copy = self.empty_repofolder.objectValues()[0]
+        manager = RoleAssignmentManager(subdossier_copy)
+        assignments = manager.get_assignments_by_cause(assignment_type)
+
+        self.assertEqual(0, len(assignments),
+                         "{} should not get copied".format(assignment_class))
+
+    @browsing
+    def test_does_not_preserve_local_roles_from_task_agency(self, browser):
+        assignment_type = ASSIGNMENT_VIA_TASK_AGENCY
+        assignment_class = RoleAssignment.registry[assignment_type]
+
+        self.login(self.administrator, browser=browser)
+
+        manager = RoleAssignmentManager(self.subdossier)
+        manager.add_or_update_assignment(
+            assignment_class(self.regular_user.id,
+                             ['Reader', 'Editor', 'Contributor'],
+                             self.task))
+        manager = RoleAssignmentManager(self.subdossier)
+        assignments = manager.get_assignments_by_cause(assignment_type)
+        self.assertEqual(1, len(assignments))
+
+        browser.open(self.dossier,
+                     data=self.make_path_param(self.subdossier), view="copy_items")
+
+        browser.open(self.empty_repofolder)
+        browser.click_on('Paste')
+
+        subdossier_copy = self.empty_repofolder.objectValues()[0]
+        manager = RoleAssignmentManager(subdossier_copy)
+        assignments = manager.get_assignments_by_cause(assignment_type)
+
+        self.assertEqual(0, len(assignments),
+                         "{} should not get copied".format(assignment_class))
+
+    @browsing
+    def test_does_not_preserve_local_roles_from_committee_group(self, browser):
+        assignment_type = ASSIGNMENT_VIA_COMMITTEE_GROUP
+        assignment_class = RoleAssignment.registry[assignment_type]
+
+        self.login(self.administrator, browser=browser)
+
+        manager = RoleAssignmentManager(self.subdossier)
+        manager.add_or_update_assignment(
+            assignment_class(self.regular_user.id,
+                             ['Reader', 'Editor', 'Contributor'],
+                             self.committee))
+        manager = RoleAssignmentManager(self.subdossier)
+        assignments = manager.get_assignments_by_cause(assignment_type)
+        self.assertEqual(1, len(assignments))
+
+        browser.open(self.dossier,
+                     data=self.make_path_param(self.subdossier), view="copy_items")
+
+        browser.open(self.empty_repofolder)
+        browser.click_on('Paste')
+
+        subdossier_copy = self.empty_repofolder.objectValues()[0]
+        manager = RoleAssignmentManager(subdossier_copy)
+        assignments = manager.get_assignments_by_cause(assignment_type)
+
+        self.assertEqual(0, len(assignments),
+                         "{} should not get copied".format(assignment_class))
+
+    def test_all_assignment_types_are_handled(self):
+        assignments_dropped_when_copying = [ASSIGNMENT_VIA_TASK,
+                                            ASSIGNMENT_VIA_TASK_AGENCY,
+                                            ASSIGNMENT_VIA_COMMITTEE_GROUP]
+
+        for assignment in assignments_kept_when_copying:
+            assignment_class = RoleAssignment.registry[assignment]
+            self.assertNotIn(assignment, assignments_dropped_when_copying,
+                             "local roles for {} are not dropped anymore during "
+                             "copy/paste. Please adapt this test if this change "
+                             "is on purpose.".format(assignment_class))
+
+        handled_assignments = assignments_dropped_when_copying + list(assignments_kept_when_copying)
+
+        for key in RoleAssignment.registry:
+            assignment_class = RoleAssignment.registry[assignment]
+            self.assertIn(key, handled_assignments,
+                          "local roles for {} are dropped during copy/paste. If this"
+                          " is on purpose, please adapt this test.".format(assignment_class))
+
+    @browsing
+    def test_status_message_shown_when_local_roles_on_dossier_are_copied(self, browser):
+        assignment_type = ASSIGNMENT_VIA_SHARING
+        assignment_class = RoleAssignment.registry[assignment_type]
+
+        self.login(self.administrator, browser=browser)
+
+        browser.open(self.dossier,
+                     data=self.make_path_param(self.subdossier), view="copy_items")
+        browser.open(self.empty_repofolder)
+        browser.click_on('Paste')
+
+        self.assertItemsEqual(info_messages(),
+                              ["Objects from clipboard successfully pasted."])
+
+        manager = RoleAssignmentManager(self.subdossier)
+        manager.add_or_update_assignment(
+            assignment_class(self.regular_user.id,
+                             ['Reader', 'Editor', 'Contributor']))
+        manager = RoleAssignmentManager(self.subdossier)
+        assignments = manager.get_assignments_by_cause(assignment_type)
+        self.assertEqual(1, len(assignments))
+
+        browser.open(self.dossier,
+                     data=self.make_path_param(self.subdossier), view="copy_items")
+        browser.open(self.empty_repofolder)
+        browser.click_on('Paste')
+
+        self.assertItemsEqual(info_messages(),
+                              ["Some local roles were copied with the objects",
+                               "Objects from clipboard successfully pasted."])
+
+    @browsing
+    def test_status_message_shown_when_local_roles_on_subdossier_are_copied(self, browser):
+        assignment_type = ASSIGNMENT_VIA_SHARING
+        assignment_class = RoleAssignment.registry[assignment_type]
+
+        self.login(self.administrator, browser=browser)
+
+        browser.open(self.dossier,
+                     data=self.make_path_param(self.subdossier), view="copy_items")
+        browser.open(self.empty_repofolder)
+        browser.click_on('Paste')
+
+        self.assertItemsEqual(info_messages(),
+                              ["Objects from clipboard successfully pasted."])
+
+        manager = RoleAssignmentManager(self.subsubdossier)
+        manager.add_or_update_assignment(
+            assignment_class(self.regular_user.id,
+                             ['Reader', 'Editor', 'Contributor']))
+        manager = RoleAssignmentManager(self.subsubdossier)
+        assignments = manager.get_assignments_by_cause(assignment_type)
+        self.assertEqual(1, len(assignments))
+
+        browser.open(self.dossier,
+                     data=self.make_path_param(self.subdossier), view="copy_items")
+        browser.open(self.empty_repofolder)
+        browser.click_on('Paste')
+
+        self.assertItemsEqual(info_messages(),
+                              ["Some local roles were copied with the objects",
+                               "Objects from clipboard successfully pasted."])
 
 
 class TestClipboardCaching(IntegrationTestCase):

--- a/opengever/base/tests/test_copy_paste.py
+++ b/opengever/base/tests/test_copy_paste.py
@@ -259,11 +259,14 @@ class TestCopyPastePermissionHandling(IntegrationTestCase):
         browser.open(self.dossier,
                      data=self.make_path_param(self.subdossier), view="copy_items")
 
-        browser.open(self.empty_repofolder)
-        browser.click_on('Paste')
+        with self.observe_children(self. empty_repofolder) as children:
+            browser.open(self.empty_repofolder)
+            browser.click_on('Paste')
 
-        subdossier_copy = self.empty_repofolder.objectValues()[0]
+        self.assertEqual(1, len(children.get('added')))
+        subdossier_copy = children.get('added').pop()
         subsubdossier_copy = subdossier_copy.get_subdossiers()[0].getObject()
+
         self.assertTrue(getattr(subdossier_copy, '__ac_local_roles_block__', False))
         self.assertFalse(getattr(subsubdossier_copy, '__ac_local_roles_block__', False))
 
@@ -276,10 +279,12 @@ class TestCopyPastePermissionHandling(IntegrationTestCase):
         browser.open(self.dossier,
                      data=self.make_path_param(self.subdossier), view="copy_items")
 
-        browser.open(self.empty_repofolder)
-        browser.click_on('Paste')
+        with self.observe_children(self. empty_repofolder) as children:
+            browser.open(self.empty_repofolder)
+            browser.click_on('Paste')
 
-        subdossier_copy = self.empty_repofolder.objectValues()[0]
+        self.assertEqual(1, len(children.get('added')))
+        subdossier_copy = children.get('added').pop()
         subsubdossier_copy = subdossier_copy.get_subdossiers()[0].getObject()
 
         self.assertFalse(getattr(subdossier_copy, '__ac_local_roles_block__', False))
@@ -303,10 +308,12 @@ class TestCopyPastePermissionHandling(IntegrationTestCase):
         browser.open(self.dossier,
                      data=self.make_path_param(self.subdossier), view="copy_items")
 
-        browser.open(self.empty_repofolder)
-        browser.click_on('Paste')
+        with self.observe_children(self. empty_repofolder) as children:
+            browser.open(self.empty_repofolder)
+            browser.click_on('Paste')
 
-        subdossier_copy = self.empty_repofolder.objectValues()[0]
+        self.assertEqual(1, len(children.get('added')))
+        subdossier_copy = children.get('added').pop()
         manager = RoleAssignmentManager(subdossier_copy)
         assignments = manager.get_assignments_by_cause(assignment_type)
 
@@ -336,10 +343,12 @@ class TestCopyPastePermissionHandling(IntegrationTestCase):
         browser.open(self.dossier,
                      data=self.make_path_param(self.subdossier), view="copy_items")
 
-        browser.open(self.empty_repofolder)
-        browser.click_on('Paste')
+        with self.observe_children(self. empty_repofolder) as children:
+            browser.open(self.empty_repofolder)
+            browser.click_on('Paste')
 
-        subdossier_copy = self.empty_repofolder.objectValues()[0]
+        self.assertEqual(1, len(children.get('added')))
+        subdossier_copy = children.get('added').pop()
         manager = RoleAssignmentManager(subdossier_copy)
         assignments = manager.get_assignments_by_cause(assignment_type)
 
@@ -370,10 +379,12 @@ class TestCopyPastePermissionHandling(IntegrationTestCase):
         browser.open(self.dossier,
                      data=self.make_path_param(self.subdossier), view="copy_items")
 
-        browser.open(self.empty_repofolder)
-        browser.click_on('Paste')
+        with self.observe_children(self. empty_repofolder) as children:
+            browser.open(self.empty_repofolder)
+            browser.click_on('Paste')
 
-        subdossier_copy = self.empty_repofolder.objectValues()[0]
+        self.assertEqual(1, len(children.get('added')))
+        subdossier_copy = children.get('added').pop()
         manager = RoleAssignmentManager(subdossier_copy)
         assignments = manager.get_assignments_by_cause(assignment_type)
 
@@ -404,10 +415,12 @@ class TestCopyPastePermissionHandling(IntegrationTestCase):
         browser.open(self.dossier,
                      data=self.make_path_param(self.subdossier), view="copy_items")
 
-        browser.open(self.empty_repofolder)
-        browser.click_on('Paste')
+        with self.observe_children(self. empty_repofolder) as children:
+            browser.open(self.empty_repofolder)
+            browser.click_on('Paste')
 
-        subdossier_copy = self.empty_repofolder.objectValues()[0]
+        self.assertEqual(1, len(children.get('added')))
+        subdossier_copy = children.get('added').pop()
         manager = RoleAssignmentManager(subdossier_copy)
         assignments = manager.get_assignments_by_cause(assignment_type)
 
@@ -433,10 +446,12 @@ class TestCopyPastePermissionHandling(IntegrationTestCase):
         browser.open(self.dossier,
                      data=self.make_path_param(self.subdossier), view="copy_items")
 
-        browser.open(self.empty_repofolder)
-        browser.click_on('Paste')
+        with self.observe_children(self. empty_repofolder) as children:
+            browser.open(self.empty_repofolder)
+            browser.click_on('Paste')
 
-        subdossier_copy = self.empty_repofolder.objectValues()[0]
+        self.assertEqual(1, len(children.get('added')))
+        subdossier_copy = children.get('added').pop()
         manager = RoleAssignmentManager(subdossier_copy)
         assignments = manager.get_assignments_by_cause(assignment_type)
 
@@ -462,10 +477,12 @@ class TestCopyPastePermissionHandling(IntegrationTestCase):
         browser.open(self.dossier,
                      data=self.make_path_param(self.subdossier), view="copy_items")
 
-        browser.open(self.empty_repofolder)
-        browser.click_on('Paste')
+        with self.observe_children(self. empty_repofolder) as children:
+            browser.open(self.empty_repofolder)
+            browser.click_on('Paste')
 
-        subdossier_copy = self.empty_repofolder.objectValues()[0]
+        self.assertEqual(1, len(children.get('added')))
+        subdossier_copy = children.get('added').pop()
         manager = RoleAssignmentManager(subdossier_copy)
         assignments = manager.get_assignments_by_cause(assignment_type)
 


### PR DESCRIPTION
During a copy/paste, the behaviour was to clear all local_roles and set the owner to the user making the copy/paste. The desired behavior is to preserve the local roles assignment during a copy/paste operation. 
Local roles can get assigned through different behaviors, and it does not make sense to preserve all of them. For example local roles granted through a task should not be copied, as the copied dossier is not referenced in the task.

We now copy local roles from`SharingRoleAssignment`, `ProtectDossierRoleAssignment`, and `InvitationRoleAssignment` when copying an object. Local roles from other assignment classes are dropped (`TaskRoleAssignment`, `TaskAgencyRoleAssignment` and `CommitteeGroupAssignment`). We still reset the owner to the user doing the copy/paste.

We also add a status message when local roles were copied for any object during the copy/paste operation.

I added a test to force making a conscious decision of how a new Assignment type should be handled during a copy/paste action.

resolves #5276 

