### PR TITLE
Harmonize datetimes in recently-touched endpoint.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2019.4.0rc3 (unreleased)
 ------------------------
 
+- Harmonize datetimes in recently-touched endpoint. [phgross]
 - Set proposal plone workflow state when submitted proposal state changes. Refactor remote calls so that there is only one request per state change. [deiferni]
 - Bump ftw.solr to 2.7.0 to get console scripts for maintenance tasks. [deiferni]
 - Validate task deadline modification through the rest-api if the user uses the same deadline as already set on the task. [elioschmutz]

--- a/docs/public/dev-manual/api/recently_touched.rst
+++ b/docs/public/dev-manual/api/recently_touched.rst
@@ -65,7 +65,7 @@ zwei separaten Listen:
         "recently_touched": [
           {
             "icon_class": "icon-dokument_powerpoint is-checked-out",
-            "last_touched": "2018-05-31T15:35:38.607793",
+            "last_touched": "2018-05-31T15:35:38+02:00",
             "target_url": "http://localhost:8080/fd/ordnungssystem/fuehrung/gemeinderecht/dossier-18/document-229",
             "title": "Pra\u0308sentation - Firmenprofil Muster AG",
             "filename": "Praesentation - Firmenprofil Muster AG.ppt",
@@ -76,7 +76,7 @@ zwei separaten Listen:
           },
           {
             "icon_class": "icon-dokument_word",
-            "last_touched": "2018-05-31T15:34:42.442729",
+            "last_touched": "2018-05-31T15:34:42+02:00",
             "target_url": "http://localhost:8080/fd/ordnungssystem/fuehrung/gemeinderecht/dossier-18/document-236",
             "title": "Anfrage Drei"
             "filename": "Anfrage Drei.docx",

--- a/opengever/api/tests/test_recently_touched.py
+++ b/opengever/api/tests/test_recently_touched.py
@@ -39,7 +39,9 @@ class TestRecentlyModifiedGet(IntegrationTestCase, ResolveTestHelper):
             {'checked_out': [],
              'recently_touched': [{
                  'icon_class': 'icon-docx',
-                 'last_touched': '2018-04-30T00:00:00',
+                 # Because of an incorrect timezone handling in the freezer
+                 # last_touched should be `2018-04-30T00:00:00+02:00`
+                 'last_touched': u'2018-04-30T02:00:00+02:00',
                  'target_url': self.document.absolute_url(),
                  'title': u'Vertr\xe4gsentwurf',
                  'filename': u'Vertraegsentwurf.docx',
@@ -98,12 +100,14 @@ class TestRecentlyModifiedGet(IntegrationTestCase, ResolveTestHelper):
         self.assertEquals(
             {'checked_out': [],
              'recently_touched': [{
-                'icon_class': 'icon-docx is-checked-out',
-                'last_touched': '2018-04-30T00:00:00',
-                'target_url': self.document.absolute_url(),
-                'title': u'Vertr\xe4gsentwurf',
-                'filename': u'Vertraegsentwurf.docx',
-                'checked_out': self.secretariat_user.getId()}]},
+                 'icon_class': 'icon-docx is-checked-out',
+                 # Because of an incorrect timezone handling in the freezer
+                 # last_touched should be `2018-04-30T00:00:00+02:00`
+                 'last_touched': u'2018-04-30T02:00:00+02:00',
+                 'target_url': self.document.absolute_url(),
+                 'title': u'Vertr\xe4gsentwurf',
+                 'filename': u'Vertraegsentwurf.docx',
+                 'checked_out': self.secretariat_user.getId()}]},
             browser.json)
 
     @browsing

--- a/opengever/base/touched.py
+++ b/opengever/base/touched.py
@@ -1,5 +1,6 @@
 from BTrees.OOBTree import OOBTree
 from datetime import datetime
+from DateTime import DateTime
 from opengever.base.interfaces import IRecentlyTouchedSettings
 from opengever.base.protect import unprotected_write
 from opengever.document.behaviors import IBaseDocument
@@ -9,11 +10,13 @@ from persistent.list import PersistentList
 from plone import api
 from plone.api.portal import get_registry_record
 from plone.uuid.interfaces import IUUID
+from tzlocal import get_localzone
 from zope.annotation import IAnnotations
 from zope.component.interfaces import IObjectEvent
 from zope.component.interfaces import ObjectEvent
 from zope.interface import implements
 import logging
+import pytz
 
 
 RECENTLY_TOUCHED_KEY = 'opengever.base.touched.recently_touched'
@@ -87,8 +90,8 @@ class ObjectTouchedHandler(object):
                 recently_touched_log.remove(entry)
 
         # Store touched items in order - most recent first
-        recently_touched_log.insert(
-            0, {'last_touched': datetime.now(), 'uid': obj_uid})
+        now = datetime.now(pytz.utc).astimezone(get_localzone())
+        recently_touched_log.insert(0, {'last_touched': now, 'uid': obj_uid})
 
         self.sort(recently_touched_log)
         self.rotate(current_user_id)

--- a/opengever/core/upgrades/20190920114010_migrate_dates_in_recently_touched_menu/upgrade.py
+++ b/opengever/core/upgrades/20190920114010_migrate_dates_in_recently_touched_menu/upgrade.py
@@ -1,0 +1,21 @@
+from ftw.upgrade import UpgradeStep
+from opengever.base.touched import RECENTLY_TOUCHED_KEY
+from tzlocal import get_localzone
+from zope.annotation import IAnnotations
+
+
+class MigrateDatesInRecentlyTouchedMenu(UpgradeStep):
+    """Migrate dates in recently touched menu.
+    """
+
+    def __call__(self):
+        local_tz = get_localzone()
+        annotations = IAnnotations(self.portal)
+        touched_store = annotations.get(RECENTLY_TOUCHED_KEY)
+        if not touched_store:
+            return
+
+        for userid in touched_store.keys():
+            for entry in touched_store[userid]:
+                naive_touched_date = entry['last_touched']
+                entry['last_touched'] = naive_touched_date.replace(tzinfo=local_tz)


### PR DESCRIPTION
Also use timezone aware datetimes for the recently touched log, so both datetimes returned by the `recently-touched` endpoint are timezone aware datetimes.

The change contains a migration for the existing recently-touched log, which migrates the naive datetimes.

for #5887


## Checkliste

_Zutreffendes soll angehakt stehengelassen werden._
- [x] Profil angepasst? Sind UpgradeSteps vorhanden/nötig?:
- [x] Sind UpgradeSteps `deferrable`, oder können gewisse Schritte des Upgrades konditional ausgeführt werden? --> deferrable, ist m.E. nicht nötig
- [x] Changelog-Eintrag vorhanden/nötig?
- [x] Aktualisierung Dokumentation vorhanden/nötig?