### PR TITLE
Fix validation of resolve preconditions in archive form

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2019.3.0 (unreleased)
 ---------------------
 
+- Archiving form: Make sure dossier resolution preconditions are validated and handled. [lgraf]
 - Fix encoding issue in OGDSUpdater's error logging. [lgraf]
 - Provides support for some additional metadata on the search endpoint. [phgross]
 - Include file_extension in API representation of documents. [phgross]

--- a/opengever/dossier/resolve.py
+++ b/opengever/dossier/resolve.py
@@ -149,16 +149,7 @@ class LockingResolveManager(object):
             resolve_lock.release(commit=True)
 
     def execute_recursive_resolve(self):
-        # check preconditions
-        errors = self.resolver.get_precondition_violations()
-        if errors:
-            raise PreconditionsViolated(errors=errors)
-
-        # validate enddates
-        invalid_dates = self.resolver.are_enddates_valid()
-        if invalid_dates:
-            raise InvalidDates(invalid_dossier_titles=invalid_dates)
-
+        self.resolver.raise_on_failed_preconditions()
         self.resolver.resolve()
 
     def is_archive_form_needed(self):
@@ -270,6 +261,19 @@ class StrictDossierResolver(object):
         if not errors:
             self.preconditions_fulfilled = True
         return errors
+
+    def raise_on_failed_preconditions(self):
+        """Verify preconditions, and raise respective exceptions if violated.
+        """
+        # check preconditions
+        errors = self.get_precondition_violations()
+        if errors:
+            raise PreconditionsViolated(errors=errors)
+
+        # validate enddates
+        invalid_dates = self.are_enddates_valid()
+        if invalid_dates:
+            raise InvalidDates(invalid_dossier_titles=invalid_dates)
 
     def are_enddates_valid(self):
         """Check if the end dates of dossiers and subdossiers are valid.

--- a/opengever/dossier/resolve.py
+++ b/opengever/dossier/resolve.py
@@ -227,21 +227,36 @@ class DossierResolveView(BrowserView, DossierResolutionStatusmessageMixin):
 
         resolve_manager = LockingResolveManager(self.context)
 
-        if resolve_manager.is_archive_form_needed():
-            archive_url = '/'.join((self.context_url, 'transition-archive'))
-            return self.redirect(archive_url)
-
+        # Validate preconditions early. This is so we don't redirect to the
+        # archive form (if filing number feature enabled) in a case where
+        # it will fail anyway because of violated preconditions.
+        #
+        # XXX: This will validate preconditions *twice* though (the second
+        # time via resolve_manager.resolve()). This should eventually be
+        # cleaned up so we don't unnecessarily validate preconditions multiple
+        # times.
         try:
-            resolve_manager.resolve()
-
-        except AlreadyBeingResolved:
-            return self.show_being_resolved_msg()
+            resolve_manager.resolver.raise_on_failed_preconditions()
 
         except PreconditionsViolated as exc:
             return self.show_errors(exc.errors)
 
         except InvalidDates as exc:
             return self.show_invalid_end_dates(titles=exc.invalid_dossier_titles)
+
+        # If filing number feature is enabled, we redirect to an additional
+        # archive form that needs to be filled out first. The actual resolving
+        # will then be triggered from that form.
+        if resolve_manager.is_archive_form_needed():
+            archive_url = '/'.join((self.context_url, 'transition-archive'))
+            return self.redirect(archive_url)
+
+        # All good, proceed with resolving the dossier.
+        try:
+            resolve_manager.resolve()
+
+        except AlreadyBeingResolved:
+            return self.show_being_resolved_msg()
 
         # Success
         if self.context.is_subdossier():


### PR DESCRIPTION
The archive form relied on the `DossierResolveView` already **validating dossier resolution preconditions**, and presenting error messages to the user. Because that wasn't the case any more after the refactoring of the whole dossier resolution process, the archive form was broken when preconditions weren't fulfilled.

This change fixes this by:
- Refactoring the dossier resolution code so that:
  - Raising the appropriate exceptions is done in a single method on the resolver, `raise_on_failed_preconditions()` 
  - Constructing and displaying error messages for classic views, including redirecting to the appropriate context, is done in a mixin class. That way it can be reused in the archive form.
  - Handling violated preconditions in both
    - The `DossierResolveView`, before even redirecting to the archive form
    - The `ArchiveForm` itself, in case `transition-archive` is invoked directly

This approach leads to the preconditions getting check _twice_ in some cases. We should eventually optimize this, possibly when cleaning up the archive form code next.

Fixes https://basecamp.com/2768704/projects/14549453/todos/391204514

❗️ Needs backport to `2019.2-stable`

## Review notes

The diff for `cbe0071` is a mess, as displayed by git. Easier to look at the resulting code. Just moved out the status message related stuff from the [`DossierResolveView`](https://github.com/4teamwork/opengever.core/blob/cbe0071d105973e96189ae7951034f4f701a4ff3/opengever/dossier/resolve.py#L221-L253) into the [`DossierResolutionStatusmessageMixin`](https://github.com/4teamwork/opengever.core/blob/cbe0071d105973e96189ae7951034f4f701a4ff3/opengever/dossier/resolve.py#L159-L218) class (_these are links to the new classes, after the refactoring_).

## Checkliste

- [x] Könnten Kundeninstallationen von den Änderungen betroffen sein? Müssen Policies angepasst werden?

_Ja, potentiell haben diese Änderungen Einfluss auf die Logik für den Dossier-Abschluss, sowohl bei Installation mit aktiviertem Ablagenummern-Feature wie auch bei anderen. Das extern sichtbare Verhalten sollte sich aber nicht ändern. Keine Anpassungen an Policies nötig._
 
- [x] Gibt es neue Übersetzungen?

_Nein. Durch das wiederverwenden der Fehler-Übersetzungen in der Mixin-Class ist dies nicht nötig._

- [x] Changelog-Eintrag vorhanden/nötig?

