### PR TITLE
Adapt task reassign activity message.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 
 - Bump plone.restapi to 3.9.0. [phgross]
 - Improve the styling of the tabbedview keyword filter. [phgross]
+- Adapt task reassign activity message. [njohner]
 - Queue each document archival conversion only once in a single request. [njohner]
 - Do not fire task delegate activity twice. [njohner]
 - Do not allow sorting on Keywords in dossier and document listings. [njohner]

--- a/opengever/task/locales/de/LC_MESSAGES/opengever.task.po
+++ b/opengever/task/locales/de/LC_MESSAGES/opengever.task.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2019-04-04 12:13+0000\n"
+"POT-Creation-Date: 2019-04-29 07:17+0000\n"
 "PO-Revision-Date: 2015-02-17 18:41+0100\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -1012,6 +1012,11 @@ msgstr "Abgeschlossen durch ${user}"
 msgid "transition_msg_default"
 msgstr "Antwort hinzugefügt"
 
+#. Default: "Reassigned from ${responsible_old} to ${responsible_new} by ${user}"
+#: ./opengever/task/response_description.py
+msgid "transition_msg_delegated_reassign"
+msgstr "Neu zugewiesen von ${responsible_old} an ${responsible_new} durch ${user}"
+
 #. Default: "Deadline modified from ${deadline_old} to ${deadline_new} by ${user}"
 #: ./opengever/task/response_description.py
 msgid "transition_msg_modify_deadline"
@@ -1022,10 +1027,10 @@ msgstr "Frist geändert von ${deadline_old} zu ${deadline_new} durch ${user}"
 msgid "transition_msg_reactivate"
 msgstr "Reaktiviert durch ${user}"
 
-#. Default: "Reassigned from ${responsible_old} to ${responsible_new} by ${user}"
+#. Default: "Reassigned from ${responsible_old} to ${responsible_new}"
 #: ./opengever/task/response_description.py
 msgid "transition_msg_reassign"
-msgstr "Neu zugewiesen von ${responsible_old} an ${responsible_new} durch ${user}"
+msgstr "Neu zugewiesen von ${responsible_old} an ${responsible_new}"
 
 #. Default: "Refused by ${user}"
 #: ./opengever/task/response_description.py

--- a/opengever/task/locales/fr/LC_MESSAGES/opengever.task.po
+++ b/opengever/task/locales/fr/LC_MESSAGES/opengever.task.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-04-04 12:13+0000\n"
+"POT-Creation-Date: 2019-04-29 07:17+0000\n"
 "PO-Revision-Date: 2017-12-03 11:47+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-task/fr/>\n"
@@ -1014,6 +1014,11 @@ msgstr "Fermé par ${user}"
 msgid "transition_msg_default"
 msgstr "Réponse ajouté"
 
+#. Default: "Reassigned from ${responsible_old} to ${responsible_new} by ${user}"
+#: ./opengever/task/response_description.py
+msgid "transition_msg_delegated_reassign"
+msgstr "Attribué à nouveau de ${responsible_old} à ${responsible_new} par ${user}"
+
 #. Default: "Deadline modified from ${deadline_old} to ${deadline_new} by ${user}"
 #: ./opengever/task/response_description.py
 msgid "transition_msg_modify_deadline"
@@ -1024,10 +1029,10 @@ msgstr "Délai modifié de ${deadline_old} à ${deadline_new} par ${user}"
 msgid "transition_msg_reactivate"
 msgstr "Réactivé par ${user}"
 
-#. Default: "Reassigned from ${responsible_old} to ${responsible_new} by ${user}"
+#. Default: "Reassigned from ${responsible_old} to ${responsible_new}"
 #: ./opengever/task/response_description.py
 msgid "transition_msg_reassign"
-msgstr "Attribué à nouveau de ${responsible_old} à ${responsible_new} par ${user}"
+msgstr "Attribué à nouveau de ${responsible_old} à ${responsible_new}"
 
 #. Default: "Refused by ${user}"
 #: ./opengever/task/response_description.py

--- a/opengever/task/locales/opengever.task.pot
+++ b/opengever/task/locales/opengever.task.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2019-04-04 12:13+0000\n"
+"POT-Creation-Date: 2019-04-29 07:17+0000\n"
 "PO-Revision-Date: 2009-02-25 14:39+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -1010,6 +1010,11 @@ msgstr ""
 msgid "transition_msg_default"
 msgstr ""
 
+#. Default: "Reassigned from ${responsible_old} to ${responsible_new} by ${user}"
+#: ./opengever/task/response_description.py
+msgid "transition_msg_delegated_reassign"
+msgstr ""
+
 #. Default: "Deadline modified from ${deadline_old} to ${deadline_new} by ${user}"
 #: ./opengever/task/response_description.py
 msgid "transition_msg_modify_deadline"
@@ -1020,7 +1025,7 @@ msgstr ""
 msgid "transition_msg_reactivate"
 msgstr ""
 
-#. Default: "Reassigned from ${responsible_old} to ${responsible_new} by ${user}"
+#. Default: "Reassigned from ${responsible_old} to ${responsible_new}"
 #: ./opengever/task/response_description.py
 msgid "transition_msg_reassign"
 msgstr ""

--- a/opengever/task/response_description.py
+++ b/opengever/task/response_description.py
@@ -231,11 +231,19 @@ class Reassign(ResponseDescription):
         change = self.response.get_change('responsible')
         responsible_new = Actor.lookup(change.get('after')).get_link()
         responsible_old = Actor.lookup(change.get('before')).get_link()
+
+        if not change.get('before') == self.response.creator:
+          return _('transition_msg_delegated_reassign',
+                   u'Reassigned from ${responsible_old} to '
+                   u'${responsible_new} by ${user}',
+                   mapping={'user': self.response.creator_link(),
+                            'responsible_new': responsible_new,
+                            'responsible_old': responsible_old})
+
         return _('transition_msg_reassign',
                  u'Reassigned from ${responsible_old} to '
-                 u'${responsible_new} by ${user}',
-                 mapping={'user': self.response.creator_link(),
-                          'responsible_new': responsible_new,
+                 u'${responsible_new}',
+                 mapping={'responsible_new': responsible_new,
                           'responsible_old': responsible_old})
 
     def label(self):

--- a/opengever/task/tests/test_assign.py
+++ b/opengever/task/tests/test_assign.py
@@ -257,7 +257,7 @@ class TestAssignTaskWithSuccessors(IntegrationTestCase):
         response = browser.css('.answers .answer')[0]
         self.assertEquals(
             [u'Reassigned from B\xe4rfuss K\xe4thi (kathi.barfuss) to K\xf6nig '
-             u'J\xfcrgen (jurgen.konig) by B\xe4rfuss K\xe4thi (kathi.barfuss)'],
+             u'J\xfcrgen (jurgen.konig)'],
             response.css('h3').text)
         self.assertEquals(
             self.secretariat_user.getId(), self.task.responsible)
@@ -278,7 +278,7 @@ class TestAssignTaskWithSuccessors(IntegrationTestCase):
         response = browser.css('.answers .answer')[0]
         self.assertEquals(
             [u'Reassigned from B\xe4rfuss K\xe4thi (kathi.barfuss) to K\xf6nig '
-             u'J\xfcrgen (jurgen.konig) by B\xe4rfuss K\xe4thi (kathi.barfuss)'],
+             u'J\xfcrgen (jurgen.konig)'],
             response.css('h3').text)
         self.assertEquals(
             self.secretariat_user.getId(), self.successor.responsible)

--- a/opengever/task/tests/test_response_descriptions.py
+++ b/opengever/task/tests/test_response_descriptions.py
@@ -208,7 +208,7 @@ class TestResponseDescriptions(FunctionalTestCase):
 
         self.assertEqual(
             u'Reassigned from M\xfcller Hans (test_user_1_) to Steiner '
-            u'J\xf6rg (other_user) by M\xfcller Hans (test_user_1_)',
+            u'J\xf6rg (other_user)',
             self.get_latest_answer(browser))
 
     @browsing


### PR DESCRIPTION
When the activity creator is the same as the task responsible we do not need to specify the creator in the reassign activity.

While I was at it, I ported the task reassign activity tests to the integration layer.
resolves #5544 