### PR TITLE
Add document tooltip to inbox document listing.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -11,6 +11,7 @@ Changelog
 - Fix scrubbing the server version out of the HTTP response headers. [Rotonen]
 - Make sure docproperties gets updated when updating an agendaitem list or a protocol. [phgross]
 - Fix order issue when deleting a favorite.  [phgross]
+- Add document tooltip to inbox document listing. [njohner]
 - Fix logo upload in the theme control-panel. [phgross]
 - Solr TabbedView filters: Also include non-wildcarded terms in query. [lgraf]
 - Better label the Oneoffixx template selection dropdown default value. [Rotonen]

--- a/opengever/inbox/browser/overview.py
+++ b/opengever/inbox/browser/overview.py
@@ -6,6 +6,7 @@ from opengever.ogds.base.utils import get_current_org_unit
 from opengever.tabbedview import GeverTabMixin
 from opengever.task import OPEN_TASK_STATES
 from plone import api
+from plone.app.contentlisting.interfaces import IContentListing
 from Products.Five.browser import BrowserView
 from sqlalchemy import desc
 
@@ -76,13 +77,5 @@ class InboxOverview(BoxesViewMixin, BrowserView, GeverTabMixin):
                  'sort_order': 'reverse'}
 
         documents = catalog(query)[:10]
-        document_list = [{
-            'Title': document.Title,
-            'getURL': document.getURL,
-            'alt': document.document_date and
-            document.document_date.strftime('%d.%m.%Y') or '',
-            'css_class': get_css_class(document),
-            'portal_type': document.portal_type,
-        } for document in documents]
-
+        document_list = IContentListing(documents)
         return document_list

--- a/opengever/inbox/tests/test_overview.py
+++ b/opengever/inbox/tests/test_overview.py
@@ -87,6 +87,23 @@ class TestInboxOverviewDocumentBox(TestBaseInboxOverview):
              'Document 6', 'Document 5', 'Document 4', 'Document 3',
              'Document 2', 'Document 1'])
 
+    @browsing
+    def test_document_box_items_display_bumblebee_tootlip(self, browser):
+        document = create(Builder('document')
+                          .titled('inbox document')
+                          .within(self.inbox))
+
+        browser.login().open(self.inbox, view='tabbedview_view-overview')
+
+        document_nodes = browser.css('#documentsBox li:not(.moreLink) div')
+        self.assertEqual(1, len(document_nodes))
+
+        document_node = document_nodes[0]
+        self.assertEqual("linkWrapper tooltip-trigger",
+                         document_node.get("class"))
+        self.assertEqual("/".join((document.absolute_url(), "tooltip")),
+                         document_node.get("data-tooltip-url"))
+
 
 class TestInboxOverviewAssignedInboxTasks(TestBaseInboxOverview):
 


### PR DESCRIPTION
Not much to say... just a snapshot with a document worthy of storing in a GEVER:

<img width="1382" alt="screen shot 2019-02-08 at 11 05 47" src="https://user-images.githubusercontent.com/7374243/52471583-8699f600-2b91-11e9-9d8c-424683028f2e.png">

resolves #5350 