### PR TITLE
Fix task responses

### DIFF
--- a/docs/public/dev-manual/api/tasks.rst
+++ b/docs/public/dev-manual/api/tasks.rst
@@ -318,6 +318,83 @@ Zusätzliche Metadaten:
        :Datentyp: ``Text``
 
 
+Aufgabe kommentieren
+--------------------
+
+Eine Aufgabe kann über den `@responses` Endpoint kommentiert werden:
+
+
+Kommentar hinzufügen
+~~~~~~~~~~~~~~~~~~~~
+
+Ein POST Request auf den `@responses` Endpoint erstellt einen Kommentar mit dem aktuellen Benutzer.
+
+**Beispiel-Request**:
+
+   .. sourcecode:: http
+
+      POST http://example.org/ordnungssystem/fuehrung/dossier-1/task-5/@responses HTTP/1.1
+      Accept: application/json
+      Content-Type: application/json
+
+      {
+        "text": "Bitte rasch anschauen. Danke.",
+      }
+
+
+**Beispiel-Response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 201 Created
+      Content-Type: application/json
+
+      {
+        "@id": "http://example.org/ordnungssystem/fuehrung/dossier-1/task-5/@responses/1569875801956269",
+        "added_objects": [],
+        "changes": [],
+        "created": "2019-05-21T13:57:42+00:00",
+        "creator": {
+          "title": "Meier Peter",
+          "token": "peter.meier"
+        },
+        "mimetype": "",
+        "related_items": [],
+        "rendered_text": "",
+        "response_id": 1569875801956269,
+        "response_type": "comment",
+        "successor_oguid": "",
+        "text": "Bitte rasch anschauen. Danke.",
+        "transition": "task-commented"
+      }
+
+
+Kommentar bearbeiten
+~~~~~~~~~~~~~~~~~~~~
+
+Ein PATCH Request auf eine Kommentar-Ressource ändert den Kommentar.
+
+**Beispiel-Request**:
+
+   .. sourcecode:: http
+
+      PATCH http://example.org/ordnungssystem/fuehrung/dossier-1/task-5/@responses/1569875801956269 HTTP/1.1
+      Accept: application/json
+      Content-Type: application/json
+
+      {
+        "text": "Hat sich erledigt.",
+      }
+
+
+**Beispiel-Response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 204 Created
+      Content-Type: application/json
+
+
 Aufgabenverlauf
 ---------------
 Der Verlauf einer Aufgabe ist in der GET Repräsentation einer Aufgaben unter dem Attribut ``responses`` enthalten.

--- a/opengever/api/response.py
+++ b/opengever/api/response.py
@@ -104,8 +104,6 @@ class ResponsePost(Service):
     """Add a Response to the current context.
     """
 
-    response_class = Response
-
     def reply(self):
         # Disable CSRF protection
         alsoProvides(self.request, IDisableCSRFProtection)
@@ -117,15 +115,19 @@ class ResponsePost(Service):
         if not text:
             raise BadRequest("Property 'text' is required")
 
-        response = self.response_class(COMMENT_RESPONSE_TYPE)
-        response.text = text
-        IResponseContainer(self.context).add(response)
+        response = self.create_response(text)
 
         self.request.response.setStatus(201)
         self.request.response.setHeader("Location", self.context.absolute_url())
 
         serializer = getMultiAdapter((response, self.request), ISerializeToJson)
         return serializer(container=self.context)
+
+    def create_response(self, text):
+        response = Response(COMMENT_RESPONSE_TYPE)
+        response.text = text
+        IResponseContainer(self.context).add(response)
+        return response
 
 
 @implementer(IPublishTraverse)

--- a/opengever/api/task.py
+++ b/opengever/api/task.py
@@ -1,8 +1,9 @@
 from opengever.api.response import ResponsePost
 from opengever.api.response import SerializeResponseToJson
-from opengever.task.task_response import TaskResponse
+from opengever.task.interfaces import ICommentResponseHandler
 from opengever.task.task_response import ITaskResponse
 from plone.restapi.interfaces import ISerializeToJson
+from zExceptions import Unauthorized
 from zope.component import adapter
 from zope.interface import implementer
 from zope.interface import Interface
@@ -19,4 +20,10 @@ class TaskResponsePost(ResponsePost):
     """Add a Response to the current context.
     """
 
-    response_class = TaskResponse
+    def create_response(self, text):
+        response_handler = ICommentResponseHandler(self.context)
+        if not response_handler.is_allowed():
+            raise Unauthorized(
+                "The current user is not allowed to add comments")
+
+        return response_handler.add_response(text)

--- a/opengever/task/comment_response.py
+++ b/opengever/task/comment_response.py
@@ -28,7 +28,7 @@ class CommentResponseHandler(object):
         self._record_activity(response)
         self._sync_response(text)
 
-        return self
+        return response
 
     def _create_response(self, text):
         response = TaskResponse(COMMENT_RESPONSE_TYPE)


### PR DESCRIPTION
Dieser PR:

- Erweitert die REST-API Dokumentation mit dem `@responses` Endpoint für Tasks
- Verwendet den `CommentResponseHandler` beim Hinzufügen von Kommentaren über den `@responses` Endpoint. Damit wird sichergestellt, dass speziellen Attribute wie z.B. der `transition_type` korrekt für das alte UI gesetzt werden und die Kommentare korrekt synchronsiert werden.

Issuer: #5813 

## Checkliste

- [x] Aktualisierung Dokumentation vorhanden/nötig?
