### PR TITLE
Testing: Add disposition with SIP to fixture.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -572,6 +572,7 @@ Objects
         - self.closed_meeting_dossier
         - self.decided_meeting_dossier
         - self.disposition
+        - self.disposition_with_sip
         - self.dossier
           - self.document
           - self.draft_proposal
@@ -608,6 +609,7 @@ Objects
           - self.meeting_document
           - self.meeting_task
             - self.meeting_subtask
+        - self.offered_dossier_for_sip
         - self.offered_dossier_to_archive
         - self.offered_dossier_to_destroy
         - self.protected_dossier

--- a/opengever/base/tests/test_reference_prefix.py
+++ b/opengever/base/tests/test_reference_prefix.py
@@ -75,4 +75,4 @@ class TestReferencePrefixAdapter(IntegrationTestCase):
         dossier = create(Builder('dossier').within(self.leaf_repofolder))
 
         self.assertEquals(u'235', self.adapter.get_next_number(repository))
-        self.assertEquals(u'14', self.adapter.get_next_number(dossier))
+        self.assertEquals(u'15', self.adapter.get_next_number(dossier))

--- a/opengever/bundle/tests/test_oggbundle_pipeline.py
+++ b/opengever/bundle/tests/test_oggbundle_pipeline.py
@@ -290,7 +290,7 @@ class TestOggBundlePipeline(IntegrationTestCase):
         return self.assert_dossier_hanspeter_created(parent)
 
     def assert_dossier_peter_schneider_created(self, parent):
-        dossier_peter = parent.get('dossier-20')
+        dossier_peter = parent.get('dossier-21')
         self.assertEqual(
             u'Vreni Meier ist ein Tausendsassa',
             IDossier(dossier_peter).comments)
@@ -308,7 +308,7 @@ class TestOggBundlePipeline(IntegrationTestCase):
             index_data_for(dossier_peter)[GUID_INDEX_NAME])
 
     def assert_dossier_vreni_created(self, parent):
-        dossier = self.leaf_repofolder.get('dossier-22')
+        dossier = self.leaf_repofolder.get('dossier-23')
         self.assertEqual(u'Vreni Meier ist ein Tausendsassa',
                          IDossier(dossier).comments)
         self.assertEqual(tuple(), IDossier(dossier).keywords)
@@ -324,7 +324,7 @@ class TestOggBundlePipeline(IntegrationTestCase):
             index_data_for(dossier)[GUID_INDEX_NAME])
 
     def assert_dossier_hanspeter_created(self, parent):
-        dossier_peter = parent.get('dossier-21')
+        dossier_peter = parent.get('dossier-22')
         self.assertEqual(
             u'archival worthy',
             ILifeCycle(dossier_peter).archival_value)

--- a/opengever/disposition/tests/test_byline.py
+++ b/opengever/disposition/tests/test_byline.py
@@ -10,7 +10,7 @@ class TestDispositionByline(IntegrationTestCase):
         browser.open(self.disposition)
 
         self.assertEquals(
-            ['Created: Aug 31, 2016 09:05 PM',
+            ['Created: Aug 31, 2016 09:07 PM',
              'State: disposition-state-in-progress',
-             'Last modified: Aug 31, 2016 09:05 PM'],
+             'Last modified: Aug 31, 2016 09:07 PM'],
             browser.css('#plone-document-byline li').text)

--- a/opengever/disposition/tests/test_disposition.py
+++ b/opengever/disposition/tests/test_disposition.py
@@ -25,7 +25,8 @@ class TestDisposition(IntegrationTestCase):
         self.login(self.records_manager)
         disposition = create(Builder('disposition'))
         self.assertEquals('disposition-1', self.disposition.getId())
-        self.assertEquals('disposition-2', disposition.getId())
+        self.assertEquals('disposition-2', self.disposition_with_sip.getId())
+        self.assertEquals('disposition-3', disposition.getId())
 
     @browsing
     def test_title_is_prefilled_with_default_suggestion(self, browser):

--- a/opengever/disposition/tests/test_excel_export.py
+++ b/opengever/disposition/tests/test_excel_export.py
@@ -50,7 +50,7 @@ class TestDispositionExcelExport(IntegrationTestCase):
                 [cell.value for cell in rows[1]])
 
             self.assertEquals(
-                [u'Client1 1.1 / 13', u'Hans Baumann', datetime(2000, 1, 1, 0, 0),
+                [u'Client1 1.1 / 14', u'Hans Baumann', datetime(2000, 1, 1, 0, 0),
                  datetime(2000, 1, 15, 0, 0), u'unchecked',
                  u'not archival worthy', u'In Absprache mit ARCH.',
                  u'not archival worthy'],

--- a/opengever/disposition/tests/test_history.py
+++ b/opengever/disposition/tests/test_history.py
@@ -216,12 +216,12 @@ class TestHistoryListingInOverview(IntegrationTestCase):
 
         self.assertEquals(
             ["Client1 1.1 / 12 Hannah Baufrau Don't archive",
-             "Client1 1.1 / 13 Hans Baumann Don't archive"],
+             "Client1 1.1 / 14 Hans Baumann Don't archive"],
             appraise.css('li').text)
 
         self.assertEquals(
             ['Client1 1.1 / 12 Hannah Baufrau Archive',
-             "Client1 1.1 / 13 Hans Baumann Don't archive"],
+             "Client1 1.1 / 14 Hans Baumann Don't archive"],
             add.css('li').text)
 
     @browsing

--- a/opengever/disposition/tests/test_listing.py
+++ b/opengever/disposition/tests/test_listing.py
@@ -50,17 +50,21 @@ class TestDispositionListing(IntegrationTestCase):
         browser.open(self.repository_root, view='tabbedview_view-dispositions')
         self.assertEquals(
             [{'': '',
-              'Sequence Number': '2',
-              'Title': 'Angebot FD 1.2.2003',
-              'Review state': 'disposition-state-appraised'},
-             {'': '',
+              'Review state': 'disposition-state-appraised',
               'Sequence Number': '3',
-              'Title': 'Angebot FD 1.2.1995',
-              'Review state': 'disposition-state-disposed'},
+              'Title': 'Angebot FD 1.2.2003'},
+             {'': '',
+              'Review state': 'disposition-state-disposed',
+              'Sequence Number': '4',
+              'Title': 'Angebot FD 1.2.1995'},
              {'': '',
               'Review state': 'disposition-state-in-progress',
               'Sequence Number': '1',
-              'Title': 'Angebot 31.8.2016'}],
+              'Title': 'Angebot 31.8.2016'},
+             {'': '',
+              'Review state': 'disposition-state-disposed',
+              'Sequence Number': '2',
+              'Title': 'Angebot 30.12.1997'}],
             browser.css('.listing').first.dicts())
 
     @browsing
@@ -95,18 +99,21 @@ class TestDispositionListing(IntegrationTestCase):
         self.disposition.setTitle("In Progress")
         self.disposition.reindexObject()
 
+        self.disposition_with_sip.setTitle("Disposed")
+        self.disposition_with_sip.reindexObject()
+
         browser.open(self.leaf_repofolder, view='tabbedview_view-dispositions')
         rows = browser.css('.listing').first.dicts()
 
         self.assertItemsEqual(
-            ['In Progress', 'Appraised', 'Disposed', 'Disposed'],
+            ['In Progress', 'Appraised', 'Disposed', 'Disposed', 'Disposed'],
             [row.get('Title') for row in rows])
 
         browser.open(self.leaf_repofolder, view='tabbedview_view-dispositions',
                      data={'disposition_state_filter': 'filter_all'})
         rows = browser.css('.listing').first.dicts()
         self.assertItemsEqual(
-            ['In Progress', 'Appraised', 'Disposed', 'Disposed', 'Closed'],
+            ['In Progress', 'Appraised', 'Disposed', 'Disposed', 'Disposed', 'Closed'],
             [row.get('Title') for row in rows])
 
 
@@ -146,7 +153,7 @@ class TestDestroyedDossierListing(BaseLatexListingTest):
         self.assert_row_values(
             ['Client1 1.1 / 12', 'Hannah Baufrau', 'Yes'], rows[0])
         self.assert_row_values(
-            ['Client1 1.1 / 13', 'Hans Baumann', 'No'], rows[1])
+            ['Client1 1.1 / 14', 'Hans Baumann', 'No'], rows[1])
 
 
 class TestDispositionHistoryListing(BaseLatexListingTest):
@@ -177,7 +184,7 @@ class TestDispositionHistoryListing(BaseLatexListingTest):
             ['Nov 06, 2016 12:33 PM', 'Flucht Ramon (ramon.flucht)', 'disposition-transition-dispose'],
             ['Nov 06, 2016 12:33 PM', 'Flucht Ramon (ramon.flucht)', 'disposition-transition-appraise'],
             ['Nov 01, 2016 11:00 AM', 'Flucht Ramon (ramon.flucht)', 'Disposition edited'],
-            ['Aug 31, 2016 07:05 PM', 'Flucht Ramon (ramon.flucht)', 'Disposition added']]
+            ['Aug 31, 2016 07:07 PM', 'Flucht Ramon (ramon.flucht)', 'Disposition added']]
 
         for row, expected_row in zip(rows, expected_rows):
             self.assert_row_values(expected_row, row)

--- a/opengever/disposition/tests/test_overview.py
+++ b/opengever/disposition/tests/test_overview.py
@@ -21,7 +21,7 @@ class TestDispositionOverview(IntegrationTestCase):
 
         self.assertEquals(
             ['Client1 1.1 / 12 Hannah Baufrau',
-             'Client1 1.1 / 13 Hans Baumann'],
+             'Client1 1.1 / 14 Hans Baumann'],
             browser.css('.dispositions .title').text)
 
     @browsing
@@ -229,7 +229,7 @@ class TestDispositionOverview(IntegrationTestCase):
             ['Inactive Dossiers', 'Archive'],
             inactive_list.css('.label h3').text)
         self.assertEquals(
-            ['Client1 1.1 / 13 Hans Baumann'],
+            ['Client1 1.1 / 14 Hans Baumann'],
             inactive_list.css('.dispositions h3.title').text)
 
     @browsing
@@ -307,7 +307,7 @@ class TestClosedDispositionOverview(IntegrationTestCase):
         browser.open(self.disposition, view='overview')
 
         self.assertEquals(
-            ['Client1 1.1 / 12', 'Hannah Baufrau', 'Client1 1.1 / 13', 'Hans Baumann'],
+            ['Client1 1.1 / 12', 'Hannah Baufrau', 'Client1 1.1 / 14', 'Hans Baumann'],
             browser.css('h3.title span').text)
 
         self.assertEquals([], browser.css('h3.title a'))

--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -146,6 +146,7 @@ class OpengeverContentFixture(object):
                 self.create_offered_dossiers()
             with self.login(self.records_manager):
                 self.create_disposition()
+                self.create_disposition_with_sip()
 
     def __call__(self):
         return self._lookup_table
@@ -1399,6 +1400,19 @@ class OpengeverContentFixture(object):
             .in_state('dossier-state-resolved')
             ))
 
+        self.offered_dossier_for_sip = self.register('offered_dossier_for_sip', create(
+            Builder('dossier')
+            .within(self.repofolder00)
+            .titled(u'Dossier for SIP')
+            .having(
+                start=date(1997, 1, 1),
+                end=date(1997, 1, 31),
+                responsible=self.dossier_responsible.getId(),
+                archival_value=ARCHIVAL_VALUE_WORTHY,
+                )
+            .in_state('dossier-state-resolved')
+            ))
+
         self.offered_dossier_to_destroy = self.register('offered_dossier_to_destroy', create(
             Builder('dossier')
             .within(self.repofolder00)
@@ -1421,6 +1435,18 @@ class OpengeverContentFixture(object):
             .having(dossiers=[self.offered_dossier_to_archive,
                               self.offered_dossier_to_destroy])
             .within(self.repofolder00)))
+
+    @staticuid()
+    def create_disposition_with_sip(self):
+        self.disposition_with_sip = self.register('disposition_with_sip', create(
+            Builder('disposition')
+            .titled(u'Angebot 30.12.1997')
+            .having(dossiers=[self.offered_dossier_for_sip])
+            .in_state('disposition-state-appraised')
+            .within(self.repofolder00)))
+
+        api.content.transition(self.disposition_with_sip,
+                               transition='disposition-transition-dispose')
 
     @staticuid()
     def create_shadow_document(self):


### PR DESCRIPTION
This adds a disposition to the fixture which is in state `disposition-state-disposed` and has a SIP package, ready to be delivered.

This is necessary because transports (which will be implemented as part of #5167) need to access the underlying blob on the filesystem. The blob will only have a stable filesystem location once it's committed though. Because in our `IntegrationTestCase` we only emulate `transaction.commit()`, but never actually do a hard commit, this requires the blob to have already been created as part of the fixture to be actually committed and accessible. 

## Checkliste

- [x] Aktualisierung Dokumentation vorhanden/nötig?
