### PR TITLE
Fix tests failing due to timezone leading to date shift.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2019.2.0 (unreleased)
 ---------------------
 
+- Fix tests failing due to timezone leading to date shift. [njohner]
 - Prevent tasks from being created as private or switched to private when feature is not enabled. [Rotonen, phgross]
 - Bump ftw.mail to 2.6.0 to get error logging on inbound mail failures. [lgraf]
 - Handle complex URLs as titles on journal PDF exports. [Rotonen]

--- a/opengever/base/tests/test_default_values_for_types.py
+++ b/opengever/base/tests/test_default_values_for_types.py
@@ -26,9 +26,12 @@ from zope.schema import List
 import json
 import textwrap
 
-
+# changed is timezone aware, so we need a timezone aware FROZEN_NOW, but dates
+# in GEVER are timezone naive, so to avoid this test failing when timezone
+# offset leads to a date shift, we define a timezone naive FROZEN_TODAY.
 FROZEN_NOW = utcnow_tz_aware()
-FROZEN_TODAY = FROZEN_NOW.date()
+with freeze(FROZEN_NOW):
+    FROZEN_TODAY = date.today()
 
 DEFAULT_TITLE = u'My title'
 DEFAULT_CLIENT = u'fa'


### PR DESCRIPTION
Nightlies are failing because of a date shift. This comes from a timezone issue. In the tests for the default values, we freeze with a TZ aware `datetime`, which is correct for looking at `changed` which is TZ aware, but fails for other dates, e.g. the document date, which defaults to `date.today()`.

We now simply use a TZ aware `datetime` for freezing and comparing with `changed` and a TZ naive `date` to check other date defaults.

I did check that this solves the problem when the offset leads to a date shift.