### PR TITLE
Add missing header to obtain access token on remote system

### DIFF
--- a/opengever/workspaceclient/session.py
+++ b/opengever/workspaceclient/session.py
@@ -77,7 +77,9 @@ class FtwTokenAuthSession(requests.Session):
         grant = jwt.encode(claim_set, self.service_key["private_key"], algorithm="RS256")
         payload = {"grant_type": GRANT_TYPE, "assertion": grant}
 
-        response = requests.post(self.service_key["token_uri"], data=payload)
+        response = requests.post(self.service_key["token_uri"], data=payload,
+                                 headers={"Accept": "application/json"})
+
         self.raise_for_status(response)
 
         bearer_token = response.json()["access_token"]


### PR DESCRIPTION
Wir müssen den `Accept` header explizit setzten bei der Token-Abfrage für den `WorkspaceClient`. Sonst wird in einer Live-Umgebung zum Teil kein JSON zurückgegeben.

Related to #6154 
