### PR TITLE
Fix styling bug in tabbedview after showing bumblebee tooltip.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2019.4.2 (unreleased)
 ---------------------
 
+- Fix styling bug in tabbedview after showing bumblebee tooltip. [njohner]
 - Do not manipulate the persisten journal list on @history get. [phgross]
 
 

--- a/opengever/base/browser/resources/tooltip.js
+++ b/opengever/base/browser/resources/tooltip.js
@@ -69,22 +69,28 @@
     $(target).closest('.x-grid3-row').addClass('bumblebee-tooltip-active');
   }
 
-  function deactivateTableCells(target) {
+  function deactivateOtherTableCells(target) {
     $(target).closest('.x-grid3-row').siblings().removeClass('bumblebee-tooltip-active');
+  }
+
+  function deactivateTableCell(target) {
+    $(target).closest('.x-grid3-row').removeClass('bumblebee-tooltip-active');
   }
 
   function showBackdrop(event) {
     var target = event.originalEvent.target;
-    deactivateTableCells(target);
+    deactivateOtherTableCells(target);
     clearTimeout(tooltipHideTimer);
     $('body').addClass('bumblebee-tooltip-open');
     activateTableCell(target);
   }
 
-  function hideBackdrop() {
+  function hideBackdrop(event) {
     tooltipHideTimer = setTimeout(function() {
       $('body').removeClass('bumblebee-tooltip-open');
     }, settings.hide.delay / 2);
+    var target = event.originalEvent.target;
+    deactivateTableCell(target);
   }
 
   function closeTooltips(event, api) {


### PR DESCRIPTION
We fix a styling issue in the documents tab, where after opening the bumblebee tooltip, the highlighting of the corresponding row does not get removed when the tooltip is closed again.

It also happens that the highlighted row is in front of other open menus (search menu for example), but I think that is fine, as long as the highlighting is not left behind...

**With open search and tooltip, the row color and text is above the search menu.**
<img width="1454" alt="Screenshot 2019-11-28 at 13 06 31" src="https://user-images.githubusercontent.com/7374243/69804949-ef656400-11df-11ea-97ee-c843009f26f9.png">

**Once the tooltip is closed, the color is removed and does not overlap the search menu anymore**
<img width="1437" alt="Screenshot 2019-11-28 at 13 03 16" src="https://user-images.githubusercontent.com/7374243/69804771-90075400-11df-11ea-8b6d-caed7f06597a.png">


For https://github.com/4teamwork/opengever.core/issues/5898

## Checkliste
- [x] Changelog-Eintrag vorhanden/nötig?
