### PR TITLE
Extend the @config endpoint with an `apps_url` attribute.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2020.2.0rc1 (unreleased)
 ------------------------
 
+- Extend the @config endpoint with an `apps_url` attribute. [elioschmutz]
 - Extend policytemplates to use the single thread setup. [elioschmutz]
 - Extend policytemplates with workspace deployment. [elioschmutz]
 - Extend policytemplates with gever-ui activation. [elioschmutz]

--- a/docs/intern/kurzreferenzen/index.rst
+++ b/docs/intern/kurzreferenzen/index.rst
@@ -12,3 +12,4 @@ Inhalt:
    ogip
    feedbackforum-prozess
    ubersetzungen
+   multi-app-setup

--- a/docs/intern/kurzreferenzen/multi-app-setup.rst
+++ b/docs/intern/kurzreferenzen/multi-app-setup.rst
@@ -1,0 +1,7 @@
+Alternative Apps im neuen Frontend anzeigen
+===========================================
+Der ``@config``-Endpoint stellt im Attribut ``apps_url`` eine URL zum Abfragen von verfügbaren Applikationen zur Verfügung. Das Frontend führt einen GET request auf die URL aus und zeigt die zurückgegebenen Applikationen im App-Switcher an.
+
+Die ``apps_url`` kann über eine Umgebungsvariable gesetzt werden:
+
+``export APPS_ENDPOINT_URL=htt://example.com/portal/api/apps``

--- a/opengever/base/configuration.py
+++ b/opengever/base/configuration.py
@@ -35,6 +35,7 @@ from plone import api
 from zope.component import adapter
 from zope.interface import implementer
 from zope.interface import Interface
+import os
 
 
 @implementer(IGeverSettings)
@@ -54,6 +55,7 @@ class GeverSettingsAdpaterV1(object):
             config['features'] = self.get_features()
         config['root_url'] = api.portal.get().absolute_url()
         config['cas_url'] = get_cas_server_url()
+        config['apps_url'] = os.environ.get('APPS_ENDPOINT_URL')
         return config
 
     def get_info(self):


### PR DESCRIPTION
This PR extends the `@config` endpoint with an `apps_url` attribute.

This URL is required for the GEVER-UI to fetch a list of Applications for the `AppSwitcher` compoment. See https://github.com/4teamwork/gever-ui/pull/1005

Issuer: https://github.com/4teamwork/gever-ui/issues/834

## Checkliste

_Zutreffendes soll angehakt stehengelassen werden._

- [x] Changelog-Eintrag vorhanden/nötig?
- [x] Aktualisierung Dokumentation vorhanden/nötig?
