### PR TITLE
Fix plone site deletion issue.

### DIFF
--- a/opengever/base/handlers.py
+++ b/opengever/base/handlers.py
@@ -144,6 +144,13 @@ def update_favorited_repositoryfolder(context, event):
     - A favorited branch node becomes a leaf node when the last same
       type child has been removed.
     """
+
+    # Skip plone site removals. Unfortunately no deletion-order seems to be
+    # guaranteed, when removing the plone site, so it might happen that the
+    # intid utility is removed before removing content.
+    if IPloneSiteRoot.providedBy(event.object) and IObjectRemovedEvent.providedBy(event):
+        return
+
     Favorite.query.update_is_leafnode(aq_parent(context))
 
 


### PR DESCRIPTION
A new event handler was introduced for repositoryfolders which uses the IIntID utility (see https://github.com/4teamwork/opengever.core/pull/6386). This will fail when deleting the plone site root as the utility might get deleted before the repositoryfolders.

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry: No changelog as it is in the same release where the bug was introduced
- [x] Documentation updated (notably for API and deployment)
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

For https://4teamwork.atlassian.net/browse/GEVER-327 and https://4teamwork.atlassian.net/browse/GEVER-247
