### PR TITLE
Use plone.restapi summary serialization in the recently-touched endpoint.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2019.4.0rc4 (unreleased)
 ------------------------
 
+- Use plone.restapi summary serialization in the recently-touched endpoint. [phgross]
 - Fix a problem in the watcher handling when reassigning a task to the same user but a different org unit. [phgross]
 - Support the bundle-import of mails in the msg format. [phgross]
 - Add API endpoints for user-setings and add additional setting seen_tours. [phgross]

--- a/docs/public/dev-manual/api/docs_changelog.rst
+++ b/docs/public/dev-manual/api/docs_changelog.rst
@@ -6,6 +6,12 @@ Changelog
 Im Folgenden sind (substantielle) Änderungen an der Dokumentation aufgeführt.
 
 
+2019-10-08
+----------
+
+- Kapitel "Kürzich bearbeitet" aktualisiert: Repräsentation hat sich verändert, unterstützt neu aber den Parameter ``metadata_fields``.
+
+
 2019-06-04
 ----------
 

--- a/docs/public/dev-manual/api/recently_touched.rst
+++ b/docs/public/dev-manual/api/recently_touched.rst
@@ -47,40 +47,47 @@ zwei separaten Listen:
         "checked_out": [
           {
             "icon_class": "icon-dokument_word is-checked-out-by-current-user",
+            "description": "Wichtige Dokumentation",
             "last_touched": "2018-05-31T15:40:23+02:00",
-            "target_url": "http://localhost:8080/fd/ordnungssystem/fuehrung/gemeinderecht/dossier-25/document-197",
+            "@id": "http://localhost:8080/fd/ordnungssystem/fuehrung/gemeinderecht/dossier-25/document-197",
+            "@type": "opengever.document.document",
             "title": "Datenschutzrichtlinien Muster AG",
-            "filename": "Datenschutzrichtlinien Muster AG.docx",
-            "checked_out": "peter.muster"
+            "review_state": "Datenschutzrichtlinien Muster AG.docx",
           },
           {
             "icon_class": "icon-dokument_excel is-checked-out-by-current-user",
+            "description": "",
             "last_touched": "2018-05-31T15:40:01+02:00",
-            "target_url": "http://localhost:8080/fd/ordnungssystem/fuehrung/gemeinderecht/dossier-25/document-191",
+            "@id": "http://localhost:8080/fd/ordnungssystem/fuehrung/gemeinderecht/dossier-25/document-191",
+            "@type": "opengever.document.document",
             "title": "Bilanz Muster AG 2018",
-            "filename": "Bilanz Muster AG 2018.xlsx",
-            "checked_out": "peter.muster"
+            "review_state": "Datenschutzrichtlinien Muster AG.docx",
           }
         ],
         "recently_touched": [
           {
             "icon_class": "icon-dokument_powerpoint is-checked-out",
+            "description": "",
             "last_touched": "2018-05-31T15:35:38+02:00",
-            "target_url": "http://localhost:8080/fd/ordnungssystem/fuehrung/gemeinderecht/dossier-18/document-229",
+            "@id": "http://localhost:8080/fd/ordnungssystem/fuehrung/gemeinderecht/dossier-18/document-229",
+            "@type": "opengever.document.document",
             "title": "Pra\u0308sentation - Firmenprofil Muster AG",
-            "filename": "Praesentation - Firmenprofil Muster AG.ppt",
-            "checked_out": "anderer.user"
+            "review_state": "Datenschutzrichtlinien Muster AG.docx",
           },
           {
             "...": ""
           },
           {
             "icon_class": "icon-dokument_word",
+            "description": "",
             "last_touched": "2018-05-31T15:34:42+02:00",
-            "target_url": "http://localhost:8080/fd/ordnungssystem/fuehrung/gemeinderecht/dossier-18/document-236",
+            "@id": "http://localhost:8080/fd/ordnungssystem/fuehrung/gemeinderecht/dossier-18/document-236",
+            "@type": "opengever.document.document",
             "title": "Anfrage Drei"
-            "filename": "Anfrage Drei.docx",
-            "checked_out": ""
+            "review_state": "Datenschutzrichtlinien Muster AG.docx",
           }
         ]
       }
+
+
+Die Repräsentation der Dokumente entspricht der :ref:`Summary Repräsentation von Inhalten <summaries>`, wie sie auch in anderen Feldern zum Einsatz kommt. Dabei wird auch der Parmater ``metadata_fields`` unterstützt, welches es erlaubt zusätzliche Felder abzufragen.

--- a/opengever/api/tests/test_recently_touched.py
+++ b/opengever/api/tests/test_recently_touched.py
@@ -39,13 +39,14 @@ class TestRecentlyModifiedGet(IntegrationTestCase, ResolveTestHelper):
             {'checked_out': [],
              'recently_touched': [{
                  'icon_class': 'icon-docx',
+                 'description': u'Wichtige Vertr\xe4ge',
                  # Because of an incorrect timezone handling in the freezer
                  # last_touched should be `2018-04-30T00:00:00+02:00`
-                 'last_touched': u'2018-04-30T02:00:00+02:00',
-                 'target_url': self.document.absolute_url(),
+                 'last_touched': '2018-04-30T02:00:00+02:00',
                  'title': u'Vertr\xe4gsentwurf',
-                 'filename': u'Vertraegsentwurf.docx',
-                 'checked_out': ''}]},
+                 'review_state': 'document-state-draft',
+                 '@id': self.document.absolute_url(),
+                 '@type': 'opengever.document.document'}]},
             browser.json)
 
     @browsing
@@ -67,11 +68,44 @@ class TestRecentlyModifiedGet(IntegrationTestCase, ResolveTestHelper):
         self.assertEquals(
             {'checked_out': [{
                 'icon_class': 'icon-docx is-checked-out-by-current-user',
+                'description': u'Wichtige Vertr\xe4ge',
                 'last_touched': '2018-04-30T00:00:00+02:00',
-                'target_url': self.document.absolute_url(),
                 'title': u'Vertr\xe4gsentwurf',
-                'filename': u'Vertraegsentwurf.docx',
-                'checked_out': self.regular_user.getId()}],
+                'review_state': 'document-state-draft',
+                '@id': self.document.absolute_url(),
+                '@type': 'opengever.document.document'}],
+             'recently_touched': []},
+            browser.json)
+
+    @browsing
+    def test_respects_metadata_fields_parameter(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        self._clear_recently_touched_log(self.regular_user.getId())
+
+        with freeze(datetime(2018, 4, 30)):
+            manager = queryMultiAdapter(
+                (self.document, self.request), ICheckinCheckoutManager)
+            manager.checkout()
+
+        url = '%s/@recently-touched/%s?metadata_fields:list=checked_out&metadata_fields:list=filename' % (
+            self.portal.absolute_url(), self.regular_user.getId())
+        browser.open(url, method='GET', headers={'Accept': 'application/json'})
+
+        self.assertEqual(200, browser.status_code)
+        self.assertEquals(
+            {'checked_out': [{
+                'icon_class': 'icon-docx is-checked-out-by-current-user',
+                'description': u'Wichtige Vertr\xe4ge',
+                'checked_out': self.regular_user.id,
+                'filename': 'Vertraegsentwurf.docx',
+                # Because of an incorrect timezone handling in the freezer
+                # last_touched should be `2018-04-30T00:00:00+02:00`
+                'last_touched': '2018-04-30T00:00:00+02:00',
+                'title': u'Vertr\xe4gsentwurf',
+                'review_state': 'document-state-draft',
+                '@id': self.document.absolute_url(),
+                '@type': 'opengever.document.document'}],
              'recently_touched': []},
             browser.json)
 
@@ -101,13 +135,14 @@ class TestRecentlyModifiedGet(IntegrationTestCase, ResolveTestHelper):
             {'checked_out': [],
              'recently_touched': [{
                  'icon_class': 'icon-docx is-checked-out',
+                 'description': u'Wichtige Vertr\xe4ge',
                  # Because of an incorrect timezone handling in the freezer
                  # last_touched should be `2018-04-30T00:00:00+02:00`
-                 'last_touched': u'2018-04-30T02:00:00+02:00',
-                 'target_url': self.document.absolute_url(),
+                 'last_touched': '2018-04-30T02:00:00+02:00',
                  'title': u'Vertr\xe4gsentwurf',
-                 'filename': u'Vertraegsentwurf.docx',
-                 'checked_out': self.secretariat_user.getId()}]},
+                 'review_state': 'document-state-draft',
+                 '@id': self.document.absolute_url(),
+                 '@type': 'opengever.document.document'}]},
             browser.json)
 
     @browsing
@@ -134,11 +169,12 @@ class TestRecentlyModifiedGet(IntegrationTestCase, ResolveTestHelper):
         self.assertEquals(
             {'checked_out': [{
                 'icon_class': 'icon-docx is-checked-out-by-current-user',
+                'description': u'Wichtige Vertr\xe4ge',
                 'last_touched': '2018-04-30T00:00:00+02:00',
-                'target_url': self.document.absolute_url(),
                 'title': u'Vertr\xe4gsentwurf',
-                'filename': u'Vertraegsentwurf.docx',
-                'checked_out': self.regular_user.getId()}],
+                'review_state': 'document-state-draft',
+                '@id': self.document.absolute_url(),
+                '@type': 'opengever.document.document'}],
              'recently_touched': []},
             browser.json)
 

--- a/opengever/base/viewlets/recently_touched_menu.html
+++ b/opengever/base/viewlets/recently_touched_menu.html
@@ -13,7 +13,7 @@
         <ul class="dropdown-list">
           <li><span class="dropdown-list-header">{{i18n.label_checked_out}}</span></li>
           <li v-for="entry in checkedOut">
-            <a class="dropdown-list-item" :href="entry.target_url">
+            <a class="dropdown-list-item" :href="entry['@id']">
               <i :class="entry.icon_class" class="dropdown-list-item-icon"></i>
               <span class="dropdown-list-item-content">{{entry.title}}</span>
               <span class="dropdown-list-item-suffix timeago relativetime" :title="entry.last_touched">{{entry.last_touched}}</span>
@@ -34,7 +34,7 @@
         <ul class="dropdown-list">
           <li><span class="dropdown-list-header">{{i18n.label_recently_touched}}</span></li>
           <li v-for="entry in recentlyTouched">
-            <a class="dropdown-list-item" :href="entry.target_url">
+            <a class="dropdown-list-item" :href="entry['@id']">
               <i :class="entry.icon_class" class="dropdown-list-item-icon"></i>
               <span class="dropdown-list-item-content">{{entry.title}}</span>
               <span class="dropdown-list-item-suffix timeago relativetime" :title="entry.last_touched">{{entry.last_touched}}</span>


### PR DESCRIPTION
So we support also the `metadata_fields` parameter which allows to
fetch additional metadata. For #5976 

Implementation details:
 - The summary representation is extended with the information `icon_class` and `last_touched` which are not supported by the summary and used for the existing UI
 - Breaking change: The attributes `filename` and `checked_out` are no longer part of the default representation. But with the `metadata_fields` parameter still accessible.

## Checkliste
- [x] Gibt es neue Funktionalität mit einem `Dokument`? Funktioniert das auch mit einem `Mail`?
- [x] Changelog-Eintrag vorhanden/nötig?
- [x] Aktualisierung Dokumentation vorhanden/nötig?
