### PR TITLE
Lock dossier subtree during resolve transition

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 2019.1.0 (unreleased)
 ---------------------
 
+- Lock dossier subtree during resolve transition. [lgraf]
+- Prevent dossiers from being resolved twice. [lgraf]
 - Fix subject-filter for personal overview. [elioschmutz]
 - Add date string localization for sablon data. [njohner]
 - Fixed the REST API scan-in end point for organization units with non-ASCII in their titles. [Rotonen]

--- a/opengever/dossier/locales/de/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/de/LC_MESSAGES/opengever.dossier.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2019-02-13 16:45+0000\n"
+"POT-Creation-Date: 2019-02-14 16:43+0000\n"
 "PO-Revision-Date: 2017-05-23 04:53+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: German <https://translations.onegovgever.ch/projects/onegov-gever/opengever-dossier/de/>\n"
@@ -15,6 +15,10 @@ msgstr ""
 "Domain: DOMAIN\n"
 "Language: de\n"
 "X-Generator: Weblate 2.13.1\n"
+
+#: ./opengever/dossier/viewlets/byline.py
+msgid " (currently being resolved)"
+msgstr " (wird gerade abgeschlossen)"
 
 #: ./opengever/dossier/move_items.py
 msgid "${copied_items} Elements were moved successfully"
@@ -48,6 +52,14 @@ msgstr "Report konnte nicht generiert werden."
 #: ./opengever/dossier/browser/overview.py
 msgid "Description"
 msgstr "Beschreibung"
+
+#: ./opengever/dossier/resolve.py
+msgid "Dossier has already been resolved."
+msgstr "Dieses Dossier wurde bereits abgeschlossen."
+
+#: ./opengever/dossier/resolve.py
+msgid "Dossier is already being resolved"
+msgstr "Der Abschlussvorgang für dieses Dossier läuft bereits."
 
 #: ./opengever/dossier/browser/templates/overview.pt
 msgid "Dossier structure"

--- a/opengever/dossier/locales/fr/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/fr/LC_MESSAGES/opengever.dossier.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-02-13 16:45+0000\n"
+"POT-Creation-Date: 2019-02-14 16:43+0000\n"
 "PO-Revision-Date: 2017-12-03 11:16+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-dossier/fr/>\n"
@@ -15,6 +15,10 @@ msgstr ""
 "Domain: DOMAIN\n"
 "Language: fr\n"
 "X-Generator: Weblate 2.13.1\n"
+
+#: ./opengever/dossier/viewlets/byline.py
+msgid " (currently being resolved)"
+msgstr " (en train d'être clôturé)"
 
 #: ./opengever/dossier/move_items.py
 msgid "${copied_items} Elements were moved successfully"
@@ -47,6 +51,14 @@ msgstr "Impossible de générer l'affichage."
 #: ./opengever/dossier/browser/overview.py
 msgid "Description"
 msgstr "Description"
+
+#: ./opengever/dossier/resolve.py
+msgid "Dossier has already been resolved."
+msgstr "Ce dossier a déjà été clôturé."
+
+#: ./opengever/dossier/resolve.py
+msgid "Dossier is already being resolved"
+msgstr "Le processus de clôture de ce dossier est déjà en cours."
 
 #: ./opengever/dossier/browser/templates/overview.pt
 msgid "Dossier structure"

--- a/opengever/dossier/locales/opengever.dossier.pot
+++ b/opengever/dossier/locales/opengever.dossier.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-02-13 16:45+0000\n"
+"POT-Creation-Date: 2019-02-14 16:43+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,6 +16,10 @@ msgstr ""
 "Language-Name: English\n"
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: opengever.dossier\n"
+
+#: ./opengever/dossier/viewlets/byline.py
+msgid " (currently being resolved)"
+msgstr ""
 
 #: ./opengever/dossier/move_items.py
 msgid "${copied_items} Elements were moved successfully"
@@ -47,6 +51,14 @@ msgstr ""
 
 #: ./opengever/dossier/browser/overview.py
 msgid "Description"
+msgstr ""
+
+#: ./opengever/dossier/resolve.py
+msgid "Dossier has already been resolved."
+msgstr ""
+
+#: ./opengever/dossier/resolve.py
+msgid "Dossier is already being resolved"
 msgstr ""
 
 #: ./opengever/dossier/browser/templates/overview.pt

--- a/opengever/dossier/resolve.py
+++ b/opengever/dossier/resolve.py
@@ -67,39 +67,54 @@ class DossierResolveView(BrowserView):
         # check preconditions
         errors = resolver.is_resolve_possible()
         if errors:
-            for msg in errors:
-                api.portal.show_message(
-                    message=msg, request=self.request, type='error')
-
-            return self.request.RESPONSE.redirect(
-                self.context.absolute_url())
+            self.show_errors(errors)
+            return self.redirect(self.context_url)
 
         # validate enddates
         invalid_dates = resolver.are_enddates_valid()
         if invalid_dates:
-            for title in invalid_dates:
-                msg = _("The dossier ${dossier} has a invalid end_date",
-                        mapping=dict(dossier=title,))
-                api.portal.show_message(
-                    message=msg, request=self.request, type='error')
-
-            return self.request.RESPONSE.redirect(
-                self.context.absolute_url())
+            self.show_invalid_end_dates(titles=invalid_dates)
+            return self.redirect(self.context_url)
 
         if resolver.is_archive_form_needed():
-            self.request.RESPONSE.redirect('transition-archive')
+            self.redirect('transition-archive')
         else:
             resolver.resolve()
             if self.context.is_subdossier():
-                api.portal.show_message(
-                    message=_('The subdossier has been succesfully resolved.'),
-                    request=self.request, type='info')
+                self.show_subdossier_resolved_msg()
             else:
-                api.portal.show_message(
-                    message=_('The dossier has been succesfully resolved.'),
-                    request=self.request, type='info')
+                self.show_dossier_resolved_msg()
 
-            self.request.RESPONSE.redirect(self.context.absolute_url())
+            self.redirect(self.context_url)
+
+    @property
+    def context_url(self):
+        return self.context.absolute_url()
+
+    def redirect(self, url):
+        return self.request.RESPONSE.redirect(url)
+
+    def show_errors(self, errors):
+        for msg in errors:
+            api.portal.show_message(
+                message=msg, request=self.request, type='error')
+
+    def show_invalid_end_dates(self, titles):
+        for title in titles:
+            msg = _("The dossier ${dossier} has a invalid end_date",
+                    mapping=dict(dossier=title,))
+            api.portal.show_message(
+                message=msg, request=self.request, type='error')
+
+    def show_subdossier_resolved_msg(self):
+        api.portal.show_message(
+            message=_('The subdossier has been succesfully resolved.'),
+            request=self.request, type='info')
+
+    def show_dossier_resolved_msg(self):
+        api.portal.show_message(
+            message=_('The dossier has been succesfully resolved.'),
+            request=self.request, type='info')
 
 
 class DossierReactivateView(BrowserView):

--- a/opengever/dossier/resolve.py
+++ b/opengever/dossier/resolve.py
@@ -59,6 +59,9 @@ class ValidResolverNamesVocabularyFactory(object):
 class DossierResolveView(BrowserView):
 
     def __call__(self):
+        self.execute_recursive_resolve()
+
+    def execute_recursive_resolve(self):
         resolver = get_resolver(self.context)
 
         # check preconditions

--- a/opengever/dossier/resolve.py
+++ b/opengever/dossier/resolve.py
@@ -67,25 +67,21 @@ class DossierResolveView(BrowserView):
         # check preconditions
         errors = resolver.is_resolve_possible()
         if errors:
-            self.show_errors(errors)
-            return self.redirect(self.context_url)
+            return self.show_errors(errors)
 
         # validate enddates
         invalid_dates = resolver.are_enddates_valid()
         if invalid_dates:
-            self.show_invalid_end_dates(titles=invalid_dates)
-            return self.redirect(self.context_url)
+            return self.show_invalid_end_dates(titles=invalid_dates)
 
         if resolver.is_archive_form_needed():
-            self.redirect('transition-archive')
-        else:
-            resolver.resolve()
-            if self.context.is_subdossier():
-                self.show_subdossier_resolved_msg()
-            else:
-                self.show_dossier_resolved_msg()
+            return self.redirect('transition-archive')
 
-            self.redirect(self.context_url)
+        resolver.resolve()
+        if self.context.is_subdossier():
+            return self.show_subdossier_resolved_msg()
+
+        return self.show_dossier_resolved_msg()
 
     @property
     def context_url(self):
@@ -98,6 +94,7 @@ class DossierResolveView(BrowserView):
         for msg in errors:
             api.portal.show_message(
                 message=msg, request=self.request, type='error')
+        return self.redirect(self.context_url)
 
     def show_invalid_end_dates(self, titles):
         for title in titles:
@@ -105,16 +102,19 @@ class DossierResolveView(BrowserView):
                     mapping=dict(dossier=title,))
             api.portal.show_message(
                 message=msg, request=self.request, type='error')
+        return self.redirect(self.context_url)
 
     def show_subdossier_resolved_msg(self):
         api.portal.show_message(
             message=_('The subdossier has been succesfully resolved.'),
             request=self.request, type='info')
+        return self.redirect(self.context_url)
 
     def show_dossier_resolved_msg(self):
         api.portal.show_message(
             message=_('The dossier has been succesfully resolved.'),
             request=self.request, type='info')
+        return self.redirect(self.context_url)
 
 
 class DossierReactivateView(BrowserView):

--- a/opengever/dossier/resolve_lock.py
+++ b/opengever/dossier/resolve_lock.py
@@ -1,0 +1,132 @@
+from Acquisition import aq_parent
+from datetime import datetime
+from datetime import timedelta
+from opengever.dossier.behaviors.dossier import IDossierMarker
+from persistent.mapping import PersistentMapping
+from plone import api
+from zope.annotation import IAnnotations
+import logging
+import transaction
+
+
+logger = logging.getLogger('opengever.dossier')
+
+
+RESOLVE_LOCK_KEY = 'opengever.dossier.resolve_lock'
+RESOLVE_LOCK_LIFETIME = timedelta(hours=24)
+
+
+class ResolveLock(object):
+    """Locking mechanism to prevent concurrent dossier resolution.
+
+    This mechanism is intended to prevent users from simultaneously triggering
+    the 'resolve' transition for a dossier (which would result in degraded
+    performance because retries of conflicting transactions).
+
+    We do this by issuing a persistent lock that gets committed in its own
+    transaction as the very first thing in the resolution process. Further
+    attempts at resolving a dossier are then rejected as long as such a lock
+    exists (and hasn't expired). Once the dossier is resolved successfully,
+    the lock is removed and the removal will be committed again.
+
+    In case of an exception, we catch it, abort the transaction, remove the
+    lock, commit the removal, and re-reaise the exception to be handled by
+    the usual error handling in ZPublisher.
+
+    This class implements the necessary primitives for this locking mechanism.
+    The high-level implementation of the strategy described above is actually
+    done in the view in opengever.dossier.resolve.
+    """
+
+    def __init__(self, context):
+        self.context = context
+        self.catalog = api.portal.get_tool('portal_catalog')
+
+    def acquire(self, commit=False):
+        """Acquire a resolve lock for a dossier.
+
+        Will overwrite a possibly existing expired lock.
+        """
+        self.log("Acquiring resolve lock for %s..." % self.context)
+        ann = IAnnotations(self.context)
+        lockinfo = PersistentMapping({
+            'timestamp': datetime.now(),
+            'userid': api.user.get_current().id,
+        })
+        ann[RESOLVE_LOCK_KEY] = lockinfo
+        self.invalidate_cache()
+
+        if commit:
+            transaction.commit()
+
+        self.log("Resolve lock acquired.")
+
+    def release(self, commit=False):
+        """Release a previously acquired lock.
+
+        Will raise a KeyError if no lock has been acquired.
+        """
+        self.log("Releasing resolve lock...")
+        ann = IAnnotations(self.context)
+        del ann[RESOLVE_LOCK_KEY]
+        self.invalidate_cache()
+
+        if commit:
+            transaction.commit()
+
+        self.log("Resolve lock released for %s" % self.context)
+
+    def invalidate_cache(self):
+        """Increment catalog counter to invalidate plone.app.caching ETAGs.
+        """
+        self.catalog._increment_counter()
+
+    def is_expired(self, lockinfo):
+        """Determine whether a lock is expired.
+        """
+        ts = lockinfo['timestamp']
+        age = datetime.now() - ts
+        expired = age > RESOLVE_LOCK_LIFETIME
+        if expired:
+            self.log("Resolve lock is expired (age: %s): %s" % (age, lockinfo))
+        return expired
+
+    def is_locked(self, recursive=True):
+        """Determine whether a dossier currently is resolve locked.
+
+        By default also considers a subdossier locked if any of its parent
+        dossiers have a lock on them.
+
+        If recursive=False is given, only the current dossier is checked for
+        a lock (cheaper, this is used to display the state in the byline).
+
+        If a lock exists (somewhere) but is older than RESOLVE_LOCK_LIFETIME,
+        it is considered expired and treated as if it wouldn't exist.
+        """
+        if not recursive:
+            lockinfo = self.get_lockinfo(self.context)
+            if lockinfo is not None and not self.is_expired(lockinfo):
+                self.log("%s is resolve locked" % self.context)
+                return True
+            return False
+
+        item = self.context
+
+        while IDossierMarker.providedBy(item):
+
+            lockinfo = self.get_lockinfo(item)
+            if lockinfo is not None and not self.is_expired(lockinfo):
+                self.log("%s is resolve locked via lock on %r" % (self.context, item))
+                return True
+            item = aq_parent(item)
+
+        return False
+
+    def get_lockinfo(self, context):
+        return IAnnotations(context).get(RESOLVE_LOCK_KEY)
+
+    def log(self, msg):
+        """Log a message including the current connection identifier.
+        """
+        conn = self.context._p_jar
+        logger.info('[%r] %s' % (conn, msg))

--- a/opengever/dossier/resolve_lock.py
+++ b/opengever/dossier/resolve_lock.py
@@ -120,13 +120,6 @@ class ResolveLock(object):
         If a lock exists (somewhere) but is older than RESOLVE_LOCK_LIFETIME,
         it is considered expired and treated as if it wouldn't exist.
         """
-        if not recursive:
-            lockinfo = self.get_lockinfo(self.context)
-            if lockinfo is not None and not self.is_expired(lockinfo):
-                self.log("%s is resolve locked" % self.context)
-                return True
-            return False
-
         item = self.context
 
         while IDossierMarker.providedBy(item):
@@ -135,6 +128,10 @@ class ResolveLock(object):
             if lockinfo is not None and not self.is_expired(lockinfo):
                 self.log("%s is resolve locked via lock on %r" % (self.context, item))
                 return True
+
+            if not recursive:
+                return False
+
             item = aq_parent(item)
 
         return False

--- a/opengever/dossier/tests/test_resolve.py
+++ b/opengever/dossier/tests/test_resolve.py
@@ -12,9 +12,11 @@ from ftw.testbrowser.pages import statusmessages
 from ftw.testbrowser.pages.statusmessages import error_messages
 from ftw.testbrowser.pages.statusmessages import info_messages
 from ftw.testing import freeze
+from opengever.base.tests.byline_base_test import TestBylineBase
 from opengever.core.testing import OPENGEVER_FUNCTIONAL_BUMBLEBEE_LAYER
 from opengever.dossier.behaviors.dossier import IDossier
 from opengever.dossier.interfaces import IDossierResolveProperties
+from opengever.dossier.resolve_lock import ResolveLock
 from opengever.testing import FunctionalTestCase
 from opengever.testing import IntegrationTestCase
 from plone import api
@@ -754,3 +756,65 @@ class TestResolving(FunctionalTestCase):
                           api.content.get_state(dossier))
         self.assertEquals('dossier-state-resolved',
                           api.content.get_state(subdossier))
+
+
+class TestResolveLocking(TestBylineBase):
+
+    @browsing
+    def test_resolve_locked_dossier_is_recognized_as_such(self, browser):
+        self.login(self.secretariat_user, browser)
+
+        resolve_lock = ResolveLock(self.empty_dossier)
+        resolve_lock.acquire(commit=False)
+
+        self.assertTrue(resolve_lock.is_locked())
+
+        browser.open(self.empty_dossier)
+
+        wfstate = self.get_byline_value_by_label('State:').text
+        self.assertEqual('dossier-state-active (currently being resolved)', wfstate)
+
+    @browsing
+    def test_expired_resolve_lock_is_recognized(self, browser):
+        self.login(self.secretariat_user, browser)
+
+        with freeze(datetime(2018, 4, 30)) as freezer:
+            resolve_lock = ResolveLock(self.empty_dossier)
+            resolve_lock.acquire(commit=False)
+
+            self.assertTrue(resolve_lock.is_locked())
+
+            freezer.forward(hours=25)
+            self.assertFalse(resolve_lock.is_locked())
+
+    @browsing
+    def test_resolve_lock_works_recursively_for_whole_subtree(self, browser):
+        self.login(self.secretariat_user, browser)
+
+        main_dossier = self.subdossier.aq_parent
+
+        # Issue lock on the main dossier
+        resolve_lock = ResolveLock(main_dossier)
+        resolve_lock.acquire(commit=False)
+
+        # Subdossier should also be considered locked
+        self.assertTrue(ResolveLock(self.subdossier).is_locked())
+
+        # Except if we explicitly check with recursive=False
+        # (used for low-cost display in byline on every view)
+        self.assertFalse(ResolveLock(self.subdossier).is_locked(recursive=False))
+
+    @browsing
+    def test_locked_dossier_cant_be_resolved(self, browser):
+        self.login(self.secretariat_user, browser)
+
+        resolve_lock = ResolveLock(self.empty_dossier)
+        resolve_lock.acquire(commit=False)
+
+        resolve_dossier(self.empty_dossier, browser)
+
+        self.assertEquals(
+            ['Dossier is already being resolved'], info_messages())
+
+        self.assertEquals('dossier-state-active',
+                          api.content.get_state(self.empty_dossier))

--- a/opengever/dossier/tests/test_resolve.py
+++ b/opengever/dossier/tests/test_resolve.py
@@ -90,6 +90,17 @@ class TestResolvingDossiers(IntegrationTestCase):
         self.assertEquals(['The subdossier has been succesfully resolved.'],
                           info_messages())
 
+    @browsing
+    def test_cant_resolve_already_resolved_dossier(self, browser):
+        self.login(self.secretariat_user, browser)
+
+        resolve_dossier(self.subdossier, browser)
+        resolve_dossier(self.subdossier, browser)
+
+        self.assertEquals(self.subdossier.absolute_url(), browser.url)
+        self.assertEquals(['Dossier has already been resolved.'],
+                          info_messages())
+
 
 class TestResolveJobs(IntegrationTestCase):
 


### PR DESCRIPTION
Implements a **locking mechanism to prevent concurrent dossier resolution**.

This mechanism is intended to prevent users from simultaneously triggering the `resolve` transition for a dossier (which would result in degraded performance because retries of conflicting transactions).

We do this by issuing a **persistent lock** that gets committed in its own transaction as the very first thing in the resolution process. Further attempts at resolving a dossier are then rejected as long as such a lock exists (and hasn't expired). Once the dossier is resolved successfully, the lock is removed and the removal will be committed again. The lock will **expire after 24h**, and which point it will just be treated as if it wouldn't exist.

In case of an exception, we catch it, abort the transaction, remove the lock, commit the removal, and re-reaise the exception to be handled by the usual error handling in `ZPublisher`.

When checking whether a subdossier is locked, possible locks on any of its parents are also considered. So basically an **entire dossier subtree is locked as a whole**, by attaching a lock to the main dossier. If a dossier is locked, this is displayed by appending a message to the workflow status in the byline - this is however only displayed for the current context, not determined recursively (for performance reasons).

In addition, this change includes a **guard condition to prevent dossiers from being resolved twice**.

Logging is currently very much on the verbose side, and could eventually be toned down once this proves to be a reliable strategy in the field.

**Note:** I added a check for a dirty transaction when committing the lock. When the transaction is found to be dirty (which it usually shouldn't be), this is logged to Sentry, but we still proceed with committing. 

#### View of a dossier during resolve process
![view_during_resolve](https://user-images.githubusercontent.com/405124/52805533-130f5180-3087-11e9-9bfd-50c1ee8637ac.png)

---

#### View of a dossier when a concurrent resolution is attempted
![attempt_at_concurrent_resolution](https://user-images.githubusercontent.com/405124/52805578-2e7a5c80-3087-11e9-9f0d-3d51074a2231.png)

---

#### Example logs for a concurrent attempt at resolving the same dossier

```
2019-02-14 18:24:41 INFO opengever.dossier [<Connection at 10a79c050>] Acquiring resolve lock for <DossierContainer at dossier-54>...
2019-02-14 18:24:41 INFO opengever.dossier [<Connection at 10a79c050>] Resolve lock acquired.
2019-02-14 18:24:52 INFO opengever.dossier [<Connection at 11ada90d0>] <DossierContainer at dossier-54> is resolve locked
2019-02-14 18:24:55 INFO opengever.dossier [<Connection at 11ada90d0>] <DossierContainer at dossier-54> is resolve locked via lock on <DossierContainer at /fd/ordnungssystem/bildung/dossier-54>
2019-02-14 18:24:55 INFO opengever.dossier [<Connection at 11ada90d0>] Concurrent attempt at resolving <DossierContainer at dossier-54> rejected
2019-02-14 18:24:55 INFO opengever.dossier [<Connection at 11ada90d0>] <DossierContainer at dossier-54> is resolve locked
2019-02-14 18:25:11 INFO opengever.dossier [<Connection at 10a79c050>] Successfully resolved <DossierContainer at dossier-54>
2019-02-14 18:25:11 INFO opengever.dossier [<Connection at 10a79c050>] Releasing resolve lock...
2019-02-14 18:25:11 INFO opengever.dossier [<Connection at 10a79c050>] Resolve lock released for <DossierContainer at dossier-54>
```
---

#### Example logs for an exception during resolution
```
2019-02-14 18:21:31 INFO opengever.dossier [<Connection at 10a79c050>] Acquiring resolve lock for <DossierContainer at dossier-54>...
2019-02-14 18:21:31 INFO opengever.dossier [<Connection at 10a79c050>] Resolve lock acquired.
2019-02-14 18:22:01 INFO opengever.dossier [<Connection at 10a79c050>] Releasing resolve lock...
2019-02-14 18:22:01 INFO opengever.dossier [<Connection at 10a79c050>] Resolve lock released for <DossierContainer at dossier-54>
2019-02-14 18:22:01 ERROR Zope.SiteErrorLog 1550164921.490.941219581584 http://localhost:8080/fd/ordnungssystem/bildung/dossier-54/transition-resolve
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module opengever.dossier.resolve, line 81, in __call__
  Module opengever.dossier.resolve, line 132, in execute_recursive_resolve
Exception: Boom
2019-02-14 18:22:01 ERROR Zope.SiteErrorLog 1550164921.50.650119714009 http://localhost:8080/fd/ordnungssystem/bildung/dossier-54/transition-resolve
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module opengever.dossier.resolve, line 81, in __call__
  Module opengever.dossier.resolve, line 132, in execute_recursive_resolve
Exception: Boom
```

*(**Note**: The exception being reported twice has nothing to do with the changes in this PR. I checked, the actual code is only run once, it's just a case of double-reporting that already happens in `maser`. The reason for this is that first ZPublisher [invokes`SiteErrorLog.raising()`](https://github.com/zopefoundation/Zope/blob/2.13.28/src/Zope2/App/startup.py#L214), later [looks up the exception handling view and calls it](https://github.com/zopefoundation/Zope/blob/2.13.28/src/Zope2/App/startup.py#L232), which finds our own error handling view, which then [calls `SiteErrorLog.raising()` again](https://github.com/4teamwork/opengever.core/blob/master/opengever/base/browser/errors.py#L48-L50). )* 