### PR TITLE
Extends policytemplates

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2020.2.0rc1 (unreleased)
 ------------------------
 
+- Extend policytemplates to use the single thread setup. [elioschmutz]
 - Extend policytemplates with workspace deployment. [elioschmutz]
 - Extend policytemplates with gever-ui activation. [elioschmutz]
 - Restrict `geverui` cookie to admin unit. [elioschmutz]

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2020.2.0rc1 (unreleased)
 ------------------------
 
+- Extend policytemplates with workspace deployment. [elioschmutz]
 - Extend policytemplates with gever-ui activation. [elioschmutz]
 - Restrict `geverui` cookie to admin unit. [elioschmutz]
 - Extend the opengever deployment directive with workspace roles. [elioschmutz]

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2020.2.0rc1 (unreleased)
 ------------------------
 
+- Extend policytemplates with gever-ui activation. [elioschmutz]
 - Restrict `geverui` cookie to admin unit. [elioschmutz]
 - Extend the opengever deployment directive with workspace roles. [elioschmutz]
 - Set seen_tours for all users in test fixture. [njohner]

--- a/opengever/policytemplates/hooks.py
+++ b/opengever/policytemplates/hooks.py
@@ -155,12 +155,17 @@ def post_preserved_as_paper(configurator, question, answer):
 def post_render(configurator):
     has_templates = configurator.variables['include_templates']
     has_meeting = configurator.variables['setup.enable_meeting_feature']
+    has_workspace = configurator.variables['setup.workspace']
 
     package_name = configurator.variables['package.name']
-    content_path = os.path.join(
+    profiles_path = os.path.join(
         configurator.target_directory,
         'opengever.{}'.format(package_name),
-        'opengever', package_name, 'profiles', 'default_content',
+        'opengever', package_name, 'profiles')
+
+    content_path = os.path.join(
+        profiles_path,
+        'default_content',
         'opengever_content')
 
     if has_meeting:
@@ -171,6 +176,9 @@ def post_render(configurator):
 
         if not has_templates:
             _delete_templates_files(configurator, content_path)
+
+    if not has_workspace:
+        _delete_workspaces_content_profile(profiles_path)
 
 
 def _delete_templates_files(configurator, content_path):
@@ -203,3 +211,7 @@ def _get_sablon_template_paths():
                 filename)))
 
     return paths
+
+
+def _delete_workspaces_content_profile(profiles_path):
+    os.remove(os.path.join(profiles_path, 'workspaces_content'))

--- a/opengever/policytemplates/policy_template/.mrbob.ini
+++ b/opengever/policytemplates/policy_template/.mrbob.ini
@@ -175,6 +175,14 @@ setup.workspace.required = True
 setup.workspace.default = False
 setup.workspace.post_ask_hook = mrbob.hooks:to_boolean
 
+deployment.workspace_creators_group.question = Worskpace creators group
+deployment.workspace_creators_group.default = tr_creators
+deployment.workspace_creators_group.required = False
+
+deployment.workspace_users_group.question = Worskpace userss group
+deployment.workspace_users_group.default = tr_users
+deployment.workspace_users_group.required = False
+
 setup.geverui.question = Enable GEVER UI
 setup.geverui.required = True
 setup.geverui.default = False

--- a/opengever/policytemplates/policy_template/.mrbob.ini
+++ b/opengever/policytemplates/policy_template/.mrbob.ini
@@ -174,3 +174,8 @@ setup.workspace.question = Enable Workspace feature
 setup.workspace.required = True
 setup.workspace.default = False
 setup.workspace.post_ask_hook = mrbob.hooks:to_boolean
+
+setup.geverui.question = Enable GEVER UI
+setup.geverui.required = True
+setup.geverui.default = False
+setup.geverui.post_ask_hook = mrbob.hooks:to_boolean

--- a/opengever/policytemplates/policy_template/opengever.+package.name+/deployment-+base.server_name+-+base.deployment_number+-+base.domain+.cfg.bob
+++ b/opengever/policytemplates/policy_template/opengever.+package.name+/deployment-+base.server_name+-+base.deployment_number+-+base.domain+.cfg.bob
@@ -2,11 +2,12 @@
 extends =
     https://raw.githubusercontent.com/4teamwork/gever-buildouts/master/standard-deployment-v2.cfg
     https://raw.githubusercontent.com/4teamwork/gever-buildouts/master/ogds-postgres.cfg
-    https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/zeoclients/2.cfg
+    https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/zeoclients/4.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/bumblebee.cfg
     versions.cfg
     https://raw.githubusercontent.com/4teamwork/gever-buildouts/master/solr.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/production-v2.cfg
+    https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/single-thread.cfg
 
 
 deployment-number = {{{base.deployment_number}}}

--- a/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/configure.zcml.bob
+++ b/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/configure.zcml.bob
@@ -46,6 +46,22 @@
       provides="Products.GenericSetup.interfaces.EXTENSION"
       />
 
+  <opengever:registerLDAP
+      title="OneGov GEVER {{{package.title}}} LDAP"
+      ldap_profile="opengever.{{{package.name}}}:ldap"
+      is_default="True"
+      />
+
+{{% if setup.workspace %}}
+  <genericsetup:registerProfile
+      name="workspaces_content"
+      title="opengever.{{{package.name}}}:workspaces_content"
+      description="Default content for {{{package.title}}}."
+      directory="profiles/workspaces_content"
+      provides="Products.GenericSetup.interfaces.EXTENSION"
+      />
+{{% endif %}}
+
   <!-- deployments -->
   <opengever:registerDeployment
       title="OneGov GEVER {{{package.title}}}"
@@ -63,10 +79,20 @@
       mail_from_address="{{{deployment.mail_from_address}}}"
       />
 
-  <opengever:registerLDAP
-      title="OneGov GEVER {{{package.title}}} LDAP"
-      ldap_profile="opengever.{{{package.name}}}:ldap"
-      is_default="True"
+{{% if setup.workspace %}}
+  <opengever:registerDeployment
+      title="Teamraum {{{package.title}}}"
+      policy_profile="opengever.{{{package.name}}}:default"
+      additional_profiles="opengever.{{{package.name}}}:workspaces_content
+                           opengever.setup:casauth
+                          "
+      admin_unit_id="{{{adminunit.id}}}"
+      rolemanager_group="{{{deployment.rolemanager_group}}}"
+      records_manager_group="{{{deployment.records_manager_group}}}"
+      workspace_creators_group="{{{deployment.workspace_creators_group}}}"
+      workspace_users_group="{{{deployment.workspace_users_group}}}"
+      mail_domain="{{{deployment.mail_domain}}}"
+      mail_from_address="{{{deployment.mail_from_address}}}"
       />
-
+{{% endif %}}
 </configure>

--- a/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/profiles/default/registry.xml.bob
+++ b/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/profiles/default/registry.xml.bob
@@ -120,6 +120,12 @@
   </records>
 
 {{% endif %}}
+{{% if setup.geverui %}}
+  <records interface="opengever.base.interfaces.IGeverUI">
+    <value key="is_feature_enabled">True</value>
+  </records>
+
+{{% endif %}}
   <record interface="opengever.bumblebee.interfaces.IGeverBumblebeeSettings" field="is_feature_enabled">
     <field type="plone.registry.field.Bool" />
     <value>True</value>

--- a/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/profiles/workspaces_content/metadata.xml
+++ b/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/profiles/workspaces_content/metadata.xml
@@ -1,0 +1,3 @@
+<metadata>
+  <version>1</version>
+</metadata>

--- a/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/profiles/workspaces_content/opengever_content/01-initial-structure.json
+++ b/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/profiles/workspaces_content/opengever_content/01-initial-structure.json
@@ -1,0 +1,8 @@
+[
+    {
+        "_path": "workspaces",
+        "_type": "opengever.workspace.root",
+        "title_de": "Teamräume",
+        "title_fr": "Espace partagé"
+    }
+]


### PR DESCRIPTION
This PR extends the policytemplates with:

- Question to activate the `gever-ui` in the backend (enables the switch to new UI action link in the user-menu)
- Question about the workspaces deployment (will create a new profile to install a teamraum deployment)
- Updates the template to use the single thread setup: https://github.com/4teamwork/opengever.hatchery/pull/53

This PR helps creating new teamraum deployments with `bin/create-policy`

related to #6258 