### PR TITLE
Fix @history patch endpoint to correctly revert to older document version.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 ------------------------
 
 - Fixes is already done check in multi admin unit tasks completion. [phgross]
+- Fix @history patch endpoint to correctly revert to older document version. [njohner]
 - Fix unicode error in @listing endpoint filters. [lgraf]
 - Fix document serialization for older document versions. [phgross]
 - Add main dossier count to contentstats. [njohner]

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -77,6 +77,15 @@
       permission="opengever.trash.UntrashContent"
       />
 
+
+  <plone:service
+      method="PATCH"
+      name="@history"
+      for="opengever.document.document.IDocumentSchema"
+      factory=".history.HistoryPatch"
+      permission="CMFEditions.RevertToPreviousVersions"
+      />
+
   <plone:service
       method="POST"
       name="@scan-in"

--- a/opengever/api/history.py
+++ b/opengever/api/history.py
@@ -1,0 +1,26 @@
+from plone.restapi.deserializer import json_body
+from plone.restapi.serializer.converters import json_compatible
+from plone.restapi.services import Service
+from opengever.document.interfaces import ICheckinCheckoutManager
+from zope.component import getMultiAdapter
+
+
+class HistoryPatch(Service):
+    """ Copy of the plone.restapi.services.HistoryPatch but uses
+    the ICheckinCheckoutManager to revert to an older file
+    version instead of the portal_repository tool.
+    """
+
+    def reply(self):
+        body = json_body(self.request)
+        version = body["version"]
+
+        # revert the file
+        manager = getMultiAdapter((self.context, self.request),
+                                  ICheckinCheckoutManager)
+        manager.revert_to_version(version)
+
+        title = self.context.title_or_id()
+        msg = u"{} has been reverted to revision {}.".format(title, version)
+
+        return json_compatible({"message": msg})

--- a/opengever/api/tests/test_history.py
+++ b/opengever/api/tests/test_history.py
@@ -1,0 +1,110 @@
+from ftw.testbrowser import browsing
+from opengever.testing import IntegrationTestCase
+from opengever.testing.helpers import create_document_version
+from plone import api
+import json
+
+
+class TestHistoryPatchEndpointForDocuments(IntegrationTestCase):
+
+    @browsing
+    def test_reverting_to_older_version(self, browser):
+        self.login(self.regular_user, browser)
+
+        create_document_version(self.document, 0)
+        create_document_version(self.document, 1)
+
+        self.assertEqual('VERSION 1 DATA', self.document.file.data)
+
+        browser.open(self.document,
+                     view='@history',
+                     data=json.dumps({"version": 0}),
+                     method='PATCH',
+                     headers=self.api_headers)
+
+        self.assertEqual(200, browser.status_code)
+        self.assertEqual('VERSION 0 DATA', self.document.file.data)
+
+    @browsing
+    def test_reverting_to_older_version_creates_new_version(self, browser):
+        self.login(self.regular_user, browser)
+
+        create_document_version(self.document, 0)
+        create_document_version(self.document, 1)
+
+        repo_tool = api.portal.get_tool('portal_repository')
+        self.assertEqual(2, len(repo_tool.getHistory(self.document)))
+        self.assertEqual(1, self.document.version_id)
+
+        browser.open(self.document,
+                     view='@history',
+                     data=json.dumps({"version": 0}),
+                     method='PATCH',
+                     headers=self.api_headers)
+
+        self.assertEqual(200, browser.status_code)
+        self.assertEqual(3, len(repo_tool.getHistory(self.document)))
+        self.assertEqual(2, self.document.version_id)
+
+    @browsing
+    def test_reverting_to_older_version_does_not_revert_metadata(self, browser):
+        self.login(self.regular_user, browser)
+
+        self.document.title = "Title version 0"
+        create_document_version(self.document, 0)
+        self.document.title = "Title version 1"
+        create_document_version(self.document, 1)
+
+        self.assertEqual('Title version 1', self.document.title)
+
+        browser.open(self.document,
+                     view='@history',
+                     data=json.dumps({"version": 0}),
+                     method='PATCH',
+                     headers=self.api_headers)
+
+        self.assertEqual('Title version 1', self.document.title)
+
+    @browsing
+    def test_reverting_to_older_version_fails_when_document_checked_out(self, browser):
+        self.login(self.regular_user, browser)
+
+        create_document_version(self.document, 0)
+        create_document_version(self.document, 1)
+        self.checkout_document(self.document)
+
+        self.assertEqual('VERSION 1 DATA', self.document.file.data)
+
+        with browser.expect_http_error(401):
+            browser.open(self.document,
+                         view='@history',
+                         data=json.dumps({"version": 0}),
+                         method='PATCH',
+                         headers=self.api_headers)
+
+        self.assertEqual(
+            {u'message': u'Unauthorized()', u'type': u'Unauthorized'},
+            browser.json)
+        self.assertEqual('VERSION 1 DATA', self.document.file.data)
+
+    @browsing
+    def test_reverting_inexistant_version_fails(self, browser):
+        self.login(self.regular_user, browser)
+
+        create_document_version(self.document, 0)
+
+        self.assertEqual('VERSION 0 DATA', self.document.file.data)
+
+        with browser.expect_http_error(500):
+            browser.open(self.document,
+                         view='@history',
+                         data=json.dumps({"version": 3}),
+                         method='PATCH',
+                         headers=self.api_headers)
+
+        self.assertEqual(
+            {u'message':
+                u"Retrieving of '<Document at {}>' failed. Version '3' "
+                u"does not exist. ".format(self.document.absolute_url_path()),
+             u'type': u'ArchivistRetrieveError'}, browser.json)
+        self.assertEqual('VERSION 0 DATA', self.document.file.data)

--- a/opengever/document/checkout/manager.py
+++ b/opengever/document/checkout/manager.py
@@ -235,7 +235,7 @@ class CheckinCheckoutManager(object):
                                                     self.context)
 
     def is_revert_allowed(self):
-        """Return wheter reverting a the document to a previous version is
+        """Return wheter reverting the document to a previous version is
         allowed.
         """
         # is it already checked out?


### PR DESCRIPTION
In this PR we overwrite the `@history` PATCH endpoint for documents to correctly revert documents to older versions. Indeed in GEVER we have customised the reverting to older versions for documents, to avoid reverting the metadata (we only revert the file data), but the API was doing the standard Plone revert.

For https://github.com/4teamwork/opengever.core/issues/6008

## Checkliste
- [x] Changelog-Eintrag vorhanden/nötig?
