### PR TITLE
Add custom sortable_title indexer to avoid cropping of content titles.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -9,6 +9,7 @@ Changelog
 - Skip creation of the tasks pdf on resolve for dossiers without tasks. [phgross]
 - Give View permission to Editors on mails. [njohner]
 - Clear role assignments on contained object after forwarding creation. [njohner]
+- Add custom sortable_title indexer to avoid cropping of content titles. [njohner]
 - Testserver: add support for custom fixtures. [jone]
 - Reindex and store additionally supported bumblebee documents. [elioschmutz]
 - Fix scrubbing the server version out of the HTTP response headers. [Rotonen]

--- a/opengever/base/configure.zcml
+++ b/opengever/base/configure.zcml
@@ -351,6 +351,11 @@
       name="changed"
       />
 
+  <adapter
+      factory=".indexes.sortable_title"
+      name="sortable_title"
+      />
+
   <utility factory=".sequence.SequenceNumber" />
 
   <adapter factory=".quickupload.OGQuickUploadCapableFileFactory" />

--- a/opengever/base/model/__init__.py
+++ b/opengever/base/model/__init__.py
@@ -13,6 +13,9 @@ DEFAULT_LOCALE = 'de'
 SUPPORTED_LOCALES = ['de', 'fr', 'en']
 
 CONTENT_TITLE_LENGTH = 255
+# Sortable title length is a bit larger than content title due to number
+# padding (we make room for 5 numbers separated by dots and then some margin).
+SORTABLE_TITLE_LENGTH = CONTENT_TITLE_LENGTH + 45
 CSS_CLASS_LENGTH = 100
 EMAIL_LENGTH = 255
 FIRSTNAME_LENGTH = 255

--- a/opengever/core/upgrades/20190204085532_increase_sortable_title_max_length/upgrade.py
+++ b/opengever/core/upgrades/20190204085532_increase_sortable_title_max_length/upgrade.py
@@ -1,0 +1,23 @@
+from collective.indexing.interfaces import IIndexQueueProcessor
+from collective.indexing.queue import getQueue
+from ftw.upgrade import UpgradeStep
+from plone.dexterity.interfaces import IDexterityContent
+from plone import api
+from zope.component import getUtility
+
+
+class InccreaseSortableTitleMaxLength(UpgradeStep):
+    """Increase maximal length of sortable title.
+    """
+
+    deferrable = True
+
+    def __call__(self):
+        getQueue().hook()
+        processor = getUtility(IIndexQueueProcessor, name='ftw.solr')
+        catalog = api.portal.get_tool('portal_catalog')
+        for obj in self.objects({'object_provides': IDexterityContent.__identifier__},
+                                "Reindex sortable title."):
+            catalog.reindexObject(obj, idxs=['sortable_title'],
+                                  update_metadata=False)
+            processor.index(obj, ['sortable_title'])

--- a/opengever/document/tests/test_indexers.py
+++ b/opengever/document/tests/test_indexers.py
@@ -1,8 +1,8 @@
-from DateTime import DateTime
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testing import freeze
 from ftw.testing import MockTestCase
+from opengever.base.model import CONTENT_TITLE_LENGTH
 from opengever.core.testing import COMPONENT_UNIT_TESTING
 from opengever.document.checkout.manager import CHECKIN_CHECKOUT_ANNOTATIONS_KEY
 from opengever.document.indexers import DefaultDocumentIndexer
@@ -23,6 +23,17 @@ import pytz
 
 
 class TestDocumentIndexers(FunctionalTestCase):
+
+    def test_sortable_title_indexer_accomodates_padding_for_five_numbers(self):
+        numeric_part = "1 2 3 4 5"
+        alphabetic_part = u"".join(["a" for i in range(CONTENT_TITLE_LENGTH
+                                                       - len(numeric_part))])
+        title = numeric_part + alphabetic_part
+        document = create(Builder("document").titled(title))
+
+        self.assertEquals(
+            '0001 0002 0003 0004 0005' + alphabetic_part,
+            index_data_for(document).get('sortable_title'))
 
     def test_author_indexers(self):
         """check the author indexers."""

--- a/opengever/dossier/tests/test_indexer.py
+++ b/opengever/dossier/tests/test_indexer.py
@@ -1,4 +1,5 @@
 from opengever.base.behaviors.base import IOpenGeverBase
+from opengever.base.model import CONTENT_TITLE_LENGTH
 from opengever.dossier.behaviors.dossier import IDossier
 from opengever.dossier.behaviors.filing import IFilingNumber
 from opengever.sharing.events import LocalRolesAcquisitionActivated
@@ -14,6 +15,21 @@ from zope.lifecycleevent import ObjectModifiedEvent
 
 
 class TestDossierIndexers(IntegrationTestCase):
+
+    def test_sortable_title_indexer_accomodates_padding_for_five_numbers(self):
+        self.login(self.regular_user)
+        numeric_part = "1 2 3 4 5"
+        alphabetic_part = u"".join(["a" for i in range(CONTENT_TITLE_LENGTH
+                                                       - len(numeric_part))])
+        title = numeric_part + alphabetic_part
+
+        self.dossier.setTitle(title)
+        self.dossier.reindexObject(["sortable_title"])
+
+        self.assertEquals(
+            '0001 0002 0003 0004 0005' + alphabetic_part,
+            index_data_for(self.dossier).get('sortable_title'))
+
     def test_containing_dossier(self):
         self.login(self.regular_user)
 

--- a/opengever/mail/tests/test_indexers.py
+++ b/opengever/mail/tests/test_indexers.py
@@ -1,4 +1,5 @@
 from collective.dexteritytextindexer.interfaces import IDynamicTextIndexExtender  # noqa
+from opengever.base.model import CONTENT_TITLE_LENGTH
 from opengever.mail.indexer import checked_out
 from opengever.testing import index_data_for
 from opengever.testing import IntegrationTestCase
@@ -6,6 +7,20 @@ from zope.component import getAdapter
 
 
 class TestMailIndexers(IntegrationTestCase):
+
+    def test_sortable_title_indexer_accomodates_padding_for_five_numbers(self):
+        self.login(self.regular_user)
+        numeric_part = "1 2 3 4 5"
+        alphabetic_part = u"".join(["a" for i in range(CONTENT_TITLE_LENGTH
+                                                       - len(numeric_part))])
+        title = numeric_part + alphabetic_part
+
+        self.mail_eml.setTitle(title)
+        self.mail_eml.reindexObject(["sortable_title"])
+
+        self.assertEquals(
+            '0001 0002 0003 0004 0005' + alphabetic_part,
+            index_data_for(self.mail_eml).get('sortable_title'))
 
     def test_keywords_field_is_indexed_in_Subject_index(self):
         self.login(self.regular_user)

--- a/opengever/repository/configure.zcml
+++ b/opengever/repository/configure.zcml
@@ -28,11 +28,6 @@
       name="blocked_local_roles"
       />
 
-  <adapter
-      factory=".indexers.sortable_title"
-      name="sortable_title"
-      />
-
   <adapter factory=".repositoryfolder.NameFromTitle" />
 
   <adapter factory=".repositoryroot.RepositoryRootNameFromTitle" />

--- a/opengever/repository/indexers.py
+++ b/opengever/repository/indexers.py
@@ -1,13 +1,6 @@
 from Acquisition import aq_inner
 from opengever.repository.repositoryfolder import IRepositoryFolder
-from plone.i18n.normalizer.base import mapUnicode
 from plone.indexer import indexer
-from Products.CMFPlone.CatalogTool import MAX_SORTABLE_TITLE
-from Products.CMFPlone.CatalogTool import num_sort_regex
-from Products.CMFPlone.CatalogTool import zero_fill
-from Products.CMFPlone.utils import safe_callable
-from Products.CMFPlone.utils import safe_unicode
-import re
 
 
 @indexer(IRepositoryFolder)
@@ -24,39 +17,3 @@ def title_fr_indexer(obj):
 def blocked_local_roles(obj):
     """Return whether acquisition is blocked or not."""
     return bool(getattr(aq_inner(obj), '__ac_local_roles_block__', False))
-
-
-@indexer(IRepositoryFolder)
-def sortable_title(obj):
-    """Custom sortable_title indexer for RepositoryFolders.
-
-    This implementation doesn't count space needed for zero padded numbers
-    towards the maximum length. We need this for repofolders because otherwise
-    for deeply nested folders the reference numbers alone eat up all
-    the available space (40 characters).
-    """
-    title = getattr(obj, 'Title', None)
-    if title is not None:
-        if safe_callable(title):
-            title = title()
-
-        if isinstance(title, basestring):
-            # Ignore case, normalize accents, strip spaces
-            sortabletitle = mapUnicode(safe_unicode(title)).lower().strip()
-            # Replace numbers with zero filled numbers
-            sortabletitle = num_sort_regex.sub(zero_fill, sortabletitle)
-
-            # Determine the length of the sortable title
-            padded_numbers = re.findall(num_sort_regex, sortabletitle)
-            max_length = MAX_SORTABLE_TITLE + sum([
-                len(match) - len(match.lstrip('0'))
-                for match in padded_numbers
-            ])
-
-            # Truncate to prevent bloat, take bits from start and end
-            if len(sortabletitle) > max_length:
-                start = sortabletitle[:(max_length - 13)]
-                end = sortabletitle[-10:]
-                sortabletitle = start + '...' + end
-            return sortabletitle.encode('utf-8')
-    return ''

--- a/opengever/repository/tests/test_indexer.py
+++ b/opengever/repository/tests/test_indexer.py
@@ -1,32 +1,34 @@
 from ftw.builder import Builder
 from ftw.builder import create
+from opengever.base.model import CONTENT_TITLE_LENGTH
 from opengever.testing import IntegrationTestCase
 from opengever.sharing.events import LocalRolesAcquisitionActivated
 from opengever.sharing.events import LocalRolesAcquisitionBlocked
-from opengever.repository.indexers import sortable_title
+from opengever.base.indexes import sortable_title
 from zope.event import notify
 
 
 class TestRepositoryFolderIndexers(IntegrationTestCase):
 
-    def test_sortable_title_index_ignores_refernce_number_length(self):
+    def test_sortable_title_index_accomodates_five_numbers_without_cropping(self):
         self.login(self.secretariat_user)
 
+        title = u"".join(["a" for i in range(CONTENT_TITLE_LENGTH)])
         # create a 5 fold nested folder
         repofolder = reduce(
             lambda repofolder, level: create(
                 Builder('repository')
                 .within(repofolder)
                 .having(
-                    title_de=u'Vertr\xe4ge {}'.format(level),
-                    title_fr=u'Contrats {}'.format(level),
+                    title_de=title,
+                    title_fr=title,
                 )),
-            range(5),
+            range(3),
             self.leaf_repofolder,
         )
 
         self.assertEquals(
-            '0001.0001.0001.0001.0001.0001.0001. vertrage 0004',
+            '0001.0001.0001.0001.0001. ' + title,
             sortable_title(repofolder)())
 
     def test_blocked_local_roles(self):

--- a/opengever/testing/tests/test_integration_test_case.py
+++ b/opengever/testing/tests/test_integration_test_case.py
@@ -69,7 +69,7 @@ class TestIntegrationTestCase(IntegrationTestCase):
         self.maxDiff = None
         self.assertDictContainsSubset(
             {'Type': u'Business Case Dossier',
-             'sortable_title': 'vertrage mit der kantonalen...verwaltung'},
+             'sortable_title': 'vertrage mit der kantonalen finanzverwaltung'},
             self.get_catalog_indexdata(self.dossier))
 
     def test_get_catalog_metadata(self):


### PR DESCRIPTION
Add custom `sortable_title` indexer to avoid cropping of content titles. We set the maximal length for the `sortable_title` larger than the maximal allowed content title length, to allow for number padding without cropping long titles.

resolves #4398 