### PR TITLE
Fix performance issue with search root exclusion in tabbed view listings

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2019.2.0 (unreleased)
 ---------------------
 
+- Fix performance issue with search root exclusion in tabbed view listings. [lgraf]
 - Do not list resolved tasks as pending in the 'My Tasks' tab. [Rotonen]
 - Adapt footer to new 4teamwork website. [njohner]
 - Move personal bar customization into opengever.base. [njohner]


### PR DESCRIPTION
The original implementation for excluding the search root in `ftw.table`, introduced in 4teamwork/ftw.table#53, creates one path query for each immediate child. Turns out that performs much worse than expected for containers with lots of immediate children.

Because in GEVER we have a more recent version of `Products.ZCatalog`, and also [monkeypatch the UIDIndex's query options to add support for the 'not' operator](https://github.com/4teamwork/opengever.core/blob/master/opengever/base/monkey/patches/uuidindex.py), we're able to use a more efficient strategy here, and simply exclude the current context using `{'not': uuid}` filter.

Fixes #5487 