### PR TITLE
Configure Solr replication handler

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2019.5.1 (unreleased)
 ---------------------
 
+- Configure Solr replication handler. [buchi]
 - Implement @role-inheritance serivce endpoint for workspace folders. [deiferni]
 - Include permissions.zcml of Products.CMFEditions. [lgraf]
 - Add action to create new invitations to workspaces. [deiferni]

--- a/solr-conf/solrconfig.xml
+++ b/solr-conf/solrconfig.xml
@@ -806,6 +806,18 @@
     </lst>
   </requestHandler>
 
+  <requestHandler name="/replication" class="solr.ReplicationHandler" >
+    <lst name="master">
+      <str name="replicateAfter">commit</str>
+      <str name="replicateAfter">optimize</str>
+   </lst>
+   <lst name="slave">
+      <str name="enable">${solr.replication.enable:false}</str>
+      <str name="masterUrl">${solr.replication.masterUrl:http://localhost:8983/solr/core/replication}</str>
+      <str name="pollInterval">${solr.replication.pollInterval:00:00:15}</str>
+   </lst>
+  </requestHandler>
+
   <!-- Search Components
 
        Search components are registered to SolrCore and used by


### PR DESCRIPTION
Allows to run Solr in a master/slave replication setup.

Replication is disabled by default. It can be enabled using the Solr Config API by setting the `solr.replication.masterUrl` and `solr.replication.enable` properties on the slave.

Example:
```
curl -X POST \
  -H 'Content-type:application/json' \
  -d '{"set-user-property": {"solr.replication.masterUrl": "http://solr-master:8983/solr/core1/replication"}}' \
 http://solr-slave:8983/api/cores/core1/config

curl -X POST \
  -H 'Content-type:application/json' \
  -d '{"set-user-property": {"solr.replication.enable": "true"}}' \
   http://solr-slave:8983/api/cores/core1/config
```
