### PR TITLE
Add a file extension column to document listings

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -36,6 +36,7 @@ Changelog
 2019.1.2 (2019-03-07)
 ---------------------
 
+- Add a file extension column to document listings. [Rotonen]
 - Make sure task and journal PDFs object_provides index is up to date after resolving a dossier. [njohner]
 - Readd Office template files into Office Connector editable MIME types. [Rotonen]
 - Make sure end date is reindexed when resolving/reactivating a dossier. [njohner]

--- a/opengever/dossier/tests/test_templatefolder.py
+++ b/opengever/dossier/tests/test_templatefolder.py
@@ -795,6 +795,7 @@ class TestTemplateFolderListings(IntegrationTestCase):
             'Checked out by',
             'Public Trial',
             'Reference Number',
+            'File extension',
             ]
 
         self.assertEquals(expected_table_header, browser.css('table.listing').first.lists()[0])
@@ -815,6 +816,7 @@ class TestTemplateFolderListings(IntegrationTestCase):
             'Checked out by',
             'Public Trial',
             'Reference Number',
+            'File extension',
             ]
 
         self.assertEquals(expected_table_header, browser.css('table.listing').first.lists()[0])
@@ -835,6 +837,7 @@ class TestTemplateFolderListings(IntegrationTestCase):
             'Checked out by',
             'Public Trial',
             'Reference Number',
+            'File extension',
             ]
 
         self.assertEquals(expected_table_header, browser.css('table.listing').first.lists()[0])

--- a/opengever/inbox/tests/test_tabs.py
+++ b/opengever/inbox/tests/test_tabs.py
@@ -19,7 +19,7 @@ class TestInboxTabbedview(IntegrationTestCase):
             ['', 'Sequence Number', 'Title', 'Document Author',
              'Document Date', 'Modification Date', 'Creation Date',
              'Receipt Date', 'Delivery Date', 'Public Trial',
-             'Reference Number'],
+             'Reference Number', 'File extension'],
             browser.css('.listing th').text)
 
     @browsing
@@ -31,7 +31,8 @@ class TestInboxTabbedview(IntegrationTestCase):
         self.assertEquals(
             ['', 'Sequence Number', 'Title', 'Document Author',
              'Document Date', 'Modification Date', 'Creation Date',
-             'Receipt Date', 'Delivery Date', 'Public Trial'],
+             'Receipt Date', 'Delivery Date', 'Public Trial',
+             'File extension'],
             browser.css('.listing th').text)
 
     @browsing

--- a/opengever/repository/tests/test_repositoryfolder_tabs.py
+++ b/opengever/repository/tests/test_repositoryfolder_tabs.py
@@ -109,6 +109,7 @@ class TestRepositoryFolderDocumentsTab(IntegrationTestCase):
             'Document Author': 'test_user_1_',
             'Document Date': '03.01.2010',
             'Dossier': u'Vertr\xe4ge mit der kantonalen Finanzverwaltung',
+            'File extension': '.docx',
             'Modification Date': '31.08.2016',
             'Public Trial': 'unchecked',
             'Receipt Date': '03.01.2010',

--- a/opengever/tabbedview/browser/tabs.py
+++ b/opengever/tabbedview/browser/tabs.py
@@ -187,6 +187,10 @@ class Documents(BaseCatalogListingTab):
         {'column': 'reference',
          'column_title': _(u'label_document_reference',
                            default=u'Reference Number')},
+
+        {'column': 'file_extension',
+         'column_title': _(u'label_document_file_extension',
+                           default=u'File extension')},
         )
 
     major_actions = [

--- a/opengever/tabbedview/locales/de/LC_MESSAGES/opengever.tabbedview.po
+++ b/opengever/tabbedview/locales/de/LC_MESSAGES/opengever.tabbedview.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2019-01-31 09:17+0000\n"
+"POT-Creation-Date: 2019-03-07 18:16+0000\n"
 "PO-Revision-Date: 2012-11-22 14:19+0100\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -230,6 +230,11 @@ msgstr "Autor"
 #: ./opengever/tabbedview/browser/tabs.py
 msgid "label_document_date"
 msgstr "Dokumentdatum"
+
+#. Default: "File extension"
+#: ./opengever/tabbedview/browser/tabs.py
+msgid "label_document_file_extension"
+msgstr "Dateiendung"
 
 #. Default: "Reference Number"
 #: ./opengever/tabbedview/browser/tabs.py

--- a/opengever/tabbedview/locales/fr/LC_MESSAGES/opengever.tabbedview.po
+++ b/opengever/tabbedview/locales/fr/LC_MESSAGES/opengever.tabbedview.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-01-31 09:17+0000\n"
+"POT-Creation-Date: 2019-03-07 18:16+0000\n"
 "PO-Revision-Date: 2017-12-03 09:48+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-tabbedview/fr/>\n"
@@ -224,6 +224,11 @@ msgstr "Auteur"
 #: ./opengever/tabbedview/browser/tabs.py
 msgid "label_document_date"
 msgstr "Date du document"
+
+#. Default: "File extension"
+#: ./opengever/tabbedview/browser/tabs.py
+msgid "label_document_file_extension"
+msgstr "Extension"
 
 #. Default: "Reference Number"
 #: ./opengever/tabbedview/browser/tabs.py

--- a/opengever/tabbedview/locales/opengever.tabbedview.pot
+++ b/opengever/tabbedview/locales/opengever.tabbedview.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2019-01-31 09:17+0000\n"
+"POT-Creation-Date: 2019-03-07 18:16+0000\n"
 "PO-Revision-Date: 2009-02-25 14:39+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -222,6 +222,11 @@ msgstr ""
 #. Default: "Document Date"
 #: ./opengever/tabbedview/browser/tabs.py
 msgid "label_document_date"
+msgstr ""
+
+#. Default: "File extension"
+#: ./opengever/tabbedview/browser/tabs.py
+msgid "label_document_file_extension"
 msgstr ""
 
 #. Default: "Reference Number"

--- a/opengever/tabbedview/tests/test_document_listing.py
+++ b/opengever/tabbedview/tests/test_document_listing.py
@@ -17,6 +17,7 @@ class TestDocumentListing(IntegrationTestCase):
             'Delivery Date': '03.01.2010',
             'Document Author': 'test_user_1_',
             'Document Date': '03.01.2010',
+            'File extension': '.docx',
             'Public Trial': 'unchecked',
             'Receipt Date': '03.01.2010',
             'Reference Number': 'Client1 1.1 / 1 / 12',
@@ -28,5 +29,4 @@ class TestDocumentListing(IntegrationTestCase):
             }
 
         listings = browser.css('.listing').first.dicts()
-
         self.assertIn(expected_metadata, listings)


### PR DESCRIPTION
Added the column to the base Document tab, added translations and amended the tests.

Closes #5478 