### PR TITLE
Add sharing white and black list prefix to config endpoint/view.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -15,6 +15,7 @@ Changelog
 - Make reject to skip transition only available for tasks part of a sequence. [phgross]
 - Adapt footer to new 4teamwork website. [njohner]
 - Extend @listing endpoint with `workspaces`-listing. [elioschmutz]
+- Add sharing white and black list prefix to config endpoint/view. [njohner]
 - Move personal bar customization into opengever.base. [njohner]
 - Unify Bumblebee URLs on REST API for document vs. document on a listing. [Rotonen]
 - Make sure all workflow IDs are unique. [njohner]

--- a/docs/public/dev-manual/api/config.rst
+++ b/docs/public/dev-manual/api/config.rst
@@ -54,7 +54,11 @@ GEVER-Mandanten abgefragt werden.
           "max_repositoryfolder_levels": 3,
           "recently_touched_limit": 10,
           "root_url": "http://localhost:8080/fd",
-          "version": "2018.4.0.dev0"
+          "sharing_configuration": {
+              "black_list_prefix": "^$",
+              "white_list_prefix": "^.+"
+          }
+          "version": "2018.4.0.dev0",
       }
 
 
@@ -120,3 +124,11 @@ features
 
     workspace
         Arbeitsräume
+
+sharing_configuration
+
+    white_list_prefix
+        regex Muster für Gruppen die in der Freigabe angezeigt werden sollen
+
+    black_list_prefix
+        regex Muster für Gruppen die in der Freigabe nicht angezeigt werden sollen

--- a/opengever/api/tests/test_config.py
+++ b/opengever/api/tests/test_config.py
@@ -120,3 +120,14 @@ class TestConfig(IntegrationTestCase):
         }
         oneoffixx_settings = browser.json.get('oneoffixx_settings')
         self.assertEqual(expected_oneoffixx_settings, oneoffixx_settings)
+
+    @browsing
+    def test_config_contains_sharing_configuration_white_and_black_lists(self, browser):
+        self.login(self.regular_user, browser)
+        browser.open(self.portal.absolute_url() + '/@config',
+                     headers={'Accept': 'application/json'})
+        self.assertEqual(browser.status_code, 200)
+
+        browser.json.get(u'sharing_configuration')
+        self.assertEqual(browser.json.get(u'sharing_configuration'),
+                         {u'white_list_prefix': '^.+', u'black_list_prefix': '^$'})

--- a/opengever/base/configuration.py
+++ b/opengever/base/configuration.py
@@ -20,6 +20,7 @@ from opengever.officeatwork.interfaces import IOfficeatworkSettings
 from opengever.officeconnector.interfaces import IOfficeConnectorSettings
 from opengever.oneoffixx.interfaces import IOneoffixxSettings
 from opengever.repository.interfaces import IRepositoryFolderRecords
+from opengever.sharing.interfaces import ISharingConfiguration
 from opengever.task.interfaces import ITaskSettings
 from opengever.workspace.interfaces import IWorkspaceSettings
 from pkg_resources import get_distribution
@@ -60,7 +61,14 @@ class GeverSettingsAdpaterV1(object):
         settings['max_repositoryfolder_levels'] = api.portal.get_registry_record('maximum_repository_depth', interface=IRepositoryFolderRecords)  # noqa
         settings['recently_touched_limit'] = api.portal.get_registry_record('limit', interface=IRecentlyTouchedSettings)  # noqa
         settings['oneoffixx_settings'] = self.get_oneoffixx_settings()
+        settings['sharing_configuration'] = self.get_sharing_configuration()
         return settings
+
+    def get_sharing_configuration(self):
+        sharing_configuration = OrderedDict()
+        sharing_configuration['white_list_prefix'] = api.portal.get_registry_record('white_list_prefix', interface=ISharingConfiguration)  # noqa
+        sharing_configuration['black_list_prefix'] = api.portal.get_registry_record('black_list_prefix', interface=ISharingConfiguration)  # noqa
+        return sharing_configuration
 
     def get_oneoffixx_settings(self):
         oneoffixx_settings = OrderedDict()

--- a/opengever/base/tests/test_configuration_adapter.py
+++ b/opengever/base/tests/test_configuration_adapter.py
@@ -5,6 +5,7 @@ from pkg_resources import get_distribution
 
 
 class TestConfigurationAdapter(IntegrationTestCase):
+
     def test_configuration(self):
         expected_configuration = OrderedDict([
             ('@id', 'http://nohost/plone/@config'),
@@ -18,6 +19,10 @@ class TestConfigurationAdapter(IntegrationTestCase):
                 ('double_encode_bug', True),
                 ('cache_timeout', 2592000),
             ])),
+            ('sharing_configuration', OrderedDict([
+                ('white_list_prefix', u'^.+'),
+                ('black_list_prefix', u'^$'),
+                ])),
             ('features', OrderedDict([
                 ('activity', False),
                 ('archival_file_conversion', False),

--- a/opengever/sharing/interfaces.py
+++ b/opengever/sharing/interfaces.py
@@ -29,13 +29,13 @@ class ISharingConfiguration(Interface):
 
     white_list_prefix = schema.TextLine(
         title=u'white list prefix',
-        description=u'The prrefix pattern, for groups wich should displayed'
-        'in the sharing view, equal the black list prefix would also match.',
+        description=u'The prefix pattern for groups which should be displayed'
+        'in the sharing view, even if the black list prefix also matches.',
         default=u"^.+")
 
     black_list_prefix = schema.TextLine(
         title=u'black list prefix',
-        description=u"The prrefix pattern, for groups wich shouldn't be "
+        description=u"The prefix pattern for groups which shouldn't be "
         "displayed in the sharing view. For example another client group.",
         default=u"^$")
 


### PR DESCRIPTION
We add the `black_list_prefix` and `white_list_prefix` from `ISharingConfiguration` to the config endpoint.

I wonder whether we should group them under `sharing_config` or something like that? Just the names as they are now are not very explicit.

<img width="1310" alt="screen shot 2019-02-28 at 15 13 25" src="https://user-images.githubusercontent.com/7374243/53573018-e9692680-3b6c-11e9-8156-e97904f7e825.png">


resolves #5423 