### PR TITLE
Enable the solr flag in the policytemplate.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -23,6 +23,7 @@ Changelog
 - Update invitation and participation GET json response format. [deiferni]
 - Fix to reassign a task to a new inbox group. [elioschmutz]
 - Add missing french translation for example repository root. [elioschmutz]
+- Enable the solr flag in the policytempalte. [phgross]
 - Always use API for OfficeConnector. [njohner]
 - Refactor solrsearch and listing endpoints. [njohner]
 - Add tests for solrsearch and listing endpoints. [njohner]

--- a/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/profiles/default/registry.xml.bob
+++ b/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/profiles/default/registry.xml.bob
@@ -125,4 +125,8 @@
     <value>True</value>
   </record>
 
+  <records interface="opengever.base.interfaces.ISearchSettings">
+    <value key="use_solr">True</value>
+  </records>
+
 </registry>


### PR DESCRIPTION
We enable solr for every new deployment, so it makes sense to configure this default. 

## Checkliste

_Zutreffendes soll angehakt stehengelassen werden._
- [x] Changelog-Eintrag vorhanden/nötig?
