### PR TITLE
Disallow choosing inbox of hidden OrgUnit as responsible in forwardings.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2020.2.0rc2 (unreleased)
 ------------------------
 
+- Do not allow to choose inbox of hidden OrgUnit as responsible in forwardings. [njohner]
 - Add hidden flag to OrgUnits and AdminUnits. [njohner]
 - Disallow choosing hidden orgunits as responsible_client in tasks and forwardings. [njohner]
 - Do not display hidden orgunits in orgunit selector. [njohner]

--- a/opengever/inbox/tests/test_forwarding.py
+++ b/opengever/inbox/tests/test_forwarding.py
@@ -120,6 +120,27 @@ class TestForwarding(IntegrationTestCase):
         self.assertEqual(0, search_result['total_count'])
 
     @browsing
+    def test_inbox_of_hidden_orgunits_are_not_available_as_responsible(self, browser):
+        """Inbox of hidden orgunit is valid, but the widget does not allow us
+        to choose them. We therefore need to test searching the responsible
+        directly in the widget.
+        """
+        self.login(self.secretariat_user, browser=browser)
+        orgunit = get_current_org_unit()
+        widget_url = "{}/{}".format(
+            self.inbox.absolute_url(),
+            '++add++opengever.inbox.forwarding/++widget++form.widgets.responsible')
+        search_url = widget_url + '/search?q={}:{}'.format(
+            'inbox', orgunit.id())
+
+        search_result = browser.open(search_url).json
+        self.assertEqual(1, search_result['total_count'])
+
+        orgunit.hidden = True
+        search_result = browser.open(search_url).json
+        self.assertEqual(0, search_result['total_count'])
+
+    @browsing
     def test_teams_are_available_as_responsible(self, browser):
         self.login(self.secretariat_user, browser=browser)
 

--- a/opengever/ogds/base/sources.py
+++ b/opengever/ogds/base/sources.py
@@ -274,6 +274,7 @@ class AllUsersInboxesAndTeamsSource(BaseQuerySoure):
 
         query = OrgUnit.query
         query = query.filter(OrgUnit.enabled == True)  # noqa
+        query = query.filter(OrgUnit.hidden == False)  # noqa
 
         if self.only_current_inbox:
             query = query.filter(OrgUnit.unit_id == self.client_id)

--- a/opengever/ogds/base/tests/test_sources.py
+++ b/opengever/ogds/base/tests/test_sources.py
@@ -322,6 +322,21 @@ class TestAllUsersInboxesAndTeamsSource(FunctionalTestCase):
         self.assertFalse(result,
                          'Expect no Inbox for the inactive OrgUnit Steueramt')
 
+    def test_do_not_return_inboxes_of_hidden_orgunits(self):
+        self.org_unit1.hidden = True
+        result = self.source.search('inbox:org-unit-1')
+
+        self.assertFalse(result,
+                         'Expect no Inbox for the hidden OrgUnit org-unit-1')
+
+    def test_inboxes_of_hidden_orgunits_are_valid_terms(self):
+        self.org_unit1.hidden = True
+        term = self.source.getTermByToken('inbox:org-unit-1')
+
+        self.assertTrue(
+          term, 'Inbox for the hidden OrgUnit org-unit-1 should be a valid term')
+        self.assertEqual('inbox:org-unit-1', term.token)
+
     def test_search_for_term_inbox_or_partial_term_that_matches_inbox(self):
         inboxes = self.source.search('Inbox')
         self.assertEquals(2, len(inboxes), 'Expect two inboxes')


### PR DESCRIPTION
With https://github.com/4teamwork/opengever.core/pull/6318 we introduced the `hidden` attribute for `OrgUnit`s and `AdminUnit`s and dissalowed selecting users from hidden `OrgUnit`s as responisble for tasks and forwardings. Here we also disallow choosing the inbox of a hidden `OrgUnit` as responsible for a forwarding.

For https://github.com/4teamwork/opengever.core/issues/6129

## Checkliste
- [x] Changelog-Eintrag vorhanden/nötig?
