### PR TITLE
Readd Office template, macro, stencil files into Office Connector editable MIME types

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2019.2.0 (unreleased)
 ---------------------
 
+- Readd Office template files into Office Connector editable MIME types. [Rotonen]
 - Readd Office macro files into Office Connector editable MIME types. [Rotonen]
 - Complete French translations of repository in examplecontent. [andresoberhaensli]
 - Adapt footer to new 4teamwork website. [njohner]

--- a/opengever/document/extra_mimetypes.py
+++ b/opengever/document/extra_mimetypes.py
@@ -141,7 +141,7 @@ ADDITIONAL_TYPES = [
     ('application/vnd.ms-powerpoint.presentation.macroEnabled.12', '.pptm'),
 
     # MS Powerpoint Template (Macro Enabled)
-    ('application/vnd.ms-powerpoint.presentation.macroEnabled.12', '.potm'),
+    ('application/vnd.ms-powerpoint.template.macroEnabled.12', '.potm'),
 
     # MS Powerpoint Slideshow (Macro Enabled)
     ('application/vnd.ms-powerpoint.slideshow.macroEnabled.12', '.ppsm'),

--- a/opengever/officeconnector/mimetypes.py
+++ b/opengever/officeconnector/mimetypes.py
@@ -24,28 +24,43 @@ EDITABLE_TYPES = [
     # Mindjet Mind Manager
     'application/vnd.mindjet.mindmanager',
     # MS Excel
+    'application/vnd.ms-excel.addin.macroEnabled.12',
+    'application/vnd.ms-excel.sheet.binary.macroEnabled.12',
     'application/vnd.ms-excel.sheet.macroEnabled.12',
+    'application/vnd.ms-excel.template.macroEnabled.12',
     'application/vnd.ms-excel',
     'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    'application/vnd.openxmlformats-officedocument.spreadsheetml.template',
     # MS OneNote
     'application/onenote',
     # MS Powerpoint
+    'application/vnd.ms-powerpoint.addin.macroEnabled.12',
     'application/vnd.ms-powerpoint.presentation.macroEnabled.12',
+    'application/vnd.ms-powerpoint.slideshow.macroEnabled.12',
+    'application/vnd.ms-powerpoint.template.macroEnabled.12',
     'application/vnd.ms-powerpoint',
     'application/vnd.openxmlformats-officedocument.presentationml.presentation',
     'application/vnd.openxmlformats-officedocument.presentationml.slideshow',
+    'application/vnd.openxmlformats-officedocument.presentationml.template',
     # MS Project
     'application/vnd.ms-project',
     'application/x-project',
     # MS Publisher
     'application/x-mspublisher',
     # MS Visio
-    'application/vnd.visio',
+    'application/vnd.ms-visio.drawing.macroEnabled.12',
     'application/vnd.ms-visio.drawing',
+    'application/vnd.ms-visio.stencil.macroEnabled.12',
+    'application/vnd.ms-visio.stencil',
+    'application/vnd.ms-visio.template.macroEnabled.12',
+    'application/vnd.ms-visio.template',
+    'application/vnd.visio',
     # MS Word
     'application/msword',
     'application/vnd.ms-word.document.macroEnabled.12',
+    'application/vnd.ms-word.template.macroEnabled.12',
     'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+    'application/vnd.openxmlformats-officedocument.wordprocessingml.template',
     # PDF editors - Adobe Acrobat or Nitro PDF
     'application/pdf',
     'application/postscript',


### PR DESCRIPTION
We're readding Office Connector editability for Office template formats, as they work on Windows.

Closes https://github.com/4teamwork/opengever.core/issues/5453