### PR TITLE
Drop custom model forms for proposals and create proposal model via event handler.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,7 @@ Changelog
 - Prevent copy / paste of checked out documents. [njohner]
 - Bump ftw.solr to 2.6.1 to get fix path_depth handling. [phgross]
 - Correctly handle inactive groups in the sharing view. [njohner]
+- Drop custom model forms for proposals and create proposal model via event handler. [deiferni]
 - Include original files in ech0160 SIP export even when archival_file exists. [njohner]
 - Add filename and checked_out fields to recently-touched endpoint. [njohner]
 - Add new registry field to switch between changed and document_date for dossier end date calculation. [njohner]

--- a/opengever/base/tests/test_default_values_for_types.py
+++ b/opengever/base/tests/test_default_values_for_types.py
@@ -251,7 +251,8 @@ CONTACT_MISSING_VALUES = {
 
 PROPOSAL_REQUIREDS = {
     'issuer': u'herbert.jager',
-    'committee_oguid': u'fd:1337',
+    # the oguid should be stable due to `time_based_intids`
+    'committee_oguid': u'plone:1009313300',
 }
 PROPOSAL_DEFAULTS = {
     'changed': FROZEN_NOW,

--- a/opengever/meeting/browser/proposalforms.py
+++ b/opengever/meeting/browser/proposalforms.py
@@ -1,13 +1,10 @@
 from ftw.table import helper
-from opengever.base.oguid import Oguid
 from opengever.base.schema import TableChoice
 from opengever.base.source import DossierPathSourceBinder
 from opengever.document.interfaces import ICheckinCheckoutManager
 from opengever.meeting import _
 from opengever.meeting import is_meeting_feature_enabled
-from opengever.meeting.activity.watchers import add_watcher_on_proposal_created
 from opengever.meeting.activity.watchers import change_watcher_on_proposal_edited
-from opengever.meeting.interfaces import IHistory
 from opengever.meeting.proposal import IProposal
 from opengever.officeconnector.helpers import is_officeconnector_checkout_feature_enabled  # noqa
 from opengever.tabbedview.helper import document_with_icon
@@ -310,14 +307,6 @@ class ProposalAddForm(DefaultAddForm):
         )
         if edit_after_creation:
             self.checkout_and_external_edit(proposal_doc)
-
-        add_watcher_on_proposal_created(proposal)
-        IHistory(proposal).append_record(u'created')
-        if proposal.predecessor_proposal is not None:
-            predecessor = proposal.predecessor_proposal.to_object
-            IHistory(predecessor).append_record(
-                u'successor_created',
-                successor_oguid=Oguid.for_object(proposal).id)
 
         return proposal
 

--- a/opengever/meeting/browser/proposalforms.py
+++ b/opengever/meeting/browser/proposalforms.py
@@ -10,16 +10,15 @@ from opengever.meeting.activity.watchers import change_watcher_on_proposal_edite
 from opengever.meeting.form import ModelProxyEditForm
 from opengever.meeting.interfaces import IHistory
 from opengever.meeting.proposal import IProposal
-from opengever.meeting.proposal import Proposal
 from opengever.meeting.proposal import SubmittedProposal
 from opengever.officeconnector.helpers import is_officeconnector_checkout_feature_enabled  # noqa
 from opengever.tabbedview.helper import document_with_icon
 from plone import api
 from plone.app.uuid.utils import uuidToObject
 from plone.autoform import directives as form
-from plone.dexterity.browser import edit
 from plone.dexterity.browser.add import DefaultAddForm
 from plone.dexterity.browser.add import DefaultAddView
+from plone.dexterity.browser.edit import DefaultEditForm
 from plone.dexterity.interfaces import IDexterityFTI
 from plone.z3cform.fieldsets.utils import move
 from Products.CMFCore.interfaces import IFolderish
@@ -43,11 +42,13 @@ from zope.schema.vocabulary import SimpleTerm
 from zope.schema.vocabulary import SimpleVocabulary
 
 
-class ProposalEditForm(ModelProxyEditForm,
-                       edit.DefaultEditForm):
+class ProposalEditForm(DefaultEditForm):
 
-    fields = field.Fields(Proposal.model_schema, ignoreContext=True)
-    content_type = Proposal
+    def render(self):
+        if not is_meeting_feature_enabled():
+            raise Unauthorized
+
+        return super(ProposalEditForm, self).render()
 
     def updateFields(self):
         super(ProposalEditForm, self).updateFields()
@@ -72,8 +73,7 @@ class ProposalEditForm(ModelProxyEditForm,
         return super(ProposalEditForm, self).applyChanges(data)
 
 
-class SubmittedProposalEditForm(ModelProxyEditForm,
-                                edit.DefaultEditForm):
+class SubmittedProposalEditForm(ModelProxyEditForm, DefaultEditForm):
 
     fields = field.Fields(SubmittedProposal.model_schema, ignoreContext=True)
     content_type = SubmittedProposal

--- a/opengever/meeting/configure.zcml
+++ b/opengever/meeting/configure.zcml
@@ -185,25 +185,25 @@
   <subscriber
       for="opengever.meeting.proposal.IBaseProposal
            zope.lifecycleevent.interfaces.IObjectMovedEvent"
-      handler=".handlers.sync_moved_proposal"
+      handler=".handlers.proposal_moved"
       />
 
   <subscriber
       for="opengever.meeting.proposal.IProposal
            zope.lifecycleevent.interfaces.IObjectModifiedEvent"
-      handler=".handlers.sync_proposal"
+      handler=".handlers.proposal_modified"
       />
 
   <subscriber
       for="opengever.meeting.proposal.IProposal
            zope.lifecycleevent.interfaces.IObjectAddedEvent"
-      handler=".handlers.sync_proposal"
+      handler=".handlers.proposal_added"
       />
 
   <subscriber
       for="opengever.meeting.proposal.ISubmittedProposal
            zope.lifecycleevent.interfaces.IObjectModifiedEvent"
-      handler=".handlers.sync_submitted_proposal"
+      handler=".handlers.submitted_proposal_modified"
       />
 
   <adapter factory=".committee.RepositoryfolderValidator" />

--- a/opengever/meeting/configure.zcml
+++ b/opengever/meeting/configure.zcml
@@ -189,7 +189,7 @@
       />
 
   <subscriber
-      for="opengever.meeting.proposal.IBaseProposal
+      for="opengever.meeting.proposal.IProposal
            zope.lifecycleevent.interfaces.IObjectModifiedEvent"
       handler=".handlers.sync_proposal"
       />
@@ -198,6 +198,12 @@
       for="opengever.meeting.proposal.IProposal
            zope.lifecycleevent.interfaces.IObjectAddedEvent"
       handler=".handlers.sync_proposal"
+      />
+
+  <subscriber
+      for="opengever.meeting.proposal.ISubmittedProposal
+           zope.lifecycleevent.interfaces.IObjectModifiedEvent"
+      handler=".handlers.sync_submitted_proposal"
       />
 
   <adapter factory=".committee.RepositoryfolderValidator" />

--- a/opengever/meeting/configure.zcml
+++ b/opengever/meeting/configure.zcml
@@ -194,6 +194,12 @@
       handler=".handlers.sync_proposal"
       />
 
+  <subscriber
+      for="opengever.meeting.proposal.IProposal
+           zope.lifecycleevent.interfaces.IObjectAddedEvent"
+      handler=".handlers.sync_proposal"
+      />
+
   <adapter factory=".committee.RepositoryfolderValidator" />
 
 </configure>

--- a/opengever/meeting/docprops.py
+++ b/opengever/meeting/docprops.py
@@ -25,12 +25,17 @@ class ProposalDocPropertyProvider(object):
                                         context=self.context.REQUEST),
         }
 
-        agenda_item = proposal.load_model().agenda_item
-        if agenda_item:
-            properties['decision_number'] = agenda_item.get_decision_number()
-            properties['agenda_item_number'] = agenda_item.formatted_number
-            properties['agenda_item_number_raw'] = agenda_item.item_number
+        model = proposal.load_model()
+        if not model:
+            return properties
 
+        agenda_item = model.agenda_item
+        if not agenda_item:
+            return properties
+
+        properties['decision_number'] = agenda_item.get_decision_number()
+        properties['agenda_item_number'] = agenda_item.formatted_number
+        properties['agenda_item_number_raw'] = agenda_item.item_number
         return properties
 
     def get_properties(self):

--- a/opengever/meeting/handlers.py
+++ b/opengever/meeting/handlers.py
@@ -5,13 +5,13 @@ from opengever.base.model import create_session
 from opengever.base.oguid import Oguid
 from opengever.base.portlets import block_context_portlet_inheritance
 from opengever.base.security import elevated_privileges
-from opengever.base.sqlsyncer import SqlSyncer
 from opengever.meeting.command import UpdateExcerptInDossierCommand
 from opengever.meeting.model import GeneratedExcerpt
 from opengever.meeting.model import Proposal
 from opengever.meeting.model import SubmittedDocument
 from opengever.meeting.model.excerpt import Excerpt
 from opengever.meeting.proposal import ISubmittedProposal
+from opengever.meeting.proposalsqlsyncer import ProposalSqlSyncer
 from opengever.meeting.sablontemplate import sablon_template_is_valid
 from opengever.setup.interfaces import IDuringSetup
 from zc.relation.interfaces import ICatalog
@@ -103,12 +103,6 @@ def delete_copied_proposal(copied_proposal, event):
     with elevated_privileges():
         container = aq_parent(copied_proposal)
         container._delObject(copied_proposal.id, suppress_events=True)
-
-
-class ProposalSqlSyncer(SqlSyncer):
-
-    def sync_with_sql(self):
-        self.obj.sync_model()
 
 
 def sync_moved_proposal(obj, event):

--- a/opengever/meeting/handlers.py
+++ b/opengever/meeting/handlers.py
@@ -12,6 +12,7 @@ from opengever.meeting.model import SubmittedDocument
 from opengever.meeting.model.excerpt import Excerpt
 from opengever.meeting.proposal import ISubmittedProposal
 from opengever.meeting.proposalsqlsyncer import ProposalSqlSyncer
+from opengever.meeting.proposalsqlsyncer import SubmittedProposalSqlSyncer
 from opengever.meeting.sablontemplate import sablon_template_is_valid
 from opengever.setup.interfaces import IDuringSetup
 from zc.relation.interfaces import ICatalog
@@ -122,6 +123,13 @@ def sync_proposal(obj, event):
         return
 
     ProposalSqlSyncer(obj, event).sync()
+
+
+def sync_submitted_proposal(obj, event):
+    if IContainerModifiedEvent.providedBy(event):
+        return
+
+    SubmittedProposalSqlSyncer(obj, event).sync()
 
 
 def configure_committee_container_portlets(container, event):

--- a/opengever/meeting/handlers.py
+++ b/opengever/meeting/handlers.py
@@ -5,7 +5,9 @@ from opengever.base.model import create_session
 from opengever.base.oguid import Oguid
 from opengever.base.portlets import block_context_portlet_inheritance
 from opengever.base.security import elevated_privileges
+from opengever.meeting.activity.watchers import add_watcher_on_proposal_created
 from opengever.meeting.command import UpdateExcerptInDossierCommand
+from opengever.meeting.interfaces import IHistory
 from opengever.meeting.model import GeneratedExcerpt
 from opengever.meeting.model import Proposal
 from opengever.meeting.model import SubmittedDocument
@@ -106,7 +108,7 @@ def delete_copied_proposal(copied_proposal, event):
         container._delObject(copied_proposal.id, suppress_events=True)
 
 
-def sync_moved_proposal(obj, event):
+def proposal_moved(obj, event):
     # Skip automatically renamed objects during copy & paste process.
     if ICopyPasteRequestLayer.providedBy(getRequest()):
         return
@@ -118,14 +120,26 @@ def sync_moved_proposal(obj, event):
     ProposalSqlSyncer(obj, event).sync()
 
 
-def sync_proposal(obj, event):
+def proposal_added(obj, event):
+    add_watcher_on_proposal_created(obj)
+    IHistory(obj).append_record(u'created')
+    if obj.predecessor_proposal is not None:
+        predecessor = obj.predecessor_proposal.to_object
+        IHistory(predecessor).append_record(
+            u'successor_created',
+            successor_oguid=Oguid.for_object(obj).id)
+
+    ProposalSqlSyncer(obj, event).sync()
+
+
+def proposal_modified(obj, event):
     if IContainerModifiedEvent.providedBy(event):
         return
 
     ProposalSqlSyncer(obj, event).sync()
 
 
-def sync_submitted_proposal(obj, event):
+def submitted_proposal_modified(obj, event):
     if IContainerModifiedEvent.providedBy(event):
         return
 

--- a/opengever/meeting/model/agendaitem.py
+++ b/opengever/meeting/model/agendaitem.py
@@ -131,7 +131,7 @@ class AgendaItem(Base):
         return '{}.'.format(self.item_number)
 
     def get_title(self, include_number=False, formatted=False):
-        title = (self.submitted_proposal.title if self.has_proposal else self.title)
+        title = (self.proposal.submitted_title if self.has_proposal else self.title)
 
         if include_number and self.item_number:
             if formatted:
@@ -147,12 +147,12 @@ class AgendaItem(Base):
     def set_title(self, title):
         if self.has_proposal:
             self.submitted_proposal.title = title
-            self.submitted_proposal.sync_model()
+            self.proposal.sync_with_submitted_proposal(self.submitted_proposal)
         else:
             self.title = title
 
     def get_description(self):
-        return (self.submitted_proposal.description if self.has_proposal
+        return (self.proposal.submitted_description if self.has_proposal
                 else self.description) or None
 
     def get_description_html(self):

--- a/opengever/meeting/model/proposal.py
+++ b/opengever/meeting/model/proposal.py
@@ -15,6 +15,7 @@ from opengever.meeting.model.generateddocument import GeneratedExcerpt
 from opengever.meeting.workflow import State
 from opengever.meeting.workflow import Transition
 from opengever.meeting.workflow import Workflow
+from opengever.ogds.base.utils import get_current_admin_unit
 from opengever.ogds.base.utils import ogds_service
 from plone import api
 from Products.CMFPlone.utils import safe_unicode
@@ -191,6 +192,8 @@ class Proposal(Base):
         return model
 
     def sync_with_proposal(self, proposal):
+        """Sync self with a plone proposal instance."""
+
         from opengever.meeting.model.committee import Committee
 
         reference_number = proposal.get_main_dossier_reference_number()
@@ -208,6 +211,16 @@ class Proposal(Base):
         self.issuer = proposal.issuer
         self.description = proposal.description
         self.date_of_submission = proposal.date_of_submission
+
+    def sync_with_submitted_proposal(self, submitted_proposal):
+        """Sync self with a plone submitted proposal instance."""
+
+        self.submitted_oguid = Oguid.for_object(submitted_proposal)
+        self.submitted_physical_path = submitted_proposal.get_physical_path()
+        self.submitted_admin_unit_id = get_current_admin_unit().id()
+        self.submitted_title = submitted_proposal.title
+        self.submitted_description = submitted_proposal.description
+        self.date_of_submission = submitted_proposal.date_of_submission
 
     def get_state(self):
         return self.workflow.get_state(self.workflow_state)

--- a/opengever/meeting/proposal.py
+++ b/opengever/meeting/proposal.py
@@ -323,7 +323,7 @@ class ProposalBase(object):
         return model.is_submitted()
 
 
-class SubmittedProposal(ProposalBase, ModelContainer):
+class SubmittedProposal(ModelContainer, ProposalBase):
     """Proxy for a proposal in queue with a committee."""
 
     content_schema = ISubmittedProposal
@@ -509,7 +509,7 @@ class SubmittedProposal(ProposalBase, ModelContainer):
         return values
 
 
-class Proposal(ProposalBase, Container):
+class Proposal(Container, ProposalBase):
     """Act as proxy for the proposal stored in the database.
 
     """

--- a/opengever/meeting/proposal.py
+++ b/opengever/meeting/proposal.py
@@ -381,9 +381,6 @@ class SubmittedProposal(ProposalBase, ModelContainer):
         url_tool = api.portal.get_tool(name="portal_url")
         return '/'.join(url_tool.getRelativeContentPath(self))
 
-    def load_proposal(self, oguid):
-        return ProposalModel.query.get_by_oguid(oguid)
-
     def sync_model(self, proposal_model=None):
         proposal_model = proposal_model or self.load_model()
 

--- a/opengever/meeting/proposal.py
+++ b/opengever/meeting/proposal.py
@@ -27,7 +27,6 @@ from opengever.meeting.command import RejectProposalCommand
 from opengever.meeting.command import UpdateSubmittedDocumentCommand
 from opengever.meeting.container import ModelContainer
 from opengever.meeting.interfaces import IHistory
-from opengever.meeting.model import Committee
 from opengever.meeting.model import SubmittedDocument
 from opengever.meeting.model.proposal import Proposal as ProposalModel
 from opengever.ogds.base.actor import Actor
@@ -40,9 +39,9 @@ from plone.app.uuid.utils import uuidToObject
 from plone.autoform.directives import mode
 from plone.autoform.directives import omitted
 from plone.autoform.directives import widget
+from plone.dexterity.content import Container
 from plone.supermodel import model
 from plone.uuid.interfaces import IUUID
-from Products.CMFPlone.utils import safe_unicode
 from z3c.relationfield.event import addRelations
 from z3c.relationfield.relation import RelationValue
 from z3c.relationfield.schema import RelationChoice
@@ -177,7 +176,7 @@ class ISubmittedProposal(IBaseProposal):
         required=False)
 
 
-class ProposalBase(ModelContainer):
+class ProposalBase(object):
 
     workflow = None
 
@@ -251,7 +250,11 @@ class ProposalBase(ModelContainer):
         return self.workflow.get_transitions(self.get_state())
 
     def get_state(self):
-        return self.load_model().get_state()
+        model = self.load_model()
+        if model:
+            return model.get_state()
+
+        return self.workflow.default_state
 
     def get_physical_path(self):
         url_tool = api.portal.get_tool(name="portal_url")
@@ -320,7 +323,7 @@ class ProposalBase(ModelContainer):
         return model.is_submitted()
 
 
-class SubmittedProposal(ProposalBase):
+class SubmittedProposal(ProposalBase, ModelContainer):
     """Proxy for a proposal in queue with a committee."""
 
     content_schema = ISubmittedProposal
@@ -519,33 +522,26 @@ class SubmittedProposal(ProposalBase):
         return values
 
 
-class Proposal(ProposalBase):
+class Proposal(ProposalBase, Container):
     """Act as proxy for the proposal stored in the database.
 
     """
-    content_schema = IProposal
-    model_schema = IProposalModel
-    model_class = ProposalModel
-
-    implements(content_schema)
+    implements(IProposal)
 
     workflow = ProposalModel.workflow.with_visible_transitions(
         ['pending-submitted', 'pending-cancelled', 'cancelled-pending'])
+
+    def load_model(self):
+        oguid = Oguid.for_object(self)
+        if oguid is None:
+            return None
+        return ProposalModel.query.get_by_oguid(oguid)
 
     def get_sync_admin_unit_id(self):
         return self.load_model().submitted_admin_unit_id
 
     def get_sync_target_path(self):
         return self.load_model().submitted_physical_path
-
-    def _after_model_created(self, model_instance):
-        IHistory(self).append_record(u'created')
-
-        if self.predecessor_proposal is not None:
-            predecessor = self.predecessor_proposal.to_object
-            IHistory(predecessor).append_record(
-                u'successor_created',
-                successor_oguid=Oguid.for_object(self).id)
 
     def is_editable(self):
         """A proposal in a dossier is only editable while not submitted.
@@ -580,50 +576,8 @@ class Proposal(ProposalBase):
         return repository_folder.Title(language=self.language,
                                        prefix_with_reference_number=False)
 
-    def update_model_create_arguments(self, data, context):
-        aq_wrapped_self = self.__of__(context)
-
-        workflow_state = self.workflow.default_state.name
-        reference_number = IReferenceNumber(
-            context.get_main_dossier()).get_number()
-
-        repository_folder_title = safe_unicode(
-            aq_wrapped_self.get_repository_folder_title())
-
-        committee_model = Committee.get_one(
-            oguid=Oguid.parse(self.committee_oguid))
-
-        data.update(dict(workflow_state=workflow_state,
-                         physical_path=aq_wrapped_self.get_physical_path(),
-                         dossier_reference_number=reference_number,
-                         repository_folder_title=repository_folder_title,
-                         committee=committee_model,
-                         issuer=self.issuer,
-                         language=self.language))
-        return data
-
-    def update_model(self, data):
-        data['repository_folder_title'] = safe_unicode(
-            self.get_repository_folder_title())
-        return super(Proposal, self).update_model(data)
-
-    def sync_model(self, proposal_model=None):
-        proposal_model = proposal_model or self.load_model()
-
-        reference_number = IReferenceNumber(
-            self.get_containing_dossier().get_main_dossier()).get_number()
-        repository_folder_title = safe_unicode(self.get_repository_folder_title())
-
-        proposal_model.committee = Committee.get_one(
-            oguid=Oguid.parse(self.committee_oguid))
-        proposal_model.language = self.language
-        proposal_model.physical_path = self.get_physical_path()
-        proposal_model.dossier_reference_number = reference_number
-        proposal_model.repository_folder_title = repository_folder_title
-        proposal_model.title = self.title
-        proposal_model.issuer = self.issuer
-        proposal_model.description = self.description
-        proposal_model.date_of_submission = self.date_of_submission
+    def get_main_dossier_reference_number(self):
+        return IReferenceNumber(self.get_main_dossier()).get_number()
 
     def is_submit_additional_documents_allowed(self):
         return self.load_model().is_submit_additional_documents_allowed()

--- a/opengever/meeting/proposal.py
+++ b/opengever/meeting/proposal.py
@@ -381,16 +381,6 @@ class SubmittedProposal(ProposalBase, ModelContainer):
         url_tool = api.portal.get_tool(name="portal_url")
         return '/'.join(url_tool.getRelativeContentPath(self))
 
-    def sync_model(self, proposal_model=None):
-        proposal_model = proposal_model or self.load_model()
-
-        proposal_model.submitted_oguid = Oguid.for_object(self)
-        proposal_model.submitted_physical_path = self.get_physical_path()
-        proposal_model.submitted_admin_unit_id = get_current_admin_unit().id()
-        proposal_model.submitted_title = self.title
-        proposal_model.submitted_description = self.description
-        proposal_model.date_of_submission = self.date_of_submission
-
     def load_model(self):
         oguid = Oguid.for_object(self)
         if oguid is None:

--- a/opengever/meeting/proposalsqlsyncer.py
+++ b/opengever/meeting/proposalsqlsyncer.py
@@ -7,6 +7,8 @@ from opengever.meeting.model.proposal import Proposal
 class ProposalSqlSyncer(SqlSyncer):
 
     def get_proposal(self):
+        """Return or create the corresponding proposal model."""
+
         oguid = Oguid.for_object(self.obj)
         proposal = Proposal.query.get_by_oguid(oguid)
         if proposal is None:
@@ -16,3 +18,15 @@ class ProposalSqlSyncer(SqlSyncer):
 
     def sync_with_sql(self):
         self.get_proposal().sync_with_proposal(self.obj)
+
+
+class SubmittedProposalSqlSyncer(SqlSyncer):
+
+    def get_proposal(self):
+        """Return the corresponding proposal model."""
+
+        oguid = Oguid.for_object(self.obj)
+        return Proposal.query.filter_by(submitted_oguid=oguid).one()
+
+    def sync_with_sql(self):
+        self.get_proposal().sync_with_submitted_proposal(self.obj)

--- a/opengever/meeting/proposalsqlsyncer.py
+++ b/opengever/meeting/proposalsqlsyncer.py
@@ -1,0 +1,18 @@
+from opengever.base.model import Session
+from opengever.base.oguid import Oguid
+from opengever.base.sqlsyncer import SqlSyncer
+from opengever.meeting.model.proposal import Proposal
+
+
+class ProposalSqlSyncer(SqlSyncer):
+
+    def get_proposal(self):
+        oguid = Oguid.for_object(self.obj)
+        proposal = Proposal.query.get_by_oguid(oguid)
+        if proposal is None:
+            proposal = Proposal.create_from(self.obj)
+            Session.add(proposal)
+        return proposal
+
+    def sync_with_sql(self):
+        self.get_proposal().sync_with_proposal(self.obj)

--- a/opengever/meeting/tests/test_proposal.py
+++ b/opengever/meeting/tests/test_proposal.py
@@ -35,6 +35,10 @@ from zope.component import getUtility
 
 class TestProposalViewsDisabled(IntegrationTestCase):
 
+    features = (
+        '!meeting',
+    )
+
     @browsing
     def test_add_form_is_disabled(self, browser):
         self.login(self.manager, browser)

--- a/opengever/meeting/tests/test_toc.py
+++ b/opengever/meeting/tests/test_toc.py
@@ -10,6 +10,7 @@ from opengever.base.interfaces import IReferenceNumberSettings
 from opengever.core.testing import OPENGEVER_FUNCTIONAL_MEETING_LAYER
 from opengever.meeting.command import MIME_DOCX
 from opengever.meeting.interfaces import IMeetingSettings
+from opengever.meeting.model import Proposal
 from opengever.meeting.toc.alphabetical import AlphabeticalToc
 from opengever.meeting.toc.dossier_refnum import DossierReferenceNumberBasedTOC
 from opengever.meeting.toc.repository import RepositoryBasedTOC
@@ -260,33 +261,43 @@ class TestAlphabeticalTOC(FunctionalTestCase):
             start=pytz.UTC.localize(datetime(2011, 1, 1, 0, 0)),
             protocol_start_page_number=99))
 
-        proposal1_1 = create(Builder('submitted_proposal').having(
-            title=u'proposal 1',
+        proposal1_1 = create(Builder('proposal_model').having(
+            submitted_title=u'proposal 1',
+            committee=self.committee_model,
+            workflow_state=Proposal.STATE_DECIDED.name,
             repository_folder_title=u'\xc4 Business',
             dossier_reference_number='1.1.4 / 1',
-            int_id=1).within(self.committee))
-        proposal1_2 = create(Builder('submitted_proposal').having(
-            title=u'\xc4a proposal',
+            int_id=1))
+        proposal1_2 = create(Builder('proposal_model').having(
+            submitted_title=u'\xc4a proposal',
+            committee=self.committee_model,
+            workflow_state=Proposal.STATE_DECIDED.name,
             repository_folder_title=u'\xc4 Business',
             dossier_reference_number='1.1.4 / 2',
-            int_id=2).within(self.committee))
-        proposal1_3 = create(Builder('submitted_proposal').having(
-            title=u'aa proposal',
+            int_id=2))
+        proposal1_3 = create(Builder('proposal_model').having(
+            submitted_title=u'aa proposal',
+            committee=self.committee_model,
+            workflow_state=Proposal.STATE_DECIDED.name,
             repository_folder_title=u'\xc4 Business',
             dossier_reference_number='1.1.4 / 1',
-            int_id=5).within(self.committee))
+            int_id=5))
 
-        proposal2_1 = create(Builder('submitted_proposal').having(
-            title=u'Proposal 3',
+        proposal2_1 = create(Builder('proposal_model').having(
+            submitted_title=u'Proposal 3',
+            committee=self.committee_model,
+            workflow_state=Proposal.STATE_DECIDED.name,
             repository_folder_title='A Business',
             dossier_reference_number='10.1.4 / 1',
-            int_id=3).within(self.committee))
-        proposal2_2 = create(Builder('submitted_proposal').having(
-            title=u'Anything goes',
-            description=u'Really, Anything.',
+            int_id=3))
+        proposal2_2 = create(Builder('proposal_model').having(
+            submitted_title=u'Anything goes',
+            committee=self.committee_model,
+            workflow_state=Proposal.STATE_DECIDED.name,
+            submitted_description=u'Really, Anything.',
             repository_folder_title='Other Stuff',
             dossier_reference_number='3.1.4 / 77',
-            int_id=4).within(self.committee))
+            int_id=4))
 
         create(Builder('agenda_item').having(
             meeting=self.meeting_before,

--- a/opengever/testing/builders/dx.py
+++ b/opengever/testing/builders/dx.py
@@ -20,7 +20,6 @@ from opengever.tasktemplates.interfaces import IFromSequentialTasktemplate
 from opengever.testing import assets
 from opengever.testing.builders.base import TEST_USER_ID
 from opengever.testing.builders.translated import TranslatedTitleBuilderMixin
-from opengever.testing.model import TransparentModelLoader
 from opengever.trash.trash import ITrashable
 from plone import api
 from plone.namedfile.file import NamedBlobFile
@@ -369,7 +368,6 @@ class ProposalBuilder(DexterityBuilder):
         self.arguments = {'title': 'Fooo',
                           'language': TranslatedTitle.FALLBACK_LANGUAGE,
                           'issuer': TEST_USER_ID}
-        self.model_arguments = None
         self._transition = None
         self._proposal_file_data = assets.load('empty.docx')
         self._also_return_submitted_proposal = False
@@ -388,11 +386,7 @@ class ProposalBuilder(DexterityBuilder):
 
         super(ProposalBuilder, self).before_create()
 
-        self.arguments, self.model_arguments = Proposal.partition_data(
-            self.arguments)
-
     def after_create(self, obj):
-        obj.create_model(self.model_arguments, self.container)
         obj.create_proposal_document(
             title=obj.title_or_id(),
             filename=u'proposal_document.docx',


### PR DESCRIPTION
This PR is part of https://github.com/4teamwork/opengever.core/issues/5799. we move functionality that creates SQL records and syncs to SQL out of add and edit forms and use event handlers instead. In order to be able to easily create proposals via api endpoint and make sure the corresponding SQL records are created and synced automatically via event handler. This further decouples SQL from plone objects. Functionality and knowledge about what to sync from proposals and submitted proposals is also moved to the SQL model. The following things are addressed in this PR:

- Forms for proposals are no longer inheriting from `ModelProxyEditForm`
- Creating/Updating proposal record is now done via event handler
- Some care has to be taken when creating submitted proposals, we make sure that the Oguid for the newly created submitted proposal plone content object is also stored on the SQL record


## Checkliste

_Zutreffendes soll angehakt stehengelassen werden._

- [x] Changelog-Eintrag vorhanden/nötig?
