### PR TITLE
@listing endpoint: Exclude searchroot from Solr results.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2019.4.0 (unreleased)
 ---------------------
 
+- @listing endpoint: Exclude searchroot from Solr results. [lgraf]
 - Avoid reindexing 'created' during IObjectCopiedEvent to fix copy & pasting with Solr. [lgraf]
 - @listing endpoint: Add support for filtering by relative path depth. [lgraf]
 - Update plone.restapi to latest release. [phgross]

--- a/opengever/api/listing.py
+++ b/opengever/api/listing.py
@@ -18,6 +18,7 @@ from plone.restapi.batching import HypermediaBatch
 from plone.restapi.serializer.converters import json_compatible
 from plone.restapi.services import Service
 from plone.rfc822.interfaces import IPrimaryFieldInfo
+from plone.uuid.interfaces import IUUID
 from Products.CMFCore.utils import getToolByName
 from Products.ZCatalog.Lazy import LazyMap
 from Products.ZCTextIndex.ParseTree import ParseError
@@ -367,6 +368,12 @@ class Listing(Service):
             query = u' AND '.join(term_queries)
 
         filter_queries = []
+
+        # Exclude searchroot
+        context_uid = IUUID(self.context, None)
+        if context_uid:
+            filter_queries.append(u'-UID:%s' % context_uid)
+
         if 'trashed' not in filters:
             filter_queries.append(u'trashed:false')
         filter_queries.extend(SOLR_FILTERS[name])


### PR DESCRIPTION
This also excludes the searchroot from **Solr results** for the `@listing` endpoint _(like we already do for Catalog results)_.

It filters the search context by adding a `-UID: <uid>` filter query to the Solr query. For contexts that don't have an UID (like the Plone site root), this filter query is omitted. This shouldn't be an issue however, because the Plone site itself is not indexed in Solr.

Fixes #5757

## Checkliste

- [x] Changelog-Eintrag vorhanden/nötig?
