### PR TITLE
Add WorkspaceClient to access the connected workspace

### DIFF
--- a/development.cfg
+++ b/development.cfg
@@ -55,6 +55,7 @@ environment-vars +=
     BUMBLEBEE_APP_ID gever_dev
     BUMBLEBEE_INTERNAL_PLONE_URL http://localhost:${instance:http-address}/fd
     BUMBLEBEE_PUBLIC_URL http://localhost:3000/
+    TEAMRAUM_URL http://localhost:8080/fd
 
 zcml +=
   opengever.core

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,8 @@ Changelog
 
 - Bump ftw.solr to 2.8.1 for to_iso8601 fix for years before 1900. [deiferni]
 - Implement the teamraum client authentication flow. [elioschmutz]
+- Implement the workspace client to make requests to a teamraum from GEVER. [elioschmutz]
+- Implement the workspace client authentication flow. [elioschmutz]
 - Add documentation for sharing endpoint. [njohner]
 - Always request UID from solr, as it is needed for snippets. [njohner]
 - Speed up validation of dossier resolution preconditions. [njohner]

--- a/docs/intern/kurzreferenzen/teamraum.rst
+++ b/docs/intern/kurzreferenzen/teamraum.rst
@@ -19,3 +19,17 @@ Der von `ftw.tokenauth <https://github.com/4teamwork/ftw.tokenauth>`__ generiert
 GEVER sucht im Ordner ``~/.opengever/ftw_tokenauth_keys`` nach entsprechenden Schlüsseln.
 
 Erstellen Sie ein ``.json`` z.B. ``teamraum_dev.json`` mit dem gesamten Schlüssel als Inhalt. GEVER wird später anhand der ``token_uri`` im Schlüssel automatisch das korrekte Schlüssel-File für den Request auf den Teamraum verwenden.
+
+Teamraum-URL definieren
+-----------------------
+Damit GEVER weiss, wo sich die Teamraum-Installation befindet, muss die URL in den Umgebungsvariablen konfiguriert werden:
+
+``export TEAMRAUM_URL=http://example.com``
+
+**Hinweis** Das ``development.cfg`` setzt die Umgebungsvariable bereits auf ``http://localhost:8080/fd``. Das GEVER und die Teamraum installation ist somit das gleiche Deployment.
+
+Feature aktivieren
+------------------
+Nachdem die Verbindung konfiguriert ist, muss das Feature für den Teamraum-Client in der Plone-Registry unter dem Key: ``IWorkspaceClientSettings`` aktiviert werden.
+
+**Achtung**: Die Verbindung funktioniert nicht mit dem zopemaster: https://github.com/4teamwork/ftw.tokenauth/blob/master/ftw/tokenauth/pas/plugin.py#L254

--- a/opengever/api/tests/test_config.py
+++ b/opengever/api/tests/test_config.py
@@ -73,6 +73,7 @@ class TestConfig(IntegrationTestCase):
                 u'solr': False,
                 u'tasks_pdf': False,
                 u'workspace': False,
+                u'workspace_client': False,
             })
 
     @browsing

--- a/opengever/base/configuration.py
+++ b/opengever/base/configuration.py
@@ -29,6 +29,7 @@ from opengever.repository.interfaces import IRepositoryFolderRecords
 from opengever.sharing.interfaces import ISharingConfiguration
 from opengever.task.interfaces import ITaskSettings
 from opengever.workspace.interfaces import IWorkspaceSettings
+from opengever.workspaceclient.interfaces import IWorkspaceClientSettings
 from pkg_resources import get_distribution
 from plone import api
 from zope.component import adapter
@@ -134,6 +135,7 @@ class GeverSettingsAdpaterV1(object):
         features['sablon_date_format'] = api.portal.get_registry_record('sablon_date_format_string', interface=IMeetingSettings)  # noqa
         features['solr'] = api.portal.get_registry_record('use_solr', interface=ISearchSettings)
         features['workspace'] = api.portal.get_registry_record('is_feature_enabled', interface=IWorkspaceSettings)
+        features['workspace_client'] = api.portal.get_registry_record('is_feature_enabled', interface=IWorkspaceClientSettings)  # noqa
         features['private_tasks'] = api.portal.get_registry_record('private_task_feature_enabled', interface=ITaskSettings)
         features['optional_task_permissions_revoking'] = api.portal.get_registry_record('optional_task_permissions_revoking_enabled', interface=ITaskSettings)  # noqa
         return features

--- a/opengever/base/tests/test_configuration_adapter.py
+++ b/opengever/base/tests/test_configuration_adapter.py
@@ -67,6 +67,7 @@ class TestConfigurationAdapter(IntegrationTestCase):
                 ('sablon_date_format', u'%d.%m.%Y'),
                 ('solr', False),
                 ('workspace', False),
+                ('workspace_client', False),
                 ('private_tasks', True),
                 ('optional_task_permissions_revoking', False),
                 ])),

--- a/opengever/core/profiles/default/registry.xml
+++ b/opengever/core/profiles/default/registry.xml
@@ -176,4 +176,7 @@
   <!-- Workspace -->
   <records interface="opengever.workspace.interfaces.IWorkspaceSettings" />
 
+  <!-- WorkspaceClient-->
+  <records interface="opengever.workspaceclient.interfaces.IWorkspaceClientSettings" />
+
 </registry>

--- a/opengever/core/upgrades/20200204154822_add_workspace_client_settings/registry.xml
+++ b/opengever/core/upgrades/20200204154822_add_workspace_client_settings/registry.xml
@@ -1,0 +1,6 @@
+<registry>
+
+  <!-- WorkspaceClient-->
+  <records interface="opengever.workspaceclient.interfaces.IWorkspaceClientSettings" />
+
+</registry>

--- a/opengever/core/upgrades/20200204154822_add_workspace_client_settings/upgrade.py
+++ b/opengever/core/upgrades/20200204154822_add_workspace_client_settings/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddWorkspaceClientSettings(UpgradeStep):
+    """Add workspace client settings.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/testing/integration_test_case.py
+++ b/opengever/testing/integration_test_case.py
@@ -81,6 +81,7 @@ FEATURE_FLAGS = {
     'repositoryfolder-proposals-tab': 'opengever.repository.interfaces.IRepositoryFolderRecords.show_proposals_tab',
     'repositoryfolder-tasks-tab': 'opengever.repository.interfaces.IRepositoryFolderRecords.show_tasks_tab',
     'workspace': 'opengever.workspace.interfaces.IWorkspaceSettings.is_feature_enabled',
+    'workspace_client': 'opengever.workspace.interfaces.IWorkspaceClientSettings.is_feature_enabled',
     'favorites': 'opengever.base.interfaces.IFavoritesSettings.is_feature_enabled',
     'solr': 'opengever.base.interfaces.ISearchSettings.use_solr',
     'purge-trash': 'opengever.dossier.interfaces.IDossierResolveProperties.purge_trash_enabled',

--- a/opengever/workspaceclient/__init__.py
+++ b/opengever/workspaceclient/__init__.py
@@ -1,3 +1,10 @@
+from opengever.workspaceclient.interfaces import IWorkspaceClientSettings
+from plone import api
 import logging
 
 logger = logging.getLogger('opengever.workspaceclient')
+
+
+def is_workspace_client_feature_enabled():
+    return api.portal.get_registry_record(
+        'is_feature_enabled', IWorkspaceClientSettings, False)

--- a/opengever/workspaceclient/client.py
+++ b/opengever/workspaceclient/client.py
@@ -1,0 +1,39 @@
+from opengever.workspaceclient import is_workspace_client_feature_enabled
+from opengever.workspaceclient.exceptions import WorkspaceClientFeatureNotEnabled
+from opengever.workspaceclient.exceptions import WorkspaceURLMissing
+from opengever.workspaceclient.session import WorkspaceSession
+from plone import api
+import os
+
+
+class WorkspaceClient(object):
+    """The client is used for communicating with a workspace through the
+    REST API. It is instantiated for the current logged in user.
+    """
+
+    def __init__(self):
+        if not is_workspace_client_feature_enabled():
+            raise WorkspaceClientFeatureNotEnabled()
+
+        if not self.workspace_url:
+            raise WorkspaceURLMissing()
+
+    @property
+    def session(self):
+        """We always need to invoke a new workspace-session. Otherwise it is
+        possible to dispatch a reqeust with another users session.
+        """
+        return WorkspaceSession(self.workspace_url,
+                                api.user.get_current().getId())
+
+    @property
+    def request(self):
+        """Returns the request object from the current session.
+        """
+        return self.session.request
+
+    @property
+    def workspace_url(self):
+        """Retruns the configured workspace url in the env variable.
+        """
+        return os.environ.get('TEAMRAUM_URL', '').strip('/')

--- a/opengever/workspaceclient/exceptions.py
+++ b/opengever/workspaceclient/exceptions.py
@@ -35,3 +35,20 @@ class APIRequestException(Exception):
                 msgs.append("Response from service app: {}".format(self.original_exception.response.text))
 
         return "\n".join(msgs)
+
+
+class WorkspaceURLMissing(Exception):
+
+    def __init__(self):
+        super(WorkspaceURLMissing, self).__init__(
+            'The WorkspaceClient does not know where to dispatch the request.\n'
+            'Please specify a URL to the workspace through the environment '
+            'variable: TEAMRAUM_URL ')
+
+
+class WorkspaceClientFeatureNotEnabled(Exception):
+
+    def __init__(self):
+        super(WorkspaceClientFeatureNotEnabled, self).__init__(
+            'Please activate the workspace client feature in the portal '
+            'registry in the IWorkspaceClientSettings')

--- a/opengever/workspaceclient/interfaces.py
+++ b/opengever/workspaceclient/interfaces.py
@@ -1,0 +1,10 @@
+from zope import schema
+from zope.interface import Interface
+
+
+class IWorkspaceClientSettings(Interface):
+
+    is_feature_enabled = schema.Bool(
+        title=u'Enable workspace client feature',
+        description=u'Whether a remote workspace integration is enabled',
+        default=False)

--- a/opengever/workspaceclient/session.py
+++ b/opengever/workspaceclient/session.py
@@ -155,6 +155,7 @@ class WorkspaceSession(object):
         session.obtain_token()
         return session
 
+    @property
     def _unique_session_key(self):
         return (self.workspace_url, self.username)
 

--- a/opengever/workspaceclient/session.py
+++ b/opengever/workspaceclient/session.py
@@ -15,25 +15,37 @@ GEVER_VERSION = pkg_resources.get_distribution('opengever.core').version
 
 
 class FtwTokenAuthSession(requests.Session):
-    """This Session class takes care of the authentication token.
+    """This Session class takes care of the authentication token. It will
+    auto-renew the access-token as soon as it is expired.
 
-    It will auto-renew the access-token as soon as it is expired.
+    In addition, it binds the request to the base_url. Requests made by
+    this session object will always prepend the base_url to the request-url.
+    This allows us to use relative urls for further requests.
+
+    Example usage of this session object:
+
+    session = FtwTokenAuthSession('http://example.com', service_key, 'test.user')
+    session.get('folder-1')  # will resolve to 'http://example.com/folder-1'
     """
     session_expiration_seconds = 60 * 60
 
-    def __init__(self, service_key, username):
+    def __init__(self, base_url, service_key, username):
         super(FtwTokenAuthSession, self).__init__()
+        self.base_url = base_url.strip('/')
         self.service_key = service_key
         self.username = username
 
-    def request(self, *args, **kwargs):
-        response = super(FtwTokenAuthSession, self).request(*args, **kwargs)
+    def request(self, method, path_or_url, *args, **kwargs):
+        url = self.url_from_path_or_url(path_or_url)
+        response = super(FtwTokenAuthSession, self).request(method, url,
+                                                            *args, **kwargs)
 
         if self.token_has_expired(response):
             # We got an 'Access token expired' response => refresh token
             self.obtain_token()
             # Re-dispatch the request that previously failed
-            response = super(FtwTokenAuthSession, self).request(*args, **kwargs)
+            response = super(FtwTokenAuthSession, self).request(method, url,
+                                                                *args, **kwargs)
 
         self.raise_for_status(response)
 
@@ -76,6 +88,22 @@ class FtwTokenAuthSession(requests.Session):
             response.raise_for_status()
         except HTTPError as exception:
             raise APIRequestException(exception)
+
+    def url_from_path_or_url(self, path_or_url):
+        """Generates a url based on the path_or_url:
+
+        1. Path "workspace-1/folder-1"
+
+        1a. replace base_url: workspace-1/folder-1 => workspace-1/folder-1
+        1b. prepend base_url: workspace-1/folder-1 => http://example.com/workspace-1/folder-1
+
+        2. URL "http://example.com/workspace-1/folder-1"
+
+        2a. replace base_url: http://example.com/workspace-1/folder-1 => workspace-1/folder-1
+        1b. prepend base_url: workspace-1/folder-1 => http://example.com/workspace-1/folder-1
+        """
+        path = path_or_url.replace(self.base_url, '')
+        return '/'.join([self.base_url, path.lstrip('/')]).strip('/')
 
 
 class WorkspaceSession(object):
@@ -121,7 +149,7 @@ class WorkspaceSession(object):
         """Create a fresh requests session and return it.
         """
         service_key = key_registry.get_key_for(self.workspace_url)
-        session = FtwTokenAuthSession(service_key, self.username)
+        session = FtwTokenAuthSession(self.workspace_url, service_key, self.username)
         session.headers.update({"User-Agent": self._user_agent})
         session.headers.update({"Accept": "application/json"})
         session.obtain_token()

--- a/opengever/workspaceclient/tests/__init__.py
+++ b/opengever/workspaceclient/tests/__init__.py
@@ -4,6 +4,7 @@ from ftw.builder import create
 from ftw.tokenauth.testing.builders import KeyPairBuilder  # noqa
 from opengever.core.testing import OPENGEVER_FUNCTIONAL_ZSERVER_TESTING
 from opengever.testing import FunctionalTestCase
+from opengever.workspaceclient.interfaces import IWorkspaceClientSettings
 from plone import api
 import os
 
@@ -24,6 +25,8 @@ class FunctionalWorkspaceClientTestCase(FunctionalTestCase):
         api.user.grant_roles(user=self.service_user,
                              roles=['ServiceKeyUser', 'Impersonator'])
 
+        self.enable_feature()
+
     @contextmanager
     def env(self, **env):
         """Temporary set env variables.
@@ -35,3 +38,7 @@ class FunctionalWorkspaceClientTestCase(FunctionalTestCase):
         finally:
             os.environ.clear()
             os.environ.update(original)
+
+    def enable_feature(self, enabled=True):
+        api.portal.set_registry_record(
+            'is_feature_enabled', enabled, IWorkspaceClientSettings)

--- a/opengever/workspaceclient/tests/__init__.py
+++ b/opengever/workspaceclient/tests/__init__.py
@@ -6,6 +6,7 @@ from opengever.core.testing import OPENGEVER_FUNCTIONAL_ZSERVER_TESTING
 from opengever.testing import FunctionalTestCase
 from opengever.workspaceclient.client import WorkspaceClient
 from opengever.workspaceclient.interfaces import IWorkspaceClientSettings
+from opengever.workspaceclient.session import SESSION_STORAGE
 from plone import api
 import os
 import transaction
@@ -29,6 +30,9 @@ class FunctionalWorkspaceClientTestCase(FunctionalTestCase):
                                             username='service.user')
         api.user.grant_roles(user=self.service_user,
                              roles=['ServiceKeyUser', 'Impersonator'])
+
+        # Reset the session store
+        SESSION_STORAGE.sessions = None
 
         self.enable_feature()
 

--- a/opengever/workspaceclient/tests/test_client.py
+++ b/opengever/workspaceclient/tests/test_client.py
@@ -1,0 +1,23 @@
+from opengever.workspaceclient.client import WorkspaceClient
+from opengever.workspaceclient.exceptions import WorkspaceClientFeatureNotEnabled
+from opengever.workspaceclient.exceptions import WorkspaceURLMissing
+from opengever.workspaceclient.tests import FunctionalWorkspaceClientTestCase
+
+
+class TestWorkspaceClient(FunctionalWorkspaceClientTestCase):
+
+    def test_raises_an_error_if_using_the_client_with_disabled_feature(self):
+        self.enable_feature(False)
+        with self.assertRaises(WorkspaceClientFeatureNotEnabled):
+            WorkspaceClient()
+
+    def test_raises_an_error_if_the_workspace_url_is_not_configured(self):
+        with self.env(TEAMRAUM_URL=''):
+            with self.assertRaises(WorkspaceURLMissing):
+                WorkspaceClient()
+
+    def test_make_requests_to_the_configured_workspace(self):
+        with self.workspace_client_env() as client:
+            response = client.request.get(self.portal.absolute_url()).json()
+
+        self.assertEqual(self.portal.absolute_url(), response.get('@id'))

--- a/opengever/workspaceclient/tests/test_client.py
+++ b/opengever/workspaceclient/tests/test_client.py
@@ -18,6 +18,6 @@ class TestWorkspaceClient(FunctionalWorkspaceClientTestCase):
 
     def test_make_requests_to_the_configured_workspace(self):
         with self.workspace_client_env() as client:
-            response = client.request.get(self.portal.absolute_url()).json()
+            response = client.request.get('/').json()
 
         self.assertEqual(self.portal.absolute_url(), response.get('@id'))

--- a/opengever/workspaceclient/tests/test_session.py
+++ b/opengever/workspaceclient/tests/test_session.py
@@ -110,3 +110,25 @@ class TestWorkspaceSessionManager(FunctionalWorkspaceClientTestCase):
             self.assertEqual(
                 manager.session.headers.get('User-Agent'),
                 'opengever.core/{} Baumverwaltung/7.0'.format(GEVER_VERSION))
+
+    def test_unique_session_for_each_user(self):
+        create(Builder('workspace_token_auth_app')
+               .issuer(self.service_user)
+               .uri(self.portal.absolute_url()))
+        transaction.commit()
+
+        session_1 = WorkspaceSession(self.portal.absolute_url(), TEST_USER_ID)
+        session_2 = WorkspaceSession(self.portal.absolute_url(), self.service_user.getId())
+
+        self.assertIsNot(session_1.session, session_2.session)
+
+    def test_reuse_session(self):
+        create(Builder('workspace_token_auth_app')
+               .issuer(self.service_user)
+               .uri(self.portal.absolute_url()))
+        transaction.commit()
+
+        session_1 = WorkspaceSession(self.portal.absolute_url(), TEST_USER_ID)
+        session_2 = WorkspaceSession(self.portal.absolute_url(), TEST_USER_ID)
+
+        self.assertIs(session_1.session, session_2.session)

--- a/opengever/workspaceclient/tests/test_session.py
+++ b/opengever/workspaceclient/tests/test_session.py
@@ -35,7 +35,7 @@ class TestWorkspaceSessionManager(FunctionalWorkspaceClientTestCase):
 
         session = WorkspaceSession(self.portal.absolute_url(), TEST_USER_ID)
 
-        response = session.request.get(self.portal.absolute_url()).json()
+        response = session.request.get('/').json()
 
         self.assertEqual(self.portal.absolute_url(), response.get('@id'))
 
@@ -56,7 +56,7 @@ class TestWorkspaceSessionManager(FunctionalWorkspaceClientTestCase):
         transaction.commit()
 
         # Making a request with the same session will reuse the jwt_token
-        response = session.request.get(self.portal.absolute_url()).json()
+        response = session.request.get('/').json()
         self.assertEqual(jwt_token, extract_jwt_token(session),
                          "JWT token should still be the same")
 
@@ -66,7 +66,7 @@ class TestWorkspaceSessionManager(FunctionalWorkspaceClientTestCase):
         transaction.commit()
 
         # Making a request with an expired token will auto-renew the jwt-token
-        response = session.request.get(self.portal.absolute_url()).json()
+        response = session.request.get('/').json()
         self.assertNotEqual(jwt_token, extract_jwt_token(session),
                             "JWT should have been renewed")
         self.assertEqual(self.portal.absolute_url(), response.get('@id'))


### PR DESCRIPTION
Issuer #6153 

Dieser PR implementiert den `WorkspaceClient`.

Die Klasse wird für Requests auf einen Teamraum verwendet.

Eine Instanz des Objektes stellt automatisch ein authentisiertes Session-Objekt für den in den Umgebungsvariablen konfigurierten Teamraum zur Verfügung.

Requests werden dabei relativ zum Teamraum gesendet.

```python
client = WorksapceClient()
client.request.get('folder-1')
```

## Checkliste
- [x] Sind UpgradeSteps `deferrable`, oder können gewisse Schritte des Upgrades konditional ausgeführt werden?
- [x] Gibt es ein neues Feature-Flag? Wurden dafür Tests mit aktiviertem und deaktivierte Flag geschrieben?
- [x] Changelog-Eintrag vorhanden/nötig?
