### PR TITLE
 Add a three-tier mechanism for mapping MIME types to Office Connector

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -579,6 +579,7 @@ Objects
           - self.mail_msg
           - self.proposal
             - self.proposaldocument
+          - self.removed_document
           - self.sequential_task
             - self.seq_subtask_1
             - self.seq_subtask_2

--- a/README.rst
+++ b/README.rst
@@ -588,6 +588,7 @@ Objects
           - self.subdossier
             - self.subdocument
             - self.subsubdossier
+              - self.subsubdocument
           - self.subdossier2
           - self.task
             - self.subtask

--- a/README.rst
+++ b/README.rst
@@ -574,7 +574,6 @@ Objects
         - self.dossier
           - self.document
           - self.draft_proposal
-          - self.empty_document
           - self.info_task
           - self.mail_eml
           - self.mail_msg
@@ -586,6 +585,7 @@ Objects
             - self.seq_subtask_3
           - self.shadow_document
           - self.subdossier
+            - self.empty_document
             - self.subdocument
             - self.subsubdossier
               - self.subsubdocument

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -8,6 +8,7 @@ Changelog
 - Add date string localization for sablon data. [njohner]
 - Fixed the REST API scan-in end point for organization units with non-ASCII in their titles. [Rotonen]
 - Set default language for task reminders. [njohner]
+- Add a three-tier mechanism for mapping MIME types to Office Connector. [Rotonen]
 - Suppress deletion events when filtering objects from copied subtrees. [lgraf]
 - Avoid infinite loops when looking for parent dossiers. [lgraf]
 - Make sure favorite button is in front of the watermark header. [njohner]

--- a/opengever/advancedsearch/tests/test_search.py
+++ b/opengever/advancedsearch/tests/test_search.py
@@ -79,18 +79,17 @@ class TestSearchWithContent(IntegrationTestCase):
     @browsing
     def test_search_documents(self, browser):
         self.login(self.regular_user, browser=browser)
-
         browser.open(self.portal, view='advanced_search')
         browser.fill({
             'Text': u'Vertr\xe4gsentwurf',
-            'Type': ['opengever.document.behaviors.IBaseDocument']})
+            'Type': ['opengever.document.behaviors.IBaseDocument'],
+        })
         browser.css('#form-buttons-button_search').first.click()
-
-        self.assertEquals(['3'], browser.css('#search-results-number').text)
-        self.assertEquals(
-            [self.document.title, self.taskdocument.title,
-             self.proposaldocument.title],
-            browser.css('.searchResults .searchItem dt').text)
+        self.assertEqual(['3'], browser.css('#search-results-number').text)
+        self.assertItemsEqual(
+            [self.document.title, self.taskdocument.title, self.proposaldocument.title],
+            browser.css('.searchResults .searchItem dt').text,
+        )
 
     @browsing
     def test_search_tasks(self, browser):

--- a/opengever/api/tests/test_mail.py
+++ b/opengever/api/tests/test_mail.py
@@ -21,7 +21,7 @@ class TestGetMail(IntegrationTestCase):
         self.assertEqual(200, browser.status_code)
         expected_message = {
             u'content-type': u'application/vnd.ms-outlook',
-            u'download': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/document-24'
+            u'download': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/document-25'
                          u'/@@download/original_message',
             u'filename': u'testmail.msg',
             u'size': 8,

--- a/opengever/api/tests/test_mail.py
+++ b/opengever/api/tests/test_mail.py
@@ -21,7 +21,7 @@ class TestGetMail(IntegrationTestCase):
         self.assertEqual(200, browser.status_code)
         expected_message = {
             u'content-type': u'application/vnd.ms-outlook',
-            u'download': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/document-25'
+            u'download': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/document-26'
                          u'/@@download/original_message',
             u'filename': u'testmail.msg',
             u'size': 8,

--- a/opengever/api/tests/test_serializer.py
+++ b/opengever/api/tests/test_serializer.py
@@ -114,7 +114,7 @@ class TestDocumentSerializer(IntegrationTestCase):
         self.login(self.regular_user, browser)
         browser.open(self.mail_eml, headers={'Accept': 'application/json'})
         self.assertEqual(browser.status_code, 200)
-        self.assertEqual(browser.json.get(u'reference_number'), u'Client1 1.1 / 1 / 24')
+        self.assertEqual(browser.json.get(u'reference_number'), u'Client1 1.1 / 1 / 25')
 
     @browsing
     def test_mail_serialization_contains_bumblebee_checksum(self, browser):

--- a/opengever/api/tests/test_serializer.py
+++ b/opengever/api/tests/test_serializer.py
@@ -113,8 +113,8 @@ class TestDocumentSerializer(IntegrationTestCase):
     def test_mail_serialization_contains_reference_number(self, browser):
         self.login(self.regular_user, browser)
         browser.open(self.mail_eml, headers={'Accept': 'application/json'})
-        self.assertEqual(browser.status_code, 200)
-        self.assertEqual(browser.json.get(u'reference_number'), u'Client1 1.1 / 1 / 25')
+        self.assertEqual(200, browser.status_code)
+        self.assertEqual(u'Client1 1.1 / 1 / 26', browser.json.get(u'reference_number'))
 
     @browsing
     def test_mail_serialization_contains_bumblebee_checksum(self, browser):

--- a/opengever/api/tests/test_summary.py
+++ b/opengever/api/tests/test_summary.py
@@ -137,7 +137,7 @@ class TestGeverJSONSummarySerializer(IntegrationTestCase):
                      '?items.fl=filename,filesize',
                      headers={'Accept': 'application/json'})
 
-        summary = browser.json['items'][10]
+        summary = browser.json['items'][9]
         self.assertEqual(
             {u'@id': u'http://nohost/plone/ordnungssystem/fuhrung/'
              'vertrage-und-vereinbarungen/dossier-1/task-1',

--- a/opengever/base/tests/test_contentlisting.py
+++ b/opengever/base/tests/test_contentlisting.py
@@ -108,15 +108,9 @@ class TestOpengeverContentListing(IntegrationTestCase):
                 ).CroppedDescription(),
             )
 
-    def test_cropped_description_returns_empty_string_for_objs_without_description(self):  # noqa
+    def test_cropped_description_returns_empty_string_for_objs_without_description(self):
         self.login(self.regular_user)
-
-        self.assertEquals(
-            '',
-            IContentListingObject(
-                obj2brain(self.document),
-                ).CroppedDescription(),
-            )
+        self.assertEqual('', IContentListingObject(obj2brain(self.empty_document)).CroppedDescription())
 
     def test_is_document(self):
         self.login(self.regular_user)

--- a/opengever/bumblebee/tests/test_overlay_adapter_mail.py
+++ b/opengever/bumblebee/tests/test_overlay_adapter_mail.py
@@ -66,7 +66,7 @@ class TestGetOpenAsPdfLink(IntegrationTestCase):
 
         expected_url = (
             'http://nohost/plone/ordnungssystem/fuhrung'
-            '/vertrage-und-vereinbarungen/dossier-1/document-25'
+            '/vertrage-und-vereinbarungen/dossier-1/document-26'
             '/bumblebee-open-pdf?filename=Die%20Buergschaft.pdf'
             )
 
@@ -79,7 +79,7 @@ class TestGetOpenAsPdfLink(IntegrationTestCase):
 
         expected_url = (
             u'http://nohost/plone/ordnungssystem/fuhrung'
-            u'/vertrage-und-vereinbarungen/dossier-1/document-25'
+            u'/vertrage-und-vereinbarungen/dossier-1/document-26'
             u'/bumblebee-open-pdf?filename=GEVER%20-%20%C3%9Cbernahme.pdf'
             )
 

--- a/opengever/bumblebee/tests/test_overlay_adapter_mail.py
+++ b/opengever/bumblebee/tests/test_overlay_adapter_mail.py
@@ -66,7 +66,7 @@ class TestGetOpenAsPdfLink(IntegrationTestCase):
 
         expected_url = (
             'http://nohost/plone/ordnungssystem/fuhrung'
-            '/vertrage-und-vereinbarungen/dossier-1/document-24'
+            '/vertrage-und-vereinbarungen/dossier-1/document-25'
             '/bumblebee-open-pdf?filename=Die%20Buergschaft.pdf'
             )
 
@@ -79,7 +79,7 @@ class TestGetOpenAsPdfLink(IntegrationTestCase):
 
         expected_url = (
             u'http://nohost/plone/ordnungssystem/fuhrung'
-            u'/vertrage-und-vereinbarungen/dossier-1/document-24'
+            u'/vertrage-und-vereinbarungen/dossier-1/document-25'
             u'/bumblebee-open-pdf?filename=GEVER%20-%20%C3%9Cbernahme.pdf'
             )
 

--- a/opengever/contentstats/tests/test_content_stats_integration.py
+++ b/opengever/contentstats/tests/test_content_stats_integration.py
@@ -159,16 +159,16 @@ class TestContentStatsIntegration(IntegrationTestCase):
     def test_checked_out_docs_stats_provider(self):
         self.login(self.regular_user)
         stats_provider = getMultiAdapter((self.portal, self.portal.REQUEST), IStatsProvider, name='checked_out_docs')
-        self.assertEqual({'checked_out': 0, 'checked_in': 35}, stats_provider.get_raw_stats())
+        self.assertEqual({'checked_out': 0, 'checked_in': 36}, stats_provider.get_raw_stats())
 
         self.checkout_document(self.document)
-        self.assertEqual({'checked_out': 1, 'checked_in': 34}, stats_provider.get_raw_stats())
+        self.assertEqual({'checked_out': 1, 'checked_in': 35}, stats_provider.get_raw_stats())
 
     def test_file_mimetypes_provider(self):
         stats_provider = getMultiAdapter((self.portal, self.portal.REQUEST), IStatsProvider, name='file_mimetypes')
         expected_stats = {
             'application/msword': 3,
-            'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': 2,
+            'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': 3,
             'application/vnd.openxmlformats-officedocument.wordprocessingml.document': 17,
             'message/rfc822': 3,
             'text/plain': 3,
@@ -188,7 +188,7 @@ class TestContentStatsIntegration(IntegrationTestCase):
         table = browser.css('#content-stats-file_mimetypes').first
         expected_stats = [
             ['', 'application/msword', '3'],
-            ['', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', '2'],
+            ['', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', '3'],
             ['', 'application/vnd.openxmlformats-officedocument.wordprocessingml.document', '17'],
             ['', 'message/rfc822', '3'],
             ['', 'text/plain', '3'],
@@ -200,12 +200,12 @@ class TestContentStatsIntegration(IntegrationTestCase):
         self.login(self.manager, browser)
         browser.open(view='@@content-stats')
         table = browser.css('#content-stats-checked_out_docs').first
-        self.assertEqual([['', 'checked_in', '35'], ['', 'checked_out', '0']], table.lists())
+        self.assertEqual([['', 'checked_in', '36'], ['', 'checked_out', '0']], table.lists())
 
         self.checkout_document(self.document)
         browser.open(self.portal, view='@@content-stats')
         table = browser.css('#content-stats-checked_out_docs').first
-        self.assertEqual([['', 'checked_in', '34'], ['', 'checked_out', '1']], table.lists())
+        self.assertEqual([['', 'checked_in', '35'], ['', 'checked_out', '1']], table.lists())
 
     def test_gever_portal_types_contains_base_documents(self):
         stats_provider = getMultiAdapter((self.portal, self.portal.REQUEST), IStatsProvider, name='portal_types')

--- a/opengever/contentstats/tests/test_content_stats_integration.py
+++ b/opengever/contentstats/tests/test_content_stats_integration.py
@@ -159,10 +159,10 @@ class TestContentStatsIntegration(IntegrationTestCase):
     def test_checked_out_docs_stats_provider(self):
         self.login(self.regular_user)
         stats_provider = getMultiAdapter((self.portal, self.portal.REQUEST), IStatsProvider, name='checked_out_docs')
-        self.assertEqual({'checked_out': 0, 'checked_in': 36}, stats_provider.get_raw_stats())
+        self.assertEqual({'checked_out': 0, 'checked_in': 37}, stats_provider.get_raw_stats())
 
         self.checkout_document(self.document)
-        self.assertEqual({'checked_out': 1, 'checked_in': 35}, stats_provider.get_raw_stats())
+        self.assertEqual({'checked_out': 1, 'checked_in': 36}, stats_provider.get_raw_stats())
 
     def test_file_mimetypes_provider(self):
         stats_provider = getMultiAdapter((self.portal, self.portal.REQUEST), IStatsProvider, name='file_mimetypes')
@@ -200,12 +200,12 @@ class TestContentStatsIntegration(IntegrationTestCase):
         self.login(self.manager, browser)
         browser.open(view='@@content-stats')
         table = browser.css('#content-stats-checked_out_docs').first
-        self.assertEqual([['', 'checked_in', '36'], ['', 'checked_out', '0']], table.lists())
+        self.assertEqual([['', 'checked_in', '37'], ['', 'checked_out', '0']], table.lists())
 
         self.checkout_document(self.document)
         browser.open(self.portal, view='@@content-stats')
         table = browser.css('#content-stats-checked_out_docs').first
-        self.assertEqual([['', 'checked_in', '35'], ['', 'checked_out', '1']], table.lists())
+        self.assertEqual([['', 'checked_in', '36'], ['', 'checked_out', '1']], table.lists())
 
     def test_gever_portal_types_contains_base_documents(self):
         stats_provider = getMultiAdapter((self.portal, self.portal.REQUEST), IStatsProvider, name='portal_types')

--- a/opengever/core/profiles/default/registry.xml
+++ b/opengever/core/profiles/default/registry.xml
@@ -97,97 +97,20 @@
   <records interface="opengever.officeconnector.interfaces.IOfficeConnectorSettings" />
   <record
       interface="opengever.officeconnector.interfaces.IOfficeConnectorSettings"
-      field="officeconnector_editable_types">
+      field="officeconnector_editable_types_extra">
     <field type="plone.registry.field.List">
       <value_type type="plone.registry.field.TextLine" />
     </field>
-    <value>
-      <!-- TextEdit -->
-      <element>text/plain</element>
-      <element>application/rtf</element>
-      <element>text/csv</element>
-      <element>text/css</element>
-      <element>text/xml</element>
-      <element>text/tab-separated-values</element>
-      <element>text/richtext</element>
-      <element>text/html</element>
-
-      <!-- Acrobat Pro, Reader, Preview -->
-      <element>application/pdf</element>
-      <element>application/postscript</element>
-
-      <!-- Preview -->
-      <element>image/jpeg</element>
-      <element>image/jpg</element>
-      <element>image/tiff</element>
-      <element>image/gif</element>
-      <element>image/png</element>
-      <element>image/bmp</element>
-
-      <!-- MS Visio -->
-      <element>application/vnd.visio</element>
-
-      <!-- MS Project -->
-      <element>application/vnd.ms-project</element>
-
-      <!-- MS Project (generic) -->
-      <element>application/x-project</element>
-
-      <!-- Adobe InDesign -->
-      <element>application/x-indesign</element>
-
-      <!-- Adobe Photoshop -->
-      <element>image/vnd.adobe.photoshop</element>
-
-      <!-- Adobe Illustrator -->
-      <element>application/illustrator</element>
-
-      <!-- MS OneNote -->
-      <element>application/onenote</element>
-
-      <!-- MS Excel -->
-      <element>application/vnd.ms-excel</element>
-      <element>application/vnd.openxmlformats-officedocument.spreadsheetml.sheet</element>
-      <element>application/vnd.openxmlformats-officedocument.spreadsheetml.template</element>
-      <element>application/vnd.ms-excel.sheet.macroEnabled.12</element>
-      <element>application/vnd.ms-excel.sheet.binary.macroEnabled.12</element>
-      <element>application/vnd.ms-excel.template.macroEnabled.12</element>
-      <element>application/vnd.ms-excel.addin.macroEnabled.12</element>
-
-      <!-- MS Powerpoint -->
-      <element>application/vnd.ms-powerpoint</element>
-      <element>application/vnd.ms-powerpoint.addin.macroEnabled.12</element>
-      <element>application/vnd.ms-powerpoint.presentation.macroEnabled.12</element>
-      <element>application/vnd.ms-powerpoint.slideshow.macroEnabled.12</element>
-      <element>application/vnd.openxmlformats-officedocument.presentationml.presentation</element>
-      <element>application/vnd.openxmlformats-officedocument.presentationml.template</element>
-      <element>application/vnd.openxmlformats-officedocument.presentationml.slideshow</element>
-
-      <!-- MS Publisher -->
-      <element>application/x-mspublisher</element>
-
-      <!-- MS Word -->
-      <element>application/msword</element>
-      <element>application/vnd.ms-word.document.macroEnabled.12</element>
-      <element>application/vnd.ms-word.template.macroEnabled.12</element>
-      <element>application/vnd.openxmlformats-officedocument.wordprocessingml.document</element>
-      <element>application/vnd.openxmlformats-officedocument.wordprocessingml.template</element>
-
-      <!-- Apple Numbers -->
-      <element>application/x-iwork-numbers-sffnumbers</element>
-
-      <!-- Apple Keynote -->
-      <element>application/x-iwork-keynote-sffkey</element>
-
-      <!-- Apple Pages -->
-      <element>application/x-iwork-pages-sffpages</element>
-
-      <!-- Mindjet Mind Manager -->
-      <element>application/vnd.mindjet.mindmanager</element>
-
-    </value>
+    <value />
   </record>
-
+  <record
+      interface="opengever.officeconnector.interfaces.IOfficeConnectorSettings"
+      field="officeconnector_editable_types_blacklist">
+    <field type="plone.registry.field.List">
+      <value_type type="plone.registry.field.TextLine" />
+    </field>
+    <value />
+  </record>
 
   <!-- OGDS -->
   <records interface="opengever.ogds.base.interfaces.IAdminUnitConfiguration" />

--- a/opengever/core/upgrades/20190211131715_drop_the_list_of_office_connector_editable_mime_types_from_the_registry/registry.xml
+++ b/opengever/core/upgrades/20190211131715_drop_the_list_of_office_connector_editable_mime_types_from_the_registry/registry.xml
@@ -1,0 +1,3 @@
+<registry>
+  <record name="opengever.officeconnector.interfaces.IOfficeConnectorSettings.officeconnector_editable_types" remove="True" />
+</registry>

--- a/opengever/core/upgrades/20190211131715_drop_the_list_of_office_connector_editable_mime_types_from_the_registry/upgrade.py
+++ b/opengever/core/upgrades/20190211131715_drop_the_list_of_office_connector_editable_mime_types_from_the_registry/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class DropTheListOfOfficeConnectorEditableMIMETypesFromTheRegistry(UpgradeStep):
+    """Drop the list of office connector editable MIME types from the registry.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/core/upgrades/20190213143848_add_an_additional_mime_types_record_for_office_connector/registry.xml
+++ b/opengever/core/upgrades/20190213143848_add_an_additional_mime_types_record_for_office_connector/registry.xml
@@ -1,0 +1,8 @@
+<registry>
+  <record interface="opengever.officeconnector.interfaces.IOfficeConnectorSettings" field="officeconnector_editable_types_extra">
+    <field type="plone.registry.field.List">
+      <value_type type="plone.registry.field.TextLine" />
+    </field>
+    <value />
+  </record>
+</registry>

--- a/opengever/core/upgrades/20190213143848_add_an_additional_mime_types_record_for_office_connector/upgrade.py
+++ b/opengever/core/upgrades/20190213143848_add_an_additional_mime_types_record_for_office_connector/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddAnAdditionalMIMETypesRecordForOfficeConnector(UpgradeStep):
+    """Add an additional MIME types record for Office Connector.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/core/upgrades/20190213143906_add_a_record_of_blacklisted_mime_types_for_office_connector/registry.xml
+++ b/opengever/core/upgrades/20190213143906_add_a_record_of_blacklisted_mime_types_for_office_connector/registry.xml
@@ -1,0 +1,8 @@
+<registry>
+  <record interface="opengever.officeconnector.interfaces.IOfficeConnectorSettings" field="officeconnector_editable_types_blacklist">
+    <field type="plone.registry.field.List">
+      <value_type type="plone.registry.field.TextLine" />
+    </field>
+    <value />
+  </record>
+</registry>

--- a/opengever/core/upgrades/20190213143906_add_a_record_of_blacklisted_mime_types_for_office_connector/upgrade.py
+++ b/opengever/core/upgrades/20190213143906_add_a_record_of_blacklisted_mime_types_for_office_connector/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddARecordOfBlacklistedMIMETypesForOfficeConnector(UpgradeStep):
+    """Add a record of blacklisted MIME types for Office Connector.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/disposition/tests/test_model.py
+++ b/opengever/disposition/tests/test_model.py
@@ -330,7 +330,7 @@ class TestFolderAndFileModel(IntegrationTestCase):
         # self.subsubdossier
         subsubdossier_model = subdossier_model.folders[0]
         self.assertEquals([], subsubdossier_model.folders)
-        self.assertEquals(0, len(subsubdossier_model.files))
+        self.assertEquals(1, len(subsubdossier_model.files))
 
         # self.subdossier2
         self.assertEquals([], subdossier2_model.folders)

--- a/opengever/document/tests/test_document.py
+++ b/opengever/document/tests/test_document.py
@@ -41,30 +41,30 @@ import mimetypes
 import transaction
 
 
-class TestDocumentConfiguration(FunctionalTestCase):
+class TestDocumentConfiguration(IntegrationTestCase):
 
     def test_documents_provide_IDocumentSchema(self):
-        document = create(Builder("document"))
-        self.assertProvides(document, interface=IDocumentSchema)
+        self.login(self.regular_user)
+        self.assert_provides(self.document, interface=IDocumentSchema)
 
     def test_documents_provide_IBaseDocument(self):
-        document = create(Builder("document"))
-        self.assertProvides(document, interface=IBaseDocument)
+        self.login(self.regular_user)
+        self.assert_provides(self.document, interface=IBaseDocument)
 
     def test_fti(self):
         fti = queryUtility(IDexterityFTI, name='opengever.document.document')
-        self.assertNotEquals(None, fti)
+        self.assertNotEqual(None, fti)
 
     def test_schema(self):
         fti = queryUtility(IDexterityFTI, name='opengever.document.document')
         schema = fti.lookupSchema()
-        self.assertEquals(IDocumentSchema, schema)
+        self.assertEqual(IDocumentSchema, schema)
 
     def test_factory(self):
         fti = queryUtility(IDexterityFTI, name='opengever.document.document')
         factory = fti.factory
         new_object = createObject(factory)
-        self.assertProvides(new_object, interface=IDocumentSchema)
+        self.assert_provides(new_object, interface=IDocumentSchema)
 
 
 class TestDocument(FunctionalTestCase):

--- a/opengever/document/tests/test_document.py
+++ b/opengever/document/tests/test_document.py
@@ -257,58 +257,45 @@ class TestDocument(IntegrationTestCase):
         self.assertIsNone(checkout_manager.get_checked_out_by())
 
 
-class TestDocumentDefaultValues(FunctionalTestCase):
-
-    def setUp(self):
-        super(TestDocumentDefaultValues, self).setUp()
-        self.dossier = create(Builder('dossier'))
+class TestDocumentDefaultValues(IntegrationTestCase):
 
     @browsing
     def test_default_document_date_is_today(self, browser):
+        self.login(self.regular_user, browser)
+
         now = datetime.now()
         today = now.date()
-
-        browser.login().open(self.dossier)
+        browser.open(self.dossier)
 
         with freeze(now):
             factoriesmenu.add('Document')
             browser.fill({'Title': u'My Document'}).save()
-        document = self.dossier['document-1']
 
+        document = self.dossier['document-38']
         self.assertEqual(today, document.document_date)
 
     @browsing
     def test_preserved_as_paper_default_false(self, browser):
-        browser.login()
-
-        # registry default of False
-        api.portal.set_registry_record(
-            'preserved_as_paper_default', False,
-            interface=IDocumentSettings)
-        transaction.commit()
-
+        api.portal.set_registry_record('preserved_as_paper_default', False, interface=IDocumentSettings)
+        self.login(self.regular_user, browser)
         browser.open(self.dossier)
+
         factoriesmenu.add('Document')
-        browser.fill(
-            {'Title': u'My Document',
-             'File': ('DATA', 'file.txt', 'text/plain')}).save()
-        document = self.dossier['document-1']
+        browser.fill({'Title': u'My Document', 'File': ('DATA', 'file.txt', 'text/plain')}).save()
+
+        document = self.dossier['document-38']
         self.assertFalse(document.preserved_as_paper)
 
     @browsing
     def test_preserved_as_paper_default_true(self, browser):
-        browser.login()
-
-        # registry default of True
-        api.portal.set_registry_record(
-            'preserved_as_paper_default', True,
-            interface=IDocumentSettings)
-        transaction.commit()
-
+        api.portal.set_registry_record('preserved_as_paper_default', True, interface=IDocumentSettings)
+        self.login(self.regular_user, browser)
         browser.open(self.dossier)
+
         factoriesmenu.add('Document')
         browser.fill({'Title': u'My Document'}).save()
-        document = self.dossier['document-1']
+
+        document = self.dossier['document-38']
         self.assertTrue(document.preserved_as_paper)
 
 

--- a/opengever/document/tests/test_forms.py
+++ b/opengever/document/tests/test_forms.py
@@ -81,7 +81,6 @@ class TestDocumentIntegration(IntegrationTestCase):
             '[No Subject]',
             u'Die B\xfcrgschaft',
             u'Initialvertrag f\xfcr Bearbeitung',
-            u'L\xe4\xe4r',
             u'Vertr\xe4gsentwurf',
         ]
         self.assertEqual(expected_documents, browser.css('li').text)

--- a/opengever/dossier/tests/__init__.py
+++ b/opengever/dossier/tests/__init__.py
@@ -76,12 +76,12 @@ EXPECTED_DOCUMENT_PROPERTIES = {
 }
 
 EXPECTED_TASKDOCUMENT_PROPERTIES = {
-    'Document.ReferenceNumber': 'Client1 1.1 / 1 / 30',
-    'Document.SequenceNumber': '30',
+    'Document.ReferenceNumber': 'Client1 1.1 / 1 / 31',
+    'Document.SequenceNumber': '31',
     'ogg.document.title': u'Feedback zum Vertragsentwurf',
-    'ogg.document.reference_number': 'Client1 1.1 / 1 / 30',
+    'ogg.document.reference_number': 'Client1 1.1 / 1 / 31',
     'ogg.document.document_date': datetime(2016, 8, 31, 0, 0),
-    'ogg.document.sequence_number': '30',
+    'ogg.document.sequence_number': '31',
     'ogg.document.version_number': 0
 }
 

--- a/opengever/dossier/tests/__init__.py
+++ b/opengever/dossier/tests/__init__.py
@@ -76,12 +76,12 @@ EXPECTED_DOCUMENT_PROPERTIES = {
 }
 
 EXPECTED_TASKDOCUMENT_PROPERTIES = {
-    'Document.ReferenceNumber': 'Client1 1.1 / 1 / 31',
-    'Document.SequenceNumber': '31',
+    'Document.ReferenceNumber': 'Client1 1.1 / 1 / 32',
+    'Document.SequenceNumber': '32',
     'ogg.document.title': u'Feedback zum Vertragsentwurf',
-    'ogg.document.reference_number': 'Client1 1.1 / 1 / 31',
+    'ogg.document.reference_number': 'Client1 1.1 / 1 / 32',
     'ogg.document.document_date': datetime(2016, 8, 31, 0, 0),
-    'ogg.document.sequence_number': '31',
+    'ogg.document.sequence_number': '32',
     'ogg.document.version_number': 0
 }
 

--- a/opengever/dossier/tests/test_documents_tab.py
+++ b/opengever/dossier/tests/test_documents_tab.py
@@ -8,31 +8,25 @@ class TestDocumentsTab(IntegrationTestCase):
     @browsing
     def test_containing_subdossiers_are_linked(self, browser):
         self.login(self.regular_user, browser)
-
         IOpenGeverBase(self.subdossier).title = u'S\xfcbdossier <Foo> Bar'
+
         self.subdocument.reindexObject()
-
         browser.open(self.dossier, view='tabbedview_view-documents')
-
-        link = browser.css('table.listing').first.css('a.subdossierLink').first
-
+        link = browser.css('table.listing').first.css('a.subdossierLink')[-1]
         self.assertEqual(u'S\xfcbdossier &lt;Foo&gt; Bar', link.innerHTML)
-        link.click()
 
+        link.click()
         self.assertEqual(browser.url, self.subdossier.absolute_url())
 
     @browsing
     def test_documents_in_listing_are_linked(self, browser):
         self.login(self.regular_user, browser)
         browser.open(self.dossier, view='tabbedview_view-documents')
-
         items = browser.css('table.listing a.icon-xlsx')
-
-        self.assertEqual(1, len(items))
+        self.assertEqual(2, len(items))
 
         expected_url = (
             'http://nohost/plone/ordnungssystem/fuhrung'
             '/vertrage-und-vereinbarungen/dossier-1/dossier-2/document-20'
-            )
-
+        )
         self.assertEqual(expected_url, items.first.get('href'))

--- a/opengever/dossier/tests/test_templatefolder.py
+++ b/opengever/dossier/tests/test_templatefolder.py
@@ -213,15 +213,15 @@ class TestDocumentWithTemplateFormWithDocProperties(IntegrationTestCase):
         self.assertEquals(u'Test Docx.docx', document.file.filename)
 
         expected_doc_properties = {
-            'Document.ReferenceNumber': 'Client1 1.1 / 1 / 36',
-            'Document.SequenceNumber': '36',
+            'Document.ReferenceNumber': 'Client1 1.1 / 1 / 37',
+            'Document.SequenceNumber': '37',
             'Dossier.ReferenceNumber': 'Client1 1.1 / 1',
             'Dossier.Title': u'Vertr\xe4ge mit der kantonalen Finanzverwaltung',
             'User.FullName': u'B\xe4rfuss K\xe4thi',
             'User.ID': 'kathi.barfuss',
             'ogg.document.document_date': datetime(2020, 9, 28, 0, 0),
-            'ogg.document.reference_number': 'Client1 1.1 / 1 / 36',
-            'ogg.document.sequence_number': '36',
+            'ogg.document.reference_number': 'Client1 1.1 / 1 / 37',
+            'ogg.document.sequence_number': '37',
             'ogg.document.title': 'Test Docx',
             'ogg.document.version_number': 0,
             'ogg.dossier.external_reference': u'qpr-900-9001-\xf7',
@@ -272,15 +272,15 @@ class TestDocumentWithTemplateFormWithDocProperties(IntegrationTestCase):
         self.assertEquals(u'Test Docx.docx', document.file.filename)
 
         expected_doc_properties = {
-            'Document.ReferenceNumber': 'Client1 1.1 / 1 / 36',
-            'Document.SequenceNumber': '36',
+            'Document.ReferenceNumber': 'Client1 1.1 / 1 / 37',
+            'Document.SequenceNumber': '37',
             'Dossier.ReferenceNumber': 'Client1 1.1 / 1',
             'Dossier.Title': u'Vertr\xe4ge mit der kantonalen Finanzverwaltung',
             'User.FullName': u'B\xe4rfuss K\xe4thi',
             'User.ID': 'kathi.barfuss',
             'ogg.document.document_date': datetime(2020, 10, 28, 0, 0),
-            'ogg.document.reference_number': 'Client1 1.1 / 1 / 36',
-            'ogg.document.sequence_number': '36',
+            'ogg.document.reference_number': 'Client1 1.1 / 1 / 37',
+            'ogg.document.sequence_number': '37',
             'ogg.document.title': 'Test Docx',
             'ogg.document.version_number': 0,
             'ogg.dossier.external_reference': u'qpr-900-9001-\xf7',

--- a/opengever/dossier/tests/test_templatefolder.py
+++ b/opengever/dossier/tests/test_templatefolder.py
@@ -213,15 +213,15 @@ class TestDocumentWithTemplateFormWithDocProperties(IntegrationTestCase):
         self.assertEquals(u'Test Docx.docx', document.file.filename)
 
         expected_doc_properties = {
-            'Document.ReferenceNumber': 'Client1 1.1 / 1 / 37',
-            'Document.SequenceNumber': '37',
+            'Document.ReferenceNumber': 'Client1 1.1 / 1 / 38',
+            'Document.SequenceNumber': '38',
             'Dossier.ReferenceNumber': 'Client1 1.1 / 1',
             'Dossier.Title': u'Vertr\xe4ge mit der kantonalen Finanzverwaltung',
             'User.FullName': u'B\xe4rfuss K\xe4thi',
             'User.ID': 'kathi.barfuss',
             'ogg.document.document_date': datetime(2020, 9, 28, 0, 0),
-            'ogg.document.reference_number': 'Client1 1.1 / 1 / 37',
-            'ogg.document.sequence_number': '37',
+            'ogg.document.reference_number': 'Client1 1.1 / 1 / 38',
+            'ogg.document.sequence_number': '38',
             'ogg.document.title': 'Test Docx',
             'ogg.document.version_number': 0,
             'ogg.dossier.external_reference': u'qpr-900-9001-\xf7',
@@ -272,15 +272,15 @@ class TestDocumentWithTemplateFormWithDocProperties(IntegrationTestCase):
         self.assertEquals(u'Test Docx.docx', document.file.filename)
 
         expected_doc_properties = {
-            'Document.ReferenceNumber': 'Client1 1.1 / 1 / 37',
-            'Document.SequenceNumber': '37',
+            'Document.ReferenceNumber': 'Client1 1.1 / 1 / 38',
+            'Document.SequenceNumber': '38',
             'Dossier.ReferenceNumber': 'Client1 1.1 / 1',
             'Dossier.Title': u'Vertr\xe4ge mit der kantonalen Finanzverwaltung',
             'User.FullName': u'B\xe4rfuss K\xe4thi',
             'User.ID': 'kathi.barfuss',
             'ogg.document.document_date': datetime(2020, 10, 28, 0, 0),
-            'ogg.document.reference_number': 'Client1 1.1 / 1 / 37',
-            'ogg.document.sequence_number': '37',
+            'ogg.document.reference_number': 'Client1 1.1 / 1 / 38',
+            'ogg.document.sequence_number': '38',
             'ogg.document.title': 'Test Docx',
             'ogg.document.version_number': 0,
             'ogg.dossier.external_reference': u'qpr-900-9001-\xf7',

--- a/opengever/ech0147/tests/test_model.py
+++ b/opengever/ech0147/tests/test_model.py
@@ -68,14 +68,16 @@ class TestMessageModel(IntegrationTestCase):
         zipfile = DummyZipFile()
         msg.add_to_zip(zipfile)
 
-        self.assertEqual(
-            [u'files/dossier-1/dossier-2/Uebersicht der Vertraege von 2016.xlsx',
-             u'files/dossier-1/Vertraegsentwurf.docx',
-             u'files/dossier-1/Die Buergschaft.eml',
-             u'files/dossier-1/testm\xe4il.msg',
-             u'files/dossier-1/Initialvertrag fuer Bearbeitung.docx',
-             u'files/Vertraegsentwurf.docx'],
-            zipfile.arcnames)
+        expected_files = [
+            u'files/dossier-1/dossier-2/dossier-4/Uebersicht der Vertraege von 2014.xlsx',
+            u'files/dossier-1/dossier-2/Uebersicht der Vertraege von 2016.xlsx',
+            u'files/dossier-1/Vertraegsentwurf.docx',
+            u'files/dossier-1/Die Buergschaft.eml',
+            u'files/dossier-1/testm\xe4il.msg',
+            u'files/dossier-1/Initialvertrag fuer Bearbeitung.docx',
+            u'files/Vertraegsentwurf.docx',
+        ]
+        self.assertEqual(expected_files, zipfile.arcnames)
 
     def test_message_with_subjects(self):
         msg = MessageT1()

--- a/opengever/mail/tests/test_indexers.py
+++ b/opengever/mail/tests/test_indexers.py
@@ -56,4 +56,4 @@ class TestMailIndexers(IntegrationTestCase):
     def test_reference_number(self):
         self.login(self.regular_user)
         extender = getAdapter(self.mail_eml, IDynamicTextIndexExtender, u'IDocumentSchema')
-        self.assertEqual('Client1 1.1 / 1 / 25 25', extender())
+        self.assertEqual('Client1 1.1 / 1 / 26 26', extender())

--- a/opengever/mail/tests/test_indexers.py
+++ b/opengever/mail/tests/test_indexers.py
@@ -55,11 +55,5 @@ class TestMailIndexers(IntegrationTestCase):
 
     def test_reference_number(self):
         self.login(self.regular_user)
-
-        extender = getAdapter(
-            self.mail_eml,
-            IDynamicTextIndexExtender,
-            u'IDocumentSchema',
-            )
-
-        self.assertEquals('Client1 1.1 / 1 / 24 24', extender())
+        extender = getAdapter(self.mail_eml, IDynamicTextIndexExtender, u'IDocumentSchema')
+        self.assertEqual('Client1 1.1 / 1 / 25 25', extender())

--- a/opengever/mail/tests/test_mail_byline.py
+++ b/opengever/mail/tests/test_mail_byline.py
@@ -17,14 +17,14 @@ class TestMailByline(TestBylineBase):
         self.login(self.regular_user, browser=browser)
         browser.open(self.mail_eml)
         seq_number = self.get_byline_value_by_label('Sequence Number:')
-        self.assertEqual('25', seq_number.text)
+        self.assertEqual('26', seq_number.text)
 
     @browsing
     def test_document_byline_reference_number(self, browser):
         self.login(self.regular_user, browser=browser)
         browser.open(self.mail_eml)
         ref_number = self.get_byline_value_by_label('Reference Number:')
-        self.assertEqual('Client1 1.1 / 1 / 25', ref_number.text)
+        self.assertEqual('Client1 1.1 / 1 / 26', ref_number.text)
 
     @browsing
     def test_document_byline_document_author(self, browser):

--- a/opengever/mail/tests/test_mail_byline.py
+++ b/opengever/mail/tests/test_mail_byline.py
@@ -1,9 +1,5 @@
-from datetime import date
-from ftw.builder import Builder
-from ftw.builder import create
 from ftw.testbrowser import browsing
 from opengever.base.tests.byline_base_test import TestBylineBase
-from opengever.mail.tests import MAIL_DATA
 
 
 class TestMailByline(TestBylineBase):
@@ -20,17 +16,15 @@ class TestMailByline(TestBylineBase):
     def test_document_byline_sequence_number(self, browser):
         self.login(self.regular_user, browser=browser)
         browser.open(self.mail_eml)
-
         seq_number = self.get_byline_value_by_label('Sequence Number:')
-        self.assertEquals('24', seq_number.text)
+        self.assertEqual('25', seq_number.text)
 
     @browsing
     def test_document_byline_reference_number(self, browser):
         self.login(self.regular_user, browser=browser)
         browser.open(self.mail_eml)
-
         ref_number = self.get_byline_value_by_label('Reference Number:')
-        self.assertEquals('Client1 1.1 / 1 / 24', ref_number.text)
+        self.assertEqual('Client1 1.1 / 1 / 25', ref_number.text)
 
     @browsing
     def test_document_byline_document_author(self, browser):

--- a/opengever/meeting/tests/test_proposal.py
+++ b/opengever/meeting/tests/test_proposal.py
@@ -82,7 +82,7 @@ class TestProposal(IntegrationTestCase):
         original_template = ('orig_template', '#'.join((self.dossier.absolute_url(), 'documents')), )
         authenticator = ('_authenticator', createToken(), )
         document_12_path = ('paths:list', browser.css('#document-12').first.node.attrib.get('value'), )
-        document_30_path = ('paths:list', browser.css('#document-30').first.node.attrib.get('value'), )
+        document_30_path = ('paths:list', browser.css('#document-31').first.node.attrib.get('value'), )
         method = ('++add++opengever.meeting.proposal:method', '1', )
         browser.open(
             self.dossier.absolute_url(),

--- a/opengever/meeting/tests/test_proposal.py
+++ b/opengever/meeting/tests/test_proposal.py
@@ -82,12 +82,12 @@ class TestProposal(IntegrationTestCase):
         original_template = ('orig_template', '#'.join((self.dossier.absolute_url(), 'documents')), )
         authenticator = ('_authenticator', createToken(), )
         document_12_path = ('paths:list', browser.css('#document-12').first.node.attrib.get('value'), )
-        document_30_path = ('paths:list', browser.css('#document-31').first.node.attrib.get('value'), )
+        document_32_path = ('paths:list', browser.css('#document-32').first.node.attrib.get('value'), )
         method = ('++add++opengever.meeting.proposal:method', '1', )
         browser.open(
             self.dossier.absolute_url(),
             headers={'Content-Type': 'application/x-www-form-urlencoded'},
-            data=formdata.urlencode((original_template, authenticator, document_12_path, document_30_path, method, )),
+            data=formdata.urlencode((original_template, authenticator, document_12_path, document_32_path, method, )),
             )
         self.assertEqual(
             [u'Vertr\xe4gsentwurf', 'Feedback zum Vertragsentwurf'],

--- a/opengever/meeting/tests/test_proposal.py
+++ b/opengever/meeting/tests/test_proposal.py
@@ -1115,7 +1115,6 @@ class TestProposal(IntegrationTestCase):
             u'Die B\xfcrgschaft',
             u'Initialvertrag f\xfcr Bearbeitung',
             u'Initialvertrag f\xfcr Bearbeitung',
-            u'L\xe4\xe4r',
             'Personaleintritt',
             u'Vertr\xe4ge',
             u'Vertr\xe4gsentwurf',

--- a/opengever/officeconnector/interfaces.py
+++ b/opengever/officeconnector/interfaces.py
@@ -21,6 +21,18 @@ class IOfficeConnectorSettings(Interface):
         description=u'Enable sending restapi payloads Office Connector.',
         default=False)
 
+    officeconnector_editable_types_extra = schema.List(
+        title=u'Office Connector supported additional MIME types',
+        description=u'A list of Office Connector supported additional MIME types.'
+        u'These are additive to the default list.',
+        default=[])
+
+    officeconnector_editable_types_blacklist = schema.List(
+        title=u'Office Connector supported MIME types blacklist',
+        description=u'A list of Office Connector blacklisted MIME types.'
+        u'These are subtractive from the default list.',
+        default=[])
+
 
 class IOfficeConnectorSettingsView(Interface):
 

--- a/opengever/officeconnector/mimetypes.py
+++ b/opengever/officeconnector/mimetypes.py
@@ -1,0 +1,55 @@
+EDITABLE_TYPES = [
+    # Adobe Illustrator
+    'application/illustrator',
+    # Adobe InDesign
+    'application/x-indesign',
+    # Adobe Photoshop
+    'image/vnd.adobe.photoshop',
+    # Apple Keynote
+    'application/x-iwork-keynote-sffkey',
+    # Apple Numbers
+    'application/x-iwork-numbers-sffnumbers',
+    # Apple Pages
+    'application/x-iwork-pages-sffpages',
+    # Images - MS Paint or Adobe Photoshop
+    'image/bmp',
+    'image/gif',
+    'image/jpeg',
+    'image/jpg',
+    'image/png',
+    'image/tiff',
+    # Mindjet Mind Manager
+    'application/vnd.mindjet.mindmanager',
+    # MS Excel
+    'application/vnd.ms-excel',
+    'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    # MS OneNote
+    'application/onenote',
+    # MS Powerpoint
+    'application/vnd.ms-powerpoint',
+    'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+    'application/vnd.openxmlformats-officedocument.presentationml.slideshow',
+    # MS Project
+    'application/vnd.ms-project',
+    'application/x-project',
+    # MS Publisher
+    'application/x-mspublisher',
+    # MS Visio
+    'application/vnd.visio',
+    # MS Word
+    'application/msword',
+    'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+    # PDF editors - Adobe Acrobat or Nitro PDF
+    'application/pdf',
+    'application/postscript',
+    # Richtext editors - various
+    'application/rtf',
+    'text/richtext',
+    # Text editors - various
+    'text/css',
+    'text/csv',
+    'text/html',
+    'text/plain',
+    'text/tab-separated-values',
+    'text/xml',
+]

--- a/opengever/officeconnector/tests/test_api_dossier_attach.py
+++ b/opengever/officeconnector/tests/test_api_dossier_attach.py
@@ -92,7 +92,7 @@ class TestOfficeconnectorDossierAPIWithAttach(OCIntegrationTestCase):
         expected_payloads = [{
             u'content-type': u'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
             u'csrf-token': u'86ecf9b4135514f8c94c61ce336a4b98b4aaed8a',
-            u'document-url': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-6/document-23',
+            u'document-url': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-6/document-24',
             u'download': u'download',
             u'filename': u'Uebersicht der Inaktiven Vertraege von 2016.xlsx',
             u'title': u'\xdcbersicht der Inaktiven Vertr\xe4ge von 2016',
@@ -139,7 +139,7 @@ class TestOfficeconnectorDossierAPIWithAttach(OCIntegrationTestCase):
         expected_payloads = [{
             u'content-type': u'application/msword',
             u'csrf-token': u'86ecf9b4135514f8c94c61ce336a4b98b4aaed8a',
-            u'document-url': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-5/document-22',
+            u'document-url': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-5/document-23',
             u'download': u'download',
             u'filename': u'Uebersicht der Vertraege vor 2000.doc',
             u'title': u'\xdcbersicht der Vertr\xe4ge vor 2000',
@@ -206,7 +206,7 @@ class TestOfficeconnectorDossierAPIWithAttach(OCIntegrationTestCase):
                 u'content-type': u'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
                 u'csrf-token': u'86ecf9b4135514f8c94c61ce336a4b98b4aaed8a',
                 u'document-url': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/'
-                                 u'dossier-1/task-1/document-30',
+                                 u'dossier-1/task-1/document-31',
                 u'download': u'download',
                 u'filename': u'Feedback zum Vertragsentwurf.docx',
                 u'title': u'Feedback zum Vertragsentwurf',
@@ -268,7 +268,7 @@ class TestOfficeconnectorDossierAPIWithAttach(OCIntegrationTestCase):
                 u'content-type': u'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
                 u'csrf-token': u'86ecf9b4135514f8c94c61ce336a4b98b4aaed8a',
                 u'document-url': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/'
-                                 u'dossier-1/task-1/document-30',
+                                 u'dossier-1/task-1/document-31',
                 u'download': u'download',
                 u'filename': u'Feedback zum Vertragsentwurf.docx',
                 u'title': u'Feedback zum Vertragsentwurf',
@@ -330,7 +330,7 @@ class TestOfficeconnectorDossierAPIWithAttach(OCIntegrationTestCase):
                 u'content-type': u'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
                 u'csrf-token': u'86ecf9b4135514f8c94c61ce336a4b98b4aaed8a',
                 u'document-url': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/'
-                                 u'dossier-1/task-1/document-30',
+                                 u'dossier-1/task-1/document-31',
                 u'download': u'download',
                 u'filename': u'Feedback zum Vertragsentwurf.docx',
                 u'title': u'Feedback zum Vertragsentwurf',

--- a/opengever/officeconnector/tests/test_api_dossier_attach.py
+++ b/opengever/officeconnector/tests/test_api_dossier_attach.py
@@ -92,7 +92,7 @@ class TestOfficeconnectorDossierAPIWithAttach(OCIntegrationTestCase):
         expected_payloads = [{
             u'content-type': u'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
             u'csrf-token': u'86ecf9b4135514f8c94c61ce336a4b98b4aaed8a',
-            u'document-url': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-6/document-24',
+            u'document-url': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-6/document-25',
             u'download': u'download',
             u'filename': u'Uebersicht der Inaktiven Vertraege von 2016.xlsx',
             u'title': u'\xdcbersicht der Inaktiven Vertr\xe4ge von 2016',
@@ -139,7 +139,7 @@ class TestOfficeconnectorDossierAPIWithAttach(OCIntegrationTestCase):
         expected_payloads = [{
             u'content-type': u'application/msword',
             u'csrf-token': u'86ecf9b4135514f8c94c61ce336a4b98b4aaed8a',
-            u'document-url': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-5/document-23',
+            u'document-url': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-5/document-24',
             u'download': u'download',
             u'filename': u'Uebersicht der Vertraege vor 2000.doc',
             u'title': u'\xdcbersicht der Vertr\xe4ge vor 2000',
@@ -206,7 +206,7 @@ class TestOfficeconnectorDossierAPIWithAttach(OCIntegrationTestCase):
                 u'content-type': u'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
                 u'csrf-token': u'86ecf9b4135514f8c94c61ce336a4b98b4aaed8a',
                 u'document-url': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/'
-                                 u'dossier-1/task-1/document-31',
+                                 u'dossier-1/task-1/document-32',
                 u'download': u'download',
                 u'filename': u'Feedback zum Vertragsentwurf.docx',
                 u'title': u'Feedback zum Vertragsentwurf',
@@ -268,7 +268,7 @@ class TestOfficeconnectorDossierAPIWithAttach(OCIntegrationTestCase):
                 u'content-type': u'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
                 u'csrf-token': u'86ecf9b4135514f8c94c61ce336a4b98b4aaed8a',
                 u'document-url': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/'
-                                 u'dossier-1/task-1/document-31',
+                                 u'dossier-1/task-1/document-32',
                 u'download': u'download',
                 u'filename': u'Feedback zum Vertragsentwurf.docx',
                 u'title': u'Feedback zum Vertragsentwurf',
@@ -330,7 +330,7 @@ class TestOfficeconnectorDossierAPIWithAttach(OCIntegrationTestCase):
                 u'content-type': u'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
                 u'csrf-token': u'86ecf9b4135514f8c94c61ce336a4b98b4aaed8a',
                 u'document-url': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/'
-                                 u'dossier-1/task-1/document-31',
+                                 u'dossier-1/task-1/document-32',
                 u'download': u'download',
                 u'filename': u'Feedback zum Vertragsentwurf.docx',
                 u'title': u'Feedback zum Vertragsentwurf',

--- a/opengever/officeconnector/tests/test_api_dossier_oneoffixx.py
+++ b/opengever/officeconnector/tests/test_api_dossier_oneoffixx.py
@@ -41,7 +41,7 @@ class TestOfficeconnectorDossierAPIWithOneOffixx(OCIntegrationTestCase):
         expected_payloads = [{
             u'connect-xml': u'@@oneoffix_connect_xml',
             u'content-type': u'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-            u'document-url': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/document-34',
+            u'document-url': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/document-35',
             u'filename': None,
             u'uuid': u'createshadowdocument000000000001',
             }]
@@ -88,7 +88,7 @@ class TestOfficeconnectorDossierAPIWithOneOffixx(OCIntegrationTestCase):
             u'checkin-without-comment': u'checkin_without_comment',
             u'checkout': u'@@checkout_documents',
             u'content-type': 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-            u'document-url': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/document-33',
+            u'document-url': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/document-35',
             u'download': u'download',
             u'filename': None,
             u'upload-form': u'file_upload',
@@ -156,7 +156,7 @@ class TestOfficeconnectorDossierAPIWithOneOffixxWithRESTAPI(TestOfficeconnectorD
         expected_payloads = [{
             u'connect-xml': u'@@oneoffix_connect_xml',
             u'content-type': u'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-            u'document-url': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/document-33',
+            u'document-url': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/document-35',
             u'filename': None,
             u'uuid': u'createshadowdocument000000000001',
             }]
@@ -203,7 +203,7 @@ class TestOfficeconnectorDossierAPIWithOneOffixxWithRESTAPI(TestOfficeconnectorD
             u'checkin': u'@checkin',
             u'checkout': u'@checkout',
             u'content-type': 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-            u'document-url': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/document-33',
+            u'document-url': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/document-35',
             u'download': u'download',
             u'filename': None,
             u'lock': u'@lock',

--- a/opengever/officeconnector/tests/test_api_dossier_oneoffixx.py
+++ b/opengever/officeconnector/tests/test_api_dossier_oneoffixx.py
@@ -41,7 +41,7 @@ class TestOfficeconnectorDossierAPIWithOneOffixx(OCIntegrationTestCase):
         expected_payloads = [{
             u'connect-xml': u'@@oneoffix_connect_xml',
             u'content-type': u'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-            u'document-url': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/document-33',
+            u'document-url': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/document-34',
             u'filename': None,
             u'uuid': u'createshadowdocument000000000001',
             }]

--- a/opengever/officeconnector/tests/test_api_mail_attach.py
+++ b/opengever/officeconnector/tests/test_api_mail_attach.py
@@ -18,7 +18,7 @@ class TestOfficeconnectorMailAPIWithAttach(OCIntegrationTestCase):
             oc_url = self.fetch_document_attach_oc_url(browser, self.mail_eml)
 
         self.assertIsNotNone(oc_url)
-        self.assertEquals(200, browser.status_code)
+        self.assertEqual(200, browser.status_code)
 
         expected_token = {
             u"action": u"attach",
@@ -36,18 +36,18 @@ class TestOfficeconnectorMailAPIWithAttach(OCIntegrationTestCase):
             u"content-type": u"message/rfc822",
             u"csrf-token": u"86ecf9b4135514f8c94c61ce336a4b98b4aaed8a",
             u"document-url": u"http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/"
-                             u"document-24",
+                             u"document-25",
             u"download": u"download",
             u"filename": u"Die Buergschaft.eml",
             u"title": u"Die B\xfcrgschaft",
             u"uuid": u"createemails00000000000000000001",
         }]
         payloads = self.fetch_document_attach_payloads(browser, raw_token, token)
-        self.assertEquals(200, browser.status_code)
-        self.assertEqual(payloads, expected_payloads)
+        self.assertEqual(200, browser.status_code)
+        self.assertEqual(expected_payloads, payloads)
 
         file_contents = self.download_document(browser, raw_token, payloads[0])
-        self.assertEquals(file_contents, self.mail_eml.get_file().data)
+        self.assertEqual(file_contents, self.mail_eml.get_file().data)
 
     @browsing
     def test_attach_to_email_msg(self, browser):
@@ -57,7 +57,7 @@ class TestOfficeconnectorMailAPIWithAttach(OCIntegrationTestCase):
             oc_url = self.fetch_document_attach_oc_url(browser, self.mail_msg)
 
         self.assertIsNotNone(oc_url)
-        self.assertEquals(200, browser.status_code)
+        self.assertEqual(200, browser.status_code)
 
         expected_token = {
             u"action": u"attach",
@@ -75,18 +75,18 @@ class TestOfficeconnectorMailAPIWithAttach(OCIntegrationTestCase):
             u"content-type": u"application/vnd.ms-outlook",
             u"csrf-token": u"86ecf9b4135514f8c94c61ce336a4b98b4aaed8a",
             u"document-url": u"http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/"
-                             u"document-25",
+                             u"document-26",
             u"download": u"@@download/original_message",
             u"filename": u"testm\xe4il.msg",
             u"title": u"[No Subject]",
             u"uuid": u"createemails00000000000000000002",
         }]
         payloads = self.fetch_document_attach_payloads(browser, raw_token, token)
-        self.assertEquals(200, browser.status_code)
-        self.assertEqual(payloads, expected_payloads)
+        self.assertEqual(200, browser.status_code)
+        self.assertEqual(expected_payloads, payloads)
 
         file_contents = self.download_document(browser, raw_token, payloads[0])
-        self.assertEquals(file_contents, self.mail_msg.get_file().data)
+        self.assertEqual(file_contents, self.mail_msg.get_file().data)
 
     @browsing
     def test_attach_many_to_email_open(self, browser):
@@ -95,7 +95,7 @@ class TestOfficeconnectorMailAPIWithAttach(OCIntegrationTestCase):
         dossier_email = self.fetch_dossier_bcc(browser, self.dossier)
 
         self.assertTrue(dossier_email)
-        self.assertEquals(200, browser.status_code)
+        self.assertEqual(200, browser.status_code)
 
         documents = [self.mail_eml, self.mail_msg]
 
@@ -103,7 +103,7 @@ class TestOfficeconnectorMailAPIWithAttach(OCIntegrationTestCase):
             oc_url = self.fetch_dossier_multiattach_oc_url(browser, self.dossier, documents, dossier_email)
 
         self.assertIsNotNone(oc_url)
-        self.assertEquals(200, browser.status_code)
+        self.assertEqual(200, browser.status_code)
 
         expected_token = {
             u"action": u"attach",
@@ -123,7 +123,7 @@ class TestOfficeconnectorMailAPIWithAttach(OCIntegrationTestCase):
                 u"content-type": u"message/rfc822",
                 u"csrf-token": u"86ecf9b4135514f8c94c61ce336a4b98b4aaed8a",
                 u"document-url": u"http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/"
-                                 u"document-24",
+                                 u"document-25",
                 u"download": u"download",
                 u"filename": u"Die Buergschaft.eml",
                 u"title": u"Die B\xfcrgschaft",
@@ -134,7 +134,7 @@ class TestOfficeconnectorMailAPIWithAttach(OCIntegrationTestCase):
                 u"content-type": u"application/vnd.ms-outlook",
                 u"csrf-token": u"86ecf9b4135514f8c94c61ce336a4b98b4aaed8a",
                 u"document-url": u"http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/"
-                                 u"document-25",
+                                 u"document-26",
                 u"download": u"@@download/original_message",
                 u"filename": u"testm\xe4il.msg",
                 u"title": u"[No Subject]",
@@ -143,7 +143,7 @@ class TestOfficeconnectorMailAPIWithAttach(OCIntegrationTestCase):
         ]
 
         payloads = self.fetch_document_attach_payloads(browser, raw_token, token)
-        self.assertEqual(payloads, expected_payloads)
+        self.assertEqual(expected_payloads, payloads)
 
     @browsing
     def test_checkout_checkin(self, browser):

--- a/opengever/officeconnector/tests/test_api_mail_attach.py
+++ b/opengever/officeconnector/tests/test_api_mail_attach.py
@@ -36,7 +36,7 @@ class TestOfficeconnectorMailAPIWithAttach(OCIntegrationTestCase):
             u"content-type": u"message/rfc822",
             u"csrf-token": u"86ecf9b4135514f8c94c61ce336a4b98b4aaed8a",
             u"document-url": u"http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/"
-                             u"document-25",
+                             u"document-26",
             u"download": u"download",
             u"filename": u"Die Buergschaft.eml",
             u"title": u"Die B\xfcrgschaft",
@@ -75,7 +75,7 @@ class TestOfficeconnectorMailAPIWithAttach(OCIntegrationTestCase):
             u"content-type": u"application/vnd.ms-outlook",
             u"csrf-token": u"86ecf9b4135514f8c94c61ce336a4b98b4aaed8a",
             u"document-url": u"http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/"
-                             u"document-26",
+                             u"document-27",
             u"download": u"@@download/original_message",
             u"filename": u"testm\xe4il.msg",
             u"title": u"[No Subject]",
@@ -123,7 +123,7 @@ class TestOfficeconnectorMailAPIWithAttach(OCIntegrationTestCase):
                 u"content-type": u"message/rfc822",
                 u"csrf-token": u"86ecf9b4135514f8c94c61ce336a4b98b4aaed8a",
                 u"document-url": u"http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/"
-                                 u"document-25",
+                                 u"document-26",
                 u"download": u"download",
                 u"filename": u"Die Buergschaft.eml",
                 u"title": u"Die B\xfcrgschaft",
@@ -134,7 +134,7 @@ class TestOfficeconnectorMailAPIWithAttach(OCIntegrationTestCase):
                 u"content-type": u"application/vnd.ms-outlook",
                 u"csrf-token": u"86ecf9b4135514f8c94c61ce336a4b98b4aaed8a",
                 u"document-url": u"http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/"
-                                 u"document-26",
+                                 u"document-27",
                 u"download": u"@@download/original_message",
                 u"filename": u"testm\xe4il.msg",
                 u"title": u"[No Subject]",

--- a/opengever/oneoffixx/tests/assets/oneoffixx_connect_xml.txt
+++ b/opengever/oneoffixx/tests/assets/oneoffixx_connect_xml.txt
@@ -14,18 +14,18 @@
       <Function name="CustomInterfaceConnector" id="70E94788-CE84-4460-9698-5663878A295B">
         <Arguments>
           <Interface Name="OneGovGEVER">
-            <Node Id="ogg.document.sequence_number">33</Node>
+            <Node Id="ogg.document.sequence_number">34</Node>
             <Node Id="ogg.dossier.sequence_number">1</Node>
             <Node Id="ogg.user.userid">robert.ziegler</Node>
-            <Node Id="Document.SequenceNumber">33</Node>
-            <Node Id="Document.ReferenceNumber">Client1 1.1 / 1 / 33</Node>
+            <Node Id="Document.SequenceNumber">34</Node>
+            <Node Id="Document.ReferenceNumber">Client1 1.1 / 1 / 34</Node>
             <Node Id="ogg.dossier.reference_number">Client1 1.1 / 1</Node>
             <Node Id="ogg.user.email">robert.ziegler@gever.local</Node>
             <Node Id="ogg.document.document_date">Aug 31, 2016</Node>
             <Node Id="ogg.user.firstname">Robert</Node>
             <Node Id="ogg.document.title">Schättengarten</Node>
             <Node Id="ogg.user.title">Ziegler Robert</Node>
-            <Node Id="ogg.document.reference_number">Client1 1.1 / 1 / 33</Node>
+            <Node Id="ogg.document.reference_number">Client1 1.1 / 1 / 34</Node>
             <Node Id="ogg.document.version_number">0</Node>
             <Node Id="ogg.dossier.title">Verträge mit der kantonalen Finanzverwaltung</Node>
             <Node Id="Dossier.ReferenceNumber">Client1 1.1 / 1</Node>
@@ -38,18 +38,18 @@
         </Arguments>
       </Function>
       <Function name="MetaData" id="c364b495-7176-4ce2-9f7c-e71f302b8096">
-        <Value key="ogg.document.sequence_number" type="string">33</Value>
+        <Value key="ogg.document.sequence_number" type="string">34</Value>
         <Value key="ogg.dossier.sequence_number" type="string">1</Value>
         <Value key="ogg.user.userid" type="string">robert.ziegler</Value>
-        <Value key="Document.SequenceNumber" type="string">33</Value>
-        <Value key="Document.ReferenceNumber" type="string">Client1 1.1 / 1 / 33</Value>
+        <Value key="Document.SequenceNumber" type="string">34</Value>
+        <Value key="Document.ReferenceNumber" type="string">Client1 1.1 / 1 / 34</Value>
         <Value key="ogg.dossier.reference_number" type="string">Client1 1.1 / 1</Value>
         <Value key="ogg.user.email" type="string">robert.ziegler@gever.local</Value>
         <Value key="ogg.document.document_date" type="string">Aug 31, 2016</Value>
         <Value key="ogg.user.firstname" type="string">Robert</Value>
         <Value key="ogg.document.title" type="string">Schättengarten</Value>
         <Value key="ogg.user.title" type="string">Ziegler Robert</Value>
-        <Value key="ogg.document.reference_number" type="string">Client1 1.1 / 1 / 33</Value>
+        <Value key="ogg.document.reference_number" type="string">Client1 1.1 / 1 / 34</Value>
         <Value key="ogg.document.version_number" type="string">0</Value>
         <Value key="ogg.dossier.title" type="string">Verträge mit der kantonalen Finanzverwaltung</Value>
         <Value key="Dossier.ReferenceNumber" type="string">Client1 1.1 / 1</Value>

--- a/opengever/oneoffixx/tests/assets/oneoffixx_connect_xml.txt
+++ b/opengever/oneoffixx/tests/assets/oneoffixx_connect_xml.txt
@@ -14,18 +14,18 @@
       <Function name="CustomInterfaceConnector" id="70E94788-CE84-4460-9698-5663878A295B">
         <Arguments>
           <Interface Name="OneGovGEVER">
-            <Node Id="ogg.document.sequence_number">34</Node>
+            <Node Id="ogg.document.sequence_number">35</Node>
             <Node Id="ogg.dossier.sequence_number">1</Node>
             <Node Id="ogg.user.userid">robert.ziegler</Node>
-            <Node Id="Document.SequenceNumber">34</Node>
-            <Node Id="Document.ReferenceNumber">Client1 1.1 / 1 / 34</Node>
+            <Node Id="Document.SequenceNumber">35</Node>
+            <Node Id="Document.ReferenceNumber">Client1 1.1 / 1 / 35</Node>
             <Node Id="ogg.dossier.reference_number">Client1 1.1 / 1</Node>
             <Node Id="ogg.user.email">robert.ziegler@gever.local</Node>
             <Node Id="ogg.document.document_date">Aug 31, 2016</Node>
             <Node Id="ogg.user.firstname">Robert</Node>
             <Node Id="ogg.document.title">Schättengarten</Node>
             <Node Id="ogg.user.title">Ziegler Robert</Node>
-            <Node Id="ogg.document.reference_number">Client1 1.1 / 1 / 34</Node>
+            <Node Id="ogg.document.reference_number">Client1 1.1 / 1 / 35</Node>
             <Node Id="ogg.document.version_number">0</Node>
             <Node Id="ogg.dossier.title">Verträge mit der kantonalen Finanzverwaltung</Node>
             <Node Id="Dossier.ReferenceNumber">Client1 1.1 / 1</Node>
@@ -38,18 +38,18 @@
         </Arguments>
       </Function>
       <Function name="MetaData" id="c364b495-7176-4ce2-9f7c-e71f302b8096">
-        <Value key="ogg.document.sequence_number" type="string">34</Value>
+        <Value key="ogg.document.sequence_number" type="string">35</Value>
         <Value key="ogg.dossier.sequence_number" type="string">1</Value>
         <Value key="ogg.user.userid" type="string">robert.ziegler</Value>
-        <Value key="Document.SequenceNumber" type="string">34</Value>
-        <Value key="Document.ReferenceNumber" type="string">Client1 1.1 / 1 / 34</Value>
+        <Value key="Document.SequenceNumber" type="string">35</Value>
+        <Value key="Document.ReferenceNumber" type="string">Client1 1.1 / 1 / 35</Value>
         <Value key="ogg.dossier.reference_number" type="string">Client1 1.1 / 1</Value>
         <Value key="ogg.user.email" type="string">robert.ziegler@gever.local</Value>
         <Value key="ogg.document.document_date" type="string">Aug 31, 2016</Value>
         <Value key="ogg.user.firstname" type="string">Robert</Value>
         <Value key="ogg.document.title" type="string">Schättengarten</Value>
         <Value key="ogg.user.title" type="string">Ziegler Robert</Value>
-        <Value key="ogg.document.reference_number" type="string">Client1 1.1 / 1 / 34</Value>
+        <Value key="ogg.document.reference_number" type="string">Client1 1.1 / 1 / 35</Value>
         <Value key="ogg.document.version_number" type="string">0</Value>
         <Value key="ogg.dossier.title" type="string">Verträge mit der kantonalen Finanzverwaltung</Value>
         <Value key="Dossier.ReferenceNumber" type="string">Client1 1.1 / 1</Value>

--- a/opengever/private/tests/test_reference_number.py
+++ b/opengever/private/tests/test_reference_number.py
@@ -138,7 +138,7 @@ class TestPrivateReferenceNumber(IntegrationTestCase):
         self.login(self.regular_user, browser)
         browser.open(self.private_document)
 
-        expected_reference_number = 'P Client1 kathi-barfuss / 1 / 31'
+        expected_reference_number = 'P Client1 kathi-barfuss / 1 / 32'
         found_reference_number = browser.css('.referenceNumber .value').text[0]
 
-        self.assertEqual(found_reference_number, expected_reference_number)
+        self.assertEqual(expected_reference_number, found_reference_number)

--- a/opengever/private/tests/test_reference_number.py
+++ b/opengever/private/tests/test_reference_number.py
@@ -138,7 +138,7 @@ class TestPrivateReferenceNumber(IntegrationTestCase):
         self.login(self.regular_user, browser)
         browser.open(self.private_document)
 
-        expected_reference_number = 'P Client1 kathi-barfuss / 1 / 32'
+        expected_reference_number = 'P Client1 kathi-barfuss / 1 / 33'
         found_reference_number = browser.css('.referenceNumber .value').text[0]
 
         self.assertEqual(expected_reference_number, found_reference_number)

--- a/opengever/task/tests/test_forms.py
+++ b/opengever/task/tests/test_forms.py
@@ -97,7 +97,6 @@ class TestTaskEditForm(IntegrationTestCase):
             u'Die B\xfcrgschaft',
             u'Initialvertrag f\xfcr Bearbeitung',
             u'Initialvertrag f\xfcr Bearbeitung',
-            u'L\xe4\xe4r',
             'Personaleintritt',
             u'Vertr\xe4ge',
             u'Vertr\xe4gsentwurf',

--- a/opengever/tasktemplates/tests/test_trigger.py
+++ b/opengever/tasktemplates/tests/test_trigger.py
@@ -494,7 +494,6 @@ class TestTriggeringTaskTemplate(IntegrationTestCase):
             '[No Subject]',
             u'Die B\xfcrgschaft',
             u'Initialvertrag f\xfcr Bearbeitung',
-            u'L\xe4\xe4r',
             'Personaleintritt',
             u'Vertr\xe4gsentwurf',
             u'Vertragsentwurf \xdcberpr\xfcfen',

--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -1049,12 +1049,10 @@ class OpengeverContentFixture(object):
 
         self.register('empty_document', create(
             Builder('document')
-            .within(self.dossier)
+            .within(subdossier)
             .titled(u'L\xe4\xe4r')
-            .having(
-                preserved_as_paper=True,
-                )
-            ))
+            .having(preserved_as_paper=True)
+        ))
 
     @staticuid()
     def create_tasks(self):

--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -1018,7 +1018,7 @@ class OpengeverContentFixture(object):
             .titled(u'2015')
             ))
 
-        self.register('subdocument', create(
+        subdocument = self.register('subdocument', create(
             Builder('document')
             .within(subdossier)
             .titled(u'\xdcbersicht der Vertr\xe4ge von 2016')
@@ -1046,6 +1046,7 @@ class OpengeverContentFixture(object):
                 'Excel dummy content',
                 u'tab\xe4lle neu.xlsx',
             )
+            .relate_to([self.document, subdocument])
         ))
 
         self.register('empty_document', create(

--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -1028,14 +1028,24 @@ class OpengeverContentFixture(object):
                 )
             ))
 
-        self.register('subsubdossier', create(
+        subsubdossier = self.register('subsubdossier', create(
             Builder('dossier')
             .within(subdossier)
             .titled(u'Subsubdossier')
             .having(
                 keywords=(u'Subsubkeyword', u'Subsubkeyw\xf6rd'),
-                )
-            ))
+            )
+        ))
+
+        self.register('subsubdocument', create(
+            Builder('document')
+            .within(subsubdossier)
+            .titled(u'\xdcbersicht der Vertr\xe4ge von 2014')
+            .attach_file_containing(
+                'Excel dummy content',
+                u'tab\xe4lle neu.xlsx',
+            )
+        ))
 
         self.register('empty_document', create(
             Builder('document')

--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -934,11 +934,12 @@ class OpengeverContentFixture(object):
             .within(self.dossier)
             .titled(u'Vertr\xe4gsentwurf')
             .having(
-                document_date=datetime(2010, 1, 3),
+                delivery_date=datetime(2010, 1, 3),
+                description=u'Wichtige Vertr\xe4ge',
                 document_author=TEST_USER_ID,
+                document_date=datetime(2010, 1, 3),
                 document_type='contract',
                 receipt_date=datetime(2010, 1, 3),
-                delivery_date=datetime(2010, 1, 3),
                 )
             .attach_file_containing(
                 bumblebee_asset('example.docx').bytes(),

--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -1056,6 +1056,13 @@ class OpengeverContentFixture(object):
             .having(preserved_as_paper=True)
         ))
 
+        self.register('removed_document', create(
+            Builder('document')
+            .within(self.dossier)
+            .titled(u'W\xe4g')
+            .removed()
+        ))
+
     @staticuid()
     def create_tasks(self):
         self.task = self.register('task', create(

--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -1025,8 +1025,9 @@ class OpengeverContentFixture(object):
             .attach_file_containing(
                 'Excel dummy content',
                 u'tab\xe4lle.xlsx',
-                )
-            ))
+            )
+            .relate_to([self.document])
+        ))
 
         subsubdossier = self.register('subsubdossier', create(
             Builder('dossier')

--- a/opengever/testing/integration_test_case.py
+++ b/opengever/testing/integration_test_case.py
@@ -700,3 +700,6 @@ class IntegrationTestCase(TestCase):
     def trash_documents(self, *objects):
         for obj in objects:
             Trasher(obj).trash()
+
+    def assert_provides(self, obj, interface=None):
+        self.assertTrue(interface.providedBy(obj), '{} should provide {}'.format(obj, interface))

--- a/opengever/trash/tests/test_remove_conditions.py
+++ b/opengever/trash/tests/test_remove_conditions.py
@@ -12,8 +12,7 @@ from zope.i18n import translate
 class TestRemoveConditionsChecker(IntegrationTestCase):
 
     def assert_error_messages(self, expected, msgs):
-        self.assertEquals(
-            expected, [translate(msg) for msg in msgs])
+        self.assertEqual(expected, [translate(msg) for msg in msgs])
 
     def test_document_must_not_have_relations(self):
         self.login(self.manager)
@@ -31,13 +30,13 @@ class TestRemoveConditionsChecker(IntegrationTestCase):
     @browsing
     def test_document_must_not_have_backreferences(self, browser):
         self.login(self.manager, browser=browser)
-        self.trash_documents(self.subdocument)
+        self.trash_documents(self.empty_document)
 
         browser.open(self.taskdocument, view='edit')
-        browser.fill({'Related Documents': [self.subdocument]})
+        browser.fill({'Related Documents': [self.empty_document]})
         browser.find('Save').click()
 
-        checker = RemoveConditionsChecker(self.subdocument)
+        checker = RemoveConditionsChecker(self.empty_document)
 
         self.assertFalse(checker.removal_allowed())
         self.assert_error_messages(
@@ -50,18 +49,18 @@ class TestRemoveConditionsChecker(IntegrationTestCase):
         self.login(self.manager, browser=browser)
 
         browser.open(self.taskdocument, view='edit')
-        browser.fill({'Related Documents': [self.subdocument]})
+        browser.fill({'Related Documents': [self.empty_document]})
         browser.find('Save').click()
 
-        self.trash_documents(self.subdocument)
+        self.trash_documents(self.empty_document)
 
-        checker = RemoveConditionsChecker(self.subdocument)
+        checker = RemoveConditionsChecker(self.empty_document)
         self.assertFalse(checker.removal_allowed())
 
         with elevated_privileges():
             api.content.delete(obj=self.taskdocument)
 
-        checker = RemoveConditionsChecker(self.subdocument)
+        checker = RemoveConditionsChecker(self.empty_document)
         self.assertTrue(checker.removal_allowed())
 
     def test_document_must_be_trashed(self):


### PR DESCRIPTION
The testing changes propagate from a few previous failed launch attempts, but there was no reason to not roll them in for the parts where stuff is converted into integration tests.

* Drop the current list of MIME types
* Define a fresh 'what OC can support and is OK for everyone' list of MIME types in code
* Add an empty list of additional MIME types into the registry
* Add an empty list of blacklisted MIME types into the registry

The intent for the additional types is to enable very specific clients to enable site specific software.

The intent of the blacklisted types is to disallow MIME types on a site specific basis.

Closes #5087
Closes #5318