### PR TITLE
Allow teams as task responsible when delegating a task

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 ------------------------
 
 - Pin ftw.monitor to 1.0.0. [lgraf]
+- Allow teams as task responsible when delegating a task. [phgross]
 - Fix fallback to default sorting index in listing endpoint. [njohner]
 - Display returned documents in the task-resolved history entry. [phgross]
 - Fixes is already done check in multi admin unit tasks completion. [phgross]

--- a/opengever/task/browser/delegate/recipients.py
+++ b/opengever/task/browser/delegate/recipients.py
@@ -29,7 +29,7 @@ class ISelectRecipientsSchema(Schema):
         required=True,
         missing_value=[],
         value_type=schema.Choice(
-            source=AllUsersInboxesAndTeamsSourceBinder()))
+            source=AllUsersInboxesAndTeamsSourceBinder(include_teams=True)))
 
     documents = schema.List(
         title=_(u'delegate_label_documents', default=u'Attach documents'),

--- a/opengever/task/tests/test_delegate.py
+++ b/opengever/task/tests/test_delegate.py
@@ -77,3 +77,20 @@ class TestDelegateTaskForm(IntegrationTestCase):
         self.assertEqual(
             ['Required input is missing.'],
             browser.css('#formfield-form-widgets-responsibles .error').text)
+
+    @browsing
+    def test_teams_are_selectable_as_responsible(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        browser.open(self.task, view='delegate_recipients')
+
+        form = browser.find_form_by_field('Responsibles')
+        form.find_widget('Responsibles').fill(['team:1'])
+        browser.css('#form-buttons-save').first.click()  # can't use submit()
+
+        form = browser.find_form_by_field('Issuer')
+        form.find_widget('Issuer').fill(self.dossier_responsible.getId())
+        browser.css('#form-buttons-save').first.click()  # can't use submit()
+
+        self.assertEqual(
+            ['1 subtasks were create.'], statusmessages.info_messages())


### PR DESCRIPTION
For #5929.

## Checkliste

_Zutreffendes soll angehakt stehengelassen werden._

- [ ] Wurde etwas an der `Aufgabe` angepasst? Funktioniert das auch mit einer `Weiterleitung`? Die Weiterleitung kann nicht delegiert werden.
- [x] Changelog-Eintrag vorhanden/nötig?
