### PR TITLE
Register ChoiceFieldDeserializer using overrides instead of configure ZCML

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2019.3.1 (unreleased)
 ---------------------
 
+- Register ChoiceFieldDeserializer using overrides instead of configure ZCML. [lgraf]
 - Docs: Add tasks to documented content types. [lgraf]
 
 

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -14,7 +14,6 @@
   <adapter factory=".serializer.GeverSerializeFolderToJson" />
 
   <adapter factory=".summary.GeverJSONSummarySerializer" />
-  <adapter factory=".fields.ChoiceFieldDeserializer" />
   <adapter factory=".catalog.GeverBrainSerializer" />
 
   <adapter factory=".repositoryfolder.SerializeRepositoryFolderToJson" />

--- a/opengever/api/overrides.zcml
+++ b/opengever/api/overrides.zcml
@@ -1,0 +1,7 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:zcml="http://namespaces.zope.org/zcml">
+
+  <adapter factory=".fields.ChoiceFieldDeserializer" />
+
+</configure>


### PR DESCRIPTION
This ensures that it will be loaded with the currently pinned version of `plone.restapi` (which doesn't have it's own `ChoiceFieldDeserializer` yet) and will also not cause conflicting configurations with `plone.restapi:master`, which now [does have a `ChoiceFieldDeserializer`](https://github.com/plone/plone.restapi/blob/25446902caaec5b7e930f8c0d8bc198e5ddf7ed3/src/plone/restapi/deserializer/dxfields.py#L117-L130).

That way we make sure that GEVER tests against `plone.restapi` are green again and don't shadow problems that might be introduced in the upcoming restapi sprint.

## Checkliste

- [x] Changelog-Eintrag vorhanden/nötig?
