### PR TITLE
Update link to DoD from GEVER to github wiki.

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,7 +9,7 @@ _Screenshot: erwünscht, sollen aber immer nur unterstützend eingesetzt werden.
 
 _Link zum Issue: `closes` oder `fixes` keyword verwenden._
 
-Definition of Done: https://gever.4teamwork.ch/ordnungssystem/3/2/2/allgemeines/dossier-3644/document-30943
+Definition of Done: https://github.com/4teamwork/opengever.core/wiki/Definition-of-Done
 
 
 ## Checkliste


### PR DESCRIPTION
We've decide the DoD shall be moved. It is now at https://github.com/4teamwork/opengever.core/wiki/Definition-of-Done and the link in the PR description should be updated accordingly.