### PR TITLE
Do not sync deadline modifications to forwarding predecessors.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 
 - Add CMFEditions modifier that prevents journals from being versioned. [lgraf]
 - Forbid transitions linked to dossier offer process through RESTAPI. [njohner]
+- Do not sync deadline modifications to forwarding predecessors. [phgross]
 - Only allow dossier transitions that are possible on the main dossier. [njohner]
 - Prefix agendaitem decision numbers and meeting number by correct period title. [njohner]
 - Handle dossier activation through RESTAPI. [njohner]

--- a/opengever/task/response_syncer/deadline.py
+++ b/opengever/task/response_syncer/deadline.py
@@ -19,6 +19,15 @@ class ModifyDeadlineResponseSyncerSender(BaseResponseSyncerSender):
         kwargs['new_deadline'] = kwargs['new_deadline'].toordinal()
         super(ModifyDeadlineResponseSyncerSender, self).extend_payload(payload, task, **kwargs)
 
+    def get_related_tasks_to_sync(self, transition=''):
+        """Skip forwarding predecessors. Forwarding predecessors are already
+        closed and stored in the yearfolder, and should not be changed.
+        """
+
+        tasks = super(ModifyDeadlineResponseSyncerSender, self).get_related_tasks_to_sync(
+            transition=transition)
+        return [task for task in tasks if not task.is_forwarding]
+
 
 class ModifyDeadlineResponseSyncerReceiver(BaseResponseSyncerReceiver):
     """This view receives a sync-task-modify-deadline-response request from another


### PR DESCRIPTION
Skip forwarding predecessors. Forwarding predecessors are already closed and stored in the yearfolder, and should not longer be changed.

Fixes #5710

Needs backport to `2019.2`