### PR TITLE
Make subject column non-sortable in storred dictstorage settings.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 ---------------------
 
 - Show filters also on no contents page in document listings. [phgross]
+- Make subject column non-sortable in storred dictstorage settings. [flipsi]
 
 
 2019.2.0 (2019-05-16)

--- a/opengever/core/upgrades/20190520140249_make_subjects_column_non_sortable/upgrade.py
+++ b/opengever/core/upgrades/20190520140249_make_subjects_column_non_sortable/upgrade.py
@@ -1,0 +1,33 @@
+from opengever.core.upgrade import SchemaMigration
+from sqlalchemy.sql.expression import column
+from sqlalchemy.sql.expression import table
+import json
+
+
+class MakeSubjectsColumnNonSortable(SchemaMigration):
+    """Make subjects column non sortable.
+    """
+
+    def migrate(self):
+        _table = table('dictstorage', column("key"), column('value'))
+
+        items = self.connection.execute(_table.select()).fetchall()
+        for item in items:
+            if item.value is None:
+                continue
+
+            try:
+                value = json.loads(item.value)
+            except ValueError:
+                # The dictstorage contains non json values, the ldap
+                # syncronisation timestampe for example
+                continue
+
+            for col in value.get('columns', []):
+                if col.get('id') == 'Subject':
+                    col['sortable'] = False
+
+            new_value = json.dumps(value)
+            self.execute(_table.update()
+                         .values(value=new_value)
+                         .where(_table.columns.key == item.key))


### PR DESCRIPTION
With #5601 the subject column of dossier listings has been marked as not sortable, but for users which have their own tabbeview setting in the dictstorage, the column was still sortable. Therefore we need to update those dictstorage entries.