### PR TITLE
Adapt footer to new 4teamwork website.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,7 @@ Changelog
 
 - Readd Office macro files into Office Connector editable MIME types. [Rotonen]
 - Complete French translations of repository in examplecontent. [andresoberhaensli]
+- Adapt footer to new 4teamwork website. [njohner]
 - Move personal bar customization into opengever.base. [njohner]
 - Unify Bumblebee URLs on REST API for document vs. document on a listing. [Rotonen]
 - Make sure all workflow IDs are unique. [njohner]

--- a/opengever/base/viewlets/footer.pt
+++ b/opengever/base/viewlets/footer.pt
@@ -1,9 +1,9 @@
 <div id="ftw-footer" class="row">
     <div id="footer-column-1" class="column cell position-0 width-4">
         <h2>OneGov GEVER</h2>
-        <p><a href="https://onegovgever.ch">Über OneGov GEVER</a></p>
+        <p><a href="https://www.4teamwork.ch/loesungen/onegov-gever/">Über OneGov GEVER</a></p>
         <p><a href="https://github.com/4teamwork/opengever.core">Quellcode</a></p>
-        <p><a href="https://onegovgever.ch/aktuell">Release-Informationen</a></p>
+        <p><a href="https://docs.onegovgever.ch/release-notes/">Release-Informationen</a></p>
         <p>Version: <span tal:content="view/get_gever_version" /></p>
     </div>
 


### PR DESCRIPTION
While working on https://github.com/4teamwork/opengever.core/issues/5187, I realized the footer in GEVER is also outdated. It now points to our new 4teamwork website.