### PR TITLE
Add trash_document and untrash_document file_actions

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2019.4.0rc5 (unreleased)
 ------------------------
 
+- Add trash_document and untrash_document file_actions. [lgraf]
 - Bump plone.restapi to 5.0.3 to get fix for filtering vocabs by non-ASCII titles. [lgraf]
 - Update the usersettings-serializer: A pure plone user has always seen all screens. [elioschmutz]
 - Support combined notation for task responsible. [phgross]

--- a/opengever/api/tests/test_actions.py
+++ b/opengever/api/tests/test_actions.py
@@ -1,5 +1,6 @@
 from ftw.testbrowser import browsing
 from opengever.testing import IntegrationTestCase
+from opengever.trash.trash import ITrashable
 
 
 class FileActionsTestBase(IntegrationTestCase):
@@ -87,6 +88,9 @@ class TestFileActionsGetForMails(FileActionsTestBase):
             {u'id': u'open_as_pdf',
              u'title': u'Open as PDF',
              u'icon': u''},
+            {u'id': u'trash_document',
+             u'title': u'Trash document',
+             u'icon': u''},
             ]
 
         self.assertEqual(expected_file_actions,
@@ -111,6 +115,9 @@ class TestFileActionsGetForDocuments(FileActionsTestBase):
             {u'id': u'open_as_pdf',
              u'title': u'Open as PDF',
              u'icon': u''},
+            {u'id': u'trash_document',
+             u'title': u'Trash document',
+             u'icon': u''},
             ]
         self.assertEqual(expected_file_actions,
                          self.get_file_actions(browser, self.document))
@@ -132,6 +139,9 @@ class TestFileActionsGetForDocuments(FileActionsTestBase):
             {u'id': u'open_as_pdf',
              u'title': u'Open as PDF',
              u'icon': u''},
+            {u'id': u'trash_document',
+             u'title': u'Trash document',
+             u'icon': u''},
             ]
         self.assertEqual(expected_file_actions,
                          self.get_file_actions(browser, self.document))
@@ -149,6 +159,9 @@ class TestFileActionsGetForDocuments(FileActionsTestBase):
              u'icon': u''},
             {u'id': u'attach_to_email',
              u'title': u'Attach to email',
+             u'icon': u''},
+            {u'id': u'trash_document',
+             u'title': u'Trash document',
              u'icon': u''},
             ]
         self.assertEqual(expected_file_actions,
@@ -264,6 +277,9 @@ class TestFileActionsGetForDocuments(FileActionsTestBase):
             {u'id': u'open_as_pdf',
              u'title': u'Open as PDF',
              u'icon': u''},
+            {u'id': u'trash_document',
+             u'title': u'Trash document',
+             u'icon': u''},
             ]
         self.assertEqual(expected_file_actions,
                          self.get_file_actions(browser, self.document))
@@ -275,6 +291,9 @@ class TestFileActionsGetForDocuments(FileActionsTestBase):
         expected_file_actions = [
             {u'id': u'oneoffixx_retry',
              u'title': u'Oneoffixx retry',
+             u'icon': u''},
+            {u'id': u'trash_document',
+             u'title': u'Trash document',
              u'icon': u''},
             ]
         self.assertEqual(expected_file_actions,
@@ -293,6 +312,59 @@ class TestFileActionsGetForDocuments(FileActionsTestBase):
              u'icon': u''},
             {u'id': u'attach_to_email',
              u'title': u'Attach to email',
+             u'icon': u''},
+            {u'id': u'trash_document',
+             u'title': u'Trash document',
+             u'icon': u''},
+            ]
+        self.assertEqual(expected_file_actions,
+                         self.get_file_actions(browser, self.document))
+
+
+class TestTrashingActionsForDocuments(FileActionsTestBase):
+
+    @browsing
+    def test_trashing_available_for_document(self, browser):
+        self.login(self.regular_user, browser)
+        expected_file_actions = [
+            {u'id': u'oc_direct_checkout',
+             u'title': u'Checkout and edit',
+             u'icon': u''},
+            {u'id': u'download_copy',
+             u'title': u'Download copy',
+             u'icon': u''},
+            {u'id': u'attach_to_email',
+             u'title': u'Attach to email',
+             u'icon': u''},
+            {u'id': u'open_as_pdf',
+             u'title': u'Open as PDF',
+             u'icon': u''},
+            {u'id': u'trash_document',
+             u'title': u'Trash document',
+             u'icon': u''},
+            ]
+        self.assertEqual(expected_file_actions,
+                         self.get_file_actions(browser, self.document))
+
+    @browsing
+    def test_untrashing_available_for_trashed_document(self, browser):
+        self.login(self.regular_user, browser)
+
+        trasher = ITrashable(self.document)
+        trasher.trash()
+
+        expected_file_actions = [
+            {u'id': u'download_copy',
+             u'title': u'Download copy',
+             u'icon': u''},
+            {u'id': u'attach_to_email',
+             u'title': u'Attach to email',
+             u'icon': u''},
+            {u'id': u'open_as_pdf',
+             u'title': u'Open as PDF',
+             u'icon': u''},
+            {u'id': u'untrash_document',
+             u'title': u'Untrash document',
              u'icon': u''},
             ]
         self.assertEqual(expected_file_actions,

--- a/opengever/base/monkey/patches/__init__.py
+++ b/opengever/base/monkey/patches/__init__.py
@@ -1,3 +1,4 @@
+from .action_info import PatchActionInfo
 from .cmf_catalog_aware import PatchCMFCatalogAware
 from .cmf_catalog_aware import PatchCMFCatalogAwareHandlers
 from .default_values import PatchBuilderCreate
@@ -28,6 +29,7 @@ from .workflowtool import PatchWorkflowTool
 from .plone_restapi import PatchPloneRestAPIOrdering
 
 
+PatchActionInfo()()
 PatchBaseOrderedViewletManagerExceptions()()
 PatchBuilderCreate()()
 PatchExtendedPathIndex()()

--- a/opengever/base/monkey/patches/action_info.py
+++ b/opengever/base/monkey/patches/action_info.py
@@ -1,0 +1,40 @@
+from opengever.base.monkey.patching import MonkeyPatch
+from Products.CMFCore.utils import _checkPermission
+
+
+class PatchActionInfo(MonkeyPatch):
+    """We patch the _checkPermissions() method of the ActionInfo object
+    in order to also consider our 'file_actions' category one that should
+    have its actions' permissions checked on the context.
+
+    Without this, the permissions would be checked on the Plone Site instead.
+    """
+
+    def __call__(self):
+
+        def _checkPermissions(self, ec):
+            """ Check permissions in the current context.
+            """
+            category = self['category']
+            object = ec.contexts['object']
+            if object is not None and ( category.startswith('object') or
+                                        category.startswith('workflow') or
+                                        category.startswith('file') or  # <-- patched
+                                        category.startswith('document') ):
+                context = object
+            else:
+                folder = ec.contexts['folder']
+                if folder is not None and category.startswith('folder'):
+                    context = folder
+                else:
+                    context = ec.contexts['portal']
+
+            for permission in self._permissions:
+                if _checkPermission(permission, context):
+                    return True
+            return False
+
+        from Products.CMFCore.ActionInformation import ActionInfo
+        locals()['__patch_refs__'] = False
+
+        self.patch_refs(ActionInfo, '_checkPermissions', _checkPermissions)

--- a/opengever/core/profiles/default/actions.xml
+++ b/opengever/core/profiles/default/actions.xml
@@ -136,6 +136,24 @@
       <property name="visible">True</property>
     </object>
 
+    <object name="trash_document" meta_type="CMF Action" i18n:domain="opengever.document">
+      <property name="title" i18n:translate="label_trash_document">Trash document</property>
+      <property name="available_expr">object/@@file_actions_availability/is_trash_document_available</property>
+      <property name="permissions">
+        <element value="opengever.trash: Trash content" />
+      </property>
+      <property name="visible">True</property>
+    </object>
+
+    <object name="untrash_document" meta_type="CMF Action" i18n:domain="opengever.document">
+      <property name="title" i18n:translate="label_untrash_document">Untrash document</property>
+      <property name="available_expr">object/@@file_actions_availability/is_untrash_document_available</property>
+      <property name="permissions">
+        <element value="opengever.trash: Untrash content" />
+      </property>
+      <property name="visible">True</property>
+    </object>
+
   </object>
 
   <!-- SITE ACTIONS -->

--- a/opengever/core/upgrades/20191104145517_add_trash_document_and_untrash_document_file_actions/actions.xml
+++ b/opengever/core/upgrades/20191104145517_add_trash_document_and_untrash_document_file_actions/actions.xml
@@ -1,0 +1,26 @@
+<object xmlns:i18n="http://xml.zope.org/namespaces/i18n" name="portal_actions" meta_type="Plone Actions Tool">
+
+  <!-- FILE ACTIONS used to list available actions through the actions endpoint-->
+  <object name="file_actions" meta_type="CMF Action Category">
+
+    <object name="trash_document" meta_type="CMF Action" i18n:domain="opengever.document">
+      <property name="title" i18n:translate="label_trash_document">Trash document</property>
+      <property name="available_expr">object/@@file_actions_availability/is_trash_document_available</property>
+      <property name="permissions">
+        <element value="opengever.trash: Trash content" />
+      </property>
+      <property name="visible">True</property>
+    </object>
+
+    <object name="untrash_document" meta_type="CMF Action" i18n:domain="opengever.document">
+      <property name="title" i18n:translate="label_untrash_document">Untrash document</property>
+      <property name="available_expr">object/@@file_actions_availability/is_untrash_document_available</property>
+      <property name="permissions">
+        <element value="opengever.trash: Untrash content" />
+      </property>
+      <property name="visible">True</property>
+    </object>
+
+  </object>
+
+</object>

--- a/opengever/core/upgrades/20191104145517_add_trash_document_and_untrash_document_file_actions/upgrade.py
+++ b/opengever/core/upgrades/20191104145517_add_trash_document_and_untrash_document_file_actions/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddTrashDocumentAndUntrashDocumentFileActions(UpgradeStep):
+    """Add trash_document and untrash_document file actions.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/document/fileactions.py
+++ b/opengever/document/fileactions.py
@@ -6,6 +6,8 @@ from opengever.document.interfaces import ICheckinCheckoutManager
 from opengever.document.interfaces import IFileActions
 from opengever.officeconnector.helpers import is_officeconnector_attach_feature_enabled  # noqa
 from opengever.officeconnector.helpers import is_officeconnector_checkout_feature_enabled  # noqa
+from opengever.trash.trash import ITrashable
+from opengever.trash.trash import TrashError
 from plone import api
 from zope.component import adapter
 from zope.component import getMultiAdapter
@@ -85,6 +87,14 @@ class BaseDocumentFileActions(object):
 
     def is_revert_to_version_action_available(self):
         return False
+
+    def is_trash_document_available(self):
+        trasher = ITrashable(self.context)
+        return trasher.verify_may_trash(raise_on_violations=False)
+
+    def is_untrash_document_available(self):
+        trasher = ITrashable(self.context)
+        return trasher.verify_may_untrash(raise_on_violations=False)
 
 
 @implementer(IFileActions)

--- a/opengever/document/interfaces.py
+++ b/opengever/document/interfaces.py
@@ -193,3 +193,9 @@ class IFileActions(Interface):
 
     def is_revert_to_version_action_available():
         """Return whether the revert to version action is available."""
+
+    def is_trash_document_available():
+        """Return whether the trash_document action is available."""
+
+    def is_untrash_document_available():
+        """Return whether the untrash_document action is available."""


### PR DESCRIPTION
Add `trash_document` and `untrash_document` file_actions.

Because [`ActionInfo._checkPermissions()`](https://github.com/zopefoundation/Products.CMFCore/blob/master/Products/CMFCore/ActionInformation.py#L262-L281) only checks permissions on the actual context for action categories that start with `object`,`workflow` or `document`, our permissions for our own `file_actions` category were always checked against the Plone site root. Because so far we only used `View` to protect those actions, this seemed to sort of work. But when using permissions like `"opengever.trash: Trash content"` this failure now surfaces.

🐒I therefore patched `_checkPermissions()` to also consider our `file_actions` category a context based one. IMHO this is even preferrable to renaming the action category, because we don't know what subtle magic around action category names might be lurking around somewhere else, and renaming it to something like `object_file_actions` might lead to unforeseen side effects.

Addresses #6022 

## Checkliste

- [x] Gibt es neue Funktionalität mit einem `Dokument`? Funktioniert das auch mit einem `Mail`?
- [x] Profil angepasst? Sind UpgradeSteps vorhanden/nötig?:
- [x] Changelog-Eintrag vorhanden/nötig?

