### PR TITLE
Always use API for OfficeConnector.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2019.5.1 (unreleased)
 ---------------------
 
+- Always use API for OfficeConnector. [njohner]
 - Refactor solrsearch and listing endpoints. [njohner]
 - Add tests for solrsearch and listing endpoints. [njohner]
 - Split invitations from participations endpoints. [njohner]

--- a/opengever/core/upgrades/20181120131154_add_office_connector_tus_upload_settings/registry.xml
+++ b/opengever/core/upgrades/20181120131154_add_office_connector_tus_upload_settings/registry.xml
@@ -1,3 +1,0 @@
-<registry>
-  <record interface="opengever.officeconnector.interfaces.IOfficeConnectorSettings" field="restapi_enabled" />
-</registry>

--- a/opengever/core/upgrades/20181120131154_add_office_connector_tus_upload_settings/upgrade.py
+++ b/opengever/core/upgrades/20181120131154_add_office_connector_tus_upload_settings/upgrade.py
@@ -1,9 +1,0 @@
-from ftw.upgrade import UpgradeStep
-
-
-class AddOfficeConnectorTUSUploadSettings(UpgradeStep):
-    """Add Office Connector TUS upload settings.
-    """
-
-    def __call__(self):
-        self.install_upgrade_profile()

--- a/opengever/core/upgrades/20191115105256_remove_oc_rest_api_feature_flag/registry.xml
+++ b/opengever/core/upgrades/20191115105256_remove_oc_rest_api_feature_flag/registry.xml
@@ -1,0 +1,3 @@
+<registry>
+  <record interface="opengever.officeconnector.interfaces.IOfficeConnectorSettings" field="restapi_enabled" remove="True" />
+</registry>

--- a/opengever/core/upgrades/20191115105256_remove_oc_rest_api_feature_flag/upgrade.py
+++ b/opengever/core/upgrades/20191115105256_remove_oc_rest_api_feature_flag/upgrade.py
@@ -1,0 +1,10 @@
+from ftw.upgrade import UpgradeStep
+
+
+class RemoveOCRestAPIFeatureFlag(UpgradeStep):
+    """Remove OfficeConnector REST-API feature flag. We now always use the
+    REST-API path.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/locking/tests/test_force_unlock.py
+++ b/opengever/locking/tests/test_force_unlock.py
@@ -35,7 +35,9 @@ class TestDocumentForceUnlock(OCIntegrationTestCase):
             token = jwt.decode(raw_token, JWT_SIGNING_SECRET_PLONE, algorithms=('HS256',))
             self.assertEqual(expected_token, token)
 
-            self.lock_document(browser, raw_token, self.document)
+            payloads = self.fetch_document_checkout_payloads(
+                browser, raw_token, token)
+            self.lock_document(browser, raw_token, payloads[0], self.document)
 
             self.login(self.meeting_user, browser)
             browser.open(self.document)
@@ -65,7 +67,10 @@ class TestDocumentForceUnlock(OCIntegrationTestCase):
         self.assertEqual(expected_token, token)
 
         lockable = ILockable(self.document)
-        self.lock_document(browser, raw_token, self.document)
+
+        payloads = self.fetch_document_checkout_payloads(
+            browser, raw_token, token)
+        self.lock_document(browser, raw_token, payloads[0], self.document)
         self.assertTrue(lockable.locked())
 
         self.login(self.manager, browser)

--- a/opengever/officeconnector/browser/settings.py
+++ b/opengever/officeconnector/browser/settings.py
@@ -1,6 +1,5 @@
 from opengever.officeconnector.helpers import is_officeconnector_attach_feature_enabled  # noqa
 from opengever.officeconnector.helpers import is_officeconnector_checkout_feature_enabled  # noqa
-from opengever.officeconnector.helpers import is_officeconnector_restapi_feature_enabled
 from opengever.officeconnector.interfaces import IOfficeConnectorSettingsView
 from plone.memoize.view import memoize_contextless
 from Products.Five import BrowserView
@@ -18,7 +17,3 @@ class SettingsView(BrowserView):
     @memoize_contextless
     def is_checkout_enabled(self):
         return is_officeconnector_checkout_feature_enabled()
-
-    @memoize_contextless
-    def is_restapi_enabled(self):
-        return is_officeconnector_restapi_feature_enabled()

--- a/opengever/officeconnector/helpers.py
+++ b/opengever/officeconnector/helpers.py
@@ -25,13 +25,6 @@ def is_officeconnector_checkout_feature_enabled():
         )
 
 
-def is_officeconnector_restapi_feature_enabled():
-    return api.portal.get_registry_record(
-        'restapi_enabled',
-        interface=IOfficeConnectorSettings,
-        )
-
-
 def parse_bcc(request):
     body = request.get('BODY', None)
     if body and 'bcc' in body:

--- a/opengever/officeconnector/interfaces.py
+++ b/opengever/officeconnector/interfaces.py
@@ -16,11 +16,6 @@ class IOfficeConnectorSettings(Interface):
         u'OfficeConnector URLs',
         default=True)
 
-    restapi_enabled = schema.Bool(
-        title=u'OfficeConnector restapi support',
-        description=u'Enable sending restapi payloads Office Connector.',
-        default=False)
-
     officeconnector_editable_types_extra = schema.List(
         title=u'Office Connector supported additional MIME types',
         description=u'A list of Office Connector supported additional MIME types.'
@@ -40,7 +35,4 @@ class IOfficeConnectorSettingsView(Interface):
         pass
 
     def is_checkout_enabled():
-        pass
-
-    def is_restapi_enabled():
         pass

--- a/opengever/officeconnector/service.py
+++ b/opengever/officeconnector/service.py
@@ -7,7 +7,6 @@ from opengever.officeconnector import _
 from opengever.officeconnector.helpers import create_oc_url
 from opengever.officeconnector.helpers import is_officeconnector_attach_feature_enabled  # noqa
 from opengever.officeconnector.helpers import is_officeconnector_checkout_feature_enabled  # noqa
-from opengever.officeconnector.helpers import is_officeconnector_restapi_feature_enabled
 from opengever.oneoffixx import is_oneoffixx_feature_enabled
 from plone import api
 from plone.protect import createToken
@@ -230,24 +229,18 @@ class OfficeConnectorCheckoutPayload(OfficeConnectorPayload):
                 else:
                     payload['filename'] = document.get_filename()
 
-                if is_officeconnector_restapi_feature_enabled():
-                    reauth_querystring = '&'.join((
-                        '_authenticator={}'.format(payload.pop('csrf-token')),
-                        'mode=external',
-                        'reauth=1',
-                    ))
-                    payload['reauth'] = '?'.join(('@@checkout_documents', reauth_querystring))
-                    payload['status'] = 'status'
-                    payload['lock'] = '@lock'
-                    payload['checkout'] = '@checkout'
-                    payload['upload'] = '@tus-replace'
-                    payload['checkin'] = '@checkin'
-                    payload['unlock'] = '@unlock'
-                else:
-                    payload['checkin-with-comment'] = '@@checkin_document'
-                    payload['checkin-without-comment'] = 'checkin_without_comment'
-                    payload['checkout'] = '@@checkout_documents'
-                    payload['upload-form'] = 'file_upload'
+                reauth_querystring = '&'.join((
+                    '_authenticator={}'.format(payload.pop('csrf-token')),
+                    'mode=external',
+                    'reauth=1',
+                ))
+                payload['reauth'] = '?'.join(('@@checkout_documents', reauth_querystring))
+                payload['status'] = 'status'
+                payload['lock'] = '@lock'
+                payload['checkout'] = '@checkout'
+                payload['upload'] = '@tus-replace'
+                payload['checkin'] = '@checkin'
+                payload['unlock'] = '@unlock'
 
             else:
                 # Fail per default

--- a/opengever/officeconnector/tests/test_api_dossier_oneoffixx.py
+++ b/opengever/officeconnector/tests/test_api_dossier_oneoffixx.py
@@ -84,121 +84,6 @@ class TestOfficeconnectorDossierAPIWithOneOffixx(OCIntegrationTestCase):
         self.assertEqual(expected_token, token)
 
         expected_payloads = [{
-            u'checkin-with-comment': u'@@checkin_document',
-            u'checkin-without-comment': u'checkin_without_comment',
-            u'checkout': u'@@checkout_documents',
-            u'content-type': 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-            u'document-url': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/document-38',
-            u'download': u'download',
-            u'filename': None,
-            u'upload-form': u'file_upload',
-            u'uuid': u'createshadowdocument000000000001',
-        }]
-        # XXX - As the last document we touched was XML and we touched XML
-        # namespacing after that, we'll need to reset the browser to circumvent
-        # an ftw.testbrowser bug
-        browser.reset()
-        payloads = self.fetch_document_checkout_payloads(browser, raw_token, token)
-        self.assertEquals(200, browser.status_code)
-        for payload, expected_payload in zip(payloads, expected_payloads):
-            payload_copy = deepcopy(payload)
-            self.assertTrue(payload_copy.pop('csrf-token', None))
-            self.assertFalse(payload_copy.pop('reauth', None))
-            self.assertEqual(expected_payload, payload_copy)
-
-        self.assertTrue(self.shadow_document.is_shadow_document())
-        self.checkout_document(browser, raw_token, payloads[0], self.shadow_document)
-        lock_token = self.lock_document(browser, raw_token, self.shadow_document)
-
-        with open(path_to_asset('addendum.docx')) as f:
-            self.upload_document(browser, raw_token, payloads[0], self.shadow_document, f)
-        self.assertFalse(self.shadow_document.is_shadow_document())
-
-        self.unlock_document(browser, raw_token, self.shadow_document, lock_token)
-        self.checkin_document(browser, raw_token, payloads[0], self.shadow_document, comment='foobar')
-
-    @browsing
-    def test_create_with_oneoffixx_when_not_shadow_document(self, browser):
-        self.login(self.dossier_responsible, browser)
-        with browser.expect_http_error(404):
-            oc_url = self.fetch_document_oneoffixx_oc_url(browser, self.empty_document)
-            self.assertIsNone(oc_url)
-
-
-class TestOfficeconnectorDossierAPIWithOneOffixxWithRESTAPI(TestOfficeconnectorDossierAPIWithOneOffixx):
-    features = (
-        'officeconnector-checkout',
-        'officeconnector-restapi',
-        'oneoffixx'
-    )
-
-    @browsing
-    def test_create_with_oneoffixx(self, browser):
-        self.login(self.dossier_responsible, browser)
-
-        with freeze(FREEZE_DATE):
-            oc_url = self.fetch_document_oneoffixx_oc_url(browser, self.shadow_document)
-
-        self.assertIsNotNone(oc_url)
-        self.assertEquals(200, browser.status_code)
-
-        expected_token = {
-            u'action': u'oneoffixx',
-            u'documents': [u'createshadowdocument000000000001'],
-            u'exp': 4121033100,
-            u'sub': u'robert.ziegler',
-            u'url': u'http://nohost/plone/oc_oneoffixx',
-            }
-        raw_token = oc_url.split(':')[-1]
-        token = jwt.decode(raw_token, JWT_SIGNING_SECRET_PLONE, algorithms=('HS256',))
-        self.assertEqual(expected_token, token)
-
-        expected_payloads = [{
-            u'connect-xml': u'@@oneoffix_connect_xml',
-            u'content-type': u'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-            u'document-url': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/document-38',
-            u'filename': None,
-            u'uuid': u'createshadowdocument000000000001',
-            }]
-
-        payloads = self.fetch_document_oneoffixx_payloads(browser, raw_token, token)
-        self.assertEquals(200, browser.status_code)
-
-        for payload, expected_payload in zip(payloads, expected_payloads):
-            self.assertTrue(payload.pop('csrf-token', None))
-            self.assertEqual(expected_payload, payload)
-
-        expected_oneoffixx_xml = resource_string("opengever.oneoffixx.tests.assets", "oneoffixx_connect_xml.txt")
-
-        with freeze(FREEZE_DATE):
-            oneoffixx_xml = self.download_oneoffixx_xml(browser, raw_token, payloads[0])
-
-        self.maxDiff = None
-        self.assertEqual(expected_oneoffixx_xml.splitlines(), oneoffixx_xml.splitlines())
-
-        tree = ET.ElementTree(ET.fromstring(oneoffixx_xml))
-        namespace = re.match(r'\{.*\}', tree.getroot().tag).group(0)
-        namespace_url = namespace.strip('{}')
-        ET.register_namespace('', namespace_url)
-        ET.register_namespace('xsi', 'http://www.w3.org/2001/XMLSchema-instance')
-
-        raw_token = tree.find(
-            './/{namespace}Command[@Name="InvokeProcess"]'
-            '/{namespace}Parameters'
-            '/{namespace}Add[@key="Arguments"]'
-            .format(namespace=namespace)
-        ).text.split(':')[-1]
-        expected_token = {
-            u'action': u'checkout',
-            u'documents': [u'createshadowdocument000000000001'],
-            u'exp': 4121033100,
-            u'sub': u'robert.ziegler',
-            u'url': u'http://nohost/plone/oc_checkout',
-        }
-        token = jwt.decode(raw_token, JWT_SIGNING_SECRET_PLONE, algorithms=('HS256',))
-        self.assertEqual(expected_token, token)
-
-        expected_payloads = [{
             u'status': u'status',
             u'checkin': u'@checkin',
             u'checkout': u'@checkout',
@@ -224,12 +109,19 @@ class TestOfficeconnectorDossierAPIWithOneOffixxWithRESTAPI(TestOfficeconnectorD
             self.assertEqual(expected_payload, payload_copy)
 
         self.assertTrue(self.shadow_document.is_shadow_document())
-        self.checkout_document_via_api(browser, raw_token, payloads[0], self.shadow_document)
-        self.lock_document_via_api(browser, raw_token, payloads[0], self.shadow_document)
+        self.checkout_document(browser, raw_token, payloads[0], self.shadow_document)
+        self.lock_document(browser, raw_token, payloads[0], self.shadow_document)
 
         with open(path_to_asset('addendum.docx')) as f:
-            self.upload_document_via_api(browser, raw_token, payloads[0], self.shadow_document, f)
+            self.upload_document(browser, raw_token, payloads[0], self.shadow_document, f)
         self.assertFalse(self.shadow_document.is_shadow_document())
 
-        self.unlock_document_via_api(browser, raw_token, payloads[0], self.shadow_document)
-        self.checkin_document_via_api(browser, raw_token, payloads[0], self.shadow_document, comment='foobar')
+        self.unlock_document(browser, raw_token, payloads[0], self.shadow_document)
+        self.checkin_document(browser, raw_token, payloads[0], self.shadow_document, comment='foobar')
+
+    @browsing
+    def test_create_with_oneoffixx_when_not_shadow_document(self, browser):
+        self.login(self.dossier_responsible, browser)
+        with browser.expect_http_error(404):
+            oc_url = self.fetch_document_oneoffixx_oc_url(browser, self.empty_document)
+            self.assertIsNone(oc_url)

--- a/opengever/officeconnector/tests/test_api_task_checkout.py
+++ b/opengever/officeconnector/tests/test_api_task_checkout.py
@@ -15,7 +15,6 @@ class TestOfficeconnectorTaskAPIWithCheckoutWithRESTAPI(OCIntegrationTestCase):
     features = (
         '!officeconnector-attach',
         'officeconnector-checkout',
-        'officeconnector-restapi',
     )
 
     @browsing
@@ -76,16 +75,16 @@ class TestOfficeconnectorTaskAPIWithCheckoutWithRESTAPI(OCIntegrationTestCase):
             self.assertTrue(payload_copy.pop('reauth', None))
             self.assertEqual(expected_payload, payload_copy)
 
-        self.checkout_document_via_api(browser, raw_token, payloads[0], document)
-        self.lock_document_via_api(browser, raw_token, payloads[0], document)
+        self.checkout_document(browser, raw_token, payloads[0], document)
+        self.lock_document(browser, raw_token, payloads[0], document)
 
         original_checksum = sha256(self.download_document(browser, raw_token, payloads[0])).hexdigest()
 
         with open(path_to_asset('addendum.docx')) as f:
-            self.upload_document_via_api(browser, raw_token, payloads[0], document, f)
+            self.upload_document(browser, raw_token, payloads[0], document, f)
 
         new_checksum = sha256(self.download_document(browser, raw_token, payloads[0])).hexdigest()
         self.assertNotEqual(new_checksum, original_checksum)
 
-        self.unlock_document_via_api(browser, raw_token, payloads[0], document)
-        self.checkin_document_via_api(browser, raw_token, payloads[0], document)
+        self.unlock_document(browser, raw_token, payloads[0], document)
+        self.checkin_document(browser, raw_token, payloads[0], document)

--- a/opengever/officeconnector/tests/test_feature.py
+++ b/opengever/officeconnector/tests/test_feature.py
@@ -1,6 +1,5 @@
 from opengever.officeconnector.helpers import is_officeconnector_attach_feature_enabled
 from opengever.officeconnector.helpers import is_officeconnector_checkout_feature_enabled
-from opengever.officeconnector.helpers import is_officeconnector_restapi_feature_enabled
 from opengever.officeconnector.interfaces import IOfficeConnectorSettings
 from opengever.testing import FunctionalTestCase
 from plone import api
@@ -11,44 +10,48 @@ class TestIsOfficeConnectorFeatureEnabled(FunctionalTestCase):
     def test_registry_entry_defaults(self):
         self.assertTrue(is_officeconnector_attach_feature_enabled())
         self.assertTrue(is_officeconnector_checkout_feature_enabled())
-        self.assertFalse(is_officeconnector_restapi_feature_enabled())
 
     def test_if_registry_entries_are_true(self):
-        api.portal.set_registry_record('attach_to_outlook_enabled', True, interface=IOfficeConnectorSettings)
-        api.portal.set_registry_record('direct_checkout_and_edit_enabled', True, interface=IOfficeConnectorSettings)
-        api.portal.set_registry_record('restapi_enabled', True, interface=IOfficeConnectorSettings)
+        api.portal.set_registry_record('attach_to_outlook_enabled', True,
+                                       interface=IOfficeConnectorSettings)
+        api.portal.set_registry_record('direct_checkout_and_edit_enabled', True,
+                                       interface=IOfficeConnectorSettings)
         self.assertTrue(is_officeconnector_attach_feature_enabled())
         self.assertTrue(is_officeconnector_checkout_feature_enabled())
-        self.assertTrue(is_officeconnector_restapi_feature_enabled())
 
     def test_if_registry_entries_are_false(self):
-        api.portal.set_registry_record('attach_to_outlook_enabled', False, interface=IOfficeConnectorSettings)
-        api.portal.set_registry_record('direct_checkout_and_edit_enabled', False, interface=IOfficeConnectorSettings)
-        api.portal.set_registry_record('restapi_enabled', False, interface=IOfficeConnectorSettings)
+        api.portal.set_registry_record('attach_to_outlook_enabled', False,
+                                       interface=IOfficeConnectorSettings)
+        api.portal.set_registry_record('direct_checkout_and_edit_enabled', False,
+                                       interface=IOfficeConnectorSettings)
         self.assertFalse(is_officeconnector_attach_feature_enabled())
         self.assertFalse(is_officeconnector_checkout_feature_enabled())
-        self.assertFalse(is_officeconnector_restapi_feature_enabled())
 
 
 class TestIsOfficeConnectorFeatureEnabledView(FunctionalTestCase):
 
     def test_registry_entry_defaults(self):
-        self.assertTrue(self.portal.restrictedTraverse('@@officeconnector_settings/is_attach_enabled')())
-        self.assertTrue(self.portal.restrictedTraverse('@@officeconnector_settings/is_checkout_enabled')())
-        self.assertFalse(self.portal.restrictedTraverse('@@officeconnector_settings/is_restapi_enabled')())
+        self.assertTrue(self.portal.restrictedTraverse(
+            '@@officeconnector_settings/is_attach_enabled')())
+        self.assertTrue(self.portal.restrictedTraverse(
+            '@@officeconnector_settings/is_checkout_enabled')())
 
     def test_if_registry_entry_is_true(self):
-        api.portal.set_registry_record('attach_to_outlook_enabled', True, interface=IOfficeConnectorSettings)
-        api.portal.set_registry_record('direct_checkout_and_edit_enabled', True, interface=IOfficeConnectorSettings)
-        api.portal.set_registry_record('restapi_enabled', True, interface=IOfficeConnectorSettings)
-        self.assertTrue(self.portal.restrictedTraverse('@@officeconnector_settings/is_attach_enabled')())
-        self.assertTrue(self.portal.restrictedTraverse('@@officeconnector_settings/is_checkout_enabled')())
-        self.assertTrue(self.portal.restrictedTraverse('@@officeconnector_settings/is_restapi_enabled')())
+        api.portal.set_registry_record('attach_to_outlook_enabled', True,
+                                       interface=IOfficeConnectorSettings)
+        api.portal.set_registry_record('direct_checkout_and_edit_enabled', True,
+                                       interface=IOfficeConnectorSettings)
+        self.assertTrue(self.portal.restrictedTraverse(
+            '@@officeconnector_settings/is_attach_enabled')())
+        self.assertTrue(self.portal.restrictedTraverse(
+            '@@officeconnector_settings/is_checkout_enabled')())
 
     def test_false_if_registry_entry_is_false(self):
-        api.portal.set_registry_record('attach_to_outlook_enabled', False, interface=IOfficeConnectorSettings)
-        api.portal.set_registry_record('direct_checkout_and_edit_enabled', False, interface=IOfficeConnectorSettings)
-        api.portal.set_registry_record('restapi_enabled', False, interface=IOfficeConnectorSettings)
-        self.assertFalse(self.portal.restrictedTraverse('@@officeconnector_settings/is_attach_enabled')())
-        self.assertFalse(self.portal.restrictedTraverse('@@officeconnector_settings/is_checkout_enabled')())
-        self.assertFalse(self.portal.restrictedTraverse('@@officeconnector_settings/is_restapi_enabled')())
+        api.portal.set_registry_record('attach_to_outlook_enabled', False,
+                                       interface=IOfficeConnectorSettings)
+        api.portal.set_registry_record('direct_checkout_and_edit_enabled', False,
+                                       interface=IOfficeConnectorSettings)
+        self.assertFalse(self.portal.restrictedTraverse(
+            '@@officeconnector_settings/is_attach_enabled')())
+        self.assertFalse(self.portal.restrictedTraverse(
+            '@@officeconnector_settings/is_checkout_enabled')())

--- a/opengever/testing/integration_test_case.py
+++ b/opengever/testing/integration_test_case.py
@@ -21,7 +21,6 @@ from opengever.document.archival_file import STATE_CONVERTED
 from opengever.document.behaviors.metadata import IDocumentMetadata
 from opengever.document.interfaces import ICheckinCheckoutManager
 from opengever.journal.tests.utils import get_journal_entry
-from opengever.meeting.model import SubmittedDocument
 from opengever.meeting.model.agendaitem import AgendaItem
 from opengever.meeting.wrapper import MeetingWrapper
 from opengever.ogds.base.utils import get_current_admin_unit
@@ -76,7 +75,6 @@ FEATURE_FLAGS = {
                               'IOfficeConnectorSettings.attach_to_outlook_enabled',
     'officeconnector-checkout': 'opengever.officeconnector.interfaces.'
                                 'IOfficeConnectorSettings.direct_checkout_and_edit_enabled',
-    'officeconnector-restapi': 'opengever.officeconnector.interfaces.IOfficeConnectorSettings.restapi_enabled',
     'oneoffixx': 'opengever.oneoffixx.interfaces.IOneoffixxSettings.is_feature_enabled',
     'repositoryfolder-documents-tab': 'opengever.repository.interfaces.IRepositoryFolderRecords.show_documents_tab',
     'repositoryfolder-proposals-tab': 'opengever.repository.interfaces.IRepositoryFolderRecords.show_proposals_tab',


### PR DESCRIPTION
In this PR we remove support for non-API based OfficeConnector actions (checkout, upload, checkin, lock and unlock). This makes API-based OfficeConnector the one and only default.

For https://github.com/4teamwork/opengever.core/issues/5848

## Checkliste
- [x] Profil angepasst? Sind UpgradeSteps vorhanden/nötig?:
- [x] Changelog-Eintrag vorhanden/nötig?

Introduced in GEVER in https://github.com/4teamwork/opengever.core/pull/5126
Introduced in OC in https://github.com/4teamwork/OfficeConnector/pull/307
