### PR TITLE
Cast the userid to bytestring so that validation to ASCIILine passes

### DIFF
--- a/opengever/webactions/storage.py
+++ b/opengever/webactions/storage.py
@@ -92,7 +92,9 @@ class WebActionsStorage(object):
         new_action = PersistentMapping(action_data)
         self._actions[action_id] = new_action
 
-        userid = api.user.get_current().getId()
+        # This is a workaround: the returned userid is of type unicode. As the "owner" field is of type ASCIILine, it is
+        # simply casted to a bytestring.
+        userid = str(api.user.get_current().getId())
         now = datetime.now()
 
         # The `action_id` is stored redundantly here in the actual


### PR DESCRIPTION
In some test cases, a unicode string is returned which raises an error when patching webactions with valid data due to invalid, but generated unicode data for the owner field.

This is a quick, but not complete fix so that the RIS team can finish implementing changes. Changelog entry, tests and more may follow depending on how the GEVER team decieds to approach this issue.

Relates to  #6011 (but does not close it).