### PR TITLE
Correctly handle inactive groups in the sharing view.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 ------------------------
 
 - Bump ftw.solr to 2.6.1 to get fix path_depth handling. [phgross]
+- Correctly handle inactive groups in the sharing view. [njohner]
 - Include original files in ech0160 SIP export even when archival_file exists. [njohner]
 - Add filename and checked_out fields to recently-touched endpoint. [njohner]
 - Add new registry field to switch between changed and document_date for dossier end date calculation. [njohner]

--- a/opengever/sharing/browser/templates/sharing.html
+++ b/opengever/sharing/browser/templates/sharing.html
@@ -14,9 +14,13 @@
       </tr>
       <tr v-for="entry in entries" :key="entry.id">
         <td>
-          <a class="principal link-overlay"
+          <a v-if="!!entry.url"
+             class="principal link-overlay"
              :class="entry.type"
              :href="entry.url">{{entry.title}}</a>
+          <span v-else
+             class="principal"
+             :class="entry.type">{{entry.title}}</span>
           <a class="assignments_info_button"
              v-bind:class="{ folded: entry.assignments}"
              @click="toggle_assignments(entry)"


### PR DESCRIPTION
When a user or a group gets deleted from the LDAP, it is not deleted from the `ogds` but set to `inactive`, as it might still be used somewhere in the Gever instance. For example a user that gets deleted might still be set as responsible on a given dossier or so. 

There was a bug in the `sharing` view not handling such an inactive group properly. The problem was that we get the local roles with the `acl_users` tool (https://github.com/plone/plone.app.workflow/blob/master/plone/app/workflow/browser/sharing.py#L231), which will wrongly assign the type `user` to inactive groups (deleted from the LDAP), as it will not find them (https://github.com/plone/Products.PlonePAS/blob/master/src/Products/PlonePAS/pas.py#L276-L282). This leads to the detailed view url pointing to an inexistant user (`@@user-details-plain/groupid`), instead of to the group (`@@list_groupmembers?groupid`). We fix this directly in the `get_detail_view_url` by verifying whether a given `id` corresponds to a user or a group in the `ogds`. As discussed with @deiferni, this is the correct way to deal with this, as the detailed views are anyway custom views that show informations based on the `ogds`.

This is for https://github.com/4teamwork/opengever.sg/issues/325 for support issue https://extranet.4teamwork.ch/support/gever-st-gallen/tracker/811

**An inactive group is now correctly linked to the detailed view for the group, also showing that the group in question is inactive**
<img width="1289" alt="Screenshot 2019-08-26 at 13 47 47" src="https://user-images.githubusercontent.com/7374243/63688718-66b5e100-c808-11e9-9a08-8f8c732e17b1.png">

## Checkliste
- [x] Changelog-Eintrag vorhanden/nötig?