### PR TITLE
Extend the opengever deployment directive with workspace roles.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2020.2.0rc1 (unreleased)
 ------------------------
 
+- Extend the opengever deployment directive with workspace roles. [elioschmutz]
 - Set seen_tours for all users in test fixture. [njohner]
 
 

--- a/opengever/setup/deploy.py
+++ b/opengever/setup/deploy.py
@@ -175,6 +175,13 @@ class GeverDeployment(object):
                                   'records_manager_group', 'Records Manager')
         self.assign_group_to_role(self.site, self.config,
                                   'api_group', 'APIUser')
+        self.assign_group_to_role(self.site, self.config,
+                                  'workspace_client_user_group',
+                                  'WorkspaceClientUser')
+        self.assign_group_to_role(self.site, self.config,
+                                  'workspace_user_group', 'WorkspacesUser')
+        self.assign_group_to_role(self.site, self.config,
+                                  'workspace_creator_group', 'WorkspacesCreator')
 
         # REALLY set the language - the plone4 addPloneSite is really
         # buggy with languages.

--- a/opengever/setup/meta.py
+++ b/opengever/setup/meta.py
@@ -85,6 +85,21 @@ class IDeploymentDirective(Interface):
         required=False,
         max_length=GROUP_ID_LENGTH)
 
+    workspace_creator_group = TextLine(
+        title=u'Workspace creator group',
+        required=False,
+        max_length=GROUP_ID_LENGTH)
+
+    workspace_user_group = TextLine(
+        title=u'Workspace user group',
+        required=False,
+        max_length=GROUP_ID_LENGTH)
+
+    workspace_client_user_group = TextLine(
+        title=u'Workspace client group',
+        required=False,
+        max_length=GROUP_ID_LENGTH)
+
 
 def register_ldap(context, **kwargs):
     title = kwargs.get('title')


### PR DESCRIPTION
Issuer #6258 

This PR extends the opengever deployment directive with workspace roles.

This lets us define the groups for a specific role in the deployment configuration:

```xml
  <opengever:registerDeployment
      title="OneGov GEVER"
      ...
      workspace_creator_group="tr_creators"
      workspace_user_group="tr_users"
      />

```
## Checkliste

_Zutreffendes soll angehakt stehengelassen werden._

- [ ] Gibt es neue Funktionalität mit einem `Dokument`? Funktioniert das auch mit einem `Mail`?
- [ ] Wurde etwas an der `Aufgabe` angepasst? Funktioniert das auch mit einer `Weiterleitung`?
- [ ] Profil angepasst? Sind UpgradeSteps vorhanden/nötig?:
- [ ] Sind UpgradeSteps `deferrable`, oder können gewisse Schritte des Upgrades konditional ausgeführt werden?
- [ ] Gibts es eine DB-Schema Migration?
  - [ ] Wurde alle Columns/Änderungen aus dem Modell in einer DB-Schema Migration nachgeführt.
  - [ ] Sind Constraint-Namen maximal 30 Zeichen lang (`Oracle`)?
- [ ] Gibt es ein neues Feature-Flag? Wurden dafür Tests mit aktiviertem und deaktivierte Flag geschrieben?
- [ ] Könnten Kundeninstallationen von den Änderungen betroffen sein? Müssen Policies angepasst werden?
- [ ] Gibt es neue Übersetzungen?
  - [ ] Sind alle msg-Strings in Übersetzungen Unicode?
  - [ ] Wird die richtige i18n-domain verwendet (Copy-Paste Fehler sind hier häufig)?
- [ ] Wenn bei Schema-definitionen `missing_value` spezifiziert ist muss immer auch `default` auf den gleichen Wert gesetzt werden
- [x] Changelog-Eintrag vorhanden/nötig?
- [ ] Aktualisierung Dokumentation vorhanden/nötig?
