### PR TITLE
Make sure that owner has correct type in webactions.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -8,6 +8,7 @@ Changelog
 - Refactor solrsearch and listing endpoints. [njohner]
 - Add tests for solrsearch and listing endpoints. [njohner]
 - Split invitations from participations endpoints. [njohner]
+- Make and enforce unicode for webaction owner and groups. [njohner]
 - Implement testing against a real Solr. [lgraf]
 - Sharing on workspace folders should always show workspace users. [njohner]
 

--- a/opengever/api/tests/test_webactions.py
+++ b/opengever/api/tests/test_webactions.py
@@ -28,7 +28,7 @@ class TestWebActionsPost(IntegrationTestCase):
             'order': 0,
             'scope': 'global',
             'types': ['opengever.dossier.businesscasedossier'],
-            'groups': ['some-group'],
+            'groups': [u'some-group'],
             'permissions': ['add:opengever.document.document'],
             'comment': u'Lorem Ipsum',
             'unique_name': u'open-in-external-app-title-action',

--- a/opengever/core/upgrades/20191211081852_make_webaction_owners_and_groups_unicode/upgrade.py
+++ b/opengever/core/upgrades/20191211081852_make_webaction_owners_and_groups_unicode/upgrade.py
@@ -1,0 +1,18 @@
+from ftw.upgrade import UpgradeStep
+from opengever.webactions.storage import get_storage
+from Products.CMFPlone.utils import safe_unicode
+
+
+class MakeWebactionOwnersAndGroupsUnicode(UpgradeStep):
+    """Make webaction owners and groups unicode.
+    """
+
+    deferrable = True
+
+    def __call__(self):
+        storage = get_storage()
+        for action in storage._actions.values():
+            action['owner'] = safe_unicode(action['owner'])
+            if 'groups' in action:
+                action['groups'] = map(safe_unicode,
+                                       action['groups'])

--- a/opengever/testing/builders/webactions.py
+++ b/opengever/testing/builders/webactions.py
@@ -1,5 +1,6 @@
 from ftw.builder import builder_registry
 from opengever.webactions.interfaces import IWebActionsStorage
+from Products.CMFPlone.utils import safe_unicode
 from zope.component import getMultiAdapter
 from zope.component.hooks import getSite
 from zope.globalrequest import getRequest
@@ -30,7 +31,7 @@ class WebActionBuilder(object):
         return self
 
     def owned_by(self, owner):
-        self.owner = owner
+        self.owner = safe_unicode(owner)
         return self
 
     def create(self, **kwargs):

--- a/opengever/webactions/schema.py
+++ b/opengever/webactions/schema.py
@@ -125,7 +125,7 @@ class IWebActionSchema(Interface):
         description=u'List of groups this action is to be shown for. The '
                     u'action is only shown when the user is in at least one '
                     u'of these groups, as determined by querying the OGDS.',
-        value_type=ASCIILine(),
+        value_type=TextLine(),
         required=False)
 
     permissions = List(
@@ -187,7 +187,7 @@ class IWebActionMetadataSchema(Interface):
         description=u'Time when this action was last modified.',
         required=True)
 
-    owner = ASCIILine(
+    owner = TextLine(
         title=u'Owner',
         description=u'User that created the action.',
         required=True)

--- a/opengever/webactions/storage.py
+++ b/opengever/webactions/storage.py
@@ -11,6 +11,7 @@ from opengever.webactions.schema import IWebActionSchema
 from persistent.mapping import PersistentMapping
 from plone import api
 from Products.CMFPlone.interfaces import IPloneSiteRoot
+from Products.CMFPlone.utils import safe_unicode
 from zope.annotation import IAnnotations
 from zope.component import adapter
 from zope.component import getMultiAdapter
@@ -105,9 +106,10 @@ class WebActionsStorage(object):
         new_action['action_id'] = action_id
         new_action['created'] = now
         new_action['modified'] = now
-        # Some userids are unicode so we need to make sure to cast them to the
-        # correct type
-        new_action['owner'] = str(userid) if userid else 'Anonymous'
+
+        # Some userids are unicode others are strings, so we need to make sure
+        # to cast them to the correct type
+        new_action['owner'] = safe_unicode(userid) if userid else u'Anonymous'
 
         # To be sure to only store valid webactions, we also validate
         # with the automatically added data

--- a/opengever/webactions/storage.py
+++ b/opengever/webactions/storage.py
@@ -105,7 +105,9 @@ class WebActionsStorage(object):
         new_action['action_id'] = action_id
         new_action['created'] = now
         new_action['modified'] = now
-        new_action['owner'] = userid if userid else 'Anonymous'
+        # Some userids are unicode so we need to make sure to cast them to the
+        # correct type
+        new_action['owner'] = str(userid) if userid else 'Anonymous'
 
         # To be sure to only store valid webactions, we also validate
         # with the automatically added data

--- a/opengever/webactions/storage.py
+++ b/opengever/webactions/storage.py
@@ -107,6 +107,10 @@ class WebActionsStorage(object):
         new_action['modified'] = now
         new_action['owner'] = userid if userid else 'Anonymous'
 
+        # To be sure to only store valid webactions, we also validate
+        # with the automatically added data
+        validate_schema(new_action, IPersistedWebActionSchema)
+
         self.index_action(new_action)
         return action_id
 

--- a/opengever/webactions/tests/test_webactions_provider.py
+++ b/opengever/webactions/tests/test_webactions_provider.py
@@ -171,9 +171,9 @@ class TestWebActionProvider(TestWebActionBase):
     def test_webaction_provider_respects_groups(self):
         self.login(self.regular_user)
         storage = get_storage()
-        storage.update(0, {"groups": ['fa_inbox_users']})
-        storage.update(1, {"groups": ['fa_inbox_users', 'committee_rpk_group']})
-        storage.update(2, {"groups": ['committee_rpk_group']})
+        storage.update(0, {"groups": [u'fa_inbox_users']})
+        storage.update(1, {"groups": [u'fa_inbox_users', u'committee_rpk_group']})
+        storage.update(2, {"groups": [u'committee_rpk_group']})
 
         provider = getMultiAdapter((self.dossier, self.request),
                                    IWebActionsProvider)

--- a/opengever/webactions/tests/test_webactions_storage.py
+++ b/opengever/webactions/tests/test_webactions_storage.py
@@ -89,7 +89,7 @@ class TestWebActionsStorageAdding(IntegrationTestCase):
             'order': 0,
             'scope': 'global',
             'types': ['opengever.dossier.businesscasedossier'],
-            'groups': ['some-group'],
+            'groups': [u'some-group'],
             'permissions': ['add:opengever.document.document'],
             'comment': u'Lorem Ipsum',
             'unique_name': u'open-in-external-app-title-action',


### PR DESCRIPTION
For some webactions, `owner` was set to a unicode string, which then does not pass validation when patching the webaction. We were not validating that field when adding a webaction as it is generated in the backend and not user input. I now:
- Added validation of all the fields when creating a new webaction
- Cast the `userid` to correct type before setting it to the `owner` field of the webaction
- Switch `owner` and `groups` field to unicode
- Update existing webactions to make sure correct type is being used

I switch to unicode as some userids and groups can be unicode

For https://github.com/4teamwork/opengever.core/issues/6011

## Checkliste
- [x] Sind UpgradeSteps `deferrable`, oder können gewisse Schritte des Upgrades konditional ausgeführt werden?
- [x] Changelog-Eintrag vorhanden/nötig?
