### PR TITLE
Bump sablon and nokogiri to RPM versions.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -9,6 +9,7 @@ Changelog
 - Allow range queries on deadline in listing endpoint. [njohner]
 - Update and improve documentation for checked-out documents. [phgross, njohner]
 - Add fields available in listing endpoint for each type to documentation. [njohner]
+- Bump sablon to 0.3.1 and nokogiri to 1.9.1. [deiferni]
 - Add restapi @participations endpoint to handle participations. [elioschmutz]
 - Add per user configuration to deactivate inbox notifications. [njohner]
 - Register ChoiceFieldDeserializer using overrides instead of configure ZCML. [lgraf]

--- a/versions.cfg
+++ b/versions.cfg
@@ -9,7 +9,7 @@ extends =
 [ruby-versions]
 nokogiri = 1.8.1
 ruby = 2.4.5
-sablon = 0.0.21
+sablon = 0.3.1
 
 
 [versions]

--- a/versions.cfg
+++ b/versions.cfg
@@ -7,7 +7,7 @@ extends =
 
 
 [ruby-versions]
-nokogiri = 1.8.1
+nokogiri = 1.9.1
 ruby = 2.4.5
 sablon = 0.3.1
 


### PR DESCRIPTION
In order to get rid of installing ruby dependencies via buildout and to get rid of https://raw.githubusercontent.com/4teamwork/gever-buildouts/master/ruby-gems.cfg we'd like to switch to the sablon and nokogiri versions provided in http://rpm.4teamwork.ch/el7/x86_64/sablon-0.3.1-1.el7.x86_64.rpm as a first step.

- I have locally validated that our example files still can be generated from sablon and that they still look the same.
- I have validated the same thing with a wider set of examples from production.

## Checkliste

_Zutreffendes soll angehakt stehengelassen werden._

- [x] Changelog-Eintrag vorhanden/nötig?
