### PR TITLE
Update Dokument-Metadaten bearbeiten docu screenshot. 

### DIFF
--- a/docs/public/user-manual/dokumente/bearbeiten.rst
+++ b/docs/public/user-manual/dokumente/bearbeiten.rst
@@ -7,7 +7,7 @@ External Editor / Office Connector
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Zum Bearbeiten von Dokumenten muss der External Editor oder Office Connector
-installiert werden. Wir empfhelen den Office Connector, da dieser laufend von
+installiert werden. Wir empfehlen den Office Connector, da dieser laufend von
 4teamwork weiterentwickelt und verbessert wird.
 
 Sie können den Office Connector für Windows und Mac `auf der 4teamwork-Website <https://www.4teamwork.ch/office-connector>`_ herunterladen.

--- a/docs/public/user-manual/img/media/img-dokumente-7.png
+++ b/docs/public/user-manual/img/media/img-dokumente-7.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1526fa80299f42b47aecf2a0c0a4fb7216be3ad686ae307d24f8b131524bcaae
-size 52210
+oid sha256:afc58de7fa5cdd954819389407ef6874b31fe4cd24406d87b7a08bc11cabd4bc
+size 365739


### PR DESCRIPTION
There was an old screenshot used, which showed also the no longer existing `Auschecken / Bearbeiten` acction above the title.

See https://basecamp.com/2768704/projects/14549453/todos/388184388.