### PR TITLE
Revert "Cast the userid to bytestring so that validation to ASCIILine passes"

### DIFF
--- a/opengever/webactions/storage.py
+++ b/opengever/webactions/storage.py
@@ -92,9 +92,7 @@ class WebActionsStorage(object):
         new_action = PersistentMapping(action_data)
         self._actions[action_id] = new_action
 
-        # This is a workaround: the returned userid is of type unicode. As the "owner" field is of type ASCIILine, it is
-        # simply casted to a bytestring.
-        userid = str(api.user.get_current().getId())
+        userid = api.user.get_current().getId()
         now = datetime.now()
 
         # The `action_id` is stored redundantly here in the actual


### PR DESCRIPTION
Reverts 4teamwork/opengever.core#6012.

As discussed, adding a workaround for this issue to the `ris` branch turned out to be an incorrect, even detrimental approach: Until the issue is fixed in `master`, tests are *supposed* to fail, since it also can't work in production.