### PR TITLE
Docs: Add tasks to documented content types

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,7 @@ Changelog
 2019.3.1 (unreleased)
 ---------------------
 
-- Nothing changed yet.
+- Docs: Add tasks to documented content types. [lgraf]
 
 
 2019.3.0 (2019-06-17)

--- a/docs/public/_static/custom.css
+++ b/docs/public/_static/custom.css
@@ -65,6 +65,19 @@ blockquote {
     background-repeat: no-repeat;
     padding-left: 2.5em;
     padding-top: 0.25em;
+    padding-bottom: 0.25em;
+    min-height: 38px;
+}
+
+#schemas .small-comment {
+    font-style: italic;
+    font-size: small;
+}
+
+#schemas .small-comment::before {
+    /* Insert a CSS line break before the small comment */
+    display: block;
+    content: "\A";
 }
 
 #schemas #ordnungssystem > h3 {
@@ -89,6 +102,10 @@ blockquote {
 
 #schemas #kontakt > h3 {
     background-image: url('img/contact.png');
+}
+
+#schemas #aufgabe > h3 {
+    background-image: url('img/task.png');
 }
 
 

--- a/docs/public/dev-manual/api/content_types.rst
+++ b/docs/public/dev-manual/api/content_types.rst
@@ -13,6 +13,7 @@ Schemas
 
 .. role:: required
 .. role:: field-title
+.. role:: small-comment
 
 
 Ordnungssystem
@@ -63,5 +64,14 @@ Kontakt
 ^^^^^^^
 
 .. include:: schemas/opengever.contact.contact.inc
+
+--------------------
+
+
+
+Aufgabe
+^^^^^^^
+
+.. include:: schemas/opengever.task.task.inc
 
 .. disqus::

--- a/docs/public/dev-manual/api/schemas/opengever.task.task.inc
+++ b/docs/public/dev-manual/api/schemas/opengever.task.task.inc
@@ -1,0 +1,184 @@
+.. py:class:: opengever.task.task
+
+    Inhaltstyp 'Aufgabe'
+
+
+
+   .. py:attribute:: title
+
+       :Feldname: :field-title:`Titel`
+       :Datentyp: ``TextLine``
+       :Pflichtfeld: Ja :required:`(*)`
+       
+       :Beschreibung: Der Name der Aufgabe
+       
+
+
+   .. py:attribute:: issuer
+
+       :Feldname: :field-title:`Auftraggeber`
+       :Datentyp: ``Choice``
+       :Pflichtfeld: Ja :required:`(*)`
+       
+       
+       :Wertebereich: <User-ID eines gültigen Auftraggebers>
+
+
+   .. py:attribute:: task_type
+
+       :Feldname: :field-title:`Auftragstyp`
+       :Datentyp: ``Choice``
+       :Pflichtfeld: Ja :required:`(*)`
+       
+       :Beschreibung: Wählen Sie den Auftragstyp
+       :Wertebereich: ["information", "direct-execution", "report", "approval", "correction", "comment"]
+
+
+   .. py:attribute:: responsible_client
+
+       :Feldname: :field-title:`Mandant des Auftragnehmers`
+       :Datentyp: ``Choice``
+       
+       :Default: <Kein Default> :small-comment:`(Obwohl dieses Feld im User-Interface nicht erscheint (vom System automatisch gesetzt wird), muss es über die REST API angegeben werden)`
+       :Beschreibung: Wählen Sie zuerst den Mandanten des Auftragnehmers, anschliessend den Auftragnehmer.
+       :Wertebereich: <Gültige Org-Unit-ID>
+
+
+   .. py:attribute:: responsible
+
+       :Feldname: :field-title:`Auftragnehmer`
+       :Datentyp: ``Choice``
+       :Pflichtfeld: Ja :required:`(*)`
+       
+       :Beschreibung: Wählen Sie die verantwortlichen Personen aus.
+       :Wertebereich: <User-ID eines gültigen Auftragnehmers>
+
+
+   .. py:attribute:: is_private
+
+       :Feldname: :field-title:`Persönliche Aufgabe`
+       :Datentyp: ``Bool``
+       
+       :Default: false
+       :Beschreibung: Eingangskorb-Stellvertreter Berechtigung für diese Aufgabe deaktivieren
+       
+
+
+   .. py:attribute:: revoke_permissions
+
+       :Feldname: :field-title:`Berechtigungen nach Abschluss entziehen`
+       :Datentyp: ``Bool``
+       
+       :Default: true
+       :Beschreibung: Berechtigungen für den Auftragnehmer und dessen Stellvertretung nach Abschluss oder Neuzuweisung der Aufgabe entziehen.
+       
+
+
+   .. py:attribute:: deadline
+
+       :Feldname: :field-title:`Zu erledigen bis`
+       :Datentyp: ``Date``
+       
+       :Default: <Aktuelles Datum + 5 Tage> :small-comment:`(konfigurierbarer Default)`
+       :Beschreibung: Tragen Sie ein Datum ein, bis wann die Aufgabe erledigt werden muss
+       
+
+
+   .. py:attribute:: date_of_completion
+
+       :Feldname: :field-title:`Erledigungsdatum`
+       :Datentyp: ``Date``
+       
+       
+       :Beschreibung: Das Datum an dem die Aufgabe beendet wurde
+       
+
+
+   .. py:attribute:: text
+
+       :Feldname: :field-title:`Beschreibung`
+       :Datentyp: ``Text``
+       
+       
+       :Beschreibung: Geben Sie eine detaillierte Arbeitsanweisung oder einen Kommentar ein
+       
+
+
+   .. py:attribute:: relatedItems
+
+       :Feldname: :field-title:`Verweise`
+       :Datentyp: ``RelationList``
+       
+       :Default: []
+       
+       
+
+
+   .. py:attribute:: expectedStartOfWork
+
+       :Feldname: :field-title:`Beginn der Arbeit`
+       :Datentyp: ``Date``
+       
+       
+       
+       
+
+
+   .. py:attribute:: expectedDuration
+
+       :Feldname: :field-title:`Geschätzte Dauer (h)`
+       :Datentyp: ``Float``
+       
+       
+       :Beschreibung: Dauer in h
+       
+
+
+   .. py:attribute:: expectedCost
+
+       :Feldname: :field-title:`Geschätzte Kosten (CHF)`
+       :Datentyp: ``Float``
+       
+       
+       :Beschreibung: Kosten in CHF
+       
+
+
+   .. py:attribute:: effectiveDuration
+
+       :Feldname: :field-title:`Effektive Dauer (h)`
+       :Datentyp: ``Float``
+       
+       
+       :Beschreibung: Dauer in h
+       
+
+
+   .. py:attribute:: effectiveCost
+
+       :Feldname: :field-title:`Effektive Kosten (CHF)`
+       :Datentyp: ``Float``
+       
+       
+       :Beschreibung: Kosten in CHF
+       
+
+
+   .. py:attribute:: predecessor
+
+       :Feldname: :field-title:`Vorgänger`
+       :Datentyp: ``TextLine``
+       
+       
+       
+       
+
+
+   .. py:attribute:: changed
+
+       :Feldname: :field-title:`Zuletzt verändert`
+       :Datentyp: ``Datetime``
+       
+       
+       
+       

--- a/docs/schema-dumps/opengever.task.task.schema.json
+++ b/docs/schema-dumps/opengever.task.task.schema.json
@@ -1,0 +1,163 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "type": "object",
+    "title": "Aufgabe",
+    "additionalProperties": false,
+    "properties": {
+        "title": {
+            "type": "string",
+            "title": "Titel",
+            "maxLength": 256,
+            "description": "Der Name der Aufgabe",
+            "_zope_schema_type": "TextLine"
+        },
+        "issuer": {
+            "type": "string",
+            "title": "Auftraggeber",
+            "description": "",
+            "_zope_schema_type": "Choice",
+            "_vocabulary": "<User-ID eines g\u00fcltigen Auftraggebers>"
+        },
+        "task_type": {
+            "type": "string",
+            "title": "Auftragstyp",
+            "description": "W\u00e4hlen Sie den Auftragstyp",
+            "_zope_schema_type": "Choice",
+            "enum": [
+                "information",
+                "direct-execution",
+                "report",
+                "approval",
+                "correction",
+                "comment"
+            ]
+        },
+        "responsible_client": {
+            "type": "string",
+            "title": "Mandant des Auftragnehmers",
+            "description": "W\u00e4hlen Sie zuerst den Mandanten des Auftragnehmers, anschliessend den Auftragnehmer.",
+            "_zope_schema_type": "Choice",
+            "default": "<Kein Default> :small-comment:`(Obwohl dieses Feld im User-Interface nicht erscheint (vom System automatisch gesetzt wird), muss es \u00fcber die REST API angegeben werden)`",
+            "_vocabulary": "<G\u00fcltige Org-Unit-ID>"
+        },
+        "responsible": {
+            "type": "string",
+            "title": "Auftragnehmer",
+            "description": "W\u00e4hlen Sie die verantwortlichen Personen aus.",
+            "_zope_schema_type": "Choice",
+            "_vocabulary": "<User-ID eines g\u00fcltigen Auftragnehmers>"
+        },
+        "is_private": {
+            "type": "boolean",
+            "title": "Pers\u00f6nliche Aufgabe",
+            "description": "Eingangskorb-Stellvertreter Berechtigung f\u00fcr diese Aufgabe deaktivieren",
+            "_zope_schema_type": "Bool",
+            "default": false
+        },
+        "revoke_permissions": {
+            "type": "boolean",
+            "title": "Berechtigungen nach Abschluss entziehen",
+            "description": "Berechtigungen f\u00fcr den Auftragnehmer und dessen Stellvertretung nach Abschluss oder Neuzuweisung der Aufgabe entziehen.",
+            "_zope_schema_type": "Bool",
+            "default": true
+        },
+        "deadline": {
+            "type": "string",
+            "title": "Zu erledigen bis",
+            "format": "date",
+            "description": "Tragen Sie ein Datum ein, bis wann die Aufgabe erledigt werden muss",
+            "_zope_schema_type": "Date",
+            "default": "<Aktuelles Datum + 5 Tage> :small-comment:`(konfigurierbarer Default)`"
+        },
+        "date_of_completion": {
+            "type": "string",
+            "title": "Erledigungsdatum",
+            "format": "date",
+            "description": "Das Datum an dem die Aufgabe beendet wurde",
+            "_zope_schema_type": "Date"
+        },
+        "text": {
+            "type": "string",
+            "title": "Beschreibung",
+            "description": "Geben Sie eine detaillierte Arbeitsanweisung oder einen Kommentar ein",
+            "_zope_schema_type": "Text"
+        },
+        "relatedItems": {
+            "type": "array",
+            "title": "Verweise",
+            "description": "",
+            "_zope_schema_type": "RelationList",
+            "default": []
+        },
+        "expectedStartOfWork": {
+            "type": "string",
+            "title": "Beginn der Arbeit",
+            "format": "date",
+            "description": "",
+            "_zope_schema_type": "Date"
+        },
+        "expectedDuration": {
+            "type": "number",
+            "title": "Gesch\u00e4tzte Dauer (h)",
+            "description": "Dauer in h",
+            "_zope_schema_type": "Float"
+        },
+        "expectedCost": {
+            "type": "number",
+            "title": "Gesch\u00e4tzte Kosten (CHF)",
+            "description": "Kosten in CHF",
+            "_zope_schema_type": "Float"
+        },
+        "effectiveDuration": {
+            "type": "number",
+            "title": "Effektive Dauer (h)",
+            "description": "Dauer in h",
+            "_zope_schema_type": "Float"
+        },
+        "effectiveCost": {
+            "type": "number",
+            "title": "Effektive Kosten (CHF)",
+            "description": "Kosten in CHF",
+            "_zope_schema_type": "Float"
+        },
+        "predecessor": {
+            "type": "string",
+            "title": "Vorg\u00e4nger",
+            "description": "",
+            "_zope_schema_type": "TextLine"
+        },
+        "changed": {
+            "type": "string",
+            "title": "Zuletzt ver\u00e4ndert",
+            "format": "datetime",
+            "description": "",
+            "_zope_schema_type": "Datetime"
+        }
+    },
+    "required": [
+        "title",
+        "issuer",
+        "task_type",
+        "responsible"
+    ],
+    "field_order": [
+        "title",
+        "issuer",
+        "task_type",
+        "responsible_client",
+        "responsible",
+        "is_private",
+        "revoke_permissions",
+        "deadline",
+        "date_of_completion",
+        "text",
+        "relatedItems",
+        "expectedStartOfWork",
+        "expectedDuration",
+        "expectedCost",
+        "effectiveDuration",
+        "effectiveCost",
+        "predecessor",
+        "changed"
+    ]
+}

--- a/docs/schema-dumps/opengever.task.task.schema.json
+++ b/docs/schema-dumps/opengever.task.task.schema.json
@@ -24,12 +24,12 @@
             "description": "W\u00e4hlen Sie den Auftragstyp",
             "_zope_schema_type": "Choice",
             "enum": [
-                "information",
-                "direct-execution",
-                "report",
                 "approval",
+                "comment",
                 "correction",
-                "comment"
+                "direct-execution",
+                "information",
+                "report"
             ]
         },
         "responsible_client": {

--- a/opengever/base/schemadump/config.py
+++ b/opengever/base/schemadump/config.py
@@ -8,6 +8,7 @@ GEVER_TYPES = [
     'opengever.document.document',
     'ftw.mail.mail',
     'opengever.contact.contact',
+    'opengever.task.task',
     'opengever.repository.repositoryfolder',
     'opengever.repository.repositoryroot',
 ]
@@ -72,8 +73,9 @@ VOCAB_OVERRIDES = {
         'responsible': u'<G\xfcltige User-ID>',
     },
     'opengever.task.task.ITask': {
-        'issuer': u'<G\xfcltige User-ID>',
-        'responsible': u'<G\xfcltige User-ID>',
+        'issuer': u'<User-ID eines g\xfcltigen Auftraggebers>',
+        'responsible': u'<User-ID eines g\xfcltigen Auftragnehmers>',
+        'responsible_client': u'<G\xfcltige Org-Unit-ID>',
     },
 }
 
@@ -89,7 +91,12 @@ DEFAULT_OVERRIDES = {
             u'<H\xf6chste auf dieser Ebene vergebene Nummer + 1>',
     },
     'opengever.task.task.ITask': {
-        'deadline': u'<Aktuelles Datum>',
+        'deadline': u'<Aktuelles Datum + 5 Tage> '
+                    u':small-comment:`(konfigurierbarer Default)`',
+        'responsible_client': u'<Kein Default> '
+                              u':small-comment:`(Obwohl dieses Feld im User-Interface '
+                              u'nicht erscheint (vom System automatisch gesetzt wird), '
+                              u'muss es \xfcber die REST API angegeben werden)`',
     },
 }
 

--- a/opengever/base/schemadump/field.py
+++ b/opengever/base/schemadump/field.py
@@ -156,6 +156,12 @@ class FieldDumper(object):
             if isinstance(wrapped_vocab, VdexVocabulary):
                 order_significant = wrapped_vocab.vdex.isOrderSignificant()
 
+            # XXX: The getTaskTypeVocabulary() factory destroys the reference
+            # to the underlying VDEX vocabulary by incorrectly wrapping it.
+            # Therefore the detection for order significance doesn't work.
+            if field.vocabulary and getattr(field.vocabulary, '__name__', '') == 'getTaskTypeVocabulary':  # noqa
+                order_significant = False
+
             # Build list of terms
             if vocabulary is not None:
                 terms = [t.value for t in vocabulary._terms]

--- a/opengever/base/schemadump/tests/test_schemadumps.py
+++ b/opengever/base/schemadump/tests/test_schemadumps.py
@@ -31,9 +31,13 @@ class TestCheckedInSchemaDumpsAreUpToDate(IntegrationTestCase):
             with open(dump_path) as dump_file:
                 existing_schema = json.load(dump_file)
 
+            # Shove schema through dump / load in order to get rid of
+            # OrderedDicts and get better diffability
+            current_schema = json.loads(json.dumps(current_schema.serialize()))
+
             self.assertDictEqual(
                 existing_schema,
-                current_schema.serialize(),
+                current_schema,
                 '\n\nError: JSON schema dumps for %s have changed '
                 '(see diff  above), please run bin/instance dump_schemas and '
                 'commit the modified schema files together with '


### PR DESCRIPTION
As currently published to https://docs.onegovgever.ch/dev-manual/api/content_types/#aufgabe

I had to implement a workaround of the `task_type`s vocabulary in the schema dumper: The [`getTaskTypeVocabulary()`](https://github.com/4teamwork/opengever.core/blob/master/opengever/task/util.py#L66-L79) function incorrectly wraps the underlying VDEX vocabulary, so the reference to the VDEX gets completely destroyed and we can't determine any more whether term order is significant or not, leading to flaky tests (if not addressed).

## Checkliste

- [x] Changelog-Eintrag vorhanden/nötig?
- [x] Aktualisierung Dokumentation vorhanden/nötig?
