### PR TITLE
Allow text field in task deadline modification through API.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2019.4.0rc4 (unreleased)
 ------------------------
 
+- Allow text field in task deadline modification through API. [njohner]
 - Downpin ftw.recipe.solr to 1.2.1 to have log4j configuration valid for solr < 7.4.X [deiferni]
 - Use plone.restapi summary serialization in the recently-touched endpoint. [phgross]
 - Fix a problem in the watcher handling when reassigning a task to the same user but a different org unit. [phgross]

--- a/docs/public/dev-manual/api/tasks.rst
+++ b/docs/public/dev-manual/api/tasks.rst
@@ -135,22 +135,7 @@ Transition IDs:
 
 Zusätzliche Metadaten:
 
-   .. py:attribute:: responsibles
-
-       :Datentyp: ``List``
-       :Pflichtfeld: Ja :required:`(*)`
-
-   .. py:attribute:: title
-
-       :Datentyp: ``TextLine``
-       :Pflichtfeld: Ja :required:`(*)`
-
-   .. py:attribute:: issuer
-
-       :Datentyp: ``Choice``
-       :Pflichtfeld: Ja :required:`(*)`
-
-   .. py:attribute:: deadline
+   .. py:attribute:: new_deadline
 
        :Datentyp: ``Date``
        :Pflichtfeld: Ja :required:`(*)`

--- a/opengever/task/transition.py
+++ b/opengever/task/transition.py
@@ -188,7 +188,7 @@ class AcceptTransitionExtender(DefaultTransitionExtender):
 @adapter(ITask, IBrowserRequest)
 class ModifyDeadlineTransitionExtender(TransitionExtender):
 
-    schemas = [INewDeadline, ]
+    schemas = [IResponse, INewDeadline, ]
 
     def after_transition_hook(self, transition, disable_sync, transition_params):
         IDeadlineModifier(self.context).modify_deadline(


### PR DESCRIPTION
Text field was missing in the `ModifyDeadlineTransitionExtender`. There were also some errors in the documentation that I corrected.

## Checkliste

- [ ] Wurde etwas an der `Aufgabe` angepasst? Funktioniert das auch mit einer `Weiterleitung`? I think we cannot modify deadline of a forwarding
- [x] Changelog-Eintrag vorhanden/nötig?
- [x] Aktualisierung Dokumentation vorhanden/nötig?
