### PR TITLE
Implement SIP delivery via filesystem

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -10,6 +10,7 @@ Changelog
 2019.4.0rc1 (2019-08-08)
 ------------------------
 
+- Implement SIP delivery via FilesystemTransport. [lgraf]
 - Disallow deleting repository folders and roots except from the RepositoryDeleter. [njohner]
 - Expose document actions in @actions endpoint in separate file_actions category. [njohner, deiferni]
 - Nightly jobs: Add short -f option as alias for --force. [lgraf]

--- a/docs/public/admin-manual/aussonderung.rst
+++ b/docs/public/admin-manual/aussonderung.rst
@@ -89,6 +89,11 @@ Aktion ``Ablieferungspaket herunterladen`` zur Verfügung, welches den eCH-0160
 Export für die enthaltenen Dossiers mit einer positiven Bewertung zum Download
 anbietet.
 
+Wenn in GEVER ein Ablieferungsmechanismus aktiviert und
+konfiguriert wurde (durch 4teamwork), kann das Ablieferungspaket auch direkt
+durch einen nächtlichen Job in ein definiertes Verzeichnis oder ein gemountetes
+Share abgelegt werden.
+
 Enthält eine Angebot nur Dossier die nicht ans Archiv abgeliefert werden müssen, so können die Schritte 3 und 4 übersprungen werden und die Dossiers direkt ausgesondert und das Angebot abgeschlossen werden.
 
 

--- a/opengever/base/locales/de/LC_MESSAGES/plone.po
+++ b/opengever/base/locales/de/LC_MESSAGES/plone.po
@@ -148,7 +148,7 @@ msgid "disposition-state-closed"
 msgstr "Abgeschlossen"
 
 msgid "disposition-state-disposed"
-msgstr "Abgeliefert"
+msgstr "In Ablieferung"
 
 msgid "disposition-state-in-progress"
 msgstr "In Bearbeitung"

--- a/opengever/base/locales/fr/LC_MESSAGES/plone.po
+++ b/opengever/base/locales/fr/LC_MESSAGES/plone.po
@@ -148,7 +148,7 @@ msgid "disposition-state-closed"
 msgstr "Clôturé"
 
 msgid "disposition-state-disposed"
-msgstr "Livré"
+msgstr ""
 
 msgid "disposition-state-in-progress"
 msgstr "En cours"

--- a/opengever/base/locales/fr/LC_MESSAGES/plone.po
+++ b/opengever/base/locales/fr/LC_MESSAGES/plone.po
@@ -148,7 +148,7 @@ msgid "disposition-state-closed"
 msgstr "Clôturé"
 
 msgid "disposition-state-disposed"
-msgstr ""
+msgstr "En cours de livraison"
 
 msgid "disposition-state-in-progress"
 msgstr "En cours"

--- a/opengever/core/profiles/default/registry.xml
+++ b/opengever/core/profiles/default/registry.xml
@@ -60,6 +60,9 @@
     <value>{"dayOfWeekStart": 1, "scrollMonth": false, "scrollTime": false, "scrollInput": false}</value>
   </record>
 
+  <!-- DISPOSITION -->
+  <records interface="opengever.disposition.interfaces.IFilesystemTransportSettings" />
+
   <!-- DOCUMENT -->
   <records interface="opengever.document.interfaces.IDocumentType" />
   <records interface="opengever.document.interfaces.IDocumentSettings" />

--- a/opengever/core/upgrades/20190730111610_add_i_filesystem_transport_settings_registry_record/registry.xml
+++ b/opengever/core/upgrades/20190730111610_add_i_filesystem_transport_settings_registry_record/registry.xml
@@ -1,0 +1,6 @@
+<registry>
+
+  <!-- DISPOSITION -->
+  <records interface="opengever.disposition.interfaces.IFilesystemTransportSettings" />
+
+</registry>

--- a/opengever/core/upgrades/20190730111610_add_i_filesystem_transport_settings_registry_record/upgrade.py
+++ b/opengever/core/upgrades/20190730111610_add_i_filesystem_transport_settings_registry_record/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddIFilesystemTransportSettingsRegistryRecord(UpgradeStep):
+    """Add IFilesystemTransportSettings registry record.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/disposition/browser/ech0160.py
+++ b/opengever/disposition/browser/ech0160.py
@@ -65,6 +65,6 @@ class ECH0160DownloadView(BrowserView):
             return self.request.RESPONSE.redirect(self.context.absolute_url())
 
         sip_package = self.context.get_sip_package()
-        set_headers(sip_package, self.request.response,
-                    u'{}.zip'.format(self.context.get_sip_name()))
+        filename = self.context.get_sip_filename()
+        set_headers(sip_package, self.request.response, filename)
         return stream_data(sip_package)

--- a/opengever/disposition/browser/overview.py
+++ b/opengever/disposition/browser/overview.py
@@ -1,6 +1,7 @@
 from opengever.base.behaviors.lifecycle import ARCHIVAL_VALUE_UNWORTHY
 from opengever.base.behaviors.lifecycle import ILifeCycle
 from opengever.disposition import _
+from opengever.disposition.delivery import DeliveryScheduler
 from opengever.disposition.interfaces import IHistoryStorage
 from plone import api
 from plone.protect.utils import addTokenToUrl
@@ -65,6 +66,13 @@ class DispositionOverview(BrowserView):
         infos = wftool.listActionInfos(object=self.context, check_condition=False)
         return infos
 
+    def get_delivery_status_infos(self):
+        """Get delivery status infos in a template friendly format.
+        """
+        statuses = DeliveryScheduler(self.context).get_statuses()
+        status_infos = [{'name': n, 'status': s} for n, s in statuses.items()]
+        return status_infos
+
     def get_actions(self):
         return [
             {'id': 'export_appraisal_list',
@@ -90,7 +98,7 @@ class DispositionOverview(BrowserView):
     def sip_download_available(self):
         if api.user.has_permission(
             'opengever.disposition: Download SIP Package',
-            obj=self.context):
+                obj=self.context):
 
             return self.context.has_sip_package()
 

--- a/opengever/disposition/browser/overview.py
+++ b/opengever/disposition/browser/overview.py
@@ -1,6 +1,7 @@
 from opengever.base.behaviors.lifecycle import ARCHIVAL_VALUE_UNWORTHY
 from opengever.base.behaviors.lifecycle import ILifeCycle
 from opengever.disposition import _
+from opengever.disposition.delivery import DELIVERY_STATUS_LABELS
 from opengever.disposition.delivery import DeliveryScheduler
 from opengever.disposition.interfaces import IHistoryStorage
 from plone import api
@@ -8,6 +9,7 @@ from plone.protect.utils import addTokenToUrl
 from Products.CMFPlone.CatalogTool import num_sort_regex
 from Products.CMFPlone.CatalogTool import zero_fill
 from Products.Five.browser import BrowserView
+from zope.i18n import translate
 
 
 def sort_on_sortable_title(item):
@@ -67,10 +69,12 @@ class DispositionOverview(BrowserView):
         return infos
 
     def get_delivery_status_infos(self):
-        """Get delivery status infos in a template friendly format.
+        """Get translated delivery status infos in a template friendly format.
         """
         statuses = DeliveryScheduler(self.context).get_statuses()
-        status_infos = [{'name': n, 'status': s} for n, s in statuses.items()]
+        status_infos = [
+            {'name': n, 'status': translate(DELIVERY_STATUS_LABELS[s], context=self.request)}
+            for n, s in statuses.items()]
         return status_infos
 
     def get_actions(self):

--- a/opengever/disposition/browser/templates/overview.pt
+++ b/opengever/disposition/browser/templates/overview.pt
@@ -38,9 +38,9 @@
 
             <tal:deliverystatus tal:condition="python:view.get_current_state() == 'disposition-state-disposed'">
                 <h3 class="metadata" i18n:translate="label_delivery_status">Delivery Status</h3>
-                <table class="listing" id="delivery-status">
-                    <tr tal:repeat="status_info python:view.get_delivery_status_infos()">
-                        <td><a tal:content="status_info/name" /></td>
+                <table class="listing" id="delivery-status" tal:define="status_infos view/get_delivery_status_infos">
+                    <tr tal:repeat="status_info status_infos">
+                        <td tal:condition="python: len(status_infos) > 1" tal:content="status_info/name" />
                         <td tal:content="status_info/status"/>
                     </tr>
                 </table>

--- a/opengever/disposition/browser/templates/overview.pt
+++ b/opengever/disposition/browser/templates/overview.pt
@@ -36,6 +36,17 @@
               </div>
             </div>
 
+            <tal:deliverystatus tal:condition="python:view.get_current_state() == 'disposition-state-disposed'">
+                <h3 class="metadata" i18n:translate="label_delivery_status">Delivery Status</h3>
+                <table class="listing" id="delivery-status">
+                    <tr tal:repeat="status_info python:view.get_delivery_status_infos()">
+                        <td><a tal:content="status_info/name" /></td>
+                        <td tal:content="status_info/status"/>
+                    </tr>
+                </table>
+
+            </tal:deliverystatus>
+
             <div class="metadata">
               <h3 class="metadata" i18n:translate="label_metadata">Metadata</h3>
               <div>

--- a/opengever/disposition/browser/templates/overview.pt
+++ b/opengever/disposition/browser/templates/overview.pt
@@ -49,12 +49,16 @@
 
             <div class="metadata">
               <h3 class="metadata" i18n:translate="label_metadata">Metadata</h3>
-              <div>
 
+              <div>
                 <span class="label" i18n:translate="label_transfer_number">Transfer number</span>
                 <span id="transfer-number-value" tal:content="context/transfer_number"></span>
                 <a href="#" class="edit edit_transfer_number" tal:condition="view/is_transfer_number_editable" i18n:translate="label_edit">Edit</a>
+              </div>
 
+              <div>
+                <span class="label" i18n:translate="label_sip_filename">SIP Filename</span>
+                <span tal:content="context/get_sip_filename"></span>
               </div>
 
             </div>

--- a/opengever/disposition/configure.zcml
+++ b/opengever/disposition/configure.zcml
@@ -25,6 +25,11 @@
       name="filesystem"
       />
 
+  <adapter
+      factory=".nightly_jobs.NightlySIPDelivery"
+      name="deliver-sip-packages"
+      />
+
   <genericsetup:registerProfile
       name="default"
       title="opengever.disposition"

--- a/opengever/disposition/configure.zcml
+++ b/opengever/disposition/configure.zcml
@@ -20,6 +20,11 @@
   <adapter factory=".history.HistoryStorage" />
   <adapter factory=".validators.OfferedDossiersValidator" />
 
+  <adapter
+      factory=".delivery.FilesystemTransport"
+      name="filesystem"
+      />
+
   <genericsetup:registerProfile
       name="default"
       title="opengever.disposition"

--- a/opengever/disposition/configure.zcml
+++ b/opengever/disposition/configure.zcml
@@ -7,11 +7,7 @@
 
   <i18n:registerTranslations directory="locales" />
 
-  <permission id="opengever.disposition.AddDisposition" title="opengever.disposition: Add disposition" />
-
-  <permission id="opengever.disposition.DownloadSIPPackage" title="opengever.disposition: Download SIP Package" />
-
-  <permission id="opengever.disposition.EditTransferNumber" title="opengever.disposition: Edit transfer number" />
+  <include file="permissions.zcml" />
 
   <include package=".browser" />
   <include package=".viewlets" />

--- a/opengever/disposition/delivery.py
+++ b/opengever/disposition/delivery.py
@@ -1,4 +1,5 @@
 from opengever.base.sentry import maybe_report_exception
+from opengever.disposition import _
 from opengever.disposition.interfaces import IDisposition
 from opengever.disposition.interfaces import IFilesystemTransportSettings
 from opengever.disposition.interfaces import ISIPTransport
@@ -27,6 +28,12 @@ TRANSPORT_STATUSES_KEY = 'opengever.disposition.delivery.transport_statuses'
 STATUS_SCHEDULED = 'status_scheduled'
 STATUS_SUCCESS = 'status_success'
 STATUS_FAILED = 'status_failed'
+
+DELIVERY_STATUS_LABELS = {
+    STATUS_SCHEDULED: _(u'label_delivery_status_scheduled', default=u'Scheduled for delivery'),
+    STATUS_SUCCESS: _(u'label_delivery_status_success', default=u'Delivered successfully'),
+    STATUS_FAILED: _(u'label_delivery_status_failed', default=u'Delivery failed'),
+}
 
 
 class DeliveryScheduler(object):

--- a/opengever/disposition/delivery.py
+++ b/opengever/disposition/delivery.py
@@ -1,0 +1,139 @@
+from opengever.base.sentry import maybe_report_exception
+from opengever.disposition.interfaces import ISIPTransport
+from persistent.mapping import PersistentMapping
+from ZODB.POSException import ConflictError
+from zope.annotation import IAnnotations
+from zope.component import getAdapters
+from zope.globalrequest import getRequest
+import logging
+import sys
+
+
+TRANSPORT_STATUSES_KEY = 'opengever.disposition.delivery.transport_statuses'
+
+STATUS_SCHEDULED = 'status_scheduled'
+STATUS_SUCCESS = 'status_success'
+STATUS_FAILED = 'status_failed'
+
+
+class DeliveryScheduler(object):
+    """The DeliveryScheduler takes care of scheduling SIP packages for delivery,
+    performing scheduled deliveries by delegating to the respective transports,
+    and tracking delivery statuses (per transport).
+    """
+
+    def __init__(self, disposition, parent_logger=None):
+        self.disposition = disposition
+
+        # When run via nightly job, the NightlyJobRunner's logger will be
+        # passed in, so that the DeliveryScheduler's and the transporter's
+        # log messages also can be logged to the nightly job logfile.
+        if not parent_logger:
+            parent_logger = logging.root
+
+        self.parent_logger = parent_logger
+        self.logger = logging.getLogger('opengever.disposition.delivery')
+        self.logger.setLevel(logging.INFO)
+        self.logger.parent = self.parent_logger
+
+    def schedule_delivery(self, force=False):
+        """Schedule the disposition's SIP for delivery with enabled transports.
+
+        If `force` is `True`, the SIP will be rescheduled for delivery with
+        all enabled transports, regardless of whether there already were any
+        (successful or failed) delivery attempts.
+
+        Otherwise, the SIP will be scheduled for delivery only for (enabled)
+        transports that have not made a delivery attempt yet.
+        """
+        statuses = self.get_statuses(create_if_missing=True)
+        for name, transport in self.get_transports():
+            # Only schedule for enabled transports
+            if not transport.is_enabled():
+                self.logger.info("Skip: Transport '%s' is disabled" % name)
+                continue
+
+            current_status = statuses.get(name)
+
+            # Only schedule if no delivery was attempted yet
+            # (Except when forcefully rescheduling)
+            if force or current_status is None:
+                self.logger.info("Scheduling delivery for transport: '%s'" % name)
+                statuses[name] = STATUS_SCHEDULED
+
+    def is_scheduled_for_delivery_with(self, name):
+        """Determine wheter this disposition is scheduled for delivery with
+        transport `name`.
+        """
+        transport_status = self.get_statuses().get(name)
+        return transport_status == STATUS_SCHEDULED
+
+    def deliver(self):
+        """Perform delivery of this disposition's SIP by delegating to transports.
+        """
+        for name, transport in self.get_transports():
+            if not transport.is_enabled():
+                self.logger.info("Skip: Transport '%s' is disabled" % name)
+                continue
+
+            if not self.is_scheduled_for_delivery_with(name):
+                self.logger.info("Skip: Not scheduled for delivery with transport '%s'" % name)
+                continue
+
+            self.logger.info("Delivering using transport '%s'" % name)
+            try:
+                transport.deliver()
+                self.mark_delivery_success(name)
+                self.logger.info("Successful delivery using transport '%s'" % name)
+
+            except ConflictError:
+                raise
+
+            except Exception as exc:
+                self.logger.info("Delivery with transport '%s' failed: %r" % (name, exc))
+                self.mark_delivery_failure(name)
+                e_type, e_value, tb = sys.exc_info()
+                maybe_report_exception(self.disposition, getRequest(), e_type, e_value, tb)
+
+    def get_statuses(self, create_if_missing=False):
+        """Get the mapping of delivery statuses by transport.
+        """
+        ann = IAnnotations(self.disposition)
+        if TRANSPORT_STATUSES_KEY not in ann and create_if_missing:
+            ann[TRANSPORT_STATUSES_KEY] = PersistentMapping()
+        return ann.get(TRANSPORT_STATUSES_KEY, {})
+
+    def get_transports(self):
+        """Return a list of (name, transport) tuples of all transports.
+        """
+        transports = getAdapters(
+            [self.disposition, getRequest(), self.parent_logger],
+            ISIPTransport
+        )
+        return sorted(transports)
+
+    def mark_delivery_success(self, name):
+        """Mark the delivery as successful with the transport `name`.
+        """
+        statuses = self.get_statuses(create_if_missing=True)
+        statuses[name] = STATUS_SUCCESS
+
+    def mark_delivery_failure(self, name):
+        """Mark the delivery as failed with the transport `name`.
+        """
+        statuses = self.get_statuses(create_if_missing=True)
+        statuses[name] = STATUS_FAILED
+
+
+class BaseTransport(object):
+    """Base class for Transports that sets up proper logging.
+    """
+
+    def __init__(self, disposition, request, parent_logger):
+        self.disposition = disposition
+        self.request = request
+        self.parent_logger = parent_logger
+
+        self.log = logging.getLogger(self.__class__.__name__)
+        self.log.setLevel(logging.INFO)
+        self.log.parent = parent_logger

--- a/opengever/disposition/delivery.py
+++ b/opengever/disposition/delivery.py
@@ -74,6 +74,12 @@ class DeliveryScheduler(object):
                 self.logger.info("Scheduling delivery for transport: '%s'" % name)
                 statuses[name] = STATUS_SCHEDULED
 
+    def is_scheduled_for_delivery(self):
+        """Whether the disposition is scheduled for delivery with any transport.
+        """
+        statuses = self.get_statuses()
+        return any(s == STATUS_SCHEDULED for s in statuses.values())
+
     def is_scheduled_for_delivery_with(self, name):
         """Determine wheter this disposition is scheduled for delivery with
         transport `name`.

--- a/opengever/disposition/disposition.py
+++ b/opengever/disposition/disposition.py
@@ -20,7 +20,6 @@ from opengever.dossier.base import DOSSIER_STATES_OFFERABLE
 from opengever.dossier.behaviors.dossier import IDossier
 from opengever.ogds.base.utils import get_current_admin_unit
 from opengever.ogds.base.utils import ogds_service
-from path import Path
 from persistent.dict import PersistentDict
 from persistent.list import PersistentList
 from plone import api
@@ -37,14 +36,12 @@ from zipfile import ZIP_DEFLATED
 from zipfile import ZipFile
 from zope import schema
 from zope.annotation import IAnnotations
-from zope.annotation.interfaces import IAnnotations
 from zope.component import getUtility
 from zope.globalrequest import getRequest
 from zope.i18n import translate
 from zope.interface import alsoProvides
 from zope.interface import implements
 from zope.intid.interfaces import IIntIds
-import os
 
 DESTROY_PERMISSION = 'opengever.dossier: Destroy dossier'
 

--- a/opengever/disposition/disposition.py
+++ b/opengever/disposition/disposition.py
@@ -334,3 +334,6 @@ class Disposition(Container):
             name = u'{}_{}'.format(name, self.transfer_number)
 
         return name
+
+    def get_sip_filename(self):
+        return u'{}.zip'.format(self.get_sip_name())

--- a/opengever/disposition/disposition.py
+++ b/opengever/disposition/disposition.py
@@ -12,6 +12,7 @@ from opengever.base.security import elevated_privileges
 from opengever.base.source import SolrObjPathSourceBinder
 from opengever.disposition import _
 from opengever.disposition.appraisal import IAppraisal
+from opengever.disposition.delivery import DeliveryScheduler
 from opengever.disposition.ech0160.sippackage import SIPPackage
 from opengever.disposition.interfaces import IDisposition
 from opengever.disposition.interfaces import IDuringDossierDestruction
@@ -311,6 +312,12 @@ class Disposition(Container):
         zip_file = self.create_zipfile(package)
         zip_file.seek(0)
         return NamedBlobFile(zip_file.read(), contentType='application/zip')
+
+    def schedule_sip_for_delivery(self):
+        DeliveryScheduler(self).schedule_delivery()
+
+    def is_scheduled_for_delivery(self):
+        return DeliveryScheduler(self).is_scheduled_for_delivery()
 
     def create_zipfile(self, package):
         tmpfile = TemporaryFile()

--- a/opengever/disposition/handlers.py
+++ b/opengever/disposition/handlers.py
@@ -25,6 +25,7 @@ def disposition_state_changed(context, event):
 
     if event.action == 'disposition-transition-dispose':
         context.store_sip_package()
+        context.schedule_sip_for_delivery()
 
     storage = IHistoryStorage(context)
     storage.add(event.action,

--- a/opengever/disposition/interfaces.py
+++ b/opengever/disposition/interfaces.py
@@ -16,3 +16,38 @@ class IDisposition(Interface):
 class IDuringDossierDestruction(Interface):
     """Request layer to indicate that dossiers are currently being destroyed.
     """
+
+
+class ISIPTransport(Interface):
+    """A specific transport for delivering SIP packages.
+
+    Transports will be registered as named adapters, and their name will be
+    used by the DeliveryScheduler to track delivery status.
+    """
+
+    def __init__(disposition, request, parent_logger):
+        """A transport adapts a disposition, request and a parent_logger.
+
+        The parent_logger should be used by the transport for logging. Either
+        by reparenting its own logger to it (which the BaseTransport class
+        does for convenience) or by using it directly to log.
+
+        This is so that e.g. during nightly jobs the transporter's log
+        messages can be captured and written to the logfile as well by the
+        NightlyJobRunner's log handler.
+        """
+
+    def deliver():
+        """Perform the delivery using the mechanism implemented by this transport.
+
+        Error signalling by the transport should be done using exceptions.
+        The return value of this method will be ignored.
+        """
+
+    def is_enabled():
+        """Whether this transport is enabled or not.
+
+        Only enabled transports will be invoked for scheduled deliveries, and
+        a delivery will also only be scheduled for a particular transport if
+        that transport is active that the time of SIP generation.
+        """

--- a/opengever/disposition/interfaces.py
+++ b/opengever/disposition/interfaces.py
@@ -1,3 +1,4 @@
+from zope import schema
 from zope.interface import Interface
 
 
@@ -49,5 +50,18 @@ class ISIPTransport(Interface):
 
         Only enabled transports will be invoked for scheduled deliveries, and
         a delivery will also only be scheduled for a particular transport if
-        that transport is active that the time of SIP generation.
+        that transport is active at the time of SIP generation.
         """
+
+
+class IFilesystemTransportSettings(Interface):
+
+    enabled = schema.Bool(
+        title=u'Enabled',
+        description=u'Whether FilesystemTransport is enabled or not.',
+        default=False)
+
+    destination_directory = schema.TextLine(
+        title=u'Destination directory',
+        description=u'Directory into which SIP packages should be delivered.',
+        default=u'')

--- a/opengever/disposition/locales/de/LC_MESSAGES/opengever.disposition.po
+++ b/opengever/disposition/locales/de/LC_MESSAGES/opengever.disposition.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-08-05 20:56+0000\n"
+"POT-Creation-Date: 2019-08-08 08:41+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -95,6 +95,21 @@ msgstr "Abbrechen"
 #: ./opengever/disposition/browser/templates/overview.pt
 msgid "label_delivery_status"
 msgstr "Ablieferungsstatus"
+
+#. Default: "Delivery failed"
+#: ./opengever/disposition/delivery.py
+msgid "label_delivery_status_failed"
+msgstr "Zustellung fehlgeschlagen"
+
+#. Default: "Scheduled for delivery"
+#: ./opengever/disposition/delivery.py
+msgid "label_delivery_status_scheduled"
+msgstr "Zustellung geplant"
+
+#. Default: "Delivered successfully"
+#: ./opengever/disposition/delivery.py
+msgid "label_delivery_status_success"
+msgstr "Erfolgreich zugestellt"
 
 #. Default: "Details:"
 #: ./opengever/disposition/browser/templates/overview.pt

--- a/opengever/disposition/locales/de/LC_MESSAGES/opengever.disposition.po
+++ b/opengever/disposition/locales/de/LC_MESSAGES/opengever.disposition.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-07-25 14:32+0000\n"
+"POT-Creation-Date: 2019-08-05 20:56+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -90,6 +90,11 @@ msgstr "Archiviert"
 #: ./opengever/disposition/browser/templates/overview.pt
 msgid "label_cancel"
 msgstr "Abbrechen"
+
+#. Default: "Delivery Status"
+#: ./opengever/disposition/browser/templates/overview.pt
+msgid "label_delivery_status"
+msgstr "Ablieferungsstatus"
 
 #. Default: "Details:"
 #: ./opengever/disposition/browser/templates/overview.pt

--- a/opengever/disposition/locales/de/LC_MESSAGES/opengever.disposition.po
+++ b/opengever/disposition/locales/de/LC_MESSAGES/opengever.disposition.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-08-08 08:41+0000\n"
+"POT-Creation-Date: 2019-08-08 15:06+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -223,6 +223,11 @@ msgstr "Status"
 #: ./opengever/disposition/browser/templates/overview.pt
 msgid "label_save"
 msgstr "Speichern"
+
+#. Default: "SIP Filename"
+#: ./opengever/disposition/browser/templates/overview.pt
+msgid "label_sip_filename"
+msgstr "SIP Dateiname"
 
 #. Default: "Time"
 #: ./opengever/disposition/browser/removal_protocol.py

--- a/opengever/disposition/locales/fr/LC_MESSAGES/opengever.disposition.po
+++ b/opengever/disposition/locales/fr/LC_MESSAGES/opengever.disposition.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-08-05 20:56+0000\n"
+"POT-Creation-Date: 2019-08-08 08:41+0000\n"
 "PO-Revision-Date: 2018-05-22 10:09+0000\n"
 "Last-Translator: Niklaus Johner <Niklaus.johner@4teamwork.ch>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-disposition/fr/>\n"
@@ -96,6 +96,21 @@ msgstr "Annuler"
 #. Default: "Delivery Status"
 #: ./opengever/disposition/browser/templates/overview.pt
 msgid "label_delivery_status"
+msgstr ""
+
+#. Default: "Delivery failed"
+#: ./opengever/disposition/delivery.py
+msgid "label_delivery_status_failed"
+msgstr ""
+
+#. Default: "Scheduled for delivery"
+#: ./opengever/disposition/delivery.py
+msgid "label_delivery_status_scheduled"
+msgstr ""
+
+#. Default: "Delivered successfully"
+#: ./opengever/disposition/delivery.py
+msgid "label_delivery_status_success"
 msgstr ""
 
 #. Default: "Details:"

--- a/opengever/disposition/locales/fr/LC_MESSAGES/opengever.disposition.po
+++ b/opengever/disposition/locales/fr/LC_MESSAGES/opengever.disposition.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-08-08 08:41+0000\n"
+"POT-Creation-Date: 2019-08-08 15:06+0000\n"
 "PO-Revision-Date: 2018-05-22 10:09+0000\n"
 "Last-Translator: Niklaus Johner <Niklaus.johner@4teamwork.ch>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-disposition/fr/>\n"
@@ -225,6 +225,11 @@ msgstr "Etat"
 #: ./opengever/disposition/browser/templates/overview.pt
 msgid "label_save"
 msgstr "Enregistrer"
+
+#. Default: "SIP Filename"
+#: ./opengever/disposition/browser/templates/overview.pt
+msgid "label_sip_filename"
+msgstr ""
 
 #. Default: "Time"
 #: ./opengever/disposition/browser/removal_protocol.py

--- a/opengever/disposition/locales/fr/LC_MESSAGES/opengever.disposition.po
+++ b/opengever/disposition/locales/fr/LC_MESSAGES/opengever.disposition.po
@@ -96,22 +96,22 @@ msgstr "Annuler"
 #. Default: "Delivery Status"
 #: ./opengever/disposition/browser/templates/overview.pt
 msgid "label_delivery_status"
-msgstr ""
+msgstr "Etat de la livraison"
 
 #. Default: "Delivery failed"
 #: ./opengever/disposition/delivery.py
 msgid "label_delivery_status_failed"
-msgstr ""
+msgstr "Distribution échouée"
 
 #. Default: "Scheduled for delivery"
 #: ./opengever/disposition/delivery.py
 msgid "label_delivery_status_scheduled"
-msgstr ""
+msgstr "Distribution planifiée"
 
 #. Default: "Delivered successfully"
 #: ./opengever/disposition/delivery.py
 msgid "label_delivery_status_success"
-msgstr ""
+msgstr "Distribué avec succès"
 
 #. Default: "Details:"
 #: ./opengever/disposition/browser/templates/overview.pt
@@ -229,7 +229,7 @@ msgstr "Enregistrer"
 #. Default: "SIP Filename"
 #: ./opengever/disposition/browser/templates/overview.pt
 msgid "label_sip_filename"
-msgstr ""
+msgstr "Nom du fichier SIP"
 
 #. Default: "Time"
 #: ./opengever/disposition/browser/removal_protocol.py

--- a/opengever/disposition/locales/fr/LC_MESSAGES/opengever.disposition.po
+++ b/opengever/disposition/locales/fr/LC_MESSAGES/opengever.disposition.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-07-25 14:32+0000\n"
+"POT-Creation-Date: 2019-08-05 20:56+0000\n"
 "PO-Revision-Date: 2018-05-22 10:09+0000\n"
 "Last-Translator: Niklaus Johner <Niklaus.johner@4teamwork.ch>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-disposition/fr/>\n"
@@ -92,6 +92,11 @@ msgstr "Archivé"
 #: ./opengever/disposition/browser/templates/overview.pt
 msgid "label_cancel"
 msgstr "Annuler"
+
+#. Default: "Delivery Status"
+#: ./opengever/disposition/browser/templates/overview.pt
+msgid "label_delivery_status"
+msgstr ""
 
 #. Default: "Details:"
 #: ./opengever/disposition/browser/templates/overview.pt

--- a/opengever/disposition/locales/opengever.disposition.pot
+++ b/opengever/disposition/locales/opengever.disposition.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-08-05 20:56+0000\n"
+"POT-Creation-Date: 2019-08-08 08:41+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -97,6 +97,21 @@ msgstr ""
 #. Default: "Delivery Status"
 #: ./opengever/disposition/browser/templates/overview.pt
 msgid "label_delivery_status"
+msgstr ""
+
+#. Default: "Delivery failed"
+#: ./opengever/disposition/delivery.py
+msgid "label_delivery_status_failed"
+msgstr ""
+
+#. Default: "Scheduled for delivery"
+#: ./opengever/disposition/delivery.py
+msgid "label_delivery_status_scheduled"
+msgstr ""
+
+#. Default: "Delivered successfully"
+#: ./opengever/disposition/delivery.py
+msgid "label_delivery_status_success"
 msgstr ""
 
 #. Default: "Details:"

--- a/opengever/disposition/locales/opengever.disposition.pot
+++ b/opengever/disposition/locales/opengever.disposition.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-07-25 14:32+0000\n"
+"POT-Creation-Date: 2019-08-05 20:56+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -92,6 +92,11 @@ msgstr ""
 #. Default: "Cancel"
 #: ./opengever/disposition/browser/templates/overview.pt
 msgid "label_cancel"
+msgstr ""
+
+#. Default: "Delivery Status"
+#: ./opengever/disposition/browser/templates/overview.pt
+msgid "label_delivery_status"
 msgstr ""
 
 #. Default: "Details:"

--- a/opengever/disposition/locales/opengever.disposition.pot
+++ b/opengever/disposition/locales/opengever.disposition.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-08-08 08:41+0000\n"
+"POT-Creation-Date: 2019-08-08 15:06+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -225,6 +225,11 @@ msgstr ""
 #. Default: "Save"
 #: ./opengever/disposition/browser/templates/overview.pt
 msgid "label_save"
+msgstr ""
+
+#. Default: "SIP Filename"
+#: ./opengever/disposition/browser/templates/overview.pt
+msgid "label_sip_filename"
 msgstr ""
 
 #. Default: "Time"

--- a/opengever/disposition/nightly_jobs.py
+++ b/opengever/disposition/nightly_jobs.py
@@ -1,0 +1,47 @@
+from opengever.disposition.delivery import DeliveryScheduler
+from opengever.disposition.interfaces import IDisposition
+from opengever.nightlyjobs.interfaces import INightlyJobProvider
+from plone import api
+from Products.CMFPlone.interfaces import IPloneSiteRoot
+from zope.component import adapter
+from zope.interface import implementer
+from zope.publisher.interfaces.browser import IBrowserRequest
+import logging
+
+
+@implementer(INightlyJobProvider)
+@adapter(IPloneSiteRoot, IBrowserRequest, logging.Logger)
+class NightlySIPDelivery(object):
+    """Nightly job provider that delivers SIP packages scheduled for delivery.
+    """
+
+    def __init__(self, context, request, logger):
+        self.context = context
+        self.request = request
+        self.logger = logger
+
+        self.catalog = api.portal.get_tool('portal_catalog')
+
+    def _get_dispositions_for_delivery(self):
+        """Get all dispositions that are in status 'disposed' and have a SIP.
+        """
+        query = dict(
+            object_provides=IDisposition.__identifier__,
+            review_state='disposition-state-disposed',
+        )
+        brains = self.catalog.unrestrictedSearchResults(query)
+        for brain in brains:
+            disposition = brain.getObject()
+            if disposition.is_scheduled_for_delivery():
+                yield disposition
+
+    def __iter__(self):
+        return iter(list(self._get_dispositions_for_delivery()))
+
+    def __len__(self):
+        return len(list(self._get_dispositions_for_delivery()))
+
+    def run_job(self, job, interrupt_if_necessary):
+        disposition = job
+        self.logger.info("Delivering SIP for %r" % disposition)
+        DeliveryScheduler(disposition, parent_logger=self.logger).deliver()

--- a/opengever/disposition/permissions.zcml
+++ b/opengever/disposition/permissions.zcml
@@ -1,0 +1,11 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    i18n_domain="opengever.disposition">
+
+  <permission id="opengever.disposition.AddDisposition" title="opengever.disposition: Add disposition" />
+
+  <permission id="opengever.disposition.DownloadSIPPackage" title="opengever.disposition: Download SIP Package" />
+
+  <permission id="opengever.disposition.EditTransferNumber" title="opengever.disposition: Edit transfer number" />
+
+</configure>

--- a/opengever/disposition/testing.py
+++ b/opengever/disposition/testing.py
@@ -1,12 +1,18 @@
 from opengever.disposition.delivery import BaseTransport
+from opengever.disposition.delivery import DeliveryScheduler
 from opengever.disposition.interfaces import IDisposition
+from opengever.disposition.interfaces import IFilesystemTransportSettings
 from opengever.disposition.interfaces import ISIPTransport
 from opengever.testing import IntegrationTestCase
 from opengever.testing.helpers import CapturingLogHandler
+from plone.registry.interfaces import IRegistry
 from zope.component import adapter
+from zope.component import getUtility
 from zope.interface import implementer
 from zope.publisher.interfaces.browser import IBrowserRequest
 import logging
+import shutil
+import tempfile
 
 
 @implementer(ISIPTransport)
@@ -50,3 +56,43 @@ class LogCapturingTestCase(IntegrationTestCase):
     def tearDown(self):
         super(LogCapturingTestCase, self).tearDown()
         logging.root.removeHandler(self.captured_log)
+
+
+class TestFilesystemTransportBase(LogCapturingTestCase):
+    """TestCase base class to base FilesystemTransport tests on.
+
+    This class
+    - provides temporary directory that is isolated between tests
+    - sets up log capturing
+    - enables the FilesystemTransport (disabled by default)
+    - makes sure a SIP is scheduled for delivery with the FS transport, like
+      it would be if the FS transport was enabled all along
+    """
+
+    def setUp(self):
+        super(TestFilesystemTransportBase, self).setUp()
+        # Keep track of temporary files we create
+        self.tempdir = tempfile.mkdtemp()
+
+        # Enable FilesystemTransport
+        registry = getUtility(IRegistry)
+        settings = registry.forInterface(IFilesystemTransportSettings)
+        settings.enabled = True
+        settings.destination_directory = self.tempdir.decode('utf-8')
+
+        # Scheduling deliveries would normally happen automatically after the
+        # 'disposition-transition-dispose' transition.
+        # However, because the disposition was created as part of the fixture,
+        # and the FilesystemTransport was disabled at that time, the SIP
+        # won't be scheduled for delivery yet.
+        with self.login(self.records_manager):
+            scheduler = DeliveryScheduler(self.disposition_with_sip)
+            scheduler.schedule_delivery()
+
+        self.captured_log.clear()
+
+    def tearDown(self):
+        super(TestFilesystemTransportBase, self).tearDown()
+        # Clean up all temporary files we created
+        shutil.rmtree(self.tempdir)
+        self.captured_log.clear()

--- a/opengever/disposition/testing.py
+++ b/opengever/disposition/testing.py
@@ -1,0 +1,52 @@
+from opengever.disposition.delivery import BaseTransport
+from opengever.disposition.interfaces import IDisposition
+from opengever.disposition.interfaces import ISIPTransport
+from opengever.testing import IntegrationTestCase
+from opengever.testing.helpers import CapturingLogHandler
+from zope.component import adapter
+from zope.interface import implementer
+from zope.publisher.interfaces.browser import IBrowserRequest
+import logging
+
+
+@implementer(ISIPTransport)
+@adapter(IDisposition, IBrowserRequest, logging.Logger)
+class DummyTransport(BaseTransport):
+
+    def deliver(self):
+        pass
+
+    def is_enabled(self):
+        return False
+
+
+class EnabledTransport(DummyTransport):
+
+    def is_enabled(self):
+        return True
+
+
+class DisabledTransport(DummyTransport):
+
+    def is_enabled(self):
+        return False
+
+
+class FailingTransport(EnabledTransport):
+
+    def deliver(self):
+        raise Exception('Boom')
+
+
+class LogCapturingTestCase(IntegrationTestCase):
+    """TestCase base class that allows to capture logged log records.
+    """
+
+    def setUp(self):
+        super(LogCapturingTestCase, self).setUp()
+        self.captured_log = CapturingLogHandler()
+        logging.root.addHandler(self.captured_log)
+
+    def tearDown(self):
+        super(LogCapturingTestCase, self).tearDown()
+        logging.root.removeHandler(self.captured_log)

--- a/opengever/disposition/tests/test_delivery.py
+++ b/opengever/disposition/tests/test_delivery.py
@@ -2,10 +2,17 @@ from opengever.disposition.delivery import DeliveryScheduler
 from opengever.disposition.delivery import STATUS_FAILED
 from opengever.disposition.delivery import STATUS_SCHEDULED
 from opengever.disposition.delivery import STATUS_SUCCESS
+from opengever.disposition.interfaces import ISIPTransport
 from opengever.disposition.testing import DisabledTransport
+from opengever.disposition.testing import DummyTransport
 from opengever.disposition.testing import EnabledTransport
 from opengever.disposition.testing import FailingTransport
 from opengever.disposition.testing import LogCapturingTestCase
+from opengever.disposition.testing import TestFilesystemTransportBase
+from opengever.testing import IntegrationTestCase
+from os.path import join as pjoin
+from zope.interface.verify import verifyObject
+import os
 
 
 class TestDeliveryScheduler(LogCapturingTestCase):
@@ -94,6 +101,7 @@ class TestDeliveryScheduler(LogCapturingTestCase):
         statuses[u't-disabled'] = STATUS_SCHEDULED
 
         self.assertEqual([
+            u"Skip: Transport 'filesystem' is disabled",
             u"Skip: Transport 't-disabled' is disabled",
             u"Delivering using transport 't-enabled'",
             u"Successful delivery using transport 't-enabled'"],
@@ -120,3 +128,105 @@ class TestDeliveryScheduler(LogCapturingTestCase):
             self.captured_log.msgs)
 
         self.assertEqual(STATUS_FAILED, statuses[u't-failing'])
+
+
+class TestFilesystemTransport(TestFilesystemTransportBase):
+
+    def setUp(self):
+        super(TestFilesystemTransport, self).setUp()
+        with self.login(self.records_manager):
+            self.sip_filename = self.disposition_with_sip.get_sip_filename()
+            self.dst_path = pjoin(self.tempdir, self.sip_filename)
+
+    def test_sip_package_is_delivered_via_filesystem_transport(self):
+        self.login(self.records_manager)
+
+        scheduler = DeliveryScheduler(self.disposition_with_sip)
+        scheduler.deliver()
+
+        self.assertEqual([
+            u"Delivering using transport 'filesystem'",
+            u"Transported %r to %r" % (self.sip_filename, self.dst_path),
+            u"Successful delivery using transport 'filesystem'"],
+            self.captured_log.pop_msgs())
+
+        self.assertEqual([self.sip_filename], os.listdir(self.tempdir))
+
+        with open(self.dst_path) as delivered_file:
+            delivered_data = delivered_file.read()
+
+        self.assertEqual(
+            self.disposition_with_sip.get_sip_package().data,
+            delivered_data)
+
+    def test_doesnt_deliver_twice_unless_rescheduled(self):
+        self.login(self.records_manager)
+
+        scheduler = DeliveryScheduler(self.disposition_with_sip)
+        scheduler.deliver()
+
+        self.assertEqual([
+            u"Delivering using transport 'filesystem'",
+            u"Transported %r to %r" % (self.sip_filename, self.dst_path),
+            u"Successful delivery using transport 'filesystem'"],
+            self.captured_log.pop_msgs())
+
+        self.assertTrue(os.path.isfile(self.dst_path))
+
+        os.remove(self.dst_path)
+        scheduler.deliver()
+
+        self.assertEqual([
+            u"Skip: Not scheduled for delivery with transport 'filesystem'"],
+            self.captured_log.pop_msgs())
+
+        self.assertFalse(os.path.isfile(self.dst_path))
+
+    def test_logs_when_overwriting_existing_sip(self):
+        self.login(self.records_manager)
+
+        scheduler = DeliveryScheduler(self.disposition_with_sip)
+
+        filename = '%s.zip' % self.disposition_with_sip.get_sip_name()
+        dst_path = pjoin(self.tempdir, filename)
+
+        scheduler.deliver()
+        self.assertEqual([
+            u"Delivering using transport 'filesystem'",
+            u"Transported %r to %r" % (self.sip_filename, self.dst_path),
+            u"Successful delivery using transport 'filesystem'"],
+            self.captured_log.pop_msgs())
+
+        scheduler.schedule_delivery(force=True)
+        self.assertEqual([
+            u"Scheduling delivery for transport: 'filesystem'"],
+            self.captured_log.pop_msgs())
+
+        scheduler.deliver()
+
+        self.assertEqual([
+            u"Delivering using transport 'filesystem'",
+            u'Overwriting existing file %s' % dst_path,
+            u"Transported %r to %r" % (self.sip_filename, self.dst_path),
+            u"Successful delivery using transport 'filesystem'"],
+            self.captured_log.pop_msgs())
+
+
+class TestTransports(IntegrationTestCase):
+
+    def register_transport(self, factory, name):
+        getSiteManager().registerAdapter(factory, name=name)
+
+    def test_all_transports_implement_interface(self):
+        self.login(self.records_manager)
+
+        # Also check our testing transports
+        self.register_transport(DummyTransport, 't-dummy')
+        self.register_transport(EnabledTransport, 't-enabled')
+        self.register_transport(DisabledTransport, 't-disabled')
+        self.register_transport(FailingTransport, 't-failing')
+
+        scheduler = DeliveryScheduler(self.disposition_with_sip)
+        transports = scheduler.get_transports()
+        for name, transport in transports:
+            verifyObject(ISIPTransport, transport)

--- a/opengever/disposition/tests/test_delivery.py
+++ b/opengever/disposition/tests/test_delivery.py
@@ -1,0 +1,122 @@
+from opengever.disposition.delivery import DeliveryScheduler
+from opengever.disposition.delivery import STATUS_FAILED
+from opengever.disposition.delivery import STATUS_SCHEDULED
+from opengever.disposition.delivery import STATUS_SUCCESS
+from opengever.disposition.testing import DisabledTransport
+from opengever.disposition.testing import EnabledTransport
+from opengever.disposition.testing import FailingTransport
+from opengever.disposition.testing import LogCapturingTestCase
+
+
+class TestDeliveryScheduler(LogCapturingTestCase):
+
+    def setUp(self):
+        super(TestDeliveryScheduler, self).setUp()
+        with self.login(self.records_manager):
+            self.register_transport(EnabledTransport, 't-enabled')
+            self.register_transport(DisabledTransport, 't-disabled')
+
+            scheduler = DeliveryScheduler(self.disposition_with_sip)
+            scheduler.schedule_delivery()
+            self.captured_log.clear()
+
+    def register_transport(self, cls, name):
+        self.layer['load_zcml_string']("""
+            <configure xmlns="http://namespaces.zope.org/zope">
+                <adapter
+                     name="%s"
+                     factory="%s.%s"
+                     />
+            </configure>
+        """ % (name, self.__module__, cls.__name__))
+
+    def test_schedules_for_transports_with_no_delivery_attempt_yet(self):
+        self.login(self.records_manager)
+
+        scheduler = DeliveryScheduler(self.disposition_with_sip)
+        statuses = scheduler.get_statuses(create_if_missing=True)
+        statuses.clear()
+
+        scheduler.schedule_delivery()
+        self.assertEqual({u't-enabled': STATUS_SCHEDULED}, statuses)
+
+    def test_does_not_automatically_reschedule_successful_delivery(self):
+        self.login(self.records_manager)
+
+        scheduler = DeliveryScheduler(self.disposition_with_sip)
+        statuses = scheduler.get_statuses(create_if_missing=True)
+        statuses.clear()
+
+        statuses[u't-enabled'] = STATUS_SUCCESS
+        scheduler.schedule_delivery()
+        self.assertEqual({u't-enabled': STATUS_SUCCESS}, statuses)
+
+    def test_does_not_automatically_reschedule_failed_delivery(self):
+        self.login(self.records_manager)
+
+        scheduler = DeliveryScheduler(self.disposition_with_sip)
+        statuses = scheduler.get_statuses(create_if_missing=True)
+        statuses.clear()
+
+        statuses[u't-enabled'] = STATUS_FAILED
+        scheduler.schedule_delivery()
+        self.assertEqual({u't-enabled': STATUS_FAILED}, statuses)
+
+    def test_force_schedule_reschedules_all_states(self):
+        self.login(self.records_manager)
+
+        scheduler = DeliveryScheduler(self.disposition_with_sip)
+        statuses = scheduler.get_statuses(create_if_missing=True)
+        statuses.clear()
+
+        scheduler.schedule_delivery(force=True)
+        self.assertEqual({u't-enabled': STATUS_SCHEDULED}, statuses)
+
+        statuses[u't-enabled'] = STATUS_FAILED
+        scheduler.schedule_delivery(force=True)
+        self.assertEqual({u't-enabled': STATUS_SCHEDULED}, statuses)
+
+        statuses[u't-enabled'] = STATUS_SUCCESS
+        scheduler.schedule_delivery(force=True)
+        self.assertEqual({u't-enabled': STATUS_SCHEDULED}, statuses)
+
+        statuses[u't-enabled'] = STATUS_SCHEDULED
+        scheduler.schedule_delivery(force=True)
+        self.assertEqual({u't-enabled': STATUS_SCHEDULED}, statuses)
+
+    def test_delivers_only_using_enabled_transports(self):
+        self.login(self.records_manager)
+
+        scheduler = DeliveryScheduler(self.disposition_with_sip)
+        scheduler.deliver()
+
+        statuses = scheduler.get_statuses()
+        statuses[u't-disabled'] = STATUS_SCHEDULED
+
+        self.assertEqual([
+            u"Skip: Transport 't-disabled' is disabled",
+            u"Delivering using transport 't-enabled'",
+            u"Successful delivery using transport 't-enabled'"],
+            self.captured_log.pop_msgs())
+
+    def test_catches_transport_exceptions_and_sets_failed_status(self):
+        self.login(self.records_manager)
+
+        scheduler = DeliveryScheduler(self.disposition_with_sip)
+        statuses = scheduler.get_statuses(create_if_missing=True)
+        statuses.clear()
+
+        self.register_transport(FailingTransport, 't-failing')
+        statuses[u't-failing'] = STATUS_SCHEDULED
+
+        scheduler.deliver()
+
+        self.assertIn(
+            u"Delivering using transport 't-failing'",
+            self.captured_log.msgs)
+
+        self.assertIn(
+            u"Delivery with transport 't-failing' failed: Exception('Boom',)",
+            self.captured_log.msgs)
+
+        self.assertEqual(STATUS_FAILED, statuses[u't-failing'])

--- a/opengever/disposition/tests/test_delivery.py
+++ b/opengever/disposition/tests/test_delivery.py
@@ -11,6 +11,7 @@ from opengever.disposition.testing import LogCapturingTestCase
 from opengever.disposition.testing import TestFilesystemTransportBase
 from opengever.testing import IntegrationTestCase
 from os.path import join as pjoin
+from zope.component import getSiteManager
 from zope.interface.verify import verifyObject
 import os
 
@@ -27,15 +28,8 @@ class TestDeliveryScheduler(LogCapturingTestCase):
             scheduler.schedule_delivery()
             self.captured_log.clear()
 
-    def register_transport(self, cls, name):
-        self.layer['load_zcml_string']("""
-            <configure xmlns="http://namespaces.zope.org/zope">
-                <adapter
-                     name="%s"
-                     factory="%s.%s"
-                     />
-            </configure>
-        """ % (name, self.__module__, cls.__name__))
+    def register_transport(self, factory, name):
+        getSiteManager().registerAdapter(factory, name=name)
 
     def test_schedules_for_transports_with_no_delivery_attempt_yet(self):
         self.login(self.records_manager)

--- a/opengever/disposition/tests/test_disposition.py
+++ b/opengever/disposition/tests/test_disposition.py
@@ -312,5 +312,5 @@ class TestDispositionDelivery(IntegrationTestCase):
 
         tbl_delivery_status = browser.css('#delivery-status').first
         self.assertEqual(
-            [['filesystem', 'status_scheduled']],
+            [['filesystem', 'Scheduled for delivery']],
             tbl_delivery_status.lists())

--- a/opengever/disposition/tests/test_disposition.py
+++ b/opengever/disposition/tests/test_disposition.py
@@ -10,6 +10,7 @@ from ftw.testing import freeze
 from opengever.base.behaviors.lifecycle import ILifeCycle
 from opengever.disposition.delivery import DeliveryScheduler
 from opengever.disposition.delivery import IFilesystemTransportSettings
+from opengever.disposition.delivery import STATUS_SCHEDULED
 from opengever.disposition.testing import EnabledTransport
 from opengever.dossier.behaviors.dossier import IDossier
 from opengever.testing import IntegrationTestCase
@@ -287,16 +288,16 @@ class TestDispositionDelivery(IntegrationTestCase):
 
         self.enable_filesystem_transport()
         scheduler = DeliveryScheduler(self.disposition)
-        statuses = scheduler.get_statuses()
 
         self.assertFalse(scheduler.is_scheduled_for_delivery())
-        self.assertEqual({}, statuses)
+        self.assertEqual({}, scheduler.get_statuses())
 
         browser.open(self.disposition, view='overview')
         browser.click_on('disposition-transition-dispose')
 
         self.assertTrue(scheduler.is_scheduled_for_delivery())
-        self.assertEqual({}, statuses)
+        self.assertEqual({u'filesystem': STATUS_SCHEDULED},
+                          scheduler.get_statuses())
 
         self.assertEquals(['Item state changed.'], info_messages())
         self.assertTrue(self.disposition.has_sip_package())

--- a/opengever/disposition/tests/test_disposition.py
+++ b/opengever/disposition/tests/test_disposition.py
@@ -4,15 +4,19 @@ from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
 from ftw.testbrowser.pages import factoriesmenu
-from ftw.testbrowser.pages.statusmessages import info_messages
 from ftw.testbrowser.pages.statusmessages import error_messages
+from ftw.testbrowser.pages.statusmessages import info_messages
 from ftw.testing import freeze
 from opengever.base.behaviors.lifecycle import ILifeCycle
+from opengever.disposition.delivery import DeliveryScheduler
+from opengever.disposition.delivery import IFilesystemTransportSettings
 from opengever.dossier.behaviors.dossier import IDossier
 from opengever.testing import IntegrationTestCase
 from opengever.testing import obj2paths
 from plone import api
 from plone.protect import createToken
+from plone.registry.interfaces import IRegistry
+from zope.component import getUtility
 
 OFFERED_STATE = 'dossier-state-offered'
 RESOLVED_STATE = 'dossier-state-resolved'
@@ -262,3 +266,51 @@ class TestDispositionEditForm(IntegrationTestCase):
 
         self.assertEquals(['Item state changed.'], info_messages())
         self.assertFalse(self.disposition.has_sip_package())
+
+
+class TestDispositionDelivery(IntegrationTestCase):
+
+    def enable_filesystem_transport(self):
+        # Enable FilesystemTransport
+        registry = getUtility(IRegistry)
+        settings = registry.forInterface(IFilesystemTransportSettings)
+        settings.enabled = True
+        settings.destination_directory = u'/tmp/will-not-be-used'
+
+    @browsing
+    def test_sip_package_is_scheduled_for_delivery_on_dispose(self, browser):
+        self.login(self.records_manager, browser)
+
+        self.set_workflow_state('disposition-state-appraised', self.disposition)
+
+        self.enable_filesystem_transport()
+        scheduler = DeliveryScheduler(self.disposition)
+        statuses = scheduler.get_statuses()
+
+        self.assertFalse(scheduler.is_scheduled_for_delivery())
+        self.assertEqual({}, statuses)
+
+        browser.open(self.disposition, view='overview')
+        browser.click_on('disposition-transition-dispose')
+
+        self.assertTrue(scheduler.is_scheduled_for_delivery())
+        self.assertEqual({}, statuses)
+
+        self.assertEquals(['Item state changed.'], info_messages())
+        self.assertTrue(self.disposition.has_sip_package())
+
+    @browsing
+    def test_delivery_status_is_displayed(self, browser):
+        self.login(self.records_manager, browser)
+
+        self.set_workflow_state('disposition-state-appraised', self.disposition)
+
+        self.enable_filesystem_transport()
+
+        browser.open(self.disposition, view='overview')
+        browser.click_on('disposition-transition-dispose')
+
+        tbl_delivery_status = browser.css('#delivery-status').first
+        self.assertEqual(
+            [['filesystem', 'status_scheduled']],
+            tbl_delivery_status.lists())

--- a/opengever/disposition/tests/test_nightly_jobs.py
+++ b/opengever/disposition/tests/test_nightly_jobs.py
@@ -1,0 +1,83 @@
+from opengever.disposition.delivery import DeliveryScheduler
+from opengever.disposition.delivery import STATUS_SCHEDULED
+from opengever.disposition.delivery import STATUS_SUCCESS
+from opengever.disposition.nightly_jobs import NightlySIPDelivery
+from opengever.disposition.tests.test_delivery import TestFilesystemTransportBase
+from opengever.testing.helpers import CapturingLogHandler
+from os.path import join as pjoin
+import logging
+import os
+
+
+class TestNightlyDelivery(TestFilesystemTransportBase):
+
+    features = ('nightly-jobs', )
+
+    def setUp(self):
+        super(TestNightlyDelivery, self).setUp()
+        with self.login(self.records_manager):
+            self.sip_filename = self.disposition_with_sip.get_sip_filename()
+            self.dst_path = pjoin(self.tempdir, self.sip_filename)
+
+    def interrupt_if_necessary(self):
+        """Stub out the runner's `interrupt_if_necessary` function.
+        """
+
+    def execute_nightly_jobs(self, expected=None, logger=None):
+        if not logger:
+            logger = logging.getLogger('opengever.nightlyjobs')
+            logger.addHandler(logging.NullHandler())
+
+        nightly_job_provider = NightlySIPDelivery(
+            self.portal, self.request, logger)
+
+        jobs = list(nightly_job_provider)
+        if expected:
+            self.assertEqual(expected, len(jobs))
+            self.assertEqual(expected, len(nightly_job_provider))
+
+        for job in jobs:
+            nightly_job_provider.run_job(job, self.interrupt_if_necessary)
+
+    def test_nightly_sip_delivery(self):
+        self.login(self.records_manager)
+
+        scheduler = DeliveryScheduler(self.disposition_with_sip)
+        statuses = scheduler.get_statuses()
+
+        self.assertEqual({u'filesystem': STATUS_SCHEDULED}, statuses)
+        self.execute_nightly_jobs(expected=1)
+        self.assertEqual({u'filesystem': STATUS_SUCCESS}, statuses)
+
+        self.assertEqual([self.sip_filename], os.listdir(self.tempdir))
+
+    def test_transport_logging_propagates_up_to_nightly_log_handler(self):
+        self.login(self.records_manager)
+
+        # Create a logging setup similar to cronjob scenario
+        nightly_logger = logging.getLogger('opengever.nightlyjobs')
+        nightly_logger.setLevel(logging.INFO)
+        nightly_log_handler = CapturingLogHandler()
+        nightly_logger.addHandler(nightly_log_handler)
+
+        self.execute_nightly_jobs(expected=1, logger=nightly_logger)
+
+        logrecords = [(r.name, r.msg) for r in nightly_log_handler.records]
+
+        expected = [
+            ('opengever.nightlyjobs',
+                "Delivering SIP for %r" % self.disposition_with_sip),
+
+            ('opengever.disposition.delivery',
+                "Delivering using transport 'filesystem'"),
+
+            ('FilesystemTransport',
+                "Transported %r to %r" % (self.sip_filename, self.dst_path)),
+
+            ('opengever.disposition.delivery',
+                "Successful delivery using transport 'filesystem'")
+        ]
+
+        self.assertEqual(expected, logrecords,
+                         "Expected log messages from DeliveryScheduler and "
+                         "Transport to also show up in nightly logs")


### PR DESCRIPTION
Implements SIP delivery via filesystem.

This addresses part of #5167 _(addressing the FTPS usecase will be solved by mounting an FTPS connection using CurlFtpFS, and using filesystem delivery to drop the SIP on that mounted share)_.

### Implementation

- A new `ISIPTransport` adapter is introduced. These adapters are meant to implement specific transport mechanisms.
- For now, a `FilesystemTransport` is provided (disabled by default), which copies the SIP to a configured destination directory
- Upon disposing a disposition, a new class `DeliveryScheduler` will schedule the SIP for delivery with all enabled transports.
- Delivery status is tracked (by the `DeliveryScheduler` per transport, in annotations on the disposition
- A nightly job is provided that collects all dispositions that are eligble for transport, and invokes delivery via enabled transports


---

The delivery status will be shown on the disposition overview. If only one transport is enabled, it is displayed in a compact form (without the transport name):



![delivery_status](https://user-images.githubusercontent.com/405124/62713535-31825400-b9fd-11e9-94c5-fd2300660b70.png)

---

If more than one transport is configured, the delivery status will be listed per transport:

![delivery_status_multiple](https://user-images.githubusercontent.com/405124/62713583-44952400-b9fd-11e9-9688-701638a19716.png)

---

- [x] Polish delivery status table on Disposition overview
  - [x] Hide transport name if only 1 enabled transport
  - [x] Translate `status_success` etc into something human readable
- [x] Status `abgeliefert` anpassen z.B. zu`in Ablieferung`

~- [ ] Add "redeliver" button (backend functionality already exists, `DeliveryScheduler.schedule_delivery(force=True)`~

_(Cancelled because the required JS work to do this properly is in no relation to the value for a "reschedule" button, that probably won't do anything useful without our intervention anyway)_



## Checkliste

- [x] Profil angepasst? Sind UpgradeSteps vorhanden/nötig?:
- [x] Gibt es neue Übersetzungen?
  - [x] Sind alle msg-Strings in Übersetzungen Unicode?
  - [x] Wird die richtige i18n-domain verwendet (Copy-Paste Fehler sind hier häufig)?
- [x] Changelog-Eintrag vorhanden/nötig?
- [x] Aktualisierung Dokumentation vorhanden/nötig?



