### PR TITLE
Forbid transitions linked to dossier offer process through RESTAPI.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2019.3.0 (unreleased)
 ---------------------
 
+- Forbid transitions linked to dossier offer process through RESTAPI. [njohner]
 - Only allow dossier transitions that are possible on the main dossier. [njohner]
 - Handle dossier activation through RESTAPI. [njohner]
 - Improve error message when trying to delete a referenced document. [njohner]

--- a/opengever/api/tests/test_dossier_workflow.py
+++ b/opengever/api/tests/test_dossier_workflow.py
@@ -112,7 +112,7 @@ class TestDossierWorkflowRESTAPITransitions(IntegrationTestCase):
             browser.json)
 
     @browsing
-    def test_offer_resolved_via_restapi(self, browser):
+    def test_offer_resolved_via_restapi_is_forbidden(self, browser):
         self.login(self.secretariat_user, browser)
 
         resolve_manager = LockingResolveManager(self.resolvable_dossier)
@@ -120,101 +120,82 @@ class TestDossierWorkflowRESTAPITransitions(IntegrationTestCase):
         self.assert_state('dossier-state-resolved', self.resolvable_dossier)
 
         self.login(self.records_manager, browser)
+        browser.raise_http_errors = False
+        self.api_transition(
+            self.resolvable_dossier, 'dossier-transition-offer', browser)
 
-        with freeze(datetime(2018, 4, 30)):
-            self.api_transition(
-                self.resolvable_dossier, 'dossier-transition-offer', browser)
-
-        self.assert_state('dossier-state-offered', self.resolvable_dossier)
-        self.assertEqual(200, browser.status_code)
-        self.assertEquals(
-            {u'title': u'dossier-state-offered',
-             u'comments': u'',
-             u'actor': u'ramon.flucht',
-             u'time': u'2018-04-29T22:00:00+00:00',
-             u'action': u'dossier-transition-offer',
-             u'review_state': u'dossier-state-offered'},
+        self.assert_state('dossier-state-resolved', self.resolvable_dossier)
+        self.assertEqual(400, browser.status_code)
+        self.assertEqual(
+            {u'error':
+                {u'message': u"Invalid transition 'dossier-transition-offer'.\nValid transitions are:\n",
+                 u'type': u'Bad Request'}},
             browser.json)
 
     @browsing
-    def test_offered_to_resolved_via_restapi(self, browser):
+    def test_offered_to_resolved_via_restapi_is_forbidden(self, browser):
         self.login(self.records_manager, browser)
         self.assert_state('dossier-state-offered', self.offered_dossier_to_archive)
 
-        with freeze(datetime(2018, 4, 30)):
-            self.api_transition(
-                self.offered_dossier_to_archive,
-                'dossier-transition-offered-to-resolved', browser)
+        browser.raise_http_errors = False
+        self.api_transition(self.offered_dossier_to_archive,
+                            'dossier-transition-offered-to-resolved', browser)
 
-        self.assert_state('dossier-state-resolved', self.offered_dossier_to_archive)
-        self.assertEqual(200, browser.status_code)
-        self.assertEquals(
-            {u'title': u'dossier-state-resolved',
-             u'comments': u'',
-             u'actor': u'ramon.flucht',
-             u'time': u'2018-04-29T22:00:00+00:00',
-             u'action': u'dossier-transition-offered-to-resolved',
-             u'review_state': u'dossier-state-resolved'},
+        self.assert_state('dossier-state-offered', self.offered_dossier_to_archive)
+        self.assertEqual(400, browser.status_code)
+        self.assertEqual(
+            {u'error':
+                {u'message': u"Invalid transition 'dossier-transition-offered-to-resolved'.\nValid transitions are:\n",
+                 u'type': u'Bad Request'}},
             browser.json)
 
     @browsing
-    def test_offer_inactive_via_restapi(self, browser):
+    def test_offer_inactive_via_restapi_is_forbidden(self, browser):
         self.login(self.records_manager, browser)
         self.assert_state('dossier-state-inactive', self.inactive_dossier)
 
-        with freeze(datetime(2018, 4, 30)):
-            self.api_transition(
-                self.inactive_dossier, 'dossier-transition-offer', browser)
+        browser.raise_http_errors = False
+        self.api_transition(
+            self.inactive_dossier, 'dossier-transition-offer', browser)
 
-        self.assert_state('dossier-state-offered', self.inactive_dossier)
-        self.assertEqual(200, browser.status_code)
-        self.assertEquals(
-            {u'title': u'dossier-state-offered',
-             u'comments': u'',
-             u'actor': u'ramon.flucht',
-             u'time': u'2018-04-29T22:00:00+00:00',
-             u'action': u'dossier-transition-offer',
-             u'review_state': u'dossier-state-offered'},
+        self.assert_state('dossier-state-inactive', self.inactive_dossier)
+        self.assertEqual(400, browser.status_code)
+        self.assertEqual(
+            {u'error':
+                {u'message': u"Invalid transition 'dossier-transition-offer'.\nValid transitions are:\n",
+                 u'type': u'Bad Request'}},
             browser.json)
 
     @browsing
-    def test_offered_to_inactive_via_restapi(self, browser):
+    def test_offered_to_inactive_via_restapi_is_forbidden(self, browser):
         self.login(self.records_manager, browser)
         self.assert_state('dossier-state-offered', self.offered_dossier_to_archive)
 
-        with freeze(datetime(2018, 4, 30)):
-            self.api_transition(
-                self.offered_dossier_to_archive,
-                'dossier-transition-offered-to-inactive', browser)
+        browser.raise_http_errors = False
+        self.api_transition(self.offered_dossier_to_archive,
+                            'dossier-transition-offered-to-inactive', browser)
 
-        self.assert_state('dossier-state-inactive', self.offered_dossier_to_archive)
-        self.assertEqual(200, browser.status_code)
-        self.assertEquals(
-            {u'title': u'dossier-state-inactive',
-             u'comments': u'',
-             u'actor': u'ramon.flucht',
-             u'time': u'2018-04-29T22:00:00+00:00',
-             u'action': u'dossier-transition-offered-to-inactive',
-             u'review_state': u'dossier-state-inactive'},
+        self.assert_state('dossier-state-offered', self.offered_dossier_to_archive)
+        self.assertEqual(400, browser.status_code)
+        self.assertEqual(
+            {u'error':
+                {u'message': u"Invalid transition 'dossier-transition-offered-to-inactive'.\nValid transitions are:\n",
+                 u'type': u'Bad Request'}},
             browser.json)
 
     @browsing
-    def test_archive_offered_via_restapi(self, browser):
+    def test_archive_offered_via_restapi_is_forbidden(self, browser):
         self.login(self.records_manager, browser)
         self.assert_state('dossier-state-offered', self.offered_dossier_to_archive)
 
-        with freeze(datetime(2018, 4, 30)):
-            self.api_transition(
-                self.offered_dossier_to_archive,
-                'dossier-transition-archive', browser)
+        browser.raise_http_errors = False
+        self.api_transition(self.offered_dossier_to_archive,
+                            'dossier-transition-archive', browser)
 
-        self.assert_state('dossier-state-archived', self.offered_dossier_to_archive)
-        self.assertEqual(200, browser.status_code)
-        self.assertEquals(
-            {u'title': u'dossier-state-archived',
-             u'comments': u'',
-             u'actor': u'ramon.flucht',
-             u'time': u'2018-04-29T22:00:00+00:00',
-             u'action': u'dossier-transition-archive',
-             u'review_state': u'dossier-state-archived'},
+        self.assert_state('dossier-state-offered', self.offered_dossier_to_archive)
+        self.assertEqual(400, browser.status_code)
+        self.assertEqual(
+            {u'error':
+                {u'message': u"Invalid transition 'dossier-transition-archive'.\nValid transitions are:\n",
+                 u'type': u'Bad Request'}},
             browser.json)

--- a/opengever/dossier/tests/test_activate.py
+++ b/opengever/dossier/tests/test_activate.py
@@ -158,7 +158,7 @@ class TestDossierActivationRESTAPI(TestDossierActivation):
 
     @browsing
     def test_activating_dossier_non_recursively_is_forbidden(self, browser):
-        self.login(self.regular_user, browser)
+        self.login(self.secretariat_user, browser)
         payload = {'include_children': False}
         self.activate(self.inactive_dossier, browser, payload=payload)
         self.assertEqual(

--- a/opengever/dossier/tests/test_resolve.py
+++ b/opengever/dossier/tests/test_resolve.py
@@ -157,7 +157,9 @@ class ResolveTestHelperRESTAPI(ResolveTestHelper):
         self.assertEquals(400, browser.status_code)
         self.assertEquals(
             {u'error':
-                {u'message': u'Dossier has already been resolved.',
+                {u'message': u"Invalid transition 'dossier-transition-resolve'."
+                             "\nValid transitions are:"
+                             "\ndossier-transition-reactivate",
                  u'type': u'Bad Request'}},
             browser.json)
         expected_url = dossier.absolute_url() + '/@workflow/dossier-transition-resolve'

--- a/opengever/dossier/tests/test_resolve.py
+++ b/opengever/dossier/tests/test_resolve.py
@@ -29,6 +29,7 @@ from plone import api
 from plone.app.testing import applyProfile
 from plone.protect import createToken
 from plone.uuid.interfaces import IUUID
+from Products.CMFCore.utils import getToolByName
 from zope.component import getUtility
 from zope.schema.interfaces import IVocabularyFactory
 import json
@@ -105,6 +106,10 @@ class ResolveTestHelper(object):
                    dossier, self.active_state, dossier_state))
         self.assertEquals(self.active_state, dossier_state, msg)
 
+    def assert_resolve_transition_invalid(self, dossier, browser):
+        self.assert_errors(dossier, browser,
+                           ['Dossier is not active and cannot be resolved.'])
+
 
 class ResolveTestHelperRESTAPI(ResolveTestHelper):
     """Implementation of the ResolveTestHelper for use with REST API.
@@ -113,11 +118,6 @@ class ResolveTestHelperRESTAPI(ResolveTestHelper):
     success / failure by looking at HTTP status codes and JSON content of
     the response.
     """
-
-    api_headers = {
-        'Accept': 'application/json',
-        'Content-Type': 'application/json',
-    }
 
     def resolve(self, dossier, browser, payload=None):
         browser.raise_http_errors = False
@@ -154,16 +154,7 @@ class ResolveTestHelperRESTAPI(ResolveTestHelper):
         self.assertEquals(expected_url, browser.url)
 
     def assert_already_resolved(self, dossier, browser):
-        self.assertEquals(400, browser.status_code)
-        self.assertEquals(
-            {u'error':
-                {u'message': u"Invalid transition 'dossier-transition-resolve'."
-                             "\nValid transitions are:"
-                             "\ndossier-transition-reactivate",
-                 u'type': u'Bad Request'}},
-            browser.json)
-        expected_url = dossier.absolute_url() + '/@workflow/dossier-transition-resolve'
-        self.assertEquals(expected_url, browser.url)
+        self.assert_resolve_transition_invalid(dossier, browser)
 
     def assert_already_being_resolved(self, dossier, browser):
         self.assertEquals(400, browser.status_code)
@@ -172,6 +163,28 @@ class ResolveTestHelperRESTAPI(ResolveTestHelper):
                 u'message': u'Dossier is already being resolved',
                 u'type': u'AlreadyBeingResolved'}},
             browser.json)
+
+    def assert_resolve_transition_invalid(self, dossier, browser):
+        transition = 'dossier-transition-resolve'
+        self.assertEqual(400, browser.status_code)
+        self.assertEqual(
+            {u'error': {
+                u'message': self.invalid_transition_message(dossier, transition),
+                u'type': u'Bad Request'}},
+            browser.json)
+        expected_url = '{}/@workflow/{}'.format(dossier.absolute_url(), transition)
+        self.assertEquals(expected_url, browser.url)
+
+    def invalid_transition_message(self, dossier, transition):
+        wftool = getToolByName(dossier, 'portal_workflow')
+        actions = wftool.listActionInfos(object=dossier)
+        action_ids = [action['id'] for action in actions
+                      if action['category'] == 'workflow']
+
+        message = ("Invalid transition '{}'.\n"
+                   "Valid transitions are:\n"
+                   "{}".format(transition, '\n'.join(sorted(action_ids))))
+        return message
 
 
 class TestResolverVocabulary(IntegrationTestCase):
@@ -256,7 +269,7 @@ class TestResolvingDossiersRESTAPI(ResolveTestHelperRESTAPI, TestResolvingDossie
 
     @browsing
     def test_resolving_dossier_non_recursively_is_forbidden(self, browser):
-        self.login(self.regular_user, browser)
+        self.login(self.secretariat_user, browser)
         payload = {'include_children': False}
         self.resolve(self.resolvable_dossier, browser, payload=payload)
         self.assertEqual(
@@ -1289,8 +1302,7 @@ class TestResolveConditions(IntegrationTestCase, ResolveTestHelper):
         self.resolve(self.resolvable_dossier, browser)
 
         self.assert_not_resolved(self.resolvable_dossier)
-        self.assert_errors(self.resolvable_dossier, browser,
-                           ['Dossier is not active and cannot be resolved.'])
+        self.assert_resolve_transition_invalid(self.resolvable_dossier, browser)
 
     @browsing
     def test_resolving_is_cancelled_when_documents_are_not_filed_correctly(self, browser):


### PR DESCRIPTION
Certain dossiers transitions should not be allowed through the RESTAPI, as they are handled by a specific process in GEVER. This is the case of all the transitions linked to the offer/archive process.

We now reply to such requests with a 400 `BadRequest`.

This is part of and closes #5432