### PR TITLE
Do not allow sorting on Keywords in dossier and document listings.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 
 - Queue each document archival conversion only once in a single request. [njohner]
 - Do not fire task delegate activity twice. [njohner]
+- Do not allow sorting on Keywords in dossier and document listings. [njohner]
 - Include preserved_as_paper_default in the @config endpoint and view. [Rotonen]
 - Pass context and orgunit as parameters to webactions. [njohner]
 - Implement resolving dossiers recursively via REST API. [lgraf]

--- a/opengever/tabbedview/browser/tabs.py
+++ b/opengever/tabbedview/browser/tabs.py
@@ -196,7 +196,8 @@ class Documents(BaseCatalogListingTab):
 
         {'column': 'Subject',
          'column_title': _(u'label_keywords', default=u'Keywords'),
-         'transform': linked_subjects},
+         'transform': linked_subjects,
+         'sortable': False},
         )
 
     major_actions = [
@@ -297,7 +298,8 @@ class Dossiers(BaseCatalogListingTab):
 
         {'column': 'Subject',
          'column_title': _(u'label_keywords', default=u'Keywords'),
-         'transform': linked_subjects},
+         'transform': linked_subjects,
+         'sortable': False},
         )
 
     search_options = {'is_subdossier': False}


### PR DESCRIPTION
The catalog does not handle sorting on Subjects correctly, so that all items with no Subject will not be returned by the query in that case.

I don't think we can write tests for this.

resolves #5489 