### PR TITLE
Teamraum Beteiligungen - REST-Endpoints

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -96,6 +96,7 @@ Changelog
 - Do not allow sorting on Keywords in dossier and document listings. [njohner]
 - Also update content controls when updating doc properties. [buchi]
 - Include userid and fullname of current user in @config endpoint. [buchi]
+- Add restapi @participations endpoint to handle participations. [elioschmutz]
 - Include preserved_as_paper_default in the @config endpoint and view. [Rotonen]
 - Pass context and orgunit as parameters to webactions. [njohner]
 - Implement resolving dossiers recursively via REST API. [lgraf]

--- a/docs/public/dev-manual/api/index.rst
+++ b/docs/public/dev-manual/api/index.rst
@@ -31,6 +31,7 @@ Inhalt:
    tasks.rst
    reminder.rst
    journal.rst
+   participation.rst
    examples/index.rst
    docs_changelog.rst
 

--- a/docs/public/dev-manual/api/participation.rst
+++ b/docs/public/dev-manual/api/participation.rst
@@ -149,3 +149,32 @@ Pflicht:
           "participation_type": "invitation",
           "readable_participation_type": "Invitation",
     }
+
+
+Beteiligungen bearbeiten:
+-------------------------
+Sowohl Beteiligungen wie auch Einladungen können über einen PATCH request auf die jeweilige Ressourece geändert werden.
+
+**Parameter:**
+
+Pflicht:
+
+``role``: ``String``
+   Eine Arbeitsraum-Rolle
+
+**Beispiel-Request**:
+
+   .. sourcecode:: http
+
+       POST /workspaces/workspace-1/@participations/invitations/3a8bfcb1b6294edfb60e2a43717fc301 HTTP/1.1
+       Accept: application/json
+
+       {
+         "role": "WorkspaceAdmin",
+       }
+
+**Beispiel-Response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 204 No Content

--- a/docs/public/dev-manual/api/participation.rst
+++ b/docs/public/dev-manual/api/participation.rst
@@ -1,0 +1,79 @@
+.. _participation:
+
+Teamraum Beteiligungen
+======================
+
+Der ``@participations`` Endpoint behandelt Teamraum Beteiligungen.
+
+
+Beteiligungen abrufen:
+----------------------
+Ein GET Request gibt die Beteiligungen sowie die aktiven Einladungen eines Inhalts zurück.
+
+Zusätzlich werden alle verfügbaren Rollen im Attribut "roles" zurückgegeben. Dies erleichtert die Darstellung und Verwaltung von Rollen.
+
+**Beispiel-Request**:
+
+   .. sourcecode:: http
+
+       GET /workspace-1/@participations HTTP/1.1
+       Accept: application/json
+
+**Beispiel-Response**:
+
+
+   .. sourcecode:: http
+
+    HTTP/1.1 200 OK
+    Content-Type: application/json
+
+    {
+      "items": [
+        {
+          "@id": "http://localhost:8080/fd/workspaces/workspace-1/@participations/users/max.muster",
+          "@type": "virtual.participations.user",
+          "inviter_fullname": null,
+          "is_editable": false,
+          "participant_fullname": "Max Muster (max.muster)",
+          "readable_role": "Federführung",
+          "role": "WorkspaceOwner",
+          "token": "max.muster",
+          "participation_type": "user",
+          "readable_participation_type": "User",
+        },
+        {
+          "@id": "http://localhost:8080/fd/workspaces/workspace-1/@participations/invitations/3a8bfcb1b6294edfb60e2a43717fc300",
+          "@type": "virtual.participations.invitation",
+          "inviter_fullname": "Max Muster (max.muster)",
+          "is_editable": true,
+          "participant_fullname": "Petra Fröhlich (petra.frohlich)",
+          "readable_role": "Gast",
+          "role": "WorkspaceGuest",
+          "token": "3a8bfcb1b6294edfb60e2a43717fc300",
+          "participation_type": "invitation",
+          "readable_participation_type": "Invitation",
+        }
+      ],
+      "roles": [
+        {
+          "id": "WorkspaceOwner",
+          "managed": false,
+          "title": "Federführung"
+        },
+        {
+          "id": "WorkspaceAdmin",
+          "managed": true,
+          "title": "Admin"
+        },
+        {
+          "id": "WorkspaceMember",
+          "managed": true,
+          "title": "Teammitglied"
+        },
+        {
+          "id": "WorkspaceGuest",
+          "managed": true,
+          "title": "Gast"
+        }
+      ]
+    }

--- a/docs/public/dev-manual/api/participation.rst
+++ b/docs/public/dev-manual/api/participation.rst
@@ -10,8 +10,6 @@ Beteiligungen abrufen:
 ----------------------
 Ein GET Request gibt die Beteiligungen sowie die aktiven Einladungen eines Inhalts zurück.
 
-Zusätzlich werden alle verfügbaren Rollen im Attribut "roles" zurückgegeben. Dies erleichtert die Darstellung und Verwaltung von Rollen.
-
 **Beispiel-Request**:
 
    .. sourcecode:: http
@@ -52,28 +50,6 @@ Zusätzlich werden alle verfügbaren Rollen im Attribut "roles" zurückgegeben. 
           "token": "3a8bfcb1b6294edfb60e2a43717fc300",
           "participation_type": "invitation",
           "readable_participation_type": "Invitation",
-        }
-      ],
-      "roles": [
-        {
-          "id": "WorkspaceOwner",
-          "managed": false,
-          "title": "Federführung"
-        },
-        {
-          "id": "WorkspaceAdmin",
-          "managed": true,
-          "title": "Admin"
-        },
-        {
-          "id": "WorkspaceMember",
-          "managed": true,
-          "title": "Teammitglied"
-        },
-        {
-          "id": "WorkspaceGuest",
-          "managed": true,
-          "title": "Gast"
         }
       ]
     }

--- a/docs/public/dev-manual/api/participation.rst
+++ b/docs/public/dev-manual/api/participation.rst
@@ -99,3 +99,53 @@ Die URL setzt sich dabei folgendermassen zusammen:
    .. sourcecode:: http
 
       HTTP/1.1 204 No Content
+
+
+Beteiligungen hinzufügen (Benutzer einladen):
+---------------------------------------------
+Eine Beteiligung kann nur über eine Einladung hinzugefügt werden. Der eingeladene Benutzer muss seine Beteiligung erste bestätigen, bevor der Benutzer effektiv berechtigt wird.
+
+Eine Einladung wird durch einen POST request auf den `@participation/invitations` Endpoint erstellt.
+
+
+**Parameter:**
+
+Pflicht:
+
+``userid``: ``String``
+   ID des Benutzers, welcher eingeladen werden soll
+
+``role``: ``String``
+   Eine Arbeitsraum-Rolle
+
+**Beispiel-Request**:
+
+   .. sourcecode:: http
+
+       POST /workspaces/workspace-1/@participations/invitations/ HTTP/1.1
+       Accept: application/json
+
+       {
+         "userid": "maria.meier",
+         "role": "WorkspaceMember",
+       }
+
+**Beispiel-Response**:
+
+   .. sourcecode:: http
+
+    HTTP/1.1 200 OK
+    Content-Type: application/json
+
+    {
+          "@id": "http://localhost:8080/fd/workspaces/workspace-1/@participations/invitations/3a8bfcb1b6294edfb60e2a43717fc301",
+          "@type": "virtual.participations.invitation",
+          "inviter_fullname": "Max Muster (max.muster)",
+          "is_editable": true,
+          "participant_fullname": "Maria Meier (maria.meier)",
+          "readable_role": "Teammitglied",
+          "role": "WorkspaceMember",
+          "token": "3a8bfcb1b6294edfb60e2a43717fc301",
+          "participation_type": "invitation",
+          "readable_participation_type": "Invitation",
+    }

--- a/docs/public/dev-manual/api/participation.rst
+++ b/docs/public/dev-manual/api/participation.rst
@@ -77,3 +77,25 @@ Zusätzlich werden alle verfügbaren Rollen im Attribut "roles" zurückgegeben. 
         }
       ]
     }
+
+
+Beteiligungen löschen:
+----------------------
+Ein DELETE Request auf die `@id` einer Beteiligung löscht die entsprechnede Beteilungung oder Einladung.
+
+Die URL setzt sich dabei folgendermassen zusammen:
+``gever-url/workspaces/workspace/@participations/{participation_type}/{token}``
+
+**Beispiel-Request**:
+
+   .. sourcecode:: http
+
+       DELETE /workspace-1/@participations/invitations/3a8bfcb1b6294edfb60e2a43717fc300 HTTP/1.1
+       Accept: application/json
+
+
+**Beispiel-Response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 204 No Content

--- a/docs/public/dev-manual/api/participation.rst
+++ b/docs/public/dev-manual/api/participation.rst
@@ -79,6 +79,39 @@ Zusätzlich werden alle verfügbaren Rollen im Attribut "roles" zurückgegeben. 
     }
 
 
+Eine einzelne Beteiligung abrufen:
+----------------------------------
+Ein GET Request auf die jeweilige Resource gibt die Beteiligungen oder die Einladungen eines Inhalts zurück.
+
+**Beispiel-Request**:
+
+   .. sourcecode:: http
+
+       GET /workspaces/workspace-1/@participations/users/max.muster HTTP/1.1
+       Accept: application/json
+
+**Beispiel-Response**:
+
+
+   .. sourcecode:: http
+
+    HTTP/1.1 200 OK
+    Content-Type: application/json
+
+    {
+      "@id": "http://localhost:8080/fd/workspaces/workspace-1/@participations/users/max.muster",
+      "@type": "virtual.participations.user",
+      "inviter_fullname": null,
+      "is_editable": false,
+      "participant_fullname": "Max Muster (max.muster)",
+      "readable_role": "Federführung",
+      "role": "WorkspaceOwner",
+      "token": "max.muster",
+      "participation_type": "user",
+      "readable_participation_type": "User",
+    }
+
+
 Beteiligungen löschen:
 ----------------------
 Ein DELETE Request auf die `@id` einer Beteiligung löscht die entsprechnede Beteilungung oder Einladung.

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -340,4 +340,12 @@
       permission="zope2.View"
       />
 
+  <plone:service
+      method="GET"
+      name="@participations"
+      for="opengever.workspace.interfaces.IWorkspace"
+      factory=".participation.ParticipationsGet"
+      permission="zope2.View"
+      />
+
 </configure>

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -357,4 +357,12 @@
       permission="plone.DelegateWorkspaceAdminRole"
       />
 
+  <plone:service
+      method="POST"
+      name="@participations"
+      for="opengever.workspace.interfaces.IWorkspace"
+      factory=".participation.ParticipationsPost"
+      permission="plone.DelegateWorkspaceAdminRole"
+      />
+
 </configure>

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -9,6 +9,7 @@
   <include package="opengever.document" file="permissions.zcml" />
   <include package="opengever.trash" file="permissions.zcml" />
   <include package="opengever.webactions" file="permissions.zcml" />
+  <include package="opengever.workspace" file="permissions.zcml" />
 
   <adapter factory=".serializer.GeverSerializeToJson" />
   <adapter factory=".serializer.GeverSerializeFolderToJson" />
@@ -346,6 +347,14 @@
       for="opengever.workspace.interfaces.IWorkspace"
       factory=".participation.ParticipationsGet"
       permission="zope2.View"
+      />
+
+  <plone:service
+      method="DELETE"
+      name="@participations"
+      for="opengever.workspace.interfaces.IWorkspace"
+      factory=".participation.ParticipationsDelete"
+      permission="plone.DelegateWorkspaceAdminRole"
       />
 
 </configure>

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -365,4 +365,12 @@
       permission="plone.DelegateWorkspaceAdminRole"
       />
 
+  <plone:service
+      method="PATCH"
+      name="@participations"
+      for="opengever.workspace.interfaces.IWorkspace"
+      factory=".participation.ParticipationsPatch"
+      permission="plone.DelegateWorkspaceAdminRole"
+      />
+
 </configure>

--- a/opengever/api/participation.py
+++ b/opengever/api/participation.py
@@ -129,3 +129,27 @@ class ParticipationsPost(ParticipationTraverseService):
             raise BadRequest('Missing parameter role')
 
         return data
+
+
+class ParticipationsPatch(ParticipationTraverseService):
+
+    def reply(self):
+        participation_type, token = self.read_params()
+        data = self.validate_data(json_body(self.request))
+
+        manager = ManageParticipants(self.context, self.request)
+        manager._modify(token, data.get('role'), participation_type.id)
+        return None
+
+    def read_params(self):
+        if len(self.params) != 2:
+            raise BadRequest(
+                "Must supply type and token ID as URL path parameters.")
+
+        return PARTICIPATION_TYPES_BY_PATH_IDENTIFIER.get(self.params[0]), self.params[1]
+
+    def validate_data(self, data):
+        if not data.get('role'):
+            raise BadRequest('Missing parameter role')
+
+        return data

--- a/opengever/api/participation.py
+++ b/opengever/api/participation.py
@@ -59,13 +59,8 @@ class ParticipationsGet(ParticipationTraverseService):
             return self._participant(token)
         else:
             result = {}
-            self.extend_with_roles(result)
             self.extend_with_participations(result)
             return result
-
-    def extend_with_roles(self, result):
-        result['roles'] = map(lambda role: role.serialize(self.request),
-                              PARTICIPATION_ROLES.values())
 
     def extend_with_participations(self, result):
         result['items'] = list(self._participations())

--- a/opengever/api/participation.py
+++ b/opengever/api/participation.py
@@ -1,0 +1,58 @@
+from opengever.workspace.participation import PARTICIPATION_ROLES
+from opengever.workspace.participation import PARTICIPATION_TYPES
+from opengever.workspace.participation.browser.manage_participants import ManageParticipants
+from plone.restapi.services import Service
+
+
+def participation_item(
+        context, request, token,
+        participation_type, editable, role, participant_fullname, inviter_fullname):
+
+    return {
+        '@id': '{}/@participations/{}/{}'.format(
+            context.absolute_url(),
+            participation_type.path_identifier,
+            token),
+        '@type': 'virtual.participations.{}'.format(participation_type.id),
+        'participant_fullname': participant_fullname,
+        'inviter_fullname': inviter_fullname,
+        'role': role,
+        'readable_role': PARTICIPATION_ROLES.get(role).translated_title(request),
+        'is_editable': editable,
+        'participation_type': participation_type.id,
+        'readable_participation_type': participation_type.translated_title(request),
+        'token': token,
+    }
+
+
+class ParticipationsGet(Service):
+    """API Endpoint which returns a list of all participants for the current
+    workspace.
+
+    GET workspace/@participations HTTP/1.1
+    """
+
+    def reply(self):
+        result = {}
+        self.extend_with_roles(result)
+        self.extend_with_participations(result)
+        return result
+
+    def extend_with_roles(self, result):
+        result['roles'] = map(lambda role: role.serialize(self.request),
+                              PARTICIPATION_ROLES.values())
+
+    def extend_with_participations(self, result):
+        manager = ManageParticipants(self.context, self.request)
+        participants = manager.get_participants() + manager.get_pending_invitations()
+        result['items'] = []
+        for participant in participants:
+            result['items'].append(participation_item(
+                self.context, self.request,
+                token=participant.get('token'),
+                participation_type=PARTICIPATION_TYPES[participant.get('type_')],
+                editable=participant.get('can_manage'),
+                role=participant.get('roles')[0],
+                participant_fullname=participant.get('name'),
+                inviter_fullname=participant.get('inviter')
+                ))

--- a/opengever/api/tests/test_participation.py
+++ b/opengever/api/tests/test_participation.py
@@ -199,6 +199,60 @@ class TestParticipationGet(IntegrationTestCase):
             any([item.get('is_editable') for item in response.get('items')]),
             'No entry should be editable because the user has no permission')
 
+    @browsing
+    def test_get_single_invitation(self, browser):
+        self.login(self.workspace_owner, browser)
+
+        iid = getUtility(IInvitationStorage).add_invitation(
+            self.workspace,
+            self.regular_user.getId(),
+            self.workspace_owner.getId(),
+            'WorkspaceGuest')
+
+        response = browser.open(
+            self.workspace.absolute_url() + '/@participations/invitations/{}'.format(iid),
+            method='GET',
+            headers=http_headers(),
+        ).json
+
+        self.assertDictEqual(
+            {
+                u'@id': u'http://nohost/plone/workspaces/workspace-1/@participations/invitations/{}'.format(iid),
+                u'@type': u'virtual.participations.invitation',
+                u'is_editable': True,
+                u'inviter_fullname': u'Fr\xf6hlich G\xfcnther (gunther.frohlich)',
+                u'participant_fullname': u'B\xe4rfuss K\xe4thi (kathi.barfuss)',
+                u'token': iid,
+                u'readable_role': u'Guest',
+                u'role': u'WorkspaceGuest',
+                u'participation_type': u'invitation',
+                u'readable_participation_type': u'Invitation',
+            }, response)
+
+    @browsing
+    def test_get_single_participant(self, browser):
+        self.login(self.workspace_owner, browser)
+
+        response = browser.open(
+            self.workspace.absolute_url() + '/@participations/users/{}'.format(self.workspace_guest.id),
+            method='GET',
+            headers=http_headers(),
+        ).json
+
+        self.assertDictEqual(
+            {
+                u'@id': u'http://nohost/plone/workspaces/workspace-1/@participations/users/hans.peter',
+                u'@type': u'virtual.participations.user',
+                u'is_editable': True,
+                u'inviter_fullname': None,
+                u'participant_fullname': u'Peter Hans (hans.peter)',
+                u'token': 'hans.peter',
+                u'readable_role': u'Guest',
+                u'role': u'WorkspaceGuest',
+                u'participation_type': u'user',
+                u'readable_participation_type': u'User',
+            }, response)
+
 
 class TestParticipationDelete(IntegrationTestCase):
 

--- a/opengever/api/tests/test_participation.py
+++ b/opengever/api/tests/test_participation.py
@@ -432,6 +432,19 @@ class TestParticipationPost(IntegrationTestCase):
                 headers=http_headers(),
                 )
 
+    @browsing
+    def test_raise_bad_request_if_adding_existing_user(self, browser):
+        self.login(self.workspace_admin, browser=browser)
+        data = json.dumps({'userid': self.workspace_guest.id, 'role': 'WorkspaceMember'})
+
+        with browser.expect_http_error(400):
+            browser.open(
+                self.workspace.absolute_url() + '/@participations/invitations',
+                method='POST',
+                data=data,
+                headers=http_headers(),
+            ).json
+
 
 class TestParticipationPatch(IntegrationTestCase):
 

--- a/opengever/api/tests/test_participation.py
+++ b/opengever/api/tests/test_participation.py
@@ -1,0 +1,199 @@
+from ftw.testbrowser import browsing
+from opengever.testing import IntegrationTestCase
+from opengever.workspace.participation.storage import IInvitationStorage
+from zope.component import getUtility
+
+
+def http_headers():
+    return {'Accept': 'application/json',
+            'Content-Type': 'application/json'}
+
+
+def get_entry_by_token(entries, token):
+    for entry in entries:
+        if entry['token'] == token:
+            return entry
+    return None
+
+
+class TestParticipationGet(IntegrationTestCase):
+
+    @browsing
+    def test_list_all_available_roles(self, browser):
+        self.login(self.workspace_owner, browser)
+
+        response = browser.open(
+            self.workspace.absolute_url() + '/@participations',
+            method='GET',
+            headers=http_headers(),
+        ).json
+
+        self.assertItemsEqual(
+            [
+                {
+                    u'managed': False,
+                    u'id': u'WorkspaceOwner',
+                    u'title': u'Owner'
+                },
+                {
+                    u'managed': True,
+                    u'id': u'WorkspaceAdmin',
+                    u'title': u'Admin'
+                },
+                {
+                    u'managed': True,
+                    u'id': u'WorkspaceMember',
+                    u'title': u'Member'
+                },
+                {
+                    u'managed': True,
+                    u'id': u'WorkspaceGuest',
+                    u'title': u'Guest'
+                }
+            ], response.get('roles'))
+
+    @browsing
+    def test_list_all_current_participants_and_invitations(self, browser):
+        self.login(self.workspace_owner, browser)
+
+        iid = getUtility(IInvitationStorage).add_invitation(
+            self.workspace,
+            self.regular_user.getId(),
+            self.workspace_owner.getId(),
+            'WorkspaceGuest')
+
+        response = browser.open(
+            self.workspace.absolute_url() + '/@participations',
+            method='GET',
+            headers=http_headers(),
+        ).json
+
+        self.assertItemsEqual(
+            [
+                {
+                    u'@id': u'http://nohost/plone/workspaces/workspace-1/@participations/users/beatrice.schrodinger',
+                    u'@type': u'virtual.participations.user',
+                    u'is_editable': True,
+                    u'inviter_fullname': None,
+                    u'participant_fullname': u'Schr\xf6dinger B\xe9atrice (beatrice.schrodinger)',
+                    u'token': 'beatrice.schrodinger',
+                    u'readable_role': u'Member',
+                    u'role': u'WorkspaceMember',
+                    u'participation_type': u'user',
+                    u'readable_participation_type': u'User',
+                },
+                {
+                    u'@id': u'http://nohost/plone/workspaces/workspace-1/@participations/users/fridolin.hugentobler',
+                    u'@type': u'virtual.participations.user',
+                    u'is_editable': True,
+                    u'inviter_fullname': None,
+                    u'participant_fullname': u'Hugentobler Fridolin (fridolin.hugentobler)',
+                    u'token': 'fridolin.hugentobler',
+                    u'readable_role': u'Admin',
+                    u'role': u'WorkspaceAdmin',
+                    u'participation_type': u'user',
+                    u'readable_participation_type': u'User',
+                },
+                {
+                    u'@id': u'http://nohost/plone/workspaces/workspace-1/@participations/users/gunther.frohlich',
+                    u'@type': u'virtual.participations.user',
+                    u'is_editable': False,
+                    u'inviter_fullname': None,
+                    u'participant_fullname': u'Fr\xf6hlich G\xfcnther (gunther.frohlich)',
+                    u'token': 'gunther.frohlich',
+                    u'readable_role': u'Owner',
+                    u'role': u'WorkspaceOwner',
+                    u'participation_type': u'user',
+                    u'readable_participation_type': u'User',
+                },
+                {
+                    u'@id': u'http://nohost/plone/workspaces/workspace-1/@participations/users/hans.peter',
+                    u'@type': u'virtual.participations.user',
+                    u'is_editable': True,
+                    u'inviter_fullname': None,
+                    u'participant_fullname': u'Peter Hans (hans.peter)',
+                    u'token': 'hans.peter',
+                    u'readable_role': u'Guest',
+                    u'role': u'WorkspaceGuest',
+                    u'participation_type': u'user',
+                    u'readable_participation_type': u'User',
+                },
+                {
+                    u'@id': u'http://nohost/plone/workspaces/workspace-1/@participations/invitations/{}'.format(iid),
+                    u'@type': u'virtual.participations.invitation',
+                    u'is_editable': True,
+                    u'inviter_fullname': u'Fr\xf6hlich G\xfcnther (gunther.frohlich)',
+                    u'participant_fullname': u'B\xe4rfuss K\xe4thi (kathi.barfuss)',
+                    u'token': iid,
+                    u'readable_role': u'Guest',
+                    u'role': u'WorkspaceGuest',
+                    u'participation_type': u'invitation',
+                    u'readable_participation_type': u'Invitation',
+                },
+            ], response.get('items'))
+
+    @browsing
+    def test_owner_is_not_editable(self, browser):
+        self.login(self.workspace_admin, browser)
+
+        response = browser.open(
+            self.workspace.absolute_url() + '/@participations',
+            method='GET',
+            headers=http_headers(),
+        ).json
+
+        items = response.get('items')
+
+        self.assertFalse(
+            get_entry_by_token(items, self.workspace_owner.id)['is_editable'],
+            'The admin should not be able to manage himself')
+
+    @browsing
+    def test_current_logged_in_admin_cannot_edit_himself(self, browser):
+        self.login(self.workspace_admin, browser)
+
+        response = browser.open(
+            self.workspace.absolute_url() + '/@participations',
+            method='GET',
+            headers=http_headers(),
+        ).json
+
+        items = response.get('items')
+
+        self.assertFalse(
+            get_entry_by_token(items, self.workspace_admin.id)['is_editable'],
+            'The admin should not be able to manage himself')
+
+        self.assertTrue(
+            get_entry_by_token(items, 'hans.peter')['is_editable'],
+            'The admin should be able to manage hans.peter')
+
+    @browsing
+    def test_an_admin_can_edit_other_members(self, browser):
+        self.login(self.workspace_admin, browser)
+
+        response = browser.open(
+            self.workspace.absolute_url() + '/@participations',
+            method='GET',
+            headers=http_headers(),
+        ).json
+
+        items = response.get('items')
+
+        self.assertTrue(
+            get_entry_by_token(items, self.workspace_guest.id)['is_editable'],
+            'The admin should be able to manage {}'.format(self.workspace_guest.id))
+
+    @browsing
+    def test_user_without_sharing_permission_cannot_manage(self, browser):
+        self.login(self.workspace_member, browser)
+
+        response = browser.open(
+            self.workspace.absolute_url() + '/@participations',
+            method='GET',
+            headers=http_headers(),
+        ).json
+
+        self.assertFalse(
+            any([item.get('is_editable') for item in response.get('items')]),
+            'No entry should be editable because the user has no permission')

--- a/opengever/api/tests/test_participation.py
+++ b/opengever/api/tests/test_participation.py
@@ -20,40 +20,6 @@ def get_entry_by_token(entries, token):
 class TestParticipationGet(IntegrationTestCase):
 
     @browsing
-    def test_list_all_available_roles(self, browser):
-        self.login(self.workspace_owner, browser)
-
-        response = browser.open(
-            self.workspace.absolute_url() + '/@participations',
-            method='GET',
-            headers=http_headers(),
-        ).json
-
-        self.assertItemsEqual(
-            [
-                {
-                    u'managed': False,
-                    u'id': u'WorkspaceOwner',
-                    u'title': u'Owner'
-                },
-                {
-                    u'managed': True,
-                    u'id': u'WorkspaceAdmin',
-                    u'title': u'Admin'
-                },
-                {
-                    u'managed': True,
-                    u'id': u'WorkspaceMember',
-                    u'title': u'Member'
-                },
-                {
-                    u'managed': True,
-                    u'id': u'WorkspaceGuest',
-                    u'title': u'Guest'
-                }
-            ], response.get('roles'))
-
-    @browsing
     def test_list_all_current_participants_and_invitations(self, browser):
         self.login(self.workspace_owner, browser)
 

--- a/opengever/api/tests/test_vocabularies.py
+++ b/opengever/api/tests/test_vocabularies.py
@@ -54,6 +54,7 @@ NON_SENSITIVE_VOCABUALRIES = [
     'opengever.tasktemplates.active_tasktemplatefolders',
     'opengever.tasktemplates.ResponsibleOrgUnitVocabulary',
     'opengever.tasktemplates.tasktemplates',
+    'opengever.workspace.RolesVocabulary',
     'plone.app.content.ValidAddableTypes',
     'plone.app.controlpanel.WickedPortalTypes',
     'plone.app.discussion.vocabularies.CaptchaVocabulary',

--- a/opengever/workspace/configure.zcml
+++ b/opengever/workspace/configure.zcml
@@ -19,4 +19,9 @@
       handler=".subscribers.assign_owner_role_on_creation"
       />
 
+  <utility
+      factory=".vocabularies.RolesVocabulary"
+      name="opengever.workspace.RolesVocabulary"
+      />
+
 </configure>

--- a/opengever/workspace/locales/de/LC_MESSAGES/opengever.workspace.po
+++ b/opengever/workspace/locales/de/LC_MESSAGES/opengever.workspace.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-04-18 10:43+0000\n"
+"POT-Creation-Date: 2019-04-25 12:07+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -87,19 +87,23 @@ msgstr "Benutzer"
 msgid "Workspace"
 msgstr "Teamraum"
 
-#: ./opengever/workspace/participation/browser/participants_view.py
+#. Default: "Admin"
+#: ./opengever/workspace/participation/__init__.py
 msgid "WorkspaceAdmin"
 msgstr "Admin"
 
-#: ./opengever/workspace/participation/browser/participants_view.py
+#. Default: "Guest"
+#: ./opengever/workspace/participation/__init__.py
 msgid "WorkspaceGuest"
 msgstr "Gast"
 
-#: ./opengever/workspace/participation/browser/participants_view.py
+#. Default: "Member"
+#: ./opengever/workspace/participation/__init__.py
 msgid "WorkspaceMember"
 msgstr "Teammitglied"
 
-#: ./opengever/workspace/participation/browser/participants_view.py
+#. Default: "Owner"
+#: ./opengever/workspace/participation/__init__.py
 msgid "WorkspaceOwner"
 msgstr "Federführung"
 

--- a/opengever/workspace/locales/de/LC_MESSAGES/opengever.workspace.po
+++ b/opengever/workspace/locales/de/LC_MESSAGES/opengever.workspace.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-04-25 12:07+0000\n"
+"POT-Creation-Date: 2019-04-26 12:32+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -107,6 +107,11 @@ msgstr "Teammitglied"
 msgid "WorkspaceOwner"
 msgstr "Federführung"
 
+#. Default: "Invitation"
+#: ./opengever/workspace/participation/__init__.py
+msgid "invitation"
+msgstr "Einladung"
+
 #. Default: "Description"
 #: ./opengever/workspace/browser/tabs.py
 msgid "label_description"
@@ -151,3 +156,8 @@ msgstr "Teamräume"
 #: ./opengever/workspace/participation/browser/templates/participants-view.pt
 msgid "title_manage_participation"
 msgstr "Teilnehmer von  \"${workspace}\""
+
+#. Default: "User"
+#: ./opengever/workspace/participation/__init__.py
+msgid "user"
+msgstr "Benutzer"

--- a/opengever/workspace/locales/fr/LC_MESSAGES/opengever.workspace.po
+++ b/opengever/workspace/locales/fr/LC_MESSAGES/opengever.workspace.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-04-25 12:07+0000\n"
+"POT-Creation-Date: 2019-04-26 12:32+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -107,6 +107,11 @@ msgstr "Membre du team"
 msgid "WorkspaceOwner"
 msgstr "Titulaire"
 
+#. Default: "Invitation"
+#: ./opengever/workspace/participation/__init__.py
+msgid "invitation"
+msgstr ""
+
 #. Default: "Description"
 #: ./opengever/workspace/browser/tabs.py
 msgid "label_description"
@@ -151,3 +156,8 @@ msgstr "Teamraüme"
 #: ./opengever/workspace/participation/browser/templates/participants-view.pt
 msgid "title_manage_participation"
 msgstr "Participant de  \"${workspace}\""
+
+#. Default: "User"
+#: ./opengever/workspace/participation/__init__.py
+msgid "user"
+msgstr ""

--- a/opengever/workspace/locales/fr/LC_MESSAGES/opengever.workspace.po
+++ b/opengever/workspace/locales/fr/LC_MESSAGES/opengever.workspace.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-04-18 10:43+0000\n"
+"POT-Creation-Date: 2019-04-25 12:07+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -87,19 +87,23 @@ msgstr "Utilisateur"
 msgid "Workspace"
 msgstr "Teamraum"
 
-#: ./opengever/workspace/participation/browser/participants_view.py
+#. Default: "Admin"
+#: ./opengever/workspace/participation/__init__.py
 msgid "WorkspaceAdmin"
 msgstr "Admin"
 
-#: ./opengever/workspace/participation/browser/participants_view.py
+#. Default: "Guest"
+#: ./opengever/workspace/participation/__init__.py
 msgid "WorkspaceGuest"
 msgstr "Invité"
 
-#: ./opengever/workspace/participation/browser/participants_view.py
+#. Default: "Member"
+#: ./opengever/workspace/participation/__init__.py
 msgid "WorkspaceMember"
 msgstr "Membre du team"
 
-#: ./opengever/workspace/participation/browser/participants_view.py
+#. Default: "Owner"
+#: ./opengever/workspace/participation/__init__.py
 msgid "WorkspaceOwner"
 msgstr "Titulaire"
 

--- a/opengever/workspace/locales/opengever.workspace.pot
+++ b/opengever/workspace/locales/opengever.workspace.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-04-25 12:07+0000\n"
+"POT-Creation-Date: 2019-04-26 12:32+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -110,6 +110,11 @@ msgstr ""
 msgid "WorkspaceOwner"
 msgstr ""
 
+#. Default: "Invitation"
+#: ./opengever/workspace/participation/__init__.py
+msgid "invitation"
+msgstr ""
+
 #. Default: "Description"
 #: ./opengever/workspace/browser/tabs.py
 msgid "label_description"
@@ -153,4 +158,9 @@ msgstr ""
 #. Default: "Manage participation of ${workspace}"
 #: ./opengever/workspace/participation/browser/templates/participants-view.pt
 msgid "title_manage_participation"
+msgstr ""
+
+#. Default: "User"
+#: ./opengever/workspace/participation/__init__.py
+msgid "user"
 msgstr ""

--- a/opengever/workspace/locales/opengever.workspace.pot
+++ b/opengever/workspace/locales/opengever.workspace.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-04-18 10:43+0000\n"
+"POT-Creation-Date: 2019-04-25 12:07+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -90,19 +90,23 @@ msgstr ""
 msgid "Workspace"
 msgstr ""
 
-#: ./opengever/workspace/participation/browser/participants_view.py
+#. Default: "Admin"
+#: ./opengever/workspace/participation/__init__.py
 msgid "WorkspaceAdmin"
 msgstr ""
 
-#: ./opengever/workspace/participation/browser/participants_view.py
+#. Default: "Guest"
+#: ./opengever/workspace/participation/__init__.py
 msgid "WorkspaceGuest"
 msgstr ""
 
-#: ./opengever/workspace/participation/browser/participants_view.py
+#. Default: "Member"
+#: ./opengever/workspace/participation/__init__.py
 msgid "WorkspaceMember"
 msgstr ""
 
-#: ./opengever/workspace/participation/browser/participants_view.py
+#. Default: "Owner"
+#: ./opengever/workspace/participation/__init__.py
 msgid "WorkspaceOwner"
 msgstr ""
 

--- a/opengever/workspace/participation/__init__.py
+++ b/opengever/workspace/participation/__init__.py
@@ -59,3 +59,6 @@ PARTICIPATION_TYPES = {
     TYPE_USER.id: TYPE_USER,
     TYPE_INVITATION.id: TYPE_INVITATION,
 }
+
+PARTICIPATION_TYPES_BY_PATH_IDENTIFIER = {
+    value.path_identifier: value for value in PARTICIPATION_TYPES.values()}

--- a/opengever/workspace/participation/__init__.py
+++ b/opengever/workspace/participation/__init__.py
@@ -33,3 +33,29 @@ PARTICIPATION_ROLES = {
     WORKSPCAE_ADMIN.id: WORKSPCAE_ADMIN,
     WORKSPCAE_MEMBER.id: WORKSPCAE_MEMBER
 }
+
+
+class ParticipationType(object):
+    def __init__(self, id_, title, path_identifier):
+        self.id = id_
+        self.title = title
+        self.path_identifier = path_identifier
+
+    def translated_title(self, request):
+        return translate(self.title, context=request)
+
+    def serialize(self, request):
+        return {
+            'id': self.id,
+            'title': self.translated_title(request)
+        }
+
+TYPE_USER = ParticipationType('user', _('user', default="User"), 'users')
+TYPE_INVITATION = ParticipationType('invitation',
+                                    _('invitation', default="Invitation"),
+                                    'invitations')
+
+PARTICIPATION_TYPES = {
+    TYPE_USER.id: TYPE_USER,
+    TYPE_INVITATION.id: TYPE_INVITATION,
+}

--- a/opengever/workspace/participation/__init__.py
+++ b/opengever/workspace/participation/__init__.py
@@ -1,0 +1,35 @@
+from zope.i18n import translate
+from opengever.workspace import _
+
+
+class ParticipationRole(object):
+    def __init__(self, id_, title, managed):
+        self.id = id_
+        self.title = title
+        self.managed = managed
+
+    def translated_title(self, request):
+        return translate(self.title, context=request)
+
+    def serialize(self, request):
+        return {
+            'id': self.id,
+            'title': self.translated_title(request),
+            'managed': self.managed
+        }
+
+WORKSPCAE_GUEST = ParticipationRole(
+    'WorkspaceGuest', _('WorkspaceGuest', default="Guest"), True)
+WORKSPCAE_MEMBER = ParticipationRole(
+    'WorkspaceMember', _('WorkspaceMember', default="Member"), True)
+WORKSPCAE_ADMIN = ParticipationRole(
+    'WorkspaceAdmin', _('WorkspaceAdmin', default="Admin"), True)
+WORKSPCAE_OWNER = ParticipationRole(
+    'WorkspaceOwner', _('WorkspaceOwner', default="Owner"), False)
+
+PARTICIPATION_ROLES = {
+    WORKSPCAE_GUEST.id: WORKSPCAE_GUEST,
+    WORKSPCAE_OWNER.id: WORKSPCAE_OWNER,
+    WORKSPCAE_ADMIN.id: WORKSPCAE_ADMIN,
+    WORKSPCAE_MEMBER.id: WORKSPCAE_MEMBER
+}

--- a/opengever/workspace/participation/__init__.py
+++ b/opengever/workspace/participation/__init__.py
@@ -11,12 +11,6 @@ class ParticipationRole(object):
     def translated_title(self, request):
         return translate(self.title, context=request)
 
-    def serialize(self, request):
-        return {
-            'id': self.id,
-            'title': self.translated_title(request),
-            'managed': self.managed
-        }
 
 WORKSPCAE_GUEST = ParticipationRole(
     'WorkspaceGuest', _('WorkspaceGuest', default="Guest"), True)
@@ -44,11 +38,6 @@ class ParticipationType(object):
     def translated_title(self, request):
         return translate(self.title, context=request)
 
-    def serialize(self, request):
-        return {
-            'id': self.id,
-            'title': self.translated_title(request)
-        }
 
 TYPE_USER = ParticipationType('user', _('user', default="User"), 'users')
 TYPE_INVITATION = ParticipationType('invitation',

--- a/opengever/workspace/participation/browser/manage_participants.py
+++ b/opengever/workspace/participation/browser/manage_participants.py
@@ -44,7 +44,8 @@ class ManageParticipants(BrowserView):
                                 MANAGED_ROLES + ['WorkspaceOwner'])),
                             can_manage=self.can_manage_member(member, roles),
                             type_='user',
-                            name=self.get_full_user_info(member=member))
+                            name=self.get_full_user_info(member=member),
+                            userid=userid)
                 entries.append(item)
         return entries
 
@@ -70,7 +71,8 @@ class ManageParticipants(BrowserView):
                             userid=invitation['inviter']),
                         can_manage=self.can_manage_member(),
                         type_='invitation',
-                        token=invitation['iid'])
+                        token=invitation['iid'],
+                        userid=invitation['recipient'])
             entries.append(item)
 
         return entries

--- a/opengever/workspace/participation/browser/manage_participants.py
+++ b/opengever/workspace/participation/browser/manage_participants.py
@@ -117,15 +117,19 @@ class ManageParticipants(BrowserView):
         if not token or not type_:
             raise BadRequest('A token and a type is required')
 
+        self._delete(type_, token)
+        return self.__call__()
+
+    def _delete(self, type_, token):
         if type_ == 'invitation' and self.can_manage_member():
             storage = getUtility(IInvitationStorage)
             storage.remove_invitation(token)
-            return self.__call__()
+            return
 
         elif type_ == 'user' and self.can_manage_member(api.user.get(userid=token)):
             RoleAssignmentManager(self.context).clear_by_cause_and_principal(
                 ASSIGNMENT_VIA_INVITATION, token)
-            return self.__call__()
+            return
         else:
             raise BadRequest('Oh my, something went wrong')
 

--- a/opengever/workspace/participation/browser/manage_participants.py
+++ b/opengever/workspace/participation/browser/manage_participants.py
@@ -93,7 +93,10 @@ class ManageParticipants(BrowserView):
         CheckAuthenticator(self.request)
         userid = self.request.get('userid', None)
         role = self.request.get('role', None)
+        self._add(userid, role)
+        return self.__call__()
 
+    def _add(self, userid, role):
         if not userid or not role or not self.can_manage_member():
             raise BadRequest('No userid or role provided')
 
@@ -101,9 +104,9 @@ class ManageParticipants(BrowserView):
             raise Unauthorized('No allowed to delegate this permission')
 
         storage = getUtility(IInvitationStorage)
-        storage.add_invitation(self.context, userid,
-                               api.user.get_current().getId(), role)
-        return self.__call__()
+        iid = storage.add_invitation(self.context, userid,
+                                     api.user.get_current().getId(), role)
+        return storage.get_invitation(iid)
 
     def delete(self):
         """A traversable method to delete a pending invitation or local roles.

--- a/opengever/workspace/participation/browser/manage_participants.py
+++ b/opengever/workspace/participation/browser/manage_participants.py
@@ -143,12 +143,18 @@ class ManageParticipants(BrowserView):
         token = self.request.get('token', None)
         role = self.request.get('role', None)
         type_ = self.request.get('type', None)
+        self._modify(token, role, type_)
+        return ''
 
+    def _modify(self, token, role, type_):
         if not token or not type_:
             raise BadRequest('No userid or type provided.')
 
         if role not in MANAGED_ROLES:
             raise Unauthorized('Inavlid role provided.')
+
+        if token == api.user.get_current().id:
+            raise Unauthorized('Not allowed to modify the current user.')
 
         if type_ == 'user':
             user_roles = api.user.get_roles(username=token, obj=self.context,
@@ -160,7 +166,7 @@ class ManageParticipants(BrowserView):
                 self.context.setModificationDate()
                 self.context.reindexObject(idxs=['modified'])
                 self.request.RESPONSE.setStatus(204)
-                return ''
+                return True
             else:
                 raise BadRequest('User does not have any local roles')
         elif type_ == 'invitation':

--- a/opengever/workspace/participation/browser/participants_view.py
+++ b/opengever/workspace/participation/browser/participants_view.py
@@ -1,6 +1,7 @@
 from ftw.keywordwidget import _ as KWMF
 from opengever.base.handlebars import get_handlebars_template
 from opengever.workspace import _
+from opengever.workspace.participation import PARTICIPATION_ROLES
 from Products.Five.browser import BrowserView
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from zope.i18n import translate
@@ -30,10 +31,10 @@ class ParticipantsView(BrowserView):
             'label_loading_more': translate(KWMF('Load more results...'), context=self.request),
             'label_tooshort_prefix': translate(KWMF('Please enter '), context=self.request),
             'label_tooshort_postfix': translate(KWMF(' or more characters'), context=self.request),
-            'workspaceguest': translate(_('WorkspaceGuest'), context=self.request),
-            'workspacemember': translate(_('WorkspaceMember'), context=self.request),
-            'workspaceadmin': translate(_('WorkspaceAdmin'), context=self.request),
-            'workspaceowner': translate(_('WorkspaceOwner'), context=self.request),
+            'workspaceguest': PARTICIPATION_ROLES.get('WorkspaceGuest').translated_title(self.request),
+            'workspacemember': PARTICIPATION_ROLES.get('WorkspaceMember').translated_title(self.request),
+            'workspaceadmin': PARTICIPATION_ROLES.get('WorkspaceAdmin').translated_title(self.request),
+            'workspaceowner': PARTICIPATION_ROLES.get('WorkspaceOwner').translated_title(self.request),
             'user': translate(_('User'), context=self.request),
             'type': translate(_('Type'), context=self.request),
             'role': translate(_('Rolle'), context=self.request),

--- a/opengever/workspace/permissions.zcml
+++ b/opengever/workspace/permissions.zcml
@@ -8,4 +8,6 @@
 
   <permission id="opengever.workspace.AddWorkspaceFolder" title="opengever.workspace: Add WorkspaceFolder" />
 
+  <permission id="plone.DelegateWorkspaceAdminRole" title="Sharing page: Delegate WorkspaceAdmin role" />
+
 </configure>

--- a/opengever/workspace/tests/test_vocabularies.py
+++ b/opengever/workspace/tests/test_vocabularies.py
@@ -1,0 +1,14 @@
+from opengever.testing import IntegrationTestCase
+from zope.component import getUtility
+from zope.schema.interfaces import IVocabularyFactory
+
+
+class TestRolesVocabulary(IntegrationTestCase):
+
+    def test_roles_vocabulary_list_all_managed_roles(self):
+        self.login(self.workspace_owner)
+        factory = getUtility(IVocabularyFactory,
+                             name='opengever.workspace.RolesVocabulary')
+        self.assertItemsEqual(
+            ['Admin', 'Member', 'Guest'],
+            [term.title for term in factory(context=self.portal)])

--- a/opengever/workspace/tests/test_workspace_manage_participants.py
+++ b/opengever/workspace/tests/test_workspace_manage_participants.py
@@ -33,22 +33,26 @@ class TestWorkspaceManageParticipants(IntegrationTestCase):
                  u'name': u'Schr\xf6dinger B\xe9atrice (beatrice.schrodinger)',
                  u'roles': [u'WorkspaceMember'],
                  u'type_': u'user',
-                 u'token': u'beatrice.schrodinger'},
+                 u'token': u'beatrice.schrodinger',
+                 u'userid': u'beatrice.schrodinger'},
                 {u'can_manage': False,
                  u'name': u'Hugentobler Fridolin (fridolin.hugentobler)',
                  u'roles': [u'WorkspaceAdmin'],
                  u'type_': u'user',
-                 u'token': u'fridolin.hugentobler'},
+                 u'token': u'fridolin.hugentobler',
+                 u'userid': u'fridolin.hugentobler'},
                 {u'can_manage': False,
                  u'name': u'Fr\xf6hlich G\xfcnther (gunther.frohlich)',
                  u'roles': [u'WorkspaceOwner'],
                  u'type_': u'user',
-                 u'token': u'gunther.frohlich'},
+                 u'token': u'gunther.frohlich',
+                 u'userid': u'gunther.frohlich'},
                 {u'can_manage': True,
                  u'name': u'Peter Hans (hans.peter)',
                  u'roles': [u'WorkspaceGuest'],
                  u'type_': u'user',
-                 u'token': u'hans.peter'},
+                 u'token': u'hans.peter',
+                 u'userid': u'hans.peter'},
             ],
             browser.json
         )
@@ -91,13 +95,15 @@ class TestWorkspaceManageParticipants(IntegrationTestCase):
                  u'token': u'fridolin.hugentobler',
                  u'type_': u'user',
                  u'roles': [u'WorkspaceOwner'],
-                 u'name': u'Hugentobler Fridolin (fridolin.hugentobler)'},
+                 u'name': u'Hugentobler Fridolin (fridolin.hugentobler)',
+                 u'userid': u'fridolin.hugentobler'},
                 {u'name': u'B\xe4rfuss K\xe4thi (kathi.barfuss)',
                  u'roles': [u'WorkspacesGuest'],
                  u'can_manage': True,
                  u'token': iid,
                  u'type_': u'invitation',
-                 u'inviter': u'Hugentobler Fridolin (fridolin.hugentobler)'}
+                 u'inviter': u'Hugentobler Fridolin (fridolin.hugentobler)',
+                 u'userid': u'kathi.barfuss'}
             ],
             browser.json)
 
@@ -125,7 +131,8 @@ class TestWorkspaceManageParticipants(IntegrationTestCase):
              u'inviter': u'Hugentobler Fridolin (fridolin.hugentobler)',
              u'name': u'B\xe4rfuss K\xe4thi (kathi.barfuss)',
              u'roles': [u'WorkspaceGuest'],
-             u'type_': u'invitation'},
+             u'type_': u'invitation',
+             u'userid': u'kathi.barfuss'},
             invitations_in_response[0])
 
     @browsing

--- a/opengever/workspace/vocabularies.py
+++ b/opengever/workspace/vocabularies.py
@@ -1,0 +1,22 @@
+from opengever.workspace.participation import PARTICIPATION_ROLES
+from Products.CMFPlone.utils import safe_unicode
+from zope.interface import implementer
+from zope.schema.interfaces import IVocabularyFactory
+from zope.schema.vocabulary import SimpleTerm
+from zope.schema.vocabulary import SimpleVocabulary
+
+
+@implementer(IVocabularyFactory)
+class RolesVocabulary(object):
+
+    def __call__(self, context):
+        terms = []
+        for role in PARTICIPATION_ROLES.values():
+            if not role.managed:
+                continue
+            terms.append(SimpleTerm(value=role.id,
+                                    token=role.id,
+                                    title=safe_unicode(
+                                        role.translated_title(context.REQUEST))))
+
+        return SimpleVocabulary(terms)


### PR DESCRIPTION
Dieser PR implementiert die REST-API für Beteiligungen.

Die alte API besteht weiterhin. Die neue API verwendet hauptsächlich die alte Implementation.

closes #5589 