### PR TITLE
Catch oneoffixx api calls failures and show statusmessage instead.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 ---------------------
 
 - Register virtual host monster on site setup for testserver [bierik]
+- Catch oneoffixx api calls failures and show statusmessage instead. [phgross]
 - Fix setting agenda item description. [deiferni]
 - Fix automatic start of additionally added sequential tasks. [phgross]
 - Fix styling bug in tabbedview after showing bumblebee tooltip. [njohner]

--- a/opengever/oneoffixx/locales/de/LC_MESSAGES/opengever.oneoffixx.po
+++ b/opengever/oneoffixx/locales/de/LC_MESSAGES/opengever.oneoffixx.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-11-15 14:40+0000\n"
+"POT-Creation-Date: 2019-11-29 13:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -53,3 +53,8 @@ msgstr "Vorlagengruppe"
 #: ./opengever/oneoffixx/browser/form.py
 msgid "label_title"
 msgstr "Titel"
+
+#. Default: "Connection to OneOffixx failed."
+#: ./opengever/oneoffixx/browser/form.py
+msgid "msg_could_not_connect_to_oneoffixx"
+msgstr "Verbindung zu OneOffixx fehlgeschlagen."

--- a/opengever/oneoffixx/locales/fr/LC_MESSAGES/opengever.oneoffixx.po
+++ b/opengever/oneoffixx/locales/fr/LC_MESSAGES/opengever.oneoffixx.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-11-15 14:40+0000\n"
+"POT-Creation-Date: 2019-11-29 13:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -53,3 +53,8 @@ msgstr "Groupe de modèles"
 #: ./opengever/oneoffixx/browser/form.py
 msgid "label_title"
 msgstr "Titre"
+
+#. Default: "Connection to OneOffixx failed."
+#: ./opengever/oneoffixx/browser/form.py
+msgid "msg_could_not_connect_to_oneoffixx"
+msgstr "Erreur de connection à OneOffix."

--- a/opengever/oneoffixx/locales/opengever.oneoffixx.pot
+++ b/opengever/oneoffixx/locales/opengever.oneoffixx.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-11-15 14:40+0000\n"
+"POT-Creation-Date: 2019-11-29 13:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -55,4 +55,9 @@ msgstr ""
 #. Default: "Title"
 #: ./opengever/oneoffixx/browser/form.py
 msgid "label_title"
+msgstr ""
+
+#. Default: "Connection to OneOffixx failed."
+#: ./opengever/oneoffixx/browser/form.py
+msgid "msg_could_not_connect_to_oneoffixx"
 msgstr ""

--- a/opengever/oneoffixx/tests/test_oneoffixx.py
+++ b/opengever/oneoffixx/tests/test_oneoffixx.py
@@ -1,8 +1,8 @@
 from ftw.testbrowser import browsing
 from ftw.testbrowser.pages import factoriesmenu
+from ftw.testbrowser.pages.statusmessages import error_messages
 from opengever.oneoffixx.api_client import OneoffixxAPIClient
 from opengever.oneoffixx.exceptions import OneoffixxBackendException
-from opengever.oneoffixx.exceptions import OneoffixxConfigurationException
 from opengever.oneoffixx.interfaces import IOneoffixxSettings
 from opengever.oneoffixx.utils import whitelisted_template_types
 from opengever.testing import IntegrationTestCase
@@ -360,9 +360,10 @@ class TestCreateDocFromUnconfiguredOneoffixxTemplate(IntegrationTestCase):
         self.login(self.regular_user, browser)
         browser.open(self.dossier)
         browser.exception_bubbling = True
+        factoriesmenu.add('document_with_oneoffixx_template')
+
         # Do note this will not fail if you actually do have the config file!
-        with self.assertRaises(OneoffixxConfigurationException):
-            factoriesmenu.add('document_with_oneoffixx_template')
+        self.assertEqual(['Connection to OneOffixx failed.'], error_messages())
 
 
 class TestCreateDocFromUnconfiguredOneoffixxFakeSIDTemplate(IntegrationTestCase):
@@ -379,8 +380,9 @@ class TestCreateDocFromUnconfiguredOneoffixxFakeSIDTemplate(IntegrationTestCase)
         self.login(self.regular_user, browser)
         browser.open(self.dossier)
         browser.exception_bubbling = True
-        with self.assertRaises(OneoffixxConfigurationException):
-            factoriesmenu.add('document_with_oneoffixx_template')
+        factoriesmenu.add('document_with_oneoffixx_template')
+
+        self.assertEqual(['Connection to OneOffixx failed.'], error_messages())
 
 
 class TestCreateDocFromOneoffixxBackendFailuresTemplate(IntegrationTestCase):
@@ -440,8 +442,9 @@ class TestCreateDocFromOneoffixxBackendFailuresTemplate(IntegrationTestCase):
         self.login(self.regular_user, browser)
         browser.open(self.dossier)
         browser.exception_bubbling = True
-        with self.assertRaises(OneoffixxBackendException):
-            factoriesmenu.add('document_with_oneoffixx_template')
+
+        factoriesmenu.add('document_with_oneoffixx_template')
+        self.assertEqual(['Connection to OneOffixx failed.'], error_messages())
 
     @browsing
     def test_template_groups_bad_return(self, browser):
@@ -458,8 +461,10 @@ class TestCreateDocFromOneoffixxBackendFailuresTemplate(IntegrationTestCase):
         self.login(self.regular_user, browser)
         browser.open(self.dossier)
         browser.exception_bubbling = True
-        with self.assertRaises(OneoffixxBackendException):
-            factoriesmenu.add('document_with_oneoffixx_template')
+
+        factoriesmenu.add('document_with_oneoffixx_template')
+
+        self.assertEqual(['Connection to OneOffixx failed.'], error_messages())
 
 
 class TestOneOffixxTemplateFeature(IntegrationTestCase):


### PR DESCRIPTION
![Bildschirmfoto 2019-11-29 um 14 07 22](https://user-images.githubusercontent.com/485755/69871567-6b7cac00-12b3-11ea-8cba-e7c25507bd31.png)

Do not completely hide the exceptions, it still logs the error to sentry.

See https://basecamp.com/2768704/projects/12554551/todos/404990430#comment_735363271 

## Checkliste

- [x] Gibt es neue Übersetzungen?
  - [x] Sind alle msg-Strings in Übersetzungen Unicode?
  - [x] Wird die richtige i18n-domain verwendet (Copy-Paste Fehler sind hier häufig)?
- [x] Changelog-Eintrag vorhanden/nötig?
