### PR TITLE
Avoid queuing same document conversion more than once in a single request

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2019.2.0 (unreleased)
 ---------------------
 
+- Queue each document archival conversion only once in a single request. [njohner]
 - Include preserved_as_paper_default in the @config endpoint and view. [Rotonen]
 - Implement resolving dossiers recursively via REST API. [lgraf]
 - Allow members to access plone vocabularies through restapi. [elioschmutz]

--- a/opengever/document/archival_file.py
+++ b/opengever/document/archival_file.py
@@ -2,6 +2,9 @@ from ftw.bumblebee.config import PROCESSING_QUEUE
 from ftw.bumblebee.interfaces import IBumblebeeServiceV3
 from opengever.document.behaviors.metadata import IDocumentMetadata
 from plone.namedfile.file import NamedBlobFile
+from zope.annotation.interfaces import IAnnotations
+from zope.app.intid.interfaces import IIntIds
+from zope.component import getUtility
 from zope.globalrequest import getRequest
 import os
 
@@ -20,20 +23,43 @@ ARCHIVAL_FILE_STATE_MAPPING = {
     5: "STATE_FAILED_PERMANENTLY",
 }
 
+ARCHIVAL_FILE_CONVERSION_QUEUE_KEY = 'opengever.document.\
+                                      archival_file_conversion_queue_annotations_key'
+
 
 class ArchivalFileConverter(object):
 
     def __init__(self, document):
         self.document = document
+        self.document_intid = getUtility(IIntIds).getId(self.document)
 
     def trigger_conversion(self):
         if self.get_state() == STATE_MANUALLY_PROVIDED:
             return
 
+        if self.is_already_queued():
+            return
+
+        self.queue_conversion()
+
+    def queue_conversion(self):
         self.set_state(STATE_CONVERTING)
         IBumblebeeServiceV3(getRequest()).queue_conversion(
             self.document, PROCESSING_QUEUE,
             self.get_callback_url(), target_format='pdf/a')
+
+        annotations = IAnnotations(getRequest())
+        if ARCHIVAL_FILE_CONVERSION_QUEUE_KEY not in annotations:
+            annotations[ARCHIVAL_FILE_CONVERSION_QUEUE_KEY] = []
+        annotations[ARCHIVAL_FILE_CONVERSION_QUEUE_KEY].append(self.document_intid)
+
+    def is_already_queued(self):
+        """ Check whether the conversion has already been queued during this
+        request
+        """
+        annotations = IAnnotations(getRequest())
+        queued = annotations.get(ARCHIVAL_FILE_CONVERSION_QUEUE_KEY, [])
+        return self.document_intid in queued
 
     def get_state(self):
         return IDocumentMetadata(self.document).archival_file_state

--- a/opengever/dossier/tests/test_resolve.py
+++ b/opengever/dossier/tests/test_resolve.py
@@ -523,17 +523,12 @@ class TestAutomaticPDFAConversion(IntegrationTestCase, ResolveTestHelper):
         get_queue().reset()
         with RequestsSessionMock.installed():
             self.resolve(self.resolvable_dossier, browser)
-
-            # XXX: Queue length should actually be 2 instead of 4 - the one
-            # doc we added just above, and one from the fixture. However,
-            # because StrictDossierResolver.trigger_pdf_conversion() is broken,
-            # it queues documents multiple times.
-            self.assertEquals(4, len(get_queue().queue))
+            self.assertEquals(2, len(get_queue().queue))
             queue_contents = list(get_queue().queue)
             queue_contents.sort(key=itemgetter('url'))
 
             fixture_doc_job = queue_contents[0]
-            additional_doc_job = queue_contents[2]
+            additional_doc_job = queue_contents[1]
 
             self.assertDictContainsSubset(
                 {'callback_url': '{}/archival_file_conversion_callback'.format(


### PR DESCRIPTION
When resolving a dossier, the archival file conversion of documents typically gets triggered multiple times as it is triggered for all contained documents on each dossier (because resolution is recursive), but the main dossier already contains all the documents...

The approach here is to avoid queuing documents several times in the same request, by storing the already queued documents in the annotations on the request and checking if a document is already in the queue before queuing it.

resolves #5596 