### PR TITLE
Add french documentation for SPV and tasks

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2019.2.1 (unreleased)
 ---------------------
 
+- Add french translation for spv documentation. [andresoberhaensli, njohner]
 - Add french translation for task documentation. [andresoberhaensli, njohner]
 
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,7 @@ Changelog
 2019.2.1 (unreleased)
 ---------------------
 
-- Nothing changed yet.
+- Add french translation for task documentation. [andresoberhaensli, njohner]
 
 
 2019.2.0 (2019-05-16)

--- a/docs/public-fr/_static/img/img-accomplir_tache-01.png
+++ b/docs/public-fr/_static/img/img-accomplir_tache-01.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9ef16ceb30552cfc063ec503f22df5712784717e366e8d075a2c7af43ed3c02f
+size 145469

--- a/docs/public-fr/_static/img/img-accomplir_tache-02.png
+++ b/docs/public-fr/_static/img/img-accomplir_tache-02.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fc9f8ad71e052d0de548e591e9c25c83243f377bb3b50c21e6df7f32cb1accc7
+size 226068

--- a/docs/public-fr/_static/img/img-ajouter_ordre_jour_01.png
+++ b/docs/public-fr/_static/img/img-ajouter_ordre_jour_01.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ceebee3a909c3b51ca0bd905eb05858723bf2a87b884844897ff36317614b85d
+size 406155

--- a/docs/public-fr/_static/img/img-ajouter_ordre_jour_02.png
+++ b/docs/public-fr/_static/img/img-ajouter_ordre_jour_02.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f64c4539849b34080abb6d69087b35a3abcfcbd4dc61a9875b097014ae8f66ab
+size 126833

--- a/docs/public-fr/_static/img/img-ajouter_ordre_jour_03.png
+++ b/docs/public-fr/_static/img/img-ajouter_ordre_jour_03.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b770ffda612b98db52cb9a4c78aeea092b74df401777b86dba97a57169a8e510
+size 136794

--- a/docs/public-fr/_static/img/img-ajouter_ordre_jour_04.png
+++ b/docs/public-fr/_static/img/img-ajouter_ordre_jour_04.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:70b134d50b8c48abdcc2c44b429f5739f405659636bd5b5244d9e7c1de9c26ae
+size 68432

--- a/docs/public-fr/_static/img/img-ajouter_ordre_jour_05.png
+++ b/docs/public-fr/_static/img/img-ajouter_ordre_jour_05.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5c88c1abf8b63d2b6b733b651d8d885c632371ad91660849f60b5fd640e46c71
+size 111374

--- a/docs/public-fr/_static/img/img-approbation_proces_verbal-01.png
+++ b/docs/public-fr/_static/img/img-approbation_proces_verbal-01.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:462bc56cef0f54e8234456c4ebdb65a1614353df684d4175a1aace2d7990a720
+size 51970

--- a/docs/public-fr/_static/img/img-approbation_proces_verbal-02.png
+++ b/docs/public-fr/_static/img/img-approbation_proces_verbal-02.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2c9027a1ebf46bfbb9bca3917cbe6dbf1859c252292172edab1f906a49dd6bd4
+size 92652

--- a/docs/public-fr/_static/img/img-approbation_proces_verbal-03.png
+++ b/docs/public-fr/_static/img/img-approbation_proces_verbal-03.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5af06a145f23992e8d72684c7d56791ece547feb32a358a9329f6aad541b1bfc
+size 114246

--- a/docs/public-fr/_static/img/img-approbation_proces_verbal-04.png
+++ b/docs/public-fr/_static/img/img-approbation_proces_verbal-04.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a8d03701edf417cbfa6419af8f433e7e6c3a3e8f3f37bcd10c65437abdff0e8b
+size 61705

--- a/docs/public-fr/_static/img/img-cloturer_periode-01.png
+++ b/docs/public-fr/_static/img/img-cloturer_periode-01.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:05b8633ddc5f65b37d4cff6897c5de29e326c8f30335855daf9c7f3fe94b1904
+size 143724

--- a/docs/public-fr/_static/img/img-cloturer_periode-02.png
+++ b/docs/public-fr/_static/img/img-cloturer_periode-02.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ff01f64ac5b733f7ca41890bd94e2d8d0a7b302ec3f4f24ed2d258a4fdb99d76
+size 78422

--- a/docs/public-fr/_static/img/img-cloturer_seance-01.png
+++ b/docs/public-fr/_static/img/img-cloturer_seance-01.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:24c117f0f4681481faae82a958b853be0276cf9e20b3175343a257b64d650432
+size 195540

--- a/docs/public-fr/_static/img/img-cloturer_seance-02.png
+++ b/docs/public-fr/_static/img/img-cloturer_seance-02.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3be29e155d40c0e2075e97a355c5e492b980d6c9b05260551c8f9d01eaca223c
+size 70265

--- a/docs/public-fr/_static/img/img-cloturer_seance-03.png
+++ b/docs/public-fr/_static/img/img-cloturer_seance-03.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:95437137de74cd96cc1b4dad55f905ad8c35566aea19dc4ff2f084a59e913486
+size 127784

--- a/docs/public-fr/_static/img/img-cloturer_seance-04.png
+++ b/docs/public-fr/_static/img/img-cloturer_seance-04.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:399faa6e66b8028c91fc0d1467c9a2e4d7f3ad630615f8ad05f5a93abec69cbf
+size 212002

--- a/docs/public-fr/_static/img/img-cloturer_seance-05.png
+++ b/docs/public-fr/_static/img/img-cloturer_seance-05.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5a36bb7cbd6b7d83497fcc2bee9664f4053c478ec39ca7733608e69095176240
+size 126151

--- a/docs/public-fr/_static/img/img-cloturer_seance-06.png
+++ b/docs/public-fr/_static/img/img-cloturer_seance-06.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b245e4d413ba1b25ab84b37a18951086eb1083204704381b3f47b5094faaf191
+size 258491

--- a/docs/public-fr/_static/img/img-cloturer_seance-07.png
+++ b/docs/public-fr/_static/img/img-cloturer_seance-07.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4826b86a1a337468c7c8af525b44848df0d9acf2c446798bb545e51c1a5a5543
+size 215090

--- a/docs/public-fr/_static/img/img-commission_et_membres-01.png
+++ b/docs/public-fr/_static/img/img-commission_et_membres-01.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:da293d0c7839c3dfdf2e9b5b406eed17f6e42f9635f8f15571b064a3b7c609b5
+size 65319

--- a/docs/public-fr/_static/img/img-commission_et_membres-02.png
+++ b/docs/public-fr/_static/img/img-commission_et_membres-02.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b2d9d471486ad5734a78797e06588bc75bb06fdcf800b13d87bbac25d48f5663
+size 86277

--- a/docs/public-fr/_static/img/img-commission_et_membres-03.png
+++ b/docs/public-fr/_static/img/img-commission_et_membres-03.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5f6572dadefd0e8a1751f1fe8d8fbf43b2dcfb793eb5fa02dc6b886c431bab71
+size 94322

--- a/docs/public-fr/_static/img/img-commission_et_membres-04.png
+++ b/docs/public-fr/_static/img/img-commission_et_membres-04.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:214ed5b30ebd03e08003898dfbe892e6ccec76229e045cd4c5e9483c693e4b09
+size 136085

--- a/docs/public-fr/_static/img/img-commission_et_membres-05.png
+++ b/docs/public-fr/_static/img/img-commission_et_membres-05.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3bcc05bf35b166e5f0a19d68ea5a920ceb7345fc19017ae373d41ef460f3f506
+size 196723

--- a/docs/public-fr/_static/img/img-commission_et_membres-06.png
+++ b/docs/public-fr/_static/img/img-commission_et_membres-06.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:afc39ce78d5570fccac818a99ae152da8ab446a595e009c6198dfaba14a1c317
+size 198386

--- a/docs/public-fr/_static/img/img-commission_et_membres-07.png
+++ b/docs/public-fr/_static/img/img-commission_et_membres-07.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:071096cb1906757897bcb3823d793f1c8af2bef11b164287ff2f18cc9eaec5d0
+size 126161

--- a/docs/public-fr/_static/img/img-commission_et_membres-08.png
+++ b/docs/public-fr/_static/img/img-commission_et_membres-08.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:737aff15c65fee5d3fbb93e2ba83306501cfe4f940b8e8cbf264e939c6b9741f
+size 111273

--- a/docs/public-fr/_static/img/img-commission_et_membres-09.png
+++ b/docs/public-fr/_static/img/img-commission_et_membres-09.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fa0aceeb164e923e2a971c3de12e7abb07aba486f1366b1c31fc978a6618a978
+size 88224

--- a/docs/public-fr/_static/img/img-commission_et_membres-10.png
+++ b/docs/public-fr/_static/img/img-commission_et_membres-10.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2edd59393818eda29b6cb89da315e537e30de299bbd3e1900d81a73ae25f13c3
+size 129127

--- a/docs/public-fr/_static/img/img-commission_et_membres-11.png
+++ b/docs/public-fr/_static/img/img-commission_et_membres-11.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2517f961ee3704a5b0c025b1a1dc588846d62890bc03c95e4b1e175c9cd1afc3
+size 82666

--- a/docs/public-fr/_static/img/img-controle_taches-01.png
+++ b/docs/public-fr/_static/img/img-controle_taches-01.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7f339191d4973bfa1aed96b6cab9230bcdd2323aa63ab6df865b8318601d9f67
+size 117341

--- a/docs/public-fr/_static/img/img-controle_taches-02.png
+++ b/docs/public-fr/_static/img/img-controle_taches-02.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4210e8fb072b0052c93a0b60bf12165776102fe4c34dc13049bf59d644f2b1cb
+size 114407

--- a/docs/public-fr/_static/img/img-controle_taches-03.png
+++ b/docs/public-fr/_static/img/img-controle_taches-03.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d168cc7f12ff5ac86cc4cea7ba66414066e6ae62305f2d55379671215a23e8a9
+size 187365

--- a/docs/public-fr/_static/img/img-controle_taches-04.png
+++ b/docs/public-fr/_static/img/img-controle_taches-04.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b5a587b50faea02162491ff296e5e508acc1ef634ea113919215a4a318105c9b
+size 180103

--- a/docs/public-fr/_static/img/img-controle_taches-05.png
+++ b/docs/public-fr/_static/img/img-controle_taches-05.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:51bc1485ff0c9c50b018ca33d470da5196b9065d0d50ec162cdc352ff80d6185
+size 75052

--- a/docs/public-fr/_static/img/img-controle_taches-06.png
+++ b/docs/public-fr/_static/img/img-controle_taches-06.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:11ec40973e71ceca8333c3a3ed72ed0a8d97ad6973b88b39351c78c6f91078dc
+size 58998

--- a/docs/public-fr/_static/img/img-controle_taches-07.png
+++ b/docs/public-fr/_static/img/img-controle_taches-07.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fbde88585b4cd7d854d0220649eab4273069c65b4e0d0e4b0d7a6dbfd86048a5
+size 114306

--- a/docs/public-fr/_static/img/img-cooperation_inter_mandants-01.png
+++ b/docs/public-fr/_static/img/img-cooperation_inter_mandants-01.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0b0aaf7887392c8224c0916bdcc8738e642ec6445324b17a91b2c87157158653
+size 544

--- a/docs/public-fr/_static/img/img-cooperation_inter_mandants-02.png
+++ b/docs/public-fr/_static/img/img-cooperation_inter_mandants-02.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:30f92080f44daf2372a9933c61cbe39a1413819695732718c119604e0f5d191e
+size 57710

--- a/docs/public-fr/_static/img/img-cooperation_inter_mandants-03.png
+++ b/docs/public-fr/_static/img/img-cooperation_inter_mandants-03.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:116b8d8b592e7f2a1f4a79bea404253a9f163633f909c7da66e0db9a971e0a7a
+size 69662

--- a/docs/public-fr/_static/img/img-cooperation_inter_mandants-04.png
+++ b/docs/public-fr/_static/img/img-cooperation_inter_mandants-04.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:04f80c2ff6c431f500c1f8567c2ea1254948341cabfbb12413177eed26071d18
+size 96044

--- a/docs/public-fr/_static/img/img-cooperation_inter_mandants-05.png
+++ b/docs/public-fr/_static/img/img-cooperation_inter_mandants-05.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:815514809854e04d19f8a59b90b4fffefffab470efe64db0e695a0cf15e79ae8
+size 28525

--- a/docs/public-fr/_static/img/img-cooperation_inter_mandants-06.png
+++ b/docs/public-fr/_static/img/img-cooperation_inter_mandants-06.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:24bc6e9869447880f0fb1376f80a77e7348499ca70d1b837eb5931b9f9b1a559
+size 107626

--- a/docs/public-fr/_static/img/img-cooperation_inter_mandants-07.png
+++ b/docs/public-fr/_static/img/img-cooperation_inter_mandants-07.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8a822332c11b0c58014bac1b42fbaf96cbf92f41f295be36adfd82ff0e4ca0b9
+size 38137

--- a/docs/public-fr/_static/img/img-cooperation_inter_mandants-08.png
+++ b/docs/public-fr/_static/img/img-cooperation_inter_mandants-08.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d700c3adc31885ee53a6eb3f9e02c76db208b6bce3c0d860492514843531a3e4
+size 38688

--- a/docs/public-fr/_static/img/img-cooperation_inter_mandants-09.png
+++ b/docs/public-fr/_static/img/img-cooperation_inter_mandants-09.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aeac0850234b02c1878dacdcd9dc97761c1e546fc3e8beb3dced2401d1d70e6e
+size 38649

--- a/docs/public-fr/_static/img/img-cooperation_inter_mandants-10.png
+++ b/docs/public-fr/_static/img/img-cooperation_inter_mandants-10.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a63a11d393b070697818cc29a7b672cdc07c9c43acd7682c1d4d30648b93112b
+size 31000

--- a/docs/public-fr/_static/img/img-cooperation_inter_mandants-11.png
+++ b/docs/public-fr/_static/img/img-cooperation_inter_mandants-11.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f9f4398ee1cea1b93c051184d43f6ad5861d62f1766fcb39ffb2788c0fdeb59d
+size 117234

--- a/docs/public-fr/_static/img/img-cooperation_inter_mandants-12.png
+++ b/docs/public-fr/_static/img/img-cooperation_inter_mandants-12.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:92f6bcaf3177b83e82d05d487de93a37382abbe104ad7619dcd1a9c211cb5d2f
+size 107730

--- a/docs/public-fr/_static/img/img-cooperation_inter_mandants-13.png
+++ b/docs/public-fr/_static/img/img-cooperation_inter_mandants-13.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2b62b9051b7eaed01c66bf70cc2e44ae3dcc0522d930fdb2d2c2e30b62d78baf
+size 38262

--- a/docs/public-fr/_static/img/img-cooperation_inter_mandants-14.png
+++ b/docs/public-fr/_static/img/img-cooperation_inter_mandants-14.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ef13141d47aaaf76badf23ef5d8d96efdbf96b4b430656bfbc3a861bbd9003b1
+size 38802

--- a/docs/public-fr/_static/img/img-cooperation_inter_mandants-15.png
+++ b/docs/public-fr/_static/img/img-cooperation_inter_mandants-15.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:174a5bb077d38d3265f105b81c1b80391556e218aa61d38d7215225f0f1849ae
+size 34873

--- a/docs/public-fr/_static/img/img-cooperation_inter_mandants-16.png
+++ b/docs/public-fr/_static/img/img-cooperation_inter_mandants-16.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:713625620b7379eec2f59d743b221d087500c3b0112d262348318e1b7bedc262
+size 67592

--- a/docs/public-fr/_static/img/img-cooperation_inter_mandants-17.png
+++ b/docs/public-fr/_static/img/img-cooperation_inter_mandants-17.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ce0b0f6f622806d7db1a160350b7fe2fc2a237708e2714a25e2d95bcfc1bc1b1
+size 103056

--- a/docs/public-fr/_static/img/img-cooperation_inter_mandants-18.png
+++ b/docs/public-fr/_static/img/img-cooperation_inter_mandants-18.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b5b9e6abd750c46d3a187a7266eecdf84466cc78937d8f3722c391e015f87f87
+size 104309

--- a/docs/public-fr/_static/img/img-cooperation_inter_mandants-19.png
+++ b/docs/public-fr/_static/img/img-cooperation_inter_mandants-19.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2276d3f95ded631e8563c92c4a5355178c90e282c752f2dc0ab258e720e4ac54
+size 31545

--- a/docs/public-fr/_static/img/img-cooperation_inter_mandants-20.png
+++ b/docs/public-fr/_static/img/img-cooperation_inter_mandants-20.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1f8e01313a2b0742656699d3ea6c27b6c187c91d39da99f1a05235304e8289a9
+size 92543

--- a/docs/public-fr/_static/img/img-cooperation_inter_mandants-21.png
+++ b/docs/public-fr/_static/img/img-cooperation_inter_mandants-21.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4b56f9c9a6694cce775ca84b6ebd13beb196dbb7e4ac94ce4369a7ec1c442447
+size 100066

--- a/docs/public-fr/_static/img/img-cooperation_inter_mandants-22.png
+++ b/docs/public-fr/_static/img/img-cooperation_inter_mandants-22.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7d8c5fef4d8f423fcd72fca12d6252641da48351f7f1d2f1d04a9885b77c97df
+size 40130

--- a/docs/public-fr/_static/img/img-cooperation_inter_mandants-23.png
+++ b/docs/public-fr/_static/img/img-cooperation_inter_mandants-23.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dde83c3f6bb345a001942afb3d057e78a78250bea0946c67cbe8dcf3a4910d14
+size 32464

--- a/docs/public-fr/_static/img/img-cooperation_inter_mandants-24.png
+++ b/docs/public-fr/_static/img/img-cooperation_inter_mandants-24.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c14ab0718dc9869af37dc732baedddbd862d39deda72f392218e7952a7b22e82
+size 84667

--- a/docs/public-fr/_static/img/img-cooperation_inter_mandants-25.png
+++ b/docs/public-fr/_static/img/img-cooperation_inter_mandants-25.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a5ac2a0c092904a644812331893161be37b84b39ca632a543611e711150fdd25
+size 98261

--- a/docs/public-fr/_static/img/img-cooperation_inter_mandants-26.png
+++ b/docs/public-fr/_static/img/img-cooperation_inter_mandants-26.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:99241c88c0c903c537f19eadae025bb314c9e27dc6d6bb40d97b37d2ad73ae48
+size 101655

--- a/docs/public-fr/_static/img/img-cooperation_inter_mandants-27.png
+++ b/docs/public-fr/_static/img/img-cooperation_inter_mandants-27.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:23ba454e497ece1d5a4aae6f9bcf46975c8c67947a903ce383b0f59ee43ba6d7
+size 103330

--- a/docs/public-fr/_static/img/img-cooperation_inter_mandants-28.png
+++ b/docs/public-fr/_static/img/img-cooperation_inter_mandants-28.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:46d3695ad52d4254ee2cff5770a0cf46508ab5c42a647da4594ac8eb0c5cb8ff
+size 92128

--- a/docs/public-fr/_static/img/img-cooperation_inter_mandants-29.png
+++ b/docs/public-fr/_static/img/img-cooperation_inter_mandants-29.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bcfc9b29ea2df7b2934a2a068fc82cbc0dea06d9f32a8b4eb6db78b19f175aa2
+size 46749

--- a/docs/public-fr/_static/img/img-cooperation_inter_mandants-30.png
+++ b/docs/public-fr/_static/img/img-cooperation_inter_mandants-30.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5c779f5fe3149b8cb5a4d629836b2b71854a8a1ccf03255b4a07acb091918c5b
+size 54202

--- a/docs/public-fr/_static/img/img-cooperation_inter_mandants-31.png
+++ b/docs/public-fr/_static/img/img-cooperation_inter_mandants-31.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c454b6f7d65924918bb6852dc62cb2e399065bbee6b4fb2d4dcfee93f0037efe
+size 104840

--- a/docs/public-fr/_static/img/img-creer_sous_tache-01.png
+++ b/docs/public-fr/_static/img/img-creer_sous_tache-01.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:17cd9ba35adb335fb08450b60bb6039a39080ff9413ed48ea2f1f4b4201396d6
+size 61702

--- a/docs/public-fr/_static/img/img-creer_sous_tache-02.png
+++ b/docs/public-fr/_static/img/img-creer_sous_tache-02.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:411c68940ab975787f0e644547b2fd31ef0608f4a94090075377885792598172
+size 54840

--- a/docs/public-fr/_static/img/img-creer_tache-01.png
+++ b/docs/public-fr/_static/img/img-creer_tache-01.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:55e3c99082b6ab57aeb832a7c9293733d091c682b889b5c5edb29675ac62aa6e
+size 127648

--- a/docs/public-fr/_static/img/img-creer_tache-02.png
+++ b/docs/public-fr/_static/img/img-creer_tache-02.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e50fbafa0edfdd34b3ae26560cc75085e7fb0be940952bc557baa4a62db2a448
+size 125714

--- a/docs/public-fr/_static/img/img-creer_tache-03.png
+++ b/docs/public-fr/_static/img/img-creer_tache-03.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eba0b44552f1ede7ae8b6ff7913e251a54ceb6f83f3787caa68e28b34baa0a69
+size 99570

--- a/docs/public-fr/_static/img/img-creer_tache-04.png
+++ b/docs/public-fr/_static/img/img-creer_tache-04.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c8c981cfaac60e47aad20d840bd85cc9670bd0b1fe58ca737badb8cc6e24e95c
+size 38787

--- a/docs/public-fr/_static/img/img-detail_tache-01.png
+++ b/docs/public-fr/_static/img/img-detail_tache-01.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:75007762b38711267a96db1c8c6a285aaeb4960c1d458896e1a346aaa8ccb18d
+size 139256

--- a/docs/public-fr/_static/img/img-exporter_documents-01.png
+++ b/docs/public-fr/_static/img/img-exporter_documents-01.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8e44dbf7fb5f545dcecd5350eb602ee74fce2f6d05ad3e0eb7abfab6e86a182a
+size 121575

--- a/docs/public-fr/_static/img/img-flux_de_travail-01.png
+++ b/docs/public-fr/_static/img/img-flux_de_travail-01.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:be4fde19cad363291148a9826af26f171663dceb7fb4c11d4fcd3e0b4df99a9a
+size 160449

--- a/docs/public-fr/_static/img/img-lister_changements-01.png
+++ b/docs/public-fr/_static/img/img-lister_changements-01.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:634d5664eb88e02e715d90d3e28716ed33021e3c7eb333832bab36c012f6b344
+size 75291

--- a/docs/public-fr/_static/img/img-preparer_seance-01.png
+++ b/docs/public-fr/_static/img/img-preparer_seance-01.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5b80891df7bc6dfcfa1bcfd6fb73b1f70da4e68ebd675ced72c30d2ddc7fa42c
+size 176127

--- a/docs/public-fr/_static/img/img-preparer_seance-02.png
+++ b/docs/public-fr/_static/img/img-preparer_seance-02.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:54f8148acdf61eb2b1e0b9bff3bccd8de4cd009dadc16d95fa45671c2b497c76
+size 228319

--- a/docs/public-fr/_static/img/img-preparer_seance-03.png
+++ b/docs/public-fr/_static/img/img-preparer_seance-03.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:da7b5ff5c852b0daf58c223e3ca3a5596d67a5e0691e327b50c2a8723d1cef59
+size 189543

--- a/docs/public-fr/_static/img/img-preparer_seance-04.png
+++ b/docs/public-fr/_static/img/img-preparer_seance-04.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:734a15891e4d9f0f6488057e4b2713336c2c4780b682eeaf556e53ab888fe25e
+size 54244

--- a/docs/public-fr/_static/img/img-saisir_requete_01.png
+++ b/docs/public-fr/_static/img/img-saisir_requete_01.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fbd13c2de77b10827751f555f43e1711306a331ec90e6d59d766efa6d0cf0e6e
+size 255245

--- a/docs/public-fr/_static/img/img-saisir_requete_02.png
+++ b/docs/public-fr/_static/img/img-saisir_requete_02.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5c45f06fa747a9db538c95f25721915a8d11b57728feea9a37902d3253602c13
+size 270076

--- a/docs/public-fr/_static/img/img-saisir_requete_03.png
+++ b/docs/public-fr/_static/img/img-saisir_requete_03.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d876b1fb46342ced86443c47355d7cbe6c38fd371eb7e27725030401512ad305
+size 83686

--- a/docs/public-fr/_static/img/img-saisir_requete_04.png
+++ b/docs/public-fr/_static/img/img-saisir_requete_04.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bfc08392e3ce81e3b42f6a1b6df80937aee31f1f3789a265feb616d39b79476e
+size 66967

--- a/docs/public-fr/_static/img/img-saisir_requete_05.png
+++ b/docs/public-fr/_static/img/img-saisir_requete_05.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c4c13d7654d2dff68f08e291ea01575b649ea14f727fdb9dec20a2bb4e8b0572
+size 196131

--- a/docs/public-fr/_static/img/img-saisir_requete_06.png
+++ b/docs/public-fr/_static/img/img-saisir_requete_06.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3e750075407589cf1f9ef5ac2bad92aab8d8dbb6d94e9b5c0e57fa6d700a7bc8
+size 46111

--- a/docs/public-fr/_static/img/img-saisir_requete_07.png
+++ b/docs/public-fr/_static/img/img-saisir_requete_07.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:886109564c9dbc5ffe787e419394fc5446258ebc29222767db289085ced5df24
+size 361131

--- a/docs/public-fr/_static/img/img-saisir_requete_08.png
+++ b/docs/public-fr/_static/img/img-saisir_requete_08.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:89cdf557e736a9c097f287d8276033f43325521a908c5f1dd34b7bc9483d7c63
+size 529127

--- a/docs/public-fr/_static/img/img-saisir_requete_09.png
+++ b/docs/public-fr/_static/img/img-saisir_requete_09.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e440c1a426ae0656ca0afcfeabe51e92a5ebd9d6abb13ffb149c311b9277bda1
+size 277686

--- a/docs/public-fr/_static/img/img-suppleance-01.png
+++ b/docs/public-fr/_static/img/img-suppleance-01.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2f52134da5578c830a4db890721439b137a2be076dd2128d0058f2f644255180
+size 89472

--- a/docs/public-fr/_static/img/img-suppleance-02.png
+++ b/docs/public-fr/_static/img/img-suppleance-02.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b5a18856fe40f89c531040a0844c729ab81ec10f5a1458f3cd5147b59859b68e
+size 65680

--- a/docs/public-fr/_static/img/img-tache_recapitulative-01.png
+++ b/docs/public-fr/_static/img/img-tache_recapitulative-01.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cbe497333c597899720c11ae335c62f5aaa7e6fce997cc2693a09fb71723449d
+size 91159

--- a/docs/public-fr/_static/img/img-tache_recapitulative-02.png
+++ b/docs/public-fr/_static/img/img-tache_recapitulative-02.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:586fa85eb334738da0697c0b0846b5b6a163849ebbc04e8182f591dca72f2064
+size 266537

--- a/docs/public-fr/_static/img/img-taches01.png
+++ b/docs/public-fr/_static/img/img-taches01.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a5a320461fc2fccb38428620630bd0f0620f25a94eca6ac7f1499d40bd7a87c4
+size 274862

--- a/docs/public-fr/_static/img/img-taches02.png
+++ b/docs/public-fr/_static/img/img-taches02.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6a9e8c2c55bf970e0ff2e6b923e09b9ce76aeff7be199b5fdda1acfc68b997dc
+size 97910

--- a/docs/public-fr/_static/img/img-taches03.png
+++ b/docs/public-fr/_static/img/img-taches03.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b5b932791925275bb0b04a828233974a2f9706742ad1c6ef19de75fd9c3d97ad
+size 97659

--- a/docs/public-fr/_static/img/img-taches04.png
+++ b/docs/public-fr/_static/img/img-taches04.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c5264c26141e7a010046b9a1dd9b32ccbf7135e8ad6bd9448b37150b151121ed
+size 83471

--- a/docs/public-fr/_static/img/img-taches05.png
+++ b/docs/public-fr/_static/img/img-taches05.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c0f548033d2b6a29a6893da67d9ed9bee5282bce20c2c41a7627762eac1e2a14
+size 97914

--- a/docs/public-fr/_static/img/img-taches06.png
+++ b/docs/public-fr/_static/img/img-taches06.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6a387ef2c963a1f50b23d865dbf23e2f8e4ea55514367ad8b6f44df452a1e445
+size 34056

--- a/docs/public-fr/_static/img/img-taches07.png
+++ b/docs/public-fr/_static/img/img-taches07.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:75abe6e159b985154d11850c8f16861f01c412df992079086dfd48319a15e883
+size 118220

--- a/docs/public-fr/_static/img/img-taches08.png
+++ b/docs/public-fr/_static/img/img-taches08.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:67b0750d3b3da0eae1574e1ff6792ec7c25dada6e725fd0ea52dc9a291f42e6c
+size 104588

--- a/docs/public-fr/_static/img/img-taches09.png
+++ b/docs/public-fr/_static/img/img-taches09.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1d4041e9a010ed7f61ed81443fb811f5032f9703176cd5f8e037c73c66aa8254
+size 36224

--- a/docs/public-fr/_static/img/img-taches10.png
+++ b/docs/public-fr/_static/img/img-taches10.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7eb78a6fc1fc388c3baafba55dc18e1d446010b1df835f1ee0c17a5ab6a50ba4
+size 52136

--- a/docs/public-fr/_static/img/img-taches11.png
+++ b/docs/public-fr/_static/img/img-taches11.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9d6523fc982288a442332e561ac5550f93d0c37eb2460b564a5cfa098ba918f7
+size 113540

--- a/docs/public-fr/_static/img/img-taches12.png
+++ b/docs/public-fr/_static/img/img-taches12.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b153042df58f3f2a51d81121e89ba3d0869dee1747a950fedb1c0d17cbae1853
+size 66139

--- a/docs/public-fr/_static/img/img-taches13.png
+++ b/docs/public-fr/_static/img/img-taches13.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4e172a26d0a46d8863b40185435563b8aaa8f203bad98724d5553d2e560e5417
+size 109617

--- a/docs/public-fr/_static/img/img-taches14.png
+++ b/docs/public-fr/_static/img/img-taches14.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6405d3a207861c9246eb6416da114c3166433d9f394ade039a68ffc1940f0b7a
+size 23838

--- a/docs/public-fr/_static/img/img-taches15.png
+++ b/docs/public-fr/_static/img/img-taches15.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:06e2ab871cc5d449f5ecb93d80f2fefebcc6a3b41eaf941f17aa0cdfb2c903d2
+size 97281

--- a/docs/public-fr/_static/img/img-taches_equipe-01.png
+++ b/docs/public-fr/_static/img/img-taches_equipe-01.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cd62028ba8c6aa94b79708e874da47f1d3ee65637a8b3cb31a5c902a0c81fb6b
+size 119576

--- a/docs/public-fr/_static/img/img-taches_equipe-02.png
+++ b/docs/public-fr/_static/img/img-taches_equipe-02.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3176a9f862ee827ae119a643e84cf683882d3b3ccfabf107acbefa3947e0d286
+size 95707

--- a/docs/public-fr/_static/img/img-taches_equipe-03.png
+++ b/docs/public-fr/_static/img/img-taches_equipe-03.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aa7cc025d1036c065d2b5c9fe3735f798a24535688d7bf2dd969dfd723324a20
+size 157015

--- a/docs/public-fr/_static/img/img-taches_equipe-04.png
+++ b/docs/public-fr/_static/img/img-taches_equipe-04.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cf54df8aca5528f5b4c79f974699b7e851a9b2ab1118b8e513e56425afccce4a
+size 109390

--- a/docs/public-fr/_static/img/img-taches_equipe-05.png
+++ b/docs/public-fr/_static/img/img-taches_equipe-05.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:86963b7323ad9de9cdb01f29fa47c9111c850b903ece7b5fcc9b6026604630d7
+size 127654

--- a/docs/public-fr/_static/img/img-tenir_seance-01.png
+++ b/docs/public-fr/_static/img/img-tenir_seance-01.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aed514e95a8a6330752558fa63c6b6e54ea8969badb8909ec61ac3bfa7301dcd
+size 211899

--- a/docs/public-fr/_static/img/img-tenir_seance-02.png
+++ b/docs/public-fr/_static/img/img-tenir_seance-02.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0107e5a9371abb4877cd385d1bb526bae5b66525c02b99ef54bdb18906f95a85
+size 107990

--- a/docs/public-fr/_static/img/img-tenir_seance-03.png
+++ b/docs/public-fr/_static/img/img-tenir_seance-03.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:56561be84b11168d40d3e1888acbfaa28f6b647982b5242daca8d23a95d13661
+size 58919

--- a/docs/public-fr/_static/img/img-tenir_seance-04.png
+++ b/docs/public-fr/_static/img/img-tenir_seance-04.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:435b36c12e395bced68bcfa20cb3db77f2811d28487e34d275809071603ddb32
+size 228207

--- a/docs/public-fr/_static/img/img-tenir_seance-05.png
+++ b/docs/public-fr/_static/img/img-tenir_seance-05.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:92b1b63267553abb44b2b33961dbb952acf959d41440385e78971c620627c967
+size 130601

--- a/docs/public-fr/app-seances/notifier_documents.rst
+++ b/docs/public-fr/app-seances/notifier_documents.rst
@@ -10,7 +10,7 @@ Vous pouvez envoyer la notification à tous ou seulement une sélection de parti
 |img-notifier2|
 |img-notifier3|
 
-L’envoi d’un message par email est déclenché à l’aide du bouton «Envoyer». Cette notification contient un lien qui permettra aux participants d’accéder à l’App et ainsi aux documents de la séance. 
+L’envoi d’un message par email est déclenché à l’aide du bouton «Envoyer». Cette notification contient un lien qui permettra aux participants d’accéder à l’App et ainsi aux documents de la séance.
 
 .. |img-notifier1| image:: ../_static/img/img-notifier1.png
 .. |img-notifier2| image:: ../_static/img/img-notifier2.png

--- a/docs/public-fr/chapitre11-boitereception.rst
+++ b/docs/public-fr/chapitre11-boitereception.rst
@@ -6,7 +6,7 @@ Utilisation de la boîte de réception
 Fonctionnalité boîte de réception
 ---------------------------------
 
-Les courriers entrants qui doivent être justifiables au niveau directionnel sont saisis dans la boîte de réception et, de cet endroit, assignés à une personne responsable ou transmis à un autre mandant.
+Les courriers entrants qui doivent être justifiables au niveau directionnel sont saisis dans la boîte de réception et, de cet endroit, assignés à une personne responsable ou transmis à un autre client.
 
 .. note::
    Pour la saisie de courriers entrants, des droit spécifiques sont nécessaires ; par défaut ils sont assignés aux personnes avec les rôles de type *secrétariat* ou *direction*.
@@ -111,13 +111,13 @@ Réattribuer des courriers entrants
 Le courrier entrant est ensuite affiché sous l’onglet *Sommaire → Mes tâches* et peut être traité comme une tâche normale.
 
 
-Courrier entrant couvrant de multiples mandants
------------------------------------------------
+Courrier entrant couvrant de multiples clients
+----------------------------------------------
 
 Saisir le courrier entrant
 """"""""""""""""""""""""""
 
-Consultez la section `Saisir un courrier entrant`_ pour une procédure détaillée. La marche à suivre reste la même dans la situation où le traitement du courrier entrant se fait pour de multiples mandants.
+Consultez la section `Saisir un courrier entrant`_ pour une procédure détaillée. La marche à suivre reste la même dans la situation où le traitement du courrier entrant se fait pour de multiples clients.
 
 Transférer un courrier entrant
 """"""""""""""""""""""""""""""
@@ -126,19 +126,19 @@ Cochez le courrier entrant à transférer et sélectionnez *Transmettre*.
 
 |img-boitereception24|
 
-Saisissez un titre, le mandant destinataire et la boîte de réception du mandant destinataire.
+Saisissez un titre, le client destinataire et la boîte de réception du client destinataire.
 
 |img-boitereception25|
 
 .. note::
-  Les transmissions entre mandants doivent toujours être adressés à une boîte de réception.
+  Les transmissions entre clients doivent toujours être adressés à une boîte de réception.
 
 Après avoir sauvegardé, le courrier entrant apparaît chez l’expéditeur sous l’onglet *Tâches attribuées*. Chez le destinataire, le courrier entrant apparaît sous l’onglet *Tâches reçues*.
 
-Traiter le courrier entrant provenant d’un autre mandant
-""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+Traiter le courrier entrant provenant d’un autre client
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""
 
-Le traitement d’un un courrier entrant provenant d’un autre mandant est couvert dans la rubrique :ref:`label-cooperation_ic`
+Le traitement d’un un courrier entrant provenant d’un autre client est couvert dans la rubrique :ref:`label-cooperation_ic`
 
 
 .. |img-boitereception1| image:: _static/img/img-boitereception01.png

--- a/docs/public-fr/chapitre11-boitereception.rst
+++ b/docs/public-fr/chapitre11-boitereception.rst
@@ -1,3 +1,4 @@
+.. _label-boite_reception:
 
 Utilisation de la boîte de réception
 ====================================
@@ -116,7 +117,7 @@ Courrier entrant couvrant de multiples mandants
 Saisir le courrier entrant
 """"""""""""""""""""""""""
 
-Consultez la section « Saisir un courrier entrant » **[PLEASE LINK]** pour une procédure détaillée. La marche à suivre reste la même dans la situation où le traitement du courrier entrant se fait pour de multiples mandants.
+Consultez la section `Saisir un courrier entrant`_ pour une procédure détaillée. La marche à suivre reste la même dans la situation où le traitement du courrier entrant se fait pour de multiples mandants.
 
 Transférer un courrier entrant
 """"""""""""""""""""""""""""""
@@ -137,7 +138,7 @@ Après avoir sauvegardé, le courrier entrant apparaît chez l’expéditeur sou
 Traiter le courrier entrant provenant d’un autre mandant
 """"""""""""""""""""""""""""""""""""""""""""""""""""""""
 
-Le traitement d’un un courrier entrant provenant d’un autre mandant est couvert dans la rubrique Collaboration entre mandants **[PLEASE LINK]**
+Le traitement d’un un courrier entrant provenant d’un autre mandant est couvert dans la rubrique :ref:`label-cooperation_ic`
 
 
 .. |img-boitereception1| image:: _static/img/img-boitereception01.png

--- a/docs/public-fr/chapitre13-deroulements-standards.rst
+++ b/docs/public-fr/chapitre13-deroulements-standards.rst
@@ -1,3 +1,5 @@
+.. _chapitre-deroulement_standard:
+
 Travailler avec des déroulements standard
 =========================================
 
@@ -6,7 +8,7 @@ Qu’est-ce qu’un déroulement standard?
 
 Les séquences de tâches récurrentes (p. ex. Étapes de projet prédéfinies) peuvent être enregistrées dans la section « Modèles ». Ces séquences de tâches prédéfinies sont aussi nommées *déroulements standard*.
 
-La création et modification de déroulements standard est réservée aux utilisateurs ayant un profil qui inclut la gestion de modèles. La plupart du temps, il s’agit des administrateurs. De ce fait, la création de déroulements standard est couverte dans la documentation « Admin ».
+La création et modification de déroulements standard est réservée aux utilisateurs ayant un profil qui inclut la gestion de modèles. La plupart du temps, il s’agit des administrateurs. De ce fait, la création de déroulements standard est couverte dans `la documentation admin <https://docs.onegovgever.ch/admin-manual/standardablauferstellen/>`_ (disponible seulement en Allemand).
 
 |img-deroulstandard-1|
 
@@ -52,7 +54,7 @@ Les modèles de tâches marqués comme présélectionnés sont déjà inclus. Le
 
 |img-deroulstandard-6|
 
-En cliquant sur *Enclencher*, les tâches sélectionnées sont reprises par le dossier. Elles peuvent maintenant être traitées comme convenu (Voir *travailler avec des tâches*). C’est ici que les différences entre une séquence parallèle et séquentielle deviennent visibles, en particulier au niveau de l’état.
+En cliquant sur *Enclencher*, les tâches sélectionnées sont reprises par le dossier. Elles peuvent maintenant être traitées comme convenu (Voir :ref:`chapitre-taches`). C’est ici que les différences entre une séquence parallèle et séquentielle deviennent visibles, en particulier au niveau de l’état.
 
 Lors de l’activation d’un déroulement standard *parallèle*, une tâche principale avec plusieurs sous-tâches est créée. Dans les propriétés de la tâche principale, on peut voir qu’il s’agit d’un déroulement standard parallèle. Si un déroulement standard parallèle est déclenché, toutes les tâches sont automatiquement passées dans l’état « en traitement » et peuvent donc être traitées en même temps.
 
@@ -68,7 +70,7 @@ Points à considérer avec les déroulements standard séquentiels
 
 |img-deroulstandard-8|
 
--   Dans le sommaire des propriétés de la tâche principale d’un déroulement standard, il est possible d’insérer directement une nouvelle tâche dans la liste des tâches existante. Le déroulement standard peut ainsi être complété individuellement. Le formulaire « ajouter une nouvelle tâche » se comporte de la même manière que l’ajout d’une tâche standard et insert automatiquement une nouvelle tâche dans la séquence.
+-   Dans le sommaire des propriétés de la tâche principale d’un déroulement standard, il est possible d’insérer directement une nouvelle tâche dans la liste des tâches existante. Le déroulement standard peut ainsi être complété individuellement. Le formulaire « ajouter une nouvelle tâche » se comporte de la même manière que :ref:`l’ajout d’une tâche standard <label-creer_tache>` et insert automatiquement une nouvelle tâche dans la séquence.
 
 |img-deroulstandard-9|
 

--- a/docs/public-fr/chapitre14-referentiel.rst
+++ b/docs/public-fr/chapitre14-referentiel.rst
@@ -1,3 +1,5 @@
+.. _label-mon_referentiel:
+
 Mon Référentiel
 ===============
 

--- a/docs/public-fr/chapitre2-base.rst
+++ b/docs/public-fr/chapitre2-base.rst
@@ -40,7 +40,7 @@ Pour plus de sécurité, nous conseillons d’activer l’authentification
 d’un deuxième facteur. Le système vous demandera ensuite, à chaque nouvelle connexion,
 un mot de passe à usage unique que vous générerez à chaque fois au moyen
 d’une application supplémentaire depuis votre smartphone. Vous trouverez
-plus d’informations à ce sujet dans ce `Rapport <https://de.wikipedia.org/wiki/Zwei-Faktor-Authentifizierung>`_.
+plus d’informations à ce sujet dans ce `Rapport <https://fr.wikipedia.org/wiki/Double_authentification>`_.
 Pour l’activation, on peut d’abord tout simplement
 cliquer sur *Activer* depuis la page de portail.
 
@@ -52,8 +52,8 @@ Cela étant fait, on accède à la page du dispositif de l’authentification à
 
 Téléchargez l’application *Google Authenticator* et suivez les consignes d’installation :
 
--	`Pour iOS <https://support.google.com/accounts/answer/1066447?co=GENIE.Platform%3DiOS&hl=de&oco=0>`_
--	`Pour Android <https://support.google.com/accounts/answer/1066447?co=GENIE.Platform%3DAndroid&hl=de>`_
+-	`Pour iOS <https://support.google.com/accounts/answer/1066447?co=GENIE.Platform%3DiOS&hl=fr&oco=0>`_
+-	`Pour Android <https://support.google.com/accounts/answer/1066447?co=GENIE.Platform%3DAndroid&hl=fr>`_
 
 Avec l’application *Google Authenticator*, vous pouvez scanner les QR-codes.
 Pour cela, vous recevez un mot de passage à usage unique, mot de passe qui
@@ -107,14 +107,13 @@ est un module complémentaire et c’est pourquoi il n’est pas non plus visibl
 |img-base-8|
 
 1. Sommaire : celui-ci est la vue par défaut au moment du login et montre tous les dossiers personnels, les documents, les tâches etc. de l’utilisateur.
-2. Sous l‘onglet `Mon référentiel <https://docs.onegovgever.ch/user-manual/meine_ablage/#label-meineablage>`_
-   (disponible uniquement en allemand), chaque utilisateur se voit offrir la possibilité de pouvoir classer et gérer des documents personnels importants dans un domaine privé sur OneGov GEVER.
+2. Sous l‘onglet :ref:`label-mon_referentiel`, chaque utilisateur se voit offrir la possibilité de pouvoir classer et gérer des documents personnels importants dans un domaine privé sur OneGov GEVER.
 3. Système de classification: Via le système de classification, vous pouvez naviguer vers une rubrique où des dossiers et des documents peuvent ensuite être constitués et classés.
-4. Sous l‘onglet `Boîte de réception <https://docs.onegovgever.ch/user-manual/posteingang/#label-eingangskorb>`_
+4. Sous l‘onglet Boîte de réception :ref:`label-boite_reception`
    (disponible uniquement en allemand), des courriers peuvent être répertoriés et transmis.
 5. Sous l’onglet :ref:`Modèles <label-modeles-de-documents>`, vous trouvez tous les modèles de documents standards et vous pouvez en insérer de nouveaux.
 6. L‘onglet :ref:`Contacts <label-contacts>` contient des personnes externes à l’administration (sous-onglet local) et le carnet d’adresses central de tous les collaborateurs de l’administration (sous-onglet utilisateur).
-7. Sous l‘onglet `Sessions <https://docs.onegovgever.ch/user-manual/spv/#label-spv>`_
+7. Sous l‘onglet Sessions :ref:`chapitre-spv`
    (disponible uniquement en allemand), vous trouvez le gestionnaire des séances et des procès-verbaux (SPV).
 
 Fil d’Ariane

--- a/docs/public-fr/chapitre3-trucs.rst
+++ b/docs/public-fr/chapitre3-trucs.rst
@@ -73,8 +73,6 @@ de la largeur de la colonne en gardant le bouton de la souris appuyé.
 
 |img-trucs-4|
 
-.. _label-Trier à l'intérieur des colonnes:
-
 Trier à l'intérieur des colonnes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/public-fr/chapitre4-notifications.rst
+++ b/docs/public-fr/chapitre4-notifications.rst
@@ -1,29 +1,31 @@
+.. _label-notification:
+
 Paramètres de notification
 ==========================
 
 Dans les paramètres de notification, il est possible d’ajuster manuellement de quels évènements OneGov GEVER notifie son utilisateur respectif. Pour faire cela, cliquez sur le nom d’utilisateur en haut à droite et sélectionnez « Préférences » dans le menu déroulant.
 
 |img-notification1|
- 
-Une vue similaire à celle ci-dessous s’ouvre ensuite, présentant les réglages actuels des activités pour lesquelles OneGov GEVER vous notifie. Vous pouvez ainsi modifier, pour chaque activité, la (ou les) manière(s) dont vous serez notifié. Actuellement, les notifications proposées sont : la notification GEVER (via le symbole « cloche ») ou l’email. De plus, il est possible de souscrire à un résumé quotidien (daily digest) également envoyé par email. 
+
+Une vue similaire à celle ci-dessous s’ouvre ensuite, présentant les réglages actuels des activités pour lesquelles OneGov GEVER vous notifie. Vous pouvez ainsi modifier, pour chaque activité, la (ou les) manière(s) dont vous serez notifié. Actuellement, les notifications proposées sont : la notification GEVER (via le symbole « cloche ») ou l’email. De plus, il est possible de souscrire à un résumé quotidien (daily digest) également envoyé par email.
 
 |img-notification2|
- 
-Si vous désirez modifier les réglages par défaut, cliquez simplement sur la case à cocher pertinente pour cocher ou décocher celle-ci. Lorsqu’un réglage a été modifié, il vous est possible de sauvegarder ou d’annuler ce changement via le message de confirmation apparaissant sur la droite. 
+
+Si vous désirez modifier les réglages par défaut, cliquez simplement sur la case à cocher pertinente pour cocher ou décocher celle-ci. Lorsqu’un réglage a été modifié, il vous est possible de sauvegarder ou d’annuler ce changement via le message de confirmation apparaissant sur la droite.
 
 |img-notification3|
- 
+
 Les personnalisations peuvent être réinitialisées aux valeurs par défaut GEVER par l’intermédiaire de l’action « rétablir les valeurs par défaut »
 
 |img-notification4|
- 
-Notifications pour les transmissions, rappels et tâches. 
+
+Notifications pour les transmissions, rappels et tâches.
 --------------------------------------------------------
 
 Comme pour les notifications concernant les tâches, il est possible d’ajuster les notifications concernant les transmissions et rappels dans les onglet « Transmissions » et « Rappels » respectivement.
 
 |img-notification5|
- 
+
 Notifications concernant les dossiers
 -------------------------------------
 

--- a/docs/public-fr/chapitre6-recents.rst
+++ b/docs/public-fr/chapitre6-recents.rst
@@ -1,3 +1,5 @@
+.. _label-recemment_modifie:
+
 Documents récents
 =================
 

--- a/docs/public-fr/chapitre9-contacts.rst
+++ b/docs/public-fr/chapitre9-contacts.rst
@@ -38,7 +38,7 @@ En cliquant sur un contact, seuls les champs qui ont réellement été remplis s
 
 |img-contacts-3|
 
-Si vous devez travailler les données, choisissez *Modifier*.
+Si vous devez éditer les données, choisissez *Modifier*.
 
 Onglet Utilisateur
 ------------------

--- a/docs/public-fr/chapitre9-contacts.rst
+++ b/docs/public-fr/chapitre9-contacts.rst
@@ -31,8 +31,8 @@ et Prénom, les champs restants peuvent simplement être remplis au besoin.
 Affichage et traitement des contacts
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Dans la liste de présentation, les *Noms*, *Prénoms*, *E-mail* 1 et *Téléphone
-professionnel* sont en principe affichés.
+Dans la liste de présentation, les *Noms*, *Prénoms*, *E-mail 1* et
+*Téléphone professionnel* sont en principe affichés.
 
 En cliquant sur un contact, seuls les champs qui ont réellement été remplis s’affichent:
 

--- a/docs/public-fr/conf.py
+++ b/docs/public-fr/conf.py
@@ -123,7 +123,7 @@ html_theme_options = {
     'github_button': False,
     'logo_name': False,
     'logo': 'img/gever_logo.png',
-    'analytics_id': 'UA-7414398-7',
+    'analytics_id': 'UA-7414398-8',
     'fixed_sidebar': False,
     'extra_nav_links': {u'Site du produit': 'https://onegovgever.ch',
                         u'Forum de feedback': 'https://feedback.onegovgever.ch',

--- a/docs/public-fr/documents/chapitre6-actionsdiverses.rst
+++ b/docs/public-fr/documents/chapitre6-actionsdiverses.rst
@@ -138,6 +138,8 @@ sont également indiqués (aperçu complet avec le curseur de la souris).
 Export/Import ZIP
 ~~~~~~~~~~~~~~~~~
 
+.. _label-export-zip-documents:
+
 Export ZIP
 ----------
 

--- a/docs/public-fr/documents/chapitre6-actionsdiverses.rst
+++ b/docs/public-fr/documents/chapitre6-actionsdiverses.rst
@@ -24,7 +24,7 @@ et choisissez Aperçu PDF dans le Tooltip. De façon optionnelle, on peut ouvrir
 le PDF sans quitter le browser de la page actuelle (niveau du dossier) avec la commande
 Clic droit – Ouvrir un lien dans une nouvelle fenêtre. A partir des documents,
 GEVER produit des fichiers PDF en arrière-plan. De cette façon on peut éviter que
-des documents dont le check-out n’aurait pas été fait d‘être travaillés par inadvertance.
+des documents dont le check-out n’aurait pas été fait ne soient édités par inadvertance.
 
 |img-document-36|
 
@@ -34,7 +34,7 @@ après l’enregistrement, l’aperçu PDF peut éventuellement ne pas être enc
 Le message *PDF pas encore disponible, doit encore être constitué apparaît*.
 
 Dans ce cas, en cliquant sur le fichier, le fichier original est affiché.
-Si le fichier doit être travaillé, le check-out doit de nouveau être fait, sinon
+Si le fichier doit être édité, le check-out doit de nouveau être fait, sinon
 les modifications ne seront pas sauvegardées !
 
 Aperçu des formats de fichier qui peuvent être convertis en PDF (est cependant

--- a/docs/public-fr/documents/chapitre6-classer.rst
+++ b/docs/public-fr/documents/chapitre6-classer.rst
@@ -1,6 +1,8 @@
 Classer un e-mail en tant que document
 ======================================
 
+.. _label-importer_email:
+
 Importer un e-mail
 ------------------
 

--- a/docs/public-fr/documents/chapitre6-consulter.rst
+++ b/docs/public-fr/documents/chapitre6-consulter.rst
@@ -20,7 +20,7 @@ de l’utilisateur et utilise ce réglage par défaut pour les listages futurs.
 |img-document-16|
 
 Grâce au survol de la souris, un premier petit aperçu de document apparaît
-et donne la possibilité de travailler les métadonnées du document, d’en faire
+et donne la possibilité d'éditer les métadonnées du document, d’en faire
 le check-out ou encore d’en faire une copie.
 
 |img-document-17|

--- a/docs/public-fr/documents/chapitre6-introduire.rst
+++ b/docs/public-fr/documents/chapitre6-introduire.rst
@@ -64,7 +64,7 @@ Sauvegardez et fermez le fichier après l’avoir travaillé puis enregistrez-le
 Insérer un e-mail en tant que document
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Cette variante est détaillée ici.
+Cette variante est détaillée sous la rubrique :ref:`label-importer_email`.
 
 .. |img-document-1| image:: ../_static/img/img-document-1.png
 .. |image43| image:: ../_static/img/image43.png

--- a/docs/public-fr/documents/chapitre6-travailler.rst
+++ b/docs/public-fr/documents/chapitre6-travailler.rst
@@ -1,5 +1,5 @@
-Travailler les documents
-========================
+Editer les documents
+====================
 
 External Editor / Office Connector
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -16,18 +16,18 @@ External Editor pour Windows et ZopeEditManager pour Mac.
 Principes de base
 ~~~~~~~~~~~~~~~~~
 
-Pour pouvoir travailler des documents, le check-out doit avoir été fait. Une fois
+Pour pouvoir éditer des documents, le check-out doit avoir été fait. Une fois
 que le check-out du document a été fait, le document n’est disponible que pour
 le collaborateur ou la collaboratrice qui en a fait le check-out.
 
 On reconnait un document dont le check-out a été fait au statut *En cours de
 traitement* inscrit dans la colonne de la liste des documents.
 
-Travailler uniquement les métadonnées (propriétés)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Editer uniquement les métadonnées (propriétés)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Avec la souris, allez dans la liste des documents sur l’icône du document dont
-vous aimeriez travailler les propriétés (par exemple Titre, Description)
+vous aimeriez éditer les propriétés (par exemple Titre, Description)
 et choisissez l’option Modifier les métadonnées dans la fenêtre Tooltip affichée.
 
 |img-document-20|
@@ -49,7 +49,7 @@ que vous aimeriez éditer et choisissez l’option Faire le check-out / Editer.
 |img-document-22|
 
 Le fichier n’est ouvert que par External Editor / Office Connector avec
-l’application correspondante; il peut ensuite être travaillé. Pendant
+l’application correspondante; il peut ensuite être édité. Pendant
 le traitement, External Editor / Office Connector constitue un fichier
 temporaire qui disparaitra à nouveau après le checkin.
 
@@ -61,7 +61,7 @@ ont été faites ou non, et ce grâce à un message d’information apparaissant
 la fermeture du travail.
 
 **Important:** Un fichier ne peut être ouvert qu'en un seul exemplaire par
-l'utilisateur qui a effectué le check-out pour être travaillé dans l’application
+l'utilisateur qui a effectué le check-out pour être édité dans l’application
 correspondante. Si pendant ce temps on veut ouvrir encore une fois ce même document
 sur l’aperçu des documents dans OneGov GEVER avec l’icône du crayon ou un lien,
 une indication correspondante apparaît alors.
@@ -91,7 +91,7 @@ est envoyé dans le dossier dans lequel le document est classé.
 
 |img-document-25|
 
-Le mail peut ensuite être travaillé au gré du collaborateur, être complété et
+Le mail peut ensuite être édité au gré du collaborateur, être complété et
 être envoyé au destinataire souhaité.
 
 Faire le checkin directement:
@@ -177,10 +177,10 @@ Le traitement avec Adobe pour les fichiers graphiques (Photoshop, Illustrator, I
 avec External Editor fonctionne, certes, mais n’est cependant pas conseillé, étant
 donné que des erreurs ont déjà été constatées. Pour de tels fichiers et pour d’autres
 fichiers qui ne sont pas supportés, ils doivent être suivis selon l’indication ci-après,
-sous `Travailler des documents sans External Editor / Office Connector`_.
+sous `Editer des documents sans External Editor / Office Connector`_.
 
-Travailler des documents sans External Editor / Office Connector
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Editer des documents sans External Editor / Office Connector
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Choisissez l‘action *Faire le check-out*. Après le check-out, cliquez sur *Modifier
 les métadonnées*, le masque du document s’ouvre alors.
@@ -191,7 +191,7 @@ le nouveau fichier est sauvegardé comme la version la plus récente.
 
 |img-document-28|
 
-Cette action est aussi utile quand des fichiers ne peuvent pas être travaillés avec
+Cette action est aussi utile quand des fichiers ne peuvent pas être édités avec
 External Editor ou quand External Editor n’est pas disponible.
 
 Une autre manière de faire est aussi possible:
@@ -206,7 +206,7 @@ Une autre manière de faire est aussi possible:
 
 |img-document-29|
 
-Travaillez le fichier et fermez-le après l’enregistrement des modifications.
+Editez le fichier et fermez-le après l’enregistrement des modifications.
 Pour importer le fichier modifié vers OneGov GEVER, le fichier en question
 peut être tiré vers GEVER via le drag‘n‘drop.
 

--- a/docs/public-fr/documents/chapitre6-travailler.rst
+++ b/docs/public-fr/documents/chapitre6-travailler.rst
@@ -8,7 +8,7 @@ Pour le traitement des documents, External Editor ou Office Connector doivent
 être installés. Nous conseillons Office Connector étant donné qu’il est
 en permanence développé et amélioré par 4teamwork.
 
-Vous pouvez télécharger Office Connector pour Windows et Mac `grâce au lien <https://www.4teamwork.ch/office-connector>`_.
+Vous pouvez télécharger Office Connector pour Windows et Mac `sur le site de 4teamwork <https://www.4teamwork.ch/fr/solutions/office-connector/>`_.
 Là, vous trouverez également les liens de téléchargement
 pour les deux applications qui ne sont plus entretenues,
 External Editor pour Windows et ZopeEditManager pour Mac.
@@ -177,7 +177,7 @@ Le traitement avec Adobe pour les fichiers graphiques (Photoshop, Illustrator, I
 avec External Editor fonctionne, certes, mais n’est cependant pas conseillé, étant
 donné que des erreurs ont déjà été constatées. Pour de tels fichiers et pour d’autres
 fichiers qui ne sont pas supportés, ils doivent être suivis selon l’indication ci-après,
-sous Modifier des documents sans "External Editor" ou "Office Connector".
+sous `Travailler des documents sans External Editor / Office Connector`_.
 
 Travailler des documents sans External Editor / Office Connector
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/public-fr/documents/chapitre6-trouver.rst
+++ b/docs/public-fr/documents/chapitre6-trouver.rst
@@ -2,9 +2,11 @@ Trouver un document avec check-out
 ==================================
 
 Quand vous terminez votre session OneGovGEVER avec Quitter GEVER, le message
-ci-dessous s‘affiche, dans le cas où vous auriez encore des documents dont le check-out
-aurait été fait. En sélectionnant le titre d'un des documents en question, vous serez
+ci-dessous s‘affiche, dans le cas où vous auriez encore des :ref:`documents dont le check-out
+aurait été fait <label-recemment_modifie>`. En sélectionnant le titre d'un des documents en question, vous serez
 directement redirigé vers le document correspondant.
+
+|img-document-30|
 
 Avec la recherche avancée
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -20,8 +22,6 @@ En cliquant sur le masque des propriétés du document sur *Versions*, ces versi
 avec les informations suivantes: Numéro de version, collaborateur / collaboratrice,
 date des modifications (incl. la date de constitution de la Version initiale),
 commentaire (dans le cas où un commentaire aurait été consigné au moment de la sauvegarde).
-
-|img-document-30|
 
 Actions possibles:
 

--- a/docs/public-fr/documents/chapitre6-trouver.rst
+++ b/docs/public-fr/documents/chapitre6-trouver.rst
@@ -26,8 +26,8 @@ commentaire (dans le cas où un commentaire aurait été consigné au moment de 
 Actions possibles:
 
 - **Télécharger une copie:** En cliquant sur le fichier, il est rappelé dans son format original
-  (pas en PDF). Précision: A ce moment, un fichier ne peut pas directement être travaillé
-  (mode écriture protégée)! Il peut cependant être par exemple téléchargé.
+  (pas en PDF). Précision: A ce moment, un fichier ne peut pas directement être édité
+  (mode écriture protégée)! Il peut cependant être, par exemple, téléchargé.
 
 - **Aperçu PDF:** En cliquant sur l’aperçu PDF, la version correspondante est affichée en format PDF.
   Condition préalable : Un service de création de PDF externe est disponible et
@@ -40,7 +40,7 @@ Télécharger les versions dans leur format original (sans faire le check-out)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 OneGov GEVER ouvre toujours les documents avec checkin en mode lecture. Si on veut
-travailler le contenu d’un fichier, le check-out de ce dernier doit bien entendu avoir
+éditer le contenu d’un fichier, le check-out de ce dernier doit bien entendu avoir
 été fait. Si on veut toutefois consulter le fichier original (par exemple Word, Excel),
 le sauvegarder sur son bureau ou encore copier le contenu du fichier original, on peut
 télécharger ce fichier depuis l’aperçu des fichiers (version actuelle) ou depuis

--- a/docs/public-fr/documents/chapitre6-utiliser.rst
+++ b/docs/public-fr/documents/chapitre6-utiliser.rst
@@ -37,8 +37,8 @@ dans OneGov GEVER et peuvent être sélectionnés au moment de constituer des do
 
 |img-document-47|
 
-Travailler / supprimer les modèles de documents
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Editer / supprimer les modèles de documents
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Le traitement de modèle après coup fonctionne par analogie au traitement des
 documents normaux. Vous pouvez à tout moment changer les métadonnées (*Modifier

--- a/docs/public-fr/documents/chapitre6-utiliser.rst
+++ b/docs/public-fr/documents/chapitre6-utiliser.rst
@@ -7,9 +7,7 @@ Modèles de documents
 ~~~~~~~~~~~~~~~~~~~~
 
 La composante de l’application *Modèles* se trouve dans la liste d’aperçu GEVER et
-comprend les menus *Documents* et *Procédures standards* (voir aussi Travailler avec
-les `procédures standards <https://docs.onegovgever.ch/user-manual/standardablaeufe/#kapitel-standardablaeufe>`_
-,disponible uniquement en allemand).
+comprend les menus *Documents* et *Procédures standards* (voir aussi :ref:`chapitre-deroulement_standard`).
 
 |img-document-46|
 

--- a/docs/public-fr/dossiers/creer_nouveau_dossier.rst
+++ b/docs/public-fr/dossiers/creer_nouveau_dossier.rst
@@ -1,3 +1,5 @@
+.. _label-creer-dossier:
+
 Ouvrir un nouveau dossier
 -------------------------
 Pour ouvrir un nouveau dossier, sélectionnez le numéro de classement sous lequel le dossier doit être saisi dans la structure de classement et cliquez sur *Ajout d'un élément -> Dossier*.

--- a/docs/public-fr/dossiers/modifier_dossier.rst
+++ b/docs/public-fr/dossiers/modifier_dossier.rst
@@ -1,3 +1,5 @@
+.. _label-modifier-dossier:
+
 Modifier un dossier
 -------------------
 
@@ -127,7 +129,7 @@ Un dossier entier peut être combiné en un seul fichier ZIP et téléchargé de
 
 .. note::
 
-   Il est également possible d’exporter une sélection restreinte de documents sous forme de fichier zip. Vous trouverez les instructions à ce sujet dans le chapitre couvrant l’export au format ZIP **[PLEASE INSERT LINK]**
+   Il est également possible d’exporter une sélection restreinte de documents sous forme de fichier zip. Vous trouverez les instructions à ce sujet dans le chapitre couvrant l’:ref:`label-export-zip-documents`.
 
 .. |img-modifierdossier01| image:: ../_static/img/img-modifierdossier01.png
 .. |img-modifierdossier02| image:: ../_static/img/img-modifierdossier02.png

--- a/docs/public-fr/dossiers/sous_dossiers.rst
+++ b/docs/public-fr/dossiers/sous_dossiers.rst
@@ -6,12 +6,12 @@ Ouvrir un sous-dossier
 
 Dans le dossier principal, sélectionnez *Ajout d'un élément → Sous-dossier*
 
-Les pages de saisie de dossiers principaux est sous-dossiers sont identiques (Voir Ouvrir un nouveau dossier **[PLEASE INSERT LINK]**). La personne responsable du dossier est automatiquement reprise du dossier principal, mais peut être modifiée. Même s’il est techniquement possible d’imbriquer un nombre illimité de dossiers, une limite est normalement établie au niveau du numéro de classement.
+Les pages de saisie de dossiers principaux est sous-dossiers sont identiques (Voir :ref:`label-creer-dossier`). La personne responsable du dossier est automatiquement reprise du dossier principal, mais peut être modifiée. Même s’il est techniquement possible d’imbriquer un nombre illimité de dossiers, une limite est normalement établie au niveau du numéro de classement.
 
 Modifier un sous-dossier
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-La modification d’un sous-dossier se passe d’une manière identique à celle d’un dossier principal (voir modifier un dossier **[PLEASE INSERT LINK]**)
+La modification d’un sous-dossier se passe d’une manière identique à celle d’un dossier principal (voir modifier un dossier :ref:`label-modifier-dossier`)
 
 Fermer un dossier contenant des sous-dossiers
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/public-fr/index.rst
+++ b/docs/public-fr/index.rst
@@ -20,5 +20,6 @@ Index:
    taches/index
    chapitre13-deroulements-standards
    chapitre14-referentiel
+   spv/index
    app-seances/index.rst
    chapitre17-triage

--- a/docs/public-fr/index.rst
+++ b/docs/public-fr/index.rst
@@ -17,6 +17,7 @@ Index:
    chapitre9-contacts
    chapitre10-recherches
    chapitre11-boitereception
+   taches/index
    chapitre13-deroulements-standards
    chapitre14-referentiel
    app-seances/index.rst

--- a/docs/public-fr/spv/ajouter_ordre_jour.rst
+++ b/docs/public-fr/spv/ajouter_ordre_jour.rst
@@ -1,0 +1,29 @@
+Soumettre une requête
+---------------------
+Après la saisie de la requête, celle-ci peut être soumise à la commission par l’intermédiaire du bouton « Soumettre ». L’état de la requête passe alors de « en modification » à « Soumis ».
+
+|img-ajouter_ordre_jour-01|
+
+Par cette démarche, les affaires ordinaires, connues à l'avance, sont ajoutées à la séance pertinente ou annulées. Note : Aucun des documents concernés ne doit se trouver en « check-out » lors de la soumission d’une requête.
+
+Une fois que toutes les requêtes courantes ont été soumises, la séance est ensuite à traiter au niveau « Séances ». Dans notre exemple, 3 requêtes ont été soumises au conseil communal de Musterhausen.
+
+|img-ajouter_ordre_jour-02|
+
+La prochaine séance doit donc maintenant être ouverte, afin d’y ajouter les requêtes à l’ordre du jour. Celles-ci ne sont pas ajoutées automatiquement à une séance arbitraire. Elles doivent être spécifiquement ajoutées à un ordre du jour.
+
+|img-ajouter_ordre_jour-03|
+
+Une fois qu’une requête a été ajoutée à l’ordre du jour, celle-ci n’est plus visible dans le sommaire de la commission.
+
+|img-ajouter_ordre_jour-04|
+
+Les requêtes ne correspondant pas aux exigences peuvent être rejetées. La raison peut être spécifiée dans un champ de commentaires séparé.
+
+|img-ajouter_ordre_jour-05|
+
+.. |img-ajouter_ordre_jour-01| image:: ../_static/img/img-ajouter_ordre_jour_01.png
+.. |img-ajouter_ordre_jour-02| image:: ../_static/img/img-ajouter_ordre_jour_02.png
+.. |img-ajouter_ordre_jour-03| image:: ../_static/img/img-ajouter_ordre_jour_03.png
+.. |img-ajouter_ordre_jour-04| image:: ../_static/img/img-ajouter_ordre_jour_04.png
+.. |img-ajouter_ordre_jour-05| image:: ../_static/img/img-ajouter_ordre_jour_05.png

--- a/docs/public-fr/spv/ajouter_ordre_jour.rst
+++ b/docs/public-fr/spv/ajouter_ordre_jour.rst
@@ -1,5 +1,6 @@
 Soumettre une requête
 ---------------------
+
 Après la saisie de la requête, celle-ci peut être soumise à la commission par l’intermédiaire du bouton « Soumettre ». L’état de la requête passe alors de « en modification » à « Soumis ».
 
 |img-ajouter_ordre_jour-01|

--- a/docs/public-fr/spv/approbation_proces_verbal.rst
+++ b/docs/public-fr/spv/approbation_proces_verbal.rst
@@ -1,0 +1,32 @@
+Approbabtion du procès-verbal
+=============================
+
+Le procès-verbal de la dernière séance devrait être ajoutable à l’ordre du jour de la séance suivante d’une manière aussi directe que possible. Dans la plupart des cas, l’approbation du procès-verbal est toujours le premier point à être traité lors de la séance (Conseil communal, Parlement, Commissions, etc…).
+
+À partir de la version 2019.2, la gestion de séances et procès-verbaux inclut un lien apparaissant après la clôture d’une séance et permettant de créer une nouvelle requête pour l’approbation du p.-v., qui peut ensuite être agendée dans la séance suivante.
+
+|img-approbation_proces_verbal-01|
+
+Après avoir cliqué le lien, la page de création de requête est ouverte. Les champs suivants sont pré-remplis par GEVER :
+- Titre : « Approbation du procès-verbal » + le nom du p.-v. courant
+- Commission : La commission  de la séance courante
+- Pièces jointes : Proces-verbal de la séance courante.
+
+|img-approbation_proces_verbal-02|
+
+.. note::
+
+   Il est recommandé de créer un modèle de requête séparé pour l’approbation du procès-verbal dans la gestion de séances et procès-verbaux.
+
+|img-approbation_proces_verbal-03|
+
+La requête pour l’approbation du procès-verbal apparaît de la même manière au niveau de la commission que les requêtes provenant de la gestion d’affaires.
+
+|img-approbation_proces_verbal-04|
+
+
+
+.. |img-approbation_proces_verbal-01| image:: ../_static/img/img-approbation_proces_verbal-01.png
+.. |img-approbation_proces_verbal-02| image:: ../_static/img/img-approbation_proces_verbal-02.png
+.. |img-approbation_proces_verbal-03| image:: ../_static/img/img-approbation_proces_verbal-03.png
+.. |img-approbation_proces_verbal-04| image:: ../_static/img/img-approbation_proces_verbal-04.png

--- a/docs/public-fr/spv/cloturer_periode.rst
+++ b/docs/public-fr/spv/cloturer_periode.rst
@@ -1,0 +1,24 @@
+Clôturer une période
+--------------------
+
+Afin de pouvoir assigner les numéros de décisions et de séances de manière correcte pour la période en cours ainsi que pour la prochaine période, au moins un point à l'ordre du jour de chaque séance dans la période en cours doit être fermé (de sorte que les numéros de décisions et de séances soient visibles). C'est seulement là que la période courante pourra être clôturée et qu'il sera ensuite possible de clôturer des points à l'ordre du jour d'une séance dans la prochaine période nouvellement créée.
+
+Voici les étapes à suivre pour chaque commission:
+
+1. Dans chaque séance de la période courante, clôtuer au moins **un** point à l'ordre du jour par l'intermédiaire du bouton *Clôturer un point à l'ordre du jour* (voir 1.).
+
+2. Les numéros de décision des points à l'ordre du jour sont assignés automatiquement aux requêtes (voir 2.) et le no de séance (voir 3.) est établi et assigné correctement. La séance est ainsi considérée comme complétée (voir 4.) et peut donc être clôturée via *Actions → Clôturer*. Ce dernier point n'est toutefois pas obligatoire.
+
+   |img-cloturer_periode-1|
+
+3. Une fois toutes ces actions ont été effectuées pour toutes les séances de la période courante d'une commission, la période peut être clôturée par l'intermédiaire de *Clôturer la période courante*. Dans la même étape, la période suivante est créée.
+
+   |img-cloturer_periode-2|
+
+4. À partir de ce point, seuls les points aux ordres du jour de séances de la nouvelle période devraient être clôturés.
+
+.. note::
+   Il est important qu'aucun point soit clos dans la nouvelle année, avant que l'ancienne n'ait été clôturée, tel que décrit dans les étapes 1 à 3.
+
+.. |img-cloturer_periode-1| image:: ../_static/img/img-cloturer_periode-01.png
+.. |img-cloturer_periode-2| image:: ../_static/img/img-cloturer_periode-02.png

--- a/docs/public-fr/spv/commission_et_membres.rst
+++ b/docs/public-fr/spv/commission_et_membres.rst
@@ -1,0 +1,72 @@
+
+La commission, ses membres et ses séances
+-----------------------------------------
+
+Créer une nouvelle commission
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Les nouvelles commissions peuvent être créées sous "Séances".
+
+1. Un groupe d'utilisateurs spécifique doit être crée par commission. Ce groupe est visible pour et administré par ses membres.
+
+2. De plus, une position sous un numéro de classement dans le système d'organisation doit être établi. C'est là que seront créés automatiquement de nouveaux dossiers de séances, contenant les documents de séances et procès-verbaux.
+
+3. Selon les droits attribués, seuls des utilisateurs spécifiques sont autorisés d'ajouter et modifier les membres et documents relatifs à la commission.
+
+|img-commission_et_membres-01|
+
+Ajouter des utilisateurs et les assigner à une commission
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Les utilisateurs autorisés peuvent ajouter de nouveaux membres sous *Séances*, onglet *Membres*. Il est à noter que ces Membres n'ont pas de lien direct avec les contacts de OneGov GEVER.
+
+|img-commission_et_membres-02|
+
+Une fois que tous les membres requis ont été saisis, passez de la zone "Séances" à la commission en question et assignez-y les membres de commission nouvellement crées (*Ajouter membre*). Assignez ensuite les rôles aux membres pertinents, et définissez une durée de mandat. le/la secrétaire sont également définis à cet endroit.
+
+|img-commission_et_membres-03|
+|img-commission_et_membres-04|
+
+La représentation, la saisie et la gestion de membres de commissions sont encore soumis à des développements additionnels de la GSPV.
+
+|img-commission_et_membres-05|
+
+Les utilisateurs autorisés peuvent gérer les modèles de procès-verbaux et extraits par l'intermédiaire de « Modifier / Éditer commission », et ajuster la visibilité des modèles de requêtes pour ladite commission.
+
+|img-commission_et_membres-06|
+
+
+Une fois que vous avez ajouté tous les membres, vous pouvez maintenant créer les séances. Le dossier de séance est automatiquement assignée à la rubrique appropriée dans le système de classement.
+
+Créer une séance
+~~~~~~~~~~~~~~~~
+Pour créer une nouvelle séance, rendez-vous dans la commission pertinente (dans notre exemple, Musterhausen)
+
+|img-commission_et_membres-07|
+
+Vous pouvez ensuite y créer une nouvelle séance par l'intermédiaire de *Ajout d'un élément* → *Séance*.
+|img-commission_et_membres-08|
+
+Apparaît ensuite l'écran de saisie pour le dossier de séance - séparé en 2 onglets : Dans le premier, le titre ainsi que la date de début et de fin peuvent être saisis.
+
+|img-commission_et_membres-09|
+
+Dans le second onglet, une description ainsi que d'autre métadonnées peuvent être saisis.
+
+|img-commission_et_membres-10|
+
+Après la sauvegarde, la séance apparaît dans le sommaire.
+
+|img-commission_et_membres-11|
+
+.. |img-commission_et_membres-01| image:: ../_static/img/img-commission_et_membres-01.png
+.. |img-commission_et_membres-02| image:: ../_static/img/img-commission_et_membres-02.png
+.. |img-commission_et_membres-03| image:: ../_static/img/img-commission_et_membres-03.png
+.. |img-commission_et_membres-04| image:: ../_static/img/img-commission_et_membres-04.png
+.. |img-commission_et_membres-05| image:: ../_static/img/img-commission_et_membres-05.png
+.. |img-commission_et_membres-06| image:: ../_static/img/img-commission_et_membres-06.png
+.. |img-commission_et_membres-07| image:: ../_static/img/img-commission_et_membres-07.png
+.. |img-commission_et_membres-08| image:: ../_static/img/img-commission_et_membres-08.png
+.. |img-commission_et_membres-09| image:: ../_static/img/img-commission_et_membres-09.png
+.. |img-commission_et_membres-10| image:: ../_static/img/img-commission_et_membres-10.png
+.. |img-commission_et_membres-11| image:: ../_static/img/img-commission_et_membres-11.png

--- a/docs/public-fr/spv/exporter_documents.rst
+++ b/docs/public-fr/spv/exporter_documents.rst
@@ -1,0 +1,13 @@
+Exporter les documents de séance
+--------------------------------
+Il est possible d'exporter les contenus de GSPV sous forme de fichier ZIP (Affaires spécifiques, pièces jointes incluses). Les documents sont automatiquement convertis au format PDF. Ils peuvent ensuite être mis à disposition d'autres membres d'autorités via email, teamraum ou toute autre plate-forme de collaboration en ligne.
+
+De plus il est possible de générer le fichier ZIP d'une séance complète, où tous les documents restent au format Word.
+
+|img-exporter_documents-01|
+
+.. note::
+    Le nom d'un fichier ZIP sous Windows est d'une longueur maximale de 260 caractères. Veillez donc à ce que le nom de la séance ne dépasse pas cette limite. A partir de Windows 10 (Version 1607), il est possible de configurer une limite plus élevée. Alternativement, il est aussi possible d'installer l'application de compression "7-Zip" (http://www.7-zip.org/), qui gère les noms de fichiers plus longs.
+
+
+.. |img-exporter_documents-01| image:: ../_static/img/img-exporter_documents-01.png

--- a/docs/public-fr/spv/fermer_seance.rst
+++ b/docs/public-fr/spv/fermer_seance.rst
@@ -1,0 +1,32 @@
+Clôturer une séance
+-------------------
+
+Une fois que tous les points ont été traités et complétés de manière satisfaisante, la séance peut être revue et corrigée.
+
+|img-cloturer_seance-01|
+
+Les extraits de procès-verbal peuvent maintenant être générés. Il est possible de générer de multiples versions d'extraits de procès-verbal. Pour une bonne traçabilité de la gestion de l’affaire, un extrait de procès-verbal doit obligatoirement être retourné à son mandant, en l'occurrence, le dossier d'affaire pertinent. Des extraits de procès-verbal additionnel peuvent être utiles pour d'autres destinataires externes, tels que des communes, administrations cantonales, etc...
+
+|img-cloturer_seance-02|
+|img-cloturer_seance-03|
+
+Clôturer la séance correctement en cliquant le bouton « Clôturer la séance »
+
+|img-cloturer_seance-04|
+
+Le procès-verbal peut maintenant être finalisé. Cliquez sur le titre du p.-v. pour ensuite en effectuer le check-out. Une fois sauvegardé, il remplacera le pré-procès-verbal. Il est important de noter que le procès-verbal doit être généré avant la fermeture de la séance. Une fois la séance fermée, il faut la réouvrir avant de pouvoir générer le p.-v. à nouveau.
+
+|img-cloturer_seance-05|
+|img-cloturer_seance-06|
+
+Une fois tous les points clôturés, il est possible de générer des tâches directement depuis la séance, de la même manière que dans GEVER.
+
+|img-cloturer_seance-07|
+
+.. |img-cloturer_seance-01| image:: ../_static/img/img-cloturer_seance-01.png
+.. |img-cloturer_seance-02| image:: ../_static/img/img-cloturer_seance-02.png
+.. |img-cloturer_seance-03| image:: ../_static/img/img-cloturer_seance-03.png
+.. |img-cloturer_seance-04| image:: ../_static/img/img-cloturer_seance-04.png
+.. |img-cloturer_seance-05| image:: ../_static/img/img-cloturer_seance-05.png
+.. |img-cloturer_seance-06| image:: ../_static/img/img-cloturer_seance-06.png
+.. |img-cloturer_seance-07| image:: ../_static/img/img-cloturer_seance-07.png

--- a/docs/public-fr/spv/index.rst
+++ b/docs/public-fr/spv/index.rst
@@ -1,5 +1,4 @@
 .. _chapitre-spv:
-.. _label-spv:
 
 Gestion des séances et procès-verbaux
 =====================================

--- a/docs/public-fr/spv/index.rst
+++ b/docs/public-fr/spv/index.rst
@@ -1,0 +1,28 @@
+.. _chapitre-spv:
+.. _label-spv:
+
+Gestion des séances et procès-verbaux
+=====================================
+
+L'utilisation des fonctionnalités de *Gestion des Séances et Procès-Verbaux*,
+abrégées en GSPV, requiert un travail préparatiore: Il faut tout d'abord ajouter
+des commissions, leurs attribuer des membres, créer et modifier des séances.
+La séance peut ensuite être préparée, tenue et puis clôturée. Les chapitres
+ci-dessous expliquent comment ces différentes étapes de la SPV sont accomplies
+avec OneGovGever.
+
+.. toctree::
+   :maxdepth: 2
+
+   saisir_requete
+   ajouter_ordre_jour
+   notification_requete
+   commission_et_membres
+   preparer_seance
+   tenir_seance
+   fermer_seance
+   approbation_proces_verbal
+   exporter_documents
+   cloturer_periode
+
+.. disqus::

--- a/docs/public-fr/spv/notification_requete.rst
+++ b/docs/public-fr/spv/notification_requete.rst
@@ -1,3 +1,5 @@
+.. _label-notifications-requetes:
+
 Notifications de requêtes
 --------------------------
 
@@ -17,4 +19,4 @@ Lors des actions suivantes, une notification est envoyée au(x) responsable(s) d
 -   Nouvelles pièces jointes ajoutées à une requête
 -   Mise à jour de pièces jointes d'une requête
 
-Les notifications pour les actions ci-dessus peuvent être ajustés individuellement par chaque utilisateur dans les paramètres de notification. Plus de détails à ce sujet sont disponibles dans le chapitre "Paramètres de notifications".
+Les notifications pour les actions ci-dessus peuvent être ajustés individuellement par chaque utilisateur dans les paramètres de notification. Plus de détails à ce sujet sont disponibles dans le chapitre :ref:`label-notification`.

--- a/docs/public-fr/spv/notification_requete.rst
+++ b/docs/public-fr/spv/notification_requete.rst
@@ -1,0 +1,20 @@
+Notifications de requêtes
+--------------------------
+
+La personne définie dans le champ "mandant" reçoit une notification lors des actions suivantes :
+
+-   Rejet d'une requête
+-   Requête ajoutée au procès-verbal
+-   Retour d'un extrait de procès-verbal au mandant/dossier de requête.
+-   Commentaire ajouté à la requête
+
+Il est important de distinguer la différence entre la création d'une requête par un mandant et le responsable de commission. Les membres d'une commission sont définis par leur appartenance à un groupe LDAP. Celui-ci permet l'assignement de la responsabilité d'une commission via le champ responsable de commission. Le Mandant correspond à l'utilisateur ayant soumis la requête.
+
+Lors des actions suivantes, une notification est envoyée au(x) responsable(s) de commission :
+
+-   Soumission d'une nouvelle requête
+-   Commentaire ajouté sur une requête soumise
+-   Nouvelles pièces jointes ajoutées à une requête
+-   Mise à jour de pièces jointes d'une requête
+
+Les notifications pour les actions ci-dessus peuvent être ajustés individuellement par chaque utilisateur dans les paramètres de notification. Plus de détails à ce sujet sont disponibles dans le chapitre "Paramètres de notifications".

--- a/docs/public-fr/spv/preparer_seance.rst
+++ b/docs/public-fr/spv/preparer_seance.rst
@@ -1,0 +1,26 @@
+Préparer une séance
+-------------------
+Les séances peuvent être structurées différemment  selon la commission. Pour cela, il est possible d'ajouter de intertitres (Par exemple pour organiser par affaires de types A, B et C). Les intertitres peuvent être décalés manuellement.
+
+Avec l'action « ajouter au procès-verbal », les requêtes peuvent être ajoutés à une séance. Ils peuvent ensuite être déplacés dans l'ordre de la séance par glisser-déposer. La numérotation se fait automatiquement.
+
+|img-preparer_seance-01|
+
+Une fois la séance préparée, il est possible de générer l'ordre du jour ainsi qu'un pré-procès-verbal. Selon besoin, ces documents peuvent être envoyés aux membres du conseil sous forme de fichier zip.
+
+|img-preparer_seance-02|
+
+Aperçu d'une séance entièrement préparée:
+|img-preparer_seance-03|
+|img-preparer_seance-04|
+
+1. L'aperçu des pièces jointes peut être étendu ou caché.
+2. Il est possible d'ajouter des participants additionnels en cliquant sur « Modifier ».
+3. Dans ce champ, il est possible de définir le/la secrétaire.
+4. Le début de la numérotation peut être fixé ici.
+
+
+.. |img-preparer_seance-01| image:: ../_static/img/img-preparer_seance-01.png
+.. |img-preparer_seance-02| image:: ../_static/img/img-preparer_seance-02.png
+.. |img-preparer_seance-03| image:: ../_static/img/img-preparer_seance-03.png
+.. |img-preparer_seance-04| image:: ../_static/img/img-preparer_seance-04.png

--- a/docs/public-fr/spv/saisir_requete.rst
+++ b/docs/public-fr/spv/saisir_requete.rst
@@ -1,0 +1,56 @@
+Saisir une requête
+------------------
+
+Pour assigner les requêtes aux séances planifiées, il faut tout d’abord se rendre dans le dossier pertinent dans OneGov GEVER. Dans l’exemple ci-dessous, l'embauche de Mme Marlies Suter en tant que directrice des finances doit être agendée à la prochaine séance du conseil communal de Musterhausen.
+
+**Créer une requête**
+
+Tous les documents et informations requis sont saisis au niveau du dossier d'affaire. Pour saisir une requête, il y a 2 possibilités :
+
+-   Sous "Ajout d'un élément", une requête à l'attention du conseil communal de Musterhausen peut être saisie. Cette méthode sera décrite plus en détail ci-dessous.
+
+|img-saisir_requete-1|
+
+-   Tout en bas, dans l'onglet *documents* d'un dossier, se trouve le bouton "Saisir une requête". Cette variante offre l'avantage de pouvoir directement joindre des documents du dossier à la requête, en les cochant.
+
+|img-saisir_requete-2|
+
+**Compléter une requête**
+
+Sous "ajouter une requête", le titre de l'objet, la commission pertinente, le bon modèle de requête et toutes les pièces jointes nécessaires peuvent être saisis/sélectionnés.
+
+Les annexes peuvent être soit joints à partir d'un modèle :
+
+|img-saisir_requete-3|
+
+Soit à partir d'un ou plusieurs documents existants.
+
+|img-saisir_requete-4|
+
+|img-saisir_requete-5|
+
+Le champ "Mandant" contient, par défaut, l'utilisateur courant. Il est également possible de saisir une requête pour un autre utilisateur. Dans ce cas, il est à noter que l'utilisateur spécifié dans le champ "Mandant" recevra une notification de requête.
+
+Si la case "modifier après la création" a été cochée (sa valeur par défaut), le document sera ouvert dans Word pour des modification additionnelles.
+
+|img-saisir_requete-6|
+
+Après la sauvegarde, vous vous retrouverez sur l'écran suivant. C'est normalement à ce point que le document de la requête à l'attention du conseil communal doit être traité (Le document est déjà en check-out). Une requête peut ensuite être annulée, soumise ou encore pourvue d'un commentaire.
+
+|img-saisir_requete-7|
+
+Le traitement dans Word se passe comme pour un document GEVER courant. Dans l'exemple ci-dessous, les passages marqués en jaune sont modifiés. Après avoir complété la requête, le document doit être sauvegarde et un check-in effectué, comme à l'usuelle.
+
+|img-saisir_requete-8|
+|img-saisir_requete-9|
+
+
+.. |img-saisir_requete-1| image:: ../_static/img/img-saisir_requete_01.png
+.. |img-saisir_requete-2| image:: ../_static/img/img-saisir_requete_02.png
+.. |img-saisir_requete-3| image:: ../_static/img/img-saisir_requete_03.png
+.. |img-saisir_requete-4| image:: ../_static/img/img-saisir_requete_04.png
+.. |img-saisir_requete-5| image:: ../_static/img/img-saisir_requete_05.png
+.. |img-saisir_requete-6| image:: ../_static/img/img-saisir_requete_06.png
+.. |img-saisir_requete-7| image:: ../_static/img/img-saisir_requete_07.png
+.. |img-saisir_requete-8| image:: ../_static/img/img-saisir_requete_08.png
+.. |img-saisir_requete-9| image:: ../_static/img/img-saisir_requete_09.png

--- a/docs/public-fr/spv/saisir_requete.rst
+++ b/docs/public-fr/spv/saisir_requete.rst
@@ -29,7 +29,7 @@ Soit à partir d'un ou plusieurs documents existants.
 
 |img-saisir_requete-5|
 
-Le champ "Mandant" contient, par défaut, l'utilisateur courant. Il est également possible de saisir une requête pour un autre utilisateur. Dans ce cas, il est à noter que l'utilisateur spécifié dans le champ "Mandant" recevra une notification de requête.
+Le champ "Mandant" contient, par défaut, l'utilisateur courant. Il est également possible de saisir une requête pour un autre utilisateur. Dans ce cas, il est à noter que l'utilisateur spécifié dans le champ "Mandant" recevra une :ref:`notification de requete <label-notifications-requetes>`.
 
 Si la case "modifier après la création" a été cochée (sa valeur par défaut), le document sera ouvert dans Word pour des modification additionnelles.
 

--- a/docs/public-fr/spv/tenir_seance.rst
+++ b/docs/public-fr/spv/tenir_seance.rst
@@ -1,0 +1,35 @@
+
+Tenir la séance
+---------------
+
+Les membres de la commission sont listés sous l'onglet « Participants ».
+
+|img-tenir_seance-01|
+
+Les participants membres de la commission mais n'ayant plus de particiaption active sont marqués d'un point rouge. De plus, il est aussi possible de marquer les absents d'une manière similaire, si besoin. Il est également possible d'assigner le rôle de «Président de séance»
+
+|img-tenir_seance-02|
+
+Le texte de la décision ainsi que les éventuelles discussions sont enregistrés dans le document de requête. Le document peut être passé en check-out par l'intermédiaire du bouton « Modifier avec Word » et il devient ainsi immédiatement éditable. Selon besoin, toutes les requêtes peuvent être passées en check-out et ouvertes au début de la séance. Comme déjà établi précédemment. Les documents doivent être sauvegardés et repassés en check-in une fois les modifications terminées.
+
+|img-tenir_seance-03|
+
+Si, durant la séance, un sujet non planifié doit être discuté, il est possible d'ajouter un point ad hoc à l'ordre du jour, en utilisant un modèle de document simple prévu à cet effet. Il est possible de choisir parmi plusieurs modèles de requêtes ad hoc.
+
+Tant que la séance n'est pas marquée comme clôturée, l'ordre du jour peut être modifié selon le système ou la structure établis par le client (p.ex. Crédit d'urgence rupture de conduite nouveau No 2 ci-dessous)
+
+
+
+|img-tenir_seance-04|
+
+.. note::
+    Ne clôturez les points à l'ordre du jour définitivement que lors du traitement post-séance. Une fois qu'un point est clôturé, l'ordre du jour n'est plus modifiable.
+
+    |img-tenir_seance-05|
+
+
+.. |img-tenir_seance-01| image:: ../_static/img/img-tenir_seance-01.png
+.. |img-tenir_seance-02| image:: ../_static/img/img-tenir_seance-02.png
+.. |img-tenir_seance-03| image:: ../_static/img/img-tenir_seance-03.png
+.. |img-tenir_seance-04| image:: ../_static/img/img-tenir_seance-04.png
+.. |img-tenir_seance-05| image:: ../_static/img/img-tenir_seance-05.png

--- a/docs/public-fr/taches/accomplir_tache.rst
+++ b/docs/public-fr/taches/accomplir_tache.rst
@@ -1,0 +1,15 @@
+Accomplir et clôturer une tâche
+-------------------------------
+
+Lorsque le mandant est satisfait avec la complétion de la tâche, il ferme cette dernière par l’intermédiaire de *Actions → Clôturer*. Si besoin, il est possible de saisir un texte dans le champ de réponse.
+
+|img-accomplir_tache-01|
+
+En sauvegardant, une date de fin est automatiquement enregistrée et l’état de la tâche passe à *clôturé*. Une fois clôturée, une tâche ne peut plus être modifiée.
+
+|img-accomplir_tache-02|
+
+Si une tâche complétée par le mandataire doit encore une fois être traitée, le mandant peut, au lieu de la fermer utiliser l’action *réviser*, pour que son état repasse à *en traitement*.
+
+.. |img-accomplir_tache-01| image:: ../_static/img/img-accomplir_tache-01.png
+.. |img-accomplir_tache-02| image:: ../_static/img/img-accomplir_tache-02.png

--- a/docs/public-fr/taches/controle_taches_en_suspens.rst
+++ b/docs/public-fr/taches/controle_taches_en_suspens.rst
@@ -1,0 +1,49 @@
+Contrôler les tâches en suspens
+-------------------------------
+
+Dans la l’aperçu de la *Vue d’ensemble personnelle*, on retrouve une liste de toutes les tâches personnelles. Ceci permet d’assurer un suivi des points en suspens.
+
+Contrôle personnel des points en suspens
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Les onglets *Mes tâches* et *Tâches attribuées* dans la *Vue d’ensemble personnelle* servent au contrôle des tâches en suspens à travers tous les dossiers.
+
+Par défaut, seules les tâches en suspens sont affichées, donc ayant pour état *Ouvert, En traitement, Accompli*, et *Refusé*. Pour afficher toutes les tâches, il faut cliquer sur État : *Tous*.
+
+|img-controle_taches-01|
+
+|img-controle_taches-02|
+
+Contrôle des tâches inter-clients
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Les membres du groupe « Boîte de réception » et les administrateurs disposent d’onglets additionnels *Toutes les tâches* et *Toutes les tâches attribuées*, permettant un contrôle des tâches inter-clients. Sous ses onglets, sont listées toutes les tâches reçues, respectivement assignées de tous les clients desquels l’utilisateur fait partie.
+
+|img-controle_taches-04|
+
+|img-controle_taches-05|
+
+Liste de points en suspens PDF
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Il est également possible, sous *Actions*, de générer un PDF contenant une liste de toutes les tâches en suspens pour l’ensemble du client.
+
+|img-controle_taches-03|
+
+Liste de points en suspens Excel
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Avec *Actions supplémentaires* → *Exporter le choix*, il est aussi possible de générer une liste des tâches en suspens au format Excel.
+
+|img-controle_taches-06|
+
+Activer un rappel
+~~~~~~~~~~~~~~~~~
+Il est possible d’activer une fonction de rappel au niveau de la tâche. Ceci peut déjà être fait au niveau de la vue détaillée, au moment d’acceptation de la tâche. Selon les paramètres de notification définis pour l’utilisateur, un rappel sera déclenché par GEVER au moment choisi.
+
+|img-controle_taches-07|
+
+.. |img-controle_taches-01| image:: ../_static/img/img-controle_taches-01.png
+.. |img-controle_taches-02| image:: ../_static/img/img-controle_taches-02.png
+.. |img-controle_taches-03| image:: ../_static/img/img-controle_taches-03.png
+.. |img-controle_taches-04| image:: ../_static/img/img-controle_taches-04.png
+.. |img-controle_taches-05| image:: ../_static/img/img-controle_taches-05.png
+.. |img-controle_taches-06| image:: ../_static/img/img-controle_taches-06.png
+.. |img-controle_taches-07| image:: ../_static/img/img-controle_taches-07.png

--- a/docs/public-fr/taches/cooperation_inter_clients.rst
+++ b/docs/public-fr/taches/cooperation_inter_clients.rst
@@ -96,7 +96,7 @@ Dans le dossier du client d’origine, on trouvera aussi une référence à la t
 
 |img-cooperation_inter_mandants-12|
 
-La tâche peut maintenant être traitée dans son propre dossier, en y ajoutant, par Example, de nouveaux documents ou en travaillant sur ceux auxquels la tâche fait référence.
+La tâche peut maintenant être traitée dans son propre dossier, en y ajoutant, par example, de nouveaux documents ou en travaillant sur ceux auxquels la tâche fait référence.
 
 .. note::
    Lorsque le mandataire modifie des documents référencés par le mandant, il fait cela sur des **copies** qui devront être retransmises au mandant à la conclusion de la tâche.

--- a/docs/public-fr/taches/cooperation_inter_clients.rst
+++ b/docs/public-fr/taches/cooperation_inter_clients.rst
@@ -1,3 +1,6 @@
+
+.. _label-cooperation_ic:
+
 Coopération inter-clients
 --------------------------
 

--- a/docs/public-fr/taches/cooperation_inter_clients.rst
+++ b/docs/public-fr/taches/cooperation_inter_clients.rst
@@ -1,0 +1,235 @@
+Coopération inter-clients
+--------------------------
+
+Créer une tâche inter-clients
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+La création d’une tâche inter-clients ne change que très peu de celle d’une tâche à être complétée par quelqu’un du même client.
+
+L’icône suivante identifie une tâche inter-clients :
+
+|img-cooperation_inter_mandants-01|
+
+L’exemple suivant traite de la vérification d’une commande de matériel.
+Créez une tâche et joignez-y tous les documents dont le mandataire aura besoin pour la compléter. Tous les autres documents du dossier resteront invisibles pour lui.
+
+Dans le champ *Mandataire*, sélectionnez le destinataire de la tâche. En règle générale, c’est la boîte de réception du client responsable qui est choisie. Il est toutefois aussi possible de directement sélectionner le chargé d’affaires pertinent.
+
+   |img-cooperation_inter_mandants-02|
+
+Une fois la boite réception du client pertinent définie en tant que Mandataire, et la tâche sauvegardée, celle-ci apparaîtra dans la boite de réception de celui-ci (Onglet *tâches reçues*). Les personnes disposant des droits « boite de réception » peuvent donc assigner la tâche à la bonne personne.
+
+Si un utilisateur spécifique a été choisi, la tâche apparaîtra chez lui dans les onglets *Sommaire* et *Mes tâches reçues*.
+
+   |img-cooperation_inter_mandants-03|
+
+Modifier une tâche inter-clients
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Les dossiers ne sont pas copiés pour les tâches inter-clients dans OneGov GEVER, ce sont les autres services qui viennent participer au dossier d’affaire courant. Cela signifie que les services participants ont des droits de lecture et modification directement dans le dossier du mandant. Pour le mandataire, seule une tâche est créée, pas de dossier. Pour cette raison, la tâche apparaît uniquement dans *vue d’ensemble personnelle*/*Mes tâches reçues*, ou dans la boîte de réception du client, si elle n’a pas encore été assignée à un utilisateur spécifique. Pour le traitement de la tâche, OneGov GEVER offre la possibilité de travailler sur des documents directement dans le dossier du mandant d’où ils proviennent ou dans le client de l’utilisateur courant.
+
+Ouvrir, assigner et accepter une tâche inter-clients
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Selon besoin, la tâche est réattribuée à un chargé d’affaires via *Actions → Ré-attribuer*. Cela n’est possible que si l’utilisateur dispose de droits appropriés (Boite de réception, Admin).
+
+1.	Cliquer le bouton « Ré-attribuer ».
+
+  |img-cooperation_inter_mandants-04|
+
+2.	Sélectionner l’utilisateur chargé de traiter la tâche.
+
+  |img-cooperation_inter_mandants-05|
+
+3.	Sommaire avec le nouvel utilisateur en charge de la tâche.
+
+  |img-cooperation_inter_mandants-06|
+
+A ce moment, on est automatiquement envoyé dans le client d’origine de la tâche dans un nouvel onglet de navigateur. Le mandataire ne voit que les documents du dossier qui ont été référencés dans la tâche. Même le système de classement n’est visible que dans une forme réduite. Afin de maintenir une vue d’ensemble, le « Client hôte » est affiché en grisé.
+
+Sélectionnez *Actions → Accepter*.
+
+OneGov GEVER propose maintenant 3 options pour traiter la tâche :
+
+  |img-cooperation_inter_mandants-07|
+
+1.	Directement dans le dossier du client d’origine
+
+2.	En sauvegardant dans un dossier existant de son propre client
+
+3.	En sauvegardant dans un nouveau dossier dans son propre client
+
+
+Travailler directement dans le dossier du client d’origine
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+En acceptant la tâche, sélectionnez l’option *Travailler directement dans le dossier du client*.
+
+|img-cooperation_inter_mandants-08|
+
+Un nouvel onglet s’ouvre dans le navigateur et vous mène directement dans le client depuis lequel la tâche a été envoyée. Seuls les documents auxquels la tâche fait référence sont visibles. Le système de classement est affiché de façon restreinte et en grisé.
+
+La tâche peut maintenant être traitée de la même manière qu’au sein de votre propre client. Il est possible d’effectuer un check-out/check-in pour modifier un document ou encore le mettre à jour par un téléchargement depuis votre système de fichiers.
+
+Les tâches accomplies et leurs contenus restent visibles pour le mandataire et les utilisateurs disposant des droits d’admin ou de boîte de réception jusqu’à l’archivage du dossier chez le client d’origine.
+
+
+Traiter une tâche dans un dossier existant de son propre client
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Lors de l’acceptation de la tâche, sélectionnez l’option *Traiter dans un dossier existant de [votre client]* et cliquez sur *suivant*.
+
+|img-cooperation_inter_mandants-09|
+
+Sélectionnez le dossier cible en saisissant son nom ou en parcourant le système de classement par l’intermédiaire du bouton *Ajouter*. Seuls les dossiers actuellement ouverts sont affichés dans cette vue.
+
+|img-cooperation_inter_mandants-10|
+
+En cliquant sur *sauvegarder*, la tâche et tous les documents qui y sont liés sont recopiés dans le dossier choisi. Les documents recopiés avec la tâche sont pourvus du commentaire « Document copié d’une tâche (Tâche acceptée) ». Une référence à la tâche d’origine et son dossier est également ajoutée.
+
+|img-cooperation_inter_mandants-11|
+
+Dans le dossier du client d’origine, on trouvera aussi une référence à la tâche copiée par le mandataire. L’état des 2 tâches est automatiquement synchronisé.
+
+|img-cooperation_inter_mandants-12|
+
+La tâche peut maintenant être traitée dans son propre dossier, en y ajoutant, par Example, de nouveaux documents ou en travaillant sur ceux auxquels la tâche fait référence.
+
+.. note::
+   Lorsque le mandataire modifie des documents référencés par le mandant, il fait cela sur des **copies** qui devront être retransmises au mandant à la conclusion de la tâche.
+
+Lors de l’accomplissement de la tâche, il est possible de sélectionner dans un listing de documents, lesquels seront retournés au client d’origine. Les fichiers sélectionnés seront joints à la tâche sous forme de copies et ajoutés au dossier. Tous les documents retournés par le mandataire apparaissent chez le mandant avec le préfixe **RE : (Réponse)**. Au niveau de la Version, ces documents sont également pourvus d’un commentaire « Document copié d’une tâche (Tâche accomplie) ».
+
+  |img-cooperation_inter_mandants-13|
+
+Traiter une tâche dans un nouveau dossier de son propre client
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Sélectionnez *Traiter dans un nouveau dossier de [votre client]* et cliquez sur *continuer*.
+
+  |img-cooperation_inter_mandants-14|
+
+Sélectionnez un numéro de classement sous lequel le nouveau dossier sera créé, soit en saisissant son nom, soit en parcourant le système de classement à l’aide du bouton *Ajouter*. Note : Si plusieurs types de dossiers sont utilisés dans le système (p. ex. dossiers d’affaires et dossiers de cas), une étape intermédiaire vous permettra de choisir le bon type.
+
+|img-cooperation_inter_mandants-15|
+
+En cliquant sur *sauvegarder*, un nouveau dossier est créé sous le numéro de classement sélectionné, en reprenant le nom de dossier du client d’origine. Il est possible de changer le nom du dossier à tout moment.
+
+La tâche et tous les documents qui y sont liés sont recopiés dans le nouveau dossier. Les documents recopiés avec la tâche sont pourvus du commentaire « Document copié d’une tâche (Tâche acceptée) ». Une référence à la tâche d’origine et son dossier est également ajoutée.
+
+Une référence à la tâche copiée par le mandataire est ajoutée à la tâche du dossier d’origine. L’état des 2 tâches est automatiquement synchronisé.
+
+|img-cooperation_inter_mandants-16|
+
+La tâche peut maintenant être traitée dans son propre dossier. Il est donc possible d’y ajouter des documents et de modifier les documents qui y étaient liés.
+
+|img-cooperation_inter_mandants-17|
+
+Dans le dossier du client d’origine, on retrouve également une référence à la tâche copiée par le mandataire. L’état de la tâche dans le client d’origine et de sa copie sont synchronisés automatiquement.
+
+|img-cooperation_inter_mandants-18|
+
+Lors de l’accomplissement de la tâche, il est possible de sélectionner dans un listing de documents, lesquels seront retournés au client d’origine. Les fichiers sélectionnés seront joints à la tâche sous forme de copies et ajoutés au dossier. Tous les documents retournés par le mandataire apparaissent chez le mandant avec le préfixe **RE : (Réponse)**. Au niveau de la Version, ces documents sont également pourvus d’un commentaire « Document copié d’une tâche (Tâche accomplie) ».
+
+
+|img-cooperation_inter_mandants-19|
+
+.. note::
+   Si le mandataire travaille sur des documents transmis avec la tâche, il s’agit là de **copies** qui devront être retransmises au mandant lors de la complétion de la tâche.
+
+Cas spécial: Tâche inter-clients « Pour prise de connaissance »
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Avec une tâche de type « Pour prise de connaissance », il est possible de procéder comme suit :
+
+Le mandant crée une tâche de type « Pour prise de connaissance » pour un document donné à destination d’un autre client.
+
+   |img-cooperation_inter_mandants-20|
+
+Le mandataire ouvre la tâche depuis la boite de réception (et la réassigne, si nécessaire, au chargé d’affaire pertinent). Avec l'action *Clôturer*, la tâche est automatiquement clôturée dans le client d’origine.
+
+   |img-cooperation_inter_mandants-21|
+
+À l’étape suivante, le mandataire a la possibilité de sélectionner des documents qui seront copiés dans un de ses propres dossiers.
+
+   |img-cooperation_inter_mandants-22|
+
+En cliquant sur *Suivant*, il est ensuite possible de sélectionner le dossier de destination (soit par saisie directe, soit en parcourant le système de classement à l’aide de *Ajouter*).
+
+   |img-cooperation_inter_mandants-23|
+
+Après avoir cliqué sur *Sauvegarder*, les documents sélectionnés sont copiés dans le dossier cible. La tâche « Pour prise de connaissance » n’est pas copiée.
+
+   |img-cooperation_inter_mandants-24|
+
+Cas spécial: Déléguer
+^^^^^^^^^^^^^^^^^^^^^
+
+Avec la fonction *déléguer*, une tâche peut facilement être transmise à plusieurs intéressés, aussi bien internes qu’externes au client courant. Un exemple typique serait la procédure de consultation.
+
+Créez tout d’abord une tâche avec les documents à être transmis aux autres services. Acceptez cette tâche pour voir apparaître l’option de délégation.
+
+   |img-cooperation_inter_mandants-25|
+
+   |img-cooperation_inter_mandants-26|
+
+   |img-cooperation_inter_mandants-27|
+
+La tâche peut maintenant être déléguée. Saisissez tous les destinataires de la tâche via le champ de saisie et sélectionnez les documents à être transmis avec la tâche.
+
+Cliquez sur *Suivant*.
+
+   |img-cooperation_inter_mandants-28|
+
+   |img-cooperation_inter_mandants-29|
+
+.. note::
+   Attention : les documents joints ne sont pas copiés, il s’agit là d’un lien vers le document original.
+
+Ajustez selon besoin de nom de la tâche et la date, puis sauvegardez.
+
+   |img-cooperation_inter_mandants-30|
+
+Après la sauvegarde, un nombre de sous-tâches correspondant au nombre de destinataires est généré. Les sous-tâches sont visibles depuis la tâche principale et vice-versa. Si des destinataires additionnels doivent être ajoutés après-coup, il est toujours possible d’utiliser la fonction *déléguer*, et ce un nombre illimité de fois.
+
+   |img-cooperation_inter_mandants-24|
+
+.. note::
+   Si une délégation inter-clients a été créée, le destinataire a la possibilité de traiter la tâche directement dans le dossier du mandant, ou, alternativement, de travailler dans son propre dossier (Similairement à une tâche inter-clients).
+
+   Si la tâche est traitée directement dans le dossier du client d’origine, il est à noter que le document devra probablement être téléchargé pour éviter que tout le monde travaille sur le même document (p.ex. pour des prises de position par différents services).
+
+   La tâche principale ne peut être complétée et fermée seulement une fois que toutes les sous-tâches ont été accomplies.
+
+
+   .. |img-cooperation_inter_mandants-01| image:: ../_static/img/img-cooperation_inter_mandants-01.png
+   .. |img-cooperation_inter_mandants-02| image:: ../_static/img/img-cooperation_inter_mandants-02.png
+   .. |img-cooperation_inter_mandants-03| image:: ../_static/img/img-cooperation_inter_mandants-03.png
+   .. |img-cooperation_inter_mandants-04| image:: ../_static/img/img-cooperation_inter_mandants-04.png
+   .. |img-cooperation_inter_mandants-05| image:: ../_static/img/img-cooperation_inter_mandants-05.png
+   .. |img-cooperation_inter_mandants-06| image:: ../_static/img/img-cooperation_inter_mandants-06.png
+   .. |img-cooperation_inter_mandants-07| image:: ../_static/img/img-cooperation_inter_mandants-07.png
+   .. |img-cooperation_inter_mandants-08| image:: ../_static/img/img-cooperation_inter_mandants-08.png
+   .. |img-cooperation_inter_mandants-09| image:: ../_static/img/img-cooperation_inter_mandants-09.png
+   .. |img-cooperation_inter_mandants-10| image:: ../_static/img/img-cooperation_inter_mandants-10.png
+   .. |img-cooperation_inter_mandants-11| image:: ../_static/img/img-cooperation_inter_mandants-11.png
+   .. |img-cooperation_inter_mandants-12| image:: ../_static/img/img-cooperation_inter_mandants-12.png
+   .. |img-cooperation_inter_mandants-13| image:: ../_static/img/img-cooperation_inter_mandants-13.png
+   .. |img-cooperation_inter_mandants-14| image:: ../_static/img/img-cooperation_inter_mandants-14.png
+   .. |img-cooperation_inter_mandants-15| image:: ../_static/img/img-cooperation_inter_mandants-15.png
+   .. |img-cooperation_inter_mandants-16| image:: ../_static/img/img-cooperation_inter_mandants-16.png
+   .. |img-cooperation_inter_mandants-17| image:: ../_static/img/img-cooperation_inter_mandants-17.png
+   .. |img-cooperation_inter_mandants-18| image:: ../_static/img/img-cooperation_inter_mandants-18.png
+   .. |img-cooperation_inter_mandants-19| image:: ../_static/img/img-cooperation_inter_mandants-19.png
+   .. |img-cooperation_inter_mandants-20| image:: ../_static/img/img-cooperation_inter_mandants-20.png
+   .. |img-cooperation_inter_mandants-21| image:: ../_static/img/img-cooperation_inter_mandants-21.png
+   .. |img-cooperation_inter_mandants-22| image:: ../_static/img/img-cooperation_inter_mandants-22.png
+   .. |img-cooperation_inter_mandants-23| image:: ../_static/img/img-cooperation_inter_mandants-23.png
+   .. |img-cooperation_inter_mandants-24| image:: ../_static/img/img-cooperation_inter_mandants-24.png
+   .. |img-cooperation_inter_mandants-25| image:: ../_static/img/img-cooperation_inter_mandants-25.png
+   .. |img-cooperation_inter_mandants-26| image:: ../_static/img/img-cooperation_inter_mandants-26.png
+   .. |img-cooperation_inter_mandants-27| image:: ../_static/img/img-cooperation_inter_mandants-27.png
+   .. |img-cooperation_inter_mandants-28| image:: ../_static/img/img-cooperation_inter_mandants-28.png
+   .. |img-cooperation_inter_mandants-29| image:: ../_static/img/img-cooperation_inter_mandants-29.png
+   .. |img-cooperation_inter_mandants-30| image:: ../_static/img/img-cooperation_inter_mandants-30.png
+   .. |img-cooperation_inter_mandants-31| image:: ../_static/img/img-cooperation_inter_mandants-31.png

--- a/docs/public-fr/taches/creer_tache.rst
+++ b/docs/public-fr/taches/creer_tache.rst
@@ -1,3 +1,5 @@
+.. _label-creer_tache:
+
 Créer une tâche
 ---------------
 
@@ -39,7 +41,7 @@ Onglet Général
 
     .. [#FN1] Aucun retour nécessitant un contrôle n'est attendu du mandataire, ces 2 types de mandats peuvent être fermés directement par le mandataire.
 
-    Plus d'information à ce sujet (p. ex. quels droits sont applicables à quel type de mandat se trouvent dans le chapitre "Flux de travail".
+    Plus d'information à ce sujet (p. ex. quels droits sont applicables à quel type de mandat se trouvent dans le chapitre :ref:`label-taches-flux-travail`.
 
 4. **Mandataire :** L'utilisateur qui doit compléter la tâche.
 

--- a/docs/public-fr/taches/creer_tache.rst
+++ b/docs/public-fr/taches/creer_tache.rst
@@ -1,0 +1,73 @@
+Créer une tâche
+---------------
+
+Il existe essentiellement 2 manières de créer une tâche.
+
+-  Au niveau dossier ou sous-dossier, via *Ajout d'un élément →
+   Tâche*.
+
+   |img-creer_tache-01|
+
+-  En sélectionnant un ou plusieurs documents (à l'aide de la touche :kbd:`Ctrl`) puis en cliquant sur *créer une tâche*.
+
+   |img-creer_tache-02|
+
+L'écran de saisie est subdivisé en 2 onglets : *Général* et *Avancé*. L'onglet actif est marqué en bleu. Les champs obligatoires sont marqués d'un carré rouge.
+
+Onglet Général
+~~~~~~~~~~~~~~
+
+|img-creer_tache-03|
+
+1. **Titre :** Description du contenu de la tâche.
+
+2. **Mandant :** la personne assignant la tâche. Par défaut, l'utilisateur courant est présélectionné.
+
+3. **Type de mandat :** le type de tâche identifie ce qui est attendu du mandataire. Dans OneGov GEVER, on distingue parmi 6 types par défaut.
+
+    - Pour prise de connaissance [#FN1]_
+
+    - Pour traitement immédiat [#FN1]_
+
+    - Pour rapport/requête
+
+    - Pour autorisation
+
+    - Pour contrôle / correction
+
+    - Pour prise de position
+
+    .. [#FN1] Aucun retour nécessitant un contrôle n'est attendu du mandataire, ces 2 types de mandats peuvent être fermés directement par le mandataire.
+
+    Plus d'information à ce sujet (p. ex. quels droits sont applicables à quel type de mandat se trouvent dans le chapitre "Flux de travail".
+
+4. **Mandataire :** L'utilisateur qui doit compléter la tâche.
+
+   Dans des installations OneGov GEVER couvrant de multiples clients, il est possible à ce point de sélectionner le client-cible (aussi connu en tant que coopération inter-clients).
+
+5. **À réaliser jusqu'au:** Délai pour compléter la tâche. La date courante plus 5 jours est proposée par défaut.
+
+6. **Description :** Si nécessaire, la tâche peut être décrite en détail dans cette section.
+
+7. **Renvois :** Des documents ayant un rapport avec la tâche peuvent être peuvent être sélectionnés ici, ou même simplement saisis, si leur nom est connu.
+
+
+   Si la tâche a été générée en sélectionnant un ou plusieurs documents dans l'onglet *Documents*, ces documents sont déjà listés ici.
+
+Onglet Avancé
+~~~~~~~~~~~~~
+
+|img-creer_tache-04|
+
+Avec pour seule exception la date de réalisation, ces champs sont tous prévus pour l'évaluation de la performance.
+
+La date de réalisation est automatiquement complétée lorsque l'action *Fermer* est lancée.
+
+.. note::
+   Après sauvegarde, la tâche passe automatiquement dans l'état *"Ouvert*. Dans cet état, le créateur de la tâche peut encore modifier ses champs. Aussi, les tâches dans l'état *Ouvert* peuvent encore être annulées. Tout cela n'est plus possible une fois qu'elle est *En traitement*.
+
+
+.. |img-creer_tache-01| image:: ../_static/img/img-creer_tache-01.png
+.. |img-creer_tache-02| image:: ../_static/img/img-creer_tache-02.png
+.. |img-creer_tache-03| image:: ../_static/img/img-creer_tache-03.png
+.. |img-creer_tache-04| image:: ../_static/img/img-creer_tache-04.png

--- a/docs/public-fr/taches/flux_de_travail.rst
+++ b/docs/public-fr/taches/flux_de_travail.rst
@@ -1,0 +1,69 @@
+Aperçu d’un flux de travail typique
+-----------------------------------
+
+Après avoir sauvegardé, la tâche se retrouve dans l’état *ouvert*.
+
+**Séquence typique de complétion d’une tâche**
+
+-   Mandant créé la tâche – État : *Ouvert*
+
+-   Mandataire accepte la tâche – État : *En traitement*
+
+-   Mandataire complète la tâche – État : *Accompli*
+
+-   Mandant conclut la tâche – État : *Clôturé*
+
+
+.. note::
+   Pour les types de tâche « pour prise de connaissance » et « Pour réalisation immédiate » : Comme le mandant n’attend pas de réponse pour vérification, le flux de travail est raccourci.
+
+   - « Pour prendre connaissance » : Cette tâche peut être fermée sans être acceptée au préalable.
+
+   - « Pour réalisation immédiate » : Cette tâche peut être fermée directement après avoir été acceptée.
+
+   Les utilisateurs ayant accès à la boîte de réception peuvent également déclencher des actions concernant les tâches additionnelles lorsqu’ils ne sont pas les mandataires.
+
+**Exceptions**
+
+-   Si le mandataire décline une tâche, celle-ci est retournée au mandant – État : *Refusé*
+
+-   Si le mandant annule une tâche, sont état passe à *Annulé*
+
+-   Si le mandant rouvre une tâche après que celle-ci ait déjà été accomplie ou refusée, l’état de la tâche passe à *Ouvert*
+
+-   Si le mandant assigne une tâche à une autre personne, l’état de celle-ci reste *Ouvert*.
+
+**Déroulement séquentiel**
+
+Avec ce type de déroulement, *Planifié* et *Omis* viennent s’ajouter à la liste des états de tâche possibles. Avec ce genre de déroulement, les tâches sont traitées l’une après l’autre, c’est-à-dire que la tâche subséquente n’est déclenchée que lorsque la précédente a été fermée. Lorsqu’un déroulement standard séquentiel est déclenché la première tâche passe donc en statut *Ouvert* tandis que toutes les autres restent en *Planifié* jusqu’à ce que ce soit leur tour. Les tâches d’un déroulement séquentiel peuvent également être *Omises*, une action qui se reflète bien sûr dans son état.
+
+**Autorisations avec les différentes tâches**
+
+Les droits sur les documents suivants viennent compléter les droits existants au niveau numéro de classement et dossier pour la durée de la tâche. Aussitôt que la tâche est accomplie, ces droits sont à nouveau retirés au mandataire.
+
+============================ =========================
+Type de tâche                Droits du mandataire
+============================ =========================
+Pour prendre connaissance    Lecture uniquement
+
+Pour réalisation immédiate   Lecture et modification
+
+Pour Accord	                 Lecture et modification
+
+Pour contrôle/correction     Lecture et modification
+
+Pour prise de position       Lecture et modification
+
+Pour rapport/demande         Lecture et modification
+
+============================ =========================
+
+En plus du mandataire, les membres du groupes « Boîte de réception » obtiennent également les droits nécessaires, dans l’idée de la règle de suppléance.
+
+**Déroulement d’une tâche**
+
+Le schéma suivant illustre la façon dont interagissent les actions et états des tâches.
+
+|img-flux_de_travail-01|
+
+.. |img-flux_de_travail-01| image:: ../_static/img/img-flux_de_travail-01.png

--- a/docs/public-fr/taches/flux_de_travail.rst
+++ b/docs/public-fr/taches/flux_de_travail.rst
@@ -1,3 +1,5 @@
+.. _label-taches-flux-travail:
+
 Aperçu d’un flux de travail typique
 -----------------------------------
 

--- a/docs/public-fr/taches/index.rst
+++ b/docs/public-fr/taches/index.rst
@@ -1,0 +1,22 @@
+.. _chapitre-taches:
+
+Travailler avec des tâches
+==========================
+
+.. toctree::
+   :maxdepth: 2
+
+   creer_tache
+   vue_detaillee
+   sous_tache
+   flux_de_travail
+   taches_recues
+   accomplir_tache
+   lister_changements
+   taches_multiples
+   taches_equipes
+   cooperation_inter_clients
+   controle_taches_en_suspens
+   suppleance
+
+.. disqus::

--- a/docs/public-fr/taches/lister_changements.rst
+++ b/docs/public-fr/taches/lister_changements.rst
@@ -1,0 +1,8 @@
+Lister les changements d'état, réponses et documents
+----------------------------------------------------
+
+Les changements d’état, réponses et fichiers ajoutés sont listés dans la partie inférieure de la page de détails d’une tâche. Ainsi, toute l’historique peut être retracée. L’évènement le plus récent est toujours listé en haut.
+
+|img-lister_changements-01|
+
+.. |img-lister_changements-01| image:: ../_static/img/img-lister_changements-01.png

--- a/docs/public-fr/taches/sous_tache.rst
+++ b/docs/public-fr/taches/sous_tache.rst
@@ -5,11 +5,13 @@ Pour chaque tâche, il est possible de créer un nombre illimité de sous-tâche
 
 |img-creer_sous_tache-01|
 
-Une nouvelle page de création de sous-tâche est ouverte, ressemblant à celle utilisée pour une tâche principale. Pour savoir comment la compléter, référez-vous à Créer une nouvelle tâche **[please link]**
+Une nouvelle page de création de sous-tâche est ouverte, ressemblant à celle utilisée pour une tâche principale. Pour savoir comment la compléter, référez-vous à :ref:`label-creer_tache`.
 
 Après avoir sauvegardé, on se retrouve directement dans la sous-tâche. La tâche principale y est également indiquée:
 
 |img-creer_sous_tache-02|
+
+On retrouve également la sous-tache dans la vue détaillée de la tâche principale (voir :ref:`taches-vue-detaillee`)
 
 .. |img-creer_sous_tache-01| image:: ../_static/img/img-creer_sous_tache-01.png
 .. |img-creer_sous_tache-02| image:: ../_static/img/img-creer_sous_tache-02.png

--- a/docs/public-fr/taches/sous_tache.rst
+++ b/docs/public-fr/taches/sous_tache.rst
@@ -1,0 +1,15 @@
+Créer une sous-tâche
+--------------------
+
+Pour chaque tâche, il est possible de créer un nombre illimité de sous-tâches. Auparavant, il faut toutefois que la tâche principale soit acceptée. Au niveau de la tâche, cliquez sur *Ajout d'un élément → Sous-tâche*
+
+|img-creer_sous_tache-01|
+
+Une nouvelle page de création de sous-tâche est ouverte, ressemblant à celle utilisée pour une tâche principale. Pour savoir comment la compléter, référez-vous à Créer une nouvelle tâche **[please link]**
+
+Après avoir sauvegardé, on se retrouve directement dans la sous-tâche. La tâche principale y est également indiquée:
+
+|img-creer_sous_tache-02|
+
+.. |img-creer_sous_tache-01| image:: ../_static/img/img-creer_sous_tache-01.png
+.. |img-creer_sous_tache-02| image:: ../_static/img/img-creer_sous_tache-02.png

--- a/docs/public-fr/taches/suppleance.rst
+++ b/docs/public-fr/taches/suppleance.rst
@@ -1,0 +1,16 @@
+Traiter des tâches en suppléance
+--------------------------------
+Les personnes autorisées à voir toutes les tâches d’un service peuvent aussi les traiter en tant que suppléants pour leurs collègues. Elles peuvent aussi effectuer des actions à leur place
+
+Par exemple, une secrétaire peut accomplir une tâche en tant que suppléante du chargé d’affaire. Cela se fait directement via le menu déroulant *Suppléance*.
+
+|img-suppleance-01|
+
+Tâches personnelles
+~~~~~~~~~~~~~~~~~~~
+En marquant la case à cocher *Tâche personnelle*, il est possible de désactiver les droits de suppléance du groupe « Boîte de Réception ». Cette fonction peut être utile pour des tâches incluant, par exemple, des données personnelles et devant être protégées.
+
+|img-suppleance-02|
+
+.. |img-suppleance-01| image:: ../_static/img/img-suppleance-01.png
+.. |img-suppleance-02| image:: ../_static/img/img-suppleance-02.png

--- a/docs/public-fr/taches/taches_equipes.rst
+++ b/docs/public-fr/taches/taches_equipes.rst
@@ -1,0 +1,28 @@
+Tâches d'équipes
+----------------
+
+Avec les tâches d'équipes, il est possible d’assigner des tâches à des groupes Active Directory. Ces équipes peuvent être composées par les utilisateurs de type Admin.
+
+|img-taches_equipe-01|
+
+Une fois qu’une équipe a été saisie, il est possible de lui assigner des tâches. La tâche est créée comme à l’usuelle, l’équipe peut simplement être saisie dans le champ Mandataire.
+
+|img-taches_equipe-02|
+
+Dans un premier temps, la tâche apparaît chez tous les membres de l’équipe, dans leurs sommaires personnels respectifs.
+
+|img-taches_equipe-03|
+
+Dans la vue détaillée de la tâche, toute l’équipe est encore le mandataire.
+
+|img-taches_equipe-04|
+
+Aussitôt qu’un membre de l’équipe a accepté la tâche, celle-ci n’est visible plus que pour ce dernier. Il est aussi automatiquement défini en tant que mandataire.
+
+|img-taches_equipe-05|
+
+.. |img-taches_equipe-01| image:: ../_static/img/img-taches_equipe-01.png
+.. |img-taches_equipe-02| image:: ../_static/img/img-taches_equipe-02.png
+.. |img-taches_equipe-03| image:: ../_static/img/img-taches_equipe-03.png
+.. |img-taches_equipe-04| image:: ../_static/img/img-taches_equipe-04.png
+.. |img-taches_equipe-05| image:: ../_static/img/img-taches_equipe-05.png

--- a/docs/public-fr/taches/taches_multiples.rst
+++ b/docs/public-fr/taches/taches_multiples.rst
@@ -1,0 +1,17 @@
+Tâches-multiples
+----------------
+
+Par l’intermédiaire de tâches-multiples, OneGov GEVER offre la possibilité d’assigner une tâche à de multiples mandataires. Dans ce cas, une tâche distincte est créée pour chacun d’entre eux. Une fois créées, ces tâches ne peuvent toutefois plus être identifiées comme des tâches-multiples. Leur seul but est de permettre d’adresser une tâche à de multiples personnes. Elles sont donc fonctionnellement identiques à une tâche assignée à un seul mandataire.
+
+Le déroulement est donc semblable à celui où l’on assigne une tâche à une seule personne. Dès que plusieurs personnes sont sélectionnées dans la champ « Mandant », elle devient automatiquement une tâche-multiple. Ainsi, une tâche distincte est générée par mandataires. Il n’est plus possible d’ajouter des mandataires additionnels après coup, et il n’est plus possible de voir quelles tâches ont été générées par la tâche-multiple.
+
+|img-tache_recapitulative-01|
+
+Après la saisie des données nécessaires dans la tâche, la procédure est complétée par un clic sur « Sauvegarder ».
+
+Dans le sommaire, sous « Tâches assignées », apparaissent maintenant toutes les tâches ainsi créées (une par mandataire). En cliquant sur une tâche, les détails usuels d’une tâche sont affichés. Dans l’onglet « Tâches assignées » il est également possible de suivre l’avancement des tâches par l’intermédiaire de la colonne « État », où il est possible de savoir qui a déjà accepté, voir complété sa tâche ou chez qui le travail est encore en cours.
+
+|img-tache_recapitulative-02|
+
+.. |img-tache_recapitulative-01| image:: ../_static/img/img-tache_recapitulative-01.png
+.. |img-tache_recapitulative-02| image:: ../_static/img/img-tache_recapitulative-02.png

--- a/docs/public-fr/taches/taches_recues.rst
+++ b/docs/public-fr/taches/taches_recues.rst
@@ -1,0 +1,109 @@
+Traiter la tâche reçue en tant que responsable
+----------------------------------------------
+
+Après sa création, une tâche se trouve dans l’état *Ouvert*. Les documents liés à la tâche se trouvent sous l’onglet *Documents*. Ils sont également listés dans la section « Documents » :
+
+|img-taches01|
+
+Accepter une tâche
+~~~~~~~~~~~~~~~~~~
+
+Le mandant accepte la tâche par l’intermédiaire de *Actions → Accepter Tâche*. Selon besoin, un commentaire peut être ajouté. Le statut passe d’*Ouvert* à *En traitement*.
+
+|img-taches02|
+
+Refuser une tâche
+~~~~~~~~~~~~~~~~~
+
+Si la tâche est refusée (p.ex. en raison de vacances), le statut passe à « refusé ». La tâche est ainsi automatiquement retournée au mandataire, qui a la possibilité de rouvrir et réassigner celle-ci à un autre chargé d’affaires.
+
+|img-taches03|
+|img-taches04|
+
+Ré-attribuer une tâche
+~~~~~~~~~~~~~~~~~~~~~~
+
+Une tâche peut aussi être ré-attribuée à un autre responsable. Ainsi, le mandataire courant d’une tâche est remplacé par un autre. Pour ce faire, cliquez sur *Actions → Ré-attribuer*. Cette fonction reste disponible durant tout le cycle actif d’une tâche.
+
+|img-taches05|
+
+La nouvelle page de saisie affichée permet de choisir la bonne personne en charge de la tâche. Dans le champ *Commentaire*, il est possible, selon besoin, de saisir des détails additionnels.
+
+|img-taches06|
+
+La ré-attribution de la tâche à un nouveau mandataire peut être suivie dans l’historique de cette dernière.
+
+|img-taches07|
+
+
+Déléguer une tâche
+~~~~~~~~~~~~~~~~~~
+
+Une tâche peut être déléguée à une autre personne. Pour cela, il est possible de créer une ou plusieurs sous-tâches, tout en gardant le même mandant pour la tâche principale. Acceptez la tâche auparavant et séléctionnez ensuite *Actions → Déléguer*.
+
+|img-taches08|
+
+Dans une première étape, sélectionnez la (ou les) personne(s) à qui la tâche sera déléguée.
+
+|img-taches09|
+
+Durant la 2ème étape, le mandant peut être sélectionné. Complétez la délégation en cliquant sur « Sauvegarder »
+
+|img-taches10|
+
+
+Modifier des documents liés à des tâches (références)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Les documents liés à des tâches peuvent être directement modifiés depuis la tâche. Dans l’onglet Documents, déplacez le curseur sur le nom du document afin de faire apparaître le menu contextuel pour y effectuer le check-out du document et ainsi pouvoir le modifier. Les modifications sont enregistrées comme une nouvelle version une fois le check-in effectué.
+
+|img-taches11|
+
+Documents dans une tâche
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Ajouter un document
+^^^^^^^^^^^^^^^^^^^
+
+Par *Ajout d'un élément → Document*, il est possible d’importer un fichier depuis le système de fichiers.
+
+|img-taches12|
+
+Les documents nouvellement ajoutés vont aussi bien être listés sous l’onglet « Documents » que dans la section « Documents » du sommaire. Ils sont automatiquement ajoutés à la liste des documents du dossier pertinent.
+
+Référencer un document existant
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Un fichier déjà présent dans OneGov GEVER peut être référencé via le champ *Renvois*. (Voir étape suivante)
+
+Marquer une tâche comme accomplie
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Cliquez sur *Accomplir*.
+
+|img-taches13|
+
+Un document se trouvant dans le dossier relatif à la tâche peut être référencé par l’intermédiaire du champ *Renvois*. Le champ de texte pour la réponse est facultatif. Selon le type de tâche, il est possible de la compléter uniquement par le champ de réponse.
+
+|img-taches14|
+
+Après la sauvegarde, l’état de la tâche passe à *Tâche accomplie*. S’il y a besoin de compléter la réponse, il est possible d’éditer celle-ci en réactivant la tâche par l’intermédiaire d’*Action → Réviser*
+
+|img-taches15|
+
+
+.. |img-taches01| image:: ../_static/img/img-taches01.png
+.. |img-taches02| image:: ../_static/img/img-taches02.png
+.. |img-taches03| image:: ../_static/img/img-taches03.png
+.. |img-taches04| image:: ../_static/img/img-taches04.png
+.. |img-taches05| image:: ../_static/img/img-taches05.png
+.. |img-taches06| image:: ../_static/img/img-taches06.png
+.. |img-taches07| image:: ../_static/img/img-taches07.png
+.. |img-taches08| image:: ../_static/img/img-taches08.png
+.. |img-taches09| image:: ../_static/img/img-taches09.png
+.. |img-taches10| image:: ../_static/img/img-taches10.png
+.. |img-taches11| image:: ../_static/img/img-taches11.png
+.. |img-taches12| image:: ../_static/img/img-taches12.png
+.. |img-taches13| image:: ../_static/img/img-taches13.png
+.. |img-taches14| image:: ../_static/img/img-taches14.png
+.. |img-taches15| image:: ../_static/img/img-taches15.png

--- a/docs/public-fr/taches/vue_detaillee.rst
+++ b/docs/public-fr/taches/vue_detaillee.rst
@@ -1,0 +1,22 @@
+Vue détaillée d'une tâche
+--------------------------
+
+La vue détaillée d'une tâche est structurée d'une façon à ce que l'utilisateur puisse obtenir toutes les informations essentielles d'un seul coup d'œil.
+
+|img-detail_tache-01|
+
+Les 5 blocs d'informations suivants y sont inclus :
+
+1. **Titre de la tâche**: Description du contenu de la tâche.
+
+2. **Onglets Sommaire et Documents**: Entre les onglets *Sommaire* et *Documents*, il est possible d'alterner entre différentes vues. L'onglet *documents* liste tous les documents qui sont liés à la tâche.
+
+3. **Attributs**: Toutes les informations importantes concernant la tâche sont listées ici. Entre autres, on y trouve l'état actuel ("Ouvert", "En traitement", "Terminé", "Fermé").
+
+4. **Options de réponse**: Plusieurs boutons permettent de sélectionner des réponses à la tâches.
+
+5. **Progrès**: Le déroulement de la tâche liste toutes les activités ayant eu lieu en lien avec cette tâche. L'activité la plus récente est affichée au sommet de la liste.
+
+6. **Tâche principale et sous-tâches**: Si la tâche inclut des sous-tâches, celles-ci seront listées dans cette zone. S'il s'agit d'une sous-tâche, c'est la tâche principale qui sera indiquée ici.
+
+.. |img-detail_tache-01| image:: ../_static/img/img-detail_tache-01.png

--- a/docs/public-fr/taches/vue_detaillee.rst
+++ b/docs/public-fr/taches/vue_detaillee.rst
@@ -1,3 +1,5 @@
+.. _taches-vue-detaillee:
+
 Vue détaillée d'une tâche
 --------------------------
 

--- a/docs/public/user-manual/aufgaben/empfangene_bearbeiten.rst
+++ b/docs/public/user-manual/aufgaben/empfangene_bearbeiten.rst
@@ -31,7 +31,7 @@ Aufgabe neu zuweisen
 ~~~~~~~~~~~~~~~~~~~~
 
 Eine Aufgabe kann auch einem anderen Sachbearbeitenden zugewiesen werden.
-Dadurch wird der Auftraggeber der Aufgabe geändert. Wählen Sie dazu
+Dadurch wird der Auftragnehmer der Aufgabe geändert. Wählen Sie dazu
 *Aktionen → Neuzuweisen*. Diese Möglichkeit besteht auch im späteren
 Arbeitsverlauf noch.
 

--- a/docs/public/user-manual/img/media/img-spvupdate-15.png
+++ b/docs/public/user-manual/img/media/img-spvupdate-15.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e2ab960702b5ba891aefdeb619a1e606debae14c29715a807f666b2fa0691e23
-size 197349
+oid sha256:149a845b03fe5b16f6560c93db4ff6ed3d6f39e4074a4ad552ea4a37e88e46b8
+size 154410


### PR DESCRIPTION
@andresoberhaensli I split the PR in first adding the documentation as you sent it (except for renaming snapshots, including them correctly and other syntax correction), and then my own corrections to the documentation (last two commits), so you can see the changes that I've made.

The biggest changes are:
* Make sure to use `client` in French for what is `Mandant` in German, as `mandant` does not have the same meaning in French and is already used for `Auftraggeber`
* Change `Tâches récapitulatives` to `tâches multiples`
* Added links in the whole French documentation

I also made an issue with errors I encountered in the docs, screenshots that need updating and such here:
https://github.com/4teamwork/opengever.core/issues/5668
