### PR TITLE
Expose document actions in @actions endpoint in separate `file_actions` category.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2019.4.0 (unreleased)
 ---------------------
 
+- Expose document actions in @actions endpoint in separate file_actions category. [njohner, deiferni]
 - Nightly jobs: Add short -f option as alias for --force. [lgraf]
 - Nightly jobs: Don't require ftw.raven when running locally [lgraf]
 - Fix team actor profile_url for foreign users. [phgross]

--- a/opengever/api/tests/test_actions.py
+++ b/opengever/api/tests/test_actions.py
@@ -6,6 +6,7 @@ from zope.component import getMultiAdapter
 
 class TestFileActionsGet(IntegrationTestCase):
 
+    features = ('bumblebee',)
     maxDiff = None
 
     def get_file_actions(self, browser, context):
@@ -26,6 +27,9 @@ class TestFileActionsGet(IntegrationTestCase):
             {u'id': u'attach_to_email',
              u'title': u'Attach to email',
              u'icon': u''},
+            {u'id': u'open_as_pdf',
+             u'title': u'Open as PDF',
+             u'icon': u''},
             ]
         self.assertEqual(expected_file_actions,
                          self.get_file_actions(browser, self.document))
@@ -43,6 +47,9 @@ class TestFileActionsGet(IntegrationTestCase):
              u'icon': u''},
             {u'id': u'attach_to_email',
              u'title': u'Attach to email',
+             u'icon': u''},
+            {u'id': u'open_as_pdf',
+             u'title': u'Open as PDF',
              u'icon': u''},
             ]
         self.assertEqual(expected_file_actions,
@@ -92,6 +99,9 @@ class TestFileActionsGet(IntegrationTestCase):
             {u'id': u'attach_to_email',
              u'title': u'Attach to email',
              u'icon': u''},
+            {u'id': u'open_as_pdf',
+             u'title': u'Open as PDF',
+             u'icon': u''},
             ]
 
         self.assertEqual(expected_file_actions,
@@ -123,6 +133,9 @@ class TestFileActionsGet(IntegrationTestCase):
             {u'id': u'attach_to_email',
              u'title': u'Attach to email',
              u'icon': u''},
+            {u'id': u'open_as_pdf',
+             u'title': u'Open as PDF',
+             u'icon': u''},
             ]
 
         self.assertEqual(expected_file_actions,
@@ -146,12 +159,18 @@ class TestFileActionsGet(IntegrationTestCase):
             {u'id': u'cancel_checkout',
              u'title': u'Cancel checkout',
              u'icon': u''},
+            {u'id': u'open_as_pdf',
+             u'title': u'Open as PDF',
+             u'icon': u''},
             ]
         self.assertEqual(expected_manager_file_actions,
                          self.get_file_actions(browser, self.document))
 
         self.login(self.dossier_manager, browser)
         expected_dossier_manager_file_actions = [
+            {u'id': u'open_as_pdf',
+             u'title': u'Open as PDF',
+             u'icon': u''},
             ]
         self.assertEqual(expected_dossier_manager_file_actions,
                          self.get_file_actions(browser, self.document))
@@ -165,6 +184,9 @@ class TestFileActionsGet(IntegrationTestCase):
              u'icon': u''},
             {u'id': u'attach_to_email',
              u'title': u'Attach to email',
+             u'icon': u''},
+            {u'id': u'open_as_pdf',
+             u'title': u'Open as PDF',
              u'icon': u''},
             ]
 
@@ -182,6 +204,9 @@ class TestFileActionsGet(IntegrationTestCase):
             {u'id': u'download_copy',
              u'title': u'Download copy',
              u'icon': u''},
+            {u'id': u'open_as_pdf',
+             u'title': u'Open as PDF',
+             u'icon': u''},
             ]
         self.assertEqual(expected_file_actions,
                          self.get_file_actions(browser, self.document))
@@ -197,3 +222,21 @@ class TestFileActionsGet(IntegrationTestCase):
             ]
         self.assertEqual(expected_file_actions,
                          self.get_file_actions(browser, self.shadow_document))
+
+    @browsing
+    def test_open_as_pdf_not_available_if_bumblebee_disabled(self, browser):
+        self.deactivate_feature('bumblebee')
+        self.login(self.regular_user, browser)
+        expected_file_actions = [
+            {u'id': u'oc_direct_checkout',
+             u'title': u'Checkout and edit',
+             u'icon': u''},
+            {u'id': u'download_copy',
+             u'title': u'Download copy',
+             u'icon': u''},
+            {u'id': u'attach_to_email',
+             u'title': u'Attach to email',
+             u'icon': u''},
+            ]
+        self.assertEqual(expected_file_actions,
+                         self.get_file_actions(browser, self.document))

--- a/opengever/api/tests/test_actions.py
+++ b/opengever/api/tests/test_actions.py
@@ -1,5 +1,7 @@
 from ftw.testbrowser import browsing
+from opengever.document.interfaces import ICheckinCheckoutManager
 from opengever.testing import IntegrationTestCase
+from zope.component import getMultiAdapter
 
 
 class TestCheckoutAPI(IntegrationTestCase):
@@ -41,6 +43,23 @@ class TestCheckoutAPI(IntegrationTestCase):
             {u'title': u'Download copy', u'id': u'download', u'icon': u''},
             {u'icon': u'', u'id': u'simple_checkout', u'title': u'Checkout'}
             ]
+        listed_file_actions = browser.json['file_actions']
+        self.assertEqual(expected_file_actions, listed_file_actions)
+
+    @browsing
+    def test_checkin_without_comment_available_if_checked_out_by_current_user(self, browser):
+        self.login(self.regular_user, browser)
+        manager = getMultiAdapter((self.document, self.request),
+                                  ICheckinCheckoutManager)
+        manager.checkout()
+        browser.open(self.document.absolute_url() + '/@actions',
+                     method='GET', headers=self.api_headers)
+        expected_file_actions = [
+            {u'title': u'Download copy', u'id': u'download', u'icon': u''},
+            {u'title': u'Checkout and edit', u'id': u'officeconnector_checkout_url', u'icon': u''},
+            {u'title': u'Checkin without comment', u'id': u'checkin_without_comment', u'icon': u''}
+            ]
+
         listed_file_actions = browser.json['file_actions']
         self.assertEqual(expected_file_actions, listed_file_actions)
 

--- a/opengever/api/tests/test_actions.py
+++ b/opengever/api/tests/test_actions.py
@@ -4,47 +4,67 @@ from opengever.testing import IntegrationTestCase
 from zope.component import getMultiAdapter
 
 
-class TestCheckoutAPI(IntegrationTestCase):
+class TestFileActionsGet(IntegrationTestCase):
+
+    maxDiff = None
+
+    def get_file_actions(self, browser, context):
+        browser.open(context.absolute_url() + '/@actions',
+                     method='GET', headers=self.api_headers)
+        return browser.json['file_actions']
 
     @browsing
     def test_available_file_actions_for_document(self, browser):
         self.login(self.regular_user, browser)
-        browser.open(self.document.absolute_url() + '/@actions',
-                     method='GET', headers=self.api_headers)
         expected_file_actions = [
-            {u'title': u'Download copy', u'id': u'download', u'icon': u''},
-            {u'icon': u'',
-             u'id': u'officeconnector_checkout_url',
-             u'title': u'Checkout and edit'},
+            {u'id': u'oc_direct_checkout',
+             u'title': u'Checkout and edit',
+             u'icon': u''},
+            {u'id': u'download_copy',
+             u'title': u'Download copy',
+             u'icon': u''},
+            {u'id': u'attach_to_email',
+             u'title': u'Attach to email',
+             u'icon': u''},
             ]
-        listed_file_actions = browser.json['file_actions']
-        self.assertEqual(expected_file_actions, listed_file_actions)
+        self.assertEqual(expected_file_actions,
+                         self.get_file_actions(browser, self.document))
 
     @browsing
-    def test_zem_checkout_available_if_oc_checkout_deactivated(self, browser):
+    def test_oc_zem_checkout_available_if_oc_checkout_deactivated(self, browser):
         self.deactivate_feature('officeconnector-checkout')
         self.login(self.regular_user, browser)
-        browser.open(self.document.absolute_url() + '/@actions',
-                     method='GET', headers=self.api_headers)
         expected_file_actions = [
-            {u'title': u'Download copy', u'id': u'download', u'icon': u''},
-            {u'icon': u'', u'id': u'zem_checkout', u'title': u'Checkout and edit'}
+            {u'id': u'oc_zem_checkout',
+             u'title': u'Checkout and edit',
+             u'icon': u''},
+            {u'id': u'download_copy',
+             u'title': u'Download copy',
+             u'icon': u''},
+            {u'id': u'attach_to_email',
+             u'title': u'Attach to email',
+             u'icon': u''},
             ]
-        listed_file_actions = browser.json['file_actions']
-        self.assertEqual(expected_file_actions, listed_file_actions)
+        self.assertEqual(expected_file_actions,
+                         self.get_file_actions(browser, self.document))
 
     @browsing
-    def test_simple_checkout_available_if_file_not_oc_editable(self, browser):
+    def test_oc_unsupported_file_checkout_available_if_file_not_oc_editable(self, browser):
         self.login(self.regular_user, browser)
         self.document.file.contentType = u'foo/bar'
-        browser.open(self.document.absolute_url() + '/@actions',
-                     method='GET', headers=self.api_headers)
         expected_file_actions = [
-            {u'title': u'Download copy', u'id': u'download', u'icon': u''},
-            {u'icon': u'', u'id': u'simple_checkout', u'title': u'Checkout'}
+            {u'id': u'oc_unsupported_file_checkout',
+             u'title': u'Checkout',
+             u'icon': u''},
+            {u'id': u'download_copy',
+             u'title': u'Download copy',
+             u'icon': u''},
+            {u'id': u'attach_to_email',
+             u'title': u'Attach to email',
+             u'icon': u''},
             ]
-        listed_file_actions = browser.json['file_actions']
-        self.assertEqual(expected_file_actions, listed_file_actions)
+        self.assertEqual(expected_file_actions,
+                         self.get_file_actions(browser, self.document))
 
     @browsing
     def test_checkin_available_if_checked_out_by_current_user(self, browser):
@@ -52,17 +72,61 @@ class TestCheckoutAPI(IntegrationTestCase):
         manager = getMultiAdapter((self.document, self.request),
                                   ICheckinCheckoutManager)
         manager.checkout()
-        browser.open(self.document.absolute_url() + '/@actions',
-                     method='GET', headers=self.api_headers)
+
         expected_file_actions = [
-            {u'title': u'Download copy', u'id': u'download', u'icon': u''},
-            {u'title': u'Checkout and edit', u'id': u'officeconnector_checkout_url', u'icon': u''},
-            {u'title': u'Checkin without comment', u'id': u'checkin_without_comment', u'icon': u''},
-            {u'title': u'Checkin with comment', u'id': u'checkin_with_comment', u'icon': u''}
+            {u'id': u'oc_direct_edit',
+             u'title': u'Edit',
+             u'icon': u''},
+            {u'id': u'checkin_without_comment',
+             u'title': u'Checkin without comment',
+             u'icon': u''},
+            {u'id': u'checkin_with_comment',
+             u'title': u'Checkin with comment',
+             u'icon': u''},
+            {u'id': u'cancel_checkout',
+             u'title': u'Cancel checkout',
+             u'icon': u''},
+            {u'id': u'download_copy',
+             u'title': u'Download copy',
+             u'icon': u''},
+            {u'id': u'attach_to_email',
+             u'title': u'Attach to email',
+             u'icon': u''},
             ]
 
-        listed_file_actions = browser.json['file_actions']
-        self.assertEqual(expected_file_actions, listed_file_actions)
+        self.assertEqual(expected_file_actions,
+                         self.get_file_actions(browser, self.document))
+
+    @browsing
+    def test_checkin_available_if_checked_out_by_current_user_oc_checkout_deactivated(self, browser):
+        self.login(self.regular_user, browser)
+        manager = getMultiAdapter((self.document, self.request),
+                                  ICheckinCheckoutManager)
+        manager.checkout()
+
+        expected_file_actions = [
+            {u'id': u'oc_direct_edit',
+             u'title': u'Edit',
+             u'icon': u''},
+            {u'id': u'checkin_without_comment',
+             u'title': u'Checkin without comment',
+             u'icon': u''},
+            {u'id': u'checkin_with_comment',
+             u'title': u'Checkin with comment',
+             u'icon': u''},
+            {u'id': u'cancel_checkout',
+             u'title': u'Cancel checkout',
+             u'icon': u''},
+            {u'id': u'download_copy',
+             u'title': u'Download copy',
+             u'icon': u''},
+            {u'id': u'attach_to_email',
+             u'title': u'Attach to email',
+             u'icon': u''},
+            ]
+
+        self.assertEqual(expected_file_actions,
+                         self.get_file_actions(browser, self.document))
 
     @browsing
     def test_checkin_only_available_for_managers_if_checked_out_by_other_user(self, browser):
@@ -72,31 +136,64 @@ class TestCheckoutAPI(IntegrationTestCase):
         manager.checkout()
 
         self.login(self.manager, browser)
-        browser.open(self.document.absolute_url() + '/@actions',
-                     method='GET', headers=self.api_headers)
-        expected_file_actions = [
-            {u'title': u'Download copy', u'id': u'download', u'icon': u''},
-            {u'title': u'Checkin without comment', u'id': u'checkin_without_comment', u'icon': u''},
-            {u'title': u'Checkin with comment', u'id': u'checkin_with_comment', u'icon': u''}
+        expected_manager_file_actions = [
+            {u'id': u'checkin_without_comment',
+             u'title': u'Checkin without comment',
+             u'icon': u''},
+            {u'id': u'checkin_with_comment',
+             u'title': u'Checkin with comment',
+             u'icon': u''},
+            {u'id': u'cancel_checkout',
+             u'title': u'Cancel checkout',
+             u'icon': u''},
             ]
-        listed_file_actions = browser.json['file_actions']
-        self.assertEqual(expected_file_actions, listed_file_actions)
+        self.assertEqual(expected_manager_file_actions,
+                         self.get_file_actions(browser, self.document))
 
         self.login(self.dossier_manager, browser)
-        browser.open(self.document.absolute_url() + '/@actions',
-                     method='GET', headers=self.api_headers)
-        expected_file_actions = [
-            {u'title': u'Download copy', u'id': u'download', u'icon': u''}]
-        listed_file_actions = browser.json['file_actions']
-        self.assertEqual(expected_file_actions, listed_file_actions)
+        expected_dossier_manager_file_actions = [
+            ]
+        self.assertEqual(expected_dossier_manager_file_actions,
+                         self.get_file_actions(browser, self.document))
 
     @browsing
     def test_available_file_actions_for_mail(self, browser):
         self.login(self.regular_user, browser)
-        browser.open(self.mail_eml.absolute_url() + '/@actions',
-                     method='GET', headers=self.api_headers)
         expected_file_actions = [
-            {u'title': u'Download copy', u'id': u'download', u'icon': u''},
+            {u'id': u'download_copy',
+             u'title': u'Download copy',
+             u'icon': u''},
+            {u'id': u'attach_to_email',
+             u'title': u'Attach to email',
+             u'icon': u''},
             ]
-        listed_file_actions = browser.json['file_actions']
-        self.assertEqual(expected_file_actions, listed_file_actions)
+
+        self.assertEqual(expected_file_actions,
+                         self.get_file_actions(browser, self.mail_eml))
+
+    @browsing
+    def test_attach_not_available_if_feature_disabled(self, browser):
+        self.deactivate_feature('officeconnector-attach')
+        self.login(self.regular_user, browser)
+        expected_file_actions = [
+            {u'id': u'oc_direct_checkout',
+             u'title': u'Checkout and edit',
+             u'icon': u''},
+            {u'id': u'download_copy',
+             u'title': u'Download copy',
+             u'icon': u''},
+            ]
+        self.assertEqual(expected_file_actions,
+                         self.get_file_actions(browser, self.document))
+
+    @browsing
+    def test_oneoffixx_retry_available_for_shadow_documents(self, browser):
+        self.activate_feature('oneoffixx')
+        self.login(self.manager, browser)
+        expected_file_actions = [
+            {u'id': u'oneoffixx_retry',
+             u'title': u'Oneoffixx retry',
+             u'icon': u''},
+            ]
+        self.assertEqual(expected_file_actions,
+                         self.get_file_actions(browser, self.shadow_document))

--- a/opengever/api/tests/test_actions.py
+++ b/opengever/api/tests/test_actions.py
@@ -1,7 +1,5 @@
 from ftw.testbrowser import browsing
-from opengever.document.interfaces import ICheckinCheckoutManager
 from opengever.testing import IntegrationTestCase
-from zope.component import getMultiAdapter
 
 
 class TestFileActionsGet(IntegrationTestCase):
@@ -76,9 +74,7 @@ class TestFileActionsGet(IntegrationTestCase):
     @browsing
     def test_checkin_available_if_checked_out_by_current_user(self, browser):
         self.login(self.regular_user, browser)
-        manager = getMultiAdapter((self.document, self.request),
-                                  ICheckinCheckoutManager)
-        manager.checkout()
+        self.checkout_document(self.document)
 
         expected_file_actions = [
             {u'id': u'oc_direct_edit',
@@ -110,9 +106,7 @@ class TestFileActionsGet(IntegrationTestCase):
     @browsing
     def test_checkin_available_if_checked_out_by_current_user_oc_checkout_deactivated(self, browser):
         self.login(self.regular_user, browser)
-        manager = getMultiAdapter((self.document, self.request),
-                                  ICheckinCheckoutManager)
-        manager.checkout()
+        self.checkout_document(self.document)
 
         expected_file_actions = [
             {u'id': u'oc_direct_edit',
@@ -144,9 +138,7 @@ class TestFileActionsGet(IntegrationTestCase):
     @browsing
     def test_checkin_only_available_for_managers_if_checked_out_by_other_user(self, browser):
         self.login(self.regular_user, browser)
-        manager = getMultiAdapter((self.document, self.request),
-                                  ICheckinCheckoutManager)
-        manager.checkout()
+        self.checkout_document(self.document)
 
         self.login(self.manager, browser)
         expected_manager_file_actions = [

--- a/opengever/api/tests/test_actions.py
+++ b/opengever/api/tests/test_actions.py
@@ -32,6 +32,19 @@ class TestCheckoutAPI(IntegrationTestCase):
         self.assertEqual(expected_file_actions, listed_file_actions)
 
     @browsing
+    def test_simple_checkout_available_if_file_not_oc_editable(self, browser):
+        self.login(self.regular_user, browser)
+        self.document.file.contentType = u'foo/bar'
+        browser.open(self.document.absolute_url() + '/@actions',
+                     method='GET', headers=self.api_headers)
+        expected_file_actions = [
+            {u'title': u'Download copy', u'id': u'download', u'icon': u''},
+            {u'icon': u'', u'id': u'simple_checkout', u'title': u'Checkout'}
+            ]
+        listed_file_actions = browser.json['file_actions']
+        self.assertEqual(expected_file_actions, listed_file_actions)
+
+    @browsing
     def test_available_file_actions_for_mail(self, browser):
         self.login(self.regular_user, browser)
         browser.open(self.mail_eml.absolute_url() + '/@actions',

--- a/opengever/api/tests/test_actions.py
+++ b/opengever/api/tests/test_actions.py
@@ -11,6 +11,9 @@ class TestCheckoutAPI(IntegrationTestCase):
                      method='GET', headers=self.api_headers)
         expected_file_actions = [
             {u'title': u'Download copy', u'id': u'download', u'icon': u''},
+            {u'icon': u'',
+             u'id': u'officeconnector_checkout_url',
+             u'title': u'Checkout and edit with office connector'},
             ]
         listed_file_actions = browser.json['file_actions']
         self.assertEqual(expected_file_actions, listed_file_actions)

--- a/opengever/api/tests/test_actions.py
+++ b/opengever/api/tests/test_actions.py
@@ -47,7 +47,7 @@ class TestCheckoutAPI(IntegrationTestCase):
         self.assertEqual(expected_file_actions, listed_file_actions)
 
     @browsing
-    def test_checkin_without_comment_available_if_checked_out_by_current_user(self, browser):
+    def test_checkin_available_if_checked_out_by_current_user(self, browser):
         self.login(self.regular_user, browser)
         manager = getMultiAdapter((self.document, self.request),
                                   ICheckinCheckoutManager)
@@ -57,9 +57,36 @@ class TestCheckoutAPI(IntegrationTestCase):
         expected_file_actions = [
             {u'title': u'Download copy', u'id': u'download', u'icon': u''},
             {u'title': u'Checkout and edit', u'id': u'officeconnector_checkout_url', u'icon': u''},
-            {u'title': u'Checkin without comment', u'id': u'checkin_without_comment', u'icon': u''}
+            {u'title': u'Checkin without comment', u'id': u'checkin_without_comment', u'icon': u''},
+            {u'title': u'Checkin with comment', u'id': u'checkin_with_comment', u'icon': u''}
             ]
 
+        listed_file_actions = browser.json['file_actions']
+        self.assertEqual(expected_file_actions, listed_file_actions)
+
+    @browsing
+    def test_checkin_only_available_for_managers_if_checked_out_by_other_user(self, browser):
+        self.login(self.regular_user, browser)
+        manager = getMultiAdapter((self.document, self.request),
+                                  ICheckinCheckoutManager)
+        manager.checkout()
+
+        self.login(self.manager, browser)
+        browser.open(self.document.absolute_url() + '/@actions',
+                     method='GET', headers=self.api_headers)
+        expected_file_actions = [
+            {u'title': u'Download copy', u'id': u'download', u'icon': u''},
+            {u'title': u'Checkin without comment', u'id': u'checkin_without_comment', u'icon': u''},
+            {u'title': u'Checkin with comment', u'id': u'checkin_with_comment', u'icon': u''}
+            ]
+        listed_file_actions = browser.json['file_actions']
+        self.assertEqual(expected_file_actions, listed_file_actions)
+
+        self.login(self.dossier_manager, browser)
+        browser.open(self.document.absolute_url() + '/@actions',
+                     method='GET', headers=self.api_headers)
+        expected_file_actions = [
+            {u'title': u'Download copy', u'id': u'download', u'icon': u''}]
         listed_file_actions = browser.json['file_actions']
         self.assertEqual(expected_file_actions, listed_file_actions)
 

--- a/opengever/api/tests/test_actions.py
+++ b/opengever/api/tests/test_actions.py
@@ -1,0 +1,27 @@
+from ftw.testbrowser import browsing
+from opengever.testing import IntegrationTestCase
+
+
+class TestCheckoutAPI(IntegrationTestCase):
+
+    @browsing
+    def test_available_file_actions_for_document(self, browser):
+        self.login(self.regular_user, browser)
+        browser.open(self.document.absolute_url() + '/@actions',
+                     method='GET', headers=self.api_headers)
+        expected_file_actions = [
+            {u'title': u'Download copy', u'id': u'download', u'icon': u''},
+            ]
+        listed_file_actions = browser.json['file_actions']
+        self.assertEqual(expected_file_actions, listed_file_actions)
+
+    @browsing
+    def test_available_file_actions_for_mail(self, browser):
+        self.login(self.regular_user, browser)
+        browser.open(self.mail_eml.absolute_url() + '/@actions',
+                     method='GET', headers=self.api_headers)
+        expected_file_actions = [
+            {u'title': u'Download copy', u'id': u'download', u'icon': u''},
+            ]
+        listed_file_actions = browser.json['file_actions']
+        self.assertEqual(expected_file_actions, listed_file_actions)

--- a/opengever/api/tests/test_actions.py
+++ b/opengever/api/tests/test_actions.py
@@ -13,7 +13,20 @@ class TestCheckoutAPI(IntegrationTestCase):
             {u'title': u'Download copy', u'id': u'download', u'icon': u''},
             {u'icon': u'',
              u'id': u'officeconnector_checkout_url',
-             u'title': u'Checkout and edit with office connector'},
+             u'title': u'Checkout and edit'},
+            ]
+        listed_file_actions = browser.json['file_actions']
+        self.assertEqual(expected_file_actions, listed_file_actions)
+
+    @browsing
+    def test_zem_checkout_available_if_oc_checkout_deactivated(self, browser):
+        self.deactivate_feature('officeconnector-checkout')
+        self.login(self.regular_user, browser)
+        browser.open(self.document.absolute_url() + '/@actions',
+                     method='GET', headers=self.api_headers)
+        expected_file_actions = [
+            {u'title': u'Download copy', u'id': u'download', u'icon': u''},
+            {u'icon': u'', u'id': u'zem_checkout', u'title': u'Checkout and edit'}
             ]
         listed_file_actions = browser.json['file_actions']
         self.assertEqual(expected_file_actions, listed_file_actions)

--- a/opengever/bumblebee/browser/overlay.py
+++ b/opengever/bumblebee/browser/overlay.py
@@ -102,9 +102,6 @@ class BumblebeeBaseDocumentOverlay(VisibleActionButtonRendererMixin):
 
         return u'{}/edit'.format(self.context.absolute_url())
 
-    def get_detail_view_url(self):
-        return self.context.absolute_url()
-
     def get_title(self):
         return self.context.title
 
@@ -209,9 +206,6 @@ class BumblebeeDocumentVersionOverlay(BumblebeeBaseDocumentOverlay):
         return None
 
     def get_edit_metadata_url(self):
-        return None
-
-    def get_detail_view_url(self):
         return None
 
     def render_checked_out_viewlet(self):

--- a/opengever/bumblebee/browser/overlay.py
+++ b/opengever/bumblebee/browser/overlay.py
@@ -118,14 +118,6 @@ class BumblebeeBaseDocumentOverlay(VisibleActionButtonRendererMixin):
     def get_filename(self):
         return self.get_file().filename if self.has_file() else None
 
-    def get_checkout_url(self):
-        if not self.has_file() or not self._is_checkout_and_edit_available():
-            return None
-
-        return u'{}/editing_document?_authenticator={}'.format(
-            self.context.absolute_url(),
-            createToken())
-
     def get_download_copy_link(self):
         # Because of cyclic dependencies, we can not import
         # DownloadConfirmationHelper in the top of the file.
@@ -175,9 +167,6 @@ class BumblebeeMailOverlay(BumblebeeBaseDocumentOverlay):
         """Mails are not versionable."""
         return True
 
-    def get_checkout_url(self):
-        return None
-
     def get_checkin_without_comment_url(self):
         return None
 
@@ -212,9 +201,6 @@ class BumblebeeDocumentVersionOverlay(BumblebeeBaseDocumentOverlay):
 
     def is_open_as_pdf_action_visible(self):
         return False
-
-    def get_checkout_url(self):
-        return None
 
     def get_checkin_without_comment_url(self):
         return None

--- a/opengever/bumblebee/browser/overlay.py
+++ b/opengever/bumblebee/browser/overlay.py
@@ -115,20 +115,6 @@ class BumblebeeBaseDocumentOverlay(VisibleActionButtonRendererMixin):
     def get_filename(self):
         return self.get_file().filename if self.has_file() else None
 
-    def get_download_copy_link(self):
-        # Because of cyclic dependencies, we can not import
-        # DownloadConfirmationHelper in the top of the file.
-        from opengever.document.browser.download import DownloadConfirmationHelper  # noqa
-
-        if not self.has_file():
-            return None
-
-        dc_helper = DownloadConfirmationHelper(self.context)
-        return dc_helper.get_html_tag(
-            additional_classes=['function-download-copy'],
-            include_token=True
-            )
-
     def render_checked_out_viewlet(self):
         viewlet = CheckedOutViewlet(self.context, self.request, None, None)
         viewlet.update()
@@ -169,19 +155,6 @@ class BumblebeeMailOverlay(BumblebeeBaseDocumentOverlay):
 
     def get_checkin_with_comment_url(self):
         return None
-
-    def get_download_copy_link(self):
-        href = u"{}/download?_authenticator={}".format(
-            self.context.absolute_url(),
-            self.context.restrictedTraverse('@@authenticator').token())
-
-        return u'<a href="{}" class="{}">{}</a>'.format(
-            href,
-            'function-download-copy',
-            translate('label_download_copy',
-                      default="Download copy",
-                      domain='opengever.document',
-                      context=self.request))
 
 
 @adapter(IDocumentSchema, IVersionedContextMarker)

--- a/opengever/bumblebee/browser/overlay.py
+++ b/opengever/bumblebee/browser/overlay.py
@@ -6,13 +6,11 @@ from opengever.base.interfaces import IReferenceNumber
 from opengever.base.interfaces import ISequenceNumber
 from opengever.base.protect import unprotected_write
 from opengever.base.utils import to_html_xweb_intelligent
-from opengever.bumblebee import _
 from opengever.bumblebee import is_bumblebee_feature_enabled
 from opengever.bumblebee.interfaces import IBumblebeeOverlay
 from opengever.bumblebee.interfaces import IVersionedContextMarker
 from opengever.document import _ as document_mf
 from opengever.document.browser.actionbuttons import VisibleActionButtonRendererMixin
-from opengever.document.browser.versions_tab import translate_link
 from opengever.document.checkout.viewlets import CheckedOutViewlet
 from opengever.document.document import IDocumentSchema
 from opengever.document.interfaces import ICheckinCheckoutManager
@@ -23,8 +21,6 @@ from opengever.mail.mail import IOGMailMarker
 from opengever.ogds.base.actor import Actor
 from opengever.trash.trash import ITrashed
 from plone import api
-from plone.protect import createToken
-from plone.protect.utils import addTokenToUrl
 from Products.CMFEditions.interfaces.IArchivist import ArchivistRetrieveError
 from Products.Five import BrowserView
 from zExceptions import NotFound
@@ -33,7 +29,6 @@ from zope.component import getAdapter
 from zope.component import getMultiAdapter
 from zope.component import getUtility
 from zope.component import queryMultiAdapter
-from zope.i18n import translate
 from zope.interface import alsoProvides
 from zope.interface import implementer
 from zope.interface import Interface
@@ -155,11 +150,6 @@ class BumblebeeBaseDocumentOverlay(VisibleActionButtonRendererMixin):
         viewlet.update()
         return viewlet.render()
 
-    def get_revert_link(self):
-        if self.is_versioned():
-            return self._get_revert_link()
-        return None
-
     def _is_checkout_and_edit_available(self):
         manager = queryMultiAdapter(
             (self.context, self.request), ICheckinCheckoutManager)
@@ -169,17 +159,6 @@ class BumblebeeBaseDocumentOverlay(VisibleActionButtonRendererMixin):
         if not userid:
             return manager.is_checkout_allowed()
         return userid == api.user.get_current().getId()
-
-    def _get_revert_link(self):
-        url = u'{}/revert-file-to-version?version_id={}'.format(
-            self.context.absolute_url(),
-            self.version_id)
-
-        url = addTokenToUrl(url)
-
-        return translate_link(
-            url, _(u'label_revert', default=u'Revert document'),
-            css_class='standalone function-revert')
 
 
 @adapter(IOGMailMarker, Interface)

--- a/opengever/bumblebee/browser/overlay.py
+++ b/opengever/bumblebee/browser/overlay.py
@@ -13,7 +13,7 @@ from opengever.bumblebee.interfaces import IBumblebeeOverlay
 from opengever.bumblebee.interfaces import IGeverBumblebeeSettings
 from opengever.bumblebee.interfaces import IVersionedContextMarker
 from opengever.document import _ as document_mf
-from opengever.document.browser.actionbuttons import ActionButtonRendererMixin
+from opengever.document.browser.actionbuttons import VisibleActionButtonRendererMixin
 from opengever.document.browser.versions_tab import translate_link
 from opengever.document.checkout.viewlets import CheckedOutViewlet
 from opengever.document.document import IDocumentSchema
@@ -45,7 +45,7 @@ import os
 
 @implementer(IBumblebeeOverlay)
 @adapter(IDocumentSchema, Interface)
-class BumblebeeBaseDocumentOverlay(ActionButtonRendererMixin):
+class BumblebeeBaseDocumentOverlay(VisibleActionButtonRendererMixin):
     """Bumblebee overlay for base documents.
     """
 
@@ -282,7 +282,7 @@ class BumblebeeDocumentVersionOverlay(BumblebeeBaseDocumentOverlay):
         return ''
 
 
-class BumblebeeOverlayBaseView(BrowserView, ActionButtonRendererMixin):
+class BumblebeeOverlayBaseView(BrowserView, VisibleActionButtonRendererMixin):
     """Baseview for the bumblebeeoverlay.
     """
 

--- a/opengever/bumblebee/browser/overlay.py
+++ b/opengever/bumblebee/browser/overlay.py
@@ -333,9 +333,10 @@ class BumblebeeOverlayListingView(BumblebeeOverlayBaseView):
     i.e. documents-tab, search-view, overview-tab
     """
 
+    def is_detail_view_link_visible(self):
+        return True
+
 
 class BumblebeeOverlayDocumentView(BumblebeeOverlayBaseView):
     """Bumblebeeoverlay called from the document itself.
     """
-
-    is_on_detail_view = True

--- a/opengever/bumblebee/browser/overlay.py
+++ b/opengever/bumblebee/browser/overlay.py
@@ -143,9 +143,6 @@ class BumblebeeMailOverlay(BumblebeeBaseDocumentOverlay):
         """Mails are not versionable."""
         return True
 
-    def get_checkin_without_comment_url(self):
-        return None
-
     def get_checkin_with_comment_url(self):
         return None
 
@@ -164,9 +161,6 @@ class BumblebeeDocumentVersionOverlay(BumblebeeBaseDocumentOverlay):
 
     def is_open_as_pdf_action_visible(self):
         return False
-
-    def get_checkin_without_comment_url(self):
-        return None
 
     def get_checkin_with_comment_url(self):
         return None

--- a/opengever/bumblebee/browser/overlay.py
+++ b/opengever/bumblebee/browser/overlay.py
@@ -143,9 +143,6 @@ class BumblebeeMailOverlay(BumblebeeBaseDocumentOverlay):
         """Mails are not versionable."""
         return True
 
-    def get_checkin_with_comment_url(self):
-        return None
-
 
 @adapter(IDocumentSchema, IVersionedContextMarker)
 class BumblebeeDocumentVersionOverlay(BumblebeeBaseDocumentOverlay):
@@ -161,9 +158,6 @@ class BumblebeeDocumentVersionOverlay(BumblebeeBaseDocumentOverlay):
 
     def is_open_as_pdf_action_visible(self):
         return False
-
-    def get_checkin_with_comment_url(self):
-        return None
 
     def render_checked_out_viewlet(self):
         return ''

--- a/opengever/bumblebee/browser/overlay.py
+++ b/opengever/bumblebee/browser/overlay.py
@@ -95,13 +95,6 @@ class BumblebeeBaseDocumentOverlay(VisibleActionButtonRendererMixin):
     def get_reference_number(self):
         return getAdapter(self.context, IReferenceNumber).get_number()
 
-    def get_edit_metadata_url(self):
-        if not api.user.has_permission(
-                'Modify portal content', obj=self.context):
-            return None
-
-        return u'{}/edit'.format(self.context.absolute_url())
-
     def get_title(self):
         return self.context.title
 
@@ -176,9 +169,6 @@ class BumblebeeDocumentVersionOverlay(BumblebeeBaseDocumentOverlay):
         return None
 
     def get_checkin_with_comment_url(self):
-        return None
-
-    def get_edit_metadata_url(self):
         return None
 
     def render_checked_out_viewlet(self):

--- a/opengever/bumblebee/browser/overlay.py
+++ b/opengever/bumblebee/browser/overlay.py
@@ -13,7 +13,6 @@ from opengever.document import _ as document_mf
 from opengever.document.browser.actionbuttons import VisibleActionButtonRendererMixin
 from opengever.document.checkout.viewlets import CheckedOutViewlet
 from opengever.document.document import IDocumentSchema
-from opengever.document.interfaces import ICheckinCheckoutManager
 from opengever.document.versioner import Versioner
 from opengever.locking.info import GeverLockInfoViewlet
 from opengever.mail import _ as mail_mf
@@ -28,7 +27,6 @@ from zope.component import adapter
 from zope.component import getAdapter
 from zope.component import getMultiAdapter
 from zope.component import getUtility
-from zope.component import queryMultiAdapter
 from zope.interface import alsoProvides
 from zope.interface import implementer
 from zope.interface import Interface
@@ -36,7 +34,7 @@ from zope.interface import Interface
 
 @implementer(IBumblebeeOverlay)
 @adapter(IDocumentSchema, Interface)
-class BumblebeeBaseDocumentOverlay(VisibleActionButtonRendererMixin):
+class BumblebeeBaseDocumentOverlay(object):
     """Bumblebee overlay for base documents.
     """
 
@@ -101,6 +99,12 @@ class BumblebeeBaseDocumentOverlay(VisibleActionButtonRendererMixin):
     def get_description(self):
         return to_html_xweb_intelligent(self.context.description)
 
+    def has_file(self):
+        return self.context.has_file()
+
+    def get_file(self):
+        return self.context.get_file()
+
     def get_file_size(self):
         """Return the filesize in KB."""
         return self.get_file().getSize() / 1024 if self.has_file() else None
@@ -117,16 +121,6 @@ class BumblebeeBaseDocumentOverlay(VisibleActionButtonRendererMixin):
         viewlet = GeverLockInfoViewlet(self.context, self.request, None, None)
         viewlet.update()
         return viewlet.render()
-
-    def _is_checkout_and_edit_available(self):
-        manager = queryMultiAdapter(
-            (self.context, self.request), ICheckinCheckoutManager)
-
-        userid = manager.get_checked_out_by()
-
-        if not userid:
-            return manager.is_checkout_allowed()
-        return userid == api.user.get_current().getId()
 
 
 @adapter(IOGMailMarker, Interface)

--- a/opengever/bumblebee/interfaces.py
+++ b/opengever/bumblebee/interfaces.py
@@ -93,10 +93,6 @@ class IBumblebeeOverlay(Interface):
         """Returns the url to edit the metadata of the current object.
         """
 
-    def get_detail_view_url():
-        """Returns the url to the base-view of the current object.
-        """
-
     def get_checkin_without_comment_url():
         """Returns the url to checkin the file.
 

--- a/opengever/bumblebee/interfaces.py
+++ b/opengever/bumblebee/interfaces.py
@@ -95,12 +95,6 @@ class IBumblebeeOverlay(Interface):
         Returns None if its not possible to download a copy.
         """
 
-    def get_open_as_pdf_url():
-        """Returns the url to open the file as a pdf representation.
-
-        If there is no pdf-representation, it returns None
-        """
-
     def get_edit_metadata_url():
         """Returns the url to edit the metadata of the current object.
         """

--- a/opengever/bumblebee/interfaces.py
+++ b/opengever/bumblebee/interfaces.py
@@ -139,10 +139,6 @@ class IBumblebeeOverlay(Interface):
         Returns html.
         """
 
-    def get_revert_link():
-        """Returns the url to retrieve the document.
-        """
-
     def is_versioned():
         """Returns True if the context is a versioned context.
         """

--- a/opengever/bumblebee/interfaces.py
+++ b/opengever/bumblebee/interfaces.py
@@ -83,12 +83,6 @@ class IBumblebeeOverlay(Interface):
         If there is no reference number it returns None
         """
 
-    def get_download_copy_link():
-        """Returns the html-link to download a copy of the file.
-
-        Returns None if its not possible to download a copy.
-        """
-
     def get_edit_metadata_url():
         """Returns the url to edit the metadata of the current object.
         """

--- a/opengever/bumblebee/interfaces.py
+++ b/opengever/bumblebee/interfaces.py
@@ -83,12 +83,6 @@ class IBumblebeeOverlay(Interface):
         If there is no reference number it returns None
         """
 
-    def get_checkin_without_comment_url():
-        """Returns the url to checkin the file.
-
-        Returns None if it's not possible to checkin the file.
-        """
-
     def get_checkin_with_comment_url():
         """Returns the url to checkin the file with a comment.
 

--- a/opengever/bumblebee/interfaces.py
+++ b/opengever/bumblebee/interfaces.py
@@ -83,12 +83,6 @@ class IBumblebeeOverlay(Interface):
         If there is no reference number it returns None
         """
 
-    def get_checkin_with_comment_url():
-        """Returns the url to checkin the file with a comment.
-
-        Returns None if it's not possible to checkin the file.
-        """
-
     def has_file():
         """Returns True if the object contains a file.
 

--- a/opengever/bumblebee/interfaces.py
+++ b/opengever/bumblebee/interfaces.py
@@ -106,7 +106,3 @@ class IBumblebeeOverlay(Interface):
 
         Returns html.
         """
-
-    def is_versioned():
-        """Returns True if the context is a versioned context.
-        """

--- a/opengever/bumblebee/interfaces.py
+++ b/opengever/bumblebee/interfaces.py
@@ -83,12 +83,6 @@ class IBumblebeeOverlay(Interface):
         If there is no reference number it returns None
         """
 
-    def get_checkout_url():
-        """Returns the url to checkout the file.
-
-        Returns None if it's not possible to checkout the file.
-        """
-
     def get_download_copy_link():
         """Returns the html-link to download a copy of the file.
 

--- a/opengever/bumblebee/interfaces.py
+++ b/opengever/bumblebee/interfaces.py
@@ -83,10 +83,6 @@ class IBumblebeeOverlay(Interface):
         If there is no reference number it returns None
         """
 
-    def get_edit_metadata_url():
-        """Returns the url to edit the metadata of the current object.
-        """
-
     def get_checkin_without_comment_url():
         """Returns the url to checkin the file.
 

--- a/opengever/bumblebee/locales/de/LC_MESSAGES/opengever.bumblebee.po
+++ b/opengever/bumblebee/locales/de/LC_MESSAGES/opengever.bumblebee.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-06-28 13:31+0000\n"
+"POT-Creation-Date: 2019-08-02 12:46+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -51,11 +51,6 @@ msgstr "Mehr anzeigen"
 #: ./opengever/bumblebee/browser/templates/preview_listing.pt
 msgid "label_no_contents"
 msgstr "Keine Inhalte"
-
-#. Default: "Revert document"
-#: ./opengever/bumblebee/browser/overlay.py
-msgid "label_revert"
-msgstr "Dokument zurücksetzen"
 
 #. Default: "Reviving the preview is not available for this context."
 #: ./opengever/bumblebee/browser/revive_preview.py

--- a/opengever/bumblebee/locales/fr/LC_MESSAGES/opengever.bumblebee.po
+++ b/opengever/bumblebee/locales/fr/LC_MESSAGES/opengever.bumblebee.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-06-28 13:31+0000\n"
+"POT-Creation-Date: 2019-08-02 12:46+0000\n"
 "PO-Revision-Date: 2017-10-16 16:28+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -51,11 +51,6 @@ msgstr "Montre plus"
 #: ./opengever/bumblebee/browser/templates/preview_listing.pt
 msgid "label_no_contents"
 msgstr "Aucun contenu"
-
-#. Default: "Revert document"
-#: ./opengever/bumblebee/browser/overlay.py
-msgid "label_revert"
-msgstr "Restaurer le document"
 
 #. Default: "Reviving the preview is not available for this context."
 #: ./opengever/bumblebee/browser/revive_preview.py

--- a/opengever/bumblebee/locales/opengever.bumblebee.pot
+++ b/opengever/bumblebee/locales/opengever.bumblebee.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-06-28 13:31+0000\n"
+"POT-Creation-Date: 2019-08-02 12:46+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -53,11 +53,6 @@ msgstr ""
 #. Default: "No contents"
 #: ./opengever/bumblebee/browser/templates/preview_listing.pt
 msgid "label_no_contents"
-msgstr ""
-
-#. Default: "Revert document"
-#: ./opengever/bumblebee/browser/overlay.py
-msgid "label_revert"
 msgstr ""
 
 #. Default: "Reviving the preview is not available for this context."

--- a/opengever/bumblebee/tests/test_overlay_adapter_document.py
+++ b/opengever/bumblebee/tests/test_overlay_adapter_document.py
@@ -141,30 +141,6 @@ class TestGetReferenceNumber(IntegrationTestCase):
         self.assertEqual(IReferenceNumber(self.document).get_number(), adapter.get_reference_number())
 
 
-class TestGetCheckoutLink(IntegrationTestCase):
-    """Test we correctly generate the document checkout link."""
-
-    features = (
-        'bumblebee',
-        )
-
-    def test_returns_checkout_and_edit_url(self):
-        self.login(self.regular_user)
-        adapter = getMultiAdapter((self.document, self.request), IBumblebeeOverlay)
-        expected_url = '{}/editing_document?_authenticator='.format(self.document.absolute_url())
-        self.assertTrue(adapter.get_checkout_url().startswith(expected_url))
-
-    def test_returns_none_if_no_document_is_available_to_checkout(self):
-        self.login(self.regular_user)
-        adapter = getMultiAdapter((self.empty_document, self.request), IBumblebeeOverlay)
-        self.assertIsNone(adapter.get_checkout_url())
-
-    def test_returns_none_if_user_is_not_allowed_to_edit(self):
-        self.login(self.regular_user)
-        adapter = getMultiAdapter((self.proposaldocument, self.request), IBumblebeeOverlay)
-        self.assertIsNone(adapter.get_checkout_url())
-
-
 class TestGetDownloadCopyLink(IntegrationTestCase):
     """Test we correctly generate the document download link."""
 

--- a/opengever/bumblebee/tests/test_overlay_adapter_document.py
+++ b/opengever/bumblebee/tests/test_overlay_adapter_document.py
@@ -141,26 +141,6 @@ class TestGetReferenceNumber(IntegrationTestCase):
         self.assertEqual(IReferenceNumber(self.document).get_number(), adapter.get_reference_number())
 
 
-class TestGetDownloadCopyLink(IntegrationTestCase):
-    """Test we correctly generate the document download link."""
-
-    features = (
-        'bumblebee',
-        )
-
-    @browsing
-    def test_returns_download_copy_link_as_html_link(self, browser):
-        self.login(self.regular_user)
-        adapter = getMultiAdapter((self.document, self.request), IBumblebeeOverlay)
-        browser.open_html(adapter.get_download_copy_link())
-        self.assertEqual('Download copy', browser.css('a').first.text)
-
-    def test_returns_none_if_no_document_is_available(self):
-        self.login(self.regular_user)
-        adapter = getMultiAdapter((self.empty_document, self.request), IBumblebeeOverlay)
-        self.assertIsNone(adapter.get_download_copy_link())
-
-
 class TestGetEditMetadataLink(IntegrationTestCase):
     """Test we correctly generate the document edit metadata link."""
 

--- a/opengever/bumblebee/tests/test_overlay_adapter_document.py
+++ b/opengever/bumblebee/tests/test_overlay_adapter_document.py
@@ -177,26 +177,6 @@ class TestGetFile(IntegrationTestCase):
         self.assertEqual(self.document.file, adapter.get_file())
 
 
-class TestGetCheckinWithoutCommentUrl(IntegrationTestCase):
-    """Test we correctly generate a checkin without comment link."""
-
-    features = (
-        'bumblebee',
-        )
-
-    def test_returns_none_when_document_is_not_checked_out(self):
-        self.login(self.regular_user)
-        adapter = getMultiAdapter((self.document, self.request), IBumblebeeOverlay)
-        self.assertIsNone(adapter.get_checkin_without_comment_url())
-
-    def test_returns_checkin_without_comment_url_as_string(self):
-        self.login(self.regular_user)
-        self.checkout_document(self.document)
-        adapter = getMultiAdapter((self.document, self.request), IBumblebeeOverlay)
-        expected_url = '{}/@@checkin_without_comment?_authenticator='.format(self.document.absolute_url())
-        self.assertTrue(adapter.get_checkin_without_comment_url().startswith(expected_url))
-
-
 class TestGetCheckinWithCommentUrl(IntegrationTestCase):
     """Test we correctly generate a checkin with comment link."""
 

--- a/opengever/bumblebee/tests/test_overlay_adapter_document.py
+++ b/opengever/bumblebee/tests/test_overlay_adapter_document.py
@@ -218,28 +218,3 @@ class TestRenderCheckedOutViewlet(IntegrationTestCase):
         adapter = getMultiAdapter((self.document, self.request), IBumblebeeOverlay)
         browser.open_html(adapter.render_checked_out_viewlet())
         self.assertEqual(1, len(browser.css('.portalMessage')))
-
-
-class TestIsVersionedContext(IntegrationTestCase):
-    """Test if we correctly detect if we're on a versioned document or not."""
-
-    features = (
-        'bumblebee',
-        )
-
-    def test_returns_false_if_no_version_id_is_given(self):
-        self.login(self.regular_user)
-        adapter = getMultiAdapter((self.document, self.request), IBumblebeeOverlay)
-        self.assertFalse(adapter.is_versioned())
-
-    def test_returns_true_if_version_id_is_a_string(self):
-        self.login(self.regular_user)
-        self.request['version_id'] = '0'
-        adapter = getMultiAdapter((self.document, self.request), IBumblebeeOverlay)
-        self.assertTrue(adapter.is_versioned())
-
-    def test_returns_true_if_version_id_is_a_number(self):
-        self.login(self.regular_user)
-        self.request['version_id'] = 123
-        adapter = getMultiAdapter((self.document, self.request), IBumblebeeOverlay)
-        self.assertTrue(adapter.is_versioned())

--- a/opengever/bumblebee/tests/test_overlay_adapter_document.py
+++ b/opengever/bumblebee/tests/test_overlay_adapter_document.py
@@ -6,7 +6,6 @@ from opengever.bumblebee.interfaces import IBumblebeeOverlay
 from opengever.bumblebee.interfaces import IVersionedContextMarker
 from opengever.testing import IntegrationTestCase
 from plone.locking.interfaces import IRefreshableLockable
-from plone.namedfile.file import NamedBlobFile
 from zope.component import getMultiAdapter
 from zope.component import getUtility
 from zope.interface import alsoProvides
@@ -43,56 +42,6 @@ class TestGetPreviewPdfUrl(IntegrationTestCase):
             'http://nohost/plone/++resource++opengever.bumblebee.resources/fallback_not_digitally_available.svg',
             adapter.preview_pdf_url(),
             )
-
-
-class TestGetOpenAsPdfLink(IntegrationTestCase):
-    """Test the integrity of generated bumblebee links."""
-
-    features = (
-        'bumblebee',
-        )
-
-    def test_returns_pdf_url_as_string(self):
-        self.login(self.regular_user)
-        adapter = getMultiAdapter((self.document, self.request), IBumblebeeOverlay)
-        self.assertEqual(
-            '{}/bumblebee-open-pdf?filename=Vertraegsentwurf.pdf'.format(self.document.absolute_url()),
-            adapter.get_open_as_pdf_url(),
-            )
-
-    def test_returns_none_if_no_mimetype_is_available(self):
-        self.login(self.regular_user)
-        adapter = getMultiAdapter((self.empty_document, self.request), IBumblebeeOverlay)
-        self.assertIsNone(adapter.get_open_as_pdf_url())
-
-    def test_returns_none_if_mimetype_is_not_supported(self):
-        self.login(self.regular_user)
-        self.document.file = NamedBlobFile(
-            data=u'T\xc3\xa4stfil\xc3\xa9',
-            contentType='test/notsupported',
-            filename=u'test.notsupported',
-            )
-        adapter = getMultiAdapter((self.document, self.request), IBumblebeeOverlay)
-        self.assertIsNone(adapter.get_open_as_pdf_url())
-
-
-class TestGetPdfFilename(IntegrationTestCase):
-    """Test we generate bumblebee filenames correctly."""
-
-    features = (
-        'bumblebee',
-        )
-
-    def test_changes_filename_extension_to_pdf_and_returns_filename(self):
-        self.login(self.regular_user)
-        adapter = getMultiAdapter((self.document, self.request), IBumblebeeOverlay)
-        self.assertEqual('Vertraegsentwurf.docx', self.document.file.filename)
-        self.assertEqual('Vertraegsentwurf.pdf', adapter._get_pdf_filename())
-
-    def test_returns_none_if_no_file_is_given(self):
-        self.login(self.regular_user)
-        adapter = getMultiAdapter((self.empty_document, self.request), IBumblebeeOverlay)
-        self.assertIsNone(adapter._get_pdf_filename())
 
 
 class TestGetFileSize(IntegrationTestCase):

--- a/opengever/bumblebee/tests/test_overlay_adapter_document.py
+++ b/opengever/bumblebee/tests/test_overlay_adapter_document.py
@@ -3,12 +3,10 @@ from opengever.base.interfaces import IReferenceNumber
 from opengever.base.interfaces import ISequenceNumber
 from opengever.bumblebee.browser.overlay import BumblebeeBaseDocumentOverlay
 from opengever.bumblebee.interfaces import IBumblebeeOverlay
-from opengever.bumblebee.interfaces import IVersionedContextMarker
 from opengever.testing import IntegrationTestCase
 from plone.locking.interfaces import IRefreshableLockable
 from zope.component import getMultiAdapter
 from zope.component import getUtility
-from zope.interface import alsoProvides
 from zope.interface.verify import verifyClass
 
 

--- a/opengever/bumblebee/tests/test_overlay_adapter_document.py
+++ b/opengever/bumblebee/tests/test_overlay_adapter_document.py
@@ -141,24 +141,6 @@ class TestGetReferenceNumber(IntegrationTestCase):
         self.assertEqual(IReferenceNumber(self.document).get_number(), adapter.get_reference_number())
 
 
-class TestGetEditMetadataLink(IntegrationTestCase):
-    """Test we correctly generate the document edit metadata link."""
-
-    features = (
-        'bumblebee',
-        )
-
-    def test_returns_edit_metadata_url(self):
-        self.login(self.regular_user)
-        adapter = getMultiAdapter((self.document, self.request), IBumblebeeOverlay)
-        self.assertEqual('{}/edit'.format(self.document.absolute_url()), adapter.get_edit_metadata_url())
-
-    def test_returns_none_if_user_is_not_allowed_to_edit(self):
-        self.login(self.regular_user)
-        adapter = getMultiAdapter((self.proposaldocument, self.request), IBumblebeeOverlay)
-        self.assertIsNone(adapter.get_edit_metadata_url())
-
-
 class TestHasFile(IntegrationTestCase):
     """Test we correctly detect if a document has a file."""
 

--- a/opengever/bumblebee/tests/test_overlay_adapter_document.py
+++ b/opengever/bumblebee/tests/test_overlay_adapter_document.py
@@ -347,26 +347,3 @@ class TestIsVersionedContext(IntegrationTestCase):
         self.request['version_id'] = 123
         adapter = getMultiAdapter((self.document, self.request), IBumblebeeOverlay)
         self.assertTrue(adapter.is_versioned())
-
-
-class TestGetRevertUrl(IntegrationTestCase):
-    """Test we generate proper document version revert links."""
-
-    features = (
-        'bumblebee',
-        )
-
-    def test_returns_revert_url_as_string(self):
-        self.login(self.regular_user)
-        alsoProvides(self.request, IVersionedContextMarker)
-        # We need to do both in order to fake a real request here
-        self.request['version_id'] = 3
-        adapter = getMultiAdapter((self.document, self.request), IBumblebeeOverlay)
-        adapter.version_id = 3
-        self.assertIn('revert-file-to-version?version_id=3', adapter.get_revert_link())
-
-    def test_returns_none_if_context_is_not_a_versioned_context(self):
-        self.login(self.regular_user)
-        alsoProvides(self.request, IVersionedContextMarker)
-        adapter = getMultiAdapter((self.document, self.request), IBumblebeeOverlay)
-        self.assertIsNone(adapter.get_revert_link())

--- a/opengever/bumblebee/tests/test_overlay_adapter_document.py
+++ b/opengever/bumblebee/tests/test_overlay_adapter_document.py
@@ -177,26 +177,6 @@ class TestGetFile(IntegrationTestCase):
         self.assertEqual(self.document.file, adapter.get_file())
 
 
-class TestGetCheckinWithCommentUrl(IntegrationTestCase):
-    """Test we correctly generate a checkin with comment link."""
-
-    features = (
-        'bumblebee',
-        )
-
-    def test_returns_none_when_document_is_not_checked_out(self):
-        self.login(self.regular_user)
-        adapter = getMultiAdapter((self.document, self.request), IBumblebeeOverlay)
-        self.assertIsNone(adapter.get_checkin_with_comment_url())
-
-    def test_returns_checkin_with_comment_url_as_string(self):
-        self.login(self.regular_user)
-        self.checkout_document(self.document)
-        adapter = getMultiAdapter((self.document, self.request), IBumblebeeOverlay)
-        expected_url = '{}/@@checkin_document?_authenticator='.format(self.document.absolute_url())
-        self.assertTrue(adapter.get_checkin_with_comment_url().startswith(expected_url))
-
-
 class TestRenderLockInfoViewlet(IntegrationTestCase):
     """Test we correctly render the document locking status."""
 

--- a/opengever/bumblebee/tests/test_overlay_adapter_mail.py
+++ b/opengever/bumblebee/tests/test_overlay_adapter_mail.py
@@ -54,14 +54,3 @@ class TestGetFile(IntegrationTestCase):
         adapter = getMultiAdapter((self.mail_eml, self.request), IBumblebeeOverlay)
 
         self.assertEqual(self.mail_eml.message, adapter.get_file())
-
-
-class TestGetCheckinWithCommentUrl(IntegrationTestCase):
-
-    features = ('bumblebee', )
-
-    def test_returns_none_because_its_not_possible_to_checkin_emails(self):
-        self.login(self.regular_user)
-        adapter = getMultiAdapter((self.mail_eml, self.request), IBumblebeeOverlay)
-
-        self.assertIsNone(adapter.get_checkin_with_comment_url())

--- a/opengever/bumblebee/tests/test_overlay_adapter_mail.py
+++ b/opengever/bumblebee/tests/test_overlay_adapter_mail.py
@@ -56,36 +56,6 @@ class TestGetFile(IntegrationTestCase):
         self.assertEqual(self.mail_eml.message, adapter.get_file())
 
 
-class TestGetOpenAsPdfLink(IntegrationTestCase):
-
-    features = ('bumblebee', )
-
-    def test_returns_none_for_unsupported_mail_conversion(self):
-        self.login(self.regular_user)
-        adapter = getMultiAdapter((self.mail_eml, self.request), IBumblebeeOverlay)
-
-        expected_url = (
-            'http://nohost/plone/ordnungssystem/fuhrung'
-            '/vertrage-und-vereinbarungen/dossier-1/document-29'
-            '/bumblebee-open-pdf?filename=Die%20Buergschaft.pdf'
-            )
-
-        self.assertEqual(expected_url, adapter.get_open_as_pdf_url())
-
-    def test_handles_non_ascii_characters_in_filename(self):
-        self.login(self.regular_user)
-        IMail(self.mail_eml).message.filename = u'GEVER - \xdcbernahme.msg'
-        adapter = getMultiAdapter((self.mail_eml, self.request), IBumblebeeOverlay)
-
-        expected_url = (
-            u'http://nohost/plone/ordnungssystem/fuhrung'
-            u'/vertrage-und-vereinbarungen/dossier-1/document-29'
-            u'/bumblebee-open-pdf?filename=GEVER%20-%20%C3%9Cbernahme.pdf'
-            )
-
-        self.assertEqual(expected_url, adapter.get_open_as_pdf_url())
-
-
 class TestGetCheckoutUrl(IntegrationTestCase):
 
     features = ('bumblebee', )

--- a/opengever/bumblebee/tests/test_overlay_adapter_mail.py
+++ b/opengever/bumblebee/tests/test_overlay_adapter_mail.py
@@ -56,17 +56,6 @@ class TestGetFile(IntegrationTestCase):
         self.assertEqual(self.mail_eml.message, adapter.get_file())
 
 
-class TestGetCheckinWithoutCommentUrl(IntegrationTestCase):
-
-    features = ('bumblebee', )
-
-    def test_returns_none_because_its_not_possible_to_checkin_emails(self):
-        self.login(self.regular_user)
-        adapter = getMultiAdapter((self.mail_eml, self.request), IBumblebeeOverlay)
-
-        self.assertIsNone(adapter.get_checkin_without_comment_url())
-
-
 class TestGetCheckinWithCommentUrl(IntegrationTestCase):
 
     features = ('bumblebee', )

--- a/opengever/bumblebee/tests/test_overlay_adapter_mail.py
+++ b/opengever/bumblebee/tests/test_overlay_adapter_mail.py
@@ -56,17 +56,6 @@ class TestGetFile(IntegrationTestCase):
         self.assertEqual(self.mail_eml.message, adapter.get_file())
 
 
-class TestGetCheckoutUrl(IntegrationTestCase):
-
-    features = ('bumblebee', )
-
-    def test_returns_none_because_its_not_possible_to_checkout_emails(self):
-        self.login(self.regular_user)
-        adapter = getMultiAdapter((self.mail_eml, self.request), IBumblebeeOverlay)
-
-        self.assertIsNone(adapter.get_checkout_url())
-
-
 class TestGetCheckinWithoutCommentUrl(IntegrationTestCase):
 
     features = ('bumblebee', )

--- a/opengever/bumblebee/tests/test_overlay_view.py
+++ b/opengever/bumblebee/tests/test_overlay_view.py
@@ -3,8 +3,26 @@ from opengever.bumblebee.browser.overlay import BumblebeeOverlayBaseView
 from opengever.document.interfaces import ICheckinCheckoutManager
 from opengever.testing import IntegrationTestCase
 from opengever.testing.helpers import create_document_version
+from plone import api
 from zExceptions import NotFound
 from zope.component import getMultiAdapter
+
+
+class TestGetRevertUrl(IntegrationTestCase):
+    """Test we generate proper document version revert links."""
+
+    features = (
+        'bumblebee',
+        )
+
+    def test_returns_revert_url_as_string(self):
+        self.login(self.regular_user)
+        # We need to do both in order to fake a real request here
+        self.request['version_id'] = 3
+        view = api.content.get_view('bumblebee-overlay-document',
+                                    self.document, self.request)
+        self.assertIn('revert-file-to-version?version_id=3',
+                      view.get_revert_to_version_url())
 
 
 class TestBumblebeeOverlayListing(IntegrationTestCase):

--- a/opengever/core/profiles/default/actions.xml
+++ b/opengever/core/profiles/default/actions.xml
@@ -63,6 +63,15 @@
       <property name="visible">True</property>
     </object>
 
+    <object name="checkin_with_comment" meta_type="CMF Action" i18n:domain="opengever.core">
+      <property name="title" i18n:translate="">Checkin with comment</property>
+      <property name="available_expr">object/file_actions_availability/is_checkin_with_comment_available</property>
+      <property name="permissions">
+        <element value="View" />
+      </property>
+      <property name="visible">True</property>
+    </object>
+
   </object>
 
   <!-- SITE ACTIONS -->

--- a/opengever/core/profiles/default/actions.xml
+++ b/opengever/core/profiles/default/actions.xml
@@ -16,56 +16,102 @@
   <!-- FILE ACTIONS used to list available actions through the actions endpoint-->
   <object name="file_actions" meta_type="CMF Action Category">
 
-    <object name="download" meta_type="CMF Action" i18n:domain="opengever.core">
-      <property name="title" i18n:translate="">Download copy</property>
-      <property name="description" i18n:translate="" />
-      <property name="icon_expr" />
-      <property name="available_expr">python:object.restrictedTraverse('@@plone_interface_info').provides('opengever.document.behaviors.IBaseDocument') and object.restrictedTraverse('file_download_confirmation/download_available')</property>
+    <object name="oc_direct_checkout" meta_type="CMF Action" i18n:domain="opengever.document">
+      <property name="title" i18n:translate="label_checkout_and_edit">Checkout and edit</property>
+      <property name="available_expr">object/@@file_actions_availability/is_oc_direct_checkout_action_available</property>
       <property name="permissions">
         <element value="View" />
       </property>
       <property name="visible">True</property>
     </object>
 
-    <object name="officeconnector_checkout_url" meta_type="CMF Action" i18n:domain="opengever.core">
-      <property name="title" i18n:translate="">Checkout and edit</property>
-      <property name="available_expr">object/file_actions_availability/is_oc_direct_checkout_action_available</property>
+    <object name="oc_direct_edit" meta_type="CMF Action" i18n:domain="opengever.document">
+      <property name="title" i18n:translate="label_edit">Edit</property>
+      <property name="available_expr">object/@@file_actions_availability/is_oc_direct_edit_action_available</property>
       <property name="permissions">
         <element value="View" />
       </property>
       <property name="visible">True</property>
     </object>
 
-    <object name="zem_checkout" meta_type="CMF Action" i18n:domain="opengever.core">
-      <property name="title" i18n:translate="">Checkout and edit</property>
-      <property name="available_expr">object/file_actions_availability/is_oc_zem_checkout_action_available</property>
+    <object name="oc_zem_checkout" meta_type="CMF Action" i18n:domain="opengever.document">
+      <property name="title" i18n:translate="label_checkout_and_edit">Checkout and edit</property>
+      <property name="available_expr">object/@@file_actions_availability/is_oc_zem_checkout_action_available</property>
       <property name="permissions">
         <element value="View" />
       </property>
       <property name="visible">True</property>
     </object>
 
-    <object name="simple_checkout" meta_type="CMF Action" i18n:domain="opengever.core">
-      <property name="title" i18n:translate="">Checkout</property>
-      <property name="available_expr">object/file_actions_availability/is_checkout_action_available</property>
+    <object name="oc_zem_edit" meta_type="CMF Action" i18n:domain="opengever.document">
+      <property name="title" i18n:translate="label_edit">Edit</property>
+      <property name="available_expr">object/@@file_actions_availability/is_oc_zem_edit_action_available</property>
       <property name="permissions">
         <element value="View" />
       </property>
       <property name="visible">True</property>
     </object>
 
-    <object name="checkin_without_comment" meta_type="CMF Action" i18n:domain="opengever.core">
+    <object name="oc_unsupported_file_checkout" meta_type="CMF Action" i18n:domain="opengever.document">
+      <property name="title" i18n:translate="label_checkout">Checkout</property>
+      <property name="available_expr">object/@@file_actions_availability/is_oc_unsupported_file_checkout_action_available</property>
+      <property name="permissions">
+        <element value="View" />
+      </property>
+      <property name="visible">True</property>
+    </object>
+
+    <object name="checkin_without_comment" meta_type="CMF Action" i18n:domain="opengever.document">
       <property name="title" i18n:translate="">Checkin without comment</property>
-      <property name="available_expr">object/file_actions_availability/is_checkin_without_comment_available</property>
+      <property name="available_expr">object/@@file_actions_availability/is_checkin_without_comment_available</property>
       <property name="permissions">
         <element value="View" />
       </property>
       <property name="visible">True</property>
     </object>
 
-    <object name="checkin_with_comment" meta_type="CMF Action" i18n:domain="opengever.core">
+    <object name="checkin_with_comment" meta_type="CMF Action" i18n:domain="opengever.document">
       <property name="title" i18n:translate="">Checkin with comment</property>
-      <property name="available_expr">object/file_actions_availability/is_checkin_with_comment_available</property>
+      <property name="available_expr">object/@@file_actions_availability/is_checkin_with_comment_available</property>
+      <property name="permissions">
+        <element value="View" />
+      </property>
+      <property name="visible">True</property>
+    </object>
+
+    <object name="cancel_checkout" meta_type="CMF Action" i18n:domain="opengever.document">
+      <property name="title" i18n:translate="">Cancel checkout</property>
+      <property name="available_expr">object/@@file_actions_availability/is_cancel_checkout_action_available</property>
+      <property name="permissions">
+        <element value="View" />
+      </property>
+      <property name="visible">True</property>
+    </object>
+
+    <object name="download_copy" meta_type="CMF Action" i18n:domain="opengever.document">
+      <property name="title" i18n:translate="">Download copy</property>
+      <property name="description" i18n:translate="label_download_copy" />
+      <property name="available_expr">object/@@file_actions_availability/is_download_copy_action_available</property>
+      <property name="permissions">
+        <element value="View" />
+      </property>
+      <property name="visible">True</property>
+    </object>
+
+    <object name="attach_to_email" meta_type="CMF Action" i18n:domain="opengever.document">
+      <property name="title" i18n:translate="">Attach to email</property>
+      <property name="description" i18n:translate="label_attach_to_email" />
+      <property name="available_expr">object/@@file_actions_availability/is_attach_to_email_action_available</property>
+      <property name="permissions">
+        <element value="View" />
+      </property>
+      <property name="visible">True</property>
+    </object>
+
+    <object name="oneoffixx_retry" meta_type="CMF Action" i18n:domain="opengever.document">
+      <property name="title" i18n:translate="">Oneoffixx retry</property>
+      <property name="description" i18n:translate="label_retry_oneoffixx" />
+      <property name="available_expr">object/@@file_actions_availability/is_oneoffixx_retry_action_available</property>
       <property name="permissions">
         <element value="View" />
       </property>

--- a/opengever/core/profiles/default/actions.xml
+++ b/opengever/core/profiles/default/actions.xml
@@ -45,6 +45,15 @@
       <property name="visible">True</property>
     </object>
 
+    <object name="simple_checkout" meta_type="CMF Action" i18n:domain="opengever.core">
+      <property name="title" i18n:translate="">Checkout</property>
+      <property name="available_expr">object/file_actions_availability/is_checkout_action_available</property>
+      <property name="permissions">
+        <element value="View" />
+      </property>
+      <property name="visible">True</property>
+    </object>
+
   </object>
 
   <!-- SITE ACTIONS -->

--- a/opengever/core/profiles/default/actions.xml
+++ b/opengever/core/profiles/default/actions.xml
@@ -27,6 +27,15 @@
       <property name="visible">True</property>
     </object>
 
+    <object name="officeconnector_checkout_url" meta_type="CMF Action" i18n:domain="opengever.core">
+      <property name="title" i18n:translate="">Checkout and edit with office connector</property>
+      <property name="available_expr">object/file_actions_availability/is_oc_direct_checkout_action_available</property>
+      <property name="permissions">
+        <element value="View" />
+      </property>
+      <property name="visible">True</property>
+    </object>
+
   </object>
 
   <!-- SITE ACTIONS -->

--- a/opengever/core/profiles/default/actions.xml
+++ b/opengever/core/profiles/default/actions.xml
@@ -128,7 +128,7 @@
     </object>
 
     <object name="revert_to_version" meta_type="CMF Action" i18n:domain="opengever.document">
-      <property name="title" i18n:translate="label_revert">Revert document</property>
+      <property name="title" i18n:translate="label_revert_document">Revert document</property>
       <property name="available_expr">object/@@file_actions_availability/is_revert_to_version_action_available</property>
       <property name="permissions">
         <element value="View" />

--- a/opengever/core/profiles/default/actions.xml
+++ b/opengever/core/profiles/default/actions.xml
@@ -127,6 +127,15 @@
       <property name="visible">True</property>
     </object>
 
+    <object name="revert_to_version" meta_type="CMF Action" i18n:domain="opengever.document">
+      <property name="title" i18n:translate="label_revert">Revert document</property>
+      <property name="available_expr">object/@@file_actions_availability/is_revert_to_version_action_available</property>
+      <property name="permissions">
+        <element value="View" />
+      </property>
+      <property name="visible">True</property>
+    </object>
+
   </object>
 
   <!-- SITE ACTIONS -->

--- a/opengever/core/profiles/default/actions.xml
+++ b/opengever/core/profiles/default/actions.xml
@@ -16,6 +16,17 @@
   <!-- FILE ACTIONS used to list available actions through the actions endpoint-->
   <object name="file_actions" meta_type="CMF Action Category">
 
+    <object name="download" meta_type="CMF Action" i18n:domain="opengever.core">
+      <property name="title" i18n:translate="">Download copy</property>
+      <property name="description" i18n:translate="" />
+      <property name="icon_expr" />
+      <property name="available_expr">python:object.restrictedTraverse('@@plone_interface_info').provides('opengever.document.behaviors.IBaseDocument') and object.restrictedTraverse('file_download_confirmation/download_available')</property>
+      <property name="permissions">
+        <element value="View" />
+      </property>
+      <property name="visible">True</property>
+    </object>
+
   </object>
 
   <!-- SITE ACTIONS -->

--- a/opengever/core/profiles/default/actions.xml
+++ b/opengever/core/profiles/default/actions.xml
@@ -54,6 +54,15 @@
       <property name="visible">True</property>
     </object>
 
+    <object name="checkin_without_comment" meta_type="CMF Action" i18n:domain="opengever.core">
+      <property name="title" i18n:translate="">Checkin without comment</property>
+      <property name="available_expr">object/file_actions_availability/is_checkin_without_comment_available</property>
+      <property name="permissions">
+        <element value="View" />
+      </property>
+      <property name="visible">True</property>
+    </object>
+
   </object>
 
   <!-- SITE ACTIONS -->

--- a/opengever/core/profiles/default/actions.xml
+++ b/opengever/core/profiles/default/actions.xml
@@ -118,6 +118,15 @@
       <property name="visible">True</property>
     </object>
 
+    <object name="open_as_pdf" meta_type="CMF Action" i18n:domain="opengever.document">
+      <property name="title" i18n:translate="label_open_document_as_pdf">Open as PDF</property>
+      <property name="available_expr">object/@@file_actions_availability/is_open_as_pdf_action_available</property>
+      <property name="permissions">
+        <element value="View" />
+      </property>
+      <property name="visible">True</property>
+    </object>
+
   </object>
 
   <!-- SITE ACTIONS -->

--- a/opengever/core/profiles/default/actions.xml
+++ b/opengever/core/profiles/default/actions.xml
@@ -28,8 +28,17 @@
     </object>
 
     <object name="officeconnector_checkout_url" meta_type="CMF Action" i18n:domain="opengever.core">
-      <property name="title" i18n:translate="">Checkout and edit with office connector</property>
+      <property name="title" i18n:translate="">Checkout and edit</property>
       <property name="available_expr">object/file_actions_availability/is_oc_direct_checkout_action_available</property>
+      <property name="permissions">
+        <element value="View" />
+      </property>
+      <property name="visible">True</property>
+    </object>
+
+    <object name="zem_checkout" meta_type="CMF Action" i18n:domain="opengever.core">
+      <property name="title" i18n:translate="">Checkout and edit</property>
+      <property name="available_expr">object/file_actions_availability/is_oc_zem_checkout_action_available</property>
       <property name="permissions">
         <element value="View" />
       </property>

--- a/opengever/core/profiles/default/actions.xml
+++ b/opengever/core/profiles/default/actions.xml
@@ -13,6 +13,10 @@
 
   </object>
 
+  <!-- FILE ACTIONS used to list available actions through the actions endpoint-->
+  <object name="file_actions" meta_type="CMF Action Category">
+
+  </object>
 
   <!-- SITE ACTIONS -->
   <object name="site_actions" meta_type="CMF Action Category">

--- a/opengever/core/upgrades/20190726084602_add_document_actions_for_api/actions.xml
+++ b/opengever/core/upgrades/20190726084602_add_document_actions_for_api/actions.xml
@@ -115,7 +115,7 @@
     </object>
 
     <object name="revert_to_version" meta_type="CMF Action" i18n:domain="opengever.document">
-      <property name="title" i18n:translate="label_revert">Revert document</property>
+      <property name="title" i18n:translate="label_revert_document">Revert document</property>
       <property name="available_expr">object/@@file_actions_availability/is_revert_to_version_action_available</property>
       <property name="permissions">
         <element value="View" />

--- a/opengever/core/upgrades/20190726084602_add_document_actions_for_api/actions.xml
+++ b/opengever/core/upgrades/20190726084602_add_document_actions_for_api/actions.xml
@@ -114,6 +114,15 @@
       <property name="visible">True</property>
     </object>
 
+    <object name="revert_to_version" meta_type="CMF Action" i18n:domain="opengever.document">
+      <property name="title" i18n:translate="label_revert">Revert document</property>
+      <property name="available_expr">object/@@file_actions_availability/is_revert_to_version_action_available</property>
+      <property name="permissions">
+        <element value="View" />
+      </property>
+      <property name="visible">True</property>
+    </object>
+
   </object>
 
 </object>

--- a/opengever/core/upgrades/20190726084602_add_document_actions_for_api/actions.xml
+++ b/opengever/core/upgrades/20190726084602_add_document_actions_for_api/actions.xml
@@ -1,0 +1,8 @@
+<object xmlns:i18n="http://xml.zope.org/namespaces/i18n" name="portal_actions" meta_type="Plone Actions Tool">
+
+  <!-- FILE ACTIONS used to list available actions through the actions endpoint-->
+  <object name="file_actions" meta_type="CMF Action Category">
+
+  </object>
+
+</object>

--- a/opengever/core/upgrades/20190726084602_add_document_actions_for_api/actions.xml
+++ b/opengever/core/upgrades/20190726084602_add_document_actions_for_api/actions.xml
@@ -32,6 +32,15 @@
       <property name="visible">True</property>
     </object>
 
+    <object name="simple_checkout" meta_type="CMF Action" i18n:domain="opengever.core">
+      <property name="title" i18n:translate="">Checkout</property>
+      <property name="available_expr">object/file_actions_availability/is_checkout_action_available</property>
+      <property name="permissions">
+        <element value="View" />
+      </property>
+      <property name="visible">True</property>
+    </object>
+
   </object>
 
 </object>

--- a/opengever/core/upgrades/20190726084602_add_document_actions_for_api/actions.xml
+++ b/opengever/core/upgrades/20190726084602_add_document_actions_for_api/actions.xml
@@ -14,6 +14,15 @@
       <property name="visible">True</property>
     </object>
 
+    <object name="officeconnector_checkout_url" meta_type="CMF Action" i18n:domain="opengever.core">
+      <property name="title" i18n:translate="">Checkout and edit with office connector</property>
+      <property name="available_expr">object/file_actions_availability/is_oc_direct_checkout_action_available</property>
+      <property name="permissions">
+        <element value="View" />
+      </property>
+      <property name="visible">True</property>
+    </object>
+
   </object>
 
 </object>

--- a/opengever/core/upgrades/20190726084602_add_document_actions_for_api/actions.xml
+++ b/opengever/core/upgrades/20190726084602_add_document_actions_for_api/actions.xml
@@ -15,8 +15,17 @@
     </object>
 
     <object name="officeconnector_checkout_url" meta_type="CMF Action" i18n:domain="opengever.core">
-      <property name="title" i18n:translate="">Checkout and edit with office connector</property>
+      <property name="title" i18n:translate="">Checkout and edit</property>
       <property name="available_expr">object/file_actions_availability/is_oc_direct_checkout_action_available</property>
+      <property name="permissions">
+        <element value="View" />
+      </property>
+      <property name="visible">True</property>
+    </object>
+
+    <object name="zem_checkout" meta_type="CMF Action" i18n:domain="opengever.core">
+      <property name="title" i18n:translate="">Checkout and edit</property>
+      <property name="available_expr">object/file_actions_availability/is_oc_zem_checkout_action_available</property>
       <property name="permissions">
         <element value="View" />
       </property>

--- a/opengever/core/upgrades/20190726084602_add_document_actions_for_api/actions.xml
+++ b/opengever/core/upgrades/20190726084602_add_document_actions_for_api/actions.xml
@@ -50,6 +50,15 @@
       <property name="visible">True</property>
     </object>
 
+    <object name="checkin_with_comment" meta_type="CMF Action" i18n:domain="opengever.core">
+      <property name="title" i18n:translate="">Checkin with comment</property>
+      <property name="available_expr">object/file_actions_availability/is_checkin_with_comment_available</property>
+      <property name="permissions">
+        <element value="View" />
+      </property>
+      <property name="visible">True</property>
+    </object>
+
   </object>
 
 </object>

--- a/opengever/core/upgrades/20190726084602_add_document_actions_for_api/actions.xml
+++ b/opengever/core/upgrades/20190726084602_add_document_actions_for_api/actions.xml
@@ -105,6 +105,15 @@
       <property name="visible">True</property>
     </object>
 
+    <object name="open_as_pdf" meta_type="CMF Action" i18n:domain="opengever.document">
+      <property name="title" i18n:translate="label_open_document_as_pdf">Open as PDF</property>
+      <property name="available_expr">object/@@file_actions_availability/is_open_as_pdf_action_available</property>
+      <property name="permissions">
+        <element value="View" />
+      </property>
+      <property name="visible">True</property>
+    </object>
+
   </object>
 
 </object>

--- a/opengever/core/upgrades/20190726084602_add_document_actions_for_api/actions.xml
+++ b/opengever/core/upgrades/20190726084602_add_document_actions_for_api/actions.xml
@@ -3,56 +3,102 @@
   <!-- FILE ACTIONS used to list available actions through the actions endpoint-->
   <object name="file_actions" meta_type="CMF Action Category">
 
-    <object name="download" meta_type="CMF Action" i18n:domain="opengever.core">
-      <property name="title" i18n:translate="">Download copy</property>
-      <property name="description" i18n:translate="" />
-      <property name="icon_expr" />
-      <property name="available_expr">python:object.restrictedTraverse('@@plone_interface_info').provides('opengever.document.behaviors.IBaseDocument') and object.restrictedTraverse('file_download_confirmation/download_available')</property>
+    <object name="oc_direct_checkout" meta_type="CMF Action" i18n:domain="opengever.document">
+      <property name="title" i18n:translate="label_checkout_and_edit">Checkout and edit</property>
+      <property name="available_expr">object/@@file_actions_availability/is_oc_direct_checkout_action_available</property>
       <property name="permissions">
         <element value="View" />
       </property>
       <property name="visible">True</property>
     </object>
 
-    <object name="officeconnector_checkout_url" meta_type="CMF Action" i18n:domain="opengever.core">
-      <property name="title" i18n:translate="">Checkout and edit</property>
-      <property name="available_expr">object/file_actions_availability/is_oc_direct_checkout_action_available</property>
+    <object name="oc_direct_edit" meta_type="CMF Action" i18n:domain="opengever.document">
+      <property name="title" i18n:translate="label_edit">Edit</property>
+      <property name="available_expr">object/@@file_actions_availability/is_oc_direct_edit_action_available</property>
       <property name="permissions">
         <element value="View" />
       </property>
       <property name="visible">True</property>
     </object>
 
-    <object name="zem_checkout" meta_type="CMF Action" i18n:domain="opengever.core">
-      <property name="title" i18n:translate="">Checkout and edit</property>
-      <property name="available_expr">object/file_actions_availability/is_oc_zem_checkout_action_available</property>
+    <object name="oc_zem_checkout" meta_type="CMF Action" i18n:domain="opengever.document">
+      <property name="title" i18n:translate="label_checkout_and_edit">Checkout and edit</property>
+      <property name="available_expr">object/@@file_actions_availability/is_oc_zem_checkout_action_available</property>
       <property name="permissions">
         <element value="View" />
       </property>
       <property name="visible">True</property>
     </object>
 
-    <object name="simple_checkout" meta_type="CMF Action" i18n:domain="opengever.core">
-      <property name="title" i18n:translate="">Checkout</property>
-      <property name="available_expr">object/file_actions_availability/is_checkout_action_available</property>
+    <object name="oc_zem_edit" meta_type="CMF Action" i18n:domain="opengever.document">
+      <property name="title" i18n:translate="label_edit">Edit</property>
+      <property name="available_expr">object/@@file_actions_availability/is_oc_zem_edit_action_available</property>
       <property name="permissions">
         <element value="View" />
       </property>
       <property name="visible">True</property>
     </object>
 
-    <object name="checkin_without_comment" meta_type="CMF Action" i18n:domain="opengever.core">
+    <object name="oc_unsupported_file_checkout" meta_type="CMF Action" i18n:domain="opengever.document">
+      <property name="title" i18n:translate="label_checkout">Checkout</property>
+      <property name="available_expr">object/@@file_actions_availability/is_oc_unsupported_file_checkout_action_available</property>
+      <property name="permissions">
+        <element value="View" />
+      </property>
+      <property name="visible">True</property>
+    </object>
+
+    <object name="checkin_without_comment" meta_type="CMF Action" i18n:domain="opengever.document">
       <property name="title" i18n:translate="">Checkin without comment</property>
-      <property name="available_expr">object/file_actions_availability/is_checkin_without_comment_available</property>
+      <property name="available_expr">object/@@file_actions_availability/is_checkin_without_comment_available</property>
       <property name="permissions">
         <element value="View" />
       </property>
       <property name="visible">True</property>
     </object>
 
-    <object name="checkin_with_comment" meta_type="CMF Action" i18n:domain="opengever.core">
+    <object name="checkin_with_comment" meta_type="CMF Action" i18n:domain="opengever.document">
       <property name="title" i18n:translate="">Checkin with comment</property>
-      <property name="available_expr">object/file_actions_availability/is_checkin_with_comment_available</property>
+      <property name="available_expr">object/@@file_actions_availability/is_checkin_with_comment_available</property>
+      <property name="permissions">
+        <element value="View" />
+      </property>
+      <property name="visible">True</property>
+    </object>
+
+    <object name="cancel_checkout" meta_type="CMF Action" i18n:domain="opengever.document">
+      <property name="title" i18n:translate="">Cancel checkout</property>
+      <property name="available_expr">object/@@file_actions_availability/is_cancel_checkout_action_available</property>
+      <property name="permissions">
+        <element value="View" />
+      </property>
+      <property name="visible">True</property>
+    </object>
+
+    <object name="download_copy" meta_type="CMF Action" i18n:domain="opengever.document">
+      <property name="title" i18n:translate="">Download copy</property>
+      <property name="description" i18n:translate="label_download_copy" />
+      <property name="available_expr">object/@@file_actions_availability/is_download_copy_action_available</property>
+      <property name="permissions">
+        <element value="View" />
+      </property>
+      <property name="visible">True</property>
+    </object>
+
+    <object name="attach_to_email" meta_type="CMF Action" i18n:domain="opengever.document">
+      <property name="title" i18n:translate="">Attach to email</property>
+      <property name="description" i18n:translate="label_attach_to_email" />
+      <property name="available_expr">object/@@file_actions_availability/is_attach_to_email_action_available</property>
+      <property name="permissions">
+        <element value="View" />
+      </property>
+      <property name="visible">True</property>
+    </object>
+
+    <object name="oneoffixx_retry" meta_type="CMF Action" i18n:domain="opengever.document">
+      <property name="title" i18n:translate="">Oneoffixx retry</property>
+      <property name="description" i18n:translate="label_retry_oneoffixx" />
+      <property name="available_expr">object/@@file_actions_availability/is_oneoffixx_retry_action_available</property>
       <property name="permissions">
         <element value="View" />
       </property>

--- a/opengever/core/upgrades/20190726084602_add_document_actions_for_api/actions.xml
+++ b/opengever/core/upgrades/20190726084602_add_document_actions_for_api/actions.xml
@@ -41,6 +41,15 @@
       <property name="visible">True</property>
     </object>
 
+    <object name="checkin_without_comment" meta_type="CMF Action" i18n:domain="opengever.core">
+      <property name="title" i18n:translate="">Checkin without comment</property>
+      <property name="available_expr">object/file_actions_availability/is_checkin_without_comment_available</property>
+      <property name="permissions">
+        <element value="View" />
+      </property>
+      <property name="visible">True</property>
+    </object>
+
   </object>
 
 </object>

--- a/opengever/core/upgrades/20190726084602_add_document_actions_for_api/actions.xml
+++ b/opengever/core/upgrades/20190726084602_add_document_actions_for_api/actions.xml
@@ -3,6 +3,17 @@
   <!-- FILE ACTIONS used to list available actions through the actions endpoint-->
   <object name="file_actions" meta_type="CMF Action Category">
 
+    <object name="download" meta_type="CMF Action" i18n:domain="opengever.core">
+      <property name="title" i18n:translate="">Download copy</property>
+      <property name="description" i18n:translate="" />
+      <property name="icon_expr" />
+      <property name="available_expr">python:object.restrictedTraverse('@@plone_interface_info').provides('opengever.document.behaviors.IBaseDocument') and object.restrictedTraverse('file_download_confirmation/download_available')</property>
+      <property name="permissions">
+        <element value="View" />
+      </property>
+      <property name="visible">True</property>
+    </object>
+
   </object>
 
 </object>

--- a/opengever/core/upgrades/20190726084602_add_document_actions_for_api/upgrade.py
+++ b/opengever/core/upgrades/20190726084602_add_document_actions_for_api/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddDocumentActionsForAPI(UpgradeStep):
+    """Add document actions for api.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/document/base.py
+++ b/opengever/document/base.py
@@ -167,7 +167,7 @@ class BaseDocumentMixin(object):
         """
         mtr = getToolByName(self, 'mimetypes_registry', None)
 
-        field = self.file
+        field = self.get_file()
         if not field or not field.getSize():
             # there is no file
             return False

--- a/opengever/document/base.py
+++ b/opengever/document/base.py
@@ -189,6 +189,12 @@ class BaseDocumentMixin(object):
     def is_shadow_document(self):
         return False
 
+    def is_checkin_allowed(self):
+        return False
+
+    def is_locked(self):
+        return False
+
 
 def mimetype_lookup(mtr, contenttype):
     """Reimplemented as case insensitive from Products.MimetypesRegistry."""

--- a/opengever/document/browser/actionbuttons.py
+++ b/opengever/document/browser/actionbuttons.py
@@ -31,6 +31,9 @@ class FileActionAvailabilityChecker(object):
     def is_versioned(self):
         return self.request.get('version_id') is not None
 
+    def is_checked_out(self):
+        return self.context.is_checked_out()
+
     def is_checkout_and_edit_available(self):
         """Check whether the current user is allowed to checkout the document
         """
@@ -59,6 +62,15 @@ class FileActionAvailabilityChecker(object):
                 self.is_checkout_and_edit_available() and
                 self.is_office_connector_editable() and
                 not is_officeconnector_checkout_feature_enabled())
+
+    def is_checkout_action_available(self):
+        """Check whether simple checkout action is available
+        """
+        return (self.is_document() and
+                self.has_file() and
+                self.is_checkout_and_edit_available() and
+                not self.is_office_connector_editable() and
+                not self.is_checked_out())
 
 
 class FileActionAvailabilityCheckerView(BrowserView, FileActionAvailabilityChecker):
@@ -154,9 +166,6 @@ class ActionButtonRendererMixin(FileActionAvailabilityChecker):
             return True
 
         return not self.is_checked_out_by_another_user()
-
-    def is_checked_out(self):
-        return self.context.is_checked_out()
 
     def is_checked_out_by_another_user(self):
         manager = queryMultiAdapter(

--- a/opengever/document/browser/actionbuttons.py
+++ b/opengever/document/browser/actionbuttons.py
@@ -222,7 +222,7 @@ class ActionButtonRendererMixin(FileActionAvailabilityChecker):
         return self._get_checkin_url(with_comment=True)
 
     def _get_checkin_url(self, with_comment=False):
-        if not self._is_checkin_allowed():
+        if not self.is_checkin_allowed():
             return None
 
         if with_comment:

--- a/opengever/document/browser/actionbuttons.py
+++ b/opengever/document/browser/actionbuttons.py
@@ -85,10 +85,13 @@ class FileActionAvailabilityChecker(object):
                 not self.is_office_connector_editable() and
                 not self.is_checked_out())
 
-    def is_checkin_without_comment_available(self):
+    def is_checkin_with_comment_available(self):
         return (self.is_document() and
                 self.has_file() and
-                self.is_checkin_allowed() and
+                self.is_checkin_allowed())
+
+    def is_checkin_without_comment_available(self):
+        return (self.is_checkin_with_comment_available() and
                 not self.is_locked())
 
 

--- a/opengever/document/browser/actionbuttons.py
+++ b/opengever/document/browser/actionbuttons.py
@@ -1,28 +1,21 @@
-from opengever.document import _
-from opengever.document.behaviors import IBaseDocument
 from opengever.document.browser.download import DownloadConfirmationHelper
-from opengever.document.document import IDocumentSchema
-from opengever.document.interfaces import ICheckinCheckoutManager
-from opengever.officeconnector.helpers import is_officeconnector_attach_feature_enabled  # noqa
-from opengever.officeconnector.helpers import is_officeconnector_checkout_feature_enabled
+from opengever.document.interfaces import IFileActions
 from opengever.webactions.interfaces import IWebActionsRenderer
-from plone import api
-from plone.locking.interfaces import IRefreshableLockable
 from plone.protect import createToken
 from Products.Five.browser import BrowserView
 from zope.component import getMultiAdapter
-from zope.component import queryMultiAdapter
-from zope.i18n import translate
 
 
 class FileActionAvailabilityChecker(object):
     """Mixin containing the methods to check whether certain
     actions should be available on a document.
     """
+    @property
+    def ifileactions(self):
+        return getMultiAdapter((self.context, self.request), IFileActions)
 
-    def is_document(self):
-        """Check that the current context is a document or an E-mail"""
-        return IBaseDocument.providedBy(self.context)
+    def is_edit_metadata_action_available(self):
+        return self.ifileactions.is_edit_metadata_action_available()
 
     def has_file(self):
         """Check whether the context has a file"""
@@ -34,65 +27,41 @@ class FileActionAvailabilityChecker(object):
     def is_checked_out(self):
         return self.context.is_checked_out()
 
-    def is_checkout_and_edit_available(self):
-        """Check whether the current user is allowed to checkout the document
-        """
-        if self.is_versioned():
-            return False
-        return self.context.is_checkout_and_edit_available()
+    def is_any_checkout_or_edit_available(self):
+        return self.ifileactions.is_any_checkout_or_edit_available()
 
-    def is_office_connector_editable(self):
-        """Check whether the filetype is supported by office connector"""
-        return self.context.is_office_connector_editable()
-
-    def is_checkin_allowed(self):
-        manager = queryMultiAdapter(
-            (self.context, self.request), ICheckinCheckoutManager)
-
-        if not manager:
-            # This is probably a mail
-            return False
-
-        return manager.is_checkin_allowed()
-
-    def is_locked(self):
-        return IRefreshableLockable(self.context).locked()
+    def is_oc_direct_edit_action_available(self):
+        return self.ifileactions.is_oc_direct_edit_action_available()
 
     def is_oc_direct_checkout_action_available(self):
-        """Check whether the new office connector checkout action is available
-        """
-        return (self.is_document() and
-                self.has_file() and
-                self.is_checkout_and_edit_available() and
-                self.is_office_connector_editable() and
-                is_officeconnector_checkout_feature_enabled())
+        return self.ifileactions.is_oc_direct_checkout_action_available()
 
     def is_oc_zem_checkout_action_available(self):
-        """Check whether the old style zem office connector checkout action
-        is available"""
-        return (self.is_document() and
-                self.has_file() and
-                self.is_checkout_and_edit_available() and
-                self.is_office_connector_editable() and
-                not is_officeconnector_checkout_feature_enabled())
+        return self.ifileactions.is_oc_zem_checkout_action_available()
 
-    def is_checkout_action_available(self):
-        """Check whether simple checkout action is available
-        """
-        return (self.is_document() and
-                self.has_file() and
-                self.is_checkout_and_edit_available() and
-                not self.is_office_connector_editable() and
-                not self.is_checked_out())
+    def is_oc_zem_edit_action_available(self):
+        return self.ifileactions.is_oc_zem_edit_action_available()
 
-    def is_checkin_with_comment_available(self):
-        return (self.is_document() and
-                self.has_file() and
-                self.is_checkin_allowed())
+    def is_oc_unsupported_file_checkout_action_available(self):
+        return self.ifileactions.is_oc_unsupported_file_checkout_action_available()
 
     def is_checkin_without_comment_available(self):
-        return (self.is_checkin_with_comment_available() and
-                not self.is_locked())
+        return self.ifileactions.is_checkin_without_comment_available()
+
+    def is_checkin_with_comment_available(self):
+        return self.ifileactions.is_checkin_with_comment_available()
+
+    def is_cancel_checkout_action_available(self):
+        return self.ifileactions.is_cancel_checkout_action_available()
+
+    def is_download_copy_action_available(self):
+        return self.ifileactions.is_download_copy_action_available()
+
+    def is_attach_to_email_action_available(self):
+        return self.ifileactions.is_attach_to_email_action_available()
+
+    def is_oneoffixx_retry_action_available(self):
+        return self.ifileactions.is_oneoffixx_retry_action_available()
 
 
 class FileActionAvailabilityCheckerView(BrowserView, FileActionAvailabilityChecker):
@@ -107,6 +76,11 @@ class ActionButtonRendererMixin(FileActionAvailabilityChecker):
     is_on_detail_view = False
     overlay = None
 
+    def is_oc_unsupported_file_edit_action_available(self):
+        return (self.ifileactions.is_any_checkout_or_edit_available()
+                and not self.context.is_office_connector_editable()
+                and self.context.is_checked_out())
+
     def is_edit_metadata_link_visible(self):
         if self.is_overview_tab:
             return False
@@ -116,32 +90,10 @@ class ActionButtonRendererMixin(FileActionAvailabilityChecker):
 
         return True
 
-    def is_edit_metadata_available(self):
-        # XXX object orient me, the object should know some of this stuff
-        if self.is_checked_out_by_another_user():
-            return False
+    def is_detail_view_link_available(self):
+        return not self.is_on_detail_view
 
-        if self.is_locked():
-            return False
-
-        return api.user.has_permission(
-            'Modify portal content',
-            obj=self.context,
-            )
-
-    def is_download_copy_available(self):
-        """Disable downloading copies when the document is checked out by an
-        another user.
-        """
-        manager = queryMultiAdapter(
-            (self.context, self.request), ICheckinCheckoutManager)
-        if manager is None:
-            # This is probably a mail
-            return True
-
-        return not self.is_checked_out_by_another_user()
-
-    def get_download_copy_tag(self):
+    def render_download_copy_link(self):
         """Returns the DownloadConfirmationHelper tag containing
         the donwload link. For mails, containing an original_message, the tag
         links to the orginal message download view.
@@ -168,63 +120,17 @@ class ActionButtonRendererMixin(FileActionAvailabilityChecker):
 
         return dc_helper.get_html_tag(**kwargs)
 
-    def is_document(self):
-        return IDocumentSchema.providedBy(self.context)
-
-    def is_oneoffixx_creatable(self):
-        return self.is_document() and self.context.is_oneoffixx_creatable()
-
-    def is_attach_to_email_available(self):
-        if not is_officeconnector_attach_feature_enabled():
-            return False
-
-        manager = queryMultiAdapter(
-            (self.context, self.request), ICheckinCheckoutManager)
-        if manager is None:
-            # This is probably a mail
-            return True
-
-        return not self.is_checked_out_by_another_user()
-
-    def is_checked_out_by_another_user(self):
-        manager = queryMultiAdapter(
-            (self.context, self.request), ICheckinCheckoutManager)
-
-        if not manager:
-            return False
-
-        checked_out_by = manager.get_checked_out_by()
-        if not checked_out_by:
-            return False
-
-        return checked_out_by != api.user.get_current().getId()
-
-    def is_checked_out_by_current_user(self):
-        manager = queryMultiAdapter(
-            (self.context, self.request), ICheckinCheckoutManager)
-        if manager is None:
-            # This is probably a mail
-            return False
-
-        return manager.is_checked_out_by_current_user()
-
-    def is_detail_view_link_available(self):
-        return not self.is_on_detail_view
-
     def get_checkin_without_comment_url(self):
-        if not self.has_file():
+        if not self.is_checkin_without_comment_available():
             return None
         return self._get_checkin_url(with_comment=False)
 
     def get_checkin_with_comment_url(self):
-        if not self.has_file():
+        if not self.is_checkin_with_comment_available():
             return None
         return self._get_checkin_url(with_comment=True)
 
     def _get_checkin_url(self, with_comment=False):
-        if not self.is_checkin_allowed():
-            return None
-
         if with_comment:
             checkin_view = u'@@checkin_document'
         else:
@@ -235,35 +141,12 @@ class ActionButtonRendererMixin(FileActionAvailabilityChecker):
             checkin_view,
             createToken())
 
-    def is_checkout_cancel_available(self):
-        manager = queryMultiAdapter(
-            (self.context, self.request), ICheckinCheckoutManager)
-
-        if not manager:
-            return False
-
-        return manager.is_cancel_allowed()
-
-    def get_checkout_cancel_tag(self):
-        if not self.has_file() or not self.is_checkout_cancel_available():
-            return None
-        clazz = 'link-overlay modal function-revert'
-        url = u'{}/@@cancel_document_checkout_confirmation'.format(
+    def get_cancel_checkout_url(self):
+        return u'{}/@@cancel_document_checkout_confirmation'.format(
             self.context.absolute_url())
-        label = translate(_(u'Cancel checkout'),
-                          context=self.request).encode('utf-8')
-        return ('<a href="{0}" '
-                'id="action-cancel-checkout" '
-                'class="{1}">{2}</a>').format(url, clazz, label)
-
-    def has_file(self):
-        return self.context.has_file()
 
     def get_file(self):
         return self.context.get_file()
-
-    def get_url(self):
-        return self.context.absolute_url()
 
     def get_webaction_items(self):
         renderer = getMultiAdapter((self.context, self.request),

--- a/opengever/document/browser/actionbuttons.py
+++ b/opengever/document/browser/actionbuttons.py
@@ -25,7 +25,7 @@ class FileActionAvailabilityCheckerView(BrowserView, FileActionAvailabilityCheck
     """
 
 
-class ActionButtonRendererMixin(object):
+class ActionButtonRendererMixin(FileActionAvailabilityChecker):
     """Mixin for views that render action buttons."""
 
     is_overview_tab = False

--- a/opengever/document/browser/actionbuttons.py
+++ b/opengever/document/browser/actionbuttons.py
@@ -5,6 +5,7 @@ from opengever.officeconnector.helpers import is_officeconnector_attach_feature_
 from opengever.webactions.interfaces import IWebActionsRenderer
 from plone import api
 from plone.protect import createToken
+from plone.protect.utils import addTokenToUrl
 from Products.Five.browser import BrowserView
 from urllib import quote
 from zope.component import getMultiAdapter
@@ -90,8 +91,6 @@ class VisibleActionButtonRendererMixin(FileActionAvailabilityMixin):
     to make an available action invisible however.
 
     """
-    overlay = None
-
     def is_oc_unsupported_file_discreet_edit_visible(self):
         return (self.ifileactions.is_any_checkout_or_edit_available()
                 and not self.context.is_office_connector_editable()
@@ -216,6 +215,12 @@ class VisibleActionButtonRendererMixin(FileActionAvailabilityMixin):
 
     def get_file(self):
         return self.context.get_file()
+
+    def get_revert_to_version_url(self):
+        url = u'{}/revert-file-to-version?version_id={}'.format(
+            self.context.absolute_url(),
+            self.request.get('version_id'))
+        return addTokenToUrl(url)
 
     def get_webaction_items(self):
         renderer = getMultiAdapter((self.context, self.request),

--- a/opengever/document/browser/actionbuttons.py
+++ b/opengever/document/browser/actionbuttons.py
@@ -1,4 +1,5 @@
 from opengever.document import _
+from opengever.document.behaviors import IBaseDocument
 from opengever.document.browser.download import DownloadConfirmationHelper
 from opengever.document.document import IDocumentSchema
 from opengever.document.interfaces import ICheckinCheckoutManager
@@ -7,9 +8,21 @@ from opengever.webactions.interfaces import IWebActionsRenderer
 from plone import api
 from plone.locking.interfaces import IRefreshableLockable
 from plone.protect import createToken
+from Products.Five.browser import BrowserView
 from zope.component import getMultiAdapter
 from zope.component import queryMultiAdapter
 from zope.i18n import translate
+
+
+class FileActionAvailabilityChecker(object):
+    """Mixin containing the methods to check whether certain
+    actions should be available on a document.
+    """
+
+
+class FileActionAvailabilityCheckerView(BrowserView, FileActionAvailabilityChecker):
+    """View used to check the availability of file actions
+    """
 
 
 class ActionButtonRendererMixin(object):
@@ -208,3 +221,4 @@ class ActionButtonRendererMixin(object):
         renderer = getMultiAdapter((self.context, self.request),
                                    IWebActionsRenderer, name='action-buttons')
         return renderer()
+

--- a/opengever/document/browser/actionbuttons.py
+++ b/opengever/document/browser/actionbuttons.py
@@ -73,6 +73,9 @@ class FileActionAvailabilityMixin(object):
     def is_open_as_pdf_action_available(self):
         return self.ifileactions.is_open_as_pdf_action_available()
 
+    def is_revert_to_version_action_available(self):
+        return self.ifileactions.is_revert_to_version_action_available()
+
 
 class FileActionAvailabilityView(BrowserView, FileActionAvailabilityMixin):
     """View that exposes file action availaibility."""

--- a/opengever/document/browser/actionbuttons.py
+++ b/opengever/document/browser/actionbuttons.py
@@ -90,6 +90,9 @@ class VisibleActionButtonRendererMixin(FileActionAvailabilityMixin):
     to make an available action invisible however.
 
     """
+    def get_edit_metadata_url(self):
+        return u'{}/edit_checker'.format(self.context.absolute_url())
+
     def is_oc_unsupported_file_discreet_edit_visible(self):
         return (self.ifileactions.is_any_checkout_or_edit_available()
                 and not self.context.is_office_connector_editable()

--- a/opengever/document/browser/actionbuttons.py
+++ b/opengever/document/browser/actionbuttons.py
@@ -24,16 +24,6 @@ class FileActionAvailabilityMixin(object):
     def is_edit_metadata_action_available(self):
         return self.ifileactions.is_edit_metadata_action_available()
 
-    def has_file(self):
-        """Check whether the context has a file"""
-        return self.context.has_file()
-
-    def is_versioned(self):
-        return self.request.get('version_id') is not None
-
-    def is_checked_out(self):
-        return self.context.is_checked_out()
-
     def is_any_checkout_or_edit_available(self):
         return self.ifileactions.is_any_checkout_or_edit_available()
 
@@ -210,9 +200,6 @@ class VisibleActionButtonRendererMixin(FileActionAvailabilityMixin):
     def get_cancel_checkout_url(self):
         return u'{}/@@cancel_document_checkout_confirmation'.format(
             self.context.absolute_url())
-
-    def get_file(self):
-        return self.context.get_file()
 
     def get_revert_to_version_url(self):
         url = u'{}/revert-file-to-version?version_id={}'.format(

--- a/opengever/document/browser/actionbuttons.py
+++ b/opengever/document/browser/actionbuttons.py
@@ -51,6 +51,15 @@ class FileActionAvailabilityChecker(object):
                 self.is_office_connector_editable() and
                 is_officeconnector_checkout_feature_enabled())
 
+    def is_oc_zem_checkout_action_available(self):
+        """Check whether the old style zem office connector checkout action
+        is available"""
+        return (self.is_document() and
+                self.has_file() and
+                self.is_checkout_and_edit_available() and
+                self.is_office_connector_editable() and
+                not is_officeconnector_checkout_feature_enabled())
+
 
 class FileActionAvailabilityCheckerView(BrowserView, FileActionAvailabilityChecker):
     """View used to check the availability of file actions

--- a/opengever/document/browser/actionbuttons.py
+++ b/opengever/document/browser/actionbuttons.py
@@ -66,6 +66,9 @@ class FileActionAvailabilityMixin(object):
     def is_oneoffixx_retry_action_available(self):
         return self.ifileactions.is_oneoffixx_retry_action_available()
 
+    def is_open_as_pdf_action_available(self):
+        return self.ifileactions.is_open_as_pdf_action_available()
+
 
 class FileActionAvailabilityView(BrowserView, FileActionAvailabilityMixin):
     """View that exposes file action availaibility."""

--- a/opengever/document/browser/actionbuttons.py
+++ b/opengever/document/browser/actionbuttons.py
@@ -4,7 +4,6 @@ from opengever.document.interfaces import IFileActions
 from opengever.officeconnector.helpers import is_officeconnector_attach_feature_enabled  # noqa
 from opengever.webactions.interfaces import IWebActionsRenderer
 from plone import api
-from plone.protect import createToken
 from plone.protect.utils import addTokenToUrl
 from Products.Five.browser import BrowserView
 from urllib import quote
@@ -135,14 +134,12 @@ class VisibleActionButtonRendererMixin(FileActionAvailabilityMixin):
             ");".format(self.context.absolute_url()))
 
     def get_oc_zem_checkout_url(self):
-        return u'{}/editing_document?_authenticator={}'.format(
-            self.context.absolute_url(),
-            createToken())
+        url = u'{}/editing_document'.format(self.context.absolute_url())
+        return addTokenToUrl(url)
 
     def get_checkout_url(self):
-        return "{}/@@checkout_documents?_authenticator={}".format(
-            self.context.absolute_url(),
-            createToken())
+        url = "{}/@@checkout_documents".format(self.context.absolute_url())
+        return addTokenToUrl(url)
 
     def get_open_as_pdf_url(self):
         if not self.is_open_as_pdf_action_available():
@@ -204,10 +201,8 @@ class VisibleActionButtonRendererMixin(FileActionAvailabilityMixin):
         else:
             checkin_view = u'@@checkin_without_comment'
 
-        return u"{}/{}?_authenticator={}".format(
-            self.context.absolute_url(),
-            checkin_view,
-            createToken())
+        url = u"{}/{}".format(self.context.absolute_url(), checkin_view)
+        return addTokenToUrl(url)
 
     def get_cancel_checkout_url(self):
         return u'{}/@@cancel_document_checkout_confirmation'.format(

--- a/opengever/document/browser/actionbuttons.py
+++ b/opengever/document/browser/actionbuttons.py
@@ -80,8 +80,6 @@ class VisibleActionButtonRendererMixin(FileActionAvailabilityMixin):
     to make an available action invisible however.
 
     """
-    is_overview_tab = False
-    is_on_detail_view = False
     overlay = None
 
     def is_oc_unsupported_file_discreet_edit_visible(self):
@@ -93,13 +91,13 @@ class VisibleActionButtonRendererMixin(FileActionAvailabilityMixin):
         return not self.context.has_file()
 
     def is_edit_metadata_action_visible(self):
-        if self.is_overview_tab:
-            return False
-
         return self.is_edit_metadata_action_available()
 
+    def is_discreet_edit_metadata_action_visible(self):
+        return not self.is_edit_metadata_action_visible()
+
     def is_detail_view_link_visible(self):
-        return not self.is_on_detail_view
+        return False
 
     def is_attach_to_email_action_set_visible(self):
         """Only show the actions if the feature is enabled."""

--- a/opengever/document/browser/configure.zcml
+++ b/opengever/document/browser/configure.zcml
@@ -14,10 +14,10 @@
 
   <browser:page
       name="file_download_confirmation"
-      for="opengever.document.document.IDocumentSchema"
+      for="opengever.document.behaviors.IBaseDocument"
       class=".download.DownloadConfirmation"
-      template="templates/downloadconfirmation.pt"
       permission="zope2.View"
+      allowed_attributes="download_available"
       />
 
   <browser:page

--- a/opengever/document/browser/configure.zcml
+++ b/opengever/document/browser/configure.zcml
@@ -133,4 +133,11 @@
       class=".report.DocumentReporter"
       permission="zope2.View"
       />
+
+  <browser:page
+      for="*"
+      name="file_actions_availability"
+      class=".actionbuttons.FileActionAvailabilityCheckerView"
+      permission="zope2.View"
+      />
 </configure>

--- a/opengever/document/browser/configure.zcml
+++ b/opengever/document/browser/configure.zcml
@@ -137,7 +137,7 @@
   <browser:page
       for="*"
       name="file_actions_availability"
-      class=".actionbuttons.FileActionAvailabilityCheckerView"
+      class=".actionbuttons.FileActionAvailabilityView"
       permission="zope2.View"
       />
 </configure>

--- a/opengever/document/browser/download.py
+++ b/opengever/document/browser/download.py
@@ -13,6 +13,7 @@ from plone.namedfile.utils import stream_data
 from plone.protect.utils import addTokenToUrl
 from Products.CMFCore.utils import getToolByName
 from Products.Five import BrowserView
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from zope.component import queryUtility
 from zope.component.hooks import getSite
 from zope.event import notify
@@ -63,6 +64,11 @@ class DocumentishDownload(Download):
 class DownloadConfirmation(BrowserView):
     """Download Confirmation View, allways displayed in a overlay."""
 
+    template = ViewPageTemplateFile('templates/downloadconfirmation.pt')
+
+    def __call__(self):
+        return self.template()
+
     def download_url(self):
         if self.request.get('version_id'):
             return '%s/download_file_version?version_id=%s' % (
@@ -72,6 +78,8 @@ class DownloadConfirmation(BrowserView):
             return '%s/download' % (self.context.absolute_url())
 
     def download_available(self):
+        """ check whether download is available.
+        """
         return self.context.file is not None
 
     def msg_no_file_available(self):

--- a/opengever/document/browser/overview.py
+++ b/opengever/document/browser/overview.py
@@ -139,10 +139,6 @@ class TemplateRow(CustomRow):
 class Overview(DefaultView, GeverTabMixin, VisibleActionButtonRendererMixin):
     """File details overview.
     """
-
-    is_on_detail_view = True
-    is_overview_tab = True
-
     show_searchform = False
 
     file_template = ViewPageTemplateFile('templates/file.pt')
@@ -152,6 +148,15 @@ class Overview(DefaultView, GeverTabMixin, VisibleActionButtonRendererMixin):
     archival_file_template = ViewPageTemplateFile('templates/archiv_file.pt')
     public_trial_template = ViewPageTemplateFile('templates/public_trial.pt')
     submitted_with_template = ViewPageTemplateFile('templates/submitted_with.pt')  # noqa
+
+    def is_edit_metadata_action_visible(self):
+        return False
+
+    def is_discreet_edit_metadata_action_visible(self):
+        return False
+
+    def is_detail_view_link_visible(self):
+        return False
 
     def get_metadata_config(self):
         rows = [

--- a/opengever/document/browser/overview.py
+++ b/opengever/document/browser/overview.py
@@ -11,7 +11,7 @@ from opengever.document import _
 from opengever.document.archival_file import ARCHIVAL_FILE_STATE_MAPPING
 from opengever.document.behaviors.metadata import IDocumentMetadata
 from opengever.document.browser import archival_file_form
-from opengever.document.browser.actionbuttons import ActionButtonRendererMixin
+from opengever.document.browser.actionbuttons import VisibleActionButtonRendererMixin
 from opengever.document.interfaces import ICheckinCheckoutManager
 from opengever.dossier.base import DOSSIER_STATES_CLOSED
 from opengever.meeting import is_meeting_feature_enabled
@@ -136,7 +136,7 @@ class TemplateRow(CustomRow):
         return self.renderer(self.view)
 
 
-class Overview(DefaultView, GeverTabMixin, ActionButtonRendererMixin):
+class Overview(DefaultView, GeverTabMixin, VisibleActionButtonRendererMixin):
     """File details overview.
     """
 

--- a/opengever/document/browser/templates/macros.pt
+++ b/opengever/document/browser/templates/macros.pt
@@ -150,13 +150,13 @@
           </a>
       </tal:open_as_pdf>
 
-      <tal:overlay tal:condition="view/overlay">
-          <tal:revert
-              tal:define="link view/overlay/get_revert_link"
-              tal:condition="nocall: link"
-              tal:content="structure link">
-          </tal:revert>
-      </tal:overlay>
+      <tal:revert_to_version tal:condition="view/is_revert_to_version_action_available">
+          <a class="standalone function-revert"
+              tal:attributes="href view/get_revert_to_version_url"
+              i18n:translate="label_revert">
+              Revert document
+          </a>
+      </tal:revert_to_version>
 
       <tal:details_view  tal:condition="view/is_detail_view_link_visible">
           <a class="function-view-details"

--- a/opengever/document/browser/templates/macros.pt
+++ b/opengever/document/browser/templates/macros.pt
@@ -28,7 +28,7 @@
             office_connector_editable view/is_office_connector_editable;
             copy_download_available view/is_download_copy_available;
             attach_to_email_available view/is_attach_to_email_available;
-            is_checkin_allowed view/_is_checkin_allowed;
+            is_checkin_allowed view/is_checkin_allowed;
             is_cancel_allowed view/is_checkout_cancel_available;
             new_external_edit_enabled context/@@officeconnector_settings/is_checkout_enabled">
 

--- a/opengever/document/browser/templates/macros.pt
+++ b/opengever/document/browser/templates/macros.pt
@@ -3,10 +3,10 @@
     <div class="file-action-buttons">
 
         <tal:edit_metadata_link tal:condition="view/is_edit_metadata_link_visible"
-                tal:define="edit_metadata_available view/is_edit_metadata_available">
+                tal:define="edit_metadata_available view/is_edit_metadata_action_available">
             <tal:edit_metadata tal:condition="edit_metadata_available">
                 <a class="function-edit-metadata"
-                    tal:attributes="href string:${view/get_url}/edit_checker"
+                    tal:attributes="href string:${context/absolute_url}/edit_checker"
                     i18n:domain="plone"
                     i18n:translate="">
                     Edit metadata
@@ -22,171 +22,157 @@
             </tal:not_edit_metadata>
         </tal:edit_metadata_link>
 
-        <tal:file tal:condition="context/has_file"
-            tal:define="checked_out view/is_checked_out;
-            checkout_and_edit_available view/is_checkout_and_edit_available;
-            office_connector_editable view/is_office_connector_editable;
-            copy_download_available view/is_download_copy_available;
-            attach_to_email_available view/is_attach_to_email_available;
-            is_checkin_allowed view/is_checkin_allowed;
-            is_cancel_allowed view/is_checkout_cancel_available;
-            new_external_edit_enabled context/@@officeconnector_settings/is_checkout_enabled">
-
-            <tal:checkout_and_edit_enabled tal:condition="checkout_and_edit_available">
-                <tal:oc_editable tal:condition="office_connector_editable">
-                    <tal:oc_checkout tal:condition="new_external_edit_enabled">
-                        <tal:checkedout tal:condition="checked_out">
-                            <a tal:attributes="href string:javascript:officeConnectorCheckout('${context/absolute_url}/officeconnector_checkout_url');;;
-                                               data-document-url context/absolute_url"
-                                class="function-edit oc-checkout"
-                                href="#"
-                                i18n:translate="label_edit">
-                                Edit
-                            </a>
-                        </tal:checkedout>
-                        <tal:notcheckedout tal:condition="not: checked_out">
-                            <a tal:attributes="href string:javascript:officeConnectorCheckout('${context/absolute_url}/officeconnector_checkout_url');;;
-                                               data-document-url context/absolute_url"
-                                class="function-edit oc-checkout"
-                                href="#"
-                                i18n:translate="label_checkout_and_edit">
-                                Checkout and edit
-                            </a>
-                        </tal:notcheckedout>
-                    </tal:oc_checkout>
-
-                    <tal:zem_checkout tal:condition="not: new_external_edit_enabled">
-                        <tal:checkedout tal:condition="checked_out">
-                            <a tal:attributes="href string:${context/absolute_url}/editing_document?_authenticator=${context/@@authenticator/token}"
-                                class="function-edit"
-                                href="#"
-                                i18n:translate="label_edit">
-                                Edit
-                            </a>
-                        </tal:checkedout>
-                        <tal:notcheckedout tal:condition="not: checked_out">
-                            <a tal:attributes="href string:${context/absolute_url}/editing_document?_authenticator=${context/@@authenticator/token}"
-                                class="function-edit"
-                                href="#"
-                                i18n:translate="label_checkout_and_edit">
-                                Checkout and edit
-                            </a>
-                        </tal:notcheckedout>
-                    </tal:zem_checkout>
-                </tal:oc_editable>
-
-                <tal:oc_uneditable tal:condition="not: office_connector_editable">
-                    <tal:checkedout tal:condition="checked_out">
-                        <span class="fa-exclamation-triangle-after function-edit-inactive discreet" title="Office connector unsupported type" value="Edit"
-                        i18n:attributes="title oc_unsupported_message" i18n:translate="label_edit">
-                            Edit
-                        </span>
-                    </tal:checkedout>
-                    <tal:notcheckedout tal:condition="not: checked_out">
-                        <span class="fa-exclamation-triangle-after function-edit-inactive discreet" title="Office connector unsupported type" value="Checkout and edit"
-                        i18n:attributes="title oc_unsupported_message" i18n:translate="label_checkout_and_edit">
-                            Checkout and edit
-                        </span>
-                        <a tal:attributes="href string:${context/absolute_url}/@@checkout_documents?_authenticator=${context/@@authenticator/token}"
-                            class="function-edit"
-                            href="#"
-                            i18n:translate="label_checkout">
-                            Checkout
-                        </a>
-                    </tal:notcheckedout>
-                </tal:oc_uneditable>
-            </tal:checkout_and_edit_enabled>
-
-            <tal:checkout_and_edit_disabled tal:condition="not: checkout_and_edit_available">
-                <span class="function-edit-inactive discreet"
-                    i18n:translate="label_checkout_and_edit">
-                    Checkout and edit
-                </span>
-            </tal:checkout_and_edit_disabled>
-
-            <tal:checked_out tal:condition="is_checkin_allowed">
-              <tal:checkin_without_comment tal:condition="not: view/is_locked">
-                <a tal:attributes="href view/get_checkin_without_comment_url; class string:function-checkin" i18n:translate="">
-                    Checkin without comment
-                </a>
-              </tal:checkin_without_comment>
-              <a tal:attributes="href view/get_checkin_with_comment_url; class string:function-checkin" i18n:translate="">
-                  Checkin with comment
-              </a>
-            </tal:checked_out>
-
-            <tal:check_out_cancel tal:condition="is_cancel_allowed">
-                <span tal:replace="structure view/get_checkout_cancel_tag"></span>
-            </tal:check_out_cancel>
-
-            <tal:download_copy_enabled tal:condition="copy_download_available">
-                <span tal:replace="structure view/get_download_copy_tag"></span>
-            </tal:download_copy_enabled>
-
-            <tal:download_copy_disabled tal:condition="not: copy_download_available">
-                <span class="function-download-copy-inactive modal discreet"
-                    i18n:translate="label_download_copy">
-                    Download copy
-                </span>
-            </tal:download_copy_disabled>
-
-            <tal:attach_feature_enabled tal:condition="context/@@officeconnector_settings/is_attach_enabled">
-
-              <tal:oc_attach_to_email_available tal:condition="attach_to_email_available">
-                  <a tal:attributes="href string:javascript:officeConnectorAttach('${context/absolute_url}/officeconnector_attach_url');;"
-                      class="function-attach"
-                      href="#"
-                      i18n:translate="label_attach_to_email">
-                      Attach to email
-                  </a>
-              </tal:oc_attach_to_email_available>
-
-              <tal:oc_attach_to_email_inactive tal:condition="not: attach_to_email_available">
-                  <span class="function-attach-inactive modal discreet"
-                      i18n:translate="label_attach_to_email">
-                      Attach to email
-                  </span>
-              </tal:oc_attach_to_email_inactive>
-
-            </tal:attach_feature_enabled>
-
-            <tal:overlay tal:condition="view/overlay">
-                <tal:open_as_pdf
-                    tal:define="link view/overlay/get_open_as_pdf_url; target python: '_blank' if view.overlay.should_open_in_new_window() else None"
-                    tal:condition="nocall: link">
-                    <a tal:attributes="href link; target target | nothing; class string:function-pdf-preview"
-                        i18n:translate="label_open_document_as_pdf">
-                        Open as PDF
-                    </a>
-                </tal:open_as_pdf>
-                <tal:revert
-                    tal:define="link view/overlay/get_revert_link"
-                    tal:condition="nocall: link"
-                    tal:content="structure link">
-                </tal:revert>
-            </tal:overlay>
-
-        </tal:file>
-
-        <tal:details_view tal:define="link context/absolute_url" tal:condition="view/is_detail_view_link_available">
-            <a class="function-view-details"
-                tal:attributes="href link"
-                i18n:translate="label_open_detail_view">Open detail view
+        <tal:direct_checkout_oc tal:condition="view/is_oc_direct_checkout_action_available">
+            <a tal:attributes="href string:javascript:officeConnectorCheckout('${context/absolute_url}/officeconnector_checkout_url');;;
+                               data-document-url context/absolute_url"
+                class="function-edit oc-checkout"
+                href="#"
+                i18n:translate="label_checkout_and_edit">
+                Checkout and edit
             </a>
-        </tal:details_view>
+        </tal:direct_checkout_oc>
 
-        <tal:oneoffixx tal:define="link context/absolute_url" tal:condition="view/is_oneoffixx_creatable">
-          <a tal:attributes="href string:javascript:officeConnectorCheckout('${context/absolute_url}/officeconnector_oneoffixx_url');
-                             data-document-url context/absolute_url"
-              class="function-revert oc-checkout"
-              href="#"
-              i18n:translate="label_retry_oneoffixx">
-              Oneoffixx retry
+        <tal:direct_edit_oc tal:condition="view/is_oc_direct_edit_action_available">
+            <a tal:attributes="href string:javascript:officeConnectorCheckout('${context/absolute_url}/officeconnector_checkout_url');;;
+                               data-document-url context/absolute_url"
+                class="function-edit oc-checkout"
+                href="#"
+                i18n:translate="label_edit">
+                Edit
+            </a>
+        </tal:direct_edit_oc>
+
+        <tal:zem_checkout_oc tal:condition="view/is_oc_zem_checkout_action_available">
+            <a tal:attributes="href string:${context/absolute_url}/editing_document?_authenticator=${context/@@authenticator/token}"
+                class="function-edit"
+                href="#"
+                i18n:translate="label_checkout_and_edit">
+                Checkout and edit
+            </a>
+        </tal:zem_checkout_oc>
+
+        <tal:zem_edit_oc tal:condition="view/is_oc_zem_edit_action_available">
+            <a tal:attributes="href string:${context/absolute_url}/editing_document?_authenticator=${context/@@authenticator/token}"
+                class="function-edit"
+                href="#"
+                i18n:translate="label_edit">
+                Edit
+            </a>
+        </tal:zem_edit_oc>
+
+        <tal:oc_unsupported_checkout tal:condition="view/is_oc_unsupported_file_checkout_action_available">
+            <span class="fa-exclamation-triangle-after function-edit-inactive discreet" title="Office connector unsupported type" value="Checkout and edit"
+            i18n:attributes="title oc_unsupported_message" i18n:translate="label_checkout_and_edit">
+                Checkout and edit
+            </span>
+            <a tal:attributes="href string:${context/absolute_url}/@@checkout_documents?_authenticator=${context/@@authenticator/token}"
+                class="function-edit"
+                href="#"
+                i18n:translate="label_checkout">
+                Checkout
+            </a>
+        </tal:oc_unsupported_checkout>
+
+        <tal:oc_unsupported_edit_discreet tal:condition="view/is_oc_unsupported_file_edit_action_available">
+            <span class="fa-exclamation-triangle-after function-edit-inactive discreet" title="Office connector unsupported type" value="Edit"
+            i18n:attributes="title oc_unsupported_message" i18n:translate="label_edit">
+                Edit
+            </span>
+        </tal:oc_unsupported_edit_discreet>
+
+        <tal:checkout_and_edit_discreet tal:condition="not: view/is_any_checkout_or_edit_available">
+            <span class="function-edit-inactive discreet"
+                i18n:translate="label_checkout_and_edit">
+                Checkout and edit
+            </span>
+        </tal:checkout_and_edit_discreet>
+
+        <tal:checkin_without_comment tal:condition="view/is_checkin_without_comment_available">
+          <a tal:attributes="href view/get_checkin_without_comment_url; class string:function-checkin" i18n:translate="">
+              Checkin without comment
           </a>
-        </tal:oneoffixx>
-        <tal:block repeat="subMenuItem view/get_webaction_items">
-            <a tal:replace="structure subMenuItem" />
-        </tal:block>
+        </tal:checkin_without_comment>
+
+        <tal:checkin_with_comment tal:condition="view/is_checkin_with_comment_available">
+          <a tal:attributes="href view/get_checkin_with_comment_url; class string:function-checkin" i18n:translate="">
+              Checkin with comment
+          </a>
+        </tal:checkin_with_comment>
+
+        <tal:check_out_cancel tal:condition="view/is_cancel_checkout_action_available">
+          <a id="action-cancel-checkout" class="link-overlay modal function-revert"
+             tal:attributes="href view/get_cancel_checkout_url" i18n:translate="">
+              Cancel checkout
+          </a>
+        </tal:check_out_cancel>
+
+        <tal:download_copy_enabled tal:condition="view/is_download_copy_action_available">
+            <span tal:replace="structure view/render_download_copy_link"></span>
+        </tal:download_copy_enabled>
+
+        <tal:download_copy_discreet tal:condition="not: view/is_download_copy_action_available">
+            <span class="function-download-copy-inactive modal discreet"
+                i18n:translate="label_download_copy">
+                Download copy
+            </span>
+        </tal:download_copy_discreet>
+
+        <tal:attach_feature_enabled tal:condition="context/@@officeconnector_settings/is_attach_enabled">
+
+          <tal:oc_attach_to_email_available tal:condition="view/is_attach_to_email_action_available">
+              <a tal:attributes="href string:javascript:officeConnectorAttach('${context/absolute_url}/officeconnector_attach_url');;"
+                  class="function-attach"
+                  href="#"
+                  i18n:translate="label_attach_to_email">
+                  Attach to email
+              </a>
+          </tal:oc_attach_to_email_available>
+
+          <tal:oc_attach_to_email_inactive tal:condition="not: view/is_attach_to_email_action_available">
+              <span class="function-attach-inactive modal discreet"
+                  i18n:translate="label_attach_to_email">
+                  Attach to email
+              </span>
+          </tal:oc_attach_to_email_inactive>
+
+      </tal:attach_feature_enabled>
+
+      <tal:overlay tal:condition="view/overlay">
+          <tal:open_as_pdf
+              tal:define="link view/overlay/get_open_as_pdf_url; target python: '_blank' if view.overlay.should_open_in_new_window() else None"
+              tal:condition="nocall: link">
+              <a tal:attributes="href link; target target | nothing; class string:function-pdf-preview"
+                  i18n:translate="label_open_document_as_pdf">
+                  Open as PDF
+              </a>
+          </tal:open_as_pdf>
+          <tal:revert
+              tal:define="link view/overlay/get_revert_link"
+              tal:condition="nocall: link"
+              tal:content="structure link">
+          </tal:revert>
+      </tal:overlay>
+
+      <tal:details_view tal:define="link context/absolute_url" tal:condition="view/is_detail_view_link_available">
+          <a class="function-view-details"
+              tal:attributes="href link"
+              i18n:translate="label_open_detail_view">Open detail view
+          </a>
+      </tal:details_view>
+
+      <tal:oneoffixx tal:define="link context/absolute_url" tal:condition="view/is_oneoffixx_retry_action_available">
+        <a tal:attributes="href string:javascript:officeConnectorCheckout('${context/absolute_url}/officeconnector_oneoffixx_url');
+                           data-document-url context/absolute_url"
+            class="function-revert oc-checkout"
+            href="#"
+            i18n:translate="label_retry_oneoffixx">
+            Oneoffixx retry
+        </a>
+      </tal:oneoffixx>
+
+      <tal:block repeat="subMenuItem view/get_webaction_items">
+          <a tal:replace="structure subMenuItem" />
+      </tal:block>
     </div>
 
     <tal:nofile tal:condition="not:context/has_file">

--- a/opengever/document/browser/templates/macros.pt
+++ b/opengever/document/browser/templates/macros.pt
@@ -2,80 +2,78 @@
 
     <div class="file-action-buttons">
 
-        <tal:edit_metadata_link tal:condition="view/is_edit_metadata_link_visible"
-                tal:define="edit_metadata_available view/is_edit_metadata_action_available">
-            <tal:edit_metadata tal:condition="edit_metadata_available">
-                <a class="function-edit-metadata"
-                    tal:attributes="href string:${context/absolute_url}/edit_checker"
-                    i18n:domain="plone"
-                    i18n:translate="">
-                    Edit metadata
-                </a>
-            </tal:edit_metadata>
+        <tal:edit_metadata tal:condition="view/is_edit_metadata_action_visible">
+            <a class="function-edit-metadata"
+                tal:attributes="href string:${context/absolute_url}/edit_checker"
+                i18n:domain="plone"
+                i18n:translate="">
+                Edit metadata
+            </a>
+        </tal:edit_metadata>
 
-            <tal:not_edit_metadata tal:condition="not: edit_metadata_available">
-                <span class="function-edit-metadata-inactive discreet"
-                    i18n:domain="plone"
-                    i18n:translate="">
-                    Edit metadata
-                </span>
-            </tal:not_edit_metadata>
-        </tal:edit_metadata_link>
+        <tal:edit_metadata_discreet tal:condition="not: view/is_edit_metadata_action_visible">
+            <span class="function-edit-metadata-inactive discreet"
+                i18n:domain="plone"
+                i18n:translate="">
+                Edit metadata
+            </span>
+        </tal:edit_metadata_discreet>
 
-        <tal:direct_checkout_oc tal:condition="view/is_oc_direct_checkout_action_available">
-            <a tal:attributes="href string:javascript:officeConnectorCheckout('${context/absolute_url}/officeconnector_checkout_url');;;
+        <tal:oc_direct_checkout tal:condition="view/is_oc_direct_checkout_action_available">
+            <a tal:attributes="href view/get_oc_direct_checkout_url;
                                data-document-url context/absolute_url"
                 class="function-edit oc-checkout"
-                href="#"
                 i18n:translate="label_checkout_and_edit">
                 Checkout and edit
             </a>
-        </tal:direct_checkout_oc>
+        </tal:oc_direct_checkout>
 
-        <tal:direct_edit_oc tal:condition="view/is_oc_direct_edit_action_available">
-            <a tal:attributes="href string:javascript:officeConnectorCheckout('${context/absolute_url}/officeconnector_checkout_url');;;
+        <tal:oc_direct_edit tal:condition="view/is_oc_direct_edit_action_available">
+            <a tal:attributes="href view/get_oc_direct_checkout_url;
                                data-document-url context/absolute_url"
                 class="function-edit oc-checkout"
-                href="#"
                 i18n:translate="label_edit">
                 Edit
             </a>
-        </tal:direct_edit_oc>
+        </tal:oc_direct_edit>
 
-        <tal:zem_checkout_oc tal:condition="view/is_oc_zem_checkout_action_available">
-            <a tal:attributes="href string:${context/absolute_url}/editing_document?_authenticator=${context/@@authenticator/token}"
+        <tal:oc_zem_checkout tal:condition="view/is_oc_zem_checkout_action_available">
+            <a tal:attributes="href view/get_oc_zem_checkout_url"
                 class="function-edit"
-                href="#"
                 i18n:translate="label_checkout_and_edit">
                 Checkout and edit
             </a>
-        </tal:zem_checkout_oc>
+        </tal:oc_zem_checkout>
 
-        <tal:zem_edit_oc tal:condition="view/is_oc_zem_edit_action_available">
-            <a tal:attributes="href string:${context/absolute_url}/editing_document?_authenticator=${context/@@authenticator/token}"
+        <tal:oc_zem_edit tal:condition="view/is_oc_zem_edit_action_available">
+            <a tal:attributes="href view/get_oc_zem_checkout_url"
                 class="function-edit"
-                href="#"
                 i18n:translate="label_edit">
                 Edit
             </a>
-        </tal:zem_edit_oc>
+        </tal:oc_zem_edit>
 
         <tal:oc_unsupported_checkout tal:condition="view/is_oc_unsupported_file_checkout_action_available">
-            <span class="fa-exclamation-triangle-after function-edit-inactive discreet" title="Office connector unsupported type" value="Checkout and edit"
-            i18n:attributes="title oc_unsupported_message" i18n:translate="label_checkout_and_edit">
+            <span class="fa-exclamation-triangle-after function-edit-inactive discreet"
+                title="Office connector unsupported type"
+                value="Checkout and edit"
+                i18n:attributes="title oc_unsupported_message"
+                i18n:translate="label_checkout_and_edit">
                 Checkout and edit
             </span>
-            <a tal:attributes="href string:${context/absolute_url}/@@checkout_documents?_authenticator=${context/@@authenticator/token}"
+            <a tal:attributes="href view/get_checkout_url"
                 class="function-edit"
-                href="#"
                 i18n:translate="label_checkout">
                 Checkout
             </a>
         </tal:oc_unsupported_checkout>
 
-        <tal:oc_unsupported_edit_discreet tal:condition="view/is_oc_unsupported_file_edit_action_available">
-            <span class="fa-exclamation-triangle-after function-edit-inactive discreet" title="Office connector unsupported type" value="Edit"
-            i18n:attributes="title oc_unsupported_message" i18n:translate="label_edit">
+        <tal:oc_unsupported_edit_discreet tal:condition="view/is_oc_unsupported_file_discreet_edit_visible">
+            <span class="fa-exclamation-triangle-after function-edit-inactive discreet"
+                title="Office connector unsupported type"
+                value="Edit"
+                i18n:attributes="title oc_unsupported_message"
+                i18n:translate="label_edit">
                 Edit
             </span>
         </tal:oc_unsupported_edit_discreet>
@@ -88,27 +86,32 @@
         </tal:checkout_and_edit_discreet>
 
         <tal:checkin_without_comment tal:condition="view/is_checkin_without_comment_available">
-          <a tal:attributes="href view/get_checkin_without_comment_url; class string:function-checkin" i18n:translate="">
+          <a class="function-checkin"
+              tal:attributes="href view/get_checkin_without_comment_url"
+              i18n:translate="">
               Checkin without comment
           </a>
         </tal:checkin_without_comment>
 
         <tal:checkin_with_comment tal:condition="view/is_checkin_with_comment_available">
-          <a tal:attributes="href view/get_checkin_with_comment_url; class string:function-checkin" i18n:translate="">
+          <a class="function-checkin"
+              tal:attributes="href view/get_checkin_with_comment_url"
+              i18n:translate="">
               Checkin with comment
           </a>
         </tal:checkin_with_comment>
 
         <tal:check_out_cancel tal:condition="view/is_cancel_checkout_action_available">
           <a id="action-cancel-checkout" class="link-overlay modal function-revert"
-             tal:attributes="href view/get_cancel_checkout_url" i18n:translate="">
+              tal:attributes="href view/get_cancel_checkout_url"
+              i18n:translate="">
               Cancel checkout
           </a>
         </tal:check_out_cancel>
 
-        <tal:download_copy_enabled tal:condition="view/is_download_copy_action_available">
+        <tal:download_copy tal:condition="view/is_download_copy_action_available">
             <span tal:replace="structure view/render_download_copy_link"></span>
-        </tal:download_copy_enabled>
+        </tal:download_copy>
 
         <tal:download_copy_discreet tal:condition="not: view/is_download_copy_action_available">
             <span class="function-download-copy-inactive modal discreet"
@@ -117,23 +120,22 @@
             </span>
         </tal:download_copy_discreet>
 
-        <tal:attach_feature_enabled tal:condition="context/@@officeconnector_settings/is_attach_enabled">
+        <tal:attach_feature_enabled tal:condition="view/is_attach_to_email_action_set_visible">
 
-          <tal:oc_attach_to_email_available tal:condition="view/is_attach_to_email_action_available">
-              <a tal:attributes="href string:javascript:officeConnectorAttach('${context/absolute_url}/officeconnector_attach_url');;"
+          <tal:oc_attach_to_email tal:condition="view/is_attach_to_email_action_available">
+              <a tal:attributes="href view/get_oc_attach_to_email_url"
                   class="function-attach"
-                  href="#"
                   i18n:translate="label_attach_to_email">
                   Attach to email
               </a>
-          </tal:oc_attach_to_email_available>
+          </tal:oc_attach_to_email>
 
-          <tal:oc_attach_to_email_inactive tal:condition="not: view/is_attach_to_email_action_available">
+          <tal:oc_attach_to_email_discreet tal:condition="not: view/is_attach_to_email_action_available">
               <span class="function-attach-inactive modal discreet"
                   i18n:translate="label_attach_to_email">
                   Attach to email
               </span>
-          </tal:oc_attach_to_email_inactive>
+          </tal:oc_attach_to_email_discreet>
 
       </tal:attach_feature_enabled>
 
@@ -153,18 +155,18 @@
           </tal:revert>
       </tal:overlay>
 
-      <tal:details_view tal:define="link context/absolute_url" tal:condition="view/is_detail_view_link_available">
+      <tal:details_view  tal:condition="view/is_detail_view_link_visible">
           <a class="function-view-details"
-              tal:attributes="href link"
-              i18n:translate="label_open_detail_view">Open detail view
+              tal:attributes="href context/absolute_url"
+              i18n:translate="label_open_detail_view">
+              Open detail view
           </a>
       </tal:details_view>
 
-      <tal:oneoffixx tal:define="link context/absolute_url" tal:condition="view/is_oneoffixx_retry_action_available">
-        <a tal:attributes="href string:javascript:officeConnectorCheckout('${context/absolute_url}/officeconnector_oneoffixx_url');
+      <tal:oneoffixx tal:condition="view/is_oneoffixx_retry_action_available">
+        <a tal:attributes="href view/get_oc_oneoffixx_retry_url;
                            data-document-url context/absolute_url"
             class="function-revert oc-checkout"
-            href="#"
             i18n:translate="label_retry_oneoffixx">
             Oneoffixx retry
         </a>
@@ -175,7 +177,7 @@
       </tal:block>
     </div>
 
-    <tal:nofile tal:condition="not:context/has_file">
+    <tal:nofile tal:condition="view/is_discreet_no_file_hint_visible">
         <span class="discreet" i18n:translate="no_file">
             No file
         </span>

--- a/opengever/document/browser/templates/macros.pt
+++ b/opengever/document/browser/templates/macros.pt
@@ -11,7 +11,7 @@
             </a>
         </tal:edit_metadata>
 
-        <tal:edit_metadata_discreet tal:condition="not: view/is_edit_metadata_action_visible">
+        <tal:edit_metadata_discreet tal:condition="view/is_discreet_edit_metadata_action_visible">
             <span class="function-edit-metadata-inactive discreet"
                 i18n:domain="plone"
                 i18n:translate="">

--- a/opengever/document/browser/templates/macros.pt
+++ b/opengever/document/browser/templates/macros.pt
@@ -139,15 +139,18 @@
 
       </tal:attach_feature_enabled>
 
+      <tal:open_as_pdf
+          tal:define="target python: '_blank' if view.should_pdfs_open_in_new_window() else None"
+          tal:condition="view/is_open_as_pdf_action_visible">
+          <a class="function-pdf-preview"
+              tal:attributes="href view/get_open_as_pdf_url;
+                              target target | nothing;"
+              i18n:translate="label_open_document_as_pdf">
+              Open as PDF
+          </a>
+      </tal:open_as_pdf>
+
       <tal:overlay tal:condition="view/overlay">
-          <tal:open_as_pdf
-              tal:define="link view/overlay/get_open_as_pdf_url; target python: '_blank' if view.overlay.should_open_in_new_window() else None"
-              tal:condition="nocall: link">
-              <a tal:attributes="href link; target target | nothing; class string:function-pdf-preview"
-                  i18n:translate="label_open_document_as_pdf">
-                  Open as PDF
-              </a>
-          </tal:open_as_pdf>
           <tal:revert
               tal:define="link view/overlay/get_revert_link"
               tal:condition="nocall: link"

--- a/opengever/document/browser/templates/macros.pt
+++ b/opengever/document/browser/templates/macros.pt
@@ -153,7 +153,7 @@
       <tal:revert_to_version tal:condition="view/is_revert_to_version_action_available">
           <a class="standalone function-revert"
               tal:attributes="href view/get_revert_to_version_url"
-              i18n:translate="label_revert">
+              i18n:translate="label_revert_document">
               Revert document
           </a>
       </tal:revert_to_version>

--- a/opengever/document/browser/templates/macros.pt
+++ b/opengever/document/browser/templates/macros.pt
@@ -4,7 +4,7 @@
 
         <tal:edit_metadata tal:condition="view/is_edit_metadata_action_visible">
             <a class="function-edit-metadata"
-                tal:attributes="href string:${context/absolute_url}/edit_checker"
+                tal:attributes="href view/get_edit_metadata_url"
                 i18n:domain="plone"
                 i18n:translate="">
                 Edit metadata

--- a/opengever/document/checkout/manager.py
+++ b/opengever/document/checkout/manager.py
@@ -43,6 +43,9 @@ class CheckinCheckoutManager(object):
         """
         return self.annotations.get(CHECKIN_CHECKOUT_ANNOTATIONS_KEY, None)
 
+    def is_checked_out_by_another_user(self):
+        return bool(self.get_checked_out_by()) and not self.is_checked_out_by_current_user()
+
     def is_checked_out_by_current_user(self):
         return self.get_checked_out_by() == api.user.get_current().getId()
 

--- a/opengever/document/configure.zcml
+++ b/opengever/document/configure.zcml
@@ -320,4 +320,7 @@
 
   <adapter factory=".document.UploadValidator" />
 
+  <adapter factory=".fileactions.BaseDocumentFileActions" />
+  <adapter factory=".fileactions.DocumentFileActions" />
+
 </configure>

--- a/opengever/document/document.py
+++ b/opengever/document/document.py
@@ -304,6 +304,16 @@ class Document(Item, BaseDocumentMixin):
 
         return manager.is_checkout_allowed()
 
+    def is_checkin_allowed(self):
+        manager = queryMultiAdapter(
+            (self, self.REQUEST), ICheckinCheckoutManager)
+        return manager.is_checkin_allowed()
+
+    def is_locked(self):
+        manager = queryMultiAdapter(
+            (self, self.REQUEST), ICheckinCheckoutManager)
+        return manager.is_locked()
+
     def is_shadow_document(self):
         return api.content.get_state(self) == self.shadow_state
 

--- a/opengever/document/fileactions.py
+++ b/opengever/document/fileactions.py
@@ -24,6 +24,9 @@ class BaseDocumentFileActions(object):
         self.context = context
         self.request = request
 
+    def is_versioned(self):
+        return False
+
     def is_edit_metadata_action_available(self):
         return api.user.has_permission(
             'Modify portal content',
@@ -90,7 +93,16 @@ class DocumentFileActions(BaseDocumentFileActions):
 
     def is_versioned(self):
         version_id = self.request.get('version_id', '')
-        return version_id.isdigit()
+
+        if isinstance(version_id, basestring):
+            return version_id.isdigit()
+
+        try:
+            int(version_id)
+        except ValueError:
+            return False
+        else:
+            return True
 
     def is_any_checkout_or_edit_available(self):
         return (

--- a/opengever/document/fileactions.py
+++ b/opengever/document/fileactions.py
@@ -1,0 +1,159 @@
+from opengever.document.behaviors import IBaseDocument
+from opengever.document.document import IDocumentSchema
+from opengever.document.interfaces import ICheckinCheckoutManager
+from opengever.document.interfaces import IFileActions
+from opengever.officeconnector.helpers import is_officeconnector_attach_feature_enabled  # noqa
+from opengever.officeconnector.helpers import is_officeconnector_checkout_feature_enabled  # noqa
+from plone import api
+from zope.component import adapter
+from zope.component import getMultiAdapter
+from zope.interface import implementer
+from zope.interface import Interface
+
+
+@implementer(IFileActions)
+@adapter(IBaseDocument, Interface)
+class BaseDocumentFileActions(object):
+    """Define availability for actions and action sets on IBaseDocument.
+
+    Methods should return availability for one single action.
+    """
+    def __init__(self, context, request):
+        self.context = context
+        self.request = request
+
+    def is_edit_metadata_action_available(self):
+        return api.user.has_permission(
+            'Modify portal content',
+            obj=self.context)
+
+    def is_any_checkout_or_edit_available(self):
+        return False
+
+    def is_oc_direct_checkout_action_available(self):
+        return False
+
+    def is_oc_direct_edit_action_available(self):
+        return False
+
+    def is_oc_zem_checkout_action_available(self):
+        return False
+
+    def is_oc_zem_edit_action_available(self):
+        return False
+
+    def is_oc_unsupported_file_checkout_action_available(self):
+        return False
+
+    def is_checkin_without_comment_available(self):
+        return False
+
+    def is_checkin_with_comment_available(self):
+        return False
+
+    def is_cancel_checkout_action_available(self):
+        return False
+
+    def is_download_copy_action_available(self):
+        return self.context.has_file()
+
+    def is_attach_to_email_action_available(self):
+        return (
+            is_officeconnector_attach_feature_enabled()
+            and self.context.has_file())
+
+    def is_oneoffixx_retry_action_available(self):
+        return False
+
+
+@implementer(IFileActions)
+@adapter(IDocumentSchema, Interface)
+class DocumentFileActions(BaseDocumentFileActions):
+
+    def is_versioned(self):
+        return self.request.get('version_id') is not None
+
+    def is_any_checkout_or_edit_available(self):
+        return (
+            not self.is_versioned()
+            and self.context.has_file()
+            and self.context.is_checkout_and_edit_available())
+
+    def is_edit_metadata_action_available(self):
+        manager = getMultiAdapter(
+            (self.context, self.request), ICheckinCheckoutManager)
+
+        return (
+            super(DocumentFileActions, self).is_edit_metadata_action_available()
+            and not manager.is_locked()
+            and not manager.is_checked_out_by_another_user()
+            )
+
+    def is_oc_direct_checkout_action_available(self):
+        return (self.is_any_checkout_or_edit_available()
+                and self.context.is_office_connector_editable()
+                and not self.context.is_checked_out()
+                and is_officeconnector_checkout_feature_enabled())
+
+    def is_oc_direct_edit_action_available(self):
+        return (self.is_any_checkout_or_edit_available()
+                and self.context.is_office_connector_editable()
+                and self.context.is_checked_out()
+                and is_officeconnector_checkout_feature_enabled())
+
+    def is_oc_zem_checkout_action_available(self):
+        return (self.is_any_checkout_or_edit_available()
+                and self.context.is_office_connector_editable()
+                and not self.context.is_checked_out()
+                and not is_officeconnector_checkout_feature_enabled())
+
+    def is_oc_zem_edit_action_available(self):
+        return (self.is_any_checkout_or_edit_available()
+                and self.context.is_office_connector_editable()
+                and self.context.is_checked_out()
+                and not is_officeconnector_checkout_feature_enabled())
+
+    def is_oc_unsupported_file_checkout_action_available(self):
+        return (self.is_any_checkout_or_edit_available()
+                and not self.context.is_office_connector_editable()
+                and not self.context.is_checked_out())
+
+    def is_checkin_without_comment_available(self):
+        return (not self.is_versioned()
+                and self.is_checkin_with_comment_available()
+                and not self.context.is_locked())
+
+    def is_checkin_with_comment_available(self):
+        return (not self.is_versioned()
+                and self.context.has_file()
+                and self.context.is_checkin_allowed())
+
+    def is_cancel_checkout_action_available(self):
+        if not self.context.has_file():
+            return False
+
+        manager = getMultiAdapter(
+            (self.context, self.request), ICheckinCheckoutManager)
+        return manager.is_cancel_allowed()
+
+    def is_download_copy_action_available(self):
+        """Disable downloading copies when the document is checked out by
+        another user.
+        """
+        manager = getMultiAdapter(
+            (self.context, self.request), ICheckinCheckoutManager)
+        return (
+            super(DocumentFileActions, self).is_download_copy_action_available()
+            and not manager.is_checked_out_by_another_user())
+
+    def is_attach_to_email_action_available(self):
+        manager = getMultiAdapter(
+            (self.context, self.request), ICheckinCheckoutManager)
+
+        return (
+            super(DocumentFileActions, self).is_attach_to_email_action_available()
+            and not manager.is_checked_out_by_another_user()
+            )
+
+    def is_oneoffixx_retry_action_available(self):
+        return self.context.is_oneoffixx_creatable()

--- a/opengever/document/fileactions.py
+++ b/opengever/document/fileactions.py
@@ -80,13 +80,17 @@ class BaseDocumentFileActions(object):
 
         return is_mimetype_supported(mime_type_item[0])
 
+    def is_revert_to_version_action_available(self):
+        return False
+
 
 @implementer(IFileActions)
 @adapter(IDocumentSchema, Interface)
 class DocumentFileActions(BaseDocumentFileActions):
 
     def is_versioned(self):
-        return self.request.get('version_id') is not None
+        version_id = self.request.get('version_id', '')
+        return version_id.isdigit()
 
     def is_any_checkout_or_edit_available(self):
         return (
@@ -171,3 +175,12 @@ class DocumentFileActions(BaseDocumentFileActions):
 
     def is_oneoffixx_retry_action_available(self):
         return self.context.is_oneoffixx_creatable()
+
+    def is_revert_to_version_action_available(self):
+        manager = getMultiAdapter(
+            (self.context, self.request), ICheckinCheckoutManager)
+
+        return (self.is_versioned()
+                and self.context.has_file()
+                and not self.context.is_checked_out()
+                and manager.is_checkout_allowed())

--- a/opengever/document/fileactions.py
+++ b/opengever/document/fileactions.py
@@ -1,3 +1,4 @@
+from ftw.bumblebee.mimetypes import is_mimetype_supported
 from opengever.document.behaviors import IBaseDocument
 from opengever.document.document import IDocumentSchema
 from opengever.document.interfaces import ICheckinCheckoutManager
@@ -64,6 +65,13 @@ class BaseDocumentFileActions(object):
 
     def is_oneoffixx_retry_action_available(self):
         return False
+
+    def is_open_as_pdf_action_available(self):
+        mime_type_item = self.context.get_mimetype()
+        if not mime_type_item:
+            return False
+
+        return is_mimetype_supported(mime_type_item[0])
 
 
 @implementer(IFileActions)

--- a/opengever/document/fileactions.py
+++ b/opengever/document/fileactions.py
@@ -85,9 +85,9 @@ class DocumentFileActions(BaseDocumentFileActions):
 
         return (
             super(DocumentFileActions, self).is_edit_metadata_action_available()
+            and not self.is_versioned()
             and not manager.is_locked()
-            and not manager.is_checked_out_by_another_user()
-            )
+            and not manager.is_checked_out_by_another_user())
 
     def is_oc_direct_checkout_action_available(self):
         return (self.is_any_checkout_or_edit_available()
@@ -152,8 +152,7 @@ class DocumentFileActions(BaseDocumentFileActions):
 
         return (
             super(DocumentFileActions, self).is_attach_to_email_action_available()
-            and not manager.is_checked_out_by_another_user()
-            )
+            and not manager.is_checked_out_by_another_user())
 
     def is_oneoffixx_retry_action_available(self):
         return self.context.is_oneoffixx_creatable()

--- a/opengever/document/fileactions.py
+++ b/opengever/document/fileactions.py
@@ -1,4 +1,5 @@
 from ftw.bumblebee.mimetypes import is_mimetype_supported
+from opengever.bumblebee import is_bumblebee_feature_enabled
 from opengever.document.behaviors import IBaseDocument
 from opengever.document.document import IDocumentSchema
 from opengever.document.interfaces import ICheckinCheckoutManager
@@ -67,6 +68,12 @@ class BaseDocumentFileActions(object):
         return False
 
     def is_open_as_pdf_action_available(self):
+        if not is_bumblebee_feature_enabled():
+            return False
+
+        if not self.context.has_file():
+            return False
+
         mime_type_item = self.context.get_mimetype()
         if not mime_type_item:
             return False

--- a/opengever/document/interfaces.py
+++ b/opengever/document/interfaces.py
@@ -187,3 +187,6 @@ class IFileActions(Interface):
 
     def is_oneoffixx_retry_action_available():
         """Return whether oneoffixx retry action is available."""
+
+    def is_open_as_pdf_action_available():
+        """Return whether the open aos pdf action is available."""

--- a/opengever/document/interfaces.py
+++ b/opengever/document/interfaces.py
@@ -134,3 +134,56 @@ class IDocumentSavedAsPDFMarker(Interface):
     """Marker Interface for documents that are copies of another document
     in PDF format. Such documents contain the Source document and version
     in their annotations."""
+
+
+class IFileActions(Interface):
+    """Knows availability of specific ations from the `file_actions` category.
+    """
+
+    def is_edit_metadata_action_available():
+        """Return whether the action to edit metadata is available."""
+
+    def is_any_checkout_or_edit_available():
+        """Return wheter any of the checkout or edit actions are available."""
+
+    def is_oc_direct_checkout_action_available():
+        """Return whether OfficeConnector direct checkout action is available.
+        """
+
+    def is_oc_direct_edit_action_available():
+        """Return whether OfficeConnector direct edit action is available.
+        """
+
+    def is_oc_zem_checkout_action_available():
+        """Return whether deprecated ZEM OfficeConnector checkout action
+        is available.
+        """
+
+    def is_oc_zem_edit_action_available():
+        """Return whether deprecated ZEM OfficeConnector edit action
+        is available.
+        """
+
+    def is_oc_unsupported_file_checkout_action_available():
+        """Return whether checkout action for unsupported OfficeConnector
+        types is available."""
+
+    def is_checkin_without_comment_available():
+        """Return whether checkin without comment action is available.
+        """
+
+    def is_checkin_with_comment_available():
+        """Return whether checkin with comment action is available.
+        """
+
+    def is_cancel_checkout_action_available():
+        """Return whether cancel checkout action is available."""
+
+    def is_download_copy_action_available():
+        """Return download copy action is available."""
+
+    def is_attach_to_email_action_available():
+        """Return whether attach to email action is available."""
+
+    def is_oneoffixx_retry_action_available():
+        """Return whether oneoffixx retry action is available."""

--- a/opengever/document/interfaces.py
+++ b/opengever/document/interfaces.py
@@ -190,3 +190,6 @@ class IFileActions(Interface):
 
     def is_open_as_pdf_action_available():
         """Return whether the open aos pdf action is available."""
+
+    def is_revert_to_version_action_available():
+        """Return whether the revert to version action is available."""

--- a/opengever/document/locales/de/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/de/LC_MESSAGES/opengever.document.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2019-04-08 11:37+0000\n"
+"POT-Creation-Date: 2019-08-02 12:46+0000\n"
 "PO-Revision-Date: 2017-10-13 14:27+0200\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -24,7 +24,7 @@ msgid "Can't edit the document at moment, beacuse it's locked."
 msgstr "Das Dokument kann momentan nicht bearbeitet werden, es ist gesperrt."
 
 #. Default: "Cancel checkout"
-#: ./opengever/document/browser/actionbuttons.py
+#: ./opengever/document/browser/templates/macros.pt
 #: ./opengever/document/checkout/cancel.py
 #: ./opengever/document/checkout/templates/cancelconfirmation.pt
 msgid "Cancel checkout"
@@ -77,10 +77,6 @@ msgstr "Es ist nicht erlaubt, das Dokument ${title} auszuchecken."
 #: ./opengever/document/checkout/checkout.py
 msgid "Could not check out object: ${title}, it is not a document."
 msgstr "${title} ist kein Dokument und konnte deshalb nicht ausgecheckt werden."
-
-#: ./opengever/document/browser/report.py
-msgid "Could not generate the report."
-msgstr "Rapport konnte nicht generiert werden."
 
 #: ./opengever/document/browser/overview.py
 msgid "Current version: ${version}"
@@ -592,6 +588,11 @@ msgstr "Mit Oneoffixx wiederholen"
 #: ./opengever/document/browser/versions_tab.py
 msgid "label_revert"
 msgstr "Zurücksetzen"
+
+#. Default: "Revert document"
+#: ./opengever/document/browser/templates/macros.pt
+msgid "label_revert_document"
+msgstr "Dokument zurücksetzen"
 
 #. Default: "Save PDF"
 #: ./opengever/document/browser/versions_tab.py

--- a/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-04-08 11:37+0000\n"
+"POT-Creation-Date: 2019-08-02 12:46+0000\n"
 "PO-Revision-Date: 2017-09-03 08:50+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-document/fr/>\n"
@@ -26,7 +26,7 @@ msgid "Can't edit the document at moment, beacuse it's locked."
 msgstr "Impossible de modifier le document en ce moment car il est verrouillé."
 
 #. Default: "Cancel checkout"
-#: ./opengever/document/browser/actionbuttons.py
+#: ./opengever/document/browser/templates/macros.pt
 #: ./opengever/document/checkout/cancel.py
 #: ./opengever/document/checkout/templates/cancelconfirmation.pt
 msgid "Cancel checkout"
@@ -79,10 +79,6 @@ msgstr "Checkout de ${title} n'a pas abouti."
 #: ./opengever/document/checkout/checkout.py
 msgid "Could not check out object: ${title}, it is not a document."
 msgstr "${title} n'est pas un document, par consequet checkout n'a pas abouti."
-
-#: ./opengever/document/browser/report.py
-msgid "Could not generate the report."
-msgstr "Le rapport n'a pas pu être généré."
 
 #: ./opengever/document/browser/overview.py
 msgid "Current version: ${version}"
@@ -589,6 +585,11 @@ msgstr "Réessayer avec Oneoffixx"
 #: ./opengever/document/browser/versions_tab.py
 msgid "label_revert"
 msgstr "Restaurer"
+
+#. Default: "Revert document"
+#: ./opengever/document/browser/templates/macros.pt
+msgid "label_revert_document"
+msgstr "Restaurer le document"
 
 #. Default: "Save PDF"
 #: ./opengever/document/browser/versions_tab.py

--- a/opengever/document/locales/opengever.document.pot
+++ b/opengever/document/locales/opengever.document.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-04-08 11:37+0000\n"
+"POT-Creation-Date: 2019-08-02 12:46+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -26,7 +26,7 @@ msgstr ""
 msgid "Can't edit the document at moment, beacuse it's locked."
 msgstr ""
 
-#: ./opengever/document/browser/actionbuttons.py
+#: ./opengever/document/browser/templates/macros.pt
 #: ./opengever/document/checkout/cancel.py
 #: ./opengever/document/checkout/templates/cancelconfirmation.pt
 msgid "Cancel checkout"
@@ -78,10 +78,6 @@ msgstr ""
 
 #: ./opengever/document/checkout/checkout.py
 msgid "Could not check out object: ${title}, it is not a document."
-msgstr ""
-
-#: ./opengever/document/browser/report.py
-msgid "Could not generate the report."
 msgstr ""
 
 #: ./opengever/document/browser/overview.py
@@ -588,6 +584,11 @@ msgstr ""
 #. Default: "Revert"
 #: ./opengever/document/browser/versions_tab.py
 msgid "label_revert"
+msgstr ""
+
+#. Default: "Revert document"
+#: ./opengever/document/browser/templates/macros.pt
+msgid "label_revert_document"
 msgstr ""
 
 #. Default: "Save PDF"

--- a/opengever/document/tests/test_fileactions.py
+++ b/opengever/document/tests/test_fileactions.py
@@ -1,0 +1,14 @@
+from opengever.document.fileactions import BaseDocumentFileActions
+from opengever.document.fileactions import DocumentFileActions
+from opengever.document.interfaces import IFileActions
+from opengever.testing.test_case import TestCase
+from zope.interface.verify import verifyClass
+
+
+class TestFileActionsInterface(TestCase):
+
+    def test_base_document_file_actions_implements_ifileactions(self):
+        verifyClass(IFileActions, BaseDocumentFileActions)
+
+    def test_document_file_actions_implements_ifileactions(self):
+        verifyClass(IFileActions, DocumentFileActions)

--- a/opengever/document/tests/test_fileactions.py
+++ b/opengever/document/tests/test_fileactions.py
@@ -1,7 +1,9 @@
 from opengever.document.fileactions import BaseDocumentFileActions
 from opengever.document.fileactions import DocumentFileActions
 from opengever.document.interfaces import IFileActions
+from opengever.testing import IntegrationTestCase
 from opengever.testing.test_case import TestCase
+from zope.component import getMultiAdapter
 from zope.interface.verify import verifyClass
 
 
@@ -12,3 +14,39 @@ class TestFileActionsInterface(TestCase):
 
     def test_document_file_actions_implements_ifileactions(self):
         verifyClass(IFileActions, DocumentFileActions)
+
+
+class TestIsVersionedDocument(IntegrationTestCase):
+    """Test if we correctly detect if we're on a versioned document or not."""
+
+    def test_returns_false_if_no_version_id_is_given(self):
+        self.login(self.regular_user)
+        adapter = getMultiAdapter((self.document, self.request), IFileActions)
+        self.assertFalse(adapter.is_versioned())
+
+    def test_returns_true_if_version_id_is_a_string(self):
+        self.login(self.regular_user)
+        self.request['version_id'] = '0'
+        adapter = getMultiAdapter((self.document, self.request), IFileActions)
+        self.assertTrue(adapter.is_versioned())
+
+    def test_test_returns_false_if_version_id_is_no_digit(self):
+        self.login(self.regular_user)
+        self.request['version_id'] = u'g\xe4x'
+        adapter = getMultiAdapter((self.document, self.request), IFileActions)
+        self.assertFalse(adapter.is_versioned())
+
+    def test_returns_true_if_version_id_is_a_number(self):
+        self.login(self.regular_user)
+        self.request['version_id'] = 123
+        adapter = getMultiAdapter((self.document, self.request), IFileActions)
+        self.assertTrue(adapter.is_versioned())
+
+
+class TestIsVersionedMail(IntegrationTestCase):
+
+    def test_mails_are_never_versioned(self):
+        self.login(self.regular_user)
+        self.request['version_id'] = '0'
+        adapter = getMultiAdapter((self.mail_eml, self.request), IFileActions)
+        self.assertFalse(adapter.is_versioned())

--- a/opengever/document/tests/test_overview.py
+++ b/opengever/document/tests/test_overview.py
@@ -69,6 +69,40 @@ class TestGetPdfFilename(IntegrationTestCase):
         self.assertEqual(u'Vertr\xe4ge Wichtig.pdf', view._get_pdf_filename())
 
 
+class TestGetCheckoutURL(IntegrationTestCase):
+    """Test we correctly generate the document checkout urls."""
+
+    features = (
+        'bumblebee',
+        )
+
+    def test_get_oc_zem_checkout_url(self):
+        self.login(self.regular_user)
+        view = api.content.get_view('tabbedview_view-overview',
+                                    self.document, self.request)
+        expected_url = '{}/editing_document?_authenticator='.format(
+            self.document.absolute_url())
+        self.assertTrue(view.get_oc_zem_checkout_url().startswith(expected_url))
+
+    def test_get_checkout_url(self):
+        self.login(self.regular_user)
+        view = api.content.get_view('tabbedview_view-overview',
+                                    self.document, self.request)
+        expected_url = '{}/@@checkout_documents?_authenticator='.format(
+            self.document.absolute_url())
+        self.assertTrue(view.get_checkout_url().startswith(expected_url))
+
+    def test_get_oc_direct_checkout_url(self):
+        self.login(self.regular_user)
+        view = api.content.get_view('tabbedview_view-overview',
+                                    self.document, self.request)
+        expected_url = (
+            u"javascript:officeConnectorCheckout("
+            "'{}/officeconnector_checkout_url'"
+            ");".format(self.document.absolute_url()))
+        self.assertEqual(expected_url, view.get_oc_direct_checkout_url())
+
+
 class TestDocumentOverviewVanilla(IntegrationTestCase):
 
     features = (

--- a/opengever/document/tests/test_overview.py
+++ b/opengever/document/tests/test_overview.py
@@ -143,6 +143,30 @@ class TestGetCheckinWithoutCommentURL(IntegrationTestCase):
             view.get_checkin_without_comment_url().startswith(expected_url))
 
 
+class TestGetCheckinWithCommentURL(IntegrationTestCase):
+    """Test we correctly generate a checkin with comment link."""
+
+    features = (
+        'bumblebee',
+        )
+
+    def test_returns_none_when_document_is_not_checked_out(self):
+        self.login(self.regular_user)
+        view = api.content.get_view('tabbedview_view-overview',
+                                    self.document, self.request)
+        self.assertIsNone(view.get_checkin_with_comment_url())
+
+    def test_returns_checkin_with_comment_url_as_string(self):
+        self.login(self.regular_user)
+        self.checkout_document(self.document)
+        view = api.content.get_view('tabbedview_view-overview',
+                                    self.document, self.request)
+        expected_url = '{}/@@checkin_document?_authenticator='.format(
+            self.document.absolute_url())
+        self.assertTrue(
+            view.get_checkin_with_comment_url().startswith(expected_url))
+
+
 class TestDocumentOverviewVanilla(IntegrationTestCase):
 
     features = (

--- a/opengever/document/tests/test_overview.py
+++ b/opengever/document/tests/test_overview.py
@@ -103,6 +103,22 @@ class TestGetCheckoutURL(IntegrationTestCase):
         self.assertEqual(expected_url, view.get_oc_direct_checkout_url())
 
 
+class TestGetEditMetadataURL(IntegrationTestCase):
+    """Test we correctly generate the document edit metadata link."""
+
+    features = (
+        'bumblebee',
+        )
+
+    def test_returns_edit_metadata_url(self):
+        self.login(self.regular_user)
+        view = api.content.get_view('tabbedview_view-overview',
+                                    self.document, self.request)
+        self.assertEqual(
+            '{}/edit_checker'.format(self.document.absolute_url()),
+            view.get_edit_metadata_url())
+
+
 class TestDocumentOverviewVanilla(IntegrationTestCase):
 
     features = (

--- a/opengever/document/tests/test_overview.py
+++ b/opengever/document/tests/test_overview.py
@@ -119,6 +119,30 @@ class TestGetEditMetadataURL(IntegrationTestCase):
             view.get_edit_metadata_url())
 
 
+class TestGetCheckinWithoutCommentURL(IntegrationTestCase):
+    """Test we correctly generate a checkin without comment link."""
+
+    features = (
+        'bumblebee',
+        )
+
+    def test_returns_none_when_document_is_not_checked_out(self):
+        self.login(self.regular_user)
+        view = api.content.get_view('tabbedview_view-overview',
+                                    self.document, self.request)
+        self.assertIsNone(view.get_checkin_without_comment_url())
+
+    def test_returns_checkin_without_comment_url_as_string(self):
+        self.login(self.regular_user)
+        self.checkout_document(self.document)
+        view = api.content.get_view('tabbedview_view-overview',
+                                    self.document, self.request)
+        expected_url = '{}/@@checkin_without_comment?_authenticator='.format(
+            self.document.absolute_url())
+        self.assertTrue(
+            view.get_checkin_without_comment_url().startswith(expected_url))
+
+
 class TestDocumentOverviewVanilla(IntegrationTestCase):
 
     features = (

--- a/opengever/document/widgets/tooltip.py
+++ b/opengever/document/widgets/tooltip.py
@@ -13,3 +13,6 @@ class TooltipView(VisibleActionButtonRendererMixin):
 
     def get_bumblebee_checksum(self):
         return IBumblebeeDocument(self.context).get_checksum()
+
+    def is_detail_view_link_visible(self):
+        return True

--- a/opengever/document/widgets/tooltip.py
+++ b/opengever/document/widgets/tooltip.py
@@ -1,9 +1,9 @@
 from ftw.bumblebee.interfaces import IBumblebeeDocument
-from opengever.document.browser.actionbuttons import ActionButtonRendererMixin
+from opengever.document.browser.actionbuttons import VisibleActionButtonRendererMixin
 from plone.app.contentlisting.interfaces import IContentListingObject
 
 
-class TooltipView(ActionButtonRendererMixin):
+class TooltipView(VisibleActionButtonRendererMixin):
     """File tooltip"""
 
     def __init__(self, context, request):

--- a/opengever/mail/tests/test_overview.py
+++ b/opengever/mail/tests/test_overview.py
@@ -46,6 +46,17 @@ class TestGetOpenAsPdfURL(IntegrationTestCase):
         self.assertEqual(expected_url, view.get_open_as_pdf_url())
 
 
+class TestGetCheckinWithCommentURL(IntegrationTestCase):
+
+    features = ('bumblebee', )
+
+    def test_returns_none_because_its_not_possible_to_checkin_emails(self):
+        self.login(self.regular_user)
+        view = api.content.get_view('tabbedview_view-overview',
+                                    self.mail_eml, self.request)
+        self.assertIsNone(view.get_checkin_with_comment_url())
+
+
 class TestMailOverview(IntegrationTestCase):
 
     @browsing

--- a/opengever/mail/tests/test_overview.py
+++ b/opengever/mail/tests/test_overview.py
@@ -1,6 +1,18 @@
 from ftw.mail.mail import IMail
 from ftw.testbrowser import browsing
 from opengever.testing import IntegrationTestCase
+from plone import api
+
+
+class TestGetCheckinWithoutCommentURL(IntegrationTestCase):
+
+    features = ('bumblebee', )
+
+    def test_returns_none_because_its_not_possible_to_checkin_emails(self):
+        self.login(self.regular_user)
+        view = api.content.get_view('tabbedview_view-overview',
+                                    self.mail_eml, self.request)
+        self.assertIsNone(view.get_checkin_without_comment_url())
 
 
 class TestGetOpenAsPdfURL(IntegrationTestCase):

--- a/opengever/mail/tests/test_overview.py
+++ b/opengever/mail/tests/test_overview.py
@@ -1,5 +1,37 @@
+from ftw.mail.mail import IMail
 from ftw.testbrowser import browsing
 from opengever.testing import IntegrationTestCase
+
+
+class TestGetOpenAsPdfURL(IntegrationTestCase):
+
+    features = ('bumblebee', )
+
+    def test_returns_none_for_unsupported_mail_conversion(self):
+        self.login(self.regular_user)
+        view = api.content.get_view('tabbedview_view-overview',
+                                    self.mail_eml, self.request)
+        expected_url = (
+            'http://nohost/plone/ordnungssystem/fuhrung'
+            '/vertrage-und-vereinbarungen/dossier-1/document-29'
+            '/bumblebee-open-pdf?filename=Die%20Buergschaft.pdf'
+            )
+
+        self.assertEqual(expected_url, view.get_open_as_pdf_url())
+
+    def test_handles_non_ascii_characters_in_filename(self):
+        self.login(self.regular_user)
+        IMail(self.mail_eml).message.filename = u'GEVER - \xdcbernahme.msg'
+        view = api.content.get_view('tabbedview_view-overview',
+                                    self.mail_eml, self.request)
+
+        expected_url = (
+            u'http://nohost/plone/ordnungssystem/fuhrung'
+            u'/vertrage-und-vereinbarungen/dossier-1/document-29'
+            u'/bumblebee-open-pdf?filename=GEVER%20-%20%C3%9Cbernahme.pdf'
+            )
+
+        self.assertEqual(expected_url, view.get_open_as_pdf_url())
 
 
 class TestMailOverview(IntegrationTestCase):


### PR DESCRIPTION
This PR exposes  document/mail actions in the `@actions` endpoint. It adds a new actions category `file_actions`.

We attempt to address the concerns of **availability** and **visibility** separately.
The logic for the availability of document actions are placed in adapters implementing `IFileActions`. Most of the logic was available in `ActionButtonRendererMixin` or in one of the bumblebee things and is moved into the new classes to clearly split up availability from rendering. The `@actions` endpoint returns all **available** actions. 

**Visibility** is handled by the view subclassing `ActionButtonRendererMixin` and is considered a separate additional layer on top of availability. This means that some actions will not be shown by the view even though they would be available.

Some general remarks:
- As the actions currently only answer availabilty and we do not use the additional data they provide (title, target url) we currently do not fetch the actions while rendering the macro but instead directly rely on `FileActionAvailabilityMixin`.
- The template in https://github.com/4teamwork/opengever.core/blob/b6cb3cda15cc2ee4bf9609f9b7dc330873b619f6/opengever/base/browser/templates/macros.pt contained a lot of nested logic. This has been moved to `ActionButtonRendererMixin` and `IFileActions`. The action rendering macro is now almost flat, this should improve readability.
- I have discovered some more actions in `IBumblebeeOverlay` and `BumblebeeOverlayBaseView` and also included them in `@actions`. I had to remove some duplication and dead code (which died with https://github.com/4teamwork/opengever.core/pull/2744). Most of the rendering now happens in `VisibleActionButtonRendererMixin` and the subclasses only override certain aspects, if necessary.
- The actions endpoint does not return the url of the action, which is kind of stupid. This means that actions that have an id that is different from their url, cannot be used as returned by the actions endpoint
- We have several actions that cannot be called simply with an url. For those at least, the frontend will have to know what to do when the action is available.
- In the current frontend, we display different titles for the checkout actions depending on whether the document is already checked out. This is be handled by registering a different action for each case.

_Despite the good test coverage i have attempted to also manually verify the actions are still rendered correctly with all possible permutations. The permutation matrix is quite high as we render the actions in various places (listing tooltip, listing overlay, overview, versions, ...) and there are states (checked out, locked, closed dossier) which have an effect on the actions, too._

Closes #5786.

⚠️ Issues discovered but not addressed with this PR. Might be something to discuss in our review:
- Currently we use the request to decide whether we are on a versioned context. I would prefer if we could somehow annotate the documents-versions loaded from a repository for the time of one request. Maybe the `Versioner` in https://github.com/4teamwork/opengever.core/blob/b6cb3cda15cc2ee4bf9609f9b7dc330873b619f6/opengever/document/versioner.py could set a volatile attribute on a document after it is retrieved from the repository?
- The revert to version action was always shown, even when not possible to execute. I have changed the condition to make the action unavailable when it can't be performed. There is currently no placeholder in such cases and the action in the overlay will disappear.

## Checkliste

_Zutreffendes soll angehakt stehengelassen werden._

- [x] Gibt es neue Funktionalität mit einem `Dokument`? Funktioniert das auch mit einem `Mail`?
- [x] Profil angepasst? Sind UpgradeSteps vorhanden/nötig?:
- [x] Gibt es neue Übersetzungen?
  - [x] Sind alle msg-Strings in Übersetzungen Unicode?
  - [x] Wird die richtige i18n-domain verwendet (Copy-Paste Fehler sind hier häufig)?
- [x] Changelog-Eintrag vorhanden/nötig?
