### PR TITLE
Add API Support for tasks and forwarding transitions

### DIFF
--- a/docs/public/dev-manual/api/index.rst
+++ b/docs/public/dev-manual/api/index.rst
@@ -27,6 +27,7 @@ Inhalt:
    recently_touched.rst
    preview.rst
    webactions.rst
+   tasks.rst
    examples/index.rst
    docs_changelog.rst
 

--- a/docs/public/dev-manual/api/tasks.rst
+++ b/docs/public/dev-manual/api/tasks.rst
@@ -17,7 +17,7 @@ Auch Aufgaben können via REST API bedient werden. Die Erstellung einer Aufgabe 
         "responsible": "john.doe",
         "issuer": "john.doe",
         "responsible_client": "afi",
-        "task_type": "direct-execution",
+        "task_type": "direct-execution"
       }
 
 
@@ -31,7 +31,7 @@ Auch Aufgaben können via REST API bedient werden. Die Erstellung einer Aufgabe 
       {
         "@id": "http://example.org/ordnungssystem/fuehrung/dossier-1/task-5",
         "@type": "opengever.task.task",
-        "...": "...",
+        "...": "..."
       }
 
 
@@ -47,7 +47,7 @@ Ein GET Request auf den @workflow endpoint listet mögiche Transitions auf:
 
    .. sourcecode:: http
 
-      POST /(path)/@workflow/task-transition-open-in-progress HTTP/1.1
+      GET /(path)/@workflow HTTP/1.1
       Accept: application/json
 
 
@@ -117,7 +117,7 @@ Akzeptieren
 ~~~~~~~~~~~
 
 Transition IDs:
- - `task-transition-open-in-progress`
+ - ``task-transition-open-in-progress``
 
 Zusätzliche Metadaten:
 
@@ -130,7 +130,7 @@ Frist verlängern
 ~~~~~~~~~~~~~~~~
 
 Transition IDs:
- - `task-transition-modify-deadline`
+ - ``task-transition-modify-deadline``
 
 Zusätzliche Metadaten:
 
@@ -163,7 +163,7 @@ Neu zuweisen
 ~~~~~~~~~~~~
 
 Transition IDs:
- - `task-transition-reassign`
+ - ``task-transition-reassign``
 
 Zusätzliche Metadaten:
 
@@ -187,8 +187,8 @@ Erledigen
 ~~~~~~~~~
 
 Transition IDs:
- - `task-transition-in-progress-resolved`
- - `task-transition-open-resolved`
+ - ``task-transition-in-progress-resolved``
+ - ``task-transition-open-resolved``
 
 Zusätzliche Metadaten:
 
@@ -285,7 +285,7 @@ Zusätzliche Metadaten:
        :Datentyp: ``Text``
 
 
-Des weiteren stehen auch die Statuswechseln für sequentielle Aufgaben zur Verfügung:
+Des weiteren stehen auch die Statuswechsel für sequentielle Aufgaben zur Verfügung:
 
 
 Überspringen

--- a/docs/public/dev-manual/api/tasks.rst
+++ b/docs/public/dev-manual/api/tasks.rst
@@ -1,0 +1,317 @@
+Aufgaben
+========
+
+Auch Aufgaben können via REST API bedient werden. Die Erstellung einer Aufgabe erfolgt wie bei anderen Inhalten (siehe Kapitel :ref:`operations`) via POST request:
+
+
+**Beispiel-Request**:
+
+   .. sourcecode:: http
+
+      POST /(container) HTTP/1.1
+      Accept: application/json
+
+      {
+        "@type": "opengever.task.task",
+        "title": "Bitte Dokument reviewen",
+        "responsible": "john.doe",
+        "issuer": "john.doe",
+        "responsible_client": "afi",
+        "task_type": "direct-execution",
+      }
+
+
+**Beispiel-Response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 201 Created
+      Accept: application/json
+
+      {
+        "@id": "http://example.org/ordnungssystem/fuehrung/dossier-1/task-5",
+        "@type": "opengever.task.task",
+        "...": "...",
+      }
+
+
+Bearbeitung bzw. Statusänderungen
+---------------------------------
+
+
+Die Bearbeitung einer Aufgabe via Patch Request ist limitiert und nur möglich solange sich die Aufgabe im Status `offen` befindet. Im weiteren Verlauf einer Aufgabe werden diese auschliesslich via Statusänderungen bearbeitet. Dies geschieht über den ``@workflow`` Endpoint mit entsprechender Transition ID als zusätzlicher Parameter.
+
+Ein GET Request auf den @workflow endpoint listet mögiche Transitions auf:
+
+**Beispiel-Request**:
+
+   .. sourcecode:: http
+
+      POST /(path)/@workflow/task-transition-open-in-progress HTTP/1.1
+      Accept: application/json
+
+
+**Beispiel-Response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 200 OK
+      Accept: application/json
+
+      {
+        "@id": "http://example.org/ordnungssystem/fuehrung/dossier-1/task-5/@workflow",
+        "history": [],
+        "transitions": [
+          {
+          "@id": "http://example.org/ordnungssystem/fuehrung/dossier-1/task-5/@workflow/task-transition-modify-deadline",
+          "title": "Frist ändern"
+          },
+          {
+          "@id": "http://example.org/ordnungssystem/fuehrung/dossier-1/task-5/@workflow/task-transition-open-in-progress",
+          "title": "Akzeptieren"
+          },
+          {
+          "@id": "http://example.org/ordnungssystem/fuehrung/dossier-1/task-5/@workflow/task-transition-reassign",
+          "title": "Neu zuweisen"
+          }
+        ]
+      }
+
+
+Eine Transition wird dann folgendermassen ausgeführt:
+
+**Beispiel-Request**:
+
+   .. sourcecode:: http
+
+      POST /(path)/@workflow/task-transition-open-in-progress HTTP/1.1
+      Accept: application/json
+
+      {
+        "text": "Ok, wird gemacht!"
+      }
+
+
+**Beispiel-Response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 200 OK
+      Accept: application/json
+
+      {
+        "action": "task-transition-open-in-progress",
+        "actor": "philippe.gross",
+        "comments": "",
+        "review_state": "task-state-in-progress",
+        "time": "2019-01-24T16:12:12+00:00",
+        "title": "In Arbeit"
+      }
+
+
+
+Folgend sind die möglichen Statusänderungen kurz dokumentiert:
+
+
+Akzeptieren
+~~~~~~~~~~~
+
+Transition IDs:
+ - `task-transition-open-in-progress`
+
+Zusätzliche Metadaten:
+
+   .. py:attribute:: text
+
+       :Datentyp: ``Text``
+
+
+Frist verlängern
+~~~~~~~~~~~~~~~~
+
+Transition IDs:
+ - `task-transition-modify-deadline`
+
+Zusätzliche Metadaten:
+
+   .. py:attribute:: responsibles
+
+       :Datentyp: ``List``
+       :Pflichtfeld: Ja :required:`(*)`
+
+   .. py:attribute:: title
+
+       :Datentyp: ``TextLine``
+       :Pflichtfeld: Ja :required:`(*)`
+
+   .. py:attribute:: issuer
+
+       :Datentyp: ``Choice``
+       :Pflichtfeld: Ja :required:`(*)`
+
+   .. py:attribute:: deadline
+
+       :Datentyp: ``Date``
+       :Pflichtfeld: Ja :required:`(*)`
+
+   .. py:attribute:: text
+
+       :Datentyp: ``Text``
+
+
+Neu zuweisen
+~~~~~~~~~~~~
+
+Transition IDs:
+ - `task-transition-reassign`
+
+Zusätzliche Metadaten:
+
+   .. py:attribute:: text
+
+       :Datentyp: ``Text``
+
+   .. py:attribute:: responsible
+
+       :Datentyp: ``Choice``
+       :Pflichtfeld: Ja :required:`(*)`
+
+
+   .. py:attribute:: responsible_client
+
+       :Datentyp: ``Choice``
+       :Pflichtfeld: Ja :required:`(*)`
+
+
+Erledigen
+~~~~~~~~~
+
+Transition IDs:
+ - `task-transition-in-progress-resolved`
+ - `task-transition-open-resolved`
+
+Zusätzliche Metadaten:
+
+   .. py:attribute:: text
+
+       :Datentyp: ``Text``
+
+
+Überarbeiten
+~~~~~~~~~~~~
+
+Transition IDs:
+ - `task-transition-resolved-in-progress`
+
+Zusätzliche Metadaten:
+
+   .. py:attribute:: text
+
+       :Datentyp: ``Text``
+
+
+Abschliessen
+~~~~~~~~~~~~
+
+Transition IDs:
+ - ``task-transition-resolved-tested-and-closed``
+ - ``task-transition-in-progress-tested-and-closed``
+ - ``task-transition-open-tested-and-closed``
+
+
+Zusätzliche Metadaten:
+
+   .. py:attribute:: text
+
+       :Datentyp: ``Text``
+
+
+Abbrechen
+~~~~~~~~~
+
+Transition IDs:
+ - ``task-transition-open-cancelled``
+ - ``task-transition-in-progress-cancelled``
+
+
+Zusätzliche Metadaten:
+
+   .. py:attribute:: text
+
+       :Datentyp: ``Text``
+
+
+Ablehnen
+~~~~~~~~~
+
+Transition IDs:
+ - ``task-transition-open-rejected``
+ - ``task-transition-in-progress-cancelled``
+
+
+Zusätzliche Metadaten:
+
+   .. py:attribute:: text
+
+       :Datentyp: ``Text``
+
+
+Wieder eröffnen
+~~~~~~~~~~~~~~~
+
+Transition IDs:
+ - ``task-transition-cancelled-open``
+ - ``task-transition-rejected-open``
+
+
+Zusätzliche Metadaten:
+
+   .. py:attribute:: text
+
+       :Datentyp: ``Text``
+
+
+Delegieren
+~~~~~~~~~~
+
+Transition IDs:
+ - ``task-transition-delegate``
+
+
+Zusätzliche Metadaten:
+
+   .. py:attribute:: text
+
+       :Datentyp: ``Text``
+
+
+Des weiteren stehen auch die Statuswechseln für sequentielle Aufgaben zur Verfügung:
+
+
+Überspringen
+~~~~~~~~~~~~
+
+Transition IDs:
+ - ``task-transition-planned-skipped``
+ - ``task-transition-rejected-skipped``
+
+
+Zusätzliche Metadaten:
+
+   .. py:attribute:: text
+
+       :Datentyp: ``Text``
+
+
+Öffnen
+~~~~~~
+
+Transition IDs:
+ - ``task-transition-planned-open``
+
+
+Zusätzliche Metadaten:
+
+   .. py:attribute:: text
+
+       :Datentyp: ``Text``

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -295,4 +295,13 @@
       permission="opengever.webactions.ManageOwnWebActions"
       />
 
+  <plone:service
+      method="POST"
+      name="@workflow"
+      for="Products.CMFCore.interfaces.IContentish"
+      factory=".transition.GEVERWorkflowTransition"
+      layer="opengever.base.interfaces.IOpengeverBaseLayer"
+      permission="zope2.View"
+      />
+
 </configure>

--- a/opengever/api/transition.py
+++ b/opengever/api/transition.py
@@ -1,0 +1,25 @@
+from plone.restapi.deserializer import json_body
+from plone.restapi.interfaces import IDeserializeFromJson
+from plone.restapi.services.workflow.transition import WorkflowTransition
+from Products.CMFCore.interfaces import IFolderish
+from zope.component import queryMultiAdapter
+
+
+class GEVERWorkflowTransition(WorkflowTransition):
+
+    def recurse_transition(self, objs, comment, publication_dates,
+                           include_children=False):
+
+        data = json_body(self.request)
+
+        for obj in objs:
+            if publication_dates:
+                deserializer = queryMultiAdapter((obj, self.request),
+                                                 IDeserializeFromJson)
+                deserializer(data=publication_dates)
+
+            self.wftool.doActionFor(obj, self.transition, comment=comment, **data)
+            if include_children and IFolderish.providedBy(obj):
+                self.recurse_transition(
+                    obj.objectValues(), comment, publication_dates,
+                    include_children)

--- a/opengever/api/transition.py
+++ b/opengever/api/transition.py
@@ -18,7 +18,8 @@ class GEVERWorkflowTransition(WorkflowTransition):
                                                  IDeserializeFromJson)
                 deserializer(data=publication_dates)
 
-            self.wftool.doActionFor(obj, self.transition, comment=comment, **data)
+            self.wftool.doActionFor(obj, self.transition,
+                                    comment=comment, transition_params=data)
             if include_children and IFolderish.providedBy(obj):
                 self.recurse_transition(
                     obj.objectValues(), comment, publication_dates,

--- a/opengever/api/transition.py
+++ b/opengever/api/transition.py
@@ -1,8 +1,11 @@
+from opengever.base.transition import ITransitionExtender
 from plone.restapi.deserializer import json_body
 from plone.restapi.interfaces import IDeserializeFromJson
 from plone.restapi.services.workflow.transition import WorkflowTransition
 from Products.CMFCore.interfaces import IFolderish
+from zExceptions import BadRequest
 from zope.component import queryMultiAdapter
+from zope.globalrequest import getRequest
 
 
 class GEVERWorkflowTransition(WorkflowTransition):
@@ -17,6 +20,13 @@ class GEVERWorkflowTransition(WorkflowTransition):
                 deserializer = queryMultiAdapter((obj, self.request),
                                                  IDeserializeFromJson)
                 deserializer(data=publication_dates)
+
+            adapter = queryMultiAdapter(
+                (obj, getRequest()), ITransitionExtender, name=self.transition)
+            if adapter:
+                errors = adapter.validate_schema(data)
+                if errors:
+                    raise BadRequest(errors)
 
             self.wftool.doActionFor(obj, self.transition,
                                     comment=comment, transition_params=data)

--- a/opengever/base/configure.zcml
+++ b/opengever/base/configure.zcml
@@ -381,4 +381,24 @@
       permission="zope.Public"
       />
 
+  <adapter
+      factory=".transition.AcceptTransitionExtender"
+      name="task-transition-open-in-progress"
+      />
+
+  <adapter
+      factory=".transition.ModifyDeadlineTransitionExtender"
+      name="task-transition-modify-deadline"
+      />
+
+  <adapter
+      factory=".transition.ResolveTransitionExtender"
+      name="task-transition-in-progress-resolved"
+      />
+
+  <adapter
+      factory=".transition.CloseTransitionExtender"
+      name="task-transition-resolved-tested-and-closed"
+      />
+
 </configure>

--- a/opengever/base/configure.zcml
+++ b/opengever/base/configure.zcml
@@ -381,24 +381,4 @@
       permission="zope.Public"
       />
 
-  <adapter
-      factory=".transition.AcceptTransitionExtender"
-      name="task-transition-open-in-progress"
-      />
-
-  <adapter
-      factory=".transition.ModifyDeadlineTransitionExtender"
-      name="task-transition-modify-deadline"
-      />
-
-  <adapter
-      factory=".transition.ResolveTransitionExtender"
-      name="task-transition-in-progress-resolved"
-      />
-
-  <adapter
-      factory=".transition.CloseTransitionExtender"
-      name="task-transition-resolved-tested-and-closed"
-      />
-
 </configure>

--- a/opengever/base/monkey/patches/__init__.py
+++ b/opengever/base/monkey/patches/__init__.py
@@ -23,6 +23,7 @@ from .tz_for_log import PatchZ2LogTimezone
 from .uuidindex import PatchUUIDIndex
 from .verify_object_paste import PatchCopyContainerVerifyObjectPaste
 from .webdav_lock_timeout import PatchWebDAVLockTimeout
+from .workflowtool import PatchWorkflowTool
 
 
 PatchBuilderCreate()()
@@ -50,3 +51,4 @@ PatchOFSRoleManager()()
 PatchCMFCatalogAwareHandlers()()
 ScrubBoboExceptions()()
 PatchExceptionFormatter()()
+PatchWorkflowTool()()

--- a/opengever/base/monkey/patches/workflowtool.py
+++ b/opengever/base/monkey/patches/workflowtool.py
@@ -6,7 +6,7 @@ class PatchWorkflowTool(MonkeyPatch):
 
     def __call__(self):
 
-        def doActionFor(self, ob, action, wf_id=None, *args, **kw):
+        def doActionFor(self, ob, action, wf_id=None, disable_sync=False, *args, **kw):
             from opengever.base.transition import ITransitionExtender
 
             adapter = queryAdapter(ob, ITransitionExtender, name=action)
@@ -15,7 +15,8 @@ class PatchWorkflowTool(MonkeyPatch):
 
             values = adapter.deserialize(**kw)
             value = original_doActionFor(self, ob, action, wf_id=wf_id, *args, **kw)
-            adapter.after_transition_hook(transition=action, **values)
+            adapter.after_transition_hook(
+                transition=action, disable_sync=disable_sync, **values)
             return value
 
         from Products.CMFPlone.WorkflowTool import WorkflowTool

--- a/opengever/base/monkey/patches/workflowtool.py
+++ b/opengever/base/monkey/patches/workflowtool.py
@@ -14,10 +14,9 @@ class PatchWorkflowTool(MonkeyPatch):
                 return original_doActionFor(self, ob, action, wf_id=wf_id, *args, **kw)
 
             values = adapter.deserialize(**kw)
-            value = original_doActionFor(self, ob, action, wf_id=wf_id, *args, **kw)
-            adapter.after_transition_hook(
+            original_doActionFor(self, ob, action, wf_id=wf_id, *args, **kw)
+            return adapter.after_transition_hook(
                 transition=action, disable_sync=disable_sync, **values)
-            return value
 
         from Products.CMFPlone.WorkflowTool import WorkflowTool
         locals()['__patch_refs__'] = False

--- a/opengever/base/monkey/patches/workflowtool.py
+++ b/opengever/base/monkey/patches/workflowtool.py
@@ -1,5 +1,6 @@
 from opengever.base.monkey.patching import MonkeyPatch
-from zope.component import queryAdapter
+from zope.component import queryMultiAdapter
+from zope.globalrequest import getRequest
 
 
 class PatchWorkflowTool(MonkeyPatch):
@@ -9,7 +10,7 @@ class PatchWorkflowTool(MonkeyPatch):
         def doActionFor(self, ob, action, wf_id=None, disable_sync=False, *args, **kw):
             from opengever.base.transition import ITransitionExtender
 
-            adapter = queryAdapter(ob, ITransitionExtender, name=action)
+            adapter = queryMultiAdapter((ob, getRequest()), ITransitionExtender, name=action)
             if not adapter:
                 return original_doActionFor(self, ob, action, wf_id=wf_id, *args, **kw)
 

--- a/opengever/base/monkey/patches/workflowtool.py
+++ b/opengever/base/monkey/patches/workflowtool.py
@@ -7,17 +7,22 @@ class PatchWorkflowTool(MonkeyPatch):
 
     def __call__(self):
 
-        def doActionFor(self, ob, action, wf_id=None, disable_sync=False, *args, **kw):
+        def doActionFor(self, ob, action, wf_id=None, disable_sync=False, transition_params=None, *args, **kw):
             from opengever.base.transition import ITransitionExtender
 
             adapter = queryMultiAdapter((ob, getRequest()), ITransitionExtender, name=action)
             if not adapter:
                 return original_doActionFor(self, ob, action, wf_id=wf_id, *args, **kw)
 
-            values = adapter.deserialize(**kw)
+            if not transition_params:
+                transition_params = {}
+
+            values = adapter.deserialize(transition_params=transition_params)
+
             original_doActionFor(self, ob, action, wf_id=wf_id, *args, **kw)
             return adapter.after_transition_hook(
-                transition=action, disable_sync=disable_sync, **values)
+                transition=action, disable_sync=disable_sync,
+                transition_params=values)
 
         from Products.CMFPlone.WorkflowTool import WorkflowTool
         locals()['__patch_refs__'] = False

--- a/opengever/base/monkey/patches/workflowtool.py
+++ b/opengever/base/monkey/patches/workflowtool.py
@@ -1,0 +1,23 @@
+from opengever.base.monkey.patching import MonkeyPatch
+from zope.component import getAdapter
+
+
+class PatchWorkflowTool(MonkeyPatch):
+
+    def __call__(self):
+
+        def doActionFor(self, ob, action, wf_id=None, *args, **kw):
+            from opengever.base.transition import ITransitionExtender
+            adapter = getAdapter(ob, ITransitionExtender, name=action)
+            values = adapter.deserialize(**kw)
+            value = original_doActionFor(self, ob, action, wf_id=wf_id, *args, **kw)
+
+            adapter.after_transition_hook(transition=action, **values)
+
+            return value
+
+        from Products.CMFPlone.WorkflowTool import WorkflowTool
+        locals()['__patch_refs__'] = False
+        original_doActionFor = WorkflowTool.doActionFor
+
+        self.patch_refs(WorkflowTool, 'doActionFor', doActionFor)

--- a/opengever/base/tests/test_changed_date.py
+++ b/opengever/base/tests/test_changed_date.py
@@ -1,14 +1,15 @@
+from datetime import date
 from datetime import datetime
 from DateTime import DateTime
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
 from ftw.testing import freeze
-from opengever.testing import IntegrationTestCase
 from opengever.base.behaviors.changed import IChanged
 from opengever.base.indexes import changed_indexer
 from opengever.document.interfaces import ICheckinCheckoutManager
 from opengever.dossier.behaviors.dossier import IDossier
+from opengever.testing import IntegrationTestCase
 from plone import api
 from zope.component import getMultiAdapter
 import pytz
@@ -183,8 +184,10 @@ class TestChangedUpdateForTask(TestChangedUpdateBase):
     def test_changed_is_updated_when_workflow_status_is_changed(self):
         self.login(self.manager)
         with freeze(FREEZING_TIME):
-            api.content.transition(obj=self.task, transition='task-transition-delegate')
-        self.assert_changed_value(self.task, FREEZING_TIME)
+            api.content.transition(
+                obj=self.subtask,
+                transition='task-transition-resolved-tested-and-closed')
+            self.assert_changed_value(self.subtask, FREEZING_TIME)
 
 
 class TestChangedUpdateForProposal(TestChangedUpdateBase):
@@ -480,7 +483,11 @@ class TestChangedUpdateForForwarding(TestChangedUpdateBase):
     def test_changed_is_updated_when_workflow_status_is_changed(self):
         self.login(self.manager)
         with freeze(FREEZING_TIME):
-            api.content.transition(obj=self.inbox_forwarding, transition="forwarding-transition-assign-to-dossier")
+            api.content.transition(
+                obj=self.inbox_forwarding,
+                transition="forwarding-transition-reassign",
+                responsible=self.regular_user.id, responsible_client='fa')
+
         self.assert_changed_value(self.inbox_forwarding, FREEZING_TIME)
 
 

--- a/opengever/base/tests/test_changed_date.py
+++ b/opengever/base/tests/test_changed_date.py
@@ -486,7 +486,8 @@ class TestChangedUpdateForForwarding(TestChangedUpdateBase):
             api.content.transition(
                 obj=self.inbox_forwarding,
                 transition="forwarding-transition-reassign",
-                responsible=self.regular_user.id, responsible_client='fa')
+                transition_params={'responsible': self.regular_user.id,
+                                   'responsible_client':'fa'})
 
         self.assert_changed_value(self.inbox_forwarding, FREEZING_TIME)
 

--- a/opengever/base/tests/test_transition.py
+++ b/opengever/base/tests/test_transition.py
@@ -1,9 +1,39 @@
-from opengever.testing import IntegrationTestCase
-from opengever.base.transition import TransitionExtender
+from ftw.testbrowser import browsing
 from opengever.base.transition import ITransitionExtender
+from opengever.base.transition import TransitionExtender
+from opengever.testing import IntegrationTestCase
+from plone import api
+from zope.interface.verify import verifyClass
+from zope.schema._bootstrapinterfaces import WrongType
+import json
 
 
 class TestTransitionExtender(IntegrationTestCase):
 
+    api_headers = {
+        'Accept': 'application/json',
+        'Content-Type': 'application/json',
+    }
+
     def test_implements_interface(self):
         verifyClass(ITransitionExtender, TransitionExtender)
+
+    def test_raises_validation_error_when_called_invalid_via_python_api(self):
+        self.login(self.dossier_responsible)
+
+        wftool = api.portal.get_tool('portal_workflow')
+        with self.assertRaises(WrongType):
+            wftool.doActionFor(self.task, 'task-transition-modify-deadline',
+                               transition_params={'new_deadline':'XYZ'})
+
+    @browsing
+    def test_raises_badrequest_when_called_invalid_via_rest_api(self, browser):
+        self.login(self.dossier_responsible, browser=browser)
+
+        url = '{}/@workflow/task-transition-modify-deadline'.format(
+            self.task.absolute_url())
+
+        data = {'text': 'Deadline change!', 'new_deadline': 'not-valid'}
+        with browser.expect_http_error(400):
+            browser.open(url, method='POST', data=json.dumps(data),
+                         headers=self.api_headers)

--- a/opengever/base/tests/test_transition.py
+++ b/opengever/base/tests/test_transition.py
@@ -1,0 +1,9 @@
+from opengever.testing import IntegrationTestCase
+from opengever.base.transition import TransitionExtender
+from opengever.base.transition import ITransitionExtender
+
+
+class TestTransitionExtender(IntegrationTestCase):
+
+    def test_implements_interface(self):
+        verifyClass(ITransitionExtender, TransitionExtender)

--- a/opengever/base/transition.py
+++ b/opengever/base/transition.py
@@ -5,16 +5,30 @@ from zExceptions import BadRequest
 from zope.component import adapter
 from zope.component import queryMultiAdapter
 from zope.globalrequest import getRequest
+from zope.interface import Attribute
 from zope.interface import implementer
 from zope.interface import Interface
 from zope.publisher.interfaces.browser import IBrowserRequest
 from zope.schema import getFields
 from zope.schema.interfaces import ValidationError
 
-
 class ITransitionExtender(Interface):
-    """Transition extender interface
+    """Interface for adapters, to extend a specific worklow transition,
+    with additional required attributes and fuctionality.
     """
+
+    schemas = Attribute(
+        "A list of zope schemas, to define additional transition parameters.")
+
+    def after_transition_hook(transition, disable_sync, transition_params):
+        """Method which is called after the regular workflow transition (state change),
+        to run additional functionality.
+        """
+
+    def deserialize(transition_params):
+        """Method which deserialize and validate transition paramters according
+        to the fields defined in the schemas attribute.
+        """
 
 
 @implementer(ITransitionExtender)

--- a/opengever/base/transition.py
+++ b/opengever/base/transition.py
@@ -1,3 +1,4 @@
+from plone.dexterity.interfaces import IDexterityContent
 from plone.restapi.interfaces import IFieldDeserializer
 from z3c.form.interfaces import IManagerValidator
 from zExceptions import BadRequest
@@ -6,6 +7,7 @@ from zope.component import queryMultiAdapter
 from zope.globalrequest import getRequest
 from zope.interface import implementer
 from zope.interface import Interface
+from zope.publisher.interfaces.browser import IBrowserRequest
 from zope.schema import getFields
 from zope.schema.interfaces import ValidationError
 
@@ -16,13 +18,14 @@ class ITransitionExtender(Interface):
 
 
 @implementer(ITransitionExtender)
-@adapter(Interface)
+@adapter(IDexterityContent, IBrowserRequest)
 class TransitionExtender(object):
 
     schemas = []
 
-    def __init__(self, context):
+    def __init__(self, context, request):
         self.context = context
+        self.request = request
 
     def after_transition_hook(self, **kwargs):
         pass

--- a/opengever/base/transition.py
+++ b/opengever/base/transition.py
@@ -27,10 +27,10 @@ class TransitionExtender(object):
         self.context = context
         self.request = request
 
-    def after_transition_hook(self, **kwargs):
+    def after_transition_hook(self, transition, disable_sync, transition_params):
         pass
 
-    def deserialize(self, **data):
+    def deserialize(self, transition_params):
         validate_all = True
         schema_data = {}
         errors = []
@@ -40,7 +40,7 @@ class TransitionExtender(object):
             for name, field in getFields(schemata).items():
                 field_data = schema_data.setdefault(schemata, {})
 
-                if name in data:
+                if name in transition_params:
                     # Deserialize to field value
                     deserializer = queryMultiAdapter(
                         (field, self.context, getRequest()),
@@ -49,7 +49,7 @@ class TransitionExtender(object):
                         continue
 
                     try:
-                        value = deserializer(data[name])
+                        value = deserializer(transition_params[name])
                     except ValueError as e:
                         errors.append({
                             'message': e.message, 'field': name, 'error': e})

--- a/opengever/base/transition.py
+++ b/opengever/base/transition.py
@@ -57,6 +57,8 @@ class TransitionExtender(object):
                         field_data[name] = value
 
                 elif validate_all:
+                    field_data[name] = field.missing_value
+
                     try:
                         field.validate(field_data.get(name))
                     except ValidationError as e:

--- a/opengever/base/transition.py
+++ b/opengever/base/transition.py
@@ -1,12 +1,6 @@
-from opengever.task import _
-from opengever.task.interfaces import IDeadlineModifier
-from opengever.task.task import ITask
-from opengever.task.util import add_simple_response
 from plone.restapi.interfaces import IFieldDeserializer
-from plone.supermodel.model import Schema
 from z3c.form.interfaces import IManagerValidator
 from zExceptions import BadRequest
-from zope import schema
 from zope.component import adapter
 from zope.component import queryMultiAdapter
 from zope.globalrequest import getRequest
@@ -19,21 +13,6 @@ from zope.schema.interfaces import ValidationError
 class ITransitionExtender(Interface):
     """Transition extender interface
     """
-
-
-class IResponse(Schema):
-
-    text = schema.Text(
-        title=_('label_response', default="Response"),
-        required=False,
-        )
-
-
-class INewDeadline(Schema):
-
-    new_deadline = schema.Date(
-        title=_(u"label_new_deadline", default=u"New Deadline"),
-        required=True)
 
 
 @implementer(ITransitionExtender)
@@ -98,47 +77,3 @@ class TransitionExtender(object):
             raise BadRequest(errors)
 
         return values
-
-
-@implementer(ITransitionExtender)
-@adapter(ITask)
-class AcceptTransitionExtender(TransitionExtender):
-
-    schemas = [IResponse, ]
-
-    def after_transition_hook(self, transition, **kwargs):
-        add_simple_response(
-            self.context, transition=transition, text=kwargs.get('text'))
-
-
-@implementer(ITransitionExtender)
-@adapter(ITask)
-class ModifyDeadlineTransitionExtender(TransitionExtender):
-
-    schemas = [INewDeadline, ]
-
-    def after_transition_hook(self, transition, **kwargs):
-        IDeadlineModifier(self.context).modify_deadline(
-            kwargs['new_deadline'], kwargs.get('text'), transition)
-
-
-@implementer(ITransitionExtender)
-@adapter(ITask)
-class ResolveTransitionExtender(TransitionExtender):
-
-    schemas = [IResponse, ]
-
-    def after_transition_hook(self, transition, **kwargs):
-        add_simple_response(
-            self.context, transition=transition, text=kwargs.get('text'))
-
-
-@implementer(ITransitionExtender)
-@adapter(ITask)
-class CloseTransitionExtender(TransitionExtender):
-
-    schemas = [IResponse, ]
-
-    def after_transition_hook(self, transition, **kwargs):
-        add_simple_response(
-            self.context, transition=transition, text=kwargs.get('text'))

--- a/opengever/base/transition.py
+++ b/opengever/base/transition.py
@@ -1,0 +1,83 @@
+from opengever.task import _
+from opengever.task.interfaces import IDeadlineModifier
+from opengever.task.task import ITask
+from opengever.task.util import add_simple_response
+from plone.restapi.interfaces import IFieldDeserializer
+from plone.supermodel.model import Schema
+from z3c.form.interfaces import IManagerValidator
+from zExceptions import BadRequest
+from zope import schema
+from zope.component import adapter
+from zope.component import queryMultiAdapter
+from zope.globalrequest import getRequest
+from zope.interface import implementer
+from zope.interface import Interface
+from zope.schema import getFields
+from zope.schema.interfaces import ValidationError
+
+
+class ITransitionExtender(Interface):
+    """Transition extender interface
+    """
+
+
+
+@implementer(ITransitionExtender)
+@adapter(Interface)
+class TransitionExtender(object):
+
+    schemas = []
+
+    def __init__(self, context):
+        self.context = context
+
+    def after_transition_hook(self, **kwargs):
+        pass
+
+    def deserialize(self, **data):
+        validate_all = True
+        schema_data = {}
+        errors = []
+
+        for schemata in self.schemas:
+            for name, field in getFields(schemata).items():
+                field_data = schema_data.setdefault(schemata, {})
+
+                if name in data:
+                    # Deserialize to field value
+                    deserializer = queryMultiAdapter(
+                        (field, self.context, getRequest()),
+                        IFieldDeserializer)
+                    if deserializer is None:
+                        continue
+
+                    try:
+                        value = deserializer(data[name])
+                    except ValueError as e:
+                        errors.append({
+                            'message': e.message, 'field': name, 'error': e})
+                    except ValidationError as e:
+                        errors.append({
+                            'message': e.doc(), 'field': name, 'error': e})
+                    else:
+                        field_data[name] = value
+
+                elif validate_all:
+                    try:
+                        field.validate(field_data.get(name))
+                    except ValidationError as e:
+                        errors.append({
+                            'message': e.doc(), 'field': name, 'error': e})
+
+        # Validate schemata
+        for schemata, field_data in schema_data.items():
+            validator = queryMultiAdapter(
+                (self.context, getRequest(), None, schemata, None),
+                IManagerValidator)
+            for error in validator.validate(field_data):
+                errors.append({'error': error, 'message': error.message})
+
+        if errors:
+            raise BadRequest(errors)
+
+        return field_data

--- a/opengever/inbox/browser/close.py
+++ b/opengever/inbox/browser/close.py
@@ -37,7 +37,8 @@ class ForwardingCloseForm(Form):
         data, errors = self.extractData()
         if not errors:
             wftool = api.portal.get_tool('portal_workflow')
-            wftool.doActionFor(self.context, 'forwarding-transition-close', **data)
+            wftool.doActionFor(self.context, 'forwarding-transition-close',
+                               transition_params=data)
 
             return self.request.RESPONSE.redirect(self.context.absolute_url())
 

--- a/opengever/inbox/browser/close.py
+++ b/opengever/inbox/browser/close.py
@@ -1,7 +1,6 @@
 from opengever.inbox import _
 from opengever.task import _ as task_mf
-from opengever.task.interfaces import IYearfolderStorer
-from opengever.task.util import change_task_workflow_state
+from plone import api
 from plone.supermodel import model
 from plone.z3cform import layout
 from z3c.form import button
@@ -37,16 +36,10 @@ class ForwardingCloseForm(Form):
 
         data, errors = self.extractData()
         if not errors:
+            wftool = api.portal.get_tool('portal_workflow')
+            wftool.doActionFor(self.context, 'forwarding-transition-close', **data)
 
-            # close and store the forwarding in yearfolder
-            change_task_workflow_state(
-                self.context,
-                'forwarding-transition-close',
-                text=data.get('text'))
-
-            IYearfolderStorer(self.context).store_in_yearfolder()
-
-            return self.request.RESPONSE.redirect('.')
+            return self.request.RESPONSE.redirect(self.context.absolute_url())
 
     @button.buttonAndHandler(task_mf(u'button_cancel', default=u'Cancel'))
     def handle_cancel(self, action):

--- a/opengever/inbox/configure.zcml
+++ b/opengever/inbox/configure.zcml
@@ -71,4 +71,9 @@
       handler=".forwarding.set_dates"
       />
 
+  <adapter
+      factory=".transition.ForwardingCloseTransitionExtender"
+      name="forwarding-transition-close"
+      />
+
 </configure>

--- a/opengever/inbox/configure.zcml
+++ b/opengever/inbox/configure.zcml
@@ -76,4 +76,9 @@
       name="forwarding-transition-close"
       />
 
+  <adapter
+      factory=".transition.ForwardingAssignToDossierTransitionExtender"
+      name="forwarding-transition-assign-to-dossier"
+      />
+
 </configure>

--- a/opengever/inbox/configure.zcml
+++ b/opengever/inbox/configure.zcml
@@ -86,4 +86,9 @@
       name="forwarding-transition-reassign"
       />
 
+  <adapter
+      factory=".transition.ForwardingReassignTransitionExtender"
+      name="forwarding-transition-reassign-refused"
+      />
+
 </configure>

--- a/opengever/inbox/configure.zcml
+++ b/opengever/inbox/configure.zcml
@@ -81,4 +81,9 @@
       name="forwarding-transition-assign-to-dossier"
       />
 
+  <adapter
+      factory=".transition.ForwardingReassignTransitionExtender"
+      name="forwarding-transition-reassign"
+      />
+
 </configure>

--- a/opengever/inbox/locales/de/LC_MESSAGES/opengever.inbox.po
+++ b/opengever/inbox/locales/de/LC_MESSAGES/opengever.inbox.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-10-02 12:51+0000\n"
+"POT-Creation-Date: 2019-01-31 18:37+0000\n"
 "PO-Revision-Date: 2015-03-30 08:56+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -64,6 +64,11 @@ msgstr "Wählen Sie die verantwortliche Person bzw. den Eingangskorb des zustän
 msgid "label_assigned_inbox_tasks"
 msgstr "Erhaltene Aufgaben"
 
+#. Default: "Dossier"
+#: ./opengever/inbox/transition.py
+msgid "label_dossier"
+msgstr "Dossier"
+
 #. Default: "Forwarding added"
 #: ./opengever/inbox/activities.py
 msgid "label_forwarding_added"
@@ -113,4 +118,3 @@ msgstr "Weiterleitung abschliessen"
 #: ./opengever/inbox/yearfolder.py
 msgid "yearfolder_title"
 msgstr "Abgeschlossen ${year}"
-

--- a/opengever/inbox/locales/fr/LC_MESSAGES/opengever.inbox.po
+++ b/opengever/inbox/locales/fr/LC_MESSAGES/opengever.inbox.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-10-02 12:51+0000\n"
+"POT-Creation-Date: 2019-01-31 18:37+0000\n"
 "PO-Revision-Date: 2016-08-10 04:54+0000\n"
 "Last-Translator: Philippe Gross <gross.philippe@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-inbox/fr/>\n"
@@ -66,6 +66,11 @@ msgstr "Choix de la personne responsable ou de la boîte de réception du client
 msgid "label_assigned_inbox_tasks"
 msgstr "Tâches reçues"
 
+#. Default: "Dossier"
+#: ./opengever/inbox/transition.py
+msgid "label_dossier"
+msgstr "Dossier"
+
 #. Default: "Forwarding added"
 #: ./opengever/inbox/activities.py
 msgid "label_forwarding_added"
@@ -115,4 +120,3 @@ msgstr "Fermer le transfert"
 #: ./opengever/inbox/yearfolder.py
 msgid "yearfolder_title"
 msgstr "Fermé ${year}"
-

--- a/opengever/inbox/locales/opengever.inbox.pot
+++ b/opengever/inbox/locales/opengever.inbox.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-10-02 12:51+0000\n"
+"POT-Creation-Date: 2019-01-31 18:37+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -67,6 +67,11 @@ msgstr ""
 msgid "label_assigned_inbox_tasks"
 msgstr ""
 
+#. Default: "Dossier"
+#: ./opengever/inbox/transition.py
+msgid "label_dossier"
+msgstr ""
+
 #. Default: "Forwarding added"
 #: ./opengever/inbox/activities.py
 msgid "label_forwarding_added"
@@ -116,4 +121,3 @@ msgstr ""
 #: ./opengever/inbox/yearfolder.py
 msgid "yearfolder_title"
 msgstr ""
-

--- a/opengever/inbox/tests/test_accept.py
+++ b/opengever/inbox/tests/test_accept.py
@@ -1,7 +1,6 @@
 from ftw.builder import Builder
 from ftw.builder import create
 from opengever.task.browser.accept.utils import accept_forwarding_with_successor
-from opengever.task.browser.accept.utils import assign_forwarding_to_dossier
 from opengever.testing import FunctionalTestCase
 from plone.app.testing import TEST_USER_ID
 
@@ -18,21 +17,5 @@ class TestForwardingAccepting(FunctionalTestCase):
                             .within(inbox))
         task = accept_forwarding_with_successor(
             self.portal, forwarding.oguid.id, 'OK, thx.', dossier=dossier)
-
-        self.assertEquals('information', task.task_type)
-
-
-class TestAssignToDossier(FunctionalTestCase):
-
-    def test_successor_task_is_created_with_information_task_type(self):
-        inbox = create(Builder('inbox'))
-        dossier = create(Builder('dossier'))
-        forwarding = create(Builder('forwarding')
-                            .having(responsible=TEST_USER_ID,
-                                    responsible_client='org-unit-1',
-                                    issuer='hugo.boss')
-                            .within(inbox))
-        task = assign_forwarding_to_dossier(
-            self.portal, forwarding.oguid.id, dossier,  'OK, thx.')
 
         self.assertEquals('information', task.task_type)

--- a/opengever/inbox/tests/test_api_support.py
+++ b/opengever/inbox/tests/test_api_support.py
@@ -1,7 +1,10 @@
 from ftw.testbrowser import browsing
+from opengever.base.oguid import Oguid
 from opengever.inbox.yearfolder import get_current_yearfolder
 from opengever.task.adapters import IResponseContainer
+from opengever.task.browser.accept.utils import FORWARDING_SUCCESSOR_TYPE
 from opengever.testing import IntegrationTestCase
+from opengever.testing import obj2brain
 from plone import api
 import json
 
@@ -36,3 +39,48 @@ class TestAPITransitions(IntegrationTestCase):
         response = IResponseContainer(forwarding)[-1]
         self.assertEqual('Wird gemacht.', response.text)
         self.assertEqual('forwarding-transition-close', response.transition)
+
+    @browsing
+    def test_assign_to_dossier_stores_and_close_forwarding(self, browser):
+        self.login(self.secretariat_user, browser=browser)
+
+        url = '{}/@workflow/forwarding-transition-assign-to-dossier'.format(
+            self.inbox_forwarding.absolute_url())
+
+        dossier_uid = obj2brain(self.empty_dossier).UID
+        data = {'dossier': dossier_uid}
+        browser.open(url, method='POST',
+                     data=json.dumps(data), headers=self.api_headers)
+
+        self.assertEqual(200, browser.status_code)
+
+        yearfolder = get_current_yearfolder(context=self.inbox)
+        self.assertEqual(1, len(yearfolder.objectValues()))
+
+        forwarding = yearfolder.objectValues()[0]
+        self.assertEqual(
+            'forwarding-state-closed', api.content.get_state(forwarding))
+
+        response = IResponseContainer(forwarding)[-1]
+        task = self.empty_dossier.objectValues()[-1]
+        self.assertEqual(
+            'forwarding-transition-assign-to-dossier', response.transition)
+        self.assertEqual(Oguid.for_object(task).id, response.successor_oguid)
+
+    @browsing
+    def test_assign_to_dossier_open_successor_task(self, browser):
+        self.login(self.secretariat_user, browser=browser)
+
+        url = '{}/@workflow/forwarding-transition-assign-to-dossier'.format(
+            self.inbox_forwarding.absolute_url())
+
+        dossier_uid = obj2brain(self.empty_dossier).UID
+        data = {'dossier': dossier_uid}
+        browser.open(url, method='POST',
+                     data=json.dumps(data), headers=self.api_headers)
+
+        task = self.empty_dossier.objectValues()[-1]
+
+        self.assertEqual(FORWARDING_SUCCESSOR_TYPE, task.task_type)
+        self.assertEqual('inbox:fa', task.issuer)
+        self.assertEqual(u'F\xf6rw\xe4rding', task.title)

--- a/opengever/inbox/tests/test_api_support.py
+++ b/opengever/inbox/tests/test_api_support.py
@@ -1,0 +1,38 @@
+from ftw.testbrowser import browsing
+from opengever.inbox.yearfolder import get_current_yearfolder
+from opengever.task.adapters import IResponseContainer
+from opengever.testing import IntegrationTestCase
+from plone import api
+import json
+
+
+class TestAPITransitions(IntegrationTestCase):
+
+    api_headers = {
+        'Accept': 'application/json',
+        'Content-Type': 'application/json',
+    }
+
+    @browsing
+    def test_close_forwarding(self, browser):
+        self.login(self.secretariat_user, browser=browser)
+
+        url = '{}/@workflow/forwarding-transition-close'.format(
+            self.inbox_forwarding.absolute_url())
+
+        data = {'text': 'Wird gemacht.'}
+        browser.open(url, method='POST', data=json.dumps(data),
+                     headers=self.api_headers)
+
+        self.assertEqual(200, browser.status_code)
+
+        yearfolder = get_current_yearfolder(context=self.inbox)
+        self.assertEqual(1, len(yearfolder.objectValues()))
+
+        forwarding = yearfolder.objectValues()[0]
+        self.assertEqual(
+            'forwarding-state-closed', api.content.get_state(forwarding))
+
+        response = IResponseContainer(forwarding)[-1]
+        self.assertEqual('Wird gemacht.', response.text)
+        self.assertEqual('forwarding-transition-close', response.transition)

--- a/opengever/inbox/transition.py
+++ b/opengever/inbox/transition.py
@@ -45,7 +45,7 @@ class IChooseDossierSchema(Schema):
 @implementer(ITransitionExtender)
 @adapter(IForwarding, IBrowserRequest)
 class ForwardingDefaultTransitionExtender(DefaultTransitionExtender):
-    """Default transiition extender for all forwarding transitions."""
+    """Default transition extender for all forwarding transitions."""
 
 
 @implementer(ITransitionExtender)

--- a/opengever/inbox/transition.py
+++ b/opengever/inbox/transition.py
@@ -21,6 +21,7 @@ from plone.supermodel.model import Schema
 from z3c.relationfield.schema import RelationChoice
 from zope.component import adapter
 from zope.interface import implementer
+from zope.publisher.interfaces.browser import IBrowserRequest
 
 
 class IChooseDossierSchema(Schema):
@@ -42,13 +43,13 @@ class IChooseDossierSchema(Schema):
 
 
 @implementer(ITransitionExtender)
-@adapter(IForwarding)
+@adapter(IForwarding, IBrowserRequest)
 class ForwardingDefaultTransitionExtender(DefaultTransitionExtender):
     """Default transiition extender for all forwarding transitions."""
 
 
 @implementer(ITransitionExtender)
-@adapter(IForwarding)
+@adapter(IForwarding, IBrowserRequest)
 class ForwardingCloseTransitionExtender(ForwardingDefaultTransitionExtender):
     """Transition Extender for forwardings close transition, stores forwarding
     to yearfolder after state change.
@@ -62,7 +63,7 @@ class ForwardingCloseTransitionExtender(ForwardingDefaultTransitionExtender):
 
 
 @implementer(ITransitionExtender)
-@adapter(IForwarding)
+@adapter(IForwarding, IBrowserRequest)
 class ForwardingAssignToDossierTransitionExtender(ForwardingDefaultTransitionExtender):
     """Transition extender for forwarding closing
     """
@@ -119,6 +120,6 @@ class ForwardingAssignToDossierTransitionExtender(ForwardingDefaultTransitionExt
 
 
 @implementer(ITransitionExtender)
-@adapter(IForwarding)
+@adapter(IForwarding, IBrowserRequest)
 class ForwardingReassignTransitionExtender(ReassignTransitionExtender):
     """Transition extender for forwarding reassign transition."""

--- a/opengever/inbox/transition.py
+++ b/opengever/inbox/transition.py
@@ -1,0 +1,26 @@
+from opengever.base.transition import ITransitionExtender
+from opengever.inbox.forwarding import IForwarding
+from opengever.task.interfaces import IYearfolderStorer
+from opengever.task.transition import DefaultTransitionExtender
+from opengever.task.util import add_simple_response
+from zope.component import adapter
+from zope.interface import implementer
+
+
+@implementer(ITransitionExtender)
+@adapter(IForwarding)
+class ForwardingDefaultTransitionExtender(DefaultTransitionExtender):
+    """Default transiition extender for all forwarding transitions."""
+
+
+@implementer(ITransitionExtender)
+@adapter(IForwarding)
+class ForwardingCloseTransitionExtender(ForwardingDefaultTransitionExtender):
+    """Transition Extender for forwardings close transition,
+    """
+
+    def after_transition_hook(self, transition, disable_sync, **kwargs):
+        add_simple_response(
+            self.context, transition=transition, text=kwargs.get('text'))
+
+        IYearfolderStorer(self.context).store_in_yearfolder()

--- a/opengever/inbox/transition.py
+++ b/opengever/inbox/transition.py
@@ -13,6 +13,7 @@ from opengever.task.interfaces import IYearfolderStorer
 from opengever.task.task import ITask
 from opengever.task.transition import DefaultTransitionExtender
 from opengever.task.transition import IResponse
+from opengever.task.transition import ReassignTransitionExtender
 from opengever.task.transporter import IResponseTransporter
 from opengever.task.util import add_simple_response
 from plone.dexterity.utils import createContentInContainer
@@ -115,3 +116,9 @@ class ForwardingAssignToDossierTransitionExtender(ForwardingDefaultTransitionExt
             intids_mapping=intids_mapping)
 
         return task
+
+
+@implementer(ITransitionExtender)
+@adapter(IForwarding)
+class ForwardingReassignTransitionExtender(ReassignTransitionExtender):
+    """Transition extender for forwarding reassign transition."""

--- a/opengever/inbox/transition.py
+++ b/opengever/inbox/transition.py
@@ -1,10 +1,43 @@
+from opengever.activity import notification_center
+from opengever.base.oguid import Oguid
+from opengever.base.source import RepositoryPathSourceBinder
 from opengever.base.transition import ITransitionExtender
+from opengever.inbox import _
 from opengever.inbox.forwarding import IForwarding
+from opengever.ogds.base.utils import get_current_admin_unit
+from opengever.ogds.base.utils import get_current_org_unit
+from opengever.task.browser.accept.utils import _copy_documents_from_forwarding
+from opengever.task.browser.accept.utils import FORWARDING_SUCCESSOR_TYPE
+from opengever.task.interfaces import ISuccessorTaskController
 from opengever.task.interfaces import IYearfolderStorer
+from opengever.task.task import ITask
 from opengever.task.transition import DefaultTransitionExtender
+from opengever.task.transition import IResponse
+from opengever.task.transporter import IResponseTransporter
 from opengever.task.util import add_simple_response
+from plone.dexterity.utils import createContentInContainer
+from plone.supermodel.model import Schema
+from z3c.relationfield.schema import RelationChoice
 from zope.component import adapter
 from zope.interface import implementer
+
+
+class IChooseDossierSchema(Schema):
+
+    dossier = RelationChoice(
+        title=_(u'label_dossier', default=u'Dossier'),
+        source=RepositoryPathSourceBinder(
+            object_provides='opengever.dossier.behaviors.dossier.'
+            'IDossierMarker',
+            navigation_tree_query={
+                'object_provides': [
+                    'opengever.repository.repositoryroot.IRepositoryRoot',
+                    'opengever.repository.repositoryfolder.'
+                    'IRepositoryFolderSchema',
+                    'opengever.dossier.behaviors.dossier.IDossierMarker',
+                ]
+                }),
+        required=False)
 
 
 @implementer(ITransitionExtender)
@@ -16,7 +49,8 @@ class ForwardingDefaultTransitionExtender(DefaultTransitionExtender):
 @implementer(ITransitionExtender)
 @adapter(IForwarding)
 class ForwardingCloseTransitionExtender(ForwardingDefaultTransitionExtender):
-    """Transition Extender for forwardings close transition,
+    """Transition Extender for forwardings close transition, stores forwarding
+    to yearfolder after state change.
     """
 
     def after_transition_hook(self, transition, disable_sync, **kwargs):
@@ -24,3 +58,60 @@ class ForwardingCloseTransitionExtender(ForwardingDefaultTransitionExtender):
             self.context, transition=transition, text=kwargs.get('text'))
 
         IYearfolderStorer(self.context).store_in_yearfolder()
+
+
+@implementer(ITransitionExtender)
+@adapter(IForwarding)
+class ForwardingAssignToDossierTransitionExtender(ForwardingDefaultTransitionExtender):
+    """Transition extender for forwarding closing
+    """
+
+    schemas = [IResponse, IChooseDossierSchema]
+
+    def after_transition_hook(self, transition, disable_sync, **kwargs):
+        successor_task = self.create_successor_task(kwargs['dossier'])
+
+        add_simple_response(
+            self.context, transition=transition, text=kwargs.get('text'),
+            successor_oguid=Oguid.for_object(successor_task).id)
+
+        # set predecessor on successor task
+        successor_tc_task = ISuccessorTaskController(successor_task)
+        successor_tc_task.set_predecessor(Oguid.for_object(self.context).id)
+
+        IYearfolderStorer(self.context).store_in_yearfolder()
+        return successor_task
+
+    def create_successor_task(self, dossier):
+        # we need all task field values from the forwarding
+        fielddata = {}
+        for fieldname in ITask.names():
+            value = ITask.get(fieldname).get(self.context)
+            fielddata[fieldname] = value
+
+        # Reset issuer to the current inbox
+        fielddata['issuer'] = get_current_org_unit().inbox().id()
+
+        # Predefine the task_type to avoid tasks with an invalid task_type
+        fielddata['task_type'] = FORWARDING_SUCCESSOR_TYPE
+
+        # lets create a new task - the successor task
+        task = createContentInContainer(
+            dossier, 'opengever.task.task', **fielddata)
+
+        # Add issuer and responsible to the watchers of the newly created task
+        center = notification_center()
+        center.add_task_responsible(task, task.responsible)
+        center.add_task_issuer(task, task.issuer)
+
+        # copy documents and map the intids
+        intids_mapping = _copy_documents_from_forwarding(self.context, task)
+
+        # copy the responses
+        response_transporter = IResponseTransporter(task)
+        response_transporter.get_responses(
+            get_current_admin_unit().id(),
+            '/'.join(self.context.getPhysicalPath()),
+            intids_mapping=intids_mapping)
+
+        return task

--- a/opengever/inbox/transition.py
+++ b/opengever/inbox/transition.py
@@ -55,9 +55,9 @@ class ForwardingCloseTransitionExtender(ForwardingDefaultTransitionExtender):
     to yearfolder after state change.
     """
 
-    def after_transition_hook(self, transition, disable_sync, **kwargs):
+    def after_transition_hook(self, transition, disable_sync, transition_params):
         add_simple_response(
-            self.context, transition=transition, text=kwargs.get('text'))
+            self.context, transition=transition, text=transition_params.get('text'))
 
         IYearfolderStorer(self.context).store_in_yearfolder()
 
@@ -70,11 +70,11 @@ class ForwardingAssignToDossierTransitionExtender(ForwardingDefaultTransitionExt
 
     schemas = [IResponse, IChooseDossierSchema]
 
-    def after_transition_hook(self, transition, disable_sync, **kwargs):
-        successor_task = self.create_successor_task(kwargs['dossier'])
+    def after_transition_hook(self, transition, disable_sync, transition_params):
+        successor_task = self.create_successor_task(transition_params['dossier'])
 
         add_simple_response(
-            self.context, transition=transition, text=kwargs.get('text'),
+            self.context, transition=transition, text=transition_params.get('text'),
             successor_oguid=Oguid.for_object(successor_task).id)
 
         # set predecessor on successor task

--- a/opengever/latex/tests/test_dossiertasks.py
+++ b/opengever/latex/tests/test_dossiertasks.py
@@ -90,7 +90,6 @@ class TestDossierTasksLaTeXView(FunctionalTestCase):
                         'task_data_list': [{'completion_date': completion_date.strftime('%d.%m.%Y'),
                                             'deadline': expected_deadline.strftime('%d.%m.%Y'),
                                             'description': '',
-                                            'history': None,
                                             'responsible': 'Test User (test\\_user\\_1\\_)',
                                             'issuer': 'admin (admin)',
                                             'sequence_number': 1,
@@ -99,14 +98,19 @@ class TestDossierTasksLaTeXView(FunctionalTestCase):
                                            {'completion_date': None,
                                             'deadline': expected_deadline.strftime('%d.%m.%Y'),
                                             'description': '',
-                                            'history': None,
                                             'responsible': 'Test User (test\\_user\\_1\\_)',
                                             'issuer': 'Test User (test\\_user\\_1\\_)',
                                             'sequence_number': 2,
                                             'title': 'task 2',
                                             'type': ''}]}
 
-            self.assertEquals(expected, dossiertasks.get_render_arguments())
+            values = dossiertasks.get_render_arguments()
+            # remove history attribute from the dicts, history is tested in
+            # a separate test
+            [item.pop('history') for item in values['task_data_list']]
+
+            self.assertEquals(expected['label'], values['label'])
+            self.assertEquals(expected['task_data_list'], values['task_data_list'])
 
     @browsing
     def test_dossier_tasks_history(self, browser):

--- a/opengever/task/browser/accept/existingdossier.py
+++ b/opengever/task/browser/accept/existingdossier.py
@@ -111,7 +111,8 @@ class ChooseDossierStepForm(AcceptWizardFormMixin, Form):
                     task = wftool.doActionFor(
                         Oguid.parse(oguid).resolve_object(),
                         'forwarding-transition-assign-to-dossier',
-                        comment=transition_data['text'], **transition_data)
+                        comment=transition_data['text'],
+                        transition_params=transition_data)
 
                     IStatusMessage(self.request).addStatusMessage(
                         _(u'The forwarding is now assigned to the dossier'),

--- a/opengever/task/browser/accept/existingdossier.py
+++ b/opengever/task/browser/accept/existingdossier.py
@@ -3,20 +3,21 @@ views for the method when a user wants to work within an existing dossier and
 the task needs to be copied to this dossier (successor task).
 """
 
-from Products.CMFCore.utils import getToolByName
-from Products.Five.browser import BrowserView
-from Products.statusmessages.interfaces import IStatusMessage
 from opengever.base.browser.wizard.interfaces import IWizardDataStorage
+from opengever.base.oguid import Oguid
 from opengever.base.source import RepositoryPathSourceBinder
 from opengever.dossier.base import DOSSIER_STATES_OPEN
 from opengever.task import _
 from opengever.task.browser.accept.main import AcceptWizardFormMixin
+from opengever.task.browser.accept.utils import accept_forwarding_with_successor
 from opengever.task.browser.accept.utils import accept_task_with_successor
-from opengever.task.browser.accept.utils import \
-    accept_forwarding_with_successor
-from opengever.task.browser.accept.utils import assign_forwarding_to_dossier
+from plone import api
 from plone.supermodel.model import Schema
+from plone.uuid.interfaces import IUUID
 from plone.z3cform.layout import FormWrapper
+from Products.CMFCore.utils import getToolByName
+from Products.Five.browser import BrowserView
+from Products.statusmessages.interfaces import IStatusMessage
 from z3c.form.button import buttonAndHandler
 from z3c.form.field import Fields
 from z3c.form.form import Form
@@ -102,8 +103,16 @@ class ChooseDossierStepForm(AcceptWizardFormMixin, Form):
             # forwarding
             if dm.get(key, 'is_forwarding'):
                 if dm.get(key, 'is_only_assign'):
-                    task = assign_forwarding_to_dossier(
-                        self.context, oguid, data['dossier'], text)
+                    transition_data = {
+                        'text': text,
+                        'dossier': IUUID(data['dossier'])}
+
+                    wftool = api.portal.get_tool('portal_workflow')
+                    task = wftool.doActionFor(
+                        Oguid.parse(oguid).resolve_object(),
+                        'forwarding-transition-assign-to-dossier',
+                        comment=transition_data['text'], **transition_data)
+
                     IStatusMessage(self.request).addStatusMessage(
                         _(u'The forwarding is now assigned to the dossier'),
                         'info')

--- a/opengever/task/browser/accept/newdossier.py
+++ b/opengever/task/browser/accept/newdossier.py
@@ -5,6 +5,7 @@ dossier where the task is then filed.
 
 from opengever.base.browser.wizard.interfaces import IWizardDataStorage
 from opengever.base.form import WizzardWrappedAddForm
+from opengever.base.oguid import Oguid
 from opengever.base.source import RepositoryPathSourceBinder
 from opengever.base.validators import BaseRepositoryfolderValidator
 from opengever.globalindex.model.task import Task
@@ -13,9 +14,10 @@ from opengever.task import _
 from opengever.task.browser.accept.main import AcceptWizardFormMixin
 from opengever.task.browser.accept.utils import accept_forwarding_with_successor
 from opengever.task.browser.accept.utils import accept_task_with_successor
-from opengever.task.browser.accept.utils import assign_forwarding_to_dossier
+from plone import api
 from plone.dexterity.i18n import MessageFactory as dexterityMF
 from plone.supermodel.model import Schema
+from plone.uuid.interfaces import IUUID
 from plone.z3cform.layout import FormWrapper
 from Products.CMFCore.utils import getToolByName
 from Products.Five.browser import BrowserView
@@ -272,9 +274,14 @@ class DossierAddFormView(WizzardWrappedAddForm):
                 # forwarding
                 if dm.get(dmkey, 'is_forwarding'):
                     if dm.get(dmkey, 'is_only_assign'):
-                        task = assign_forwarding_to_dossier(
-                            self.context, oguid, dossier, dm.get(
-                                dmkey, 'text'))
+                        transition_data = {
+                            'text': dm.get(dmkey, 'text'),
+                            'dossier': IUUID(dossier)}
+                        wftool = api.portal.get_tool('portal_workflow')
+                        task = wftool.doActionFor(
+                            Oguid.parse(oguid).resolve_object(),
+                            'forwarding-transition-assign-to-dossier',
+                            comment=transition_data['text'], **transition_data)
 
                         IStatusMessage(self.request).addStatusMessage(
                             _(u'The forwarding is now assigned to the new '

--- a/opengever/task/browser/accept/newdossier.py
+++ b/opengever/task/browser/accept/newdossier.py
@@ -281,7 +281,8 @@ class DossierAddFormView(WizzardWrappedAddForm):
                         task = wftool.doActionFor(
                             Oguid.parse(oguid).resolve_object(),
                             'forwarding-transition-assign-to-dossier',
-                            comment=transition_data['text'], **transition_data)
+                            comment=transition_data['text'],
+                            transition_params=transition_data)
 
                         IStatusMessage(self.request).addStatusMessage(
                             _(u'The forwarding is now assigned to the new '

--- a/opengever/task/browser/accept/utils.py
+++ b/opengever/task/browser/accept/utils.py
@@ -19,6 +19,7 @@ from opengever.task.task import ITask
 from opengever.task.transporter import IResponseTransporter
 from opengever.task.util import change_task_workflow_state
 from plone.dexterity.utils import createContentInContainer
+from Products.CMFPlone.utils import safe_unicode
 from Products.Five.browser import BrowserView
 from zope.app.intid.interfaces import IIntIds
 from zope.component import getUtility
@@ -311,7 +312,7 @@ class AcceptTaskWorkflowTransitionView(BrowserView):
         if self.is_already_accepted():
             return ok_response()
 
-        text = self.request.get('text')
+        text = safe_unicode(self.request.get('text'))
         successor_oguid = self.request.get('successor_oguid')
 
         center = notification_center()

--- a/opengever/task/browser/accept/utils.py
+++ b/opengever/task/browser/accept/utils.py
@@ -224,13 +224,6 @@ def assign_forwarding_to_dossier(
         '/'.join(forwarding_obj.getPhysicalPath()),
         intids_mapping=intids_mapping)
 
-    # close and store the forwarding in yearfolder
-    change_task_workflow_state(
-        forwarding_obj,
-        'forwarding-transition-assign-to-dossier',
-        text=response_text,
-        successor_oguid=successor_tc_task.get_oguid())
-
     IYearfolderStorer(forwarding_obj).store_in_yearfolder()
 
     # successor

--- a/opengever/task/browser/assign.py
+++ b/opengever/task/browser/assign.py
@@ -3,10 +3,6 @@ from opengever.ogds.base.actor import ActorLookup
 from opengever.ogds.base.sources import AllUsersInboxesAndTeamsSourceBinder
 from opengever.ogds.base.utils import get_current_org_unit
 from opengever.task import _
-from opengever.task.activities import TaskReassignActivity
-from opengever.task.localroles import LocalRolesSetter
-from opengever.task.reminder.reminder import TaskReminder
-from opengever.task.response_syncer import sync_task_response
 from opengever.task.task import ITask
 from opengever.task.util import add_simple_response
 from opengever.task.util import getTransitionVocab
@@ -130,41 +126,9 @@ class AssignTaskForm(Form):
         return self.request.RESPONSE.redirect(api.portal.get().absolute_url())
 
     def reassign_task(self, **kwargs):
-        response = self.add_response(**kwargs)
-        # Revoke local roles for current responsible
-        LocalRolesSetter(self.context).revoke_roles()
-
-        TaskReminder().clear_reminder(self.context, self.context.responsible)
-
-        self.update_task(**kwargs)
-        notify(ObjectModifiedEvent(self.context))
-        self.record_activity(response)
-        self.sync_remote_task(**kwargs)
-
-    def update_task(self, **kwargs):
-        self.context.responsible_client = kwargs.get('responsible_client')
-        self.context.responsible = kwargs.get('responsible')
-
-    def add_response(self, **kwargs):
-        return add_simple_response(
-            self.context,
-            text=kwargs.get('text'),
-            field_changes=(
-                (ITask['responsible'], kwargs.get('responsible')),
-                (ITask['responsible_client'],
-                 kwargs.get('responsible_client')),),
-            transition=kwargs.get('transition'),
-            supress_events=True)
-
-    def sync_remote_task(self, **kwargs):
-        sync_task_response(self.context, self.request, 'workflow',
-                           kwargs.get('transition'),
-                           kwargs.get('text'),
-                           responsible=kwargs.get('responsible'),
-                           responsible_client=kwargs.get('responsible_client'))
-
-    def record_activity(self, response):
-        TaskReassignActivity(self.context, self.context.REQUEST, response).record()
+        wftool = api.portal.get_tool('portal_workflow')
+        wftool.doActionFor(self.context, kwargs.pop('transition'),
+                           comment=kwargs.get('text'), **kwargs)
 
     @buttonAndHandler(_(u'button_cancel', default=u'Cancel'))
     def handle_cancel(self, action):

--- a/opengever/task/browser/assign.py
+++ b/opengever/task/browser/assign.py
@@ -128,7 +128,7 @@ class AssignTaskForm(Form):
     def reassign_task(self, **kwargs):
         wftool = api.portal.get_tool('portal_workflow')
         wftool.doActionFor(self.context, kwargs.pop('transition'),
-                           comment=kwargs.get('text'), **kwargs)
+                           comment=kwargs.get('text'), transition_params=kwargs)
 
     @buttonAndHandler(_(u'button_cancel', default=u'Cancel'))
     def handle_cancel(self, action):

--- a/opengever/task/browser/close.py
+++ b/opengever/task/browser/close.py
@@ -21,6 +21,7 @@ from plone import api
 from plone.supermodel.model import Schema
 from plone.z3cform.layout import FormWrapper
 from Products.CMFCore.utils import getToolByName
+from Products.CMFPlone.utils import safe_unicode
 from Products.Five.browser import BrowserView
 from Products.statusmessages.interfaces import IStatusMessage
 from z3c.form.browser.checkbox import CheckBoxFieldWidget
@@ -280,7 +281,8 @@ class CloseTaskView(BrowserView):
     transition = 'task-transition-open-tested-and-closed'
 
     def __call__(self):
-        text = self.request.get('text')
+        text = safe_unicode(self.request.get('text'))
+
         if self.is_already_done():
             return ok_response(self.request)
 

--- a/opengever/task/browser/delegate/metadata.py
+++ b/opengever/task/browser/delegate/metadata.py
@@ -3,7 +3,6 @@ from ftw.keywordwidget.widget import KeywordWidget
 from opengever.ogds.base.sources import UsersContactsInboxesSourceBinder
 from opengever.task import _
 from opengever.task.browser.delegate.main import DelegateWizardFormMixin
-from opengever.task.browser.delegate.utils import create_subtasks
 from plone import api
 from plone.autoform.widgets import ParameterizedWidget
 from plone.supermodel.model import Schema
@@ -76,13 +75,14 @@ class UpdateMetadataForm(DelegateWizardFormMixin, Form):
     def handle_save(self, action):
         data, errors = self.extractData()
         if not errors:
-            responsibles = self.request.get('responsibles')
-            documents = self.request.get('documents', None) or []
-            subtasks = create_subtasks(self.context, responsibles,
-                                       documents, data)
+
+            data['responsibles'] = self.request.get('responsibles')
+            data['documents'] = self.request.get('documents', None) or []
+            wftool = api.portal.get_tool('portal_workflow')
+            wftool.doActionFor(self.context, 'task-transition-delegate', **data)
 
             msg = _(u'${subtask_num} subtasks were create.',
-                    mapping={u'subtask_num': len(subtasks)})
+                    mapping={u'subtask_num': len(data['responsibles'])})
             IStatusMessage(self.request).addStatusMessage(msg, 'info')
 
             url = self.context.absolute_url()

--- a/opengever/task/browser/delegate/metadata.py
+++ b/opengever/task/browser/delegate/metadata.py
@@ -79,7 +79,8 @@ class UpdateMetadataForm(DelegateWizardFormMixin, Form):
             data['responsibles'] = self.request.get('responsibles')
             data['documents'] = self.request.get('documents', None) or []
             wftool = api.portal.get_tool('portal_workflow')
-            wftool.doActionFor(self.context, 'task-transition-delegate', **data)
+            wftool.doActionFor(self.context, 'task-transition-delegate',
+                               transition_params=data)
 
             msg = _(u'${subtask_num} subtasks were create.',
                     mapping={u'subtask_num': len(data['responsibles'])})

--- a/opengever/task/browser/delegate/recipients.py
+++ b/opengever/task/browser/delegate/recipients.py
@@ -35,6 +35,7 @@ class ISelectRecipientsSchema(Schema):
         title=_(u'delegate_label_documents', default=u'Attach documents'),
         description=_(u'Select the related documents you wish to attach '
                       u'to the new subtasks.'),
+        missing_value=[],
         required=False,
         value_type=schema.Choice(
             source=vocabulary.attachable_documents_vocabulary))

--- a/opengever/task/configure.zcml
+++ b/opengever/task/configure.zcml
@@ -269,4 +269,9 @@
       name="task-transition-open-rejected"
       />
 
+  <adapter
+      factory=".transition.DefaultTransitionExtender"
+      name="task-transition-rejected-open"
+      />
+
 </configure>

--- a/opengever/task/configure.zcml
+++ b/opengever/task/configure.zcml
@@ -241,6 +241,11 @@
       />
 
   <adapter
+      factory=".transition.CloseTransitionExtender"
+      name="task-transition-in-progress-tested-and-closed"
+      />
+
+  <adapter
       factory=".transition.ReassignTransitionExtender"
       name="task-transition-reassign"
       />

--- a/opengever/task/configure.zcml
+++ b/opengever/task/configure.zcml
@@ -115,12 +115,6 @@
   <subscriber
       for="opengever.task.task.ITask
            Products.CMFCore.interfaces.IActionSucceededEvent"
-      handler=".handlers.reassign_team_tasks"
-      />
-
-  <subscriber
-      for="opengever.task.task.ITask
-           Products.CMFCore.interfaces.IActionSucceededEvent"
       handler=".handlers.cancel_subtasks"
       />
 

--- a/opengever/task/configure.zcml
+++ b/opengever/task/configure.zcml
@@ -127,12 +127,6 @@
   <subscriber
       for="opengever.task.task.ITask
            Products.CMFCore.interfaces.IActionSucceededEvent"
-      handler=".handlers.set_responsible_to_issuer_on_reject"
-      />
-
-  <subscriber
-      for="opengever.task.task.ITask
-           Products.CMFCore.interfaces.IActionSucceededEvent"
       handler=".handlers.start_next_task"
       />
 
@@ -268,6 +262,11 @@
   <adapter
       factory=".transition.DefaultTransitionExtender"
       name="task-transition-in-progress-cancelled"
+      />
+
+  <adapter
+      factory=".transition.RejectTransitionExtender"
+      name="task-transition-open-rejected"
       />
 
 </configure>

--- a/opengever/task/configure.zcml
+++ b/opengever/task/configure.zcml
@@ -219,4 +219,26 @@
       name="default"
       />
 
+  <!-- transitions -->
+  <adapter
+      factory=".transition.AcceptTransitionExtender"
+      name="task-transition-open-in-progress"
+      />
+
+  <adapter
+      factory=".transition.ModifyDeadlineTransitionExtender"
+      name="task-transition-modify-deadline"
+      />
+
+  <adapter
+      factory=".transition.ResolveTransitionExtender"
+      name="task-transition-in-progress-resolved"
+      />
+
+  <adapter
+      factory=".transition.CloseTransitionExtender"
+      name="task-transition-resolved-tested-and-closed"
+      />
+
+
 </configure>

--- a/opengever/task/configure.zcml
+++ b/opengever/task/configure.zcml
@@ -294,7 +294,7 @@
       />
 
   <adapter
-      factory=".transition.OpenPlanedTransitionExtender"
+      factory=".transition.OpenPlannedTransitionExtender"
       name="task-transition-planned-open"
       />
 

--- a/opengever/task/configure.zcml
+++ b/opengever/task/configure.zcml
@@ -246,6 +246,11 @@
       />
 
   <adapter
+      factory=".transition.CloseTransitionExtender"
+      name="task-transition-open-tested-and-closed"
+      />
+
+  <adapter
       factory=".transition.ReassignTransitionExtender"
       name="task-transition-reassign"
       />

--- a/opengever/task/configure.zcml
+++ b/opengever/task/configure.zcml
@@ -240,5 +240,10 @@
       name="task-transition-resolved-tested-and-closed"
       />
 
+  <adapter
+      factory=".transition.ReassignTransitionExtender"
+      name="task-transition-reassign"
+      />
+
 
 </configure>

--- a/opengever/task/configure.zcml
+++ b/opengever/task/configure.zcml
@@ -230,6 +230,11 @@
       />
 
   <adapter
+      factory=".transition.ResolveTransitionExtender"
+      name="task-transition-open-resolved"
+      />
+
+  <adapter
       factory=".transition.DefaultTransitionExtender"
       name="task-transition-resolved-in-progress"
       />

--- a/opengever/task/configure.zcml
+++ b/opengever/task/configure.zcml
@@ -230,6 +230,11 @@
       />
 
   <adapter
+      factory=".transition.DefaultTransitionExtender"
+      name="task-transition-resolved-in-progress"
+      />
+
+  <adapter
       factory=".transition.CloseTransitionExtender"
       name="task-transition-resolved-tested-and-closed"
       />

--- a/opengever/task/configure.zcml
+++ b/opengever/task/configure.zcml
@@ -279,4 +279,9 @@
       name="task-transition-rejected-open"
       />
 
+  <adapter
+      factory=".transition.DelegateTransitionExtender"
+      name="task-transition-delegate"
+      />
+
 </configure>

--- a/opengever/task/configure.zcml
+++ b/opengever/task/configure.zcml
@@ -283,4 +283,19 @@
       name="task-transition-delegate"
       />
 
+  <adapter
+      factory=".transition.DefaultTransitionExtender"
+      name="task-transition-rejected-skipped"
+      />
+
+  <adapter
+      factory=".transition.DefaultTransitionExtender"
+      name="task-transition-planned-skipped"
+      />
+
+  <adapter
+      factory=".transition.OpenPlanedTransitionExtender"
+      name="task-transition-planned-open"
+      />
+
 </configure>

--- a/opengever/task/configure.zcml
+++ b/opengever/task/configure.zcml
@@ -250,5 +250,19 @@
       name="task-transition-reassign"
       />
 
+  <adapter
+      factory=".transition.DefaultTransitionExtender"
+      name="task-transition-open-cancelled"
+      />
+
+  <adapter
+      factory=".transition.DefaultTransitionExtender"
+      name="task-transition-cancelled-open"
+      />
+
+  <adapter
+      factory=".transition.DefaultTransitionExtender"
+      name="task-transition-in-progress-cancelled"
+      />
 
 </configure>

--- a/opengever/task/handlers.py
+++ b/opengever/task/handlers.py
@@ -85,19 +85,6 @@ def set_dates(task, event):
         task.date_of_completion = None
 
 
-def reassign_team_tasks(task, event):
-    if event.action != 'task-transition-open-in-progress':
-        return
-
-    if task.is_team_task:
-        old_responsible = ITask(task).responsible
-        ITask(task).responsible = api.user.get_current().getId()
-        IResponseContainer(task)[-1].add_change(
-            'responsible',
-            _(u"label_responsible", default=u"Responsible"),
-            old_responsible, ITask(task).responsible)
-
-
 def cancel_subtasks(task, event):
     if event.action not in ['task-transition-in-progress-cancelled',
                             'task-transition-open-cancelled']:

--- a/opengever/task/handlers.py
+++ b/opengever/task/handlers.py
@@ -1,8 +1,5 @@
 from Acquisition import aq_inner, aq_parent
 from datetime import date
-from opengever.activity import notification_center
-from opengever.activity.roles import TASK_ISSUER_ROLE
-from opengever.activity.roles import TASK_RESPONSIBLE_ROLE
 from opengever.base.security import elevated_privileges
 from opengever.document.behaviors import IBaseDocument
 from opengever.globalindex.handlers.task import TaskSqlSyncer
@@ -95,19 +92,6 @@ def reassign_team_tasks(task, event):
     if task.is_team_task:
         old_responsible = ITask(task).responsible
         ITask(task).responsible = api.user.get_current().getId()
-        IResponseContainer(task)[-1].add_change(
-            'responsible',
-            _(u"label_responsible", default=u"Responsible"),
-            old_responsible, ITask(task).responsible)
-
-
-def set_responsible_to_issuer_on_reject(task, event):
-    if event.action == 'task-transition-open-rejected':
-        notification_center().remove_watcher_from_resource(task.oguid, task.responsible, TASK_RESPONSIBLE_ROLE)
-        notification_center().add_watcher_to_resource(task.oguid, task.issuer, TASK_ISSUER_ROLE)
-        notification_center().add_watcher_to_resource(task.oguid, task.issuer, TASK_RESPONSIBLE_ROLE)
-        old_responsible = ITask(task).responsible
-        task.responsible = task.issuer
         IResponseContainer(task)[-1].add_change(
             'responsible',
             _(u"label_responsible", default=u"Responsible"),

--- a/opengever/task/locales/de/LC_MESSAGES/opengever.task.po
+++ b/opengever/task/locales/de/LC_MESSAGES/opengever.task.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2018-12-10 07:42+0000\n"
+"POT-Creation-Date: 2019-01-31 18:37+0000\n"
 "PO-Revision-Date: 2015-02-17 18:41+0100\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -33,12 +33,6 @@ msgstr "Löschen"
 #: ./opengever/task/viewlets/templates/responseview.pt
 msgid "Edit"
 msgstr "Bearbeiten"
-
-#: ./opengever/task/response.py
-#: ./opengever/task/response_syncer/workflow.py
-#: ./opengever/task/util.py
-msgid "Issue state"
-msgstr "Status"
 
 #: ./opengever/task/response.py
 msgid "No response selected for removal."
@@ -192,10 +186,6 @@ msgstr "Speichern"
 msgid "cancel"
 msgstr "Abbrechen"
 
-#: ./opengever/task/response.py
-msgid "date_of_completion"
-msgstr "Erledigungsdatum"
-
 #. Default: "Select one or more responsibles. For each selected responsible a subtask will be created and assigned."
 #: ./opengever/task/browser/delegate/recipients.py
 msgid "delegate_help_responsible"
@@ -340,10 +330,12 @@ msgstr "Wann möchten Sie über das Fristende der Aufgabe benachrichtigt werden.
 
 #: ./opengever/task/browser/assign.py
 #: ./opengever/task/task.py
+#: ./opengever/task/transition.py
 msgid "help_responsible"
 msgstr "Wählen Sie die verantwortlichen Personen aus."
 
 #: ./opengever/task/task.py
+#: ./opengever/task/transition.py
 msgid "help_responsible_client"
 msgstr "Wählen Sie zuerst den Mandanten des Auftragnehmers, anschliessend den Auftragnehmer."
 
@@ -522,6 +514,7 @@ msgstr "Eigenschaften"
 
 #. Default: "New Deadline"
 #: ./opengever/task/browser/modify_deadline.py
+#: ./opengever/task/transition.py
 msgid "label_new_deadline"
 msgstr "Neue Frist"
 
@@ -575,6 +568,7 @@ msgstr "Erinnerung"
 
 #. Default: "Responsible Client"
 #: ./opengever/task/task.py
+#: ./opengever/task/transition.py
 msgid "label_resonsible_client"
 msgstr "Mandant des Auftragnehmers"
 

--- a/opengever/task/locales/fr/LC_MESSAGES/opengever.task.po
+++ b/opengever/task/locales/fr/LC_MESSAGES/opengever.task.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-12-10 07:42+0000\n"
+"POT-Creation-Date: 2019-01-31 18:37+0000\n"
 "PO-Revision-Date: 2017-12-03 11:47+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-task/fr/>\n"
@@ -35,12 +35,6 @@ msgstr "Supprimer"
 #: ./opengever/task/viewlets/templates/responseview.pt
 msgid "Edit"
 msgstr "Modifier"
-
-#: ./opengever/task/response.py
-#: ./opengever/task/response_syncer/workflow.py
-#: ./opengever/task/util.py
-msgid "Issue state"
-msgstr "Etat"
 
 #: ./opengever/task/response.py
 msgid "No response selected for removal."
@@ -194,10 +188,6 @@ msgstr "Enregistrer"
 msgid "cancel"
 msgstr "Annuler"
 
-#: ./opengever/task/response.py
-msgid "date_of_completion"
-msgstr "Date d'accomplissement"
-
 #. Default: "Select one or more responsibles. For each selected responsible a subtask will be created and assigned."
 #: ./opengever/task/browser/delegate/recipients.py
 msgid "delegate_help_responsible"
@@ -342,10 +332,12 @@ msgstr "Quand voulez-vous un rappel du délai de cette tâche."
 #. Default: "Select the responsible user from the client chosen above, or the corresponding inbox."
 #: ./opengever/task/browser/assign.py
 #: ./opengever/task/task.py
+#: ./opengever/task/transition.py
 msgid "help_responsible"
 msgstr "Sélectionnez les personnes responsables."
 
 #: ./opengever/task/task.py
+#: ./opengever/task/transition.py
 msgid "help_responsible_client"
 msgstr "Sélectionner d'abord le client du mandataire et ensuite le mandataire."
 
@@ -524,6 +516,7 @@ msgstr "Attributs"
 
 #. Default: "New Deadline"
 #: ./opengever/task/browser/modify_deadline.py
+#: ./opengever/task/transition.py
 msgid "label_new_deadline"
 msgstr "Nouveau délai"
 
@@ -577,6 +570,7 @@ msgstr "Rappel"
 
 #. Default: "Responsible Client"
 #: ./opengever/task/task.py
+#: ./opengever/task/transition.py
 msgid "label_resonsible_client"
 msgstr "Client responsable"
 

--- a/opengever/task/locales/opengever.task.pot
+++ b/opengever/task/locales/opengever.task.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2018-12-10 07:42+0000\n"
+"POT-Creation-Date: 2019-01-31 18:37+0000\n"
 "PO-Revision-Date: 2009-02-25 14:39+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -33,12 +33,6 @@ msgstr ""
 
 #: ./opengever/task/viewlets/templates/responseview.pt
 msgid "Edit"
-msgstr ""
-
-#: ./opengever/task/response.py
-#: ./opengever/task/response_syncer/workflow.py
-#: ./opengever/task/util.py
-msgid "Issue state"
 msgstr ""
 
 #: ./opengever/task/response.py
@@ -193,10 +187,6 @@ msgstr ""
 msgid "cancel"
 msgstr ""
 
-#: ./opengever/task/response.py
-msgid "date_of_completion"
-msgstr ""
-
 #. Default: "Select one or more responsibles. For each selected responsible a subtask will be created and assigned."
 #: ./opengever/task/browser/delegate/recipients.py
 msgid "delegate_help_responsible"
@@ -340,10 +330,12 @@ msgstr ""
 
 #: ./opengever/task/browser/assign.py
 #: ./opengever/task/task.py
+#: ./opengever/task/transition.py
 msgid "help_responsible"
 msgstr ""
 
 #: ./opengever/task/task.py
+#: ./opengever/task/transition.py
 msgid "help_responsible_client"
 msgstr ""
 
@@ -522,6 +514,7 @@ msgstr ""
 
 #. Default: "New Deadline"
 #: ./opengever/task/browser/modify_deadline.py
+#: ./opengever/task/transition.py
 msgid "label_new_deadline"
 msgstr ""
 
@@ -574,6 +567,7 @@ msgstr ""
 
 #. Default: "Responsible Client"
 #: ./opengever/task/task.py
+#: ./opengever/task/transition.py
 msgid "label_resonsible_client"
 msgstr ""
 

--- a/opengever/task/response.py
+++ b/opengever/task/response.py
@@ -272,7 +272,7 @@ class TaskTransitionResponseAddForm(form.AddForm, AutoExtensibleForm):
             intids.getId(item) for item in data['relatedItems']]
         wftool = api.portal.get_tool('portal_workflow')
         wftool.doActionFor(self.context, self.transition,
-                           comment=data.get('text'), **data)
+                           comment=data.get('text'), transition_params=data)
 
         return self.redirect()
 

--- a/opengever/task/response.py
+++ b/opengever/task/response.py
@@ -220,6 +220,9 @@ class TaskTransitionResponseAddForm(form.AddForm, AutoExtensibleForm):
 
     def update(self):
         super(TaskTransitionResponseAddForm, self).update()
+        if api.user.is_anonymous():
+            # Traversing request from relation widget
+            return ''
 
         disable_edit_bar()
 

--- a/opengever/task/response.py
+++ b/opengever/task/response.py
@@ -251,6 +251,18 @@ class TaskTransitionResponseAddForm(form.AddForm, AutoExtensibleForm):
     def is_final_transition(self):
         return self.transition in FINAL_TRANSITIONS
 
+    def is_api_supported_transition(self, transition):
+        return transition in ["task-transition-open-in-progress",
+                              "task-transition-in-progress-resolved",
+                              "task-transition-resolved-tested-and-closed",
+                              "task-transition-in-progress-tested-and-closed"
+                              "task-transition-open-tested-and-closed",
+                              "task-transition-open-rejected",
+                              "task-transition-in-progress-cancelled",
+                              "task-transition-open-cancelled",
+                              "task-transition-cancelled-open",
+                              "task-transition-rejected-open"]
+
     def updateActions(self):
         super(TaskTransitionResponseAddForm, self).updateActions()
         self.actions["save"].addClass("context")
@@ -267,6 +279,12 @@ class TaskTransitionResponseAddForm(form.AddForm, AutoExtensibleForm):
             errorMessage += '</ul>'
             self.status = errorMessage
             return None
+
+        elif self.is_api_supported_transition(data.pop('transition')):
+            wftool = api.portal.get_tool('portal_workflow')
+            wftool.doActionFor(self.context, self.transition,
+                               comment=data.get('text'), **data)
+            return self.request.RESPONSE.redirect(self.context.absolute_url())
 
         else:
             new_response = Response(data.get('text'))

--- a/opengever/task/response_syncer/workflow.py
+++ b/opengever/task/response_syncer/workflow.py
@@ -54,6 +54,9 @@ class WorkflowResponseSyncerReceiver(BaseResponseSyncerReceiver):
         wftool = api.portal.get_tool('portal_workflow')
         with elevated_privileges():
 
+            # Because this is already teh syncing of the foreign side, we need
+            # to disable syncing of the transition, otherwise it would end in
+            # a snycing-loop
             wftool.doActionFor(
                 self.context, transition, disable_sync=True, transition_params=data)
 

--- a/opengever/task/response_syncer/workflow.py
+++ b/opengever/task/response_syncer/workflow.py
@@ -55,6 +55,6 @@ class WorkflowResponseSyncerReceiver(BaseResponseSyncerReceiver):
         with elevated_privileges():
 
             wftool.doActionFor(
-                self.context, transition, disable_sync=True, **data)
+                self.context, transition, disable_sync=True, transition_params=data)
 
         notify(ObjectModifiedEvent(self.context))

--- a/opengever/task/task.py
+++ b/opengever/task/task.py
@@ -26,7 +26,6 @@ from opengever.task import _
 from opengever.task import FINAL_TASK_STATES
 from opengever.task import TASK_STATE_PLANNED
 from opengever.task import util
-from opengever.task.activities import TaskAddedActivity
 from opengever.task.interfaces import ITaskSettings
 from opengever.task.validators import NoCheckedoutDocsValidator
 from opengever.tasktemplates.interfaces import IFromSequentialTasktemplate
@@ -597,10 +596,6 @@ class Task(Container):
                     obj=next_task, transition='task-transition-planned-open')
 
             next_task.sync()
-
-            activity = TaskAddedActivity(
-                next_task, getRequest(), aq_parent(next_task))
-            activity.record()
 
     def sync(self):
         """Syncs the corresponding SQL task (globalindex).

--- a/opengever/task/tests/test_activities.py
+++ b/opengever/task/tests/test_activities.py
@@ -433,7 +433,7 @@ class TestSuccesssorHandling(FunctionalTestCase):
 
     def test_when_accepting_task_with_successor_responsible_watcher_gets_moved_from_predecessor_to_successsor(self):
         successor = accept_task_with_successor(
-            self.dossier, self.predecessor.oguid.id, 'Ok.')
+            self.dossier, self.predecessor.oguid.id, u'Ok.')
 
         predecessor_resource = self.center.fetch_resource(self.predecessor)
         successor_resource = self.center.fetch_resource(successor)

--- a/opengever/task/tests/test_api_support.py
+++ b/opengever/task/tests/test_api_support.py
@@ -306,3 +306,27 @@ class TestAPITransitions(IntegrationTestCase):
         response = IResponseContainer(self.subtask)[-1]
         self.assertEqual(u'Brauchen wir trotzdem.', response.text)
         self.assertEqual('task-transition-cancelled-open', response.transition)
+
+    @browsing
+    def test_reject_successful(self, browser):
+        self.login(self.regular_user, browser=browser)
+        self.set_workflow_state('task-state-open', self.subtask)
+
+        url = '{}/@workflow/task-transition-open-rejected'.format(
+            self.subtask.absolute_url())
+        data = {'text': u'Kann nicht.'}
+        browser.open(url, method='POST',
+                     data=json.dumps(data), headers=self.api_headers)
+
+        self.assertEqual(200, browser.status_code)
+        self.assertEqual('task-state-rejected',
+                         api.content.get_state(self.subtask))
+
+        response = IResponseContainer(self.subtask)[-1]
+        self.assertEqual(u'Kann nicht.', response.text)
+        self.assertEqual('task-transition-open-rejected', response.transition)
+        self.assertEqual([{'after': self.dossier_responsible.id,
+                           'id': 'responsible',
+                           'name': u'label_responsible',
+                           'before': self.regular_user.id}],
+                         response.changes)

--- a/opengever/task/tests/test_api_support.py
+++ b/opengever/task/tests/test_api_support.py
@@ -204,6 +204,27 @@ class TestAPITransitions(IntegrationTestCase):
                          response.transition)
 
     @browsing
+    def test_close_information_successful(self, browser):
+        self.login(self.regular_user, browser=browser)
+        self.subtask.task_type = 'information'
+        self.subtask.sync()
+        self.set_workflow_state('task-state-open', self.subtask)
+
+        url = '{}/@workflow/task-transition-open-tested-and-closed'.format(
+            self.subtask.absolute_url())
+        browser.open(url, method='POST', data=json.dumps({'text': 'Done!'}),
+                     headers=self.api_headers)
+
+        self.assertEqual(200, browser.status_code)
+        self.assertEqual('task-state-tested-and-closed',
+                         api.content.get_state(self.subtask))
+
+        response = IResponseContainer(self.subtask)[-1]
+        self.assertEqual(u'Done!', response.text)
+        self.assertEqual('task-transition-open-tested-and-closed',
+                         response.transition)
+
+    @browsing
     def test_resolve_successful(self, browser):
         self.login(self.regular_user, browser=browser)
 

--- a/opengever/task/tests/test_api_support.py
+++ b/opengever/task/tests/test_api_support.py
@@ -330,3 +330,22 @@ class TestAPITransitions(IntegrationTestCase):
                            'name': u'label_responsible',
                            'before': self.regular_user.id}],
                          response.changes)
+
+    @browsing
+    def test_reopen_rejected_task_successful(self, browser):
+        self.login(self.dossier_responsible, browser=browser)
+        self.set_workflow_state('task-state-rejected', self.subtask)
+
+        url = '{}/@workflow/task-transition-rejected-open'.format(
+            self.subtask.absolute_url())
+        data = {'text': u'Dann erledige ich das selbst.'}
+        browser.open(url, method='POST',
+                     data=json.dumps(data), headers=self.api_headers)
+
+        self.assertEqual(200, browser.status_code)
+        self.assertEqual('task-state-open',
+                         api.content.get_state(self.subtask))
+
+        response = IResponseContainer(self.subtask)[-1]
+        self.assertEqual(u'Dann erledige ich das selbst.', response.text)
+        self.assertEqual('task-transition-rejected-open', response.transition)

--- a/opengever/task/tests/test_api_support.py
+++ b/opengever/task/tests/test_api_support.py
@@ -183,6 +183,27 @@ class TestAPITransitions(IntegrationTestCase):
                          response.transition)
 
     @browsing
+    def test_close_direct_execution_successful(self, browser):
+        self.login(self.regular_user, browser=browser)
+        self.subtask.task_type = 'direct-execution'
+        self.subtask.sync()
+        self.set_workflow_state('task-state-in-progress', self.subtask)
+
+        url = '{}/@workflow/task-transition-in-progress-tested-and-closed'.format(
+            self.subtask.absolute_url())
+        browser.open(url, method='POST',
+                     data=json.dumps({'text': 'Done!'}), headers=self.api_headers)
+
+        self.assertEqual(200, browser.status_code)
+        self.assertEqual('task-state-tested-and-closed',
+                         api.content.get_state(self.subtask))
+
+        response = IResponseContainer(self.subtask)[-1]
+        self.assertEqual(u'Done!', response.text)
+        self.assertEqual('task-transition-in-progress-tested-and-closed',
+                         response.transition)
+
+    @browsing
     def test_resolve_successful(self, browser):
         self.login(self.regular_user, browser=browser)
 

--- a/opengever/task/tests/test_api_support.py
+++ b/opengever/task/tests/test_api_support.py
@@ -349,3 +349,22 @@ class TestAPITransitions(IntegrationTestCase):
         response = IResponseContainer(self.subtask)[-1]
         self.assertEqual(u'Dann erledige ich das selbst.', response.text)
         self.assertEqual('task-transition-rejected-open', response.transition)
+
+    @browsing
+    def test_revise_task_successful(self, browser):
+        self.login(self.dossier_responsible, browser=browser)
+        self.set_workflow_state('task-state-resolved', self.subtask)
+
+        url = '{}/@workflow/task-transition-resolved-in-progress'.format(
+            self.subtask.absolute_url())
+        data = {'text': u'Da stimmt was nicht.'}
+        browser.open(url, method='POST',
+                     data=json.dumps(data), headers=self.api_headers)
+
+        self.assertEqual(200, browser.status_code)
+        self.assertEqual('task-state-in-progress',
+                         api.content.get_state(self.subtask))
+
+        response = IResponseContainer(self.subtask)[-1]
+        self.assertEqual(u'Da stimmt was nicht.', response.text)
+        self.assertEqual('task-transition-resolved-in-progress', response.transition)

--- a/opengever/task/tests/test_close.py
+++ b/opengever/task/tests/test_close.py
@@ -28,10 +28,13 @@ class TestClosingForInformationTask(IntegrationTestCase):
             view=u'close-task-wizard-remote_close',
         )
         self.assertEquals('OK', browser.contents)
-        self.assertEquals('task-state-tested-and-closed', api.content.get_state(self.info_task))
+
+        self.assertEquals('task-state-tested-and-closed',
+                          api.content.get_state(self.info_task))
         response = IResponseContainer(self.info_task)[-1]
-        self.assertEquals(u'Danke sch\xf6n'.encode('utf-8'), response.text)
-        self.assertEquals('task-transition-open-tested-and-closed', response.transition)
+        self.assertEquals(u'Danke sch\xf6n', response.text)
+        self.assertEquals('task-transition-open-tested-and-closed',
+                          response.transition)
 
     @browsing
     def test_ignores_conflict_retries(self, browser):

--- a/opengever/task/tests/test_response_syncer.py
+++ b/opengever/task/tests/test_response_syncer.py
@@ -528,7 +528,7 @@ class TestWorkflowSyncer(FunctionalTestCase):
 
         wftool = api.portal.get_tool('portal_workflow')
         wftool.doActionFor(predecessor, 'task-transition-resolved-in-progress',
-                           text=u'Please extend chapter 2.4.')
+                           transition_params={'text': u'Please extend chapter 2.4.'})
 
         self.assertEquals('task-state-in-progress',
                           api.content.get_state(successor))
@@ -543,7 +543,7 @@ class TestWorkflowSyncer(FunctionalTestCase):
 
         wftool = api.portal.get_tool('portal_workflow')
         wftool.doActionFor(predecessor, 'task-transition-resolved-in-progress',
-                           text=u'\xe4\xe4hhh I am done!')
+                           transition_params={'text': u'\xe4\xe4hhh I am done!'})
 
         response = IResponseContainer(successor)[-1]
         self.assertEquals('task-transition-resolved-in-progress', response.transition)

--- a/opengever/task/tests/test_sequential_task_process.py
+++ b/opengever/task/tests/test_sequential_task_process.py
@@ -2,6 +2,7 @@ from datetime import date
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
+from opengever.activity.model import Resource
 from opengever.activity.model.activity import Activity
 from opengever.base.oguid import Oguid
 from opengever.tasktemplates.interfaces import IFromSequentialTasktemplate
@@ -169,7 +170,9 @@ class TestSequentialTaskProcess(IntegrationTestCase):
         self.assertEquals(
             'task-state-open', api.content.get_state(subtask2))
 
-        activity = Activity.query.all()[-1]
+        activities = Resource.query.get_by_oguid(
+            Oguid.for_object(subtask2)).activities
+        activity = activities[-1]
         self.assertEquals('task-added', activity.kind)
         self.assertEquals('Task opened', activity.label)
         self.assertEquals(u'New task opened by B\xe4rfuss K\xe4thi',

--- a/opengever/task/tests/test_task.py
+++ b/opengever/task/tests/test_task.py
@@ -8,8 +8,8 @@ from ftw.testbrowser.pages.dexterity import erroneous_fields
 from opengever.activity.model import Activity
 from opengever.core.testing import OPENGEVER_FUNCTIONAL_ACTIVITY_LAYER
 from opengever.task.adapters import IResponseContainer
+from opengever.task.adapters import Response
 from opengever.task.interfaces import ITaskSettings
-from opengever.task.response import Response
 from opengever.task.task import ITask
 from opengever.testing import FunctionalTestCase
 from plone import api

--- a/opengever/task/tests/test_team_tasks.py
+++ b/opengever/task/tests/test_team_tasks.py
@@ -126,11 +126,7 @@ class TestTeamTasks(IntegrationTestCase):
         expected = [{'before': u'team:1',
                      'after': 'kathi.barfuss',
                      'id': 'responsible',
-                     'name': u'label_responsible'},
-                    {'before': 'task-state-open',
-                     'after': 'task-state-in-progress',
-                     'id': 'review_state',
-                     'name': u'Issue state'}]
+                     'name': u'label_responsible'}]
 
         self.assertEqual(
             expected, [dict(change) for change in response.changes])
@@ -150,17 +146,17 @@ class TestTeamTasks(IntegrationTestCase):
         self.set_workflow_state('task-state-open', self.task)
 
         successor = accept_task_with_successor(
-            self.dossier, self.task.oguid.id, 'Ok.')
+            self.dossier, self.task.oguid.id, u'Ok.')
 
         self.assertEquals(self.regular_user.getId(), successor.responsible)
         self.assertEquals(
             self.regular_user.getId(), successor.get_sql_object().responsible)
         self.assertEquals(
             [{'after': 'kathi.barfuss', 'id': 'responsible',
-              'name': u'label_responsible', 'before': u'team:1'},
-             {'after': 'task-state-in-progress', 'id': 'review_state',
-              'name': u'Issue state', 'before': 'task-state-open'}],
+              'name': u'label_responsible', 'before': u'team:1'}],
             IResponseContainer(self.task)[-1].changes)
+        self.assertEquals('task-transition-open-in-progress',
+                          IResponseContainer(self.task)[-1].transition)
 
     @browsing
     def test_multi_admin_unit_team_task_edit_in_issuer_dossier(self, browser):

--- a/opengever/task/transition.py
+++ b/opengever/task/transition.py
@@ -5,6 +5,9 @@ from opengever.base.transition import TransitionExtender
 from opengever.ogds.base.sources import AllUsersInboxesAndTeamsSourceBinder
 from opengever.task import _
 from opengever.task.activities import TaskReassignActivity
+from opengever.task.browser.delegate.metadata import IUpdateMetadata
+from opengever.task.browser.delegate.recipients import ISelectRecipientsSchema
+from opengever.task.browser.delegate.utils import create_subtasks
 from opengever.task.interfaces import IDeadlineModifier
 from opengever.task.response_syncer import sync_task_response
 from opengever.task.task import ITask
@@ -173,3 +176,15 @@ class RejectTransitionExtender(DefaultTransitionExtender):
 
     def switch_responsible(self):
         self.context.responsible = ITask(self.context).issuer
+
+
+@implementer(ITransitionExtender)
+@adapter(ITask)
+class DelegateTransitionExtender(DefaultTransitionExtender):
+
+    schemas = [IUpdateMetadata, ISelectRecipientsSchema]
+
+    def after_transition_hook(self, transition, **kwargs):
+        create_subtasks(self.context,
+                        kwargs.pop('responsibles'),
+                        kwargs.get('documents', []), kwargs)

--- a/opengever/task/transition.py
+++ b/opengever/task/transition.py
@@ -1,0 +1,69 @@
+from opengever.base.transition import ITransitionExtender
+from opengever.base.transition import TransitionExtender
+from opengever.task import _
+from opengever.task.interfaces import IDeadlineModifier
+from opengever.task.task import ITask
+from opengever.task.util import add_simple_response
+from plone.supermodel.model import Schema
+from zope import schema
+from zope.component import adapter
+from zope.interface import implementer
+
+
+class IResponse(Schema):
+
+    text = schema.Text(
+        title=_('label_response', default="Response"),
+        required=False,
+        )
+
+
+class INewDeadline(Schema):
+
+    new_deadline = schema.Date(
+        title=_(u"label_new_deadline", default=u"New Deadline"),
+        required=True)
+
+
+@implementer(ITransitionExtender)
+@adapter(ITask)
+class AcceptTransitionExtender(TransitionExtender):
+
+    schemas = [IResponse, ]
+
+    def after_transition_hook(self, transition, **kwargs):
+        add_simple_response(
+            self.context, transition=transition, text=kwargs.get('text'))
+
+
+@implementer(ITransitionExtender)
+@adapter(ITask)
+class ModifyDeadlineTransitionExtender(TransitionExtender):
+
+    schemas = [INewDeadline, ]
+
+    def after_transition_hook(self, transition, **kwargs):
+        IDeadlineModifier(self.context).modify_deadline(
+            kwargs['new_deadline'], kwargs.get('text'), transition)
+
+
+@implementer(ITransitionExtender)
+@adapter(ITask)
+class ResolveTransitionExtender(TransitionExtender):
+
+    schemas = [IResponse, ]
+
+    def after_transition_hook(self, transition, **kwargs):
+        add_simple_response(
+            self.context, transition=transition, text=kwargs.get('text'))
+
+
+@implementer(ITransitionExtender)
+@adapter(ITask)
+class CloseTransitionExtender(TransitionExtender):
+
+    schemas = [IResponse, ]
+
+    def after_transition_hook(self, transition, **kwargs):
+        add_simple_response(
+            self.context, transition=transition, text=kwargs.get('text'))

--- a/opengever/task/transition.py
+++ b/opengever/task/transition.py
@@ -51,6 +51,17 @@ class INewResponsibleSchema(Schema):
 
 @implementer(ITransitionExtender)
 @adapter(ITask)
+class DefaultTransitionExtender(TransitionExtender):
+
+    schemas = [IResponse, ]
+
+    def after_transition_hook(self, transition, **kwargs):
+        add_simple_response(
+            self.context, transition=transition, text=kwargs.get('text'))
+
+
+@implementer(ITransitionExtender)
+@adapter(ITask)
 class AcceptTransitionExtender(TransitionExtender):
 
     schemas = [IResponse, ]

--- a/opengever/task/transition.py
+++ b/opengever/task/transition.py
@@ -1,13 +1,19 @@
 from opengever.base.transition import ITransitionExtender
 from opengever.base.transition import TransitionExtender
+from opengever.ogds.base.sources import AllUsersInboxesAndTeamsSourceBinder
 from opengever.task import _
+from opengever.task.activities import TaskReassignActivity
 from opengever.task.interfaces import IDeadlineModifier
+from opengever.task.response_syncer import sync_task_response
 from opengever.task.task import ITask
 from opengever.task.util import add_simple_response
 from plone.supermodel.model import Schema
 from zope import schema
 from zope.component import adapter
+from zope.event import notify
+from zope.globalrequest import getRequest
 from zope.interface import implementer
+from zope.lifecycleevent import ObjectModifiedEvent
 
 
 class IResponse(Schema):
@@ -22,6 +28,24 @@ class INewDeadline(Schema):
 
     new_deadline = schema.Date(
         title=_(u"label_new_deadline", default=u"New Deadline"),
+        required=True)
+
+
+class INewResponsibleSchema(Schema):
+
+    responsible = schema.Choice(
+        title=_(u"label_responsible", default=u"Responsible"),
+        description=_(u"help_responsible", default=""),
+        source=AllUsersInboxesAndTeamsSourceBinder(
+            only_current_inbox=True,
+            only_current_orgunit=True,
+            include_teams=True),
+        required=True)
+
+    responsible_client = schema.Choice(
+        title=_(u'label_resonsible_client', default=u'Responsible Client'),
+        description=_(u'help_responsible_client', default=u''),
+        vocabulary='opengever.ogds.base.OrgUnitsVocabularyFactory',
         required=True)
 
 
@@ -67,3 +91,38 @@ class CloseTransitionExtender(TransitionExtender):
     def after_transition_hook(self, transition, **kwargs):
         add_simple_response(
             self.context, transition=transition, text=kwargs.get('text'))
+
+
+@implementer(ITransitionExtender)
+@adapter(ITask)
+class ReassignTransitionExtender(TransitionExtender):
+
+    schemas = [IResponse, INewResponsibleSchema]
+
+    def after_transition_hook(self, transition, **kwargs):
+        former_responsible = ITask['responsible']
+        former_responsible_client = ITask['responsible_client']
+
+        changes =(
+            (former_responsible, kwargs.get('responsible')),
+            (former_responsible_client, kwargs.get('responsible_client')))
+        response = add_simple_response(
+            self.context, transition=transition, text=kwargs.get('text'),
+            field_changes=changes, supress_events=True)
+
+        self.change_responsible(**kwargs)
+        notify(ObjectModifiedEvent(self.context))
+        self.record_activity(response)
+
+        sync_task_response(self.context, getRequest(), 'workflow',
+                           transition,
+                           kwargs.get('text'),
+                           responsible=kwargs.get('responsible'),
+                           responsible_client=kwargs.get('responsible_client'))
+
+    def change_responsible(self, **kwargs):
+        self.context.responsible_client = kwargs.get('responsible_client')
+        self.context.responsible = kwargs.get('responsible')
+
+    def record_activity(self, response):
+        TaskReassignActivity(self.context, self.context.REQUEST, response).record()

--- a/opengever/task/transition.py
+++ b/opengever/task/transition.py
@@ -282,7 +282,7 @@ class DelegateTransitionExtender(DefaultTransitionExtender):
 
 @implementer(ITransitionExtender)
 @adapter(ITask, IBrowserRequest)
-class OpenPlanedTransitionExtender(DefaultTransitionExtender):
+class OpenPlannedTransitionExtender(DefaultTransitionExtender):
     """Default transition extender but supress default activity and
     record an TaskAdded activity instead."""
 

--- a/opengever/task/transition.py
+++ b/opengever/task/transition.py
@@ -30,6 +30,7 @@ from zope.globalrequest import getRequest
 from zope.interface import implementer
 from zope.intid.interfaces import IIntIds
 from zope.lifecycleevent import ObjectModifiedEvent
+from zope.publisher.interfaces.browser import IBrowserRequest
 
 
 class IResponse(Schema):
@@ -88,7 +89,7 @@ class INewResponsibleSchema(Schema):
 
 
 @implementer(ITransitionExtender)
-@adapter(ITask)
+@adapter(ITask, IBrowserRequest)
 class DefaultTransitionExtender(TransitionExtender):
 
     schemas = [IResponse, ]
@@ -123,7 +124,7 @@ class DefaultTransitionExtender(TransitionExtender):
 
 
 @implementer(ITransitionExtender)
-@adapter(ITask)
+@adapter(ITask, IBrowserRequest)
 class AcceptTransitionExtender(DefaultTransitionExtender):
 
     schemas = [IResponse, ]
@@ -149,7 +150,7 @@ class AcceptTransitionExtender(DefaultTransitionExtender):
 
 
 @implementer(ITransitionExtender)
-@adapter(ITask)
+@adapter(ITask, IBrowserRequest)
 class ModifyDeadlineTransitionExtender(TransitionExtender):
 
     schemas = [INewDeadline, ]
@@ -160,7 +161,7 @@ class ModifyDeadlineTransitionExtender(TransitionExtender):
 
 
 @implementer(ITransitionExtender)
-@adapter(ITask)
+@adapter(ITask, IBrowserRequest)
 class ResolveTransitionExtender(DefaultTransitionExtender):
 
     schemas = [IResponse, ]
@@ -174,7 +175,7 @@ class ResolveTransitionExtender(DefaultTransitionExtender):
 
 
 @implementer(ITransitionExtender)
-@adapter(ITask)
+@adapter(ITask, IBrowserRequest)
 class CloseTransitionExtender(DefaultTransitionExtender):
 
     schemas = [IResponse, ]
@@ -188,7 +189,7 @@ class CloseTransitionExtender(DefaultTransitionExtender):
 
 
 @implementer(ITransitionExtender)
-@adapter(ITask)
+@adapter(ITask, IBrowserRequest)
 class ReassignTransitionExtender(DefaultTransitionExtender):
 
     schemas = [IResponse, INewResponsibleSchema]
@@ -231,7 +232,7 @@ class ReassignTransitionExtender(DefaultTransitionExtender):
 
 
 @implementer(ITransitionExtender)
-@adapter(ITask)
+@adapter(ITask, IBrowserRequest)
 class RejectTransitionExtender(DefaultTransitionExtender):
     """Default task transition handling expect the responsible is switched
     to task's issuer.
@@ -265,7 +266,7 @@ class RejectTransitionExtender(DefaultTransitionExtender):
 
 
 @implementer(ITransitionExtender)
-@adapter(ITask)
+@adapter(ITask, IBrowserRequest)
 class DelegateTransitionExtender(DefaultTransitionExtender):
 
     schemas = [IUpdateMetadata, ISelectRecipientsSchema]
@@ -278,7 +279,7 @@ class DelegateTransitionExtender(DefaultTransitionExtender):
 
 
 @implementer(ITransitionExtender)
-@adapter(ITask)
+@adapter(ITask, IBrowserRequest)
 class OpenPlanedTransitionExtender(DefaultTransitionExtender):
     """Default transition extender but supress default activity and
     record an TaskAdded activity instead."""

--- a/opengever/task/transition.py
+++ b/opengever/task/transition.py
@@ -128,7 +128,6 @@ class AcceptTransitionExtender(DefaultTransitionExtender):
                            transition, kwargs.get('text'))
 
 
-
 @implementer(ITransitionExtender)
 @adapter(ITask)
 class ModifyDeadlineTransitionExtender(TransitionExtender):
@@ -180,7 +179,7 @@ class ReassignTransitionExtender(DefaultTransitionExtender):
         former_responsible = ITask['responsible']
         former_responsible_client = ITask['responsible_client']
 
-        changes =(
+        changes = (
             (former_responsible, kwargs.get('responsible')),
             (former_responsible_client, kwargs.get('responsible_client')))
         response = add_simple_response(

--- a/opengever/task/transition.py
+++ b/opengever/task/transition.py
@@ -93,6 +93,8 @@ class DefaultTransitionExtender(TransitionExtender):
             self.context, transition=transition, text=kwargs.get('text'))
 
         self.save_related_items(response, kwargs.get('relatedItems'))
+        sync_task_response(self.context, getRequest(), 'workflow',
+                           transition, kwargs.get('text'))
 
     def save_related_items(self, response, related_items):
         if not related_items:
@@ -122,6 +124,9 @@ class AcceptTransitionExtender(DefaultTransitionExtender):
             self.context, transition=transition, text=kwargs.get('text'))
 
         self.save_related_items(response, kwargs.get('relatedItems'))
+        sync_task_response(self.context, getRequest(), 'workflow',
+                           transition, kwargs.get('text'))
+
 
 
 @implementer(ITransitionExtender)
@@ -146,6 +151,8 @@ class ResolveTransitionExtender(DefaultTransitionExtender):
             self.context, transition=transition, text=kwargs.get('text'))
 
         self.save_related_items(response, kwargs.get('relatedItems'))
+        sync_task_response(self.context, getRequest(), 'workflow',
+                           transition, kwargs.get('text'))
 
 
 @implementer(ITransitionExtender)
@@ -159,6 +166,8 @@ class CloseTransitionExtender(DefaultTransitionExtender):
             self.context, transition=transition, text=kwargs.get('text'))
 
         self.save_related_items(response, kwargs.get('relatedItems'))
+        sync_task_response(self.context, getRequest(), 'workflow',
+                           transition, kwargs.get('text'))
 
 
 @implementer(ITransitionExtender)

--- a/opengever/task/transporter.py
+++ b/opengever/task/transporter.py
@@ -10,8 +10,8 @@ from opengever.base.utils import ok_response
 from opengever.document.versioner import Versioner
 from opengever.task.adapters import IResponse as IPersistentResponse
 from opengever.task.adapters import IResponseContainer
+from opengever.task.adapters import Response
 from opengever.task.interfaces import ITaskDocumentsTransporter
-from opengever.task.response import Response
 from opengever.task.task import ITask
 from opengever.task.util import get_documents_of_task
 from persistent.dict import PersistentDict

--- a/opengever/task/util.py
+++ b/opengever/task/util.py
@@ -1,10 +1,9 @@
 from collective.elephantvocabulary import wrap_vocabulary
-from opengever.globalindex.handlers.task import TaskSqlSyncer
 from opengever.ogds.base.actor import ActorLookup
 from opengever.ogds.models.team import Team
-from opengever.task import _
 from opengever.task.activities import TaskTransitionActivity
 from persistent.list import PersistentList
+from plone import api
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone import PloneMessageFactory as PMF
 from z3c.relationfield import RelationValue
@@ -147,29 +146,11 @@ def add_simple_response(task, text='', field_changes=None, added_object=None,
 
 
 def change_task_workflow_state(task, transition, **kwargs):
-    """Changes the workflow state of the task by executing a transition
-    and adding a response. The keyword args are passed to
-    add_simple_response, allowing to add additional information on the
-    created response.
+    """Changes the workflow state of the task.
     """
 
-    wftool = getToolByName(task, 'portal_workflow')
-
-    before = wftool.getInfoFor(task, 'review_state')
-    before = wftool.getTitleForStateOnType(before, task.Type())
-
-    response = add_simple_response(task, transition=transition, **kwargs)
-
-    wftool.doActionFor(task, transition)
-    TaskSqlSyncer(task, None).sync()
-
-    after = wftool.getInfoFor(task, 'review_state')
-    after = wftool.getTitleForStateOnType(after, task.Type())
-
-    response.add_change('review_state', _(u'Issue state'),
-                        before, after)
-    response.transition = transition
-    return response
+    wftool = api.portal.get_tool('portal_workflow')
+    wftool.doActionFor(task, transition, **kwargs)
 
 
 def get_documents_of_task(task, include_mails=False):

--- a/opengever/task/util.py
+++ b/opengever/task/util.py
@@ -93,7 +93,8 @@ def get_task_type_title(task_type, language):
 
 
 def add_simple_response(task, text='', field_changes=None, added_object=None,
-                        successor_oguid=None, supress_events=False, **kwargs):
+                        successor_oguid=None, supress_events=False,
+                        supress_activity=False, **kwargs):
     """Add a simple response which does (not change the task itself).
     `task`: task context
     `text`: fulltext
@@ -141,7 +142,9 @@ def add_simple_response(task, text='', field_changes=None, added_object=None,
     if not supress_events:
         notify(ObjectModifiedEvent(task))
 
-    TaskTransitionActivity(task, task.REQUEST, response).record()
+    if not supress_activity:
+        TaskTransitionActivity(task, task.REQUEST, response).record()
+
     return response
 
 

--- a/opengever/task/util.py
+++ b/opengever/task/util.py
@@ -153,7 +153,7 @@ def change_task_workflow_state(task, transition, **kwargs):
     """
 
     wftool = api.portal.get_tool('portal_workflow')
-    wftool.doActionFor(task, transition, **kwargs)
+    wftool.doActionFor(task, transition, transition_params=kwargs)
 
 
 def get_documents_of_task(task, include_mails=False):

--- a/opengever/tasktemplates/tests/test_activities.py
+++ b/opengever/tasktemplates/tests/test_activities.py
@@ -34,13 +34,14 @@ class TestTaskTemplateActivites(IntegrationTestCase):
         browser.click_on('Trigger')
 
         main_task = self.dossier.objectValues()[-1]
+        seq1, seq2 = main_task.objectValues()
 
         self.assertItemsEqual(
-            main_task.objectValues(),
+            [main_task, seq1, seq2],
             [activity.resource.oguid.resolve_object() for activity in Activity.query.all()])
 
         self.assertItemsEqual(
-            [u'task-added', u'task-added'],
+            [u'task-transition-open-in-progress', u'task-added', u'task-added'],
             [activity.kind for activity in Activity.query.all()])
 
     @browsing
@@ -69,9 +70,8 @@ class TestTaskTemplateActivites(IntegrationTestCase):
         browser.click_on('Trigger')
 
         main_task = self.dossier.objectValues()[-1]
+        seq1, seq2 = main_task.objectValues()
 
-        self.assertItemsEqual(
-            [task for task in main_task.objectValues()
-             if api.content.get_state(task) == 'task-state-open'],
-            [activity.resource.oguid.resolve_object()
-             for activity in Activity.query.all()])
+        self.assertItemsEqual([main_task, seq1],
+                              [activity.resource.oguid.resolve_object()
+                               for activity in Activity.query.all()])


### PR DESCRIPTION
Currently the default @workflow API endpoint, would have worked for some transitions, but you we’re not able to add additional arguments as the response text or other attributes, maybe even required ones. Because Plone does not support additional arguments on transition, all the functionality has been implemented on the different transition forms. But does form functionality, was skipped by plone, when running a transition with the API.

### technical solution
To extend workflow transitions with schema-fields and additional functionality, I introduced an adapter TransitionExtender. The named adapter which can be registered for each transition separately, is queried and called by the workflow tool. The monkey patched `doActionFor` method now validates the schema convienience and calls the `after_transition_hook` with the additional arguments passed by. 

Currently there are only TransitionExtenders implemented for task and inbox transitions, but can be used also for other form-based transition functionality, as we have for dossiers etc.

### implementation und currently supported transitions 
This PR only provide TransitionExtenders for the „simple“ one-adminunit task transitions. The support for the multi-adminunit will follow in a separate PR. See [documentation chapter](https://github.com/4teamwork/opengever.core/blob/pg_task_api_support/docs/public/dev-manual/api/tasks.rst) for more information. 

For all currently supported transitions, I moved the functionality from the form in to the TransitionExtender, to reduce complexity in the forms. They're now only triggering a workflow transition, passing by the form values.


