### PR TITLE
Fix encoding issue in OGDSUpdater's error logging.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2019.3.0 (unreleased)
 ---------------------
 
+- Fix encoding issue in OGDSUpdater's error logging. [lgraf]
 - Provides support for some additional metadata on the search endpoint. [phgross]
 - Include file_extension in API representation of documents. [phgross]
 - Translate keyword-filter label. [phgross]

--- a/opengever/ogds/base/sync/ogds_updater.py
+++ b/opengever/ogds/base/sync/ogds_updater.py
@@ -23,10 +23,10 @@ import os
 import time
 
 
-NO_UID_MSG = u"User '{}' has no 'uid' attribute."
-NO_UID_AD_MSG = u"User '{}' has none of the attributes {} - skipping."
-USER_NOT_FOUND_LDAP = u"Referenced user {} not found in LDAP, ignoring!"
-USER_NOT_FOUND_SQL = u"Referenced user {} not found in SQL, ignoring!"
+NO_UID_MSG = u"User {!r} has no 'uid' attribute."
+NO_UID_AD_MSG = u"User {!r} has none of the attributes {!r} - skipping."
+USER_NOT_FOUND_LDAP = u"Referenced user {!r} not found in LDAP, ignoring!"
+USER_NOT_FOUND_SQL = u"Referenced user {!r} not found in SQL, ignoring!"
 
 AD_UID_KEYS = [u'userid', u'sAMAccountName', u'windows_login_name']
 


### PR DESCRIPTION
Fix encoding issue in `OGDSUpdater`'s error logging.

When logging errors about a referenced user not being found in LDAP, the error logging blew up with an encoding error when a user with non-ASCII character in its DN was logged, because a UTF-8 bytestring was formatted into a unicode message.

This changes all the format strings to use the `repr()` of the respective values to avoid such errors in the future.

(Discovered via https://extranet.4teamwork.ch/betrieb/tracker/880)
Sentry Issue: https://sentry.4teamwork.ch/sentry/onegov-gever/issues/30789/

## Checkliste

- [x] Changelog-Eintrag vorhanden/nötig?

