### PR TITLE
Allow sharing view and action on workspaces

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 ---------------------
 
 - Make Period a proper plone content type. Migrate old SQL base periods. [deiferni]
+- Restrict available users in sharing on workspaces and workspace folders. [njohner]
 
 
 2019.4.2 (2019-11-29)

--- a/opengever/core/profiles/default/actions.xml
+++ b/opengever/core/profiles/default/actions.xml
@@ -666,7 +666,7 @@
       <property name="description" i18n:translate="" />
       <property name="url_expr">string:${object_url}/@@sharing</property>
       <property name="icon_expr" />
-      <property name="available_expr">python:not here.restrictedTraverse('@@plone_interface_info').provides('opengever.workspace.interfaces.IWorkspace')</property>
+      <property name="available_expr" />
       <property name="permissions">
         <element value="Sharing page: Delegate roles" />
       </property>

--- a/opengever/core/upgrades/20191128155237_allow_sharing_action_on_workspaces/actions.xml
+++ b/opengever/core/upgrades/20191128155237_allow_sharing_action_on_workspaces/actions.xml
@@ -1,0 +1,19 @@
+<object xmlns:i18n="http://xml.zope.org/namespaces/i18n" name="portal_actions" meta_type="Plone Actions Tool">
+
+  <object name="object_buttons" meta_type="CMF Action Category">
+
+    <object name="local_roles" meta_type="CMF Action" i18n:domain="plone">
+      <property name="title" i18n:translate="">Sharing</property>
+      <property name="description" i18n:translate="" />
+      <property name="url_expr">string:${object_url}/@@sharing</property>
+      <property name="icon_expr" />
+      <property name="available_expr" />
+      <property name="permissions">
+        <element value="Sharing page: Delegate roles" />
+      </property>
+      <property name="visible">True</property>
+    </object>
+
+  </object>
+
+</object>

--- a/opengever/core/upgrades/20191128155237_allow_sharing_action_on_workspaces/upgrade.py
+++ b/opengever/core/upgrades/20191128155237_allow_sharing_action_on_workspaces/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AllowSharingActionOnWorkspaces(UpgradeStep):
+    """Allow sharing action on workspaces.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/sharing/browser/configure.zcml
+++ b/opengever/sharing/browser/configure.zcml
@@ -12,6 +12,15 @@
       />
 
   <browser:page
+      name="sharing"
+      for="opengever.workspace.interfaces.IWorkspace"
+      class=".sharing.WorkspaceSharingView"
+      permission="plone.DelegateRoles"
+      layer="opengever.sharing.interfaces.IOpengeverSharing"
+      allowed_attributes="saved"
+      />
+
+  <browser:page
       name="updateSharingInfo"
       for="*"
       class=".sharing.OpengeverSharingView"

--- a/opengever/sharing/browser/configure.zcml
+++ b/opengever/sharing/browser/configure.zcml
@@ -21,6 +21,15 @@
       />
 
   <browser:page
+      name="sharing"
+      for="opengever.workspace.interfaces.IWorkspaceFolder"
+      class=".sharing.WorkspaceSharingView"
+      permission="plone.DelegateRoles"
+      layer="opengever.sharing.interfaces.IOpengeverSharing"
+      allowed_attributes="saved"
+      />
+
+  <browser:page
       name="updateSharingInfo"
       for="*"
       class=".sharing.OpengeverSharingView"

--- a/opengever/sharing/tests/test_sharing.py
+++ b/opengever/sharing/tests/test_sharing.py
@@ -429,6 +429,17 @@ class TestWorkspaceSharing(IntegrationTestCase):
             [role['id'] for role in browser.json.get('available_roles')])
 
     @browsing
+    def test_available_roles_on_a_workspace_folder(self, browser):
+        self.login(self.administrator, browser=browser)
+
+        browser.open(self.workspace_folder, view='@sharing',
+                     method='GET', headers={'Accept': 'application/json'})
+
+        self.assertEqual(
+            [u'WorkspaceAdmin', u'WorkspaceMember', u'WorkspaceGuest'],
+            [role['id'] for role in browser.json.get('available_roles')])
+
+    @browsing
     def test_only_workspace_users_are_shown_for_workspace_admin_on_workspace(self, browser):
         self.login(self.workspace_admin, browser=browser)
 
@@ -473,3 +484,45 @@ class TestWorkspaceSharing(IntegrationTestCase):
              u'hans.peter', u'beatrice.schrodinger'],
             [entry['id'] for entry in browser.json.get('entries')])
 
+    @browsing
+    def test_only_workspace_users_are_shown_for_workspace_admin_on_workspace_folder(self, browser):
+        self.login(self.workspace_admin, browser=browser)
+
+        query = {"search": "nicole"}
+        browser.open(self.workspace_folder,
+                     view='@sharing?{}'.format(urlencode(query)),
+                     method='GET',
+                     headers={'Accept': 'application/json'})
+
+        self.assertItemsEqual(
+            [u'fridolin.hugentobler', u'hans.peter', u'beatrice.schrodinger'],
+            [entry['id'] for entry in browser.json.get('entries')])
+
+    @browsing
+    def test_only_workspace_users_are_shown_for_workspace_owner_on_workspace_folder(self, browser):
+        self.login(self.workspace_owner, browser=browser)
+
+        query = {"search": "nicole"}
+        browser.open(self.workspace_folder,
+                     view='@sharing?{}'.format(urlencode(query)),
+                     method='GET',
+                     headers={'Accept': 'application/json'})
+
+        self.assertItemsEqual(
+            [u'fridolin.hugentobler', u'hans.peter', u'beatrice.schrodinger'],
+            [entry['id'] for entry in browser.json.get('entries')])
+
+    @browsing
+    def test_all_users_are_shown_for_admins_on_workspace_folder(self, browser):
+        self.login(self.administrator, browser=browser)
+
+        query = {"search": "nicole"}
+        browser.open(self.workspace_folder,
+                     view='@sharing?{}'.format(urlencode(query)),
+                     method='GET',
+                     headers={'Accept': 'application/json'})
+
+        self.assertItemsEqual(
+            [u'nicole.kohler', u'fridolin.hugentobler',
+             u'hans.peter', u'beatrice.schrodinger'],
+            [entry['id'] for entry in browser.json.get('entries')])

--- a/opengever/sharing/tests/test_sharing.py
+++ b/opengever/sharing/tests/test_sharing.py
@@ -10,10 +10,11 @@ from opengever.base.role_assignments import TaskRoleAssignment
 from opengever.ogds.base.interfaces import IOGDSSyncConfiguration
 from opengever.testing import IntegrationTestCase
 from plone import api
+from urllib import urlencode
 import json
 
 
-class TestOpengeverSharingIntegration(IntegrationTestCase):
+class TestOpengeverSharing(IntegrationTestCase):
 
     @browsing
     def test_available_roles_on_a_dossier(self, browser):
@@ -400,3 +401,75 @@ class TestRoleAssignmentsGet(IntegrationTestCase):
         self.assertEquals(
             [],
             RoleAssignmentManager(self.empty_dossier).storage._storage())
+
+
+class TestWorkspaceSharing(IntegrationTestCase):
+
+    @browsing
+    def test_available_roles_on_a_workspace_root(self, browser):
+        # Only managers can delegate roles on the workspace root
+        self.login(self.manager, browser=browser)
+
+        browser.open(self.workspace_root, view='@sharing',
+                     method='GET', headers={'Accept': 'application/json'})
+
+        self.assertEqual(
+            [u'WorkspacesCreator', u'WorkspacesUser'],
+            [role['id'] for role in browser.json.get('available_roles')])
+
+    @browsing
+    def test_available_roles_on_a_workspace(self, browser):
+        self.login(self.administrator, browser=browser)
+
+        browser.open(self.workspace, view='@sharing',
+                     method='GET', headers={'Accept': 'application/json'})
+
+        self.assertEqual(
+            [u'WorkspaceAdmin', u'WorkspaceOwner', u'WorkspaceMember', u'WorkspaceGuest'],
+            [role['id'] for role in browser.json.get('available_roles')])
+
+    @browsing
+    def test_only_workspace_users_are_shown_for_workspace_admin_on_workspace(self, browser):
+        self.login(self.workspace_admin, browser=browser)
+
+        query = {"search": "nicole"}
+        browser.open(self.workspace,
+                     view='@sharing?{}'.format(urlencode(query)),
+                     method='GET',
+                     headers={'Accept': 'application/json'})
+
+        self.assertItemsEqual(
+            [u'fridolin.hugentobler', u'hans.peter',
+             u'beatrice.schrodinger', u'gunther.frohlich'],
+            [entry['id'] for entry in browser.json.get('entries')])
+
+    @browsing
+    def test_only_workspace_users_are_shown_for_workspace_owner_on_workspace(self, browser):
+        self.login(self.workspace_owner, browser=browser)
+
+        query = {"search": "nicole"}
+        browser.open(self.workspace,
+                     view='@sharing?{}'.format(urlencode(query)),
+                     method='GET',
+                     headers={'Accept': 'application/json'})
+
+        self.assertItemsEqual(
+            [u'fridolin.hugentobler', u'hans.peter',
+             u'beatrice.schrodinger', u'gunther.frohlich'],
+            [entry['id'] for entry in browser.json.get('entries')])
+
+    @browsing
+    def test_all_users_are_shown_for_admins_on_workspace(self, browser):
+        self.login(self.administrator, browser=browser)
+
+        query = {"search": "nicole"}
+        browser.open(self.workspace,
+                     view='@sharing?{}'.format(urlencode(query)),
+                     method='GET',
+                     headers={'Accept': 'application/json'})
+
+        self.assertItemsEqual(
+            [u'nicole.kohler', u'fridolin.hugentobler', u'gunther.frohlich',
+             u'hans.peter', u'beatrice.schrodinger'],
+            [entry['id'] for entry in browser.json.get('entries')])
+


### PR DESCRIPTION
For the new frontend we need the `@sharing` action and view to work on `workspace`s and `workspace_folder`s. In this PR we:
- Allow the sharing action on workspaces.
- Restrict available users (for `GET`) on `workspace`s and `workspace_folder`s to users with local roles in the `workspace`, except for admins and managers.

For https://github.com/4teamwork/opengever.core/issues/6041

## Checkliste
- [x] Changelog-Eintrag vorhanden/nötig?
