### PR TITLE
Improve performance while determining leaf node state.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2020.3.0rc3 (unreleased)
 ------------------------
 
+- Improve performance while determining leaf nodes. [mbaechtold]
 - The widget used to select users or groups while protecting a business dossier now respects the sharing configuration. [mbaechtold]
 - Fix an issue where solr facet labels have not been transformed correctly. [elioschmutz]
 - Skip unknown attributes in POST @invitation endpoint. [elioschmutz]

--- a/opengever/repository/repositoryfolder.py
+++ b/opengever/repository/repositoryfolder.py
@@ -149,9 +149,13 @@ class RepositoryFolder(content.Container, RepositoryMixin):
     def is_leaf_node(self):
         """ Checks if the current repository folder is a leaf-node.
         """
-        for id, obj in self.contentItems():
+        for obj in self.objectValues():
+            # A repository folder cannot contain other repository folders and
+            # items of other content types at the same time.
             if obj.portal_type == self.portal_type:
                 return False
+            else:
+                return True
         return True
 
 


### PR DESCRIPTION
The previous implementation was not performing well for repository folders containing lots of folders, because `contentItems` is not lazy. It should only be used for small number of items (see https://docs.plone.org/develop/plone/content/listing.html).

Furthermore, the exit condition has been improved due to the fact that a a repository folder cannot contain other repository folders and items of other content types at the same time.

Belongs to the Jira issue [GEVER-375](https://4teamwork.atlassian.net/browse/GEVER-375) (which contains the proposed solution and a flame graph).

## Checklist

- [x] Changelog entry
- [x] Documentation updated (notably for API and deployment)
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
