### PR TITLE
Change container title format in task activities.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 ------------------------
 
 - Do not allow to choose inbox of hidden OrgUnit as responsible in forwardings. [njohner]
+- Change container title format in task activities. [njohner]
 - Add hidden flag to OrgUnits and AdminUnits. [njohner]
 - Disallow choosing hidden orgunits as responsible_client in tasks and forwardings. [njohner]
 - Do not display hidden orgunits in orgunit selector. [njohner]

--- a/opengever/activity/tests/test_mail.py
+++ b/opengever/activity/tests/test_mail.py
@@ -67,7 +67,7 @@ class TestEmailNotification(IntegrationTestCase):
         mail = email.message_from_string(Mailing(self.portal).pop())
 
         self.assertEquals(
-            'GEVER Activity: [Dossier title] Test Task', mail.get('Subject'))
+            'GEVER Activity: Dossier title - Test Task', mail.get('Subject'))
 
     @browsing
     def test_notification_summary_is_split_into_paragraphs(self, browser):
@@ -153,7 +153,7 @@ class TestEmailNotification(IntegrationTestCase):
 
         raw_mail = Mailing(self.portal).pop()
         link = ('<p><a href=3D"http://nohost/plone/@@resolve_notification?notificati=\non_id=3D1">'
-                '[Vertr=C3=A4ge mit der kantonalen...] Test Task</a></p>')
+                'Vertr=C3=A4ge mit der kantonalen... - Test Task</a></p>')
         self.assertIn(link, raw_mail.strip())
 
     @browsing

--- a/opengever/api/tests/test_notifications.py
+++ b/opengever/api/tests/test_notifications.py
@@ -53,7 +53,7 @@ class TestNotificationsGet(IntegrationTestCase):
               u'notification_id': 3,
               u'read': False,
               u'summary': u'New task opened by Ziegler Robert',
-              u'title': u'[Vertr\xe4ge mit der kantonalen...] Vertragsentwurf \xdcberpr\xfcfen'},
+              u'title': u'Vertr\xe4ge mit der kantonalen... - Vertragsentwurf \xdcberpr\xfcfen'},
              {u'@id': u'http://nohost/plone/@notifications/kathi.barfuss/1',
               u'actor_id': u'nicole.kohler',
               u'actor_label': u'Kohler Nicole',
@@ -63,7 +63,7 @@ class TestNotificationsGet(IntegrationTestCase):
               u'notification_id': 1,
               u'read': True,
               u'summary': u'New task opened by Ziegler Robert',
-              u'title': u'[Vertr\xe4ge mit der kantonalen...] Vertragsentwurf \xdcberpr\xfcfen'}],
+              u'title': u'Vertr\xe4ge mit der kantonalen... - Vertragsentwurf \xdcberpr\xfcfen'}],
             browser.json.get('items'))
 
     @browsing
@@ -127,7 +127,7 @@ class TestNotificationsGet(IntegrationTestCase):
              u'notification_id': 1,
              u'read': False,
              u'summary': u'New task opened by Ziegler Robert',
-             u'title': u'[Vertr\xe4ge mit der kantonalen...] Vertragsentwurf \xdcberpr\xfcfen'},
+             u'title': u'Vertr\xe4ge mit der kantonalen... - Vertragsentwurf \xdcberpr\xfcfen'},
             browser.json)
 
     @browsing

--- a/opengever/task/activities.py
+++ b/opengever/task/activities.py
@@ -47,7 +47,7 @@ class BaseTaskActivity(BaseActivity):
         else:
             cropped_dossier_title = self.dossier_title
 
-        return {code: u"[{dossier_title}] {task_title}".format(
+        return {code: u"{dossier_title} - {task_title}".format(
                     dossier_title=cropped_dossier_title,
                     task_title=task_title[code])
                 for code in self._get_supported_languages()}

--- a/opengever/task/tests/test_activities.py
+++ b/opengever/task/tests/test_activities.py
@@ -59,7 +59,7 @@ class TestTaskActivites(FunctionalTestCase):
         activity = Activity.query.one()
         self.assertEquals('task-added', activity.kind)
         self.assertEquals(
-          u'[Dossier XY] Abkl\xe4rung Fall Meier', activity.title)
+          u'Dossier XY - Abkl\xe4rung Fall Meier', activity.title)
         self.assertEquals(u'New task opened by Test User', activity.summary)
 
         browser.open_html(activity.description)
@@ -133,7 +133,7 @@ class TestTaskActivites(FunctionalTestCase):
 
         activity = Activity.query.order_by(desc(Activity.id)).first()
         self.assertEquals(u'task-transition-open-in-progress', activity.kind)
-        self.assertEquals(u'[Dossier XY] Abkl\xe4rung Fall Meier', activity.title)
+        self.assertEquals(u'Dossier XY - Abkl\xe4rung Fall Meier', activity.title)
         self.assertEquals(
             u'Accepted by <a href="http://nohost/plone/@@user-details/test_user_1_">Test User (test_user_1_)</a>',
             activity.summary)
@@ -159,7 +159,7 @@ class TestTaskActivites(FunctionalTestCase):
         activity = Activity.query.order_by(desc(Activity.id)).first()
         self.assertEquals(u'task-commented', activity.kind)
         self.assertEquals(
-          u'[Dossier XY] Abkl\xe4rung Fall Meier', activity.title)
+          u'Dossier XY - Abkl\xe4rung Fall Meier', activity.title)
         self.assertEquals(
             u'Commented by <a href="http://nohost/plone/@@user-details/test_user_1_">Test User (test_user_1_)</a>',
             activity.summary)
@@ -204,7 +204,7 @@ class TestTaskActivites(FunctionalTestCase):
         activity = Activity.query.order_by(desc(Activity.id)).first()
         self.assertEquals(u'task-transition-in-progress-resolved', activity.kind)
         self.assertEquals(
-          u'[Dossier XY] Abkl\xe4rung Fall Meier', activity.title)
+          u'Dossier XY - Abkl\xe4rung Fall Meier', activity.title)
         self.assertEquals(
             u'Resolved by <a href="http://nohost/plone/@@user-details/test_user_1_">Test User (test_user_1_)</a>', activity.summary)
         self.assertEquals(u'Ist erledigt.', activity.description)
@@ -232,7 +232,7 @@ class TestTaskActivites(FunctionalTestCase):
         activity = Activity.query.order_by(desc(Activity.id)).first()
         self.assertEquals(u'task-transition-rejected-skipped', activity.kind)
         self.assertEquals(
-          u'[Dossier XY] Abkl\xe4rung Fall Meier', activity.title)
+          u'Dossier XY - Abkl\xe4rung Fall Meier', activity.title)
         self.assertEquals(
             u'Skipped by <a href="http://nohost/plone/@@user-details/test_user_1_">Test User (test_user_1_)</a>', activity.summary)
         self.assertEquals(u'Wird \xfcbersprungen.', activity.description)
@@ -260,7 +260,7 @@ class TestTaskActivites(FunctionalTestCase):
 
         activity = Activity.query.order_by(desc(Activity.id)).first()
         self.assertEquals(u'task-transition-modify-deadline', activity.kind)
-        self.assertEquals(u'[Dossier XY] Abkl\xe4rung Fall Meier',
+        self.assertEquals(u'Dossier XY - Abkl\xe4rung Fall Meier',
                           activity.title)
         self.assertEquals(
             'Deadline modified from 01.03.2015 to 20.03.2016 by'
@@ -296,7 +296,7 @@ class TestTaskActivites(FunctionalTestCase):
 
         activity = Activity.query.order_by(desc(Activity.id)).first()
         self.assertEquals('task-added', activity.kind)
-        self.assertEquals(u'[Dossier XY] Unteraufgabe Abkl\xe4rung Fall Meier',
+        self.assertEquals(u'Dossier XY - Unteraufgabe Abkl\xe4rung Fall Meier',
                           activity.title)
         self.assertEquals(u'New task opened by Test User', activity.summary)
 
@@ -358,7 +358,7 @@ class TestTaskActivites(FunctionalTestCase):
 
         activity = Activity.query.order_by(desc(Activity.id)).first()
         self.assertEquals('task-added', activity.kind)
-        self.assertEquals(u'[Dossier XY] Abkl\xe4rung Fall Huber', activity.title)
+        self.assertEquals(u'Dossier XY - Abkl\xe4rung Fall Huber', activity.title)
         self.assertEquals(u'New task opened by Test User', activity.summary)
 
 
@@ -388,7 +388,7 @@ class TestTaskReassignActivity(IntegrationTestCase):
 
         self.assertEquals(u'task-transition-reassign', reassign_activity.kind)
         self.assertEquals(
-          u'[Vertr\xe4ge mit der kantonalen...] Vertragsentwurf \xdcberpr\xfcfen',
+          u'Vertr\xe4ge mit der kantonalen... - Vertragsentwurf \xdcberpr\xfcfen',
           reassign_activity.title)
         self.assertEquals(u'Reassigned from <a href="http://nohost/plone/@@user-details/kathi.barfuss">'
                           u'B\xe4rfuss K\xe4thi (kathi.barfuss)</a> '
@@ -410,7 +410,7 @@ class TestTaskReassignActivity(IntegrationTestCase):
 
         self.assertEquals(u'task-transition-reassign', reassign_activity.kind)
         self.assertEquals(
-          u'[Vertr\xe4ge mit der kantonalen...] Vertragsentwurf \xdcberpr\xfcfen',
+          u'Vertr\xe4ge mit der kantonalen... - Vertragsentwurf \xdcberpr\xfcfen',
           reassign_activity.title)
         self.assertEquals(u'Reassigned from <a href="http://nohost/plone/@@user-details/kathi.barfuss">'
                           u'B\xe4rfuss K\xe4thi (kathi.barfuss)</a> '
@@ -555,7 +555,7 @@ class TestTaskReminderActivity(IntegrationTestCase):
         self.assertEquals('task-reminder', activity.kind)
         self.assertEquals('Task reminder', activity.label)
         self.assertEquals(
-          u'[Vertr\xe4ge mit der kantonalen...] Vertragsentwurf \xdcberpr\xfcfen',
+          u'Vertr\xe4ge mit der kantonalen... - Vertragsentwurf \xdcberpr\xfcfen',
           activity.title)
         self.assertEqual(SYSTEM_ACTOR_ID, activity.actor_id)
         self.assertEquals(u'Deadline is on Nov 01, 2016', activity.summary)


### PR DESCRIPTION
With https://github.com/4teamwork/opengever.core/pull/6270 we added the dossier title in task activities. Here we change the format used to display the dossier titles in these activities, using "dossier title - task title" instead of "[dossier title] - task title"

For https://github.com/4teamwork/opengever.sg/issues/424

## Checkliste
- [x] Changelog-Eintrag vorhanden/nötig?
