### PR TITLE
Add upgrade to drop old-style workspace invitations.

### DIFF
--- a/opengever/core/upgrades/20191216161532_remove_old_workspace_invitations/upgrade.py
+++ b/opengever/core/upgrades/20191216161532_remove_old_workspace_invitations/upgrade.py
@@ -1,0 +1,17 @@
+from ftw.upgrade import UpgradeStep
+from plone import api
+from zope.annotation.interfaces import IAnnotations
+
+
+ANNOTATIONS_DATA_KEY = 'opengever.workspace : invitations'
+
+
+class RemoveOldWorkspaceInvitations(UpgradeStep):
+    """Remove old workspace invitations.
+    """
+
+    def __call__(self):
+        annotations = IAnnotations(api.portal.get())
+
+        if ANNOTATIONS_DATA_KEY in annotations:
+            del annotations[ANNOTATIONS_DATA_KEY]


### PR DESCRIPTION
Part of https://github.com/4teamwork/opengever.core/issues/5911. We changed the data-format of invitations. Older invitations are no longer valid. Thus we delete them.

Should be merged with https://github.com/4teamwork/opengever.core/pull/6123. Didn't add a CL as it is already covered there and part of the same set of changes.