### PR TITLE
Correctly handle dossier activation through RESTAPI

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -10,6 +10,7 @@ Changelog
 2019.2.2 (2019-05-27)
 ---------------------
 
+- Handle dossier activation through RESTAPI. [njohner]
 - Fix revoke_permission field and validation in the fowarding forms. [phgross]
 - Hide byline for the teams. [phgross]
 - Cleanup/fix oneoffix upgradesteps and make dicstorage upgrades more failsafe. [phgross]

--- a/opengever/dossier/activate.py
+++ b/opengever/dossier/activate.py
@@ -7,27 +7,10 @@ MAIN_DOSSIER_ACTIVE = _("This subdossier can't be activated,"
                         "because the main dossiers is inactive")
 
 
-class DossierActivateView(BrowserView):
-    """View which activates the dossier including its subdossiers."""
+class DossierActivator(object):
 
-    def __call__(self):
-        errors = self.check_preconditions()
-        if errors:
-            self.show_errors(errors)
-            return self.redirect()
-
-        self.activate()
-        api.portal.show_message(_("The Dossier has been activated"),
-                                self.request, type='info')
-        return self.redirect()
-
-    def show_errors(self, errors):
-        for msg in errors:
-            api.portal.show_message(
-                message=msg, request=self.request, type='error')
-
-    def redirect(self):
-        return self.request.RESPONSE.redirect(self.context.absolute_url())
+    def __init__(self, context):
+        self.context = context
 
     def check_preconditions(self):
         errors = []
@@ -44,3 +27,27 @@ class DossierActivateView(BrowserView):
 
         # main dossier
         self.context.activate()
+
+
+class DossierActivateView(BrowserView):
+    """View which activates the dossier including its subdossiers."""
+
+    def __call__(self):
+        activator = DossierActivator(self.context)
+        errors = activator.check_preconditions()
+        if errors:
+            self.show_errors(errors)
+            return self.redirect()
+
+        activator.activate()
+        api.portal.show_message(_("The Dossier has been activated"),
+                                self.request, type='info')
+        return self.redirect()
+
+    def show_errors(self, errors):
+        for msg in errors:
+            api.portal.show_message(
+                message=msg, request=self.request, type='error')
+
+    def redirect(self):
+        return self.request.RESPONSE.redirect(self.context.absolute_url())

--- a/opengever/dossier/activate.py
+++ b/opengever/dossier/activate.py
@@ -4,8 +4,8 @@ from plone import api
 from Products.Five.browser import BrowserView
 
 
-MAIN_DOSSIER_ACTIVE = _("This subdossier can't be activated,"
-                        "because the main dossiers is inactive")
+MAIN_DOSSIER_ACTIVE = _("This subdossier can't be activated, "
+                        "because the main dossiers is not active")
 
 
 class DossierActivator(object):
@@ -17,7 +17,7 @@ class DossierActivator(object):
         errors = []
         if self.context.is_subdossier():
             state = api.content.get_state(self.context.get_parent_dossier())
-            if state == 'dossier-state-inactive':
+            if state != 'dossier-state-active':
                 errors.append(MAIN_DOSSIER_ACTIVE)
         return errors
 

--- a/opengever/dossier/activate.py
+++ b/opengever/dossier/activate.py
@@ -1,29 +1,41 @@
 from opengever.dossier import _
 from plone import api
 from Products.Five.browser import BrowserView
-from Products.statusmessages.interfaces import IStatusMessage
+
+
+MAIN_DOSSIER_ACTIVE = _("This subdossier can't be activated,"
+                        "because the main dossiers is inactive")
 
 
 class DossierActivateView(BrowserView):
     """View which activates the dossier including its subdossiers."""
 
     def __call__(self):
-        if self.check_preconditions():
-            self.activate()
+        errors = self.check_preconditions()
+        if errors:
+            self.show_errors(errors)
+            return self.redirect()
 
+        self.activate()
+        api.portal.show_message(_("The Dossier has been activated"),
+                                self.request, type='info')
+        return self.redirect()
+
+    def show_errors(self, errors):
+        for msg in errors:
+            api.portal.show_message(
+                message=msg, request=self.request, type='error')
+
+    def redirect(self):
         return self.request.RESPONSE.redirect(self.context.absolute_url())
 
     def check_preconditions(self):
-        satisfied = True
+        errors = []
         if self.context.is_subdossier():
             state = api.content.get_state(self.context.get_parent_dossier())
             if state == 'dossier-state-inactive':
-                satisfied = False
-                IStatusMessage(self.request).add(
-                    _("This subdossier can't be activated,"
-                      "because the main dossiers is inactive"), type='error')
-
-        return satisfied
+                errors.append(MAIN_DOSSIER_ACTIVE)
+        return errors
 
     def activate(self):
         # subdossiers
@@ -32,6 +44,3 @@ class DossierActivateView(BrowserView):
 
         # main dossier
         self.context.activate()
-
-        IStatusMessage(self.request).add(_("The Dossier has been activated"),
-                                         type='info')

--- a/opengever/dossier/locales/de/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/de/LC_MESSAGES/opengever.dossier.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2019-04-28 14:26+0000\n"
+"POT-Creation-Date: 2019-05-29 07:53+0000\n"
 "PO-Revision-Date: 2017-05-23 04:53+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: German <https://translations.onegovgever.ch/projects/onegov-gever/opengever-dossier/de/>\n"
@@ -224,8 +224,8 @@ msgid "The subdossier has been succesfully resolved."
 msgstr "Das Subdossier wurde erfolgreich abgeschlossen."
 
 #: ./opengever/dossier/activate.py
-msgid "This subdossier can't be activated,because the main dossiers is inactive"
-msgstr "Dieses Subdossier kann nicht wieder aktiviert werden, da das Hauptdossier storniert ist."
+msgid "This subdossier can't be activated, because the main dossiers is not active"
+msgstr "Dieses Subdossier kann nicht wieder aktiviert werden, da das Hauptdossier nicht aktiv ist."
 
 #: ./opengever/dossier/resolve.py
 msgid "Updated with a newer generated version from dossier ${title}."

--- a/opengever/dossier/locales/fr/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/fr/LC_MESSAGES/opengever.dossier.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-04-28 14:26+0000\n"
+"POT-Creation-Date: 2019-05-29 07:53+0000\n"
 "PO-Revision-Date: 2017-12-03 11:16+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-dossier/fr/>\n"
@@ -222,8 +222,8 @@ msgid "The subdossier has been succesfully resolved."
 msgstr "Le sous-dossier a été clôturé avec succès."
 
 #: ./opengever/dossier/activate.py
-msgid "This subdossier can't be activated,because the main dossiers is inactive"
-msgstr "Ce sous-dossier ne peut pas être réactivé, parce que le dossier principal a été annulé."
+msgid "This subdossier can't be activated, because the main dossiers is not active"
+msgstr "Ce sous-dossier ne peut pas être réactivé, parce que le dossier principal n'est pas actif."
 
 #: ./opengever/dossier/resolve.py
 msgid "Updated with a newer generated version from dossier ${title}."

--- a/opengever/dossier/locales/opengever.dossier.pot
+++ b/opengever/dossier/locales/opengever.dossier.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-04-28 14:26+0000\n"
+"POT-Creation-Date: 2019-05-29 07:53+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -223,7 +223,7 @@ msgid "The subdossier has been succesfully resolved."
 msgstr ""
 
 #: ./opengever/dossier/activate.py
-msgid "This subdossier can't be activated,because the main dossiers is inactive"
+msgid "This subdossier can't be activated, because the main dossiers is not active"
 msgstr ""
 
 #: ./opengever/dossier/resolve.py

--- a/opengever/dossier/tests/test_activate.py
+++ b/opengever/dossier/tests/test_activate.py
@@ -69,24 +69,16 @@ class TestDossierActivation(IntegrationTestCase):
 
     @browsing
     def test_end_date_is_reindexed(self, browser):
-        enddate = date(2013, 2, 21)
+        self.login(self.secretariat_user, browser)
+        enddate = date(2016, 12, 31)
         enddate_index_value = self.dateindex_value_from_datetime(enddate)
 
-        self.login(self.secretariat_user, browser)
-        IDossier(self.subsubdossier).end = enddate
-        self.subsubdossier.reindexObject(idxs=['end'])
+        self.assertEqual(enddate, IDossier(self.inactive_dossier).end)
+        self.assert_index_value(enddate_index_value, 'end', self.inactive_dossier)
+        self.assert_metadata_value(enddate, 'end', self.inactive_dossier)
 
-        self.set_workflow_state(
-            'dossier-state-inactive',
-            self.subsubdossier,
-            )
-
-        self.assertEqual(enddate, IDossier(self.subsubdossier).end)
-        self.assert_index_value(enddate_index_value, 'end', self.subsubdossier)
-        self.assert_metadata_value(enddate, 'end', self.subsubdossier)
-
-        browser.open(self.subsubdossier)
+        browser.open(self.inactive_dossier)
         editbar.menu_option('Actions', 'dossier-transition-activate').click()
 
-        self.assert_index_value('', 'end', self.subsubdossier)
-        self.assert_metadata_value(None, 'end', self.subsubdossier)
+        self.assert_index_value('', 'end', self.inactive_dossier)
+        self.assert_metadata_value(None, 'end', self.inactive_dossier)

--- a/opengever/dossier/tests/test_activate.py
+++ b/opengever/dossier/tests/test_activate.py
@@ -57,13 +57,26 @@ class TestDossierActivation(IntegrationTestCase):
             self, browser):
         self.login(self.secretariat_user, browser)
         self.set_workflow_state('dossier-state-inactive',
-                                self.dossier, self.subdossier)
+                                self.dossier, self.subdossier2)
 
-        self.activate(self.subdossier, browser)
-        self.assert_errors(self.subdossier, browser,
-                           ["This subdossier can't be activated,"
-                            "because the main dossiers is inactive"])
-        self.assert_workflow_state('dossier-state-inactive', self.subdossier)
+        self.activate(self.subdossier2, browser)
+        self.assert_errors(self.subdossier2, browser,
+                           ["This subdossier can't be activated, "
+                            "because the main dossiers is not active"])
+        self.assert_workflow_state('dossier-state-inactive', self.subdossier2)
+
+    @browsing
+    def test_activate_subdossier_is_disallowed_when_main_dossier_is_resolved(
+            self, browser):
+        self.login(self.secretariat_user, browser)
+        self.set_workflow_state('dossier-state-inactive', self.subdossier2)
+        self.set_workflow_state('dossier-state-resolved', self.dossier)
+
+        self.activate(self.subdossier2, browser)
+        self.assert_errors(self.subdossier2, browser,
+                           ["This subdossier can't be activated, "
+                            "because the main dossiers is not active"])
+        self.assert_workflow_state('dossier-state-inactive', self.subdossier2)
 
     @browsing
     def test_resets_end_dates_recursively(self, browser):


### PR DESCRIPTION
In the same spirits as the other PRs for #5432:
* We add the RESTAPI endpoint to properly handle the activate dossier transition.
* I refactored the tests of the dossier activate transition to allow for easier code reuse and have the same tests for the transition via browser or via RESTAPI.

This is part of https://github.com/4teamwork/opengever.core/issues/5432