### PR TITLE
Pass context and orgunit as GET parameters to webactions.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 ---------------------
 
 - Include preserved_as_paper_default in the @config endpoint and view. [Rotonen]
+- Pass context and orgunit as parameters to webactions. [njohner]
 - Implement resolving dossiers recursively via REST API. [lgraf]
 - Allow members to access plone vocabularies through restapi. [elioschmutz]
 - Workspaces do no longer inherit from dossiers. [elioschmutz]

--- a/opengever/base/tests/test_personal_bar.py
+++ b/opengever/base/tests/test_personal_bar.py
@@ -5,6 +5,7 @@ from opengever.testing import IntegrationTestCase
 from opengever.webactions.storage import get_storage
 from plonetheme.teamraum.testing import TeamraumThemeTestCase
 from Products.CMFCore.utils import getToolByName
+from urllib import urlencode
 import transaction
 
 
@@ -87,9 +88,10 @@ class TestWebactionsInPersonalBar(IntegrationTestCase):
 
         self.assertEqual(['Action 2', 'Action 1'], webactions.text)
 
-        self.assertEqual(
-            map(lambda item: item.get("href"), webactions),
-            ['http://example.org/endpoint2', 'http://example.org/endpoint'])
+        params = urlencode({'context': self.dossier.absolute_url(), 'orgunit': 'fa'})
+        self.assertEqual(map(lambda item: item.get("href"), webactions),
+                         ['http://example.org/endpoint2?{}'.format(params),
+                          'http://example.org/endpoint?{}'.format(params)])
 
     @browsing
     def test_only_webactions_with_display_user_menu_are_shown_in_usermenu(self, browser):

--- a/opengever/document/tests/test_overview.py
+++ b/opengever/document/tests/test_overview.py
@@ -7,6 +7,7 @@ from opengever.document.interfaces import ICheckinCheckoutManager
 from opengever.testing import IntegrationTestCase
 from opengever.testing.helpers import create_document_version
 from plone.locking.interfaces import IRefreshableLockable
+from urllib import urlencode
 from zope.component import queryMultiAdapter
 
 
@@ -614,9 +615,11 @@ class TestDocumentOverviewVanilla(IntegrationTestCase):
         webactions = browser.css('.file-action-buttons a.webaction_button')
         self.assertEqual(['Action 2', u'\xc4ction 1'], webactions.text)
 
-        self.assertEqual(
-            map(lambda item: item.get("href"), webactions),
-            ['http://example.org/endpoint2', 'http://example.org/endpoint'])
+        params = urlencode({'context': self.document.absolute_url(),
+                            'orgunit': 'fa'})
+        self.assertEqual(map(lambda item: item.get("href"), webactions),
+                         ['http://example.org/endpoint2?{}'.format(params),
+                          'http://example.org/endpoint?{}'.format(params)])
 
         self.assertEqual(
             map(lambda item: item.get("class"), webactions),

--- a/opengever/meeting/tests/test_proposal_overview.py
+++ b/opengever/meeting/tests/test_proposal_overview.py
@@ -3,6 +3,7 @@ from ftw.builder import create
 from ftw.testbrowser import browsing
 from ftw.testbrowser.pages import statusmessages
 from opengever.testing import IntegrationTestCase
+from urllib import urlencode
 
 
 class TestProposalOverview(IntegrationTestCase):
@@ -93,9 +94,11 @@ class TestProposalOverview(IntegrationTestCase):
         webactions = browser.css('.webactions_buttons a.webaction_button')
         self.assertEquals(['Action 2', 'Action 1'], webactions.text)
 
-        self.assertEqual(
-            map(lambda item: item.get("href"), webactions),
-            ['http://example.org/endpoint2', 'http://example.org/endpoint'])
+        params = urlencode({'context': self.submitted_proposal.absolute_url(),
+                            'orgunit': 'fa'})
+        self.assertEqual(map(lambda item: item.get("href"), webactions),
+                         ['http://example.org/endpoint2?{}'.format(params),
+                          'http://example.org/endpoint?{}'.format(params)])
 
         self.assertEqual(
             map(lambda item: item.get("class"), webactions),

--- a/opengever/task/tests/test_actionmenu_viewlet.py
+++ b/opengever/task/tests/test_actionmenu_viewlet.py
@@ -5,6 +5,7 @@ from opengever.testing import FunctionalTestCase
 from opengever.testing import IntegrationTestCase
 from opengever.webactions.storage import get_storage
 from plone.app.testing import TEST_USER_ID
+from urllib import urlencode
 
 
 class TestActionmenuViewlet(FunctionalTestCase):
@@ -82,9 +83,10 @@ class TestActionmenuViewletWebactions(IntegrationTestCase):
         self.assertEqual(2, len(webactions))
         self.assertEqual(['Action 2', 'Action 1'], webactions.text)
 
-        self.assertEqual(
-            map(lambda item: item.get("href"), webactions),
-            ['http://example.org/endpoint2', 'http://example.org/endpoint'])
+        params = urlencode({'context': self.task.absolute_url(), 'orgunit': 'fa'})
+        self.assertEqual(map(lambda item: item.get("href"), webactions),
+                         ['http://example.org/endpoint2?{}'.format(params),
+                          'http://example.org/endpoint?{}'.format(params)])
 
         self.assertEqual(
             map(lambda item: item.get("class"), webactions),

--- a/opengever/webactions/renderer.py
+++ b/opengever/webactions/renderer.py
@@ -1,11 +1,13 @@
 from opengever.base.utils import escape_html
+from opengever.ogds.base.utils import get_current_org_unit
+from opengever.webactions.interfaces import IWebActionsProvider
 from opengever.webactions.interfaces import IWebActionsRenderer
+from urllib import urlencode
 from zope.component import adapter
+from zope.component import queryMultiAdapter
 from zope.interface import implementer
 from zope.interface import Interface
 from zope.publisher.interfaces.browser import IBrowserRequest
-from opengever.webactions.interfaces import IWebActionsProvider
-from zope.component import queryMultiAdapter
 
 
 class WebActionsSafeDataGetter(object):
@@ -31,8 +33,16 @@ class WebActionsSafeDataGetter(object):
                     for display, webactions in webactions_dict.items())
 
     def _prepare_webaction_data(self, action):
-        return {key: value if key in self._attributes_not_to_escape else escape_html(value)
+        data = {key: value if key in self._attributes_not_to_escape else escape_html(value)
                 for key, value in action.items()}
+
+        data['target_url'] = "{}?{}".format(
+            data['target_url'], urlencode(self._get_webaction_parameters()))
+        return data
+
+    def _get_webaction_parameters(self):
+        return {'context': self.context.absolute_url(),
+                'orgunit': get_current_org_unit().id()}
 
 
 @implementer(IWebActionsRenderer)

--- a/opengever/webactions/tests/test_webaction_menus.py
+++ b/opengever/webactions/tests/test_webaction_menus.py
@@ -1,11 +1,12 @@
 from ftw.builder import Builder
 from ftw.builder import create
+from ftw.contentmenu.menu import FactoriesMenu
 from ftw.testbrowser import browsing
 from opengever.base.menu import OGCombinedActionsWorkflowMenu
 from opengever.testing import IntegrationTestCase
 from opengever.webactions.storage import get_storage
 from opengever.webactions.tests.test_webactions_provider import TestWebActionBase
-from ftw.contentmenu.menu import FactoriesMenu
+from urllib import urlencode
 
 
 class TestWebActionsTitleButtons(IntegrationTestCase):
@@ -57,8 +58,11 @@ class TestWebActionsTitleButtons(IntegrationTestCase):
         self.assertEqual(len(webactions), 2)
 
         action1, action2 = webactions
-        self.assertEqual('http://example.org/endpoint', action1.get("href"))
-        self.assertEqual('http://example.org/endpoint2', action2.get("href"))
+        params = urlencode({'context': self.dossier.absolute_url(), 'orgunit': 'fa'})
+        self.assertEqual('http://example.org/endpoint?{}'.format(params),
+                         action1.get("href"))
+        self.assertEqual('http://example.org/endpoint2?{}'.format(params),
+                         action2.get("href"))
 
         self.assertEqual(u'\xc4ction 1', action1.get("title"))
         self.assertEqual('Action 2', action2.get("title"))
@@ -267,10 +271,12 @@ class TestWebActionsFactoryMenus(IntegrationTestCase):
             webactions = action_menu.css('.webaction')
 
             action1, action2 = webactions
-
+            params = urlencode({'context': obj.absolute_url(), 'orgunit': 'fa'})
             # check that they point to correct url
-            self.assertEqual('http://example.org/endpoint', action1.get("href"))
-            self.assertEqual('http://example.org/endpoint2', action2.get("href"))
+            self.assertEqual('http://example.org/endpoint?{}'.format(params),
+                             action1.get("href"))
+            self.assertEqual('http://example.org/endpoint2?{}'.format(params),
+                             action2.get("href"))
 
             # check the displayed title
             self.assertEqual(u'\xc4ction 1', action1.text)

--- a/opengever/webactions/tests/test_webactions_menu_items_preparer.py
+++ b/opengever/webactions/tests/test_webactions_menu_items_preparer.py
@@ -1,5 +1,6 @@
 from opengever.webactions.interfaces import IWebActionsMenuItemsPreparer
 from opengever.webactions.tests.test_webactions_renderer import TestWebActionRendererTitleButtons
+from urllib import urlencode
 
 
 class TestWebActionRendererActionsMenu(TestWebActionRendererTitleButtons):
@@ -8,8 +9,12 @@ class TestWebActionRendererActionsMenu(TestWebActionRendererTitleButtons):
     icon = ''
     adapter_interface = IWebActionsMenuItemsPreparer
 
+    params = {'context': 'http://nohost/plone/ordnungssystem/fuhrung'
+              '/vertrage-und-vereinbarungen/dossier-1',
+              'orgunit': 'fa'}
+
     expected_data = [
-        {'action': 'http://example.org/endpoint',
+        {'action': 'http://example.org/endpoint?{}'.format(urlencode(params)),
          'description': '',
          'extra': {'class': 'actionicon-object_webaction',
                    'id': 'webaction-0',
@@ -18,7 +23,7 @@ class TestWebActionRendererActionsMenu(TestWebActionRendererTitleButtons):
          'selected': False,
          'submenu': None,
          'title': u'Action 1'},
-        {'action': 'http://example.org/endpoint',
+        {'action': 'http://example.org/endpoint?{}'.format(urlencode(params)),
          'description': '',
          'extra': {'class': 'actionicon-object_webaction',
                    'id': 'webaction-1',
@@ -33,15 +38,19 @@ class TestWebActionRendererUserMenu(TestWebActionRendererActionsMenu):
 
     display = 'user-menu'
 
+    params = {'context': 'http://nohost/plone/ordnungssystem/fuhrung'
+              '/vertrage-und-vereinbarungen/dossier-1',
+              'orgunit': 'fa'}
+
     expected_data = [
         {'title': u'Action 1',
          'category': 'webactions',
-         'url': 'http://example.org/endpoint',
+         'url': 'http://example.org/endpoint?{}'.format(urlencode(params)),
          'separator': None,
          'id': 'webaction-0'},
         {'title': u'Action 2',
          'category': 'webactions',
-         'url': 'http://example.org/endpoint',
+         'url': 'http://example.org/endpoint?{}'.format(urlencode(params)),
          'separator': 'actionSeparator',
          'id': 'webaction-1'}]
 
@@ -51,8 +60,12 @@ class TestWebActionRendererAddMenu(TestWebActionRendererActionsMenu):
     display = 'add-menu'
     icon = 'fa-helicopter'
 
+    params = {'context': 'http://nohost/plone/ordnungssystem/fuhrung'
+              '/vertrage-und-vereinbarungen/dossier-1',
+              'orgunit': 'fa'}
+
     expected_data = [
-        {'action': 'http://example.org/endpoint',
+        {'action': 'http://example.org/endpoint?{}'.format(urlencode(params)),
          'description': '',
          'extra': {'class': 'webaction fa-helicopter',
                    'id': 'webaction-0',
@@ -61,7 +74,7 @@ class TestWebActionRendererAddMenu(TestWebActionRendererActionsMenu):
          'selected': False,
          'submenu': None,
          'title': u'Action 1'},
-        {'action': 'http://example.org/endpoint',
+        {'action': 'http://example.org/endpoint?{}'.format(urlencode(params)),
          'description': '',
          'extra': {'class': 'webaction fa-helicopter',
                    'id': 'webaction-1',

--- a/opengever/webactions/tests/test_webactions_renderer.py
+++ b/opengever/webactions/tests/test_webactions_renderer.py
@@ -2,6 +2,7 @@ from ftw.builder import Builder
 from ftw.builder import create
 from opengever.testing import IntegrationTestCase
 from opengever.webactions.interfaces import IWebActionsRenderer
+from urllib import urlencode
 from zope.component import getMultiAdapter
 
 
@@ -11,12 +12,16 @@ class TestWebActionRendererTitleButtons(IntegrationTestCase):
     icon = 'fa-helicopter'
     adapter_interface = IWebActionsRenderer
 
-    expected_data = [
-        '<a title="Action 1" href="http://example.org/endpoint" '
-        'class="webaction_button fa fa-helicopter"></a>',
+    params = {'context': 'http://nohost/plone/ordnungssystem/fuhrung'
+              '/vertrage-und-vereinbarungen/dossier-1',
+              'orgunit': 'fa'}
 
-        '<a title="Action 2" href="http://example.org/endpoint" '
-        'class="webaction_button fa fa-helicopter"></a>']
+    expected_data = [
+        '<a title="Action 1" href="http://example.org/endpoint?{}" '
+        'class="webaction_button fa fa-helicopter"></a>'.format(urlencode(params)),
+
+        '<a title="Action 2" href="http://example.org/endpoint?{}" '
+        'class="webaction_button fa fa-helicopter"></a>'.format(urlencode(params))]
 
     def setUp(self):
         super(TestWebActionRendererTitleButtons, self).setUp()
@@ -43,11 +48,17 @@ class TestWebActionRendererActionButtons(TestWebActionRendererTitleButtons):
     display = 'action-buttons'
     icon = 'fa-helicopter'
 
-    expected_data = [
-            '<a title="Action 1" href="http://example.org/endpoint" '
-            'class="webaction_button fa fa-helicopter">'
-            '<span class="subMenuTitle actionText">Action 1</span></a>',
+    params = {'context': 'http://nohost/plone/ordnungssystem/fuhrung'
+              '/vertrage-und-vereinbarungen/dossier-1',
+              'orgunit': 'fa'}
 
-            '<a title="Action 2" href="http://example.org/endpoint" '
+    expected_data = [
+            '<a title="Action 1" href="http://example.org/endpoint?{}" '
             'class="webaction_button fa fa-helicopter">'
-            '<span class="subMenuTitle actionText">Action 2</span></a>']
+            '<span class="subMenuTitle actionText">Action 1</span></a>'.format(
+              urlencode(params)),
+
+            '<a title="Action 2" href="http://example.org/endpoint?{}" '
+            'class="webaction_button fa fa-helicopter">'
+            '<span class="subMenuTitle actionText">Action 2</span></a>'.format(
+              urlencode(params))]


### PR DESCRIPTION
We add the parameters directly in the `WebActionsSafeDataGetter`, which is used by all `Renderers` and `ItemPreparers`, so that we directly have the parameters passed for all the display locations.

resolves #5586 