### PR TITLE
Add archival file management view on dossier level.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2019.2.0 (unreleased)
 ---------------------
 
+- Add archival file management view on dossier level. [njohner]
 - Show archival file state on documents overview for managers. [njohner]
 - Fix tests failing due to timezone leading to date shift. [njohner]
 - Prevent tasks from being created as private or switched to private when feature is not enabled. [Rotonen, phgross]

--- a/opengever/dossier/browser/archival_file_management_view.py
+++ b/opengever/dossier/browser/archival_file_management_view.py
@@ -1,0 +1,33 @@
+from opengever.document.archival_file import ARCHIVAL_FILE_STATE_MAPPING
+from opengever.document.behaviors.metadata import IDocumentMetadata
+from plone import api
+from Products.Five.browser import BrowserView
+
+
+class ArchivalFileManagementView(BrowserView):
+    """A view to list the archival status (whether the document has an archival
+    file and its conversion status) of documents from a dossier.
+    """
+
+    def __call__(self):
+        # disable Plone's editable border
+        self.request.set('disable_border', True)
+        return self.index()
+
+    def get_documents(self):
+        catalog = api.portal.get_tool('portal_catalog')
+
+        docs = catalog.unrestrictedSearchResults(path=self.context.absolute_url_path(),
+                                                 portal_type='opengever.document.document',
+                                                 sort_on="path")
+        for doc in docs:
+            obj = doc.getObject()
+            metadata = IDocumentMetadata(obj)
+            doc_info = {}
+            doc_info["path"] = obj.absolute_url_path()
+            doc_info["url"] = obj.absolute_url()
+            doc_info["filetype"] = doc.file_extension
+            doc_info["has_archival_file"] = bool(metadata.archival_file)
+            doc_info["archival_file_state"] = ARCHIVAL_FILE_STATE_MAPPING.get(
+                metadata.archival_file_state)
+            yield doc_info

--- a/opengever/dossier/browser/configure.zcml
+++ b/opengever/dossier/browser/configure.zcml
@@ -148,4 +148,12 @@
       permission="cmf.ModifyPortalContent"
       />
 
+  <browser:page
+      for="opengever.dossier.behaviors.dossier.IDossierMarker"
+      name="archival_file_management"
+      class=".archival_file_management_view.ArchivalFileManagementView"
+      permission="cmf.ManagePortal"
+      template="templates/archival_file_management_view.pt"
+      />
+
 </configure>

--- a/opengever/dossier/browser/templates/archival_file_management_view.pt
+++ b/opengever/dossier/browser/templates/archival_file_management_view.pt
@@ -1,0 +1,50 @@
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en"
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      xmlns:metal="http://xml.zope.org/namespaces/metal"
+      xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+      lang="en"
+      metal:use-macro="context/main_template/macros/master"
+      i18n:domain="opengever.dossier">
+
+<body>
+
+<metal:main fill-slot="main">
+
+    <tal:main-macro metal:define-macro="main">
+
+    <div tal:replace="structure provider:plone.abovecontenttitle" />
+
+    <h1>Archival file management view</h1>
+
+    <h1 class="documentFirstHeading" tal:content="view/context/Title"> </h1>
+
+    <div tal:replace="structure provider:plone.belowcontenttitle" />
+
+    <p class="documentDescription" tal:content="context/Description" />
+
+    <div tal:replace="structure provider:plone.abovecontentbody" />
+
+    <h2>List of Document archival files and states</h2>
+    <table class="listing">
+        <tr>
+            <th>Path</th>
+            <th>Filetype</th>
+            <th>Has archival PDF</th>
+            <th>Archival file state</th>
+        </tr>
+        <tr tal:repeat="document view/get_documents">
+            <td><a tal:content="document/path" tal:attributes="href document/url"/></td>
+            <td tal:content="document/filetype"/>
+            <td tal:content="document/has_archival_file"/>
+            <td tal:content="document/archival_file_state"/>
+        </tr>
+    </table>
+
+    <div class="visualClear"><!----></div>
+    <div tal:replace="structure provider:plone.belowcontentbody" />
+    <div class="visualClear"><!----></div>
+    </tal:main-macro>
+</metal:main>
+
+</body>
+</html>

--- a/opengever/dossier/tests/test_archival_file_management_view.py
+++ b/opengever/dossier/tests/test_archival_file_management_view.py
@@ -1,0 +1,57 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.testbrowser import browsing
+from ftw.testbrowser.pages import plone
+from opengever.document.archival_file import ArchivalFileConverter
+from opengever.document.archival_file import STATE_FAILED_TEMPORARILY
+from opengever.document.behaviors.metadata import IDocumentMetadata
+from opengever.testing import IntegrationTestCase
+
+
+class TestArchivalFileManagementView(IntegrationTestCase):
+
+    @browsing
+    def test_archival_file_management_view_only_visible_for_managers(self, browser):
+        self.login(self.regular_user, browser)
+        with browser.expect_unauthorized():
+            browser.open(self.expired_dossier, view="archival_file_management")
+        self.assertEqual('Insufficient Privileges', plone.first_heading())
+
+        self.login(self.manager, browser)
+        browser.open(self.expired_dossier, view="archival_file_management")
+        self.assertEqual(self.expired_dossier.Title().decode("utf-8"),
+                         plone.first_heading())
+
+    @browsing
+    def test_archival_file_management_view_listing(self, browser):
+        self.login(self.manager, browser)
+        subdossier = create(Builder('dossier')
+                            .within(self.expired_dossier)
+                            .titled(u"Subdossier"))
+        subdocument = create(Builder('document')
+                             .within(subdossier)
+                             .with_dummy_content()
+                             .titled(u"subdocument"))
+        document = create(Builder('document')
+                          .within(self.expired_dossier)
+                          .with_dummy_content()
+                          .titled(u"Another document"))
+
+        ArchivalFileConverter(subdocument).store_file('TEST DATA')
+        IDocumentMetadata(self.expired_document).archival_file_state = STATE_FAILED_TEMPORARILY
+
+        # make sure that document with no archival file is handled by the view
+        self.assertIsNone(IDocumentMetadata(document).archival_file)
+
+        browser.open(self.expired_dossier, view="archival_file_management")
+        table = browser.css('table').first
+        expected = [['Path', 'Filetype', 'Has archival PDF',
+                     'Archival file state'],
+                    [self.expired_document.absolute_url_path(), '.doc',
+                     'True', "STATE_FAILED_TEMPORARILY"],
+                    [document.absolute_url_path(), '.doc',
+                     'False', ''],
+                    [subdocument.absolute_url_path(), '.doc',
+                     'True', "STATE_CONVERTED"]
+                    ]
+        self.assertEqual(expected, table.lists())


### PR DESCRIPTION
We add a management view on the dossier level, which lists all documents and their archival file state.
Documents are sorted by path and the information displayed is:
* the path to the document (link)
* the filetype
* whether the document has an `archival_file`
* The `archival_file_state` of the document

Notice that we are rendering the `plone.belowcontenttitle` viewlets, as this contains the byline listing. This handler also adds the favorite menu, which is a bit less welcome here. I'm not sure how to selectively disable some viewlets? For now, I simply display the dossier title, as `firstHeading`, so that the favorite menu is actually next to the dossier name.
 
**Example archival file management view**
<img width="1423" alt="Screen Shot 2019-04-08 at 17 01 37" src="https://user-images.githubusercontent.com/7374243/55734649-353aa580-5a20-11e9-9209-fe715bf1fd25.png">

resolves #5538 