### PR TITLE
Uses newline character to break text for helptext in forms

### DIFF
--- a/docs/schema-dumps/ftw.mail.mail.schema.json
+++ b/docs/schema-dumps/ftw.mail.mail.schema.json
@@ -70,7 +70,7 @@
         "keywords": {
             "type": "array",
             "title": "Schlagw\u00f6rter",
-            "description": "Schlagw\u00f6rter zur Umschreibung eines Dokuments. Nicht zu verwechseln mit der Ordnungsposition. <br>ACHTUNG: Beachten Sie bei der Verwendung von Schlagw\u00f6rter die Datenschutzvorgaben (z.B. keine Eigennamen).",
+            "description": "Schlagw\u00f6rter zur Umschreibung eines Dokuments. Nicht zu verwechseln mit der Ordnungsposition.\nACHTUNG: Beachten Sie bei der Verwendung von Schlagw\u00f6rter die Datenschutzvorgaben (z.B. keine Eigennamen).",
             "_zope_schema_type": "Tuple"
         },
         "foreign_reference": {

--- a/docs/schema-dumps/opengever.document.document.schema.json
+++ b/docs/schema-dumps/opengever.document.document.schema.json
@@ -83,7 +83,7 @@
         "keywords": {
             "type": "array",
             "title": "Schlagw\u00f6rter",
-            "description": "Schlagw\u00f6rter zur Umschreibung eines Dokuments. Nicht zu verwechseln mit der Ordnungsposition. <br>ACHTUNG: Beachten Sie bei der Verwendung von Schlagw\u00f6rter die Datenschutzvorgaben (z.B. keine Eigennamen).",
+            "description": "Schlagw\u00f6rter zur Umschreibung eines Dokuments. Nicht zu verwechseln mit der Ordnungsposition.\nACHTUNG: Beachten Sie bei der Verwendung von Schlagw\u00f6rter die Datenschutzvorgaben (z.B. keine Eigennamen).",
             "_zope_schema_type": "Tuple"
         },
         "foreign_reference": {

--- a/docs/schema-dumps/opengever.dossier.businesscasedossier.schema.json
+++ b/docs/schema-dumps/opengever.dossier.businesscasedossier.schema.json
@@ -26,7 +26,7 @@
         "keywords": {
             "type": "array",
             "title": "Schlagw\u00f6rter",
-            "description": "Schlagw\u00f6rter zur Umschreibung eines Dossiers. Nicht zu verwechseln mit der Ordnungsposition. <br>ACHTUNG: Beachten Sie bei der Verwendung von Schlagw\u00f6rter die Datenschutzvorgaben (z.B. keine Eigennamen).",
+            "description": "Schlagw\u00f6rter zur Umschreibung eines Dossiers. Nicht zu verwechseln mit der Ordnungsposition.\nACHTUNG: Beachten Sie bei der Verwendung von Schlagw\u00f6rter die Datenschutzvorgaben (z.B. keine Eigennamen).",
             "_zope_schema_type": "Tuple"
         },
         "start": {

--- a/opengever/bundle/schemas/documents.schema.json
+++ b/opengever/bundle/schemas/documents.schema.json
@@ -110,7 +110,7 @@
                         "array"
                     ],
                     "title": "Schlagw\u00f6rter",
-                    "description": "Schlagw\u00f6rter zur Umschreibung eines Dokuments. Nicht zu verwechseln mit der Ordnungsposition. <br>ACHTUNG: Beachten Sie bei der Verwendung von Schlagw\u00f6rter die Datenschutzvorgaben (z.B. keine Eigennamen).",
+                    "description": "Schlagw\u00f6rter zur Umschreibung eines Dokuments. Nicht zu verwechseln mit der Ordnungsposition.\nACHTUNG: Beachten Sie bei der Verwendung von Schlagw\u00f6rter die Datenschutzvorgaben (z.B. keine Eigennamen).",
                     "_zope_schema_type": "Tuple"
                 },
                 "foreign_reference": {

--- a/opengever/bundle/schemas/dossiers.schema.json
+++ b/opengever/bundle/schemas/dossiers.schema.json
@@ -41,7 +41,7 @@
                         "array"
                     ],
                     "title": "Schlagw\u00f6rter",
-                    "description": "Schlagw\u00f6rter zur Umschreibung eines Dossiers. Nicht zu verwechseln mit der Ordnungsposition. <br>ACHTUNG: Beachten Sie bei der Verwendung von Schlagw\u00f6rter die Datenschutzvorgaben (z.B. keine Eigennamen).",
+                    "description": "Schlagw\u00f6rter zur Umschreibung eines Dossiers. Nicht zu verwechseln mit der Ordnungsposition.\nACHTUNG: Beachten Sie bei der Verwendung von Schlagw\u00f6rter die Datenschutzvorgaben (z.B. keine Eigennamen).",
                     "_zope_schema_type": "Tuple"
                 },
                 "start": {

--- a/opengever/document/locales/de/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/de/LC_MESSAGES/opengever.document.po
@@ -289,7 +289,7 @@ msgstr "Referenz auf das entsprechende Dossier des Absenders"
 
 #: ./opengever/document/behaviors/metadata.py
 msgid "help_keywords"
-msgstr "Schlagwörter zur Umschreibung eines Dokuments. Nicht zu verwechseln mit der Ordnungsposition. <br>ACHTUNG: Beachten Sie bei der Verwendung von Schlagwörter die Datenschutzvorgaben (z.B. keine Eigennamen)."
+msgstr "Schlagwörter zur Umschreibung eines Dokuments. Nicht zu verwechseln mit der Ordnungsposition.\nACHTUNG: Beachten Sie bei der Verwendung von Schlagwörter die Datenschutzvorgaben (z.B. keine Eigennamen)."
 
 #. Default: ""
 #: ./opengever/document/behaviors/metadata.py

--- a/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
@@ -288,7 +288,7 @@ msgstr "Référence sur le dossier correspondant de l'expéditeur"
 
 #: ./opengever/document/behaviors/metadata.py
 msgid "help_keywords"
-msgstr "Mots-clés pour la description du document. Ne pas confondre avec le numéro de classement. <br>ATTENTION: Veuillez vous conformer aux directives de Protection des Données lors de l'utilisation de Mots-clés (par ex. pas de noms propres)."
+msgstr "Mots-clés pour la description du document. Ne pas confondre avec le numéro de classement.\nATTENTION: Veuillez vous conformer aux directives de Protection des Données lors de l'utilisation de Mots-clés (par ex. pas de noms propres)."
 
 #: ./opengever/document/behaviors/metadata.py
 msgid "help_preserved_as_paper"

--- a/opengever/dossier/locales/de/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/de/LC_MESSAGES/opengever.dossier.po
@@ -447,7 +447,7 @@ msgstr "Geben Sie die vollständige Ablagenummer an."
 
 #: ./opengever/dossier/behaviors/dossier.py
 msgid "help_keywords"
-msgstr "Schlagwörter zur Umschreibung eines Dossiers. Nicht zu verwechseln mit der Ordnungsposition. <br>ACHTUNG: Beachten Sie bei der Verwendung von Schlagwörter die Datenschutzvorgaben (z.B. keine Eigennamen)."
+msgstr "Schlagwörter zur Umschreibung eines Dossiers. Nicht zu verwechseln mit der Ordnungsposition.\nACHTUNG: Beachten Sie bei der Verwendung von Schlagwörter die Datenschutzvorgaben (z.B. keine Eigennamen)."
 
 #: ./opengever/dossier/behaviors/dossier.py
 msgid "help_number_of_containers"

--- a/opengever/dossier/locales/fr/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/fr/LC_MESSAGES/opengever.dossier.po
@@ -445,7 +445,7 @@ msgstr "Saisir le numéro d'inventaire complet."
 
 #: ./opengever/dossier/behaviors/dossier.py
 msgid "help_keywords"
-msgstr "Mots-clés pour la description du dossier. Ne pas confondre avec le numéro de classement. <br>ATTENTION: Veuillez vous conformer aux directives de Protection des Données lors de l'utilisation de Mots-clés (par ex. pas de noms propres)."
+msgstr "Mots-clés pour la description du dossier. Ne pas confondre avec le numéro de classement.\nATTENTION: Veuillez vous conformer aux directives de Protection des Données lors de l'utilisation de Mots-clés (par ex. pas de noms propres)."
 
 #: ./opengever/dossier/behaviors/dossier.py
 msgid "help_number_of_containers"

--- a/plonetheme/teamraum/resources/css/gever/partials/_form.scss
+++ b/plonetheme/teamraum/resources/css/gever/partials/_form.scss
@@ -117,3 +117,7 @@ body.portaltype-opengever-meeting-committee.template-edit {
       }
   }
 }
+
+.formHelp {
+  white-space: pre-wrap;
+}


### PR DESCRIPTION
As discussed in https://github.com/4teamwork/gever-ui/issues/976 the gever-ui is not able to format form hints using HTML. So change the </br> to a \n. To make the newline character visible in the opengever.core use `white-space: pre-wrap;`. See the `pre-wrap` specification in https://tympanus.net/codrops/css_reference/white-space/.