### PR TITLE
Fix resolving of multi-adminunit tasks.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 ---------------------
 
 - Set 90px as a minimum instead of fixed height for description-like widgets. [lgraf]
+- Fix resolving of multi-adminunit tasks. [phgross]
 - Concistently use "déroulement standard" for tasktemplates in French. [njohner]
 - Update and add missing French translations. [njohner, andresoberhaensli]
 - Fix has_children indexer which lead to duplicate brains. [njohner, phgross]

--- a/opengever/task/util.py
+++ b/opengever/task/util.py
@@ -148,12 +148,13 @@ def add_simple_response(task, text='', field_changes=None, added_object=None,
     return response
 
 
-def change_task_workflow_state(task, transition, **kwargs):
+def change_task_workflow_state(task, transition, disable_sync=False, **kwargs):
     """Changes the workflow state of the task.
     """
 
     wftool = api.portal.get_tool('portal_workflow')
-    wftool.doActionFor(task, transition, transition_params=kwargs)
+    wftool.doActionFor(
+        task, transition, disable_sync=disable_sync, transition_params=kwargs)
 
 
 def get_documents_of_task(task, include_mails=False):


### PR DESCRIPTION
Avoid unnecessary workflow changes syncs, when resolve a multi adminunit task. Because this leads do erorrs or incomplete task completions (not delivered documents etc.)

Unfortunately adding a test which checks for this issues was not possible, because we can not completly test the multi-adminunit communication.

Closes #5651 