### PR TITLE
Fix order issue when deleting a favorite.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -8,6 +8,7 @@ Changelog
 - Testserver: add support for custom fixtures. [jone]
 - Reindex and store additionally supported bumblebee documents. [elioschmutz]
 - Make sure docproperties gets updated when updating an agendaitem list or a protocol. [phgross]
+- Fix order issue when deleting a favorite.  [phgross]
 - Fix logo upload in the theme control-panel. [phgross]
 - Solr TabbedView filters: Also include non-wildcarded terms in query. [lgraf]
 - Better label the Oneoffixx template selection dropdown default value. [Rotonen]

--- a/opengever/api/tests/test_favorites.py
+++ b/opengever/api/tests/test_favorites.py
@@ -291,26 +291,31 @@ class TestFavoritesDelete(IntegrationTestCase):
     def test_updates_positions_when_deleting_favorite(self, browser):
         self.login(self.administrator, browser=browser)
 
-        fav1 = create(Builder('favorite')
-                      .for_user(self.administrator)
-                      .having(position=0)
-                      .for_object(self.dossier))
-        fav2 = create(Builder('favorite')
-                      .for_user(self.administrator)
-                      .having(position=1)
-                      .for_object(self.document))
-        fav3 = create(Builder('favorite')
+        fav_on_2 = create(Builder('favorite')
                       .for_user(self.administrator)
                       .having(position=2)
+                      .for_object(self.dossier))
+        fav_on_0 = create(Builder('favorite')
+                      .for_user(self.administrator)
+                      .having(position=0)
+                      .for_object(self.document))
+        fav_on_1 = create(Builder('favorite')
+                      .for_user(self.administrator)
+                      .having(position=1)
                       .for_object(self.leaf_repofolder))
+        fav_on_3 = create(Builder('favorite')
+                      .for_user(self.administrator)
+                      .having(position=3)
+                      .for_object(self.meeting_dossier))
 
         url = '{}/@favorites/{}/{}'.format(
             self.portal.absolute_url(), self.administrator.getId(),
-            fav1.favorite_id)
+            fav_on_0.favorite_id)
         browser.open(url, method='DELETE', headers={'Accept': 'application/json'})
 
-        self.assertEqual(0, fav2.position)
-        self.assertEqual(1, fav3.position)
+        self.assertEqual(0, fav_on_1.position)
+        self.assertEqual(1, fav_on_2.position)
+        self.assertEqual(2, fav_on_3.position)
 
     @browsing
     def test_raises_unauthorized_when_removing_a_favorite_of_a_other_user(self, browser):

--- a/opengever/base/favorite.py
+++ b/opengever/base/favorite.py
@@ -18,7 +18,8 @@ class FavoriteManager(object):
 
         # update positions
         favorites_to_reduce = Favorite.query.by_userid(userid).filter(
-            Favorite.position > favorite.position).with_for_update()
+            Favorite.position > favorite.position).with_for_update().order_by(
+                Favorite.position)
 
         for new_pos, fav_to_reduce in enumerate(
                 favorites_to_reduce, start=favorite.position):


### PR DESCRIPTION
The functionality which raises the position for the favorites after the one which has been deleted, destruct the order.

Closes #5288