### PR TITLE
Nightly Jobs: Minor Quality of Life improvements

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2019.4.0 (unreleased)
 ---------------------
 
+- Nightly jobs: Don't require ftw.raven when running locally [lgraf]
 - Include actor_id and actor_label in @notifications endpoint responses. [lgraf]
 - Bump docxcompose version to 1.0.1 [njohner]
 - Improve SIP package generation and download. [phgross]

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2019.4.0 (unreleased)
 ---------------------
 
+- Nightly jobs: Add short -f option as alias for --force. [lgraf]
 - Nightly jobs: Don't require ftw.raven when running locally [lgraf]
 - Include actor_id and actor_label in @notifications endpoint responses. [lgraf]
 - Bump docxcompose version to 1.0.1 [njohner]

--- a/opengever/activity/dispatcher.py
+++ b/opengever/activity/dispatcher.py
@@ -3,20 +3,11 @@ from opengever.activity.model import Subscription
 from opengever.activity.model import Watcher
 from opengever.activity.model.settings import NotificationSetting
 from opengever.base.model import create_session
+from opengever.base.sentry import maybe_report_exception
 from ZODB.POSException import ConflictError
 import logging
-import pkg_resources
 import sys
 import traceback
-
-
-try:
-    pkg_resources.get_distribution('ftw.raven')
-    from ftw.raven.reporter import maybe_report_exception
-except pkg_resources.DistributionNotFound:
-    HAS_RAVEN = False
-else:
-    HAS_RAVEN = True
 
 
 logger = logging.getLogger('opengever.activity')
@@ -92,8 +83,7 @@ class NotificationDispatcher(object):
 
             except BaseException:
                 e_type, e_value, tb = sys.exc_info()
-                if HAS_RAVEN:
-                    maybe_report_exception(self.context, self.request, e_type, e_value, tb)
+                maybe_report_exception(self.context, self.request, e_type, e_value, tb)
                 not_dispatched.append(notifications)
                 formatted_traceback = ''.join(traceback.format_exception(e_type, e_value, tb))
                 logger.error('Exception while dispatch activity (MailDispatcher):\n%s', formatted_traceback)

--- a/opengever/base/request.py
+++ b/opengever/base/request.py
@@ -1,3 +1,4 @@
+from opengever.base.sentry import maybe_report_exception
 from opengever.ogds.base.exceptions import ClientNotFound
 from opengever.ogds.base.interfaces import IInternalOpengeverRequestLayer
 from opengever.ogds.base.utils import get_current_admin_unit
@@ -11,20 +12,10 @@ from zope.globalrequest import getRequest
 from zope.interface import alsoProvides
 import json
 import os.path
-import pkg_resources
 import sys
 import traceback
 import urllib
 import urllib2
-
-
-try:
-    pkg_resources.get_distribution('ftw.raven')
-    from ftw.raven.reporter import maybe_report_exception
-except pkg_resources.DistributionNotFound:
-    HAS_RAVEN = False
-else:
-    HAS_RAVEN = True
 
 
 class RemoteRequestFailed(Exception):
@@ -195,9 +186,8 @@ def tracebackify(*args, **kwargs):
                                                     "text/x.traceback")
                     e_type, e_value, tb = sys.exc_info()
 
-                    if HAS_RAVEN:
-                        maybe_report_exception(self.context, self.request,
-                                               e_type, e_value, tb)
+                    maybe_report_exception(self.context, self.request,
+                                           e_type, e_value, tb)
 
                     return ''.join(traceback.format_exception(e_type, e_value,
                                                               tb))

--- a/opengever/base/sentry.py
+++ b/opengever/base/sentry.py
@@ -1,18 +1,29 @@
 from contextlib import contextmanager
 from zope.globalrequest import getRequest
 import logging
+import pkg_resources
 
+# Conditional imports to ease local development (without ftw.raven)
 try:
+    pkg_resources.get_distribution('ftw.raven')
+
+except pkg_resources.DistributionNotFound:
+    FTW_RAVEN_AVAILABLE = False
+
+    def maybe_report_exception(*args, **kwargs):
+        """Noop function that gets used during local development.
+        """
+        pass
+else:
+    FTW_RAVEN_AVAILABLE = True
     from ftw.raven.client import get_raven_client
     from ftw.raven.reporter import get_default_tags
     from ftw.raven.reporter import get_release
+    from ftw.raven.reporter import maybe_report_exception  # noqa
     from ftw.raven.reporter import prepare_extra_infos
     from ftw.raven.reporter import prepare_modules_infos
     from ftw.raven.reporter import prepare_request_infos
     from ftw.raven.reporter import prepare_user_infos
-    FTW_RAVEN_AVAILABLE = True
-except ImportError:
-    FTW_RAVEN_AVAILABLE = False
 
 
 log = logging.getLogger('opengever.base.sentry')

--- a/opengever/nightlyjobs/cronjobs.py
+++ b/opengever/nightlyjobs/cronjobs.py
@@ -1,5 +1,6 @@
 from logging.handlers import TimedRotatingFileHandler
 from opengever.base.pathfinder import PathFinder
+from opengever.base.sentry import maybe_report_exception
 from opengever.core.debughelpers import all_plone_sites
 from opengever.core.debughelpers import setup_plone
 from opengever.nightlyjobs.runner import nightly_jobs_feature_enabled
@@ -11,14 +12,6 @@ import logging
 import os
 import sys
 import traceback
-
-
-try:
-    from ftw.raven.reporter import maybe_report_exception
-except ImportError:
-    # Local development, ftw.raven may not be present
-    def maybe_report_exception(context, request, exc_type, exc, traceback):
-        pass
 
 
 LOG_FORMAT = "%(asctime)s - %(levelname)s - %(message)s"

--- a/opengever/nightlyjobs/cronjobs.py
+++ b/opengever/nightlyjobs/cronjobs.py
@@ -29,7 +29,7 @@ logger = None
 def parse_args(argv):
     parser = argparse.ArgumentParser(description='Run nightly jobs')
     parser.add_argument(
-        '--force', action='store_true',
+        '-f', '--force', action='store_true',
         help="Force execution even if outside time window or when load is high")
 
     args = parser.parse_args(argv)

--- a/opengever/nightlyjobs/cronjobs.py
+++ b/opengever/nightlyjobs/cronjobs.py
@@ -1,4 +1,3 @@
-from ftw.raven.reporter import maybe_report_exception
 from logging.handlers import TimedRotatingFileHandler
 from opengever.base.pathfinder import PathFinder
 from opengever.core.debughelpers import all_plone_sites
@@ -12,6 +11,14 @@ import logging
 import os
 import sys
 import traceback
+
+
+try:
+    from ftw.raven.reporter import maybe_report_exception
+except ImportError:
+    # Local development, ftw.raven may not be present
+    def maybe_report_exception(context, request, exc_type, exc, traceback):
+        pass
 
 
 LOG_FORMAT = "%(asctime)s - %(levelname)s - %(message)s"


### PR DESCRIPTION
Two small Quality of Life improvements for nightly jobs:

- Don't require `ftw.raven` when running nightly jobs locally.
- Add short `-f` option as alias for `--force`.

#5302  Checkliste

- [x] Changelog-Eintrag vorhanden/nötig?

