### PR TITLE
Pin ftw.monitor = 1.0.0 for next release.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2019.4.0rc6 (unreleased)
 ------------------------
 
+- Pin ftw.monitor to 1.0.0. [lgraf]
 - Fix fallback to default sorting index in listing endpoint. [njohner]
 - Fixes is already done check in multi admin unit tasks completion. [phgross]
 - Fix @history patch endpoint to correctly revert to older document version. [njohner]

--- a/versions.cfg
+++ b/versions.cfg
@@ -89,6 +89,7 @@ ftw.lawgiver = 1.14.1
 ftw.mail = 2.6.1
 ftw.maintenanceserver = 1.1.2
 ftw.mobilenavigation = 1.4.8
+ftw.monitor = 1.0.0
 ftw.pdfgenerator = 1.6.4
 ftw.profilehook = 1.2.1
 ftw.raven = 1.2.0


### PR DESCRIPTION
This adds a version pin for the initial version of `ftw.monitor`.

This is so we have a version pin in place going forward (for the next release), even though for currently rolling it out without being tied to a release we've already added a temporary one in 4teamwork/gever-buildouts#31

## Checkliste

- [x] Changelog-Eintrag vorhanden/nötig?