### PR TITLE
Use SOLR for listings even without SearchableText in the query

### DIFF
--- a/opengever/tabbedview/catalog_source.py
+++ b/opengever/tabbedview/catalog_source.py
@@ -54,6 +54,10 @@ class GeverCatalogTableSource(FilteredTableSourceMixin, CatalogTableSource):
         for key, value in query.items():
             if key == 'SearchableText':
                 continue
+            if key == 'Subject':
+                operator = value['operator'].upper()
+                termlist = operator.join(escape(term) for term in value['query'])
+                filters.append(u'Subject:({})'.format(termlist))
             elif key == 'sort_on' or key == 'sort_order':
                 continue
             elif key == 'path':

--- a/opengever/tabbedview/tests/test_catalog_source.py
+++ b/opengever/tabbedview/tests/test_catalog_source.py
@@ -104,9 +104,9 @@ class TestSolrSearch(IntegrationTestCase):
         self.source.search_results({'SearchableText': 'foo'})
         self.assertFalse(self.solr.search.called)
 
-    def test_solr_is_not_used_if_no_searchable_text(self):
+    def test_solr_is_used_if_enabled_and_no_searchable_text(self):
         registry = getUtility(IRegistry)
         settings = registry.forInterface(ISearchSettings)
         settings.use_solr = True
         self.source.search_results({})
-        self.assertFalse(self.solr.search.called)
+        self.assertTrue(self.solr.search.called)

--- a/opengever/tabbedview/tests/test_dossier_listing.py
+++ b/opengever/tabbedview/tests/test_dossier_listing.py
@@ -266,11 +266,56 @@ class TestDossierListing(IntegrationTestCase):
     def test_filter_dossiers_by_subjects(self, browser):
         self.activate_feature('solr')
         self.login(self.regular_user, browser=browser)
-
-        self.mock_solr(response_json=self.solr_response('Wichtig'))
+        docs = [
+            {  # self.offered_dossier_to_archive
+                u'Subject': [u'Wichtig'],
+                u'Title': u'Hannah Baufrau',
+                u'UID': u'createoffereddossiers00000000001',
+                u'getIcon': u'',
+                u'id': u'dossier-16',
+                u'modified': u'2016-08-31T21:01:33+02:00',
+                u'path': u'/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-16',
+                u'portal_type': u'opengever.dossier.businesscasedossier',
+                u'reference': u'Client1 1.1 / 11',
+                u'responsible': u'robert.ziegler',
+                u'review_state': u'dossier-state-offered',
+                u'start': u'2019-03-07T00:00:00Z',
+            },
+            {  # self.dossier
+                u'Title': u'Vertr\xe4ge mit der kantonalen Finanzverwaltung',
+                u'UID': u'createtreatydossiers000000000001',
+                u'getIcon': u'',
+                u'id': u'dossier-1',
+                u'modified': u'2016-08-31T20:05:33+02:00',
+                u'path': u'/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1',
+                u'portal_type': u'opengever.dossier.businesscasedossier',
+                u'reference': u'Client1 1.1 / 1',
+                u'responsible': u'robert.ziegler',
+                u'review_state': u'dossier-state-active',
+                u'start': u'2019-03-07T00:00:00Z',
+            },
+        ]
+        self.mock_solr(response_json=self.solr_response('Wichtig'), docs_json=docs)
 
         self.open_repo_with_filter(browser, self.leaf_repofolder, 'filter_all')
         self.assertLess(1, len(browser.css('.listing tbody tr')))
+
+        # XXX - what do we actually manage to *test* here?
+        docs = [{  # self.offered_dossier_to_archive
+            u'Subject': [u'Wichtig'],
+            u'Title': u'Hannah Baufrau',
+            u'UID': u'createoffereddossiers00000000001',
+            u'getIcon': u'',
+            u'id': u'dossier-16',
+            u'modified': u'2016-08-31T21:01:33+02:00',
+            u'path': u'/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-16',
+            u'portal_type': u'opengever.dossier.businesscasedossier',
+            u'reference': u'Client1 1.1 / 11',
+            u'responsible': u'robert.ziegler',
+            u'review_state': u'dossier-state-offered',
+            u'start': u'2019-03-07T00:00:00Z',
+        }]
+        self.mock_solr(response_json=self.solr_response('Wichtig'), docs_json=docs)
 
         self.open_repo_with_filter(
             browser, self.leaf_repofolder, 'filter_all', ['Wichtig'])

--- a/opengever/testing/integration_test_case.py
+++ b/opengever/testing/integration_test_case.py
@@ -649,8 +649,9 @@ class IntegrationTestCase(TestCase):
             'paths:list': ['/'.join(obj.getPhysicalPath()) for obj in objects]}
 
     @mutually_exclusive_parameters('response_file', 'response_json')
+    @mutually_exclusive_parameters('docs_file', 'docs_json')
     @at_least_one_of('response_file', 'response_json')
-    def mock_solr(self, response_file=None, response_json=None):
+    def mock_solr(self, response_file=None, response_json=None, docs_file=None, docs_json=None):
         conn = MagicMock(name='SolrConnection')
         schema_resp = assets.load('solr_schema.json')
         conn.get = MagicMock(name='get', return_value=SolrResponse(
@@ -666,6 +667,14 @@ class IntegrationTestCase(TestCase):
             search_resp = json.dumps(response_json)
         solr.search = MagicMock(name='search', return_value=SolrResponse(
             body=search_resp, status=200))
+
+        if docs_file or docs_json:
+            if docs_file:
+                docs = json.loads(assets.load(docs_file))
+            elif docs_json:
+                docs = docs_json
+            solr.search().docs = docs
+
         return solr
 
     def add_additional_org_unit(self):


### PR DESCRIPTION
* We now default to using a wildcard `*:*` in the lack of `SearchableText`
* This surfaced our SOLR mocking does not ever return documents
  * Added support for mocking found SOLR documents in SOLR responses
* This surfaced our dossier keyword filters do not work with SOLR
  * Added support for the `Subject` field catalog table source when using SOLR

Closes #5442 