### PR TITLE
 Group fields in Committee edit forms.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ---------------------
 
 - Fix bug in paragraph agendaitem item_number display. [njohner]
+- Group fields in Committee edit forms. [njohner]
 - Scrub Bobo Call Interface data out of the HTTP response headers. [Rotonen]
 - Scrub the server version out of the HTTP response headers. [Rotonen]
 - Fix bug in excerpt overview when user has no permissions on meeting. [njohner]

--- a/opengever/meeting/committee.py
+++ b/opengever/meeting/committee.py
@@ -188,14 +188,13 @@ class ICommittee(model.Schema):
     def default_template_is_in_allowed_templates(data):
         """ Validate ad-hoc agenda item templates
         """
-
         default_template = data.ad_hoc_template
         allowed_templates = data.allowed_ad_hoc_agenda_item_templates
 
         if default_template is None:
             return
 
-        if not len(allowed_templates):
+        if not allowed_templates:
             return
 
         if IUUID(default_template) not in allowed_templates:

--- a/opengever/meeting/committee.py
+++ b/opengever/meeting/committee.py
@@ -56,6 +56,36 @@ class ICommittee(model.Schema):
     """Base schema for the committee.
     """
 
+    model.fieldset(
+        u'protocol',
+        label=_(u'fieldset_protocol_templates', u'Protocol templates'),
+        fields=[
+            'protocol_header_template',
+            'paragraph_template',
+            'agenda_item_header_template',
+            'agenda_item_suffix_template',
+            'protocol_suffix_template',
+            ],
+        )
+
+    model.fieldset(
+        u'excerpt',
+        label=_(u'fieldset_excerpt_templates', u'Excerpt templates'),
+        fields=[
+            'excerpt_header_template',
+            'excerpt_suffix_template',
+            ],
+        )
+
+    repository_folder = RelationChoice(
+        title=_(u'Linked repository folder'),
+        description=_(
+            u'label_linked_repository_folder',
+            default=u'Contains automatically generated dossiers and documents '
+                    u'for this committee.'),
+        source=repository_folder_source,
+        required=True)
+
     protocol_header_template = RelationChoice(
         title=_('label_protocol_header_template',
                 default='Protocol header template'),
@@ -112,15 +142,6 @@ class ICommittee(model.Schema):
         required=False,
     )
 
-    repository_folder = RelationChoice(
-        title=_(u'Linked repository folder'),
-        description=_(
-            u'label_linked_repository_folder',
-            default=u'Contains automatically generated dossiers and documents '
-                    u'for this committee.'),
-        source=repository_folder_source,
-        required=True)
-
     paragraph_template = RelationChoice(
         title=_('label_paragraph_template',
                 default=u'Paragraph template'),
@@ -142,13 +163,6 @@ class ICommittee(model.Schema):
         default=None,
         missing_value=None)
 
-    ad_hoc_template = RelationChoice(
-        title=_('label_ad_hoc_template',
-                default=u'Ad hoc agenda item template'),
-        source=proposal_template_source,
-        required=False,
-    )
-
     form.widget('allowed_ad_hoc_agenda_item_templates', CheckBoxFieldWidget)
     allowed_ad_hoc_agenda_item_templates = schema.List(
         title=_(u'label_allowed_ad_hoc_agenda_item_templates',
@@ -162,6 +176,13 @@ class ICommittee(model.Schema):
         required=False,
         default=None,
         missing_value=None)
+
+    ad_hoc_template = RelationChoice(
+        title=_('label_ad_hoc_template',
+                default=u'Ad hoc agenda item template'),
+        source=proposal_template_source,
+        required=False,
+    )
 
     @invariant
     def default_template_is_in_allowed_templates(data):

--- a/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
@@ -700,6 +700,16 @@ msgstr "Der Protokollauszug wurde im Urspurungsdossier abgelegt."
 msgid "excused"
 msgstr "Entschuldigt"
 
+#. Default: "Excerpt templates"
+#: ./opengever/meeting/committee.py
+msgid "fieldset_excerpt_templates"
+msgstr "Vorlagen Protokollauszug"
+
+#. Default: "Protocol templates"
+#: ./opengever/meeting/committee.py
+msgid "fieldset_protocol_templates"
+msgstr "Vorlagen Protokoll"
+
 #. Default: "Alphabetical Toc ${period} ${committee}"
 #: ./opengever/meeting/browser/toc.py
 msgid "filename_alphabetical_toc"

--- a/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
@@ -702,6 +702,16 @@ msgstr "L'extrait de protocole a été déposé dans le dossier d'origine de la 
 msgid "excused"
 msgstr "Excusé"
 
+#. Default: "Excerpt templates"
+#: ./opengever/meeting/committee.py
+msgid "fieldset_excerpt_templates"
+msgstr "Modèles extrait de protocole"
+
+#. Default: "Protocol templates"
+#: ./opengever/meeting/committee.py
+msgid "fieldset_protocol_templates"
+msgstr "Modèles protocole"
+
 #. Default: "Alphabetical Toc ${period} ${committee}"
 #: ./opengever/meeting/browser/toc.py
 msgid "filename_alphabetical_toc"

--- a/opengever/meeting/locales/opengever.meeting.pot
+++ b/opengever/meeting/locales/opengever.meeting.pot
@@ -699,6 +699,16 @@ msgstr ""
 msgid "excused"
 msgstr ""
 
+#. Default: "Excerpt templates"
+#: ./opengever/meeting/committee.py
+msgid "fieldset_excerpt_templates"
+msgstr ""
+
+#. Default: "Protocol templates"
+#: ./opengever/meeting/committee.py
+msgid "fieldset_protocol_templates"
+msgstr ""
+
 #. Default: "Alphabetical Toc ${period} ${committee}"
 #: ./opengever/meeting/browser/toc.py
 msgid "filename_alphabetical_toc"

--- a/opengever/meeting/tests/test_committee.py
+++ b/opengever/meeting/tests/test_committee.py
@@ -88,6 +88,24 @@ class TestCommittee(IntegrationTestCase):
             self.sablon_template, self.committee.get_protocol_suffix_template())
 
     @browsing
+    def test_committee_edit_form_fieldsets(self, browser):
+        self.login(self.committee_responsible, browser)
+        browser.open(self.committee, view='edit')
+        form = browser.forms["form"]
+
+        self.assertEqual(1, len(form.css("#fieldset-default")))
+        fieldset = form.css("#fieldset-default")
+        self.assertEqual('Default', fieldset.css("legend").first.text)
+
+        self.assertEqual(1, len(form.css("#fieldset-0")))
+        fieldset = form.css("#fieldset-0")
+        self.assertEqual('Protocol templates', fieldset.css("legend").first.text)
+
+        self.assertEqual(1, len(form.css("#fieldset-1")))
+        fieldset = form.css("#fieldset-1")
+        self.assertEqual('Excerpt templates', fieldset.css("legend").first.text)
+
+    @browsing
     def test_can_configure_ad_hoc_template(self, browser):
         self.login(self.committee_responsible, browser)
 
@@ -110,6 +128,7 @@ class TestCommittee(IntegrationTestCase):
         browser.open(self.committee, view='edit')
         browser.fill({'Allowed ad-hoc agenda item templates': u'Freitext Traktandum'})
         browser.fill({'Ad hoc agenda item template': self.proposal_template})
+
         browser.find('Save').click()
         self.assertItemsEqual(['There were some errors.'],
                               statusmessages.error_messages())
@@ -452,30 +471,31 @@ class TestCommitteeWorkflow(IntegrationTestCase):
 
         fields = ['Title',
                   'Committeeresponsible',
-                  'Protocol header template',
-                  'Protocol suffix template',
-                  'Agenda item header template for the protocol',
-                  'Agenda item suffix template for the protocol',
-                  'Excerpt header template',
-                  'Excerpt suffix template',
+                  'Linked repository folder',
                   'Agendaitem list template',
                   'Table of contents template',
-                  'Linked repository folder',
-                  'Paragraph template',
                   'Allowed proposal templates',
+                  'Allowed ad-hoc agenda item templates',
                   'Ad hoc agenda item template',
-                  'Allowed ad-hoc agenda item templates']
+                  'Protocol header template',
+                  'Paragraph template',
+                  'Agenda item header template for the protocol',
+                  'Agenda item suffix template for the protocol',
+                  'Protocol suffix template',
+                  'Excerpt header template',
+                  'Excerpt suffix template']
+
         with self.login(self.administrator, browser):
             browser.open(self.committee_container)
             factoriesmenu.add('Committee')
             self.assertEquals(
                 fields,
                 map(methodcaller('normalized_text', recursive=False),
-                    browser.css('form#form > div.field > label')))
+                    browser.css('form#form > fieldset > div.field > label')))
 
         with self.login(self.committee_responsible, browser):
             browser.open(self.committee, view='edit')
             self.assertEquals(
                 fields,
                 map(methodcaller('normalized_text', recursive=False),
-                    browser.css('form#form > div.field > label')))
+                    browser.css('form#form > fieldset > div.field > label')))


### PR DESCRIPTION
We group the fields in the committee edit forms in several tabs, to make it a bit clearer.

The fields come from separate schemas, so that it was not possible (let's say I couldn't find how) to make a fieldset with fields from the different schemas (usually we have one schema inheriting from several, and then it works). But as there is only one set that has fields from the two schemas, leaving those in no fieldset and putting the remaining ones in separate fieldsets did the trick.

Another problem appeared during validation. Somehow the invariant gets called once on the form and then on each group. In the latter case, some of the fields were `None` and the invariant failed. Not sure why that is.

<img width="1429" alt="screen shot 2019-01-31 at 15 39 40" src="https://user-images.githubusercontent.com/7374243/52061385-78831e80-256e-11e9-91a5-29c18bfdfb29.png">

resolves #4800 