### PR TITLE
Add has_sametype_children metadata column.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -17,6 +17,7 @@ Changelog
 - Workspaces do no longer inherit from dossiers. [elioschmutz]
 - Optimise local roles security reindexing in tasks. [Rotonen]
 - Add keywords-filter for document listings. [njohner]
+- Add has_sametype_children metadata column. [njohner]
 - Show dossier from template action also when adding dossier disallowed. [njohner]
 - Improve task restriction query, so that it works also on oracle backends. [phgross]
 - Add restapi @journal endpoint to get journal entries. [elioschmutz]

--- a/opengever/api/listing.py
+++ b/opengever/api/listing.py
@@ -95,6 +95,7 @@ FIELDS = {
     'document_author': ('document_author', 'document_author', 'document_author'),
     'document_date': ('document_date', 'document_date', 'document_date'),
     'end': ('end', 'end', 'end'),
+    'has_sametype_children': ('has_sametype_children', 'has_sametype_children', 'has_sametype_children'),
     'mimetype': ('getContentType', 'getContentType', 'mimetype'),
     'modified': ('modified', 'modified', 'modified'),
     'keywords': ('Subject', 'Subject', 'Subject'),

--- a/opengever/base/configure.zcml
+++ b/opengever/base/configure.zcml
@@ -356,6 +356,11 @@
       name="sortable_title"
       />
 
+  <adapter
+      factory=".indexes.has_sametype_children"
+      name="has_sametype_children"
+      />
+
   <utility factory=".sequence.SequenceNumber" />
 
   <adapter factory=".quickupload.OGQuickUploadCapableFileFactory" />

--- a/opengever/base/indexes.py
+++ b/opengever/base/indexes.py
@@ -4,15 +4,17 @@ from opengever.base.behaviors.translated_title import ITranslatedTitle
 from opengever.base.behaviors.translated_title import ITranslatedTitleSupport
 from opengever.base.interfaces import IReferenceNumber
 from opengever.base.model import SORTABLE_TITLE_LENGTH
+from opengever.bundle.sections.constructor import BUNDLE_GUID_KEY
+from plone import api
 from plone.dexterity.interfaces import IDexterityContent
-from plone.indexer import indexer
 from plone.i18n.normalizer.base import mapUnicode
+from plone.indexer import indexer
+from Products.CMFCore.interfaces import IFolderish
 from Products.CMFPlone.CatalogTool import num_sort_regex
 from Products.CMFPlone.CatalogTool import zero_fill
 from Products.CMFPlone.utils import safe_callable
 from Products.CMFPlone.utils import safe_unicode
 from zope.annotation import IAnnotations
-from opengever.bundle.sections.constructor import BUNDLE_GUID_KEY
 
 
 @indexer(IDexterityContent)
@@ -80,3 +82,11 @@ def sortable_title(obj):
                 sortabletitle = start + u'...' + end
             return sortabletitle.encode('utf-8')
     return ''
+
+
+@indexer(IFolderish)
+def has_sametype_children(obj):
+    catalog = api.portal.get_tool("portal_catalog")
+    return bool(catalog.unrestrictedSearchResults(
+                    path={'query': obj.absolute_url_path(), 'depth': 1},
+                    portal_type=obj.portal_type))

--- a/opengever/base/tests/test_indexers.py
+++ b/opengever/base/tests/test_indexers.py
@@ -1,0 +1,192 @@
+from ftw.testbrowser import browsing
+from ftw.testbrowser.pages import factoriesmenu
+from opengever.testing import IntegrationTestCase
+
+
+class TestHasSameTypeChildren(IntegrationTestCase):
+
+    def move_items(self, items, source=None, target=None):
+        paths = u";;".join(["/".join(i.getPhysicalPath()) for i in items])
+        self.request['paths'] = paths
+        self.request['form.widgets.request_paths'] = paths
+        self.request['form.widgets.destination_folder'] = "/".join(
+            target.getPhysicalPath())
+
+        view = source.restrictedTraverse('move_items')
+        form = view.form(source, self.request)
+        form.updateWidgets()
+        form.widgets['destination_folder'].value = target
+        form.widgets['request_paths'].value = paths
+
+        form.handle_submit(form, object)
+
+    def test_has_sametype_children_for_businesscasedossier(self):
+        self.login(self.regular_user)
+
+        self.assert_metadata_value(True, 'has_sametype_children',
+                                   self.dossier)
+        self.assert_metadata_value(True, 'has_sametype_children',
+                                   self.subdossier)
+        self.assert_metadata_value(False, 'has_sametype_children',
+                                   self.subsubdossier)
+
+    def test_has_sametype_children_for_repofolders(self):
+        self.login(self.regular_user)
+
+        # Repofolder does not have the same type as reporoot
+        self.assert_metadata_value(False, 'has_sametype_children',
+                                   self.repository_root)
+        # branch_repofolder has leaf_repofolder as child
+        self.assert_metadata_value(True, 'has_sametype_children',
+                                   self.branch_repofolder)
+        self.assert_metadata_value(False, 'has_sametype_children',
+                                   self.leaf_repofolder)
+
+    def test_has_sametype_children_for_tasks(self):
+        self.login(self.regular_user)
+
+        self.assert_metadata_value(True, 'has_sametype_children',
+                                   self.task)
+        self.assert_metadata_value(False, 'has_sametype_children',
+                                   self.subtask)
+
+    def test_has_sametype_children_for_workspaces(self):
+        self.login(self.workspace_member)
+
+        # workspace_root does not have the same type as workspace
+        self.assert_metadata_value(False, 'has_sametype_children',
+                                   self.workspace_root)
+        # workspace does not have the same type as workspace_folder
+        self.assert_metadata_value(False, 'has_sametype_children',
+                                   self.workspace)
+        self.assert_metadata_value(False, 'has_sametype_children',
+                                   self.workspace_folder)
+
+    def test_has_sametype_children_for_private_folder(self):
+        self.login(self.regular_user)
+
+        # private_root does not have the same type as private_folder
+        self.assert_metadata_value(False, 'has_sametype_children',
+                                   self.private_root)
+        # private_folder does not have the same type as private_dossier
+        self.assert_metadata_value(False, 'has_sametype_children',
+                                   self.private_folder)
+        self.assert_metadata_value(False, 'has_sametype_children',
+                                   self.private_dossier)
+
+    @browsing
+    def test_is_updated_when_adding_subdossier(self, browser):
+        self.login(self.regular_user, browser)
+
+        self.assert_metadata_value(False, 'has_sametype_children',
+                                   self.empty_dossier)
+
+        browser.open(self.empty_dossier)
+        factoriesmenu.add('Subdossier')
+        browser.fill({'Title': u'Subossier'}).save()
+
+        self.assert_metadata_value(True, 'has_sametype_children',
+                                   self.empty_dossier)
+
+    @browsing
+    def test_is_updated_when_adding_repofolder(self, browser):
+        self.login(self.manager, browser)
+
+        self.assert_metadata_value(False, 'has_sametype_children',
+                                   self.empty_repofolder)
+
+        browser.open(self.empty_repofolder)
+        factoriesmenu.add('RepositoryFolder')
+        browser.fill({'Title': u'Sub repository'}).save()
+
+        self.assert_metadata_value(True, 'has_sametype_children',
+                                   self.empty_repofolder)
+
+    @browsing
+    def test_is_updated_when_adding_task(self, browser):
+        self.login(self.manager, browser)
+
+        self.assert_metadata_value(False, 'has_sametype_children',
+                                   self.inbox_task)
+
+        browser.open(self.inbox_task)
+        factoriesmenu.add('Subtask')
+        browser.fill({'Title': 'Subtask',
+                      'Task Type': 'direct-execution'})
+        form = browser.find_form_by_field('Issuer')
+        form.find_widget('Issuer').fill(self.regular_user.id)
+        form.find_widget('Responsible').fill('fa:' + self.regular_user.id)
+        browser.click_on('Save')
+
+        self.assert_metadata_value(True, 'has_sametype_children',
+                                   self.inbox_task)
+
+    @browsing
+    def test_is_updated_when_pasting_dossier(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        self.assert_metadata_value(False, 'has_sametype_children',
+                                   self.empty_dossier)
+
+        browser.open(self.subsubdossier, view='copy_item')
+        browser.open(self.empty_dossier, view='tabbed_view')
+        browser.css('#contentActionMenus a#paste').first.click()
+
+        self.assert_metadata_value(True, 'has_sametype_children',
+                                   self.empty_dossier)
+
+    @browsing
+    def test_is_updated_when_pasting_repofolder(self, browser):
+        self.login(self.manager, browser=browser)
+
+        self.assert_metadata_value(False, 'has_sametype_children',
+                                   self.empty_repofolder)
+
+        browser.open(self.empty_repofolder, view='copy_item')
+        browser.open(self.empty_repofolder, view='tabbed_view')
+        browser.css('#contentActionMenus a#paste').first.click()
+
+        self.assert_metadata_value(True, 'has_sametype_children',
+                                   self.empty_repofolder)
+
+    @browsing
+    def test_is_updated_when_moving_dossier(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        self.assert_metadata_value(False, 'has_sametype_children',
+                                   self.empty_dossier)
+        self.assert_metadata_value(True, 'has_sametype_children',
+                                   self.subdossier)
+
+        self.move_items([self.subsubdossier],
+                        source=self.subdossier,
+                        target=self.empty_dossier)
+
+        self.assert_metadata_value(True, 'has_sametype_children',
+                                   self.empty_dossier)
+        self.assert_metadata_value(False, 'has_sametype_children',
+                                   self.subdossier)
+
+    @browsing
+    def test_is_updated_when_moving_repofolder(self, browser):
+        self.login(self.manager, browser=browser)
+
+        self.assert_metadata_value(False, 'has_sametype_children',
+                                   self.empty_repofolder)
+
+        with self.observe_children(self.empty_repofolder) as children:
+            self.move_items([self.inactive_repofolder],
+                            source=self.repository_root,
+                            target=self.empty_repofolder)
+
+        self.assert_metadata_value(True, 'has_sametype_children',
+                                   self.empty_repofolder)
+        self.assertEqual(1, len(children['added']))
+        inactive_repofolder = children['added'].pop()
+
+        self.move_items([inactive_repofolder],
+                        source=self.empty_repofolder,
+                        target=self.branch_repofolder)
+
+        self.assert_metadata_value(False, 'has_sametype_children',
+                                   self.empty_repofolder)

--- a/opengever/core/profiles/default/catalog.xml
+++ b/opengever/core/profiles/default/catalog.xml
@@ -11,6 +11,7 @@
   <column value="reference" />
   <column value="title_de" />
   <column value="title_fr" />
+  <column value="has_sametype_children" />
 
   <!-- CHANGED -->
   <column value="changed" />

--- a/opengever/core/upgrades/20190418160803_add_has_same_type_children_metadata_column/catalog.xml
+++ b/opengever/core/upgrades/20190418160803_add_has_same_type_children_metadata_column/catalog.xml
@@ -1,0 +1,3 @@
+<object name="portal_catalog">
+    <column value="has_sametype_children" />
+</object>

--- a/opengever/core/upgrades/20190418160803_add_has_same_type_children_metadata_column/upgrade.py
+++ b/opengever/core/upgrades/20190418160803_add_has_same_type_children_metadata_column/upgrade.py
@@ -1,0 +1,18 @@
+from ftw.upgrade import UpgradeStep
+from plone.dexterity.interfaces import IDexterityContainer
+
+
+class AddHasSameTypeChildrenMetadataColumn(UpgradeStep):
+    """Add has same type children metadata column.
+    """
+
+    deferrable = True
+
+    def __call__(self):
+        self.install_upgrade_profile()
+        query = {
+            'object_provides': IDexterityContainer.__identifier__,
+            }
+        # To avoid reindexing the whole objects, we pick any index that exists
+        # for all objects and is fast to compute
+        self.catalog_reindex_objects(query, idxs=['UID', 'has_sametype_children'])

--- a/solr-conf/managed-schema
+++ b/solr-conf/managed-schema
@@ -143,6 +143,7 @@
     <field name="filename" type="string" indexed="true" stored="false" />
     <field name="filesize" type="pint" indexed="true" stored="false" />
     <field name="firstname" type="string" indexed="true" stored="false" />
+    <field name="has_sametype_children" type="boolean" indexed="false" stored="true" />
     <field name="is_subdossier" type="boolean" indexed="true" stored="false" />
     <field name="issuer" type="string" indexed="true" stored="false" />
     <field name="lastname" type="string" indexed="true" stored="false" />


### PR DESCRIPTION
* added a new column `has_sametype_children` to the metadata.
* add the `has_sametype_children` to solr.
* add it as a column in the `listing` endpoint

A question that surfaced is whether this is what we really wanted. For example:
* should `has_sametype_children` be `True` for a dossier containing an inactive or trashed dossier?
* should `has_sametype_children` be `True` for a dossier containing a dossier that the current user cannot see?

resolves #5527 