### PR TITLE
Avoid infinite loops when looking for parent dossiers

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2019.1.0 (unreleased)
 ---------------------
 
+- Avoid infinite loops when looking for parent dossiers. [lgraf]
 - Make sure favorite button is in front of the watermark header. [njohner]
 - Skip creation of the tasks pdf on resolve for dossiers without tasks. [phgross]
 - Give View permission to Editors on mails. [njohner]

--- a/opengever/dossier/utils.py
+++ b/opengever/dossier/utils.py
@@ -11,7 +11,7 @@ ELLIPSIS = unicodedata.lookup('HORIZONTAL ELLIPSIS')
 
 
 def get_containing_dossier(obj):
-    while not IPloneSiteRoot.providedBy(obj):
+    while obj and not IPloneSiteRoot.providedBy(obj):
         if IDossierMarker.providedBy(obj) or IInbox.providedBy(obj):
             return obj
         obj = aq_parent(aq_inner(obj))
@@ -39,7 +39,7 @@ def get_main_dossier(obj):
     If the given object is not storred inside a dossier it returns None."""
 
     dossier = None
-    while not IPloneSiteRoot.providedBy(obj):
+    while obj and not IPloneSiteRoot.providedBy(obj):
         if IDossierMarker.providedBy(obj) or IInbox.providedBy(obj):
             dossier = obj
 


### PR DESCRIPTION
When using `while` loops to walk up the parents in the acquisition chain to find a particular object (or stop at the site root), care must be taken to consider the case of **improperly AQ wrapped objects**:

When these functions get passed objects that aren't AQ wrapped (or don't have a full acquisition chain that reaches up to the Plone site), `aq_parent()` will return `None` at some point.

If this isn't accounted for and dealt with by terminating the loop, this kind of a while loop can end in an infinite loop.

*(No tests, because failing tests for this would cause Jenkins jobs to get stuck pretty much by definition)*