### PR TITLE
Hide byline for the teams

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 ---------------------
 
 - Fix revoke_permission field and validation in the fowarding forms. [phgross]
+- Hide byline for the teams. [phgross]
 - Cleanup/fix oneoffix upgradesteps and make dicstorage upgrades more failsafe. [phgross]
 - Add french translation for spv documentation. [andresoberhaensli, njohner]
 - Add french translation for task documentation. [andresoberhaensli, njohner]

--- a/opengever/contact/browser/byline.py
+++ b/opengever/contact/browser/byline.py
@@ -28,3 +28,12 @@ class ContactByline(BylineBase):
         if self.context.model.is_active:
             return PMF('Yes')
         return PMF('No')
+
+
+class TeamByline(BylineBase):
+    """Hidden byline for TeamWrapper objects.
+    There is no sensible byline data for team objects - so we hide them.
+    """
+
+    def show(self):
+        return False

--- a/opengever/contact/browser/configure.zcml
+++ b/opengever/contact/browser/configure.zcml
@@ -77,6 +77,14 @@
       permission="zope2.View"
       />
 
+  <browser:viewlet
+      name="plone.belowcontenttitle.documentbyline"
+      for="opengever.ogds.base.interfaces.ITeam"
+      manager="plone.app.layout.viewlets.interfaces.IBelowContentTitle"
+      class=".byline.TeamByline"
+      permission="zope2.View"
+      />
+
   <browser:page
       name="participations"
       for="opengever.contact.interfaces.IOrganization"

--- a/opengever/ogds/base/tests/test_team_details.py
+++ b/opengever/ogds/base/tests/test_team_details.py
@@ -63,3 +63,16 @@ class TestTeamDetails(IntegrationTestCase):
             ['http://nohost/plone/@@user-details/kathi.barfuss',
              'http://nohost/plone/@@user-details/robert.ziegler'],
             [link.get('href') for link in links])
+
+    @browsing
+    def test_byline_is_not_shown(self, browser):
+        self.login(self.administrator, browser=browser)
+
+        byline_css_selector = '.documentByLine'
+
+        # test-precondition: byline is shown for the contactfolder
+        browser.open(self.contactfolder)
+        self.assertIsNotNone(browser.css(byline_css_selector))
+
+        browser.open(self.contactfolder, view='team-1/view')
+        self.assertEquals([], browser.css(byline_css_selector))


### PR DESCRIPTION
There is no sensible data which should be displayed in the team 
details view. So we register an hidden byline for teams.

![Bildschirmfoto 2019-05-27 um 14 17 44](https://user-images.githubusercontent.com/485755/58419268-6895ca00-808a-11e9-8c2f-78bfd123961f.png)

See https://basecamp.com/2768704/projects/14549453/todos/388925855