### PR TITLE
Reenable testserver selftest on jenkins by fixing port choosing.

### DIFF
--- a/base-testserver.cfg
+++ b/base-testserver.cfg
@@ -20,8 +20,6 @@ initialization =
     os.environ.setdefault('FTW_STRUCTLOG_MUTE_SETUP_ERRORS', 'true')
     import sys
     sys.argv.insert(1, 'opengever.core.testserver.OPENGEVER_TESTSERVER')
-    print 'Plone:  http://localhost:{}/plone'.format(os.environ.get('ZSERVER_PORT'))
-    print 'XMLRPC: http://localhost:{}'.format(os.environ.get('LISTENER_PORT'))
 
 
 [testserver-selftest]

--- a/test-testserver-selftest.cfg
+++ b/test-testserver-selftest.cfg
@@ -1,0 +1,23 @@
+[buildout]
+extends =
+    base-plone-4.3.x.cfg
+    base-testserver.cfg
+    https://raw.githubusercontent.com/4teamwork/gever-buildouts/master/ruby-gems.cfg
+
+parts =
+    test
+    gems
+    bin-test-jenkins
+    ${:testserver-parts}
+
+jenkins_python = $PYTHON27
+
+
+[bin-test-jenkins]
+recipe = collective.recipe.template
+input = inline:
+    #!/bin/bash
+    export PYTHONUNBUFFERED=true
+    ${buildout:bin-directory}/testserver-selftest
+output = ${buildout:bin-directory}/test-jenkins
+mode = 755

--- a/versions.cfg
+++ b/versions.cfg
@@ -137,6 +137,7 @@ openpyxl = 2.5.2
 path.py = 11.0.1
 perfmetrics = 2.0
 plone.app.jquery = 1.11.2
+plone.app.robotframework = 1.2.3
 plone.app.transmogrifier = 1.4.1
 plone.app.versioningbehavior = 1.3.1
 plone.principalsource = 1.0


### PR DESCRIPTION
Closes #5331
 
The port choosing method is switched to using a 0-port so that the OS chooses the port in the testserver.

This is done in order to avoid problems where the jenkins master chooses a port, but the test is run at the slave, on which the port is already used.

The robot server is extended so that it prints out the URLs including the chosen ports for the ZServer and the XMLRPC-server. The selftest script now needs to watch the stdout of the testserver process and wait until the URLs appear