### PR TITLE
Support searching on group description in sharing form.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2019.3.0 (unreleased)
 ---------------------
 
+- Support searching on group description in sharing form. [phgross]
 - Add CMFEditions modifier that prevents journals from being versioned. [lgraf]
 - Forbid transitions linked to dossier offer process through RESTAPI. [njohner]
 - Only allow dossier transitions that are possible on the main dossier. [njohner]

--- a/opengever/sharing/browser/resources/sharing.js
+++ b/opengever/sharing/browser/resources/sharing.js
@@ -9,6 +9,7 @@ var sharingApp = {
     principal_search: null,
     isEditable: false,
     isSaving: false,
+    isSearching: false,
   },
 
   beforeMount: function () {
@@ -95,6 +96,8 @@ var sharingApp = {
     },
 
     search: function() {
+      this.isSearching = true;
+
       // make sure IE 11 does not cache the fetch request
       var params = { _t: Date.now().toString(), search: this.principal_search };
       if (this.isEditable === false){
@@ -113,6 +116,7 @@ var sharingApp = {
           }));
         this.inherit = response.data['inherit'];
 
+        this.isSearching = false;
       }.bind(this));
     },
 

--- a/opengever/sharing/browser/templates/sharing.html
+++ b/opengever/sharing/browser/templates/sharing.html
@@ -4,7 +4,7 @@
     <form @submit.prevent="search" class="search-form" v-if="isEditable">
       <input type="text" class="search_box" v-model="principal_search"
              :placeholder="i18n.principal_search_placeholder" />
-      <a class="button" @click="search">{{i18n.label_search}}</a>
+      <a class="button" :class="{ loading: isSearching }" @click="search">{{i18n.label_search}}</a>
     </form>
 
     <table class="sharing-table listing">


### PR DESCRIPTION
_Harvest: `[3.2.2.1] OneGov GEVER` - `CR 2019.3 SG`_

If the `group_title_ldap_attribute` is configured, we also search that field. This makes sense because thats the value which is visible and displayed as group title. See https://extranet.4teamwork.ch/support/gever-st-gallen/tracker/762

Besides that I also added a spinner, similar to the save button, which is shown when searching for a principal,  to give the user feedback when the search request takes some time.

