### PR TITLE
Move task reminders of responsibles to the successor, when accepting a multi admin unit task.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2019.4.0rc2 (unreleased)
 ------------------------
 
+- Move task reminders of responsibles to the successor, when accepting a multi admin unit task. [phgross]
 - Bump ftw.tabbedview version to 4.1.3 [njohner]
 
 

--- a/opengever/base/configure.zcml
+++ b/opengever/base/configure.zcml
@@ -232,6 +232,11 @@
       name="dublin-core"
       />
 
+  <adapter
+      factory=".transport.ResponsibleTaskRemindersDataCollector"
+      name="task-reminders"
+      />
+
   <subscriber
       for="plone.app.lockingbehavior.behaviors.ILocking
            plone.dexterity.interfaces.IEditBegunEvent"

--- a/opengever/base/transport.py
+++ b/opengever/base/transport.py
@@ -4,6 +4,9 @@ from opengever.base.request import dispatch_json_request
 from opengever.base.security import elevated_privileges
 from opengever.ogds.base.utils import decode_for_json
 from opengever.ogds.base.utils import encode_after_json
+from opengever.task.reminder import TASK_REMINDER_OPTIONS
+from opengever.task.reminder.reminder import TaskReminder
+from opengever.task.task import ITask
 from plone.dexterity.interfaces import IDexterityContent
 from plone.dexterity.utils import addContentToContainer
 from plone.dexterity.utils import createContent
@@ -344,3 +347,21 @@ class DublinCoreMetaDataCollector(object):
 
         self.context.creation_date = DateTime.DateTime(
             data.get('created'))
+
+
+@implementer(IDataCollector)
+@adapter(ITask)
+class ResponsibleTaskRemindersDataCollector(object):
+    """This data collector stores task reminders of all potential resopnsibles.
+    """
+
+    def __init__(self, context):
+        self.context = context
+
+    def extract(self):
+        return TaskReminder().get_reminders_of_potential_responsibles(self.context)
+
+    def insert(self, data):
+        for userid, option_tpye in data.items():
+            option = TASK_REMINDER_OPTIONS[option_tpye]
+            TaskReminder().set_reminder(self.context, option, user_id=userid)

--- a/opengever/task/browser/accept/utils.py
+++ b/opengever/task/browser/accept/utils.py
@@ -14,6 +14,7 @@ from opengever.task.adapters import IResponseContainer
 from opengever.task.exceptions import TaskRemoteRequestError
 from opengever.task.interfaces import ISuccessorTaskController
 from opengever.task.interfaces import ITaskDocumentsTransporter
+from opengever.task.reminder.reminder import TaskReminder
 from opengever.task.task import ITask
 from opengever.task.transporter import IResponseTransporter
 from opengever.task.util import change_task_workflow_state
@@ -260,6 +261,11 @@ class AcceptTaskWorkflowTransitionView(BrowserView):
 
         center = notification_center()
         center.remove_task_responsible(self.context, self.context.responsible)
+
+        # Remove task reminders of potential responsibles
+        reminders = TaskReminder().get_reminders_of_potential_responsibles(self.context)
+        for userid in reminders.keys():
+            TaskReminder().clear_reminder(self.context, user_id=userid)
 
         accept_task_with_response(self.context, text,
                                   successor_oguid=successor_oguid)

--- a/opengever/task/reminder/reminder.py
+++ b/opengever/task/reminder/reminder.py
@@ -50,6 +50,18 @@ class TaskReminder(object):
         return {actor: TASK_REMINDER_OPTIONS.get(value)
                 for actor, value in storage.items()}
 
+    def get_reminders_of_potential_responsibles(self, obj):
+        """Get reminders of all responsible representatives.
+        """
+        representatives = [actor.userid for actor in
+                           obj.get_responsible_actor().representatives()]
+
+        data = {}
+        for userid, reminder in self.get_reminders(obj).items():
+            if userid in representatives:
+                data[userid] = reminder.option_type
+        return data
+
     def get_sql_reminder(self, obj, user_id=None):
         """Get the sql-reminder for the given object for a specific user or
         for the current logged in user.

--- a/opengever/task/tests/test_accept.py
+++ b/opengever/task/tests/test_accept.py
@@ -1,0 +1,27 @@
+from ftw.testbrowser import browsing
+from opengever.task.reminder import TASK_REMINDER_ONE_DAY_BEFORE
+from opengever.task.reminder.reminder import TaskReminder
+from opengever.testing import IntegrationTestCase
+
+
+class TestAcceptTaskWorkflowTransitionView(IntegrationTestCase):
+
+    @browsing
+    def test_reminders_of_responsbile_gets_cleared(self, browser):
+        self.login(self.regular_user, browser)
+
+        task_reminder = TaskReminder()
+        task_reminder.set_reminder(
+            self.seq_subtask_1, TASK_REMINDER_ONE_DAY_BEFORE,
+            user_id=self.regular_user.id)
+
+        self.assertEqual(
+            [self.regular_user.id],
+            TaskReminder().get_reminders(self.seq_subtask_1).keys())
+
+        browser.open(self.seq_subtask_1, view='accept_task_workflow_transition')
+
+        self.assertEqual('OK', browser.contents)
+        self.assertEqual(
+            {},
+            TaskReminder().get_reminders(self.seq_subtask_1))


### PR DESCRIPTION
The movement is split up in to two parts - a creation of the reminder(s) as part of the successor task creation via Transporter's new ResponsibleTaskRemindersDataCollector and the removal on the predecessor side when accepting the predecessor task.

Closes #5783 (the reason why we move the reminders of responsibles from the predecessor to the successors is described in the issue).

## Checkliste

_Zutreffendes soll angehakt stehengelassen werden._
- [x] Wurde etwas an der `Aufgabe` angepasst? Funktioniert das auch mit einer `Weiterleitung`?
 -> Die Reminders funktionieren zurzeit nicht, bzw. können gar nicht funktionieren da Weiterleitungen keine Deadline definiert habe, ich eröffne hierzu ein separaten Issue.
- [x] Changelog-Eintrag vorhanden/nötig?