### PR TITLE
Preserve query string in the resolve notification view.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -10,6 +10,7 @@ Changelog
 2019.4.0rc4 (2019-10-22)
 ------------------------
 
+- Preserve query string in the resolve notification view. [phgross]
 - Add UID to listing endpoints supported fields. [phgross]
 - Allow adding favorites by UID parameter via favorites endpoint. [phgross]
 - Add UID to listing endpoints supported fields. [phgross]

--- a/opengever/activity/browser/resolve.py
+++ b/opengever/activity/browser/resolve.py
@@ -8,6 +8,8 @@ from zExceptions import Unauthorized
 
 class ResolveNotificationView(ResolveOGUIDView):
 
+    key_to_strip = 'notification_id'
+
     def __call__(self):
         notification_id = self.request.get('notification_id', '')
         center = notification_center()
@@ -48,4 +50,4 @@ class ResolveNotificationView(ResolveOGUIDView):
             admin_unit = ogds_service().fetch_admin_unit(oguid.admin_unit_id)
             url = ResolveOGUIDView.url_for(oguid, admin_unit)
 
-        return self.request.RESPONSE.redirect(url)
+        return self.request.RESPONSE.redirect(self.preserve_query_string(url))

--- a/opengever/activity/tests/test_resolve.py
+++ b/opengever/activity/tests/test_resolve.py
@@ -87,3 +87,13 @@ class TestResolveNotificationView(IntegrationTestCase):
         self.login(self.regular_user, browser)
         browser.open(self.portal, view='resolve_notification', data={'notification_id': self.notification.notification_id})
         self.assertEquals(self.task.absolute_url(), browser.url)
+
+    @browsing
+    def test_preserves_query_string_in_remote_url(self, browser):
+        self.login(self.regular_user, browser)
+        url = '{}/resolve_notification?notification_id={}&foo=bar'.format(
+            self.portal.absolute_url(), self.notification.notification_id)
+        browser.open(url)
+
+        self.assertEquals('{}?foo=bar'.format(self.task.absolute_url()),
+                          browser.url)

--- a/opengever/document/tests/test_copy_document.py
+++ b/opengever/document/tests/test_copy_document.py
@@ -6,6 +6,7 @@ from ftw.testing import freeze
 from OFS.CopySupport import CopyError
 from opengever.testing import IntegrationTestCase
 from plone import api
+from tzlocal import get_localzone
 import pytz
 
 
@@ -13,8 +14,6 @@ class TestCopyDocuments(IntegrationTestCase):
 
     COPY_TIME = datetime(2018, 4, 28, 0, 0, tzinfo=pytz.UTC)
     PASTE_TIME = datetime(2018, 4, 30, 0, 0, tzinfo=pytz.UTC)
-    ZOPE_PASTE_TIME = DateTime(PASTE_TIME).toZone(DateTime().localZone())
-    ZOPE_PASTE_TIME_STR = '2018-04-30T02:00:00+02:00'
 
     def test_copying_a_document_prefixes_title_with_copy_of(self):
         self.login(self.regular_user)
@@ -65,6 +64,8 @@ class TestCopyDocuments(IntegrationTestCase):
             browser.open(self.empty_dossier, view="copy_items", data=data)
 
         with freeze(self.PASTE_TIME):
+            ZOPE_PASTE_TIME = DateTime()
+
             with self.observe_children(self.empty_dossier) as children:
                 browser.css('#contentActionMenus a#paste').first.click()
 
@@ -73,6 +74,8 @@ class TestCopyDocuments(IntegrationTestCase):
 
         original_metadata = self.get_catalog_metadata(self.subdocument)
         copy_metadata = self.get_catalog_metadata(copy)
+
+        ZOPE_PASTE_TIME_STR = ZOPE_PASTE_TIME.toZone(DateTime().localZone()).ISO()
 
         # We expect some of the metadata to get modified during pasting
         modified_metadata = {'UID': copy.UID(),
@@ -85,12 +88,12 @@ class TestCopyDocuments(IntegrationTestCase):
                              'listCreators': (self.regular_user.id,),
                              'Creator': self.regular_user.id,
                              # dates
-                             'created': self.ZOPE_PASTE_TIME,
-                             'CreationDate': self.ZOPE_PASTE_TIME_STR,
+                             'created': ZOPE_PASTE_TIME,
+                             'CreationDate': ZOPE_PASTE_TIME_STR,
                              'start': self.PASTE_TIME.date(),
-                             'modified': self.ZOPE_PASTE_TIME,
-                             'ModificationDate': self.ZOPE_PASTE_TIME_STR,
-                             'Date': self.ZOPE_PASTE_TIME_STR,
+                             'modified': ZOPE_PASTE_TIME,
+                             'ModificationDate': ZOPE_PASTE_TIME_STR,
+                             'Date': ZOPE_PASTE_TIME_STR,
                              'changed': self.PASTE_TIME,
                              # containing dossier and subdossier
                              'containing_dossier': self.empty_dossier.Title(),


### PR DESCRIPTION
Use functionality from the base class (the resolveoguid class), so there is no need to test any possible case, because it's already done in the TestResolveOGUIDView class.

Closes #5773 

## Checkliste
- [ ] Changelog-Eintrag vorhanden/nötig?
