### PR TITLE
Allow to move proposals

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,7 @@ Changelog
 - Add documentation for sharing endpoint. [njohner]
 - Always request UID from solr, as it is needed for snippets. [njohner]
 - Speed up validation of dossier resolution preconditions. [njohner]
+- Add tabbedview move action for proposals. [elioschmutz]
 
 
 2020.1.0rc1 (2020-01-30)

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,7 @@ Changelog
 - Add documentation for sharing endpoint. [njohner]
 - Always request UID from solr, as it is needed for snippets. [njohner]
 - Speed up validation of dossier resolution preconditions. [njohner]
+- Generally disallow to move proposals outside of its main dossier. [elioschmutz]
 - Add tabbedview move action for proposals. [elioschmutz]
 
 

--- a/opengever/core/profiles/default/actions.xml
+++ b/opengever/core/profiles/default/actions.xml
@@ -408,6 +408,18 @@
       <property name="visible">True</property>
     </object>
 
+    <object name="move_proposal_items" meta_type="CMF Action" i18n:domain="opengever.core">
+      <property name="title" i18n:translate="">Move Items</property>
+      <property name="description" i18n:translate="" />
+      <property name="url_expr">string:@@move_proposal_items:method</property>
+      <property name="icon_expr" />
+      <property name="available_expr" />
+      <property name="permissions">
+        <element value="View" />
+      </property>
+      <property name="visible">True</property>
+    </object>
+
     <object name="export_dossiers" meta_type="CMF Action" i18n:domain="opengever.core">
       <property name="title" i18n:translate="">Export selection</property>
       <property name="description" i18n:translate="" />

--- a/opengever/core/upgrades/20200129170738_add_move_proposal_items_action/actions.xml
+++ b/opengever/core/upgrades/20200129170738_add_move_proposal_items_action/actions.xml
@@ -1,0 +1,20 @@
+<object xmlns:i18n="http://xml.zope.org/namespaces/i18n" name="portal_actions" meta_type="Plone Actions Tool">
+
+  <!-- FOLDER BUTTONS -->
+  <object name="folder_buttons" meta_type="CMF Action Category">
+
+    <object name="move_proposal_items" meta_type="CMF Action" i18n:domain="opengever.core">
+      <property name="title" i18n:translate="">Move Items</property>
+      <property name="description" i18n:translate="" />
+      <property name="url_expr">string:@@move_proposal_items:method</property>
+      <property name="icon_expr" />
+      <property name="available_expr" />
+      <property name="permissions">
+        <element value="View" />
+      </property>
+      <property name="visible">True</property>
+    </object>
+
+  </object>
+
+</object>

--- a/opengever/core/upgrades/20200129170738_add_move_proposal_items_action/upgrade.py
+++ b/opengever/core/upgrades/20200129170738_add_move_proposal_items_action/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddMoveProposalItemsAction(UpgradeStep):
+    """Add move proposal items action.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/meeting/browser/configure.zcml
+++ b/opengever/meeting/browser/configure.zcml
@@ -461,4 +461,11 @@
       class=".unlock_submitted_document_form.UnlockSubmittedDocumentForm"
       />
 
+  <browser:page
+      for="opengever.dossier.behaviors.dossier.IDossierMarker"
+      name="move_proposal_items"
+      class=".move_proposal_items.MoveProposalItemsFormView"
+      permission="zope2.CopyOrMove"
+      />
+
 </configure>

--- a/opengever/meeting/browser/move_proposal_items.py
+++ b/opengever/meeting/browser/move_proposal_items.py
@@ -1,0 +1,65 @@
+from opengever.base.source import DossierPathSourceBinder
+from opengever.dossier.base import DOSSIER_STATES_OPEN
+from opengever.dossier.move_items import MoveItemsForm
+from opengever.meeting import _
+from plone import api
+from plone.z3cform import layout
+from z3c.form import field
+from z3c.relationfield.schema import RelationChoice
+from zope import schema
+from zope.interface import Interface
+
+
+class IMoveProposalItemsSchema(Interface):
+    destination_folder = RelationChoice(
+        title=_('label_destination', default="Destination"),
+        source=DossierPathSourceBinder(
+            review_state=DOSSIER_STATES_OPEN,
+            object_provides=[
+                'opengever.dossier.behaviors.dossier.IDossierMarker',
+                ],
+            navigation_tree_query={
+                'object_provides': [
+                    'opengever.dossier.behaviors.dossier.IDossierMarker',
+                ],
+                'review_state': DOSSIER_STATES_OPEN
+                },
+            ),
+        required=True,
+        )
+
+    # We Use TextLine here because Tuple and List have no hidden_mode.
+    request_paths = schema.TextLine(title=u"request_paths")
+
+
+class MoveProposalItemsForm(MoveItemsForm):
+
+    fields = field.Fields(IMoveProposalItemsSchema)
+
+
+class MoveProposalItemsFormView(layout.FormWrapper):
+    """ View to move selected proposal items into another location
+    """
+
+    form = MoveProposalItemsForm
+
+    def assert_valid_container_state(self):
+        container = self.context
+        if not container.is_open():
+            msg = _(u'error_move_proposal_dossier_not_open',
+                    default=u'Can only move objects from open dossiers')
+            api.portal.show_message(msg, request=self.request, type='error')
+            self.request.RESPONSE.redirect(
+                '%s#proposals' % container.absolute_url())
+
+    def render(self):
+        self.assert_valid_container_state()
+        if not self.request.get('paths') and not \
+                self.form_instance.widgets['request_paths'].value:
+            msg = _(u'error_no_items_selected',
+                    default=u'You have not selected any items')
+            api.portal.show_message(msg, request=self.request, type='error')
+
+            return self.request.RESPONSE.redirect(
+                '%s#proposals' % self.context.absolute_url())
+        return super(MoveProposalItemsFormView, self).render()

--- a/opengever/meeting/configure.zcml
+++ b/opengever/meeting/configure.zcml
@@ -183,6 +183,12 @@
       />
 
   <subscriber
+      for="opengever.meeting.proposal.IBaseProposal
+           OFS.interfaces.IObjectWillBeMovedEvent"
+      handler=".handlers.proposal_will_be_moved"
+      />
+
+  <subscriber
       for="opengever.meeting.proposal.IProposal
            zope.lifecycleevent.interfaces.IObjectModifiedEvent"
       handler=".handlers.proposal_modified"

--- a/opengever/meeting/exceptions.py
+++ b/opengever/meeting/exceptions.py
@@ -49,3 +49,8 @@ class SablonProcessingFailed(Exception):
 
 class MultiplePeriodsFound(Exception):
     """Multiple periods were found for the same date."""
+
+
+class ProposalMovedOutsideOfMainDossierError(Exception):
+    """The proposal have been moved outside of its main dossier which is not allowed.
+    """

--- a/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/de/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2020-01-24 09:09+0000\n"
+"POT-Creation-Date: 2020-01-29 22:31+0000\n"
 "PO-Revision-Date: 2017-10-23 18:40+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -660,10 +660,20 @@ msgstr "Der Freitext darf nicht leer sein."
 msgid "error_default_template_is_in_allowed_templates"
 msgstr "Die Standardvorlage für Traktanden ohne Antrag sollte bei den erlaubten Vorlagen ausgewählt sein."
 
+#. Default: "Can only move objects from open dossiers"
+#: ./opengever/meeting/browser/move_proposal_items.py
+msgid "error_move_proposal_dossier_not_open"
+msgstr "Es können nur Objekte aus aktiven Dossiers verschoben werden."
+
 #. Default: "Cannot change the state because the proposal contains checked out documents."
 #: ./opengever/meeting/proposal_transition_comment.py
 msgid "error_must_checkin_documents_for_transition"
 msgstr "Der Status kann nicht geändert werden solange der Antrag ausgecheckte Dokumente enthält."
+
+#. Default: "You have not selected any items"
+#: ./opengever/meeting/browser/move_proposal_items.py
+msgid "error_no_items_selected"
+msgstr "Sie haben kein Element ausgewählt"
 
 #. Default: "Insufficient privileges to add a document to the meeting dossier."
 #: ./opengever/meeting/browser/meetings/agendaitem.py
@@ -994,6 +1004,11 @@ msgstr "Wollen Sie dieses Element wirklich streichen?"
 #: ./opengever/meeting/proposal.py
 msgid "label_description"
 msgstr "Beschreibung"
+
+#. Default: "Destination"
+#: ./opengever/meeting/browser/move_proposal_items.py
+msgid "label_destination"
+msgstr "Zieldossier"
 
 #. Default: "Dossier"
 #: ./opengever/meeting/proposal.py

--- a/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2020-01-24 09:09+0000\n"
+"POT-Creation-Date: 2020-01-29 22:31+0000\n"
 "PO-Revision-Date: 2018-05-22 10:15+0000\n"
 "Last-Translator: Niklaus Johner <Niklaus.johner@4teamwork.ch>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-meeting/fr/>\n"
@@ -662,10 +662,20 @@ msgstr "Ce texte libre ne doit pas être vide."
 msgid "error_default_template_is_in_allowed_templates"
 msgstr "Le modèle pour les points à l'ordre du jour sans requête doit être sélectionné parmis les modèles autorisés."
 
+#. Default: "Can only move objects from open dossiers"
+#: ./opengever/meeting/browser/move_proposal_items.py
+msgid "error_move_proposal_dossier_not_open"
+msgstr ""
+
 #. Default: "Cannot change the state because the proposal contains checked out documents."
 #: ./opengever/meeting/proposal_transition_comment.py
 msgid "error_must_checkin_documents_for_transition"
 msgstr "L'état ne peut pas être changé tant que la requête contient des documents qui ont été extraits."
+
+#. Default: "You have not selected any items"
+#: ./opengever/meeting/browser/move_proposal_items.py
+msgid "error_no_items_selected"
+msgstr ""
 
 #. Default: "Insufficient privileges to add a document to the meeting dossier."
 #: ./opengever/meeting/browser/meetings/agendaitem.py
@@ -996,6 +1006,11 @@ msgstr "Êtes-vous sûr de vouloir supprimer cet élément?"
 #: ./opengever/meeting/proposal.py
 msgid "label_description"
 msgstr "Description"
+
+#. Default: "Destination"
+#: ./opengever/meeting/browser/move_proposal_items.py
+msgid "label_destination"
+msgstr ""
 
 #. Default: "Dossier"
 #: ./opengever/meeting/proposal.py

--- a/opengever/meeting/locales/opengever.meeting.pot
+++ b/opengever/meeting/locales/opengever.meeting.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2020-01-24 09:09+0000\n"
+"POT-Creation-Date: 2020-01-29 22:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -659,9 +659,19 @@ msgstr ""
 msgid "error_default_template_is_in_allowed_templates"
 msgstr ""
 
+#. Default: "Can only move objects from open dossiers"
+#: ./opengever/meeting/browser/move_proposal_items.py
+msgid "error_move_proposal_dossier_not_open"
+msgstr ""
+
 #. Default: "Cannot change the state because the proposal contains checked out documents."
 #: ./opengever/meeting/proposal_transition_comment.py
 msgid "error_must_checkin_documents_for_transition"
+msgstr ""
+
+#. Default: "You have not selected any items"
+#: ./opengever/meeting/browser/move_proposal_items.py
+msgid "error_no_items_selected"
 msgstr ""
 
 #. Default: "Insufficient privileges to add a document to the meeting dossier."
@@ -992,6 +1002,11 @@ msgstr ""
 #: ./opengever/meeting/browser/meetings/templates/meeting.pt
 #: ./opengever/meeting/proposal.py
 msgid "label_description"
+msgstr ""
+
+#. Default: "Destination"
+#: ./opengever/meeting/browser/move_proposal_items.py
+msgid "label_destination"
 msgstr ""
 
 #. Default: "Dossier"

--- a/opengever/meeting/tests/test_move_proposal.py
+++ b/opengever/meeting/tests/test_move_proposal.py
@@ -1,0 +1,25 @@
+from ftw.testbrowser import browsing
+from opengever.meeting.exceptions import ProposalMovedOutsideOfMainDossierError
+from opengever.testing import IntegrationTestCase
+from plone import api
+
+
+class TestMoveProposal(IntegrationTestCase):
+
+    features = ('meeting',)
+
+    @browsing
+    def test_a_proposal_can_be_moved_inside_of_its_main_dossier(self, browser):
+        self.login(self.dossier_manager)
+        proposal = self.proposal
+
+        self.assertIn(proposal, self.dossier.objectValues())
+        api.content.move(proposal, self.subdossier)
+        self.assertIn(proposal, self.subdossier.objectValues())
+
+    @browsing
+    def test_it_is_not_allowed_to_move_a_proposal_outside_of_its_main_dossier(self, browser):
+        self.login(self.dossier_manager)
+
+        with self.assertRaises(ProposalMovedOutsideOfMainDossierError):
+            api.content.move(self.proposal, self.resolvable_dossier)

--- a/opengever/meeting/tests/test_move_proposal_items.py
+++ b/opengever/meeting/tests/test_move_proposal_items.py
@@ -1,0 +1,131 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.testbrowser import browsing
+from ftw.testbrowser.pages.statusmessages import assert_message
+from opengever.testing import IntegrationTestCase
+from plone import api
+from Products.CMFPlone.utils import safe_unicode
+
+
+class TestMoveProposalItems(IntegrationTestCase):
+
+    @browsing
+    def test_move_proposal_to_new_dossier(self, browser):
+        self.login(self.regular_user, browser)
+        proposal = self.proposal
+
+        payload = {'paths:list': ['/'.join(proposal.getPhysicalPath())]}
+
+        self.assertNotIn(proposal, self.subdossier.objectValues())
+
+        browser.open(self.dossier, payload, view='move_proposal_items')
+        browser.fill({'Destination': self.subdossier})
+        browser.css('#form-buttons-button_submit').first.click()
+
+        assert_message('1 Elements were moved successfully')
+        self.assertIn(proposal, self.subdossier.objectValues())
+
+    @browsing
+    def test_redirects_to_context_and_shows_statusmessage_when_obj_cant_be_found(self, browser):
+        self.login(self.regular_user, browser)
+        payload = {'paths:list': ['/invalid/path']}
+
+        browser.open(self.dossier, payload, view='move_proposal_items')
+
+        browser.fill({'Destination': self.subdossier})
+        browser.css('#form-buttons-button_submit').first.click()
+
+        assert_message("The selected objects can't be found, please try it again.")
+
+    @browsing
+    def test_proposal_inside_closed_dossier_is_not_movable(self, browser):
+        self.login(self.dossier_manager, browser)
+
+        with self.login(self.manager):
+            api.content.transition(obj=self.subdossier,
+                                   transition="dossier-transition-resolve")
+
+        browser.open(self.subdossier, {}, view='move_proposal_items')
+
+        assert_message('Can only move objects from open dossiers')
+        self.assertIn(self.proposal, self.dossier.objectValues())
+
+    @browsing
+    def test_do_not_allow_to_move_proposal_into_a_resolved_dossier(self, browser):
+        self.login(self.regular_user, browser)
+
+        payload = {'paths:list': ['/'.join(self.proposal.getPhysicalPath())]}
+
+        with self.login(self.manager):
+            api.content.transition(obj=self.subdossier,
+                                   transition="dossier-transition-resolve")
+
+        browser.open(self.dossier, payload, view='move_proposal_items')
+        browser.fill({'Destination': self.subdossier})
+        browser.css('#form-buttons-button_submit').first.click()
+
+        self.assertEquals(['Required input is missing.'],
+                          browser.css('.fieldErrorBox .error').text,
+                          "It's not allowed to select a closed dossier")
+
+    @browsing
+    def test_do_not_allow_to_move_proposal_outside_of_main_dossier(self, browser):
+        self.login(self.regular_user, browser)
+
+        payload = {'paths:list': ['/'.join(self.proposal.getPhysicalPath())]}
+
+        browser.open(self.dossier, payload, view='move_proposal_items')
+        browser.fill({'Destination': self.resolvable_dossier})
+        browser.css('#form-buttons-button_submit').first.click()
+
+        self.assertEquals(['Required input is missing.'],
+                          browser.css('.fieldErrorBox .error').text,
+                          "It's not allowed to select a dossier outside of the "
+                          "current main dossier")
+
+    @browsing
+    def test_move_target_autocomplete_widget_lists_only_dossiers_of_the_proposals_current_main_dossier(self, browser):
+        self.login(self.dossier_responsible, browser)
+        autocomplete_url = u'/'.join((
+            self.dossier.absolute_url(),
+            u'@@move_proposal_items',
+            u'++widget++form.widgets.destination_folder',
+            u'@@autocomplete-search',
+        ))
+
+        sister_dossier = create(Builder('dossier')
+                                .titled(safe_unicode(self.dossier.title_or_id()))
+                                .within(self.leaf_repofolder))
+
+        # This subdossier in sister_dossier is not found in the autocomplete
+        create(Builder('dossier')
+               .titled(safe_unicode(self.subsubdossier.title_or_id()))
+               .within(sister_dossier))
+
+        browser.open(u'?'.join((autocomplete_url, u'q={}'.format(self.subsubdossier.title_or_id()))))
+        self.assertEqual(
+            '/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/dossier-2/dossier-4|Subsubdossier',
+            browser.contents,
+            'Only the dossier in the main dossier should be found.')
+
+        browser.open(u'?'.join((autocomplete_url, u'q={}'.format(self.dossier.title_or_id()))))
+        self.assertEqual(
+            '/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1|Vertr\xc3\xa4ge mit der kantonalen Finanzverwaltung',
+            browser.contents)
+
+    @browsing
+    def test_move_target_autocomplete_widget_does_not_list_closed_dossiers(self, browser):
+        self.login(self.dossier_responsible, browser)
+        autocomplete_url = u'/'.join((
+            self.dossier.absolute_url(),
+            u'@@move_proposal_items',
+            u'++widget++form.widgets.destination_folder',
+            u'@@autocomplete-search',
+        ))
+
+        with self.login(self.manager):
+            api.content.transition(obj=self.subsubdossier,
+                                   transition="dossier-transition-resolve")
+
+        browser.open(u'?'.join((autocomplete_url, u'q={}'.format(self.subsubdossier.title_or_id()))))
+        self.assertEqual('', browser.contents)

--- a/opengever/meeting/tests/test_proposal_listings.py
+++ b/opengever/meeting/tests/test_proposal_listings.py
@@ -42,6 +42,19 @@ def proposal_dicts(browser):
     return proposals_table(browser).dicts()
 
 
+def with_checkbox(expected_results):
+    """In the default proposal listings we have to extend the expected
+    results with the "checkbox"-row. These cells do not contain any text and
+    are the first cells of the row.
+    """
+    results = []
+    for expected_result in expected_results:
+        result = {'': ''}
+        result.update(expected_result)
+        results.append(result)
+    return results
+
+
 class TestDossierProposalListing(IntegrationTestCase):
 
     features = ('meeting',)
@@ -52,7 +65,7 @@ class TestDossierProposalListing(IntegrationTestCase):
     def test_listing_shows_active_proposals_by_default(self, browser):
         self.login(self.dossier_responsible, browser)
         browser.open(self.dossier, view='tabbedview_view-proposals')
-        self.assertEqual([SUBMITTED_PROPOSAL, DRAFT_PROPOSAL], proposal_dicts(browser))
+        self.assertEqual(with_checkbox([SUBMITTED_PROPOSAL, DRAFT_PROPOSAL]), proposal_dicts(browser))
 
     @browsing
     def test_listing_shows_translated_state(self, browser):
@@ -94,7 +107,7 @@ class TestDossierProposalListing(IntegrationTestCase):
                 'Description': '',
             },
         ]
-        self.assertEqual(expected_proposals, browser.css('.listing').first.dicts())
+        self.assertEqual(with_checkbox(expected_proposals), browser.css('.listing').first.dicts())
 
     @browsing
     def test_listing_only_shows_visible_proposals(self, browser):
@@ -104,7 +117,7 @@ class TestDossierProposalListing(IntegrationTestCase):
         self.draft_proposal.reindexObject()
 
         browser.open(self.dossier, view='tabbedview_view-proposals')
-        self.assertEqual([SUBMITTED_PROPOSAL], proposal_dicts(browser))
+        self.assertEqual(with_checkbox([SUBMITTED_PROPOSAL]), proposal_dicts(browser))
 
     @browsing
     def test_proposals_are_linked_correctly(self, browser):
@@ -136,7 +149,7 @@ class TestDossierProposalListing(IntegrationTestCase):
         browser.click_on("proposal-transition-cancel")
         browser.click_on("Confirm")
         browser.open(self.dossier, view='tabbedview_view-proposals')
-        self.assertEqual([SUBMITTED_PROPOSAL], proposal_dicts(browser))
+        self.assertEqual(with_checkbox([SUBMITTED_PROPOSAL]), proposal_dicts(browser))
 
     @browsing
     def test_all_filter_shows_all_proposals(self, browser):
@@ -147,7 +160,9 @@ class TestDossierProposalListing(IntegrationTestCase):
         browser.open(self.dossier, view='tabbedview_view-proposals', data={'proposal_state_filter': 'filter_proposals_all'})
         cancelled_proposal = DRAFT_PROPOSAL.copy()
         cancelled_proposal['State'] = 'Cancelled'
-        self.assertEqual([SUBMITTED_PROPOSAL, cancelled_proposal, DECIDED_PROPOSAL], proposal_dicts(browser))
+        self.assertEqual(
+            with_checkbox([SUBMITTED_PROPOSAL, cancelled_proposal, DECIDED_PROPOSAL]),
+            proposal_dicts(browser))
 
     @browsing
     def test_decided_filter_shows_only_decided_proposals(self, browser):
@@ -157,7 +172,7 @@ class TestDossierProposalListing(IntegrationTestCase):
             view='tabbedview_view-proposals',
             data={'proposal_state_filter': 'filter_proposals_decided'},
         )
-        self.assertEqual([DECIDED_PROPOSAL], proposal_dicts(browser))
+        self.assertEqual(with_checkbox([DECIDED_PROPOSAL]), proposal_dicts(browser))
 
     @browsing
     def test_decision_number_is_prefixed(self, browser):
@@ -172,13 +187,13 @@ class TestDossierProposalListing(IntegrationTestCase):
         )
         proposal = deepcopy(DECIDED_PROPOSAL)
         proposal['Decision number'] = '2016 / 1'
-        self.assertEqual([proposal], proposal_dicts(browser))
+        self.assertEqual(with_checkbox([proposal]), proposal_dicts(browser))
 
     @browsing
     def test_filtering_dossier_proposal_listing_by_name(self, browser):
         self.login(self.dossier_responsible, browser)
         browser.open(self.dossier, view='tabbedview_view-proposals', data={'searchable_text': u'f\xfcr Kreisel'})
-        self.assertEqual([DRAFT_PROPOSAL], proposal_dicts(browser))
+        self.assertEqual(with_checkbox([DRAFT_PROPOSAL]), proposal_dicts(browser))
 
 
 class TestMyProposals(IntegrationTestCase):
@@ -204,7 +219,8 @@ class TestMyProposals(IntegrationTestCase):
     def test_listing_shows_active_proposals_by_default(self, browser):
         self.login(self.dossier_responsible, browser)
         browser.open(view='tabbedview_view-myproposals')
-        self.assertEqual([SUBMITTED_PROPOSAL, DRAFT_PROPOSAL], proposal_dicts(browser))
+        self.assertEqual([SUBMITTED_PROPOSAL, DRAFT_PROPOSAL],
+                         proposal_dicts(browser))
 
     @browsing
     def test_decided_filter_shows_only_decided_proposals(self, browser):


### PR DESCRIPTION
Issuer #6014 

Dieser PR implementiert eine Tabbedview-Action zum Verschieben von Anträgen.

Anträge können nur innerhalb ihres Hauptdossiers verschoben werden.

![screen1](https://user-images.githubusercontent.com/557005/73436668-40621780-434b-11ea-9d65-16ac87c92e91.gif)

ℹ️ Die bereits vorhandene View "move_items" kann leider nicht verwendet werden. Siehe https://github.com/4teamwork/opengever.core/issues/6211 für mehr Informationen.

⚠️ Abgrenzung: Es ist momentan nicht möglich, einen Antrag zurück in das Hauptdossier zu verschieben. Das Problem wird hier weiterbehandelt: Siehe https://github.com/4teamwork/opengever.core/issues/6224

❓Verhindert die o.g. Abgrenzung das Schliessen dieses PBIs?

## Checkliste

- [x] Profil angepasst? Sind UpgradeSteps vorhanden/nötig?:
- [x] Gibt es neue Übersetzungen?
  - [x] Sind alle msg-Strings in Übersetzungen Unicode?
  - [x] Wird die richtige i18n-domain verwendet (Copy-Paste Fehler sind hier häufig)?
- [x] Changelog-Eintrag vorhanden/nötig?
