### PR TITLE
Disable properties action for teams.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2019.4.0 (unreleased)
 ---------------------
 
+- Disable properties action for teams. [deiferni]
 - Enable c.indexing during tests, but patch it to not defer operations. [lgraf]
 - Add teamraum todo content-type. [elioschmutz]
 - Fix creation and handling for subtasks of sequential tasks. [phgross]

--- a/opengever/base/browser/gever_state.py
+++ b/opengever/base/browser/gever_state.py
@@ -4,6 +4,7 @@ from opengever.base.casauth import get_gever_portal_url
 from opengever.base.interfaces import IGeverState
 from opengever.contact.interfaces import IContactFolder
 from opengever.inbox.yearfolder import IYearFolder
+from opengever.ogds.base.interfaces import ITeam
 from plone.memoize.view import memoize
 from plone.memoize.view import memoize_contextless
 from Products.Five import BrowserView
@@ -18,6 +19,7 @@ class GeverStateView(BrowserView):
 
     types_without_properties_action = (
         IContactFolder,
+        ITeam,
         IYearFolder,
     )
 

--- a/opengever/base/browser/gever_state.py
+++ b/opengever/base/browser/gever_state.py
@@ -16,6 +16,11 @@ class GeverStateView(BrowserView):
     """
     implements(IGeverState)
 
+    types_without_properties_action = (
+        IContactFolder,
+        IYearFolder,
+    )
+
     @memoize_contextless
     def cluster_base_url(self):
         return get_cluster_base_url()
@@ -35,8 +40,8 @@ class GeverStateView(BrowserView):
            plone_view.isPortalOrPortalDefaultPage():
             return False
 
-        if IContactFolder.providedBy(self.context) \
-           or IYearFolder.providedBy(self.context):
+        if any(iface.providedBy(self.context)
+               for iface in self.types_without_properties_action):
             return False
 
         return True

--- a/opengever/base/tests/test_gever_state.py
+++ b/opengever/base/tests/test_gever_state.py
@@ -70,3 +70,12 @@ class TestGeverStateView(IntegrationTestCase):
         self.assertNotIn(
             'Properties',
             browser.css('#plone-contentmenu-actions .actionMenuContent a').text)
+
+    @browsing
+    def test_properties_action_not_available_for_teams(self, browser):
+        self.login(self.administrator, browser=browser)
+
+        browser.open(self.contactfolder, view='team-1/view')
+        self.assertNotIn(
+            'Properties',
+            browser.css('#plone-contentmenu-actions .actionMenuContent a').text)


### PR DESCRIPTION
Currently the properties action is shown for teams. This is incorrect as teams don't implement properties view. Therefore we disable the action.

Fixes #5827.

## Checkliste

- [x] Changelog-Eintrag vorhanden/nötig?
