### PR TITLE
Prevent creating private task or switching a task to private when feature is disabled.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -577,6 +577,7 @@ Objects
           - self.info_task
           - self.mail_eml
           - self.mail_msg
+          - self.private_task
           - self.proposal
             - self.proposaldocument
           - self.removed_document

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2019.2.0 (unreleased)
 ---------------------
 
+- Prevent tasks from being created as private or switched to private when feature is not enabled. [Rotonen, phgross]
 - Bump ftw.mail to 2.6.0 to get error logging on inbound mail failures. [lgraf]
 - Handle complex URLs as titles on journal PDF exports. [Rotonen]
 - Move translation overrides for ftw.mail from og.mail to og.base. [lgraf]

--- a/docs/public/dev-manual/api/tasks.rst
+++ b/docs/public/dev-manual/api/tasks.rst
@@ -10,6 +10,7 @@ Auch Aufgaben können via REST API bedient werden. Die Erstellung einer Aufgabe 
 
       POST /(container) HTTP/1.1
       Accept: application/json
+      Content-Type: application/json
 
       {
         "@type": "opengever.task.task",

--- a/opengever/base/tests/test_role_assignments.py
+++ b/opengever/base/tests/test_role_assignments.py
@@ -246,6 +246,16 @@ class TestManageRoleAssignmentsView(IntegrationTestCase):
                     u'title': u'Vertragsentw\xfcrfe 2018',
                 },
                 u'principal': u'kathi.barfuss',
+            },
+            {
+                u'cause': {u'id': 1, u'title': u'By task'},
+                u'roles': [u'Contributor'],
+                u'reference': {
+                    u'url': u'http://nohost/plone/ordnungssystem/fuhrung'
+                            u'/vertrage-und-vereinbarungen/dossier-1/task-12',
+                    u'title': u'Diskr\xe4te Dinge',
+                },
+                u'principal': u'kathi.barfuss',
             }
         ]
         self.assertEquals(expected_assignments, browser.json)

--- a/opengever/dossier/tests/test_overview.py
+++ b/opengever/dossier/tests/test_overview.py
@@ -35,7 +35,8 @@ class TestOverview(IntegrationTestCase):
 
     @property
     def tested_subtask(self):
-        return self.subtask
+        # XXX - not expected, but a quick way around the visibility limit
+        return self.private_task
 
     @property
     def participants(self):
@@ -44,6 +45,17 @@ class TestOverview(IntegrationTestCase):
 
     @property
     def task_titles(self):
+        return [
+            u'Diskr\xe4te Dinge',
+            u'Vertragsentw\xfcrfe 2018',
+            u'Personaleintritt',
+            u'Mitarbeiter Dossier generieren',
+            u'Vertragsentwurf \xdcberpr\xfcfen',
+        ]
+
+    @property
+    def task_titles_minus_pending(self):
+        # As we have more than 5 tasks, they shift in like this
         return [
             u'Vertragsentw\xfcrfe 2018',
             u'Personaleintritt',
@@ -117,11 +129,11 @@ class TestOverview(IntegrationTestCase):
         self.set_workflow_state(
             'task-state-tested-and-closed', self.tested_subtask)
 
-        browser.open(self.tested_dossier,
-                     view='tabbedview_view-overview')
+        browser.open(self.tested_dossier, view='tabbedview_view-overview')
         self.assertSequenceEqual(
-            self.task_titles[:-1],
-            browser.css('#newest_tasksBox li:not(.moreLink) a').text)
+            self.task_titles_minus_pending,
+            browser.css('#newest_tasksBox li:not(.moreLink) a').text,
+        )
 
     @browsing
     def test_participant_labels_are_displayed(self, browser):

--- a/opengever/globalindex/tests/test_query.py
+++ b/opengever/globalindex/tests/test_query.py
@@ -155,7 +155,8 @@ class TestTaskQueries(IntegrationTestCase):
              self.seq_subtask_1.get_sql_object(),
              self.seq_subtask_2.get_sql_object(),
              self.seq_subtask_3.get_sql_object(),
-             self.info_task.get_sql_object()],
+             self.info_task.get_sql_object(),
+             self.private_task.get_sql_object()],
             Task.query.by_container(self.dossier, get_current_admin_unit()).all())
 
     def test_by_container_handles_similar_paths_exactly(self):

--- a/opengever/globalindex/tests/test_query.py
+++ b/opengever/globalindex/tests/test_query.py
@@ -162,7 +162,10 @@ class TestTaskQueries(IntegrationTestCase):
         self.login(self.regular_user)
 
         # manually set a similar physical path than self.task
-        self.sequential_task.get_sql_object().physical_path = 'ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-11/task-3'
+        self.sequential_task.get_sql_object().physical_path = (
+            'ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-11'
+            '/task-3'
+        )  # Do not add commas within this grouping - this is a string!
 
         tasks = Task.query.by_container(self.dossier, get_current_admin_unit()).all()
 

--- a/opengever/globalindex/tests/test_task_sql_syncer.py
+++ b/opengever/globalindex/tests/test_task_sql_syncer.py
@@ -1,124 +1,141 @@
 from datetime import date
-from ftw.builder import Builder
-from ftw.builder import create
 from opengever.base.model import Session
 from opengever.globalindex.model.task import Task
 from opengever.ogds.base.utils import get_current_admin_unit
 from opengever.ogds.base.utils import get_current_org_unit
-from opengever.testing import FunctionalTestCase
+from opengever.testing import IntegrationTestCase
 from plone import api
-from plone.app.testing import TEST_USER_ID
 from zope.event import notify
 from zope.lifecycleevent import ObjectModifiedEvent
 
 
-class TestTaskSQLSyncer(FunctionalTestCase):
-
-    def setUp(self):
-        super(TestTaskSQLSyncer, self).setUp()
-
-        self.dossier = create(Builder('dossier')
-                              .titled(u'dossier'))
-        self.subdossier = create(Builder('dossier')
-                                 .titled(u'subdossier')
-                                 .within(self.dossier))
-        self.task = create(
-            Builder('task')
-            .having(title=u'Mach mau!',
-                    issuer=self.user.userid,
-                    task_type='direct-execution',
-                    responsible_client=get_current_org_unit().id(),
-                    responsible=self.user.userid,
-                    is_private=True,
-                    deadline=date(2010, 1, 1),
-                    text='Lorem ipsum dolor sit amet, consectetur')
-            .within(self.subdossier)
-        )
+class TestTaskSQLSyncer(IntegrationTestCase):
 
     def test_sql_task_is_created_on_plone_object_creation(self):
-        self.assertEqual(1, Session.query(Task).count())
-        task = Session.query(Task).one()
+        self.login(self.regular_user)
+        self.assertEqual(14, Session.query(Task).count())
+
+        # self.private_task
+        task = Session.query(Task).filter(
+            Task.title == u'Diskr\xe4te Dinge').one()
         self.assertEqual(get_current_org_unit().id(), task.assigned_org_unit)
         self.assertEqual(get_current_org_unit().id(), task.issuing_org_unit)
         self.assertEqual(get_current_admin_unit().id(), task.admin_unit_id)
-        self.assertEqual(u'Mach mau!', task.title)
-        self.assertEqual(self.user.userid, task.issuer)
+        self.assertEqual(u'Diskr\xe4te Dinge', task.title)
+        self.assertEqual(self.dossier_responsible.getId(), task.issuer)
         self.assertTrue(task.is_private)
-        self.assertEqual(self.user.userid, task.responsible)
-        self.assertEqual(u'dossier > subdossier > Mach mau!',
-                         task.breadcrumb_title)
-        self.assertEqual(u'task-state-open', task.review_state)
-        self.assertEqual(u'dossier-1/dossier-2/task-1', task.physical_path)
+        self.assertEqual(self.regular_user.getId(), task.responsible)
+        expected_breadcrumbs =(
+            u'Ordnungssystem'
+            u' > 1. F\xfchrung'
+            u' > 1.1. Vertr\xe4ge und Vereinbarungen'
+            u' > Vertr\xe4ge mit der kantonalen Finanzverwaltung'
+            u' > Diskr\xe4te Dinge'
+        )  # Do not add commas here - this is a string!
+        self.assertEqual(expected_breadcrumbs, task.breadcrumb_title)
+        self.assertEqual('task-state-in-progress', task.review_state)
+        self.assertEqual(
+            'ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/task-12',
+            task.physical_path)
         self.assertIsNotNone(task.icon)
-        self.assertEqual(task.deadline, date(2010, 1, 1))
+        self.assertEqual(task.deadline, date(2020, 1, 1))
         self.assertIsNotNone(task.modified)
         self.assertEqual('direct-execution', task.task_type)
         self.assertFalse(task.is_subtask)
-        self.assertEqual(1, task.sequence_number)
-        self.assertEqual('Client1 / 1.1', task.reference_number)
-        self.assertEqual('dossier', task.containing_dossier)
-        self.assertEqual('subdossier', task.containing_subdossier)
-        self.assertEqual(2, task.dossier_sequence_number)
-        self.assertEqual('Lorem ipsum dolor sit amet, consectetur', task.text)
-        self.assertSequenceEqual([TEST_USER_ID], task.principals)
+        self.assertEqual(12, task.sequence_number)
+        self.assertEqual('Client1 1.1 / 1', task.reference_number)
+        self.assertEqual(
+            u'Vertr\xe4ge mit der kantonalen Finanzverwaltung',
+            task.containing_dossier,
+        )
+        self.assertEqual('', task.containing_subdossier)
+        self.assertEqual(1, task.dossier_sequence_number)
+        self.assertEqual(
+            u'L\xf6rem ipsum dolor sit amet, consectetur', task.text)
+        expected_principals = [
+            get_current_org_unit().users_group.id(), self.regular_user.getId()]
+        self.assertItemsEqual(expected_principals, task.principals)
         self.assertIsNone(task.predecessor)
 
     def test_sql_task_is_updated_on_plone_object_update(self):
+        self.login(self.regular_user)
         self.task.responsible_client = 'asd'
-        self.task.title = u'Gopf, iz mach mau'
+        self.task.title = u'G\xf6pf, iz mach mau'
         notify(ObjectModifiedEvent(self.task))
 
-        self.assertEqual(1, Session.query(Task).count())
-        task = Session.query(Task).one()
+        self.assertEqual(14, Session.query(Task).count())
+        task = Session.query(Task).filter(
+            Task.title == u'G\xf6pf, iz mach mau').one()
 
         self.assertEqual('asd', task.assigned_org_unit)
-        self.assertEqual(u'dossier > subdossier > Gopf, iz mach mau',
-                         task.breadcrumb_title)
-        self.assertEqual(u'Gopf, iz mach mau', task.title)
+        expected_breadcrumbs = (
+            u'Ordnungssystem'
+            u' > 1. F\xfchrung'
+            u' > 1.1. Vertr\xe4ge und Vereinbarungen'
+            u' > Vertr\xe4ge mit der kantonalen Finanzverwaltung'
+            u' > G\xf6pf, iz mach mau'
+        )  # Do not add commas here - this is a string!
+        self.assertEqual(expected_breadcrumbs, task.breadcrumb_title)
+        self.assertEqual(u'G\xf6pf, iz mach mau', task.title)
 
         self.assertEqual(get_current_org_unit().id(), task.issuing_org_unit)
         self.assertEqual(get_current_admin_unit().id(), task.admin_unit_id)
-        self.assertEqual(self.user.userid, task.issuer)
-        self.assertEqual(self.user.userid, task.responsible)
-        self.assertEqual(u'task-state-open', task.review_state)
-        self.assertEqual(u'dossier-1/dossier-2/task-1', task.physical_path)
+        self.assertEqual(self.dossier_responsible.getId(), task.issuer)
+        self.assertEqual(self.regular_user.getId(), task.responsible)
+        self.assertEqual('task-state-in-progress', task.review_state)
+        self.assertEqual(
+            'ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/task-1',
+            task.physical_path)
         self.assertIsNotNone(task.icon)
-        self.assertEqual(task.deadline, date(2010, 1, 1))
+        self.assertEqual(task.deadline, date(2016, 11, 1))
         self.assertIsNotNone(task.modified)
-        self.assertEqual('direct-execution', task.task_type)
+        self.assertEqual('correction', task.task_type)
         self.assertFalse(task.is_subtask)
         self.assertEqual(1, task.sequence_number)
-        self.assertEqual('Client1 / 1.1', task.reference_number)
-        self.assertEqual('dossier', task.containing_dossier)
-        self.assertEqual('subdossier', task.containing_subdossier)
-        self.assertEqual(2, task.dossier_sequence_number)
-        self.assertEqual('Lorem ipsum dolor sit amet, consectetur', task.text)
-        self.assertSequenceEqual([TEST_USER_ID], task.principals)
+        self.assertEqual('Client1 1.1 / 1', task.reference_number)
+        self.assertEqual(
+            u'Vertr\xe4ge mit der kantonalen Finanzverwaltung', task.containing_dossier)
+        self.assertEqual('', task.containing_subdossier)
+        self.assertEqual(1, task.dossier_sequence_number)
+        self.assertIsNone(task.text)
+        expected_principals = [
+            get_current_org_unit().users_group.id(), self.regular_user.getId()]
+        self.assertItemsEqual(expected_principals, task.principals)
         self.assertIsNone(task.predecessor)
 
     def test_sql_task_is_updated_when_task_is_moved(self):
-        dossier2 = create(Builder('dossier')
-                          .titled(u'Dossier 2'))
-        subdossier2 = create(Builder('dossier')
-                             .titled(u'Subdossier 2')
-                             .within(dossier2))
+        self.login(self.regular_user)
+        api.content.move(source=self.task, target=self.subdossier)
 
-        api.content.move(source=self.task, target=subdossier2)
-
-        task = Session.query(Task).one()
-        self.assertEqual('Subdossier 2', task.containing_subdossier)
-        self.assertEqual(u'dossier-3/dossier-4/task-1', task.physical_path)
-        self.assertEqual(4, task.dossier_sequence_number)
-        self.assertEqual(u'Client1 / 2.1', task.reference_number)
+        # self.task
+        task = Session.query(Task).filter(
+            Task.title == u'Vertragsentwurf \xdcberpr\xfcfen').one()
+        self.assertEqual(
+            u'Vertr\xe4ge mit der kantonalen Finanzverwaltung',
+            task.containing_dossier,
+        )
+        self.assertEqual('2016', task.containing_subdossier)
+        self.assertEqual(
+            'ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/dossier-2/task-1',
+            task.physical_path)
+        self.assertEqual(2, task.dossier_sequence_number)
+        self.assertEqual('Client1 1.1 / 1.1', task.reference_number)
 
     def test_sql_task_is_updated_when_container_is_moved(self):
-        dossier2 = create(Builder('dossier')
-                          .titled(u'Dossier 2'))
+        self.login(self.regular_user)
+        api.content.move(source=self.dossier, target=self.empty_dossier)
 
-        api.content.move(source=self.subdossier, target=dossier2)
+        # self.task
+        task = Session.query(Task).filter(
+            Task.title == u'Vertragsentwurf \xdcberpr\xfcfen').one()
+        self.assertEqual(u'An empty dossier', task.containing_dossier)
+        self.assertEqual(
+            u'Vertr\xe4ge mit der kantonalen Finanzverwaltung',
+            task.containing_subdossier,
+        )
 
-        task = Session.query(Task).one()
-        self.assertEqual('subdossier', task.containing_subdossier)
-        self.assertEqual(u'dossier-3/dossier-2/task-1', task.physical_path)
-        self.assertEqual(2, task.dossier_sequence_number)
-        self.assertEqual(u'Client1 / 2.1', task.reference_number)
+        self.assertEqual(
+            'ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-7/dossier-1/task-1',
+            task.physical_path)
+        self.assertEqual(1, task.dossier_sequence_number)
+        self.assertEqual('Client1 1.1 / 4.1', task.reference_number)

--- a/opengever/latex/tests/test_dossierjournal.py
+++ b/opengever/latex/tests/test_dossierjournal.py
@@ -195,6 +195,16 @@ class TestJournalListingLaTeXView(IntegrationTestCase):
             {
                 'action': {
                     'visible': True,
+                    'type': 'Task added',
+                    'title': u'label_task_added',
+                },
+                'comments': '',
+                'actor': 'robert.ziegler',
+                'time': DateTime('2016/08/31 18:25:33 GMT+2'),
+            },
+            {
+                'action': {
+                    'visible': True,
                     'type': 'Document added',
                     'title': u'label_document_added',
                 },

--- a/opengever/meeting/tests/test_meeting_dossier_overview.py
+++ b/opengever/meeting/tests/test_meeting_dossier_overview.py
@@ -30,6 +30,10 @@ class TestMeetingDossierOverview(test_overview.TestOverview):
         return [u'Programm \xdcberpr\xfcfen',
                 u'H\xf6rsaal reservieren']
 
+    @property
+    def task_titles_minus_pending(self):
+        return [u'Programm \xdcberpr\xfcfen']
+
     @browsing
     def test_meeting_is_linked_on_overview(self, browser):
         self.login(self.meeting_user, browser)

--- a/opengever/meeting/tests/test_proposal.py
+++ b/opengever/meeting/tests/test_proposal.py
@@ -1156,6 +1156,7 @@ class TestProposal(IntegrationTestCase):
             '[No Subject]',
             u'Antrag f\xfcr Kreiselbau',
             u'Die B\xfcrgschaft',
+            u'Diskr\xe4te Dinge',
             u'Initialvertrag f\xfcr Bearbeitung',
             u'Initialvertrag f\xfcr Bearbeitung',
             'Personaleintritt',

--- a/opengever/tabbedview/tests/test_personaloverview.py
+++ b/opengever/tabbedview/tests/test_personaloverview.py
@@ -181,6 +181,7 @@ class TestGlobalTaskListings(IntegrationTestCase):
             u'Vertragsentw\xfcrfe 2018',
             u'Status \xdcberpr\xfcfen',
             u'Ein notwendiges \xdcbel',
+            u'Diskr\xe4te Dinge',
         ]
         found_tasks = [row.get('Title') for row in browser.css('.listing').first.dicts()]
         self.assertItemsEqual(expected_tasks, found_tasks)
@@ -193,6 +194,7 @@ class TestGlobalTaskListings(IntegrationTestCase):
             u'Vertragsentw\xfcrfe 2018',
             u'Status \xdcberpr\xfcfen',
             u'Ein notwendiges \xdcbel',
+            u'Diskr\xe4te Dinge',
             ]
         found_tasks = [row.get('Title') for row in browser.css('.listing').first.dicts()]
 
@@ -252,6 +254,7 @@ class TestGlobalTaskListings(IntegrationTestCase):
             u'Status \xdcberpr\xfcfen',
             u'Programm \xdcberpr\xfcfen',
             u'H\xf6rsaal reservieren',
+            u'Diskr\xe4te Dinge',
             ]
         found_tasks = [row.get('Title') for row in browser.css('.listing').first.dicts()]
         self.assertEquals(expected_tasks, found_tasks)
@@ -263,6 +266,7 @@ class TestGlobalTaskListings(IntegrationTestCase):
             u'Status \xdcberpr\xfcfen',
             u'Programm \xdcberpr\xfcfen',
             u'H\xf6rsaal reservieren',
+            u'Diskr\xe4te Dinge',
             ]
         found_tasks = [row.get('Title') for row in browser.css('.listing').first.dicts()]
         self.assertEquals(expected_tasks, found_tasks)
@@ -282,6 +286,7 @@ class TestGlobalTaskListings(IntegrationTestCase):
             u'Status \xdcberpr\xfcfen',
             u'Programm \xdcberpr\xfcfen',
             u'H\xf6rsaal reservieren',
+            u'Diskr\xe4te Dinge',
             ]
         found_tasks = [row.get('Title') for row in browser.css('.listing').first.dicts()]
         self.assertItemsEqual(expected_tasks, found_tasks)
@@ -297,6 +302,7 @@ class TestGlobalTaskListings(IntegrationTestCase):
             u'Status \xdcberpr\xfcfen',
             u'Programm \xdcberpr\xfcfen',
             u'H\xf6rsaal reservieren',
+            u'Diskr\xe4te Dinge',
             ]
         found_tasks = [row.get('Title') for row in browser.css('.listing').first.dicts()]
         self.assertItemsEqual(expected_tasks, found_tasks)
@@ -316,6 +322,7 @@ class TestGlobalTaskListings(IntegrationTestCase):
             u'Status \xdcberpr\xfcfen',
             u'Programm \xdcberpr\xfcfen',
             u'H\xf6rsaal reservieren',
+            u'Diskr\xe4te Dinge',
             ]
         found_tasks = [row.get('Title') for row in browser.css('.listing').first.dicts()]
         self.assertItemsEqual(expected_tasks, found_tasks)
@@ -340,6 +347,7 @@ class TestGlobalTaskListings(IntegrationTestCase):
             u'Status \xdcberpr\xfcfen',
             u'Programm \xdcberpr\xfcfen',
             u'H\xf6rsaal reservieren',
+            u'Diskr\xe4te Dinge',
         ]
         found_tasks = [row.get('Title') for row in browser.css('.listing').first.dicts()]
         self.assertItemsEqual(expected_tasks, found_tasks)

--- a/opengever/tabbedview/tests/test_tasklisting.py
+++ b/opengever/tabbedview/tests/test_tasklisting.py
@@ -17,6 +17,7 @@ class TestTaskListing(IntegrationTestCase):
             u'Mitarbeiter Dossier generieren',
             u'Personaleintritt',
             u'Vertragsentw\xfcrfe 2018',
+            u'Diskr\xe4te Dinge',
         ]
         self.assertEquals(expected_tasks, [row.get('Title') for row in table.dicts()])
 
@@ -34,6 +35,7 @@ class TestTaskListing(IntegrationTestCase):
             'Personaleintritt',
             'Vorstellungsrunde bei anderen Mitarbeitern',
             u'Vertragsentw\xfcrfe 2018',
+            u'Diskr\xe4te Dinge',
         ]
         self.assertEqual(expected_tasks, [row.get('Title') for row in table.dicts()])
 

--- a/opengever/task/locales/de/LC_MESSAGES/opengever.task.po
+++ b/opengever/task/locales/de/LC_MESSAGES/opengever.task.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2019-03-07 11:08+0000\n"
+"POT-Creation-Date: 2019-03-28 06:54+0000\n"
 "PO-Revision-Date: 2015-02-17 18:41+0100\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -215,6 +215,11 @@ msgstr "Mandanten-Wechsel sind bei bereits akzeptierten Aufgaben nicht erlaubt."
 #: ./opengever/task/browser/assign.py
 msgid "error_no_team_responsible_in_progress_state"
 msgstr "Teams sind nur bei offenen Aufgaben oder Weiterleitungen als Auftragnehmer erlaubt."
+
+#. Default: "The private task feature is disabled"
+#: ./opengever/task/task.py
+msgid "error_private_task_feature_is_disabled"
+msgstr "Die Funktionalität private Aufgaben ist deaktiviert."
 
 #. Default: "No changes: same responsible selected"
 #: ./opengever/task/browser/assign.py

--- a/opengever/task/locales/fr/LC_MESSAGES/opengever.task.po
+++ b/opengever/task/locales/fr/LC_MESSAGES/opengever.task.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-03-07 11:08+0000\n"
+"POT-Creation-Date: 2019-03-28 06:54+0000\n"
 "PO-Revision-Date: 2017-12-03 11:47+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-task/fr/>\n"
@@ -217,6 +217,11 @@ msgstr ""
 #: ./opengever/task/browser/assign.py
 msgid "error_no_team_responsible_in_progress_state"
 msgstr "Les équipes ne sont autorisées comme mandataires que pour des transmissions ou des tâches ouvertes."
+
+#. Default: "The private task feature is disabled"
+#: ./opengever/task/task.py
+msgid "error_private_task_feature_is_disabled"
+msgstr ""
 
 #. Default: "No changes: same responsible selected"
 #: ./opengever/task/browser/assign.py

--- a/opengever/task/locales/opengever.task.pot
+++ b/opengever/task/locales/opengever.task.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2019-03-07 11:08+0000\n"
+"POT-Creation-Date: 2019-03-28 06:54+0000\n"
 "PO-Revision-Date: 2009-02-25 14:39+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -215,6 +215,11 @@ msgstr ""
 #. Default: "Team responsibles are only allowed if the task or forwarding is open."
 #: ./opengever/task/browser/assign.py
 msgid "error_no_team_responsible_in_progress_state"
+msgstr ""
+
+#. Default: "The private task feature is disabled"
+#: ./opengever/task/task.py
+msgid "error_private_task_feature_is_disabled"
 msgstr ""
 
 #. Default: "No changes: same responsible selected"

--- a/opengever/task/tests/test_forms.py
+++ b/opengever/task/tests/test_forms.py
@@ -95,6 +95,7 @@ class TestTaskEditForm(IntegrationTestCase):
             '[No Subject]',
             u'Antrag f\xfcr Kreiselbau',
             u'Die B\xfcrgschaft',
+            u'Diskr\xe4te Dinge',
             u'Initialvertrag f\xfcr Bearbeitung',
             u'Initialvertrag f\xfcr Bearbeitung',
             'Personaleintritt',

--- a/opengever/task/tests/test_localroles.py
+++ b/opengever/task/tests/test_localroles.py
@@ -266,15 +266,28 @@ class TestLocalRolesRevoking(IntegrationTestCase):
         self.set_workflow_state('task-state-tested-and-closed', self.subtask)
         self.set_workflow_state('task-state-resolved', self.task)
         storage = RoleAssignmentManager(self.document).storage
-        expected_oguids = [Oguid.for_object(task).id for task in (self.task, self.subtask, self.info_task, )]
-        self.assertEqual(expected_oguids, [item.get('reference') for item in storage._storage()])
+        expected_oguids = [
+            Oguid.for_object(task).id
+            for task in (
+                self.task, self.subtask, self.info_task, self.private_task)
+        ]
+        self.assertEqual(
+            expected_oguids,
+            [item.get('reference') for item in storage._storage()],
+        )
         # close
         browser.open(self.task, view='tabbedview_view-overview')
         browser.click_on('task-transition-resolved-tested-and-closed')
         browser.fill({'Response': 'Done!'})
         browser.click_on('Save')
-        expected_oguids = [Oguid.for_object(task).id for task in (self.subtask, self.info_task, )]
-        self.assertEqual(expected_oguids, [item.get('reference') for item in storage._storage()])
+        expected_oguids = [
+            Oguid.for_object(task).id
+            for task in (self.subtask, self.info_task, self.private_task)
+        ]
+        self.assertEqual(
+            expected_oguids,
+            [item.get('reference') for item in storage._storage()],
+        )
 
     @browsing
     def test_closing_a_task_revokes_roles_on_proposal(self, browser):

--- a/opengever/task/tests/test_private_task.py
+++ b/opengever/task/tests/test_private_task.py
@@ -6,8 +6,7 @@ from opengever.testing import IntegrationTestCase
 
 class TestPrivateTaskIntegration(IntegrationTestCase):
 
-    @browsing
-    def test_feature_is_activated_by_default(self, browser):
+    def test_feature_is_activated_by_default(self):
         self.assertTrue(is_private_task_feature_enabled())
 
     @browsing
@@ -45,8 +44,7 @@ class TestPrivateTaskDeactivatedIntegration(IntegrationTestCase):
 
     features = ('!private-tasks', )
 
-    @browsing
-    def test_feature_is_deactivated(self, browser):
+    def test_feature_is_deactivated(self):
         self.assertFalse(is_private_task_feature_enabled())
 
     @browsing

--- a/opengever/tasktemplates/tests/test_trigger.py
+++ b/opengever/tasktemplates/tests/test_trigger.py
@@ -493,6 +493,7 @@ class TestTriggeringTaskTemplate(IntegrationTestCase):
             '2016',
             '[No Subject]',
             u'Die B\xfcrgschaft',
+            u'Diskr\xe4te Dinge',
             u'Initialvertrag f\xfcr Bearbeitung',
             'Personaleintritt',
             u'Vertr\xe4gsentwurf',

--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -1249,6 +1249,23 @@ class OpengeverContentFixture(object):
             .relate_to(self.document)
         ))
 
+        self.register('private_task', create(
+            Builder('task')
+            .titled(u'Diskr\xe4te Dinge')
+            .within(self.dossier)
+            .having(
+                deadline=date(2020, 1, 1),
+                is_private=True,
+                issuer=self.dossier_responsible.getId(),
+                responsible_client=self.org_unit.id(),
+                responsible=self.regular_user.getId(),
+                task_type=u'direct-execution',
+                text=u'L\xf6rem ipsum dolor sit amet, consectetur'
+            )
+            .relate_to(self.document)
+            .in_state('task-state-in-progress')
+        ))
+
     @staticuid()
     def create_expired_dossier(self):
         self.expired_dossier = self.register('expired_dossier', create(


### PR DESCRIPTION
I added an invariant to the ITask schema, thats imho the only way to have a schema validation, which is also called on api POST/PATCH requests.

Because invariants get an `z3c.form.validator.Data` object passed in, which provides his own getattr with a fallback, fetching the value from the context when the field was not passed in via form/api , I had to check if the is_private value was part of the input-data with the help of the attribute `_Data_data___`. I don't see any other way to check if the field is passed in or if it's already set on the object.

Besides that Joni did some testing and cleanup work, thx ...

Closes #5441 