### PR TITLE
Nightly job runner: Immediately check for time window and system load

### DIFF
--- a/opengever/nightlyjobs/runner.py
+++ b/opengever/nightlyjobs/runner.py
@@ -70,7 +70,12 @@ class NightlyJobRunner(object):
             for job in job_provider:
                 yield job
 
-    def execute_pending_jobs(self):
+    def execute_pending_jobs(self, early_check=True):
+        if early_check:
+            # When invoked from a cron job, we first check that time window
+            # and system load are acceptable. Otherwise cron job is misconfigured.
+            self.interrupt_if_necessary()
+
         for job in self.get_jobs():
             try:
                 self.interrupt_if_necessary()


### PR DESCRIPTION
Nightly job runner: Immediately check for time window and system load upon invocation, before even attempting to look up providers and collect jobs. This will result in an unhandled exception every time the runner is invoked outside the time window (from a misconfigured cron job), and allows us to notice these misconfigurations.

(Otherwise a situation with 0 pending jobs would lead to "success", because `NightlyJobRunner.interrupt_if_necessary()` is never called).

For testing purposes I had to introduce an `early_check=True` kwarg to be able to disable this behavior when we want to test for when these conditions happen later, during job execution.

_(No change log entry, since introduced in the same release)_