### PR TITLE
Provide additional attributes in the API representation of documents and mails

### DIFF
--- a/opengever/api/document.py
+++ b/opengever/api/document.py
@@ -31,6 +31,18 @@ class SerializeDocumentToJson(GeverSerializeToJson):
             self.context, 'pdf')
         result[u'file_extension'] = self.context.get_file_extension()
 
+        additional_metadata = {
+            'checked_out': self.context.checked_out_by(),
+            'is_locked': self.context.is_locked(),
+            'containing_dossier': self.context.containing_dossier_title(),
+            'containing_subdossier': self.context.containing_subdossier_title(),
+            'trashed': self.context.is_trashed,
+            'is_shadow_document': self.context.is_shadow_document(),
+            'current_version_id': self.context.get_current_version_id(
+                missing_as_zero=True),
+        }
+
+        result.update(additional_metadata)
         return result
 
 

--- a/opengever/api/tests/test_document.py
+++ b/opengever/api/tests/test_document.py
@@ -48,6 +48,40 @@ class TestDocumentSerializer(IntegrationTestCase):
         self.assertEqual(browser.status_code, 200)
         self.assertEqual('.msg', browser.json.get(u'file_extension'))
 
+    @browsing
+    def test_contains_additional_metadata(self, browser):
+        self.login(self.regular_user, browser)
+
+        # The helpers used for the api are already tested, so no
+        # need to repeat these here.
+        self.checkout_document(self.subdocument)
+
+        browser.open(self.subdocument, headers={'Accept': 'application/json'})
+
+        self.assertEqual(self.regular_user.id, browser.json['checked_out'])
+        self.assertFalse(browser.json['is_locked'])
+        self.assertEqual(u'Vertr\xe4ge mit der kantonalen Finanzverwaltung',
+                         browser.json['containing_dossier'])
+        self.assertEqual(u'2016', browser.json['containing_subdossier'])
+        self.assertFalse(browser.json['trashed'])
+        self.assertFalse(browser.json['is_shadow_document'])
+        self.assertFalse(0, browser.json['current_version_id'])
+
+    @browsing
+    def test_additional_metadata_for_mails(self, browser):
+        self.login(self.regular_user, browser)
+
+        browser.open(self.mail_eml, headers={'Accept': 'application/json'})
+
+        self.assertIsNone(browser.json['checked_out'])
+        self.assertFalse(browser.json['is_locked'])
+        self.assertEqual(u'Vertr\xe4ge mit der kantonalen Finanzverwaltung',
+                         browser.json['containing_dossier'])
+        self.assertIsNone(browser.json['containing_subdossier'])
+        self.assertFalse(browser.json['trashed'])
+        self.assertFalse(browser.json['is_shadow_document'])
+        self.assertFalse(0, browser.json['current_version_id'])
+
 
 class TestDocumentPatch(IntegrationTestCase):
 

--- a/opengever/document/base.py
+++ b/opengever/document/base.py
@@ -12,6 +12,7 @@ from opengever.meeting.model.generateddocument import GeneratedExcerpt
 from opengever.meeting.proposal import IBaseProposal
 from opengever.meeting.proposal import ISubmittedProposal
 from opengever.task.task import ITask
+from opengever.trash.trash import ITrashed
 from plone import api
 from plone.dexterity.content import Item
 from Products.CMFCore.utils import getToolByName
@@ -106,6 +107,10 @@ class BaseDocumentMixin(object):
     @property
     def is_mail(self):
         return False
+
+    @property
+    def is_trashed(self):
+        return ITrashed.providedBy(self)
 
     def is_inside_a_proposal(self):
         parent = aq_parent(aq_inner(self))

--- a/opengever/document/base.py
+++ b/opengever/document/base.py
@@ -224,6 +224,17 @@ class BaseDocumentMixin(object):
         if dossier:
             return dossier.title
 
+    def containing_subdossier_title(self):
+        """"Returns the title of the subdossier which the document is placed in.
+        Returns None when the object is placed directly inside a main dossier.
+        """
+        dossier = self.get_parent_dossier()
+
+        # Return None if the dossier is a main dossier
+        if not IDossierMarker.providedBy(aq_parent(dossier)):
+            return None
+
+        return dossier.title
 
 def mimetype_lookup(mtr, contenttype):
     """Reimplemented as case insensitive from Products.MimetypesRegistry."""

--- a/opengever/document/base.py
+++ b/opengever/document/base.py
@@ -7,6 +7,7 @@ from opengever.dossier.behaviors.dossier import IDossierMarker
 from opengever.dossier.dossiertemplate.behaviors import IDossierTemplateMarker
 from opengever.dossier.interfaces import IDossierResolveProperties
 from opengever.dossier.templatefolder.interfaces import ITemplateFolder
+from opengever.dossier.utils import get_main_dossier
 from opengever.inbox.inbox import IInbox
 from opengever.meeting.model.generateddocument import GeneratedExcerpt
 from opengever.meeting.proposal import IBaseProposal
@@ -215,6 +216,13 @@ class BaseDocumentMixin(object):
             return False
 
         return self.get_file().contentType.lower() in black_listed_types
+
+    def containing_dossier_title(self):
+        """"Returns the title of the main dossier which the document is placed in.
+        """
+        dossier = get_main_dossier(self)
+        if dossier:
+            return dossier.title
 
 
 def mimetype_lookup(mtr, contenttype):

--- a/opengever/document/contentlisting.py
+++ b/opengever/document/contentlisting.py
@@ -19,7 +19,7 @@ class DocumentContentListingObject(RealContentListingObject):
 
     @property
     def is_trashed(self):
-        return ITrashed.providedBy(self._realobject)
+        return self._realobject.is_trashed
 
     @property
     def is_removed(self):

--- a/opengever/document/tests/test_base.py
+++ b/opengever/document/tests/test_base.py
@@ -32,6 +32,18 @@ class TestBaseDocument(IntegrationTestCase):
             u'Vertr\xe4ge mit der kantonalen Finanzverwaltung',
             self.sub_document.containing_dossier_title())
 
+    def test_containing_subdossier_title_returns_subdossier_title(self):
+        self.login(self.regular_user)
+
+        self.assertEqual(
+            u'2016',
+            self.subdocument.containing_subdossier_title())
+
+    def test_containing_subdossier_title_returns_None_for_document_inside_main_dossier(self):
+        self.login(self.regular_user)
+
+        self.assertIsNone(self.document.containing_subdossier_title())
+
 
 class TestBaseDocumentMails(TestBaseDocument):
 

--- a/opengever/document/tests/test_base.py
+++ b/opengever/document/tests/test_base.py
@@ -1,3 +1,6 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from opengever.mail.tests import MAIL_DATA
 from opengever.testing import IntegrationTestCase
 
 
@@ -7,6 +10,10 @@ class TestBaseDocument(IntegrationTestCase):
     def base_document(self):
         return self.document
 
+    @property
+    def sub_document(self):
+        return self.subdocument
+
     def test_is_trashed(self):
         self.login(self.regular_user)
         self.assertFalse(self.base_document.is_trashed)
@@ -14,9 +21,26 @@ class TestBaseDocument(IntegrationTestCase):
         self.trash_documents(self.base_document)
         self.assertTrue(self.base_document.is_trashed)
 
+    def test_containing_dossier_title_returns_main_dossier_title(self):
+        self.login(self.regular_user)
+
+        self.assertEqual(
+            u'Vertr\xe4ge mit der kantonalen Finanzverwaltung',
+            self.document.containing_dossier_title())
+
+        self.assertEqual(
+            u'Vertr\xe4ge mit der kantonalen Finanzverwaltung',
+            self.sub_document.containing_dossier_title())
+
 
 class TestBaseDocumentMails(TestBaseDocument):
 
     @property
     def base_document(self):
         return self.mail_eml
+
+    @property
+    def sub_document(self):
+        return create(Builder("mail")
+                      .with_message(MAIL_DATA)
+                      .within(self.subdossier))

--- a/opengever/document/tests/test_base.py
+++ b/opengever/document/tests/test_base.py
@@ -1,0 +1,22 @@
+from opengever.testing import IntegrationTestCase
+
+
+class TestBaseDocument(IntegrationTestCase):
+
+    @property
+    def base_document(self):
+        return self.document
+
+    def test_is_trashed(self):
+        self.login(self.regular_user)
+        self.assertFalse(self.base_document.is_trashed)
+
+        self.trash_documents(self.base_document)
+        self.assertTrue(self.base_document.is_trashed)
+
+
+class TestBaseDocumentMails(TestBaseDocument):
+
+    @property
+    def base_document(self):
+        return self.mail_eml


### PR DESCRIPTION
For #5905 

We also wondered during the Scrum meeting if it would make sense to namespace the additional attributes or use the `metadata_fields` behavior. I decided against it for the following reasons:
 - The document representation already contains "ready-only" metadata which is not part of a schema on the top level
 - Non schema keys are ignored by the restapi on Patch and Post requests
 - `metadata_fields` is currently not supported for the representation of a context

## Checkliste

_Zutreffendes soll angehakt stehengelassen werden._
- [x] Gibt es neue Funktionalität mit einem `Dokument`? Funktioniert das auch mit einem `Mail`?
- [x] Changelog-Eintrag vorhanden/nötig?
- [ ] Aktualisierung Dokumentation vorhanden/nötig? Nein, ich bin der Meinung das die zusätzlichen Werte nicht zusätzlich erwähnt werden müssen. 
