### PR TITLE
Extend listing endpoint fields with file_extension and document_type.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -11,6 +11,7 @@ Changelog
 - Fix bug with resolving a reopened dossier. [njohner]
 - Update documentation for SaaS deployment update. [njohner]
 - Correctly handle dossier reactivation through RESTAPI. [njohner]
+- Extend listing endpoint fields with file_extension and document_type. [phgross]
 - Extend task API serialization with responses data. [phgross]
 
 

--- a/docs/public/dev-manual/api/listings.rst
+++ b/docs/public/dev-manual/api/listings.rst
@@ -66,6 +66,7 @@ werden. Folgende Felder stehen zur Verfügung:
 - ``delivery_date``: Ausgangsdatum
 - ``document_author``: Dokumentauthor
 - ``document_date``: Dokumentdatum
+- ``document_type``: Dokumenttyp
 - ``end``: Enddatum des Dossiers
 - ``mimetype``: Mimetype
 - ``modified``: Modifikationsdatum

--- a/docs/public/dev-manual/api/listings.rst
+++ b/docs/public/dev-manual/api/listings.rst
@@ -86,6 +86,7 @@ werden. Folgende Felder stehen zur Verfügung:
 - ``title``: Titel
 - ``filesize``: Dateigrösse
 - ``filename``: Dateiname
+- ``file_extension``: Datei-Endung
 - ``task_type``: Aufgaben-Typ
 - ``deadline``: Aufgabenfrist
 

--- a/opengever/api/listing.py
+++ b/opengever/api/listing.py
@@ -108,6 +108,7 @@ FIELDS = {
     'delivery_date': ('delivery_date', 'delivery_date', 'delivery_date'),
     'document_author': ('document_author', 'document_author', 'document_author'),
     'document_date': ('document_date', 'document_date', 'document_date'),
+    'document_type': ('document_type', 'document_type', 'document_type'),
     'end': ('end', 'end', 'end'),
     'has_sametype_children': ('has_sametype_children', 'has_sametype_children', 'has_sametype_children'),
     'mimetype': ('getContentType', 'getContentType', 'mimetype'),

--- a/opengever/api/listing.py
+++ b/opengever/api/listing.py
@@ -133,6 +133,7 @@ FIELDS = {
     'type': ('portal_type', 'PortalType', 'portal_type'),
     'filesize': ('filesize', filesize, 'filesize'),
     'filename': ('filename', filename, 'filename'),
+    'file_extension': ('file_extension', 'file_extension', 'file_extension'),
     'task_type': ('task_type', translated_task_type, 'task_type'),
     'deadline': ('deadline', 'deadline', 'deadline'),
 }

--- a/opengever/api/tests/test_listing.py
+++ b/opengever/api/tests/test_listing.py
@@ -320,6 +320,27 @@ class TestListingEndpoint(IntegrationTestCase):
              u'@id': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/task-1'},
             item)
 
+    @browsing
+    def test_filter_by_file_extension(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        # all documents
+        view = ('@listing?name=documents&'
+                'columns:list=filename&columns:list=start')
+        browser.open(self.repository_root, view=view, headers=self.api_headers)
+        filenames = [item['filename'] for item in browser.json['items']]
+
+        # docx documents only
+        view = ('@listing?name=documents&'
+                'columns:list=filename&columns:list=start'
+                '&filters.file_extension:record:list=.docx')
+        browser.open(self.repository_root, view=view, headers=self.api_headers)
+
+        self.assertNotEqual(len(filenames), len(browser.json['items']))
+        self.assertEqual(
+            [filename for filename in filenames if filename.endswith('.docx')],
+            [item['filename'] for item in browser.json['items']])
+
 
 class TestListingEndpointWithSolr(IntegrationTestCase):
 
@@ -384,3 +405,16 @@ class TestListingEndpointWithSolr(IntegrationTestCase):
             'start:([2016-01-01T00:00:00.000Z TO 2016-01-01T23:59:59.000Z])',
             filters,
         )
+
+    @browsing
+    def test_filter_by_file_extension(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        view = ('@listing?name=documents&columns:list=title'
+                '&columns:list=start'
+                '&filters.file_extension:record:list=.docx')
+        browser.open(self.repository_root, view=view,
+                     headers={'Accept': 'application/json'})
+
+        filters = self.conn.search.call_args[0][0]['filter']
+        self.assertIn(u'file_extension:(.docx)', filters)


### PR DESCRIPTION
So the listing endpoint supports now filtering on file_extension and document_type. Closes https://github.com/4teamwork/gever-ui/issues/159.