### PR TITLE
Disallow mail upload as documents via API.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -9,6 +9,7 @@ Changelog
 - Update the usersettings-serializer: A pure plone user has always seen all screens. [elioschmutz]
 - Support combined notation for task responsible. [phgross]
 - Fix an issue with todo(-list) ids not being stored as bytestring. [deiferni]
+- Disallow mail upload as documents via API. [phgross]
 - Update Products.LDAPUserFolder from 2.28.post2 to 2.28.post3. [elioschmutz]
 - Extend dossier serializer with `is_subdossier`. [elioschmutz]
 - Add @globalindex API endpoint. [phgross]

--- a/opengever/document/locales/de/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/de/LC_MESSAGES/opengever.document.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2019-08-02 12:46+0000\n"
+"POT-Creation-Date: 2019-11-04 13:11+0000\n"
 "PO-Revision-Date: 2017-10-13 14:27+0200\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -190,6 +190,11 @@ msgstr "Sie haben weder eine Datei ausgewählt noch ist das Dokument in Papierfo
 #: ./opengever/document/document.py
 msgid "error_mail_upload"
 msgstr "Es ist nicht erlaubt hier E-Mails anzufügen. Bitte senden Sie das E-Mail an die Addresse ${mailaddress} oder ziehen Sie es in das Dossier (Drag'n'Drop)."
+
+#. Default: "It's not possible to add E-mails as document, use portal_type ftw.mail.mail."
+#: ./opengever/document/document.py
+msgid "error_mail_upload_api"
+msgstr "Es ist nicht erlaubt hier E-Mails anzufügen. Verwenden Sie den Typ ftw.mail.mail."
 
 #. Default: "You have not selected any Items"
 #: ./opengever/document/browser/report.py

--- a/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-08-02 12:46+0000\n"
+"POT-Creation-Date: 2019-11-04 13:11+0000\n"
 "PO-Revision-Date: 2017-09-03 08:50+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-document/fr/>\n"
@@ -192,6 +192,11 @@ msgstr "Vous n'avez pas sélectionné un fichier ni conservé un document en ver
 #: ./opengever/document/document.py
 msgid "error_mail_upload"
 msgstr "Il n'est pas possible d'insérer des Email à cet endroit. Pour le faire, utilisez l'adresse E-Mail ${mailaddress}  ou glissez-le dans le dossier (Drag'n'Drop)."
+
+#. Default: "It's not possible to add E-mails as document, use portal_type ftw.mail.mail."
+#: ./opengever/document/document.py
+msgid "error_mail_upload_api"
+msgstr ""
 
 #. Default: "You have not selected any Items"
 #: ./opengever/document/browser/report.py

--- a/opengever/document/locales/opengever.document.pot
+++ b/opengever/document/locales/opengever.document.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-08-02 12:46+0000\n"
+"POT-Creation-Date: 2019-11-04 13:11+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -191,6 +191,11 @@ msgstr ""
 #. Default: "It's not possible to add E-mails here, please send it to ${mailaddress} or drag it to the dossier (Dragn'n'Drop)."
 #: ./opengever/document/document.py
 msgid "error_mail_upload"
+msgstr ""
+
+#. Default: "It's not possible to add E-mails as document, use portal_type ftw.mail.mail."
+#: ./opengever/document/document.py
+msgid "error_mail_upload_api"
 msgstr ""
 
 #. Default: "You have not selected any Items"


### PR DESCRIPTION
Because we still wont an detailed error message (including the mail-in address) directly placed by the field, I duplicate the check from the simplefieldvalitor and register it also as a schema invariant. Simplefieldvalidator are z3c form bsed validation and therefore not called by plone.restapi.

An migration/upgradestep is not necessary, I doublechecked our gever installation, there were only 2 which i migrated manually (delete and recreate). Other productive deployment should not be affected by this.

For #5988

## Checkliste
- [ ] Gibt es neue Funktionalität mit einem `Dokument`? Funktioniert das auch mit einem `Mail`? _Nur bei einem Dokument relevant._ 
- [x] Gibt es neue Übersetzungen?
  - [x] Sind alle msg-Strings in Übersetzungen Unicode?
  - [x] Wird die richtige i18n-domain verwendet (Copy-Paste Fehler sind hier häufig)?
- [x] Changelog-Eintrag vorhanden/nötig?

Checked by:
```
from opengever.maintenance import dm
dm()
from plone import api
cat = api.portal.get_tool('portal_catalog')

MAIL_EXTENSIONS = ['.eml', '.msg', '.p7m']
wrong = []

for brain in docs:
    doc = brain.getObject()
    if doc.get_file() and doc.get_file_extension() in MAIL_EXTENSIONS:
        wrong.append(doc)
```

