### PR TITLE
Improve performance of the subdossier tree.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2020.3.0rc3 (unreleased)
 ------------------------
 
+- Improve performance of the subdossier tree (on the dossier overview tab). [mbaechtold]
 - Improve performance while determining repositoryfolder emptiness. [mbaechtold]
 - Improve performance while determining leaf nodes. [mbaechtold]
 - The widget used to select users or groups while protecting a business dossier now respects the sharing configuration. [mbaechtold]

--- a/opengever/dossier/browser/navigation.py
+++ b/opengever/dossier/browser/navigation.py
@@ -30,12 +30,12 @@ class JSONNavigation(BrowserView):
                 'uid': api.content.get_uuid(obj=self.context)}
 
     def _tree(self):
-        subdossier_nodes = map(
+        nodes = map(
             self._brain_to_node,
             self.context.get_subdossiers(sort_on='sortable_title',
                                          review_state=DOSSIER_STATES_OPEN))
-        nodes = [self._context_as_node()] + subdossier_nodes
-
+        if nodes:
+            nodes = [self._context_as_node()] + nodes
         return make_tree_by_url(nodes)
 
     def _brain_to_node(self, brain):

--- a/opengever/dossier/browser/overview.py
+++ b/opengever/dossier/browser/overview.py
@@ -96,10 +96,6 @@ class DossierOverview(BoxesViewMixin, BrowserView, GeverTabMixin):
             'text/html', self.context.description,
             mimetype='text/x-web-intelligent').getData()
 
-    def is_subdossier_navigation_available(self):
-        main_dossier = self.context.get_main_dossier()
-        return main_dossier.has_subdossiers()
-
     def navigation_json_url(self):
         return '{}/dossier_navigation.json'.format(
             self.context.get_main_dossier().absolute_url())

--- a/opengever/dossier/browser/overview.py
+++ b/opengever/dossier/browser/overview.py
@@ -4,7 +4,6 @@ from opengever.base.browser.helper import get_css_class
 from opengever.contact import is_contact_feature_enabled
 from opengever.contact.models import Participation
 from opengever.dossier import _
-from opengever.dossier import _ as _dossier
 from opengever.dossier.base import DOSSIER_STATES_OPEN
 from opengever.dossier.behaviors.dossier import IDossier
 from opengever.dossier.behaviors.participation import IParticipationAware
@@ -150,7 +149,7 @@ class DossierOverview(BoxesViewMixin, BrowserView, GeverTabMixin):
             pass
 
         responsible = ResponsibleParticipant()
-        responsible.roles = _dossier(u'label_responsible', 'Responsible')
+        responsible.roles = _(u'label_responsible', 'Responsible')
         responsible.role_list = responsible.roles
 
         dossier_adpt = IDossier(self.context)

--- a/opengever/dossier/browser/templates/overview.pt
+++ b/opengever/dossier/browser/templates/overview.pt
@@ -7,7 +7,7 @@
     <div class="box" id="subdossiersBox">
       <h2 i18n:translate="">Dossier structure</h2>
 
-      <tal:block tal:condition="view/is_subdossier_navigation_available">
+      <tal:block>
         <div id="dossier-tree"
              tal:attributes="data-dossier-navigation-url view/navigation_json_url;
                              data-context-url context_url;"
@@ -24,9 +24,8 @@
         </script>
       </tal:block>
 
-      <tal:block tal:condition="not: view/is_subdossier_navigation_available">
-        <span i18n:translate="" >No Subdossiers</span>
-      </tal:block>
+      <!-- Will be made visible through JavaScript if the tree is empty. -->
+      <span id="dossier-tree-empty" i18n:translate="" style="display:none">No Subdossiers</span>
 
     </div>
   </div>

--- a/opengever/dossier/resources/init_tree.js
+++ b/opengever/dossier/resources/init_tree.js
@@ -14,6 +14,11 @@ $(function() {
   }
 
   function render_tree(tree_data) {
+    if (tree_data.length === 0 ) {
+      $('#dossier-tree').hide();
+      $('#dossier-tree-empty').show();
+      return;
+    }
     var navtree = make_tree(tree_data, {
       components: [new BusinessCaseDossierIconLinks()],
       expandActive: true

--- a/opengever/dossier/tests/test_navigation.py
+++ b/opengever/dossier/tests/test_navigation.py
@@ -40,6 +40,11 @@ class TestNavigation(FunctionalTestCase):
             browser.json)
 
     @browsing
+    def test_empty_dossier_navigation(self, browser):
+        browser.login().visit(self.main_dossier, view='dossier_navigation.json')
+        self.assertEqual([], browser.json)
+
+    @browsing
     def test_dossiers_are_sorted_by_title(self, browser):
         sub1 = create(Builder('dossier')
                       .titled(u'XXX')


### PR DESCRIPTION
We can remove the server-side checks because when the checks are positive (which are called twice by the way), the data needs to be fetched anyway. So instead we simply try to get the data and render the empty message when there is no data to be displayed.

Belongs to [GEVER-388](https://4teamwork.atlassian.net/browse/GEVER-388)

## Checklist (Must have)

- [x] Changelog entry
- [x] Documentation updated (notably for API and deployment)
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)