### PR TITLE
Amend PR checklist, optional and mandatory part, link jira issue (if available).

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-_PR-Beschreibung: muss alle notwendigen Informationen enthalten, so dass ein Aussenstehender die Änderung versteht ohne den Code anzuschauen_
+_PR-Beschreibung: muss alle notwendigen Informationen enthalten, so dass ein Aussenstehender die Änderung versteht ohne den Code oder den Issue anzuschauen!_
 
 - _Grund, wieso diese Änderung notwendig ist_
 - _Was das Ziel dieser Änderung ist_
@@ -7,14 +7,22 @@ _PR-Beschreibung: muss alle notwendigen Informationen enthalten, so dass ein Aus
 
 _Screenshot: erwünscht, sollen aber immer nur unterstützend eingesetzt werden._
 
-_Link zum Issue: `closes` oder `fixes` keyword verwenden._
 
-Definition of Done: https://github.com/4teamwork/opengever.core/wiki/Definition-of-Done
+Definition of Done: https://4teamwork.atlassian.net/wiki/spaces/CHX4TW/pages/917562/
 
 
-## Checkliste
+## Checkliste (Must have)
 
-_Zutreffendes soll angehakt stehengelassen werden._
+_Alles muss gemacht/angehakt werden._
+
+- [ ] Changelog-Eintrag erstellt? _Falls im PR nicht vorhanden erachtet es der PR-Ersteller als unnötig._
+- [ ] Aktualisierung Dokumentation (API/Deployment/...) aktualisiert? _Falls im PR nicht vorhanden erachtet es der PR-Ersteller als unnötig._
+- [ ] Jira Link + Backlink im Jira / Github Issue Link. _Link muss im PR-Body vorhanden sein._
+
+
+## Checkliste (optional)
+
+_Nur Zutreffendes soll angehakt stehengelassen werden._
 
 - [ ] Gibt es neue Funktionalität mit einem `Dokument`? Funktioniert das auch mit einem `Mail`?
 - [ ] Wurde etwas an der `Aufgabe` angepasst? Funktioniert das auch mit einer `Weiterleitung`?
@@ -29,5 +37,3 @@ _Zutreffendes soll angehakt stehengelassen werden._
   - [ ] Sind alle msg-Strings in Übersetzungen Unicode?
   - [ ] Wird die richtige i18n-domain verwendet (Copy-Paste Fehler sind hier häufig)?
 - [ ] Wenn bei Schema-definitionen `missing_value` spezifiziert ist muss immer auch `default` auf den gleichen Wert gesetzt werden
-- [ ] Changelog-Eintrag vorhanden/nötig?
-- [ ] Aktualisierung Dokumentation vorhanden/nötig?


### PR DESCRIPTION
Update the PR checklist as discussed in a meeting, the checklist now has an optional and mandatory part as suggested by @elioschmutz. The mandatory part must be left in place and checked off, from the optional part we only keep the relevant items.

Changes:
- split checklist into optional and non-optional parts.
- add/improve description a bit.
- update DoD link to jira.
- amend issue linking, mandatory jira link/backlink.

I have also replaced the DoD in our wiki at https://github.com/4teamwork/opengever.core/wiki/Definition-of-Done and put a link to the new DoD in jira.

_I have not yet translated the checklist but we might wan't to do that eventually._
