### PR TITLE
Task completion history

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 ------------------------
 
 - Fix fallback to default sorting index in listing endpoint. [njohner]
+- Display returned documents in the task-resolved history entry. [phgross]
 - Fixes is already done check in multi admin unit tasks completion. [phgross]
 - Fix @history patch endpoint to correctly revert to older document version. [njohner]
 - Fix unicode error in @listing endpoint filters. [lgraf]

--- a/opengever/task/browser/complete.py
+++ b/opengever/task/browser/complete.py
@@ -210,7 +210,7 @@ class CompleteSuccessorTaskForm(Form):
 
                     # set relation flag
                     doc._v__is_relation = True
-                    response.add_change('relatedItems',
+                    response.add_change('related_items',
                         '',
                         linked(doc, doc.Title()),
                         _(u'label_related_items', default=u"Related Items"))
@@ -221,7 +221,7 @@ class CompleteSuccessorTaskForm(Form):
             else:
                 # append only the relation on the response
                 doc._v__is_relation = True
-                response.add_change('relatedItems',
+                response.add_change('related_items',
                     '',
                     linked(doc, doc.Title()),
                     _(u'label_related_items', default=u"Related Items"))

--- a/opengever/task/locales/de/LC_MESSAGES/opengever.task.po
+++ b/opengever/task/locales/de/LC_MESSAGES/opengever.task.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2019-10-17 19:56+0000\n"
+"POT-Creation-Date: 2019-11-18 10:28+0000\n"
 "PO-Revision-Date: 2015-02-17 18:41+0100\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -1066,6 +1066,11 @@ msgstr "Wieder eröffnet durch ${user}"
 #: ./opengever/task/response_description.py
 msgid "transition_msg_resolve"
 msgstr "Erledigt durch ${user}"
+
+#. Default: "Resolved by ${user} and ${documents} returned"
+#: ./opengever/task/response_description.py
+msgid "transition_msg_resolve_with_documents"
+msgstr "Erledigt durch ${user} und ${documents} zurückgesandt."
 
 #. Default: "Revised by ${user}"
 #: ./opengever/task/response_description.py

--- a/opengever/task/locales/fr/LC_MESSAGES/opengever.task.po
+++ b/opengever/task/locales/fr/LC_MESSAGES/opengever.task.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-10-17 19:56+0000\n"
+"POT-Creation-Date: 2019-11-18 10:28+0000\n"
 "PO-Revision-Date: 2017-12-03 11:47+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-task/fr/>\n"
@@ -1068,6 +1068,11 @@ msgstr "Réouvert par ${user}"
 #: ./opengever/task/response_description.py
 msgid "transition_msg_resolve"
 msgstr "Accompli par ${user}"
+
+#. Default: "Resolved by ${user} and ${documents} returned"
+#: ./opengever/task/response_description.py
+msgid "transition_msg_resolve_with_documents"
+msgstr ""
 
 #. Default: "Revised by ${user}"
 #: ./opengever/task/response_description.py

--- a/opengever/task/locales/opengever.task.pot
+++ b/opengever/task/locales/opengever.task.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2019-10-17 19:56+0000\n"
+"POT-Creation-Date: 2019-11-18 10:28+0000\n"
 "PO-Revision-Date: 2009-02-25 14:39+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -1063,6 +1063,11 @@ msgstr ""
 #. Default: "Resolved by ${user}"
 #: ./opengever/task/response_description.py
 msgid "transition_msg_resolve"
+msgstr ""
+
+#. Default: "Resolved by ${user} and ${documents} returned"
+#: ./opengever/task/response_description.py
+msgid "transition_msg_resolve_with_documents"
 msgstr ""
 
 #. Default: "Revised by ${user}"

--- a/opengever/task/response_description.py
+++ b/opengever/task/response_description.py
@@ -1,4 +1,5 @@
 from opengever.base.utils import to_safe_html
+from opengever.document.widgets.document_link import DocumentLinkWidget
 from opengever.ogds.base.actor import Actor
 from opengever.task import _
 
@@ -145,9 +146,26 @@ class Resolve(ResponseDescription):
 
     css_class = 'complete'
 
+    def get_documents_labels(self):
+        docs, subtasks = self.get_added_objects(self.response)
+        document_links = [DocumentLinkWidget(doc).render() for doc in docs]
+        related_items_links = [
+            change.get('after').decode('utf-8') for change in self.response.changes
+            if change.get('field_id') == 'related_items']
+
+        return u', '.join(document_links + related_items_links)
+
     def msg(self):
-        return _('transition_msg_resolve', u'Resolved by ${user}',
-                 mapping=self._msg_mapping)
+        document_labels = self.get_documents_labels()
+        if document_labels:
+            return _('transition_msg_resolve_with_documents',
+                     u'Resolved by ${user} and ${documents} returned',
+                     mapping={'user': self.creator_link(),
+                              'documents': document_labels})
+
+        else:
+            return _('transition_msg_resolve', u'Resolved by ${user}',
+                     mapping=self._msg_mapping)
 
     def label(self):
         return _('transition_label_resolve', u'Task resolved')

--- a/opengever/task/response_description.py
+++ b/opengever/task/response_description.py
@@ -287,12 +287,12 @@ class Reassign(ResponseDescription):
         responsible_old = Actor.lookup(change.get('before')).get_link()
 
         if not change.get('before') == self.response.creator:
-          return _('transition_msg_delegated_reassign',
-                   u'Reassigned from ${responsible_old} to '
-                   u'${responsible_new} by ${user}',
-                   mapping={'user': self.creator_link(),
-                            'responsible_new': responsible_new,
-                            'responsible_old': responsible_old})
+            return _('transition_msg_delegated_reassign',
+                     u'Reassigned from ${responsible_old} to '
+                     u'${responsible_new} by ${user}',
+                     mapping={'user': self.creator_link(),
+                              'responsible_new': responsible_new,
+                              'responsible_old': responsible_old})
 
         return _('transition_msg_reassign',
                  u'Reassigned from ${responsible_old} to '

--- a/opengever/task/tests/test_resolve.py
+++ b/opengever/task/tests/test_resolve.py
@@ -46,6 +46,15 @@ class TestResolveMultiAdminUnitTasks(IntegrationTestCase):
         self.assertEqual(
             ['The documents were delivered to the issuer and the tasks were completed.'],
             info_messages())
+
         self.assertEqual(1, len(self.private_task.listFolderContents()))
         copied_doc, = self.private_task.listFolderContents()
         self.assertEqual(u'RE: Vertr\xe4gsentwurf', copied_doc.title)
+
+        browser.open(self.inbox_task, view='tabbedview_view-overview')
+
+        self.assertEqual(
+            u'Resolved by B\xe4rfuss K\xe4thi (kathi.barfuss) and Vertr\xe4gsentwurf returned',
+            browser.css('.answers h3')[0].text)
+        self.assertEqual(self.document.absolute_url(),
+                         browser.css('.answers h3 a')[1].get('href'))


### PR DESCRIPTION
Display returned documents in the task-resolved history entry.

When resolving a multi admin unit task, the user has the possibility to return some documents, those are now displayed in the task history. Both ways referenced or contained documents are handled and combined if necessary.

![Bildschirmfoto 2019-11-18 um 14 33 29](https://user-images.githubusercontent.com/485755/69134221-6f404f80-0ab7-11ea-8e28-02130172f8b3.png)
![Bildschirmfoto 2019-11-18 um 14 33 26](https://user-images.githubusercontent.com/485755/69134222-6f404f80-0ab7-11ea-9da1-30a730f2ffbf.png)

For #6065

## Checkliste

_Zutreffendes soll angehakt stehengelassen werden._

- [x] Wurde etwas an der `Aufgabe` angepasst? Funktioniert das auch mit einer `Weiterleitung`? Die Weiterleitung kennt keine solche Funktionalität
- [x] Gibt es neue Übersetzungen?
  - [x] Sind alle msg-Strings in Übersetzungen Unicode?
  - [x] Wird die richtige i18n-domain verwendet (Copy-Paste Fehler sind hier häufig)?
- [x] Changelog-Eintrag vorhanden/nötig?

