### PR TITLE
Add 'filing_no' field to Solr schema.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2020.1.0 (unreleased)
 ---------------------
 
+- Add 'filing_no' field to Solr schema. [lgraf]
 - Fix volatile related proposal documents. [elioschmutz]
 - Add a button to create a task from a proposal. [elioschmutz]
 - Allow to unlock and edit submitted documents in a submitted proposal. [elioschmutz]

--- a/solr-conf/managed-schema
+++ b/solr-conf/managed-schema
@@ -143,6 +143,7 @@
     <field name="file_extension" type="string" indexed="true" stored="false" />
     <field name="filename" type="string" indexed="true" stored="false" />
     <field name="filesize" type="pint" indexed="true" stored="false" />
+    <field name="filing_no" type="string" indexed="true" stored="false" />
     <field name="firstname" type="string" indexed="true" stored="false" />
     <field name="has_sametype_children" type="boolean" indexed="false" stored="true" />
     <field name="is_subdossier" type="boolean" indexed="true" stored="false" />


### PR DESCRIPTION
Adds `filing_no` field to Solr schema.

Tested:
- Installations without the `IFilingNumber` behavior don't index anything into Solr, and search / sorting still works
- Sorting by filing number works for deployments with the activated behavior

Reindexing of the `filing_no` field in Solr for deployments that actually need it can be done as follows:
`http://localhost:8080/plone/@@solr-maintenance/reindex?idxs:list=filing_no`

Addresses #6203 

## Checkliste

- [x] Changelog-Eintrag vorhanden/nötig?

