### PR TITLE
Fix an issue where it was no longer possible to modify a workspace

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2019.4.0rc2 (unreleased)
 ------------------------
 
+- Fix an issue where it was no longer possible to modify a workspace as a workspace owner. [elioschmutz]
 - Fix workspace participation restapi to handle new payload format for post and patch requests due to the new plone.restapi. [elioschmutz]
 - Update workflow security for opengever_workspace workflow to fix permission on existing workspaces. [elioschmutz]
 - Remove userid from the users fullname in all teamraum sources. [phgross]

--- a/opengever/workspace/workspace.py
+++ b/opengever/workspace/workspace.py
@@ -28,7 +28,8 @@ class WorkspaceContentPatch(ContentPatch):
     def reply(self):
         data = json_body(self.request)
         if data.keys() != ['ordering']:
-            if not api.user.has_permission('cmf.ModifyPortalContent'):
+            if not api.user.has_permission('Modify portal content',
+                                           obj=self.context):
                 raise Unauthorized()
 
         return super(WorkspaceContentPatch, self).reply()


### PR DESCRIPTION
This PR fixes a broken permission check for the `WorkspacePatch`-API endpoint. 

# Before

![screen1](https://user-images.githubusercontent.com/557005/63163179-f5667900-c024-11e9-9ed9-d77402ac6932.gif)

# After

![screen2](https://user-images.githubusercontent.com/557005/63163223-2181fa00-c025-11e9-8cca-f94bb5886edf.gif)

@all4manu FYI

Fixes an issue introduced in https://github.com/4teamwork/opengever.core/pull/5829

## Checkliste
- [x] Changelog-Eintrag vorhanden/nötig?
