### PR TITLE
Add date string localization for sablon data.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2019.1.0 (unreleased)
 ---------------------
 
+- Add date string localization for sablon data. [njohner]
 - Set default language for task reminders. [njohner]
 - Suppress deletion events when filtering objects from copied subtrees. [lgraf]
 - Avoid infinite loops when looking for parent dossiers. [lgraf]

--- a/opengever/base/date_time.py
+++ b/opengever/base/date_time.py
@@ -1,5 +1,17 @@
 from datetime import datetime
+from DateTime import DateTime
+from DateTime.interfaces import IDateTime
+from Products.CMFPlone.utils import log
+from zope.i18n import translate
+from Products.CMFPlone.i18nl10n import _interp_regex
+from Products.CMFPlone.i18nl10n import datetime_formatvariables
+from Products.CMFPlone.i18nl10n import name_formatvariables
+from Products.CMFPlone.i18nl10n import weekdayname_msgid_abbr
+from Products.CMFPlone.i18nl10n import weekdayname_msgid
+from Products.CMFPlone.i18nl10n import monthname_msgid_abbr
+from Products.CMFPlone.i18nl10n import monthname_msgid
 import pytz
+import logging
 
 
 def utcnow_tz_aware():
@@ -11,3 +23,97 @@ def as_utc(aware_dt):
     """Convert timezone aware datetime to UTC timezone."""
 
     return pytz.UTC.normalize(aware_dt.astimezone(pytz.UTC))
+
+
+def format_string_to_message_string(formatstring):
+    """python date format string (e.g. u"%A %d %B %Y") to
+    translatable message string ("${A} ${d} ${B} ${Y}")
+    """
+
+    for key in datetime_formatvariables + name_formatvariables:
+        formatstring = formatstring.replace("%" + key, "${{{}}}".format(key))
+    return formatstring
+
+
+def ulocalized_time(time, formatstring, request, target_language=None):
+    """time localization method copied from Products.CMFPlone.i18nl10n.
+    The method was modified to allow for a custom formatstring in the
+    normal python format.
+
+    From http://docs.python.org/lib/module-time.html
+
+    %a        Locale's abbreviated weekday name.
+    %A        Locale's full weekday name.
+    %b        Locale's abbreviated month name.
+    %B        Locale's full month name.
+    %d        Day of the month as a decimal number [01,31].
+    %H        Hour (24-hour clock) as a decimal number [00,23].
+    %I        Hour (12-hour clock) as a decimal number [01,12].
+    %m        Month as a decimal number [01,12].
+    %M        Minute as a decimal number [00,59].
+    %p        Locale's equivalent of either AM or PM.
+    %S        Second as a decimal number [00,61].
+    %y        Year without century as a decimal number [00,99].
+    %Y        Year with century as a decimal number.
+    %Z        Time zone name (no characters if no time zone exists).
+    """
+
+    domain = 'plonelocales'
+    # map to a message string, to make easier reuse of original
+    # method and _interp_regex.
+    formatstring = format_string_to_message_string(formatstring)
+
+    mapping = {}
+    # convert to DateTime instances. Either a date string or
+    # a DateTime instance needs to be passed.
+    if not IDateTime.providedBy(time):
+        try:
+            time = DateTime(time)
+        except Exception:
+            log('Failed to convert %s to a DateTime object' % time,
+                severity=logging.DEBUG)
+            return None
+
+    # get the format elements used in the formatstring
+    formatelements = _interp_regex.findall(formatstring)
+
+    # reformat the ${foo} to foo
+    formatelements = [el[2:-1] for el in formatelements]
+
+    # add used elements to mapping
+    elements = [e for e in formatelements if e in datetime_formatvariables]
+
+    # add weekday name, abbr. weekday name, month name, abbr month name
+    week_included = True
+    month_included = True
+
+    name_elements = [e for e in formatelements if e in name_formatvariables]
+    if not ('a' in name_elements or 'A' in name_elements):
+        week_included = False
+    if not ('b' in name_elements or 'B' in name_elements):
+        month_included = False
+
+    for key in elements:
+        mapping[key] = time.strftime('%' + key)
+
+    if week_included:
+        weekday = int(time.strftime('%w'))  # weekday, sunday = 0
+        if 'a' in name_elements:
+            mapping['a'] = weekdayname_msgid_abbr(weekday)
+        if 'A' in name_elements:
+            mapping['A'] = weekdayname_msgid(weekday)
+    if month_included:
+        monthday = int(time.strftime('%m'))  # month, january = 1
+        if 'b' in name_elements:
+            mapping['b'] = monthname_msgid_abbr(monthday)
+        if 'B' in name_elements:
+            mapping['B'] = monthname_msgid(monthday)
+
+    # translate translateable elements
+    for key in name_elements:
+        mapping[key] = translate(mapping[key], domain,
+                                 context=request, default=mapping[key],
+                                 target_language=target_language)
+
+    # translate the time string
+    return formatstring.replace("${", "{").format(**mapping)

--- a/opengever/base/tests/test_date_time.py
+++ b/opengever/base/tests/test_date_time.py
@@ -1,5 +1,7 @@
 from datetime import datetime
 from opengever.base.date_time import as_utc
+from opengever.base.date_time import ulocalized_time
+from opengever.testing import IntegrationTestCase
 from unittest import TestCase
 import pytz
 
@@ -23,3 +25,24 @@ class TestDateTime(TestCase):
         self.assertEqual(
             pytz.UTC.localize(datetime(2011, 6, 17, 9, 30)),
             as_utc(zurich_dt_summer))
+
+
+class TestDateTimeLocalisation(IntegrationTestCase):
+
+    def test_ulocalized_time_translation(self):
+        date = datetime(2011, 6, 17, 11, 30)
+        frmt = "%A %a %B %b %H %I %m %d %M %p %S %Y %y"
+
+        self.assertEqual('Friday Fri June Jun 11 11 06 17 30 AM 00 2011 11',
+                         ulocalized_time(date, frmt, self.request))
+        self.assertEqual('Friday Fri June Jun 11 11 06 17 30 AM 00 2011 11',
+                         ulocalized_time(date, frmt, self.request, 'en'))
+        self.assertEqual('Freitag Fre Juni Jun 11 11 06 17 30 AM 00 2011 11',
+                         ulocalized_time(date, frmt, self.request, 'de'))
+        self.assertEqual('Vendredi Ven Juin Jui 11 11 06 17 30 AM 00 2011 11',
+                         ulocalized_time(date, frmt, self.request, 'fr'))
+
+    def test_ulocalized_time_is_zero_padded(self):
+        date = datetime(2011, 6, 3)
+        frmt = "%d.%m.%y"
+        self.assertEqual('03.06.11', ulocalized_time(date, frmt, self.request))

--- a/opengever/meeting/tests/test_agendaitem_list.py
+++ b/opengever/meeting/tests/test_agendaitem_list.py
@@ -8,7 +8,9 @@ from ftw.testing import freeze
 from ooxml_docprops import read_properties
 from opengever.dossier.docprops import TemporaryDocFile
 from opengever.meeting.command import MIME_DOCX
+from opengever.meeting.interfaces import IMeetingSettings
 from opengever.testing import IntegrationTestCase
+from plone import api
 import pytz
 
 
@@ -191,3 +193,113 @@ class TestAgendaItemList(IntegrationTestCase):
         self.assertDictContainsSubset(expected_metadata, browser.json)
         self.assertDictContainsSubset(expected_participants, browser.json['participants'])
         self.assertEqual(expected_agenda_items, browser.json['agenda_items'])
+
+    @browsing
+    def test_json_data_with_en_locale(self, browser):
+        self.login(self.committee_responsible, browser)
+        self.schedule_proposal(self.meeting, self.proposal)
+        self.schedule_ad_hoc(self.meeting, 'ad-hoc')
+
+        api.portal.set_registry_record(
+            "sablon_date_format_string", u"%A %d %B %Y", interface=IMeetingSettings)
+        lang_tool = api.portal.get_tool('portal_languages')
+
+        lang_tool.setDefaultLanguage('en')
+        with freeze(datetime(2017, 11, 10, 13, 0, tzinfo=pytz.utc)):
+            browser.open(self.meeting, view='agenda_item_list/as_json')
+        expected_metadata = {
+            u'document': {u'generated':  u'Friday 10 November 2017'},
+            u'meeting': {u'date': u'Monday 12 September 2016',
+                         u'end_time': u'07:00 PM',
+                         u'start_time': u'05:30 PM',
+                         u'location': u'B\xfcren an der Aare',
+                         u'number': None}}
+        self.assertDictContainsSubset(expected_metadata, browser.json)
+
+    @browsing
+    def test_json_data_with_fr_locale(self, browser):
+        self.login(self.committee_responsible, browser)
+        self.schedule_proposal(self.meeting, self.proposal)
+        self.schedule_ad_hoc(self.meeting, 'ad-hoc')
+
+        api.portal.set_registry_record(
+            "sablon_date_format_string", u"%A %d %B %Y", interface=IMeetingSettings)
+        lang_tool = api.portal.get_tool('portal_languages')
+
+        lang_tool.setDefaultLanguage('fr')
+        with freeze(datetime(2017, 11, 10, 13, 0, tzinfo=pytz.utc)):
+            browser.open(self.meeting, view='agenda_item_list/as_json')
+        expected_metadata = {
+            u'document': {u'generated':  u'Vendredi 10 Novembre 2017'},
+            u'meeting': {u'date': u'Lundi 12 Septembre 2016',
+                         u'end_time': u'19:00',
+                         u'start_time': u'17:30',
+                         u'location': u'B\xfcren an der Aare',
+                         u'number': None}}
+        self.assertDictContainsSubset(expected_metadata, browser.json)
+
+    @browsing
+    def test_json_data_with_de_locale(self, browser):
+        self.login(self.committee_responsible, browser)
+        self.schedule_proposal(self.meeting, self.proposal)
+        self.schedule_ad_hoc(self.meeting, 'ad-hoc')
+
+        api.portal.set_registry_record(
+            "sablon_date_format_string", u"%A %d %B %Y", interface=IMeetingSettings)
+        lang_tool = api.portal.get_tool('portal_languages')
+
+        lang_tool.setDefaultLanguage('de')
+        with freeze(datetime(2017, 11, 10, 13, 0, tzinfo=pytz.utc)):
+            browser.open(self.meeting, view='agenda_item_list/as_json')
+        expected_metadata = {
+            u'document': {u'generated':  u'Freitag 10 November 2017'},
+            u'meeting': {u'date': u'Montag 12 September 2016',
+                         u'end_time': u'19:00',
+                         u'start_time': u'17:30',
+                         u'location': u'B\xfcren an der Aare',
+                         u'number': None}}
+        self.assertDictContainsSubset(expected_metadata, browser.json)
+
+    @browsing
+    def test_json_data_with_de_ch_locale(self, browser):
+        self.login(self.committee_responsible, browser)
+        self.schedule_proposal(self.meeting, self.proposal)
+        self.schedule_ad_hoc(self.meeting, 'ad-hoc')
+
+        api.portal.set_registry_record(
+            "sablon_date_format_string", u"%A %d %B %Y", interface=IMeetingSettings)
+        lang_tool = api.portal.get_tool('portal_languages')
+
+        lang_tool.setDefaultLanguage('de-ch')
+        with freeze(datetime(2017, 11, 10, 13, 0, tzinfo=pytz.utc)):
+            browser.open(self.meeting, view='agenda_item_list/as_json')
+        expected_metadata = {
+            u'document': {u'generated':  u'Freitag 10 November 2017'},
+            u'meeting': {u'date': u'Montag 12 September 2016',
+                         u'end_time': u'19:00',
+                         u'start_time': u'17:30',
+                         u'location': u'B\xfcren an der Aare',
+                         u'number': None}}
+        self.assertDictContainsSubset(expected_metadata, browser.json)
+
+    @browsing
+    def test_json_data_with_fr_ch_locale(self, browser):
+        self.login(self.committee_responsible, browser)
+        self.schedule_proposal(self.meeting, self.proposal)
+        self.schedule_ad_hoc(self.meeting, 'ad-hoc')
+
+        api.portal.set_registry_record(
+            "sablon_date_format_string", u"%A %d %B %Y", interface=IMeetingSettings)
+        lang_tool = api.portal.get_tool('portal_languages')
+
+        lang_tool.setDefaultLanguage('fr-ch')
+        with freeze(datetime(2017, 11, 10, 13, 0, tzinfo=pytz.utc)):
+            browser.open(self.meeting, view='agenda_item_list/as_json')
+        expected_metadata = {
+            u'document': {u'generated':  u'Vendredi 10 Novembre 2017'},
+            u'meeting': {u'date': u'Lundi 12 Septembre 2016',
+                         u'end_time': u'19:00',
+                         u'start_time': u'17:30',
+                         u'location': u'B\xfcren an der Aare',
+                         u'number': None}}
+        self.assertDictContainsSubset(expected_metadata, browser.json)

--- a/opengever/meeting/tests/test_toc.py
+++ b/opengever/meeting/tests/test_toc.py
@@ -9,6 +9,7 @@ from ftw.testing import freeze
 from opengever.base.interfaces import IReferenceNumberSettings
 from opengever.core.testing import OPENGEVER_FUNCTIONAL_MEETING_LAYER
 from opengever.meeting.command import MIME_DOCX
+from opengever.meeting.interfaces import IMeetingSettings
 from opengever.meeting.toc.alphabetical import AlphabeticalToc
 from opengever.meeting.toc.dossier_refnum import DossierReferenceNumberBasedTOC
 from opengever.meeting.toc.repository import RepositoryBasedTOC
@@ -18,6 +19,7 @@ from opengever.meeting.toc.utils import normalise_string
 from opengever.meeting.toc.utils import repo_refnum
 from opengever.meeting.toc.utils import to_human_sortable_key
 from opengever.testing import FunctionalTestCase
+from opengever.testing import IntegrationTestCase
 from plone import api
 from z3c.relationfield.relation import RelationValue
 from zope.component import getUtility
@@ -671,3 +673,47 @@ class TestTOCByRepositoryReferenceNumber(TestAlphabeticalTOC):
             }]
         }]
     }
+
+
+class TestMeetingTocDataLocalisation(IntegrationTestCase):
+
+    @browsing
+    def test_date_localisation_in_toc_json_with_en_local(self, browser):
+        self.login(self.manager, browser)
+        api.portal.set_registry_record(
+            "sablon_date_format_string", u"%a %d %b", interface=IMeetingSettings)
+        lang_tool = api.portal.get_tool('portal_languages')
+        period = self.committee.load_model().periods[0]
+        url = period.get_url(self.committee)
+
+        lang_tool.setDefaultLanguage('en')
+        browser.open(url, view='alphabetical_toc/as_json')
+        self.assertEqual(u'Sun 17 Jul',
+                         browser.json["toc"][0]["contents"][0]["meeting_date"])
+
+    @browsing
+    def test_date_localisation_in_toc_json_with_fr_local(self, browser):
+        self.login(self.manager, browser)
+        api.portal.set_registry_record(
+            "sablon_date_format_string", u"%a %d %b", interface=IMeetingSettings)
+        lang_tool = api.portal.get_tool('portal_languages')
+        period = self.committee.load_model().periods[0]
+        url = period.get_url(self.committee)
+
+        lang_tool.setDefaultLanguage('fr')
+        browser.open(url, view='alphabetical_toc/as_json')
+        self.assertEqual(u'Dim 17 Juil',
+                         browser.json["toc"][0]["contents"][0]["meeting_date"])
+
+    @browsing
+    def test_date_localisation_in_toc_json_with_de_local(self, browser):
+        self.login(self.manager, browser)
+        api.portal.set_registry_record(
+            "sablon_date_format_string", u"%a %d %b", interface=IMeetingSettings)
+        lang_tool = api.portal.get_tool('portal_languages')
+        period = self.committee.load_model().periods[0]
+        url = period.get_url(self.committee)
+        lang_tool.setDefaultLanguage('de')
+        browser.open(url, view='alphabetical_toc/as_json')
+        self.assertEqual(u'Son 17 Jul',
+                         browser.json["toc"][0]["contents"][0]["meeting_date"])

--- a/opengever/meeting/utils.py
+++ b/opengever/meeting/utils.py
@@ -1,5 +1,7 @@
+from opengever.base.date_time import ulocalized_time
 from opengever.meeting.interfaces import IMeetingSettings
 from plone import api
+from zope.globalrequest import getRequest
 
 
 class JsonDataProcessor(object):
@@ -27,7 +29,9 @@ class JsonDataProcessor(object):
         return data
 
 
-def format_date(date):
+def format_date(date, request=None):
+    if request is None:
+        request = getRequest()
     date_string_format = api.portal.get_registry_record(
         "sablon_date_format_string", interface=IMeetingSettings)
-    return date.strftime(date_string_format)
+    return ulocalized_time(date, date_string_format, request)


### PR DESCRIPTION
In #4417 we have introduced custom format strings for dates in sablons. The problem is that these dates are not localized to the user's locale, but to the servers, i.e. english.

To allow for localizations of these dates with a custom format string, we introduce our own date localization method, based upon `i18nl10n.ulocalized_time`. Below an example of a generated agendaitem list with GEVER in french and in german:

<img width="904" alt="screen shot 2019-02-13 at 09 32 07" src="https://user-images.githubusercontent.com/7374243/52697758-7065ae80-2f72-11e9-9f8b-749928ec85b4.png">

<img width="916" alt="screen shot 2019-02-13 at 09 32 17" src="https://user-images.githubusercontent.com/7374243/52697759-70fe4500-2f72-11e9-9531-79d90c89f901.png">
Also note that the resulting dates are zero padded.

resolves #4989 