### PR TITLE
Reindex object without changing modified date.

### DIFF
--- a/opengever/testing/builders/dx.py
+++ b/opengever/testing/builders/dx.py
@@ -139,7 +139,13 @@ class DocumentBuilder(DexterityBuilder):
     def create_object(self):
         obj = super(DocumentBuilder, self).create_object()
         # Trigger bumblebee checksum creation:
-        notify(ObjectAddedEvent(obj))
+        # Store modification date, reindex the object (which overwrites the modification date),
+        # then set the modification date and reindex yet again without overwriting the modification
+        # date. Similar to `catalog_reindex_objects` in ftw/upgrade/step.py.
+        modification_date = obj.modified()
+        obj.reindexObject()
+        obj.setModificationDate(modification_date)
+        obj.reindexObject(idxs=['modified'])
         return obj
 
     def after_create(self, obj):


### PR DESCRIPTION
Der failing Test in RIS war unabhängig von diesen Änderungen.

Ich habe mit diesen Änderungen alle Backend-Tapes neu aufzeichnen lassen (https://github.com/4teamwork/ris/pull/1615) ohne dass sich etwas an den Tapes geändert hätte (*zur Sicherheit könnte man noch alle frontend-Tapes neu aufzeichnen lassen, das dauerte mir aber zu lange ...*).