### PR TITLE
Fix to reassign a task to a new inbox group.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2019.5.1 (unreleased)
 ---------------------
 
+- Fix to reassign a task to a new inbox group. [elioschmutz]
 - Always use API for OfficeConnector. [njohner]
 - Refactor solrsearch and listing endpoints. [njohner]
 - Add tests for solrsearch and listing endpoints. [njohner]

--- a/opengever/task/tests/test_assign.py
+++ b/opengever/task/tests/test_assign.py
@@ -140,6 +140,21 @@ class TestAssignTask(IntegrationTestCase):
         self.assertEquals('team:1', self.task.responsible)
 
     @browsing
+    def test_reassign_task_to_a_inbox_group_is_possible(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        self.set_workflow_state('task-state-open', self.task)
+        odgs = self.add_additional_admin_and_org_unit()[1]
+        inbox_group_name = u'inbox:gdgs'
+
+        self.assign_task(inbox_group_name, u'Please make that for me.')
+
+        self.assertEquals(['Task successfully reassigned.'], info_messages())
+
+        self.assertEquals(odgs.id(), self.task.responsible_client)
+        self.assertEquals(inbox_group_name, self.task.responsible)
+
+    @browsing
     def test_reassign_task_in_progress_state_to_a_team_isnt_possible(self, browser):
         self.login(self.regular_user, browser=browser)
 

--- a/opengever/task/transition.py
+++ b/opengever/task/transition.py
@@ -80,7 +80,7 @@ class INewResponsibleSchema(Schema):
         title=_(u"label_responsible", default=u"Responsible"),
         description=_(u"help_responsible", default=""),
         source=AllUsersInboxesAndTeamsSourceBinder(
-            only_current_inbox=True,
+            only_current_inbox=False,
             only_current_orgunit=True,
             include_teams=True),
         required=True)


### PR DESCRIPTION
Issuer: https://github.com/4teamwork/opengever.sg/issues/372

This PR fixes an issue where it was not possible to reassign a task to a new inbox group. It was only possible through the edit or add form.

Before:
![screen1](https://user-images.githubusercontent.com/557005/71250908-28957d80-2321-11ea-95d8-5aa22b4aeeef.gif)

After:
![screen2](https://user-images.githubusercontent.com/557005/71250911-2a5f4100-2321-11ea-89c8-de8d2cf659e4.gif)

## Checkliste
- [x] Changelog-Eintrag vorhanden/nötig?
