### PR TITLE
Extend task API serialization with responses data.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,7 @@ Changelog
 2019.3.0 (unreleased)
 ---------------------
 
-- Nothing changed yet.
+- Extend task API serialization with responses data. [phgross]
 
 
 2019.2.2 (2019-05-27)

--- a/docs/public/dev-manual/api/index.rst
+++ b/docs/public/dev-manual/api/index.rst
@@ -24,12 +24,12 @@ Inhalt:
    metadata.rst
    config.rst
    favorite.rst
-   reminder.rst
    notifications.rst
    recently_touched.rst
    preview.rst
    webactions.rst
    tasks.rst
+   reminder.rst
    journal.rst
    examples/index.rst
    docs_changelog.rst

--- a/docs/public/dev-manual/api/tasks.rst
+++ b/docs/public/dev-manual/api/tasks.rst
@@ -316,3 +316,48 @@ Zusätzliche Metadaten:
    .. py:attribute:: text
 
        :Datentyp: ``Text``
+
+
+Aufgabenverlauf
+---------------
+Der Verlauf einer Aufgabe ist in der GET Repräsentation einer Aufgaben unter dem Attribut ``responses`` enthalten.
+
+
+**Beispiel-Respones auf ein GET Request**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 200 OK
+      Accept: application/json
+
+      {
+        "@id": "http://example.org/ordnungssystem/fuehrung/dossier-1/task-5",
+        "@type": "opengever.task.task",
+        "UID": "3a551f6e3b62421da029dfceb71656e6",
+        "items": [],
+        "responses": [
+          {
+            "added_object": null,
+            "changes": [],
+            "creator": "zopemaster",
+            "date": "2019-05-21T13:57:42+00:00",
+            "date_of_completion": null,
+            "relatedItems": [],
+            "reminder_option": null,
+            "text": "Lorem ipsum.",
+            "transition": "task-commented"
+          },
+          {
+            "added_object": null,
+            "changes": [],
+            "creator": "zopemaster",
+            "date": "2019-05-21T14:02:01+00:00",
+            "date_of_completion": null,
+            "relatedItems": [],
+            "text": "Suspendisse faucibus, nunc et pellentesque egestas.",
+            "transition": "task-transition-open-in-progress"
+          },
+        ]
+        "responsible": "david.erni",
+        "...": "...",
+      }

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -19,6 +19,9 @@
   <adapter factory=".repositoryfolder.SerializeRepositoryFolderToJson" />
   <adapter factory=".dossier.SerializeDossierToJson" />
   <adapter factory=".document.SerializeDocumentToJson" />
+  <adapter factory=".task.SerializeTaskToJson" />
+  <adapter factory=".response.ResponseDefaultFieldSerializer" />
+  <adapter factory=".response.SerializeTaskResponseToJson" />
 
   <adapter factory=".mail.DeserializeMailFromJson" />
 

--- a/opengever/api/response.py
+++ b/opengever/api/response.py
@@ -1,0 +1,61 @@
+from opengever.task.adapters import IResponse
+from opengever.task.response import ITaskTransitionResponseFormSchema
+from plone.restapi.interfaces import IFieldSerializer
+from plone.restapi.interfaces import ISerializeToJson
+from plone.restapi.serializer.converters import json_compatible
+from plone.restapi.serializer.dxcontent import SerializeFolderToJson
+from zope.component import adapter
+from zope.component import queryMultiAdapter
+from zope.interface import implementer
+from zope.interface import Interface
+from zope.schema import getFields
+from zope.schema.interfaces import IField
+
+
+@adapter(IField, IResponse, Interface)
+@implementer(IFieldSerializer)
+class ResponseDefaultFieldSerializer(object):
+
+    def __init__(self, field, context, request):
+        self.context = context
+        self.request = request
+        self.field = field
+
+    def __call__(self):
+        return json_compatible(self.get_value())
+
+    def get_value(self, default=None):
+        return getattr(self.context, self.field.__name__, default)
+
+
+@implementer(ISerializeToJson)
+@adapter(IResponse, Interface)
+class SerializeTaskResponseToJson(SerializeFolderToJson):
+
+    # The `reminder_option` is not stored on the response object, but the
+    # field only controls the reminder of the task.
+    SKIPPED_FIELDS = ['reminder_option']
+
+    def __init__(self, context, request):
+        self.context = context
+        self.request = request
+
+    def __call__(self, *args, **kwargs):
+        result = {
+            'date': json_compatible(self.context.date),
+            'creator': json_compatible(self.context.creator),
+            'added_object': json_compatible(self.context.added_object),
+            'changes': json_compatible(self.context.changes),
+        }
+
+        # Add attributes from the response schema
+        for name, field in getFields(ITaskTransitionResponseFormSchema).items():
+            if name in self.SKIPPED_FIELDS:
+                continue
+
+            serializer = queryMultiAdapter(
+                (field, self.context, self.request), IFieldSerializer)
+            value = serializer()
+            result[json_compatible(name)] = value
+
+        return result

--- a/opengever/api/task.py
+++ b/opengever/api/task.py
@@ -1,0 +1,22 @@
+from opengever.api.serializer import GeverSerializeFolderToJson
+from opengever.task.adapters import IResponseContainer
+from opengever.task.task import ITask
+from plone.restapi.interfaces import ISerializeToJson
+from zope.component import adapter
+from zope.component import getMultiAdapter
+from zope.interface import implementer
+from zope.interface import Interface
+
+
+@implementer(ISerializeToJson)
+@adapter(ITask, Interface)
+class SerializeTaskToJson(GeverSerializeFolderToJson):
+    def __call__(self, *args, **kwargs):
+        result = super(SerializeTaskToJson, self).__call__(*args, **kwargs)
+
+        responses = IResponseContainer(self.context)
+        result['responses'] = [
+            getMultiAdapter((response, self.request), ISerializeToJson)()
+            for response in responses]
+
+        return result

--- a/opengever/api/tests/test_task.py
+++ b/opengever/api/tests/test_task.py
@@ -1,0 +1,80 @@
+from ftw.testbrowser import browsing
+from opengever.testing import IntegrationTestCase
+from plone.restapi.serializer.converters import json_compatible
+
+
+class TestTaskSerialization(IntegrationTestCase):
+
+    @browsing
+    def test_task_contains_a_list_of_responses(self, browser):
+        self.login(self.regular_user, browser=browser)
+        browser.open(self.task, method="GET", headers=self.api_headers)
+
+        responses = browser.json['responses']
+        self.assertEquals(2, len(responses))
+        self.assertEquals(
+            {u'added_object': {u'@id': self.subtask.absolute_url(),
+                               u'@type': u'opengever.task.task',
+                               u'description': u'',
+                               u'review_state': u'task-state-resolved',
+                               u'title': self.subtask.title},
+             u'changes': [],
+             u'creator': self.dossier_responsible.id,
+             u'date': json_compatible(self.subtask.created()),
+             u'date_of_completion': None,
+             u'relatedItems': [],
+             u'text': u'',
+             u'transition': u'transition-add-subtask'},
+            responses[0])
+
+    @browsing
+    def test_task_response_contains_changes(self, browser):
+        # Modify deadline to have a response containing field changes
+        self.login(self.dossier_responsible, browser=browser)
+        browser.open(self.task)
+        browser.click_on('task-transition-modify-deadline')
+        browser.fill({'Response': 'Nicht mehr dringend',
+                      'New Deadline': '1.1.2023'})
+        browser.click_on('Save')
+
+        self.login(self.regular_user, browser=browser)
+        browser.open(self.task, method="GET", headers=self.api_headers)
+
+        response = browser.json['responses'][-1]
+        self.assertEquals(self.dossier_responsible.id, response['creator'])
+        self.assertEquals(
+            u'task-transition-modify-deadline', response['transition'])
+        self.assertEquals(
+            [{u'id': u'deadline', u'name': u'Deadline',
+              u'after': u'2023-01-01', u'before': u'2016-11-01'}],
+            response['changes'])
+
+    @browsing
+    def test_response_key_contains_empty_list_for_task_without_responses(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        browser.open(self.inbox_task, method="GET", headers=self.api_headers)
+        self.assertEquals([], browser.json['responses'])
+
+    @browsing
+    def test_fowardings_contains_a_list_of_responses(self, browser):
+        self.login(self.secretariat_user, browser=browser)
+
+        browser.open(
+            self.inbox_forwarding, method="GET", headers=self.api_headers)
+
+        self.assertEquals(
+            [{u'added_object': {
+                u'@id': u'http://nohost/plone/eingangskorb/forwarding-1/document-13',
+                u'@type': u'opengever.document.document',
+                u'description': u'',
+                u'review_state': u'document-state-draft',
+                u'title': u'Dokument im Eingangsk\xf6rbliweiterleitung'},
+              u'changes': [],
+              u'creator': u'nicole.kohler',
+              u'date': u'2016-08-31T10:07:33+00:00',
+              u'date_of_completion': None,
+              u'relatedItems': [],
+              u'text': u'',
+              u'transition': u'transition-add-document'}],
+            browser.json['responses'])

--- a/opengever/testing/integration_test_case.py
+++ b/opengever/testing/integration_test_case.py
@@ -97,6 +97,9 @@ FEATURE_METHODS = {
 class IntegrationTestCase(TestCase):
     layer = OPENGEVER_INTEGRATION_TESTING
     features = ()
+    api_headers = {
+        'Accept': 'application/json',
+        'Content-Type': 'application/json'}
 
     def setUp(self):
         super(IntegrationTestCase, self).setUp()


### PR DESCRIPTION
A GET request on a task, now contains the task history in the key `responses`. 

Closes #5676 

See documentation (part of the PR) for further information.
