### PR TITLE
Upgradestep improvements 2017.7 - 2019.2

### DIFF
--- a/opengever/core/upgrades/20171026172342_add_new_dossier_manager_role/upgrade.py
+++ b/opengever/core/upgrades/20171026172342_add_new_dossier_manager_role/upgrade.py
@@ -7,9 +7,20 @@ class AddNewDossierManagerRole(UpgradeStep):
 
     def __call__(self):
         self.install_upgrade_profile()
+
+        # Skip security reindexing of dossiers, because it's done by
+        # the later upgradestep
+        # `20180604105148_add_proposal_comment_permission` anyways.
+
+        # self.update_workflow_security(
+        #     [
+        #         'opengever_dossier_workflow',
+        #         'opengever_repository_workflow',
+        #     ],
+        #     reindex_security=False)
+
         self.update_workflow_security(
             [
-                'opengever_dossier_workflow',
                 'opengever_repository_workflow',
             ],
             reindex_security=False)

--- a/opengever/core/upgrades/20171029220954_make_task_response_changes_persistent/upgrade.py
+++ b/opengever/core/upgrades/20171029220954_make_task_response_changes_persistent/upgrade.py
@@ -9,6 +9,10 @@ class MakeTaskResponseChangesPersistent(UpgradeStep):
     """Make task response changes persistent.
     """
 
+    # This upgrade step was retroactively marked as deferrable.
+    # No need to run this upgradestep immediately.
+    deferrable = True
+
     def __call__(self):
         for task in self.objects({'object_provides': ITask.__identifier__},
                                 'Make task responses persistent'):

--- a/opengever/core/upgrades/20171108161558_add_a_boolean_index_for_blocked_local_roles/upgrade.py
+++ b/opengever/core/upgrades/20171108161558_add_a_boolean_index_for_blocked_local_roles/upgrade.py
@@ -7,8 +7,17 @@ class AddABooleanIndexForBlockedLocalRoles(UpgradeStep):
     """Add BooleanIndex for blocked local roles.
     """
 
+    # Originally this upgradestep was not implemented as an deferrable
+    # Ugpradestep, but because the blocked_local_roles is only used for
+    # an admin view, we did this at a later point. To make sure the index
+    # is created in any case, i added an additional non-deferrable upgradestep
+    # which only adds the index.
+    deferrable = True
+
     def __call__(self):
-        self.catalog_add_index('blocked_local_roles', 'BooleanIndex')
+        if not self.catalog_has_index('blocked_local_roles'):
+            self.catalog_add_index('blocked_local_roles', 'BooleanIndex')
+
         self.index_blocked_local_roles_in_repository_folders()
         self.index_blocked_local_roles_in_dossiers()
 

--- a/opengever/core/upgrades/20180424145246_fix_date_for_transported_objects/upgrade.py
+++ b/opengever/core/upgrades/20180424145246_fix_date_for_transported_objects/upgrade.py
@@ -19,6 +19,11 @@ class FixDateForTransportedObjects(SQLUpgradeStep):
     """Fix date for transported objects.
     """
 
+    # This upgrade step was retroactively marked as deferrable.
+    # There is no need to fix the dates immediately, there have been broken
+    # for quit a long time.
+    deferrable = True
+
     def migrate(self):
         if not self.has_multiple_admin_units():
             # Transporter is only used on deployments with multiple adminunits,

--- a/opengever/core/upgrades/20180503231632_add_additional_task_state_planed/upgrade.py
+++ b/opengever/core/upgrades/20180503231632_add_additional_task_state_planed/upgrade.py
@@ -7,5 +7,10 @@ class AddAdditionalTaskStatePlanned(UpgradeStep):
 
     def __call__(self):
         self.install_upgrade_profile()
-        self.update_workflow_security(
-            ['opengever_task_workflow'], reindex_security=False)
+
+        # Skip the workflow security updating of all tasks because it's done by
+        # the later upgradestep
+        # 20181019172817_reader_gets_view_on_all_task_states anyways
+
+        # self.update_workflow_security(
+        #     ['opengever_task_workflow'], reindex_security=False)

--- a/opengever/core/upgrades/20180508155014_add_task_state_skipped/upgrade.py
+++ b/opengever/core/upgrades/20180508155014_add_task_state_skipped/upgrade.py
@@ -7,5 +7,10 @@ class AddTaskStateSkipped(UpgradeStep):
 
     def __call__(self):
         self.install_upgrade_profile()
-        self.update_workflow_security(
-            ['opengever_task_workflow'], reindex_security=False)
+
+        # Skip the workflow security updating of all tasks because it's done by
+        # the later upgradestep
+        # 20181019172817_reader_gets_view_on_all_task_states anyways
+
+        # self.update_workflow_security(
+        #     ['opengever_task_workflow'], reindex_security=False)

--- a/opengever/core/upgrades/20180515125607_add_task_transition_in_progress_to_cancelled/upgrade.py
+++ b/opengever/core/upgrades/20180515125607_add_task_transition_in_progress_to_cancelled/upgrade.py
@@ -7,5 +7,10 @@ class AddTaskTransitionInProgressToCancelled(UpgradeStep):
 
     def __call__(self):
         self.install_upgrade_profile()
-        self.update_workflow_security(
-            ['opengever_task_workflow'], reindex_security=False)
+
+        # Skip the workflow security updating of all tasks because it's done by
+        # the later upgradestep
+        # 20181019172817_reader_gets_view_on_all_task_states anyways
+
+        # self.update_workflow_security(
+        #     ['opengever_task_workflow'], reindex_security=False)

--- a/opengever/core/upgrades/20180604105148_add_proposal_comment_permission/upgrade.py
+++ b/opengever/core/upgrades/20180604105148_add_proposal_comment_permission/upgrade.py
@@ -5,6 +5,9 @@ class AddProposalCommentPermission(UpgradeStep):
     """Add proposal comment permission.
     """
 
+    # Reindexes the security for all dossiers also for the
+    # `20171026172342_add_new_dossier_manager_role` upgradestep.
+
     def __call__(self):
         self.install_upgrade_profile()
         self.update_workflow_security(

--- a/opengever/core/upgrades/20180911140637_fix_contenttype_for_ms_publisher_files/upgrade.py
+++ b/opengever/core/upgrades/20180911140637_fix_contenttype_for_ms_publisher_files/upgrade.py
@@ -19,22 +19,27 @@ class FixContenttypeForMSPublisherFiles(UpgradeStep):
     def __call__(self):
         self.install_upgrade_profile()
 
-        catalog = api.portal.get_tool('portal_catalog')
-        brains = catalog.unrestrictedSearchResults(
-            {'object_provides': IDocumentSchema.__identifier__})
+        # This upgradestep has been merged to the later one
+        # (20181113161333_fix_content_type_for_open_xml_visio) to avoid
+        # looping trough all document brains twice.
+        return
 
-        for brain in ProgressLogger(
-                'Fix contettype for MS Publisher and wmf files', brains):
-            if brain.getContentType == 'application/octet-stream':
-                obj = brain.getObject()
-                if not obj.file:
-                    continue
+        # catalog = api.portal.get_tool('portal_catalog')
+        # brains = catalog.unrestrictedSearchResults(
+        #     {'object_provides': IDocumentSchema.__identifier__})
 
-                filename, ext = splitext(obj.file.filename)
-                if ext == MS_PUBLISHER_EXTENSION:
-                    obj.file.contentType = MS_PUBLISHER_MIMETYPE
-                    obj.reindexObject()
+        # for brain in ProgressLogger(
+        #         'Fix contettype for MS Publisher and wmf files', brains):
+        #     if brain.getContentType == 'application/octet-stream':
+        #         obj = brain.getObject()
+        #         if not obj.file:
+        #             continue
 
-                if ext == WMF_EXTENSION:
-                    obj.file.contentType = WMF_MIMETYPE
-                    obj.reindexObject()
+        #         filename, ext = splitext(obj.file.filename)
+        #         if ext == MS_PUBLISHER_EXTENSION:
+        #             obj.file.contentType = MS_PUBLISHER_MIMETYPE
+        #             obj.reindexObject()
+
+        #         if ext == WMF_EXTENSION:
+        #             obj.file.contentType = WMF_MIMETYPE
+        #             obj.reindexObject()

--- a/opengever/core/upgrades/20181019172817_reader_gets_view_on_all_task_states/upgrade.py
+++ b/opengever/core/upgrades/20181019172817_reader_gets_view_on_all_task_states/upgrade.py
@@ -7,4 +7,10 @@ class ReaderGetsViewOnAllTaskStates(UpgradeStep):
 
     def __call__(self):
         self.install_upgrade_profile()
+
+        # Reindex is also done for the earlier upgradesteps
+        # - 20180503231632_add_additional_task_state_planed
+        # - 20180508155014_add_task_state_skipped
+        # - 20180515125607_add_task_transition_in_progress_to_cancelled
+        # where we skip the workflow security update to reduce update-time.
         self.update_workflow_security(['opengever_task_workflow'], reindex_security=True)

--- a/opengever/core/upgrades/20181113161333_fix_content_type_for_open_xml_visio/upgrade.py
+++ b/opengever/core/upgrades/20181113161333_fix_content_type_for_open_xml_visio/upgrade.py
@@ -23,6 +23,15 @@ EXTENSION_TO_MIMETYPE = {
 
     # Office Open XML Visio Stencil (macro-enabled)
     '.vssm': 'application/vnd.ms-visio.stencil.macroEnabled.12',
+
+    # The following two extensions has been merged from the former upgradestep
+    # 20180911140637_fix_contenttype_for_ms_publisher_files
+
+    # MS Publisher
+    '.pub': 'application/x-mspublisher',
+
+    # Windows Metafile (WMF)
+    '.wmf': 'image/x-wmf',
 }
 
 

--- a/opengever/core/upgrades/20190424164904_add_a_boolean_index_for_blocked_local_roles/upgrade.py
+++ b/opengever/core/upgrades/20190424164904_add_a_boolean_index_for_blocked_local_roles/upgrade.py
@@ -1,0 +1,16 @@
+from ftw.upgrade import UpgradeStep
+from opengever.dossier.behaviors.dossier import IDossierMarker
+from opengever.repository.interfaces import IRepositoryFolder
+
+
+class AddABooleanIndexForBlockedLocalRoles(UpgradeStep):
+    """Add BooleanIndex for blocked local roles (index only).
+    """
+
+    # An upgradestep which only adds the blocked_local_roles index, if the
+    # index is not already existing. This allows us to register the
+    # blocked_local_roles reindexing as an deferrable upgradestep.
+
+    def __call__(self):
+        if not self.catalog_has_index('blocked_local_roles'):
+            self.catalog_add_index('blocked_local_roles', 'BooleanIndex')


### PR DESCRIPTION
According to the [analysis](https://github.com/4teamwork/opengever.zug/issues/301) we did for the upcoming upgrade in zug, some upgradesteps could be merged or at least marked as deferrable to reduce the upgrade time.

I added my considerations why an optimization is possible in the particular commit message of each commit.