### PR TITLE
Translate keyword-filter label.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2019.3.0 (unreleased)
 ---------------------
 
+- Translate keyword-filter label. [phgross]
 - Support searching on group description in sharing form. [phgross]
 - Add CMFEditions modifier that prevents journals from being versioned. [lgraf]
 - Forbid transitions linked to dossier offer process through RESTAPI. [njohner]

--- a/opengever/tabbedview/browser/generic_with_bumblebee_viewchooser.pt
+++ b/opengever/tabbedview/browser/generic_with_bumblebee_viewchooser.pt
@@ -88,7 +88,7 @@
       </tal:cond>
       <tal:subjectFilter tal:define="widget view/render_subject_filter_widget" tal:condition="widget">
         <span tal:condition="view/filterlist_available">|</span>
-        <span>Schlagworte</span>
+        <span i18n:domain="opengever.tabbedview" i18n:translate="label_keywords">Keywords</span>
         <tal:subjectFilterWidget replace="structure widget" />
       </tal:subjectFilter>
       <p id="message_no_contents"

--- a/opengever/tabbedview/browser/generic_with_filters.pt
+++ b/opengever/tabbedview/browser/generic_with_filters.pt
@@ -71,7 +71,7 @@
       </tal:cond>
       <tal:subjectFilter tal:define="widget view/render_subject_filter_widget" tal:condition="widget">
         <span>|</span>
-        <span>Schlagworte</span>
+        <span i18n:domain="opengever.tabbedview" i18n:translate="label_keywords">Keywords</span>
         <tal:subjectFilterWidget replace="structure widget" />
       </tal:subjectFilter>
       <p id="message_no_contents"

--- a/opengever/tabbedview/browser/selection_with_filters.pt
+++ b/opengever/tabbedview/browser/selection_with_filters.pt
@@ -30,7 +30,7 @@
     </tal:condition>
     <tal:subjectFilter tal:define="widget view/render_subject_filter_widget" tal:condition="widget">
         <span>|</span>
-        <span>Schlagworte</span>
+        <span i18n:domain="opengever.tabbedview" i18n:translate="label_keywords">Keywords</span>
         <tal:subjectFilterWidget replace="structure widget" />
     </tal:subjectFilter>
 </div>

--- a/opengever/tabbedview/locales/de/LC_MESSAGES/opengever.tabbedview.po
+++ b/opengever/tabbedview/locales/de/LC_MESSAGES/opengever.tabbedview.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2019-03-07 18:16+0000\n"
+"POT-Creation-Date: 2019-06-07 11:47+0000\n"
 "PO-Revision-Date: 2012-11-22 14:19+0100\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -39,6 +39,7 @@ msgstr "Treffer pro Seite"
 msgid "Show all in this Folder"
 msgstr "Alle in diesem Ordner anzeigen"
 
+#: ./opengever/tabbedview/browser/generic_with_bumblebee_viewchooser.pt
 #: ./opengever/tabbedview/browser/generic_with_filters.pt
 #: ./opengever/tabbedview/browser/selection_with_filters.pt
 msgid "State"
@@ -257,6 +258,8 @@ msgid "label_issuer"
 msgstr "Auftraggeber"
 
 #. Default: "Keywords"
+#: ./opengever/tabbedview/browser/generic_with_bumblebee_viewchooser.pt
+#: ./opengever/tabbedview/browser/generic_with_filters.pt
 #: ./opengever/tabbedview/browser/tabs.py
 msgid "label_keywords"
 msgstr "Schlagwörter"
@@ -277,6 +280,7 @@ msgid "label_my_proposals"
 msgstr "Meine Anträge"
 
 #. Default: "Pending"
+#: ./opengever/tabbedview/browser/personal_overview.py
 #: ./opengever/tabbedview/browser/tasklisting.py
 msgid "label_pending"
 msgstr "Pendent"
@@ -326,9 +330,9 @@ msgstr "Beginn"
 msgid "label_subdossier"
 msgstr "Subdossier"
 
+#: ./opengever/tabbedview/browser/personal_overview.py
 #: ./opengever/tabbedview/browser/tabs.py
 #: ./opengever/tabbedview/browser/tasklisting.py
-#: ./opengever/tabbedview/browser/users.py
 msgid "label_tabbedview_filter_all"
 msgstr "Alle"
 

--- a/opengever/tabbedview/locales/fr/LC_MESSAGES/opengever.tabbedview.po
+++ b/opengever/tabbedview/locales/fr/LC_MESSAGES/opengever.tabbedview.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-03-07 18:16+0000\n"
+"POT-Creation-Date: 2019-06-07 11:47+0000\n"
 "PO-Revision-Date: 2017-12-03 09:48+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-tabbedview/fr/>\n"
@@ -40,6 +40,7 @@ msgstr "Résultats par page"
 msgid "Show all in this Folder"
 msgstr "Tout afficher dans ce classeur"
 
+#: ./opengever/tabbedview/browser/generic_with_bumblebee_viewchooser.pt
 #: ./opengever/tabbedview/browser/generic_with_filters.pt
 #: ./opengever/tabbedview/browser/selection_with_filters.pt
 msgid "State"
@@ -251,6 +252,8 @@ msgid "label_issuer"
 msgstr "Mandant"
 
 #. Default: "Keywords"
+#: ./opengever/tabbedview/browser/generic_with_bumblebee_viewchooser.pt
+#: ./opengever/tabbedview/browser/generic_with_filters.pt
 #: ./opengever/tabbedview/browser/tabs.py
 msgid "label_keywords"
 msgstr "Mots-clés"
@@ -271,6 +274,7 @@ msgid "label_my_proposals"
 msgstr "Mes requêtes"
 
 #. Default: "Pending"
+#: ./opengever/tabbedview/browser/personal_overview.py
 #: ./opengever/tabbedview/browser/tasklisting.py
 msgid "label_pending"
 msgstr "En suspens"
@@ -320,9 +324,9 @@ msgstr "Début"
 msgid "label_subdossier"
 msgstr "Sous-dossier"
 
+#: ./opengever/tabbedview/browser/personal_overview.py
 #: ./opengever/tabbedview/browser/tabs.py
 #: ./opengever/tabbedview/browser/tasklisting.py
-#: ./opengever/tabbedview/browser/users.py
 msgid "label_tabbedview_filter_all"
 msgstr "Tous"
 

--- a/opengever/tabbedview/locales/opengever.tabbedview.pot
+++ b/opengever/tabbedview/locales/opengever.tabbedview.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2019-03-07 18:16+0000\n"
+"POT-Creation-Date: 2019-06-07 11:47+0000\n"
 "PO-Revision-Date: 2009-02-25 14:39+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -39,6 +39,7 @@ msgstr ""
 msgid "Show all in this Folder"
 msgstr ""
 
+#: ./opengever/tabbedview/browser/generic_with_bumblebee_viewchooser.pt
 #: ./opengever/tabbedview/browser/generic_with_filters.pt
 #: ./opengever/tabbedview/browser/selection_with_filters.pt
 msgid "State"
@@ -250,6 +251,8 @@ msgid "label_issuer"
 msgstr ""
 
 #. Default: "Keywords"
+#: ./opengever/tabbedview/browser/generic_with_bumblebee_viewchooser.pt
+#: ./opengever/tabbedview/browser/generic_with_filters.pt
 #: ./opengever/tabbedview/browser/tabs.py
 msgid "label_keywords"
 msgstr ""
@@ -270,6 +273,7 @@ msgid "label_my_proposals"
 msgstr ""
 
 #. Default: "Pending"
+#: ./opengever/tabbedview/browser/personal_overview.py
 #: ./opengever/tabbedview/browser/tasklisting.py
 msgid "label_pending"
 msgstr ""
@@ -319,9 +323,9 @@ msgstr ""
 msgid "label_subdossier"
 msgstr ""
 
+#: ./opengever/tabbedview/browser/personal_overview.py
 #: ./opengever/tabbedview/browser/tabs.py
 #: ./opengever/tabbedview/browser/tasklisting.py
-#: ./opengever/tabbedview/browser/users.py
 msgid "label_tabbedview_filter_all"
 msgstr ""
 


### PR DESCRIPTION
The label of the keyword-filter has not been implemented as a translatable label, and also another name was used for it (`Schlagworte` instead of `Schlagwörter`).

Before:
![Bildschirmfoto 2019-06-07 um 13 52 21](https://user-images.githubusercontent.com/485755/59102550-b6cd8780-892c-11e9-9aa2-aa201035f21d.png)
After:
![Bildschirmfoto 2019-06-07 um 13 52 00](https://user-images.githubusercontent.com/485755/59102551-b6cd8780-892c-11e9-91e9-dfdd0fc0fa8a.png)


See https://extranet.4teamwork.ch/support/gemeinde-koeniz/tracker/163