### PR TITLE
Show dossier from template action also when adding dossier disallowed.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2019.2.0 (unreleased)
 ---------------------
 
+- Show dossier from template action also when adding dossier disallowed. [njohner]
 - Add webaction forms (add and edit) and management view. [njohner]
 - Fix solr error during copy/paste of word document. [njohner]
 - Add archival file management view on dossier level. [njohner]

--- a/opengever/dossier/dossiertemplate/form.py
+++ b/opengever/dossier/dossiertemplate/form.py
@@ -337,4 +337,4 @@ class SelectDossierTemplateView(FormWrapper):
         return is_dossier_template_feature_enabled() and \
             self.context.is_leaf_node() and \
             api.user.has_permission('opengever.dossier: Add businesscasedossier', obj=self.context) and \
-            self.context.allow_add_businesscase_dossier
+            (self.context.allow_add_businesscase_dossier or self.context.addable_dossier_templates)

--- a/opengever/dossier/tests/test_dossier_template.py
+++ b/opengever/dossier/tests/test_dossier_template.py
@@ -34,7 +34,7 @@ class TestDossierTemplate(IntegrationTestCase):
 
     features = ('dossiertemplate', )
 
-    def test_templatedosisers_does_not_provide_dossier_interface(self):
+    def test_templatedossiers_does_not_provide_dossier_interface(self):
         self.login(self.administrator)
 
         self.assertFalse(IDossierMarker.providedBy(self.dossiertemplate))
@@ -269,6 +269,28 @@ class TestDossierTemplateAddWizard(IntegrationTestCase):
 
         self.assertTrue(api.user.has_permission(
             'opengever.dossier: Add businesscasedossier', obj=self.leaf_repofolder))
+
+        self.assertTrue(
+            self.leaf_repofolder.restrictedTraverse(
+                '@@dossier_with_template/is_available')())
+
+    def test_is_not_available_if_businesscasedossier_disallowed(self):
+        self.login(self.regular_user)
+
+        self.leaf_repofolder.allow_add_businesscase_dossier = False
+
+        self.assertFalse(
+            self.leaf_repofolder.restrictedTraverse(
+                '@@dossier_with_template/is_available')())
+
+    def test_is_available_if_businesscasedossier_disallowed_but_addable_templates_selected(self):
+        self.login(self.regular_user)
+
+        self.leaf_repofolder.allow_add_businesscase_dossier = False
+
+        self.set_related_items(
+            self.leaf_repofolder, [self.dossiertemplate, ],
+            fieldname='addable_dossier_templates')
 
         self.assertTrue(
             self.leaf_repofolder.restrictedTraverse(


### PR DESCRIPTION
When adding `businesscasedossier` is disallowed in a leaf repofolder but `add_businesscase_dossier` have been selected, we show the add dossier from template action. This allows for repofolders where dossiers can only be added from templates.

Note that in general when adding `businesscasedossier` is disallowed, we do not show the add dossier from template action.

resolves #5543 