### PR TITLE
Add main dossier count to contentstats.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,7 @@ Changelog
 2019.4.0rc6 (unreleased)
 ------------------------
 
-- Nothing changed yet.
+- Add main dossier count to contentstats. [njohner]
 
 
 2019.4.0rc5 (2019-11-13)

--- a/opengever/contentstats/providers.py
+++ b/opengever/contentstats/providers.py
@@ -26,7 +26,15 @@ class GEVERPortalTypesProvider(PortalTypesProvider):
         mails = counts.get('ftw.mail.mail', 0)
         docs = counts.get('opengever.document.document', 0)
         counts['_opengever.document.behaviors.IBaseDocument'] = (docs + mails)
+        counts['_opengever.dossier.maindossier'] = self.get_main_dossiers_count()
         return counts
+
+    def get_main_dossiers_count(self):
+        catalog = api.portal.get_tool('portal_catalog')
+        count = len(catalog.unrestrictedSearchResults(
+            object_provides=['opengever.dossier.behaviors.dossier.IDossierMarker'],
+            is_subdossier=False))
+        return count
 
 
 @implementer(IStatsProvider)

--- a/opengever/contentstats/tests/test_content_stats_integration.py
+++ b/opengever/contentstats/tests/test_content_stats_integration.py
@@ -218,3 +218,19 @@ class TestContentStatsIntegration(IntegrationTestCase):
         self.assertIn('_opengever.document.behaviors.IBaseDocument', stats)
         documentish_stats = stats['opengever.document.document'] + stats['ftw.mail.mail']
         self.assertEqual(documentish_stats, stats['_opengever.document.behaviors.IBaseDocument'])
+
+    def test_gever_portal_types_contains_main_dossiers(self):
+        stats_provider = getMultiAdapter((self.portal, self.portal.REQUEST),
+                                         IStatsProvider,
+                                         name='portal_types')
+        stats = stats_provider.get_raw_stats()
+        self.assertIn('_opengever.dossier.maindossier', stats)
+
+        catalog = api.portal.get_tool('portal_catalog')
+        expected = stats['opengever.dossier.businesscasedossier']
+        expected += stats['opengever.meeting.meetingdossier']
+        expected += stats['opengever.private.dossier']
+        expected -= len(catalog.unrestrictedSearchResults(
+            object_provides=['opengever.dossier.behaviors.dossier.IDossierMarker'],
+            is_subdossier=True))
+        self.assertEqual(expected, stats['_opengever.dossier.maindossier'])


### PR DESCRIPTION
We extend the `GEVERContentStatsProvider` with a count of the main dossiers.

For https://github.com/4teamwork/opengever.core/issues/6043

## Checkliste
- [x] Changelog-Eintrag vorhanden/nötig?
