### PR TITLE
WOPI: Fix lock token mismatches on PutFile:

### DIFF
--- a/opengever/wopi/tests/test_lock.py
+++ b/opengever/wopi/tests/test_lock.py
@@ -3,6 +3,7 @@ from opengever.wopi.lock import create_lock
 from opengever.wopi.lock import get_lock_token
 from opengever.wopi.lock import refresh_lock
 from opengever.wopi.lock import unlock
+from opengever.wopi.lock import validate_lock
 from plone.locking.interfaces import ILockable
 
 
@@ -42,3 +43,18 @@ class TestLocking(IntegrationTestCase):
         refresh_lock(self.document)
         self.assertGreater(
             self.document.wl_lockItems()[0][1].getModifiedTime(), mtime)
+
+    def test_validate_lock_strict(self):
+        self.assertTrue(validate_lock('LOCK-TOKEN', 'LOCK-TOKEN'))
+        self.assertFalse(validate_lock('LOCK-TOKEN', 'OCK-TO'))
+
+    def test_validate_lock_forgiving(self):
+        self.assertTrue(
+            validate_lock('LOCK-TOKEN', 'LOCK-TOKEN', strict=False))
+        self.assertTrue(
+            validate_lock('LOCK-TOKEN', 'OCK-TO', strict=False))
+        self.assertTrue(
+            validate_lock("{'a': 1, 'b': 2}", "{'a': 1}", strict=False))
+
+        self.assertFalse(
+            validate_lock('LOCK-TOKEN', 'SOMETHING-ELSE', strict=False))


### PR DESCRIPTION
This change fixes some **lock token mismatches** on `PutFile` operations we were seeing because the MS WOPI client sometimes sends incomplete / partial tokens.

I addressed this by moving comparison of the lock tokens to a small helper function that does an exact string comparison in `strict` mode (which is the default), and a more loose comparison otherwise.

We've so far only seen this behavior for the `PutFile` operation, and in these two specific variants:
- The client token is a substring of the server token
- The client token looks like JSON, and contains a subset of the key/value
  pairs present in the server token (with keys in the same order).

The **validator tests using docker** pass against this change. _(And they did indeed fail when rejecting any token, or accepting any token)._

## Checkliste

- [x] Changelog-Eintrag vorhanden/nötig?
  _(Nicht nötig da im selben Release eingeführt wie angepasst)_