### PR TITLE
Make bumblebee access tokens predictable in testing.

### DIFF
--- a/opengever/core/testserver.py
+++ b/opengever/core/testserver.py
@@ -31,6 +31,12 @@ class TestserverLayer(OpengeverFixture):
         portal.portal_languages.use_combined_language_codes = True
         portal.portal_languages.addSupportedLanguage('de-ch')
 
+        os.environ['BUMBLEBEE_DEACTIVATE'] = 'True'
+        os.environ['BUMBLEBEE_APP_ID'] = 'local'
+        os.environ['BUMBLEBEE_SECRET'] = 'secret'
+        os.environ['BUMBLEBEE_INTERNAL_PLONE_URL'] = 'http://nohost/plone'
+        os.environ['BUMBLEBEE_PUBLIC_URL'] = 'http://bumblebee'
+
         setRequest(portal.REQUEST)
         print 'Installing fixture. Have patience.'
         self.get_fixture_class()()

--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -9,6 +9,7 @@ from datetime import timedelta
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.builder import ticking_creator
+from ftw.bumblebee.interfaces import IBumblebeeUserSaltStore
 from ftw.bumblebee.tests.helpers import asset as bumblebee_asset
 from ftw.testing import freeze
 from ftw.testing import staticuid
@@ -1745,6 +1746,9 @@ class OpengeverContentFixture(object):
             .in_group(group)
             .having(**kwargs)
             )
+
+        user_salt_storage = IBumblebeeUserSaltStore(api.portal.get())._get_storage()
+        user_salt_storage[plone_user.getId()] = '{}-user-salt'.format(plone_user.getId())
 
         self._lookup_table[attrname] = ('user', plone_user.getId())
         return plone_user


### PR DESCRIPTION
In testing, we want to have predictable access tokens in order to test against or when using `testserver` with a VCR tape.
In order to make the access token predictable we need a predictable user salt and a configured bumblebee salt.

Bumblebee's `bid` is also random, but we decided to not solve that in GEVER yet because we probably would have to monkey patch it.
There are other solutions, such as:
- append `?bid=static-bid-xy` to all requests; the same bid will be returned
- remove the bid from all urls before serializing VCR tapes

The bid is not relevant for the bumblebee or GEVER functionality. The sole purpose is to be able to correlate requests over multiple services.

/cc @lvonlanthen 