### PR TITLE
Add is_subdossier to catalog metadata.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 ------------------------
 
 - Improve performance when resolving large dossiers. [deiferni]
+- Add is_subdossier to catalog metadata. [deiferni]
 - Add Bumblebee auto refresh feature to policy template. [2e12]
 - Task GET API: Also include info about containing dossier. [mbaechtold]
 - Fix `task_type_helper` to respect the current language for the ram-cache. [elioschmutz]

--- a/opengever/base/configure.zcml
+++ b/opengever/base/configure.zcml
@@ -381,6 +381,11 @@
       name="has_sametype_children"
       />
 
+  <adapter
+      factory=".indexes.is_subdossier"
+      name="is_subdossier"
+      />
+
   <utility factory=".sequence.SequenceNumber" />
 
   <adapter factory=".quickupload.OGQuickUploadCapableFileFactory" />

--- a/opengever/base/indexes.py
+++ b/opengever/base/indexes.py
@@ -92,3 +92,8 @@ def has_sametype_children(obj):
     # portal_type attribute.
     return any(obj.portal_type == getattr(aq_base(child), "portal_type", None)
                for child in obj.objectValues())
+
+
+@indexer(IDexterityContent)
+def is_subdossier(obj):
+    return None

--- a/opengever/base/tests/test_indexers.py
+++ b/opengever/base/tests/test_indexers.py
@@ -190,3 +190,97 @@ class TestHasSameTypeChildren(IntegrationTestCase):
 
         self.assert_metadata_value(False, 'has_sametype_children',
                                    self.empty_repofolder)
+
+
+class TestIsSubdossierIndexer(IntegrationTestCase):
+
+    def test_is_subdossier_for_dossier(self):
+        self.login(self.regular_user)
+
+        self.assert_index_value(False, 'is_subdossier', self.dossier)
+        self.assert_metadata_value(False, 'is_subdossier', self.dossier)
+
+    def test_is_subdossier_for_meetingdossier(self):
+        self.login(self.regular_user)
+
+        self.assert_index_value(False, 'is_subdossier', self.meeting_dossier)
+        self.assert_metadata_value(False, 'is_subdossier', self.meeting_dossier)
+
+    def test_is_subdossier_for_subdossiers(self):
+        self.login(self.regular_user)
+
+        self.assert_index_value(True, 'is_subdossier', self.subdossier)
+        self.assert_metadata_value(True, 'is_subdossier', self.subdossier)
+        self.assert_index_value(True, 'is_subdossier', self.subsubdossier)
+        self.assert_metadata_value(True, 'is_subdossier', self.subsubdossier)
+
+    def test_is_subdossier_for_dossiertemplate(self):
+        self.login(self.regular_user)
+
+        self.assert_index_value(False, 'is_subdossier',
+                                self.dossiertemplate)
+        self.assert_metadata_value(False, 'is_subdossier',
+                                   self.dossiertemplate)
+
+    def test_is_subdossier_for_subdossiertemplate(self):
+        self.login(self.regular_user)
+
+        self.assert_index_value(True, 'is_subdossier',
+                                self.subdossiertemplate)
+        self.assert_metadata_value(True, 'is_subdossier',
+                                   self.subdossiertemplate)
+
+    def test_is_subdossier_for_reporoot(self):
+        self.login(self.regular_user)
+
+        self.assert_index_value(False, 'is_subdossier',
+                                self.repository_root)
+        self.assert_metadata_value(None, 'is_subdossier',
+                                   self.repository_root)
+
+    def test_is_subdossier_for_repofolders(self):
+        self.login(self.regular_user)
+
+        self.assert_index_value(False, 'is_subdossier',
+                                self.branch_repofolder)
+        self.assert_metadata_value(None, 'is_subdossier',
+                                   self.branch_repofolder)
+        self.assert_index_value(False, 'is_subdossier',
+                                self.leaf_repofolder)
+        self.assert_metadata_value(None, 'is_subdossier',
+                                   self.leaf_repofolder)
+
+    def test_is_subdossier_for_tasks(self):
+        self.login(self.regular_user)
+
+        self.assert_index_value(False, 'is_subdossier', self.task)
+        self.assert_metadata_value(None, 'is_subdossier', self.task)
+        self.assert_index_value(False, 'is_subdossier', self.subtask)
+        self.assert_metadata_value(None, 'is_subdossier', self.subtask)
+
+    def test_is_subdossier_for_workspaces(self):
+        self.login(self.workspace_member)
+
+        self.assert_index_value(False, 'is_subdossier', self.workspace_root)
+        self.assert_metadata_value(None, 'is_subdossier', self.workspace_root)
+        self.assert_index_value(False, 'is_subdossier', self.workspace)
+        self.assert_metadata_value(None, 'is_subdossier', self.workspace)
+        self.assert_index_value(False, 'is_subdossier', self.workspace_folder)
+        self.assert_metadata_value(None, 'is_subdossier', self.workspace_folder)
+
+    def test_is_subdossier_for_private_folder(self):
+        self.login(self.regular_user)
+
+        self.assert_index_value(False, 'is_subdossier', self.private_root)
+        self.assert_metadata_value(None, 'is_subdossier', self.private_root)
+
+        self.assert_index_value(False, 'is_subdossier', self.private_folder)
+        self.assert_metadata_value(None, 'is_subdossier', self.private_folder)
+
+    def test_is_subdossier_for_private_dossier(self):
+        self.login(self.regular_user)
+
+        self.assert_index_value(False, 'is_subdossier',
+                                self.private_dossier)
+        self.assert_metadata_value(False, 'is_subdossier',
+                                   self.private_dossier)

--- a/opengever/core/profiles/default/catalog.xml
+++ b/opengever/core/profiles/default/catalog.xml
@@ -39,6 +39,7 @@
   <column value="containing_subdossier" />
   <column value="containing_dossier" />
   <column value="retention_expiration" />
+  <column value="is_subdossier" />
 
   <!-- TASK -->
   <column value="deadline" />

--- a/opengever/core/upgrades/20200429114820_add_is_subdossier_to_catalog_metadata/catalog.xml
+++ b/opengever/core/upgrades/20200429114820_add_is_subdossier_to_catalog_metadata/catalog.xml
@@ -1,0 +1,3 @@
+<object name="portal_catalog">
+    <column value="is_subdossier" />
+</object>

--- a/opengever/core/upgrades/20200429114820_add_is_subdossier_to_catalog_metadata/upgrade.py
+++ b/opengever/core/upgrades/20200429114820_add_is_subdossier_to_catalog_metadata/upgrade.py
@@ -1,0 +1,25 @@
+from ftw.upgrade import UpgradeStep
+from opengever.dossier.behaviors.dossier import IDossierMarker
+from opengever.dossier.dossiertemplate.behaviors import IDossierTemplateMarker
+
+
+class AddIsSubdossierToCatalogMetadata(UpgradeStep):
+    """Add is_subdossier to catalog metadata.
+
+    We purposefully only reindex dossiers to make sure metadata is updated
+    since those are the only types where it should be truly relevant.
+    """
+
+    deferrable = True
+
+    def __call__(self):
+        self.install_upgrade_profile()
+        query = {
+            'object_provides': [IDossierMarker.__identifier__,
+                                IDossierTemplateMarker.__identifier__]
+            }
+        # To avoid reindexing the whole objects, we pick any index that exists
+        # for all objects and is fast to compute.
+        # is_subdossier is already a solr field, so we don't need to pass it
+        # as an index here.
+        self.catalog_reindex_objects(query, idxs=['UID'])

--- a/opengever/document/tests/test_copy_document.py
+++ b/opengever/document/tests/test_copy_document.py
@@ -135,6 +135,7 @@ class TestCopyDocuments(IntegrationTestCase):
                               'has_sametype_children',
                               'in_response_to',
                               'is_folderish',
+                              'is_subdossier',
                               'is_subtask',
                               'issuer',
                               'last_comment_date',

--- a/opengever/dossier/configure.zcml
+++ b/opengever/dossier/configure.zcml
@@ -125,11 +125,6 @@
       />
 
   <adapter
-      factory=".indexers.DossierTemplateSubjectIndexer"
-      name="Subject"
-      />
-
-  <adapter
       factory=".indexers.startIndexer"
       name="start"
       />
@@ -172,11 +167,6 @@
   <adapter
       factory=".indexers.SearchableTextExtender"
       name="IDossier"
-      />
-
-  <adapter
-      factory=".indexers.DossierTemplateSearchableTextExtender"
-      name="IDossierTemplate"
       />
 
   <adapter

--- a/opengever/dossier/configure.zcml
+++ b/opengever/dossier/configure.zcml
@@ -165,6 +165,11 @@
       />
 
   <adapter
+      factory=".indexers.is_subdossier"
+      name="is_subdossier"
+      />
+
+  <adapter
       factory=".indexers.SearchableTextExtender"
       name="IDossier"
       />

--- a/opengever/dossier/dossiertemplate/configure.zcml
+++ b/opengever/dossier/dossiertemplate/configure.zcml
@@ -3,6 +3,16 @@
     xmlns:browser="http://namespaces.zope.org/browser"
     i18n_domain="opengever.dossier">
 
+  <adapter
+      factory=".indexers.DossierTemplateSubjectIndexer"
+      name="Subject"
+      />
+
+  <adapter
+      factory=".indexers.DossierTemplateSearchableTextExtender"
+      name="IDossierTemplate"
+      />
+
   <browser:page
       for="opengever.repository.interfaces.IRepositoryFolder"
       name="dossier_with_template"

--- a/opengever/dossier/dossiertemplate/configure.zcml
+++ b/opengever/dossier/dossiertemplate/configure.zcml
@@ -9,6 +9,11 @@
       />
 
   <adapter
+      factory=".indexers.is_subdossier"
+      name="is_subdossier"
+      />
+
+  <adapter
       factory=".indexers.DossierTemplateSearchableTextExtender"
       name="IDossierTemplate"
       />

--- a/opengever/dossier/dossiertemplate/indexers.py
+++ b/opengever/dossier/dossiertemplate/indexers.py
@@ -14,3 +14,8 @@ def DossierTemplateSubjectIndexer(obj):
 @adapter(IDossierTemplateMarker)
 class DossierTemplateSearchableTextExtender(SearchableTextExtender):
     """Make dossier templates full text searchable."""
+
+
+@indexer(IDossierTemplateMarker)
+def is_subdossier(obj):
+    return obj.is_subdossier()

--- a/opengever/dossier/dossiertemplate/indexers.py
+++ b/opengever/dossier/dossiertemplate/indexers.py
@@ -1,0 +1,16 @@
+from opengever.dossier.behaviors.dossier import IDossier
+from opengever.dossier.dossiertemplate.behaviors import IDossierTemplateMarker
+from opengever.dossier.indexers import SearchableTextExtender
+from plone.indexer import indexer
+from zope.component import adapter
+
+
+@indexer(IDossierTemplateMarker)
+def DossierTemplateSubjectIndexer(obj):
+    aobj = IDossier(obj)
+    return aobj.keywords
+
+
+@adapter(IDossierTemplateMarker)
+class DossierTemplateSearchableTextExtender(SearchableTextExtender):
+    """Make dossier templates full text searchable."""

--- a/opengever/dossier/indexers.py
+++ b/opengever/dossier/indexers.py
@@ -8,7 +8,6 @@ from opengever.dossier.behaviors.dossier import IDossier
 from opengever.dossier.behaviors.dossier import IDossierMarker
 from opengever.dossier.behaviors.filing import IFilingNumber
 from opengever.dossier.behaviors.filing import IFilingNumberMarker
-from opengever.dossier.dossiertemplate.behaviors import IDossierTemplateMarker
 from opengever.dossier.resolve import AfterResolveJobs
 from opengever.dossier.utils import get_main_dossier
 from opengever.inbox.inbox import IInbox
@@ -30,12 +29,6 @@ def after_resolve_jobs_pending_indexer(obj):
 
 @indexer(IDossierMarker)
 def DossierSubjectIndexer(obj):
-    aobj = IDossier(obj)
-    return aobj.keywords
-
-
-@indexer(IDossierTemplateMarker)
-def DossierTemplateSubjectIndexer(obj):
     aobj = IDossier(obj)
     return aobj.keywords
 
@@ -222,8 +215,3 @@ class SearchableTextExtender(object):
             searchable.append(searchable_external_reference.encode('utf-8'))
 
         return ' '.join(searchable)
-
-
-@adapter(IDossierTemplateMarker)
-class DossierTemplateSearchableTextExtender(SearchableTextExtender):
-    """Make dossier templates full text searchable."""

--- a/opengever/dossier/indexers.py
+++ b/opengever/dossier/indexers.py
@@ -169,6 +169,11 @@ def containing_subdossier(obj):
     return ''
 
 
+@indexer(IDossierMarker)
+def is_subdossier(obj):
+    return obj.is_subdossier()
+
+
 @implementer(dexteritytextindexer.IDynamicTextIndexExtender)
 @adapter(IDossierMarker)
 class SearchableTextExtender(object):

--- a/opengever/dossier/tests/test_catalog.py
+++ b/opengever/dossier/tests/test_catalog.py
@@ -5,15 +5,6 @@ from plone import api
 
 class TestCatalog(IntegrationTestCase):
 
-    def test_is_subdossier_index(self):
-        """The ``is_subdossier`` index indicates whether a dossier is
-        a subdossier.
-        """
-        self.login(self.dossier_responsible)
-        self.assert_index_value(False, 'is_subdossier', self.dossier)
-        self.assert_index_value(True, 'is_subdossier', self.subdossier)
-        self.assert_index_value('', 'is_subdossier', self.leaf_repofolder)
-
     def test_reindex_is_subdossier_index_after_moving_subdossier(self):
         self.login(self.dossier_responsible)
         api.content.move(source=self.subdossier, target=self.leaf_repofolder)

--- a/opengever/dossier/tests/test_indexer.py
+++ b/opengever/dossier/tests/test_indexer.py
@@ -68,20 +68,6 @@ class TestDossierIndexers(IntegrationTestCase):
             obj2brain(self.document).containing_dossier,
             )
 
-    def test_is_subdossier_index(self):
-        self.login(self.regular_user)
-
-        self.dossier.reindexObject()
-        self.subdossier.reindexObject()
-        self.dossiertemplate.reindexObject()
-        self.subdossiertemplate.reindexObject()
-
-        index_name = 'is_subdossier'
-        self.assert_index_value(False, index_name, self.dossier)
-        self.assert_index_value(False, index_name, self.dossiertemplate)
-        self.assert_index_value(True, index_name, self.subdossier)
-        self.assert_index_value(True, index_name, self.subdossiertemplate)
-
     def test_containing_subdossier(self):
         self.login(self.regular_user)
 

--- a/opengever/dossier/tests/test_move_items.py
+++ b/opengever/dossier/tests/test_move_items.py
@@ -196,6 +196,7 @@ class TestMoveItemsUpdatesIndexAndMetadata(IntegrationTestCase, MoveItemsHelper)
                               'has_sametype_children',
                               'in_response_to',
                               'is_folderish',
+                              'is_subdossier',
                               'is_subtask',
                               'issuer',
                               'last_comment_date',
@@ -371,11 +372,10 @@ class TestMoveItemsUpdatesIndexAndMetadata(IntegrationTestCase, MoveItemsHelper)
             reindexed_moved_indexdata = self.get_catalog_indexdata(moved)
 
         # Some index data is not up to date, but does not have to be
-        # such as "is_subdossier".
         # Other data should be up to date but is not. For example the SearchableText
         # is not reindexed on purpose for efficiency, but it actually changes
         # because the reference number changes...
-        not_up_to_date = ['SearchableText', 'is_subdossier', 'reference', 'start']
+        not_up_to_date = ['SearchableText', 'reference', 'start']
         for key in not_up_to_date:
             self.assertNotEqual(moved_indexdata.pop(key),
                                 reindexed_moved_indexdata.pop(key))


### PR DESCRIPTION
It is already an index, but unfortunately not in metadata. We need it for some still catalog based api listings, namely when displaying item summaries for a parent in e.g. a `GET` request on the parent.

I've noticed that documents and other objects within dossiers seem to index the parents value via acquisition. I've disabled that behavior and registered one generic indexer which does return `None` and specific indexers for content types where we should access the `is_subdossier` method on the object.

I have only added an upgrade step for dossiers (and templatedossiers) as those are the only types where the new metadata field is truly relevant. This is a trade-off leaning towards upgrade-step performance.

it will slightly change the indexers behavior:
- the index will contain `False` for all objects unless it is a dossier and a subdossier, then it will be `True`, this is tue to a call to `bool` in the `BooleanIndex`
- the metadata will contain `False` for main dossiers, `True` for subdossiers and `None` for all other objects

See https://4teamwork.atlassian.net/browse/GEVER-122

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry_
- [ ] Documentation updated (notably for API and deployment)
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

## Checklist (optional)

- Upgrade steps (changes in profile):
  - [x] Make it deferrable if possible
  - [x] Execute as much as possible conditionally
