### PR TITLE
Add @watchers API endpoint

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 
 - Improve performance when resolving large dossiers. [deiferni]
 - Add is_subdossier to catalog metadata. [deiferni]
+- Add @watchers endpoint for tasks and inbox forwardings. [tinagerber]
 - Add Bumblebee auto refresh feature to policy template. [2e12]
 - Task GET API: Also include info about containing dossier. [mbaechtold]
 - Fix `task_type_helper` to respect the current language for the ram-cache. [elioschmutz]

--- a/docs/public/dev-manual/api/docs_changelog.rst
+++ b/docs/public/dev-manual/api/docs_changelog.rst
@@ -6,6 +6,12 @@ Changelog
 Im Folgenden sind (substantielle) Änderungen an der Dokumentation aufgeführt.
 
 
+2020-04-29
+----------
+
+- Kapitel "Beobachter" hinzugefügt
+
+
 2020-04-24
 ----------
 

--- a/docs/public/dev-manual/api/index.rst
+++ b/docs/public/dev-manual/api/index.rst
@@ -38,6 +38,7 @@ Inhalt:
    journal.rst
    sharing.rst
    allowed_roles_and_principals.rst
+   watchers.rst
    workspace/index
    linked_workspaces.rst
    templatefolder.rst

--- a/docs/public/dev-manual/api/watchers.rst
+++ b/docs/public/dev-manual/api/watchers.rst
@@ -1,0 +1,114 @@
+Beobachter
+==========
+
+Der ``@watchers`` Endpoint dient dazu, für Aufgaben und Weiterleitungen Beobachter zu registrieren.
+
+
+Auflistung
+----------
+
+Ein Beobachter kann verschiedene Rollen haben, beispielsweise die Rollen Auftraggeber (``task_issuer``), Auftragnehmer (``task_responsible``) oder Beobachter (``regular_watcher``). Mittels eines GET-Requests können alle Beobachter und alle Rollen einer Aufgabe abgefragt werden.
+
+**Beispiel-Request**:
+
+   .. sourcecode:: http
+
+       GET /task-1/@watchers HTTP/1.1
+       Accept: application/json
+
+
+**Beispiel-Response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 200 OK
+      Content-Type: application/json
+
+      {
+        "@id": "https://example.org/ordnungssystem/fuehrung/dossier-23/task-1/@watchers",
+        "watchers_and_roles": {
+          "rolf.ziegler": [
+            "regular_watcher",
+            "task_responsible"
+          ],
+          "peter.mueller": [
+            "task_issuer"
+          ]
+        }
+      }
+
+
+Beobachter als erweiterbare Komponente
+--------------------------------------
+
+Die Beobachter können als Kompomente einer Aufgabe direkt über den ``expand``-Parameter eingebettet werden, so dass keine zusätzliche Abfrage nötig ist.
+
+**Beispiel-Request**:
+
+  .. sourcecode:: http
+
+    GET /task-1?expand=watchers HTTP/1.1
+    Accept: application/json
+
+**Beispiel-Response**:
+
+  .. sourcecode:: http
+
+    HTTP/1.1 200 OK
+    Content-Type: application/json
+
+    {
+      "@id": "https://example.org/ordnungssystem/fuehrung/dossier-23/task-1?expand=watchers",
+      "@components": {
+        "watchers": {
+          "@id": "https://example.org/ordnungssystem/fuehrung/dossier-23/task-1/@listing-stats",
+          "watchers_and_roles": { "...": "..." }
+        }
+      },
+      "...": "..."
+    }
+
+
+Beobachter hinzufügen
+---------------------
+
+Ein Benutzer kann mittels POST-Requests als Beobachter mit der Rolle ``regular_watcher`` bei einer Aufgabe registriert werden.
+
+
+**Beispiel-Request**:
+
+   .. sourcecode:: http
+
+       POST /task-1/@watchers HTTP/1.1
+       Accept: application/json
+
+       {
+         "userid": "peter.mueller"
+       }
+
+**Beispiel-Response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 204 No content
+
+
+Beobachter entfernen
+--------------------
+
+Mittels DELETE-Requests kann die Rolle ``regular_watcher`` eines Beobachters von einer Aufgabe wieder entfernt werden.
+
+**Beispiel-Request**:
+
+   .. sourcecode:: http
+
+       DELETE /task-1/@watchers HTTP/1.1
+       Accept: application/json
+
+**Beispiel-Response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 204 No content
+
+

--- a/opengever/activity/center.py
+++ b/opengever/activity/center.py
@@ -99,6 +99,16 @@ class NotificationCenter(object):
         # error. In order to avoid that we consume it by making a tuple.
         return tuple(resource.watchers)
 
+    def get_subscriptions(self, oguid):
+        resource = self.fetch_resource(oguid)
+        if not resource:
+            return ()
+
+        # resources.subscriptions is an association_proxy. When not consumed properly
+        # the GC will remove things, resulting in a "stale association proxy"
+        # error. In order to avoid that we consume it by making a tuple.
+        return tuple(resource.subscriptions)
+
     def add_activity(self, oguid, kind, title, label, summary, actor_id, description):
         """Creates an activity and the related notifications..
         """
@@ -251,6 +261,10 @@ class PloneNotificationCenter(NotificationCenter):
         oguid = self._get_oguid_for(obj)
         return super(PloneNotificationCenter, self).get_watchers(oguid)
 
+    def get_subscriptions(self, obj):
+        oguid = self._get_oguid_for(obj)
+        return super(PloneNotificationCenter, self).get_subscriptions(oguid)
+
     def fetch_resource(self, obj):
         oguid = self._get_oguid_for(obj)
         return super(PloneNotificationCenter, self).fetch_resource(oguid)
@@ -305,6 +319,9 @@ class DisabledNotificationCenter(NotificationCenter):
         pass
 
     def get_watchers(self, obj):
+        return []
+
+    def get_subscriptions(self, oguid):
         return []
 
     def add_activity(self, obj, kind, title, label, summary, actor_id, description):

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -678,4 +678,33 @@
       permission="opengever.api.ViewAllowedRolesAndPrincipals"
       />
 
+  <plone:service
+      method="GET"
+      name="@watchers"
+      for="opengever.task.task.ITask"
+      factory=".watchers.WatchersGet"
+      permission="zope2.View"
+      />
+
+  <plone:service
+      method="POST"
+      name="@watchers"
+      for="opengever.task.task.ITask"
+      factory=".watchers.WatchersPost"
+      permission="zope2.View"
+      />
+
+  <plone:service
+      method="DELETE"
+      name="@watchers"
+      for="opengever.task.task.ITask"
+      factory=".watchers.WatchersDelete"
+      permission="zope2.View"
+      />
+
+  <adapter
+      factory=".watchers.Watchers"
+      name="watchers"
+      />
+
 </configure>

--- a/opengever/api/tests/test_watchers.py
+++ b/opengever/api/tests/test_watchers.py
@@ -1,0 +1,238 @@
+from ftw.testbrowser import browsing
+from opengever.activity import notification_center
+from opengever.activity.roles import TASK_ISSUER_ROLE
+from opengever.activity.roles import TASK_RESPONSIBLE_ROLE
+from opengever.activity.roles import WATCHER_ROLE
+from opengever.testing import IntegrationTestCase
+import json
+
+
+class TestWatchersGet(IntegrationTestCase):
+    features = ('activity', )
+
+    @browsing
+    def test_get_watchers_for_tasks(self, browser):
+        center = notification_center()
+        self.login(self.regular_user, browser=browser)
+        center.add_watcher_to_resource(self.task, self.task.creators[0], TASK_ISSUER_ROLE)
+        center.add_watcher_to_resource(self.task, self.task.responsible, TASK_RESPONSIBLE_ROLE)
+        center.add_watcher_to_resource(self.task, self.task.responsible, WATCHER_ROLE)
+        browser.open(self.task.absolute_url() + '/@watchers',
+                     method='GET', headers=self.api_headers)
+
+        expected_json = {
+            u'@id': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/'
+                    u'dossier-1/task-1/@watchers',
+            u'watchers_and_roles': {
+                u'kathi.barfuss': [u'regular_watcher', u'task_responsible'],
+                u'robert.ziegler': [u'task_issuer']}}
+
+        self.assertEqual(expected_json, browser.json)
+
+        browser.open(self.task, method='GET', headers=self.api_headers)
+
+        self.assertEqual({u'@id': u'http://nohost/plone/ordnungssystem/fuhrung/'
+                                  u'vertrage-und-vereinbarungen/dossier-1/task-1/@watchers'},
+                         browser.json['@components']['watchers'])
+        browser.open(self.task.absolute_url() + '?expand=watchers',
+                     method='GET', headers=self.api_headers)
+        self.assertEqual(expected_json, browser.json['@components']['watchers'])
+
+    @browsing
+    def test_get_watchers_for_inbox_forwarding(self, browser):
+        center = notification_center()
+        self.login(self.secretariat_user, browser=browser)
+        center.add_watcher_to_resource(self.inbox_forwarding, self.inbox_forwarding.creators[0],
+                                       TASK_ISSUER_ROLE)
+        center.add_watcher_to_resource(self.inbox_forwarding, self.inbox_forwarding.responsible,
+                                       TASK_RESPONSIBLE_ROLE)
+        center.add_watcher_to_resource(self.inbox_forwarding, self.inbox_forwarding.responsible,
+                                       WATCHER_ROLE)
+        browser.open(self.inbox_forwarding.absolute_url() + '/@watchers',
+                     method='GET', headers=self.api_headers)
+
+        expected_json = {
+            u'@id': u'http://nohost/plone/eingangskorb/forwarding-1/@watchers',
+            u'watchers_and_roles': {
+                u'kathi.barfuss': [u'regular_watcher', u'task_responsible'],
+                u'nicole.kohler': [u'task_issuer']}}
+
+        self.assertEqual(expected_json, browser.json)
+
+        browser.open(self.inbox_forwarding, method='GET', headers=self.api_headers)
+
+        self.assertEqual({u'@id': u'http://nohost/plone/eingangskorb/forwarding-1/@watchers'},
+                         browser.json['@components']['watchers'])
+        browser.open(self.inbox_forwarding.absolute_url() + '?expand=watchers',
+                     method='GET', headers=self.api_headers)
+        self.assertEqual(expected_json, browser.json['@components']['watchers'])
+
+    @browsing
+    def test_watchers_not_available_for_dossier(self, browser):
+        self.login(self.regular_user, browser=browser)
+        with browser.expect_http_error(404):
+            browser.open(self.dossier.absolute_url() + '/@watchers', method='GET',
+                         headers=self.api_headers)
+        browser.open(self.dossier, method='GET', headers=self.api_headers)
+        self.assertNotIn('watchers', browser.json['@components'])
+
+
+class TestWatchersPost(IntegrationTestCase):
+    features = ('activity', )
+
+    @browsing
+    def test_post_watchers_for_task(self, browser):
+        center = notification_center()
+        self.login(self.regular_user, browser=browser)
+        center.add_watcher_to_resource(self.task, self.meeting_user.getId(), TASK_RESPONSIBLE_ROLE)
+        browser.open(self.task.absolute_url() + '/@watchers', method='GET',
+                     headers=self.api_headers)
+
+        self.assertEqual({
+            u'@id': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/'
+                    u'dossier-1/task-1/@watchers',
+            u'watchers_and_roles': {u'herbert.jager': [u'task_responsible']}}, browser.json)
+        browser.open(self.task.absolute_url() + '/@watchers',
+                     method='POST',
+                     headers=self.api_headers,
+                     data=json.dumps({"userid": self.meeting_user.getId()}))
+
+        self.assertEqual(browser.status_code, 204)
+
+        browser.open(self.task.absolute_url() + '/@watchers', method='GET',
+                     headers=self.api_headers)
+        self.assertEqual({
+            u'@id': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/'
+                    u'dossier-1/task-1/@watchers',
+            u'watchers_and_roles': {u'herbert.jager': [u'regular_watcher', u'task_responsible']}},
+            browser.json)
+
+    @browsing
+    def test_post_watchers_without_data_raises_bad_request(self, browser):
+        self.login(self.regular_user, browser=browser)
+        with browser.expect_http_error(400):
+            browser.open(self.task.absolute_url() + '/@watchers', method='POST',
+                         headers=self.api_headers)
+        self.assertEqual(
+            {"message": "Property 'userid' is required",
+             "type": "BadRequest"},
+            browser.json)
+
+    @browsing
+    def test_post_watchers_with_invalid_userid_raises_bad_request(self, browser):
+        self.login(self.regular_user, browser=browser)
+        with browser.expect_http_error(400):
+            browser.open(self.task.absolute_url() + '/@watchers',
+                         method='POST',
+                         headers=self.api_headers,
+                         data=json.dumps({"userid": "chaosqueen"}))
+        self.assertEqual(
+            {"message": "userid 'chaosqueen' does not exist",
+             "type": "BadRequest"},
+            browser.json)
+
+    @browsing
+    def test_post_watchers_for_inbox_forwarding(self, browser):
+        center = notification_center()
+        self.login(self.secretariat_user, browser=browser)
+        center.add_watcher_to_resource(self.inbox_forwarding, self.meeting_user.getId(),
+                                       TASK_RESPONSIBLE_ROLE)
+        browser.open(self.inbox_forwarding.absolute_url() + '/@watchers', method='GET',
+                     headers=self.api_headers)
+
+        self.assertEqual({
+            u'@id': u'http://nohost/plone/eingangskorb/forwarding-1/@watchers',
+            u'watchers_and_roles': {u'herbert.jager': [u'task_responsible']}},
+            browser.json)
+        browser.open(self.inbox_forwarding.absolute_url() + '/@watchers',
+                     method='POST',
+                     headers=self.api_headers,
+                     data=json.dumps({"userid": self.meeting_user.getId()}))
+
+        self.assertEqual(browser.status_code, 204)
+
+        browser.open(self.inbox_forwarding.absolute_url() + '/@watchers', method='GET',
+                     headers=self.api_headers)
+        self.assertEqual({
+            u'@id': u'http://nohost/plone/eingangskorb/forwarding-1/@watchers',
+            u'watchers_and_roles': {
+                u'herbert.jager': [u'regular_watcher', u'task_responsible']}}, browser.json)
+
+
+class TestWatchersDelete(IntegrationTestCase):
+    features = ('activity', )
+
+    @browsing
+    def test_delete_watchers_for_task(self, browser):
+        center = notification_center()
+        self.login(self.regular_user, browser=browser)
+        center.add_watcher_to_resource(self.task, self.regular_user.getId(), TASK_RESPONSIBLE_ROLE)
+        center.add_watcher_to_resource(self.task, self.regular_user.getId(), WATCHER_ROLE)
+        browser.open(self.task.absolute_url() + '/@watchers',
+                     method='GET', headers=self.api_headers)
+
+        self.assertEqual({
+            u'@id': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/'
+                    u'dossier-1/task-1/@watchers',
+            u'watchers_and_roles': {
+                u'kathi.barfuss': [u'regular_watcher', u'task_responsible']}}, browser.json)
+
+        browser.open(self.task.absolute_url() + '/@watchers',
+                     method='DELETE', headers=self.api_headers)
+
+        self.assertEqual(browser.status_code, 204)
+        browser.open(self.task.absolute_url() + '/@watchers', method='GET',
+                     headers=self.api_headers)
+        self.assertEqual({
+            u'@id': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/'
+                    u'dossier-1/task-1/@watchers',
+            u'watchers_and_roles': {u'kathi.barfuss': [u'task_responsible']}}, browser.json)
+
+    @browsing
+    def test_delete_watchers_for_inbox_forwarding(self, browser):
+        center = notification_center()
+        self.login(self.secretariat_user, browser=browser)
+        center.add_watcher_to_resource(self.inbox_forwarding, self.secretariat_user.getId(),
+                                       TASK_RESPONSIBLE_ROLE)
+        center.add_watcher_to_resource(self.inbox_forwarding, self.secretariat_user.getId(),
+                                       WATCHER_ROLE)
+        browser.open(self.inbox_forwarding.absolute_url() + '/@watchers',
+                     method='GET', headers=self.api_headers)
+
+        self.assertEqual({u'@id': u'http://nohost/plone/eingangskorb/forwarding-1/@watchers',
+                          u'watchers_and_roles': {
+                              u'jurgen.konig': [u'regular_watcher', u'task_responsible']}},
+                         browser.json)
+        browser.open(self.inbox_forwarding.absolute_url() + '/@watchers',
+                     method='DELETE', headers=self.api_headers)
+
+        self.assertEqual(browser.status_code, 204)
+
+        browser.open(self.inbox_forwarding.absolute_url() + '/@watchers', method='GET',
+                     headers=self.api_headers)
+        self.assertEqual({
+            u'@id': u'http://nohost/plone/eingangskorb/forwarding-1/@watchers',
+            u'watchers_and_roles': {u'jurgen.konig': [u'task_responsible']}}, browser.json)
+
+    @browsing
+    def test_delete_watchers_with_data_raises_bad_request(self, browser):
+        center = notification_center()
+        self.login(self.regular_user, browser=browser)
+        center.add_watcher_to_resource(self.task, self.regular_user.getId(), WATCHER_ROLE)
+        browser.open(self.task.absolute_url() + '/@watchers',
+                     method='GET', headers=self.api_headers)
+
+        self.assertEqual({
+            u'@id': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/'
+                    u'dossier-1/task-1/@watchers',
+            u'watchers_and_roles': {
+                u'kathi.barfuss': [u'regular_watcher']}}, browser.json)
+
+        with browser.expect_http_error(400):
+            browser.open(self.task.absolute_url() + '/@watchers',
+                         method='DELETE', headers=self.api_headers,
+                         data=json.dumps({"userid": self.meeting_user.getId()}))
+        self.assertEqual(
+            {"message": "DELETE does not take any data",
+             "type": "BadRequest"},
+            browser.json)

--- a/opengever/api/watchers.py
+++ b/opengever/api/watchers.py
@@ -1,0 +1,80 @@
+from collections import defaultdict
+from opengever.activity import notification_center
+from opengever.activity.roles import WATCHER_ROLE
+from opengever.base.interfaces import IOpengeverBaseLayer
+from opengever.task.task import ITask
+from plone import api
+from plone.restapi.deserializer import json_body
+from plone.restapi.interfaces import IExpandableElement
+from plone.restapi.services import Service
+from zExceptions import BadRequest
+from zope.component import adapter
+from zope.interface import implementer
+
+
+@implementer(IExpandableElement)
+@adapter(ITask, IOpengeverBaseLayer)
+class Watchers(object):
+    def __init__(self, context, request):
+        self.context = context
+        self.request = request
+        self.center = notification_center()
+
+    def __call__(self, expand=False):
+        result = {
+            'watchers': {
+                '@id': '/'.join((self.context.absolute_url(), '@watchers')),
+            },
+        }
+        if not expand:
+            return result
+
+        result['watchers']['watchers_and_roles'] = self.get_watchers_and_roles()
+        return result
+
+    def get_watchers_and_roles(self):
+        watchers_and_roles = defaultdict(list)
+        for subscription in self.center.get_subscriptions(self.context):
+            watchers_and_roles[subscription.watcher.actorid].append(subscription.role)
+        return watchers_and_roles
+
+
+class WatchersGet(Service):
+
+    def reply(self):
+        watchers = Watchers(self.context, self.request)
+        return watchers(expand=True)['watchers']
+
+
+class WatchersPost(Service):
+
+    def reply(self):
+        self.extract_data()
+        self.center = notification_center()
+        self.center.add_watcher_to_resource(self.context, self.userid, WATCHER_ROLE)
+        self.request.response.setStatus(204)
+        return super(WatchersPost, self).reply()
+
+    def extract_data(self):
+        data = json_body(self.request)
+        self.userid = data.get("userid", None)
+        if not self.userid:
+            raise BadRequest("Property 'userid' is required")
+        if not api.user.get(self.userid):
+            raise BadRequest("userid '{}' does not exist".format(self.userid))
+
+
+class WatchersDelete(Service):
+    def reply(self):
+        self.extract_data()
+        self.userid = api.user.get_current().getId()
+        self.center = notification_center()
+        self.center.remove_watcher_from_resource(self.context, self.userid, WATCHER_ROLE)
+
+        self.request.response.setStatus(204)
+        return None
+
+    def extract_data(self):
+        data = json_body(self.request)
+        if data:
+            raise BadRequest("DELETE does not take any data")


### PR DESCRIPTION
It should be possible to observe tasks as a watcher in order to stay informed.
This PR provides the API support for watchers. 

With the `@watcher` endpoint, it is possible to query all watchers of a task and their roles and add new watchers with the role `regula_watcher`. In addition, a user can delete his role as `regular_watcher` of a task.
Jira: https://4teamwork.atlassian.net/browse/GEVER-22

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Documentation updated (notably for API and deployment)
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


## Checklist (optional)

_Only applicable should be left and checked._

- [x] New functionality  for `task` also works for `forwarding`
