### PR TITLE
Always raise viewlet(-manager) rendering errors in dev mode.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2019.4.0rc3 (unreleased)
 ------------------------
 
+- Always raise when viewlet rendering errors occur during development. [deiferni]
 - Rename label and values of the privacy layer field. [phgross]
 - Prevent copy / paste of checked out documents. [njohner]
 - Bump ftw.solr to 2.6.1 to get fix path_depth handling. [phgross]

--- a/opengever/base/monkey/patches/__init__.py
+++ b/opengever/base/monkey/patches/__init__.py
@@ -9,6 +9,7 @@ from .default_values import PatchInvokeFactory
 from .default_values import PatchTransmogrifyDXSchemaUpdater
 from .default_values import PatchZ3CFormChangedField
 from .default_values import PatchZ3CFormWidgetUpdate
+from .development import PatchBaseOrderedViewletManagerExceptions
 from .exception_formatter import PatchExceptionFormatter
 from .extendedpathindex import PatchExtendedPathIndex
 from .filter_trashed_from_catalog import PatchCatalogToFilterTrashedDocs
@@ -26,6 +27,7 @@ from .webdav_lock_timeout import PatchWebDAVLockTimeout
 from .workflowtool import PatchWorkflowTool
 
 
+PatchBaseOrderedViewletManagerExceptions()()
 PatchBuilderCreate()()
 PatchExtendedPathIndex()()
 PatchCatalogToFilterTrashedDocs()()

--- a/opengever/base/monkey/patches/development.py
+++ b/opengever/base/monkey/patches/development.py
@@ -1,0 +1,19 @@
+from opengever.base.monkey.patching import MonkeyPatch
+import os
+
+
+class PatchBaseOrderedViewletManagerExceptions(MonkeyPatch):
+    """Patch exceptions so that all are raised during viewlet rendering.
+
+    Only apply the patch in development mode.
+    """
+    def __call__(self):
+        if not os.environ.get('IS_DEVELOPMENT_MODE', False):
+            return
+
+        from plone.app.viewletmanager.manager import BaseOrderedViewletManager
+
+        new_exceptions = (Exception,)
+        self.patch_value(BaseOrderedViewletManager,
+                         '_exceptions_handled_elsewhere',
+                         new_exceptions)


### PR DESCRIPTION
This PR patches a tuple of exceptions that should be re-raised in `BaseOrderedViewletManager` so that all exceptions are re-raised. The patch is only applied for local development, i.e. when the env variable `IS_DEVELOPMENT_MODE` is enabled.

With the patch active rendering of a page is aborted when a viewlet or viewlet manager fails to render. Without this patch a placeholder markup snippet is rendered indicating rendering errors, e.g. `error while rendering plone.failing.viewlet`. That snippet will then be cached happily by `plone.app.caching` and can remain in place even after the error has been fixed. After spending way too much time attempting to debug a "failing" viewlet i'd prefer to have this patch for local development.

## Checkliste

_Zutreffendes soll angehakt stehengelassen werden._

- [x] Changelog-Eintrag vorhanden/nötig?
