### PR TITLE
Display the `changed` date instead the `modified` date for meeting-protocols.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -19,6 +19,7 @@ Changelog
 - Optimise local roles security reindexing in tasks. [Rotonen]
 - Add keywords-filter for document listings. [njohner]
 - Add has_sametype_children metadata column. [njohner]
+- Display the `changed` date instead the `modified` date for meeting-protocols. [elioschmutz]
 - Show dossier from template action also when adding dossier disallowed. [njohner]
 - Improve task restriction query, so that it works also on oracle backends. [phgross]
 - Add restapi @journal endpoint to get journal entries. [elioschmutz]

--- a/opengever/meeting/browser/meetings/templates/meeting.pt
+++ b/opengever/meeting/browser/meetings/templates/meeting.pt
@@ -269,7 +269,7 @@
                          i18n:translate="document_last_modified">
                       Modified at
                       <tal:date
-                          replace="python:toLocalizedTime(agendaitem_list_document.getObject().ModificationDate(), long_format=1)"
+                          replace="python:toLocalizedTime(agendaitem_list_document.getObject().changed, long_format=1)"
                           i18n:name="date" />
                     </div>
                   </tal:GENERATED>
@@ -323,7 +323,7 @@
                          i18n:translate="document_last_modified">
                       Modified at
                       <tal:date
-                          replace="python:toLocalizedTime(protocol_document.getObject().ModificationDate(), long_format=1)"
+                          replace="python:toLocalizedTime(protocol_document.getObject().changed, long_format=1)"
                           i18n:name="date" />
                     </div>
                   </tal:GENERATED>

--- a/opengever/meeting/tests/test_agendaitem.py
+++ b/opengever/meeting/tests/test_agendaitem.py
@@ -183,6 +183,36 @@ class TestEditAgendaItems(IntegrationTestCase):
         self.assertEqual(update_date, document.changed)
 
     @browsing
+    def test_display_changed_property_as_last_modified_date(self, browser):
+        self.login(self.committee_responsible, browser)
+        model = self.meeting.model
+
+        creation_date = datetime(2017, 10, 16, 0, 0, tzinfo=pytz.utc)
+        update_date = datetime(2018, 10, 16, 0, 0, tzinfo=pytz.utc)
+
+        def generate_agendaitem_list(meeting):
+            meeting_view = getMultiAdapter(
+                (self.meeting, self.request), name='view')
+            browser.open(meeting_view.url_generate_agendaitem_list())
+
+        # Generate first protocol
+        with freeze(creation_date):
+            generate_agendaitem_list(self.meeting)
+
+        document = model.agendaitem_list_document.resolve_document()
+        document.changed = update_date
+        document.reindexObject(idxs=["changed"])
+
+        self.assertEqual(creation_date, as_utc(document.modified().asdatetime()))
+        self.assertEqual(update_date, document.changed)
+
+        browser.open(self.meeting)
+
+        self.assertEqual(
+            'Modified at Oct 16, 2018 02:00 AM',
+            browser.css('.agenda-item-list-doc .document-modified').first.text)
+
+    @browsing
     def test_when_title_is_missing_returns_json_error(self, browser):
         self.login(self.committee_responsible, browser)
 

--- a/opengever/meeting/tests/test_protocol.py
+++ b/opengever/meeting/tests/test_protocol.py
@@ -67,6 +67,32 @@ class TestProtocol(IntegrationTestCase):
         self.assertEqual(update_date, document.changed)
 
     @browsing
+    def test_display_changed_property_as_last_modified_date(self, browser):
+        self.login(self.committee_responsible, browser)
+        model = self.meeting.model
+
+        creation_date = datetime(2017, 10, 16, 0, 0, tzinfo=pytz.utc)
+        update_date = datetime(2018, 10, 16, 0, 0, tzinfo=pytz.utc)
+
+        # Generate first protocol
+        with freeze(creation_date):
+            model.update_protocol_document()
+
+        document = model.protocol_document.resolve_document()
+
+        document.changed = update_date
+        document.reindexObject(idxs=["changed"])
+
+        self.assertEqual(creation_date, as_utc(document.modified().asdatetime()))
+        self.assertEqual(update_date, document.changed)
+
+        browser.open(self.meeting)
+
+        self.assertEqual(
+            'Modified at Oct 16, 2018 02:00 AM',
+            browser.css('.protocol-doc .document-modified').first.text)
+
+    @browsing
     def test_protocol_generate_action_only_available_for_unedited_protocols(self, browser):
         self.login(self.committee_responsible, browser)
         self.schedule_paragraph(self.meeting, u'A-Gesch\xe4fte')


### PR DESCRIPTION
This PR display the `changed` date instead the `modified` date for meeting-protocols.

After this change, the meeting-view is using the same implementation as the [document-view](https://github.com/4teamwork/opengever.core/blob/master/opengever/document/browser/overview.py#L367)

Closes #5154 