### PR TITLE
Make bumblebeeable documents uniform on API endpoints

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2019.2.0 (unreleased)
 ---------------------
 
-- Nothing changed yet.
+- Unify Bumblebee URLs on REST API for document vs. document on a listing. [Rotonen]
 
 
 2019.1.1 (2019-02-26)

--- a/opengever/api/document.py
+++ b/opengever/api/document.py
@@ -27,6 +27,8 @@ class SerializeDocumentToJson(GeverSerializeToJson):
             self.context, 'thumbnail')
         result[u'preview_url'] = bumblebee_service.get_representation_url(
             self.context, 'preview')
+        result[u'pdf_url'] = bumblebee_service.get_representation_url(
+            self.context, 'pdf')
 
         return result
 

--- a/opengever/api/listing.py
+++ b/opengever/api/listing.py
@@ -101,7 +101,7 @@ FIELDS = {
     'sequence_number': ('sequence_number', 'sequence_number', 'sequence_number'),
     'start': ('start', 'start', 'start'),
     'thumbnail_url': (None, 'get_preview_image_url', DEFAULT_SORT_INDEX),
-    'preview_url': (None, 'get_preview_pdf_url', DEFAULT_SORT_INDEX),
+    'preview_url': (None, 'get_preview_frame_url', DEFAULT_SORT_INDEX),
     'title': ('Title', translated_title, 'sortable_title'),
     'type': ('portal_type', 'PortalType', 'portal_type'),
     'filesize': (None, filesize, 'filesize'),

--- a/opengever/api/listing.py
+++ b/opengever/api/listing.py
@@ -102,6 +102,7 @@ FIELDS = {
     'start': ('start', 'start', 'start'),
     'thumbnail_url': (None, 'get_preview_image_url', DEFAULT_SORT_INDEX),
     'preview_url': (None, 'get_preview_frame_url', DEFAULT_SORT_INDEX),
+    'pdf_url': (None, 'get_preview_pdf_url', DEFAULT_SORT_INDEX),
     'title': ('Title', translated_title, 'sortable_title'),
     'type': ('portal_type', 'PortalType', 'portal_type'),
     'filesize': (None, filesize, 'filesize'),

--- a/opengever/api/tests/test_document.py
+++ b/opengever/api/tests/test_document.py
@@ -17,6 +17,16 @@ class TestDocumentSerializer(IntegrationTestCase):
             u'ccc4a73154625a6820cb6b50dc1455eb4cf26399299d4f9ce77b2/preview')
 
     @browsing
+    def test_document_serialization_contains_pdf_url(self, browser):
+        self.login(self.regular_user, browser)
+        browser.open(self.document, headers={'Accept': 'application/json'})
+        self.assertEqual(browser.status_code, 200)
+        self.assertEqual(
+            browser.json.get(u'pdf_url')[:120],
+            u'http://bumblebee/YnVtYmxlYmVl/api/v3/resource/local/51d6317494e'
+            u'ccc4a73154625a6820cb6b50dc1455eb4cf26399299d4f9ce77b2/pdf')
+
+    @browsing
     def test_document_serialization_contains_thumbnail_url(self, browser):
         self.login(self.regular_user, browser)
         browser.open(self.document, headers={'Accept': 'application/json'})

--- a/opengever/api/tests/test_listing.py
+++ b/opengever/api/tests/test_listing.py
@@ -5,6 +5,8 @@ from opengever.testing import IntegrationTestCase
 
 class TestListingEndpoint(IntegrationTestCase):
 
+    features = ('bumblebee',)
+
     @browsing
     def test_dossier_listing(self, browser):
         self.login(self.regular_user, browser=browser)
@@ -56,6 +58,23 @@ class TestListingEndpoint(IntegrationTestCase):
              u'bumblebee_checksum': DOCX_CHECKSUM,
              u'relative_path': u'ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/document-12'},
             browser.json['items'][-1])
+
+    @browsing
+    def test_document_listing_preview_url(self, browser):
+        self.login(self.regular_user, browser)
+        query_string = '&'.join((
+            'name=documents',
+            'columns:list=preview_url',
+            'sort_on=created',
+        ))
+        view = '?'.join(('@listing', query_string))
+        browser.open(self.dossier, view=view, headers={'Accept': 'application/json'})
+
+        self.assertEqual(
+            'http://bumblebee/YnVtYmxlYmVl/api/v3/resource/local'
+            '/51d6317494eccc4a73154625a6820cb6b50dc1455eb4cf26399299d4f9ce77b2/preview',
+            browser.json['items'][-1]['preview_url'][:124],
+        )
 
     @browsing
     def test_file_information(self, browser):

--- a/opengever/api/tests/test_listing.py
+++ b/opengever/api/tests/test_listing.py
@@ -8,8 +8,16 @@ class TestListingEndpoint(IntegrationTestCase):
     @browsing
     def test_dossier_listing(self, browser):
         self.login(self.regular_user, browser=browser)
-
-        view = '@listing?name=dossiers&columns=reference&columns=title&columns=review_state&columns=responsible_fullname&columns=relative_path&sort_on=created'
+        query_string = '&'.join((
+            'name=dossiers',
+            'columns=reference',
+            'columns=title',
+            'columns=review_state',
+            'columns=responsible_fullname',
+            'columns=relative_path',
+            'sort_on=created',
+        ))
+        view = '?'.join(('@listing', query_string))
         browser.open(self.repository_root, view=view, headers={'Accept': 'application/json'})
 
         self.assertEqual(
@@ -24,8 +32,18 @@ class TestListingEndpoint(IntegrationTestCase):
     @browsing
     def test_document_listing(self, browser):
         self.login(self.regular_user, browser=browser)
-
-        view = '@listing?name=documents&columns=reference&columns=title&columns=modified&columns=document_author&columns=containing_dossier&columns=bumblebee_checksum&columns=relative_path&sort_on=created'
+        query_string = '&'.join((
+            'name=documents',
+            'columns=reference',
+            'columns=title',
+            'columns=modified',
+            'columns=document_author',
+            'columns=containing_dossier',
+            'columns=bumblebee_checksum',
+            'columns=relative_path',
+            'sort_on=created',
+        ))
+        view = '?'.join(('@listing', query_string))
         browser.open(self.dossier, view=view, headers={'Accept': 'application/json'})
 
         self.assertEqual(

--- a/opengever/api/tests/test_listing.py
+++ b/opengever/api/tests/test_listing.py
@@ -77,6 +77,22 @@ class TestListingEndpoint(IntegrationTestCase):
         )
 
     @browsing
+    def test_document_listing_pdf_url(self, browser):
+        self.login(self.regular_user, browser)
+        query_string = '&'.join((
+            'name=documents',
+            'columns:list=pdf_url',
+            'sort_on=created',
+        ))
+        view = '?'.join(('@listing', query_string))
+        browser.open(self.dossier, view=view, headers={'Accept': 'application/json'})
+        self.assertEqual(
+            'http://bumblebee/YnVtYmxlYmVl/api/v3/resource/local'
+            '/51d6317494eccc4a73154625a6820cb6b50dc1455eb4cf26399299d4f9ce77b2/pdf',
+            browser.json['items'][-1]['pdf_url'][:120],
+        )
+
+    @browsing
     def test_file_information(self, browser):
         self.login(self.regular_user, browser=browser)
 

--- a/opengever/base/contentlisting.py
+++ b/opengever/base/contentlisting.py
@@ -101,6 +101,14 @@ class OpengeverCatalogContentListingObject(CatalogContentListingObject):
         return bumblebee.get_service_v3().get_representation_url(
             self.getDataOrigin(), 'thumbnail')
 
+    def get_preview_frame_url(self):
+        """Return the url to fetch the bumblebee preview HTML frame."""
+        if not self.is_bumblebeeable():
+            return None
+
+        return bumblebee.get_service_v3().get_representation_url(
+            self.getDataOrigin(), 'preview')
+
     def get_preview_pdf_url(self):
         """Return the url to fetch the bumblebee preview pdf."""
         if not self.is_bumblebeeable():

--- a/opengever/base/tests/test_contentlisting.py
+++ b/opengever/base/tests/test_contentlisting.py
@@ -288,6 +288,9 @@ class TestOpengeverContentListingWithDisabledBumblebee(IntegrationTestCase):
     def test_get_preview_image_url(self):
         self.assertIsNone(self.obj.get_preview_image_url())
 
+    def test_get_preview_frame_url(self):
+        self.assertIsNone(self.obj.get_preview_frame_url())
+
     def test_get_preview_pdf_url(self):
         self.assertIsNone(self.obj.get_preview_pdf_url())
 
@@ -317,6 +320,9 @@ class TestOpengeverContentListingWithEnabledBumblebee(IntegrationTestCase):
 
     def test_get_preview_image_url(self):
         self.assertIsNotNone(self.obj.get_preview_image_url())
+
+    def test_get_preview_frame_url(self):
+        self.assertRegexpMatches(self.obj.get_preview_frame_url(), r'/preview\?')
 
     def test_get_preview_pdf_url(self):
         self.assertRegexpMatches(self.obj.get_preview_pdf_url(), r'/pdf\?')


### PR DESCRIPTION
* Added the Bumblebee PDF URL to the document API GET endpoint
* Unified the listing GET endpoint vs. the document GET endpoint

I'm not quite up to documenting the document and listing endpoints at this point. These commits can also be dropped, if the placeholders are undesired.

//cc @jone @sebastianmanger 

Closes #5391