### PR TITLE
Handle creation of new proposals over the REST-API.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -16,6 +16,7 @@ Changelog
 - Bump docxcompose to version 1.0.2. [njohner]
 - Bump ftw.zipexport to include a bugfix to avoid doubled subfolders. [phgross]
 - Change task specific response implementation to the new base response implementation. [elioschmutz]
+- Handle creation of new proposals over the REST-API. [njohner]
 - Introduce plone proposal workflow, provide api support for proposal workflow transitions. [deiferni]
 - Always raise when viewlet rendering errors occur during development. [deiferni]
 - Rename label and values of the privacy layer field. [phgross]

--- a/docs/public/dev-manual/api/content_types.rst
+++ b/docs/public/dev-manual/api/content_types.rst
@@ -74,4 +74,11 @@ Aufgabe
 
 .. include:: schemas/opengever.task.task.inc
 
+
+
+Anträge
+^^^^^^^
+
+.. include:: schemas/opengever.meeting.proposal.inc
+
 .. disqus::

--- a/docs/public/dev-manual/api/index.rst
+++ b/docs/public/dev-manual/api/index.rst
@@ -29,6 +29,7 @@ Inhalt:
    preview.rst
    webactions.rst
    tasks.rst
+   proposals.rst
    reminder.rst
    journal.rst
    workspace/index

--- a/docs/public/dev-manual/api/proposals.rst
+++ b/docs/public/dev-manual/api/proposals.rst
@@ -1,0 +1,60 @@
+Anträge
+=======
+
+Auch Anträge können via REST API bedient werden. Die Erstellung eines Antrags erfolgt wie bei anderen Inhalten (siehe Kapitel :ref:`operations`) via POST request. Man muss entweder ``proposal_template`` oder ``proposal_document`` und ``"proposal_document_type": "existing"`` spezifizieren (``proposal_template`` und ``proposal_document`` als ``UUID``):
+
+
+**Beispiel-Request mit `proposal_template`**:
+
+   .. sourcecode:: http
+
+      POST /(container) HTTP/1.1
+      Accept: application/json
+      Content-Type: application/json
+
+      {
+        "@type": "opengever.meeting.proposal",
+        "title": "Antrag für Kreiselbau",
+        "committee_oguid": "fd:1722088772",
+        "issuer": "john.doe",
+        "proposal_template": "c6df8eb485a448ef861caf97198e1dae"
+      }
+
+
+**Beispiel-Request mit `proposal_document`**:
+
+   .. sourcecode:: http
+
+      POST /(container) HTTP/1.1
+      Accept: application/json
+      Content-Type: application/json
+
+      {
+        "@type": "opengever.meeting.proposal",
+        "title": "Antrag für Kreiselbau",
+        "committee_oguid": "fd:1722088772",
+        "issuer": "john.doe",
+        "proposal_document":"a7f51d19d31141ac84bd368d44d17f05",
+        "proposal_document_type": "existing"
+      }
+
+**Beispiel-Response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 201 Created
+      Accept: application/json
+
+      {
+        "@id": "http://example.org/ordnungssystem/fuehrung/dossier-1/proposal-5",
+        "@type": "opengever.meeting.proposal",
+        "committee_oguid": {
+          "title": "Kommission für Rechtsfragen",
+          "token": "fd:1722088772"
+        },
+        "issuer": {
+          "title": "Boss Hugo (hugo.boss)",
+          "token": "hugo.boss"
+        },
+        "...": "..."
+      }

--- a/docs/public/dev-manual/api/schemas/opengever.meeting.proposal.inc
+++ b/docs/public/dev-manual/api/schemas/opengever.meeting.proposal.inc
@@ -1,0 +1,94 @@
+.. py:class:: opengever.meeting.proposal
+
+    Inhaltstyp 'Antrag'
+
+
+
+   .. py:attribute:: title
+
+       :Feldname: :field-title:`Titel`
+       :Datentyp: ``TextLine``
+       
+       :Default: ""
+       
+       
+
+
+   .. py:attribute:: description
+
+       :Feldname: :field-title:`Beschreibung`
+       :Datentyp: ``Text``
+       
+       
+       
+       
+
+
+   .. py:attribute:: issuer
+
+       :Feldname: :field-title:`Antragssteller`
+       :Datentyp: ``Choice``
+       :Pflichtfeld: Ja :required:`(*)`
+       
+       
+       :Wertebereich: <User-ID eines gültigen Auftraggebers>
+
+
+   .. py:attribute:: date_of_submission
+
+       :Feldname: :field-title:``
+       :Datentyp: ``Date``
+       
+       
+       :Beschreibung: Eingereicht am
+       
+
+
+   .. py:attribute:: language
+
+       :Feldname: :field-title:`Sprache`
+       :Datentyp: ``Choice``
+       
+       :Default: <User-spezifischer Default>
+       
+       :Wertebereich: <Ein gültiges Sprach-Code (de, en, fr...)>
+
+
+   .. py:attribute:: committee_oguid
+
+       :Feldname: :field-title:`Gremium`
+       :Datentyp: ``Choice``
+       :Pflichtfeld: Ja :required:`(*)`
+       
+       
+       :Wertebereich: <OGUID eines Committees>
+
+
+   .. py:attribute:: relatedItems
+
+       :Feldname: :field-title:`Beilagen`
+       :Datentyp: ``RelationList``
+       
+       :Default: []
+       
+       
+
+
+   .. py:attribute:: predecessor_proposal
+
+       :Feldname: :field-title:`Vorgängiger Antrag`
+       :Datentyp: ``RelationChoice``
+       
+       
+       
+       :Wertebereich: <UID eines Antrags>
+
+
+   .. py:attribute:: changed
+
+       :Feldname: :field-title:`Zuletzt verändert`
+       :Datentyp: ``Datetime``
+       
+       
+       
+       

--- a/docs/schema-dumps/opengever.meeting.proposal.schema.json
+++ b/docs/schema-dumps/opengever.meeting.proposal.schema.json
@@ -1,0 +1,87 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "type": "object",
+    "title": "Antrag",
+    "additionalProperties": false,
+    "properties": {
+        "title": {
+            "type": "string",
+            "title": "Titel",
+            "maxLength": 256,
+            "description": "",
+            "_zope_schema_type": "TextLine",
+            "default": ""
+        },
+        "description": {
+            "type": "string",
+            "title": "Beschreibung",
+            "description": "",
+            "_zope_schema_type": "Text"
+        },
+        "issuer": {
+            "type": "string",
+            "title": "Antragssteller",
+            "description": "",
+            "_zope_schema_type": "Choice",
+            "_vocabulary": "<User-ID eines g\u00fcltigen Antragsstellers>"
+        },
+        "date_of_submission": {
+            "type": "string",
+            "title": "",
+            "format": "date",
+            "description": "Eingereicht am",
+            "_zope_schema_type": "Date"
+        },
+        "language": {
+            "type": "string",
+            "title": "Sprache",
+            "description": "",
+            "_zope_schema_type": "Choice",
+            "default": "<User-spezifischer Default>",
+            "_vocabulary": "<Ein g\u00fcltiger Sprach-Code (de, en, fr...)>"
+        },
+        "committee_oguid": {
+            "type": "string",
+            "title": "Gremium",
+            "description": "",
+            "_zope_schema_type": "Choice",
+            "_vocabulary": "<OGUID eines Committees>"
+        },
+        "relatedItems": {
+            "type": "array",
+            "title": "Beilagen",
+            "description": "",
+            "_zope_schema_type": "RelationList",
+            "default": []
+        },
+        "predecessor_proposal": {
+            "type": "string",
+            "title": "Vorg\u00e4ngiger Antrag",
+            "description": "",
+            "_zope_schema_type": "RelationChoice",
+            "_vocabulary": "<UID eines Antrags>"
+        },
+        "changed": {
+            "type": "string",
+            "title": "Zuletzt ver\u00e4ndert",
+            "format": "datetime",
+            "description": "",
+            "_zope_schema_type": "Datetime"
+        }
+    },
+    "required": [
+        "issuer",
+        "committee_oguid"
+    ],
+    "field_order": [
+        "title",
+        "description",
+        "issuer",
+        "date_of_submission",
+        "language",
+        "committee_oguid",
+        "relatedItems",
+        "predecessor_proposal",
+        "changed"
+    ]
+}

--- a/opengever/api/add.py
+++ b/opengever/api/add.py
@@ -1,9 +1,12 @@
 # -*- coding: utf-8 -*-
 from Acquisition import aq_base
 from Acquisition.interfaces import IAcquirer
+from opengever.meeting.browser.proposalforms import get_selected_template
+from opengever.meeting.browser.proposalforms import IAddProposalSupplementaryFields
 from plone.restapi.deserializer import json_body
 from plone.restapi.exceptions import DeserializationError
 from plone.restapi.interfaces import IDeserializeFromJson
+from plone.restapi.interfaces import IFieldDeserializer
 from plone.restapi.interfaces import ISerializeToJson
 from plone.restapi.services import Service
 from plone.restapi.services.content.utils import add
@@ -16,8 +19,11 @@ from zope.component import getMultiAdapter
 from zope.component import queryMultiAdapter
 from zope.event import notify
 from zope.interface import alsoProvides
+from zope.interface.exceptions import Invalid
 from zope.lifecycleevent import ObjectCreatedEvent
-
+from zope.schema import getFieldsInOrder
+from zope.schema import ValidationError
+from zope.schema.interfaces import RequiredMissing
 import plone.protect.interfaces
 
 
@@ -35,6 +41,7 @@ class FolderPost(Service):
 
         if not self.type:
             raise BadRequest("Property '@type' is required")
+        return data
 
     def deserialize_object(self):
         # Acquisition wrap temporarily to satisfy things like vocabularies
@@ -103,3 +110,137 @@ class FolderPost(Service):
         serialized_obj = self.serialize_object()
 
         return serialized_obj
+
+
+class GeverFolderPost(FolderPost):
+    """Contains specific treatment for creation of certain portal types
+    """
+
+    def extract_data(self):
+        data = super(GeverFolderPost, self).extract_data()
+        if self.type == 'opengever.meeting.proposal':
+            data.update(self.extract_additional_data(data, IAddProposalSupplementaryFields))
+            self.validate_additional_schema(data, IAddProposalSupplementaryFields)
+        self.data = data
+        return data
+
+    def extract_additional_data(self, data, schema):
+        """ Deserializes the values corresponding to the passed schema found in
+        data. Note that validation of the value happens during deserialization.
+        """
+        for name, field in getFieldsInOrder(schema):
+            if name not in data:
+                continue
+            validation_data = SchemaValidationData(schema, data, self.context)
+            deserializer = queryMultiAdapter((field, validation_data, self.request),
+                                             IFieldDeserializer)
+            value = deserializer(data[name])
+            data[name] = value
+        return data
+
+    def validate_additional_schema(self, data, schema):
+        """This will validate the values in data corresponding to
+        the fields from schema, check that all required fields are
+        in data, and validate the invariants.
+        """
+        errors = get_validation_errors(self.context, data, schema)
+        if errors:
+            raise BadRequest(errors)
+
+    def add_object_to_context(self):
+        super(GeverFolderPost, self).add_object_to_context()
+        if self.obj.portal_type == 'opengever.meeting.proposal':
+            # For proposals we also need to create the proposal document
+            data = SchemaValidationData(IAddProposalSupplementaryFields,
+                                        self.data,
+                                        self.context)
+            proposal_template = get_selected_template(data)
+            self.obj.create_proposal_document(
+                title=self.obj.title_or_id(),
+                source_blob=proposal_template.file,
+            )
+
+
+class SchemaValidationData(object):
+    """To validate a field, it needs to be bound to its context, as for example
+    certain vocabularies are context-dependent. In the case of content creation,
+    the object does not exist yet and the container is used as context, so we
+    need to provide access to the data that will be set on the object being
+    created (contained either in data or as default values on the schema).
+    For example the ProposalTemplatesForCommitteeVocabulary used for the
+    proposal_template field needs access to the predeessor_proposal and
+    committee_oguid both stored in data.
+
+    This class therefore wraps the context (container) together with data and
+    schema defaults to allow correct validation. This is similar to the
+    z3c.form.validator.Data class used during form invariants validation.
+    """
+    def __init__(self, schema, data, context):
+        self.context = context
+        self.data = data
+        self.schema = schema
+
+    def __getattr__(self, name):
+        if name in self.data:
+            return self.data.get(name)
+        if hasattr(self.context, name):
+            return getattr(self.context, name)
+        if name in self.schema:
+            return self.schema.get(name).default
+        return None
+
+
+def get_schema_validation_errors(context, data, schema):
+    """Validate a dict against a schema.
+
+    Return a list of basic schema validation errors (required fields,
+    constraints, but doesn't check invariants yet).
+
+    Loosely based on zope.schema.getSchemaValidationErrors, but:
+
+    - Processes fields in schema order
+    - Handles dict subscription access instead of object attribute access
+    - Respects required / optional fields
+    - Raises RequiredMissing instead of SchemaNotFullyImplemented
+    """
+    validation_data = SchemaValidationData(schema, data, context)
+    errors = []
+    for name, field in getFieldsInOrder(schema):
+        try:
+            value = data[name]
+        except KeyError:
+            # property for the given name is not implemented
+            if not field.required:
+                continue
+            errors.append((name, RequiredMissing(name)))
+        else:
+            try:
+                field.bind(validation_data).validate(value)
+            except ValidationError as e:
+                errors.append((name, e))
+
+    return errors
+
+
+def get_validation_errors(context, data, schema):
+    """Validate a dict against a schema and invariants.
+
+    Return a list of all validation errors, including invariants.
+    Based on zope.schema.getValidationErrors.
+    """
+    errors = get_schema_validation_errors(context, data, schema)
+    if errors:
+        return errors
+
+    # Only validate invariants if there were no previous errors. Previous
+    # errors could be missing attributes which would most likely make an
+    # invariant raise an AttributeError.
+    invariant_errors = []
+    try:
+        schema.validateInvariants(SchemaValidationData(schema, data, context),
+                                  invariant_errors)
+    except Invalid:
+        # Just collect errors
+        pass
+    errors = [(None, e) for e in invariant_errors]
+    return errors

--- a/opengever/api/add.py
+++ b/opengever/api/add.py
@@ -35,11 +35,11 @@ class FolderPost(Service):
     def extract_data(self):
         data = json_body(self.request)
 
-        self.type = data.get("@type", None)
-        self.id = data.get("id", None)
-        self.title = data.get("title", None)
+        self.type_ = data.get("@type", None)
+        self.id_ = data.get("id", None)
+        self.title_ = data.get("title", None)
 
-        if not self.type:
+        if not self.type_:
             raise BadRequest("Property '@type' is required")
         return data
 
@@ -62,7 +62,7 @@ class FolderPost(Service):
             notify(ObjectCreatedEvent(self.obj))
 
     def add_object_to_context(self):
-        self.obj = add(self.context, self.obj, rename=not bool(self.id))
+        self.obj = add(self.context, self.obj, rename=not bool(self.id_))
 
     def serialize_object(self):
         serializer = queryMultiAdapter((self.obj, self.request), ISerializeToJson)
@@ -83,7 +83,7 @@ class FolderPost(Service):
             alsoProvides(self.request, plone.protect.interfaces.IDisableCSRFProtection)
 
         try:
-            self.obj = create(self.context, self.type, id_=self.id, title=self.title)
+            self.obj = create(self.context, self.type_, id_=self.id_, title=self.title_)
         except Unauthorized as exc:
             self.request.response.setStatus(403)
             return dict(error=dict(type="Forbidden", message=str(exc)))
@@ -118,7 +118,7 @@ class GeverFolderPost(FolderPost):
 
     def extract_data(self):
         data = super(GeverFolderPost, self).extract_data()
-        if self.type == 'opengever.meeting.proposal':
+        if self.type_ == 'opengever.meeting.proposal':
             data.update(self.extract_additional_data(data, IAddProposalSupplementaryFields))
             self.validate_additional_schema(data, IAddProposalSupplementaryFields)
         self.data = data

--- a/opengever/api/add.py
+++ b/opengever/api/add.py
@@ -1,0 +1,90 @@
+# -*- coding: utf-8 -*-
+from Acquisition import aq_base
+from Acquisition.interfaces import IAcquirer
+from plone.restapi.deserializer import json_body
+from plone.restapi.exceptions import DeserializationError
+from plone.restapi.interfaces import IDeserializeFromJson
+from plone.restapi.interfaces import ISerializeToJson
+from plone.restapi.services import Service
+from plone.restapi.services.content.utils import add
+from plone.restapi.services.content.utils import create
+from Products.CMFPlone.utils import safe_hasattr
+from zExceptions import BadRequest
+from zExceptions import Unauthorized
+from zope.component import queryMultiAdapter
+from zope.event import notify
+from zope.interface import alsoProvides
+from zope.lifecycleevent import ObjectCreatedEvent
+
+import plone.protect.interfaces
+
+
+class FolderPost(Service):
+    """Copy of plone.restapi.services.content.add.FolderPost
+    """
+
+    def reply(self):
+        data = json_body(self.request)
+
+        type_ = data.get("@type", None)
+        id_ = data.get("id", None)
+        title = data.get("title", None)
+
+        if not type_:
+            raise BadRequest("Property '@type' is required")
+
+        # Disable CSRF protection
+        if "IDisableCSRFProtection" in dir(plone.protect.interfaces):
+            alsoProvides(self.request, plone.protect.interfaces.IDisableCSRFProtection)
+
+        try:
+            obj = create(self.context, type_, id_=id_, title=title)
+        except Unauthorized as exc:
+            self.request.response.setStatus(403)
+            return dict(error=dict(type="Forbidden", message=str(exc)))
+        except BadRequest as exc:
+            self.request.response.setStatus(400)
+            return dict(error=dict(type="Bad Request", message=str(exc)))
+
+        # Acquisition wrap temporarily to satisfy things like vocabularies
+        # depending on tools
+        temporarily_wrapped = False
+        if IAcquirer.providedBy(obj) and not safe_hasattr(obj, "aq_base"):
+            obj = obj.__of__(self.context)
+            temporarily_wrapped = True
+
+        # Update fields
+        deserializer = queryMultiAdapter((obj, self.request), IDeserializeFromJson)
+        if deserializer is None:
+            self.request.response.setStatus(501)
+            return dict(
+                error=dict(message="Cannot deserialize type {}".format(obj.portal_type))
+            )
+
+        try:
+            deserializer(validate_all=True, create=True)
+        except DeserializationError as e:
+            self.request.response.setStatus(400)
+            return dict(error=dict(type="DeserializationError", message=str(e)))
+
+        if temporarily_wrapped:
+            obj = aq_base(obj)
+
+        if not getattr(deserializer, "notifies_create", False):
+            notify(ObjectCreatedEvent(obj))
+
+        obj = add(self.context, obj, rename=not bool(id_))
+
+        self.request.response.setStatus(201)
+        self.request.response.setHeader("Location", obj.absolute_url())
+
+        serializer = queryMultiAdapter((obj, self.request), ISerializeToJson)
+
+        serialized_obj = serializer()
+
+        # HypermediaBatch can't determine the correct canonical URL for
+        # objects that have just been created via POST - so we make sure
+        # to set it here
+        serialized_obj["@id"] = obj.absolute_url()
+
+        return serialized_obj

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -447,4 +447,11 @@
       layer="opengever.base.interfaces.IOpengeverBaseLayer"
       />
 
+  <plone:service
+      method="POST"
+      for="opengever.dossier.behaviors.dossier.IDossierMarker"
+      factory=".add.FolderPost"
+      permission="cmf.AddPortalContent"
+      />
+
 </configure>

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -450,7 +450,7 @@
   <plone:service
       method="POST"
       for="opengever.dossier.behaviors.dossier.IDossierMarker"
-      factory=".add.FolderPost"
+      factory=".add.GeverFolderPost"
       permission="cmf.AddPortalContent"
       />
 

--- a/opengever/api/tests/test_content_creation.py
+++ b/opengever/api/tests/test_content_creation.py
@@ -1,13 +1,17 @@
 from ftw.bumblebee.interfaces import IBumblebeeDocument
 from ftw.testbrowser import browsing
 from opengever.base.behaviors.lifecycle import ILifeCycle
+from opengever.base.oguid import Oguid
 from opengever.dossier.behaviors.dossier import IDossier
 from opengever.testing import IntegrationTestCase
 from plone import api
+from plone.uuid.interfaces import IUUID
 import json
 
 
 class TestContentCreation(IntegrationTestCase):
+
+    features = ('meeting',)
 
     def setUp(self):
         super(TestContentCreation, self).setUp()
@@ -72,3 +76,144 @@ class TestContentCreation(IntegrationTestCase):
 
         checksum = IBumblebeeDocument(doc).get_checksum()
         self.assertIsNotNone(checksum)
+
+    @browsing
+    def test_proposal_creation(self, browser):
+        self.login(self.meeting_user, browser)
+
+        committee_oguid = Oguid.for_object(self.committee).id
+        payload = {
+            u'@type': u'opengever.meeting.proposal',
+            u'title': u'Sanierung B\xe4rengraben 2016',
+            u'proposal_template': IUUID(self.proposal_template),
+            u"committee_oguid": committee_oguid,
+            u'issuer': self.meeting_user.getId(),
+        }
+        response = browser.open(
+            self.dossier.absolute_url(),
+            data=json.dumps(payload),
+            method='POST',
+            headers=self.api_headers)
+
+        self.assertEqual(201, response.status_code)
+
+        new_object_id = str(response.json['id'])
+        proposal = self.dossier.restrictedTraverse(new_object_id)
+        self.assertEqual(u'Sanierung B\xe4rengraben 2016', proposal.title)
+        self.assertEqual(self.meeting_user.getId(), proposal.issuer)
+
+        proposal_doc = proposal.get_proposal_document()
+        self.assertIsNotNone(proposal_doc)
+        self.assertEqual(u'Sanierung B\xe4rengraben 2016',
+                         proposal_doc.title)
+        self.assertEqual(u'Sanierung Baerengraben 2016.docx',
+                         proposal_doc.get_filename())
+
+        checksum = IBumblebeeDocument(proposal_doc).get_checksum()
+        self.assertIsNotNone(checksum)
+        self.assertEqual(IBumblebeeDocument(self.proposal_template).get_checksum(),
+                         checksum)
+
+    @browsing
+    def test_template_is_mandatory_for_proposal_creation(self, browser):
+        self.login(self.meeting_user, browser)
+
+        committee_oguid = Oguid.for_object(self.committee).id
+        payload = {
+            u'@type': u'opengever.meeting.proposal',
+            u'title': u'Sanierung B\xe4rengraben 2016',
+            u"committee_oguid": committee_oguid,
+            u'issuer': self.meeting_user.getId(),
+        }
+
+        with browser.expect_http_error():
+            browser.open(
+                self.dossier.absolute_url(),
+                data=json.dumps(payload),
+                method='POST',
+                headers=self.api_headers)
+
+        self.assertEqual(400, browser.status_code)
+        self.assertDictEqual(
+            {u'message': u"[(None, Invalid(u'error_template_or_document_required_for_creation',))]",
+             u'type': u'BadRequest'},
+            browser.json)
+
+    @browsing
+    def test_proposal_creation_from_docx_template(self, browser):
+        self.login(self.meeting_user, browser)
+
+        committee_oguid = Oguid.for_object(self.committee).id
+        payload = {
+            u'@type': u'opengever.meeting.proposal',
+            u'title': u'Sanierung B\xe4rengraben 2016',
+            u'proposal_document_type': 'existing',
+            u'proposal_document': IUUID(self.document),
+            u"committee_oguid": committee_oguid,
+            u'issuer': self.meeting_user.getId(),
+        }
+
+        response = browser.open(
+            self.dossier.absolute_url(),
+            data=json.dumps(payload),
+            method='POST',
+            headers=self.api_headers)
+
+        self.assertEqual(201, response.status_code)
+
+        new_object_id = str(response.json['id'])
+        proposal = self.dossier.restrictedTraverse(new_object_id)
+        self.assertEqual(u'Sanierung B\xe4rengraben 2016', proposal.title)
+        self.assertEqual(self.meeting_user.getId(), proposal.issuer)
+
+        proposal_doc = proposal.get_proposal_document()
+        self.assertIsNotNone(proposal_doc)
+        self.assertEqual(u'Sanierung B\xe4rengraben 2016',
+                         proposal_doc.title)
+        self.assertEqual(u'Sanierung Baerengraben 2016.docx',
+                         proposal_doc.get_filename())
+
+        checksum = IBumblebeeDocument(proposal_doc).get_checksum()
+        self.assertIsNotNone(checksum)
+        self.assertEqual(IBumblebeeDocument(self.document).get_checksum(),
+                         checksum)
+
+    @browsing
+    def test_proposal_creation_from_predecessor_proposal_document(self, browser):
+        self.login(self.meeting_user, browser)
+
+        committee_oguid = Oguid.for_object(self.committee).id
+        payload = {
+            u'@type': u'opengever.meeting.proposal',
+            u'title': u'Sanierung B\xe4rengraben 2016',
+            u'proposal_template': IUUID(self.proposal.get_proposal_document()),
+            u'predecessor_proposal': IUUID(self.proposal),
+            u"committee_oguid": committee_oguid,
+            u'issuer': self.meeting_user.getId(),
+        }
+
+        response = browser.open(
+            self.dossier.absolute_url(),
+            data=json.dumps(payload),
+            method='POST',
+            headers=self.api_headers)
+
+        self.assertEqual(201, response.status_code)
+
+        new_object_id = str(response.json['id'])
+        proposal = self.dossier.restrictedTraverse(new_object_id)
+        self.assertEqual(u'Sanierung B\xe4rengraben 2016', proposal.title)
+        self.assertEqual(self.meeting_user.getId(), proposal.issuer)
+
+        proposal_doc = proposal.get_proposal_document()
+        self.assertIsNotNone(proposal_doc)
+        self.assertEqual(u'Sanierung B\xe4rengraben 2016',
+                         proposal_doc.title)
+        self.assertEqual(u'Sanierung Baerengraben 2016.docx',
+                         proposal_doc.get_filename())
+
+        checksum = IBumblebeeDocument(proposal_doc).get_checksum()
+        self.assertIsNotNone(checksum)
+        self.assertEqual(
+            IBumblebeeDocument(self.proposal.get_proposal_document()).get_checksum(),
+            checksum)

--- a/opengever/base/schemadump/config.py
+++ b/opengever/base/schemadump/config.py
@@ -11,6 +11,7 @@ GEVER_TYPES = [
     'opengever.task.task',
     'opengever.repository.repositoryfolder',
     'opengever.repository.repositoryroot',
+    'opengever.meeting.proposal',
 ]
 
 GEVER_TYPES_TO_OGGBUNDLE_TYPES = {
@@ -77,6 +78,12 @@ VOCAB_OVERRIDES = {
         'responsible': u'<User-ID eines g\xfcltigen Auftragnehmers>',
         'responsible_client': u'<G\xfcltige Org-Unit-ID>',
     },
+    'opengever.meeting.proposal.IProposal': {
+        'issuer': u'<User-ID eines g\xfcltigen Antragsstellers>',
+        'predecessor_proposal': u'<UID eines Antrags>',
+        'committee_oguid': u'<OGUID eines Committees>',
+        'language': u'<Ein g\xfcltiger Sprach-Code (de, en, fr...)>'
+    },
 }
 
 DEFAULT_OVERRIDES = {
@@ -97,6 +104,9 @@ DEFAULT_OVERRIDES = {
                               u':small-comment:`(Obwohl dieses Feld im User-Interface '
                               u'nicht erscheint (vom System automatisch gesetzt wird), '
                               u'muss es \xfcber die REST API angegeben werden)`',
+    },
+    'opengever.meeting.proposal.IProposal': {
+        'language': u'<User-spezifischer Default>'
     },
 }
 
@@ -138,6 +148,8 @@ JSON_SCHEMA_FIELD_TYPES = {
         'type': 'integer'},
     'RelationList': {
         'type': 'array'},
+    'RelationChoice': {
+        'type': 'string'},
     'Bool': {
         'type': 'boolean'},
     'NamedBlobFile': {

--- a/opengever/meeting/browser/proposalforms.py
+++ b/opengever/meeting/browser/proposalforms.py
@@ -145,13 +145,7 @@ class IAddProposalSupplementaryFields(Schema):
 
     @invariant
     def template_or_document_required_for_creation(data):
-        proposal_template = data.proposal_template
-        proposal_document = data.proposal_document
-        proposal_document_type = data.proposal_document_type
-
-        selected_document_type_choosen = proposal_template \
-            if proposal_document_type == 'template' else proposal_document
-
+        selected_document_type_choosen = get_selected_template(data)
         if not selected_document_type_choosen:
             raise Invalid(_(
                 u'error_template_or_document_required_for_creation',
@@ -168,6 +162,16 @@ class IAddProposalSupplementaryFields(Schema):
                     u'error_only_docx_files_allowed_as_proposal_documents',
                     default=u'Only .docx files allowed as proposal documents.',
                     ))
+
+
+def get_selected_template(data):
+    proposal_template = data.proposal_template
+    proposal_document = data.proposal_document
+    proposal_document_type = data.proposal_document_type
+
+    selected_template = proposal_template \
+        if proposal_document_type == 'template' else proposal_document
+    return selected_template
 
 
 class IAddProposal(IProposal, IAddProposalSupplementaryFields):

--- a/opengever/meeting/browser/proposalforms.py
+++ b/opengever/meeting/browser/proposalforms.py
@@ -6,6 +6,7 @@ from opengever.meeting import _
 from opengever.meeting import is_meeting_feature_enabled
 from opengever.meeting.activity.watchers import change_watcher_on_proposal_edited
 from opengever.meeting.proposal import IProposal
+from opengever.meeting.utils import is_docx
 from opengever.officeconnector.helpers import is_officeconnector_checkout_feature_enabled  # noqa
 from opengever.tabbedview.helper import document_with_icon
 from plone import api
@@ -161,9 +162,7 @@ class IAddProposal(IProposal):
         # XXX - this should get removed once we have a mimetype index based on which we can filter at source
         proposal_document = data.proposal_document
         if proposal_document:
-            proposal_document_mimetype = proposal_document.file.contentType
-            docx_mimetype = 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
-            if not proposal_document_mimetype == docx_mimetype:
+            if not is_docx(proposal_document):
                 raise Invalid(_(
                     u'error_only_docx_files_allowed_as_proposal_documents',
                     default=u'Only .docx files allowed as proposal documents.',

--- a/opengever/meeting/browser/proposalforms.py
+++ b/opengever/meeting/browser/proposalforms.py
@@ -16,6 +16,7 @@ from plone.dexterity.browser.add import DefaultAddForm
 from plone.dexterity.browser.add import DefaultAddView
 from plone.dexterity.browser.edit import DefaultEditForm
 from plone.dexterity.interfaces import IDexterityFTI
+from plone.supermodel.model import Schema
 from plone.z3cform.fieldsets.utils import move
 from Products.CMFCore.interfaces import IFolderish
 from Products.CMFPlone.utils import safe_unicode
@@ -89,7 +90,7 @@ class SubmittedProposalEditForm(DefaultEditForm):
         self.widgets['issuer'].mode = HIDDEN_MODE
 
 
-class IAddProposal(IProposal):
+class IAddProposalSupplementaryFields(Schema):
 
     proposal_document_type = Choice(
         title=_(u'label_template_or_existing_document',
@@ -167,6 +168,11 @@ class IAddProposal(IProposal):
                     u'error_only_docx_files_allowed_as_proposal_documents',
                     default=u'Only .docx files allowed as proposal documents.',
                     ))
+
+
+class IAddProposal(IProposal, IAddProposalSupplementaryFields):
+    """Schema used for the proposal add form
+    """
 
 
 class ProposalAddForm(DefaultAddForm):

--- a/opengever/meeting/utils.py
+++ b/opengever/meeting/utils.py
@@ -35,3 +35,9 @@ def format_date(date, request=None):
     date_string_format = api.portal.get_registry_record(
         "sablon_date_format_string", interface=IMeetingSettings)
     return ulocalized_time(date, date_string_format, request)
+
+
+def is_docx(document):
+    document_mimetype = document.file.contentType
+    docx_mimetype = 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+    return document_mimetype == docx_mimetype

--- a/opengever/meeting/utils.py
+++ b/opengever/meeting/utils.py
@@ -38,6 +38,9 @@ def format_date(date, request=None):
 
 
 def is_docx(document):
-    document_mimetype = document.file.contentType
+    document_file = document.get_file()
+    if not document_file:
+        return False
+    document_mimetype = document_file.contentType
     docx_mimetype = 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
     return document_mimetype == docx_mimetype


### PR DESCRIPTION
This PR supersedes https://github.com/4teamwork/opengever.core/pull/5924.

The Add form for proposals contained some logic and specific steps needed for the creation of a `Proposal`, such as the creation of a `Document` (the proposal document). Because of that, creation of a `Proposal` through the REST-API was not possible (or rather broken).

In this PR we make it possible to create proposals through the REST-API. For that we:
* Copy and refactor  `plone.restapi.services.content.add.FolderPost`, splitting it into several methods to allow to hook into it in a subclass. This should allow us to move that code into `plone.restapi` later on.
* Overwrite `FolderPost` (with `GeverFolderPost`) to handle special cases like `proposal` creation in gever
    * `GeverFolderPost` allows to extract and validate data from additional schemata (including invariants)
    * We make sure that a valid template is specified for the proposal
    * We create the proposal document just after adding the `proposal` into its parent.

These changes are necessary to allow working with `Proposal`s in the new UI.

This is part of https://github.com/4teamwork/opengever.core/issues/5799

## Checkliste
- [x] Changelog-Eintrag vorhanden/nötig?
- [x] Aktualisierung Dokumentation vorhanden/nötig?