### PR TITLE
Rename bundle-factory to create-bundle.

### DIFF
--- a/docs/public/dev-manual/oggbundle/index.rst
+++ b/docs/public/dev-manual/oggbundle/index.rst
@@ -459,7 +459,7 @@ Die JSON-Schemas, welche die Struktur der JSON-Dateien für die Metadaten defini
 Generieren von OGGBundle
 ========================
 
-Mit ``bin/bundle-factory`` kann ein ``OGGBundle`` von einem Datenverzeichnis generiert werden.
+Mit ``bin/create-bundle`` kann ein ``OGGBundle`` von einem Datenverzeichnis generiert werden.
 
 -  Wenn ``--repo-nesting-depth`` gesetzt ist, wird das Skript ein ``OGGBundle`` für ein komplettes ``Ordnungssystem`` generieren. In diesem Fall wird das ``source_dir`` im ``OGGBundle`` als ein ``reporoot`` abgebildet, und alle Verzeichnisse welche eine Verschachtelungstiefe geringer als ``--repo-nesting-depth`` haben werden als ``repofolders`` abgebildet. Andere Verzeichnisse als ``dossiers`` und Dateien als ``documents``.
 

--- a/setup.py
+++ b/setup.py
@@ -210,6 +210,6 @@ setup(name='opengever.core',
       [console_scripts]
       create-policy = opengever.policytemplates.cli:main
       pyxbgen = opengever.disposition.ech0160.pyxbgen:main
-      bundle-factory = opengever.bundle.factory:main
+      create-bundle = opengever.bundle.factory:main
       """,
       )


### PR DESCRIPTION
This avoids an auto-completion clash with buildout and starts to establish a
`create-` prefix convention for commands that create things.

Closes #5930.