### PR TITLE
Allow viewing closed meeting when meeting dossier is closed.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 
 - Add french translation for spv documentation. [andresoberhaensli, njohner]
 - Add french translation for task documentation. [andresoberhaensli, njohner]
+- Allow viewing closed meeting when meeting dossier is closed. [njohner]
 
 
 2019.2.1 (2019-05-21)

--- a/opengever/meeting/browser/meetings/meeting.py
+++ b/opengever/meeting/browser/meetings/meeting.py
@@ -271,7 +271,8 @@ class MeetingView(BrowserView):
         meeting_dossier = self.model.get_dossier()
         committee = self.model.committee.resolve_committee()
         if (api.user.has_permission('Modify portal content', obj=committee) and not
-                api.user.has_permission('Modify portal content', obj=meeting_dossier)):
+                api.user.has_permission('Modify portal content', obj=meeting_dossier) and not
+                self.model.is_closed()):
             self.error_message = translate(
                 _("no_edit_permissions_on_meeting_dossier",
                   default="User does not have permission to edit the meeting dossier:"),


### PR DESCRIPTION
A user with edit permissions on the meeting would not be able to view the meeting if the meeting dossier is closed. This is to avoid problems with buttons in the meeting view that do not work because of lack of edit permissions on the meeting dossier. Nevertheless when the meeting is closed, it should be visible for a user with edit permissions even when the meeting dossier is closed.

When a user with edit permissions goes on a closed meeting with a closed meeting dossier, there is at least one button that will not work, the one to generate the protocol acceptance proposal.

resolves #5680 