### PR TITLE
Also return facet labels in solrsearch endpoint.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,7 @@ Changelog
 - Pin ftw.monitor to 1.0.0. [lgraf]
 - Allow teams as task responsible when delegating a task. [phgross]
 - Fix contentlisting and API summary for documents inside tasks. [phgross]
+- Also return facet labels in solrsearch endpoint. [njohner]
 - Fix fallback to default sorting index in listing endpoint. [njohner]
 - Display returned documents in the task-resolved history entry. [phgross]
 - Fixes is already done check in multi admin unit tasks completion. [phgross]

--- a/docs/public/dev-manual/api/searching.rst
+++ b/docs/public/dev-manual/api/searching.rst
@@ -160,4 +160,58 @@ Weitere optionale Parameter:
 - ``sort``: Sortierung nach einem indexierten Feld
 
 
+Facetten
+~~~~~~~~
+``facet``: Muss auf ``true`` gesetzt sein damit Solr die Facetten zurückgibt.
+``facet.field``: Feld für welches Solr Facetten zurückgeben soll.
+
+Beispiel für ein Suchabfrage mit Facetten für ``responsible`` und ``portal_type``:
+
+  .. sourcecode:: http
+
+    GET /plone/@solrsearch?facet=true&facet.field=portal_type&facet.field=responsible HTTP/1.1
+
+  .. sourcecode:: http
+
+    HTTP/1.1 200 OK
+    Content-Type: application/json
+
+    {
+      "@id": "/plone/@solrsearch?facet=true&facet.field=portal_type&facet.field=responsible",
+      "facet_counts": {
+        "portal_type": {
+          "opengever.document.document": {
+            "count": 2
+          }
+        },
+        "responsible": {
+          "committee:161": {
+            "count": 2,
+            "label": "Kommission für Rechtsfragen"
+          },
+          "hugo.boss": {
+            "count": 1,
+            "label": "Hugo Boss"
+          }
+        }
+      },
+      "items": [
+        {
+          "@id": "/plone/ordnungssystem/fuehrung/dossier-23/document-59",
+          "filesize": 12303,
+          "modified": "2019-03-11T13:50:14+00:00",
+          "title": "Ein Brief"
+        },
+        {
+          "@id": "/plone/ordnungssystem/fuehrung/dossier-23/document-54",
+          "filesize": 8574,
+          "modified": "2019-03-11T12:32:24+00:00",
+          "title": "Eine Mappe"
+        }
+      ],
+      "items_total": 2,
+      "rows": 25,
+      "start": 0
+    }
+
 .. disqus::

--- a/opengever/api/listing.py
+++ b/opengever/api/listing.py
@@ -290,9 +290,6 @@ class Listing(Service):
         for item in items[start:start + rows]:
             res['items'].append(create_list_item(item, columns))
 
-        facets = dict((field, dict((facet, {"count": count})
-                                   for facet, count in facets.items()))
-                      for field, facets in facet_counts.items())
         if facet_counts:
             for field, facets in facet_counts.items():
                 transform = FACET_TRANSFORMS.get(field)

--- a/opengever/api/listing.py
+++ b/opengever/api/listing.py
@@ -224,6 +224,7 @@ FACET_TRANSFORMS = {
     'document_type': translate_document_type,
     'task_type': translate_task_type,
     'checked_out': display_name,
+    'Creator': display_name,
 }
 
 
@@ -292,7 +293,7 @@ class Listing(Service):
 
         if facet_counts:
             for field, facets in facet_counts.items():
-                transform = FACET_TRANSFORMS.get(field)
+                transform = FACET_TRANSFORMS.get(FIELDS[field][0])
                 for facet, count in facets.items():
                     facets[facet] = {"count": count}
                     if transform:

--- a/opengever/api/listing.py
+++ b/opengever/api/listing.py
@@ -297,6 +297,8 @@ class Listing(Service):
                     facets[facet] = {"count": count}
                     if transform:
                         facets[facet]['label'] = transform(facet)
+                    else:
+                        facets[facet]['label'] = facet
             res['facets'] = facet_counts
 
         return res

--- a/opengever/api/solrsearch.py
+++ b/opengever/api/solrsearch.py
@@ -1,5 +1,6 @@
 from ftw.solr.interfaces import ISolrSearch
 from ftw.solr.query import make_query
+from opengever.api.listing import FACET_TRANSFORMS
 from opengever.base.interfaces import ISearchSettings
 from opengever.base.solr import OGSolrContentListing
 from plone import api
@@ -143,6 +144,13 @@ class SolrSearchGet(Service):
             "rows": rows,
         }
 
-        if resp.facets:
-            res['facet_counts'] = resp.facets
+        facet_counts = {}
+        for field, facets in resp.facets.items():
+            facet_counts[field] = {}
+            transform = FACET_TRANSFORMS.get(field)
+            for facet, count in facets.items():
+                facet_counts[field][facet] = {"count": count}
+                if transform:
+                    facet_counts[field][facet]['label'] = transform(facet)
+        res['facet_counts'] = facet_counts
         return res

--- a/opengever/api/solrsearch.py
+++ b/opengever/api/solrsearch.py
@@ -143,6 +143,6 @@ class SolrSearchGet(Service):
             "rows": rows,
         }
 
-        if 'facet_counts' in resp.body:
-            res['facet_counts'] = resp.body['facet_counts']
+        if resp.facets:
+            res['facet_counts'] = resp.facets
         return res

--- a/opengever/api/solrsearch.py
+++ b/opengever/api/solrsearch.py
@@ -152,5 +152,7 @@ class SolrSearchGet(Service):
                 facet_counts[field][facet] = {"count": count}
                 if transform:
                     facet_counts[field][facet]['label'] = transform(facet)
+                else:
+                    facet_counts[field][facet]['label'] = facet
         res['facet_counts'] = facet_counts
         return res

--- a/opengever/api/tests/test_solrsearch.py
+++ b/opengever/api/tests/test_solrsearch.py
@@ -1,5 +1,6 @@
 from ftw.testbrowser import browsing
 from opengever.testing import IntegrationTestCase
+from unittest import skip
 
 
 class TestSolrSearchGet(IntegrationTestCase):
@@ -194,6 +195,10 @@ class TestSolrSearchGet(IntegrationTestCase):
         browser.open(url, method='GET', headers=self.api_headers)
 
         self.assertIn(u'facet_counts', browser.json)
+
+    @skip("Just a reminder to test that facets also return translated labels")
+    def test_returns_facet_labels(self):
+        pass
 
     @browsing
     def test_default_start_and_rows(self, browser):

--- a/opengever/api/tests/test_solrsearch.py
+++ b/opengever/api/tests/test_solrsearch.py
@@ -42,8 +42,8 @@ class TestSolrSearchGet(IntegrationTestCase):
         },
         "facet_counts": {
             "portal_type": {
-                "opengever.dossier.businesscasedossier": 2,
-                "opengever.document.document": 1
+                "opengever.dossier.businesscasedossier": {'count': 2},
+                "opengever.document.document": {'count': 1}
             }
         },
         "highlighting": {

--- a/opengever/api/tests/test_solrsearch.py
+++ b/opengever/api/tests/test_solrsearch.py
@@ -41,11 +41,9 @@ class TestSolrSearchGet(IntegrationTestCase):
             ]
         },
         "facet_counts": {
-            "facet_fields": {
-                "portal_type": [
-                    "opengever.dossier.businesscasedossier", 2,
-                    "opengever.document.document", 1
-                ]
+            "portal_type": {
+                "opengever.dossier.businesscasedossier": 2,
+                "opengever.document.document": 1
             }
         },
         "highlighting": {


### PR DESCRIPTION
The `solrsearch` endpoint returned the facets directly as received from solr, without any of cleanup done in the `SolrResponse` and in the `@listing` endpoint, i.e. in the form:
```
"facet_counts": {
    "facet_fields": {
        "document_type": [
            "contract",
            1,
            "request",
            1
        ]
    },
    "facet_heatmaps": {},
    "facet_intervals": {},
    "facet_queries": {},
    "facet_ranges": {}
}
```
This is hard to use in the frontend and labels for the facets are missing, which poses challenges for the translations in the frontend.

In this PR, we fix the `facet_counts` in the response to match that of `@listing` endpoint:
- We use the facets from `SolrResponse`, which is a dictionary of facets and counts (instead of the list with every second element being a facet or a count)
- We add the labels to the facets for certain fields, as done in the `@listing` endpoint

Response now looks like:
```
    "facet_counts": {
        "document_type": {
            "contract": {
                "count": 1,
                "label": "Vertrag"
            },
            "request": {
                "count": 1,
                "label": "Antrag"
            }
        },
        "responsible": {
            "committee:161": {
                "count": 2,
                "label": "Kommission für Rechtsfragen"
            }
        }
    }
```
For https://github.com/4teamwork/opengever.core/issues/6026

Note that we should extract the method preparing the facets for the response to a separate function used in both the `listing` and `solrsearch` endpoints, but this will be done when refactoring the `listing` endpoint (https://github.com/4teamwork/opengever.core/issues/5901)

## Checkliste
- [x] Changelog-Eintrag vorhanden/nötig?
- [x] Aktualisierung Dokumentation vorhanden/nötig?
