### PR TITLE
No longer add journal entry for document file modifications.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 ------------------------
 
 - Add main dossier count to contentstats. [njohner]
+- No longer add journal entry for document file modification. [njohner]
 
 
 2019.4.0rc5 (2019-11-13)

--- a/opengever/document/versioner.py
+++ b/opengever/document/versioner.py
@@ -29,7 +29,7 @@ class Versioner(object):
         return self.repository.getHistoryMetadata(self.document)
 
     def get_version_metadata(self, version_id):
-            return self.get_history_metadata().retrieve(version_id)['metadata']
+        return self.get_history_metadata().retrieve(version_id)['metadata']
 
     def create_version(self, comment):
         """Creates a new version in CMFEditions.

--- a/opengever/journal/locales/de/LC_MESSAGES/opengever.journal.po
+++ b/opengever/journal/locales/de/LC_MESSAGES/opengever.journal.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2017-10-02 12:51+0000\n"
+"POT-Creation-Date: 2019-11-13 15:05+0000\n"
 "PO-Revision-Date: 2014-11-19 12:25+0100\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -85,26 +85,6 @@ msgstr "Dokument ausgecheckt"
 #: ./opengever/journal/handlers.py
 msgid "label_document_checkout_cancel"
 msgstr "Änderungen an der Datei widerrufen"
-
-#. Default: "Changed file and metadata"
-#: ./opengever/journal/handlers.py
-msgid "label_document_file_and_metadata_modified"
-msgstr "Datei und Metadaten bearbeitet"
-
-#. Default: "Changed file and metadata of document ${title}"
-#: ./opengever/journal/handlers.py
-msgid "label_document_file_and_metadata_modified__parent"
-msgstr "Datei und Metadaten des Dokuments «${title}» bearbeitet"
-
-#. Default: "Changed file"
-#: ./opengever/journal/handlers.py
-msgid "label_document_file_modified"
-msgstr "Datei bearbeitet"
-
-#. Default: "Changed file of document ${title}"
-#: ./opengever/journal/handlers.py
-msgid "label_document_file_modified__parent"
-msgstr "Datei des Dokuments «${title}» bearbeitet"
 
 #. Default: "Reverte document file to version ${version_id}"
 #: ./opengever/journal/handlers.py
@@ -310,4 +290,3 @@ msgstr "Journal"
 #: ./opengever/journal/templates/journal_selection.pt
 msgid "tab_matches"
 msgstr "${amount} Treffer"
-

--- a/opengever/journal/locales/fr/LC_MESSAGES/opengever.journal.po
+++ b/opengever/journal/locales/fr/LC_MESSAGES/opengever.journal.po
@@ -1,21 +1,20 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-10-02 12:51+0000\n"
+"POT-Creation-Date: 2019-11-13 15:05+0000\n"
 "PO-Revision-Date: 2018-05-22 10:09+0000\n"
 "Last-Translator: Niklaus Johner <Niklaus.johner@4teamwork.ch>\n"
-"Language-Team: French <https://translations.onegovgever.ch/projects/onegov-"
-"gever/opengever-journal/fr/>\n"
-"Language: fr\n"
+"Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-journal/fr/>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
-"X-Generator: Weblate 2.13.1\n"
 "Language-Code: en\n"
 "Language-Name: English\n"
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
+"Language: fr\n"
+"X-Generator: Weblate 2.13.1\n"
 
 #. Default: "Journal"
 #: ./opengever/journal/templates/journalhistory.pt
@@ -88,26 +87,6 @@ msgstr "Document avec checkout"
 #: ./opengever/journal/handlers.py
 msgid "label_document_checkout_cancel"
 msgstr "Annuler les modification du fichier"
-
-#. Default: "Changed file and metadata"
-#: ./opengever/journal/handlers.py
-msgid "label_document_file_and_metadata_modified"
-msgstr "Fichier et méta-données modifiés"
-
-#. Default: "Changed file and metadata of document ${title}"
-#: ./opengever/journal/handlers.py
-msgid "label_document_file_and_metadata_modified__parent"
-msgstr "Fichier et méta-données du document «${title}» modifiés"
-
-#. Default: "Changed file"
-#: ./opengever/journal/handlers.py
-msgid "label_document_file_modified"
-msgstr "Fichier modifié"
-
-#. Default: "Changed file of document ${title}"
-#: ./opengever/journal/handlers.py
-msgid "label_document_file_modified__parent"
-msgstr "Fichier du document «${title}» modifié"
 
 #. Default: "Reverte document file to version ${version_id}"
 #: ./opengever/journal/handlers.py

--- a/opengever/journal/locales/opengever.journal.pot
+++ b/opengever/journal/locales/opengever.journal.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-10-02 12:51+0000\n"
+"POT-Creation-Date: 2019-11-13 15:05+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -87,26 +87,6 @@ msgstr ""
 #. Default: "Canceled document checkout"
 #: ./opengever/journal/handlers.py
 msgid "label_document_checkout_cancel"
-msgstr ""
-
-#. Default: "Changed file and metadata"
-#: ./opengever/journal/handlers.py
-msgid "label_document_file_and_metadata_modified"
-msgstr ""
-
-#. Default: "Changed file and metadata of document ${title}"
-#: ./opengever/journal/handlers.py
-msgid "label_document_file_and_metadata_modified__parent"
-msgstr ""
-
-#. Default: "Changed file"
-#: ./opengever/journal/handlers.py
-msgid "label_document_file_modified"
-msgstr ""
-
-#. Default: "Changed file of document ${title}"
-#: ./opengever/journal/handlers.py
-msgid "label_document_file_modified__parent"
 msgstr ""
 
 #. Default: "Reverte document file to version ${version_id}"
@@ -313,4 +293,3 @@ msgstr ""
 #: ./opengever/journal/templates/journal_selection.pt
 msgid "tab_matches"
 msgstr ""
-

--- a/opengever/journal/tests/test_document_journalization.py
+++ b/opengever/journal/tests/test_document_journalization.py
@@ -58,16 +58,17 @@ class TestDocumentEventJournalizations(FunctionalTestCase):
             DOCUMENT_MODIIFED_ACTION, u'Changed metadata', entry)
 
     @browsing
-    def test_modifying_the_file_is_journalized(self, browser):
+    def test_modifying_the_file_is_NOT_journalized(self, browser):
+        journal_entries = self.get_journal_entries()
+
         browser.login().open(self.document, view='edit')
         browser.fill({'File': ('Raw file data', 'file.txt', 'text/plain'),
                       'form.widgets.file.action': 'replace'})
         browser.css('#form-buttons-save').first.click()
 
-        entry = self.get_journal_entries()[-1]
-
-        self.assert_journal_entry(
-            DOCUMENT_MODIIFED_ACTION, u'Changed file', entry)
+        self.assertEqual(self.get_journal_entries(), journal_entries,
+                         'Modifying only the file wrongly created a journal '
+                         'entry')
 
     @browsing
     def test_modifying_the_file_and_metadata_is_journalized(self, browser):
@@ -80,7 +81,7 @@ class TestDocumentEventJournalizations(FunctionalTestCase):
         entry = self.get_journal_entries()[-1]
 
         self.assert_journal_entry(
-            DOCUMENT_MODIIFED_ACTION, u'Changed file and metadata', entry)
+            DOCUMENT_MODIIFED_ACTION, u'Changed metadata', entry)
 
     @browsing
     def test_modifying_the_public_trial_metadata_is_journalized(self, browser):


### PR DESCRIPTION
Newer OfficeConnector versions upload the modified file each time it gets saved. As these file modifications get journalised, this clogs up the journal with uninformative entries. With this change, we no longer journalise file modifications. Instead, document checkin/checkout entries serve as markers to who modified a document and when (although a checkout/checkin cycle with no modifications cannot be distinguished in the journal from one with modifications, but document versions would allow to track changes if necessary).

For https://github.com/4teamwork/opengever.core/issues/6003

## Checkliste

- [x] Gibt es neue Funktionalität mit einem `Dokument`? Funktioniert das auch mit einem `Mail`?
- [x] Changelog-Eintrag vorhanden/nötig?
