### PR TITLE
Avoid truncating committee responsible group token while normalizing.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ---------------------
 
 - Change wording of info for inactiv close meeting button. [njohner]
+- Avoid truncating committee responsible group token while normalizing. [deiferni]
 - Prevent tasks from being copied. [lgraf]
 - ResolveOGUIDView: Preserve query string. [lgraf]
 - Bump docxcompose to 1.0.0a16 to fix updating docproperties. [deiferni]

--- a/opengever/meeting/committee.py
+++ b/opengever/meeting/committee.py
@@ -1,5 +1,6 @@
 from Acquisition import aq_inner
 from Acquisition import aq_parent
+from opengever.base.model import GROUP_ID_LENGTH
 from opengever.base.validators import BaseRepositoryfolderValidator
 from opengever.meeting import _
 from opengever.meeting.committeeroles import CommitteeRoles
@@ -46,7 +47,7 @@ def get_group_vocabulary(context):
     for group in groups:
         terms.append(SimpleTerm(
             group.groupid,
-            token=normalize(group.groupid),
+            token=normalize(group.groupid, max_length=GROUP_ID_LENGTH),
             title=group.title or group.groupid))
     return SimpleVocabulary(terms)
 

--- a/opengever/meeting/tests/test_committee_roles.py
+++ b/opengever/meeting/tests/test_committee_roles.py
@@ -69,3 +69,13 @@ class TestCommitteeGroupsVocabulary(IntegrationTestCase):
              u'committee_ver_group'],
             [term.value for term in
              get_group_vocabulary(self.committee_container)])
+
+    def test_committee_group_vocabulary_does_not_truncate_long_group_ids(self):
+        self.login(self.committee_responsible)
+        long_id = 255 * 'x'
+
+        create(Builder('ogds_group')
+              .having(groupid=long_id, title=u'I have a very long ... ID!'))
+
+        vocabulary = get_group_vocabulary(self.committee_container)
+        self.assertEqual(long_id, vocabulary._terms[-1].token)


### PR DESCRIPTION
The normalizer normalizes to a length of 50 by default. As this is shorter than the maximum length of the groupid column and some customers have a naming schema where the the first 50 chars of a group id might be identical we must allow for longer tokens.
Same maximum length as the groupid column should be safe.