### PR TITLE
Fix documentation build by removing newline chars in description fields.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,7 @@ Changelog
 2020.2.2 (unreleased)
 ---------------------
 
-- Nothing changed yet.
+- Fix public documentation build. [elioschmutz]
 
 
 2020.2.1 (2020-03-27)

--- a/docs/public/dev-manual/api/schemas/ftw.mail.mail.inc
+++ b/docs/public/dev-manual/api/schemas/ftw.mail.mail.inc
@@ -80,7 +80,7 @@
        :Datentyp: ``Tuple``
        
        
-       :Beschreibung: Schlagwörter zur Umschreibung eines Dokuments. Nicht zu verwechseln mit der Ordnungsposition. <br>ACHTUNG: Beachten Sie bei der Verwendung von Schlagwörter die Datenschutzvorgaben (z.B. keine Eigennamen).
+       :Beschreibung: Schlagwörter zur Umschreibung eines Dokuments. Nicht zu verwechseln mit der Ordnungsposition. ACHTUNG: Beachten Sie bei der Verwendung von Schlagwörter die Datenschutzvorgaben (z.B. keine Eigennamen).
        
 
 

--- a/docs/public/dev-manual/api/schemas/opengever.document.document.inc
+++ b/docs/public/dev-manual/api/schemas/opengever.document.document.inc
@@ -100,7 +100,7 @@
        :Datentyp: ``Tuple``
        
        
-       :Beschreibung: Schlagwörter zur Umschreibung eines Dokuments. Nicht zu verwechseln mit der Ordnungsposition. <br>ACHTUNG: Beachten Sie bei der Verwendung von Schlagwörter die Datenschutzvorgaben (z.B. keine Eigennamen).
+       :Beschreibung: Schlagwörter zur Umschreibung eines Dokuments. Nicht zu verwechseln mit der Ordnungsposition. ACHTUNG: Beachten Sie bei der Verwendung von Schlagwörter die Datenschutzvorgaben (z.B. keine Eigennamen).
        
 
 

--- a/docs/public/dev-manual/api/schemas/opengever.dossier.businesscasedossier.inc
+++ b/docs/public/dev-manual/api/schemas/opengever.dossier.businesscasedossier.inc
@@ -40,7 +40,7 @@
        :Datentyp: ``Tuple``
        
        
-       :Beschreibung: Schlagwörter zur Umschreibung eines Dossiers. Nicht zu verwechseln mit der Ordnungsposition. <br>ACHTUNG: Beachten Sie bei der Verwendung von Schlagwörter die Datenschutzvorgaben (z.B. keine Eigennamen).
+       :Beschreibung: Schlagwörter zur Umschreibung eines Dossiers. Nicht zu verwechseln mit der Ordnungsposition. ACHTUNG: Beachten Sie bei der Verwendung von Schlagwörter die Datenschutzvorgaben (z.B. keine Eigennamen).
        
 
 

--- a/opengever/api/docsbuilder/schemadocs.py
+++ b/opengever/api/docsbuilder/schemadocs.py
@@ -102,6 +102,7 @@ class SchemaDocsBuilder(DirectoryHelperMixin):
             # placeholder
             field['vocabulary'] = field['_vocabulary']
 
+        self._cleanup_field_values(field)
         field_template = env.get_template('field.rst')
         field_doc = field_template.render(**field)
         return field_doc
@@ -127,3 +128,20 @@ class SchemaDocsBuilder(DirectoryHelperMixin):
         for name in os.listdir(dir_):
             if name.endswith('.' + SCHEMA_DOC_EXTENSION):
                 os.remove(pjoin(dir_, name))
+
+    def _cleanup_field_values(self, field):
+        description = field.get('description')
+        if description:
+            # Fixes: https://github.com/4teamwork/opengever.core/issues/6340
+            #
+            # We need to use newline chars instead of <br> in schema
+            # descriptions for new lines because the new UI does not render html
+            # tags in field descriptions.
+            #
+            # Unfortunately, using a new-line char will unindent the description
+            # block and will raise a sphinx build warning which will cause a
+            # test failure.
+            #
+            # We remove the newline chars in the description fields completely
+            # to fix the layout in the build documentation and to fix the tests.
+            field['description'] = description.replace('\n', ' ')


### PR DESCRIPTION
 We need to use newline chars instead of `<br>` in schema  descriptions for new lines because the new UI does not render html  tags in field descriptions.

 Unfortunately, using a new-line char will unindent the description block and will raise a sphinx build warning which will cause a test failure.

 We remove the newline chars in the description fields completely to fix the layout in the build documentation and to fix the tests.

## With `<br>`
<img width="728" alt="Bildschirmfoto 2020-03-26 um 09 20 54" src="https://user-images.githubusercontent.com/557005/77625051-273ca800-6f43-11ea-9e65-3236f708b92e.png">


## With `\n`
<img width="842" alt="Bildschirmfoto 2020-03-26 um 09 24 44" src="https://user-images.githubusercontent.com/557005/77625316-a92cd100-6f43-11ea-9054-6d6080f1df82.png">

## Without `\n` or `<br>` (This PR)
<img width="827" alt="Bildschirmfoto 2020-03-26 um 09 14 36" src="https://user-images.githubusercontent.com/557005/77624980-05dbbc00-6f43-11ea-8aab-3ea0b0c88c0f.png">

Issuer: #6340 