### PR TITLE
Make attachments for `direct-execution` tasks editable by the responsible.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,9 @@ Changelog
 
 - Fix performance issue with search root exclusion in tabbed view listings. [lgraf]
 - Do not list resolved tasks as pending in the 'My Tasks' tab. [Rotonen]
+- Make attachments for `direct-execution` tasks editable by the responsible. [phgross]
+- Readd Office macro files into Office Connector editable MIME types. [Rotonen]
+- Complete French translations of repository in examplecontent. [andresoberhaensli]
 - Adapt footer to new 4teamwork website. [njohner]
 - Move personal bar customization into opengever.base. [njohner]
 - Unify Bumblebee URLs on REST API for document vs. document on a listing. [Rotonen]

--- a/docs/public/user-manual/aufgaben/aufgaben-workflow.rst
+++ b/docs/public/user-manual/aufgaben/aufgaben-workflow.rst
@@ -66,7 +66,7 @@ Auftragstyp               Auftragnehmende
 ======================== =================
 Zur Kenntnisnahme         zu lesen
 
-Zur direkten Erledigung   zu lesen
+Zur direkten Erledigung   zu überarbeiten
 
 Zum Bericht/Antrag        zu überarbeiten
 

--- a/opengever/task/localroles.py
+++ b/opengever/task/localroles.py
@@ -145,7 +145,8 @@ class LocalRolesSetter(object):
     def set_roles_on_related_items(self):
         """Set local roles on related items (usually documents)."""
         roles = ['Reader']
-        if self.task.task_type_category == 'bidirectional_by_reference':
+        if self.task.task_type_category in [
+                'bidirectional_by_reference', 'unidirectional_by_value']:
             roles.append('Editor')
 
         for item in getattr(aq_base(self.task), 'relatedItems', []):


### PR DESCRIPTION
Closes #5463.