### PR TITLE
Handle special characters in link to advanced search.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 ------------------------
 
 - Bump ftw.solr to 2.6.1 to get fix path_depth handling. [phgross]
+- Handle special characters in link to advanced search. [njohner]
 - Correctly handle inactive groups in the sharing view. [njohner]
 - Include original files in ech0160 SIP export even when archival_file exists. [njohner]
 - Add filename and checked_out fields to recently-touched endpoint. [njohner]

--- a/opengever/base/browser/search.pt
+++ b/opengever/base/browser/search.pt
@@ -91,7 +91,7 @@
                    i18n:domain="opengever.base"
                    i18n:translate="search_results_advanced_link"
                    tal:define="nav_root_url context/@@plone_portal_state/navigation_root_url;
-                               st python:request.get('SearchableText', '');"
+                               st view/quoted_searchable_text;"
                    tal:attributes="href string:${nav_root_url}/advanced_search?SearchableText=${st}">Advanced Search</a>
               </span>
               to refine your search.

--- a/opengever/base/browser/search.py
+++ b/opengever/base/browser/search.py
@@ -14,6 +14,7 @@ from plone.app.search.browser import Search
 from Products.CMFPlone.browser.navtree import getNavigationRoot
 from Products.CMFPlone.PloneBatch import Batch
 from Products.CMFPlone.utils import safe_unicode
+from Products.PythonScripts.standard import url_quote_plus
 from zope.component import getMultiAdapter
 from zope.component import getUtility
 from ZPublisher.HTTPRequest import record
@@ -267,3 +268,7 @@ class OpengeverSearch(Search):
             query['Subject'] = safe_unicode(query['Subject'])
 
         return query
+
+    @property
+    def quoted_searchable_text(self):
+        return url_quote_plus(self.request.form.get('SearchableText', ''))

--- a/opengever/base/tests/test_search.py
+++ b/opengever/base/tests/test_search.py
@@ -56,6 +56,17 @@ class TestOpengeverSearch(IntegrationTestCase):
         self.assertNotIn('OR', prefill)
         self.assertNotIn('NOT', prefill)
 
+    @browsing
+    def test_advanced_search_link_is_url_encoded(self, browser):
+        self.login(self.regular_user, browser=browser)
+        browser.open(self.portal, view='@@search?SearchableText=M\xc3\xbcller and {co)')
+
+        advanced_search = browser.find("Advanced Search")
+        expected_url = (self.portal.absolute_url() +
+                        '/advanced_search?SearchableText=M%C3%BCller+and+%7Bco%29')
+
+        self.assertEqual(expected_url, advanced_search.get("href"))
+
 
 class TestBumblebeePreview(IntegrationTestCase):
 
@@ -316,3 +327,14 @@ class TestSolrSearch(IntegrationTestCase):
             '<a class="dropdown-list-item LSRow" href="@@search?SearchableText=test&amp;path=/plone">Show all items</a>',
             all_items_link.outerHTML,
             )
+
+    @browsing
+    def test_advanced_search_link_is_url_encoded(self, browser):
+        self.login(self.regular_user, browser=browser)
+        browser.open(self.portal, view='@@search?SearchableText=M\xc3\xbcller and {co)')
+
+        advanced_search = browser.find("Advanced Search")
+        expected_url = (self.portal.absolute_url() +
+                        '/advanced_search?SearchableText=M%C3%BCller+and+%7Bco%29')
+
+        self.assertEqual(expected_url, advanced_search.get("href"))


### PR DESCRIPTION
When searching for a term with special character, the url for the `advanced search` button was not url-encoded, which would raise a 400 on IE. We now properly encode the url.

For https://github.com/4teamwork/opengever.core/issues/5859, support issue https://extranet.4teamwork.ch/extern/opengever-kanton-zug/sprint-backlog/20437/

## Checkliste
- [x] Changelog-Eintrag vorhanden/nötig?
