### PR TITLE
Update French translations for release 2019.4

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,7 @@ Changelog
 2019.4.1 (unreleased)
 ---------------------
 
-- Nothing changed yet.
+- Update French translations. [njohner]
 
 
 2019.4.0 (2019-11-22)

--- a/opengever/base/locales/de/LC_MESSAGES/plone.po
+++ b/opengever/base/locales/de/LC_MESSAGES/plone.po
@@ -160,7 +160,7 @@ msgid "disposition-transition-appraised-to-closed"
 msgstr "Dossiers aussondern"
 
 msgid "disposition-transition-archive"
-msgstr "Archivieren"
+msgstr "Archivierung bestätigen"
 
 msgid "disposition-transition-close"
 msgstr "Dossiers aussondern"

--- a/opengever/base/locales/fr/LC_MESSAGES/plone.po
+++ b/opengever/base/locales/fr/LC_MESSAGES/plone.po
@@ -160,7 +160,7 @@ msgid "disposition-transition-appraised-to-closed"
 msgstr "Offre clôturée"
 
 msgid "disposition-transition-archive"
-msgstr "Archivage confirmé"
+msgstr "Confirmer archivage"
 
 msgid "disposition-transition-close"
 msgstr "Offre clôturée"

--- a/opengever/core/locales/fr/LC_MESSAGES/ftw.lawgiver.po
+++ b/opengever/core/locales/fr/LC_MESSAGES/ftw.lawgiver.po
@@ -16,20 +16,20 @@ msgstr ""
 
 #: ./opengever/core/lawgiver.zcml
 msgid "dispose"
-msgstr ""
+msgstr "livrer"
 
 #: ./opengever/core/lawgiver.zcml
 msgid "manage the repository"
-msgstr ""
+msgstr "administrer le système de classement"
 
 #: ./opengever/core/lawgiver.zcml
 msgid "trash"
-msgstr ""
+msgstr "mettre dans la corbeille"
 
 #: ./opengever/core/lawgiver.zcml
 msgid "use the REST API"
-msgstr ""
+msgstr "utiliser la REST API"
 
 #: ./opengever/core/lawgiver.zcml
 msgid "use the developer tools"
-msgstr ""
+msgstr "utiliser les outils de développement"

--- a/opengever/core/locales/fr/LC_MESSAGES/opengever.core.po
+++ b/opengever/core/locales/fr/LC_MESSAGES/opengever.core.po
@@ -260,7 +260,7 @@ msgstr "Requête soumise"
 #: ./opengever/core/profiles/default/actions.xml
 #: ./opengever/core/upgrades/20191028103858_add_ui_switcher/actions.xml
 msgid "Switch UI"
-msgstr ""
+msgstr "Utiliser la nouvelle interface"
 
 #: ./opengever/core/profiles/default/types/opengever.task.task.xml
 msgid "Task"
@@ -281,12 +281,12 @@ msgstr "Dossier des modèles"
 #: ./opengever/core/profiles/default/types/opengever.workspace.todo.xml
 #: ./opengever/core/upgrades/20190710151706_install_workspace_todo_type/types/opengever.workspace.todo.xml
 msgid "ToDo"
-msgstr ""
+msgstr "ToDo"
 
 #: ./opengever/core/profiles/default/types/opengever.workspace.todolist.xml
 #: ./opengever/core/upgrades/20190716140644_add_to_do_list_contenttype/types/opengever.workspace.todolist.xml
 msgid "ToDo list"
-msgstr ""
+msgstr "Liste de ToDo"
 
 #: ./opengever/core/profiles/default/actions.xml
 msgid "Toggle orgunit selector"

--- a/opengever/core/locales/fr/LC_MESSAGES/plone.po
+++ b/opengever/core/locales/fr/LC_MESSAGES/plone.po
@@ -155,7 +155,7 @@ msgstr "Membre d'équipe"
 #. Default: "workspace owner"
 #: opengever/core/profiles/default/workflows/opengever_workspace/specification.txt
 msgid "opengever_workspace--ROLE--WorkspaceOwner"
-msgstr "Titulaire"
+msgstr "Responsable"
 
 #. Default: "Workspace admins can manage the team as well as read and modify all contents."
 #: opengever/core/profiles/default/workflows/opengever_workspace/specification.txt
@@ -175,7 +175,7 @@ msgstr "Les membres d'équipe ont accès en lécture et écriture à tous les co
 #. Default: "The workspace owner is the responsible person for this workspace."
 #: opengever/core/profiles/default/workflows/opengever_workspace/specification.txt
 msgid "opengever_workspace--ROLE-DESCRIPTION--WorkspaceOwner"
-msgstr "Les titulaires sont responsables du Teamraum."
+msgstr "Les responsables sont responsables du Teamraum."
 
 #. Default: "Active"
 #: opengever/core/profiles/default/workflows/opengever_workspace/specification.txt
@@ -210,7 +210,7 @@ msgstr "Membre d'équipe"
 #. Default: "workspace owner"
 #: opengever/core/profiles/default/workflows/opengever_workspace_folder/specification.txt
 msgid "opengever_workspace_folder--ROLE--WorkspaceOwner"
-msgstr "Titulaire"
+msgstr "Responsable"
 
 #. Default: "Workspace admins can manage the team as well as read and modify all contents."
 #: opengever/core/profiles/default/workflows/opengever_workspace_folder/specification.txt
@@ -270,37 +270,37 @@ msgstr "Actif"
 #. Default: "admin"
 #: opengever/core/profiles/default/workflows/opengever_workspace_todolist/specification.txt
 msgid "opengever_workspace_todolist--ROLE--Administrator"
-msgstr ""
+msgstr "Administrateur"
 
 #. Default: "systems administrator"
 #: opengever/core/profiles/default/workflows/opengever_workspace_todolist/specification.txt
 msgid "opengever_workspace_todolist--ROLE--Manager"
-msgstr ""
+msgstr "System Administrator"
 
 #. Default: "workspace admin"
 #: opengever/core/profiles/default/workflows/opengever_workspace_todolist/specification.txt
 msgid "opengever_workspace_todolist--ROLE--WorkspaceAdmin"
-msgstr ""
+msgstr "Admin"
 
 #. Default: "workspace guest"
 #: opengever/core/profiles/default/workflows/opengever_workspace_todolist/specification.txt
 msgid "opengever_workspace_todolist--ROLE--WorkspaceGuest"
-msgstr ""
+msgstr "Invité"
 
 #. Default: "workspace member"
 #: opengever/core/profiles/default/workflows/opengever_workspace_todolist/specification.txt
 msgid "opengever_workspace_todolist--ROLE--WorkspaceMember"
-msgstr ""
+msgstr "Membre d'équipe"
 
 #. Default: "workspace owner"
 #: opengever/core/profiles/default/workflows/opengever_workspace_todolist/specification.txt
 msgid "opengever_workspace_todolist--ROLE--WorkspaceOwner"
-msgstr ""
+msgstr "Responsable"
 
 #. Default: "Active"
 #: opengever/core/profiles/default/workflows/opengever_workspace_todolist/specification.txt
 msgid "opengever_workspace_todolist--STATUS--active"
-msgstr ""
+msgstr "Actif"
 
 #. Default: "reactivate"
 #: opengever/core/profiles/default/workflows/opengever_committee_workflow/specification.txt

--- a/opengever/disposition/locales/fr/LC_MESSAGES/opengever.disposition.po
+++ b/opengever/disposition/locales/fr/LC_MESSAGES/opengever.disposition.po
@@ -303,12 +303,12 @@ msgstr "Actualisé par ${user}"
 #. Default: "No SIP Package generated for this disposition."
 #: ./opengever/disposition/browser/ech0160.py
 msgid "msg_no_sip_package_generated"
-msgstr ""
+msgstr "Aucun paquet SIP n'a encore été généré pour cette offre."
 
 #. Default: "SIP Package generated successfully."
 #: ./opengever/disposition/browser/ech0160.py
 msgid "msg_sip_package_sucessfully_generated"
-msgstr ""
+msgstr "Paquet SIP généré avec succès."
 
 #. Default: "Period"
 #: ./opengever/disposition/browser/templates/overview.pt

--- a/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
@@ -65,7 +65,7 @@ msgstr "Annulation du checkout du document ${title} inabouti."
 
 #: ./opengever/document/checkout/checkin.py
 msgid "Could not check in ${title}, it is not a document."
-msgstr "${title} n'est pas un document, par consequent checkin n'a pas abouti."
+msgstr "${title} n'est pas un document, le checkout n'a donc pas abouti."
 
 #: ./opengever/document/checkout/checkin.py
 msgid "Could not check in document ${title}"
@@ -78,7 +78,7 @@ msgstr "Checkout de ${title} n'a pas abouti."
 
 #: ./opengever/document/checkout/checkout.py
 msgid "Could not check out object: ${title}, it is not a document."
-msgstr "${title} n'est pas un document, par consequet checkout n'a pas abouti."
+msgstr "${title} n'est pas un document, par consequent checkout n'a pas abouti."
 
 #: ./opengever/document/browser/overview.py
 msgid "Current version: ${version}"
@@ -196,7 +196,7 @@ msgstr "Il n'est pas possible d'insérer des Email à cet endroit. Pour le faire
 #. Default: "It's not possible to add E-mails as document, use portal_type ftw.mail.mail."
 #: ./opengever/document/document.py
 msgid "error_mail_upload_api"
-msgstr ""
+msgstr "Il n'est pas possible d'ajouter un E-mail en tant que document, ajoutez-le en tant que ftw.mail.mail."
 
 #. Default: "You have not selected any Items"
 #: ./opengever/document/browser/report.py

--- a/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
@@ -1486,7 +1486,7 @@ msgstr "Das Antragsdokument wurde von ${creator} ausgecheckt."
 #. Default: "The committee ${committee_title} is no longer active."
 #: ./opengever/meeting/browser/templates/proposalinfoviewlet.pt
 msgid "message_committee_inactive_warning"
-msgstr "Das Ko­mi­tee ${committee_title} wurde deaktiviert."
+msgstr "Das Gremium ${committee_title} wurde deaktiviert."
 
 #. Default: "Your changes were not saved, the protocol is locked by ${username}."
 #: ./opengever/meeting/browser/meetings/edit_meeting.py

--- a/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
@@ -1483,12 +1483,12 @@ msgstr "Adhésions"
 #. Default: "The proposal document is being checked out by ${creator}."
 #: ./opengever/meeting/browser/templates/proposalinfoviewlet.pt
 msgid "message_checkout_info"
-msgstr ""
+msgstr "Le document de requête a déjà un checkout par ${creator}."
 
 #. Default: "The committee ${committee_title} is no longer active."
 #: ./opengever/meeting/browser/templates/proposalinfoviewlet.pt
 msgid "message_committee_inactive_warning"
-msgstr ""
+msgstr "La commission ${committee_title} a été désactivée."
 
 #. Default: "Your changes were not saved, the protocol is locked by ${username}."
 #: ./opengever/meeting/browser/meetings/edit_meeting.py

--- a/opengever/task/locales/fr/LC_MESSAGES/opengever.task.po
+++ b/opengever/task/locales/fr/LC_MESSAGES/opengever.task.po
@@ -704,7 +704,7 @@ msgstr "Etat"
 #. Default: "Choose remind date"
 #: ./opengever/task/response.py
 msgid "lable_reminder_choose_date"
-msgstr ""
+msgstr "Choisissez une date pour le rappel."
 
 #. Default: "Deadline successfully changed."
 #: ./opengever/task/browser/modify_deadline.py
@@ -767,7 +767,7 @@ msgstr "Nouveau Dossier"
 #. Default: "Please choose a remind date"
 #: ./opengever/task/response.py
 msgid "no_remind_date_error"
-msgstr ""
+msgstr "Veuillez choisir une date pour le rappel."
 
 #. Default: "No reminder"
 #: ./opengever/task/browser/overview.py
@@ -792,7 +792,7 @@ msgstr "Au début de la semaine"
 #. Default: "On a specific date"
 #: ./opengever/task/reminder/model.py
 msgid "reminder_option_title_on_date"
-msgstr ""
+msgstr "A une date donnée"
 
 #. Default: "One day before deadline"
 #: ./opengever/task/reminder/model.py
@@ -1072,7 +1072,7 @@ msgstr "Accompli par ${user}"
 #. Default: "Resolved by ${user} and ${documents} returned"
 #: ./opengever/task/response_description.py
 msgid "transition_msg_resolve_with_documents"
-msgstr ""
+msgstr "Accompli par ${user} et ${documents} renvoyés."
 
 #. Default: "Revised by ${user}"
 #: ./opengever/task/response_description.py

--- a/opengever/workspace/locales/fr/LC_MESSAGES/opengever.workspace.po
+++ b/opengever/workspace/locales/fr/LC_MESSAGES/opengever.workspace.po
@@ -117,22 +117,22 @@ msgstr "Membre du team"
 #. Default: "Owner"
 #: ./opengever/workspace/participation/__init__.py
 msgid "WorkspaceOwner"
-msgstr "Titulaire"
+msgstr "Responsable"
 
 #. Default: "Invitation"
 #: ./opengever/workspace/participation/__init__.py
 msgid "invitation"
-msgstr ""
+msgstr "Invitation"
 
 #. Default: "Completed"
 #: ./opengever/workspace/todo.py
 msgid "label_completed"
-msgstr ""
+msgstr "Accompli"
 
 #. Default: "Deadline"
 #: ./opengever/workspace/todo.py
 msgid "label_deadline"
-msgstr ""
+msgstr "A compléter d'ici le"
 
 #. Default: "Description"
 #: ./opengever/workspace/browser/tabs.py
@@ -157,12 +157,12 @@ msgstr "Journal"
 #. Default: "Responsible"
 #: ./opengever/workspace/todo.py
 msgid "label_responsible"
-msgstr ""
+msgstr "Responsable"
 
 #. Default: "Text"
 #: ./opengever/workspace/todo.py
 msgid "label_text"
-msgstr ""
+msgstr "Texte"
 
 #. Default: "Title"
 #: ./opengever/workspace/browser/tabs.py
@@ -174,7 +174,7 @@ msgstr "Titre"
 #. Default: "ToDo"
 #: ./opengever/workspace/browser/tabbed.py
 msgid "label_todo"
-msgstr ""
+msgstr "ToDo"
 
 #. Default: "ToDo assigned"
 #: ./opengever/workspace/activities.py
@@ -219,4 +219,4 @@ msgstr "Participant de  \"${workspace}\""
 #. Default: "User"
 #: ./opengever/workspace/participation/__init__.py
 msgid "user"
-msgstr ""
+msgstr "Utilisateur"


### PR DESCRIPTION
- Added the French translations for release 2019.4.
- Update translation for disposition archive action

<img width="1150" alt="Screenshot 2019-11-25 at 09 27 36" src="https://user-images.githubusercontent.com/7374243/69525644-dd2dc080-0f68-11ea-9d80-280ece7893d4.png">

This is for https://github.com/4teamwork/opengever.core/issues/6080

- [x] Changelog-Eintrag vorhanden/nötig?
