### PR TITLE
Add pull request/review checklist.

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,31 @@
+_PR-Beschreibung: muss alle notwendigen Informationen enthalten, so dass ein Aussenstehender die Änderung versteht ohne den Code anzuschauen_
+
+- _Grund, wieso diese Änderung notwendig ist_
+- _Was das Ziel dieser Änderung ist_
+- _Wie die Änderung erreicht wird (z.B. Design-Entscheide)_
+- _Der Autor soll im PR Body die Änderung anpreisen und verkaufen_
+
+_Screenshot: erwünscht, sollen aber immer nur unterstützend eingesetzt werden._
+
+_Link zum Issue: `closes` oder `fixes` keyword verwenden._
+
+
+## Checkliste
+
+_Zutreffendes soll angehakt stehengelassen werden._
+
+- [ ] Gibt es neue Funktionalität mit einem `Dokument`? Funktioniert das auch mit einem `Mail`?
+- [ ] Wurde etwas an der `Aufgabe` angepasst? Funktioniert das auch mit einer `Weiterleitung`?
+- [ ] Profil angepasst? Sind UpgradeSteps vorhanden/nötig?:
+- [ ] Sind UpgradeSteps `deferrable`, oder können gewisse Schritte des Upgrades konditional ausgeführt werden?
+- [ ] Gibts es eine DB-Schema Migration?
+  - [ ] Wurde alle Columns/Änderungen aus dem Modell in einer DB-Schema Migration nachgeführt.
+  - [ ] Sind Constraint-Namen maximal 30 Zeichen lang (`Oracle`)?
+- [ ] Gibt es ein neues Feature-Flag? Wurden dafür Tests mit aktiviertem und deaktivierte Flag geschrieben?
+- [ ] Könnten Kundeninstallationen von den Änderungen betroffen sein? Müssen Policies angepasst werden?
+- [ ] Gibt es neue Übersetzungen?
+  - [ ] Sind alle msg-Strings in Übersetzungen Unicode?
+  - [ ] Wird die richtige i18n-domain verwendet (Copy-Paste Fehler sind hier häufig)?
+- [ ] Wenn bei Schema-definitionen `missing_value` spezifiziert ist muss immer auch `default` auf den gleichen Wert gesetzt werden
+- [ ] Changelog-Eintrag vorhanden/nötig?
+- [ ] Aktualisierung Dokumentation vorhanden/nötig?


### PR DESCRIPTION
We would like to make the existing pull-request checklist more visible. In our opinion the best way to do this at the moment is by creating a pull-request template for github.

We move the existing pull request checklist from the wiki (currently at https://github.com/4teamwork/opengever.core/wiki/Prozess:-PullRequest-Review-Checkliste, will be removed once merged) and enrich it with https://basecamp.com/2768704/projects/9430593/todos/320310258. I've chosen the `.github` folder as that seems to be the convention adopted by other projects, e.g. https://github.com/4teamwork/ris.

I have compressed the list a bit, so we can start with something "simple". If there is an important point i forgot please let me know.