### PR TITLE
Test that RepositoryPathSourceBinder is limited to current repository.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2020.3.0rc3 (unreleased)
 ------------------------
 
+- Limit query to current repository in RepositoryPathSourceBinder. [njohner]
 - Improve performance of the subdossier tree (on the dossier overview tab). [mbaechtold]
 - Improve performance while determining repositoryfolder emptiness. [mbaechtold]
 - Improve performance while determining leaf nodes. [mbaechtold]

--- a/opengever/base/source.py
+++ b/opengever/base/source.py
@@ -152,6 +152,12 @@ class RepositoryPathSourceBinder(SolrObjPathSourceBinder):
             self.navigation_tree_query['path'] = {}
 
         self.navigation_tree_query['path']['query'] = root_path
+        # We also add the path filter to the selectable_filter as the
+        # navigation_tree_query is not used when querying the source and
+        # we need to only allow to query objects in the root_path.
+        if "path" not in self.selectable_filter.criteria:
+            self.selectable_filter.criteria['path'] = {}
+        self.selectable_filter.criteria['path']['query'] = root_path
 
         modificator = queryMultiAdapter((
             context, context.REQUEST),

--- a/opengever/base/tests/test_source_binder.py
+++ b/opengever/base/tests/test_source_binder.py
@@ -5,7 +5,7 @@ from opengever.testing import IntegrationTestCase
 from opengever.testing import SolrIntegrationTestCase
 
 
-class TestRepositoryPathSourceBinder(IntegrationTestCase):
+class TestRepositoryPathSourceBinderSolr(SolrIntegrationTestCase):
 
     def test_navigation_tree_query_is_limited_to_current_repository(self):
         self.login(self.regular_user)
@@ -19,6 +19,56 @@ class TestRepositoryPathSourceBinder(IntegrationTestCase):
         source = source_binder(self.leaf_repofolder)
         self.assertEqual({'query': '/plone/ordnungssystem'},
                          source.navigation_tree_query['path'])
+
+    def test_query_is_limited_to_current_repository(self):
+        self.login(self.manager)
+
+        source_binder = RepositoryPathSourceBinder()
+        source = source_binder(self.branch_repofolder)
+
+        self.document.title = 'source test document'
+        self.document.reindexObject()
+
+        self.proposaldocument.title = 'source test proposal document'
+        self.proposaldocument.reindexObject()
+
+        self.inbox_document.title = 'source test inbox document'
+        self.inbox_document.reindexObject()
+
+        self.private_document.title = 'source test private document'
+        self.private_document.reindexObject()
+        self.commit_solr()
+
+        self.assertItemsEqual(
+            ['source test document', 'source test proposal document'],
+            [term.title for term in source.search("source")])
+
+
+class TestRepositoryPathSourceBinder(IntegrationTestCase):
+
+    features = ('!solr', )
+
+    def test_query_is_limited_to_current_repository(self):
+        self.login(self.manager)
+
+        source_binder = RepositoryPathSourceBinder()
+        source = source_binder(self.branch_repofolder)
+
+        self.document.title = 'source test document'
+        self.document.reindexObject()
+
+        self.proposaldocument.title = 'source test proposal document'
+        self.proposaldocument.reindexObject()
+
+        self.inbox_document.title = 'source test inbox document'
+        self.inbox_document.reindexObject()
+
+        self.private_document.title = 'source test private document'
+        self.private_document.reindexObject()
+
+        self.assertItemsEqual(
+            ['source test document', 'source test proposal document'],
+            [term.title for term in source.search("source")])
 
 
 class TestDossierSourceBinder(SolrIntegrationTestCase):

--- a/opengever/base/tests/test_source_binder.py
+++ b/opengever/base/tests/test_source_binder.py
@@ -123,7 +123,8 @@ class TestRelatedDossierAutocomplete(IntegrationTestCase):
         )
         self.assert_solr_called(
             self.solr, 'empty', rows=20, fl=['path'],
-            filters=[u'object_provides:opengever.dossier.behaviors.dossier.IDossierMarker']
+            filters=[u'object_provides:opengever.dossier.behaviors.dossier.IDossierMarker',
+                     u'path_parent:\\/plone\\/ordnungssystem']
         )
 
     @browsing


### PR DESCRIPTION
This PR fixes a bug which allowed to move documents from a businesscasedossier to a private dossier, which is almost equivalent to deleting the document. 

Private dossiers were not selectable when using the selection widget with navigation, but were selectable when using searching for them using a query. The issue was that the `RepositoryPathSourceBinder` restricts the navigation to the current repository but not the query.

**Note for reviewer: I first pushed failing tests to better show that the second commit actually fixes the issue**
For https://4teamwork.atlassian.net/browse/GEVER-337

## Checklist (Must have)

- [x] Changelog entry
- [x] Documentation updated (notably for API and deployment)
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
