### PR TITLE
Support Oneoffixx template favorites

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -9,6 +9,7 @@ Changelog
 - Show archival file state on documents overview for managers. [njohner]
 - Fix tests failing due to timezone leading to date shift. [njohner]
 - Fix creation of scaneingang dossier in the scan-in endpoint. [phgross]
+- Display user chosen Favorites as a Oneoffixx template group. [Rotonen]
 - Prevent tasks from being created as private or switched to private when feature is not enabled. [Rotonen, phgross]
 - Bump ftw.mail to 2.6.0 to get error logging on inbound mail failures. [lgraf]
 - Handle complex URLs as titles on journal PDF exports. [Rotonen]

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -10,6 +10,8 @@ Changelog
 - Fix tests failing due to timezone leading to date shift. [njohner]
 - Fix creation of scaneingang dossier in the scan-in endpoint. [phgross]
 - Display user chosen Favorites as a Oneoffixx template group. [Rotonen]
+- Use user chosen favorites as the default Oneoffixx template group. [Rotonen]
+- Display user chosen Favorites as an Oneoffixx template group. [Rotonen]
 - Prevent tasks from being created as private or switched to private when feature is not enabled. [Rotonen, phgross]
 - Bump ftw.mail to 2.6.0 to get error logging on inbound mail failures. [lgraf]
 - Handle complex URLs as titles on journal PDF exports. [Rotonen]

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -10,6 +10,7 @@ Changelog
 - Fix tests failing due to timezone leading to date shift. [njohner]
 - Fix creation of scaneingang dossier in the scan-in endpoint. [phgross]
 - Display user chosen Favorites as a Oneoffixx template group. [Rotonen]
+- Add a filter to the Oneoffixx template selection wizard. [Rotonen]
 - Use user chosen favorites as the default Oneoffixx template group. [Rotonen]
 - Display user chosen Favorites as an Oneoffixx template group. [Rotonen]
 - Prevent tasks from being created as private or switched to private when feature is not enabled. [Rotonen, phgross]

--- a/opengever/base/browser/resources/base.js
+++ b/opengever/base/browser/resources/base.js
@@ -1,6 +1,6 @@
 $(window).load(function(){
   // set focus on first form field
-  var firstFormElement = $('form#form input:text:visible, form#form textarea:visible, .keyword-widget, .choice-field').first();
+  var firstFormElement = $('form#form input:text:visible, form#form textarea:visible, .keyword-widget').first();
   // Check if element is select2 widget
   if (firstFormElement.data('select2')) {
     firstFormElement.focus();

--- a/opengever/oneoffixx/browser/form.py
+++ b/opengever/oneoffixx/browser/form.py
@@ -151,7 +151,7 @@ class ICreateDocumentFromOneOffixxTemplate(model.Schema):
         title=_(u"label_template", default=u"Template"),
         source=list_templates,
         required=True,
-        show_filter=False,
+        show_filter=True,
         vocabulary_depends_on=['form.widgets.template_group'],
         columns=(
             {'column': 'title',

--- a/opengever/oneoffixx/browser/form.py
+++ b/opengever/oneoffixx/browser/form.py
@@ -55,6 +55,14 @@ def get_oneoffixx_templates():
     )
 
 
+def default_template_group():
+    """Return all templates, or the user favorites, if defined by user."""
+    favorites = get_oneoffixx_favorites()
+    if favorites:
+        return favorites.get('id')
+    return None
+
+
 @provider(IContextSourceBinder)
 def list_templates(context):
     """Return a list available templates."""
@@ -130,10 +138,13 @@ class MutableObjectVocabulary(SimpleVocabulary):
 
 class ICreateDocumentFromOneOffixxTemplate(model.Schema):
 
+    # XXX - this always renders the --NOVALUE-- as the actually chosen
+    # default is actually loaded over AJAX - confusing and bad UX
     template_group = schema.Choice(
         title=_(u'label_template_group', default=u'Template group'),
         source=list_template_groups,
         required=False,
+        defaultFactory=default_template_group,
     )
 
     template = TableChoice(

--- a/opengever/oneoffixx/tests/test_oneoffixx.py
+++ b/opengever/oneoffixx/tests/test_oneoffixx.py
@@ -98,6 +98,16 @@ class TestCreateDocFromOneoffixxTemplate(IntegrationTestCase):
         super(TestCreateDocFromOneoffixxTemplate, self).tearDown()
 
     @browsing
+    def test_oneoffixx_defaults_to_listing_all(self, browser):
+        self.login(self.regular_user, browser)
+        browser.open(self.dossier)
+        factoriesmenu.add('document_with_oneoffixx_template')
+        self.assertEqual([], browser.css('option[selected=selected]').text)
+        self.assertIsNone(browser.css('select').first.value)
+        # XXX - this always renders the --NOVALUE-- as the actually chosen
+        # default is actually loaded over AJAX - confusing and bad UX
+
+    @browsing
     def test_document_creation_from_oneoffixx_template_creates_shadow_doc(self, browser):
         self.login(self.regular_user, browser)
         browser.open(self.dossier)
@@ -543,10 +553,32 @@ class TestOneoffixxTemplateFavorites(IntegrationTestCase):
         self.assertEqual(expected_categories, browser.css('select option').text)
 
     @browsing
-    def test_oneoffixx_favorites_not_duplicated_on_select_all(self, browser):
+    def test_oneoffixx_defaults_to_listing_favorites(self, browser):
         self.login(self.regular_user, browser)
         browser.open(self.dossier)
         factoriesmenu.add('document_with_oneoffixx_template')
+        self.assertEqual(
+            ['Favorites'], browser.css('option[selected=selected]').text)
+        self.assertEqual(
+            'c2ddc01a-befd-4e0d-b15f-f67025f532bd',
+            browser.css('select').first.value,
+        )
+        # XXX - this always renders the --NOVALUE-- as the actually chosen
+        # default is actually loaded over AJAX - confusing and bad UX
+
+    @browsing
+    def test_oneoffixx_favorites_not_duplicated_on_select_all(self, browser):
+        self.login(self.regular_user, browser)
+        view = (
+            'document_with_oneoffixx_template'
+            '/++widget++form.widgets.template'
+            '/ajax_render'
+            '?form.widgets.template_group:list=--NOVALUE--'
+            '&form.widgets.template_group-empty-marker=1'
+            '&form.widgets.template-empty-marker=1'
+            '&form.widgets.title'
+        )  # Do not add commas above, this is a string!
+        browser.open(self.dossier, view=view, send_authenticator=True)
         expected_options = [
             '3 Example Word file',
             '2 Example Excel file',

--- a/opengever/oneoffixx/tests/test_oneoffixx.py
+++ b/opengever/oneoffixx/tests/test_oneoffixx.py
@@ -98,6 +98,16 @@ class TestCreateDocFromOneoffixxTemplate(IntegrationTestCase):
         super(TestCreateDocFromOneoffixxTemplate, self).tearDown()
 
     @browsing
+    def test_oneoffixx_wizard_shows_filter(self, browser):
+        self.login(self.regular_user, browser)
+        browser.open(self.dossier)
+        factoriesmenu.add('document_with_oneoffixx_template')
+        self.assertEqual(
+            'Filter',
+            browser.css('input.tableradioSearchbox').first.get('placeholder'),
+        )
+
+    @browsing
     def test_oneoffixx_defaults_to_listing_all(self, browser):
         self.login(self.regular_user, browser)
         browser.open(self.dossier)

--- a/opengever/oneoffixx/tests/test_oneoffixx.py
+++ b/opengever/oneoffixx/tests/test_oneoffixx.py
@@ -45,11 +45,27 @@ class TestCreateDocFromOneoffixxTemplate(IntegrationTestCase):
             'templateGroupId': 3,
         }
         template_groups = [
-            {'id': 1, 'localizedName': 'Word templates', 'templates': [template_word]},
-            {'id': 2, 'localizedName': 'Excel templates', 'templates': [template_excel]},
-            {'id': 3, 'localizedName': 'Powerpoint template folder', 'templates': [template_powerpoint]},
+            {
+                'id': 'c2ddc01a-befd-4e0d-b15f-f67025f532be',
+                'localizedName': 'Word templates',
+                'templates': [template_word],
+            },
+            {
+                'id': 'c2ddc01a-befd-4e0d-b15f-f67025f532bf',
+                'localizedName': 'Excel templates',
+                'templates': [template_excel],
+            },
+            {
+                'id': 'c2ddc01a-befd-4e0d-b15f-f67025f532c0',
+                'localizedName': 'Powerpoint template folder',
+                'templates': [template_powerpoint],
+            },
         ]
-
+        favorites = {
+            'id': 'c2ddc01a-befd-4e0d-b15f-f67025f532bd',
+            'localizedName': 'Favorites',
+            'templates': [],
+        }
         session = requests.Session()
         adapter = requests_mock.Adapter()
         adapter.register_uri('POST', 'mock://nohost/ids/connect/token', text=json.dumps(access_token))
@@ -58,6 +74,11 @@ class TestCreateDocFromOneoffixxTemplate(IntegrationTestCase):
             'GET',
             'mock://nohost/webapi/api/v1/1/TemplateLibrary/TemplateGroups',
             text=json.dumps(template_groups),
+        )
+        adapter.register_uri(
+            'GET',
+            'mock://nohost/webapi/api/v1/1/TemplateLibrary/TemplateFavorites',
+            text=json.dumps(favorites),
         )
         session.mount('mock', adapter)
 
@@ -237,7 +258,7 @@ class TestCreateDocFromOneoffixxFilterTemplate(IntegrationTestCase):
             'templateGroupId': 1,
         }
         template_groups = [{'templates': [valid_template, invalid_template]}]
-
+        favorites = {'id': 'c2ddc01a-befd-4e0d-b15f-f67025f532bd', 'localizedName': 'Favorites', 'templates': []}
         session = requests.Session()
         adapter = requests_mock.Adapter()
         adapter.register_uri('POST', 'mock://nohost/ids/connect/token', text=json.dumps(access_token))
@@ -246,6 +267,11 @@ class TestCreateDocFromOneoffixxFilterTemplate(IntegrationTestCase):
             'GET',
             'mock://nohost/webapi/api/v1/1/TemplateLibrary/TemplateGroups',
             text=json.dumps(template_groups),
+        )
+        adapter.register_uri(
+            'GET',
+            'mock://nohost/webapi/api/v1/1/TemplateLibrary/TemplateFavorites',
+            text=json.dumps(favorites),
         )
         session.mount('mock', adapter)
 
@@ -415,3 +441,137 @@ class TestOneOffixxTemplateFeature(IntegrationTestCase):
              'Subdossier',
              'Participant'],
             factoriesmenu.addable_types())
+
+
+class TestOneoffixxTemplateFavorites(IntegrationTestCase):
+
+    features = ("officeconnector-checkout", "oneoffixx")
+
+    def setUp(self):
+        super(TestOneoffixxTemplateFavorites, self).setUp()
+        api.portal.set_registry_record('baseurl', u'mock://nohost', IOneoffixxSettings)
+        api.portal.set_registry_record('fake_sid', u'foobar', IOneoffixxSettings)
+
+        access_token = {'access_token': 'all_may_enter'}
+        template_library = [{'datasources': [{'id': 1}]}]
+        template_word = {
+            'id': '2574d08d-95ea-4639-beab-3103fe4c3bc7',
+            'metaTemplateId': '275af32e-bc40-45c2-85b7-afb1c0382653',
+            'languages': ['2055'],
+            'localizedName': '3 Example Word file',
+            'templateGroupId': 1,
+        }
+        template_excel = {
+            'id': '2574d08d-95ea-4639-beab-3103fe4c3bc8',
+            'metaTemplateId': 'e31ca353-2ab1-4408-921b-a70ae2f57ad1',
+            'languages': ['2055'],
+            'localizedName': '2 Example Excel file',
+            'templateGroupId': 2,
+        }
+        template_powerpoint = {
+            'id': '2574d08d-95ea-4639-beab-3103fe4c3bc9',
+            'metaTemplateId': 'a2c9b700-86cd-4481-a17f-533fe9c504a2',
+            'languages': ['2055'],
+            'localizedName': '1 Example Powerpoint presentation',
+            'templateGroupId': 3,
+        }
+        template_groups = [
+            {
+                'id': 'c2ddc01a-befd-4e0d-b15f-f67025f532be',
+                'localizedName': 'Word templates',
+                'templates': [template_word],
+            },
+            {
+                'id': 'c2ddc01a-befd-4e0d-b15f-f67025f532bf',
+                'localizedName': 'Excel templates',
+                'templates': [template_excel],
+            },
+            {
+                'id': 'c2ddc01a-befd-4e0d-b15f-f67025f532c0',
+                'localizedName': 'Powerpoint template folder',
+                'templates': [template_powerpoint],
+            },
+        ]
+        favorites = {
+            'id': 'c2ddc01a-befd-4e0d-b15f-f67025f532bd',
+            'localizedName': 'Favorites',
+            'templates': [template_powerpoint],
+        }
+        session = requests.Session()
+        adapter = requests_mock.Adapter()
+        adapter.register_uri('POST', 'mock://nohost/ids/connect/token', text=json.dumps(access_token))
+        adapter.register_uri('GET', 'mock://nohost/webapi/api/v1/TenantInfo', text=json.dumps(template_library))
+        adapter.register_uri(
+            'GET',
+            'mock://nohost/webapi/api/v1/1/TemplateLibrary/TemplateGroups',
+            text=json.dumps(template_groups),
+        )
+        adapter.register_uri(
+            'GET',
+            'mock://nohost/webapi/api/v1/1/TemplateLibrary/TemplateFavorites',
+            text=json.dumps(favorites),
+        )
+        session.mount('mock', adapter)
+
+        credentials = {
+            'client_id': 'foo',
+            'client_secret': 'topsecret',
+            'preshared_key': 'horribletruth',
+        }
+
+        OneoffixxAPIClient(session, credentials)
+
+    def tearDown(self):
+        api.portal.set_registry_record('baseurl', u'', IOneoffixxSettings)
+        api.portal.set_registry_record('fake_sid', u'', IOneoffixxSettings)
+        # Tear down the singleton
+        OneoffixxAPIClient.__metaclass__._instances.pop(OneoffixxAPIClient, None)
+        super(TestOneoffixxTemplateFavorites, self).tearDown()
+
+    @browsing
+    def test_oneoffixx_favorites_listed_as_a_category(self, browser):
+        self.login(self.regular_user, browser)
+        browser.open(self.dossier)
+        factoriesmenu.add('document_with_oneoffixx_template')
+        expected_categories = [
+            'All templates',
+            'Favorites',
+            'Word templates',
+            'Excel templates',
+            'Powerpoint template folder',
+        ]
+        self.assertEqual(expected_categories, browser.css('select option').text)
+
+    @browsing
+    def test_oneoffixx_favorites_not_duplicated_on_select_all(self, browser):
+        self.login(self.regular_user, browser)
+        browser.open(self.dossier)
+        factoriesmenu.add('document_with_oneoffixx_template')
+        expected_options = [
+            '3 Example Word file',
+            '2 Example Excel file',
+            '1 Example Powerpoint presentation',
+        ]
+        self.assertEqual(
+            expected_options,
+            [e.get('title') for e in browser.css('input[type=radio]')],
+        )
+
+    @browsing
+    def test_oneoffixx_favorites_lists_only_favorites(self, browser):
+        self.login(self.regular_user, browser)
+        view = (
+            'document_with_oneoffixx_template'
+            '/++widget++form.widgets.template'
+            '/ajax_render'
+            '?form.widgets.template_group:list=c2ddc01a-befd-4e0d-b15f-f67025f532bd'
+            '&form.widgets.template_group-empty-marker=1'
+            '&form.widgets.template-empty-marker=1'
+            '&form.widgets.title'
+        )  # Do not add commas above, this is a string!
+        browser.open(self.dossier, view=view, send_authenticator=True)
+        expected_options = ['1 Example Powerpoint presentation']
+        self.assertEqual(
+            expected_options,
+            [e.get('title') for e in browser.css('input[type=radio]')],
+        )


### PR DESCRIPTION
* Added a fetcher for the per user selected favorites to the api client
* Injecting the favorites, if any, as a template group
* Added a filter to the select field
* Refixed the autofocus JS

A demo of the filter:
![oneoffixx-filter](https://user-images.githubusercontent.com/935317/55807839-3254b900-5ae3-11e9-9a60-33ba81be2be0.gif)


We do not currently know of a user on a real backend, which would have selected favorites. Validation should ultimately still wait for this ability to be achieved.

Closes https://github.com/4teamwork/opengever.core/issues/5445
Closes https://github.com/4teamwork/opengever.core/issues/5246