### PR TITLE
Include agenda item description in TOC json.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -11,6 +11,7 @@ Changelog
 - Fix creating private tasks by mistake. [deiferni]
 - Add simple cache invalidation mechanism for javascript included in templates. [deiferni]
 - Fix handling of initial version when saving a document as PDF. [njohner]
+- Include agenda item description in TOC json. [deiferni]
 - Fix bug in paragraph agendaitem item_number display. [njohner]
 - Group fields in Committee edit forms. [njohner]
 - Scrub Bobo Call Interface data out of the HTTP response headers. [Rotonen]

--- a/opengever/meeting/model/agendaitem.py
+++ b/opengever/meeting/model/agendaitem.py
@@ -153,7 +153,7 @@ class AgendaItem(Base):
 
     def get_description(self):
         return (self.submitted_proposal.description if self.has_proposal
-                else self.description)
+                else self.description) or None
 
     def get_description_html(self):
         return to_html_xweb_intelligent(self.get_description()) or None

--- a/opengever/meeting/tests/test_periods.py
+++ b/opengever/meeting/tests/test_periods.py
@@ -148,7 +148,8 @@ class TestPeriod(IntegrationTestCase):
         button = browser.find('download TOC json alphabetical')
 
         period = self.committee.load_model().periods[0]
-        expected_url = os.path.join(period.get_url(self.committee), 'alphabetical_toc/as_json')
+        expected_url = os.path.join(
+            period.get_url(self.committee), 'alphabetical_toc/as_json')
         self.assertEqual(expected_url, button.get("href"))
 
         button.click()
@@ -159,7 +160,8 @@ class TestPeriod(IntegrationTestCase):
                                                 u'meeting_date': u'17.07.2016',
                                                 u'meeting_start_page_number': None,
                                                 u'repository_folder_title': u'Vertr\xe4ge und Vereinbarungen',
-                                                u'title': u'Initialvertrag f\xfcr Bearbeitung'}],
+                                                u'title': u'Initialvertrag f\xfcr Bearbeitung',
+                                                u'description': None}],
                                  }]}
         self.assertEqual(toc_content, browser.json)
 
@@ -181,7 +183,8 @@ class TestPeriod(IntegrationTestCase):
                                                 u'meeting_date': u'17.07.2016',
                                                 u'meeting_start_page_number': None,
                                                 u'repository_folder_title': u'Vertr\xe4ge und Vereinbarungen',
-                                                u'title': u'Initialvertrag f\xfcr Bearbeitung'}],
+                                                u'title': u'Initialvertrag f\xfcr Bearbeitung',
+                                                u'description': None}],
                                  }]}
 
         self.assertEqual(toc_content, browser.json)
@@ -199,6 +202,7 @@ class TestPeriod(IntegrationTestCase):
         button.click()
         toc_content = {u'toc': [{u'group_title': u'Client1 1.1 / 1',
                                  u'contents': [{u'decision_number': 1,
+                                                u'description': None,
                                                 u'dossier_reference_number': u'Client1 1.1 / 1',
                                                 u'has_proposal': True,
                                                 u'meeting_date': u'17.07.2016',
@@ -224,6 +228,7 @@ class TestPeriod(IntegrationTestCase):
 
         toc_content = {u'toc': [{u'group_title': u'Client1 1.1',
                                  u'contents': [{u'decision_number': 1,
+                                                u'description': None,
                                                 u'dossier_reference_number': u'Client1 1.1 / 1',
                                                 u'has_proposal': True,
                                                 u'meeting_date': u'17.07.2016',

--- a/opengever/meeting/tests/test_toc.py
+++ b/opengever/meeting/tests/test_toc.py
@@ -151,6 +151,7 @@ class TestAlphabeticalTOC(FunctionalTestCase):
         'contents': [
             {
                 'title': u'aa proposal',
+                'description': None,
                 'dossier_reference_number': '1.1.4 / 1',
                 'repository_folder_title': u'\xc4 Business',
                 'meeting_date': u'01.01.2010',
@@ -159,6 +160,7 @@ class TestAlphabeticalTOC(FunctionalTestCase):
                 'meeting_start_page_number': 33,
                 }, {
                 'title': u'\xc4a proposal',
+                'description': None,
                 'dossier_reference_number': '1.1.4 / 2',
                 'repository_folder_title': u'\xc4 Business',
                 'meeting_date': u'01.01.2010',
@@ -167,6 +169,7 @@ class TestAlphabeticalTOC(FunctionalTestCase):
                 'meeting_start_page_number': 33,
                 }, {
                 'title': u'Anything goes',
+                'description': u'Really, Anything.',
                 'dossier_reference_number': '3.1.4 / 77',
                 'repository_folder_title': 'Other Stuff',
                 'meeting_date': u'31.12.2010',
@@ -179,6 +182,7 @@ class TestAlphabeticalTOC(FunctionalTestCase):
         'contents': [
             {
                 'title': u'Nahhh not here either',
+                'description': u'But a description!',
                 'dossier_reference_number': None,
                 'repository_folder_title': None,
                 'meeting_date': u'31.12.2010',
@@ -187,6 +191,7 @@ class TestAlphabeticalTOC(FunctionalTestCase):
                 'meeting_start_page_number': 129,
             }, {
                 'title': u'No Proposal here',
+                'description': None,
                 'dossier_reference_number': None,
                 'repository_folder_title': None,
                 'meeting_date': u'31.12.2010',
@@ -199,6 +204,7 @@ class TestAlphabeticalTOC(FunctionalTestCase):
         'contents': [
             {
                 'title': u'proposal 1',
+                'description': None,
                 'dossier_reference_number': u'1.1.4 / 1',
                 'repository_folder_title': u'\xc4 Business',
                 'meeting_date': '01.01.2010',
@@ -207,6 +213,7 @@ class TestAlphabeticalTOC(FunctionalTestCase):
                 'meeting_start_page_number': 33,
                 }, {
                 'title': u'Proposal 3',
+                'description': None,
                 'dossier_reference_number': '10.1.4 / 1',
                 'repository_folder_title': 'A Business',
                 'meeting_date': u'31.12.2010',
@@ -274,6 +281,7 @@ class TestAlphabeticalTOC(FunctionalTestCase):
             int_id=3).within(self.committee))
         proposal2_2 = create(Builder('submitted_proposal').having(
             title=u'Anything goes',
+            description=u'Really, Anything.',
             repository_folder_title='Other Stuff',
             dossier_reference_number='3.1.4 / 77',
             int_id=4).within(self.committee))
@@ -317,6 +325,7 @@ class TestAlphabeticalTOC(FunctionalTestCase):
         create(Builder('agenda_item').having(
             meeting=self.meeting2,
             title=u'Nahhh not here either',
+            description=u'But a description!',
             decision_number=7,
         ))
 
@@ -353,8 +362,9 @@ class TestAlphabeticalTOC(FunctionalTestCase):
         ))
 
     def test_toc_json_is_generated_correctly(self):
-        self.assertEqual(
-            self.expected_toc_json, self.toc_class(self.period).get_json())
+        self.assertDictEqual(
+            self.expected_toc_json, self.toc_class(self.period).get_json(),
+            "Toc mismatch in {}".format(self.toc_class.__name__))
 
     @browsing
     def test_shows_statusmessage_when_no_template_is_configured(self, browser):
@@ -413,6 +423,7 @@ class TestTOCByRepository(TestAlphabeticalTOC):
         'group_title': u'Ad hoc agendaitems',
         'contents': [{
                 'title': u'Nahhh not here either',
+                'description': u'But a description!',
                 'dossier_reference_number': None,
                 'repository_folder_title': None,
                 'meeting_date': u'31.12.2010',
@@ -421,6 +432,7 @@ class TestTOCByRepository(TestAlphabeticalTOC):
                 'meeting_start_page_number': 129,
             }, {
                 'title': u'No Proposal here',
+                'description': None,
                 'dossier_reference_number': None,
                 'repository_folder_title': None,
                 'meeting_date': u'31.12.2010',
@@ -432,6 +444,7 @@ class TestTOCByRepository(TestAlphabeticalTOC):
             'group_title': u'A Business',
             'contents': [{
                 'title': u'Proposal 3',
+                'description': None,
                 'dossier_reference_number': '10.1.4 / 1',
                 'repository_folder_title': 'A Business',
                 'meeting_date': u'31.12.2010',
@@ -443,6 +456,7 @@ class TestTOCByRepository(TestAlphabeticalTOC):
             'group_title': u'\xc4 Business',
             'contents': [{
                 'title': u'aa proposal',
+                'description': None,
                 'dossier_reference_number': '1.1.4 / 1',
                 'repository_folder_title': u'\xc4 Business',
                 'meeting_date': u'01.01.2010',
@@ -451,6 +465,7 @@ class TestTOCByRepository(TestAlphabeticalTOC):
                 'meeting_start_page_number': 33,
             }, {
                 'title': u'\xc4a proposal',
+                'description': None,
                 'dossier_reference_number': '1.1.4 / 2',
                 'repository_folder_title': u'\xc4 Business',
                 'meeting_date': u'01.01.2010',
@@ -459,6 +474,7 @@ class TestTOCByRepository(TestAlphabeticalTOC):
                 'meeting_start_page_number': 33,
             }, {
                 'title': u'proposal 1',
+                'description': None,
                 'dossier_reference_number': u'1.1.4 / 1',
                 'repository_folder_title': u'\xc4 Business',
                 'meeting_date': '01.01.2010',
@@ -470,6 +486,7 @@ class TestTOCByRepository(TestAlphabeticalTOC):
             'group_title': u'Other Stuff',
             'contents': [{
                 'title': u'Anything goes',
+                'description': u'Really, Anything.',
                 'dossier_reference_number': '3.1.4 / 77',
                 'repository_folder_title': 'Other Stuff',
                 'meeting_date': u'31.12.2010',
@@ -492,6 +509,7 @@ class TestTOCByDossierReferenceNumber(TestAlphabeticalTOC):
         'group_title': u'Ad hoc agendaitems',
         'contents': [{
                 'title': u'Nahhh not here either',
+                'description': u'But a description!',
                 'dossier_reference_number': None,
                 'repository_folder_title': None,
                 'meeting_date': u'31.12.2010',
@@ -500,6 +518,7 @@ class TestTOCByDossierReferenceNumber(TestAlphabeticalTOC):
                 'meeting_start_page_number': 129,
             }, {
                 'title': u'No Proposal here',
+                'description': None,
                 'dossier_reference_number': None,
                 'repository_folder_title': None,
                 'meeting_date': u'31.12.2010',
@@ -511,6 +530,7 @@ class TestTOCByDossierReferenceNumber(TestAlphabeticalTOC):
             'group_title': u'1.1.4 / 1',
             'contents': [{
                 'title': u'aa proposal',
+                'description': None,
                 'dossier_reference_number': '1.1.4 / 1',
                 'repository_folder_title': u'\xc4 Business',
                 'meeting_date': u'01.01.2010',
@@ -519,18 +539,19 @@ class TestTOCByDossierReferenceNumber(TestAlphabeticalTOC):
                 'meeting_start_page_number': 33,
             }, {
                 'title': u'proposal 1',
+                'description': None,
                 'dossier_reference_number': u'1.1.4 / 1',
                 'repository_folder_title': u'\xc4 Business',
                 'meeting_date': '01.01.2010',
                 'decision_number': 2,
                 'has_proposal': True,
                 'meeting_start_page_number': 33,
-
-            }]
+             }]
         }, {
             'group_title': u'1.1.4 / 2',
             'contents': [{
                 'title': u'\xc4a proposal',
+                'description': None,
                 'dossier_reference_number': '1.1.4 / 2',
                 'repository_folder_title': u'\xc4 Business',
                 'meeting_date': u'01.01.2010',
@@ -542,6 +563,7 @@ class TestTOCByDossierReferenceNumber(TestAlphabeticalTOC):
             'group_title': u'3.1.4 / 77',
             'contents': [{
                 'title': u'Anything goes',
+                'description': u'Really, Anything.',
                 'dossier_reference_number': '3.1.4 / 77',
                 'repository_folder_title': 'Other Stuff',
                 'meeting_date': u'31.12.2010',
@@ -553,6 +575,7 @@ class TestTOCByDossierReferenceNumber(TestAlphabeticalTOC):
             'group_title': u'10.1.4 / 1',
             'contents': [{
                 'title': u'Proposal 3',
+                'description': None,
                 'dossier_reference_number': '10.1.4 / 1',
                 'repository_folder_title': 'A Business',
                 'meeting_date': u'31.12.2010',
@@ -575,6 +598,7 @@ class TestTOCByRepositoryReferenceNumber(TestAlphabeticalTOC):
         'group_title': u'Ad hoc agendaitems',
         'contents': [{
                 'title': u'Nahhh not here either',
+                'description': u'But a description!',
                 'dossier_reference_number': None,
                 'repository_folder_title': None,
                 'meeting_date': u'31.12.2010',
@@ -583,6 +607,7 @@ class TestTOCByRepositoryReferenceNumber(TestAlphabeticalTOC):
                 'meeting_start_page_number': 129,
             }, {
                 'title': u'No Proposal here',
+                'description': None,
                 'dossier_reference_number': None,
                 'repository_folder_title': None,
                 'meeting_date': u'31.12.2010',
@@ -594,6 +619,7 @@ class TestTOCByRepositoryReferenceNumber(TestAlphabeticalTOC):
             'group_title': u'1.1.4',
             'contents': [{
                 'title': u'aa proposal',
+                'description': None,
                 'dossier_reference_number': '1.1.4 / 1',
                 'repository_folder_title': u'\xc4 Business',
                 'meeting_date': u'01.01.2010',
@@ -602,6 +628,7 @@ class TestTOCByRepositoryReferenceNumber(TestAlphabeticalTOC):
                 'meeting_start_page_number': 33,
             }, {
                 'title': u'\xc4a proposal',
+                'description': None,
                 'dossier_reference_number': '1.1.4 / 2',
                 'repository_folder_title': u'\xc4 Business',
                 'meeting_date': u'01.01.2010',
@@ -610,6 +637,7 @@ class TestTOCByRepositoryReferenceNumber(TestAlphabeticalTOC):
                 'meeting_start_page_number': 33,
             }, {
                 'title': u'proposal 1',
+                'description': None,
                 'dossier_reference_number': u'1.1.4 / 1',
                 'repository_folder_title': u'\xc4 Business',
                 'meeting_date': '01.01.2010',
@@ -621,6 +649,7 @@ class TestTOCByRepositoryReferenceNumber(TestAlphabeticalTOC):
             'group_title': u'3.1.4',
             'contents': [{
                 'title': u'Anything goes',
+                'description': u'Really, Anything.',
                 'dossier_reference_number': '3.1.4 / 77',
                 'repository_folder_title': 'Other Stuff',
                 'meeting_date': u'31.12.2010',
@@ -632,6 +661,7 @@ class TestTOCByRepositoryReferenceNumber(TestAlphabeticalTOC):
             'group_title': u'10.1.4',
             'contents': [{
                 'title': u'Proposal 3',
+                'description': None,
                 'dossier_reference_number': '10.1.4 / 1',
                 'repository_folder_title': 'A Business',
                 'meeting_date': u'31.12.2010',

--- a/opengever/meeting/toc/alphabetical.py
+++ b/opengever/meeting/toc/alphabetical.py
@@ -86,6 +86,7 @@ class AlphabeticalToc(object):
             unordered_items.append(processor.process(
                 {
                  'title': agenda_item.get_title(),
+                 'description': agenda_item.get_description(),
                  'dossier_reference_number': agenda_item.get_dossier_reference_number(),
                  'repository_folder_title': agenda_item.get_repository_folder_title(),
                  'decision_number': agenda_item.decision_number,


### PR DESCRIPTION
Include agenda item or proposal description in JSON provided as input for TOC sablon templates. It is already included in JSON for protocol, agenda item list and excerpt but unfortunately was not added to the TOC.
Closes #5305.