### PR TITLE
Revert "Split search terms at non-alphanumeric characters" #4895

### DIFF
--- a/solr-conf/managed-schema
+++ b/solr-conf/managed-schema
@@ -277,16 +277,6 @@
         <tokenizer class="solr.WhitespaceTokenizerFactory"/>
         <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" />
-        <filter class="solr.WordDelimiterGraphFilterFactory"
-              splitOnCaseChange="0"
-              splitOnNumerics="0"
-              stemEnglishPossessive="0"
-              generateWordParts="1"
-              generateNumberParts="1"
-              catenateWords="0"
-              catenateNumbers="0"
-              catenateAll="0"
-              preserveOriginal="1"/>
         <filter class="solr.LowerCaseFilterFactory"/>
       </analyzer>
     </fieldType>


### PR DESCRIPTION
This reverts commit 0c12bfda739d4c79240dc1a22e749a24866ba182.

The change has negative side effects to other searches, for example on short query strings containing `-` like `m-039` or something similar. See https://extranet.4teamwork.ch/support/gever-st-gallen/tracker/612#rb49671ef for a further description.