### PR TITLE
Fix creating incorrect metadata changed journal entries for OC file uploads.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2019.3.1 (unreleased)
 ---------------------
 
+- Fix journal entries for OfficeConnector API file uploads. [deiferni]
 - Register ChoiceFieldDeserializer using overrides instead of configure ZCML. [lgraf]
 - Docs: Add tasks to documented content types. [lgraf]
 

--- a/opengever/api/tests/test_journal.py
+++ b/opengever/api/tests/test_journal.py
@@ -1,13 +1,11 @@
 from datetime import datetime
 from ftw.builder import Builder
 from ftw.builder import create
-from ftw.journal.config import JOURNAL_ENTRIES_ANNOTATIONS_KEY
 from ftw.testbrowser import browsing
 from ftw.testing import freeze
 from opengever.contact.ogdsuser import OgdsUserToContactAdapter
 from opengever.journal.entry import ManualJournalEntry
 from opengever.testing import IntegrationTestCase
-from zope.annotation import IAnnotations
 import json
 import pytz
 
@@ -18,9 +16,6 @@ def http_headers():
 
 
 class TestJournalPost(IntegrationTestCase):
-
-    def journal_entries(self, obj):
-        return IAnnotations(obj).get(JOURNAL_ENTRIES_ANNOTATIONS_KEY)
 
     @browsing
     def test_add_journal_entry(self, browser):
@@ -211,4 +206,3 @@ class TestJournalGet(IntegrationTestCase):
             'time': u'2017-10-16T00:00:00+00:00',
             'title': u'Manual entry: Information'
             }, response.get('items')[0])
-

--- a/opengever/journal/handlers.py
+++ b/opengever/journal/handlers.py
@@ -358,7 +358,10 @@ def document_modified(context, event):
 
     for desc in event.descriptions:
         for attr in desc.attributes:
-            if attr in ('file', 'message', 'IDocumentMetadata.archival_file'):
+            if attr in ('file',
+                        'message',
+                        'IDocumentMetadata.archival_file',
+                        'IDocumentSchema.file'):
                 file_changed = True
             elif attr in ('IClassification.public_trial', 'public_trial'):
                 # Attribute name is different when changed through regular

--- a/opengever/journal/handlers.py
+++ b/opengever/journal/handlers.py
@@ -367,8 +367,7 @@ def document_modified(context, event):
             else:
                 metadata_changed = True
 
-    if context.REQUEST.get('form.widgets.file.action',
-                           u'nochange') == u'nochange':
+    if context.REQUEST.get('form.widgets.file.action') == u'nochange':
         file_changed = False
 
     if not file_changed and not metadata_changed and not public_trial_changed:

--- a/opengever/officeconnector/tests/test_api_dossier_checkout.py
+++ b/opengever/officeconnector/tests/test_api_dossier_checkout.py
@@ -3,6 +3,7 @@ from ftw.testbrowser import browsing
 from ftw.testing import freeze
 from hashlib import sha256
 from opengever.document.document import Document
+from opengever.journal.handlers import DOCUMENT_MODIIFED_ACTION
 from opengever.officeconnector.testing import FREEZE_DATE
 from opengever.officeconnector.testing import JWT_SIGNING_SECRET_PLONE
 from opengever.officeconnector.testing import OCIntegrationTestCase
@@ -393,6 +394,10 @@ class TestOfficeconnectorDossierAPIWithCheckoutWithRESTAPI(TestOfficeconnectorDo
 
         with open(path_to_asset('addendum.docx')) as f:
             self.upload_document_via_api(browser, raw_token, payloads[0], self.document, f)
+
+        most_recent_journal_entry = self.journal_entries(self.document)[-1]
+        self.assertEqual(DOCUMENT_MODIIFED_ACTION,
+                         most_recent_journal_entry['action']['type'])
 
         new_checksum = sha256(self.download_document(browser, raw_token, payloads[0])).hexdigest()
         self.assertNotEqual(new_checksum, original_checksum)

--- a/opengever/testing/integration_test_case.py
+++ b/opengever/testing/integration_test_case.py
@@ -4,6 +4,7 @@ from contextlib import contextmanager
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.flamegraph import flamegraph
+from ftw.journal.config import JOURNAL_ENTRIES_ANNOTATIONS_KEY
 from ftw.mail.mail import IMail
 from ftw.solr.connection import SolrResponse
 from ftw.solr.interfaces import ISolrSearch
@@ -44,6 +45,7 @@ from plone.portlets.interfaces import ILocalPortletAssignmentManager
 from plone.portlets.interfaces import IPortletManager
 from sqlalchemy.sql.expression import desc
 from z3c.relationfield.relation import RelationValue
+from zope.annotation import IAnnotations
 from zope.component import getMultiAdapter
 from zope.component import getUtility
 from zope.i18n import translate
@@ -748,3 +750,6 @@ class IntegrationTestCase(TestCase):
 
     def assert_provides(self, obj, interface=None):
         self.assertTrue(interface.providedBy(obj), '{} should provide {}'.format(obj, interface))
+
+    def journal_entries(self, obj):
+        return IAnnotations(obj).get(JOURNAL_ENTRIES_ANNOTATIONS_KEY)


### PR DESCRIPTION
🚧 _it has turned out modification detection is a bit meh. investigating._

This PR fixes creation of journal entries when the OfficeConnector API upload feature is enabled.

- Add the correct field to the detection logic that determines if the file has been modified
- Fix an evil default that could not have worked outside web-forms

Fixes #5735.

## Checkliste

- [x] Changelog-Eintrag vorhanden/nötig?
