### PR TITLE
Implement @copy-document-to-workspace endpoint

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 ------------------------
 
 - Allow Administrators to add new keywords. [njohner]
+- Implement @copy-document-to-workspace endpoint. [elioschmutz]
 - Assign correct role Reader to reader_group. [deiferni]
 - Allow administrators to deactivate dossiers. [njohner]
 - Add permission and role to use the workspace Client. [njohner]

--- a/docs/public/dev-manual/api/linked_workspaces.rst
+++ b/docs/public/dev-manual/api/linked_workspaces.rst
@@ -69,3 +69,39 @@ Als Antwort erhalten Sie eine Representation des erstellten Teamraums
       "title": "Externe Zusammenarbeit",
        "...": "..."
     }
+
+
+Ein GEVER-Dokument in einen verknüpften Teamraum kopieren
+---------------------------------------------------------
+
+Über den Endpoint `@copy-document-to-workspace` kann eine Kopie eines GEVER-Dokuments in einen bestehenden Teamraum hochgeladen werden. Dabei ist zu beachten, dass der Teamraum mit dem Haupt-Dossier verknüpft sein muss und dass sich das Dokument innerhalb des aktuellen Hauptdossier oder in einem seiner Subdossiers befindet.
+
+Achtung: Die Kopie wird nicht mit dem originalen Dokument verknüpft. Es handelt sich um ein komplett unabhängiges Objekt. Ein automatisches zurückführen oder synchronisieren mit dem Originaldokument ist nicht möglich.
+
+**Beispiel-Request**:
+
+  .. sourcecode:: http
+
+    POST /ordnungssystem/dossier-23/@copy-document-to-workspace HTTP/1.1
+    Accept: application/json
+    Content-Type: application/json
+
+    {
+      "workspace_uid": "c11627f492b6447fb61617bb06b9a21a"
+      "document_uid": "c2ae40cf41c84493ac4b7618d75ee7f7"
+    }
+
+
+**Beispiel-Response**:
+
+  .. sourcecode:: http
+
+    HTTP/1.1 200 OK
+    Content-Type: application/json
+
+    {
+      "@id": ".../workspaces/workspace-1/document-1",
+      "@type": "opengever.document.document",
+      "title": "Ein Dokument",
+       "...": "..."
+    }

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -584,4 +584,12 @@
       permission="zope2.View"
       />
 
+  <plone:service
+      method="POST"
+      name="@copy-document-to-workspace"
+      for="opengever.dossier.behaviors.dossier.IDossierMarker"
+      factory=".linked_workspaces.CopyDocumentToWorkspacePost"
+      permission="opengever.workspaceclient.UserWorkspaceClient"
+      />
+
 </configure>

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -573,7 +573,7 @@
       name="@create-linked-workspace"
       for="opengever.dossier.behaviors.dossier.IDossierMarker"
       factory=".linked_workspaces.LinkedWorkspacesPost"
-      permission="opengever.workspaceclient.UserWorkspaceClient"
+      permission="opengever.workspaceclient.UseWorkspaceClient"
       />
 
   <plone:service
@@ -589,7 +589,7 @@
       name="@copy-document-to-workspace"
       for="opengever.dossier.behaviors.dossier.IDossierMarker"
       factory=".linked_workspaces.CopyDocumentToWorkspacePost"
-      permission="opengever.workspaceclient.UserWorkspaceClient"
+      permission="opengever.workspaceclient.UseWorkspaceClient"
       />
 
 </configure>

--- a/opengever/core/locales/de/LC_MESSAGES/opengever.core.po
+++ b/opengever/core/locales/de/LC_MESSAGES/opengever.core.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2019-11-25 09:52+0000\n"
+"POT-Creation-Date: 2020-02-18 15:58+0000\n"
 "PO-Revision-Date: 2017-09-18 15:21+0200\n"
 "Last-Translator: Philippe Gross <p.gross@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -77,6 +77,11 @@ msgid "Copy Items"
 msgstr "Kopieren"
 
 #: ./opengever/core/profiles/default/actions.xml
+#: ./opengever/core/upgrades/20200218164654_add_copy_documents_to_workspace_action/actions.xml
+msgid "Copy documents to workspace"
+msgstr "Dokumente in Arbeitsraum kopieren"
+
+#: ./opengever/core/profiles/default/actions.xml
 msgid "Cover (PDF)"
 msgstr "Deckblatt (PDF)"
 
@@ -91,6 +96,7 @@ msgid "Create Proposal"
 msgstr "Antrag erstellen"
 
 #: ./opengever/core/profiles/default/actions.xml
+#: ./opengever/core/upgrades/20200205102852_add_new_task_from_documents_action/actions.xml
 msgid "Create Task"
 msgstr "Aufgabe erstellen"
 
@@ -161,6 +167,7 @@ msgid "Meeting Template"
 msgstr "Sitzungsvorlage"
 
 #: ./opengever/core/profiles/default/actions.xml
+#: ./opengever/core/upgrades/20200129170738_add_move_proposal_items_action/actions.xml
 msgid "Move Items"
 msgstr "Elemente verschieben"
 

--- a/opengever/core/locales/fr/LC_MESSAGES/opengever.core.po
+++ b/opengever/core/locales/fr/LC_MESSAGES/opengever.core.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2019-11-25 09:52+0000\n"
+"POT-Creation-Date: 2020-02-18 15:58+0000\n"
 "PO-Revision-Date: 2013-03-27 10:44+0100\n"
 "Last-Translator: Philippe Gross <p.gross@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -74,6 +74,11 @@ msgid "Copy Items"
 msgstr "Copier"
 
 #: ./opengever/core/profiles/default/actions.xml
+#: ./opengever/core/upgrades/20200218164654_add_copy_documents_to_workspace_action/actions.xml
+msgid "Copy documents to workspace"
+msgstr ""
+
+#: ./opengever/core/profiles/default/actions.xml
 msgid "Cover (PDF)"
 msgstr "Couverture (PDF)"
 
@@ -88,6 +93,7 @@ msgid "Create Proposal"
 msgstr "Créer une requête"
 
 #: ./opengever/core/profiles/default/actions.xml
+#: ./opengever/core/upgrades/20200205102852_add_new_task_from_documents_action/actions.xml
 msgid "Create Task"
 msgstr "Créer une tâche"
 
@@ -158,6 +164,7 @@ msgid "Meeting Template"
 msgstr "Modèle de séance"
 
 #: ./opengever/core/profiles/default/actions.xml
+#: ./opengever/core/upgrades/20200129170738_add_move_proposal_items_action/actions.xml
 msgid "Move Items"
 msgstr "Déplacer éléments"
 

--- a/opengever/core/locales/opengever.core.pot
+++ b/opengever/core/locales/opengever.core.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-11-25 09:52+0000\n"
+"POT-Creation-Date: 2020-02-18 15:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -77,6 +77,11 @@ msgid "Copy Items"
 msgstr ""
 
 #: ./opengever/core/profiles/default/actions.xml
+#: ./opengever/core/upgrades/20200218164654_add_copy_documents_to_workspace_action/actions.xml
+msgid "Copy documents to workspace"
+msgstr ""
+
+#: ./opengever/core/profiles/default/actions.xml
 msgid "Cover (PDF)"
 msgstr ""
 
@@ -91,6 +96,7 @@ msgid "Create Proposal"
 msgstr ""
 
 #: ./opengever/core/profiles/default/actions.xml
+#: ./opengever/core/upgrades/20200205102852_add_new_task_from_documents_action/actions.xml
 msgid "Create Task"
 msgstr ""
 
@@ -161,6 +167,7 @@ msgid "Meeting Template"
 msgstr ""
 
 #: ./opengever/core/profiles/default/actions.xml
+#: ./opengever/core/upgrades/20200129170738_add_move_proposal_items_action/actions.xml
 msgid "Move Items"
 msgstr ""
 

--- a/opengever/core/profiles/default/actions.xml
+++ b/opengever/core/profiles/default/actions.xml
@@ -525,6 +525,15 @@
       <property name="visible">True</property>
     </object>
 
+    <object name="copy_documents_to_workspace" meta_type="CMF Action" i18n:domain="opengever.core">
+      <property name="title" i18n:translate="">Copy documents to workspace</property>
+      <property name="description">Gever-UI action</property>
+      <property name="url_expr" />
+      <property name="icon_expr" />
+      <property name="available_expr">object/@@folder_buttons_availability/is_copy_documents_to_workspace_available</property>
+      <property name="visible">True</property>
+    </object>
+
   </object>
 
 

--- a/opengever/core/upgrades/20200218164654_add_copy_documents_to_workspace_action/actions.xml
+++ b/opengever/core/upgrades/20200218164654_add_copy_documents_to_workspace_action/actions.xml
@@ -1,0 +1,16 @@
+<object xmlns:i18n="http://xml.zope.org/namespaces/i18n" name="portal_actions" meta_type="Plone Actions Tool">
+
+  <object name="folder_buttons" meta_type="CMF Action Category">
+
+    <object name="copy_documents_to_workspace" meta_type="CMF Action" i18n:domain="opengever.core">
+      <property name="title" i18n:translate="">Copy documents to workspace</property>
+      <property name="description">Gever-UI action</property>
+      <property name="url_expr" />
+      <property name="icon_expr" />
+      <property name="available_expr">object/@@folder_buttons_availability/is_copy_documents_to_workspace_available</property>
+      <property name="visible">True</property>
+    </object>
+
+  </object>
+
+</object>

--- a/opengever/core/upgrades/20200218164654_add_copy_documents_to_workspace_action/upgrade.py
+++ b/opengever/core/upgrades/20200218164654_add_copy_documents_to_workspace_action/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddCopyDocumentsToWorkspaceAction(UpgradeStep):
+    """Add copy documents to workspace action.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/workspaceclient/client.py
+++ b/opengever/workspaceclient/client.py
@@ -72,3 +72,16 @@ class WorkspaceClient(object):
         })
 
         return self.request.post('/workspaces', json=payload).json()
+
+    def lookup_url_by_uid(self, uid):
+        """Searches on the remote system for an object having the given UID and
+        returns the URL to this object.
+
+        If no object is found with the given UID, it returns None.
+        """
+        items = self.search(UID=uid).get('items')
+
+        if len(items) > 1:
+            raise LookupError("Found multiple workspaces with the same UID")
+
+        return items[0].get('@id') if items else None

--- a/opengever/workspaceclient/client.py
+++ b/opengever/workspaceclient/client.py
@@ -48,9 +48,19 @@ class WorkspaceClient(object):
         return self.request.get(url_or_path, params=kwargs).json()
 
     def get(self, url_or_path):
-        """Lookup an object.
+        """Proxy method to perform a get request.
         """
         return self.request.get(url_or_path).json()
+
+    def post(self, url_or_path, *args, **kwargs):
+        """Proxy method to perform a post request.
+        """
+        return self.request.post(url_or_path, *args, **kwargs).json()
+
+    def patch(self, url_or_path, *args, **kwargs):
+        """Proxy method to perform a patch request.
+        """
+        return self.request.patch(url_or_path, *args, **kwargs).json()
 
     def create_workspace(self, **data):
         """Crates a new workspace and returns the serialization of the new

--- a/opengever/workspaceclient/exceptions.py
+++ b/opengever/workspaceclient/exceptions.py
@@ -23,3 +23,17 @@ class WorkspaceClientFeatureNotEnabled(Exception):
         super(WorkspaceClientFeatureNotEnabled, self).__init__(
             'Please activate the workspace client feature in the portal '
             'registry in the IWorkspaceClientSettings')
+
+
+class WorkspaceNotLinked(Exception):
+
+    def __init__(self):
+        super(WorkspaceNotLinked, self).__init__(
+            'The workspace in not linked with the current dossier.')
+
+
+class WorkspaceNotFound(Exception):
+
+    def __init__(self):
+        super(WorkspaceNotFound, self).__init__(
+            'No workspace found.')

--- a/opengever/workspaceclient/linked_workspaces.py
+++ b/opengever/workspaceclient/linked_workspaces.py
@@ -59,7 +59,8 @@ class LinkedWorkspaces(object):
 
         return self.client.search(
             UID=uids,
-            portal_type="opengever.workspace.workspace")
+            portal_type="opengever.workspace.workspace",
+            metadata_fields="UID")
 
     def create(self, **data):
         """Creates a new workspace an links it with the current dossier.

--- a/opengever/workspaceclient/linked_workspaces.py
+++ b/opengever/workspaceclient/linked_workspaces.py
@@ -97,6 +97,11 @@ class LinkedWorkspaces(object):
                                       content_type, filename,
                                       **self._tus_document_repr(document_repr))
 
+    def has_linked_workspaces(self):
+        """Returns true if the current context has linked workspaces
+        """
+        return self.list().get('items_total', 0) > 0
+
     def _form_fields(self, obj):
         """Returns a list of all form field names of the given object.
         """

--- a/opengever/workspaceclient/linked_workspaces.py
+++ b/opengever/workspaceclient/linked_workspaces.py
@@ -1,13 +1,18 @@
 from opengever.dossier.behaviors.dossier import IDossierMarker
 from opengever.workspaceclient.client import WorkspaceClient
+from opengever.workspaceclient.exceptions import WorkspaceNotFound
+from opengever.workspaceclient.exceptions import WorkspaceNotLinked
 from opengever.workspaceclient.interfaces import ILinkedWorkspaces
 from opengever.workspaceclient.storage import LinkedWorkspacesStorage
 from plone import api
 from plone.memoize import ram
+from plone.restapi.interfaces import ISerializeToJson
 from time import time
 from zope.component import adapter
+from zope.component import getMultiAdapter
 from zope.component.interfaces import ComponentLookupError
 from zope.interface import implementer
+from plone.dexterity.utils import iterSchemata
 
 
 CACHE_TIMEOUT = 24 * 60 * 60
@@ -64,3 +69,47 @@ class LinkedWorkspaces(object):
         workspace = self.client.create_workspace(**data)
         self.storage.add(workspace.get('UID'))
         return workspace
+
+    def copy_document_to_workspace(self, document, workspace_uid):
+        """Will upload a copy of a document to a linked workspace.
+        """
+        if workspace_uid not in self.storage:
+            raise WorkspaceNotLinked()
+
+        workspace_url = self.client.lookup_url_by_uid(workspace_uid)
+
+        if not workspace_url:
+            raise WorkspaceNotFound()
+
+        file_ = document.file
+        document_repr = self._serialized_document_schema_fields(document)
+
+        if not file_:
+            # File only preserved in paper.
+            return self.client.post(workspace_url, json=document_repr)
+
+        # TUS upload is not yet implemented.
+        raise NotImplemented
+
+    def _form_fields(self, obj):
+        """Returns a list of all form field names of the given object.
+        """
+        fieldnames = []
+        for schema in iterSchemata(obj):
+            for fieldname in schema:
+                fieldnames.append(fieldname)
+        return fieldnames
+
+    def _serialized_document_schema_fields(self, document):
+        """Serializes all document schema fields.
+        """
+        serializer = getMultiAdapter((document, self.context.REQUEST), ISerializeToJson)
+        document_repr = serializer()
+        whitelisted = self._form_fields(document)
+        whitelisted.append('@type')
+        keys = document_repr.keys()
+        for key in keys:
+            if key not in whitelisted:
+                del document_repr[key]
+
+        return document_repr

--- a/opengever/workspaceclient/permissions.zcml
+++ b/opengever/workspaceclient/permissions.zcml
@@ -2,6 +2,6 @@
     xmlns="http://namespaces.zope.org/zope"
     i18n_domain="opengever.workspaceclient">
 
-  <permission id="opengever.workspaceclient.UserWorkspaceClient" title="opengever.workspaceclient: Use Workspace Client" />
+  <permission id="opengever.workspaceclient.UseWorkspaceClient" title="opengever.workspaceclient: Use Workspace Client" />
 
 </configure>

--- a/opengever/workspaceclient/session.py
+++ b/opengever/workspaceclient/session.py
@@ -40,7 +40,6 @@ class FtwTokenAuthSession(requests.Session):
 
         response = super(FtwTokenAuthSession, self).request(method, url,
                                                             *args, **kwargs)
-
         if self.token_has_expired(response):
             # We got an 'Access token expired' response => refresh token
             self.obtain_token()
@@ -54,7 +53,7 @@ class FtwTokenAuthSession(requests.Session):
 
     def token_has_expired(self, response):
         status = response.status_code
-        content_type = response.headers['Content-Type']
+        content_type = response.headers.get('Content-Type')
 
         if status == 401 and content_type == 'application/json':
             body = response.json()

--- a/opengever/workspaceclient/storage.py
+++ b/opengever/workspaceclient/storage.py
@@ -12,6 +12,9 @@ class LinkedWorkspacesStorage(object):
         self.context = context
         self._initialize_storage()
 
+    def __contains__(self, item):
+        return item in self._storage
+
     def add(self, uid):
         """Add a workspace by its UID.
         """

--- a/opengever/workspaceclient/tests/__init__.py
+++ b/opengever/workspaceclient/tests/__init__.py
@@ -68,6 +68,7 @@ class FunctionalWorkspaceClientTestCase(FunctionalTestCase):
     def enable_feature(self, enabled=True):
         api.portal.set_registry_record(
             'is_feature_enabled', enabled, IWorkspaceClientSettings)
+        transaction.commit()
 
     @contextmanager
     def workspace_client_env(self, url=DEFAULT_MARKER):

--- a/opengever/workspaceclient/tests/test_client.py
+++ b/opengever/workspaceclient/tests/test_client.py
@@ -58,3 +58,13 @@ class TestWorkspaceClient(FunctionalWorkspaceClientTestCase):
 
         workspace = children['added'].pop()
         self.assertEqual(workspace.title, response.get('title'))
+
+    def test_lookup_url_by_uid_returns_none_if_nothing_found(self):
+        with self.workspace_client_env() as client:
+            url = client.lookup_url_by_uid('not-existing-uid')
+            self.assertIsNone(url)
+
+    def test_lookup_url_by_uid_returns_the_absolute_url_to_the_obeject_if_found(self):
+        with self.workspace_client_env() as client:
+            url = client.lookup_url_by_uid(self.workspace.UID())
+            self.assertEqual(self.workspace.absolute_url(), url)

--- a/opengever/workspaceclient/tests/test_client.py
+++ b/opengever/workspaceclient/tests/test_client.py
@@ -1,9 +1,11 @@
+from opengever.testing import assets
 from opengever.workspaceclient.client import WorkspaceClient
 from opengever.workspaceclient.exceptions import WorkspaceClientFeatureNotEnabled
 from opengever.workspaceclient.exceptions import WorkspaceURLMissing
 from opengever.workspaceclient.tests import FunctionalWorkspaceClientTestCase
 from plone import api
 from zExceptions import Unauthorized
+import os
 import transaction
 
 
@@ -68,3 +70,31 @@ class TestWorkspaceClient(FunctionalWorkspaceClientTestCase):
         with self.workspace_client_env() as client:
             url = client.lookup_url_by_uid(self.workspace.UID())
             self.assertEqual(self.workspace.absolute_url(), url)
+
+    def test_tus_upload(self):
+        with self.workspace_client_env() as client:
+            filepath = assets.path_to_asset('vertragsentwurf.docx')
+            file_size = os.path.getsize(filepath)
+            content_type = 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+            additional_metadata = {
+                'title': u"My new d\xf6kument",
+                'description': u'Fantastic'
+            }
+
+            with self.observe_children(self.workspace) as children:
+                response = client.tus_upload(
+                    self.workspace.absolute_url(),
+                    open(filepath, 'r'), file_size, content_type,
+                    'vertragsentwurf.docx', **additional_metadata)
+                transaction.commit()
+
+            self.assertEqual(1, len(children['added']))
+            document = children['added'].pop()
+
+            self.assertEqual(document.absolute_url(), response.get('@id'))
+            self.assertEqual(open(filepath, 'r').read(),
+                             document.file.open().read())
+
+            self.assertEqual(u'My new doekument.docx', document.file.filename)
+            self.assertEqual(u'My new d\xf6kument', document.title)
+            self.assertEqual('Fantastic', document.description)

--- a/opengever/workspaceclient/tests/test_linked_workspaces.py
+++ b/opengever/workspaceclient/tests/test_linked_workspaces.py
@@ -193,6 +193,8 @@ class TestLinkedWorkspaces(FunctionalWorkspaceClientTestCase):
 
             self.assertEqual(workspace_document.absolute_url(), response.get('@id'))
             self.assertEqual(workspace_document.title, document.title)
+            self.assertEqual(workspace_document.file.open().read(),
+                             document.file.open().read())
 
             self.assertItemsEqual(
                 manager._serialized_document_schema_fields(document),

--- a/opengever/workspaceclient/tests/test_linked_workspaces.py
+++ b/opengever/workspaceclient/tests/test_linked_workspaces.py
@@ -199,3 +199,13 @@ class TestLinkedWorkspaces(FunctionalWorkspaceClientTestCase):
             self.assertItemsEqual(
                 manager._serialized_document_schema_fields(document),
                 manager._serialized_document_schema_fields(workspace_document))
+
+    def test_has_linked_workspaces(self):
+        with self.workspace_client_env():
+            manager = ILinkedWorkspaces(self.dossier)
+
+            self.assertFalse(manager.has_linked_workspaces())
+
+            manager.storage.add(self.workspace.UID())
+
+            self.assertTrue(manager.has_linked_workspaces())

--- a/opengever/workspaceclient/tests/test_linked_workspaces.py
+++ b/opengever/workspaceclient/tests/test_linked_workspaces.py
@@ -1,5 +1,7 @@
 from ftw.builder import Builder
 from ftw.builder import create
+from opengever.workspaceclient.exceptions import WorkspaceNotFound
+from opengever.workspaceclient.exceptions import WorkspaceNotLinked
 from opengever.workspaceclient.interfaces import ILinkedWorkspaces
 from opengever.workspaceclient.tests import FunctionalWorkspaceClientTestCase
 from plone import api
@@ -99,3 +101,50 @@ class TestLinkedWorkspaces(FunctionalWorkspaceClientTestCase):
 
             with self.assertRaises(ComponentLookupError):
                 getAdapter(subdossier, ILinkedWorkspaces)
+
+    def test_copy_document_without_file_to_workspace(self):
+        document = create(Builder('document')
+                          .within(self.dossier)
+                          .having(preserved_as_paper=True))
+
+        with self.workspace_client_env():
+            manager = ILinkedWorkspaces(self.dossier)
+            manager.storage.add(self.workspace.UID())
+
+            with self.observe_children(self.workspace) as children:
+                response = manager.copy_document_to_workspace(document, self.workspace.UID())
+                transaction.commit()
+
+            self.assertEqual(1, len(children['added']))
+            workspace_document = children['added'].pop()
+
+            self.assertEqual(workspace_document.absolute_url(), response.get('@id'))
+            self.assertEqual(workspace_document.title, document.title)
+
+            self.assertItemsEqual(
+                manager._serialized_document_schema_fields(document),
+                manager._serialized_document_schema_fields(workspace_document))
+
+    def test_copy_document_to_workspace_raises_error_if_workspace_is_not_linked_to_the_dossier(self):
+        document = create(Builder('document')
+                          .within(self.dossier)
+                          .having(preserved_as_paper=True))
+
+        with self.workspace_client_env():
+            manager = ILinkedWorkspaces(self.dossier)
+
+            self.assertNotIn(self.workspace.UID(), manager.storage)
+            with self.assertRaises(WorkspaceNotLinked):
+                manager.copy_document_to_workspace(document, self.workspace.UID())
+
+    def test_copy_document_to_workspace_raises_error_if_workspace_could_not_be_found(self):
+        document = create(Builder('document')
+                          .within(self.dossier)
+                          .having(preserved_as_paper=True))
+
+        with self.workspace_client_env():
+            manager = ILinkedWorkspaces(self.dossier)
+            manager.storage.add('removed-workspace-uid')
+
+            with self.assertRaises(WorkspaceNotFound):
+                manager.copy_document_to_workspace(document, 'removed-workspace-uid')

--- a/opengever/workspaceclient/tests/test_storage.py
+++ b/opengever/workspaceclient/tests/test_storage.py
@@ -33,3 +33,10 @@ class TestLinkedWorkspacesStorage(FunctionalWorkspaceClientTestCase):
         storage.add('UID-2')
 
         self.assertEqual(['UID-1', 'UID-2'], storage.list())
+
+    def test_storage_contains_uid(self):
+        storage = LinkedWorkspacesStorage(self.dossier)
+        storage.add('UID-1')
+
+        self.assertIn('UID-1', storage)
+        self.assertNotIn('UID-2', storage)


### PR DESCRIPTION
This PR impements the `@copy-document-to-workspace` endpoint according to the specs in https://github.com/4teamwork/opengever.core/issues/6197#issuecomment-586218068 .

## Checkliste

- [x] Sind UpgradeSteps `deferrable`, oder können gewisse Schritte des Upgrades konditional ausgeführt werden?
- [x] Gibt es neue Übersetzungen?
  - [x] Sind alle msg-Strings in Übersetzungen Unicode?
  - [x] Wird die richtige i18n-domain verwendet (Copy-Paste Fehler sind hier häufig)?
- [x] Changelog-Eintrag vorhanden/nötig?
- [x] Aktualisierung Dokumentation vorhanden/nötig?
