### PR TITLE
Fix CreateDocumentFromTemplateCommand.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2020.2.4 (unreleased)
 ---------------------
 
+- Fix solr indexing bug when creating a document from a template. [njohner]
 - Bump docxcompose to 1.1.0 for header/footer docproperty support. [deiferni]
 
 

--- a/opengever/dossier/tests/test_command.py
+++ b/opengever/dossier/tests/test_command.py
@@ -1,12 +1,17 @@
+from docx import Document
+from docxcompose.properties import CustomProperties
 from ftw.builder import Builder
 from ftw.builder import create
-from opengever.testing import IntegrationTestCase
+from opengever.document.docprops import TemporaryDocFile
 from opengever.dossier.behaviors.dossier import IDossierMarker
-from opengever.dossier.command import CreateDossierFromTemplateCommand
 from opengever.dossier.command import CreateDocumentFromTemplateCommand
+from opengever.dossier.command import CreateDossierFromTemplateCommand
+from opengever.testing import IntegrationTestCase
 
 
 class TestCreateDocumentFromTemplateCommand(IntegrationTestCase):
+
+    features = ('doc-properties',)
 
     def test_create_document_from_template(self):
         expected_title = 'My title'
@@ -26,6 +31,33 @@ class TestCreateDocumentFromTemplateCommand(IntegrationTestCase):
         document = command.execute()
         self.assertEqual(expected_title, document.title)
         self.assertIsNone(document.file)
+
+    def test_create_document_from_template_updates_docproperties(self):
+        expected_title = 'My title'
+        self.login(self.regular_user)
+        template = create(Builder('document')
+                          .within(self.dossiertemplate)
+                          .with_asset_file('with_gever_properties.docx'))
+
+        with TemporaryDocFile(template.file) as tmpfile:
+            template_properties = CustomProperties(Document(tmpfile.path)).items()
+        self.assertItemsEqual(
+            [('ogg.dossier.reference_number', 'Client1 / 2')],
+            template_properties)
+
+        command = CreateDocumentFromTemplateCommand(
+            self.dossier, template, expected_title)
+        document = command.execute()
+
+        with TemporaryDocFile(document.file) as tmpfile:
+            properties = CustomProperties(Document(tmpfile.path))
+
+        self.assertEquals(
+            'Client1 1.1 / 1',
+            properties['ogg.dossier.reference_number'])
+        self.assertEquals(
+            u'B\xe4rfuss K\xe4thi',
+            properties['ogg.user.title'])
 
 
 class TestCreateDossierFromTemplateCommand(IntegrationTestCase):


### PR DESCRIPTION
The CreateDocumentFromTemplateCommand changes the docproperties just after creating the object. This seems to break the indexing of the blob in solr.

I added a test to make sure docproperties still get updated upon document creation from template.

I also tested by hand that the document still gets indexed properly in solr (with up to date docproperties). While doing this I noticed that a document with docporperties gets added 7 times in the solr indexing queue (6 after this change).

For https://github.com/4teamwork/opengever.core/issues/6371

## Checkliste (Must have)

- [x] Changelog-Eintrag erstellt? _Falls im PR nicht vorhanden erachtet es der PR-Ersteller als unnötig._
- [ ] Aktualisierung Dokumentation (API/Deployment/...) aktualisiert? _Falls im PR nicht vorhanden erachtet es der PR-Ersteller als unnötig._
- [x] Jira Link + Backlink im Jira / Github Issue Link. _Link muss im PR-Body vorhanden sein._
