### PR TITLE
Add dossier title to task activity summaries.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,7 @@ Changelog
 2020.1.0rc3 (unreleased)
 ------------------------
 
-- Nothing changed yet.
+- Add container title to task activities. [njohner]
 
 
 2020.1.0rc2 (2020-02-11)

--- a/opengever/activity/browser/views.py
+++ b/opengever/activity/browser/views.py
@@ -99,7 +99,7 @@ class NotificationView(BrowserView):
             data.append({
                 'title': notification.activity.title,
                 'label': notification.activity.label,
-                'summary': notification.activity.summary,
+                'summary': notification.activity.summary.splitlines(),
                 'created': notification.activity.created.astimezone(
                     pytz.UTC).isoformat(),
                 'link': resolve_notification_url(notification),

--- a/opengever/activity/mailer.py
+++ b/opengever/activity/mailer.py
@@ -103,6 +103,10 @@ class Mailer(object):
         if data.get('description'):
             data['description'] = data.get('description').splitlines()
 
+        # Break (potential) summary up into a list of lines
+        if data.get('summary'):
+            data['summary'] = data.get('summary').splitlines()
+
         html = self.prepare_html(data)
         msg.attach(MIMEText(html.encode('utf-8'), 'html', 'utf-8'))
         return msg

--- a/opengever/activity/templates/digest.pt
+++ b/opengever/activity/templates/digest.pt
@@ -32,7 +32,9 @@
           <dd style="margin: 0; padding: 0;">
             <ul style="padding: 0; Margin: 0;">
               <li style="Margin:0 0 1em; list-style:disc; mso-special-format:bullet;" tal:repeat="activity item/activities">
-                <p tal:content="structure activity/summary" />
+                <tal:block tal:repeat="paragraph activity/summary">
+                  <p tal:content="structure paragraph" />
+                </tal:block>
               </li>
             </ul>
           </dd>

--- a/opengever/activity/templates/notification.pt
+++ b/opengever/activity/templates/notification.pt
@@ -18,7 +18,9 @@
     </metal:title>
 
     <metal:content metal:fill-slot="content">
-      <p class="notification_label" tal:content="structure options/summary" />
+      <tal:block tal:repeat="paragraph options/summary">
+        <p class="notification_label" tal:content="structure paragraph" />
+      </tal:block>
 
       <p><a href="" tal:content="options/title" tal:attributes="href options/link"></a></p>
 

--- a/opengever/activity/tests/test_mail.py
+++ b/opengever/activity/tests/test_mail.py
@@ -216,7 +216,7 @@ class TestNotificationMailsAndSavepoints(IntegrationTestCase):
         self.login(self.dossier_responsible)
 
         # Trigger a notification that dispatches a mail
-        activity = TaskAddedActivity(self.task, getRequest(), self.dossier)
+        activity = TaskAddedActivity(self.task, getRequest())
         activity.record()
 
         # Creating a savepoint will fail with the MailDataManager if it's

--- a/opengever/activity/tests/test_views.py
+++ b/opengever/activity/tests/test_views.py
@@ -165,7 +165,7 @@ class TestListNotifications(IntegrationTestCase):
                 u'link': u'http://nohost/plone/@@resolve_notification'
                          u'?notification_id=1',
                 u'read': False,
-                u'summary': u'Task created by Test User',
+                u'summary': [u'Task created by Test User'],
                 u'target': u'_self',
                 u'title': u'Kennzahlen 2014 erfassen',
             },
@@ -176,7 +176,7 @@ class TestListNotifications(IntegrationTestCase):
                 u'link': u'http://nohost/plone/@@resolve_notification'
                          u'?notification_id=2',
                 u'read': True,
-                u'summary': u'Task created by Test User',
+                u'summary': [u'Task created by Test User'],
                 u'target': u'_self',
                 u'title': u'Kennzahlen 2014 erfassen',
             },
@@ -358,7 +358,7 @@ class TestListNotifications(IntegrationTestCase):
                 u'link': u'http://nohost/plone/@@resolve_notification'
                          u'?notification_id=1',
                 u'read': False,
-                u'summary': u'Task created by Test User',
+                u'summary': [u'Task created by Test User'],
                 u'target': u'_self',
                 u'title': u'Kennzahlen 2014 erfassen',
             },
@@ -369,7 +369,7 @@ class TestListNotifications(IntegrationTestCase):
                 u'link': u'http://nohost/plone/@@resolve_notification'
                          u'?notification_id=2',
                 u'read': False,
-                u'summary': u'Task bla added by Hugo',
+                u'summary': [u'Task bla added by Hugo'],
                 u'target': u'_self',
                 u'title': u'Kennzahlen 2015 erfassen',
             },
@@ -422,7 +422,7 @@ class TestListNotifications(IntegrationTestCase):
             u'link': u'http://nohost/plone/@@resolve_notification'
                      u'?notification_id=2',
             u'read': False,
-            u'summary': u'Task bla added by Hugo',
+            u'summary': [u'Task bla added by Hugo'],
             u'target': u'_self',
             u'title': u'Kennzahlen 2015 erfassen',
         }]

--- a/opengever/activity/viewlets/notification.pt
+++ b/opengever/activity/viewlets/notification.pt
@@ -25,7 +25,9 @@
                     <span class="timeago relativetime" title="{{created}}">{{created}}</span>
                   </div>
                   <a class="notification-list-item-title" target="{{target}}" href="{{link}}">{{title}}</a>
-                  <div class="notification-list-item-summary">{{{summary}}}</div>
+                  {{#each summary}}
+                    <div class="notification-list-item-summary">{{{this}}}</div>
+                  {{/each}}
                 </span>
               </li>
             {{/each}}

--- a/opengever/api/tests/test_notifications.py
+++ b/opengever/api/tests/test_notifications.py
@@ -52,7 +52,8 @@ class TestNotificationsGet(IntegrationTestCase):
               u'link': u'http://nohost/plone/@@resolve_notification?notification_id=3',
               u'notification_id': 3,
               u'read': False,
-              u'summary': u'New task opened by Ziegler Robert',
+              u'summary': u'New task opened by Ziegler Robert\n'
+                          u'Dossier: Vertr\xe4ge mit der kantonalen Finanzverwaltung',
               u'title': u'Vertragsentwurf \xdcberpr\xfcfen'},
              {u'@id': u'http://nohost/plone/@notifications/kathi.barfuss/1',
               u'actor_id': u'nicole.kohler',
@@ -62,7 +63,8 @@ class TestNotificationsGet(IntegrationTestCase):
               u'link': u'http://nohost/plone/@@resolve_notification?notification_id=1',
               u'notification_id': 1,
               u'read': True,
-              u'summary': u'New task opened by Ziegler Robert',
+              u'summary': u'New task opened by Ziegler Robert\n'
+                          u'Dossier: Vertr\xe4ge mit der kantonalen Finanzverwaltung',
               u'title': u'Vertragsentwurf \xdcberpr\xfcfen'}],
             browser.json.get('items'))
 
@@ -126,7 +128,8 @@ class TestNotificationsGet(IntegrationTestCase):
              u'link': u'http://nohost/plone/@@resolve_notification?notification_id=1',
              u'notification_id': 1,
              u'read': False,
-             u'summary': u'New task opened by Ziegler Robert',
+             u'summary': u'New task opened by Ziegler Robert\n'
+                         u'Dossier: Vertr\xe4ge mit der kantonalen Finanzverwaltung',
              u'title': u'Vertragsentwurf \xdcberpr\xfcfen'},
             browser.json)
 

--- a/opengever/api/tests/test_notifications.py
+++ b/opengever/api/tests/test_notifications.py
@@ -22,13 +22,13 @@ class TestNotificationsGet(IntegrationTestCase):
         self.assertEqual(0,  Notification.query.count())
 
         with freeze(datetime(2017, 10, 16, 0, 0, tzinfo=pytz.utc)):
-            TaskAddedActivity(self.task, self.request, self.task.__parent__).record()
+            TaskAddedActivity(self.task, self.request).record()
 
         for notification in Notification.query.all():
             notification.is_read = True
 
         with freeze(datetime(2018, 10, 16, 0, 0, tzinfo=pytz.utc)):
-            TaskAddedActivity(self.task, self.request, self.task.__parent__).record()
+            TaskAddedActivity(self.task, self.request).record()
 
         self.assertEqual(2, len(center.get_watchers(self.task)))
 
@@ -78,7 +78,7 @@ class TestNotificationsGet(IntegrationTestCase):
 
         with freeze(datetime(2017, 10, 16, 0, 0, tzinfo=pytz.utc)):
             for i in range(5):
-                TaskAddedActivity(self.task, self.request, self.task.__parent__).record()
+                TaskAddedActivity(self.task, self.request).record()
 
         self.login(self.regular_user, browser=browser)
 
@@ -109,7 +109,7 @@ class TestNotificationsGet(IntegrationTestCase):
         self.assertEqual(0,  Notification.query.count())
 
         with freeze(datetime(2017, 10, 16, 0, 0, tzinfo=pytz.utc)):
-            TaskAddedActivity(self.task, self.request, self.task.__parent__).record()
+            TaskAddedActivity(self.task, self.request).record()
 
         url = '{}/@notifications/{}/1'.format(self.portal.absolute_url(),
                                               self.regular_user.getId())
@@ -163,7 +163,7 @@ class TestNotificationsGet(IntegrationTestCase):
         self.login(self.dossier_responsible, browser=browser)
 
         with freeze(datetime(2017, 10, 16, 0, 0, tzinfo=pytz.utc)):
-            TaskAddedActivity(self.task, self.request, self.task.__parent__).record()
+            TaskAddedActivity(self.task, self.request).record()
 
         # Different username in path
         with browser.expect_http_error(401):
@@ -188,7 +188,7 @@ class TestNotificationsPatch(IntegrationTestCase):
     def test_mark_notification_as_read(self, browser):
         self.login(self.dossier_responsible, browser=browser)
 
-        TaskAddedActivity(self.task, self.request, self.task.__parent__).record()
+        TaskAddedActivity(self.task, self.request).record()
 
         url = '{}/@notifications/{}/{}'.format(self.portal.absolute_url(),
                                                self.regular_user.getId(), 1)
@@ -224,7 +224,7 @@ class TestNotificationsPatch(IntegrationTestCase):
         self.login(self.dossier_responsible, browser=browser)
 
         with freeze(datetime(2017, 10, 16, 0, 0, tzinfo=pytz.utc)):
-            TaskAddedActivity(self.task, self.request, self.task.__parent__).record()
+            TaskAddedActivity(self.task, self.request).record()
 
         # Different username in path
         with browser.expect_http_error(401):

--- a/opengever/task/activities.py
+++ b/opengever/task/activities.py
@@ -1,3 +1,5 @@
+from Acquisition import aq_inner
+from Acquisition import aq_parent
 from opengever.activity import ACTIVITY_TRANSLATIONS
 from opengever.activity import base_notification_center
 from opengever.activity.base import BaseActivity
@@ -98,7 +100,7 @@ class TaskAddedActivity(BaseTaskActivity):
     def collect_description_data(self, language):
         """Returns a list with [label, value] pairs.
         """
-        return [
+        data = [
             [_('label_task_title', u'Task title'), self.context.title],
             [_('label_deadline', u'Deadline'),
              api.portal.get_localized_time(str(self.context.deadline))],
@@ -110,7 +112,13 @@ class TaskAddedActivity(BaseTaskActivity):
              self.context.get_responsible_actor().get_label()],
             [_('label_issuer', u'Issuer'),
              self.context.get_issuer_actor().get_label()]
-        ]
+            ]
+        if self.context.get_is_subtask():
+            parent = aq_parent(aq_inner(self.context))
+            data.insert(
+                3, [_('label_containing_task', u'Containing tasks'), parent.title]
+                )
+        return data
 
     def before_recording(self):
         self.center.add_task_responsible(self.context,

--- a/opengever/task/activities.py
+++ b/opengever/task/activities.py
@@ -53,10 +53,6 @@ class TaskAddedActivity(BaseTaskActivity):
     """Activity representation for adding a task.
     """
 
-    def __init__(self, context, request, parent):
-        super(TaskAddedActivity, self).__init__(context, request)
-        self.parent = parent
-
     @property
     def kind(self):
         return PloneMessageFactory(u'task-added', default=u'Task added')
@@ -108,8 +104,6 @@ class TaskAddedActivity(BaseTaskActivity):
              api.portal.get_localized_time(str(self.context.deadline))],
             [_('label_task_type', u'Task Type'),
              self.context.get_task_type_label(language=language)],
-            [_('label_dossier_title', u'Dossier title'),
-             self.parent.title],
             [_('label_text', u'Text'),
              self.context.text if self.context.text else u'-'],
             [_('label_responsible', u'Responsible'),

--- a/opengever/task/browser/delegate/utils.py
+++ b/opengever/task/browser/delegate/utils.py
@@ -1,4 +1,3 @@
-from opengever.task.activities import TaskAddedActivity
 from opengever.task.util import update_reponsible_field_data
 from plone.dexterity.utils import addContentToContainer
 from plone.dexterity.utils import createContent
@@ -6,7 +5,6 @@ from plone.dexterity.utils import iterSchemata
 from z3c.relationfield import RelationValue
 from zope import schema
 from zope.event import notify
-from zope.lifecycleevent import ObjectCreatedEvent
 from zope.lifecycleevent import ObjectModifiedEvent
 import urllib
 

--- a/opengever/task/handlers.py
+++ b/opengever/task/handlers.py
@@ -11,7 +11,6 @@ from opengever.task.localroles import LocalRolesSetter
 from opengever.task.task import ITask
 from opengever.task.util import add_simple_response
 from opengever.tasktemplates.interfaces import IDuringTaskTemplateFolderTriggering
-from opengever.tasktemplates.interfaces import IFromSequentialTasktemplate
 from zope.container.interfaces import IContainerModifiedEvent
 from zope.globalrequest import getRequest
 
@@ -159,10 +158,9 @@ def record_added_activity(task, event):
     if IDuringTaskTemplateFolderTriggering.providedBy(getRequest()):
         return
 
-    parent = aq_parent(aq_inner(task))
     if IForwarding.providedBy(task):
-        activity = ForwardingAddedActivity(task, getRequest(), parent)
+        activity = ForwardingAddedActivity(task, getRequest())
     else:
-        activity = TaskAddedActivity(task, getRequest(), parent)
+        activity = TaskAddedActivity(task, getRequest())
 
     activity.record()

--- a/opengever/task/locales/de/LC_MESSAGES/opengever.task.po
+++ b/opengever/task/locales/de/LC_MESSAGES/opengever.task.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2019-11-18 10:28+0000\n"
+"POT-Creation-Date: 2020-02-13 14:09+0000\n"
 "PO-Revision-Date: 2015-02-17 18:41+0100\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -437,6 +437,7 @@ msgid "label_complete_documents"
 msgstr "Dokumente"
 
 #. Default: "Containing tasks"
+#: ./opengever/task/activities.py
 #: ./opengever/task/browser/templates/overview.pt
 msgid "label_containing_task"
 msgstr "Hauptaufgabe"
@@ -465,10 +466,10 @@ msgstr "Zu erledigen bis"
 msgid "label_documents"
 msgstr "Dokumente"
 
-#. Default: "Dossier title"
+#. Default: "Dossier: ${title}"
 #: ./opengever/task/activities.py
 msgid "label_dossier_title"
-msgstr "Dossiertitel"
+msgstr "Dossiertitel: ${title}"
 
 #. Default: "You are not allowed to edit this response."
 #: ./opengever/task/templates/edit_response.pt

--- a/opengever/task/locales/fr/LC_MESSAGES/opengever.task.po
+++ b/opengever/task/locales/fr/LC_MESSAGES/opengever.task.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-11-18 10:28+0000\n"
+"POT-Creation-Date: 2020-02-13 14:09+0000\n"
 "PO-Revision-Date: 2017-12-03 11:47+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-task/fr/>\n"
@@ -439,6 +439,7 @@ msgid "label_complete_documents"
 msgstr "Documents"
 
 #. Default: "Containing tasks"
+#: ./opengever/task/activities.py
 #: ./opengever/task/browser/templates/overview.pt
 msgid "label_containing_task"
 msgstr "Tâche principale"
@@ -467,10 +468,10 @@ msgstr "A réaliser jusqu'au"
 msgid "label_documents"
 msgstr "Documents"
 
-#. Default: "Dossier title"
+#. Default: "Dossier: ${title}"
 #: ./opengever/task/activities.py
 msgid "label_dossier_title"
-msgstr "Titre du dossier"
+msgstr "Titre du dossier: ${title}"
 
 #. Default: "You are not allowed to edit this response."
 #: ./opengever/task/templates/edit_response.pt

--- a/opengever/task/locales/opengever.task.pot
+++ b/opengever/task/locales/opengever.task.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2019-11-18 10:28+0000\n"
+"POT-Creation-Date: 2020-02-13 14:09+0000\n"
 "PO-Revision-Date: 2009-02-25 14:39+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -437,6 +437,7 @@ msgid "label_complete_documents"
 msgstr ""
 
 #. Default: "Containing tasks"
+#: ./opengever/task/activities.py
 #: ./opengever/task/browser/templates/overview.pt
 msgid "label_containing_task"
 msgstr ""
@@ -465,7 +466,7 @@ msgstr ""
 msgid "label_documents"
 msgstr ""
 
-#. Default: "Dossier title"
+#. Default: "Dossier: ${title}"
 #: ./opengever/task/activities.py
 msgid "label_dossier_title"
 msgstr ""

--- a/opengever/task/task.py
+++ b/opengever/task/task.py
@@ -491,9 +491,11 @@ class Task(Container, TaskReminderSupport):
         return IReferenceNumber(self).get_number()
 
     def get_containing_dossier(self):
+        """Returns the first parent dossier or inbox"""
         return get_containing_dossier(self)
 
     def get_containing_dossier_title(self):
+        """Title of the main dossier or inbox"""
         # get the containing_dossier value directly with the indexer
         adapter = getMultiAdapter(
             (self, getToolByName(self, 'portal_catalog')),
@@ -503,6 +505,8 @@ class Task(Container, TaskReminderSupport):
         return adapter()
 
     def get_containing_subdossier(self):
+        """Title of the containing subdossier or empty string if it is
+        contained directly in a dossier"""
         # get the containing_dossier value directly with the indexer
         adapter = getMultiAdapter(
             (self, getToolByName(self, 'portal_catalog')),

--- a/opengever/task/tests/test_activities.py
+++ b/opengever/task/tests/test_activities.py
@@ -1,8 +1,10 @@
 from datetime import date
+from datetime import datetime
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.mail.utils import get_header
 from ftw.testbrowser import browsing
+from ftw.testing import freeze
 from ftw.testing.mailing import Mailing
 from opengever.activity import notification_center
 from opengever.activity.mailer import process_mail_queue
@@ -279,16 +281,17 @@ class TestTaskActivites(FunctionalTestCase):
                       .in_state('task-state-in-progress')
                       .within(self.dossier))
 
-        browser.login().open(task, view='++add++opengever.task.task')
-        browser.fill({'Title': u'Unteraufgabe Abkl\xe4rung Fall Meier',
-                      'Task Type': 'comment',
-                      'Text': 'Lorem ipsum'})
+        with freeze(datetime(2015, 03, 02)):
+            browser.login().open(task, view='++add++opengever.task.task')
+            browser.fill({'Title': u'Unteraufgabe Abkl\xe4rung Fall Meier',
+                          'Task Type': 'comment',
+                          'Text': 'Lorem ipsum'})
 
-        form = browser.find_form_by_field('Responsible')
-        form.find_widget('Responsible').fill('hugo.boss')
-        form.find_widget('Issuer').fill(u'hugo.boss')
+            form = browser.find_form_by_field('Responsible')
+            form.find_widget('Responsible').fill('hugo.boss')
+            form.find_widget('Issuer').fill(u'hugo.boss')
 
-        browser.css('#form-buttons-save').first.click()
+            browser.css('#form-buttons-save').first.click()
 
         # Ensure adding subtask activity is fired only once.
         # Second activity is for task creation
@@ -301,6 +304,18 @@ class TestTaskActivites(FunctionalTestCase):
                           u'Dossier: Dossier XY',
                           activity.summary)
 
+        browser.open_html(activity.description)
+        rows = browser.css('table').first.rows
+
+        self.assertEquals(
+            [['Task title', u'Unteraufgabe Abkl\xe4rung Fall Meier'],
+             ['Deadline', 'Mar 07, 2015'],
+             ['Task Type', 'To comment'],
+             ['Containing tasks', u'Abkl\xe4rung Fall Meier'],
+             ['Text', 'Lorem ipsum'],
+             ['Responsible', 'Boss Hugo (hugo.boss)'],
+             ['Issuer', 'Boss Hugo (hugo.boss)']],
+            [row.css('td').text for row in rows])
 
     @browsing
     def test_adding_a_document_notifies_watchers(self, browser):

--- a/opengever/task/tests/test_activities.py
+++ b/opengever/task/tests/test_activities.py
@@ -67,7 +67,6 @@ class TestTaskActivites(FunctionalTestCase):
             [['Task title', u'Abkl\xe4rung Fall Meier'],
              ['Deadline', 'Feb 13, 2015'],
              ['Task Type', 'To comment'],
-             ['Dossier title', 'Dossier XY'],
              ['Text', 'Lorem ipsum'],
              ['Responsible', 'Boss Hugo (hugo.boss)'],
              ['Issuer', 'Test User (test_user_1_)']],

--- a/opengever/task/tests/test_sequential_task_process.py
+++ b/opengever/task/tests/test_sequential_task_process.py
@@ -176,7 +176,8 @@ class TestSequentialTaskProcess(IntegrationTestCase):
         activity = activities[-1]
         self.assertEquals('task-added', activity.kind)
         self.assertEquals('Task opened', activity.label)
-        self.assertEquals(u'New task opened by B\xe4rfuss K\xe4thi',
+        self.assertEquals(u'New task opened by B\xe4rfuss K\xe4thi\n'
+                          u'Dossier: Vertr\xe4ge mit der kantonalen Finanzverwaltung',
                           activity.summary)
         self.assertEquals(Oguid.for_object(subtask2), activity.resource.oguid)
 

--- a/opengever/task/transition.py
+++ b/opengever/task/transition.py
@@ -1,4 +1,3 @@
-from Acquisition import aq_parent
 from opengever.activity import notification_center
 from opengever.activity.roles import TASK_RESPONSIBLE_ROLE
 from opengever.base.source import DossierPathSourceBinder
@@ -28,7 +27,6 @@ from z3c.relationfield.schema import RelationList
 from zope import schema
 from zope.component import adapter
 from zope.component import getUtility
-from zope.component import queryMultiAdapter
 from zope.event import notify
 from zope.globalrequest import getRequest
 from zope.interface import implementer
@@ -347,12 +345,13 @@ class OpenPlannedTransitionExtender(DefaultTransitionExtender):
     record an TaskAdded activity instead."""
 
     def after_transition_hook(self, transition, disable_sync, transition_params):
-        response = add_simple_response(self.context, transition=transition,
+        response = add_simple_response(self.context,
+                                       transition=transition,
                                        text=transition_params.get('text'),
-            supress_activity=True)
+                                       supress_activity=True)
 
         TaskAddedActivity(
-            self.context, getRequest(), aq_parent(self.context)).record()
+            self.context, getRequest()).record()
 
         self.save_related_items(response, transition_params.get('relatedItems'))
         self.sync_change(transition, transition_params.get('text'), disable_sync)

--- a/opengever/tasktemplates/browser/form.py
+++ b/opengever/tasktemplates/browser/form.py
@@ -300,11 +300,11 @@ class AddForm(BrowserView):
             task.reindexObject()
 
             # add activity record for subtask
-            activity = TaskAddedActivity(task, self.request, self.context)
+            activity = TaskAddedActivity(task, self.request)
             activity.record()
 
         # add activity record for the main task
-        activity = TaskAddedActivity(main_task, self.request, self.context)
+        activity = TaskAddedActivity(main_task, self.request)
         activity.record()
 
         IStatusMessage(self.request).addStatusMessage(

--- a/opengever/tasktemplates/tasktemplatefolder.py
+++ b/opengever/tasktemplates/tasktemplatefolder.py
@@ -127,7 +127,7 @@ class TaskTemplateFolderTrigger(object):
 
         # add activity record for subtask
         if api.content.get_state(task) != TASK_STATE_PLANNED:
-            activity = TaskAddedActivity(task, getRequest(), main_task)
+            activity = TaskAddedActivity(task, getRequest())
             activity.record()
 
         return task


### PR DESCRIPTION
To give more context to the users we add the dossier title in task activities. 
As we want to add the information about the dossier only for certain types of activities, adding a new column in the `Activity` model that would be empty for most activities did not seem to make too much sense, especially that then `Notification` serialization would also need to support cases with or without that field and so on. 

Instead we simply add the dossier title in the `summary` field for the task activities. I chose to add it in the `summary` and not the `description` field as the `description` is only displayed in the notification mails, but not in the badges and digests.

The tabular view (`mynotifications` tab) also displays notifications, but it does neither display the summary nor the description, hence the dossier will not appear there. As already said, I don't think it would make too much sense to add a column here that would be mainly empty.

**Badge notification**
<img width="456" alt="Screenshot 2020-02-14 at 12 03 09" src="https://user-images.githubusercontent.com/7374243/74525765-35e67700-4f22-11ea-859c-dc9ce9b83319.png">

**New task created E-mail**
<img width="840" alt="Screenshot 2020-02-14 at 12 04 14" src="https://user-images.githubusercontent.com/7374243/74525768-3848d100-4f22-11ea-94fa-ef5433777b75.png">

For https://github.com/4teamwork/opengever.sg/issues/376

## Checkliste
- [x] Gibt es neue Übersetzungen?
  - [x] Sind alle msg-Strings in Übersetzungen Unicode?
  - [x] Wird die richtige i18n-domain verwendet (Copy-Paste Fehler sind hier häufig)?
- [x] Changelog-Eintrag vorhanden/nötig?