### PR TITLE
Adapt response format for invitations and participations for new UI.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 ---------------------
 
 - Allow invitations to external users through E-mails. [njohner]
+- Update invitation and participation GET json response format. [deiferni]
 - Fix to reassign a task to a new inbox group. [elioschmutz]
 - Always use API for OfficeConnector. [njohner]
 - Refactor solrsearch and listing endpoints. [njohner]

--- a/opengever/api/invitations.py
+++ b/opengever/api/invitations.py
@@ -1,4 +1,3 @@
-from opengever.api.participations import ParticipationsGet
 from opengever.api.participations import ParticipationTraverseService
 from opengever.api.validation import get_validation_errors
 from opengever.workspace.invitation import IWorkspaceInvitationSchema
@@ -20,14 +19,19 @@ from zope.component import getUtility
 from zope.interface import alsoProvides
 
 
-class InvitationsGet(ParticipationsGet):
+class InvitationsGet(Service):
     """API Endpoint which returns a list of all invitations for the current
     workspace.
 
     GET workspace/@invitations HTTP/1.1
     """
 
-    def _items(self):
+    def reply(self):
+        result = {}
+        result['items'] = self.get_response_items()
+        return result
+
+    def get_response_items(self):
         manager = ManageParticipants(self.context, self.request)
         return manager.get_pending_invitations()
 
@@ -169,5 +173,4 @@ class InvitationsPost(ParticipationTraverseService):
         self.request.response.setStatus(201)
         self.request.response.setHeader('Location', self.context.absolute_url())
         invitation = storage.get_invitation(iid)
-        return self.prepare_response_item(invitation_to_item(
-            invitation, self.context))
+        return invitation_to_item(invitation, self.context)

--- a/opengever/api/participations.py
+++ b/opengever/api/participations.py
@@ -9,6 +9,7 @@ from zExceptions import BadRequest
 from zExceptions import NotFound
 from zope.interface import implements
 from zope.publisher.interfaces import IPublishTraverse
+from plone import api
 
 
 class ParticipationTraverseService(Service):
@@ -51,6 +52,24 @@ class ParticipationsGet(ParticipationTraverseService):
 
     GET workspace/@participations HTTP/1.1
     """
+
+    def prepare_response_item(self, participant):
+        userid = participant.get('token')
+        role = PARTICIPATION_ROLES.get(participant.get('roles')[0])
+        member = api.user.get(userid=userid)
+        return {
+            '@id': '{}/@participations/{}'.format(
+                self.context.absolute_url(), userid),
+            '@type': 'virtual.participations.user',
+            'participant_fullname': participant.get('name'),
+            'is_editable': participant.get('can_manage'),
+            'role': {
+                'token': role.id,
+                'title': role.translated_title(self.request),
+            },
+            'token': userid,
+            'participant_email': member.getProperty('email'),
+        }
 
     def reply(self):
         token = self.read_params()

--- a/opengever/api/tests/test_invitation.py
+++ b/opengever/api/tests/test_invitation.py
@@ -15,6 +15,8 @@ import json
 
 class TestInvitationsPost(IntegrationTestCase):
 
+    maxDiff = None
+
     @browsing
     def test_adding_new_invitation(self, browser):
         self.login(self.workspace_admin, browser=browser)
@@ -36,12 +38,11 @@ class TestInvitationsPost(IntegrationTestCase):
                 u'@id': u'http://nohost/plone/workspaces/workspace-1/@invitations/{}'.format(iid),
                 u'@type': u'virtual.participations.invitation',
                 u'inviter_fullname': u'Hugentobler Fridolin (fridolin.hugentobler)',
-                u'is_editable': True,
-                u'participant_fullname': u'B\xe4rfuss K\xe4thi (kathi.barfuss)',
-                u'participation_type': u'invitation',
-                u'readable_participation_type': u'Invitation',
-                u'readable_role': u'Guest',
-                u'role': WORKSPCAE_GUEST.id,
+                u'recipient_email': u'kathi.barfuss@gever.local',
+                u'role': {
+                    'token': 'WorkspaceGuest',
+                    'title': 'Guest',
+                },
                 u'token': iid,
             },
             item)

--- a/opengever/api/tests/test_participation.py
+++ b/opengever/api/tests/test_participation.py
@@ -386,36 +386,6 @@ class TestParticipationPatch(IntegrationTestCase):
                 )
 
     @browsing
-    def test_modify_role_of_invitation(self, browser):
-        self.login(self.workspace_admin, browser=browser)
-
-        storage = getUtility(IInvitationStorage)
-        iid = storage.add_invitation(
-            self.workspace, self.regular_user.getProperty('email'),
-            self.workspace_admin.getId(), 'WorkspaceGuest')
-
-        data = json.dumps(json_compatible({
-            'role': {'token': 'WorkspaceAdmin'}
-        }))
-
-        browser.open(
-            self.workspace.absolute_url() + '/@invitations/{}'.format(iid),
-            method='PATCH',
-            data=data,
-            headers=http_headers(),
-            )
-
-        browser.open(
-            self.workspace.absolute_url() + '/@invitations',
-            method='GET',
-            headers=http_headers(),
-        )
-
-        self.assertEquals(
-            'WorkspaceAdmin',
-            get_entry_by_token(browser.json.get('items'), iid).get('role'))
-
-    @browsing
     def test_do_not_allow_modifying_the_WorkspaceOwnerRole(self, browser):
         self.login(self.workspace_admin, browser=browser)
 


### PR DESCRIPTION
With this PR we adapt the response format used in the `@invitations` and `@participations` endpoint for the new UI. Some tests which can no longer work are removed. Functionality that can be removed is double checked with issues attached to the epic https://github.com/4teamwork/opengever.core/issues/6141.

Closes https://github.com/4teamwork/opengever.core/issues/6168.

- [x] Changelog-Eintrag vorhanden/nötig?
- [ ] Aktualisierung Dokumentation vorhanden/nötig? _yes, but we will do that separately_
