### PR TITLE
Improve task restriction query, to work also on oracle backends.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 ---------------------
 
 - Show dossier from template action also when adding dossier disallowed. [njohner]
+- Improve task restriction query, so that it works also on oracle backends. [phgross]
 - Add webaction forms (add and edit) and management view. [njohner]
 - Fix solr error during copy/paste of word document. [njohner]
 - Allow non-member contributors to use the REST API. [Rotonen]

--- a/opengever/globalindex/model/task.py
+++ b/opengever/globalindex/model/task.py
@@ -477,6 +477,16 @@ class TaskQuery(BaseQuery):
             return self
 
         principals = member.getGroupIds() + [member.getId()]
+
+        if is_oracle():
+            # Oracle does not support DISTINCT with SELECTs that have CLOB
+            # type columns. But the task model uses CLOB for the physical_path
+            # and text column. So we need to use a subquery instead.
+            principal_query = self.session.query(
+                TaskPrincipal.task_id).filter(
+                    TaskPrincipal.principal.in_(principals))
+            return self.filter(Task.task_id.in_(principal_query))
+
         return self.join(Task._principals).filter(
             TaskPrincipal.principal.in_(principals)).distinct()
 


### PR DESCRIPTION
The restriction query, which has been introduced with #5007, contained an distinct statement, which lead to problems on oracle backends. Because Oracle does not support DISTINCT with SELECTs that have CLOB type columns. But the task model uses CLOB for the physical_path and text column.

So we need to use a subquery instead, when using an oracle backend. I extend the restrict method, to a oracle specific implementation with subqueries.

Update: Because PostgreSQL optimize the subquery too and a subquery is even faster, we don't need to avoid the subquery and use the same query for PostgreSQL backends too, instead of a specific Oracle query.


Fixes #5565.