### PR TITLE
Fix authorization handling when fetching the template_group_id.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 ---------------------
 
 - Do not manipulate the persisten journal list on @history get. [phgross]
+- Fix authorization handling when fetching the template_group_id. [phgross]
 
 
 2019.4.1 (2019-11-26)


### PR DESCRIPTION
With the latest change, we adjust the handling to extract the templatelibrary id. But with this change, we mistakenly only adjusted the happy case, but not the case when the first requests is answered with an 401, because of a no longer valid token.

Fixes https://sentry.4teamwork.ch/sentry/onegov-gever/issues/52318/

## Checkliste

_Zutreffendes soll angehakt stehengelassen werden._
- [x] Changelog-Eintrag vorhanden/nötig?
