### PR TITLE
Add 'Edit in Office Online' file action button in classic UI.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 
 - Do not allow to choose inbox of hidden OrgUnit as responsible in forwardings. [njohner]
 - Change container title format in task activities. [njohner]
+- Disable OfficeOnline action on docs in resolved or inactive dossiers. [lgraf]
 - Add hidden flag to OrgUnits and AdminUnits. [njohner]
 - Disallow choosing hidden orgunits as responsible_client in tasks and forwardings. [njohner]
 - Do not display hidden orgunits in orgunit selector. [njohner]

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -9,6 +9,7 @@ Changelog
 - Add hidden flag to OrgUnits and AdminUnits. [njohner]
 - Disallow choosing hidden orgunits as responsible_client in tasks and forwardings. [njohner]
 - Do not display hidden orgunits in orgunit selector. [njohner]
+- Disable regular checkout and edit actions for documents currently being edited in Office Online. [lgraf]
 - Add 'Edit in Office Online' file action button in classic UI. [lgraf]
 - OfficeOnline: Show specific message for collaborative checkouts. [lgraf]
 - Document GET API: Also include info about collaborative checkouts. [lgraf]

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -9,6 +9,7 @@ Changelog
 - Add hidden flag to OrgUnits and AdminUnits. [njohner]
 - Disallow choosing hidden orgunits as responsible_client in tasks and forwardings. [njohner]
 - Do not display hidden orgunits in orgunit selector. [njohner]
+- Add 'Edit in Office Online' file action button in classic UI. [lgraf]
 - OfficeOnline: Show specific message for collaborative checkouts. [lgraf]
 - Document GET API: Also include info about collaborative checkouts. [lgraf]
 - Also return @id in globalindex endpoint. [njohner]

--- a/opengever/document/browser/actionbuttons.py
+++ b/opengever/document/browser/actionbuttons.py
@@ -101,6 +101,9 @@ class VisibleActionButtonRendererMixin(FileActionAvailabilityMixin):
         url = "{}/@@checkout_documents".format(self.context.absolute_url())
         return addTokenToUrl(url)
 
+    def get_office_online_edit_url(self):
+        return u'{}/office_online_edit'.format(self.context.absolute_url())
+
     def get_open_as_pdf_url(self):
         if not self.is_open_as_pdf_action_available():
             return None

--- a/opengever/document/browser/templates/macros.pt
+++ b/opengever/document/browser/templates/macros.pt
@@ -85,6 +85,14 @@
             </span>
         </tal:checkout_and_edit_discreet>
 
+        <tal:edit_in_office_online tal:condition="view/is_office_online_edit_action_available">
+            <a class="function-edit"
+                tal:attributes="href view/get_office_online_edit_url"
+                i18n:translate="label_edit_in_office_online">
+                Edit in Office Online
+            </a>
+        </tal:edit_in_office_online>
+
         <tal:checkin_without_comment tal:condition="view/is_checkin_without_comment_available">
           <a class="function-checkin"
               tal:attributes="href view/get_checkin_without_comment_url"

--- a/opengever/document/document.py
+++ b/opengever/document/document.py
@@ -344,6 +344,11 @@ class Document(Item, BaseDocumentMixin):
             (self, self.REQUEST), ICheckinCheckoutManager)
         return manager.is_locked()
 
+    def is_checkout_permitted(self):
+        manager = queryMultiAdapter(
+            (self, self.REQUEST), ICheckinCheckoutManager)
+        return manager.is_checkout_permitted()
+
     def is_shadow_document(self):
         return api.content.get_state(self) == self.shadow_state
 

--- a/opengever/document/document.py
+++ b/opengever/document/document.py
@@ -321,6 +321,11 @@ class Document(Item, BaseDocumentMixin):
             (self, getRequest()), ICheckinCheckoutManager)
 
         if manager.get_checked_out_by():
+            if manager.is_collaborative_checkout():
+                # Collaborative checkouts should never be mixed with regular
+                # checkouts / OfficeConnector editing
+                return False
+
             if manager.get_checked_out_by() == \
                     getSecurityManager().getUser().getId():
                 return True

--- a/opengever/document/fileactions.py
+++ b/opengever/document/fileactions.py
@@ -146,6 +146,7 @@ class DocumentFileActions(BaseDocumentFileActions):
 
     def is_office_online_edit_action_available(self):
         return (is_wopi_feature_enabled()
+                and self.context.is_checkout_permitted()
                 and self.context.is_office_online_editable()
                 and self._can_edit_with_office_online())
 

--- a/opengever/document/locales/de/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/de/LC_MESSAGES/opengever.document.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2020-03-17 15:18+0000\n"
+"POT-Creation-Date: 2020-03-22 12:27+0000\n"
 "PO-Revision-Date: 2017-10-13 14:27+0200\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -289,7 +289,9 @@ msgstr "Referenz auf das entsprechende Dossier des Absenders"
 
 #: ./opengever/document/behaviors/metadata.py
 msgid "help_keywords"
-msgstr "Schlagwörter zur Umschreibung eines Dokuments. Nicht zu verwechseln mit der Ordnungsposition.\nACHTUNG: Beachten Sie bei der Verwendung von Schlagwörter die Datenschutzvorgaben (z.B. keine Eigennamen)."
+msgstr ""
+"Schlagwörter zur Umschreibung eines Dokuments. Nicht zu verwechseln mit der Ordnungsposition.\n"
+"ACHTUNG: Beachten Sie bei der Verwendung von Schlagwörter die Datenschutzvorgaben (z.B. keine Eigennamen)."
 
 #. Default: ""
 #: ./opengever/document/behaviors/metadata.py
@@ -491,6 +493,11 @@ msgstr "Kopie herunterladen"
 #: ./opengever/document/browser/templates/macros.pt
 msgid "label_edit"
 msgstr "Erneut Bearbeiten"
+
+#. Default: "Edit in Office Online"
+#: ./opengever/document/browser/templates/macros.pt
+msgid "label_edit_in_office_online"
+msgstr "In Office Online bearbeiten"
 
 #. Default: "Error"
 #: ./opengever/document/browser/save_pdf_document_under.py

--- a/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2020-03-17 15:18+0000\n"
+"POT-Creation-Date: 2020-03-22 12:27+0000\n"
 "PO-Revision-Date: 2017-09-03 08:50+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-document/fr/>\n"
@@ -288,7 +288,9 @@ msgstr "Référence sur le dossier correspondant de l'expéditeur"
 
 #: ./opengever/document/behaviors/metadata.py
 msgid "help_keywords"
-msgstr "Mots-clés pour la description du document. Ne pas confondre avec le numéro de classement.\nATTENTION: Veuillez vous conformer aux directives de Protection des Données lors de l'utilisation de Mots-clés (par ex. pas de noms propres)."
+msgstr ""
+"Mots-clés pour la description du document. Ne pas confondre avec le numéro de classement.\n"
+"ATTENTION: Veuillez vous conformer aux directives de Protection des Données lors de l'utilisation de Mots-clés (par ex. pas de noms propres)."
 
 #: ./opengever/document/behaviors/metadata.py
 msgid "help_preserved_as_paper"
@@ -488,6 +490,11 @@ msgstr "Télécharger une copie"
 #: ./opengever/document/browser/templates/macros.pt
 msgid "label_edit"
 msgstr "Editer à nouveau"
+
+#. Default: "Edit in Office Online"
+#: ./opengever/document/browser/templates/macros.pt
+msgid "label_edit_in_office_online"
+msgstr ""
 
 #. Default: "Error"
 #: ./opengever/document/browser/save_pdf_document_under.py

--- a/opengever/document/locales/opengever.document.pot
+++ b/opengever/document/locales/opengever.document.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2020-03-17 15:18+0000\n"
+"POT-Creation-Date: 2020-03-22 12:27+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -487,6 +487,11 @@ msgstr ""
 #. Default: "Edit"
 #: ./opengever/document/browser/templates/macros.pt
 msgid "label_edit"
+msgstr ""
+
+#. Default: "Edit in Office Online"
+#: ./opengever/document/browser/templates/macros.pt
+msgid "label_edit_in_office_online"
 msgstr ""
 
 #. Default: "Error"

--- a/opengever/document/tests/test_document_tooltip.py
+++ b/opengever/document/tests/test_document_tooltip.py
@@ -1,165 +1,153 @@
-from datetime import datetime
 from ftw import bumblebee
-from ftw.builder import Builder
-from ftw.builder import create
-from ftw.bumblebee.tests.helpers import asset as bumblebee_asset
 from ftw.testbrowser import browsing
-from ftw.testing import freeze
-from opengever.core.testing import OPENGEVER_FUNCTIONAL_BUMBLEBEE_LAYER
-from opengever.officeconnector.interfaces import IOfficeConnectorSettings
-from opengever.testing import FunctionalTestCase
-from plone import api
+from opengever.testing import IntegrationTestCase
+from plone.protect import createToken
 
 
-class TestDocumentTooltip(FunctionalTestCase):
+class TestDocumentTooltip(IntegrationTestCase):
     """Test the lazy loading document tooltip."""
 
-    def setUp(self):
-        super(TestDocumentTooltip, self).setUp()
-        api.portal.set_registry_record('attach_to_outlook_enabled', False, interface=IOfficeConnectorSettings)
-        api.portal.set_registry_record('direct_checkout_and_edit_enabled', False, interface=IOfficeConnectorSettings)
+    features = ('!officeconnector-attach', '!officeconnector-checkout')
 
     @browsing
     def test_tooltip_contains_linked_breadcrumb(self, browser):
-        root = create(Builder('repository_root').titled(u'Ordnungssystem'))
-        repo = create(Builder('repository')
-                      .within(root)
-                      .titled(u'Ablage 1'))
-        dossier = create(Builder('dossier')
-                         .within(repo)
-                         .titled('Hans Meier'.decode('utf-8')))
-        document = create(Builder('document')
-                          .titled('Anfrage Meier')
-                          .within(dossier)
-                          .with_dummy_content())
+        self.login(self.regular_user, browser)
 
-        browser.login().open(document, view='tooltip')
+        browser.open(self.document, view='tooltip')
+
+        chain = [self.repository_root, self.branch_repofolder,
+                 self.leaf_repofolder, self.dossier, self.document]
+
         self.assertEquals(
-            ['Ordnungssystem', '1. Ablage 1', 'Hans Meier', 'Anfrage Meier'],
+            [obj.Title().decode('utf-8') for obj in chain],
             browser.css('.tooltip-breadcrumb li').text)
 
         self.assertEquals(
-            [obj.absolute_url() for obj in [root, repo, dossier, document]],
+            [obj.absolute_url() for obj in chain],
             [link.get('href')
              for link in browser.css('.tooltip-breadcrumb li a')])
 
     @browsing
     def test_tooltip_actions(self, browser):
-        dossier = create(Builder('dossier'))
-        document = create(Builder('document')
-                          .within(dossier)
-                          .with_dummy_content()
-                          .attach_file_containing(
-                              bumblebee_asset('example.docx').bytes(),
-                              u'example.docx'))
+        self.login(self.regular_user, browser)
 
-        browser.login().open(document, view='tooltip')
+        browser.open(self.document, view='tooltip')
         metadata, checkout, download, details = browser.css(
             '.file-action-buttons a')
 
         # metadata
         self.assertEquals('Edit metadata', metadata.text)
         self.assertEquals(
-            'http://nohost/plone/dossier-1/document-1'
+            'http://nohost/plone/ordnungssystem/fuhrung'
+            '/vertrage-und-vereinbarungen/dossier-1/document-14'
             '/edit_checker',
             metadata.get('href'))
 
         # checkout and edit
         self.assertEquals('Checkout and edit', checkout.text)
         self.assertTrue(checkout.get('href').startswith(
-            'http://nohost/plone/dossier-1/document-1'
+            'http://nohost/plone/ordnungssystem/fuhrung'
+            '/vertrage-und-vereinbarungen/dossier-1/document-14'
             '/editing_document?_authenticator='
-            ))
+        ))
 
         # download copy
         self.assertEquals('Download copy', download.text)
         self.assertTrue(download.get('href').startswith(
-            'http://nohost/plone/dossier-1/document-1'
+            'http://nohost/plone/ordnungssystem/fuhrung'
+            '/vertrage-und-vereinbarungen/dossier-1/document-14'
             '/file_download_confirmation?_authenticator='))
 
         # link to details
         self.assertEquals('Open detail view', details.text)
-        self.assertEquals('http://nohost/plone/dossier-1/document-1',
-                          details.get('href'))
+        self.assertEquals(
+            'http://nohost/plone/ordnungssystem/fuhrung'
+            '/vertrage-und-vereinbarungen/dossier-1/document-14',
+            details.get('href'))
 
     @browsing
     def test_checkout_link_is_only_available_for_documents(self, browser):
-        dossier = create(Builder('dossier'))
-        document = create(Builder('document')
-                          .within(dossier)
-                          .with_dummy_content())
-        mail = create(Builder('mail')
-                      .within(dossier))
+        self.login(self.regular_user, browser)
 
-        browser.login().open(document, view='tooltip')
+        browser.open(self.document, view='tooltip')
         self.assertIn('Checkout and edit',
                       browser.css('.file-action-buttons a').text)
 
-        browser.open(mail, view='tooltip')
+        browser.open(self.mail_eml, view='tooltip')
+        self.assertNotIn('Checkout and edit',
+                         browser.css('.file-action-buttons a').text)
+
+        browser.open(self.mail_msg, view='tooltip')
         self.assertNotIn('Checkout and edit',
                          browser.css('.file-action-buttons a').text)
 
     @browsing
     def test_checkout_link_is_only_available_for_editable_docs(self, browser):
-        dossier = create(Builder('dossier').in_state('dossier-state-resolved'))
-        document = create(Builder('document')
-                          .within(dossier)
-                          .with_dummy_content())
+        self.login(self.secretariat_user, browser)
 
-        browser.login().open(document, view='tooltip')
+        browser.open(self.resolvable_dossier,
+                     view='transition-resolve',
+                     data={'_authenticator': createToken()})
+
+        browser.open(self.resolvable_document, view='tooltip')
         self.assertEquals(['Download copy',
                            'Open detail view'],
                           browser.css('.file-action-buttons a').text)
 
     @browsing
     def test_download_link_is_available_for_documents_and_mails_when_file_exists(self, browser):  # noqa
-        document = create(Builder('document').with_dummy_content())
-        document_without_file = create(Builder('document'))
-        mail = create(Builder('mail').with_dummy_message())
+        self.login(self.regular_user, browser)
 
-        browser.login().open(document, view='tooltip')
+        browser.open(self.document, view='tooltip')
         self.assertIn(
             'Download copy', browser.css('.file-action-buttons a').text)
 
-        browser.login().open(mail, view='tooltip')
+        browser.open(self.mail_eml, view='tooltip')
         self.assertIn(
             'Download copy', browser.css('.file-action-buttons a').text)
 
-        browser.login().open(document_without_file, view='tooltip')
+        browser.open(self.mail_msg, view='tooltip')
+        self.assertIn(
+            'Download copy', browser.css('.file-action-buttons a').text)
+
+        browser.open(self.empty_document, view='tooltip')
         self.assertNotIn(
             'Download copy', browser.css('.file-action-buttons a').text)
 
     @browsing
     def test_download_link_redirects_to_orginal_message_when_exists(self, browser):  # noqa
-        mail = create(Builder('mail')
-                      .with_dummy_message()
-                      .with_dummy_original_message())
-        browser.login().open(mail, view='tooltip')
+        self.login(self.regular_user, browser)
+
+        browser.open(self.mail_msg, view='tooltip')
 
         self.assertTrue(
             browser.find('Download copy').get('href').startswith(
-                'http://nohost/plone/document-1/@@download/original_message?'))
+                'http://nohost/plone/ordnungssystem/fuhrung'
+                '/vertrage-und-vereinbarungen/dossier-1/document-30'
+                '/@@download/original_message?'
+            ))
 
 
-class TestDocumentLinkWidgetWithActivatedBumblebee(FunctionalTestCase):
+class TestDocumentLinkWidgetWithActivatedBumblebee(IntegrationTestCase):
     """Test document link widget interactions with Bumblebee."""
 
-    layer = OPENGEVER_FUNCTIONAL_BUMBLEBEE_LAYER
+    features = ('bumblebee', )
 
     @browsing
     def test_tooltip_contains_preview_thumbnail(self, browser):
-        with freeze(datetime(2016, 1, 1)):
-            document = create(Builder('document').with_dummy_content())
+        self.login(self.regular_user, browser)
 
-            self.request.form['bid'] = 'THEBID'
-            browser.login().open(document, {'bid': 'THEBID'}, view='tooltip')
-            thumbnail_url = bumblebee.get_service_v3().get_representation_url(
-                document, 'thumbnail')
+        self.request.form['bid'] = 'THEBID'
+        thumbnail_url = bumblebee.get_service_v3().get_representation_url(
+            self.document, 'thumbnail')
+        del self.request.form['bid']
 
-            self.assertEquals(
-                thumbnail_url,
-                browser.css('.preview img').first.get('src'))
+        browser.open(self.document, {'bid': 'THEBID'}, view='tooltip')
 
-            self.assertEquals(
-                ['Open document preview'],
-                browser.css('.preview span').text)
+        self.assertEquals(
+            thumbnail_url,
+            browser.css('.preview img').first.get('src'))
+
+        self.assertEquals(
+            ['Open document preview'],
+            browser.css('.preview span').text)

--- a/opengever/document/tests/test_overview.py
+++ b/opengever/document/tests/test_overview.py
@@ -935,11 +935,11 @@ class TestDocumentOverviewWithOfficeOnline(IntegrationTestCase):
         # Collaborative checkout by self:
         # - "Edit in Office Online" action is available
         # But not:
+        # - Edit [with OfficeConnector] (because it's a collaborative checkout)
         # - Cancel checkout (because it's locked)
         # - Checkin (because it's a collaborative checkout)
         self.assertEquals(
-            ['Edit',
-             'Edit in Office Online',
+            ['Edit in Office Online',
              'Download copy'],
             file_actions)
 


### PR DESCRIPTION
This adds the `Edit in Office Online` file action button in the classic UI as well.

> ℹ️  **Note**: This branch is deployed on https://lab.onegovgever.ch/ for easier review ℹ️

It will be shown on:

### Document Overview

![office_online_overview](https://user-images.githubusercontent.com/405124/77302155-33c9c200-6cf1-11ea-850d-49386a191f38.png)

---

### Document Tooltip

![office_online_tooltip](https://user-images.githubusercontent.com/405124/77302177-3e845700-6cf1-11ea-845b-dd9f85a80029.png)

---

### Document PDF Preview

![office_online_pdf_preview](https://user-images.githubusercontent.com/405124/77302200-48a65580-6cf1-11ea-958f-63fd574f1565.png)

---


(Addresses 4teamwork/opengever.sg#421)

This also fixes **action availability**, so that Office Online editing and Office Connector editing flows are mutually exclusive (addresses #6319): When a document is being edited using Office Online, the regular checkout and edit actions are disabled:

![office_online_checked_out](https://user-images.githubusercontent.com/405124/77302388-8acf9700-6cf1-11ea-9e32-77ae1a94c78a.png)

---

## Checkliste

_Zutreffendes soll angehakt stehengelassen werden._

- [x] Gibt es neue Funktionalität mit einem `Dokument`? Funktioniert das auch mit einem `Mail`?
- [x] Gibt es neue Übersetzungen?
  - [x] Sind alle msg-Strings in Übersetzungen Unicode?
  - [x] Wird die richtige i18n-domain verwendet (Copy-Paste Fehler sind hier häufig)?
- [x] Changelog-Eintrag vorhanden/nötig?
