### PR TITLE
Add explicit sentry logging for unknown sort_on.

### DIFF
--- a/opengever/tabbedview/catalog_source.py
+++ b/opengever/tabbedview/catalog_source.py
@@ -4,6 +4,7 @@ from ftw.solr.query import escape
 from ftw.table.catalog_source import CatalogTableSource
 from ftw.table.interfaces import ITableSource
 from opengever.base.interfaces import ISearchSettings
+from opengever.base.sentry import log_msg_to_sentry
 from opengever.base.solr import OGSolrDocument
 from opengever.tabbedview.filtered_source import FilteredTableSourceMixin
 from opengever.tabbedview.interfaces import IGeverCatalogTableSourceConfig
@@ -13,6 +14,7 @@ from zope.component import getUtility
 from zope.interface import implementer
 from zope.interface import Interface
 import logging
+
 
 logger = logging.getLogger('opengever.tabbedview.catalog_source')
 
@@ -155,6 +157,9 @@ class GeverCatalogTableSource(FilteredTableSourceMixin, CatalogTableSource):
                 sort += ' asc'
         else:
             logger.warning('Ignoring unknown sort criteria %s', sort)
+            log_msg_to_sentry(
+                'Ignoring unknown sort criteria', level='warning',
+                extra={'sort_criteria': sort})
             sort = None
 
         # Todo: modified be removed once the changed metadata is filled on


### PR DESCRIPTION
This is a follow-up for what we discussed in https://github.com/4teamwork/opengever.core/pull/6382#discussion_r416655539. We want to catch issues early so we temporarily add explicit logging to sentry to be aware when this happens. Quickly discussed this with @buchi and he's now fine with temporarily adding explicit sentry logging until we manage to get messages from `logging` into sentry with https://4teamwork.atlassian.net/browse/GEVER-233. 

Motivation:

- we want to see when this issue happens in production early, especially now after we have our new solr listings
- if we just `log`, even with `error` level we won't be aware of the error in production as only exceptions are logged to sentry with our current sentry integration
- we have already adopted the strategy of explicit logging in other places

Example of the event which is logged at https://sentry.4teamwork.ch/sentry/onegov-gever/issues/67486/events/957386/. 
_I will clean this up once the PR is merged_

Issue: https://4teamwork.atlassian.net/browse/GEVER-207

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [ ] Changelog entry
- [ ] Documentation updated (notably for API and deployment)
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)