### PR TITLE
Fix reassigning a task to the same user but a different org unit.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2019.4.0rc4 (unreleased)
 ------------------------
 
+- Fix a problem in the watcher handling when reassigning a task to the same user but a different org unit. [phgross]
 - Support the bundle-import of mails in the msg format. [phgross]
 
 

--- a/opengever/task/activities.py
+++ b/opengever/task/activities.py
@@ -164,8 +164,15 @@ class TaskReassignActivity(TaskTransitionActivity):
         to OLD_RESPONSIBLE.
         """
         change = ResponseDescription.get(response=self.response).get_change('responsible')
-        self.center.add_task_responsible(self.context, self.context.responsible)
 
+        # If the `responsible` is not part of the response changes, it means
+        # that the same responsible in another org unit has been selected. So
+        # there is no need to manipulate the watcher list, everything stays
+        # the same.
+        if not change:
+            return
+
+        self.center.add_task_responsible(self.context, self.context.responsible)
         self.center.remove_task_responsible(self.context, change.get('before'))
         self.center.add_watcher_to_resource(
             self.context, change.get('before'), TASK_OLD_RESPONSIBLE_ROLE)


### PR DESCRIPTION
There was a problem in the watcher handling when reassing a task to
the same user but a different org_unit. It tried to remove the watcher
for the former responsible, but thats also the new one, so now change necessary.

For #5963 

## Checkliste

_Zutreffendes soll angehakt stehengelassen werden._

- [x] Wurde etwas an der `Aufgabe` angepasst? Funktioniert das auch mit einer `Weiterleitung`?
- [x] Changelog-Eintrag vorhanden/nötig?