### PR TITLE
Extend the `meeting.json` with a `agenda_item_list` property

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,7 @@ Changelog
 2020.3.0rc2 (unreleased)
 ------------------------
 
-- Nothing changed yet.
+- Extend the `meeting.json`, which will be generated for an exported meeting, with a `agenda_item_list` property which contains a link to the agenda item list document. [elioschmutz]
 
 
 2020.3.0rc1 (2020-04-09)

--- a/opengever/meeting/zipexport.py
+++ b/opengever/meeting/zipexport.py
@@ -169,6 +169,13 @@ class MeetingJSONSerializer(MeetingDocumentWithFileTraverser):
             'modified': format_modified(document.modified()),
         }
 
+    def traverse_agenda_item_list_document(self, document):
+        self.data['agenda_item_list'] = {
+            'checksum': IBumblebeeDocument(document).get_checksum(),
+            'file': self.zipper.get_filename(document),
+            'modified': format_modified(document.modified()),
+        }
+
     def traverse_agenda_item(self, agenda_item):
         self.current_agenda_item_data = {
             'opengever_id': agenda_item.agenda_item_id,


### PR DESCRIPTION
Exporting a meeting to a zip file will generate a `meeting.json`-file which contains properties with links to the generated documents and agenda items. The` agenda_item_list` document have been included in the zip-file but have not been linked in the `meeting.json`.

This commit extends the `meeting.json` whith the `agenda_item_list` document.

Issuer: https://4teamwork.atlassian.net/browse/GEVER-149

## Checkliste (Must have)

_Alles muss gemacht/angehakt werden._

- [x] Changelog-Eintrag erstellt? _Falls im PR nicht vorhanden erachtet es der PR-Ersteller als unnötig._
- [x] Aktualisierung Dokumentation (API/Deployment/...) aktualisiert? _Falls im PR nicht vorhanden erachtet es der PR-Ersteller als unnötig._
- [x] Jira Link + Backlink im Jira / Github Issue Link. _Link muss im PR-Body vorhanden sein._
