### PR TITLE
Register virtual host monster on site setup for testserver

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2019.4.2 (unreleased)
 ---------------------
 
+- Register virtual host monster on site setup for testserver [bierik]
 - Fix setting agenda item description. [deiferni]
 - Fix styling bug in tabbedview after showing bumblebee tooltip. [njohner]
 - Only show workspace notification tab when feature is activated. [njohner]

--- a/opengever/core/testserver.py
+++ b/opengever/core/testserver.py
@@ -51,6 +51,16 @@ class TestserverLayer(OpengeverFixture):
         # Clear solr from potential artefacts of the previous run.
         SolrReplicationAPIClient.get_instance().clear()
 
+        # Install a Virtual Host Monster
+        if "virtual_hosting" not in app.objectIds():
+            # If ZopeLite was imported, we have no default virtual
+            # host monster
+            from Products.SiteAccess.VirtualHostMonster import (
+                manage_addVirtualHostMonster,
+            )
+
+            manage_addVirtualHostMonster(app, "virtual_hosting")
+
     def setUpPloneSite(self, portal):
         session.current_session = session.BuilderSession()
         session.current_session.session = create_session()


### PR DESCRIPTION
This is needed so that virtual hosting URLs work with the testserver, which is required for the upcoming `gever-ui` E2E tests. 

## Checkliste

- [x] Changelog-Eintrag vorhanden/nötig?
