### PR TITLE
Fix creation of scaneingang dossier in the scan-in endpoint.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -8,6 +8,7 @@ Changelog
 - Add archival file management view on dossier level. [njohner]
 - Show archival file state on documents overview for managers. [njohner]
 - Fix tests failing due to timezone leading to date shift. [njohner]
+- Fix creation of scaneingang dossier in the scan-in endpoint. [phgross]
 - Prevent tasks from being created as private or switched to private when feature is not enabled. [Rotonen, phgross]
 - Bump ftw.mail to 2.6.0 to get error logging on inbound mail failures. [lgraf]
 - Handle complex URLs as titles on journal PDF exports. [Rotonen]

--- a/opengever/api/scanin.py
+++ b/opengever/api/scanin.py
@@ -1,9 +1,8 @@
 from opengever.base.command import CreateDocumentCommand
 from opengever.base.security import elevated_privileges
 from plone import api
+from plone.dexterity.utils import createContentInContainer
 from plone.restapi.services import Service
-from plone.restapi.services.content.utils import add
-from plone.restapi.services.content.utils import create
 from zope.interface import alsoProvides
 import plone.protect.interfaces
 
@@ -76,10 +75,10 @@ class ScanIn(Service):
                     return dossiers[0].getObject()
 
                 # No dossier found, create a new one
-                obj = create(private_folder,
+                obj = createContentInContainer(
+                    private_folder,
                     'opengever.private.dossier',
                     title='Scaneingang')
-                obj = add(private_folder, obj, rename=True)
                 return obj
 
         return self.error(

--- a/opengever/api/tests/test_scanin.py
+++ b/opengever/api/tests/test_scanin.py
@@ -4,7 +4,9 @@ from ftw.testbrowser import browsing
 from opengever.base.role_assignments import RoleAssignmentManager
 from opengever.base.role_assignments import SharingRoleAssignment
 from opengever.testing import IntegrationTestCase
+from opengever.testing import obj2brain
 from plone import api
+from plone.uuid.interfaces import IUUID
 from requests_toolbelt.multipart.encoder import MultipartEncoder
 
 
@@ -128,6 +130,8 @@ class TestScanIn(IntegrationTestCase):
         self.assertEqual(201, browser.status_code)
         dossier = private_folder.objectValues()[0]
         self.assertEqual('Scaneingang', dossier.Title())
+        self.assertIsNotNone(IUUID(dossier))
+        self.assertIsNotNone(obj2brain(dossier).UID)
         doc = dossier.objectValues()[0]
         self.assertEqual('mydocument', doc.Title())
 

--- a/opengever/core/upgrades/20190403172610_fix_scaneingang_privatedossiers/upgrade.py
+++ b/opengever/core/upgrades/20190403172610_fix_scaneingang_privatedossiers/upgrade.py
@@ -1,0 +1,22 @@
+from ftw.upgrade import UpgradeStep
+from plone import api
+from zope.event import notify
+from zope.lifecycleevent import ObjectCreatedEvent
+
+
+class FixScaneingangPrivatedossiers(UpgradeStep):
+    """Fix scaneingang privatedossiers.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()
+        catalog = api.portal.get_tool('portal_catalog')
+
+        dossiers = catalog(sortable_title='scaneingang',  # Exact match
+                           portal_type='opengever.private.dossier')
+
+        for brain in dossiers:
+            if not brain.UID:
+                dossier = brain.getObject()
+                notify(ObjectCreatedEvent(dossier))
+                dossier.reindexObject()


### PR DESCRIPTION
the scan-in endpoint used the `create` helper from plone.restapi to create the private dossier `Scaneingang`, but this helper does not fires the CreatedEvent which leads to object without an UID. In combination with the recently introduced not-query on UIDs those dossiers are no longer listed in the dossier listing. 

I changed now the creation to `createContentInContainer` (the way we use for other in code content creation) and provide an upgradestep which fires (again) the ObjectCreatedEvent and reindex the object.

Closes #5529 

Needs backport to `2019.1-stable`