### PR TITLE
Fix notification settings view for zopemaster.

### DIFF
--- a/opengever/activity/__init__.py
+++ b/opengever/activity/__init__.py
@@ -170,20 +170,18 @@ ACTIVITY_TRANSLATIONS = {
         'title': _('notify_own_actions_title',
                    default=u'Enable notifications for own actions'),
         'help_text': _('notify_own_actions_help',
-                   default=u'By default notifications are suppressed when the '
-                             'recipient is the user who performed the action. '
-                             'Please note that, notwithstanding this setting, '
-                             'notifications only get generated for combinations '
-                             'of actions and roles for which the user has '
-                             'activated the notifications')
+                   default=u'By default no notifications are emitted for a '
+                            'users\'own actions. This option allows to modify '
+                            'this behavior. Notwithstanding this configuration, '
+                            'user notification settings for each action type '
+                            'will get applied anyway.')
          },
     'notify_inbox_actions': {
         'title': _('notify_inbox_actions_title',
                    default=u'Enable notifications for inbox actions'),
         'help_text': _('notify_inbox_actions_help',
-                   default=u'Some notifications are sent to all users of an '
-                            'inbox. This option allows these users to activate'
-                            'or deactivate such notifications.')
+                   default=u'Activate, respectively deactivate, all '
+                            'notifications due to your inbox permissions.')
          }
 }
 

--- a/opengever/activity/browser/settings.py
+++ b/opengever/activity/browser/settings.py
@@ -141,7 +141,11 @@ class NotificationSettings(BrowserView):
         """Save global configuration change
         """
         userid = api.user.get_current().getId()
-        user = User.query.filter_by(userid=userid).one()
+        user = User.query.filter_by(userid=userid).one_or_none()
+        if user is None:
+            # User with no entry in the ogds, probably zopemaster.
+            msg = "Cannot save configuration for this user as he is not in the ogds"
+            return JSONResponse(self.request).error(msg).proceed().dump()
 
         config_name = self.request.form['config_name']
         value = json.loads(self.request.form['value'])
@@ -266,7 +270,10 @@ class NotificationSettings(BrowserView):
 
     def get_user_configuration(self, config_name):
         userid = api.user.get_current().getId()
-        user = User.query.filter_by(userid=userid).one()
+        user = User.query.filter_by(userid=userid).one_or_none()
+        if user is None:
+            # User with no entry in the ogds, probably zopemaster.
+            return self.get_default_configuration(config_name)
         return getattr(user, config_name)
 
     def get_default_configuration(self, config_name):

--- a/opengever/activity/locales/de/LC_MESSAGES/opengever.activity.po
+++ b/opengever/activity/locales/de/LC_MESSAGES/opengever.activity.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-06-24 12:11+0000\n"
+"POT-Creation-Date: 2019-06-28 06:53+0000\n"
 "PO-Revision-Date: 2015-02-24 08:40+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -218,25 +218,25 @@ msgstr "Aufgaben"
 msgid "msg_error_not_notified"
 msgstr "Während dem Erzeugen der Benachrichtigung ist ein Fehler aufgetreten. Die Benachrichtigung wurde deshalb nicht oder nur zum Teil ausgelöst."
 
-#. Default: "Some notifications are sent to all users of an inbox. This option allows these users to activateor deactivate such notifications."
+#. Default: "Activate, respectively deactivate, all notifications due to your inbox permissions."
 #: ./opengever/activity/__init__.py
 msgid "notify_inbox_actions_help"
-msgstr "Gewisse Benachrichtigungen werden an alle Benutzer vom Eingangskorb gesendet. Mit dieser Option können die betroffenen Benutzer diese Art von Benachrichtigungen aktivieren oder deaktivieren."
+msgstr "Alle Benachrichtigungen aufgrund von Eingangskorbberechtigung aktivieren bzw. deaktivieren."
 
 #. Default: "Enable notifications for inbox actions"
 #: ./opengever/activity/__init__.py
 msgid "notify_inbox_actions_title"
 msgstr "Benachrichtigungen für Eingangskorb aktivieren"
 
-#. Default: "By default notifications are suppressed when the recipient is the user who performed the action. Please note that, notwithstanding this setting, notifications only get generated for combinations of actions and roles for which the user has activated the notifications"
+#. Default: "By default no notifications are emitted for a users'own actions. This option allows to modify this behavior. Notwithstanding this configuration, user notification settings for each action type will get applied anyway."
 #: ./opengever/activity/__init__.py
 msgid "notify_own_actions_help"
-msgstr "Standardmässig werden keine Benachrichtigungen ausgelöst, wenn der Empfänger der Benachrichtigung identisch ist mit der Person, welche die Aktion ausgeführt hat. Mit dieser neuen Option kann die Benachrichtigung ausdrücklich zugelassen werden.<br/>Bitte beachten Sie, dass Ihre persönlich vorgenommenen Benachrichtigungseinstellungen pro einzelne Aktion aber nach wie vor angewendet werden. Mit anderen Worten: Sie persönlich erhalten keine Benachrichtigung, wenn Sie die entsprechende Checkbox (zB Aufgabe abgeschlossen) deaktiviert haben."
+msgstr "Standardmässig werden für selbst ausgeführte Aktionen keine Benachrichtigungen ausgelöst. Mit dieser Option kann dieses Verhalten verändert werden. Persönlich vorgenommene Benachrichtigungseinstellungen pro Aktionstyp gelten dabei nach wie vor."
 
 #. Default: "Enable notifications for own actions"
 #: ./opengever/activity/__init__.py
 msgid "notify_own_actions_title"
-msgstr "Benachrichtigung für eigene Aktionen zulassen"
+msgstr "Benachrichtigung für eigene Aktionen aktivieren"
 
 #. Default: "Additional documents submitted"
 #: ./opengever/activity/__init__.py

--- a/opengever/activity/locales/fr/LC_MESSAGES/opengever.activity.po
+++ b/opengever/activity/locales/fr/LC_MESSAGES/opengever.activity.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-06-24 12:11+0000\n"
+"POT-Creation-Date: 2019-06-28 06:53+0000\n"
 "PO-Revision-Date: 2017-12-03 16:14+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-activity/fr/>\n"
@@ -220,25 +220,25 @@ msgstr "Tâches"
 msgid "msg_error_not_notified"
 msgstr "Un problème a apparu pendant la création de la notification. La notification n’a pas pu être produite ou seulement partiellement."
 
-#. Default: "Some notifications are sent to all users of an inbox. This option allows these users to activateor deactivate such notifications."
+#. Default: "Activate, respectively deactivate, all notifications due to your inbox permissions."
 #: ./opengever/activity/__init__.py
 msgid "notify_inbox_actions_help"
-msgstr "Certaines notifications sont émises pour tous les utilisateurs de la boîte de récéption. Avec cette option, les utilisateurs concernés peuvent choisir d'activer ou de désactiver ce type de notifications."
+msgstr "Activer, respectivement désactiver, toutes les notifications dues à vos autorisations sur une boîte de réception"
 
 #. Default: "Enable notifications for inbox actions"
 #: ./opengever/activity/__init__.py
 msgid "notify_inbox_actions_title"
 msgstr "Activer les notifications pour la boîte de réception"
 
-#. Default: "By default notifications are suppressed when the recipient is the user who performed the action. Please note that, notwithstanding this setting, notifications only get generated for combinations of actions and roles for which the user has activated the notifications"
+#. Default: "By default no notifications are emitted for a users'own actions. This option allows to modify this behavior. Notwithstanding this configuration, user notification settings for each action type will get applied anyway."
 #: ./opengever/activity/__init__.py
 msgid "notify_own_actions_help"
-msgstr "Normalement aucune notification n'est émise pour une action si le destinataire est identique à la personne qui vient d'exécuter cette action. Cette option permet d'expressément autoriser ces notifications.<br/>Veuillez noter que vos paramètres de notifications personnels par action s'appliquent indépendamment de cette option. En d'autres termes: vous, personellement, ne recevrez pas de notifications pour un évènement (par exemple une tâche clôturée), si vous n'avez pas activé les notifications pour cet évènement (par exemple case à cocher 'tâche clôturée')"
+msgstr "Normalement aucune notification n'est émise pour vos propres actions. Cette option permet de modifier ce comportement. Les paramètres personnels de notifications pour chaque type d'action sont néanmoins toujours appliqués."
 
 #. Default: "Enable notifications for own actions"
 #: ./opengever/activity/__init__.py
 msgid "notify_own_actions_title"
-msgstr "Autoriser les notifications pour ses propres actions"
+msgstr "Activer les notifications pour ses propres actions"
 
 #. Default: "Additional documents submitted"
 #: ./opengever/activity/__init__.py

--- a/opengever/activity/locales/opengever.activity.pot
+++ b/opengever/activity/locales/opengever.activity.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-06-24 12:11+0000\n"
+"POT-Creation-Date: 2019-06-28 06:53+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -218,7 +218,7 @@ msgstr ""
 msgid "msg_error_not_notified"
 msgstr ""
 
-#. Default: "Some notifications are sent to all users of an inbox. This option allows these users to activateor deactivate such notifications."
+#. Default: "Activate, respectively deactivate, all notifications due to your inbox permissions."
 #: ./opengever/activity/__init__.py
 msgid "notify_inbox_actions_help"
 msgstr ""
@@ -228,7 +228,7 @@ msgstr ""
 msgid "notify_inbox_actions_title"
 msgstr ""
 
-#. Default: "By default notifications are suppressed when the recipient is the user who performed the action. Please note that, notwithstanding this setting, notifications only get generated for combinations of actions and roles for which the user has activated the notifications"
+#. Default: "By default no notifications are emitted for a users'own actions. This option allows to modify this behavior. Notwithstanding this configuration, user notification settings for each action type will get applied anyway."
 #: ./opengever/activity/__init__.py
 msgid "notify_own_actions_help"
 msgstr ""


### PR DESCRIPTION
The notification settings view was not working for zopemaster (see https://github.com/4teamwork/opengever.core/pull/5730), which gets fixed with this PR. Users with no entry in the ogds, like zopemaster, are now handled separately. Default configurations are shown for them and an error message is displayed if they try to save a personal configuration.

**notification settings view for zopemaster after trying to save a config change. An error message is displayed and default values are shown for the configurations**
<img width="1061" alt="Screen Shot 2019-06-28 at 10 11 12" src="https://user-images.githubusercontent.com/7374243/60327807-244d6080-998d-11e9-9acf-93106afa3c38.png">

closes #5762 

## Checkliste
- [x] Gibt es neue Übersetzungen?
  *I did not translate the error message, which is only meant for zopemaster*
- [x] Changelog-Eintrag vorhanden/nötig?
  *No changelog, as there is already a CL entry for these settings in the same release*
