### PR TITLE
Fix broken mimetypes.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -13,6 +13,7 @@ Changelog
 - Make the Oneoffixx timeout configurable via the registry. [Rotonen]
 - Update change-date properly if meeting documents have been updated. [elioschmutz]
 - Update unmatching label for modification dates for meeting documents. [elioschmutz]
+- Fix broken .xls mimetypes-registry entry. [elioschmutz]
 - Implement WebActions storage and REST API. [lgraf]
 - Fix changing task to or from private via edit form. [deiferni]
 - Fix creating private tasks by mistake. [deiferni]

--- a/opengever/core/upgrades/20190205142415_fix_broken_mimetypes/mimetypes.xml
+++ b/opengever/core/upgrades/20190205142415_fix_broken_mimetypes/mimetypes.xml
@@ -1,0 +1,29 @@
+<object name="mimetypes_registry" meta_type="MimeTypes Registry">
+
+  <!-- MS Excel -->
+  <mimetype
+      name="Microsoft Excel Spreadsheet"
+      binary="True"
+      extensions="xls xlt xla xlb xlc xld xll xlm xlw"
+      globs="*.xls *.xlt *.xla *.xlb *.xlc *.xld *.xll *.xlm *.xlw"
+      icon_path="icon_dokument_excel.gif"
+      mimetypes="application/vnd.ms-excel
+                 application/msexcel
+                 application/excel
+                 application/vnd.msexcel
+                 application/x-msexcel"
+      />
+
+  <mimetype
+      name="Comma-separated values"
+      binary="False"
+      extensions="csv"
+      globs="*.csv"
+      icon_path="icon_dokument_excel.gif"
+      mimetypes="text/comma-separated-values
+                 text/csv
+                 application/csv
+                 text/anytext"
+      />
+
+</object>

--- a/opengever/core/upgrades/20190205142415_fix_broken_mimetypes/upgrade.py
+++ b/opengever/core/upgrades/20190205142415_fix_broken_mimetypes/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class FixBrokenMimetypes(UpgradeStep):
+    """Fix broken mimetypes.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/policy/base/profiles/mimetype/mimetypes.xml
+++ b/opengever/policy/base/profiles/mimetype/mimetypes.xml
@@ -104,6 +104,8 @@
       icon_path="icon_dokument_excel.gif"
       mimetypes="application/vnd.ms-excel
                  application/msexcel
+                 application/excel
+                 application/vnd.msexcel
                  application/x-msexcel"
       />
 
@@ -408,9 +410,6 @@
       mimetypes="text/comma-separated-values
                  text/csv
                  application/csv
-                 application/excel
-                 application/vnd.ms-excel
-                 application/vnd.msexcel
                  text/anytext"
       />
 


### PR DESCRIPTION
Dieser PR fügt den fehlenden .xls mimetype-Eintrag wieder hinzu.

Der Eintrag wurde durch diesen PR gelöscht: https://github.com/4teamwork/opengever.core/pull/4494

Grund:
-------
Der [erste definierte Mimetype](https://github.com/collective/collective.mtrsetup/blob/master/collective/mtrsetup/handler.py#L53) wird als ID verwendet. Bei folgender Registrierung:

```xml
<object name="mimetypes_registry" meta_type="MimeTypes Registry">
  <mimetype
      name="Microsoft Excel Spreadsheet"
      extensions="xls"
      globs="*.xls"
      mimetypes="application/vnd.ms-excel
                 application/msexcel"
      />
  </object>
```

Wird `application/vnd.ms-excel` als ID verwendet. Es wird danach geschaut, ob diese [ID bereits irgendwo definiert wurde](https://github.com/collective/collective.mtrsetup/blob/master/collective/mtrsetup/handler.py#L55).  Bei folgender Konfiguration wäre dies der Fall. Die ID `application/vnd.ms-excel` wurde bereits für ein CSV verwendet. Die Reihenfolge spielt beim CSV keine Rolle mehr. 

```
<object name="mimetypes_registry" meta_type="MimeTypes Registry">
  <mimetype
      name="Microsoft Excel Spreadsheet"
      extensions="xls"
      globs="*.xls"
      mimetypes="application/vnd.ms-excel
                 application/msexcel"
      />
  <mimetype
      name="CSV"
      extensions="csv"
      globs="*.csv"
      mimetypes="text/comma-separated-values
                 application/vnd.ms-excel"
      />
  </object>
```

Es wird somit der CSV Eintrag aktualisiert und der Excel Eintrag gelöscht. Genau dies ist im o.g. PR geschehen. `application/vnd.ms-excel` wurde zusätzlich beim CSV-Mimetype hinzugefügt. Beim nächsten Upgrade ging das `.xls` verloren.

Doppelte Mimetypes
--------------------
Es gibt mehrere doppelte Mimetypes, welche jedoch nicht wirklich doppelt registriert sind. Die ID ist die gleiche. Sie werden lediglich mehrfach angezeigt. Das Problem kann mit einer neuen Plonesite reproduziert werden (kein GEVER). Somit ist dies wohl keine Fehlkonfiguration, sondern das aktuelle Verhalten der Mimetypesregistry. Ich bin dem Problem nicht nachgegangen. Bitte um Rückmeldung, falls ich das genauer anschauen soll.


Die Implementation ist ein wenig merkwürdig, wie es im detail genau funktioniert konnte ich auf die schnelle nicht herausfinden. Bitte um Rückmeldung, falls ich mehr Zeit investieren soll.

⚠️ Ich habe keine Tests für die Behebung des Fehlers gemacht. Wir müssten jeden Mimetype-Eintrag überprüfen. Das ist möglich. Die Frage ist, ob es erwünscht ist. Bitte um Rückmeldung, falls ich die Mimetypes mit einem Test abdecken soll.

Fixes #5304 