### PR TITLE
Upgradestep cleanup 2019.2

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2019.2.2 (unreleased)
 ---------------------
 
+- Cleanup/fix oneoffix upgradesteps and make dicstorage upgrades more failsafe. [phgross]
 - Add french translation for spv documentation. [andresoberhaensli, njohner]
 - Add french translation for task documentation. [andresoberhaensli, njohner]
 

--- a/opengever/core/upgrades/20181012203011_make_oneoffixx_textline_configs_optional_so_they_can_be_unset/registry.xml
+++ b/opengever/core/upgrades/20181012203011_make_oneoffixx_textline_configs_optional_so_they_can_be_unset/registry.xml
@@ -1,7 +1,4 @@
 <registry>
-  <record interface="opengever.oneoffixx.interfaces.IOneoffixxSettings" field="baseurl">
-    <required>False</required>
-  </record>
   <record interface="opengever.oneoffixx.interfaces.IOneoffixxSettings" field="fake_sid">
     <required>False</required>
   </record>

--- a/opengever/core/upgrades/20190515134907_remove_oneoffixx_baseurl_from_the_registry/registry.xml
+++ b/opengever/core/upgrades/20190515134907_remove_oneoffixx_baseurl_from_the_registry/registry.xml
@@ -1,5 +1,0 @@
-<registry>
-  <record interface="opengever.oneoffixx.interfaces.IOneoffixxSettings" field="baseurl" delete="True" remove="True" >
-    <required>False</required>
-  </record>
-</registry>

--- a/opengever/core/upgrades/20190515134907_remove_oneoffixx_baseurl_from_the_registry/upgrade.py
+++ b/opengever/core/upgrades/20190515134907_remove_oneoffixx_baseurl_from_the_registry/upgrade.py
@@ -1,8 +1,0 @@
-from ftw.upgrade import UpgradeStep
-
-
-class RemoveOneoffixxBaseurlFromTheRegistry(UpgradeStep):
-    """Remove Oneoffixx baseurl from the registry."""
-
-    def __call__(self):
-        self.install_upgrade_profile()

--- a/opengever/core/upgrades/20190520140249_make_subjects_column_non_sortable/upgrade.py
+++ b/opengever/core/upgrades/20190520140249_make_subjects_column_non_sortable/upgrade.py
@@ -1,4 +1,5 @@
 from opengever.core.upgrade import SchemaMigration
+from opengever.base.model import create_session
 from sqlalchemy.sql.expression import column
 from sqlalchemy.sql.expression import table
 import json
@@ -11,14 +12,14 @@ class MakeSubjectsColumnNonSortable(SchemaMigration):
     def migrate(self):
         _table = table('dictstorage', column("key"), column('value'))
 
-        items = self.connection.execute(_table.select()).fetchall()
+        items = create_session().execute(_table.select()).fetchall()
         for item in items:
             if item.value is None:
                 continue
 
             try:
                 value = json.loads(item.value)
-            except ValueError:
+            except (ValueError, TypeError):
                 # The dictstorage contains non json values, the ldap
                 # syncronisation timestampe for example
                 continue


### PR DESCRIPTION
- Remove outdated and no longer working upgradestep 2019.2. Because the IOneoffixxSettings has been changed and no longer provides an field base_url. Closes #5679.
- Make dictostorage migration, for the subject column more "fail-safe". 