### PR TITLE
REST-API: Handle workspace invitations

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2019.3.1 (unreleased)
 ---------------------
 
+- Add GET restapi endpint @my-workspace-invitations. [elioschmutz]
 - Add restapi @participations endpoint to handle participations. [elioschmutz]
 - Register ChoiceFieldDeserializer using overrides instead of configure ZCML. [lgraf]
 - Docs: Add tasks to documented content types. [lgraf]

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2019.3.1 (unreleased)
 ---------------------
 
+- Add POST restapi endpint @mworkspace-invitations/{id}/{action}. [elioschmutz]
 - Add GET restapi endpint @my-workspace-invitations. [elioschmutz]
 - Add restapi @participations endpoint to handle participations. [elioschmutz]
 - Register ChoiceFieldDeserializer using overrides instead of configure ZCML. [lgraf]

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -381,4 +381,12 @@
       permission="zope2.View"
       />
 
+  <plone:service
+      method="POST"
+      name="@workspace-invitations"
+      for="*"
+      factory=".participation.InvitationsPost"
+      permission="zope2.View"
+      />
+
 </configure>

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -23,6 +23,7 @@
   <adapter factory=".task.SerializeTaskToJson" />
   <adapter factory=".response.ResponseDefaultFieldSerializer" />
   <adapter factory=".response.SerializeTaskResponseToJson" />
+  <adapter factory=".workspace.SerializeWorkspaceToJson" />
 
   <adapter factory=".mail.DeserializeMailFromJson" />
 

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -373,4 +373,12 @@
       permission="plone.DelegateWorkspaceAdminRole"
       />
 
+  <plone:service
+      method="GET"
+      name="@my-workspace-invitations"
+      for="*"
+      factory=".participation.MyInvitationsGet"
+      permission="zope2.View"
+      />
+
 </configure>

--- a/opengever/api/tests/test_participation.py
+++ b/opengever/api/tests/test_participation.py
@@ -580,3 +580,42 @@ class TestParticipationPatch(IntegrationTestCase):
                 data=data,
                 headers=http_headers(),
                 )
+
+
+class TestMyInvitationsGet(IntegrationTestCase):
+
+    @browsing
+    def test_list_all_my_invitations(self, browser):
+        self.login(self.workspace_owner, browser)
+
+        iid = getUtility(IInvitationStorage).add_invitation(
+            self.workspace,
+            self.regular_user.getId(),
+            self.workspace_owner.getId(),
+            'WorkspaceGuest')
+
+        getUtility(IInvitationStorage).add_invitation(
+            self.workspace,
+            self.reader_user.getId(),
+            self.workspace_owner.getId(),
+            'WorkspaceGuest')
+
+        self.login(self.regular_user, browser)
+
+        response = browser.open(
+            self.portal.absolute_url() + '/@my-workspace-invitations',
+            method='GET',
+            headers=http_headers(),
+        ).json
+
+        self.assertItemsEqual(
+            [
+                {
+                    u'@id': u'http://nohost/plone/@workspace-invitations/{}'.format(iid),
+                    u'@type': u'virtual.participations.invitation',
+                    u'accept': u'http://nohost/plone/@workspace-invitations/{}/accept'.format(iid),
+                    u'decline': u'http://nohost/plone/@workspace-invitations/{}/decline'.format(iid),
+                    u'inviter_fullname': u'Fr\xf6hlich G\xfcnther (gunther.frohlich)',
+                    u'title': u'A Workspace'
+                }
+            ], response.get('items'))

--- a/opengever/api/tests/test_participation.py
+++ b/opengever/api/tests/test_participation.py
@@ -1,6 +1,9 @@
+from datetime import datetime
 from ftw.testbrowser import browsing
+from ftw.testing import freeze
 from opengever.testing import IntegrationTestCase
 from opengever.workspace.participation.storage import IInvitationStorage
+from zExceptions import Unauthorized
 from zope.component import getUtility
 import json
 
@@ -588,11 +591,12 @@ class TestMyInvitationsGet(IntegrationTestCase):
     def test_list_all_my_invitations(self, browser):
         self.login(self.workspace_owner, browser)
 
-        iid = getUtility(IInvitationStorage).add_invitation(
-            self.workspace,
-            self.regular_user.getId(),
-            self.workspace_owner.getId(),
-            'WorkspaceGuest')
+        with freeze(datetime(2018, 4, 30, 10, 30)):
+            iid = getUtility(IInvitationStorage).add_invitation(
+                self.workspace,
+                self.regular_user.getId(),
+                self.workspace_owner.getId(),
+                'WorkspaceGuest')
 
         getUtility(IInvitationStorage).add_invitation(
             self.workspace,
@@ -614,8 +618,156 @@ class TestMyInvitationsGet(IntegrationTestCase):
                     u'@id': u'http://nohost/plone/@workspace-invitations/{}'.format(iid),
                     u'@type': u'virtual.participations.invitation',
                     u'accept': u'http://nohost/plone/@workspace-invitations/{}/accept'.format(iid),
+                    u'created': u'2018-04-30T10:30:00+00:00',
                     u'decline': u'http://nohost/plone/@workspace-invitations/{}/decline'.format(iid),
                     u'inviter_fullname': u'Fr\xf6hlich G\xfcnther (gunther.frohlich)',
                     u'title': u'A Workspace'
                 }
             ], response.get('items'))
+
+
+class TestInvitationsPOST(IntegrationTestCase):
+
+    def get_my_invitations(self, browser):
+        return browser.open(
+            self.portal.absolute_url() + '/@my-workspace-invitations',
+            method='GET',
+            headers=http_headers(),
+        ).json
+
+    @browsing
+    def test_accept_invitation(self, browser):
+        self.login(self.workspace_owner, browser)
+
+        getUtility(IInvitationStorage).add_invitation(
+            self.workspace,
+            self.regular_user.getId(),
+            self.workspace_owner.getId(),
+            'WorkspaceGuest')
+
+        self.login(self.regular_user, browser)
+
+        with self.assertRaises(Unauthorized):
+            browser.visit(self.workspace)
+
+        my_invitations = self.get_my_invitations(browser)
+
+        # Accept first invitation
+        json_workspace = browser.open(
+            my_invitations.get('items')[0].get('accept'),
+            method='POST',
+            headers=http_headers()).json
+
+        my_invitations = self.get_my_invitations(browser)
+        self.assertEqual([], my_invitations.get('items'))
+
+        self.assertEqual(200, browser.visit(json_workspace['@id']).status_code)
+
+    @browsing
+    def test_decline_invitation(self, browser):
+        self.login(self.workspace_owner, browser)
+
+        getUtility(IInvitationStorage).add_invitation(
+            self.workspace,
+            self.regular_user.getId(),
+            self.workspace_owner.getId(),
+            'WorkspaceGuest')
+
+        self.login(self.regular_user, browser)
+
+        with self.assertRaises(Unauthorized):
+            browser.visit(self.workspace)
+
+        my_invitations = self.get_my_invitations(browser)
+
+        # Decline first invitation
+        browser.open(
+            my_invitations.get('items')[0].get('decline'),
+            method='POST',
+            headers=http_headers()).json
+
+        my_invitations = self.get_my_invitations(browser)
+        self.assertEqual([], my_invitations.get('items'))
+
+        with self.assertRaises(Unauthorized):
+            browser.visit(self.workspace)
+
+    @browsing
+    def test_disallow_accept_invitation_of_other_user(self, browser):
+        self.login(self.workspace_owner, browser)
+
+        getUtility(IInvitationStorage).add_invitation(
+            self.workspace,
+            self.regular_user.getId(),
+            self.workspace_owner.getId(),
+            'WorkspaceGuest')
+
+        self.login(self.regular_user, browser)
+
+        my_invitations = self.get_my_invitations(browser)
+        accept_link = my_invitations.get('items')[0].get('accept')
+
+        self.login(self.workspace_owner, browser)
+
+        # Accept invitation of regular-user
+        with browser.expect_http_error(400):
+            browser.open(
+                accept_link,
+                method='POST',
+                headers=http_headers()).json
+
+        self.login(self.regular_user, browser)
+        my_invitations = self.get_my_invitations(browser)
+        self.assertEqual(1, len(my_invitations.get('items')))
+
+    @browsing
+    def test_disallow_decline_invitation_of_other_user(self, browser):
+        self.login(self.workspace_owner, browser)
+
+        getUtility(IInvitationStorage).add_invitation(
+            self.workspace,
+            self.regular_user.getId(),
+            self.workspace_owner.getId(),
+            'WorkspaceGuest')
+
+        self.login(self.regular_user, browser)
+
+        my_invitations = self.get_my_invitations(browser)
+        accept_link = my_invitations.get('items')[0].get('decline')
+
+        self.login(self.workspace_owner, browser)
+
+        # Decline invitation of regular-user
+        with browser.expect_http_error(400):
+            browser.open(
+                accept_link,
+                method='POST',
+                headers=http_headers()).json
+
+        self.login(self.regular_user, browser)
+        my_invitations = self.get_my_invitations(browser)
+        self.assertEqual(1, len(my_invitations.get('items')))
+
+    @browsing
+    def test_raise_404_for_unknown_action(self, browser):
+        self.login(self.workspace_owner, browser)
+
+        getUtility(IInvitationStorage).add_invitation(
+            self.workspace,
+            self.regular_user.getId(),
+            self.workspace_owner.getId(),
+            'WorkspaceGuest')
+
+        self.login(self.regular_user, browser)
+
+        my_invitations = self.get_my_invitations(browser)
+        accept_link = my_invitations.get('items')[0].get('decline')
+
+        self.login(self.workspace_owner, browser)
+
+        # Decline invitation of regular-user
+        with browser.expect_http_error(404):
+            browser.open(
+                accept_link + 'unknown',
+                method='POST',
+                headers=http_headers()).json

--- a/opengever/api/tests/test_workspace.py
+++ b/opengever/api/tests/test_workspace.py
@@ -1,0 +1,19 @@
+from ftw.testbrowser import browsing
+from opengever.testing import IntegrationTestCase
+
+
+class TestWorkspaceSerializer(IntegrationTestCase):
+
+    @browsing
+    def test_workspace_serialization_contains_can_manage_participants(self, browser):
+        self.login(self.workspace_member, browser)
+        response = browser.open(
+            self.workspace, headers={'Accept': 'application/json'}).json
+
+        self.assertFalse(response.get(u'can_manage_participants'))
+
+        self.login(self.workspace_owner, browser)
+        response = browser.open(
+            self.workspace, headers={'Accept': 'application/json'}).json
+
+        self.assertTrue(response.get(u'can_manage_participants'))

--- a/opengever/api/workspace.py
+++ b/opengever/api/workspace.py
@@ -1,0 +1,21 @@
+from opengever.api.serializer import GeverSerializeFolderToJson
+from opengever.workspace.interfaces import IWorkspace
+from opengever.workspace.participation.browser.manage_participants import ManageParticipants
+from plone.restapi.interfaces import ISerializeToJson
+from zope.component import adapter
+from zope.interface import implementer
+from zope.interface import Interface
+
+
+@implementer(ISerializeToJson)
+@adapter(IWorkspace, Interface)
+class SerializeWorkspaceToJson(GeverSerializeFolderToJson):
+
+    def __call__(self, *args, **kwargs):
+        result = super(SerializeWorkspaceToJson, self).__call__(*args, **kwargs)
+
+        manager = ManageParticipants(self.context, self.request)
+
+        result[u"can_manage_participants"] = manager.can_manage_member()
+
+        return result

--- a/opengever/workspace/tests/test_my_invitations.py
+++ b/opengever/workspace/tests/test_my_invitations.py
@@ -71,7 +71,7 @@ class TestMyInvitationsView(IntegrationTestCase):
     def test_cannot_accept_invalid_invitation(self, browser):
         self.login(self.regular_user, browser=browser)
 
-        with browser.expect_http_error(503):
+        with browser.expect_http_error(400):
             browser.open(self.workspace_root.absolute_url() + '/my-invitations/accept',
                          data={'iid': 'someinvalidiid',
                                '_authenticator': createToken()})
@@ -115,7 +115,7 @@ class TestMyInvitationsView(IntegrationTestCase):
     def test_cannot_decline_invalid_invitation(self, browser):
         self.login(self.regular_user, browser=browser)
 
-        with browser.expect_http_error(503):
+        with browser.expect_http_error(400):
             browser.open(self.workspace_root.absolute_url() + '/my-invitations/decline',
                          data={'iid': 'someinvalidiid',
                                '_authenticator': createToken()})


### PR DESCRIPTION
Das GEVER-UI benötigt einen Endpoint zum Anzeigen von Teamraum-Einladungen sowie zum Annehmen und Ablehnen von Einladungen.

Dieser PR implementiert die entsprechenden Endpoints.

Issuer: https://github.com/4teamwork/gever-ui/issues/21
## Checkliste

_Zutreffendes soll angehakt stehengelassen werden._

- [x] Changelog-Eintrag vorhanden/nötig?
- [x] Aktualisierung Dokumentation vorhanden/nötig?
