### PR TITLE
Fix fallback to default sorting index in listing endpoint.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2019.4.0rc6 (unreleased)
 ------------------------
 
+- Fix fallback to default sorting index in listing endpoint. [njohner]
 - Fixes is already done check in multi admin unit tasks completion. [phgross]
 - Fix @history patch endpoint to correctly revert to older document version. [njohner]
 - Fix unicode error in @listing endpoint filters. [lgraf]

--- a/opengever/api/listing.py
+++ b/opengever/api/listing.py
@@ -258,7 +258,7 @@ class Listing(Service):
             rows = 25
 
         sort_on = self.request.form.get('sort_on', DEFAULT_SORT_INDEX)
-        sort_on = FIELDS.get(sort_on, (None, DEFAULT_SORT_INDEX))[2]
+        sort_on = FIELDS.get(sort_on, (None, None, DEFAULT_SORT_INDEX))[2]
         sort_order = self.request.form.get('sort_order', 'descending')
         term = self.request.form.get('search', '').strip()
         columns = self.request.form.get('columns', [])

--- a/opengever/api/tests/test_listing.py
+++ b/opengever/api/tests/test_listing.py
@@ -249,7 +249,7 @@ class TestListingEndpointWithSolr(IntegrationTestCase):
                      headers={'Accept': 'application/json'})
 
         sort = self.conn.search.call_args[0][0]["sort"]
-        self.assertEqual('desponsible desc', sort)
+        self.assertEqual('responsible desc', sort)
 
     @browsing
     def test_sort_on_inexistant_field(self, browser):

--- a/opengever/api/tests/test_listing.py
+++ b/opengever/api/tests/test_listing.py
@@ -239,3 +239,25 @@ class TestListingEndpointWithSolr(IntegrationTestCase):
         self.assertEqual(u'(Title:feedb\xe4ck* OR SearchableText:feedb\xe4ck* '
                          u'OR metadata:feedb\xe4ck*)',
                          query)
+
+    @browsing
+    def test_sort_on_existing_field(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        view = '@listing?name=documents&columns=title&sort_on=responsible'
+        browser.open(self.repository_root, view=view,
+                     headers={'Accept': 'application/json'})
+
+        sort = self.conn.search.call_args[0][0]["sort"]
+        self.assertEqual('desponsible desc', sort)
+
+    @browsing
+    def test_sort_on_inexistant_field(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        view = '@listing?name=documents&columns=title&sort_on=inexistant'
+        browser.open(self.repository_root, view=view,
+                     headers={'Accept': 'application/json'})
+
+        sort = self.conn.search.call_args[0][0]["sort"]
+        self.assertEqual('modified desc', sort)


### PR DESCRIPTION
The fallback to the default sorting index in the `listing` endpoint was broken. This PR fixes that bug and adds tests that sorting parameters get set properly.

## Checkliste

- [x] Changelog-Eintrag vorhanden/nötig?

For https://sentry.4teamwork.ch/sentry/onegov-gever/issues/35027/