### PR TITLE
Add documentation to configure the app-switcher

### DIFF
--- a/docs/intern/kurzreferenzen/appswitcher.rst
+++ b/docs/intern/kurzreferenzen/appswitcher.rst
@@ -1,0 +1,68 @@
+App-Switcher im neuen Frontend
+==============================
+Jeder Mandant und jeder Teamraum repräsetiert eine eigene Applikation. Der Benutzer kann über den App-Switcher oben links im neuen UI zwischen diesen Applikationen wechseln.
+
+Das UI erhält vom Backend im ``@config``-Endpoint eine ``apps_url``. Anschließend führt das UI einen GET Request auf die URL aus und erhält eine Liste von möglichen Applikationen zurück. Die Anwendungen werden anhand der erhaltenen Konfiguration für den Benutzer angezeigt.
+
+Unsere GEVER-Installationen beziehen die Apps vom `neuen Portal Ianus <https://github.com/4teamwork/ianus>`_.
+
+Installation
+------------
+Development
+~~~~~~~~~~~
+Wird GEVER im Development-Modus ausgeführt, wird ein Set von Entwickler-Applikationen im Appswitcher angezeigt. Die Applikationen sind statisch.
+
+`developmentApps.js <https://github.com/4teamwork/gever-ui/blob/master/src/apps/service/developmentApps.js>`_
+
+Eine weitere Konfiguration ist nicht nötig.
+
+Produktion
+~~~~~~~~~~
+Folgende Schritte sind für ein produktives Deployment notwendig:
+
+1. das neue Portal Ianus muss installiert sein
+2. alle zur Verfügung stehenden Applikationen müssen im Ianus erfasst sein
+3. die ``apps_url`` muss auf den Ianus Endpoint ``/api/apps`` zeigen
+
+Apps-Konfiguration im Inaus
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Das `neue Portal Ianus <https://github.com/4teamwork/ianus>`_ stellt unter ``/api/apps`` einen Endpoint für Applikationen zur Verfügung. Der Endpoint kann im GEVER als ``apps_url`` verwendet werden.
+
+Alle zur Verfügung stehenden Mandanten oder Applikationen müssen im Ianus manuell unter **Applications** erfasst werden. Folgende Konfigurationen sind bisher möglich:
+
+**GEVER**
+
+- Titel: ``OneGov GEVER``
+- Subtitle: ``4teamwork``
+- URL: ``URL zur Applikation oder Mandanten: www.example.com/fd``
+- Farbe: ``#03A9F4``
+- Icon: `appGever.svg <https://github.com/4teamwork/gever-ui/blob/master/src/assets/icons/appGever.svg>`_
+- Typ: ``gever``
+
+**Teamraum**
+
+- Titel: ``Teamraum``
+- Subtitle: ``4teamwork``
+- URL: ``URL zur Applikation: www.example.com/tr``
+- Farbe: ``#3F51B5``
+- Icon: `appWorkspaces.svg <https://github.com/4teamwork/gever-ui/blob/master/src/assets/icons/appWorkspaces.svg>`_
+- Typ: ``teamraum``
+
+Natürlich können die Konfigurationen individuell an den Kunden und an die Umgebung frei angepasst werden.
+
+``apps_url`` im GEVER konfigurieren
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Für ein produktives Deployment muss die ``apps_url`` über eine Umgebungsvariable gesetzt werden
+
+``export APPS_ENDPOINT_URL=http://example.com/portal/api/apps``
+
+Die URL muss eine Liste von Anwendungen zurückgeben.
+
+In einem produktiven Deployment setzten wir die URL auf das neue Portal: ``www.example.com/portal/api/apps``
+
+
+Edge Cases
+----------
+Wenn keine ``apps_url`` in einem produktiven Deployment gesetzt wurde, wird standardmässig ein Set von Standard-Applikationen im Appswitcher angezeigt. Die Applikationen sind statisch unter `defaultApps.js <https://github.com/4teamwork/gever-ui/blob/master/src/apps/service/defaultApps.js>`_ zu finden.
+
+Wenn also ein GEVER mit nur einem Mandanten betrieben wird, müssen keine Apps speziell erfasst oder konfiguriert werden.

--- a/docs/intern/kurzreferenzen/appswitcher.rst
+++ b/docs/intern/kurzreferenzen/appswitcher.rst
@@ -1,3 +1,5 @@
+.. _appswitcher:
+
 App-Switcher im neuen Frontend
 ==============================
 Jeder Mandant und jeder Teamraum repräsetiert eine eigene Applikation. Der Benutzer kann über den App-Switcher oben links im neuen UI zwischen diesen Applikationen wechseln.

--- a/docs/intern/kurzreferenzen/index.rst
+++ b/docs/intern/kurzreferenzen/index.rst
@@ -12,4 +12,4 @@ Inhalt:
    ogip
    feedbackforum-prozess
    ubersetzungen
-   multi-app-setup
+   appswitcher

--- a/docs/intern/kurzreferenzen/multi-app-setup.rst
+++ b/docs/intern/kurzreferenzen/multi-app-setup.rst
@@ -1,7 +1,0 @@
-Alternative Apps im neuen Frontend anzeigen
-===========================================
-Der ``@config``-Endpoint stellt im Attribut ``apps_url`` eine URL zum Abfragen von verfügbaren Applikationen zur Verfügung. Das Frontend führt einen GET request auf die URL aus und zeigt die zurückgegebenen Applikationen im App-Switcher an.
-
-Die ``apps_url`` kann über eine Umgebungsvariable gesetzt werden:
-
-``export APPS_ENDPOINT_URL=htt://example.com/portal/api/apps``

--- a/docs/intern/operations/allgemein.rst
+++ b/docs/intern/operations/allgemein.rst
@@ -126,3 +126,10 @@ anzugeben:
 
 ``23:00 - 26:00`` würde dementsprechend Start um ``23:00``, und Ende um
 ``02:00`` *am nächsten Tag* bedeuten.
+
+App-Switcher konfigurieren
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Für jedes neue Deployment muss der App-Switcher konfiguriert werden.
+
+Dazu gibt es eine Kurzreferenz unter dem Kapitel :ref:`appswitcher`.

--- a/docs/intern/wopi/index.rst
+++ b/docs/intern/wopi/index.rst
@@ -102,7 +102,7 @@ Docker Desktop (macOS) the ZServer needs to listen on all interfaces to be
 accessible from the Docker container. This can be acomplished by setting the
 environment variable ZSERVER_HOST before executing the test.
 
-.. code-block::
+.. code-block:: bash
 
   export ZSERVER_HOST="0.0.0.0"
   bin/test -m opengever.wopi -t test_validator
@@ -115,7 +115,7 @@ After that the ``WOPISrc`` URL and the ``access token`` have to be extracted fro
 
 Example: run the ``PutFileReturnsDifferentVersion`` test
 
-.. code-block::
+.. code-block:: bash
 
   docker run -it --rm tylerbutler/wopi-validator -- \
     -w <WOPISrc> -t <access_token> -l 0 -s -n files.PutFileReturnsDifferentVersion


### PR DESCRIPTION
Dieser PR enthält die Dokumentation für das einrichten des neuen App-Switchers.

Follow-Up PR von: https://github.com/4teamwork/gever-ui/issues/834
