### PR TITLE
Enable c.indexing during tests, but patch it to not defer operations:

### DIFF
--- a/base-plone-4.3.x.cfg
+++ b/base-plone-4.3.x.cfg
@@ -10,6 +10,12 @@ package-namespace = opengever
 test-egg = opengever.core[api, tests]
 
 [test]
+initialization +=
+    # Enable c.indexing during tests, but patch it to not defer operations
+    from opengever.testing.patch import patch_collective_indexing
+    patch_collective_indexing()
+    from collective.indexing import monkey
+
 arguments = ['-s', '${buildout:package-namespace}', '-s', 'plonetheme', '--exit-with-status', '--auto-color', '--auto-progress', '--xml', '--package-path', '${buildout:directory}/${buildout:package-namespace}', '${buildout:package-namespace}', '--package-path', '${buildout:directory}/plonetheme', 'plonetheme']
 
 eggs +=

--- a/base-testserver.cfg
+++ b/base-testserver.cfg
@@ -20,6 +20,10 @@ initialization =
     os.environ.setdefault('FTW_STRUCTLOG_MUTE_SETUP_ERRORS', 'true')
     import sys
     sys.argv.insert(1, 'opengever.core.testserver.OPENGEVER_TESTSERVER')
+    # Enable c.indexing during tests, but patch it to not defer operations
+    from opengever.testing.patch import patch_collective_indexing
+    patch_collective_indexing()
+    from collective.indexing import monkey
 
 
 [testserver-selftest]

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2019.4.0 (unreleased)
 ---------------------
 
+- Enable c.indexing during tests, but patch it to not defer operations. [lgraf]
 - Add teamraum todo content-type. [elioschmutz]
 - Fix upgrade step that adds linguistic index for task principal. [lgraf]
 - Add ftw.catalogdoctor to dependencies. [deiferni]

--- a/opengever/testing/tests/test_collective_indexing_active.py
+++ b/opengever/testing/tests/test_collective_indexing_active.py
@@ -1,0 +1,60 @@
+from collective.indexing.interfaces import IIndexQueueProcessor
+from opengever.testing import IntegrationTestCase
+from plone.uuid.interfaces import IUUID
+from zope.interface import implementer
+
+
+@implementer(IIndexQueueProcessor)
+class DemoIndexQueueProcessor(object):
+
+    reindex_log = []
+    unindex_log = []
+    index_log = []
+
+    def index(self, obj, attributes=None):
+        self.index_log.append((IUUID(obj), attributes))
+
+    def reindex(self, obj, attributes=None):
+        self.reindex_log.append((IUUID(obj), attributes))
+
+    def unindex(self, obj):
+        self.unindex_log.append(IUUID(obj))
+
+    def begin(self):
+        pass
+
+    def commit(self):
+        pass
+
+    def abort(self):
+        pass
+
+
+class TestCollectiveIndexingActive(IntegrationTestCase):
+
+    def test_pluggable_index_queue_processors(self):
+        self.login(self.regular_user)
+        self.layer['load_zcml_string']("""
+            <configure xmlns="http://namespaces.zope.org/zope">
+                <utility
+                     provides="collective.indexing.interfaces.IIndexQueueProcessor"
+                     name="demo"
+                     factory="opengever.testing.tests.test_collective_indexing_active.DemoIndexQueueProcessor"
+                     />
+            </configure>
+        """)
+
+        self.document.unindexObject()
+        self.assertEqual(
+            [IUUID(self.document)],
+            DemoIndexQueueProcessor.unindex_log)
+
+        self.document.indexObject()
+        self.assertEqual(
+            [(IUUID(self.document), None)],
+            DemoIndexQueueProcessor.index_log)
+
+        self.document.reindexObject(idxs=['sortable_title'])
+        self.assertEqual(
+            [(IUUID(self.document), ('sortable_title',))],
+            DemoIndexQueueProcessor.reindex_log)


### PR DESCRIPTION
We need to enable `collective.indexing` during tests in order to create Solr tests (because `ftw.solr` integrates itself by providing an `IIndexQueueProcessor`).

So we need `collective.indexing`'s pluggable `IndexQueueProcessor` mechanism, but we don't want the unpredictable behavior of reindexes that are deferred until the end of the transaction during tests (or the queue getting flushed at arbitrary points).

We therefore patch the `IndexQueue`'s operation methods so that they always immediately process the queue after being called.

Closes #5801

**Note**:
I checked for any negative effects on test runtime - wallclock time for tests on CI stayed exactly the same.

## Checkliste

- [x] Changelog-Eintrag vorhanden/nötig?

