### PR TITLE
Add custom IWarmupPerformer to also warm up GEVER's trashed index.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,7 @@ Changelog
 2019.5.0rc2 (unreleased)
 ------------------------
 
-- Nothing changed yet.
+- Add custom IWarmupPerformer to also warm up GEVER's trashed index. [lgraf]
 
 
 2019.5.0rc1 (2019-12-03)

--- a/opengever/base/overrides.zcml
+++ b/opengever/base/overrides.zcml
@@ -2,6 +2,7 @@
     xmlns="http://namespaces.zope.org/zope"
     xmlns:browser="http://namespaces.zope.org/browser"
     xmlns:i18n="http://namespaces.zope.org/i18n"
+    xmlns:zcml="http://namespaces.zope.org/zcml"
     i18n_domain="opengever.base">
 
   <browser:menu
@@ -57,5 +58,13 @@
       factory=".contentlisting.OpengeverRealContentListingObject"
       for="Products.CMFCore.interfaces.IContentish"
       />
+
+  <!-- We need to use overrides for customizing this adapter (instead of our
+  browser layer) because the @@warmup view gets called on the Zope App root
+  (instead of the Plone site) and we therefore don't have our
+  IOpengeverBaseLayer browser layer on the request -->
+  <configure zcml:condition="installed ftw.monitor">
+    <adapter factory=".warmup.GEVERWarmupPerformer" />
+  </configure>
 
 </configure>

--- a/opengever/base/warmup.py
+++ b/opengever/base/warmup.py
@@ -1,0 +1,15 @@
+from ftw.monitor.interfaces import IWarmupPerformer
+from ftw.monitor.warmup import DefaultWarmupPerformer
+from Products.CMFPlone.interfaces import IPloneSiteRoot
+from zope.component import adapter
+from zope.interface import implementer
+from zope.publisher.interfaces.browser import IBrowserRequest
+
+
+@implementer(IWarmupPerformer)
+@adapter(IPloneSiteRoot, IBrowserRequest)
+class GEVERWarmupPerformer(DefaultWarmupPerformer):
+    """Extends DefaultWarmupPerformer from ftw.monitor with 'trashed' index.
+    """
+
+    WARMUP_INDEXES = DefaultWarmupPerformer.WARMUP_INDEXES + ['trashed']


### PR DESCRIPTION
Add custom `IWarmupPerformer` to also warm up GEVER's `trashed` index.

This extends the standard indexes (`allowedRolesAndUsers` and `object_provides`) that are [warmed up by `ftw.monitor`](https://github.com/4teamwork/ftw.monitor/blob/master/ftw/monitor/warmup.py#L50-L53) with our GEVER-specific `trashed` index.

With this we will warm up the same indexes that were determined as a good trade-off between effectiveness and warmup-time and [got used in the monitor prototype](https://github.com/4teamwork/opengever.maintenance/blob/24908aae0b3784b25dde06b95bbbf488452ebedd/opengever/maintenance/browser/warmup.py#L27-L31).


## Checkliste

- [x] Changelog-Eintrag vorhanden/nötig?
