### PR TITLE
Fix revoke_permission field and validation in the fowarding forms.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2019.2.2 (unreleased)
 ---------------------
 
+- Fix revoke_permission field and validation in the fowarding forms. [phgross]
 - Cleanup/fix oneoffix upgradesteps and make dicstorage upgrades more failsafe. [phgross]
 - Add french translation for spv documentation. [andresoberhaensli, njohner]
 - Add french translation for task documentation. [andresoberhaensli, njohner]

--- a/opengever/inbox/forwarding.py
+++ b/opengever/inbox/forwarding.py
@@ -8,8 +8,7 @@ from opengever.ogds.base.sources import AllUsersInboxesAndTeamsSourceBinder
 from opengever.ogds.base.utils import get_current_org_unit
 from opengever.ogds.base.utils import get_ou_selector
 from opengever.task import _ as task_mf
-from opengever.task import is_private_task_feature_enabled
-from opengever.task import is_optional_task_permissions_revoking_enabled
+from opengever.task.browser.forms import hide_feature_flagged_fields
 from opengever.task.task import ITask
 from opengever.task.task import Task
 from opengever.task.util import update_reponsible_field_data
@@ -173,15 +172,7 @@ class ForwardingAddForm(add.DefaultAddForm):
         super(ForwardingAddForm, self).updateFieldsFromSchemata()
         _drop_empty_additional_fieldset(self.groups)
 
-        if not is_private_task_feature_enabled():
-            common_group = next(
-                group for group in self.groups if group.__name__ == u'common')
-            common_group.fields = common_group.fields.omit('is_private')
-
-        if not is_optional_task_permissions_revoking_enabled():
-            common_group = next(
-                group for group in self.groups if group.__name__ == u'common')
-            common_group.fields = common_group.fields.omit('revoke_permissions')
+        hide_feature_flagged_fields(self.groups)
 
     def createAndAdd(self, data):
         update_reponsible_field_data(data)
@@ -202,15 +193,7 @@ class ForwardingEditForm(DefaultEditForm):
         super(ForwardingEditForm, self).updateFieldsFromSchemata()
         _drop_empty_additional_fieldset(self.groups)
 
-        if not is_private_task_feature_enabled():
-            common_group = next(
-                group for group in self.groups if group.__name__ == u'common')
-            common_group.fields = common_group.fields.omit('is_private')
-
-        if not is_optional_task_permissions_revoking_enabled():
-            common_group = next(
-                group for group in self.groups if group.__name__ == u'common')
-            common_group.fields = common_group.fields.omit('revoke_permissions')
+        hide_feature_flagged_fields(self.groups)
 
     def applyChanges(self, data):
         """Records reassign activity when the responsible has changed.

--- a/opengever/inbox/forwarding.py
+++ b/opengever/inbox/forwarding.py
@@ -9,6 +9,7 @@ from opengever.ogds.base.utils import get_current_org_unit
 from opengever.ogds.base.utils import get_ou_selector
 from opengever.task import _ as task_mf
 from opengever.task import is_private_task_feature_enabled
+from opengever.task import is_optional_task_permissions_revoking_enabled
 from opengever.task.task import ITask
 from opengever.task.task import Task
 from opengever.task.util import update_reponsible_field_data
@@ -168,15 +169,19 @@ class ForwardingAddForm(add.DefaultAddForm):
 
         super(ForwardingAddForm, self).update()
 
-        # Disable is_private field according to the feature flag
-        if not is_private_task_feature_enabled():
-            common_group = next(
-                group for group in self.groups if group.__name__ == u'common')
-            common_group.widgets['is_private'].mode = HIDDEN_MODE
-
     def updateFieldsFromSchemata(self):
         super(ForwardingAddForm, self).updateFieldsFromSchemata()
         _drop_empty_additional_fieldset(self.groups)
+
+        if not is_private_task_feature_enabled():
+            common_group = next(
+                group for group in self.groups if group.__name__ == u'common')
+            common_group.fields = common_group.fields.omit('is_private')
+
+        if not is_optional_task_permissions_revoking_enabled():
+            common_group = next(
+                group for group in self.groups if group.__name__ == u'common')
+            common_group.fields = common_group.fields.omit('revoke_permissions')
 
     def createAndAdd(self, data):
         update_reponsible_field_data(data)
@@ -196,6 +201,16 @@ class ForwardingEditForm(DefaultEditForm):
     def updateFieldsFromSchemata(self):
         super(ForwardingEditForm, self).updateFieldsFromSchemata()
         _drop_empty_additional_fieldset(self.groups)
+
+        if not is_private_task_feature_enabled():
+            common_group = next(
+                group for group in self.groups if group.__name__ == u'common')
+            common_group.fields = common_group.fields.omit('is_private')
+
+        if not is_optional_task_permissions_revoking_enabled():
+            common_group = next(
+                group for group in self.groups if group.__name__ == u'common')
+            common_group.fields = common_group.fields.omit('revoke_permissions')
 
     def applyChanges(self, data):
         """Records reassign activity when the responsible has changed.

--- a/opengever/task/browser/forms.py
+++ b/opengever/task/browser/forms.py
@@ -26,6 +26,18 @@ REASSIGN_TRANSITION = 'task-transition-reassign'
 # thus we use an add form hack by injecting the values into the request.
 
 
+def hide_feature_flagged_fields(groups):
+    if not is_private_task_feature_enabled():
+        common_group = next(
+            group for group in groups if group.__name__ == u'common')
+        common_group.fields = common_group.fields.omit('is_private')
+
+    if not is_optional_task_permissions_revoking_enabled():
+        common_group = next(
+            group for group in groups if group.__name__ == u'common')
+        common_group.fields = common_group.fields.omit('revoke_permissions')
+
+
 class TaskAddForm(DefaultAddForm):
 
     def __init__(self, *args, **kwargs):
@@ -38,15 +50,7 @@ class TaskAddForm(DefaultAddForm):
 
     def updateFieldsFromSchemata(self):
         super(TaskAddForm, self).updateFieldsFromSchemata()
-        if not is_private_task_feature_enabled():
-            common_group = next(
-                group for group in self.groups if group.__name__ == u'common')
-            common_group.fields = common_group.fields.omit('is_private')
-
-        if not is_optional_task_permissions_revoking_enabled():
-            common_group = next(
-                group for group in self.groups if group.__name__ == u'common')
-            common_group.fields = common_group.fields.omit('revoke_permissions')
+        hide_feature_flagged_fields(self.groups)
 
     def update(self):
         # put default value for relatedItems into request
@@ -160,15 +164,7 @@ class TaskEditForm(DefaultEditForm):
     def updateFieldsFromSchemata(self):
         super(TaskEditForm, self).updateFieldsFromSchemata()
 
-        if not is_private_task_feature_enabled():
-            common_group = next(
-                group for group in self.groups if group.__name__ == u'common')
-            common_group.fields = common_group.fields.omit('is_private')
-
-        if not is_optional_task_permissions_revoking_enabled():
-            common_group = next(
-                group for group in self.groups if group.__name__ == u'common')
-            common_group.fields = common_group.fields.omit('revoke_permissions')
+        hide_feature_flagged_fields(self.groups)
 
     def applyChanges(self, data):
         """Records reassign activity when the responsible has changed.

--- a/opengever/task/tests/test_revoke_permissions.py
+++ b/opengever/task/tests/test_revoke_permissions.py
@@ -297,6 +297,60 @@ class TestRevokePermissionsFeatureDeactivated(IntegrationTestCase):
         with browser.expect_http_error(400):
             browser.open(self.dossier, headers=headers, data=data)
 
+    @browsing
+    def test_disabled_revoke_permissions_in_forwarding_add_form(self, browser):
+        self.login(self.secretariat_user, browser)
+
+        browser.open(self.inbox, view='++add++opengever.inbox.forwarding',
+                     data=self.make_path_param(self.inbox_document))
+        self.assertIsNone(
+            browser.forms.get('form').find_field("Revoke permissions."))
+
+        browser.fill({'Title': 'Anfragen'})
+        browser.click_on('Save')
+        self.assertEquals(['Item created'], info_messages())
+
+    @browsing
+    def test_enabled_revoke_permissions_in_forwarding_add_form(self, browser):
+        self.login(self.secretariat_user, browser)
+
+        self.activate_feature('optional-task-permissions-revoking')
+
+        browser.open(self.inbox, view='++add++opengever.inbox.forwarding',
+                     data=self.make_path_param(self.inbox_document))
+        self.assertIsNotNone(
+            browser.forms.get('form').find_field("Revoke permissions."))
+
+        browser.fill({'Title': 'Anfragen'})
+        browser.click_on('Save')
+        self.assertEquals(['Item created'], info_messages())
+
+    @browsing
+    def test_disabled_revoke_permissions_in_forwarding_edit_form(self, browser):
+        self.login(self.administrator, browser)
+
+        browser.open(self.inbox_forwarding, view='edit')
+        self.assertIsNone(
+            browser.forms.get('form').find_field("Revoke permissions."))
+
+        browser.fill({'Title': 'Anfragen'})
+        browser.click_on('Save')
+        self.assertEquals(['Changes saved'], info_messages())
+
+    @browsing
+    def test_enabled_revoke_permissions_in_forwarding_edit_form(self, browser):
+        self.login(self.administrator, browser)
+
+        self.activate_feature('optional-task-permissions-revoking')
+
+        browser.open(self.inbox_forwarding, view='edit')
+        self.assertIsNotNone(
+            browser.forms.get('form').find_field("Revoke permissions."))
+
+        browser.fill({'Title': 'Anfragen'})
+        browser.click_on('Save')
+        self.assertEquals(['Changes saved'], info_messages())
+
 
 class TestRevokePermissionsDefault(IntegrationTestCase):
 


### PR DESCRIPTION
The recently added revoke_permission fields, wasn't handled in the add and edit forwarding forms, therefore the creation of a forwarding, when the feature flag was disabled, did not worked.

Closes #5685