### PR TITLE
Speed up validation of dossier resolution preconditions.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 
 - Add documentation for sharing endpoint. [njohner]
 - Always request UID from solr, as it is needed for snippets. [njohner]
+- Speed up validation of dossier resolution preconditions. [njohner]
 
 
 2020.1.0rc1 (2020-01-30)

--- a/opengever/dossier/base.py
+++ b/opengever/dossier/base.py
@@ -307,13 +307,13 @@ class DossierContainer(Container):
         """Check if the enddate is valid.
         """
         dossier = IDossier(self)
-        end_date = self.earliest_possible_end_date()
 
         # no enddate is valid because it would be overwritten
         # with the earliest_possible_end_date
         if dossier.end is None:
             return True
 
+        end_date = self.earliest_possible_end_date()
         if end_date:
             # Dossier end date needs to be older
             # than the earliest possible end_date

--- a/opengever/dossier/base.py
+++ b/opengever/dossier/base.py
@@ -288,7 +288,6 @@ class DossierContainer(Container):
         docs = self.portal_catalog(
             portal_type="opengever.document.document",
             path=dict(
-                depth=2,
                 query='/'.join(self.getPhysicalPath()),
                 ),
             )

--- a/opengever/dossier/resolve.py
+++ b/opengever/dossier/resolve.py
@@ -227,33 +227,38 @@ class DossierResolveView(BrowserView, DossierResolutionStatusmessageMixin):
 
         resolve_manager = LockingResolveManager(self.context)
 
-        # Validate preconditions early. This is so we don't redirect to the
-        # archive form (if filing number feature enabled) in a case where
-        # it will fail anyway because of violated preconditions.
-        #
-        # XXX: This will validate preconditions *twice* though (the second
-        # time via resolve_manager.resolve()). This should eventually be
-        # cleaned up so we don't unnecessarily validate preconditions multiple
-        # times.
+        # If filing number feature is enabled, we redirect to an additional
+        # archive form that needs to be filled out first. The actual resolving
+        # will then be triggered from that form.
+        if resolve_manager.is_archive_form_needed():
+            # Validate preconditions early. This is so we don't redirect to the
+            # archive form (if filing number feature enabled) in a case where
+            # it will fail anyway because of violated preconditions.
+            #
+            # XXX: This will validate preconditions *thrice* though (the second
+            # time in the archiv form and then via resolve_manager.resolve()).
+            # This should eventually be cleaned up so we don't unnecessarily
+            # validate preconditions multiple times.
+            try:
+                resolve_manager.resolver.raise_on_failed_preconditions()
+
+            except PreconditionsViolated as exc:
+                return self.show_errors(exc.errors)
+
+            except InvalidDates as exc:
+                return self.show_invalid_end_dates(titles=exc.invalid_dossier_titles)
+
+            archive_url = '/'.join((self.context_url, 'transition-archive'))
+            return self.redirect(archive_url)
+
         try:
-            resolve_manager.resolver.raise_on_failed_preconditions()
+            resolve_manager.resolve()
 
         except PreconditionsViolated as exc:
             return self.show_errors(exc.errors)
 
         except InvalidDates as exc:
             return self.show_invalid_end_dates(titles=exc.invalid_dossier_titles)
-
-        # If filing number feature is enabled, we redirect to an additional
-        # archive form that needs to be filled out first. The actual resolving
-        # will then be triggered from that form.
-        if resolve_manager.is_archive_form_needed():
-            archive_url = '/'.join((self.context_url, 'transition-archive'))
-            return self.redirect(archive_url)
-
-        # All good, proceed with resolving the dossier.
-        try:
-            resolve_manager.resolve()
 
         except AlreadyBeingResolved:
             return self.show_being_resolved_msg()

--- a/opengever/dossier/resolve.py
+++ b/opengever/dossier/resolve.py
@@ -621,7 +621,6 @@ class ResolveConditions(object):
         return self._invalid_dates
 
     def _recursive_date_validation(self, dossier, main=True):
-
         if not main:
             # check end_date
             # If a dossier is already resolved, but seems to have an invalid
@@ -633,7 +632,7 @@ class ResolveConditions(object):
                 self._invalid_dates.append(dossier.title)
 
         # recursively check subdossiers
-        subdossiers = dossier.get_subdossiers()
+        subdossiers = dossier.get_subdossiers(depth=1)
         for sub in subdossiers:
             sub = sub.getObject()
             self._recursive_date_validation(sub, main=False)

--- a/opengever/dossier/tests/test_resolve.py
+++ b/opengever/dossier/tests/test_resolve.py
@@ -1329,6 +1329,22 @@ class TestResolveConditions(IntegrationTestCase, ResolveTestHelper):
                            ['not all documents are checked in'])
 
     @browsing
+    def test_resolving_is_cancelled_when_documents_in_subsubdossiers_are_checked_out(self, browser):
+        self.login(self.secretariat_user, browser)
+
+        subsubdossier = create(Builder('dossier')
+                               .within(self.resolvable_subdossier))
+        subsubdocument = create(Builder('document').within(subsubdossier))
+
+        self.checkout_document(subsubdocument)
+
+        self.resolve(self.resolvable_dossier, browser)
+
+        self.assert_not_resolved(self.resolvable_dossier)
+        self.assert_errors(self.resolvable_dossier, browser,
+                           ['not all documents are checked in'])
+
+    @browsing
     def test_resolving_is_cancelled_when_active_tasks_exist(self, browser):
         self.login(self.secretariat_user, browser)
 


### PR DESCRIPTION
This is for https://extranet.4teamwork.ch/support/gever-st-gallen/tracker/908

It seems that checking the preconditions for resolving a dossier can be very slow. After inspecting the code I found:
- A bug in the recursion in `ResolveConditions.check_end_dates`, which led to visiting certain objects several times and hence calculating the `earliest_possible_enddate` several times per object in the main dossier.
- A bug in `ResolveConditions.is_all_checked_in`, which only checked documents in the main dossier and within to a depth of 2.

I corrected these two bugs and optimised `DossierContainer.has_valid_enddate` to only calculate `earliest_possible_end_date` when necessary, which is probably almost never in most cases.

This should speed up the precondition calculation quite a bit and I also ensured that the preconditions are only calculated once in the `DossierResolveView`.

## Checkliste
- [x] Changelog-Eintrag vorhanden/nötig?