### PR TITLE
Remove unwanted disabling of csrf protection in @workspace-invitations endpoint

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2019.3.1 (unreleased)
 ---------------------
 
+- Remove unwanted disabling of csrf protection in @workspace-invitations endpoint [elioschmutz]
 - @listing endpoint: Add support for filtering by relative path depth. [lgraf]
 - Add POST restapi endpint @mworkspace-invitations/{id}/{action}. [elioschmutz]
 - Add GET restapi endpint @my-workspace-invitations. [elioschmutz]

--- a/opengever/api/participation.py
+++ b/opengever/api/participation.py
@@ -231,9 +231,6 @@ class InvitationsPost(ParticipationTraverseService):
                 "There is no invitation for the current user with "
                 "the id: ".format(iid))
 
-        # Disable CSRF protection
-        alsoProvides(self.request, IDisableCSRFProtection)
-
         if action == 'decline':
             my_invitations_manager._decline(invitation)
             return self.request.response.setStatus(204)


### PR DESCRIPTION
Dieser PR entfernt eine fälschlicherweise hinzugefügte Codezeile, welche den CSRF-Schutz für den @workspace-invitations Endpoint entfernt.

Ursprünglicher PR: https://github.com/4teamwork/opengever.core/pull/5750 

## Checkliste

- [x] Changelog-Eintrag vorhanden/nötig?

