### PR TITLE
Correctly handle dossier deactivation through RESTAPI

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 ---------------------
 
 - Improve error message when trying to delete a referenced document. [njohner]
+- Handle dossier deactivation through RESTAPI. [njohner]
 - Update documentation for SaaS deployment update. [njohner]
 - Extend task API serialization with responses data. [phgross]
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2019.3.0 (unreleased)
 ---------------------
 
+- Handle dossier activation through RESTAPI. [njohner]
 - Improve error message when trying to delete a referenced document. [njohner]
 - Handle dossier deactivation through RESTAPI. [njohner]
 - Update documentation for SaaS deployment update. [njohner]
@@ -13,7 +14,6 @@ Changelog
 2019.2.2 (2019-05-27)
 ---------------------
 
-- Handle dossier activation through RESTAPI. [njohner]
 - Fix revoke_permission field and validation in the fowarding forms. [phgross]
 - Hide byline for the teams. [phgross]
 - Cleanup/fix oneoffix upgradesteps and make dicstorage upgrades more failsafe. [phgross]

--- a/opengever/api/transition.py
+++ b/opengever/api/transition.py
@@ -83,7 +83,7 @@ class GEVERDossierWorkflowTransition(GEVERWorkflowTransition):
             self.request.response.setStatus(400)
             return dict(error=dict(
                 type='PreconditionsViolated',
-                errors=e.errors,
+                errors=map(self.translate, e.errors),
                 message=self.translate(str(e))))
 
         except InvalidDates as e:

--- a/opengever/api/transition.py
+++ b/opengever/api/transition.py
@@ -1,6 +1,7 @@
 from opengever.base.transition import ITransitionExtender
 from opengever.dossier.activate import DossierActivator
 from opengever.dossier.base import DOSSIER_STATE_RESOLVED
+from opengever.dossier.deactivate import DossierDeactivator
 from opengever.dossier.resolve import AlreadyBeingResolved
 from opengever.dossier.resolve import InvalidDates
 from opengever.dossier.resolve import LockingResolveManager
@@ -60,7 +61,8 @@ class GEVERDossierWorkflowTransition(GEVERWorkflowTransition):
     """
 
     CUSTOMIZED_TRANSITIONS = ['dossier-transition-resolve',
-                              'dossier-transition-activate']
+                              'dossier-transition-activate',
+                              'dossier-transition-deactivate']
 
     def reply(self):
         if self.transition not in self.CUSTOMIZED_TRANSITIONS:
@@ -130,6 +132,8 @@ class GEVERDossierWorkflowTransition(GEVERWorkflowTransition):
             self.resolve_dossier(*args)
         elif self.transition == 'dossier-transition-activate':
             self.activate_dossier(*args)
+        elif self.transition == 'dossier-transition-deactivate':
+            self.deactivate_dossier(*args)
         else:
             raise BadRequest('Unexpected custom transition %r' % self.transition)
 
@@ -161,6 +165,15 @@ class GEVERDossierWorkflowTransition(GEVERWorkflowTransition):
                 "feature is activated")
 
         resolve_manager.resolve()
+
+    def deactivate_dossier(self, objs, comment, publication_dates,
+                           include_children=False):
+        # Reject explicit attempts to non-recursively deactivate a dossier
+        if not json_body(self.request).get('include_children', True):
+            raise BadRequest('Deactivating dossier must always be recursive')
+
+        deactivator = DossierDeactivator(self.context)
+        deactivator.deactivate()
 
     def get_latest_wf_action(self):
         history = self.wftool.getInfoFor(self.context, "review_history")

--- a/opengever/dossier/deactivate.py
+++ b/opengever/dossier/deactivate.py
@@ -5,6 +5,15 @@ from opengever.dossier.behaviors.dossier import IDossier
 from plone import api
 from Products.Five.browser import BrowserView
 
+NOT_ALL_CHECKED_IN = _(u"The Dossier can't be deactivated, not all contained"
+                       "documents are checked in.")
+
+CONTAINS_ACTIVE_PROPOSAL = _(u"The Dossier can't be deactivated, it contains"
+                             " active proposals.")
+
+CONTAINS_ACTIVE_TASK = _(u"The Dossier can't be deactivated, not all contained"
+                         " tasks are in a closed state.")
+
 
 class DossierDeactivator(object):
     """Recursively deactivate the dossier and its subdossiers.
@@ -16,9 +25,8 @@ class DossierDeactivator(object):
     * The user has no access to some of the subdossiers.
     * The dossier contains active tasks.
     """
-    def __init__(self, context, request):
+    def __init__(self, context):
         self.context = context
-        self.request = request
 
     def deactivate(self):
         # recursively deactivate all dossiers
@@ -39,19 +47,12 @@ class DossierDeactivator(object):
             IDossier(dossier).end = date.today()
 
     def check_preconditions(self):
-        satisfied = True
-
+        errors = []
         if not self.context.is_all_checked_in():
-            api.portal.show_message(
-                _(u"The Dossier can't be deactivated, not all contained"
-                  "documents are checked in."), self.request, type='error')
-            satisfied = False
+            errors.append(NOT_ALL_CHECKED_IN)
 
         if self.context.has_active_proposals():
-            api.portal.show_message(
-                _(u"The Dossier can't be deactivated, it contains active "
-                  "proposals."), self.request, type='error')
-            satisfied = False
+            errors.append(CONTAINS_ACTIVE_PROPOSAL)
 
         # Check for subdossiers the user cannot deactivate
         for subdossier in self.context.get_subdossiers(unrestricted=True):
@@ -98,32 +99,34 @@ class DossierDeactivator(object):
                         u"The Dossier ${dossier} contains a subdossier which can't be deactivated by the user.",
                         mapping=dict(dossier=parent_title),
                     )
-
-                api.portal.show_message(msg, self.request, type='error')
-                satisfied = False
+                errors.append(msg)
 
         if self.context.has_active_tasks():
-            satisfied = False
-            api.portal.show_message(
-                _(u"The Dossier can't be deactivated, not all contained "
-                  "tasks are in a closed state."),
-                self.request, type='error')
+            errors.append(CONTAINS_ACTIVE_TASK)
 
-        return satisfied
+        return errors
 
 
 class DossierDeactivateView(BrowserView):
 
     def __call__(self):
-        deactivator = DossierDeactivator(self.context, self.request)
-        if not deactivator.check_preconditions():
-            return self.redirect()
+        deactivator = DossierDeactivator(self.context)
+
+        errors = deactivator.check_preconditions()
+        if errors:
+            self.show_errors(errors)
+            self.redirect()
 
         deactivator.deactivate()
         api.portal.show_message(
             _("The Dossier has been deactivated"), self.request, type='info')
 
         return self.redirect()
+
+    def show_errors(self, errors):
+        for msg in errors:
+            api.portal.show_message(
+                message=msg, request=self.request, type='error')
 
     def redirect(self):
         return self.request.RESPONSE.redirect(self.context.absolute_url())

--- a/opengever/dossier/deactivate.py
+++ b/opengever/dossier/deactivate.py
@@ -7,7 +7,7 @@ from plone import api
 from Products.Five.browser import BrowserView
 
 NOT_ALL_CHECKED_IN = _(u"The Dossier can't be deactivated, not all contained"
-                       "documents are checked in.")
+                       " documents are checked in.")
 
 CONTAINS_ACTIVE_PROPOSAL = _(u"The Dossier can't be deactivated, it contains"
                              " active proposals.")

--- a/opengever/dossier/exceptions.py
+++ b/opengever/dossier/exceptions.py
@@ -1,0 +1,7 @@
+
+class PreconditionsViolated(Exception):
+    """One or more preconditions for a workflow transition have been violated.
+    """
+
+    def __init__(self, errors):
+        self.errors = errors

--- a/opengever/dossier/locales/de/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/de/LC_MESSAGES/opengever.dossier.po
@@ -164,7 +164,7 @@ msgid "The Dossier can't be deactivated, not all contained tasks are in a closed
 msgstr "Das Dossier kann nicht storniert werden, da nicht alle enthaltenen Aufgaben abgeschlossen sind."
 
 #: ./opengever/dossier/deactivate.py
-msgid "The Dossier can't be deactivated, not all containeddocuments are checked in."
+msgid "The Dossier can't be deactivated, not all contained documents are checked in."
 msgstr "Das Dossier kann nicht storniert werden, da nicht alle enthaltenen Dokumente eingecheckt sind."
 
 #: ./opengever/dossier/deactivate.py

--- a/opengever/dossier/locales/fr/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/fr/LC_MESSAGES/opengever.dossier.po
@@ -162,7 +162,7 @@ msgid "The Dossier can't be deactivated, not all contained tasks are in a closed
 msgstr "Ce dossier ne peut pas être annulé, il contient encore des tâches non accomplies."
 
 #: ./opengever/dossier/deactivate.py
-msgid "The Dossier can't be deactivated, not all containeddocuments are checked in."
+msgid "The Dossier can't be deactivated, not all contained documents are checked in."
 msgstr "Ce dossier ne peut pas être annulé, parce qu'il contient des documents qui ne sont pas en statut \"checkin\"."
 
 #: ./opengever/dossier/deactivate.py

--- a/opengever/dossier/locales/opengever.dossier.pot
+++ b/opengever/dossier/locales/opengever.dossier.pot
@@ -163,7 +163,7 @@ msgid "The Dossier can't be deactivated, not all contained tasks are in a closed
 msgstr ""
 
 #: ./opengever/dossier/deactivate.py
-msgid "The Dossier can't be deactivated, not all containeddocuments are checked in."
+msgid "The Dossier can't be deactivated, not all contained documents are checked in."
 msgstr ""
 
 #: ./opengever/dossier/deactivate.py

--- a/opengever/dossier/resolve.py
+++ b/opengever/dossier/resolve.py
@@ -13,6 +13,7 @@ from opengever.dossier.base import DOSSIER_STATES_OPEN
 from opengever.dossier.behaviors.dossier import IDossier
 from opengever.dossier.behaviors.dossier import IDossierMarker
 from opengever.dossier.behaviors.filing import IFilingNumberMarker
+from opengever.dossier.exceptions import PreconditionsViolated
 from opengever.dossier.interfaces import IDossierResolveProperties
 from opengever.dossier.interfaces import IDossierResolver
 from opengever.dossier.resolve_lock import ResolveLock
@@ -48,14 +49,6 @@ AFTER_RESOLVE_JOBS_PENDING_KEY = 'opengever.dossier.resolve.after_resolve_jobs_p
 class AlreadyBeingResolved(Exception):
     """A concurrent attempt at resolving a dossier was made.
     """
-
-
-class PreconditionsViolated(Exception):
-    """One or more preconditions for resolving a dossier have been violated.
-    """
-
-    def __init__(self, errors):
-        self.errors = errors
 
 
 class InvalidDates(Exception):

--- a/opengever/dossier/tests/test_deactivate.py
+++ b/opengever/dossier/tests/test_deactivate.py
@@ -50,7 +50,7 @@ class TestDossierDeactivation(IntegrationTestCase):
         self.deactivate(self.resolvable_dossier, browser)
         self.assert_workflow_state('dossier-state-active', self.resolvable_dossier)
         expected_msgs = [u"The Dossier can't be deactivated, not all "
-                         u"containeddocuments are checked in."]
+                         u"contained documents are checked in."]
         self.assert_errors(self.resolvable_dossier, browser, expected_msgs)
 
     @browsing

--- a/opengever/dossier/tests/test_deactivate.py
+++ b/opengever/dossier/tests/test_deactivate.py
@@ -5,6 +5,7 @@ from ftw.builder import create
 from ftw.testbrowser import browsing
 from ftw.testbrowser.pages import editbar
 from ftw.testbrowser.pages import statusmessages
+from ftw.testbrowser.pages.statusmessages import error_messages
 from ftw.testing import freeze
 from opengever.base.role_assignments import RoleAssignmentManager
 from opengever.base.role_assignments import SharingRoleAssignment
@@ -16,56 +17,78 @@ from plone import api
 
 class TestDossierDeactivation(IntegrationTestCase):
 
+    def deactivate(self, dossier, browser, use_editbar=False):
+        if use_editbar:
+            browser.open(dossier)
+            editbar.menu_option('Actions', 'dossier-transition-deactivate').click()
+        else:
+            browser.open(dossier, view='transition-deactivate',
+                         send_authenticator=True)
+
+    def assert_errors(self, dossier, browser, error_msgs):
+        self.assertEquals(dossier.absolute_url(), browser.url)
+        self.assertEquals(error_msgs, error_messages())
+
+    def assert_end_date(self, dossier, end_date):
+        self.assertEqual(end_date, IDossier(dossier).end)
+
     @browsing
     def test_fails_with_resolved_subdossier(self, browser):
         self.login(self.dossier_responsible, browser)
         self.set_workflow_state('dossier-state-resolved', self.subdossier)
-        browser.open(self.dossier, view='transition-deactivate',
-                     send_authenticator=True)
+        self.deactivate(self.dossier, browser)
         self.assert_workflow_state('dossier-state-active', self.dossier)
-        statusmessages.assert_message(
-            u"The Dossier can\'t be deactivated,"
-            u" the subdossier 2016 is already resolved.")
+        expected_msgs = [u"The Dossier can't be deactivated, it contains "
+                         u"active proposals.",
+                         u"The Dossier can\'t be deactivated, the subdossier"
+                         u" 2016 is already resolved.",
+                         u"The Dossier can't be deactivated, not all contained"
+                         u" tasks are in a closed state."]
+        self.assert_errors(self.dossier, browser, expected_msgs)
 
     @browsing
     def test_fails_with_checked_out_documents(self, browser):
         self.login(self.dossier_responsible, browser)
         self.checkout_document(self.document)
-        browser.open(self.dossier, view='transition-deactivate',
-                     send_authenticator=True)
+        self.deactivate(self.dossier, browser)
         self.assert_workflow_state('dossier-state-active', self.dossier)
-        statusmessages.assert_message(
-            u"The Dossier can't be deactivated, not all containeddocuments"
-            u" are checked in.")
+        expected_msgs = [u"The Dossier can't be deactivated, not all "
+                         u"containeddocuments are checked in.",
+                         u"The Dossier can't be deactivated, it contains "
+                         u"active proposals.",
+                         u"The Dossier can't be deactivated, not all contained"
+                         u" tasks are in a closed state."]
+        self.assert_errors(self.dossier, browser, expected_msgs)
 
     @browsing
     def test_not_possible_with_not_closed_tasks(self, browser):
         self.login(self.dossier_responsible, browser)
         self.assert_workflow_state('task-state-in-progress', self.task)
-        browser.open(self.dossier, view='transition-deactivate',
-                     send_authenticator=True)
+        self.deactivate(self.dossier, browser)
         self.assert_workflow_state('dossier-state-active', self.dossier)
-        statusmessages.assert_message(
-            u"The Dossier can't be deactivated, not all contained"
-            u" tasks are in a closed state.")
+        expected_msgs = [u"The Dossier can't be deactivated, it contains "
+                         u"active proposals.",
+                         u"The Dossier can't be deactivated, not all contained"
+                         u" tasks are in a closed state."]
+        self.assert_errors(self.dossier, browser, expected_msgs)
 
     @browsing
     def test_not_possible_with_active_proposals(self, browser):
         self.login(self.dossier_responsible, browser)
         self.assert_workflow_state('proposal-state-active', self.draft_proposal)
-        browser.open(self.dossier, view='transition-deactivate',
-                     send_authenticator=True)
+        self.deactivate(self.dossier, browser)
         self.assert_workflow_state('dossier-state-active', self.dossier)
-        statusmessages.assert_message(
-            u"The Dossier can't be deactivated,"
-            u" not all contained tasks are in a closed state.")
+        expected_msgs = [u"The Dossier can't be deactivated, it contains "
+                         u"active proposals.",
+                         u"The Dossier can't be deactivated, not all contained"
+                         u" tasks are in a closed state."]
+        self.assert_errors(self.dossier, browser, expected_msgs)
 
     @browsing
     def test_recursively_deactivate_subdossier(self, browser):
         self.login(self.secretariat_user, browser)
         subdossier = create(Builder('dossier').within(self.empty_dossier))
-        browser.open(self.empty_dossier)
-        editbar.menu_option('Actions', 'dossier-transition-deactivate').click()
+        self.deactivate(self.empty_dossier, browser, use_editbar=True)
         statusmessages.assert_no_error_messages()
         self.assert_workflow_state('dossier-state-inactive', self.empty_dossier)
         self.assert_workflow_state('dossier-state-inactive', subdossier)
@@ -75,8 +98,7 @@ class TestDossierDeactivation(IntegrationTestCase):
         self.login(self.secretariat_user, browser)
         subdossier = create(Builder('dossier').within(self.empty_dossier)
                             .in_state('dossier-state-inactive'))
-        browser.open(self.empty_dossier)
-        editbar.menu_option('Actions', 'dossier-transition-deactivate').click()
+        self.deactivate(self.empty_dossier, browser, use_editbar=True)
         statusmessages.assert_no_error_messages()
         self.assert_workflow_state('dossier-state-inactive', self.empty_dossier)
         self.assert_workflow_state('dossier-state-inactive', subdossier)
@@ -85,10 +107,9 @@ class TestDossierDeactivation(IntegrationTestCase):
     def test_sets_end_date_to_current_date(self, browser):
         self.login(self.secretariat_user, browser)
         with freeze(datetime(2016, 3, 29)):
-            browser.open(self.empty_dossier)
-            editbar.menu_option('Actions', 'dossier-transition-deactivate').click()
+            self.deactivate(self.empty_dossier, browser, use_editbar=True)
 
-        self.assertEqual(date(2016, 3, 29), IDossier(self.empty_dossier).end)
+        self.assert_end_date(self.empty_dossier, date(2016, 3, 29))
 
     @browsing
     def test_subdossiers_the_user_cannot_view_can_also_block_deactivation(self, browser):
@@ -110,5 +131,7 @@ class TestDossierDeactivation(IntegrationTestCase):
                 SharingRoleAssignment(self.regular_user.getId(), ['Reader', 'Contributor', 'Editor']))
 
         self.login(self.regular_user, browser)
-        browser.open(self.subdossier, view='transition-deactivate', send_authenticator=True)
-        statusmessages.assert_message("The Dossier 2016 contains a subdossier which can't be deactivated by the user.")
+        self.deactivate(self.subdossier, browser)
+        expected_msgs = [u"The Dossier 2016 contains a subdossier "
+                         u"which can't be deactivated by the user."]
+        self.assert_errors(self.subdossier, browser, expected_msgs)


### PR DESCRIPTION
We add the RESTAPI endpoint to properly handle the deactivate dossier transition. As for dossier resolution, the transition is handled by custom transition handler. We do not need to use a `TransitionExtender` here, as there are no jobs that need to be executed after transition to the inactive state.

I refactored the tests of the dossier deactivate transition to allow for easier code reuse and have the same tests for the transition via browser or via RESTAPI.

I also added a test that trying to resolve a dossier non-recursively through the RESTAPI is not allowed. It seemed that this was not tested, or at least I did not find a test for it. 

This is part of https://github.com/4teamwork/opengever.core/issues/5432