### PR TITLE
Fix issue on task creation when is_private feature is disabled.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,7 @@ Changelog
 - Show dossier from template action also when adding dossier disallowed. [njohner]
 - Improve task restriction query, so that it works also on oracle backends. [phgross]
 - Add restapi @journal endpoint to get journal entries. [elioschmutz]
+- Fix issue on task creation when is_private feature is disabled. [phgross]
 - Add webaction forms (add and edit) and management view. [njohner]
 - Fix solr error during copy/paste of word document. [njohner]
 - Allow non-member contributors to use the REST API. [Rotonen]

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,7 @@ Changelog
 - Show dossier from template action also when adding dossier disallowed. [njohner]
 - Improve task restriction query, so that it works also on oracle backends. [phgross]
 - Add restapi @journal endpoint to get journal entries. [elioschmutz]
+- Omit the `revoke_permissions` field instead of only hiding it. [phgross]
 - Fix issue on task creation when is_private feature is disabled. [phgross]
 - Add webaction forms (add and edit) and management view. [njohner]
 - Fix solr error during copy/paste of word document. [njohner]

--- a/opengever/task/browser/forms.py
+++ b/opengever/task/browser/forms.py
@@ -36,6 +36,13 @@ class TaskAddForm(DefaultAddForm):
     def schema(self):
         return self.instance_schema
 
+    def updateFieldsFromSchemata(self):
+        super(TaskAddForm, self).updateFieldsFromSchemata()
+        if not is_private_task_feature_enabled():
+            common_group = next(
+                group for group in self.groups if group.__name__ == u'common')
+            common_group.fields = common_group.fields.omit('is_private')
+
     def update(self):
         # put default value for relatedItems into request
         paths = self.request.get('paths', [])
@@ -59,11 +66,6 @@ class TaskAddForm(DefaultAddForm):
             additional_group.widgets['tasktemplate_position'].value = position
 
         additional_group.widgets['tasktemplate_position'].mode = HIDDEN_MODE
-
-        if not is_private_task_feature_enabled():
-            common_group = next(
-                group for group in self.groups if group.__name__ == u'common')
-            common_group.widgets['is_private'].mode = HIDDEN_MODE
 
         if not is_optional_task_permissions_revoking_enabled():
             common_group = next(
@@ -154,6 +156,14 @@ class TaskEditForm(DefaultEditForm):
      - Require the Edit Task permission
      - Records reassign activity when the responsible has changed.
     """
+
+    def updateFieldsFromSchemata(self):
+        super(TaskEditForm, self).updateFieldsFromSchemata()
+
+        if not is_private_task_feature_enabled():
+            common_group = next(
+                group for group in self.groups if group.__name__ == u'common')
+            common_group.fields = common_group.fields.omit('is_private')
 
     def applyChanges(self, data):
         """Records reassign activity when the responsible has changed.

--- a/opengever/task/browser/forms.py
+++ b/opengever/task/browser/forms.py
@@ -43,6 +43,11 @@ class TaskAddForm(DefaultAddForm):
                 group for group in self.groups if group.__name__ == u'common')
             common_group.fields = common_group.fields.omit('is_private')
 
+        if not is_optional_task_permissions_revoking_enabled():
+            common_group = next(
+                group for group in self.groups if group.__name__ == u'common')
+            common_group.fields = common_group.fields.omit('revoke_permissions')
+
     def update(self):
         # put default value for relatedItems into request
         paths = self.request.get('paths', [])
@@ -66,11 +71,6 @@ class TaskAddForm(DefaultAddForm):
             additional_group.widgets['tasktemplate_position'].value = position
 
         additional_group.widgets['tasktemplate_position'].mode = HIDDEN_MODE
-
-        if not is_optional_task_permissions_revoking_enabled():
-            common_group = next(
-                group for group in self.groups if group.__name__ == u'common')
-            common_group.widgets['revoke_permissions'].mode = HIDDEN_MODE
 
     def createAndAdd(self, data):
         created = []
@@ -165,6 +165,11 @@ class TaskEditForm(DefaultEditForm):
                 group for group in self.groups if group.__name__ == u'common')
             common_group.fields = common_group.fields.omit('is_private')
 
+        if not is_optional_task_permissions_revoking_enabled():
+            common_group = next(
+                group for group in self.groups if group.__name__ == u'common')
+            common_group.fields = common_group.fields.omit('revoke_permissions')
+
     def applyChanges(self, data):
         """Records reassign activity when the responsible has changed.
         Also update the responsible_cliend and responsible user
@@ -199,11 +204,3 @@ class TaskEditForm(DefaultEditForm):
                 (ITask['responsible_client'],
                  data.get('responsible_client')),),
             transition=REASSIGN_TRANSITION, supress_events=True)
-
-    def update(self):
-        super(TaskEditForm, self).update()
-
-        if not is_optional_task_permissions_revoking_enabled():
-            common_group = next(
-                group for group in self.groups if group.__name__ == u'common')
-            common_group.widgets['revoke_permissions'].mode = HIDDEN_MODE

--- a/opengever/task/tests/test_activities.py
+++ b/opengever/task/tests/test_activities.py
@@ -17,6 +17,7 @@ from opengever.task.browser.accept.utils import accept_task_with_successor
 from opengever.tasktemplates.interfaces import IFromSequentialTasktemplate
 from opengever.testing import FunctionalTestCase
 from opengever.testing import IntegrationTestCase
+from plone import api
 from plone.app.testing import TEST_USER_ID
 from sqlalchemy import desc
 from zope.interface import alsoProvides
@@ -71,6 +72,9 @@ class TestTaskActivites(FunctionalTestCase):
 
     @browsing
     def test_private_task_added(self, browser):
+        api.portal.set_registry_record(
+            'opengever.task.interfaces.ITaskSettings.private_task_feature_enabled',
+            True)
         browser.login().open(self.dossier, view='++add++opengever.task.task')
         browser.fill({'Title': u'Abkl\xe4rung Fall Meier',
                       'Task Type': 'comment',

--- a/opengever/task/tests/test_revoke_permissions.py
+++ b/opengever/task/tests/test_revoke_permissions.py
@@ -277,27 +277,6 @@ class TestRevokePermissionsFeatureDeactivated(IntegrationTestCase):
         self.assertIsNotNone(browser.forms.get('form').find_field("Revoke permissions."))
 
     @browsing
-    def test_cant_create_task_with_revoke_permissions_false_when_feature_disabled(self, browser):
-        self.login(self.dossier_responsible, browser)
-
-        with self.observe_children(self.dossier) as children:
-            browser.open(self.dossier, view='++add++opengever.task.task')
-            browser.fill({'Title': u'Cannot change revoke permissions',
-                          'Task Type': 'comment',
-                          'form.widgets.revoke_permissions:list': 'False'})
-
-            form = browser.find_form_by_field('Responsible')
-            form.find_widget('Responsible').fill(
-                'fa:{}'.format(self.secretariat_user.getId()))
-
-            browser.css('#form-buttons-save').first.click()
-
-        self.assertEqual(['There were some errors.'], error_messages())
-        self.assertEqual(['The revoke permissions feature is disabled'],
-                         browser.css('form .error').text)
-        self.assertEqual(0, len(children['added']))
-
-    @browsing
     def test_cant_create_task_over_api_with_revoke_permissions_false_when_feature_disabled(self, browser):
         self.login(self.dossier_responsible, browser)
 


### PR DESCRIPTION
Omit the is_private field instead of only set it to hidden mode, when the feature is disabled. Fixes #5568 
