### PR TITLE
Docs: Officially publish release notes

### DIFF
--- a/docs/public/index.rst
+++ b/docs/public/index.rst
@@ -11,20 +11,4 @@ Inhalt:
    systemadmin-manual/index.rst
    dev-manual/index.rst
    user-manual/glossary.rst
-
-.. Release notes section shouldn't be published quite yet.
-..
-.. Remove this entire block and simply append the 'release-notes/index.rst'
-.. to the toctree above once it should be published.
-..
-.. Please also remove the :orphan: directive from the top of
-.. docs/public/release-notes/index.rst once you do this (that directive
-.. prevents Sphinx warning about the release notes section not being included
-.. in any toctree).
-
-.. ifconfig:: publication_level == 'private'
-
-   .. toctree::
-      :maxdepth: 3
-
-      release-notes/index.rst
+   release-notes/index.rst

--- a/docs/public/release-notes/index.rst
+++ b/docs/public/release-notes/index.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 Release-Notes
 =============
 


### PR DESCRIPTION
Officially **publish release notes**, since they are now being linked to from the https://onegovgever.ch/aktuell redirect.

*(They were already reachable, but not completely integrated into the navigation/TOC)* 