### PR TITLE
 Rework SIP Package generation and download

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 ---------------------
 
 - Bump docxcompose version to 1.0.1 [njohner]
+- Improve SIP package generation and download. [phgross]
 - Fix qa tests. [lgraf]
 - Disable properties action for teams. [deiferni]
 - Add source vocabularies for workspace invitations and todo responsibles. [njohner]

--- a/opengever/disposition/browser/configure.zcml
+++ b/opengever/disposition/browser/configure.zcml
@@ -39,6 +39,20 @@
       />
 
   <browser:page
+      class=".ech0160.ECH0160StoreView"
+      for="opengever.disposition.interfaces.IDisposition"
+      name="ech0160_store"
+      permission="zope2.View"
+      />
+
+  <browser:page
+      class=".ech0160.ECH0160DownloadView"
+      for="opengever.disposition.interfaces.IDisposition"
+      name="ech0160_download"
+      permission="opengever.disposition.DownloadSIPPackage"
+      />
+
+  <browser:page
       class=".overview.DispositionOverview"
       for="opengever.disposition.interfaces.IDisposition"
       name="overview"

--- a/opengever/disposition/browser/ech0160.py
+++ b/opengever/disposition/browser/ech0160.py
@@ -60,7 +60,7 @@ class ECH0160DownloadView(BrowserView):
     def __call__(self):
         if not self.context.has_sip_package():
             msg = _('msg_no_sip_package_generated',
-                    default=u'No SIP Package generated for this disposition')
+                    default=u'No SIP Package generated for this disposition.')
             api.portal.show_message(msg, request=self.request, type='error')
             return self.request.RESPONSE.redirect(self.context.absolute_url())
 

--- a/opengever/disposition/browser/ech0160.py
+++ b/opengever/disposition/browser/ech0160.py
@@ -1,5 +1,8 @@
 from opengever.base.stream import TempfileStreamIterator
+from opengever.disposition import _
 from opengever.disposition.ech0160.sippackage import SIPPackage
+from plone import api
+from plone.namedfile.utils import stream_data
 from Products.Five import BrowserView
 from pyxb.utils.domutils import BindingDOMSupport
 from tempfile import TemporaryFile
@@ -34,3 +37,38 @@ class ECH0160ExportView(BrowserView):
             package.write_to_zipfile(zipfile)
 
         return tmpfile
+
+
+class ECH0160StoreView(BrowserView):
+    """A view which generates and store's the SIP package as a blob file.
+    """
+
+    def __call__(self):
+        self.context.store_sip_package()
+        msg = _('msg_sip_package_sucessfully_generated',
+                default=u'SIP Package generated successfully.')
+        api.portal.show_message(msg, request=self.request, type='info')
+        return self.request.RESPONSE.redirect(self.context.absolute_url())
+
+
+class ECH0160DownloadView(BrowserView):
+    """View which streams the existing SIP Package. Redirect and show status
+    message when SIP package does not exist.
+    """
+
+    def __call__(self):
+        if not self.context.has_sip_package():
+            msg = _('msg_no_sip_package_generated',
+                    default=u'No SIP Package generated for this disposition')
+            api.portal.show_message(msg, request=self.request, type='error')
+            return self.request.RESPONSE.redirect(self.context.absolute_url())
+
+        sip_package = self.context.get_sip_package()
+        response = self.request.response
+        response.setHeader(
+            "Content-Disposition",
+            'inline; filename="%s.zip"' % self.context.get_sip_name())
+        response.setHeader("Content-type", "application/zip")
+        response.setHeader("Content-Length", sip_package.getSize())
+
+        return stream_data(sip_package)

--- a/opengever/disposition/browser/ech0160.py
+++ b/opengever/disposition/browser/ech0160.py
@@ -2,6 +2,7 @@ from opengever.base.stream import TempfileStreamIterator
 from opengever.disposition import _
 from opengever.disposition.ech0160.sippackage import SIPPackage
 from plone import api
+from plone.namedfile.utils import set_headers
 from plone.namedfile.utils import stream_data
 from Products.Five import BrowserView
 from pyxb.utils.domutils import BindingDOMSupport
@@ -64,11 +65,6 @@ class ECH0160DownloadView(BrowserView):
             return self.request.RESPONSE.redirect(self.context.absolute_url())
 
         sip_package = self.context.get_sip_package()
-        response = self.request.response
-        response.setHeader(
-            "Content-Disposition",
-            'inline; filename="%s.zip"' % self.context.get_sip_name())
-        response.setHeader("Content-type", "application/zip")
-        response.setHeader("Content-Length", sip_package.getSize())
-
+        set_headers(sip_package, self.request.response,
+                    u'{}.zip'.format(self.context.get_sip_name()))
         return stream_data(sip_package)

--- a/opengever/disposition/browser/overview.py
+++ b/opengever/disposition/browser/overview.py
@@ -76,7 +76,7 @@ class DispositionOverview(BrowserView):
             {'id': 'sip_download',
              'label': _('label_dispositon_package_download',
                         default=u'Download disposition package'),
-             'url': '{}/ech0160_export'.format(self.context.absolute_url()),
+             'url': '{}/ech0160_download'.format(self.context.absolute_url()),
              'visible': self.sip_download_available(),
              'class': 'sip_download'},
             {'id': 'removal_protocol',
@@ -88,6 +88,15 @@ class DispositionOverview(BrowserView):
         ]
 
     def sip_download_available(self):
+        if api.user.has_permission(
+            'opengever.disposition: Download SIP Package',
+            obj=self.context):
+
+            return self.context.has_sip_package()
+
+        return None
+
+    def sip_store_available(self):
         return api.user.has_permission(
             'opengever.disposition: Download SIP Package',
             obj=self.context)

--- a/opengever/disposition/disposition.py
+++ b/opengever/disposition/disposition.py
@@ -306,6 +306,9 @@ class Disposition(Container):
     def store_sip_package(self):
         self._sip_package = self.generate_sip_package()
 
+    def remove_sip_package(self):
+        self._sip_package = None
+
     def generate_sip_package(self):
         package = SIPPackage(self)
         zip_file = self.create_zipfile(package)

--- a/opengever/disposition/disposition.py
+++ b/opengever/disposition/disposition.py
@@ -2,6 +2,7 @@ from Acquisition import aq_inner
 from Acquisition import aq_parent
 from collective import dexteritytextindexer
 from datetime import date
+from DateTime import DateTime
 from opengever.activity import notification_center
 from opengever.activity.roles import DISPOSITION_ARCHIVIST_ROLE
 from opengever.activity.roles import DISPOSITION_RECORDS_MANAGER_ROLE
@@ -11,6 +12,7 @@ from opengever.base.security import elevated_privileges
 from opengever.base.source import SolrObjPathSourceBinder
 from opengever.disposition import _
 from opengever.disposition.appraisal import IAppraisal
+from opengever.disposition.ech0160.sippackage import SIPPackage
 from opengever.disposition.interfaces import IDisposition
 from opengever.disposition.interfaces import IDuringDossierDestruction
 from opengever.disposition.interfaces import IHistoryStorage
@@ -18,16 +20,23 @@ from opengever.dossier.base import DOSSIER_STATES_OFFERABLE
 from opengever.dossier.behaviors.dossier import IDossier
 from opengever.ogds.base.utils import get_current_admin_unit
 from opengever.ogds.base.utils import ogds_service
+from path import Path
 from persistent.dict import PersistentDict
 from persistent.list import PersistentList
 from plone import api
 from plone.autoform.directives import write_permission
 from plone.dexterity.content import Container
+from plone.namedfile.file import NamedBlobFile
 from plone.supermodel import model
+from pyxb.utils.domutils import BindingDOMSupport
+from tempfile import TemporaryFile
 from z3c.relationfield.schema import RelationChoice
 from z3c.relationfield.schema import RelationList
 from zExceptions import Unauthorized
+from zipfile import ZIP_DEFLATED
+from zipfile import ZipFile
 from zope import schema
+from zope.annotation import IAnnotations
 from zope.annotation.interfaces import IAnnotations
 from zope.component import getUtility
 from zope.globalrequest import getRequest
@@ -35,7 +44,7 @@ from zope.i18n import translate
 from zope.interface import alsoProvides
 from zope.interface import implements
 from zope.intid.interfaces import IIntIds
-
+import os
 
 DESTROY_PERMISSION = 'opengever.dossier: Destroy dossier'
 
@@ -293,3 +302,35 @@ class Disposition(Container):
                 archivists.append(principal)
 
         return archivists
+
+    def store_sip_package(self):
+        self._sip_package = self.generate_sip_package()
+
+    def generate_sip_package(self):
+        package = SIPPackage(self)
+        zip_file = self.create_zipfile(package)
+        zip_file.seek(0)
+        return NamedBlobFile(zip_file.read(), contentType='application/zip')
+
+    def create_zipfile(self, package):
+        tmpfile = TemporaryFile()
+        BindingDOMSupport.SetDefaultNamespace(u'http://bar.admin.ch/arelda/v4')
+        with ZipFile(tmpfile, 'w', ZIP_DEFLATED, True) as zipfile:
+            package.write_to_zipfile(zipfile)
+
+        return tmpfile
+
+    def has_sip_package(self):
+        return bool(self.get_sip_package())
+
+    def get_sip_package(self):
+        return getattr(self, '_sip_package', None)
+
+    def get_sip_name(self):
+        name = u'SIP_{}_{}'.format(
+            DateTime().strftime('%Y%m%d'),
+            api.portal.get().getId().upper())
+        if self.transfer_number:
+            name = u'{}_{}'.format(name, self.transfer_number)
+
+        return name

--- a/opengever/disposition/handlers.py
+++ b/opengever/disposition/handlers.py
@@ -16,10 +16,12 @@ def disposition_state_changed(context, event):
 
     if event.action == 'disposition-transition-close':
         context.destroy_dossiers()
+        context.remove_sip_package()
 
     if event.action == 'disposition-transition-appraised-to-closed':
         context.mark_dossiers_as_archived()
         context.destroy_dossiers()
+        context.remove_sip_package()
 
     if event.action == 'disposition-transition-dispose':
         context.store_sip_package()

--- a/opengever/disposition/handlers.py
+++ b/opengever/disposition/handlers.py
@@ -21,6 +21,9 @@ def disposition_state_changed(context, event):
         context.mark_dossiers_as_archived()
         context.destroy_dossiers()
 
+    if event.action == 'disposition-transition-dispose':
+        context.store_sip_package()
+
     storage = IHistoryStorage(context)
     storage.add(event.action,
                 api.user.get_current().getId(),

--- a/opengever/disposition/locales/de/LC_MESSAGES/opengever.disposition.po
+++ b/opengever/disposition/locales/de/LC_MESSAGES/opengever.disposition.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-03-19 12:59+0000\n"
+"POT-Creation-Date: 2019-07-25 14:32+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -272,6 +272,16 @@ msgstr "Angebot abgelehnt durch ${user}"
 #: ./opengever/disposition/history.py
 msgid "msg_disposition_updated"
 msgstr "Aktualisiert durch ${user}"
+
+#. Default: "No SIP Package generated for this disposition."
+#: ./opengever/disposition/browser/ech0160.py
+msgid "msg_no_sip_package_generated"
+msgstr "Es wurde noch kein SIP Paket generiert für dieses Angebot."
+
+#. Default: "SIP Package generated successfully."
+#: ./opengever/disposition/browser/ech0160.py
+msgid "msg_sip_package_sucessfully_generated"
+msgstr "SIP Paket erfolgreich generiert."
 
 #. Default: "Period"
 #: ./opengever/disposition/browser/templates/overview.pt

--- a/opengever/disposition/locales/fr/LC_MESSAGES/opengever.disposition.po
+++ b/opengever/disposition/locales/fr/LC_MESSAGES/opengever.disposition.po
@@ -1,21 +1,20 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-03-19 12:59+0000\n"
+"POT-Creation-Date: 2019-07-25 14:32+0000\n"
 "PO-Revision-Date: 2018-05-22 10:09+0000\n"
 "Last-Translator: Niklaus Johner <Niklaus.johner@4teamwork.ch>\n"
-"Language-Team: French <https://translations.onegovgever.ch/projects/onegov-"
-"gever/opengever-disposition/fr/>\n"
-"Language: fr\n"
+"Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-disposition/fr/>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
-"X-Generator: Weblate 2.13.1\n"
 "Language-Code: en\n"
 "Language-Name: English\n"
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
+"Language: fr\n"
+"X-Generator: Weblate 2.13.1\n"
 
 #: ./opengever/disposition/browser/excel_export.py
 msgid "The report could not been generated."
@@ -275,6 +274,16 @@ msgstr "Offre refusée par ${user}"
 #: ./opengever/disposition/history.py
 msgid "msg_disposition_updated"
 msgstr "Actualisé par ${user}"
+
+#. Default: "No SIP Package generated for this disposition."
+#: ./opengever/disposition/browser/ech0160.py
+msgid "msg_no_sip_package_generated"
+msgstr ""
+
+#. Default: "SIP Package generated successfully."
+#: ./opengever/disposition/browser/ech0160.py
+msgid "msg_sip_package_sucessfully_generated"
+msgstr ""
 
 #. Default: "Period"
 #: ./opengever/disposition/browser/templates/overview.pt

--- a/opengever/disposition/locales/opengever.disposition.pot
+++ b/opengever/disposition/locales/opengever.disposition.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-03-19 12:59+0000\n"
+"POT-Creation-Date: 2019-07-25 14:32+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -274,6 +274,16 @@ msgstr ""
 #. Default: "Updated by ${user}"
 #: ./opengever/disposition/history.py
 msgid "msg_disposition_updated"
+msgstr ""
+
+#. Default: "No SIP Package generated for this disposition."
+#: ./opengever/disposition/browser/ech0160.py
+msgid "msg_no_sip_package_generated"
+msgstr ""
+
+#. Default: "SIP Package generated successfully."
+#: ./opengever/disposition/browser/ech0160.py
+msgid "msg_sip_package_sucessfully_generated"
 msgstr ""
 
 #. Default: "Period"

--- a/opengever/disposition/tests/test_disposition.py
+++ b/opengever/disposition/tests/test_disposition.py
@@ -224,3 +224,19 @@ class TestDispositionEditForm(IntegrationTestCase):
             None, ILifeCycle(self.offered_dossier_to_destroy).date_of_submission)
         self.assertEquals(
             date.today(), ILifeCycle(self.expired_dossier).date_of_submission)
+
+    @browsing
+    def test_sip_package_is_genarated_and_stored_on_dispose(self, browser):
+        self.login(self.records_manager, browser)
+
+        self.set_workflow_state('disposition-state-appraised', self.disposition)
+
+        browser.open(self.disposition, view='overview')
+        browser.click_on('disposition-transition-dispose')
+
+        self.assertEquals(['Item state changed.'], info_messages())
+        self.assertTrue(self.disposition.has_sip_package())
+
+        # Download is possible
+        self.assertIn(
+            'Download disposition package', browser.css('ul.actions li').text)

--- a/opengever/disposition/tests/test_disposition.py
+++ b/opengever/disposition/tests/test_disposition.py
@@ -240,3 +240,24 @@ class TestDispositionEditForm(IntegrationTestCase):
         # Download is possible
         self.assertIn(
             'Download disposition package', browser.css('ul.actions li').text)
+
+    @browsing
+    def test_sip_package_is_removed_on_close(self, browser):
+        self.login(self.records_manager, browser)
+
+        self.disposition.store_sip_package()
+        self.set_workflow_state('disposition-state-appraised', self.disposition)
+        browser.open(self.disposition, view='overview')
+
+        browser.click_on('disposition-transition-dispose')
+        self.assertTrue(self.disposition.has_sip_package())
+
+        with self.login(self.archivist, browser=browser):
+            browser.open(self.disposition, view='overview')
+            browser.click_on('disposition-transition-archive')
+
+        browser.open(self.disposition, view='overview')
+        browser.click_on('disposition-transition-close')
+
+        self.assertEquals(['Item state changed.'], info_messages())
+        self.assertFalse(self.disposition.has_sip_package())

--- a/opengever/disposition/tests/test_ech0160export.py
+++ b/opengever/disposition/tests/test_ech0160export.py
@@ -1,7 +1,10 @@
 from datetime import datetime
 from ftw.testbrowser import browsing
+from ftw.testbrowser.pages.statusmessages import error_messages
+from ftw.testbrowser.pages.statusmessages import info_messages
 from ftw.testing import freeze
 from opengever.testing import IntegrationTestCase
+import os
 
 
 class TesteCH0160Deployment(IntegrationTestCase):
@@ -22,3 +25,50 @@ class TesteCH0160Deployment(IntegrationTestCase):
             self.assertEquals(
                 'inline; filename="SIP_20160611_PLONE_10xy.zip"',
                 self.request.response.headers.get('content-disposition'))
+
+
+class TestECH0160StoreView(IntegrationTestCase):
+
+    @browsing
+    def test_generates_sip_package_and_stores_it_as_a_blob_on_the_filesystem(self, browser):
+        self.login(self.records_manager, browser=browser)
+
+        self.set_workflow_state('disposition-state-disposed', self.disposition)
+        self.disposition.transfer_number = "10xy"
+        self.assertFalse(self.disposition.has_sip_package())
+
+        with freeze(datetime(2016, 6, 11)):
+            browser.open(self.disposition, view='ech0160_store')
+
+        self.assertEquals(
+            ['SIP Package generated successfully.'], info_messages())
+        self.assertTrue(self.disposition.has_sip_package())
+
+
+class TestECH0160DownloadView(IntegrationTestCase):
+
+    @browsing
+    def test_shows_status_message_when_no_zip_is_stored(self, browser):
+        self.login(self.archivist, browser=browser)
+
+        self.set_workflow_state('disposition-state-disposed', self.disposition)
+        browser.open(self.disposition, view='ech0160_download')
+        self.assertEquals([u'No SIP Package generated for this disposition'],
+                          error_messages())
+
+    @browsing
+    def test_streams_zip_when_sip_package_is_stored(self, browser):
+        self.login(self.archivist, browser=browser)
+
+        self.set_workflow_state('disposition-state-disposed', self.disposition)
+        self.disposition.transfer_number = "10xy"
+        self.disposition.store_sip_package()
+
+        with freeze(datetime(2016, 6, 11)):
+            browser.open(self.disposition, view='ech0160_download')
+
+        self.assertEquals(
+            'application/zip', browser.headers.get('content-type'))
+        self.assertEquals(
+            'inline; filename="SIP_20160611_PLONE_10xy.zip"',
+            browser.headers.get('content-disposition'))

--- a/opengever/disposition/tests/test_ech0160export.py
+++ b/opengever/disposition/tests/test_ech0160export.py
@@ -70,5 +70,5 @@ class TestECH0160DownloadView(IntegrationTestCase):
         self.assertEquals(
             'application/zip', browser.headers.get('content-type'))
         self.assertEquals(
-            'inline; filename="SIP_20160611_PLONE_10xy.zip"',
+            "attachment; filename*=UTF-8''SIP_20160611_PLONE_10xy.zip",
             browser.headers.get('content-disposition'))

--- a/opengever/disposition/tests/test_ech0160export.py
+++ b/opengever/disposition/tests/test_ech0160export.py
@@ -53,7 +53,7 @@ class TestECH0160DownloadView(IntegrationTestCase):
 
         self.set_workflow_state('disposition-state-disposed', self.disposition)
         browser.open(self.disposition, view='ech0160_download')
-        self.assertEquals([u'No SIP Package generated for this disposition'],
+        self.assertEquals([u'No SIP Package generated for this disposition.'],
                           error_messages())
 
     @browsing

--- a/opengever/disposition/tests/test_overview.py
+++ b/opengever/disposition/tests/test_overview.py
@@ -153,14 +153,6 @@ class TestDispositionOverview(IntegrationTestCase):
 
         browser.find('disposition-transition-dispose').click()
 
-        # SIP currently not generated
-        self.assertEquals(['Export appraisal list as excel'],
-                          browser.css('ul.actions li').text)
-
-        # Manually store the sip package
-        self.disposition.store_sip_package()
-        browser.open(self.disposition, view='overview')
-
         self.assertEquals(['Export appraisal list as excel',
                            'Download disposition package'],
                           browser.css('ul.actions li').text)

--- a/opengever/disposition/tests/test_overview.py
+++ b/opengever/disposition/tests/test_overview.py
@@ -152,11 +152,21 @@ class TestDispositionOverview(IntegrationTestCase):
                           browser.css('ul.actions li').text)
 
         browser.find('disposition-transition-dispose').click()
+
+        # SIP currently not generated
+        self.assertEquals(['Export appraisal list as excel'],
+                          browser.css('ul.actions li').text)
+
+        # Manually store the sip package
+        self.disposition.store_sip_package()
+        browser.open(self.disposition, view='overview')
+
         self.assertEquals(['Export appraisal list as excel',
                            'Download disposition package'],
                           browser.css('ul.actions li').text)
+
         self.assertEquals(
-            os.path.join(self.disposition.absolute_url(), 'ech0160_export'),
+            os.path.join(self.disposition.absolute_url(), 'ech0160_download'),
             browser.find('Download disposition package').get('href'))
         self.assertEquals(
             os.path.join(self.disposition.absolute_url(), 'download_excel'),


### PR DESCRIPTION
This is the first part of the work we do for #5167, a short summary of the changes this PR does.
- **Rework SIP Package generation and download.** Store SIP package as a blob locally instead of re generating them for each download. This solves time and ressources and makes it possible to provide customer specific scripts and SIP package handling. 
- **Switch SIP download button to the download view.** The export view stays still available, but is no longer available trough the UI, can be useful for debugging purposes.
- Instead of a manual trigger, generate and store the SIP Package automatically, when disposing a disposition.
- Remove local copy of the SIP package after closing a disposition.


## Checkliste

_Zutreffendes soll angehakt stehengelassen werden._
- [x] Gibt es neue Übersetzungen?
- [x] Changelog-Eintrag vorhanden/nötig?
- [ ] Aktualisierung Dokumentation vorhanden/nötig? _Nicht notwendig, das sich für den Benutzer nichts ändert. Es handelt sich hier ausschliesslich um technische Anpassungen._
