### PR TITLE
Smoketest: Switch dev.onegovgever.ch to classic UI default.

### DIFF
--- a/rewrite_rule_smoketests/config.py
+++ b/rewrite_rule_smoketests/config.py
@@ -16,7 +16,7 @@ CLUSTERS_TO_TEST = [
             AdminUnit('rk'),
         ],
         new_portal=False,
-        gever_ui_is_default=True,
+        gever_ui_is_default=False,
     ),
 
     Cluster(


### PR DESCRIPTION
Since [`dev.onegovgever.ch` has been switched to serve the classic UI by default](https://git.4teamwork.ch/misc/puppet/commit/88923ee96c0bb3daf1e7907e234ecb96a51a4733) (instead of the new UI like before), the smoketests, which are currently failing because of that, need to be updated accordingly.
