### PR TITLE
Skip unknown attributes in POST @invitation endpoint.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 ------------------------
 
 - Fix an issue where solr facet labels have not been transformed correctly. [elioschmutz]
+- Skip unknown attributes in POST @invitation endpoint. [elioschmutz]
 - Add `is_admin_menu_visible` to the `@config` API endpoint. [mbaechtold]
 - Watchers GET API: Also include info about referenced_users and referenced_watcher_roles. [tinagerber]
 - Fix @solrsearch endpoint default sort order. [elioschmutz]

--- a/opengever/api/invitations.py
+++ b/opengever/api/invitations.py
@@ -134,7 +134,8 @@ class InvitationsPost(ParticipationTraverseService):
 
         data = json_body(self.request)
         data['role'] = data.get('role', {}).get('token')
-        errors = get_validation_errors(data, IWorkspaceInvitationSchema)
+        errors = get_validation_errors(data, IWorkspaceInvitationSchema,
+                                       allow_unknown_fields=True)
         if errors:
             raise BadRequest(errors)
 

--- a/opengever/api/tests/test_invitation.py
+++ b/opengever/api/tests/test_invitation.py
@@ -61,6 +61,26 @@ class TestInvitationsPost(IntegrationTestCase):
             "same as the serialized invitation in the GET request.")
 
     @browsing
+    def test_endpoint_ignores_unknown_properties(self, browser):
+        self.login(self.workspace_admin, browser=browser)
+
+        url = '{}/@invitations'.format(self.workspace.absolute_url())
+
+        # The `@type` property is not defined in the IWorkspaceInvitationSchema.
+        # The endpoint should not fail if this property is present.
+        data = json.dumps({
+            '@type': 'virtual.participation.invitation',
+            'recipient_email': self.regular_user.getProperty('email'),
+            'role': {'token': WORKSPCAE_GUEST.id},
+        })
+        browser.open(url, method='POST', headers=self.api_headers, data=data)
+        item = browser.json
+        iid = item.get('token')
+        self.assertEqual(
+            u'http://nohost/plone/workspaces/workspace-1/@invitations/{}'.format(iid),
+            item['@id'])
+
+    @browsing
     def test_prevents_duplicate_invitation(self, browser):
         self.login(self.workspace_admin, browser=browser)
 

--- a/opengever/api/tests/test_validation.py
+++ b/opengever/api/tests/test_validation.py
@@ -1,0 +1,26 @@
+from opengever.api.exceptions import UnknownField
+from opengever.api.validation import get_validation_errors
+from opengever.testing import FunctionalTestCase
+from plone.supermodel.model import Schema
+
+
+class TestSchema(Schema):
+    """
+    """
+
+
+class TestSchemaValidation(FunctionalTestCase):
+
+    def test_allow_unknown_fields(self):
+        data = {'lorem_ipsum_field': u'james.bond'}
+
+        errors = get_validation_errors(data, TestSchema, allow_unknown_fields=True)
+        self.assertEqual([], errors)
+
+        errors = get_validation_errors(data, TestSchema, allow_unknown_fields=False)
+        self.assertEqual(1, len(errors))
+
+        field, error = errors[0]
+        self.assertEqual('lorem_ipsum_field', field)
+        self.assertIsInstance(error, UnknownField)
+        self.assertEqual('lorem_ipsum_field', error.message)

--- a/opengever/api/validation.py
+++ b/opengever/api/validation.py
@@ -54,7 +54,7 @@ def get_unknown_fields(action_data, schema):
     return errors
 
 
-def get_schema_validation_errors(action_data, schema):
+def get_schema_validation_errors(action_data, schema, allow_unknown_fields=False):
     """Validate a dict against a schema.
 
     Return a list of basic schema validation errors (required fields,
@@ -82,19 +82,21 @@ def get_schema_validation_errors(action_data, schema):
             except ValidationError as e:
                 errors.append((name, e))
 
-    # Also reject fields that are not part of the schema
-    errors.extend(get_unknown_fields(action_data, schema))
+    if not allow_unknown_fields:
+        # Also reject fields that are not part of the schema
+        errors.extend(get_unknown_fields(action_data, schema))
 
     return errors
 
 
-def get_validation_errors(action_data, schema):
+def get_validation_errors(action_data, schema, allow_unknown_fields=False):
     """Validate a dict against a schema and invariants.
 
     Return a list of all validation errors, including invariants.
     Based on zope.schema.getValidationErrors.
     """
-    errors = get_schema_validation_errors(action_data, schema)
+    errors = get_schema_validation_errors(action_data, schema,
+                                          allow_unknown_fields)
     if errors:
         return errors
 


### PR DESCRIPTION
Jira: https://4teamwork.atlassian.net/browse/GEVER-357

The `@invitation` endpoint is currently hard-validating the json-body and will raise an error if there is an unknown attribute. That's not the same behavior like the default plone restapi for adding resources.

This PR refactors the endpoint to extract all relevant attributes from the body.

**Side-Info**
The frontend provides a generic add form which uses a predefined schema for a type. Since an invitation is a kind of type in the frontend, it also sends the `@type` property to the server for adding a new invitation.

<img width="551" alt="Bildschirmfoto 2020-05-13 um 10 16 37" src="https://user-images.githubusercontent.com/557005/81788465-da1c9180-9502-11ea-9470-b92175e3b347.png">

This will raise an error on the backend because `@type` is not part of the `IWorkspaceInvitationSchema`:

`BadRequest: [(u'@type', UnknownField(u'@type'))]`
https://sentry.4teamwork.ch/sentry/onegov-gever/issues/67036/

Of course, we could fix this in the frontend by not sending the `@type` property. But the API should be robust enough to handle this kind of request.

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Documentation updated (notably for API and deployment)
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
