### PR TITLE
Add API endpoint to create document from template.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,7 @@ Changelog
 - Extend policytemplates to use the single thread setup. [elioschmutz]
 - Extend policytemplates with workspace deployment. [elioschmutz]
 - Extend policytemplates with gever-ui activation. [elioschmutz]
+- Add API service to create document from template. [deiferni]
 - Restrict `geverui` cookie to admin unit. [elioschmutz]
 - Extend the opengever deployment directive with workspace roles. [elioschmutz]
 - Set seen_tours for all users in test fixture. [njohner]

--- a/docs/public/dev-manual/api/index.rst
+++ b/docs/public/dev-manual/api/index.rst
@@ -37,6 +37,7 @@ Inhalt:
    sharing.rst
    workspace/index
    linked_workspaces.rst
+   templatefolder.rst
    examples/index.rst
    docs_changelog.rst
 

--- a/docs/public/dev-manual/api/templatefolder.rst
+++ b/docs/public/dev-manual/api/templatefolder.rst
@@ -1,0 +1,33 @@
+.. _templatefolder:
+
+Dokumente ab Vorlage erstellen
+==============================
+
+In einem Dosser kann über den Endpoint ``@document-from-template`` ein neues
+Dokument ab Vorlage erstellt werden.
+
+Der Endpoint steht auf einem Dossier zur Verfügung. Der Endpoint ist mit der
+Berechtigung ``opengever.document: Add document`` geschützt, kann also verwendet
+werden wenn der Benutzer Dokumente hinzufügen kann.
+
+Der Endpoint erwartet zwei Parameter:
+
+- ``template`` das zu verwendende template aus dem Vokabular ``opengever.dossier.DocumentTemplatesVocabulary``
+- ``title`` Titel des zu erstellenden Dokumentes
+
+
+**Beispiel-Request**:
+
+   .. sourcecode:: http
+
+       POST /ordnungssystem/fuehrung/dossier-23/@document-from-template HTTP/1.1
+       Accept: application/json
+
+       {
+        "template": {"token": "1234567890"},
+        "title": "Document title"
+       }
+
+
+Als Reponse wird die JSON-Repräsentation des neu erstellen Dokuments geliefert,
+siehe :ref:`Inhaltstypen <content-types>`.

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -592,4 +592,12 @@
       permission="opengever.workspaceclient.UseWorkspaceClient"
       />
 
+  <plone:service
+      method="POST"
+      name="@document-from-template"
+      for="opengever.dossier.behaviors.dossier.IDossierMarker"
+      factory=".templatefolder.DocumentFromTemplatePost"
+      permission="opengever.document.AddDocument"
+      />
+
 </configure>

--- a/opengever/api/templatefolder.py
+++ b/opengever/api/templatefolder.py
@@ -1,0 +1,44 @@
+from opengever.dossier.command import CreateDocumentFromTemplateCommand
+from plone.protect.interfaces import IDisableCSRFProtection
+from plone.restapi.deserializer import json_body
+from plone.restapi.interfaces import ISerializeToJson
+from plone.restapi.services import Service
+from zExceptions import BadRequest
+from zope.component import getUtility
+from zope.component import queryMultiAdapter
+from zope.interface import alsoProvides
+from zope.schema.interfaces import IVocabularyFactory
+
+
+class DocumentFromTemplatePost(Service):
+    """API Endpoint to create a document in a dossier from a template.
+    """
+
+    def reply(self):
+        # Disable CSRF protection
+        alsoProvides(self.request, IDisableCSRFProtection)
+
+        data = json_body(self.request)
+
+        token = data.get('template')
+        if isinstance(token, dict):
+            token = token.get('token')
+
+        if not token:
+            raise BadRequest('Missing parameter template')
+
+        vocabulary = getUtility(IVocabularyFactory,
+                             name='opengever.dossier.DocumentTemplatesVocabulary')
+        term = vocabulary(self.context).getTermByToken(token)
+        template = term.value
+
+        title = data.get('title')
+        if not title:
+            raise BadRequest('Missing parameter title')
+
+        command = CreateDocumentFromTemplateCommand(
+            self.context, template, title)
+        document = command.execute()
+
+        serializer = queryMultiAdapter((document, self.request), ISerializeToJson)
+        return serializer()

--- a/opengever/api/tests/test_templatefolder.py
+++ b/opengever/api/tests/test_templatefolder.py
@@ -1,0 +1,91 @@
+from datetime import date
+from ftw.testbrowser import browsing
+from opengever.base.role_assignments import RoleAssignmentManager
+from opengever.base.role_assignments import SharingRoleAssignment
+from opengever.testing import IntegrationTestCase
+from zExceptions import BadRequest
+import json
+
+
+class TestDocumentFromTemplatePost(IntegrationTestCase):
+
+    @browsing
+    def test_creates_document_from_template(self, browser):
+        self.login(self.regular_user, browser)
+
+        browser.open(
+            '{}/@vocabularies/opengever.dossier.DocumentTemplatesVocabulary'.format(
+                self.portal.absolute_url()),
+            headers=self.api_headers)
+        template = browser.json['items'][0]
+
+        data = {'template': template,
+                'title': u'New d\xf6cument'}
+
+        with self.observe_children(self.dossier) as children:
+            browser.open('{}/@document-from-template'.format(
+                         self.dossier.absolute_url()),
+                         data=json.dumps(data),
+                         headers=self.api_headers)
+
+        self.assertEqual(1, len(children['added']))
+        document = children['added'].pop()
+
+        self.assertEqual(u'New d\xf6cument', document.title)
+        self.assertEquals(date.today(), document.document_date)
+
+    @browsing
+    def test_requires_title(self, browser):
+        self.login(self.regular_user, browser)
+
+        browser.open(
+            '{}/@vocabularies/opengever.dossier.DocumentTemplatesVocabulary'.format(
+                self.portal.absolute_url()),
+            headers=self.api_headers)
+        template = browser.json['items'][0]
+
+        data = {'template': template}
+
+        browser.exception_bubbling = True
+        with self.assertRaises(BadRequest) as exc:
+            browser.open('{}/@document-from-template'.format(
+                         self.dossier.absolute_url()),
+                         data=json.dumps(data),
+                         headers=self.api_headers)
+
+        self.assertEqual('Missing parameter title', str(exc.exception))
+
+    @browsing
+    def test_requires_template(self, browser):
+        self.login(self.regular_user, browser)
+
+        data = {'title': u'New d\xf6cument'}
+
+        browser.exception_bubbling = True
+        with self.assertRaises(BadRequest) as exc:
+            browser.open('{}/@document-from-template'.format(
+                         self.dossier.absolute_url()),
+                         data=json.dumps(data),
+                         headers=self.api_headers)
+
+        self.assertEqual('Missing parameter template', str(exc.exception))
+
+    @browsing
+    def test_requires_add_permission(self, browser):
+        with self.login(self.regular_user):
+            RoleAssignmentManager(self.portal).add_or_update_assignment(
+                SharingRoleAssignment(self.reader_user.getId(), ['Reader']),
+            )
+            RoleAssignmentManager(self.dossier).add_or_update_assignment(
+                SharingRoleAssignment(self.reader_user.getId(), ['Reader']),
+            )
+
+        self.login(self.reader_user, browser)
+        data = {'template': {'token': '1234567890'},
+                'title': u'New d\xf6cument'}
+
+        with browser.expect_unauthorized():
+            browser.open('{}/@document-from-template'.format(
+                         self.dossier.absolute_url()),
+                         data=json.dumps(data),
+                         headers=self.api_headers)

--- a/opengever/api/tests/test_vocabularies.py
+++ b/opengever/api/tests/test_vocabularies.py
@@ -27,6 +27,7 @@ NON_SENSITIVE_VOCABUALRIES = [
     'opengever.base.ReferenceFormatterVocabulary',
     'opengever.document.document_types',
     'opengever.dossier.container_types',
+    'opengever.dossier.DocumentTemplatesVocabulary',
     'opengever.dossier.participation_roles',
     'opengever.dossier.type_prefixes',
     'opengever.dossier.ValidResolverNamesVocabulary',

--- a/opengever/dossier/templatefolder/configure.zcml
+++ b/opengever/dossier/templatefolder/configure.zcml
@@ -114,4 +114,9 @@
       handler=".subscribers.configure_templatefolder_portlets"
       />
 
+  <utility
+      factory=".vocabulary.DocumentTemplatesVocabulary"
+      name="opengever.dossier.DocumentTemplatesVocabulary"
+      />
+
 </configure>

--- a/opengever/dossier/templatefolder/vocabulary.py
+++ b/opengever/dossier/templatefolder/vocabulary.py
@@ -1,0 +1,10 @@
+from opengever.dossier.templatefolder.form import get_templates
+from zope.interface import implementer
+from zope.schema.interfaces import IVocabularyFactory
+
+
+@implementer(IVocabularyFactory)
+class DocumentTemplatesVocabulary(object):
+
+    def __call__(self, context):
+        return get_templates(context)

--- a/opengever/dossier/tests/test_documenttemplates_vocabulary.py
+++ b/opengever/dossier/tests/test_documenttemplates_vocabulary.py
@@ -1,0 +1,18 @@
+from opengever.testing import IntegrationTestCase
+from zope.component import getUtility
+from zope.schema.interfaces import IVocabularyFactory
+
+
+class TestDocumentTemplatesVocabulary(IntegrationTestCase):
+
+    def test_roles_vocabulary_list_all_managed_roles(self):
+        self.login(self.regular_user)
+        factory = getUtility(IVocabularyFactory,
+                             name='opengever.dossier.DocumentTemplatesVocabulary')
+
+        self.assertItemsEqual(
+            [u'T\xc3\xb6mpl\xc3\xb6te Mit',
+             u'T\xc3\xb6mpl\xc3\xb6te Normal',
+             u'T\xc3\xb6mpl\xc3\xb6te Ohne',
+             u'T\xc3\xb6mpl\xc3\xb6te Sub'],
+            [term.title for term in factory(context=self.portal)])


### PR DESCRIPTION
This PR adds an api endpoint `@document-from-template` to create documents based on a document template. It also adds a vocabulary `opengever.dossier.DocumentTemplatesVocabulary` that contains the available templates.

The endpoint is very simple and mirrors the functionality currently available in the old UI. It just allows the user to select a template and a title for the document which will be created as a copy of the template.

I have made the following disputable decisions while implementing:
- the vocabulary namespace is `opengever.dossier` as the dossier might in the future restrict the templates that are available. currently it does not though, so we migth also choose `opengever.templatefolder...` as namespace for the vocabulary. If you think so please speak up.
- currently the helper `get_validation_errors` does not seem handle vocabulary-based schema fields at all. Thus i have not implemented a schema/interface with two fields but instead just hardcoded the two fields into the service endpoint. I can invest some more time to fix `get_validation_errors` and implement a "proper" schema if desired.

For https://github.com/4teamwork/gever-ui/issues/944.

## Checkliste

_Zutreffendes soll angehakt stehengelassen werden._

- [x] Gibt es neue Funktionalität mit einem `Dokument`? ~~Funktioniert das auch mit einem `Mail`?~~
- [x] Changelog-Eintrag vorhanden/nötig?
- [x] Aktualisierung Dokumentation vorhanden/nötig?
