### PR TITLE
Docs: Update nightly cron jobs example

### DIFF
--- a/docs/intern/operations/allgemein.rst
+++ b/docs/intern/operations/allgemein.rst
@@ -110,7 +110,14 @@ Die Uhrzeit für den Cron-Job muss so gewählt werden, dass sie dem in den
 .. code:: bash
 
     # Nightly Jobs
-    0 01 * * * /home/zope/server/01-gever.example.org/bin/instance run_nightly_jobs >/dev/null 2>&1
+    0 01 * * * /bin/bash -l -c "/home/zope/server/01-gever.example.org/bin/instance0 run_nightly_jobs >/dev/null 2>&1"
+
+.. warning::
+    Der ``/bin/bash -l -c "<command>"`` wrapper ist nötig damit
+    der Cron-Job mit einer Login-Shell ausgeführt wird (damit die
+    Umgebungsvariablen für den ``zope`` User geladen werden). Dies ist
+    insbesondere relevant damit Umgebungsvariablen wie ``http_proxy``,
+    ``no_proxy`` oder ``RAVEN_DSN`` auch im Cron-Job verfügbar sind.
 
 Das Zeitfenster in der Registry wird mittels timedeltas (nicht Uhrzeiten)
 definiert - die Werte können also grösser als ``24:00`` sein. Dies erlaubt es,


### PR DESCRIPTION
The nightly cron jobs need to run with the zope user's environment variables. Because these are not normally sourced in a crontab, we prefix the nightly job command with `bash -l -c` in order to run them in a login shell, which will load the environment variables.

This is of particular importantance for the nightly jobs for at least two reasons:

- When triggering archival PDF generation via bumblebee, the `http_proxy` and `no_proxy` environment variables must be set correctly, otherwise requests may fail (with 502 notresolvable / BadStatusLine errors).

- We're attempting to log errors from the nightly jobs to  Sentry. For that to work, the `RAVEN_DSN` env variable needs to be set properly.