### PR TITLE
Include preserved_as_paper_default in the @config endpoint and view

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2019.2.0 (unreleased)
 ---------------------
 
+- Include preserved_as_paper_default in the @config endpoint and view. [Rotonen]
 - Implement resolving dossiers recursively via REST API. [lgraf]
 - Allow members to access plone vocabularies through restapi. [elioschmutz]
 - Workspaces do no longer inherit from dossiers. [elioschmutz]

--- a/opengever/base/configuration.py
+++ b/opengever/base/configuration.py
@@ -10,6 +10,7 @@ from opengever.base.interfaces import IRecentlyTouchedSettings
 from opengever.base.interfaces import ISearchSettings
 from opengever.bumblebee.interfaces import IGeverBumblebeeSettings
 from opengever.contact.interfaces import IContactSettings
+from opengever.document.interfaces import IDocumentSettings
 from opengever.dossier.dossiertemplate.interfaces import IDossierTemplateSettings
 from opengever.dossier.interfaces import IDossierContainerTypes
 from opengever.dossier.interfaces import IDossierResolveProperties
@@ -60,6 +61,7 @@ class GeverSettingsAdpaterV1(object):
         settings['max_dossier_levels'] = api.portal.get_registry_record('maximum_dossier_depth', interface=IDossierContainerTypes) + 1  # noqa
         settings['max_repositoryfolder_levels'] = api.portal.get_registry_record('maximum_repository_depth', interface=IRepositoryFolderRecords)  # noqa
         settings['recently_touched_limit'] = api.portal.get_registry_record('limit', interface=IRecentlyTouchedSettings)  # noqa
+        settings['document_preserved_as_paper_default'] = api.portal.get_registry_record('preserved_as_paper_default', interface=IDocumentSettings)  # noqa
         settings['oneoffixx_settings'] = self.get_oneoffixx_settings()
         settings['sharing_configuration'] = self.get_sharing_configuration()
         return settings

--- a/opengever/base/tests/test_configuration_adapter.py
+++ b/opengever/base/tests/test_configuration_adapter.py
@@ -13,6 +13,7 @@ class TestConfigurationAdapter(IntegrationTestCase):
             ('max_dossier_levels', 2),
             ('max_repositoryfolder_levels', 3),
             ('recently_touched_limit', 10),
+            ('document_preserved_as_paper_default', True),
             ('oneoffixx_settings', OrderedDict([
                 ('baseurl', u''),
                 ('fake_sid', u''),


### PR DESCRIPTION
Simply added the setting to the configuration adapter implementation.

Closes #5588