### PR TITLE
Add file_extension indexer for mails.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2019.2.0 (unreleased)
 ---------------------
 
+- Add file_extension indexer for mails. [phgross]
 - Fix upgrade step adding document_type index to not update the metadata. [njohner]
 - Log nightly job output to a dedicated, self-rotating logfile. [lgraf]
 - Add flag to force execution of nightly jobs. [njohner]

--- a/opengever/core/upgrades/20190506084117_reindex_file_extension_for_mails/upgrade.py
+++ b/opengever/core/upgrades/20190506084117_reindex_file_extension_for_mails/upgrade.py
@@ -1,0 +1,14 @@
+from ftw.mail.mail import IMail
+from ftw.upgrade import UpgradeStep
+
+
+class ReindexFileExtensionForMails(UpgradeStep):
+    """Reindex file_extension for mails.
+    """
+
+    deferrable = True
+
+    def __call__(self):
+        query = {'object_provides': IMail.__identifier__}
+        for obj in self.objects(query, 'Reindex file extension'):
+            obj.reindexObject(idxs=['file_extension'])

--- a/opengever/document/indexers.py
+++ b/opengever/document/indexers.py
@@ -219,8 +219,13 @@ def filename(obj):
     return u''
 
 
-@indexer(IDocumentSchema)
+@indexer(IBaseDocument)
 def file_extension(obj):
+    """file_extension indexer for documents and mails.
+    For document it returns the extension of the file for mails it returns the
+    extension of the original_message file if exists.
+    """
+
     filename = obj.get_filename()
     if filename:
         # We should not rely on the normalization to have happened

--- a/opengever/mail/tests/test_indexers.py
+++ b/opengever/mail/tests/test_indexers.py
@@ -57,3 +57,11 @@ class TestMailIndexers(IntegrationTestCase):
         self.login(self.regular_user)
         extender = getAdapter(self.mail_eml, IDynamicTextIndexExtender, u'IDocumentSchema')
         self.assertEqual('Client1 1.1 / 1 / 29 29', extender())
+
+    def test_file_extension_uses_extension_of_original_message_if_exists(self):
+        self.login(self.regular_user)
+
+        self.assertEqual('.msg',
+                         index_data_for(self.mail_msg).get('file_extension'))
+        self.assertEqual('.eml',
+                         index_data_for(self.mail_eml).get('file_extension'))


### PR DESCRIPTION
The indexer uses the file_extension of the original_message, if exists.

Provides a deferrable upgradestep which reindexes the file_extension for all mails.

Closes #5623.