### PR TITLE
 Nightly jobs: Log all output to a dedicated self-rotating logfile.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2019.2.0 (unreleased)
 ---------------------
 
+- Log nightly job output to a dedicated, self-rotating logfile. [lgraf]
 - Add flag to force execution of nightly jobs. [njohner]
 - Implement nightly job to perform jobs after dossier resolution. [lgraf]
 - Bump plone.restapi to 3.9.0. [phgross]

--- a/opengever/dossier/tests/test_resolve.py
+++ b/opengever/dossier/tests/test_resolve.py
@@ -30,6 +30,7 @@ from plone.protect import createToken
 from plone.uuid.interfaces import IUUID
 from zope.component import getUtility
 from zope.schema.interfaces import IVocabularyFactory
+import logging
 import pytz
 
 
@@ -598,8 +599,11 @@ class TestResolveJobsNightly(NightlyResolveJobsTestHelper, TestResolveJobs):
         """Run all pending after resolve nightly jobs, and assert on the
         number of jobs.
         """
+        null_logger = logging.getLogger('opengever.nightlyjobs')
+        null_logger.addHandler(logging.NullHandler())
+
         nightly_job_provider = ExecuteNightlyAfterResolveJobs(
-            self.portal, self.request)
+            self.portal, self.request, null_logger)
 
         jobs = list(nightly_job_provider)
         if expected:

--- a/opengever/nightlyjobs/cronjobs.py
+++ b/opengever/nightlyjobs/cronjobs.py
@@ -102,7 +102,11 @@ def invoke_nightly_job_runner(plone_site, force, logger):
 
     setup_language(plone_site)
 
-    runner = NightlyJobRunner(setup_own_task_queue=True, force_execution=force)
+    runner = NightlyJobRunner(
+        setup_own_task_queue=True,
+        force_execution=force,
+        logger=logger)
+
     logger.info('Found {} providers: {}'.format(len(runner.job_providers),
                                                 runner.job_providers.keys()))
     logger.info('Number of jobs: {}'.format(runner.get_initial_jobs_count()))

--- a/opengever/nightlyjobs/testing.py
+++ b/opengever/nightlyjobs/testing.py
@@ -20,5 +20,5 @@ class TestingNightlyJobRunner(NightlyJobRunner):
 
     def get_job_providers(self):
         return {name: provider for name, provider
-                in getAdapters([api.portal.get(), getRequest()],
+                in getAdapters([api.portal.get(), getRequest(), self.log],
                                ITestingNightlyJobProvider)}

--- a/opengever/nightlyjobs/tests/test_nightly_job_runner.py
+++ b/opengever/nightlyjobs/tests/test_nightly_job_runner.py
@@ -15,20 +15,22 @@ from Products.CMFPlone.interfaces import IPloneSiteRoot
 from zope.component import adapter
 from zope.interface import alsoProvides
 from zope.publisher.interfaces.browser import IBrowserRequest
+import logging
 
 
-@adapter(IPloneSiteRoot, IBrowserRequest)
+@adapter(IPloneSiteRoot, IBrowserRequest, logging.Logger)
 class DossierTitleModifierJobProvider(DocumentTitleModifierJobProvider):
 
     portal_type = 'opengever.dossier.businesscasedossier'
     provider_name = 'dossier-title'
 
 
-@adapter(IPloneSiteRoot, IOpengeverBaseLayer)
+@adapter(IPloneSiteRoot, IOpengeverBaseLayer, logging.Logger)
 class TickingDocumentTitleModifierJobProvider(DocumentTitleModifierJobProvider):
 
-    def __init__(self, context, request):
-        super(TickingDocumentTitleModifierJobProvider, self).__init__(context, request)
+    def __init__(self, context, request, logger):
+        super(TickingDocumentTitleModifierJobProvider, self).__init__(
+            context, request, logger)
         self.clock = self.request.clock
 
     def run_job(self, job, interrupt_if_necessary):


### PR DESCRIPTION
Nightly jobs: Log all output to a dedicated self-rotating logfile in `var/log/nightly-jobs.log`.

In order to accomplish that, we set up the logger appropriately in the cronjob wrapper (in other context, a logfile handler would already be present). That properly configured logger then gets passed to the providers by having them adapt a third discriminator, `logging.Logger` (i.e., an instance of the Python stdlib `Logger` class).