### PR TITLE
Fix encoding issue in query-source `query` param.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 ------------------------
 
 - Add a new profile to setup a cas auth plugin for the ianus portal. [elioschmutz]
+- Fix encoding issue in query-source `query` parameter. [deiferni]
 - OfficeOnline: Use collaborative checkout / checkins. [lgraf]
 - Add list workspaces action for new frontend. [njohner]
 - Add additional fields to @user-listing endpoint. [njohner]

--- a/opengever/api/schema/querysources.py
+++ b/opengever/api/schema/querysources.py
@@ -5,6 +5,7 @@ from plone.dexterity.utils import iterSchemata
 from plone.dexterity.utils import iterSchemataForType
 from plone.restapi.batching import HypermediaBatch
 from plone.restapi.interfaces import ISerializeToJson
+from Products.CMFPlone.utils import safe_unicode
 from z3c.formwidget.query.interfaces import IQuerySource
 from zope.component import getMultiAdapter
 from zope.interface import alsoProvides
@@ -81,8 +82,7 @@ class GEVERQuerySourcesGet(GEVERSourcesGet):
                 u'the source using the ?query= QS parameter'
             )
 
-        query = self.request.form['query']
-
+        query = safe_unicode(self.request.form['query'])
         result = source.search(query)
 
         terms = []

--- a/opengever/api/tests/test_vocabularies.py
+++ b/opengever/api/tests/test_vocabularies.py
@@ -2,6 +2,7 @@ from ftw.testbrowser import browsing
 from opengever.base.behaviors.classification import IClassification
 from opengever.testing import IntegrationTestCase
 from plone import api
+from urllib import urlencode
 
 
 NON_SENSITIVE_VOCABUALRIES = [
@@ -304,6 +305,19 @@ class TestGetQuerySources(IntegrationTestCase):
         self.assertEqual(1, response.get('items_total'))
         self.assertItemsEqual([u'secret'],
                               [item['token'] for item in response.get('items')])
+
+    @browsing
+    def test_get_task_issuer_non_ascii_char_handling(self, browser):
+        self.login(self.regular_user, browser)
+        url = self.task.absolute_url() + '/@querysources/issuer?{}'.format(
+            urlencode({'query': u'k\xf6vin'.encode('utf-8')}))
+        response = browser.open(
+            url,
+            method='GET',
+            headers=self.api_headers,
+        ).json
+        self.assertEqual(url, response.get('@id'))
+        self.assertEqual(0, response.get('items_total'))
 
 
 class TestGetSources(IntegrationTestCase):


### PR DESCRIPTION
The query will be used for arbitrary queries containing non-ascii characters. We have to properly sanitize and convert the input query string parameter to unicode for app-internal handling.

@bierik stumbled upon this in https://github.com/4teamwork/gever-ui/issues/839, ironically while improving error handling.

- [x] Changelog-Eintrag vorhanden/nötig?
