### PR TITLE
Add action to add invitations to workspaces.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2019.5.1 (unreleased)
 ---------------------
 
+- Add action to create new invitations to workspaces. [deiferni]
 - Return creator of workspace in GET, make sure he is a WorkspaceAdministrator upon workspace creation. Get rid of WorkspaceOwner role. [deiferni]
 - Allow invitations to external users through E-mails. [njohner]
 - Update invitation and participation GET json response format. [deiferni]

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -414,14 +414,6 @@
       />
 
   <plone:service
-      method="PATCH"
-      name="@invitations"
-      for="opengever.workspace.interfaces.IWorkspace"
-      factory=".invitations.InvitationsPatch"
-      permission="plone.DelegateWorkspaceAdminRole"
-      />
-
-  <plone:service
       method="GET"
       name="@my-workspace-invitations"
       for="*"

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -367,26 +367,10 @@
 
   <plone:service
       method="GET"
-      name="@participations"
-      for="opengever.workspace.interfaces.IWorkspace"
-      factory=".participations.ParticipationsGet"
-      permission="zope2.View"
-      />
-
-  <plone:service
-      method="GET"
       name="@invitations"
       for="opengever.workspace.interfaces.IWorkspace"
       factory=".invitations.InvitationsGet"
       permission="zope2.View"
-      />
-
-  <plone:service
-      method="DELETE"
-      name="@participations"
-      for="opengever.workspace.interfaces.IWorkspace"
-      factory=".participations.ParticipationsDelete"
-      permission="plone.DelegateWorkspaceAdminRole"
       />
 
   <plone:service
@@ -402,6 +386,22 @@
       name="@invitations"
       for="opengever.workspace.interfaces.IWorkspace"
       factory=".invitations.InvitationsPost"
+      permission="plone.DelegateWorkspaceAdminRole"
+      />
+
+  <plone:service
+      method="GET"
+      name="@participations"
+      for="opengever.workspace.interfaces.IWorkspace"
+      factory=".participations.ParticipationsGet"
+      permission="zope2.View"
+      />
+
+  <plone:service
+      method="DELETE"
+      name="@participations"
+      for="opengever.workspace.interfaces.IWorkspace"
+      factory=".participations.ParticipationsDelete"
       permission="plone.DelegateWorkspaceAdminRole"
       />
 

--- a/opengever/api/invitations.py
+++ b/opengever/api/invitations.py
@@ -125,30 +125,6 @@ class InvitationsDelete(ParticipationTraverseService):
         return self.params[0]
 
 
-class InvitationsPatch(ParticipationTraverseService):
-
-    def reply(self):
-        token = self.read_params()
-        data = self.validate_data(json_body(self.request))
-
-        manager = ManageParticipants(self.context, self.request)
-        manager._modify(token, data.get('role').get('token'), 'invitation')
-        return None
-
-    def read_params(self):
-        if len(self.params) != 1:
-            raise BadRequest(
-                "Must supply token ID as URL path parameters.")
-
-        return self.params[0]
-
-    def validate_data(self, data):
-        if not data.get('role'):
-            raise BadRequest('Missing parameter role')
-
-        return data
-
-
 class InvitationsPost(ParticipationTraverseService):
 
     def reply(self):

--- a/opengever/api/tests/test_participation.py
+++ b/opengever/api/tests/test_participation.py
@@ -170,44 +170,6 @@ class TestParticipationGet(IntegrationTestCase):
 class TestParticipationDelete(IntegrationTestCase):
 
     @browsing
-    def test_delete_invitation(self, browser):
-        self.login(self.workspace_admin, browser=browser)
-        storage = getUtility(IInvitationStorage)
-        iid = storage.add_invitation(
-            self.workspace,
-            self.regular_user.getProperty('email'),
-            self.workspace_admin.getId(),
-            'WorkspaceGuest')
-
-        browser.open(
-            self.workspace.absolute_url() + '/@invitations',
-            method='GET',
-            headers=http_headers(),
-        )
-
-        self.assertIsNotNone(
-            get_entry_by_token(browser.json.get('items'), iid),
-            'Expect an invitation.')
-
-        browser.open(
-            self.workspace.absolute_url() + '/@invitations/{}'.format(iid),
-            method='DELETE',
-            headers=http_headers(),
-        )
-
-        self.assertEqual(204, browser.status_code)
-
-        browser.open(
-            self.workspace.absolute_url() + '/@invitations',
-            method='GET',
-            headers=http_headers(),
-        )
-
-        self.assertIsNone(
-            get_entry_by_token(browser.json.get('items'), iid),
-            'Expect no invitation anymore.')
-
-    @browsing
     def test_delete_local_role(self, browser):
         self.login(self.workspace_admin, browser=browser)
 

--- a/opengever/core/profiles/default/types/opengever.workspace.workspace.xml
+++ b/opengever/core/profiles/default/types/opengever.workspace.workspace.xml
@@ -73,4 +73,14 @@
     <permission value="Modify portal content" />
   </action>
 
+  <action
+      action_id="add_invitation"
+      visible="True"
+      title="Add invitation"
+      url_expr="string:${object_url}/@invitations"
+      condition_expr=""
+      category="object_buttons">
+    <permission value="Sharing page: Delegate WorkspaceAdmin role" />
+  </action>
+
 </object>

--- a/opengever/core/upgrades/20191230160531_add__add_invitation__action_to_workspace/types/opengever.workspace.workspace.xml
+++ b/opengever/core/upgrades/20191230160531_add__add_invitation__action_to_workspace/types/opengever.workspace.workspace.xml
@@ -1,0 +1,13 @@
+<object xmlns:i18n="http://xml.zope.org/namespaces/i18n" name="opengever.workspace.workspace" meta_type="Dexterity FTI" i18n:domain="opengever.core">
+
+  <action
+      action_id="add_invitation"
+      visible="True"
+      title="Add invitation"
+      url_expr="string:${object_url}/@invitations"
+      condition_expr=""
+      category="object_buttons">
+    <permission value="Sharing page: Delegate WorkspaceAdmin role" />
+  </action>
+
+</object>

--- a/opengever/core/upgrades/20191230160531_add__add_invitation__action_to_workspace/upgrade.py
+++ b/opengever/core/upgrades/20191230160531_add__add_invitation__action_to_workspace/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class Add_addInvitation_actionToWorkspace(UpgradeStep):
+    """Add 'add invitation' action to workspace.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/workspace/tests/test_workspace_workspace.py
+++ b/opengever/workspace/tests/test_workspace_workspace.py
@@ -161,6 +161,12 @@ class TestWorkspaceWorkspace(IntegrationTestCase):
 
 class TestWorkspaceWorkspaceAPI(IntegrationTestCase):
 
+    EXPECTED_ADD_INVITATION_ACTION = {
+        u'title': u'Add invitation',
+        u'id': u'add_invitation',
+        u'icon': u''
+    }
+
     @browsing
     def test_update(self, browser):
         self.login(self.workspace_owner, browser)
@@ -181,3 +187,21 @@ class TestWorkspaceWorkspaceAPI(IntegrationTestCase):
             browser.open(self.workspace, method='PATCH',
                          headers=self.api_headers,
                          data=json.dumps({'title': u'\xfcberarbeitungsphase'}))
+
+    @browsing
+    def test_workspace_admin_can_view_add_invitation_action(self, browser):
+        self.login(self.workspace_admin, browser)
+
+        browser.open(self.workspace, view='@actions', headers=self.api_headers)
+        actions = browser.json['object_buttons']
+
+        self.assertIn(self.EXPECTED_ADD_INVITATION_ACTION, actions)
+
+    @browsing
+    def test_workspace_member_cannot_see_add_invitation_action(self, browser):
+        self.login(self.workspace_member, browser)
+
+        browser.open(self.workspace, view='@actions', headers=self.api_headers)
+        actions = browser.json['object_buttons']
+
+        self.assertNotIn(self.EXPECTED_ADD_INVITATION_ACTION, actions)


### PR DESCRIPTION
~~based on `deif-6163-add-responsible-to-workspace` and https://github.com/4teamwork/opengever.core/pull/6177~~

This PR adds an action to add invitations to workspaces. We also drop `PATCH`-ing invitations as unwanted/incorrect invitations can be deleted and re-added.

Part of https://github.com/4teamwork/opengever.core/issues/6141, closes https://github.com/4teamwork/opengever.core/issues/6164.

## Checkliste

_Zutreffendes soll angehakt stehengelassen werden._

- [x] Profil angepasst? Sind UpgradeSteps vorhanden/nötig?:
- [x] Changelog-Eintrag vorhanden/nötig?
- [ ] Aktualisierung Dokumentation vorhanden/nötig? _With https://github.com/4teamwork/opengever.core/issues/6176_
