### PR TITLE
Fix check for allowed number of orgunits in a workspaces installation.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2020.1.0rc2 (unreleased)
 ------------------------
 
+- Use Teamraum in mail header for invitations. [njohner]
 - Implement the teamraum client authentication flow. [elioschmutz]
 - Implement the workspace client to make requests to a teamraum from GEVER. [elioschmutz]
 - Implement the workspace client authentication flow. [elioschmutz]

--- a/opengever/activity/mailer.py
+++ b/opengever/activity/mailer.py
@@ -45,6 +45,8 @@ class Mailer(object):
     and digest mails.
     """
 
+    default_addr_header = u'OneGov GEVER'
+
     def __init__(self):
         # This is required by ViewPageTemplateFile for
         # the html mail-template
@@ -90,7 +92,7 @@ class Mailer(object):
                                            actor.email, 'utf-8')
         else:
             msg['From'] = make_addr_header(
-                u'OneGov GEVER', api.portal.get().email_from_address, 'utf-8')
+                self.default_addr_header, api.portal.get().email_from_address, 'utf-8')
 
         if to_userid:
             to_email = ogds_service().fetch_user(to_userid).email

--- a/opengever/workspace/participation/browser/my_invitations.py
+++ b/opengever/workspace/participation/browser/my_invitations.py
@@ -1,10 +1,11 @@
 from logging import getLogger
 from opengever.base.casauth import get_gever_portal_url
 from opengever.base.model import create_session
-from opengever.base.role_assignments import SharingRoleAssignment
 from opengever.base.role_assignments import RoleAssignmentManager
+from opengever.base.role_assignments import SharingRoleAssignment
 from opengever.base.security import elevated_privileges
 from opengever.ogds.base.actor import PloneUserActor
+from opengever.ogds.base.utils import get_current_admin_unit
 from opengever.ogds.base.utils import ogds_service
 from opengever.ogds.models.group import Group
 from opengever.ogds.models.user import User
@@ -92,7 +93,7 @@ class MyWorkspaceInvitations(BrowserView):
         """get the dn of the group associated with the current orgunit
         """
         portal = api.portal.get()
-        org_units = ogds_service().all_org_units()
+        org_units = get_current_admin_unit().org_units
         if len(org_units) > 1:
             raise InternalError("Workspace installation can only have a "
                                 "single enabled org_unit")

--- a/opengever/workspace/participation/invitation_mailer.py
+++ b/opengever/workspace/participation/invitation_mailer.py
@@ -12,6 +12,7 @@ _ = MessageFactory("opengever.workspace")
 class InvitationMailer(Mailer):
 
     template = ViewPageTemplateFile("templates/invitation_mail.pt")
+    default_addr_header = u'Teamraum'
 
     def send_invitation(self, invitation):
         target_workspace = uuidToObject(invitation['target_uuid'])


### PR DESCRIPTION
- A workspace installation should have only a single `orgunit`, so that we can find out to which group to assign a user accepting an invitation. The check we were doing for this was wrong as it looked for all org_units, not restricting the search to the `admin_unit` of the workspaces installation. 
- Also change mail header for invitations

For https://github.com/4teamwork/opengever.core/issues/6181