### PR TITLE
Improve performance while determining repositoryfolder emptiness.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2020.3.0rc3 (unreleased)
 ------------------------
 
+- Improve performance while determining repositoryfolder emptiness. [mbaechtold]
 - Improve performance while determining leaf nodes. [mbaechtold]
 - The widget used to select users or groups while protecting a business dossier now respects the sharing configuration. [mbaechtold]
 - Fix an issue where solr facet labels have not been transformed correctly. [elioschmutz]

--- a/opengever/repository/deleter.py
+++ b/opengever/repository/deleter.py
@@ -27,4 +27,4 @@ class RepositoryDeleter(object):
         return self.is_repository_empty()
 
     def is_repository_empty(self):
-        return len(self.repository.listFolderContents()) == 0
+        return self.repository.objectCount() == 0


### PR DESCRIPTION
`listFolderContents` honors the currently logged-in user roles, so the computed value might be misleading. Furthermore it is slow for large folders (see https://docs.plone.org/develop/plone/content/listing.html#getting-folder-objects-filtered).

Belongs to [GEVER-373](https://4teamwork.atlassian.net/browse/GEVER-373) (which contains the proposed solution and a flame graph).

## Checklist

- [x] Changelog entry
- [x] Documentation updated (notably for API and deployment)
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
