### PR TITLE
Allow adding favorites by UID parameter via favorites endpoint.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 2019.4.0rc4 (unreleased)
 ------------------------
 
+- Allow adding favorites by UID parameter via favorites endpoint. [phgross]
+- Add UID to listing endpoints supported fields. [phgross]
+- Allow adding favorites with UID parameter via favorites endpoint. [phgross]
 - Bump ftw.keywordwidget version to fix missing titles on terms. [njohner]
 - Allow text field in task deadline modification through API. [njohner]
 - Make `issuer` filterable in the @lising endpoint. [elioschmutz]

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2019.4.0rc4 (unreleased)
 ------------------------
 
+- Add UID to listing endpoints supported fields. [phgross]
 - Allow adding favorites by UID parameter via favorites endpoint. [phgross]
 - Add UID to listing endpoints supported fields. [phgross]
 - Allow adding favorites with UID parameter via favorites endpoint. [phgross]

--- a/docs/public/dev-manual/api/favorite.rst
+++ b/docs/public/dev-manual/api/favorite.rst
@@ -54,7 +54,7 @@ Mittels eines GET Request können Favoriten des Benutzers abgefragt werden. Dabe
 
 Favorit hinzufügen:
 -------------------
-Ein Favorit für ein beliebiges Objekt kann mittels POST Request hinzugefügt werden. Dabei wird die Oguid des Objektes im Paramter ``oguid`` erwartet.
+Ein Favorit für ein beliebiges Objekt kann mittels POST Request hinzugefügt werden. Dabei wird die Oguid als ``oguid`` Parameter oder die UID als ``uid`` Parameter erwartet.
 
 
 **Beispiel-Request**:

--- a/docs/public/dev-manual/api/listings.rst
+++ b/docs/public/dev-manual/api/listings.rst
@@ -98,6 +98,7 @@ werden. Folgende Felder stehen zur Verfügung:
 - ``title``: Titel
 - ``type``: Inhaltstyp
 - ``@type``: Inhaltstyp
+- ``UID``: UID des Objektes
 
 Je nach Auflistungstyp und Inhalt sind bestimmte Felder nicht verfügbar. In diesem
 Fall wird der Wert ``none`` zurückgegeben. So haben Dossiers bspw. keinen Dateinamen,
@@ -194,6 +195,8 @@ siehe Tabelle:
     |``type``                  |    ja    |    ja   |      ja      |         ja         |   ja    |   ja    |
     +--------------------------+----------+---------+--------------+--------------------+---------+---------+
     |``@type``                 |    ja    |    ja   |      ja      |         ja         |   ja    |   ja    |
+    +--------------------------+----------+---------+--------------+--------------------+---------+---------+
+    |``UID``                   |    ja    |    ja   |      ja      |         ja         |   ja    |   ja    |
     +--------------------------+----------+---------+--------------+--------------------+---------+---------+
 
 

--- a/opengever/api/listing.py
+++ b/opengever/api/listing.py
@@ -153,6 +153,7 @@ FIELDS = {
     'title': ('Title', translated_title, 'sortable_title'),
     'type': ('portal_type', 'PortalType', 'portal_type'),
     '@type': ('portal_type', 'PortalType', 'portal_type'),
+    'UID': ('UID', 'UID', 'UID'),
 }
 
 DATE_INDEXES = set([

--- a/opengever/api/tests/test_listing.py
+++ b/opengever/api/tests/test_listing.py
@@ -28,6 +28,7 @@ class TestListingEndpoint(IntegrationTestCase):
             'columns=review_state',
             'columns=responsible_fullname',
             'columns=relative_path',
+            'columns=UID',
             'sort_on=created',
         ))
         view = '?'.join(('@listing', query_string))
@@ -37,6 +38,7 @@ class TestListingEndpoint(IntegrationTestCase):
             {u'review_state': u'dossier-state-active',
              u'responsible_fullname': u'Ziegler Robert',
              u'@id': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1',
+             u'UID': IUUID(self.dossier),
              u'reference': u'Client1 1.1 / 1',
              u'title': u'Vertr\xe4ge mit der kantonalen Finanzverwaltung',
              u'relative_path': u'ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1'},
@@ -54,6 +56,7 @@ class TestListingEndpoint(IntegrationTestCase):
             'columns=containing_dossier',
             'columns=bumblebee_checksum',
             'columns=relative_path',
+            'columns=UID',
             'sort_on=created',
         ))
         view = '?'.join(('@listing', query_string))
@@ -63,6 +66,7 @@ class TestListingEndpoint(IntegrationTestCase):
              u'title': u'Vertr\xe4gsentwurf',
              u'document_author': u'test_user_1_',
              u'@id': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/document-14',
+             u'UID': IUUID(self.document),
              u'modified': u'2016-08-31T14:07:33+00:00',
              u'containing_dossier': u'Vertr\xe4ge mit der kantonalen Finanzverwaltung',
              u'bumblebee_checksum': DOCX_CHECKSUM,
@@ -323,6 +327,7 @@ class TestListingEndpoint(IntegrationTestCase):
             'columns=completed',
             'columns=responsible_fullname',
             'columns=issuer_fullname',
+            'columns=UID',
             'columns=created',
             'columns=is_subtask',
         ))
@@ -344,6 +349,7 @@ class TestListingEndpoint(IntegrationTestCase):
              u'review_state_label': u'In Arbeit',
              u'title': u'Vertragsentwurf \xdcberpr\xfcfen',
              u'@id': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/task-1',
+             u'UID': IUUID(self.task),
              u'is_subtask': False},
             item)
 

--- a/opengever/api/tests/test_repository_favorites.py
+++ b/opengever/api/tests/test_repository_favorites.py
@@ -193,6 +193,7 @@ class TestRepositoryFavoritesPost(IntegrationTestCase):
              u'favorite_id': 1,
              u'icon_class': u'icon-docx',
              u'oguid': u'plone:1014073300',
+             u'uid': IUUID(self.document),
              u'portal_type': u'opengever.document.document',
              u'position': None,
              u'target_url': u'http://nohost/plone/resolve_oguid/plone:1014073300',

--- a/opengever/base/model/favorite.py
+++ b/opengever/base/model/favorite.py
@@ -58,6 +58,7 @@ class Favorite(Base):
             'portal_type': self.portal_type,
             'favorite_id': self.favorite_id,
             'oguid': self.oguid.id,
+            'uid': self.plone_uid,
             'title': self.title,
             'icon_class': self.icon_class,
             'target_url': self.get_target_url(),


### PR DESCRIPTION
The oguid parameter is still supported. In addition the `listing` endpoint now also supports the UID as a column.

Used for https://github.com/4teamwork/gever-ui/issues/490

_Zutreffendes soll angehakt stehengelassen werden._
- [x] Changelog-Eintrag vorhanden/nötig?
- [x] Aktualisierung Dokumentation vorhanden/nötig?
