### PR TITLE
Fix issue in watchers endpoint with inactive ogds-users.

### DIFF
--- a/opengever/api/watchers.py
+++ b/opengever/api/watchers.py
@@ -4,6 +4,7 @@ from opengever.activity.roles import ROLE_TRANSLATIONS
 from opengever.activity.roles import WATCHER_ROLE
 from opengever.activity.sources import PossibleWatchersSource
 from opengever.base.interfaces import IOpengeverBaseLayer
+from opengever.ogds.base.actor import ActorLookup
 from opengever.task.task import ITask
 from plone import api
 from plone.restapi.batching import HypermediaBatch
@@ -43,13 +44,15 @@ class Watchers(object):
             roles.add(subscription.role)
 
         portal_url = api.portal.get().absolute_url()
-        referenced_users = [
-            {
-                '@id': "{}/@users/{}".format(portal_url, userid),
-                'id': userid,
-                'fullname': api.user.get(userid).getProperty('fullname')
-            }
-            for userid in watchers_and_roles]
+        referenced_users = []
+        for actor_id in watchers_and_roles:
+            actor = ActorLookup(actor_id).lookup()
+            referenced_users.append(
+                {
+                    '@id': "{}/@users/{}".format(portal_url, actor_id),
+                    'id': actor_id,
+                    'fullname': actor.get_label(with_principal=False)
+                })
 
         referenced_watcher_roles = [
             {


### PR DESCRIPTION
The `@watchers` endpoint will fail for watchers that aren't users (for example system users, inactive ogds-users...). Activities use Actors most everywhere and the watcher endpoints should do the same. This PR avoids `@watchers` to fail for such users, but this is not a definitive fix, as for example `@id` will not be correct for watchers that are not users and the `fullname` attribute does not really make sense for actors and should be renamed. I opened an issue to have a closer look at the watchers, but basically `Actor`s should be used most everywhere and should know the URL with which a given actor can be accessed over the API (https://4teamwork.atlassian.net/browse/GEVER-406). Moreover the Frontend will need to deal with actors as well.

Sentry: https://sentry.4teamwork.ch/sentry/onegov-gever/issues/67701/

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry. No CL Entry as in the same RC release as introduction of API endpoint (https://github.com/4teamwork/opengever.core/pull/6393)
- [x] Documentation updated (notably for API and deployment).
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
