### PR TITLE
 Support combined notation for task responsible

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 ------------------------
 
 - Update the usersettings-serializer: A pure plone user has always seen all screens. [elioschmutz]
+- Support combined notation for task responsible. [phgross]
 - Update Products.LDAPUserFolder from 2.28.post2 to 2.28.post3. [elioschmutz]
 - Extend dossier serializer with `is_subdossier`. [elioschmutz]
 - Add @globalindex API endpoint. [phgross]

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -24,6 +24,7 @@
   <adapter factory=".response.ResponseDefaultFieldSerializer" />
   <adapter factory=".response.SerializeResponseToJson" />
   <adapter factory=".task.SerializeTaskResponseToJson" />
+  <adapter factory=".task.TaskDeserializeFromJson" />
   <adapter factory=".serializer.long_converter" />
 
   <adapter factory=".todo.DeserializeToDoFromJson" />

--- a/opengever/api/task.py
+++ b/opengever/api/task.py
@@ -1,7 +1,13 @@
 from opengever.api.response import ResponsePost
 from opengever.api.response import SerializeResponseToJson
+from opengever.ogds.base.actor import ActorLookup
+from opengever.ogds.models.team import Team
 from opengever.task.interfaces import ICommentResponseHandler
+from opengever.task.task import ITask
 from opengever.task.task_response import ITaskResponse
+from plone.restapi.deserializer import json_body
+from plone.restapi.deserializer.dxcontent import DeserializeFromJson
+from plone.restapi.interfaces import IDeserializeFromJson
 from plone.restapi.interfaces import ISerializeToJson
 from zExceptions import Unauthorized
 from zope.component import adapter
@@ -14,6 +20,54 @@ from zope.interface import Interface
 class SerializeTaskResponseToJson(SerializeResponseToJson):
 
     model = ITaskResponse
+
+
+@implementer(IDeserializeFromJson)
+@adapter(ITask, Interface)
+class TaskDeserializeFromJson(DeserializeFromJson):
+    """A task specific deserializer which allows to pass in the
+    responsible_client and responsible value in a combined string.
+    In the smae way as it is exposed by the APIs querysoure endpoint.
+    """
+
+    def __call__(self, validate_all=False, data=None, create=False):
+        if data is None:
+            data = json_body(self.request)
+
+        self.update_reponsible_field_data(data)
+
+        super(TaskDeserializeFromJson, self).__call__(
+            validate_all=validate_all, data=data, create=create)
+
+    def update_reponsible_field_data(self, data):
+        """Extract responsible_client when a combined value is used (client,
+        responsible separated by a colon).
+        """
+
+        if not data.get('responsible'):
+            return
+
+        if isinstance(data['responsible'], dict):
+            responsible = data['responsible']['token']
+        else:
+            responsible = data['responsible']
+
+        # Skip values without the orgunit prefix
+        if ':' not in responsible:
+            return
+
+        if ActorLookup(responsible).is_inbox():
+            responsible_client = responsible.split(':', 1)[1]
+
+        elif ActorLookup(responsible).is_team():
+            team = Team.query.get_by_actor_id(responsible)
+            responsible_client = team.org_unit.unit_id
+
+        else:
+            responsible_client, responsible = responsible.split(':', 1)
+
+        data['responsible'] = responsible
+        data['responsible_client'] = responsible_client
 
 
 class TaskResponsePost(ResponsePost):

--- a/opengever/api/task.py
+++ b/opengever/api/task.py
@@ -27,7 +27,7 @@ class SerializeTaskResponseToJson(SerializeResponseToJson):
 class TaskDeserializeFromJson(DeserializeFromJson):
     """A task specific deserializer which allows to pass in the
     responsible_client and responsible value in a combined string.
-    In the smae way as it is exposed by the APIs querysoure endpoint.
+    In the same way as it is exposed by the APIs querysoure endpoint.
     """
 
     def __call__(self, validate_all=False, data=None, create=False):

--- a/opengever/ogds/base/sources.py
+++ b/opengever/ogds/base/sources.py
@@ -233,6 +233,8 @@ class AllUsersInboxesAndTeamsSource(BaseQuerySoure):
 
     def search(self, query_string):
         self.terms = []
+        # Ignore colons to support queries on inboxes-id.
+        query_string = query_string.replace(':', ' ')
 
         text_filters = query_string.split(' ')
         query = extend_query_with_textfilter(

--- a/opengever/ogds/base/tests/test_sources.py
+++ b/opengever/ogds/base/tests/test_sources.py
@@ -225,6 +225,12 @@ class TestAllUsersInboxesAndTeamsSource(FunctionalTestCase):
         self.assertTermKeys([u'org-unit-1:hans', u'org-unit-1:hugo', u'org-unit-1:john'],
                             result)
 
+    def test_search_for_inbox(self):
+        result = self.source.search('inbox:org-unit-1')
+
+        self.assertEquals(1, len(result), 'Expect 1 item')
+        self.assertTermKeys([u'inbox:org-unit-1'], result)
+
     def test_return_no_search_result_for_inactive_orgunits(self):
         result = self.source.search('Steueramt')
 


### PR DESCRIPTION
Currently the api for task creation/editing only supports a single value for the `responsible_client` and `responsible` field. But the `schema´ or `querysources` endpoint returnes a combined value for the users containing `responsible_client` and `responsible`. This difference leads to bad situation where we would need to split the values in the frontend or need to use a separate endpoint to fetch the responsible values.

I was also thinking about adding a different endpoint or moving the ":" splitting to the frontend, but I think thats the cleanest way. I see the following advantages:
 - The value exposed by the schema endpoint is valid and can be used for a POST or PATCH request. The default implementation on the frontend side works also for tasks.
 - The special handling for combined values are only in the backend and not spread over different endpoints and sources
 - The change does not have any impact on other featueres/modules or on the old frontend, the sources works still the same.
 - No data migration necessary 

Additional fixes for task add/edit support in the frontend:
 - Also pass in the data to the deserialization instead of refetching it from the request.
 - Ignore colons when query one of the contact sources

For https://github.com/4teamwork/gever-ui/issues/124 

## Checkliste
- [x] Wurde etwas an der `Aufgabe` angepasst? Funktioniert das auch mit einer `Weiterleitung`?
 the forwarding are currently not supported by the rest api, so no need to invest time.
- [x] Changelog-Eintrag vorhanden/nötig?
- [ ] Aktualisierung Dokumentation vorhanden/nötig?
 _I'm not sure if I should provide documentation about this "feature" or not, what you think._
