### PR TITLE
Fix unicode error in @listing endpoint filters.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2019.4.0rc6 (unreleased)
 ------------------------
 
+- Fix unicode error in @listing endpoint filters. [lgraf]
 - Add main dossier count to contentstats. [njohner]
 
 

--- a/opengever/api/listing.py
+++ b/opengever/api/listing.py
@@ -364,10 +364,16 @@ class Listing(Service):
                 value = self.daterange_filter(value)
             elif isinstance(value, list):
                 value = map(escape, value)
+                value = map(safe_unicode, value)
                 value = u' OR '.join(value)
             else:
                 value = escape(value)
             if value is not None:
+                # XXX: Instead of littering all this code with safe_unicode,
+                # we should convert user-supplied input to unicode *once*
+                # at the system boundaries (when extracting values from
+                # self.request.form) once this endpoint gets refactored.
+                value = safe_unicode(value)
                 filter_queries.append(u'{}:({})'.format(escape(key), value))
 
         sort = sort_on


### PR DESCRIPTION
Fixes yet another Unicode error in `@listing`.

Because that entire code is a mess and deals with a mix of bytestrings and unicode in different places, it's out of scope of this PR to fix all those encoding issues that are most likely still lurking here. Instead, I left a comment that (and how) this should be fixed once this endpoint is refactored as part of #5901. 

Addresses #5975 

## Checkliste

- [x] Changelog-Eintrag vorhanden/nötig?

