### PR TITLE
Remove catalog indexes and metadata of "plone.app.discussion".

### DIFF
--- a/opengever/base/tests/test_solr.py
+++ b/opengever/base/tests/test_solr.py
@@ -84,7 +84,6 @@ class TestSolr(IntegrationTestCase):
             'blocked_local_roles',
             'client_id',
             'cmf_uid',
-            'commentators',
             'contactid',
             'date_of_completion',
             'effective',
@@ -100,7 +99,6 @@ class TestSolr(IntegrationTestCase):
             'meta_type',
             'predecessor',
             'sortable_author',
-            'total_comments',
         ]
 
         for index in catalog.indexes():
@@ -117,9 +115,7 @@ class TestSolr(IntegrationTestCase):
             'ExpirationDate',
             'ModificationDate',
             'Type',
-            'author_name',
             'cmf_uid',
-            'commentators',
             'contactid',
             'css_icon_class',
             'date_of_completion',
@@ -131,14 +127,12 @@ class TestSolr(IntegrationTestCase):
             'getRemoteUrl',
             'in_response_to',
             'is_folderish',
-            'last_comment_date',
             'listCreators',
             'location',
             'meta_type',
             'predecessor',
             'title_de',
             'title_fr',
-            'total_comments'
         ]
 
         for metadata in catalog.schema():

--- a/opengever/core/hooks.py
+++ b/opengever/core/hooks.py
@@ -1,3 +1,4 @@
+from plone import api
 from zope.annotation.interfaces import IAnnotations
 from zope.component.hooks import getSite
 import logging
@@ -81,6 +82,8 @@ def should_prevent_duplicate_installation(profile):
 def installed(site):
     trigger_subpackage_hooks(site)
     enable_secure_flag_for_cookies(site)
+    remove_unused_catalog_indexes(site)
+    remove_unused_catalog_metadata(site)
 
 
 def trigger_subpackage_hooks(site):
@@ -106,3 +109,53 @@ def trigger_subpackage_hooks(site):
 def enable_secure_flag_for_cookies(context):
     session_plugin = context.acl_users.session
     session_plugin.secure = True
+
+
+def remove_unused_catalog_indexes(site):
+    indexes_to_remove = [
+        'commentators',
+        'total_comments',
+    ]
+    catalog = api.portal.get_tool('portal_catalog')
+    for index in indexes_to_remove:
+        if index in catalog._catalog.indexes:
+            catalog._catalog.delIndex(index)
+
+
+def remove_unused_catalog_metadata(site):
+    columns_to_remove = [
+        'author_name',
+        'commentators',
+        'last_comment_date',
+        'total_comments',
+    ]
+    catalog = api.portal.get_tool('portal_catalog')
+    schema = catalog._catalog.schema
+    names = list(catalog._catalog.names)
+    del_indexes = []
+    del_column_numbers = []
+    for column in columns_to_remove:
+        if column in names and column in schema:
+            del_indexes.append(names.index(column))
+            del_column_numbers.append(schema[column])
+
+    # Remove columns from names
+    for del_index in del_indexes:
+        del names[del_index]
+
+    # Rebuild the schema
+    schema = {}
+    for i, name in enumerate(names):
+        schema[name] = i
+
+    catalog._catalog.schema = schema
+    catalog._catalog.names = tuple(names)
+
+    catalog._catalog.updateBrains()
+
+    # Remove the column values from each record
+    del_column_numbers.sort(reverse=True)
+    for key, value in catalog._catalog.data.items():
+        for column_number in del_column_numbers:
+            value = value[:column_number] + value[column_number + 1:]
+        catalog._catalog.data[key] = value

--- a/opengever/core/upgrades/20200518084137_cleanup_catalog_indexes_and_metadata/upgrade.py
+++ b/opengever/core/upgrades/20200518084137_cleanup_catalog_indexes_and_metadata/upgrade.py
@@ -4,10 +4,16 @@ from ftw.upgrade import UpgradeStep
 
 INDEXES_TO_REMOVE = [
     'assigned_client',
+    'commentators',
+    'total_comments',
 ]
 
 METADATA_TO_REMOVE = [
+    'author_name',
     'assigned_client',
+    'commentators',
+    'last_comment_date',
+    'total_comments',
 ]
 
 

--- a/opengever/document/tests/test_copy_document.py
+++ b/opengever/document/tests/test_copy_document.py
@@ -106,11 +106,9 @@ class TestCopyDocuments(IntegrationTestCase):
                               'EffectiveDate',
                               'ExpirationDate',
                               'Subject', 'Type',
-                              'author_name',
                               'bumblebee_checksum',
                               'checked_out',
                               'cmf_uid',
-                              'commentators',
                               'contactid',
                               'css_icon_class',
                               'date_of_completion',
@@ -137,7 +135,6 @@ class TestCopyDocuments(IntegrationTestCase):
                               'is_subdossier',
                               'is_subtask',
                               'issuer',
-                              'last_comment_date',
                               'lastname',
                               'location',
                               'meta_type',
@@ -153,7 +150,6 @@ class TestCopyDocuments(IntegrationTestCase):
                               'task_type',
                               'title_de',
                               'title_fr',
-                              'total_comments',
                               'trashed']
 
         # Make sure no metadata key is in both lists of unchanged and modified metadata
@@ -250,7 +246,6 @@ class TestCopyDocuments(IntegrationTestCase):
                                'checked_out',
                                'client_id',
                                'cmf_uid',
-                               'commentators',
                                'contactid',
                                'date_of_completion',
                                'deadline',
@@ -287,7 +282,6 @@ class TestCopyDocuments(IntegrationTestCase):
                                'review_state',
                                'sortable_author',
                                'task_type',
-                               'total_comments',
                                'trashed']
 
         # Make sure no index is in both lists of unchanged and modified indexdata

--- a/opengever/dossier/tests/test_move_items.py
+++ b/opengever/dossier/tests/test_move_items.py
@@ -167,11 +167,9 @@ class TestMoveItemsUpdatesIndexAndMetadata(IntegrationTestCase, MoveItemsHelper)
                               'ExpirationDate',
                               'Subject',
                               'Type',
-                              'author_name',
                               'bumblebee_checksum',
                               'checked_out',
                               'cmf_uid',
-                              'commentators',
                               'contactid',
                               'css_icon_class',
                               'date_of_completion',
@@ -198,7 +196,6 @@ class TestMoveItemsUpdatesIndexAndMetadata(IntegrationTestCase, MoveItemsHelper)
                               'is_subdossier',
                               'is_subtask',
                               'issuer',
-                              'last_comment_date',
                               'lastname',
                               'location',
                               'meta_type',
@@ -214,7 +211,6 @@ class TestMoveItemsUpdatesIndexAndMetadata(IntegrationTestCase, MoveItemsHelper)
                               'task_type',
                               'title_de',
                               'title_fr',
-                              'total_comments',
                               'trashed']
 
         # Make sure no metadata key is in both lists of unchanged and modified metadata
@@ -302,7 +298,6 @@ class TestMoveItemsUpdatesIndexAndMetadata(IntegrationTestCase, MoveItemsHelper)
                                'checked_out',
                                'client_id',
                                'cmf_uid',
-                               'commentators',
                                'contactid',
                                'created',
                                'date_of_completion',
@@ -340,7 +335,6 @@ class TestMoveItemsUpdatesIndexAndMetadata(IntegrationTestCase, MoveItemsHelper)
                                'review_state',
                                'sortable_author',
                                'task_type',
-                               'total_comments',
                                'trashed']
 
         # Make sure no index is in both lists of unchanged and modified indexdata


### PR DESCRIPTION
This also introduces a profile hook which removes unneeded catalog indexes and metadata when a fresh GEVER is installed.