### PR TITLE
Modify/delete correct role assignment in @participation endpoints.

### DIFF
--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -2011,15 +2011,15 @@ class OpengeverContentFixture(object):
             .within(self.workspace_root)
             ))
 
-        RoleAssignmentManager(self.workspace).reset([
-            InvitationRoleAssignment(
-                self.workspace_member.id, ['WorkspaceMember'], self.workspace),
-            InvitationRoleAssignment(
-                self.workspace_guest.id, ['WorkspaceGuest'], self.workspace)
-        ])
         self.set_roles(
             self.workspace, self.workspace_admin.getId(),
             ['WorkspaceAdmin'])
+        self.set_roles(
+            self.workspace, self.workspace_member.getId(),
+            ['WorkspaceMember'])
+        self.set_roles(
+            self.workspace, self.workspace_guest.getId(),
+            ['WorkspaceGuest'])
 
         self.workspace_folder = self.register('workspace_folder', create(
             Builder('workspace folder')

--- a/opengever/workspace/participation/browser/manage_participants.py
+++ b/opengever/workspace/participation/browser/manage_participants.py
@@ -1,4 +1,4 @@
-from opengever.base.role_assignments import ASSIGNMENT_VIA_INVITATION
+from opengever.base.role_assignments import ASSIGNMENT_VIA_SHARING
 from opengever.base.role_assignments import InvitationRoleAssignment
 from opengever.base.role_assignments import RoleAssignmentManager
 from opengever.ogds.base.sources import PotentialWorkspaceMembersSource
@@ -109,7 +109,7 @@ class ManageParticipants(BrowserView):
 
         elif type_ == 'user' and can_manage_member(self.context, api.user.get(userid=token)):
             RoleAssignmentManager(self.context).clear_by_cause_and_principal(
-                ASSIGNMENT_VIA_INVITATION, token)
+                ASSIGNMENT_VIA_SHARING, token)
             # Avoid circular imports
             from opengever.workspace.activities import WorkspaceWatcherManager
             manager = WorkspaceWatcherManager(self.context)

--- a/opengever/workspace/participation/browser/manage_participants.py
+++ b/opengever/workspace/participation/browser/manage_participants.py
@@ -1,5 +1,5 @@
 from opengever.base.role_assignments import ASSIGNMENT_VIA_SHARING
-from opengever.base.role_assignments import InvitationRoleAssignment
+from opengever.base.role_assignments import SharingRoleAssignment
 from opengever.base.role_assignments import RoleAssignmentManager
 from opengever.ogds.base.sources import PotentialWorkspaceMembersSource
 from opengever.workspace.participation import can_manage_member
@@ -142,7 +142,7 @@ class ManageParticipants(BrowserView):
             user_roles = api.user.get_roles(username=token, obj=self.context,
                                             inherit=False)
             if user_roles:
-                assignment = InvitationRoleAssignment(token, [role], self.context)
+                assignment = SharingRoleAssignment(token, [role], self.context)
                 RoleAssignmentManager(self.context).add_or_update_assignment(assignment)
 
                 self.context.setModificationDate()

--- a/opengever/workspace/participation/browser/my_invitations.py
+++ b/opengever/workspace/participation/browser/my_invitations.py
@@ -1,7 +1,7 @@
 from logging import getLogger
 from opengever.base.casauth import get_gever_portal_url
 from opengever.base.model import create_session
-from opengever.base.role_assignments import InvitationRoleAssignment
+from opengever.base.role_assignments import SharingRoleAssignment
 from opengever.base.role_assignments import RoleAssignmentManager
 from opengever.base.security import elevated_privileges
 from opengever.ogds.base.actor import PloneUserActor
@@ -206,7 +206,7 @@ class MyWorkspaceInvitations(BrowserView):
             # recipient was set in the invitation, so we need to fetch it anew
             invitation = self.storage().get_invitation(invitation['iid'])
 
-            assignment = InvitationRoleAssignment(
+            assignment = SharingRoleAssignment(
                 invitation['recipient'], [invitation['role']], target)
             RoleAssignmentManager(target).add_or_update_assignment(assignment)
             self.storage().mark_invitation_as_accepted(invitation['iid'])

--- a/opengever/workspace/tests/test_my_invitations.py
+++ b/opengever/workspace/tests/test_my_invitations.py
@@ -143,7 +143,7 @@ class TestMyInvitationsView(IntegrationTestCase):
                 self.workspace).get_assignments_by_principal_id(self.regular_user.getId())
         self.assertEqual(1, len(assignments))
         assignment = assignments[0]
-        self.assertEqual(u'label_assignment_via_workspace_invitation',
+        self.assertEqual(u'label_assignment_via_sharing',
                          assignment.cause_title())
         self.assertEqual(['WorkspaceGuest'], assignment.roles)
         self.assertEqual(self.regular_user.getId(), assignment.principal)


### PR DESCRIPTION
~~based on `deif-6164-actions-for-invitations` and https://github.com/4teamwork/opengever.core/pull/6178~~

This PR adapts the kind of role-assignment that we modify in the @participations endpoint. We now expect a normal sharing role assignment. The invitation role assignment is no longer used at the moment. The role assignment can be modified by the users which makes it equivalent to a sharing role assignment. Also for workspace folders only sharing role assignments will be used. Having to manage both sharing and invitation role assignments seems complicated for now. We may re-activate the invitation role assignments eventually in the near future, so they are not dropped from the code-base yet. Doing so has been added to https://github.com/4teamwork/opengever.core/issues/6176 however.

Closes https://github.com/4teamwork/opengever.core/pull/6166.


