### PR TITLE
Always request UID from solr as it is needed for snippets.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 ------------------------
 
 - Add documentation for sharing endpoint. [njohner]
+- Always request UID from solr, as it is needed for snippets. [njohner]
 
 
 2020.1.0rc1 (2020-01-30)

--- a/opengever/api/listing.py
+++ b/opengever/api/listing.py
@@ -1,4 +1,5 @@
 from ftw.solr.query import escape
+from opengever.api.solr_query_service import REQUIRED_RESPONSE_FIELDS as DEFAULT_REQUIRED_RESPONSE_FIELDS
 from opengever.api.solr_query_service import SolrQueryBaseService
 from opengever.base.interfaces import ISearchSettings
 from plone.registry.interfaces import IRegistry
@@ -77,7 +78,7 @@ FILTERS = {
 }
 
 
-REQUIRED_RESPONSE_FIELDS = set(['@id'])
+REQUIRED_RESPONSE_FIELDS = DEFAULT_REQUIRED_RESPONSE_FIELDS.union(set(['@id']))
 
 
 def with_active_solr_only(func):

--- a/opengever/api/listing.py
+++ b/opengever/api/listing.py
@@ -186,8 +186,8 @@ class Listing(SolrQueryBaseService):
         }
 
         self.facets = [facet for facet in params.get('facets', [])
-                       if self.is_field_allowed(facet) and
-                       self.get_field_index(facet) in self.solr_fields]
+                       if self.is_field_allowed(facet)
+                       and self.get_field_index(facet) in self.solr_fields]
         facet_fields = map(self.get_field_index, self.facets)
 
         if facet_fields:

--- a/opengever/api/solr_query_service.py
+++ b/opengever/api/solr_query_service.py
@@ -332,8 +332,8 @@ class SolrQueryBaseService(Service):
         else:
             requested_fields = self.default_fields
 
-        self.response_fields = (set(requested_fields) |
-                                self.required_response_fields)
+        self.response_fields = (set(requested_fields)
+                                | self.required_response_fields)
 
         requested_solr_fields = set([])
         for field_name in self.response_fields:

--- a/opengever/api/solr_query_service.py
+++ b/opengever/api/solr_query_service.py
@@ -189,6 +189,9 @@ DEFAULT_FIELDS = set([
     'review_state',
 ])
 
+# UID is necessary when requesting snippets
+REQUIRED_RESPONSE_FIELDS = set(['UID'])
+
 FIELDS_WITH_MAPPING = [
     ListingField('checked_out', 'checked_out', transform=display_name),
     ListingField('bumblebee_checksum', 'bumblebee_checksum', sort_index=DEFAULT_SORT_INDEX),
@@ -245,7 +248,7 @@ class SolrQueryBaseService(Service):
     field_mapping = {field.field_name: field for field in FIELDS_WITH_MAPPING}
 
     default_fields = DEFAULT_FIELDS
-    required_response_fields = set()
+    required_response_fields = REQUIRED_RESPONSE_FIELDS
 
     def __init__(self, context, request):
         super(SolrQueryBaseService, self).__init__(context, request)

--- a/opengever/api/tests/test_listing.py
+++ b/opengever/api/tests/test_listing.py
@@ -1,7 +1,6 @@
 from ftw.bumblebee.tests.helpers import DOCX_CHECKSUM
 from ftw.testbrowser import browsing
 from mock import Mock
-from opengever.api.listing import get_path_depth
 from opengever.api.solr_query_service import filename
 from opengever.api.solr_query_service import filesize
 from opengever.base.solr import OGSolrContentListingObject
@@ -270,6 +269,7 @@ class TestListingWithRealSolr(SolrIntegrationTestCase):
 
         self.assertEqual(
             {u'@id': self.document.absolute_url(),
+             u'UID': IUUID(self.document),
              u'filesize': self.document.file.size,
              u'filename': u'Vertraegsentwurf.docx'},
             browser.json['items'][-1])
@@ -417,6 +417,7 @@ class TestListingWithRealSolr(SolrIntegrationTestCase):
 
         self.assertDictEqual(
             {u'@id': u'http://nohost/plone/workspaces/workspace-1',
+             u'UID': IUUID(self.workspace),
              u'title': u'A Workspace',
              u'description': u'A Workspace description'},
             browser.json['items'][-1])
@@ -434,6 +435,7 @@ class TestListingWithRealSolr(SolrIntegrationTestCase):
 
         self.assertDictEqual(
             {u'@id': u'http://nohost/plone/workspaces/workspace-1/folder-1',
+             u'UID': IUUID(self.workspace_folder),
              u'title': u'WS F\xc3lder',
              u'description': u'A Workspace folder description'},
             browser.json['items'][-1])
@@ -643,18 +645,21 @@ class TestListingWithRealSolr(SolrIntegrationTestCase):
             [
                 {
                     u'@id': u'http://nohost/plone/workspaces/workspace-1/todo-1',
+                    u'UID': IUUID(self.todo),
                     u'completed': False,
                     u'deadline': u'2016-09-01T00:00:00Z',
                     u'responsible': None,
                     u'title': u'Fix user login'},
                 {
                     u'@id': u'http://nohost/plone/workspaces/workspace-1/todolist-2/todo-3',
+                    u'UID': IUUID(self.completed_todo),
                     u'completed': True,
                     u'deadline': u'2016-09-02T00:00:00Z',
                     u'responsible': u'beatrice.schrodinger',
                     u'title': u'Cleanup installation'},
                 {
                     u'@id': u'http://nohost/plone/workspaces/workspace-1/todolist-2/todo-2',
+                    u'UID': IUUID(self.assigned_todo),
                     u'completed': False,
                     u'deadline': u'2016-12-01T00:00:00Z',
                     u'responsible': u'beatrice.schrodinger',

--- a/opengever/api/tests/test_solrsearch.py
+++ b/opengever/api/tests/test_solrsearch.py
@@ -77,12 +77,13 @@ class TestSolrSearchGet(SolrIntegrationTestCase):
         url = u'{}/@solrsearch'.format(self.portal.absolute_url())
         browser.open(url, method='GET', headers=self.api_headers)
 
-        self.assertEqual([u'review_state',
-                          u'title',
-                          u'@id',
-                          u'@type',
-                          u'description'],
-                         browser.json["items"][0].keys())
+        self.assertItemsEqual([u'review_state',
+                               u'title',
+                               u'@id',
+                               u'UID',
+                               u'@type',
+                               u'description'],
+                              browser.json["items"][0].keys())
 
     @browsing
     def test_blacklisted_attributes_are_skipped(self, browser):

--- a/opengever/core/testserver_selftest.py
+++ b/opengever/core/testserver_selftest.py
@@ -106,7 +106,8 @@ class TestserverSelftest(object):
             browser.open(self.plone_url + '@solrsearch?fq=id:document-1&fl=id,bumblebee_checksum')
             self.assertEqual(
                 [{'bumblebee_checksum': '9fb7bce1d9bc0eb51d26ea7018ad41f542851ed75cb21e33e04b65a7f9757028',
-                  'id': 'document-1'}],
+                  'id': 'document-1',
+                  'UID': u'createtemplates00000000000000002'}],
                 browser.json['items'])
 
             self.testserverctl('zodb_teardown')


### PR DESCRIPTION
`solrsearch` failed when we requested the snippets, because `ftw.solr` relies on `UID` being on the `SolrDocument` to extract the snippets from the response. We therefore always need to have the `UID` in the list of requested fields when we request snippets. Here we simply always require the `UID`.

For https://github.com/4teamwork/opengever.core/issues/6184

## Checkliste

- [x] Changelog-Eintrag vorhanden/nötig?