### PR TITLE
Nightly jobs: Also log exceptions to logfile, not just Sentry.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2019.2.0 (unreleased)
 ---------------------
 
+- Nightly jobs: Also log exceptions to logfile, not just Sentry. [lgraf]
 - Set 90px as a minimum instead of fixed height for description-like widgets. [lgraf]
 - Fix resolving of multi-adminunit tasks. [phgross]
 - Fix the setting of the content-type for Oneoffixx templates. [Rotonen]


### PR DESCRIPTION
This extends our custom exception hook so that any unhandled exception also gets written to `var/log/nightly-jobs.log` (not just reported to Sentry).