### PR TITLE
Fix team actor profile_url for foreign users

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 
 - Nightly jobs: Add short -f option as alias for --force. [lgraf]
 - Nightly jobs: Don't require ftw.raven when running locally [lgraf]
+- Fix team actor profile_url for foreign users. [phgross]
 - Include actor_id and actor_label in @notifications endpoint responses. [lgraf]
 - Bump docxcompose version to 1.0.1 [njohner]
 - Improve SIP package generation and download. [phgross]

--- a/opengever/base/__init__.py
+++ b/opengever/base/__init__.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
-from zope.i18nmessageid import MessageFactory
 from opengever.base.interfaces import IFavoritesSettings
+from opengever.base.interfaces import ISearchSettings
 from plone import api
 from plone.i18n.locales import languages
+from zope.i18nmessageid import MessageFactory
 import csv
 
 _ = MessageFactory('opengever.base')
@@ -16,6 +17,11 @@ VERSION = 'GEVER Version %(version)s'
 def is_favorites_feature_enabled():
     return api.portal.get_registry_record(
         'is_feature_enabled', interface=IFavoritesSettings)
+
+
+def is_solr_feature_enabled():
+    return api.portal.get_registry_record(
+        'use_solr', interface=ISearchSettings)
 
 
 class OpenGeverCSVDialect(csv.excel):

--- a/opengever/base/security.py
+++ b/opengever/base/security.py
@@ -5,6 +5,7 @@ from AccessControl.User import UnrestrictedUser as BaseUnrestrictedUser
 from collective.indexing.interfaces import IIndexQueueProcessor
 from collective.indexing.queue import getQueue
 from contextlib import contextmanager
+from opengever.base import is_solr_feature_enabled
 from opengever.base.interfaces import IInternalWorkflowTransition
 from plone import api
 from Products.CMFCore.CMFCatalogAware import CatalogAware
@@ -12,7 +13,6 @@ from zope.component import getUtility
 from zope.globalrequest import getRequest
 from zope.interface import alsoProvides
 from zope.interface import noLongerProvides
-from opengever.ogds.base.sources import is_solr_feature_enabled
 
 
 class UnrestrictedUser(BaseUnrestrictedUser):

--- a/opengever/base/source.py
+++ b/opengever/base/source.py
@@ -4,7 +4,7 @@ from ftw.solr.interfaces import ISolrSearch
 from ftw.solr.query import escape
 from ftw.solr.query import make_query
 from opengever.base import interfaces
-from opengever.ogds.base.sources import is_solr_feature_enabled
+from opengever.base import is_solr_feature_enabled
 from plone.formwidget.contenttree import ObjPathSourceBinder
 from plone.formwidget.contenttree.source import CustomFilter
 from plone.formwidget.contenttree.source import ObjPathSource

--- a/opengever/contact/utils.py
+++ b/opengever/contact/utils.py
@@ -1,3 +1,4 @@
+from opengever.base.security import elevated_privileges
 from opengever.base.utils import get_hostname
 from opengever.contact.interfaces import IContactFolder
 from plone import api
@@ -12,7 +13,7 @@ def hostname_cache_key(m, *args, **kwargs):
 @ram.cache(hostname_cache_key)
 def get_contactfolder_url(elevate_privileges=False):
     if elevate_privileges:
-        from opengever.base.security import elevated_privileges
+
         with elevated_privileges():
             result = api.content.find(object_provides=IContactFolder)
     else:

--- a/opengever/contact/utils.py
+++ b/opengever/contact/utils.py
@@ -5,13 +5,19 @@ from plone.memoize import ram
 from zope.globalrequest import getRequest
 
 
-def hostname_cache_key(m):
+def hostname_cache_key(m, *args, **kwargs):
     return get_hostname(getRequest())
 
 
 @ram.cache(hostname_cache_key)
-def get_contactfolder_url():
-    result = api.content.find(object_provides=IContactFolder)
+def get_contactfolder_url(elevate_privileges=False):
+    if elevate_privileges:
+        from opengever.base.security import elevated_privileges
+        with elevated_privileges():
+            result = api.content.find(object_provides=IContactFolder)
+    else:
+        result = api.content.find(object_provides=IContactFolder)
+
     if not result:
         raise Exception('Contactfolder is missing, GEVER deployment was not '
                         'correctly set up.')

--- a/opengever/contact/utils.py
+++ b/opengever/contact/utils.py
@@ -1,4 +1,3 @@
-from opengever.base.security import elevated_privileges
 from opengever.base.utils import get_hostname
 from opengever.contact.interfaces import IContactFolder
 from plone import api
@@ -11,13 +10,13 @@ def hostname_cache_key(m, *args, **kwargs):
 
 
 @ram.cache(hostname_cache_key)
-def get_contactfolder_url(elevate_privileges=False):
-    if elevate_privileges:
-
-        with elevated_privileges():
-            result = api.content.find(object_provides=IContactFolder)
+def get_contactfolder_url(unrestricted=False):
+    catalog = api.portal.get_tool('portal_catalog')
+    if unrestricted:
+        result = catalog.unrestrictedSearchResults(
+            object_provides=IContactFolder.__identifier__)
     else:
-        result = api.content.find(object_provides=IContactFolder)
+        result = catalog(object_provides=IContactFolder.__identifier__)
 
     if not result:
         raise Exception('Contactfolder is missing, GEVER deployment was not '

--- a/opengever/ogds/base/actor.py
+++ b/opengever/ogds/base/actor.py
@@ -212,7 +212,7 @@ class TeamActor(Actor):
 
     def get_profile_url(self):
         return '{}/team-{}/view'.format(
-            get_contactfolder_url(), self.team.team_id)
+            get_contactfolder_url(elevate_privileges=True), self.team.team_id)
 
     def corresponds_to(self, user):
         return user in self.team.group.users

--- a/opengever/ogds/base/actor.py
+++ b/opengever/ogds/base/actor.py
@@ -212,7 +212,7 @@ class TeamActor(Actor):
 
     def get_profile_url(self):
         return '{}/team-{}/view'.format(
-            get_contactfolder_url(elevate_privileges=True), self.team.team_id)
+            get_contactfolder_url(unrestricted=True), self.team.team_id)
 
     def corresponds_to(self, user):
         return user in self.team.group.users

--- a/opengever/ogds/base/sources.py
+++ b/opengever/ogds/base/sources.py
@@ -1,5 +1,5 @@
 from ftw.solr.interfaces import ISolrSearch
-from opengever.base.interfaces import ISearchSettings
+from opengever.base import is_solr_feature_enabled
 from opengever.base.model import create_session
 from opengever.base.query import extend_query_with_textfilter
 from opengever.contact.contact import IContact
@@ -28,11 +28,6 @@ from zope.interface import implementer
 from zope.schema.interfaces import IContextSourceBinder
 from zope.schema.vocabulary import SimpleTerm
 import re
-
-
-def is_solr_feature_enabled():
-    return api.portal.get_registry_record(
-        'use_solr', interface=ISearchSettings)
 
 
 @implementer(IQuerySource)

--- a/opengever/ogds/base/tests/test_actor_lookup.py
+++ b/opengever/ogds/base/tests/test_actor_lookup.py
@@ -55,6 +55,14 @@ class TestActorLookup(IntegrationTestCase):
             u'Projekt \xdcberbaung Dorfmatte (Finanz\xe4mt)</a>',
             actor.get_link())
 
+    def test_team_profile_url_for_foreign_user(self):
+        self.login(self.foreign_contributor)
+        actor = Actor.lookup('team:1')
+        self.assertEqual(
+            u'<a href="http://nohost/plone/kontakte/team-1/view">'
+            u'Projekt \xdcberbaung Dorfmatte (Finanz\xe4mt)</a>',
+            actor.get_link())
+
     def test_user_actor_ogds_user(self):
         actor = Actor.lookup('jurgen.konig')
 

--- a/opengever/tabbedview/browser/base_tabs.py
+++ b/opengever/tabbedview/browser/base_tabs.py
@@ -3,7 +3,6 @@ from opengever.base.behaviors.classification import translated_public_trial_term
 from opengever.base.interfaces import IReferenceNumberFormatter
 from opengever.base.interfaces import IReferenceNumberSettings
 from opengever.ogds.base.sort_helpers import SortHelpers
-from opengever.ogds.base.sources import is_solr_feature_enabled
 from opengever.tabbedview.browser.listing import CatalogListingView
 from opengever.tabbedview.browser.listing import ListingView
 from opengever.tabbedview.filters import SubjectFilter

--- a/opengever/tabbedview/filters.py
+++ b/opengever/tabbedview/filters.py
@@ -3,8 +3,8 @@ from collections import OrderedDict
 from ftw.keywordwidget.widget import KeywordFieldWidget
 from ftw.solr.interfaces import ISolrSearch
 from ftw.solr.query import escape
+from opengever.base import is_solr_feature_enabled
 from opengever.globalindex.model.task import Task
-from opengever.ogds.base.sources import is_solr_feature_enabled
 from opengever.tabbedview import _
 from Products.CMFDiffTool.utils import safe_utf8
 from Products.CMFPlone.utils import safe_unicode


### PR DESCRIPTION
The profile_url fetches the contact folder which is not possible for a foreign user (is not permitted to see the contactfolder). Therefore I introduced a `elevate_privileges` keyword to get the contact_folder url even if the user is not allowed to access it.

In my opinion it's the right solution and part of an access as a foreign user, that some links are not accessible and answer with an unauthorized message.

Fixes #5843 

In addition to the actual change, I moved the `is_solr_feature_enabled` flag where it belongs to.


## Checkliste
_Zutreffendes soll angehakt stehengelassen werden._
- [x] Wurde etwas an der `Aufgabe` angepasst? Funktioniert das auch mit einer `Weiterleitung`? _Ja, eine Weiterleitung kann nicht direkt neu zugewiesen werden, sondern muss zuerst akzeptiert werden, demnach ist diese Situation so nicht möglich. _
- [x] Changelog-Eintrag vorhanden/nötig?
