### PR TITLE
Add "is_admin_menu_visible" to the @config API endpoint.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,7 @@ Changelog
 2020.3.0rc3 (unreleased)
 ------------------------
 
-- Nothing changed yet.
+- Add `is_admin_menu_visible` to the `@config` API endpoint. [mbaechtold]
 
 
 2020.3.0rc2 (2020-05-07)

--- a/docs/public/dev-manual/api/config.rst
+++ b/docs/public/dev-manual/api/config.rst
@@ -51,6 +51,7 @@ GEVER-Mandanten abgefragt werden.
               "solr": true,
               "workspace": false
           },
+          "is_admin_menu_visible": false,
           "max_dossier_levels": 5,
           "max_repositoryfolder_levels": 3,
           "recently_touched_limit": 10,

--- a/docs/public/dev-manual/api/config.rst
+++ b/docs/public/dev-manual/api/config.rst
@@ -52,6 +52,7 @@ GEVER-Mandanten abgefragt werden.
               "workspace": false
           },
           "is_admin_menu_visible": false,
+          "is_emm_environment": false,
           "max_dossier_levels": 5,
           "max_repositoryfolder_levels": 3,
           "recently_touched_limit": 10,

--- a/opengever/api/config.py
+++ b/opengever/api/config.py
@@ -1,3 +1,4 @@
+from opengever.base import utils
 from opengever.base.interfaces import IGeverSettings
 from opengever.officeconnector.helpers import is_client_ip_in_office_connector_disallowed_ip_ranges
 from plone.restapi.services import Service
@@ -15,4 +16,10 @@ class Config(Service):
         return
 
     def add_additional_infos(self, config):
+        """
+        Injects additional configuration information.
+        - is_admin_menu_visible: Indication for the GEVER UI if it should display
+          the menu item "Verwaltung" in the navigation drawer.
+        """
         config['is_emm_environment'] = is_client_ip_in_office_connector_disallowed_ip_ranges()
+        config['is_admin_menu_visible'] = utils.is_administrator()

--- a/opengever/api/tests/test_config.py
+++ b/opengever/api/tests/test_config.py
@@ -172,3 +172,19 @@ class TestConfig(IntegrationTestCase):
                      headers={'Accept': 'application/json'})
         self.assertEqual(browser.status_code, 200)
         self.assertIn(u'is_emm_environment', browser.json)
+
+    @browsing
+    def test_is_admin_menu_visible_is_true_for_administrators(self, browser):
+        self.login(self.administrator, browser)
+        url = self.portal.absolute_url() + '/@config'
+        browser.open(url, headers=self.api_headers)
+        self.assertEqual(browser.status_code, 200)
+        self.assertTrue(browser.json.get(u'is_admin_menu_visible'))
+
+    @browsing
+    def test_is_admin_menu_visible_is_false_for_regular_user(self, browser):
+        self.login(self.regular_user, browser)
+        url = self.portal.absolute_url() + '/@config'
+        browser.open(url, headers=self.api_headers)
+        self.assertEqual(browser.status_code, 200)
+        self.assertFalse(browser.json.get(u'is_admin_menu_visible'))

--- a/opengever/base/tests/test_utils.py
+++ b/opengever/base/tests/test_utils.py
@@ -5,6 +5,7 @@ from mocker import ANY
 from opengever.base.behaviors.utils import set_attachment_content_disposition
 from opengever.base.utils import escape_html
 from opengever.base.utils import file_checksum
+from opengever.base.utils import is_administrator
 from opengever.base.utils import safe_int
 from opengever.dossier.utils import find_parent_dossier
 from opengever.testing import IntegrationTestCase
@@ -184,3 +185,16 @@ class TestSafeInt(TestCase):
     def test_custom_default_value(self):
         value = 'not an int'
         self.assertEqual(7, safe_int(value, 7))
+
+
+class TestIsAdministrator(IntegrationTestCase):
+
+    def test_is_administrator_with_regular_user(self):
+        self.assertFalse(is_administrator(user=self.regular_user))
+        self.login(self.regular_user)
+        self.assertFalse(is_administrator())
+
+    def test_is_administrator_with_administrator(self):
+        self.assertTrue(is_administrator(user=self.administrator))
+        self.login(self.administrator)
+        self.assertTrue(is_administrator())

--- a/opengever/base/utils.py
+++ b/opengever/base/utils.py
@@ -214,3 +214,13 @@ def safe_int(value, default=0):
         return int(value)
     except (ValueError, TypeError):
         return default
+
+
+def is_administrator(user=None):
+    """
+    Returns a boolean indicating if the given user is considered a GEVER administrator.
+    If no user is given, the current user is used.
+    """
+    if not user:
+        user = api.user.get_current()
+    return bool(user.has_role('Administrator') or user.has_role('Manager'))

--- a/opengever/sharing/browser/sharing.py
+++ b/opengever/sharing/browser/sharing.py
@@ -5,6 +5,7 @@ from Acquisition import aq_base
 from ftw.lawgiver.utils import get_specification_for
 from itertools import chain
 from opengever.base import _ as base_mf
+from opengever.base import utils
 from opengever.base.handlebars import get_handlebars_template
 from opengever.base.role_assignments import ASSIGNMENT_VIA_SHARING
 from opengever.base.role_assignments import RoleAssignmentManager
@@ -270,8 +271,8 @@ class OpengeverSharingView(SharingView):
         corresponding event. Needed for adding a Journalentry after a
         change of the inheritance
         """
-        user = api.user.get_current()
-        is_administrator = user.has_role('Administrator') or user.has_role('Manager')
+
+        is_administrator = utils.is_administrator()
 
         # Modifying local roles needs the "Sharing page: Delegate roles"
         # permission as well as "Modify portal content". However, we don't
@@ -471,9 +472,7 @@ class WorkspaceSharingView(OpengeverSharingView):
             return all_principals
 
         # Administrators can give permissions to any user
-        user = api.user.get_current()
-        is_administrator = user.has_role('Administrator') or user.has_role('Manager')
-        if is_administrator:
+        if utils.is_administrator():
             return all_principals
 
         workspace_users = set(get_workspace_user_ids(self.context, disregard_block=True))

--- a/opengever/tabbedview/browser/personal_overview.py
+++ b/opengever/tabbedview/browser/personal_overview.py
@@ -3,6 +3,7 @@ from AccessControl import SecurityManagement
 from AccessControl import Unauthorized
 from ftw.tabbedview.browser.tabbed import TabbedView
 from opengever.activity import is_activity_feature_enabled
+from opengever.base import utils
 from opengever.globalindex.model.task import Task
 from opengever.latex.opentaskreport import is_open_task_report_allowed
 from opengever.meeting import is_meeting_feature_enabled
@@ -103,9 +104,7 @@ class PersonalOverview(TabbedView):
         m_tool = getToolByName(self.context, 'portal_membership')
         member = m_tool.getAuthenticatedMember()
         if member:
-            if member.has_role('Administrator') \
-                    or member.has_role('Manager'):
-                return True
+            return utils.is_administrator(user=member)
         return False
 
     @property

--- a/opengever/task/browser/transitioncontroller.py
+++ b/opengever/task/browser/transitioncontroller.py
@@ -1,4 +1,5 @@
 from Acquisition import aq_parent
+from opengever.base import utils
 from opengever.base.interfaces import IInternalWorkflowTransition
 from opengever.dossier.base import DOSSIER_STATES_OPEN
 from opengever.globalindex.model.task import Task
@@ -654,9 +655,7 @@ class CurrentUserChecker(object):
 
     @property
     def is_administrator(self):
-        current = api.user.get_current()
-        return bool(current.has_role('Administrator')
-                    or current.has_role('Manager'))
+        return utils.is_administrator()
 
 
 class TaskChecker(object):


### PR DESCRIPTION
This new information is used by the the GEVER UI in order to determine if it should display the menu item "Verwaltung" in the navigation drawer. 

The chosen solution has been discussed with @all4manu and @deiferni prior to its implementation and was deemed as a "good-is-good-enough" solution. All other options we discussed (dedicated endpoint @navigationdrawer, enhancement of @navigation or @actions endpoints) were deemed bloated, "unnatural" or violated the YAGNI principle.

This pull requests belongs to [GEVER-297](https://4teamwork.atlassian.net/browse/GEVER-297), a sub task of the Jira issue [GEVER-36](https://4teamwork.atlassian.net/browse/GEVER-36).

## Checklist (Must have)

- [x] Changelog entry
- [x] Documentation updated (notably for API and deployment)
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)