### PR TITLE
 Make sure agenda item template ids are ascii.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2019.4.0rc3 (unreleased)
 ------------------------
 
+- Fix an issue with agenda item template ids not being stored as ascii. [deiferni]
 - Add support for multipart/signed a.k.a. *.p7m mails. [deiferni]
 - Add documentation for the cancelcheckout endpoint. [njohner]
 - Bump plone.restapi to 4.5.1. [phgross]

--- a/opengever/core/upgrades/20191001090415_fix_paragraph_template_ordering_object_id_type/upgrade.py
+++ b/opengever/core/upgrades/20191001090415_fix_paragraph_template_ordering_object_id_type/upgrade.py
@@ -1,0 +1,32 @@
+from ftw.upgrade import UpgradeStep
+from persistent.list import PersistentList
+from zope.annotation.interfaces import IAnnotations
+
+
+ORDER_KEY = 'plone.folder.ordered.order'
+
+
+def safe_ascii(as_ascii):
+    if isinstance(as_ascii, unicode):
+        as_ascii = as_ascii.encode('ascii')
+    return as_ascii
+
+
+class FixParagraphTemplateOrderingObjectIdType(UpgradeStep):
+    """Fix paragraph template ordering object id type.
+    """
+    def __call__(self):
+        for template in self.objects(
+                {'portal_type': ['opengever.meeting.meetingtemplate']},
+                'Fix paragraph template ordering id in meeeting template'):
+
+            self.ensure_ordering_object_ids_are_ascii(template)
+
+    def ensure_ordering_object_ids_are_ascii(self, template):
+        annotations = IAnnotations(template)
+        if ORDER_KEY not in annotations:
+            return
+
+        fixed_ordering = PersistentList(
+            safe_ascii(item_id) for item_id in annotations[ORDER_KEY])
+        annotations[ORDER_KEY] = fixed_ordering

--- a/opengever/meeting/browser/meetingtemplate.py
+++ b/opengever/meeting/browser/meetingtemplate.py
@@ -22,6 +22,8 @@ class UpdateMeetingTemplateContentOrderView(BrowserView):
         order = reversed(json.loads(self.request.get('sortOrder')))
 
         for object_id in order:
+            # OFS IDs are ascii only, json strings are loaded as unicode
+            object_id = object_id.encode('ascii')
             self.context.moveObjectsToTop([object_id])
 
         return self.request.RESPONSE.redirect(self.context.absolute_url())

--- a/opengever/meeting/tests/test_meeting_template.py
+++ b/opengever/meeting/tests/test_meeting_template.py
@@ -136,7 +136,9 @@ class TestMeetingTemplate(IntegrationTestCase):
             ['paragraphtemplate-1',
              'paragraphtemplate-2',
              'paragraphtemplate-3'],
-            [paragraph.getId() for paragraph in self.meeting_template.get_paragraphs()])
+            self.meeting_template.objectIds())
+        for item in self.meeting_template.objectIds():
+            self.assertIsInstance(item, str)
 
         new_order = ['paragraphtemplate-2',
                      'paragraphtemplate-1',
@@ -153,6 +155,8 @@ class TestMeetingTemplate(IntegrationTestCase):
         self.assertEquals(
             new_order,
             [paragraph.getId() for paragraph in self.meeting_template.get_paragraphs()])
+        for item in self.meeting_template.objectIds():
+            self.assertIsInstance(item, str)
 
     @browsing
     def test_meeting_template_name_from_title_behaviour(self, browser):


### PR DESCRIPTION
Fixes https://github.com/4teamwork/opengever.core/issues/5957. With this PR we make sure that plone object ids are always stored as ascii when using the `OFS.interfaces.IOrderedContainer` interface. We also migrate existing incorrect ids to ascii.

This issue currently blocks https://github.com/4teamwork/opengever.core/issues/5863 from moving forward as a solr reindex is not possible for agenda item templates/meeting templates.

## Checkliste

- [x] Changelog-Eintrag vorhanden/nötig?
