### PR TITLE
Allow range queries on deadline in listing endpoint.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 
 - Add POST restapi endpint @mworkspace-invitations/{id}/{action}. [elioschmutz]
 - Add GET restapi endpint @my-workspace-invitations. [elioschmutz]
+- Allow range queries on deadline in listing endpoint. [njohner]
 - Add restapi @participations endpoint to handle participations. [elioschmutz]
 - Add per user configuration to deactivate inbox notifications. [njohner]
 - Register ChoiceFieldDeserializer using overrides instead of configure ZCML. [lgraf]

--- a/opengever/api/listing.py
+++ b/opengever/api/listing.py
@@ -148,6 +148,7 @@ DATE_INDEXES = set([
     'modified',
     'receipt_date',
     'start',
+    'deadline',
 ])
 
 SOLR_FILTERS = {


### PR DESCRIPTION
We allow range queries on the deadline in the listing endpoint. This is necessary for the new frontend.

resolves #5743 

## Checkliste

- [x] Wurde etwas an der `Aufgabe` angepasst? Funktioniert das auch mit einer `Weiterleitung`?
- [x] Changelog-Eintrag vorhanden/nötig?
- [ ] Aktualisierung Dokumentation vorhanden/nötig? Not necessary.
