### PR TITLE
Update the usersettings-serializer: A manager has always seen all scr…

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2019.4.0rc5 (unreleased)
 ------------------------
 
+- Update the usersettings-serializer: A pure plone user has always seen all screens. [elioschmutz]
 - Update Products.LDAPUserFolder from 2.28.post2 to 2.28.post3. [elioschmutz]
 - Extend dossier serializer with `is_subdossier`. [elioschmutz]
 - Add @globalindex API endpoint. [phgross]

--- a/opengever/api/tests/test_user_settings.py
+++ b/opengever/api/tests/test_user_settings.py
@@ -40,6 +40,23 @@ class TestUsersSettingsGet(IntegrationTestCase):
              u'notify_own_actions': True},
             browser.json)
 
+    @browsing
+    def test_a_pure_plone_user_has_always_seen_all_tours(self, browser):
+        # Ogds-user user has no seen tours by default
+        self.login(self.regular_user, browser)
+        self.assertIsNotNone(self.get_ogds_user(self.regular_user))
+        browser.open('{}/@user-settings'.format(self.portal.absolute_url()),
+                     headers=self.api_headers)
+        self.assertEquals([], browser.json.get('seen_tours'))
+
+        # Pure plone user has all tours seen by default
+        self.login(self.manager, browser)
+        self.assertIsNone(self.get_ogds_user(self.manager))
+
+        browser.open('{}/@user-settings'.format(self.portal.absolute_url()),
+                     headers=self.api_headers)
+        self.assertEquals([u'*'], browser.json.get('seen_tours'))
+
 
 class TestUsersSettingsPatch(IntegrationTestCase):
 


### PR DESCRIPTION
Issue: https://github.com/4teamwork/gever-ui/issues/594
Required for frontend issue: https://github.com/4teamwork/gever-ui/pull/655

The `user_settings` provides the seen tours of a user. But pure Plone-Users (like the `zopemaster`) are not stored in the OGDS and the usersettings are based on users in the OGDS.

So we're not able to store seen tours for pure plone users. A pure plone user would always see every available tour on the frontend.

To fix this issue, this PR extends the user_settings serializer to mark all tours as seen if we call it as a pure plone user.

## Checkliste
- [x] Changelog-Eintrag vorhanden/nötig?
