### PR TITLE
Implement authentication flow

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2020.1.0rc2 (unreleased)
 ------------------------
 
+- Implement the teamraum client authentication flow. [elioschmutz]
 - Add documentation for sharing endpoint. [njohner]
 - Always request UID from solr, as it is needed for snippets. [njohner]
 - Speed up validation of dossier resolution preconditions. [njohner]

--- a/docs/intern/kurzreferenzen/index.rst
+++ b/docs/intern/kurzreferenzen/index.rst
@@ -7,6 +7,7 @@ Inhalt:
    :maxdepth: 2
 
    bumblebee
+   teamraum
    solr
    ogip
    feedbackforum-prozess

--- a/docs/intern/kurzreferenzen/teamraum.rst
+++ b/docs/intern/kurzreferenzen/teamraum.rst
@@ -1,0 +1,21 @@
+Teamraum einbinden
+==================
+Der Teamraum wird als eigenes Deployment betrieben und wird in GEVER integriert.
+
+Da die Kommunikation immer nur von GEVER nach Teamraum (nie umgekehrt) stattfinden darf, wird GEVER dementsprechend als Client gegenüber Teamraum auftreten. Es wird der von `ftw.tokenauth <https://github.com/4teamwork/ftw.tokenauth>`__ unterstützte OAuth2 Flow verwendet, um Requests von GEVER an den Teamraum zu authentisieren.
+
+Service-Benutzer erstellen
+--------------------------
+Erstellen Sie einen Benutzer sowohl auf GEVER wie auch auf Teamraum Seite mit den Rollen ``ServiceKeyUser`` und ``Impersonator``.
+
+Service-Schlüssel ausstellen
+----------------------------
+Erstellen Sie im Teamraum einen Service-Key für das GEVER gem. Dokumentation von `ftw.tokenauth <https://github.com/4teamwork/ftw.tokenauth#1-issue-service-key>`__
+
+Service-Schlüssel im GEVER registrieren
+---------------------------------------
+Der von `ftw.tokenauth <https://github.com/4teamwork/ftw.tokenauth>`__ generierte Schlüssel welcher zum Download angeboten wird, muss nach dem Erstellen im GEVER zur Verfügung gestellt werden.
+
+GEVER sucht im Ordner ``~/.opengever/ftw_tokenauth_keys`` nach entsprechenden Schlüsseln.
+
+Erstellen Sie ein ``.json`` z.B. ``teamraum_dev.json`` mit dem gesamten Schlüssel als Inhalt. GEVER wird später anhand der ``token_uri`` im Schlüssel automatisch das korrekte Schlüssel-File für den Request auf den Teamraum verwenden.

--- a/opengever/testing/builders/__init__.py
+++ b/opengever/testing/builders/__init__.py
@@ -7,3 +7,4 @@ from opengever.testing.builders.qickupload import *
 from opengever.testing.builders.repositorytree import *
 from opengever.testing.builders.sql import *
 from opengever.testing.builders.webactions import *
+from opengever.testing.builders.workspaceclient import *

--- a/opengever/testing/builders/workspaceclient.py
+++ b/opengever/testing/builders/workspaceclient.py
@@ -1,0 +1,59 @@
+from DateTime import DateTime
+from ftw.builder import builder_registry
+from ftw.tokenauth.pas.storage import CredentialStorage
+from ftw.tokenauth.service_keys.key_generation import create_service_key_pair
+from opengever.workspaceclient.keys import key_registry
+from zope.component.hooks import getSite
+
+
+class WorkspaceTokenAuthAppBuilder(object):
+    """Creates a workspace service key and registers it properly.
+    """
+
+    def __init__(self, session):
+        self.session = session
+        self.portal = getSite()
+        self.arguments = {
+            'client_id': 'default-client-id',
+            'title': 'Test Key',
+        }
+        self.uri(self.portal.absolute_url())
+
+    def having(self, **kwargs):
+        self.arguments.update(kwargs)
+        return self
+
+    def issuer(self, user):
+        self.having(user_id=user.getId())
+        return self
+
+    def uri(self, uri):
+        uri = '{}/@@oauth2-token'.format(uri.strip('/'))
+        self.having(token_uri=uri)
+        return self
+
+    def create(self, **kwargs):
+        # Create a new keypair
+        private_key, service_key = create_service_key_pair(
+            self.arguments.get('user_id'),
+            self.arguments.get('title'),
+            self.arguments.get('token_uri'),
+            self.arguments.get('ip_range'),
+        )
+        # Register the service app (server side)
+        plugin = getSite().acl_users.token_auth
+        credential_storage = CredentialStorage(plugin)
+        credential_storage.add_service_key(service_key)
+
+        # Regsister the service app (client side)
+        service_key_client = {'private_key': private_key}
+        service_key_client.update(service_key)
+        service_key_client['issued'] = DateTime(service_key_client['issued']).asdatetime()
+        del service_key_client['public_key']
+
+        key_registry.add_key(service_key_client)
+
+        return service_key_client
+
+
+builder_registry.register('workspace_token_auth_app', WorkspaceTokenAuthAppBuilder)

--- a/opengever/workspaceclient/__init__.py
+++ b/opengever/workspaceclient/__init__.py
@@ -1,0 +1,3 @@
+import logging
+
+logger = logging.getLogger('opengever.workspaceclient')

--- a/opengever/workspaceclient/exceptions.py
+++ b/opengever/workspaceclient/exceptions.py
@@ -6,3 +6,32 @@ class ServiceKeyMissing(Exception):
         super(ServiceKeyMissing, self).__init__(
             'No workspace service key found for URL {}.\n'
             'Found keys {} in the folder: {}'.format(url, known_key_urls, path))
+
+
+class APIRequestException(Exception):
+    """Base class for exceptions when making a request to a service app.
+    This base class can be used to build custom exception classes which will then
+    be raised by the api client when something bad happens in the communication
+    with the service app.
+    """
+
+    message = "Request to workspaces failed."
+
+    def __init__(self, original_exception=None):
+        """
+        :param original_exception: An instance of an exception. Will be logged too.
+        """
+        self.original_exception = original_exception
+        super(APIRequestException, self).__init__(self.msg())
+
+    def msg(self):
+        msgs = [self.__class__.__name__]
+        msgs.append(self.message)
+
+        if self.original_exception:
+            msgs.append("Original exception: {}.".format(self.original_exception))
+
+            if hasattr(self.original_exception, "response") and self.original_exception.response.text:
+                msgs.append("Response from service app: {}".format(self.original_exception.response.text))
+
+        return "\n".join(msgs)

--- a/opengever/workspaceclient/exceptions.py
+++ b/opengever/workspaceclient/exceptions.py
@@ -1,0 +1,8 @@
+class ServiceKeyMissing(Exception):
+
+    def __init__(self, url, keys, path):
+        known_key_urls = repr(tuple(keys))
+
+        super(ServiceKeyMissing, self).__init__(
+            'No workspace service key found for URL {}.\n'
+            'Found keys {} in the folder: {}'.format(url, known_key_urls, path))

--- a/opengever/workspaceclient/keys.py
+++ b/opengever/workspaceclient/keys.py
@@ -1,0 +1,66 @@
+from opengever.workspaceclient import logger
+from opengever.workspaceclient.exceptions import ServiceKeyMissing
+from path import Path
+import json
+import os
+
+
+class KeyRegistry(object):
+    """The KeyRegistry handles service-keys provided by ftw.tokenauth.
+    It returns the right key for a specific url.
+
+    It looks up keys provided by a static directory on the filesystem.
+    """
+    key_directory = os.path.expanduser(
+        os.path.join('~', '.opengever/ftw_tokenauth_keys'))
+
+    def __init__(self):
+        self.load_file_system_keys()
+
+    def get_key_for(self, url):
+        """Returns the service key matching the given URL.
+
+        Will raise an error if no key is found.
+        """
+        url = url.strip('/')
+        key = self.keys_by_token_uri.get(url)
+        if not key:
+            raise ServiceKeyMissing(url, self.keys_by_token_uri.keys(),
+                                    self.key_directory)
+
+        return key
+
+    @property
+    def keys_by_token_uri(self):
+        """Returns all registered keys in a dict with the service-app url as
+        the key and the full service-key as the value.
+        """
+        keys = {}
+        for key in self.keys:
+            service_app_url = key.get('token_uri').replace(
+                "@@oauth2-token", "").strip('/')
+            keys[service_app_url] = key
+
+        return keys
+
+    def load_file_system_keys(self):
+        """Loads the keys stored on the file system.
+        """
+        self.keys = []
+        for key_file in Path(self.key_directory).glob("*.json"):
+            key = json.loads(key_file.bytes())
+            if "token_uri" not in key:
+                logger.warning(
+                    'Found a broken workspace service key at {}'.format(
+                        str(key_file)))
+                continue
+
+            self.add_key(key)
+
+    def add_key(self, key):
+        """Adds a key to the available keys.
+        """
+        self.keys.append(key)
+
+
+key_registry = KeyRegistry()

--- a/opengever/workspaceclient/session.py
+++ b/opengever/workspaceclient/session.py
@@ -1,0 +1,151 @@
+from opengever.workspaceclient.exceptions import APIRequestException
+from opengever.workspaceclient.keys import key_registry
+from requests import HTTPError
+import jwt
+import pkg_resources
+import requests
+import threading
+import time
+import os
+
+
+SESSION_STORAGE = threading.local()
+GRANT_TYPE = "urn:ietf:params:oauth:grant-type:jwt-bearer"
+GEVER_VERSION = pkg_resources.get_distribution('opengever.core').version
+
+
+class FtwTokenAuthSession(requests.Session):
+    """This Session class takes care of the authentication token.
+
+    It will auto-renew the access-token as soon as it is expired.
+    """
+    session_expiration_seconds = 60 * 60
+
+    def __init__(self, service_key, username):
+        super(FtwTokenAuthSession, self).__init__()
+        self.service_key = service_key
+        self.username = username
+
+    def request(self, *args, **kwargs):
+        response = super(FtwTokenAuthSession, self).request(*args, **kwargs)
+
+        if self.token_has_expired(response):
+            # We got an 'Access token expired' response => refresh token
+            self.obtain_token()
+            # Re-dispatch the request that previously failed
+            response = super(FtwTokenAuthSession, self).request(*args, **kwargs)
+
+        self.raise_for_status(response)
+
+        return response
+
+    def token_has_expired(self, response):
+        status = response.status_code
+        content_type = response.headers['Content-Type']
+
+        if status == 401 and content_type == 'application/json':
+            body = response.json()
+            if body.get('error_description') == 'Access token expired':
+                return True
+
+        return False
+
+    def obtain_token(self):
+        """Acquires a fresh authorization token from the workspace and sets it
+        in the current session.
+        """
+        claim_set = {
+            "iss": self.service_key["client_id"],
+            "sub": self.username,
+            "aud": self.service_key["token_uri"],
+            "iat": int(unfrozen_time()),
+            "exp": int(unfrozen_time() + self.session_expiration_seconds),
+        }
+
+        grant = jwt.encode(claim_set, self.service_key["private_key"], algorithm="RS256")
+        payload = {"grant_type": GRANT_TYPE, "assertion": grant}
+
+        response = requests.post(self.service_key["token_uri"], data=payload)
+        self.raise_for_status(response)
+
+        bearer_token = response.json()["access_token"]
+        self.headers.update({"Authorization": "Bearer {}".format(bearer_token)})
+
+    def raise_for_status(self, response):
+        try:
+            response.raise_for_status()
+        except HTTPError as exception:
+            raise APIRequestException(exception)
+
+
+class WorkspaceSession(object):
+    """The WorkspaceSession object provides a preconfigured request session for
+    a workspace.
+    The requests session is reused for multiple requests so that we have a smaller
+    footprint regarding oauth authentication requests. The session is cached in memory.
+    The WorkspaceSession is instantiated with a workspace url (to any ressource)
+    and the operating user.
+    """
+
+    def __init__(self, workspace_url, username):
+        self.workspace_url = workspace_url
+        self.username = username
+        self.session = self._get_or_create_session()
+
+    @property
+    def request(self):
+        """Returns the current session to perform a request.
+        """
+        return self.session
+
+    @staticmethod
+    def clear():
+        """Clear all caches.
+        """
+        SESSION_STORAGE.sessions = None
+
+    def _get_or_create_session(self):
+        """Returns a ``requests`` session for the GEVER client with the given url.
+        The session may be outdated. The session is reused over multiple
+        requests by the same person.
+        """
+        if getattr(SESSION_STORAGE, "sessions", None) is None:
+            SESSION_STORAGE.sessions = {}
+
+        if self._unique_session_key not in SESSION_STORAGE.sessions:
+            SESSION_STORAGE.sessions[self._unique_session_key] = self._make_session()
+
+        return SESSION_STORAGE.sessions[self._unique_session_key]
+
+    def _make_session(self):
+        """Create a fresh requests session and return it.
+        """
+        service_key = key_registry.get_key_for(self.workspace_url)
+        session = FtwTokenAuthSession(service_key, self.username)
+        session.headers.update({"User-Agent": self._user_agent})
+        session.headers.update({"Accept": "application/json"})
+        session.obtain_token()
+        return session
+
+    def _unique_session_key(self):
+        return (self.workspace_url, self.username)
+
+    @property
+    def _user_agent(self):
+        custom_user_agent = os.environ.get('OPENGEVER_APICLIENT_USER_AGENT', '')
+        return 'opengever.core/{} {}'.format(
+            GEVER_VERSION, custom_user_agent).strip()
+
+
+def unfrozen_time(*args, **kwargs):
+    """In testing, we want to be able to freeze the time. But we never want to freeze
+    the time when generating JWT access tokens for accessing other systems.
+    The unfrozen_time function makes sure to always return a real time, no matter
+    whether the time is frozen or the freezegun is even installed.
+    """
+    try:
+        from freezegun.api import real_time
+    except ImportError:
+        return time.time(*args, **kwargs)
+    else:
+        return real_time(*args, **kwargs)

--- a/opengever/workspaceclient/tests/__init__.py
+++ b/opengever/workspaceclient/tests/__init__.py
@@ -1,0 +1,37 @@
+from contextlib import contextmanager
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.tokenauth.testing.builders import KeyPairBuilder  # noqa
+from opengever.core.testing import OPENGEVER_FUNCTIONAL_ZSERVER_TESTING
+from opengever.testing import FunctionalTestCase
+from plone import api
+import os
+
+
+class FunctionalWorkspaceClientTestCase(FunctionalTestCase):
+
+    layer = OPENGEVER_FUNCTIONAL_ZSERVER_TESTING
+
+    def setUp(self):
+        super(FunctionalWorkspaceClientTestCase, self).setUp()
+
+        # Minimal GEVER setup
+        self.repo = create(Builder('repository_root'))
+
+        # Generate a service user
+        self.service_user = api.user.create(email="service-user@example.com",
+                                            username='service.user')
+        api.user.grant_roles(user=self.service_user,
+                             roles=['ServiceKeyUser', 'Impersonator'])
+
+    @contextmanager
+    def env(self, **env):
+        """Temporary set env variables.
+        """
+        original = os.environ.copy()
+        os.environ.update(env)
+        try:
+            yield
+        finally:
+            os.environ.clear()
+            os.environ.update(original)

--- a/opengever/workspaceclient/tests/test_keys.py
+++ b/opengever/workspaceclient/tests/test_keys.py
@@ -1,0 +1,65 @@
+from contextlib import contextmanager
+from ftw.builder import Builder
+from ftw.builder import create
+from opengever.testing import IntegrationTestCase
+from opengever.workspaceclient.exceptions import ServiceKeyMissing
+from opengever.workspaceclient.keys import key_registry
+from plone.restapi.serializer.converters import json_compatible
+import json
+import shutil
+import tempfile
+
+
+class TestKeyRegistry(IntegrationTestCase):
+
+    @contextmanager
+    def temp_fs_key(self, key):
+        temp_dir = tempfile.mkdtemp()
+        original_key_directory = key_registry.key_directory
+        key_registry.key_directory = temp_dir
+        file_ = tempfile.NamedTemporaryFile(
+            dir=temp_dir, suffix=".json", delete=False)
+        file_.write(json.dumps(json_compatible(key)))
+        file_.close()
+        try:
+            yield temp_dir
+        finally:
+            shutil.rmtree(temp_dir)
+            key_registry.key_directory = original_key_directory
+
+    def test_raises_an_error_if_the_key_file_not_found_for_a_specific_url(self):
+        service_key_client = create(Builder('workspace_token_auth_app')
+                                    .uri('http://example.com/plone/'))
+        with self.temp_fs_key(service_key_client) as path:
+            with self.assertRaises(ServiceKeyMissing) as cm:
+                key_registry.get_key_for('http://example.de/plone/')
+
+            self.maxDiff = None
+            self.assertEqual(
+                "No workspace service key found for URL http://example.de/plone.\n"
+                "Found keys ('http://example.com/plone',) in the folder: {}".format(path),
+                str(cm.exception))
+
+    def test_skip_fs_keys_without_a_token_uri(self):
+        service_key_client = create(Builder('workspace_token_auth_app')
+                                    .uri('http://example.com/plone/'))
+
+        del service_key_client['token_uri']
+        with self.temp_fs_key(service_key_client):
+            key_registry.load_file_system_keys()
+            self.assertEqual([], key_registry.keys)
+
+    def test_return_registered_keys_on_the_filesystem(self):
+        service_key_client = create(Builder('workspace_token_auth_app')
+                                    .uri('http://example.com/plone'))
+        with self.temp_fs_key(service_key_client):
+            self.assertEqual(
+                ['http://example.com/plone'],
+                key_registry.keys_by_token_uri.keys())
+
+    def test_get_key_for(self):
+        service_key_client = create(Builder('workspace_token_auth_app')
+                                    .uri('http://example.com/plone/'))
+        self.assertDictContainsSubset(
+            service_key_client,
+            key_registry.get_key_for('http://example.com/plone/'))

--- a/opengever/workspaceclient/tests/test_session.py
+++ b/opengever/workspaceclient/tests/test_session.py
@@ -1,0 +1,112 @@
+from datetime import datetime
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.tokenauth.pas.storage import CredentialStorage
+from opengever.workspaceclient.exceptions import APIRequestException
+from opengever.workspaceclient.session import GEVER_VERSION
+from opengever.workspaceclient.session import WorkspaceSession
+from opengever.workspaceclient.tests import FunctionalWorkspaceClientTestCase
+from plone import api
+from plone.app.testing import TEST_USER_ID
+import requests_mock
+import transaction
+
+
+class TestWorkspaceSessionManager(FunctionalWorkspaceClientTestCase):
+
+    def test_prepare_authenticated_session_object(self):
+        create(Builder('workspace_token_auth_app')
+               .issuer(self.service_user)
+               .uri(self.portal.absolute_url()))
+        transaction.commit()
+
+        session = WorkspaceSession(self.portal.absolute_url(), TEST_USER_ID)
+
+        self.assertIn('Bearer ',
+                      session.session.headers.get('Authorization'))
+        self.assertEqual('application/json',
+                         session.session.headers.get('Accept'))
+
+    def test_make_requests_with_the_session(self):
+        create(Builder('workspace_token_auth_app')
+               .issuer(self.service_user)
+               .uri(self.portal.absolute_url()))
+        transaction.commit()
+
+        session = WorkspaceSession(self.portal.absolute_url(), TEST_USER_ID)
+
+        response = session.request.get(self.portal.absolute_url()).json()
+
+        self.assertEqual(self.portal.absolute_url(), response.get('@id'))
+
+    def test_auto_renew_access_token_if_expired(self):
+        def extract_jwt_token(session):
+            return session.session.headers.get('Authorization').split(' ')[-1]
+
+        plugin = api.portal.get_tool('acl_users')['token_auth']
+        storage = CredentialStorage(plugin)
+        create(Builder('workspace_token_auth_app')
+               .issuer(self.service_user)
+               .uri(self.portal.absolute_url()))
+        transaction.commit()
+
+        # Make a new session will create a jwt-token for the current session
+        session = WorkspaceSession(self.portal.absolute_url(), TEST_USER_ID)
+        jwt_token = extract_jwt_token(session)
+        transaction.commit()
+
+        # Making a request with the same session will reuse the jwt_token
+        response = session.request.get(self.portal.absolute_url()).json()
+        self.assertEqual(jwt_token, extract_jwt_token(session),
+                         "JWT token should still be the same")
+
+        # Set access token as expired
+        access_token = storage.get_access_token(jwt_token)
+        access_token['issued'] = datetime(2018, 1, 1, 15, 30)
+        transaction.commit()
+
+        # Making a request with an expired token will auto-renew the jwt-token
+        response = session.request.get(self.portal.absolute_url()).json()
+        self.assertNotEqual(jwt_token, extract_jwt_token(session),
+                            "JWT should have been renewed")
+        self.assertEqual(self.portal.absolute_url(), response.get('@id'))
+
+    def test_error_when_key_invalid(self):
+        create(Builder('workspace_token_auth_app')
+               .issuer(self.service_user)
+               .uri(self.portal.absolute_url()))
+        transaction.commit()
+
+        with requests_mock.Mocker() as mocker:
+            mocker.post('{}/@@oauth2-token'.format(self.portal.absolute_url()),
+                        status_code=500)
+            with self.assertRaises(APIRequestException) as cm:
+                WorkspaceSession(self.portal.absolute_url(), 'john.doe')
+
+        self.maxDiff = None
+        self.assertEqual(
+            '500 Server Error: None for url: {}/@@oauth2-token'.format(self.portal.absolute_url()),
+            str(cm.exception.original_exception))
+
+    def test_user_agent(self):
+        create(Builder('workspace_token_auth_app')
+               .issuer(self.service_user)
+               .uri(self.portal.absolute_url()))
+        transaction.commit()
+
+        manager = WorkspaceSession(self.portal.absolute_url(), self.service_user.getId())
+        self.assertEqual(
+            manager.session.headers.get('User-Agent'),
+            'opengever.core/{}'.format(GEVER_VERSION))
+
+    def test_user_agent_is_configurable(self):
+        create(Builder('workspace_token_auth_app')
+               .issuer(self.service_user)
+               .uri(self.portal.absolute_url()))
+        transaction.commit()
+
+        with self.env(OPENGEVER_APICLIENT_USER_AGENT='Baumverwaltung/7.0'):
+            manager = WorkspaceSession(self.portal.absolute_url(), self.service_user.getId())
+            self.assertEqual(
+                manager.session.headers.get('User-Agent'),
+                'opengever.core/{} Baumverwaltung/7.0'.format(GEVER_VERSION))


### PR DESCRIPTION
Issuer #6205 

Dieser PR implementiert den Auth-Flow gem. #6205 

Mit dieser Anpassung wird opengever.core zum Client gegenüber Serviceapplikationen. Diese Anforderung wird momentan für den Teamraum benötigt. Der Teamraum wird neu als Serviceapplikation als eigenständiges Deployment installiert. GEVER muss sich nun am Teamraum authentisieren können und entsprechende Abfragen absetzen können.

Der PR implementiert die Möglichkeit, das generierte Claim-Set mit dem Private-Key von [ftw.tokenauth](https://github.com/4teamwork/ftw.tokenauth) in GEVER zu speichern und für eine bestimmte URL zu verwenden.

⚠️ Dieser PR implementiert das Key-Handling und die Authentisierung mit [ftw.tokenauth](https://github.com/4teamwork/ftw.tokenauth). Die Teamraum-Integration wird nicht durch diesen PR implementiert.

## Checkliste
- [x] Sind UpgradeSteps `deferrable`, oder können gewisse Schritte des Upgrades konditional ausgeführt werden?
- [x] Changelog-Eintrag vorhanden/nötig?
- [x] Aktualisierung Dokumentation vorhanden/nötig?
