### PR TITLE
Fix setting agenda item description.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2019.4.2 (unreleased)
 ---------------------
 
+- Fix setting agenda item description. [deiferni]
 - Fix styling bug in tabbedview after showing bumblebee tooltip. [njohner]
 - Only show workspace notification tab when feature is activated. [njohner]
 - Do not manipulate the persisten journal list on @history get. [phgross]

--- a/opengever/meeting/model/agendaitem.py
+++ b/opengever/meeting/model/agendaitem.py
@@ -161,7 +161,7 @@ class AgendaItem(Base):
     def set_description(self, description):
         if self.has_proposal:
             self.submitted_proposal.description = description
-            self.submitted_proposal.sync_model()
+            self.proposal.sync_with_submitted_proposal(self.submitted_proposal)
         else:
             self.description = description
 

--- a/opengever/meeting/tests/test_submitted_proposal.py
+++ b/opengever/meeting/tests/test_submitted_proposal.py
@@ -89,7 +89,7 @@ class TestSubmittedProposal(IntegrationTestCase):
             [attribute.get('label') for attribute in attributes],
             )
 
-    def test_sql_index_proposal_title_is_updated(self):
+    def test_sql_index_proposal_title_and_description_are_updated(self):
         # an agenda item is needed for this test
         self.login(self.committee_responsible)
         self.meeting.model.schedule_proposal(self.proposal.load_model())
@@ -97,9 +97,13 @@ class TestSubmittedProposal(IntegrationTestCase):
         self.assertEquals(agenda_item.get_title(), agenda_item.proposal.submitted_title)
 
         agenda_item.set_title('New agenda item title')
+        agenda_item.set_description('New agenda item description')
 
         self.assertEquals('New agenda item title', agenda_item.get_title())
         self.assertEquals('New agenda item title', agenda_item.proposal.submitted_title)
+
+        self.assertEquals('New agenda item description', agenda_item.get_description())
+        self.assertEquals('New agenda item description', agenda_item.proposal.submitted_description)
 
     def test_get_containing_dossier_for_submitted_proposal_if_on_same_admin_unit(self):
         self.login(self.committee_responsible)


### PR DESCRIPTION
Fix setting the description of an agenda-item when it has a proposal.

Apparently this code-branch was not tested 😢. This PR fixes an attribute-error when attempting to set the description of an agenda-item that is attached to a proposal.

Fixes #6090.

- [x] Changelog-Eintrag vorhanden/nötig?
