### PR TITLE
Add config to switch between changed and document_date for dossier end date calculation

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,7 @@ Changelog
 2019.4.0rc3 (unreleased)
 ------------------------
 
-- Nothing changed yet.
+- Add new registry field to switch between changed and document_date for dossier end date calculation. [njohner]
 
 
 2019.4.0rc2 (2019-08-21)

--- a/docs/public/dev-manual/api/config.rst
+++ b/docs/public/dev-manual/api/config.rst
@@ -26,6 +26,7 @@ GEVER-Mandanten abgefragt werden.
           "features": {
               "activity": true,
               "archival_file_conversion": false,
+              "changed_for_end_date": true,
               "contacts": false,
               "doc_properties": true,
               "dossier_templates": true,

--- a/docs/public/user-manual/dossiers/bearbeiten.rst
+++ b/docs/public/user-manual/dossiers/bearbeiten.rst
@@ -81,7 +81,8 @@ Vor dem Abschluss müssen zudem folgende Abschlussregeln beachtet werden:
 - Falls das Dossier Subdossiers enthält, so müssen alle Inhalte in Subdossiers abgelegt sein. Diese Regel kann bei Bedarf via Konfigurationsoption deaktiviert werden.
 
 Weiter muss das Abschlussdatum beachtet werden. Dieses muss mind. das letzte
-Bearbeitungs-Datum des zuletzt bearbeiteten Dokumentes haben. Beim
+Bearbeitungs-Datum (oder Dokument-Datum, gemäss Konfigurationsoption der GEVER Installation)
+des zuletzt bearbeiteten Dokumentes haben. Beim
 Dossier-Abschluss wird dies vom System überprüft. Wurde beispielsweise
 bei der Dossier-Erstellung bereits ein Datum gewählt, dass jedoch vor dem
 zuletzt bearbeiteten Dokument liegt, zeigt OneGov GEVER einen Fehler an und das

--- a/opengever/api/tests/test_config.py
+++ b/opengever/api/tests/test_config.py
@@ -42,6 +42,7 @@ class TestConfig(IntegrationTestCase):
             {
                 u'activity': False,
                 u'archival_file_conversion': False,
+                u'changed_for_end_date': True,
                 u'contacts': False,
                 u'disposition_transport_filesystem': False,
                 u'disposition_transport_ftps': False,

--- a/opengever/base/configuration.py
+++ b/opengever/base/configuration.py
@@ -98,6 +98,7 @@ class GeverSettingsAdpaterV1(object):
         features = OrderedDict()
         features['activity'] = api.portal.get_registry_record('is_feature_enabled', interface=IActivitySettings)
         features['archival_file_conversion'] = api.portal.get_registry_record('archival_file_conversion_enabled', interface=IDossierResolveProperties)  # noqa
+        features['changed_for_end_date'] = api.portal.get_registry_record('use_changed_for_end_date', interface=IDossierResolveProperties)  # noqa
         features['contacts'] = api.portal.get_registry_record('is_feature_enabled', interface=IContactSettings)
         features['disposition_transport_filesystem'] = api.portal.get_registry_record('enabled', interface=IFilesystemTransportSettings)  # noqa
         features['disposition_transport_ftps'] = api.portal.get_registry_record('enabled', interface=IFTPSTransportSettings)  # noqa

--- a/opengever/base/tests/test_configuration_adapter.py
+++ b/opengever/base/tests/test_configuration_adapter.py
@@ -33,6 +33,7 @@ class TestConfigurationAdapter(IntegrationTestCase):
             ('features', OrderedDict([
                 ('activity', False),
                 ('archival_file_conversion', False),
+                ('changed_for_end_date', True),
                 ('contacts', False),
                 ('disposition_transport_filesystem', False),
                 ('disposition_transport_ftps', False),

--- a/opengever/core/upgrades/20190821114305_add_use_changed_for_end_date_registry_field/registry.xml
+++ b/opengever/core/upgrades/20190821114305_add_use_changed_for_end_date_registry_field/registry.xml
@@ -1,0 +1,3 @@
+<registry purge="False">
+  <records interface="opengever.dossier.interfaces.IDossierResolveProperties" />
+</registry>

--- a/opengever/core/upgrades/20190821114305_add_use_changed_for_end_date_registry_field/upgrade.py
+++ b/opengever/core/upgrades/20190821114305_add_use_changed_for_end_date_registry_field/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddUseChangedForEndDateRegistryField(UpgradeStep):
+    """Add use_changed_for_end_date registry field.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/dossier/interfaces.py
+++ b/opengever/dossier/interfaces.py
@@ -231,6 +231,14 @@ class IDossierResolveProperties(Interface):
         default='strict'
     )
 
+    use_changed_for_end_date = schema.Bool(
+        title=u"Use the 'changed' date for earliest possible end date",
+        description=u'When True, changed will be used in the calculation of '
+        'the earliest possible end date. If set to False, the document_date '
+        'will be used instead.',
+        default=True
+    )
+
 
 """
 These two interfaces have been moved and renamed to

--- a/opengever/testing/integration_test_case.py
+++ b/opengever/testing/integration_test_case.py
@@ -57,6 +57,7 @@ FEATURE_FLAGS = {
     'bumblebee': 'opengever.bumblebee.interfaces.IGeverBumblebeeSettings.is_feature_enabled',
     'bumblebee-open-pdf-new-tab': 'opengever.bumblebee.interfaces.IGeverBumblebeeSettings.open_pdf_in_a_new_window',
     'bumblebee-auto-refresh': 'opengever.bumblebee.interfaces.IGeverBumblebeeSettings.is_auto_refresh_enabled',
+    'changed_for_end_date': 'opengever.dossier.interfaces.IDossierResolveProperties.use_changed_for_end_date',
     'contact': 'opengever.contact.interfaces.IContactSettings.is_feature_enabled',
     'doc-properties': 'opengever.dossier.interfaces.ITemplateFolderProperties.create_doc_properties',
     'dossiertemplate': 'opengever.dossier.dossiertemplate.interfaces.IDossierTemplateSettings.is_feature_enabled',


### PR DESCRIPTION
The newly introduced use of the `changed` date of documents in the calculation of the `earliest_possible_end_date` of a dossier (https://github.com/4teamwork/opengever.core/pull/4806) does not seem to cover all use cases. Indeed some users will modify document metadata, or add some documents while cleaning up a dossier just prior to closing it. The end date will in that case not reflect the what they consider to be the end date of the dossier. To accommodate these use cases, we introduce a new configuration setting allowing to restore the behaviour we had before, i.e. use the `document_date` in the calculation of the `earliest_possible_end_date`.

For https://github.com/4teamwork/opengever.zug/issues/319

## Checkliste
- [x] Profil angepasst? Sind UpgradeSteps vorhanden/nötig?:
- [x] Sind UpgradeSteps `deferrable`, oder können gewisse Schritte des Upgrades konditional ausgeführt werden? Not necessary to use deferrable here
- [x] Gibt es ein neues Feature-Flag? Wurden dafür Tests mit aktiviertem und deaktivierte Flag geschrieben?
- [x] Changelog-Eintrag vorhanden/nötig?
- [x] Aktualisierung Dokumentation vorhanden/nötig?
