### PR TITLE
Handle deployments with no repository in navigation endpoint.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,7 @@ Changelog
 - Implement the teamraum client authentication flow. [elioschmutz]
 - Implement the workspace client to make requests to a teamraum from GEVER. [elioschmutz]
 - Implement the workspace client authentication flow. [elioschmutz]
+- Handle deployments with no repository in navigation endpoint. [njohner]
 - Add documentation for sharing endpoint. [njohner]
 - Always request UID from solr, as it is needed for snippets. [njohner]
 - Speed up validation of dossier resolution preconditions. [njohner]

--- a/opengever/api/navigation.py
+++ b/opengever/api/navigation.py
@@ -57,7 +57,11 @@ class Navigation(object):
             if roots:
                 root = roots[0].getObject()
             else:
+                # when on a teamraum deployment with no repository, no root
+                # is found. As a temporary fix we return no navigation in these
+                # cases.
                 root = None
+                return {'navigation': {}}
 
         result = {
             'navigation': {


### PR DESCRIPTION
This is a fix for the devteamraum installation, I think we need to discuss these issues further. I created an issue to decide how to correctly handle teamraum installations (https://github.com/4teamwork/opengever.core/issues/6234)

In a gever installation we always assume that we are actually running a Gever, but it can now also be a Teamraum instead. As such we default the navigation to look for the repository root and display the repository folders. This default does not make sense in the case of a Teamraum installation and leads to an error if there is not repository.

This PR is a simple fix, but we should have some sort of concept of how we want to go about supporting Teamraum installations...

For https://github.com/4teamwork/opengever.core/issues/6181

## Checkliste
- [x] Changelog-Eintrag vorhanden/nötig?