### PR TITLE
Handle path depth when filtering a table.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 ------------------------
 
 - Bump ftw.solr to 2.8.1 for to_iso8601 fix for years before 1900. [deiferni]
+- Handle path depth when filtering a table. [njohner]
 - Implement the teamraum client authentication flow. [elioschmutz]
 - Add documentation for sharing endpoint. [njohner]
 - Always request UID from solr, as it is needed for snippets. [njohner]

--- a/opengever/tabbedview/catalog_source.py
+++ b/opengever/tabbedview/catalog_source.py
@@ -78,8 +78,21 @@ class GeverCatalogTableSource(FilteredTableSourceMixin, CatalogTableSource):
             elif key == 'sort_on' or key == 'sort_order':
                 continue
             elif key == 'path':
+                path_query = value.get('query')
                 filters.append(u'path_parent:{}'.format(
-                    escape(value.get('query'))))
+                    escape(path_query)))
+
+                depth = value.get('depth', -1)
+                try:
+                    depth = int(depth)
+                except ValueError:
+                    depth = -1
+                if depth > 0:
+                    # path starts with /, so splitting gives context_depth + 1
+                    context_depth = len(path_query.split("/")) - 1
+                    max_path_depth = context_depth + depth
+                    filters.append(u'path_depth:[* TO {}]'.format(max_path_depth))
+
             elif isinstance(value, (list, tuple)):
                 filters.append(u'{}:({})'.format(
                     key, escape(' OR '.join(value))))

--- a/opengever/tabbedview/tests/test_catalog_source.py
+++ b/opengever/tabbedview/tests/test_catalog_source.py
@@ -50,6 +50,15 @@ class TestSolrSearch(IntegrationTestCase):
             self.solr.search.call_args[1]['filters'],
             [u'trashed:false', u'path_parent:\\/my\\/path'])
 
+    def test_solr_filters_contain_path_depth(self):
+        self.source.solr_results(
+            {'SearchableText': 'foo', 'path': {'query': '/my/path', 'depth': '1'}})
+        self.assertEqual(
+            self.solr.search.call_args[1]['filters'],
+            [u'trashed:false',
+             u'path_parent:\\/my\\/path',
+             u'path_depth:[* TO 3]'])
+
     def test_solr_filters_handle_booleans(self):
         self.source.solr_results(
             {'SearchableText': 'foo', 'is_subdossier': True})


### PR DESCRIPTION
In the InboxDocuments tab, the depth is set to 1 to avoid listing documents in forwardings. This depth restriction was not handled when the query is sent to solr (i.e. when documents are filtered), leading to more documents being displayed when applying a filter.

For https://basecamp.com/2768704/projects/14549453/todos/410114932

## Checkliste
- [x] Changelog-Eintrag vorhanden/nötig?
