### PR TITLE
Fix solr complex search pattern configuration.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 
 - Add @listing-stats API endpoint to get statistical data from folderish content. [elioschmutz]
 - Fix public documentation build. [elioschmutz]
+- Fix solr complex search pattern configuration. [deiferni]
 
 
 2020.2.1 (2020-03-27)

--- a/opengever/core/profiles/default/registry.xml
+++ b/opengever/core/profiles/default/registry.xml
@@ -146,7 +146,7 @@
     <value key="local_query_parameters">{!boost b=recip(ms(NOW,modified),3.858e-10,10,1)}</value>
     <value key="simple_search_term_pattern">Title:{term}^100 OR Title:{term}*^20 OR SearchableText:{term}^5 OR SearchableText:{term}* OR metadata:{term}^10 OR metadata:{term}*^2 OR sequence_number_string:{term}^2000</value>
     <value key="simple_search_phrase_pattern">Title:"{phrase}"^500 OR SearchableText:"{phrase}"^200 OR metadata:"{phrase}"^300</value>
-    <value key="complex_search_pattern">Title:({term})^10 OR SearchableText:({term})</value>
+    <value key="complex_search_pattern">Title:({phrase})^10 OR SearchableText:({phrase})</value>
   </records>
   <records interface="opengever.base.interfaces.ISearchSettings" />
 

--- a/opengever/core/upgrades/20200401120441_fix_solr_complex_search_pattern/registry.xml
+++ b/opengever/core/upgrades/20200401120441_fix_solr_complex_search_pattern/registry.xml
@@ -1,0 +1,7 @@
+<registry>
+
+  <records interface="ftw.solr.interfaces.ISolrSettings">
+    <value key="complex_search_pattern">Title:({phrase})^10 OR SearchableText:({phrase})</value>
+  </records>
+
+</registry>

--- a/opengever/core/upgrades/20200401120441_fix_solr_complex_search_pattern/upgrade.py
+++ b/opengever/core/upgrades/20200401120441_fix_solr_complex_search_pattern/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class FixSolrComplexSearchPattern(UpgradeStep):
+    """Fix solr complex search pattern.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()


### PR DESCRIPTION
We used the string formatting argument `title`, but solr passes the argument as `phrase` in https://github.com/4teamwork/ftw.solr/blob/8354f7658a9e301854d671e3d478923509fa55fe/ftw/solr/query.py#L74. This lead to an error when users applied complex search patterns.

The argument has been renamed in https://github.com/4teamwork/ftw.solr/commit/ac91691ef147d9a594a9e19b454654af948e736e but it seems we never updated the configuration in GEVER.

Fixes https://github.com/4teamwork/opengever.core/issues/5937.

## Checkliste

- [x] Profil angepasst? Sind UpgradeSteps vorhanden/nötig?:
- [x] Changelog-Eintrag vorhanden/nötig?
