### PR TITLE
Make the Oneoffixx timeout configurable via the registry

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,7 @@ Changelog
 
 - Better label the Oneoffixx template selection dropdown default value. [Rotonen]
 - Notifications: Defer sending mails until end of transaction. [lgraf]
+- Make the Oneoffixx timeout configurable via the registry. [Rotonen]
 - Implement WebActions storage and REST API. [lgraf]
 - Fix changing task to or from private via edit form. [deiferni]
 - Fix creating private tasks by mistake. [deiferni]

--- a/opengever/api/tests/test_config.py
+++ b/opengever/api/tests/test_config.py
@@ -112,6 +112,11 @@ class TestConfig(IntegrationTestCase):
         self.login(self.regular_user, browser)
         browser.open(self.portal.absolute_url() + '/@config', headers={'Accept': 'application/json'})
         self.assertEqual(browser.status_code, 200)
-        expected_oneoffixx_settings = {u'baseurl': u'', u'fake_sid': u'', u'double_encode_bug': True}
+        expected_oneoffixx_settings = {
+            u'baseurl': u'',
+            u'fake_sid': u'',
+            u'double_encode_bug': True,
+            u'cache_timeout': 2592000,
+        }
         oneoffixx_settings = browser.json.get('oneoffixx_settings')
         self.assertEqual(expected_oneoffixx_settings, oneoffixx_settings)

--- a/opengever/base/configuration.py
+++ b/opengever/base/configuration.py
@@ -67,6 +67,7 @@ class GeverSettingsAdpaterV1(object):
         oneoffixx_settings['baseurl'] = api.portal.get_registry_record('baseurl', interface=IOneoffixxSettings)
         oneoffixx_settings['fake_sid'] = api.portal.get_registry_record('fake_sid', interface=IOneoffixxSettings)
         oneoffixx_settings['double_encode_bug'] = api.portal.get_registry_record('double_encode_bug', interface=IOneoffixxSettings)  # noqa
+        oneoffixx_settings['cache_timeout'] = api.portal.get_registry_record('cache_timeout', interface=IOneoffixxSettings)
         return oneoffixx_settings
 
     def get_features(self):

--- a/opengever/base/tests/test_configuration_adapter.py
+++ b/opengever/base/tests/test_configuration_adapter.py
@@ -16,6 +16,7 @@ class TestConfigurationAdapter(IntegrationTestCase):
                 ('baseurl', u''),
                 ('fake_sid', u''),
                 ('double_encode_bug', True),
+                ('cache_timeout', 2592000),
             ])),
             ('features', OrderedDict([
                 ('activity', False),

--- a/opengever/core/upgrades/20190205162955_make_the_oneoffixx_timeout_configurable_via_the_registry/registry.xml
+++ b/opengever/core/upgrades/20190205162955_make_the_oneoffixx_timeout_configurable_via_the_registry/registry.xml
@@ -1,0 +1,3 @@
+<registry>
+  <record interface="opengever.oneoffixx.interfaces.IOneoffixxSettings" field="cache_timeout" />
+</registry>

--- a/opengever/core/upgrades/20190205162955_make_the_oneoffixx_timeout_configurable_via_the_registry/upgrade.py
+++ b/opengever/core/upgrades/20190205162955_make_the_oneoffixx_timeout_configurable_via_the_registry/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class MakeTheOneoffixxTimeoutConfigurableViaTheRegistry(UpgradeStep):
+    """Make the Oneoffixx timeout configurable via the registry.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/oneoffixx/api_client.py
+++ b/opengever/oneoffixx/api_client.py
@@ -17,21 +17,29 @@ def oneoffixx_access_token_cachekey(*args):
 
 
 def oneoffixx_templatelibrary_id_cachekey(*args):
-    """Cache the template library, per user, for 30 minutes.
+    """Cache the template library, per user.
 
     The left-behind-by-instability cache keys this produces will get reaped by
     the global cache LRU cleanups.
+
+    The timeout is configurable in the registry and used a part of the cache
+    key so changing the timeout immediately invalidates all caches.
     """
-    return '-'.join(('oneoffixx_templatelibrary_id', api.user.get_current().id, str(time() // (60 * 30)), ))
+    timeout = api.portal.get_registry_record('cache_timeout', interface=IOneoffixxSettings)
+    return '-'.join(('oneoffixx_templatelibrary_id', api.user.get_current().id, str(timeout), str(time() // timeout), ))
 
 
 def oneoffixx_template_groups_cachekey(*args):
-    """Cache the template groups, per user, for 5 minutes.
+    """Cache the template groups, per user.
 
     The left-behind-by-instability cache keys this produces will get reaped by
     the global cache LRU cleanups.
+
+    The timeout is configurable in the registry and used a part of the cache
+    key so changing the timeout immediately invalidates all caches.
     """
-    return '-'.join(('oneoffixx_template_groups', api.user.get_current().id, str(time() // (60 * 5)), ))
+    timeout = api.portal.get_registry_record('cache_timeout', interface=IOneoffixxSettings)
+    return '-'.join(('oneoffixx_template_groups', api.user.get_current().id, str(timeout), str(time() // timeout), ))
 
 
 class OneoffixxAPIClientSingleton(type):

--- a/opengever/oneoffixx/interfaces.py
+++ b/opengever/oneoffixx/interfaces.py
@@ -31,3 +31,9 @@ class IOneoffixxSettings(Interface):
                     u'This setting provides a disablable future proofing toggle for that behaviour.',
         default=True,
     )
+
+    cache_timeout = schema.Int(
+        title=u'Oneoffixx backend caching timeout in seconds.',
+        description=u'Quite many of the backend responses are very slow, so we cache them per user. Defaults to 30 days.',
+        default=30 * 24 * 60 * 60,
+    )


### PR DESCRIPTION
It has arisen we want much longer timeouts for the caching and it'd thus be prudent to make the timeouts configurable. For the sake of simplicity both non-eternal caches are now using the same timeout.

Closes #5323