### PR TITLE
Sort BlockedLocalRolesList on reference number.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 
 - Only allow dossier transitions that are possible on the main dossier. [njohner]
 - Handle dossier activation through RESTAPI. [njohner]
+- Sort BlockedLocalRolesList on reference number. [njohner]
 - Improve error message when trying to delete a referenced document. [njohner]
 - Handle dossier deactivation through RESTAPI. [njohner]
 - Fix bug with resolving a reopened dossier. [njohner]

--- a/docs/public/admin-manual/aussonderung.rst
+++ b/docs/public/admin-manual/aussonderung.rst
@@ -130,7 +130,7 @@ Anträgen dargestellt.
 
 Auflistung
 ----------
-Auf Stufe Ordnungssytem steht für Benutzer mit den Rollen `Records Manager`
+Auf Stufe Ordnungssystem steht für Benutzer mit den Rollen `Records Manager`
 oder `Archivist` ein zusätzlicher Reiter `Angebote` zur Verfügung, welcher alle
 Angebote dieses Ordnungssystems auflistet. Dabei werden standardmässig nur aktive Angebote aufgelistet, mittels dem Statusfilter `Alle` können aber auch abgeschlossene Angebote angezeigt werden.
 

--- a/opengever/sharing/tests/test_blocked_local_roles_listing.py
+++ b/opengever/sharing/tests/test_blocked_local_roles_listing.py
@@ -141,7 +141,7 @@ class TestBlockedLocalRolesListing(IntegrationTestCase):
         self.assertEqual(u'1. F\xfchrung - Client1 1', browser.css('.blocked-local-roles-listing a').first.text)
 
     @browsing
-    def test_blocked_role_tab_does_renders_tree_for_administrator(self, browser):
+    def test_blocked_role_tab_does_render_tree_for_administrator(self, browser):
         browser.append_request_header('Accept-Language', 'de-ch')
 
         self.login(self.manager)
@@ -152,7 +152,6 @@ class TestBlockedLocalRolesListing(IntegrationTestCase):
         browser.open(self.repository_root, view="tabbedview_view-blocked-local-roles")
         self.assertEqual(u'1. F\xfchrung - Client1 1', browser.css('.blocked-local-roles-listing a').first.text)
 
-    @unittest.skip("This test is currently flaky")
     @browsing
     def test_blocked_role_tab_tree_rendering(self, browser):
         browser.append_request_header('Accept-Language', 'de-ch')


### PR DESCRIPTION
Testing is a bit weak I guess. There was a test which was probably flaky because we were not sorting the list of blocked local roles. Modifying the reference number of an object and checking that the order is updated would be better, but did not find a simple way of doing this and it did not quite seem worth investing more time in this.

resolves #5670