### PR TITLE
Concistently use "déroulement standard" for tasktemplates in French.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2019.2.0 (unreleased)
 ---------------------
 
+- Concistently use "déroulement standard" for tasktemplates in French. [njohner]
 - Fix has_children indexer which lead to duplicate brains. [njohner, phgross]
 - Trash: Update and reindex modification date when trashing documents. [lgraf]
 - Respect tabbedview settings when generating a document excel export. [phgross]

--- a/docs/public-fr/chapitre13-deroulements-standards.rst
+++ b/docs/public-fr/chapitre13-deroulements-standards.rst
@@ -36,7 +36,7 @@ Le type de séquence est défini par le créateur du déroulement standard et ne
 Déclencher un déroulement standard
 ----------------------------------
 
-Dans un dossier ou sous-dossier, sélectionnez *Ajout d’un élément→ Ajouter une tâche à partir du modèle*
+Dans un dossier ou sous-dossier, sélectionnez *Ajout d’un élément→ Déclencher un déroulement standard*
 
 |img-deroulstandard-3|
 

--- a/opengever/base/locales/fr/LC_MESSAGES/plone.po
+++ b/opengever/base/locales/fr/LC_MESSAGES/plone.po
@@ -18,7 +18,7 @@ msgid "Add response"
 msgstr "Réponse"
 
 msgid "Add task from template"
-msgstr "Ajouter une tâche à partir du modèle"
+msgstr "Déclencher un déroulement standard"
 
 msgid "Attach remote document"
 msgstr "Copie d'un document de votre service"

--- a/opengever/tasktemplates/locales/fr/LC_MESSAGES/opengever.tasktemplates.po
+++ b/opengever/tasktemplates/locales/fr/LC_MESSAGES/opengever.tasktemplates.po
@@ -182,7 +182,7 @@ msgstr "Choix Mandataires"
 #. Default: "Select tasktemplatefolder"
 #: ./opengever/tasktemplates/browser/trigger.py
 msgid "label_select_tasktemplatefolder"
-msgstr "Sélectionner le processus standard"
+msgstr "Sélectionner le déroulement standard"
 
 #. Default: "Select tasktemplates"
 #: ./opengever/tasktemplates/browser/trigger.py
@@ -213,12 +213,12 @@ msgstr "Sélectionner les modèles de tâches"
 #. Default: "Tasktemplatefolder"
 #: ./opengever/tasktemplates/browser/trigger.py
 msgid "label_tasktemplatefolder"
-msgstr "Processus standard"
+msgstr "Déroulement standard"
 
 #. Default: "Tasktemplatefolder selection"
 #: ./opengever/tasktemplates/browser/trigger.py
 msgid "label_tasktemplatefolder_selection"
-msgstr "Sélectionner le processus standard"
+msgstr "Sélectionner le déroulement standard"
 
 #. Default: "Tasktemplates"
 #: ./opengever/tasktemplates/browser/trigger.py
@@ -257,7 +257,7 @@ msgstr "Toutes les tâches du procédé standard ont été créées."
 #: ./opengever/tasktemplates/browser/form.py
 #: ./opengever/tasktemplates/browser/trigger.py
 msgid "msg_no_active_tasktemplatefolders"
-msgstr "Aucun processus standard actif n'est enregistré pour le moment."
+msgstr "Aucun déroulement standard actif n'est enregistré pour le moment."
 
 #. Default: "Yes"
 #: ./opengever/tasktemplates/browser/tasktemplates.py


### PR DESCRIPTION
Found that we were using a 3rd version `processus standard`. Hope I caught them all...

resolves #5634 