### PR TITLE
Fix workspace participation restapi.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2019.4.0rc2 (unreleased)
 ------------------------
 
+- Fix workspace participation restapi to handle new payload format for post and patch requests due to the new plone.restapi. [elioschmutz]
 - Update workflow security for opengever_workspace workflow to fix permission on existing workspaces. [elioschmutz]
 - Move task reminders of responsibles to the successor, when accepting a multi admin unit task. [phgross]
 - Bump ftw.tabbedview version to 4.1.3 [njohner]

--- a/opengever/api/participation.py
+++ b/opengever/api/participation.py
@@ -121,12 +121,13 @@ class ParticipationsPost(ParticipationTraverseService):
     def reply(self):
         self.validate_params()
         data = self.validate_data(json_body(self.request))
-
-        if not self.validate_duplicated_users(data.get('userid')):
+        userid = data.get('user').get('token')
+        role = data.get('role').get('token')
+        if not self.validate_duplicated_users(userid):
             raise BadRequest("User already participate to this workspace")
 
         manager = ManageParticipants(self.context, self.request)
-        invitation = manager._add(data.get('userid'), data.get('role'))
+        invitation = manager._add(userid, role)
         return participation_item(
             self.context, self.request,
             token=invitation['iid'],
@@ -148,7 +149,7 @@ class ParticipationsPost(ParticipationTraverseService):
             raise NotFound
 
     def validate_data(self, data):
-        if not data.get('userid'):
+        if not data.get('user'):
             raise BadRequest('Missing parameter userid')
 
         if not data.get('role'):
@@ -164,7 +165,7 @@ class ParticipationsPatch(ParticipationTraverseService):
         data = self.validate_data(json_body(self.request))
 
         manager = ManageParticipants(self.context, self.request)
-        manager._modify(token, data.get('role'), participation_type.id)
+        manager._modify(token, data.get('role').get('token'), participation_type.id)
         return None
 
     def read_params(self):

--- a/opengever/api/participation.py
+++ b/opengever/api/participation.py
@@ -242,7 +242,7 @@ class InvitationsPost(ParticipationTraverseService):
         if action == 'accept':
             target = my_invitations_manager._accept(invitation)
             return getMultiAdapter(
-                (target, self.request),ISerializeToJson)(include_items=False)
+                (target, self.request), ISerializeToJson)(include_items=False)
 
     def read_params(self):
         if len(self.params) != 2:


### PR DESCRIPTION
The new plone.restapi sends a dict having a token and a title for vocabularie values like the users. The frontend is using this new format as well. We have to update the participation implementation to use it as well to fix an issue where it was no longer possible to add participants.

Related frontend PR: https://github.com/4teamwork/gever-ui/pull/396

## Checkliste

- [x] Changelog-Eintrag vorhanden/nötig?
