### PR TITLE
Update and improve French translations for 2019.2 release

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 ---------------------
 
 - Concistently use "déroulement standard" for tasktemplates in French. [njohner]
+- Update and add missing French translations. [njohner, andresoberhaensli]
 - Fix has_children indexer which lead to duplicate brains. [njohner, phgross]
 - Trash: Update and reindex modification date when trashing documents. [lgraf]
 - Respect tabbedview settings when generating a document excel export. [phgross]

--- a/docs/public-fr/chapitre17-triage.rst
+++ b/docs/public-fr/chapitre17-triage.rst
@@ -116,7 +116,7 @@ Historique
 ----------
 
 Pour chaque offre, un historique est généré et affiché de façon similaire comme
-pour les tâches ou les propositions.
+pour les tâches ou les requêtes.
 
 |img-triage-4|
 

--- a/docs/public-fr/documents/chapitre6-metadonnees.rst
+++ b/docs/public-fr/documents/chapitre6-metadonnees.rst
@@ -55,7 +55,7 @@ Onglet En général
 
     - Si on connait le titre du document ou une de ses composantes, le texte
       est entré directement dans le champ. Apparait alors la liste déroulante
-      de propositions, liste dans laquelle le document souhaité peut être sélectionné.
+      de requêtes, liste dans laquelle le document souhaité peut être sélectionné.
 
     |img-document-14|
 

--- a/docs/public-fr/dossiers/creer_nouveau_dossier.rst
+++ b/docs/public-fr/dossiers/creer_nouveau_dossier.rst
@@ -123,7 +123,7 @@ Vue du dossier après sauvegarde
 
 3. **Options d’édition**: Plusieurs options pour éditer le dossier sont disponibles au-dessus du titre.
 
-4. **Onglets**: Les contenus relatifs à l’affaire sont stockés sous les différents onglets. L’onglet *Sommaire* est affiché par défaut et liste les contenus les plus récents des onglets *Sous-dossiers*, *Documents*, *Tâches* et *Participants*. De plus, on y trouve le texte du champ « Description », si ce dernier a été rempli. L’onglet *Historique* contient une liste des actions effectuées au niveau du dossier. Sous l’onglet *Info*, il est possible de vérifier les droits d’utilisateurs assignés à ce dossier. L’onglet *Propositions* est uniquement disponible si le module « Gestion de séances et procès-verbaux » a été activé.
+4. **Onglets**: Les contenus relatifs à l’affaire sont stockés sous les différents onglets. L’onglet *Sommaire* est affiché par défaut et liste les contenus les plus récents des onglets *Sous-dossiers*, *Documents*, *Tâches* et *Participants*. De plus, on y trouve le texte du champ « Description », si ce dernier a été rempli. L’onglet *Historique* contient une liste des actions effectuées au niveau du dossier. Sous l’onglet *Info*, il est possible de vérifier les droits d’utilisateurs assignés à ce dossier. L’onglet *Requêtes* est uniquement disponible si le module « Gestion de séances et procès-verbaux » a été activé.
 
 
 .. |img-creernouveaudossier01| image:: ../_static/img/img-creernouveaudossier01.png

--- a/opengever/activity/locales/fr/LC_MESSAGES/opengever.activity.po
+++ b/opengever/activity/locales/fr/LC_MESSAGES/opengever.activity.po
@@ -193,7 +193,7 @@ msgstr "Toutes les notifications"
 #. Default: "Proposals"
 #: ./opengever/activity/browser/settings.py
 msgid "label_proposals"
-msgstr "Propositions"
+msgstr "Requêtes"
 
 #. Default: "Mark all notifications as read"
 #: ./opengever/activity/viewlets/notification.pt
@@ -228,37 +228,37 @@ msgstr "Pièce jointe actualisée"
 #. Default: "Proposal commented"
 #: ./opengever/activity/__init__.py
 msgid "proposal-commented"
-msgstr "Proposition commentée"
+msgstr "Requête commentée"
 
 #. Default: "Proposal decided"
 #: ./opengever/activity/__init__.py
 msgid "proposal-transition-decide"
-msgstr "Proposition décidée"
+msgstr "Requête décidée"
 
 #. Default: "Proposal pulled"
 #: ./opengever/activity/__init__.py
 msgid "proposal-transition-pull"
-msgstr "Proposition retirée de l'ordre du jour"
+msgstr "Requête retirée de l'ordre du jour"
 
 #. Default: "Proposal rejected"
 #: ./opengever/activity/__init__.py
 msgid "proposal-transition-reject"
-msgstr "Proposition rejetée"
+msgstr "Requête rejetée"
 
 #. Default: "Proposal scheduled"
 #: ./opengever/activity/__init__.py
 msgid "proposal-transition-schedule"
-msgstr "Proposition mise à l'ordre du jour"
+msgstr "Requête mise à l'ordre du jour"
 
 #. Default: "Proposal submitted"
 #: ./opengever/activity/__init__.py
 msgid "proposal-transition-submit"
-msgstr "Proposition soumise"
+msgstr "Requête soumise"
 
 #. Default: "Proposal issuer"
 #: ./opengever/activity/roles.py
 msgid "proposal_issuer"
-msgstr "Auteur de la proposition"
+msgstr "Auteur de la requête"
 
 #. Default: "Records Manager"
 #: ./opengever/activity/roles.py
@@ -283,7 +283,7 @@ msgstr "Activité GEVER"
 #. Default: "Submitted proposal commented"
 #: ./opengever/activity/__init__.py
 msgid "submitted-proposal-commented"
-msgstr "Proposition soumise commentée"
+msgstr "Requête soumise commentée"
 
 #. Default: "Task added"
 #: ./opengever/activity/__init__.py

--- a/opengever/activity/locales/fr/LC_MESSAGES/opengever.activity.po
+++ b/opengever/activity/locales/fr/LC_MESSAGES/opengever.activity.po
@@ -42,7 +42,7 @@ msgstr "sauvegarder"
 #. Default: "Actor"
 #: ./opengever/activity/browser/listing.py
 msgid "column_Actor"
-msgstr "acteur"
+msgstr "Acteur"
 
 #. Default: "Kind"
 #: ./opengever/activity/browser/listing.py

--- a/opengever/activity/locales/fr/LC_MESSAGES/opengever.activity.po
+++ b/opengever/activity/locales/fr/LC_MESSAGES/opengever.activity.po
@@ -313,12 +313,12 @@ msgstr "tâche déléguée"
 #. Default: "Task resolved"
 #: ./opengever/activity/__init__.py
 msgid "task-transition-in-progress-resolved"
-msgstr "tâche effectuée"
+msgstr "tâche accomplie"
 
 #. Default: "Task closed"
 #: ./opengever/activity/__init__.py
 msgid "task-transition-in-progress-tested-and-closed"
-msgstr "tâche close"
+msgstr "tâche clôturée"
 
 #. Default: "Task deadline modified"
 #: ./opengever/activity/__init__.py
@@ -343,12 +343,12 @@ msgstr "tâche refusée"
 #. Default: "Task resolved"
 #: ./opengever/activity/__init__.py
 msgid "task-transition-open-resolved"
-msgstr "tâche traitée"
+msgstr "tâche accomplie"
 
 #. Default: "Task closed"
 #: ./opengever/activity/__init__.py
 msgid "task-transition-open-tested-and-closed"
-msgstr "tâche close"
+msgstr "tâche clôturée"
 
 #. Default: "Task skipped"
 #: ./opengever/activity/__init__.py
@@ -378,7 +378,7 @@ msgstr "révision de la tâche requise"
 #. Default: "Task closed"
 #: ./opengever/activity/__init__.py
 msgid "task-transition-resolved-tested-and-closed"
-msgstr "tâche close"
+msgstr "tâche clôturée"
 
 #. Default: "Task reopened"
 #: ./opengever/activity/__init__.py

--- a/opengever/activity/locales/fr/LC_MESSAGES/opengever.activity.po
+++ b/opengever/activity/locales/fr/LC_MESSAGES/opengever.activity.po
@@ -198,7 +198,7 @@ msgstr "Requêtes"
 #. Default: "Mark all notifications as read"
 #: ./opengever/activity/viewlets/notification.pt
 msgid "label_read_all_notifications"
-msgstr ""
+msgstr "Marquer toutes les notifications comme lues"
 
 #. Default: "Reminders"
 #: ./opengever/activity/browser/settings.py

--- a/opengever/base/locales/fr/LC_MESSAGES/ftw.tabbedview.po
+++ b/opengever/base/locales/fr/LC_MESSAGES/ftw.tabbedview.po
@@ -180,7 +180,7 @@ msgid "process"
 msgstr "Avancement"
 
 msgid "proposals"
-msgstr "Propositions"
+msgstr "Requêtes"
 
 msgid "related_documents"
 msgstr "Documents liés"

--- a/opengever/base/locales/fr/LC_MESSAGES/ftw.tabbedview.po
+++ b/opengever/base/locales/fr/LC_MESSAGES/ftw.tabbedview.po
@@ -66,7 +66,7 @@ msgid "changes"
 msgstr "Dernières modifications"
 
 msgid "closed-forwardings"
-msgstr "Transmissions fermé"
+msgstr "Transmissions clôturées"
 
 msgid "committees"
 msgstr "Commissions"

--- a/opengever/base/locales/fr/LC_MESSAGES/opengever.base.po
+++ b/opengever/base/locales/fr/LC_MESSAGES/opengever.base.po
@@ -268,7 +268,7 @@ msgstr "Date d'élimination"
 #. Default: "Date of submission"
 #: ./opengever/base/behaviors/lifecycle.py
 msgid "label_dateofsubmission"
-msgstr "Date de proposition (des documents)"
+msgstr "Date de requête (des documents)"
 
 #. Default: "An unexpected error has occured"
 #: ./opengever/base/browser/templates/gever-macros.pt

--- a/opengever/base/locales/fr/LC_MESSAGES/opengever.base.po
+++ b/opengever/base/locales/fr/LC_MESSAGES/opengever.base.po
@@ -142,7 +142,7 @@ msgstr "Visibilité"
 #: ./opengever/base/behaviors/base.py
 #: ./opengever/base/behaviors/translated_title.py
 msgid "fieldset_common"
-msgstr "En général"
+msgstr "Général"
 
 #. Default: "Life Cycle"
 #: ./opengever/base/behaviors/lifecycle.py
@@ -156,7 +156,7 @@ msgstr "Valeur archivistique"
 
 #: ./opengever/base/behaviors/classification.py
 msgid "help_classification"
-msgstr "Degré de besoin de protection des documents contre la consultation non-autorisée."
+msgstr "Degré de protection des documents contre la consultation non-autorisée requis."
 
 #: ./opengever/base/behaviors/lifecycle.py
 msgid "help_custody_period"
@@ -176,7 +176,7 @@ msgstr "Date de la requête, requérant, date de la décision, référence vers 
 
 #: ./opengever/base/behaviors/lifecycle.py
 msgid "help_retention_period"
-msgstr "Durée entre la date du document plus récent contenu dans un dossier et la date à partir de laquelle le document n'est plus requis pour les activités administratives."
+msgstr "Temps entre la date du document le plus récent contenu dans un dossier et la date à partir de laquelle le document n'est plus requis pour les activités administratives."
 
 #. Default: "-- Already removed object --"
 #: ./opengever/base/adapters.py

--- a/opengever/base/locales/fr/LC_MESSAGES/plone.po
+++ b/opengever/base/locales/fr/LC_MESSAGES/plone.po
@@ -69,7 +69,7 @@ msgid "Dossier state changed to dossier-state-offered"
 msgstr "Etat du dossier modifié: Offert"
 
 msgid "Dossier state changed to dossier-state-resolved"
-msgstr "Etat du dossier modifié: Fermé"
+msgstr "Etat du dossier modifié: Clôturé"
 
 msgid "Dossier with template"
 msgstr "Dossier à partir du modèle"
@@ -211,7 +211,7 @@ msgid "dossier-state-offered"
 msgstr "Offert"
 
 msgid "dossier-state-resolved"
-msgstr "Fermé"
+msgstr "Clôturé"
 
 msgid "dossier-transition-activate"
 msgstr "Activer"

--- a/opengever/base/locales/fr/LC_MESSAGES/plone.po
+++ b/opengever/base/locales/fr/LC_MESSAGES/plone.po
@@ -87,7 +87,7 @@ msgid "Meeting"
 msgstr "Séance"
 
 msgid "Membership"
-msgstr "Affiliation"
+msgstr "Adhésion"
 
 msgid "Modify deadline"
 msgstr "Changer le délai"
@@ -229,7 +229,7 @@ msgid "dossier-transition-resolve"
 msgstr "Fermer"
 
 msgid "forwarding-state-closed"
-msgstr "Fermé"
+msgstr "Clôturé"
 
 msgid "forwarding-state-open"
 msgstr "Ouvert"
@@ -244,13 +244,13 @@ msgid "forwarding-transition-assign-to-dossier"
 msgstr "Attribuer à un dossier"
 
 msgid "forwarding-transition-close"
-msgstr "Fermer"
+msgstr "Clôturer"
 
 msgid "forwarding-transition-reassign"
-msgstr "Attribuer"
+msgstr "Ré-attribuer"
 
 msgid "forwarding-transition-reassign-refused"
-msgstr "Attribuer"
+msgstr "Transmettre"
 
 msgid "forwarding-transition-refuse"
 msgstr "Refuser"
@@ -310,7 +310,7 @@ msgid "task-state-skipped"
 msgstr "Omis"
 
 msgid "task-state-tested-and-closed"
-msgstr "Fermé"
+msgstr "Clôturé"
 
 msgid "task-transition-cancelled-open"
 msgstr "Rouvrir"
@@ -325,7 +325,7 @@ msgid "task-transition-in-progress-resolved"
 msgstr "Accomplir"
 
 msgid "task-transition-in-progress-tested-and-closed"
-msgstr "Fermer"
+msgstr "Clôturer"
 
 msgid "task-transition-modify-deadline"
 msgstr "Changer le délai"
@@ -346,7 +346,7 @@ msgid "task-transition-open-resolved"
 msgstr "Accomplir"
 
 msgid "task-transition-open-tested-and-closed"
-msgstr "Fermer"
+msgstr "Clôturer"
 
 msgid "task-transition-planned-open"
 msgstr "Ouvrir"
@@ -355,7 +355,7 @@ msgid "task-transition-planned-skipped"
 msgstr "Omettre"
 
 msgid "task-transition-reassign"
-msgstr "Attribuer à nouveau"
+msgstr "Ré-attribuer"
 
 msgid "task-transition-rejected-open"
 msgstr "Rouvrir"
@@ -367,7 +367,7 @@ msgid "task-transition-resolved-in-progress"
 msgstr "Réviser"
 
 msgid "task-transition-resolved-tested-and-closed"
-msgstr "Fermer"
+msgstr "Clôturer"
 
 msgid "task-transition-skipped-open"
 msgstr "Rouvrir"

--- a/opengever/bumblebee/locales/fr/LC_MESSAGES/opengever.bumblebee.po
+++ b/opengever/bumblebee/locales/fr/LC_MESSAGES/opengever.bumblebee.po
@@ -55,7 +55,7 @@ msgstr "Aucun contenu"
 #. Default: "Revert document"
 #: ./opengever/bumblebee/browser/overlay.py
 msgid "label_revert"
-msgstr "Reculer le document"
+msgstr "Restaurer le document"
 
 #. Default: "Reviving the preview is not available for this context."
 #: ./opengever/bumblebee/browser/revive_preview.py

--- a/opengever/contact/locales/fr/LC_MESSAGES/opengever.contact.po
+++ b/opengever/contact/locales/fr/LC_MESSAGES/opengever.contact.po
@@ -436,7 +436,7 @@ msgstr "Tous"
 #. Default: "Teams"
 #: ./opengever/contact/browser/tabbed.py
 msgid "label_teams"
-msgstr "Equipes"
+msgstr "Teams"
 
 #. Default: "Title"
 #: ./opengever/contact/browser/tabs.py

--- a/opengever/core/locales/de/LC_MESSAGES/plone.po
+++ b/opengever/core/locales/de/LC_MESSAGES/plone.po
@@ -45,7 +45,7 @@ msgstr "Reaktivieren"
 #. Default: "deactivate"
 #: opengever/core/profiles/default/workflows/opengever_committee_workflow/specification.txt
 msgid "deactivate"
-msgstr "deaktivieren"
+msgstr "Deaktivieren"
 
 #. Default: "committee admin"
 #: opengever/core/profiles/default/workflows/opengever_committee_workflow/specification.txt

--- a/opengever/core/locales/fr/LC_MESSAGES/opengever.core.po
+++ b/opengever/core/locales/fr/LC_MESSAGES/opengever.core.po
@@ -84,7 +84,7 @@ msgstr "Créer une offre d'archivage"
 #: ./opengever/core/upgrades/20180623132731_add_a_create_proposal_action/actions.xml
 #: ./opengever/core/upgrades/20180813145550_create_proposal_unavailable_if_meeting_feature_disabled/actions.xml
 msgid "Create Proposal"
-msgstr "Créer une proposition"
+msgstr "Créer une requête"
 
 #: ./opengever/core/profiles/default/actions.xml
 msgid "Create Task"
@@ -215,11 +215,11 @@ msgstr "Afficher les métadonnées"
 #. Default: "Proposal"
 #: ./opengever/core/profiles/default/types/opengever.meeting.proposal.xml
 msgid "Proposal"
-msgstr "Proposition"
+msgstr "Requête"
 
 #: ./opengever/core/profiles/default/types/opengever.meeting.proposaltemplate.xml
 msgid "Proposal Template"
-msgstr "Modèle de proposition"
+msgstr "Modèle de requête"
 
 #: ./opengever/core/profiles/default/types/opengever.repository.repositoryfolder.xml
 msgid "RepositoryFolder"
@@ -253,7 +253,7 @@ msgstr "Soumettre des pièces jointes additionnelles"
 
 #: ./opengever/core/profiles/default/types/opengever.meeting.submittedproposal.xml
 msgid "Submitted Proposal"
-msgstr "Proposition soumise"
+msgstr "Requête soumise"
 
 #: ./opengever/core/profiles/default/actions.xml
 #: ./opengever/core/upgrades/20180809152739_add_gever_ui_action/actions.xml

--- a/opengever/core/locales/fr/LC_MESSAGES/opengever.core.po
+++ b/opengever/core/locales/fr/LC_MESSAGES/opengever.core.po
@@ -20,7 +20,7 @@ msgstr "Participant"
 
 #: ./opengever/core/profiles/default/actions.xml
 msgid "Attach selection"
-msgstr "Envoyer par le programme de messagerie"
+msgstr "Envoyer par programme de messagerie"
 
 #: ./opengever/core/profiles/default/types/opengever.dossier.businesscasedossier.xml
 msgid "Business Case Dossier"
@@ -124,7 +124,7 @@ msgstr "Exporter comme fichier ZIP"
 
 #: ./opengever/core/profiles/default/actions.xml
 msgid "Export selection"
-msgstr "Exporter le choix"
+msgstr "Exporter la sélection"
 
 #: ./opengever/core/profiles/default/actions.xml
 msgid "Forward"
@@ -157,7 +157,7 @@ msgstr "Modèle de séance"
 
 #: ./opengever/core/profiles/default/actions.xml
 msgid "Move Items"
-msgstr "Déplacer d'éléments"
+msgstr "Déplacer éléments"
 
 #: ./opengever/core/profiles/default/actions.xml
 #: ./opengever/core/upgrades/20180122154722_add_my_invitation_action/actions.xml

--- a/opengever/core/locales/fr/LC_MESSAGES/plone.po
+++ b/opengever/core/locales/fr/LC_MESSAGES/plone.po
@@ -70,7 +70,7 @@ msgstr "Manager"
 #. Default: "A committe member is part of a committee and can view the committee data, such as meetings and proposals."
 #: opengever/core/profiles/default/workflows/opengever_committee_workflow/specification.txt
 msgid "opengever_committee_workflow--ROLE-DESCRIPTION--CommitteeMember"
-msgstr "Un membre de commission fait partie d'une commission et peut voir les contenus comme les séances et les propositions de la commission."
+msgstr "Un membre de commission fait partie d'une commission et peut voir les contenus comme les séances et les requêtes de la commission."
 
 #. Default: "The committe responsible is in charge of a committee. This involves creating, planing and hold meetings as well as configuring and deactivating the committee. The committee responsible role is assigned automatically to the group that can be configured per committee."
 #: opengever/core/profiles/default/workflows/opengever_committee_workflow/specification.txt

--- a/opengever/core/locales/fr/LC_MESSAGES/plone.po
+++ b/opengever/core/locales/fr/LC_MESSAGES/plone.po
@@ -45,7 +45,7 @@ msgstr "Reactiver"
 #. Default: "deactivate"
 #: opengever/core/profiles/default/workflows/opengever_committee_workflow/specification.txt
 msgid "deactivate"
-msgstr "déactiver"
+msgstr "Déactiver"
 
 #. Default: "committee admin"
 #: opengever/core/profiles/default/workflows/opengever_committee_workflow/specification.txt

--- a/opengever/disposition/locales/fr/LC_MESSAGES/opengever.disposition.po
+++ b/opengever/disposition/locales/fr/LC_MESSAGES/opengever.disposition.po
@@ -57,7 +57,7 @@ msgstr "Le période de rétention des dossiers sélectionnés n'est pas échue."
 #. Default: "Common"
 #: ./opengever/disposition/disposition.py
 msgid "fieldset_common"
-msgstr "En général"
+msgstr "Général"
 
 #. Default: "Action"
 #: ./opengever/disposition/browser/removal_protocol.py

--- a/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
@@ -19,7 +19,7 @@ msgstr ""
 #: ./opengever/document/upgrades/20170322142153_add_office_connector_multi_attach_action_to_documents/actions.xml
 #: ./opengever/document/upgrades/20170424163920_adjust_sort_order_of_actions/actions.xml
 msgid "Attach selection"
-msgstr "Envoyer par le programme de messagerie"
+msgstr "Envoyer par programme de messagerie"
 
 #: ./opengever/document/browser/edit.py
 msgid "Can't edit the document at moment, beacuse it's locked."
@@ -98,7 +98,7 @@ msgstr "Ne plus afficher ce message."
 
 #: ./opengever/document/upgrades/20161111090446_add_document_export_actions/actions.xml
 msgid "Export selection"
-msgstr "Exporter le choix"
+msgstr "Exporter la sélection"
 
 #: ./opengever/document/checkout/manager.py
 #: ./opengever/document/checkout/revert.py
@@ -228,7 +228,7 @@ msgstr "Fichier d'archivage"
 #: ./opengever/document/behaviors/related_docs.py
 #: ./opengever/document/document.py
 msgid "fieldset_common"
-msgstr "En général"
+msgstr "Général"
 
 #. Default: "Keep existing file"
 #: ./opengever/document/widgets/no_download_input.pt
@@ -296,7 +296,7 @@ msgstr "Mots-clés pour la description du document. Ne pas confondre avec le num
 
 #: ./opengever/document/behaviors/metadata.py
 msgid "help_preserved_as_paper"
-msgstr "Conserver sous forme papier"
+msgstr "Conservé sous forme papier"
 
 #: ./opengever/document/behaviors/metadata.py
 msgid "help_preview"
@@ -380,7 +380,7 @@ msgstr "Modifier le fichier d'archivage"
 #: ./opengever/document/browser/overview.py
 #: ./opengever/document/checkout/templates/checkedoutviewlet.pt
 msgid "label_checked_out"
-msgstr "Avec check-out"
+msgstr "En check-out"
 
 #. Default: "Journal Comment"
 #: ./opengever/document/checkout/checkin.py
@@ -410,7 +410,7 @@ msgstr "Créé"
 #. Default: "creator"
 #: ./opengever/document/browser/overview.py
 msgid "label_creator"
-msgstr "Auteur"
+msgstr "Créé par"
 
 #. Default: "Date"
 #: ./opengever/document/browser/versions_tab.py
@@ -588,7 +588,7 @@ msgstr "Réessayer avec Oneoffixx"
 #. Default: "Revert"
 #: ./opengever/document/browser/versions_tab.py
 msgid "label_revert"
-msgstr "Reculer"
+msgstr "Restaurer"
 
 #. Default: "Save PDF"
 #: ./opengever/document/browser/versions_tab.py

--- a/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
@@ -700,7 +700,7 @@ msgstr "Attention! En ouvrant le document de cette manière, toutes les modific
 #. Default: "This document is trashed."
 #: ./opengever/document/browser/tabbed.py
 msgid "warning_trashed"
-msgstr ""
+msgstr "Ce document se trouve dans la corbeille."
 
 #: ./opengever/document/upgrades/profiles/4000/actions.xml
 msgid "with comment"

--- a/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
@@ -206,12 +206,12 @@ msgstr "Vous n'avez sélectionné aucun élément."
 #: ./opengever/document/document.py
 #: ./opengever/document/quick_upload.py
 msgid "error_proposal_document_type"
-msgstr "Les documents de proposition doivent toujours être des fichiers Word. Les autres formats ne sont pas autorisés."
+msgstr "Les documents de requête doivent toujours être des fichiers Word. Les autres formats ne sont pas autorisés."
 
 #. Default: "It's not possible to have no file in proposal documents."
 #: ./opengever/document/document.py
 msgid "error_proposal_no_document"
-msgstr "Un document de proposition sans fichier n'est pas autorisé."
+msgstr "Un document de requête sans fichier n'est pas autorisé."
 
 #. Default: "Either the title or the file is required."
 #: ./opengever/document/document.py
@@ -558,7 +558,7 @@ msgstr "Aperçu"
 #. Default: "Proposal"
 #: ./opengever/document/browser/overview.py
 msgid "label_proposal"
-msgstr "Proposition"
+msgstr "Requête"
 
 #: ./opengever/document/browser/report.py
 msgid "label_public_trial"

--- a/opengever/dossier/locales/fr/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/fr/LC_MESSAGES/opengever.dossier.po
@@ -18,7 +18,7 @@ msgstr ""
 
 #: ./opengever/dossier/viewlets/byline.py
 msgid " (after resolve jobs pending)"
-msgstr ""
+msgstr " (tâches de clôturation nocturnes en suspens)"
 
 #: ./opengever/dossier/viewlets/byline.py
 msgid " (currently being resolved)"

--- a/opengever/dossier/locales/fr/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/fr/LC_MESSAGES/opengever.dossier.po
@@ -79,7 +79,7 @@ msgstr "Modifier le sous-dossier"
 
 #: ./opengever/dossier/upgrades/profiles/2601/actions.xml
 msgid "Export selection"
-msgstr "Exporter le choix"
+msgstr "Exporter la sélection"
 
 #: ./opengever/dossier/move_items.py
 msgid "Failed to copy following objects: ${failed_objects}"
@@ -343,13 +343,13 @@ msgstr "Vous n'avez sélectionné aucun élément."
 #. Default: "Common"
 #: ./opengever/dossier/behaviors/dossier.py
 msgid "fieldset_common"
-msgstr "En général"
+msgstr "Général"
 
 #. Default: "Filing"
 #: ./opengever/dossier/behaviors/dossier.py
 #: ./opengever/dossier/behaviors/filing.py
 msgid "fieldset_filing"
-msgstr "Classeur"
+msgstr "Stockage"
 
 #. Default: "Protect"
 #: ./opengever/dossier/behaviors/protect_dossier.py

--- a/opengever/dossier/locales/fr/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/fr/LC_MESSAGES/opengever.dossier.po
@@ -187,7 +187,7 @@ msgstr "La date de clôture du dossier ${dossier} n'est pas valable."
 
 #: ./opengever/dossier/resolve.py
 msgid "The dossier contains active proposals."
-msgstr "Le dossier contient des propositions actives."
+msgstr "Le dossier contient des requêtes actives."
 
 #: ./opengever/dossier/resolve.py
 msgid "The dossier has been succesfully resolved."
@@ -670,7 +670,7 @@ msgstr "Le numéro de classement est seulement généré lors de la création du
 #. Default: "Document ${name} is inside a proposal and therefore not movable. Move the proposal instead"
 #: ./opengever/dossier/move_items.py
 msgid "label_not_movable_since_inside_proposal"
-msgstr "Le document «${name}» est dans une proposition et ne peut pas être déplacé. Déplacez la proposition."
+msgstr "Le document «${name}» est dans une requête et ne peut pas être déplacé. Déplacez la requête."
 
 #. Default: "Document ${name} is inside a task and therefore not movable. Move the task instead"
 #: ./opengever/dossier/move_items.py
@@ -720,12 +720,12 @@ msgstr "Prédéfinition des mots-clés"
 #. Default: "Proposal Templates"
 #: ./opengever/dossier/browser/tabbed.py
 msgid "label_proposal_templates"
-msgstr "Modèles pour la soumission de propositions"
+msgstr "Modèles pour la soumission de requêtes"
 
 #. Default: "Proposals"
 #: ./opengever/dossier/browser/tabbed.py
 msgid "label_proposals"
-msgstr "Propositions"
+msgstr "Requêtes"
 
 #. Default: "Reading"
 #: ./opengever/dossier/behaviors/protect_dossier.py

--- a/opengever/globalindex/locales/fr/LC_MESSAGES/opengever.globalindex.po
+++ b/opengever/globalindex/locales/fr/LC_MESSAGES/opengever.globalindex.po
@@ -18,7 +18,7 @@ msgstr ""
 
 #: ./opengever/globalindex/upgrades/profiles/2601/actions.xml
 msgid "Export selection"
-msgstr "Exporter le choix"
+msgstr "Exporter la sélection"
 
 #. Default: "You have not selected any items."
 #: ./opengever/globalindex/browser/report.py

--- a/opengever/inbox/locales/fr/LC_MESSAGES/opengever.inbox.po
+++ b/opengever/inbox/locales/fr/LC_MESSAGES/opengever.inbox.po
@@ -31,7 +31,7 @@ msgstr "Conteneur de la boîte de réception"
 #. Default: "Close"
 #: ./opengever/inbox/browser/close.py
 msgid "close"
-msgstr "Fermer"
+msgstr "Clôturer"
 
 #. Default: "Your not allowed to access the inbox of ${current_org_unit}."
 #: ./opengever/inbox/browser/view.py
@@ -114,9 +114,9 @@ msgstr "Envoyer le transfert"
 #. Default: "Close orwarding"
 #: ./opengever/inbox/browser/close.py
 msgid "title_close_forwarding"
-msgstr "Fermer le transfert"
+msgstr "Clôturer le transfert"
 
 #. Default: "Closed ${year}"
 #: ./opengever/inbox/yearfolder.py
 msgid "yearfolder_title"
-msgstr "Fermé ${year}"
+msgstr "Clôturé ${year}"

--- a/opengever/inbox/locales/fr/LC_MESSAGES/opengever.inbox.po
+++ b/opengever/inbox/locales/fr/LC_MESSAGES/opengever.inbox.po
@@ -46,7 +46,7 @@ msgstr "Erreur: Choisissez au minimum un document à transmettre."
 #. Default: "Common"
 #: ./opengever/inbox/inbox.py
 msgid "fieldset_common"
-msgstr "En général"
+msgstr "Général"
 
 #. Default: "Forwarding"
 #: ./opengever/inbox/forwarding.py

--- a/opengever/journal/locales/fr/LC_MESSAGES/opengever.journal.po
+++ b/opengever/journal/locales/fr/LC_MESSAGES/opengever.journal.po
@@ -25,13 +25,13 @@ msgstr "Historique"
 #. Default: "Changed by"
 #: ./opengever/journal/tab.py
 msgid "label_actor"
-msgstr "Modifier par"
+msgstr "Modifié par"
 
 #. Default: "Add journal entry"
 #: ./opengever/journal/form.py
 #: ./opengever/journal/templates/journal_selection.pt
 msgid "label_add_journal_entry"
-msgstr "Ajouter une entrée de journal"
+msgstr "Ajouter une entrée à l'historique"
 
 #. Default: "Attachments deleted: ${filenames}"
 #: ./opengever/journal/handlers.py
@@ -292,7 +292,7 @@ msgstr "Tâche modifiée: ${title}"
 #. Default: "Time"
 #: ./opengever/journal/tab.py
 msgid "label_time"
-msgstr "date"
+msgstr "Date"
 
 #. Default: "Title"
 #: ./opengever/journal/tab.py

--- a/opengever/journal/vdexvocabs/manual_journal_entry_categories.vdex
+++ b/opengever/journal/vdexvocabs/manual_journal_entry_categories.vdex
@@ -19,8 +19,8 @@
             <langstring language="en">Meeting</langstring>
             <langstring language="de-ch">Sitzung</langstring>
             <langstring language="de">Sitzung</langstring>
-            <langstring language="fr">Séances</langstring>
-            <langstring language="fr-ch">Séances</langstring>
+            <langstring language="fr">Séance</langstring>
+            <langstring language="fr-ch">Séance</langstring>
         </caption>
     </term>
     <term>

--- a/opengever/mail/locales/fr/LC_MESSAGES/opengever.mail.po
+++ b/opengever/mail/locales/fr/LC_MESSAGES/opengever.mail.po
@@ -248,4 +248,4 @@ msgstr "Destinataire"
 #. Default: "This mail is trashed."
 #: ./opengever/mail/browser/tabbed.py
 msgid "warning_trashed"
-msgstr ""
+msgstr "Ce courriel se trouve dans la corbeille"

--- a/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-02-28 07:21+0000\n"
+"POT-Creation-Date: 2019-05-09 08:18+0000\n"
 "PO-Revision-Date: 2017-10-23 18:40+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -804,7 +804,6 @@ msgstr "Abgeschlossen"
 
 #. Default: "Agenda item header template for the protocol"
 #: ./opengever/meeting/committee.py
-#: ./opengever/meeting/committeecontainer.py
 msgid "label_agenda_item_header_template"
 msgstr "Kopfvorlage Traktandum in Protokoll"
 
@@ -820,7 +819,6 @@ msgstr "Nummer des Traktandums in dieser Sitzung (unformattiert)"
 
 #. Default: "Agenda item suffix template for the protocol"
 #: ./opengever/meeting/committee.py
-#: ./opengever/meeting/committeecontainer.py
 msgid "label_agenda_item_suffix_template"
 msgstr "Schlussteilvorlage Traktandum in Protokoll"
 
@@ -832,7 +830,6 @@ msgstr "Traktandenliste"
 
 #. Default: "Agendaitem list template"
 #: ./opengever/meeting/committee.py
-#: ./opengever/meeting/committeecontainer.py
 msgid "label_agendaitem_list_template"
 msgstr "Vorlage Traktandenliste"
 
@@ -1104,13 +1101,11 @@ msgstr "Protokollauszug"
 
 #. Default: "Excerpt header template"
 #: ./opengever/meeting/committee.py
-#: ./opengever/meeting/committeecontainer.py
 msgid "label_excerpt_header_template"
 msgstr "Vorlage Kopf für Protokollauszüge"
 
 #. Default: "Excerpt suffix template"
 #: ./opengever/meeting/committee.py
-#: ./opengever/meeting/committeecontainer.py
 msgid "label_excerpt_suffix_template"
 msgstr "Vorlage Schlussteil für Protokollauszüge"
 
@@ -1243,7 +1238,6 @@ msgstr "Weitere Teilnehmende"
 
 #. Default: "Paragraph template"
 #: ./opengever/meeting/committee.py
-#: ./opengever/meeting/committeecontainer.py
 msgid "label_paragraph_template"
 msgstr "Vorlage für Zwischentitel"
 
@@ -1279,7 +1273,6 @@ msgstr "Protokollgenehmigung"
 
 #. Default: "Protocol header template"
 #: ./opengever/meeting/committee.py
-#: ./opengever/meeting/committeecontainer.py
 msgid "label_protocol_header_template"
 msgstr "Vorlage Protokollkopf"
 
@@ -1290,7 +1283,6 @@ msgstr "Beginn Seitennummerierung Protokoll"
 
 #. Default: "Protocol suffix template"
 #: ./opengever/meeting/committee.py
-#: ./opengever/meeting/committeecontainer.py
 msgid "label_protocol_suffix_template"
 msgstr "Vorlage Schlussteil des Protokolls"
 
@@ -1382,7 +1374,6 @@ msgstr "Titel"
 
 #. Default: "Table of contents template"
 #: ./opengever/meeting/committee.py
-#: ./opengever/meeting/committeecontainer.py
 msgid "label_toc_template"
 msgstr "Vorlage Inhaltsverzeichnis"
 
@@ -1658,6 +1649,11 @@ msgstr "In Bearbeitung"
 #: ./opengever/meeting/browser/tabbed.py
 msgid "periods"
 msgstr "Perioden"
+
+#. Default: "Predecessor proposal"
+#: ./opengever/meeting/proposal.py
+msgid "predecessor_proposal_label"
+msgstr "Vorgängiger Antrag"
 
 #. Default: "Document ${title} submitted"
 #: ./opengever/meeting/activity/activities.py

--- a/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
@@ -90,7 +90,7 @@ msgstr "Voulez-vous vraiment déposer l'extrait du protocole dans le dossier d'o
 
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt
 msgid "Are you sure, you want to decide this agendaitem?"
-msgstr "Êtes-vous sûr de vouloir clôturer ce point de l'ordre du jour?"
+msgstr "Êtes-vous sûr de vouloir clôturer ce point à l'ordre du jour?"
 
 #: ./opengever/meeting/browser/memberships.py
 msgid "Can't add membership, it overlaps an existing membership from ${date_from} to ${date_to}."
@@ -243,7 +243,7 @@ msgstr "Enlever"
 
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt
 msgid "Unschedule proposal"
-msgstr "Enlever le point de l'ordre du jour"
+msgstr "Enlever le point à l'ordre du jour"
 
 #: ./opengever/meeting/browser/submitdocuments.py
 msgid "Updated with a newer docment version from proposal's dossier."
@@ -288,7 +288,7 @@ msgstr "Télécharger les fichiers docxcompose"
 #. Default: "Decide"
 #: ./opengever/meeting/browser/meetings/meeting.py
 msgid "action_decide"
-msgstr "Clôturer un point de l'ordre du jour"
+msgstr "Clôturer un point à l'ordre du jour"
 
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt
 msgid "action_download_document"
@@ -311,7 +311,7 @@ msgstr "Générer l'extrait de protocole"
 #. Default: "Remove agenda item"
 #: ./opengever/meeting/browser/meetings/meeting.py
 msgid "action_remove_agenda_item"
-msgstr "Supprimer le point de l'ordre du jour"
+msgstr "Supprimer le point à l'ordre du jour"
 
 #. Default: "Remove paragraph"
 #: ./opengever/meeting/browser/meetings/meeting.py
@@ -321,7 +321,7 @@ msgstr "Supprimer l'intertitre"
 #. Default: "Rename agenda item"
 #: ./opengever/meeting/browser/meetings/meeting.py
 msgid "action_rename_agenda_item"
-msgstr "Editer le point de l'ordre du jour"
+msgstr "Editer le point à l'ordre du jour"
 
 #. Default: "Rename paragraph"
 #: ./opengever/meeting/browser/meetings/meeting.py
@@ -355,17 +355,17 @@ msgstr "Actif"
 #: ./opengever/meeting/toc/repository.py
 #: ./opengever/meeting/toc/repository_refnum.py
 msgid "ad_hoc_toc_group_title"
-msgstr "Points de l'ordre du jour sans demande"
+msgstr "Points à l'ordre du jour sans demande"
 
 #. Default: "Cannot decide agenda item: someone else has checked out the document."
 #: ./opengever/meeting/browser/meetings/agendaitem.py
 msgid "agenda_item_cannot_decide_document_checked_out"
-msgstr "Le point de l'ordre du jour ne peut pas être clôturé: le document de décision a été extrait par quelqu'un d'autre."
+msgstr "Le point à l'ordre du jour ne peut pas être clôturé: le document de décision a été extrait par quelqu'un d'autre."
 
 #. Default: "Agenda Item decided."
 #: ./opengever/meeting/browser/meetings/agendaitem.py
 msgid "agenda_item_decided"
-msgstr "Le point de l'ordre du jour a été clôturé."
+msgstr "Le point à l'ordre du jour a été clôturé."
 
 #. Default: "Agenda Item Successfully deleted"
 #: ./opengever/meeting/browser/meetings/agendaitem.py
@@ -375,37 +375,37 @@ msgstr "Le point a été enlevé avec succès de l'ordre du jour."
 #. Default: "Agendaitem has been decided and the meeting has been held."
 #: ./opengever/meeting/browser/meetings/agendaitem.py
 msgid "agenda_item_meeting_held"
-msgstr "Le point de l'ordre du jour a été clôturé et la séance a eu lieu."
+msgstr "Le point à l'ordre du jour a été clôturé et la séance a eu lieu."
 
 #. Default: "Agenda Item order updated."
 #: ./opengever/meeting/browser/meetings/agendaitem.py
 msgid "agenda_item_order_updated"
-msgstr "Les points de l'ordre du jour ont été réarrangés."
+msgstr "Les points à l'ordre du jour ont été réarrangés."
 
 #. Default: "Agenda Item successfully reopened."
 #: ./opengever/meeting/browser/meetings/agendaitem.py
 msgid "agenda_item_reopened"
-msgstr "Le point de l'ordre du jour a été rouvert."
+msgstr "Le point à l'ordre du jour a été rouvert."
 
 #. Default: "Agenda Item revised successfully."
 #: ./opengever/meeting/browser/meetings/agendaitem.py
 msgid "agenda_item_revised"
-msgstr "Le point de l'ordre du jour a été révisé avec succès."
+msgstr "Le point à l'ordre du jour a été révisé avec succès."
 
 #. Default: "Agenda Item title must not be empty."
 #: ./opengever/meeting/browser/meetings/agendaitem.py
 msgid "agenda_item_update_empty_string"
-msgstr "Le titre d'un point de l'ordre du jour ne peut pas être laissé vide."
+msgstr "Le titre d'un point à l'ordre du jour ne peut pas être laissé vide."
 
 #. Default: "Agenda Item title is too long."
 #: ./opengever/meeting/browser/meetings/agendaitem.py
 msgid "agenda_item_update_too_long_title"
-msgstr "Le titre du point de l'ordre du jour est trop long."
+msgstr "Le titre du point à l'ordre du jour est trop long."
 
 #. Default: "Agenda Item updated."
 #: ./opengever/meeting/browser/meetings/agendaitem.py
 msgid "agenda_item_updated"
-msgstr "Le point de l'ordre du jour a été mis à jour avec succès."
+msgstr "Le point à l'ordre du jour a été mis à jour avec succès."
 
 #. Default: "All"
 #: ./opengever/meeting/browser/documents/proposalstab.py
@@ -589,7 +589,7 @@ msgstr "Décider"
 #. Default: "Decide Agendaitem"
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt
 msgid "decide_agendaitem"
-msgstr "Clôturer un point de l'ordre du jour"
+msgstr "Clôturer un point à l'ordre du jour"
 
 #. Default: "Decided"
 #: ./opengever/meeting/browser/documents/proposalstab.py
@@ -667,7 +667,7 @@ msgstr "Ce texte libre ne doit pas être vide."
 #. Default: "The default ad-hoc agenda item template has to be amongst the allowed ones for this committee."
 #: ./opengever/meeting/committee.py
 msgid "error_default_template_is_in_allowed_templates"
-msgstr "Le modèle pour les points de l'ordre du jour sans demande doit être sélectionné parmis les modèles autorisés."
+msgstr "Le modèle pour les points à l'ordre du jour sans demande doit être sélectionné parmis les modèles autorisés."
 
 #. Default: "Cannot change the state because the proposal contains checked out documents."
 #: ./opengever/meeting/proposal_transition_comment.py
@@ -727,22 +727,22 @@ msgstr "Modèles protocole"
 #. Default: "Alphabetical Toc ${period} ${committee}"
 #: ./opengever/meeting/browser/toc.py
 msgid "filename_alphabetical_toc"
-msgstr "Table de matière ${period} ${committee} alphabétique"
+msgstr "Table des matières ${period} ${committee} alphabétique"
 
 #. Default: "Dossier Reference Number Toc ${period} ${committee}"
 #: ./opengever/meeting/browser/toc.py
 msgid "filename_dossier_reference_number_toc"
-msgstr "Table de matière ${period} ${committee} selon Numéro de référence"
+msgstr "Table des matières ${period} ${committee} selon Numéro de référence"
 
 #. Default: "Repository Reference Number Toc ${period} ${committee}"
 #: ./opengever/meeting/browser/toc.py
 msgid "filename_repository_reference_number_toc"
-msgstr "Table de matière ${period} ${committee} selon Numéro de classement"
+msgstr "Table des matières ${period} ${committee} selon Numéro de classement"
 
 #. Default: "Repository Toc ${period} ${committee}"
 #: ./opengever/meeting/browser/toc.py
 msgid "filename_repository_toc"
-msgstr "Table de matière ${period} ${committee} selon l'ordre des points"
+msgstr "Table des matières ${period} ${committee} selon l'ordre des points"
 
 #. Default: "Held"
 #: ./opengever/meeting/model/meeting.py
@@ -752,7 +752,7 @@ msgstr "Tenue"
 #. Default: "Select the ad-hoc agenda item templates allowed for this commitee, or select no templates for allowing all templates."
 #: ./opengever/meeting/committee.py
 msgid "help_allowed_ad_hoc_agenda_item_templates"
-msgstr "Choisissez tous les modèles pour les points de l'ordre du jour sans demande autorisés dans ce comité. Ne choisissez aucun modèle de proposition pour autoriser tous les modèles."
+msgstr "Choisissez tous les modèles pour les points à l'ordre du jour sans demande autorisés dans ce comité. Ne choisissez aucun modèle de proposition pour autoriser tous les modèles."
 
 #. Default: "Select the proposal templates allowed for this commitee, or select no templates for allowing all templates."
 #: ./opengever/meeting/committee.py
@@ -792,12 +792,12 @@ msgstr "Inactif"
 #. Default: "The agenda item is in an invalid state for this action."
 #: ./opengever/meeting/browser/meetings/agendaitem.py
 msgid "invalid_agenda_item_state"
-msgstr "Cette action ne peut pas être effectuée dans l'état actuel de ce point de l'ordre du jour."
+msgstr "Cette action ne peut pas être effectuée dans l'état actuel de ce point à l'ordre du jour."
 
 #. Default: "Ad hoc agenda item template"
 #: ./opengever/meeting/committee.py
 msgid "label_ad_hoc_template"
-msgstr "Modèle pour les points de l'ordre du jour sans demande"
+msgstr "Modèle pour les points à l'ordre du jour sans proposition"
 
 #. Default: "Decided"
 #: ./opengever/meeting/browser/meetings/meeting.py
@@ -808,23 +808,23 @@ msgstr "Clôturé"
 #: ./opengever/meeting/committee.py
 #: ./opengever/meeting/committeecontainer.py
 msgid "label_agenda_item_header_template"
-msgstr "Modèle pour l'en-tête d'un point de l'ordre du jour dans le protocole"
+msgstr "Modèle pour l'en-tête d'un point à l'ordre du jour dans le protocole"
 
 #. Default: "Agenda item number"
 #: ./opengever/meeting/browser/meetings/meeting.py
 msgid "label_agenda_item_number"
-msgstr "Numéro du point de l'ordre du jour dans cette séance"
+msgstr "Numéro du point à l'ordre du jour dans cette séance"
 
 #. Default: "Agenda item number (unformatted)"
 #: ./opengever/meeting/browser/meetings/meeting.py
 msgid "label_agenda_item_number_raw"
-msgstr "Numéro du point de l'ordre du jour dans cette séance (non-formatté)"
+msgstr "Numéro du point à l'ordre du jour dans cette séance (non-formatté)"
 
 #. Default: "Agenda item suffix template for the protocol"
 #: ./opengever/meeting/committee.py
 #: ./opengever/meeting/committeecontainer.py
 msgid "label_agenda_item_suffix_template"
-msgstr "Modèle pour la partie finale d'un point de l'ordre du jour dans le protocole"
+msgstr "Modèle pour la partie finale d'un point à l'ordre du jour dans le protocole"
 
 #. Default: "Agendaitem list"
 #: ./opengever/meeting/model/meeting.py
@@ -841,7 +841,7 @@ msgstr "Modèle de l'ordre du jour"
 #. Default: "Allowed ad-hoc agenda item templates"
 #: ./opengever/meeting/committee.py
 msgid "label_allowed_ad_hoc_agenda_item_templates"
-msgstr "Modèles pour les points de l'ordre du jour sans demande autorisés"
+msgstr "Modèles pour les points à l'ordre du jour sans proposition autorisés"
 
 #. Default: "Allowed proposal templates"
 #: ./opengever/meeting/committee.py
@@ -888,7 +888,7 @@ msgstr "Annuler la séance"
 #. Default: "The meeting cannot be closed because it has undecided agenda items."
 #: ./opengever/meeting/model/meeting.py
 msgid "label_close_error_has_undecided_agenda_items"
-msgstr "La séance ne peut pas être clôturée avant que tous les points de l'ordre du jour ne soient clôturés et les extraits de protocol générés et déposés comme réponse dans le dossier d'origine de la demande."
+msgstr "La séance ne peut pas être clôturée avant que tous les points à l'ordre du jour ne soient clôturés et les extraits de protocol générés et déposés comme réponse dans le dossier d'origine de la demande."
 
 #. Default: "Closed meetings"
 #: ./opengever/meeting/browser/committee.py
@@ -1009,42 +1009,42 @@ msgstr "Dossier indisponible"
 #. Default: "download TOC alphabetical"
 #: ./opengever/meeting/browser/templates/periods.pt
 msgid "label_download_alphabetical_toc"
-msgstr "Table de matière alphabétique"
+msgstr "Table des matières alphabétique"
 
 #. Default: "download TOC json alphabetical"
 #: ./opengever/meeting/browser/templates/periods.pt
 msgid "label_download_alphabetical_toc_json"
-msgstr "Table de matière alphabétique JSON"
+msgstr "Table des matières alphabétique JSON"
 
 #. Default: "download TOC by dossier reference number"
 #: ./opengever/meeting/browser/templates/periods.pt
 msgid "label_download_dossier_refnum_toc"
-msgstr "Table de matière selon le Numéro de référence"
+msgstr "Table des matières selon le Numéro de référence"
 
 #. Default: "download TOC json by dossier reference number"
 #: ./opengever/meeting/browser/templates/periods.pt
 msgid "label_download_dossier_refnum_toc_json"
-msgstr "Table de matière selon le Numéro de référence JSON"
+msgstr "Table des matières selon le Numéro de référence JSON"
 
 #. Default: "download TOC by repository reference number"
 #: ./opengever/meeting/browser/templates/periods.pt
 msgid "label_download_repository_refnum_toc"
-msgstr "Table de matière selon le Numéro de classement"
+msgstr "Table des matières selon le Numéro de classement"
 
 #. Default: "download TOC json by repository reference number"
 #: ./opengever/meeting/browser/templates/periods.pt
 msgid "label_download_repository_refnum_toc_json"
-msgstr "Table de matière selon le Numéro de classement JSON"
+msgstr "Table des matières selon le Numéro de classement JSON"
 
 #. Default: "download TOC by repository"
 #: ./opengever/meeting/browser/templates/periods.pt
 msgid "label_download_repository_toc"
-msgstr "Table de matière selon l'ordre des points"
+msgstr "Table des matières selon l'ordre des points"
 
 #. Default: "download TOC json repository"
 #: ./opengever/meeting/browser/templates/periods.pt
 msgid "label_download_repository_toc_json"
-msgstr "Table de matière selon l'ordre des points JSON"
+msgstr "Table des matières selon l'ordre des points JSON"
 
 #. Default: "Download Zip of original files"
 #: ./opengever/meeting/browser/meetings/templates/demand_zip.pt
@@ -1108,7 +1108,7 @@ msgstr "Extrait du protocole"
 #: ./opengever/meeting/committee.py
 #: ./opengever/meeting/committeecontainer.py
 msgid "label_excerpt_header_template"
-msgstr "Modèle en-tête pour les extraits de protocole"
+msgstr "Modèle pour l'en-tête des extraits de protocole"
 
 #. Default: "Excerpt suffix template"
 #: ./opengever/meeting/committee.py
@@ -1386,7 +1386,7 @@ msgstr "Titre"
 #: ./opengever/meeting/committee.py
 #: ./opengever/meeting/committeecontainer.py
 msgid "label_toc_template"
-msgstr "Modèle de la table de matière"
+msgstr "Modèle de la table des matières"
 
 #. Default: "Toggle attachments"
 #: ./opengever/meeting/browser/meetings/meeting.py
@@ -1406,12 +1406,12 @@ msgstr "Modification d'état ${transition} exécutée"
 #. Default: "Are you sure you want to unschedule this agendaitem?"
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt
 msgid "label_unschedule_agenda_item_confirm_text"
-msgstr "Êtes-vous sûr de vouloir enlever ce point de l'ordre du jour?"
+msgstr "Êtes-vous sûr de vouloir enlever ce point à l'ordre du jour?"
 
 #. Default: "Unscheduled proposals"
 #: ./opengever/meeting/browser/committee.py
 msgid "label_unscheduled_proposals"
-msgstr "Propositions imprévues"
+msgstr "Propositions non-agendées"
 
 #. Default: "Upcoming meetings"
 #: ./opengever/meeting/browser/committee.py
@@ -1502,7 +1502,7 @@ msgstr "Vos modifications n'ont pas pu être sauvegardées; le protocole a été
 #. Default: "No ad-hoc agenda-item template has been configured."
 #: ./opengever/meeting/browser/meetings/agendaitem.py
 msgid "missing_ad_hoc_template"
-msgstr "Aucun modèle n'a pu être trouvé pour un point de l'ordre du jour."
+msgstr "Aucun modèle n'a pu être trouvé pour un point à l'ordre du jour."
 
 #. Default: "Choose a meaningful title to distinguish the created excerpts better."
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt
@@ -1532,7 +1532,7 @@ msgstr "Aucun modèle n'est configuré pour l'ordre du jour; l'ordre du jour n'a
 #. Default: "When deciding an agendaitem the agenda list is no longer editable."
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt
 msgid "msg_hold_meeting_dialog"
-msgstr "L'ordre du jour ne pourra plus être modifié après la clôture d'un point de l'ordre du jour."
+msgstr "L'ordre du jour ne pourra plus être modifié après la clôture d'un point à l'ordre du jour."
 
 #. Default: "The selected committeee has been deactivated, the proposal could not been submitted."
 #: ./opengever/meeting/model/proposal.py
@@ -1587,7 +1587,7 @@ msgstr "Proposition soumise avec succès."
 #. Default: "The meeting can only be closed when all agenda items are decided."
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt
 msgid "msg_require_all_agenda_items_decided_for_closing"
-msgstr "La séance ne pourra être clôturée que lorsque tous les points de l'ordre du jour seront clôturés et les extraits de protocol générés et déposés comme réponse dans le dossier d'origine de la demande."
+msgstr "La séance ne pourra être clôturée que lorsque tous les points à l'ordre du jour seront clôturés et les extraits de protocol générés et déposés comme réponse dans le dossier d'origine de la demande."
 
 #. Default: "Some documents could not be converted to PDF, their original files will be included in the Zip."
 #: ./opengever/meeting/browser/meetings/zipexport.py
@@ -1850,7 +1850,7 @@ msgstr "Texte libre ajouté à l'ordre du jour avec succès."
 #. Default: "Agenda item ${agenda_item_number}"
 #: ./opengever/meeting/zipexport.py
 msgid "title_agenda_item"
-msgstr "Point de l'ordre du jour ${number}"
+msgstr "point à l'ordre du jour ${number}"
 
 #. Default: "Delete proposal"
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt
@@ -1870,7 +1870,7 @@ msgstr "Export fichier Zip: ${title}"
 #. Default: "Remove from schedule"
 #: ./opengever/meeting/model/proposal.py
 msgid "un-schedule"
-msgstr "Enlever le point de l'ordre du jour"
+msgstr "Enlever le point à l'ordre du jour"
 
 #. Default: "Add"
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt
@@ -1880,17 +1880,17 @@ msgstr "Ajouter"
 #. Default: "Add section header:"
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt
 msgid "view_label_add_section_header"
-msgstr "Insérer l'intertitre:"
+msgstr "Insérer un intertitre:"
 
 #. Default: "Agenda items"
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt
 msgid "view_label_agenda_items"
-msgstr "Les points de l'ordre du jour"
+msgstr "Les points à l'ordre du jour"
 
 #. Default: "Schedule ad hoc agenda item:"
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt
 msgid "view_label_schedule_ad_hoc"
-msgstr "Insérer le point de l'ordre du jour:"
+msgstr "Insérer le point à l'ordre du jour:"
 
 #. Default: "Schedule proposal:"
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt

--- a/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-02-28 07:21+0000\n"
+"POT-Creation-Date: 2019-05-09 08:18+0000\n"
 "PO-Revision-Date: 2018-05-22 10:15+0000\n"
 "Last-Translator: Niklaus Johner <Niklaus.johner@4teamwork.ch>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-meeting/fr/>\n"
@@ -806,7 +806,6 @@ msgstr "Clôturé"
 
 #. Default: "Agenda item header template for the protocol"
 #: ./opengever/meeting/committee.py
-#: ./opengever/meeting/committeecontainer.py
 msgid "label_agenda_item_header_template"
 msgstr "Modèle pour l'en-tête d'un point à l'ordre du jour dans le protocole"
 
@@ -822,7 +821,6 @@ msgstr "Numéro du point à l'ordre du jour dans cette séance (non-formatté)"
 
 #. Default: "Agenda item suffix template for the protocol"
 #: ./opengever/meeting/committee.py
-#: ./opengever/meeting/committeecontainer.py
 msgid "label_agenda_item_suffix_template"
 msgstr "Modèle pour la partie finale d'un point à l'ordre du jour dans le protocole"
 
@@ -834,7 +832,6 @@ msgstr "Liste des points du jour"
 
 #. Default: "Agendaitem list template"
 #: ./opengever/meeting/committee.py
-#: ./opengever/meeting/committeecontainer.py
 msgid "label_agendaitem_list_template"
 msgstr "Modèle de l'ordre du jour"
 
@@ -1106,13 +1103,11 @@ msgstr "Extrait du protocole"
 
 #. Default: "Excerpt header template"
 #: ./opengever/meeting/committee.py
-#: ./opengever/meeting/committeecontainer.py
 msgid "label_excerpt_header_template"
 msgstr "Modèle pour l'en-tête des extraits de protocole"
 
 #. Default: "Excerpt suffix template"
 #: ./opengever/meeting/committee.py
-#: ./opengever/meeting/committeecontainer.py
 msgid "label_excerpt_suffix_template"
 msgstr "Modèle pour la partie finale des extraits de protocole"
 
@@ -1245,7 +1240,6 @@ msgstr "Autres participants"
 
 #. Default: "Paragraph template"
 #: ./opengever/meeting/committee.py
-#: ./opengever/meeting/committeecontainer.py
 msgid "label_paragraph_template"
 msgstr "Modèle pour l'intertitre"
 
@@ -1281,7 +1275,6 @@ msgstr "Approbation du procès-verbal"
 
 #. Default: "Protocol header template"
 #: ./opengever/meeting/committee.py
-#: ./opengever/meeting/committeecontainer.py
 msgid "label_protocol_header_template"
 msgstr "Modèle pour l'en-tête du protocole"
 
@@ -1292,7 +1285,6 @@ msgstr "Début de la numérotation de pages du protocole"
 
 #. Default: "Protocol suffix template"
 #: ./opengever/meeting/committee.py
-#: ./opengever/meeting/committeecontainer.py
 msgid "label_protocol_suffix_template"
 msgstr "Modèle pour la partie finale du protocole"
 
@@ -1384,7 +1376,6 @@ msgstr "Titre"
 
 #. Default: "Table of contents template"
 #: ./opengever/meeting/committee.py
-#: ./opengever/meeting/committeecontainer.py
 msgid "label_toc_template"
 msgstr "Modèle de la table des matières"
 
@@ -1660,6 +1651,11 @@ msgstr "En modification"
 #: ./opengever/meeting/browser/tabbed.py
 msgid "periods"
 msgstr "Périodes"
+
+#. Default: "Predecessor proposal"
+#: ./opengever/meeting/proposal.py
+msgid "predecessor_proposal_label"
+msgstr "Requête prédécesseur"
 
 #. Default: "Document ${title} submitted"
 #: ./opengever/meeting/activity/activities.py

--- a/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
@@ -186,11 +186,11 @@ msgstr "Propriétés"
 #. Default: "Proposal"
 #: ./opengever/meeting/browser/documents/submit.py
 msgid "Proposal"
-msgstr "Proposition"
+msgstr "Requête"
 
 #: ./opengever/meeting/upgrades/20170407103324_add_proposal_template_fti/types/opengever.meeting.proposaltemplate.xml
 msgid "Proposal Template"
-msgstr "Modèle de proposition"
+msgstr "Modèle de requête"
 
 #: ./opengever/meeting/model/meeting.py
 msgid "Protocol"
@@ -231,7 +231,7 @@ msgstr "La séance et le dossier y associé ont été créés avec succès."
 
 #: ./opengever/meeting/model/proposal.py
 msgid "The proposal has been rejected successfully"
-msgstr "La proposition a été rejetée avec succès."
+msgstr "La requête a été rejetée avec succès."
 
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt
 msgid "The protocol has been modified manually. These modifications will be lost if you regenerate the protocol."
@@ -247,7 +247,7 @@ msgstr "Enlever le point à l'ordre du jour"
 
 #: ./opengever/meeting/browser/submitdocuments.py
 msgid "Updated with a newer docment version from proposal's dossier."
-msgstr "Le document a été écrasé par une version plus récente provenant du dossier d'origine de la demande."
+msgstr "Le document a été écrasé par une version plus récente provenant du dossier d'origine de la requête."
 
 #: ./opengever/meeting/browser/excerpt.py
 msgid "Updated with a newer excerpt version."
@@ -355,7 +355,7 @@ msgstr "Actif"
 #: ./opengever/meeting/toc/repository.py
 #: ./opengever/meeting/toc/repository_refnum.py
 msgid "ad_hoc_toc_group_title"
-msgstr "Points à l'ordre du jour sans demande"
+msgstr "Points à l'ordre du jour sans requête"
 
 #. Default: "Cannot decide agenda item: someone else has checked out the document."
 #: ./opengever/meeting/browser/meetings/agendaitem.py
@@ -445,12 +445,12 @@ msgstr "Continuer"
 #. Default: "Create protocol approval proposal"
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt
 msgid "button_create_protocol_approval_proposal"
-msgstr "Créer proposition d'approbation"
+msgstr "Créer requête d'approbation"
 
 #. Default: "Create successor proposal"
 #: ./opengever/meeting/browser/templates/proposaloverview.pt
 msgid "button_create_successor_proposal"
-msgstr "Créer une demande ultérieure"
+msgstr "Créer une requête ultérieure"
 
 #. Default: "Submit Attachments"
 #: ./opengever/meeting/browser/documents/submit.py
@@ -667,12 +667,12 @@ msgstr "Ce texte libre ne doit pas être vide."
 #. Default: "The default ad-hoc agenda item template has to be amongst the allowed ones for this committee."
 #: ./opengever/meeting/committee.py
 msgid "error_default_template_is_in_allowed_templates"
-msgstr "Le modèle pour les points à l'ordre du jour sans demande doit être sélectionné parmis les modèles autorisés."
+msgstr "Le modèle pour les points à l'ordre du jour sans requête doit être sélectionné parmis les modèles autorisés."
 
 #. Default: "Cannot change the state because the proposal contains checked out documents."
 #: ./opengever/meeting/proposal_transition_comment.py
 msgid "error_must_checkin_documents_for_transition"
-msgstr "L'état ne peut pas être changé tant que la proposition contient des documents qui ont été extraits."
+msgstr "L'état ne peut pas être changé tant que la requête contient des documents qui ont été extraits."
 
 #. Default: "Insufficient privileges to add a document to the meeting dossier."
 #: ./opengever/meeting/browser/meetings/agendaitem.py
@@ -682,7 +682,7 @@ msgstr "Autorisations insuffisantes pour ajouter un document au dossier de séan
 #. Default: "Only .docx files allowed as proposal documents."
 #: ./opengever/meeting/browser/proposalforms.py
 msgid "error_only_docx_files_allowed_as_proposal_documents"
-msgstr "Seuls les fichiers .docx sont autorisés comme documents de proposition."
+msgstr "Seuls les fichiers .docx sont autorisés comme documents de requête."
 
 #. Default: "Only word files (.docx) can be added here."
 #: ./opengever/meeting/proposaltemplate.py
@@ -692,7 +692,7 @@ msgstr "Seuls les fichiers Word (.docx) sont acceptés."
 #. Default: "Either a proposal template or a proposal document is required."
 #: ./opengever/meeting/browser/proposalforms.py
 msgid "error_template_or_document_required_for_creation"
-msgstr "Veuillez choisir soit un modèle de proposition, soit un document de proposition."
+msgstr "Veuillez choisir soit un modèle de requête, soit un document de requête."
 
 #. Default: "Excerpt ${title}"
 #: ./opengever/meeting/browser/meetings/agendaitem.py
@@ -707,7 +707,7 @@ msgstr "Extrait de protocole généré avec succès."
 #. Default: "Excerpt was returned to proposer."
 #: ./opengever/meeting/browser/meetings/agendaitem.py
 msgid "excerpt_returned"
-msgstr "L'extrait de protocole a été déposé dans le dossier d'origine de la demande."
+msgstr "L'extrait de protocole a été déposé dans le dossier d'origine de la requête."
 
 #. Default: "Excused"
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt
@@ -752,12 +752,12 @@ msgstr "Tenue"
 #. Default: "Select the ad-hoc agenda item templates allowed for this commitee, or select no templates for allowing all templates."
 #: ./opengever/meeting/committee.py
 msgid "help_allowed_ad_hoc_agenda_item_templates"
-msgstr "Choisissez tous les modèles pour les points à l'ordre du jour sans demande autorisés dans cette commission. Ne choisissez aucun modèle de proposition pour autoriser tous les modèles."
+msgstr "Choisissez tous les modèles pour les points à l'ordre du jour sans requête autorisés dans cette commission. Ne choisissez aucun modèle de requête pour autoriser tous les modèles."
 
 #. Default: "Select the proposal templates allowed for this commitee, or select no templates for allowing all templates."
 #: ./opengever/meeting/committee.py
 msgid "help_allowed_proposal_templates"
-msgstr "Choisissez tous les modèles de proposition autorisés dans cette commission. Ne choisissez aucun modèle de proposition pour autoriser tous les modèles."
+msgstr "Choisissez tous les modèles de requête autorisés dans cette commission. Ne choisissez aucun modèle de requête pour autoriser tous les modèles."
 
 #. Default: "Create a new task the meeting dossier and attach this excerpt."
 #: ./opengever/meeting/browser/meetings/meeting.py
@@ -772,12 +772,12 @@ msgstr "Modèle de séance avec intertitre prédéfinis"
 #. Default: "Return this excerpt the as official answer to the proposal."
 #: ./opengever/meeting/browser/meetings/meeting.py
 msgid "help_return_excerpt"
-msgstr "Déposer cet extrait de protocole comme réponse définitive dans le dossier d'origine de la demande."
+msgstr "Déposer cet extrait de protocole comme réponse définitive dans le dossier d'origine de la requête."
 
 #. Default: "This excerpt was returned to the dossier"
 #: ./opengever/meeting/browser/meetings/meeting.py
 msgid "help_returned_excerpt"
-msgstr "Cet extrait de protocole a été déposé comme réponse dans le dossier d'origine de la demande."
+msgstr "Cet extrait de protocole a été déposé comme réponse dans le dossier d'origine de la requête."
 
 #. Default: "Hold meeting"
 #: ./opengever/meeting/model/meeting.py
@@ -797,7 +797,7 @@ msgstr "Cette action ne peut pas être effectuée dans l'état actuel de ce poin
 #. Default: "Ad hoc agenda item template"
 #: ./opengever/meeting/committee.py
 msgid "label_ad_hoc_template"
-msgstr "Modèle pour les points à l'ordre du jour sans proposition"
+msgstr "Modèle pour les points à l'ordre du jour sans requête"
 
 #. Default: "Decided"
 #: ./opengever/meeting/browser/meetings/meeting.py
@@ -838,12 +838,12 @@ msgstr "Modèle de l'ordre du jour"
 #. Default: "Allowed ad-hoc agenda item templates"
 #: ./opengever/meeting/committee.py
 msgid "label_allowed_ad_hoc_agenda_item_templates"
-msgstr "Modèles pour les points à l'ordre du jour sans proposition autorisés"
+msgstr "Modèles pour les points à l'ordre du jour sans requête autorisés"
 
 #. Default: "Allowed proposal templates"
 #: ./opengever/meeting/committee.py
 msgid "label_allowed_proposal_templates"
-msgstr "Modèles de propositions autorisés"
+msgstr "Modèles de requêtes autorisés"
 
 #. Default: "Attachments"
 #: ./opengever/meeting/browser/meetings/meeting.py
@@ -885,7 +885,7 @@ msgstr "Annuler la séance"
 #. Default: "The meeting cannot be closed because it has undecided agenda items."
 #: ./opengever/meeting/model/meeting.py
 msgid "label_close_error_has_undecided_agenda_items"
-msgstr "La séance ne peut pas être clôturée avant que tous les points à l'ordre du jour ne soient clôturés et les extraits de protocol générés et déposés comme réponse dans le dossier d'origine de la demande."
+msgstr "La séance ne peut pas être clôturée avant que tous les points à l'ordre du jour ne soient clôturés et les extraits de protocol générés et déposés comme réponse dans le dossier d'origine de la requête."
 
 #. Default: "Closed meetings"
 #: ./opengever/meeting/browser/committee.py
@@ -1230,7 +1230,7 @@ msgstr "Cet utilisateur n'a pas d'adhésion."
 #. Default: "No proposals submitted"
 #: ./opengever/meeting/browser/meetings/meeting.py
 msgid "label_no_proposals"
-msgstr "Aucune proposition n'a été soumise."
+msgstr "Aucune requête n'a été soumise."
 
 #. Default: "Other Participants"
 #: ./opengever/meeting/browser/meetings/protocol.py
@@ -1261,12 +1261,12 @@ msgstr "Présidence"
 #. Default: "Proposal Document"
 #: ./opengever/meeting/browser/proposalforms.py
 msgid "label_proposal_document"
-msgstr "Document de proposition"
+msgstr "Document de requête"
 
 #. Default: "Proposal template"
 #: ./opengever/meeting/browser/proposalforms.py
 msgid "label_proposal_template"
-msgstr "Modèle de proposition"
+msgstr "Modèle de requête"
 
 #. Default: "Approve protocol"
 #: ./opengever/meeting/browser/proposalforms.py
@@ -1355,12 +1355,12 @@ msgstr "Soumettre une nouvelle version"
 #. Default: "Successors"
 #: ./opengever/meeting/proposal.py
 msgid "label_successors"
-msgstr "Demandes ultérieures"
+msgstr "Requêtes ultérieures"
 
 #. Default: "Proposal document type"
 #: ./opengever/meeting/browser/proposalforms.py
 msgid "label_template_or_existing_document"
-msgstr "Document de proposition"
+msgstr "Document de requête"
 
 #. Default: "Title"
 #: ./opengever/meeting/browser/meetings/meeting.py
@@ -1402,7 +1402,7 @@ msgstr "Êtes-vous sûr de vouloir enlever ce point à l'ordre du jour?"
 #. Default: "Unscheduled proposals"
 #: ./opengever/meeting/browser/committee.py
 msgid "label_unscheduled_proposals"
-msgstr "Propositions non-agendées"
+msgstr "Requêtes non-agendées"
 
 #. Default: "Upcoming meetings"
 #: ./opengever/meeting/browser/committee.py
@@ -1503,7 +1503,7 @@ msgstr "Choisissez un titre pertinent permettant de mieux différencier les extr
 #. Default: "When returning an excerpt to the proposer the selected document will be sent back to the proposals originating dossier. No other excerpts can be returned."
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt
 msgid "msg_confirm_return_excerpt_dialog"
-msgstr "L'extrait de protocole est déposé dans le dossier d'origine de la demande. Aucun extrait de protocole supplémentaire ne peut y être déposé."
+msgstr "L'extrait de protocole est déposé dans le dossier d'origine de la requête. Aucun extrait de protocole supplémentaire ne peut y être déposé."
 
 #. Default: "Download original files rather than PDF files."
 #: ./opengever/meeting/browser/meetings/templates/demand_zip.pt
@@ -1528,7 +1528,7 @@ msgstr "L'ordre du jour ne pourra plus être modifié après la clôture d'un po
 #. Default: "The selected committeee has been deactivated, the proposal could not been submitted."
 #: ./opengever/meeting/model/proposal.py
 msgid "msg_inactive_committee_selected"
-msgstr "La commission sélectionnée a été désactivé; la proposition n'a pas pu être soumise."
+msgstr "La commission sélectionnée a été désactivé; la requête n'a pas pu être soumise."
 
 #. Default: "The meeting ${title} has been successfully cancelled."
 #: ./opengever/meeting/model/meeting.py
@@ -1563,22 +1563,22 @@ msgstr "Il y a des séances non clôturées."
 #. Default: "Proposal cancelled successfully."
 #: ./opengever/meeting/model/proposal.py
 msgid "msg_proposal_cancelled"
-msgstr "Proposition annulée avec succès."
+msgstr "Requête annulée avec succès."
 
 #. Default: "Proposal reactivated successfully."
 #: ./opengever/meeting/model/proposal.py
 msgid "msg_proposal_reactivated"
-msgstr "La proposition a été réactivée."
+msgstr "La requête a été réactivée."
 
 #. Default: "Proposal successfully submitted."
 #: ./opengever/meeting/model/proposal.py
 msgid "msg_proposal_submitted"
-msgstr "Proposition soumise avec succès."
+msgstr "Requête soumise avec succès."
 
 #. Default: "The meeting can only be closed when all agenda items are decided."
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt
 msgid "msg_require_all_agenda_items_decided_for_closing"
-msgstr "La séance ne pourra être clôturée que lorsque tous les points à l'ordre du jour seront clôturés et les extraits de protocol générés et déposés comme réponse dans le dossier d'origine de la demande."
+msgstr "La séance ne pourra être clôturée que lorsque tous les points à l'ordre du jour seront clôturés et les extraits de protocol générés et déposés comme réponse dans le dossier d'origine de la requête."
 
 #. Default: "Some documents could not be converted to PDF, their original files will be included in the Zip."
 #: ./opengever/meeting/browser/meetings/zipexport.py
@@ -1593,7 +1593,7 @@ msgstr "L'objet a été supprimé avec succès."
 #. Default: "There are unscheduled proposals submitted to this committee."
 #: ./opengever/meeting/browser/committeetransitioncontroller.py
 msgid "msg_unscheduled_proposals"
-msgstr "Des propositions qui ne figurent pas sur l'ordre du jour ont été attribuées à cette commission."
+msgstr "Des requêtes qui ne figurent pas sur l'ordre du jour ont été attribuées à cette commission."
 
 #. Default: "A Zip file with PDFs for all documents of this meeting is being generated."
 #: ./opengever/meeting/browser/meetings/zipexport.py
@@ -1618,7 +1618,7 @@ msgstr "La génération du fichier Zip a duré trop longtemps"
 #. Default: "New unscheduled proposals:"
 #: ./opengever/meeting/browser/templates/committee.pt
 msgid "new_unscheduled_proposals"
-msgstr "Nouvelles propositions soumises"
+msgstr "Nouvelles requêtes soumises"
 
 #. Default: "User does not have permission to edit the meeting dossier:"
 #: ./opengever/meeting/browser/meetings/meeting.py
@@ -1670,7 +1670,7 @@ msgstr "Document soumis ${title} actualisé à la version ${version}"
 #. Default: "Proposal document"
 #: ./opengever/meeting/proposal.py
 msgid "proposal_document"
-msgstr "Document de proposition"
+msgstr "Document de requête"
 
 #. Default: "Proposal cancelled by ${user}"
 #: ./opengever/meeting/proposalhistory.py
@@ -1692,7 +1692,7 @@ msgstr "Créé par ${user}"
 #: ./opengever/meeting/activity/activities.py
 #: ./opengever/meeting/proposalhistory.py
 msgid "proposal_history_label_decided"
-msgstr "Proposition décidée par ${user}"
+msgstr "Requête décidée par ${user}"
 
 #. Default: "Document ${title} submitted in version ${version} by ${user}"
 #: ./opengever/meeting/proposalhistory.py
@@ -1724,12 +1724,12 @@ msgstr "Enlevé de l'ordre du jour de la séance ${meeting} par ${user}"
 #. Default: "Proposal reopened by ${user}"
 #: ./opengever/meeting/proposalhistory.py
 msgid "proposal_history_label_reopened"
-msgstr "Proposition de révision rouverte par ${user}"
+msgstr "Requête de révision rouverte par ${user}"
 
 #. Default: "Proposal revised by ${user}"
 #: ./opengever/meeting/proposalhistory.py
 msgid "proposal_history_label_revised"
-msgstr "Décision de proposition révisée par ${user}"
+msgstr "Décision de requête révisée par ${user}"
 
 #. Default: "Scheduled for meeting ${meeting} by ${user}"
 #: ./opengever/meeting/activity/activities.py
@@ -1746,7 +1746,7 @@ msgstr "Soumis par ${user}"
 #. Default: "Successor proposal ${successor_link} created by ${user}"
 #: ./opengever/meeting/proposalhistory.py
 msgid "proposal_history_label_successor_created"
-msgstr "Demande ultérieure «${successor_link}» établie par ${user}"
+msgstr "Requête ultérieure «${successor_link}» établie par ${user}"
 
 #. Default: "Protocol"
 #: ./opengever/meeting/protocol.py
@@ -1821,7 +1821,7 @@ msgstr "Soumis"
 #. Default: "Submitted Proposals"
 #: ./opengever/meeting/browser/tabbed.py
 msgid "submittedproposals"
-msgstr "Propositions"
+msgstr "Requêtes"
 
 #. Default: "${amount} matches"
 #: ./opengever/meeting/browser/templates/no_selection.pt

--- a/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
@@ -1846,7 +1846,7 @@ msgstr "Texte libre ajouté à l'ordre du jour avec succès."
 #. Default: "Agenda item ${agenda_item_number}"
 #: ./opengever/meeting/zipexport.py
 msgid "title_agenda_item"
-msgstr "point à l'ordre du jour ${number}"
+msgstr "Point à l'ordre du jour ${number}"
 
 #. Default: "Delete proposal"
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt

--- a/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
@@ -44,7 +44,7 @@ msgstr "Ajouter une adhésion"
 
 #: ./opengever/meeting/browser/committeeforms.py
 msgid "Add committee"
-msgstr "Ajouter un comité"
+msgstr "Ajouter une commission"
 
 #: ./opengever/meeting/browser/periods.py
 msgid "Add new period"
@@ -490,7 +490,7 @@ msgstr "Clôturé"
 #. Default: "Comittee"
 #: ./opengever/meeting/browser/documents/proposalstab.py
 msgid "column_comittee"
-msgstr "Comité"
+msgstr "Commission"
 
 #. Default: "Date"
 #: ./opengever/meeting/tabs/meetinglisting.py
@@ -611,7 +611,7 @@ msgstr "Le fichier Zip contient un fichier PDF pour chaque document de cette sé
 #. Default: "Automatically configure permissions on the committee for this group."
 #: ./opengever/meeting/committee.py
 msgid "description_group"
-msgstr "Ce groupe peut modifier et consulter le comité."
+msgstr "Ce groupe peut modifier et consulter la commission."
 
 #. Default: "You are not allowed to checkout the document."
 #: ./opengever/meeting/browser/meetings/agendaitem.py
@@ -752,12 +752,12 @@ msgstr "Tenue"
 #. Default: "Select the ad-hoc agenda item templates allowed for this commitee, or select no templates for allowing all templates."
 #: ./opengever/meeting/committee.py
 msgid "help_allowed_ad_hoc_agenda_item_templates"
-msgstr "Choisissez tous les modèles pour les points à l'ordre du jour sans demande autorisés dans ce comité. Ne choisissez aucun modèle de proposition pour autoriser tous les modèles."
+msgstr "Choisissez tous les modèles pour les points à l'ordre du jour sans demande autorisés dans cette commission. Ne choisissez aucun modèle de proposition pour autoriser tous les modèles."
 
 #. Default: "Select the proposal templates allowed for this commitee, or select no templates for allowing all templates."
 #: ./opengever/meeting/committee.py
 msgid "help_allowed_proposal_templates"
-msgstr "Choisissez tous les modèles de proposition autorisés dans ce comité. Ne choisissez aucun modèle de proposition pour autoriser tous les modèles."
+msgstr "Choisissez tous les modèles de proposition autorisés dans cette commission. Ne choisissez aucun modèle de proposition pour autoriser tous les modèles."
 
 #. Default: "Create a new task the meeting dossier and attach this excerpt."
 #: ./opengever/meeting/browser/meetings/meeting.py
@@ -901,24 +901,24 @@ msgstr "Commentaire"
 #. Default: "Committee deactivated successfully"
 #: ./opengever/meeting/browser/committeetransitioncontroller.py
 msgid "label_committe_deactivated"
-msgstr "Comité déactivé avec succès."
+msgstr "Commission déactivé avec succès."
 
 #. Default: "Committee reactivated successfully"
 #: ./opengever/meeting/browser/committeetransitioncontroller.py
 msgid "label_committe_reactivated"
-msgstr "Comité réactivé avec succès."
+msgstr "Commission réactivé avec succès."
 
 #. Default: "Committee"
 #: ./opengever/meeting/browser/meetings/meeting.py
 #: ./opengever/meeting/browser/templates/member.pt
 #: ./opengever/meeting/proposal.py
 msgid "label_committee"
-msgstr "Comité"
+msgstr "Commission"
 
 #. Default: "Committeeresponsible"
 #: ./opengever/meeting/committee.py
 msgid "label_committee_responsible"
-msgstr "Responsables de comités"
+msgstr "Responsables de commissions"
 
 #. Default: "Generate Protocol"
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt
@@ -968,7 +968,7 @@ msgstr "Jusqu'à"
 #. Default: "Deactivate committee"
 #: ./opengever/meeting/model/committee.py
 msgid "label_deactivate"
-msgstr "Déactiver le comité"
+msgstr "Déactiver la commission"
 
 #. Default: "Decide"
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt
@@ -1291,7 +1291,7 @@ msgstr "Modèle pour la partie finale du protocole"
 #. Default: "Reactivate committee"
 #: ./opengever/meeting/model/committee.py
 msgid "label_reactivate"
-msgstr "Réactiver le comité"
+msgstr "Réactiver la commission"
 
 #. Default: "Remove"
 #: ./opengever/meeting/browser/templates/member.pt
@@ -1528,7 +1528,7 @@ msgstr "L'ordre du jour ne pourra plus être modifié après la clôture d'un po
 #. Default: "The selected committeee has been deactivated, the proposal could not been submitted."
 #: ./opengever/meeting/model/proposal.py
 msgid "msg_inactive_committee_selected"
-msgstr "Le comité sélectionné a été désactivé; la proposition n'a pas pu être soumise."
+msgstr "La commission sélectionnée a été désactivé; la proposition n'a pas pu être soumise."
 
 #. Default: "The meeting ${title} has been successfully cancelled."
 #: ./opengever/meeting/model/meeting.py
@@ -1593,7 +1593,7 @@ msgstr "L'objet a été supprimé avec succès."
 #. Default: "There are unscheduled proposals submitted to this committee."
 #: ./opengever/meeting/browser/committeetransitioncontroller.py
 msgid "msg_unscheduled_proposals"
-msgstr "Des propositions qui ne figurent pas sur l'ordre du jour ont été attribuées à ce comité."
+msgstr "Des propositions qui ne figurent pas sur l'ordre du jour ont été attribuées à cette commission."
 
 #. Default: "A Zip file with PDFs for all documents of this meeting is being generated."
 #: ./opengever/meeting/browser/meetings/zipexport.py

--- a/opengever/meeting/locales/opengever.meeting.pot
+++ b/opengever/meeting/locales/opengever.meeting.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-02-28 07:21+0000\n"
+"POT-Creation-Date: 2019-05-09 08:18+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -803,7 +803,6 @@ msgstr ""
 
 #. Default: "Agenda item header template for the protocol"
 #: ./opengever/meeting/committee.py
-#: ./opengever/meeting/committeecontainer.py
 msgid "label_agenda_item_header_template"
 msgstr ""
 
@@ -819,7 +818,6 @@ msgstr ""
 
 #. Default: "Agenda item suffix template for the protocol"
 #: ./opengever/meeting/committee.py
-#: ./opengever/meeting/committeecontainer.py
 msgid "label_agenda_item_suffix_template"
 msgstr ""
 
@@ -831,7 +829,6 @@ msgstr ""
 
 #. Default: "Agendaitem list template"
 #: ./opengever/meeting/committee.py
-#: ./opengever/meeting/committeecontainer.py
 msgid "label_agendaitem_list_template"
 msgstr ""
 
@@ -1103,13 +1100,11 @@ msgstr ""
 
 #. Default: "Excerpt header template"
 #: ./opengever/meeting/committee.py
-#: ./opengever/meeting/committeecontainer.py
 msgid "label_excerpt_header_template"
 msgstr ""
 
 #. Default: "Excerpt suffix template"
 #: ./opengever/meeting/committee.py
-#: ./opengever/meeting/committeecontainer.py
 msgid "label_excerpt_suffix_template"
 msgstr ""
 
@@ -1242,7 +1237,6 @@ msgstr ""
 
 #. Default: "Paragraph template"
 #: ./opengever/meeting/committee.py
-#: ./opengever/meeting/committeecontainer.py
 msgid "label_paragraph_template"
 msgstr ""
 
@@ -1278,7 +1272,6 @@ msgstr ""
 
 #. Default: "Protocol header template"
 #: ./opengever/meeting/committee.py
-#: ./opengever/meeting/committeecontainer.py
 msgid "label_protocol_header_template"
 msgstr ""
 
@@ -1289,7 +1282,6 @@ msgstr ""
 
 #. Default: "Protocol suffix template"
 #: ./opengever/meeting/committee.py
-#: ./opengever/meeting/committeecontainer.py
 msgid "label_protocol_suffix_template"
 msgstr ""
 
@@ -1381,7 +1373,6 @@ msgstr ""
 
 #. Default: "Table of contents template"
 #: ./opengever/meeting/committee.py
-#: ./opengever/meeting/committeecontainer.py
 msgid "label_toc_template"
 msgstr ""
 
@@ -1656,6 +1647,11 @@ msgstr ""
 #. Default: "Periods"
 #: ./opengever/meeting/browser/tabbed.py
 msgid "periods"
+msgstr ""
+
+#. Default: "Predecessor proposal"
+#: ./opengever/meeting/proposal.py
+msgid "predecessor_proposal_label"
 msgstr ""
 
 #. Default: "Document ${title} submitted"

--- a/opengever/meeting/proposal.py
+++ b/opengever/meeting/proposal.py
@@ -137,7 +137,7 @@ class IProposal(model.Schema):
 
     mode(predecessor_proposal='hidden')
     predecessor_proposal = RelationChoice(
-        title=u'Predecessor proposal',
+        title=_(u'predecessor_proposal_label', default=u'Predecessor proposal'),
         default=None,
         missing_value=None,
         required=False,

--- a/opengever/meeting/tests/test_proposal_listings.py
+++ b/opengever/meeting/tests/test_proposal_listings.py
@@ -64,7 +64,7 @@ class TestDossierProposalListing(IntegrationTestCase):
         browser.open(self.dossier, view='tabbedview_view-proposals', data={'proposal_state_filter': 'filter_proposals_all'})
         expected_proposals = [
             {
-                u'Comit\xe9': u'Rechnungspr\xfcfungskommission',
+                u'Commission': u'Rechnungspr\xfcfungskommission',
                 'Etat': 'Soumis',
                 'Mandant': 'Ziegler Robert (robert.ziegler)',
                 u'Num\xe9ro de d\xe9cision': '',
@@ -74,7 +74,7 @@ class TestDossierProposalListing(IntegrationTestCase):
                 'Description': u'F\xfcr weitere Bearbeitung bewilligen',
             },
             {
-                u'Comit\xe9': u'Kommission f\xfcr Verkehr',
+                u'Commission': u'Kommission f\xfcr Verkehr',
                 'Etat': 'En modification',
                 'Mandant': 'Ziegler Robert (robert.ziegler)',
                 u'Num\xe9ro de d\xe9cision': '',
@@ -84,7 +84,7 @@ class TestDossierProposalListing(IntegrationTestCase):
                 'Description': '',
             },
             {
-                u'Comit\xe9': u'Rechnungspr\xfcfungskommission',
+                u'Commission': u'Rechnungspr\xfcfungskommission',
                 'Etat': u'Cl\xf4tur\xe9',
                 'Mandant': 'Ziegler Robert (robert.ziegler)',
                 u'Num\xe9ro de d\xe9cision': '2016 / 1',

--- a/opengever/ogds/base/locales/fr/LC_MESSAGES/opengever.ogds.base.po
+++ b/opengever/ogds/base/locales/fr/LC_MESSAGES/opengever.ogds.base.po
@@ -137,7 +137,7 @@ msgstr "Titre"
 #. Default: "Teams"
 #: ./opengever/ogds/base/browser/templates/userdetails.pt
 msgid "label_teams"
-msgstr "Equipes"
+msgstr "Teams"
 
 #. Default: "Title"
 #: ./opengever/ogds/base/browser/team_forms.py

--- a/opengever/repository/locales/fr/LC_MESSAGES/opengever.repository.po
+++ b/opengever/repository/locales/fr/LC_MESSAGES/opengever.repository.po
@@ -177,7 +177,7 @@ msgstr "Sommaire"
 #. Default: "Proposals"
 #: ./opengever/repository/browser/tabbed.py
 msgid "label_proposals"
-msgstr "Propositions"
+msgstr "Requêtes"
 
 #. Default: "Reference Prefix"
 #: ./opengever/repository/behaviors/referenceprefix.py

--- a/opengever/repository/locales/fr/LC_MESSAGES/opengever.repository.po
+++ b/opengever/repository/locales/fr/LC_MESSAGES/opengever.repository.po
@@ -57,7 +57,7 @@ msgstr "A ce niveau du classement ce numéro de référence existe déjà."
 #: ./opengever/repository/behaviors/responsibleorg.py
 #: ./opengever/repository/repositoryfolder.py
 msgid "fieldset_common"
-msgstr "En général"
+msgstr "Général"
 
 #. Default: "Select all additional dossier types which should be addable in this repository folder."
 #: ./opengever/repository/repositoryfolder.py

--- a/opengever/sharing/locales/fr/LC_MESSAGES/opengever.sharing.po
+++ b/opengever/sharing/locales/fr/LC_MESSAGES/opengever.sharing.po
@@ -87,7 +87,7 @@ msgstr "Lire les dossiers"
 
 #: ./opengever/sharing/browser/sharing.py
 msgid "sharing_dossier_reviewer"
-msgstr "Fermer les dossiers"
+msgstr "Clôturer les dossiers"
 
 #: ./opengever/sharing/browser/sharing.py
 msgid "sharing_editor"

--- a/opengever/tabbedview/locales/fr/LC_MESSAGES/opengever.tabbedview.po
+++ b/opengever/tabbedview/locales/fr/LC_MESSAGES/opengever.tabbedview.po
@@ -177,10 +177,10 @@ msgid "expired"
 msgstr "Expiré"
 
 msgid "important_contact"
-msgstr "En général"
+msgstr "Général"
 
 msgid "issuer"
-msgstr "Attribuer à nouveau"
+msgstr "Attribué par"
 
 msgid "journal"
 msgstr "Historique"
@@ -354,7 +354,7 @@ msgstr "Téléphone professionnel"
 #. Default: "Userid"
 #: ./opengever/tabbedview/browser/users.py
 msgid "label_userstab_userid"
-msgstr "N° d'utilisateur"
+msgstr "Nom d'utilisateur"
 
 msgid "modified"
 msgstr "Date de modification"

--- a/opengever/task/locales/de/LC_MESSAGES/opengever.task.po
+++ b/opengever/task/locales/de/LC_MESSAGES/opengever.task.po
@@ -219,7 +219,7 @@ msgstr "Teams sind nur bei offenen Aufgaben oder Weiterleitungen als Auftragnehm
 #. Default: "The private task feature is disabled"
 #: ./opengever/task/task.py
 msgid "error_private_task_feature_is_disabled"
-msgstr "Die Funktionalität private Aufgaben ist deaktiviert."
+msgstr "Die Funktionalität persönliche Aufgaben ist deaktiviert."
 
 #. Default: "The revoke permissions feature is disabled"
 #: ./opengever/task/task.py

--- a/opengever/task/locales/fr/LC_MESSAGES/opengever.task.po
+++ b/opengever/task/locales/fr/LC_MESSAGES/opengever.task.po
@@ -866,7 +866,7 @@ msgstr "Clôturer la tâche"
 #. Default: "Complete task"
 #: ./opengever/task/browser/complete.py
 msgid "title_complete_task"
-msgstr "Accomplir / Clôturer la tâche"
+msgstr "Accomplir / clôturer la tâche"
 
 #. Default: "Delegate task"
 #: ./opengever/task/browser/delegate/main.py

--- a/opengever/task/locales/fr/LC_MESSAGES/opengever.task.po
+++ b/opengever/task/locales/fr/LC_MESSAGES/opengever.task.po
@@ -71,7 +71,7 @@ msgstr "Tâche"
 
 #: ./opengever/task/browser/complete.py
 msgid "The documents were delivered to the issuer and the tasks were completed."
-msgstr "Les documents sont transmis au mandant et les tâches sont fermées."
+msgstr "Les documents sont transmis au mandant et les tâches sont clôturées."
 
 #: ./opengever/task/browser/accept/inbox.py
 msgid "The forwarding has been stored in the local inbox"
@@ -116,11 +116,11 @@ msgstr "Vous n'avez pas été assigné au mandant responsable. Vous ne pouvez tr
 
 #: ./opengever/task/browser/close.py
 msgid "You cannot add documents to the selected dossier. Either the dossier is closed or you do not have the privileges."
-msgstr "Vos droits ne sont pas suffisants pour ajouter des documents dans le dossier choisi. Le dossier est probablement déjà fermé."
+msgstr "Vos droits ne sont pas suffisants pour ajouter des documents dans le dossier choisi. Le dossier est probablement déjà clôturé."
 
 #: ./opengever/task/browser/accept/existingdossier.py
 msgid "You cannot add tasks in the selected dossier. Either the dossier is closed or you do not have the privileges."
-msgstr "Dans le dossier choisi, vous ne pouvez créer aucune tâche. Soit parce que le dossier est déjà fermé; soit parce que vous n'avez pas les droits suffisants pour effectuer cette tâche."
+msgstr "Dans le dossier choisi, vous ne pouvez créer aucune tâche. Soit parce que le dossier est déjà clôturé; soit parce que vous n'avez pas les droits suffisants pour effectuer cette tâche."
 
 #. Default: "file in existing dossier in ${client}"
 #: ./opengever/task/browser/accept/main.py
@@ -861,12 +861,12 @@ msgstr "Attribuer à un dossier"
 #. Default: "Close task"
 #: ./opengever/task/browser/close.py
 msgid "title_close_task"
-msgstr "Fermer la tâche"
+msgstr "Clôturer la tâche"
 
 #. Default: "Complete task"
 #: ./opengever/task/browser/complete.py
 msgid "title_complete_task"
-msgstr "Accomplir / Fermer la tâche"
+msgstr "Accomplir / Clôturer la tâche"
 
 #. Default: "Delegate task"
 #: ./opengever/task/browser/delegate/main.py
@@ -926,7 +926,7 @@ msgstr "Tâche annulée"
 #. Default: "Task closed"
 #: ./opengever/task/response_description.py
 msgid "transition_label_close"
-msgstr "Tâche fermée"
+msgstr "Tâche clôturée"
 
 #. Default: "Created by ${user}"
 #: ./opengever/task/viewlets/response.py
@@ -1007,7 +1007,7 @@ msgstr "Annulé par ${user}"
 #. Default: "Closed by ${user}"
 #: ./opengever/task/response_description.py
 msgid "transition_msg_close"
-msgstr "Fermé par ${user}"
+msgstr "Clôturé par ${user}"
 
 #. Default: "Response added"
 #: ./opengever/task/response_description.py

--- a/opengever/task/locales/fr/LC_MESSAGES/opengever.task.po
+++ b/opengever/task/locales/fr/LC_MESSAGES/opengever.task.po
@@ -112,7 +112,7 @@ msgstr "Vous n'avez pas l'autorisation pour éditer ces réponses"
 
 #: ./opengever/task/browser/accept/main.py
 msgid "You are not assigned to the responsible client (${client}). You can only process the task in the issuers dossier."
-msgstr "Vous n'avez pas été assigné au mandant responsable. Vous ne pouvez traiter la tâche que dans le dossier du mandant."
+msgstr "Vous n'avez pas été assigné au client responsable. Vous ne pouvez traiter la tâche que dans le dossier du mandant."
 
 #: ./opengever/task/browser/close.py
 msgid "You cannot add documents to the selected dossier. Either the dossier is closed or you do not have the privileges."
@@ -211,7 +211,7 @@ msgstr "Les documents suivants (${title}) sont en checkout. Vous devez faire un 
 #. Default: "Admin unit changes are not allowed if the task or forwarding is already accepted."
 #: ./opengever/task/browser/assign.py
 msgid "error_no_admin_unit_change_in_progress_state"
-msgstr ""
+msgstr "Les changements de clients no sont pas autorisés si la tâche ou la transmisison est déjà acceptée."
 
 #. Default: "Team responsibles are only allowed if the task or forwarding is open."
 #: ./opengever/task/browser/assign.py
@@ -221,7 +221,7 @@ msgstr "Les équipes ne sont autorisées comme mandataires que pour des transmis
 #. Default: "The private task feature is disabled"
 #: ./opengever/task/task.py
 msgid "error_private_task_feature_is_disabled"
-msgstr ""
+msgstr "La fonctionalité tâches personelles est désactivée"
 
 #. Default: "The revoke permissions feature is disabled"
 #: ./opengever/task/task.py

--- a/opengever/task/locales/fr/LC_MESSAGES/opengever.task.po
+++ b/opengever/task/locales/fr/LC_MESSAGES/opengever.task.po
@@ -251,7 +251,7 @@ msgstr "Avancé"
 #. Default: "Common"
 #: ./opengever/task/task.py
 msgid "fieldset_common"
-msgstr "En général"
+msgstr "Général"
 
 #. Default: "Forwarding"
 #: ./opengever/task/helper.py
@@ -500,7 +500,7 @@ msgstr "Coûts estimés (CHF)"
 #. Default: "Expected duration"
 #: ./opengever/task/task.py
 msgid "label_expectedDuration"
-msgstr "Durée estimées (h)"
+msgstr "Durée estimée (h)"
 
 #. Default: "Start with work"
 #: ./opengever/task/task.py
@@ -553,7 +553,7 @@ msgstr "Déroulement en parallèle"
 #. Default: "Dossiertitle"
 #: ./opengever/task/browser/overview.py
 msgid "label_parent_dossier_title"
-msgstr "Titre de la dossier"
+msgstr "Titre du dossier"
 
 #. Default: "Predecessor"
 #: ./opengever/task/task.py
@@ -599,7 +599,7 @@ msgstr "Client responsable"
 #: ./opengever/task/browser/assign.py
 #: ./opengever/task/browser/assign_dossier.py
 msgid "label_response"
-msgstr "Response"
+msgstr "Réponse"
 
 #. Default: "Responsible"
 #: ./opengever/task/activities.py
@@ -814,7 +814,7 @@ msgstr "Enregistrer"
 #: ./opengever/task/browser/accept/main.py
 #: ./opengever/task/browser/accept/newdossier.py
 msgid "step_1"
-msgstr "Premier étape"
+msgstr "Première étape"
 
 #. Default: "Step 2"
 #: ./opengever/task/browser/accept/existingdossier.py
@@ -851,7 +851,7 @@ msgstr "Accepter la tâche"
 #. Default: "Assign task"
 #: ./opengever/task/browser/assign.py
 msgid "title_assign_task"
-msgstr "Attribuer à nouveau"
+msgstr "Ré-attribuer"
 
 #. Default: "Assign to Dossier"
 #: ./opengever/task/browser/assign_dossier.py

--- a/opengever/task/tests/test_overview.py
+++ b/opengever/task/tests/test_overview.py
@@ -149,7 +149,7 @@ class TestTaskOverview(IntegrationTestCase):
         lang_tool.setDefaultLanguage('fr-ch')
 
         browser.open(self.task, view='tabbedview_view-overview')
-        self.assertIn(['Etat', u'Ferm\xe9'],
+        self.assertIn(['Etat', u'Cl\xf4tur\xe9'],
                       browser.css('table.listing').first.lists())
 
 

--- a/opengever/tasktemplates/locales/fr/LC_MESSAGES/opengever.tasktemplates.po
+++ b/opengever/tasktemplates/locales/fr/LC_MESSAGES/opengever.tasktemplates.po
@@ -67,7 +67,7 @@ msgstr "Commencer la première tâche immédiatement après la création"
 #: ./opengever/tasktemplates/content/tasktemplate.py
 #: ./opengever/tasktemplates/content/templatefoldersschema.py
 msgid "fieldset_common"
-msgstr "En général"
+msgstr "Général"
 
 #: ./opengever/tasktemplates/content/tasktemplate.py
 msgid "help_deadline"
@@ -79,7 +79,7 @@ msgstr "Choix du mandant. Vous pouvez aussi choisir les utilisateurs interactifs
 
 #: ./opengever/tasktemplates/content/tasktemplate.py
 msgid "help_preselected"
-msgstr "Ce modèle fait parti du choix standard des procédés standards."
+msgstr "Ce modèle fait partie du choix par défaut dans la séléction de modèles de tâches."
 
 #: ./opengever/tasktemplates/content/tasktemplate.py
 msgid "help_responsible"

--- a/opengever/workspace/locales/fr/LC_MESSAGES/opengever.workspace.po
+++ b/opengever/workspace/locales/fr/LC_MESSAGES/opengever.workspace.po
@@ -106,7 +106,7 @@ msgstr "Titulaire"
 #. Default: "Description"
 #: ./opengever/workspace/browser/tabs.py
 msgid "label_description"
-msgstr ""
+msgstr "Description"
 
 #. Default: "Documents"
 #: ./opengever/workspace/browser/tabbed.py
@@ -116,7 +116,7 @@ msgstr "Documents"
 #. Default: "Folders"
 #: ./opengever/workspace/browser/tabbed.py
 msgid "label_folders"
-msgstr ""
+msgstr "Répertoires"
 
 #. Default: "Journal"
 #: ./opengever/workspace/browser/tabbed.py


### PR DESCRIPTION
* Completed most of what was reported in https://gever.4teamwork.ch/ordnungssystem/3/5/3/dossier-3437/document-29508
* I also added all the missing translations from 2019.2
* Committe is now translated to Comission everywhere
* proposal is now translated as requête everywhere
* Tried to have a more consistent french vocabulary used for closing and resolving tasks and forwardings

What I did not do:
* replace `courriel` with `E-mail`. `courriel` is used everywhere in plone, so if we want this consistent, we would probably have to overwrite the translation in several different places.
* I did not change the task-type `Transmission` to `Attribution`, as this word is already used for assignments
* I did not use `complété` anywhere for task states, instead I tried to make the vocabulary used more consistent. `clôturé` for closed tasks (so it's the same word as for dossiers) and used `accompli` everywhere for `resolved` (`erledigt` in German).

resolves #5540 