### PR TITLE
Avoid reindexing 'created' during IObjectCopiedEvent

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2019.4.0 (unreleased)
 ---------------------
 
+- Avoid reindexing 'created' during IObjectCopiedEvent to fix copy & pasting with Solr. [lgraf]
 - @listing endpoint: Add support for filtering by relative path depth. [lgraf]
 - Update plone.restapi to latest release. [phgross]
 - Add POST restapi endpint @mworkspace-invitations/{id}/{action}. [elioschmutz]


### PR DESCRIPTION
If an object has been copy & pasted, we need to reindex some fields. The `IObjectCopiedEvent` is too early to do that though, because at that point the object doesn't have a full AQ chain yet. We therefore just mark the object during `IObjectCopiedEvent`, and do the reindexing later during `IObjectAddedEvent`.

This fixes copy & pasting in Solr-enabled deployments.

Fixes #5765 

## Checkliste

- [x] Changelog-Eintrag vorhanden/nötig?

