### PR TITLE
Update favorite-icon after cancel a document checkout.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -11,6 +11,7 @@ Changelog
 - Fix the setting of the content-type for Oneoffixx templates. [Rotonen]
 - Concistently use "déroulement standard" for tasktemplates in French. [njohner]
 - Update and add missing French translations. [njohner, andresoberhaensli]
+- Update favorite-icon after cancel a document checkout. [phgross]
 - Fix has_children indexer which lead to duplicate brains. [njohner, phgross]
 - Add a configurable scope for Oneoffixx OAuth2 grant requests. [Rotonen]
 - Trash: Update and reindex modification date when trashing documents. [lgraf]

--- a/opengever/base/tests/test_favorite.py
+++ b/opengever/base/tests/test_favorite.py
@@ -218,3 +218,25 @@ class TestHandlers(IntegrationTestCase):
             self.assertEqual('icon-docx', fav_admin.icon_class)
         with self.login(self.regular_user):
             self.assertEqual('icon-docx', fav_user.icon_class)
+
+    def test_icon_class_of_favorites_get_updated_on_checkout_cancel(self):
+        with self.login(self.regular_user):
+            self.checkout_document(self.document)
+
+        self.login(self.administrator)
+
+        fav_admin = create(Builder('favorite')
+                           .for_object(self.document)
+                           .for_user(self.administrator))
+
+        fav_user = create(Builder('favorite')
+                          .for_object(self.document)
+                          .for_user(self.regular_user))
+
+        with self.login(self.regular_user):
+            self.cancel_document_checkout(self.document)
+
+        with self.login(self.administrator):
+            self.assertEqual('icon-docx', fav_admin.icon_class)
+        with self.login(self.regular_user):
+            self.assertEqual('icon-docx', fav_user.icon_class)

--- a/opengever/document/configure.zcml
+++ b/opengever/document/configure.zcml
@@ -149,6 +149,12 @@
 
   <subscriber
       for="opengever.document.document.IDocumentSchema
+           opengever.document.interfaces.IObjectCheckoutCanceledEvent"
+      handler=".handlers.checkout_canceled"
+      />
+
+  <subscriber
+      for="opengever.document.document.IDocumentSchema
            opengever.document.interfaces.IObjectBeforeCheckInEvent"
       handler=".handlers.before_documend_checked_in"
       />

--- a/opengever/document/handlers.py
+++ b/opengever/document/handlers.py
@@ -31,6 +31,10 @@ def checked_in(context, event):
     _update_favorites_icon_class(context)
 
 
+def checkout_canceled(context, event):
+    _update_favorites_icon_class(context)
+
+
 def before_documend_checked_in(context, event):
     # Don't prevent checkin by failure to update DocProperties
     _update_docproperties(context, raise_on_error=False)

--- a/opengever/testing/integration_test_case.py
+++ b/opengever/testing/integration_test_case.py
@@ -555,6 +555,11 @@ class IntegrationTestCase(TestCase):
         """
         return self.get_checkout_manager(document).checkin()
 
+    def cancel_document_checkout(self, document):
+        """Checkin the given document.
+        """
+        return self.get_checkout_manager(document).cancel()
+
     def get_checkout_manager(self, document):
         """Returns the checkin checkout manager for a document.
         """


### PR DESCRIPTION
Since #4581 the document icon of documents marked as favorite gets updated on checkout and checkin. But on checkout-cancel the icon gets not updated, which leads in a wrong inconsistent document icon. This change solves this issue.