### PR TITLE
Add upgrade step to correct public_trial_statement type.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 ---------------------
 
 - Add 'filing_no' field to Solr schema. [lgraf]
+- Add upgrade step to correct public_trial_statement type. [njohner]
 - Fix volatile related proposal documents. [elioschmutz]
 - Add a button to create a task from a proposal. [elioschmutz]
 - Allow to unlock and edit submitted documents in a submitted proposal. [elioschmutz]

--- a/opengever/core/upgrades/20200124171823_correct_public_trial_statement_type/upgrade.py
+++ b/opengever/core/upgrades/20200124171823_correct_public_trial_statement_type/upgrade.py
@@ -1,0 +1,39 @@
+from Acquisition import aq_base
+from DateTime import DateTime
+from ftw.upgrade import UpgradeStep
+from Products.CMFDiffTool.utils import safe_utf8
+import pkg_resources
+
+
+class CorrectPublicTrialStatementType(UpgradeStep):
+    """Correct public_trial_statement type.
+
+    On some older objects public_trial_statement is saved as unicode
+    on the object which will lead to errors if it contains non ASCII
+    characters.
+    We did not determine in which commit this was fixed and even
+    then we would still need to find out for each deployment when that
+    fix was introduced. Nevertheless we only fix objects older than 2016
+    as this seems to be a problem only for Zug, and it seems the issue was
+    fixed there mid 2015.
+    """
+
+    deferrable = True
+
+    def __call__(self):
+        # we only run this upgrade for Zug for now.
+        try:
+            pkg_resources.get_distribution('opengever.zug')
+        except pkg_resources.DistributionNotFound:
+            return
+
+        query = {'portal_type': ['opengever.document.document', 'ftw.mail.mail'],
+                 'created': {'query': DateTime('2016-01-01'),
+                             'range': 'max'}}
+
+        for obj in self.objects(query, 'Correct public_trial_statement type'):
+            # We only need to correct the field if it is not empty and this way
+            # we avoid casting None to a string.
+            pts_value = getattr(aq_base(obj), 'public_trial_statement', None)
+            if pts_value and isinstance(pts_value, unicode):
+                obj.public_trial_statement = safe_utf8(pts_value)


### PR DESCRIPTION
On some older objects public_trial_statement is saved as unicode on the object which will lead to errors if it contains non ASCII characters. We did not determine in which commit this was fixed and even then we would still need to find out for each deployment when that fix was introduced. Nevertheless we only fix objects older than 2016 as this seems to be a problem only for Zug, and it seems the issue was fixed there mid 2015.

for https://github.com/4teamwork/opengever.core/issues/6204

## Checkliste

- [x] Gibt es neue Funktionalität mit einem `Dokument`? Funktioniert das auch mit einem `Mail`?
- [x] Sind UpgradeSteps `deferrable`, oder können gewisse Schritte des Upgrades konditional ausgeführt werden?
- [x] Changelog-Eintrag vorhanden/nötig?