### PR TITLE
Remove a now-unneeded layer of Oneoffixx related Localization

### DIFF
--- a/opengever/dossier/browser/tabbed.py
+++ b/opengever/dossier/browser/tabbed.py
@@ -171,8 +171,6 @@ class TemplateFolderTabbedView(GeverTabbedView):
         return None
 
     def _get_tabs(self):
-        if is_oneoffixx_feature_enabled():
-            self.template_tab['title'] = _(u'label_local_templates', default=u'Documents')
         return filter(None, [
             self.oneoffixxtemplate_tab,
             self.template_tab,

--- a/opengever/dossier/locales/de/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/de/LC_MESSAGES/opengever.dossier.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2019-02-06 20:56+0000\n"
+"POT-Creation-Date: 2019-02-13 16:45+0000\n"
 "PO-Revision-Date: 2017-05-23 04:53+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: German <https://translations.onegovgever.ch/projects/onegov-gever/opengever-dossier/de/>\n"
@@ -635,11 +635,6 @@ msgstr "Label"
 #: ./opengever/dossier/browser/overview.py
 msgid "label_linked_dossiers"
 msgstr "Verlinkte Dossiers"
-
-#. Default: "Documents"
-#: ./opengever/dossier/browser/tabbed.py
-msgid "label_local_templates"
-msgstr "Dokumente"
 
 #. Default: "Mail-Address"
 #: ./opengever/dossier/templatefolder/form.py

--- a/opengever/dossier/locales/fr/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/fr/LC_MESSAGES/opengever.dossier.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-02-06 20:56+0000\n"
+"POT-Creation-Date: 2019-02-13 16:45+0000\n"
 "PO-Revision-Date: 2017-12-03 11:16+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-dossier/fr/>\n"
@@ -633,11 +633,6 @@ msgstr "label"
 #: ./opengever/dossier/browser/overview.py
 msgid "label_linked_dossiers"
 msgstr "Dossiers liés"
-
-#. Default: "Documents"
-#: ./opengever/dossier/browser/tabbed.py
-msgid "label_local_templates"
-msgstr ""
 
 #. Default: "Mail-Address"
 #: ./opengever/dossier/templatefolder/form.py

--- a/opengever/dossier/locales/opengever.dossier.pot
+++ b/opengever/dossier/locales/opengever.dossier.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-02-06 20:56+0000\n"
+"POT-Creation-Date: 2019-02-13 16:45+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -633,11 +633,6 @@ msgstr ""
 #. Default: "Linked Dossiers"
 #: ./opengever/dossier/browser/overview.py
 msgid "label_linked_dossiers"
-msgstr ""
-
-#. Default: "Documents"
-#: ./opengever/dossier/browser/tabbed.py
-msgid "label_local_templates"
 msgstr ""
 
 #. Default: "Mail-Address"


### PR DESCRIPTION
With https://github.com/4teamwork/opengever.core/pull/5353 I introduced an unnecessary translation for the document templates tab and also broke the french translation for it, when OneOffixx is enabled.