### PR TITLE
OfficeOnline: Use collaborative checkout / checkins

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2020.2.0rc2 (unreleased)
 ------------------------
 
+- OfficeOnline: Use collaborative checkout / checkins. [lgraf]
 - Add list workspaces action for new frontend. [njohner]
 - Add ogds user listing via @user-listing endpoint. [deiferni]
 - Add ogds team listing via @team-listing endpoint. [deiferni]

--- a/opengever/document/checkout/manager.py
+++ b/opengever/document/checkout/manager.py
@@ -13,6 +13,7 @@ from opengever.document.events import ObjectRevertedToVersion
 from opengever.document.interfaces import ICheckinCheckoutManager
 from opengever.document.versioner import Versioner
 from opengever.trash.trash import ITrashed
+from persistent.list import PersistentList
 from plone import api
 from plone.locking.interfaces import IRefreshableLockable
 from plone.namedfile.file import NamedBlobFile
@@ -25,6 +26,7 @@ from zope.publisher.interfaces.browser import IBrowserRequest
 
 
 CHECKIN_CHECKOUT_ANNOTATIONS_KEY = 'opengever.document.checked_out_by'
+COLLABORATORS_ANNOTATIONS_KEY = 'opengever.document.collaborators'
 
 
 @implementer(ICheckinCheckoutManager)
@@ -75,7 +77,7 @@ class CheckinCheckoutManager(object):
             and self.is_not_trashed()
             )
 
-    def checkout(self):
+    def checkout(self, collaborative=False):
         """Checkout the adapted document.
         """
         # is the user allowed to checkout?
@@ -86,6 +88,9 @@ class CheckinCheckoutManager(object):
         user_id = getSecurityManager().getUser().getId()
         self.annotations[CHECKIN_CHECKOUT_ANNOTATIONS_KEY] = user_id
 
+        if collaborative:
+            self.add_collaborator(user_id)
+
         # update last modified timestamp for recently modified menu
         self.context.setModificationDate()
 
@@ -95,6 +100,16 @@ class CheckinCheckoutManager(object):
         notify(ObjectCheckedOutEvent(self.context, ''))
         notify(ObjectTouchedEvent(self.context))
 
+    def add_collaborator(self, collaborator):
+        if COLLABORATORS_ANNOTATIONS_KEY not in self.annotations:
+            self.annotations[COLLABORATORS_ANNOTATIONS_KEY] = PersistentList()
+
+        if collaborator not in self.annotations[COLLABORATORS_ANNOTATIONS_KEY]:
+            self.annotations[COLLABORATORS_ANNOTATIONS_KEY].append(collaborator)
+
+    def get_collaborators(self):
+        return self.annotations.get(COLLABORATORS_ANNOTATIONS_KEY, [])
+
     def is_simple_checkin_allowed(self):
         return self.is_checkin_allowed() and not self.is_locked()
 
@@ -103,7 +118,22 @@ class CheckinCheckoutManager(object):
             return True
         return False
 
-    def is_checkin_allowed(self):
+    def is_collaborative_checkout(self):
+        """Whether this is a collaborative checkout or not.
+
+        Collaborative checkouts are currently intended to be used by the
+        Office Online WOPI view. They behave slightly differently
+        than regular checkouts:
+
+        - For collaborative checkouts, collaborators are tracked
+        - They may only be checked in with checkin(collaborative=True)
+          (Except force checkin)
+        - Any of the collaborators may check in a collaborative checkout,
+          not just the user that initially checked out the document.
+        """
+        return bool(self.get_collaborators())
+
+    def is_checkin_allowed(self, collaborative=False):
         """Checks whether checkin is allowed for the current user on the
         adapted document.
         """
@@ -127,23 +157,33 @@ class CheckinCheckoutManager(object):
         if not self.check_permission('opengever.document: Checkin'):
             return False
 
-        # is the user the one who owns the checkout
+        if self.is_collaborative_checkout() and not collaborative:
+            # If collaboratively checked out, only checkin(collaborative=True)
+            # is allowed (via the WOPI View for now)
+            return False
+
         current_user_id = getSecurityManager().getUser().getId()
+
+        if collaborative:
+            # For collaborative checkouts, any of the collaborators are
+            # allowed to check in
+            return current_user_id in self.get_collaborators()
 
         return self.get_checked_out_by() == current_user_id
 
-    def checkin(self, comment=''):
+    def checkin(self, comment='', collaborative=False):
         """Checkin the adapted document, using the `comment` for the
         journal entry.
         """
         notify(ObjectBeforeCheckInEvent(self.context))
 
         # is the user allowed to checkin?
-        if not self.is_checkin_allowed():
+        if not self.is_checkin_allowed(collaborative=collaborative):
             raise Unauthorized
 
         # remember that we checked in
         self.annotations[CHECKIN_CHECKOUT_ANNOTATIONS_KEY] = None
+        self.annotations.pop(COLLABORATORS_ANNOTATIONS_KEY, None)
 
         # Clear any WebDAV locks left over by ExternalEditor if necessary
         self.clear_locks()

--- a/opengever/document/locales/de/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/de/LC_MESSAGES/opengever.document.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2019-11-04 13:11+0000\n"
+"POT-Creation-Date: 2020-03-13 14:31+0000\n"
 "PO-Revision-Date: 2017-10-13 14:27+0200\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -190,11 +190,6 @@ msgstr "Sie haben weder eine Datei ausgewählt noch ist das Dokument in Papierfo
 #: ./opengever/document/document.py
 msgid "error_mail_upload"
 msgstr "Es ist nicht erlaubt hier E-Mails anzufügen. Bitte senden Sie das E-Mail an die Addresse ${mailaddress} oder ziehen Sie es in das Dossier (Drag'n'Drop)."
-
-#. Default: "It's not possible to add E-mails as document, use portal_type ftw.mail.mail."
-#: ./opengever/document/document.py
-msgid "error_mail_upload_api"
-msgstr "Es ist nicht erlaubt hier E-Mails anzufügen. Verwenden Sie den Typ ftw.mail.mail."
 
 #. Default: "You have not selected any Items"
 #: ./opengever/document/browser/report.py
@@ -444,6 +439,11 @@ msgstr "Digital verfügbar"
 #: ./opengever/document/browser/report.py
 msgid "label_document_checked_out_by"
 msgstr "In Bearbeitung"
+
+#. Default: "Collaborators: ${collaborators}"
+#: ./opengever/document/checkout/manager.py
+msgid "label_document_collaborators"
+msgstr "Bearbeitet durch: ${collaborators}"
 
 #. Default: "Document Date"
 #: ./opengever/document/behaviors/metadata.py

--- a/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-11-04 13:11+0000\n"
+"POT-Creation-Date: 2020-03-13 14:31+0000\n"
 "PO-Revision-Date: 2017-09-03 08:50+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-document/fr/>\n"
@@ -192,11 +192,6 @@ msgstr "Vous n'avez pas sélectionné un fichier ni conservé un document en ver
 #: ./opengever/document/document.py
 msgid "error_mail_upload"
 msgstr "Il n'est pas possible d'insérer des Email à cet endroit. Pour le faire, utilisez l'adresse E-Mail ${mailaddress}  ou glissez-le dans le dossier (Drag'n'Drop)."
-
-#. Default: "It's not possible to add E-mails as document, use portal_type ftw.mail.mail."
-#: ./opengever/document/document.py
-msgid "error_mail_upload_api"
-msgstr "Il n'est pas possible d'ajouter un E-mail en tant que document, ajoutez-le en tant que ftw.mail.mail."
 
 #. Default: "You have not selected any Items"
 #: ./opengever/document/browser/report.py
@@ -441,6 +436,11 @@ msgstr "Disponble sous forme numérique"
 #: ./opengever/document/browser/report.py
 msgid "label_document_checked_out_by"
 msgstr "En cours de traitement"
+
+#. Default: "Collaborators: ${collaborators}"
+#: ./opengever/document/checkout/manager.py
+msgid "label_document_collaborators"
+msgstr "Edité par: ${collaborators}"
 
 #. Default: "Document Date"
 #: ./opengever/document/behaviors/metadata.py

--- a/opengever/document/locales/opengever.document.pot
+++ b/opengever/document/locales/opengever.document.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-11-04 13:11+0000\n"
+"POT-Creation-Date: 2020-03-13 14:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -191,11 +191,6 @@ msgstr ""
 #. Default: "It's not possible to add E-mails here, please send it to ${mailaddress} or drag it to the dossier (Dragn'n'Drop)."
 #: ./opengever/document/document.py
 msgid "error_mail_upload"
-msgstr ""
-
-#. Default: "It's not possible to add E-mails as document, use portal_type ftw.mail.mail."
-#: ./opengever/document/document.py
-msgid "error_mail_upload_api"
 msgstr ""
 
 #. Default: "You have not selected any Items"
@@ -440,6 +435,11 @@ msgstr ""
 
 #: ./opengever/document/browser/report.py
 msgid "label_document_checked_out_by"
+msgstr ""
+
+#. Default: "Collaborators: ${collaborators}"
+#: ./opengever/document/checkout/manager.py
+msgid "label_document_collaborators"
 msgstr ""
 
 #. Default: "Document Date"

--- a/opengever/wopi/browser/wopi.py
+++ b/opengever/wopi/browser/wopi.py
@@ -12,11 +12,13 @@ from plone.app.uuid.utils import uuidToObject
 from plone.namedfile.file import NamedBlobFile
 from plone.namedfile.utils import set_headers
 from plone.namedfile.utils import stream_data
+from plone.protect.interfaces import IDisableCSRFProtection
 from Products.Five.browser import BrowserView
 from zExceptions import NotFound as zNotFound
 from ZODB.utils import u64
 from zope.component import getMultiAdapter
 from zope.component import queryMultiAdapter
+from zope.interface import alsoProvides
 from zope.interface import implementer
 from zope.publisher.interfaces import IPublishTraverse
 from zope.publisher.interfaces import NotFound
@@ -100,6 +102,9 @@ class WOPIView(BrowserView):
 
         operation_name = ''.join([o.title() for o in operation.split('_')])
         logger.debug('WOPI Operation: %s', operation_name)
+
+        # Disable CSRF protection - WOPI client can't supply a CSRF token
+        alsoProvides(self.request, IDisableCSRFProtection)
 
         method = getattr(self, operation)
         with api.env.adopt_user(username=userid):


### PR DESCRIPTION
This introduces the concept of **collaborative checkouts** and applies it to the **OfficeOnline** (WOPI) integration.

> ℹ️  This branch is currently deployed to https://lab.onegovgever.ch/ for easier review 

With this change,
- Documents may be checked in collaborators other than the user that initially checked out the document (_addresses #6229_)
- Collaborators are written to version and journal comment on checkin (_addresses #6230_)

**Caveat**
- The version and journal comments get written as a fixed-language string (in the site's default language at the time of checkin). 

## Checkliste

- [x] Gibt es neue Übersetzungen?
  - [x] Sind alle msg-Strings in Übersetzungen Unicode?
  - [x] Wird die richtige i18n-domain verwendet (Copy-Paste Fehler sind hier häufig)?
- [x] Changelog-Eintrag vorhanden/nötig?
