### PR TITLE
Fix labels of notification user settings

### DIFF
--- a/opengever/activity/browser/settings.py
+++ b/opengever/activity/browser/settings.py
@@ -210,8 +210,8 @@ class NotificationSettingsView(BrowserView):
 
         user_settings = []
         for setting in USER_SETTINGS:
-            title = translate(config.get('title'), context=self.request)
-            help_text = translate(config.get('help_text'), context=self.request)
+            title = translate(setting.get('title'), context=self.request)
+            help_text = translate(setting.get('help_text'), context=self.request)
 
             default = self.get_default_user_setting_value(setting.get('id'))
             value = UserSettings.get_setting_for_user(


### PR DESCRIPTION
This is a follow-up pr of #6397 

Due to a refactoring, the labels of the general tab in the notification settings have not been displayed correctly.

This PR fixes the issue.

Before:
<img width="591" alt="Bildschirmfoto 2020-05-05 um 11 54 24" src="https://user-images.githubusercontent.com/557005/81054472-32caa980-8ec7-11ea-8e45-c19173fc9d85.png">

After:
<img width="656" alt="Bildschirmfoto 2020-05-05 um 11 54 28" src="https://user-images.githubusercontent.com/557005/81054477-35c59a00-8ec7-11ea-92cf-766ba1ecf0fd.png">
