### PR TITLE
Display a portal warning on the overview of trashed documents

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -14,6 +14,7 @@ Changelog
 - Add WebActionsProvider. [njohner]
 - Add mapping between public and gever permissions. [njohner]
 - Disable CSRF protect on webaction api post requests. [njohner]
+- Warn the user on overviews and overlays of trashed mails or documents. [Rotonen]
 - Update plone.rest api to 3.7.2. [mathias.leimgruber]
 - Respect tabbedview settings when generating an task or dossier excel export. [phgross]
 - Exclusively handle templates on Committee and not on CommitteeContainer anymore. [njohner]

--- a/opengever/bumblebee/browser/templates/bumblebeeoverlay.pt
+++ b/opengever/bumblebee/browser/templates/bumblebeeoverlay.pt
@@ -48,6 +48,12 @@
     <div class="info-viewlets">
       <div tal:replace="structure view/overlay/render_checked_out_viewlet" />
       <div tal:replace="structure view/overlay/render_lock_info_viewlet" />
+      <div tal:define="message view/overlay/trash_warning" tal:condition="message">
+        <dl class="portalMessage warning">
+          <dt i18n:domain="plone" i18n:translate="">Warning</dt>
+          <dd tal:content="message | nothing" />
+        </dl>
+      </div>
       <div tal:condition="not: view/overlay/is_latest_version">
         <dl class="portalMessage warning">
           <dt i18n:domain="plone" i18n:translate="">Warning</dt>

--- a/opengever/document/browser/tabbed.py
+++ b/opengever/document/browser/tabbed.py
@@ -1,5 +1,8 @@
 from ftw.tabbedview.browser.tabbed import TabbedView
+from opengever.document import _
 from opengever.document.interfaces import ICheckinCheckoutManager
+from opengever.trash.trash import ITrashed
+from plone import api
 from zope.component import getMultiAdapter
 
 
@@ -7,6 +10,22 @@ class DocumentTabbedView(TabbedView):
     """Tabbedview for documentish types, implements a separate check for the
     uploadbox, to allow drag and drop replacing of a file.
     """
+
+    def __init__(self, context, request):
+        """Slap a warning onto the overview of a trashed document.
+
+        We're asserting on the request not having a form as the tabs themselves,
+        which get requested by AJAX, rely on a form in the request data. If
+        we'd also slap the portal warning onto those requests, the next 'full'
+        page view would display them, as the tabs do not consume a portal
+        warning.
+        """
+        super(DocumentTabbedView, self).__init__(context, request)
+        if ITrashed.providedBy(self.context):
+            if not self.request.form:
+                msg = _(
+                    u'warning_trashed', default=u'This document is trashed.')
+                api.portal.show_message(msg, self.request, type='warning')
 
     def show_uploadbox(self):
         """Only checks if a file_upload is available, means document is

--- a/opengever/document/locales/de/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/de/LC_MESSAGES/opengever.document.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2018-11-08 13:36+0000\n"
+"POT-Creation-Date: 2019-03-26 18:31+0000\n"
 "PO-Revision-Date: 2017-10-13 14:27+0200\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -698,6 +698,11 @@ msgstr "Version"
 #: ./opengever/document/browser/templates/downloadconfirmation.pt
 msgid "warning_download_confirmation"
 msgstr "Bitte beachten Sie, dass in diesem Fall Änderungen an diesem Dokument NICHT in GEVER gespeichert werden."
+
+#. Default: "This document is trashed."
+#: ./opengever/document/browser/tabbed.py
+msgid "warning_trashed"
+msgstr "Dieses Dokument befindet sich im Papierkorb."
 
 #: ./opengever/document/upgrades/profiles/4000/actions.xml
 msgid "with comment"

--- a/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-11-08 13:36+0000\n"
+"POT-Creation-Date: 2019-03-26 18:31+0000\n"
 "PO-Revision-Date: 2017-09-03 08:50+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-document/fr/>\n"
@@ -695,6 +695,11 @@ msgstr "Version"
 #: ./opengever/document/browser/templates/downloadconfirmation.pt
 msgid "warning_download_confirmation"
 msgstr "Attention! En ouvrant le document de cette manière, toutes les modifications apportées ne seront PAS sauvegardées en GEVER."
+
+#. Default: "This document is trashed."
+#: ./opengever/document/browser/tabbed.py
+msgid "warning_trashed"
+msgstr ""
 
 #: ./opengever/document/upgrades/profiles/4000/actions.xml
 msgid "with comment"

--- a/opengever/document/locales/opengever.document.pot
+++ b/opengever/document/locales/opengever.document.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-11-08 13:36+0000\n"
+"POT-Creation-Date: 2019-03-26 18:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -694,6 +694,11 @@ msgstr ""
 #. Default: "Please note that in this case changes on the document wouldn't be saved in to GEVER."
 #: ./opengever/document/browser/templates/downloadconfirmation.pt
 msgid "warning_download_confirmation"
+msgstr ""
+
+#. Default: "This document is trashed."
+#: ./opengever/document/browser/tabbed.py
+msgid "warning_trashed"
 msgstr ""
 
 #: ./opengever/document/upgrades/profiles/4000/actions.xml

--- a/opengever/mail/browser/tabbed.py
+++ b/opengever/mail/browser/tabbed.py
@@ -1,6 +1,7 @@
 from opengever.mail import _
 from opengever.mail.interfaces import IMailTabbedviewSettings
 from opengever.tabbedview import GeverTabbedView
+from opengever.trash.trash import ITrashed
 from plone import api
 
 
@@ -23,6 +24,21 @@ class MailTabbedView(GeverTabbedView):
         'id': 'sharing',
         'title': _(u'label_sharing', default=u'Sharing'),
         }
+
+    def __init__(self, context, request):
+        """Slap a warning onto the overview of a trashed mail.
+
+        We're asserting on the request not having a form as the tabs themselves,
+        which get requested by AJAX, rely on a form in the request data. If
+        we'd also slap the portal warning onto those requests, the next 'full'
+        page view would display them, as the tabs do not consume a portal
+        warning.
+        """
+        super(MailTabbedView, self).__init__(context, request)
+        if ITrashed.providedBy(self.context):
+            if not self.request.form:
+                msg = _(u'warning_trashed', default=u'This mail is trashed.')
+                api.portal.show_message(msg, self.request, type='warning')
 
     @property
     def preview_tab(self):

--- a/opengever/mail/locales/de/LC_MESSAGES/opengever.mail.po
+++ b/opengever/mail/locales/de/LC_MESSAGES/opengever.mail.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-06-19 16:36+0000\n"
+"POT-Creation-Date: 2019-03-20 17:02+0000\n"
 "PO-Revision-Date: 2016-07-22 16:52+0000\n"
 "Last-Translator: Philippe Gross <gross.philippe@gmail.com>\n"
 "Language-Team: German <https://translations.onegovgever.ch/projects/onegov-gever/opengever-mail/de/>\n"
@@ -244,3 +244,8 @@ msgstr "E-Mails"
 #: ./opengever/mail/browser/send_document.py
 msgid "receiver"
 msgstr "Empfänger"
+
+#. Default: "This mail is trashed."
+#: ./opengever/mail/browser/tabbed.py
+msgid "warning_trashed"
+msgstr "Das E-Mail ist im Papierkorb."

--- a/opengever/mail/locales/fr/LC_MESSAGES/opengever.mail.po
+++ b/opengever/mail/locales/fr/LC_MESSAGES/opengever.mail.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-06-19 16:36+0000\n"
+"POT-Creation-Date: 2019-03-20 17:02+0000\n"
 "PO-Revision-Date: 2017-09-04 06:15+0000\n"
 "Last-Translator: Philippe Gross <gross.philippe@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-mail/fr/>\n"
@@ -244,3 +244,8 @@ msgstr "E-mails"
 #: ./opengever/mail/browser/send_document.py
 msgid "receiver"
 msgstr "Destinataire"
+
+#. Default: "This mail is trashed."
+#: ./opengever/mail/browser/tabbed.py
+msgid "warning_trashed"
+msgstr ""

--- a/opengever/mail/locales/opengever.mail.pot
+++ b/opengever/mail/locales/opengever.mail.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-06-19 16:36+0000\n"
+"POT-Creation-Date: 2019-03-20 17:02+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -244,4 +244,9 @@ msgstr ""
 
 #: ./opengever/mail/browser/send_document.py
 msgid "receiver"
+msgstr ""
+
+#. Default: "This mail is trashed."
+#: ./opengever/mail/browser/tabbed.py
+msgid "warning_trashed"
 msgstr ""

--- a/opengever/trash/tests/test_trash.py
+++ b/opengever/trash/tests/test_trash.py
@@ -2,6 +2,7 @@ from AccessControl.Permission import Permission
 from ftw.testbrowser import browsing
 from ftw.testbrowser.pages.statusmessages import error_messages
 from ftw.testbrowser.pages.statusmessages import info_messages
+from ftw.testbrowser.pages.statusmessages import warning_messages
 from opengever.testing import IntegrationTestCase
 from opengever.testing import obj2brain
 from opengever.trash.remover import Remover
@@ -39,6 +40,156 @@ class TestTrash(IntegrationTestCase):
             info_messages())
         self.assertEquals(
             '{}#documents'.format(self.dossier.absolute_url()), browser.url)
+
+    @browsing
+    def test_shows_statusmessage_on_trashed_document(self, browser):
+        self.login(self.regular_user, browser)
+        browser.open(
+            self.dossier,
+            view='trashed',
+            data=self.make_path_param(self.subdocument),
+            send_authenticator=True,
+        )
+        browser.open(self.subdocument)
+        self.assertEqual(['This document is trashed.'], warning_messages())
+
+    @browsing
+    def test_does_not_show_statusmessage_on_next_view_after_viewing_trashed_document(self, browser):
+        self.login(self.regular_user, browser)
+        browser.open(
+            self.dossier,
+            view='trashed',
+            data=self.make_path_param(self.subdocument),
+            send_authenticator=True,
+        )
+        browser.open(self.subdocument)
+        browser.open(self.dossier)
+        self.assertEqual([], warning_messages())
+
+    @browsing
+    def test_does_not_show_statusmessage_on_tab_of_trashed_document(self, browser):
+        self.login(self.regular_user, browser)
+        browser.open(
+            self.dossier,
+            view='trashed',
+            data=self.make_path_param(self.subdocument),
+            send_authenticator=True,
+        )
+        browser.open(self.subdocument, view='tabbedview_view-overview')
+        self.assertEqual([], warning_messages())
+
+    @browsing
+    def test_does_not_show_statusmessage_on_next_view_after_viewing_a_tab_of_a_trashed_document(self, browser):
+        self.login(self.regular_user, browser)
+        browser.open(
+            self.dossier,
+            view='trashed',
+            data=self.make_path_param(self.subdocument),
+            send_authenticator=True,
+        )
+        browser.open(self.subdocument, view='tabbedview_view-overview')
+        browser.open(self.dossier)
+        self.assertEqual([], warning_messages())
+
+    @browsing
+    def test_shows_statusmessage_on_trashed_mail_eml(self, browser):
+        self.login(self.regular_user, browser)
+        browser.open(
+            self.dossier,
+            view='trashed',
+            data=self.make_path_param(self.mail_eml),
+            send_authenticator=True,
+        )
+        browser.open(self.mail_eml)
+        self.assertEqual(['This mail is trashed.'], warning_messages())
+
+    @browsing
+    def test_does_not_show_statusmessage_on_next_view_after_viewing_trashed_mail_eml(self, browser):
+        self.login(self.regular_user, browser)
+        browser.open(
+            self.dossier,
+            view='trashed',
+            data=self.make_path_param(self.mail_eml),
+            send_authenticator=True,
+        )
+        browser.open(self.mail_eml)
+        browser.open(self.dossier)
+        self.assertEqual([], warning_messages())
+
+    @browsing
+    def test_does_not_show_statusmessage_on_tab_of_trashed_mail_eml(self, browser):
+        self.login(self.regular_user, browser)
+        browser.open(
+            self.dossier,
+            view='trashed',
+            data=self.make_path_param(self.mail_eml),
+            send_authenticator=True,
+        )
+        browser.open(self.mail_eml, view='tabbedview_view-overview')
+        self.assertEqual([], warning_messages())
+
+    @browsing
+    def test_does_not_show_statusmessage_on_next_view_after_viewing_a_tab_of_a_trashed_mail_eml(self, browser):
+        self.login(self.regular_user, browser)
+        browser.open(
+            self.dossier,
+            view='trashed',
+            data=self.make_path_param(self.mail_eml),
+            send_authenticator=True,
+        )
+        browser.open(self.mail_eml, view='tabbedview_view-overview')
+        browser.open(self.dossier)
+        self.assertEqual([], warning_messages())
+
+    @browsing
+    def test_shows_statusmessage_on_trashed_mail_msg(self, browser):
+        self.login(self.regular_user, browser)
+        browser.open(
+            self.dossier,
+            view='trashed',
+            data=self.make_path_param(self.mail_msg),
+            send_authenticator=True,
+        )
+        browser.open(self.mail_msg)
+        self.assertEqual(['This mail is trashed.'], warning_messages())
+
+    @browsing
+    def test_does_not_show_statusmessage_on_next_view_after_viewing_trashed_mail_msg(self, browser):
+        self.login(self.regular_user, browser)
+        browser.open(
+            self.dossier,
+            view='trashed',
+            data=self.make_path_param(self.mail_msg),
+            send_authenticator=True,
+        )
+        browser.open(self.mail_msg)
+        browser.open(self.dossier)
+        self.assertEqual([], warning_messages())
+
+    @browsing
+    def test_does_not_show_statusmessage_on_tab_of_trashed_mail_msg(self, browser):
+        self.login(self.regular_user, browser)
+        browser.open(
+            self.dossier,
+            view='trashed',
+            data=self.make_path_param(self.mail_msg),
+            send_authenticator=True,
+        )
+        browser.open(self.mail_msg, view='tabbedview_view-overview')
+        self.assertEqual([], warning_messages())
+
+    @browsing
+    def test_does_not_show_statusmessage_on_next_view_after_viewing_a_tab_of_a_trashed_mail_msg(self, browser):
+        self.login(self.regular_user, browser)
+        browser.open(
+            self.dossier,
+            view='trashed',
+            data=self.make_path_param(self.mail_msg),
+            send_authenticator=True,
+        )
+        browser.open(self.mail_msg, view='tabbedview_view-overview')
+        browser.open(self.dossier)
+        self.assertEqual([], warning_messages())
 
     @browsing
     def test_redirect_back_and_shows_message_when_no_items_is_selected(self, browser):
@@ -170,3 +321,123 @@ class TestUntrash(IntegrationTestCase):
 
         browser.open(self.empty_dossier, view="untrashed", data=data)
         self.assertFalse(ITrashed.providedBy(self.empty_document))
+
+
+class TestTrashWithBumblebee(IntegrationTestCase):
+
+    features = ('bumblebee',)
+
+    @browsing
+    def test_shows_statusmessage_on_trashed_document_bumblebee_document_overlay(self, browser):
+        self.login(self.regular_user, browser)
+        browser.open(
+            self.dossier,
+            view='trashed',
+            data=self.make_path_param(self.subdocument),
+            send_authenticator=True,
+        )
+        browser.open(self.subdocument, view='bumblebee-overlay-document')
+        self.assertEqual(
+            ['This document is trashed.'],
+            browser.css('.portalMessage.warning dd').text,
+        )
+
+    @browsing
+    def test_shows_statusmessage_on_trashed_document_bumblebee_listing_overlay(self, browser):
+        self.login(self.regular_user, browser)
+        browser.open(
+            self.dossier,
+            view='trashed',
+            data=self.make_path_param(self.subdocument),
+            send_authenticator=True,
+        )
+        browser.open(self.subdocument, view='bumblebee-overlay-listing')
+        self.assertEqual(
+            ['This document is trashed.'],
+            browser.css('.portalMessage.warning dd').text,
+        )
+
+    @browsing
+    def test_shows_statusmessage_on_trashed_document_bumblebee_version_listing_overlay(self, browser):
+        self.login(self.regular_user, browser)
+        # Ensure we have two versions of the document
+        self.checkout_document(self.subdocument)
+        self.checkin_document(self.subdocument)
+        self.checkout_document(self.subdocument)
+        self.checkin_document(self.subdocument)
+        browser.open(
+            self.dossier,
+            view='trashed',
+            data=self.make_path_param(self.subdocument),
+            send_authenticator=True,
+        )
+        browser.open(self.subdocument, view='bumblebee-overlay-listing?version_id=0')
+        self.assertEqual(
+            ['This document is trashed.', 'You are looking at a versioned file.'],
+            browser.css('.portalMessage.warning dd').text,
+        )
+        browser.open(self.subdocument, view='bumblebee-overlay-listing?version_id=1')
+        self.assertEqual(
+            ['This document is trashed.'],
+            browser.css('.portalMessage.warning dd').text,
+        )
+
+    @browsing
+    def test_shows_statusmessage_on_trashed_mail_eml_bumblebee_document_overlay(self, browser):
+        self.login(self.regular_user, browser)
+        browser.open(
+            self.dossier,
+            view='trashed',
+            data=self.make_path_param(self.mail_eml),
+            send_authenticator=True,
+        )
+        browser.open(self.mail_eml, view='bumblebee-overlay-document')
+        self.assertEqual(
+            ['This mail is trashed.'],
+            browser.css('.portalMessage.warning dd').text,
+        )
+
+    @browsing
+    def test_shows_statusmessage_on_trashed_mail_eml_bumblebee_listing_overlay(self, browser):
+        self.login(self.regular_user, browser)
+        browser.open(
+            self.dossier,
+            view='trashed',
+            data=self.make_path_param(self.mail_eml),
+            send_authenticator=True,
+        )
+        browser.open(self.mail_eml, view='bumblebee-overlay-listing')
+        self.assertEqual(
+            ['This mail is trashed.'],
+            browser.css('.portalMessage.warning dd').text,
+        )
+
+    @browsing
+    def test_shows_statusmessage_on_trashed_mail_msg_bumblebee_document_overlay(self, browser):
+        self.login(self.regular_user, browser)
+        browser.open(
+            self.dossier,
+            view='trashed',
+            data=self.make_path_param(self.mail_msg),
+            send_authenticator=True,
+        )
+        browser.open(self.mail_msg, view='bumblebee-overlay-document')
+        self.assertEqual(
+            ['This mail is trashed.'],
+            browser.css('.portalMessage.warning dd').text,
+        )
+
+    @browsing
+    def test_shows_statusmessage_on_trashed_mail_msg_bumblebee_listing_overlay(self, browser):
+        self.login(self.regular_user, browser)
+        browser.open(
+            self.dossier,
+            view='trashed',
+            data=self.make_path_param(self.mail_msg),
+            send_authenticator=True,
+        )
+        browser.open(self.mail_msg, view='bumblebee-overlay-listing')
+        self.assertEqual(
+            ['This mail is trashed.'],
+            browser.css('.portalMessage.warning dd').text,
+        )


### PR DESCRIPTION
* Adding a portal warning onto the tabbedview of a document or a mail
  * Only if the request is a 'simple get'
* Adding a warning to bumblebee overlays for documents and mails
* Added a versioned attribute to the versioned overlay as the adapter loses the context proper

Document overview:
![Screenshot 2019-03-25 at 15 46 29](https://user-images.githubusercontent.com/935317/54929129-60e46880-4f15-11e9-9602-30af56d8c2c7.png)

Document overview overlay:
![Screenshot 2019-03-25 at 15 46 40](https://user-images.githubusercontent.com/935317/54929196-7a85b000-4f15-11e9-8ac8-0bf1d54ea697.png)

Document version listing overlay of current version:
![Screenshot 2019-03-25 at 15 47 05](https://user-images.githubusercontent.com/935317/54929215-81acbe00-4f15-11e9-8157-d0da59a8212f.png)

Document version listing overlay of old version:
![Screenshot 2019-03-25 at 15 47 12](https://user-images.githubusercontent.com/935317/54929303-9f7a2300-4f15-11e9-8700-fcf086ef9da2.png)

Closes #5481 