### PR TITLE
 Fix solr error during copy/paste of word document.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2019.2.0 (unreleased)
 ---------------------
 
+- Fix solr error during copy/paste of word document. [njohner]
 - Add archival file management view on dossier level. [njohner]
 - Show archival file state on documents overview for managers. [njohner]
 - Fix tests failing due to timezone leading to date shift. [njohner]

--- a/opengever/document/tests/test_handlers.py
+++ b/opengever/document/tests/test_handlers.py
@@ -136,9 +136,13 @@ class TestHandlers(FunctionalTestCase):
         self.assert_doc_properties_updated_journal_entry_generated(
             self.doc_with_gever_properties, entry=-2)
 
-    def test_copying_documents_updates_doc_properties(self):
-        api.content.copy(source=self.doc_with_gever_properties,
-                         target=self.target_dossier)
+    @browsing
+    def test_copying_documents_updates_doc_properties(self, browser):
+        browser.login()
+        browser.open(self.doc_with_gever_properties, view='copy_item')
+        browser.open(self.target_dossier, view='tabbed_view')
+        browser.css('#contentActionMenus a#paste').first.click()
+
         copied_doc = self.target_dossier.getFirstChild()
 
         expected_doc_properties = [


### PR DESCRIPTION
Docproperties get updated several times during a copy/paste operation of a word document, overwriting the blob file each time. Each time the blob file is changed, a reindex operation is queued in solr, which is processed after the transaction ends. When that happens, solr tries to process some blobs that do not exist anymore and fails. We now update the docproperties only once during a copy/paste operation.

I don't think I can write a test for this, as long as we do not have a real solr running for testing purposes. For now I've written a test making sure that my changes did not break the update of the docproperties when copy/pasting a dossier containing a document. I added a comment in the test to also test sorl indexing of the object once we can.

**Here some notes on the analysis of the problem:**
So basically the problem comes from the renaming. In the copy/paste, we first create the new objects
and then rename them. During renaming we recursively rename all objects, but renaming of folderish objects also propagate the `ObjectMovedEvent` down to their children. For each `ObjectMovedEvent`, we update the docproperties, which means overwriting the blob file.

So when copying a dossier containing a document we updated the docproperties:
- When the document is added
- When renaming the dossier
- When renaming the document

The update of the docproperties when the document is added does not cause any problems (I think because the docproperties did not change, so the blob does not get overwritten, that's why copy/pasting a word document actually works). The one causing the issue is when renaming the dossier, as there we overwrite the blob of the document, then overwrite it again when renaming the document, but solr wants to index both blobs...

resolves #5547 
