### PR TITLE
Make `issuer` filterable in the @lising endpoint.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 ------------------------
 
 - Allow text field in task deadline modification through API. [njohner]
+- Make `issuer` filterable in the @lising endpoint. [elioschmutz]
 - Downpin ftw.recipe.solr to 1.2.1 to have log4j configuration valid for solr < 7.4.X [deiferni]
 - Use plone.restapi summary serialization in the recently-touched endpoint. [phgross]
 - Fix a problem in the watcher handling when reassigning a task to the same user but a different org unit. [phgross]

--- a/docs/public/dev-manual/api/listings.rst
+++ b/docs/public/dev-manual/api/listings.rst
@@ -75,6 +75,7 @@ werden. Folgende Felder stehen zur Verfügung:
 - ``filesize``: Dateigrösse
 - ``has_sametype_children``: Ob es Objekte vom selben Inhaltstyp enthält.
 - ``issuer_fullname``: Auftraggeber (Anzeigename)
+- ``issuer``: Auftraggeber (Benutzername)
 - ``is_subdossier``: Ob das Dossier ein Subdossier ist.
 - ``is_sutask``: Ob die Aufgabe eine Unteraufgabe ist.
 - ``keywords``: Schlagwörter

--- a/opengever/api/listing.py
+++ b/opengever/api/listing.py
@@ -131,6 +131,7 @@ FIELDS = {
     'is_subdossier': ('is_subdossier', 'is_subdossier', 'is_subdossier'),
     'is_subtask': ('is_subtask', 'is_subtask', 'is_subtask'),
     'issuer_fullname': ('issuer', 'issuer_fullname', 'issuer'),
+    'issuer': ('issuer', 'issuer', 'issuer'),
     'keywords': ('Subject', 'Subject', 'Subject'),
     'mimetype': ('getContentType', 'getContentType', 'mimetype'),
     'modified': ('modified', 'modified', 'modified'),


### PR DESCRIPTION
This PR updates the listing-endpoint to support `issuer` as a filter parameter.

Issuer: https://github.com/4teamwork/gever-ui/pull/532

## Checkliste

- [x] Changelog-Eintrag vorhanden/nötig?
- [x] Aktualisierung Dokumentation vorhanden/nötig?
