### PR TITLE
Set seen_tours for all users in test fixture.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,7 @@ Changelog
 2020.2.0rc1 (unreleased)
 ------------------------
 
-- Nothing changed yet.
+- Set seen_tours for all users in test fixture. [njohner]
 
 
 2020.1.0 (2020-02-26)

--- a/opengever/api/tests/test_config.py
+++ b/opengever/api/tests/test_config.py
@@ -153,7 +153,7 @@ class TestConfig(IntegrationTestCase):
         self.assertEqual(
             {u'notify_inbox_actions': True,
              u'notify_own_actions': False,
-             u'seen_tours': []},
+             u'seen_tours': [u'*']},
             browser.json.get(u'user_settings'))
 
     @browsing

--- a/opengever/api/tests/test_user_settings.py
+++ b/opengever/api/tests/test_user_settings.py
@@ -15,15 +15,15 @@ class TestUsersSettingsGet(IntegrationTestCase):
 
         self.assertEquals(
             {"notify_inbox_actions": True,
-             "seen_tours": [],
+             "seen_tours": ['*'],
              "notify_own_actions": False},
             browser.json)
 
     @browsing
     def test_returns_personal_settings(self, browser):
-        self.login(self.regular_user, browser)
+        self.login(self.service_user, browser)
         setting = UserSettings(
-            userid=self.regular_user.id,
+            userid=self.service_user.id,
             notify_own_actions=True,
             notify_inbox_actions=True,
             _seen_tours=json.dumps(
@@ -41,8 +41,8 @@ class TestUsersSettingsGet(IntegrationTestCase):
 
     @browsing
     def test_a_pure_plone_user_has_always_seen_all_tours(self, browser):
-        # Ogds-user user has no seen tours by default
-        self.login(self.regular_user, browser)
+        # Ogds-user user has not seen tours by default
+        self.login(self.service_user, browser)
         self.assertIsNotNone(self.get_ogds_user(self.regular_user))
         browser.open('{}/@user-settings'.format(self.portal.absolute_url()),
                      headers=self.api_headers)
@@ -61,10 +61,10 @@ class TestUsersSettingsPatch(IntegrationTestCase):
 
     @browsing
     def test_creates_settings_if_not_exists(self, browser):
-        self.login(self.regular_user, browser)
+        self.login(self.service_user, browser)
 
         self.assertEquals(
-            0, UserSettings.query.filter_by(userid=self.regular_user.id).count())
+            0, UserSettings.query.filter_by(userid=self.service_user.id).count())
 
         data = json.dumps(
             {'seen_tours': ['gever.introduction', 'gever.release_2019.3']})
@@ -73,7 +73,7 @@ class TestUsersSettingsPatch(IntegrationTestCase):
 
         self.assertEquals(204, browser.status_code)
 
-        setting = UserSettings.query.filter_by(userid=self.regular_user.id).one()
+        setting = UserSettings.query.filter_by(userid=self.service_user.id).one()
         self.assertEquals(
             json.dumps(['gever.introduction', 'gever.release_2019.3']),
             setting._seen_tours)

--- a/opengever/api/tests/test_user_settings.py
+++ b/opengever/api/tests/test_user_settings.py
@@ -2,7 +2,6 @@ from ftw.testbrowser import browsing
 from opengever.base.model import create_session
 from opengever.ogds.models.user_settings import UserSettings
 from opengever.testing import IntegrationTestCase
-from zExceptions import Unauthorized
 import json
 
 

--- a/opengever/base/tests/test_configuration_adapter.py
+++ b/opengever/base/tests/test_configuration_adapter.py
@@ -29,7 +29,7 @@ class TestConfigurationAdapter(IntegrationTestCase):
             ('user_settings', OrderedDict([
                 ('notify_inbox_actions', True),
                 ('notify_own_actions', False),
-                ('seen_tours', []),
+                ('seen_tours', ['*']),
             ])),
             ('sharing_configuration', OrderedDict([
                 ('white_list_prefix', u'^.+'),

--- a/opengever/ogds/models/user_settings.py
+++ b/opengever/ogds/models/user_settings.py
@@ -50,6 +50,14 @@ class UserSettings(Base):
 
     @classmethod
     def save_setting_for_user(cls, userid, setting_name, value):
+        """Creates a new entry for the user if necessary and saves the value
+        for the given setting.
+
+        Note that seen_tours cannot be set through this method as it is not
+        a column in the table. One can set _seen_tours instead, but this
+        circumvents the setter, so make sure that the value is not a list but
+        a json.dumps of the list.
+        """
         # Make sure that setting_name is a column of the UserSettings model.
         error_msg = "{} has to be a column on UserSettings".format(setting_name)
         assert setting_name in cls.__table__.columns, error_msg

--- a/opengever/ogds/models/user_settings.py
+++ b/opengever/ogds/models/user_settings.py
@@ -2,7 +2,6 @@ from opengever.base.model import Base
 from opengever.base.model import create_session
 from opengever.base.model import USER_ID_LENGTH
 from opengever.ogds.models.user import User
-from plone import api
 from sqlalchemy import Boolean
 from sqlalchemy import Column
 from sqlalchemy import ForeignKey

--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -18,12 +18,12 @@ from opengever.base.behaviors.lifecycle import ARCHIVAL_VALUE_UNWORTHY
 from opengever.base.behaviors.lifecycle import ARCHIVAL_VALUE_WORTHY
 from opengever.base.command import CreateEmailCommand
 from opengever.base.model import create_session
-from opengever.base.role_assignments import InvitationRoleAssignment
 from opengever.base.role_assignments import RoleAssignmentManager
 from opengever.base.role_assignments import SharingRoleAssignment
 from opengever.mail.tests import MAIL_DATA
 from opengever.officeconnector.helpers import get_auth_plugin
 from opengever.ogds.base.utils import ogds_service
+from opengever.ogds.models.user_settings import UserSettings
 from opengever.testing import assets
 from opengever.testing.helpers import time_based_intids
 from opengever.testing.integration_test_case import FEATURE_FLAGS
@@ -192,6 +192,7 @@ class OpengeverContentFixture(object):
             u'Nicole',
             u'Kohler',
             ['Administrator', 'APIUser'],
+            user_settings={'_seen_tours': '["*"]'},
             )
 
         self.member_admin = self.create_user(
@@ -199,12 +200,14 @@ class OpengeverContentFixture(object):
             u'David',
             u'Meier',
             ['MemberAreaAdministrator', 'APIUser'],
+            user_settings={'_seen_tours': '["*"]'},
             )
 
         self.dossier_responsible = self.create_user(
             'dossier_responsible',
             u'Robert',
             u'Ziegler',
+            user_settings={'_seen_tours': '["*"]'},
             )
 
         self.regular_user = self.create_user(
@@ -228,12 +231,14 @@ class OpengeverContentFixture(object):
             salutation='Prof. Dr.',
             url='http://www.example.com',
             zip_code='1234',
+            user_settings={'_seen_tours': '["*"]'},
             )
 
         self.meeting_user = self.create_user(
             'meeting_user',
             u'Herbert',
             u'J\xe4ger',
+            user_settings={'_seen_tours': '["*"]'},
             )
 
         self.secretariat_user = self.create_user(
@@ -241,18 +246,21 @@ class OpengeverContentFixture(object):
             u'J\xfcrgen',
             u'K\xf6nig',
             group=self.org_unit_fd.inbox_group,
+            user_settings={'_seen_tours': '["*"]'},
             )
 
         self.committee_responsible = self.create_user(
             'committee_responsible',
             u'Fr\xe4nzi',
             u'M\xfcller',
+            user_settings={'_seen_tours': '["*"]'},
             )
 
         self.dossier_manager = self.create_user(
             'dossier_manager',
             u'F\xe4ivel',
             u'Fr\xfchling',
+            user_settings={'_seen_tours': '["*"]'},
             )
 
         self.records_manager = self.create_user(
@@ -260,37 +268,43 @@ class OpengeverContentFixture(object):
             u'Ramon',
             u'Flucht',
             ['Records Manager'],
+            user_settings={'_seen_tours': '["*"]'},
             )
 
         self.workspace_owner = self.create_user(
             'workspace_owner',
             u'G\xfcnther',
             u'Fr\xf6hlich',
+            user_settings={'_seen_tours': '["*"]'},
             )
 
         self.workspace_admin = self.create_user(
             'workspace_admin',
             u'Fridolin',
             u'Hugentobler',
+            user_settings={'_seen_tours': '["*"]'},
             )
 
         self.workspace_member = self.create_user(
             'workspace_member',
             u'B\xe9atrice',
             u'Schr\xf6dinger',
+            user_settings={'_seen_tours': '["*"]'},
             )
 
         self.workspace_guest = self.create_user(
             'workspace_guest',
             u'Hans',
             u'Peter',
+            user_settings={'_seen_tours': '["*"]'},
             )
 
         self.archivist = self.create_user(
             'archivist',
             u'J\xfcrgen',
             u'Fischer',
-            ['Archivist']
+            ['Archivist'],
+            user_settings={'_seen_tours': '["*"]'},
             )
 
         self.service_user = self.create_user(
@@ -302,13 +316,15 @@ class OpengeverContentFixture(object):
                 'ServiceKeyUser',
                 'Impersonator',
                 'Administrator',
-            ])
+            ],
+            )
 
         self.webaction_manager = self.create_user(
             'webaction_manager',
             u'WebAction',
             u'Manager',
             ['WebActionManager'],
+            user_settings={'_seen_tours': '["*"]'},
             )
 
         # This user is intended to be used in situations where you need a user
@@ -1862,8 +1878,8 @@ class OpengeverContentFixture(object):
             lastname,
             globalroles=(),
             group=None,
-            **kwargs
-        ):
+            user_settings=None,
+            **kwargs):
         """Create an OGDS user and a Plone user.
         The user is member of the current org unit user group.
         The ``attrname`` is the attribute name used to access this user
@@ -1888,6 +1904,7 @@ class OpengeverContentFixture(object):
             .assign_to_org_units([self.org_unit_fd])
             .in_group(group)
             .having(**kwargs)
+            .with_user_settings(**(user_settings or {}))
             )
 
         # Use a static bumblebee user salt so that access tokens are predictable

--- a/opengever/testing/tests/test_fixtures.py
+++ b/opengever/testing/tests/test_fixtures.py
@@ -1,6 +1,7 @@
 from DateTime import DateTime
 from ftw.testbrowser import browsing
 from ftw.testbrowser.pages import plone
+from opengever.ogds.models.user_settings import UserSettings
 from opengever.repository.interfaces import IRepositoryFolder
 from opengever.testing import IntegrationTestCase
 from plone import api
@@ -15,6 +16,12 @@ class TestTestingFixture(IntegrationTestCase):
         self.login(self.regular_user)
         self.assertEquals('nicole.kohler', self.administrator.getId())
         self.assertIn('Administrator', self.administrator.getRoles())
+
+    def test_users_have_seen_all_tours(self):
+        self.login(self.regular_user)
+        self.assertEqual(
+            ["*"],
+            UserSettings.get_setting_for_user(api.user.get_current().getId(), 'seen_tours'))
 
     def test_repository_root_has_static_creation_date(self):
         self.login(self.regular_user)


### PR DESCRIPTION
It seems we have a isolation issue for the SQL db in the `gever-ui` tests. As a result, the tours will get opened in the tests, until one tests closes the tour, which will then leak into the following tests. 
To make it easier for the frontend we set the `seen_tours` attribute to `[*]` for all users in the fixture except one, so that tours will not open in any tests in the frontend. We keep one user with the default settings, i.e. no settings.

For https://github.com/4teamwork/gever-ui/issues/781

## Checkliste
- [x] Changelog-Eintrag vorhanden/nötig?
