### PR TITLE
Add an ftw.tesbrowser widget for filling responsible(s) in the tests

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -10,6 +10,7 @@ Changelog
 - Support searching on group description in sharing form. [phgross]
 - Add CMFEditions modifier that prevents journals from being versioned. [lgraf]
 - Forbid transitions linked to dossier offer process through RESTAPI. [njohner]
+- Add an ftw.tesbrowser widget for filling responsible(s) in the tests. [Rotonen]
 - Only allow dossier transitions that are possible on the main dossier. [njohner]
 - Prefix agendaitem decision numbers and meeting number by correct period title. [njohner]
 - Handle dossier activation through RESTAPI. [njohner]

--- a/opengever/activity/tests/test_mail.py
+++ b/opengever/activity/tests/test_mail.py
@@ -44,13 +44,11 @@ class TestEmailNotification(IntegrationTestCase):
         browser.fill({'Title': 'Test Task', 'Task Type': 'comment'})
         if description is not None:
             browser.fill({"Text": description})
-        # XXX - we cannot yet fixturize SQL objects so we have to hardcode here
-        org_unit_id = u'fa'
         form = browser.find_form_by_field('Responsible')
-        responsible_id = u':'.join((org_unit_id, self.regular_user.id, ))
-        form.find_widget('Responsible').fill(responsible_id)
+        form.find_widget('Responsible').fill(self.regular_user)
         if inbox:
             # XXX - How to get the correct id from the fixtured objects?
+            org_unit_id = u'fa'
             inbox_id = u':'.join(('inbox', org_unit_id, ))
             form.find_widget('Issuer').fill(inbox_id)
         browser.css('#form-buttons-save').first.click()
@@ -116,9 +114,8 @@ class TestEmailNotification(IntegrationTestCase):
         task = self.dossier.objectValues()[-1]
         data = {'form.widgets.transition': 'task-transition-reassign'}
         browser.open(task, data, view='assign-task')
-        responsible = 'fa:{}'.format(self.secretariat_user.getId())
         form = browser.find_form_by_field('Responsible')
-        form.find_widget('Responsible').fill(responsible)
+        form.find_widget('Responsible').fill(self.secretariat_user)
         browser.click_on('Assign')
         process_mail_queue()
 

--- a/opengever/activity/tests/test_plone_center.py
+++ b/opengever/activity/tests/test_plone_center.py
@@ -109,7 +109,7 @@ class TestNotifactionCenterErrorHandling(FunctionalTestCase):
                       'Task Type': 'comment'})
 
         form = browser.find_form_by_field('Responsible')
-        form.find_widget('Responsible').fill('org-unit-1:hugo.boss')
+        form.find_widget('Responsible').fill('hugo.boss')
         form.find_widget('Issuer').fill(TEST_USER_ID)
 
         browser.css('#form-buttons-save').first.click()

--- a/opengever/advancedsearch/tests/test_search.py
+++ b/opengever/advancedsearch/tests/test_search.py
@@ -243,7 +243,7 @@ class TestQueryStrings(IntegrationTestCase):
                       'form.widgets.dossier_review_state:list': 'dossier-state-active'})
 
         form = browser.find_form_by_field('Responsible')
-        form.find_widget('Responsible').fill(self.regular_user.id)
+        form.find_widget('Responsible').fill(self.regular_user, auto_org_unit=False)
         browser.css('#form-buttons-button_search').first.click()
 
         self.assertBrowserUrlContainsSearchParams(browser, [

--- a/opengever/base/tests/test_indexers.py
+++ b/opengever/base/tests/test_indexers.py
@@ -115,7 +115,7 @@ class TestHasSameTypeChildren(IntegrationTestCase):
                       'Task Type': 'direct-execution'})
         form = browser.find_form_by_field('Issuer')
         form.find_widget('Issuer').fill(self.regular_user.id)
-        form.find_widget('Responsible').fill('fa:' + self.regular_user.id)
+        form.find_widget('Responsible').fill(self.regular_user)
         browser.click_on('Save')
 
         self.assert_metadata_value(True, 'has_sametype_children',

--- a/opengever/inbox/tests/test_activities.py
+++ b/opengever/inbox/tests/test_activities.py
@@ -148,8 +148,7 @@ class TestForwardingReassignActivity(FunctionalTestCase):
         browser.fill({'Response': u'Peter k\xf6nntest du das \xfcbernehmen.'})
 
         form = browser.find_form_by_field('Responsible')
-        form.find_widget('Responsible').fill(
-            self.org_unit.id() + ':' + responsible)
+        form.find_widget('Responsible').fill(responsible)
 
         browser.find('Assign').click()
 

--- a/opengever/inbox/tests/test_workflow.py
+++ b/opengever/inbox/tests/test_workflow.py
@@ -177,7 +177,7 @@ class TestInboxWorkflow(IntegrationTestCase):
         browser.open(self.inbox_forwarding)
         browser.click_on('forwarding-transition-reassign')
         form = browser.find_form_by_field('Responsible')
-        form.find_widget('Responsible').fill('fa:{}'.format(self.secretariat_user.getId()))
+        form.find_widget('Responsible').fill(self.secretariat_user)
         browser.click_on('Assign')
 
         assignment_manager = RoleAssignmentManager(self.inbox_forwarding)
@@ -213,7 +213,7 @@ class TestInboxWorkflow(IntegrationTestCase):
         browser.open(self.inbox_forwarding)
         browser.click_on('forwarding-transition-reassign')
         form = browser.find_form_by_field('Responsible')
-        form.find_widget('Responsible').fill('fa:{}'.format(self.meeting_user.getId()))
+        form.find_widget('Responsible').fill(self.meeting_user)
         browser.click_on('Assign')
 
         self.assertNotIn("user:{}".format(self.regular_user),

--- a/opengever/latex/tests/test_dossiertasks.py
+++ b/opengever/latex/tests/test_dossiertasks.py
@@ -127,7 +127,7 @@ class TestDossierTasksLaTeXView(FunctionalTestCase):
                       'Task Type': 'To comment'})
 
         form = browser.find_form_by_field('Responsible')
-        form.find_widget('Responsible').fill(self.get_org_unit().id() + ':' + TEST_USER_ID)
+        form.find_widget('Responsible').fill(TEST_USER_ID)
         browser.find('Save').click()
 
         browser.open('http://nohost/plone/repository/dossier-1/task-1')

--- a/opengever/task/tests/test_activities.py
+++ b/opengever/task/tests/test_activities.py
@@ -49,7 +49,7 @@ class TestTaskActivites(FunctionalTestCase):
                       'Text': 'Lorem ipsum'})
 
         form = browser.find_form_by_field('Responsible')
-        form.find_widget('Responsible').fill(self.org_unit.id() + ':hugo.boss')
+        form.find_widget('Responsible').fill('hugo.boss')
 
         browser.css('#form-buttons-save').first.click()
 
@@ -83,7 +83,7 @@ class TestTaskActivites(FunctionalTestCase):
                       'Text': 'Lorem ipsum'})
 
         form = browser.find_form_by_field('Responsible')
-        form.find_widget('Responsible').fill(self.org_unit.id() + ':hugo.boss')
+        form.find_widget('Responsible').fill('hugo.boss')
 
         browser.css('#form-buttons-save').first.click()
 
@@ -98,7 +98,7 @@ class TestTaskActivites(FunctionalTestCase):
                       'Text': 'Lorem ipsum'})
 
         form = browser.find_form_by_field('Responsible')
-        form.find_widget('Responsible').fill(self.org_unit.id() + ':hugo.boss')
+        form.find_widget('Responsible').fill('hugo.boss')
         browser.css('#form-buttons-save').first.click()
 
         center = notification_center()
@@ -268,8 +268,7 @@ class TestTaskActivites(FunctionalTestCase):
                       'Text': 'Lorem ipsum'})
 
         form = browser.find_form_by_field('Responsible')
-        form.find_widget('Responsible').fill(
-            self.org_unit.id() + ':hugo.boss')
+        form.find_widget('Responsible').fill('hugo.boss')
         form.find_widget('Issuer').fill(u'hugo.boss')
 
         browser.css('#form-buttons-save').first.click()
@@ -342,7 +341,7 @@ class TestTaskReassignActivity(IntegrationTestCase):
             browser.css('#workflow-transition-task-transition-reassign').first.click()
             browser.fill({'Response': response})
             form = browser.find_form_by_field('Responsible')
-            form.find_widget('Responsible').fill('fa:' + responsible.getId())
+            form.find_widget('Responsible').fill(responsible)
             browser.css('#form-buttons-save').first.click()
 
     @browsing

--- a/opengever/task/tests/test_assign.py
+++ b/opengever/task/tests/test_assign.py
@@ -24,9 +24,7 @@ class TestAssignTask(IntegrationTestCase):
     @browsing
     def test_do_nothing_when_responsible_has_not_changed(self, browser):
         self.login(self.regular_user, browser=browser)
-
-        responsible = 'fa:{}'.format(self.regular_user.getId())
-        self.assign_task(responsible, u'Thats a job for you.')
+        self.assign_task(self.regular_user, u'Thats a job for you.')
 
         self.assertEquals(self.task.absolute_url(), browser.url.strip('/'))
         self.assertEquals(['No changes: same responsible selected'],
@@ -62,9 +60,7 @@ class TestAssignTask(IntegrationTestCase):
     @browsing
     def test_updates_responsible(self, browser):
         self.login(self.regular_user, browser=browser)
-
-        responsible = 'fa:{}'.format(self.secretariat_user.getId())
-        self.assign_task(responsible, u'Thats a job for you.')
+        self.assign_task(self.secretariat_user, u'Thats a job for you.')
 
         self.assertEquals(self.secretariat_user.getId(),
                           self.task.responsible)
@@ -83,17 +79,13 @@ class TestAssignTask(IntegrationTestCase):
 
         self.assertIsNotNone(task_reminder.get_reminder(self.task))
 
-        responsible = 'fa:{}'.format(self.secretariat_user.getId())
-        self.assign_task(responsible, u'Thats a job for you.')
-
+        self.assign_task(self.secretariat_user, u'Thats a job for you.')
         self.assertIsNone(task_reminder.get_reminder(self.task))
 
     @browsing
     def test_adds_an_corresponding_response(self, browser):
         self.login(self.regular_user, browser=browser)
-
-        responsible = 'fa:{}'.format(self.secretariat_user.getId())
-        self.assign_task(responsible, u'Please make that for me.')
+        self.assign_task(self.secretariat_user, u'Please make that for me.')
 
         response = IResponseContainer(self.task)[-1]
         self.assertEquals(
@@ -116,8 +108,7 @@ class TestAssignTask(IntegrationTestCase):
                .having(firstname=u'Johnny', lastname=u'English')
                .assign_to_org_units([org_unit]))
 
-        responsible = u'gdgs:johnny.english'
-        self.assign_task(responsible, u'Please make that for me.')
+        self.assign_task(u'gdgs:johnny.english', u'Please make that for me.')
 
         self.assertEquals('johnny.english', self.task.responsible)
         self.assertEquals('gdgs', self.task.responsible_client)
@@ -133,8 +124,7 @@ class TestAssignTask(IntegrationTestCase):
                .having(firstname=u'Johnny', lastname=u'English')
                .assign_to_org_units([org_unit]))
 
-        responsible = u'gdgs:johnny.english'
-        self.assign_task(responsible, u'Please make that for me.')
+        self.assign_task(u'gdgs:johnny.english', u'Please make that for me.')
 
         self.assertEquals(
             [u'Admin unit changes are not allowed if the task or forwarding is'
@@ -168,8 +158,7 @@ class TestAssignTask(IntegrationTestCase):
         register_event_recorder(IObjectModifiedEvent)
 
         self.login(self.regular_user, browser=browser)
-        responsible = 'fa:{}'.format(self.secretariat_user.getId())
-        self.assign_task(responsible, u'Thats a job for you.')
+        self.assign_task(self.secretariat_user, u'Thats a job for you.')
 
         events = get_recorded_events()
 
@@ -180,8 +169,7 @@ class TestAssignTask(IntegrationTestCase):
     def test_revokes_permission_for_former_responsible(self, browser):
         self.login(self.regular_user, browser=browser)
 
-        responsible = 'fa:{}'.format(self.secretariat_user.getId())
-        self.assign_task(responsible, u'Thats a job for you.')
+        self.assign_task(self.secretariat_user, u'Thats a job for you.')
 
         manager = RoleAssignmentManager(self.task)
         self.assertEqual(
@@ -200,8 +188,7 @@ class TestAssignTask(IntegrationTestCase):
         self.login(self.regular_user, browser=browser)
 
         api.content.disable_roles_acquisition(obj=self.dossier)
-        responsible = 'fa:{}'.format(self.secretariat_user.getId())
-        self.assign_task(responsible, u'Thats a job for you.')
+        self.assign_task(self.secretariat_user, u'Thats a job for you.')
 
         manager = RoleAssignmentManager(self.task)
         self.assertEqual(
@@ -249,8 +236,7 @@ class TestAssignTaskWithSuccessors(IntegrationTestCase):
         browser.find('task-transition-reassign').click()
         browser.fill({'Response': u'Bitte \xfcbernehmen Sie, Danke!'})
         form = browser.find_form_by_field('Responsible')
-        form.find_widget('Responsible').fill(
-            'fa:{}'.format(self.secretariat_user.getId()))
+        form.find_widget('Responsible').fill(self.secretariat_user)
         browser.find('Assign').click()
 
         browser.open(self.task, view='tabbedview_view-overview')
@@ -270,8 +256,7 @@ class TestAssignTaskWithSuccessors(IntegrationTestCase):
         browser.find('task-transition-reassign').click()
         browser.fill({'Response': u'Bitte \xfcbernehmen Sie, Danke!'})
         form = browser.find_form_by_field('Responsible')
-        form.find_widget('Responsible').fill(
-            'fa:{}'.format(self.secretariat_user.getId()))
+        form.find_widget('Responsible').fill(self.secretariat_user)
         browser.find('Assign').click()
 
         browser.open(self.successor, view='tabbedview_view-overview')
@@ -291,8 +276,7 @@ class TestAssignTaskWithSuccessors(IntegrationTestCase):
         browser.find('task-transition-reassign').click()
         browser.fill({'Response': u'Bitte \xfcbernehmen Sie, Danke!'})
         form = browser.find_form_by_field('Responsible')
-        form.find_widget('Responsible').fill(
-            'fa:{}'.format(self.secretariat_user.getId()))
+        form.find_widget('Responsible').fill(self.secretariat_user)
         browser.find('Assign').click()
 
         manager = RoleAssignmentManager(self.task)
@@ -315,8 +299,7 @@ class TestAssignTaskWithSuccessors(IntegrationTestCase):
         browser.find('task-transition-reassign').click()
         browser.fill({'Response': u'Bitte \xfcbernehmen Sie, Danke!'})
         form = browser.find_form_by_field('Responsible')
-        form.find_widget('Responsible').fill(
-            'fa:{}'.format(self.secretariat_user.getId()))
+        form.find_widget('Responsible').fill(self.secretariat_user)
         browser.find('Assign').click()
 
         manager = RoleAssignmentManager(self.successor)

--- a/opengever/task/tests/test_assign_to_dossier.py
+++ b/opengever/task/tests/test_assign_to_dossier.py
@@ -60,7 +60,7 @@ class TestAssignForwardignToDossier(FunctionalTestCase):
                       'Issuer': 'inbox:org-unit-1'})
 
         form = browser.find_form_by_field('Responsible')
-        form.find_widget('Responsible').fill('org-unit-1:' + TEST_USER_ID)
+        form.find_widget('Responsible').fill(TEST_USER_ID)
 
         browser.css('#form-buttons-save').first.click()
 
@@ -105,7 +105,7 @@ class TestAssignForwardignToDossier(FunctionalTestCase):
                       'Issuer': 'inbox:org-unit-1'})
 
         form = browser.find_form_by_field('Responsible')
-        form.find_widget('Responsible').fill('org-unit-1:' + TEST_USER_ID)
+        form.find_widget('Responsible').fill(TEST_USER_ID)
 
         browser.css('#form-buttons-save').first.click()
 

--- a/opengever/task/tests/test_delegate.py
+++ b/opengever/task/tests/test_delegate.py
@@ -39,7 +39,7 @@ class TestDelegateTaskForm(IntegrationTestCase):
 
         # step 1
         form = browser.find_form_by_field('Responsibles')
-        form.find_widget('Responsibles').fill('fa:robert.ziegler')
+        form.find_widget('Responsibles').fill(self.dossier_responsible)
         browser.css('#form-buttons-save').first.click()
 
         # step 2
@@ -61,7 +61,7 @@ class TestDelegateTaskForm(IntegrationTestCase):
         browser.open(self.task, view='delegate_recipients')
 
         form = browser.find_form_by_field('Responsibles')
-        form.find_widget('Responsibles').fill('fa:robert.ziegler')
+        form.find_widget('Responsibles').fill(self.dossier_responsible)
         browser.css('#form-buttons-save').first.click()
 
         self.assertEqual(

--- a/opengever/task/tests/test_forms.py
+++ b/opengever/task/tests/test_forms.py
@@ -58,7 +58,7 @@ class TestTaskEditForm(IntegrationTestCase):
         browser.open(self.task, view='edit')
 
         form = browser.find_form_by_field('Responsible')
-        form.find_widget('Responsible').fill('fa:{}'.format(self.secretariat_user.id))
+        form.find_widget('Responsible').fill(self.secretariat_user)
         browser.find('Save').click()
 
         browser.open(self.task, view='tabbedview_view-overview')
@@ -83,7 +83,7 @@ class TestTaskEditForm(IntegrationTestCase):
 
         browser.open(self.task, view='edit')
         form = browser.find_form_by_field('Responsible')
-        form.find_widget('Responsible').fill('fa:{}'.format(self.secretariat_user.id))
+        form.find_widget('Responsible').fill(self.secretariat_user.id)
         browser.find('Save').click()
 
         activity = Activity.query.order_by(Activity.created.desc()).first()
@@ -103,7 +103,7 @@ class TestTaskEditForm(IntegrationTestCase):
         browser.open(self.task, view='edit')
 
         form = browser.find_form_by_field('Responsible')
-        form.find_widget('Responsible').fill('fa:{}'.format(self.secretariat_user.id))
+        form.find_widget('Responsible').fill(self.secretariat_user.id)
         browser.find('Save').click()
 
         events = get_recorded_events()

--- a/opengever/task/tests/test_localroles.py
+++ b/opengever/task/tests/test_localroles.py
@@ -258,7 +258,7 @@ class TestLocalRolesRevoking(IntegrationTestCase):
         browser.open(self.task, view='tabbedview_view-overview')
         browser.click_on('task-transition-reassign')
         form = browser.find_form_by_field('Responsible')
-        form.find_widget('Responsible').fill('fa:{}'.format(self.secretariat_user.id))
+        form.find_widget('Responsible').fill(self.secretariat_user)
         browser.fill({'Response': 'For you'})
         browser.click_on('Assign')
 
@@ -289,7 +289,7 @@ class TestLocalRolesRevoking(IntegrationTestCase):
         browser.open(self.task, view='tabbedview_view-overview')
         browser.click_on('task-transition-reassign')
         form = browser.find_form_by_field('Responsible')
-        form.find_widget('Responsible').fill('fa:{}'.format(self.secretariat_user.id))
+        form.find_widget('Responsible').fill(self.secretariat_user)
         browser.fill({'Response': 'For you'})
         browser.click_on('Assign')
 
@@ -767,9 +767,8 @@ class TestLocalRolesReindexing(IntegrationTestCase):
         browser.click_on('task-transition-reassign')
 
         # Reassign
-        responsible = 'fa:{}'.format(self.dossier_responsible.id)
         form = browser.find_form_by_field('Responsible')
-        form.find_widget('Responsible').fill(responsible)
+        form.find_widget('Responsible').fill(self.dossier_responsible)
         browser.click_on('Assign')
 
         old_principal = 'user:{}'.format(self.secretariat_user.id)

--- a/opengever/task/tests/test_private_task.py
+++ b/opengever/task/tests/test_private_task.py
@@ -68,7 +68,7 @@ class TestPrivateTaskDeactivatedIntegration(IntegrationTestCase):
         factoriesmenu.add('Task')
         browser.fill({'Title': u'Testaufgabe', 'Task Type': 'For information'})
         form = browser.find_form_by_field('Responsible')
-        form.find_widget('Responsible').fill('fa:{}'.format(self.regular_user.id))
+        form.find_widget('Responsible').fill(self.regular_user)
         browser.click_on('Save')
 
         self.assertEqual(['Item created'], info_messages())

--- a/opengever/task/tests/test_redirector.py
+++ b/opengever/task/tests/test_redirector.py
@@ -20,7 +20,7 @@ class TestTaskRedirector(FunctionalTestCase):
                       'Task Type': 'direct-execution'})
 
         form = browser.find_form_by_field('Responsible')
-        form.find_widget('Responsible').fill('org-unit-1:' + TEST_USER_ID)
+        form.find_widget('Responsible').fill(TEST_USER_ID)
 
         browser.click_on('Save')
 
@@ -43,7 +43,7 @@ class TestTaskRedirector(FunctionalTestCase):
                       'Task Type': 'direct-execution'})
 
         form = browser.find_form_by_field('Responsible')
-        form.find_widget('Responsible').fill('org-unit-1:' + TEST_USER_ID)
+        form.find_widget('Responsible').fill(TEST_USER_ID)
 
         browser.click_on('Save')
 

--- a/opengever/task/tests/test_response_descriptions.py
+++ b/opengever/task/tests/test_response_descriptions.py
@@ -201,7 +201,7 @@ class TestResponseDescriptions(FunctionalTestCase):
         self.click_task_button(browser, 'reassign', save_and_reload=False)
 
         form = browser.find_form_by_field('Responsible')
-        form.find_widget('Responsible').fill('org-unit-1:other_user')
+        form.find_widget('Responsible').fill('other_user')
 
         browser.find('Assign').click()
         self.visit_overview(browser)

--- a/opengever/task/tests/test_revoke_permissions.py
+++ b/opengever/task/tests/test_revoke_permissions.py
@@ -367,8 +367,7 @@ class TestRevokePermissionsDefault(IntegrationTestCase):
                           'Task Type': 'comment'})
 
             form = browser.find_form_by_field('Responsible')
-            form.find_widget('Responsible').fill(
-                'fa:{}'.format(self.secretariat_user.getId()))
+            form.find_widget('Responsible').fill(self.secretariat_user)
 
             browser.css('#form-buttons-save').first.click()
 
@@ -412,8 +411,7 @@ class TestRevokePermissionsDefault(IntegrationTestCase):
                           'Task Type': 'comment'})
 
             form = browser.find_form_by_field('Responsible')
-            form.find_widget('Responsible').fill(
-                'fa:{}'.format(self.secretariat_user.getId()))
+            form.find_widget('Responsible').fill(self.secretariat_user)
 
             browser.css('#form-buttons-save').first.click()
 

--- a/opengever/task/tests/test_sequential_task_process.py
+++ b/opengever/task/tests/test_sequential_task_process.py
@@ -189,8 +189,7 @@ class TestInitialStateForSubtasks(IntegrationTestCase):
             browser.open(self.task, view='++add++opengever.task.task')
             browser.fill({'Title': 'Subtas', 'Task Type': 'comment'})
             form = browser.find_form_by_field('Responsible')
-            form.find_widget('Responsible').fill(
-                'fa:{}'.format(self.secretariat_user.getId()))
+            form.find_widget('Responsible').fill(self.secretariat_user)
             browser.click_on('Save')
 
         subtask = children['added'].pop()
@@ -206,8 +205,7 @@ class TestInitialStateForSubtasks(IntegrationTestCase):
             browser.open(self.task, view='++add++opengever.task.task')
             browser.fill({'Title': 'Subtas', 'Task Type': 'comment'})
             form = browser.find_form_by_field('Responsible')
-            form.find_widget('Responsible').fill(
-                'fa:{}'.format(self.secretariat_user.getId()))
+            form.find_widget('Responsible').fill(self.secretariat_user)
             browser.click_on('Save')
 
         subtask = children['added'].pop()
@@ -233,8 +231,7 @@ class TestAddingAdditionalTaskToSequentialProcess(IntegrationTestCase):
                      view='++add++opengever.task.task?position=1')
         browser.fill({'Title': 'Subtask', 'Task Type': 'comment'})
         form = browser.find_form_by_field('Responsible')
-        form.find_widget('Responsible').fill(
-            u'fa:{}'.format(self.secretariat_user.id))
+        form.find_widget('Responsible').fill(self.secretariat_user)
         browser.click_on('Save')
 
         oguids = self.sequential_task.get_tasktemplate_order()
@@ -252,8 +249,7 @@ class TestAddingAdditionalTaskToSequentialProcess(IntegrationTestCase):
         browser.open(self.sequential_task, view='++add++opengever.task.task')
         browser.fill({'Title': 'Subtask', 'Task Type': 'comment'})
         form = browser.find_form_by_field('Responsible')
-        form.find_widget('Responsible').fill(
-            u'fa:{}'.format(self.secretariat_user.id))
+        form.find_widget('Responsible').fill(self.secretariat_user)
         browser.click_on('Save')
 
         oguids = self.sequential_task.get_tasktemplate_order()

--- a/opengever/tasktemplates/tests/test_tasktemplate.py
+++ b/opengever/tasktemplates/tests/test_tasktemplate.py
@@ -19,7 +19,7 @@ class TestTaskTemplates(IntegrationTestCase):
              'Deadline in Days': u'10'})
 
         form = browser.find_form_by_field('Responsible')
-        form.find_widget('Responsible').fill('fa:robert.ziegler')
+        form.find_widget('Responsible').fill(self.dossier_responsible)
         form.find_widget('Issuer').fill(u'responsible')
 
         browser.click_on('Save')

--- a/opengever/tasktemplates/tests/test_trigger.py
+++ b/opengever/tasktemplates/tests/test_trigger.py
@@ -258,7 +258,7 @@ class TestTriggeringTaskTemplate(IntegrationTestCase):
 
         field_name = u'Responsible \xabUser Accounts erstellen.\xbb'
         form = browser.find_form_by_field(field_name)
-        form.find_widget(field_name).fill('fa:jurgen.konig')
+        form.find_widget(field_name).fill(self.secretariat_user)
         browser.click_on('Trigger')
 
         self.assertEquals(['tasks created'], info_messages())

--- a/opengever/testing/__init__.py
+++ b/opengever/testing/__init__.py
@@ -24,3 +24,4 @@ else:
     from opengever.testing.test_case import TestCase
     import opengever.testing.testbrowser_datetime_widget
     import opengever.testing.testbrowser_tablechoice_widget
+    import opengever.testing.testbrowser_responsible_user_widget

--- a/opengever/testing/testbrowser_responsible_user_widget.py
+++ b/opengever/testing/testbrowser_responsible_user_widget.py
@@ -1,0 +1,74 @@
+from ftw.keywordwidget.tests.widget import AsyncKeywordWidget
+from ftw.testbrowser.widgets.base import widget
+from opengever.ogds.base.utils import get_current_org_unit
+from Products.CMFCore.MemberDataTool import MemberData
+
+
+@widget
+class OpengeverResponsibleUsersAsyncKeywordWidget(AsyncKeywordWidget):
+    """Autofill the correct admin unit for a responsible user."""
+
+    @staticmethod
+    def match(node):
+        """Match an async keyword widget responsible(s) field.
+
+        We optimize by using the match result of the superclass as a filter.
+
+        As there is quite some variability to the actual field names, as per
+        multi step wizards and such, we're just relying on the fact all of the
+        responsible(s) fields are currently AsyncKeywordWidgets.
+
+        Examples of field names found so far:
+        ``"form.widgets.opengever-tasktemplates-tasktemplate.responsible"``
+        ``"form.widgets.opengever-tasktemplates-tasktemplate-3.responsible"``
+        ``"form.widgets.responsible"``
+        ``"form.widgets.responsibles"``
+        """
+        if super(
+            OpengeverResponsibleUsersAsyncKeywordWidget,
+            OpengeverResponsibleUsersAsyncKeywordWidget,
+        ).match(node):
+            fieldname = node.node.attrib.get("data-fieldname")
+            matching_suffixes = ("responsible", "responsibles")
+            if fieldname and fieldname.split(".")[-1] in matching_suffixes:
+                return True
+        return False
+
+    def fill(self, users, auto_org_unit=True):
+        """Fill the AsyncKeywordWidget, auto.
+
+        Mostly copied over from
+        ``ftw.keywordwidget.tests.widget.AsyncKeywordWidget``.
+
+        Can take a ``MemberData``, ``str`` or ``unicode`` object as an input.
+
+        Having a colon in a string or a unicode input is considered a manual
+        override for the org unit, or a non-user input, like a team, a foreign
+        org unit or an inbox.
+
+        Cases where a user without an admin unit is required, like search,
+        are handled via ``auto_org_unit=True``.
+        """
+        if isinstance(users, (MemberData, str, unicode)):
+            users = [users]
+
+        if not all(isinstance(user, (MemberData, str, unicode)) for user in users):
+            raise ValueError(
+                "You can only pass in MemberData objects or user ID strings."
+            )
+
+        if auto_org_unit:
+            org_unit = get_current_org_unit().id()
+        else:
+            org_unit = None
+
+        users = tuple(self.user_to_string(user, org_unit) for user in users)
+        super(OpengeverResponsibleUsersAsyncKeywordWidget, self).fill(users)
+
+    @staticmethod
+    def user_to_string(user, org_unit):
+        if not isinstance(user, (str, unicode)):
+            user = user.getId()
+        if org_unit and ":" not in user:
+            user = "{}:{}".format(org_unit, user)
+        return user


### PR DESCRIPTION
The convolution around the `AsyncKeywordWidget`, task template wizards and the registration-at-module-init-time magic of the `ftw.testbrowser` widgets threw me off for a bit.

This PR adds easier handling for the most common use case for the responsible fields, users. It can later be further amended to handle teams and inboxes.

Closes #5330 