### PR TITLE
Fix has_children indexer which lead to duplicate brains.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2019.2.0 (unreleased)
 ---------------------
 
+- Fix has_children indexer which lead to duplicate brains. [njohner, phgross]
 - Trash: Update and reindex modification date when trashing documents. [lgraf]
 - Respect tabbedview settings when generating a document excel export. [phgross]
 - Add file_extension indexer for mails. [phgross]

--- a/opengever/base/indexes.py
+++ b/opengever/base/indexes.py
@@ -1,3 +1,4 @@
+from Acquisition import aq_base
 from opengever.base.behaviors.changed import IChanged
 from opengever.base.behaviors.changed import IChangedMarker
 from opengever.base.behaviors.translated_title import ITranslatedTitle
@@ -86,7 +87,8 @@ def sortable_title(obj):
 
 @indexer(IFolderish)
 def has_sametype_children(obj):
-    catalog = api.portal.get_tool("portal_catalog")
-    return bool(catalog.unrestrictedSearchResults(
-                    path={'query': obj.absolute_url_path(), 'depth': 1},
-                    portal_type=obj.portal_type))
+    # child objects are acquisition wrapped, so any child.portal_type would
+    # return the obj.portal_type if the child object does not have a
+    # portal_type attribute.
+    return any(obj.portal_type == getattr(aq_base(child), "portal_type", None)
+               for child in obj.objectValues())


### PR DESCRIPTION
The has_children indexer was making a catalog query, which leads to processing the indexing queue in the middle of operations like creating a folderish object. This led to duplicate brains in the catalog. At least that is my best guess as to what the problem was...

I could not reproduce the problem in tests (tried Integration and Functional tests), but I can confirm that I could reproduce the two issues locally and that they do not happen anymore with these changes.

resolves #5635 #5632 