### PR TITLE
Fix bug in paragraph agendaitem item_number display.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2019.1.0 (unreleased)
 ---------------------
 
+- Fix bug in paragraph agendaitem item_number display. [njohner]
 - Scrub Bobo Call Interface data out of the HTTP response headers. [Rotonen]
 - Scrub the server version out of the HTTP response headers. [Rotonen]
 - Fix bug in excerpt overview when user has no permissions on meeting. [njohner]

--- a/opengever/meeting/model/agendaitem.py
+++ b/opengever/meeting/model/agendaitem.py
@@ -126,6 +126,8 @@ class AgendaItem(Base):
 
     @property
     def formatted_number(self):
+        if not self.item_number:
+            return ""
         return '{}.'.format(self.item_number)
 
     def get_title(self, include_number=False, formatted=False):


### PR DESCRIPTION
It seems that in https://github.com/4teamwork/opengever.core/pull/5207 we introduced a bug for the display of paragraph agendaitems. Because paragraphs have an `item_number` that is `None`, we need to avoid formatting it in a string, see screenshot below.

<img width="1292" alt="screen shot 2019-01-31 at 16 07 59" src="https://user-images.githubusercontent.com/7374243/52063804-943cf380-2573-11e9-86bb-5273fbc2d9a2.png">

