### PR TITLE
Fix response text for responsible changes to the same user.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,7 @@ Changelog
 - Fix setting agenda item description. [deiferni]
 - Fix styling bug in tabbedview after showing bumblebee tooltip. [njohner]
 - Only show workspace notification tab when feature is activated. [njohner]
+- Fix response text for responsible changes to the same user. [phgross]
 - Do not manipulate the persisten journal list on @history get. [phgross]
 - Fix authorization handling when fetching the template_group_id. [phgross]
 

--- a/opengever/task/activities.py
+++ b/opengever/task/activities.py
@@ -169,7 +169,7 @@ class TaskReassignActivity(TaskTransitionActivity):
         # that the same responsible in another org unit has been selected. So
         # there is no need to manipulate the watcher list, everything stays
         # the same.
-        if not change:
+        if not change or change.get('before') == self.context.responsible:
             return
 
         self.center.add_task_responsible(self.context, self.context.responsible)

--- a/opengever/task/util.py
+++ b/opengever/task/util.py
@@ -111,12 +111,11 @@ def add_simple_response(task, text='', field_changes=None, added_objects=None,
     if field_changes:
         for field, new_value in field_changes:
             old_value = field.get(field.interface(task))
-            if old_value != new_value:
-                response.add_change(
-                    field.__name__,
-                    old_value,
-                    new_value,
-                    field_title=field.title)
+            response.add_change(
+                field.__name__,
+                old_value,
+                new_value,
+                field_title=field.title)
 
     if added_objects:
         intids = getUtility(IIntIds)


### PR DESCRIPTION
With the 2019.4 release it's now possible to reassign a task to the same user but different org_unit (`responsible_client`). But the response representation was wrong, because the responsible change was not tracked correctly.

No upgradestep/migration needed, because it is only possible since 2019.4.x

## Checkliste

_Zutreffendes soll angehakt stehengelassen werden._

- [x] Wurde etwas an der `Aufgabe` angepasst? Funktioniert das auch mit einer `Weiterleitung`? *Ja, habe es auch mit Weiterleitungen getestet.*
- [x] Changelog-Eintrag vorhanden/nötig?
