### PR TITLE
Fix broken upgradestep introduced in es-5563-remove-dossier-inheritance-for-workspaces

### DIFF
--- a/opengever/core/upgrades/20190507160417_remove_dossier_inheritance_for_workspaces/types/opengever.workspace.folder.xml
+++ b/opengever/core/upgrades/20190507160417_remove_dossier_inheritance_for_workspaces/types/opengever.workspace.folder.xml
@@ -1,7 +1,7 @@
 <object xmlns:i18n="http://xml.zope.org/namespaces/i18n" name="opengever.workspace.folder" meta_type="Dexterity FTI" i18n:domain="opengever.core">
 
   <!-- enabled behaviors -->
-  <property name="behaviors">
+  <property name="behaviors" purge="false">
     <element remove="True" value="opengever.dossier.behaviors.dossier.IDossier" />
   </property>
 

--- a/opengever/core/upgrades/20190507160417_remove_dossier_inheritance_for_workspaces/types/opengever.workspace.workspace.xml
+++ b/opengever/core/upgrades/20190507160417_remove_dossier_inheritance_for_workspaces/types/opengever.workspace.workspace.xml
@@ -1,7 +1,7 @@
 <object xmlns:i18n="http://xml.zope.org/namespaces/i18n" name="opengever.workspace.workspace" meta_type="Dexterity FTI" i18n:domain="opengever.core">
 
   <!-- Enabled behaviors -->
-  <property name="behaviors">
+  <property name="behaviors" purge="false">
     <element remove="True" value="opengever.dossier.behaviors.dossier.IDossier" />
   </property>
 

--- a/opengever/core/upgrades/20190507160417_remove_dossier_inheritance_for_workspaces/upgrade.py
+++ b/opengever/core/upgrades/20190507160417_remove_dossier_inheritance_for_workspaces/upgrade.py
@@ -1,5 +1,6 @@
 from ftw.upgrade import UpgradeStep
 from opengever.workspace.interfaces import IWorkspace
+from opengever.workspace.interfaces import IWorkspaceFolder
 
 
 class RemoveDossierInheritanceForWorkspaces(UpgradeStep):
@@ -8,4 +9,7 @@ class RemoveDossierInheritanceForWorkspaces(UpgradeStep):
 
     def __call__(self):
         self.install_upgrade_profile()
-        self.catalog_reindex_objects({'object_provides': IWorkspace.__identifier__})
+        self.catalog_reindex_objects({
+            'object_provides':
+            [IWorkspace.__identifier__, IWorkspaceFolder.__identifier__]
+            })


### PR DESCRIPTION
Dieser PR behebt einen Fehler im Upgradestep von folgendem PR: https://github.com/4teamwork/opengever.core/pull/5578/

1. Die Type-Files waren nicht im `types` Ordner und wurden somit garnicht ausgeführt
2. die Behaviors dürfen nicht gelöscht werden (purge). Dies wäre der Fall gewesen, wenn das Profil korrekt importiert worden wäre