### PR TITLE
Fix label and modification date for protocol documents

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -11,6 +11,7 @@ Changelog
 - Better label the Oneoffixx template selection dropdown default value. [Rotonen]
 - Notifications: Defer sending mails until end of transaction. [lgraf]
 - Make the Oneoffixx timeout configurable via the registry. [Rotonen]
+- Update change-date properly if meeting documents have been updated. [elioschmutz]
 - Update unmatching label for modification dates for meeting documents. [elioschmutz]
 - Implement WebActions storage and REST API. [lgraf]
 - Fix changing task to or from private via edit form. [deiferni]

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -11,6 +11,7 @@ Changelog
 - Better label the Oneoffixx template selection dropdown default value. [Rotonen]
 - Notifications: Defer sending mails until end of transaction. [lgraf]
 - Make the Oneoffixx timeout configurable via the registry. [Rotonen]
+- Update unmatching label for modification dates for meeting documents. [elioschmutz]
 - Implement WebActions storage and REST API. [lgraf]
 - Fix changing task to or from private via edit form. [deiferni]
 - Fix creating private tasks by mistake. [deiferni]

--- a/opengever/meeting/browser/meetings/templates/meeting.pt
+++ b/opengever/meeting/browser/meetings/templates/meeting.pt
@@ -255,7 +255,7 @@
                          i18n:translate="document_label_agenda_item_list">
                       Agenda item list
                     </div>
-                    <div class="document-created"
+                    <div class="document-modified"
                          i18n:translate="document_not_yet_generated">
                       Not yet generated.
                     </div>
@@ -265,9 +265,9 @@
                     <div class="document-label">
                       <a tal:replace="structure view/get_agendaitem_list_document_link" />
                     </div>
-                    <div class="document-created"
-                         i18n:translate="document_created_at">
-                      Created at
+                    <div class="document-modified"
+                         i18n:translate="document_last_modified">
+                      Modified at
                       <tal:date
                           replace="python:toLocalizedTime(agendaitem_list_document.getObject().ModificationDate(), long_format=1)"
                           i18n:name="date" />
@@ -309,7 +309,7 @@
                   <tal:NOT_GENERATED tal:condition="not:protocol_document">
                     <div class="document-label"
                          tal:content="view/get_protocol_document_label" />
-                    <div class="document-created"
+                    <div class="document-modified"
                          i18n:translate="document_not_yet_generated">
                       Not yet generated.
                     </div>
@@ -319,9 +319,9 @@
                     <div class="document-label">
                       <a tal:replace="structure view/get_protocol_document_link" />
                     </div>
-                    <div class="document-created"
-                         i18n:translate="document_created_at">
-                      Created at
+                    <div class="document-modified"
+                         i18n:translate="document_last_modified">
+                      Modified at
                       <tal:date
                           replace="python:toLocalizedTime(protocol_document.getObject().ModificationDate(), long_format=1)"
                           i18n:name="date" />

--- a/opengever/meeting/command.py
+++ b/opengever/meeting/command.py
@@ -29,8 +29,10 @@ from opengever.ogds.base.utils import decode_for_json
 from plone import api
 from plone.memoize import instance
 from zope.component import getMultiAdapter
+from zope.event import notify
 from zope.globalrequest import getRequest
 from zope.i18n import translate
+from zope.lifecycleevent import ObjectModifiedEvent
 import base64
 import json
 
@@ -271,8 +273,9 @@ class MergeDocxProtocolCommand(CreateGeneratedDocumentCommand):
         Versioner(document).create_version(comment)
         new_version = document.get_current_version_id()
         self.meeting.protocol_document.generated_version = new_version
-        document.setModificationDate(DateTime())
-        document.reindexObject(idxs=['modified'])
+
+        notify(ObjectModifiedEvent(document))
+
         self.protocol_updated = True
         return document
 
@@ -370,8 +373,8 @@ class UpdateGeneratedDocumentCommand(object):
         Versioner(document).create_version(comment)
         new_version = document.get_current_version_id()
         self.generated_document.generated_version = new_version
-        document.setModificationDate(DateTime())
-        document.reindexObject(idxs=['modified'])
+
+        notify(ObjectModifiedEvent(document))
 
         return document
 

--- a/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-01-24 15:53+0000\n"
+"POT-Creation-Date: 2019-02-07 09:13+0000\n"
 "PO-Revision-Date: 2017-10-23 18:40+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -609,11 +609,6 @@ msgstr "Diese Gruppe kann die Kommission bearbeiten und einsehen."
 msgid "document_checkout_not_allowed"
 msgstr "Sie dürfen das Dokument nicht auschecken."
 
-#. Default: "Created at ${date}"
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt
-msgid "document_created_at"
-msgstr "Erstellt am ${date} Uhr"
-
 #. Default: "Agenda item list"
 #: ./opengever/meeting/browser/meetings/meeting.py
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt
@@ -629,6 +624,11 @@ msgstr "Vorprotokoll"
 #: ./opengever/meeting/browser/meetings/meeting.py
 msgid "document_label_protocol"
 msgstr "Protokoll"
+
+#. Default: "Modified at ${date}"
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt
+msgid "document_last_modified"
+msgstr "Zuletzt verändert: ${date}"
 
 #. Default: "Not yet generated."
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt

--- a/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-01-24 15:53+0000\n"
+"POT-Creation-Date: 2019-02-07 09:13+0000\n"
 "PO-Revision-Date: 2018-05-22 10:15+0000\n"
 "Last-Translator: Niklaus Johner <Niklaus.johner@4teamwork.ch>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-meeting/fr/>\n"
@@ -611,11 +611,6 @@ msgstr "Ce groupe peut modifier et consulter le comité."
 msgid "document_checkout_not_allowed"
 msgstr "Vous n'êtes pas autorisé(e) à extraire le document."
 
-#. Default: "Created at ${date}"
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt
-msgid "document_created_at"
-msgstr "Etabli le ${date} heure"
-
 #. Default: "Agenda item list"
 #: ./opengever/meeting/browser/meetings/meeting.py
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt
@@ -631,6 +626,11 @@ msgstr "Pré-protocole"
 #: ./opengever/meeting/browser/meetings/meeting.py
 msgid "document_label_protocol"
 msgstr "Protocole"
+
+#. Default: "Modified at ${date}"
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt
+msgid "document_last_modified"
+msgstr ""
 
 #. Default: "Not yet generated."
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt

--- a/opengever/meeting/locales/opengever.meeting.pot
+++ b/opengever/meeting/locales/opengever.meeting.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-01-24 15:53+0000\n"
+"POT-Creation-Date: 2019-02-07 09:13+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -608,11 +608,6 @@ msgstr ""
 msgid "document_checkout_not_allowed"
 msgstr ""
 
-#. Default: "Created at ${date}"
-#: ./opengever/meeting/browser/meetings/templates/meeting.pt
-msgid "document_created_at"
-msgstr ""
-
 #. Default: "Agenda item list"
 #: ./opengever/meeting/browser/meetings/meeting.py
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt
@@ -627,6 +622,11 @@ msgstr ""
 #. Default: "Protocol"
 #: ./opengever/meeting/browser/meetings/meeting.py
 msgid "document_label_protocol"
+msgstr ""
+
+#. Default: "Modified at ${date}"
+#: ./opengever/meeting/browser/meetings/templates/meeting.pt
+msgid "document_last_modified"
 msgstr ""
 
 #. Default: "Not yet generated."

--- a/opengever/meeting/tests/test_meeting_view.py
+++ b/opengever/meeting/tests/test_meeting_view.py
@@ -62,7 +62,7 @@ class TestMeetingView(IntegrationTestCase):
         docnode = browser.css('.meeting-document.agenda-item-list-doc').first
         self.assertFalse(docnode.css('div.document-label a'))
         self.assertEquals('Agenda item list', docnode.css('.document-label').first.text)
-        self.assertEquals('Not yet generated.', docnode.css('.document-created').first.text)
+        self.assertEquals('Not yet generated.', docnode.css('.document-modified').first.text)
         self.assertTrue(docnode.css('.action.generate'))
         self.assertFalse(docnode.css('.action.download'))
 
@@ -71,7 +71,7 @@ class TestMeetingView(IntegrationTestCase):
             docnode = browser.css('.meeting-document.agenda-item-list-doc').first
             self.assertTrue(docnode.css('div.document-label a'))
             self.assertEquals('Agenda item list', docnode.css('.document-label').first.text)
-            self.assertEquals('Created at Sep 02, 2016 12:15 PM', docnode.css('.document-created').first.text)
+            self.assertEquals('Modified at Sep 02, 2016 12:15 PM', docnode.css('.document-modified').first.text)
             self.assertTrue(docnode.css('.action.generate'))
             self.assertTrue(docnode.css('.action.download'))
 
@@ -81,7 +81,7 @@ class TestMeetingView(IntegrationTestCase):
             clock.forward(hours=1)
             docnode.css('.action.generate').first.click()
             docnode = browser.css('.meeting-document.agenda-item-list-doc').first
-            self.assertEquals('Created at Sep 02, 2016 01:15 PM', docnode.css('.document-created').first.text)
+            self.assertEquals('Modified at Sep 02, 2016 01:15 PM', docnode.css('.document-modified').first.text)
 
     @browsing
     def test_protocol_document(self, browser):
@@ -91,7 +91,7 @@ class TestMeetingView(IntegrationTestCase):
         docnode = browser.css('.meeting-document.protocol-doc').first
         self.assertFalse(docnode.css('div.document-label a'))
         self.assertEquals('Pre-protocol', docnode.css('.document-label').first.text)
-        self.assertEquals('Not yet generated.', docnode.css('.document-created').first.text)
+        self.assertEquals('Not yet generated.', docnode.css('.document-modified').first.text)
         self.assertTrue(docnode.css('.action.generate'))
         self.assertFalse(docnode.css('.action.download'))
 
@@ -100,7 +100,7 @@ class TestMeetingView(IntegrationTestCase):
             docnode = browser.css('.meeting-document.protocol-doc').first
             self.assertTrue(docnode.css('div.document-label a'))
             self.assertEquals('Pre-protocol', docnode.css('.document-label').first.text)
-            self.assertEquals('Created at Sep 02, 2016 12:15 PM', docnode.css('.document-created').first.text)
+            self.assertEquals('Modified at Sep 02, 2016 12:15 PM', docnode.css('.document-modified').first.text)
             self.assertTrue(docnode.css('.action.generate'))
             self.assertTrue(docnode.css('.action.download'))
 
@@ -110,7 +110,7 @@ class TestMeetingView(IntegrationTestCase):
             clock.forward(hours=1)
             docnode.css('.action.generate').first.click()
             docnode = browser.css('.meeting-document.protocol-doc').first
-            self.assertEquals('Created at Sep 02, 2016 01:15 PM', docnode.css('.document-created').first.text)
+            self.assertEquals('Modified at Sep 02, 2016 01:15 PM', docnode.css('.document-modified').first.text)
 
             self.meeting.model.workflow_state = self.meeting.model.STATE_HELD.name
             browser.reload()


### PR DESCRIPTION
This PR fixes an unmatched label and missing change-date update.

![screen2](https://user-images.githubusercontent.com/557005/52401506-1a9c8c80-2ac2-11e9-8b30-5bbd7ca592e0.gif)

Fixes #5154 