### PR TITLE
Aktaulisierung interne Informationen zu Feedbackforum

### DIFF
--- a/docs/intern/kurzreferenzen/feedbackforum-prozess.rst
+++ b/docs/intern/kurzreferenzen/feedbackforum-prozess.rst
@@ -1,38 +1,27 @@
-Prozess Feedbackforum
-=====================
-Der Prozess innerhalb des Feedbackforums wird primär durch die Kategorien und
-Schlagwörter bestimmt. Sobald durch einen OneGov GEVER-Benutzer ein neues Thema
-im Feedbackforum erstellt wird, wird die Kategorisierung und Setzung eines
-Schlagwortes durch den Feedbackforum-Moderator (aktuell primär durch Livia)
-vorgenommen und dadurch der Prozess jeweils angestossen.
+Feedbackforum
+=============
+Sobald durch einen Benutzenden des Feedbackforums ein neues Thema erstellt wird,
+wird die Kategorisierung und Setzung eines Schlagwortes durch den Moderator des
+Feedbackforums vorgenommen. Dabei soll folgendes beim Festlegen einer
+Kategorie/Schlagwort beachtet werden:
 
 Kategorien
 ----------
 Es wurden folgende Kategorien für die Themen definiert:
 
-- ``Feature:`` Thema behandelt eine Erweiterung von OneGov GEVER
+- ``Feature:`` Thema behandelt eine mögliche Erweiterung von OneGov GEVER
 
 - ``Info:`` Thema informiert über neuen Release, Modul etc.
 
 - ``Support:`` Thema behandelt Problem, das im Alltag eines Benutzers aufgetreten ist und nach einer Best-Practice-Empfehlung von anderen versierten Benutzern fragt.
 
-- ``Intern:`` Thema wurde von 4tw-Mitarbeitern erfasst und beinhaltet Verbesserungs-Vorschläge.
+- ``Intern:`` Thema wurde von 4tw-Mitarbeitern erfasst und beinhaltet Verbesserungs-Vorschläge. Diese Kategorie ist nur für 4tw-Mitarbeiter ersichtlich.
 
 Schlagwörter
 ------------
-Die Schlagwörter können in folgende zwei Gruppen unterteilt werden:
+Jedes Thema soll mind. eines der nachfolgenden Schlagworte besitzen:
 
-1. Es gibt Schlagwörter, die definieren den Status des Themas. Pro Thema darf immer nur ein Schlagwort von dieser Liste aktiv sein. Es können aber parallel Schlagwörter von der zweiten Liste unten angewählt werden:
-
-- ``diskussion:`` Ein neuer Beitrag wird meist zuerst in diesen Status gesetzt, da die Community darüber diskutieren soll.
-
-- ``geplant:`` Wurde durch die Diskussion herausgefunden, dass dies ein nützliches Feature ist und gut umsetzbar ist (resp. kein OGIP dazu geschrieben werden muss oder eine Korrektur ist) wird in Absprache mit einem GEVER-Entwickler der Status auf geplant gesetzt und ein Github-Issue vom Moderator erstellt.
-
-- ``umsetzung:`` Sobald das Thema in Umsetzung ist, wird dieses Schlagwort vom Entwickler gesetzt.
-
-- ``realisiert:`` Sobald das Thema realisert wurde, wird dieses Schlagwort gesetzt. Sobald der Release herauskommt, bei welchem dieses Thema eingespielt wird, kann das Thema dann geschlossen werden.
-
-2. Es gibt Schlagwörter, die behandeln ein spezifisches Thema. Von diesen können mehrere aktiviert werden und es sollte max. 1 Schlagwort von der ersten Liste oben ergänzt werden:
+- ``diskussion:`` Ein neuer Beitrag wird meist zuerst in diesen Status gesetzt, da die Community darüber diskutieren soll. In diesem Status bleibt es auch, während es in der Umsetzungs-Phase ist, da auch da noch relevante Inputs eingehen können.
 
 - ``spv:`` Alle Beiträge die sich mit der SPV (Sitzungs- und Protokollverwaltung) auseinander setzen.
 
@@ -40,10 +29,12 @@ Die Schlagwörter können in folgende zwei Gruppen unterteilt werden:
 
 - ``workshop:`` Alle Beiträge die an einem Workshop im Detail angeschaut werden müssen / sollten.
 
+- ``realisiert:`` Sobald das Thema realisert resp. das Feature umgesetzt wurde, wird dieses Schlagwort gesetzt und das Thema kann geschlossen werden.
+
 
 Schliessen eines Themas
 -----------------------
-Ein Thema wird meist nachdem es im Status „realisiert“ ist und der dazugehörige
-Release verfügbar ist, vom Moderator geschlossen. Falls ein Thema in der
-Diskussions-Phase auf keine Zustimmung der restlichen Community stösst, kann
-auch dieses durch den Moderator geschlossen werden.
+Ein Thema wird meist sobald dieses im Status „realisiert“ ist vom Moderator
+geschlossen. Falls ein Thema in der Diskussions-Phase auf keine Zustimmung der
+restlichen Community stösst, kann dieses auch vorher durch den Moderator
+geschlossen werden.


### PR DESCRIPTION
Habe beim Aufräumen des FF die Tags vereinheitlicht resp. zusammengestrichen, da wir viel zu viele hatten, welche nicht gepflegt wurden. Diese Anpassung habe ich nun auch in der Doku aktualisiert.