### PR TITLE
Dont require plone site in exception formatter.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 
 - Fix upgrade step that adds linguistic index for task principal. [lgraf]
 - Add ftw.catalogdoctor to dependencies. [deiferni]
+- Fix exception formatter patch when there is no plone site. [deiferni]
 - @listing endpoint: Exclude searchroot from Solr results. [lgraf]
 - Avoid reindexing 'created' during IObjectCopiedEvent to fix copy & pasting with Solr. [lgraf]
 - Allow Readers, Member and Managers to access users information for all users. [phgross]


### PR DESCRIPTION
If the plone site does not exist, e.g. for errors that happen while we install the plone site in the first place, displaying the exception would fail with `CannotGetPortalError`.

We change the permission check to use the zope application and retrieve the application from the request. Gracefully hide the trace in case of a missing request or if the app cannot be retrieved (which should not happen).

Fixes #5758.

There don't seem to be any automated test for this. I have manually tested that formatting still works as desired by stopping postgres on a running site and when attempting to setup a new site.

## Checkliste

_Zutreffendes soll angehakt stehengelassen werden._

- [x] Changelog-Eintrag vorhanden/nötig?