### PR TITLE
Testserver: add support for custom fixtures.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1032,6 +1032,39 @@ The ports used by the testserver can easily be changed through environment varia
 - ``TESTSERVER_CTL_PORT`` - the port of the XMLRPC control server (default: ``55002`).
 
 
+Custom fixtures
+~~~~~~~~~~~~~~~
+
+A custom fixture can be loaded in the testserver.
+This is helpful when other projects are testing GEVER integration and need specific content.
+The custom fixture can be defined with an environment variable:
+
+.. code::
+
+   FIXTURE=~/projects/myproject/gever/fixture.py ./bin/testserver
+
+The fixture will be loaded into the testserver process with the dottedname
+``customfixture.fixture``; the package name is always ``customfixture``.
+It is possible to import local files of this folder with ``import .otherfile``.
+
+Example fixture:
+
+.. code::
+
+   from opengever.testing.fixtures import OpengeverContentFixture
+
+   class Fixture(OpengeverContentFixture):
+
+       def __init__(self):
+           super(Fixture, self).__init__()
+           with self.freeze_at_hour(20):
+               self.create_my_custom_content()
+
+The fixture class name defaults to ``Fixture`` and can be changed with the environment
+variable ``FIXTURE_CLASS``.
+
+
+
 Testing on the CI
 ~~~~~~~~~~~~~~~~~
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2019.1.0 (unreleased)
 ---------------------
 
+- Testserver: add support for custom fixtures. [jone]
 - Make sure docproperties gets updated when updating an agendaitem list or a protocol. [phgross]
 - Fix logo upload in the theme control-panel. [phgross]
 - Solr TabbedView filters: Also include non-wildcarded terms in query. [lgraf]

--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -52,9 +52,13 @@ class OpengeverContentFixture(object):
         self._logger = logger = logging.getLogger('opengever.testing')
         self._lookup_table = {
             'manager': ('user', SITE_OWNER_NAME),
-            }
+        }
         self._registered_paths = set()
+        self.configure_jwt_plugin()
+        self.create_fixture_content()
+        logger.info('(fixture setup in %ds) ', round(time() - start, 3))
 
+    def configure_jwt_plugin(self):
         # Set up a static secret for the Zope acl_users JWT plugin
         # XXX - the __call__ based _lookup_table cannot be used within __init__
         with self.login(api.user.get(SITE_OWNER_NAME)):
@@ -67,6 +71,7 @@ class OpengeverContentFixture(object):
         jwt_plugin.use_keyring = False
         jwt_plugin._secret = JWT_SECRET
 
+    def create_fixture_content(self):
         with self.freeze_at_hour(4):
             self.create_units()
 
@@ -138,8 +143,6 @@ class OpengeverContentFixture(object):
                 self.create_offered_dossiers()
             with self.login(self.records_manager):
                 self.create_disposition()
-
-        logger.info('(fixture setup in %ds) ', round(time() - start, 3))
 
     def __call__(self):
         return self._lookup_table


### PR DESCRIPTION
The testserver is useful for testing other projects which use / work
with a GEVER.
Those projects have specific needs: they may need certain content or a specific structure and may not need some parts of GEVER at all.

Thats why we want to be able to inject a custom fixture when starting up the testserver. We need to be able to subclass the default fixture though, so that we can profit from the features in the default fixture.

The custom fixture can be inserted by setting the ``FIXTURE`` environment variable to the path to the fixture python file. The directory of the file needs to be a package, so there needs to be a ``__init__.py``. Since the fixture is stored and maintained in the third party project, it is not part of the python path. The testserver loads the package of the fixture file under the name ``customfixture``, so that importing from gever as well as from this directory works well.

The fixture is changed so that the content creation is moved into a separate method for easier subclassing and changing. We do not want to repeat the init code.