### PR TITLE
Revoke permissions for former responsible, when task gets rejected.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,7 @@ Changelog
 - Fix unicode error in @listing endpoint filters. [lgraf]
 - Add main dossier count to contentstats. [njohner]
 - No longer add journal entry for document file modification. [njohner]
+- Revoke permissions for former responsible, when task gets rejected. [phgross]
 
 
 2019.4.0rc5 (2019-11-13)

--- a/opengever/task/transition.py
+++ b/opengever/task/transition.py
@@ -307,6 +307,7 @@ class RejectTransitionExtender(DefaultTransitionExtender):
 
         self.save_related_items(response, transition_params.get('relatedItems'))
         self.switch_responsible()
+        notify(ObjectModifiedEvent(self.context))
 
     def update_watchers(self):
         center = notification_center()
@@ -316,6 +317,13 @@ class RejectTransitionExtender(DefaultTransitionExtender):
             self.context.oguid, self.context.issuer, TASK_RESPONSIBLE_ROLE)
 
     def switch_responsible(self):
+        # Revoke local roles for current responsible, except if
+        # revoke_permissions is set to False.
+        # The roles for the new responsible will be assigned afterwards
+        # in set_roles_after_modifying on the ObjectModifiedEvent.
+        if self.context.revoke_permissions:
+            LocalRolesSetter(self.context).revoke_roles()
+
         self.context.responsible = ITask(self.context).issuer
 
 


### PR DESCRIPTION
When rejecting a task the responsible gets changed to the tasks issuer, but the local permissions sets has not been revoked (#5984) this PR fixes that. 

## Checkliste
- [x] Wurde etwas an der `Aufgabe` angepasst? Funktioniert das auch mit einer `Weiterleitung`? Gibt keine solches Verhalten bei Weiterleitungen. 
- [x] Changelog-Eintrag vorhanden/nötig?
