### PR TITLE
Include filename in the livesearch endpoint results.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -15,6 +15,7 @@ Changelog
 - Add a filter to the Oneoffixx template selection wizard. [Rotonen]
 - Use user chosen favorites as the default Oneoffixx template group. [Rotonen]
 - Display user chosen Favorites as an Oneoffixx template group. [Rotonen]
+- Include filename in the livesearch endpoint results. [phgross]
 - Prevent tasks from being created as private or switched to private when feature is not enabled. [Rotonen, phgross]
 - Bump ftw.mail to 2.6.0 to get error logging on inbound mail failures. [lgraf]
 - Handle complex URLs as titles on journal PDF exports. [Rotonen]

--- a/opengever/api/livesearch.py
+++ b/opengever/api/livesearch.py
@@ -39,6 +39,7 @@ class GeverLiveSearchGet(SearchGet):
             return [
                 {
                     'title': entry.Title(),
+                    'filename': entry.filename,
                     '@id': entry.getURL(),
                     '@type': entry.portal_type,
                 }
@@ -49,13 +50,15 @@ class GeverLiveSearchGet(SearchGet):
             self.request.form.update({
                 'SearchableText': search_term + '*',
                 'sort_limit': limit,
-                'path': path
+                'path': path,
+                'metadata_fields': ['Title', 'filename', 'id', 'portal_type']
             })
 
             results = super(GeverLiveSearchGet, self).reply()
             return [
                 {
-                    'title': entry['title'],
+                    'title': entry['Title'],
+                    'filename': entry['filename'],
                     '@id': entry['@id'],
                     '@type': entry['@type'],
                 }

--- a/opengever/api/tests/test_livesearch.py
+++ b/opengever/api/tests/test_livesearch.py
@@ -8,17 +8,29 @@ class TestLivesearchGet(IntegrationTestCase):
     def test_livesearch(self, browser):
         self.login(self.regular_user, browser=browser)
 
+        # dossier
         url = u'{}/@livesearch?q={}'.format(self.portal.absolute_url(),
-                                            self.document.title)
+                                            self.dossier.title)
         browser.open(url, method='GET', headers={'Accept': 'application/json'})
 
-        self.assertEqual(200, browser.status_code)
-        self.assertGreater(len(browser.json), 0)
+        self.assertEqual(
+            {'@id': self.dossier.absolute_url(),
+             '@type': 'opengever.dossier.businesscasedossier',
+             'title': self.dossier.title,
+             'filename': None},
+            browser.json[0])
 
-        entry = browser.json[0]
-        self.assertIn('title', entry)
-        self.assertIn('@id', entry)
-        self.assertIn('@type', entry)
+        # document
+        url = u'{}/@livesearch?q={}'.format(self.portal.absolute_url(),
+                                            self.proposaldocument.title)
+        browser.open(url, method='GET', headers={'Accept': 'application/json'})
+
+        self.assertEqual(
+            {u'title': self.proposaldocument.title,
+             u'@id': self.proposaldocument.absolute_url(),
+             u'@type': u'opengever.document.document',
+             u'filename': self.proposaldocument.file.filename},
+            browser.json[0])
 
     @browsing
     def test_livesearch_limit(self, browser):

--- a/opengever/base/browser/livesearch.py
+++ b/opengever/base/browser/livesearch.py
@@ -60,7 +60,8 @@ class LiveSearchReplyView(BrowserView):
             filters.append(u'path_parent:%s' % escape(self.path))
         params = {
             'fl': [
-                'UID', 'id', 'Title', 'getIcon', 'portal_type', 'path', 'Description'
+                'UID', 'id', 'Title', 'getIcon', 'portal_type',
+                'path', 'Description', 'filename'
             ],
         }
 

--- a/opengever/base/solr.py
+++ b/opengever/base/solr.py
@@ -18,6 +18,10 @@ class OGSolrDocument(SolrDocument):
     def containing_dossier(self):
         return self.get('containing_dossier', None)
 
+    @property
+    def filename(self):
+        return self.get('filename', None)
+
 
 class OGSolrContentListing(SolrContentListing):
 


### PR DESCRIPTION
Adjustment for solr and non-solr deployments.

Closes #5550.