### PR TITLE
Backdate AddHiddenFlagToAdminAndOrgUnit upgrade step.

### DIFF
--- a/opengever/core/upgrades/20170601103050_add_hidden_flag_to_admin_and_org_units/upgrade.py
+++ b/opengever/core/upgrades/20170601103050_add_hidden_flag_to_admin_and_org_units/upgrade.py
@@ -11,6 +11,8 @@ class AddHiddenFlagToAdminAndOrgUnits(SchemaMigration):
 
     def migrate(self):
         for tablename in ['admin_units', 'org_units']:
+            if self.has_column(tablename, "hidden"):
+                continue
             self.add_column(tablename)
             self.insert_default_value(tablename)
             self.make_column_non_nullable(tablename)
@@ -32,3 +34,7 @@ class AddHiddenFlagToAdminAndOrgUnits(SchemaMigration):
     def make_column_non_nullable(self, tablename):
         self.op.alter_column(tablename, 'hidden',
                              existing_type=Boolean, nullable=False)
+
+    def has_column(self, table_name, column_name):
+        table = self.metadata.tables.get(table_name)
+        return column_name in table.columns


### PR DESCRIPTION
The current admin unit is fetched every time the metadata of an object is updated, because of the reference number indexer. This will lead to failing upgrade steps if we do not update the admin_units table first. So we predate this upgrade step to just before the oldest upgrade that has not been executed on all client installations yet.