### PR TITLE
Prevent documents being edited in Office Online from getting opened in OfficeConnector.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2020.2.2 (unreleased)
 ---------------------
 
+- Prevent documents being edited in Office Online from getting opened in OfficeConnector. [lgraf]
 - Bump ftw.solr version to 2.8.4 to get update of modified index. [njohner]
 - Add @listing-stats API endpoint to get statistical data from folderish content. [elioschmutz]
 - Fix public documentation build. [elioschmutz]

--- a/opengever/base/service.py
+++ b/opengever/base/service.py
@@ -22,6 +22,7 @@ class DocumentStatus(Service):
         payload['int_id'] = getUtility(IIntIds).getId(self.context)
         payload['title'] = self.context.title_or_id()
         payload['checked_out'] = self.context.is_checked_out()
+        payload['checked_out_collaboratively'] = self.context.is_collaborative_checkout()
         payload['checked_out_by'] = checkout_manager.get_checked_out_by()
         payload['locked'] = lock_manager.is_locked()
         if lock_manager.lock_info():

--- a/opengever/officeconnector/service.py
+++ b/opengever/officeconnector/service.py
@@ -79,6 +79,11 @@ class OfficeConnectorCheckoutURL(OfficeConnectorURL):
     """
 
     def render(self):
+        if self.context.is_collaborative_checkout():
+            # Documents currently being edited in Office Online must not be
+            # edited in Office Connector, even if checked out by the same user
+            raise Forbidden
+
         if is_officeconnector_checkout_feature_enabled():
             payload = {'action': 'checkout'}
 

--- a/opengever/officeconnector/tests/test_api_dossier_checkout.py
+++ b/opengever/officeconnector/tests/test_api_dossier_checkout.py
@@ -348,3 +348,29 @@ class TestOfficeconnectorDossierAPIWithCheckout(OCIntegrationTestCase):
                 )
 
             self.assertIsNone(oc_url)
+
+    @browsing
+    def test_checkout_checkin_collaboratively_checked_out_without_file(self, browser):
+        self.login(self.regular_user, browser)
+        self.get_checkout_manager(self.empty_document).checkout(collaborative=True)
+
+        with browser.expect_http_error(403):
+            oc_url = self.fetch_document_checkout_oc_url(
+                browser,
+                self.empty_document,
+                )
+
+            self.assertIsNone(oc_url)
+
+    @browsing
+    def test_checkout_checkin_collaboratively_checked_out_with_file(self, browser):
+        self.login(self.regular_user, browser)
+        self.get_checkout_manager(self.document).checkout(collaborative=True)
+
+        with browser.expect_http_error(403):
+            oc_url = self.fetch_document_checkout_oc_url(
+                browser,
+                self.document,
+                )
+
+            self.assertIsNone(oc_url)


### PR DESCRIPTION
This prevents documents that are currently being edited in Office Online from being opened (and edited) with OfficeConnector _when the user clicks the "Check out and edit" action in a **stale tab** that hasn't been updated_.

> ℹ️ This branch is deployed on https://lab.onegovgever.ch/ for easier review ℹ️ 

The **steps to reproduce** this issue are:
- Open two tabs for the same document (one that's not checked out yet)
- Start editing the document in Office Online in Tab 1
- Switch to Tab 2, and click the "Check out and edit" action

---

Before this fix, Office Connector was opened, and allowed to to make local changes that could never be saved. With this fix, this is prevented (**classic UI**):
- OC won't launch
- Instead a page refresh will be triggered
-  and then the user will then see the OC button disabled, and the status messages telling him that the document is being edited in Office Online.

![checkout_info](https://user-images.githubusercontent.com/405124/78243041-545cfd80-74e3-11ea-9252-44b2241b0b32.png)


In the **new frontend**, there will be a generic error message, and nothing will happen:

![message_frontend](https://user-images.githubusercontent.com/405124/78242998-460ee180-74e3-11ea-82f9-b51c50ecbae1.png)

This is a follow up to https://github.com/4teamwork/opengever.core/pull/6357#pullrequestreview-384047955

##  Checkliste (Must have)

- [x] Changelog-Eintrag erstellt? _Falls im PR nicht vorhanden erachtet es der PR-Ersteller als unnötig._
- [x] Aktualisierung Dokumentation (API/Deployment/...) aktualisiert? _Falls im PR nicht vorhanden erachtet es der PR-Ersteller als unnötig._
- [x] Jira Link + Backlink im Jira / Github Issue Link. _Link muss im PR-Body vorhanden sein._
  _(z.Z. Keine Jira issue)_


## Checkliste (optional)

- [x] Gibt es neue Funktionalität mit einem `Dokument`? Funktioniert das auch mit einem `Mail`?

