### PR TITLE
Prevent deactivating dossiers with undeactivatable subdossiers

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -23,6 +23,7 @@ Changelog
 - Add a template tab for OneOffixx. [Rotonen]
 - Fix logo upload in the theme control-panel. [phgross]
 - Solr TabbedView filters: Also include non-wildcarded terms in query. [lgraf]
+- Prevent deactivating dossiers with undeactivatable subdossiers. [Rotonen]
 - Add an unrestricted search option to get_subdossiers(). [Rotonen]
 - Better label the Oneoffixx template selection dropdown default value. [Rotonen]
 - Notifications: Defer sending mails until end of transaction. [lgraf]

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -23,6 +23,7 @@ Changelog
 - Add a template tab for OneOffixx. [Rotonen]
 - Fix logo upload in the theme control-panel. [phgross]
 - Solr TabbedView filters: Also include non-wildcarded terms in query. [lgraf]
+- Add an unrestricted search option to get_subdossiers(). [Rotonen]
 - Better label the Oneoffixx template selection dropdown default value. [Rotonen]
 - Notifications: Defer sending mails until end of transaction. [lgraf]
 - Make the Oneoffixx timeout configurable via the registry. [Rotonen]

--- a/opengever/dossier/base.py
+++ b/opengever/dossier/base.py
@@ -185,6 +185,7 @@ class DossierContainer(Container):
             sort_order='ascending',
             review_state=None,
             depth=-1,
+            unrestricted=False,
         ):
 
         dossier_path = '/'.join(self.getPhysicalPath())
@@ -199,7 +200,10 @@ class DossierContainer(Container):
         if review_state:
             query['review_state'] = review_state
 
-        subdossiers = self.portal_catalog(query)
+        if unrestricted:
+            subdossiers = self.portal_catalog.unrestrictedSearchResults(query)
+        else:
+            subdossiers = self.portal_catalog(query)
 
         # Remove the object itself from the list of subdossiers
         subdossiers = [

--- a/opengever/dossier/deactivate.py
+++ b/opengever/dossier/deactivate.py
@@ -1,4 +1,5 @@
 from datetime import date
+from opengever.base.security import elevated_privileges
 from opengever.dossier import _
 from opengever.dossier.behaviors.dossier import IDossier
 from plone import api
@@ -6,9 +7,15 @@ from Products.Five.browser import BrowserView
 
 
 class DossierDeactivateView(BrowserView):
-    """ Recursively deactivate the dossier and his subdossiers.
-    If some subdossiers are already resolved we return a status err msg.
-    If some subdossiers are already deactivated we ignore them."""
+    """Recursively deactivate the dossier and its subdossiers.
+
+    Preconditions:
+    * All contained documents are checked in.
+    * Some subdossiers are already resolved.
+    * Some subdossiers cannot be deactivated by the user.
+    * The user has no access to some of the subdossiers.
+    * The dossier contains active tasks.
+    """
 
     def __call__(self):
         if not self.check_preconditions():
@@ -54,15 +61,53 @@ class DossierDeactivateView(BrowserView):
                   "proposals."), self.request, type='error')
             satisfied = False
 
-        # check for resolved subdossiers
-        for subdossier in self.context.get_subdossiers():
-            state = api.content.get_state(obj=subdossier.getObject())
-            if state == 'dossier-state-resolved':
-                msg = _(u"The Dossier can't be deactivated, the subdossier "
-                       "${dossier} is already resolved",
-                       mapping=dict(dossier=subdossier.Title.decode('utf-8')))
-                api.portal.show_message(msg, self.request, type='error')
+        # Check for subdossiers the user cannot deactivate
+        for subdossier in self.context.get_subdossiers(unrestricted=True):
+            with elevated_privileges():
+                subdossier = subdossier.getObject()
 
+            wftool = api.portal.get_tool('portal_workflow')
+            user_can_deactivate = any(
+                transition['name'] == 'dossier-transition-deactivate'
+                for transition in wftool.getTransitionsFor(subdossier)
+            )
+            state = api.content.get_state(subdossier)
+
+            # A subdossier already being inactive is not a blocker
+            if not user_can_deactivate and state != 'dossier-state-inactive':
+                if api.user.has_permission('View', obj=subdossier):
+                    subdossier_title = subdossier.title_or_id()
+                    # We cannot deactivate if some of the subdossiers are already resolved
+                    if state == 'dossier-state-resolved':
+                        msg = _(
+                            u"The Dossier can't be deactivated, the subdossier ${dossier} is already resolved.",
+                            mapping=dict(dossier=subdossier_title),
+                        )
+                    else:
+                        # The deactvation of this subdossier is most likely not allowed by role
+                        msg = _(
+                            u"The Dossier ${dossier} can't be deactivated by the user.",
+                            mapping=dict(dossier=subdossier_title),
+                        )
+                # Inform the user which of the parents contains the blocking subdossier they cannot see
+                else:
+                    # We are guaranteed to hit a dossier the user can view
+                    # Grab the title of the first parent we do have access to
+                    # Default to an empty string
+                    parent_title = ''
+                    parent = subdossier.get_parent_dossier()
+                    while parent:
+                        if api.user.has_permission('View', obj=parent):
+                            parent_title = parent.title_or_id()
+                            break
+                        parent = subdossier.get_parent_dossier()
+
+                    msg = _(
+                        u"The Dossier ${dossier} contains a subdossier which can't be deactivated by the user.",
+                        mapping=dict(dossier=parent_title),
+                    )
+
+                api.portal.show_message(msg, self.request, type='error')
                 satisfied = False
 
         if self.context.has_active_tasks():

--- a/opengever/dossier/locales/de/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/de/LC_MESSAGES/opengever.dossier.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2019-02-08 12:46+0000\n"
+"POT-Creation-Date: 2019-02-06 20:56+0000\n"
 "PO-Revision-Date: 2017-05-23 04:53+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: German <https://translations.onegovgever.ch/projects/onegov-gever/opengever-dossier/de/>\n"
@@ -136,6 +136,14 @@ msgid "Templates"
 msgstr "Vorlagen"
 
 #: ./opengever/dossier/deactivate.py
+msgid "The Dossier ${dossier} can't be deactivated by the user."
+msgstr "Der Benutzer darf das Dossier ${dossier} nicht stornieren."
+
+#: ./opengever/dossier/deactivate.py
+msgid "The Dossier ${dossier} contains a subdossier which can't be deactivated by the user."
+msgstr "Das Dossier ${dossier} enthält ein Subdossier welches der Benutzer nicht stornieren darf."
+
+#: ./opengever/dossier/deactivate.py
 msgid "The Dossier can't be deactivated, it contains active proposals."
 msgstr "Das Dossier kann nicht storniert werden, es enthält aktive Anträge."
 
@@ -148,7 +156,7 @@ msgid "The Dossier can't be deactivated, not all containeddocuments are checked 
 msgstr "Das Dossier kann nicht storniert werden, da nicht alle enthaltenen Dokumente eingecheckt sind."
 
 #: ./opengever/dossier/deactivate.py
-msgid "The Dossier can't be deactivated, the subdossier ${dossier} is already resolved"
+msgid "The Dossier can't be deactivated, the subdossier ${dossier} is already resolved."
 msgstr "Das Dossier konnte nicht storniert werden, da das Subdossier ${dossier} bereits abgeschlossen ist. Das Subdossier muss vorgängig wieder eröffnet werden."
 
 #: ./opengever/dossier/activate.py

--- a/opengever/dossier/locales/fr/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/fr/LC_MESSAGES/opengever.dossier.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-02-08 12:46+0000\n"
+"POT-Creation-Date: 2019-02-06 20:56+0000\n"
 "PO-Revision-Date: 2017-12-03 11:16+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-dossier/fr/>\n"
@@ -134,6 +134,14 @@ msgid "Templates"
 msgstr "Modèles"
 
 #: ./opengever/dossier/deactivate.py
+msgid "The Dossier ${dossier} can't be deactivated by the user."
+msgstr "L'utilisateur n'a pas le droit d'annuler le dossier ${dossier}."
+
+#: ./opengever/dossier/deactivate.py
+msgid "The Dossier ${dossier} contains a subdossier which can't be deactivated by the user."
+msgstr "Le dossier ${dossier} contient un sous-dossier que l'utilisateur n'a pas le droit d'annuler."
+
+#: ./opengever/dossier/deactivate.py
 msgid "The Dossier can't be deactivated, it contains active proposals."
 msgstr "Le dossier ne peut pas être annulé, il contient des requêtes actives."
 
@@ -146,7 +154,7 @@ msgid "The Dossier can't be deactivated, not all containeddocuments are checked 
 msgstr "Ce dossier ne peut pas être annulé, parce qu'il contient des documents qui ne sont pas en statut \"checkin\"."
 
 #: ./opengever/dossier/deactivate.py
-msgid "The Dossier can't be deactivated, the subdossier ${dossier} is already resolved"
+msgid "The Dossier can't be deactivated, the subdossier ${dossier} is already resolved."
 msgstr "Impossible d'annuler le dossier, parce que le sous-dossier ${dossier} a déjà été clôturé. Le sous-dossier doit d'abord être rouvert."
 
 #: ./opengever/dossier/activate.py

--- a/opengever/dossier/locales/opengever.dossier.pot
+++ b/opengever/dossier/locales/opengever.dossier.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-02-08 12:46+0000\n"
+"POT-Creation-Date: 2019-02-06 20:56+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -135,6 +135,14 @@ msgid "Templates"
 msgstr ""
 
 #: ./opengever/dossier/deactivate.py
+msgid "The Dossier ${dossier} can't be deactivated by the user."
+msgstr ""
+
+#: ./opengever/dossier/deactivate.py
+msgid "The Dossier ${dossier} contains a subdossier which can't be deactivated by the user."
+msgstr ""
+
+#: ./opengever/dossier/deactivate.py
 msgid "The Dossier can't be deactivated, it contains active proposals."
 msgstr ""
 
@@ -147,7 +155,7 @@ msgid "The Dossier can't be deactivated, not all containeddocuments are checked 
 msgstr ""
 
 #: ./opengever/dossier/deactivate.py
-msgid "The Dossier can't be deactivated, the subdossier ${dossier} is already resolved"
+msgid "The Dossier can't be deactivated, the subdossier ${dossier} is already resolved."
 msgstr ""
 
 #: ./opengever/dossier/activate.py

--- a/opengever/dossier/tests/test_base.py
+++ b/opengever/dossier/tests/test_base.py
@@ -6,8 +6,11 @@ from ftw.testbrowser import browsing
 from ftw.testbrowser.pages import factoriesmenu
 from ftw.testing import freeze
 from opengever.base.behaviors.changed import IChanged
+from opengever.base.role_assignments import RoleAssignmentManager
+from opengever.base.role_assignments import SharingRoleAssignment
 from opengever.document.interfaces import IDossierJournalPDFMarker
 from opengever.dossier.behaviors.dossier import IDossier
+from opengever.dossier.behaviors.protect_dossier import IProtectDossier
 from opengever.dossier.interfaces import IDossierContainerTypes
 from opengever.testing import IntegrationTestCase
 from plone import api
@@ -347,3 +350,28 @@ class TestDateCalculations(IntegrationTestCase):
         self.login(self.dossier_responsible)
         self.assertTrue(self.dossier.is_addable('opengever.document.document'))
         self.assertFalse(self.expired_dossier.is_addable('opengever.document.document'))
+
+    def test_get_subdossiers_unrestricted_search(self):
+        self.login(self.dossier_manager)
+        # Protect self.subsubdossier so it cannot be seen by an 'Editor' of self.subdossier
+        self.assertFalse(getattr(self.subsubdossier, '__ac_local_roles_block__', False))
+        dossier_protector = IProtectDossier(self.subsubdossier)
+        dossier_protector.dossier_manager = self.dossier_manager.getId()
+        dossier_protector.reading = [self.secretariat_user.getId()]
+        dossier_protector.protect()
+        self.assertTrue(getattr(self.subsubdossier, '__ac_local_roles_block__', False))
+        self.assertFalse(
+            api.user.has_permission('View', user=self.regular_user, obj=self.subsubdossier),
+            'This test does not actually test what it says on the tin, if self.regular_user can see self.subsubdossier.',
+        )
+
+        # Grant self.regular_user 'Editor' on self.subdossier so it can be closed by that user
+        RoleAssignmentManager(self.subdossier).add_or_update_assignment(
+            SharingRoleAssignment(self.regular_user.getId(), ['Reader', 'Contributor', 'Editor']))
+
+        with self.login(self.regular_user):
+            restricted_subdossiers = self.subdossier.get_subdossiers()
+            unrestricted_subdossiers = self.subdossier.get_subdossiers(unrestricted=True)
+
+        self.assertSequenceEqual([], map(self.brain_to_object, restricted_subdossiers))
+        self.assertSequenceEqual([self.subsubdossier], map(self.brain_to_object, unrestricted_subdossiers))

--- a/opengever/dossier/tests/test_base.py
+++ b/opengever/dossier/tests/test_base.py
@@ -6,8 +6,6 @@ from ftw.testbrowser import browsing
 from ftw.testbrowser.pages import factoriesmenu
 from ftw.testing import freeze
 from opengever.base.behaviors.changed import IChanged
-from opengever.base.role_assignments import RoleAssignmentManager
-from opengever.base.role_assignments import SharingRoleAssignment
 from opengever.document.interfaces import IDossierJournalPDFMarker
 from opengever.dossier.behaviors.dossier import IDossier
 from opengever.dossier.behaviors.protect_dossier import IProtectDossier
@@ -364,10 +362,6 @@ class TestDateCalculations(IntegrationTestCase):
             api.user.has_permission('View', user=self.regular_user, obj=self.subsubdossier),
             'This test does not actually test what it says on the tin, if self.regular_user can see self.subsubdossier.',
         )
-
-        # Grant self.regular_user 'Editor' on self.subdossier so it can be closed by that user
-        RoleAssignmentManager(self.subdossier).add_or_update_assignment(
-            SharingRoleAssignment(self.regular_user.getId(), ['Reader', 'Contributor', 'Editor']))
 
         with self.login(self.regular_user):
             restricted_subdossiers = self.subdossier.get_subdossiers()

--- a/opengever/dossier/tests/test_deactivate.py
+++ b/opengever/dossier/tests/test_deactivate.py
@@ -6,8 +6,12 @@ from ftw.testbrowser import browsing
 from ftw.testbrowser.pages import editbar
 from ftw.testbrowser.pages import statusmessages
 from ftw.testing import freeze
+from opengever.base.role_assignments import RoleAssignmentManager
+from opengever.base.role_assignments import SharingRoleAssignment
 from opengever.dossier.behaviors.dossier import IDossier
+from opengever.dossier.behaviors.protect_dossier import IProtectDossier
 from opengever.testing import IntegrationTestCase
+from plone import api
 
 
 class TestDossierDeactivation(IntegrationTestCase):
@@ -21,7 +25,7 @@ class TestDossierDeactivation(IntegrationTestCase):
         self.assert_workflow_state('dossier-state-active', self.dossier)
         statusmessages.assert_message(
             u"The Dossier can\'t be deactivated,"
-            u" the subdossier 2016 is already resolved")
+            u" the subdossier 2016 is already resolved.")
 
     @browsing
     def test_fails_with_checked_out_documents(self, browser):
@@ -85,3 +89,26 @@ class TestDossierDeactivation(IntegrationTestCase):
             editbar.menu_option('Actions', 'dossier-transition-deactivate').click()
 
         self.assertEqual(date(2016, 3, 29), IDossier(self.empty_dossier).end)
+
+    @browsing
+    def test_subdossiers_the_user_cannot_view_can_also_block_deactivation(self, browser):
+        with self.login(self.dossier_manager):
+            # Protect self.subsubdossier so it cannot be seen by an 'Editor' of self.subdossier
+            self.assertFalse(getattr(self.subsubdossier, '__ac_local_roles_block__', False))
+            dossier_protector = IProtectDossier(self.subsubdossier)
+            dossier_protector.dossier_manager = self.dossier_manager.getId()
+            dossier_protector.reading = [self.secretariat_user.getId()]
+            dossier_protector.protect()
+            self.assertTrue(getattr(self.subsubdossier, '__ac_local_roles_block__', False))
+            self.assertFalse(
+                api.user.has_permission('View', user=self.regular_user, obj=self.subsubdossier),
+                'This test does not actually test what it says on the tin, if self.regular_user can see self.subsubdossier.',
+            )
+
+            # Grant self.regular_user 'Editor' on self.subdossier so the action to deactivate is presented to the user
+            RoleAssignmentManager(self.subdossier).add_or_update_assignment(
+                SharingRoleAssignment(self.regular_user.getId(), ['Reader', 'Contributor', 'Editor']))
+
+        self.login(self.regular_user, browser)
+        browser.open(self.subdossier, view='transition-deactivate', send_authenticator=True)
+        statusmessages.assert_message("The Dossier 2016 contains a subdossier which can't be deactivated by the user.")


### PR DESCRIPTION
The check is not done as a workflow transition guard as that'd make visiting deeply/widely populated dossiers very expensive.

⚠️ Missing translations.

Closes #5153