### PR TITLE
Revert: Do no longer send activity mails from the current user.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-2020.3.0 (unreleased)
+2020.2.3 (unreleased)
 ---------------------
 
 - Nothing changed yet.

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,7 @@ Changelog
 2020.2.3 (unreleased)
 ---------------------
 
-- Nothing changed yet.
+- Revert always using the `mail_from` for notifications, this breaks customers auto-reply use case. [deiferni]
 
 
 2020.2.2 (2020-04-03)

--- a/opengever/activity/mailer.py
+++ b/opengever/activity/mailer.py
@@ -85,8 +85,14 @@ class Mailer(object):
             data = {}
 
         msg = MIMEMultipart('related')
-        msg['From'] = make_addr_header(
-            self.default_addr_header, api.portal.get().email_from_address, 'utf-8')
+        actor = ogds_service().fetch_user(from_userid) if from_userid else None
+
+        if actor:
+            msg['From'] = make_addr_header(actor.fullname(),
+                                           actor.email, 'utf-8')
+        else:
+            msg['From'] = make_addr_header(
+                self.default_addr_header, api.portal.get().email_from_address, 'utf-8')
 
         if to_userid:
             to_email = ogds_service().fetch_user(to_userid).email

--- a/opengever/activity/tests/test_mail.py
+++ b/opengever/activity/tests/test_mail.py
@@ -142,7 +142,7 @@ class TestEmailNotification(IntegrationTestCase):
 
         mail = email.message_from_string(Mailing(self.portal).pop())
         self.assertEquals('foo@example.com', mail.get('To'))
-        self.assertEquals('OneGov GEVER <test@localhost>', get_header(mail, 'From'))
+        self.assertEquals('Ziegler Robert <robert.ziegler@gever.local>', get_header(mail, 'From'))
 
     @browsing
     def test_task_title_is_linked_to_resolve_notification_view(self, browser):

--- a/opengever/workspace/tests/test_invitation.py
+++ b/opengever/workspace/tests/test_invitation.py
@@ -73,7 +73,7 @@ class TestInvitationMail(IntegrationTestCase):
             self.assertEqual(1, len(mails))
             mail = email.message_from_string(mails[0])
 
-            self.assertIn('test@localhost', mail.get("From"))
+            self.assertIn(self.workspace_admin.getProperty('email'), mail.get("From"))
             self.assertEqual(self.regular_user.getProperty('email'), mail.get("To"))
 
             payload = {"iid": iid}

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 import os
 
 
-version = '2020.3.0.dev0'
+version = '2020.2.3.dev0'
 maintainer = '4teamwork AG'
 
 


### PR DESCRIPTION
Revert "Merge pull request #6334 from 4teamwork/es-6285-fix-activiy-mails-in-spam-folder"

This reverts commit a992c60c336efa602bb61fcb9a04120a2e7c5c3f, reversing
changes made to 9c0796ea1c2b0dc31ef52e812ade6bdc391eeb53.

This change is necessary for now as issues with mail dispatching surfaced during a release.
Also we broke the use-case of users getting mail auto-replies, e.g. when the assignee of a task is absent.

Reverted PR: https://github.com/4teamwork/opengever.core/pull/6334
Origin of reverted change: https://github.com/4teamwork/opengever.core/issues/6258#issuecomment-600501160

## Checkliste (Must have)

_Alles muss gemacht/angehakt werden._

- [x] Changelog-Eintrag erstellt? _Falls im PR nicht vorhanden erachtet es der PR-Ersteller als unnötig._
- [ ] Aktualisierung Dokumentation (API/Deployment/...) aktualisiert? _Falls im PR nicht vorhanden erachtet es der PR-Ersteller als unnötig._
- [ ] Jira Link + Backlink im Jira / Github Issue Link. _Link muss im PR-Body vorhanden sein._
