### PR TITLE
Provide poor man's cache invalidation mechanism  for vue apps.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2019.1.0 (unreleased)
 ---------------------
 
+- Add simple cache invalidation mechanism for javascript included in templates. [deiferni]
 - Fix bug in paragraph agendaitem item_number display. [njohner]
 - Group fields in Committee edit forms. [njohner]
 - Scrub Bobo Call Interface data out of the HTTP response headers. [Rotonen]

--- a/opengever/base/browser/templates/favorites.pt
+++ b/opengever/base/browser/templates/favorites.pt
@@ -24,7 +24,7 @@
                              data-userid view/get_userid;
                              data-authtoken context/@@authenticator/token"></div>
 
-        <script tal:attributes="src string:${here/portal_url}/++resource++opengever.base/favorites_app.js?_v=1"></script>
+        <script tal:attributes="src string:${here/portal_url}/++resource++opengever.base/favorites_app.js?_v=501b97dec4c77aa4bb750a9b58103ce1"></script>
 
       </metal:core-macro>
     </div>

--- a/opengever/base/browser/templates/favorites.pt
+++ b/opengever/base/browser/templates/favorites.pt
@@ -24,7 +24,7 @@
                              data-userid view/get_userid;
                              data-authtoken context/@@authenticator/token"></div>
 
-        <script tal:attributes="src string:${here/portal_url}/++resource++opengever.base/favorites_app.js"></script>
+        <script tal:attributes="src string:${here/portal_url}/++resource++opengever.base/favorites_app.js?_v=1"></script>
 
       </metal:core-macro>
     </div>

--- a/opengever/base/tests/test_js_cache_invalidation.py
+++ b/opengever/base/tests/test_js_cache_invalidation.py
@@ -1,0 +1,118 @@
+from os.path import join as pjoin
+from os.path import normpath
+from os.path import relpath
+from pkg_resources import resource_filename
+import fnmatch
+import hashlib
+import os
+import pprint
+import re
+import unittest
+
+
+class TestJSCacheInvalidation(unittest.TestCase):
+    """Test that poor mans cache invalidation information is updated.
+
+    Test that cache invalidation parameters for manually included javscripts
+    are updated whenever the file changes.
+
+    May not catch all manual includes but is hopefully better than nothing.
+    """
+    maxDiff = None
+
+    # we don't have a naming convention, some packages deviate from the
+    # package/name/browser/resources naming scheme.
+    resource_dir_to_path_segments = {
+        'opengever.workspace.participants.resources':
+            ('opengever', 'workspace', 'participation', 'browser', 'resources',),
+        'opengever.document':
+            ('opengever', 'document', 'static',),
+    }
+    og_core_package_path = normpath(pjoin(
+            resource_filename('opengever.core', ''), '..', '..'))
+    og_namespace_path = pjoin(og_core_package_path, 'opengever')
+    exp_script_with_checksum = re.compile(
+        r'<script\s*tal:attributes="src string:\${here/portal_url}/\+\+resource\+\+(?P<resource>.*)/(?P<filename>.*\.js)\?_v=(?P<checksum>.*)\s*"')
+    exp_script_without_checksum = re.compile(
+        r'<script\s*tal:attributes="src string:\${here/portal_url}/(?P<resource_id>\+\+resource\+\+.*/.*\.js)\s*"')
+
+    def md5(self, file_path):
+        """Return an md5 checksum for the file at file_path."""
+
+        hash_md5 = hashlib.md5()
+        with open(file_path, "rb") as f:
+            for chunk in iter(lambda: f.read(4096), b""):
+                hash_md5.update(chunk)
+        return hash_md5.hexdigest()
+
+    def zope_page_template_paths(self):
+        for root, dirnames, filenames in os.walk(self.og_namespace_path):
+            for filename in fnmatch.filter(filenames, '*.pt'):
+                yield pjoin(root, filename)
+
+    def find_scripts_with_checksum_query_parameter(self):
+        for template_path in self.zope_page_template_paths():
+            with open(template_path, 'r') as template_file:
+                match = self.exp_script_with_checksum.search(
+                    template_file.read())
+                if match:
+                    yield(template_path, match)
+
+    def find_scripts_without_checksum_query_parameter(self):
+        for template_path in self.zope_page_template_paths():
+            with open(template_path, 'r') as template_file:
+                match = self.exp_script_without_checksum.search(
+                    template_file.read())
+                if match:
+                    yield(template_path, match)
+
+    def format_resource_name(self, template_path, resource_id):
+        """Return an unique resource name for template_path and resource_id."""
+
+        relative_path = relpath(template_path, start=self.og_core_package_path)
+        return "{}:{}".format(relative_path, resource_id)
+
+    def test_manually_included_js_files_have_cache_invalidation(self):
+        missing = []
+        for template_path, match in self.find_scripts_without_checksum_query_parameter():
+            resource_id = match.group('resource_id')
+            missing.append(self.format_resource_name(template_path, resource_id))
+        if missing:
+            self.fail(
+                'The following javascript includes are missing a cache '
+                'invalidation query string parameter. Please append '
+                '"?_v=[checksum]" to the "src" url.\n\n{}'.format(
+                    pprint.pformat(missing)))
+
+    def test_js_cache_invalidation_parameters_are_updated_in_templates(self):
+        current_checksums = {}
+        expected_checksums = {}
+
+        for template_path, match in self.find_scripts_with_checksum_query_parameter():
+            resource = match.group('resource')
+            js_filename = match.group('filename')
+            current_checksum = match.group('checksum')
+
+            segments = self.resource_dir_to_path_segments.get(resource)
+            if not segments:
+                segments = tuple(resource.split('.')) + ('browser', 'resources',)
+            full_segments = (self.og_core_package_path,) + segments + (js_filename,)
+            js_file_path = pjoin(*full_segments)
+            expected_checksum = self.md5(js_file_path)
+
+            resource_id = "++resource++{}/{}".format(resource, js_filename)
+            key = self.format_resource_name(template_path, resource_id)
+            # Only populate the dict when the checksums are different, this
+            # results in better exception failure output. Otherwise correct
+            # checksums are listed as context which is a bit confusing.
+            if current_checksum != expected_checksum:
+                current_checksums[key] = current_checksum
+                expected_checksums[key] = expected_checksum
+
+        self.assertDictEqual(
+            current_checksums,
+            expected_checksums,
+            '\n\nError: You seem to have modified a javascript file without '
+            'updating the cache invalidation version parameter. You most '
+            'likely should update the template with the new checksum (see '
+            'diff above).')

--- a/opengever/base/viewlets/favorites_menu.pt
+++ b/opengever/base/viewlets/favorites_menu.pt
@@ -10,6 +10,6 @@
                        data-i18n view/translations;
                        data-userid view/get_userid" />
 
-  <script tal:attributes="src string:${here/portal_url}/++resource++opengever.base/favorites_menu_app.js"></script>
+  <script tal:attributes="src string:${here/portal_url}/++resource++opengever.base/favorites_menu_app.js?_v=1"></script>
 
 </div>

--- a/opengever/base/viewlets/favorites_menu.pt
+++ b/opengever/base/viewlets/favorites_menu.pt
@@ -10,6 +10,6 @@
                        data-i18n view/translations;
                        data-userid view/get_userid" />
 
-  <script tal:attributes="src string:${here/portal_url}/++resource++opengever.base/favorites_menu_app.js?_v=1"></script>
+  <script tal:attributes="src string:${here/portal_url}/++resource++opengever.base/favorites_menu_app.js?_v=bd2593a93b06feed765fd9993e241a79"></script>
 
 </div>

--- a/opengever/base/viewlets/recently_touched_menu.pt
+++ b/opengever/base/viewlets/recently_touched_menu.pt
@@ -8,6 +8,6 @@
                        data-num-checked-out view/get_num_checked_out;
                        data-userid view/get_userid" />
 
-  <script tal:attributes="src string:${here/portal_url}/++resource++opengever.base/recently_touched_menu_app.js?_v=1"></script>
+  <script tal:attributes="src string:${here/portal_url}/++resource++opengever.base/recently_touched_menu_app.js?_v=0c00a7420a791059bbd0e91785b74b9d"></script>
 
 </div>

--- a/opengever/base/viewlets/recently_touched_menu.pt
+++ b/opengever/base/viewlets/recently_touched_menu.pt
@@ -8,6 +8,6 @@
                        data-num-checked-out view/get_num_checked_out;
                        data-userid view/get_userid" />
 
-  <script tal:attributes="src string:${here/portal_url}/++resource++opengever.base/recently_touched_menu_app.js"></script>
+  <script tal:attributes="src string:${here/portal_url}/++resource++opengever.base/recently_touched_menu_app.js?_v=1"></script>
 
 </div>

--- a/opengever/document/browser/templates/save_pdf_under.pt
+++ b/opengever/document/browser/templates/save_pdf_under.pt
@@ -24,7 +24,7 @@
                            data-sourcedocumenturl view/source_document_url;">
       </span>
 
-      <script tal:attributes="src string:${here/portal_url}/++resource++opengever.document/save_pdf_under_app.js" />
+      <script tal:attributes="src string:${here/portal_url}/++resource++opengever.document/save_pdf_under_app.js?_v=1" />
 
     </div>
 

--- a/opengever/document/browser/templates/save_pdf_under.pt
+++ b/opengever/document/browser/templates/save_pdf_under.pt
@@ -24,7 +24,7 @@
                            data-sourcedocumenturl view/source_document_url;">
       </span>
 
-      <script tal:attributes="src string:${here/portal_url}/++resource++opengever.document/save_pdf_under_app.js?_v=1" />
+      <script tal:attributes="src string:${here/portal_url}/++resource++opengever.document/save_pdf_under_app.js?_v=76dae3940196a28dc485a39e48b16fed" />
 
     </div>
 

--- a/opengever/meeting/browser/meetings/templates/demand_zip.pt
+++ b/opengever/meeting/browser/meetings/templates/demand_zip.pt
@@ -24,7 +24,7 @@
                            data-meetingurl view/meeting_url;">
       </span>
 
-      <script tal:attributes="src string:${here/portal_url}/++resource++opengever.meeting/zip_export_app.js?_v=1" />
+      <script tal:attributes="src string:${here/portal_url}/++resource++opengever.meeting/zip_export_app.js?_v=c5ab8d15f54c06d30b7af35e5431870a" />
 
       <hr />
 

--- a/opengever/task/browser/templates/overview.pt
+++ b/opengever/task/browser/templates/overview.pt
@@ -143,5 +143,5 @@
     <div class="visualClear"><!----></div>
   </tal:i18n>
   <div tal:replace="structure view/task_reminder_vuejs_template" />
-  <script tal:attributes="src string:${context/portal_url}/++resource++opengever.base/task_reminder_selector.js"></script>
+  <script tal:attributes="src string:${context/portal_url}/++resource++opengever.base/task_reminder_selector.js?_v=1"></script>
 </html>

--- a/opengever/workspace/participation/browser/templates/participants-view.pt
+++ b/opengever/workspace/participation/browser/templates/participants-view.pt
@@ -31,7 +31,7 @@
                              data-i18n view/translations;
                              data-authtoken context/@@authenticator/token"></div>
 
-        <script tal:attributes="src string:${here/portal_url}/++resource++opengever.workspace.participants.resources/app.js"></script>
+        <script tal:attributes="src string:${here/portal_url}/++resource++opengever.workspace.participants.resources/app.js?_v=1"></script>
 
       </metal:core-macro>
     </div>

--- a/opengever/workspace/participation/browser/templates/participants-view.pt
+++ b/opengever/workspace/participation/browser/templates/participants-view.pt
@@ -23,7 +23,7 @@
                              data-i18n view/translations;
                              data-authtoken context/@@authenticator/token"></div>
 
-        <script tal:attributes="src string:${here/portal_url}/++resource++opengever.workspace.participants.resources/app.js?_v=1"></script>
+        <script tal:attributes="src string:${here/portal_url}/++resource++opengever.workspace.participants.resources/app.js?_v=df3da290de17529f737e5ce36d1a4820"></script>
 
       </metal:core-macro>
     </div>

--- a/opengever/workspace/participation/browser/templates/participants-view.pt
+++ b/opengever/workspace/participation/browser/templates/participants-view.pt
@@ -7,14 +7,6 @@
       i18n:domain="opengever.workspace">
 
   <body>
-    <metal:js fill-slot="javascript_head_slot">
-      <script tal:attributes="src string:${here/portal_url}/++resource++opengever.base/vue.min.js"></script>
-
-      <script tal:attributes="src string:${here/portal_url}/++resource++opengever.base/axios.min.js"></script>
-
-    </metal:js>
-
-
     <metal:title fill-slot="content-title">
        <h1 class="documentFirstHeading" i18n:translate="title_manage_participation">
            Manage participation of <span i18n:name="workspace" tal:replace="here/Title" />


### PR DESCRIPTION
Provide a query string parameter wherever we include vue apps directly in a template. This will invalidate all those apps, theoretically that would not be necessary now but only when the file changes next time. We do it now anyway so it serves as an example for future uses, also new files we include will then already have the version query parameter when the line is copied from an existing template. Also hopefully hints that the version must be increased manually whenever the javascript file changes. 

We should come up with something better soon, but until then this approach must do.

I have manually verified that the apps affected by this change still work 😓.

Also provide tests that make sure that the query string parameter is updated when the files change and that we do not introduce new includes without cache invalidation. Sample test output.

Query string parameter not updated correctly:
![screenshot 2019-02-01 at 20 23 47](https://user-images.githubusercontent.com/736583/52147376-d430d300-2666-11e9-970d-3f5e38ea728f.png)

Missing parameter:
![screenshot 2019-02-01 at 21 09 57](https://user-images.githubusercontent.com/736583/52147409-e90d6680-2666-11e9-89a4-64314e0f6de2.png)

closes #5180 