### PR TITLE
Add keyword filter to document listings

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -8,6 +8,7 @@ Changelog
 - Allow members to access plone vocabularies through restapi. [elioschmutz]
 - Workspaces do no longer inherit from dossiers. [elioschmutz]
 - Optimise local roles security reindexing in tasks. [Rotonen]
+- Add keywords-filter for document listings. [njohner]
 - Show dossier from template action also when adding dossier disallowed. [njohner]
 - Improve task restriction query, so that it works also on oracle backends. [phgross]
 - Add restapi @journal endpoint to get journal entries. [elioschmutz]

--- a/opengever/document/tests/test_document.py
+++ b/opengever/document/tests/test_document.py
@@ -217,14 +217,14 @@ class TestDocument(IntegrationTestCase):
     @browsing
     def test_regular_user_can_add_new_keywords_in_document(self, browser):
         self.login(self.regular_user, browser)
-        browser.open(self.document, view='@@edit')
+        browser.open(self.subsubdocument, view='@@edit')
 
         keywords = browser.find_field_by_text(u'Keywords')
         new = browser.css('#' + keywords.attrib['id'] + '_new').first
         new.text = u'NewItem1\nNew Item 2\nN\xf6i 3'
         browser.find_button_by_label('Save').click()
 
-        browser.open(self.document, view='edit')
+        browser.open(self.subsubdocument, view='edit')
         keywords = browser.find_field_by_text(u'Keywords')
         self.assertTupleEqual(('New Item 2', 'NewItem1', 'N=C3=B6i 3'), tuple(keywords.value))
 

--- a/opengever/dossier/tests/test_indexer.py
+++ b/opengever/dossier/tests/test_indexer.py
@@ -149,9 +149,9 @@ class TestDossierIndexers(IntegrationTestCase):
         self.subdossier.reindexObject()
 
         self.assertEquals(
-            1,
+            3,
             len(catalog(Subject=u'Subkeyword')),
-            'Expected one item with Keyword "Subkeyword"',
+            'Expected three item with Keyword "Subkeyword"',
             )
 
         self.assertEquals(

--- a/opengever/dossier/tests/test_templatefolder.py
+++ b/opengever/dossier/tests/test_templatefolder.py
@@ -796,6 +796,7 @@ class TestTemplateFolderListings(IntegrationTestCase):
             'Public Trial',
             'Reference Number',
             'File extension',
+            'Keywords',
             ]
 
         self.assertEquals(expected_table_header, browser.css('table.listing').first.lists()[0])
@@ -817,6 +818,7 @@ class TestTemplateFolderListings(IntegrationTestCase):
             'Public Trial',
             'Reference Number',
             'File extension',
+            'Keywords',
             ]
 
         self.assertEquals(expected_table_header, browser.css('table.listing').first.lists()[0])
@@ -838,6 +840,7 @@ class TestTemplateFolderListings(IntegrationTestCase):
             'Public Trial',
             'Reference Number',
             'File extension',
+            'Keywords',
             ]
 
         self.assertEquals(expected_table_header, browser.css('table.listing').first.lists()[0])

--- a/opengever/inbox/tests/test_tabs.py
+++ b/opengever/inbox/tests/test_tabs.py
@@ -19,7 +19,7 @@ class TestInboxTabbedview(IntegrationTestCase):
             ['', 'Sequence Number', 'Title', 'Document Author',
              'Document Date', 'Modification Date', 'Creation Date',
              'Receipt Date', 'Delivery Date', 'Public Trial',
-             'Reference Number', 'File extension'],
+             'Reference Number', 'File extension', 'Keywords'],
             browser.css('.listing th').text)
 
     @browsing
@@ -32,7 +32,7 @@ class TestInboxTabbedview(IntegrationTestCase):
             ['', 'Sequence Number', 'Title', 'Document Author',
              'Document Date', 'Modification Date', 'Creation Date',
              'Receipt Date', 'Delivery Date', 'Public Trial',
-             'File extension'],
+             'File extension', 'Keywords'],
             browser.css('.listing th').text)
 
     @browsing

--- a/opengever/repository/tests/test_repositoryfolder_tabs.py
+++ b/opengever/repository/tests/test_repositoryfolder_tabs.py
@@ -110,6 +110,7 @@ class TestRepositoryFolderDocumentsTab(IntegrationTestCase):
             'Document Date': '03.01.2010',
             'Dossier': u'Vertr\xe4ge mit der kantonalen Finanzverwaltung',
             'File extension': '.docx',
+            'Keywords': 'Wichtig',
             'Modification Date': '31.08.2016',
             'Public Trial': 'unchecked',
             'Receipt Date': '03.01.2010',

--- a/opengever/tabbedview/browser/tabs.py
+++ b/opengever/tabbedview/browser/tabs.py
@@ -191,6 +191,10 @@ class Documents(BaseCatalogListingTab):
         {'column': 'file_extension',
          'column_title': _(u'label_document_file_extension',
                            default=u'File extension')},
+
+        {'column': 'Subject',
+         'column_title': _(u'label_keywords', default=u'Keywords'),
+         'transform': linked_subjects},
         )
 
     major_actions = [

--- a/opengever/tabbedview/browser/tabs.py
+++ b/opengever/tabbedview/browser/tabs.py
@@ -120,6 +120,8 @@ class Documents(BaseCatalogListingTab):
     """List all documents recursively. Working copies are not listed.
     """
 
+    subject_filter_available = True
+
     types = ['opengever.document.document', 'ftw.mail.mail']
 
     # XXX Can be set back to 'columns' once the changed metadata has been filled on all deployments

--- a/opengever/tabbedview/filtered_source.py
+++ b/opengever/tabbedview/filtered_source.py
@@ -12,12 +12,13 @@ class FilteredTableSourceMixin(object):
         if self.config.filterlist_available:
             query = self.extend_query_with_filter(query)
 
+        if self.config.subject_filter_available:
+            SubjectFilter(self.config.context, self.request).update_query(query)
+
         return query
 
     def extend_query_with_filter(self, query):
         """When the filterlist is active, we update the query with
         the current filter."""
-
-        SubjectFilter(self.config.context, self.request).update_query(query)
         selected_filter_id = self.request.get(self.config.filterlist_name)
         return self.config.filterlist.update_query(query, selected_filter_id)

--- a/opengever/tabbedview/filters.py
+++ b/opengever/tabbedview/filters.py
@@ -169,7 +169,8 @@ class SubjectFilter(object):
         solr = getUtility(ISolrSearch)
         response = solr.search(
             query="*:*", filters=self._solr_filters(), **self._solr_params())
-
+        if not response.is_ok():
+            return list()
         return self._extract_facets_from_solr_response(response)
 
     def _solr_filters(self):

--- a/opengever/tabbedview/filters.py
+++ b/opengever/tabbedview/filters.py
@@ -182,7 +182,7 @@ class SubjectFilter(object):
     def _solr_params(self):
         return {
             'facet': True,  # activate facetting
-            'facet.field': 'Subject',  # add factes for this field
+            'facet.field': 'Subject',  # add facets for this field
             'facet.limit': -1,  # do not limit the number of facet-terms
             'rows': 0,  # do not return documents found by the query
             'facet.mincount': 1  # exclude facet-terms with no document

--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -994,6 +994,7 @@ class OpengeverContentFixture(object):
                 document_date=datetime(2010, 1, 3),
                 document_type='contract',
                 receipt_date=datetime(2010, 1, 3),
+                keywords=(u'Wichtig', ),
                 )
             .attach_file_containing(
                 bumblebee_asset('example.docx').bytes(),
@@ -1081,6 +1082,7 @@ class OpengeverContentFixture(object):
                 u'tab\xe4lle.xlsx',
             )
             .relate_to([self.document])
+            .having(keywords=(u'Wichtig', u'Subkeyword', ))
         ))
 
         subsubdossier = self.register('subsubdossier', create(
@@ -1107,7 +1109,8 @@ class OpengeverContentFixture(object):
             Builder('document')
             .within(subdossier)
             .titled(u'L\xe4\xe4r')
-            .having(preserved_as_paper=True)
+            .having(preserved_as_paper=True,
+                    keywords=(u'Subkeyword', ))
         ))
 
         self.register('removed_document', create(

--- a/opengever/testing/integration_test_case.py
+++ b/opengever/testing/integration_test_case.py
@@ -665,7 +665,13 @@ class IntegrationTestCase(TestCase):
         if response_file:
             search_resp = assets.load(response_file)
         else:
+            # Make sure status is in header
+            if u'responseHeader' not in response_json:
+                response_json[u'responseHeader'] = {}
+            if 'status' not in response_json[u'responseHeader']:
+                response_json[u'responseHeader']['status'] = 0
             search_resp = json.dumps(response_json)
+
         solr.search = MagicMock(name='search', return_value=SolrResponse(
             body=search_resp, status=200))
         return solr


### PR DESCRIPTION
We add a keywords filter to the document listings, when solr is active. This reuses the implementation of the filter for the dossiers, which breaks the listings if solr is not reachable. I added a commit which handles this by ignoring keywords in that case. This is just a proposal, not sure whether we want the listing to be broken when solr is unavailable.

![keyword_filter](https://user-images.githubusercontent.com/7374243/56358945-75e4ac80-61e0-11e9-9287-1e4421641c5b.gif)

resolves #5464 