### PR TITLE
Add linguistic index on task principal column for oracle backends.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -13,6 +13,7 @@ Changelog
 - Bump sablon to 0.3.1 and nokogiri to 1.9.1. [deiferni]
 - Add restapi @participations endpoint to handle participations. [elioschmutz]
 - Add per user configuration to deactivate inbox notifications. [njohner]
+- Add linguistic index on task principal column for oracle backends. [phgross]
 - Register ChoiceFieldDeserializer using overrides instead of configure ZCML. [lgraf]
 - Update Creator, created and Date when copy/pasting an object. [njohner]
 - Docs: Add tasks to documented content types. [lgraf]

--- a/opengever/core/upgrades/20190628142921_add_index_for_task_principal/upgrade.py
+++ b/opengever/core/upgrades/20190628142921_add_index_for_task_principal/upgrade.py
@@ -1,0 +1,21 @@
+from opengever.base.model import is_oracle
+from opengever.core.upgrade import SchemaMigration
+from opengever.globalindex.model.task import TaskPrincipal
+from sqlalchemy import func
+from sqlalchemy import Index
+
+
+INDEX_NAME = 'task_principals_ix'
+
+
+class AddIndexForTaskPrincipal(SchemaMigration):
+    """Add Index for task principal.
+    """
+
+    def migrate(self):
+        if is_oracle() and not self._has_index(INDEX_NAME, 'task_principals'):
+            task_principals_ix = Index(
+                INDEX_NAME,
+                func.nlssort(TaskPrincipal.principal, 'NLS_SORT=GERMAN_CI'))
+
+            task_principals_ix.create(self.session.bind)


### PR DESCRIPTION
This fixes performance Issues on task listings when using an oracle backed for the OGDS DB (closes 4teamwork/opengever.zug#313). Because of the NLS_SORT and NLS_COMP settings we use for oracle backends (see https://github.com/4teamwork/opengever.core/blob/master/opengever/ogds/base/events.py#L6-L11), we need to make sure that oracles indexes supports linguistic sort.

Upgradestep: The PR provides a  schema migration which adds the index if it's not existing yet.

## Checkliste
- [x] Gibts es eine DB-Schema Migration?
  - [ ] Wurde alle Columns/Änderungen aus dem Modell in einer DB-Schema Migration nachgeführt. 
      _--> War leider nicht möglich. Stellt aber m.E. keine Problem dar._
  - [x] Sind Constraint-Namen maximal 30 Zeichen lang (`Oracle`)?
- [x] Changelog-Eintrag vorhanden/nötig?
