### PR TITLE
Isolate ftw.lawgiver tests onto their own layer

### DIFF
--- a/opengever/core/testing.py
+++ b/opengever/core/testing.py
@@ -268,6 +268,19 @@ def inactivate_filing_number(portal):
     SCHEMA_CACHE.invalidate('opengever.dossier.businesscasedossier')
 
 
+class LawGiverLayer(PloneSandboxLayer):
+    """Isolate lawgiver tests onto their own layer.
+
+    We do this as they cause writes to filesystem hierarchies and bust the path
+    modification time based caching strategy of the integration testing
+    fixtures."""
+
+    defaultBases = (OPENGEVER_FUNCTIONAL_TESTING,)
+
+
+OPENGEVER_LAWGIVER_LAYER = LawGiverLayer()
+
+
 class FilingLayer(PloneSandboxLayer):
 
     defaultBases = (OPENGEVER_FUNCTIONAL_TESTING,)

--- a/opengever/core/tests/base.py
+++ b/opengever/core/tests/base.py
@@ -1,10 +1,10 @@
 from ftw.lawgiver.tests.base import WorkflowTest
-from opengever.core.testing import OPENGEVER_INTEGRATION_TESTING
+from opengever.core.testing import OPENGEVER_LAWGIVER_LAYER
 
 
 class GeverWorkflowTest(WorkflowTest):
 
-    layer = OPENGEVER_INTEGRATION_TESTING
+    layer = OPENGEVER_LAWGIVER_LAYER
     workflow_name = None
 
     def _is_base_test(self):


### PR DESCRIPTION
Salvaged from https://github.com/4teamwork/opengever.core/pull/5574

This can still be useful for any scripts which iterate over the modules and rely on the cache, like local fixture amendment test runs or profiling runs.