### PR TITLE
Add new reminder type ReminderOnDate (backend only)

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -10,6 +10,7 @@ Changelog
 2019.4.0rc3 (2019-10-02)
 ------------------------
 
+- Add GET implementation for @reminder endpoint. [lgraf]
 - Add new reminder type ReminderOnDate (backend only). [lgraf]
 - Fix an issue with agenda item template ids not being stored as ascii. [deiferni]
 - Bump ftw.bumblebee to 3.8.0 for p7m support. [deiferni]

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -10,6 +10,7 @@ Changelog
 2019.4.0rc3 (2019-10-02)
 ------------------------
 
+- Add new reminder type ReminderOnDate (backend only). [lgraf]
 - Fix an issue with agenda item template ids not being stored as ascii. [deiferni]
 - Bump ftw.bumblebee to 3.8.0 for p7m support. [deiferni]
 - Add support for multipart/signed a.k.a. *.p7m mails. [deiferni]

--- a/docs/public/dev-manual/api/reminder.rst
+++ b/docs/public/dev-manual/api/reminder.rst
@@ -30,6 +30,24 @@ Wenn das Attribut einen Wert enthält, welcher nicht zulässig ist, wird eine Li
 
       HTTP/1.1 204 No content
 
+Für gewisse Reminder-Typen sind zusätzliche Parameter erforderlich. Diese
+können der entsprechenden Reminder-Subklasse entnommen werden. Parameter
+werden als Dictionary im 'params' property angegeben:
+
+**Beispiel-Request**:
+
+   .. sourcecode:: http
+
+       POST /task-1/@reminder HTTP/1.1
+       Accept: application/json
+
+       {
+        "option_type": "on_date",
+        "params": {
+            "date": "2019-12-30"
+           }
+       }
+
 
 Erinnerung aktualisieren:
 -------------------------

--- a/docs/public/dev-manual/api/reminder.rst
+++ b/docs/public/dev-manual/api/reminder.rst
@@ -6,6 +6,44 @@ Aufgaben-Erinnerungen
 Der ``@reminder`` Endpoint behandelt Erinnerungen für Aufgabe. Jeder Benutzer kann für jede Aufgabe eine eigene Erinnerung setzten.
 
 
+Erinnerung auslesen:
+--------------------
+Mit einem GET Request kann eine bestehende Erinnerung für den aktuellen Benutzer ausgelesen werden:
+
+
+**Beispiel-Request**:
+
+   .. sourcecode:: http
+
+       GET /task-1/@reminder HTTP/1.1
+       Accept: application/json
+
+
+**Beispiel-Response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 200 OK
+
+       {
+        "@id": "http://example.onegovgever.ch/ordnungssystem/dossier-20/task-1/@reminder",
+        "option_type": "one_day_before",
+        "params": {}
+       }
+
+Falls für den aktuellen Benutzer keine Erinnerung gesetzt ist, antwortet der Endpoint mit 404 Not Found:
+
+**Beispiel-Response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 404 Not Found
+
+       {
+          "message": "Resource not found: http://example.onegovgever.ch/ordnungssystem/dossier-20/task-1/@reminder",
+          "type": "NotFound"
+       }
+
 Erinnerung setzten:
 -------------------
 Mit einem POST Request wird eine neue Erinnerung gesetzt. Als Body wird das Attribut ``option_type`` erwartet.

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -212,6 +212,14 @@
       />
 
   <plone:service
+      method="GET"
+      name="@reminder"
+      for="opengever.task.task.ITask"
+      factory=".reminder.TaskReminderGet"
+      permission="zope2.View"
+      />
+
+  <plone:service
       method="POST"
       name="@reminder"
       for="opengever.task.task.ITask"

--- a/opengever/api/reminder.py
+++ b/opengever/api/reminder.py
@@ -4,6 +4,7 @@ from plone.protect.interfaces import IDisableCSRFProtection
 from plone.restapi.deserializer import json_body
 from plone.restapi.services import Service
 from zExceptions import BadRequest
+from zExceptions import NotFound
 from zope.interface import alsoProvides
 from zope.schema import ValidationError
 
@@ -14,6 +15,22 @@ error_msgs = {
                                 "Use one of the following options: {}".format(
                                     ', '.join(REMINDER_TYPE_REGISTRY.keys())),
 }
+
+
+class TaskReminderGet(Service):
+    """API endpoint to get a task-reminder for the current user.
+
+    GET /task/@reminder
+    """
+
+    def reply(self):
+        reminder = self.context.get_reminder()
+        if not reminder:
+            raise NotFound
+
+        reminder_data = reminder.serialize(json_compat=True)
+        reminder_data['@id'] = '/'.join((self.context.absolute_url(), '@reminder'))
+        return reminder_data
 
 
 class TaskReminderPost(Service):

--- a/opengever/api/reminder.py
+++ b/opengever/api/reminder.py
@@ -1,6 +1,5 @@
 from opengever.task.reminder import Reminder
 from opengever.task.reminder import REMINDER_TYPE_REGISTRY
-from opengever.task.reminder.reminder import TaskReminder
 from plone.protect.interfaces import IDisableCSRFProtection
 from plone.restapi.deserializer import json_body
 from plone.restapi.services import Service
@@ -46,13 +45,11 @@ class TaskReminderPost(Service):
         # Disable CSRF protection
         alsoProvides(self.request, IDisableCSRFProtection)
 
-        task_reminder = TaskReminder()
-
-        if task_reminder.get_reminder(self.context):
+        if self.context.get_reminder():
             self.request.response.setStatus(409)
             return super(TaskReminderPost, self).reply()
 
-        task_reminder.set_reminder(self.context, reminder)
+        self.context.set_reminder(reminder)
         self.context.sync()
 
         self.request.response.setStatus(204)
@@ -88,13 +85,11 @@ class TaskReminderPatch(Service):
         alsoProvides(self.request, IDisableCSRFProtection)
 
         if reminder_option:
-            task_reminder = TaskReminder()
-
-            if not task_reminder.get_reminder(self.context):
+            if not self.context.get_reminder():
                 self.request.response.setStatus(404)
                 return super(TaskReminderPatch, self).reply()
 
-            task_reminder.set_reminder(self.context, reminder)
+            self.context.set_reminder(reminder)
             self.context.sync()
 
         self.request.response.setStatus(204)
@@ -108,16 +103,14 @@ class TaskReminderDelete(Service):
     """
 
     def reply(self):
-        task_reminder = TaskReminder()
-
-        if not task_reminder.get_reminder(self.context):
+        if not self.context.get_reminder():
             self.request.response.setStatus(404)
             return super(TaskReminderDelete, self).reply()
 
         # Disable CSRF protection
         alsoProvides(self.request, IDisableCSRFProtection)
 
-        task_reminder.clear_reminder(self.context)
+        self.context.clear_reminder()
         self.context.sync()
 
         self.request.response.setStatus(204)

--- a/opengever/api/reminder.py
+++ b/opengever/api/reminder.py
@@ -2,6 +2,7 @@ from opengever.task.reminder import Reminder
 from opengever.task.reminder import REMINDER_TYPE_REGISTRY
 from plone.protect.interfaces import IDisableCSRFProtection
 from plone.restapi.deserializer import json_body
+from plone.restapi.services import _no_content_marker
 from plone.restapi.services import Service
 from zExceptions import BadRequest
 from zExceptions import NotFound
@@ -70,13 +71,13 @@ class TaskReminderPost(Service):
 
         if self.context.get_reminder():
             self.request.response.setStatus(409)
-            return super(TaskReminderPost, self).reply()
+            return _no_content_marker
 
         self.context.set_reminder(reminder)
         self.context.sync()
 
         self.request.response.setStatus(204)
-        return super(TaskReminderPost, self).reply()
+        return _no_content_marker
 
 
 class TaskReminderPatch(Service):
@@ -107,8 +108,7 @@ class TaskReminderPatch(Service):
         if option_type or params:
             existing_reminder = self.context.get_reminder()
             if not existing_reminder:
-                self.request.response.setStatus(404)
-                return super(TaskReminderPatch, self).reply()
+                raise NotFound
 
             # Pick existing settings if not given (PATCH semantics)
             option_type = option_type or existing_reminder.option_type
@@ -124,7 +124,7 @@ class TaskReminderPatch(Service):
             self.context.sync()
 
         self.request.response.setStatus(204)
-        return super(TaskReminderPatch, self).reply()
+        return _no_content_marker
 
 
 class TaskReminderDelete(Service):
@@ -135,8 +135,7 @@ class TaskReminderDelete(Service):
 
     def reply(self):
         if not self.context.get_reminder():
-            self.request.response.setStatus(404)
-            return super(TaskReminderDelete, self).reply()
+            raise NotFound
 
         # Disable CSRF protection
         alsoProvides(self.request, IDisableCSRFProtection)
@@ -145,4 +144,4 @@ class TaskReminderDelete(Service):
         self.context.sync()
 
         self.request.response.setStatus(204)
-        return super(TaskReminderDelete, self).reply()
+        return _no_content_marker

--- a/opengever/api/tests/test_reminder.py
+++ b/opengever/api/tests/test_reminder.py
@@ -1,7 +1,7 @@
 from ftw.testbrowser import browsing
 from opengever.api.reminder import error_msgs
-from opengever.task.reminder import TASK_REMINDER_ONE_DAY_BEFORE
-from opengever.task.reminder import TASK_REMINDER_ONE_WEEK_BEFORE
+from opengever.task.reminder import ReminderOneDayBefore
+from opengever.task.reminder import ReminderOneWeekBefore
 from opengever.task.reminder.reminder import TaskReminder
 from opengever.testing import IntegrationTestCase
 import json
@@ -20,7 +20,7 @@ class TestTaskReminderAPI(IntegrationTestCase):
     @browsing
     def test_post_adds_task_reminder(self, browser):
         self.login(self.regular_user, browser)
-        payload = {'option_type': TASK_REMINDER_ONE_DAY_BEFORE.option_type}
+        payload = {'option_type': ReminderOneDayBefore.option_type}
 
         self.assertIsNone(
             self.task_reminder.get_reminder(self.task))
@@ -34,8 +34,8 @@ class TestTaskReminderAPI(IntegrationTestCase):
 
         self.assertEqual(204, browser.status_code)
         self.assertEqual(
-            TASK_REMINDER_ONE_DAY_BEFORE.option_type,
-            self.task_reminder.get_reminder(self.task).option_type)
+            ReminderOneDayBefore(),
+            self.task_reminder.get_reminder(self.task))
 
     @browsing
     def test_post_raises_when_option_type_is_missing(self, browser):
@@ -58,9 +58,9 @@ class TestTaskReminderAPI(IntegrationTestCase):
     @browsing
     def test_post_raises_409_when_adding_already_set_reminder(self, browser):
         self.login(self.regular_user, browser)
-        self.task_reminder.set_reminder(self.task, TASK_REMINDER_ONE_DAY_BEFORE)
+        self.task_reminder.set_reminder(self.task, ReminderOneDayBefore())
 
-        payload = {'option_type': TASK_REMINDER_ONE_WEEK_BEFORE.option_type}
+        payload = {'option_type': ReminderOneDayBefore.option_type}
 
         with browser.expect_http_error(409):
             browser.open(
@@ -71,8 +71,8 @@ class TestTaskReminderAPI(IntegrationTestCase):
             )
 
         self.assertEqual(
-            TASK_REMINDER_ONE_DAY_BEFORE.option_type,
-            self.task_reminder.get_reminder(self.task).option_type)
+            ReminderOneDayBefore(),
+            self.task_reminder.get_reminder(self.task))
 
     @browsing
     def test_post_shows_possible_reminder_options_if_option_does_not_exists(self, browser):
@@ -95,9 +95,9 @@ class TestTaskReminderAPI(IntegrationTestCase):
     @browsing
     def test_patch_updates_set_reminder(self, browser):
         self.login(self.regular_user, browser)
-        self.task_reminder.set_reminder(self.task, TASK_REMINDER_ONE_DAY_BEFORE)
+        self.task_reminder.set_reminder(self.task, ReminderOneDayBefore())
 
-        payload = {'option_type': TASK_REMINDER_ONE_WEEK_BEFORE.option_type}
+        payload = {'option_type': ReminderOneWeekBefore.option_type}
 
         browser.open(
             self.task.absolute_url() + '/@reminder',
@@ -108,14 +108,14 @@ class TestTaskReminderAPI(IntegrationTestCase):
 
         self.assertEqual(204, browser.status_code)
         self.assertEqual(
-            TASK_REMINDER_ONE_WEEK_BEFORE.option_type,
-            self.task_reminder.get_reminder(self.task).option_type)
+            ReminderOneWeekBefore(),
+            self.task_reminder.get_reminder(self.task))
 
     @browsing
     def test_patch_raises_404_when_updating_not_yet_set_reminder(self, browser):
         self.login(self.regular_user, browser)
 
-        payload = {'option_type': TASK_REMINDER_ONE_WEEK_BEFORE.option_type}
+        payload = {'option_type': ReminderOneWeekBefore.option_type}
 
         with browser.expect_http_error(404):
             browser.open(
@@ -131,11 +131,11 @@ class TestTaskReminderAPI(IntegrationTestCase):
     @browsing
     def test_delete_removes_task_reminder(self, browser):
         self.login(self.regular_user, browser)
-        self.task_reminder.set_reminder(self.task, TASK_REMINDER_ONE_DAY_BEFORE)
+        self.task_reminder.set_reminder(self.task, ReminderOneDayBefore())
 
         self.assertEqual(
-            TASK_REMINDER_ONE_DAY_BEFORE.option_type,
-            self.task_reminder.get_reminder(self.task).option_type)
+            ReminderOneDayBefore(),
+            self.task_reminder.get_reminder(self.task))
 
         browser.open(
             self.task.absolute_url() + '/@reminder',

--- a/opengever/api/tests/test_reminder.py
+++ b/opengever/api/tests/test_reminder.py
@@ -2,7 +2,6 @@ from ftw.testbrowser import browsing
 from opengever.api.reminder import error_msgs
 from opengever.task.reminder import ReminderOneDayBefore
 from opengever.task.reminder import ReminderOneWeekBefore
-from opengever.task.reminder.reminder import TaskReminder
 from opengever.testing import IntegrationTestCase
 import json
 
@@ -11,7 +10,6 @@ class TestTaskReminderAPI(IntegrationTestCase):
 
     def setUp(self):
         super(TestTaskReminderAPI, self).setUp()
-        self.task_reminder = TaskReminder()
         self.http_headers = {
             'Accept': 'application/json',
             'Content-Type': 'application/json'
@@ -23,7 +21,7 @@ class TestTaskReminderAPI(IntegrationTestCase):
         payload = {'option_type': ReminderOneDayBefore.option_type}
 
         self.assertIsNone(
-            self.task_reminder.get_reminder(self.task))
+            self.task.get_reminder())
 
         browser.open(
             self.task.absolute_url() + '/@reminder',
@@ -35,7 +33,7 @@ class TestTaskReminderAPI(IntegrationTestCase):
         self.assertEqual(204, browser.status_code)
         self.assertEqual(
             ReminderOneDayBefore(),
-            self.task_reminder.get_reminder(self.task))
+            self.task.get_reminder())
 
     @browsing
     def test_post_raises_when_option_type_is_missing(self, browser):
@@ -58,7 +56,7 @@ class TestTaskReminderAPI(IntegrationTestCase):
     @browsing
     def test_post_raises_409_when_adding_already_set_reminder(self, browser):
         self.login(self.regular_user, browser)
-        self.task_reminder.set_reminder(self.task, ReminderOneDayBefore())
+        self.task.set_reminder(ReminderOneDayBefore())
 
         payload = {'option_type': ReminderOneDayBefore.option_type}
 
@@ -72,7 +70,7 @@ class TestTaskReminderAPI(IntegrationTestCase):
 
         self.assertEqual(
             ReminderOneDayBefore(),
-            self.task_reminder.get_reminder(self.task))
+            self.task.get_reminder())
 
     @browsing
     def test_post_shows_possible_reminder_options_if_option_does_not_exists(self, browser):
@@ -95,7 +93,7 @@ class TestTaskReminderAPI(IntegrationTestCase):
     @browsing
     def test_patch_updates_set_reminder(self, browser):
         self.login(self.regular_user, browser)
-        self.task_reminder.set_reminder(self.task, ReminderOneDayBefore())
+        self.task.set_reminder(ReminderOneDayBefore())
 
         payload = {'option_type': ReminderOneWeekBefore.option_type}
 
@@ -109,7 +107,7 @@ class TestTaskReminderAPI(IntegrationTestCase):
         self.assertEqual(204, browser.status_code)
         self.assertEqual(
             ReminderOneWeekBefore(),
-            self.task_reminder.get_reminder(self.task))
+            self.task.get_reminder())
 
     @browsing
     def test_patch_raises_404_when_updating_not_yet_set_reminder(self, browser):
@@ -126,16 +124,16 @@ class TestTaskReminderAPI(IntegrationTestCase):
             )
 
         self.assertIsNone(
-            self.task_reminder.get_reminder(self.task))
+            self.task.get_reminder())
 
     @browsing
     def test_delete_removes_task_reminder(self, browser):
         self.login(self.regular_user, browser)
-        self.task_reminder.set_reminder(self.task, ReminderOneDayBefore())
+        self.task.set_reminder(ReminderOneDayBefore())
 
         self.assertEqual(
             ReminderOneDayBefore(),
-            self.task_reminder.get_reminder(self.task))
+            self.task.get_reminder())
 
         browser.open(
             self.task.absolute_url() + '/@reminder',
@@ -145,14 +143,14 @@ class TestTaskReminderAPI(IntegrationTestCase):
 
         self.assertEqual(204, browser.status_code)
         self.assertIsNone(
-            self.task_reminder.get_reminder(self.task))
+            self.task.get_reminder())
 
     @browsing
     def test_delete_raises_404_if_removing_non_existing_task_reminder(self, browser):
         self.login(self.regular_user, browser)
 
         self.assertIsNone(
-            self.task_reminder.get_reminder(self.task))
+            self.task.get_reminder())
 
         with browser.expect_http_error(404):
             browser.open(
@@ -162,4 +160,4 @@ class TestTaskReminderAPI(IntegrationTestCase):
             )
 
         self.assertIsNone(
-            self.task_reminder.get_reminder(self.task))
+            self.task.get_reminder())

--- a/opengever/api/tests/test_reminder.py
+++ b/opengever/api/tests/test_reminder.py
@@ -1,5 +1,7 @@
+from datetime import date
 from ftw.testbrowser import browsing
 from opengever.api.reminder import error_msgs
+from opengever.task.reminder import ReminderOnDate
 from opengever.task.reminder import ReminderOneDayBefore
 from opengever.task.reminder import ReminderOneWeekBefore
 from opengever.testing import IntegrationTestCase
@@ -33,6 +35,27 @@ class TestTaskReminderAPI(IntegrationTestCase):
         self.assertEqual(204, browser.status_code)
         self.assertEqual(
             ReminderOneDayBefore(),
+            self.task.get_reminder())
+
+    @browsing
+    def test_post_supports_reminder_params(self, browser):
+        self.login(self.regular_user, browser)
+        payload = {'option_type': ReminderOnDate.option_type,
+                   'params': {'date': '2018-12-30'}}
+
+        self.assertIsNone(
+            self.task.get_reminder())
+
+        browser.open(
+            self.task.absolute_url() + '/@reminder',
+            data=json.dumps(payload),
+            method='POST',
+            headers=self.http_headers,
+        )
+
+        self.assertEqual(204, browser.status_code)
+        self.assertEqual(
+            ReminderOnDate({'date': date(2018, 12, 30)}),
             self.task.get_reminder())
 
     @browsing
@@ -107,6 +130,25 @@ class TestTaskReminderAPI(IntegrationTestCase):
         self.assertEqual(204, browser.status_code)
         self.assertEqual(
             ReminderOneWeekBefore(),
+            self.task.get_reminder())
+
+    @browsing
+    def test_patch_supports_reminder_params(self, browser):
+        self.login(self.regular_user, browser)
+        self.task.set_reminder(ReminderOnDate({'date': date(1995, 6, 29)}))
+
+        payload = {'params': {'date': '2018-12-30'}}
+
+        browser.open(
+            self.task.absolute_url() + '/@reminder',
+            data=json.dumps(payload),
+            method='PATCH',
+            headers=self.http_headers,
+        )
+
+        self.assertEqual(204, browser.status_code)
+        self.assertEqual(
+            ReminderOnDate({'date': date(2018, 12, 30)}),
             self.task.get_reminder())
 
     @browsing

--- a/opengever/api/tests/test_reminder.py
+++ b/opengever/api/tests/test_reminder.py
@@ -18,6 +18,24 @@ class TestTaskReminderAPI(IntegrationTestCase):
         }
 
     @browsing
+    def test_get_returns_task_reminder(self, browser):
+        self.login(self.regular_user, browser)
+
+        self.task.set_reminder(ReminderOnDate({'date': date(1995, 6, 29)}))
+
+        browser.open(
+            self.task.absolute_url() + '/@reminder',
+            method='GET',
+            headers=self.http_headers,
+        )
+
+        self.assertEqual(
+            {u'@id': u'%s/@reminder' % self.task.absolute_url(),
+             u'option_type': u'on_date',
+             u'params': {u'date': u'1995-06-29'}},
+            browser.json)
+
+    @browsing
     def test_post_adds_task_reminder(self, browser):
         self.login(self.regular_user, browser)
         payload = {'option_type': ReminderOneDayBefore.option_type}

--- a/opengever/base/tests/test_transport.py
+++ b/opengever/base/tests/test_transport.py
@@ -1,8 +1,11 @@
 from datetime import datetime
 from opengever.base.behaviors.classification import IClassification
+from opengever.base.interfaces import IDataCollector
 from opengever.base.transport import Transporter
 from opengever.testing import IntegrationTestCase
 from zExceptions import Unauthorized
+from zope.component import getAdapters
+import json
 
 
 class TestTransporter(IntegrationTestCase):
@@ -13,6 +16,21 @@ class TestTransporter(IntegrationTestCase):
     def setUp(self):
         super(TestTransporter, self).setUp()
         self.request = self.portal.REQUEST
+
+    def test_all_data_collectors_extract_json_compatible_data(self):
+        self.login(self.regular_user)
+
+        objects_to_test = [self.task]
+        for obj in objects_to_test:
+            adapters = getAdapters((self.task,), IDataCollector)
+            for name, adapter in adapters:
+                data = adapter.extract()
+                try:
+                    json.dumps(data)
+                except TypeError:
+                    self.fail("Extracted data from IDataCollector adapter "
+                              "%r (%r) is not JSON serializable: "
+                              "%r" % (name, adapter, data))
 
     def test_transport_from_copies_the_object_inclusive_metadata_and_dublin_core_data(self):
         self.login(self.regular_user)

--- a/opengever/base/tests/test_transport.py
+++ b/opengever/base/tests/test_transport.py
@@ -1,7 +1,9 @@
+from datetime import date
 from datetime import datetime
 from opengever.base.behaviors.classification import IClassification
 from opengever.base.interfaces import IDataCollector
 from opengever.base.transport import Transporter
+from opengever.task.reminder import ReminderOnDate
 from opengever.testing import IntegrationTestCase
 from zExceptions import Unauthorized
 from zope.component import getAdapters
@@ -20,7 +22,9 @@ class TestTransporter(IntegrationTestCase):
     def test_all_data_collectors_extract_json_compatible_data(self):
         self.login(self.regular_user)
 
+        self.task.set_reminder(ReminderOnDate({'date': date(2019, 12, 30)}))
         objects_to_test = [self.task]
+
         for obj in objects_to_test:
             adapters = getAdapters((self.task,), IDataCollector)
             for name, adapter in adapters:

--- a/opengever/base/transport.py
+++ b/opengever/base/transport.py
@@ -361,7 +361,7 @@ class ResponsibleTaskRemindersDataCollector(object):
 
     def extract(self):
         reminders = self.context.get_reminders_of_potential_responsibles()
-        return {user_id: reminder.serialize()
+        return {user_id: reminder.serialize(json_compat=True)
                 for user_id, reminder in reminders.items()}
 
     def insert(self, data):

--- a/opengever/base/transport.py
+++ b/opengever/base/transport.py
@@ -5,7 +5,6 @@ from opengever.base.security import elevated_privileges
 from opengever.ogds.base.utils import decode_for_json
 from opengever.ogds.base.utils import encode_after_json
 from opengever.task.reminder import Reminder
-from opengever.task.reminder.reminder import TaskReminder
 from opengever.task.task import ITask
 from plone.dexterity.interfaces import IDexterityContent
 from plone.dexterity.utils import addContentToContainer
@@ -361,11 +360,11 @@ class ResponsibleTaskRemindersDataCollector(object):
         self.context = context
 
     def extract(self):
-        reminders = TaskReminder().get_reminders_of_potential_responsibles(self.context)
+        reminders = self.context.get_reminders_of_potential_responsibles()
         return {user_id: reminder.serialize()
                 for user_id, reminder in reminders.items()}
 
     def insert(self, data):
         for user_id, reminder_data in data.items():
             reminder = Reminder.deserialize(reminder_data)
-            TaskReminder().set_reminder(self.context, reminder, user_id=user_id)
+            self.context.set_reminder(reminder, user_id=user_id)

--- a/opengever/base/transport.py
+++ b/opengever/base/transport.py
@@ -4,7 +4,7 @@ from opengever.base.request import dispatch_json_request
 from opengever.base.security import elevated_privileges
 from opengever.ogds.base.utils import decode_for_json
 from opengever.ogds.base.utils import encode_after_json
-from opengever.task.reminder import TASK_REMINDER_OPTIONS
+from opengever.task.reminder import Reminder
 from opengever.task.reminder.reminder import TaskReminder
 from opengever.task.task import ITask
 from plone.dexterity.interfaces import IDexterityContent
@@ -361,9 +361,11 @@ class ResponsibleTaskRemindersDataCollector(object):
         self.context = context
 
     def extract(self):
-        return TaskReminder().get_reminders_of_potential_responsibles(self.context)
+        reminders = TaskReminder().get_reminders_of_potential_responsibles(self.context)
+        return {user_id: reminder.serialize()
+                for user_id, reminder in reminders.items()}
 
     def insert(self, data):
-        for userid, option_tpye in data.items():
-            option = TASK_REMINDER_OPTIONS[option_tpye]
-            TaskReminder().set_reminder(self.context, option, user_id=userid)
+        for user_id, reminder_data in data.items():
+            reminder = Reminder.deserialize(reminder_data)
+            TaskReminder().set_reminder(self.context, reminder, user_id=user_id)

--- a/opengever/base/utils.py
+++ b/opengever/base/utils.py
@@ -1,3 +1,5 @@
+from persistent.dict import PersistentDict
+from persistent.list import PersistentList
 from plone import api
 from Products.CMFCore.utils import getToolByName
 from xml.sax.saxutils import escape
@@ -152,3 +154,23 @@ def file_checksum(filename, chunksize=65536, algorithm=u'MD5'):
             h.update(chunk)
             chunk = f.read(chunksize)
         return algorithm, h.hexdigest()
+
+
+def make_persistent(data):
+    """Recursively turn a nested data structure of lists and dicts
+    into one using PersistentDics and PersistentLists.
+    """
+    if isinstance(data, dict):
+        new = PersistentDict()
+        for key, value in data.items():
+            new[make_persistent(key)] = make_persistent(value)
+        return new
+
+    elif isinstance(data, list):
+        new = PersistentList()
+        for value in data:
+            new.append(make_persistent(value))
+        return new
+
+    else:
+        return data

--- a/opengever/core/tests/test_relations.py
+++ b/opengever/core/tests/test_relations.py
@@ -91,6 +91,7 @@ EXPECTED_INTERFACES = [
     'opengever.repository.interfaces.IRepositoryFolder',
     'opengever.repository.repositoryfolder.IRepositoryFolderSchema',
     'opengever.sharing.behaviors.IDossier',
+    'opengever.task.reminder.interfaces.IReminderSupport',
     'opengever.task.task.ITask',
     'opengever.trash.trash.ITrashableMarker',
     'persistent.interfaces.IPersistent',

--- a/opengever/core/upgrades/20191006123328_migrate_task_reminders_to_new_storage_format/upgrade.py
+++ b/opengever/core/upgrades/20191006123328_migrate_task_reminders_to_new_storage_format/upgrade.py
@@ -14,7 +14,7 @@ class MigrateTaskRemindersToNewStorageFormat(UpgradeStep):
     {'john.doe': 'same_day'}
 
     New format:
-    {'john.doe': {'option_type': 'same_day'}}
+    {'john.doe': {'option_type': 'same_day', 'params': {}}}
     """
 
     def __call__(self):
@@ -24,9 +24,13 @@ class MigrateTaskRemindersToNewStorageFormat(UpgradeStep):
 
     def migrate_reminder_annotations(self, task):
         ann = IAnnotations(task)
+
         if TASK_REMINDER_ANNOTATIONS_KEY in ann:
             reminder_annotations = ann[TASK_REMINDER_ANNOTATIONS_KEY]
+
             for user_id, option_type in reminder_annotations.items():
                 if isinstance(option_type, basestring):
-                    new_entry = PersistentDict({'option_type': option_type})
+                    new_entry = PersistentDict(
+                        {'option_type': option_type,
+                         'params': PersistentDict()})
                     reminder_annotations[user_id] = new_entry

--- a/opengever/core/upgrades/20191006123328_migrate_task_reminders_to_new_storage_format/upgrade.py
+++ b/opengever/core/upgrades/20191006123328_migrate_task_reminders_to_new_storage_format/upgrade.py
@@ -1,0 +1,32 @@
+from ftw.upgrade import UpgradeStep
+from opengever.task.task import ITask
+from persistent.dict import PersistentDict
+from zope.annotation import IAnnotations
+
+
+TASK_REMINDER_ANNOTATIONS_KEY = 'opengever.task.task_reminder'
+
+
+class MigrateTaskRemindersToNewStorageFormat(UpgradeStep):
+    """Migrate task reminder annotations to new storage format.
+
+    Old format:
+    {'john.doe': 'same_day'}
+
+    New format:
+    {'john.doe': {'option_type': 'same_day'}}
+    """
+
+    def __call__(self):
+        for task in self.objects({'object_provides': ITask.__identifier__},
+                                 'Migrate task reminder annotations to new storage format'):
+            self.migrate_reminder_annotations(task)
+
+    def migrate_reminder_annotations(self, task):
+        ann = IAnnotations(task)
+        if TASK_REMINDER_ANNOTATIONS_KEY in ann:
+            reminder_annotations = ann[TASK_REMINDER_ANNOTATIONS_KEY]
+            for user_id, option_type in reminder_annotations.items():
+                if isinstance(option_type, basestring):
+                    new_entry = PersistentDict({'option_type': option_type})
+                    reminder_annotations[user_id] = new_entry

--- a/opengever/globalindex/model/reminder_settings.py
+++ b/opengever/globalindex/model/reminder_settings.py
@@ -2,7 +2,6 @@ from opengever.base.date_time import utcnow_tz_aware
 from opengever.base.model import Base
 from opengever.base.model import USER_ID_LENGTH
 from opengever.base.model import UTCDateTime
-from opengever.task.reminder import TASK_REMINDER_OPTIONS
 from sqlalchemy import Column
 from sqlalchemy import Date
 from sqlalchemy import ForeignKey
@@ -35,7 +34,3 @@ class ReminderSetting(Base):
             self.actor_id,
             repr(self.task),
             self.remind_day)
-
-    def update_remind_day(self):
-        option = TASK_REMINDER_OPTIONS[self.option_type]
-        self.remind_day = option.calculate_remind_on(self.task.deadline)

--- a/opengever/globalindex/model/task.py
+++ b/opengever/globalindex/model/task.py
@@ -240,7 +240,7 @@ class Task(Base):
             if sql_setting.actor_id in reminders:
                 setting = reminders[sql_setting.actor_id]
                 sql_setting.option_type = setting.option_type
-                sql_setting.remind_day = setting.calculate_remind_on(
+                sql_setting.remind_day = setting.calculate_trigger_date(
                     plone_task.deadline)
                 reminders.pop(sql_setting.actor_id)
 
@@ -252,7 +252,7 @@ class Task(Base):
         for actor_id, reminder in reminders.items():
             setting = ReminderSetting(
                 task=self, actor_id=actor_id, option_type=reminder.option_type,
-                remind_day=reminder.calculate_remind_on(plone_task.deadline))
+                remind_day=reminder.calculate_trigger_date(plone_task.deadline))
             self.session.add(setting)
 
     # XXX move me to task query

--- a/opengever/globalindex/model/task.py
+++ b/opengever/globalindex/model/task.py
@@ -16,7 +16,6 @@ from opengever.globalindex.model.reminder_settings import ReminderSetting
 from opengever.ogds.base.actor import Actor
 from opengever.ogds.base.utils import get_current_admin_unit
 from opengever.ogds.base.utils import ogds_service
-from opengever.task.reminder.reminder import TaskReminder
 from plone import api
 from Products.CMFPlone.utils import safe_unicode
 from sqlalchemy import and_
@@ -232,7 +231,7 @@ class Task(Base):
         self.sync_reminders(plone_task)
 
     def sync_reminders(self, plone_task):
-        reminders = TaskReminder().get_reminders(plone_task)
+        reminders = plone_task.get_reminders()
 
         for sql_setting in self.reminder_settings:
 

--- a/opengever/globalindex/tests/test_reminder_setttings.py
+++ b/opengever/globalindex/tests/test_reminder_setttings.py
@@ -2,7 +2,7 @@ from datetime import date
 from ftw.builder import Builder
 from ftw.builder import create
 from opengever.globalindex.model.reminder_settings import ReminderSetting
-from opengever.task.reminder import TASK_REMINDER_ONE_WEEK_BEFORE
+from opengever.task.reminder import ReminderOneWeekBefore
 from opengever.task.reminder.reminder import TaskReminder
 from opengever.testing import IntegrationTestCase
 
@@ -25,21 +25,21 @@ class TestReminderSettings(IntegrationTestCase):
     def test_gets_added_when_syncing_a_task(self):
         self.login(self.dossier_responsible)
         reminder = TaskReminder()
-        reminder.set_reminder(self.task, TASK_REMINDER_ONE_WEEK_BEFORE)
+        reminder.set_reminder(self.task, ReminderOneWeekBefore())
         self.task.sync()
 
         self.assertEquals(1, ReminderSetting.query.count())
         setting = ReminderSetting.query.first()
         self.assertEquals(self.dossier_responsible.id, setting.actor_id)
         self.assertEquals(
-            TASK_REMINDER_ONE_WEEK_BEFORE.option_type, setting.option_type)
+            ReminderOneWeekBefore.option_type, setting.option_type)
         self.assertEquals(date(2016, 10, 25), setting.remind_day)
 
     def test_gets_updated_when_syncing_a_task(self):
         self.login(self.dossier_responsible)
 
         reminder = TaskReminder()
-        reminder.set_reminder(self.task, TASK_REMINDER_ONE_WEEK_BEFORE)
+        reminder.set_reminder(self.task, ReminderOneWeekBefore())
         self.task.sync()
 
         ReminderSetting.query.all()
@@ -54,7 +54,7 @@ class TestReminderSettings(IntegrationTestCase):
     def test_gets_removed_when_syncing_a_task(self):
         self.login(self.dossier_responsible)
         reminder = TaskReminder()
-        reminder.set_reminder(self.task, TASK_REMINDER_ONE_WEEK_BEFORE)
+        reminder.set_reminder(self.task, ReminderOneWeekBefore())
         self.task.sync()
 
         self.assertEquals(1, ReminderSetting.query.count())

--- a/opengever/globalindex/tests/test_reminder_setttings.py
+++ b/opengever/globalindex/tests/test_reminder_setttings.py
@@ -3,7 +3,6 @@ from ftw.builder import Builder
 from ftw.builder import create
 from opengever.globalindex.model.reminder_settings import ReminderSetting
 from opengever.task.reminder import ReminderOneWeekBefore
-from opengever.task.reminder.reminder import TaskReminder
 from opengever.testing import IntegrationTestCase
 
 
@@ -24,8 +23,7 @@ class TestReminderSettings(IntegrationTestCase):
 
     def test_gets_added_when_syncing_a_task(self):
         self.login(self.dossier_responsible)
-        reminder = TaskReminder()
-        reminder.set_reminder(self.task, ReminderOneWeekBefore())
+        self.task.set_reminder(ReminderOneWeekBefore())
         self.task.sync()
 
         self.assertEquals(1, ReminderSetting.query.count())
@@ -38,8 +36,7 @@ class TestReminderSettings(IntegrationTestCase):
     def test_gets_updated_when_syncing_a_task(self):
         self.login(self.dossier_responsible)
 
-        reminder = TaskReminder()
-        reminder.set_reminder(self.task, ReminderOneWeekBefore())
+        self.task.set_reminder(ReminderOneWeekBefore())
         self.task.sync()
 
         ReminderSetting.query.all()
@@ -53,13 +50,12 @@ class TestReminderSettings(IntegrationTestCase):
 
     def test_gets_removed_when_syncing_a_task(self):
         self.login(self.dossier_responsible)
-        reminder = TaskReminder()
-        reminder.set_reminder(self.task, ReminderOneWeekBefore())
+        self.task.set_reminder(ReminderOneWeekBefore())
         self.task.sync()
 
         self.assertEquals(1, ReminderSetting.query.count())
 
-        reminder.clear_reminder(self.task, user_id=self.dossier_responsible.id)
+        self.task.clear_reminder(user_id=self.dossier_responsible.id)
         self.task.sync()
 
         self.assertEquals(0, ReminderSetting.query.count())

--- a/opengever/task/browser/accept/utils.py
+++ b/opengever/task/browser/accept/utils.py
@@ -14,7 +14,6 @@ from opengever.base.response import IResponseContainer
 from opengever.task.exceptions import TaskRemoteRequestError
 from opengever.task.interfaces import ISuccessorTaskController
 from opengever.task.interfaces import ITaskDocumentsTransporter
-from opengever.task.reminder.reminder import TaskReminder
 from opengever.task.task import ITask
 from opengever.task.transporter import IResponseTransporter
 from opengever.task.util import change_task_workflow_state
@@ -263,9 +262,9 @@ class AcceptTaskWorkflowTransitionView(BrowserView):
         center.remove_task_responsible(self.context, self.context.responsible)
 
         # Remove task reminders of potential responsibles
-        reminders = TaskReminder().get_reminders_of_potential_responsibles(self.context)
+        reminders = self.context.get_reminders_of_potential_responsibles()
         for userid in reminders.keys():
-            TaskReminder().clear_reminder(self.context, user_id=userid)
+            self.context.clear_reminder(user_id=userid)
 
         accept_task_with_response(self.context, text,
                                   successor_oguid=successor_oguid)

--- a/opengever/task/browser/overview.py
+++ b/opengever/task/browser/overview.py
@@ -7,6 +7,7 @@ from opengever.tabbedview import GeverTabMixin
 from opengever.task import _
 from opengever.task.activities import TaskReminderActivity
 from opengever.task.reminder import REMINDER_TYPE_REGISTRY
+from opengever.task.reminder.model import REMINDER_TYPES_BLACKLISTED_FROM_UI
 from opengever.task.task import ITask
 from opengever.tasktemplates.interfaces import IFromParallelTasktemplate
 from opengever.tasktemplates.interfaces import IFromSequentialTasktemplate
@@ -231,6 +232,13 @@ class Overview(BrowserView, GeverTabMixin):
             })
 
         for option in REMINDER_TYPE_REGISTRY.values():
+            # XXX: Once the sort_order has been eliminated, this place should
+            # be able to use the vocabulary as well, instead of directly
+            # accessing REMINDER_TYPE_REGISTRY
+
+            if option in REMINDER_TYPES_BLACKLISTED_FROM_UI:
+                continue
+
             selected = option.option_type == reminder_option.option_type if \
                 reminder_option else None
             options.append({

--- a/opengever/task/browser/overview.py
+++ b/opengever/task/browser/overview.py
@@ -7,7 +7,6 @@ from opengever.tabbedview import GeverTabMixin
 from opengever.task import _
 from opengever.task.activities import TaskReminderActivity
 from opengever.task.reminder import REMINDER_TYPE_REGISTRY
-from opengever.task.reminder.reminder import TaskReminder
 from opengever.task.task import ITask
 from opengever.tasktemplates.interfaces import IFromParallelTasktemplate
 from opengever.tasktemplates.interfaces import IFromSequentialTasktemplate
@@ -220,7 +219,7 @@ class Overview(BrowserView, GeverTabMixin):
 
     def reminder_options(self):
         options = []
-        reminder_option = TaskReminder().get_reminder(self.context)
+        reminder_option = self.context.get_reminder()
 
         options.append({
             'option_type': 'no-reminder',

--- a/opengever/task/browser/overview.py
+++ b/opengever/task/browser/overview.py
@@ -6,7 +6,7 @@ from opengever.globalindex.model.task import Task
 from opengever.tabbedview import GeverTabMixin
 from opengever.task import _
 from opengever.task.activities import TaskReminderActivity
-from opengever.task.reminder import TASK_REMINDER_OPTIONS
+from opengever.task.reminder import REMINDER_TYPE_REGISTRY
 from opengever.task.reminder.reminder import TaskReminder
 from opengever.task.task import ITask
 from opengever.tasktemplates.interfaces import IFromParallelTasktemplate
@@ -231,7 +231,7 @@ class Overview(BrowserView, GeverTabMixin):
             'showSpinner': False,
             })
 
-        for option in TASK_REMINDER_OPTIONS.values():
+        for option in REMINDER_TYPE_REGISTRY.values():
             selected = option.option_type == reminder_option.option_type if \
                 reminder_option else None
             options.append({

--- a/opengever/task/configure.zcml
+++ b/opengever/task/configure.zcml
@@ -12,6 +12,7 @@
 
   <include package=".browser" />
   <include package=".viewlets" />
+  <include package=".reminder" />
 
   <include file="profiles.zcml" />
   <include file="behaviors.zcml" />

--- a/opengever/task/deadline_modifier.py
+++ b/opengever/task/deadline_modifier.py
@@ -1,6 +1,5 @@
 from opengever.task.browser.transitioncontroller import get_checker
 from opengever.task.interfaces import IDeadlineModifier
-from opengever.task.reminder.reminder import TaskReminder
 from opengever.task.response_syncer import sync_task_response
 from opengever.task.task import ITask
 from opengever.task.util import add_simple_response
@@ -62,7 +61,7 @@ class DeadlineModifier(object):
 
         self.context.deadline = new_deadline
         notify(ObjectModifiedEvent(self.context))
-        TaskReminder().recalculate_remind_day_for_obj(self.context)
+        self.context.update_reminder_trigger_dates()
 
     def sync_deadline(self, new_deadline, text, transition):
         sync_task_response(self.context, self.context.REQUEST, 'deadline',

--- a/opengever/task/locales/de/LC_MESSAGES/opengever.task.po
+++ b/opengever/task/locales/de/LC_MESSAGES/opengever.task.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2019-04-29 07:17+0000\n"
+"POT-Creation-Date: 2019-10-06 22:54+0000\n"
 "PO-Revision-Date: 2015-02-17 18:41+0100\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -773,22 +773,27 @@ msgid "progress"
 msgstr "Verlauf"
 
 #. Default: "At the beginning of the week of the deadline"
-#: ./opengever/task/reminder/__init__.py
+#: ./opengever/task/reminder/model.py
 msgid "reminder_option_title_beginning_of_week"
 msgstr "Zu Beginn der Woche"
 
+#. Default: "On a specific date"
+#: ./opengever/task/reminder/model.py
+msgid "reminder_option_title_on_date"
+msgstr "An bestimmtem Tag"
+
 #. Default: "One day before deadline"
-#: ./opengever/task/reminder/__init__.py
+#: ./opengever/task/reminder/model.py
 msgid "reminder_option_title_one_day_before"
 msgstr "Am Tag vorher"
 
 #. Default: "One week before deadline"
-#: ./opengever/task/reminder/__init__.py
+#: ./opengever/task/reminder/model.py
 msgid "reminder_option_title_one_week_before"
 msgstr "Eine Woche vorher"
 
 #. Default: "At the morging of the deadline"
-#: ./opengever/task/reminder/__init__.py
+#: ./opengever/task/reminder/model.py
 msgid "reminder_option_title_today"
 msgstr "Am Morgen"
 

--- a/opengever/task/locales/fr/LC_MESSAGES/opengever.task.po
+++ b/opengever/task/locales/fr/LC_MESSAGES/opengever.task.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-04-29 07:17+0000\n"
+"POT-Creation-Date: 2019-10-06 22:54+0000\n"
 "PO-Revision-Date: 2017-12-03 11:47+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-task/fr/>\n"
@@ -775,22 +775,27 @@ msgid "progress"
 msgstr "Progrès"
 
 #. Default: "At the beginning of the week of the deadline"
-#: ./opengever/task/reminder/__init__.py
+#: ./opengever/task/reminder/model.py
 msgid "reminder_option_title_beginning_of_week"
 msgstr "Au début de la semaine"
 
+#. Default: "On a specific date"
+#: ./opengever/task/reminder/model.py
+msgid "reminder_option_title_on_date"
+msgstr ""
+
 #. Default: "One day before deadline"
-#: ./opengever/task/reminder/__init__.py
+#: ./opengever/task/reminder/model.py
 msgid "reminder_option_title_one_day_before"
 msgstr "Le jour précédent"
 
 #. Default: "One week before deadline"
-#: ./opengever/task/reminder/__init__.py
+#: ./opengever/task/reminder/model.py
 msgid "reminder_option_title_one_week_before"
 msgstr "Une semaine avant"
 
 #. Default: "At the morging of the deadline"
-#: ./opengever/task/reminder/__init__.py
+#: ./opengever/task/reminder/model.py
 msgid "reminder_option_title_today"
 msgstr "Le matin"
 

--- a/opengever/task/locales/opengever.task.pot
+++ b/opengever/task/locales/opengever.task.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2019-04-29 07:17+0000\n"
+"POT-Creation-Date: 2019-10-06 22:54+0000\n"
 "PO-Revision-Date: 2009-02-25 14:39+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -771,22 +771,27 @@ msgid "progress"
 msgstr ""
 
 #. Default: "At the beginning of the week of the deadline"
-#: ./opengever/task/reminder/__init__.py
+#: ./opengever/task/reminder/model.py
 msgid "reminder_option_title_beginning_of_week"
 msgstr ""
 
+#. Default: "On a specific date"
+#: ./opengever/task/reminder/model.py
+msgid "reminder_option_title_on_date"
+msgstr ""
+
 #. Default: "One day before deadline"
-#: ./opengever/task/reminder/__init__.py
+#: ./opengever/task/reminder/model.py
 msgid "reminder_option_title_one_day_before"
 msgstr ""
 
 #. Default: "One week before deadline"
-#: ./opengever/task/reminder/__init__.py
+#: ./opengever/task/reminder/model.py
 msgid "reminder_option_title_one_week_before"
 msgstr ""
 
 #. Default: "At the morging of the deadline"
-#: ./opengever/task/reminder/__init__.py
+#: ./opengever/task/reminder/model.py
 msgid "reminder_option_title_today"
 msgstr ""
 

--- a/opengever/task/reminder/__init__.py
+++ b/opengever/task/reminder/__init__.py
@@ -1,6 +1,7 @@
 from opengever.task.reminder.model import Reminder  # noqa
 from opengever.task.reminder.model import REMINDER_TYPE_REGISTRY  # noqa
 from opengever.task.reminder.model import ReminderBeginningOfWeek  # noqa
+from opengever.task.reminder.model import ReminderOnDate  # noqa
 from opengever.task.reminder.model import ReminderOneDayBefore  # noqa
 from opengever.task.reminder.model import ReminderOneDayBefore  # noqa
 from opengever.task.reminder.model import ReminderOneWeekBefore  # noqa

--- a/opengever/task/reminder/__init__.py
+++ b/opengever/task/reminder/__init__.py
@@ -1,82 +1,11 @@
-from datetime import date
-from datetime import timedelta
-from opengever.task import _
-from zope.schema.vocabulary import SimpleTerm
-from zope.schema.vocabulary import SimpleVocabulary
+from opengever.task.reminder.model import Reminder  # noqa
+from opengever.task.reminder.model import REMINDER_TYPE_REGISTRY  # noqa
+from opengever.task.reminder.model import ReminderBeginningOfWeek  # noqa
+from opengever.task.reminder.model import ReminderOneDayBefore  # noqa
+from opengever.task.reminder.model import ReminderOneDayBefore  # noqa
+from opengever.task.reminder.model import ReminderOneWeekBefore  # noqa
+from opengever.task.reminder.model import ReminderSameDay  # noqa
 import logging
 
 
-logger = logging.getLogger('opengever.activity.reminder')
-
-
-def day_delta(delta):
-    """Returns a function, calculating a date with the given day-delta.
-    """
-    def calc(date_):
-        return date_ - timedelta(days=delta)
-
-    return calc
-
-
-def last_monday(date_):
-    """Returns a function, getting the last monday.
-    """
-    return date_ - timedelta(days=date_.weekday())
-
-
-class ReminderOption(object):
-
-    def __init__(self, option_type, option_title, remind_day_func, sort_order):
-        self.option_type = option_type
-        self.option_title = option_title
-        self.sort_order = sort_order
-        self._remind_day_func = remind_day_func
-
-    def calculate_remind_on(self, deadline):
-        return self._remind_day_func(deadline)
-
-
-TASK_REMINDER_SAME_DAY = ReminderOption(
-    option_type='same_day',
-    option_title=_(u'reminder_option_title_today',
-                   default="At the morging of the deadline"),
-    remind_day_func=day_delta(0),
-    sort_order=0)
-
-TASK_REMINDER_ONE_DAY_BEFORE = ReminderOption(
-    option_type='one_day_before',
-    option_title=_(u'reminder_option_title_one_day_before',
-                   default="One day before deadline"),
-    remind_day_func=day_delta(1),
-    sort_order=1)
-
-TASK_REMINDER_ONE_WEEK_BEFORE = ReminderOption(
-    option_type='one_week_before',
-    option_title=_(u'reminder_option_title_one_week_before',
-                   default="One week before deadline"),
-    remind_day_func=day_delta(7),
-    sort_order=3)
-
-TASK_REMINDER_BEGINNING_OF_WEEK = ReminderOption(
-    option_type='beginning_of_week',
-    option_title=_(u'reminder_option_title_beginning_of_week',
-                   default="At the beginning of the week of the deadline"),
-    remind_day_func=last_monday,
-    sort_order=2)
-
-TASK_REMINDER_OPTIONS = {
-    TASK_REMINDER_SAME_DAY.option_type: TASK_REMINDER_SAME_DAY,
-    TASK_REMINDER_ONE_DAY_BEFORE.option_type: TASK_REMINDER_ONE_DAY_BEFORE,
-    TASK_REMINDER_ONE_WEEK_BEFORE.option_type: TASK_REMINDER_ONE_WEEK_BEFORE,
-    TASK_REMINDER_BEGINNING_OF_WEEK.option_type: TASK_REMINDER_BEGINNING_OF_WEEK,
-}
-
-
-def get_task_reminder_options_vocabulary():
-    terms = []
-    options = TASK_REMINDER_OPTIONS.values()
-    for option in sorted(options, key=lambda x: x.sort_order):
-        terms.append(SimpleTerm(
-            option.option_type, title=option.option_title))
-
-    return SimpleVocabulary(terms)
+logger = logging.getLogger('opengever.task.reminder')

--- a/opengever/task/reminder/configure.zcml
+++ b/opengever/task/reminder/configure.zcml
@@ -1,0 +1,8 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:i18n="http://namespaces.zope.org/i18n"
+    i18n_domain="opengever.task">
+
+  <adapter factory=".storage.ReminderAnnotationStorage" />
+
+</configure>

--- a/opengever/task/reminder/interfaces.py
+++ b/opengever/task/reminder/interfaces.py
@@ -1,0 +1,39 @@
+from zope.interface import Interface
+
+
+class IReminderStorage(Interface):
+    """Storage abstraction for reminders.
+    """
+
+    def __init__(context):
+        """Adapts the context for reminders to be stored on.
+        """
+
+    def set(option_type, user_id=None):
+        """Set a reminder on the adapted object.
+
+        option_type -- The kind of reminder to set
+        user_id -- User to set the reminder for
+
+        If no user_id is given, defaults to the currently logged in user.
+        """
+
+    def get(user_id=None):
+        """Return reminder for adapted object, or None if no reminder exists.
+
+        user_id -- User to get the reminder for
+
+        If no user_id is given, defaults to the currently logged in user.
+        """
+
+    def list():
+        """Return user_id -> reminder mapping of all reminders for adapted obj.
+        """
+
+    def clear(user_id=None):
+        """Clear an existing reminder.
+
+        user_id -- User to clear the reminder for
+
+        If no user_id is given, defaults to the currently logged in user.
+        """

--- a/opengever/task/reminder/interfaces.py
+++ b/opengever/task/reminder/interfaces.py
@@ -37,3 +37,32 @@ class IReminderStorage(Interface):
 
         If no user_id is given, defaults to the currently logged in user.
         """
+
+
+class IReminderSupport(Interface):
+    """Implements support for reminders for a particular content type.
+    """
+
+    def set_reminder(reminder, user_id=None):
+        """Sets a reminder for the given object for a specific user or for the
+        current logged in user.
+
+        A previously set reminder for the given user for the given object will
+        be overridden by the new reminder.
+        """
+
+    def get_reminder(user_id=None):
+        """Get the reminder for the given object for a specific user or for
+        the current logged in user.
+
+        Returns None, if no reminder is set.
+        """
+
+    def get_reminders():
+        """Get all reminders for this obj as a {userid: reminder} mapping.
+        """
+
+    def clear_reminder(user_id=None):
+        """Removes a registered reminder for the given object for a specific
+        user or for the current logged in user.
+        """

--- a/opengever/task/reminder/model.py
+++ b/opengever/task/reminder/model.py
@@ -1,0 +1,121 @@
+from datetime import timedelta
+from opengever.task import _
+from zope.schema.vocabulary import SimpleTerm
+from zope.schema.vocabulary import SimpleVocabulary
+
+
+class Reminder(object):
+    """Base class for reminders.
+
+    Will never be persisted directly. Instead, it supports serialize() and
+    deserialize() methods that handle serialization to/from a simple nested
+    dictionary.
+    """
+
+    option_type = None
+    option_title = None
+    sort_order = None
+
+    def __init__(self, params=None):
+        if params is None:
+            params = {}
+        self.params = params
+
+    @staticmethod
+    def create(option_type, params=None):
+        """Factory method to create Reminder instance based on option_type.
+        """
+        klass = REMINDER_TYPE_REGISTRY[option_type]
+        return klass(params)
+
+    def serialize(self):
+        """Turn reminder instance's state into JSON serializable data.
+        """
+        data = {}
+        data['option_type'] = self.option_type
+        data['params'] = self.params
+        return data
+
+    @classmethod
+    def deserialize(cls, reminder_data):
+        """Construct reminder instance from serialized data dict.
+        """
+        return cls.create(**reminder_data)
+
+    def calculate_trigger_date(self, deadline):
+        """Compute on which date this reminder should be triggered.
+
+        Needs to be implemented by the specific subclass.
+        """
+        raise NotImplementedError
+
+    def __eq__(self, other):
+        """Compare whether two reminder instances are equivalent.
+        """
+        return isinstance(other, self.__class__) and other.params == self.params
+
+
+class ReminderSameDay(Reminder):
+
+    option_type = 'same_day'
+    option_title = _(u'reminder_option_title_today',
+                     default="At the morging of the deadline")
+    sort_order = 0
+
+    def calculate_trigger_date(self, deadline):
+        return deadline - timedelta(days=0)
+
+
+class ReminderOneDayBefore(Reminder):
+
+    option_type = 'one_day_before'
+    option_title = _(u'reminder_option_title_one_day_before',
+                     default="One day before deadline")
+    sort_order = 1
+
+    def calculate_trigger_date(self, deadline):
+        return deadline - timedelta(days=1)
+
+
+class ReminderOneWeekBefore(Reminder):
+
+    option_type = 'one_week_before'
+    option_title = _(u'reminder_option_title_one_week_before',
+                     default="One week before deadline")
+    sort_order = 3
+
+    def calculate_trigger_date(self, deadline):
+        return deadline - timedelta(days=7)
+
+
+class ReminderBeginningOfWeek(Reminder):
+
+    option_type = 'beginning_of_week'
+    option_title = _(u'reminder_option_title_beginning_of_week',
+                     default="At the beginning of the week of the deadline")
+    sort_order = 2
+
+    def calculate_trigger_date(self, deadline):
+        return deadline - timedelta(days=deadline.weekday())
+
+
+TASK_REMINDER_TYPES = (
+    ReminderSameDay,
+    ReminderOneDayBefore,
+    ReminderOneWeekBefore,
+    ReminderBeginningOfWeek,
+)
+
+REMINDER_TYPE_REGISTRY = {
+    klass.option_type: klass for klass in TASK_REMINDER_TYPES
+}
+
+
+def get_task_reminder_options_vocabulary():
+    terms = []
+    options = REMINDER_TYPE_REGISTRY.values()
+    for option in sorted(options, key=lambda x: x.sort_order):
+        terms.append(SimpleTerm(
+            option.option_type, title=option.option_title))
+
+    return SimpleVocabulary(terms)

--- a/opengever/task/reminder/model.py
+++ b/opengever/task/reminder/model.py
@@ -188,7 +188,7 @@ class ReminderOnDate(Reminder):
         return self.params['date']
 
 
-TASK_REMINDER_TYPES = (
+REMINDER_TYPES = (
     ReminderSameDay,
     ReminderOneDayBefore,
     ReminderOneWeekBefore,
@@ -197,14 +197,21 @@ TASK_REMINDER_TYPES = (
 )
 
 REMINDER_TYPE_REGISTRY = {
-    klass.option_type: klass for klass in TASK_REMINDER_TYPES
+    klass.option_type: klass for klass in REMINDER_TYPES
 }
+
+# This type requires a special widget and would therefore break the UI
+# until that widget is implemented. Remove this blacklist to have it show up.
+REMINDER_TYPES_BLACKLISTED_FROM_UI = (ReminderOnDate, )
 
 
 def get_task_reminder_options_vocabulary():
     terms = []
     options = REMINDER_TYPE_REGISTRY.values()
     for option in sorted(options, key=lambda x: x.sort_order):
+        if option in REMINDER_TYPES_BLACKLISTED_FROM_UI:
+            continue
+
         terms.append(SimpleTerm(
             option.option_type, title=option.option_title))
 

--- a/opengever/task/reminder/reminder.py
+++ b/opengever/task/reminder/reminder.py
@@ -85,5 +85,9 @@ class TaskReminder(object):
         """If the duedate of a task will change, we have to update the
         reminde-day of all reminders set for this object.
         """
-        map(lambda reminder: reminder.update_remind_day(),
-            obj.get_sql_object().reminder_settings)
+        sql_task = obj.get_sql_object()
+
+        for reminder_setting in sql_task.reminder_settings:
+            option = TASK_REMINDER_OPTIONS[reminder_setting.option_type]
+            new_remind_day = option.calculate_remind_on(sql_task.deadline)
+            reminder_setting.remind_day = new_remind_day

--- a/opengever/task/reminder/reminder.py
+++ b/opengever/task/reminder/reminder.py
@@ -62,17 +62,6 @@ class TaskReminder(object):
                 data[userid] = reminder.option_type
         return data
 
-    def get_sql_reminder(self, obj, user_id=None):
-        """Get the sql-reminder for the given object for a specific user or
-        for the current logged in user.
-
-        Returns None, if no reminder is set.
-        """
-        user_id = user_id or api.user.get_current().getId()
-        return ReminderSetting.query.filter(
-            ReminderSetting.actor_id == user_id,
-            ReminderSetting.task.has(task_id=obj.get_sql_object().task_id)).first()
-
     def clear_reminder(self, obj, user_id=None):
         """Removes a registered reminder for the given object for a specific
         user or for the current logged in user.

--- a/opengever/task/reminder/reminder.py
+++ b/opengever/task/reminder/reminder.py
@@ -2,9 +2,7 @@ from datetime import date
 from opengever.base.model import create_session
 from opengever.globalindex.model.reminder_settings import ReminderSetting
 from opengever.task.activities import TaskReminderActivity
-from opengever.task.reminder import TASK_REMINDER_OPTIONS
 from opengever.task.reminder.interfaces import IReminderStorage
-from plone import api
 from zope.globalrequest import getRequest
 
 
@@ -13,42 +11,30 @@ class TaskReminder(object):
     def __init__(self):
         self.session = create_session()
 
-    def set_reminder(self, obj, option, user_id=None):
+    def set_reminder(self, obj, reminder, user_id=None):
         """Sets a reminder for the given object for a specific user or for the
         current logged in user.
 
         A previously set reminder for the given user for the given object will
-        be overridden by the new reminder-setting.
-
-        arguments:
-        obj -- the object for which the reminder should be set
-        option -- a TASK_REMINDER_OPTIONS option
+        be overridden by the new reminder.
         """
-        user_id = user_id or api.user.get_current().getId()
         storage = IReminderStorage(obj)
-        storage.set(option.option_type, user_id)
+        storage.set(reminder, user_id)
 
     def get_reminder(self, obj, user_id=None):
-        """Get the reminder-option object for the given object for a specific
+        """Get the reminder for the given object for a specific
         user or for the current logged in user.
 
         Returns None, if no reminder is set.
         """
-        user_id = user_id or api.user.get_current().getId()
         storage = IReminderStorage(obj)
-        reminder_data = storage.get(user_id)
-        if reminder_data:
-            return TASK_REMINDER_OPTIONS.get(reminder_data['option_type'])
+        return storage.get(user_id)
 
     def get_reminders(self, obj):
-        """Get the reminder-option object for the given object for a specific
-        user or for the current logged in user.
-
-        Returns None, if no reminder is set.
+        """Get all reminders for this obj as a {userid: reminder} mapping.
         """
         storage = IReminderStorage(obj)
-        return {actor: TASK_REMINDER_OPTIONS.get(reminder_data['option_type'])
-                for actor, reminder_data in storage.list().items()}
+        return storage.list()
 
     def get_reminders_of_potential_responsibles(self, obj):
         """Get reminders of all responsible representatives.
@@ -56,17 +42,14 @@ class TaskReminder(object):
         representatives = [actor.userid for actor in
                            obj.get_responsible_actor().representatives()]
 
-        data = {}
-        for userid, reminder in self.get_reminders(obj).items():
-            if userid in representatives:
-                data[userid] = reminder.option_type
-        return data
+        return {user_id: reminder
+                for user_id, reminder in self.get_reminders(obj).items()
+                if user_id in representatives}
 
     def clear_reminder(self, obj, user_id=None):
         """Removes a registered reminder for the given object for a specific
         user or for the current logged in user.
         """
-        user_id = user_id or api.user.get_current().getId()
         storage = IReminderStorage(obj)
         storage.clear(user_id)
 
@@ -88,6 +71,6 @@ class TaskReminder(object):
         sql_task = obj.get_sql_object()
 
         for reminder_setting in sql_task.reminder_settings:
-            option = TASK_REMINDER_OPTIONS[reminder_setting.option_type]
-            new_remind_day = option.calculate_remind_on(sql_task.deadline)
+            reminder = self.get_reminder(obj, user_id=reminder_setting.actor_id)
+            new_remind_day = reminder.calculate_trigger_date(sql_task.deadline)
             reminder_setting.remind_day = new_remind_day

--- a/opengever/task/reminder/reminder.py
+++ b/opengever/task/reminder/reminder.py
@@ -37,8 +37,9 @@ class TaskReminder(object):
         Returns None, if no reminder is set.
         """
         user_id = user_id or api.user.get_current().getId()
-        return TASK_REMINDER_OPTIONS.get(
-            self._get_user_annotation(obj, user_id))
+        reminder_data = self._get_user_annotation(obj, user_id)
+        if reminder_data:
+            return TASK_REMINDER_OPTIONS.get(reminder_data['option_type'])
 
     def get_reminders(self, obj):
         """Get the reminder-option object for the given object for a specific
@@ -47,8 +48,8 @@ class TaskReminder(object):
         Returns None, if no reminder is set.
         """
         storage = self._annotation_storage(obj)
-        return {actor: TASK_REMINDER_OPTIONS.get(value)
-                for actor, value in storage.items()}
+        return {actor: TASK_REMINDER_OPTIONS.get(reminder_data['option_type'])
+                for actor, reminder_data in storage.items()}
 
     def get_reminders_of_potential_responsibles(self, obj):
         """Get reminders of all responsible representatives.
@@ -88,7 +89,8 @@ class TaskReminder(object):
             obj.get_sql_object().reminder_settings)
 
     def _set_reminder_setting_in_annotation(self, obj, user_id, option):
-        self._set_user_annotation(obj, user_id, option.option_type)
+        reminder_data = PersistentDict({'option_type': option.option_type})
+        self._set_user_annotation(obj, user_id, reminder_data)
 
     def _clear_reminder_setting_in_annotation(self, obj, user_id):
         storage = self._annotation_storage(obj)

--- a/opengever/task/reminder/reminder.py
+++ b/opengever/task/reminder/reminder.py
@@ -1,9 +1,5 @@
-from datetime import date
 from opengever.base.model import create_session
-from opengever.globalindex.model.reminder_settings import ReminderSetting
-from opengever.task.activities import TaskReminderActivity
 from opengever.task.reminder.interfaces import IReminderStorage
-from zope.globalrequest import getRequest
 
 
 class TaskReminder(object):
@@ -52,17 +48,6 @@ class TaskReminder(object):
         """
         storage = IReminderStorage(obj)
         storage.clear(user_id)
-
-    def create_reminder_notifications(self):
-        """Creates an activity and the related notification for set reminders.
-        """
-        query = ReminderSetting.query.filter(
-            ReminderSetting.remind_day == date.today())
-
-        for reminder in query.all():
-            TaskReminderActivity(reminder.task, getRequest()).record(reminder.actor_id)
-
-        return query.count()
 
     def recalculate_remind_day_for_obj(self, obj):
         """If the duedate of a task will change, we have to update the

--- a/opengever/task/reminder/storage.py
+++ b/opengever/task/reminder/storage.py
@@ -1,0 +1,77 @@
+from opengever.task.reminder import TASK_REMINDER_OPTIONS
+from opengever.task.reminder.interfaces import IReminderStorage
+from persistent.dict import PersistentDict
+from plone import api
+from plone.dexterity.interfaces import IDexterityContent
+from zope.annotation import IAnnotations
+from zope.component import adapter
+from zope.interface import implementer
+
+
+REMINDER_ANNOTATIONS_KEY = 'opengever.task.task_reminder'
+
+
+@implementer(IReminderStorage)
+@adapter(IDexterityContent)
+class ReminderAnnotationStorage(object):
+
+    def __init__(self, context):
+        self.context = context
+
+    def set(self, option_type, user_id=None):
+        """Set a reminder on the adapted object.
+
+        option_type -- The kind of reminder to set
+        user_id -- User to set the reminder for
+
+        If no user_id is given, defaults to the currently logged in user.
+        """
+        user_id = user_id or api.user.get_current().getId()
+        assert option_type in TASK_REMINDER_OPTIONS.keys()
+        reminder_data = PersistentDict({'option_type': option_type})
+        self._set_user_annotation(user_id, reminder_data)
+
+    def get(self, user_id=None):
+        """Return reminder for adapted object, or None if no reminder exists.
+
+        user_id -- User to get the reminder for
+
+        If no user_id is given, defaults to the currently logged in user.
+        """
+        user_id = user_id or api.user.get_current().getId()
+        reminder_data = self._get_user_annotation(user_id)
+        return reminder_data
+
+    def list(self):
+        """Return user_id -> reminder mapping of all reminders for adapted obj.
+        """
+        reminders_by_user = self._annotation_storage()
+        return reminders_by_user
+
+    def clear(self, user_id=None):
+        """Clear an existing reminder.
+
+        user_id -- User to clear the reminder for
+
+        If no user_id is given, defaults to the currently logged in user.
+        """
+        user_id = user_id or api.user.get_current().getId()
+        storage = self._annotation_storage()
+        if user_id in storage:
+            del storage[user_id]
+
+    def _annotation_storage(self, create_if_missing=False):
+        annotations = IAnnotations(self.context)
+        # Avoid writes on read
+        if REMINDER_ANNOTATIONS_KEY not in annotations and create_if_missing:
+            annotations[REMINDER_ANNOTATIONS_KEY] = PersistentDict()
+
+        return annotations.get(REMINDER_ANNOTATIONS_KEY, {})
+
+    def _set_user_annotation(self, user_id, value):
+        assert isinstance(user_id, str)
+        storage = self._annotation_storage(create_if_missing=True)
+        storage[user_id] = value
+
+    def _get_user_annotation(self, user_id):
+        return self._annotation_storage().get(user_id)

--- a/opengever/task/response.py
+++ b/opengever/task/response.py
@@ -11,7 +11,6 @@ from opengever.task import util
 from opengever.task.interfaces import ICommentResponseHandler
 from opengever.task.permissions import DEFAULT_ISSUE_MIME_TYPE
 from opengever.task.reminder.model import get_task_reminder_options_vocabulary
-from opengever.task.reminder.reminder import TaskReminder
 from plone import api
 from plone.autoform.form import AutoExtensibleForm
 from plone.memoize.view import memoize
@@ -41,7 +40,7 @@ from zope.schema.interfaces import IContextAwareDefaultFactory
 
 @provider(IContextAwareDefaultFactory)
 def get_current_user_reminder(context):
-    reminder = TaskReminder().get_reminder(context)
+    reminder = context.get_reminder()
     return reminder.option_type if reminder else None
 
 

--- a/opengever/task/response.py
+++ b/opengever/task/response.py
@@ -10,7 +10,7 @@ from opengever.task import FINAL_TRANSITIONS
 from opengever.task import util
 from opengever.task.interfaces import ICommentResponseHandler
 from opengever.task.permissions import DEFAULT_ISSUE_MIME_TYPE
-from opengever.task.reminder import get_task_reminder_options_vocabulary
+from opengever.task.reminder.model import get_task_reminder_options_vocabulary
 from opengever.task.reminder.reminder import TaskReminder
 from plone import api
 from plone.autoform.form import AutoExtensibleForm

--- a/opengever/task/task.py
+++ b/opengever/task/task.py
@@ -30,6 +30,7 @@ from opengever.task import is_private_task_feature_enabled
 from opengever.task import TASK_STATE_PLANNED
 from opengever.task import util
 from opengever.task.interfaces import ITaskSettings
+from opengever.task.reminder.reminder import TaskReminderSupport
 from opengever.task.validators import NoCheckedoutDocsValidator
 from opengever.tasktemplates.interfaces import IFromSequentialTasktemplate
 from opengever.tasktemplates.interfaces import IFromTasktemplateGenerated
@@ -334,7 +335,7 @@ class IAddTaskSchema(ITask):
     )
 
 
-class Task(Container):
+class Task(Container, TaskReminderSupport):
     """Provide a container for tasks."""
 
     implements(ITask, ITabbedviewUploadable, IResponseSupported)

--- a/opengever/task/tests/test_accept.py
+++ b/opengever/task/tests/test_accept.py
@@ -1,5 +1,5 @@
 from ftw.testbrowser import browsing
-from opengever.task.reminder import TASK_REMINDER_ONE_DAY_BEFORE
+from opengever.task.reminder import ReminderOneDayBefore
 from opengever.task.reminder.reminder import TaskReminder
 from opengever.testing import IntegrationTestCase
 
@@ -12,7 +12,7 @@ class TestAcceptTaskWorkflowTransitionView(IntegrationTestCase):
 
         task_reminder = TaskReminder()
         task_reminder.set_reminder(
-            self.seq_subtask_1, TASK_REMINDER_ONE_DAY_BEFORE,
+            self.seq_subtask_1, ReminderOneDayBefore(),
             user_id=self.regular_user.id)
 
         self.assertEqual(

--- a/opengever/task/tests/test_accept.py
+++ b/opengever/task/tests/test_accept.py
@@ -1,6 +1,5 @@
 from ftw.testbrowser import browsing
 from opengever.task.reminder import ReminderOneDayBefore
-from opengever.task.reminder.reminder import TaskReminder
 from opengever.testing import IntegrationTestCase
 
 
@@ -10,18 +9,17 @@ class TestAcceptTaskWorkflowTransitionView(IntegrationTestCase):
     def test_reminders_of_responsbile_gets_cleared(self, browser):
         self.login(self.regular_user, browser)
 
-        task_reminder = TaskReminder()
-        task_reminder.set_reminder(
-            self.seq_subtask_1, ReminderOneDayBefore(),
+        self.seq_subtask_1.set_reminder(
+            ReminderOneDayBefore(),
             user_id=self.regular_user.id)
 
         self.assertEqual(
             [self.regular_user.id],
-            TaskReminder().get_reminders(self.seq_subtask_1).keys())
+            self.seq_subtask_1.get_reminders().keys())
 
         browser.open(self.seq_subtask_1, view='accept_task_workflow_transition')
 
         self.assertEqual('OK', browser.contents)
         self.assertEqual(
             {},
-            TaskReminder().get_reminders(self.seq_subtask_1))
+            self.seq_subtask_1.get_reminders())

--- a/opengever/task/tests/test_assign.py
+++ b/opengever/task/tests/test_assign.py
@@ -10,7 +10,6 @@ from opengever.base.role_assignments import ASSIGNMENT_VIA_TASK
 from opengever.base.role_assignments import ASSIGNMENT_VIA_TASK_AGENCY
 from opengever.base.role_assignments import RoleAssignmentManager
 from opengever.task.reminder import ReminderSameDay
-from opengever.task.reminder.reminder import TaskReminder
 from opengever.task.response_syncer.workflow import WorkflowResponseSyncerReceiver
 from opengever.testing import IntegrationTestCase
 from opengever.testing.event_recorder import get_recorded_events
@@ -73,13 +72,12 @@ class TestAssignTask(IntegrationTestCase):
     def test_remove_task_reminder_of_old_responsible(self, browser):
         self.login(self.regular_user, browser=browser)
 
-        task_reminder = TaskReminder()
-        task_reminder.set_reminder(self.task, ReminderSameDay())
+        self.task.set_reminder(ReminderSameDay())
 
-        self.assertIsNotNone(task_reminder.get_reminder(self.task))
+        self.assertIsNotNone(self.task.get_reminder())
 
         self.assign_task(self.secretariat_user, u'Thats a job for you.')
-        self.assertIsNone(task_reminder.get_reminder(self.task))
+        self.assertIsNone(self.task.get_reminder())
 
     @browsing
     def test_adds_an_corresponding_response(self, browser):

--- a/opengever/task/tests/test_assign.py
+++ b/opengever/task/tests/test_assign.py
@@ -5,11 +5,11 @@ from ftw.testbrowser import browsing
 from ftw.testbrowser.pages.statusmessages import error_messages
 from ftw.testbrowser.pages.statusmessages import info_messages
 from opengever.base.oguid import Oguid
+from opengever.base.response import IResponseContainer
 from opengever.base.role_assignments import ASSIGNMENT_VIA_TASK
 from opengever.base.role_assignments import ASSIGNMENT_VIA_TASK_AGENCY
 from opengever.base.role_assignments import RoleAssignmentManager
-from opengever.base.response import IResponseContainer
-from opengever.task.reminder import TASK_REMINDER_SAME_DAY
+from opengever.task.reminder import ReminderSameDay
 from opengever.task.reminder.reminder import TaskReminder
 from opengever.task.response_syncer.workflow import WorkflowResponseSyncerReceiver
 from opengever.testing import IntegrationTestCase
@@ -74,8 +74,7 @@ class TestAssignTask(IntegrationTestCase):
         self.login(self.regular_user, browser=browser)
 
         task_reminder = TaskReminder()
-        task_reminder.set_reminder(
-            self.task, TASK_REMINDER_SAME_DAY)
+        task_reminder.set_reminder(self.task, ReminderSameDay())
 
         self.assertIsNotNone(task_reminder.get_reminder(self.task))
 

--- a/opengever/task/tests/test_deadline_modification.py
+++ b/opengever/task/tests/test_deadline_modification.py
@@ -2,8 +2,8 @@ from ftw.testbrowser import browser as default_browser
 from ftw.testbrowser import browsing
 from ftw.testbrowser.pages.statusmessages import info_messages
 from opengever.base.oguid import Oguid
-from opengever.globalindex.model.reminder_settings import ReminderSetting
 from opengever.base.response import IResponseContainer
+from opengever.globalindex.model.reminder_settings import ReminderSetting
 from opengever.task.interfaces import IDeadlineModifier
 from opengever.task.interfaces import ISuccessorTaskController
 from opengever.task.reminder import TASK_REMINDER_SAME_DAY
@@ -12,7 +12,6 @@ from opengever.task.response_syncer.deadline import ModifyDeadlineResponseSyncer
 from opengever.testing import IntegrationTestCase
 from opengever.testing.event_recorder import get_recorded_events
 from opengever.testing.event_recorder import register_event_recorder
-from unittest import skip
 from zExceptions import Unauthorized
 from zope.lifecycleevent.interfaces import IObjectModifiedEvent
 import datetime
@@ -138,8 +137,6 @@ class TestDeadlineModificationForm(IntegrationTestCase):
         self.assertEquals(1, len(events))
         self.assertEqual(self.task, events[0].object)
 
-    @skip("This test currently fails in a flaky way on CI."
-          "https://github.com/4teamwork/opengever.core/issues/4945")
     @browsing
     def test_recalculate_remind_on_for_set_reminders_if_deadline_changed(self, browser):
         self.login(self.dossier_responsible, browser=browser)

--- a/opengever/task/tests/test_deadline_modification.py
+++ b/opengever/task/tests/test_deadline_modification.py
@@ -6,7 +6,7 @@ from opengever.base.response import IResponseContainer
 from opengever.globalindex.model.reminder_settings import ReminderSetting
 from opengever.task.interfaces import IDeadlineModifier
 from opengever.task.interfaces import ISuccessorTaskController
-from opengever.task.reminder import TASK_REMINDER_SAME_DAY
+from opengever.task.reminder import ReminderSameDay
 from opengever.task.reminder.reminder import TaskReminder
 from opengever.task.response_syncer.deadline import ModifyDeadlineResponseSyncerReceiver
 from opengever.testing import IntegrationTestCase
@@ -146,7 +146,7 @@ class TestDeadlineModificationForm(IntegrationTestCase):
 
         self.task.deadline = today
         task_reminder.set_reminder(
-            self.task, TASK_REMINDER_SAME_DAY, self.regular_user.id)
+            self.task, ReminderSameDay(), self.regular_user.id)
         self.task.sync()
 
         sql_setting = ReminderSetting.query.first()

--- a/opengever/task/tests/test_deadline_modification.py
+++ b/opengever/task/tests/test_deadline_modification.py
@@ -7,7 +7,6 @@ from opengever.globalindex.model.reminder_settings import ReminderSetting
 from opengever.task.interfaces import IDeadlineModifier
 from opengever.task.interfaces import ISuccessorTaskController
 from opengever.task.reminder import ReminderSameDay
-from opengever.task.reminder.reminder import TaskReminder
 from opengever.task.response_syncer.deadline import ModifyDeadlineResponseSyncerReceiver
 from opengever.testing import IntegrationTestCase
 from opengever.testing.event_recorder import get_recorded_events
@@ -140,13 +139,12 @@ class TestDeadlineModificationForm(IntegrationTestCase):
     @browsing
     def test_recalculate_remind_on_for_set_reminders_if_deadline_changed(self, browser):
         self.login(self.dossier_responsible, browser=browser)
-        task_reminder = TaskReminder()
         today = datetime.date.today()
         tomorrow = today + datetime.timedelta(days=1)
 
         self.task.deadline = today
-        task_reminder.set_reminder(
-            self.task, ReminderSameDay(), self.regular_user.id)
+        self.task.set_reminder(
+            ReminderSameDay(), self.regular_user.id)
         self.task.sync()
 
         sql_setting = ReminderSetting.query.first()

--- a/opengever/task/tests/test_reminder.py
+++ b/opengever/task/tests/test_reminder.py
@@ -9,10 +9,9 @@ from opengever.activity.model import Notification
 from opengever.activity.roles import TASK_REMINDER_WATCHER_ROLE
 from opengever.base.interfaces import IDataCollector
 from opengever.task.activities import TaskReminderActivity
-from opengever.task.reminder import TASK_REMINDER_BEGINNING_OF_WEEK
-from opengever.task.reminder import TASK_REMINDER_ONE_DAY_BEFORE
-from opengever.task.reminder import TASK_REMINDER_ONE_WEEK_BEFORE
-from opengever.task.reminder import TASK_REMINDER_SAME_DAY
+from opengever.task.reminder import ReminderOneDayBefore
+from opengever.task.reminder import ReminderOneWeekBefore
+from opengever.task.reminder import ReminderSameDay
 from opengever.task.reminder.reminder import TaskReminder
 from opengever.testing import IntegrationTestCase
 from zope.component import getAdapter
@@ -20,76 +19,50 @@ import json
 import pytz
 
 
-class TestTaskReminderOptions(IntegrationTestCase):
-
-    def test_calculate_remind_on(self):
-        deadline = date(2018, 7, 1)  # 01. July 2018, Sunday
-        self.assertEqual(
-            date(2018, 7, 1),  # Sunday
-            TASK_REMINDER_SAME_DAY.calculate_remind_on(deadline))
-
-        self.assertEqual(
-            date(2018, 6, 30),  # Saturday
-            TASK_REMINDER_ONE_DAY_BEFORE.calculate_remind_on(deadline))
-
-        self.assertEqual(
-            date(2018, 6, 24),  # Sunday
-            TASK_REMINDER_ONE_WEEK_BEFORE.calculate_remind_on(deadline))
-
-        self.assertEqual(
-            date(2018, 6, 25),  # Monday
-            TASK_REMINDER_BEGINNING_OF_WEEK.calculate_remind_on(deadline))
-
-        deadline = date(2018, 7, 2)  # 02. July 2018, Monday
-        self.assertEqual(
-            date(2018, 7, 2),  # Monday
-            TASK_REMINDER_BEGINNING_OF_WEEK.calculate_remind_on(deadline))
-
-
 class TestTaskReminder(IntegrationTestCase):
 
     features = ('activity', )
 
-    def test_set_reminder_creates_annotation_entry_for_current_user(self):
+    def test_set_reminder_stores_reminder_for_current_user(self):
         self.login(self.regular_user)
         task_reminder = TaskReminder()
-        task_reminder.set_reminder(self.task, TASK_REMINDER_ONE_DAY_BEFORE)
+        task_reminder.set_reminder(self.task, ReminderOneDayBefore())
 
         self.assertEqual(
-            TASK_REMINDER_ONE_DAY_BEFORE.option_type,
-            task_reminder.get_reminder(self.task).option_type)
+            ReminderOneDayBefore(),
+            task_reminder.get_reminder(self.task))
 
         self.assertIsNone(task_reminder.get_reminder(
             self.task, user_id=self.dossier_responsible.getId()))
 
-    def test_set_reminder_updates_annotations_entry_if_already_exists(self):
+    def test_set_reminder_updates_existing_reminder(self):
         self.login(self.regular_user)
         task_reminder = TaskReminder()
-        task_reminder.set_reminder(self.task, TASK_REMINDER_ONE_DAY_BEFORE)
-        task_reminder.set_reminder(self.task, TASK_REMINDER_ONE_WEEK_BEFORE)
+        task_reminder.set_reminder(self.task, ReminderOneDayBefore())
+        task_reminder.set_reminder(self.task, ReminderOneWeekBefore())
 
         self.assertEqual(
-            TASK_REMINDER_ONE_WEEK_BEFORE.option_type,
-            task_reminder.get_reminder(self.task).option_type)
+            ReminderOneWeekBefore(),
+            task_reminder.get_reminder(self.task))
 
-    def test_clear_reminder_removes_annotation_reminder_for_current_user(self):
+    def test_clear_reminder_removes_existing_reminder(self):
         self.login(self.regular_user)
         task_reminder = TaskReminder()
 
-        task_reminder.set_reminder(self.task, TASK_REMINDER_ONE_DAY_BEFORE)
+        task_reminder.set_reminder(self.task, ReminderOneDayBefore())
         task_reminder.set_reminder(
-            self.task, TASK_REMINDER_ONE_DAY_BEFORE,
+            self.task, ReminderOneDayBefore(),
             user_id=self.dossier_responsible.getId())
 
         task_reminder.clear_reminder(self.task)
         self.assertIsNone(task_reminder.get_reminder(self.task))
 
         self.assertEqual(
-            TASK_REMINDER_ONE_DAY_BEFORE.option_type,
+            ReminderOneDayBefore(),
             task_reminder.get_reminder(
-                self.task, user_id=self.dossier_responsible.getId()).option_type)
+                self.task, user_id=self.dossier_responsible.getId()))
 
-    def test_create_reminder_notifications_does_nothing_if_there_are_no_reminder_settings(self):
+    def test_create_reminder_notifications_does_nothing_if_there_are_no_reminders(self):
         self.login(self.regular_user)
 
         TaskReminder().create_reminder_notifications()
@@ -117,14 +90,14 @@ class TestTaskReminder(IntegrationTestCase):
         task_reminder = TaskReminder()
 
         with self.login(self.regular_user):
-            task_reminder.set_reminder(self.task, TASK_REMINDER_SAME_DAY)
+            task_reminder.set_reminder(self.task, ReminderSameDay())
             self.task.sync()
 
-            task_reminder.set_reminder(self.sequential_task, TASK_REMINDER_SAME_DAY)
+            task_reminder.set_reminder(self.sequential_task, ReminderSameDay())
             self.sequential_task.sync()
 
         with self.login(self.dossier_responsible):
-            task_reminder.set_reminder(self.subtask, TASK_REMINDER_ONE_DAY_BEFORE)
+            task_reminder.set_reminder(self.subtask, ReminderOneDayBefore())
             self.subtask.sync()
 
         with freeze(pytz.UTC.localize(datetime.combine(today, datetime.min.time()))):
@@ -154,7 +127,7 @@ class TestTaskReminder(IntegrationTestCase):
         task_reminder = TaskReminder()
 
         with self.login(self.regular_user):
-            task_reminder.set_reminder(self.task, TASK_REMINDER_SAME_DAY)
+            task_reminder.set_reminder(self.task, ReminderSameDay())
             self.task.sync()
 
         def create_reminders_for_task_in_state(task, state):
@@ -198,7 +171,7 @@ class TestTaskReminder(IntegrationTestCase):
         task_reminder = TaskReminder()
 
         with self.login(self.regular_user):
-            task_reminder.set_reminder(self.task, TASK_REMINDER_SAME_DAY)
+            task_reminder.set_reminder(self.task, ReminderSameDay())
             self.task.sync()
 
         with freeze(pytz.UTC.localize(datetime.combine(today, datetime.min.time()))):
@@ -264,7 +237,7 @@ class TestTaskReminderSelector(IntegrationTestCase):
             'no-reminder',
             selected_option[0].get('option_type'))
 
-        task_reminder.set_reminder(self.task, TASK_REMINDER_ONE_DAY_BEFORE)
+        task_reminder.set_reminder(self.task, ReminderOneDayBefore())
         browser.visit(self.task, view='tabbedview_view-overview')
         init_state = self._get_init_state(browser)
         selected_option = filter(lambda x: x.get('selected'),
@@ -272,7 +245,7 @@ class TestTaskReminderSelector(IntegrationTestCase):
 
         self.assertEqual(1, len(selected_option))
         self.assertEqual(
-            TASK_REMINDER_ONE_DAY_BEFORE.option_type,
+            ReminderOneDayBefore.option_type,
             selected_option[0].get('option_type'))
 
     def _get_init_state(self, browser):
@@ -287,23 +260,27 @@ class TestTaskReminderTransport(IntegrationTestCase):
 
         task_reminder = TaskReminder()
         task_reminder.set_reminder(
-            self.task, TASK_REMINDER_ONE_DAY_BEFORE, user_id=self.regular_user.id)
+            self.task, ReminderOneDayBefore(), user_id=self.regular_user.id)
         task_reminder.set_reminder(
-            self.task, TASK_REMINDER_ONE_DAY_BEFORE, user_id=self.dossier_responsible.id)
+            self.task, ReminderOneDayBefore(), user_id=self.dossier_responsible.id)
         task_reminder.set_reminder(
-            self.task, TASK_REMINDER_ONE_DAY_BEFORE, user_id=self.secretariat_user.id)
+            self.task, ReminderOneDayBefore(), user_id=self.secretariat_user.id)
 
         # single user
         collector = getAdapter(self.task, IDataCollector, name='task-reminders')
         self.assertEqual(
-            {self.regular_user.id: TASK_REMINDER_ONE_DAY_BEFORE.option_type},
+            {self.regular_user.id: {
+                'option_type': ReminderOneDayBefore.option_type,
+                'params': {}}},
             collector.extract())
 
         # inbox group
         self.task.responsible = 'inbox:fa'
         collector = getAdapter(self.task, IDataCollector, name='task-reminders')
         self.assertEqual(
-            {self.secretariat_user.id: TASK_REMINDER_ONE_DAY_BEFORE.option_type},
+            {self.secretariat_user.id: {
+                'option_type': ReminderOneDayBefore.option_type,
+                'params': {}}},
             collector.extract())
 
     def test_transport_reminders(self):
@@ -311,7 +288,7 @@ class TestTaskReminderTransport(IntegrationTestCase):
 
         task_reminder = TaskReminder()
         task_reminder.set_reminder(
-            self.task, TASK_REMINDER_ONE_DAY_BEFORE, user_id=self.regular_user.id)
+            self.task, ReminderOneDayBefore(), user_id=self.regular_user.id)
 
         collector = getAdapter(self.task, IDataCollector, name='task-reminders')
         data = collector.extract()
@@ -320,5 +297,5 @@ class TestTaskReminderTransport(IntegrationTestCase):
         collector = getAdapter(self.subtask, IDataCollector, name='task-reminders')
         collector.insert(data)
         self.assertEqual(
-            {self.regular_user.id: TASK_REMINDER_ONE_DAY_BEFORE},
+            {self.regular_user.id: ReminderOneDayBefore()},
             TaskReminder().get_reminders(self.subtask))

--- a/opengever/task/tests/test_reminder.py
+++ b/opengever/task/tests/test_reminder.py
@@ -9,6 +9,7 @@ from opengever.activity.model import Notification
 from opengever.activity.roles import TASK_REMINDER_WATCHER_ROLE
 from opengever.base.interfaces import IDataCollector
 from opengever.task.activities import TaskReminderActivity
+from opengever.task.reminder import ReminderOnDate
 from opengever.task.reminder import ReminderOneDayBefore
 from opengever.task.reminder import ReminderOneWeekBefore
 from opengever.task.reminder import ReminderSameDay
@@ -278,11 +279,12 @@ class TestTaskReminderTransport(IntegrationTestCase):
                 'params': {}}},
             collector.extract())
 
-    def test_transport_reminders(self):
+    def test_transport_reminders_with_params(self):
         self.login(self.regular_user)
 
         self.task.set_reminder(
-            ReminderOneDayBefore(), user_id=self.regular_user.id)
+            ReminderOnDate({'date': date(2018, 12, 30)}),
+            user_id=self.regular_user.id)
 
         collector = getAdapter(self.task, IDataCollector, name='task-reminders')
         data = collector.extract()
@@ -291,5 +293,5 @@ class TestTaskReminderTransport(IntegrationTestCase):
         collector = getAdapter(self.subtask, IDataCollector, name='task-reminders')
         collector.insert(data)
         self.assertEqual(
-            {self.regular_user.id: ReminderOneDayBefore()},
+            {self.regular_user.id: ReminderOnDate({'date': date(2018, 12, 30)})},
             self.subtask.get_reminders())

--- a/opengever/task/tests/test_reminder.py
+++ b/opengever/task/tests/test_reminder.py
@@ -12,6 +12,7 @@ from opengever.task.activities import TaskReminderActivity
 from opengever.task.reminder import ReminderOneDayBefore
 from opengever.task.reminder import ReminderOneWeekBefore
 from opengever.task.reminder import ReminderSameDay
+from opengever.task.reminder.cronjobs import create_reminder_notifications
 from opengever.task.reminder.reminder import TaskReminder
 from opengever.testing import IntegrationTestCase
 from zope.component import getAdapter
@@ -65,7 +66,7 @@ class TestTaskReminder(IntegrationTestCase):
     def test_create_reminder_notifications_does_nothing_if_there_are_no_reminders(self):
         self.login(self.regular_user)
 
-        TaskReminder().create_reminder_notifications()
+        create_reminder_notifications()
 
         self.assertEqual(0, Activity.query.count())
         self.assertEqual(0, Notification.query.count())
@@ -101,7 +102,7 @@ class TestTaskReminder(IntegrationTestCase):
             self.subtask.sync()
 
         with freeze(pytz.UTC.localize(datetime.combine(today, datetime.min.time()))):
-            task_reminder.create_reminder_notifications()
+            create_reminder_notifications()
 
         task_reminder_activities = Activity.query.filter(
             Activity.kind == TaskReminderActivity.kind)
@@ -134,7 +135,7 @@ class TestTaskReminder(IntegrationTestCase):
             self.set_workflow_state(state, task)
 
             with freeze(pytz.UTC.localize(datetime.combine(today, datetime.min.time()))):
-                task_reminder.create_reminder_notifications()
+                create_reminder_notifications()
 
         create_reminders_for_task_in_state(self.task, 'task-state-tested-and-closed')
         create_reminders_for_task_in_state(self.task, 'task-state-resolved')
@@ -175,7 +176,7 @@ class TestTaskReminder(IntegrationTestCase):
             self.task.sync()
 
         with freeze(pytz.UTC.localize(datetime.combine(today, datetime.min.time()))):
-            task_reminder.create_reminder_notifications()
+            create_reminder_notifications()
 
         notifications = Notification.query.by_user(self.regular_user.getId())
         self.assertEqual(1, notifications.count())

--- a/opengever/task/tests/test_reminder_model.py
+++ b/opengever/task/tests/test_reminder_model.py
@@ -1,0 +1,101 @@
+from datetime import date
+from opengever.task.reminder import Reminder
+from opengever.task.reminder import ReminderBeginningOfWeek
+from opengever.task.reminder import ReminderOneDayBefore
+from opengever.task.reminder import ReminderOneWeekBefore
+from opengever.task.reminder import ReminderSameDay
+from opengever.testing import IntegrationTestCase
+
+
+class TestTaskReminderTypes(IntegrationTestCase):
+
+    def test_reminders_can_be_created_via_factory_method(self):
+        self.assertEqual(
+            ReminderSameDay(),
+            Reminder.create('same_day'))
+
+        self.assertEqual(
+            ReminderOneDayBefore(),
+            Reminder.create('one_day_before'))
+
+        self.assertEqual(
+            ReminderOneWeekBefore(),
+            Reminder.create('one_week_before'))
+
+        self.assertEqual(
+            ReminderBeginningOfWeek(),
+            Reminder.create('beginning_of_week'))
+
+    def test_reminders_can_be_serialized(self):
+        self.assertEqual(
+            {'option_type': 'same_day', 'params': {}},
+            ReminderSameDay().serialize())
+
+        self.assertEqual(
+            {'option_type': 'one_day_before', 'params': {}},
+            ReminderOneDayBefore().serialize())
+
+        self.assertEqual(
+            {'option_type': 'one_week_before', 'params': {}},
+            ReminderOneWeekBefore().serialize())
+
+        self.assertEqual(
+            {'option_type': 'beginning_of_week', 'params': {}},
+            ReminderBeginningOfWeek().serialize())
+
+    def test_reminders_can_be_deserialized_from_data(self):
+        self.assertEqual(
+            ReminderSameDay(),
+            Reminder.deserialize({'option_type': 'same_day'}))
+
+        self.assertEqual(
+            ReminderOneDayBefore(),
+            Reminder.deserialize({'option_type': 'one_day_before'}))
+
+        self.assertEqual(
+            ReminderOneWeekBefore(),
+            Reminder.deserialize({'option_type': 'one_week_before'}))
+
+        self.assertEqual(
+            ReminderBeginningOfWeek(),
+            Reminder.deserialize({'option_type': 'beginning_of_week'}))
+
+    def test_serialization_deserialization_rountrip(self):
+        self.assertEqual(
+            ReminderSameDay(),
+            Reminder.deserialize(ReminderSameDay().serialize()))
+
+        self.assertEqual(
+            ReminderOneDayBefore(),
+            Reminder.deserialize(ReminderOneDayBefore().serialize()))
+
+        self.assertEqual(
+            ReminderOneWeekBefore(),
+            Reminder.deserialize(ReminderOneWeekBefore().serialize()))
+
+        self.assertEqual(
+            ReminderBeginningOfWeek(),
+            Reminder.deserialize(ReminderBeginningOfWeek().serialize()))
+
+    def test_calculate_trigger_date(self):
+        deadline = date(2018, 7, 1)  # 01. July 2018, Sunday
+        self.assertEqual(
+            date(2018, 7, 1),  # Sunday
+            ReminderSameDay().calculate_trigger_date(deadline))
+
+        self.assertEqual(
+            date(2018, 6, 30),  # Saturday
+            ReminderOneDayBefore().calculate_trigger_date(deadline))
+
+        self.assertEqual(
+            date(2018, 6, 24),  # Sunday
+            ReminderOneWeekBefore().calculate_trigger_date(deadline))
+
+        self.assertEqual(
+            date(2018, 6, 25),  # Monday
+            ReminderBeginningOfWeek().calculate_trigger_date(deadline))
+
+        deadline = date(2018, 7, 2)  # 02. July 2018, Monday
+        self.assertEqual(
+            date(2018, 7, 2),  # Monday
+            ReminderBeginningOfWeek().calculate_trigger_date(deadline))

--- a/opengever/task/tests/test_reminder_storage.py
+++ b/opengever/task/tests/test_reminder_storage.py
@@ -1,5 +1,5 @@
-from opengever.task.reminder import TASK_REMINDER_ONE_WEEK_BEFORE
-from opengever.task.reminder import TASK_REMINDER_SAME_DAY
+from opengever.task.reminder import ReminderOneWeekBefore
+from opengever.task.reminder import ReminderSameDay
 from opengever.task.reminder.interfaces import IReminderStorage
 from opengever.task.reminder.storage import ReminderAnnotationStorage
 from opengever.testing import IntegrationTestCase
@@ -19,18 +19,20 @@ class TestTaskReminderStorage(IntegrationTestCase):
 
     def test_storage_set_for_current_user(self):
         self.login(self.regular_user)
-        self.storage.set(TASK_REMINDER_SAME_DAY.option_type)
+        self.storage.set(ReminderSameDay())
 
-        self.assertEqual({self.regular_user.id: {'option_type': 'same_day'}},
-                         self.storage.list())
+        self.assertEqual({
+            self.regular_user.id: {'option_type': 'same_day', 'params': {}}},
+            self.storage._annotation_storage())
 
     def test_storage_set_for_other_user(self):
         self.login(self.regular_user)
-        self.storage.set(TASK_REMINDER_SAME_DAY.option_type,
+        self.storage.set(ReminderSameDay(),
                          user_id=self.dossier_responsible.id)
 
-        self.assertEqual({self.dossier_responsible.id: {'option_type': 'same_day'}},
-                         self.storage.list())
+        self.assertEqual({
+            self.dossier_responsible.id: {'option_type': 'same_day', 'params': {}}},
+            self.storage._annotation_storage())
 
     def test_storage_set_rejects_invalid_option_type(self):
         self.login(self.regular_user)
@@ -41,59 +43,59 @@ class TestTaskReminderStorage(IntegrationTestCase):
         self.login(self.regular_user)
 
         with self.assertRaises(AssertionError):
-            self.storage.set(TASK_REMINDER_SAME_DAY.option_type,
+            self.storage.set(ReminderSameDay(),
                              user_id=self.dossier_responsible)
 
         with self.assertRaises(AssertionError):
-            self.storage.set(TASK_REMINDER_SAME_DAY.option_type,
+            self.storage.set(ReminderSameDay(),
                              user_id=u'unicode')
 
     def test_storage_get_for_current_user(self):
         self.login(self.regular_user)
-        self.storage.set(TASK_REMINDER_SAME_DAY.option_type)
+        self.storage.set(ReminderSameDay())
 
-        self.assertEqual({'option_type': 'same_day'},
+        self.assertEqual(ReminderSameDay(),
                          self.storage.get())
 
     def test_storage_get_for_other_user(self):
         self.login(self.regular_user)
-        self.storage.set(TASK_REMINDER_SAME_DAY.option_type,
+        self.storage.set(ReminderSameDay(),
                          user_id=self.dossier_responsible.id)
 
         self.assertIsNone(self.storage.get())
 
-        self.assertEqual({'option_type': 'same_day'},
+        self.assertEqual(ReminderSameDay(),
                          self.storage.get(self.dossier_responsible.id))
 
     def test_storage_list(self):
         self.login(self.regular_user)
-        self.storage.set(TASK_REMINDER_SAME_DAY.option_type)
-        self.storage.set(TASK_REMINDER_ONE_WEEK_BEFORE.option_type,
+        self.storage.set(ReminderSameDay())
+        self.storage.set(ReminderOneWeekBefore(),
                          user_id=self.dossier_responsible.id)
 
         self.assertEqual({
-            self.regular_user.id: {'option_type': 'same_day'},
-            self.dossier_responsible.id: {'option_type': 'one_week_before'}},
+            self.regular_user.id: ReminderSameDay(),
+            self.dossier_responsible.id: ReminderOneWeekBefore()},
             self.storage.list())
 
     def test_storage_clear_for_current_user(self):
         self.login(self.regular_user)
-        self.storage.set(TASK_REMINDER_SAME_DAY.option_type)
-        self.storage.set(TASK_REMINDER_ONE_WEEK_BEFORE.option_type,
+        self.storage.set(ReminderSameDay())
+        self.storage.set(ReminderOneWeekBefore(),
                          user_id=self.dossier_responsible.id)
         self.storage.clear()
 
         self.assertEqual({
-            self.dossier_responsible.id: {'option_type': 'one_week_before'}},
+            self.dossier_responsible.id: ReminderOneWeekBefore()},
             self.storage.list())
 
     def test_storage_clear_for_other_user(self):
         self.login(self.regular_user)
-        self.storage.set(TASK_REMINDER_SAME_DAY.option_type)
-        self.storage.set(TASK_REMINDER_ONE_WEEK_BEFORE.option_type,
+        self.storage.set(ReminderSameDay())
+        self.storage.set(ReminderOneWeekBefore(),
                          user_id=self.dossier_responsible.id)
         self.storage.clear(user_id=self.dossier_responsible.id)
 
         self.assertEqual({
-            self.regular_user.id: {'option_type': 'same_day'}},
+            self.regular_user.id: ReminderSameDay()},
             self.storage.list())

--- a/opengever/task/tests/test_reminder_storage.py
+++ b/opengever/task/tests/test_reminder_storage.py
@@ -1,0 +1,99 @@
+from opengever.task.reminder import TASK_REMINDER_ONE_WEEK_BEFORE
+from opengever.task.reminder import TASK_REMINDER_SAME_DAY
+from opengever.task.reminder.interfaces import IReminderStorage
+from opengever.task.reminder.storage import ReminderAnnotationStorage
+from opengever.testing import IntegrationTestCase
+from zope.interface.verify import verifyClass
+
+
+class TestTaskReminderStorage(IntegrationTestCase):
+
+    features = ('activity', )
+
+    def test_storage_implements_interface(self):
+        verifyClass(IReminderStorage, ReminderAnnotationStorage)
+
+    @property
+    def storage(self):
+        return IReminderStorage(self.task)
+
+    def test_storage_set_for_current_user(self):
+        self.login(self.regular_user)
+        self.storage.set(TASK_REMINDER_SAME_DAY.option_type)
+
+        self.assertEqual({self.regular_user.id: {'option_type': 'same_day'}},
+                         self.storage.list())
+
+    def test_storage_set_for_other_user(self):
+        self.login(self.regular_user)
+        self.storage.set(TASK_REMINDER_SAME_DAY.option_type,
+                         user_id=self.dossier_responsible.id)
+
+        self.assertEqual({self.dossier_responsible.id: {'option_type': 'same_day'}},
+                         self.storage.list())
+
+    def test_storage_set_rejects_invalid_option_type(self):
+        self.login(self.regular_user)
+        with self.assertRaises(AssertionError):
+            self.storage.set('unknown_option_type')
+
+    def test_storage_set_only_accepts_bytestring_user_ids(self):
+        self.login(self.regular_user)
+
+        with self.assertRaises(AssertionError):
+            self.storage.set(TASK_REMINDER_SAME_DAY.option_type,
+                             user_id=self.dossier_responsible)
+
+        with self.assertRaises(AssertionError):
+            self.storage.set(TASK_REMINDER_SAME_DAY.option_type,
+                             user_id=u'unicode')
+
+    def test_storage_get_for_current_user(self):
+        self.login(self.regular_user)
+        self.storage.set(TASK_REMINDER_SAME_DAY.option_type)
+
+        self.assertEqual({'option_type': 'same_day'},
+                         self.storage.get())
+
+    def test_storage_get_for_other_user(self):
+        self.login(self.regular_user)
+        self.storage.set(TASK_REMINDER_SAME_DAY.option_type,
+                         user_id=self.dossier_responsible.id)
+
+        self.assertIsNone(self.storage.get())
+
+        self.assertEqual({'option_type': 'same_day'},
+                         self.storage.get(self.dossier_responsible.id))
+
+    def test_storage_list(self):
+        self.login(self.regular_user)
+        self.storage.set(TASK_REMINDER_SAME_DAY.option_type)
+        self.storage.set(TASK_REMINDER_ONE_WEEK_BEFORE.option_type,
+                         user_id=self.dossier_responsible.id)
+
+        self.assertEqual({
+            self.regular_user.id: {'option_type': 'same_day'},
+            self.dossier_responsible.id: {'option_type': 'one_week_before'}},
+            self.storage.list())
+
+    def test_storage_clear_for_current_user(self):
+        self.login(self.regular_user)
+        self.storage.set(TASK_REMINDER_SAME_DAY.option_type)
+        self.storage.set(TASK_REMINDER_ONE_WEEK_BEFORE.option_type,
+                         user_id=self.dossier_responsible.id)
+        self.storage.clear()
+
+        self.assertEqual({
+            self.dossier_responsible.id: {'option_type': 'one_week_before'}},
+            self.storage.list())
+
+    def test_storage_clear_for_other_user(self):
+        self.login(self.regular_user)
+        self.storage.set(TASK_REMINDER_SAME_DAY.option_type)
+        self.storage.set(TASK_REMINDER_ONE_WEEK_BEFORE.option_type,
+                         user_id=self.dossier_responsible.id)
+        self.storage.clear(user_id=self.dossier_responsible.id)
+
+        self.assertEqual({
+            self.regular_user.id: {'option_type': 'same_day'}},
+            self.storage.list())

--- a/opengever/task/tests/test_response_syncer.py
+++ b/opengever/task/tests/test_response_syncer.py
@@ -5,7 +5,6 @@ from opengever.ogds.base.Extensions.plugins import activate_request_layer
 from opengever.ogds.base.interfaces import IInternalOpengeverRequestLayer
 from opengever.task.interfaces import IResponseSyncerSender
 from opengever.task.reminder import ReminderSameDay
-from opengever.task.reminder.reminder import TaskReminder
 from opengever.task.response_syncer import BaseResponseSyncerReceiver
 from opengever.task.response_syncer import BaseResponseSyncerSender
 from opengever.task.response_syncer import ResponseSyncerSenderException
@@ -370,7 +369,6 @@ class TestWorkflowSyncerReceiver(FunctionalTestCase):
         create(Builder('ogds_user').id('hugo.boss'))
         create(Builder('ogds_user').id('james.bond'))
 
-        task_reminder = TaskReminder()
         task = create(Builder('task')
                       .in_state('task-state-in-progress')
                       .having(
@@ -379,9 +377,9 @@ class TestWorkflowSyncerReceiver(FunctionalTestCase):
                           responsible_client='org-unit-1',
                           deadline=datetime.date.today()))
 
-        task_reminder.set_reminder(task, ReminderSameDay(), 'hugo.boss')
+        task.set_reminder(ReminderSameDay(), 'hugo.boss')
 
-        self.assertIsNotNone(task_reminder.get_reminder(task, 'hugo.boss'))
+        self.assertIsNotNone(task.get_reminder('hugo.boss'))
 
         self.prepare_request(task, text=u'I am done!',
                              transition='task-transition-reassign',
@@ -389,7 +387,7 @@ class TestWorkflowSyncerReceiver(FunctionalTestCase):
                              responsible_client='org-unit-1')
         task.unrestrictedTraverse(self.RECEIVER_VIEW_NAME)()
 
-        self.assertIsNone(task_reminder.get_reminder(task, 'hugo.boss'))
+        self.assertIsNone(task.get_reminder('hugo.boss'))
 
     def test_allow_workflow_changes_on_remote_system_if_user_has_no_write_permission(self):
         create(Builder('ogds_user').id('hugo.boss'))

--- a/opengever/task/tests/test_response_syncer.py
+++ b/opengever/task/tests/test_response_syncer.py
@@ -1,10 +1,10 @@
 from ftw.builder import Builder
 from ftw.builder import create
+from opengever.base.response import IResponseContainer
 from opengever.ogds.base.Extensions.plugins import activate_request_layer
 from opengever.ogds.base.interfaces import IInternalOpengeverRequestLayer
-from opengever.base.response import IResponseContainer
 from opengever.task.interfaces import IResponseSyncerSender
-from opengever.task.reminder import TASK_REMINDER_SAME_DAY
+from opengever.task.reminder import ReminderSameDay
 from opengever.task.reminder.reminder import TaskReminder
 from opengever.task.response_syncer import BaseResponseSyncerReceiver
 from opengever.task.response_syncer import BaseResponseSyncerSender
@@ -379,7 +379,7 @@ class TestWorkflowSyncerReceiver(FunctionalTestCase):
                           responsible_client='org-unit-1',
                           deadline=datetime.date.today()))
 
-        task_reminder.set_reminder(task, TASK_REMINDER_SAME_DAY, 'hugo.boss')
+        task_reminder.set_reminder(task, ReminderSameDay(), 'hugo.boss')
 
         self.assertIsNotNone(task_reminder.get_reminder(task, 'hugo.boss'))
 

--- a/opengever/task/transition.py
+++ b/opengever/task/transition.py
@@ -16,7 +16,6 @@ from opengever.task.browser.delegate.utils import create_subtasks
 from opengever.task.browser.modify_deadline import validate_deadline_changed
 from opengever.task.interfaces import IDeadlineModifier
 from opengever.task.localroles import LocalRolesSetter
-from opengever.task.reminder.reminder import TaskReminder
 from opengever.task.response_syncer import sync_task_response
 from opengever.task.task import ITask
 from opengever.task.util import add_simple_response
@@ -257,7 +256,7 @@ class ReassignTransitionExtender(DefaultTransitionExtender):
         former_responsible = ITask['responsible']
         former_responsible_client = ITask['responsible_client']
 
-        TaskReminder().clear_reminder(self.context, self.context.responsible)
+        self.context.clear_reminder(self.context.responsible)
 
         changes = (
             (former_responsible, transition_params.get('responsible')),

--- a/opengever/testing/builders/sql.py
+++ b/opengever/testing/builders/sql.py
@@ -47,7 +47,8 @@ from opengever.ogds.models.group import Group
 from opengever.ogds.models.org_unit import OrgUnit
 from opengever.ogds.models.team import Team
 from opengever.ogds.models.user import User
-from opengever.task.reminder import TASK_REMINDER_SAME_DAY
+from opengever.task.reminder import Reminder
+from opengever.task.reminder import ReminderSameDay
 from opengever.testing.builders.base import TEST_USER_ID
 from opengever.testing.helpers import localized_datetime
 from opengever.testing.model import TransparentModelLoader
@@ -808,10 +809,13 @@ class ReminderSettingsBuilder(SqlObjectBuilder):
     mapped_class = ReminderSetting
     id_argument_name = 'reminder_setting_id'
 
-    def for_object(self, obj, option=TASK_REMINDER_SAME_DAY):
+    def for_object(self, obj, option_type=ReminderSameDay.option_type, params=None):
+        if params is None:
+            params = {}
+        reminder = Reminder.create(option_type, params)
         self.arguments['task_id'] = obj.get_sql_object().task_id
-        self.arguments['option_type'] = option.option_type
-        self.arguments['remind_day'] = option.calculate_remind_on(obj.deadline)
+        self.arguments['option_type'] = reminder.option_type
+        self.arguments['remind_day'] = reminder.calculate_trigger_date(obj.deadline)
 
         return self
 


### PR DESCRIPTION
This implements a new reminder type that triggers on a specific, absolute date chosen by the user.

Before introducing this new type, I had to substantially refactor the existing implementation.

The refactoring consists mainly of these aspects:
- Changing the internal storage format in annotations, so it can accomodate parameters:

```
    Old format:
    {'john.doe': 'same_day'}

    New format:
    {'john.doe': {'option_type': 'on_date',
                  'params': {'date': '...'}}
```

- Introducing an [`IReminderStorage`](https://github.com/4teamwork/opengever.core/blob/lg-absolute-task-reminders/opengever/task/reminder/interfaces.py#L4-L39) adapter to abstract the storage
- Using [actual classes for expressing Reminder types](https://github.com/4teamwork/opengever.core/blob/lg-absolute-task-reminders/opengever/task/reminder/model.py#L128-L188), and instances of them to represent specific reminder instances including parameters. These classes also handle serialization/deserialization, both for internal storage, task transporter and REST API.
- Introducing an [`IReminderSupport`](https://github.com/4teamwork/opengever.core/blob/lg-absolute-task-reminders/opengever/task/reminder/interfaces.py#L42-L68) interface that encapsulates supporting methods, and moves them onto the task object
- Moving code that was unnecessarily close to SQL closer to the Plone task object, and killing dead code


After that, I could finally introduce the new reminder type `ReminderOnDate`.
It takes exactly one `date` parameter, and can be created as follows:

```http
       POST /task-1/@reminder HTTP/1.1
       Accept: application/json

       {
        "option_type": "on_date",
        "params": {
            "date": "2019-12-30"
           }
       }
```

Adresses #5468 

**Note**: It was requests that I also sneak in a `GET` implementation for the `@reminder` endpoint, so this is contained in the same PR.

## Checkliste

- [x] Wurde etwas an der `Aufgabe` angepasst? Funktioniert das auch mit einer `Weiterleitung`?
- [x] Profil angepasst? Sind UpgradeSteps vorhanden/nötig?:
- [x] Gibt es neue Übersetzungen?
  - [x] Sind alle msg-Strings in Übersetzungen Unicode?
  - [x] Wird die richtige i18n-domain verwendet (Copy-Paste Fehler sind hier häufig)?
- [x] Changelog-Eintrag vorhanden/nötig?
- [x] Aktualisierung Dokumentation vorhanden/nötig?
