### PR TITLE
Allow reassigning tasks to other org- and adminunits.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -11,6 +11,7 @@ Changelog
 - Do not list resolved tasks as pending in the 'My Tasks' tab. [Rotonen]
 - Make attachments for `direct-execution` tasks editable by the responsible. [phgross]
 - Make reject to skip transition only available for tasks part of a sequence. [phgross]
+- Allow reassigning tasks to other org- and adminunits. [phgross]
 - Adapt footer to new 4teamwork website. [njohner]
 - Move personal bar customization into opengever.base. [njohner]
 - Unify Bumblebee URLs on REST API for document vs. document on a listing. [Rotonen]

--- a/opengever/task/browser/configure.zcml
+++ b/opengever/task/browser/configure.zcml
@@ -7,7 +7,7 @@
   <include package=".delegate" />
 
   <adapter factory=".complete.NoCheckedoutDocsValidator" />
-  <adapter factory=".assign.NoTeamsInProgressStateValidator" />
+  <adapter factory=".assign.InProgressStateLimitiationsValidator" />
 
   <browser:page
       name="task_transition_controller"

--- a/opengever/task/configure.zcml
+++ b/opengever/task/configure.zcml
@@ -23,6 +23,8 @@
   <i18n:registerTranslations directory="locales" />
 
   <adapter factory=".task.NoCheckedoutDocsValidator" />
+  <adapter factory=".transition.NoTeamsInProgressStateValidator" />
+  <adapter factory=".transition.NoAdminUnitChangeInProgressStateValidator" />
 
   <browser:page
       name="task_response_delete"

--- a/opengever/task/locales/de/LC_MESSAGES/opengever.task.po
+++ b/opengever/task/locales/de/LC_MESSAGES/opengever.task.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2019-01-31 18:37+0000\n"
+"POT-Creation-Date: 2019-03-07 11:08+0000\n"
 "PO-Revision-Date: 2015-02-17 18:41+0100\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -205,6 +205,11 @@ msgstr "Verantwortliche"
 #: ./opengever/task/validators.py
 msgid "error_checked_out_document"
 msgstr "Die folgenden Dokumente (${title}) müssen noch eingecheckt werden."
+
+#. Default: "Admin unit changes are not allowed if the task or forwarding is already accepted."
+#: ./opengever/task/browser/assign.py
+msgid "error_no_admin_unit_change_in_progress_state"
+msgstr "Mandanten-Wechsel sind bei bereits akzeptierten Aufgaben nicht erlaubt."
 
 #. Default: "Team responsibles are only allowed if the task or forwarding is open."
 #: ./opengever/task/browser/assign.py

--- a/opengever/task/locales/fr/LC_MESSAGES/opengever.task.po
+++ b/opengever/task/locales/fr/LC_MESSAGES/opengever.task.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-01-31 18:37+0000\n"
+"POT-Creation-Date: 2019-03-07 11:08+0000\n"
 "PO-Revision-Date: 2017-12-03 11:47+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-task/fr/>\n"
@@ -207,6 +207,11 @@ msgstr "Responsable"
 #: ./opengever/task/validators.py
 msgid "error_checked_out_document"
 msgstr "Les documents suivants (${title}) sont en checkout. Vous devez faire un checkin pour pouvoir les déposer."
+
+#. Default: "Admin unit changes are not allowed if the task or forwarding is already accepted."
+#: ./opengever/task/browser/assign.py
+msgid "error_no_admin_unit_change_in_progress_state"
+msgstr ""
 
 #. Default: "Team responsibles are only allowed if the task or forwarding is open."
 #: ./opengever/task/browser/assign.py

--- a/opengever/task/locales/opengever.task.pot
+++ b/opengever/task/locales/opengever.task.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2019-01-31 18:37+0000\n"
+"POT-Creation-Date: 2019-03-07 11:08+0000\n"
 "PO-Revision-Date: 2009-02-25 14:39+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -205,6 +205,11 @@ msgstr ""
 #. Default: "The documents (${title}) are still checked out.                                 Please checkin them in bevore deliver"
 #: ./opengever/task/validators.py
 msgid "error_checked_out_document"
+msgstr ""
+
+#. Default: "Admin unit changes are not allowed if the task or forwarding is already accepted."
+#: ./opengever/task/browser/assign.py
+msgid "error_no_admin_unit_change_in_progress_state"
 msgstr ""
 
 #. Default: "Team responsibles are only allowed if the task or forwarding is open."

--- a/opengever/task/tests/test_response_syncer.py
+++ b/opengever/task/tests/test_response_syncer.py
@@ -354,7 +354,7 @@ class TestWorkflowSyncerReceiver(FunctionalTestCase):
     def test_updates_responsible_if_new_value_is_given(self):
         create(Builder('ogds_user').id('hugo.boss'))
         task = create(Builder('task')
-                      .in_state('task-state-in-progress')
+                      .in_state('task-state-open')
                       .having(responsible_client='org-unit-1'))
 
         self.prepare_request(task, text=u'I am done!',

--- a/opengever/testing/integration_test_case.py
+++ b/opengever/testing/integration_test_case.py
@@ -21,6 +21,7 @@ from opengever.meeting.wrapper import MeetingWrapper
 from opengever.ogds.base.utils import get_current_admin_unit
 from opengever.ogds.base.utils import get_current_org_unit
 from opengever.ogds.base.utils import ogds_service
+from opengever.ogds.models.admin_unit import AdminUnit
 from opengever.ogds.models.org_unit import OrgUnit
 from opengever.private import enable_opengever_private
 from opengever.task.interfaces import ISuccessorTaskController
@@ -675,6 +676,20 @@ class IntegrationTestCase(TestCase):
         # Reset org_unit strategy, we need now a MultipleOrgUnitsStrategy
         get_current_org_unit()._chosen_strategy = None
         return OrgUnit.get('additional')
+
+    def add_additional_admin_and_org_unit(self):
+        admin_unit = create(Builder('admin_unit')
+                            .having(
+                                title=u'Ratskanzlei',
+                                unit_id=u'rk',
+                                public_url='http://nohost/plone'))
+        create(Builder('org_unit').id("rk")
+               .with_default_groups()
+               .having(admin_unit=admin_unit))
+
+        # Reset org_unit strategy, we need now a MultipleOrgUnitsStrategy
+        get_current_org_unit()._chosen_strategy = None
+        return AdminUnit.get('rk'), OrgUnit.get('rk')
 
     def assert_solr_called(self, solr, text, **kwargs):
         query = (


### PR DESCRIPTION
Extend the field validator, which makes sure that admin-unit changes are only possible when the task is in the open state. Registering two `SimpleFieldValidators` for the same field, does not worked, therefore I combined the two checks in one validator.

Because we do not use the exact same interface in the form than the transition extender, which is used by API requests, we need to add separate validators for each field of the transition extender interface. 

I also realized that the BaseTransitionExtender did not correctly validates the values (SimpleFieldValidators has not been called in the former implementation), I've fixed that as well.

Closes #5374 