### PR TITLE
When adding document_type index we do not need to update metadata.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2019.2.0 (unreleased)
 ---------------------
 
+- Fix upgrade step adding document_type index to not update the metadata. [njohner]
 - Log nightly job output to a dedicated, self-rotating logfile. [lgraf]
 - Add flag to force execution of nightly jobs. [njohner]
 - Fix task activity tests. [njohner]

--- a/opengever/core/upgrades/20190409141826_add_document_type_index/upgrade.py
+++ b/opengever/core/upgrades/20190409141826_add_document_type_index/upgrade.py
@@ -1,5 +1,9 @@
+from collective.indexing.interfaces import IIndexQueueProcessor
+from collective.indexing.queue import getQueue
 from ftw.upgrade import UpgradeStep
 from opengever.document.behaviors import IBaseDocument
+from plone import api
+from zope.component import getUtility
 
 
 class AddDocumentTypeIndex(UpgradeStep):
@@ -9,6 +13,10 @@ class AddDocumentTypeIndex(UpgradeStep):
     deferrable = True
 
     def __call__(self):
+        getQueue().hook()
+        processor = getUtility(IIndexQueueProcessor, name='ftw.solr')
+        catalog = api.portal.get_tool('portal_catalog')
+
         if not self.catalog_has_index('document_type'):
             self.catalog_add_index('document_type', 'FieldIndex')
 
@@ -16,4 +24,7 @@ class AddDocumentTypeIndex(UpgradeStep):
             'object_provides': IBaseDocument.__identifier__,
             }
 
-        self.catalog_reindex_objects(query, idxs=['document_type'])
+        for obj in self.objects(query, "Index document type."):
+            catalog.reindexObject(obj, idxs=['document_type'],
+                                  update_metadata=False)
+            processor.index(obj, ['document_type'])


### PR DESCRIPTION
`document_type` is only an index and not in the metadata, but is also indexed in solr. We therefore do not need to update the metadata, but need to explicitly index it in solr.

resolves #5612 