### PR TITLE
Notifications: Defer sending mails until the end of the transaction

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2019.1.0 (unreleased)
 ---------------------
 
+- Notifications: Defer sending mails until end of transaction. [lgraf]
 - Implement WebActions storage and REST API. [lgraf]
 - Add simple cache invalidation mechanism for javascript included in templates. [deiferni]
 - Fix bug in paragraph agendaitem item_number display. [njohner]

--- a/opengever/activity/error_handling.py
+++ b/opengever/activity/error_handling.py
@@ -1,0 +1,37 @@
+from plone import api
+from ZODB.POSException import ConflictError
+from zope.globalrequest import getRequest
+from zope.i18nmessageid import MessageFactory
+import logging
+import traceback
+
+
+logger = logging.getLogger('opengever.activity')
+_ = MessageFactory("opengever.activity")
+
+
+class NotificationErrorHandler(object):
+    """Context manager to prevent notification dispatching from causing
+    issues through unhandled exceptions during dispatch.
+    """
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, _type, exc, _traceback):
+        if isinstance(exc, ConflictError):
+            return False  # Propagate
+
+        if exc is not None:
+            self.show_not_notified_message()
+
+            tb = ''.join(traceback.format_exception(_type, exc, _traceback))
+            logger.error('Exception while adding an activity:\n{}'.format(tb))
+            return True
+
+    def show_not_notified_message(self):
+        msg = _(u'msg_error_not_notified',
+                default=u'A problem has occurred during the notification '
+                'creation. Notification could not or only partially '
+                'produced.')
+        api.portal.show_message(msg, getRequest(), type='warning')

--- a/opengever/activity/tests/test_mail.py
+++ b/opengever/activity/tests/test_mail.py
@@ -3,10 +3,15 @@ from ftw.builder import create
 from ftw.mail.utils import get_header
 from ftw.testbrowser import browsing
 from ftw.testing.mailing import Mailing
+from opengever.activity.hooks import insert_notification_defaults
+from opengever.activity.mailer import process_mail_queue
 from opengever.activity.roles import TASK_RESPONSIBLE_ROLE
 from opengever.globalindex.model.task import Task
+from opengever.task.activities import TaskAddedActivity
 from opengever.testing import IntegrationTestCase
+from zope.globalrequest import getRequest
 import email
+import transaction
 
 
 class TestEmailNotification(IntegrationTestCase):
@@ -52,6 +57,8 @@ class TestEmailNotification(IntegrationTestCase):
     def test_subject_is_title(self, browser):
         self.login(self.dossier_responsible, browser)
         self.create_task_via_browser(browser)
+        process_mail_queue()
+
         mail = email.message_from_string(Mailing(self.portal).pop())
         self.assertEquals('GEVER Activity: Test Task', mail.get('Subject'))
 
@@ -59,13 +66,21 @@ class TestEmailNotification(IntegrationTestCase):
     def test_notification_summary_is_split_into_paragraphs(self, browser):
         self.login(self.dossier_responsible, browser)
         self.create_task_via_browser(browser)
+        process_mail_queue()
+
+        # Discard the first mail
+        Mailing(self.portal).pop()
+
         # XXX - did not find a neater way to get the task quickly
         browser.open(Task.query.all()[-1], view='addcommentresponse')
         browser.fill({'Response': 'Multi\n\nline\ncomment'})
         browser.css('#form-buttons-save').first.click()
+        process_mail_queue()
+
         mails = Mailing(self.portal).get_messages()
-        self.assertEqual(len(mails), 2)
-        raw_mail = mails[-1]
+        self.assertEqual(len(mails), 1)
+        raw_mail = mails[0]
+
         self.assertIn('<p>Multi</p>', raw_mail)
         self.assertIn('<p></p>', raw_mail)
         self.assertIn('<p>line</p>', raw_mail)
@@ -75,6 +90,10 @@ class TestEmailNotification(IntegrationTestCase):
     def test_notification_mailer_handle_empty_activity_description(self, browser):
         self.login(self.dossier_responsible, browser)
         self.create_task_via_browser(browser)
+        process_mail_queue()
+
+        # Discard the first mail
+        Mailing(self.portal).pop()
 
         # reassign task
         task = self.dossier.objectValues()[-1]
@@ -84,16 +103,22 @@ class TestEmailNotification(IntegrationTestCase):
         form = browser.find_form_by_field('Responsible')
         form.find_widget('Responsible').fill(responsible)
         browser.click_on('Assign')
+        process_mail_queue()
 
         mails = Mailing(self.portal).get_messages()
-        self.assertEqual(len(mails), 2)
-        raw_mail = mails[-1]
+        mails.sort(key=lambda data: email.message_from_string(data).get('To'))
+
+        self.assertEqual(len(mails), 1)
+        raw_mail = mails[0]
         self.assertIn('Reassigned from', raw_mail)
 
     @browsing
     def test_from_and_to_addresses(self, browser):
         self.login(self.dossier_responsible, browser)
+
         self.create_task_via_browser(browser)
+        process_mail_queue()
+
         mail = email.message_from_string(Mailing(self.portal).pop())
         self.assertEquals('foo@example.com', mail.get('To'))
         self.assertEquals('Ziegler Robert <robert.ziegler@gever.local>', get_header(mail, 'From'))
@@ -101,7 +126,10 @@ class TestEmailNotification(IntegrationTestCase):
     @browsing
     def test_task_title_is_linked_to_resolve_notification_view(self, browser):
         self.login(self.dossier_responsible, browser)
+
         self.create_task_via_browser(browser)
+        process_mail_queue()
+
         raw_mail = Mailing(self.portal).pop()
         link = '<p><a href=3D"http://nohost/plone/@@resolve_notification?notification=\n_id=3D1">Test Task</a></p>'
         self.assertIn(link, raw_mail.strip())
@@ -114,6 +142,8 @@ class TestEmailNotification(IntegrationTestCase):
         self.login(self.dossier_responsible, browser)
         browser.open(self.dossier, view='++add++opengever.task.task')
         self.create_task_via_browser(browser)
+        process_mail_queue()
+
         self.assertEquals(1, len(Mailing(self.portal).get_messages()))
         mail = email.message_from_string(Mailing(self.portal).pop())
         self.assertEquals('foo@example.com', get_header(mail, 'To'))
@@ -126,6 +156,55 @@ class TestEmailNotification(IntegrationTestCase):
         self.login(self.dossier_responsible, browser)
         browser.open(self.dossier, view='++add++opengever.task.task')
         self.create_task_via_browser(browser, inbox=True)
+        process_mail_queue()
+
         self.assertEquals(1, len(Mailing(self.portal).get_messages()))
         mail = email.message_from_string(Mailing(self.portal).pop())
         self.assertEquals('foo@example.com', get_header(mail, 'To'))
+
+
+class TestNotificationMailsAndSavepoints(IntegrationTestCase):
+
+    features = (
+        'activity',
+    )
+
+    def setUp(self):
+        # Overridden - don't perform IntegrationTestCase's usual setup,
+        # because that would replace the MailHost with a mock. We need the
+        # real one's data manager though to reproduce the issue with the
+        # test below
+        super(IntegrationTestCase, self).setUp()
+        self.portal = self.layer['portal']
+        self.request = self.layer['request']
+        self.deactivate_extjs()
+        map(self.parse_feature, self.features)
+        if 'activity' in self.features:
+            insert_notification_defaults(self.portal)
+
+        task_responsible = self.regular_user
+        create(Builder('watcher').having(actorid=task_responsible.id))
+
+        # Make sure mails to responsible are enabled for task added
+        create(Builder('notification_setting')
+               .having(kind='task-added',
+                       userid=task_responsible.id,
+                       mail_notification_roles=[TASK_RESPONSIBLE_ROLE],
+                       badge_notification_roles=[],
+                       digest_notification_roles=[]))
+
+    def tearDown(self):
+        # Overridden - don't attempt to tear down Mailing helper
+        super(IntegrationTestCase, self).tearDown()
+
+    def test_notification_mails_dont_interfere_with_txn_savepoints(self):
+        # Login with a different user than task_responsible to trigger mail
+        self.login(self.dossier_responsible)
+
+        # Trigger a notification that dispatches a mail
+        activity = TaskAddedActivity(self.task, getRequest(), self.dossier)
+        activity.record()
+
+        # Creating a savepoint will fail with the MailDataManager if it's
+        # already registered as a transaction manager at that point
+        transaction.savepoint()


### PR DESCRIPTION
Defer sending mails until the end of the transaction, to avoid issues with the `zope.sendmail.delivery.MailDataManager` not having savepoint support.

### Issue

Immediately when doing a `mailhost.send()`, the mailhost will cause a `MailDataManager` to join the current transaction (one per mail). That's how `zope.sendmail` facilitates transactional mails. That specific `IDataManager` does not have savepoint support however. This causes any code that tries to create a transaction savepoint at a later time in that transaction to fail (this will happen during pasting, or certain meeting workflows).

### Solution

Sending of mails for notifications is already centralized in `opengever.activity.mailer.Mailer`. We change that code so that it doesn't immediately call `mailhost.send()`, but instead collects the mails to be sent (in a thread-local queue), and only calls `mailhost.send()` with them at the end of the transaction (using a `beforeCommitHook`).

Transactionality of mails is still guaranteed, because even in that `beforeCommitHook` mails aren't actually sent yet, they're just passed to `zope.sendmail`, which still has a chance to drop them if a `transaction.abort()` should happen.

Closes #4906


Resolves the following Sentry issues:
[#10395](https://sentry.4teamwork.ch/sentry/onegov-gever/issues/10395/) (pasting)
[#10257](https://sentry.4teamwork.ch/sentry/onegov-gever/issues/10257/) (copy_excerpt_to_proposal_dossier )
[#9040](https://sentry.4teamwork.ch/sentry/onegov-gever/issues/9040/) (submitdocuments)
[#9707](https://sentry.4teamwork.ch/sentry/onegov-gever/issues/9707/) (submit_additional_document)