### PR TITLE
Display disqus widget at bottom of page.

### DIFF
--- a/docs/public/dev-manual/api/searching.rst
+++ b/docs/public/dev-manual/api/searching.rst
@@ -107,8 +107,6 @@ darzustellen, kann ``metadata_fields=_all`` verwendet werden.
    ``preview_pdf_url``, bei welchen es sich nicht um eigentliche Metadaten
    handelt, zur Verfügung.
 
-.. disqus::
-
 
 Solr Suche
 ----------
@@ -153,3 +151,6 @@ Weitere optionale Parameter:
 - ``start``: Das erste zurückzugebende Element
 - ``rows``: Die maximale Anzahl der zurückzugebenden Elemente
 - ``sort``: Sortierung nach einem indexierten Feld
+
+
+.. disqus::


### PR DESCRIPTION
The widget somehow made its way to the middle of the page where it disrupts the page/docs. Move it to the bottom again.