### PR TITLE
Implement @possible-watchers endpoint

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -12,6 +12,7 @@ Changelog
 - Fix activity bug when creating tasks with tasktemplates. [tinagerber]
 - Add basic support for xlsx sources to bundle factory. [deiferni]
 - Add new filename column to Favorites. [njohner]
+- Implement @possible-watchers endpoint. [elioschmutz]
 - Add `is_admin_menu_visible` to the `@config` API endpoint. [mbaechtold]
 - Watchers GET API: Also include info about referenced_users and referenced_watcher_roles. [tinagerber]
 - Fix @solrsearch endpoint default sort order. [elioschmutz]

--- a/docs/public/dev-manual/api/watchers.rst
+++ b/docs/public/dev-manual/api/watchers.rst
@@ -140,3 +140,82 @@ Mittels DELETE-Requests kann die Rolle ``regular_watcher`` eines Beobachters von
       HTTP/1.1 204 No content
 
 
+Liste von möglichen Beobachtern
+-------------------------------
+Der ``@possible-watchers``-Endpoint liefert eine Liste von Benutzern welche als Beobachter für den aktuellen Kontext hinzugefügt werden können.
+
+Weil es üblich ist, dass man sich selbst als Beobachter hinzufügen möchte, wird der eigene Benutzer in der Sortierreihenfolge immer zuoberst dargestellt. Alle restlichen Benutzer werden nach Name und Vorname sortiert. Der eigene Benutzer sowie alle anderen Benutzer werden nur dann angezeigt, wenn diese noch keine Beobachter-Rolle besitzen.
+
+**Beispiel-Request:**
+
+
+  .. sourcecode:: http
+
+    GET /task-1/@possible-watchers HTTP/1.1
+    Accept: application/json
+
+
+**Beispiel-Response:**
+
+   .. sourcecode:: http
+
+      HTTP/1.1 200 OK
+      Content-Type: application/json
+
+      {
+        "@id": "/task-1/@possible-watchers",
+        "items": [
+          {
+            "title": "Mueller Peter (peter.mueller)",
+            "token": "peter.mueller"
+          },
+          {
+            "title": "Ziegler Rolf (rolf.ziegler)",
+            "token": "rolf.ziegler"
+          },
+          { "...": "..." },
+        ],
+        "items_total": 17
+      }
+
+Resultate filtern
+~~~~~~~~~~~~~~~~~
+Mit dem ``query``-Parameter können die Resultate gefiltert werden. Es werden die Felder:
+
+- Vorname
+- Nachname
+- E-Mail
+- Userid
+
+beim filtern berücksichtigt.
+
+**Beispiel-Request:**
+
+
+  .. sourcecode:: http
+
+    GET /task-1/@possible-watchers?query=Peter HTTP/1.1
+    Accept: application/json
+
+
+**Beispiel-Response:**
+
+   .. sourcecode:: http
+
+      HTTP/1.1 200 OK
+      Content-Type: application/json
+
+      {
+        "@id": "/task-1/@possible-watchers",
+        "items": [
+          {
+            "title": "Mueller Peter (peter.mueller)",
+            "token": "peter.mueller"
+          }
+        ],
+        "items_total": 1
+      }
+
+Paginierung
+~~~~~~~~~~~
+Die Paginierung funktioniert gleich wie bei anderen Auflistungen auch (siehe :ref:`Kapitel Paginierung <batching>`).

--- a/opengever/activity/sources.py
+++ b/opengever/activity/sources.py
@@ -1,0 +1,53 @@
+from opengever.activity import notification_center
+from opengever.ogds.base.sources import AssignedUsersSource
+from opengever.ogds.models.user import User
+from plone import api
+from sqlalchemy import case
+
+
+class PossibleWatchersSource(AssignedUsersSource):
+    """A vocabulary source of all users not watching a ressource assigned
+    to the current admin unit.
+
+    The results are sorted by the last and first name in general. Beside of
+    this sorting, the current user will be always at the first position if
+    available.
+    """
+
+    @property
+    def base_query(self):
+        query = super(PossibleWatchersSource, self).base_query
+        return self._extend_query(query)
+
+    @property
+    def search_query(self):
+        query = super(PossibleWatchersSource, self).search_query
+        return self._extend_query(query)
+
+    def _extend_query(self, query):
+        query = self._current_user_first(query)
+        query = self._filter_not_subscribing_watchers(query)
+        return query
+
+    def _current_user_first(self, query):
+        """The current user have to be at first position if available.
+
+        This function extends the query with the order_by clause to move
+        the current user to the first position if available.
+        """
+        current_user = api.user.get_current()
+        return query.order_by(case(
+            ((User.userid == current_user.getId(), 1), ),
+            else_='2'))
+
+    def _filter_not_subscribing_watchers(self, query):
+        """This function adds the filter clause to only return users without a
+        watcher-role on the current context.
+        """
+        center = notification_center()
+        regular_watchers = center.get_subscriptions(self.context)
+        userids = set([subscription.watcher.actorid for subscription in regular_watchers])
+
+        if userids:
+            query = query.filter(User.userid.notin_(userids))
+        return query

--- a/opengever/activity/tests/test_sources.py
+++ b/opengever/activity/tests/test_sources.py
@@ -1,0 +1,82 @@
+from opengever.activity import notification_center
+from opengever.activity.roles import WATCHER_ROLE
+from opengever.activity.sources import PossibleWatchersSource
+from opengever.base.model import create_session
+from opengever.testing import IntegrationTestCase
+
+
+class TestPossibleWatchersSource(IntegrationTestCase):
+
+    features = ('activity', )
+
+    def setUp(self):
+        super(TestPossibleWatchersSource, self).setUp()
+        self.login(self.administrator)
+
+        # Remove all current subscriptions to get a clean state
+        session = create_session()
+        map(session.delete, notification_center().get_subscriptions(self.task))
+
+    def test_list_users_not_having_a_watcher_role_on_an_object(self):
+        self.login(self.regular_user)
+        center = notification_center()
+        source = PossibleWatchersSource(self.task)
+
+        subscriptions = center.get_subscriptions(self.task)
+        self.assertEqual([], [s.watcher.actorid for s in subscriptions])
+        self.assertIn(u'kathi.barfuss', [term.value for term in source.search('')])
+
+        center.add_watcher_to_resource(self.task, self.regular_user.getId(), WATCHER_ROLE)
+
+        subscriptions = center.get_subscriptions(self.task)
+        self.assertEqual(['kathi.barfuss'], [s.watcher.actorid for s in subscriptions])
+        self.assertNotIn(u'kathi.barfuss', [term.value for term in source.search('')])
+
+    def test_current_user_is_always_on_first_position_if_available(self):
+        self.login(self.regular_user)
+        source = PossibleWatchersSource(self.task)
+
+        self.login(self.regular_user)
+        self.assertEqual(self.regular_user.getId(), source.search('')[0].value)
+
+        self.login(self.dossier_manager)
+        self.assertEqual(self.dossier_manager.getId(), source.search('')[0].value)
+
+        self.login(self.administrator)
+        self.assertEqual(self.administrator.getId(), source.search('')[0].value)
+
+    def test_filter_by_title_returns_the_filtered_users(self):
+        self.login(self.regular_user)
+        source = PossibleWatchersSource(self.task)
+
+        self.assertEqual([
+            u'gunther.frohlich',
+            u'faivel.fruhling',
+            u'fridolin.hugentobler',
+            u'franzi.muller'],
+            [term.value for term in source.search('fr')])
+
+    def test_search_is_case_insensitive(self):
+        self.login(self.regular_user)
+        source = PossibleWatchersSource(self.task)
+
+        self.assertEqual([
+            u'gunther.frohlich',
+            u'faivel.fruhling',
+            u'fridolin.hugentobler',
+            u'franzi.muller'],
+            [term.value for term in source.search('FR')])
+
+    def test_term_title_is_user_display_name(self):
+        self.login(self.regular_user)
+        source = PossibleWatchersSource(self.task)
+        self.assertEqual(u'B\xe4rfuss K\xe4thi (kathi.barfuss)',
+                         source.search('kathi.barfuss')[0].title)
+
+    def test_search_with_umlaut_works_properly(self):
+        self.login(self.regular_user)
+        source = PossibleWatchersSource(self.task)
+
+        self.assertEqual(
+            [self.regular_user.getId()],
+            [term.value for term in source.search(u'B\xe4rfuss')])

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -718,6 +718,14 @@
       permission="zope2.View"
       />
 
+  <plone:service
+      method="GET"
+      name="@possible-watchers"
+      for="opengever.task.task.ITask"
+      factory=".watchers.PossibleWatchers"
+      permission="zope2.View"
+      />
+
   <adapter
       factory=".watchers.Watchers"
       name="watchers"

--- a/opengever/api/watchers.py
+++ b/opengever/api/watchers.py
@@ -2,14 +2,19 @@ from collections import defaultdict
 from opengever.activity import notification_center
 from opengever.activity.roles import ROLE_TRANSLATIONS
 from opengever.activity.roles import WATCHER_ROLE
+from opengever.activity.sources import PossibleWatchersSource
 from opengever.base.interfaces import IOpengeverBaseLayer
 from opengever.task.task import ITask
 from plone import api
+from plone.restapi.batching import HypermediaBatch
 from plone.restapi.deserializer import json_body
 from plone.restapi.interfaces import IExpandableElement
+from plone.restapi.interfaces import ISerializeToJson
 from plone.restapi.services import Service
+from Products.CMFPlone.utils import safe_unicode
 from zExceptions import BadRequest
 from zope.component import adapter
+from zope.component import getMultiAdapter
 from zope.i18n import translate
 from zope.interface import implementer
 
@@ -98,3 +103,29 @@ class WatchersDelete(Service):
         data = json_body(self.request)
         if data:
             raise BadRequest("DELETE does not take any data")
+
+
+class PossibleWatchers(Service):
+    def reply(self):
+        source = PossibleWatchersSource(self.context)
+        query = safe_unicode(self.request.form.get('query', ''))
+        results = source.search(query)
+
+        batch = HypermediaBatch(self.request, results)
+
+        serialized_terms = []
+        for term in batch:
+            serializer = getMultiAdapter(
+                (term, self.request), interface=ISerializeToJson
+            )
+            serialized_terms.append(serializer())
+
+        result = {
+            "@id": batch.canonical_url,
+            "items": serialized_terms,
+            "items_total": batch.items_total,
+        }
+        links = batch.links
+        if links:
+            result["batching"] = links
+        return result


### PR DESCRIPTION
Jira: https://4teamwork.atlassian.net/browse/GEVER-320

This PR implements the `@possible-watchers` endpoint.

The Endpoint returns users without a watcher-role on the current context. The results are sorted by last and first name. The current user will be returned on the first position if he is part of the result-set.

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Documentation updated (notably for API and deployment)
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
