### PR TITLE
 Fix handling of non-ASCII in the scan-in API endpoint.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ---------------------
 
 - Add date string localization for sablon data. [njohner]
+- Fixed the REST API scan-in end point for organization units with non-ASCII in their titles. [Rotonen]
 - Set default language for task reminders. [njohner]
 - Suppress deletion events when filtering objects from copied subtrees. [lgraf]
 - Avoid infinite loops when looking for parent dossiers. [lgraf]

--- a/opengever/api/scanin.py
+++ b/opengever/api/scanin.py
@@ -91,6 +91,8 @@ class ScanIn(Service):
     def find_inbox(self):
         portal = api.portal.get()
         org_unit = self.request.form.get('org_unit')
+        if org_unit:
+            org_unit = org_unit.decode('UTF-8')
 
         with elevated_privileges():
             # Find inbox for the given org_unit

--- a/opengever/api/tests/test_scanin.py
+++ b/opengever/api/tests/test_scanin.py
@@ -104,7 +104,7 @@ class TestScanIn(IntegrationTestCase):
         self.login(self.regular_user, browser)
         inbox = self.create_org_unit_inbox()
 
-        body, headers = self.prepare_request(org_unit='Finanzamt')
+        body, headers = self.prepare_request(org_unit=u'Finanz\xe4mt')
         browser.open(self.portal.absolute_url() + '/@scan-in',
                      method='POST',
                      headers=headers,

--- a/opengever/contact/tests/test_team_listing.py
+++ b/opengever/contact/tests/test_team_listing.py
@@ -10,20 +10,37 @@ class TestTeamListing(IntegrationTestCase):
     def test_team_listing(self, browser):
         self.login(self.regular_user, browser=browser)
         browser.open(self.contactfolder, view='tabbedview_view-teams')
+        expected_listing = [
+            {
+                'Active': 'Yes',
+                'Group': 'Projekt A',
+                'Org Unit': u'Finanz\xe4mt',
+                'Title': u'Projekt \xdcberbaung Dorfmatte',
+            },
+            {
+                'Active': 'Yes',
+                'Group': u'Projekt L\xc3\xa4\xc3\xa4r',
+                'Org Unit': u'Finanz\xe4mt',
+                'Title': 'Sekretariat Abteilung Null',
+            },
+            {
+                'Active': 'Yes',
+                'Group': 'Projekt B',
+                'Org Unit': u'Finanz\xe4mt',
+                'Title': 'Sekretariat Abteilung XY',
+            },
+        ]
+        self.assertEqual(expected_listing, browser.css('.listing').first.dicts())
 
-        row = browser.css('.listing').first.dicts()[0]
-        self.assertEquals(
-            {'Active': 'Yes',
-             'Org Unit': 'Finanzamt',
-             'Group': 'Projekt A',
-             'Title': u'Projekt \xdcberbaung Dorfmatte'},
-            row)
-
-        link = browser.css('.listing tr')[1].css('a').first
-        self.assertEquals(
-            u'Projekt \xdcberbaung Dorfmatte', link.text)
-        self.assertEquals('http://nohost/plone/kontakte/team-1/view',
-                          link.get('href'))
+        expected_links = [
+            (u'Projekt \xdcberbaung Dorfmatte', 'http://nohost/plone/kontakte/team-1/view'),
+            ('Sekretariat Abteilung Null', 'http://nohost/plone/kontakte/team-3/view'),
+            ('Sekretariat Abteilung XY', 'http://nohost/plone/kontakte/team-2/view'),
+        ]
+        self.assertEqual(
+            expected_links,
+            [(row.text, row.get('href')) for row in browser.css('.listing a')],
+        )
 
     @browsing
     def test_lists_only_active_teams_by_default(self, browser):

--- a/opengever/inbox/tests/test_forwarding.py
+++ b/opengever/inbox/tests/test_forwarding.py
@@ -110,7 +110,7 @@ class TestForwarding(IntegrationTestCase):
         browser.open(self.inbox_forwarding, view='tabbedview_view-overview')
         responsible_row = browser.css('.listing').first.rows[8]
         self.assertEqual(['Responsible'], responsible_row.css('th').text)
-        self.assertEqual([u'Projekt \xdcberbaung Dorfmatte (Finanzamt)'],
+        self.assertEqual([u'Projekt \xdcberbaung Dorfmatte (Finanz\xe4mt)'],
                          responsible_row.css('td').text)
 
     @browsing

--- a/opengever/ogds/base/tests/test_actor_lookup.py
+++ b/opengever/ogds/base/tests/test_actor_lookup.py
@@ -13,12 +13,12 @@ class TestActorLookup(IntegrationTestCase):
     def test_inbox_actor_lookup(self):
         actor = Actor.lookup('inbox:fa')
 
-        self.assertEqual(u'Inbox: Finanzamt', actor.get_label())
+        self.assertEqual(u'Inbox: Finanz\xe4mt', actor.get_label())
         self.assertIsNone(actor.get_profile_url())
-        self.assertEqual('Inbox: Finanzamt', actor.get_link())
+        self.assertEqual(u'Inbox: Finanz\xe4mt', actor.get_link())
         self.assertEqual(u'fa_inbox_users', actor.permission_identifier)
         self.assertEqual(
-            u'<span class="actor-label actor-inbox">Inbox: Finanzamt</span>',
+            u'<span class="actor-label actor-inbox">Inbox: Finanz\xe4mt</span>',
             actor.get_link(with_icon=True))
 
     def test_contact_actor_lookup(self):
@@ -39,7 +39,7 @@ class TestActorLookup(IntegrationTestCase):
         self.login(self.regular_user)
         actor = Actor.lookup('team:1')
 
-        self.assertEqual(u'Projekt \xdcberbaung Dorfmatte (Finanzamt)',
+        self.assertEqual(u'Projekt \xdcberbaung Dorfmatte (Finanz\xe4mt)',
                          actor.get_label())
         self.assertEqual('http://nohost/plone/kontakte/team-1/view',
                          actor.get_profile_url())
@@ -47,12 +47,12 @@ class TestActorLookup(IntegrationTestCase):
         self.assertEqual(
             u'<a href="http://nohost/plone/kontakte/team-1/view" '
             u'class="actor-label actor-team">Projekt \xdcberbaung Dorfmatte '
-            u'(Finanzamt)</a>',
+            u'(Finanz\xe4mt)</a>',
             actor.get_link(with_icon=True))
 
         self.assertEqual(
             u'<a href="http://nohost/plone/kontakte/team-1/view">'
-            u'Projekt \xdcberbaung Dorfmatte (Finanzamt)</a>',
+            u'Projekt \xdcberbaung Dorfmatte (Finanz\xe4mt)</a>',
             actor.get_link())
 
     def test_user_actor_ogds_user(self):
@@ -83,7 +83,9 @@ class TestActorLookup(IntegrationTestCase):
         actor = Actor.lookup('contact:meier-franz')
 
         self.assertEquals(
-            u'<a href="http://nohost/plone/kontakte/meier-franz">Meier Foo &lt;b onmouseover=alert(&apos;Foo!&apos;)&gt;click me!&lt;/b&gt; (meier.f@example.com)</a>',
+            u'<a href="http://nohost/plone/kontakte/meier-franz">'
+            u'Meier Foo &lt;b onmouseover=alert(&apos;Foo!&apos;)&gt;click me!&lt;/b&gt; (meier.f@example.com)'
+            u'</a>',
             actor.get_link())
 
 

--- a/opengever/ogds/base/tests/test_sources.py
+++ b/opengever/ogds/base/tests/test_sources.py
@@ -903,9 +903,9 @@ class TestCurrentAdminUnitOrgUnitsSource(IntegrationTestCase):
         result = self.source.search('Finanz')
 
         self.assertEqual(1, len(result), 'Expect one result. only Finanzamt')
-        self.assertEquals('fa', result[0].token)
-        self.assertEquals('fa', result[0].value)
-        self.assertEquals(u'Finanzamt', result[0].title)
+        self.assertEqual('fa', result[0].token)
+        self.assertEqual('fa', result[0].value)
+        self.assertEqual(u'Finanz\xe4mt', result[0].title)
 
         result = self.source.search('Informatik')
         self.assertEqual(0, len(result),
@@ -916,7 +916,7 @@ class TestCurrentAdminUnitOrgUnitsSource(IntegrationTestCase):
             self.source.getTermByToken('invalid-id')
 
     def test_do_not_find_org_units_of_other_admin_units(self):
-        self.assertEqual(1, len(self.source.search('Finanzamt')))
+        self.assertEqual(1, len(self.source.search(u'Finanz\xe4mt')))
         self.assertEqual(0, len(self.source.search('Staatskanzlei')))
 
         api.portal.set_registry_record('current_unit_id',

--- a/opengever/ogds/base/tests/test_team_details.py
+++ b/opengever/ogds/base/tests/test_team_details.py
@@ -27,9 +27,9 @@ class TestTeamDetails(IntegrationTestCase):
         browser.open(self.contactfolder, view='team-1/view')
 
         items = browser.css('.listing').first.lists()
-        self.assertEquals(
-            ['Assigned org unit', 'Finanzamt'], items[0])
-        self.assertEquals(
+        self.assertEqual(
+            ['Assigned org unit', u'Finanz\xe4mt'], items[0])
+        self.assertEqual(
             ['Group', 'Projekt A'], items[1])
 
     @browsing

--- a/opengever/task/tests/test_assign.py
+++ b/opengever/task/tests/test_assign.py
@@ -102,10 +102,10 @@ class TestAssignTask(IntegrationTestCase):
                                    admin_unit_id='fa')
                            .with_default_groups())
 
-        self.hans = create(Builder('ogds_user')
-                           .id('james.bond')
-                           .having(firstname=u'James', lastname=u'Bond')
-                           .assign_to_org_units([org_unit2]))
+        create(Builder('ogds_user')
+               .id('james.bond')
+               .having(firstname=u'James', lastname=u'Bond')
+               .assign_to_org_units([org_unit2]))
 
         data = {'form.widgets.transition': 'task-transition-reassign'}
         browser.open(self.task, data, view='assign-task')
@@ -113,15 +113,15 @@ class TestAssignTask(IntegrationTestCase):
         browser.open(self.task,
                      data={'q': 'james', 'page': 1},
                      view='@@assign-task/++widget++form.widgets.responsible/search')
-        self.assertEquals([], browser.json.get('results'))
+        self.assertEqual([], browser.json.get('results'))
 
         browser.open(self.task,
                      data={'q': 'robert', 'page': 1},
                      view='@@assign-task/++widget++form.widgets.responsible/search')
-        self.assertEquals(
+        self.assertEqual(
             [{u'_resultId': u'fa:robert.ziegler',
               u'id': u'fa:robert.ziegler',
-              u'text': u'Finanzamt: Ziegler Robert (robert.ziegler)'}],
+              u'text': u'Finanz\xe4mt: Ziegler Robert (robert.ziegler)'}],
             browser.json.get('results'))
 
     @browsing

--- a/opengever/task/tests/test_overview.py
+++ b/opengever/task/tests/test_overview.py
@@ -31,14 +31,14 @@ class TestTaskOverview(IntegrationTestCase):
                           browser.css('.issuer a').first.text)
 
     @browsing
-    def test_issuer_is_prefixed_by_current_org_unit_on_a_multiclient_setup(self, browser):  # noqa
+    def test_issuer_is_prefixed_by_current_org_unit_on_a_multiclient_setup(self, browser):
         self.login(self.regular_user, browser=browser)
         create(Builder('org_unit').id('client2')
                .having(admin_unit=get_current_admin_unit()))
         browser.open(self.task, view='tabbedview_view-overview')
 
-        self.assertEquals(
-            'Finanzamt / Ziegler Robert (robert.ziegler)',
+        self.assertEqual(
+            u'Finanz\xe4mt / Ziegler Robert (robert.ziegler)',
             browser.css('.issuer').first.text)
 
     @browsing

--- a/opengever/task/tests/test_team_tasks.py
+++ b/opengever/task/tests/test_team_tasks.py
@@ -132,13 +132,13 @@ class TestTeamTasks(IntegrationTestCase):
                      'id': 'review_state',
                      'name': u'Issue state'}]
 
-        self.assertEquals(
+        self.assertEqual(
             expected, [dict(change) for change in response.changes])
 
         browser.open(self.task, view='tabbedview_view-overview')
-        self.assertEquals(
+        self.assertEqual(
             u'Accepted by B\xe4rfuss K\xe4thi (kathi.barfuss), responsible '
-            u'changed from Projekt \xdcberbaung Dorfmatte (Finanzamt) to '
+            u'changed from Projekt \xdcberbaung Dorfmatte (Finanz\xe4mt) to '
             u'B\xe4rfuss K\xe4thi (kathi.barfuss).',
             browser.css('.answer h3').text[0])
 

--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -166,7 +166,7 @@ class OpengeverContentFixture(object):
             Builder('org_unit')
             .id('fa')
             .having(
-                title=u'Finanzamt',
+                title=u'Finanz\xe4mt',
                 admin_unit=self.admin_unit,
                 )
             .with_default_groups()


### PR DESCRIPTION
As request objects contain byte strings, scan-in did not work for org units with non-ASCII in their titles.

Closes #5376