### PR TITLE
Add dossier title to task activity titles.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2020.1.0rc3 (unreleased)
 ------------------------
 
+- Add container title to task activities. [njohner]
 - Allow Administrators to add new keywords. [njohner]
 - Implement @copy-document-to-workspace endpoint. [elioschmutz]
 - Assign correct role Reader to reader_group. [deiferni]

--- a/opengever/activity/browser/templates/notification_mail_macros.pt
+++ b/opengever/activity/browser/templates/notification_mail_macros.pt
@@ -213,8 +213,9 @@
               <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
                 <tr>
                   <td style="padding: 40px; font-family: Arial, sans-serif; font-size: 15px; line-height: 140%; color: #555555;">
-                    <h1 style="text-align: center; margin: 0 0 10px 0; font-family: Arial, sans-serif; font-size: 24px; line-height: 125%; color: #333333; font-weight: normal;" tal:content="options/title">
+                    <h1 style="text-align: center; margin: 0 0 10px 0; font-family: Arial, sans-serif; font-size: 24px; line-height: 125%; color: #333333; font-weight: normal;">
                         <metal:title define-slot="title">
+                          <span tal:replace="options/title"/>
                         </metal:title>
                     </h1>
                     <metal:subtitle define-slot="subtitle">

--- a/opengever/activity/templates/notification.pt
+++ b/opengever/activity/templates/notification.pt
@@ -14,13 +14,11 @@
     </metal:styles>
 
     <metal:title metal:fill-slot="title">
-        <div tal:replace="options/title"></div>
+        <p><a href="" tal:content="options/title" tal:attributes="href options/link"></a></p>
     </metal:title>
 
     <metal:content metal:fill-slot="content">
       <p class="notification_label" tal:content="structure options/summary" />
-
-      <p><a href="" tal:content="options/title" tal:attributes="href options/link"></a></p>
 
       <tal:block tal:condition="options/description">
         <tal:block tal:repeat="paragraph options/description">

--- a/opengever/activity/tests/test_digest.py
+++ b/opengever/activity/tests/test_digest.py
@@ -75,7 +75,7 @@ class TestDigestMail(IntegrationTestCase):
         browser.open_html(str(messages[0].get_payload()[0]))
 
         self.assertEquals('Oct 16, 2017', browser.css('table p').text[0])
-        self.assertEquals(['Daily Digest for B=C3=A4rfuss K=C3=A4thi'],
+        self.assertEquals(['= Daily Digest for B=C3=A4rfuss K=C3=A4thi ='],
                           browser.css('h1').text)
         self.assertEquals(['Bitte =C3=84nderungen nachvollziehen'],
                           browser.css('h2 a').text)

--- a/opengever/activity/tests/test_mail.py
+++ b/opengever/activity/tests/test_mail.py
@@ -56,11 +56,18 @@ class TestEmailNotification(IntegrationTestCase):
     @browsing
     def test_subject_is_title(self, browser):
         self.login(self.dossier_responsible, browser)
+
+        # We change the dossier title to ASCII-only, makes it easier
+        # to test the mail subject
+        self.dossier.title = "Dossier title"
+
         self.create_task_via_browser(browser)
         process_mail_queue()
 
         mail = email.message_from_string(Mailing(self.portal).pop())
-        self.assertEquals('GEVER Activity: Test Task', mail.get('Subject'))
+
+        self.assertEquals(
+            'GEVER Activity: [Dossier title] Test Task', mail.get('Subject'))
 
     @browsing
     def test_notification_summary_is_split_into_paragraphs(self, browser):
@@ -145,7 +152,8 @@ class TestEmailNotification(IntegrationTestCase):
         process_mail_queue()
 
         raw_mail = Mailing(self.portal).pop()
-        link = '<p><a href=3D"http://nohost/plone/@@resolve_notification?notification=\n_id=3D1">Test Task</a></p>'
+        link = ('<p><a href=3D"http://nohost/plone/@@resolve_notification?notification=\n_id=3D1">'
+                '[Vertr=C3=A4ge mit der kantonalen...] Test Task</a></p>')
         self.assertIn(link, raw_mail.strip())
 
     @browsing

--- a/opengever/activity/tests/test_mail.py
+++ b/opengever/activity/tests/test_mail.py
@@ -152,7 +152,7 @@ class TestEmailNotification(IntegrationTestCase):
         process_mail_queue()
 
         raw_mail = Mailing(self.portal).pop()
-        link = ('<p><a href=3D"http://nohost/plone/@@resolve_notification?notification=\n_id=3D1">'
+        link = ('<p><a href=3D"http://nohost/plone/@@resolve_notification?notificati=\non_id=3D1">'
                 '[Vertr=C3=A4ge mit der kantonalen...] Test Task</a></p>')
         self.assertIn(link, raw_mail.strip())
 

--- a/opengever/activity/tests/test_mail.py
+++ b/opengever/activity/tests/test_mail.py
@@ -224,7 +224,7 @@ class TestNotificationMailsAndSavepoints(IntegrationTestCase):
         self.login(self.dossier_responsible)
 
         # Trigger a notification that dispatches a mail
-        activity = TaskAddedActivity(self.task, getRequest(), self.dossier)
+        activity = TaskAddedActivity(self.task, getRequest())
         activity.record()
 
         # Creating a savepoint will fail with the MailDataManager if it's

--- a/opengever/api/tests/test_notifications.py
+++ b/opengever/api/tests/test_notifications.py
@@ -53,7 +53,7 @@ class TestNotificationsGet(IntegrationTestCase):
               u'notification_id': 3,
               u'read': False,
               u'summary': u'New task opened by Ziegler Robert',
-              u'title': u'Vertragsentwurf \xdcberpr\xfcfen'},
+              u'title': u'[Vertr\xe4ge mit der kantonalen...] Vertragsentwurf \xdcberpr\xfcfen'},
              {u'@id': u'http://nohost/plone/@notifications/kathi.barfuss/1',
               u'actor_id': u'nicole.kohler',
               u'actor_label': u'Kohler Nicole',
@@ -63,7 +63,7 @@ class TestNotificationsGet(IntegrationTestCase):
               u'notification_id': 1,
               u'read': True,
               u'summary': u'New task opened by Ziegler Robert',
-              u'title': u'Vertragsentwurf \xdcberpr\xfcfen'}],
+              u'title': u'[Vertr\xe4ge mit der kantonalen...] Vertragsentwurf \xdcberpr\xfcfen'}],
             browser.json.get('items'))
 
     @browsing
@@ -127,7 +127,7 @@ class TestNotificationsGet(IntegrationTestCase):
              u'notification_id': 1,
              u'read': False,
              u'summary': u'New task opened by Ziegler Robert',
-             u'title': u'Vertragsentwurf \xdcberpr\xfcfen'},
+             u'title': u'[Vertr\xe4ge mit der kantonalen...] Vertragsentwurf \xdcberpr\xfcfen'},
             browser.json)
 
     @browsing

--- a/opengever/api/tests/test_notifications.py
+++ b/opengever/api/tests/test_notifications.py
@@ -22,13 +22,13 @@ class TestNotificationsGet(IntegrationTestCase):
         self.assertEqual(0,  Notification.query.count())
 
         with freeze(datetime(2017, 10, 16, 0, 0, tzinfo=pytz.utc)):
-            TaskAddedActivity(self.task, self.request, self.task.__parent__).record()
+            TaskAddedActivity(self.task, self.request).record()
 
         for notification in Notification.query.all():
             notification.is_read = True
 
         with freeze(datetime(2018, 10, 16, 0, 0, tzinfo=pytz.utc)):
-            TaskAddedActivity(self.task, self.request, self.task.__parent__).record()
+            TaskAddedActivity(self.task, self.request).record()
 
         self.assertEqual(2, len(center.get_watchers(self.task)))
 
@@ -76,7 +76,7 @@ class TestNotificationsGet(IntegrationTestCase):
 
         with freeze(datetime(2017, 10, 16, 0, 0, tzinfo=pytz.utc)):
             for i in range(5):
-                TaskAddedActivity(self.task, self.request, self.task.__parent__).record()
+                TaskAddedActivity(self.task, self.request).record()
 
         self.login(self.regular_user, browser=browser)
 
@@ -107,7 +107,7 @@ class TestNotificationsGet(IntegrationTestCase):
         self.assertEqual(0,  Notification.query.count())
 
         with freeze(datetime(2017, 10, 16, 0, 0, tzinfo=pytz.utc)):
-            TaskAddedActivity(self.task, self.request, self.task.__parent__).record()
+            TaskAddedActivity(self.task, self.request).record()
 
         url = '{}/@notifications/{}/1'.format(self.portal.absolute_url(),
                                               self.regular_user.getId())
@@ -160,7 +160,7 @@ class TestNotificationsGet(IntegrationTestCase):
         self.login(self.dossier_responsible, browser=browser)
 
         with freeze(datetime(2017, 10, 16, 0, 0, tzinfo=pytz.utc)):
-            TaskAddedActivity(self.task, self.request, self.task.__parent__).record()
+            TaskAddedActivity(self.task, self.request).record()
 
         # Different username in path
         with browser.expect_http_error(401):
@@ -185,7 +185,7 @@ class TestNotificationsPatch(IntegrationTestCase):
     def test_mark_notification_as_read(self, browser):
         self.login(self.dossier_responsible, browser=browser)
 
-        TaskAddedActivity(self.task, self.request, self.task.__parent__).record()
+        TaskAddedActivity(self.task, self.request).record()
 
         url = '{}/@notifications/{}/{}'.format(self.portal.absolute_url(),
                                                self.regular_user.getId(), 1)
@@ -221,7 +221,7 @@ class TestNotificationsPatch(IntegrationTestCase):
         self.login(self.dossier_responsible, browser=browser)
 
         with freeze(datetime(2017, 10, 16, 0, 0, tzinfo=pytz.utc)):
-            TaskAddedActivity(self.task, self.request, self.task.__parent__).record()
+            TaskAddedActivity(self.task, self.request).record()
 
         # Different username in path
         with browser.expect_http_error(401):

--- a/opengever/globalindex/model/task.py
+++ b/opengever/globalindex/model/task.py
@@ -464,6 +464,16 @@ class Task(Base):
         """Wrap a span-tag around the text with the status-css class."""
         return u'<span class="wf-%s">%s</span>' % (self.review_state, text)
 
+    def get_containing_dossier_title(self):
+        """containing dossier title encoded as utf-8 to mirror the behavior
+        of opengever.task.task.Task"""
+        return self.containing_dossier.encode('utf-8')
+
+    def get_containing_subdossier(self):
+        """containing subdossier title encoded as utf-8 to mirror the behavior
+        of opengever.task.task.Task"""
+        return self.containing_subdossier.encode('utf-8')
+
 
 class TaskQuery(BaseQuery):
 

--- a/opengever/task/activities.py
+++ b/opengever/task/activities.py
@@ -55,10 +55,6 @@ class TaskAddedActivity(BaseTaskActivity):
     """Activity representation for adding a task.
     """
 
-    def __init__(self, context, request, parent):
-        super(TaskAddedActivity, self).__init__(context, request)
-        self.parent = parent
-
     @property
     def kind(self):
         return PloneMessageFactory(u'task-added', default=u'Task added')
@@ -111,7 +107,7 @@ class TaskAddedActivity(BaseTaskActivity):
             [_('label_task_type', u'Task Type'),
              self.context.get_task_type_label(language=language)],
             [_('label_dossier_title', u'Dossier title'),
-             self.parent.title],
+             self.dossier_title],
             [_('label_text', u'Text'),
              self.context.text if self.context.text else u'-'],
             [_('label_responsible', u'Responsible'),

--- a/opengever/task/activities.py
+++ b/opengever/task/activities.py
@@ -1,3 +1,5 @@
+from Acquisition import aq_inner
+from Acquisition import aq_parent
 from opengever.activity import ACTIVITY_TRANSLATIONS
 from opengever.activity import base_notification_center
 from opengever.activity.base import BaseActivity
@@ -100,7 +102,7 @@ class TaskAddedActivity(BaseTaskActivity):
     def collect_description_data(self, language):
         """Returns a list with [label, value] pairs.
         """
-        return [
+        data = [
             [_('label_task_title', u'Task title'), self.context.title],
             [_('label_deadline', u'Deadline'),
              api.portal.get_localized_time(str(self.context.deadline))],
@@ -114,7 +116,13 @@ class TaskAddedActivity(BaseTaskActivity):
              self.context.get_responsible_actor().get_label()],
             [_('label_issuer', u'Issuer'),
              self.context.get_issuer_actor().get_label()]
-        ]
+            ]
+        if self.context.get_is_subtask():
+            parent = aq_parent(aq_inner(self.context))
+            data.insert(
+                4, [_('label_containing_task', u'Containing tasks'), parent.title]
+                )
+        return data
 
     def before_recording(self):
         self.center.add_task_responsible(self.context,

--- a/opengever/task/activities.py
+++ b/opengever/task/activities.py
@@ -35,6 +35,11 @@ class BaseTaskActivity(BaseActivity):
     def title(self):
         task_title = super(BaseTaskActivity, self).title
 
+        if not self.dossier_title:
+            # Just to be safe, but this should not happen, except in tests
+            # where tasks are created directly on the site root.
+            return task_title
+
         if len(self.dossier_title) > self.CONTAINER_TITLE_MAX_LENGHT:
             cropped_dossier_title = self.dossier_title[:self.CONTAINER_TITLE_MAX_LENGHT - 3] + u"..."
         else:

--- a/opengever/task/browser/delegate/utils.py
+++ b/opengever/task/browser/delegate/utils.py
@@ -1,4 +1,3 @@
-from opengever.task.activities import TaskAddedActivity
 from opengever.task.util import update_reponsible_field_data
 from plone.dexterity.utils import addContentToContainer
 from plone.dexterity.utils import createContent
@@ -6,7 +5,6 @@ from plone.dexterity.utils import iterSchemata
 from z3c.relationfield import RelationValue
 from zope import schema
 from zope.event import notify
-from zope.lifecycleevent import ObjectCreatedEvent
 from zope.lifecycleevent import ObjectModifiedEvent
 import urllib
 

--- a/opengever/task/handlers.py
+++ b/opengever/task/handlers.py
@@ -11,7 +11,6 @@ from opengever.task.localroles import LocalRolesSetter
 from opengever.task.task import ITask
 from opengever.task.util import add_simple_response
 from opengever.tasktemplates.interfaces import IDuringTaskTemplateFolderTriggering
-from opengever.tasktemplates.interfaces import IFromSequentialTasktemplate
 from zope.container.interfaces import IContainerModifiedEvent
 from zope.globalrequest import getRequest
 
@@ -159,10 +158,9 @@ def record_added_activity(task, event):
     if IDuringTaskTemplateFolderTriggering.providedBy(getRequest()):
         return
 
-    parent = aq_parent(aq_inner(task))
     if IForwarding.providedBy(task):
-        activity = ForwardingAddedActivity(task, getRequest(), parent)
+        activity = ForwardingAddedActivity(task, getRequest())
     else:
-        activity = TaskAddedActivity(task, getRequest(), parent)
+        activity = TaskAddedActivity(task, getRequest())
 
     activity.record()

--- a/opengever/task/task.py
+++ b/opengever/task/task.py
@@ -491,9 +491,11 @@ class Task(Container, TaskReminderSupport):
         return IReferenceNumber(self).get_number()
 
     def get_containing_dossier(self):
+        """Returns the first parent dossier or inbox"""
         return get_containing_dossier(self)
 
     def get_containing_dossier_title(self):
+        """Title of the main dossier or inbox"""
         # get the containing_dossier value directly with the indexer
         adapter = getMultiAdapter(
             (self, getToolByName(self, 'portal_catalog')),
@@ -503,6 +505,8 @@ class Task(Container, TaskReminderSupport):
         return adapter()
 
     def get_containing_subdossier(self):
+        """Title of the containing subdossier or empty string if it is
+        contained directly in a dossier"""
         # get the containing_dossier value directly with the indexer
         adapter = getMultiAdapter(
             (self, getToolByName(self, 'portal_catalog')),

--- a/opengever/task/tests/test_activities.py
+++ b/opengever/task/tests/test_activities.py
@@ -56,7 +56,8 @@ class TestTaskActivites(FunctionalTestCase):
 
         activity = Activity.query.one()
         self.assertEquals('task-added', activity.kind)
-        self.assertEquals(u'Abkl\xe4rung Fall Meier', activity.title)
+        self.assertEquals(
+          u'[Dossier XY] Abkl\xe4rung Fall Meier', activity.title)
         self.assertEquals(u'New task opened by Test User', activity.summary)
 
         browser.open_html(activity.description)
@@ -116,7 +117,8 @@ class TestTaskActivites(FunctionalTestCase):
     def test_task_accepted(self, browser):
         task = create(Builder('task')
                       .titled(u'Abkl\xe4rung Fall Meier')
-                      .having(responsible=TEST_USER_ID))
+                      .having(responsible=TEST_USER_ID)
+                      .within(self.dossier))
 
         browser.login().open(task)
         browser.css('#workflow-transition-task-transition-open-in-progress').first.click()
@@ -129,7 +131,7 @@ class TestTaskActivites(FunctionalTestCase):
 
         activity = Activity.query.order_by(desc(Activity.id)).first()
         self.assertEquals(u'task-transition-open-in-progress', activity.kind)
-        self.assertEquals(u'Abkl\xe4rung Fall Meier', activity.title)
+        self.assertEquals(u'[Dossier XY] Abkl\xe4rung Fall Meier', activity.title)
         self.assertEquals(
             u'Accepted by <a href="http://nohost/plone/@@user-details/test_user_1_">Test User (test_user_1_)</a>',
             activity.summary)
@@ -137,7 +139,8 @@ class TestTaskActivites(FunctionalTestCase):
 
     @browsing
     def test_task_commented(self, browser):
-        dossier = create(Builder('dossier'))
+        dossier = create(Builder('dossier')
+                         .titled(u"Dossier XY"))
         task = create(Builder('task')
                       .within(dossier)
                       .titled(u'Abkl\xe4rung Fall Meier')
@@ -153,7 +156,8 @@ class TestTaskActivites(FunctionalTestCase):
 
         activity = Activity.query.order_by(desc(Activity.id)).first()
         self.assertEquals(u'task-commented', activity.kind)
-        self.assertEquals(u'Abkl\xe4rung Fall Meier', activity.title)
+        self.assertEquals(
+          u'[Dossier XY] Abkl\xe4rung Fall Meier', activity.title)
         self.assertEquals(
             u'Commented by <a href="http://nohost/plone/@@user-details/test_user_1_">Test User (test_user_1_)</a>',
             activity.summary)
@@ -166,7 +170,8 @@ class TestTaskActivites(FunctionalTestCase):
                .with_roles('Reader', 'Editor', 'Contributor'))
         task = create(Builder('task')
                       .titled(u'Abkl\xe4rung Fall Meier')
-                      .having(responsible='hugo.boss'))
+                      .having(responsible='hugo.boss')
+                      .within(self.dossier))
 
         browser.login(username='hugo.boss', password='secret').open(task)
         browser.css('#workflow-transition-task-transition-open-in-progress').first.click()
@@ -182,7 +187,8 @@ class TestTaskActivites(FunctionalTestCase):
         task = create(Builder('task')
                       .titled(u'Abkl\xe4rung Fall Meier')
                       .having(responsible=TEST_USER_ID)
-                      .in_state('task-state-in-progress'))
+                      .in_state('task-state-in-progress')
+                      .within(self.dossier))
 
         browser.login().open(task)
         browser.css('#workflow-transition-task-transition-in-progress-resolved').first.click()
@@ -195,7 +201,8 @@ class TestTaskActivites(FunctionalTestCase):
 
         activity = Activity.query.order_by(desc(Activity.id)).first()
         self.assertEquals(u'task-transition-in-progress-resolved', activity.kind)
-        self.assertEquals(u'Abkl\xe4rung Fall Meier', activity.title)
+        self.assertEquals(
+          u'[Dossier XY] Abkl\xe4rung Fall Meier', activity.title)
         self.assertEquals(
             u'Resolved by <a href="http://nohost/plone/@@user-details/test_user_1_">Test User (test_user_1_)</a>', activity.summary)
         self.assertEquals(u'Ist erledigt.', activity.description)
@@ -205,7 +212,8 @@ class TestTaskActivites(FunctionalTestCase):
         task = create(Builder('task')
                       .titled(u'Abkl\xe4rung Fall Meier')
                       .having(responsible=TEST_USER_ID)
-                      .in_state('task-state-rejected'))
+                      .in_state('task-state-rejected')
+                      .within(self.dossier))
 
         alsoProvides(task, IFromSequentialTasktemplate)
         transaction.commit()
@@ -221,7 +229,8 @@ class TestTaskActivites(FunctionalTestCase):
 
         activity = Activity.query.order_by(desc(Activity.id)).first()
         self.assertEquals(u'task-transition-rejected-skipped', activity.kind)
-        self.assertEquals(u'Abkl\xe4rung Fall Meier', activity.title)
+        self.assertEquals(
+          u'[Dossier XY] Abkl\xe4rung Fall Meier', activity.title)
         self.assertEquals(
             u'Skipped by <a href="http://nohost/plone/@@user-details/test_user_1_">Test User (test_user_1_)</a>', activity.summary)
         self.assertEquals(u'Wird \xfcbersprungen.', activity.description)
@@ -232,7 +241,8 @@ class TestTaskActivites(FunctionalTestCase):
                       .titled(u'Abkl\xe4rung Fall Meier')
                       .having(responsible=u'hugo.boss',
                               deadline=date(2015, 03, 01))
-                      .in_state('task-state-in-progress'))
+                      .in_state('task-state-in-progress')
+                      .within(self.dossier))
 
         browser.login().open(
             task, view='modify_deadline',
@@ -248,11 +258,13 @@ class TestTaskActivites(FunctionalTestCase):
 
         activity = Activity.query.order_by(desc(Activity.id)).first()
         self.assertEquals(u'task-transition-modify-deadline', activity.kind)
-        self.assertEquals(u'Abkl\xe4rung Fall Meier', activity.title)
+        self.assertEquals(u'[Dossier XY] Abkl\xe4rung Fall Meier',
+                          activity.title)
         self.assertEquals(
             'Deadline modified from 01.03.2015 to 20.03.2016 by'
             ' <a href="http://nohost/plone/@@user-details/test_user_1_">'
-            'Test User (test_user_1_)</a>', activity.summary)
+            'Test User (test_user_1_)</a>',
+            activity.summary)
         self.assertEquals(u'nicht dring\xe4nd', activity.description)
 
     @browsing
@@ -261,10 +273,11 @@ class TestTaskActivites(FunctionalTestCase):
                       .titled(u'Abkl\xe4rung Fall Meier')
                       .having(responsible=u'hugo.boss',
                               deadline=date(2015, 03, 01))
-                      .in_state('task-state-in-progress'))
+                      .in_state('task-state-in-progress')
+                      .within(self.dossier))
 
         browser.login().open(task, view='++add++opengever.task.task')
-        browser.fill({'Title': u'Abkl\xe4rung Fall Meier',
+        browser.fill({'Title': u'Unteraufgabe Abkl\xe4rung Fall Meier',
                       'Task Type': 'comment',
                       'Text': 'Lorem ipsum'})
 
@@ -280,7 +293,8 @@ class TestTaskActivites(FunctionalTestCase):
 
         activity = Activity.query.order_by(desc(Activity.id)).first()
         self.assertEquals('task-added', activity.kind)
-        self.assertEquals(u'Abkl\xe4rung Fall Meier', activity.title)
+        self.assertEquals(u'[Dossier XY] Unteraufgabe Abkl\xe4rung Fall Meier',
+                          activity.title)
         self.assertEquals(u'New task opened by Test User', activity.summary)
 
     @browsing
@@ -289,7 +303,8 @@ class TestTaskActivites(FunctionalTestCase):
                       .titled(u'Abkl\xe4rung Fall Meier')
                       .having(responsible=u'hugo.boss',
                               deadline=date(2015, 03, 01))
-                      .in_state('task-state-in-progress'))
+                      .in_state('task-state-in-progress')
+                      .within(self.dossier))
 
         browser.login().open(task, view='++add++opengever.document.document')
         browser.fill({'Title': u'Letter to peter'})
@@ -308,7 +323,8 @@ class TestTaskActivites(FunctionalTestCase):
                       .titled(u'Abkl\xe4rung Fall Huber')
                       .having(responsible=u'hugo.boss',
                               deadline=date(2015, 07, 01))
-                      .in_state('task-state-in-progress'))
+                      .in_state('task-state-in-progress')
+                      .within(self.dossier))
 
         browser.login().open(task)
         browser.find('task-transition-delegate').click()
@@ -326,7 +342,7 @@ class TestTaskActivites(FunctionalTestCase):
 
         activity = Activity.query.order_by(desc(Activity.id)).first()
         self.assertEquals('task-added', activity.kind)
-        self.assertEquals(u'Abkl\xe4rung Fall Huber', activity.title)
+        self.assertEquals(u'[Dossier XY] Abkl\xe4rung Fall Huber', activity.title)
         self.assertEquals(u'New task opened by Test User', activity.summary)
 
 
@@ -355,7 +371,9 @@ class TestTaskReassignActivity(IntegrationTestCase):
         reassign_activity = activities[-1]
 
         self.assertEquals(u'task-transition-reassign', reassign_activity.kind)
-        self.assertEquals(u'Vertragsentwurf \xdcberpr\xfcfen', reassign_activity.title)
+        self.assertEquals(
+          u'[Vertr\xe4ge mit der kantonalen...] Vertragsentwurf \xdcberpr\xfcfen',
+          reassign_activity.title)
         self.assertEquals(u'Reassigned from <a href="http://nohost/plone/@@user-details/kathi.barfuss">'
                           u'B\xe4rfuss K\xe4thi (kathi.barfuss)</a> '
                           u'to <a href="http://nohost/plone/@@user-details/herbert.jager">'
@@ -375,7 +393,9 @@ class TestTaskReassignActivity(IntegrationTestCase):
         reassign_activity = activities[-1]
 
         self.assertEquals(u'task-transition-reassign', reassign_activity.kind)
-        self.assertEquals(u'Vertragsentwurf \xdcberpr\xfcfen', reassign_activity.title)
+        self.assertEquals(
+          u'[Vertr\xe4ge mit der kantonalen...] Vertragsentwurf \xdcberpr\xfcfen',
+          reassign_activity.title)
         self.assertEquals(u'Reassigned from <a href="http://nohost/plone/@@user-details/kathi.barfuss">'
                           u'B\xe4rfuss K\xe4thi (kathi.barfuss)</a> '
                           u'to <a href="http://nohost/plone/@@user-details/herbert.jager">'
@@ -473,7 +493,8 @@ class TestSuccesssorHandling(FunctionalTestCase):
         self.dossier = create(Builder('dossier').titled(u'Dosssier A'))
         self.predecessor = create(Builder('task')
                                   .having(responsible='peter.meier',
-                                          issuer='james.meier'))
+                                          issuer='james.meier')
+                                  .within(self.dossier))
 
         self.center.add_task_responsible(self.predecessor, 'peter.meier')
         self.center.add_task_issuer(self.predecessor, 'james.meier')
@@ -517,6 +538,8 @@ class TestTaskReminderActivity(IntegrationTestCase):
 
         self.assertEquals('task-reminder', activity.kind)
         self.assertEquals('Task reminder', activity.label)
-        self.assertEquals(self.task.title, activity.title)
+        self.assertEquals(
+          u'[Vertr\xe4ge mit der kantonalen...] Vertragsentwurf \xdcberpr\xfcfen',
+          activity.title)
         self.assertEqual(SYSTEM_ACTOR_ID, activity.actor_id)
         self.assertEquals(u'Deadline is on Nov 01, 2016', activity.summary)

--- a/opengever/task/transition.py
+++ b/opengever/task/transition.py
@@ -1,4 +1,3 @@
-from Acquisition import aq_parent
 from opengever.activity import notification_center
 from opengever.activity.roles import TASK_RESPONSIBLE_ROLE
 from opengever.base.source import DossierPathSourceBinder
@@ -28,7 +27,6 @@ from z3c.relationfield.schema import RelationList
 from zope import schema
 from zope.component import adapter
 from zope.component import getUtility
-from zope.component import queryMultiAdapter
 from zope.event import notify
 from zope.globalrequest import getRequest
 from zope.interface import implementer
@@ -347,12 +345,13 @@ class OpenPlannedTransitionExtender(DefaultTransitionExtender):
     record an TaskAdded activity instead."""
 
     def after_transition_hook(self, transition, disable_sync, transition_params):
-        response = add_simple_response(self.context, transition=transition,
+        response = add_simple_response(self.context,
+                                       transition=transition,
                                        text=transition_params.get('text'),
-            supress_activity=True)
+                                       supress_activity=True)
 
         TaskAddedActivity(
-            self.context, getRequest(), aq_parent(self.context)).record()
+            self.context, getRequest()).record()
 
         self.save_related_items(response, transition_params.get('relatedItems'))
         self.sync_change(transition, transition_params.get('text'), disable_sync)

--- a/opengever/tasktemplates/browser/form.py
+++ b/opengever/tasktemplates/browser/form.py
@@ -73,7 +73,7 @@ meta_data['tasks'] = {
          'width': 30,
          'sortable': False,
          'hideable': False,
-         'menuDisabled':True,
+         'menuDisabled': True,
          'dataIndex': 'path_checkbox'},
 
         {'id': 'Title',
@@ -247,8 +247,8 @@ class AddForm(BrowserView):
             responsible=self.replace_interactive_user('current_user'),
             responsible_client=get_current_org_unit().id(),
             task_type='direct-execution',
-            deadline=date.today() +
-            timedelta(highest_deadline + deadline_timedelta),
+            deadline=(date.today()
+                      + timedelta(highest_deadline + deadline_timedelta)),
             )
 
         main_task = createContent('opengever.task.task', **data)
@@ -300,11 +300,11 @@ class AddForm(BrowserView):
             task.reindexObject()
 
             # add activity record for subtask
-            activity = TaskAddedActivity(task, self.request, self.context)
+            activity = TaskAddedActivity(task, self.request)
             activity.record()
 
         # add activity record for the main task
-        activity = TaskAddedActivity(main_task, self.request, self.context)
+        activity = TaskAddedActivity(main_task, self.request)
         activity.record()
 
         IStatusMessage(self.request).addStatusMessage(

--- a/opengever/tasktemplates/tasktemplatefolder.py
+++ b/opengever/tasktemplates/tasktemplatefolder.py
@@ -127,7 +127,7 @@ class TaskTemplateFolderTrigger(object):
 
         # add activity record for subtask
         if api.content.get_state(task) != TASK_STATE_PLANNED:
-            activity = TaskAddedActivity(task, getRequest(), main_task)
+            activity = TaskAddedActivity(task, getRequest())
             activity.record()
 
         return task


### PR DESCRIPTION
To give more context to the users we add the dossier title in task activities. 
As we want to add the information about the dossier only for certain types of activities, adding a new column in the `Activity` model that would be empty for most activities did not seem to make too much sense, especially that then `Notification` serialization would also need to support cases with or without that field and so on. 

Instead we simply add the dossier title in the `title` field for the task activities in the form `[dossier title] task title`. Adding it in the title will make it visible in the badges, notification mails and digests.

The tabular view (`mynotifications` tab) also displays the notification title, so there too, the dossier name will now appear for task activities.

While I was at it I made a few further changes:
- The notification mail template displayed the title of the context thrice (once in the mail subject, once as title in the mail content and a third time as link in the mail content) for normal activities and four times for `TaskAddedActivity`. This is now cut down to twice (once in the subject and once as linked title in the mail content) for normal activities.
- For `TaskAddedActivity`, the description already displayed the dossier title, in the style `Dossier: dossier title`, but this was actually not always the dossier title but the title of the parent, which could also be a main task. We now correctly display the dossier title there (or inbox) and added the main task title when a subtask was added.
- I did leave the dossier title and task title in the description field of the `TaskAddedActivity`, which means that it now appears twice in a combined style (`[dossier title] task title`), once in the subject of the E-mail and once as title for the E-mail content. And then each field also appears separately in the E-mail content in the description of the task (see screenshots below)

**Badge notification**
<img width="464" alt="Screenshot 2020-02-18 at 17 45 55" src="https://user-images.githubusercontent.com/7374243/74759922-dbc71800-5279-11ea-806c-76cfee4cbdaa.png">

**TaskCreatedActivity E-mails**
*As it was previously, task title appears 3 times and main task title is shown as `Dossiertitle`*
<img width="840" alt="Screenshot 2020-02-18 at 17 44 56" src="https://user-images.githubusercontent.com/7374243/74760223-5f810480-527a-11ea-8eb2-396fa1508ae3.png">

*As it is now, dossier and task title appear twice combined (with dossier title cropped) and then Dossier title appears once uncropped, task title appears once on its own and main task title appears correctly labelled*
<img width="840" alt="Screenshot 2020-02-18 at 17 43 21" src="https://user-images.githubusercontent.com/7374243/74760470-bc7cba80-527a-11ea-8b03-b41f35e3939b.png">

For https://github.com/4teamwork/opengever.sg/issues/376
Supersedes https://github.com/4teamwork/opengever.core/pull/6264

## Checkliste
- [x] Changelog-Eintrag vorhanden/nötig?