### PR TITLE
Minor cleanups for cleaner test output / linter in tests

### DIFF
--- a/opengever/document/tests/test_checkout.py
+++ b/opengever/document/tests/test_checkout.py
@@ -331,7 +331,8 @@ class TestCheckinCheckoutManager(FunctionalTestCase):
         # We cannot freeze time due to the test browser being threaded
         oc_url = create_oc_url(
             self.doc1.REQUEST, self.doc1, {'action': 'checkout'})
-        decoded_oc_url = jwt.decode(oc_url.split(':')[-1], verify=False)
+        decoded_oc_url = jwt.decode(
+            oc_url.split(':')[-1], verify=False, algorithms=('HS256',))
 
         redirector_js = browser.login().open(
             self.doc1,
@@ -347,7 +348,7 @@ class TestCheckinCheckoutManager(FunctionalTestCase):
 
         parsed_oc_url = tokens_from_js[0]
         decoded_parsed_oc_url = jwt.decode(
-            parsed_oc_url.split(':')[-1], verify=False)
+            parsed_oc_url.split(':')[-1], verify=False, algorithms=('HS256',))
 
         # Take out the timestamps
         del decoded_oc_url['exp']
@@ -367,7 +368,8 @@ class TestCheckinCheckoutManager(FunctionalTestCase):
         # We cannot freeze time due to the test browser being threaded
         oc_url = create_oc_url(
             self.doc1.REQUEST, self.doc1, {'action': 'checkout'})
-        decoded_oc_url = jwt.decode(oc_url.split(':')[-1], verify=False)
+        decoded_oc_url = jwt.decode(
+            oc_url.split(':')[-1], verify=False, algorithms=('HS256',))
 
         redirector_js = browser.login().open(
             self.doc1,
@@ -383,7 +385,7 @@ class TestCheckinCheckoutManager(FunctionalTestCase):
 
         parsed_oc_url = tokens_from_js[0]
         decoded_parsed_oc_url = jwt.decode(
-            parsed_oc_url.split(':')[-1], verify=False)
+            parsed_oc_url.split(':')[-1], verify=False, algorithms=('HS256',))
 
         # Take out the timestamps
         del decoded_oc_url['exp']

--- a/opengever/dossier/tests/test_overview.py
+++ b/opengever/dossier/tests/test_overview.py
@@ -67,7 +67,6 @@ class TestOverview(IntegrationTestCase):
             u'Vertragsentwurf \xdcberpr\xfcfen',
         ]
 
-    @IntegrationTestCase.clock
     @browsing
     def test_description_box_is_web_intelligent_formatted_and_xss_safe(self, browser):
         self.login(self.regular_user, browser)

--- a/opengever/meeting/tests/test_committee.py
+++ b/opengever/meeting/tests/test_committee.py
@@ -9,7 +9,6 @@ from ftw.testbrowser.pages import statusmessages
 from opengever.base.oguid import Oguid
 from opengever.meeting.model import Committee
 from opengever.testing import IntegrationTestCase
-from operator import methodcaller
 from plone.uuid.interfaces import IUUID
 
 
@@ -416,33 +415,37 @@ class TestCommitteeWorkflow(IntegrationTestCase):
         Therefore we test the appearance of all fields.
         """
 
-        fields = ['Title',
-                  'Committeeresponsible',
-                  'Linked repository folder',
-                  'Agendaitem list template',
-                  'Table of contents template',
-                  'Allowed proposal templates',
-                  'Allowed ad-hoc agenda item templates',
-                  'Ad hoc agenda item template',
-                  'Protocol header template',
-                  'Paragraph template',
-                  'Agenda item header template for the protocol',
-                  'Agenda item suffix template for the protocol',
-                  'Protocol suffix template',
-                  'Excerpt header template',
-                  'Excerpt suffix template']
+        expected_field_names = [
+            'Title',
+            'Committeeresponsible',
+            'Linked repository folder',
+            'Agendaitem list template',
+            'Table of contents template',
+            'Allowed proposal templates',
+            'Allowed ad-hoc agenda item templates',
+            'Ad hoc agenda item template',
+            'Protocol header template',
+            'Paragraph template',
+            'Agenda item header template for the protocol',
+            'Agenda item suffix template for the protocol',
+            'Protocol suffix template',
+            'Excerpt header template',
+            'Excerpt suffix template',
+        ]
 
         with self.login(self.administrator, browser):
             browser.open(self.committee_container)
             factoriesmenu.add('Committee')
-            self.assertEquals(
-                fields,
-                map(methodcaller('normalized_text', recursive=False),
-                    browser.css('form#form > fieldset > div.field > label')))
+            discovered_field_names = [
+                node.text
+                for node in browser.css('form#form > fieldset > div.field > label')
+            ]
+            self.assertEqual(expected_field_names, discovered_field_names)
 
         with self.login(self.committee_responsible, browser):
             browser.open(self.committee, view='edit')
-            self.assertEquals(
-                fields,
-                map(methodcaller('normalized_text', recursive=False),
-                    browser.css('form#form > fieldset > div.field > label')))
+            discovered_field_names = [
+                node.text
+                for node in browser.css('form#form > fieldset > div.field > label')
+            ]
+            self.assertEqual(expected_field_names, discovered_field_names)

--- a/opengever/officeconnector/tests/test_api_mail_attach.py
+++ b/opengever/officeconnector/tests/test_api_mail_attach.py
@@ -28,7 +28,7 @@ class TestOfficeconnectorMailAPIWithAttach(OCIntegrationTestCase):
             u"url": u"http://nohost/plone/oc_attach",
         }
         raw_token = oc_url.split(":")[-1]
-        token = jwt.decode(raw_token, JWT_SIGNING_SECRET_PLONE)
+        token = jwt.decode(raw_token, JWT_SIGNING_SECRET_PLONE, algorithms=('HS256',))
         self.assertEqual(expected_token, token)
 
         expected_payloads = [{
@@ -67,7 +67,7 @@ class TestOfficeconnectorMailAPIWithAttach(OCIntegrationTestCase):
             u"url": u"http://nohost/plone/oc_attach",
         }
         raw_token = oc_url.split(":")[-1]
-        token = jwt.decode(raw_token, JWT_SIGNING_SECRET_PLONE)
+        token = jwt.decode(raw_token, JWT_SIGNING_SECRET_PLONE, algorithms=('HS256',))
         self.assertEqual(expected_token, token)
 
         expected_payloads = [{
@@ -114,7 +114,7 @@ class TestOfficeconnectorMailAPIWithAttach(OCIntegrationTestCase):
             u"url": u"http://nohost/plone/oc_attach",
         }
         raw_token = oc_url.split(":")[-1]
-        token = jwt.decode(raw_token, JWT_SIGNING_SECRET_PLONE)
+        token = jwt.decode(raw_token, JWT_SIGNING_SECRET_PLONE, algorithms=('HS256',))
         self.assertEqual(expected_token, token)
 
         expected_payloads = [


### PR DESCRIPTION
So, I started hunting for quick wins in test speeds based on the output of three log files:
[2019-06-13-functionaltestperf.log](https://github.com/4teamwork/opengever.core/files/3290314/2019-06-13-functionaltestperf.log)
[2019-06-13-integrationtestperf.log](https://github.com/4teamwork/opengever.core/files/3290315/2019-06-13-integrationtestperf.log)
[2019-06-13-othertestperf.log](https://github.com/4teamwork/opengever.core/files/3290316/2019-06-13-othertestperf.log)

I quickly hit a wall as to some event ordering issue in the test server self test:
https://ci.4teamwork.ch/builds/249683/tasks/409536

The best guess is that the SQLite DB Engine gets initialized before ZCML is registered. We have an event for forcibly enabling save points for integration testing.

https://github.com/4teamwork/opengever.core/blob/1cefc45c2ff8d521dbb0c5dcd3c0bb293b948a23/opengever/ogds/base/configure.zcml#L25-L28

https://github.com/4teamwork/opengever.core/blob/7390b2e4afd830f31cec55285d91bdf490b041fa/opengever/ogds/base/events.py#L43-L63

https://github.com/4teamwork/opengever.core/blob/7390b2e4afd830f31cec55285d91bdf490b041fa/opengever/ogds/base/events.py#L14-L20

I've left a branch behind:
https://github.com/4teamwork/opengever.core/tree/jo-test-speedups

So I've just ended up cleaning the test output as much as I could. Everything remaining should be from other packages and cannot be tackled in `opengever.core`. A good example of these are various exceptions used upstream. These are mostly already sanitized to the new style of how to do exceptions in the Python 3 transition. An another one fixed by that transition is Mocker explicitly and unconditionally overriding `assertTrue` to be `failUnless`.

[2019-06-13-deprecations.log](https://github.com/4teamwork/opengever.core/files/3290361/2019-06-13-deprecations.log)

There is now an issue on `ftw.testbrowser` as well, but I could not tackle those, as something mystical happens to timezone handling with the requests driver when bumping zope.testbrowser:
https://github.com/4teamwork/ftw.testbrowser/issues/93