### PR TITLE
Only allow dossier transitions that are possible on the main dossier

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2019.3.0 (unreleased)
 ---------------------
 
+- Only allow dossier transitions that are possible on the main dossier. [njohner]
 - Handle dossier activation through RESTAPI. [njohner]
 - Improve error message when trying to delete a referenced document. [njohner]
 - Handle dossier deactivation through RESTAPI. [njohner]

--- a/opengever/dossier/locales/de/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/de/LC_MESSAGES/opengever.dossier.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2019-05-29 07:53+0000\n"
+"POT-Creation-Date: 2019-05-29 14:10+0000\n"
 "PO-Revision-Date: 2017-05-23 04:53+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: German <https://translations.onegovgever.ch/projects/onegov-gever/opengever-dossier/de/>\n"
@@ -60,6 +60,14 @@ msgstr "Dieses Dossier wurde bereits abgeschlossen."
 #: ./opengever/dossier/resolve.py
 msgid "Dossier is already being resolved"
 msgstr "Der Abschlussvorgang für dieses Dossier läuft bereits."
+
+#: ./opengever/dossier/resolve.py
+msgid "Dossier is not active and cannot be resolved."
+msgstr "Dieses Dossier kann nicht abgeschlossen werden, weil es nicht aktiv ist."
+
+#: ./opengever/dossier/reactivate.py
+msgid "Dossier is not resolved and cannot be reactivated."
+msgstr "Dieses Dossier kann nicht wieder eröffnet werden, weil es nicht abgeschlossen ist."
 
 #: ./opengever/dossier/browser/templates/overview.pt
 msgid "Dossier structure"
@@ -160,12 +168,12 @@ msgid "The Dossier can't be deactivated, it contains active proposals."
 msgstr "Das Dossier kann nicht storniert werden, es enthält aktive Anträge."
 
 #: ./opengever/dossier/deactivate.py
-msgid "The Dossier can't be deactivated, not all contained tasks are in a closed state."
-msgstr "Das Dossier kann nicht storniert werden, da nicht alle enthaltenen Aufgaben abgeschlossen sind."
-
-#: ./opengever/dossier/deactivate.py
 msgid "The Dossier can't be deactivated, not all contained documents are checked in."
 msgstr "Das Dossier kann nicht storniert werden, da nicht alle enthaltenen Dokumente eingecheckt sind."
+
+#: ./opengever/dossier/deactivate.py
+msgid "The Dossier can't be deactivated, not all contained tasks are in a closed state."
+msgstr "Das Dossier kann nicht storniert werden, da nicht alle enthaltenen Aufgaben abgeschlossen sind."
 
 #: ./opengever/dossier/deactivate.py
 msgid "The Dossier can't be deactivated, the subdossier ${dossier} is already resolved."

--- a/opengever/dossier/locales/fr/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/fr/LC_MESSAGES/opengever.dossier.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-05-29 07:53+0000\n"
+"POT-Creation-Date: 2019-05-29 14:10+0000\n"
 "PO-Revision-Date: 2017-12-03 11:16+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-dossier/fr/>\n"
@@ -59,6 +59,14 @@ msgstr "Ce dossier a déjà été clôturé."
 #: ./opengever/dossier/resolve.py
 msgid "Dossier is already being resolved"
 msgstr "Le processus de clôture de ce dossier est déjà en cours."
+
+#: ./opengever/dossier/resolve.py
+msgid "Dossier is not active and cannot be resolved."
+msgstr "Ce dossier ne peut pas être clôturé parce qu'il n'est pas actif."
+
+#: ./opengever/dossier/reactivate.py
+msgid "Dossier is not resolved and cannot be reactivated."
+msgstr "Ce dossier ne peut pas être rouvert parce qu'il n'est pas clôturé."
 
 #: ./opengever/dossier/browser/templates/overview.pt
 msgid "Dossier structure"
@@ -158,12 +166,12 @@ msgid "The Dossier can't be deactivated, it contains active proposals."
 msgstr "Le dossier ne peut pas être annulé, il contient des requêtes actives."
 
 #: ./opengever/dossier/deactivate.py
-msgid "The Dossier can't be deactivated, not all contained tasks are in a closed state."
-msgstr "Ce dossier ne peut pas être annulé, il contient encore des tâches non accomplies."
-
-#: ./opengever/dossier/deactivate.py
 msgid "The Dossier can't be deactivated, not all contained documents are checked in."
 msgstr "Ce dossier ne peut pas être annulé, parce qu'il contient des documents qui ne sont pas en statut \"checkin\"."
+
+#: ./opengever/dossier/deactivate.py
+msgid "The Dossier can't be deactivated, not all contained tasks are in a closed state."
+msgstr "Ce dossier ne peut pas être annulé, il contient encore des tâches non accomplies."
 
 #: ./opengever/dossier/deactivate.py
 msgid "The Dossier can't be deactivated, the subdossier ${dossier} is already resolved."

--- a/opengever/dossier/locales/opengever.dossier.pot
+++ b/opengever/dossier/locales/opengever.dossier.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-05-29 07:53+0000\n"
+"POT-Creation-Date: 2019-05-29 14:10+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -59,6 +59,14 @@ msgstr ""
 
 #: ./opengever/dossier/resolve.py
 msgid "Dossier is already being resolved"
+msgstr ""
+
+#: ./opengever/dossier/resolve.py
+msgid "Dossier is not active and cannot be resolved."
+msgstr ""
+
+#: ./opengever/dossier/reactivate.py
+msgid "Dossier is not resolved and cannot be reactivated."
 msgstr ""
 
 #: ./opengever/dossier/browser/templates/overview.pt
@@ -159,11 +167,11 @@ msgid "The Dossier can't be deactivated, it contains active proposals."
 msgstr ""
 
 #: ./opengever/dossier/deactivate.py
-msgid "The Dossier can't be deactivated, not all contained tasks are in a closed state."
+msgid "The Dossier can't be deactivated, not all contained documents are checked in."
 msgstr ""
 
 #: ./opengever/dossier/deactivate.py
-msgid "The Dossier can't be deactivated, not all contained documents are checked in."
+msgid "The Dossier can't be deactivated, not all contained tasks are in a closed state."
 msgstr ""
 
 #: ./opengever/dossier/deactivate.py

--- a/opengever/dossier/reactivate.py
+++ b/opengever/dossier/reactivate.py
@@ -8,6 +8,7 @@ from Products.Five.browser import BrowserView
 
 
 MSG_SUBDOSSIER = _("It isn't possible to reactivate a sub dossier.")
+MAIN_DOSSIER_NOT_RESOLVED = _("Dossier is not resolved and cannot be reactivated.")
 
 
 class Reactivator(object):
@@ -18,6 +19,8 @@ class Reactivator(object):
 
     def get_precondition_violations(self):
         errors = []
+        if not self.context.is_resolved():
+            errors.append(MAIN_DOSSIER_NOT_RESOLVED)
         parent = self.context.get_parent_dossier()
         if parent:
             if self.wft.getInfoFor(parent, 'review_state') not in DOSSIER_STATES_OPEN:

--- a/opengever/dossier/reactivate.py
+++ b/opengever/dossier/reactivate.py
@@ -1,5 +1,4 @@
 from opengever.dossier import _
-from opengever.dossier.base import DOSSIER_STATES_OPEN
 from opengever.dossier.behaviors.dossier import IDossier
 from opengever.dossier.resolve import PreconditionsViolated
 from plone import api
@@ -23,7 +22,7 @@ class Reactivator(object):
             errors.append(MAIN_DOSSIER_NOT_RESOLVED)
         parent = self.context.get_parent_dossier()
         if parent:
-            if self.wft.getInfoFor(parent, 'review_state') not in DOSSIER_STATES_OPEN:
+            if not parent.is_open():
                 errors.append(MSG_SUBDOSSIER)
         return errors
 

--- a/opengever/dossier/resolve.py
+++ b/opengever/dossier/resolve.py
@@ -8,8 +8,6 @@ from opengever.document.behaviors import IBaseDocument
 from opengever.document.interfaces import IDossierJournalPDFMarker
 from opengever.document.interfaces import IDossierTasksPDFMarker
 from opengever.dossier import _
-from opengever.dossier.base import DOSSIER_STATE_RESOLVED
-from opengever.dossier.base import DOSSIER_STATES_OPEN
 from opengever.dossier.behaviors.dossier import IDossier
 from opengever.dossier.behaviors.dossier import IDossierMarker
 from opengever.dossier.behaviors.filing import IFilingNumberMarker
@@ -203,8 +201,7 @@ class DossierResolveView(BrowserView):
         return self.context.absolute_url()
 
     def is_already_resolved(self):
-        wfstate = api.content.get_state(obj=self.context)
-        return wfstate == DOSSIER_STATE_RESOLVED
+        return self.context.is_resolved()
 
     def redirect(self, url):
         return self.request.RESPONSE.redirect(url)
@@ -334,8 +331,7 @@ class StrictDossierResolver(object):
             self._recursive_resolve(
                 subdossier.getObject(), end_date, recursive=True)
 
-        if self.wft.getInfoFor(dossier,
-                               'review_state') in DOSSIER_STATES_OPEN:
+        if dossier.is_open():
             self.wft.doActionFor(dossier, 'dossier-transition-resolve')
 
 

--- a/opengever/dossier/resolve.py
+++ b/opengever/dossier/resolve.py
@@ -35,6 +35,7 @@ from zope.schema.vocabulary import SimpleVocabulary
 import transaction
 
 
+MAIN_DOSSIER_NOT_ACTIVE = _("Dossier is not active and cannot be resolved.")
 NOT_SUPPLIED_OBJECTS = _(
     "not all documents and tasks are stored in a subdossier.")
 NOT_CHECKED_IN_DOCS = _("not all documents are checked in")
@@ -555,13 +556,15 @@ class ResolveConditions(object):
 
     def check_preconditions(self):
         """Check if all preconditions are fulfilled:
+         - main dossier is in an open state
          - all_supplied
          - all checked in
          - all closed
         """
 
         errors = []
-
+        if not self.context.is_open():
+            errors.append(MAIN_DOSSIER_NOT_ACTIVE)
         if (self.strict
                 and not self.context.is_subdossier()
                 and not self.context.is_all_supplied()):

--- a/opengever/dossier/tests/test_resolve.py
+++ b/opengever/dossier/tests/test_resolve.py
@@ -1280,6 +1280,17 @@ class TestResolvingDossiersWithFilingNumberSupportRESTAPI(ResolveTestHelperRESTA
 class TestResolveConditions(IntegrationTestCase, ResolveTestHelper):
 
     @browsing
+    def test_resolving_is_cancelled_when_main_dossier_inactive(self, browser):
+        self.login(self.secretariat_user, browser)
+
+        self.set_workflow_state('dossier-state-inactive', self.resolvable_dossier)
+        self.resolve(self.resolvable_dossier, browser)
+
+        self.assert_not_resolved(self.resolvable_dossier)
+        self.assert_errors(self.resolvable_dossier, browser,
+                           ['Dossier is not active and cannot be resolved.'])
+
+    @browsing
     def test_resolving_is_cancelled_when_documents_are_not_filed_correctly(self, browser):
         self.login(self.secretariat_user, browser)
 


### PR DESCRIPTION
Because when resolving a dossier we skip inactive dossiers and when reactivating a dossier we skip all dossiers in states different from resolved, it was possible to resolve an inactive dossier and reactivate an active or an inactive dossier (while this would basically do nothing). We now prevent this by making sure that the transition can be executed on the main dossier.

resolves #5638