### PR TITLE
Make sure exceptions during nightly jobs get reported to Sentry.

### DIFF
--- a/opengever/nightlyjobs/cronjobs.py
+++ b/opengever/nightlyjobs/cronjobs.py
@@ -1,15 +1,21 @@
+from ftw.raven.reporter import maybe_report_exception
 from opengever.core.debughelpers import all_plone_sites
 from opengever.core.debughelpers import setup_plone
 from opengever.nightlyjobs.runner import nightly_jobs_feature_enabled
 from opengever.nightlyjobs.runner import NightlyJobRunner
 from plone import api
+from zope.globalrequest import getRequest
 import logging
+import sys
 
 
 logger = logging.getLogger('opengever.nightlyjobs')
 
 
 def run_nightly_jobs_handler(app, args):
+    # Make sure unhandled exceptions get logged to Sentry
+    register_sentry_except_hook()
+
     # Set Zope's default StreamHandler's level to INFO (default is WARNING)
     # to make sure send_digests()'s output gets logged on console
     stream_handler = logger.root.handlers[0]
@@ -26,6 +32,27 @@ def setup_language(plone):
     lang = lang_tool.getPreferredLanguage()
     plone.REQUEST.environ['HTTP_ACCEPT_LANGUAGE'] = lang
     plone.REQUEST.setupLocale()
+
+
+def sentry_except_hook(exc_type, exc, traceback):
+    """Custom excepthook to log unhandled exceptions to Sentry.
+
+    We need to install this one ourselves, because ZPublisher isn't in
+    play during a bin/instance [zopectl_cmd] script, so we don't get to
+    piggy-back on zpublisher_exception_hook_wrapper.
+
+    This isn't perfect: We don't have a context (because no traversal is
+    happening) and we get a URL like 'http://foo' reported to Sentry, but
+    it should be good enough to at least notice things going wrong.
+    """
+    context = None
+    request = getRequest()
+    maybe_report_exception(context, request, exc_type, exc, traceback)
+    return sys.__excepthook__(exc_type, exc, traceback)
+
+
+def register_sentry_except_hook():
+    sys.excepthook = sentry_except_hook
 
 
 def invoke_nightly_job_runner(plone_site):


### PR DESCRIPTION
Make sure exceptions during nightly jobs get reported to Sentry.

For that we need to register a [custom excepthook](https://docs.python.org/2/library/sys.html#sys.excepthook) to log unhandled exceptions to Sentry like `ftw.raven` would normally do.

We need to install this one ourselves, because ZPublisher isn't in play during a `bin/instance [zopectl_cmd]` script, so we don't get to piggy-back on `zpublisher_exception_hook_wrapper`.

This isn't perfect: We don't have a context (because no traversal is happening) and we get a URL like `'http://foo'` reported to Sentry, but it should be good enough to at least notice things going wrong.

Example exception in Sentry:
https://sentry.4teamwork.ch/sentry/onegov-gever/issues/23999/

Fixes #5614