### PR TITLE
Fix a typo in info message.

### DIFF
--- a/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
@@ -698,7 +698,7 @@ msgstr "Protokollauszug erfolgreich generiert."
 #. Default: "Excerpt was returned to proposer."
 #: ./opengever/meeting/browser/meetings/agendaitem.py
 msgid "excerpt_returned"
-msgstr "Der Protokollauszug wurde im Urspurungsdossier abgelegt."
+msgstr "Der Protokollauszug wurde im Ursprungsdossier abgelegt."
 
 #. Default: "Excused"
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt


### PR DESCRIPTION
This PR fixes a typo when returning an excerpt to the dossier of its proposal.