### PR TITLE
Solr update

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -17,6 +17,8 @@ Changelog
 - Update Creator, created and Date when copy/pasting an object. [njohner]
 - Docs: Add tasks to documented content types. [lgraf]
 - Add per user configuration to activate notifications for own actions. [njohner]
+- Update ftw.solr to version 2.5.0 which allows near realtime searching. [buchi]
+- Update Solr to version 8.1.1. [buchi]
 
 
 2019.3.0 (2019-06-17)

--- a/solr-conf/solrconfig.xml
+++ b/solr-conf/solrconfig.xml
@@ -35,7 +35,7 @@
        that you fully re-index after changing this setting as it can
        affect both how text is indexed and queried.
   -->
-  <luceneMatchVersion>7.3.1</luceneMatchVersion>
+  <luceneMatchVersion>8.1.1</luceneMatchVersion>
 
   <!-- <lib/> directives can be used to instruct Solr to load any Jars
        identified and use them to resolve any "plugins" specified in
@@ -85,7 +85,9 @@
   <lib dir="${solr.install.dir:../../../..}/dist/" regex="solr-langid-\d.*\.jar" />
 
   <lib dir="${solr.install.dir:../../../..}/contrib/velocity/lib" regex=".*\.jar" />
-  <lib dir="${solr.install.dir:../../../..}/dist/" regex="solr-velocity-\d.*\.jar" /> -->
+  <lib dir="${solr.install.dir:../../../..}/dist/" regex="solr-velocity-\d.*\.jar" />
+  <lib dir="${solr.install.dir:../../../..}/dist/" regex="solr-ltr-\d.*\.jar" /> -->
+
   <!-- an exact 'path' can be used instead of a 'dir' to specify a
        specific jar file.  This will cause a serious error to be logged
        if it can't be loaded.
@@ -370,12 +372,17 @@
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
   <query>
 
-    <!-- Maximum number of clauses in each BooleanQuery,  an exception
-         is thrown if exceeded.  It is safe to increase or remove this setting,
-         since it is purely an arbitrary limit to try and catch user errors where
-         large boolean queries may not be the best implementation choice.
+    <!-- Maximum number of clauses allowed when parsing a boolean query string.
+         
+         This limit only impacts boolean queries specified by a user as part of a query string,
+         and provides per-collection controls on how complex user specified boolean queries can
+         be.  Query strings that specify more clauses then this will result in an error.
+         
+         If this per-collection limit is greater then the global `maxBooleanClauses` limit
+         specified in `solr.xml`, it will have no effect, as that setting also limits the size
+         of user specified boolean queries.
       -->
-    <maxBooleanClauses>1024</maxBooleanClauses>
+    <maxBooleanClauses>${solr.max.booleanClauses:1024}</maxBooleanClauses>
 
     <!-- Solr Internal Query Caches
 
@@ -803,8 +810,8 @@
       <str name="lowernames">false</str>
       <str name="xpath">/xhtml:html/xhtml:body//text()</str>
       <str name="fmap.content">SearchableText</str>
-      <bool name="ignoreTikaException">true</bool>
       <str name="uprefix">ignored_</str>
+      <bool name="ignoreTikaException">true</bool>
     </lst>
   </requestHandler>
 

--- a/solr-conf/solrconfig.xml
+++ b/solr-conf/solrconfig.xml
@@ -314,7 +314,7 @@
          have some sort of hard autoCommit to limit the log size.
       -->
     <autoCommit>
-      <maxTime>${solr.autoCommit.maxTime:15000}</maxTime>
+      <maxTime>${solr.autoCommit.maxTime:60000}</maxTime>
       <openSearcher>false</openSearcher>
     </autoCommit>
 

--- a/versions.cfg
+++ b/versions.cfg
@@ -92,7 +92,7 @@ ftw.pdfgenerator = 1.6.4
 ftw.profilehook = 1.2.1
 ftw.raven = 1.2.0
 ftw.recipe.deployment = 1.4.3
-ftw.recipe.solr = 1.2.1
+ftw.recipe.solr = 1.3.0
 ftw.recipe.translations = 1.2.6
 ftw.showroom = 1.5.1
 ftw.slacker = 1.0.2
@@ -221,5 +221,5 @@ zope.testrunner = 4.8.1
 zptlint = 0.2.4
 
 [solr]
-url = http://archive.apache.org/dist/lucene/solr/7.3.1/solr-7.3.1.tgz
-md5sum = 042a6c0d579375be1a8886428f13755f
+url = https://archive.apache.org/dist/lucene/solr/8.1.1/solr-8.1.1.tgz
+md5sum = 9506f15df46c0a403ff41f77778df0f0


### PR DESCRIPTION
Update Solr and ftw.solr to latest versions.

ftw.solr now performs soft commits to allow near real time (NRT) searching.
This make documents available for search almost immediately after being indexed.
E.g. after uploading, documents are now visible immediately in listings in the new frontend.

Apart from that, Solr 8.1.1 comes with various bug fixes and improvements. See https://lucene.apache.org/solr/8_1_1/changes/Changes.html

Other changes:
- Tike exceptions are now properly ignored (e.g. with encrypted documents)
- Increased auto commit max time to 60s.