### PR TITLE
Add a disposable dossier to the initial content.

### DIFF
--- a/opengever/examplecontent/profiles/municipality_content/opengever_content/01_initial_dossiers.json
+++ b/opengever/examplecontent/profiles/municipality_content/opengever_content/01_initial_dossiers.json
@@ -194,5 +194,26 @@
         "description": "<script>alert('evil');</script>"
       }
     ]
+  },
+
+  {
+    "_path": "/ordnungssystem/bevoelkerung-und-sicherheit/einbuergerungen/dossier-9",
+    "_type": "opengever.dossier.businesscasedossier",
+    "responsible": "philippe.gross",
+    "title": "Dossier zum Aussondern",
+    "start": "2000-1-1",
+    "end": "2001-1-1",
+    "description": "Dossier bei dem die Aufbewahrungsfrist schon abgelaufen ist",
+    "_transitions": "dossier-transition-resolve",
+    "_children": [
+      {
+        "_id": "document-9",
+        "_type": "opengever.document.document",
+        "title": "Dokument zum Aussondern",
+        "file:file": "files/subdossier.docx",
+        "document_date": "2010-1-2",
+        "modified": "2010-1-2"
+      }
+    ]
   }
 ]


### PR DESCRIPTION
Part of https://github.com/4teamwork/opengever.core/issues/5167.

This quality of live PR adds initial content for disposition so that we can easily create disposable content for local development. It creates a dossier with one document which has its retention period expired and which is already in closed state. It should pop up when you add a new disposition on your repository.

_I have opted to not create the disposition itself yet, however that could be amended in a later PR if deemed useful._