### PR TITLE
Fixes is already done check in multi admin unit tasks completion.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2019.4.0rc6 (unreleased)
 ------------------------
 
+- Fixes is already done check in multi admin unit tasks completion. [phgross]
 - Fix unicode error in @listing endpoint filters. [lgraf]
 - Fix document serialization for older document versions. [phgross]
 - Add main dossier count to contentstats. [njohner]

--- a/opengever/task/browser/complete.py
+++ b/opengever/task/browser/complete.py
@@ -322,7 +322,7 @@ class CompleteSuccessorTaskReceiveDelivery(BrowserView):
         if len(response_container) == 0:
             return False
 
-        last_response = response_container[-1]
+        last_response = response_container.list()[-1]
         current_user = AccessControl.getSecurityManager().getUser()
 
         if last_response.transition == data['transition'] and \

--- a/opengever/task/tests/test_resolve.py
+++ b/opengever/task/tests/test_resolve.py
@@ -1,0 +1,51 @@
+from Acquisition import aq_inner
+from Acquisition import aq_parent
+from ftw.testbrowser import browsing
+from ftw.testbrowser.pages.statusmessages import info_messages
+from opengever.base.interfaces import IReferenceNumber
+from opengever.task.browser.transitioncontroller import RequestChecker
+from opengever.testing import IntegrationTestCase
+from plone import api
+
+
+class TestResolveMultiAdminUnitTasks(IntegrationTestCase):
+
+    def setUp(self):
+        super(TestResolveMultiAdminUnitTasks, self).setUp()
+        self.org_is_remote = RequestChecker.is_remote
+        RequestChecker.is_remote = True
+
+    def tearDown(self):
+        super(TestResolveMultiAdminUnitTasks, self).tearDown()
+        RequestChecker.is_remote = self.org_is_remote
+
+    @browsing
+    def test_resolve_copies_document(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        for task in (self.private_task, self.inbox_task):
+            task.task_type = 'correction'
+            task.responsible_client = 'rk'
+            task.responsible = self.regular_user.id
+            self.set_workflow_state('task-state-in-progress', task)
+            task.sync()
+
+        self.register_successor(self.private_task, self.inbox_task)
+        browser.open(self.inbox_task, view='tabbedview_view-overview')
+        browser.click_on('task-transition-in-progress-resolved')
+
+        document_label = '%s (%s, %s)' % (
+            self.document.Title(),
+            IReferenceNumber(self.document).get_number(),
+            aq_parent(aq_inner(self.document)).Title())
+        browser.fill({'Documents to deliver': document_label, 'Response': 'Done!'})
+        browser.click_on('Save')
+
+        self.assertEqual('task-state-resolved',
+                         api.content.get_state(self.inbox_task))
+        self.assertEqual(
+            ['The documents were delivered to the issuer and the tasks were completed.'],
+            info_messages())
+        self.assertEqual(1, len(self.private_task.listFolderContents()))
+        copied_doc, = self.private_task.listFolderContents()
+        self.assertEqual(u'RE: Vertr\xe4gsentwurf', copied_doc.title)


### PR DESCRIPTION
Since the TaskReponse rebuild, accessing the response container by
indexing is no longer supported.

I also added a minimal test for the whole mutli-adminunit completion, so we should noticed similar problems in the future. 

For #6062.

## Checkliste

_Zutreffendes soll angehakt stehengelassen werden._
- [x] Wurde etwas an der `Aufgabe` angepasst? Funktioniert das auch mit einer `Weiterleitung`? _Die Weiterleitung kennt keine solche Transition._
- [x] Changelog-Eintrag vorhanden/nötig?
