### PR TITLE
Testserver: introduce BUILDOUT_DIR environment variable.

### DIFF
--- a/opengever/core/solr_testing.py
+++ b/opengever/core/solr_testing.py
@@ -15,7 +15,7 @@ import subprocess
 import time
 
 
-BUILDOUT_DIR = Path(__file__).joinpath('..', '..', '..').abspath()
+BUILDOUT_DIR = Path(os.environ.get('BUILDOUT_DIR', Path(__file__).joinpath('..', '..', '..').abspath()))
 
 
 class SolrServer(object):


### PR DESCRIPTION
When the testserver is installed with a buildout located outside of opengever.core, the bin-scripts (e.g. solr) are not located within the opengever.core checkout or egg directory.

With the new BUILDOUT_DIR environment variable a caller (such as e2e UI tests) can configure the correct buildout dir so that the testserver has access to the scripts.

This change is needed in order to fix the e2e ui tests. I cannot explain why it was not failing up to now; maybe some left overs on the CI server (although this should not be possible since workspaces are wiped).

## Checkliste

_Zutreffendes soll angehakt stehengelassen werden._

- [x] Gibt es neue Funktionalität mit einem `Dokument`? Funktioniert das auch mit einem `Mail`?
- [x] Wurde etwas an der `Aufgabe` angepasst? Funktioniert das auch mit einer `Weiterleitung`?
- [x] Profil angepasst? Sind UpgradeSteps vorhanden/nötig?:
- [x] Sind UpgradeSteps `deferrable`, oder können gewisse Schritte des Upgrades konditional ausgeführt werden?
- [x] Gibts es eine DB-Schema Migration?
  - [x] Wurde alle Columns/Änderungen aus dem Modell in einer DB-Schema Migration nachgeführt.
  - [x] Sind Constraint-Namen maximal 30 Zeichen lang (`Oracle`)?
- [x] Gibt es ein neues Feature-Flag? Wurden dafür Tests mit aktiviertem und deaktivierte Flag geschrieben?
- [x] Könnten Kundeninstallationen von den Änderungen betroffen sein? Müssen Policies angepasst werden?
- [x] Gibt es neue Übersetzungen?
  - [x] Sind alle msg-Strings in Übersetzungen Unicode?
  - [x] Wird die richtige i18n-domain verwendet (Copy-Paste Fehler sind hier häufig)?
- [x] Wenn bei Schema-definitionen `missing_value` spezifiziert ist muss immer auch `default` auf den gleichen Wert gesetzt werden
- [x] Changelog-Eintrag vorhanden/nötig?
- [x] Aktualisierung Dokumentation vorhanden/nötig?
