### PR TITLE
Extend listing endpoint with `tasks`

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -18,6 +18,7 @@ Changelog
 - Update plone.rest api to 3.7.2. [mathias.leimgruber]
 - Respect tabbedview settings when generating an task or dossier excel export. [phgross]
 - Exclusively handle templates on Committee and not on CommitteeContainer anymore. [njohner]
+- Extend @listing endpoint with `tasks`-listing. [elioschmutz]
 - Fix performance issue with search root exclusion in tabbed view listings. [lgraf]
 - Do not list auto-generated documents as recently touched. [njohner]
 - Standardize french and german translation of "attachments" in meetings. [njohner]

--- a/docs/public/dev-manual/api/listings.rst
+++ b/docs/public/dev-manual/api/listings.rst
@@ -46,6 +46,7 @@ Aktuell werden folgende Auflistungen unterstützt:
 - ``dossiers``: Dossiers
 - ``documents``: Dokumente
 - ``workspaces``: Arbeitsräume
+- ``tasks``: Aufgaben
 
 
 Für jede Auflistung können verschiedene Felder (Parameter ``columns``) abgefragt
@@ -57,6 +58,7 @@ werden. Folgende Felder stehen zur Verfügung:
 - ``checked_out_fullname``: Anzeigename des Benutzers, der das Dokument ausgechecked hat
 - ``containing_dossier``: Titel des Hauptdossier in dem das Element enthalten ist
 - ``containing_subdossier``: Titel des Subdossiers in dem das Dokument enthalten ist
+- ``completed``: Zeigt an ob eine Aufgabe erledigt ist.
 - ``created``: Erstelldatum
 - ``creator``: Ersteller
 - ``description``: Beschreibung
@@ -72,7 +74,8 @@ werden. Folgende Felder stehen zur Verfügung:
 - ``reference_number``: Aktenzeichen
 - ``relative_path``: Pfad
 - ``responsible``: Federführung (Benutzername)
-- ``responsible_fullname``: Federführung (Anzeigename)
+- ``responsible_fullname``: Federführung oder Auftragnehmer (Anzeigename)
+- ``issuer_fullname``: Auftraggeber (Anzeigename)
 - ``review_state``: Status
 - ``review_state_label``: Status (Anzeigewert)
 - ``sequence_number``: Laufnummer
@@ -82,6 +85,8 @@ werden. Folgende Felder stehen zur Verfügung:
 - ``title``: Titel
 - ``filesize``: Dateigrösse
 - ``filename``: Dateiname
+- ``task_type``: Aufgaben-Typ
+- ``deadline``: Aufgabenfrist
 
 Je nach Auflistungstyp und Inhalt sind bestimmte Felder nicht verfügbar. In diesem
 Fall wird der Wert ``none`` zurückgegeben. So haben Dossiers bspw. keinen Dateinamen.

--- a/opengever/api/listing.py
+++ b/opengever/api/listing.py
@@ -7,6 +7,7 @@ from opengever.base.behaviors.translated_title import ITranslatedTitleSupport
 from opengever.base.interfaces import ISearchSettings
 from opengever.base.solr import OGSolrDocument
 from opengever.base.utils import get_preferred_language_code
+from opengever.task.helper import task_type_helper
 from plone import api
 from plone.app.contentlisting.interfaces import IContentListingObject
 from plone.registry.interfaces import IRegistry
@@ -49,6 +50,10 @@ def translated_title(obj):
         return obj.Title()
 
 
+def translated_task_type(obj):
+    return task_type_helper(obj, obj.task_type)
+
+
 def filesize(obj):
     try:
         info = IPrimaryFieldInfo(obj.getObject())
@@ -84,6 +89,7 @@ FIELDS = {
     'containing_dossier': ('containing_dossier', 'containing_dossier', 'containing_dossier'),
     'containing_subdossier': ('containing_subdossier', 'containing_subdossier', 'containing_subdossier'),  # noqa
     'created': ('created', 'created', 'created'),
+    'completed': ('completed', 'completed', 'completed'),
     'creator': ('Creator', 'Creator', 'Creator'),
     'description': ('Description', 'Description', 'Description'),
     'delivery_date': ('delivery_date', 'delivery_date', 'delivery_date'),
@@ -100,6 +106,7 @@ FIELDS = {
     'relative_path': (None, relative_path, DEFAULT_SORT_INDEX),
     'responsible': ('responsible', 'responsible', 'responsible'),
     'responsible_fullname': ('responsible', 'responsible_fullname', 'responsible'),
+    'issuer_fullname': ('issuer', 'issuer_fullname', 'issuer'),
     'review_state': ('review_state', 'review_state', 'review_state'),
     'review_state_label': ('review_state', 'translated_review_state',
                            'review_state'),
@@ -112,6 +119,8 @@ FIELDS = {
     'type': ('portal_type', 'PortalType', 'portal_type'),
     'filesize': (None, filesize, 'filesize'),
     'filename': (None, filename, 'filename'),
+    'task_type': ('task_type', translated_task_type, 'task_type'),
+    'deadline': ('deadline', 'deadline', 'deadline'),
 }
 
 DATE_INDEXES = set([
@@ -134,6 +143,9 @@ SOLR_FILTERS = {
     ],
     u'workspaces': [
         u'object_provides:opengever.workspace.interfaces.IWorkspace',
+    ],
+    u'tasks': [
+        u'object_provides:opengever.task.task.ITask',
     ]
 }
 
@@ -146,6 +158,9 @@ CATALOG_QUERIES = {
     },
     'workspaces': {
         'object_provides': 'opengever.workspace.interfaces.IWorkspace',
+    },
+    'tasks': {
+        'object_provides': 'opengever.task.task.ITask',
     }
 
 }

--- a/opengever/api/tests/test_listing.py
+++ b/opengever/api/tests/test_listing.py
@@ -234,6 +234,42 @@ class TestListingEndpoint(IntegrationTestCase):
              u'title': u'A Workspace'},
             browser.json['items'][-1])
 
+    @browsing
+    def test_tasks_listing(self, browser):
+        self.enable_languages()
+
+        self.login(self.workspace_member, browser=browser)
+        query_string = '&'.join((
+            'name=tasks',
+            'columns=review_state_label',
+            'columns=title',
+            'columns=task_type',
+            'columns=deadline',
+            'columns=completed',
+            'columns=responsible_fullname',
+            'columns=issuer_fullname',
+            'columns=created',
+        ))
+        view = '?'.join(('@listing', query_string))
+        browser.open(self.dossier, view=view,
+                     headers={'Accept': 'application/json',
+                              'Accept-Language': 'de-ch'})
+
+        item = filter(lambda item: item.get('@id') == self.task.absolute_url(),
+                      browser.json['items'])[0]
+
+        self.assertItemsEqual(
+            {u'issuer_fullname': u'Ziegler Robert',
+             u'task_type': u'Zur Pr\xfcfung / Korrektur',
+             u'responsible_fullname': u'B\xe4rfuss K\xe4thi',
+             u'completed': None,
+             u'created': u'2016-08-31T16:01:33+00:00',
+             u'deadline': u'2016-11-01',
+             u'review_state_label': u'In Arbeit',
+             u'title': u'Vertragsentwurf \xdcberpr\xfcfen',
+             u'@id': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/task-1'},
+            item)
+
 
 class TestListingEndpointWithSolr(IntegrationTestCase):
 

--- a/opengever/base/contentlisting.py
+++ b/opengever/base/contentlisting.py
@@ -153,6 +153,9 @@ class OpengeverCatalogContentListingObject(CatalogContentListingObject):
     def responsible_fullname(self):
         return display_name(self._brain.responsible)
 
+    def issuer_fullname(self):
+        return display_name(self._brain.issuer)
+
     def checked_out_fullname(self):
         return display_name(self._brain.checked_out)
 


### PR DESCRIPTION
Erweitert die vorhandenen @listing-queries mit `tasks`.

Issuer: https://github.com/4teamwork/gever-ui/issues/18