### PR TITLE
Fix duplicate catalog entries, rename depth first after copying.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -140,6 +140,7 @@ Changelog
 - Fix bug in meeting zip export with documents without files. [njohner]
 - Do not show closed dossiers in the move target autocomplete widget. [Rotonen]
 - Copy local roles depending on assignment cause during copy/paste. [njohner]
+- Potentially fix an issue with duplicated catalog enries during paste. [deiferni]
 - Change wording of info for inactiv close meeting button. [njohner]
 - Avoid truncating committee responsible group token while normalizing. [deiferni]
 - Provide a testserver for GEVER. [jone]


### PR DESCRIPTION
This should fix an issue during copy/paste when some catalog entries were duplicated.

Children are now renamed/moved postorder, i.e. children are renamed before their
parents. This is important to avoid race-conditions with the move optimization from ftw.copymovepatches.

- When moving multiple items plone dispatches the move event to children in an event handler. This event handler is registered earlier than the handler from `ftw.copymovepatches`. Thus it is called before the parent item is "moved" in the catalog by `ftw.copymovepatches`.
- The optimization in `ftw.copymovepatches` trips up if one of the children somehow cause their parent to be reindexed while it is moved as the catalog then treats it as a new entry.
- we can fix this behavior in our custom copy/paste handler by moving the children before the parents are moved.

I could not find a way to write test for this issue. It does not appear to happen when running our test suite. Input very much welcome. I can confirm the issue no longer surfaces and can no longer be reproduced according to the steps described in #5291.

I could not find any other functionality where we programmatically recursively rename objects. This should only happen in moves. And due to event handler registration order (in plone) at the moment this seems to dispatch most events for children first.

We need to discuss a way forward as imho this is an issue in the optimization provided by `ftw.copymovepatches`. It could have consequences on how we build event handlers and on what they may or may not do. Also we should maybe defer some operations (like updating doc-properites and the like) to run after the event has been processed entirely, right at the end of a request. Same strategy as `collective.indexing` may be an option.

Fixes #5291.

Detailed analysis i had to do to detect the bug in the first place. For the sake of documentation. The following happens when an item is pasted in GEVER. Descriptions refer to pasting a dossier C with one child, document D.

Firs the objects are pasted into its new container, content is created by Plone etc, this happens "normally" and does not cause any issues yet.

Gever then enforces its naming scheme, i.e. dossier-X and document-Y by renaming/moving
the already pasted objects in
https://github.com/4teamwork/opengever.core/blob/c8b0be634ccba1d63b80380074c78aa2112d22a7/opengever/base/browser/paste.py#L92-L96. This will first move the object for Dossier C, and thus the dossiers object will have a new path.
Renaming is the same as moving, so an `IObjectMovedEvent` is fired for all
renamed objects. Keep in mind, we start with the parent, then work our way down 
to the children, so the dossier is renamed first and we process moved events for
Dossier C.

When an IObjectMovedEvent is fired, that event is dispatched to all the objects children in
https://github.com/zopefoundation/Zope/blob/a78bab7935ad524f6193d4ac49a97ed78152552c/src/OFS/subscribers.py#L108-L116. So this will immediately fire an `IObjectMovedEvent` for the document D which 
will now be processed before any other event handlers for the dossier C are processed. The event handler that dispatches events to children is registered early and fires before the event handler from `ftw.copymovepatches`.

One of the event handlers for Document D comes from `ftw.copymovepatches` which performs an optimized move in 
https://github.com/4teamwork/ftw.copymovepatches/blob/91aea70798b17c7670255313b528347477ed010f/ftw/copymovepatches/cmfcatalogaware.py#L75-L80. it does not completely unindex and reindex the document D but update the RID-path
mapping in the catalog and queue specific indices for reindexing. It will correctly
update the catalog as following and also queue some more indices for update:

```
del _catalog.uids[D_old_path]
_catalog.uids[D_new_path] = D_rid
_catalog.paths[D_rid] = D_new_path
```

Important point here: since events are dispatched to children in the middle of processing the parents events the
catalog internal rid/path mapping has now been updated for Document D, but not yet for Dossier C.

In GEVER we update a document's doc-properties when the document is moved, this happens
in 
https://github.com/4teamwork/opengever.core/blob/c8b0be634ccba1d63b80380074c78aa2112d22a7/opengever/document/handlers.py#L51. As we are now processing events for Document D aforementioned handler is called.
It will modify the document to update its doc-properties, thus setting its file.

If the document is a new document without any previous versions we create an initial
version for the document when its file is set in
https://github.com/4teamwork/opengever.core/blob/c8b0be634ccba1d63b80380074c78aa2112d22a7/opengever/document/document.py#L223. This will save a document version in CMFEditions.

When an object (our document D) is saved in CMFEditions this also causes the objects parent (the dossier C) to
be registered somehow in
https://github.com/plone/Products.CMFEditions/blob/68fdce45dcac1ee921c9f4f9d78dbe8f84eaddee/Products/CMFEditions/ArchivistTool.py. 

A bit more down the call stack that this also triggers a reindexOBject for the dossier C in
https://github.com/zopefoundation/Products.CMFUid/blob/ca9f6e63ff4f5a14c733d997a0fd577f5f546c12/Products/CMFUid/UniqueIdHandlerTool.py#L84.
Mind we are using `collective.indexing`, so reindexes don't happen immeditately
but are put into an indexing queue. So dossier C is in the reindexing queue.

We continue writing the properties, whis will fire an `ObjectModifiedEvent` after properites
were written in https://github.com/4teamwork/opengever.core/blob/6f4c73dcbd44f8d3fb3e7832de5dddf1760b21fd/opengever/dossier/docprops.py#L116.

We catch the modified event and fire our own `IObjectTouchedEvent` in 
https://github.com/4teamwork/opengever.core/blob/c8b0be634ccba1d63b80380074c78aa2112d22a7/opengever/base/handlers.py#L121

The document will now be registered as a document that was touched by the user.
This will cause a rotation in the users recently touched documents which fires a
catalog query in https://github.com/4teamwork/opengever.core/blob/6f4c73dcbd44f8d3fb3e7832de5dddf1760b21fd/opengever/base/touched.py#L119.

Firing a catalog query will process the queue of `collective indexing`. Keep in mind dossier C
is in that queue with a full reindex (all indices). Also keep in mind the dossier C's object has
been moved already, but we did not yet process the event handler from `ftw.copymovepatches`  which would
have updated the catalogs rid/path mapping for the dossier C. So currently the old dossier path is in
the rid/path mapping.

Now the reindex, first it figures out if is inserting new data or updating, based on
the path (here called uid), in https://github.com/zopefoundation/Products.ZCatalog/blob/dd30d4413eb1090f2a05bb4cfe438dc0a9690611/src/Products/ZCatalog/Catalog.py#L334. Since the catalog rid/path mapping has not been updated for the dossier yet, but the
dossier object has already been moved the catalog comes to the wrong conclusion and attempts
an insert. So it assigns a new RID for the new path and updates the catalog rid/path mapping as follows:

```
_catalog.uids[C_new_path] = C_FAIL_rid
_catalog.paths[C_FAIL_rid] = C_new_path
```

For the indices, as an example this will update the UUIDIndex as follows:

_index: UUID -> rid: luckily the index is not updated as per 
https://github.com/zopefoundation/Products.ZCatalog/blob/dd30d4413eb1090f2a05bb4cfe438dc0a9690611/src/Products/PluginIndexes/UUIDIndex/UUIDIndex.py#L97-L99
and logged instead. I could also observe such log entries in production.

```
_unindex: rid -> UUID:
_unindex[C_FAIL_rid] = C_UUID
```

Thus the uidex will contain two entries, one of which is pointing tho the newly
assigned uid. For other indices this may lead to duplicate entries in the forward
index, see https://github.com/zopefoundation/Products.ZCatalog/blob/dd30d4413eb1090f2a05bb4cfe438dc0a9690611/src/Products/PluginIndexes/unindex.py#L210-L232.