### PR TITLE
Drop unittest2 in favor of unittest.

### DIFF
--- a/opengever/ogds/models/tests/base.py
+++ b/opengever/ogds/models/tests/base.py
@@ -2,10 +2,10 @@ from ftw.builder import Builder
 from ftw.builder import create
 from opengever.core.testing import MEMORY_DB_LAYER
 from opengever.ogds.base.utils import OGDSService
-import unittest2
+import unittest
 
 
-class OGDSTestCase(unittest2.TestCase):
+class OGDSTestCase(unittest.TestCase):
 
     layer = MEMORY_DB_LAYER
 

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,6 @@ tests_require = [
     'pyquery',
     'requests_mock',
     'requests_toolbelt',
-    'unittest2',
     'xlrd',
     'z3c.blobfile',
     'z3c.form',


### PR DESCRIPTION
We are at least on python2.7 on all deployments, so unittest2 and unittest are equal.

_I just stumbled upon this by chance but as unittest2 is no longer necessary we can just as well get rid of the import, no CL necessary IMO._