### PR TITLE
Add @listing-stats API endpoint to get listing statistics

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2020.2.2 (unreleased)
 ---------------------
 
+- Add @listing-stats API endpoint to get statistical data from folderish content. [elioschmutz]
 - Fix public documentation build. [elioschmutz]
 
 

--- a/docs/public/dev-manual/api/index.rst
+++ b/docs/public/dev-manual/api/index.rst
@@ -14,6 +14,7 @@ Inhalt:
    batching.rst
    summaries.rst
    listings.rst
+   listing_stats.rst
    navigation.rst
    searching.rst
    documents.rst

--- a/docs/public/dev-manual/api/listing_stats.rst
+++ b/docs/public/dev-manual/api/listing_stats.rst
@@ -1,0 +1,74 @@
+.. listing_stats:
+
+Statistik zu Auflistungen
+=========================
+
+Mit dem ``@listing-stats`` Endpoint können Statistiken zu Auflistungen unter :ref:`listings` abgefragt werden.
+
+
+**Beispiel-Request**:
+
+  .. sourcecode:: http
+
+    GET /dossier-1/@listing-stats HTTP/1.1
+    Accept: application/json
+
+**Beispiel-Response**:
+
+  .. sourcecode:: http
+
+    HTTP/1.1 200 OK
+    Content-Type: application/json
+
+    {
+      "@id": "http://localhost:8080/fd/ordnungssystem/dossier-1/@listing-stats",
+      "facet_pivot": {
+        "listing_name": [
+          {
+            "field": "listing_name",
+            "value": "dossiers",
+            "count": 10
+          },
+          {
+            "field": "listing_name",
+            "value": "documents",
+            "count": 5
+          },
+          {
+            "field": "listing_name",
+            "value": "proposals",
+            "count": 0
+          },
+          "..."
+        ]
+      }
+    }
+
+Statistik als erweiterbare Komponente
+-------------------------------------
+Die Statistiken können als Kompomente einer Ressource direkt über den ``expand``-Parameter eingebettet werden.
+
+**Beispiel-Request**:
+
+  .. sourcecode:: http
+
+    GET /dossier-1?expand=listing-stats HTTP/1.1
+    Accept: application/json
+
+**Beispiel-Response**:
+
+  .. sourcecode:: http
+
+    HTTP/1.1 200 OK
+    Content-Type: application/json
+
+    {
+      "@id": "http://localhost:8080/fd/ordnungssystem/dossier-1?expand=listing-stats",
+      "@components": {
+        "listingstats": {
+          "@id": "http://localhost:8080/fd/ordnungssystem/dossier-1/@listing-stats",
+          "facet_pivot": { "...": "..." }
+        }
+      },
+      "...": "..."
+    }

--- a/docs/public/dev-manual/api/listings.rst
+++ b/docs/public/dev-manual/api/listings.rst
@@ -1,4 +1,4 @@
-.. listings:
+.. _listings:
 
 Auflistungen
 ============

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -290,6 +290,19 @@
       permission="zope2.View"
       />
 
+  <adapter
+      factory=".listing_stats.ListingStats"
+      name="listing-stats"
+      />
+
+  <plone:service
+      method="GET"
+      for="Products.CMFCore.interfaces.IFolderish"
+      factory=".listing_stats.ListingStatsGet"
+      name="@listing-stats"
+      permission="zope2.View"
+      />
+
   <plone:service
       method="GET"
       for="opengever.contact.interfaces.IContactFolder"

--- a/opengever/api/listing_stats.py
+++ b/opengever/api/listing_stats.py
@@ -104,15 +104,19 @@ class ListingStats(object):
         i.e. the review-states for a specific type. The current implementation
         already takes care of this future improvement.
         """
+        fq = [
+            'trashed:false',
+            'path_parent:{}/*'.format(escape(
+                '/'.join(self.context.getPhysicalPath())))
+        ]
+
         params = {
             'facet': True,
             'rows': 0,
             'facet.pivot': pivot,
-            'filters': 'path_parent:{}/*'.format(escape(
-                '/'.join(self.context.getPhysicalPath())))
         }
 
-        return self.solr.search(**params)
+        return self.solr.search(filters=fq, **params)
 
     def _create_listing_name_pivot(self, solr_response, pivot):
         """Processes solr_response to extract the statistics and format them

--- a/opengever/api/listing_stats.py
+++ b/opengever/api/listing_stats.py
@@ -1,0 +1,40 @@
+from opengever.base.interfaces import IOpengeverBaseLayer
+from plone.restapi.interfaces import IExpandableElement
+from plone.restapi.services import Service
+from zope.component import adapter
+from zope.interface import implementer
+from zope.interface import Interface
+
+
+@implementer(IExpandableElement)
+@adapter(Interface, IOpengeverBaseLayer)
+class ListingStats(object):
+
+    def __init__(self, context, request):
+        self.context = context
+        self.request = request
+
+    def __call__(self, expand=False):
+        result = {
+            'listing-stats': {
+                '@id': '{}/@listing-stats'.format(self.context.absolute_url()),
+            },
+        }
+
+        if not expand:
+            return result
+
+        result['listing-stats']['facet_pivot'] = {}  # Not implemented yet
+
+        return result
+
+
+class ListingStatsGet(Service):
+    """API Endpoint which returns a solr facet_pivot for listings.
+
+    GET folder-1/@listing-stats HTTP/1.1
+    """
+
+    def reply(self):
+        stats = ListingStats(self.context, self.request)
+        return stats(expand=True)['listing-stats']

--- a/opengever/api/tests/test_listing_stats.py
+++ b/opengever/api/tests/test_listing_stats.py
@@ -1,0 +1,41 @@
+from ftw.testbrowser import browsing
+from opengever.testing import IntegrationTestCase
+
+
+class TestListingStats(IntegrationTestCase):
+
+    @browsing
+    def test_listing_stats_id_in_components(self, browser):
+        self.login(self.regular_user, browser)
+        browser.open(
+            self.dossier.absolute_url(),
+            headers={'Accept': 'application/json'},
+        )
+        self.assertEqual(browser.status_code, 200)
+        self.assertEqual(
+            browser.json['@components']['listing-stats']['@id'],
+            u'{}/@listing-stats'.format(self.dossier.absolute_url()))
+
+    @browsing
+    def test_listing_stats_is_expandable(self, browser):
+        self.login(self.regular_user, browser)
+        browser.open(
+            '{}?expand=listing-stats'.format(self.dossier.absolute_url()),
+            headers={'Accept': 'application/json'},
+        )
+
+        self.assertIn(
+            'facet_pivot',
+            browser.json.get('@components', {}).get('listing-stats', {}).keys(),
+            'The listings-stats compoment should be expandend and include '
+            'the `facet_pivot` property')
+
+    @browsing
+    def test_get_listing_stats_returns_a_pivot_query_for_listings(self, browser):
+        self.login(self.regular_user, browser)
+        browser.open(
+            '{}/@listing-stats'.format(self.dossier.absolute_url()),
+            headers={'Accept': 'application/json'},
+        )
+
+        self.assertItemsEqual(browser.json.keys(), ['@id', 'facet_pivot'])

--- a/opengever/api/tests/test_repository.py
+++ b/opengever/api/tests/test_repository.py
@@ -13,6 +13,7 @@ class TestRepositoryAPI(IntegrationTestCase):
             u'@components': {
                 u'actions': {u'@id': u'http://nohost/plone/ordnungssystem/@actions'},
                 u'breadcrumbs': {u'@id': u'http://nohost/plone/ordnungssystem/@breadcrumbs'},
+                u'listing-stats': {u'@id': u'http://nohost/plone/ordnungssystem/@listing-stats'},
                 u'navigation': {u'@id': u'http://nohost/plone/ordnungssystem/@navigation'},
                 u'types': {u'@id': u'http://nohost/plone/ordnungssystem/@types'},
                 u'workflow': {u'@id': u'http://nohost/plone/ordnungssystem/@workflow'},


### PR DESCRIPTION
Dieser PR fügt den neuen Endpoint `@listing-stats` hinzu. Er gibt für jedes [Listing](https://github.com/4teamwork/opengever.core/blob/master/opengever/api/listing.py#L53) die gesamte Anzahl der Elemente zurück:

<img width="504" alt="Bildschirmfoto 2020-03-27 um 09 27 20" src="https://user-images.githubusercontent.com/557005/77736842-35ef9180-700d-11ea-8dc7-e8e908d6298a.png">

Issuer: https://github.com/4teamwork/gever-ui/issues/973

## Checkliste

- [x] Changelog-Eintrag vorhanden/nötig?
- [x] Aktualisierung Dokumentation vorhanden/nötig?
