### PR TITLE
Fix root path exclusion performance

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -32,7 +32,7 @@ Changelog
 - Exclusively handle templates on Committee and not on CommitteeContainer anymore. [njohner]
 - Extend @listing endpoint with `tasks`-listing. [elioschmutz]
 - Add option not to revoke permissions associated with a task when closing it. [njohner]
-- Fix performance issue with search root exclusion in tabbed view listings. [lgraf]
+- Fix performance issue with search root exclusion in tabbed view listings. [lgraf, buchi]
 - Do not list auto-generated documents as recently touched. [njohner]
 - Standardize french and german translation of "attachments" in meetings. [njohner]
 - Do not list resolved tasks as pending in the 'My Tasks' tab. [Rotonen]

--- a/opengever/api/listing.py
+++ b/opengever/api/listing.py
@@ -15,7 +15,6 @@ from plone.restapi.batching import HypermediaBatch
 from plone.restapi.serializer.converters import json_compatible
 from plone.restapi.services import Service
 from plone.rfc822.interfaces import IPrimaryFieldInfo
-from plone.uuid.interfaces import IUUID
 from Products.CMFCore.utils import getToolByName
 from Products.ZCatalog.Lazy import LazyMap
 from Products.ZCTextIndex.ParseTree import ParseError
@@ -221,14 +220,15 @@ class Listing(Service):
 
         query = CATALOG_QUERIES[name].copy()
         query.update({
-            'path': '/'.join(self.context.getPhysicalPath()),
+            'path': {
+                'query': '/'.join(self.context.getPhysicalPath()),
+                'depth': -1,
+                'exclude_root': 1,
+            },
             'sort_on': sort_on,
             'sort_order': sort_order,
             'sort_limit': start + rows,
         })
-
-        # Exclude context from results, which also matches the path query.
-        query['UID'] = {'not': IUUID(self.context)}
 
         if term:
             query['SearchableText'] = term + '*'

--- a/opengever/base/monkey/patches/__init__.py
+++ b/opengever/base/monkey/patches/__init__.py
@@ -10,6 +10,7 @@ from .default_values import PatchTransmogrifyDXSchemaUpdater
 from .default_values import PatchZ3CFormChangedField
 from .default_values import PatchZ3CFormWidgetUpdate
 from .exception_formatter import PatchExceptionFormatter
+from .extendedpathindex import PatchExtendedPathIndex
 from .filter_trashed_from_catalog import PatchCatalogToFilterTrashedDocs
 from .history_handler_tool import PatchCMFEditonsHistoryHandlerTool
 from .ldap_userfolder_encoding import PatchLDAPUserFolderEncoding
@@ -28,6 +29,7 @@ from .workflowtool import PatchWorkflowTool
 
 PatchBuilderCreate()()
 PatchUUIDIndex()()
+PatchExtendedPathIndex()()
 PatchCatalogToFilterTrashedDocs()()
 PatchCMFEditonsHistoryHandlerTool()()
 PatchCopyContainerVerifyObjectPaste()()

--- a/opengever/base/monkey/patches/__init__.py
+++ b/opengever/base/monkey/patches/__init__.py
@@ -21,14 +21,12 @@ from .resource_registries_url_regex import PatchResourceRegistriesURLRegex
 from .rolemanager import PatchOFSRoleManager
 from .scrub_bobo_exceptions import ScrubBoboExceptions
 from .tz_for_log import PatchZ2LogTimezone
-from .uuidindex import PatchUUIDIndex
 from .verify_object_paste import PatchCopyContainerVerifyObjectPaste
 from .webdav_lock_timeout import PatchWebDAVLockTimeout
 from .workflowtool import PatchWorkflowTool
 
 
 PatchBuilderCreate()()
-PatchUUIDIndex()()
 PatchExtendedPathIndex()()
 PatchCatalogToFilterTrashedDocs()()
 PatchCMFEditonsHistoryHandlerTool()()

--- a/opengever/base/monkey/patches/extendedpathindex.py
+++ b/opengever/base/monkey/patches/extendedpathindex.py
@@ -1,0 +1,44 @@
+from BTrees.IIBTree import IISet, intersection, union, difference
+from opengever.base.monkey.patching import MonkeyPatch
+
+
+class PatchExtendedPathIndex(MonkeyPatch):
+    """Add support for excluding the root path."""
+
+    def __call__(self):
+        from Products.ExtendedPathIndex.ExtendedPathIndex import ExtendedPathIndex
+
+        self.patch_value(
+            ExtendedPathIndex,
+            'query_options',
+            ("query", "level", "operator", "depth", "navtree", "navtree_start",
+             "exclude_root"),
+        )
+
+        def query_index(self, record, resultset=None):
+            level = record.get("level", 0)
+            operator = record.get('operator', self.useOperator).lower()
+            depth = getattr(record, 'depth', -1)  # use getattr to get 0 value
+            navtree = record.get('navtree', 0)
+            navtree_start = record.get('navtree_start', 0)
+            exclude_root = record.get('exclude_root', 0)
+
+            # depending on the operator we use intersection of union
+            if operator == "or":
+                set_func = union
+            else:
+                set_func = intersection
+
+            result = None
+            for k in record.keys:
+                rows = self.search(k, level, depth, navtree, navtree_start,
+                                   resultset=resultset)
+                if exclude_root:
+                    root = self._index_items.get(k)
+                    rows = difference(rows, root)
+                result = set_func(result, rows)
+
+            if result:
+                return result
+            return IISet()
+        self.patch_refs(ExtendedPathIndex, 'query_index', query_index)

--- a/opengever/base/monkey/patches/uuidindex.py
+++ b/opengever/base/monkey/patches/uuidindex.py
@@ -1,9 +1,0 @@
-from opengever.base.monkey.patching import MonkeyPatch
-
-
-class PatchUUIDIndex(MonkeyPatch):
-    """Enable support for not queries."""
-
-    def __call__(self):
-        from Products.PluginIndexes.UUIDIndex.UUIDIndex import UUIDIndex
-        self.patch_value(UUIDIndex, 'query_options', ["query", "range", "not"])


### PR DESCRIPTION
Turns out that NOT queries perform very bad for indexes with a lot of unique values.
Thus we patch the ExtendedPathIndex now for root path exclusion.

- Patch ExtendedPathIndex to allow exclusion of root path
- Exclude root path within path query in tabbed view's catalog source and in the REST API's listing endpoint
- Remove no longer needed UUIDIndex patch for NOT support


