### PR TITLE
Rename Listing to ListingGet to follow naming conventions.

### DIFF
--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -280,7 +280,7 @@
   <plone:service
       method="GET"
       for="zope.interface.Interface"
-      factory=".listing.Listing"
+      factory=".listing.ListingGet"
       name="@listing"
       permission="zope2.View"
       />

--- a/opengever/api/listing.py
+++ b/opengever/api/listing.py
@@ -95,14 +95,14 @@ def with_active_solr_only(func):
     return validate
 
 
-class Listing(SolrQueryBaseService):
+class ListingGet(SolrQueryBaseService):
     """List of content items"""
 
     required_response_fields = REQUIRED_RESPONSE_FIELDS
     other_allowed_fields = OTHER_ALLOWED_FIELDS
 
     def __init__(self, context, request):
-        super(Listing, self).__init__(context, request)
+        super(ListingGet, self).__init__(context, request)
         self.allowed_fields = set(self.field_mapping.keys()) | self.other_allowed_fields
 
     def extract_query(self, params):


### PR DESCRIPTION
We have established the convention that api service classes should be postfixed with the http verb of the request they are handling. It has always annoyed me a bit that @listing with `Listing` does not follow that convention, as it is really useful for example when searching for the class in the editor via globals. so here is the rename to `ListingGet`  to calm down my nerves a bit :).

- [ ] ~~Changelog-Eintrag vorhanden/nötig?~~
