### PR TITLE
Add support for relative paths for views that take paths:list parameter

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,7 @@ Changelog
 - Allow text field in task deadline modification through API. [njohner]
 - Downpin ftw.recipe.solr to 1.2.1 to have log4j configuration valid for solr < 7.4.X [deiferni]
 - Use plone.restapi summary serialization in the recently-touched endpoint. [phgross]
+- dossier_report: Add support for pseudo-relative paths. [lgraf]
 - zip_selected view: Add support for pseudo-relative paths. [lgraf]
 - Fix a problem in the watcher handling when reassigning a task to the same user but a different org unit. [phgross]
 - Support the bundle-import of mails in the msg format. [phgross]

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,7 @@ Changelog
 - Allow text field in task deadline modification through API. [njohner]
 - Downpin ftw.recipe.solr to 1.2.1 to have log4j configuration valid for solr < 7.4.X [deiferni]
 - Use plone.restapi summary serialization in the recently-touched endpoint. [phgross]
+- zip_selected view: Add support for pseudo-relative paths. [lgraf]
 - Fix a problem in the watcher handling when reassigning a task to the same user but a different org unit. [phgross]
 - Support the bundle-import of mails in the msg format. [phgross]
 - Add API endpoints for user-setings and add additional setting seen_tours. [phgross]

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,7 @@ Changelog
 - Allow text field in task deadline modification through API. [njohner]
 - Downpin ftw.recipe.solr to 1.2.1 to have log4j configuration valid for solr < 7.4.X [deiferni]
 - Use plone.restapi summary serialization in the recently-touched endpoint. [phgross]
+- pdf-dossier-listing: Add support for pseudo-relative paths. [lgraf]
 - dossier_report: Add support for pseudo-relative paths. [lgraf]
 - zip_selected view: Add support for pseudo-relative paths. [lgraf]
 - Fix a problem in the watcher handling when reassigning a task to the same user but a different org unit. [phgross]

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,7 @@ Changelog
 - Allow text field in task deadline modification through API. [njohner]
 - Downpin ftw.recipe.solr to 1.2.1 to have log4j configuration valid for solr < 7.4.X [deiferni]
 - Use plone.restapi summary serialization in the recently-touched endpoint. [phgross]
+- document_report: Add support for pseudo-relative paths. [lgraf]
 - pdf-dossier-listing: Add support for pseudo-relative paths. [lgraf]
 - dossier_report: Add support for pseudo-relative paths. [lgraf]
 - zip_selected view: Add support for pseudo-relative paths. [lgraf]

--- a/opengever/base/browser/configure.zcml
+++ b/opengever/base/browser/configure.zcml
@@ -255,4 +255,12 @@
       layer="opengever.base.interfaces.IOpengeverBaseLayer"
       />
 
+  <browser:page
+      for="*"
+      name="zip_selected"
+      class=".zipexport.GEVERZipSelectedExportView"
+      permission="zope2.View"
+      layer="opengever.base.interfaces.IOpengeverBaseLayer"
+      />
+
 </configure>

--- a/opengever/base/browser/zipexport.py
+++ b/opengever/base/browser/zipexport.py
@@ -1,0 +1,11 @@
+from ftw.zipexport.browser.zipexportview import ZipSelectedExportView
+from opengever.base.utils import rewrite_path_list_to_absolute_paths
+
+
+class GEVERZipSelectedExportView(ZipSelectedExportView):
+
+    def __call__(self):
+        # XXX: Also make pseudo-relative paths work
+        # (as sent by the new gever-ui)
+        rewrite_path_list_to_absolute_paths(self.request)
+        return super(GEVERZipSelectedExportView, self).__call__()

--- a/opengever/base/tests/test_zipexport.py
+++ b/opengever/base/tests/test_zipexport.py
@@ -1,0 +1,37 @@
+from ftw.testbrowser import browsing
+from ftw.zipexport.zipfilestream import ZipFile
+from opengever.testing import IntegrationTestCase
+from StringIO import StringIO
+
+
+class TestZipExportView(IntegrationTestCase):
+
+    @browsing
+    def test_zip_selected_files(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        docs = [self.document, self.subdocument]
+        data = {'zip_selected:method': 1}
+        data.update(self.make_path_param(*docs))
+        # /plone/ordnungssystem/...
+
+        browser.open(self.dossier, data=data)
+
+        zipfile = ZipFile(StringIO(browser.contents), 'r')
+        self.assertEquals(
+            [doc.file.filename for doc in docs], zipfile.namelist())
+
+    @browsing
+    def test_zip_selected_files_with_pseudorelative_paths(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        docs = [self.document, self.subdocument]
+        data = {'zip_selected:method': 1}
+        data.update(self.make_pseudorelative_path_param(*docs))
+        # /ordnungssystem/...
+
+        browser.open(self.dossier, data=data)
+
+        zipfile = ZipFile(StringIO(browser.contents), 'r')
+        self.assertEquals(
+            [doc.file.filename for doc in docs], zipfile.namelist())

--- a/opengever/document/browser/report.py
+++ b/opengever/document/browser/report.py
@@ -3,6 +3,7 @@ from opengever.base.reporter import readable_author
 from opengever.base.reporter import readable_date
 from opengever.base.reporter import StringTranslater
 from opengever.base.reporter import XLSReporter
+from opengever.base.utils import rewrite_path_list_to_absolute_paths
 from opengever.document import _
 from Products.CMFCore.utils import getToolByName
 from Products.statusmessages.interfaces import IStatusMessage
@@ -68,6 +69,10 @@ class DocumentReporter(BaseReporterView):
                 'orig_template', self.context.absolute_url())
 
             return self.request.RESPONSE.redirect(return_temp)
+
+        # XXX: Also make pseudo-relative paths work
+        # (as sent by the new gever-ui)
+        rewrite_path_list_to_absolute_paths(self.request)
 
         documents = self.get_selected_documents()
         reporter = XLSReporter(self.request, self.columns(), documents)

--- a/opengever/document/tests/test_reporter.py
+++ b/opengever/document/tests/test_reporter.py
@@ -21,7 +21,51 @@ class TestDocumentReporter(IntegrationTestCase):
 
         browser.open(
             view='document_report',
+            # /plone/ordnungssystem/...
             data=self.make_path_param(self.document, self.mail_eml))
+
+        with NamedTemporaryFile(delete=False, suffix='.xlsx') as tmpfile:
+            tmpfile.write(browser.contents)
+            tmpfile.flush()
+            workbook = load_workbook(tmpfile.name)
+
+        # One title row and two data rows
+        self.assertEquals(3, len(list(workbook.active.rows)))
+
+        self.assertSequenceEqual(
+            [u'Client1 1.1 / 1 / 14',
+             14L,
+             u'Vertr\xe4gsentwurf',
+             u'test-user (test_user_1_)',
+             u'Jan 03, 2010',
+             u'Jan 03, 2010',
+             u'Jan 03, 2010',
+             None,
+             u'unchecked',
+             u'Vertr\xe4ge mit der kantonalen Finanzverwaltung'],
+            [cell.value for cell in list(workbook.active.rows)[1]])
+
+        self.assertSequenceEqual(
+            [u'Client1 1.1 / 1 / 29',
+             29L,
+             u'Die B\xfcrgschaft',
+             u'Freddy H\xf6lderlin <from@example.org>',
+             u'Jan 01, 1999',
+             u'Aug 31, 2016',
+             None,
+             None,
+             u'unchecked',
+             u'Vertr\xe4ge mit der kantonalen Finanzverwaltung'],
+            [cell.value for cell in list(workbook.active.rows)[2]])
+
+    @browsing
+    def test_document_report_with_pseudorelative_path(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        browser.open(
+            view='document_report',
+            # /ordnungssystem/...
+            data=self.make_pseudorelative_path_param(self.document, self.mail_eml))
 
         with NamedTemporaryFile(delete=False, suffix='.xlsx') as tmpfile:
             tmpfile.write(browser.contents)

--- a/opengever/dossier/browser/report.py
+++ b/opengever/dossier/browser/report.py
@@ -1,10 +1,11 @@
+from opengever.base.browser.reporting_view import BaseReporterView
 from opengever.base.reporter import DATE_NUMBER_FORMAT
 from opengever.base.reporter import readable_author
 from opengever.base.reporter import StringTranslater, XLSReporter
 from opengever.base.reporter import value
+from opengever.base.utils import rewrite_path_list_to_absolute_paths
 from opengever.dossier import _
 from Products.CMFCore.utils import getToolByName
-from opengever.base.browser.reporting_view import BaseReporterView
 from Products.statusmessages.interfaces import IStatusMessage
 
 
@@ -60,6 +61,10 @@ class DossierReporter(BaseReporterView):
                 'orig_template', self.context.absolute_url())
 
             return self.request.RESPONSE.redirect(return_temp)
+
+        # XXX: Also make pseudo-relative paths work
+        # (as sent by the new gever-ui)
+        rewrite_path_list_to_absolute_paths(self.request)
 
         dossiers = self.get_selected_dossiers()
 

--- a/opengever/latex/tests/test_latex_utils.py
+++ b/opengever/latex/tests/test_latex_utils.py
@@ -1,0 +1,31 @@
+from opengever.latex.utils import get_selected_items_from_catalog
+from opengever.testing import IntegrationTestCase
+
+
+class TestLatexUtils(IntegrationTestCase):
+
+    def test_get_selected_items_from_catalog(self):
+        self.login(self.regular_user)
+
+        docs = [self.document, self.subdocument]
+
+        # /plone/ordnungssystem
+        paths = self.make_path_param(*docs)['paths:list']
+        self.request['paths'] = paths
+
+        items = list(get_selected_items_from_catalog(self.portal, self.request))
+
+        self.assertItemsEqual(docs, [brain.getObject() for brain in items])
+
+    def test_get_selected_items_from_catalog_with_pseudorelative_paths(self):
+        self.login(self.regular_user)
+
+        docs = [self.document, self.subdocument]
+
+        # /ordnungssystem
+        paths = self.make_pseudorelative_path_param(*docs)['paths:list']
+        self.request['paths'] = paths
+
+        items = list(get_selected_items_from_catalog(self.portal, self.request))
+
+        self.assertItemsEqual(docs, [brain.getObject() for brain in items])

--- a/opengever/latex/utils.py
+++ b/opengever/latex/utils.py
@@ -3,12 +3,14 @@ from opengever.ogds.base.utils import ogds_service
 from Products.CMFCore.utils import getToolByName
 from zope.globalrequest import getRequest
 from zope.i18n import translate
+from opengever.base.utils import rewrite_path_list_to_absolute_paths
 
 
 def get_selected_items_from_catalog(context, request):
     """Returns a set of brains.
     """
 
+    rewrite_path_list_to_absolute_paths(request)
     paths = request.get('paths', None)
 
     if paths:

--- a/opengever/testing/integration_test_case.py
+++ b/opengever/testing/integration_test_case.py
@@ -669,8 +669,26 @@ class IntegrationTestCase(TestCase):
         return catalog.getIndexDataForRID(rid).get('allowedRolesAndUsers')
 
     def make_path_param(self, *objects):
+        """Build a paths:list request parameter, as expected by some views.
+        """
         return {
             'paths:list': ['/'.join(obj.getPhysicalPath()) for obj in objects]}
+
+    def make_pseudorelative_path_param(self, *objects):
+        """Build a paths:list request parameter with pseudo-relative paths.
+
+        Pseudo-relative in this context means that the paths don't start with
+        the Plone site (they are relative to it), but they still start with
+        a leading slash.
+
+        We get paths like this from the new gever-ui in some cases, that's
+        why some of our views need to also handle them.
+        """
+        def pseudo_relpath(obj):
+            return '/' + '/'.join(obj.getPhysicalPath()[2:])
+
+        return {
+            'paths:list': [pseudo_relpath(obj) for obj in objects]}
 
     @mutually_exclusive_parameters('response_file', 'response_json')
     @at_least_one_of('response_file', 'response_json')


### PR DESCRIPTION
This adds support for pseudo-relative paths for these four views that take `paths:list` parameters:

- `zip_selected` (Als Zip-Datei exportieren, Documents Tab)
- `document_report` (Auswahl exportieren, Documents Tab)
- `dossier_report` (Auswahl exportieren, Dossiers Tab)
- `pdf-dossier-listing` (Auswahl drucken, Dossiers Tab)

Pseudo-relative in this context means paths that don't start with the Plone site (so are relative to it), but still have a trailing slash).

This is required for these views because the new gever-ui sends paths that aren't prefixed with the Plone site.

Addresses #5974

## Checkliste

_Zutreffendes soll angehakt stehengelassen werden._

- [x] Changelog-Eintrag vorhanden/nötig?
