### PR TITLE
Prefix agendaitem decision numbers and meeting number by correct period title

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 ---------------------
 
 - Only allow dossier transitions that are possible on the main dossier. [njohner]
+- Prefix agendaitem decision numbers and meeting number by correct period title. [njohner]
 - Handle dossier activation through RESTAPI. [njohner]
 - Improve error message when trying to delete a referenced document. [njohner]
 - Handle dossier deactivation through RESTAPI. [njohner]

--- a/opengever/meeting/browser/meetings/templates/meeting.pt
+++ b/opengever/meeting/browser/meetings/templates/meeting.pt
@@ -17,9 +17,7 @@
               i18n:attributes="title"
               title="Meeting number">
           #
-          <tal:YEAR replace="meeting/start/year" />
-          /
-          <tal:MEETING_NUMBER replace="meeting/meeting_number" />
+          <tal:YEAR replace="meeting/get_meeting_number" />
         </span>
       </h1>
     </div>

--- a/opengever/meeting/model/agendaitem.py
+++ b/opengever/meeting/model/agendaitem.py
@@ -166,14 +166,17 @@ class AgendaItem(Base):
             self.description = description
 
     def get_decision_number(self):
-        # Before the meeting is held, agendaitems do not have a decision number
-        # and in that case we do not want to format it with the year prefixed
+        # Before the meeting is held, agendaitems do not have a decision number and
+        # in that case we do not want to format it with the period title prefixed
         if not self.decision_number:
             return None
 
-        period = Period.query.get_current_for_update(self.meeting.committee)
-        year = period.date_from.year
-        return '{} / {}'.format(year, self.decision_number)
+        period = Period.query.get_for_meeting(self.meeting)
+        if not period:
+            return str(self.decision_number)
+
+        title = period.title
+        return '{} / {}'.format(title, self.decision_number)
 
     def get_dossier_reference_number(self):
         if self.has_proposal:

--- a/opengever/meeting/model/agendaitem.py
+++ b/opengever/meeting/model/agendaitem.py
@@ -166,9 +166,10 @@ class AgendaItem(Base):
             self.description = description
 
     def get_decision_number(self):
-        # XXX huh? what is this?
+        # Before the meeting is held, agendaitems do not have a decision number
+        # and in that case we do not want to format it with the year prefixed
         if not self.decision_number:
-            return self.decision_number
+            return None
 
         period = Period.query.get_current_for_update(self.meeting.committee)
         year = period.date_from.year

--- a/opengever/meeting/model/meeting.py
+++ b/opengever/meeting/model/meeting.py
@@ -207,6 +207,19 @@ class Meeting(Base, SQLFormSupport):
 
         self.meeting_number = period.get_next_meeting_sequence_number()
 
+    def get_meeting_number(self):
+        # Before the meeting is held, it will not have a meeting number.
+        # In that case we do not want to format it with the period title prefixed
+        if not self.meeting_number:
+            return None
+
+        period = Period.query.get_for_meeting(self)
+        if not period:
+            return str(self.meeting_number)
+
+        title = period.title
+        return '{} / {}'.format(title, self.meeting_number)
+
     def generate_decision_numbers(self):
         """Generate decision numbers for each agenda item of this meeting.
 

--- a/opengever/meeting/model/query.py
+++ b/opengever/meeting/model/query.py
@@ -259,5 +259,25 @@ class PeriodQuery(BaseQuery):
     def get_current_for_update(self, committee):
         return self.with_for_update().get_current(committee)
 
+    def by_date(self, date):
+        return self.filter(and_(Period.date_from <= date,
+                                Period.date_to >= date))
+
+    def get_for_meeting(self, meeting):
+        """ returns the period matching the committee of meeting and containing
+        the meeting start date. If several periods match these conditions, return
+        the active period if it is among them, otherwise just pick the first match.
+        """
+        query = self.by_date(meeting.start).by_committee(meeting.committee)
+
+        if query.count() == 0:
+            return None
+
+        active = query.active()
+        if active.count() == 1:
+            return active.one()
+
+        return query.first()
+
 
 Period.query_cls = PeriodQuery

--- a/opengever/meeting/tests/test_period_query.py
+++ b/opengever/meeting/tests/test_period_query.py
@@ -3,6 +3,7 @@ from ftw.builder import Builder
 from ftw.builder import create
 from opengever.meeting.model import Period
 from opengever.testing import MEMORY_DB_LAYER
+from opengever.testing.helpers import localized_datetime
 from unittest import TestCase
 
 
@@ -48,3 +49,51 @@ class TestPeriodQuery(TestCase):
                                         date_to=date(2010, 12, 31)))
 
         self.assertEqual(self.period, Period.query.get_current(self.committee))
+
+    def test_by_date_returns_all_periods_containing_date(self):
+        period = create(Builder('period').having(committee=self.committee,
+                                                 date_from=date(2010, 4, 1),
+                                                 date_to=date(2010, 8, 31)))
+        self.assertItemsEqual([self.period, period],
+                              Period.query.by_date(date(2010, 5, 1)).all())
+
+        self.assertItemsEqual([self.period],
+                              Period.query.by_date(date(2010, 1, 1)).all())
+
+    def test_get_for_meeting_filters_for_correct_committee(self):
+        committee_2 = create(Builder('committee_model').having(int_id=123))
+        create(Builder('period').having(committee=committee_2,
+                                        date_from=date(2010, 1, 1),
+                                        date_to=date(2010, 12, 31)))
+
+        meeting = create(Builder('meeting').having(
+            committee=self.committee,
+            start=localized_datetime(2010, 4, 1)))
+        self.assertEqual(self.period, Period.query.get_for_meeting(meeting))
+
+    def test_get_for_meeting_filters_for_correct_date(self):
+        create(Builder('period').having(committee=self.committee,
+                                        date_from=date(2011, 1, 1),
+                                        date_to=date(2011, 12, 31)))
+
+        meeting = create(Builder('meeting').having(
+            committee=self.committee,
+            start=localized_datetime(2010, 4, 1)))
+        self.assertEqual(self.period, Period.query.get_for_meeting(meeting))
+
+    def test_get_for_meeting_returns_active_period_if_possible(self):
+        closed_period = create(Builder('period').having(
+            workflow_state='closed',
+            committee=self.committee,
+            date_from=date(2010, 6, 1),
+            date_to=date(2011, 12, 31)))
+        meeting = create(Builder('meeting').having(
+            committee=self.committee,
+            start=localized_datetime(2010, 8, 1)))
+        # Both periods match the date and committee of the meeting, but only
+        # on is active
+        self.assertEqual(self.period, Period.query.get_for_meeting(meeting))
+
+        # Only the closed period matches the meeting date
+        meeting.start = localized_datetime(2011, 8, 1)
+        self.assertEqual(closed_period, Period.query.get_for_meeting(meeting))


### PR DESCRIPTION
We were displaying the year of the current period as prefix to the agendaitem decision numbers. Instead we now the title of the period matching the date of the meeting as prefix. 

This is a bit better, but ultimately we should make sure that each meeting gets assigned to a given period as soon as the decision numbers and meeting numbers are generated (when the meeting is held), as these depend on the period. This will be tackled separately though (see https://github.com/4teamwork/opengever.core/issues/5200)

I also modified the displayed meeting number, as this should also depend on the period (and until now we simply displayed the year of the meeting...).

**meeting display if there is a period matching the committee and date of the meeting**

<img width="1381" alt="Screen Shot 2019-06-03 at 15 59 31" src="https://user-images.githubusercontent.com/7374243/58860594-c3dc4380-86ac-11e9-95e6-a9b3005f15a9.png">

**meeting display if there is no period matching the committee and date of the meeting**

<img width="1382" alt="Screen Shot 2019-06-03 at 16 00 14" src="https://user-images.githubusercontent.com/7374243/58860670-eff7c480-86ac-11e9-8c20-889790e5cc14.png">


resolves #5695