### PR TITLE
Nightly job runner: Fix virtual_memory_percent limit

### DIFF
--- a/opengever/nightlyjobs/runner.py
+++ b/opengever/nightlyjobs/runner.py
@@ -48,7 +48,7 @@ class NightlyJobRunner(object):
     """
 
     LOAD_LIMITS = {'virtual_memory_available': 100 * 1024 *1024,
-                   'virtual_memory_percent': 0.95}
+                   'virtual_memory_percent': 95}
 
     def __init__(self):
         # retrieve window start and end times

--- a/opengever/nightlyjobs/tests/test_nightly_job_runner.py
+++ b/opengever/nightlyjobs/tests/test_nightly_job_runner.py
@@ -56,7 +56,7 @@ class TestNightlyJobRunner(IntegrationTestCase):
 
     def get_load_controlled_runner(self,
                                    virtual_memory_available=200 * 1024 * 1024,
-                                   virtual_memory_percent=0.5):
+                                   virtual_memory_percent=50):
         """ get a runner with controlled system load
         """
         runner = NightlyJobRunner()
@@ -166,7 +166,7 @@ class TestNightlyJobRunner(IntegrationTestCase):
         runner = NightlyJobRunner()
 
         memory_limit = runner.LOAD_LIMITS['virtual_memory_available']
-        load = {'virtual_memory_percent': 0.5}
+        load = {'virtual_memory_percent': 50}
         load['virtual_memory_available'] = memory_limit + 1
         self.assertFalse(runner._is_memory_full(load))
 
@@ -194,7 +194,7 @@ class TestNightlyJobRunner(IntegrationTestCase):
 
     def test_runner_aborts_when_percent_memory_too_high(self):
         self.login(self.manager)
-        runner = self.get_load_controlled_runner(virtual_memory_percent=1.)
+        runner = self.get_load_controlled_runner(virtual_memory_percent=100)
         self.assertEqual(1, runner.get_initial_jobs_count())
 
         exception = runner.execute_pending_jobs()
@@ -238,7 +238,7 @@ class TestNightlyJobRunner(IntegrationTestCase):
         exception = runner.execute_pending_jobs()
         expected_message = "SystemLoadCritical('System overloaded.\\n"\
                            "Available memory: 200MB; limit: 100MB\\n"\
-                           "Percent memory: 0.5; limit: 0.95',)\n"\
+                           "Percent memory: 50; limit: 95',)\n"\
                            "document-title executed 0 out of 1 jobs"
         self.assertEqual(expected_message,
                          runner.format_early_abort_message(exception))


### PR DESCRIPTION
psutil's `virtual_memory().percent` is in percent (`0-100`), not a decimal like `0.95`.

(See [`psutil._common.usage_percent()`](https://github.com/giampaolo/psutil/blob/c78a850358af883dcaa63a3f9204f15cc129e518/psutil/_common.py#L268-L277)).

On this occasion, I also verified that [`percent` refers to the percentage of `total - available`](https://github.com/giampaolo/psutil/blob/c78a850358af883dcaa63a3f9204f15cc129e518/psutil/_pslinux.py#L478) (instead of `used`, which would be problematic), which is the behavior we want. (_That isn't explicitly documented in psutil's docs, but is what's to be expected._)

_(No change log entry, since introduced in the same release)_