### PR TITLE
Fix an issue with ids not being stored as bytestring when reordering.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,7 @@ Changelog
 - Bump plone.restapi to 5.0.3 to get fix for filtering vocabs by non-ASCII titles. [lgraf]
 - Update the usersettings-serializer: A pure plone user has always seen all screens. [elioschmutz]
 - Support combined notation for task responsible. [phgross]
+- Fix an issue with todo(-list) ids not being stored as bytestring. [deiferni]
 - Update Products.LDAPUserFolder from 2.28.post2 to 2.28.post3. [elioschmutz]
 - Extend dossier serializer with `is_subdossier`. [elioschmutz]
 - Add @globalindex API endpoint. [phgross]

--- a/opengever/base/monkey/patches/__init__.py
+++ b/opengever/base/monkey/patches/__init__.py
@@ -25,6 +25,7 @@ from .tz_for_log import PatchZ2LogTimezone
 from .verify_object_paste import PatchCopyContainerVerifyObjectPaste
 from .webdav_lock_timeout import PatchWebDAVLockTimeout
 from .workflowtool import PatchWorkflowTool
+from .plone_restapi import PatchPloneRestAPIOrdering
 
 
 PatchBaseOrderedViewletManagerExceptions()()
@@ -54,3 +55,4 @@ PatchCMFCatalogAwareHandlers()()
 ScrubBoboExceptions()()
 PatchExceptionFormatter()()
 PatchWorkflowTool()()
+PatchPloneRestAPIOrdering()()

--- a/opengever/base/monkey/patches/plone_restapi.py
+++ b/opengever/base/monkey/patches/plone_restapi.py
@@ -1,0 +1,29 @@
+from opengever.base.monkey.patching import MonkeyPatch
+
+
+def safe_utf8(to_utf8):
+    if isinstance(to_utf8, unicode):
+        to_utf8 = to_utf8.encode('utf-8')
+    return to_utf8
+
+
+class PatchPloneRestAPIOrdering(MonkeyPatch):
+    """Temporary patch for ordering stored as unicode instead of bytestring in
+    plone.restapi. Can go away as soon as we have a plone.restapi with
+    https://github.com/plone/plone.restapi/pull/828.
+    """
+
+    def __call__(self):
+        from plone.restapi.deserializer.mixins import OrderingMixin
+
+        def reorderItems(self, obj_id, delta, subset_ids):
+            """Encode any unicode-ids as ascii to prevent mixed type ids."""
+            obj_id = safe_utf8(obj_id)
+            if subset_ids:
+                subset_ids = [safe_utf8(id_) for id_ in subset_ids]
+
+            return original_reorderItems(self, obj_id, delta, subset_ids)
+
+        locals()['__patch_refs__'] = False
+        original_reorderItems = OrderingMixin.reorderItems
+        self.patch_refs(OrderingMixin, 'reorderItems', reorderItems)

--- a/opengever/core/upgrades/20191031155315_fix_todo_and_todolist_ordering_object_id_type/upgrade.py
+++ b/opengever/core/upgrades/20191031155315_fix_todo_and_todolist_ordering_object_id_type/upgrade.py
@@ -1,0 +1,36 @@
+from ftw.upgrade import UpgradeStep
+from persistent.list import PersistentList
+from zope.annotation.interfaces import IAnnotations
+
+
+ORDER_KEY = 'plone.folder.ordered.order'
+
+
+def safe_utf8(to_utf8):
+    if isinstance(to_utf8, unicode):
+        to_utf8 = to_utf8.encode('utf-8')
+    return to_utf8
+
+
+class FixTodoAndTodolistOrderingObjectIdType(UpgradeStep):
+    """Fix todo and todolist ordering object id type.
+
+    The id is persisted in an object's parent so we query for all types that
+    may contain todo and todolist.
+    """
+    def __call__(self):
+        for obj in self.objects(
+                {'portal_type': ['opengever.workspace.todolist',
+                                 'opengever.workspace.workspace']},
+                'Fix todo and todolist ordering id.'):
+
+            self.ensure_ordering_object_ids_are_utf8(obj)
+
+    def ensure_ordering_object_ids_are_utf8(self, obj):
+        annotations = IAnnotations(obj)
+        if ORDER_KEY not in annotations:
+            return
+
+        fixed_ordering = PersistentList(
+            safe_utf8(item_id) for item_id in annotations[ORDER_KEY])
+        annotations[ORDER_KEY] = fixed_ordering

--- a/opengever/meeting/browser/meetingtemplate.py
+++ b/opengever/meeting/browser/meetingtemplate.py
@@ -23,7 +23,7 @@ class UpdateMeetingTemplateContentOrderView(BrowserView):
 
         for object_id in order:
             # OFS IDs are ascii only, json strings are loaded as unicode
-            object_id = object_id.encode('ascii')
+            object_id = object_id.encode('utf-8')
             self.context.moveObjectsToTop([object_id])
 
         return self.request.RESPONSE.redirect(self.context.absolute_url())

--- a/opengever/workspace/tests/test_todolist.py
+++ b/opengever/workspace/tests/test_todolist.py
@@ -146,8 +146,8 @@ class TestAPISupportForTodoLists(IntegrationTestCase):
                .within(self.workspace))
 
         self.assertEqual(
-            ['folder-1', u'todolist-1', u'todolist-2',
-             'todo-1', u'todolist-3', u'todolist-4'],
+            ['folder-1', 'todolist-1', 'todolist-2',
+             'todo-1', 'todolist-3', 'todolist-4'],
             self.workspace.objectIds())
 
         # change order
@@ -161,9 +161,12 @@ class TestAPISupportForTodoLists(IntegrationTestCase):
                      headers=self.api_headers, data=json.dumps(data))
 
         self.assertEqual(
-            ['folder-1', u'todolist-2', u'todolist-3',
-             'todo-1', u'todolist-1', u'todolist-4'],
+            ['folder-1', 'todolist-2', 'todolist-3',
+             'todo-1', 'todolist-1', 'todolist-4'],
             self.workspace.objectIds())
+
+        for id_ in self.workspace.objectIds():
+            self.assertIsInstance(id_, str)
 
     @browsing
     def test_only_order_change_is_allowed_for_workspace_member(self, browser):


### PR DESCRIPTION
This PR fixes an issue where ids of reordered content are converted to unicode on python 2. We now convert input ids when necessary and make sure the ordering stored on a container contains only bytestring object ids.

When changing object ordering via PATCH request we used to incorrectly store ids of reordered resources as unicode instead of a bytestring. This lead to mixed types being stored in the ordering annotations and subsequently mixed types being returned when calling `objectIds` of a container.

Affected content types are todo and todolist (or their possible content types respectively).
We also discovered that with newer versions of `OFS.ObjectManager` non-ascii ids are allowed. Thus we switch agenda item template id input validation to also use the `utf-8` encoding.

See https://github.com/plone/plone.restapi/issues/827 and  https://github.com/plone/plone.restapi/pull/828 for upstream issue and PR.

Closes https://github.com/4teamwork/opengever.core/issues/5980.

## Checkliste

_Zutreffendes soll angehakt stehengelassen werden._

- [x] Changelog-Eintrag vorhanden/nötig?
