### PR TITLE
Allow non-member contributors to use the REST API

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -517,6 +517,7 @@ Users
 - ``self.committee_responsible``: ``franzi.muller``
 - ``self.dossier_manager``: ``faivel.fruhling``
 - ``self.dossier_responsible``: ``robert.ziegler``
+- ``self.foreign_contributor``: ``james.bond``
 - ``self.manager``: ``admin``
 - ``self.meeting_user``: ``herbert.jager``
 - ``self.member_admin``: ``david.meier``
@@ -574,6 +575,7 @@ Objects
         - self.dossier
           - self.document
           - self.draft_proposal
+          - self.inbox_task
           - self.info_task
           - self.mail_eml
           - self.mail_msg

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 
 - Add webaction forms (add and edit) and management view. [njohner]
 - Fix solr error during copy/paste of word document. [njohner]
+- Allow non-member contributors to use the REST API. [Rotonen]
 - Add archival file management view on dossier level. [njohner]
 - Show archival file state on documents overview for managers. [njohner]
 - Fix tests failing due to timezone leading to date shift. [njohner]

--- a/opengever/base/tests/test_role_assignments.py
+++ b/opengever/base/tests/test_role_assignments.py
@@ -105,6 +105,10 @@ class TestRoleAssignmentManager(IntegrationTestCase):
             [{'principal': self.regular_user.id,
               'roles': ['Editor'],
               'cause': ASSIGNMENT_VIA_TASK,
+              'reference': Oguid.for_object(task).id},
+             {'principal': u'fa_inbox_users',
+              'roles': ['Editor'],
+              'cause': ASSIGNMENT_VIA_TASK_AGENCY,
               'reference': Oguid.for_object(task).id}],
             RoleAssignmentManager(task).storage._storage())
 
@@ -112,13 +116,21 @@ class TestRoleAssignmentManager(IntegrationTestCase):
             [{'principal': self.regular_user.id,
               'roles': ['Reader', 'Editor'],
               'cause': ASSIGNMENT_VIA_TASK,
-              'reference': Oguid.for_object(task).id}],
+              'reference': Oguid.for_object(task).id},
+             {'principal': u'fa_inbox_users',
+              'roles': ['Reader', 'Editor'],
+              'cause': ASSIGNMENT_VIA_TASK_AGENCY,
+           'reference': Oguid.for_object(task).id}],
             RoleAssignmentManager(document).storage._storage())
 
         self.assertEquals(
             [{'principal': self.regular_user.id,
               'roles': ['Contributor'],
               'cause': ASSIGNMENT_VIA_TASK,
+              'reference': Oguid.for_object(task).id},
+             {'principal': u'fa_inbox_users',
+              'roles': ['Contributor'],
+              'cause': ASSIGNMENT_VIA_TASK_AGENCY,
               'reference': Oguid.for_object(task).id}],
             RoleAssignmentManager(self.empty_dossier).storage._storage())
 
@@ -203,6 +215,12 @@ class TestManageRoleAssignmentsView(IntegrationTestCase):
                 u'principal': u'kathi.barfuss',
             },
             {
+                u'cause': {u'id': ASSIGNMENT_VIA_TASK_AGENCY, u'title': u'By task agency'},
+                u'roles': [u'Contributor'],
+                u'reference': {u'url': self.task.absolute_url(), u'title': u'Vertragsentwurf \xdcberpr\xfcfen'},
+                u'principal': u'fa_inbox_users',
+            },
+            {
                 u'cause': {u'id': ASSIGNMENT_VIA_TASK, 'title': u'By task'},
                 u'roles': [u'Contributor'],
                 u'reference': {
@@ -212,10 +230,25 @@ class TestManageRoleAssignmentsView(IntegrationTestCase):
                 u'principal': u'kathi.barfuss',
             },
             {
+                u'cause': {u'id': ASSIGNMENT_VIA_TASK_AGENCY, 'title': u'By task agency'},
+                u'roles': [u'Contributor'],
+                u'reference': {
+                    u'url': self.subtask.absolute_url(),
+                    u'title': u'Rechtliche Grundlagen in Vertragsentwurf \xdcberpr\xfcfen',
+                    },
+                u'principal': u'fa_inbox_users',
+            },
+            {
                 u'cause': {u'id': ASSIGNMENT_VIA_TASK, u'title': u'By task'},
                 u'roles': [u'Contributor'],
                 u'reference': {u'url': self.sequential_task.absolute_url(), u'title': u'Personaleintritt'},
                 u'principal': u'kathi.barfuss',
+            },
+            {
+                u'cause': {u'id': ASSIGNMENT_VIA_TASK_AGENCY, u'title': u'By task agency'},
+                u'roles': [u'Contributor'],
+                u'reference': {u'url': self.sequential_task.absolute_url(), u'title': u'Personaleintritt'},
+                u'principal': u'fa_inbox_users',
             },
             {
                 u'cause': {u'id': ASSIGNMENT_VIA_TASK, u'title': u'By task'},
@@ -224,10 +257,22 @@ class TestManageRoleAssignmentsView(IntegrationTestCase):
                 u'principal': u'kathi.barfuss',
             },
             {
+                u'cause': {u'id': ASSIGNMENT_VIA_TASK_AGENCY, u'title': u'By task agency'},
+                u'roles': [u'Contributor'],
+                u'reference': {u'url': self.seq_subtask_1.absolute_url(), u'title': u'Mitarbeiter Dossier generieren'},
+                u'principal': u'fa_inbox_users',
+            },
+            {
                 u'cause': {u'id': ASSIGNMENT_VIA_TASK, u'title': u'By task'},
                 u'roles': [u'Contributor'],
                 u'reference': {u'url': self.seq_subtask_2.absolute_url(), u'title': u'Arbeitsplatz vorbereiten'},
                 u'principal': u'kathi.barfuss',
+            },
+            {
+                u'cause': {u'id': ASSIGNMENT_VIA_TASK_AGENCY, u'title': u'By task agency'},
+                u'roles': [u'Contributor'],
+                u'reference': {u'url': self.seq_subtask_2.absolute_url(), u'title': u'Arbeitsplatz vorbereiten'},
+                u'principal': u'fa_inbox_users',
             },
             {
                 u'cause': {u'id': ASSIGNMENT_VIA_TASK, u'title': u'By task'},
@@ -239,6 +284,15 @@ class TestManageRoleAssignmentsView(IntegrationTestCase):
                 u'principal': u'kathi.barfuss',
             },
             {
+                u'cause': {u'id': ASSIGNMENT_VIA_TASK_AGENCY, u'title': u'By task agency'},
+                u'roles': [u'Contributor'],
+                u'reference': {
+                    u'url': self.seq_subtask_3.absolute_url(),
+                    u'title': u'Vorstellungsrunde bei anderen Mitarbeitern',
+                },
+                u'principal': u'fa_inbox_users',
+            },
+            {
                 u'cause': {u'id': ASSIGNMENT_VIA_TASK, u'title': u'By task'},
                 u'roles': [u'Contributor'],
                 u'reference': {
@@ -246,6 +300,15 @@ class TestManageRoleAssignmentsView(IntegrationTestCase):
                     u'title': u'Vertragsentw\xfcrfe 2018',
                 },
                 u'principal': u'kathi.barfuss',
+            },
+            {
+                u'cause': {u'id': ASSIGNMENT_VIA_TASK_AGENCY, u'title': u'By task agency'},
+                u'roles': [u'Contributor'],
+                u'reference': {
+                    u'url': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/task-11',
+                    u'title': u'Vertragsentw\xfcrfe 2018',
+                },
+                u'principal': u'fa_inbox_users',
             },
             {
                 u'cause': {u'id': ASSIGNMENT_VIA_TASK, u'title': u'By task'},
@@ -256,6 +319,15 @@ class TestManageRoleAssignmentsView(IntegrationTestCase):
                     u'title': u'Diskr\xe4te Dinge',
                 },
                 u'principal': u'kathi.barfuss',
-            }
+            },
+            {
+                u'cause': {u'id': ASSIGNMENT_VIA_TASK, u'title': u'By task'},
+                u'roles': [u'Contributor'],
+                u'reference': {
+                    u'title': u're: Diskr\xe4te Dinge',
+                    u'url': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/task-13'
+                },
+                u'principal': u'fa_inbox_users',
+            },
         ]
         self.assertEquals(expected_assignments, browser.json)

--- a/opengever/base/tests/test_role_assignments.py
+++ b/opengever/base/tests/test_role_assignments.py
@@ -197,13 +197,13 @@ class TestManageRoleAssignmentsView(IntegrationTestCase):
         browser.open(self.dossier, view='manage-role-assignments')
         expected_assignments = [
             {
-                u'cause': {u'id': 1, u'title': u'By task'},
+                u'cause': {u'id': ASSIGNMENT_VIA_TASK, u'title': u'By task'},
                 u'roles': [u'Contributor'],
                 u'reference': {u'url': self.task.absolute_url(), u'title': u'Vertragsentwurf \xdcberpr\xfcfen'},
                 u'principal': u'kathi.barfuss',
             },
             {
-                u'cause': {u'id': 1, 'title': u'By task'},
+                u'cause': {u'id': ASSIGNMENT_VIA_TASK, 'title': u'By task'},
                 u'roles': [u'Contributor'],
                 u'reference': {
                     u'url': self.subtask.absolute_url(),
@@ -212,25 +212,25 @@ class TestManageRoleAssignmentsView(IntegrationTestCase):
                 u'principal': u'kathi.barfuss',
             },
             {
-                u'cause': {u'id': 1, u'title': u'By task'},
+                u'cause': {u'id': ASSIGNMENT_VIA_TASK, u'title': u'By task'},
                 u'roles': [u'Contributor'],
                 u'reference': {u'url': self.sequential_task.absolute_url(), u'title': u'Personaleintritt'},
                 u'principal': u'kathi.barfuss',
             },
             {
-                u'cause': {u'id': 1, u'title': u'By task'},
+                u'cause': {u'id': ASSIGNMENT_VIA_TASK, u'title': u'By task'},
                 u'roles': [u'Contributor'],
                 u'reference': {u'url': self.seq_subtask_1.absolute_url(), u'title': u'Mitarbeiter Dossier generieren'},
                 u'principal': u'kathi.barfuss',
             },
             {
-                u'cause': {u'id': 1, u'title': u'By task'},
+                u'cause': {u'id': ASSIGNMENT_VIA_TASK, u'title': u'By task'},
                 u'roles': [u'Contributor'],
                 u'reference': {u'url': self.seq_subtask_2.absolute_url(), u'title': u'Arbeitsplatz vorbereiten'},
                 u'principal': u'kathi.barfuss',
             },
             {
-                u'cause': {u'id': 1, u'title': u'By task'},
+                u'cause': {u'id': ASSIGNMENT_VIA_TASK, u'title': u'By task'},
                 u'roles': [u'Contributor'],
                 u'reference': {
                     u'url': self.seq_subtask_3.absolute_url(),
@@ -239,7 +239,7 @@ class TestManageRoleAssignmentsView(IntegrationTestCase):
                 u'principal': u'kathi.barfuss',
             },
             {
-                u'cause': {u'id': 1, u'title': u'By task'},
+                u'cause': {u'id': ASSIGNMENT_VIA_TASK, u'title': u'By task'},
                 u'roles': [u'Contributor'],
                 u'reference': {
                     u'url': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/task-11',
@@ -248,7 +248,7 @@ class TestManageRoleAssignmentsView(IntegrationTestCase):
                 u'principal': u'kathi.barfuss',
             },
             {
-                u'cause': {u'id': 1, u'title': u'By task'},
+                u'cause': {u'id': ASSIGNMENT_VIA_TASK, u'title': u'By task'},
                 u'roles': [u'Contributor'],
                 u'reference': {
                     u'url': u'http://nohost/plone/ordnungssystem/fuhrung'

--- a/opengever/core/profiles/default/rolemap.xml
+++ b/opengever/core/profiles/default/rolemap.xml
@@ -176,6 +176,7 @@
 
     <!-- POLICY -->
     <permission name="plone.restapi: Use REST API" acquire="True">
+      <role name="Contributor" />
       <role name="Manager" />
       <role name="Member" />
     </permission>

--- a/opengever/core/upgrades/20190411161653_allow_non_member_contributors_to_use_the_rest_api/rolemap.xml
+++ b/opengever/core/upgrades/20190411161653_allow_non_member_contributors_to_use_the_rest_api/rolemap.xml
@@ -1,0 +1,9 @@
+<rolemap>
+  <permissions>
+    <permission name="plone.restapi: Use REST API" acquire="True">
+      <role name="Contributor" />
+      <role name="Manager" />
+      <role name="Member" />
+    </permission>
+  </permissions>
+</rolemap>

--- a/opengever/core/upgrades/20190411161653_allow_non_member_contributors_to_use_the_rest_api/upgrade.py
+++ b/opengever/core/upgrades/20190411161653_allow_non_member_contributors_to_use_the_rest_api/upgrade.py
@@ -1,0 +1,8 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AllowNonMemberContributorsToUseTheRESTAPI(UpgradeStep):
+    """Allow non-member contributors to use the REST API."""
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/dossier/tests/test_base.py
+++ b/opengever/dossier/tests/test_base.py
@@ -35,7 +35,8 @@ class TestDossierContainer(IntegrationTestCase):
         self.login(self.dossier_responsible)
         create(Builder('dossier').within(self.empty_dossier))
         create(Builder('task').within(self.empty_dossier)
-               .having(responsible=self.regular_user.getId()))
+               .having(responsible=self.regular_user.getId(),
+                       responsible_client=u'fa'))
         self.assertFalse(self.empty_dossier.is_all_supplied())
 
     def test_is_not_all_supplied_with_subdossier_and_mails(self):
@@ -48,7 +49,8 @@ class TestDossierContainer(IntegrationTestCase):
         self.login(self.dossier_responsible)
         subdossier = create(Builder('dossier').within(self.empty_dossier))
         create(Builder('task').within(subdossier)
-               .having(responsible=self.regular_user.getId()))
+               .having(responsible=self.regular_user.getId(),
+                       responsible_client=u'fa'))
         create(Builder('document').within(subdossier))
         self.assertTrue(self.empty_dossier.is_all_supplied())
 

--- a/opengever/dossier/tests/test_overview.py
+++ b/opengever/dossier/tests/test_overview.py
@@ -26,15 +26,17 @@ class TestOverview(IntegrationTestCase):
 
     @property
     def tested_document(self):
-        # XXX - this needs to be within the 10 latest documents
+        # XXX - This rotates out as we have more than 10 in the fixture
         return self.empty_document
 
     @property
     def tested_task(self):
-        return self.task
+        # XXX - This rotates out as we have more than 5 in the fixture
+        return self.inbox_task
 
     @property
     def tested_subtask(self):
+        # XXX - This rotates out as we have more than 5 in the fixture
         # XXX - not expected, but a quick way around the visibility limit
         return self.private_task
 
@@ -45,23 +47,24 @@ class TestOverview(IntegrationTestCase):
 
     @property
     def task_titles(self):
+        # XXX - These rotate out as we have more than 5 in the fixture
         return [
+            u're: Diskr\xe4te Dinge',
             u'Diskr\xe4te Dinge',
             u'Vertragsentw\xfcrfe 2018',
             u'Personaleintritt',
             u'Mitarbeiter Dossier generieren',
-            u'Vertragsentwurf \xdcberpr\xfcfen',
         ]
 
     @property
     def task_titles_minus_pending(self):
-        # As we have more than 5 tasks, they shift in like this
+        # XXX - These rotate out as we have more than 5 in the fixture
         return [
+            u're: Diskr\xe4te Dinge',
             u'Vertragsentw\xfcrfe 2018',
             u'Personaleintritt',
             u'Mitarbeiter Dossier generieren',
             u'Vertragsentwurf \xdcberpr\xfcfen',
-            u'Rechtliche Grundlagen in Vertragsentwurf \xdcberpr\xfcfen',
         ]
 
     @IntegrationTestCase.clock

--- a/opengever/dossier/tests/test_protect_dossier.py
+++ b/opengever/dossier/tests/test_protect_dossier.py
@@ -348,7 +348,8 @@ class TestProtectDossier(IntegrationTestCase):
 
         self.assertItemsEqual(
             ['Administrator', 'Contributor', 'Editor', 'Manager', 'Reader',
-             'user:fa_users', 'user:{}'.format(self.regular_user.getId())],
+             'user:fa_users', 'user:{}'.format(self.regular_user.getId()),
+             'user:fa_inbox_users'],
             self.get_allowed_roles_and_users_for(self.dossier))
 
         dossier_protector = IProtectDossier(self.dossier)

--- a/opengever/examplecontent/tests/test_hooks.py
+++ b/opengever/examplecontent/tests/test_hooks.py
@@ -23,4 +23,4 @@ class TestHooks(IntegrationTestCase):
         self.assertEqual(4, AgendaItem.query.count())
         self.assertEqual(9, Meeting.query.count())
 
-        self.assertEqual(10, Team.query.count())
+        self.assertEqual(12, Team.query.count())

--- a/opengever/globalindex/tests/test_query.py
+++ b/opengever/globalindex/tests/test_query.py
@@ -156,7 +156,8 @@ class TestTaskQueries(IntegrationTestCase):
              self.seq_subtask_2.get_sql_object(),
              self.seq_subtask_3.get_sql_object(),
              self.info_task.get_sql_object(),
-             self.private_task.get_sql_object()],
+             self.private_task.get_sql_object(),
+             self.inbox_task.get_sql_object()],
             Task.query.by_container(self.dossier, get_current_admin_unit()).all())
 
     def test_by_container_handles_similar_paths_exactly(self):

--- a/opengever/globalindex/tests/test_task_sql_syncer.py
+++ b/opengever/globalindex/tests/test_task_sql_syncer.py
@@ -25,7 +25,7 @@ class TestTaskSQLSyncer(IntegrationTestCase):
         self.assertEqual(self.dossier_responsible.getId(), task.issuer)
         self.assertTrue(task.is_private)
         self.assertEqual(self.regular_user.getId(), task.responsible)
-        expected_breadcrumbs =(
+        expected_breadcrumbs = (
             u'Ordnungssystem'
             u' > 1. F\xfchrung'
             u' > 1.1. Vertr\xe4ge und Vereinbarungen'

--- a/opengever/globalindex/tests/test_task_sql_syncer.py
+++ b/opengever/globalindex/tests/test_task_sql_syncer.py
@@ -13,7 +13,7 @@ class TestTaskSQLSyncer(IntegrationTestCase):
 
     def test_sql_task_is_created_on_plone_object_creation(self):
         self.login(self.regular_user)
-        self.assertEqual(14, Session.query(Task).count())
+        self.assertEqual(15, Session.query(Task).count())
 
         # self.private_task
         task = Session.query(Task).filter(
@@ -59,15 +59,15 @@ class TestTaskSQLSyncer(IntegrationTestCase):
 
     def test_sql_task_is_updated_on_plone_object_update(self):
         self.login(self.regular_user)
-        self.task.responsible_client = 'asd'
+        self.task.responsible_client = 'rk'
         self.task.title = u'G\xf6pf, iz mach mau'
         notify(ObjectModifiedEvent(self.task))
 
-        self.assertEqual(14, Session.query(Task).count())
+        self.assertEqual(15, Session.query(Task).count())
         task = Session.query(Task).filter(
             Task.title == u'G\xf6pf, iz mach mau').one()
 
-        self.assertEqual('asd', task.assigned_org_unit)
+        self.assertEqual('rk', task.assigned_org_unit)
         expected_breadcrumbs = (
             u'Ordnungssystem'
             u' > 1. F\xfchrung'
@@ -99,7 +99,8 @@ class TestTaskSQLSyncer(IntegrationTestCase):
         self.assertEqual(1, task.dossier_sequence_number)
         self.assertIsNone(task.text)
         expected_principals = [
-            get_current_org_unit().users_group.id(), self.regular_user.getId()]
+            get_current_org_unit().users_group.id(), self.regular_user.getId(),
+            get_current_org_unit().inbox_group.id(), u'rk_inbox_users']
         self.assertItemsEqual(expected_principals, task.principals)
         self.assertIsNone(task.predecessor)
 

--- a/opengever/inbox/tests/test_forwarding.py
+++ b/opengever/inbox/tests/test_forwarding.py
@@ -110,7 +110,7 @@ class TestForwarding(IntegrationTestCase):
         browser.open(self.inbox_forwarding, view='tabbedview_view-overview')
         responsible_row = browser.css('.listing').first.rows[8]
         self.assertEqual(['Responsible'], responsible_row.css('th').text)
-        self.assertEqual([u'Projekt \xdcberbaung Dorfmatte (Finanz\xe4mt)'],
+        self.assertEqual([u'Finanz\xe4mt / Projekt \xdcberbaung Dorfmatte (Finanz\xe4mt)'],
                          responsible_row.css('td').text)
 
     @browsing

--- a/opengever/inbox/tests/test_tabs.py
+++ b/opengever/inbox/tests/test_tabs.py
@@ -54,19 +54,14 @@ class TestAssignedInboxTaskTab(IntegrationTestCase):
     def test_lists_only_tasks_assigned_to_the_current_org_units_inbox(self):
         self.login(self.secretariat_user)
 
-        self.add_additional_org_unit()
-
-        self.inbox_forwarding.responsible = 'inbox:fa'
-        self.inbox_forwarding.sync()
-
         view = self.inbox.restrictedTraverse(
             'tabbedview_view-{}'.format(self.viewname))
         view.update()
 
         self.assertEquals(
-            [self.inbox_forwarding.get_sql_object()], view.contents)
+            [self.inbox_task.get_sql_object()], view.contents)
 
-        select_current_org_unit('additional')
+        select_current_org_unit('rk')
         view.update()
         self.assertEquals([], view.contents)
 
@@ -80,7 +75,8 @@ class TestAssignedInboxTaskTab(IntegrationTestCase):
             'tabbedview_view-{}'.format(self.viewname))
         view.update()
 
-        self.assertEquals([self.task.get_sql_object()], view.contents)
+        self.assertEquals([self.task.get_sql_object(),
+                           self.inbox_task.get_sql_object()], view.contents)
 
 
 class TestIssuedInboxTaskTab(IntegrationTestCase):

--- a/opengever/inbox/tests/test_workflow.py
+++ b/opengever/inbox/tests/test_workflow.py
@@ -2,6 +2,7 @@ from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
 from opengever.base.role_assignments import ASSIGNMENT_VIA_TASK
+from opengever.base.role_assignments import ASSIGNMENT_VIA_TASK_AGENCY
 from opengever.base.role_assignments import RoleAssignmentManager
 from opengever.testing import IntegrationTestCase
 from opengever.testing.helpers import index_data_for
@@ -145,11 +146,14 @@ class TestInboxWorkflow(IntegrationTestCase):
         # Editor role is granted to forwarding responsible
         assignment_manager = RoleAssignmentManager(self.forwarding)
         assignments = assignment_manager.storage._storage()
-        self.assertEqual(1, len(assignments))
-        assignment = assignments[0]
-        self.assertEqual(ASSIGNMENT_VIA_TASK, assignment["cause"])
-        self.assertEqual(["Editor"], assignment["roles"])
-        self.assertEqual(self.secretariat_user.getId(), assignment["principal"])
+        self.assertEqual(2, len(assignments))
+        user_assignment, inbox_assignment = assignments
+        self.assertEqual(ASSIGNMENT_VIA_TASK, user_assignment["cause"])
+        self.assertEqual(["Editor"], user_assignment["roles"])
+        self.assertEqual(self.secretariat_user.getId(), user_assignment["principal"])
+        self.assertEqual(ASSIGNMENT_VIA_TASK_AGENCY, inbox_assignment["cause"])
+        self.assertEqual(["Editor"], inbox_assignment["roles"])
+        self.assertEqual(self.secretariat_user.getId(), user_assignment["principal"])
 
         # No role assignments on contained objects as they already
         # inherit from the forwarding
@@ -178,11 +182,14 @@ class TestInboxWorkflow(IntegrationTestCase):
 
         assignment_manager = RoleAssignmentManager(self.inbox_forwarding)
         assignments = assignment_manager.storage._storage()
-        self.assertEqual(1, len(assignments))
-        assignment = assignments[0]
-        self.assertEqual(ASSIGNMENT_VIA_TASK, assignment["cause"])
-        self.assertEqual(["Editor"], assignment["roles"])
-        self.assertEqual(self.secretariat_user.getId(), assignment["principal"])
+        self.assertEqual(2, len(assignments))
+        user_assignment, inbox_assignment = assignments
+        self.assertEqual(ASSIGNMENT_VIA_TASK, user_assignment["cause"])
+        self.assertEqual(["Editor"], user_assignment["roles"])
+        self.assertEqual(self.secretariat_user.getId(), user_assignment["principal"])
+        self.assertEqual(ASSIGNMENT_VIA_TASK_AGENCY, inbox_assignment["cause"])
+        self.assertEqual(["Editor"], inbox_assignment["roles"])
+        self.assertEqual(u'fa_inbox_users', inbox_assignment["principal"])
 
     @browsing
     def test_forwarding_grants_view_permissions(self, browser):

--- a/opengever/inbox/tests/test_workflow.py
+++ b/opengever/inbox/tests/test_workflow.py
@@ -166,7 +166,7 @@ class TestInboxWorkflow(IntegrationTestCase):
         assignments = assignment_manager.storage._storage()
         self.assertEqual(2, len(assignments))
         assignment = assignments[0]
-        self.assertEqual(1, assignment["cause"])
+        self.assertEqual(ASSIGNMENT_VIA_TASK, assignment["cause"])
         self.assertEqual(["Editor"], assignment["roles"])
         self.assertEqual(self.regular_user.getId(), assignment["principal"])
 

--- a/opengever/inbox/tests/test_workflow.py
+++ b/opengever/inbox/tests/test_workflow.py
@@ -1,6 +1,7 @@
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
+from opengever.base.role_assignments import ASSIGNMENT_VIA_TASK
 from opengever.base.role_assignments import RoleAssignmentManager
 from opengever.testing import IntegrationTestCase
 from opengever.testing.helpers import index_data_for
@@ -146,7 +147,7 @@ class TestInboxWorkflow(IntegrationTestCase):
         assignments = assignment_manager.storage._storage()
         self.assertEqual(1, len(assignments))
         assignment = assignments[0]
-        self.assertEqual(1, assignment["cause"])
+        self.assertEqual(ASSIGNMENT_VIA_TASK, assignment["cause"])
         self.assertEqual(["Editor"], assignment["roles"])
         self.assertEqual(self.secretariat_user.getId(), assignment["principal"])
 
@@ -163,7 +164,7 @@ class TestInboxWorkflow(IntegrationTestCase):
 
         assignment_manager = RoleAssignmentManager(self.inbox_forwarding)
         assignments = assignment_manager.storage._storage()
-        self.assertEqual(1, len(assignments))
+        self.assertEqual(2, len(assignments))
         assignment = assignments[0]
         self.assertEqual(1, assignment["cause"])
         self.assertEqual(["Editor"], assignment["roles"])
@@ -179,7 +180,7 @@ class TestInboxWorkflow(IntegrationTestCase):
         assignments = assignment_manager.storage._storage()
         self.assertEqual(1, len(assignments))
         assignment = assignments[0]
-        self.assertEqual(1, assignment["cause"])
+        self.assertEqual(ASSIGNMENT_VIA_TASK, assignment["cause"])
         self.assertEqual(["Editor"], assignment["roles"])
         self.assertEqual(self.secretariat_user.getId(), assignment["principal"])
 

--- a/opengever/latex/tests/test_dossierjournal.py
+++ b/opengever/latex/tests/test_dossierjournal.py
@@ -205,6 +205,16 @@ class TestJournalListingLaTeXView(IntegrationTestCase):
             {
                 'action': {
                     'visible': True,
+                    'type': 'Task added',
+                    'title': u'label_task_added',
+                },
+                'comments': '',
+                'actor': 'robert.ziegler',
+                'time': DateTime('2016/08/31 18:27:33 GMT+2'),
+            },
+            {
+                'action': {
+                    'visible': True,
                     'type': 'Document added',
                     'title': u'label_document_added',
                 },

--- a/opengever/meeting/tests/test_committee_roles.py
+++ b/opengever/meeting/tests/test_committee_roles.py
@@ -62,6 +62,8 @@ class TestCommitteeGroupsVocabulary(IntegrationTestCase):
         self.assertItemsEqual(
             [u'fa_users',
              u'fa_inbox_users',
+             u'rk_users',
+             u'rk_inbox_users',
              u'projekt_a',
              u'projekt_b',
              u'projekt_laeaer',

--- a/opengever/meeting/tests/test_proposal.py
+++ b/opengever/meeting/tests/test_proposal.py
@@ -1160,6 +1160,7 @@ class TestProposal(IntegrationTestCase):
             u'Initialvertrag f\xfcr Bearbeitung',
             u'Initialvertrag f\xfcr Bearbeitung',
             'Personaleintritt',
+            u're: Diskr\xe4te Dinge',
             u'Vertr\xe4ge',
             u'Vertr\xe4gsentwurf',
             u'Vertragsentwurf \xdcberpr\xfcfen',

--- a/opengever/officeconnector/tests/test_api_task_checkout.py
+++ b/opengever/officeconnector/tests/test_api_task_checkout.py
@@ -1,0 +1,91 @@
+from copy import deepcopy
+from ftw.testbrowser import browsing
+from ftw.testbrowser.pages import factoriesmenu
+from ftw.testing import freeze
+from hashlib import sha256
+from opengever.officeconnector.testing import FREEZE_DATE
+from opengever.officeconnector.testing import JWT_SIGNING_SECRET_PLONE
+from opengever.officeconnector.testing import OCIntegrationTestCase
+from opengever.testing.assets import path_to_asset
+import jwt
+
+
+class TestOfficeconnectorTaskAPIWithCheckoutWithRESTAPI(OCIntegrationTestCase):
+
+    features = (
+        '!officeconnector-attach',
+        'officeconnector-checkout',
+        'officeconnector-restapi',
+    )
+
+    @browsing
+    def test_foreign_contributor_can_checkout_related_document_on_assigned_task(self, browser):
+        self.login(self.regular_user, browser)
+        # We get a reference to self.document so the foreign user can access it
+        document = self.document
+
+        browser.open(self.dossier)
+        factoriesmenu.add('Task')
+        browser.fill({
+            'Title': 'Task title',
+            'Task Type': 'For direct execution',
+            'Related Items': document,
+        })
+        form = browser.find_form_by_field('Responsible')
+        form.find_widget('Responsible').fill(
+            ':'.join(('rk', self.foreign_contributor.getId())))
+        browser.find('Save').click()
+
+        self.login(self.foreign_contributor, browser)
+
+        with freeze(FREEZE_DATE):
+            oc_url = self.fetch_document_checkout_oc_url(browser, document)
+
+        self.assertIsNotNone(oc_url)
+        self.assertEqual(200, browser.status_code)
+
+        expected_token = {
+            u'action': u'checkout',
+            u'documents': [u'createtreatydossiers000000000002'],
+            u'exp': 4121033100,
+            u'sub': u'james.bond',
+            u'url': u'http://nohost/plone/oc_checkout',
+            }
+        raw_token = oc_url.split(':')[-1]
+        token = jwt.decode(raw_token, JWT_SIGNING_SECRET_PLONE, algorithms=('HS256',))
+        self.assertEqual(expected_token, token)
+
+        expected_payloads = [{
+            u'status': u'status',
+            u'checkin': u'@checkin',
+            u'checkout': u'@checkout',
+            u'content-type': u'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+            u'document-url': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/document-14',
+            u'download': u'download',
+            u'filename': u'Vertraegsentwurf.docx',
+            u'lock': u'@lock',
+            u'unlock': u'@unlock',
+            u'upload': u'@tus-replace',
+            u'uuid': u'createtreatydossiers000000000002',
+        }]
+        payloads = self.fetch_document_checkout_payloads(browser, raw_token, token)
+        self.assertEqual(200, browser.status_code)
+        for payload, expected_payload in zip(payloads, expected_payloads):
+            payload_copy = deepcopy(payload)
+            self.assertFalse(payload_copy.pop('csrf-token', None))
+            self.assertTrue(payload_copy.pop('reauth', None))
+            self.assertEqual(expected_payload, payload_copy)
+
+        self.checkout_document_via_api(browser, raw_token, payloads[0], document)
+        self.lock_document_via_api(browser, raw_token, payloads[0], document)
+
+        original_checksum = sha256(self.download_document(browser, raw_token, payloads[0])).hexdigest()
+
+        with open(path_to_asset('addendum.docx')) as f:
+            self.upload_document_via_api(browser, raw_token, payloads[0], document, f)
+
+        new_checksum = sha256(self.download_document(browser, raw_token, payloads[0])).hexdigest()
+        self.assertNotEqual(new_checksum, original_checksum)
+
+        self.unlock_document_via_api(browser, raw_token, payloads[0], document)
+        self.checkin_document_via_api(browser, raw_token, payloads[0], document)

--- a/opengever/ogds/base/tests/test_sources.py
+++ b/opengever/ogds/base/tests/test_sources.py
@@ -1002,6 +1002,8 @@ class TestAllFilteredGroupsSource(TestAllGroupsSource):
         expected_groups = [
             u'fa_users',
             u'fa_inbox_users',
+            u'rk_users',
+            u'rk_inbox_users',
             u'projekt_a',
             u'projekt_b',
             u'projekt_laeaer',
@@ -1017,6 +1019,8 @@ class TestAllFilteredGroupsSource(TestAllGroupsSource):
         api.portal.set_registry_record('black_list_prefix', u'^fa_', ISharingConfiguration)
 
         expected_groups = [
+            u'rk_users',
+            u'rk_inbox_users',
             u'projekt_a',
             u'projekt_b',
             u'projekt_laeaer',

--- a/opengever/repository/tests/test_repositoryfolder_tabs.py
+++ b/opengever/repository/tests/test_repositoryfolder_tabs.py
@@ -173,6 +173,7 @@ class TestRepositoryFolderTasksTab(IntegrationTestCase):
             'Dossier': u'Vertr\xe4ge mit der kantonalen Finanzverwaltung',
             'Issued at': '31.08.2016',
             'Issuer': 'Ziegler Robert (robert.ziegler)',
+            'Organisational Unit': u'Finanz\xe4mt',
             'Responsible': u'B\xe4rfuss K\xe4thi (kathi.barfuss)',
             'Review state': 'task-state-in-progress',
             'Sequence number': '1',

--- a/opengever/tabbedview/tests/test_personaloverview.py
+++ b/opengever/tabbedview/tests/test_personaloverview.py
@@ -255,6 +255,7 @@ class TestGlobalTaskListings(IntegrationTestCase):
             u'Programm \xdcberpr\xfcfen',
             u'H\xf6rsaal reservieren',
             u'Diskr\xe4te Dinge',
+            u're: Diskr\xe4te Dinge',
             ]
         found_tasks = [row.get('Title') for row in browser.css('.listing').first.dicts()]
         self.assertEquals(expected_tasks, found_tasks)
@@ -267,6 +268,7 @@ class TestGlobalTaskListings(IntegrationTestCase):
             u'Programm \xdcberpr\xfcfen',
             u'H\xf6rsaal reservieren',
             u'Diskr\xe4te Dinge',
+            u're: Diskr\xe4te Dinge',
             ]
         found_tasks = [row.get('Title') for row in browser.css('.listing').first.dicts()]
         self.assertEquals(expected_tasks, found_tasks)
@@ -287,6 +289,7 @@ class TestGlobalTaskListings(IntegrationTestCase):
             u'Programm \xdcberpr\xfcfen',
             u'H\xf6rsaal reservieren',
             u'Diskr\xe4te Dinge',
+            u're: Diskr\xe4te Dinge',
             ]
         found_tasks = [row.get('Title') for row in browser.css('.listing').first.dicts()]
         self.assertItemsEqual(expected_tasks, found_tasks)
@@ -303,6 +306,7 @@ class TestGlobalTaskListings(IntegrationTestCase):
             u'Programm \xdcberpr\xfcfen',
             u'H\xf6rsaal reservieren',
             u'Diskr\xe4te Dinge',
+            u're: Diskr\xe4te Dinge',
             ]
         found_tasks = [row.get('Title') for row in browser.css('.listing').first.dicts()]
         self.assertItemsEqual(expected_tasks, found_tasks)
@@ -323,6 +327,7 @@ class TestGlobalTaskListings(IntegrationTestCase):
             u'Programm \xdcberpr\xfcfen',
             u'H\xf6rsaal reservieren',
             u'Diskr\xe4te Dinge',
+            u're: Diskr\xe4te Dinge',
             ]
         found_tasks = [row.get('Title') for row in browser.css('.listing').first.dicts()]
         self.assertItemsEqual(expected_tasks, found_tasks)
@@ -348,6 +353,7 @@ class TestGlobalTaskListings(IntegrationTestCase):
             u'Programm \xdcberpr\xfcfen',
             u'H\xf6rsaal reservieren',
             u'Diskr\xe4te Dinge',
+            u're: Diskr\xe4te Dinge',
         ]
         found_tasks = [row.get('Title') for row in browser.css('.listing').first.dicts()]
         self.assertItemsEqual(expected_tasks, found_tasks)

--- a/opengever/tabbedview/tests/test_tasklisting.py
+++ b/opengever/tabbedview/tests/test_tasklisting.py
@@ -18,6 +18,7 @@ class TestTaskListing(IntegrationTestCase):
             u'Personaleintritt',
             u'Vertragsentw\xfcrfe 2018',
             u'Diskr\xe4te Dinge',
+            u're: Diskr\xe4te Dinge',
         ]
         self.assertEquals(expected_tasks, [row.get('Title') for row in table.dicts()])
 
@@ -36,6 +37,7 @@ class TestTaskListing(IntegrationTestCase):
             'Vorstellungsrunde bei anderen Mitarbeitern',
             u'Vertragsentw\xfcrfe 2018',
             u'Diskr\xe4te Dinge',
+            u're: Diskr\xe4te Dinge',
         ]
         self.assertEqual(expected_tasks, [row.get('Title') for row in table.dicts()])
 

--- a/opengever/task/tests/test_api_support.py
+++ b/opengever/task/tests/test_api_support.py
@@ -289,17 +289,17 @@ class TestAPITransitions(IntegrationTestCase):
     def test_reassign_admin_unit_change_validation(self, browser):
         self.login(self.regular_user, browser=browser)
 
-        admin_unit, org_unit = self.add_additional_admin_and_org_unit()
+        org_unit = self.add_additional_admin_and_org_unit()[1]
         create(Builder('ogds_user')
-               .id('james.bond')
-               .having(firstname=u'James', lastname=u'Bond')
+               .id('johny.english')
+               .having(firstname=u'Johnny', lastname=u'English')
                .assign_to_org_units([org_unit]))
 
         url = '{}/@workflow/task-transition-reassign'.format(
             self.task.absolute_url())
         data = {'text': 'Robert macht das.',
-                'responsible': 'james.bond',
-                'responsible_client': u'rk'}
+                'responsible': 'johnny.english',
+                'responsible_client': u'gdgs'}
 
         with browser.expect_http_error(400):
             browser.open(url, method='POST',

--- a/opengever/task/tests/test_assign.py
+++ b/opengever/task/tests/test_assign.py
@@ -6,6 +6,7 @@ from ftw.testbrowser.pages.statusmessages import error_messages
 from ftw.testbrowser.pages.statusmessages import info_messages
 from opengever.base.oguid import Oguid
 from opengever.base.role_assignments import ASSIGNMENT_VIA_TASK
+from opengever.base.role_assignments import ASSIGNMENT_VIA_TASK_AGENCY
 from opengever.base.role_assignments import RoleAssignmentManager
 from opengever.task.adapters import IResponseContainer
 from opengever.task.reminder import TASK_REMINDER_SAME_DAY
@@ -108,31 +109,31 @@ class TestAssignTask(IntegrationTestCase):
         self.login(self.regular_user, browser=browser)
         self.set_workflow_state('task-state-open', self.task)
 
-        admin_unit, org_unit = self.add_additional_admin_and_org_unit()
+        org_unit = self.add_additional_admin_and_org_unit()[1]
 
         create(Builder('ogds_user')
-               .id('james.bond')
-               .having(firstname=u'James', lastname=u'Bond')
+               .id('johnny.english')
+               .having(firstname=u'Johnny', lastname=u'English')
                .assign_to_org_units([org_unit]))
 
-        responsible = u'rk:james.bond'
+        responsible = u'gdgs:johnny.english'
         self.assign_task(responsible, u'Please make that for me.')
 
-        self.assertEquals('james.bond', self.task.responsible)
-        self.assertEquals('rk', self.task.responsible_client)
+        self.assertEquals('johnny.english', self.task.responsible)
+        self.assertEquals('gdgs', self.task.responsible_client)
 
     @browsing
     def test_switching_admin_unit_in_progress_state_is_not_possible(self, browser):
         self.login(self.regular_user, browser=browser)
 
-        admin_unit, org_unit = self.add_additional_admin_and_org_unit()
+        org_unit = self.add_additional_admin_and_org_unit()[1]
 
         create(Builder('ogds_user')
-               .id('james.bond')
-               .having(firstname=u'James', lastname=u'Bond')
+               .id('johnny.english')
+               .having(firstname=u'Johnny', lastname=u'English')
                .assign_to_org_units([org_unit]))
 
-        responsible = u'rk:james.bond'
+        responsible = u'gdgs:johnny.english'
         self.assign_task(responsible, u'Please make that for me.')
 
         self.assertEquals(
@@ -187,7 +188,11 @@ class TestAssignTask(IntegrationTestCase):
             [{'cause': ASSIGNMENT_VIA_TASK,
               'roles': ['Editor'],
               'reference': Oguid.for_object(self.task).id,
-              'principal': 'jurgen.konig'}],
+              'principal': 'jurgen.konig'},
+             {'cause': ASSIGNMENT_VIA_TASK_AGENCY,
+              'roles': ['Editor'],
+              'reference': Oguid.for_object(self.task).id,
+              'principal': u'fa_inbox_users'}],
             manager.storage._storage())
 
     @browsing
@@ -203,7 +208,11 @@ class TestAssignTask(IntegrationTestCase):
             [{'cause': ASSIGNMENT_VIA_TASK,
               'roles': ['Editor'],
               'reference': Oguid.for_object(self.task).id,
-              'principal': 'jurgen.konig'}],
+              'principal': 'jurgen.konig'},
+             {'cause': ASSIGNMENT_VIA_TASK_AGENCY,
+              'roles': ['Editor'],
+              'reference': Oguid.for_object(self.task).id,
+              'principal': u'fa_inbox_users'}],
             manager.storage._storage())
 
         self.assertEqual(self.portal.absolute_url(), browser.url)
@@ -291,7 +300,11 @@ class TestAssignTaskWithSuccessors(IntegrationTestCase):
             [{'cause': ASSIGNMENT_VIA_TASK,
               'roles': ['Editor'],
               'reference': Oguid.for_object(self.task).id,
-              'principal': 'jurgen.konig'}],
+              'principal': 'jurgen.konig'},
+             {'cause': ASSIGNMENT_VIA_TASK_AGENCY,
+              'roles': ['Editor'],
+              'reference': Oguid.for_object(self.task).id,
+              'principal': u'fa_inbox_users'}],
             manager.storage._storage())
 
     @browsing
@@ -311,5 +324,9 @@ class TestAssignTaskWithSuccessors(IntegrationTestCase):
             [{'cause': ASSIGNMENT_VIA_TASK,
               'roles': ['Editor'],
               'reference': Oguid.for_object(self.successor).id,
-              'principal': 'jurgen.konig'}],
+              'principal': 'jurgen.konig'},
+             {'cause': ASSIGNMENT_VIA_TASK_AGENCY,
+              'roles': ['Editor'],
+              'reference': Oguid.for_object(self.successor).id,
+              'principal': u'fa_inbox_users'}],
             manager.storage._storage())

--- a/opengever/task/tests/test_assign.py
+++ b/opengever/task/tests/test_assign.py
@@ -5,6 +5,7 @@ from ftw.testbrowser import browsing
 from ftw.testbrowser.pages.statusmessages import error_messages
 from ftw.testbrowser.pages.statusmessages import info_messages
 from opengever.base.oguid import Oguid
+from opengever.base.role_assignments import ASSIGNMENT_VIA_TASK
 from opengever.base.role_assignments import RoleAssignmentManager
 from opengever.task.adapters import IResponseContainer
 from opengever.task.reminder import TASK_REMINDER_SAME_DAY
@@ -183,7 +184,7 @@ class TestAssignTask(IntegrationTestCase):
 
         manager = RoleAssignmentManager(self.task)
         self.assertEqual(
-            [{'cause': 1,
+            [{'cause': ASSIGNMENT_VIA_TASK,
               'roles': ['Editor'],
               'reference': Oguid.for_object(self.task).id,
               'principal': 'jurgen.konig'}],
@@ -199,7 +200,7 @@ class TestAssignTask(IntegrationTestCase):
 
         manager = RoleAssignmentManager(self.task)
         self.assertEqual(
-            [{'cause': 1,
+            [{'cause': ASSIGNMENT_VIA_TASK,
               'roles': ['Editor'],
               'reference': Oguid.for_object(self.task).id,
               'principal': 'jurgen.konig'}],
@@ -287,7 +288,7 @@ class TestAssignTaskWithSuccessors(IntegrationTestCase):
 
         manager = RoleAssignmentManager(self.task)
         self.assertEqual(
-            [{'cause': 1,
+            [{'cause': ASSIGNMENT_VIA_TASK,
               'roles': ['Editor'],
               'reference': Oguid.for_object(self.task).id,
               'principal': 'jurgen.konig'}],
@@ -307,7 +308,7 @@ class TestAssignTaskWithSuccessors(IntegrationTestCase):
 
         manager = RoleAssignmentManager(self.successor)
         self.assertEqual(
-            [{'cause': 1,
+            [{'cause': ASSIGNMENT_VIA_TASK,
               'roles': ['Editor'],
               'reference': Oguid.for_object(self.successor).id,
               'principal': 'jurgen.konig'}],

--- a/opengever/task/tests/test_forms.py
+++ b/opengever/task/tests/test_forms.py
@@ -40,6 +40,7 @@ class TestTaskAddForm(IntegrationTestCase):
             u'Initialvertrag f\xfcr Bearbeitung',
             u'Initialvertrag f\xfcr Bearbeitung',
             'Personaleintritt',
+            u're: Diskr\xe4te Dinge',
             u'Vertr\xe4ge',
             u'Vertr\xe4gsentwurf',
             u'Vertragsentwurf \xdcberpr\xfcfen',

--- a/opengever/task/tests/test_localroles.py
+++ b/opengever/task/tests/test_localroles.py
@@ -4,6 +4,7 @@ from ftw.builder import create
 from ftw.testbrowser import browsing
 from opengever.base.oguid import Oguid
 from opengever.base.role_assignments import ASSIGNMENT_VIA_TASK
+from opengever.base.role_assignments import ASSIGNMENT_VIA_TASK_AGENCY
 from opengever.base.role_assignments import RoleAssignmentManager
 from opengever.base.role_assignments import SharingRoleAssignment
 from opengever.task.task import ITask
@@ -113,40 +114,32 @@ class TestLocalRolesSetter(IntegrationTestCase):
 
     def test_inbox_group_of_the_responsible_client_has_the_same_localroles_as_the_responsible_in_a_multiclient_setup(self):
         self.login(self.regular_user)
-
-        self.add_additional_org_unit()
-
-        dossier = create(Builder('dossier'))
-        document = create(Builder('document'))
-        task = create(Builder('task')
-                      .within(dossier)
-                      .relate_to(document)
-                      .having(responsible=self.regular_user.id,
-                              responsible_client='fa'))
-
         self.assertEqual(
             ('Editor', ),
-            task.get_local_roles_for_userid('fa_inbox_users'))
+            self.task.get_local_roles_for_userid('fa_inbox_users'))
         self.assertEqual(
-            ('Reader', ),
-            document.get_local_roles_for_userid('fa_inbox_users'))
+            ('Editor', 'Reader', ),
+            self.document.get_local_roles_for_userid('fa_inbox_users'))
         self.assertEqual(
             ('Contributor', ),
-            dossier.get_local_roles_for_userid('fa_inbox_users'))
+            self.dossier.get_local_roles_for_userid('fa_inbox_users'))
 
     def test_inbox_group_has_no_additional_localroles_on_private_tasks(self):
         self.login(self.regular_user)
+        self.assertEqual(
+            (),
+            self.private_task.get_local_roles_for_userid('fa_inbox_users'))
 
-        self.add_additional_org_unit()
+    def test_inbox_group_has_no_additional_localroles_in_a_oneclient_setup(self):
+        self.login(self.regular_user)
+        self.disable_additional_org_units()
 
         dossier = create(Builder('dossier'))
         document = create(Builder('document'))
         task = create(Builder('task')
                       .within(dossier)
                       .relate_to(document)
-                      .having(responsible=self.regular_user.id,
-                              is_private=True,
-                              responsible_client='fa'))
+                      .having(responsible=self.regular_user.getId()))
 
         self.assertEqual(
             (),
@@ -157,37 +150,20 @@ class TestLocalRolesSetter(IntegrationTestCase):
         self.assertEqual(
             (),
             dossier.get_local_roles_for_userid('fa_inbox_users'))
-
-    def test_inbox_group_has_no_additional_localroles_in_a_oneclient_setup(self):
-        self.login(self.regular_user)
-
-        self.assertEqual(
-            (),
-            self.task.get_local_roles_for_userid('fa_inbox_users'))
-        self.assertEqual(
-            (),
-            self.document.get_local_roles_for_userid('fa_inbox_users'))
-        self.assertEqual(
-            (),
-            self.dossier.get_local_roles_for_userid('fa_inbox_users'))
 
     def test_use_inbox_group_when_inbox_is_responsible(self):
         self.login(self.regular_user)
 
-        task = create(Builder('task')
-                      .within(self.dossier)
-                      .having(responsible='inbox:fa'))
-
         self.assertEqual(
             ('Editor', ),
-            task.get_local_roles_for_userid('fa_inbox_users'))
+            self.inbox_task.get_local_roles_for_userid('fa_inbox_users'))
 
         self.assertEqual(
             ('Contributor', ),
             self.dossier.get_local_roles_for_userid('fa_inbox_users'))
 
         self.assertEqual(
-            (), task.get_local_roles_for_userid('inbox:client1'))
+            (), self.inbox_task.get_local_roles_for_userid('inbox:fa'))
 
     @browsing
     def test_responsible_can_edit_related_documents_that_are_inside_a_task(self, browser):
@@ -218,7 +194,11 @@ class TestLocalRolesRevoking(IntegrationTestCase):
             [{'cause': ASSIGNMENT_VIA_TASK,
               'roles': ['Editor'],
               'reference': Oguid.for_object(self.task),
-              'principal': 'kathi.barfuss'}], storage._storage())
+              'principal': 'kathi.barfuss'},
+             {'cause': ASSIGNMENT_VIA_TASK_AGENCY,
+              'roles': ['Editor'],
+              'reference': Oguid.for_object(self.task),
+              'principal': 'fa_inbox_users'}], storage._storage())
 
         # close
         browser.open(self.task, view='tabbedview_view-overview')
@@ -240,7 +220,11 @@ class TestLocalRolesRevoking(IntegrationTestCase):
             [{'cause': ASSIGNMENT_VIA_TASK,
               'roles': ['Editor'],
               'reference': Oguid.for_object(self.task),
-              'principal': 'kathi.barfuss'}], storage._storage())
+              'principal': 'kathi.barfuss'},
+             {'cause': ASSIGNMENT_VIA_TASK_AGENCY,
+              'roles': ['Editor'],
+              'reference': Oguid.for_object(self.task),
+              'principal': 'fa_inbox_users'}], storage._storage())
 
         # close
         browser.open(self.task, view='tabbedview_view-overview')
@@ -252,7 +236,11 @@ class TestLocalRolesRevoking(IntegrationTestCase):
             [{'cause': ASSIGNMENT_VIA_TASK,
               'roles': ['Editor'],
               'reference': Oguid.for_object(self.task),
-              'principal': 'kathi.barfuss'}], storage._storage())
+              'principal': 'kathi.barfuss'},
+             {'cause': ASSIGNMENT_VIA_TASK_AGENCY,
+              'roles': ['Editor'],
+              'reference': Oguid.for_object(self.task),
+              'principal': 'fa_inbox_users'}], storage._storage())
 
     @browsing
     def test_reassigning_task_revokes_responsible_roles_on_task(self, browser):
@@ -347,7 +335,9 @@ class TestLocalRolesRevoking(IntegrationTestCase):
         expected_oguids = [
             Oguid.for_object(task).id
             for task in (
-                self.task, self.subtask, self.info_task, self.private_task)
+                self.task, self.task, self.subtask, self.subtask,
+                self.info_task, self.info_task, self.private_task,
+                self.inbox_task)
         ]
         self.assertEqual(
             expected_oguids,
@@ -360,7 +350,8 @@ class TestLocalRolesRevoking(IntegrationTestCase):
         browser.click_on('Save')
         expected_oguids = [
             Oguid.for_object(task).id
-            for task in (self.subtask, self.info_task, self.private_task)
+            for task in (self.subtask, self.subtask, self.info_task,
+                         self.info_task, self.private_task, self.inbox_task)
         ]
         self.assertEqual(
             expected_oguids,
@@ -376,7 +367,9 @@ class TestLocalRolesRevoking(IntegrationTestCase):
 
         storage = RoleAssignmentManager(self.document).storage
         expected_oguids = [Oguid.for_object(task).id for task in (self.task,
-                           self.subtask, self.info_task, self.private_task)]
+                           self.task, self.subtask, self.subtask,
+                           self.info_task, self.info_task, self.private_task,
+                           self.inbox_task)]
         self.assertEqual(expected_oguids, [item.get('reference') for item in storage._storage()])
 
         # close
@@ -399,7 +392,11 @@ class TestLocalRolesRevoking(IntegrationTestCase):
         expected_assignments = [{'cause': ASSIGNMENT_VIA_TASK,
                                  'roles': ['Reader', 'Editor'],
                                  'reference': Oguid.for_object(self.task),
-                                 'principal': self.regular_user.id}]
+                                 'principal': self.regular_user.id},
+                                {'cause': ASSIGNMENT_VIA_TASK_AGENCY,
+                                 'roles': ['Reader', 'Editor'],
+                                 'reference': Oguid.for_object(self.task),
+                                 'principal': u'fa_inbox_users'}]
 
         document_storage = RoleAssignmentManager(self.proposaldocument).storage
         self.assertEqual(expected_assignments, document_storage._storage())
@@ -431,7 +428,11 @@ class TestLocalRolesRevoking(IntegrationTestCase):
         expected_assignments = [{'cause': ASSIGNMENT_VIA_TASK,
                                  'roles': ['Reader', 'Editor'],
                                  'reference': Oguid.for_object(self.task),
-                                 'principal': self.regular_user.id}]
+                                 'principal': self.regular_user.id},
+                                {'cause': ASSIGNMENT_VIA_TASK_AGENCY,
+                                 'roles': ['Reader', 'Editor'],
+                                 'reference': Oguid.for_object(self.task),
+                                 'principal': u'fa_inbox_users'}]
 
         document_storage = RoleAssignmentManager(self.proposaldocument).storage
         self.assertEqual(expected_assignments, document_storage._storage())
@@ -461,10 +462,18 @@ class TestLocalRolesRevoking(IntegrationTestCase):
               'roles': ['Contributor'],
               'reference': Oguid.for_object(self.meeting_task),
               'principal': self.dossier_responsible.id},
+             {'cause': ASSIGNMENT_VIA_TASK_AGENCY,
+              'roles': ['Contributor'],
+              'reference': Oguid.for_object(self.meeting_task),
+              'principal': 'fa_inbox_users'},
              {'cause': ASSIGNMENT_VIA_TASK,
               'roles': ['Contributor'],
               'reference': Oguid.for_object(self.meeting_subtask),
-              'principal': self.dossier_responsible.id}],
+              'principal': self.dossier_responsible.id},
+             {'cause': ASSIGNMENT_VIA_TASK_AGENCY,
+              'roles': ['Contributor'],
+              'reference': Oguid.for_object(self.meeting_subtask),
+              'principal': 'fa_inbox_users'}],
             storage._storage())
 
         # close subtask
@@ -488,7 +497,9 @@ class TestLocalRolesRevoking(IntegrationTestCase):
         self.meeting_task.revoke_permissions = False
 
         self.assertEqual(
-            (('franzi.muller', ('Owner',)), ('robert.ziegler', ('Contributor',))),
+            (('fa_inbox_users', ('Contributor',)),
+             ('franzi.muller', ('Owner',)),
+             ('robert.ziegler', ('Contributor',))),
             self.meeting_dossier.get_local_roles())
 
         storage = RoleAssignmentManager(self.meeting_dossier).storage
@@ -497,10 +508,18 @@ class TestLocalRolesRevoking(IntegrationTestCase):
               'roles': ['Contributor'],
               'reference': Oguid.for_object(self.meeting_task),
               'principal': self.dossier_responsible.id},
+             {'cause': ASSIGNMENT_VIA_TASK_AGENCY,
+              'roles': ['Contributor'],
+              'reference': Oguid.for_object(self.meeting_task),
+              'principal': 'fa_inbox_users'},
              {'cause': ASSIGNMENT_VIA_TASK,
               'roles': ['Contributor'],
               'reference': Oguid.for_object(self.meeting_subtask),
-              'principal': self.dossier_responsible.id}],
+              'principal': self.dossier_responsible.id},
+             {'cause': ASSIGNMENT_VIA_TASK_AGENCY,
+              'roles': ['Contributor'],
+              'reference': Oguid.for_object(self.meeting_subtask),
+              'principal': 'fa_inbox_users'}],
             storage._storage())
 
         # close subtask
@@ -516,10 +535,15 @@ class TestLocalRolesRevoking(IntegrationTestCase):
             [{'cause': ASSIGNMENT_VIA_TASK,
               'roles': ['Contributor'],
               'reference': Oguid.for_object(self.meeting_task),
-              'principal': self.dossier_responsible.id}],
+              'principal': self.dossier_responsible.id},
+             {'cause': ASSIGNMENT_VIA_TASK_AGENCY,
+              'roles': ['Contributor'],
+              'reference': Oguid.for_object(self.meeting_task),
+              'principal': 'fa_inbox_users'}],
             storage._storage())
         self.assertEqual(
-            (('franzi.muller', ('Owner',)),
+            (('fa_inbox_users', ('Contributor',)),
+             ('franzi.muller', ('Owner',)),
              ('robert.ziegler', ('Contributor',))),
             self.meeting_dossier.get_local_roles())
 
@@ -553,7 +577,11 @@ class TestLocalRolesRevoking(IntegrationTestCase):
             [{'cause': ASSIGNMENT_VIA_TASK,
               'roles': ['Editor'],
               'reference': Oguid.for_object(self.subtask),
-              'principal': self.regular_user.id}],
+              'principal': self.regular_user.id},
+             {'cause': ASSIGNMENT_VIA_TASK_AGENCY,
+              'roles': ['Editor'],
+              'reference': Oguid.for_object(self.subtask),
+              'principal': 'fa_inbox_users'}],
             storage._storage())
 
     @browsing
@@ -589,7 +617,11 @@ class TestLocalRolesRevoking(IntegrationTestCase):
             [{'cause': ASSIGNMENT_VIA_TASK,
               'roles': ['Editor'],
               'reference': Oguid.for_object(self.subtask),
-              'principal': self.regular_user.id}],
+              'principal': self.regular_user.id},
+             {'cause': ASSIGNMENT_VIA_TASK_AGENCY,
+              'roles': ['Editor'],
+              'reference': Oguid.for_object(self.subtask),
+              'principal': 'fa_inbox_users'}],
             storage._storage())
 
     @browsing
@@ -601,7 +633,11 @@ class TestLocalRolesRevoking(IntegrationTestCase):
             [{'cause': ASSIGNMENT_VIA_TASK,
               'roles': ['Editor'],
               'reference': Oguid.for_object(self.seq_subtask_2),
-              'principal': 'kathi.barfuss'}], storage._storage())
+              'principal': 'kathi.barfuss'},
+             {'cause': ASSIGNMENT_VIA_TASK_AGENCY,
+              'roles': ['Editor'],
+              'reference': Oguid.for_object(self.seq_subtask_2),
+              'principal': 'fa_inbox_users'}], storage._storage())
 
         # skip
         browser.open(self.seq_subtask_2, view='tabbedview_view-overview')
@@ -620,7 +656,11 @@ class TestLocalRolesRevoking(IntegrationTestCase):
             [{'cause': ASSIGNMENT_VIA_TASK,
               'roles': ['Editor'],
               'reference': Oguid.for_object(self.seq_subtask_2),
-              'principal': 'kathi.barfuss'}], storage._storage())
+              'principal': 'kathi.barfuss'},
+             {'cause': ASSIGNMENT_VIA_TASK_AGENCY,
+              'roles': ['Editor'],
+              'reference': Oguid.for_object(self.seq_subtask_2),
+              'principal': 'fa_inbox_users'}], storage._storage())
 
         # skip
         browser.open(self.seq_subtask_2, view='tabbedview_view-overview')
@@ -631,7 +671,11 @@ class TestLocalRolesRevoking(IntegrationTestCase):
             [{'cause': ASSIGNMENT_VIA_TASK,
               'roles': ['Editor'],
               'reference': Oguid.for_object(self.seq_subtask_2),
-              'principal': 'kathi.barfuss'}], storage._storage())
+              'principal': 'kathi.barfuss'},
+             {'cause': ASSIGNMENT_VIA_TASK_AGENCY,
+              'roles': ['Editor'],
+              'reference': Oguid.for_object(self.seq_subtask_2),
+              'principal': 'fa_inbox_users'}], storage._storage())
 
     def test_can_delete_related_document_from_task(self):
         """The localroles update event used to explode when a related item was

--- a/opengever/task/tests/test_localroles.py
+++ b/opengever/task/tests/test_localroles.py
@@ -3,6 +3,7 @@ from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
 from opengever.base.oguid import Oguid
+from opengever.base.role_assignments import ASSIGNMENT_VIA_TASK
 from opengever.base.role_assignments import RoleAssignmentManager
 from opengever.base.role_assignments import SharingRoleAssignment
 from opengever.task.task import ITask
@@ -214,7 +215,7 @@ class TestLocalRolesRevoking(IntegrationTestCase):
 
         storage = RoleAssignmentManager(self.task).storage
         self.assertEqual(
-            [{'cause': 1,
+            [{'cause': ASSIGNMENT_VIA_TASK,
               'roles': ['Editor'],
               'reference': Oguid.for_object(self.task),
               'principal': 'kathi.barfuss'}], storage._storage())
@@ -236,7 +237,7 @@ class TestLocalRolesRevoking(IntegrationTestCase):
 
         storage = RoleAssignmentManager(self.task).storage
         self.assertEqual(
-            [{'cause': 1,
+            [{'cause': ASSIGNMENT_VIA_TASK,
               'roles': ['Editor'],
               'reference': Oguid.for_object(self.task),
               'principal': 'kathi.barfuss'}], storage._storage())
@@ -248,7 +249,7 @@ class TestLocalRolesRevoking(IntegrationTestCase):
         browser.click_on('Save')
 
         self.assertEqual(
-            [{'cause': 1,
+            [{'cause': ASSIGNMENT_VIA_TASK,
               'roles': ['Editor'],
               'reference': Oguid.for_object(self.task),
               'principal': 'kathi.barfuss'}], storage._storage())
@@ -395,7 +396,7 @@ class TestLocalRolesRevoking(IntegrationTestCase):
         ITask(self.task).relatedItems.append(relation)
         notify(ObjectModifiedEvent(self.task))
 
-        expected_assignments = [{'cause': 1,
+        expected_assignments = [{'cause': ASSIGNMENT_VIA_TASK,
                                  'roles': ['Reader', 'Editor'],
                                  'reference': Oguid.for_object(self.task),
                                  'principal': self.regular_user.id}]
@@ -427,7 +428,7 @@ class TestLocalRolesRevoking(IntegrationTestCase):
         ITask(self.task).relatedItems.append(relation)
         notify(ObjectModifiedEvent(self.task))
 
-        expected_assignments = [{'cause': 1,
+        expected_assignments = [{'cause': ASSIGNMENT_VIA_TASK,
                                  'roles': ['Reader', 'Editor'],
                                  'reference': Oguid.for_object(self.task),
                                  'principal': self.regular_user.id}]
@@ -456,11 +457,11 @@ class TestLocalRolesRevoking(IntegrationTestCase):
 
         storage = RoleAssignmentManager(self.meeting_dossier).storage
         self.assertEqual(
-            [{'cause': 1,
+            [{'cause': ASSIGNMENT_VIA_TASK,
               'roles': ['Contributor'],
               'reference': Oguid.for_object(self.meeting_task),
               'principal': self.dossier_responsible.id},
-             {'cause': 1,
+             {'cause': ASSIGNMENT_VIA_TASK,
               'roles': ['Contributor'],
               'reference': Oguid.for_object(self.meeting_subtask),
               'principal': self.dossier_responsible.id}],
@@ -492,11 +493,11 @@ class TestLocalRolesRevoking(IntegrationTestCase):
 
         storage = RoleAssignmentManager(self.meeting_dossier).storage
         self.assertEqual(
-            [{'cause': 1,
+            [{'cause': ASSIGNMENT_VIA_TASK,
               'roles': ['Contributor'],
               'reference': Oguid.for_object(self.meeting_task),
               'principal': self.dossier_responsible.id},
-             {'cause': 1,
+             {'cause': ASSIGNMENT_VIA_TASK,
               'roles': ['Contributor'],
               'reference': Oguid.for_object(self.meeting_subtask),
               'principal': self.dossier_responsible.id}],
@@ -512,7 +513,7 @@ class TestLocalRolesRevoking(IntegrationTestCase):
         browser.click_on('Save')
 
         self.assertEqual(
-            [{'cause': 1,
+            [{'cause': ASSIGNMENT_VIA_TASK,
               'roles': ['Contributor'],
               'reference': Oguid.for_object(self.meeting_task),
               'principal': self.dossier_responsible.id}],
@@ -549,7 +550,7 @@ class TestLocalRolesRevoking(IntegrationTestCase):
         storage = RoleAssignmentManager(self.subtask).storage
 
         self.assertEqual(
-            [{'cause': 1,
+            [{'cause': ASSIGNMENT_VIA_TASK,
               'roles': ['Editor'],
               'reference': Oguid.for_object(self.subtask),
               'principal': self.regular_user.id}],
@@ -585,7 +586,7 @@ class TestLocalRolesRevoking(IntegrationTestCase):
 
         storage = RoleAssignmentManager(self.subtask).storage
         self.assertEqual(
-            [{'cause': 1,
+            [{'cause': ASSIGNMENT_VIA_TASK,
               'roles': ['Editor'],
               'reference': Oguid.for_object(self.subtask),
               'principal': self.regular_user.id}],
@@ -597,7 +598,7 @@ class TestLocalRolesRevoking(IntegrationTestCase):
 
         storage = RoleAssignmentManager(self.seq_subtask_2).storage
         self.assertEqual(
-            [{'cause': 1,
+            [{'cause': ASSIGNMENT_VIA_TASK,
               'roles': ['Editor'],
               'reference': Oguid.for_object(self.seq_subtask_2),
               'principal': 'kathi.barfuss'}], storage._storage())
@@ -616,7 +617,7 @@ class TestLocalRolesRevoking(IntegrationTestCase):
 
         storage = RoleAssignmentManager(self.seq_subtask_2).storage
         self.assertEqual(
-            [{'cause': 1,
+            [{'cause': ASSIGNMENT_VIA_TASK,
               'roles': ['Editor'],
               'reference': Oguid.for_object(self.seq_subtask_2),
               'principal': 'kathi.barfuss'}], storage._storage())
@@ -627,7 +628,7 @@ class TestLocalRolesRevoking(IntegrationTestCase):
         browser.click_on('Save')
 
         self.assertEqual(
-            [{'cause': 1,
+            [{'cause': ASSIGNMENT_VIA_TASK,
               'roles': ['Editor'],
               'reference': Oguid.for_object(self.seq_subtask_2),
               'principal': 'kathi.barfuss'}], storage._storage())

--- a/opengever/task/tests/test_localroles.py
+++ b/opengever/task/tests/test_localroles.py
@@ -777,4 +777,4 @@ class TestDossierReindexShortcut(IntegrationTestCase):
                     u'`{}` allows Contributor to View on `{}` state.'.format(wf_id, state_id))
                 self.assertEqual(
                     0, permission_info['acquired'],
-                    u'{} has acquired View permission on state.'.format(wf_id, state_id))
+                    u'{} has acquired View permission on `{}` state.'.format(wf_id, state_id))

--- a/opengever/task/tests/test_overview.py
+++ b/opengever/task/tests/test_overview.py
@@ -227,8 +227,8 @@ class TestTaskTextTransformation(IntegrationTestCase):
              'task-state-in-progress',
              'November 1, 2016',
              'No reminder',
-             'Ziegler Robert (robert.ziegler)',
-             u'B\xe4rfuss K\xe4thi (kathi.barfuss)', ''],
+             u'Finanz\xe4mt / Ziegler Robert (robert.ziegler)',
+             u'Finanz\xe4mt / B\xe4rfuss K\xe4thi (kathi.barfuss)', ''],
             table_data)
 
     @browsing

--- a/opengever/task/tests/test_principals.py
+++ b/opengever/task/tests/test_principals.py
@@ -7,10 +7,10 @@ class TestTaskPrincipals(IntegrationTestCase):
         self.login(self.regular_user)
 
         self.assertEqual(
-            [u'kathi.barfuss', u'fa_users'], self.task.get_principals())
+            [u'kathi.barfuss', u'fa_inbox_users', u'fa_users'], self.task.get_principals())
 
     def test_does_respect_blocked_role_inheritance(self):
         self.login(self.regular_user)
 
         self.assertEqual(
-            [u'kathi.barfuss'], self.task_in_protected_dossier.get_principals())
+            [u'kathi.barfuss', u'fa_inbox_users'], self.task_in_protected_dossier.get_principals())

--- a/opengever/task/tests/test_revoke_permissions.py
+++ b/opengever/task/tests/test_revoke_permissions.py
@@ -3,6 +3,7 @@ from ftw.testbrowser.pages import editbar
 from ftw.testbrowser.pages.statusmessages import error_messages
 from ftw.testbrowser.pages.statusmessages import info_messages
 from opengever.base.oguid import Oguid
+from opengever.base.role_assignments import ASSIGNMENT_VIA_TASK
 from opengever.base.role_assignments import RoleAssignmentManager
 from opengever.task import is_optional_task_permissions_revoking_enabled
 from opengever.task.browser.revoke_permissions import RevokePermissions
@@ -31,7 +32,7 @@ class TestRevokePermissions(IntegrationTestCase):
 
         storage = RoleAssignmentManager(self.subtask).storage
         self.assertEqual(
-            [{'cause': 1,
+            [{'cause': ASSIGNMENT_VIA_TASK,
               'roles': ['Editor'],
               'reference': Oguid.for_object(self.subtask),
               'principal': self.regular_user.id}],
@@ -66,7 +67,7 @@ class TestRevokePermissions(IntegrationTestCase):
 
         self.set_workflow_state('task-state-tested-and-closed', self.subtask)
 
-        expected_assignments = [{'cause': 1,
+        expected_assignments = [{'cause': ASSIGNMENT_VIA_TASK,
                                  'roles': ['Reader', 'Editor'],
                                  'reference': Oguid.for_object(self.subtask),
                                  'principal': self.regular_user.id}]
@@ -87,7 +88,7 @@ class TestRevokePermissions(IntegrationTestCase):
 
         storage = RoleAssignmentManager(self.dossier).storage
         self.assertIn(
-            {'cause': 1,
+            {'cause': ASSIGNMENT_VIA_TASK,
              'roles': ['Contributor'],
              'reference': Oguid.for_object(self.subtask),
              'principal': self.regular_user.id},
@@ -95,7 +96,7 @@ class TestRevokePermissions(IntegrationTestCase):
 
         RevokePermissions(self.subtask, self.request)()
         self.assertNotIn(
-            {'cause': 1,
+            {'cause': ASSIGNMENT_VIA_TASK,
              'roles': ['Contributor'],
              'reference': Oguid.for_object(self.subtask),
              'principal': self.regular_user.id},
@@ -188,7 +189,7 @@ class TestRevokePermissionsAction(IntegrationTestCase):
 
         storage = RoleAssignmentManager(self.subtask).storage
         self.assertEqual(
-            [{'cause': 1,
+            [{'cause': ASSIGNMENT_VIA_TASK,
               'roles': ['Editor'],
               'reference': Oguid.for_object(self.subtask),
               'principal': self.regular_user.id}],

--- a/opengever/task/tests/test_revoke_permissions.py
+++ b/opengever/task/tests/test_revoke_permissions.py
@@ -7,7 +7,6 @@ from opengever.base.role_assignments import ASSIGNMENT_VIA_TASK
 from opengever.base.role_assignments import RoleAssignmentManager
 from opengever.task import is_optional_task_permissions_revoking_enabled
 from opengever.task.browser.revoke_permissions import RevokePermissions
-from opengever.task.interfaces import ITaskSettings
 from opengever.task.task import ITask
 from opengever.testing import IntegrationTestCase
 from plone import api

--- a/opengever/task/tests/test_revoke_permissions.py
+++ b/opengever/task/tests/test_revoke_permissions.py
@@ -4,6 +4,7 @@ from ftw.testbrowser.pages.statusmessages import error_messages
 from ftw.testbrowser.pages.statusmessages import info_messages
 from opengever.base.oguid import Oguid
 from opengever.base.role_assignments import ASSIGNMENT_VIA_TASK
+from opengever.base.role_assignments import ASSIGNMENT_VIA_TASK_AGENCY
 from opengever.base.role_assignments import RoleAssignmentManager
 from opengever.task import is_optional_task_permissions_revoking_enabled
 from opengever.task.browser.revoke_permissions import RevokePermissions
@@ -34,7 +35,11 @@ class TestRevokePermissions(IntegrationTestCase):
             [{'cause': ASSIGNMENT_VIA_TASK,
               'roles': ['Editor'],
               'reference': Oguid.for_object(self.subtask),
-              'principal': self.regular_user.id}],
+              'principal': self.regular_user.id},
+             {'cause': ASSIGNMENT_VIA_TASK_AGENCY,
+              'roles': ['Editor'],
+              'reference': Oguid.for_object(self.subtask),
+              'principal': u'fa_inbox_users'}],
             storage._storage())
 
         RevokePermissions(self.subtask, self.request)()
@@ -46,13 +51,16 @@ class TestRevokePermissions(IntegrationTestCase):
 
         storage = RoleAssignmentManager(self.document).storage
         expected_oguids = [Oguid.for_object(task).id for task in (self.task,
-                           self.subtask, self.info_task, self.private_task)]
+                           self.task, self.subtask, self.subtask,
+                           self.info_task, self.info_task, self.private_task,
+                           self.inbox_task)]
         self.assertEqual(expected_oguids,
                          [item.get('reference') for item in storage._storage()])
 
         RevokePermissions(self.subtask, self.request)()
         expected_oguids = [Oguid.for_object(task).id for task in
-                           (self.task, self.info_task, self.private_task)]
+                           (self.task, self.task, self.info_task,
+                            self.info_task, self.private_task, self.inbox_task)]
         self.assertEqual(expected_oguids,
                          [item.get('reference') for item in storage._storage()])
 
@@ -69,7 +77,11 @@ class TestRevokePermissions(IntegrationTestCase):
         expected_assignments = [{'cause': ASSIGNMENT_VIA_TASK,
                                  'roles': ['Reader', 'Editor'],
                                  'reference': Oguid.for_object(self.subtask),
-                                 'principal': self.regular_user.id}]
+                                 'principal': self.regular_user.id},
+                                {'cause': ASSIGNMENT_VIA_TASK_AGENCY,
+                                 'roles': ['Reader', 'Editor'],
+                                 'reference': Oguid.for_object(self.subtask),
+                                 'principal': u'fa_inbox_users'}]
 
         document_storage = RoleAssignmentManager(self.proposaldocument).storage
         self.assertEqual(expected_assignments, document_storage._storage())
@@ -191,7 +203,11 @@ class TestRevokePermissionsAction(IntegrationTestCase):
             [{'cause': ASSIGNMENT_VIA_TASK,
               'roles': ['Editor'],
               'reference': Oguid.for_object(self.subtask),
-              'principal': self.regular_user.id}],
+              'principal': self.regular_user.id},
+             {'cause': ASSIGNMENT_VIA_TASK_AGENCY,
+              'roles': ['Editor'],
+              'reference': Oguid.for_object(self.subtask),
+              'principal': 'fa_inbox_users'}],
             storage._storage())
 
         browser.open(self.subtask)

--- a/opengever/task/tests/test_team_tasks.py
+++ b/opengever/task/tests/test_team_tasks.py
@@ -162,20 +162,12 @@ class TestTeamTasks(IntegrationTestCase):
     def test_multi_admin_unit_team_task_edit_in_issuer_dossier(self, browser):
         self.login(self.regular_user, browser=browser)
 
-        ra_admin_unit = create(Builder('admin_unit')
-                                .having(title=u'Ratskanzlei',
-                                        unit_id=u'rk',
-                                        public_url='http://nohost/plone'))
-
-        create(Builder('org_unit')
-               .id('rk')
-               .having(title=u'Ratskanzlei', admin_unit=ra_admin_unit)
-               .with_default_groups())
+        self.add_additional_admin_and_org_unit()
 
         ITask(self.task).responsible = u'team:1'
-        ITask(self.task).responsible_client = u'rk'
+        ITask(self.task).responsible_client = u'gdgs'
         self.task.get_sql_object().responsible = u'team:1'
-        self.task.get_sql_object().assigned_org_unit = u'rk'
+        self.task.get_sql_object().assigned_org_unit = u'gdgs'
 
         self.set_workflow_state('task-state-open', self.task)
 

--- a/opengever/tasktemplates/tests/test_trigger.py
+++ b/opengever/tasktemplates/tests/test_trigger.py
@@ -496,6 +496,7 @@ class TestTriggeringTaskTemplate(IntegrationTestCase):
             u'Diskr\xe4te Dinge',
             u'Initialvertrag f\xfcr Bearbeitung',
             'Personaleintritt',
+            u're: Diskr\xe4te Dinge',
             u'Vertr\xe4gsentwurf',
             u'Vertragsentwurf \xdcberpr\xfcfen',
             u'Vertragsentw\xfcrfe 2018',


### PR DESCRIPTION
* Amended the fixture to be a two org unit setup
* Non-`Member` `Contributor`s can now use the REST API

Closes https://github.com/4teamwork/opengever.core/issues/5541