### PR TITLE
Use solr per default in policy templates.

### DIFF
--- a/opengever/policytemplates/policy_template/opengever.+package.name+/deployment-+base.server_name+-+base.deployment_number+-+base.domain+.cfg.bob
+++ b/opengever/policytemplates/policy_template/opengever.+package.name+/deployment-+base.server_name+-+base.deployment_number+-+base.domain+.cfg.bob
@@ -2,12 +2,12 @@
 extends =
     https://raw.githubusercontent.com/4teamwork/gever-buildouts/master/standard-deployment-v2.cfg
     https://raw.githubusercontent.com/4teamwork/gever-buildouts/master/ogds-postgres.cfg
-    https://raw.githubusercontent.com/4teamwork/gever-buildouts/master/tika-standalone.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/zeoclients/2.cfg
 {{% if setup.enable_bumblebee_feature %}}
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/bumblebee.cfg
 {{% endif %}}
     versions.cfg
+    https://raw.githubusercontent.com/4teamwork/gever-buildouts/master/solr.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/production-v2.cfg
 
 
@@ -16,6 +16,7 @@ ogds-db-name = ogds_{{{package.name}}}
 client-policy = opengever.{{{package.name}}}
 usernamelogger_ac_cookie_name = __ac_{{{adminunit.ac_cookie_name}}}
 instance-eggs += opengever.{{{package.name}}}
+solr-core-name = {{{package.name}}}
 raven_tags = {"cluster": "{{{base.domain}}}"}
 develop = .
 


### PR DESCRIPTION
This PR updates policy templates so that they are created according to our newest feature set. We always want to enable solr. Tika can be dropped as with solr it is not used.