### PR TITLE
Set default language for dossier overdue activity.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -9,6 +9,7 @@ Changelog
   [lgraf]
 - Fix handling of valid terms in repository tree xlsx file. [njohner]
 - Handle translations for block_inheritance in repository xlsx file. [njohner]
+- Set default language for dossier overdue activity. [njohner]
 
 
 2019.1.0 (2019-02-19)

--- a/opengever/activity/__init__.py
+++ b/opengever/activity/__init__.py
@@ -56,6 +56,8 @@ def send_digest_zopectl_handler(app, args):
 
     plone = setup_plone(get_first_plone_site(app))
 
+    # XXX This should not be necessary, but it seems that language negotiation
+    # fails somewhere down the line.
     # Set up the language based on site wide preferred language. We do this
     # so all the i18n and l10n machinery down the line uses the right language.
     lang_tool = api.portal.get_tool('portal_languages')

--- a/opengever/task/reminder/cronjobs.py
+++ b/opengever/task/reminder/cronjobs.py
@@ -14,6 +14,8 @@ def generate_remind_notifications_zopectl_handler(app, args):
 
     plone = setup_plone(get_first_plone_site(app))
 
+    # XXX This should not be necessary, but it seems that language negotiation
+    # fails somewhere down the line.
     # Set up the language based on site wide preferred language. We do this
     # so all the i18n and l10n machinery down the line uses the right language.
     lang_tool = api.portal.get_tool('portal_languages')


### PR DESCRIPTION
More translations problems for mails generated via cron jobs. We corrected this for task reminders in https://github.com/4teamwork/opengever.core/pull/5379, and now the same fix is applied for dossier overdue activity. We are simply making sure the language is set on the request before generating the E-mails.

This resolves https://basecamp.com/2768704/projects/12554551/todos/380774579