### PR TITLE
Suppress deletion events when filtering objects from copied subtrees

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2019.1.0 (unreleased)
 ---------------------
 
+- Suppress deletion events when filtering objects from copied subtrees. [lgraf]
 - Avoid infinite loops when looking for parent dossiers. [lgraf]
 - Make sure favorite button is in front of the watermark header. [njohner]
 - Fix mail for task added activity with multiline comment. [njohner]

--- a/opengever/dossier/tests/test_copy_dossier.py
+++ b/opengever/dossier/tests/test_copy_dossier.py
@@ -1,7 +1,10 @@
 from ftw.builder import Builder
 from ftw.builder import create
+from OFS.interfaces import IObjectWillBeRemovedEvent
 from opengever.base.interfaces import IReferenceNumberPrefix
 from opengever.testing import IntegrationTestCase
+from opengever.testing.event_recorder import get_recorded_events
+from opengever.testing.event_recorder import register_event_recorder
 from plone import api
 from zope.app.intid.interfaces import IIntIds
 from zope.component import getUtility
@@ -82,6 +85,13 @@ class TestCopyDossiers(IntegrationTestCase):
                        responsible=self.regular_user.getId(),
                        issuer=self.dossier_responsible.getId()))
 
+        register_event_recorder(IObjectWillBeRemovedEvent)
+
         copied_dossier = api.content.copy(
             source=self.empty_dossier, target=self.empty_repofolder)
         self.assertItemsEqual([], copied_dossier.getFolderContents())
+
+        self.assertFalse(
+            any(IObjectWillBeRemovedEvent.providedBy(event) for
+                event in get_recorded_events())
+        )

--- a/opengever/task/handlers.py
+++ b/opengever/task/handlers.py
@@ -26,9 +26,17 @@ def delete_copied_task(copied_task, event):
 
     This deletes the task from the copied subtree (a ZEXP) before the subtree
     gets inserted into the destination location.
+
+    Suppress deletion events in order to avoid attempts to uncatalog
+    an object that
+    1) hasn't even been cataloged yet
+    2) doesn't have a proper AQ chain because it's parts of a subtree
+       that only exists as a temporary ZEXP that hasn't been attached to
+       a container yet
     """
     with elevated_privileges():
-        api.content.delete(copied_task)
+        container = aq_parent(copied_task)
+        container._delObject(copied_task.id, suppress_events=True)
 
 
 def create_subtask_response(context, event):


### PR DESCRIPTION
When "filtering" objects (currently tasks and proposals) from copied subtrees, we do so by deleting them from the temporary ZEXP that's about to be attached to the destination container.

We need to **suppress deletion events** in order to avoid attempts to uncatalog objects that
- haven't even been cataloged yet and
- dont' have a proper AQ chain because they're part of a subtree
that hasn't been attached to a container yet.

Fixes #5347