### PR TITLE
Add watchers, resources and subscriptions to tasks and forwarding in fixtures

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,7 @@ Changelog
 - The widget used to select users or groups while protecting a business dossier now respects the sharing configuration. [mbaechtold]
 - Fix an issue where solr facet labels have not been transformed correctly. [elioschmutz]
 - Skip unknown attributes in POST @invitation endpoint. [elioschmutz]
+- Add watchers, resources and subscriptions to tasks and forwarding in fixtures. [tinagerber]
 - Add `is_admin_menu_visible` to the `@config` API endpoint. [mbaechtold]
 - Watchers GET API: Also include info about referenced_users and referenced_watcher_roles. [tinagerber]
 - Fix @solrsearch endpoint default sort order. [elioschmutz]

--- a/opengever/activity/tests/test_listing.py
+++ b/opengever/activity/tests/test_listing.py
@@ -3,6 +3,7 @@ from ftw.builder import create
 from ftw.testbrowser import browsing
 from opengever.activity.badge import BadgeIconDispatcher
 from opengever.activity.center import NotificationCenter
+from opengever.activity.model import Watcher
 from opengever.activity.model.notification import Notification
 from opengever.activity.model.settings import NotificationDefault
 from opengever.activity.roles import WATCHER_ROLE
@@ -24,8 +25,7 @@ class TestMyNotifications(IntegrationTestCase):
 
         self.center = NotificationCenter(dispatchers=[BadgeIconDispatcher()])
 
-        self.test_watcher = create(Builder('watcher')
-                                .having(actorid=self.regular_user.getId()))
+        self.test_watcher = Watcher.query.get_by_actorid(self.regular_user.getId())
 
         self.resource_a = create(Builder('resource')
                                  .oguid('fd:123')

--- a/opengever/activity/tests/test_mail.py
+++ b/opengever/activity/tests/test_mail.py
@@ -23,8 +23,6 @@ class TestEmailNotification(IntegrationTestCase):
     def setUp(self):
         super(TestEmailNotification, self).setUp()
         # XXX - we cannot yet fixturize SQL objects
-        create(Builder('watcher').having(actorid=self.regular_user.id))
-        # XXX - we cannot yet fixturize SQL objects
         create(
             Builder('notification_setting')
             .having(
@@ -205,7 +203,6 @@ class TestNotificationMailsAndSavepoints(IntegrationTestCase):
             insert_notification_defaults(self.portal)
 
         task_responsible = self.regular_user
-        create(Builder('watcher').having(actorid=task_responsible.id))
 
         # Make sure mails to responsible are enabled for task added
         create(Builder('notification_setting')

--- a/opengever/activity/tests/test_notification_viewlet.py
+++ b/opengever/activity/tests/test_notification_viewlet.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
+from opengever.activity.model import Watcher
 from opengever.testing import IntegrationTestCase
 import pytz
 
@@ -23,8 +24,8 @@ class TestNotificationViewlet(IntegrationTestCase):
 
     def setUp(self):
         super(TestNotificationViewlet, self).setUp()
-        self.regular_watcher = create(Builder('watcher').having(actorid=self.regular_user.id))
-        self.dossier_responsible_watcher = create(Builder('watcher').having(actorid=self.dossier_responsible.id))
+        self.regular_watcher = Watcher.query.get_by_actorid(self.regular_user.id)
+        self.dossier_responsible_watcher = Watcher.query.get_by_actorid(self.dossier_responsible.id)
         self.resource_a = create(
             Builder('resource')
             .oguid('fd:123')

--- a/opengever/activity/tests/test_resolve.py
+++ b/opengever/activity/tests/test_resolve.py
@@ -6,6 +6,7 @@ from opengever.activity.model import Notification
 from opengever.base.oguid import Oguid
 from opengever.testing import IntegrationTestCase
 from plone import api
+from opengever.activity.model import Resource
 
 
 class TestResolveNotificationView(IntegrationTestCase):
@@ -14,8 +15,7 @@ class TestResolveNotificationView(IntegrationTestCase):
         super(TestResolveNotificationView, self).setUp()
         # XXX - Cannot fixturise SQL objects yet.
         with self.login(self.regular_user):
-            oguid = Oguid.for_object(self.task)
-            resource = create(Builder('resource').oguid(oguid.id))
+            resource = Resource.query.get_by_oguid(Oguid.for_object(self.task))
             activity = create(Builder('activity').having(resource=resource))
             self.notification_id = 123
             create(

--- a/opengever/activity/tests/test_views.py
+++ b/opengever/activity/tests/test_views.py
@@ -26,16 +26,7 @@ class TestMarkAsRead(IntegrationTestCase):
         super(TestMarkAsRead, self).setUp()
         with self.login(self.regular_user):
             self.center = NotificationCenter()
-            self.watcher = create(
-                Builder('watcher')
-                .having(actorid=self.regular_user.id)
-            )
-            oguid = Oguid.for_object(self.task)
-            self.resource = create(
-                Builder('resource')
-                .oguid(oguid.id)
-                .watchers([self.watcher])
-            )
+            self.resource = Resource.query.get_by_oguid(Oguid.for_object(self.task))
 
             # XXX - something is wonky with the builder for activities
             with freeze(FREEZE_TIME_FIRST):
@@ -120,16 +111,7 @@ class TestListNotifications(IntegrationTestCase):
         super(TestListNotifications, self).setUp()
         with self.login(self.regular_user), freeze(FREEZE_TIME):
             self.center = NotificationCenter()
-            self.watcher = create(
-                Builder('watcher')
-                .having(actorid=self.regular_user.id)
-            )
-            oguid = Oguid.for_object(self.task)
-            self.resource = create(
-                Builder('resource')
-                .oguid(oguid.id)
-                .watchers([self.watcher])
-            )
+            self.resource = Resource.query.get_by_oguid(Oguid.for_object(self.task))
 
             self.activity = create(
                 Builder('activity')
@@ -202,8 +184,9 @@ class TestListNotifications(IntegrationTestCase):
         self.assertEqual(u'_self', target)
 
         # On foreign admin unit - 'fd'
-        Resource.query.first().admin_unit_id = 'fd'
+        Resource.query.get_by_oguid(self.task.oguid).admin_unit_id = 'fd'
         browser.open(view="notifications/list")
+
         target = browser.json.get('notifications')[0]['target']
         self.assertEqual(u'_blank', target)
 

--- a/opengever/disposition/tests/test_activities.py
+++ b/opengever/disposition/tests/test_activities.py
@@ -7,6 +7,7 @@ from opengever.activity.roles import DISPOSITION_RECORDS_MANAGER_ROLE
 from opengever.base.behaviors.lifecycle import ARCHIVAL_VALUE_UNWORTHY
 from opengever.base.behaviors.lifecycle import ARCHIVAL_VALUE_WORTHY
 from opengever.base.behaviors.lifecycle import ILifeCycle
+from opengever.base.oguid import Oguid
 from opengever.ogds.base.actor import ActorLookup
 from opengever.testing import IntegrationTestCase
 from plone import api
@@ -18,9 +19,8 @@ class TestDispositionNotifications(IntegrationTestCase):
 
     def test_creator_and_all_archivist_are_registered_as_watchers(self):
         self.login(self.regular_user)
-        create(Builder('disposition'))
-
-        resource = Resource.query.one()
+        disposition = create(Builder('disposition'))
+        resource = Resource.query.get_by_oguid(Oguid.for_object(disposition))
 
         archivist_watchers = [
             sub.watcher.actorid for sub in resource.subscriptions

--- a/opengever/task/tests/test_activities.py
+++ b/opengever/task/tests/test_activities.py
@@ -420,7 +420,9 @@ class TestTaskReassignActivity(IntegrationTestCase):
         self.assertEquals(u'Bitte Abkl\xe4rungen erledigen.', reassign_activity.description)
 
     @browsing
-    def test_notifies_old_and_new_responsible(self, browser):
+    def test_notifies_old_and_new_responsible_and_issuer(self, browser):
+        self.login(self.meeting_user, browser)
+        old_responsible = self.task.responsible
         self.reassign(browser, self.meeting_user, u'Bitte Abkl\xe4rungen erledigen.')
 
         activities = Activity.query.all()
@@ -429,7 +431,7 @@ class TestTaskReassignActivity(IntegrationTestCase):
         reassign_activity = activities[-1]
 
         self.assertItemsEqual(
-            [self.regular_user.getId(), self.meeting_user.getId()],
+            [old_responsible, self.task.responsible, self.task.issuer],
             [notes.userid for notes in reassign_activity.notifications])
 
     @browsing
@@ -442,7 +444,7 @@ class TestTaskReassignActivity(IntegrationTestCase):
         subscriptions = resource.subscriptions
 
         self.assertItemsEqual(
-            [(u'herbert.jager', TASK_RESPONSIBLE_ROLE)],
+            [(u'robert.ziegler', u'task_issuer'), (u'herbert.jager', TASK_RESPONSIBLE_ROLE)],
             [(sub.watcher.actorid, sub.role) for sub in subscriptions])
 
     @browsing
@@ -481,7 +483,7 @@ class TestTaskReassignActivity(IntegrationTestCase):
 
         mail = email.message_from_string(Mailing(self.portal).pop())
         self.assertEquals(
-            'herbert.jager@gever.local', get_header(mail, 'To'))
+            'herbert@jager.com', get_header(mail, 'To'))
 
 
 class TestSuccesssorHandling(FunctionalTestCase):

--- a/opengever/task/tests/test_forms.py
+++ b/opengever/task/tests/test_forms.py
@@ -73,12 +73,6 @@ class TestTaskEditForm(IntegrationTestCase):
     def test_edit_responsible_records_activity(self, browser):
         self.activate_feature('activity')
         self.login(self.administrator, browser=browser)
-
-        # register_watchers
-        center = notification_center()
-        center.add_task_responsible(self.task, self.task.responsible)
-        center.add_task_issuer(self.task, self.task.issuer)
-
         self.set_workflow_state('task-state-open', self.task)
 
         browser.open(self.task, view='edit')
@@ -87,12 +81,12 @@ class TestTaskEditForm(IntegrationTestCase):
         browser.find('Save').click()
 
         activity = Activity.query.order_by(Activity.created.desc()).first()
-
         self.assertEquals(u'task-transition-reassign', activity.kind)
         self.assertEquals(
             [(u'robert.ziegler', u'task_issuer'),
              (u'jurgen.konig', u'task_responsible')],
-            [(sub.watcher.actorid, sub.role) for sub in Subscription.query.all()])
+            [(sub.watcher.actorid, sub.role) for sub in Subscription.query.all()
+             if sub.resource.int_id == self.task.int_id])
 
     @browsing
     def test_modify_event_is_fired_but_only_once(self, browser):

--- a/opengever/task/tests/test_team_tasks.py
+++ b/opengever/task/tests/test_team_tasks.py
@@ -80,7 +80,7 @@ class TestTeamTasks(IntegrationTestCase):
         # list comprehension.
         watchers = center.get_watchers(task)
         self.assertEquals(
-            [u'team:2', u'kathi.barfuss'],
+            [u'kathi.barfuss', u'team:2'],
             [watcher.actorid for watcher in watchers]
         )
 

--- a/opengever/task/tests/test_transition_actions.py
+++ b/opengever/task/tests/test_transition_actions.py
@@ -2,14 +2,11 @@ from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
 from opengever.activity import notification_center
-from opengever.activity.roles import TASK_ISSUER_ROLE
-from opengever.activity.roles import TASK_RESPONSIBLE_ROLE
 from opengever.testing import FunctionalTestCase
 from opengever.testing import IntegrationTestCase
 from plone import api
 import re
 import unittest
-
 
 URL_WIHOUT_TOKEN_RE = re.compile(r'(.*)([\?, &]_authenticator=.*)')
 
@@ -125,23 +122,7 @@ class TestTaskTransitionActionsForOpen(BaseTransitionActionIntegrationTest):
 
     def setUp(self):
         super(TestTaskTransitionActionsForOpen, self).setUp()
-        # XXX - we cannot yet fixturize SQL objects
-        regular_user_watcher = create(Builder('watcher').having(actorid=self.regular_user.id))
-        dossier_responsible_watcher = create(Builder('watcher').having(actorid=self.dossier_responsible.id))
         with self.login(self.regular_user):
-            task_resource = create(
-                Builder('resource')
-                .oguid(self.task.oguid.id)
-                )
-            # XXX - the subscriptions must match the fixture for the tests to make sense
-            create(
-                Builder('subscription')
-                .having(resource=task_resource, watcher=regular_user_watcher, role=TASK_RESPONSIBLE_ROLE)
-                )
-            create(
-                Builder('subscription')
-                .having(resource=task_resource, watcher=dossier_responsible_watcher, role=TASK_ISSUER_ROLE)
-                )
             self.set_workflow_state('task-state-open', self.task)
 
     @browsing

--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -263,6 +263,7 @@ class OpengeverContentFixture(object):
             'meeting_user',
             u'Herbert',
             u'J\xe4ger',
+            email='herbert@jager.com',
             user_settings={'_seen_tours': '["*"]'},
             )
 

--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -9,21 +9,25 @@ from datetime import timedelta
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.builder import ticking_creator
+from ftw.builder.builder import original_create
 from ftw.bumblebee.interfaces import IBumblebeeUserSaltStore
 from ftw.bumblebee.tests.helpers import asset as bumblebee_asset
 from ftw.testing import freeze
 from ftw.testing import staticuid
 from ftw.tokenauth.pas.storage import CredentialStorage
+from opengever.activity.model import Watcher
+from opengever.activity.roles import TASK_ISSUER_ROLE
+from opengever.activity.roles import TASK_RESPONSIBLE_ROLE
 from opengever.base.behaviors.lifecycle import ARCHIVAL_VALUE_UNWORTHY
 from opengever.base.behaviors.lifecycle import ARCHIVAL_VALUE_WORTHY
 from opengever.base.command import CreateEmailCommand
 from opengever.base.model import create_session
+from opengever.base.oguid import Oguid
 from opengever.base.role_assignments import RoleAssignmentManager
 from opengever.base.role_assignments import SharingRoleAssignment
 from opengever.mail.tests import MAIL_DATA
 from opengever.officeconnector.helpers import get_auth_plugin
 from opengever.ogds.models.service import ogds_service
-from opengever.ogds.models.user_settings import UserSettings
 from opengever.testing import assets
 from opengever.testing.helpers import time_based_intids
 from opengever.testing.integration_test_case import FEATURE_FLAGS
@@ -69,6 +73,27 @@ class OpengeverContentFixture(object):
         jwt_plugin = get_auth_plugin(api.portal.get())
         jwt_plugin.use_keyring = False
         jwt_plugin._secret = JWT_SECRET
+
+    def get_or_create_watcher(self, actorid):
+        watcher = Watcher.query.get_by_actorid(actorid)
+        if watcher:
+            return watcher
+        # With original_create the ticking_creator doesn't move the clock forward
+        # when an object is created
+        return original_create(Builder('watcher').having(actorid=actorid))
+
+    def create_task_subscriptions(self, obj):
+        oguid = Oguid.for_object(obj)
+        # With original_create the ticking_creator doesn't move the clock forward
+        # when an object is created
+        resource = original_create(Builder('resource').oguid(oguid.id))
+        responsible_watcher = self.get_or_create_watcher(obj.responsible)
+        issuer_watcher = self.get_or_create_watcher(obj.issuer)
+        original_create(Builder('subscription').having(resource=resource,
+                                                       watcher=responsible_watcher,
+                                                       role=TASK_RESPONSIBLE_ROLE))
+        original_create(Builder('subscription').having(resource=resource, watcher=issuer_watcher,
+                                                       role=TASK_ISSUER_ROLE))
 
     def create_fixture_content(self):
         with self.freeze_at_hour(4):
@@ -898,6 +923,7 @@ class OpengeverContentFixture(object):
                 issuer=self.dossier_responsible.getId(),
                 )
             ))
+        self.create_task_subscriptions(inbox_forwarding)
 
         self.register('inbox_forwarding_document', create(
             Builder('document')
@@ -1158,8 +1184,9 @@ class OpengeverContentFixture(object):
             .in_state('task-state-in-progress')
             .relate_to(self.document)
         ))
+        self.create_task_subscriptions(self.task)
 
-        self.register('subtask', create(
+        subtask = self.register('subtask', create(
             Builder('task')
             .within(self.task)
             .titled(u'Rechtliche Grundlagen in Vertragsentwurf \xdcberpr\xfcfen')
@@ -1173,6 +1200,7 @@ class OpengeverContentFixture(object):
             .in_state('task-state-resolved')
             .relate_to(self.document)
         ))
+        self.create_task_subscriptions(subtask)
 
         self.register('taskdocument', create(
             Builder('document')
@@ -1198,6 +1226,7 @@ class OpengeverContentFixture(object):
             .in_state('task-state-in-progress')
             .as_sequential_task()
         ))
+        self.create_task_subscriptions(sequential_task)
 
         seq_subtask_1 = self.register('seq_subtask_1', create(
             Builder('task')
@@ -1294,8 +1323,9 @@ class OpengeverContentFixture(object):
                 .in_state('task-state-in-progress')
                 .relate_to(self.meeting_document)
             ))
+            self.create_task_subscriptions(meeting_task)
 
-            self.register('meeting_subtask', create(
+            meeting_subtask = self.register('meeting_subtask', create(
                 Builder('task')
                 .within(meeting_task)
                 .titled(u'H\xf6rsaal reservieren')
@@ -1308,8 +1338,9 @@ class OpengeverContentFixture(object):
                 .in_state('task-state-resolved')
                 .relate_to(self.meeting_document)
             ))
+            self.create_task_subscriptions(meeting_subtask)
 
-        self.register('info_task', create(
+        info_task = self.register('info_task', create(
             Builder('task')
             .titled(u'Vertragsentw\xfcrfe 2018')
             .within(self.dossier)
@@ -1320,8 +1351,9 @@ class OpengeverContentFixture(object):
             )
             .relate_to(self.document)
         ))
+        self.create_task_subscriptions(info_task)
 
-        self.register('private_task', create(
+        private_task = self.register('private_task', create(
             Builder('task')
             .titled(u'Diskr\xe4te Dinge')
             .within(self.dossier)
@@ -1337,8 +1369,9 @@ class OpengeverContentFixture(object):
             .relate_to(self.document)
             .in_state('task-state-in-progress')
         ))
+        self.create_task_subscriptions(private_task)
 
-        self.register('inbox_task', create(
+        inbox_task = self.register('inbox_task', create(
             Builder('task')
             .titled(u're: Diskr\xe4te Dinge')
             .within(self.dossier)
@@ -1354,6 +1387,7 @@ class OpengeverContentFixture(object):
             .relate_to(self.document)
             .in_state('task-state-in-progress')
         ))
+        self.create_task_subscriptions(inbox_task)
 
     @staticuid()
     def create_expired_dossier(self):
@@ -1583,7 +1617,7 @@ class OpengeverContentFixture(object):
                 u'kunststuck.docx')
             ))
 
-        self.register('task_in_protected_dossier', create(
+        task_in_protected_dossier = self.register('task_in_protected_dossier', create(
             Builder('task')
             .within(protected_dossier_with_task)
             .titled(u'Ein notwendiges \xdcbel')
@@ -1597,6 +1631,7 @@ class OpengeverContentFixture(object):
             .in_state('task-state-in-progress')
             .relate_to(protected_document_with_task)
             ))
+        self.create_task_subscriptions(task_in_protected_dossier)
 
     @staticuid()
     def create_emails(self):

--- a/opengever/workspace/tests/test_activities.py
+++ b/opengever/workspace/tests/test_activities.py
@@ -127,18 +127,18 @@ class TestToDoWatchers(IntegrationTestCase):
 
         getUtility(IInvitationStorage).add_invitation(
             self.workspace,
-            self.regular_user.getProperty('email'),
+            self.meeting_user.getProperty('email'),
             self.workspace_owner.getId(),
             'WorkspaceGuest')
 
-        self.login(self.regular_user, browser)
+        self.login(self.meeting_user, browser)
         my_invitations = browser.open(
             self.portal.absolute_url() + '/@my-workspace-invitations',
             method='GET',
             headers=self.api_headers,
             ).json
 
-        watcher = self.center.fetch_watcher(self.regular_user.getId())
+        watcher = self.center.fetch_watcher(self.meeting_user.getId())
         self.assertIsNone(watcher)
 
         # Accept invitation
@@ -147,7 +147,7 @@ class TestToDoWatchers(IntegrationTestCase):
             method='POST',
             headers=self.api_headers).json
 
-        watcher = self.center.fetch_watcher(self.regular_user.getId())
+        watcher = self.center.fetch_watcher(self.meeting_user.getId())
         self.assertIsNotNone(watcher)
 
         self.login(self.workspace_member, browser)


### PR DESCRIPTION
Since the `activity` feature is not enabled when creating tasks (and forwardings) in the `OpengeverContentFixture`, no subscriptions, resources and watchers are created in the database for the tasks.

Currently it is not possible to enable the feature, so the required content is now created manually for each task.

Now subscriptions, resources and watchers for tasks no longer need to be created first in each test

Jira: https://4teamwork.atlassian.net/browse/GEVER-32

Definition of Done: https://4teamwork.atlassian.net/wiki/spaces/CHX4TW/pages/917562/


## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Documentation updated (notably for API and deployment)
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


## Checklist (optional)

_Only applicable should be left and checked._

- [x] New functionality  for `task` also works for `forwarding`