### PR TITLE
Fix mail for task added activity with multiline comment.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ---------------------
 
 - Make sure favorite button is in front of the watermark header. [njohner]
+- Fix mail for task added activity with multiline comment. [njohner]
 - Skip creation of the tasks pdf on resolve for dossiers without tasks. [phgross]
 - Give View permission to Editors on mails. [njohner]
 - Clear role assignments on contained object after forwarding creation. [njohner]

--- a/opengever/task/activities.py
+++ b/opengever/task/activities.py
@@ -56,9 +56,12 @@ class TaskAddedActivity(BaseActivity):
     def render_description_markup(self, data, language):
         msg = u'<table><tbody>'
         for label, value in data:
-            msg = u'{}<tr><td class="label">{}</td><td>{}</td></tr>'.format(
-                msg, self.translate(label, language), value)
-
+            msg = u'{}<tr><td class="label">{}</td><td>'.format(
+                msg, self.translate(label, language))
+            # Break lines correctly in the table rows
+            if value:
+                msg += u"<br />".join(value.splitlines())
+            msg += u"</td></tr>"
         return u'{}</tbody></table>'.format(msg)
 
     def collect_description_data(self, language):


### PR DESCRIPTION
Notification mails for task added activity were not displayed correctly if the Description was multiline.
The problem stems from https://github.com/4teamwork/opengever.core/pull/4152/commits/a2b502635b4576d4b9a29d6b99bc49a6ca3e6b19, where we break up the description into html paragraph blocks if it is multiline. Problem is that for task-added activity, the Description is already an html table, leading to overlapping tags in the final html. gmail then tries to fix the html, but doesn't manage it correctly (whereas mail for example succeeded in fixing the markup).

Proposed solution is to treat the linebreaks beforehand for the case of task-added activity.

**task-added activity before this fix**

<img width="1399" alt="screen shot 2019-02-11 at 11 32 52" src="https://user-images.githubusercontent.com/7374243/52564609-ed731580-2e04-11e9-8c8e-64c1a3f006df.png">

**task-added activity before this fix**

<img width="1399" alt="screen shot 2019-02-11 at 11 32 36" src="https://user-images.githubusercontent.com/7374243/52564599-e64c0780-2e04-11e9-96df-24e234f22f24.png">

resolves #5290 and https://github.com/4teamwork/opengever.ftw/issues/81