### PR TITLE
Register and use a tree portlet builder for testing.

### DIFF
--- a/opengever/api/tests/test_repository.py
+++ b/opengever/api/tests/test_repository.py
@@ -3,6 +3,7 @@ from opengever.testing import IntegrationTestCase
 
 
 class TestRepositoryAPI(IntegrationTestCase):
+
     @browsing
     def test_can_get_repository_root(self, browser):
         self.login(self.regular_user, browser=browser)
@@ -47,7 +48,7 @@ class TestRepositoryAPI(IntegrationTestCase):
             ],
             u'items_total': 3,
             u'layout': u'tabbed_view',
-            u'modified': u'2016-08-31T07:09:33+00:00',
+            u'modified': u'2016-08-31T07:11:33+00:00',
             u'parent': {
                 u'@id': u'http://nohost/plone',
                 u'@type': u'Plone Site',
@@ -62,4 +63,4 @@ class TestRepositoryAPI(IntegrationTestCase):
             u'valid_until': None,
             u'version': None,
         }
-        self.assertEqual(expected_repository_root, browser.json)
+        self.assert_json_structure_equal(expected_repository_root, browser.json)

--- a/opengever/portlets/tree/tests/test_treeportlet.py
+++ b/opengever/portlets/tree/tests/test_treeportlet.py
@@ -11,26 +11,6 @@ class TestTreePortlet(IntegrationTestCase):
 
     features = ('favorites', )
 
-    def setUp(self):
-        super(TestTreePortlet, self).setUp()
-        with self.login(self.administrator):
-            self.add_treeportlet(self.repository_root, self.repository_root)
-
-    def add_treeportlet(self, context, repository_root):
-        manager = getUtility(IPortletManager,
-                             name=u'plone.leftcolumn',
-                             context=self.portal)
-        assignments = getMultiAdapter((context, manager),
-                                      IPortletAssignmentMapping,
-                                      context=self.portal)
-
-        portlet = treeportlet.Assignment(
-            root_path='/'.join(repository_root.getPhysicalPath()))
-
-        name = 'treeportlet_1'
-        portlet.__name__ = portlet
-        assignments[name] = portlet
-
     @browsing
     def test_context_url_data_object_is_absolute_url_of_current_context(self, browser):
         self.login(self.regular_user, browser)

--- a/opengever/testing/builders/__init__.py
+++ b/opengever/testing/builders/__init__.py
@@ -2,6 +2,7 @@ from opengever.testing.builders.activity import *
 from opengever.testing.builders.dx import *
 from opengever.testing.builders.fixture import *
 from opengever.testing.builders.ldap import *
+from opengever.testing.builders.portlets import *
 from opengever.testing.builders.qickupload import *
 from opengever.testing.builders.repositorytree import *
 from opengever.testing.builders.sql import *

--- a/opengever/testing/builders/dx.py
+++ b/opengever/testing/builders/dx.py
@@ -1,6 +1,8 @@
 from datetime import date
 from dateutil.relativedelta import relativedelta
+from ftw.builder import Builder
 from ftw.builder import builder_registry
+from ftw.builder import create
 from ftw.builder.dexterity import DexterityBuilder
 from opengever.base.behaviors.translated_title import TranslatedTitle
 from opengever.base.oguid import Oguid
@@ -327,9 +329,19 @@ class RepositoryRootBuilder(TranslatedTitleBuilderMixin, DexterityBuilder):
 
     def __init__(self, session):
         super(RepositoryRootBuilder, self).__init__(session)
+        self._with_tree_portlet = False
         self.arguments = {
             'title_de': u'Ordnungssystem',
         }
+
+    def with_tree_portlet(self):
+        self._with_tree_portlet = True
+        return self
+
+    def after_create(self, obj):
+        super(RepositoryRootBuilder, self).after_create(obj)
+        if self._with_tree_portlet:
+            create(Builder('tree portlet').for_root(obj))
 
 
 builder_registry.register('repository_root', RepositoryRootBuilder)

--- a/opengever/testing/builders/portlets.py
+++ b/opengever/testing/builders/portlets.py
@@ -1,0 +1,14 @@
+from ftw.builder import builder_registry
+from ftw.builder.portlets import PlonePortletBuilder
+from opengever.portlets.tree import treeportlet
+
+
+class TreePortletBuilder(PlonePortletBuilder):
+    assignment_class = treeportlet.Assignment
+
+    def for_root(self, repository_root):
+        self.having(root_path=repository_root.getId())
+        return self
+
+
+builder_registry.register('tree portlet', TreePortletBuilder)

--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -394,6 +394,7 @@ class OpengeverContentFixture(object):
     def create_repository_tree(self):
         self.root = self.register('repository_root', create(
             Builder('repository_root')
+            .with_tree_portlet()
             .having(
                 title_de=u'Ordnungssystem',
                 title_fr=u'Syst\xe8me de classement',


### PR DESCRIPTION
- Register a new portlet builder `tree portlet` for building tree portlets.
- Add a `with_tree_portlet()` option to the `repository_root` builder.
- Setup the tree in the standard fixture with a portlet.

This is very useful when starting the testserver: until now there was no navigation, which was confusing, especially for non-geverists.