### PR TITLE
Add a new profile to setup a cas auth plugin for the new portal

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2020.2.0rc2 (unreleased)
 ------------------------
 
+- Add a new profile to setup a cas auth plugin for the ianus portal. [elioschmutz]
 - OfficeOnline: Use collaborative checkout / checkins. [lgraf]
 - Add list workspaces action for new frontend. [njohner]
 - Add additional fields to @user-listing endpoint. [njohner]

--- a/opengever/base/casauth.py
+++ b/opengever/base/casauth.py
@@ -53,11 +53,11 @@ def get_cas_server_url():
     return url
 
 
-def build_cas_server_url():
+def build_cas_server_url(cas_path):
     """Build the URL to the CAS server, based on the GEVER cluster URL.
 
     This URL should only be constructed once during setup, in order to
     initially configure the ftw.casauth plugin.
     """
     base_url = get_cluster_base_url()
-    return urljoin(base_url, 'portal')
+    return urljoin(base_url, cas_path)

--- a/opengever/base/tests/test_casauth.py
+++ b/opengever/base/tests/test_casauth.py
@@ -37,7 +37,7 @@ class TestClusterBaseURL(IntegrationTestCase):
             'http://dev.example.com/', get_cluster_base_url())
 
 
-class TestCASServerURL(IntegrationTestCase):
+class TestCASServerURLForGeverPortal(IntegrationTestCase):
 
     def test_cas_plugin_server_url_is_based_on_public_url(self):
         get_current_admin_unit().public_url = 'http://example.com/foobar'
@@ -59,6 +59,16 @@ class TestCASServerURL(IntegrationTestCase):
 
     def test_cas_server_url_is_none_if_cas_plugin_is_missing(self):
         self.assertEquals(None, get_cas_server_url())
+
+
+class TestCASServerURLForIanusPortal(IntegrationTestCase):
+
+    def test_cas_plugin_server_url_is_based_on_public_url(self):
+        get_current_admin_unit().public_url = 'http://example.com/foobar'
+        applyProfile(self.layer['portal'], 'opengever.setup:casauth_ianus_portal')
+        cas_plugin = self.portal.acl_users.cas_auth
+        self.assertEquals(
+            'http://example.com/foobar/portal/cas', cas_plugin.cas_server_url)
 
 
 class TestGEVERPortalURL(IntegrationTestCase):

--- a/opengever/base/tests/test_logout.py
+++ b/opengever/base/tests/test_logout.py
@@ -18,7 +18,7 @@ class TestLogoutWithCASAuth(IntegrationTestCase):
 
     def setUp(self):
         super(TestLogoutWithCASAuth, self).setUp()
-        install_cas_auth_plugin()
+        install_cas_auth_plugin('portal')
 
     def tearDown(self):
         super(TestLogoutWithCASAuth, self).tearDown()

--- a/opengever/setup/casauth.py
+++ b/opengever/setup/casauth.py
@@ -7,21 +7,29 @@ from Products.PluggableAuthService.interfaces.plugins import IChallengePlugin
 SESSION_DEFAULT_TIMEOUT = 24 * 60 * 60
 
 
-def setup_cas(site):
+def setup_cas_gever_portal(site):
+    setup_cas(site, cas_path='portal')
+
+
+def setup_cas_ianus_portal(site):
+    setup_cas(site, cas_path='portal/cas')
+
+
+def setup_cas(site, cas_path):
     """Install and configure CAS authentication plugin.
        Rename session cookie to avoid conflicts with multiple clients.
     """
-    install_cas_auth_plugin()
+    install_cas_auth_plugin(cas_path)
     rename_session_cookie(site)
 
 
-def install_cas_auth_plugin():
+def install_cas_auth_plugin(cas_path):
     acl_users = api.portal.get_tool('acl_users')
 
     if 'cas_auth' not in acl_users.objectIds():
         # Build the URL for the CAS server once during initial setup and
         # configure it for the plugin.
-        cas_server_url = build_cas_server_url()
+        cas_server_url = build_cas_server_url(cas_path)
 
         plugin = CASAuthenticationPlugin(
             'cas_auth', cas_server_url=cas_server_url)

--- a/opengever/setup/profiles.zcml
+++ b/opengever/setup/profiles.zcml
@@ -39,7 +39,20 @@
 
   <profilehook:hook
       profile="opengever.setup:casauth"
-      handler=".casauth.setup_cas"
+      handler=".casauth.setup_cas_gever_portal"
+      />
+
+  <genericsetup:registerProfile
+      name="casauth_ianus_portal"
+      title="opengever.setup: casauth ianus portal"
+      directory="profiles/casauth_ianus_portal"
+      description="Sets up the cas authentication plugin for the ianus portal."
+      provides="Products.GenericSetup.interfaces.EXTENSION"
+      />
+
+  <profilehook:hook
+      profile="opengever.setup:casauth_ianus_portal"
+      handler=".casauth.setup_cas_ianus_portal"
       />
 
 </configure>

--- a/opengever/setup/profiles/casauth_ianus_portal/actions.xml
+++ b/opengever/setup/profiles/casauth_ianus_portal/actions.xml
@@ -1,0 +1,18 @@
+<object xmlns:i18n="http://xml.zope.org/namespaces/i18n" name="portal_actions" meta_type="Plone Actions Tool">
+
+  <object name="user" meta_type="CMF Action Category">
+    <object name="my-portal" meta_type="CMF Action" i18n:domain="opengever.setup" insert-before="logout">
+      <property name="title" i18n:translate="">My portal</property>
+      <property name="description" i18n:translate="" />
+      <property name="url_expr">string:${context/@@gever_state/gever_portal_url}</property>
+      <property name="link_target" />
+      <property name="icon_expr" />
+      <property name="available_expr">python:member is not None</property>
+      <property name="permissions">
+        <element value="View" />
+      </property>
+      <property name="visible">True</property>
+    </object>
+
+  </object>
+</object>

--- a/opengever/setup/profiles/casauth_ianus_portal/metadata.xml
+++ b/opengever/setup/profiles/casauth_ianus_portal/metadata.xml
@@ -1,0 +1,3 @@
+<metadata>
+  <version>1</version>
+</metadata>


### PR DESCRIPTION
The new Ianus-Portal provides a differen CAS-Auth URL than the old portal. In the PR: https://github.com/4teamwork/opengever.core/pull/6296 I already tried to permanently use the new url. But that was declined because we still use the old portal for several new deployments.

The URL is part of the plugin and will be set during a profile-hook. If we want to use the new cas-url, we would have to manually adjust it after installation or have to create a new fake-profile in the deployment repositories which will be installed after the `casauth` profile to get an additional hook to reset the URL.

This PR adds a brand new profile `casauth_ianus_portal` which already sets the URL to the new endpoint. We can now just use this new profile instead the old `casauth` to get a deployment with the correct url.

## Checkliste

_Zutreffendes soll angehakt stehengelassen werden._

- [x] Profil angepasst? Sind UpgradeSteps vorhanden/nötig?:
- [x] Changelog-Eintrag vorhanden/nötig?
