### PR TITLE
Add version pin for itsdangerous.

### DIFF
--- a/versions.cfg
+++ b/versions.cfg
@@ -120,6 +120,7 @@ inflection = 0.3.1
 ipaddress = 1.0.22
 iso8601 = 0.1.12
 isort = 4.3.4
+itsdangerous = 1.1.0
 jdcal = 1.4
 jsonschema = 2.6.0
 kombu = 3.0.29


### PR DESCRIPTION
Add version pin for the previously unpinned `itsdangerous`. This is a new dependency that was introduced in #6161.