### PR TITLE
Do no longer render `None` value in document description.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,7 @@ Changelog
 - Always raise when viewlet rendering errors occur during development. [deiferni]
 - Rename label and values of the privacy layer field. [phgross]
 - Add configuration possibility, to blacklist mimetypes from archival conversion. [phgross]
+- Do no longer render `None` value in document description. [elioschmutz]
 - Prevent copy / paste of checked out documents. [njohner]
 - Bump ftw.solr to 2.6.1 to get fix path_depth handling. [phgross]
 - Handle special characters in link to advanced search. [njohner]

--- a/opengever/document/browser/overview.py
+++ b/opengever/document/browser/overview.py
@@ -97,7 +97,11 @@ class WebIntelligentFieldRow(FieldRow):
 
     def get_content(self):
         widget = self.view.w[self.field]
-        content = to_html_xweb_intelligent(widget.value)
+
+        if not widget.field.get(self._view.context):
+            content = ''
+        else:
+            content = to_html_xweb_intelligent(widget.value)
         return '<div id="{}" class="{}">{}</div>'.format(widget.id, widget.klass, content)
 
 

--- a/opengever/document/tests/test_overview.py
+++ b/opengever/document/tests/test_overview.py
@@ -750,6 +750,16 @@ class TestDocumentOverviewVanilla(IntegrationTestCase):
         )
 
     @browsing
+    def test_description_does_not_display_none_value(self, browser):
+        self.login(self.regular_user, browser)
+        self.document.description = None
+        browser.open(self.document, view='tabbedview_view-overview')
+        self.assertEqual(
+            u'',
+            browser.css('#form-widgets-IDocumentMetadata-description')[0].innerHTML,
+        )
+
+    @browsing
     def test_webactions_are_shown_in_overview(self, browser):
         self.login(self.regular_user, browser)
 


### PR DESCRIPTION
Die `WebIntelligentFieldRow` rendert den Value `None` als String. Mit diesem PR wird ein `None` Value nicht mehr gerendert.

Related Issue: #5785 

## Checkliste

_Zutreffendes soll angehakt stehengelassen werden._

- [x] Gibt es neue Funktionalität mit einem `Dokument`? Funktioniert das auch mit einem `Mail`?
- [x] Changelog-Eintrag vorhanden/nötig?
