### PR TITLE
Move changelog entry to the proper position

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2019.3.1 (unreleased)
 ---------------------
 
+- Add restapi @participations endpoint to handle participations. [elioschmutz]
 - Register ChoiceFieldDeserializer using overrides instead of configure ZCML. [lgraf]
 - Docs: Add tasks to documented content types. [lgraf]
 
@@ -96,7 +97,6 @@ Changelog
 - Do not allow sorting on Keywords in dossier and document listings. [njohner]
 - Also update content controls when updating doc properties. [buchi]
 - Include userid and fullname of current user in @config endpoint. [buchi]
-- Add restapi @participations endpoint to handle participations. [elioschmutz]
 - Include preserved_as_paper_default in the @config endpoint and view. [Rotonen]
 - Pass context and orgunit as parameters to webactions. [njohner]
 - Implement resolving dossiers recursively via REST API. [lgraf]


### PR DESCRIPTION
Dieser PR schiebt den Changelog-Eintrag von PR #5599 an die richtige Stelle.

Ich habe nach einem Rebase vergessen, das Changelog zu kontrollieren. In der Zwischenzeit gab es bereits neue Releases.

related to #5589  