### PR TITLE
Validate task deadline modification through the rest-api

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 
 - Set proposal plone workflow state when submitted proposal state changes. Refactor remote calls so that there is only one request per state change. [deiferni]
 - Bump ftw.solr to 2.7.0 to get console scripts for maintenance tasks. [deiferni]
+- Validate task deadline modification through the rest-api if the user uses the same deadline as already set on the task. [elioschmutz]
 - Bump ftw.solr to 2.6.2 to get fix for avoiding atomic updates with null-documents. [lgraf]
 - Add example contentent for workspaces. [elioschmutz]
 - Fix unicode error in listing endpoint. [njohner]

--- a/opengever/task/configure.zcml
+++ b/opengever/task/configure.zcml
@@ -25,6 +25,7 @@
   <adapter factory=".task.NoCheckedoutDocsValidator" />
   <adapter factory=".transition.NoTeamsInProgressStateValidator" />
   <adapter factory=".transition.NoAdminUnitChangeInProgressStateValidator" />
+  <adapter factory=".transition.DeadlineChangedValidator" />
 
   <browser:page
       name="task_response_delete"

--- a/opengever/task/tests/test_api_support.py
+++ b/opengever/task/tests/test_api_support.py
@@ -155,6 +155,23 @@ class TestAPITransitions(IntegrationTestCase):
             response.changes)
 
     @browsing
+    def test_modify_deadline_with_same_deadline_as_before_raises_an_error(self, browser):
+        self.login(self.dossier_responsible, browser=browser)
+
+        url = '{}/@workflow/task-transition-modify-deadline'.format(
+            self.task.absolute_url())
+
+        data = {'new_deadline': self.task.deadline.strftime('%Y-%m-%d')}
+
+        with browser.expect_http_error(400):
+            browser.open(url, method='POST', data=json.dumps(data),
+                         headers=self.api_headers)
+
+        self.assertIn(
+            'same_deadline_error',
+            browser.json.get('error').get('message'))
+
+    @browsing
     def test_close_successful(self, browser):
         self.login(self.dossier_responsible, browser=browser)
 

--- a/opengever/task/transition.py
+++ b/opengever/task/transition.py
@@ -13,6 +13,7 @@ from opengever.task.browser.assign import validate_no_teams
 from opengever.task.browser.delegate.metadata import IUpdateMetadata
 from opengever.task.browser.delegate.recipients import ISelectRecipientsSchema
 from opengever.task.browser.delegate.utils import create_subtasks
+from opengever.task.browser.modify_deadline import validate_deadline_changed
 from opengever.task.interfaces import IDeadlineModifier
 from opengever.task.localroles import LocalRolesSetter
 from opengever.task.reminder.reminder import TaskReminder
@@ -28,6 +29,7 @@ from z3c.relationfield.schema import RelationList
 from zope import schema
 from zope.component import adapter
 from zope.component import getUtility
+from zope.component import queryMultiAdapter
 from zope.event import notify
 from zope.globalrequest import getRequest
 from zope.interface import implementer
@@ -193,6 +195,20 @@ class ModifyDeadlineTransitionExtender(TransitionExtender):
         IDeadlineModifier(self.context).modify_deadline(
             transition_params['new_deadline'], transition_params.get('text'),
             transition)
+
+
+class DeadlineChangedValidator(validator.SimpleFieldValidator):
+    """Deadline have to be changed.
+    """
+
+    def validate(self, value):
+        validate_deadline_changed(self.context, value)
+
+
+validator.WidgetValidatorDiscriminators(
+    DeadlineChangedValidator,
+    field=INewDeadline['new_deadline'],
+)
 
 
 @implementer(ITransitionExtender)


### PR DESCRIPTION
Validate task deadline modification through the rest-api if the user uses the same deadline as already set on the task.

Issuer: #5814 

## Checkliste

_Zutreffendes soll angehakt stehengelassen werden._

- [x] Wurde etwas an der `Aufgabe` angepasst? Funktioniert das auch mit einer `Weiterleitung`?
- [x] Changelog-Eintrag vorhanden/nötig?
