### PR TITLE
Fix broken rest endpoint to add workspace

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 
 - Add webaction forms (add and edit) and management view. [njohner]
 - Fix solr error during copy/paste of word document. [njohner]
+- Fix an issue where it was not possible to create workspaces through the restapi. [elioschmutz]
 - Add archival file management view on dossier level. [njohner]
 - Show archival file state on documents overview for managers. [njohner]
 - Fix tests failing due to timezone leading to date shift. [njohner]

--- a/opengever/api/tests/test_workspace.py
+++ b/opengever/api/tests/test_workspace.py
@@ -1,0 +1,28 @@
+from ftw.testbrowser import browsing
+from opengever.dossier.behaviors.dossier import IDossier
+from opengever.testing import IntegrationTestCase
+import json
+
+api_headers = {
+    'Accept': 'application/json',
+    'Content-Type': 'application/json',
+}
+
+
+class TestWorkspace(IntegrationTestCase):
+
+    @browsing
+    def test_user_can_add_a_workspace(self, browser):
+        self.login(self.workspace_admin, browser=browser)
+        payload = {
+            "@type": "opengever.workspace.workspace",
+            "title": "My workspace",
+            "responsible": self.regular_user.getId()
+        }
+        browser.open(self.workspace_root.absolute_url(), method='POST',
+                     headers=api_headers, data=json.dumps(payload))
+
+        workspace = self.workspace_root.listFolderContents()[-1]
+        self.assertEqual('My workspace', workspace.title)
+        self.assertEqual(self.regular_user.getId(),
+                         IDossier(workspace).responsible)

--- a/opengever/workspace/utils.py
+++ b/opengever/workspace/utils.py
@@ -23,6 +23,10 @@ def roles_of_permission(context, permission):
 
 def is_within_workspace(context):
     """ Checks, if the content is a workspace or is within the workspace.
+
+    This function is required for the ogds-vocabularies. If the current context
+    is within a workspace, a special workspace-query hook will be used for
+    extending the query with workspace specific functionality.
     """
     # Avoid circular imports
     from opengever.workspace.interfaces import IWorkspace


### PR DESCRIPTION
⚠️ dieser PR wird durch #5563 überflüssig. Bitte noch warten mit Mergen... ⚠️ 

Dieser PR behebt ein Problem, bei dem es nicht möglich war, einen Arbeitsraum über die REST-API zu erstellen.

Siehe Kommentar im Code für weitere Informationen.

Issuer: https://github.com/4teamwork/gever-ui/issues/16

~ℹ️ Dieser PR fügt u.a. ein neues Test-Objekt hinzu: `RestAPIHandler`. Mit dem `RestAPIHandler` können REST-API einfacher getestet werden. Der Handler ist bereits in einem anderen Projekt erfolgreich im Einsatz (https://github.com/4teamwork/bernmobil.instructions/blob/master/bernmobil/instructions/tests/__init__.py#L17)~

~Diese Erweiterung hat keinen Einfluss auf bestehende Tests. Ein Refactoring wäre jedoch angebracht.~