### PR TITLE
Handle empty responsible field when assigning task.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -8,6 +8,7 @@ Changelog
 - Lock dossier subtree during resolve transition. [lgraf]
 - Prevent dossiers from being resolved twice. [lgraf]
 - Fix subject-filter for personal overview. [elioschmutz]
+- Handle empty responsible field when assigning task. [njohner]
 - Add date string localization for sablon data. [njohner]
 - Fixed the REST API scan-in end point for organization units with non-ASCII in their titles. [Rotonen]
 - Set default language for task reminders. [njohner]

--- a/opengever/task/browser/assign.py
+++ b/opengever/task/browser/assign.py
@@ -61,7 +61,7 @@ class NoTeamsInProgressStateValidator(validator.SimpleFieldValidator):
     """
 
     def validate(self, value):
-        if ActorLookup(value).is_team() and not self.context.is_open():
+        if value and ActorLookup(value).is_team() and not self.context.is_open():
             raise Invalid(
                 _(u'error_no_team_responsible_in_progress_state',
                   default=u'Team responsibles are only allowed if the task or '

--- a/opengever/task/tests/test_assign.py
+++ b/opengever/task/tests/test_assign.py
@@ -48,6 +48,16 @@ class TestAssignTask(IntegrationTestCase):
         self.assertIsNone(browser.find('Transition'))
 
     @browsing
+    def test_responsible_is_mandatory(self, browser):
+        self.login(self.regular_user, browser=browser)
+        browser.open(self.task, view='assign-task')
+        browser.click_on('Assign')
+
+        self.assertEqual([], info_messages())
+        errors = browser.css("#formfield-form-widgets-transition .error")
+        self.assertEqual(['Required input is missing.'], errors.text)
+
+    @browsing
     def test_updates_responsible(self, browser):
         self.login(self.regular_user, browser=browser)
 


### PR DESCRIPTION
When reassigning the task, leaving the responsible field empty would lead to an exception. This is now handled. What will happen now is that you stay on the form and get an error message (see screenshot)

resolves #5392 

<img width="1306" alt="screen shot 2019-02-15 at 17 43 33" src="https://user-images.githubusercontent.com/7374243/52870957-503c1800-3149-11e9-9a8f-3e60964e4bb8.png">
