### PR TITLE
Include permissions.zcml of Products.CMFEditions:

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2019.5.1 (unreleased)
 ---------------------
 
+- Include permissions.zcml of Products.CMFEditions. [lgraf]
 - Add action to create new invitations to workspaces. [deiferni]
 - Return creator of workspace in GET, make sure he is a WorkspaceAdministrator upon workspace creation. Get rid of WorkspaceOwner role. [deiferni]
 - Allow invitations to external users through E-mails. [njohner]

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -7,6 +7,7 @@
 
   <include package="plone.rest" file="meta.zcml" />
   <include package="plone.restapi" file="permissions.zcml" />
+  <include package="Products.CMFEditions" file="permissions.zcml" />
   <include package="opengever.document" file="permissions.zcml" />
   <include package="opengever.trash" file="permissions.zcml" />
   <include package="opengever.webactions" file="permissions.zcml" />


### PR DESCRIPTION
Since we use the `CMFEditions.RevertToPreviousVersions` permission, we need to explicitly load the `permissions.zcml` in order to not be dependent on ZCML load order.

(This turned out to be an issue in ZG from the `2019.5-stable` branch, where the ZCML load order seems to turn out differently). 

## Checkliste

- [x] Changelog-Eintrag vorhanden/nötig?
