### PR TITLE
Teamraum Aufgaben Typ

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -11,6 +11,7 @@ Changelog
 - @listing endpoint: Add support for filtering by relative path depth. [lgraf]
 - Update plone.restapi to latest release. [phgross]
 - Add optional facet values and counts search to listing endpoint. [njohner]
+- Add teamraum todo content-type. [elioschmutz]
 - Add POST restapi endpint @mworkspace-invitations/{id}/{action}. [elioschmutz]
 - Add GET restapi endpint @my-workspace-invitations. [elioschmutz]
 - Allow range queries on deadline in listing endpoint. [njohner]

--- a/opengever/core/locales/de/LC_MESSAGES/opengever.core.po
+++ b/opengever/core/locales/de/LC_MESSAGES/opengever.core.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2019-05-14 08:01+0000\n"
+"POT-Creation-Date: 2019-06-28 11:22+0000\n"
 "PO-Revision-Date: 2017-09-18 15:21+0200\n"
 "Last-Translator: Philippe Gross <p.gross@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -281,6 +281,11 @@ msgstr "Standardablauf"
 #: ./opengever/core/profiles/default/types/opengever.dossier.templatefolder.xml
 msgid "Template Folder"
 msgstr "Vorlagenordner"
+
+#: ./opengever/core/profiles/default/types/opengever.workspace.todo.xml
+#: ./opengever/core/upgrades/20190628125241_install_workspace_todo_type/types/opengever.workspace.todo.xml
+msgid "ToDo"
+msgstr "ToDo"
 
 #: ./opengever/core/profiles/default/actions.xml
 msgid "Toggle orgunit selector"

--- a/opengever/core/locales/fr/LC_MESSAGES/opengever.core.po
+++ b/opengever/core/locales/fr/LC_MESSAGES/opengever.core.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2019-05-14 08:01+0000\n"
+"POT-Creation-Date: 2019-06-28 11:22+0000\n"
 "PO-Revision-Date: 2013-03-27 10:44+0100\n"
 "Last-Translator: Philippe Gross <p.gross@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -276,6 +276,11 @@ msgstr "Déroulement standard"
 #: ./opengever/core/profiles/default/types/opengever.dossier.templatefolder.xml
 msgid "Template Folder"
 msgstr "Dossier des modèles"
+
+#: ./opengever/core/profiles/default/types/opengever.workspace.todo.xml
+#: ./opengever/core/upgrades/20190628125241_install_workspace_todo_type/types/opengever.workspace.todo.xml
+msgid "ToDo"
+msgstr ""
 
 #: ./opengever/core/profiles/default/actions.xml
 msgid "Toggle orgunit selector"

--- a/opengever/core/locales/opengever.core.pot
+++ b/opengever/core/locales/opengever.core.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-05-14 08:01+0000\n"
+"POT-Creation-Date: 2019-06-28 11:22+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -278,6 +278,11 @@ msgstr ""
 
 #: ./opengever/core/profiles/default/types/opengever.dossier.templatefolder.xml
 msgid "Template Folder"
+msgstr ""
+
+#: ./opengever/core/profiles/default/types/opengever.workspace.todo.xml
+#: ./opengever/core/upgrades/20190628125241_install_workspace_todo_type/types/opengever.workspace.todo.xml
+msgid "ToDo"
 msgstr ""
 
 #: ./opengever/core/profiles/default/actions.xml

--- a/opengever/core/profiles/default/types.xml
+++ b/opengever/core/profiles/default/types.xml
@@ -58,6 +58,7 @@
   <object name="opengever.workspace.root" meta_type="Dexterity FTI" />
   <object name="opengever.workspace.workspace" meta_type="Dexterity FTI" />
   <object name="opengever.workspace.folder" meta_type="Dexterity FTI" />
+  <object name="opengever.workspace.todo" meta_type="Dexterity FTI" />
 
   <!-- POLICY -->
   <object name="Plone Site" meta_type="Factory-based Type Information with dynamic views" />

--- a/opengever/core/profiles/default/types/opengever.workspace.todo.xml
+++ b/opengever/core/profiles/default/types/opengever.workspace.todo.xml
@@ -1,0 +1,60 @@
+<object xmlns:i18n="http://xml.zope.org/namespaces/i18n" name="opengever.workspace.todo" meta_type="Dexterity FTI" i18n:domain="opengever.core">
+
+  <!-- Basic metadata -->
+  <property name="title" i18n:translate="">ToDo</property>
+  <property name="description" />
+  <property name="icon_expr" />
+  <property name="allow_discussion">False</property>
+  <property name="global_allow">False</property>
+  <property name="filter_content_types">True</property>
+  <property name="allowed_content_types" />
+
+  <!-- schema interface -->
+  <property name="schema">opengever.workspace.workspace_todo.IToDoSchema</property>
+
+  <!-- class used for content items -->
+  <property name="klass">opengever.workspace.workspace_todo.ToDo</property>
+
+  <!-- add permission -->
+  <property name="add_permission">cmf.AddPortalContent</property>
+
+  <!-- enabled behaviors -->
+  <property name="behaviors">
+    </property>
+
+  <!-- View information -->
+  <property name="immediate_view">view</property>
+  <property name="default_view">view</property>
+  <property name="default_view_fallback">False</property>
+  <property name="view_methods">
+    <element value="view" />
+  </property>
+
+  <!-- Method aliases -->
+  <alias from="(Default)" to="(selected layout)" />
+  <alias from="edit" to="@@edit" />
+  <alias from="sharing" to="@@sharing" />
+  <alias from="view" to="@@view" />
+
+  <!-- Actions -->
+  <action
+      title="View"
+      action_id="view"
+      category="object"
+      condition_expr=""
+      url_expr="string:${object_url}"
+      visible="True">
+    <permission value="View" />
+  </action>
+
+  <action
+      title="Edit"
+      action_id="edit"
+      category="object"
+      condition_expr=""
+      url_expr="string:${object_url}/edit"
+      visible="True">
+    <permission value="Modify portal content" />
+  </action>
+
+</object>

--- a/opengever/core/profiles/default/types/opengever.workspace.workspace.xml
+++ b/opengever/core/profiles/default/types/opengever.workspace.workspace.xml
@@ -10,7 +10,7 @@
   <property name="allowed_content_types">
     <element value="opengever.document.document" />
     <element value="ftw.mail.mail" />
-    <element value="opengever.task.task" />
+    <element value="opengever.workspace.todo" />
     <element value="opengever.workspace.folder" />
   </property>
 

--- a/opengever/core/profiles/default/workflows.xml
+++ b/opengever/core/profiles/default/workflows.xml
@@ -161,6 +161,8 @@
       <bound-workflow workflow_id="opengever_workspace_folder" />
     </type>
 
+    <type type_id="opengever.workspace.todo" />
+
   </bindings>
 
 </object>

--- a/opengever/core/upgrades/20190628125241_install_workspace_todo_type/types.xml
+++ b/opengever/core/upgrades/20190628125241_install_workspace_todo_type/types.xml
@@ -1,0 +1,3 @@
+<object name="portal_types" meta_type="Plone Types Tool">
+  <object name="opengever.workspace.todo" meta_type="Dexterity FTI" />
+</object>

--- a/opengever/core/upgrades/20190628125241_install_workspace_todo_type/types/opengever.workspace.todo.xml
+++ b/opengever/core/upgrades/20190628125241_install_workspace_todo_type/types/opengever.workspace.todo.xml
@@ -1,0 +1,60 @@
+<object xmlns:i18n="http://xml.zope.org/namespaces/i18n" name="opengever.workspace.todo" meta_type="Dexterity FTI" i18n:domain="opengever.core">
+
+  <!-- Basic metadata -->
+  <property name="title" i18n:translate="">ToDo</property>
+  <property name="description" />
+  <property name="icon_expr" />
+  <property name="allow_discussion">False</property>
+  <property name="global_allow">False</property>
+  <property name="filter_content_types">True</property>
+  <property name="allowed_content_types" />
+
+  <!-- schema interface -->
+  <property name="schema">opengever.workspace.workspace_todo.IToDoSchema</property>
+
+  <!-- class used for content items -->
+  <property name="klass">opengever.workspace.workspace_todo.ToDo</property>
+
+  <!-- add permission -->
+  <property name="add_permission">cmf.AddPortalContent</property>
+
+  <!-- enabled behaviors -->
+  <property name="behaviors">
+    </property>
+
+  <!-- View information -->
+  <property name="immediate_view">view</property>
+  <property name="default_view">view</property>
+  <property name="default_view_fallback">False</property>
+  <property name="view_methods">
+    <element value="view" />
+  </property>
+
+  <!-- Method aliases -->
+  <alias from="(Default)" to="(selected layout)" />
+  <alias from="edit" to="@@edit" />
+  <alias from="sharing" to="@@sharing" />
+  <alias from="view" to="@@view" />
+
+  <!-- Actions -->
+  <action
+      title="View"
+      action_id="view"
+      category="object"
+      condition_expr=""
+      url_expr="string:${object_url}"
+      visible="True">
+    <permission value="View" />
+  </action>
+
+  <action
+      title="Edit"
+      action_id="edit"
+      category="object"
+      condition_expr=""
+      url_expr="string:${object_url}/edit"
+      visible="True">
+    <permission value="Modify portal content" />
+  </action>
+
+</object>

--- a/opengever/core/upgrades/20190628125241_install_workspace_todo_type/types/opengever.workspace.workspace.xml
+++ b/opengever/core/upgrades/20190628125241_install_workspace_todo_type/types/opengever.workspace.workspace.xml
@@ -1,0 +1,8 @@
+<object xmlns:i18n="http://xml.zope.org/namespaces/i18n" name="opengever.workspace.workspace" meta_type="Dexterity FTI" i18n:domain="opengever.core">
+
+  <property name="allowed_content_types" purge="False">
+    <element value="opengever.task.task" remove="True"/>
+    <element value="opengever.workspace.todo" />
+  </property>
+
+</object>

--- a/opengever/core/upgrades/20190628125241_install_workspace_todo_type/upgrade.py
+++ b/opengever/core/upgrades/20190628125241_install_workspace_todo_type/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class InstallWorkspaceTodoType(UpgradeStep):
+    """Install workspace todo type.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/core/upgrades/20190628125241_install_workspace_todo_type/workflows.xml
+++ b/opengever/core/upgrades/20190628125241_install_workspace_todo_type/workflows.xml
@@ -1,0 +1,7 @@
+<object name="portal_workflow" meta_type="Plone Workflow Tool">
+
+  <bindings>
+    <type type_id="opengever.workspace.todo" />
+  </bindings>
+
+</object>

--- a/opengever/testing/builders/dx.py
+++ b/opengever/testing/builders/dx.py
@@ -634,3 +634,10 @@ class WorkspaceFolderBuilder(DexterityBuilder):
 
 
 builder_registry.register('workspace folder', WorkspaceFolderBuilder)
+
+
+class ToDoBuilder(DexterityBuilder):
+    portal_type = 'opengever.workspace.todo'
+
+
+builder_registry.register('todo', ToDoBuilder)

--- a/opengever/workspace/browser/configure.zcml
+++ b/opengever/workspace/browser/configure.zcml
@@ -48,4 +48,11 @@
       permission="zope2.View"
       />
 
+  <browser:page
+      for="*"
+      name="tabbedview_view-todos"
+      class=".tabs.Todos"
+      permission="zope2.View"
+      />
+
 </configure>

--- a/opengever/workspace/browser/tabbed.py
+++ b/opengever/workspace/browser/tabbed.py
@@ -15,9 +15,9 @@ class WorkspaceTabbedView(GeverTabbedView):
         'title': _(u'label_documents', default=u'Documents'),
         }
 
-    tasks_tab = {
-        'id': 'tasks',
-        'title': _(u'label_tasks', default=u'Tasks'),
+    todo_tab = {
+        'id': 'todos',
+        'title': _(u'label_todo', default=u'ToDo'),
         }
 
     trash_tab = {
@@ -34,7 +34,7 @@ class WorkspaceTabbedView(GeverTabbedView):
         return filter(None, [
             self.folders_tab,
             self.documents_tab,
-            self.tasks_tab,
+            self.todo_tab,
             self.trash_tab,
             self.journal_tab,
 

--- a/opengever/workspace/browser/tabs.py
+++ b/opengever/workspace/browser/tabs.py
@@ -1,6 +1,8 @@
-from opengever.tabbedview.helper import linked
-from opengever.workspace import _
 from opengever.tabbedview import BaseCatalogListingTab
+from opengever.tabbedview.helper import linked
+from opengever.tabbedview.helper import readable_date
+from opengever.tabbedview.helper import readable_ogds_author
+from opengever.workspace import _
 
 
 class Workspaces(BaseCatalogListingTab):
@@ -27,3 +29,26 @@ class WorkspaceFolders(Workspaces):
     """
 
     types = ['opengever.workspace.folder']
+
+
+class Todos(BaseCatalogListingTab):
+
+    types = ['opengever.workspace.todo']
+
+    columns = (
+
+        {'column': 'Title',
+         'column_title': _(u'label_title', default=u'Title'),
+         'sort_index': 'sortable_title',
+         'transform': linked,
+         'width': 500},
+
+        {'column': 'responsible',
+         'column_title': _(u'label_responsible',
+                           default=u"Responsible"),
+         'transform': readable_ogds_author},
+
+        {'column': 'deadline',
+         'column_title': _(u'label_deadline', default=u'Deadline'),
+         'transform': readable_date},
+    )

--- a/opengever/workspace/configure.zcml
+++ b/opengever/workspace/configure.zcml
@@ -10,8 +10,10 @@
   <include package=".browser" />
   <include package=".behaviors" />
   <include package=".participation" />
+
   <adapter factory=".sequence.WorkspaceSequenceNumberGenerator" />
   <adapter factory=".sequence.WorkspaceFolderSequenceNumberGenerator" />
+  <adapter factory=".workspace_todo.ToDoNameChooser" />
 
   <subscriber
       for="opengever.workspace.interfaces.IWorkspace

--- a/opengever/workspace/interfaces.py
+++ b/opengever/workspace/interfaces.py
@@ -21,3 +21,7 @@ class IWorkspaceSettings(Interface):
         title=u'Enable workspace feature',
         description=u'Whether workspace integration is enabled',
         default=False)
+
+
+class IToDo(Interface):
+    """ Marker interface for ToDos """

--- a/opengever/workspace/locales/de/LC_MESSAGES/opengever.workspace.po
+++ b/opengever/workspace/locales/de/LC_MESSAGES/opengever.workspace.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-04-26 12:32+0000\n"
+"POT-Creation-Date: 2019-07-01 07:32+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -112,6 +112,17 @@ msgstr "Federführung"
 msgid "invitation"
 msgstr "Einladung"
 
+#. Default: "Completed"
+#: ./opengever/workspace/workspace_todo.py
+msgid "label_completed"
+msgstr "Erledigt"
+
+#. Default: "Deadline"
+#: ./opengever/workspace/browser/tabs.py
+#: ./opengever/workspace/workspace_todo.py
+msgid "label_deadline"
+msgstr "Zu erledigen bis"
+
 #. Default: "Description"
 #: ./opengever/workspace/browser/tabs.py
 msgid "label_description"
@@ -132,15 +143,27 @@ msgstr "Ordner"
 msgid "label_journal"
 msgstr "Journal"
 
-#. Default: "Tasks"
-#: ./opengever/workspace/browser/tabbed.py
-msgid "label_tasks"
-msgstr "Aufgaben"
+#. Default: "Responsible"
+#: ./opengever/workspace/browser/tabs.py
+#: ./opengever/workspace/workspace_todo.py
+msgid "label_responsible"
+msgstr "Verantwortlich"
+
+#. Default: "Text"
+#: ./opengever/workspace/workspace_todo.py
+msgid "label_text"
+msgstr "Text"
 
 #. Default: "Title"
 #: ./opengever/workspace/browser/tabs.py
+#: ./opengever/workspace/workspace_todo.py
 msgid "label_title"
 msgstr "Titel"
+
+#. Default: "ToDo"
+#: ./opengever/workspace/browser/tabbed.py
+msgid "label_todo"
+msgstr "ToDo"
 
 #. Default: "Trash"
 #: ./opengever/workspace/browser/tabbed.py

--- a/opengever/workspace/locales/fr/LC_MESSAGES/opengever.workspace.po
+++ b/opengever/workspace/locales/fr/LC_MESSAGES/opengever.workspace.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-04-26 12:32+0000\n"
+"POT-Creation-Date: 2019-07-01 07:32+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -112,6 +112,17 @@ msgstr "Titulaire"
 msgid "invitation"
 msgstr ""
 
+#. Default: "Completed"
+#: ./opengever/workspace/workspace_todo.py
+msgid "label_completed"
+msgstr ""
+
+#. Default: "Deadline"
+#: ./opengever/workspace/browser/tabs.py
+#: ./opengever/workspace/workspace_todo.py
+msgid "label_deadline"
+msgstr ""
+
 #. Default: "Description"
 #: ./opengever/workspace/browser/tabs.py
 msgid "label_description"
@@ -132,15 +143,27 @@ msgstr "Répertoires"
 msgid "label_journal"
 msgstr "Journal"
 
-#. Default: "Tasks"
-#: ./opengever/workspace/browser/tabbed.py
-msgid "label_tasks"
-msgstr "Tâches"
+#. Default: "Responsible"
+#: ./opengever/workspace/browser/tabs.py
+#: ./opengever/workspace/workspace_todo.py
+msgid "label_responsible"
+msgstr ""
+
+#. Default: "Text"
+#: ./opengever/workspace/workspace_todo.py
+msgid "label_text"
+msgstr ""
 
 #. Default: "Title"
 #: ./opengever/workspace/browser/tabs.py
+#: ./opengever/workspace/workspace_todo.py
 msgid "label_title"
 msgstr "Titre"
+
+#. Default: "ToDo"
+#: ./opengever/workspace/browser/tabbed.py
+msgid "label_todo"
+msgstr ""
 
 #. Default: "Trash"
 #: ./opengever/workspace/browser/tabbed.py

--- a/opengever/workspace/locales/opengever.workspace.pot
+++ b/opengever/workspace/locales/opengever.workspace.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-04-26 12:32+0000\n"
+"POT-Creation-Date: 2019-07-01 07:32+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -115,6 +115,17 @@ msgstr ""
 msgid "invitation"
 msgstr ""
 
+#. Default: "Completed"
+#: ./opengever/workspace/workspace_todo.py
+msgid "label_completed"
+msgstr ""
+
+#. Default: "Deadline"
+#: ./opengever/workspace/browser/tabs.py
+#: ./opengever/workspace/workspace_todo.py
+msgid "label_deadline"
+msgstr ""
+
 #. Default: "Description"
 #: ./opengever/workspace/browser/tabs.py
 msgid "label_description"
@@ -135,14 +146,26 @@ msgstr ""
 msgid "label_journal"
 msgstr ""
 
-#. Default: "Tasks"
-#: ./opengever/workspace/browser/tabbed.py
-msgid "label_tasks"
+#. Default: "Responsible"
+#: ./opengever/workspace/browser/tabs.py
+#: ./opengever/workspace/workspace_todo.py
+msgid "label_responsible"
+msgstr ""
+
+#. Default: "Text"
+#: ./opengever/workspace/workspace_todo.py
+msgid "label_text"
 msgstr ""
 
 #. Default: "Title"
 #: ./opengever/workspace/browser/tabs.py
+#: ./opengever/workspace/workspace_todo.py
 msgid "label_title"
+msgstr ""
+
+#. Default: "ToDo"
+#: ./opengever/workspace/browser/tabbed.py
+msgid "label_todo"
 msgstr ""
 
 #. Default: "Trash"

--- a/opengever/workspace/tests/test_todo.py
+++ b/opengever/workspace/tests/test_todo.py
@@ -1,0 +1,18 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from opengever.testing import IntegrationTestCase
+
+
+class TestToDo(IntegrationTestCase):
+
+    def test_todo_have_auto_increment_ids(self):
+        self.login(self.administrator)
+        todo = create(Builder('todo').within(self.workspace)
+                      .titled(u'The Todo'))
+        self.assertEquals('/plone/workspaces/workspace-1/todo-1',
+                          '/'.join(todo.getPhysicalPath()))
+
+        todo = create(Builder('todo').within(self.workspace)
+                      .titled(u'Another todo'))
+        self.assertEquals('/plone/workspaces/workspace-1/todo-2',
+                          '/'.join(todo.getPhysicalPath()))

--- a/opengever/workspace/workspace_todo.py
+++ b/opengever/workspace/workspace_todo.py
@@ -1,0 +1,58 @@
+from ftw.keywordwidget.widget import KeywordFieldWidget
+from opengever.ogds.base.sources import AllUsersSourceBinder
+from opengever.workspace import _
+from opengever.workspace.interfaces import IToDo
+from opengever.workspace.interfaces import IWorkspace
+from plone.app.content.namechooser import NormalizingNameChooser
+from plone.autoform import directives as form
+from plone.autoform.interfaces import IFormFieldProvider
+from plone.dexterity.content import Container
+from plone.supermodel import model
+from zope import schema
+from zope.annotation import IAnnotations
+from zope.component import adapter
+from zope.container.interfaces import INameChooser
+from zope.interface import implements
+from zope.interface import provider
+
+
+@provider(IFormFieldProvider)
+class IToDoSchema(model.Schema):
+
+    title = schema.TextLine(title=_(u'label_title', default='Title'), required=True)
+    text = schema.Text(title=_(u'label_text', default='Text'), required=False)
+
+    form.widget('responsible', KeywordFieldWidget, async=True)
+    responsible = schema.Choice(
+        title=_('label_responsible', default='Responsible'),
+        source=AllUsersSourceBinder(),
+        required=False,
+    )
+    deadline = schema.Date(title=_(u'label_deadline', default='Deadline'), required=False)
+    completed = schema.Bool(
+        title=_(u'label_completed', default='Completed'),
+        required=False, default=False)
+
+
+class ToDo(Container):
+    implements(IToDo)
+
+
+@provider(INameChooser)
+@adapter(IWorkspace)
+class ToDoNameChooser(NormalizingNameChooser):
+    """ We change the behavior to auto-increment a number so that we have an
+    auto-increment todo id.
+    """
+
+    def chooseName(self, name, obj):
+        if IToDo.providedBy(obj):
+            return self.get_next_issue_name()
+        return super(ToDoNameChooser, self).chooseName(name, obj)
+
+    def get_next_issue_name(self):
+        ann_key = 'opengever.workspace.todo:last-todo-number'
+        annotations = IAnnotations(self.context)
+        number = annotations.get(ann_key, 0) + 1
+        annotations[ann_key] = number
+        return 'todo-{}'.format(str(number))


### PR DESCRIPTION
Dieser PR installiert den neuen Teamraum Aufgaben Typ.

Aufgaben können in einem Teamraum hinzugefügt werden. Eine Aufgabe erhält die ID `todo-${number}`.

ℹ️ die Aufgaben werden v.a. für das neue GEVER-UI verwendet. Deshalb fällt das UI im alten GEVER relativ mager aus.

![screen2](https://user-images.githubusercontent.com/557005/60342064-c3d01a80-99b0-11e9-8bd2-1ed1e1671dd7.gif)

Issuer: https://github.com/4teamwork/gever-ui/issues/305


## Checkliste

- [x] Profil angepasst? Sind UpgradeSteps vorhanden/nötig?:
- [x] Gibt es neue Übersetzungen?
  - [x] Sind alle msg-Strings in Übersetzungen Unicode?
  - [x] Wird die richtige i18n-domain verwendet (Copy-Paste Fehler sind hier häufig)?
- [x] Changelog-Eintrag vorhanden/nötig?
