### PR TITLE
Refactor Solr search and listing endpoints

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2019.5.1 (unreleased)
 ---------------------
 
+- Refactor solrsearch and listing endpoints. [njohner]
 - Add tests for solrsearch and listing endpoints. [njohner]
 - Split invitations from participations endpoints. [njohner]
 - Implement testing against a real Solr. [lgraf]

--- a/opengever/api/globalindex.py
+++ b/opengever/api/globalindex.py
@@ -1,5 +1,5 @@
 from opengever.api.batch import SQLHypermediaBatch
-from opengever.api.listing import DEFAULT_SORT_INDEX
+from opengever.api.solr_query_service import DEFAULT_SORT_INDEX
 from opengever.base.helpers import display_name
 from opengever.globalindex.model.task import Task
 from plone.restapi.serializer.converters import json_compatible

--- a/opengever/api/listing.py
+++ b/opengever/api/listing.py
@@ -16,7 +16,8 @@ def get_path_depth(context):
     return len(context.getPhysicalPath()) - 1
 
 
-OTHER_FIELDS = set([
+# Fields with no mapping but allowed in the listing endpoint.
+OTHER_ALLOWED_FIELDS = set([
     'file_extension',
     'deadline',
     'containing_dossier',
@@ -97,7 +98,7 @@ class Listing(SolrQueryBaseService):
     """List of content items"""
 
     required_response_fields = REQUIRED_RESPONSE_FIELDS
-    other_allowed_fields = OTHER_FIELDS
+    other_allowed_fields = OTHER_ALLOWED_FIELDS
 
     def __init__(self, context, request):
         super(Listing, self).__init__(context, request)

--- a/opengever/api/listing.py
+++ b/opengever/api/listing.py
@@ -176,6 +176,8 @@ FILTERS = {
     ]
 }
 
+DEFAULT_FIELDS = set()
+
 
 def with_active_solr_only(func):
     """Raises an error if solr is not activated
@@ -280,12 +282,15 @@ class Listing(SolrQueryBaseService):
         return sort
 
     def parse_requested_fields(self, params):
-        return params.get('columns', [])
+        return params.get('columns', None)
 
     def extract_field_list(self, params):
         self.requested_fields = self.parse_requested_fields(params)
-        self.requested_fields = filter(
-            self.is_field_allowed, self.requested_fields)
+        if self.requested_fields is not None:
+            self.requested_fields = filter(
+                self.is_field_allowed, self.requested_fields)
+        else:
+            self.requested_fields = DEFAULT_FIELDS
 
         fl = ['UID', 'getIcon', 'portal_type', 'path', 'id',
               'bumblebee_checksum']

--- a/opengever/api/listing.py
+++ b/opengever/api/listing.py
@@ -1,6 +1,3 @@
-from DateTime import DateTime
-from DateTime.interfaces import DateTimeError
-from ftw.solr.converters import to_iso8601
 from ftw.solr.interfaces import ISolrSearch
 from ftw.solr.query import escape
 from opengever.api.solr_query_service import SolrQueryBaseService
@@ -200,7 +197,9 @@ class Listing(SolrQueryBaseService):
     def reply(self):
         self.listing_name = self.request.form.get('name')
         if self.listing_name not in FILTERS:
-            raise BadRequest
+            raise BadRequest(
+                "Unknown listing {}. Available listings are: {}".format(
+                    self.name, ",".join(FILTERS.keys())))
 
         self.solr = getUtility(ISolrSearch)
 

--- a/opengever/api/listing.py
+++ b/opengever/api/listing.py
@@ -279,11 +279,15 @@ class Listing(SolrQueryBaseService):
                 sort += ' asc'
         return sort
 
+    def parse_requested_fields(self, params):
+        return params.get('columns', [])
+
     def extract_field_list(self, params):
-        self.columns = params.get('columns', [])
+        self.requested_fields = self.parse_requested_fields(params)
+
         fl = ['UID', 'getIcon', 'portal_type', 'path', 'id',
               'bumblebee_checksum']
-        fl.extend(filter(None, map(self.get_field_index, self.columns)))
+        fl.extend(filter(None, map(self.get_field_index, self.requested_fields)))
         return fl
 
     def prepare_additional_params(self, params):
@@ -329,7 +333,7 @@ class Listing(SolrQueryBaseService):
 
         res['items'] = []
         for item in items[start:start + rows]:
-            res['items'].append(self.create_list_item(item, self.columns))
+            res['items'].append(self.create_list_item(item, self.requested_fields))
 
         facet_counts = self.extract_facets_from_response(resp)
 

--- a/opengever/api/listing.py
+++ b/opengever/api/listing.py
@@ -176,15 +176,13 @@ FILTERS = {
     ]
 }
 
-DEFAULT_FIELDS = set()
 
-
-REQUIRED_FIELDS = set(['UID',
-                       'getIcon',
-                       'portal_type',
-                       'path',
-                       'id',
-                       'bumblebee_checksum'])
+REQUIRED_SEARCH_FIELDS = set(['UID',
+                              'getIcon',
+                              'portal_type',
+                              'path',
+                              'id',
+                              'bumblebee_checksum'])
 
 
 def with_active_solr_only(func):
@@ -205,6 +203,7 @@ class Listing(SolrQueryBaseService):
     """List of content items"""
 
     field_mapping = FIELDS_WITH_MAPPING
+    required_search_fields = REQUIRED_SEARCH_FIELDS
     other_allowed_fields = OTHER_FIELDS
     allowed_fields = set(field_mapping.keys()) | other_allowed_fields
 
@@ -291,20 +290,6 @@ class Listing(SolrQueryBaseService):
 
     def parse_requested_fields(self, params):
         return params.get('columns', None)
-
-    def extract_field_list(self, params):
-        self.requested_fields = self.parse_requested_fields(params)
-        if self.requested_fields is not None:
-            self.requested_fields = filter(
-                self.is_field_allowed, self.requested_fields)
-        else:
-            self.requested_fields = DEFAULT_FIELDS
-
-        solr_fields = set(self.solr.manager.schema.fields.keys())
-        requested_solr_fields = set([])
-        for field in self.requested_fields:
-            requested_solr_fields.add(self.get_field_index(field))
-        return list((requested_solr_fields | REQUIRED_FIELDS) & solr_fields)
 
     def prepare_additional_params(self, params):
         additional_params = {

--- a/opengever/api/listing.py
+++ b/opengever/api/listing.py
@@ -179,6 +179,14 @@ FILTERS = {
 DEFAULT_FIELDS = set()
 
 
+REQUIRED_FIELDS = set(['UID',
+                       'getIcon',
+                       'portal_type',
+                       'path',
+                       'id',
+                       'bumblebee_checksum'])
+
+
 def with_active_solr_only(func):
     """Raises an error if solr is not activated
     """
@@ -292,10 +300,11 @@ class Listing(SolrQueryBaseService):
         else:
             self.requested_fields = DEFAULT_FIELDS
 
-        fl = ['UID', 'getIcon', 'portal_type', 'path', 'id',
-              'bumblebee_checksum']
-        fl.extend(filter(None, map(self.get_field_index, self.requested_fields)))
-        return fl
+        solr_fields = set(self.solr.manager.schema.fields.keys())
+        requested_solr_fields = set([])
+        for field in self.requested_fields:
+            requested_solr_fields.add(self.get_field_index(field))
+        return list((requested_solr_fields | REQUIRED_FIELDS) & solr_fields)
 
     def prepare_additional_params(self, params):
         additional_params = {

--- a/opengever/api/listing.py
+++ b/opengever/api/listing.py
@@ -183,7 +183,9 @@ class Listing(SolrQueryBaseService):
             'q.op': 'AND',
         }
 
-        self.facets = filter(self.is_field_allowed, params.get('facets', []))
+        self.facets = [facet for facet in params.get('facets', [])
+                       if self.is_field_allowed(facet) and
+                       self.get_field_index(facet) in self.solr_fields]
         facet_fields = map(self.get_field_index, self.facets)
 
         if facet_fields:

--- a/opengever/api/listing.py
+++ b/opengever/api/listing.py
@@ -323,7 +323,7 @@ class Listing(Service):
                 sort_order, filters, depth, facets):
 
         if name not in FILTERS:
-            return []
+            raise BadRequest
 
         query = '*:*'
         if term:

--- a/opengever/api/listing.py
+++ b/opengever/api/listing.py
@@ -284,6 +284,8 @@ class Listing(SolrQueryBaseService):
 
     def extract_field_list(self, params):
         self.requested_fields = self.parse_requested_fields(params)
+        self.requested_fields = filter(
+            self.is_field_allowed, self.requested_fields)
 
         fl = ['UID', 'getIcon', 'portal_type', 'path', 'id',
               'bumblebee_checksum']
@@ -376,8 +378,6 @@ class Listing(SolrQueryBaseService):
         obj = IContentListingObject(item)
         data = {'@id': obj.getURL()}
         for field in fields:
-            if not self.is_field_allowed(field):
-                continue
             accessor = self.get_field_accessor(field)
             if isinstance(accessor, str):
                 value = getattr(obj, accessor, None)

--- a/opengever/api/listing.py
+++ b/opengever/api/listing.py
@@ -80,14 +80,6 @@ FILTERS = {
 }
 
 
-REQUIRED_SEARCH_FIELDS = set(['UID',
-                              'getIcon',
-                              'portal_type',
-                              'path',
-                              'id',
-                              'bumblebee_checksum'])
-
-
 REQUIRED_RESPONSE_FIELDS = set(['@id'])
 
 
@@ -109,7 +101,6 @@ class Listing(SolrQueryBaseService):
     """List of content items"""
 
     required_response_fields = REQUIRED_RESPONSE_FIELDS
-    required_search_fields = REQUIRED_SEARCH_FIELDS
     other_allowed_fields = OTHER_FIELDS
 
     def __init__(self, context, request):

--- a/opengever/api/listing.py
+++ b/opengever/api/listing.py
@@ -1,4 +1,3 @@
-from ftw.solr.interfaces import ISolrSearch
 from ftw.solr.query import escape
 from opengever.api.solr_query_service import SolrQueryBaseService
 from opengever.base.interfaces import ISearchSettings
@@ -200,8 +199,6 @@ class Listing(SolrQueryBaseService):
             raise BadRequest(
                 "Unknown listing {}. Available listings are: {}".format(
                     self.name, ",".join(FILTERS.keys())))
-
-        self.solr = getUtility(ISolrSearch)
 
         query, filters, start, rows, sort, field_list, params = self.prepare_solr_query()
 

--- a/opengever/api/solr_query_service.py
+++ b/opengever/api/solr_query_service.py
@@ -45,6 +45,8 @@ def safe_int(value, default=0):
 
 class SolrQueryBaseService(Service):
 
+    field_mapping = {}
+
     def prepare_solr_query(self):
         params = self.request.form.copy()
         query = self.extract_query(params)
@@ -105,3 +107,21 @@ class SolrQueryBaseService(Service):
 
     def prepare_additional_params(self, params):
         return params
+
+    def is_field_allowed(self, field):
+        return False
+
+    def get_field_index(self, field):
+        if field in self.field_mapping:
+            return self.field_mapping[field][0]
+        return field
+
+    def get_field_accessor(self, field):
+        if field in self.field_mapping:
+            return self.field_mapping[field][1]
+        return field
+
+    def get_field_sort_index(self, field):
+        if field in self.field_mapping:
+            return self.field_mapping[field][2]
+        return field

--- a/opengever/api/solr_query_service.py
+++ b/opengever/api/solr_query_service.py
@@ -165,6 +165,14 @@ class DateListingField(SimpleListingField):
 
 DEFAULT_SORT_INDEX = 'modified'
 
+DEFAULT_FIELDS = set([
+    '@id',
+    '@type',
+    'title',
+    'description',
+    'review_state',
+])
+
 FIELDS_WITH_MAPPING = [
     ListingField('checked_out', 'checked_out', transform=display_name),
     ListingField('bumblebee_checksum', 'bumblebee_checksum', sort_index=DEFAULT_SORT_INDEX),
@@ -224,7 +232,7 @@ class SolrQueryBaseService(Service):
 
     field_mapping = {field.field_name: field for field in FIELDS_WITH_MAPPING}
 
-    default_fields = set()
+    default_fields = DEFAULT_FIELDS
     required_response_fields = set()
 
     def __init__(self, context, request):

--- a/opengever/api/solr_query_service.py
+++ b/opengever/api/solr_query_service.py
@@ -238,6 +238,7 @@ class SolrQueryBaseService(Service):
     def __init__(self, context, request):
         super(SolrQueryBaseService, self).__init__(context, request)
         self.default_sort_index = DEFAULT_SORT_INDEX
+        self.response_fields = None
 
     def prepare_solr_query(self):
         """ Extract the requested parameters and prepare the solr query
@@ -311,14 +312,14 @@ class SolrQueryBaseService(Service):
         """Extracts fields from request and prepare the list
         of solr fields for the query and for the response.
         """
-        self.requested_fields = self.parse_requested_fields(params)
-        if self.requested_fields is not None:
-            self.requested_fields = filter(
-                self.is_field_allowed, self.requested_fields)
+        requested_fields = self.parse_requested_fields(params)
+        if requested_fields is not None:
+            requested_fields = filter(
+                self.is_field_allowed, requested_fields)
         else:
-            self.requested_fields = self.default_fields
+            requested_fields = self.default_fields
 
-        self.response_fields = (set(self.requested_fields) |
+        self.response_fields = (set(requested_fields) |
                                 self.required_response_fields)
 
         solr_fields = set(self.solr.manager.schema.fields.keys())

--- a/opengever/api/solr_query_service.py
+++ b/opengever/api/solr_query_service.py
@@ -2,6 +2,7 @@ from collective.elephantvocabulary import wrap_vocabulary
 from DateTime import DateTime
 from DateTime.interfaces import DateTimeError
 from ftw.solr.converters import to_iso8601
+from ftw.solr.interfaces import ISolrSearch
 from ftw.solr.query import escape
 from opengever.base.behaviors.translated_title import ITranslatedTitleSupport
 from opengever.base.helpers import display_name
@@ -14,6 +15,7 @@ from plone.restapi.serializer.converters import json_compatible
 from plone.restapi.services import Service
 from plone.rfc822.interfaces import IPrimaryFieldInfo
 from Products.CMFPlone.utils import safe_unicode
+from zope.component import getUtility
 from zope.component.hooks import getSite
 from zope.globalrequest import getRequest
 from zope.i18n import translate
@@ -253,6 +255,7 @@ class SolrQueryBaseService(Service):
 
     def __init__(self, context, request):
         super(SolrQueryBaseService, self).__init__(context, request)
+        self.solr = getUtility(ISolrSearch)
         self.default_sort_index = DEFAULT_SORT_INDEX
         self.response_fields = None
 

--- a/opengever/api/solr_query_service.py
+++ b/opengever/api/solr_query_service.py
@@ -97,7 +97,7 @@ def relative_path(brain):
 
 class SimpleListingField(object):
     """Mapping between a requested field_name, the corresponding index
-    in sol, the accessor on the ContentListingObject, and an index used
+    in solr, the accessor on the ContentListingObject, and an index used
     when sorting according to this field.
 
     transform: used to cast the value of the index to a label
@@ -271,11 +271,9 @@ class SolrQueryBaseService(Service):
         """Solrsearch endpoint uses start while listing endpoint uses start_b
         """
         if 'start' in params:
-            start = safe_int(params['start'])
-            del params['start']
+            start = safe_int(params.pop('start'))
         elif 'start_b' in params:
-            start = safe_int(params['start_b'])
-            del params['start_b']
+            start = safe_int(params.pop('start_b'))
         else:
             start = 0
         return start
@@ -284,11 +282,9 @@ class SolrQueryBaseService(Service):
         """Solrsearch endpoint uses rows while listing endpoint uses b_size
         """
         if 'rows' in params:
-            rows = min(safe_int(params['rows'], 25), 1000)
-            del params['rows']
+            rows = min(safe_int(params.pop('rows'), 25), 1000)
         elif 'b_size' in params:
-            rows = min(safe_int(params['b_size'], 25), 1000)
-            del params['b_size']
+            rows = min(safe_int(params.pop('b_size'), 25), 1000)
         else:
             rows = 25
         return rows

--- a/opengever/api/solr_query_service.py
+++ b/opengever/api/solr_query_service.py
@@ -1,0 +1,59 @@
+from plone.restapi.services import Service
+
+
+def safe_int(value, default=0):
+    try:
+        return int(value)
+    except (ValueError, TypeError):
+        return default
+
+
+class SolrQueryBaseService(Service):
+
+    def prepare_solr_query(self):
+        params = self.request.form.copy()
+        query = self.extract_query(params)
+        filters = self.extract_filters(params)
+        start = self.extract_start(params)
+        rows = self.extract_rows(params)
+        sort = self.extract_sort(params, query)
+        field_list = self.extract_field_list(params)
+        additional_params = self.prepare_additional_params(params)
+        return query, filters, start, rows, sort, field_list, additional_params
+
+    def extract_start(self, params):
+        if 'start' in params:
+            start = safe_int(params['start'])
+            del params['start']
+        elif 'start_b' in params:
+            start = safe_int(params['start_b'])
+            del params['start_b']
+        else:
+            start = 0
+        return start
+
+    def extract_rows(self, params):
+        if 'rows' in params:
+            rows = min(safe_int(params['rows'], 25), 1000)
+            del params['rows']
+        elif 'b_size' in params:
+            rows = min(safe_int(params['b_size'], 25), 1000)
+            del params['b_size']
+        else:
+            rows = 25
+        return rows
+
+    def extract_query(self, params):
+        return "*:*"
+
+    def extract_filters(self, params):
+        return []
+
+    def extract_sort(self, params, query):
+        return None
+
+    def extract_field_list(self, params):
+        return ''
+
+    def prepare_additional_params(self, params):
+        return params

--- a/opengever/api/solr_query_service.py
+++ b/opengever/api/solr_query_service.py
@@ -268,12 +268,12 @@ class SolrQueryBaseService(Service):
         return query, filters, start, rows, sort, field_list, additional_params
 
     def extract_start(self, params):
-        """Solrsearch endpoint uses start while listing endpoint uses start_b
+        """Solrsearch endpoint uses start while listing endpoint uses b_start
         """
         if 'start' in params:
             start = safe_int(params.pop('start'))
-        elif 'start_b' in params:
-            start = safe_int(params.pop('start_b'))
+        elif 'b_start' in params:
+            start = safe_int(params.pop('b_start'))
         else:
             start = 0
         return start

--- a/opengever/api/solr_query_service.py
+++ b/opengever/api/solr_query_service.py
@@ -167,7 +167,7 @@ DEFAULT_SORT_INDEX = 'modified'
 
 FIELDS_WITH_MAPPING = [
     ListingField('checked_out', 'checked_out', transform=display_name),
-    ListingField('bumblebee_checksum', None, sort_index=DEFAULT_SORT_INDEX),
+    ListingField('bumblebee_checksum', 'bumblebee_checksum', sort_index=DEFAULT_SORT_INDEX),
     ListingField('checked_out', 'checked_out', transform=display_name),
     ListingField('checked_out_fullname', 'checked_out', 'checked_out_fullname'),
     ListingField('creator', 'Creator', transform=display_name),

--- a/opengever/api/solr_query_service.py
+++ b/opengever/api/solr_query_service.py
@@ -302,7 +302,7 @@ class SolrQueryBaseService(Service):
 
         solr_fields = set(self.solr.manager.schema.fields.keys())
         requested_solr_fields = set([])
-        for field in self.requested_fields:
+        for field in self.response_fields:
             requested_solr_fields.add(self.get_field_index(field))
         return list((requested_solr_fields | self.required_search_fields) & solr_fields)
 

--- a/opengever/api/solr_query_service.py
+++ b/opengever/api/solr_query_service.py
@@ -225,7 +225,6 @@ class SolrQueryBaseService(Service):
     field_mapping = {field.field_name: field for field in FIELDS_WITH_MAPPING}
 
     default_fields = set()
-    required_search_fields = set()
     required_response_fields = set()
 
     def __init__(self, context, request):
@@ -304,7 +303,7 @@ class SolrQueryBaseService(Service):
         requested_solr_fields = set([])
         for field in self.response_fields:
             requested_solr_fields.add(self.get_field_index(field))
-        return list((requested_solr_fields | self.required_search_fields) & solr_fields)
+        return list(requested_solr_fields & solr_fields)
 
     def prepare_additional_params(self, params):
         return params

--- a/opengever/api/solr_query_service.py
+++ b/opengever/api/solr_query_service.py
@@ -82,10 +82,14 @@ def translated_task_type(obj):
     return task_type_helper(obj, obj.task_type)
 
 
-def relative_path(brain):
+def to_relative_path(value):
     portal_path_length = len(api.portal.get().getPhysicalPath())
-    content_path = brain.getPath().split('/')
+    content_path = value.split('/')
     return '/'.join(content_path[portal_path_length:])
+
+
+def relative_path(brain):
+    return to_relative_path(brain.getPath())
 
 
 class SimpleListingField(object):
@@ -177,7 +181,7 @@ FIELDS_WITH_MAPPING = [
     ListingField('pdf_url', None, 'preview_pdf_url', DEFAULT_SORT_INDEX),
     ListingField('preview_url', None, 'get_preview_frame_url', DEFAULT_SORT_INDEX),
     ListingField('reference_number', 'reference'),
-    ListingField('relative_path', None, relative_path, DEFAULT_SORT_INDEX),
+    ListingField('relative_path', 'path', relative_path, transform=to_relative_path),
     ListingField('responsible', 'responsible', transform=display_name),
     ListingField('responsible_fullname', 'responsible', 'responsible_fullname'),
     ListingField('review_state', 'review_state',

--- a/opengever/api/solr_query_service.py
+++ b/opengever/api/solr_query_service.py
@@ -46,8 +46,10 @@ def safe_int(value, default=0):
 class SolrQueryBaseService(Service):
 
     field_mapping = {}
+
     default_fields = set()
     required_search_fields = set()
+    required_response_fields = set()
 
     def prepare_solr_query(self):
         params = self.request.form.copy()
@@ -114,6 +116,9 @@ class SolrQueryBaseService(Service):
                 self.is_field_allowed, self.requested_fields)
         else:
             self.requested_fields = self.default_fields
+
+        self.response_fields = (set(self.requested_fields) |
+                                self.required_response_fields)
 
         solr_fields = set(self.solr.manager.schema.fields.keys())
         requested_solr_fields = set([])

--- a/opengever/api/solr_query_service.py
+++ b/opengever/api/solr_query_service.py
@@ -256,6 +256,7 @@ class SolrQueryBaseService(Service):
     def __init__(self, context, request):
         super(SolrQueryBaseService, self).__init__(context, request)
         self.solr = getUtility(ISolrSearch)
+        self.solr_fields = set(self.solr.manager.schema.fields.keys())
         self.default_sort_index = DEFAULT_SORT_INDEX
         self.response_fields = None
 
@@ -341,14 +342,13 @@ class SolrQueryBaseService(Service):
         self.response_fields = (set(requested_fields) |
                                 self.required_response_fields)
 
-        solr_fields = set(self.solr.manager.schema.fields.keys())
         requested_solr_fields = set([])
         for field_name in self.response_fields:
             field = self.get_field(field_name)
             requested_solr_fields.add(field.index)
             # certain fields require data from other solr fields to be computed.
             requested_solr_fields.update(set(field.additional_required_fields))
-        return list(requested_solr_fields & solr_fields)
+        return list(requested_solr_fields & self.solr_fields)
 
     def prepare_additional_params(self, params):
         return params

--- a/opengever/api/solr_query_service.py
+++ b/opengever/api/solr_query_service.py
@@ -79,7 +79,7 @@ def translated_title(obj):
 
 
 def translated_task_type(obj):
-    return task_type_helper(obj, obj.task_type)
+    return task_type_helper(obj, obj.get("task_type"))
 
 
 def to_relative_path(value):

--- a/opengever/api/solr_query_service.py
+++ b/opengever/api/solr_query_service.py
@@ -8,6 +8,7 @@ from opengever.base.behaviors.translated_title import ITranslatedTitleSupport
 from opengever.base.helpers import display_name
 from opengever.base.solr import OGSolrContentListing
 from opengever.base.utils import get_preferred_language_code
+from opengever.base.utils import safe_int
 from opengever.globalindex.browser.report import task_type_helper as task_type_value_helper
 from opengever.task.helper import task_type_helper
 from plone import api
@@ -237,13 +238,6 @@ date_fields = set([
 
 FIELDS_WITH_MAPPING.extend(
     [DateListingField(field_name) for field_name in date_fields])
-
-
-def safe_int(value, default=0):
-    try:
-        return int(value)
-    except (ValueError, TypeError):
-        return default
 
 
 class SolrQueryBaseService(Service):

--- a/opengever/api/solrsearch.py
+++ b/opengever/api/solrsearch.py
@@ -75,10 +75,15 @@ class SolrSearchGet(SolrQueryBaseService):
                 sort = 'score asc'
         return sort
 
+    def parse_requested_fields(self, params):
+        requested_fields = params.pop('fl', None)
+        if requested_fields:
+            return requested_fields.split(',')
+        return requested_fields
+
     def extract_field_list(self, params):
-        self.requested_fields = params.pop('fl', None)
-        if self.requested_fields:
-            self.requested_fields = self.requested_fields.split(',')
+        self.requested_fields = self.parse_requested_fields(params)
+        if self.requested_fields is not None:
             self.requested_fields = filter(
                 self.is_field_allowed, self.requested_fields)
         else:

--- a/opengever/api/solrsearch.py
+++ b/opengever/api/solrsearch.py
@@ -15,13 +15,6 @@ DEFAULT_FIELDS = set([
     'review_state',
 ])
 
-# Field name -> (Solr field, accessor)
-FIELD_MAPPING = {
-    "@id": ("path", "getURL"),
-    "@type": ("portal_type", "PortalType"),
-    "title": ("Title", "Title"),
-    "description": ("Description", "Description"),
-}
 
 BLACKLISTED_ATTRIBUTES = set([
     'getDataOrigin',
@@ -41,7 +34,6 @@ class SolrSearchGet(SolrQueryBaseService):
     """REST API endpoint for querying Solr
     """
 
-    field_mapping = FIELD_MAPPING
     default_fields = DEFAULT_FIELDS
     required_search_fields = REQUIRED_SEARCH_FIELDS
 

--- a/opengever/api/solrsearch.py
+++ b/opengever/api/solrsearch.py
@@ -100,7 +100,7 @@ class SolrSearchGet(SolrQueryBaseService):
         items = []
         for doc in docs:
             item = {}
-            for field in self.requested_fields:
+            for field in self.response_fields:
                 accessor = self.get_field_accessor(field)
                 value = getattr(doc, accessor, None)
                 if callable(value):

--- a/opengever/api/solrsearch.py
+++ b/opengever/api/solrsearch.py
@@ -1,10 +1,8 @@
-from ftw.solr.interfaces import ISolrSearch
 from ftw.solr.query import make_query
 from opengever.api.solr_query_service import SolrQueryBaseService
 from opengever.base.interfaces import ISearchSettings
 from plone import api
 from zExceptions import BadRequest
-from zope.component import getUtility
 
 
 BLACKLISTED_ATTRIBUTES = set([
@@ -60,8 +58,6 @@ class SolrSearchGet(SolrQueryBaseService):
         if not api.portal.get_registry_record(
                 'use_solr', interface=ISearchSettings):
             raise BadRequest('Solr is not enabled on this GEVER installation.')
-
-        self.solr = getUtility(ISolrSearch)
 
         query, filters, start, rows, sort, field_list, params = self.prepare_solr_query()
 

--- a/opengever/api/solrsearch.py
+++ b/opengever/api/solrsearch.py
@@ -1,6 +1,5 @@
 from ftw.solr.interfaces import ISolrSearch
 from ftw.solr.query import make_query
-from opengever.api.listing import FACET_TRANSFORMS
 from opengever.api.solr_query_service import SolrQueryBaseService
 from opengever.base.interfaces import ISearchSettings
 from opengever.base.solr import OGSolrContentListing
@@ -128,15 +127,7 @@ class SolrSearchGet(SolrQueryBaseService):
             "rows": rows,
         }
 
-        facet_counts = {}
-        for field, facets in resp.facets.items():
-            facet_counts[field] = {}
-            transform = FACET_TRANSFORMS.get(field)
-            for facet, count in facets.items():
-                facet_counts[field][facet] = {"count": count}
-                if transform:
-                    facet_counts[field][facet]['label'] = transform(facet)
-                else:
-                    facet_counts[field][facet]['label'] = facet
+        facet_counts = self.extract_facets_from_response(resp)
         res['facet_counts'] = facet_counts
+
         return res

--- a/opengever/api/solrsearch.py
+++ b/opengever/api/solrsearch.py
@@ -33,7 +33,7 @@ BLACKLISTED_ATTRIBUTES = set([
     'allowedRolesAndUsers',
 ])
 
-REQUIRED_FIELDS = set([
+REQUIRED_SEARCH_FIELDS = set([
     'UID',
     'path',
 ])
@@ -44,6 +44,8 @@ class SolrSearchGet(SolrQueryBaseService):
     """
 
     field_mapping = FIELD_MAPPING
+    default_fields = DEFAULT_FIELDS
+    required_search_fields = REQUIRED_SEARCH_FIELDS
 
     def extract_query(self, params):
         if 'q' in params:
@@ -80,21 +82,6 @@ class SolrSearchGet(SolrQueryBaseService):
         if requested_fields:
             return requested_fields.split(',')
         return requested_fields
-
-    def extract_field_list(self, params):
-        self.requested_fields = self.parse_requested_fields(params)
-        if self.requested_fields is not None:
-            self.requested_fields = filter(
-                self.is_field_allowed, self.requested_fields)
-        else:
-            self.requested_fields = DEFAULT_FIELDS
-
-        solr_fields = set(self.solr.manager.schema.fields.keys())
-        requested_solr_fields = set([])
-        for field in self.requested_fields:
-            requested_solr_fields.add(self.get_field_index(field))
-        return ','.join(
-            (requested_solr_fields | REQUIRED_FIELDS) & solr_fields)
 
     def reply(self):
         if not api.portal.get_registry_record(

--- a/opengever/api/solrsearch.py
+++ b/opengever/api/solrsearch.py
@@ -7,15 +7,6 @@ from zExceptions import BadRequest
 from zope.component import getUtility
 
 
-DEFAULT_FIELDS = set([
-    '@id',
-    '@type',
-    'title',
-    'description',
-    'review_state',
-])
-
-
 BLACKLISTED_ATTRIBUTES = set([
     'getDataOrigin',
     'getObject',
@@ -28,8 +19,6 @@ BLACKLISTED_ATTRIBUTES = set([
 class SolrSearchGet(SolrQueryBaseService):
     """REST API endpoint for querying Solr
     """
-
-    default_fields = DEFAULT_FIELDS
 
     def extract_query(self, params):
         if 'q' in params:

--- a/opengever/api/solrsearch.py
+++ b/opengever/api/solrsearch.py
@@ -24,18 +24,12 @@ BLACKLISTED_ATTRIBUTES = set([
     'allowedRolesAndUsers',
 ])
 
-REQUIRED_SEARCH_FIELDS = set([
-    'UID',
-    'path',
-])
-
 
 class SolrSearchGet(SolrQueryBaseService):
     """REST API endpoint for querying Solr
     """
 
     default_fields = DEFAULT_FIELDS
-    required_search_fields = REQUIRED_SEARCH_FIELDS
 
     def extract_query(self, params):
         if 'q' in params:

--- a/opengever/api/solrsearch.py
+++ b/opengever/api/solrsearch.py
@@ -54,6 +54,18 @@ class SolrSearchGet(SolrQueryBaseService):
             return requested_fields.split(',')
         return requested_fields
 
+    def prepare_additional_params(self, params):
+        facet_fields = params.get('facet.field', [])
+        if not isinstance(facet_fields, list):
+            facet_fields = [facet_fields]
+        if facet_fields:
+            facet_fields = [
+                facet for facet in facet_fields
+                if self.is_field_allowed(facet) and
+                self.get_field_index(facet) in self.solr_fields]
+            params['facet.field'] = facet_fields
+        return params
+
     def reply(self):
         if not api.portal.get_registry_record(
                 'use_solr', interface=ISearchSettings):

--- a/opengever/api/solrsearch.py
+++ b/opengever/api/solrsearch.py
@@ -92,7 +92,7 @@ class SolrSearchGet(SolrQueryBaseService):
         return res
 
     def is_field_allowed(self, field):
-        # Do not allow access to private attributes
+        """Do not allow private or blacklisted attributes"""
         if field.startswith("_") or field in BLACKLISTED_ATTRIBUTES:
             return False
         return True

--- a/opengever/api/solrsearch.py
+++ b/opengever/api/solrsearch.py
@@ -2,9 +2,7 @@ from ftw.solr.interfaces import ISolrSearch
 from ftw.solr.query import make_query
 from opengever.api.solr_query_service import SolrQueryBaseService
 from opengever.base.interfaces import ISearchSettings
-from opengever.base.solr import OGSolrContentListing
 from plone import api
-from plone.restapi.serializer.converters import json_compatible
 from zExceptions import BadRequest
 from zope.component import getUtility
 
@@ -96,22 +94,10 @@ class SolrSearchGet(SolrQueryBaseService):
             query=query, filters=filters, start=start, rows=rows, sort=sort,
             fl=field_list, **params)
 
-        docs = OGSolrContentListing(resp)
-        items = []
-        for doc in docs:
-            item = {}
-            for field in self.response_fields:
-                accessor = self.get_field_accessor(field)
-                value = getattr(doc, accessor, None)
-                if callable(value):
-                    value = value()
-                item[field] = json_compatible(value)
-            items.append(item)
-
         res = {
             "@id": "{}?{}".format(
                 self.request['ACTUAL_URL'], self.request['QUERY_STRING']),
-            "items": items,
+            "items": self.prepare_response_items(resp),
             "items_total": resp.num_found,
             "start": start,
             "rows": rows,

--- a/opengever/api/tests/test_listing.py
+++ b/opengever/api/tests/test_listing.py
@@ -277,7 +277,7 @@ class TestListingWithRealSolr(SolrIntegrationTestCase):
         results = browser.json
 
         self.assertItemsEqual(
-            [u'b_size', u'b_start', u'@id', u'items_total', u'items'],
+            [u'b_size', u'b_start', u'@id', u'items_total', u'items', u'facets'],
             results.keys())
         self.assertEqual(0, results["b_start"])
         self.assertEqual(25, results["b_size"])

--- a/opengever/api/tests/test_listing.py
+++ b/opengever/api/tests/test_listing.py
@@ -245,7 +245,7 @@ class TestListingWithRealSolr(SolrIntegrationTestCase):
     features = ('bumblebee', 'solr')
 
     @browsing
-    def test_dossier_listing_fails_for_responsible_fullname(self, browser):
+    def test_dossier_listing_works_for_responsible_fullname(self, browser):
         self.login(self.regular_user, browser=browser)
         query_string = '&'.join((
             'name=dossiers',
@@ -258,8 +258,7 @@ class TestListingWithRealSolr(SolrIntegrationTestCase):
             'sort_on=created',
         ))
         view = '?'.join(('@listing', query_string))
-        with browser.expect_http_error(500):
-            browser.open(self.repository_root, view=view, headers=self.api_headers)
+        browser.open(self.repository_root, view=view, headers=self.api_headers)
 
     @browsing
     def test_dossier_listing(self, browser):

--- a/opengever/api/tests/test_listing.py
+++ b/opengever/api/tests/test_listing.py
@@ -276,8 +276,9 @@ class TestListingWithRealSolr(SolrIntegrationTestCase):
         browser.open(self.repository_root, view=view, headers=self.api_headers)
         results = browser.json
 
-        self.assertEqual([u'b_size', u'b_start', u'@id', u'items_total', u'items'],
-                         results.keys())
+        self.assertItemsEqual(
+            [u'b_size', u'b_start', u'@id', u'items_total', u'items'],
+            results.keys())
         self.assertEqual(0, results["b_start"])
         self.assertEqual(25, results["b_size"])
         expected_url = "{}/{}".format(self.repository_root.absolute_url(),

--- a/opengever/api/tests/test_listing.py
+++ b/opengever/api/tests/test_listing.py
@@ -23,7 +23,7 @@ class TestListingEndpointWithoutSolr(IntegrationTestCase):
         with browser.expect_http_error(code=400):
             browser.open(self.repository_root,
                          view='@listing',
-                         headers={'Accept': 'application/json'})
+                         headers=self.api_headers)
 
 
 class TestListingEndpointWithSolr(IntegrationTestCase):
@@ -76,9 +76,7 @@ class TestListingEndpointWithSolr(IntegrationTestCase):
         view = ('@listing?name=dossiers&columns:list=title'
                 '&columns:list=review_state'
                 '&filters.review_state:record=dossier-state-active')
-        browser.open(self.repository_root, view=view,
-                     headers={'Accept': 'application/json'})
-
+        browser.open(self.repository_root, view=view, headers=self.api_headers)
         filters = self.solr.search.call_args[1]['filters']
         self.assertIn('review_state:(dossier\\-state\\-active)', filters)
 
@@ -90,9 +88,7 @@ class TestListingEndpointWithSolr(IntegrationTestCase):
                 '&columns:list=review_state'
                 '&filters.review_state:record:list=dossier-state-active'
                 '&filters.review_state:record:list=dossier-state-inactive')
-        browser.open(self.repository_root, view=view,
-                     headers={'Accept': 'application/json'})
-
+        browser.open(self.repository_root, view=view, headers=self.api_headers)
         filters = self.solr.search.call_args[1]['filters']
         self.assertIn(
             'review_state:(dossier\\-state\\-active OR dossier\\-state\\-inactive)',
@@ -107,8 +103,7 @@ class TestListingEndpointWithSolr(IntegrationTestCase):
                 '&columns:list=start'
                 '&filters.start:record=2016-01-01TO2016-01-01')
         browser.open(self.repository_root, view=view,
-                     headers={'Accept': 'application/json'})
-
+                     headers=self.api_headers)
         filters = self.solr.search.call_args[1]['filters']
         self.assertIn(
             'start:([2016-01-01T00:00:00.000Z TO 2016-01-01T23:59:59.000Z])',
@@ -123,8 +118,7 @@ class TestListingEndpointWithSolr(IntegrationTestCase):
                 '&columns:list=deadline'
                 '&filters.deadline:record=2016-01-01TO2016-01-01')
         browser.open(self.dossier, view=view,
-                     headers={'Accept': 'application/json'})
-
+                     headers=self.api_headers)
         filters = self.solr.search.call_args[1]['filters']
         self.assertIn(
             'deadline:([2016-01-01T00:00:00.000Z TO 2016-01-01T23:59:59.000Z])',
@@ -139,8 +133,7 @@ class TestListingEndpointWithSolr(IntegrationTestCase):
                 '&columns:list=start'
                 '&filters.file_extension:record:list=.docx')
         browser.open(self.repository_root, view=view,
-                     headers={'Accept': 'application/json'})
-
+                     headers=self.api_headers)
         filters = self.solr.search.call_args[1]['filters']
         self.assertIn(u'file_extension:(.docx)', filters)
 
@@ -152,8 +145,7 @@ class TestListingEndpointWithSolr(IntegrationTestCase):
                 '&columns:list=start'
                 '&filters.document_type:record:list=contract')
         browser.open(self.repository_root, view=view,
-                     headers={'Accept': 'application/json'})
-
+                     headers=self.api_headers)
         filters = self.solr.search.call_args[1]['filters']
         self.assertIn(u'document_type:(contract)', filters)
 
@@ -168,8 +160,7 @@ class TestListingEndpointWithSolr(IntegrationTestCase):
                 '&columns:list=start'
                 '&depth=1')
         browser.open(self.dossier, view=view,
-                     headers={'Accept': 'application/json'})
-
+                     headers=self.api_headers)
         filters = self.solr.search.call_args[1]['filters']
         self.assertIn(u'path_depth:[* TO 6]', filters)
 
@@ -180,8 +171,7 @@ class TestListingEndpointWithSolr(IntegrationTestCase):
         view = ('@listing?name=documents&columns:list=title'
                 '&facets:list=start')
         browser.open(self.repository_root, view=view,
-                     headers={'Accept': 'application/json'})
-
+                     headers=self.api_headers)
         params = self.solr.search.call_args[1]
         self.assertTrue(params['facet'],
                         msg="facet=true is needed to get facet counts back")
@@ -198,7 +188,7 @@ class TestListingEndpointWithSolr(IntegrationTestCase):
 
         view = '@listing?name=dossiers'
         browser.open(self.dossier, view=view,
-                     headers={'Accept': 'application/json'})
+                     headers=self.api_headers)
 
         context_uid = IUUID(self.dossier)
         filters = self.solr.search.call_args[1]['filters']
@@ -210,7 +200,7 @@ class TestListingEndpointWithSolr(IntegrationTestCase):
 
         view = '@listing?name=dossiers'
         browser.open(self.portal, view=view,
-                     headers={'Accept': 'application/json'})
+                     headers=self.api_headers)
 
         portal_uid = IUUID(self.portal, None)
         self.assertIsNone(portal_uid)
@@ -223,8 +213,7 @@ class TestListingEndpointWithSolr(IntegrationTestCase):
 
         view = '@listing?name=documents&search=feedb\xc3\xa4ck&columns=title'
         browser.open(self.repository_root, view=view,
-                     headers={'Accept': 'application/json'})
-
+                     headers=self.api_headers)
         query = self.solr.search.call_args[1]["query"]
         self.assertEqual(u'(Title:feedb\xe4ck* OR SearchableText:feedb\xe4ck* '
                          u'OR metadata:feedb\xe4ck*)',
@@ -236,8 +225,7 @@ class TestListingEndpointWithSolr(IntegrationTestCase):
 
         view = '@listing?name=documents&columns=title&sort_on=responsible'
         browser.open(self.repository_root, view=view,
-                     headers={'Accept': 'application/json'})
-
+                     headers=self.api_headers)
         sort = self.solr.search.call_args[1]["sort"]
         self.assertEqual('responsible desc', sort)
 
@@ -247,8 +235,7 @@ class TestListingEndpointWithSolr(IntegrationTestCase):
 
         view = '@listing?name=documents&columns=title&sort_on=inexistant'
         browser.open(self.repository_root, view=view,
-                     headers={'Accept': 'application/json'})
-
+                     headers=self.api_headers)
         sort = self.solr.search.call_args[1]["sort"]
         self.assertEqual('modified desc', sort)
 
@@ -272,7 +259,7 @@ class TestListingWithRealSolr(SolrIntegrationTestCase):
         ))
         view = '?'.join(('@listing', query_string))
         with browser.expect_http_error(500):
-            browser.open(self.repository_root, view=view, headers={'Accept': 'application/json'})
+            browser.open(self.repository_root, view=view, headers=self.api_headers)
 
     @browsing
     def test_dossier_listing(self, browser):
@@ -287,7 +274,7 @@ class TestListingWithRealSolr(SolrIntegrationTestCase):
             'sort_on=created',
         ))
         view = '?'.join(('@listing', query_string))
-        browser.open(self.repository_root, view=view, headers={'Accept': 'application/json'})
+        browser.open(self.repository_root, view=view, headers=self.api_headers)
         results = browser.json
 
         self.assertEqual([u'b_size', u'b_start', u'@id', u'items_total', u'items'],
@@ -323,7 +310,7 @@ class TestListingWithRealSolr(SolrIntegrationTestCase):
             'sort_on=created',
         ))
         view = '?'.join(('@listing', query_string))
-        browser.open(self.dossier, view=view, headers={'Accept': 'application/json'})
+        browser.open(self.dossier, view=view, headers=self.api_headers)
         self.assertEqual(
             {u'reference': u'Client1 1.1 / 1 / 14',
              u'title': u'Vertr\xe4gsentwurf',
@@ -345,7 +332,7 @@ class TestListingWithRealSolr(SolrIntegrationTestCase):
             'sort_on=created',
         ))
         view = '?'.join(('@listing', query_string))
-        browser.open(self.dossier, view=view, headers={'Accept': 'application/json'})
+        browser.open(self.dossier, view=view, headers=self.api_headers)
 
         self.assertEqual(
             'http://bumblebee/YnVtYmxlYmVl/api/v3/resource/local'
@@ -362,7 +349,7 @@ class TestListingWithRealSolr(SolrIntegrationTestCase):
             'sort_on=created',
         ))
         view = '?'.join(('@listing', query_string))
-        browser.open(self.dossier, view=view, headers={'Accept': 'application/json'})
+        browser.open(self.dossier, view=view, headers=self.api_headers)
         self.assertEqual(
             'http://bumblebee/YnVtYmxlYmVl/api/v3/resource/local'
             '/51d6317494eccc4a73154625a6820cb6b50dc1455eb4cf26399299d4f9ce77b2/pdf',
@@ -374,7 +361,7 @@ class TestListingWithRealSolr(SolrIntegrationTestCase):
         self.login(self.regular_user, browser=browser)
 
         view = '@listing?name=documents&columns=filename&columns=filesize&sort_on=created'
-        browser.open(self.dossier, view=view, headers={'Accept': 'application/json'})
+        browser.open(self.dossier, view=view, headers=self.api_headers)
 
         self.assertEqual(
             {u'@id': self.document.absolute_url(),
@@ -418,20 +405,20 @@ class TestListingWithRealSolr(SolrIntegrationTestCase):
 
         view = '@listing?name=dossiers'
         browser.open(
-            self.repository_root, view=view, headers={'Accept': 'application/json'})
+            self.repository_root, view=view, headers=self.api_headers)
         all_dossiers = browser.json['items']
 
         # batched no start point
         view = '@listing?name=dossiers&b_size=3'
         browser.open(
-            self.repository_root, view=view, headers={'Accept': 'application/json'})
+            self.repository_root, view=view, headers=self.api_headers)
         self.assertEqual(3, len(browser.json['items']))
         self.assertEqual(all_dossiers[0:3], browser.json['items'])
 
         # batched with start point
         view = '@listing?name=dossiers&b_size=2&b_start=4'
         browser.open(
-            self.repository_root, view=view, headers={'Accept': 'application/json'})
+            self.repository_root, view=view, headers=self.api_headers)
         self.assertEqual(2, len(browser.json['items']))
         self.assertEqual(all_dossiers[4:6], browser.json['items'])
 
@@ -441,7 +428,7 @@ class TestListingWithRealSolr(SolrIntegrationTestCase):
 
         view = '@listing?name=documents&search=feedb\xc3\xa4ck&columns=title'
         browser.open(self.repository_root, view=view,
-                     headers={'Accept': 'application/json'})
+                     headers=self.api_headers)
         self.assertEqual(
             [self.taskdocument.absolute_url()],
             [item['@id'] for item in browser.json['items']])
@@ -452,7 +439,7 @@ class TestListingWithRealSolr(SolrIntegrationTestCase):
 
         view = '@listing?name=dossiers&columns:list=title&sort_on=created'
         browser.open(
-            self.dossier, view=view, headers={'Accept': 'application/json'})
+            self.dossier, view=view, headers=self.api_headers)
 
         self.assertNotIn(
             self.dossier.Title().decode('utf8'),
@@ -481,7 +468,7 @@ class TestListingWithRealSolr(SolrIntegrationTestCase):
                 '&columns:list=review_state'
                 '&filters.review_state:record=dossier-state-active')
         browser.open(self.repository_root, view=view,
-                     headers={'Accept': 'application/json'})
+                     headers=self.api_headers)
 
         items = browser.json['items']
         review_states = list(set(map(lambda x: x['review_state'], items)))
@@ -497,7 +484,7 @@ class TestListingWithRealSolr(SolrIntegrationTestCase):
                 '&filters.review_state:record:list=dossier-state-active'
                 '&filters.review_state:record:list=dossier-state-inactive')
         browser.open(self.repository_root, view=view,
-                     headers={'Accept': 'application/json'})
+                     headers=self.api_headers)
 
         items = browser.json['items']
         review_states = list(set(map(lambda x: x['review_state'], items)))
@@ -513,7 +500,7 @@ class TestListingWithRealSolr(SolrIntegrationTestCase):
                 '&columns:list=start'
                 '&filters.start:record=2016-01-01TO2016-01-01')
         browser.open(self.repository_root, view=view,
-                     headers={'Accept': 'application/json'})
+                     headers=self.api_headers)
 
         items = browser.json['items']
         start_dates = list(set(map(lambda x: x['start'], items)))
@@ -526,7 +513,7 @@ class TestListingWithRealSolr(SolrIntegrationTestCase):
 
         view = '@listing?name=tasks&columns:list=title&columns:list=deadline'
         browser.open(self.dossier, view=view,
-                     headers={'Accept': 'application/json'})
+                     headers=self.api_headers)
 
         items = browser.json['items']
         self.assertTrue(
@@ -535,7 +522,7 @@ class TestListingWithRealSolr(SolrIntegrationTestCase):
 
         view = '{}&filters.deadline:record=2016-08-01TO2016-10-01'.format(view)
         browser.open(self.dossier, view=view,
-                     headers={'Accept': 'application/json'})
+                     headers=self.api_headers)
 
         items = browser.json['items']
         deadlines = list(set(map(lambda x: x['deadline'], items)))
@@ -551,7 +538,7 @@ class TestListingWithRealSolr(SolrIntegrationTestCase):
             'columns=description',
         ))
         view = '?'.join(('@listing', query_string))
-        browser.open(self.workspace_root, view=view, headers={'Accept': 'application/json'})
+        browser.open(self.workspace_root, view=view, headers=self.api_headers)
 
         self.assertDictEqual(
             {u'@id': u'http://nohost/plone/workspaces/workspace-1',
@@ -568,7 +555,7 @@ class TestListingWithRealSolr(SolrIntegrationTestCase):
             'columns=description',
         ))
         view = '?'.join(('@listing', query_string))
-        browser.open(self.workspace, view=view, headers={'Accept': 'application/json'})
+        browser.open(self.workspace, view=view, headers=self.api_headers)
 
         self.assertDictEqual(
             {u'@id': u'http://nohost/plone/workspaces/workspace-1/folder-1',
@@ -776,7 +763,7 @@ class TestListingWithRealSolr(SolrIntegrationTestCase):
             'sort_order=ascending',
         ))
         view = '?'.join(('@listing', query_string))
-        browser.open(self.workspace, view=view, headers={'Accept': 'application/json'})
+        browser.open(self.workspace, view=view, headers=self.api_headers)
 
         self.assertEqual(
             [

--- a/opengever/api/tests/test_search.py
+++ b/opengever/api/tests/test_search.py
@@ -11,8 +11,6 @@ import urlparse
 
 class TestSearchEndpoint(IntegrationTestCase):
 
-    api_headers = {'Accept': 'application/json'}
-
     def search_catalog(self, context, query):
         catalog = api.portal.get_tool('portal_catalog')
         path = '/'.join(context.getPhysicalPath())

--- a/opengever/api/tests/test_solrsearch.py
+++ b/opengever/api/tests/test_solrsearch.py
@@ -7,7 +7,6 @@ from unittest import skip
 
 class TestMockSolrSearchGet(IntegrationTestCase):
 
-    api_headers = {'Accept': 'application/json'}
     features = ['solr']
 
     @browsing

--- a/opengever/base/contentlisting.py
+++ b/opengever/base/contentlisting.py
@@ -51,10 +51,7 @@ class OpengeverCatalogContentListingObject(CatalogContentListingObject):
         when the brain does not have keywords, as solr will simply not return
         the field in that case.
         """
-        if hasattr(self._brain, "Subject"):
-            return self._brain.Subject
-        else:
-            return None
+        return getattr(self._brain, "Subject", None)
 
     @property
     def is_document(self):

--- a/opengever/base/contentlisting.py
+++ b/opengever/base/contentlisting.py
@@ -46,6 +46,16 @@ class OpengeverCatalogContentListingObject(CatalogContentListingObject):
         else:
             raise AttributeError(name)
 
+    def Subject(self):
+        """We need to overwrite CatalogContentListingObject.Subject which fails
+        when the brain does not have keywords, as solr will simply not return
+        the field in that case.
+        """
+        if hasattr(self._brain, "Subject"):
+            return self._brain.Subject
+        else:
+            return None
+
     @property
     def is_document(self):
         return self._brain.portal_type == 'opengever.document.document'
@@ -172,13 +182,16 @@ class OpengeverCatalogContentListingObject(CatalogContentListingObject):
                 review_state, domain='plone', context=self.request)
 
     def responsible_fullname(self):
-        return display_name(self._brain.responsible)
+        userid = getattr(self._brain, "responsible", None)
+        return None if userid is None else display_name(userid)
 
     def issuer_fullname(self):
-        return display_name(self._brain.issuer)
+        userid = getattr(self._brain, "issuer", None)
+        return None if userid is None else display_name(userid)
 
     def checked_out_fullname(self):
-        return display_name(self._brain.checked_out)
+        userid = getattr(self._brain, "checked_out", None)
+        return None if userid is None else display_name(userid)
 
     def creator(self):
         return self._brain.Creator

--- a/opengever/base/tests/test_utils.py
+++ b/opengever/base/tests/test_utils.py
@@ -5,6 +5,7 @@ from mocker import ANY
 from opengever.base.behaviors.utils import set_attachment_content_disposition
 from opengever.base.utils import escape_html
 from opengever.base.utils import file_checksum
+from opengever.base.utils import safe_int
 from opengever.dossier.utils import find_parent_dossier
 from opengever.testing import IntegrationTestCase
 from plone.namedfile.file import NamedFile
@@ -164,3 +165,22 @@ class TestChecksum(TestCase):
         alg, chksum = file_checksum(filename, algorithm=u'SHA256')
         self.assertEqual(alg, u'SHA256')
         self.assertEqual(chksum, '2cbe78150099d95789ceb5606818eeefccc7228cedd9bbe9cf7ce6af7071abd2')
+
+
+class TestSafeInt(TestCase):
+
+    def test_transparently_returns_int(self):
+        value = 3
+        self.assertEquals(3, safe_int(value))
+
+    def test_casts_string_to_int(self):
+        value = '3'
+        self.assertEquals(3, safe_int(value))
+
+    def test_defaults_to_zero(self):
+        value = 'not an int'
+        self.assertEqual(0, safe_int(value))
+
+    def test_custom_default_value(self):
+        value = 'not an int'
+        self.assertEqual(7, safe_int(value, 7))

--- a/opengever/base/utils.py
+++ b/opengever/base/utils.py
@@ -207,3 +207,10 @@ def rewrite_path_list_to_absolute_paths(request):
             new_paths.append(new_path)
 
         request['paths'] = request.form['paths'] = new_paths
+
+
+def safe_int(value, default=0):
+    try:
+        return int(value)
+    except (ValueError, TypeError):
+        return default


### PR DESCRIPTION
With this PR we refactor the listing and search endpoints. The two endpoints mainly have the same functionality but were each doing things differently, not sharing any code. 
Refactoring led to:
- The two endpoints share a baseclass 
- They return similar responses (see also https://github.com/4teamwork/opengever.core/pull/6071). 
- Batching is still done differently in the two endpoints (one uses `rows` and `start`, the other `b_size` and `start_b`), as this would be a breaking change...
- The field, index, accessor mapping was rewritten using classes for fields, which also know things like casting a value to a label, etc. This leads to fewer conditions strewn around in the code.
- Fields now know if they need to request other fields (for example `preview_url` needs the `bumblebee_checksum` and `path`)

I also introduced some changes to the endpoints:
- The `@search` endpoint now also accepts the same fields as the listing endpoint (but not only)
- The `@listing` endpoint uses the same default fields as the `@search` endpoint when no fields are requested
- The search endpoint now also returns the `translated_title`
- I fixed the issues with certain fields leading to a failure in the endpoints

For https://github.com/4teamwork/opengever.core/pull/6071, https://github.com/4teamwork/opengever.core/issues/5755 and https://github.com/4teamwork/opengever.core/issues/5901

## Checkliste
- [ ] Changelog-Eintrag vorhanden/nötig?
- [ ] Aktualisierung Dokumentation vorhanden/nötig?
