### PR TITLE
Fix `task_type_helper` to respect the current language for the ram-cache.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2020.3.0rc2 (unreleased)
 ------------------------
 
+- Fix `task_type_helper` to respect the current language for the ram-cache. [elioschmutz]
 - Extend the ftw.mail.mail workflow with teamraum specific roles. [elioschmutz]
 - Extend the `meeting.json`, which will be generated for an exported meeting, with a `agenda_item_list` property which contains a link to the agenda item list document. [elioschmutz]
 

--- a/opengever/task/helper.py
+++ b/opengever/task/helper.py
@@ -1,10 +1,11 @@
 from opengever.task import _
 from opengever.task.util import getTaskTypeVocabulary
+from plone.api.portal import get_current_language
 from plone.memoize import ram
 from zope.component.hooks import getSite
 
-#XXX remove me
-@ram.cache(lambda m, i, value: value)
+
+@ram.cache(lambda m, i, value: '{}-{}'.format(value, get_current_language()))
 def task_type_helper(item, value):
     """Translate the task type with the vdex vocabulary, which provides
     its own translations stored in the vdex files.


### PR DESCRIPTION
The `task_type_helper` is a helper function for listings to return the task type title based on a task_type. The used vocabulary is a vdex vocabulary and provides language specific task type titles. The function is decorated with a ram-cache but only with the task_type as a cache-key. That means, if the user changes the language, the cache key is still valid and the returned value will be in the old language.

To fix this problem, we have to make the cache key language dependent.

ℹ️ I don't know why we should remove the function or the cache-decorator (see code). 

ℹ️ This PR fixes both listings, in the old and in the new UI.

## Before
![screen2](https://user-images.githubusercontent.com/557005/79984717-db314480-84a9-11ea-9639-99f293733761.gif)

## After
![screen1](https://user-images.githubusercontent.com/557005/79984585-ab823c80-84a9-11ea-9293-47cc4733b26a.gif)

Jira: https://4teamwork.atlassian.net/browse/GEVER-99

## Checkliste (Must have)

- [x] Changelog-Eintrag erstellt? _Falls im PR nicht vorhanden erachtet es der PR-Ersteller als unnötig._
- [x] Aktualisierung Dokumentation (API/Deployment/...) aktualisiert? _Falls im PR nicht vorhanden erachtet es der PR-Ersteller als unnötig._
- [x] Jira Link + Backlink im Jira / Github Issue Link. _Link muss im PR-Body vorhanden sein._

## Checkliste (optional)

_Nur Zutreffendes soll angehakt stehengelassen werden._

- [ ] Gibt es neue Funktionalität mit einem `Dokument`? Funktioniert das auch mit einem `Mail`?
- [ ] Wurde etwas an der `Aufgabe` angepasst? Funktioniert das auch mit einer `Weiterleitung`?
- [ ] Profil angepasst? Sind UpgradeSteps vorhanden/nötig?:
- [ ] Sind UpgradeSteps `deferrable`, oder können gewisse Schritte des Upgrades konditional ausgeführt werden?
- [ ] Gibts es eine DB-Schema Migration?
  - [ ] Wurde alle Columns/Änderungen aus dem Modell in einer DB-Schema Migration nachgeführt.
  - [ ] Sind Constraint-Namen maximal 30 Zeichen lang (`Oracle`)?
- [ ] Gibt es ein neues Feature-Flag? Wurden dafür Tests mit aktiviertem und deaktivierte Flag geschrieben?
- [ ] Könnten Kundeninstallationen von den Änderungen betroffen sein? Müssen Policies angepasst werden?
- [ ] Gibt es neue Übersetzungen?
  - [ ] Sind alle msg-Strings in Übersetzungen Unicode?
  - [ ] Wird die richtige i18n-domain verwendet (Copy-Paste Fehler sind hier häufig)?
- [ ] Wenn bei Schema-definitionen `missing_value` spezifiziert ist muss immer auch `default` auf den gleichen Wert gesetzt werden
