### PR TITLE
Add solrsearch REST API endpoint.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ---------------------
 
 - Move translation overrides for ftw.mail from og.mail to og.base. [lgraf]
+- Add solrsearch REST API endpoint. [phgross]
 - Fix upgrade step that reindexes object_provides for PDFs so it performs better. [lgraf]
 - Add webactions in user menu. [njohner]
 - Add webaction action-buttons for documents, tasks and proposals. [njohner]

--- a/docs/public/dev-manual/api/searching.rst
+++ b/docs/public/dev-manual/api/searching.rst
@@ -104,3 +104,48 @@ darzustellen, kann ``metadata_fields=_all`` verwendet werden.
     einen separaten Mechanismus.
 
 .. disqus::
+
+
+Solr Suche
+----------
+Um direkt eine Suchabfrage an den Solr Service abzusetzen, steht der ``@solrsearch`` Endpoint zur Verfügung. Für die Abfrage kann SOLR API Syntax und dessen Parameter verwendet werden. Der Endpoint liefert ein Liste von Treffern zurück mit den im Parameter ``fl`` definierten Felder. Die folgende Parameter sind zurzeit vom Endpoint unterstützt:
+
+
+Query
+~~~~~
+``q``: Query in Solr syntax.
+
+Beipsiel für eine Suchabfrage nach dem Titel Kurzinfo:
+
+.. sourcecode:: http
+
+  GET /plone/@solrsearch?query=Title:Kurz* HTTP/1.1
+
+
+Filters
+~~~~~~~
+``fq``: Filtern nach einem bestimmten Wert eines Feldes.
+
+Beispiel für ein Suchabfrage gefiltert nach portal_type nur für Dokumente und Dossiers
+
+.. sourcecode:: http
+
+  GET /plone/@solrsearch?fq=portal_type:(opengever.document.document%20OR%20opengever.dossier.businesscasedossier) HTTP/1.1
+
+
+Fields
+~~~~~~
+``fl``: Liste der Felder, die zurückgegeben werden sollen. Standardmässig werden die Felder ``UID``, ``Title``, ``Description``, ``path`` zurückgegeben.
+
+Beispiel für ein Suchabfrage, mit id, Title und Laufnummer als Resultat
+
+.. sourcecode:: http
+
+  GET /plone/@solrsearch?query=Title:Kurz*&fl=id,Title,sequence_number HTTP/1.1
+
+
+Weitere optionale Parameter:
+
+- ``start``: Das erste zurückzugebende Element
+- ``rows``: Die maximale Anzahl der zurückzugebenden Elemente
+- ``sort``: Sortierung nach einem indexierten Feld

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -264,6 +264,14 @@
       />
 
   <plone:service
+      method="GET"
+      for="zope.interface.Interface"
+      factory=".solrsearch.SolrSearchGet"
+      name="@solrsearch"
+      permission="zope2.View"
+      />
+
+  <plone:service
       method="POST"
       name="@webactions"
       for="Products.CMFPlone.interfaces.IPloneSiteRoot"

--- a/opengever/api/solrsearch.py
+++ b/opengever/api/solrsearch.py
@@ -1,0 +1,45 @@
+from ftw.solr.interfaces import ISolrSearch
+from opengever.base.interfaces import ISearchSettings
+from plone import api
+from plone.restapi.services import Service
+from zExceptions import BadRequest
+from zope.component import getUtility
+
+
+class SolrSearchGet(Service):
+    """REST API endpoint to querying SOLR
+    """
+
+    DEFAULT_RESULT_FIELDS = ['UID', 'Title', 'Description', 'path']
+    NOT_SUPPORTED_FIELDS = ['SearchableText', 'allowedRolesAndUsers']
+    SUPPORTED_PARAMETERS = {
+        'q': 'query',
+        'fq': 'filters',
+        'start': 'start',
+        'rows': 'rows',
+        'sort': 'sort'}
+
+    def reply(self):
+        if not api.portal.get_registry_record(
+                'use_solr', interface=ISearchSettings):
+            raise BadRequest('Solr is not enabled on this GEVER installation.')
+
+        kwargs = self.request.form
+        kwargs['fl'] = self.update_fields(kwargs.get('fl'))
+
+        for request_name, utility_name in self.SUPPORTED_PARAMETERS.items():
+            if request_name in kwargs:
+                kwargs[utility_name] = kwargs.pop(request_name)
+
+        solr = getUtility(ISolrSearch)
+        res = solr.search(**kwargs)
+        return res.docs
+
+    def update_fields(self, field_string):
+        if not field_string:
+            fields = self.DEFAULT_RESULT_FIELDS
+        else:
+            fields = field_string.split(',')
+
+        return ','.join(
+            [field for field in fields if field not in self.NOT_SUPPORTED_FIELDS])

--- a/opengever/api/tests/test_solrsearch.py
+++ b/opengever/api/tests/test_solrsearch.py
@@ -1,0 +1,111 @@
+from ftw.testbrowser import browsing
+from opengever.testing import IntegrationTestCase
+
+
+class TestSolrSearchGet(IntegrationTestCase):
+
+    # TODO: Replace mock tests using a real solr as soon this
+    # is possible (see #4844).
+
+    api_headers = {'Accept': 'application/json'}
+    features = ['solr']
+
+    solr_search_response = {
+        "responseHeader": {
+            "status": 0,
+            "QTime": 3,
+            "limit": 10,
+            "params": {
+                "json": "{\n  \"query\": \":\"\n}"
+            }
+        },
+        "response": {
+            "numFound": 3,
+            "start": 0,
+            "docs": [
+                {
+                    "UID": "85bed8c49f6d4f8b841693c6a7c6cff1",
+                    "Title": "My Folder 1",
+                },
+                {
+                    "UID": "85a29144758f494c88df19182f749ed6",
+                    "Title": "My Folder 2",
+                },
+                {
+                    "UID": "9398dad21bcd49f8a197cd50d10ea778",
+                    "Title": "My Document",
+                }
+            ]
+        }
+    }
+
+    @browsing
+    def test_raises_bad_request_if_solr_is_not_enabled(self, browser):
+        self.deactivate_feature('solr')
+
+        self.login(self.regular_user, browser=browser)
+
+        with browser.expect_http_error(400):
+            url = u'{}/@solrsearch'.format(self.portal.absolute_url())
+            browser.open(url, method='GET', headers=self.api_headers)
+
+        self.assertEqual(
+            {u'message': u'Solr is not enabled on this GEVER installation.',
+             u'type': u'BadRequest'}, browser.json)
+
+    @browsing
+    def test_passes_known_parameters_to_solr_utility(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        self.solr = self.mock_solr(response_json=self.solr_search_response)
+
+        url = u'{}/@solrsearch?query=Title:Kurz*&fq=portal_type:opengever.document.document'.format(self.portal.absolute_url())
+        browser.open(url, method='GET', headers=self.api_headers)
+
+        self.solr.search.assert_called_once_with(
+            fl='UID,Title,Description,path',
+            filters='portal_type:opengever.document.document',
+            query='Title:Kurz*')
+
+    @browsing
+    def test_fallback_to_default_fields_if_fl_parameter_is_empty(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        self.solr = self.mock_solr(response_json=self.solr_search_response)
+
+        url = u'{}/@solrsearch'.format(self.portal.absolute_url())
+        browser.open(url, method='GET', headers=self.api_headers)
+
+        self.solr.search.assert_called_once_with(fl='UID,Title,Description,path')
+
+    @browsing
+    def test_not_supported_fields_are_skipped(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        self.solr = self.mock_solr(response_json=self.solr_search_response)
+
+        # SearchableText is an unsupported field
+        url = u'{}/@solrsearch?fl=UID,SearchableText,Title'.format(
+            self.portal.absolute_url())
+        browser.open(url, method='GET', headers=self.api_headers)
+
+        self.solr.search.assert_called_once_with(fl='UID,Title')
+
+    @browsing
+    def test_returns_json_serialized_solr_docs(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        self.solr = self.mock_solr(response_json=self.solr_search_response)
+
+        url = u'{}/@solrsearch?fl=UID,Title'.format(
+            self.portal.absolute_url())
+        browser.open(url, method='GET', headers=self.api_headers)
+
+        self.assertEqual(
+            [{u'UID': u'85bed8c49f6d4f8b841693c6a7c6cff1',
+              u'Title': u'My Folder 1'},
+             {u'UID': u'85a29144758f494c88df19182f749ed6',
+              u'Title': u'My Folder 2'},
+             {u'UID': u'9398dad21bcd49f8a197cd50d10ea778',
+              u'Title': u'My Document'}],
+            browser.json)


### PR DESCRIPTION
The endpoint passes the parameter to ftw.solr's SolrSearchUtiliy, so we don't have to care about the security index and preparing the different parameters.

If solr is not enabled the endpoints raises a BadRequest exception.

Closes #5406 