### PR TITLE
Fix upgrade step that reindexes object_provides for PDFs so it performs better

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2019.2.0 (unreleased)
 ---------------------
 
+- Fix upgrade step that reindexes object_provides for PDFs so it performs better. [lgraf]
 - Update plone.rest api to 3.7.2. [mathias.leimgruber]
 - Respect tabbedview settings when generating an task or dossier excel export. [phgross]
 - Fix performance issue with search root exclusion in tabbed view listings. [lgraf]

--- a/opengever/core/upgrades/20190307132714_fix_task_and_journal_pdf_object_provides/upgrade.py
+++ b/opengever/core/upgrades/20190307132714_fix_task_and_journal_pdf_object_provides/upgrade.py
@@ -24,7 +24,7 @@ class FixTaskAndJournalPDFObjectProvides(UpgradeStep):
         possible_titles = [title_fr, title_de, title_en]
 
         for title in possible_titles:
-            query = {'portal_type': 'opengever.document.document', 'title': title}
+            query = {'portal_type': 'opengever.document.document', 'Title': title}
             for brain in self.catalog_unrestricted_search(query):
                 # If the interface is already in the index, we can skip
                 if journal_interface_name in object_provides.getEntryForObject(brain.getRID(), ""):
@@ -41,7 +41,7 @@ class FixTaskAndJournalPDFObjectProvides(UpgradeStep):
         possible_titles = [title_fr, title_de, title_en]
 
         for title in possible_titles:
-            query = {'portal_type': 'opengever.document.document', 'title': title}
+            query = {'portal_type': 'opengever.document.document', 'Title': title}
             for brain in self.catalog_unrestricted_search(query):
                 # If the interface is already in the index, we can skip
                 if task_interface_name in object_provides.getEntryForObject(brain.getRID(), ""):


### PR DESCRIPTION
Because the index name was misspelled in the query (`title` instead of `Title`), the initial query returned all documents, leading to many unnecessary objects getting checked. With this fix the query runs as originally intended.

I also verified that the new query does indeed match and find the automatically generated PDF documents that are supposed to be reindexed.

_Needs to be backported to `2019.1.x` (and possibly `2018.5.x`)._ 