### PR TITLE
Fix livesearch endpoint when using Solr

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -11,6 +11,7 @@ Changelog
 - Update documentation for SaaS deployment update. [njohner]
 - Correctly handle dossier reactivation through RESTAPI. [njohner]
 - Extend task API serialization with responses data. [phgross]
+- Fix livesearch endpoint when using Solr. [buchi]
 
 
 2019.2.2 (2019-05-27)

--- a/opengever/api/livesearch.py
+++ b/opengever/api/livesearch.py
@@ -16,15 +16,6 @@ class GeverLiveSearchGet(SearchGet):
             self.request.form.get('path', '/').lstrip('/'),
         ).rstrip('/')
 
-        # Strip VHM path because plone.restapi SearchHandler will add it
-        vhm_physical_path = '/'.join(
-            self.request.get('VirtualRootPhysicalPath', ''))
-        if vhm_physical_path:
-            if path.startswith(vhm_physical_path):
-                path = path[len(vhm_physical_path):]
-                if not path:
-                    path = '/'
-
         if not search_term:
             return []
 
@@ -47,6 +38,16 @@ class GeverLiveSearchGet(SearchGet):
 
         else:
             del self.request.form['q']
+
+            # Strip VHM path because plone.restapi SearchHandler will add it
+            vhm_physical_path = '/'.join(
+                self.request.get('VirtualRootPhysicalPath', ''))
+            if vhm_physical_path:
+                if path.startswith(vhm_physical_path):
+                    path = path[len(vhm_physical_path):]
+                    if not path:
+                        path = '/'
+
             self.request.form.update({
                 'SearchableText': search_term + '*',
                 'sort_limit': limit,


### PR DESCRIPTION
Only strip Virtual Host Monster path if we are actually using the plone.restapi
SearchHandler.