### PR TITLE
Fix volatile related proposal documents.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2020.1.0 (unreleased)
 ---------------------
 
+- Fix volatile related proposal documents. [elioschmutz]
 - Add new_document_from_task file_action. [lgraf]
 - When tearing down test layer, wait for solr to be torn down properly. [siegy]
 - Configure Solr replication handler. [buchi]

--- a/opengever/core/upgrades/20200122154137_fix_missing_related_proposal_documents/upgrade.py
+++ b/opengever/core/upgrades/20200122154137_fix_missing_related_proposal_documents/upgrade.py
@@ -1,0 +1,52 @@
+from ftw.upgrade import UpgradeStep
+from opengever.meeting.model import SubmittedDocument
+from z3c.relationfield.relation import RelationValue
+from zope.component import getUtility
+from zope.intid.interfaces import IIntIds
+import logging
+
+logger = logging.getLogger('opengever.core')
+
+
+class FixMissingRelatedProposalDocuments(UpgradeStep):
+    """Fix missing related proposal documents.
+    """
+
+    deferrable = True
+
+    def __call__(self):
+        self.install_upgrade_profile()
+
+        updated_proposals = []
+        updated_documents = 0
+
+        submitted_documents = SubmittedDocument.query.all()
+
+        # The postgres db still contains all the relations between documents and
+        # proposals. We iterate over each submitted document relation in the
+        # postgres db and look if the proposal have the document in the related
+        # items. If not, we add it.
+        #
+        # Submitted proposals are not affected by this issue.
+        for submitted_document in submitted_documents:
+            proposal = submitted_document.proposal.resolve_proposal()
+            source_document = submitted_document.resolve_source()
+
+            if source_document not in self.lookup_relations(proposal):
+                proposal.relatedItems.append(self.get_intid(source_document))
+                proposal._p_changed = 1
+
+                # For loggin
+                updated_documents += 1
+                if proposal not in updated_proposals:
+                    updated_proposals.append(proposal)
+
+        logger.info(
+            "Fixed {} proposals by adding {} missing document relations".format(
+                len(updated_proposals), updated_documents))
+
+    def lookup_relations(self, obj):
+        return [rel.to_object for rel in obj.relatedItems]
+
+    def get_intid(self, obj):
+        return RelationValue(getUtility(IIntIds).getId(obj))

--- a/opengever/meeting/proposal.py
+++ b/opengever/meeting/proposal.py
@@ -591,6 +591,10 @@ class Proposal(Container, ProposalBase):
             self.relatedItems.append(
                 RelationValue(getUtility(IIntIds).getId(document)))
 
+            # We have to manually notfiy the ZODB about the changed relatedItems.
+            # https://zodb.readthedocs.io/en/latest/working.html#handling-changes-to-mutable-objects
+            self._p_changed = 1
+
         command.execute()
         return command
 


### PR DESCRIPTION
# Problem
Zusätzlich eingereichte Dokumente für einen Antrag verschwinden nach einem Reload im Antrag und erscheinen später wieder

![72603065-9f219d00-3918-11ea-958b-f344a6f78c5e](https://user-images.githubusercontent.com/557005/72902173-4e9cac00-3d2b-11ea-85bf-05ca927ddba3.gif)

# Analyse
Zope stellt mehrere Threads pro Instanz zur Verfügung. Jeder Thread wiederum hat Zugriff auf ein Pool von ZODB-Verbindungen. 

Wenn wir nun einen Antrag mit einem Dokument als Beilage erstellen, einreichen und anschließend ein zusätzliches Dokument einreichen, erhalten wir für den gleichen Thread verschiedene Objekte der `relatedItems`. Einmal mit nur einem Dokument und einmal mit zwei Dokumenten:

<img width="398" alt="Bildschirmfoto 2020-01-22 um 12 37 43" src="https://user-images.githubusercontent.com/557005/72902383-a9360800-3d2b-11ea-99cc-e76e0f41624a.png">

Das bedeutet, je nachdem, welche DB-Verbindung der Thread verwendet, wird ihm die aktuelle Version oder eine veraltete Version des Objektes zurückgegeben. Dies wiederum bedeutet, dass die Änderungen am Objekt nicht in die DB gespeichert werden. Das können wir überprüfen, indem wir den DB-Cache leeren und die Seite erneut laden:

![screen1](https://user-images.githubusercontent.com/557005/72902861-77717100-3d2c-11ea-9134-7be7974ea5e8.gif)

Die zusätzlich eingereichten Dokumenten sind nun nicht mehr als Relation im Antrag gespeichert, weil diese nie in der DB gespeichert wurden, sondern lediglich im Cache.

# Lösung
Die ZODB stellt ein spezielles Attribut für solche Fälle zur Verfügung. Siehe [Handling changes to mutable objects](https://zodb.readthedocs.io/en/latest/working.html#handling-changes-to-mutable-objects). Wir müssen das Objekt als `_p_changed` markieren, damit die Änderungen am Mutable in die DB gespeichert werden.

![screen2](https://user-images.githubusercontent.com/557005/72903211-22822a80-3d2d-11ea-84fe-57f8f5b6dd4f.gif)

✅ Weil die Relationen in der PostgresDB gespeichert sind, können wir alle Relationen wiederherstellen. Wir haben somit keinen Datenverlust.

⚠️ Der Upgradestep fügt nicht mehr vorhandene Relationen wieder hinzu. Gibt es dabei etwas zu beachten? Gibt es Anträge, welche nicht nachträglich bearbeitet werden dürfen? Oder Relationen welche nicht mehr funktionieren? Braucht es ein spezielles Error-Handling für Prod-Systeme?

## Checkliste

_Zutreffendes soll angehakt stehengelassen werden._

- [x] Sind UpgradeSteps `deferrable`, oder können gewisse Schritte des Upgrades konditional ausgeführt werden?
- [x] Changelog-Eintrag vorhanden/nötig?

Related to #3368 but does not solve it