### PR TITLE
Task GET API: Also include info about containing dossier.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2020.3.0rc2 (unreleased)
 ------------------------
 
+- Task GET API: Also include info about containing dossier. [mbaechtold]
 - Fix `task_type_helper` to respect the current language for the ram-cache. [elioschmutz]
 - Extend the ftw.mail.mail workflow with teamraum specific roles. [elioschmutz]
 - Extend the `meeting.json`, which will be generated for an exported meeting, with a `agenda_item_list` property which contains a link to the agenda item list document. [elioschmutz]

--- a/docs/public/dev-manual/api/tasks.rst
+++ b/docs/public/dev-manual/api/tasks.rst
@@ -385,7 +385,7 @@ Aufgabenverlauf
 Der Verlauf einer Aufgabe ist in der GET Repräsentation einer Aufgaben unter dem Attribut ``responses`` enthalten.
 
 
-**Beispiel-Respones auf ein GET Request**:
+**Beispiel-Response auf ein GET Request**:
 
    .. sourcecode:: http
 
@@ -425,5 +425,29 @@ Der Verlauf einer Aufgabe ist in der GET Repräsentation einer Aufgaben unter de
           },
         ]
         "responsible": "david.erni",
+        "...": "...",
+      }
+
+Übergeordnetes Dossier
+----------------------
+Angaben zum übergeordneten Dossier einer Aufgabe ist in der GET Repräsentation der Aufgaben unter dem Attribut ``containing_dossier`` enthalten. Dies ist auch bei Unteraufgaben und Weiterleitungen im Eingangskorb der Fall.
+
+
+**Beispiel-Response auf ein GET Request**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 200 OK
+      Accept: application/json
+
+      {
+        "@id": "http://example.org/ordnungssystem/fuehrung/dossier-1/task-5",
+        "@type": "opengever.task.task",
+        "UID": "3a551f6e3b62421da029dfceb71656e6",
+        "...": "...",
+        "containing_dossier": {
+          "@id": "http://example.org/ordnungssystem/fuehrung/dossier-1",
+          "title": "Ein Dossier mit Tasks",
+        },
         "...": "...",
       }

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -30,6 +30,7 @@
   <adapter factory=".workspace.SerializeWorkspaceToJson" />
   <adapter factory=".response.ResponseDefaultFieldSerializer" />
   <adapter factory=".response.SerializeResponseToJson" />
+  <adapter factory=".task.SerializeTaskToJson" />
   <adapter factory=".task.SerializeTaskResponseToJson" />
   <adapter factory=".task.TaskDeserializeFromJson" />
   <adapter factory=".proposal.SerializeProposalResponseToJson" />

--- a/opengever/api/tests/test_task.py
+++ b/opengever/api/tests/test_task.py
@@ -141,6 +141,54 @@ class TestTaskSerialization(IntegrationTestCase):
              u'added_objects': []},
             browser.json)
 
+    @browsing
+    def test_containing_dossier_for_task(self, browser):
+        self.login(self.regular_user, browser=browser)
+        browser.open(self.task, method="GET", headers=self.api_headers)
+        self.maxDiff = None
+        self.assertDictEqual(
+            {
+                u'@id': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1',
+                u'@type': u'opengever.dossier.businesscasedossier',
+                u'description': u'Alle aktuellen Vertr\xe4ge mit der kantonalen Finanzverwaltung sind hier abzulegen. Vertr\xe4ge vor 2016 geh\xf6ren ins Archiv.',  # noqa
+                u'review_state': u'dossier-state-active',
+                u'title': u'Vertr\xe4ge mit der kantonalen Finanzverwaltung',
+            },
+            browser.json['containing_dossier']
+        )
+
+    @browsing
+    def test_containing_dossier_for_subtask(self, browser):
+        self.login(self.regular_user, browser=browser)
+        browser.open(self.subtask, method="GET", headers=self.api_headers)
+        self.maxDiff = None
+        self.assertDictEqual(
+            {
+                u'@id': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1',
+                u'@type': u'opengever.dossier.businesscasedossier',
+                u'description': u'Alle aktuellen Vertr\xe4ge mit der kantonalen Finanzverwaltung sind hier abzulegen. Vertr\xe4ge vor 2016 geh\xf6ren ins Archiv.',  # noqa
+                u'review_state': u'dossier-state-active',
+                u'title': u'Vertr\xe4ge mit der kantonalen Finanzverwaltung',
+            },
+            browser.json['containing_dossier']
+        )
+
+    @browsing
+    def test_containing_dossier_for_inbox_forwarding(self, browser):
+        self.login(self.secretariat_user, browser=browser)
+        browser.open(self.inbox_forwarding, method="GET", headers=self.api_headers)
+        self.maxDiff = None
+        self.assertDictEqual(
+            {
+                u'@id': u'http://nohost/plone/eingangskorb',
+                u'@type': u'opengever.inbox.inbox',
+                u'description': u'',
+                u'review_state': u'inbox-state-default',
+                u'title': u'Eingangsk\xf6rbli',
+            },
+            browser.json['containing_dossier']
+        )
+
 
 class TestTaskCommentSync(FunctionalTestCase):
 


### PR DESCRIPTION
The response of a GET request of a task now includes the information about the containing dossier of the task. This is achieved by using a custom serializer for the task.

Belongs to the Jira task https://4teamwork.atlassian.net/browse/GEVER-245

## Checklist (Must have)

- [x] Changelog entry
- [x] Documentation updated (notably for API and deployment)
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


## Checklist (optional)

- [x] New functionality  for `task` also works for `forwarding`