### PR TITLE
Do no longer send activity mails from the current user.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -9,6 +9,7 @@ Changelog
 - Extend the document serialization with `checked_out_fullname`. [elioschmutz]
 - Add a new profile to setup a cas auth plugin for the ianus portal. [elioschmutz]
 - Fix encoding issue in query-source `query` parameter. [deiferni]
+- Do no longer send activity mails from the current user due to spam issues when the user's email address does not match the portal domain. [elioschmutz]
 - OfficeOnline: Use collaborative checkout / checkins. [lgraf]
 - Add list workspaces action for new frontend. [njohner]
 - Add additional fields to @user-listing endpoint. [njohner]

--- a/opengever/activity/mailer.py
+++ b/opengever/activity/mailer.py
@@ -85,14 +85,8 @@ class Mailer(object):
             data = {}
 
         msg = MIMEMultipart('related')
-        actor = ogds_service().fetch_user(from_userid) if from_userid else None
-
-        if actor:
-            msg['From'] = make_addr_header(actor.fullname(),
-                                           actor.email, 'utf-8')
-        else:
-            msg['From'] = make_addr_header(
-                self.default_addr_header, api.portal.get().email_from_address, 'utf-8')
+        msg['From'] = make_addr_header(
+            self.default_addr_header, api.portal.get().email_from_address, 'utf-8')
 
         if to_userid:
             to_email = ogds_service().fetch_user(to_userid).email

--- a/opengever/activity/tests/test_mail.py
+++ b/opengever/activity/tests/test_mail.py
@@ -142,7 +142,7 @@ class TestEmailNotification(IntegrationTestCase):
 
         mail = email.message_from_string(Mailing(self.portal).pop())
         self.assertEquals('foo@example.com', mail.get('To'))
-        self.assertEquals('Ziegler Robert <robert.ziegler@gever.local>', get_header(mail, 'From'))
+        self.assertEquals('OneGov GEVER <test@localhost>', get_header(mail, 'From'))
 
     @browsing
     def test_task_title_is_linked_to_resolve_notification_view(self, browser):

--- a/opengever/workspace/tests/test_invitation.py
+++ b/opengever/workspace/tests/test_invitation.py
@@ -73,7 +73,7 @@ class TestInvitationMail(IntegrationTestCase):
             self.assertEqual(1, len(mails))
             mail = email.message_from_string(mails[0])
 
-            self.assertIn(self.workspace_admin.getProperty('email'), mail.get("From"))
+            self.assertIn('test@localhost', mail.get("From"))
             self.assertEqual(self.regular_user.getProperty('email'), mail.get("To"))
 
             payload = {"iid": iid}


### PR DESCRIPTION
An activity mail should always be sent by the system itself and not under the users email address. It is possible that the user is registered by with a different email address than the portal domain. This will end up in spam issues.

Issuer: #6258  (https://github.com/4teamwork/opengever.core/issues/6258#issuecomment-600501160)

## Checkliste

- [x] Changelog-Eintrag vorhanden/nötig?
