### PR TITLE
Return main dossier instead of containing dossier.

### DIFF
--- a/opengever/api/task.py
+++ b/opengever/api/task.py
@@ -28,7 +28,7 @@ class SerializeTaskToJson(GeverSerializeToJson):
         return result
 
     def _get_containing_dossier_summary(self):
-        containing_dossier = self.context.get_containing_dossier()
+        containing_dossier = self.context.get_main_dossier()
         if not containing_dossier:
             return None
         return getMultiAdapter(

--- a/opengever/api/tests/test_task.py
+++ b/opengever/api/tests/test_task.py
@@ -142,7 +142,7 @@ class TestTaskSerialization(IntegrationTestCase):
             browser.json)
 
     @browsing
-    def test_containing_dossier_for_task(self, browser):
+    def test_containing_dossier_for_task_within_dossier(self, browser):
         self.login(self.regular_user, browser=browser)
         browser.open(self.task, method="GET", headers=self.api_headers)
         self.maxDiff = None
@@ -151,6 +151,30 @@ class TestTaskSerialization(IntegrationTestCase):
                 u'@id': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1',
                 u'@type': u'opengever.dossier.businesscasedossier',
                 u'description': u'Alle aktuellen Vertr\xe4ge mit der kantonalen Finanzverwaltung sind hier abzulegen. Vertr\xe4ge vor 2016 geh\xf6ren ins Archiv.',  # noqa
+                u'review_state': u'dossier-state-active',
+                u'title': u'Vertr\xe4ge mit der kantonalen Finanzverwaltung',
+            },
+            browser.json['containing_dossier']
+        )
+
+    @browsing
+    def test_containing_dossier_for_task_within_subdossier(self, browser):
+        self.login(self.regular_user, browser=browser)
+        task_in_subdossier = create(Builder('task')
+                                    .within(self.subdossier)
+                                    .having(
+                                        responsible_client='fa',
+                                        responsible=self.regular_user.getId(),
+                                        issuer=self.dossier_responsible.getId(),
+                                    ))
+        browser.open(task_in_subdossier, method="GET", headers=self.api_headers)
+        self.maxDiff = None
+        self.assertDictEqual(
+            {
+                u'@id': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1',
+                u'@type': u'opengever.dossier.businesscasedossier',
+                u'description': u'Alle aktuellen Vertr\xe4ge mit der kantonalen Finanzverwaltung sind hier '
+                                u'abzulegen. Vertr\xe4ge vor 2016 geh\xf6ren ins Archiv.',
                 u'review_state': u'dossier-state-active',
                 u'title': u'Vertr\xe4ge mit der kantonalen Finanzverwaltung',
             },

--- a/opengever/task/task.py
+++ b/opengever/task/task.py
@@ -15,6 +15,7 @@ from opengever.base.response import IResponseSupported
 from opengever.base.security import as_internal_workflow_transition
 from opengever.base.source import DossierPathSourceBinder
 from opengever.dossier.utils import get_containing_dossier
+from opengever.dossier.utils import get_main_dossier
 from opengever.globalindex.model.task import Task as TaskModel
 from opengever.ogds.base.actor import Actor
 from opengever.ogds.base.actor import ActorLookup
@@ -493,6 +494,10 @@ class Task(Container, TaskReminderSupport):
     def get_containing_dossier(self):
         """Returns the first parent dossier or inbox"""
         return get_containing_dossier(self)
+
+    def get_main_dossier(self):
+        """Returns the main dossier or inbox"""
+        return get_main_dossier(self)
 
     def get_containing_dossier_title(self):
         """Title of the main dossier or inbox"""


### PR DESCRIPTION
On the detail view of a task (in the new GEVER UI), the  linked dossier must be the main dossier, not the parent of the task. This is mainly relevant for tasks in subdossiers.

This is a follow-up of https://github.com/4teamwork/opengever.core/pull/6387 and belongs to https://4teamwork.atlassian.net/browse/GEVER-246.

## Checklist (Must have)
- [ ] Changelog entry
- [ ] Documentation updated (notably for API and deployment)
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
