### PR TITLE
Add Visio *.vsdx to the base list of OC-editable types

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 2019.2.0 (unreleased)
 ---------------------
 
-- Nothing changed yet.
+- Add *.vsdx to the base list of OC-editable types.
+  [lgraf]
 
 
 2019.1.0 (2019-02-19)

--- a/opengever/document/document.py
+++ b/opengever/document/document.py
@@ -17,7 +17,7 @@ from opengever.dossier.behaviors.dossier import IDossierMarker
 from opengever.meeting.proposal import ISubmittedProposal
 from opengever.officeconnector.helpers import create_oc_url
 from opengever.officeconnector.helpers import is_officeconnector_checkout_feature_enabled
-from opengever.officeconnector.mimetypes import EDITABLE_TYPES
+from opengever.officeconnector.mimetypes import get_editable_types
 from opengever.oneoffixx import is_oneoffixx_feature_enabled
 from opengever.task.task import ITask
 from plone import api
@@ -288,18 +288,7 @@ class Document(Item, BaseDocumentMixin):
         if self.file is None:
             return False
 
-        editable_mimetypes = set(type.lower() for type in EDITABLE_TYPES)
-
-        # Append extra MIME types from the registry
-        extra_mimetypes = set(type.lower() for type in api.portal.get_registry_record(
-            'opengever.officeconnector.interfaces.IOfficeConnectorSettings.officeconnector_editable_types_extra'))
-        editable_mimetypes.update(extra_mimetypes)
-
-        # Remove blacklisted-in-registry MIME types
-        blacklisted_mimetypes = set(type.lower() for type in api.portal.get_registry_record(
-            'opengever.officeconnector.interfaces.IOfficeConnectorSettings.officeconnector_editable_types_blacklist'))
-        editable_mimetypes.difference_update(blacklisted_mimetypes)
-
+        editable_mimetypes = get_editable_types()
         return self.content_type().lower() in editable_mimetypes
 
     def is_checkout_and_edit_available(self):

--- a/opengever/officeconnector/mimetypes.py
+++ b/opengever/officeconnector/mimetypes.py
@@ -39,6 +39,7 @@ EDITABLE_TYPES = [
     'application/x-mspublisher',
     # MS Visio
     'application/vnd.visio',
+    'application/vnd.ms-visio.drawing',
     # MS Word
     'application/msword',
     'application/vnd.openxmlformats-officedocument.wordprocessingml.document',

--- a/opengever/officeconnector/mimetypes.py
+++ b/opengever/officeconnector/mimetypes.py
@@ -1,3 +1,6 @@
+from plone import api
+
+
 EDITABLE_TYPES = [
     # Adobe Illustrator
     'application/illustrator',
@@ -53,3 +56,25 @@ EDITABLE_TYPES = [
     'text/tab-separated-values',
     'text/xml',
 ]
+
+
+def get_editable_types():
+    """Return the full list of OC-editable mimetypes (lowercased).
+
+    This function compiles the final list based on the standard set from
+    EDITABLE_TYPES, plus/minus some customer-specific blacklisted / whitelisted
+    types defined in registry settings.
+    """
+    editable_mimetypes = set(type.lower() for type in EDITABLE_TYPES)
+
+    # Append extra MIME types from the registry
+    extra_mimetypes = set(type.lower() for type in api.portal.get_registry_record(
+        'opengever.officeconnector.interfaces.IOfficeConnectorSettings.officeconnector_editable_types_extra'))
+    editable_mimetypes.update(extra_mimetypes)
+
+    # Remove blacklisted-in-registry MIME types
+    blacklisted_mimetypes = set(type.lower() for type in api.portal.get_registry_record(
+        'opengever.officeconnector.interfaces.IOfficeConnectorSettings.officeconnector_editable_types_blacklist'))
+    editable_mimetypes.difference_update(blacklisted_mimetypes)
+
+    return editable_mimetypes


### PR DESCRIPTION
Adds the mimetype for XML based Visio `*.vsdx` files (`'application/vnd.ms-visio.drawing'`) to the base list of OC-editable types.

The intent was to do this in #5085, but this type was only added as part of upgrade steps, not to the base profile. Therefore it got omitted when switching to the new three-tier mechanism in #5382.

The macro enabled Visio types, as well as template and stencils, are not added on purpose because those currently won't work with OfficeConnector.

See #5413 for some more background.

---

In addition, this PR factors out the `get_editable_types()` function for cleaner separation of concerns (building the final list vs. determining whether a particular document is editable) and easier use for debugging.