### PR TITLE
Do not manipulate the persistent journal list on @history get.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,7 @@ Changelog
 2019.4.2 (unreleased)
 ---------------------
 
-- Nothing changed yet.
+- Do not manipulate the persisten journal list on @history get. [phgross]
 
 
 2019.4.1 (2019-11-26)

--- a/opengever/api/journal.py
+++ b/opengever/api/journal.py
@@ -1,6 +1,5 @@
 from copy import deepcopy
 from ftw.journal.config import JOURNAL_ENTRIES_ANNOTATIONS_KEY
-from ftw.journal.interfaces import IAnnotationsJournalizable
 from opengever.base.helpers import display_name
 from opengever.base.vocabulary import voc_term_title
 from opengever.journal.entry import ManualJournalEntry

--- a/opengever/api/journal.py
+++ b/opengever/api/journal.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from ftw.journal.config import JOURNAL_ENTRIES_ANNOTATIONS_KEY
 from ftw.journal.interfaces import IAnnotationsJournalizable
 from opengever.base.helpers import display_name
@@ -128,6 +129,6 @@ class JournalGet(Service):
 
     def _data(self):
         annotations = IAnnotations(self.context)
-        items = annotations.get(JOURNAL_ENTRIES_ANNOTATIONS_KEY, [])
+        items = deepcopy(annotations.get(JOURNAL_ENTRIES_ANNOTATIONS_KEY, []))
         items.reverse()
         return items


### PR DESCRIPTION
When calling the history endpoint, it currently sorted the persistent list - which raises CSRF Warnings.

Used for https://github.com/4teamwork/gever-ui/issues/659

_Link zum Issue: `closes` oder `fixes` keyword verwenden._

Definition of Done: https://gever.4teamwork.ch/ordnungssystem/3/2/2/allgemeines/dossier-3644/document-30943


## Checkliste

_Zutreffendes soll angehakt stehengelassen werden._
- [x] Changelog-Eintrag vorhanden/nötig?