### PR TITLE
Assign correct role Reader to reader_group.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2020.1.0rc3 (unreleased)
 ------------------------
 
+- Assign correct role Reader to reader_group. [deiferni]
 - Add permission and role to use the workspace Client. [njohner]
 - Add french titles for initial content in the policytemplate. [phgross]
 - Enable the solr flag in the policytemplate. [phgross]

--- a/opengever/examplecontent/configure.zcml
+++ b/opengever/examplecontent/configure.zcml
@@ -19,6 +19,7 @@
                            opengever.examplecontent:municipality_content
                            opengever.examplecontent:workspace_content"
       admin_unit_id="fd"
+      reader_group="gever_reader"
       administrator_group="gever_admins"
       records_manager_group="record_managers"
       archivist_group="archiv"
@@ -32,6 +33,7 @@
                            opengever.examplecontent:repository_minimal
                            opengever.examplecontent:municipality_content"
       admin_unit_id="ska"
+      reader_group="gever_reader"
       administrator_group="gever_admins"
       records_manager_group="record_managers"
       archivist_group="archiv"

--- a/opengever/setup/deploy.py
+++ b/opengever/setup/deploy.py
@@ -164,7 +164,7 @@ class GeverDeployment(object):
         self.site.manage_changeProperties(title=site_title)
 
         self.assign_group_to_role(self.site, self.config,
-                                  'reader_group', 'Member')
+                                  'reader_group', 'Reader')
         self.assign_group_to_role(self.site, self.config,
                                   'rolemanager_group', 'Role Manager')
         self.assign_group_to_role(self.site, self.config,


### PR DESCRIPTION
The reader_group was assigned to the `Member` role which seems incorrect.

Seems like we only configured this for one customer so far, but only retroactively in the policy after a TTW change, see https://github.com/4teamwork/opengever.koeniz/pull/65.

I also add a fake reader group to our dev deployments that make sure the code path to set the group is executed once in a while.

## Checkliste

- [x] Changelog-Eintrag vorhanden/nötig?
