### PR TITLE
Only return create_task in actions endpoint on dossiers and tasks.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -8,6 +8,7 @@ Changelog
 - Implement the workspace client to make requests to a teamraum from GEVER. [elioschmutz]
 - Implement the workspace client authentication flow. [elioschmutz]
 - Handle deployments with no repository in navigation endpoint. [njohner]
+- Only return create_task in actions endpoint on dossiers and tasks. [njohner]
 - Add documentation for sharing endpoint. [njohner]
 - Always request UID from solr, as it is needed for snippets. [njohner]
 - Speed up validation of dossier resolution preconditions. [njohner]

--- a/opengever/api/tests/test_actions.py
+++ b/opengever/api/tests/test_actions.py
@@ -519,3 +519,65 @@ class TestNewTaskFromDocumentAction(FileActionsTestBase):
             ]
         self.assertEqual(expected_file_actions,
                          self.get_file_actions(browser, self.inactive_document))
+
+
+class TestFolderActions(IntegrationTestCase):
+
+    features = ('bumblebee',)
+    maxDiff = None
+    createTaskAction = {
+        u'id': u'create_task',
+        u'title': u'Create Task',
+        u'icon': u'',}
+
+    def get_folder_buttons(self, browser, context):
+        browser.open(context.absolute_url() + '/@actions',
+                     method='GET', headers=self.api_headers)
+        return browser.json['folder_buttons']
+
+    @browsing
+    def test_create_task_available_in_open_dossier(self, browser):
+        self.login(self.secretariat_user, browser)
+        self.assertIn(self.createTaskAction,
+                      self.get_folder_buttons(browser, self.resolvable_dossier))
+
+    @browsing
+    def test_create_task_available_in_task(self, browser):
+        self.login(self.regular_user, browser)
+        self.assertIn(self.createTaskAction,
+                         self.get_folder_buttons(browser, self.task))
+
+    @browsing
+    def test_create_task_available_in_meetingdossier(self, browser):
+        self.login(self.regular_user, browser)
+        self.assertIn(self.createTaskAction,
+                         self.get_folder_buttons(browser, self.meeting_dossier))
+
+    @browsing
+    def test_create_task_not_available_in_resolved_dossier(self, browser):
+        self.login(self.secretariat_user, browser)
+
+        browser.open(self.resolvable_dossier,
+                     view='transition-resolve',
+                     data={'_authenticator': createToken()})
+        self.assertNotIn(self.createTaskAction,
+                         self.get_folder_buttons(browser, self.resolvable_dossier))
+
+    @browsing
+    def test_create_task_not_available_in_inbox(self, browser):
+        self.login(self.secretariat_user, browser)
+        self.assertNotIn(self.createTaskAction,
+                         self.get_folder_buttons(browser, self.inbox))
+
+    @browsing
+    def test_create_task_not_available_in_private_dossier(self, browser):
+        self.login(self.regular_user, browser)
+        self.assertNotIn(self.createTaskAction,
+                         self.get_folder_buttons(browser, self.private_dossier))
+
+
+    @browsing
+    def test_create_task_not_available_inactive_dossier(self, browser):
+        self.login(self.regular_user, browser)
+        self.assertNotIn(self.createTaskAction,
+                         self.get_folder_buttons(browser, self.inactive_dossier))

--- a/opengever/base/browser/configure.zcml
+++ b/opengever/base/browser/configure.zcml
@@ -263,4 +263,11 @@
       layer="opengever.base.interfaces.IOpengeverBaseLayer"
       />
 
+  <browser:page
+      for="*"
+      name="folder_buttons_availability"
+      class=".folder_buttons_availability.FolderButtonsAvailabilityView"
+      permission="zope2.View"
+      />
+
 </configure>

--- a/opengever/base/browser/folder_buttons_availability.py
+++ b/opengever/base/browser/folder_buttons_availability.py
@@ -1,0 +1,21 @@
+from Products.Five import BrowserView
+from opengever.dossier.behaviors.dossier import IDossierMarker
+from plone import api
+from opengever.task.task import ITask
+
+
+class FolderButtonsAvailabilityView(BrowserView):
+    """Define availability for folder_button actions.
+
+    Methods should return availability for one single action.
+    """
+    def __init__(self, context, request):
+        self.context = context
+        self.request = request
+
+    def is_create_task_available(self):
+        is_dossier = IDossierMarker.providedBy(self.context)
+        is_task = ITask.providedBy(self.context)
+        may_add_task = api.user.has_permission('opengever.task: Add task',
+                                               obj=self.context)
+        return (is_dossier or is_task) and may_add_task

--- a/opengever/core/profiles/default/actions.xml
+++ b/opengever/core/profiles/default/actions.xml
@@ -280,10 +280,7 @@
       <property name="description" i18n:translate="" />
       <property name="url_expr">string:++add++opengever.task.task:method</property>
       <property name="icon_expr" />
-      <property name="available_expr" />
-      <property name="permissions">
-        <element value="opengever.task: Add task" />
-      </property>
+      <property name="available_expr">object/@@folder_buttons_availability/is_create_task_available</property>
       <property name="visible">True</property>
     </object>
 

--- a/opengever/core/upgrades/20200205102852_add_new_task_from_documents_action/actions.xml
+++ b/opengever/core/upgrades/20200205102852_add_new_task_from_documents_action/actions.xml
@@ -1,0 +1,16 @@
+<object xmlns:i18n="http://xml.zope.org/namespaces/i18n" name="portal_actions" meta_type="Plone Actions Tool">
+
+  <object name="folder_buttons" meta_type="CMF Action Category">
+
+    <object name="create_task" meta_type="CMF Action" i18n:domain="opengever.core">
+      <property name="title" i18n:translate="">Create Task</property>
+      <property name="description" i18n:translate="" />
+      <property name="url_expr">string:++add++opengever.task.task:method</property>
+      <property name="icon_expr" />
+      <property name="available_expr">object/@@folder_buttons_availability/is_create_task_available</property>
+      <property name="visible">True</property>
+    </object>
+
+  </object>
+
+</object>

--- a/opengever/core/upgrades/20200205102852_add_new_task_from_documents_action/upgrade.py
+++ b/opengever/core/upgrades/20200205102852_add_new_task_from_documents_action/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddNewTaskFromDocumentsAction(UpgradeStep):
+    """Add new task from documents action.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/dossier/templatefolder/tabs.py
+++ b/opengever/dossier/templatefolder/tabs.py
@@ -51,7 +51,6 @@ class TemplateFolderDocuments(Documents):
         'checkin',
         'checkout',
         'trashed',
-        'create_task',
         'send_as_email',
         'submit_additional_documents',
     ]
@@ -120,7 +119,6 @@ class TemplateFolderSablonTemplates(Documents):
         'cancel',
         'checkin',
         'checkout',
-        'create_task',
         'trashed',
         'move_items',
         'send_as_email',
@@ -162,7 +160,6 @@ class TemplateFolderProposalTemplates(Documents):
         'cancel',
         'checkin',
         'checkout',
-        'create_task',
         'trashed',
         'move_items',
         'send_as_email',

--- a/opengever/inbox/browser/tabs.py
+++ b/opengever/inbox/browser/tabs.py
@@ -79,7 +79,6 @@ class InboxDocuments(Documents):
     depth = 1
 
     disabled_actions = ['create_proposal',
-                        'create_task',
                         'submit_additional_documents']
 
     @property
@@ -115,8 +114,6 @@ class InboxDocuments(Documents):
     def major_actions(self):
         """Defines wich actions are major Actions"""
         actions = super(InboxDocuments, self).major_actions
-        actions = [action for action in actions
-                   if action not in ('create_task',)]
         actions += ['create_forwarding']
         return actions
 

--- a/opengever/repository/browser/tabs.py
+++ b/opengever/repository/browser/tabs.py
@@ -9,7 +9,6 @@ class RepositoryFolderDocuments(Documents):
         'zip_selected',  # disabled because ZIP does not work on repository folders
         'send_as_email',  # target not available on repository folders
         'trashed',  # target not available on repository folders
-        'create_task',  # cannot create task in repository folders
     )
 
     @property


### PR DESCRIPTION
We only return `create_task` in the `@actions` endpoint on dossiers and tasks. Before the action was available everywhere where the user has the `Add task` permission and it was then specifically disabled on some different content_types in the tabs. We now only return the action when it actually should be displayed so that the frontend can rely on the presence of the action in the `@actions` endpoint.

Note that we decided to not display the `new_task_from_document` action  (in the new UI) on documents inside tasks, although the `create_task` action is available on the document listing inside tasks.

## Checkliste
- [ ] Sind UpgradeSteps `deferrable`, oder können gewisse Schritte des Upgrades konditional ausgeführt werden? I guess we could make it deferrable, but there really isn't any benefits to it
- [x] Changelog-Eintrag vorhanden/nötig?
