### PR TITLE
Moved reminder options vocabulary to globaly registered vocabulary.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 ------------------------
 
 - Remove catalog support for @listing endpoint. [elioschmutz]
+- Moved reminder options vocabulary to globaly registered vocabulary. [phgross]
 - Add a user action to switch to the new gever-ui. [elioschmutz]
 
 

--- a/docs/public/dev-manual/api/reminder.rst
+++ b/docs/public/dev-manual/api/reminder.rst
@@ -28,6 +28,7 @@ Mit einem GET Request kann eine bestehende Erinnerung für den aktuellen Benutze
        {
         "@id": "http://example.onegovgever.ch/ordnungssystem/dossier-20/task-1/@reminder",
         "option_type": "one_day_before",
+        "option_title": "One day before deadline",
         "params": {}
        }
 

--- a/opengever/api/tests/test_reminder.py
+++ b/opengever/api/tests/test_reminder.py
@@ -32,6 +32,7 @@ class TestTaskReminderAPI(IntegrationTestCase):
         self.assertEqual(
             {u'@id': u'%s/@reminder' % self.task.absolute_url(),
              u'option_type': u'on_date',
+             u'option_title': u'On a specific date',
              u'params': {u'date': u'1995-06-29'}},
             browser.json)
 

--- a/opengever/api/tests/test_vocabularies.py
+++ b/opengever/api/tests/test_vocabularies.py
@@ -49,6 +49,7 @@ NON_SENSITIVE_VOCABUALRIES = [
     'opengever.repository.RestrictedAddableDossiersVocabulary',
     'opengever.task.bidirectional_by_reference',
     'opengever.task.bidirectional_by_value',
+    'opengever.task.reminder.TaskReminderOptionsVocabulary',
     'opengever.task.unidirectional_by_reference',
     'opengever.task.unidirectional_by_value',
     'opengever.tasktemplates.active_tasktemplatefolders',

--- a/opengever/task/reminder/configure.zcml
+++ b/opengever/task/reminder/configure.zcml
@@ -5,4 +5,9 @@
 
   <adapter factory=".storage.ReminderAnnotationStorage" />
 
+  <utility
+      factory=".vocabulary.TaskReminderOptionsVocabulary"
+      name="opengever.task.reminder.TaskReminderOptionsVocabulary"
+      />
+
 </configure>

--- a/opengever/task/reminder/model.py
+++ b/opengever/task/reminder/model.py
@@ -9,8 +9,6 @@ from zope.schema import getFields
 from zope.schema import ValidationError
 from zope.schema.interfaces import RequiredMissing
 from zope.schema.interfaces import WrongType
-from zope.schema.vocabulary import SimpleTerm
-from zope.schema.vocabulary import SimpleVocabulary
 
 
 class UnknownField(ValidationError):
@@ -199,13 +197,3 @@ REMINDER_TYPES = (
 REMINDER_TYPE_REGISTRY = {
     klass.option_type: klass for klass in REMINDER_TYPES
 }
-
-
-def get_task_reminder_options_vocabulary():
-    terms = []
-    options = REMINDER_TYPE_REGISTRY.values()
-    for option in sorted(options, key=lambda x: x.sort_order):
-        terms.append(SimpleTerm(
-            option.option_type, title=option.option_title))
-
-    return SimpleVocabulary(terms)

--- a/opengever/task/reminder/model.py
+++ b/opengever/task/reminder/model.py
@@ -3,6 +3,8 @@ from datetime import datetime
 from datetime import timedelta
 from opengever.task import _
 from plone.restapi.serializer.converters import json_compatible
+from zope.globalrequest import getRequest
+from zope.i18n import translate
 from zope.interface import Interface
 from zope.schema import Date
 from zope.schema import getFields
@@ -78,6 +80,7 @@ class Reminder(object):
         """
         data = {}
         data['option_type'] = self.option_type
+        data['option_title'] = translate(self.option_title, context=getRequest())
         data['params'] = deepcopy(self.params)
 
         if json_compat:

--- a/opengever/task/reminder/vocabulary.py
+++ b/opengever/task/reminder/vocabulary.py
@@ -1,0 +1,18 @@
+from zope.schema.vocabulary import SimpleTerm
+from zope.schema.interfaces import IVocabularyFactory
+from zope.interface import implementer
+from zope.schema.vocabulary import SimpleVocabulary
+from opengever.task.reminder.model import REMINDER_TYPE_REGISTRY
+
+
+@implementer(IVocabularyFactory)
+class TaskReminderOptionsVocabulary(object):
+
+    def __call__(self, context):
+        terms = []
+        options = REMINDER_TYPE_REGISTRY.values()
+        for option in sorted(options, key=lambda x: x.sort_order):
+            terms.append(SimpleTerm(
+                option.option_type, title=option.option_title))
+
+        return SimpleVocabulary(terms)

--- a/opengever/task/response.py
+++ b/opengever/task/response.py
@@ -13,7 +13,6 @@ from opengever.task.interfaces import ICommentResponseHandler
 from opengever.task.permissions import DEFAULT_ISSUE_MIME_TYPE
 from opengever.task.reminder import Reminder
 from opengever.task.reminder import ReminderOnDate
-from opengever.task.reminder.model import get_task_reminder_options_vocabulary
 from plone import api
 from plone.autoform.form import AutoExtensibleForm
 from plone.memoize.view import memoize
@@ -102,7 +101,7 @@ class ITaskTransitionResponseFormSchema(Interface):
         description=_("help_reminder",
                       default="Set a reminder to get notified based on "
                               "the duedate"),
-        source=get_task_reminder_options_vocabulary(),
+        source="opengever.task.reminder.TaskReminderOptionsVocabulary",
         required=False,
         defaultFactory=get_current_user_reminder
         )

--- a/opengever/task/tests/test_reminder.py
+++ b/opengever/task/tests/test_reminder.py
@@ -268,6 +268,7 @@ class TestTaskReminderTransport(IntegrationTestCase):
         self.assertEqual(
             {self.regular_user.id: {
                 'option_type': ReminderOneDayBefore.option_type,
+                'option_title': 'One day before deadline',
                 'params': {}}},
             collector.extract())
 
@@ -277,6 +278,7 @@ class TestTaskReminderTransport(IntegrationTestCase):
         self.assertEqual(
             {self.secretariat_user.id: {
                 'option_type': ReminderOneDayBefore.option_type,
+                'option_title': 'One day before deadline',
                 'params': {}}},
             collector.extract())
 

--- a/opengever/task/tests/test_reminder_model.py
+++ b/opengever/task/tests/test_reminder_model.py
@@ -36,23 +36,32 @@ class TestTaskReminderTypes(IntegrationTestCase):
 
     def test_reminders_can_be_serialized(self):
         self.assertEqual(
-            {'option_type': 'same_day', 'params': {}},
+            {'option_type': 'same_day',
+             'option_title': 'At the morging of the deadline',
+             'params': {}},
             ReminderSameDay().serialize())
 
         self.assertEqual(
-            {'option_type': 'one_day_before', 'params': {}},
+            {'option_type': 'one_day_before',
+             'option_title': 'One day before deadline',
+             'params': {}},
             ReminderOneDayBefore().serialize())
 
         self.assertEqual(
-            {'option_type': 'one_week_before', 'params': {}},
+            {'option_type': 'one_week_before',
+             'option_title': 'One week before deadline',
+             'params': {}},
             ReminderOneWeekBefore().serialize())
 
         self.assertEqual(
-            {'option_type': 'beginning_of_week', 'params': {}},
+            {'option_type': 'beginning_of_week',
+             'option_title': 'At the beginning of the week of the deadline',
+             'params': {}},
             ReminderBeginningOfWeek().serialize())
 
         self.assertEqual(
             {'option_type': 'on_date',
+             'option_title': 'On a specific date',
              'params': {'date': date(2018, 12, 30)}},
             ReminderOnDate({'date': date(2018, 12, 30)}).serialize())
 

--- a/opengever/task/tests/test_reminder_storage.py
+++ b/opengever/task/tests/test_reminder_storage.py
@@ -22,7 +22,10 @@ class TestTaskReminderStorage(IntegrationTestCase):
         self.storage.set(ReminderSameDay())
 
         self.assertEqual({
-            self.regular_user.id: {'option_type': 'same_day', 'params': {}}},
+            self.regular_user.id: {
+                'option_type': 'same_day',
+                'option_title': 'At the morging of the deadline',
+                'params': {}}},
             self.storage._annotation_storage())
 
     def test_storage_set_for_other_user(self):
@@ -31,8 +34,11 @@ class TestTaskReminderStorage(IntegrationTestCase):
                          user_id=self.dossier_responsible.id)
 
         self.assertEqual({
-            self.dossier_responsible.id: {'option_type': 'same_day', 'params': {}}},
-            self.storage._annotation_storage())
+            self.dossier_responsible.id: {
+                'option_type': 'same_day',
+                'option_title': 'At the morging of the deadline',
+                'params': {}}
+        }, self.storage._annotation_storage())
 
     def test_storage_set_rejects_invalid_option_type(self):
         self.login(self.regular_user)


### PR DESCRIPTION
Also return the option_title in the reminder API serialization, so we can display the translated title in the frontend.

for #5971 

## Checkliste

_Zutreffendes soll angehakt stehengelassen werden._
- [x] Changelog-Eintrag vorhanden/nötig?
- [x] Aktualisierung Dokumentation vorhanden/nötig?
