### PR TITLE
OfficeOnline: Show specific message for collaborative checkouts.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2020.2.0rc2 (unreleased)
 ------------------------
 
+- OfficeOnline: Show specific message for collaborative checkouts. [lgraf]
 - Extend the document serialization with `checked_out_fullname`. [elioschmutz]
 - Add a new profile to setup a cas auth plugin for the ianus portal. [elioschmutz]
 - Fix encoding issue in query-source `query` parameter. [deiferni]

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 ------------------------
 
 - OfficeOnline: Show specific message for collaborative checkouts. [lgraf]
+- Document GET API: Also include info about collaborative checkouts. [lgraf]
 - Extend the document serialization with `checked_out_fullname`. [elioschmutz]
 - Add a new profile to setup a cas auth plugin for the ianus portal. [elioschmutz]
 - Fix encoding issue in query-source `query` parameter. [deiferni]

--- a/opengever/api/document.py
+++ b/opengever/api/document.py
@@ -41,6 +41,7 @@ class SerializeDocumentToJson(GeverSerializeToJson):
         additional_metadata = {
             'checked_out': checked_out_by,
             'checked_out_fullname': checked_out_by_fullname,
+            'is_collaborative_checkout': obj.is_collaborative_checkout(),
             'is_locked': obj.is_locked(),
             'containing_dossier': obj.containing_dossier_title(),
             'containing_subdossier': obj.containing_subdossier_title(),

--- a/opengever/api/tests/test_document.py
+++ b/opengever/api/tests/test_document.py
@@ -63,6 +63,7 @@ class TestDocumentSerializer(IntegrationTestCase):
 
         self.assertEqual(self.regular_user.id, browser.json['checked_out'])
         self.assertEqual(u'B\xe4rfuss K\xe4thi', browser.json['checked_out_fullname'])
+        self.assertFalse(browser.json['is_collaborative_checkout'])
         self.assertFalse(browser.json['is_locked'])
         self.assertEqual(u'Vertr\xe4ge mit der kantonalen Finanzverwaltung',
                          browser.json['containing_dossier'])
@@ -70,6 +71,15 @@ class TestDocumentSerializer(IntegrationTestCase):
         self.assertFalse(browser.json['trashed'])
         self.assertFalse(browser.json['is_shadow_document'])
         self.assertFalse(0, browser.json['current_version_id'])
+
+    @browsing
+    def test_contains_collaborative_checkout_info(self, browser):
+        self.login(self.regular_user, browser)
+
+        self.checkout_document(self.subdocument, collaborative=True)
+
+        browser.open(self.subdocument, headers={'Accept': 'application/json'})
+        self.assertTrue(browser.json['is_collaborative_checkout'])
 
     @browsing
     def test_additional_metadata_for_mails(self, browser):

--- a/opengever/document/checkout/templates/checkedoutviewlet.pt
+++ b/opengever/document/checkout/templates/checkedoutviewlet.pt
@@ -4,8 +4,14 @@
 
     <dt i18n:translate="label_checked_out">Checked out</dt>
     <dd>
-        <tal:block i18n:translate="message_checkout_info">
+        <tal:block tal:condition="not:view/is_collaborative_checkout" i18n:translate="message_checkout_info">
             This item is being checked out by
+            <a i18n:name="creator"
+               tal:replace="structure view/checkout_by_link" />.
+        </tal:block>
+
+        <tal:block tal:condition="view/is_collaborative_checkout" i18n:translate="message_collaborative_checkout_info">
+            This item is being edited in Office Online by 
             <a i18n:name="creator"
                tal:replace="structure view/checkout_by_link" />.
         </tal:block>

--- a/opengever/document/checkout/viewlets.py
+++ b/opengever/document/checkout/viewlets.py
@@ -27,3 +27,5 @@ class CheckedOutViewlet(ViewletBase):
 
             self.checkout_by_link = Actor.user(
                 manager.get_checked_out_by()).get_link()
+
+            self.is_collaborative_checkout = manager.is_collaborative_checkout()

--- a/opengever/document/document.py
+++ b/opengever/document/document.py
@@ -295,6 +295,11 @@ class Document(Item, BaseDocumentMixin):
                                   ICheckinCheckoutManager)
         return manager.get_checked_out_by()
 
+    def is_collaborative_checkout(self):
+        manager = getMultiAdapter((self, self.REQUEST),
+                                  ICheckinCheckoutManager)
+        return manager.is_collaborative_checkout()
+
     def is_office_online_editable(self):
         filename = self.get_filename()
         if filename is None:

--- a/opengever/document/locales/de/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/de/LC_MESSAGES/opengever.document.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2020-03-13 14:31+0000\n"
+"POT-Creation-Date: 2020-03-17 15:18+0000\n"
 "PO-Revision-Date: 2017-10-13 14:27+0200\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -644,6 +644,11 @@ msgstr "Ja"
 #: ./opengever/document/checkout/templates/checkedoutviewlet.pt
 msgid "message_checkout_info"
 msgstr "Dieses Dokument wurde von ${creator} ausgecheckt."
+
+#. Default: "This item is being edited in Office Online by ${creator}."
+#: ./opengever/document/checkout/templates/checkedoutviewlet.pt
+msgid "message_collaborative_checkout_info"
+msgstr "Dieses Dokument wird von ${creator} gerade in Office Online bearbeitet."
 
 #. Default: "Could not cancel checkout on document ${title}, mails does not support the checkin checkout process."
 #: ./opengever/document/checkout/cancel.py

--- a/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2020-03-13 14:31+0000\n"
+"POT-Creation-Date: 2020-03-17 15:18+0000\n"
 "PO-Revision-Date: 2017-09-03 08:50+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-document/fr/>\n"
@@ -641,6 +641,11 @@ msgstr "Oui"
 #: ./opengever/document/checkout/templates/checkedoutviewlet.pt
 msgid "message_checkout_info"
 msgstr "${creator} a fait un checkout de ce document."
+
+#. Default: "This item is being edited in Office Online by ${creator}."
+#: ./opengever/document/checkout/templates/checkedoutviewlet.pt
+msgid "message_collaborative_checkout_info"
+msgstr ""
 
 #. Default: "Could not cancel checkout on document ${title}, mails does not support the checkin checkout process."
 #: ./opengever/document/checkout/cancel.py

--- a/opengever/document/locales/opengever.document.pot
+++ b/opengever/document/locales/opengever.document.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2020-03-13 14:31+0000\n"
+"POT-Creation-Date: 2020-03-17 15:18+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -640,6 +640,11 @@ msgstr ""
 #. Default: "This item is being checked out by ${creator}."
 #: ./opengever/document/checkout/templates/checkedoutviewlet.pt
 msgid "message_checkout_info"
+msgstr ""
+
+#. Default: "This item is being edited in Office Online by ${creator}."
+#: ./opengever/document/checkout/templates/checkedoutviewlet.pt
+msgid "message_collaborative_checkout_info"
 msgstr ""
 
 #. Default: "Could not cancel checkout on document ${title}, mails does not support the checkin checkout process."

--- a/opengever/document/tests/test_checkout_viewlet.py
+++ b/opengever/document/tests/test_checkout_viewlet.py
@@ -1,31 +1,31 @@
-from ftw.builder import Builder
-from ftw.builder import create
 from ftw.testbrowser import browsing
-from opengever.testing import FunctionalTestCase
+from opengever.document.interfaces import ICheckinCheckoutManager
+from opengever.testing import IntegrationTestCase
+from zope.component import getMultiAdapter
 
 
-class TestCheckedOutViewlet(FunctionalTestCase):
+class TestCheckedOutViewlet(IntegrationTestCase):
 
     @browsing
     def test_viewlet_show_msg_when_document_is_checked_out(self, browser):
-        document = create(Builder('document')
-                          .titled(u'TestDocument')
-                          .checked_out())
+        self.login(self.regular_user, browser)
 
-        browser.login().open(document)
+        manager = getMultiAdapter((self.document, self.portal.REQUEST),
+                                  ICheckinCheckoutManager)
+        manager.checkout()
+        browser.open(self.document)
 
         message = browser.css('dl.checked_out_viewlet dd').first
         link = browser.css('dl.checked_out_viewlet a').first
 
-        self.assertEqual('This item is being checked out by Test User (test_user_1_).',
+        self.assertEqual(u'This item is being checked out by B\xe4rfuss K\xe4thi (kathi.barfuss).',
                          message.text)
-        self.assertEqual('http://nohost/plone/@@user-details/test_user_1_',
+        self.assertEqual('http://nohost/plone/@@user-details/kathi.barfuss',
                          link.get('href'))
 
     @browsing
     def test_viewlet_is_disabled_when_document_is_not_checked_out(self, browser):
-        document = create(Builder('document').titled(u'TestDocument'))
-        browser.login().open(document)
+        self.login(self.regular_user, browser)
 
-        self.assertEqual([],
-                         browser.css('dl.checked_out_viewlet'))
+        browser.open(self.document)
+        self.assertEqual([], browser.css('dl.checked_out_viewlet'))

--- a/opengever/document/tests/test_checkout_viewlet.py
+++ b/opengever/document/tests/test_checkout_viewlet.py
@@ -24,6 +24,23 @@ class TestCheckedOutViewlet(IntegrationTestCase):
                          link.get('href'))
 
     @browsing
+    def test_viewlet_shows_msg_for_collaborative_checkout(self, browser):
+        self.login(self.regular_user, browser)
+
+        manager = getMultiAdapter((self.document, self.portal.REQUEST),
+                                  ICheckinCheckoutManager)
+        manager.checkout(collaborative=True)
+        browser.open(self.document)
+
+        message = browser.css('dl.checked_out_viewlet dd').first
+        link = browser.css('dl.checked_out_viewlet a').first
+
+        self.assertEqual(u'This item is being edited in Office Online by B\xe4rfuss K\xe4thi (kathi.barfuss).',
+                         message.text)
+        self.assertEqual('http://nohost/plone/@@user-details/kathi.barfuss',
+                         link.get('href'))
+
+    @browsing
     def test_viewlet_is_disabled_when_document_is_not_checked_out(self, browser):
         self.login(self.regular_user, browser)
 

--- a/opengever/mail/mail.py
+++ b/opengever/mail/mail.py
@@ -324,6 +324,11 @@ class OGMail(Mail, BaseDocumentMixin):
         """
         return False
 
+    def is_collaborative_checkout(self):
+        """Mail does not support checkin/checkout.
+        """
+        return False
+
     def is_checkout_and_edit_available(self):
         """Mail does not support checkin/checkout.
         """

--- a/opengever/testing/integration_test_case.py
+++ b/opengever/testing/integration_test_case.py
@@ -537,10 +537,10 @@ class IntegrationTestCase(TestCase):
         self.set_related_items(obj, [related_obj], fieldname=fieldname,
                                append=True)
 
-    def checkout_document(self, document):
+    def checkout_document(self, document, collaborative=False):
         """Checkout the given document.
         """
-        return self.get_checkout_manager(document).checkout()
+        return self.get_checkout_manager(document).checkout(collaborative=collaborative)
 
     def checkin_document(self, document):
         """Checkin the given document.


### PR DESCRIPTION
This displays a different "currently checked out" message for documents that are collaboratively checked out, meaning they're being edited in OfficeOnline.

> ℹ️  **Note**: This branch is deployed on https://lab.onegovgever.ch/ for easier review

---

![Screenshot 2020-03-17 at 17 36 52](https://user-images.githubusercontent.com/405124/76879074-05259480-6876-11ea-8867-abe5d8893ce9.png)

---

I also added the `is_collaborative_checkout` additional metadata to the API `GET` response for documents, so the frontend can do the same distinction for that message. This could possibly already be used in 4teamwork/gever-ui#982

Part of #6319 

## Checkliste

- [x] Gibt es neue Funktionalität mit einem `Dokument`? Funktioniert das auch mit einem `Mail`?
  Nein - soll es nicht.
- [x] Gibt es neue Übersetzungen?
  - [x] Sind alle msg-Strings in Übersetzungen Unicode?
  - [x] Wird die richtige i18n-domain verwendet (Copy-Paste Fehler sind hier häufig)?
- [x] Changelog-Eintrag vorhanden/nötig?
