### PR TITLE
Avoid certain test classes being run multiple times.

### DIFF
--- a/bin/mtest
+++ b/bin/mtest
@@ -251,7 +251,10 @@ def run_tests(test_run_params):
 
     for testclass in testclasses:
         params.append('-t')
-        params.append(testclass)
+        # we include the parenthesis in the classname here, this
+        # essentially leads to exact matching being done later on
+        # when we use the classname to run the tests for that class
+        params.append("\\(" + testclass + "\\)")
 
     printable_params = ' '.join(["'{}'".format(param) if ' ' in param else param for param in params])
 


### PR DESCRIPTION
When the name of a test class TC1 is contained in the name of another test class TC2 from the same python file, the tests for TC1 are potentially run more than once by mtest (as TC1 is also matched when we try to run the test TC2). As matching of the search patterns is done on strings of the form 'testname (test.class.qualified.name)', we can do exact matching if we include the parenthesis in our search patterns.