### PR TITLE
Register demo.teamraum.ch to rewrite rule tests

### DIFF
--- a/rewrite_rule_smoketests/config.py
+++ b/rewrite_rule_smoketests/config.py
@@ -48,4 +48,13 @@ CLUSTERS_TO_TEST = [
         gever_ui_is_default=False,
     ),
 
+    Cluster(
+        'https://demo.teamraum.ch',
+        admin_units=[
+            AdminUnit('tr', is_dedicated_teamraum=True),
+        ],
+        new_portal=True,
+        gever_ui_is_default=True,
+    ),
+
 ]


### PR DESCRIPTION
This PR registers demo.teamraum.ch as a new Cluster for rewrite rule tests.
