### PR TITLE
Include file_extension in API representation of documents.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 ---------------------
 
 - Provides support for some additional metadata on the search endpoint. [phgross]
+- Include file_extension in API representation of documents. [phgross]
 - Translate keyword-filter label. [phgross]
 - Support searching on group description in sharing form. [phgross]
 - Add CMFEditions modifier that prevents journals from being versioned. [lgraf]

--- a/opengever/api/document.py
+++ b/opengever/api/document.py
@@ -29,6 +29,7 @@ class SerializeDocumentToJson(GeverSerializeToJson):
             self.context, 'preview')
         result[u'pdf_url'] = bumblebee_service.get_representation_url(
             self.context, 'pdf')
+        result[u'file_extension'] = self.context.get_file_extension()
 
         return result
 

--- a/opengever/api/tests/test_document.py
+++ b/opengever/api/tests/test_document.py
@@ -36,6 +36,18 @@ class TestDocumentSerializer(IntegrationTestCase):
             u'http://bumblebee/YnVtYmxlYmVl/api/v3/resource/local/51d6317494e'
             u'ccc4a73154625a6820cb6b50dc1455eb4cf26399299d4f9ce77b2/thumbnail')
 
+    @browsing
+    def test_document_serialization_contains_file_extension(self, browser):
+        self.login(self.regular_user, browser)
+
+        browser.open(self.document, headers={'Accept': 'application/json'})
+        self.assertEqual(browser.status_code, 200)
+        self.assertEqual('.docx', browser.json.get(u'file_extension'))
+
+        browser.open(self.mail_msg, headers={'Accept': 'application/json'})
+        self.assertEqual(browser.status_code, 200)
+        self.assertEqual('.msg', browser.json.get(u'file_extension'))
+
 
 class TestDocumentPatch(IntegrationTestCase):
 

--- a/opengever/document/base.py
+++ b/opengever/document/base.py
@@ -20,6 +20,7 @@ from zc.relation.interfaces import ICatalog
 from zope.component import getUtility
 from zope.intid.interfaces import IIntIds
 import logging
+import os
 
 
 LOG = logging.getLogger('opengever.document')
@@ -123,6 +124,16 @@ class BaseDocumentMixin(object):
 
     def get_filename(self):
         raise NotImplementedError
+
+    def get_file_extension(self):
+        """For document it returns the extension of the file for mails it
+        returns the extension of the original_message file if exists.
+        """
+        filename = self.get_filename()
+        if filename:
+            # We should not rely on the normalization to have happened
+            return os.path.splitext(filename)[-1].lower()
+        return u''
 
     def get_file(self):
         raise NotImplementedError

--- a/opengever/document/indexers.py
+++ b/opengever/document/indexers.py
@@ -225,9 +225,4 @@ def file_extension(obj):
     For document it returns the extension of the file for mails it returns the
     extension of the original_message file if exists.
     """
-
-    filename = obj.get_filename()
-    if filename:
-        # We should not rely on the normalization to have happened
-        return os.path.splitext(filename)[-1].lower()
-    return u''
+    return obj.get_file_extension()


### PR DESCRIPTION
Currently the `file_extension` is only accessible on the `@listing` endpoint. So we don't get the information when creating a document. So an additional fetch would be necessary. Closes #5718.

## Checkliste
- [x] Gibt es neue Funktionalität mit einem `Dokument`? Funktioniert das auch mit einem `Mail`?
- [x] Changelog-Eintrag vorhanden/nötig?
