### PR TITLE
Update documentation for the `Metadaten anzeigen` action

### DIFF
--- a/docs/public/user-manual/dossiers/bearbeiten.rst
+++ b/docs/public/user-manual/dossiers/bearbeiten.rst
@@ -17,10 +17,10 @@ Deckblatt oder Geschäftsdetails ausdrucken
 Über *Aktionen* kann das Deckblatt oder die Geschäftsdetails gedruckt
 werden.
 
-Dossier-Eigenschaften anzeigen
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Dossier-Metadaten anzeigen
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Wählt man die Aktion *Eigenschaften anzeigen*, werden sämtliche
+Wählt man die Aktion *Metadaten anzeigen*, werden sämtliche
 Metadaten des Dossiers angezeigt. Referenzierte Dossiers können von hier
 aus direkt ausgewählt werden.
 

--- a/docs/public/user-manual/img/media/img-dossiers-12.png
+++ b/docs/public/user-manual/img/media/img-dossiers-12.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5b60451e8032f8fea63bf54f4186ed51341543aad7c3e53ecf6064d83bcccfb5
-size 99425
+oid sha256:5d93cbe5b27a79d33b9e48cf039763e095260f1de8f2abb0da67a5b2b30734b6
+size 199252

--- a/docs/public/user-manual/img/media/img-dossiers-13.png
+++ b/docs/public/user-manual/img/media/img-dossiers-13.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:af63ba5a7e9defe81f0995ba1943c298aa7c395ac7d53d7ddad027bfd10f8abb
-size 70858
+oid sha256:0652e2617e7a51497d73d8c37453afe3163744110b19e34f79a06ea1b0a07259
+size 164769


### PR DESCRIPTION
With #4264 we changed the action translation from `Eigenschaften anzeigen` to `Metadaten anzeigen`.

https://basecamp.com/2768704/projects/14549453/todos/388183457