### PR TITLE
Integrate ToDos in GEVER-Notification-System

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -9,6 +9,7 @@ Changelog
 - Rename label and values of the privacy layer field. [phgross]
 - Add configuration possibility, to blacklist mimetypes from archival conversion. [phgross]
 - Do no longer render `None` value in document description. [elioschmutz]
+- Integrate ToDos in GEVER-Notification-System. [njohner]
 - Prevent copy / paste of checked out documents. [njohner]
 - Add is_subdossier and is_subtask to listing endpoint. [njohner]
 - Bump ftw.solr to 2.6.1 to get fix path_depth handling. [phgross]

--- a/docs/public/user-manual/benachrichtigung.rst
+++ b/docs/public/user-manual/benachrichtigung.rst
@@ -32,11 +32,11 @@ gelöscht und somit auf den GEVER Standard zurück gesetzt werden.
 
 |img-benachrichtigungs-einstellungen-4|
 
-Benachrichtigungen für Weiterleitungen, Erinnerungen und Anträge
---------------------------------------------------------------------------
+Benachrichtigungen für Weiterleitungen, Erinnerungen, Anträge und Teamräume
+---------------------------------------------------------------------------
 Analog den Benachrichtigungen für Aufgaben, kann in den Tabs *Weiterleitungen*,
-*Erinnerungen* sowie *Anträge* die Benachrichtigungen für diese Aktivitäten
-eingestellt werden.
+*Erinnerungen*, *Anträge* sowie *Teamräume* (wenn *Teamräume* via Konfigurationsoption aktiviert sind)
+die Benachrichtigungen für diese Aktivitäten eingestellt werden.
 
 |img-benachrichtigungs-einstellungen-5|
 

--- a/opengever/activity/__init__.py
+++ b/opengever/activity/__init__.py
@@ -166,6 +166,12 @@ ACTIVITY_TRANSLATIONS = {
     'dossier-overdue': _(
         'dossier-overdue',
         default=u'Overdue dossier'),
+    'todo-assigned': _(
+        'todo-assigned',
+        default=u'ToDo assigned'),
+    'todo-modified': _(
+        'todo-modified',
+        default=u'ToDo modified'),
     'notify_own_actions': {
         'title': _('notify_own_actions_title',
                    default=u'Enable notifications for own actions'),

--- a/opengever/activity/base.py
+++ b/opengever/activity/base.py
@@ -27,6 +27,10 @@ class BaseActivity(object):
         raise NotImplementedError()
 
     @property
+    def label(self):
+        raise NotImplementedError()
+
+    @property
     def title(self):
         return self.translate_to_all_languages(self.context.title)
 

--- a/opengever/activity/browser/resources/settings.js
+++ b/opengever/activity/browser/resources/settings.js
@@ -99,6 +99,9 @@
         {tabId: 'reminders',
          tabTitle: this.getDataAttribute('tab-title-reminders'),
          activities: this.filterActivitiesByType(values, 'reminder')},
+        {tabId: 'workspaces',
+         tabTitle: this.getDataAttribute('tab-title-workspaces'),
+         activities: this.filterActivitiesByType(values, 'workspace')},
       ];
       if (this.getDataAttribute('show-proposals') == 'True') {
         tabs.push({tabId: 'proposals',

--- a/opengever/activity/browser/settings.py
+++ b/opengever/activity/browser/settings.py
@@ -8,6 +8,8 @@ from opengever.activity.roles import COMMITTEE_RESPONSIBLE_ROLE
 from opengever.activity.roles import DISPOSITION_ARCHIVIST_ROLE
 from opengever.activity.roles import DISPOSITION_RECORDS_MANAGER_ROLE
 from opengever.activity.roles import DOSSIER_RESPONSIBLE_ROLE
+from opengever.activity.roles import TODO_RESPONSIBLE_ROLE
+from opengever.activity.roles import WORKSPACE_MEMBER_ROLE
 from opengever.activity.roles import PROPOSAL_ISSUER_ROLE
 from opengever.activity.roles import TASK_ISSUER_ROLE
 from opengever.activity.roles import TASK_REMINDER_WATCHER_ROLE
@@ -97,6 +99,13 @@ ACTIVITY_GROUPS = [
      'roles': [DOSSIER_RESPONSIBLE_ROLE],
      'activities': [
          'dossier-overdue',
+     ]},
+
+    {'id': 'workspace',
+     'roles': [TODO_RESPONSIBLE_ROLE, WORKSPACE_MEMBER_ROLE],
+     'activities': [
+         'todo-assigned',
+         'todo-modified'
      ]},
 ]
 
@@ -399,6 +408,9 @@ class NotificationSettingsForm(BrowserView):
 
     def tab_title_dossiers(self):
         return _('label_dossiers', default=u'Dossiers')
+
+    def tab_title_workspaces(self):
+        return _('label_workspaces', default=u'Workspaces')
 
     def show_disposition_tab(self):
         return api.user.has_permission('opengever.disposition: Add disposition')

--- a/opengever/activity/browser/templates/settings.pt
+++ b/opengever/activity/browser/templates/settings.pt
@@ -36,6 +36,7 @@
                            data-tab-title-proposals view/tab_title_proposals;
                            data-tab-title-reminders view/tab_title_reminders;
                            data-tab-title-dispositions view/tab_title_dispositions;
+                           data-tab-title-workspaces view/tab_title_workspaces;
                            data-show-disposition view/show_disposition_tab;
                            data-show-proposals view/show_proposals_tab;">
 

--- a/opengever/activity/hooks.py
+++ b/opengever/activity/hooks.py
@@ -7,6 +7,8 @@ from opengever.activity.roles import PROPOSAL_ISSUER_ROLE
 from opengever.activity.roles import TASK_ISSUER_ROLE
 from opengever.activity.roles import TASK_REMINDER_WATCHER_ROLE
 from opengever.activity.roles import TASK_RESPONSIBLE_ROLE
+from opengever.activity.roles import TODO_RESPONSIBLE_ROLE
+from opengever.activity.roles import WORKSPACE_MEMBER_ROLE
 from opengever.base.model import create_session
 from sqlalchemy.orm.exc import NoResultFound
 
@@ -107,6 +109,13 @@ DEFAULT_SETTINGS = [
 
     {'kind': 'dossier-overdue',
      'badge_notification_roles': [DOSSIER_RESPONSIBLE_ROLE]},
+
+    {'kind': 'todo-assigned',
+     'badge_notification_roles': [TODO_RESPONSIBLE_ROLE],
+     'digest_notification_roles': [WORKSPACE_MEMBER_ROLE]},
+    {'kind': 'todo-modified',
+     'badge_notification_roles': [TODO_RESPONSIBLE_ROLE],
+     'digest_notification_roles': [WORKSPACE_MEMBER_ROLE]},
 ]
 
 

--- a/opengever/activity/locales/de/LC_MESSAGES/opengever.activity.po
+++ b/opengever/activity/locales/de/LC_MESSAGES/opengever.activity.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-06-28 06:53+0000\n"
+"POT-Creation-Date: 2019-09-04 09:28+0000\n"
 "PO-Revision-Date: 2015-02-24 08:40+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -212,6 +212,11 @@ msgstr "Erinnerungen"
 #: ./opengever/activity/browser/settings.py
 msgid "label_tasks"
 msgstr "Aufgaben"
+
+#. Default: "Workspaces"
+#: ./opengever/activity/browser/settings.py
+msgid "label_workspaces"
+msgstr "Teamräume"
 
 #. Default: "A problem has occurred during the notification creation. Notification could not or only partially produced."
 #: ./opengever/activity/error_handling.py
@@ -433,6 +438,21 @@ msgstr "Auftragnehmer"
 msgid "title_daily_digest"
 msgstr "Tageszusammenfassung für ${username}"
 
+#. Default: "ToDo assigned"
+#: ./opengever/activity/__init__.py
+msgid "todo-assigned"
+msgstr "ToDo zugewiesen"
+
+#. Default: "ToDo modified"
+#: ./opengever/activity/__init__.py
+msgid "todo-modified"
+msgstr "ToDo modifiziert"
+
+#. Default: "ToDo responsible"
+#: ./opengever/activity/roles.py
+msgid "todo_responsible_role"
+msgstr "ToDo Verantwortlicher"
+
 #. Default: "Document added"
 #: ./opengever/activity/__init__.py
 msgid "transition-add-document"
@@ -442,3 +462,8 @@ msgstr "Dokument hinzugefügt"
 #: ./opengever/activity/__init__.py
 msgid "transition-add-subtask"
 msgstr "Unteraufgabe erstellt"
+
+#. Default: "Workspace member"
+#: ./opengever/activity/roles.py
+msgid "workspace_member_role"
+msgstr "Teamraum Mitglied"

--- a/opengever/activity/locales/fr/LC_MESSAGES/opengever.activity.po
+++ b/opengever/activity/locales/fr/LC_MESSAGES/opengever.activity.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-06-28 06:53+0000\n"
+"POT-Creation-Date: 2019-09-04 09:28+0000\n"
 "PO-Revision-Date: 2017-12-03 16:14+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-activity/fr/>\n"
@@ -214,6 +214,11 @@ msgstr "Rappels"
 #: ./opengever/activity/browser/settings.py
 msgid "label_tasks"
 msgstr "Tâches"
+
+#. Default: "Workspaces"
+#: ./opengever/activity/browser/settings.py
+msgid "label_workspaces"
+msgstr "Teamräume"
 
 #. Default: "A problem has occurred during the notification creation. Notification could not or only partially produced."
 #: ./opengever/activity/error_handling.py
@@ -435,6 +440,21 @@ msgstr "mandataire"
 msgid "title_daily_digest"
 msgstr "Résumé quotidien pour ${username}"
 
+#. Default: "ToDo assigned"
+#: ./opengever/activity/__init__.py
+msgid "todo-assigned"
+msgstr "ToDo assigné"
+
+#. Default: "ToDo modified"
+#: ./opengever/activity/__init__.py
+msgid "todo-modified"
+msgstr "ToDo Modifié"
+
+#. Default: "ToDo responsible"
+#: ./opengever/activity/roles.py
+msgid "todo_responsible_role"
+msgstr "Responsable d'un ToDo"
+
 #. Default: "Document added"
 #: ./opengever/activity/__init__.py
 msgid "transition-add-document"
@@ -444,3 +464,8 @@ msgstr "Document ajouté"
 #: ./opengever/activity/__init__.py
 msgid "transition-add-subtask"
 msgstr "Sous-tâche ajoutée"
+
+#. Default: "Workspace member"
+#: ./opengever/activity/roles.py
+msgid "workspace_member_role"
+msgstr "Membre du Teamraum"

--- a/opengever/activity/locales/opengever.activity.pot
+++ b/opengever/activity/locales/opengever.activity.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-06-28 06:53+0000\n"
+"POT-Creation-Date: 2019-09-04 09:28+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -211,6 +211,11 @@ msgstr ""
 #. Default: "Tasks"
 #: ./opengever/activity/browser/settings.py
 msgid "label_tasks"
+msgstr ""
+
+#. Default: "Workspaces"
+#: ./opengever/activity/browser/settings.py
+msgid "label_workspaces"
 msgstr ""
 
 #. Default: "A problem has occurred during the notification creation. Notification could not or only partially produced."
@@ -433,6 +438,21 @@ msgstr ""
 msgid "title_daily_digest"
 msgstr ""
 
+#. Default: "ToDo assigned"
+#: ./opengever/activity/__init__.py
+msgid "todo-assigned"
+msgstr ""
+
+#. Default: "ToDo modified"
+#: ./opengever/activity/__init__.py
+msgid "todo-modified"
+msgstr ""
+
+#. Default: "ToDo responsible"
+#: ./opengever/activity/roles.py
+msgid "todo_responsible_role"
+msgstr ""
+
 #. Default: "Document added"
 #: ./opengever/activity/__init__.py
 msgid "transition-add-document"
@@ -441,4 +461,9 @@ msgstr ""
 #. Default: "Subtask added"
 #: ./opengever/activity/__init__.py
 msgid "transition-add-subtask"
+msgstr ""
+
+#. Default: "Workspace member"
+#: ./opengever/activity/roles.py
+msgid "workspace_member_role"
 msgstr ""

--- a/opengever/activity/model/subscription.py
+++ b/opengever/activity/model/subscription.py
@@ -6,7 +6,6 @@ from sqlalchemy import String
 from sqlalchemy.orm import relationship
 
 
-
 class Subscription(Base):
     __tablename__ = 'subscriptions'
 

--- a/opengever/activity/roles.py
+++ b/opengever/activity/roles.py
@@ -13,6 +13,8 @@ COMMITTEE_RESPONSIBLE_ROLE = 'committee_responsible'
 PROPOSAL_ISSUER_ROLE = 'proposal_issuer'
 TASK_REMINDER_WATCHER_ROLE = 'task_reminder_watcher_role'
 DOSSIER_RESPONSIBLE_ROLE = 'dossier_responsible_role'
+TODO_RESPONSIBLE_ROLE = 'todo_responsible_role'
+WORKSPACE_MEMBER_ROLE = 'workspace_member_role'
 
 _('task_issuer', default=u"Task issuer")
 _('task_responsible', default=u"Task responsible")
@@ -24,3 +26,5 @@ _('proposal_issuer', default=u"Proposal issuer")
 _('committee_responsible', default=u"Committee responsible")
 _('task_reminder_watcher_role', default=u"Watcher")
 _('dossier_responsible_role', default=u"Dossier responsible")
+_('todo_responsible_role', default=u"ToDo responsible")
+_('workspace_member_role', default=u"Workspace member")

--- a/opengever/base/response.py
+++ b/opengever/base/response.py
@@ -12,11 +12,28 @@ from zope import schema
 from zope.annotation import IAnnotations
 from zope.component import adapter
 from zope.component import queryMultiAdapter
+from zope.component.interfaces import IObjectEvent
+from zope.component.interfaces import ObjectEvent
+from zope.event import notify
 from zope.interface import implementer
 from zope.interface import implements
 from zope.interface import Interface
 from zope.schema import getFields
 import time
+
+
+class IResponseAddedEvent(IObjectEvent):
+    """A response has been added to an object"""
+
+
+class ResponseAddedEvent(ObjectEvent):
+
+    implements(IResponseAddedEvent)
+
+    def __init__(self, context, response_container, response):
+        super(ResponseAddedEvent, self).__init__(context)
+        self.response_container = response_container
+        self.response = response
 
 
 class IResponseSupported(Interface):
@@ -60,6 +77,7 @@ class ResponseContainer(object):
 
         response.response_id = response_id
         storage[response_id] = response
+        notify(ResponseAddedEvent(self.context, self, response))
         return response_id
 
     def _storage(self, create_if_missing=False):

--- a/opengever/core/upgrades/20190829091825_add_workspace_activity_setting/upgrade.py
+++ b/opengever/core/upgrades/20190829091825_add_workspace_activity_setting/upgrade.py
@@ -1,0 +1,51 @@
+from opengever.activity.roles import TODO_RESPONSIBLE_ROLE
+from opengever.activity.roles import WORKSPACE_MEMBER_ROLE
+from opengever.core.upgrade import SchemaMigration
+from sqlalchemy.schema import Sequence
+from sqlalchemy.sql.expression import column
+from sqlalchemy.sql.expression import table
+import json
+
+
+DEFAULT_SETTINGS = [
+    {'kind': 'todo-assigned',
+     'badge_notification_roles': [TODO_RESPONSIBLE_ROLE],
+     'digest_notification_roles': [WORKSPACE_MEMBER_ROLE]},
+    {'kind': 'todo-modified',
+     'badge_notification_roles': [TODO_RESPONSIBLE_ROLE],
+     'digest_notification_roles': [WORKSPACE_MEMBER_ROLE]},
+]
+
+
+defaults_table = table(
+    "notification_defaults",
+    column("id"),
+    column("kind"),
+    column("badge_notification_roles"),
+    column("digest_notification_roles"))
+
+
+class AddWorkspaceActivitySetting(SchemaMigration):
+    """Add workspace activity setting.
+    """
+
+    def migrate(self):
+        self.insert_notification_defaults()
+
+    def insert_notification_defaults(self):
+        seq = Sequence('notification_defaults_id_seq')
+        for item in DEFAULT_SETTINGS:
+            setting = self.execute(defaults_table
+                                   .select()
+                                   .where(defaults_table.columns.kind == item.get('kind')))
+
+            if setting.rowcount:
+                # We don't want to reset already inserted settings
+                continue
+
+            self.execute(defaults_table
+                         .insert()
+                         .values(id=self.execute(seq),
+                                 kind=item['kind'],
+                                 badge_notification_roles=json.dumps(item['badge_notification_roles']),
+                                 digest_notification_roles=json.dumps(item['digest_notification_roles'])))

--- a/opengever/disposition/handlers.py
+++ b/opengever/disposition/handlers.py
@@ -43,7 +43,6 @@ def disposition_added(context, event):
                 context.get_dossier_representations())
 
     DispositionAddedActivity(context, getRequest()).record()
-    context.register_watchers()
 
 
 def disposition_modified(context, event):

--- a/opengever/workspace/activities.py
+++ b/opengever/workspace/activities.py
@@ -1,7 +1,30 @@
+from opengever.activity import notification_center
 from opengever.activity.base import BaseActivity
+from opengever.activity.roles import TODO_RESPONSIBLE_ROLE
 from opengever.ogds.base.actor import Actor
 from opengever.task import _
-from opengever.activity.roles import TODO_RESPONSIBLE_ROLE
+
+
+class WorkspaceWatcherManager(object):
+
+    def __init__(self, workspace):
+        self.center = notification_center()
+        self.workspace = workspace
+
+    def new_todo_added(self, todo):
+        self._update_responsible(todo)
+
+    def todo_responsible_modified(self, todo):
+        self._update_responsible(todo)
+
+    def _update_responsible(self, todo):
+        self.center.remove_watchers_from_resource_by_role(
+            todo, TODO_RESPONSIBLE_ROLE)
+
+        if todo.responsible is not None:
+            self.center.add_watcher_to_resource(
+                todo, todo.responsible,
+                TODO_RESPONSIBLE_ROLE)
 
 
 class ToDoAssignedActivity(BaseActivity):
@@ -30,15 +53,6 @@ class ToDoAssignedActivity(BaseActivity):
     @property
     def description(self):
         return {}
-
-    def before_recording(self):
-        self.center.remove_watchers_from_resource_by_role(
-            self.context, TODO_RESPONSIBLE_ROLE)
-
-        if self.context.responsible is not None:
-            self.center.add_watcher_to_resource(
-                self.context, self.context.responsible,
-                TODO_RESPONSIBLE_ROLE)
 
 
 class ToDoModifiedBaseActivity(BaseActivity):

--- a/opengever/workspace/activities.py
+++ b/opengever/workspace/activities.py
@@ -1,3 +1,4 @@
+from Acquisition import aq_chain
 from opengever.activity import notification_center
 from opengever.activity.base import BaseActivity
 from opengever.activity.roles import TODO_RESPONSIBLE_ROLE
@@ -43,6 +44,18 @@ class WorkspaceWatcherManager(object):
         todos = catalog(portal_type="opengever.workspace.todo")
         for todo in todos:
             self.center.add_watcher_to_resource(todo.getObject(), participant, role)
+
+    def participant_removed(self, participant):
+        """We remove all subscriptions for participant on objects that are in
+        self.workspace, as the participant is being removed from the workspace.
+        """
+        watcher = self.center.fetch_watcher(participant)
+        if watcher is None:
+            return
+        for subscription in watcher.subscriptions:
+            obj = subscription.resource.oguid.resolve_object()
+            if self.workspace in aq_chain(obj):
+                self.center.remove_watcher_from_resource(obj, participant, subscription.role)
 
 
 class ToDoAssignedActivity(BaseActivity):

--- a/opengever/workspace/activities.py
+++ b/opengever/workspace/activities.py
@@ -1,8 +1,11 @@
 from opengever.activity import notification_center
 from opengever.activity.base import BaseActivity
 from opengever.activity.roles import TODO_RESPONSIBLE_ROLE
+from opengever.activity.roles import WORKSPACE_MEMBER_ROLE
 from opengever.ogds.base.actor import Actor
 from opengever.task import _
+from opengever.workspace.participation.browser.manage_participants import ManageParticipants
+from zope.globalrequest import getRequest
 
 
 class WorkspaceWatcherManager(object):
@@ -13,6 +16,7 @@ class WorkspaceWatcherManager(object):
 
     def new_todo_added(self, todo):
         self._update_responsible(todo)
+        self._add_all_workspace_users_as_watchers(todo)
 
     def todo_responsible_modified(self, todo):
         self._update_responsible(todo)
@@ -25,6 +29,13 @@ class WorkspaceWatcherManager(object):
             self.center.add_watcher_to_resource(
                 todo, todo.responsible,
                 TODO_RESPONSIBLE_ROLE)
+
+    def _add_all_workspace_users_as_watchers(self, todo):
+        manager = ManageParticipants(self.workspace, getRequest())
+
+        for member in manager.get_participants():
+            self.center.add_watcher_to_resource(
+                todo, member["userid"], WORKSPACE_MEMBER_ROLE)
 
 
 class ToDoAssignedActivity(BaseActivity):

--- a/opengever/workspace/activities.py
+++ b/opengever/workspace/activities.py
@@ -39,3 +39,50 @@ class ToDoAssignedActivity(BaseActivity):
             self.center.add_watcher_to_resource(
                 self.context, self.context.responsible,
                 TODO_RESPONSIBLE_ROLE)
+
+
+class ToDoModifiedBaseActivity(BaseActivity):
+    """Base class for ToDo modified activity.
+    """
+
+    kind = u'todo-modified'
+
+    @property
+    def description(self):
+        return {}
+
+
+class ToDoClosedActivity(ToDoModifiedBaseActivity):
+    """Activity representation for closing a todo.
+    """
+
+    @property
+    def label(self):
+        return self.translate_to_all_languages(
+            _('label_todo_closed_activity', u'ToDo closed'))
+
+    @property
+    def summary(self):
+        user = Actor.lookup(self.actor_id)
+        msg = _(u'Closed by ${user}',
+                mapping={'user': user.get_label(with_principal=False)})
+
+        return self.translate_to_all_languages(msg)
+
+
+class ToDoReopenedActivity(ToDoModifiedBaseActivity):
+    """Activity representation for reopening a todo.
+    """
+
+    @property
+    def label(self):
+        return self.translate_to_all_languages(
+            _('label_todo_reopened_activity', u'ToDo reopened'))
+
+    @property
+    def summary(self):
+        user = Actor.lookup(self.actor_id)
+        msg = _(u'Reopened by ${user}',
+                mapping={'user': user.get_label(with_principal=False)})
+
+        return self.translate_to_all_languages(msg)

--- a/opengever/workspace/activities.py
+++ b/opengever/workspace/activities.py
@@ -1,0 +1,41 @@
+from opengever.activity.base import BaseActivity
+from opengever.ogds.base.actor import Actor
+from opengever.task import _
+from opengever.activity.roles import TODO_RESPONSIBLE_ROLE
+
+
+class ToDoAssignedActivity(BaseActivity):
+    """Activity representation for assigning a todo.
+    """
+
+    kind = u'todo-assigned'
+
+    @property
+    def label(self):
+        return self.translate_to_all_languages(
+            _('label_todo_assigned_activity', u'ToDo assigned'))
+
+    @property
+    def summary(self):
+        responsible = Actor.lookup(self.context.responsible)
+        user = Actor.lookup(self.actor_id)
+
+        msg = _(u'summary_todo_assigned_activity',
+                u'Assigned to ${responsible} by ${user}',
+                mapping={'responsible': responsible.get_label(with_principal=False),
+                         'user': user.get_label(with_principal=False)})
+
+        return self.translate_to_all_languages(msg)
+
+    @property
+    def description(self):
+        return {}
+
+    def before_recording(self):
+        self.center.remove_watchers_from_resource_by_role(
+            self.context, TODO_RESPONSIBLE_ROLE)
+
+        if self.context.responsible is not None:
+            self.center.add_watcher_to_resource(
+                self.context, self.context.responsible,
+                TODO_RESPONSIBLE_ROLE)

--- a/opengever/workspace/activities.py
+++ b/opengever/workspace/activities.py
@@ -5,6 +5,7 @@ from opengever.activity.roles import WORKSPACE_MEMBER_ROLE
 from opengever.ogds.base.actor import Actor
 from opengever.task import _
 from opengever.workspace.participation.browser.manage_participants import ManageParticipants
+from plone import api
 from zope.globalrequest import getRequest
 
 
@@ -36,6 +37,12 @@ class WorkspaceWatcherManager(object):
         for member in manager.get_participants():
             self.center.add_watcher_to_resource(
                 todo, member["userid"], WORKSPACE_MEMBER_ROLE)
+
+    def new_participant_added(self, participant, role):
+        catalog = api.portal.get_tool("portal_catalog")
+        todos = catalog(portal_type="opengever.workspace.todo")
+        for todo in todos:
+            self.center.add_watcher_to_resource(todo.getObject(), participant, role)
 
 
 class ToDoAssignedActivity(BaseActivity):

--- a/opengever/workspace/activities.py
+++ b/opengever/workspace/activities.py
@@ -86,3 +86,24 @@ class ToDoReopenedActivity(ToDoModifiedBaseActivity):
                 mapping={'user': user.get_label(with_principal=False)})
 
         return self.translate_to_all_languages(msg)
+
+
+class ToDoCommentedActivity(ToDoModifiedBaseActivity):
+
+    def __init__(self, context, request, response_container, response):
+        super(ToDoCommentedActivity, self).__init__(context, request)
+        self.response_container = response_container
+        self.response = response
+
+    @property
+    def label(self):
+        return self.translate_to_all_languages(
+            _('label_todo_commented_activity', u'ToDo commented'))
+
+    @property
+    def summary(self):
+        user = Actor.lookup(self.response.creator)
+        msg = _(u'Commented by ${user}',
+                mapping={'user': user.get_label(with_principal=False)})
+
+        return self.translate_to_all_languages(msg)

--- a/opengever/workspace/configure.zcml
+++ b/opengever/workspace/configure.zcml
@@ -34,6 +34,19 @@
       handler=".subscribers.check_todo_add_preconditions"
       />
 
+  <subscriber
+      for="opengever.workspace.interfaces.IToDo
+           zope.lifecycleevent.interfaces.IObjectAddedEvent"
+      handler=".subscribers.todo_added"
+      />
+
+  <subscriber
+      for="opengever.workspace.interfaces.IToDo
+           zope.lifecycleevent.interfaces.IObjectModifiedEvent"
+      handler=".subscribers.todo_modified"
+      />
+
+
   <utility
       factory=".vocabularies.RolesVocabulary"
       name="opengever.workspace.RolesVocabulary"

--- a/opengever/workspace/configure.zcml
+++ b/opengever/workspace/configure.zcml
@@ -46,6 +46,11 @@
       handler=".subscribers.todo_modified"
       />
 
+  <subscriber
+      for="opengever.workspace.interfaces.IToDo
+           opengever.base.response.IResponseAddedEvent"
+      handler=".subscribers.response_added"
+      />
 
   <utility
       factory=".vocabularies.RolesVocabulary"

--- a/opengever/workspace/locales/de/LC_MESSAGES/opengever.workspace.po
+++ b/opengever/workspace/locales/de/LC_MESSAGES/opengever.workspace.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-07-12 15:11+0000\n"
+"POT-Creation-Date: 2019-09-04 08:28+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -22,6 +22,14 @@ msgstr "Annehmen"
 #: ./opengever/workspace/participation/browser/templates/my-invitations.pt
 msgid "Action"
 msgstr "Aktion"
+
+#: ./opengever/workspace/activities.py
+msgid "Closed by ${user}"
+msgstr "Erledigt durch ${user}"
+
+#: ./opengever/workspace/activities.py
+msgid "Commented by ${user}"
+msgstr "Kommentiert durch ${user}"
 
 #: ./opengever/workspace/participation/browser/templates/my-invitations.pt
 msgid "Decline"
@@ -62,6 +70,10 @@ msgstr "Teilnehmer wurde gelöscht"
 #: ./opengever/workspace/participation/browser/participants_view.py
 msgid "Participant invited"
 msgstr "Teilnehmer wurde eingeladen"
+
+#: ./opengever/workspace/activities.py
+msgid "Reopened by ${user}"
+msgstr "Wieder eröffnet durch ${user}"
 
 #: ./opengever/workspace/participation/browser/participants_view.py
 msgid "Role updated"
@@ -155,6 +167,7 @@ msgstr "Text"
 #. Default: "Title"
 #: ./opengever/workspace/browser/tabs.py
 #: ./opengever/workspace/todo.py
+#: ./opengever/workspace/todolist.py
 msgid "label_title"
 msgstr "Titel"
 
@@ -162,6 +175,26 @@ msgstr "Titel"
 #: ./opengever/workspace/browser/tabbed.py
 msgid "label_todo"
 msgstr "ToDo"
+
+#. Default: "ToDo assigned"
+#: ./opengever/workspace/activities.py
+msgid "label_todo_assigned_activity"
+msgstr "ToDo zugewiesen"
+
+#. Default: "ToDo closed"
+#: ./opengever/workspace/activities.py
+msgid "label_todo_closed_activity"
+msgstr "ToDo erledigt"
+
+#. Default: "ToDo commented"
+#: ./opengever/workspace/activities.py
+msgid "label_todo_commented_activity"
+msgstr "ToDo kommentiert"
+
+#. Default: "ToDo reopened"
+#: ./opengever/workspace/activities.py
+msgid "label_todo_reopened_activity"
+msgstr "ToDo wieder eröffnet"
 
 #. Default: "Trash"
 #: ./opengever/workspace/browser/tabbed.py
@@ -172,6 +205,11 @@ msgstr "Papierkorb"
 #: ./opengever/workspace/browser/tabbed.py
 msgid "label_workspaces"
 msgstr "Teamräume"
+
+#. Default: "Assigned to ${responsible} by ${user}"
+#: ./opengever/workspace/activities.py
+msgid "summary_todo_assigned_activity"
+msgstr "An ${responsible} neu zugewiesen durch ${user}"
 
 #. Default: "Manage participation of ${workspace}"
 #: ./opengever/workspace/participation/browser/templates/participants-view.pt

--- a/opengever/workspace/locales/fr/LC_MESSAGES/opengever.workspace.po
+++ b/opengever/workspace/locales/fr/LC_MESSAGES/opengever.workspace.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-07-12 15:11+0000\n"
+"POT-Creation-Date: 2019-09-04 08:28+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -22,6 +22,14 @@ msgstr "Accepter"
 #: ./opengever/workspace/participation/browser/templates/my-invitations.pt
 msgid "Action"
 msgstr "Action"
+
+#: ./opengever/workspace/activities.py
+msgid "Closed by ${user}"
+msgstr "Complété par ${user}"
+
+#: ./opengever/workspace/activities.py
+msgid "Commented by ${user}"
+msgstr "Kommentiert durch ${user}"
 
 #: ./opengever/workspace/participation/browser/templates/my-invitations.pt
 msgid "Decline"
@@ -62,6 +70,10 @@ msgstr "Participant supprimé"
 #: ./opengever/workspace/participation/browser/participants_view.py
 msgid "Participant invited"
 msgstr "Participant invité"
+
+#: ./opengever/workspace/activities.py
+msgid "Reopened by ${user}"
+msgstr "Rouvert par ${user}"
 
 #: ./opengever/workspace/participation/browser/participants_view.py
 msgid "Role updated"
@@ -155,6 +167,7 @@ msgstr ""
 #. Default: "Title"
 #: ./opengever/workspace/browser/tabs.py
 #: ./opengever/workspace/todo.py
+#: ./opengever/workspace/todolist.py
 msgid "label_title"
 msgstr "Titre"
 
@@ -162,6 +175,26 @@ msgstr "Titre"
 #: ./opengever/workspace/browser/tabbed.py
 msgid "label_todo"
 msgstr ""
+
+#. Default: "ToDo assigned"
+#: ./opengever/workspace/activities.py
+msgid "label_todo_assigned_activity"
+msgstr "Todo assigné"
+
+#. Default: "ToDo closed"
+#: ./opengever/workspace/activities.py
+msgid "label_todo_closed_activity"
+msgstr "Todo complété"
+
+#. Default: "ToDo commented"
+#: ./opengever/workspace/activities.py
+msgid "label_todo_commented_activity"
+msgstr "ToDo commenté"
+
+#. Default: "ToDo reopened"
+#: ./opengever/workspace/activities.py
+msgid "label_todo_reopened_activity"
+msgstr "Todo rouvert"
 
 #. Default: "Trash"
 #: ./opengever/workspace/browser/tabbed.py
@@ -172,6 +205,11 @@ msgstr "Corbeille"
 #: ./opengever/workspace/browser/tabbed.py
 msgid "label_workspaces"
 msgstr "Teamraüme"
+
+#. Default: "Assigned to ${responsible} by ${user}"
+#: ./opengever/workspace/activities.py
+msgid "summary_todo_assigned_activity"
+msgstr "Todo assigné à ${responsible} par ${user}"
 
 #. Default: "Manage participation of ${workspace}"
 #: ./opengever/workspace/participation/browser/templates/participants-view.pt

--- a/opengever/workspace/locales/opengever.workspace.pot
+++ b/opengever/workspace/locales/opengever.workspace.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-07-12 15:11+0000\n"
+"POT-Creation-Date: 2019-09-04 08:28+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -24,6 +24,14 @@ msgstr ""
 #: ./opengever/workspace/participation/browser/participants_view.py
 #: ./opengever/workspace/participation/browser/templates/my-invitations.pt
 msgid "Action"
+msgstr ""
+
+#: ./opengever/workspace/activities.py
+msgid "Closed by ${user}"
+msgstr ""
+
+#: ./opengever/workspace/activities.py
+msgid "Commented by ${user}"
 msgstr ""
 
 #: ./opengever/workspace/participation/browser/templates/my-invitations.pt
@@ -64,6 +72,10 @@ msgstr ""
 
 #: ./opengever/workspace/participation/browser/participants_view.py
 msgid "Participant invited"
+msgstr ""
+
+#: ./opengever/workspace/activities.py
+msgid "Reopened by ${user}"
 msgstr ""
 
 #: ./opengever/workspace/participation/browser/participants_view.py
@@ -158,12 +170,33 @@ msgstr ""
 #. Default: "Title"
 #: ./opengever/workspace/browser/tabs.py
 #: ./opengever/workspace/todo.py
+#: ./opengever/workspace/todolist.py
 msgid "label_title"
 msgstr ""
 
 #. Default: "ToDo"
 #: ./opengever/workspace/browser/tabbed.py
 msgid "label_todo"
+msgstr ""
+
+#. Default: "ToDo assigned"
+#: ./opengever/workspace/activities.py
+msgid "label_todo_assigned_activity"
+msgstr ""
+
+#. Default: "ToDo closed"
+#: ./opengever/workspace/activities.py
+msgid "label_todo_closed_activity"
+msgstr ""
+
+#. Default: "ToDo commented"
+#: ./opengever/workspace/activities.py
+msgid "label_todo_commented_activity"
+msgstr ""
+
+#. Default: "ToDo reopened"
+#: ./opengever/workspace/activities.py
+msgid "label_todo_reopened_activity"
 msgstr ""
 
 #. Default: "Trash"
@@ -174,6 +207,11 @@ msgstr ""
 #. Default: "Workspaces"
 #: ./opengever/workspace/browser/tabbed.py
 msgid "label_workspaces"
+msgstr ""
+
+#. Default: "Assigned to ${responsible} by ${user}"
+#: ./opengever/workspace/activities.py
+msgid "summary_todo_assigned_activity"
 msgstr ""
 
 #. Default: "Manage participation of ${workspace}"

--- a/opengever/workspace/participation/browser/manage_participants.py
+++ b/opengever/workspace/participation/browser/manage_participants.py
@@ -137,6 +137,10 @@ class ManageParticipants(BrowserView):
         elif type_ == 'user' and self.can_manage_member(api.user.get(userid=token)):
             RoleAssignmentManager(self.context).clear_by_cause_and_principal(
                 ASSIGNMENT_VIA_INVITATION, token)
+            # Avoid circular imports
+            from opengever.workspace.activities import WorkspaceWatcherManager
+            manager = WorkspaceWatcherManager(self.context)
+            manager.participant_removed(token)
             return
         else:
             raise BadRequest('Oh my, something went wrong')

--- a/opengever/workspace/participation/browser/my_invitations.py
+++ b/opengever/workspace/participation/browser/my_invitations.py
@@ -4,6 +4,7 @@ from opengever.base.security import elevated_privileges
 from opengever.ogds.base.actor import PloneUserActor
 from opengever.workspace import _
 from opengever.workspace import is_workspace_feature_enabled
+from opengever.workspace.activities import WorkspaceWatcherManager
 from opengever.workspace.participation.storage import IInvitationStorage
 from plone import api
 from plone.app.uuid.utils import uuidToObject
@@ -87,6 +88,9 @@ class MyWorkspaceInvitations(BrowserView):
                 invitation['recipient'], [invitation['role']], target)
             RoleAssignmentManager(target).add_or_update_assignment(assignment)
             self.storage().remove_invitation(invitation['iid'])
+
+            manager = WorkspaceWatcherManager(self.context)
+            manager.new_participant_added(invitation['recipient'], invitation['role'])
 
         return target
 

--- a/opengever/workspace/subscribers.py
+++ b/opengever/workspace/subscribers.py
@@ -1,6 +1,8 @@
 from opengever.base.role_assignments import RoleAssignmentManager
 from opengever.base.role_assignments import SharingRoleAssignment
 from opengever.workspace.activities import ToDoAssignedActivity
+from opengever.workspace.activities import ToDoClosedActivity
+from opengever.workspace.activities import ToDoReopenedActivity
 from plone import api
 from Products.CMFPlone.interfaces.siteroot import IPloneSiteRoot
 from zExceptions import Forbidden
@@ -75,3 +77,8 @@ def todo_modified(todo, event):
     if is_attribute_changed(event, "responsible", "IToDoSchema"):
         ToDoAssignedActivity(todo, getRequest()).record()
 
+    if is_attribute_changed(event, "completed", "IToDoSchema"):
+        if todo.completed:
+            ToDoClosedActivity(todo, getRequest()).record()
+        else:
+            ToDoReopenedActivity(todo, getRequest()).record()

--- a/opengever/workspace/subscribers.py
+++ b/opengever/workspace/subscribers.py
@@ -2,6 +2,7 @@ from opengever.base.role_assignments import RoleAssignmentManager
 from opengever.base.role_assignments import SharingRoleAssignment
 from opengever.workspace.activities import ToDoAssignedActivity
 from opengever.workspace.activities import ToDoClosedActivity
+from opengever.workspace.activities import ToDoCommentedActivity
 from opengever.workspace.activities import ToDoReopenedActivity
 from plone import api
 from Products.CMFPlone.interfaces.siteroot import IPloneSiteRoot
@@ -82,3 +83,10 @@ def todo_modified(todo, event):
             ToDoClosedActivity(todo, getRequest()).record()
         else:
             ToDoReopenedActivity(todo, getRequest()).record()
+
+
+def response_added(todo, event):
+    ToDoCommentedActivity(todo,
+                          getRequest(),
+                          event.response_container,
+                          event.response).record()

--- a/opengever/workspace/subscribers.py
+++ b/opengever/workspace/subscribers.py
@@ -1,3 +1,4 @@
+from opengever.base.response import COMMENT_RESPONSE_TYPE
 from opengever.base.role_assignments import RoleAssignmentManager
 from opengever.base.role_assignments import SharingRoleAssignment
 from opengever.workspace.activities import ToDoAssignedActivity
@@ -91,7 +92,8 @@ def todo_modified(todo, event):
 
 
 def response_added(todo, event):
-    ToDoCommentedActivity(todo,
-                          getRequest(),
-                          event.response_container,
-                          event.response).record()
+    if event.response.response_type == COMMENT_RESPONSE_TYPE:
+        ToDoCommentedActivity(todo,
+                              getRequest(),
+                              event.response_container,
+                              event.response).record()

--- a/opengever/workspace/subscribers.py
+++ b/opengever/workspace/subscribers.py
@@ -4,6 +4,7 @@ from opengever.workspace.activities import ToDoAssignedActivity
 from opengever.workspace.activities import ToDoClosedActivity
 from opengever.workspace.activities import ToDoCommentedActivity
 from opengever.workspace.activities import ToDoReopenedActivity
+from opengever.workspace.activities import WorkspaceWatcherManager
 from plone import api
 from Products.CMFPlone.interfaces.siteroot import IPloneSiteRoot
 from zExceptions import Forbidden
@@ -67,6 +68,8 @@ def is_attribute_changed(event, attribute, schema):
 
 
 def todo_added(todo, event):
+    workspace = todo.get_containing_workspace()
+    WorkspaceWatcherManager(workspace).new_todo_added(todo)
     if todo.responsible is not None:
         ToDoAssignedActivity(todo, getRequest()).record()
 
@@ -76,6 +79,8 @@ def todo_modified(todo, event):
         return
 
     if is_attribute_changed(event, "responsible", "IToDoSchema"):
+        workspace = todo.get_containing_workspace()
+        WorkspaceWatcherManager(workspace).todo_responsible_modified(todo)
         ToDoAssignedActivity(todo, getRequest()).record()
 
     if is_attribute_changed(event, "completed", "IToDoSchema"):

--- a/opengever/workspace/tests/test_activities.py
+++ b/opengever/workspace/tests/test_activities.py
@@ -4,8 +4,10 @@ from ftw.testbrowser import browsing
 from opengever.activity import notification_center
 from opengever.activity.model import Activity
 from opengever.activity.roles import TODO_RESPONSIBLE_ROLE
+from opengever.activity.roles import WORKSPACE_MEMBER_ROLE
 from opengever.ogds.base.actor import ActorLookup
 from opengever.testing import IntegrationTestCase
+from opengever.workspace.participation.browser.manage_participants import ManageParticipants
 from unittest import skip
 import json
 
@@ -42,6 +44,24 @@ class TestToDoWatchers(IntegrationTestCase):
             if sub.role == TODO_RESPONSIBLE_ROLE]
 
         self.assertItemsEqual([self.workspace_member.getId()], responsible_watchers)
+
+    def test_workspace_users_are_registered_as_watcher_when_todo_is_created(self):
+        self.login(self.workspace_owner)
+        todo = create(
+                    Builder('todo')
+                    .titled(u'Test ToDos')
+                    .within(self.workspace)
+                    )
+
+        resource = self.center.fetch_resource(todo)
+
+        watchers = [
+            sub.watcher.actorid for sub in resource.subscriptions
+            if sub.role == WORKSPACE_MEMBER_ROLE]
+
+        participants = ManageParticipants(self.workspace, self.request).get_participants()
+        self.assertItemsEqual([participant["userid"] for participant in participants],
+                              watchers)
 
     @browsing
     def test_responsible_is_registered_as_watcher_when_todo_is_assigned(self, browser):

--- a/opengever/workspace/tests/test_activities.py
+++ b/opengever/workspace/tests/test_activities.py
@@ -182,3 +182,21 @@ class TestToDoActivities(IntegrationTestCase):
         self.assertEquals(
             u'Reopened by {}'.format(user.get_label(with_principal=False)),
             activity.summary)
+
+    @browsing
+    def test_commented_activity_is_recorded_when_a_todo_is_commented(self, browser):
+        self.login(self.workspace_member, browser)
+
+        url = '{}/@responses'.format(self.todo.absolute_url())
+        browser.open(url, method="POST", headers=self.api_headers,
+                     data=json.dumps({'text': u'Angebot \xfcberpr\xfcft'}))
+
+        activity = Activity.query.one()
+        self.assertEquals('todo-modified', activity.kind)
+        self.assertEquals(u'ToDo commented', activity.label)
+        self.assertIsNone(activity.description)
+        self.assertEquals('Fix user login', activity.title)
+        user = ActorLookup(self.workspace_member.getId()).lookup()
+        self.assertEquals(
+            u'Commented by {}'.format(user.get_label(with_principal=False)),
+            activity.summary)

--- a/opengever/workspace/todo.py
+++ b/opengever/workspace/todo.py
@@ -1,13 +1,17 @@
+from Acquisition import aq_inner
+from Acquisition import aq_parent
 from collective import dexteritytextindexer
 from ftw.keywordwidget.widget import KeywordFieldWidget
 from opengever.base.response import IResponseSupported
 from opengever.ogds.base.sources import ActualWorkspaceMembersSourceBinder
 from opengever.workspace import _
 from opengever.workspace.interfaces import IToDo
+from opengever.workspace.interfaces import IWorkspace
 from plone.autoform import directives as form
 from plone.autoform.interfaces import IFormFieldProvider
 from plone.dexterity.content import Container
 from plone.supermodel import model
+from Products.CMFPlone.interfaces.siteroot import IPloneSiteRoot
 from zope import schema
 from zope.interface import implements
 from zope.interface import provider
@@ -45,3 +49,16 @@ class IToDoSchema(model.Schema):
 
 class ToDo(Container):
     implements(IToDo, IResponseSupported)
+
+    def get_containing_workspace(self):
+        """Return the workspace containing the todo.
+        Every ToDo should be contained in a workspace.
+        """
+        obj = self
+
+        while not IPloneSiteRoot.providedBy(obj):
+            parent = aq_parent(aq_inner(obj))
+            if IWorkspace.providedBy(parent):
+                return parent
+            obj = parent
+        return None


### PR DESCRIPTION
We integrate `ToDo`s in the notification system. For that we:
* Add new activity settings for workspaces for `TODO_RESPONSIBLE_ROLE` and `WORKSPACE_MEMBER_ROLE`
* Add activities for assigning, closing, reopening and commenting a todo.
* Automatically update watchers on the `ToDo`s outside from the activities, in prevision of the view listing all objects that user is watching:
  * Add all workspace users as watchers to a newly created ToDo.
  * Add new workspace participant as watcher on all ToDos.

For https://github.com/4teamwork/opengever.core/issues/5796

## Checkliste
- [ ] Sind UpgradeSteps `deferrable`, oder können gewisse Schritte des Upgrades konditional ausgeführt werden? Upgrade step is not deferrable.
- [x] Gibts es eine DB-Schema Migration?
  - [x] Wurde alle Columns/Änderungen aus dem Modell in einer DB-Schema Migration nachgeführt.
  - [x] Sind Constraint-Namen maximal 30 Zeichen lang (`Oracle`)?
- [x] Gibt es neue Übersetzungen?
  - [x] Sind alle msg-Strings in Übersetzungen Unicode?
  - [x] Wird die richtige i18n-domain verwendet (Copy-Paste Fehler sind hier häufig)?
- [x] Changelog-Eintrag vorhanden/nötig?
- [x] Aktualisierung Dokumentation vorhanden/nötig?
