### PR TITLE
Link Release 2020.1 in CL.

### DIFF
--- a/docs/public/release-notes/index.rst
+++ b/docs/public/release-notes/index.rst
@@ -7,6 +7,7 @@ Releases von OneGov GEVER.
 .. toctree::
    :maxdepth: 1
 
+   2020.1 <release-2020.1>
    2019.5-6 <release-2019.5-6>
    2019.4 <release-2019.4>
    2019.3 <release-2019.3>

--- a/docs/public/release-notes/release-2020.1.rst
+++ b/docs/public/release-notes/release-2020.1.rst
@@ -20,6 +20,12 @@ Neue Funktionalitäten in der SPV
 - Neu können Anhänge zu Anträgen aus der Sitzungsansicht bearbeitet werden.
 
 
+Erweiterung OGG-Bundle
+----------------------
+Die Datenschnittstelle OGG-Bundle zur Migration wurde erweitert und kann nun
+mehr Metadaten setzen, dies ist insbesondere bei Migrationen ab
+Windows-Dateisystemen nützlich.
+
 Sonstiges und Bugfixes
 ----------------------
 - Eine Performanceverbesserung von Dossierabschluss wurde eingeführt.

--- a/docs/public/release-notes/release-2020.1.rst
+++ b/docs/public/release-notes/release-2020.1.rst
@@ -22,5 +22,5 @@ Neue Funktionalitäten in der SPV
 
 Sonstiges und Bugfixes
 ----------------------
-- Eine Performanceverbesserung von Dossierabschluss wurde eingeführt
+- Eine Performanceverbesserung von Dossierabschluss wurde eingeführt.
 - Berechtigungen von Administratoren wurden angepasst um Probleme mit Dossier stornieren und dem Hinzufügen von Schlagwörtern zu beheben.

--- a/docs/public/release-notes/release-2020.1.rst
+++ b/docs/public/release-notes/release-2020.1.rst
@@ -10,7 +10,7 @@ OfficeConnector Support
 -----------------------
 
 OfficeConnector wird ab diesem Release nur noch über die REST-API mit GEVER kommunizieren.
-Dies führt zu einer Performanceverbesserung für Kunden, die dieses Feature noch nicht aktiviert hatten. GEVER wird aber nur noch OfficeConnector neuer als Version 1.9.0 unterstützen (wir empfehlen mindestens Version 1.9.2).
+Dies führt zu einer Performanceverbesserung für Kunden, die dieses Feature noch nicht aktiviert hatten. GEVER wird aber nur noch OfficeConnector ab Version 1.9.0 unterstützen (wir empfehlen die neuste verfügbare Version zu verwenden).
 
 
 Neue Funktionalitäten in der SPV


### PR DESCRIPTION
- Display link to release information in public docs
- Also quickly mention OggBundle changes for filesystem migration in changelog