### PR TITLE
Drop no longer working oneoffixx upgrade.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -11,6 +11,7 @@ Changelog
 - Update documentation for SaaS deployment update. [njohner]
 - Correctly handle dossier reactivation through RESTAPI. [njohner]
 - Extend task API serialization with responses data. [phgross]
+- Drop no longer working oneoffixx upgrade. [deiferni]
 
 
 2019.2.2 (2019-05-27)

--- a/opengever/core/upgrades/20180912145057_add_a_registry_setting_for_oneoffixx_baseurl/registry.xml
+++ b/opengever/core/upgrades/20180912145057_add_a_registry_setting_for_oneoffixx_baseurl/registry.xml
@@ -1,3 +1,0 @@
-<registry>
-  <record interface="opengever.oneoffixx.interfaces.IOneoffixxSettings" field="baseurl" />
-</registry>

--- a/opengever/core/upgrades/20180912145057_add_a_registry_setting_for_oneoffixx_baseurl/upgrade.py
+++ b/opengever/core/upgrades/20180912145057_add_a_registry_setting_for_oneoffixx_baseurl/upgrade.py
@@ -1,9 +1,0 @@
-from ftw.upgrade import UpgradeStep
-
-
-class AddARegistrySettingForOneoffixxBaseurl(UpgradeStep):
-    """Add a registry setting for Oneoffixx baseurl.
-    """
-
-    def __call__(self):
-        self.install_upgrade_profile()


### PR DESCRIPTION
The field has been removed lately, thus adding it will fail.

We have already cleaned up similar problems in https://github.com/4teamwork/opengever.core/pull/5683.

The issue was introduced with https://github.com/4teamwork/opengever.core/pull/5666 when the field was introduced.

Needs backport to `2019.2.x`.