### PR TITLE
Fix automatic start of additionally added sequential tasks.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 ---------------------
 
 - Fix setting agenda item description. [deiferni]
+- Fix automatic start of additionally added sequential tasks. [phgross]
 - Fix styling bug in tabbedview after showing bumblebee tooltip. [njohner]
 - Only show workspace notification tab when feature is activated. [njohner]
 - Fix response text for responsible changes to the same user. [phgross]

--- a/opengever/task/task.py
+++ b/opengever/task/task.py
@@ -58,6 +58,7 @@ from zope.app.intid.interfaces import IIntIds
 from zope.component import getMultiAdapter
 from zope.component import getUtility
 from zope.i18n import translate
+from zope.interface import alsoProvides
 from zope.interface import implements
 from zope.interface import Invalid
 from zope.interface import invariant
@@ -600,6 +601,7 @@ class Task(Container, TaskReminderSupport):
             return annotations.get(TASK_PROCESS_ORDER_KEY)
 
     def add_task_to_tasktemplate_order(self, position, task):
+        alsoProvides(task, IFromSequentialTasktemplate)
         subtasks = self.get_tasktemplate_order()
         subtasks.insert(position, Oguid.for_object(task))
 

--- a/opengever/task/tests/test_sequential_task_process.py
+++ b/opengever/task/tests/test_sequential_task_process.py
@@ -245,6 +245,25 @@ class TestAddingAdditionalTaskToSequentialProcess(IntegrationTestCase):
             [oguid.resolve_object().title for oguid in oguids])
 
     @browsing
+    def test_added_task_is_part_of_sequence(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        with self.observe_children(self.sequential_task) as subtasks:
+            browser.open(self.sequential_task,
+                         view='++add++opengever.task.task?position=1')
+            browser.fill({'Title': 'Subtask', 'Task Type': 'comment'})
+            form = browser.find_form_by_field('Responsible')
+            form.find_widget('Responsible').fill(self.secretariat_user)
+            browser.click_on('Save')
+
+        additional_task, = subtasks['added']
+        self.assertTrue(IFromSequentialTasktemplate.providedBy(additional_task))
+
+        self.assertEquals(
+            additional_task.get_sql_object(),
+            self.seq_subtask_1.get_sql_object().tasktemplate_successor)
+
+    @browsing
     def test_adds_task_to_the_end_if_no_position_is_given(self, browser):
         self.login(self.regular_user, browser=browser)
 


### PR DESCRIPTION
The current implementation has not added the IFromSequentialTasktemplate to additionally added sequential tasks, which lead to an incorrect tasktemplate_predecessor indexing. Which meant they weren't started automatically, when closing the previous task.

No need imho for an upgradestep, the problem in the production was solved by manually opening or skipping the task.

## Checkliste

_Zutreffendes soll angehakt stehengelassen werden._

- [ ] Wurde etwas an der `Aufgabe` angepasst? Funktioniert das auch mit einer `Weiterleitung`? Weiterleitungen kennen keinen Standardablauf.
- [x] Changelog-Eintrag vorhanden/nötig?

