### PR TITLE
Workspace folder participation

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 ---------------------
 
 - Configure Solr replication handler. [buchi]
+- Implement PossibleWorkspaceFolderParticipantsVocabulary to get all possible workspace folder participants. [elioschmutz]
+- Implement GET, PATCH and POST @participations endpoint for workspace folders. [elioschmutz]
 - Implement @role-inheritance serivce endpoint for workspace folders. [deiferni]
 - Include permissions.zcml of Products.CMFEditions. [lgraf]
 - Add action to create new invitations to workspaces. [deiferni]

--- a/docs/public/dev-manual/api/workspace/participation.rst
+++ b/docs/public/dev-manual/api/workspace/participation.rst
@@ -32,24 +32,28 @@ Ein GET Request gibt die Beteiligungen sowie die aktiven Einladungen eines Inhal
           "@type": "virtual.participations.user",
           "is_editable": true,
           "participant_email": "max.muster@example.org",
-          "participant_fullname": "Max Muster (max.muster)",
           "role": {
             "title": "Admin",
             "token": "WorkspaceAdmin"
           },
-          "token": "max.muster"
+          "participant": {
+            "title": "Max Muster (max.muster)",
+            "token": "max.muster"
+          }
         },
         {
           "@id": "http://localhost:8080/fd/workspaces/workspace-1/@participations/petra.frohlich",
           "@type": "virtual.participations.user",
           "is_editable": true,
           "participant_email": "petra.frohlich@example.org",
-          "participant_fullname": "Petra Fröhlich (petra.frohlich)",
           "role": {
             "title": "Teammitglied",
             "token": "WorkspaceMember"
           },
-          "token": "petra.frohlich"
+          "participant": {
+            "title": "Petra Fröhlich (petra.frohlich)",
+            "token": "petra.frohlich"
+          }
         }
       ]
     }
@@ -79,12 +83,14 @@ Ein GET Request auf die jeweilige Resource gibt die Beteiligungen oder die Einla
       "@type": "virtual.participations.user",
       "is_editable": true,
       "participant_email": "max.muster@example.org",
-      "participant_fullname": "Max Muster (max.muster)",
       "role": {
         "title": "Admin",
         "token": "WorkspaceAdmin"
       },
-      "token": "max.muster"
+      "participant": {
+        "title": "Max Muster (max.muster)",
+        "token": "max.muster"
+      }
     }
 
 
@@ -121,7 +127,7 @@ In einem selbst verwalteten Teamraum-Ordner (Vererbung wurde unterbrochen) könn
        Accept: application/json
 
        {
-         "token": "maria.meier",
+         "participant": "maria.meier",
          "role": "WorkspaceMember",
        }
 
@@ -142,7 +148,10 @@ In einem selbst verwalteten Teamraum-Ordner (Vererbung wurde unterbrochen) könn
         "title": "Admin",
         "token": "WorkspaceMember"
       },
-      "token": "max.muster"
+      "participant": {
+        "title": "Max Muster (max.muster)",
+        "token": "max.muster"
+      }
     }
 
 
@@ -158,7 +167,7 @@ Beteiligungen können über einen PATCH request auf die jeweilige Ressourece ge�
     Accept: application/json
 
     {
-      "role": { "token": "WorkspaceAdmin" }
+      "role": "WorkspaceAdmin"
     }
 
 **Beispiel-Response**:

--- a/docs/public/dev-manual/api/workspace/participation.rst
+++ b/docs/public/dev-manual/api/workspace/participation.rst
@@ -28,28 +28,28 @@ Ein GET Request gibt die Beteiligungen sowie die aktiven Einladungen eines Inhal
     {
       "items": [
         {
-          "@id": "http://localhost:8080/fd/workspaces/workspace-1/@participations/users/max.muster",
+          "@id": "http://localhost:8080/fd/workspaces/workspace-1/@participations/max.muster",
           "@type": "virtual.participations.user",
-          "inviter_fullname": null,
-          "is_editable": false,
+          "is_editable": true,
+          "participant_email": "max.muster@example.org",
           "participant_fullname": "Max Muster (max.muster)",
-          "readable_role": "Federführung",
-          "role": "WorkspaceOwner",
-          "token": "max.muster",
-          "participation_type": "user",
-          "readable_participation_type": "User",
+          "role": {
+            "title": "Admin",
+            "token": "WorkspaceAdmin"
+          },
+          "token": "max.muster"
         },
         {
-          "@id": "http://localhost:8080/fd/workspaces/workspace-1/@participations/invitations/3a8bfcb1b6294edfb60e2a43717fc300",
-          "@type": "virtual.participations.invitation",
-          "inviter_fullname": "Max Muster (max.muster)",
+          "@id": "http://localhost:8080/fd/workspaces/workspace-1/@participations/petra.frohlich",
+          "@type": "virtual.participations.user",
           "is_editable": true,
+          "participant_email": "petra.frohlich@example.org",
           "participant_fullname": "Petra Fröhlich (petra.frohlich)",
-          "readable_role": "Gast",
-          "role": "WorkspaceGuest",
-          "token": "3a8bfcb1b6294edfb60e2a43717fc300",
-          "participation_type": "invitation",
-          "readable_participation_type": "Invitation",
+          "role": {
+            "title": "Teammitglied",
+            "token": "WorkspaceMember"
+          },
+          "token": "petra.frohlich"
         }
       ]
     }
@@ -75,31 +75,28 @@ Ein GET Request auf die jeweilige Resource gibt die Beteiligungen oder die Einla
     Content-Type: application/json
 
     {
-      "@id": "http://localhost:8080/fd/workspaces/workspace-1/@participations/users/max.muster",
+      "@id": "http://localhost:8080/fd/workspaces/workspace-1/@participations/max.muster",
       "@type": "virtual.participations.user",
-      "inviter_fullname": null,
-      "is_editable": false,
+      "is_editable": true,
+      "participant_email": "max.muster@example.org",
       "participant_fullname": "Max Muster (max.muster)",
-      "readable_role": "Federführung",
-      "role": "WorkspaceOwner",
-      "token": "max.muster",
-      "participation_type": "user",
-      "readable_participation_type": "User",
+      "role": {
+        "title": "Admin",
+        "token": "WorkspaceAdmin"
+      },
+      "token": "max.muster"
     }
 
 
 Beteiligungen löschen:
 ----------------------
-Ein DELETE Request auf die `@id` einer Beteiligung löscht die entsprechnede Beteilungung oder Einladung.
-
-Die URL setzt sich dabei folgendermassen zusammen:
-``gever-url/workspaces/workspace/@participations/{participation_type}/{token}``
+Ein DELETE Request auf die `@id` einer Beteiligung löscht die entsprechnede Beteilungung.
 
 **Beispiel-Request**:
 
    .. sourcecode:: http
 
-       DELETE /workspace-1/@participations/invitations/3a8bfcb1b6294edfb60e2a43717fc300 HTTP/1.1
+       DELETE /workspace-1/@participations/max.muster HTTP/1.1
        Accept: application/json
 
 
@@ -110,32 +107,21 @@ Die URL setzt sich dabei folgendermassen zusammen:
       HTTP/1.1 204 No Content
 
 
-Beteiligungen hinzufügen (Benutzer einladen):
----------------------------------------------
-Eine Beteiligung kann nur über eine Einladung hinzugefügt werden. Der eingeladene Benutzer muss seine Beteiligung erste bestätigen, bevor der Benutzer effektiv berechtigt wird.
+Beteiligungen hinzufügen:
+-------------------------
+In einem selbst verwalteten Teamraum-Ordner (Vererbung wurde unterbrochen) können beteiligungen über einen POST request auf den @participations Endpoint hinzugefügt werden.
 
-Eine Einladung wird durch einen POST request auf den `@participation/invitations` Endpoint erstellt.
-
-
-**Parameter:**
-
-Pflicht:
-
-``userid``: ``String``
-   ID des Benutzers, welcher eingeladen werden soll
-
-``role``: ``String``
-   Eine Arbeitsraum-Rolle
+**Achtung**: Eine Beteiligung in einem Arbeitsraum kann nur über eine Einladung hinzugefügt werden. Der eingeladene Benutzer muss seine Beteiligung erste bestätigen, bevor der Benutzer effektiv berechtigt wird.
 
 **Beispiel-Request**:
 
    .. sourcecode:: http
 
-       POST /workspaces/workspace-1/@participations/invitations/ HTTP/1.1
+       POST /workspaces/workspace-1/folder-1/@participations HTTP/1.1
        Accept: application/json
 
        {
-         "userid": "maria.meier",
+         "token": "maria.meier",
          "role": "WorkspaceMember",
        }
 
@@ -147,40 +133,33 @@ Pflicht:
     Content-Type: application/json
 
     {
-          "@id": "http://localhost:8080/fd/workspaces/workspace-1/@participations/invitations/3a8bfcb1b6294edfb60e2a43717fc301",
-          "@type": "virtual.participations.invitation",
-          "inviter_fullname": "Max Muster (max.muster)",
-          "is_editable": true,
-          "participant_fullname": "Maria Meier (maria.meier)",
-          "readable_role": "Teammitglied",
-          "role": "WorkspaceMember",
-          "token": "3a8bfcb1b6294edfb60e2a43717fc301",
-          "participation_type": "invitation",
-          "readable_participation_type": "Invitation",
+      "@id": "http://localhost:8080/fd/workspaces/workspace-1/@participations/max.muster",
+      "@type": "virtual.participations.user",
+      "is_editable": true,
+      "participant_email": "max.muster@example.org",
+      "participant_fullname": "Max Muster (max.muster)",
+      "role": {
+        "title": "Admin",
+        "token": "WorkspaceMember"
+      },
+      "token": "max.muster"
     }
 
 
 Beteiligungen bearbeiten:
 -------------------------
-Sowohl Beteiligungen wie auch Einladungen können über einen PATCH request auf die jeweilige Ressourece geändert werden.
-
-**Parameter:**
-
-Pflicht:
-
-``role``: ``String``
-   Eine Arbeitsraum-Rolle
+Beteiligungen können über einen PATCH request auf die jeweilige Ressourece geändert werden.
 
 **Beispiel-Request**:
 
-   .. sourcecode:: http
+  .. sourcecode:: http
 
-       POST /workspaces/workspace-1/@participations/invitations/3a8bfcb1b6294edfb60e2a43717fc301 HTTP/1.1
-       Accept: application/json
+    PATCH /workspaces/workspace-1/@participations/max.muster HTTP/1.1
+    Accept: application/json
 
-       {
-         "role": "WorkspaceAdmin",
-       }
+    {
+      "role": { "token": "WorkspaceAdmin" }
+    }
 
 **Beispiel-Response**:
 

--- a/docs/public/dev-manual/api/workspace/role_inheritance.rst
+++ b/docs/public/dev-manual/api/workspace/role_inheritance.rst
@@ -31,7 +31,7 @@ Vererbung unterbrechen:
 -----------------------
 Mit einem POST Request kann die Rollenvererbung unterbrochen werden.
 
-Wird eine Vererbung unterbrochen, werden initial alle bisherigen Berechtigungen für den Ordner kopiert.
+Wird eine Vererbung unterbrochen, wird der aktuelle Benutzer als neuen und einzigen Admin hinzugefügt.
 
 **Beispiel-Request**:
 
@@ -41,7 +41,7 @@ Wird eine Vererbung unterbrochen, werden initial alle bisherigen Berechtigungen 
        Accept: application/json
 
        {
-         "blocked": true,
+         "blocked": true
        }
 
 **Beispiel-Response**:
@@ -56,6 +56,35 @@ Wird eine Vererbung unterbrochen, werden initial alle bisherigen Berechtigungen 
       "blocked": true
     }
 
+
+Vererbung unterbrechen mit Rollen-Kopie
+---------------------------------------
+Mit der Option `copy_roles` auf dem @role-inheritance Endpoint werden bestehende Berechtigungen nach dem Unterbrechen der
+Vererbung automatisch kopiert.
+
+**Beispiel-Request**:
+
+   .. sourcecode:: http
+
+       POST /workspace-1/folder-1/@role-inheritance HTTP/1.1
+       Accept: application/json
+
+       {
+         "blocked": true,
+         "copy_roles": true
+       }
+
+**Beispiel-Response**:
+
+
+   .. sourcecode:: http
+
+    HTTP/1.1 200 OK
+    Content-Type: application/json
+
+    {
+      "blocked": true,
+    }
 
 Berechtigungen vererben:
 ------------------------

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -423,6 +423,14 @@
       />
 
   <plone:service
+      method="DELETE"
+      name="@participations"
+      for="opengever.workspace.interfaces.IWorkspaceFolder"
+      factory=".participations.ParticipationsDelete"
+      permission="plone.DelegateWorkspaceAdminRole"
+      />
+
+  <plone:service
       method="GET"
       name="@role-inheritance"
       for="opengever.workspace.interfaces.IWorkspaceFolder"

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -416,6 +416,14 @@
 
   <plone:service
       method="GET"
+      name="@participations"
+      for="opengever.workspace.interfaces.IWorkspaceFolder"
+      factory=".participations.ParticipationsGet"
+      permission="zope2.View"
+      />
+
+  <plone:service
+      method="GET"
       name="@role-inheritance"
       for="opengever.workspace.interfaces.IWorkspaceFolder"
       factory=".role_inheritance.RoleInheritanceGet"

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -439,6 +439,14 @@
       />
 
   <plone:service
+      method="POST"
+      name="@participations"
+      for="opengever.workspace.interfaces.IWorkspaceFolder"
+      factory=".participations.ParticipationsPost"
+      permission="plone.DelegateWorkspaceAdminRole"
+      />
+
+  <plone:service
       method="GET"
       name="@role-inheritance"
       for="opengever.workspace.interfaces.IWorkspaceFolder"

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -431,6 +431,14 @@
       />
 
   <plone:service
+      method="PATCH"
+      name="@participations"
+      for="opengever.workspace.interfaces.IWorkspaceFolder"
+      factory=".participations.ParticipationsPatch"
+      permission="plone.DelegateWorkspaceAdminRole"
+      />
+
+  <plone:service
       method="GET"
       name="@role-inheritance"
       for="opengever.workspace.interfaces.IWorkspaceFolder"

--- a/opengever/api/participations.py
+++ b/opengever/api/participations.py
@@ -31,12 +31,12 @@ class ParticipationTraverseService(Service):
         userid = participant.get('token')
         role = PARTICIPATION_ROLES.get(participant.get('roles')[0])
         member = api.user.get(userid=userid)
+        managing_context = self.context.get_context_with_local_roles()
         return {
-            '@id': '{}/@participations/{}'.format(
-                self.context.get_context_with_local_roles().absolute_url(), userid),
+            '@id': '{}/@participations/{}'.format(managing_context.absolute_url(), userid),
             '@type': 'virtual.participations.user',
             'participant_fullname': participant.get('name'),
-            'is_editable': participant.get('can_manage'),
+            'is_editable': managing_context == self.context and participant.get('can_manage'),
             'role': {
                 'token': role.id,
                 'title': role.translated_title(self.request),

--- a/opengever/api/participations.py
+++ b/opengever/api/participations.py
@@ -1,15 +1,21 @@
+from opengever.base.role_assignments import RoleAssignmentManager
+from opengever.base.role_assignments import SharingRoleAssignment
+from opengever.workspace.activities import WorkspaceWatcherManager
 from opengever.workspace.participation import PARTICIPATION_ROLES
 from opengever.workspace.participation import PARTICIPATION_TYPES
 from opengever.workspace.participation import PARTICIPATION_TYPES_BY_PATH_IDENTIFIER
 from opengever.workspace.participation import TYPE_INVITATION
 from opengever.workspace.participation.browser.manage_participants import ManageParticipants
+from plone import api
+from plone.protect.interfaces import IDisableCSRFProtection
 from plone.restapi.deserializer import json_body
 from plone.restapi.services import Service
 from zExceptions import BadRequest
+from zExceptions import Forbidden
 from zExceptions import NotFound
+from zope.interface import alsoProvides
 from zope.interface import implements
 from zope.publisher.interfaces import IPublishTraverse
-from plone import api
 
 
 class ParticipationTraverseService(Service):
@@ -45,6 +51,15 @@ class ParticipationTraverseService(Service):
             'token': token,
         }
 
+    def participants(self, context):
+        manager = ManageParticipants(context, self.request)
+        return manager.get_participants()
+
+    def find_participant(self, token, context):
+        for item in self.participants(context):
+            if item.get('token') == token:
+                return item
+
 
 class ParticipationsGet(ParticipationTraverseService):
     """API Endpoint which returns a list of all participants for the current
@@ -74,24 +89,16 @@ class ParticipationsGet(ParticipationTraverseService):
     def reply(self):
         token = self.read_params()
         if token:
-            return self.get_response_item(token)
+            return self.prepare_response_item(self.find_participant(
+                token, self.context.get_context_with_local_roles()))
         else:
             result = {}
             result['items'] = self.get_response_items()
             return result
 
     def get_response_items(self):
-        return [self.prepare_response_item(item) for item in self._items()]
-
-    def _items(self):
-        manager = ManageParticipants(
-            self.context.get_context_with_local_roles(), self.request)
-        return manager.get_participants()
-
-    def get_response_item(self, token):
-        for item in self._items():
-            if item.get('token') == token:
-                return self.prepare_response_item(item)
+        return [self.prepare_response_item(item) for item in
+                self.participants(self.context.get_context_with_local_roles())]
 
     def read_params(self):
         if len(self.params) == 1:
@@ -139,3 +146,53 @@ class ParticipationsPatch(ParticipationTraverseService):
             raise BadRequest('Missing parameter role')
 
         return data
+
+
+class ParticipationsPost(ParticipationTraverseService):
+
+    def reply(self):
+        # Disable CSRF protection
+        alsoProvides(self.request, IDisableCSRFProtection)
+
+        token, role = self.validate_data(json_body(self.request))
+
+        self.validate_participation(token, role)
+
+        assignment = SharingRoleAssignment(token, [role], self.context)
+        RoleAssignmentManager(self.context).add_or_update_assignment(assignment)
+
+        activity_manager = WorkspaceWatcherManager(self.context)
+        activity_manager.new_participant_added(token, role)
+
+        self.request.response.setStatus(201)
+        return self.prepare_response_item(self.find_participant(
+            token, self.context.get_context_with_local_roles()))
+
+    def validate_data(self, data):
+        token = data.get('token')
+        role = data.get('role')
+
+        if not token:
+            raise BadRequest('Missing parameter token')
+
+        if not role:
+            raise BadRequest('Missing parameter role')
+
+        return token, role
+
+    def validate_participation(self, token, role):
+        if not self.context.has_blocked_local_role_inheritance():
+            raise Forbidden(
+                "The participations are not managed in this context. "
+                "Please block the role inheritance before adding "
+                "new participants.")
+
+        if not self.find_participant(token, self.context.get_parent_with_local_roles()):
+            raise BadRequest('The participant is not allowed')
+
+        if self.find_participant(token, self.context.get_context_with_local_roles()):
+            raise BadRequest('The participant already exists')
+
+        if role not in PARTICIPATION_ROLES:
+            raise BadRequest('Role is not availalbe. Available roles are: {}'.format(
+                PARTICIPATION_ROLES.keys()))

--- a/opengever/api/participations.py
+++ b/opengever/api/participations.py
@@ -59,7 +59,7 @@ class ParticipationsGet(ParticipationTraverseService):
         member = api.user.get(userid=userid)
         return {
             '@id': '{}/@participations/{}'.format(
-                self.context.absolute_url(), userid),
+                self.context.get_context_with_local_roles().absolute_url(), userid),
             '@type': 'virtual.participations.user',
             'participant_fullname': participant.get('name'),
             'is_editable': participant.get('can_manage'),
@@ -84,7 +84,8 @@ class ParticipationsGet(ParticipationTraverseService):
         return [self.prepare_response_item(item) for item in self._items()]
 
     def _items(self):
-        manager = ManageParticipants(self.context, self.request)
+        manager = ManageParticipants(
+            self.context.get_context_with_local_roles(), self.request)
         return manager.get_participants()
 
     def get_response_item(self, token):

--- a/opengever/api/participations.py
+++ b/opengever/api/participations.py
@@ -117,17 +117,19 @@ class ParticipationsDelete(ParticipationTraverseService):
 class ParticipationsPatch(ParticipationTraverseService):
 
     def reply(self):
-        token = self.read_params()
-        data = self.validate_data(json_body(self.request))
+        participant = self.read_params()
+        data = json_body(self.request)
 
         role = data.get('role')
+        if isinstance(role, dict):
+            role = role.get("token")
 
         if not role:
             self.request.RESPONSE.setStatus(204)
             return None
 
         manager = ManageParticipants(self.context, self.request)
-        manager._modify(token, role.get('token'), 'user')
+        manager._modify(participant, role, 'user')
         return None
 
     def read_params(self):
@@ -136,16 +138,6 @@ class ParticipationsPatch(ParticipationTraverseService):
                 "Must supply token ID as URL path parameters.")
 
         return self.params[0]
-
-    def validate_data(self, data):
-        role = data.get('role')
-        if isinstance(role, dict):
-            role = role.get("token")
-
-        if not role:
-            raise BadRequest('Missing parameter role')
-
-        return data
 
 
 class ParticipationsPost(ParticipationTraverseService):

--- a/opengever/api/participations.py
+++ b/opengever/api/participations.py
@@ -118,8 +118,14 @@ class ParticipationsPatch(ParticipationTraverseService):
         token = self.read_params()
         data = self.validate_data(json_body(self.request))
 
+        role = data.get('role')
+
+        if not role:
+            self.request.RESPONSE.setStatus(204)
+            return None
+
         manager = ManageParticipants(self.context, self.request)
-        manager._modify(token, data.get('role').get('token'), 'user')
+        manager._modify(token, role.get('token'), 'user')
         return None
 
     def read_params(self):
@@ -130,8 +136,9 @@ class ParticipationsPatch(ParticipationTraverseService):
         return self.params[0]
 
     def validate_data(self, data):
-        if not data.get('role'):
-            raise BadRequest('Missing parameter role')
+        role = data.get('role', {})
+        if role and not role.get('token'):
+            raise BadRequest('Missing parameter token in role parameter')
 
         return data
 

--- a/opengever/api/role_inheritance.py
+++ b/opengever/api/role_inheritance.py
@@ -1,4 +1,7 @@
 from opengever.base.role_assignments import RoleAssignmentManager
+from opengever.base.role_assignments import SharingRoleAssignment
+from opengever.workspace.participation import WORKSPCAE_ADMIN
+from plone import api
 from plone.protect.interfaces import IDisableCSRFProtection
 from plone.restapi.deserializer import json_body
 from plone.restapi.services import Service
@@ -28,6 +31,7 @@ class RoleInheritancePost(RoleInheritanceBase):
 
         data = json_body(self.request)
         blocked = data.get('blocked')
+        copy_roles = data.get('copy_roles', False)
 
         if blocked is None:
             raise BadRequest('Must supply blocked in JSON body.')
@@ -37,7 +41,20 @@ class RoleInheritancePost(RoleInheritanceBase):
             return self._serialize_blocked()
 
         if blocked:
-            self._copy_assigments_from_parent_with_local_roles()
+            if copy_roles:
+                self._copy_assigments_from_parent_with_local_roles()
+            else:
+                parent_with_local_roles = self.context.get_parent_with_local_roles()
+                if WORKSPCAE_ADMIN.id in api.user.get_roles(obj=parent_with_local_roles):
+                    # If the current user is a workspace admin, we add it
+                    # as the only workspace admin for the context.
+                    self._add_current_user_as_admin_to_local_roles()
+                else:
+                    # It's a manager or someone else without direct permission
+                    # to this workpace. We don't want to add this user to the
+                    # workspace. So we add all current workspace admins as new
+                    # workspace admins.
+                    self._add_current_worskspace_admins_to_local_roles()
         else:
             self._delete_local_role_assignments()
 
@@ -53,3 +70,18 @@ class RoleInheritancePost(RoleInheritanceBase):
 
     def _delete_local_role_assignments(self):
         RoleAssignmentManager(self.context).clear_all()
+
+    def _add_current_user_as_admin_to_local_roles(self):
+        assignment = SharingRoleAssignment(
+            api.user.get_current().id,
+            [WORKSPCAE_ADMIN.id], self.context)
+        RoleAssignmentManager(self.context).add_or_update_assignment(assignment)
+
+    def _add_current_worskspace_admins_to_local_roles(self):
+        parent_with_local_roles = self.context.get_parent_with_local_roles()
+        roles_manager = RoleAssignmentManager(self.context)
+
+        for principal, roles in parent_with_local_roles.get_local_roles():
+            if WORKSPCAE_ADMIN.id in roles:
+                assignment = SharingRoleAssignment(principal, roles, self.context)
+                roles_manager.add_or_update_assignment(assignment)

--- a/opengever/api/tests/test_invitation.py
+++ b/opengever/api/tests/test_invitation.py
@@ -3,7 +3,6 @@ from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
 from ftw.testing import freeze
-from opengever.api.tests.test_participation import get_entry_by_token
 from opengever.testing import IntegrationTestCase
 from opengever.workspace.exceptions import DuplicatePendingInvitation
 from opengever.workspace.exceptions import MultipleUsersFound
@@ -11,6 +10,13 @@ from opengever.workspace.participation import WORKSPCAE_GUEST
 from opengever.workspace.participation.storage import IInvitationStorage
 from zope.component import getUtility
 import json
+
+
+def get_entry_by_token(entries, token):
+    for entry in entries:
+        if entry['token'] == token:
+            return entry
+    return None
 
 
 class TestInvitationsPost(IntegrationTestCase):

--- a/opengever/api/tests/test_participation.py
+++ b/opengever/api/tests/test_participation.py
@@ -332,6 +332,38 @@ class TestParticipationDelete(IntegrationTestCase):
                 headers=http_headers(),
             ).json
 
+    @browsing
+    def test_remove_local_roles_from_self_managed_folders_if_removed_in_upper_context(self, browser):
+        self.login(self.workspace_admin, browser=browser)
+
+        block_role_inheritance(self.workspace_folder, browser)
+
+        browser.open(
+            self.workspace.absolute_url() + '/@participations/{}'.format(self.workspace_guest.id),
+            method='DELETE',
+            headers=http_headers(),
+        )
+
+        browser.open(
+            self.workspace.absolute_url() + '/@participations',
+            method='GET',
+            headers=http_headers(),
+        )
+
+        self.assertIsNone(
+            get_entry_by_token(browser.json.get('items'), self.workspace_guest.getId()),
+            'Expect to have no local roles anymore for the user in the workspace')
+
+        browser.open(
+            self.workspace_folder.absolute_url() + '/@participations',
+            method='GET',
+            headers=http_headers(),
+        )
+
+        self.assertIsNone(
+            get_entry_by_token(browser.json.get('items'), self.workspace_guest.getId()),
+            'Expect to have no local roles anymore for the user in the folder')
+
 
 class TestParticipationPatch(IntegrationTestCase):
 

--- a/opengever/api/tests/test_participation.py
+++ b/opengever/api/tests/test_participation.py
@@ -16,7 +16,7 @@ def http_headers():
 
 def get_entry_by_token(entries, token):
     for entry in entries:
-        if entry['token'] == token:
+        if entry['participant']['token'] == token:
             return entry
     return None
 
@@ -56,38 +56,46 @@ class TestParticipationGet(IntegrationTestCase):
                 {
                     u'@id': u'http://nohost/plone/workspaces/workspace-1/@participations/beatrice.schrodinger',
                     u'@type': u'virtual.participations.user',
-                    u'participant_fullname': u'Schr\xf6dinger B\xe9atrice (beatrice.schrodinger)',
                     u'is_editable': True,
                     u'role': {u'token': u'WorkspaceMember',
                               u'title': u'Member'},
-                    u'token': 'beatrice.schrodinger',
+                    u'participant': {
+                        'token': 'beatrice.schrodinger',
+                        'title': u'Schr\xf6dinger B\xe9atrice (beatrice.schrodinger)',
+                    },
                     u'participant_email': u'beatrice.schrodinger@gever.local',
                 }, {
                     u'@id': u'http://nohost/plone/workspaces/workspace-1/@participations/fridolin.hugentobler',
                     u'@type': u'virtual.participations.user',
-                    u'participant_fullname': u'Hugentobler Fridolin (fridolin.hugentobler)',
                     u'is_editable': True,
                     u'role': {u'token': u'WorkspaceAdmin',
                               u'title': u'Admin'},
-                    u'token': 'fridolin.hugentobler',
+                    u'participant': {
+                        'token': 'fridolin.hugentobler',
+                        'title': u'Hugentobler Fridolin (fridolin.hugentobler)',
+                    },
                     u'participant_email': u'fridolin.hugentobler@gever.local',
                 }, {
                     u'@id': u'http://nohost/plone/workspaces/workspace-1/@participations/gunther.frohlich',
                     u'@type': u'virtual.participations.user',
-                    u'participant_fullname': u'Fr\xf6hlich G\xfcnther (gunther.frohlich)',
                     u'is_editable': False,
                     u'role': {u'token': u'WorkspaceAdmin',
                               u'title': u'Admin'},
-                    u'token': 'gunther.frohlich',
+                    u'participant': {
+                        'token': 'gunther.frohlich',
+                        'title': u'Fr\xf6hlich G\xfcnther (gunther.frohlich)',
+                    },
                     u'participant_email': u'gunther.frohlich@gever.local',
                 }, {
                     u'@id': u'http://nohost/plone/workspaces/workspace-1/@participations/hans.peter',
                     u'@type': u'virtual.participations.user',
-                    u'participant_fullname': u'Peter Hans (hans.peter)',
                     u'is_editable': True,
                     u'role': {u'token': u'WorkspaceGuest',
                               u'title': u'Guest'},
-                    u'token': 'hans.peter',
+                    u'participant': {
+                        'token': 'hans.peter',
+                        'title': u'Peter Hans (hans.peter)',
+                    },
                     u'participant_email': u'hans.peter@gever.local',
                 },
             ], response.get('items'))
@@ -227,8 +235,10 @@ class TestParticipationGet(IntegrationTestCase):
                 u'@id': u'http://nohost/plone/workspaces/workspace-1/@participations/hans.peter',
                 u'@type': u'virtual.participations.user',
                 u'is_editable': True,
-                u'participant_fullname': u'Peter Hans (hans.peter)',
-                u'token': 'hans.peter',
+                u'participant': {
+                    'token': 'hans.peter',
+                    'title': u'Peter Hans (hans.peter)',
+                },
                 u'role': {
                     'token': 'WorkspaceGuest',
                     'title': 'Guest',
@@ -553,8 +563,8 @@ class TestParticipationPost(IntegrationTestCase):
         self.assertIsNone(entry)
 
         data = {
-            "token": self.workspace_member.id,
-            "role": 'WorkspaceGuest'
+            "participant": {"token": self.workspace_member.id},
+            "role": {"token": 'WorkspaceGuest'},
         }
 
         browser.open(
@@ -580,8 +590,8 @@ class TestParticipationPost(IntegrationTestCase):
         self.login(self.workspace_admin, browser=browser)
 
         data = {
-            "token": self.workspace_member.id,
-            "role": 'WorkspaceGuest'
+            "participant": {"token": self.workspace_member.id},
+            "role": {"token": 'WorkspaceGuest'},
         }
 
         with browser.expect_http_error(403):
@@ -599,8 +609,8 @@ class TestParticipationPost(IntegrationTestCase):
         block_role_inheritance(self.workspace_folder, browser)
 
         data = {
-            "token": 'not-existing-user',
-            "role": 'WorkspaceGuest'
+            "participant": {"token": 'not-existing-user'},
+            "role": {"token": 'WorkspaceGuest'},
         }
 
         with browser.expect_http_error(400):
@@ -619,8 +629,8 @@ class TestParticipationPost(IntegrationTestCase):
         remove_participation(self.workspace_folder, browser, self.workspace_member.id)
 
         data = {
-            "token": self.workspace_member.id,
-            "role": 'Manager'
+            "participant": {"token": self.workspace_member.id},
+            "role": {"token": 'Manager'},
         }
 
         with browser.expect_http_error(400):
@@ -647,8 +657,8 @@ class TestParticipationPost(IntegrationTestCase):
         self.assertIsNotNone(entry)
 
         data = {
-            "token": self.workspace_member.id,
-            "role": 'WorkspaceGuest'
+            "participant": {"token": self.workspace_member.id},
+            "role": {"token": 'WorkspaceGuest'},
         }
 
         with browser.expect_http_error(400):
@@ -668,8 +678,8 @@ class TestParticipationPost(IntegrationTestCase):
         remove_participation(self.workspace_folder, browser, self.workspace_member.id)
 
         data = {
-            "token": self.workspace_member.id,
-            "role": 'WorkspaceGuest'
+            "participant": {"token": self.workspace_member.id},
+            "role": {"token": 'WorkspaceGuest'},
         }
 
         with browser.expect_http_error(400):

--- a/opengever/api/tests/test_participation.py
+++ b/opengever/api/tests/test_participation.py
@@ -245,6 +245,55 @@ class TestParticipationDelete(IntegrationTestCase):
             'Expect to have no local roles anymore for the user')
 
     @browsing
+    def test_delete_local_role_from_folder(self, browser):
+        self.login(self.workspace_admin, browser=browser)
+
+        browser.open(
+            self.workspace_folder,
+            view='/@role_inheritance',
+            data=json.dumps({'blocked': True}),
+            method='POST',
+            headers=self.api_headers)
+
+        browser.open(
+            self.workspace_folder.absolute_url() + '/@participations',
+            method='GET',
+            headers=http_headers(),
+        )
+
+        self.assertIsNotNone(
+            get_entry_by_token(browser.json.get('items'), self.workspace_guest.getId()),
+            'Expect to have local roles for the user')
+
+        browser.open(
+            self.workspace_folder.absolute_url() + '/@participations/{}'.format(self.workspace_guest.id),
+            method='DELETE',
+            headers=http_headers(),
+        )
+
+        self.assertEqual(204, browser.status_code)
+
+        browser.open(
+            self.workspace_folder.absolute_url() + '/@participations',
+            method='GET',
+            headers=http_headers(),
+        )
+
+        self.assertIsNone(
+            get_entry_by_token(browser.json.get('items'), self.workspace_guest.getId()),
+            'Expect to have no local roles anymore for the user')
+
+        browser.open(
+            self.workspace.absolute_url() + '/@participations',
+            method='GET',
+            headers=http_headers(),
+        )
+
+        self.assertIsNotNone(
+            get_entry_by_token(browser.json.get('items'), self.workspace_guest.getId()),
+            'Expect to still have local roles for the user on the workspace')
+
+    @browsing
     def test_current_user_cannot_remove_its_local_roles(self, browser):
         self.login(self.workspace_admin, browser=browser)
 

--- a/opengever/api/tests/test_participation.py
+++ b/opengever/api/tests/test_participation.py
@@ -183,6 +183,22 @@ class TestParticipationGet(IntegrationTestCase):
             'The admin should be able to manage {}'.format(self.workspace_guest.id))
 
     @browsing
+    def test_an_admin_can_only_edit_other_members_if_role_inheritance_is_blocked(self, browser):
+        self.login(self.workspace_admin, browser)
+
+        response = browser.open(
+            self.workspace_folder.absolute_url() + '/@participations',
+            method='GET',
+            headers=http_headers(),
+        ).json
+
+        items = response.get('items')
+
+        self.assertFalse(
+            get_entry_by_token(items, self.workspace_guest.id)['is_editable'],
+            'The admin should not be able to manage {}'.format(self.workspace_guest.id))
+
+    @browsing
     def test_user_without_sharing_permission_cannot_manage(self, browser):
         self.login(self.workspace_member, browser)
 

--- a/opengever/api/tests/test_participation.py
+++ b/opengever/api/tests/test_participation.py
@@ -77,6 +77,49 @@ class TestParticipationGet(IntegrationTestCase):
             ], response.get('items'))
 
     @browsing
+    def test_list_all_current_participants_in_folder_lists_participants_of_the_workspace(self, browser):
+        self.login(self.workspace_owner, browser)
+
+        response = browser.open(
+            self.workspace_folder.absolute_url() + '/@participations',
+            method='GET',
+            headers=http_headers(),
+        ).json
+
+        self.assertItemsEqual(
+            [
+                u'http://nohost/plone/workspaces/workspace-1/@participations/beatrice.schrodinger',
+                u'http://nohost/plone/workspaces/workspace-1/@participations/fridolin.hugentobler',
+                u'http://nohost/plone/workspaces/workspace-1/@participations/gunther.frohlich',
+                u'http://nohost/plone/workspaces/workspace-1/@participations/hans.peter',
+            ], [item.get('@id') for item in response.get('items')])
+
+    @browsing
+    def test_list_all_folder_participants_with_blocked_role_inheritance_in_folder(self, browser):
+        self.login(self.workspace_owner, browser)
+
+        browser.open(
+            self.workspace_folder,
+            view='/@role_inheritance',
+            data=json.dumps({'blocked': True}),
+            method='POST',
+            headers=self.api_headers)
+
+        response = browser.open(
+            self.workspace_folder.absolute_url() + '/@participations',
+            method='GET',
+            headers=http_headers(),
+        ).json
+
+        self.assertItemsEqual(
+            [
+                u'http://nohost/plone/workspaces/workspace-1/folder-1/@participations/beatrice.schrodinger',
+                u'http://nohost/plone/workspaces/workspace-1/folder-1/@participations/fridolin.hugentobler',
+                u'http://nohost/plone/workspaces/workspace-1/folder-1/@participations/gunther.frohlich',
+                u'http://nohost/plone/workspaces/workspace-1/folder-1/@participations/hans.peter',
+            ], [item.get('@id') for item in response.get('items')])
+
+    @browsing
     def test_admin_cannot_edit_himself(self, browser):
         self.login(self.workspace_owner, browser)
 

--- a/opengever/api/tests/test_vocabularies.py
+++ b/opengever/api/tests/test_vocabularies.py
@@ -51,6 +51,7 @@ NON_SENSITIVE_VOCABUALRIES = [
     'opengever.tasktemplates.active_tasktemplatefolders',
     'opengever.tasktemplates.ResponsibleOrgUnitVocabulary',
     'opengever.tasktemplates.tasktemplates',
+    'opengever.workspace.PossibleWorkspaceFolderParticipantsVocabulary',
     'opengever.workspace.RolesVocabulary',
     'plone.app.content.ValidAddableTypes',
     'plone.app.controlpanel.WickedPortalTypes',

--- a/opengever/workspace/base.py
+++ b/opengever/workspace/base.py
@@ -8,6 +8,14 @@ class WorkspaceBase(Container):
     def has_blocked_local_role_inheritance(self):
         return getattr(self, '__ac_local_roles_block__', False)
 
+    def get_context_with_local_roles(self):
+        """Returns the context which defines the local roles for the current
+        context.
+        """
+        if not self.has_blocked_local_role_inheritance():
+            return self.get_parent_with_local_roles()
+        return self
+
     def get_parent_with_local_roles(self):
         parent = aq_parent(aq_inner(self))
         if parent.has_blocked_local_role_inheritance():

--- a/opengever/workspace/configure.zcml
+++ b/opengever/workspace/configure.zcml
@@ -57,6 +57,11 @@
       name="opengever.workspace.RolesVocabulary"
       />
 
+  <utility
+      factory=".vocabularies.PossibleWorkspaceFolderParticipantsVocabulary"
+      name="opengever.workspace.PossibleWorkspaceFolderParticipantsVocabulary"
+      />
+
   <plone:service
       method="PATCH"
       for="opengever.workspace.interfaces.IWorkspace"

--- a/opengever/workspace/participation/browser/manage_participants.py
+++ b/opengever/workspace/participation/browser/manage_participants.py
@@ -40,9 +40,10 @@ class ManageParticipants(BrowserView):
 
         for userid, roles in self.context.get_local_roles():
             member = api.user.get(userid=userid)
-            if member is not None:
+            managed_roles = list(set(roles) & set(MANAGED_ROLES))
+            if member is not None and managed_roles:
                 item = dict(token=userid,
-                            roles=list(set(roles) & set(MANAGED_ROLES)),
+                            roles=managed_roles,
                             can_manage=can_manage_member(self.context, member, roles),
                             type_='user',
                             name=get_full_user_info(member=member),

--- a/opengever/workspace/tests/test_vocabularies.py
+++ b/opengever/workspace/tests/test_vocabularies.py
@@ -1,6 +1,8 @@
+from ftw.testbrowser import browsing
 from opengever.testing import IntegrationTestCase
 from zope.component import getUtility
 from zope.schema.interfaces import IVocabularyFactory
+import json
 
 
 class TestRolesVocabulary(IntegrationTestCase):
@@ -12,3 +14,37 @@ class TestRolesVocabulary(IntegrationTestCase):
         self.assertItemsEqual(
             ['Admin', 'Member', 'Guest'],
             [term.title for term in factory(context=self.portal)])
+
+
+class TestPossibleWorkspaceFolderParticipantsVocabulary(IntegrationTestCase):
+
+    def test_vocabulary_lists_an_empty_list_if_not_on_a_folder(self):
+        self.login(self.workspace_owner)
+        factory = getUtility(IVocabularyFactory,
+                             name='opengever.workspace.PossibleWorkspaceFolderParticipantsVocabulary')
+        self.assertItemsEqual(
+            [],
+            [term.token for term in factory(context=self.workspace)])
+
+    @browsing
+    def test_vocabulary_returns_a_list_of_possible_participants(self, browser):
+        self.login(self.workspace_admin, browser)
+
+        # Only the workspace admin will be participating on the workspace folder
+        # after blocking role inheritance without copying the roles.
+        browser.open(
+            self.workspace_folder,
+            view='/@role-inheritance',
+            data=json.dumps({'blocked': True, 'copy_roles': False}),
+            method='POST',
+            headers=self.api_headers)
+
+        factory = getUtility(IVocabularyFactory,
+                             name='opengever.workspace.PossibleWorkspaceFolderParticipantsVocabulary')
+
+        self.assertItemsEqual(
+            [self.workspace_member.id, self.workspace_owner.id, self.workspace_guest.id],
+            [term.token for term in factory(context=self.workspace_folder)],
+            "The vocabulary should return only the possible participants, not "
+            "all. The workspace admin is already a member of the current "
+            "folder. It should be excluded")

--- a/opengever/workspace/vocabularies.py
+++ b/opengever/workspace/vocabularies.py
@@ -1,10 +1,12 @@
+from opengever.workspace.interfaces import IWorkspaceFolder
 from opengever.workspace.participation import PARTICIPATION_ROLES
+from opengever.workspace.participation.browser.manage_participants import ManageParticipants
 from Products.CMFPlone.utils import safe_unicode
+from zope.globalrequest import getRequest
 from zope.interface import implementer
 from zope.schema.interfaces import IVocabularyFactory
 from zope.schema.vocabulary import SimpleTerm
 from zope.schema.vocabulary import SimpleVocabulary
-from zope.globalrequest import getRequest
 
 
 @implementer(IVocabularyFactory)
@@ -19,5 +21,38 @@ class RolesVocabulary(object):
                                     token=role.id,
                                     title=safe_unicode(
                                         role.translated_title(getRequest()))))
+
+        return SimpleVocabulary(terms)
+
+
+@implementer(IVocabularyFactory)
+class PossibleWorkspaceFolderParticipantsVocabulary(object):
+    """This vocabulary is used in a workspace folder to get the available
+    participations based on the participations in the parent folder or
+    workspace.
+
+    A workspace folder can block role inheritance. Only participants from the
+    parent folder are allowed to add as new participant in a folder.
+    """
+    def __call__(self, context):
+        if not IWorkspaceFolder.providedBy(context):
+            return SimpleVocabulary([])
+
+        terms = []
+
+        parent_manager = ManageParticipants(context.get_parent_with_local_roles(), context.REQUEST)
+        context_manager = ManageParticipants(context.get_context_with_local_roles(), context.REQUEST)
+
+        context_participants = [participant.get('token') for participant
+                                in context_manager.get_participants()]
+        for participant in parent_manager.get_participants():
+            if participant.get('token') in context_participants:
+                # Participant already participated.
+                continue
+
+            terms.append(SimpleTerm(value=participant.get('token'),
+                                    token=participant.get('token'),
+                                    title=safe_unicode(
+                                        participant.get('name'))))
 
         return SimpleVocabulary(terms)


### PR DESCRIPTION
Issuer: #6167 

Dieser PR ist ein Follow UP von https://github.com/4teamwork/opengever.core/pull/6190.

Der PR implementiert:

- [x] GET, PATCH und POST @participations endpoints für workspace-folder
- [x] wird eine Beteiligung gelöscht, wird diese Beteiligung ebenfalls in Unterordner gelöscht.
- [x] der POST @role-inheritance Endpoint erhält eine neue option: copy-roles. Per default werden die Rollen nun nicht mehr kopiert, sondern nur die des aktuellen Benutzers wenn dieser ein Workspace Admin ist. Ansonsten (z.B. globaler Manager) werden alle Workspace Admins kopiert.
- [x] neues Vocabulary für alle möglichen Workspace Folder Beteiligungen (PossibleWorkspaceFolderParticipantsVocabulary)
- [x] der `role` Parameter beim PATCH @participations ist neu optional

## Checkliste

_Zutreffendes soll angehakt stehengelassen werden._
- [x] Changelog-Eintrag vorhanden/nötig?
- [x] Aktualisierung Dokumentation vorhanden/nötig?
