### PR TITLE
Smoketests: Add demo.ogg and sales.ogg (SaaS deployments).

### DIFF
--- a/rewrite_rule_smoketests/config.py
+++ b/rewrite_rule_smoketests/config.py
@@ -49,6 +49,24 @@ CLUSTERS_TO_TEST = [
     ),
 
     Cluster(
+        'https://demo.onegovgever.ch',
+        admin_units=[
+            AdminUnit('demo'),
+        ],
+        new_portal=False,
+        gever_ui_is_default=False,
+    ),
+
+    Cluster(
+        'https://sales.onegovgever.ch',
+        admin_units=[
+            AdminUnit('sales'),
+        ],
+        new_portal=False,
+        gever_ui_is_default=False,
+    ),
+
+    Cluster(
         'https://demo.teamraum.ch',
         admin_units=[
             AdminUnit('tr', is_dedicated_teamraum=True),


### PR DESCRIPTION
This change adds configs for `demo.ogg` and `sales.ogg` to the rewrite rule smoketests.

These are two SaaS deployments, one on `ipet` and the other on `sia`, respectively. Current smoketests are passing for these.