### PR TITLE
Show filters also on no contents page in document listings.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,7 @@ Changelog
 2019.2.1 (unreleased)
 ---------------------
 
-- Nothing changed yet.
+- Show filters also on no contents page in document listings. [phgross]
 
 
 2019.2.0 (2019-05-16)

--- a/opengever/tabbedview/browser/generic_with_bumblebee_viewchooser.pt
+++ b/opengever/tabbedview/browser/generic_with_bumblebee_viewchooser.pt
@@ -65,11 +65,40 @@
   </tal:has_contents>
 
   <tal:extjs condition="view/extjs_enabled">
-    <p style="display:none"
-       id="message_no_contents"
-       i18n:translate="label_no_contents">
-      No contents
-    </p>
+    <tal:START_CUSTOM_______________________________________ />
+    <div id="message_no_contents" class="tabbedview_select" style="display:none"
+        i18n:domain="opengever.tabbedview">
+
+      <tal:cond tal:condition="view/filterlist_available">
+        <span
+              tal:define="filterlist_name python: view.filterlist_name;
+                          filter_id python: view.request.get(filterlist_name)"
+              tal:attributes="id filterlist_name" class="state_filters">
+          <span i18n:translate="" >State</span>
+
+          <a tal:repeat="filter python: view.filterlist.filters()"
+             tal:attributes="id filter/id;
+                             class python: filter.is_active(filter_id) and 'active'"
+             tal:content="filter/label"
+             href="javascript:void(0);"
+             i18n:domain="opengever.tabbedview">
+          </a>
+
+        </span>
+      </tal:cond>
+      <tal:subjectFilter tal:define="widget view/render_subject_filter_widget" tal:condition="widget">
+        <span tal:condition="view/filterlist_available">|</span>
+        <span>Schlagworte</span>
+        <tal:subjectFilterWidget replace="structure widget" />
+      </tal:subjectFilter>
+      <p id="message_no_contents"
+         i18n:translate="label_no_contents"
+         i18n:domain="ftw.tabbedview">
+        No contents
+      </p>
+
+    </div>
+    <tal:END_CUSTOM_______________________________________ />
   </tal:extjs>
 
   <tal:html condition="not:view/extjs_enabled">

--- a/opengever/tabbedview/tests/test_document_listing.py
+++ b/opengever/tabbedview/tests/test_document_listing.py
@@ -92,3 +92,18 @@ class TestDocumentListing(IntegrationTestCase):
         self.assertEqual(2, len(table.rows))
         self.assertEqual(['Title', self.subdocument.title],
                          table.column("Title"))
+
+    @browsing
+    def test_filters_is_available_on_the_no_content_page(self, browser):
+        self.activate_feature('solr')
+        self.activate_feature('extjs')
+        self.login(self.regular_user, browser=browser)
+
+        self.mock_solr(response_json=self.solr_response('Wichtig', 'secret'))
+
+        browser.visit(self.dossier, view='tabbedview_view-documents',
+                      data={'subjects': ["secret"]})
+
+        self.assertEqual(
+            ['Wichtig', 'secret'],
+            browser.css('select.keyword-widget option').text)


### PR DESCRIPTION
When selecting a filter (keyword, state) with lead to no results, the filters should still be visible, otherwise deleting the filter is not possible.

se https://basecamp.com/2768704/projects/12554551/todos/388673626.