### PR TITLE
Hide OC actions when user is in EMM environment

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2020.2.2 (unreleased)
 ---------------------
 
+- Do not show OC checkout and edit buttons when user is in EMM environment. [njohner]
 - Prevent documents being edited in Office Online from getting opened in OfficeConnector. [lgraf]
 - Bump ftw.solr version to 2.8.4 to get update of modified index. [njohner]
 - Add @listing-stats API endpoint to get statistical data from folderish content. [elioschmutz]

--- a/opengever/api/config.py
+++ b/opengever/api/config.py
@@ -1,4 +1,5 @@
 from opengever.base.interfaces import IGeverSettings
+from opengever.officeconnector.helpers import is_client_ip_in_office_connector_disallowed_ip_range
 from plone.restapi.services import Service
 
 
@@ -6,7 +7,12 @@ class Config(Service):
     """GEVER configuration"""
 
     def reply(self):
-        return IGeverSettings(self.context).get_config()
+        config = IGeverSettings(self.context).get_config()
+        self.add_additional_infos(config)
+        return config
 
     def check_permission(self):
         return
+
+    def add_additional_infos(self, config):
+        config['is_emm_environment'] = is_client_ip_in_office_connector_disallowed_ip_range()

--- a/opengever/api/config.py
+++ b/opengever/api/config.py
@@ -1,5 +1,5 @@
 from opengever.base.interfaces import IGeverSettings
-from opengever.officeconnector.helpers import is_client_ip_in_office_connector_disallowed_ip_range
+from opengever.officeconnector.helpers import is_client_ip_in_office_connector_disallowed_ip_ranges
 from plone.restapi.services import Service
 
 
@@ -15,4 +15,4 @@ class Config(Service):
         return
 
     def add_additional_infos(self, config):
-        config['is_emm_environment'] = is_client_ip_in_office_connector_disallowed_ip_range()
+        config['is_emm_environment'] = is_client_ip_in_office_connector_disallowed_ip_ranges()

--- a/opengever/api/tests/test_config.py
+++ b/opengever/api/tests/test_config.py
@@ -164,3 +164,11 @@ class TestConfig(IntegrationTestCase):
         self.assertEqual(browser.status_code, 200)
         self.assertEqual(browser.json.get(u'nightly_jobs'),
                          {u'start_time': u'1:00:00', u'end_time': u'5:00:00'})
+
+    @browsing
+    def test_config_contains_is_emm_environment(self, browser):
+        self.login(self.regular_user, browser)
+        browser.open(self.portal.absolute_url() + '/@config',
+                     headers={'Accept': 'application/json'})
+        self.assertEqual(browser.status_code, 200)
+        self.assertIn(u'is_emm_environment', browser.json)

--- a/opengever/base/ip_range.py
+++ b/opengever/base/ip_range.py
@@ -13,7 +13,7 @@ class InvalidIPRangeSpecification(ValueError):
 
 
 def parse_ip_range(ip_range):
-    """Parse an IP range specification and return a list of allowed networks.
+    """Parse an IP range specification and return a corresponding list networks.
 
     IP ranges may be specified as a single IP address or as a network in CIDR
     notation using the slash-suffix.
@@ -37,16 +37,16 @@ def parse_ip_range(ip_range):
     return networks
 
 
-def permitted_ip(client_ip, ip_range):
+def is_in_ip_range(client_ip, ip_range):
     """Return True if a client IP is in the given range(s), False otherwise.
     """
     try:
-        allowed_networks = parse_ip_range(ip_range)
+        networks = parse_ip_range(ip_range)
     except InvalidIPRangeSpecification:
         return False
 
     ip = ip_address(to_unicode(client_ip))
-    return any(ip in net for net in allowed_networks)
+    return any(ip in net for net in networks)
 
 
 def to_unicode(ip_spec):

--- a/opengever/base/ip_range.py
+++ b/opengever/base/ip_range.py
@@ -57,6 +57,8 @@ def to_unicode(ip_spec):
     sure the ip_spec is unicode, decoding it as ASCII if necessary (IP specs
     should never contain any non-ASCII characters).
     """
+    if ip_spec is None:
+        return u''
     if not isinstance(ip_spec, unicode):
         ip_spec = ip_spec.decode('ascii')
     return ip_spec

--- a/opengever/base/ip_range.py
+++ b/opengever/base/ip_range.py
@@ -1,0 +1,72 @@
+from ipaddress import ip_address
+from ipaddress import ip_network
+from zope.interface import Invalid
+"""This is a copy from the ftw.tokenauth.pas.ip_range module.
+This allows us to uncouple the code used in GEVER from future change
+in ftw.tokenauth.
+"""
+
+
+class InvalidIPRangeSpecification(ValueError):
+    """Error in specification of allowed IP range.
+    """
+
+
+def parse_ip_range(ip_range):
+    """Parse an IP range specification and return a list of allowed networks.
+
+    IP ranges may be specified as a single IP address or as a network in CIDR
+    notation using the slash-suffix.
+
+    Multiple ranges may be provided in comma-separated form.
+
+    Examples:
+
+    192.168.1.1
+    192.168.0.0/16
+    192.168.1.1, 10.0.0.0/8
+    """
+    ranges = [rng.strip() for rng in to_unicode(ip_range).split(u',')]
+    networks = []
+    for rng in ranges:
+        try:
+            network = ip_network(rng)
+        except ValueError as exc:
+            raise InvalidIPRangeSpecification(exc.message)
+        networks.append(network)
+    return networks
+
+
+def permitted_ip(client_ip, ip_range):
+    """Return True if a client IP is in the given range(s), False otherwise.
+    """
+    try:
+        allowed_networks = parse_ip_range(ip_range)
+    except InvalidIPRangeSpecification:
+        return False
+
+    ip = ip_address(to_unicode(client_ip))
+    return any(ip in net for net in allowed_networks)
+
+
+def to_unicode(ip_spec):
+    """Ensure ip_spec is unicode, decoding it if necessary.
+
+    The `ipaddress` module (as opposed to `py2-ipaddress`) absolutely
+    requires IP specifications to be passed in as unicode. We therefore make
+    sure the ip_spec is unicode, decoding it as ASCII if necessary (IP specs
+    should never contain any non-ASCII characters).
+    """
+    if not isinstance(ip_spec, unicode):
+        ip_spec = ip_spec.decode('ascii')
+    return ip_spec
+
+
+def valid_ip_range(value):
+    """Form validator that checks for a valid IP range specification.
+    """
+    try:
+        parse_ip_range(value)
+    except InvalidIPRangeSpecification as exc:
+        raise Invalid('Invalid IP range: {}'.format(str(exc)))
+    return True

--- a/opengever/base/tests/test_ip_range_validation.py
+++ b/opengever/base/tests/test_ip_range_validation.py
@@ -1,0 +1,111 @@
+from ipaddress import ip_network
+from opengever.base.ip_range import InvalidIPRangeSpecification
+from opengever.base.ip_range import parse_ip_range
+from opengever.base.ip_range import permitted_ip
+from opengever.base.ip_range import valid_ip_range
+from zope.interface import Invalid
+import unittest
+
+
+class TestIPRangeParsing(unittest.TestCase):
+
+    def test_single_ipv4_address_is_parsed(self):
+        self.assertEqual(
+            [ip_network(u'192.168.0.1')],
+            parse_ip_range('192.168.0.1'))
+
+    def test_single_ipv4_cidr_network_is_parsed(self):
+        self.assertEqual(
+            [ip_network(u'192.168.0.0/16')],
+            parse_ip_range('192.168.0.0/16'))
+
+    def test_invalid_ip_address_raises_exception(self):
+        with self.assertRaises(InvalidIPRangeSpecification):
+            parse_ip_range('500.500.0.0')
+
+    def test_multiple_ipv4_addresses_are_parsed(self):
+        self.assertEqual(
+            [ip_network(u'10.0.0.1'), ip_network(u'192.168.0.1')],
+            parse_ip_range('10.0.0.1,192.168.0.1'))
+
+    def test_mix_of_single_adress_and_networks_is_parsed(self):
+        self.assertEqual(
+            [ip_network(u'10.1.1.5'), ip_network(u'192.168.0.0/16')],
+            parse_ip_range('10.1.1.5,192.168.0.0/16'))
+
+    def test_white_space_is_stripped(self):
+        self.assertEqual(
+            [ip_network(u'10.0.0.1'), ip_network(u'192.168.0.1')],
+            parse_ip_range('10.0.0.1  ,  192.168.0.1'))
+
+
+class TestPermittedIPChecking(unittest.TestCase):
+
+    def test_allowed_ip_in_single_ipv4_address_range(self):
+        self.assertTrue(
+            permitted_ip('192.168.0.1', '192.168.0.1')
+        )
+
+    def test_disallowed_ip_in_single_ipv4_address_range(self):
+        self.assertFalse(
+            permitted_ip('10.0.0.0', '192.168.0.1')
+        )
+
+    def test_allowed_ip_in_single_ipv4_cidr_network_range(self):
+        self.assertTrue(
+            permitted_ip('192.168.0.1', '192.168.0.0/16')
+        )
+
+    def test_disallowed_ip_in_single_ipv4_cidr_network_range(self):
+        self.assertFalse(
+            permitted_ip('10.0.0.0', '192.168.0.0/16')
+        )
+
+    def test_invalid_ip_address_is_rejected(self):
+        with self.assertRaises(ValueError):
+            permitted_ip('500.500.0.0', '192.168.0.0/16')
+
+    def test_invalid_ip_range_is_rejected(self):
+        self.assertFalse(
+            permitted_ip('10.0.0.1', '500.500.0.0/33')
+        )
+
+    def test_allowed_ip_in_multiple_ipv4_address_ranges(self):
+        self.assertTrue(
+            permitted_ip('10.0.0.5', '10.0.0.5, 192.168.0.1')
+        )
+        self.assertTrue(
+            permitted_ip('192.168.0.1', '10.0.0.5, 192.168.0.1')
+        )
+
+    def test_disallowed_ip_in_multiple_ipv4_address_ranges(self):
+        self.assertFalse(
+            permitted_ip('192.168.0.7', '10.0.0.5, 192.168.0.1')
+        )
+
+    def test_allowed_ip_in_multiple_ipv4_cidr_network_ranges(self):
+        self.assertTrue(
+            permitted_ip('192.168.5.5', '10.0.0.0/8, 192.168.0.0/16')
+        )
+        self.assertTrue(
+            permitted_ip('10.1.5.20', '10.0.0.0/8, 192.168.0.0/16')
+        )
+
+
+class TestIPRangeFormValidator(unittest.TestCase):
+
+    def test_single_ipv4_address_is_valid(self):
+        self.assertTrue(valid_ip_range('192.168.0.1'))
+
+    def test_single_ipv4_cidr_network_is_valid(self):
+        self.assertTrue(valid_ip_range('192.168.0.0/16'))
+
+    def test_invalid_ip_range_is_rejected(self):
+        with self.assertRaises(Invalid):
+            valid_ip_range('500.500.0.0/33')
+
+    def test_multiple_ipv4_addresses_are_valid(self):
+        self.assertTrue(valid_ip_range('10.0.0.1, 192.168.0.1'))
+
+    def test_multiple_ipv4_cidr_networks_are_valid(self):
+        self.assertTrue(valid_ip_range('10.0.0.0/8, 192.168.0.0/16'))

--- a/opengever/base/tests/test_ip_range_validation.py
+++ b/opengever/base/tests/test_ip_range_validation.py
@@ -1,7 +1,7 @@
 from ipaddress import ip_network
 from opengever.base.ip_range import InvalidIPRangeSpecification
+from opengever.base.ip_range import is_in_ip_range
 from opengever.base.ip_range import parse_ip_range
-from opengever.base.ip_range import permitted_ip
 from opengever.base.ip_range import valid_ip_range
 from zope.interface import Invalid
 import unittest
@@ -41,54 +41,54 @@ class TestIPRangeParsing(unittest.TestCase):
 
 class TestPermittedIPChecking(unittest.TestCase):
 
-    def test_allowed_ip_in_single_ipv4_address_range(self):
+    def test_ip_in_single_ipv4_address_range(self):
         self.assertTrue(
-            permitted_ip('192.168.0.1', '192.168.0.1')
+            is_in_ip_range('192.168.0.1', '192.168.0.1')
         )
 
-    def test_disallowed_ip_in_single_ipv4_address_range(self):
+    def test_ip_not_in_single_ipv4_address_range(self):
         self.assertFalse(
-            permitted_ip('10.0.0.0', '192.168.0.1')
+            is_in_ip_range('10.0.0.0', '192.168.0.1')
         )
 
-    def test_allowed_ip_in_single_ipv4_cidr_network_range(self):
+    def test_ip_in_single_ipv4_cidr_network_range(self):
         self.assertTrue(
-            permitted_ip('192.168.0.1', '192.168.0.0/16')
+            is_in_ip_range('192.168.0.1', '192.168.0.0/16')
         )
 
-    def test_disallowed_ip_in_single_ipv4_cidr_network_range(self):
+    def test_ip_not_in_single_ipv4_cidr_network_range(self):
         self.assertFalse(
-            permitted_ip('10.0.0.0', '192.168.0.0/16')
+            is_in_ip_range('10.0.0.0', '192.168.0.0/16')
         )
 
     def test_invalid_ip_address_is_rejected(self):
         with self.assertRaises(ValueError):
-            permitted_ip('500.500.0.0', '192.168.0.0/16')
+            is_in_ip_range('500.500.0.0', '192.168.0.0/16')
 
     def test_invalid_ip_range_is_rejected(self):
         self.assertFalse(
-            permitted_ip('10.0.0.1', '500.500.0.0/33')
+            is_in_ip_range('10.0.0.1', '500.500.0.0/33')
         )
 
-    def test_allowed_ip_in_multiple_ipv4_address_ranges(self):
+    def test_ip_in_multiple_ipv4_address_ranges(self):
         self.assertTrue(
-            permitted_ip('10.0.0.5', '10.0.0.5, 192.168.0.1')
+            is_in_ip_range('10.0.0.5', '10.0.0.5, 192.168.0.1')
         )
         self.assertTrue(
-            permitted_ip('192.168.0.1', '10.0.0.5, 192.168.0.1')
+            is_in_ip_range('192.168.0.1', '10.0.0.5, 192.168.0.1')
         )
 
-    def test_disallowed_ip_in_multiple_ipv4_address_ranges(self):
+    def test_ip_not_in_multiple_ipv4_address_ranges(self):
         self.assertFalse(
-            permitted_ip('192.168.0.7', '10.0.0.5, 192.168.0.1')
+            is_in_ip_range('192.168.0.7', '10.0.0.5, 192.168.0.1')
         )
 
-    def test_allowed_ip_in_multiple_ipv4_cidr_network_ranges(self):
+    def test_ip_in_multiple_ipv4_cidr_network_ranges(self):
         self.assertTrue(
-            permitted_ip('192.168.5.5', '10.0.0.0/8, 192.168.0.0/16')
+            is_in_ip_range('192.168.5.5', '10.0.0.0/8, 192.168.0.0/16')
         )
         self.assertTrue(
-            permitted_ip('10.1.5.20', '10.0.0.0/8, 192.168.0.0/16')
+            is_in_ip_range('10.1.5.20', '10.0.0.0/8, 192.168.0.0/16')
         )
 
 

--- a/opengever/core/upgrades/20200402115723_add_oc_disallowed_ip_range_setting/registry.xml
+++ b/opengever/core/upgrades/20200402115723_add_oc_disallowed_ip_range_setting/registry.xml
@@ -1,0 +1,4 @@
+<registry>
+  <!-- OFFICECONNECTOR -->
+  <records interface="opengever.officeconnector.interfaces.IOfficeConnectorSettings" />
+</registry>

--- a/opengever/core/upgrades/20200402115723_add_oc_disallowed_ip_range_setting/upgrade.py
+++ b/opengever/core/upgrades/20200402115723_add_oc_disallowed_ip_range_setting/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddOCDisallowedIPRangeSetting(UpgradeStep):
+    """Add oc disallowed ip range setting.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/document/document.py
+++ b/opengever/document/document.py
@@ -16,7 +16,7 @@ from opengever.document.versioner import Versioner
 from opengever.dossier.behaviors.dossier import IDossierMarker
 from opengever.meeting.proposal import ISubmittedProposal
 from opengever.officeconnector.helpers import create_oc_url
-from opengever.officeconnector.helpers import is_client_ip_in_office_connector_disallowed_ip_range
+from opengever.officeconnector.helpers import is_client_ip_in_office_connector_disallowed_ip_ranges
 from opengever.officeconnector.helpers import is_officeconnector_checkout_feature_enabled
 from opengever.officeconnector.mimetypes import get_editable_types
 from opengever.oneoffixx import is_oneoffixx_feature_enabled
@@ -318,7 +318,7 @@ class Document(Item, BaseDocumentMixin):
         return self.content_type().lower() in editable_mimetypes
 
     def is_checkout_and_edit_available(self):
-        if is_client_ip_in_office_connector_disallowed_ip_range():
+        if is_client_ip_in_office_connector_disallowed_ip_ranges():
             return False
 
         manager = queryMultiAdapter(

--- a/opengever/document/document.py
+++ b/opengever/document/document.py
@@ -16,6 +16,7 @@ from opengever.document.versioner import Versioner
 from opengever.dossier.behaviors.dossier import IDossierMarker
 from opengever.meeting.proposal import ISubmittedProposal
 from opengever.officeconnector.helpers import create_oc_url
+from opengever.officeconnector.helpers import is_client_ip_in_office_connector_disallowed_ip_range
 from opengever.officeconnector.helpers import is_officeconnector_checkout_feature_enabled
 from opengever.officeconnector.mimetypes import get_editable_types
 from opengever.oneoffixx import is_oneoffixx_feature_enabled
@@ -317,6 +318,9 @@ class Document(Item, BaseDocumentMixin):
         return self.content_type().lower() in editable_mimetypes
 
     def is_checkout_and_edit_available(self):
+        if is_client_ip_in_office_connector_disallowed_ip_range():
+            return False
+
         manager = queryMultiAdapter(
             (self, getRequest()), ICheckinCheckoutManager)
 

--- a/opengever/document/fileactions.py
+++ b/opengever/document/fileactions.py
@@ -10,7 +10,6 @@ from opengever.dossier.behaviors.dossier import IDossierMarker
 from opengever.officeconnector.helpers import is_officeconnector_attach_feature_enabled  # noqa
 from opengever.officeconnector.helpers import is_officeconnector_checkout_feature_enabled  # noqa
 from opengever.trash.trash import ITrashable
-from opengever.trash.trash import TrashError
 from opengever.wopi import is_wopi_feature_enabled
 from opengever.wopi.lock import get_lock_token
 from plone import api
@@ -24,6 +23,8 @@ from zope.interface import Interface
 @adapter(IBaseDocument, Interface)
 class BaseDocumentFileActions(object):
     """Define availability for actions and action sets on IBaseDocument.
+    This adapter defines the availability for mails, as it is overwritten
+    by DocumentFileActions for documents.
 
     Methods should return availability for one single action.
     """

--- a/opengever/document/interfaces.py
+++ b/opengever/document/interfaces.py
@@ -144,7 +144,7 @@ class IFileActions(Interface):
         """Return whether the action to edit metadata is available."""
 
     def is_any_checkout_or_edit_available():
-        """Return wheter any of the checkout or edit actions are available."""
+        """Return whether any of the checkout or edit actions are available."""
 
     def is_office_online_edit_action_available():
         """Return whether the edit with Office Online action is available."""

--- a/opengever/document/tests/test_fileactions.py
+++ b/opengever/document/tests/test_fileactions.py
@@ -128,7 +128,7 @@ class TestOfficeConnectorActions(IntegrationTestCase):
 
     def set_blacklisted_ip_range(self, ip_range):
         api.portal.set_registry_record(
-            'office_connector_disallowed_ip_range',
+            'office_connector_disallowed_ip_ranges',
             ip_range,
             interface=IOfficeConnectorSettings)
 

--- a/opengever/document/tests/test_fileactions.py
+++ b/opengever/document/tests/test_fileactions.py
@@ -2,11 +2,13 @@ from opengever.document.fileactions import BaseDocumentFileActions
 from opengever.document.fileactions import DocumentFileActions
 from opengever.document.interfaces import ICheckinCheckoutManager
 from opengever.document.interfaces import IFileActions
+from opengever.officeconnector.interfaces import IOfficeConnectorSettings
 from opengever.testing import IntegrationTestCase
 from opengever.testing.test_case import TestCase
 from opengever.wopi import discovery
 from opengever.wopi.interfaces import IWOPISettings
 from opengever.wopi.lock import create_lock
+from plone import api
 from plone.registry.interfaces import IRegistry
 from zope.component import getMultiAdapter
 from zope.component import getUtility
@@ -119,3 +121,90 @@ class TestOfficeOnlineEditable(IntegrationTestCase):
         create_lock(self.document, 'TOKEN')
         actions = getMultiAdapter((self.document, self.request), IFileActions)
         self.assertTrue(actions.is_office_online_edit_action_available())
+
+
+class TestOfficeConnectorActions(IntegrationTestCase):
+
+    def set_blacklisted_ip_range(self, ip_range):
+        api.portal.set_registry_record(
+            'office_connector_disallowed_ip_range',
+            ip_range,
+            interface=IOfficeConnectorSettings)
+
+    def test_oc_direct_checkout_action_availability(self):
+        self.login(self.regular_user)
+        actions = getMultiAdapter((self.document, self.request), IFileActions)
+        self.set_blacklisted_ip_range(u'192.168.0.0/16')
+
+        self.assertTrue(actions.is_oc_direct_checkout_action_available())
+
+        self.request._client_addr = '127.0.0.1'
+        self.assertTrue(actions.is_oc_direct_checkout_action_available())
+
+        self.request._client_addr = '192.168.0.0'
+        self.assertFalse(actions.is_oc_direct_checkout_action_available())
+
+    def test_oc_direct_edit_action_availability(self):
+        self.login(self.regular_user)
+        actions = getMultiAdapter((self.document, self.request), IFileActions)
+        self.set_blacklisted_ip_range(u'192.168.0.0/16')
+
+        self.assertFalse(actions.is_oc_direct_edit_action_available())
+
+        self.checkout_document(self.document)
+        self.assertTrue(actions.is_oc_direct_edit_action_available())
+
+        self.request._client_addr = '127.0.0.1'
+        self.assertTrue(actions.is_oc_direct_edit_action_available())
+
+        self.request._client_addr = '192.168.0.0'
+        self.assertFalse(actions.is_oc_direct_edit_action_available())
+
+    def test_oc_zem_checkout_action_availability(self):
+        self.deactivate_feature('officeconnector-checkout')
+
+        self.login(self.regular_user)
+        actions = getMultiAdapter((self.document, self.request), IFileActions)
+        self.set_blacklisted_ip_range(u'192.168.0.0/16')
+
+        self.assertTrue(actions.is_oc_zem_checkout_action_available())
+
+        self.request._client_addr = '127.0.0.1'
+        self.assertTrue(actions.is_oc_zem_checkout_action_available())
+
+        self.request._client_addr = '192.168.0.0'
+        self.assertFalse(actions.is_oc_zem_checkout_action_available())
+
+    def test_oc_zem_edit_action_availability(self):
+        self.deactivate_feature('officeconnector-checkout')
+
+        self.login(self.regular_user)
+        actions = getMultiAdapter((self.document, self.request), IFileActions)
+        self.set_blacklisted_ip_range(u'192.168.0.0/16')
+
+        self.assertFalse(actions.is_oc_zem_edit_action_available())
+
+        self.checkout_document(self.document)
+        self.assertTrue(actions.is_oc_zem_edit_action_available())
+
+        self.request._client_addr = '127.0.0.1'
+        self.assertTrue(actions.is_oc_zem_edit_action_available())
+
+        self.request._client_addr = '192.168.0.0'
+        self.assertFalse(actions.is_oc_zem_edit_action_available())
+
+    def test_oc_unsupported_file_checkout_action_availability(self):
+        self.login(self.regular_user)
+        actions = getMultiAdapter((self.document, self.request), IFileActions)
+        self.set_blacklisted_ip_range(u'192.168.0.0/16')
+
+        self.assertFalse(actions.is_oc_unsupported_file_checkout_action_available())
+
+        self.document.file.contentType = u'foo/bar'
+        self.assertTrue(actions.is_oc_unsupported_file_checkout_action_available())
+
+        self.request._client_addr = '127.0.0.1'
+        self.assertTrue(actions.is_oc_unsupported_file_checkout_action_available())
+
+        self.request._client_addr = '192.168.0.0'
+        self.assertFalse(actions.is_oc_unsupported_file_checkout_action_available())

--- a/opengever/dossier/templatefolder/form.py
+++ b/opengever/dossier/templatefolder/form.py
@@ -10,7 +10,7 @@ from opengever.contact.sources import ContactsSourceBinder
 from opengever.document.behaviors.metadata import IDocumentMetadata
 from opengever.dossier import _
 from opengever.dossier.command import CreateDocumentFromTemplateCommand
-from opengever.officeconnector.helpers import is_client_ip_in_office_connector_disallowed_ip_range
+from opengever.officeconnector.helpers import is_client_ip_in_office_connector_disallowed_ip_ranges
 from opengever.tabbedview.helper import document_with_icon
 from plone import api
 from plone.autoform import directives as form
@@ -171,7 +171,7 @@ class SelectTemplateDocumentWizardStep(
         super(SelectTemplateDocumentWizardStep, self).updateFieldsFromSchemata()
         if not is_contact_feature_enabled():
             self.fields = self.fields.omit('recipient')
-        if is_client_ip_in_office_connector_disallowed_ip_range():
+        if is_client_ip_in_office_connector_disallowed_ip_ranges():
             self.fields = self.fields.omit('edit_after_creation')
 
     @property

--- a/opengever/dossier/templatefolder/form.py
+++ b/opengever/dossier/templatefolder/form.py
@@ -10,7 +10,7 @@ from opengever.contact.sources import ContactsSourceBinder
 from opengever.document.behaviors.metadata import IDocumentMetadata
 from opengever.dossier import _
 from opengever.dossier.command import CreateDocumentFromTemplateCommand
-from opengever.dossier.templatefolder import get_template_folder
+from opengever.officeconnector.helpers import is_client_ip_in_office_connector_disallowed_ip_range
 from opengever.tabbedview.helper import document_with_icon
 from plone import api
 from plone.autoform import directives as form
@@ -171,6 +171,8 @@ class SelectTemplateDocumentWizardStep(
         super(SelectTemplateDocumentWizardStep, self).updateFieldsFromSchemata()
         if not is_contact_feature_enabled():
             self.fields = self.fields.omit('recipient')
+        if is_client_ip_in_office_connector_disallowed_ip_range():
+            self.fields = self.fields.omit('edit_after_creation')
 
     @property
     def schema(self):

--- a/opengever/officeconnector/helpers.py
+++ b/opengever/officeconnector/helpers.py
@@ -32,9 +32,10 @@ def is_client_ip_in_office_connector_disallowed_ip_ranges():
     request = getRequest()
     client_ip = request.getClientAddr()
     if not client_ip:
-        # trusted proxies are not set up correctly so we cannot
-        # check whether office connector should be disallowed for
-        # this request.
+        # If for some reason we cannot determine the client_ip, we
+        # cannot check whether office connector should be disallowed
+        # for this request. This could be a problem with the configuration
+        # of trusted proxies.
         log_msg_to_sentry('Cannot determine client IP.', request=request)
         return False
 

--- a/opengever/officeconnector/helpers.py
+++ b/opengever/officeconnector/helpers.py
@@ -28,7 +28,7 @@ def is_officeconnector_checkout_feature_enabled():
         )
 
 
-def is_client_ip_in_office_connector_disallowed_ip_range():
+def is_client_ip_in_office_connector_disallowed_ip_ranges():
     request = getRequest()
     client_ip = request.getClientAddr()
     if not client_ip:
@@ -39,7 +39,7 @@ def is_client_ip_in_office_connector_disallowed_ip_range():
         return False
 
     blacklisted_ip_ranges = api.portal.get_registry_record(
-        'office_connector_disallowed_ip_range',
+        'office_connector_disallowed_ip_ranges',
         interface=IOfficeConnectorSettings,
         )
     return is_in_ip_range(client_ip, blacklisted_ip_ranges)

--- a/opengever/officeconnector/interfaces.py
+++ b/opengever/officeconnector/interfaces.py
@@ -29,7 +29,7 @@ class IOfficeConnectorSettings(Interface):
         u'These are subtractive from the default list.',
         default=[])
 
-    office_connector_disallowed_ip_range = schema.TextLine(
+    office_connector_disallowed_ip_ranges = schema.TextLine(
         title=u'IP Range from which office connecctor cannot be used '
               u'(no checkout and edit)',
         required=False,

--- a/opengever/officeconnector/interfaces.py
+++ b/opengever/officeconnector/interfaces.py
@@ -1,3 +1,4 @@
+from opengever.base.ip_range import valid_ip_range
 from zope import schema
 from zope.interface import Interface
 
@@ -27,6 +28,18 @@ class IOfficeConnectorSettings(Interface):
         description=u'A list of Office Connector blacklisted MIME types.'
         u'These are subtractive from the default list.',
         default=[])
+
+    office_connector_disallowed_ip_range = schema.TextLine(
+        title=u'IP Range from which office connecctor cannot be used '
+              u'(no checkout and edit)',
+        required=False,
+        constraint=valid_ip_range,
+        description=(
+            u'IP range specification in '
+            u'<strong><a href="https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing#CIDR_notation">'  # noqa
+            u'CIDR notation</a></strong>. '
+            u'Multiple comma-separated addresses / networks may be supplied.'),
+    )
 
 
 class IOfficeConnectorSettingsView(Interface):


### PR DESCRIPTION
In this PR we add functionality to hide buttons that would triggere Office Connector when the User is on an EMM environment. 
Implementation:
- For this we add a configuration for ip ranges which are blacklisted for OfficeConnector actions. 
- When the client IP address is in the blacklisted ranges:
  - we do not display the OC actions (checkout and edit, edit...)
  - The `@actions` endpoint also does not return the OC actions
  - We omit the `edit_after_creation` field when 

For https://github.com/4teamwork/opengever.sg/issues/404

## Checkliste (Must have)

- [x] Changelog-Eintrag erstellt? _Falls im PR nicht vorhanden erachtet es der PR-Ersteller als unnötig._
- [ ] Aktualisierung Dokumentation (API/Deployment/...) aktualisiert? _Falls im PR nicht vorhanden erachtet es der PR-Ersteller als unnötig._
- [ ] Jira Link + Backlink im Jira / Github Issue Link. _Link muss im PR-Body vorhanden sein._


## Checkliste (optional)
- [x] Gibt es neue Funktionalität mit einem `Dokument`? Funktioniert das auch mit einem `Mail`?