### PR TITLE
Fix contentlisting and API summary for documents inside tasks.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 
 - Pin ftw.monitor to 1.0.0. [lgraf]
 - Allow teams as task responsible when delegating a task. [phgross]
+- Fix contentlisting and API summary for documents inside tasks. [phgross]
 - Fix fallback to default sorting index in listing endpoint. [njohner]
 - Display returned documents in the task-resolved history entry. [phgross]
 - Fixes is already done check in multi admin unit tasks completion. [phgross]

--- a/opengever/api/tests/test_summary.py
+++ b/opengever/api/tests/test_summary.py
@@ -157,3 +157,13 @@ class TestGeverJSONSummarySerializer(IntegrationTestCase):
              u'title': u'Vertragsentwurf \xdcberpr\xfcfen',
              u'filename': None,
              u'filesize': None}, summary)
+
+    @browsing
+    def test_summary_with_is_locked_on_tasks_containing_documents(self, browser):
+        self.login(self.regular_user, browser)
+
+        self.task.text = u'Sample description'
+
+        browser.open(self.task.absolute_url() +
+                     '?metadata_fields:list=is_locked',
+                     headers={'Accept': 'application/json'})

--- a/opengever/document/contentlisting.py
+++ b/opengever/document/contentlisting.py
@@ -1,17 +1,17 @@
 from ftw import bumblebee
 from opengever.base.browser.helper import get_css_class
+from opengever.base.contentlisting import OpengeverRealContentListingObject
 from opengever.bumblebee import is_bumblebee_feature_enabled
 from opengever.document.document import Document
 from opengever.document.widgets.document_link import DocumentLinkWidget
 from opengever.mail.mail import OGMail
 from opengever.trash.trash import ITrashed
 from plone import api
-from plone.app.contentlisting.realobject import RealContentListingObject
 from zope.component import getMultiAdapter
 from zope.globalrequest import getRequest
 
 
-class DocumentContentListingObject(RealContentListingObject):
+class DocumentContentListingObject(OpengeverRealContentListingObject):
 
     @property
     def is_document(self):


### PR DESCRIPTION
The original RealContentListingObject drops the acquistion information, when accessing the value. This lead to problems when calling getOwner in the Title accessor for example. This has been already fixed for OpengeverRealContentListingObject but not for the document one.

For #6057 

## Checkliste

_Zutreffendes soll angehakt stehengelassen werden._
- [x] Gibt es neue Funktionalität mit einem `Dokument`? Funktioniert das auch mit einem `Mail`?
- [x] Changelog-Eintrag vorhanden/nötig?
