### PR TITLE
Extend @navigation endpoint to be more generic

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -19,6 +19,7 @@ Changelog
 - Add mapping between public and gever permissions. [njohner]
 - Disable CSRF protect on webaction api post requests. [njohner]
 - Warn the user on overviews and overlays of trashed mails or documents. [Rotonen]
+- Include `@type`, `current` and `current_tree` property to `@navigation`-items. [elioschmutz]
 - Update plone.rest api to 3.7.2. [mathias.leimgruber]
 - Respect tabbedview settings when generating an task or dossier excel export. [phgross]
 - Exclusively handle templates on Committee and not on CommitteeContainer anymore. [njohner]

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -19,6 +19,7 @@ Changelog
 - Add mapping between public and gever permissions. [njohner]
 - Disable CSRF protect on webaction api post requests. [njohner]
 - Warn the user on overviews and overlays of trashed mails or documents. [Rotonen]
+- Include `root_interface` and `content_interfaces` parameter to `@navigation` endpoint to customize the navigation items [elioschmutz]
 - Include `@type`, `current` and `current_tree` property to `@navigation`-items. [elioschmutz]
 - Update plone.rest api to 3.7.2. [mathias.leimgruber]
 - Respect tabbedview settings when generating an task or dossier excel export. [phgross]

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -19,6 +19,7 @@ Changelog
 - Add mapping between public and gever permissions. [njohner]
 - Disable CSRF protect on webaction api post requests. [njohner]
 - Warn the user on overviews and overlays of trashed mails or documents. [Rotonen]
+- Include `include_root` parameter to `@navigation` endpoint to include the root object to the tree. [elioschmutz]
 - Include `root_interface` and `content_interfaces` parameter to `@navigation` endpoint to customize the navigation items [elioschmutz]
 - Include `@type`, `current` and `current_tree` property to `@navigation`-items. [elioschmutz]
 - Update plone.rest api to 3.7.2. [mathias.leimgruber]

--- a/docs/public/dev-manual/api/navigation.rst
+++ b/docs/public/dev-manual/api/navigation.rst
@@ -24,15 +24,24 @@ GEVER-Mandanten abgefragt werden.
           "@id": "http://localhost:8080/fd/ordnungssystem/@navigation",
           "tree": [
               {
+                  "@type": "opengever.repository.repositoryfolder",
                   "active": true,
+                  "current": false,
+                  "current_tree": false,
                   "description": "",
                   "nodes": [
                       {
+                          "@type": "opengever.repository.repositoryfolder",
                           "active": true,
+                          "current": false,
+                          "current_tree": false,
                           "description": "",
                           "nodes": [
                               {
+                                  "@type": "opengever.repository.repositoryfolder",
                                   "active": true,
+                                  "current": false,
+                                  "current_tree": false,
                                   "description": "",
                                   "nodes": [],
                                   "text": "9.5.0. Allgemeines",
@@ -40,7 +49,10 @@ GEVER-Mandanten abgefragt werden.
                                   "url": "http://localhost:8080/fd/ordnungssystem/ressourcen-und-support/ict/allgemeines"
                               },
                               {
+                                  "@type": "opengever.repository.repositoryfolder",
                                   "active": true,
+                                  "current": false,
+                                  "current_tree": false,
                                   "description": "",
                                   "nodes": [],
                                   "text": "9.5.1. Informatik",
@@ -48,7 +60,10 @@ GEVER-Mandanten abgefragt werden.
                                   "url": "http://localhost:8080/fd/ordnungssystem/ressourcen-und-support/ict/informatik"
                               },
                               {
+                                  "@type": "opengever.repository.repositoryfolder",
                                   "active": true,
+                                  "current": false,
+                                  "current_tree": false,
                                   "description": "",
                                   "nodes": [],
                                   "text": "9.5.2. Telefonie",

--- a/docs/public/dev-manual/api/navigation.rst
+++ b/docs/public/dev-manual/api/navigation.rst
@@ -3,8 +3,9 @@
 Navigation
 ==========
 
-Über den ``/@navigation`` Endpoint kann der Ordnungssystem-Baum des
-GEVER-Mandanten abgefragt werden.
+Über den ``/@navigation`` Endpoint kann ein beliebiger Navigationsbaum des GEVER-Mandanten abgefragt werden.
+
+Standardmässig wird der Ordnungssystem-Baum zurückgegeben.
 
 **Beispiel-Request**:
 
@@ -94,3 +95,39 @@ so dass keinezusätzliche Abfrage nötig ist.
 
        GET /ordnungssystem?expand=navigation HTTP/1.1
        Accept: application/json
+
+Für einen personalisierten Navigationsbaum können die Parameter `root_interface` und `content_interfaces` verwendet werden.
+
+Ein Navigationsbaum eines Arbeitsraumes kann wie folgt abgefragt werden:
+
+
+**Beispiel-Request**:
+
+   .. sourcecode:: http
+
+       GET /@navigation?root_interface=opengever.workspace.interfaces.IWorkspace&content_interfaces=opengever.workspace.interfaces.IWorkspaceFolder HTTP/1.1
+       Accept: application/json
+
+**Beispiel-Response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 200 OK
+      Content-Type: application/json
+
+      {
+          "@id": "http://localhost:8080/fd/workspaces/workspace-1/@navigation",
+          "tree": [
+              {
+                  "active": true,
+                  "current": false,
+                  "current_tree": false,
+                  "description": "",
+                  "nodes": [],
+                  "text": "",
+                  "uid": "8dee9268d10f4b2db742fb52ebefdd03",
+                  "url": "http://localhost:8080/fd/workspaces/workspace-1/folder-1"
+              }
+          ]
+      }
+

--- a/docs/public/dev-manual/api/navigation.rst
+++ b/docs/public/dev-manual/api/navigation.rst
@@ -131,3 +131,45 @@ Ein Navigationsbaum eines Arbeitsraumes kann wie folgt abgefragt werden:
           ]
       }
 
+Über den Parameter `include_root` kann das Root-Objekt im Navigationsbaum hinzugefügt werden.
+
+**Beispiel-Request**:
+
+   .. sourcecode:: http
+
+       GET /@navigation?include_root=true&root_provides=opengever.workspace.interfaces.IWorkspace&content_provides=opengever.workspace.interfaces.IWorkspaceFolder HTTP/1.1
+       Accept: application/json
+
+**Beispiel-Response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 200 OK
+      Content-Type: application/json
+
+      {
+          "@id": "http://localhost:8080/fd/workspaces/workspace-1/@navigation",
+          "tree": [
+              {
+                  "active": true,
+                  "current": false,
+                  "current_tree": false,
+                  "description": "",
+                  "nodes": [
+                      {
+                          "active": true,
+                          "current": false,
+                          "current_tree": false,
+                          "description": "",
+                          "nodes": [],
+                          "text": "",
+                          "uid": "8dee9268d10f4b2db742fb52ebefdd03",
+                          "url": "http://localhost:8080/fd/workspaces/workspace-1/folder-1"
+                      }
+                  ],
+                  "text": "",
+                  "uid": "f93938316a524fa5ac59f3b98506b47c",
+                  "url": "http://localhost:8080/fd/workspaces/workspace-1"
+              }
+          ]
+      }

--- a/opengever/api/navigation.py
+++ b/opengever/api/navigation.py
@@ -13,16 +13,6 @@ from zope.interface import implementer
 from zope.interface import Interface
 
 
-def brain_to_node(brain):
-    return {
-        'text': brain.Title,
-        'description': brain.Description,
-        'url': brain.getURL(),
-        'uid': brain.UID,
-        'active': brain.review_state != REPOSITORY_FOLDER_STATE_INACTIVE
-    }
-
-
 @implementer(IExpandableElement)
 @adapter(Interface, IOpengeverBaseLayer)
 class Navigation(object):
@@ -60,10 +50,23 @@ class Navigation(object):
             path='/'.join(root.getPhysicalPath()),
             sort_on='sortable_title',
         )
-        nodes = map(brain_to_node, items)
+
+        nodes = map(self.brain_to_node, items)
         result['navigation']['tree'] = make_tree_by_url(nodes)
 
         return result
+
+    def brain_to_node(self, brain):
+        return {
+            '@type': brain.portal_type,
+            'text': brain.Title,
+            'description': brain.Description,
+            'url': brain.getURL(),
+            'uid': brain.UID,
+            'active': brain.review_state != REPOSITORY_FOLDER_STATE_INACTIVE,
+            'current': self.context.absolute_url() == brain.getURL(),
+            'current_tree': self.context.absolute_url().startswith(brain.getURL()),
+        }
 
 
 class NavigationGet(Service):

--- a/opengever/api/navigation.py
+++ b/opengever/api/navigation.py
@@ -32,9 +32,22 @@ class Navigation(object):
 
         context = self.context
 
-        while (not root_interface.providedBy(context)
-               and not IPloneSiteRoot.providedBy(context)):
-            context = aq_parent(context)
+        if root_interface not in content_interfaces:
+            while (not root_interface.providedBy(context)
+                   and not IPloneSiteRoot.providedBy(context)):
+                context = aq_parent(context)
+        else:
+            # This happens i.e. on lookup a dossier tree from a subdossier.
+            #
+            # The current context is the subdossier which is also
+            # providing the root_interface. We have to get sure, that we return
+            # the most upper object providing the given root_interface if
+            # the root_interface is within `content_interfaces`
+            current = context
+            while (not IPloneSiteRoot.providedBy(current)):
+                if root_interface.providedBy(current):
+                    context = current
+                current = aq_parent(current)
 
         if root_interface.providedBy(context):
             root = context

--- a/opengever/api/navigation.py
+++ b/opengever/api/navigation.py
@@ -27,6 +27,9 @@ class Navigation(object):
         root_interface = self.get_root_interface()
         content_interfaces = self.get_content_interfaces()
 
+        if self.request.form.get('include_root'):
+            content_interfaces.append(root_interface)
+
         context = self.context
 
         while (not root_interface.providedBy(context)

--- a/opengever/api/tests/test_navigation.py
+++ b/opengever/api/tests/test_navigation.py
@@ -1,5 +1,6 @@
 from ftw.testbrowser import browsing
 from opengever.testing import IntegrationTestCase
+from urllib import urlencode
 
 
 def flatten_tree(items):
@@ -89,3 +90,58 @@ class TestNavigation(IntegrationTestCase):
             [self.branch_repofolder.UID(), self.leaf_repofolder.UID()],
             [item.get('uid') for item in current_items])
 
+    @browsing
+    def test_navigation_content_objects_can_be_overridden(self, browser):
+        self.login(self.workspace_member, browser)
+        params = [
+            ('root_interface', 'opengever.workspace.interfaces.IWorkspace'),
+            ('content_interfaces', 'opengever.workspace.interfaces.IWorkspaceFolder')
+        ]
+
+        browser.open(
+            self.workspace.absolute_url() + '/@navigation?{}'.format(urlencode(params)),
+            headers={'Accept': 'application/json'},
+        )
+        self.assertEqual(browser.status_code, 200)
+
+        items = flatten_tree(browser.json.get('tree'))
+
+        self.assertEqual(
+            [self.workspace_folder.UID()],
+            [item.get('uid') for item in items])
+
+    @browsing
+    def test_raises_bad_request_when_not_existing_root_interface_provided(self, browser):
+        self.login(self.workspace_member, browser)
+        params = [
+            ('root_interface', 'not.existing.Interface'),
+        ]
+
+        with browser.expect_http_error(400):
+            browser.open(
+                self.workspace.absolute_url() + '/@navigation?{}'.format(urlencode(params)),
+                headers={'Accept': 'application/json'},
+            )
+
+        self.assertEqual(
+            {"message": "The provided `root_interface` could not be looked up: not.existing.Interface",
+             "type": "BadRequest"},
+            browser.json)
+
+    @browsing
+    def test_raises_bad_request_when_not_existing_content_interfaces_provided(self, browser):
+        self.login(self.workspace_member, browser)
+        params = [
+            ('content_interfaces', 'not.existing.Interface'),
+        ]
+
+        with browser.expect_http_error(400):
+            browser.open(
+                self.workspace.absolute_url() + '/@navigation?{}'.format(urlencode(params)),
+                headers={'Accept': 'application/json'},
+            )
+
+        self.assertEqual(
+            {"message": "The provided `content_interfaces` could not be looked up: not.existing.Interface",
+             "type": "BadRequest"},
+            browser.json)

--- a/opengever/api/tests/test_navigation.py
+++ b/opengever/api/tests/test_navigation.py
@@ -145,3 +145,24 @@ class TestNavigation(IntegrationTestCase):
             {"message": "The provided `content_interfaces` could not be looked up: not.existing.Interface",
              "type": "BadRequest"},
             browser.json)
+
+    @browsing
+    def test_allow_including_root_object(self, browser):
+        self.login(self.workspace_member, browser)
+        params = [
+            ('root_interface', 'opengever.workspace.interfaces.IWorkspace'),
+            ('content_interfaces', 'opengever.workspace.interfaces.IWorkspaceFolder'),
+            ('include_root', True)
+        ]
+
+        browser.open(
+            self.workspace.absolute_url() + '/@navigation?{}'.format(urlencode(params)),
+            headers={'Accept': 'application/json'},
+        )
+        self.assertEqual(browser.status_code, 200)
+
+        items = flatten_tree(browser.json.get('tree'))
+
+        self.assertEqual(
+            [self.workspace.UID(), self.workspace_folder.UID()],
+            [item.get('uid') for item in items])

--- a/opengever/api/tests/test_navigation.py
+++ b/opengever/api/tests/test_navigation.py
@@ -111,6 +111,25 @@ class TestNavigation(IntegrationTestCase):
             [item.get('uid') for item in items])
 
     @browsing
+    def test_lookup_propper_root_if_root_interface_is_within_content_interfaces(self, browser):
+        self.login(self.workspace_member, browser)
+        params = [
+            ('root_interface', 'opengever.dossier.businesscase.IBusinessCaseDossier'),
+            ('content_interfaces', 'opengever.dossier.businesscase.IBusinessCaseDossier')
+        ]
+
+        browser.open(
+            self.subdossier.absolute_url() + '/@navigation?{}'.format(urlencode(params)),
+            headers={'Accept': 'application/json'},
+        )
+        self.assertEqual(browser.status_code, 200)
+
+        self.assertEqual(
+            self.dossier.UID(),
+            browser.json.get('tree')[0].get('uid'),
+            "The root-object needs to be the last IBusinessCaseDossier")
+
+    @browsing
     def test_raises_bad_request_when_not_existing_root_interface_provided(self, browser):
         self.login(self.workspace_member, browser)
         params = [

--- a/opengever/api/tests/test_navigation.py
+++ b/opengever/api/tests/test_navigation.py
@@ -2,6 +2,18 @@ from ftw.testbrowser import browsing
 from opengever.testing import IntegrationTestCase
 
 
+def flatten_tree(items):
+    flattened_items = []
+
+    def flatten(items):
+        for item in items:
+            flattened_items.append(item)
+            flatten(item.get('nodes', []))
+
+    flatten(items)
+    return flattened_items
+
+
 class TestNavigation(IntegrationTestCase):
 
     @browsing
@@ -41,3 +53,39 @@ class TestNavigation(IntegrationTestCase):
         self.assertEqual(
             browser.json['@components']['navigation']['@id'],
             u'http://nohost/plone/ordnungssystem/@navigation')
+
+    @browsing
+    def test_current_context_item_is_marked(self, browser):
+        self.login(self.regular_user, browser)
+        browser.open(
+            self.leaf_repofolder.absolute_url() + '/@navigation',
+            headers={'Accept': 'application/json'},
+        )
+        self.assertEqual(browser.status_code, 200)
+
+        current_items = filter(
+            lambda item: item.get('current'),
+            flatten_tree(browser.json.get('tree')))
+
+        self.assertEqual(1, len(current_items))
+
+        current_item = current_items[0]
+        self.assertEqual(current_item.get('uid'), self.leaf_repofolder.UID())
+
+    @browsing
+    def test_current_tree_items_are_marked(self, browser):
+        self.login(self.regular_user, browser)
+        browser.open(
+            self.dossier.absolute_url() + '/@navigation',
+            headers={'Accept': 'application/json'},
+        )
+        self.assertEqual(browser.status_code, 200)
+
+        current_items = filter(
+            lambda item: item.get('current_tree'),
+            flatten_tree(browser.json.get('tree')))
+
+        self.assertEqual(
+            [self.branch_repofolder.UID(), self.leaf_repofolder.UID()],
+            [item.get('uid') for item in current_items])
+


### PR DESCRIPTION
Add the following properties to a navigation-item:

- `@type`
- `current`
- `current_tree`


Add the following query-params to the `@navigation` endpoint:

- `include_root`
- `root_interface`
- `content_interfaces` 

Issuer: https://github.com/4teamwork/gever-ui/pull/107