### PR TITLE
Prevent tasks from being created as private or switched to private when feature is not enabled.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,7 @@ Changelog
 
 - Notifications: Defer sending mails until end of transaction. [lgraf]
 - Implement WebActions storage and REST API. [lgraf]
+- Fix changing task to or from private via edit form. [deiferni]
 - Fix creating private tasks by mistake. [deiferni]
 - Add simple cache invalidation mechanism for javascript included in templates. [deiferni]
 - Fix handling of initial version when saving a document as PDF. [njohner]

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,7 @@ Changelog
 
 - Notifications: Defer sending mails until end of transaction. [lgraf]
 - Implement WebActions storage and REST API. [lgraf]
+- Fix creating private tasks by mistake. [deiferni]
 - Add simple cache invalidation mechanism for javascript included in templates. [deiferni]
 - Fix handling of initial version when saving a document as PDF. [njohner]
 - Fix bug in paragraph agendaitem item_number display. [njohner]

--- a/opengever/task/browser/forms.py
+++ b/opengever/task/browser/forms.py
@@ -1,5 +1,4 @@
 from opengever.task import is_private_task_feature_enabled
-from opengever.task.activities import TaskAddedActivity
 from opengever.task.activities import TaskReassignActivity
 from opengever.task.task import IAddTaskSchema
 from opengever.task.task import ITask

--- a/opengever/task/browser/forms.py
+++ b/opengever/task/browser/forms.py
@@ -66,6 +66,12 @@ class TaskAddForm(DefaultAddForm):
 
     def createAndAdd(self, data):
         created = []
+
+        # make sure we don't create private tasks when the feature is
+        # not enabled. the field is hidden, but users could still submit.
+        if not is_private_task_feature_enabled():
+            data['is_private'] = False
+
         if isinstance(data['responsible'], basestring):
             data['responsible'] = [data['responsible']]
 

--- a/opengever/task/browser/forms.py
+++ b/opengever/task/browser/forms.py
@@ -155,6 +155,9 @@ class TaskEditForm(DefaultEditForm):
         """
         update_reponsible_field_data(data)
 
+        # make sure is_private is never changed.
+        data.pop('is_private', None)
+
         if self.is_reassigned(data):
             response = self.add_reassign_response(data)
             changes = super(TaskEditForm, self).applyChanges(data)

--- a/opengever/task/tests/test_private_task.py
+++ b/opengever/task/tests/test_private_task.py
@@ -57,3 +57,20 @@ class TestPrivateTaskDeactivatedIntegration(IntegrationTestCase):
         self.assertEqual(
             'hidden',
             browser.css('#formfield-form-widgets-is_private input').first.type)
+
+    @browsing
+    def test_cant_create_private_tasks_when_feature_is_inactive(self, browser):
+        self.login(self.dossier_responsible, browser)
+
+        with self.observe_children(self.dossier) as children:
+            browser.open(self.dossier, view='++add++opengever.task.task')
+            browser.fill({'Title': u'I should not be private despite input.',
+                          'Task Type': 'comment',
+                          'form.widgets.is_private:list': 'selected'})
+            form = browser.find_form_by_field('Responsible')
+            form.find_widget('Responsible').fill(
+                'fa:{}'.format(self.secretariat_user.getId()))
+            browser.css('#form-buttons-save').first.click()
+
+        task = children['added'].pop()
+        self.assertFalse(task.is_private)

--- a/opengever/task/tests/test_private_task.py
+++ b/opengever/task/tests/test_private_task.py
@@ -29,6 +29,17 @@ class TestPrivateTaskIntegration(IntegrationTestCase):
             'hidden',
             browser.css('#formfield-form-widgets-is_private input').first.type)
 
+    @browsing
+    def test_task_private_field_cant_be_changed_in_edit_form(self, browser):
+        self.login(self.administrator, browser=browser)
+        self.assertFalse(self.seq_subtask_1.is_private)
+
+        browser.open(self.seq_subtask_1, view='edit')
+        browser.fill({'form.widgets.is_private:list': 'selected'})
+        browser.click_on('Save')
+
+        self.assertFalse(self.seq_subtask_1.is_private)
+
 
 class TestPrivateTaskDeactivatedIntegration(IntegrationTestCase):
 


### PR DESCRIPTION
Currently the fields `is_private` on a task is hidden in a tasks add-form if the private task feature is not enabled. It is also hidden in the edit form unconditionally.

Only hiding but not omitting the field does not discard browser input. Thus input from the browser was still used even when the feature was not enabled. Under some circumstances (still not entirely sure when and when not) the hidden field is rendered as 'selected' in the markup, thus all tasks are/were created as private even when the feature was not enabled.

This PR fixes two things:
- No longer allow creation of private tasks when the feature is not enabled (form patch only, must be addressed again and fixed properly in https://github.com/4teamwork/opengever.core/pull/5316)
- Don't allow changing privateness in the edit form as this transition is currently not supported.

Upgrade is not provided intentionally, as retroactively changing the permissions and reliably figuring out which tasks to touch is not so easy.