### PR TITLE
Fix JS ordering issue: define overlayhelpers.js position.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 
 - Add 'filing_no' field to Solr schema. [lgraf]
 - Add upgrade step to correct public_trial_statement type. [njohner]
+- Fix JS ordering issue: define overlayhelpers.js position. [njohner]
 - Fix volatile related proposal documents. [elioschmutz]
 - Add a button to create a task from a proposal. [elioschmutz]
 - Allow to unlock and edit submitted documents in a submitted proposal. [elioschmutz]

--- a/opengever/core/profiles/default/jsregistry.xml
+++ b/opengever/core/profiles/default/jsregistry.xml
@@ -1,6 +1,21 @@
 <object name="portal_javascripts" meta_type="JavaScripts Registry">
 
   <javascript
+      id="++resource++plone.app.jquery.js"
+      insert-after="++resource++opengever.base/es6_promise_polyfill_auto.min.js"
+      />
+
+  <javascript
+      id="++resource++plone.app.jquerytools.js"
+      insert-after="++resource++plone.app.jquery.js"
+      />
+
+  <javascript
+      id="++resource++plone.app.jquerytools.overlayhelpers.js"
+      insert-after="++resource++plone.app.jquerytools.js"
+      />
+
+  <javascript
       enabled="False"
       id="++resource++ftw.showroom/handlebars.js"
       insert-after="++resource++datetimepicker/js/datetimepicker_widget.js"

--- a/opengever/core/upgrades/20200128082842_define_overlayhelper_order_in_js_registry/jsregistry.xml
+++ b/opengever/core/upgrades/20200128082842_define_overlayhelper_order_in_js_registry/jsregistry.xml
@@ -1,0 +1,18 @@
+<object name="portal_javascripts" meta_type="JavaScripts Registry">
+
+  <javascript
+      id="++resource++plone.app.jquery.js"
+      insert-after="++resource++opengever.base/es6_promise_polyfill_auto.min.js"
+      />
+
+  <javascript
+      id="++resource++plone.app.jquerytools.js"
+      insert-after="++resource++plone.app.jquery.js"
+      />
+
+  <javascript
+      id="++resource++plone.app.jquerytools.overlayhelpers.js"
+      insert-after="++resource++plone.app.jquerytools.js"
+      />
+
+</object>

--- a/opengever/core/upgrades/20200128082842_define_overlayhelper_order_in_js_registry/upgrade.py
+++ b/opengever/core/upgrades/20200128082842_define_overlayhelper_order_in_js_registry/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class DefineOverlayhelperOrderInJSRegistry(UpgradeStep):
+    """Define overlayhelper order in js registry.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()


### PR DESCRIPTION
https://github.com/4teamwork/opengever.core/pull/6202 made an ordering issue in the `jsregistry.xml` surface. Indeed not all installations seem to have `plone.app.jquerytools.overlayhelpers.js` positioned before `opengever.base/prepoverlay.js`, but functions from `overlayhelpers.js` are used in `prepoverlay.js`. Here we correct that ordering issue by ensuring the jquerytools are loaded early, placing them and the things they depend on at the top of the registry.

## Checkliste

- [ ] Sind UpgradeSteps `deferrable`, oder können gewisse Schritte des Upgrades konditional ausgeführt werden? Not deferrable
- [x] Changelog-Eintrag vorhanden/nötig?
