### PR TITLE
Extend dossier serializer with `is_subdossier`.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 ------------------------
 
 - Update Products.LDAPUserFolder from 2.28.post2 to 2.28.post3. [elioschmutz]
+- Extend dossier serializer with `is_subdossier`. [elioschmutz]
 - Remove catalog support for @listing endpoint. [elioschmutz]
 - Moved reminder options vocabulary to globaly registered vocabulary. [phgross]
 - Add a user action to switch to the new gever-ui. [elioschmutz]

--- a/opengever/api/dossier.py
+++ b/opengever/api/dossier.py
@@ -19,5 +19,6 @@ class SerializeDossierToJson(GeverSerializeFolderToJson):
         result[u'reference_number'] = self.context.get_reference_number()
         result[u'email'] = IEmailAddress(self.request).get_email_for_object(
             self.context)
+        result[u'is_subdossier'] = self.context.is_subdossier()
 
         return result

--- a/opengever/api/tests/test_serializer.py
+++ b/opengever/api/tests/test_serializer.py
@@ -15,24 +15,21 @@ class TestRepositoryFolderSerializer(IntegrationTestCase):
     @browsing
     def test_repofolder_serialization_contains_reference_number(self, browser):
         self.login(self.regular_user, browser)
-        browser.open(
-            self.leaf_repofolder, headers={'Accept': 'application/json'})
+        browser.open(self.leaf_repofolder, headers=self.api_headers)
         self.assertEqual(browser.status_code, 200)
         self.assertEqual(browser.json.get(u'reference_number'), u'Client1 1.1')
 
     @browsing
     def test_repofolder_serialization_contains_is_leafnode(self, browser):
         self.login(self.regular_user, browser)
-        browser.open(
-            self.leaf_repofolder, headers={'Accept': 'application/json'})
+        browser.open(self.leaf_repofolder, headers=self.api_headers)
         self.assertEqual(browser.status_code, 200)
         self.assertEqual(browser.json.get(u'is_leafnode'), True)
 
     @browsing
     def test_repofolder_serialization_contains_relative_path(self, browser):
         self.login(self.regular_user, browser)
-        browser.open(
-            self.leaf_repofolder, headers={'Accept': 'application/json'})
+        browser.open(self.leaf_repofolder, headers=self.api_headers)
         self.assertEqual(browser.status_code, 200)
         self.assertEqual(
             browser.json.get(u'relative_path'),
@@ -49,21 +46,21 @@ class TestDossierSerializer(IntegrationTestCase):
     @browsing
     def test_dossier_serialization_contains_reference_number(self, browser):
         self.login(self.regular_user, browser)
-        browser.open(self.dossier, headers={'Accept': 'application/json'})
+        browser.open(self.dossier, headers=self.api_headers)
         self.assertEqual(browser.status_code, 200)
         self.assertEqual(browser.json.get(u'reference_number'), u'Client1 1.1 / 1')
 
     @browsing
     def test_dossier_serialization_contains_email(self, browser):
         self.login(self.regular_user, browser)
-        browser.open(self.dossier, headers={'Accept': 'application/json'})
+        browser.open(self.dossier, headers=self.api_headers)
         self.assertEqual(browser.status_code, 200)
         self.assertEqual(browser.json.get(u'email'), u'1014013300@example.org')
 
     @browsing
     def test_dossier_serialization_contains_responsible_fullname(self, browser):
         self.login(self.regular_user, browser)
-        browser.open(self.dossier, headers={'Accept': 'application/json'})
+        browser.open(self.dossier, headers=self.api_headers)
         self.assertEqual(browser.status_code, 200)
         self.assertEqual(
             browser.json.get(u'responsible_fullname'), u'Ziegler Robert')
@@ -71,7 +68,7 @@ class TestDossierSerializer(IntegrationTestCase):
     @browsing
     def test_dossier_serialization_contains_relative_path(self, browser):
         self.login(self.regular_user, browser)
-        browser.open(self.dossier, headers={'Accept': 'application/json'})
+        browser.open(self.dossier, headers=self.api_headers)
         self.assertEqual(browser.status_code, 200)
         self.assertEqual(
             browser.json.get(u'relative_path'),
@@ -80,13 +77,13 @@ class TestDossierSerializer(IntegrationTestCase):
     @browsing
     def test_dossier_serialization_contains_is_subdossier(self, browser):
         self.login(self.regular_user, browser)
-        browser.open(self.dossier, headers={'Accept': 'application/json'})
+        browser.open(self.dossier, headers=self.api_headers)
         self.assertEqual(browser.status_code, 200)
         self.assertEqual(
             browser.json.get(u'is_subdossier'),
             False)
 
-        browser.open(self.subdossier, headers={'Accept': 'application/json'})
+        browser.open(self.subdossier, headers=self.api_headers)
         self.assertEqual(browser.status_code, 200)
         self.assertEqual(
             browser.json.get(u'is_subdossier'),
@@ -103,21 +100,21 @@ class TestDocumentSerializer(IntegrationTestCase):
     @browsing
     def test_document_serialization_contains_reference_number(self, browser):
         self.login(self.regular_user, browser)
-        browser.open(self.document, headers={'Accept': 'application/json'})
+        browser.open(self.document, headers=self.api_headers)
         self.assertEqual(browser.status_code, 200)
         self.assertEqual(browser.json.get(u'reference_number'), u'Client1 1.1 / 1 / 14')
 
     @browsing
     def test_document_serialization_contains_bumblebee_checksum(self, browser):
         self.login(self.regular_user, browser)
-        browser.open(self.document, headers={'Accept': 'application/json'})
+        browser.open(self.document, headers=self.api_headers)
         self.assertEqual(browser.status_code, 200)
         self.assertEqual(browser.json.get(u'bumblebee_checksum'), DOCX_CHECKSUM)
 
     @browsing
     def test_document_serialization_contains_relative_path(self, browser):
         self.login(self.regular_user, browser)
-        browser.open(self.document, headers={'Accept': 'application/json'})
+        browser.open(self.document, headers=self.api_headers)
         self.assertEqual(browser.status_code, 200)
         self.assertEqual(
             browser.json.get(u'relative_path'),
@@ -127,14 +124,14 @@ class TestDocumentSerializer(IntegrationTestCase):
     @browsing
     def test_mail_serialization_contains_reference_number(self, browser):
         self.login(self.regular_user, browser)
-        browser.open(self.mail_eml, headers={'Accept': 'application/json'})
+        browser.open(self.mail_eml, headers=self.api_headers)
         self.assertEqual(200, browser.status_code)
         self.assertEqual(u'Client1 1.1 / 1 / 29', browser.json.get(u'reference_number'))
 
     @browsing
     def test_mail_serialization_contains_bumblebee_checksum(self, browser):
         self.login(self.regular_user, browser)
-        browser.open(self.mail_eml, headers={'Accept': 'application/json'})
+        browser.open(self.mail_eml, headers=self.api_headers)
         self.assertEqual(browser.status_code, 200)
 
         checksum = IBumblebeeDocument(self.mail_eml).get_checksum()
@@ -143,7 +140,7 @@ class TestDocumentSerializer(IntegrationTestCase):
     @browsing
     def test_mail_serialization_contains_relative_path(self, browser):
         self.login(self.regular_user, browser)
-        browser.open(self.mail_eml, headers={'Accept': 'application/json'})
+        browser.open(self.mail_eml, headers=self.api_headers)
         self.assertEqual(browser.status_code, 200)
         self.assertEqual(
             browser.json.get(u'relative_path'),

--- a/opengever/api/tests/test_serializer.py
+++ b/opengever/api/tests/test_serializer.py
@@ -77,6 +77,21 @@ class TestDossierSerializer(IntegrationTestCase):
             browser.json.get(u'relative_path'),
             u'ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1')
 
+    @browsing
+    def test_dossier_serialization_contains_is_subdossier(self, browser):
+        self.login(self.regular_user, browser)
+        browser.open(self.dossier, headers={'Accept': 'application/json'})
+        self.assertEqual(browser.status_code, 200)
+        self.assertEqual(
+            browser.json.get(u'is_subdossier'),
+            False)
+
+        browser.open(self.subdossier, headers={'Accept': 'application/json'})
+        self.assertEqual(browser.status_code, 200)
+        self.assertEqual(
+            browser.json.get(u'is_subdossier'),
+            True)
+
 
 class TestDocumentSerializer(IntegrationTestCase):
 


### PR DESCRIPTION
This PR extends the dossier serializer with `is_subdossier`.

This is required for the frontend-pr: https://github.com/4teamwork/gever-ui/pull/650

Issuer: https://github.com/4teamwork/gever-ui/issues/515

## Checkliste
- [x] Changelog-Eintrag vorhanden/nötig?
