### PR TITLE
Bundle import disable collective indexing

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -8,6 +8,7 @@ Changelog
 - Enable c.indexing during tests, but patch it to not defer operations. [lgraf]
 - Add teamraum todo content-type. [elioschmutz]
 - Fix creation and handling for subtasks of sequential tasks. [phgross]
+- Disable collective.indexing during bundle import. [buchi]
 - Fix upgrade step that adds linguistic index for task principal. [lgraf]
 - Add ftw.catalogdoctor to dependencies. [deiferni]
 - Fix exception formatter patch when there is no plone site. [deiferni]

--- a/opengever/bundle/console.py
+++ b/opengever/bundle/console.py
@@ -12,7 +12,6 @@ from opengever.bundle.sections.bundlesource import BUNDLE_PATH_KEY
 from opengever.bundle.sections.commit import INTERMEDIATE_COMMITS_KEY
 from opengever.core.debughelpers import get_first_plone_site
 from opengever.core.debughelpers import setup_plone
-from opengever.setup.sections.reindexobject import SKIP_SOLR_KEY
 from plone import api
 from zope.annotation import IAnnotations
 from zope.component import getUtility
@@ -33,8 +32,6 @@ def parse_args(argv):
                         help='Path to the .oggbundle directory')
     parser.add_argument('--no-intermediate-commits', action='store_true',
                         help="Don't to intermediate commits")
-    parser.add_argument('--skip-solr', action='store_false',
-                        help="Do not reindex SOLR")
 
     args = parser.parse_args(argv)
     return args
@@ -69,21 +66,21 @@ def import_oggbundle(app, args):
     ann = IAnnotations(transmogrifier)
     ann[BUNDLE_PATH_KEY] = args.bundle_path
     ann[INTERMEDIATE_COMMITS_KEY] = not args.no_intermediate_commits
-    ann[SKIP_SOLR_KEY] = not args.skip_solr
 
     solr_enabled = api.portal.get_registry_record(
         'opengever.base.interfaces.ISearchSettings.use_solr',
         default=False)
 
-    if solr_enabled and not ann[SKIP_SOLR_KEY]:
+    if solr_enabled:
         # Check if solr is running
         conn = getUtility(ISolrConnectionManager).connection
         if conn.get('/schema').status == -1:
             raise Exception(
                 "Solr isn't running, but solr reindexing is enabled. "
                 "Skipping solr reindexing via `--skip-solr`.")
-
-    if not solr_enabled:
+    else:
+        # Disable collective indexing as it can lead to too many
+        # subtransactions
         unpatch_collective_indexing()
 
     with DisabledLDAP(plone):

--- a/opengever/bundle/console.py
+++ b/opengever/bundle/console.py
@@ -1,3 +1,6 @@
+# Avoid import error for Products.Archetypes.BaseBTreeFolder
+from Products.Archetypes import atapi  # noqa
+from collective.indexing.monkey import unpatch as unpatch_collective_indexing
 from collective.transmogrifier.transmogrifier import Transmogrifier
 from ftw.solr.interfaces import ISolrConnectionManager
 from opengever.base.interfaces import INoSeparateConnectionForSequenceNumbers
@@ -79,6 +82,9 @@ def import_oggbundle(app, args):
             raise Exception(
                 "Solr isn't running, but solr reindexing is enabled. "
                 "Skipping solr reindexing via `--skip-solr`.")
+
+    if not solr_enabled:
+        unpatch_collective_indexing()
 
     with DisabledLDAP(plone):
         transmogrifier(u'opengever.bundle.oggbundle')

--- a/opengever/setup/sections/reindexobject.py
+++ b/opengever/setup/sections/reindexobject.py
@@ -5,7 +5,6 @@ from collective.transmogrifier.interfaces import ISectionBlueprint
 from collective.transmogrifier.utils import traverse
 from plone import api
 from plone.app.transmogrifier.reindexobject import ReindexObjectSection
-from zope.annotation import IAnnotations
 from zope.component import getUtility
 from zope.interface import classProvides, implements
 import logging
@@ -19,8 +18,6 @@ except ImportError:
 
 logger = logging.getLogger('opengever.setup.reindexobject')
 
-SKIP_SOLR_KEY = 'skip_solr'
-
 
 class GeverReindexObjectSection(ReindexObjectSection):
     classProvides(ISectionBlueprint)
@@ -31,9 +28,6 @@ class GeverReindexObjectSection(ReindexObjectSection):
     def __init__(self, transmogrifier, name, options, previous):
         super(GeverReindexObjectSection, self).__init__(
             transmogrifier, name, options, previous)
-
-        self.skip_solr = IAnnotations(transmogrifier).get(
-            SKIP_SOLR_KEY, True)
 
     @property
     def solr_enabled(self):
@@ -74,7 +68,7 @@ class GeverReindexObjectSection(ReindexObjectSection):
                 self.portal_catalog.reindexObject(ob)
 
             # solr reindexing
-            if not self.skip_solr and self.solr_enabled:
+            if self.solr_enabled:
                 # Register collective.indexing hook, to make sure solr changes
                 # are realy send to solr. See
                 # collective.indexing.queue.IndexQueue.hook.


### PR DESCRIPTION
Disable collective.indexing during bundle import if Solr is disabled.

Also remove confusing `--skip-solr` option
    
The option only disables Solr in the reindex section.
But there are other places
(e.g. `opengever.base.security.reindex_object_security_without_children`)
where Solr is still called explicitly.
To avoid Solr indexing, it should be disabled in the registry.
    
Btw, the option is misnamed. If the option is provided, `skip_solr` has a
value of `False`.?! If the option is omitted, the value is `True`.