### PR TITLE
Fix @solrsearch endpoint default sort order

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 
 - Add `is_admin_menu_visible` to the `@config` API endpoint. [mbaechtold]
 - Watchers GET API: Also include info about referenced_users and referenced_watcher_roles. [tinagerber]
+- Fix @solrsearch endpoint default sort order. [elioschmutz]
 
 
 2020.3.0rc2 (2020-05-07)

--- a/opengever/api/solrsearch.py
+++ b/opengever/api/solrsearch.py
@@ -45,7 +45,7 @@ class SolrSearchGet(SolrQueryBaseService):
             if query == '*:*':
                 sort = None
             else:
-                sort = 'score asc'
+                sort = 'score desc'
         return sort
 
     def parse_requested_fields(self, params):


### PR DESCRIPTION
Jira: https://4teamwork.atlassian.net/browse/GEVER-285

The `@solrsearch` endpoint sorts the results by its `score`. That the most relevant search result is at the top, we have to sort by `desc` instead `asc`:

> score desc | Sorts in descending order from the highest score to the lowest score [Solr Documentation](https://lucene.apache.org/solr/guide/6_6/common-query-parameters.html#CommonQueryParameters-ThesortParameter )

## Before
<img width="719" alt="Bildschirmfoto 2020-05-07 um 11 16 21" src="https://user-images.githubusercontent.com/557005/81279954-18740580-9058-11ea-8de4-9ae525208513.png">

## After
<img width="774" alt="Bildschirmfoto 2020-05-07 um 11 16 31" src="https://user-images.githubusercontent.com/557005/81279973-1dd15000-9058-11ea-966f-de2e132e1315.png">

## Checklist (Must have)

- [x] Changelog entry
- [x] Documentation updated (notably for API and deployment)
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
