### PR TITLE
Update workflow security for opengever_workspace workflow

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2019.4.0rc2 (unreleased)
 ------------------------
 
+- Update workflow security for opengever_workspace workflow to fix permission on existing workspaces. [elioschmutz]
 - Move task reminders of responsibles to the successor, when accepting a multi admin unit task. [phgross]
 - Bump ftw.tabbedview version to 4.1.3 [njohner]
 

--- a/opengever/core/upgrades/20190814122549_fix_permission_for_existing_workspaces/upgrade.py
+++ b/opengever/core/upgrades/20190814122549_fix_permission_for_existing_workspaces/upgrade.py
@@ -1,0 +1,10 @@
+from ftw.upgrade import UpgradeStep
+
+
+class FixPermissionForExistingWorkspaces(UpgradeStep):
+    """Fix permission for existing workspaces.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()
+        self.update_workflow_security(['opengever_workspace'], reindex_security=False)


### PR DESCRIPTION
Update workflow security for `opengever_workspace` workflow to fix permission on existing workspaces.

Durch den PR #5829 wurde der bestehende `opengever_workspace` Workflow mit einer neuen Berechtigung `opengever.workspace.UpdateContentOrder` erweitert. Die Workflow-Security wurde jedoch nicht aktualisiert. Bestehende Arbeitsräume funktionieren somit nicht mit der neuen Berechtigung.

Dieser PR aktualisiert lediglich die Workflow-Security von bestehenden Arbeitsräumen.

Wie kann der Fehler reproduziert werden?

Ein WorkspaceMember kann bei einem bestehenden Arbeitsraum keine ToDo Listen verschieben weil ihm die Berechtigung `opengever.workspace.UpdateContentOrder` auf dem Arbeitsraum fehlt.

## Checkliste

- [x] Profil angepasst? Sind UpgradeSteps vorhanden/nötig?:
- [x] Changelog-Eintrag vorhanden/nötig?
