### PR TITLE
Update the cas_auth server url to the new endpoint of the new portal.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2020.2.0rc1 (unreleased)
 ------------------------
 
+- Update the cas_auth server url to the new endpoint of the new portal. [elioschmutz]
 - Restrict `geverui` cookie to admin unit. [elioschmutz]
 - Extend the opengever deployment directive with workspace roles. [elioschmutz]
 - Set seen_tours for all users in test fixture. [njohner]

--- a/opengever/base/casauth.py
+++ b/opengever/base/casauth.py
@@ -60,4 +60,4 @@ def build_cas_server_url():
     initially configure the ftw.casauth plugin.
     """
     base_url = get_cluster_base_url()
-    return urljoin(base_url, 'portal')
+    return urljoin(base_url, 'portal/cas')


### PR DESCRIPTION
This PR updates the `cas_auth` server url to the new endpoint introduced with the new ianus-portal. Because new deployments should all run with the new portal, we can adjust it for future installations.

This url will only be set on a gever setup. So we don't need an upgradestep.

## Checkliste

- [ ] Gibt es neue Funktionalität mit einem `Dokument`? Funktioniert das auch mit einem `Mail`?
- [ ] Wurde etwas an der `Aufgabe` angepasst? Funktioniert das auch mit einer `Weiterleitung`?
- [ ] Profil angepasst? Sind UpgradeSteps vorhanden/nötig?:
- [ ] Sind UpgradeSteps `deferrable`, oder können gewisse Schritte des Upgrades konditional ausgeführt werden?
- [ ] Gibts es eine DB-Schema Migration?
  - [ ] Wurde alle Columns/Änderungen aus dem Modell in einer DB-Schema Migration nachgeführt.
  - [ ] Sind Constraint-Namen maximal 30 Zeichen lang (`Oracle`)?
- [ ] Gibt es ein neues Feature-Flag? Wurden dafür Tests mit aktiviertem und deaktivierte Flag geschrieben?
- [ ] Könnten Kundeninstallationen von den Änderungen betroffen sein? Müssen Policies angepasst werden?
- [ ] Gibt es neue Übersetzungen?
  - [ ] Sind alle msg-Strings in Übersetzungen Unicode?
  - [ ] Wird die richtige i18n-domain verwendet (Copy-Paste Fehler sind hier häufig)?
- [ ] Wenn bei Schema-definitionen `missing_value` spezifiziert ist muss immer auch `default` auf den gleichen Wert gesetzt werden
- [x] Changelog-Eintrag vorhanden/nötig?
- [ ] Aktualisierung Dokumentation vorhanden/nötig?
