### PR TITLE
Correctly handle dossier reactivation through RESTAPI

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -8,6 +8,7 @@ Changelog
 - Improve error message when trying to delete a referenced document. [njohner]
 - Handle dossier deactivation through RESTAPI. [njohner]
 - Update documentation for SaaS deployment update. [njohner]
+- Correctly handle dossier reactivation through RESTAPI. [njohner]
 - Extend task API serialization with responses data. [phgross]
 
 

--- a/opengever/dossier/reactivate.py
+++ b/opengever/dossier/reactivate.py
@@ -1,8 +1,11 @@
 from opengever.dossier import _
 from opengever.dossier.base import DOSSIER_STATES_OPEN
 from opengever.dossier.behaviors.dossier import IDossier
+from plone import api
 from Products.CMFCore.utils import getToolByName
 from Products.Five.browser import BrowserView
+
+MSG_SUBDOSSIER = _("It isn't possible to reactivate a sub dossier.")
 
 
 class Reactivator(object):
@@ -11,15 +14,16 @@ class Reactivator(object):
         self.context = context
         self.wft = getToolByName(self.context, 'portal_workflow')
 
-    def is_reactivate_possible(self):
+    def get_precondition_violations(self):
+        errors = []
         parent = self.context.get_parent_dossier()
         if parent:
             if self.wft.getInfoFor(parent, 'review_state') not in DOSSIER_STATES_OPEN:
-                return False
-        return True
+                errors.append(MSG_SUBDOSSIER)
+        return errors
 
     def reactivate(self):
-        if not self.is_reactivate_possible():
+        if self.get_precondition_violations():
             raise TypeError
         self._recursive_reactivate(self.context)
 
@@ -41,18 +45,23 @@ class Reactivator(object):
 class DossierReactivateView(BrowserView):
 
     def __call__(self):
-        ptool = getToolByName(self, 'plone_utils')
-
         reactivator = Reactivator(self.context)
 
         # check preconditions
-        if reactivator.is_reactivate_possible():
-            reactivator.reactivate()
-            ptool.addPortalMessage(_('Dossiers successfully reactivated.'),
-                                   type="info")
-            self.request.RESPONSE.redirect(self.context.absolute_url())
-        else:
-            ptool.addPortalMessage(
-                _("It isn't possible to reactivate a sub dossier."),
-                type="warning")
-            self.request.RESPONSE.redirect(self.context.absolute_url())
+        errors = reactivator.get_precondition_violations()
+        if errors:
+            return self.show_errors(errors)
+
+        reactivator.reactivate()
+        api.portal.show_message(message=_('Dossiers successfully reactivated.'),
+                                request=self.request, type='info')
+        return self.redirect()
+
+    def redirect(self):
+        return self.request.RESPONSE.redirect(self.context.absolute_url())
+
+    def show_errors(self, errors):
+        for msg in errors:
+            api.portal.show_message(
+                message=msg, request=self.request, type='warning')
+        return self.redirect()

--- a/opengever/dossier/reactivate.py
+++ b/opengever/dossier/reactivate.py
@@ -23,8 +23,6 @@ class Reactivator(object):
         return errors
 
     def reactivate(self):
-        if self.get_precondition_violations():
-            raise TypeError
         self._recursive_reactivate(self.context)
 
     def _recursive_reactivate(self, dossier):

--- a/opengever/dossier/reactivate.py
+++ b/opengever/dossier/reactivate.py
@@ -63,5 +63,5 @@ class DossierReactivateView(BrowserView):
     def show_errors(self, errors):
         for msg in errors:
             api.portal.show_message(
-                message=msg, request=self.request, type='warning')
+                message=msg, request=self.request, type='error')
         return self.redirect()

--- a/opengever/dossier/tests/test_reactivate.py
+++ b/opengever/dossier/tests/test_reactivate.py
@@ -2,86 +2,97 @@ from datetime import date
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
-from ftw.testbrowser.pages.statusmessages import info_messages
+from ftw.testbrowser.pages import statusmessages
 from ftw.testbrowser.pages.statusmessages import error_messages
+from ftw.testbrowser.pages.statusmessages import info_messages
 from opengever.dossier.behaviors.dossier import IDossier
-from opengever.testing import FunctionalTestCase
-from plone import api
+from opengever.testing import IntegrationTestCase
 from plone.protect import createToken
 
 
-class TestReactivating(FunctionalTestCase):
+class TestReactivating(IntegrationTestCase):
 
     def setUp(self):
         super(TestReactivating, self).setUp()
-        self.grant('Reader', 'Contributor', 'Editor', 'Reviewer', 'Publisher')
+        with self.login(self.regular_user):
+            self.set_workflow_state('dossier-state-resolved',
+                                    self.resolvable_dossier,
+                                    self.resolvable_subdossier)
+
+    def reactivate(self, dossier, browser):
+        return browser.open(dossier,
+                            view='transition-reactivate',
+                            data={'_authenticator': createToken()})
+
+    def assert_errors(self, dossier, browser, error_msgs):
+        self.assertEquals(dossier.absolute_url(), browser.url)
+        self.assertEquals(error_msgs, error_messages())
+
+    def assert_success(self, dossier, browser, info_msgs=None):
+        self.assertEquals(dossier.absolute_url(), browser.url)
+        statusmessages.assert_no_error_messages()
+        self.assertEquals(info_msgs, info_messages())
 
     @browsing
     def test_reactivating_a_resolved_dossier_succesfully(self, browser):
-        dossier = create(Builder('dossier')
-                         .in_state('dossier-state-resolved'))
+        self.login(self.secretariat_user, browser)
 
-        browser.login().open(dossier)
-        browser.click_on('dossier-transition-reactivate')
+        self.reactivate(self.resolvable_dossier, browser)
 
-        self.assertEquals('dossier-state-active',
-                          api.content.get_state(dossier))
-        self.assertEquals(['Dossiers successfully reactivated.'],
-                          info_messages())
+        self.assert_workflow_state('dossier-state-active', self.resolvable_dossier)
+        self.assert_success(self.resolvable_dossier, browser,
+                            ['Dossiers successfully reactivated.'])
 
     @browsing
     def test_reactivating_a_main_dossier_reactivates_subdossiers_recursively(self, browser):
-        dossier = create(Builder('dossier')
-                         .in_state('dossier-state-resolved'))
-        sub = create(Builder('dossier')
-                     .within(dossier)
-                     .in_state('dossier-state-resolved'))
+        self.login(self.secretariat_user, browser)
         subsub = create(Builder('dossier')
-                        .within(sub)
+                        .within(self.resolvable_subdossier)
                         .in_state('dossier-state-resolved'))
 
-        browser.login().open(dossier, view=u'transition-reactivate',
-                             data={'_authenticator': createToken()})
-        self.assertEquals('dossier-state-active',
-                          api.content.get_state(dossier))
-        self.assertEquals('dossier-state-active',
-                          api.content.get_state(sub))
-        self.assertEquals('dossier-state-active',
-                          api.content.get_state(subsub))
+        self.reactivate(self.resolvable_dossier, browser)
+
+        self.assert_workflow_state('dossier-state-active', self.resolvable_dossier)
+        self.assert_workflow_state('dossier-state-active', self.resolvable_subdossier)
+        self.assert_workflow_state('dossier-state-active', subsub)
 
     @browsing
     def test_reactivating_a_subdossier_of_a_resolved_dossier_is_not_possible(self, browser):
-        dossier = create(Builder('dossier')
-                         .in_state('dossier-state-resolved'))
-        sub = create(Builder('dossier')
-                     .within(dossier)
-                     .in_state('dossier-state-resolved'))
+        self.login(self.secretariat_user, browser)
 
-        browser.login().open(sub, view=u'transition-reactivate',
-                             data={'_authenticator': createToken()})
+        self.reactivate(self.resolvable_subdossier, browser)
 
-        self.assertEquals(
-            ["It isn't possible to reactivate a sub dossier."],
-            error_messages())
-        self.assertEquals('dossier-state-resolved', api.content.get_state(sub))
+        self.assert_errors(self.resolvable_subdossier, browser,
+                           ["It isn't possible to reactivate a sub dossier."])
+        self.assert_workflow_state('dossier-state-resolved',
+                                   self.resolvable_subdossier)
 
     @browsing
     def test_resets_end_dates_recursively(self, browser):
-        dossier = create(Builder('dossier')
-                         .having(end=date(2013, 2, 21))
-                         .in_state('dossier-state-resolved'))
-        sub = create(Builder('dossier')
-                     .within(dossier)
-                     .having(end=date(2013, 2, 21))
-                     .in_state('dossier-state-resolved'))
+        end_date = date(2013, 2, 21)
+        end_date_index = self.dateindex_value_from_datetime(end_date)
+
+        self.login(self.secretariat_user, browser)
+        IDossier(self.resolvable_dossier).end = end_date
+        IDossier(self.resolvable_subdossier).end = end_date
+        self.resolvable_dossier.reindexObject(idxs=['end'])
+        self.resolvable_subdossier.reindexObject(idxs=['end'])
         subsub = create(Builder('dossier')
-                        .within(sub)
-                        .having(end=date(2013, 2, 21))
+                        .within(self.resolvable_subdossier)
+                        .having(end=end_date)
                         .in_state('dossier-state-resolved'))
 
-        browser.login().open(dossier, view=u'transition-reactivate',
-                             data={'_authenticator': createToken()})
+        self.assert_index_value(end_date_index, 'end', self.resolvable_dossier,
+                                self.resolvable_subdossier, subsub)
+        self.assert_metadata_value(end_date, 'end', self.resolvable_dossier,
+                                   self.resolvable_subdossier, subsub)
 
-        self.assertIsNone(IDossier(dossier).end)
-        self.assertIsNone(IDossier(sub).end)
+        self.reactivate(self.resolvable_dossier, browser)
+
+        self.assert_index_value('', 'end', self.resolvable_dossier,
+                                self.resolvable_subdossier, subsub)
+        self.assert_metadata_value(None, 'end', self.resolvable_dossier,
+                                   self.resolvable_subdossier, subsub)
+        self.assertIsNone(IDossier(self.resolvable_dossier).end)
+        self.assertIsNone(IDossier(self.resolvable_subdossier).end)
         self.assertIsNone(IDossier(subsub).end)

--- a/opengever/dossier/tests/test_reactivate.py
+++ b/opengever/dossier/tests/test_reactivate.py
@@ -3,7 +3,7 @@ from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
 from ftw.testbrowser.pages.statusmessages import info_messages
-from ftw.testbrowser.pages.statusmessages import warning_messages
+from ftw.testbrowser.pages.statusmessages import error_messages
 from opengever.dossier.behaviors.dossier import IDossier
 from opengever.testing import FunctionalTestCase
 from plone import api
@@ -62,7 +62,7 @@ class TestReactivating(FunctionalTestCase):
 
         self.assertEquals(
             ["It isn't possible to reactivate a sub dossier."],
-            warning_messages())
+            error_messages())
         self.assertEquals('dossier-state-resolved', api.content.get_state(sub))
 
     @browsing


### PR DESCRIPTION
We add the RESTAPI endpoint to properly handle the reactivate dossier transition. As for dossier resolution, the transition is handled by custom transition handler. We do not need to use a `TransitionExtender` here, as there are no jobs that need to be executed after the transition to the active state.

I refactored the tests of the dossier reactivate transition to allow for easier code reuse and have the same tests for the transition via browser or via RESTAPI. I also ported them to the `IntegrationTestCase`

Note: reactivating a dossier that is inactive does not throw an error, but that was already that way before... I made an issue for this https://github.com/4teamwork/opengever.core/issues/5638

This is part of https://github.com/4teamwork/opengever.core/issues/5432