### PR TITLE
Include original files in ech0160 SIP export.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2019.4.0rc3 (unreleased)
 ------------------------
 
+- Include original files in ech0160 SIP export even when archival_file exists. [njohner]
 - Add new registry field to switch between changed and document_date for dossier end date calculation. [njohner]
 
 

--- a/opengever/disposition/ech0160/model/document.py
+++ b/opengever/disposition/ech0160/model/document.py
@@ -9,7 +9,7 @@ class Document(object):
 
     def __init__(self, obj):
         self.obj = obj
-        self.file_ref = None
+        self.file_refs = []
 
     def binding(self):
         dokument = arelda.dokumentGeverSIP(id=u'_{}'.format(self.obj.UID()))
@@ -38,7 +38,7 @@ class Document(object):
 
         set_classification_attributes(dokument, self.obj)
 
-        if self.file_ref:
-            dokument.dateiRef.append(self.file_ref)
+        for file_ref in self.file_refs:
+            dokument.dateiRef.append(file_ref)
 
         return dokument

--- a/opengever/disposition/ech0160/model/file.py
+++ b/opengever/disposition/ech0160/model/file.py
@@ -7,10 +7,10 @@ import os.path
 class File(object):
     """eCH-0160 dateiSIP"""
 
-    def __init__(self, toc, document):
-        self.file = document.obj.archival_file or document.obj.file
+    def __init__(self, toc, document, file):
+        self.file = file
         self.id = u'_{}'.format(binascii.hexlify(self.file._p_oid))
-        document.file_ref = self.id
+        document.file_refs.append(self.id)
         self.document = document
         self.filename = self.file.filename
         self.filepath = self.file._blob.committed()

--- a/opengever/disposition/ech0160/model/folder.py
+++ b/opengever/disposition/ech0160/model/folder.py
@@ -18,8 +18,10 @@ class Folder(object):
             self.folders.append(Folder(toc, subdossier, self.path))
 
         for doc in dossier.documents.values():
-            if doc.obj.archival_file or doc.obj.file:
-                self.files.append(File(toc, doc))
+            if doc.obj.archival_file:
+                self.files.append(File(toc, doc, doc.obj.archival_file))
+            if doc.obj.file:
+                self.files.append(File(toc, doc, doc.obj.file))
 
     def binding(self):
         ordner = arelda.ordnerSIP(self.name)

--- a/opengever/disposition/tests/test_sippackage.py
+++ b/opengever/disposition/tests/test_sippackage.py
@@ -124,5 +124,6 @@ class TestSIPPackage(FunctionalTestCase):
                  'SIP_20160611_PLONE_10xy/header/xsd/zusatzDaten.xsd',
                  'SIP_20160611_PLONE_10xy/content/d000001/p000001.doc',
                  'SIP_20160611_PLONE_10xy/content/d000002/p000002.pdf',
+                 'SIP_20160611_PLONE_10xy/content/d000002/p000003.doc',
                  'SIP_20160611_PLONE_10xy/header/metadata.xml'],
                 zip_file.namelist())


### PR DESCRIPTION
Up to now, only the archival file would be included in the SIP package during eCH-0160 export if an archival file is present. We now always export the original file and also the archival file when one is present.

I checked that there is no problem with the numbering. We are basically simply adding another `File`, these get numbered automatically, so there cannot be any naming conflict.

For issue https://github.com/4teamwork/opengever.core/issues/5809

## Checkliste
- [x] Gibt es neue Funktionalität mit einem `Dokument`? Funktioniert das auch mit einem `Mail`? Mails are not included in the SIP export.
- [x] Changelog-Eintrag vorhanden/nötig?
- [x] Aktualisierung Dokumentation vorhanden/nötig? IMHO not necessary
