### PR TITLE
Add cloud.onegovgever.ch to smoketests.

### DIFF
--- a/rewrite_rule_smoketests/config.py
+++ b/rewrite_rule_smoketests/config.py
@@ -75,4 +75,13 @@ CLUSTERS_TO_TEST = [
         gever_ui_is_default=True,
     ),
 
+    Cluster(
+        'https://cloud.onegovgever.ch',
+        admin_units=[
+            AdminUnit('bg', is_dedicated_teamraum=False),
+        ],
+        new_portal=False,
+        gever_ui_is_default=False,
+        url_contains_site_id=True,
+    ),
 ]

--- a/rewrite_rule_smoketests/config_entities.py
+++ b/rewrite_rule_smoketests/config_entities.py
@@ -32,7 +32,7 @@ class AdminUnit(object):
     def url(self):
         """The AdminUnit's URL.
         """
-        if self.cluster.single_unit_setup:
+        if not self.cluster.url_contains_site_id:
             # https://lab.onegovgever.ch
             return self.cluster.url
 
@@ -51,11 +51,12 @@ class Cluster(object):
     """
 
     def __init__(self, url, new_portal=False, gever_ui_is_default=False,
-                 admin_units=None):
+                 admin_units=None, url_contains_site_id=None):
         self.url = url
         self.new_portal = new_portal
         self.gever_ui_is_default = gever_ui_is_default
         self.admin_units = admin_units
+        self._url_contains_site_id = url_contains_site_id
 
         # Link admin units to their containing cluster
         for admin_unit in self.admin_units:
@@ -80,6 +81,17 @@ class Cluster(object):
         """Whether this cluster is single-unit setup or not.
         """
         return len(self.admin_units) == 1
+
+    @property
+    def url_contains_site_id(self):
+        """Whether the admin_unit urls contain the site id or not.
+        This is always the case for multi-unit setups, and normally not
+        for single-unit setups
+        """
+        if self._url_contains_site_id is None:
+            return not self.single_unit_setup
+        else:
+            return self._url_contains_site_id
 
     @property
     def portal_url(self):

--- a/rewrite_rule_smoketests/smoketests.py
+++ b/rewrite_rule_smoketests/smoketests.py
@@ -42,7 +42,7 @@ def test_canonical_https_redirect(browser, entity):
     # In single unit setups canonical HTTPS redirect adds a trailing
     # slash to the admin unit URL, otherwise it doesn't
     if isinstance(entity, AdminUnit):
-        if entity.cluster.single_unit_setup:
+        if not entity.cluster.url_contains_site_id:
             expect_trailing_slash = True
 
     parsed = urlparse(entity.url)


### PR DESCRIPTION
We want to activate the new frontend for `cloud.onegovgever.ch`. I activated solr and the new UI, but it doesn't work. We probably have a problem with the rewrite rules. So we add `cloud.onegovgever.ch` to the smoketests. This is a bit of a special case, as it is a single unit installation but we have the plone site ID in the URL. I had to add support for that in the smoketests config.

## Checkliste
- [ ] Changelog-Eintrag vorhanden/nötig? No CL for this
