### PR TITLE
Add new_document_from_task file_action.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2019.5.1 (unreleased)
 ---------------------
 
+- Add new_document_from_task file_action. [lgraf]
 - When tearing down test layer, wait for solr to be torn down properly. [siegy]
 - Configure Solr replication handler. [buchi]
 - Implement PossibleWorkspaceFolderParticipantsVocabulary to get all possible workspace folder participants. [elioschmutz]

--- a/opengever/api/tests/test_actions.py
+++ b/opengever/api/tests/test_actions.py
@@ -1,6 +1,7 @@
 from ftw.testbrowser import browsing
 from opengever.testing import IntegrationTestCase
 from opengever.trash.trash import ITrashable
+from plone.protect import createToken
 
 
 class FileActionsTestBase(IntegrationTestCase):
@@ -91,6 +92,9 @@ class TestFileActionsGetForMails(FileActionsTestBase):
             {u'id': u'trash_document',
              u'title': u'Trash document',
              u'icon': u''},
+            {u'id': u'new_task_from_document',
+             u'title': u'New task from document',
+             u'icon': u''},
             ]
 
         self.assertEqual(expected_file_actions,
@@ -118,6 +122,9 @@ class TestFileActionsGetForDocuments(FileActionsTestBase):
             {u'id': u'trash_document',
              u'title': u'Trash document',
              u'icon': u''},
+            {u'id': u'new_task_from_document',
+             u'title': u'New task from document',
+             u'icon': u''},
             ]
         self.assertEqual(expected_file_actions,
                          self.get_file_actions(browser, self.document))
@@ -142,6 +149,9 @@ class TestFileActionsGetForDocuments(FileActionsTestBase):
             {u'id': u'trash_document',
              u'title': u'Trash document',
              u'icon': u''},
+            {u'id': u'new_task_from_document',
+             u'title': u'New task from document',
+             u'icon': u''},
             ]
         self.assertEqual(expected_file_actions,
                          self.get_file_actions(browser, self.document))
@@ -162,6 +172,9 @@ class TestFileActionsGetForDocuments(FileActionsTestBase):
              u'icon': u''},
             {u'id': u'trash_document',
              u'title': u'Trash document',
+             u'icon': u''},
+            {u'id': u'new_task_from_document',
+             u'title': u'New task from document',
              u'icon': u''},
             ]
         self.assertEqual(expected_file_actions,
@@ -193,6 +206,9 @@ class TestFileActionsGetForDocuments(FileActionsTestBase):
              u'icon': u''},
             {u'id': u'open_as_pdf',
              u'title': u'Open as PDF',
+             u'icon': u''},
+            {u'id': u'new_task_from_document',
+             u'title': u'New task from document',
              u'icon': u''},
             ]
 
@@ -226,6 +242,9 @@ class TestFileActionsGetForDocuments(FileActionsTestBase):
             {u'id': u'open_as_pdf',
              u'title': u'Open as PDF',
              u'icon': u''},
+            {u'id': u'new_task_from_document',
+             u'title': u'New task from document',
+             u'icon': u''},
             ]
 
         self.assertEqual(expected_file_actions,
@@ -250,6 +269,9 @@ class TestFileActionsGetForDocuments(FileActionsTestBase):
             {u'id': u'open_as_pdf',
              u'title': u'Open as PDF',
              u'icon': u''},
+            {u'id': u'new_task_from_document',
+             u'title': u'New task from document',
+             u'icon': u''},
             ]
         self.assertEqual(expected_manager_file_actions,
                          self.get_file_actions(browser, self.document))
@@ -258,6 +280,9 @@ class TestFileActionsGetForDocuments(FileActionsTestBase):
         expected_dossier_manager_file_actions = [
             {u'id': u'open_as_pdf',
              u'title': u'Open as PDF',
+             u'icon': u''},
+            {u'id': u'new_task_from_document',
+             u'title': u'New task from document',
              u'icon': u''},
             ]
         self.assertEqual(expected_dossier_manager_file_actions,
@@ -280,6 +305,9 @@ class TestFileActionsGetForDocuments(FileActionsTestBase):
             {u'id': u'trash_document',
              u'title': u'Trash document',
              u'icon': u''},
+            {u'id': u'new_task_from_document',
+             u'title': u'New task from document',
+             u'icon': u''},
             ]
         self.assertEqual(expected_file_actions,
                          self.get_file_actions(browser, self.document))
@@ -294,6 +322,9 @@ class TestFileActionsGetForDocuments(FileActionsTestBase):
              u'icon': u''},
             {u'id': u'trash_document',
              u'title': u'Trash document',
+             u'icon': u''},
+            {u'id': u'new_task_from_document',
+             u'title': u'New task from document',
              u'icon': u''},
             ]
         self.assertEqual(expected_file_actions,
@@ -315,6 +346,9 @@ class TestFileActionsGetForDocuments(FileActionsTestBase):
              u'icon': u''},
             {u'id': u'trash_document',
              u'title': u'Trash document',
+             u'icon': u''},
+            {u'id': u'new_task_from_document',
+             u'title': u'New task from document',
              u'icon': u''},
             ]
         self.assertEqual(expected_file_actions,
@@ -342,6 +376,9 @@ class TestTrashingActionsForDocuments(FileActionsTestBase):
             {u'id': u'trash_document',
              u'title': u'Trash document',
              u'icon': u''},
+            {u'id': u'new_task_from_document',
+             u'title': u'New task from document',
+             u'icon': u''},
             ]
         self.assertEqual(expected_file_actions,
                          self.get_file_actions(browser, self.document))
@@ -366,6 +403,119 @@ class TestTrashingActionsForDocuments(FileActionsTestBase):
             {u'id': u'untrash_document',
              u'title': u'Untrash document',
              u'icon': u''},
+            {u'id': u'new_task_from_document',
+             u'title': u'New task from document',
+             u'icon': u''},
             ]
         self.assertEqual(expected_file_actions,
                          self.get_file_actions(browser, self.document))
+
+
+class TestNewTaskFromDocumentAction(FileActionsTestBase):
+
+    @browsing
+    def test_task_from_doc_not_available_for_doc_in_resolved_dossier(self, browser):
+        self.login(self.secretariat_user, browser)
+
+        browser.open(self.resolvable_dossier,
+                     view='transition-resolve',
+                     data={'_authenticator': createToken()})
+        expected_file_actions = [
+            {u'id': u'download_copy',
+             u'title': u'Download copy',
+             u'icon': u''},
+            {u'id': u'attach_to_email',
+             u'title': u'Attach to email',
+             u'icon': u''},
+            {u'id': u'open_as_pdf',
+             u'title': u'Open as PDF',
+             u'icon': u''},
+            ]
+        self.assertEqual(expected_file_actions,
+                         self.get_file_actions(browser, self.resolvable_document))
+
+    @browsing
+    def test_task_from_doc_not_available_for_doc_in_task(self, browser):
+        self.login(self.regular_user, browser)
+        expected_file_actions = [
+            {u'id': u'oc_direct_checkout',
+             u'title': u'Checkout and edit',
+             u'icon': u''},
+            {u'id': u'download_copy',
+             u'title': u'Download copy',
+             u'icon': u''},
+            {u'id': u'attach_to_email',
+             u'title': u'Attach to email',
+             u'icon': u''},
+            {u'id': u'open_as_pdf',
+             u'title': u'Open as PDF',
+             u'icon': u''},
+            {u'id': u'trash_document',
+             u'title': u'Trash document',
+             u'icon': u''},
+            ]
+        self.assertEqual(expected_file_actions,
+                         self.get_file_actions(browser, self.taskdocument))
+
+    @browsing
+    def test_task_from_doc_not_available_for_doc_in_inbox(self, browser):
+        self.login(self.secretariat_user, browser)
+        expected_file_actions = [
+            {u'id': u'oc_direct_checkout',
+             u'title': u'Checkout and edit',
+             u'icon': u''},
+            {u'id': u'download_copy',
+             u'title': u'Download copy',
+             u'icon': u''},
+            {u'id': u'attach_to_email',
+             u'title': u'Attach to email',
+             u'icon': u''},
+            {u'id': u'open_as_pdf',
+             u'title': u'Open as PDF',
+             u'icon': u''},
+            {u'id': u'trash_document',
+             u'title': u'Trash document',
+             u'icon': u''},
+            ]
+        self.assertEqual(expected_file_actions,
+                         self.get_file_actions(browser, self.inbox_document))
+
+    @browsing
+    def test_task_from_doc_not_available_for_doc_in_private_dossier(self, browser):
+        self.login(self.regular_user, browser)
+        expected_file_actions = [
+            {u'id': u'oc_direct_checkout',
+             u'title': u'Checkout and edit',
+             u'icon': u''},
+            {u'id': u'download_copy',
+             u'title': u'Download copy',
+             u'icon': u''},
+            {u'id': u'attach_to_email',
+             u'title': u'Attach to email',
+             u'icon': u''},
+            {u'id': u'open_as_pdf',
+             u'title': u'Open as PDF',
+             u'icon': u''},
+            {u'id': u'trash_document',
+             u'title': u'Trash document',
+             u'icon': u''},
+            ]
+        self.assertEqual(expected_file_actions,
+                         self.get_file_actions(browser, self.private_document))
+
+    @browsing
+    def test_task_from_doc_not_available_for_doc_in_inactive_dossier(self, browser):
+        self.login(self.regular_user, browser)
+        expected_file_actions = [
+            {u'id': u'download_copy',
+             u'title': u'Download copy',
+             u'icon': u''},
+            {u'id': u'attach_to_email',
+             u'title': u'Attach to email',
+             u'icon': u''},
+            {u'id': u'open_as_pdf',
+             u'title': u'Open as PDF',
+             u'icon': u''},
+            ]
+        self.assertEqual(expected_file_actions,
+                         self.get_file_actions(browser, self.inactive_document))

--- a/opengever/core/profiles/default/actions.xml
+++ b/opengever/core/profiles/default/actions.xml
@@ -154,6 +154,15 @@
       <property name="visible">True</property>
     </object>
 
+    <object name="new_task_from_document" meta_type="CMF Action" i18n:domain="opengever.document">
+      <property name="title" i18n:translate="label_new_task_from_document">New task from document</property>
+      <property name="available_expr">object/@@file_actions_availability/is_new_task_from_document_available</property>
+      <property name="permissions">
+        <element value="View" />
+      </property>
+      <property name="visible">True</property>
+    </object>
+
   </object>
 
   <!-- SITE ACTIONS -->

--- a/opengever/core/upgrades/20200110182808_add_new_task_from_document_file_action/actions.xml
+++ b/opengever/core/upgrades/20200110182808_add_new_task_from_document_file_action/actions.xml
@@ -1,0 +1,16 @@
+<object xmlns:i18n="http://xml.zope.org/namespaces/i18n" name="portal_actions" meta_type="Plone Actions Tool">
+
+  <object name="file_actions" meta_type="CMF Action Category">
+
+    <object name="new_task_from_document" meta_type="CMF Action" i18n:domain="opengever.document">
+      <property name="title" i18n:translate="label_new_task_from_document">New task from document</property>
+      <property name="available_expr">object/@@file_actions_availability/is_new_task_from_document_available</property>
+      <property name="permissions">
+        <element value="View" />
+      </property>
+      <property name="visible">True</property>
+    </object>
+
+  </object>
+
+</object>

--- a/opengever/core/upgrades/20200110182808_add_new_task_from_document_file_action/upgrade.py
+++ b/opengever/core/upgrades/20200110182808_add_new_task_from_document_file_action/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddNewTaskFromDocumentFileAction(UpgradeStep):
+    """Add new_task_from_document file action.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/document/fileactions.py
+++ b/opengever/document/fileactions.py
@@ -1,13 +1,17 @@
+from Acquisition import aq_inner
+from Acquisition import aq_parent
 from ftw.bumblebee.mimetypes import is_mimetype_supported
 from opengever.bumblebee import is_bumblebee_feature_enabled
 from opengever.document.behaviors import IBaseDocument
 from opengever.document.document import IDocumentSchema
 from opengever.document.interfaces import ICheckinCheckoutManager
 from opengever.document.interfaces import IFileActions
+from opengever.dossier.behaviors.dossier import IDossierMarker
 from opengever.officeconnector.helpers import is_officeconnector_attach_feature_enabled  # noqa
 from opengever.officeconnector.helpers import is_officeconnector_checkout_feature_enabled  # noqa
 from opengever.trash.trash import ITrashable
 from opengever.trash.trash import TrashError
+from plone import api
 from plone import api
 from zope.component import adapter
 from zope.component import getMultiAdapter
@@ -95,6 +99,12 @@ class BaseDocumentFileActions(object):
     def is_untrash_document_available(self):
         trasher = ITrashable(self.context)
         return trasher.verify_may_untrash(raise_on_violations=False)
+
+    def is_new_task_from_document_available(self):
+        parent = aq_parent(aq_inner(self.context))
+        is_inside_dossier = IDossierMarker.providedBy(parent)
+        may_add_task = api.user.has_permission('opengever.task: Add task', obj=parent)
+        return is_inside_dossier and may_add_task
 
 
 @implementer(IFileActions)

--- a/opengever/document/interfaces.py
+++ b/opengever/document/interfaces.py
@@ -199,3 +199,6 @@ class IFileActions(Interface):
 
     def is_untrash_document_available():
         """Return whether the untrash_document action is available."""
+
+    def is_new_task_from_document_available():
+        """Return whether the new_task_from_document action is available."""


### PR DESCRIPTION
This adds the `new_task_from_document` backend action required for 4teamwork/gever-ui#837.

The action will be shown for **documents** and **mails**, whenever the parent context is a dossier and the user is allowed to add a new task to the parent (i.e. has the `opengever.task: Add task` on the parent).

## Checkliste

- [x] Gibt es neue Funktionalität mit einem `Dokument`? Funktioniert das auch mit einem `Mail`?
- [x] Profil angepasst? Sind UpgradeSteps vorhanden/nötig?:
- [x] Changelog-Eintrag vorhanden/nötig?
