### PR TITLE
Solr TabbedView filters: Also include non-wildcarded terms in query

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2019.1.0 (unreleased)
 ---------------------
 
+- Solr TabbedView filters: Also include non-wildcarded terms in query. [lgraf]
 - Better label the Oneoffixx template selection dropdown default value. [Rotonen]
 - Notifications: Defer sending mails until end of transaction. [lgraf]
 - Make the Oneoffixx timeout configurable via the registry. [Rotonen]

--- a/opengever/tabbedview/catalog_source.py
+++ b/opengever/tabbedview/catalog_source.py
@@ -33,7 +33,10 @@ class GeverCatalogTableSource(FilteredTableSourceMixin, CatalogTableSource):
     def solr_results(self, query):
         term = query['SearchableText'].rstrip('*').decode('utf8')
         pattern = (
-            u'(Title:{term}* OR SearchableText:{term}* OR metadata:{term}*)')
+            u'(Title:{term}* OR SearchableText:{term}* OR metadata:{term}* OR '
+            u'Title:{term} OR SearchableText:{term} OR metadata:{term})'
+        )
+
         term_queries = [pattern.format(term=escape(t)) for t in term.split()]
         solr_query = u' AND '.join(term_queries)
 

--- a/opengever/tabbedview/tests/test_catalog_source.py
+++ b/opengever/tabbedview/tests/test_catalog_source.py
@@ -22,14 +22,19 @@ class TestSolrSearch(IntegrationTestCase):
         self.source.solr_results({'SearchableText': 'foo*'})
         self.assertEqual(
             self.solr.search.call_args[1]['query'],
-            u'(Title:foo* OR SearchableText:foo* OR metadata:foo*)')
+            u'(Title:foo* OR SearchableText:foo* OR metadata:foo* OR '
+            u'Title:foo OR SearchableText:foo OR metadata:foo)'
+        )
 
     def test_solr_query_contains_pattern_for_each_term(self):
         self.source.solr_results({'SearchableText': 'foo bar*'})
         self.assertEqual(
             self.solr.search.call_args[1]['query'],
-            u'(Title:foo* OR SearchableText:foo* OR metadata:foo*) AND '
-            u'(Title:bar* OR SearchableText:bar* OR metadata:bar*)')
+            u'(Title:foo* OR SearchableText:foo* OR metadata:foo* OR '
+            u'Title:foo OR SearchableText:foo OR metadata:foo) AND '
+            u'(Title:bar* OR SearchableText:bar* OR metadata:bar* OR '
+            u'Title:bar OR SearchableText:bar OR metadata:bar)'
+        )
 
     def test_solr_filters_contain_trashed(self):
         self.source.solr_results(


### PR DESCRIPTION
Solr TabbedView filters: Also **include non-wildcarded terms** in query.

Wildcard queries in Solr only get analyzed with a subset of the query analyzers, not all of them (only multi term aware ones). *(See [this (old) post](https://lucidworks.com/2011/11/29/whats-with-lowercasing-wildcard-multiterm-queries-in-solr/) for an in-depth explanation of the issue, and [this section](https://lucene.apache.org/solr/guide/6_6/analyzers.html#Analyzers-AnalysisforMulti-TermExpansion) in the docs).*

Specifically, this leads to our `WhitespaceTokenizerFactory` not being run against the query, and the query therefore doesn't get tokenized.

---

This can be observed in the difference of how Solr parses the query (note the difference in `parsedquery`):

**Non-Wildcard query**
![non_wildcard_query](https://user-images.githubusercontent.com/405124/52279564-1e150400-295a-11e9-9dc9-5e750f47964a.png)

**Wildcard query**
![wildcard_query](https://user-images.githubusercontent.com/405124/52279582-29682f80-295a-11e9-98e5-4f36b1296e2f.png)

---

Also including the non-wildcarded terms in the query pattern allows us get better matches for these cases where the user enters a search term that needs to be tokenized.

Fixes https://extranet.4teamwork.ch/support/gever-st-gallen/tracker/520