### PR TITLE
Await solr to be restored when tearing down test layers

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2019.5.1 (unreleased)
 ---------------------
 
+- When tearing down test layer, wait for solr to be torn down properly. [siegy]
 - Configure Solr replication handler. [buchi]
 - Implement @role-inheritance serivce endpoint for workspace folders. [deiferni]
 - Include permissions.zcml of Products.CMFEditions. [lgraf]

--- a/opengever/core/testing.py
+++ b/opengever/core/testing.py
@@ -618,14 +618,12 @@ class GEVERIntegrationTesting(FTWIntegrationTesting):
     def testSetUp(self):
         super(GEVERIntegrationTesting, self).testSetUp()
         logout()
-        client = SolrReplicationAPIClient.get_instance()
-        if client._configured:
-            client.await_restored()
 
     def testTearDown(self):
         client = SolrReplicationAPIClient.get_instance()
         if client._configured:
             client.restore_backup('fixture')
+            client.await_restored()
         super(GEVERIntegrationTesting, self).testTearDown()
 
 

--- a/opengever/core/testserver.py
+++ b/opengever/core/testserver.py
@@ -133,11 +133,11 @@ class TestServerFunctionalTesting(FunctionalTesting):
         self.context_manager = self.isolation()
         self.context_manager.__enter__()
         transaction.commit()
-        SolrReplicationAPIClient.get_instance().await_restored()
 
     def testTearDown(self):
         self.context_manager.__exit__(None, None, None)
         SolrReplicationAPIClient.get_instance().restore_backup('fixture')
+        SolrReplicationAPIClient.get_instance().await_restored()
         super(TestServerFunctionalTesting, self).testTearDown()
 
 


### PR DESCRIPTION
Instead of waiting for solr to have restored a backup when setting up the
testlayer, properly tear it down by waiting for solr to be finished restoring.

A symptom of this issue was, that solr logged:
"Restore in progress. Cannot run multiple restore operationsfor the same core":

See https://ci.4teamwork.ch/builds/302050/tasks/496604

This needs to be backported to 2019.4.x, 2019.5.x and 2019.6.x as we test against these versions in RIS.

