### PR TITLE
Fix the setting of the content-type for Oneoffixx templates

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 
 - Set 90px as a minimum instead of fixed height for description-like widgets. [lgraf]
 - Fix resolving of multi-adminunit tasks. [phgross]
+- Fix the setting of the content-type for Oneoffixx templates. [Rotonen]
 - Concistently use "déroulement standard" for tasktemplates in French. [njohner]
 - Update and add missing French translations. [njohner, andresoberhaensli]
 - Fix has_children indexer which lead to duplicate brains. [njohner, phgross]

--- a/opengever/officeconnector/service.py
+++ b/opengever/officeconnector/service.py
@@ -217,7 +217,7 @@ class OfficeConnectorCheckoutPayload(OfficeConnectorPayload):
             if authorized:
                 if document.is_shadow_document():
                     # Oneoffixx is only used for .docx files in opengever.core
-                    payload['content-type'] = IAnnotations(document).get("content_type")
+                    payload['content-type'] = IAnnotations(document)["content_type"]
                 else:
                     payload['content-type'] = document.get_file().contentType
 

--- a/opengever/oneoffixx/command.py
+++ b/opengever/oneoffixx/command.py
@@ -23,5 +23,6 @@ class CreateDocumentFromOneOffixxTemplateCommand(BaseObjectCreatorCommand):
         annotations["template-id"] = self.template_id
         annotations["languages"] = self.languages
         annotations["filename"] = self.filename
+        annotations["content-type"] = self.content_type
 
         return obj.as_shadow_document()


### PR DESCRIPTION
Seems I actually built all the machinery we needed, but then forgot to to actually plug it in in the end.

Original PR: https://github.com/4teamwork/opengever.core/pull/4282

🐷 will get fed.