### PR TITLE
Prevent copy / paste of checked out documents

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2019.4.0rc3 (unreleased)
 ------------------------
 
+- Prevent copy / paste of checked out documents. [njohner]
 - Bump ftw.solr to 2.6.1 to get fix path_depth handling. [phgross]
 - Correctly handle inactive groups in the sharing view. [njohner]
 - Include original files in ech0160 SIP export even when archival_file exists. [njohner]

--- a/opengever/api/tests/test_copy_paste.py
+++ b/opengever/api/tests/test_copy_paste.py
@@ -1,0 +1,47 @@
+from opengever.testing import IntegrationTestCase
+from ftw.testbrowser import browsing
+import json
+
+
+class TestCopyPasteAPI(IntegrationTestCase):
+
+    @browsing
+    def test_copy_paste_document(self, browser):
+        self.login(self.regular_user, browser)
+        payload = {
+            u'source': self.document.absolute_url(),
+        }
+
+        with self.observe_children(self.empty_dossier) as children:
+            browser.open(
+                self.empty_dossier.absolute_url() + '/@copy',
+                data=json.dumps(payload),
+                method='POST',
+                headers=self.api_headers)
+
+        self.assertEqual(1, len(children["added"]))
+        copy = children["added"].pop()
+        self.assertEqual("copy of " + self.document.title, copy.title)
+        self.assertEqual([{u'source': self.document.absolute_url(),
+                           u'target': copy.absolute_url()}],
+                         browser.json)
+
+    @browsing
+    def test_copy_paste_checked_out_document_is_forbidden(self, browser):
+        self.login(self.regular_user, browser)
+        payload = {
+            u'source': self.document.absolute_url(),
+        }
+
+        self.checkout_document(self.document)
+
+        with browser.expect_http_error(500):
+            browser.open(
+                self.empty_dossier.absolute_url() + '/@copy',
+                data=json.dumps(payload),
+                method='POST',
+                headers=self.api_headers)
+
+        self.assertEqual({u'message': u'Checked out documents cannot be copied.',
+                          u'type': u'CopyError'},
+                         browser.json)

--- a/opengever/base/locales/de/LC_MESSAGES/opengever.base.po
+++ b/opengever/base/locales/de/LC_MESSAGES/opengever.base.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-08-23 12:03+0000\n"
+"POT-Creation-Date: 2019-08-23 13:27+0000\n"
 "PO-Revision-Date: 2014-09-04 01:03+0200\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: Jonas Baumann <j.baumann@4teamwork.ch>\n"
@@ -121,6 +121,11 @@ msgstr "Entschuldigung, aber die Webseite die Sie versucht haben zu erreichen is
 #: ./opengever/base/browser/templates/error.pt
 msgid "description_site_error_site_admin"
 msgstr "Bitte kontaktieren Sie die fachapplikationsverantwortliche Person, wenn dieses Problem längerfristig besteht."
+
+#. Default: "Checked out documents cannot be copied."
+#: ./opengever/base/browser/copy_items.py
+msgid "error_checked_out_cannot_be_copied"
+msgstr "Ausgecheckte Dokumente können nicht kopiert werden."
 
 #. Default: "You have not selected any Items."
 #: ./opengever/base/browser/copy_items.py

--- a/opengever/base/locales/fr/LC_MESSAGES/opengever.base.po
+++ b/opengever/base/locales/fr/LC_MESSAGES/opengever.base.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-08-23 12:03+0000\n"
+"POT-Creation-Date: 2019-08-23 13:27+0000\n"
 "PO-Revision-Date: 2017-11-29 10:53+0000\n"
 "Last-Translator: Philippe Gross <gross.philippe@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-base/fr/>\n"
@@ -122,6 +122,11 @@ msgstr "Nous nous excusons pour la gêne occasionnée, mais la page à laquelle 
 #: ./opengever/base/browser/templates/error.pt
 msgid "description_site_error_site_admin"
 msgstr "Si ce problème subsiste, veuillez contacter le responsable de l'application, s'il vous plaît."
+
+#. Default: "Checked out documents cannot be copied."
+#: ./opengever/base/browser/copy_items.py
+msgid "error_checked_out_cannot_be_copied"
+msgstr "Les documents en checkout ne peuvent pas être copiés."
 
 #. Default: "You have not selected any Items."
 #: ./opengever/base/browser/copy_items.py

--- a/opengever/base/locales/opengever.base.pot
+++ b/opengever/base/locales/opengever.base.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-08-23 12:03+0000\n"
+"POT-Creation-Date: 2019-08-23 13:27+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -119,6 +119,11 @@ msgstr ""
 #. Default: "Please contact the responsible person if this problem persists."
 #: ./opengever/base/browser/templates/error.pt
 msgid "description_site_error_site_admin"
+msgstr ""
+
+#. Default: "Checked out documents cannot be copied."
+#: ./opengever/base/browser/copy_items.py
+msgid "error_checked_out_cannot_be_copied"
 msgstr ""
 
 #. Default: "You have not selected any Items."

--- a/opengever/base/monkey/patches/verify_object_paste.py
+++ b/opengever/base/monkey/patches/verify_object_paste.py
@@ -15,6 +15,7 @@ class PatchCopyContainerVerifyObjectPaste(MonkeyPatch):
         from cgi import escape
         from OFS.CopySupport import absattr
         from OFS.CopySupport import CopyError
+        from opengever.document.behaviors import IBaseDocument
         from ZODB.POSException import ConflictError
 
         def _verifyObjectPaste(self, object, validate_src=1):
@@ -31,6 +32,11 @@ class PatchCopyContainerVerifyObjectPaste(MonkeyPatch):
             # existing context, such as checking an object during an import
             # (the object will not yet have been connected to the acquisition
             # heirarchy).
+            #
+            # We also make sure that we are not pasting a checked-out document
+
+            if IBaseDocument.providedBy(object) and object.is_checked_out():
+                raise CopyError('Checked out documents cannot be copied.')
 
             if not hasattr(object, 'meta_type'):
                 raise CopyError(MessageDialog(

--- a/opengever/base/tests/test_copy_paste.py
+++ b/opengever/base/tests/test_copy_paste.py
@@ -39,6 +39,19 @@ class TestCopyItems(IntegrationTestCase):
         self.assertEqual(self.dossier.absolute_url(), browser.url)
         self.assertEqual(['Selected objects successfully copied.'], info_messages())
 
+    @browsing
+    def test_cannot_copy_checked_out_document(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        self.checkout_document(self.document)
+        data = self.make_path_param(self.document, self.mail_eml)
+        browser.open(self.dossier, data=data, view='copy_items')
+
+        self.assertEqual(self.dossier.absolute_url(), browser.url)
+        self.assertEqual([], info_messages())
+        self.assertEqual(['Checked out documents cannot be copied.'],
+                         error_messages())
+
 
 class TestCopyItem(IntegrationTestCase):
 
@@ -50,6 +63,17 @@ class TestCopyItem(IntegrationTestCase):
         self.assertEqual(self.document.absolute_url(), browser.url)
         self.assertEqual(['Selected objects successfully copied.'],
                          info_messages())
+
+    @browsing
+    def test_cannot_copy_checked_out_document(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        self.checkout_document(self.document)
+        browser.open(self.document, view='copy_item')
+
+        self.assertEqual(self.document.absolute_url(), browser.url)
+        self.assertEqual(['Checked out documents cannot be copied.'],
+                         error_messages())
 
     @browsing
     def test_statusmessage_if_paste_document_success(self, browser):

--- a/opengever/base/tests/test_copy_paste.py
+++ b/opengever/base/tests/test_copy_paste.py
@@ -52,6 +52,23 @@ class TestCopyItems(IntegrationTestCase):
         self.assertEqual(['Checked out documents cannot be copied.'],
                          error_messages())
 
+    @browsing
+    def test_cannot_copy_dossier_containing_checked_out_document(self, browser):
+        self.login(self.regular_user, browser=browser)
+        data = self.make_path_param(self.empty_dossier, self.dossier)
+
+        browser.open(self.leaf_repofolder, data=data, view='copy_items')
+        self.assertEqual(self.leaf_repofolder.absolute_url(), browser.url)
+        self.assertEqual(['Selected objects successfully copied.'], info_messages())
+        self.assertEqual([], error_messages())
+
+        self.checkout_document(self.document)
+        browser.open(self.leaf_repofolder, data=data, view='copy_items')
+        self.assertEqual(self.leaf_repofolder.absolute_url(), browser.url)
+        self.assertEqual([], info_messages())
+        self.assertEqual(['Checked out documents cannot be copied.'],
+                         error_messages())
+
 
 class TestCopyItem(IntegrationTestCase):
 
@@ -72,6 +89,24 @@ class TestCopyItem(IntegrationTestCase):
         browser.open(self.document, view='copy_item')
 
         self.assertEqual(self.document.absolute_url(), browser.url)
+        self.assertEqual(['Checked out documents cannot be copied.'],
+                         error_messages())
+
+    @browsing
+    def test_cannot_copy_dossier_containing_checked_out_document(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        browser.open(self.dossier, view='copy_item')
+        self.assertEqual(self.dossier.absolute_url(), browser.url)
+        self.assertEqual(['Selected objects successfully copied.'],
+                         info_messages())
+        self.assertEqual([], error_messages())
+
+        self.checkout_document(self.document)
+        browser.open(self.dossier, view='copy_item')
+
+        self.assertEqual(self.dossier.absolute_url(), browser.url)
+        self.assertEqual([], info_messages())
         self.assertEqual(['Checked out documents cannot be copied.'],
                          error_messages())
 

--- a/opengever/core/profiles/default/actions.xml
+++ b/opengever/core/profiles/default/actions.xml
@@ -540,7 +540,7 @@
       <property name="description" i18n:translate="" />
       <property name="url_expr">string:${globals_view/getCurrentObjectUrl}/copy_item</property>
       <property name="icon_expr" />
-      <property name="available_expr">python:object.restrictedTraverse('@@plone_interface_info').provides('opengever.document.behaviors.IBaseDocument')</property>
+      <property name="available_expr">python:object.restrictedTraverse('@@plone_interface_info').provides('opengever.document.behaviors.IBaseDocument') and not object.is_checked_out()</property>
       <property name="permissions">
         <element value="Copy or Move" />
       </property>

--- a/opengever/core/upgrades/20190823113658_do_not_show_copy_action_for_checked_out_documents/actions.xml
+++ b/opengever/core/upgrades/20190823113658_do_not_show_copy_action_for_checked_out_documents/actions.xml
@@ -1,0 +1,20 @@
+<object xmlns:i18n="http://xml.zope.org/namespaces/i18n" name="portal_actions" meta_type="Plone Actions Tool">
+
+  <!-- OBJECT BUTTONS -->
+  <object name="object_buttons" meta_type="CMF Action Category">
+
+    <object name="copy_item" meta_type="CMF Action" i18n:domain="opengever.core">
+      <property name="title" i18n:translate="">Copy Item</property>
+      <property name="description" i18n:translate="" />
+      <property name="url_expr">string:${globals_view/getCurrentObjectUrl}/copy_item</property>
+      <property name="icon_expr" />
+      <property name="available_expr">python:object.restrictedTraverse('@@plone_interface_info').provides('opengever.document.behaviors.IBaseDocument') and not object.is_checked_out()</property>
+      <property name="permissions">
+        <element value="Copy or Move" />
+      </property>
+      <property name="visible">True</property>
+    </object>
+
+  </object>
+
+</object>

--- a/opengever/core/upgrades/20190823113658_do_not_show_copy_action_for_checked_out_documents/upgrade.py
+++ b/opengever/core/upgrades/20190823113658_do_not_show_copy_action_for_checked_out_documents/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class DoNotShowCopyActionForCheckedOutDocuments(UpgradeStep):
+    """Do not show copy action for checked out documents.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/document/tests/test_copy_document.py
+++ b/opengever/document/tests/test_copy_document.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from DateTime import DateTime
 from ftw.testbrowser import browsing
 from ftw.testing import freeze
+from OFS.CopySupport import CopyError
 from opengever.testing import IntegrationTestCase
 from plone import api
 import pytz
@@ -47,6 +48,12 @@ class TestCopyDocuments(IntegrationTestCase):
         new_doc = self.dossier['copy_of_document-14']
         new_history = self.portal.portal_repository.getHistory(new_doc)
         self.assertEqual(len(new_history), 0)
+
+    def test_copying_a_checked_out_document_is_forbidden(self):
+        self.login(self.regular_user)
+        self.checkout_document(self.document)
+        with self.assertRaises(CopyError):
+            api.content.copy(source=self.document, target=self.subdossier)
 
     @browsing
     def test_document_copy_metadata(self, browser):

--- a/opengever/document/tests/test_menu.py
+++ b/opengever/document/tests/test_menu.py
@@ -1,0 +1,17 @@
+from ftw.testbrowser import browsing
+from ftw.testbrowser.pages import editbar
+from opengever.testing import IntegrationTestCase
+
+
+class TestActionMenu(IntegrationTestCase):
+
+    @browsing
+    def test_copy_unavailable_for_checked_out_document(self, browser):
+        self.login(self.regular_user, browser)
+
+        browser.open(self.document)
+        self.assertIn('Copy Item', editbar.menu_options('Actions'))
+
+        self.checkout_document(self.document)
+        browser.open(self.document)
+        self.assertNotIn('Copy Item', editbar.menu_options('Actions'))

--- a/opengever/document/tests/test_overview.py
+++ b/opengever/document/tests/test_overview.py
@@ -728,7 +728,6 @@ class TestDocumentOverviewVanilla(IntegrationTestCase):
         document_portal_actions = [
             'Edit metadata',
             u'Actions \u25bc',
-            'Copy Item',
             'Properties',
             u'Checkin \u25bc',
             'with comment',


### PR DESCRIPTION
We prevent copy / pasting documents that are checked out, because the state of such documents is not well defined (we might be copying a working copy of another user), and the pasted object will be in the checked-out state.

We try to handle the case gracefully whenever possible:
* Disable copy action for checked-out documents. (action not shown in the actions menu)
* Forbid copy pasting of checked-out documents from the TabbedView listings (objects will not land in the clipboard and an error message is displayed)

Other cases (rest api, or `plone.api.content.copy` for example) are handled in the `_verifyObjectPaste` that we have already monkey patched. I first tried to handle these cases with an event handler, but there on the `lifecycleevent`s we don't have access to the object being copied, especially when copying a dossier containing documents. Anyway `_verifyObjectPaste` is IMO the correct place to handle this.

This is for https://github.com/4teamwork/opengever.core/issues/5819

**copy action button on a document**
<img width="1189" alt="Screenshot 2019-08-26 at 09 59 51" src="https://user-images.githubusercontent.com/7374243/63675277-ba183700-c7e8-11e9-8aee-bfbfcb0e81eb.png">

**copy action is not available when document checked-out**
<img width="1189" alt="Screenshot 2019-08-26 at 09 59 35" src="https://user-images.githubusercontent.com/7374243/63675276-ba183700-c7e8-11e9-9d72-1dcd84ac5b90.png">

**When copying documents from the document listing**
<img width="1189" alt="Screenshot 2019-08-26 at 09 58 06" src="https://user-images.githubusercontent.com/7374243/63675278-ba183700-c7e8-11e9-93f8-9cc9dab5d398.png">

**An error message is displayed when some documents being copied are checked-out**
<img width="1189" alt="Screenshot 2019-08-26 at 09 58 16" src="https://user-images.githubusercontent.com/7374243/63675274-b97fa080-c7e8-11e9-830f-704e1e3db56f.png">

**Same thing when copying a dossier containing a checked-out document**
<img width="1189" alt="Screenshot 2019-08-26 at 09 58 40" src="https://user-images.githubusercontent.com/7374243/63675273-b97fa080-c7e8-11e9-85c1-d29d54dbef6d.png">

**The error message is displayed and objects are not copied**
<img width="1189" alt="Screenshot 2019-08-26 at 09 58 47" src="https://user-images.githubusercontent.com/7374243/63675275-ba183700-c7e8-11e9-9e41-e2867169cf4c.png">

## Checkliste

- [x] Gibt es neue Funktionalität mit einem `Dokument`? Funktioniert das auch mit einem `Mail`? Mails cannot be checked-out.
- [x] Profil angepasst? Sind UpgradeSteps vorhanden/nötig?:
- [x] Sind UpgradeSteps `deferrable`, oder können gewisse Schritte des Upgrades konditional ausgeführt werden? Nicht nötig
- [x] Gibt es neue Übersetzungen?
- [x] Changelog-Eintrag vorhanden/nötig?
