### PR TITLE
Fix encoding issue in proposal doc-properties.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 ------------------------
 
 - Bump ftw.keywordwidget to 2.1.2 to fix race condition when adding new keywords. [lgraf]
+- Fix an issue with non-ASCII characters in proposal doc-properties. [deiferni]
 - Add trash_document and untrash_document file_actions. [lgraf]
 - Bump plone.restapi to 5.0.3 to get fix for filtering vocabs by non-ASCII titles. [lgraf]
 - Add document creator metadata to available docproperties. [deiferni]

--- a/opengever/dossier/tests/__init__.py
+++ b/opengever/dossier/tests/__init__.py
@@ -136,8 +136,8 @@ EXPECTED_MEETING_PROPERTIES = {
     'ogg.meeting.agenda_item_number_raw': '',
     'ogg.meeting.decision_number': '',
     'ogg.meeting.proposal_state': 'Submitted',
-    'ogg.meeting.proposal_title': 'Vertr\xc3\xa4ge',
-    'ogg.meeting.proposal_description': 'F\xc3\xbcr weitere Bearbeitung bewilligen'
+    'ogg.meeting.proposal_title': u'Vertr\xe4ge',
+    'ogg.meeting.proposal_description': u'F\xfcr weitere Bearbeitung bewilligen'
 }
 
 EXPECTED_DOC_PROPERTIES = dict(

--- a/opengever/meeting/docprops.py
+++ b/opengever/meeting/docprops.py
@@ -14,8 +14,8 @@ class ProposalDocPropertyProvider(BaseDocPropertyProvider):
             'decision_number': '',
             'agenda_item_number': '',
             'agenda_item_number_raw': '',
-            'proposal_title': self.context.Title(),
-            'proposal_description': self.context.Description(),
+            'proposal_title': self.context.title,
+            'proposal_description': self.context.description,
             'proposal_state': translate(self.context.get_state().title,
                                         context=self.context.REQUEST),
         }

--- a/opengever/meeting/tests/test_docproperties.py
+++ b/opengever/meeting/tests/test_docproperties.py
@@ -1,4 +1,8 @@
+from docx import Document
+from docxcompose.properties import CustomProperties
 from opengever.document.docprops import DocPropertyCollector
+from opengever.document.docprops import DocPropertyWriter
+from opengever.document.docprops import TemporaryDocFile
 from opengever.testing import IntegrationTestCase
 
 
@@ -9,7 +13,7 @@ def get_doc_properties(document, prefix='ogg.meeting.'):
 
 
 class TestMeetingDocxProperties(IntegrationTestCase):
-    features = ('meeting',)
+    features = ('meeting', 'doc-properties',)
 
     def test_non_meeting_document_should_not_have_meeting_properties(self):
         self.login(self.dossier_responsible)
@@ -18,13 +22,30 @@ class TestMeetingDocxProperties(IntegrationTestCase):
             get_doc_properties(self.document),
             'A regular document should not contain meeting doc properties.')
 
+    def test_update_proposal_document_docproperties_non_ascii_proposal_title(self):
+        self.login(self.dossier_responsible)
+
+        self.draft_proposal.title = u'f\xfc\xfcck'
+        self.draft_proposal.description = u'th\xe4\xe4t'
+
+        document = self.draft_proposal.get_proposal_document()
+        DocPropertyWriter(document).update_doc_properties(only_existing=False)
+
+        expected_properties = {
+            'ogg.meeting.proposal_title': u'f\xfc\xfcck',
+            'ogg.meeting.proposal_description': u'th\xe4\xe4t',
+        }
+        with TemporaryDocFile(document.file) as tmpfile:
+            properties = dict(CustomProperties(Document(tmpfile.path)).items())
+            self.assertDictContainsSubset(expected_properties, properties)
+
     def test_pending_proposal_document(self):
         self.login(self.dossier_responsible)
         self.assertEquals(
             {'ogg.meeting.decision_number': '',
              'ogg.meeting.agenda_item_number': '',
              'ogg.meeting.agenda_item_number_raw': '',
-             'ogg.meeting.proposal_title': 'Antrag f\xc3\xbcr Kreiselbau',
+             'ogg.meeting.proposal_title': u'Antrag f\xfcr Kreiselbau',
              'ogg.meeting.proposal_description': '',
              'ogg.meeting.proposal_state': 'Pending'},
             get_doc_properties(self.draft_proposal.get_proposal_document()))
@@ -35,8 +56,8 @@ class TestMeetingDocxProperties(IntegrationTestCase):
                 {'ogg.meeting.decision_number': '',
                  'ogg.meeting.agenda_item_number': '',
                  'ogg.meeting.agenda_item_number_raw': '',
-                 'ogg.meeting.proposal_title': 'Vertr\xc3\xa4ge',
-                 'ogg.meeting.proposal_description': 'F\xc3\xbcr weitere Bearbeitung bewilligen',
+                 'ogg.meeting.proposal_title': u'Vertr\xe4ge',
+                 'ogg.meeting.proposal_description': u'F\xfcr weitere Bearbeitung bewilligen',
                  'ogg.meeting.proposal_state': 'Submitted'},
                 get_doc_properties(self.proposal.get_proposal_document()))
 
@@ -45,8 +66,8 @@ class TestMeetingDocxProperties(IntegrationTestCase):
                 {'ogg.meeting.decision_number': '',
                  'ogg.meeting.agenda_item_number': '',
                  'ogg.meeting.agenda_item_number_raw': '',
-                 'ogg.meeting.proposal_title': 'Vertr\xc3\xa4ge',
-                 'ogg.meeting.proposal_description': 'F\xc3\xbcr weitere Bearbeitung bewilligen',
+                 'ogg.meeting.proposal_title': u'Vertr\xe4ge',
+                 'ogg.meeting.proposal_description': u'F\xfcr weitere Bearbeitung bewilligen',
                  'ogg.meeting.proposal_state': 'Submitted'},
                 get_doc_properties(self.submitted_proposal.get_proposal_document()))
 
@@ -59,8 +80,8 @@ class TestMeetingDocxProperties(IntegrationTestCase):
                 {'ogg.meeting.decision_number': '',
                  'ogg.meeting.agenda_item_number': '1.',
                  'ogg.meeting.agenda_item_number_raw': 1,
-                 'ogg.meeting.proposal_title': 'Vertr\xc3\xa4ge',
-                 'ogg.meeting.proposal_description': 'F\xc3\xbcr weitere Bearbeitung bewilligen',
+                 'ogg.meeting.proposal_title': u'Vertr\xe4ge',
+                 'ogg.meeting.proposal_description': u'F\xfcr weitere Bearbeitung bewilligen',
                  'ogg.meeting.proposal_state': 'Scheduled'},
                 get_doc_properties(self.proposal.get_proposal_document()))
 
@@ -69,8 +90,8 @@ class TestMeetingDocxProperties(IntegrationTestCase):
                 {'ogg.meeting.decision_number': '',
                  'ogg.meeting.agenda_item_number': '1.',
                  'ogg.meeting.agenda_item_number_raw': 1,
-                 'ogg.meeting.proposal_title': 'Vertr\xc3\xa4ge',
-                 'ogg.meeting.proposal_description': 'F\xc3\xbcr weitere Bearbeitung bewilligen',
+                 'ogg.meeting.proposal_title': u'Vertr\xe4ge',
+                 'ogg.meeting.proposal_description': u'F\xfcr weitere Bearbeitung bewilligen',
                  'ogg.meeting.proposal_state': 'Scheduled'},
                 get_doc_properties(self.submitted_proposal.get_proposal_document()))
 
@@ -84,8 +105,8 @@ class TestMeetingDocxProperties(IntegrationTestCase):
                 {'ogg.meeting.decision_number': '2016 / 2',
                  'ogg.meeting.agenda_item_number': '1.',
                  'ogg.meeting.agenda_item_number_raw': 1,
-                 'ogg.meeting.proposal_title': 'Vertr\xc3\xa4ge',
-                 'ogg.meeting.proposal_description': 'F\xc3\xbcr weitere Bearbeitung bewilligen',
+                 'ogg.meeting.proposal_title': u'Vertr\xe4ge',
+                 'ogg.meeting.proposal_description': u'F\xfcr weitere Bearbeitung bewilligen',
                  'ogg.meeting.proposal_state': 'Decided'},
                 get_doc_properties(self.proposal.get_proposal_document()))
 
@@ -94,8 +115,8 @@ class TestMeetingDocxProperties(IntegrationTestCase):
                 {'ogg.meeting.decision_number': '2016 / 2',
                  'ogg.meeting.agenda_item_number': '1.',
                  'ogg.meeting.agenda_item_number_raw': 1,
-                 'ogg.meeting.proposal_title': 'Vertr\xc3\xa4ge',
-                 'ogg.meeting.proposal_description': 'F\xc3\xbcr weitere Bearbeitung bewilligen',
+                 'ogg.meeting.proposal_title': u'Vertr\xe4ge',
+                 'ogg.meeting.proposal_description': u'F\xfcr weitere Bearbeitung bewilligen',
                  'ogg.meeting.proposal_state': 'Decided'},
                 get_doc_properties(self.submitted_proposal.get_proposal_document()))
 
@@ -113,8 +134,8 @@ class TestMeetingDocxProperties(IntegrationTestCase):
                 {'ogg.meeting.decision_number': '2016 / 2',
                  'ogg.meeting.agenda_item_number': '1.',
                  'ogg.meeting.agenda_item_number_raw': 1,
-                 'ogg.meeting.proposal_title': 'Vertr\xc3\xa4ge',
-                 'ogg.meeting.proposal_description': 'F\xc3\xbcr weitere Bearbeitung bewilligen',
+                 'ogg.meeting.proposal_title': u'Vertr\xe4ge',
+                 'ogg.meeting.proposal_description': u'F\xfcr weitere Bearbeitung bewilligen',
                  'ogg.meeting.proposal_state': 'Scheduled'},
                 get_doc_properties(meeting_dossier_excerpt))
 
@@ -128,7 +149,7 @@ class TestMeetingDocxProperties(IntegrationTestCase):
                 {'ogg.meeting.decision_number': '2016 / 2',
                  'ogg.meeting.agenda_item_number': '1.',
                  'ogg.meeting.agenda_item_number_raw': 1,
-                 'ogg.meeting.proposal_title': 'Vertr\xc3\xa4ge',
-                 'ogg.meeting.proposal_description': 'F\xc3\xbcr weitere Bearbeitung bewilligen',
+                 'ogg.meeting.proposal_title': u'Vertr\xe4ge',
+                 'ogg.meeting.proposal_description': u'F\xfcr weitere Bearbeitung bewilligen',
                  'ogg.meeting.proposal_state': 'Decided'},
                 get_doc_properties(case_dossier_excerpt))


### PR DESCRIPTION
Proposal doc-properties were incorrectly collected as an utf-8 encoded bytestring instead of an unicode-string by using the accessor methods `Title` and `Description` respectively. 

Fixes #5955 

⚠️ based on https://github.com/4teamwork/opengever.core/pull/6037 as doc-properties are refactored there. Needs a final rebase.

## Checkliste

_Zutreffendes soll angehakt stehengelassen werden._

- [x] Changelog-Eintrag vorhanden/nötig?
