### PR TITLE
Add smoke tests for rewrite rules and VHost configs.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2020.1.0rc3 (unreleased)
 ------------------------
 
+- Add smoke tests for rewrite rules and VHost configs. [lgraf]
 - Add container title to task activities. [njohner]
 - Allow Administrators to add new keywords. [njohner]
 - Implement @copy-document-to-workspace endpoint. [elioschmutz]

--- a/rewrite_rule_smoketests/README.md
+++ b/rewrite_rule_smoketests/README.md
@@ -1,0 +1,21 @@
+### Usage
+
+Run
+
+```bash
+bin/zopepy rewrite_rule_smoketests/smoketests.py
+```
+
+to execute the smoke tests. Some tests will require credentials,
+and will therefore be skipped. In order to provide those credentials
+(one pair per cluster), run
+
+```bash
+bin/zopepy rewrite_rule_smoketests/smoketests.py --prompt-credentials
+``
+
+The credentials (username and password) will then be used to log into
+the cluster's corresponding portal, get a session, and store those
+session cookies to `~/.opengever/rewrite_rule_smoketests/session_cookies.json`.
+
+The password itself will never be stored.

--- a/rewrite_rule_smoketests/assertions.py
+++ b/rewrite_rule_smoketests/assertions.py
@@ -1,0 +1,18 @@
+def assert_equal(expected, actual):
+    try:
+        assert expected == actual
+    except AssertionError:
+        print "\nAssertionError: Items not equal"
+        print "Expected: %s" % expected
+        print "Actual: %s" % actual
+        raise
+
+
+def assert_in(needle, haystack):
+    try:
+        assert needle in haystack
+    except AssertionError:
+        print "\nAssertionError: Unable to find needle in haystack."
+        print "Needle: %r" % needle
+        print "Haystack: %r" % haystack
+        raise

--- a/rewrite_rule_smoketests/auth.py
+++ b/rewrite_rule_smoketests/auth.py
@@ -1,0 +1,96 @@
+from config import SESSION_COOKIES_FILE
+from os.path import isfile
+import json
+
+
+API_POST_HEADERS = {
+    'Accept': 'application/json',
+    'Content-Type': 'application/json',
+}
+
+# Cookie params that the CookieJar doesn't allow us to set
+UNSUPPORTED_COOKIE_PARAMS = [
+    '_rest',
+    'path_specified',
+    'domain_specified',
+    'port_specified',
+    'domain_initial_dot',
+]
+
+
+def login_to_portal(browser, cluster, username, password):
+    """Performs a login to the portal, using given username and password.
+
+    Returns the username of the logged in user, and the cookies received in
+    the response. These cookies contain the portal session, and can be
+    stored and loaded to avoid logging in all the time.
+    """
+    if cluster.new_portal:
+        payload = json.dumps({
+            'username': username,
+            'password': password,
+            'remember_me': False,
+            'invitation': ""})
+
+        login_api_url = '/'.join((cluster.portal_url, 'api', 'login'))
+        browser.open(login_api_url,
+                     method='POST',
+                     headers=API_POST_HEADERS, data=payload)
+
+        expected_response = {
+            'username': username,
+            'state': 'logged_in',
+            'invitation_callback': ''}
+
+        if not expected_response == browser.json:
+            print "Login failed: %r" % browser.contents
+
+    else:
+        login_url = '/'.join((cluster.portal_url, 'login'))
+
+        browser.open(login_url)
+        browser.fill({'Benutzername': username, 'Passwort': password}).submit()
+        # TODO: Check for login success, and maybe raise a LoginFailed
+        # exception here so we can distinguish this case.
+
+    # Extract and clean up cookies from response
+    cookies = dict(browser.cookies)
+    for cookie_name, cookie_data in cookies.items():
+        for param_to_remove in UNSUPPORTED_COOKIE_PARAMS:
+            cookies[cookie_name].pop(param_to_remove, None)
+
+    return username, cookies
+
+
+def load_session_cookies():
+    """Load stored session cookies from file.
+    """
+    if not isfile(SESSION_COOKIES_FILE):
+        return {}
+
+    with open(SESSION_COOKIES_FILE, 'r') as cookies_file:
+        return json.load(cookies_file)
+
+
+def store_session_cookies(session_cookies):
+    """Store session cookies to file, overwriting existing ones.
+    """
+    with open(SESSION_COOKIES_FILE, 'w') as cookies_file:
+        json.dump(session_cookies, cookies_file,
+                  sort_keys=True, indent=4, separators=(',', ': '))
+
+
+def login_and_store(browser, cluster, username, password):
+    """Log in, and store session cookies to file (keyed by cluster URL).
+
+    If cookies already exist for the given cluster, they get updated.
+    Cookies for other clusters are left untouched.
+    """
+    logged_in_user, cookies = login_to_portal(
+        browser, cluster, username, password)
+
+    session_cookies = load_session_cookies()
+    cookie_set = {cluster.url: {'username': username,
+                                'cookies': cookies}}
+    session_cookies.update(cookie_set)
+    store_session_cookies(session_cookies)

--- a/rewrite_rule_smoketests/colors.py
+++ b/rewrite_rule_smoketests/colors.py
@@ -1,0 +1,14 @@
+def green(msg):
+    return '\x1b[32m%s\x1b(B\x1b[m' % msg
+
+
+def yellow(msg):
+    return '\x1b[93m%s\x1b(B\x1b[m' % msg
+
+
+def red(msg):
+    return '\x1b[31m%s\x1b(B\x1b[m' % msg
+
+
+def white(msg):
+    return '\x1b[97m%s\x1b(B\x1b[m' % msg

--- a/rewrite_rule_smoketests/config.py
+++ b/rewrite_rule_smoketests/config.py
@@ -1,0 +1,51 @@
+from config_entities import AdminUnit
+from config_entities import Cluster
+from os.path import expanduser
+from os.path import join as pjoin
+
+
+SESSION_COOKIES_DIR = expanduser('~/.opengever/rewrite_rule_smoketests')
+SESSION_COOKIES_FILE = pjoin(SESSION_COOKIES_DIR, 'session_cookies.json')
+
+
+CLUSTERS_TO_TEST = [
+    Cluster(
+        'https://dev.onegovgever.ch',
+        admin_units=[
+            AdminUnit('fd'),
+            AdminUnit('rk'),
+        ],
+        new_portal=False,
+        gever_ui_is_default=True,
+    ),
+
+    Cluster(
+        'https://dev.teamraum.ch',
+        admin_units=[
+            AdminUnit('fd'),
+            AdminUnit('tr', is_dedicated_teamraum=True),
+        ],
+        new_portal=True,
+        gever_ui_is_default=True,
+    ),
+
+    Cluster(
+        'https://test.onegovgever.ch',
+        admin_units=[
+            AdminUnit('fd'),
+            AdminUnit('rk'),
+        ],
+        new_portal=False,
+        gever_ui_is_default=False,
+    ),
+
+    Cluster(
+        'https://lab.onegovgever.ch',
+        admin_units=[
+            AdminUnit('fd'),
+        ],
+        new_portal=False,
+        gever_ui_is_default=False,
+    ),
+
+]

--- a/rewrite_rule_smoketests/config_entities.py
+++ b/rewrite_rule_smoketests/config_entities.py
@@ -1,0 +1,101 @@
+class AdminUnit(object):
+    """AdminUnit configuration entity.
+
+    Is able to build its most commonly used URLs, and track whether
+    it is a classic GEVER admin unit, or one that is used for a dedicated
+    Teamraum setup.
+
+    Must be linked to a cluster before being used.
+    """
+
+    def __init__(self, unit_id, is_dedicated_teamraum=False):
+        self.unit_id = unit_id
+        self.is_dedicated_teamraum = is_dedicated_teamraum
+
+        self.cluster = None
+
+    def __repr__(self):
+        return "<AdminUnit '%s'>" % self.unit_id
+
+    @property
+    def front_page_url(self):
+        """The topmost URL of GEVER deployment.
+
+        Is usually the URL of the AdminUnit, except in the case where we
+        have a Teamraum redirect.
+        """
+        if self.is_dedicated_teamraum:
+            return self.url + '/workspaces'
+        return self.url
+
+    @property
+    def url(self):
+        """The AdminUnit's URL.
+        """
+        if self.cluster.single_unit_setup:
+            # https://lab.onegovgever.ch
+            return self.cluster.url
+
+        # https://dev.onegovgever.ch/fd
+        return '/'.join((self.cluster.url, self.unit_id))
+
+
+class Cluster(object):
+    """Cluster configuration entity.
+
+    Represents a GEVER cluster (a bunch of deployments that share the same
+    OGDS as well as portal).
+
+    The cluster's primary identifier is its base URL. From this URL, all
+    other URLs are derived.
+    """
+
+    def __init__(self, url, new_portal=False, gever_ui_is_default=False,
+                 admin_units=None):
+        self.url = url
+        self.new_portal = new_portal
+        self.gever_ui_is_default = gever_ui_is_default
+        self.admin_units = admin_units
+
+        # Link admin units to their containing cluster
+        for admin_unit in self.admin_units:
+            admin_unit.cluster = self
+
+        self.validate()
+
+    def __repr__(self):
+        return "<Cluster '%s'>" % self.url
+
+    def validate(self):
+        # We want a homogenous URL style to start building other URLs from
+        # in order to get predictable results.
+        assert not self.url.endswith('/'), \
+            "Cluster URLs must not end with trailing slash."
+
+        assert self.url.startswith('https://'), \
+            "Cluster URLs be the https:// URLs"
+
+    @property
+    def single_unit_setup(self):
+        """Whether this cluster is single-unit setup or not.
+        """
+        return len(self.admin_units) == 1
+
+    @property
+    def portal_url(self):
+        """The base URL to this cluster's portal.
+        """
+        return '/'.join((self.url, 'portal'))
+
+    @property
+    def portal_landingpage_url(self):
+        """The portal's landing page URL.
+
+        This differs slightly for the old vs. new portal.
+        """
+        if self.new_portal:
+            # https://dev.teamraum.ch/portal
+            return self.portal_url
+
+        # https://dev.onegovgever.ch/portal/landingpage
+        return '/'.join((self.portal_url, 'landingpage'))

--- a/rewrite_rule_smoketests/registry.py
+++ b/rewrite_rule_smoketests/registry.py
@@ -1,0 +1,31 @@
+"""Registry that keeps track of tests that get registered via decorators.
+"""
+
+# For a test to be run, it needs to be registered for either the
+# 'cluster' or the 'admin_unit' type. It will then be invoked by then runner
+# with its second argument being an entity of that type (AdminUnit or Cluster).
+# Tests can also be registered for both - which will run them twice.
+#
+# The @logged_in decorator can be used in addition to those. It will make
+# sure that the runner attempts to provide the browser with a valid portal
+# session before handing it to the test.
+tests_by_type = {
+    'cluster': [],
+    'admin_unit': [],
+    'logged_in': [],
+}
+
+
+def on_cluster(func):
+    tests_by_type['cluster'].append(func)
+    return func
+
+
+def on_admin_unit(func):
+    tests_by_type['admin_unit'].append(func)
+    return func
+
+
+def logged_in(func):
+    tests_by_type['logged_in'].append(func)
+    return func

--- a/rewrite_rule_smoketests/runner.py
+++ b/rewrite_rule_smoketests/runner.py
@@ -1,0 +1,149 @@
+from auth import load_session_cookies
+from auth import login_and_store
+from colors import green
+from colors import red
+from colors import white
+from colors import yellow
+from config import AdminUnit
+from config import SESSION_COOKIES_DIR
+from config import SESSION_COOKIES_FILE
+from ftw.testbrowser import browser
+from ftw.testbrowser.core import LIB_REQUESTS
+from getpass import getpass
+from os.path import expanduser
+from requests.cookies import create_cookie
+import errno
+import os
+import sys
+import traceback
+
+
+class MissingStoredSessionCookies(Exception):
+    """Unable to find stored session cookies for given cluster.
+    """
+
+
+class CookieLoaderMixin(object):
+    """Handles loading of stored session cookies.
+    """
+
+    def get_session_cookies(self, cluster):
+        """Load session cookies for a specific cluster.
+        """
+        session_cookies = load_session_cookies()
+
+        cookies = session_cookies.get(cluster.url, {}).get('cookies')
+        if not cookies:
+            raise MissingStoredSessionCookies
+
+        return cookies
+
+    def add_cookies(self, browser, cookies):
+        """Given a browser and a set of cookies, add them to the browser.
+        """
+        driver = browser.get_driver()
+        for cookie_data in cookies.values():
+            cookie = create_cookie(**cookie_data)
+            driver.requests_session.cookies.set_cookie(cookie)
+
+    def create_session_cookies_dir(self):
+        self.mkdir_p(expanduser(SESSION_COOKIES_DIR))
+
+    def mkdir_p(self, path):
+        try:
+            os.makedirs(path)
+        except OSError as exc:  # Python >=2.5
+            if exc.errno == errno.EEXIST and os.path.isdir(path):
+                pass
+            else:
+                raise
+
+
+class SmokeTestRunner(CookieLoaderMixin):
+
+    def __init__(self, clusters, tests_by_type,
+                 prompt_credentials=False):
+        self.clusters = clusters
+        self.tests_by_type = tests_by_type
+        self.create_session_cookies_dir()
+
+        self.skipped_tests = False
+
+        # Configure requests driver for all testbrowser requests
+        browser.default_driver = LIB_REQUESTS
+
+        if prompt_credentials:
+            self.prompt_for_credentials()
+
+    def prompt_for_credentials(self):
+        print "Please enter credentials for the following clusters."
+        print "These will be used to login to the corresponding portal, "
+        print "and save the Portal session cookies to %s" % SESSION_COOKIES_FILE
+        print "The password itself will never be saved."
+        print
+
+        for cluster in self.clusters:
+            with browser:
+                print "Cluster: %s" % cluster.url
+                username = raw_input('Username: ')
+                password = getpass('Password: ')
+                login_and_store(browser, cluster, username, password)
+                print "-" * 80
+                print
+
+    def run_tests(self):
+        for cluster in self.clusters:
+            self.test_cluster(cluster)
+        if self.skipped_tests:
+            print
+            print "Some tests have been skipped because no stored credentials"
+            print "could be found for them. Re-run this script with "
+            print "--prompt-credentials to be prompted for credentials."
+            print "They will then be stored for subsequent runs."
+
+    def test_cluster(self, cluster):
+        print "\nTesting Cluster: %s" % cluster.url
+        print "=" * 80
+
+        for cluster_level_test in self.tests_by_type['cluster']:
+            self.run_single_test(cluster_level_test, args=(cluster, ))
+
+        for admin_unit in cluster.admin_units:
+            for au_level_test in self.tests_by_type['admin_unit']:
+                self.run_single_test(au_level_test, args=(admin_unit, ))
+
+    def run_single_test(self, test, args):
+        test_details = '%-50s %r' % (white(test.__name__), args)
+
+        # Determine cluster. `args` are test arguments, which currently are a
+        # one-tuple of either an AdminUnit or a Cluster entity.
+        entity = args[0]
+        if isinstance(entity, AdminUnit):
+            cluster = entity.cluster
+        else:
+            cluster = entity
+
+        try:
+            with browser:
+                if test in self.tests_by_type['logged_in']:
+                    # Test expects a browser that is set up with a valid
+                    # portal session. Add session cookies if available.
+                    try:
+                        cookies = self.get_session_cookies(cluster)
+                    except MissingStoredSessionCookies:
+                        test_details += ' (Missing stored session cookies)'
+                        print '%s - %s' % (yellow('SKIP'), test_details)
+                        self.skipped_tests = True
+                        return
+                    self.add_cookies(browser, cookies)
+
+                # Run the actual test
+                test(browser, *args)
+            print '%s - %s' % (green('PASS'), test_details)
+
+        except Exception:
+            print '%s - %s' % (red('\nFAIL'), test_details)
+            exc_type, exc_value, exc_traceback = sys.exc_info()
+            tb = ''.join(traceback.format_exception(
+                exc_type, exc_value, exc_traceback))
+            print tb

--- a/rewrite_rule_smoketests/smoketests.py
+++ b/rewrite_rule_smoketests/smoketests.py
@@ -1,0 +1,197 @@
+from os.path import abspath
+from os.path import dirname
+from requests.cookies import create_cookie
+from urllib import quote
+from urlparse import urlparse
+from urlparse import urlunparse
+
+
+# Hack to allow script to use relative imports when run with bin/zopepy
+import sys
+sys.path.append(abspath(dirname(__file__)))
+
+from assertions import assert_equal  # noqa
+from assertions import assert_in  # noqa
+from auth import login_and_store  # noqa
+from auth import login_to_portal  # noqa
+from colors import green  # noqa
+from colors import red  # noqa
+from config import AdminUnit  # noqa
+from config import Cluster  # noqa
+from config import CLUSTERS_TO_TEST  # noqa
+from registry import logged_in  # noqa
+from registry import on_admin_unit  # noqa
+from registry import on_cluster  # noqa
+from registry import tests_by_type  # noqa
+from runner import SmokeTestRunner  # noqa
+
+
+@on_cluster
+@on_admin_unit
+def test_canonical_https_redirect(browser, entity):
+    """Tests for presence of canonical HTTPS redirect.
+
+    All URLs that start with a http:// scheme should be redirected to their
+    https equivalent.
+    """
+    expect_trailing_slash = False
+
+    if isinstance(entity, Cluster):
+        expect_trailing_slash = True
+
+    # In single unit setups canonical HTTPS redirect adds a trailing
+    # slash to the admin unit URL, otherwise it doesn't
+    if isinstance(entity, AdminUnit):
+        if entity.cluster.single_unit_setup:
+            expect_trailing_slash = True
+
+    parsed = urlparse(entity.url)
+    http_url = urlunparse(('http', ) + tuple(parsed)[1:])
+    https_url = urlunparse(('https', ) + tuple(parsed)[1:])
+
+    browser.allow_redirects = False
+    browser.open(http_url)
+
+    expected = https_url
+    if expect_trailing_slash:
+        expected += '/'
+
+    assert_equal(301, browser.status_code)
+    assert_equal(expected, browser.headers['Location'])
+
+
+@on_admin_unit
+def test_teamraum_redirect(browser, admin_unit):
+    if not admin_unit.is_dedicated_teamraum:
+        return
+
+    browser.allow_redirects = False
+    browser.open(admin_unit.url)
+    assert_equal(302, browser.status_code)
+    assert_equal(admin_unit.front_page_url, browser.headers['Location'])
+    assert_equal(True, browser.headers['Location'].endswith('/workspaces'))
+
+
+@on_admin_unit
+def test_anonymous_cas_redirect(browser, admin_unit):
+    """Tests that requests to GEVER without authentication cause a redirect
+
+    to the CAS portal.
+    """
+    browser.allow_redirects = False
+    browser.open(admin_unit.front_page_url)
+
+    cluster = admin_unit.cluster
+
+    if cluster.gever_ui_is_default:
+        # When the new UI is the default, we won't see a CAS redirect
+        # performed by Plone for Anonymous requests. Instead, the frontend
+        # app's index.html is served, and the frontend will trigger the CAS
+        # redirect.
+        assert_equal(200, browser.status_code)
+        assert_in('/geverui/assets/', browser.contents)
+    else:
+        assert_equal(302, browser.status_code)
+
+        service_url = quote(admin_unit.front_page_url + '/')
+        cas_login_url = '%s/login?service=%s' % (cluster.portal_url, service_url)
+        assert_equal(cas_login_url, browser.headers['Location'])
+
+
+@on_cluster
+def test_portal(browser, cluster):
+    browser.open(cluster.portal_url)
+    assert_equal(200, browser.status_code)
+
+    if cluster.new_portal:
+        # New portal
+        assert_equal(cluster.portal_url, browser.url)
+        assert_equal(200, browser.status_code)
+        assert_in('<script src=/portal/assets/js/app', browser.contents)
+    else:
+        # Old portal
+        username_field = browser.find('Benutzername')
+        assert_equal('username', username_field.attrib['name'])
+
+        password_field = browser.find('Passwort')
+        assert_equal('password', password_field.attrib['name'])
+
+
+def test_portal_login(browser, cluster):
+    """TODO: Figure out how to conveniently run this test.
+
+    It's currently unregistered because it needs an actual password to test
+    the login, and can therefore only run in --prompt-credentials mode.
+
+    It therefore is unregistered for the moment, and doesn't run.
+    """
+    username = 'foo'
+    password = 'bar'
+
+    logged_in_user, cookies = login_to_portal(browser, cluster, username, password)
+
+    if cluster.new_portal:
+        assert_equal(200, browser.status_code)
+        assert_equal({
+            'username': username,
+            'state': 'logged_in',
+            'invitation_callback': ''},
+            browser.json
+        )
+        assert_in('sessionid', browser.cookies)
+
+    else:
+        assert_equal(200, browser.status_code)
+        assert_equal(cluster.portal_landingpage_url, browser.url)
+
+
+@logged_in
+@on_cluster
+def test_portal_landingpage(browser, cluster):
+    browser.allow_redirects = False
+    browser.open(cluster.portal_landingpage_url)
+    assert_equal(200, browser.status_code)
+
+    if cluster.new_portal:
+        # Can't really assert on much more for the new portal.
+        assert_in('csrftoken', browser.cookies)
+    else:
+        logged_in_msg = browser.css('.current-user-info').first.text
+        logged_in_msg.startswith('Angemeldet als')
+
+
+@logged_in
+@on_admin_unit
+def test_gever_front_page_logged_in_old_ui(browser, admin_unit):
+    driver = browser.get_driver()
+
+    cookie_data = {'name': 'geverui', 'value': '0'}
+    cookie = create_cookie(**cookie_data)
+    driver.requests_session.cookies.set_cookie(cookie)
+
+    browser.open(admin_unit.front_page_url)
+    first_heading = browser.css('.documentFirstHeading').first.text
+
+    if admin_unit.is_dedicated_teamraum:
+        marker = u'Teamr\xe4ume'
+    else:
+        marker = u'Pers\xf6nliche \xdcbersicht'
+
+    assert_equal(True, first_heading.startswith(marker))
+
+    logo = browser.css('a#portal-logo').first
+    assert_equal(admin_unit.url, logo.attrib['href'])
+
+
+def main():
+    prompt_credentials = False
+    if '--prompt-credentials' in sys.argv:
+        prompt_credentials = True
+
+    runner = SmokeTestRunner(CLUSTERS_TO_TEST, tests_by_type,
+                             prompt_credentials=prompt_credentials)
+    runner.run_tests()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Implements some basic smoke test for our rewrite rules and VHost configurations.

### Usage

Run

```bash
bin/zopepy rewrite_rule_smoketests/smoketests.py
```

to execute the smoke tests. Some tests will require credentials, and will therefore be skipped.


![skipped_tests](https://user-images.githubusercontent.com/405124/75183510-ff3f0680-5742-11ea-80c5-c66958741681.png)


In order to provide those credentials (one pair per cluster), run

```bash
bin/zopepy rewrite_rule_smoketests/smoketests.py --prompt-credentials
```

The credentials (username and password) will then be used to log into the cluster's corresponding portal, get a session, and store those session cookies to `~/.opengever/rewrite_rule_smoketests/`.

The password itself will never be stored.

Addresses #6259 

## Checkliste

- [x] Changelog-Eintrag vorhanden/nötig?
- [x] Aktualisierung Dokumentation vorhanden/nötig?
