### PR TITLE
Add permission and role to use the Workspace Client.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2020.1.0rc3 (unreleased)
 ------------------------
 
+- Add permission and role to use the workspace Client. [njohner]
 - Add french titles for initial content in the policytemplate. [phgross]
 - Enable the solr flag in the policytemplate. [phgross]
 

--- a/opengever/core/lawgiver.zcml
+++ b/opengever/core/lawgiver.zcml
@@ -183,6 +183,13 @@
                    "
       />
 
+  <!-- Use Workspace Client is only managed globally in rolemap.xml. -->
+  <lawgiver:ignore
+      permissions="
+                   opengever.workspaceclient: Use Workspace Client,
+                   "
+      />
+
   <!--  "ftw.usermigration: Migrate users" is never managed via workflows -->
   <lawgiver:ignore
       permissions="

--- a/opengever/core/profiles/default/rolemap.xml
+++ b/opengever/core/profiles/default/rolemap.xml
@@ -19,6 +19,7 @@
     <role name="WorkspaceMember" />
     <role name="WorkspacesCreator" />
     <role name="WorkspacesUser" />
+    <role name="WorkspaceClientUser" />
     <role name="MemberAreaAdministrator" />
   </roles>
 
@@ -313,6 +314,10 @@
 
     <permission name="opengever.workspace: Update Content Order" acquire="True">
       <role name="Manager" />
+    </permission>
+
+    <permission name="opengever.workspaceclient: Use Workspace Client" acquire="True">
+      <role name="WorkspaceClientUser" />
     </permission>
 
     <permission name="plone.restapi: Access Plone vocabularies" acquire="True">

--- a/opengever/core/upgrades/20200203174321_add_permission_and_role_to_use_workspace_client/rolemap.xml
+++ b/opengever/core/upgrades/20200203174321_add_permission_and_role_to_use_workspace_client/rolemap.xml
@@ -1,0 +1,14 @@
+<rolemap>
+
+  <roles>
+    <role name="WorkspaceClientUser" />
+  </roles>
+
+  <permissions>
+    <permission name="opengever.workspaceclient: Use Workspace Client" acquire="True">
+      <role name="WorkspaceClientUser" />
+    </permission>
+
+  </permissions>
+
+</rolemap>

--- a/opengever/core/upgrades/20200203174321_add_permission_and_role_to_use_workspace_client/upgrade.py
+++ b/opengever/core/upgrades/20200203174321_add_permission_and_role_to_use_workspace_client/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddPermissionAndRoleToUseWorkspaceClient(UpgradeStep):
+    """Add permission and role to use workspace client.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/workspaceclient/client.py
+++ b/opengever/workspaceclient/client.py
@@ -3,6 +3,7 @@ from opengever.workspaceclient.exceptions import WorkspaceClientFeatureNotEnable
 from opengever.workspaceclient.exceptions import WorkspaceURLMissing
 from opengever.workspaceclient.session import WorkspaceSession
 from plone import api
+from zExceptions import Unauthorized
 import os
 
 
@@ -21,8 +22,10 @@ class WorkspaceClient(object):
     @property
     def session(self):
         """We always need to invoke a new workspace-session. Otherwise it is
-        possible to dispatch a reqeust with another users session.
+        possible to dispatch a request with another users session.
         """
+        if not api.user.has_permission('opengever.workspaceclient: Use Workspace Client'):
+            raise Unauthorized("User does not have permission to use the WorkspaceClient")
         return WorkspaceSession(self.workspace_url,
                                 api.user.get_current().getId())
 

--- a/opengever/workspaceclient/configure.zcml
+++ b/opengever/workspaceclient/configure.zcml
@@ -4,6 +4,8 @@
     xmlns:plone="http://namespaces.plone.org/plone"
     i18n_domain="opengever.workspaceclient">
 
+  <include file="permissions.zcml" />
+
   <plone:behavior
       title="Remote workpsace support"
       description="Provides functions to handle remote workspaces"

--- a/opengever/workspaceclient/permissions.zcml
+++ b/opengever/workspaceclient/permissions.zcml
@@ -1,0 +1,7 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    i18n_domain="opengever.workspaceclient">
+
+  <permission id="opengever.workspaceclient.UserWorkspaceClient" title="opengever.workspaceclient: Use Workspace Client" />
+
+</configure>

--- a/opengever/workspaceclient/tests/__init__.py
+++ b/opengever/workspaceclient/tests/__init__.py
@@ -44,6 +44,9 @@ class FunctionalWorkspaceClientTestCase(FunctionalTestCase):
         self.workspace = create(Builder('workspace').within(self.workspace_root))
         self.grant('WorkspaceMember', on=self.workspace)
 
+        # Grant necessary permissions to use the workspace client
+        self.grant('WorkspaceClientUser', *api.user.get_roles())
+
         # Reset the session store
         SESSION_STORAGE.sessions = None
 

--- a/opengever/workspaceclient/tests/test_client.py
+++ b/opengever/workspaceclient/tests/test_client.py
@@ -2,6 +2,8 @@ from opengever.workspaceclient.client import WorkspaceClient
 from opengever.workspaceclient.exceptions import WorkspaceClientFeatureNotEnabled
 from opengever.workspaceclient.exceptions import WorkspaceURLMissing
 from opengever.workspaceclient.tests import FunctionalWorkspaceClientTestCase
+from plone import api
+from zExceptions import Unauthorized
 
 
 class TestWorkspaceClient(FunctionalWorkspaceClientTestCase):
@@ -15,6 +17,15 @@ class TestWorkspaceClient(FunctionalWorkspaceClientTestCase):
         with self.env(TEAMRAUM_URL=''):
             with self.assertRaises(WorkspaceURLMissing):
                 WorkspaceClient()
+
+    def test_raises_an_error_if_user_lacks_neccesary_permissions(self):
+        with self.workspace_client_env() as client:
+            client.request.get('/').json()
+
+            roles = set(api.user.get_roles())
+            self.grant(roles.difference({'WorkspaceClientUser'}))
+            with self.assertRaises(Unauthorized):
+                client.request.get('/').json()
 
     def test_make_requests_to_the_configured_workspace(self):
         with self.workspace_client_env() as client:


### PR DESCRIPTION
We add a new role and permission to allow the use of the `WorkspaceClient`. This permission should also be used for API endpoints.

For https://github.com/4teamwork/opengever.core/issues/6192

## Checkliste
- [ ] Sind UpgradeSteps `deferrable`, oder können gewisse Schritte des Upgrades konditional ausgeführt werden? Upgrade is not deferrable
- [x] Changelog-Eintrag vorhanden/nötig?
