### PR TITLE
Also return @id in globalindex endpoint.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 
 - OfficeOnline: Show specific message for collaborative checkouts. [lgraf]
 - Document GET API: Also include info about collaborative checkouts. [lgraf]
+- Also return @id in globalindex endpoint. [njohner]
 - Extend the document serialization with `checked_out_fullname`. [elioschmutz]
 - Add a new profile to setup a cas auth plugin for the ianus portal. [elioschmutz]
 - Fix encoding issue in query-source `query` parameter. [deiferni]

--- a/docs/public/dev-manual/api/globalindex.rst
+++ b/docs/public/dev-manual/api/globalindex.rst
@@ -18,7 +18,7 @@ Der globale, also über den ganzen Mandantenverbund verteilte, Aufgabenindex kan
     {
       "batching": null,
       "items": [
-        {
+        { "@id": "http://localhost:8080//ordnungssystem/dossier-23/document-123/task-1",
           "title": "re: Direkte Anfrage",
           "task_type": "direct-execution",
           "task_id": 14,

--- a/opengever/api/globalindex.py
+++ b/opengever/api/globalindex.py
@@ -17,7 +17,8 @@ class GlobalIndexGet(Service):
         'predecessor_id', 'containing_dossier']
 
     ADDITIONAL_METADATA = {
-        'responsible_fullname': lambda task: display_name(task.responsible)}
+        'responsible_fullname': lambda task: display_name(task.responsible),
+        '@id': lambda task: task.absolute_url()}
 
     def reply(self):
 

--- a/opengever/api/tests/test_globalindex.py
+++ b/opengever/api/tests/test_globalindex.py
@@ -13,7 +13,8 @@ class TestGlobalIndexGet(IntegrationTestCase):
         self.assertEqual(15, browser.json['items_total'])
         self.assertEqual(15, len(browser.json['items']))
         self.assertEqual(
-            {u'title': u're: Diskr\xe4te Dinge',
+            {u'@id': self.inbox_task.absolute_url(),
+             u'title': u're: Diskr\xe4te Dinge',
              u'task_type': u'direct-execution',
              u'containing_dossier': u'Vertr\xe4ge mit der kantonalen Finanzverwaltung',
              u'task_id': 14,


### PR DESCRIPTION
We update the `@globalindex` endpoint to also return the url to the tasks in the `@id` attribute.
This is needed so that the new frontend can link the tasks in the listing.

For https://github.com/4teamwork/gever-ui/issues/962

## Checkliste

_Zutreffendes soll angehakt stehengelassen werden._
- [x] Changelog-Eintrag vorhanden/nötig?
- [x] Aktualisierung Dokumentation vorhanden/nötig?
