### PR TITLE
 Trash: Update and reindex modification date when trashing documents.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2019.2.0 (unreleased)
 ---------------------
 
+- Trash: Update and reindex modification date when trashing documents. [lgraf]
 - Add file_extension indexer for mails. [phgross]
 - Fix upgrade step adding document_type index to not update the metadata. [njohner]
 - Log nightly job output to a dedicated, self-rotating logfile. [lgraf]

--- a/opengever/api/tests/test_search.py
+++ b/opengever/api/tests/test_search.py
@@ -1,0 +1,79 @@
+from ftw.testbrowser import browsing
+from opengever.testing import IntegrationTestCase
+from opengever.trash.trash import Trasher
+from plone import api
+from urllib import urlencode
+
+
+class TestSearchEndpoint(IntegrationTestCase):
+
+    api_headers = {'Accept': 'application/json'}
+
+    def search_catalog(self, context, query):
+        catalog = api.portal.get_tool('portal_catalog')
+        path = '/'.join(context.getPhysicalPath())
+        query['path'] = path
+        return [b.getURL() for b in catalog(query)]
+
+    def search_restapi(self, browser, context, query):
+        browser.open(
+            context,
+            view='@search?%s' % urlencode(query),
+            headers=self.api_headers)
+        return [item['@id'] for item in browser.json['items']]
+
+    @browsing
+    def test_able_to_search_for_trashed_docs(self, browser):
+        self.login(self.regular_user, browser)
+
+        doc_url = self.document.absolute_url()
+
+        # Guard assertion - both direct catalog searches and REST API
+        # should give the same results with no trashed documents
+        catalog_results = self.search_catalog(
+            self.dossier,
+            dict(sort_on='path',
+                 portal_type='opengever.document.document'))
+
+        api_results = self.search_restapi(
+            browser, self.dossier,
+            dict(sort_on='path',
+                 portal_type='opengever.document.document'))
+
+        self.assertIn(doc_url, catalog_results)
+        self.assertIn(doc_url, api_results)
+        self.assertEqual(catalog_results, api_results)
+
+        # Trash self.document - should now disappear from regular results
+        Trasher(self.document).trash()
+
+        catalog_results = self.search_catalog(
+            self.dossier,
+            dict(sort_on='path',
+                 portal_type='opengever.document.document'))
+
+        api_results = self.search_restapi(
+            browser, self.dossier,
+            dict(sort_on='path',
+                 portal_type='opengever.document.document'))
+
+        self.assertNotIn(doc_url, catalog_results)
+        self.assertNotIn(doc_url, api_results)
+        self.assertEqual(catalog_results, api_results)
+
+        # But trashed docs can still be searched for explicitly, both
+        # directly via catalog and the REST API @search endpoint
+        catalog_results = self.search_catalog(
+            self.dossier,
+            dict(sort_on='path',
+                 portal_type='opengever.document.document',
+                 trashed=True))
+
+        api_results = self.search_restapi(
+            browser, self.dossier,
+            {'sort_on': 'path',
+             'portal_type': 'opengever.document.document',
+             'trashed:boolean': '1'})
+
+        self.assertEqual([doc_url], catalog_results)
+        self.assertEqual([doc_url], api_results)

--- a/opengever/base/monkey/patches/filter_trashed_from_catalog.py
+++ b/opengever/base/monkey/patches/filter_trashed_from_catalog.py
@@ -14,8 +14,13 @@ class PatchCatalogToFilterTrashedDocs(MonkeyPatch):
 
         def filtered_results(self, REQUEST=None, **kw):
             kw = kw.copy()
-            if 'trashed' not in kw.keys():
+
+            # If no explicit query for 'trashed' present, filter out trashed
+            # documents by default. REQUEST may be old-style ZCatalog query.
+            if not ('trashed' in kw.keys() or
+                    (REQUEST and 'trashed' in REQUEST)):
                 kw['trashed'] = [False, None]
+
             return original_search_results(self, REQUEST, **kw)
 
         self.patch_refs(CatalogTool, 'searchResults', filtered_results)

--- a/opengever/testing/helpers.py
+++ b/opengever/testing/helpers.py
@@ -112,7 +112,7 @@ def obj2brain(obj, unrestricted=False):
 
 def index_data_for(obj):
     catalog = getToolByName(obj, 'portal_catalog')
-    return catalog.getIndexDataForRID(obj2brain(obj).getRID())
+    return catalog.getIndexDataForRID(obj2brain(obj, unrestricted=True).getRID())
 
 
 def set_preferred_language(request, code):

--- a/opengever/trash/tests/test_catalog.py
+++ b/opengever/trash/tests/test_catalog.py
@@ -1,4 +1,8 @@
+from datetime import datetime
+from ftw.testing import freeze
 from opengever.testing import IntegrationTestCase
+from opengever.testing.helpers import index_data_for
+from opengever.trash.trash import Trasher
 from plone import api
 
 
@@ -6,3 +10,43 @@ class TestCatalog(IntegrationTestCase):
 
     def test_trashed_index_registered(self):
         self.assertIn('trashed', api.portal.get_tool('portal_catalog').indexes())
+
+    def test_modified_index_gets_updated_when_trashing(self):
+        self.login(self.regular_user)
+
+        with freeze(datetime(2014, 5, 7, 12, 30)) as clock:
+            Trasher(self.subsubdocument).trash()
+            clock.forward(minutes=5)
+
+            Trasher(self.taskdocument).trash()
+            clock.forward(minutes=5)
+
+            Trasher(self.document).trash()
+            clock.forward(minutes=5)
+
+            Trasher(self.subdocument).trash()
+
+        catalog = api.portal.get_tool('portal_catalog')
+        modified_idx = catalog._catalog.indexes['modified']
+
+        def modified_idx_value(obj):
+            return index_data_for(obj)['modified']
+
+        def to_idx_value(value):
+            return modified_idx._convert(value)
+
+        self.assertEqual(
+            to_idx_value(datetime(2014, 5, 7, 12, 30)),
+            modified_idx_value(self.subsubdocument))
+
+        self.assertEqual(
+            to_idx_value(datetime(2014, 5, 7, 12, 35)),
+            modified_idx_value(self.taskdocument))
+
+        self.assertEqual(
+            to_idx_value(datetime(2014, 5, 7, 12, 40)),
+            modified_idx_value(self.document))
+
+        self.assertEqual(
+            to_idx_value(datetime(2014, 5, 7, 12, 45)),
+            modified_idx_value(self.subdocument))

--- a/opengever/trash/trash.py
+++ b/opengever/trash/trash.py
@@ -101,7 +101,8 @@ class Trasher(object):
         notify(UntrashedEvent(self.context))
 
     def reindex(self):
-        self.context.reindexObject(idxs=['trashed', 'object_provides'])
+        self.context.setModificationDate()
+        self.context.reindexObject(idxs=['trashed', 'object_provides', 'modified'])
 
     def verify_is_not_already_trashed(self):
         if ITrashed.providedBy(self.context):


### PR DESCRIPTION
In order to be able to query for recently trashed documents from RIS, we need to make sure that
- **Our automatic `trashed` filter can be overridden**.
  So our patch must only inject the filter for non-trashed docs if a query against the `trashed` index isn't already present (by looking at both `REQUEST` and `kw` in the patched `searchResults()`)
- the **modification date is updated and indexed** correctly

With these in place, a query via the REST API like this works:
```http
GET .../dossier-43/@search?portal_type=opengever.document.document&trashed:boolean=True
```

(Because `trashed` in GEVER is a `FieldIndex` and not a `BooleanIndex`, `plone.restapi` can't automatically cast the query arguments. Therefore a [ZPublisher type hint](https://zope.readthedocs.io/en/latest/zdgbook/ObjectPublishing.html#argument-conversion) like `trashed:boolean` needs to be used).

/cc @jone