### PR TITLE
Fix meeting permissions in policy template.

### DIFF
--- a/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/profiles/default_content/opengever_content/03_committees.json.bob
+++ b/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/profiles/default_content/opengever_content/03_committees.json.bob
@@ -5,9 +5,11 @@
         "title_de": "Sitzungen",
         "_ac_local_roles": {
             "{{{orgunit.users_group}}}": [
-                "Contributor",
-                "Editor",
-                "Reader"
+                "MeetingUser"
+            ],
+            "{{{deployment.rolemanager_group}}}": [
+                "CommitteeAdministrator",
+                "MeetingUser"
             ]
         }
     }


### PR DESCRIPTION
Follow-up of https://github.com/4teamwork/opengever.core/pull/6089, also make sure that correct meeting roles are used in policy templates.