### PR TITLE
Improve error message when trying to delete a referenced document.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2019.3.0 (unreleased)
 ---------------------
 
+- Improve error message when trying to delete a referenced document. [njohner]
 - Update documentation for SaaS deployment update. [njohner]
 - Extend task API serialization with responses data. [phgross]
 

--- a/opengever/core/locales/de/LC_MESSAGES/opengever.core.po
+++ b/opengever/core/locales/de/LC_MESSAGES/opengever.core.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2019-04-01 14:32+0000\n"
+"POT-Creation-Date: 2019-05-14 08:01+0000\n"
 "PO-Revision-Date: 2017-09-18 15:21+0200\n"
 "Last-Translator: Philippe Gross <p.gross@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -146,6 +146,7 @@ msgid "Inbox Container"
 msgstr "Eingangskorb Ordner"
 
 #: ./opengever/core/profiles/default/actions.xml
+#: ./opengever/core/upgrades/20190401163048_add_manage_webactions_action/actions.xml
 msgid "Manage Webactions"
 msgstr "Webaktionen verwalten"
 
@@ -320,6 +321,15 @@ msgstr "eCH-0147 Import"
 #: ./opengever/core/upgrades/20170729132649_add_ech0147_import_export_actions/actions.xml
 msgid "eCH-0147/eCH-0039 Export"
 msgstr "eCH-0147/eCH-0039 Export"
+
+msgid "opengever.document.document"
+msgstr "Dokument"
+
+msgid "opengever.meeting.proposal"
+msgstr "Antrag"
+
+msgid "opengever.task.task"
+msgstr "Aufgabe"
 
 #: ./opengever/core/profiles/default/actions.xml
 msgid "remove"

--- a/opengever/core/locales/fr/LC_MESSAGES/opengever.core.po
+++ b/opengever/core/locales/fr/LC_MESSAGES/opengever.core.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2019-04-01 14:32+0000\n"
+"POT-Creation-Date: 2019-05-14 08:01+0000\n"
 "PO-Revision-Date: 2013-03-27 10:44+0100\n"
 "Last-Translator: Philippe Gross <p.gross@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -143,6 +143,7 @@ msgid "Inbox Container"
 msgstr "Conteneur de la boîte de réception"
 
 #: ./opengever/core/profiles/default/actions.xml
+#: ./opengever/core/upgrades/20190401163048_add_manage_webactions_action/actions.xml
 msgid "Manage Webactions"
 msgstr "Administrer les actions web"
 
@@ -315,6 +316,15 @@ msgstr "Import eCH-0147"
 #: ./opengever/core/upgrades/20170729132649_add_ech0147_import_export_actions/actions.xml
 msgid "eCH-0147/eCH-0039 Export"
 msgstr "Export eCH-0147/eCH-0039"
+
+msgid "opengever.document.document"
+msgstr "Document"
+
+msgid "opengever.meeting.proposal"
+msgstr "Requête"
+
+msgid "opengever.task.task"
+msgstr "Tâche"
 
 #: ./opengever/core/profiles/default/actions.xml
 msgid "remove"

--- a/opengever/core/locales/opengever.core-manual.pot
+++ b/opengever/core/locales/opengever.core-manual.pot
@@ -1,0 +1,27 @@
+# --- PLEASE EDIT THE LINES BELOW CORRECTLY ---
+# SOME DESCRIPTIVE TITLE.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"POT-Creation-Date: 2009-09-21 10:54+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0\n"
+"Language-Code: en\n"
+"Language-Name: English\n"
+"Preferred-Encodings: utf-8 latin1\n"
+"Domain: opengever.core\n"
+
+msgid "opengever.document.document"
+msgstr ""
+
+msgid "opengever.task.task"
+msgstr ""
+
+msgid "opengever.meeting.proposal"
+msgstr ""

--- a/opengever/core/locales/opengever.core.pot
+++ b/opengever/core/locales/opengever.core.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-04-01 14:32+0000\n"
+"POT-Creation-Date: 2019-05-14 08:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -146,6 +146,7 @@ msgid "Inbox Container"
 msgstr ""
 
 #: ./opengever/core/profiles/default/actions.xml
+#: ./opengever/core/upgrades/20190401163048_add_manage_webactions_action/actions.xml
 msgid "Manage Webactions"
 msgstr ""
 
@@ -317,6 +318,15 @@ msgstr ""
 
 #: ./opengever/core/upgrades/20170729132649_add_ech0147_import_export_actions/actions.xml
 msgid "eCH-0147/eCH-0039 Export"
+msgstr ""
+
+msgid "opengever.document.document"
+msgstr ""
+
+msgid "opengever.meeting.proposal"
+msgstr ""
+
+msgid "opengever.task.task"
 msgstr ""
 
 #: ./opengever/core/profiles/default/actions.xml

--- a/opengever/trash/locales/de/LC_MESSAGES/opengever.trash.po
+++ b/opengever/trash/locales/de/LC_MESSAGES/opengever.trash.po
@@ -79,10 +79,10 @@ msgstr "Möchten Sie die selektierten Dokumente wirklich löschen?"
 msgid "msg_delete_not_possible"
 msgstr "Die selektierten Dokumente können nicht gelöscht werden."
 
-#. Default: "The document is referred by the document(s) ${links}."
+#. Default: "The document is referred by ${links}."
 #: ./opengever/trash/remover.py
 msgid "msg_document_has_backreferences"
-msgstr "Auf das Dokument existiert noch eine Referenz von Dokument ${links}."
+msgstr "Auf das Dokument existiert noch eine Referenz von ${links}."
 
 #. Default: "The document contains relations."
 #: ./opengever/trash/remover.py

--- a/opengever/trash/locales/fr/LC_MESSAGES/opengever.trash.po
+++ b/opengever/trash/locales/fr/LC_MESSAGES/opengever.trash.po
@@ -80,10 +80,10 @@ msgstr "Voulez-vous vraiment effacer les documents selectionnés?"
 msgid "msg_delete_not_possible"
 msgstr "Les documents selectionnés ne peuvent pas être effacés."
 
-#. Default: "The document is referred by the document(s) ${links}."
+#. Default: "The document is referred by ${links}."
 #: ./opengever/trash/remover.py
 msgid "msg_document_has_backreferences"
-msgstr "Le document ${links} fait encore référence à ce document."
+msgstr "Ce document est encore référencé par ${links}."
 
 #. Default: "The document contains relations."
 #: ./opengever/trash/remover.py

--- a/opengever/trash/remover.py
+++ b/opengever/trash/remover.py
@@ -7,6 +7,8 @@ from zope.component import getUtility
 from zope.component.interfaces import IObjectEvent
 from zope.component.interfaces import ObjectEvent
 from zope.event import notify
+from zope.globalrequest import getRequest
+from zope.i18n import translate
 from zope.interface import implements
 from zope.intid.interfaces import IIntIds
 
@@ -80,12 +82,14 @@ class RemoveConditionsChecker(object):
         if objs_with_backreferences:
             links = []
             for obj in objs_with_backreferences:
-                links.append(u'<a href={}>{}</a>'.format(
-                    obj.absolute_url(), obj.title))
+                type_str = translate(obj.portal_type, 'opengever.core',
+                                     context=getRequest())
+                links.append(u'<a href={}>{}: {}</a>'.format(
+                    obj.absolute_url(), type_str, obj.title))
 
             self.error_msg.append(
                 _(u'msg_document_has_backreferences',
-                  default=u'The document is referred by the document(s) ${links}.',
+                  default=u'The document is referred by ${links}.',
                   mapping={'links': ', '.join(links)}))
 
     def verify_is_trashed(self):

--- a/opengever/trash/tests/test_remove_conditions.py
+++ b/opengever/trash/tests/test_remove_conditions.py
@@ -40,7 +40,7 @@ class TestRemoveConditionsChecker(IntegrationTestCase):
 
         self.assertFalse(checker.removal_allowed())
         self.assert_error_messages(
-            [u'The document is referred by the document(s) <a href={}>{}</a>.'.format(
+            [u'The document is referred by <a href={}>opengever.document.document: {}</a>.'.format(
                 self.taskdocument.absolute_url(), self.taskdocument.title)],
             checker.error_msg)
 


### PR DESCRIPTION
We improve the error message when a document cannot be deleted because it is reference by another item. Instead of only listing the titles of the items that reference the document, we also show their portal type.
I translated the portal types for documents, tasks and proposals. Is there any other portal type that can reference a document?

**Example for a document with a task, a proposal and a document referencing it**
<img width="913" alt="Screen Shot 2019-05-14 at 10 00 50" src="https://user-images.githubusercontent.com/7374243/57681366-d32d1b80-762f-11e9-95f5-4c508e33a494.png">

resolves #5592 