### PR TITLE
Add optional facet values and counts search to listing endpoint

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,7 @@ Changelog
 - Avoid reindexing 'created' during IObjectCopiedEvent to fix copy & pasting with Solr. [lgraf]
 - @listing endpoint: Add support for filtering by relative path depth. [lgraf]
 - Update plone.restapi to latest release. [phgross]
+- Add optional facet values and counts search to listing endpoint. [njohner]
 - Add POST restapi endpint @mworkspace-invitations/{id}/{action}. [elioschmutz]
 - Add GET restapi endpint @my-workspace-invitations. [elioschmutz]
 - Allow range queries on deadline in listing endpoint. [njohner]

--- a/docs/public/dev-manual/api/listings.rst
+++ b/docs/public/dev-manual/api/listings.rst
@@ -205,6 +205,7 @@ Optionale Parameter:
   - ``1``: Nur die unmittelbaren children unterhalb des Kontexts
   - ``2``: Unmittelbare children, und deren direkte children
   - etc.
+- ``facets``: Für diese Felder auch die Facetten Wertebereichen liefern.
 
 
 **Beispiel: Sortierung nach Änderungsdatum, neuste Dokumente zuerst:**
@@ -228,4 +229,11 @@ Optionale Parameter:
   .. sourcecode:: http
 
     GET /ordnungssystem/fuehrung/dossier-23/@listing?name=documents&sort_on=modified&filters.start:record:=2018-08-20TO2018-09-20 HTTP/1.1
+    Accept: application/json
+
+**Beispiel: Werte-Bereiche von Ersteller auch liefern**
+
+  .. sourcecode:: http
+
+    GET /ordnungssystem/fuehrung/dossier-23/@listing?name=documents&facets:list=creator HTTP/1.1
     Accept: application/json

--- a/opengever/api/tests/test_listing.py
+++ b/opengever/api/tests/test_listing.py
@@ -529,3 +529,18 @@ class TestListingEndpointWithSolr(IntegrationTestCase):
 
         filters = self.conn.search.call_args[0][0]['filter']
         self.assertIn(u'path_depth:[* TO 6]', filters)
+
+    @browsing
+    def test_facet_counts(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        view = ('@listing?name=documents&columns:list=title'
+                '&facets:list=start')
+        browser.open(self.repository_root, view=view,
+                     headers={'Accept': 'application/json'})
+
+        params = self.conn.search.call_args[0][0]["params"]
+        self.assertTrue(params['facet'],
+                        msg="facet=true is needed to get facet counts back")
+        self.assertEqual(1, params['facet.mincount'])
+        self.assertEqual(['start'], params['facet.field'])

--- a/opengever/api/tests/test_listing.py
+++ b/opengever/api/tests/test_listing.py
@@ -9,6 +9,7 @@ from opengever.api.listing import get_path_depth
 from opengever.base.solr import OGSolrContentListingObject
 from opengever.base.solr import OGSolrDocument
 from opengever.testing import IntegrationTestCase
+from unittest import skip
 from zope.component import getUtility
 
 
@@ -544,3 +545,7 @@ class TestListingEndpointWithSolr(IntegrationTestCase):
                         msg="facet=true is needed to get facet counts back")
         self.assertEqual(1, params['facet.mincount'])
         self.assertEqual(['start'], params['facet.field'])
+
+    @skip("Just a reminder to test that facets also return translated labels")
+    def test_facet_labels(self):
+        pass


### PR DESCRIPTION
For the new GEVER UI we need the possibility to optionally query for facet available values on the listing endpoint. 

resolves #5738 

## Checkliste

- [x] Changelog-Eintrag vorhanden/nötig?
- [x] Aktualisierung Dokumentation vorhanden/nötig?

- [x] Still need to bump ftw.solr instead of installing from source once it is released