### PR TITLE
 Fix availability checks for fileactions for non documentish types.

### DIFF
--- a/opengever/api/tests/test_actions.py
+++ b/opengever/api/tests/test_actions.py
@@ -13,6 +13,65 @@ class FileActionsTestBase(IntegrationTestCase):
         return browser.json['file_actions']
 
 
+class TestFileActionsGetForNonDocumentishTypes(FileActionsTestBase):
+
+    @browsing
+    def test_available_file_actions_for_plone_site(self, browser):
+        self.login(self.regular_user, browser)
+        expected_file_actions = []
+
+        self.assertEqual(expected_file_actions,
+                         self.get_file_actions(browser, self.portal))
+
+    @browsing
+    def test_available_file_actions_for_repository_root(self, browser):
+        self.login(self.regular_user, browser)
+        expected_file_actions = []
+
+        self.assertEqual(expected_file_actions,
+                         self.get_file_actions(browser, self.repository_root))
+
+    @browsing
+    def test_available_file_actions_for_repository_folder(self, browser):
+        self.login(self.regular_user, browser)
+        expected_file_actions = []
+
+        self.assertEqual(expected_file_actions,
+                         self.get_file_actions(browser, self.branch_repofolder))
+
+    @browsing
+    def test_available_file_actions_for_dossier(self, browser):
+        self.login(self.regular_user, browser)
+        expected_file_actions = []
+
+        self.assertEqual(expected_file_actions,
+                         self.get_file_actions(browser, self.dossier))
+
+    @browsing
+    def test_available_file_actions_for_task(self, browser):
+        self.login(self.regular_user, browser)
+        expected_file_actions = []
+
+        self.assertEqual(expected_file_actions,
+                         self.get_file_actions(browser, self.task))
+
+    @browsing
+    def test_available_file_actions_for_workspace_root(self, browser):
+        self.login(self.workspace_member, browser)
+        expected_file_actions = []
+
+        self.assertEqual(expected_file_actions,
+                         self.get_file_actions(browser, self.workspace_root))
+
+    @browsing
+    def test_available_file_actions_for_workspace(self, browser):
+        self.login(self.workspace_member, browser)
+        expected_file_actions = []
+
+        self.assertEqual(expected_file_actions,
+                         self.get_file_actions(browser, self.workspace))
+
+
 class TestFileActionsGetForMails(FileActionsTestBase):
 
     @browsing

--- a/opengever/api/tests/test_actions.py
+++ b/opengever/api/tests/test_actions.py
@@ -2,7 +2,7 @@ from ftw.testbrowser import browsing
 from opengever.testing import IntegrationTestCase
 
 
-class TestFileActionsGet(IntegrationTestCase):
+class FileActionsTestBase(IntegrationTestCase):
 
     features = ('bumblebee',)
     maxDiff = None
@@ -12,8 +12,32 @@ class TestFileActionsGet(IntegrationTestCase):
                      method='GET', headers=self.api_headers)
         return browser.json['file_actions']
 
+
+class TestFileActionsGetForMails(FileActionsTestBase):
+
     @browsing
-    def test_available_file_actions_for_document(self, browser):
+    def test_available_file_actions(self, browser):
+        self.login(self.regular_user, browser)
+        expected_file_actions = [
+            {u'id': u'download_copy',
+             u'title': u'Download copy',
+             u'icon': u''},
+            {u'id': u'attach_to_email',
+             u'title': u'Attach to email',
+             u'icon': u''},
+            {u'id': u'open_as_pdf',
+             u'title': u'Open as PDF',
+             u'icon': u''},
+            ]
+
+        self.assertEqual(expected_file_actions,
+                         self.get_file_actions(browser, self.mail_eml))
+
+
+class TestFileActionsGetForDocuments(FileActionsTestBase):
+
+    @browsing
+    def test_available_file_actions(self, browser):
         self.login(self.regular_user, browser)
         expected_file_actions = [
             {u'id': u'oc_direct_checkout',
@@ -166,24 +190,6 @@ class TestFileActionsGet(IntegrationTestCase):
             ]
         self.assertEqual(expected_dossier_manager_file_actions,
                          self.get_file_actions(browser, self.document))
-
-    @browsing
-    def test_available_file_actions_for_mail(self, browser):
-        self.login(self.regular_user, browser)
-        expected_file_actions = [
-            {u'id': u'download_copy',
-             u'title': u'Download copy',
-             u'icon': u''},
-            {u'id': u'attach_to_email',
-             u'title': u'Attach to email',
-             u'icon': u''},
-            {u'id': u'open_as_pdf',
-             u'title': u'Open as PDF',
-             u'icon': u''},
-            ]
-
-        self.assertEqual(expected_file_actions,
-                         self.get_file_actions(browser, self.mail_eml))
 
     @browsing
     def test_attach_not_available_if_feature_disabled(self, browser):


### PR DESCRIPTION
with https://github.com/4teamwork/opengever.core/pull/5847 we added fileactions as a new category of `portal_actions`. The availability checks for these actions relied on a view which delegates the checks to an adapter of `IFileActions`. We did not handle the case of `portal_type`s for which no such adapter is registered. This is now handled correctly.

**Implementation details**
The `FileActionAvailabilityMixin` was implementing all the methods of the `IFileActions` interface and delegating them to the `IFileActions` adapter. Instead we now overwrite the `__getattr__` method in this mixing and delegate to `IFileActions` adapter when the attribute is a method defined by that interface. In all other cases we raise the `AttributeError` so that normal treatment of attribute search can follow its course.
Also note that when there is no adapter of `IFileActions` registered for the current `context`, but the attribute is part if `IFileActions`, we return a `lambda` function which returns `False`. This is not strictly necessary as these methods are accessed through traversal, so both callables and non-callables are handled. But as `IFileActions` defines only methods, it seems more adequate to also return methods when the adapter is not defined.

## Checkliste
- [ ] Changelog-Eintrag vorhanden/nötig? CL nicht nötig IMHO

resolves #5786