### PR TITLE
Update oneoffixx integration with the latest oneoffixx api changes

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 ---------------------
 
 - Update French translations. [njohner]
+- Update oneoffixx intergration to latest API changes. [phgross]
 
 
 2019.4.0 (2019-11-22)

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -24,6 +24,7 @@ Changelog
 - No longer add journal entry for document file modification. [njohner]
 - Revoke permissions for former responsible, when task gets rejected. [phgross]
 - Use BaseResponse for proposal history to add API support. [njohner]
+- Update oneoffixx integration with the latest oneoffixx api changes. [phgross]
 
 
 2019.4.0rc5 (2019-11-13)

--- a/opengever/officeconnector/service.py
+++ b/opengever/officeconnector/service.py
@@ -217,7 +217,7 @@ class OfficeConnectorCheckoutPayload(OfficeConnectorPayload):
             if authorized:
                 if document.is_shadow_document():
                     # Oneoffixx is only used for .docx files in opengever.core
-                    payload['content-type'] = IAnnotations(document)["content_type"]
+                    payload['content-type'] = IAnnotations(document)["content-type"]
                 else:
                     payload['content-type'] = document.get_file().contentType
 

--- a/opengever/oneoffixx/locales/de/LC_MESSAGES/opengever.oneoffixx.po
+++ b/opengever/oneoffixx/locales/de/LC_MESSAGES/opengever.oneoffixx.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-02-05 18:08+0000\n"
+"POT-Creation-Date: 2019-11-15 14:40+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -33,6 +33,11 @@ msgstr "Dokument aus Vorlage erstellen"
 #: ./opengever/oneoffixx/browser/form.py
 msgid "label_all_template_groups"
 msgstr "Alle Vorlagen"
+
+#. Default: "Favorites"
+#: ./opengever/oneoffixx/browser/form.py
+msgid "label_favorites"
+msgstr "Favoriten"
 
 #. Default: "Template"
 #: ./opengever/oneoffixx/browser/form.py

--- a/opengever/oneoffixx/locales/fr/LC_MESSAGES/opengever.oneoffixx.po
+++ b/opengever/oneoffixx/locales/fr/LC_MESSAGES/opengever.oneoffixx.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-02-05 18:08+0000\n"
+"POT-Creation-Date: 2019-11-15 14:40+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -33,6 +33,11 @@ msgstr "Créer un document à partir d'un modèle"
 #: ./opengever/oneoffixx/browser/form.py
 msgid "label_all_template_groups"
 msgstr "Tous les modèles"
+
+#. Default: "Favorites"
+#: ./opengever/oneoffixx/browser/form.py
+msgid "label_favorites"
+msgstr "Favoris"
 
 #. Default: "Template"
 #: ./opengever/oneoffixx/browser/form.py

--- a/opengever/oneoffixx/locales/opengever.oneoffixx.pot
+++ b/opengever/oneoffixx/locales/opengever.oneoffixx.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-02-05 18:08+0000\n"
+"POT-Creation-Date: 2019-11-15 14:40+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -35,6 +35,11 @@ msgstr ""
 #. Default: "All templates"
 #: ./opengever/oneoffixx/browser/form.py
 msgid "label_all_template_groups"
+msgstr ""
+
+#. Default: "Favorites"
+#: ./opengever/oneoffixx/browser/form.py
+msgid "label_favorites"
 msgstr ""
 
 #. Default: "Template"

--- a/opengever/oneoffixx/tests/test_oneoffixx.py
+++ b/opengever/oneoffixx/tests/test_oneoffixx.py
@@ -26,7 +26,8 @@ class TestCreateDocFromOneoffixxTemplate(IntegrationTestCase):
         api.portal.set_registry_record('fake_sid', u'foobar', IOneoffixxSettings)
 
         access_token = {'access_token': 'all_may_enter'}
-        template_library = [{'datasources': [{'id': 1}]}]
+        template_library = {'datasources': [{'id': 1, 'isPrimary': True}]}
+        organization_units = [{'id': 'fake-org-id'}]
         self.template_word = {
             'id': '2574d08d-95ea-4639-beab-3103fe4c3bc7',
             'metaTemplateId': '275af32e-bc40-45c2-85b7-afb1c0382653',
@@ -65,15 +66,13 @@ class TestCreateDocFromOneoffixxTemplate(IntegrationTestCase):
                 'templates': [template_powerpoint],
             },
         ]
-        favorites = {
-            'id': 'c2ddc01a-befd-4e0d-b15f-f67025f532bd',
-            'localizedName': 'Favorites',
-            'templates': [],
-        }
+        favorites = [self.template_word, ]
         session = requests.Session()
         adapter = requests_mock.Adapter()
         adapter.register_uri('POST', 'mock://nohost/foo/ids/connect/token', text=json.dumps(access_token))
         adapter.register_uri('GET', 'mock://nohost/foo/webapi/api/v1/TenantInfo', text=json.dumps(template_library))
+        adapter.register_uri('GET', 'mock://nohost/foo/webapi/api/v1/1/OrganizationUnits',
+                             text=json.dumps(organization_units))
         adapter.register_uri(
             'GET',
             'mock://nohost/foo/webapi/api/v1/1/TemplateLibrary/TemplateGroups',
@@ -112,16 +111,6 @@ class TestCreateDocFromOneoffixxTemplate(IntegrationTestCase):
             'Filter',
             browser.css('input.tableradioSearchbox').first.get('placeholder'),
         )
-
-    @browsing
-    def test_oneoffixx_defaults_to_listing_all(self, browser):
-        self.login(self.regular_user, browser)
-        browser.open(self.dossier)
-        factoriesmenu.add('document_with_oneoffixx_template')
-        self.assertEqual([], browser.css('option[selected=selected]').text)
-        self.assertIsNone(browser.css('select').first.value)
-        # XXX - this always renders the --NOVALUE-- as the actually chosen
-        # default is actually loaded over AJAX - confusing and bad UX
 
     @browsing
     def test_document_creation_from_oneoffixx_template_creates_shadow_doc(self, browser):
@@ -290,7 +279,8 @@ class TestCreateDocFromOneoffixxFilterTemplate(IntegrationTestCase):
         api.portal.set_registry_record('fake_sid', u'foobar', IOneoffixxSettings)
 
         access_token = {'access_token': 'all_may_enter'}
-        template_library = [{'datasources': [{'id': 1}]}]
+        template_library = {'datasources': [{'id': 1, 'isPrimary': True}]}
+        organization_units = [{'id': 'fake-org-id'}]
         valid_template = {
             'id': '2574d08d-95ea-4639-beab-3103fe4c3bc7',
             'metaTemplateId': '275af32e-bc40-45c2-85b7-afb1c0382653',
@@ -306,11 +296,13 @@ class TestCreateDocFromOneoffixxFilterTemplate(IntegrationTestCase):
             'templateGroupId': 1,
         }
         template_groups = [{'templates': [valid_template, invalid_template]}]
-        favorites = {'id': 'c2ddc01a-befd-4e0d-b15f-f67025f532bd', 'localizedName': 'Favorites', 'templates': []}
+        favorites = []
         session = requests.Session()
         adapter = requests_mock.Adapter()
         adapter.register_uri('POST', 'mock://nohost/foo/ids/connect/token', text=json.dumps(access_token))
         adapter.register_uri('GET', 'mock://nohost/foo/webapi/api/v1/TenantInfo', text=json.dumps(template_library))
+        adapter.register_uri('GET', 'mock://nohost/foo/webapi/api/v1/1/OrganizationUnits',
+                             text=json.dumps(organization_units))
         adapter.register_uri(
             'GET',
             'mock://nohost/foo/webapi/api/v1/1/TemplateLibrary/TemplateGroups',
@@ -454,9 +446,12 @@ class TestCreateDocFromOneoffixxBackendFailuresTemplate(IntegrationTestCase):
     @browsing
     def test_template_groups_bad_return(self, browser):
         access_token = {'access_token': 'all_may_enter'}
-        template_library = [{'datasources': [{'id': 1}]}]
+        template_library = {'datasources': [{'id': 1, 'isPrimary': True}]}
+        organization_units = [{'id': 'fake-org-id'}]
         self.adapter.register_uri('POST', 'mock://nohost/foo/ids/connect/token', text=json.dumps(access_token))
         self.adapter.register_uri('GET', 'mock://nohost/foo/webapi/api/v1/TenantInfo', text=json.dumps(template_library))
+        self.adapter.register_uri('GET', 'mock://nohost/foo/webapi/api/v1/1/OrganizationUnits',
+                                  text=json.dumps(organization_units))
         self.adapter.register_uri('GET', 'mock://nohost/foo/webapi/api/v1/1/TemplateLibrary/TemplateGroups', status_code=400)
         OneoffixxAPIClient(self.session, self.credentials)
 
@@ -509,7 +504,8 @@ class TestOneoffixxTemplateFavorites(IntegrationTestCase):
         api.portal.set_registry_record('fake_sid', u'foobar', IOneoffixxSettings)
 
         access_token = {'access_token': 'all_may_enter'}
-        template_library = [{'datasources': [{'id': 1}]}]
+        template_library = {'datasources': [{'id': 1, 'isPrimary': True}]}
+        organization_units = [{'id': 'fake-org-id'}]
         template_word = {
             'id': '2574d08d-95ea-4639-beab-3103fe4c3bc7',
             'metaTemplateId': '275af32e-bc40-45c2-85b7-afb1c0382653',
@@ -548,15 +544,13 @@ class TestOneoffixxTemplateFavorites(IntegrationTestCase):
                 'templates': [template_powerpoint],
             },
         ]
-        favorites = {
-            'id': 'c2ddc01a-befd-4e0d-b15f-f67025f532bd',
-            'localizedName': 'Favorites',
-            'templates': [template_powerpoint],
-        }
+        favorites = [template_powerpoint]
         session = requests.Session()
         adapter = requests_mock.Adapter()
         adapter.register_uri('POST', 'mock://nohost/foo/ids/connect/token', text=json.dumps(access_token))
         adapter.register_uri('GET', 'mock://nohost/foo/webapi/api/v1/TenantInfo', text=json.dumps(template_library))
+        adapter.register_uri('GET', 'mock://nohost/foo/webapi/api/v1/1/OrganizationUnits',
+                             text=json.dumps(organization_units))
         adapter.register_uri(
             'GET',
             'mock://nohost/foo/webapi/api/v1/1/TemplateLibrary/TemplateGroups',
@@ -601,20 +595,6 @@ class TestOneoffixxTemplateFavorites(IntegrationTestCase):
         self.assertEqual(expected_categories, browser.css('select option').text)
 
     @browsing
-    def test_oneoffixx_defaults_to_listing_favorites(self, browser):
-        self.login(self.regular_user, browser)
-        browser.open(self.dossier)
-        factoriesmenu.add('document_with_oneoffixx_template')
-        self.assertEqual(
-            ['Favorites'], browser.css('option[selected=selected]').text)
-        self.assertEqual(
-            'c2ddc01a-befd-4e0d-b15f-f67025f532bd',
-            browser.css('select').first.value,
-        )
-        # XXX - this always renders the --NOVALUE-- as the actually chosen
-        # default is actually loaded over AJAX - confusing and bad UX
-
-    @browsing
     def test_oneoffixx_favorites_not_duplicated_on_select_all(self, browser):
         self.login(self.regular_user, browser)
         view = (
@@ -644,7 +624,7 @@ class TestOneoffixxTemplateFavorites(IntegrationTestCase):
             'document_with_oneoffixx_template'
             '/++widget++form.widgets.template'
             '/ajax_render'
-            '?form.widgets.template_group:list=c2ddc01a-befd-4e0d-b15f-f67025f532bd'
+            '?form.widgets.template_group:list=__favorites__'
             '&form.widgets.template_group-empty-marker=1'
             '&form.widgets.template-empty-marker=1'
             '&form.widgets.title'

--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -1459,7 +1459,7 @@ class OpengeverContentFixture(object):
             shadow_document_annotations = IAnnotations(shadow_document)
             shadow_document_annotations['template-id'] = '2574d08d-95ea-4639-beab-3103fe4c3bc7'
             shadow_document_annotations['languages'] = [2055]
-            shadow_document_annotations['content_type'] = 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'  # noqa
+            shadow_document_annotations['content-type'] = 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'  # noqa
 
     @staticuid()
     def create_resolvable_dossier(self):


### PR DESCRIPTION
There are several changes made by oneoffixx in their last OneOffix update:
 - TenantInfo returns a list of datasources, the primary is marked
 with the `isPrimary` flag
 - The parameter `orgId` is now required when quering template groups or templates.
 - Favorites does return now directly a list of templates

In Addition to the changes made necessary by the API changes, I also fixed a "typo" in the oc_checkout view, which does not correspond to the shadow_document creation.  

## Checkliste
_Zutreffendes soll angehakt stehengelassen werden._
- [x] Gibt es neue Übersetzungen?
  - [x] Sind alle msg-Strings in Übersetzungen Unicode?
  - [x] Wird die richtige i18n-domain verwendet (Copy-Paste Fehler sind hier häufig)?
- [x] Changelog-Eintrag vorhanden/nötig?
- [x] Aktualisierung Dokumentation vorhanden/nötig? _Ich habe die Doku geprüft, keine Aktualisierung notwendig_
