### PR TITLE
Fix preview tooltip for different input types.

### DIFF
--- a/opengever/base/browser/resources/tooltip.js
+++ b/opengever/base/browser/resources/tooltip.js
@@ -97,7 +97,15 @@
     showBackdrop(event);
   }
 
-  $(document).on("mouseover", ".tooltip-trigger", initTooltips);
+  var hasTouched = false;
+
+  $(document).on("touchstart", ".tooltip-trigger", function() {
+    hasTouched = true;
+  });
+  $(document).on("mouseover", ".tooltip-trigger", function(e) {
+    if (hasTouched) { return; }
+    initTooltips(e);
+  });
 
 }(window, window.jQuery));
 


### PR DESCRIPTION
☠️ I tested this on chrome, safari, IE11 and on iPad running iOS 12.1. The revert commit: https://github.com/4teamwork/opengever.core/pull/5117 documents that there were issues for so-called hybrid devices. I'm not entirely sure how those devices behave in terms of event order. So this solution may not work for such devices. I had no access to such a machine to test that out. So before merging the pull request these changes should first be tested on a real hybrid device.

Closes https://github.com/4teamwork/opengever.core/issues/4809

Uses a flag which will be set to true when the user touches the screen. So when the mouseover event is triggered after the touchevent, the tooltips are not initialized. On the other hand, when the user does not touch the screen, the touchevent is not fired so the tooltip renders as expected.