### PR TITLE
Drop sorting by sortable_author for solr and avoid handling sorting parameters as fields.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2020.3.0rc2 (unreleased)
 ------------------------
 
+- Drop sorting by sortable_author for solr and avoid handling sorting parameters as fields. [deiferni]
 - Add live chat to online documentation. [njohner]
 - Bump ftw.monitor and ftw.contentstats to get performance metrics. [lgraf]
 - Merge notification settings for tasks. [elioschmutz]

--- a/opengever/tabbedview/browser/tabs.py
+++ b/opengever/tabbedview/browser/tabs.py
@@ -147,7 +147,6 @@ class Documents(BaseCatalogListingTab):
 
         {'column': 'document_author',
          'column_title': _('label_document_author', default="Document Author"),
-         'sort_index': 'sortable_author',
          'transform': escape_html_transform},
 
         {'column': 'document_date',

--- a/opengever/tabbedview/catalog_source.py
+++ b/opengever/tabbedview/catalog_source.py
@@ -71,9 +71,10 @@ class GeverCatalogTableSource(FilteredTableSourceMixin, CatalogTableSource):
         sort = query.pop('sort_on', self.config.sort_on)
         if sort in solr.manager.schema.fields:
             if sort == self.config.sort_on:
-                sort_order = query.get('sort_order', self.config.sort_order)
+                sort_order = query.pop('sort_order', self.config.sort_order)
             else:
-                sort_order = query.get('sort_order', 'ascending')
+                sort_order = query.pop('sort_order', 'ascending')
+
             if sort_order in ['descending', 'reverse']:
                 sort += ' desc'
             else:
@@ -112,8 +113,6 @@ class GeverCatalogTableSource(FilteredTableSourceMixin, CatalogTableSource):
                     'Ignoring filter criteria for unknown field %s', key)
                 continue
             elif key == 'SearchableText':
-                continue
-            elif key == 'sort_order':
                 continue
             elif key == 'path':
                 path_query = value.get('query')

--- a/opengever/tabbedview/catalog_source.py
+++ b/opengever/tabbedview/catalog_source.py
@@ -111,6 +111,9 @@ class GeverCatalogTableSource(FilteredTableSourceMixin, CatalogTableSource):
             if key not in solr.manager.schema.fields:
                 logger.warning(
                     'Ignoring filter criteria for unknown field %s', key)
+                log_msg_to_sentry(
+                    'Ignoring filter criteria for unknown field',
+                    level='warning', extra={'field': key})
                 continue
             elif key == 'SearchableText':
                 continue

--- a/opengever/tabbedview/catalog_source.py
+++ b/opengever/tabbedview/catalog_source.py
@@ -68,7 +68,7 @@ class GeverCatalogTableSource(FilteredTableSourceMixin, CatalogTableSource):
         return query
 
     def _extract_sorting(self, solr, query):
-        sort = query.get('sort_on', self.config.sort_on)
+        sort = query.pop('sort_on', self.config.sort_on)
         if sort in solr.manager.schema.fields:
             if sort == self.config.sort_on:
                 sort_order = query.get('sort_order', self.config.sort_order)
@@ -113,7 +113,7 @@ class GeverCatalogTableSource(FilteredTableSourceMixin, CatalogTableSource):
                 continue
             elif key == 'SearchableText':
                 continue
-            elif key == 'sort_on' or key == 'sort_order':
+            elif key == 'sort_order':
                 continue
             elif key == 'path':
                 path_query = value.get('query')

--- a/opengever/tabbedview/catalog_source.py
+++ b/opengever/tabbedview/catalog_source.py
@@ -67,6 +67,26 @@ class GeverCatalogTableSource(FilteredTableSourceMixin, CatalogTableSource):
         query['path'] = path_query
         return query
 
+    def _extract_sorting(self, solr, query):
+        sort = query.get('sort_on', self.config.sort_on)
+        if sort in solr.manager.schema.fields:
+            if sort == self.config.sort_on:
+                sort_order = query.get('sort_order', self.config.sort_order)
+            else:
+                sort_order = query.get('sort_order', 'ascending')
+            if sort_order in ['descending', 'reverse']:
+                sort += ' desc'
+            else:
+                sort += ' asc'
+        else:
+            logger.warning('Ignoring unknown sort criteria %s', sort)
+            log_msg_to_sentry(
+                'Ignoring unknown sort criteria', level='warning',
+                extra={'sort_criteria': sort})
+            sort = None
+
+        return sort
+
     def solr_results(self, query):
         if 'SearchableText' in query:
             term = query['SearchableText'].rstrip('*').decode('utf8')
@@ -81,6 +101,7 @@ class GeverCatalogTableSource(FilteredTableSourceMixin, CatalogTableSource):
             solr_query = u'*:*'
 
         solr = getUtility(ISolrSearch)
+        sort = self._extract_sorting(solr, query)
 
         filters = []
         if 'trashed' not in query:
@@ -144,23 +165,6 @@ class GeverCatalogTableSource(FilteredTableSourceMixin, CatalogTableSource):
                         ))
             else:
                 filters.append(u'{}:{}'.format(key, escape(value)))
-
-        sort = query.get('sort_on', self.config.sort_on)
-        if sort in solr.manager.schema.fields:
-            if sort == self.config.sort_on:
-                sort_order = query.get('sort_order', self.config.sort_order)
-            else:
-                sort_order = query.get('sort_order', 'ascending')
-            if sort_order in ['descending', 'reverse']:
-                sort += ' desc'
-            else:
-                sort += ' asc'
-        else:
-            logger.warning('Ignoring unknown sort criteria %s', sort)
-            log_msg_to_sentry(
-                'Ignoring unknown sort criteria', level='warning',
-                extra={'sort_criteria': sort})
-            sort = None
 
         # Todo: modified be removed once the changed metadata is filled on
         # all deployments.


### PR DESCRIPTION
In https://github.com/4teamwork/opengever.core/pull/6382 and https://github.com/4teamwork/opengever.core/pull/6404 we have introduced explicit logging for potential issues in solr listing. We now have already found some cases where we need special handling/fixes. This PR addresses the following issues

- Pop sorting parameters from solr query to avoid attempting to handle them as schema fields
- No longer sort by `sortable_author` in solr as no such field exists, instead `document_author` should be used

Furthermore we should also log to sentry when we encounter unknown fields as more issues may appear.

For https://4teamwork.atlassian.net/browse/GEVER-328

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [ ] Documentation updated (notably for API and deployment)
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)