### PR TITLE
Linked workspace store with serializer extender

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 ------------------------
 
 - Use Teamraum in mail header for invitations. [njohner]
+- Integrate related workspaces to dossiers. [elioschmutz]
 - Implement the teamraum client authentication flow. [elioschmutz]
 - Implement the workspace client to make requests to a teamraum from GEVER. [elioschmutz]
 - Implement the workspace client authentication flow. [elioschmutz]

--- a/opengever/api/serializer.py
+++ b/opengever/api/serializer.py
@@ -3,7 +3,7 @@ from ftw.bumblebee.interfaces import IBumblebeeDocument
 from opengever.base.interfaces import IOpengeverBaseLayer
 from opengever.base.response import IResponseContainer
 from opengever.base.response import IResponseSupported
-from opengever.workspaceclient import is_workspace_client_feature_enabled
+from opengever.workspaceclient import is_workspace_client_feature_available
 from opengever.workspaceclient.interfaces import ILinkedWorkspaces
 from plone import api
 from plone.dexterity.interfaces import IDexterityContainer
@@ -37,7 +37,7 @@ def extend_with_responses(result, context, request):
 
 
 def extend_with_workspaces(result, context):
-    if not is_workspace_client_feature_enabled():
+    if not is_workspace_client_feature_available():
         return
 
     manager = queryAdapter(context, ILinkedWorkspaces)

--- a/opengever/api/serializer.py
+++ b/opengever/api/serializer.py
@@ -3,6 +3,8 @@ from ftw.bumblebee.interfaces import IBumblebeeDocument
 from opengever.base.interfaces import IOpengeverBaseLayer
 from opengever.base.response import IResponseContainer
 from opengever.base.response import IResponseSupported
+from opengever.workspaceclient import is_workspace_client_feature_enabled
+from opengever.workspaceclient.interfaces import ILinkedWorkspaces
 from plone import api
 from plone.dexterity.interfaces import IDexterityContainer
 from plone.dexterity.interfaces import IDexterityContent
@@ -12,6 +14,7 @@ from plone.restapi.serializer.dxcontent import SerializeFolderToJson
 from plone.restapi.serializer.dxcontent import SerializeToJson
 from zope.component import adapter
 from zope.component import getMultiAdapter
+from zope.component import queryAdapter
 from zope.interface import implementer
 
 
@@ -31,6 +34,15 @@ def extend_with_responses(result, context, request):
         for response in IResponseContainer(context).list():
             serializer = getMultiAdapter((response, request), ISerializeToJson)
             result['responses'].append(serializer(container=context))
+
+
+def extend_with_workspaces(result, context):
+    if not is_workspace_client_feature_enabled():
+        return
+
+    manager = queryAdapter(context, ILinkedWorkspaces)
+    if manager:
+        result['workspaces'] = manager.list()
 
 
 @adapter(IDexterityContent, IOpengeverBaseLayer)
@@ -54,7 +66,7 @@ class GeverSerializeFolderToJson(SerializeFolderToJson):
 
         extend_with_relative_path(result, self.context)
         extend_with_responses(result, self.context, self.request)
-
+        extend_with_workspaces(result, self.context)
         return result
 
 

--- a/opengever/core/profiles/default/types/opengever.dossier.businesscasedossier.xml
+++ b/opengever/core/profiles/default/types/opengever.dossier.businesscasedossier.xml
@@ -42,6 +42,7 @@
     <element value="plone.app.lockingbehavior.behaviors.ILocking" />
     <element value="opengever.mail.behaviors.ISendableDocsContainer" />
     <element value="opengever.dossier.behaviors.protect_dossier.IProtectDossier" />
+    <element value="opengever.workspaceclient.interfaces.ILinkedWorkspaces" />
   </property>
 
   <!-- View information -->

--- a/opengever/core/tests/test_relations.py
+++ b/opengever/core/tests/test_relations.py
@@ -94,6 +94,7 @@ EXPECTED_INTERFACES = [
     'opengever.task.reminder.interfaces.IReminderSupport',
     'opengever.task.task.ITask',
     'opengever.trash.trash.ITrashableMarker',
+    'opengever.workspaceclient.interfaces.ILinkedWorkspacesMarker',
     'persistent.interfaces.IPersistent',
     'plone.app.lockingbehavior.behaviors.ILocking',
     'plone.app.relationfield.interfaces.IDexterityHasRelations',

--- a/opengever/core/upgrades/20200206162838_add_linked_workspaces_behavior/types/opengever.dossier.businesscasedossier.xml
+++ b/opengever/core/upgrades/20200206162838_add_linked_workspaces_behavior/types/opengever.dossier.businesscasedossier.xml
@@ -1,0 +1,8 @@
+<object xmlns:i18n="http://xml.zope.org/namespaces/i18n" name="opengever.dossier.businesscasedossier" meta_type="Dexterity FTI" i18n:domain="opengever.core">
+
+  <!-- Enabled behaviors -->
+  <property name="behaviors" purge="False">
+    <element value="opengever.workspaceclient.interfaces.ILinkedWorkspaces" />
+  </property>
+
+</object>

--- a/opengever/core/upgrades/20200206162838_add_linked_workspaces_behavior/upgrade.py
+++ b/opengever/core/upgrades/20200206162838_add_linked_workspaces_behavior/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddLinkedWorkspacesBehavior(UpgradeStep):
+    """Add linked workspaces behavior.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/workspaceclient/__init__.py
+++ b/opengever/workspaceclient/__init__.py
@@ -8,3 +8,22 @@ logger = logging.getLogger('opengever.workspaceclient')
 def is_workspace_client_feature_enabled():
     return api.portal.get_registry_record(
         'is_feature_enabled', IWorkspaceClientSettings, False)
+
+
+def is_workspace_client_feature_available():
+    """The feature is available if:
+
+    - the feature-flag is set to True
+    - the logged in user is not the zopemaster
+    """
+    def is_zopemaster():
+        if api.user.get_current().getId() == 'zopemaster':
+            # ftw.tokenauth does not work with zope root users.
+            # https://github.com/4teamwork/ftw.tokenauth/blob/master/ftw/tokenauth/pas/plugin.py#L255
+            logger.warning(
+                "The 'zopemaster' is not supported to make requests to the "
+                "remote system. Please use another user.")
+            return True
+        return False
+
+    return is_workspace_client_feature_enabled() and not is_zopemaster()

--- a/opengever/workspaceclient/client.py
+++ b/opengever/workspaceclient/client.py
@@ -1,4 +1,4 @@
-from opengever.workspaceclient import is_workspace_client_feature_enabled
+from opengever.workspaceclient import is_workspace_client_feature_available
 from opengever.workspaceclient.exceptions import WorkspaceClientFeatureNotEnabled
 from opengever.workspaceclient.exceptions import WorkspaceURLMissing
 from opengever.workspaceclient.session import WorkspaceSession
@@ -12,7 +12,7 @@ class WorkspaceClient(object):
     """
 
     def __init__(self):
-        if not is_workspace_client_feature_enabled():
+        if not is_workspace_client_feature_available():
             raise WorkspaceClientFeatureNotEnabled()
 
         if not self.workspace_url:

--- a/opengever/workspaceclient/client.py
+++ b/opengever/workspaceclient/client.py
@@ -37,3 +37,14 @@ class WorkspaceClient(object):
         """Retruns the configured workspace url in the env variable.
         """
         return os.environ.get('TEAMRAUM_URL', '').strip('/')
+
+    def search(self, url_or_path='', **kwargs):
+        """Dispatches a search request to the given url or path.
+        """
+        url_or_path = '{}/@search'.format(url_or_path.strip('/'))
+        return self.request.get(url_or_path, params=kwargs).json()
+
+    def get(self, url_or_path):
+        """Lookup an object.
+        """
+        return self.request.get(url_or_path).json()

--- a/opengever/workspaceclient/configure.zcml
+++ b/opengever/workspaceclient/configure.zcml
@@ -1,0 +1,15 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:five="http://namespaces.zope.org/five"
+    xmlns:plone="http://namespaces.plone.org/plone"
+    i18n_domain="opengever.workspaceclient">
+
+  <plone:behavior
+      title="Remote workpsace support"
+      description="Provides functions to handle remote workspaces"
+      provides=".interfaces.ILinkedWorkspaces"
+      factory=".linked_workspaces.LinkedWorkspaces"
+      marker=".interfaces.ILinkedWorkspacesMarker"
+      />
+
+</configure>

--- a/opengever/workspaceclient/interfaces.py
+++ b/opengever/workspaceclient/interfaces.py
@@ -8,3 +8,13 @@ class IWorkspaceClientSettings(Interface):
         title=u'Enable workspace client feature',
         description=u'Whether a remote workspace integration is enabled',
         default=False)
+
+
+class ILinkedWorkspacesMarker(Interface):
+    """Marker interface for the ILinkedWorkspaces behavior
+    """
+
+
+class ILinkedWorkspaces(Interface):
+    """Behavior interface to manage remote workspaces
+    """

--- a/opengever/workspaceclient/linked_workspaces.py
+++ b/opengever/workspaceclient/linked_workspaces.py
@@ -1,5 +1,24 @@
 from opengever.workspaceclient.client import WorkspaceClient
 from opengever.workspaceclient.storage import LinkedWorkspacesStorage
+from plone import api
+from plone.memoize import ram
+from time import time
+
+
+CACHE_TIMEOUT = 24 * 60 * 60
+
+
+def list_cache_key(linked_workspaces_instance):
+    """Cache key builder with the current user, a timeout and an additional
+    string or list to append to the key.
+    """
+
+    uid = linked_workspaces_instance.context.UID()
+    linked_workspace_uids = '-'.join(linked_workspaces_instance.storage.list())
+    userid = api.user.get_current().getId()
+    timeout_key = str(time() // CACHE_TIMEOUT if CACHE_TIMEOUT > 0 else str(time()))
+    return '-'.join(('linked_workspaces_storage', userid, uid, linked_workspace_uids,
+                    str(CACHE_TIMEOUT), timeout_key))
 
 
 class LinkedWorkspaces(object):
@@ -11,6 +30,7 @@ class LinkedWorkspaces(object):
         self.storage = LinkedWorkspacesStorage(context)
         self.context = context
 
+    @ram.cache(lambda method, context: list_cache_key(context))
     def list(self):
         """Returns a JSON summary-representation of all stored workspaces.
         This function lookups all UIDs on the remote system by dispatching a

--- a/opengever/workspaceclient/linked_workspaces.py
+++ b/opengever/workspaceclient/linked_workspaces.py
@@ -1,0 +1,27 @@
+from opengever.workspaceclient.client import WorkspaceClient
+from opengever.workspaceclient.storage import LinkedWorkspacesStorage
+
+
+class LinkedWorkspaces(object):
+    """Manages linked workspaces for an object.
+    """
+
+    def __init__(self, context):
+        self.client = WorkspaceClient()
+        self.storage = LinkedWorkspacesStorage(context)
+        self.context = context
+
+    def list(self):
+        """Returns a JSON summary-representation of all stored workspaces.
+        This function lookups all UIDs on the remote system by dispatching a
+        search requests to the remote system.
+        This means, unauthorized objects or not existing UIDs will be skipped
+        automatically.
+        """
+        uids = self.storage.list()
+        if not uids:
+            return uids
+
+        return self.client.search(
+            UID=uids,
+            portal_type="opengever.workspace.workspace").get('items')

--- a/opengever/workspaceclient/storage.py
+++ b/opengever/workspaceclient/storage.py
@@ -1,0 +1,30 @@
+from persistent.list import PersistentList
+from zope.annotation import IAnnotations
+
+
+class LinkedWorkspacesStorage(object):
+    """Storage for remote workspaces.
+    """
+
+    ANNOTATIONS_KEY = 'opengever.workspaceclient.linked_workspaces'
+
+    def __init__(self, context):
+        self.context = context
+        self._initialize_storage()
+
+    def add(self, uid):
+        """Add a workspace by its UID.
+        """
+        self._storage.append(uid)
+
+    def list(self):
+        """Returns the stored linked workspace UID's
+        """
+        return list(self._storage)
+
+    def _initialize_storage(self):
+        ann = IAnnotations(self.context)
+        if self.ANNOTATIONS_KEY not in ann:
+            ann[self.ANNOTATIONS_KEY] = PersistentList()
+
+        self._storage = ann[self.ANNOTATIONS_KEY]

--- a/opengever/workspaceclient/tests/__init__.py
+++ b/opengever/workspaceclient/tests/__init__.py
@@ -8,6 +8,8 @@ from opengever.workspaceclient.client import WorkspaceClient
 from opengever.workspaceclient.interfaces import IWorkspaceClientSettings
 from opengever.workspaceclient.session import SESSION_STORAGE
 from plone import api
+from zope.component import queryUtility
+from zope.ramcache.interfaces.ram import IRAMCache
 import os
 import transaction
 
@@ -46,6 +48,7 @@ class FunctionalWorkspaceClientTestCase(FunctionalTestCase):
         SESSION_STORAGE.sessions = None
 
         self.enable_feature()
+        self.invalidate_cache()
 
     @contextmanager
     def env(self, **env):
@@ -75,3 +78,7 @@ class FunctionalWorkspaceClientTestCase(FunctionalTestCase):
 
         with self.env(TEAMRAUM_URL=url):
             yield WorkspaceClient()
+
+    def invalidate_cache(self):
+        util = queryUtility(IRAMCache)
+        util.invalidateAll()

--- a/opengever/workspaceclient/tests/__init__.py
+++ b/opengever/workspaceclient/tests/__init__.py
@@ -22,14 +22,25 @@ class FunctionalWorkspaceClientTestCase(FunctionalTestCase):
     def setUp(self):
         super(FunctionalWorkspaceClientTestCase, self).setUp()
 
-        # Minimal GEVER setup
-        self.repo = create(Builder('repository_root'))
-
         # Generate a service user
         self.service_user = api.user.create(email="service-user@example.com",
                                             username='service.user')
-        api.user.grant_roles(user=self.service_user,
-                             roles=['ServiceKeyUser', 'Impersonator'])
+
+        self.grant('ServiceKeyUser', 'Impersonator',
+                   user_id=self.service_user.getId())
+
+        # Minimal GEVER setup
+        self.repository_root = create(Builder('repository_root'))
+        self.leaf_repofolder = create(Builder('repository').within(self.repository_root))
+        self.dossier = create(Builder('dossier').within(self.leaf_repofolder))
+
+        # Teamraum setup
+        self.workspace_root = create(Builder('workspace_root')
+                                     .having(id='workspaces'))
+        self.grant('WorkspaceUser', on=self.workspace_root)
+
+        self.workspace = create(Builder('workspace').within(self.workspace_root))
+        self.grant('WorkspaceMember', on=self.workspace)
 
         # Reset the session store
         SESSION_STORAGE.sessions = None

--- a/opengever/workspaceclient/tests/test_client.py
+++ b/opengever/workspaceclient/tests/test_client.py
@@ -21,3 +21,17 @@ class TestWorkspaceClient(FunctionalWorkspaceClientTestCase):
             response = client.request.get('/').json()
 
         self.assertEqual(self.portal.absolute_url(), response.get('@id'))
+
+    def test_get_an_object(self):
+        with self.workspace_client_env() as client:
+            response = client.get(self.workspace.absolute_url())
+
+        self.assertEqual(self.workspace.absolute_url(), response.get('@id'))
+
+    def test_search_for_objects(self):
+        with self.workspace_client_env() as client:
+            response = client.search(UID=[self.workspace.UID()])
+
+        self.assertEqual(1, response.get('items_total'))
+        self.assertEqual(self.workspace.absolute_url(),
+                         response.get('items')[0].get('@id'))

--- a/opengever/workspaceclient/tests/test_linked_workspaces.py
+++ b/opengever/workspaceclient/tests/test_linked_workspaces.py
@@ -1,0 +1,51 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from opengever.workspaceclient.interfaces import ILinkedWorkspaces
+from opengever.workspaceclient.tests import FunctionalWorkspaceClientTestCase
+from plone import api
+import transaction
+
+
+class TestLinkedWorkspaces(FunctionalWorkspaceClientTestCase):
+
+    def test_list_linked_workspaces(self):
+        with self.workspace_client_env():
+            manager = ILinkedWorkspaces(self.dossier)
+
+            self.assertEqual([], manager.list())
+
+            manager.storage.add(self.workspace.UID())
+
+            self.assertEqual(
+                [self.workspace.absolute_url()],
+                [workspace.get('@id') for workspace in manager.list()])
+
+    def test_list_skips_workspaces_if_no_view_permission(self):
+        unauthorized_workspace = create(Builder('workspace').within(self.workspace_root))
+        self.grant('', on=unauthorized_workspace)
+
+        authorized_workspace = create(Builder('workspace').within(self.workspace_root))
+        self.grant('View', on=unauthorized_workspace)
+
+        self.assertTrue(api.user.has_permission('View', obj=self.workspace))
+        self.assertTrue(api.user.has_permission('View', obj=authorized_workspace))
+        self.assertFalse(api.user.has_permission('View', obj=unauthorized_workspace))
+
+        with self.workspace_client_env():
+            manager = ILinkedWorkspaces(self.dossier)
+            manager.storage.add(self.workspace.UID())
+            manager.storage.add(authorized_workspace.UID())
+            manager.storage.add(unauthorized_workspace.UID())
+
+            self.assertItemsEqual(
+                [self.workspace.absolute_url(), authorized_workspace.absolute_url()],
+                [workspace.get('@id') for workspace in manager.list()])
+
+            self.grant('WorkspaceMember', on=unauthorized_workspace)
+            transaction.commit()
+
+            self.assertItemsEqual(
+                [self.workspace.absolute_url(),
+                 authorized_workspace.absolute_url(),
+                 unauthorized_workspace.absolute_url()],
+                [workspace.get('@id') for workspace in manager.list()])

--- a/opengever/workspaceclient/tests/test_serializer.py
+++ b/opengever/workspaceclient/tests/test_serializer.py
@@ -1,0 +1,28 @@
+from ftw.testbrowser import browsing
+from opengever.workspaceclient.interfaces import ILinkedWorkspaces
+from opengever.workspaceclient.tests import FunctionalWorkspaceClientTestCase
+import transaction
+
+
+class TestSerializer(FunctionalWorkspaceClientTestCase):
+
+    @browsing
+    def test_dossier_serializer_includes_workspaces(self, browser):
+        with self.workspace_client_env():
+            browser.login()
+            response = browser.open(self.dossier, method='GET',
+                                    headers={'Accept': 'application/json'}).json
+
+            self.assertEqual([], response.get('workspaces'))
+
+            manager = ILinkedWorkspaces(self.dossier)
+            manager.storage.add(self.workspace.UID())
+
+            transaction.commit()
+
+            response = browser.open(self.dossier, method='GET',
+                                    headers={'Accept': 'application/json'}).json
+
+            self.assertEqual(
+                [self.workspace.absolute_url()],
+                [workspace.get('@id') for workspace in response.get('workspaces')])

--- a/opengever/workspaceclient/tests/test_storage.py
+++ b/opengever/workspaceclient/tests/test_storage.py
@@ -1,0 +1,35 @@
+from opengever.workspaceclient.storage import LinkedWorkspacesStorage
+from opengever.workspaceclient.tests import FunctionalWorkspaceClientTestCase
+from persistent.list import PersistentList
+
+
+class TestLinkedWorkspacesStorage(FunctionalWorkspaceClientTestCase):
+
+    def test_store_gets_initialized(self):
+        storage = LinkedWorkspacesStorage(self.dossier)
+
+        self.assertIsInstance(storage._storage, PersistentList)
+
+    def test_initialization_is_idempotent(self):
+        storage = LinkedWorkspacesStorage(self.dossier)
+        storage._storage.append('uid')
+
+        self.assertEqual(['uid'], storage._storage)
+
+        # Multiple initializations shouldn't remove existing data
+        storage = LinkedWorkspacesStorage(self.dossier)
+
+        self.assertEqual(['uid'], storage._storage)
+
+    def test_add_uid_to_store(self):
+        storage = LinkedWorkspacesStorage(self.dossier)
+        storage.add(self.workspace.UID())
+
+        self.assertEqual([self.workspace.UID()], storage._storage)
+
+    def test_list_stored_uids(self):
+        storage = LinkedWorkspacesStorage(self.dossier)
+        storage.add('UID-1')
+        storage.add('UID-2')
+
+        self.assertEqual(['UID-1', 'UID-2'], storage.list())


### PR DESCRIPTION
Issuer #6154 

Dieser PR
- implementiert den Store für verknüpfte Arbeitsräume
- implementiert ein Behavior, welches das Auflisten von verknüpften Arbeitsräumen zur Verfügung stellt
- registriert das Behavior für Dossiers
- benutzt den Behavior-Adapter im Item-Serializer wenn das Workspace-Client Feature aktiviert ist und das Objekt das Behavior zur Verfügung stellt

# Kurzüberblick der Objekte

![Model!Main_0](https://user-images.githubusercontent.com/557005/74140258-10413100-4bf5-11ea-9320-e6b7eb200859.jpg)


## Checkliste
- [x] Profil angepasst? Sind UpgradeSteps vorhanden/nötig?:
- [x] Changelog-Eintrag vorhanden/nötig?
