### PR TITLE
Fix activity bug when creating tasks with tasktemplates.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -8,6 +8,7 @@ Changelog
 - Fix an issue where solr facet labels have not been transformed correctly. [elioschmutz]
 - Skip unknown attributes in POST @invitation endpoint. [elioschmutz]
 - Add watchers, resources and subscriptions to tasks and forwarding in fixtures. [tinagerber]
+- Fix activity bug when creating tasks with tasktemplates. [tinagerber]
 - Add `is_admin_menu_visible` to the `@config` API endpoint. [mbaechtold]
 - Watchers GET API: Also include info about referenced_users and referenced_watcher_roles. [tinagerber]
 - Fix @solrsearch endpoint default sort order. [elioschmutz]

--- a/opengever/tasktemplates/tasktemplatefolder.py
+++ b/opengever/tasktemplates/tasktemplatefolder.py
@@ -53,8 +53,8 @@ class TaskTemplateFolderTrigger(object):
         self.request = getRequest()
 
     def generate(self):
-        alsoProvides(self.request, IDuringTaskTemplateFolderTriggering)
         main_task = self.create_main_task()
+        alsoProvides(self.request, IDuringTaskTemplateFolderTriggering)
         self.create_subtasks(main_task)
         noLongerProvides(self.request, IDuringTaskTemplateFolderTriggering)
 

--- a/opengever/tasktemplates/tests/test_activities.py
+++ b/opengever/tasktemplates/tests/test_activities.py
@@ -3,7 +3,6 @@ from ftw.builder import create
 from ftw.testbrowser import browsing
 from opengever.activity.model import Activity
 from opengever.testing import IntegrationTestCase
-from plone import api
 
 
 class TestTaskTemplateActivites(IntegrationTestCase):
@@ -37,11 +36,11 @@ class TestTaskTemplateActivites(IntegrationTestCase):
         seq1, seq2 = main_task.objectValues()
 
         self.assertItemsEqual(
-            [main_task, seq1, seq2],
+            [main_task, main_task, seq1, seq2],
             [activity.resource.oguid.resolve_object() for activity in Activity.query.all()])
 
         self.assertItemsEqual(
-            [u'task-transition-open-in-progress', u'task-added', u'task-added'],
+            [u'task-added', u'task-transition-open-in-progress', u'task-added', u'task-added'],
             [activity.kind for activity in Activity.query.all()])
 
     @browsing
@@ -72,6 +71,9 @@ class TestTaskTemplateActivites(IntegrationTestCase):
         main_task = self.dossier.objectValues()[-1]
         seq1, seq2 = main_task.objectValues()
 
-        self.assertItemsEqual([main_task, seq1],
-                              [activity.resource.oguid.resolve_object()
-                               for activity in Activity.query.all()])
+        self.assertItemsEqual([
+          (u'task-added', main_task),
+          (u'task-transition-open-in-progress', main_task),
+          (u'task-added', seq1)],
+          [(activity.kind, activity.resource.oguid.resolve_object())
+           for activity in Activity.query.all()])


### PR DESCRIPTION
If new tasks were created with the task templates and the standard process was not triggered, no watchers were created in the database for the main task. 

The `IDuringTaskTemplateFolderTriggering` inteface prevents a `TaskAddedActivity` from being triggered when creating tasks from task templates. Therefore no watchers are created.

Now a `TaskAddedActivity` is also triggered for the main task, so the watchers are also created.

Jira: https://4teamwork.atlassian.net/browse/GEVER-32

Definition of Done: https://4teamwork.atlassian.net/wiki/spaces/CHX4TW/pages/917562/


## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Documentation updated (notably for API and deployment)
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
