### PR TITLE
Smoketests: Test that POST requests never get answered with index.html.

### DIFF
--- a/rewrite_rule_smoketests/smoketests.py
+++ b/rewrite_rule_smoketests/smoketests.py
@@ -183,6 +183,22 @@ def test_gever_front_page_logged_in_old_ui(browser, admin_unit):
     assert_equal(admin_unit.url, logo.attrib['href'])
 
 
+@on_admin_unit
+def test_anonymous_post_requests_always_hit_gever(browser, admin_unit):
+    """This is a regression test for a case, where simple POST requests got
+    answered with the new frontend's index.html.
+    """
+    target_url = '/'.join((admin_unit.front_page_url, 'doesnt-exist'))
+
+    browser.raise_http_errors = False
+    browser.open(target_url, method='POST')
+
+    assert_equal(404, browser.status_code)
+
+    # Assert we hit Plone by checking for the presence of the logo
+    assert_equal(1, len(browser.css('#portal-logo')))
+
+
 def main():
     prompt_credentials = False
     if '--prompt-credentials' in sys.argv:


### PR DESCRIPTION
We had a regression in our rewrite rules where POST requests (from Bumblebee) got answered with the `index.html` for the new frontend.

This adds a failing test to ensure this doesn't happen.

The current plan to fix this is to change the RewriteRules in a way that the `index.html` _never_ gets served in response to any request with a method other than `GET`.

_(No changelog entry, since it's a testing only change)._

## Checkliste

- [ ] Changelog-Eintrag vorhanden/nötig?