### PR TITLE
Add filename and checked_out fields to the recently-touched endpoint.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 ------------------------
 
 - Include original files in ech0160 SIP export even when archival_file exists. [njohner]
+- Add filename and checked_out fields to recently-touched endpoint. [njohner]
 - Add new registry field to switch between changed and document_date for dossier end date calculation. [njohner]
 
 

--- a/docs/public/dev-manual/api/recently_touched.rst
+++ b/docs/public/dev-manual/api/recently_touched.rst
@@ -49,21 +49,27 @@ zwei separaten Listen:
             "icon_class": "icon-dokument_word is-checked-out-by-current-user",
             "last_touched": "2018-05-31T15:40:23+02:00",
             "target_url": "http://localhost:8080/fd/ordnungssystem/fuehrung/gemeinderecht/dossier-25/document-197",
-            "title": "Datenschutzrichtlinien Muster AG"
+            "title": "Datenschutzrichtlinien Muster AG",
+            "filename": "Datenschutzrichtlinien Muster AG.docx",
+            "checked_out": "peter.muster"
           },
           {
             "icon_class": "icon-dokument_excel is-checked-out-by-current-user",
             "last_touched": "2018-05-31T15:40:01+02:00",
             "target_url": "http://localhost:8080/fd/ordnungssystem/fuehrung/gemeinderecht/dossier-25/document-191",
-            "title": "Bilanz Muster AG 2018"
+            "title": "Bilanz Muster AG 2018",
+            "filename": "Bilanz Muster AG 2018.xlsx",
+            "checked_out": "peter.muster"
           }
         ],
         "recently_touched": [
           {
-            "icon_class": "icon-dokument_powerpoint",
+            "icon_class": "icon-dokument_powerpoint is-checked-out",
             "last_touched": "2018-05-31T15:35:38.607793",
             "target_url": "http://localhost:8080/fd/ordnungssystem/fuehrung/gemeinderecht/dossier-18/document-229",
-            "title": "Pra\u0308sentation - Firmenprofil Muster AG"
+            "title": "Pra\u0308sentation - Firmenprofil Muster AG",
+            "filename": "Praesentation - Firmenprofil Muster AG.ppt",
+            "checked_out": "anderer.user"
           },
           {
             "...": ""
@@ -73,6 +79,8 @@ zwei separaten Listen:
             "last_touched": "2018-05-31T15:34:42.442729",
             "target_url": "http://localhost:8080/fd/ordnungssystem/fuehrung/gemeinderecht/dossier-18/document-236",
             "title": "Anfrage Drei"
+            "filename": "Anfrage Drei.docx",
+            "checked_out": ""
           }
         ]
       }

--- a/opengever/api/recently_touched.py
+++ b/opengever/api/recently_touched.py
@@ -75,6 +75,8 @@ class RecentlyTouchedGet(Service):
                 "last_touched": brain.modified.ISO8601(),
                 "target_url": brain.getURL(),
                 "title": brain.Title,
+                "filename": brain.filename,
+                "checked_out": brain.checked_out,
             }
             entries.append(data)
         return entries
@@ -129,6 +131,8 @@ class RecentlyTouchedGet(Service):
                 "last_touched": entry['last_touched'].isoformat(),
                 "target_url": brain.getURL(),
                 "title": brain.Title,
+                "filename": brain.filename,
+                "checked_out": brain.checked_out,
             }
             entries.append(data)
 


### PR DESCRIPTION
To allow to easily display an icon and a hint whether a document is checked out or not in the recently touched menu of the new UI, we add the `filename` and `checked_out` fields to the `recently-touched` endpoint.

Note that we have a discrepancy between the `last_touched` date for recently touched vs checked out documents. In one case it's timezone aware and in the other it's not. See comment in the tests.

This is for https://github.com/4teamwork/opengever.core/issues/5760

## Checkliste

- [x] Gibt es neue Funktionalität mit einem `Dokument`? Funktioniert das auch mit einem `Mail`?
- [x] Changelog-Eintrag vorhanden/nötig?
- [x] Aktualisierung Dokumentation vorhanden/nötig?
