### PR TITLE
Workspace folder participation, implement @role_inheritance views.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2019.5.1 (unreleased)
 ---------------------
 
+- Implement @role-inheritance serivce endpoint for workspace folders. [deiferni]
 - Include permissions.zcml of Products.CMFEditions. [lgraf]
 - Add action to create new invitations to workspaces. [deiferni]
 - Return creator of workspace in GET, make sure he is a WorkspaceAdministrator upon workspace creation. Get rid of WorkspaceOwner role. [deiferni]

--- a/docs/public/dev-manual/api/workspace/index.rst
+++ b/docs/public/dev-manual/api/workspace/index.rst
@@ -11,6 +11,7 @@ Hier werden alle Teamraum-Schnittstellen beschrieben, welche von OneGov GEVER un
 
    workspace_invitations
    participation
+   role_inheritance
    todos
    todolists
 

--- a/docs/public/dev-manual/api/workspace/role_inheritance.rst
+++ b/docs/public/dev-manual/api/workspace/role_inheritance.rst
@@ -1,0 +1,87 @@
+.. _role_inheritance:
+
+Ordnerberechtigungen
+====================
+
+Teamraum-Ordner besitzen grundsätzlich die gleichen Rechte, wie der Teamraum selbst. Die Berechtigungen können jedoch explizit unterbrochen und neu gesetzt werden. Dazu wird der ``@role-inheritance`` Endpoint verwendet.
+
+Vererbungsstatus überprüfen:
+----------------------------
+Ein GET Request auf den ``@role-inheritance`` Endpoint gibt zurück, ob die Vererbung momentan unterbrochen ist oder nicht:
+
+**Beispiel-Request**:
+
+   .. sourcecode:: http
+
+       GET /workspace-1/folder-1/@role-inheritance HTTP/1.1
+       Accept: application/json
+
+**Beispiel-Response**:
+
+   .. sourcecode:: http
+
+    HTTP/1.1 200 OK
+    Content-Type: application/json
+
+    {
+      "blocked": false
+    }
+
+Vererbung unterbrechen:
+-----------------------
+Mit einem POST Request kann die Rollenvererbung unterbrochen werden.
+
+Wird eine Vererbung unterbrochen, werden initial alle bisherigen Berechtigungen für den Ordner kopiert.
+
+**Beispiel-Request**:
+
+   .. sourcecode:: http
+
+       POST /workspace-1/folder-1/@role-inheritance HTTP/1.1
+       Accept: application/json
+
+       {
+         "blocked": true,
+       }
+
+**Beispiel-Response**:
+
+
+   .. sourcecode:: http
+
+    HTTP/1.1 200 OK
+    Content-Type: application/json
+
+    {
+      "blocked": true
+    }
+
+
+Berechtigungen vererben:
+------------------------
+Sollen die Berechtigungen wieder vom übergeordneten Objekt vererbt werden, wird ein folgender POST Request verwendet.
+
+ACHTUNG: Lokale Berechtigungen werden dadurch komplett gelöscht und können nicht mehr wiederhergestellt werden.
+
+**Beispiel-Request**:
+
+   .. sourcecode:: http
+
+       POST /workspace-1/folder-1/@role-inheritance HTTP/1.1
+       Accept: application/json
+
+       {
+         "blocked": false,
+       }
+
+**Beispiel-Response**:
+
+
+   .. sourcecode:: http
+
+    HTTP/1.1 200 OK
+    Content-Type: application/json
+
+    {
+      "blocked": true
+    }

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -416,6 +416,14 @@
 
   <plone:service
       method="GET"
+      name="@role-inheritance"
+      for="opengever.workspace.interfaces.IWorkspaceFolder"
+      factory=".role_inheritance.RoleInheritanceGet"
+      permission="zope2.View"
+      />
+
+  <plone:service
+      method="GET"
       name="@my-workspace-invitations"
       for="*"
       factory=".invitations.MyInvitationsGet"

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -423,6 +423,14 @@
       />
 
   <plone:service
+      method="POST"
+      name="@role-inheritance"
+      for="opengever.workspace.interfaces.IWorkspaceFolder"
+      factory=".role_inheritance.RoleInheritancePost"
+      permission="plone.DelegateWorkspaceAdminRole"
+      />
+
+  <plone:service
       method="GET"
       name="@my-workspace-invitations"
       for="*"

--- a/opengever/api/role_inheritance.py
+++ b/opengever/api/role_inheritance.py
@@ -1,11 +1,55 @@
+from opengever.base.role_assignments import RoleAssignmentManager
+from plone.protect.interfaces import IDisableCSRFProtection
+from plone.restapi.deserializer import json_body
 from plone.restapi.services import Service
+from zExceptions import BadRequest
+from zope.interface import alsoProvides
 
 
-class RoleInheritanceGet(Service):
+class RoleInheritanceBase(Service):
 
-    def reply(self):
-        blocked = getattr(self.context, '__ac_local_roles_block__', False)
+    def _serialize_blocked(self):
         return {
-            'blocked': blocked
+            'blocked': self.context.has_blocked_local_role_inheritance()
         }
 
+
+class RoleInheritanceGet(RoleInheritanceBase):
+
+    def reply(self):
+        return self._serialize_blocked()
+
+
+class RoleInheritancePost(RoleInheritanceBase):
+
+    def reply(self):
+        # Disable CSRF protection
+        alsoProvides(self.request, IDisableCSRFProtection)
+
+        data = json_body(self.request)
+        blocked = data.get('blocked')
+
+        if blocked is None:
+            raise BadRequest('Must supply blocked in JSON body.')
+
+        if blocked == self.context.has_blocked_local_role_inheritance():
+            self.request.response.setStatus(409)
+            return self._serialize_blocked()
+
+        if blocked:
+            self._copy_assigments_from_parent_with_local_roles()
+        else:
+            self._delete_local_role_assignments()
+
+        self.context.__ac_local_roles_block__ = blocked
+        self.context.reindexObjectSecurity()
+
+        return self._serialize_blocked()
+
+    def _copy_assigments_from_parent_with_local_roles(self):
+        parent_with_local_roles = self.context.get_parent_with_local_roles()
+        source_manager = RoleAssignmentManager(parent_with_local_roles)
+        source_manager.copy_assigments_to(self.context)
+
+    def _delete_local_role_assignments(self):
+        RoleAssignmentManager(self.context).clear_all()

--- a/opengever/api/role_inheritance.py
+++ b/opengever/api/role_inheritance.py
@@ -1,0 +1,11 @@
+from plone.restapi.services import Service
+
+
+class RoleInheritanceGet(Service):
+
+    def reply(self):
+        blocked = getattr(self.context, '__ac_local_roles_block__', False)
+        return {
+            'blocked': blocked
+        }
+

--- a/opengever/api/tests/test_role_inheritance.py
+++ b/opengever/api/tests/test_role_inheritance.py
@@ -1,5 +1,9 @@
 from ftw.testbrowser import browsing
+from opengever.base.role_assignments import ASSIGNMENT_VIA_SHARING
+from opengever.base.role_assignments import RoleAssignmentManager
+from opengever.base.role_assignments import SharingRoleAssignment
 from opengever.testing import IntegrationTestCase
+import json
 
 
 class TestRoleInheritanceGet(IntegrationTestCase):
@@ -24,3 +28,77 @@ class TestRoleInheritanceGet(IntegrationTestCase):
             view='@role-inheritance',
             headers=self.api_headers)
         self.assertEqual({'blocked': True}, browser.json)
+
+
+class TestRoleInheritancePost(IntegrationTestCase):
+
+    @browsing
+    def test_block_workspace_folder_role_inheritance(self, browser):
+        self.login(self.workspace_owner, browser)
+
+        browser.open(
+            self.workspace_folder,
+            view='/@role-inheritance',
+            data=json.dumps({'blocked': True}),
+            method='POST',
+            headers=self.api_headers)
+
+        self.assertEqual({'blocked': True}, browser.json)
+        self.assertTrue(self.workspace_folder.__ac_local_roles_block__)
+
+        workspace_manager = RoleAssignmentManager(self.workspace)
+        folder_manager = RoleAssignmentManager(self.workspace_folder)
+
+        self.assertEqual(
+            workspace_manager.get_assignments_by_cause(ASSIGNMENT_VIA_SHARING),
+            folder_manager.get_assignments_by_cause(ASSIGNMENT_VIA_SHARING),
+            "Sharing assignment should be same as parent workspace"
+        )
+
+    @browsing
+    def test_unblock_workspace_folder_role_inheritance(self, browser):
+        self.login(self.workspace_owner, browser)
+        folder_manager = RoleAssignmentManager(self.workspace_folder)
+
+        userid = self.workspace_owner.getId()
+        assignment = SharingRoleAssignment(userid, ['WorkspaceAdmin'])
+        folder_manager.add_or_update_assignment(assignment)
+        self.workspace_folder.__ac_local_roles_block__ = True
+
+        browser.open(
+            self.workspace_folder,
+            view='/@role-inheritance',
+            data=json.dumps({'blocked': False}),
+            method='POST',
+            headers=self.api_headers)
+
+        self.assertEqual({'blocked': False}, browser.json)
+        self.assertEqual(
+            ([]),
+            folder_manager.get_assignments_by_cause(ASSIGNMENT_VIA_SHARING),
+            "Sharing assignment should have been cleared"
+        )
+
+    @browsing
+    def test_members_cannot_change_inheritance(self, browser):
+        self.login(self.workspace_member, browser)
+
+        with browser.expect_unauthorized():
+            browser.open(
+                self.workspace_folder,
+                view='/@role-inheritance',
+                data=json.dumps({'blocked': True}),
+                method='POST',
+                headers=self.api_headers)
+
+    @browsing
+    def test_guests_cannot_change_inheritance(self, browser):
+        self.login(self.workspace_member, browser)
+
+        with browser.expect_unauthorized():
+            browser.open(
+                self.workspace_folder,
+                view='/@role-inheritance',
+                data=json.dumps({'blocked': True}),
+                method='POST',
+                headers=self.api_headers)

--- a/opengever/api/tests/test_role_inheritance.py
+++ b/opengever/api/tests/test_role_inheritance.py
@@ -1,0 +1,26 @@
+from ftw.testbrowser import browsing
+from opengever.testing import IntegrationTestCase
+
+
+class TestRoleInheritanceGet(IntegrationTestCase):
+
+    @browsing
+    def test_role_inheritance_get_falsy(self, browser):
+        self.login(self.workspace_member, browser)
+
+        browser.open(
+            self.workspace_folder,
+            view='@role-inheritance',
+            headers=self.api_headers)
+        self.assertEqual({'blocked': False}, browser.json)
+
+    @browsing
+    def test_role_inheritance_get_truthy(self, browser):
+        self.login(self.administrator, browser)
+        self.workspace_folder.__ac_local_roles_block__ = True
+
+        browser.open(
+            self.workspace_folder,
+            view='@role-inheritance',
+            headers=self.api_headers)
+        self.assertEqual({'blocked': True}, browser.json)

--- a/opengever/base/role_assignments.py
+++ b/opengever/base/role_assignments.py
@@ -236,8 +236,13 @@ class RoleAssignmentStorage(object):
     def add_or_update(self, principal, roles, cause, reference):
         """Add or update a role assignment
         """
+        oguid = None
+        if reference:
+            if isinstance(reference, basestring):
+                oguid = reference
+            else:
+                oguid = Oguid.for_object(reference).id
 
-        oguid = Oguid.for_object(reference).id if reference else None
         data = {
             'principal': principal,
             'roles': list(roles),
@@ -270,6 +275,17 @@ class RoleAssignmentManager(object):
 
     def has_storage(self):
         return self.storage.has_storage()
+
+    def copy_assigments_to(self, target):
+        if not self.has_storage():
+            return
+
+        target_manager = RoleAssignmentManager(target)
+        source_assignments = [
+            RoleAssignment(**assignment)
+            for assignment in self.storage.get_all()
+        ]
+        target_manager.add_or_update_assignments(source_assignments)
 
     def add_or_update_assignment(self, assignment, reindex=True):
         self.storage.add_or_update(assignment.principal,

--- a/opengever/workspace/base.py
+++ b/opengever/workspace/base.py
@@ -1,0 +1,17 @@
+from Acquisition import aq_inner
+from Acquisition import aq_parent
+from plone.dexterity.content import Container
+
+
+class WorkspaceBase(Container):
+
+    def has_blocked_local_role_inheritance(self):
+        return getattr(self, '__ac_local_roles_block__', False)
+
+    def get_parent_with_local_roles(self):
+        parent = aq_parent(aq_inner(self))
+        if parent.has_blocked_local_role_inheritance():
+            return parent
+
+        else:
+            return parent.get_parent_with_local_roles()

--- a/opengever/workspace/workspace.py
+++ b/opengever/workspace/workspace.py
@@ -1,7 +1,7 @@
+from opengever.workspace.base import WorkspaceBase
 from opengever.workspace.interfaces import IWorkspace
 from plone import api
 from plone.autoform.interfaces import IFormFieldProvider
-from plone.dexterity.content import Container
 from plone.restapi.deserializer import json_body
 from plone.restapi.services.content.update import ContentPatch
 from plone.supermodel import model
@@ -15,8 +15,11 @@ class IWorkspaceSchema(model.Schema):
     """ """
 
 
-class Workspace(Container):
+class Workspace(WorkspaceBase):
     implements(IWorkspace)
+
+    def get_parent_with_local_roles(self):
+        return self
 
 
 class WorkspaceContentPatch(ContentPatch):

--- a/opengever/workspace/workspace_folder.py
+++ b/opengever/workspace/workspace_folder.py
@@ -1,9 +1,9 @@
+from opengever.workspace.base import WorkspaceBase
 from opengever.workspace.interfaces import IWorkspaceFolder
 from plone.autoform.interfaces import IFormFieldProvider
 from plone.supermodel import model
 from zope.interface import implements
 from zope.interface import provider
-from plone.dexterity.content import Container
 
 
 @provider(IFormFieldProvider)
@@ -11,5 +11,5 @@ class IWorkspaceFolderSchema(model.Schema):
     """ """
 
 
-class WorkspaceFolder(Container):
+class WorkspaceFolder(WorkspaceBase):
     implements(IWorkspaceFolder)


### PR DESCRIPTION
This PR implements the a `@role_inheritance` `POST` and `GET` service endpoint for workspace folders as specified in https://github.com/4teamwork/opengever.core/issues/6167.

- The `GET` service endpoint allows a user who can `View` to query if role inheritance on context is blocked
- The `POST` endpoint allows a workspace admin to set if inheritance on context is blocked or not. When blocking the parents local role assignments are copied, when unblocking the current folders assignments are removed.

_Creating a draft, but could be merged separately as it  fully implements the `@role_inheritance` endpoint as specified in https://github.com/4teamwork/opengever.core/issues/6167. Checkboxes ticked off accordingly. Didn't get to work on this today unfortunately, so not 100% finsihed._

- [x] Changelog-Eintrag vorhanden/nötig?
- [x] Aktualisierung Dokumentation vorhanden/nötig?
