### PR TITLE
Readd Office macro files into Office Connector editable MIME types

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2019.2.0 (unreleased)
 ---------------------
 
+- Readd Office macro files into Office Connector editable MIME types. [Rotonen]
 - Move personal bar customization into opengever.base. [njohner]
 - Unify Bumblebee URLs on REST API for document vs. document on a listing. [Rotonen]
 - Make sure all workflow IDs are unique. [njohner]

--- a/opengever/officeconnector/mimetypes.py
+++ b/opengever/officeconnector/mimetypes.py
@@ -24,11 +24,13 @@ EDITABLE_TYPES = [
     # Mindjet Mind Manager
     'application/vnd.mindjet.mindmanager',
     # MS Excel
+    'application/vnd.ms-excel.sheet.macroEnabled.12',
     'application/vnd.ms-excel',
     'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
     # MS OneNote
     'application/onenote',
     # MS Powerpoint
+    'application/vnd.ms-powerpoint.presentation.macroEnabled.12',
     'application/vnd.ms-powerpoint',
     'application/vnd.openxmlformats-officedocument.presentationml.presentation',
     'application/vnd.openxmlformats-officedocument.presentationml.slideshow',
@@ -42,6 +44,7 @@ EDITABLE_TYPES = [
     'application/vnd.ms-visio.drawing',
     # MS Word
     'application/msword',
+    'application/vnd.ms-word.document.macroEnabled.12',
     'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
     # PDF editors - Adobe Acrobat or Nitro PDF
     'application/pdf',


### PR DESCRIPTION
Despite macro files being known problematic, a source of support tickets and something we cannot guarantee to work, they are still widely used by end users.

In hindsight I should have tried to consult the content stats for the MIME type.

Closes https://github.com/4teamwork/opengever.core/issues/5447