### PR TITLE
Also hide re-risen Unauthorized tracebacks for non-manager users

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -36,6 +36,7 @@ Changelog
 - Include portal_type in @favorites endpoint response. [lgraf]
 - Supply date format locale settings for fr-ch. [lgraf]
 - Add meeting error view displayed when user has permission issues. [njohner]
+- Also hide re-risen Unauthorized tracebacks for non-manager users. [Rotonen]
 - Kill the theme functional test layer. [Rotonen]
 - Kill the theme integration test layer. [Rotonen]
 - Merge the plonetheme.teamraum gever profile into opengever.core. [Rotonen]

--- a/opengever/base/monkey/patches/__init__.py
+++ b/opengever/base/monkey/patches/__init__.py
@@ -9,6 +9,7 @@ from .default_values import PatchInvokeFactory
 from .default_values import PatchTransmogrifyDXSchemaUpdater
 from .default_values import PatchZ3CFormChangedField
 from .default_values import PatchZ3CFormWidgetUpdate
+from .exception_formatter import PatchExceptionFormatter
 from .filter_trashed_from_catalog import PatchCatalogToFilterTrashedDocs
 from .history_handler_tool import PatchCMFEditonsHistoryHandlerTool
 from .ldap_userfolder_encoding import PatchLDAPUserFolderEncoding
@@ -48,3 +49,4 @@ PatchCMFCatalogAware()()
 PatchOFSRoleManager()()
 PatchCMFCatalogAwareHandlers()()
 ScrubBoboExceptions()()
+PatchExceptionFormatter()()

--- a/opengever/base/monkey/patches/exception_formatter.py
+++ b/opengever/base/monkey/patches/exception_formatter.py
@@ -1,0 +1,52 @@
+from opengever.base.monkey.patching import MonkeyPatch
+
+
+class PatchExceptionFormatter(MonkeyPatch):
+    """Return an empty user-facing traceback for non-manager users.
+
+    This is done as ``Unauthorized`` is explicitly rerisen for PAS plugins and
+    this ends up bypassing the ``opengever.base`` exception template and
+    falling back to normal exception rendering mechanisms.
+    """
+
+    def __call__(self):
+        from App.config import getConfiguration
+        from plone import api
+        from ZODB.DemoStorage import DemoStorage
+
+        def formatException(self, etype, value, tb, limit=None):
+            portal = api.portal.get()
+            user_is_manager = api.user.has_permission("Manage Portal", obj=portal)
+            in_a_test = isinstance(portal._p_jar.db().storage, DemoStorage)
+
+            config = getConfiguration()
+            debug_mode = getattr(config, "debug_mode", False)
+            verbose_security = getattr(config, "verbose_security", False)
+
+            # The block within this if is the original implementation
+            # https://github.com/zopefoundation/zExceptions/blob/85343157fa49f04b5304f8394d27400804b292df/src/zExceptions/ExceptionFormatter.py#L178-L199
+            if user_is_manager or in_a_test or debug_mode or verbose_security:
+                # The next line provides a way to detect recursion.
+                __exception_formatter__ = 1
+                result = [self.getPrefix() + "\n"]
+                if limit is None:
+                    limit = self.getLimit()
+                n = 0
+                while tb is not None and (limit is None or n < limit):
+                    if tb.tb_frame.f_locals.get("__exception_formatter__"):
+                        # Stop recursion.
+                        result.append("(Recursive formatException() stopped)\n")
+                        break
+                    line = self.formatLine(tb)
+                    result.append(line + "\n")
+                    tb = tb.tb_next
+                    n = n + 1
+                exc_line = self.formatExceptionOnly(etype, value)
+                result.append(self.formatLastLine(exc_line))
+                return result
+
+            # We fall through in our patch with a notification of a suppression
+            return ["Exception suppressed."]
+
+        from zExceptions.ExceptionFormatter import HTMLExceptionFormatter
+        self.patch_refs(HTMLExceptionFormatter, "formatException", formatException)


### PR DESCRIPTION
Redo of https://github.com/4teamwork/opengever.core/pull/5269

Return an known-redacted user-facing traceback for non-manager users.
This is done as Unauthorized is explicitly rerisen for PAS plugins and this ends up bypassing the opengever.base exception template and falling back to normal exception rendering mechanisms.

Additionally we always display the tracebacks in tests, debug mode or with verbose security enabled.

Adding tests for this one do not seem possible.

We're hitting this logic (relevant for PAS challenge plugins) in zopefoundation/Zope@7b65910 and monkey patching the exception formatting logic was the least impactful route I found of addressing this.

An alternative would be to try to muck around with the exception hook itself, but that'd be potentially a lot more dangerous.

https://github.com/zopefoundation/Zope/blob/d916c812bdaf518053b0c3cb2cb3545ff73bc288/src/ZPublisher/Publish.py#L336

Also the exception rendering code is peppered a bit all around the place, depending on exact circumstance, but all of them I've managed to find use the zExceptions.ExceptionFormatter.

Original implementation:
https://github.com/zopefoundation/zExceptions/blob/85343157fa49f04b5304f8394d27400804b292df/src/zExceptions/ExceptionFormatter.py#L178-L196

Delta declarations:

* Patching the HTML formatter instead of the Text formatter
* Reintroduction of conditionals for when to suppress the traceback
* Addition of checking for if we are using demo storage