### PR TITLE
Handle creation of new proposals over the REST-API.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2019.4.0rc3 (unreleased)
 ------------------------
 
+- Handle creation of new proposals over the REST-API. [njohner]
 - Introduce plone proposal workflow, provide api support for proposal workflow transitions. [deiferni]
 - Always raise when viewlet rendering errors occur during development. [deiferni]
 - Rename label and values of the privacy layer field. [phgross]

--- a/docs/public/dev-manual/api/content_types.rst
+++ b/docs/public/dev-manual/api/content_types.rst
@@ -74,4 +74,11 @@ Aufgabe
 
 .. include:: schemas/opengever.task.task.inc
 
+
+
+Anträge
+^^^^^^^
+
+.. include:: schemas/opengever.meeting.proposal.inc
+
 .. disqus::

--- a/docs/public/dev-manual/api/index.rst
+++ b/docs/public/dev-manual/api/index.rst
@@ -29,6 +29,7 @@ Inhalt:
    preview.rst
    webactions.rst
    tasks.rst
+   proposals.rst
    reminder.rst
    journal.rst
    workspace/index

--- a/docs/public/dev-manual/api/proposals.rst
+++ b/docs/public/dev-manual/api/proposals.rst
@@ -1,0 +1,43 @@
+Anträge
+=======
+
+Auch Anträge können via REST API bedient werden. Die Erstellung eines Antrags erfolgt wie bei anderen Inhalten (siehe Kapitel :ref:`operations`) via POST request:
+
+
+**Beispiel-Request**:
+
+   .. sourcecode:: http
+
+      POST /(container) HTTP/1.1
+      Accept: application/json
+      Content-Type: application/json
+
+      {
+        "@type": "opengever.meeting.proposal",
+        "title": "Antrag für Kreiselbau",
+        "committee_oguid": "fd:1722088772",
+        "issuer": "john.doe",
+        "proposal_template": "fd/vorlagen/proposal-template-1"
+      }
+
+
+**Beispiel-Response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 201 Created
+      Accept: application/json
+
+      {
+        "@id": "http://example.org/ordnungssystem/fuehrung/dossier-1/proposal-5",
+        "@type": "opengever.meeting.proposal",
+        "committee_oguid": {
+          "title": "Kommission für Rechtsfragen",
+          "token": "fd:1722088772"
+        },
+        "issuer": {
+          "title": "Johner Niklaus (niklaus.johner)",
+          "token": "niklaus.johner"
+        },
+        "...": "..."
+      }

--- a/docs/public/dev-manual/api/schemas/opengever.meeting.proposal.inc
+++ b/docs/public/dev-manual/api/schemas/opengever.meeting.proposal.inc
@@ -1,0 +1,94 @@
+.. py:class:: opengever.meeting.proposal
+
+    Inhaltstyp 'Antrag'
+
+
+
+   .. py:attribute:: title
+
+       :Feldname: :field-title:`Titel`
+       :Datentyp: ``TextLine``
+       
+       :Default: ""
+       
+       
+
+
+   .. py:attribute:: description
+
+       :Feldname: :field-title:`Beschreibung`
+       :Datentyp: ``Text``
+       
+       
+       
+       
+
+
+   .. py:attribute:: issuer
+
+       :Feldname: :field-title:`Antragssteller`
+       :Datentyp: ``Choice``
+       :Pflichtfeld: Ja :required:`(*)`
+       
+       
+       :Wertebereich: <User-ID eines gültigen Auftraggebers>
+
+
+   .. py:attribute:: date_of_submission
+
+       :Feldname: :field-title:``
+       :Datentyp: ``Date``
+       
+       
+       :Beschreibung: Eingereicht am
+       
+
+
+   .. py:attribute:: language
+
+       :Feldname: :field-title:`Sprache`
+       :Datentyp: ``Choice``
+       
+       :Default: <User-spezifischer Default>
+       
+       :Wertebereich: <Ein gültiges Sprach-Code (de, en, fr...)>
+
+
+   .. py:attribute:: committee_oguid
+
+       :Feldname: :field-title:`Gremium`
+       :Datentyp: ``Choice``
+       :Pflichtfeld: Ja :required:`(*)`
+       
+       
+       :Wertebereich: <OGUID eines Committees>
+
+
+   .. py:attribute:: relatedItems
+
+       :Feldname: :field-title:`Beilagen`
+       :Datentyp: ``RelationList``
+       
+       :Default: []
+       
+       
+
+
+   .. py:attribute:: predecessor_proposal
+
+       :Feldname: :field-title:`Vorgängiger Antrag`
+       :Datentyp: ``RelationChoice``
+       
+       
+       
+       :Wertebereich: <UID eines Antrags>
+
+
+   .. py:attribute:: changed
+
+       :Feldname: :field-title:`Zuletzt verändert`
+       :Datentyp: ``Datetime``
+       
+       
+       
+       

--- a/docs/schema-dumps/opengever.meeting.proposal.schema.json
+++ b/docs/schema-dumps/opengever.meeting.proposal.schema.json
@@ -1,0 +1,87 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "type": "object",
+    "title": "Antrag",
+    "additionalProperties": false,
+    "properties": {
+        "title": {
+            "type": "string",
+            "title": "Titel",
+            "maxLength": 256,
+            "description": "",
+            "_zope_schema_type": "TextLine",
+            "default": ""
+        },
+        "description": {
+            "type": "string",
+            "title": "Beschreibung",
+            "description": "",
+            "_zope_schema_type": "Text"
+        },
+        "issuer": {
+            "type": "string",
+            "title": "Antragssteller",
+            "description": "",
+            "_zope_schema_type": "Choice",
+            "_vocabulary": "<User-ID eines g\u00fcltigen Auftraggebers>"
+        },
+        "date_of_submission": {
+            "type": "string",
+            "title": "",
+            "format": "date",
+            "description": "Eingereicht am",
+            "_zope_schema_type": "Date"
+        },
+        "language": {
+            "type": "string",
+            "title": "Sprache",
+            "description": "",
+            "_zope_schema_type": "Choice",
+            "default": "<User-spezifischer Default>",
+            "_vocabulary": "<Ein g\u00fcltiges Sprach-Code (de, en, fr...)>"
+        },
+        "committee_oguid": {
+            "type": "string",
+            "title": "Gremium",
+            "description": "",
+            "_zope_schema_type": "Choice",
+            "_vocabulary": "<OGUID eines Committees>"
+        },
+        "relatedItems": {
+            "type": "array",
+            "title": "Beilagen",
+            "description": "",
+            "_zope_schema_type": "RelationList",
+            "default": []
+        },
+        "predecessor_proposal": {
+            "type": "string",
+            "title": "Vorg\u00e4ngiger Antrag",
+            "description": "",
+            "_zope_schema_type": "RelationChoice",
+            "_vocabulary": "<UID eines Antrags>"
+        },
+        "changed": {
+            "type": "string",
+            "title": "Zuletzt ver\u00e4ndert",
+            "format": "datetime",
+            "description": "",
+            "_zope_schema_type": "Datetime"
+        }
+    },
+    "required": [
+        "issuer",
+        "committee_oguid"
+    ],
+    "field_order": [
+        "title",
+        "description",
+        "issuer",
+        "date_of_submission",
+        "language",
+        "committee_oguid",
+        "relatedItems",
+        "predecessor_proposal",
+        "changed"
+    ]
+}

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -27,6 +27,7 @@
 
   <adapter factory=".todo.DeserializeToDoFromJson" />
   <adapter factory=".mail.DeserializeMailFromJson" />
+  <adapter factory=".proposal.DeserializeProposalFromJson" />
 
   <plone:service
       method="PATCH"

--- a/opengever/api/proposal.py
+++ b/opengever/api/proposal.py
@@ -1,0 +1,34 @@
+from opengever.meeting.proposal import IProposal
+from opengever.meeting.proposal import PROPOSAL_TEMPLATE_KEY
+from plone.restapi.deserializer import json_body
+from plone.restapi.deserializer.dxcontent import DeserializeFromJson
+from plone.restapi.interfaces import IDeserializeFromJson
+from zope.annotation.interfaces import IAnnotations
+from zope.component import adapter
+from zope.interface import implementer
+from zope.interface import Interface
+from zope.schema.interfaces import RequiredMissing
+
+
+@implementer(IDeserializeFromJson)
+@adapter(IProposal, Interface)
+class DeserializeProposalFromJson(DeserializeFromJson):
+
+    def __call__(self, validate_all=False, data=None, create=False):
+        if data is None:
+            data = json_body(self.request)
+
+        # Make sure that proposal_template is passed
+        template_path = data.get("proposal_template")
+        if template_path is None:
+            raise RequiredMissing("proposal_template")
+
+        # write template path to annotations as the proposal document gets
+        # generated in opengever.meeting.handlers.proposal_added
+        ann = IAnnotations(self.request)
+        ann[PROPOSAL_TEMPLATE_KEY] = template_path
+
+        proposal = super(DeserializeProposalFromJson, self).__call__(
+            validate_all=validate_all, data=data, create=create)
+
+        return proposal

--- a/opengever/api/tests/test_content_creation.py
+++ b/opengever/api/tests/test_content_creation.py
@@ -1,6 +1,7 @@
 from ftw.bumblebee.interfaces import IBumblebeeDocument
 from ftw.testbrowser import browsing
 from opengever.base.behaviors.lifecycle import ILifeCycle
+from opengever.base.oguid import Oguid
 from opengever.dossier.behaviors.dossier import IDossier
 from opengever.testing import IntegrationTestCase
 from plone import api
@@ -8,6 +9,8 @@ import json
 
 
 class TestContentCreation(IntegrationTestCase):
+
+    features = ('meeting',)
 
     def setUp(self):
         super(TestContentCreation, self).setUp()
@@ -72,3 +75,62 @@ class TestContentCreation(IntegrationTestCase):
 
         checksum = IBumblebeeDocument(doc).get_checksum()
         self.assertIsNotNone(checksum)
+
+    @browsing
+    def test_proposal_creation(self, browser):
+        self.login(self.meeting_user, browser)
+
+        committee_oguid = Oguid.for_object(self.committee).id
+        payload = {
+            u'@type': u'opengever.meeting.proposal',
+            u'title': u'Sanierung B\xe4rengraben 2016',
+            u'proposal_template': self.proposal_template.absolute_url_path(),
+            u"committee_oguid": committee_oguid,
+            u'issuer': self.meeting_user.getId(),
+        }
+        response = browser.open(
+            self.dossier.absolute_url(),
+            data=json.dumps(payload),
+            method='POST',
+            headers=self.api_headers)
+
+        self.assertEqual(201, response.status_code)
+
+        new_object_id = str(response.json['id'])
+        proposal = self.dossier.restrictedTraverse(new_object_id)
+        self.assertEqual(u'Sanierung B\xe4rengraben 2016', proposal.title)
+        self.assertEqual(self.meeting_user.getId(), proposal.issuer)
+
+        proposal_doc = proposal.get_proposal_document()
+        self.assertIsNotNone(proposal_doc)
+        self.assertEqual(u'Sanierung B\xe4rengraben 2016',
+                         proposal_doc.title)
+        self.assertEqual(u'Sanierung Baerengraben 2016.docx',
+                         proposal_doc.get_filename())
+
+        checksum = IBumblebeeDocument(proposal_doc).get_checksum()
+        self.assertIsNotNone(checksum)
+
+    @browsing
+    def test_template_is_mandatory_for_proposal_creation(self, browser):
+        self.login(self.meeting_user, browser)
+
+        committee_oguid = Oguid.for_object(self.committee).id
+        payload = {
+            u'@type': u'opengever.meeting.proposal',
+            u'title': u'Sanierung B\xe4rengraben 2016',
+            u"committee_oguid": committee_oguid,
+            u'issuer': self.meeting_user.getId(),
+        }
+
+        with browser.expect_http_error():
+            browser.open(
+                self.dossier.absolute_url(),
+                data=json.dumps(payload),
+                method='POST',
+                headers=self.api_headers)
+
+        self.assertEqual(500, browser.status_code)
+        self.assertDictEqual({u'message': u'proposal_template',
+                              u'type': u'RequiredMissing'},
+                             browser.json)

--- a/opengever/base/schemadump/config.py
+++ b/opengever/base/schemadump/config.py
@@ -11,6 +11,7 @@ GEVER_TYPES = [
     'opengever.task.task',
     'opengever.repository.repositoryfolder',
     'opengever.repository.repositoryroot',
+    'opengever.meeting.proposal',
 ]
 
 GEVER_TYPES_TO_OGGBUNDLE_TYPES = {
@@ -77,6 +78,12 @@ VOCAB_OVERRIDES = {
         'responsible': u'<User-ID eines g\xfcltigen Auftragnehmers>',
         'responsible_client': u'<G\xfcltige Org-Unit-ID>',
     },
+    'opengever.meeting.proposal.IProposal': {
+        'issuer': u'<User-ID eines g\xfcltigen Auftraggebers>',
+        'predecessor_proposal': u'<UID eines Antrags>',
+        'committee_oguid': u'<OGUID eines Committees>',
+        'language': u'<Ein g\xfcltiges Sprach-Code (de, en, fr...)>'
+    },
 }
 
 DEFAULT_OVERRIDES = {
@@ -97,6 +104,9 @@ DEFAULT_OVERRIDES = {
                               u':small-comment:`(Obwohl dieses Feld im User-Interface '
                               u'nicht erscheint (vom System automatisch gesetzt wird), '
                               u'muss es \xfcber die REST API angegeben werden)`',
+    },
+    'opengever.meeting.proposal.IProposal': {
+        'language': u'<User-spezifischer Default>'
     },
 }
 
@@ -138,6 +148,8 @@ JSON_SCHEMA_FIELD_TYPES = {
         'type': 'integer'},
     'RelationList': {
         'type': 'array'},
+    'RelationChoice': {
+        'type': 'string'},
     'Bool': {
         'type': 'boolean'},
     'NamedBlobFile': {

--- a/opengever/base/tests/test_default_values_for_types.py
+++ b/opengever/base/tests/test_default_values_for_types.py
@@ -10,6 +10,7 @@ from hashlib import sha256
 from opengever.base.date_time import utcnow_tz_aware
 from opengever.base.default_values import get_persisted_values_for_obj
 from opengever.base.oguid import Oguid
+from opengever.meeting.proposal import PROPOSAL_TEMPLATE_KEY
 from opengever.private.tests import create_members_folder
 from opengever.testing import IntegrationTestCase
 from opengever.testing.helpers import fake_interaction
@@ -22,6 +23,7 @@ from z3c.form.browser.checkbox import CheckBoxWidget
 from z3c.form.browser.checkbox import SingleCheckBoxWidget
 from z3c.form.interfaces import IDataConverter
 from z3c.form.interfaces import IGroupForm
+from zope.annotation.interfaces import IAnnotations
 from zope.schema import getFieldsInOrder
 from zope.schema import List
 import json
@@ -1309,6 +1311,11 @@ class TestProposalDefaults(TestDefaultsBase):
         self.login(self.meeting_user)
 
         with freeze(FROZEN_NOW):
+            # To create a proposal, a template always has to be specified and
+            # saved in the annotations of the request
+            ann = IAnnotations(self.request)
+            ann[PROPOSAL_TEMPLATE_KEY] = self.proposal_template.absolute_url_path()
+
             proposal = createContentInContainer(
                 self.dossier,
                 'opengever.meeting.proposal',
@@ -1325,6 +1332,11 @@ class TestProposalDefaults(TestDefaultsBase):
         self.login(self.meeting_user)
 
         with freeze(FROZEN_NOW):
+            # To create a proposal, a template always has to be specified and
+            # saved in the annotations of the request
+            ann = IAnnotations(self.request)
+            ann[PROPOSAL_TEMPLATE_KEY] = self.proposal_template.absolute_url_path()
+
             new_id = self.dossier.invokeFactory(
                 'opengever.meeting.proposal',
                 'proposal-999',

--- a/opengever/core/tests/test_relations.py
+++ b/opengever/core/tests/test_relations.py
@@ -193,10 +193,14 @@ class TestRelationCatalogInterfaces(FunctionalTestCase):
         document_a = create(Builder('document').within(dossier_a))
         Versioner(document_a).create_initial_version()
 
-        create(Builder('document').within(dossier_a).relate_to(document_a))
+        document_b = create(Builder('document')
+                            .within(dossier_a)
+                            .relate_to(document_a)
+                            .with_asset_file('empty.docx'))
         create(Builder('proposaltemplate').relate_to(document_a))
 
         create(Builder('task').within(dossier_a).relate_to([document_a]))
+
         create(Builder('forwarding').within(dossier_a).relate_to([document_a]))
 
         sablontemplate_a = create(Builder('sablontemplate'))
@@ -214,7 +218,8 @@ class TestRelationCatalogInterfaces(FunctionalTestCase):
             .having(committee=committee.load_model())
             .within(dossier_a)
             .relate_to(document_a)
-            .with_submitted())
+            .with_submitted()
+            .from_template(document_b))
 
         dossier_expired = create(Builder('dossier').as_expired())
         self.grant('Records Manager')

--- a/opengever/dossier/tests/test_deactivate.py
+++ b/opengever/dossier/tests/test_deactivate.py
@@ -77,7 +77,8 @@ class TestDossierDeactivation(IntegrationTestCase):
     def test_not_possible_with_active_proposals(self, browser):
         self.login(self.committee_responsible, browser)
         proposal = create(Builder('proposal').within(self.empty_dossier)
-                                             .having(committee=self.committee))
+                                             .having(committee=self.committee)
+                                             .from_template(self.proposal_template))
 
         self.login(self.dossier_responsible, browser)
 

--- a/opengever/dossier/tests/test_resolve.py
+++ b/opengever/dossier/tests/test_resolve.py
@@ -1396,7 +1396,8 @@ class TestResolveConditions(IntegrationTestCase, ResolveTestHelper):
     def test_resolving_is_cancelled_when_dossier_has_active_proposals(self, browser):
         self.login(self.committee_responsible, browser)
         create(Builder('proposal').within(self.resolvable_subdossier)
-                                  .having(committee=self.committee))
+                                  .having(committee=self.committee)
+                                  .from_template(self.proposal_template))
 
         self.login(self.secretariat_user, browser)
 

--- a/opengever/meeting/browser/proposalforms.py
+++ b/opengever/meeting/browser/proposalforms.py
@@ -6,6 +6,7 @@ from opengever.meeting import _
 from opengever.meeting import is_meeting_feature_enabled
 from opengever.meeting.activity.watchers import change_watcher_on_proposal_edited
 from opengever.meeting.proposal import IProposal
+from opengever.meeting.utils import is_docx
 from opengever.officeconnector.helpers import is_officeconnector_checkout_feature_enabled  # noqa
 from opengever.tabbedview.helper import document_with_icon
 from plone import api
@@ -161,9 +162,7 @@ class IAddProposal(IProposal):
         # XXX - this should get removed once we have a mimetype index based on which we can filter at source
         proposal_document = data.proposal_document
         if proposal_document:
-            proposal_document_mimetype = proposal_document.file.contentType
-            docx_mimetype = 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
-            if not proposal_document_mimetype == docx_mimetype:
+            if not is_docx(proposal_document):
                 raise Invalid(_(
                     u'error_only_docx_files_allowed_as_proposal_documents',
                     default=u'Only .docx files allowed as proposal documents.',

--- a/opengever/meeting/browser/sablontemplate.py
+++ b/opengever/meeting/browser/sablontemplate.py
@@ -19,7 +19,7 @@ SAMPLE_MEETING_DATA = {
         'decision_number': 1,
         'attachments': [{
             "title": u'Beweisaufn\xe4hme',
-            "filename": u"Beweisaufnaehme.txt"
+            "filename": u"Beweisaufnaehme.docx"
             }, {
             "title": u"L\xf6rem",
             "filename": u"Loerem.eml"

--- a/opengever/meeting/proposal.py
+++ b/opengever/meeting/proposal.py
@@ -56,6 +56,9 @@ from zope.intid.interfaces import IIntIds
 from zope.schema.interfaces import IContextAwareDefaultFactory
 
 
+PROPOSAL_TEMPLATE_KEY = 'opengever.meeting.proposal.proposal_template'
+
+
 @provider(IContextAwareDefaultFactory)
 def default_title(context):
     # At this point, only proposals (not submitted proposals) should acquire

--- a/opengever/meeting/tests/test_agendaitem.py
+++ b/opengever/meeting/tests/test_agendaitem.py
@@ -51,7 +51,8 @@ class TestDisplayAgendaItems(IntegrationTestCase):
                           .within(self.dossier)
                           .having(committee=self.committee.load_model())
                           .with_submitted()
-                          .relate_to(*documents))
+                          .relate_to(*documents)
+                          .from_template(self.proposal_template))
         agenda_item = self.schedule_proposal(self.meeting, submitted_proposal)
 
         browser.open(self.agenda_item_url(agenda_item, 'list'))

--- a/opengever/meeting/tests/test_committee.py
+++ b/opengever/meeting/tests/test_committee.py
@@ -352,7 +352,8 @@ class TestCommitteeWorkflow(IntegrationTestCase):
             Builder('proposal').within(self.dossier)
             .having(title=u'Non-scheduled proposal',
                     committee=self.empty_committee.load_model())
-            .as_submitted())
+            .as_submitted()
+            .from_template(self.proposal_template))
         browser.open(self.empty_committee)
 
         editbar.menu_option('Actions', 'deactivate').click()

--- a/opengever/meeting/tests/test_meeting_zipexport.py
+++ b/opengever/meeting/tests/test_meeting_zipexport.py
@@ -110,6 +110,7 @@ class TestMeetingZipExportView(IntegrationTestCase):
             )
             .relate_to(self.mail_eml)
             .as_submitted()
+            .from_template(self.proposal_template)
         )
 
         self.schedule_proposal(self.meeting, submitted_proposal)
@@ -173,7 +174,7 @@ class TestMeetingZipExportView(IntegrationTestCase):
                     'number_raw': 2,
                     'opengever_id': 4,
                     'proposal': {
-                        'checksum': '114e7a059dc34c7459dab90904685584e331089d80bb6310183a0de009b66c3b',
+                        'checksum': 'e00d6c8fb32c30d3ca3a3f8e5d873565482567561023016d9ca18243ff1cfa14',
                         'file': 'Traktandum 2/Vertraege.docx',
                         'modified': u'2016-08-31T16:09:35+02:00',
                     },
@@ -248,7 +249,7 @@ class TestMeetingZipExportView(IntegrationTestCase):
                         u'number': u'2.',
                         u'number_raw': 2,
                         u'proposal': {
-                            u'checksum': u'114e7a059dc34c7459dab90904685584e331089d80bb6310183a0de009b66c3b',
+                            u'checksum': u'e00d6c8fb32c30d3ca3a3f8e5d873565482567561023016d9ca18243ff1cfa14',
                             u'file': u'Traktandum 2/Vertraege.docx',
                             u'modified': u'2016-08-31T16:09:35+02:00',
                         },

--- a/opengever/meeting/tests/test_proposal.py
+++ b/opengever/meeting/tests/test_proposal.py
@@ -641,7 +641,8 @@ class TestProposal(IntegrationTestCase):
         create(Builder('proposal')
                .within(self.empty_dossier)
                .titled(u'My Proposal')
-               .having(committee=self.committee.load_model()))
+               .having(committee=self.committee.load_model())
+               .from_template(self.proposal_template))
 
         register_event_recorder(IObjectWillBeRemovedEvent)
 

--- a/opengever/meeting/tests/test_proposalhistory.py
+++ b/opengever/meeting/tests/test_proposalhistory.py
@@ -363,7 +363,8 @@ class TestIntegrationProposalHistory(IntegrationTestCase):
                           .having(title=u'Vertr\xe4ge',
                                   committee=self.committee.load_model(),
                                   issuer=self.dossier_responsible.getId())
-                          .relate_to(self.document))
+                          .relate_to(self.document)
+                          .from_template(self.proposal_template))
 
         # Add comment
         browser.open(proposal, view='addcomment')

--- a/opengever/meeting/tests/test_protocol_json_data.py
+++ b/opengever/meeting/tests/test_protocol_json_data.py
@@ -27,7 +27,7 @@ class TestProtocolJsonData(FunctionalTestCase):
                            .titled(u'Beweisaufn\xe4hme')
                            .within(self.dossier)
                            .attach_file_containing("lorem ipsum",
-                                                   name=u"beweisaufnahme.txt"))
+                                                   name=u"beweisaufnahme.docx"))
         self.doc2 = create(Builder("document")
                            .titled(u"Strafbefehl")
                            .within(self.dossier))
@@ -47,7 +47,8 @@ class TestProtocolJsonData(FunctionalTestCase):
                     dossier_reference_number=u'FD 2.6.8/1',
                     repository_folder_title=u'Strafwesen')
             .relate_to(self.doc1, self.doc2, self.mail1)
-            .as_submitted())
+            .as_submitted()
+            .from_template(self.doc1))
         self.proposal_model = self.proposal.load_model()
         self.submitted_proposal = self.proposal_model.resolve_submitted_proposal()
         self.member_peter = create(Builder('member'))

--- a/opengever/meeting/utils.py
+++ b/opengever/meeting/utils.py
@@ -35,3 +35,9 @@ def format_date(date, request=None):
     date_string_format = api.portal.get_registry_record(
         "sablon_date_format_string", interface=IMeetingSettings)
     return ulocalized_time(date, date_string_format, request)
+
+
+def is_docx(document):
+    document_mimetype = document.file.contentType
+    docx_mimetype = 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+    return document_mimetype == docx_mimetype

--- a/opengever/meeting/utils.py
+++ b/opengever/meeting/utils.py
@@ -38,6 +38,9 @@ def format_date(date, request=None):
 
 
 def is_docx(document):
-    document_mimetype = document.file.contentType
+    document_file = document.get_file()
+    if not document_file:
+        return False
+    document_mimetype = document_file.contentType
     docx_mimetype = 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
     return document_mimetype == docx_mimetype

--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -1016,6 +1016,7 @@ class OpengeverContentFixture(object):
                     )
                 .relate_to(self.document)
                 .as_submitted()
+                .from_template(self.proposal_template)
                 ))
 
             self.register_path(
@@ -1041,6 +1042,7 @@ class OpengeverContentFixture(object):
                     committee=self.empty_committee.load_model(),
                     issuer=self.dossier_responsible.getId(),
                     )
+                .from_template(self.proposal_template)
                 ))
 
             self.decided_proposal = create(
@@ -1052,6 +1054,7 @@ class OpengeverContentFixture(object):
                     issuer=self.dossier_responsible.getId(),
                     )
                 .as_submitted()
+                .from_template(self.proposal_template)
                 )
 
             self.register_path(


### PR DESCRIPTION
The Add form for proposals contained some logic and specific steps needed for the creation of a `Proposal`, such as the creation of a `Document` (the proposal document). Because of that, creation of a `Proposal` through the REST-API was not possible (or rather broken).

In this PR we make it possible to create proposals through the REST-API. For that we:
* Move proposal creation logic from the AddForm to an event handler
* Add a custom deserializer for proposals (`DeserializeProposalFromJson`) 
    * Make sure a template is set for the proposal document
    * Store the template information on the request so that it can be retrieved in the event handler
* Adapt proposal builders, fixture, tests and example content as we now always need to specify a template in order to create a `Proposal`

These changes are necessary to allow working with `Proposal`s in the new UI.

This is part of https://github.com/4teamwork/opengever.core/issues/5799

## Checkliste
- [x] Changelog-Eintrag vorhanden/nötig?
- [x] Aktualisierung Dokumentation vorhanden/nötig?
