### PR TITLE
Only show workspace notification tab when feature is activated.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 ---------------------
 
 - Fix styling bug in tabbedview after showing bumblebee tooltip. [njohner]
+- Only show workspace notification tab when feature is activated. [njohner]
 - Do not manipulate the persisten journal list on @history get. [phgross]
 - Fix authorization handling when fetching the template_group_id. [phgross]
 

--- a/opengever/activity/browser/resources/settings.js
+++ b/opengever/activity/browser/resources/settings.js
@@ -99,10 +99,13 @@
         {tabId: 'reminders',
          tabTitle: this.getDataAttribute('tab-title-reminders'),
          activities: this.filterActivitiesByType(values, 'reminder')},
-        {tabId: 'workspaces',
-         tabTitle: this.getDataAttribute('tab-title-workspaces'),
-         activities: this.filterActivitiesByType(values, 'workspace')},
       ];
+      if (this.getDataAttribute('show-workspaces') == 'True') {
+        tabs.push({tabId: 'workspaces',
+           tabTitle: this.getDataAttribute('tab-title-workspaces'),
+           activities: this.filterActivitiesByType(values, 'workspace')
+        });
+      }
       if (this.getDataAttribute('show-proposals') == 'True') {
         tabs.push({tabId: 'proposals',
            tabTitle: this.getDataAttribute('tab-title-proposals'),

--- a/opengever/activity/browser/settings.py
+++ b/opengever/activity/browser/settings.py
@@ -8,12 +8,12 @@ from opengever.activity.roles import COMMITTEE_RESPONSIBLE_ROLE
 from opengever.activity.roles import DISPOSITION_ARCHIVIST_ROLE
 from opengever.activity.roles import DISPOSITION_RECORDS_MANAGER_ROLE
 from opengever.activity.roles import DOSSIER_RESPONSIBLE_ROLE
-from opengever.activity.roles import TODO_RESPONSIBLE_ROLE
-from opengever.activity.roles import WORKSPACE_MEMBER_ROLE
 from opengever.activity.roles import PROPOSAL_ISSUER_ROLE
 from opengever.activity.roles import TASK_ISSUER_ROLE
 from opengever.activity.roles import TASK_REMINDER_WATCHER_ROLE
 from opengever.activity.roles import TASK_RESPONSIBLE_ROLE
+from opengever.activity.roles import TODO_RESPONSIBLE_ROLE
+from opengever.activity.roles import WORKSPACE_MEMBER_ROLE
 from opengever.base.handlebars import prepare_handlebars_template
 from opengever.base.json_response import JSONResponse
 from opengever.base.model import create_session
@@ -21,6 +21,7 @@ from opengever.meeting import is_meeting_feature_enabled
 from opengever.ogds.models.user import User
 from opengever.ogds.models.user_settings import UserSettings
 from opengever.task.response_description import ResponseDescription
+from opengever.workspace import is_workspace_feature_enabled
 from path import Path
 from plone import api
 from Products.Five import BrowserView
@@ -417,3 +418,6 @@ class NotificationSettingsForm(BrowserView):
 
     def show_proposals_tab(self):
         return is_meeting_feature_enabled()
+
+    def show_workspaces_tab(self):
+        return is_workspace_feature_enabled()

--- a/opengever/activity/browser/templates/settings.pt
+++ b/opengever/activity/browser/templates/settings.pt
@@ -38,7 +38,8 @@
                            data-tab-title-dispositions view/tab_title_dispositions;
                            data-tab-title-workspaces view/tab_title_workspaces;
                            data-show-disposition view/show_disposition_tab;
-                           data-show-proposals view/show_proposals_tab;">
+                           data-show-proposals view/show_proposals_tab;
+                           data-show-workspaces view/show_workspaces_tab;">
 
         <tbody>
           <tal:block tal:replace="structure view/render_form_template"></tal:block>


### PR DESCRIPTION
Workspaces notifications settings should only be visible when the feature is activated.

For https://github.com/4teamwork/opengever.core/issues/6084

## Checkliste
- [x] Changelog-Eintrag vorhanden/nötig?