### PR TITLE
Correct styling bug fix in tabbedview after showing bumblebee tooltip.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 
 - Make Period a proper plone content type. Migrate old SQL base periods. [deiferni]
 - Restrict available users in sharing on workspaces and workspace folders. [njohner]
+- Correct styling bug fix in tabbedview after showing bumblebee tooltip. [njohner]
 
 
 2019.4.2 (2019-11-29)

--- a/opengever/base/browser/resources/tooltip.js
+++ b/opengever/base/browser/resources/tooltip.js
@@ -73,8 +73,8 @@
     $(target).closest('.x-grid3-row').siblings().removeClass('bumblebee-tooltip-active');
   }
 
-  function deactivateTableCell(target) {
-    $(target).closest('.x-grid3-row').removeClass('bumblebee-tooltip-active');
+  function deactivateActiveTableCells() {
+    $('body .bumblebee-tooltip-active').removeClass('bumblebee-tooltip-active');
   }
 
   function showBackdrop(event) {
@@ -88,9 +88,8 @@
   function hideBackdrop(event) {
     tooltipHideTimer = setTimeout(function() {
       $('body').removeClass('bumblebee-tooltip-open');
+      deactivateActiveTableCells();
     }, settings.hide.delay / 2);
-    var target = event.originalEvent.target;
-    deactivateTableCell(target);
   }
 
   function closeTooltips(event, api) {


### PR DESCRIPTION
https://github.com/4teamwork/opengever.core/pull/6092 only partially fixed the issue, but the fix did not work when leaving from the tooltip overlay instead of from the document. In that case the target from the event is not the row in the table, but the tooltip itself, and the selector to remove the `bumblebee-tooltip-active` class did not work.

There is no good way to find the correct row in the table starting from the tooltip, so I had to resort selecting directly form the `body`

For https://github.com/4teamwork/opengever.core/issues/5898

## Checkliste
- [x] Changelog-Eintrag vorhanden/nötig?
