### PR TITLE
Fix an issue where solr facet labels have not been transformed correctly

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2020.3.0rc3 (unreleased)
 ------------------------
 
+- Fix an issue where solr facet labels have not been transformed correctly. [elioschmutz]
 - Add `is_admin_menu_visible` to the `@config` API endpoint. [mbaechtold]
 - Watchers GET API: Also include info about referenced_users and referenced_watcher_roles. [tinagerber]
 - Fix @solrsearch endpoint default sort order. [elioschmutz]

--- a/opengever/api/listing.py
+++ b/opengever/api/listing.py
@@ -223,17 +223,7 @@ class ListingGet(SolrQueryBaseService):
             res['batching'] = batch.links
 
         res['items'] = self.prepare_response_items(resp)
-
-        facet_counts = self.extract_facets_from_response(resp)
-
-        # We map the index names back to the field names for the facets
-        mapped_facet_counts = {}
-        for field in self.facets:
-            index_name = self.get_field_index(field)
-            if index_name is None or index_name not in facet_counts:
-                continue
-            mapped_facet_counts[field] = facet_counts[index_name]
-        res['facets'] = mapped_facet_counts
+        res['facets'] = self.extract_facets_from_response(resp)
 
         return res
 

--- a/opengever/api/solr_query_service.py
+++ b/opengever/api/solr_query_service.py
@@ -256,6 +256,7 @@ class SolrQueryBaseService(Service):
         self.solr_fields = set(self.solr.manager.schema.fields.keys())
         self.default_sort_index = DEFAULT_SORT_INDEX
         self.response_fields = None
+        self.facets = []
 
     def prepare_solr_query(self):
         """ Extract the requested parameters and prepare the solr query
@@ -306,14 +307,21 @@ class SolrQueryBaseService(Service):
         counts and labels for endpoint response.
         """
         facet_counts = {}
-        for field_name, facets in resp.facets.items():
-            field = self.get_field(field_name)
-            facet_counts[field_name] = {}
-            for facet, count in facets.items():
-                facet_counts[field_name][facet] = {
+        for facet_name in self.facets:
+            field = self.get_field(facet_name)
+            solr_facet_name = field.index
+            solr_facet = resp.facets.get(solr_facet_name)
+
+            if not solr_facet:
+                continue
+
+            facet_counts[facet_name] = {}
+            for facet, count in solr_facet.items():
+                facet_counts[field.field_name][facet] = {
                     "count": count,
                     "label": field.index_value_to_label(facet)
                     }
+
         return facet_counts
 
     def parse_requested_fields(self, params):

--- a/opengever/api/solrsearch.py
+++ b/opengever/api/solrsearch.py
@@ -63,11 +63,10 @@ class SolrSearchGet(SolrQueryBaseService):
         if not isinstance(facet_fields, list):
             facet_fields = [facet_fields]
         if facet_fields:
-            facet_fields = [
-                facet for facet in facet_fields
-                if self.is_field_allowed(facet) and self.get_field_index(facet) in self.solr_fields
-            ]
-            params['facet.field'] = facet_fields
+            self.facets = [facet for facet in facet_fields
+                           if self.is_field_allowed(facet)
+                           and self.get_field_index(facet) in self.solr_fields]
+            params['facet.field'] = map(self.get_field_index, self.facets)
         return params
 
     def reply(self):
@@ -89,9 +88,7 @@ class SolrSearchGet(SolrQueryBaseService):
             "start": start,
             "rows": rows,
         }
-
-        facet_counts = self.extract_facets_from_response(resp)
-        res['facet_counts'] = facet_counts
+        res['facet_counts'] = self.extract_facets_from_response(resp)
 
         return res
 

--- a/opengever/api/tests/test_solrsearch.py
+++ b/opengever/api/tests/test_solrsearch.py
@@ -173,6 +173,41 @@ class TestSolrSearchGet(SolrIntegrationTestCase):
             facet_counts[u'Subject'])
 
     @browsing
+    def test_facet_labels_are_transformed_properly(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        url = (u'{}/@solrsearch?q=wichtig&facet=on&facet.field=creator&'
+               u'facet.field=responsible&facet.mincount=1'.format(
+                   self.portal.absolute_url()))
+        browser.open(url, method='GET', headers=self.api_headers)
+
+        self.assertIn(u'facet_counts', browser.json)
+        facet_counts = browser.json['facet_counts']
+
+        self.assertItemsEqual([u'creator', 'responsible'], facet_counts.keys())
+        self.assertItemsEqual(
+            {u'robert.ziegler': {u'count': 3, u'label': u'Ziegler Robert'}},
+            facet_counts[u'creator'])
+        self.assertItemsEqual(
+            {u'robert.ziegler': {u'count': 1, u'label': u'Ziegler Robert'}},
+            facet_counts[u'responsible'])
+
+    @browsing
+    def test_using_a_solr_index_as_a_facet_works_properly(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        url = (u'{}/@solrsearch?q=wichtig&facet=on&facet.field=Creator&'
+               u'facet.mincount=1'.format(
+                   self.portal.absolute_url()))
+        browser.open(url, method='GET', headers=self.api_headers)
+
+        facet_counts = browser.json['facet_counts']
+
+        self.assertItemsEqual(
+            {u'robert.ziegler': {u'count': 3, u'label': u'robert.ziegler'}},
+            facet_counts[u'Creator'])
+
+    @browsing
     def test_default_start_and_rows(self, browser):
         self.login(self.regular_user, browser=browser)
 


### PR DESCRIPTION
Jira: https://4teamwork.atlassian.net/browse/GEVER-290

This PR:
- Added a feature for the `@solrsearch` endpoint to provide the same facets like the `@listing` endpoint. This means, a facet can now be requested by entering the exact solr index name like `Creator` or a self defined `ListingField`-Name like `creator` (https://github.com/4teamwork/opengever.core/blob/master/opengever/api/solr_query_service.py#L200).
- Fixes an issue where facet values have not been tranformed if requesting a facet based on a `ListingField` (i.e.: `/@listing?name=documents&columns=title&facets=creator`)


## Checklist (Must have)

- [x] Changelog entry
- [x] Documentation updated (notably for API and deployment)
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
