### PR TITLE
Support the bundle-import of mails in the msg format.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,7 @@ Changelog
 2019.4.0rc4 (unreleased)
 ------------------------
 
-- Nothing changed yet.
+- Support the bundle-import of mails in the msg format. [phgross]
 
 
 2019.4.0rc3 (2019-10-02)

--- a/docs/public/dev-manual/oggbundle/index.rst
+++ b/docs/public/dev-manual/oggbundle/index.rst
@@ -133,8 +133,6 @@ Der tatsächlich in OneGov GEVER verwendete Titel / Dateiname wird gesteuert üb
 
 Folgende Dateitypen sind in OGGBundles nicht erlaubt:
 
--  **.msg**
-
 -  **.exe**
 
 -  **.dll**

--- a/opengever/bundle/factory.py
+++ b/opengever/bundle/factory.py
@@ -15,7 +15,7 @@ from collections import namedtuple
 
 
 # List of fnmatch() patterns to specify which "documents" to ignore
-IGNORES = ['*.DS_Store', '*.msg', '*.dll', '*.exe']
+IGNORES = ['*.DS_Store', '*.dll', '*.exe']
 
 
 DirectoryNode = namedtuple('Node', ['path', 'guid', 'parent_guid', 'level'])

--- a/opengever/bundle/loader.py
+++ b/opengever/bundle/loader.py
@@ -4,6 +4,7 @@ from collections import OrderedDict
 from datetime import datetime
 from jsonschema import FormatChecker
 from jsonschema import validate
+from opengever.document.document import MAIL_EXTENSIONS
 from pkg_resources import resource_filename as rf
 import codecs
 import json
@@ -212,7 +213,7 @@ class ItemPreprocessor(object):
         if filepath is None:
             return False
 
-        return os.path.splitext(filepath)[-1] in ('.eml', '.p7m',)
+        return os.path.splitext(filepath)[-1] in MAIL_EXTENSIONS
 
     def _strip_extension_from_title(self):
         """Strip extension from title if present.

--- a/opengever/bundle/tests/test_section_fileloader.py
+++ b/opengever/bundle/tests/test_section_fileloader.py
@@ -166,6 +166,26 @@ class TestFileLoader(FunctionalTestCase):
         self.assertEqual(13824, len(IOGMail(mail).original_message.data))
         self.assertEqual(u'Lorem Ipsum', mail.title)
 
+    def test_handles_msg_only_mails(self):
+        mail = create(Builder('mail'))
+        self.assertIsNone(mail.message)
+        relative_path = '/'.join(mail.getPhysicalPath()[2:])
+        item = {
+            u"guid": u"12345",
+            u"_type": u"ftw.mail.mail",
+            u"_path": relative_path,
+            u"filepath": u"files/sample.msg",
+        }
+        section = self.setup_section(previous=[item])
+        list(section)
+
+        self.assertEqual(
+            u'sample.msg', IOGMail(mail).original_message.filename)
+        self.assertEqual(13824, len(IOGMail(mail).original_message.data))
+
+        self.assertEqual('message/rfc822', mail.message.contentType)
+        self.assertEqual(u'Test attachment.eml', mail.message.filename)
+
     def test_uses_subject_as_title_only_when_no_title_is_given(self):
         mail2 = create(Builder('mail').titled(u'Test Mail'))
         item = {


### PR DESCRIPTION
Currently the bundle import of GEVER had no support for importing *.msg mails. With this changes it now also support the import of those mails, similar than GEVER does when uploading them via dnd (quickupload):
 - Converting the *.msg to an *.eml with `msgconvert` and stores it as `message`
 - Stores the `*.msg` as original_mesasge

For https://github.com/4teamwork/opengever.koeniz/issues/78

## Checkliste

_Zutreffendes soll angehakt stehengelassen werden._
- [x] Changelog-Eintrag vorhanden/nötig?
- [x] Aktualisierung Dokumentation vorhanden/nötig?
