### PR TITLE
Fix creation and handling for subtasks of sequential tasks.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 ---------------------
 
 - Add teamraum todo content-type. [elioschmutz]
+- Fix creation and handling for subtasks of sequential tasks. [phgross]
 - Fix upgrade step that adds linguistic index for task principal. [lgraf]
 - Add ftw.catalogdoctor to dependencies. [deiferni]
 - Fix exception formatter patch when there is no plone site. [deiferni]

--- a/opengever/task/browser/forms.py
+++ b/opengever/task/browser/forms.py
@@ -98,7 +98,7 @@ class TaskAddForm(DefaultAddForm):
 
         # Set tasktemplate order and move to planned state if it's part
         # of a sequential process
-        if IFromSequentialTasktemplate.providedBy(self.context):
+        if ITask.providedBy(self.context) and self.context.is_sequential_main_task():
             position = data['tasktemplate_position']
             if not position:
                 position = len(self.context.get_tasktemplate_order())

--- a/opengever/task/browser/overview.py
+++ b/opengever/task/browser/overview.py
@@ -151,7 +151,7 @@ class Overview(BrowserView, GeverTabMixin):
         """Returns all subtasks. On sequential process tasks, it returns
         the subtask in the process order.
         """
-        if self.context.is_from_sequential_tasktemplate:
+        if self.context.is_sequential_main_task():
             oguids = self.context.get_tasktemplate_order()
             if not oguids:
                 return []

--- a/opengever/task/browser/templates/overview.pt
+++ b/opengever/task/browser/templates/overview.pt
@@ -70,12 +70,13 @@
 
       <!-- subtasks box -->
       <div id="sub_taskBox" class="box"
-           tal:define="is_sequential context/is_from_sequential_tasktemplate">
+           tal:define="is_sequential_main_task context/is_sequential_main_task;
+                       is_main_task not: context/get_is_subtask">
 
         <!-- regular subtasks -->
-        <tal:condition tal:condition="python: sub_tasks and not is_sequential">
+        <tal:condition tal:condition="python: sub_tasks and not is_sequential_main_task">
           <h2 i18n:translate="label_sub_task">Sub tasks</h2>
-          <span class="sequence_type" tal:condition="context/is_from_tasktemplate"
+          <span class="sequence_type" tal:condition="is_main_task"
                 tal:content="view/get_sequence_type_label"/>
           <div tal:attributes="class string:task-container ${view/get_sequence_type}">
             <div class="task-list">
@@ -87,9 +88,9 @@
         </tal:condition>
 
         <!-- sequential subtasks -->
-        <tal:condition tal:condition="python: sub_tasks and is_sequential">
+        <tal:condition tal:condition="python: sub_tasks and is_sequential_main_task">
           <h2 i18n:translate="label_sub_task">Sub tasks</h2>
-          <span class="sequence_type" tal:condition="context/is_from_tasktemplate"
+          <span class="sequence_type" tal:condition="is_sequential_main_task"
                 tal:content="view/get_sequence_type_label"/>
           <div tal:attributes="class string:task-container ${view/get_sequence_type}">
             <div class="task-sequence-line-container">

--- a/opengever/task/handlers.py
+++ b/opengever/task/handlers.py
@@ -115,7 +115,7 @@ def set_initial_state(task, event):
 
     parent = aq_parent(aq_inner(task))
     if ITask.providedBy(parent) \
-       and IFromSequentialTasktemplate.providedBy(parent):
+       and parent.is_sequential_main_task():
 
         task.set_to_planned_state()
 

--- a/opengever/task/task.py
+++ b/opengever/task/task.py
@@ -398,6 +398,11 @@ class Task(Container):
         """
         return IFromSequentialTasktemplate.providedBy(self)
 
+    def is_sequential_main_task(self):
+        """If the task is the main task of a sequential process.
+        """
+        return self.is_from_sequential_tasktemplate and not self.get_is_subtask()
+
     @property
     def is_in_final_state(self):
         current_state = api.content.get_state(self)

--- a/opengever/task/tests/test_overview.py
+++ b/opengever/task/tests/test_overview.py
@@ -205,6 +205,35 @@ class TestTaskFromTasktemplateFolderOverview(IntegrationTestCase):
             [subtask_3.title],
             browser.css('#sequence_taskBox .next_task .task').text)
 
+    @browsing
+    def test_subtask_of_sequential_tasks_are_listed_as_regular_subtasks(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        self.set_workflow_state('task-state-in-progress', self.seq_subtask_1)
+        subsubtask = create(Builder('task')
+                            .within(self.seq_subtask_1)
+                            .titled(u'Recherche Kapitel 1-4 verfeinern')
+                            .having(responsible_client='fa',
+                                    responsible=self.regular_user.id,
+                                    issuer=self.regular_user.id,
+                                    task_type='direct-execution',
+                                    deadline=date(2016, 11, 1)))
+
+        browser.open(self.seq_subtask_1, view='tabbedview_view-overview')
+        self.assertEquals(['Recherche Kapitel 1-4 verfeinern'],
+                          browser.css('#sub_taskBox .task a').text)
+        self.assertEquals([],
+                          browser.css('#sub_taskBox .task-sequence-line'))
+
+        # Testing the oposite on a sequential task to validate test assertions
+        browser.open(self.sequential_task, view='tabbedview_view-overview')
+        self.assertEquals(['Mitarbeiter Dossier generieren',
+                           'Arbeitsplatz vorbereiten',
+                           'Vorstellungsrunde bei anderen Mitarbeitern'],
+                          browser.css('#sub_taskBox .task a').text)
+        self.assertEquals(
+            1, len(browser.css('#sub_taskBox .task-sequence-line')))
+
 
 class TestTaskTextTransformation(IntegrationTestCase):
 


### PR DESCRIPTION
A subtask of a sequential task should not be handled as a sequential task rather than as a simple subsubtask. Because a subsubtask is not part of the sequential order, but is more a splitting of a specific task of the sequential process. When resolving a subsubtask  it should no start the next task of the sequential process neither should be subsubtasks displayed as a sequence.

This PR corrects the misbehaviour during the creation as well as during the representation of such subsubtasks within task sequences. Closes #5821 

## Checkliste
- [X] Wurde etwas an der `Aufgabe` angepasst? Funktioniert das auch mit einer `Weiterleitung`?
_Ja, Weiterleitungen sind davon aber nicht betroffen, da bei Standardabläufen ausschliesslich Aufgaben erstellt werden._
- [x] Changelog-Eintrag vorhanden/nötig?