### PR TITLE
Downgrade solr to 7.3.1.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 
 - Add support for multipart/signed a.k.a. *.p7m mails. [deiferni]
 - Add documentation for the cancelcheckout endpoint. [njohner]
+- Downgrade solr to 7.3.1.
 - Bump plone.restapi to 4.5.1. [phgross]
 - Use persistent-mapping for recently touched entries. [phgross]
 - Harmonize datetimes in recently-touched endpoint. [phgross]

--- a/opengever/core/solr_testing.py
+++ b/opengever/core/solr_testing.py
@@ -206,11 +206,6 @@ class SolrReplicationAPIClient(object):
             raise
         response_data = response.json()
 
-        if not response_data['status'] == 'OK':
-            print response
-            print response_data
-            raise Exception('Failed to check restore status')
-
         return response_data['restorestatus']
 
     def await_restored(self, timeout=60, interval=0.1):

--- a/solr-conf/solrconfig.xml
+++ b/solr-conf/solrconfig.xml
@@ -35,7 +35,7 @@
        that you fully re-index after changing this setting as it can
        affect both how text is indexed and queried.
   -->
-  <luceneMatchVersion>8.1.1</luceneMatchVersion>
+  <luceneMatchVersion>7.3.1</luceneMatchVersion>
 
   <!-- <lib/> directives can be used to instruct Solr to load any Jars
        identified and use them to resolve any "plugins" specified in

--- a/solr-conf/solrconfig.xml
+++ b/solr-conf/solrconfig.xml
@@ -373,11 +373,11 @@
   <query>
 
     <!-- Maximum number of clauses allowed when parsing a boolean query string.
-         
+
          This limit only impacts boolean queries specified by a user as part of a query string,
          and provides per-collection controls on how complex user specified boolean queries can
          be.  Query strings that specify more clauses then this will result in an error.
-         
+
          If this per-collection limit is greater then the global `maxBooleanClauses` limit
          specified in `solr.xml`, it will have no effect, as that setting also limits the size
          of user specified boolean queries.
@@ -704,10 +704,10 @@
       <str name="echoParams">explicit</str>
       <int name="rows">10</int>
       <!-- Default search field
-         <str name="df">text</str> 
+         <str name="df">text</str>
         -->
       <!-- Change from JSON to XML format (the default prior to Solr 7.0)
-         <str name="wt">xml</str> 
+         <str name="wt">xml</str>
         -->
     </lst>
     <!-- In addition to defaults, "appends" params can be specified

--- a/versions.cfg
+++ b/versions.cfg
@@ -222,5 +222,5 @@ zope.testrunner = 4.8.1
 zptlint = 0.2.4
 
 [solr]
-url = https://archive.apache.org/dist/lucene/solr/8.1.1/solr-8.1.1.tgz
-md5sum = 9506f15df46c0a403ff41f77778df0f0
+url = http://archive.apache.org/dist/lucene/solr/7.3.1/solr-7.3.1.tgz
+md5sum = 042a6c0d579375be1a8886428f13755f


### PR DESCRIPTION
We've decided to not yet bump the solr version to an 8.x major version yet as we have discovered that a major upgrade needs a full reindex. Instead we're going to ship scripts to ease migration to 8.x with the next gever release, see https://github.com/4teamwork/opengever.core/pull/5933.

See https://github.com/4teamwork/opengever.core/issues/5863 for full background and next steps we're planning to take.

- ⚠️ before deploying this PR locally and on our RED deployment(s) we must manually run a `bin/instance solr reindex`, or for local development create a fresh deployment. You will get a `SolrCore 'development' is not available due to init failure: Error opening new searcher.` error after the downgrade, so we need to manually clear the core and make sure it is rebuilt.

the older solr can no longer load the cores of a newer solr. we need to reindex. steps to downgrade solr:
- `mv parts/solr/ parts/solr_bak`
- `mv var/solr/ var/solr_bak`
- `bin/buildout`
- start solr
- `bin/instance solr reindex`
- boot instances normally
- if successful delete backed up directories


## Checkliste

- [x] Changelog-Eintrag vorhanden/nötig?
