### PR TITLE
Improve the documentation.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -211,30 +211,15 @@ respective user in our development LDAP tree.
 Installing and activating Solr
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Extend the Solr configuration in your `buildout.cfg` and add the Solr directive:
+Solr is installed automatically during Buildout but needs to be activated in GEVER.
 
-.. code::
-
-    [buildout]
-    extends =
-        development.cfg
-        https://raw.githubusercontent.com/4teamwork/gever-buildouts/master/solr.cfg
-    solr-port = 8983
-
-
-Buildout
-
-.. code::
-
-    $ bin/buildout
-
-Then start Solr
+Just start Solr:
 
 .. code::
 
     $ bin/solr start
 
-Run the `activate_solr` maintenance script:
+Then run the `activate_solr` maintenance script:
 
 .. code::
 


### PR DESCRIPTION
The section in the README describing how to set up a local Solr for development purposes is outdated and following it will result in a configuration conflict:

```
    raise ConfigurationConflictError(conflicts)
zope.configuration.xmlconfig.ZopeXMLConfigurationError: File "/Users/mbaechtold/Developer/github.com/4teamwork/opengever.core/parts/instance/etc/site.zcml", line 19.2-19.64
    ConfigurationConflictError: Conflicting configuration actions
  For: ('utility', <InterfaceClass ftw.solr.interfaces.ISolrConnectionConfig>, '')
    File "/Users/mbaechtold/Developer/github.com/4teamwork/opengever.core/parts/instance/etc/package-includes/999-additional-overrides.zcml", line 19.4-21.41
          <solr:connection host="localhost"
                           port="8983"
                           base="/solr/plone"/>
    File "/Users/mbaechtold/Developer/github.com/4teamwork/opengever.core/parts/instance/etc/package-includes/999-additional-overrides.zcml", line 24.4-26.41
          <solr:connection host="localhost"
                           port="8983"
                           base="/solr/plone"/>
```

The buildout configuration no longer has to be tweaked manually since the advent of https://github.com/4teamwork/opengever.core/pull/5256 because Solr is installed automatically in the development setup.

This pull requests only updates the README.

## Checkliste (Must have)

_Alles muss gemacht/angehakt werden._

- [ ] Changelog-Eintrag erstellt? _Falls im PR nicht vorhanden erachtet es der PR-Ersteller als unnötig._
- [x] Aktualisierung Dokumentation (API/Deployment/...) aktualisiert? _Falls im PR nicht vorhanden erachtet es der PR-Ersteller als unnötig._
- [ ] Jira Link + Backlink im Jira / Github Issue Link. _Link muss im PR-Body vorhanden sein._

