### PR TITLE
Implement nightly job to perform jobs after dossier resolution.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2019.2.0 (unreleased)
 ---------------------
 
+- Implement nightly job to perform jobs after dossier resolution. [lgraf]
 - Bump plone.restapi to 3.9.0. [phgross]
 - Improve the styling of the tabbedview keyword filter. [phgross]
 - Queue each document archival conversion only once in a single request. [njohner]

--- a/docs/intern/operations/allgemein.rst
+++ b/docs/intern/operations/allgemein.rst
@@ -91,3 +91,31 @@ Der Cronjob sollte somit in jedem Fall **vor** dem "Daily Digest"-Job ausgeführ
     30 4 * * * /home/zope/server/01-gever.example.org/bin/instance0 generate_overdue_notifications >/dev/null 2>&1
 
 **Hinweise:** Der Job "Benachrichtigung für überfällige Dossiers" muss **für jeden Mandanten** eines Clusters einzeln ausgeführt und eingerichtet werden.
+
+Nightly Jobs
+^^^^^^^^^^^^
+
+Mit Release 2019.2 und höher kann ein Cron-Job für die Ausführung der Nightly
+Jobs eingerichtet werden.
+
+Tatsächlich ausgeführt werden die Jobs dann, wenn auch das Registry-Flag
+``INightlyJobsSettings.is_feature_enabled`` aktiviert ist. Falls das Flag
+nicht aktiviert ist, kann der Cron-Job trotzdem eingerichtet werden - es
+werden dann einfach keine Jobs ausgeführt werden.
+
+Die Uhrzeit für den Cron-Job muss so gewählt werden, dass sie dem in den
+``INightlyJobsSettings`` definierten Zeitfenster entspricht (zwischen
+``start_time`` und ``end_time``).
+
+.. code:: bash
+
+    # Nightly Jobs
+    0 01 * * * /home/zope/server/01-gever.example.org/bin/instance run_nightly_jobs >/dev/null 2>&1
+
+Das Zeitfenster in der Registry wird mittels timedeltas (nicht Uhrzeiten)
+definiert - die Werte können also grösser als ``24:00`` sein. Dies erlaubt es,
+auch Angaben über das Mitternachts-Rollover hinweg ohne Zweideutigkeit
+anzugeben:
+
+``23:00 - 26:00`` würde dementsprechend Start um ``23:00``, und Ende um
+``02:00`` *am nächsten Tag* bedeuten.

--- a/opengever/base/tests/test_solr.py
+++ b/opengever/base/tests/test_solr.py
@@ -80,6 +80,7 @@ class TestSolr(IntegrationTestCase):
         CATALOG_ONLY_INDEXES = [
             'Date',
             'Type',
+            'after_resolve_jobs_pending',
             'assigned_client',
             'blocked_local_roles',
             'client_id',

--- a/opengever/core/debughelpers.py
+++ b/opengever/core/debughelpers.py
@@ -26,11 +26,16 @@ def setup_plone(plone, options=None):
     """Takes care of setting up a request, manager security context and
     setting up the site manager for the given Plone site.
     Returns the Plone site root object.
+
+    This is based on the setup code found in p.recipe.zope2instance.ctl:
+    https://github.com/plone/plone.recipe.zope2instance/blob/
+    02bfb735/src/plone/recipe/zope2instance/ctl.py#L672-L680
     """
     app = plone.restrictedTraverse('/')
 
     # Set up request for debug / bin/instance run mode.
     app = makerequest(app)
+    app.REQUEST['PARENTS'] = [app]
     setRequest(app.REQUEST)
 
     # Get a reference to the Plone site *inside* the request-wrapped app

--- a/opengever/core/upgrades/20190428144925_add_boolean_index_after_resolve_jobs_pending/upgrade.py
+++ b/opengever/core/upgrades/20190428144925_add_boolean_index_after_resolve_jobs_pending/upgrade.py
@@ -1,0 +1,10 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddBooleanIndexAfterResolveJobsPending(UpgradeStep):
+    """Add BooleanIndex after_resolve_jobs_pending.
+    """
+
+    def __call__(self):
+        self.catalog_add_index('after_resolve_jobs_pending', 'BooleanIndex')
+        # No reindexing required

--- a/opengever/document/archival_file.py
+++ b/opengever/document/archival_file.py
@@ -1,3 +1,4 @@
+from ftw.bumblebee.config import bumblebee_config
 from ftw.bumblebee.config import PROCESSING_QUEUE
 from ftw.bumblebee.interfaces import IBumblebeeServiceV3
 from opengever.document.behaviors.metadata import IDocumentMetadata
@@ -71,8 +72,16 @@ class ArchivalFileConverter(object):
         IDocumentMetadata(self.document).archival_file_state = None
 
     def get_callback_url(self):
-        return "{}/archival_file_conversion_callback".format(
-            self.document.absolute_url())
+        """Get the URL for the callback to upload the archival PDF to.
+
+        This URL must be accessible by bumblebee, so we must not use the
+        virtual hosting based URL here, because that wouldn't work when
+        using SSH tunnels or nightly jobs run via bin/instance.
+        """
+        base_url = bumblebee_config.internal_plone_url
+        relative_path = '/'.join(self.document.getPhysicalPath()[2:])
+        doc_url = '/'.join([base_url, relative_path])
+        return "{}/archival_file_conversion_callback".format(doc_url)
 
     def store_file(self, data, mimetype='application/pdf'):
         if isinstance(mimetype, unicode):

--- a/opengever/dossier/config.py
+++ b/opengever/dossier/config.py
@@ -5,4 +5,5 @@ INDEXES = (
     ('retention_expiration', 'DateIndex'),
     ('external_reference', 'FieldIndex'),
     ('blocked_local_roles', 'BooleanIndex'),
+    ('after_resolve_jobs_pending', 'BooleanIndex'),
 )

--- a/opengever/dossier/configure.zcml
+++ b/opengever/dossier/configure.zcml
@@ -115,6 +115,11 @@
   <adapter factory=".base.DefaultConstrainTypeDecider" />
 
   <adapter
+      factory=".indexers.after_resolve_jobs_pending_indexer"
+      name="after_resolve_jobs_pending"
+      />
+
+  <adapter
       factory=".indexers.DossierSubjectIndexer"
       name="Subject"
       />

--- a/opengever/dossier/configure.zcml
+++ b/opengever/dossier/configure.zcml
@@ -250,4 +250,9 @@
       permission="zope2.View"
       />
 
+  <adapter
+      factory=".nightly_after_resolve_job.ExecuteNightlyAfterResolveJobs"
+      name="execute-after-resolve-jobs"
+      />
+
 </configure>

--- a/opengever/dossier/indexers.py
+++ b/opengever/dossier/indexers.py
@@ -8,6 +8,7 @@ from opengever.dossier.behaviors.dossier import IDossierMarker
 from opengever.dossier.behaviors.filing import IFilingNumber
 from opengever.dossier.behaviors.filing import IFilingNumberMarker
 from opengever.dossier.dossiertemplate.behaviors import IDossierTemplateMarker
+from opengever.dossier.resolve import AfterResolveJobs
 from opengever.dossier.utils import get_main_dossier
 from opengever.inbox.inbox import IInbox
 from opengever.private.dossier import IPrivateDossier
@@ -18,6 +19,12 @@ from zope.component import adapter
 from zope.component import getAdapter
 from zope.component import getUtility
 from zope.interface import implementer
+
+
+@indexer(IDossierMarker)
+def after_resolve_jobs_pending_indexer(obj):
+    pending = AfterResolveJobs(obj).after_resolve_jobs_pending
+    return pending
 
 
 @indexer(IDossierMarker)

--- a/opengever/dossier/locales/de/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/de/LC_MESSAGES/opengever.dossier.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2019-03-14 14:01+0000\n"
+"POT-Creation-Date: 2019-04-28 14:26+0000\n"
 "PO-Revision-Date: 2017-05-23 04:53+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: German <https://translations.onegovgever.ch/projects/onegov-gever/opengever-dossier/de/>\n"
@@ -15,6 +15,10 @@ msgstr ""
 "Domain: DOMAIN\n"
 "Language: de\n"
 "X-Generator: Weblate 2.13.1\n"
+
+#: ./opengever/dossier/viewlets/byline.py
+msgid " (after resolve jobs pending)"
+msgstr " (nächtliche Abschlussarbeiten ausstehend)"
 
 #: ./opengever/dossier/viewlets/byline.py
 msgid " (currently being resolved)"
@@ -65,7 +69,7 @@ msgstr "Dossier-Struktur"
 msgid "Dossier template"
 msgstr "Dossiervorlage"
 
-#: ./opengever/dossier/resolve.py
+#: ./opengever/dossier/reactivate.py
 msgid "Dossiers successfully reactivated."
 msgstr "Das Dossier wurde erfolgreich wieder eröffnet."
 
@@ -90,7 +94,7 @@ msgstr "Die folgenden Objekte konnten nicht kopiert werden: ${failed_objects}. S
 msgid "It isn't allowed to add such items there."
 msgstr "Sie dürfen dieses Objekt nicht an den Zielort verschieben."
 
-#: ./opengever/dossier/resolve.py
+#: ./opengever/dossier/reactivate.py
 msgid "It isn't possible to reactivate a sub dossier."
 msgstr "Es ist nicht möglich das Subdossier wieder zu eröffnen, das Hauptdossier muss wieder eröffnet werden."
 

--- a/opengever/dossier/locales/fr/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/fr/LC_MESSAGES/opengever.dossier.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-03-14 14:01+0000\n"
+"POT-Creation-Date: 2019-04-28 14:26+0000\n"
 "PO-Revision-Date: 2017-12-03 11:16+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-dossier/fr/>\n"
@@ -15,6 +15,10 @@ msgstr ""
 "Domain: DOMAIN\n"
 "Language: fr\n"
 "X-Generator: Weblate 2.13.1\n"
+
+#: ./opengever/dossier/viewlets/byline.py
+msgid " (after resolve jobs pending)"
+msgstr ""
 
 #: ./opengever/dossier/viewlets/byline.py
 msgid " (currently being resolved)"
@@ -64,7 +68,7 @@ msgstr "Structure du dossier"
 msgid "Dossier template"
 msgstr "Modèle de dossier"
 
-#: ./opengever/dossier/resolve.py
+#: ./opengever/dossier/reactivate.py
 msgid "Dossiers successfully reactivated."
 msgstr "Le dossier a été rouvert avec succès."
 
@@ -89,7 +93,7 @@ msgstr "Les objets suivants ne peuvent pas être copiés: ${failed_objects}. Ils
 msgid "It isn't allowed to add such items there."
 msgstr "Cet élément ne peut être déplacé vers cette position."
 
-#: ./opengever/dossier/resolve.py
+#: ./opengever/dossier/reactivate.py
 msgid "It isn't possible to reactivate a sub dossier."
 msgstr "Il n'est pas possible de rouvrir le sous-dossier, le dossier principal doit être ouvert à nouveau."
 

--- a/opengever/dossier/locales/opengever.dossier.pot
+++ b/opengever/dossier/locales/opengever.dossier.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-03-14 14:01+0000\n"
+"POT-Creation-Date: 2019-04-28 14:26+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,6 +16,10 @@ msgstr ""
 "Language-Name: English\n"
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: opengever.dossier\n"
+
+#: ./opengever/dossier/viewlets/byline.py
+msgid " (after resolve jobs pending)"
+msgstr ""
 
 #: ./opengever/dossier/viewlets/byline.py
 msgid " (currently being resolved)"
@@ -65,7 +69,7 @@ msgstr ""
 msgid "Dossier template"
 msgstr ""
 
-#: ./opengever/dossier/resolve.py
+#: ./opengever/dossier/reactivate.py
 msgid "Dossiers successfully reactivated."
 msgstr ""
 
@@ -90,7 +94,7 @@ msgstr ""
 msgid "It isn't allowed to add such items there."
 msgstr ""
 
-#: ./opengever/dossier/resolve.py
+#: ./opengever/dossier/reactivate.py
 msgid "It isn't possible to reactivate a sub dossier."
 msgstr ""
 

--- a/opengever/dossier/nightly_after_resolve_job.py
+++ b/opengever/dossier/nightly_after_resolve_job.py
@@ -1,0 +1,43 @@
+from logging import getLogger
+from opengever.dossier.behaviors.dossier import IDossierMarker
+from opengever.dossier.resolve import AfterResolveJobs
+from opengever.nightlyjobs.interfaces import INightlyJobProvider
+from plone import api
+from Products.CMFPlone.interfaces import IPloneSiteRoot
+from zope.component import adapter
+from zope.interface import implementer
+from zope.publisher.interfaces.browser import IBrowserRequest
+
+
+logger = getLogger('opengever.dossier.nightly_after_resolve_job')
+
+
+@implementer(INightlyJobProvider)
+@adapter(IPloneSiteRoot, IBrowserRequest)
+class ExecuteNightlyAfterResolveJobs(object):
+
+    def __init__(self, context, request):
+        self.catalog = api.portal.get_tool('portal_catalog')
+        self.portal = api.portal.get()
+
+        # Get all dossiers that are resolved, but still have
+        # AfterResolveJobs pending
+        self.query = dict(
+            object_provides=IDossierMarker.__identifier__,
+            review_state='dossier-state-resolved',
+            after_resolve_jobs_pending=True,
+        )
+
+    def __iter__(self):
+        pending = self.catalog.unrestrictedSearchResults(self.query)
+        return iter([{'path': brain.getPath()} for brain in pending])
+
+    def __len__(self):
+        resultset = self.catalog.unrestrictedSearchResults(self.query)
+        return resultset.actual_result_count
+
+    def run_job(self, job, interrupt_if_necessary):
+        path = job['path']
+        dossier = self.portal.unrestrictedTraverse(path)
+        logger.info("Running AfterResolve jobs for %r" % dossier)
+        AfterResolveJobs(dossier).execute(nightly_run=True)

--- a/opengever/dossier/resolve.py
+++ b/opengever/dossier/resolve.py
@@ -347,14 +347,17 @@ class AfterResolveJobs(object):
 
     def __init__(self, context):
         self.context = context
+        self.catalog = api.portal.get_tool('portal_catalog')
 
     def get_property(self, name):
         return api.portal.get_registry_record(
             name, interface=IDossierResolveProperties)
 
     def contains_tasks(self):
-        tasks = api.content.find(
-            context=self.context, depth=-1, object_provides=ITask)
+        path = '/'.join(self.context.getPhysicalPath())
+        tasks = self.catalog.unrestrictedSearchResults(
+            path=path,
+            object_provides=ITask.__identifier__)
         return len(tasks) > 0
 
     def execute(self):
@@ -506,7 +509,10 @@ class AfterResolveJobs(object):
         if not self.get_property('archival_file_conversion_enabled'):
             return
 
-        docs = api.content.find(self.context, object_provides=[IBaseDocument])
+        path = '/'.join(self.context.getPhysicalPath())
+        docs = self.catalog.unrestrictedSearchResults(
+            path=path,
+            object_provides=IBaseDocument.__identifier__)
         for doc in docs:
             ArchivalFileConverter(doc.getObject()).trigger_conversion()
 

--- a/opengever/dossier/tests/test_resolve.py
+++ b/opengever/dossier/tests/test_resolve.py
@@ -18,9 +18,11 @@ from opengever.document.interfaces import IDossierJournalPDFMarker
 from opengever.document.interfaces import IDossierTasksPDFMarker
 from opengever.dossier.behaviors.dossier import IDossier
 from opengever.dossier.interfaces import IDossierResolveProperties
+from opengever.dossier.nightly_after_resolve_job import ExecuteNightlyAfterResolveJobs
+from opengever.dossier.resolve import AfterResolveJobs
 from opengever.dossier.resolve_lock import ResolveLock
-from opengever.ogds.base.utils import get_current_org_unit
 from opengever.testing import IntegrationTestCase
+from opengever.testing.helpers import index_data_for
 from operator import itemgetter
 from plone import api
 from plone.app.testing import applyProfile
@@ -211,11 +213,43 @@ class TestResolvingDossiers(IntegrationTestCase, ResolveTestHelper):
 
 
 class TestResolvingDossiersRESTAPI(ResolveTestHelperRESTAPI, TestResolvingDossiers):
+    """Variant of the above test class to test dossier resolution via RESTAPI.
+    """
 
-    pass
+
+class TestResolvingDossiersNightly(TestResolvingDossiers):
+    """Variant of the above test class to test dossier resolution with the
+    nightly jobs feature enabled.
+    """
+
+    features = ('nightly-jobs', )
 
 
-class TestResolveJobs(IntegrationTestCase, ResolveTestHelper):
+class ResolveJobsTestHelper(object):
+    """Helper to assert on the 'after_resolve_jobs_pending' flag's state
+    in situations where after resolve jobs should have been executed.
+    """
+
+    def assert_after_resolve_jobs_pending(self, expected, dossiers):
+        for dossier in dossiers:
+            self.assertEqual(expected, AfterResolveJobs(dossier).after_resolve_jobs_pending)
+            self.assertEqual(expected, index_data_for(dossier)['after_resolve_jobs_pending'])
+
+    def assert_after_resolve_jobs_pending_in_expected_state(self, dossiers):
+        self.assert_after_resolve_jobs_pending(False, dossiers)
+
+
+class NightlyResolveJobsTestHelper(ResolveJobsTestHelper):
+    """Helper to assert on the 'after_resolve_jobs_pending' flag's state
+    in situations where after resolve jobs should NOT have been executed
+    (i.e. when nightly jobs feature is enabled).
+    """
+
+    def assert_after_resolve_jobs_pending_in_expected_state(self, dossiers):
+        self.assert_after_resolve_jobs_pending(True, dossiers)
+
+
+class TestResolveJobs(IntegrationTestCase, ResolveTestHelper, ResolveJobsTestHelper):
 
     @browsing
     def test_all_trashed_documents_are_deleted_when_resolving_a_dossier_if_enabled(self, browser):
@@ -230,6 +264,9 @@ class TestResolveJobs(IntegrationTestCase, ResolveTestHelper):
 
         self.assertIn(doc1, children['after'])
         self.assertNotIn(doc2, children['after'])
+
+        self.assert_after_resolve_jobs_pending_in_expected_state(
+            [self.empty_dossier])
 
     @browsing
     def test_purge_trashs_recursive(self, browser):
@@ -246,6 +283,9 @@ class TestResolveJobs(IntegrationTestCase, ResolveTestHelper):
         self.assertIn(doc1, children['after'])
         self.assertNotIn(doc2, children['after'])
 
+        self.assert_after_resolve_jobs_pending_in_expected_state(
+            [self.empty_dossier, subdossier])
+
     @browsing
     def test_purging_trashed_documents_is_disabled_by_default(self, browser):
         self.login(self.secretariat_user, browser)
@@ -255,6 +295,9 @@ class TestResolveJobs(IntegrationTestCase, ResolveTestHelper):
             self.resolve(self.empty_dossier, browser)
 
         self.assertIn(doc1, children['after'])
+
+        self.assert_after_resolve_jobs_pending_in_expected_state(
+            [self.empty_dossier])
 
     @browsing
     def test_adds_journal_pdf_to_main_and_subdossier(self, browser):
@@ -292,6 +335,9 @@ class TestResolveJobs(IntegrationTestCase, ResolveTestHelper):
         self.assertTrue(IDossierJournalPDFMarker.providedBy(sub_journal_pdf))
         self.assertFalse(sub_journal_pdf.preserved_as_paper)
 
+        self.assert_after_resolve_jobs_pending_in_expected_state(
+            [self.empty_dossier, subdossier])
+
     @browsing
     def test_sets_journal_pdf_document_date_to_dossier_end_date(self, browser):
         self.activate_feature('journal-pdf')
@@ -324,6 +370,9 @@ class TestResolveJobs(IntegrationTestCase, ResolveTestHelper):
         self.assertEqual(date(2016, 3, 15), main_journal_pdf.document_date,
                          "Document date should be earliest possible date")
 
+        self.assert_after_resolve_jobs_pending_in_expected_state(
+            [self.empty_dossier, subdossier])
+
     @browsing
     def test_journal_pdf_gets_updated_when_dossier_is_closed_again(self, browser):
         self.activate_feature('journal-pdf')
@@ -340,6 +389,9 @@ class TestResolveJobs(IntegrationTestCase, ResolveTestHelper):
             self.resolve(self.empty_dossier, browser)
         self.assertEquals(0, len(children['added']))
         self.assertEquals(1, journal_pdf.get_current_version_id(missing_as_zero=True))
+
+        self.assert_after_resolve_jobs_pending_in_expected_state(
+            [self.empty_dossier])
 
     @browsing
     def test_adds_tasks_pdf_only_to_main_dossier(self, browser):
@@ -377,6 +429,9 @@ class TestResolveJobs(IntegrationTestCase, ResolveTestHelper):
 
         self.assertEquals(0, len(sub_children['added']))
 
+        self.assert_after_resolve_jobs_pending_in_expected_state(
+            [self.empty_dossier, subdossier])
+
     @browsing
     def test_tasks_pdf_is_skipped_for_dossiers_without_tasks(self, browser):
         self.activate_feature('tasks-pdf')
@@ -386,6 +441,9 @@ class TestResolveJobs(IntegrationTestCase, ResolveTestHelper):
             self.resolve(self.empty_dossier, browser)
 
         self.assertEqual(0, len(children['added']))
+
+        self.assert_after_resolve_jobs_pending_in_expected_state(
+            [self.empty_dossier])
 
     @browsing
     def test_sets_tasks_pdf_document_date_to_dossier_end_date(self, browser):
@@ -429,6 +487,9 @@ class TestResolveJobs(IntegrationTestCase, ResolveTestHelper):
         self.assertEqual(date(2016, 3, 15), main_tasks_pdf.document_date,
                          "Document date should be earliest possible date")
 
+        self.assert_after_resolve_jobs_pending_in_expected_state(
+            [self.empty_dossier, subdossier])
+
     @browsing
     def test_tasks_pdf_gets_updated_when_dossier_is_closed_again(self, browser):
         self.activate_feature('tasks-pdf')
@@ -457,6 +518,9 @@ class TestResolveJobs(IntegrationTestCase, ResolveTestHelper):
         self.assertEquals(0, len(children['added']))
         self.assertEquals(1, tasks_pdf.get_current_version_id(missing_as_zero=True))
 
+        self.assert_after_resolve_jobs_pending_in_expected_state(
+            [self.empty_dossier])
+
     @browsing
     def test_tasks_and_journal_pdf_are_disabled_by_default(self, browser):
         self.login(self.secretariat_user, browser)
@@ -465,6 +529,9 @@ class TestResolveJobs(IntegrationTestCase, ResolveTestHelper):
             self.resolve(self.empty_dossier, browser)
 
         self.assertEquals(0, len(children['added']))
+
+        self.assert_after_resolve_jobs_pending_in_expected_state(
+            [self.empty_dossier])
 
     @browsing
     def test_only_shadowed_documents_are_deleted_when_resolving_a_dossier(self, browser):
@@ -478,6 +545,9 @@ class TestResolveJobs(IntegrationTestCase, ResolveTestHelper):
 
         self.assertIn(doc1, children['after'])
         self.assertNotIn(doc2, children['after'])
+
+        self.assert_after_resolve_jobs_pending_in_expected_state(
+            [self.empty_dossier])
 
     @browsing
     def test_shadowed_documents_are_deleted_recursively_when_resolving_a_dossier(self, browser):
@@ -493,10 +563,503 @@ class TestResolveJobs(IntegrationTestCase, ResolveTestHelper):
         self.assertIn(doc1, children['after'])
         self.assertNotIn(doc2, children['after'])
 
+        self.assert_after_resolve_jobs_pending_in_expected_state(
+            [self.empty_dossier, subdossier])
+
 
 class TestResolveJobsRESTAPI(ResolveTestHelperRESTAPI, TestResolveJobs):
+    """Variant of the above test class to test dossier resolution via RESTAPI.
+    """
 
-    pass
+
+class TestResolveJobsNightly(NightlyResolveJobsTestHelper, TestResolveJobs):
+    """Variant of the above test class to test dossier resolution with the
+    nightly jobs feature enabled.
+
+    These tests should test that the respective jobs are NOT executed when
+    the nightly jobs feature is enabled, but produce the same result when
+    the nightly job is triggered afterwards.
+
+    They usually follow this pattern:
+    - Resolve one or more dossiers
+    - Assert that none of the work of the AfterResolveJobs has been done yet
+    - Assert that the AfterResolveJobs are flagged as still pending
+    - Run the nightly job(s)
+    - Assert that the AfterResolveJobs work has been done
+    - Assert that the AfterResolveJobs are not flagged as pending any more
+    """
+
+    features = ('nightly-jobs', )
+
+    def interrupt_if_necessary(self):
+        """Stub out the runner's `interrupt_if_necessary` function.
+        """
+
+    def execute_nightly_jobs(self, expected=None):
+        """Run all pending after resolve nightly jobs, and assert on the
+        number of jobs.
+        """
+        nightly_job_provider = ExecuteNightlyAfterResolveJobs(
+            self.portal, self.request)
+
+        jobs = list(nightly_job_provider)
+        if expected:
+            self.assertEqual(expected, len(jobs))
+            self.assertEqual(expected, len(nightly_job_provider))
+
+        for job in jobs:
+            nightly_job_provider.run_job(job, self.interrupt_if_necessary)
+
+    @browsing
+    def test_all_trashed_documents_are_deleted_when_resolving_a_dossier_if_enabled(self, browser):
+        self.activate_feature('purge-trash')
+        self.login(self.secretariat_user, browser)
+
+        doc1 = create(Builder('document').within(self.empty_dossier))
+        doc2 = create(Builder('document').within(self.empty_dossier).trashed())
+
+        with self.observe_children(self.empty_dossier) as children:
+            self.resolve(self.empty_dossier, browser)
+
+        # Nothing happened yet, resolve jobs still flagged as pending
+        self.assertIn(doc1, children['after'])
+        self.assertIn(doc2, children['after'])
+
+        self.assert_after_resolve_jobs_pending(
+            True, [self.empty_dossier])
+
+        # Now run the nightly jobs
+        with self.observe_children(self.empty_dossier) as children:
+            self.execute_nightly_jobs(expected=1)
+
+        self.assert_after_resolve_jobs_pending(
+            False, [self.empty_dossier])
+
+        self.assertIn(doc1, children['after'])
+        self.assertNotIn(doc2, children['after'])
+
+    @browsing
+    def test_purge_trashs_recursive(self, browser):
+        self.activate_feature('purge-trash')
+        self.login(self.secretariat_user, browser)
+
+        subdossier = create(Builder('dossier').within(self.empty_dossier))
+        doc1 = create(Builder('document').within(subdossier))
+        doc2 = create(Builder('document').within(subdossier).trashed())
+
+        with self.observe_children(subdossier) as children:
+            self.resolve(self.empty_dossier, browser)
+
+        # Nothing happened yet, resolve jobs still flagged as pending
+        self.assertIn(doc1, children['after'])
+        self.assertIn(doc2, children['after'])
+
+        self.assert_after_resolve_jobs_pending(
+            True, [self.empty_dossier, subdossier])
+
+        # Now run the nightly jobs
+        with self.observe_children(subdossier) as children:
+            self.execute_nightly_jobs(expected=2)
+
+        self.assert_after_resolve_jobs_pending(
+            False, [self.empty_dossier, subdossier])
+
+        self.assertIn(doc1, children['after'])
+        self.assertNotIn(doc2, children['after'])
+
+    @browsing
+    def test_adds_journal_pdf_to_main_and_subdossier(self, browser):
+        self.activate_feature('journal-pdf')
+        self.login(self.secretariat_user, browser)
+
+        subdossier = create(Builder('dossier')
+                            .within(self.empty_dossier)
+                            .titled(u'Sub'))
+
+        with self.observe_children(self.empty_dossier) as main_children:
+            with self.observe_children(subdossier) as sub_children:
+                with freeze(datetime(2016, 4, 25)):
+                    self.resolve(self.empty_dossier, browser)
+
+        # Nothing happened yet, resolve jobs still flagged as pending
+        self.assertEquals(0, len(main_children['added']))
+        self.assertEquals(0, len(sub_children['added']))
+
+        self.assert_after_resolve_jobs_pending(
+            True, [self.empty_dossier, subdossier])
+
+        # Now run the nightly jobs
+        with self.observe_children(self.empty_dossier) as main_children:
+            with self.observe_children(subdossier) as sub_children:
+                with freeze(datetime(2016, 4, 25)):
+                    self.execute_nightly_jobs(expected=2)
+
+        self.assertEquals(1, len(main_children['added']))
+        main_journal_pdf, = main_children['added']
+        self.assertEquals(u'Journal of dossier An empty dossier, Apr 25, 2016 12:00 AM',
+                          main_journal_pdf.title)
+        self.assertEquals(u'Journal of dossier An empty dossier, Apr 25, 2016 12 00 AM.pdf',
+                          main_journal_pdf.file.filename)
+        self.assertEquals(u'application/pdf',
+                          main_journal_pdf.file.contentType)
+        self.assertTrue(IDossierJournalPDFMarker.providedBy(main_journal_pdf))
+        self.assertFalse(main_journal_pdf.preserved_as_paper)
+
+        self.assertEquals(1, len(sub_children['added']))
+        sub_journal_pdf, = sub_children['added']
+        self.assertEquals(u'Journal of dossier Sub, Apr 25, 2016 12:00 AM',
+                          sub_journal_pdf.title)
+        self.assertEquals(u'Journal of dossier Sub, Apr 25, 2016 12 00 AM.pdf',
+                          sub_journal_pdf.file.filename)
+        self.assertEquals(u'application/pdf',
+                          sub_journal_pdf.file.contentType)
+        self.assertTrue(IDossierJournalPDFMarker.providedBy(sub_journal_pdf))
+        self.assertFalse(sub_journal_pdf.preserved_as_paper)
+
+        self.assert_after_resolve_jobs_pending(
+            False, [self.empty_dossier, subdossier])
+
+    @browsing
+    def test_sets_journal_pdf_document_date_to_dossier_end_date(self, browser):
+        self.activate_feature('journal-pdf')
+        self.login(self.secretariat_user, browser)
+
+        subdossier = create(Builder('dossier')
+                            .within(self.empty_dossier)
+                            .having(
+                                start=date(2016, 1, 1),
+                                end=date(2016, 3, 15))
+                            .titled(u'Sub'))
+
+        # Resolve subdossier
+        with self.observe_children(subdossier) as sub_children:
+            with freeze(datetime(2016, 4, 25)):
+                self.resolve(subdossier, browser)
+
+        # Nothing happened yet, resolve jobs still flagged as pending
+        self.assertEquals(0, len(sub_children['added']))
+
+        self.assert_after_resolve_jobs_pending(
+            True, [subdossier])
+
+        # Now run the nightly jobs
+        with self.observe_children(subdossier) as sub_children:
+            with freeze(datetime(2016, 4, 25)):
+                self.execute_nightly_jobs(expected=1)
+
+        self.assertEquals(1, len(sub_children['added']))
+        sub_journal_pdf, = sub_children['added']
+        self.assertEqual(date(2016, 3, 15), sub_journal_pdf.document_date,
+                         "End date should be set to dossier end date")
+
+        self.assert_after_resolve_jobs_pending(
+            False, [subdossier])
+
+        # Resolve main dossier
+        with self.observe_children(self.empty_dossier) as main_children:
+            with freeze(datetime(2016, 9, 1)):
+                self.resolve(self.empty_dossier, browser)
+
+        # Nothing happened yet, resolve jobs still flagged as pending
+        self.assertEquals(0, len(main_children['added']))
+
+        self.assert_after_resolve_jobs_pending(
+            True, [self.empty_dossier])
+
+        # Now run the nightly jobs
+        with self.observe_children(self.empty_dossier) as main_children:
+            with freeze(datetime(2016, 4, 25)):
+                self.execute_nightly_jobs(expected=1)
+
+        self.assertEquals(1, len(main_children['added']))
+        main_journal_pdf, = main_children['added']
+        self.assertEqual(date(2016, 3, 15), IDossier(self.empty_dossier).end,
+                         "End should be earliest possible date")
+        self.assertEqual(date(2016, 3, 15), main_journal_pdf.document_date,
+                         "Document date should be earliest possible date")
+
+        self.assert_after_resolve_jobs_pending(
+            False, [self.empty_dossier])
+
+    @browsing
+    def test_journal_pdf_gets_updated_when_dossier_is_closed_again(self, browser):
+        self.activate_feature('journal-pdf')
+        self.login(self.secretariat_user, browser)
+
+        with self.observe_children(self.empty_dossier) as children:
+            self.resolve(self.empty_dossier, browser)
+
+        # Nothing happened yet, resolve jobs still flagged as pending
+        self.assertEquals(0, len(children['added']))
+
+        self.assert_after_resolve_jobs_pending(
+            True, [self.empty_dossier])
+
+        # Now run the nightly jobs
+        with self.observe_children(self.empty_dossier) as children:
+                self.execute_nightly_jobs(expected=1)
+
+        self.assertEquals(1, len(children['added']))
+        journal_pdf, = children['added']
+        self.assertEquals(0, journal_pdf.get_current_version_id(missing_as_zero=True))
+
+        self.assert_after_resolve_jobs_pending(
+            False, [self.empty_dossier])
+
+        # Now reactivate and close the dossier again
+        self.reactivate(self.empty_dossier, browser)
+        with self.observe_children(self.empty_dossier) as children:
+            self.resolve(self.empty_dossier, browser)
+
+        # Nothing happened yet, resolve jobs still flagged as pending
+        self.assertEquals(0, len(children['added']))
+        self.assertEquals(0, journal_pdf.get_current_version_id(missing_as_zero=True))
+
+        self.assert_after_resolve_jobs_pending(
+            True, [self.empty_dossier])
+
+        # Now run the nightly jobs
+        with self.observe_children(self.empty_dossier) as children:
+                self.execute_nightly_jobs(expected=1)
+
+        self.assertEquals(0, len(children['added']))
+        self.assertEquals(1, journal_pdf.get_current_version_id(missing_as_zero=True))
+
+        self.assert_after_resolve_jobs_pending(
+            False, [self.empty_dossier])
+
+    @browsing
+    def test_adds_tasks_pdf_only_to_main_dossier(self, browser):
+        self.activate_feature('tasks-pdf')
+        self.login(self.secretariat_user, browser)
+
+        subdossier = create(Builder('dossier')
+                            .within(self.empty_dossier)
+                            .titled(u'Sub'))
+        create(Builder('task')
+               .within(subdossier)
+               .titled(u'Arbeitsentwurf checken')
+               .having(responsible_client='fa',
+                       responsible=self.regular_user.getId(),
+                       issuer=self.dossier_responsible.getId(),
+                       task_type='correction',
+                       deadline=date(2016, 11, 1))
+               .in_state('task-state-tested-and-closed'))
+
+        with self.observe_children(self.empty_dossier) as main_children:
+            with self.observe_children(subdossier) as sub_children:
+                with freeze(datetime(2016, 4, 25)):
+                    self.resolve(self.empty_dossier, browser)
+
+        # Nothing happened yet, resolve jobs still flagged as pending
+        self.assertEquals(0, len(main_children['added']))
+        self.assertEquals(0, len(sub_children['added']))
+
+        self.assert_after_resolve_jobs_pending(
+            True, [self.empty_dossier, subdossier])
+
+        # Now run the nightly jobs
+        with self.observe_children(self.empty_dossier) as main_children:
+            with self.observe_children(subdossier) as sub_children:
+                with freeze(datetime(2016, 4, 25)):
+                    self.execute_nightly_jobs(expected=2)
+
+        self.assertEquals(1, len(main_children['added']))
+        main_tasks_pdf, = main_children['added']
+        self.assertEquals(u'Task list of dossier An empty dossier, Apr 25, 2016 12:00 AM',
+                          main_tasks_pdf.title)
+        self.assertEquals(u'Task list of dossier An empty dossier, Apr 25, 2016 12 00 AM.pdf',
+                          main_tasks_pdf.file.filename)
+        self.assertEquals(u'application/pdf',
+                          main_tasks_pdf.file.contentType)
+        self.assertTrue(IDossierTasksPDFMarker.providedBy(main_tasks_pdf))
+        self.assertFalse(main_tasks_pdf.preserved_as_paper)
+
+        self.assertEquals(0, len(sub_children['added']))
+
+        self.assert_after_resolve_jobs_pending(
+            False, [self.empty_dossier, subdossier])
+
+    @browsing
+    def test_tasks_pdf_is_skipped_for_dossiers_without_tasks(self, browser):
+        self.activate_feature('tasks-pdf')
+        self.login(self.secretariat_user, browser)
+
+        with self.observe_children(self.empty_dossier) as children:
+            self.resolve(self.empty_dossier, browser)
+            self.execute_nightly_jobs(expected=1)
+
+        self.assertEqual(0, len(children['added']))
+
+        self.assert_after_resolve_jobs_pending(
+            False, [self.empty_dossier])
+
+    @browsing
+    def test_sets_tasks_pdf_document_date_to_dossier_end_date(self, browser):
+        """When the document date is not set to the dossiers end date the
+        subdossier will be left in an inconsistent state. this will make
+        resolving the main dossier impossible.
+        """
+        self.activate_feature('tasks-pdf')
+        self.login(self.secretariat_user, browser)
+
+        subdossier = create(Builder('dossier')
+                            .within(self.empty_dossier)
+                            .having(
+                                start=date(2016, 1, 1),
+                                end=date(2016, 3, 15))
+                            .titled(u'Sub'))
+        create(Builder('task')
+               .within(subdossier)
+               .titled(u'Arbeitsentwurf checken')
+               .having(responsible_client='fa',
+                       responsible=self.regular_user.getId(),
+                       issuer=self.dossier_responsible.getId(),
+                       task_type='correction',
+                       deadline=date(2016, 11, 1))
+               .in_state('task-state-tested-and-closed'))
+
+        with self.observe_children(subdossier) as sub_children:
+            with freeze(datetime(2016, 4, 25)):
+                self.resolve(subdossier, browser)
+                self.execute_nightly_jobs(expected=1)
+
+        self.assertEquals(0, len(sub_children['added']))
+
+        with self.observe_children(self.empty_dossier) as main_children:
+            with freeze(datetime(2016, 9, 1)):
+                self.resolve(self.empty_dossier, browser)
+
+        # Nothing happened yet, resolve jobs still flagged as pending
+        self.assertEquals(0, len(main_children['added']))
+
+        self.assert_after_resolve_jobs_pending(
+            True, [self.empty_dossier])
+
+        # Now run the nightly jobs
+        with self.observe_children(self.empty_dossier) as main_children:
+            with freeze(datetime(2016, 9, 1)):
+                self.execute_nightly_jobs(expected=1)
+
+        self.assertEquals(1, len(main_children['added']))
+        main_tasks_pdf, = main_children['added']
+        self.assertEqual(date(2016, 3, 15), IDossier(self.empty_dossier).end,
+                         "End should be earliest possible date")
+        self.assertEqual(date(2016, 3, 15), main_tasks_pdf.document_date,
+                         "Document date should be earliest possible date")
+
+        self.assert_after_resolve_jobs_pending(
+            False, [self.empty_dossier])
+
+    @browsing
+    def test_tasks_pdf_gets_updated_when_dossier_is_closed_again(self, browser):
+        self.activate_feature('tasks-pdf')
+        self.login(self.secretariat_user, browser)
+
+        create(Builder('task')
+               .within(self.empty_dossier)
+               .titled(u'Arbeitsentwurf checken')
+               .having(responsible_client='fa',
+                       responsible=self.regular_user.getId(),
+                       issuer=self.dossier_responsible.getId(),
+                       task_type='correction',
+                       deadline=date(2016, 11, 1))
+               .in_state('task-state-tested-and-closed'))
+
+        with self.observe_children(self.empty_dossier) as children:
+            self.resolve(self.empty_dossier, browser)
+
+        # Nothing happened yet, resolve jobs still flagged as pending
+        self.assertEquals(0, len(children['added']))
+
+        self.assert_after_resolve_jobs_pending(
+            True, [self.empty_dossier])
+
+        # Now run the nightly jobs
+        with self.observe_children(self.empty_dossier) as children:
+            self.execute_nightly_jobs(expected=1)
+
+        self.assertEquals(1, len(children['added']))
+        tasks_pdf, = children['added']
+        tasks_pdf.reindexObject()
+        self.assertEquals(0, tasks_pdf.get_current_version_id(missing_as_zero=True))
+
+        # Now reactivate and close the dossier again
+        self.reactivate(self.empty_dossier, browser)
+        with self.observe_children(self.empty_dossier) as children:
+            self.resolve(self.empty_dossier, browser)
+
+        # Nothing happened yet, resolve jobs still flagged as pending
+        self.assertEquals(0, len(children['added']))
+        self.assertEquals(0, tasks_pdf.get_current_version_id(missing_as_zero=True))
+
+        self.assert_after_resolve_jobs_pending(
+            True, [self.empty_dossier])
+
+        # Now run the nightly jobs
+        with self.observe_children(self.empty_dossier) as children:
+            self.execute_nightly_jobs(expected=1)
+
+        self.assertEquals(0, len(children['added']))
+        self.assertEquals(1, tasks_pdf.get_current_version_id(missing_as_zero=True))
+
+        self.assert_after_resolve_jobs_pending(
+            False, [self.empty_dossier])
+
+    @browsing
+    def test_only_shadowed_documents_are_deleted_when_resolving_a_dossier(self, browser):
+        self.login(self.secretariat_user, browser)
+
+        doc1 = create(Builder('document').within(self.empty_dossier))
+        doc2 = create(Builder('document').within(self.empty_dossier).as_shadow_document())
+
+        with self.observe_children(self.empty_dossier) as children:
+            self.resolve(self.empty_dossier, browser)
+
+        # Nothing happened yet, resolve jobs still flagged as pending
+        self.assertIn(doc1, children['after'])
+        self.assertIn(doc2, children['after'])
+
+        self.assert_after_resolve_jobs_pending(
+            True, [self.empty_dossier])
+
+        # Now run the nightly jobs
+        with self.observe_children(self.empty_dossier) as children:
+            self.execute_nightly_jobs(expected=1)
+
+        self.assertIn(doc1, children['after'])
+        self.assertNotIn(doc2, children['after'])
+
+        self.assert_after_resolve_jobs_pending(
+            False, [self.empty_dossier])
+
+    @browsing
+    def test_shadowed_documents_are_deleted_recursively_when_resolving_a_dossier(self, browser):
+        self.login(self.secretariat_user, browser)
+
+        subdossier = create(Builder('dossier').within(self.empty_dossier))
+        doc1 = create(Builder('document').within(subdossier))
+        doc2 = create(Builder('document').within(subdossier).as_shadow_document())
+
+        with self.observe_children(subdossier) as children:
+            self.resolve(self.empty_dossier, browser)
+
+        # Nothing happened yet, resolve jobs still flagged as pending
+        self.assertIn(doc1, children['after'])
+        self.assertIn(doc2, children['after'])
+
+        self.assert_after_resolve_jobs_pending(
+            True, [self.empty_dossier, subdossier])
+
+        # Now run the nightly jobs
+        with self.observe_children(subdossier) as children:
+            self.execute_nightly_jobs(expected=2)
+
+        self.assertIn(doc1, children['after'])
+        self.assertNotIn(doc2, children['after'])
+
+        self.assert_after_resolve_jobs_pending(
+            False, [self.empty_dossier, subdossier])
 
 
 class TestAutomaticPDFAConversion(IntegrationTestCase, ResolveTestHelper):

--- a/opengever/dossier/tests/test_resolve.py
+++ b/opengever/dossier/tests/test_resolve.py
@@ -509,7 +509,6 @@ class TestResolveJobs(IntegrationTestCase, ResolveTestHelper, ResolveJobsTestHel
             self.resolve(self.empty_dossier, browser)
         self.assertEquals(1, len(children['added']))
         tasks_pdf, = children['added']
-        tasks_pdf.reindexObject()
         self.assertEquals(0, tasks_pdf.get_current_version_id(missing_as_zero=True))
 
         self.reactivate(self.empty_dossier, browser)
@@ -981,7 +980,6 @@ class TestResolveJobsNightly(NightlyResolveJobsTestHelper, TestResolveJobs):
 
         self.assertEquals(1, len(children['added']))
         tasks_pdf, = children['added']
-        tasks_pdf.reindexObject()
         self.assertEquals(0, tasks_pdf.get_current_version_id(missing_as_zero=True))
 
         # Now reactivate and close the dossier again

--- a/opengever/nightlyjobs/cronjobs.py
+++ b/opengever/nightlyjobs/cronjobs.py
@@ -17,7 +17,7 @@ def run_nightly_jobs_handler(app, args):
     logger.setLevel(logging.INFO)
 
     for plone_site in all_plone_sites(app):
-        setup_plone(plone_site)
+        plone_site = setup_plone(plone_site)
         invoke_nightly_job_runner(plone_site)
 
 

--- a/opengever/nightlyjobs/cronjobs.py
+++ b/opengever/nightlyjobs/cronjobs.py
@@ -5,7 +5,7 @@ from opengever.nightlyjobs.runner import NightlyJobRunner
 import logging
 
 
-logger = logging.getLogger('opengever.nightlyjobs.cronjobs')
+logger = logging.getLogger('opengever.nightlyjobs')
 
 
 def run_nightly_jobs_handler(app, args):
@@ -26,7 +26,7 @@ def invoke_nightly_job_runner(plone_site):
                     'not running any jobs for %r' % plone_site)
         return
 
-    runner = NightlyJobRunner()
+    runner = NightlyJobRunner(setup_own_task_queue=True)
     logger.info('Found {} providers: {}'.format(len(runner.job_providers),
                                                 runner.job_providers.keys()))
     logger.info('Number of jobs: {}'.format(runner.get_initial_jobs_count()))

--- a/opengever/nightlyjobs/runner.py
+++ b/opengever/nightlyjobs/runner.py
@@ -1,13 +1,24 @@
+from collective.taskqueue.interfaces import ITaskQueue
+from collective.taskqueue.interfaces import ITaskQueueLayer
+from collective.taskqueue.taskqueue import LocalVolatileTaskQueue
 from datetime import datetime
 from datetime import timedelta
 from opengever.base.sentry import log_msg_to_sentry
 from opengever.nightlyjobs.interfaces import INightlyJobProvider
 from opengever.nightlyjobs.interfaces import INightlyJobsSettings
 from plone import api
+from plone.subrequest import subrequest
 from zope.component import getAdapters
+from zope.component import provideUtility
 from zope.globalrequest import getRequest
+from zope.interface import alsoProvides
+from zope.interface import noLongerProvides
+import logging
 import psutil
 import transaction
+
+
+log = logging.getLogger('opengever.nightlyjobs')
 
 
 def nightly_jobs_feature_enabled():
@@ -55,7 +66,7 @@ class NightlyJobRunner(object):
     LOAD_LIMITS = {'virtual_memory_available': 100 * 1024 *1024,
                    'virtual_memory_percent': 95}
 
-    def __init__(self):
+    def __init__(self, setup_own_task_queue=False):
         # retrieve window start and end times
         self.window_start = api.portal.get_registry_record(
             'start_time', interface=INightlyJobsSettings)
@@ -67,6 +78,14 @@ class NightlyJobRunner(object):
 
         self.initial_jobs_count = {name: len(provider) for name, provider
                                    in self.job_providers.items()}
+
+        # The regular task queue from bumblebee isn't available when
+        # invoked as a bin/instance zopectl_cmd or script. For that case,
+        # we need to set up our own queue to catch all queued jobs, and then
+        # process them using plone.subrequest
+        self.setup_own_task_queue = setup_own_task_queue
+        if setup_own_task_queue:
+            self._task_queue = self.setup_task_queue()
 
     def get_job_providers(self):
         return {name: provider for name, provider
@@ -90,6 +109,37 @@ class NightlyJobRunner(object):
                     self.log_to_sentry(message)
                     return exc
                 transaction.commit()
+
+                # If we set up our own task queue, process its jobs.
+                # This must happen after the transaction has been committed.
+                if self.setup_own_task_queue:
+                    self.process_task_queue()
+
+    def setup_task_queue(self):
+        task_queue = LocalVolatileTaskQueue()
+        provideUtility(task_queue, ITaskQueue, name='default')
+        return task_queue
+
+    def process_task_queue(self):
+        queue = self._task_queue.queue
+
+        log.info('Processing %d task queue jobs...' % queue.qsize())
+        request = getRequest()
+        alsoProvides(request, ITaskQueueLayer)
+
+        while not queue.empty():
+            job = queue.get()
+
+            # Process job using plone.subrequest
+            response = subrequest(job['url'])
+            assert response.status == 200
+
+            # XXX: We don't currently handle the user that is supposed to be
+            # authenticated, and the task ID, both of which c.taskqueue
+            # provides in the job.
+
+        noLongerProvides(request, ITaskQueueLayer)
+        log.info('All task queue jobs processed.')
 
     def interrupt_if_necessary(self):
         now = datetime.now().time()


### PR DESCRIPTION
Implement **nightly job to perform jobs after dossier resolution** as part of #5477 (OGIP 55).

The basic mode of operation is like this:

- The `AfterResolveJobs` class tracks (on a flag in the dossier's annotations) whether the `AfterResolveJobs` already have been executed for a particular dossier or not.

- This flag's value is also indexed into a `BooleanIndex`.

- When the nightly job feature flag is enabled, the `AfterResolveJobs` are  **skipped during normal operation**, and the **flag is set** to indicate that they are still pending for that dossier.

- A nightly job is registered that collects all dossiers that have
  - `review_state='dossier-state-resolved'`
  - `after_resolve_jobs_pending=True`

  and then executes the `AfterResolveJobs` for them (which will also set the flag to `False`).

In order to get the archival PDF conversion via Bumblebee to work, I had to have the nightly job runner register its own taskqueue:

Because `collective.taskqueue` requires a ZDaemon (webserver) that usually gets started during Zope2.Startup, this can't work in the context of `bin/instance [run | zopectl_cmd]` invocations, where no ZDaemons are started.

We therefore set up our own task queue (just the queue part, not a server that performs the tasks) that does nothing more than collect the jobs that get queued.

Afterwards we process all these jobs using `plone.subrequest` in the same process.

---

The cron job needs to be registered like this:
```
/path/to/01-deployment/bin/instance run_nightly_jobs
```

With release `2019.2` and upwards, it can be registered even though the nightly jobs feature flag is disabled in the registry. It will fail gracefully and just not run any jobs. 