### PR TITLE
Make reject to skip transition only available for tasks part of a sequence.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -8,6 +8,7 @@ Changelog
 - Fix performance issue with search root exclusion in tabbed view listings. [lgraf]
 - Do not list resolved tasks as pending in the 'My Tasks' tab. [Rotonen]
 - Make attachments for `direct-execution` tasks editable by the responsible. [phgross]
+- Make reject to skip transition only available for tasks part of a sequence. [phgross]
 - Readd Office macro files into Office Connector editable MIME types. [Rotonen]
 - Complete French translations of repository in examplecontent. [andresoberhaensli]
 - Adapt footer to new 4teamwork website. [njohner]

--- a/opengever/task/browser/transitioncontroller.py
+++ b/opengever/task/browser/transitioncontroller.py
@@ -443,7 +443,11 @@ class TaskTransitionController(BrowserView):
     @guard('task-transition-rejected-skipped')
     def rejected_to_skipped_guard(self, c, include_agency):
         """Checks if:
-        - The current user is the issuer of the task"""
+        - The current user is the issuer of the task
+        - The task is part of a task process
+        """
+        if not self.context.is_from_sequential_tasktemplate:
+            return False
 
         if include_agency:
             return c.current_user.is_issuer or c.current_user.is_administrator
@@ -458,6 +462,9 @@ class TaskTransitionController(BrowserView):
     def planned_to_skipped_guard(self, c, include_agency):
         """Checks if:
         - The current user is the issuer of the task"""
+
+        # The check that the task is part of a task sequence is unnecessary,
+        # because only tasks from a sequene can be in the planned state.
 
         if include_agency:
             return c.current_user.is_issuer or c.current_user.is_administrator

--- a/opengever/task/tests/test_activities.py
+++ b/opengever/task/tests/test_activities.py
@@ -14,11 +14,14 @@ from opengever.core.testing import OPENGEVER_FUNCTIONAL_ACTIVITY_LAYER
 from opengever.ogds.base.actor import SYSTEM_ACTOR_ID
 from opengever.task.activities import TaskReminderActivity
 from opengever.task.browser.accept.utils import accept_task_with_successor
+from opengever.tasktemplates.interfaces import IFromSequentialTasktemplate
 from opengever.testing import FunctionalTestCase
 from opengever.testing import IntegrationTestCase
 from plone.app.testing import TEST_USER_ID
 from sqlalchemy import desc
+from zope.interface import alsoProvides
 import email
+import transaction
 
 
 class TestTaskActivites(FunctionalTestCase):
@@ -185,6 +188,9 @@ class TestTaskActivites(FunctionalTestCase):
                       .titled(u'Abkl\xe4rung Fall Meier')
                       .having(responsible=TEST_USER_ID)
                       .in_state('task-state-rejected'))
+
+        alsoProvides(task, IFromSequentialTasktemplate)
+        transaction.commit()
 
         browser.login().open(task)
         browser.css('#workflow-transition-task-transition-rejected-skipped').first.click()

--- a/opengever/task/tests/test_transition_actions.py
+++ b/opengever/task/tests/test_transition_actions.py
@@ -92,14 +92,14 @@ class TestTaskTransitionActionsForRejected(BaseTransitionActionIntegrationTest):
     def setUp(self):
         super(TestTaskTransitionActionsForRejected, self).setUp()
         with self.login(self.regular_user):
-            self.set_workflow_state('task-state-rejected', self.task)
+            self.set_workflow_state('task-state-rejected', self.seq_subtask_1)
 
     @browsing
     def test_skip_task(self, browser):
-        self.login(self.dossier_responsible, browser)
-        self.do_transition(browser, self.task, 'task-transition-rejected-skipped')
+        self.login(self.secretariat_user, browser)
+        self.do_transition(browser, self.seq_subtask_1, 'task-transition-rejected-skipped')
         expected_transition_action = 'addresponse?form.widgets.transition=task-transition-rejected-skipped'
-        self.assert_action(browser, '/'.join((self.task.absolute_url(), expected_transition_action, )))
+        self.assert_action(browser, '/'.join((self.seq_subtask_1.absolute_url(), expected_transition_action, )))
 
 
 class TestTaskTransitionActionsForSkipped(BaseTransitionActionIntegrationTest):

--- a/opengever/task/tests/test_transitioncontroller.py
+++ b/opengever/task/tests/test_transitioncontroller.py
@@ -260,6 +260,35 @@ class TestInProgressResolvedGuard(BaseTransitionGuardTests):
             self.transition, True, checker))
 
 
+class TestSkipRejectedGuard(IntegrationTestCase):
+    transition = 'task-transition-rejected-skipped'
+
+    def test_available_when_user_is_issuer_or_admin(self):
+        self.login(self.regular_user)
+        self.set_workflow_state('task-state-rejected', self.seq_subtask_1)
+
+        # not issuer
+        self.assertNotIn(
+            self.transition, self.get_workflow_transitions_for(self.seq_subtask_1))
+
+        # issuer
+        self.login(self.secretariat_user)
+        self.assertIn(
+            self.transition, self.get_workflow_transitions_for(self.seq_subtask_1))
+
+        # administrator
+        self.login(self.administrator)
+        self.assertIn(
+            self.transition, self.get_workflow_transitions_for(self.seq_subtask_1))
+
+    def test_not_available_when_task_is_not_part_of_a_task_sequence(self):
+        self.login(self.dossier_responsible)
+        self.set_workflow_state('task-state-rejected', self.task)
+
+        self.assertNotIn(
+            self.transition, self.get_workflow_transitions_for(self.task))
+
+
 class TestInProgressClosed(BaseTransitionGuardTests):
 
     transition = 'task-transition-in-progress-tested-and-closed'


### PR DESCRIPTION
The skip transitions should only be available for tasks generated from a tasktemplate.

Note: A special protection for the planned to skipped transition is not necessary, because only tasks part of a task sequence can be in the planned state.

Closes #5438