### PR TITLE
Fix scrubbing the server version out of the HTTP response headers

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,7 @@ Changelog
 
 - Testserver: add support for custom fixtures. [jone]
 - Reindex and store additionally supported bumblebee documents. [elioschmutz]
+- Fix scrubbing the server version out of the HTTP response headers. [Rotonen]
 - Make sure docproperties gets updated when updating an agendaitem list or a protocol. [phgross]
 - Fix logo upload in the theme control-panel. [phgross]
 - Solr TabbedView filters: Also include non-wildcarded terms in query. [lgraf]

--- a/opengever/base/subscribers.py
+++ b/opengever/base/subscribers.py
@@ -123,5 +123,7 @@ def disallow_anonymous_views_on_site_root(event):
 
 def scrub_server_version(event):
     """Scrub the server version string response headers."""
-    if getattr(event.request.RESPONSE, '_server_version', None):
-        event.request.RESPONSE._server_version = 'Zope'
+    if getattr(event, 'request', None):
+        if getattr(event.request, 'RESPONSE', None):
+            if getattr(event.request.RESPONSE, '_server_version', None):
+                event.request.RESPONSE._server_version = 'Zope'


### PR DESCRIPTION
Added pessimism to the attribute access.

Closes #5351 