### PR TITLE
Remove userid from the users fullname in all teamraum sources.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 ------------------------
 
 - Update workflow security for opengever_workspace workflow to fix permission on existing workspaces. [elioschmutz]
+- Remove userid from the users fullname in all teamraum sources. [phgross]
 - Move task reminders of responsibles to the successor, when accepting a multi admin unit task. [phgross]
 - Bump ftw.tabbedview version to 4.1.3 [njohner]
 

--- a/opengever/ogds/base/sources.py
+++ b/opengever/ogds/base/sources.py
@@ -608,6 +608,17 @@ class ActualWorkspaceMembersSource(AssignedUsersSource):
             query = query.filter(sql.false())
         return query
 
+    def getTerm(self, value):
+        """We only need the user fullname as title without the userid in
+        brackets.
+        """
+        try:
+            user = self.base_query.filter(User.userid == value).one()
+        except orm.exc.NoResultFound:
+            raise LookupError(
+                'No row was found with userid: {}'.format(value))
+        return SimpleTerm(value, value, user.fullname())
+
 
 @implementer(IContextSourceBinder)
 class ActualWorkspaceMembersSourceBinder(object):

--- a/opengever/workspace/tests/test_workspace_sources.py
+++ b/opengever/workspace/tests/test_workspace_sources.py
@@ -171,3 +171,13 @@ class TestActualWorkspaceMembersSource(IntegrationTestCase):
 
         results = source.search(self.workspace_guest.id)
         self.assertEqual(0, len(results))
+
+    def test_title_is_fullname_only(self):
+        self.login(self.workspace_admin)
+        source = ActualWorkspaceMembersSource(self.workspace)
+
+        term = source.search('beatrice')[0]
+
+        self.assertEqual(self.workspace_member.id, term.token)
+        self.assertEqual(self.workspace_member.id, term.value)
+        self.assertEqual(u'Schr\xf6dinger B\xe9atrice', term.title)


### PR DESCRIPTION
The userid is not necessary in all the teamraum sources and leads to display issues in the frontend.

I noticed it while implementing the detail view #5852 .

## Checkliste
_Zutreffendes soll angehakt stehengelassen werden._
- [x] Changelog-Eintrag vorhanden/nötig?
