### PR TITLE
Workspaces do no longer inherit from dossiers.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 ---------------------
 
 - Allow members to access plone vocabularies through restapi. [elioschmutz]
+- Workspaces do no longer inherit from dossiers. [elioschmutz]
 - Show dossier from template action also when adding dossier disallowed. [njohner]
 - Improve task restriction query, so that it works also on oracle backends. [phgross]
 - Add restapi @journal endpoint to get journal entries. [elioschmutz]

--- a/opengever/api/tests/test_listing.py
+++ b/opengever/api/tests/test_listing.py
@@ -222,15 +222,15 @@ class TestListingEndpoint(IntegrationTestCase):
         query_string = '&'.join((
             'name=workspaces',
             'columns=title',
-            'columns=responsible_fullname',
+            'columns=description',
         ))
         view = '?'.join(('@listing', query_string))
         browser.open(self.workspace_root, view=view, headers={'Accept': 'application/json'})
 
         self.assertDictEqual(
-            {u'responsible_fullname': u'Fr\xf6hlich G\xfcnther',
-             u'@id': u'http://nohost/plone/workspaces/workspace-1',
-             u'title': u'A Workspace'},
+            {u'@id': u'http://nohost/plone/workspaces/workspace-1',
+             u'title': u'A Workspace',
+             u'description': u'A Workspace description'},
             browser.json['items'][-1])
 
     @browsing

--- a/opengever/base/tests/test_changed_date.py
+++ b/opengever/base/tests/test_changed_date.py
@@ -418,7 +418,6 @@ class TestChangedUpdateForWorkspace(TestChangedUpdateBase):
     @browsing
     def test_changed_is_updated_when_metadata_is_changed(self, browser):
         self.login(self.workspace_owner, browser)
-        IDossier(self.workspace).responsible = self.workspace_owner.getUserName()
         with freeze(FREEZING_TIME):
             browser.open(self.workspace, view='edit')
             browser.fill({"Title": 'foo'})
@@ -431,7 +430,6 @@ class TestChangedUpdateForWorkspaceFolder(TestChangedUpdateBase):
     @browsing
     def test_changed_is_updated_when_metadata_is_changed(self, browser):
         self.login(self.workspace_owner, browser)
-        IDossier(self.workspace_folder).responsible = self.workspace_owner.getUserName()
         with freeze(FREEZING_TIME):
             browser.open(self.workspace_folder, view='edit')
             browser.fill({"Title": 'foo'})

--- a/opengever/core/profiles/default/types/opengever.workspace.folder.xml
+++ b/opengever/core/profiles/default/types/opengever.workspace.folder.xml
@@ -29,7 +29,6 @@
     <element value="opengever.base.behaviors.base.IOpenGeverBase" />
     <element value="opengever.base.behaviors.sequence.ISequenceNumberBehavior" />
     <element value="opengever.workspace.behaviors.namefromtitle.IWorkspaceFolderNameFromTitle" />
-    <element value="opengever.dossier.behaviors.dossier.IDossier" />
     <element value="opengever.mail.behaviors.ISendableDocsContainer" />
     <element value="opengever.tabbedview.interfaces.ITabbedViewEnabled" />
     <element value="opengever.trash.trash.ITrashable" />

--- a/opengever/core/profiles/default/types/opengever.workspace.workspace.xml
+++ b/opengever/core/profiles/default/types/opengever.workspace.workspace.xml
@@ -31,7 +31,6 @@
     <element value="opengever.base.behaviors.base.IOpenGeverBase" />
     <element value="opengever.base.behaviors.sequence.ISequenceNumberBehavior" />
     <element value="opengever.workspace.behaviors.namefromtitle.IWorkspaceNameFromTitle" />
-    <element value="opengever.dossier.behaviors.dossier.IDossier" />
     <element value="opengever.mail.behaviors.ISendableDocsContainer" />
     <element value="opengever.tabbedview.interfaces.ITabbedViewEnabled" />
     <element value="opengever.trash.trash.ITrashable" />

--- a/opengever/core/tests/test_relations.py
+++ b/opengever/core/tests/test_relations.py
@@ -148,8 +148,6 @@ EXPECTED_TYPES_WITH_RELATIONS = [
     'opengever.meeting.proposaltemplate',
     'opengever.private.dossier',
     'opengever.disposition.disposition',
-    'opengever.workspace.workspace',
-    'opengever.workspace.folder'
 ]
 
 

--- a/opengever/core/upgrades/20190418113651_remove_dossier_inheritance_for_workspaces/opengever.workspace.folder.xml
+++ b/opengever/core/upgrades/20190418113651_remove_dossier_inheritance_for_workspaces/opengever.workspace.folder.xml
@@ -1,0 +1,8 @@
+<object xmlns:i18n="http://xml.zope.org/namespaces/i18n" name="opengever.workspace.folder" meta_type="Dexterity FTI" i18n:domain="opengever.core">
+
+  <!-- enabled behaviors -->
+  <property name="behaviors">
+    <element remove="True" value="opengever.dossier.behaviors.dossier.IDossier" />
+  </property>
+
+</object>

--- a/opengever/core/upgrades/20190418113651_remove_dossier_inheritance_for_workspaces/opengever.workspace.workspace.xml
+++ b/opengever/core/upgrades/20190418113651_remove_dossier_inheritance_for_workspaces/opengever.workspace.workspace.xml
@@ -1,0 +1,8 @@
+<object xmlns:i18n="http://xml.zope.org/namespaces/i18n" name="opengever.workspace.workspace" meta_type="Dexterity FTI" i18n:domain="opengever.core">
+
+  <!-- Enabled behaviors -->
+  <property name="behaviors">
+    <element remove="True" value="opengever.dossier.behaviors.dossier.IDossier" />
+  </property>
+
+</object>

--- a/opengever/core/upgrades/20190418113651_remove_dossier_inheritance_for_workspaces/upgrade.py
+++ b/opengever/core/upgrades/20190418113651_remove_dossier_inheritance_for_workspaces/upgrade.py
@@ -1,0 +1,11 @@
+from ftw.upgrade import UpgradeStep
+from opengever.workspace.interfaces import IWorkspace
+
+
+class RemoveDossierInheritanceForWorkspaces(UpgradeStep):
+    """Remove dossier inheritance for workspaces.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()
+        self.catalog_reindex_objects({'object_provides': IWorkspace.__identifier__})

--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -1963,8 +1963,8 @@ class OpengeverContentFixture(object):
         self.workspace = self.register('workspace', create(
             Builder('workspace')
             .titled(u'A Workspace')
+            .having(description=u'A Workspace description')
             .within(self.workspace_root)
-            .having(responsible=self.workspace_owner.getId())
             ))
 
         RoleAssignmentManager(self.workspace).reset([
@@ -1978,10 +1978,7 @@ class OpengeverContentFixture(object):
 
         self.workspace_folder = self.register('workspace_folder', create(
             Builder('workspace folder')
-            .having(
-                title_de=u'WS F\xc3lder',
-                title_fr=u'WS fichi\xe9r',
-                )
+            .titled(u'WS F\xc3lder')
             .within(self.workspace)
             ))
 

--- a/opengever/workspace/browser/configure.zcml
+++ b/opengever/workspace/browser/configure.zcml
@@ -12,6 +12,20 @@
       />
 
   <browser:page
+      for="opengever.workspace.interfaces.IWorkspace"
+      name="tabbedview_view-folders"
+      class=".tabs.WorkspaceFolders"
+      permission="zope2.View"
+      />
+
+  <browser:page
+      for="opengever.workspace.interfaces.IWorkspaceFolder"
+      name="tabbedview_view-folders"
+      class=".tabs.WorkspaceFolders"
+      permission="zope2.View"
+      />
+
+  <browser:page
       for="opengever.workspace.interfaces.IWorkspaceFolder"
       name="tabbed_view"
       class=".tabbed.WorkspaceFolderTabbedView"

--- a/opengever/workspace/browser/tabbed.py
+++ b/opengever/workspace/browser/tabbed.py
@@ -5,9 +5,9 @@ from opengever.tabbedview import GeverTabbedView
 class WorkspaceTabbedView(GeverTabbedView):
     """Define the tabs available on a Workspace."""
 
-    overview_tab = {
-        'id': 'overview',
-        'title': _(u'label_overview', default=u'Overview'),
+    folders_tab = {
+        'id': 'folders',
+        'title': _(u'label_folders', default=u'Folders'),
         }
 
     documents_tab = {
@@ -32,7 +32,7 @@ class WorkspaceTabbedView(GeverTabbedView):
 
     def _get_tabs(self):
         return filter(None, [
-            self.overview_tab,
+            self.folders_tab,
             self.documents_tab,
             self.tasks_tab,
             self.trash_tab,

--- a/opengever/workspace/browser/tabs.py
+++ b/opengever/workspace/browser/tabs.py
@@ -1,20 +1,13 @@
-from opengever.tabbedview.browser.tabs import Dossiers
 from opengever.tabbedview.helper import linked
-from opengever.tabbedview.helper import readable_ogds_author
 from opengever.workspace import _
+from opengever.tabbedview import BaseCatalogListingTab
 
 
-class Workspaces(Dossiers):
+class Workspaces(BaseCatalogListingTab):
 
-    filterlist_available = False
-    major_actions = []
-    enabled_actions = []
+    types = ['opengever.workspace.workspace']
 
     columns = (
-
-        {'column': 'reference',
-         'column_title': _(u'label_reference', default=u'Reference Number'),
-         'width': 120},
 
         {'column': 'Title',
          'column_title': _(u'label_title', default=u'Title'),
@@ -22,9 +15,15 @@ class Workspaces(Dossiers):
          'transform': linked,
          'width': 500},
 
-        {'column': 'responsible',
-         'column_title': _(u'label_dossier_responsible',
-                           default=u"Responsible"),
-         'transform': readable_ogds_author,
-         'width': 300}
+        {'column': 'Description',
+         'column_title': _(u'label_description',
+                           default=u"Description"),
+         'width': 400}
     )
+
+
+class WorkspaceFolders(Workspaces):
+    """List all workspace-folders recursively.
+    """
+
+    types = ['opengever.workspace.folder']

--- a/opengever/workspace/interfaces.py
+++ b/opengever/workspace/interfaces.py
@@ -1,4 +1,4 @@
-from opengever.dossier.behaviors.dossier import IDossierMarker
+from ftw.tabbedview.interfaces import ITabbedviewUploadable
 from zope import schema
 from zope.interface import Interface
 
@@ -7,11 +7,11 @@ class IWorkspaceRoot(Interface):
     """ Marker interface for Workspace Roots """
 
 
-class IWorkspace(IDossierMarker):
+class IWorkspace(Interface, ITabbedviewUploadable):
     """ Marker interface for Workspace """
 
 
-class IWorkspaceFolder(IDossierMarker):
+class IWorkspaceFolder(Interface, ITabbedviewUploadable):
     """ Marker interface for Workspace Folders """
 
 

--- a/opengever/workspace/locales/de/LC_MESSAGES/opengever.workspace.po
+++ b/opengever/workspace/locales/de/LC_MESSAGES/opengever.workspace.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-01-29 16:24+0000\n"
+"POT-Creation-Date: 2019-04-18 10:43+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -103,30 +103,25 @@ msgstr "Teammitglied"
 msgid "WorkspaceOwner"
 msgstr "Federführung"
 
+#. Default: "Description"
+#: ./opengever/workspace/browser/tabs.py
+msgid "label_description"
+msgstr "Beschreibung"
+
 #. Default: "Documents"
 #: ./opengever/workspace/browser/tabbed.py
 msgid "label_documents"
 msgstr "Dokumente"
 
-#. Default: "Responsible"
-#: ./opengever/workspace/browser/tabs.py
-msgid "label_dossier_responsible"
-msgstr "Verantwortlicher"
+#. Default: "Folders"
+#: ./opengever/workspace/browser/tabbed.py
+msgid "label_folders"
+msgstr "Ordner"
 
 #. Default: "Journal"
 #: ./opengever/workspace/browser/tabbed.py
 msgid "label_journal"
 msgstr "Journal"
-
-#. Default: "Overview"
-#: ./opengever/workspace/browser/tabbed.py
-msgid "label_overview"
-msgstr "Übersicht"
-
-#. Default: "Reference Number"
-#: ./opengever/workspace/browser/tabs.py
-msgid "label_reference"
-msgstr "Aktenzeichen"
 
 #. Default: "Tasks"
 #: ./opengever/workspace/browser/tabbed.py

--- a/opengever/workspace/locales/fr/LC_MESSAGES/opengever.workspace.po
+++ b/opengever/workspace/locales/fr/LC_MESSAGES/opengever.workspace.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-01-29 16:24+0000\n"
+"POT-Creation-Date: 2019-04-18 10:43+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -103,30 +103,25 @@ msgstr "Membre du team"
 msgid "WorkspaceOwner"
 msgstr "Titulaire"
 
+#. Default: "Description"
+#: ./opengever/workspace/browser/tabs.py
+msgid "label_description"
+msgstr ""
+
 #. Default: "Documents"
 #: ./opengever/workspace/browser/tabbed.py
 msgid "label_documents"
 msgstr "Documents"
 
-#. Default: "Responsible"
-#: ./opengever/workspace/browser/tabs.py
-msgid "label_dossier_responsible"
-msgstr "Responsable"
+#. Default: "Folders"
+#: ./opengever/workspace/browser/tabbed.py
+msgid "label_folders"
+msgstr ""
 
 #. Default: "Journal"
 #: ./opengever/workspace/browser/tabbed.py
 msgid "label_journal"
 msgstr "Journal"
-
-#. Default: "Overview"
-#: ./opengever/workspace/browser/tabbed.py
-msgid "label_overview"
-msgstr "Aperçu"
-
-#. Default: "Reference Number"
-#: ./opengever/workspace/browser/tabs.py
-msgid "label_reference"
-msgstr "Numéro de référence"
 
 #. Default: "Tasks"
 #: ./opengever/workspace/browser/tabbed.py

--- a/opengever/workspace/locales/opengever.workspace.pot
+++ b/opengever/workspace/locales/opengever.workspace.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-01-29 16:24+0000\n"
+"POT-Creation-Date: 2019-04-18 10:43+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -106,29 +106,24 @@ msgstr ""
 msgid "WorkspaceOwner"
 msgstr ""
 
+#. Default: "Description"
+#: ./opengever/workspace/browser/tabs.py
+msgid "label_description"
+msgstr ""
+
 #. Default: "Documents"
 #: ./opengever/workspace/browser/tabbed.py
 msgid "label_documents"
 msgstr ""
 
-#. Default: "Responsible"
-#: ./opengever/workspace/browser/tabs.py
-msgid "label_dossier_responsible"
+#. Default: "Folders"
+#: ./opengever/workspace/browser/tabbed.py
+msgid "label_folders"
 msgstr ""
 
 #. Default: "Journal"
 #: ./opengever/workspace/browser/tabbed.py
 msgid "label_journal"
-msgstr ""
-
-#. Default: "Overview"
-#: ./opengever/workspace/browser/tabbed.py
-msgid "label_overview"
-msgstr ""
-
-#. Default: "Reference Number"
-#: ./opengever/workspace/browser/tabs.py
-msgid "label_reference"
 msgstr ""
 
 #. Default: "Tasks"

--- a/opengever/workspace/tests/test_workspace_folder.py
+++ b/opengever/workspace/tests/test_workspace_folder.py
@@ -16,7 +16,6 @@ class TestWorkspaceFolder(IntegrationTestCase):
         factoriesmenu.add('WorkspaceFolder')
 
         form = browser.find_form_by_field('Title')
-        form.find_widget('Responsible').fill(self.workspace_member.getId())
         form.fill({'Title': u'Ein Unter\xf6rdnerli'})
         form.save()
 

--- a/opengever/workspace/workspace.py
+++ b/opengever/workspace/workspace.py
@@ -3,7 +3,7 @@ from plone.autoform.interfaces import IFormFieldProvider
 from plone.supermodel import model
 from zope.interface import implements
 from zope.interface import provider
-from opengever.dossier.base import DossierContainer
+from plone.dexterity.content import Container
 
 
 @provider(IFormFieldProvider)
@@ -11,5 +11,5 @@ class IWorkspaceSchema(model.Schema):
     """ """
 
 
-class Workspace(DossierContainer):
+class Workspace(Container):
     implements(IWorkspace)

--- a/opengever/workspace/workspace_folder.py
+++ b/opengever/workspace/workspace_folder.py
@@ -1,9 +1,9 @@
-from opengever.dossier.base import DossierContainer
 from opengever.workspace.interfaces import IWorkspaceFolder
 from plone.autoform.interfaces import IFormFieldProvider
 from plone.supermodel import model
 from zope.interface import implements
 from zope.interface import provider
+from plone.dexterity.content import Container
 
 
 @provider(IFormFieldProvider)
@@ -11,5 +11,5 @@ class IWorkspaceFolderSchema(model.Schema):
     """ """
 
 
-class WorkspaceFolder(DossierContainer):
+class WorkspaceFolder(Container):
     implements(IWorkspaceFolder)


### PR DESCRIPTION
Dieser PR entfernt die Vererbung des Dossiers auf einen Teamraum.

Durch diesen PR wird ebenfalls das Übersichtstab ersetzt mit einem "Ordner" Tab. Der Grund: Das Übersichtstab ist nicht wirklich sinnvoll (https://github.com/4teamwork/gever-ui/pull/107). Durch die Entfernung der Vererbung müssten wir für einen Arbeitsraum ein neue Overview-View implementieren - entweder durch Refactoring der bestehenden oder eine Kopie mit kleineren Anpassungen.

Um dies zu Verhindern, wird neu nur noch ein Tab mit den Ordnern dargestellt.

Im Frontend werden wir trotzdem alle Möglichkeiten offen haben.

Beispiel mit klassischem UI:

![screen1](https://user-images.githubusercontent.com/557005/56357216-5e56f500-61db-11e9-834b-0c583ab74062.gif)

Beispiel mit neuem UI

![screen2](https://user-images.githubusercontent.com/557005/56357233-6ca51100-61db-11e9-8deb-b46b394a426d.gif)

Durch diesen PR werden folgende PRs überflüssig: https://github.com/4teamwork/opengever.core/pull/5556, https://github.com/4teamwork/opengever.core/pull/5559
closes #5563 