### PR TITLE
Allow Administrators to add new keywords.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2020.1.0rc3 (unreleased)
 ------------------------
 
+- Allow Administrators to add new keywords. [njohner]
 - Assign correct role Reader to reader_group. [deiferni]
 - Add permission and role to use the workspace Client. [njohner]
 - Add french titles for initial content in the policytemplate. [phgross]

--- a/opengever/core/profiles/default/rolemap.xml
+++ b/opengever/core/profiles/default/rolemap.xml
@@ -46,6 +46,7 @@
       <role name="Manager" />
       <role name="Site Administrator" />
       <role name="Contributor" />
+      <role name="Administrator" />
     </permission>
 
     <permission name="opengever.bumblebee: Revive Preview" acquire="True">

--- a/opengever/core/upgrades/20200217113801_allow_administrators_to_add_new_keywords/rolemap.xml
+++ b/opengever/core/upgrades/20200217113801_allow_administrators_to_add_new_keywords/rolemap.xml
@@ -1,0 +1,13 @@
+<rolemap>
+  <permissions>
+
+    <permission name="ftw.keywordwidget: Add new term" acquire="False">
+      <role name="Manager" />
+      <role name="Site Administrator" />
+      <role name="Contributor" />
+      <role name="Administrator" />
+    </permission>
+
+  </permissions>
+
+</rolemap>

--- a/opengever/core/upgrades/20200217113801_allow_administrators_to_add_new_keywords/upgrade.py
+++ b/opengever/core/upgrades/20200217113801_allow_administrators_to_add_new_keywords/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AllowAdministratorsToAddNewKeywords(UpgradeStep):
+    """Allow administrators to add new keywords.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()


### PR DESCRIPTION
Administrators did not have the permission to add new keywords, which can lead to situations where an administrator can add a new dossier, or edit a dossier, but cannot add a keyword on the dossier.

For https://extranet.4teamwork.ch/support/gemeinde-muri-guemligen/tracker/5/

## Checkliste
- [x] Profil angepasst? Sind UpgradeSteps vorhanden/nötig?:
- [x] Sind UpgradeSteps `deferrable`, oder können gewisse Schritte des Upgrades konditional ausgeführt werden? Not deferrable
- [x] Changelog-Eintrag vorhanden/nötig?
