### PR TITLE
 Optimise local roles security reindexing in tasks

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,7 @@ Changelog
 - Implement resolving dossiers recursively via REST API. [lgraf]
 - Allow members to access plone vocabularies through restapi. [elioschmutz]
 - Workspaces do no longer inherit from dossiers. [elioschmutz]
+- Optimise local roles security reindexing in tasks. [Rotonen]
 - Show dossier from template action also when adding dossier disallowed. [njohner]
 - Improve task restriction query, so that it works also on oracle backends. [phgross]
 - Add restapi @journal endpoint to get journal entries. [elioschmutz]

--- a/opengever/task/localroles.py
+++ b/opengever/task/localroles.py
@@ -6,13 +6,13 @@ from opengever.base.role_assignments import ASSIGNMENT_VIA_TASK_AGENCY
 from opengever.base.role_assignments import RoleAssignmentManager
 from opengever.base.role_assignments import TaskAgencyRoleAssignment
 from opengever.base.role_assignments import TaskRoleAssignment
+from opengever.base.security import reindex_object_security_without_children
 from opengever.document.document import IBaseDocument
 from opengever.dossier.behaviors.dossier import IDossierMarker
 from opengever.globalindex.handlers.task import sync_task
 from opengever.meeting.proposal import IProposal
 from opengever.ogds.base.utils import get_current_org_unit
 from plone import api
-from Products.CMFCore.CMFCatalogAware import CatalogAware
 
 
 class LocalRolesSetter(object):
@@ -139,7 +139,7 @@ class LocalRolesSetter(object):
             path='/'.join(distinct_parent.getPhysicalPath()))]
 
         for dossier in subdossiers:
-            dossier.reindexObject(idxs=CatalogAware._cmf_security_indexes)
+            reindex_object_security_without_children(dossier)
 
     def set_roles_on_related_items(self):
         """Set local roles on related items (usually documents)."""
@@ -216,4 +216,4 @@ class LocalRolesSetter(object):
                       self.inbox_group_id, self.task, reindex=False)
 
         for dossier in subdossiers:
-            dossier.reindexObject(idxs=CatalogAware._cmf_security_indexes)
+            reindex_object_security_without_children(dossier)


### PR DESCRIPTION
When profiling the test runs, I spotted about 20% of the runtime of the module `opengever.task` is spent in `LocalRolesSetter. set_roles_on_distinct_parent()`, for which we already have an optimisation in place for only reindexing the security indices of known-effected children of the distinct parent.

Diving deeper showed half of that time is spent in setting the metadata for those objects, which makes no sense in the context. Looking at the implementation of `.reindexObjectSecurity()` for a `CMFCatalogAware` object from `Products.CMFCore` 2.2.x revealed it does a direct catalog reindex skipping the metadata update, for the object including all of its children.

https://github.com/zopefoundation/Products.CMFCore/blob/2.2/Products/CMFCore/CMFCatalogAware.py#L122-L123

We already have a use of this in `opengever.core`:

https://github.com/4teamwork/opengever.core/blob/e2414979bc679aedf87b4bbc7dc376842b090362/opengever/base/handlers.py#L52-L54

I've refactored that out to `opengever.base.security` and also used that for the local roles setting of tasks. This can then also be used in upgrade steps going forward, as it seems we've done that a few times already. I'm not seeing it being useful to also extract out of `opengever.setup`.

https://github.com/4teamwork/opengever.core/blob/master/opengever/setup/sections/reindexobject.py#L70-L86

A local fixture-cached run of `bin/test -m opengever.task -m '!opengever.tasktemplates'` took 5 minutes before the change, 20% of which would be 1 minute, 50% of which would be 30 seconds. A local run now takes, as expected, 4 minutes 30 seconds for me.