### PR TITLE
Fix QA tests

### DIFF
--- a/bin/qa
+++ b/bin/qa
@@ -30,6 +30,9 @@ lint () {
                         | tr ' ' '\n' \
                         | grep -vE "($excludes)" \
                     ))
+                else
+                    # No specific linter config -> no excludes
+                    unexcluded_changed_files=$changed_files
 
                 fi
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2019.4.0 (unreleased)
 ---------------------
 
+- Fix qa tests. [lgraf]
 - Disable properties action for teams. [deiferni]
 - Enable c.indexing during tests, but patch it to not defer operations. [lgraf]
 - Add teamraum todo content-type. [elioschmutz]


### PR DESCRIPTION
At some point we had a (opengever-core-) custom linter config. Apparently we don't anymore, and the `bin/qa` script doesn't properly handle this:

The variable with files that will be checked (`$unexcluded_changed_files`) only ever gets set in the `if` clause that handles possible excludes from a linter config. If no linter config is present, that variable stays empty all the time and the script claims `Found nothing to complain about. Well done!`.

Fixes #5778

## Checkliste

- [x] Changelog-Eintrag vorhanden/nötig?
