### PR TITLE
Extend the document serialization with `checked_out_fullname`.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2020.2.0rc2 (unreleased)
 ------------------------
 
+- Extend the document serialization with `checked_out_fullname`. [elioschmutz]
 - Add a new profile to setup a cas auth plugin for the ianus portal. [elioschmutz]
 - Fix encoding issue in query-source `query` parameter. [deiferni]
 - OfficeOnline: Use collaborative checkout / checkins. [lgraf]

--- a/opengever/api/document.py
+++ b/opengever/api/document.py
@@ -1,10 +1,11 @@
 from ftw import bumblebee
+from opengever.api.serializer import GeverSerializeToJson
+from opengever.base.helpers import display_name
 from opengever.base.interfaces import IReferenceNumber
 from opengever.document.behaviors import IBaseDocument
 from opengever.document.interfaces import ICheckinCheckoutManager
 from plone.restapi.deserializer import json_body
 from plone.restapi.interfaces import ISerializeToJson
-from opengever.api.serializer import GeverSerializeToJson
 from plone.restapi.services.content.update import ContentPatch
 from zope.component import adapter
 from zope.component import getMultiAdapter
@@ -34,8 +35,12 @@ class SerializeDocumentToJson(GeverSerializeToJson):
             obj, 'pdf')
         result[u'file_extension'] = self.context.get_file_extension()
 
+        checked_out_by = obj.checked_out_by()
+        checked_out_by_fullname = display_name(checked_out_by) if checked_out_by else None
+
         additional_metadata = {
-            'checked_out': obj.checked_out_by(),
+            'checked_out': checked_out_by,
+            'checked_out_fullname': checked_out_by_fullname,
             'is_locked': obj.is_locked(),
             'containing_dossier': obj.containing_dossier_title(),
             'containing_subdossier': obj.containing_subdossier_title(),

--- a/opengever/api/tests/test_document.py
+++ b/opengever/api/tests/test_document.py
@@ -62,6 +62,7 @@ class TestDocumentSerializer(IntegrationTestCase):
         browser.open(self.subdocument, headers={'Accept': 'application/json'})
 
         self.assertEqual(self.regular_user.id, browser.json['checked_out'])
+        self.assertEqual(u'B\xe4rfuss K\xe4thi', browser.json['checked_out_fullname'])
         self.assertFalse(browser.json['is_locked'])
         self.assertEqual(u'Vertr\xe4ge mit der kantonalen Finanzverwaltung',
                          browser.json['containing_dossier'])
@@ -77,6 +78,7 @@ class TestDocumentSerializer(IntegrationTestCase):
         browser.open(self.mail_eml, headers={'Accept': 'application/json'})
 
         self.assertIsNone(browser.json['checked_out'])
+        self.assertIsNone(browser.json['checked_out_fullname'])
         self.assertFalse(browser.json['is_locked'])
         self.assertEqual(u'Vertr\xe4ge mit der kantonalen Finanzverwaltung',
                          browser.json['containing_dossier'])


### PR DESCRIPTION
This PR extends the document serialization with the `checked_out_fullname` property.

Issuer: https://github.com/4teamwork/gever-ui/issues/982

## Checkliste
- [x] Changelog-Eintrag vorhanden/nötig?
