### PR TITLE
Fix upgrade step that adds linguistic index for task principal

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2019.4.0 (unreleased)
 ---------------------
 
+- Fix upgrade step that adds linguistic index for task principal. [lgraf]
 - @listing endpoint: Exclude searchroot from Solr results. [lgraf]
 - Avoid reindexing 'created' during IObjectCopiedEvent to fix copy & pasting with Solr. [lgraf]
 - Allow Readers, Member and Managers to access users information for all users. [phgross]

--- a/opengever/core/upgrades/20190628142921_add_index_for_task_principal/upgrade.py
+++ b/opengever/core/upgrades/20190628142921_add_index_for_task_principal/upgrade.py
@@ -3,6 +3,7 @@ from opengever.core.upgrade import SchemaMigration
 from opengever.globalindex.model.task import TaskPrincipal
 from sqlalchemy import func
 from sqlalchemy import Index
+from sqlalchemy.sql.expression import text
 
 
 INDEX_NAME = 'task_principals_ix'
@@ -12,8 +13,17 @@ class AddIndexForTaskPrincipal(SchemaMigration):
     """Add Index for task principal.
     """
 
+    def _has_index(self, idxname):
+        stmt = text("SELECT COUNT(*) FROM user_indexes WHERE index_name = :idxname")
+        stmt = stmt.bindparams(idxname=idxname)
+        count = self.session.execute(stmt).scalar()
+        return count > 0
+
     def migrate(self):
-        if is_oracle() and not self._has_index(INDEX_NAME, 'task_principals'):
+        if is_oracle():
+            if self._has_index(INDEX_NAME):
+                return
+
             task_principals_ix = Index(
                 INDEX_NAME,
                 func.nlssort(TaskPrincipal.principal, 'NLS_SORT=GERMAN_CI'))


### PR DESCRIPTION
The `self._has_index()` method that was used before is one that only exists on the `IdempotentOperations` class, which we don't currently use for Oracle. So this upgrade step (introduced in #5767) didn't quite work yet when executed on Oracle.

For this specific upgrade step, we therefore test for index presence directly using a simple SQL query.

_(Tested (by hand) on Oracle)_

## Checkliste

- [x] Gibts es eine DB-Schema Migration?
_(bestehende angepasst)_
- [x] Changelog-Eintrag vorhanden/nötig?

