### PR TITLE
Standardize french and german translation of "attachments" in meetings.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,11 +7,10 @@ Changelog
 
 - Fix performance issue with search root exclusion in tabbed view listings. [lgraf]
 - Do not list auto-generated documents as recently touched. [njohner]
+- Standardize french and german translation of "attachments" in meetings. [njohner]
 - Do not list resolved tasks as pending in the 'My Tasks' tab. [Rotonen]
 - Make attachments for `direct-execution` tasks editable by the responsible. [phgross]
 - Make reject to skip transition only available for tasks part of a sequence. [phgross]
-- Readd Office macro files into Office Connector editable MIME types. [Rotonen]
-- Complete French translations of repository in examplecontent. [andresoberhaensli]
 - Adapt footer to new 4teamwork website. [njohner]
 - Move personal bar customization into opengever.base. [njohner]
 - Unify Bumblebee URLs on REST API for document vs. document on a listing. [Rotonen]

--- a/docs/public/admin-manual/meeting/mergefields.rst
+++ b/docs/public/admin-manual/meeting/mergefields.rst
@@ -163,11 +163,11 @@ Metadaten zu einem Traktandum (AgendaItem):
 
 - ``attachments``
 
-  Liste von Anhängen des Antrags (Liste von Attachment).
+  Liste von Beilagen des Antrags (Liste von Attachments).
 
 
-Metadaten zu einem Anhang eines Antrags (Attachment):
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Metadaten zu einer Beilage eines Antrags (Attachment):
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 - ``title``
 

--- a/docs/public/release-notes/archiv/release-3.10.rst
+++ b/docs/public/release-notes/archiv/release-3.10.rst
@@ -66,7 +66,7 @@ Zudem wurden folgende weiteren kleineren Anpassungen für diesen Release umgeset
 - Verbesserung beim Schreiben von DocProperties, diese können neu DocProperties
   eines falschen Typs überschreiben.
 
-- Die Dateinamen der Anhänge eines Antrags stehen neu beim Erstellen der Protokolle zur Verfügung.
+- Die Dateinamen der Beilagen eines Antrags stehen neu beim Erstellen der Protokolle zur Verfügung.
 
 - Die Dokumentauflistung eines Dossiers oder Subdossiers kann neu als Excel-Report exportiert werden.
 

--- a/docs/public/release-notes/release-2017.1.rst
+++ b/docs/public/release-notes/release-2017.1.rst
@@ -101,7 +101,7 @@ Sitzungs- und Protokollverwaltung
 
 Alle Unterlagen zu einer Sitzung können neu als Zip-Datei heruntergeladen werden.
 Die Zip-Datei beinhaltet neben der Traktandenliste das Vorprotokoll sowie
-sämtliche Anhänge zu den Traktanden. Dies erleichtert die Sitzungsvorbereitung,
+sämtliche Beilagen zu den Traktanden. Dies erleichtert die Sitzungsvorbereitung,
 da alle Sitzungsunterlagen als Zip-Datei an die Teilnehmenden verteilt werden können.
 
 Office Connector

--- a/docs/public/release-notes/release-2018.1.rst
+++ b/docs/public/release-notes/release-2018.1.rst
@@ -87,7 +87,7 @@ Sitzungs- und Protokollverwaltung
 
 - Mitgliedschaften werden neu nach Nachnamen sortiert
 
-- Anhänge für Antrage werden neu alphabetisch sortiert
+- Beilagen für Anträge werden neu alphabetisch sortiert
 
 - Bei den `Sablon-Vorlagen <https://docs.onegovgever.ch/admin-manual/meeting/mergefields/>`_ kann neu Vor- und Nachname separat ausgewiesen werden.
   Natürlich bleibt die Möglichkeit beide zusammen zu nehmen (fullname) noch bestehen.

--- a/docs/public/release-notes/release-2018.2.rst
+++ b/docs/public/release-notes/release-2018.2.rst
@@ -27,7 +27,7 @@ Neu kann beim Hinzufügen einer Vorlage in einem Suchfeld nach der gewünschten 
 Sitzungs- und Protokollverwaltung
 ---------------------------------
 
-- Anhänge in Traktanden werden nun alphabetisch sortiert dargestellt
+- Beilagen in Traktanden werden nun alphabetisch sortiert dargestellt
 
 - Freitext-Traktanden sind nun auch im Zip-Export enthalten
 

--- a/docs/public/release-notes/release-2018.4.rst
+++ b/docs/public/release-notes/release-2018.4.rst
@@ -98,7 +98,7 @@ Sitzungs- und Protokollverwaltung
 - Anträge und Traktanden haben neu das Feld „Beschreibung“.
 
 - Neu befindet sich ein Button „Antrag erstellen“ beim Dokumenten-Tab eines
-  Dossiers. Damit können Anträge direkt mit mehreren Dokumenten als Anhang erstellt werden.
+  Dossiers. Damit können Anträge direkt mit mehreren Dokumenten als Beilage erstellt werden.
 
 - Es können neu mehrere unterschiedliche Antragsvorlagen für Ad-Hoc Anträge konfiguriert werden.
 

--- a/docs/public/user-manual/sitzungs-app/zusammenstellen.rst
+++ b/docs/public/user-manual/sitzungs-app/zusammenstellen.rst
@@ -2,7 +2,7 @@ Situngsunterlagen zusammenstellen
 ----------------------------------
 
 Die Sitzung wird in der Sitzungs- und Protokollverwaltung vorbereitet. Wenn alle
-Unterlagen (Anträge, Anhänge, Traktandenliste, Vorprotokoll) erstellt sind,
+Unterlagen (Anträge, Beilagen, Traktandenliste, Vorprotokoll) erstellt sind,
 können die Sitzungsunterlagen als ZIP-Datei exportiert und lokal
 zwischengespeichert werden. Die Unterlagen sind nun bereit um
 auf der Sitzungs-App zur Verfügung gestellt zu werden.

--- a/docs/public/user-manual/spv/antrag-erfassen.rst
+++ b/docs/public/user-manual/spv/antrag-erfassen.rst
@@ -27,10 +27,10 @@ Zum Erfassen eines Antrags gibt es zwei Möglichkeiten:
 **Antrag ausfüllen**
 
 Unter «Antrag hinzufügen» werden der Titel des Traktandums, das betreffende
-Gremium, die passende Antragsvorlage und die dazugehörigen Anhänge bearbeitet
+Gremium, die passende Antragsvorlage und die dazugehörigen Beilagen bearbeitet
 bzw. ausgewählt.
 
-Anhänge können entweder aus einer bestehenden Vorlage angehängt
+Beilagen können entweder aus einer bestehenden Vorlage angehängt
 werden:
 
 |img-spvupdate-9|

--- a/docs/public/user-manual/spv/antrags-benachrichtigungen.rst
+++ b/docs/public/user-manual/spv/antrags-benachrichtigungen.rst
@@ -22,8 +22,8 @@ Verantwortlichen eines Gremiums ausgelöst:
 
 -   Neuer Antrag eingereicht
 -   Eingereichter Antrag kommentiert
--   Neue Anhänge eingereicht
--   Bestehende Anhänge aktualisiert
+-   Neue Beilagen eingereicht
+-   Bestehende Beilagen aktualisiert
 
 Diese oben erwähnten Aktionen werden auch in den Benachrichtigungs-Einstellungen
 sichtbar und können von den Benutzern einzeln konfiguriert werden. Mehr

--- a/docs/public/user-manual/spv/sitzung-vorbereiten.rst
+++ b/docs/public/user-manual/spv/sitzung-vorbereiten.rst
@@ -23,7 +23,7 @@ Ansicht einer vorbereiteten Sitzung:
 |img-spvupdate-22|
 |img-spvupdate-23|
 
-1. Die Ansicht der Anhänge pro Antrag lässt sich ein- und ausklappen.
+1. Die Ansicht der Beilagen pro Antrag lässt sich ein- und ausklappen.
 2. Über «Bearbeiten» können weitere Teilnehmende (Gäste) hinzugefügt werden.
 3. In diesem Feld kann die Protokollführende Person ausgewählt werden.
 4. Der Beginn der Seitennummerierung kann hier festgelegt werden.

--- a/docs/public/user-manual/spv/sitzungsunterlagen-aufbereiten.rst
+++ b/docs/public/user-manual/spv/sitzungsunterlagen-aufbereiten.rst
@@ -2,7 +2,7 @@
 Sitzungsunterlagen aufbereiten
 ------------------------------
 Sie haben jederzeit die Möglichkeit die Inhalte aus der SPV in eine ZIP-Datei
-zu exportieren (einzelne Geschäfte inkl. Anhänge). Die Dokumente werden
+zu exportieren (einzelne Geschäfte inkl. Beilagen). Die Dokumente werden
 automatisch in PDFs konvertiert. Diese können Sie den Behördenmitgliedern via
 Email, Teamraum oder einer anderen Collaborationplattform zur Verfügung stellen.
 

--- a/opengever/activity/locales/de/LC_MESSAGES/opengever.activity.po
+++ b/opengever/activity/locales/de/LC_MESSAGES/opengever.activity.po
@@ -211,12 +211,12 @@ msgstr "Während dem Erzeugen der Benachrichtigung ist ein Fehler aufgetreten. D
 #. Default: "Additional documents submitted"
 #: ./opengever/activity/__init__.py
 msgid "proposal-additional-documents-submitted"
-msgstr "Zusätzliche Anhänge eingereicht"
+msgstr "Zusätzliche Beilagen eingereicht"
 
 #. Default: "Attachment updated"
 #: ./opengever/activity/__init__.py
 msgid "proposal-attachment-updated"
-msgstr "Anhang aktualisiert"
+msgstr "Beilage aktualisiert"
 
 #. Default: "Proposal commented"
 #: ./opengever/activity/__init__.py

--- a/opengever/base/locales/de/LC_MESSAGES/plone.po
+++ b/opengever/base/locales/de/LC_MESSAGES/plone.po
@@ -116,10 +116,10 @@ msgid "Search results for ${term}"
 msgstr "Suchresultate für ${term}"
 
 msgid "Submit additional document"
-msgstr "Zusätzlichen Anhang einreichen"
+msgstr "Zusätzliche Beilage einreichen"
 
 msgid "Submit additional documents"
-msgstr "Zusätzliche Anhänge einreichen"
+msgstr "Zusätzliche Beilagen einreichen"
 
 msgid "Usage"
 msgstr "Nutzung"

--- a/opengever/base/locales/fr/LC_MESSAGES/plone.po
+++ b/opengever/base/locales/fr/LC_MESSAGES/plone.po
@@ -116,10 +116,10 @@ msgid "Search results for ${term}"
 msgstr "Résultat de la recherche pour"
 
 msgid "Submit additional document"
-msgstr "Soumettre document additionnel"
+msgstr "Soumettre pièce jointe additionnelle"
 
 msgid "Submit additional documents"
-msgstr "Soumettre documents additionnel"
+msgstr "Soumettre pièces jointes additionnel"
 
 msgid "Usage"
 msgstr "Usage"

--- a/opengever/core/locales/de/LC_MESSAGES/opengever.core.po
+++ b/opengever/core/locales/de/LC_MESSAGES/opengever.core.po
@@ -244,7 +244,7 @@ msgstr "Als E-Mail versenden"
 
 #: ./opengever/core/profiles/default/actions.xml
 msgid "Submit additional documents"
-msgstr "Zusätzliche Anhänge einreichen"
+msgstr "Zusätzliche Beilagen einreichen"
 
 #: ./opengever/core/profiles/default/types/opengever.meeting.submittedproposal.xml
 msgid "Submitted Proposal"

--- a/opengever/core/locales/fr/LC_MESSAGES/opengever.core.po
+++ b/opengever/core/locales/fr/LC_MESSAGES/opengever.core.po
@@ -239,7 +239,7 @@ msgstr "Envoyer par E-Mail"
 
 #: ./opengever/core/profiles/default/actions.xml
 msgid "Submit additional documents"
-msgstr "Soumettre des documents additionnels"
+msgstr "Soumettre des pièces jointes additionnelles"
 
 #: ./opengever/core/profiles/default/types/opengever.meeting.submittedproposal.xml
 msgid "Submitted Proposal"

--- a/opengever/document/locales/de/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/de/LC_MESSAGES/opengever.document.po
@@ -105,7 +105,7 @@ msgstr "Datei des Dokuments auf Version ${version_id} zurückgesetzt."
 
 #: ./opengever/document/upgrades/profiles/4200/actions.xml
 msgid "Submit additional documents"
-msgstr "Zusätzliche Anhänge einreichen"
+msgstr "Zusätzliche Beilagen einreichen"
 
 #: ./opengever/document/browser/overview.py
 msgid "Submitted version: ${version}"

--- a/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
@@ -107,7 +107,7 @@ msgstr "Retour à la version ${version_id} du document."
 
 #: ./opengever/document/upgrades/profiles/4200/actions.xml
 msgid "Submit additional documents"
-msgstr "Soumettre des documents additionnels"
+msgstr "Soumettre des pièces jointes additionnelles"
 
 #: ./opengever/document/browser/overview.py
 msgid "Submitted version: ${version}"

--- a/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
@@ -415,7 +415,7 @@ msgstr "Alle"
 #. Default: "Attachments"
 #: ./opengever/meeting/zipexport.py
 msgid "attachments"
-msgstr "Anhang"
+msgstr "Beilage"
 
 #. Default: "Cancel"
 #: ./opengever/meeting/browser/committeeforms.py
@@ -454,7 +454,7 @@ msgstr "Folgeantrag erstellen"
 #: ./opengever/meeting/browser/documents/submit.py
 #: ./opengever/meeting/browser/submitdocuments.py
 msgid "button_submit_attachments"
-msgstr "Anhänge einreichen"
+msgstr "Beilagen einreichen"
 
 #. Default: "Cancel"
 #: ./opengever/meeting/model/meeting.py
@@ -851,7 +851,7 @@ msgstr "Erlaubte Antragsvorlagen"
 #: ./opengever/meeting/browser/submitdocuments.py
 #: ./opengever/meeting/browser/templates/proposaloverview.pt
 msgid "label_attachments"
-msgstr "Anhänge"
+msgstr "Beilagen"
 
 #. Default: "Back to the meeting"
 #: ./opengever/meeting/browser/meetings/zipexport.py
@@ -1351,7 +1351,7 @@ msgstr "Start"
 #: ./opengever/meeting/browser/documents/submit.py
 #: ./opengever/meeting/browser/submitdocuments.py
 msgid "label_submit_additional_documents"
-msgstr "Zusätzliche Dokumente einreichen"
+msgstr "Zusätzliche Beilagen einreichen"
 
 #. Default: "Submit Updated Documents"
 #: ./opengever/meeting/browser/documents/submit.py
@@ -1389,7 +1389,7 @@ msgstr "Vorlage Inhaltsverzeichnis"
 #. Default: "Toggle attachments"
 #: ./opengever/meeting/browser/meetings/meeting.py
 msgid "label_toggle_attachments"
-msgstr "Anhänge anzeigen / ausblenden"
+msgstr "Beilagen anzeigen / ausblenden"
 
 #. Default: "Transition"
 #: ./opengever/meeting/proposal_transition_comment.py

--- a/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
@@ -417,7 +417,7 @@ msgstr "Tous"
 #. Default: "Attachments"
 #: ./opengever/meeting/zipexport.py
 msgid "attachments"
-msgstr "Annexes"
+msgstr "Pièces jointes"
 
 #. Default: "Cancel"
 #: ./opengever/meeting/browser/committeeforms.py
@@ -1353,7 +1353,7 @@ msgstr "Début"
 #: ./opengever/meeting/browser/documents/submit.py
 #: ./opengever/meeting/browser/submitdocuments.py
 msgid "label_submit_additional_documents"
-msgstr "Soumettre les documents additionnels"
+msgstr "Soumettre les pièces jointes additionnelles"
 
 #. Default: "Submit Updated Documents"
 #: ./opengever/meeting/browser/documents/submit.py

--- a/opengever/meeting/tests/test_meeting_zipexport.py
+++ b/opengever/meeting/tests/test_meeting_zipexport.py
@@ -38,7 +38,7 @@ class TestMeetingZipExportView(IntegrationTestCase):
         browser.open(self.meeting, view='export-meeting-zip')
         zip_file = ZipFile(StringIO(browser.contents), 'r')
         self.assertIn(
-            'Traktandum 1/Anhang/1_Vertraegsentwurf.docx',
+            'Traktandum 1/Beilage/1_Vertraegsentwurf.docx',
             zip_file.namelist())
 
     @browsing
@@ -54,8 +54,8 @@ class TestMeetingZipExportView(IntegrationTestCase):
         zip_file = ZipFile(StringIO(browser.contents), 'r')
         self.assertItemsEqual(
             ['Traktandum 1/Vertraege.docx',
-             'Traktandum 1/Anhang/1_Vertraegsentwurf.docx',
-             'Traktandum 1/Anhang/2_Uebersicht der Vertraege von 2016.xlsx',
+             'Traktandum 1/Beilage/1_Vertraegsentwurf.docx',
+             'Traktandum 1/Beilage/2_Uebersicht der Vertraege von 2016.xlsx',
              'meeting.json'],
             zip_file.namelist())
 
@@ -82,7 +82,7 @@ class TestMeetingZipExportView(IntegrationTestCase):
         browser.open(self.meeting, view='export-meeting-zip')
         zip_file = ZipFile(StringIO(browser.contents), 'r')
         self.assertItemsEqual(
-            ['Traktandum 1/Anhang/1_Vertraegsentwurf.docx',
+            ['Traktandum 1/Beilage/1_Vertraegsentwurf.docx',
              'Traktandum 1/Vertraege.docx',
              'meeting.json'],
             zip_file.namelist())
@@ -165,7 +165,7 @@ class TestMeetingZipExportView(IntegrationTestCase):
                 {
                     'attachments': [{
                         'checksum': '51d6317494eccc4a73154625a6820cb6b50dc1455eb4cf26399299d4f9ce77b2',
-                        'file': 'Traktandum 2/Anhang/1_Vertraegsentwurf.docx',
+                        'file': 'Traktandum 2/Beilage/1_Vertraegsentwurf.docx',
                         'modified': u'2016-08-31T16:09:37+02:00',
                         'title': u'Vertr\xe4gsentwurf',
                     }],
@@ -241,7 +241,7 @@ class TestMeetingZipExportView(IntegrationTestCase):
                     {
                         u'attachments': [{
                             u'checksum': u'51d6317494eccc4a73154625a6820cb6b50dc1455eb4cf26399299d4f9ce77b2',
-                            u'file': u'Traktandum 2/Anhang/1_Vertraegsentwurf.docx',
+                            u'file': u'Traktandum 2/Beilage/1_Vertraegsentwurf.docx',
                             u'modified': u'2016-08-31T16:09:37+02:00',
                             u'title': u'Vertr\xe4gsentwurf',
                         }],
@@ -274,7 +274,7 @@ class TestMeetingZipExportView(IntegrationTestCase):
         expected_file_names = [
             'Protokoll-9. Sitzung der Rechnungspruefungskommission- ordentlich.docx',
             'Traktandum 1/Ad-hoc Traktandthm.docx',
-            'Traktandum 2/Anhang/1_Vertraegsentwurf.docx',
+            'Traktandum 2/Beilage/1_Vertraegsentwurf.docx',
             'Traktandum 2/Vertraege.docx',
             'meeting.json',
             ]
@@ -305,9 +305,9 @@ class TestMeetingZipExportView(IntegrationTestCase):
         zip_file = ZipFile(StringIO(browser.contents), 'r')
         meeting_json = json.loads(zip_file.read('meeting.json'))
 
-        expected_file_names = [u'Traktandum 1/Anhang/1_The same title.doc',
-                               u'Traktandum 1/Anhang/2_The same title.doc',
-                               u'Traktandum 1/Anhang/3_The same title.doc']
+        expected_file_names = [u'Traktandum 1/Beilage/1_The same title.doc',
+                               u'Traktandum 1/Beilage/2_The same title.doc',
+                               u'Traktandum 1/Beilage/3_The same title.doc']
         json_file_names = [attachment.get("file") for attachment in
                            meeting_json["meetings"][0]['agenda_items'][0]["attachments"]]
 


### PR DESCRIPTION
We now use `Beilage` in German and `pièce jointe` in French everywhere in the SPV. I left `Anhang` in other places such as mails.
Side effect is that in the zip export we now have `Beilage` instead of `Anhang` as subdodisser for the attachments. I'm not sure whether that is a problem for the meeting app?
resolves #5189 