### PR TITLE
Add support for filters in listing endpoint

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -17,6 +17,7 @@ Changelog
 - Unify Bumblebee URLs on REST API for document vs. document on a listing. [Rotonen]
 - Make sure all workflow IDs are unique. [njohner]
 - Add button to create protocol approval proposal from meeting. [njohner]
+- Add support for filters in listing endpoint. [buchi]
 
 
 2019.1.2 (2019-03-07)


### PR DESCRIPTION
Filters can be passed with the `filters` record query parameter.

Example:
`/@listing?name=dossiers&filters.review_state:record:list=dossier-state-active&filters.review_state:record:list=dossier-state-archived&filters.responsible:record=hugo.boss`
