### PR TITLE
Skip document modified journal entry when saving file with OC RESTAPI.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -9,6 +9,8 @@ Changelog
 - Only show workspace notification tab when feature is activated. [njohner]
 - Do not manipulate the persisten journal list on @history get. [phgross]
 - Fix authorization handling when fetching the template_group_id. [phgross]
+- Do not add document modified journal entry when saving file with OC RESTAPI. [njohner]
+- Do not manipulate the persistent journal list on @journal get. [phgross]
 
 
 2019.4.1 (2019-11-26)

--- a/opengever/journal/handlers.py
+++ b/opengever/journal/handlers.py
@@ -361,7 +361,10 @@ def document_modified(context, event):
                 # Attribute name is different when changed through regular
                 # edit form vs. edit_public_trial form, so check for both
                 public_trial_changed = True
-            elif attr not in ('file', 'message', 'IDocumentMetadata.archival_file'):
+            elif attr not in ('file',
+                              'message',
+                              'IDocumentMetadata.archival_file',
+                              'IDocumentSchema.file'):
                 # We ignore cases where only the file was modified
                 metadata_changed = True
 

--- a/opengever/officeconnector/tests/test_api_dossier_checkout.py
+++ b/opengever/officeconnector/tests/test_api_dossier_checkout.py
@@ -1,4 +1,5 @@
 from copy import deepcopy
+from ftw.journal.config import JOURNAL_ENTRIES_ANNOTATIONS_KEY
 from ftw.testbrowser import browsing
 from ftw.testing import freeze
 from hashlib import sha256
@@ -7,6 +8,7 @@ from opengever.officeconnector.testing import FREEZE_DATE
 from opengever.officeconnector.testing import JWT_SIGNING_SECRET_PLONE
 from opengever.officeconnector.testing import OCIntegrationTestCase
 from opengever.testing.assets import path_to_asset
+from zope.annotation.interfaces import IAnnotations
 import jwt
 
 
@@ -284,6 +286,17 @@ class TestOfficeconnectorDossierAPIWithCheckout(OCIntegrationTestCase):
             comment='foobar',
             )
 
+        # Verify journal entries produced by the cycle
+        journal = IAnnotations(self.document, JOURNAL_ENTRIES_ANNOTATIONS_KEY).get(
+            JOURNAL_ENTRIES_ANNOTATIONS_KEY)
+        expected_actions = ['Document added',
+                            'Document checked out',
+                            'File copy downloaded',
+                            'File copy downloaded',
+                            'Document checked in']
+        self.assertEquals(expected_actions,
+                          [entry["action"]["type"] for entry in journal])
+
     @browsing
     def test_checkout_checkin_inactive_without_file(self, browser):
         self.login(self.regular_user, browser)
@@ -399,6 +412,17 @@ class TestOfficeconnectorDossierAPIWithCheckoutWithRESTAPI(TestOfficeconnectorDo
 
         self.unlock_document_via_api(browser, raw_token, payloads[0], self.document)
         self.checkin_document_via_api(browser, raw_token, payloads[0], self.document, comment='foobar')
+
+        # Verify journal entries produced by the cycle
+        journal = IAnnotations(self.document, JOURNAL_ENTRIES_ANNOTATIONS_KEY).get(
+            JOURNAL_ENTRIES_ANNOTATIONS_KEY)
+        expected_actions = ['Document added',
+                            'Document checked out',
+                            'File copy downloaded',
+                            'File copy downloaded',
+                            'Document checked in']
+        self.assertEquals(expected_actions,
+                          [entry["action"]["type"] for entry in journal])
 
     @browsing
     def test_checkout_checkin_open_with_file_without_comment(self, browser):


### PR DESCRIPTION
We do no longer write journal entries when saving a checked out file (as this made an entry for each save of the file see https://github.com/4teamwork/opengever.core/pull/6054). But the check to skip the journal entry did not work when using the REST-API payloads for OC. This is fixed in this PR.

For https://github.com/4teamwork/opengever.core/issues/5735

## Checkliste
- [x] Changelog-Eintrag vorhanden/nötig?
