### PR TITLE
Show proposal template corresponding to the committee.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -14,6 +14,7 @@ Changelog
 - Add attribute `is_subdossier` to the children for GET requests to the API. [mbaechtold]
 - Add is_subdossier to catalog metadata. [deiferni]
 - Add @watchers endpoint for tasks and inbox forwardings. [tinagerber]
+- Fix show proposal templates corresponding to the committee. [2e12]
 - Add Bumblebee auto refresh feature to policy template. [2e12]
 - Task GET API: Also include info about containing dossier. [mbaechtold]
 - Enhance the API endpoint `@breadcrumbs` with more attributes. [mbaechtold]

--- a/opengever/meeting/browser/proposalforms.py
+++ b/opengever/meeting/browser/proposalforms.py
@@ -124,7 +124,7 @@ class IAddProposalSupplementaryFields(Schema):
         vocabulary='opengever.meeting.ProposalTemplatesForCommitteeVocabulary',
         required=False,
         show_filter=True,
-        vocabulary_depends_on=['form.widgets.committee'],
+        vocabulary_depends_on=['form.widgets.committee_oguid'],
         columns=(
             {'column': 'title',
              'column_title': _(u'label_title', default=u'Title'),

--- a/opengever/meeting/tests/test_proposal.py
+++ b/opengever/meeting/tests/test_proposal.py
@@ -30,6 +30,7 @@ from zc.relation.interfaces import ICatalog
 from zExceptions import NotFound
 from zExceptions import Unauthorized
 from zope.component import getUtility
+import json
 
 
 class TestProposalStateGlobals(IntegrationTestCase):
@@ -88,6 +89,24 @@ class TestProposalSolr(SolrIntegrationTestCase):
         '!officeconnector-checkout',
         'meeting',
     )
+
+    @browsing
+    def test_proposal_template_field_dependencies(self, browser):
+        self.login(self.dossier_responsible, browser)
+        browser.open(self.dossier)
+        factoriesmenu.add('Proposal')
+
+        depends_on = json.loads(browser.css('.tableradio-widget-wrapper').first.get('data-vocabulary-depends-on'))
+        committee_input_name = depends_on[0]
+
+        self.assertEqual(1, len(depends_on), 'Only 1 dependency expected.')
+
+        self.assertEqual('form.widgets.committee_oguid', committee_input_name,
+                         'You changed the configuration of ProposalAddForm (probably). Please make sure that the field '
+                         '"committee_oguid" still exists.')
+
+        self.assertEqual(1, len(browser.css('select[name="{}:list"]'.format(committee_input_name))),
+                         'Could not find dependent field {}.'.format(committee_input_name))
 
     @browsing
     def test_create_proposal_visible_in_dossier_actions_for_regular_user_when_meeting_enabled(self, browser):

--- a/opengever/meeting/tests/test_vocabularies.py
+++ b/opengever/meeting/tests/test_vocabularies.py
@@ -137,8 +137,8 @@ class TestProposalTemplatesForCommitteeVocabulary(IntegrationTestCase):
             [term.value for term in factory(context=self.dossier)])
 
         self.committee.allowed_proposal_templates = [IUUID(baubewilligungen)]
-        self.request.form['form.widgets.committee'] = [
-            unicode(self.committee.load_model().committee_id)]
+        self.request.form['form.widgets.committee_oguid'] = [
+            unicode(self.committee.load_model().oguid)]
         self.assertItemsEqual(
             [baubewilligungen],
             [term.value for term in factory(context=self.dossier)])

--- a/opengever/meeting/vocabulary.py
+++ b/opengever/meeting/vocabulary.py
@@ -258,9 +258,10 @@ class ProposalTemplatesForCommitteeVocabulary(object):
             oguid = Oguid.parse(context.committee_oguid)
             return Committee.query.get_by_oguid(oguid)
 
-        committees = context.REQUEST.form.get('form.widgets.committee', None)
-        if committees:
-            return Committee.query.filter_by(committee_id=int(committees[0])).one()
+        committee_oguid = context.REQUEST.form.get('form.widgets.committee_oguid', None)
+        if committee_oguid:
+            committee_oguid = Oguid.parse(committee_oguid[0])
+            return Committee.query.filter_by(oguid=committee_oguid).one()
 
         return None
 


### PR DESCRIPTION
The proposal templates weren't filtered anymore by the selected committee. This should by repaired in this PR.

In commit 31b96c4ea3b395224d1307b5c11dccfb3898898e the field 'committee' was renamed to 'committee_oguid'. This had the consequence that a select field was renamed what caused that form.widgets.proposal_template wasn't updated anymore when changing the value in the select box.

Also the vocabulary filtered not correctly also due the switch to oguid.

Jira Issue -> https://4teamwork.atlassian.net/browse/GEVER-268


## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
