### PR TITLE
Include actor_id and actor_label in @notifications endpoint responses.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2019.4.0 (unreleased)
 ---------------------
 
+- Include actor_id and actor_label in @notifications endpoint responses. [lgraf]
 - Bump docxcompose version to 1.0.1 [njohner]
 - Fix qa tests. [lgraf]
 - Disable properties action for teams. [deiferni]

--- a/docs/public/dev-manual/api/notifications.rst
+++ b/docs/public/dev-manual/api/notifications.rst
@@ -31,6 +31,8 @@ Mittels eines GET-Request können Benachrichtigungen des Benutzers abgefragt wer
       [
           {
               "@id": "http://nohost/plone/@notifications/kathi.barfuss/3",
+              "actor_id": "robert.ziegler",
+              "actor_label": "Ziegler Robert",
               "created": "2018-10-16T00:00:00+00:00",
               "label": "Task opened",
               "link": "http://nohost/plone/@@resolve_notification?notification_id=3",
@@ -41,6 +43,8 @@ Mittels eines GET-Request können Benachrichtigungen des Benutzers abgefragt wer
           },
           {
               "@id": "http://nohost/plone/@notifications/kathi.barfuss/1",
+              "actor_id": "robert.ziegler",
+              "actor_label": "Ziegler Robert",
               "created": "2017-10-16T00:00:00+00:00",
               "label": "Task opened",
               "link": "http://nohost/plone/@@resolve_notification?notification_id=1",
@@ -74,6 +78,8 @@ Eine einzelne Benarchrichtigung kann durch hinzufügen der Benachrichtigungs-ID 
 
       {
           "@id": "http://nohost/plone/@notifications/kathi.barfuss/3",
+          "actor_id": "robert.ziegler",
+          "actor_label": "Ziegler Robert",
           "created": "2018-10-16T00:00:00+00:00",
           "label": "Task opened",
           "link": "http://nohost/plone/@@resolve_notification?notification_id=3",

--- a/opengever/activity/model/notification.py
+++ b/opengever/activity/model/notification.py
@@ -1,5 +1,6 @@
 from opengever.base.model import Base
 from opengever.base.model import USER_ID_LENGTH
+from opengever.ogds.base.actor import Actor
 from plone.restapi.serializer.converters import json_compatible
 from sqlalchemy import Boolean
 from sqlalchemy import Column
@@ -35,9 +36,12 @@ class Notification(Base):
             repr(self.activity.resource))
 
     def serialize(self, portal_url):
+        actor = Actor.lookup(self.activity.actor_id)
         return {
             '@id': self._api_url(portal_url),
             'notification_id': self.notification_id,
+            'actor_id': self.activity.actor_id,
+            'actor_label': actor.get_label(with_principal=False),
             'created': json_compatible(self.activity.created),
             'read': self.is_read,
             'title': self.activity.title,

--- a/opengever/api/tests/test_notifications.py
+++ b/opengever/api/tests/test_notifications.py
@@ -45,6 +45,8 @@ class TestNotificationsGet(IntegrationTestCase):
 
         self.assertEquals(
             [{u'@id': u'http://nohost/plone/@notifications/kathi.barfuss/3',
+              u'actor_id': u'nicole.kohler',
+              u'actor_label': u'Kohler Nicole',
               u'created': u'2018-10-16T00:00:00+00:00',
               u'label': u'Task opened',
               u'link': u'http://nohost/plone/@@resolve_notification?notification_id=3',
@@ -53,6 +55,8 @@ class TestNotificationsGet(IntegrationTestCase):
               u'summary': u'New task opened by Ziegler Robert',
               u'title': u'Vertragsentwurf \xdcberpr\xfcfen'},
              {u'@id': u'http://nohost/plone/@notifications/kathi.barfuss/1',
+              u'actor_id': u'nicole.kohler',
+              u'actor_label': u'Kohler Nicole',
               u'created': u'2017-10-16T00:00:00+00:00',
               u'label': u'Task opened',
               u'link': u'http://nohost/plone/@@resolve_notification?notification_id=1',
@@ -115,6 +119,8 @@ class TestNotificationsGet(IntegrationTestCase):
 
         self.assertEquals(
             {u'@id': u'http://nohost/plone/@notifications/kathi.barfuss/1',
+             u'actor_id': u'robert.ziegler',
+             u'actor_label': u'Ziegler Robert',
              u'created': u'2017-10-16T00:00:00+00:00',
              u'label': u'Task opened',
              u'link': u'http://nohost/plone/@@resolve_notification?notification_id=1',


### PR DESCRIPTION
This includes `actor_id` and `actor_label` in the responses of the `@notifications` endpoint.

Since the ID is already included in the `actor_id` field, the label is rendered with `principal=False`, so it will contain `Lastname Firstname` instead of `Lastname Firstname (user.id)`.

Closes #5834

## Checkliste

- [x] Changelog-Eintrag vorhanden/nötig?
- [x] Aktualisierung Dokumentation vorhanden/nötig?
