### PR TITLE
Add version constraints for tests with Plone 4.3

### DIFF
--- a/base-plone-4.3.x.cfg
+++ b/base-plone-4.3.x.cfg
@@ -4,6 +4,7 @@ extends =
     versions.cfg
     sources.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-versions.cfg
+    https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-versions-plone-4.cfg
     https://raw.githubusercontent.com/4teamwork/gever-buildouts/master/solr.cfg
 
 package-name = opengever.core


### PR DESCRIPTION
Currently setuptools is unpinned in tests which results in picking an
incompatible version that no longer supports Python 2.7.
Installation itself currently does not fail, but some eggs (e.g.
zope.interface) are not installed correctly and tests fail because of
that. This does not manifest when using shared eggs and the affected
eggs were installed with an older setuptools before.

By extending from test-versions-plone-4.cfg we include our known
version constraints for Plone 4.3/Python2.7.

## Checklist (Must have)

- [ ] Changelog entry
- [ ] Documentation updated (notably for API and deployment)
- [ ] Link to issue (Jira or GitHub) and backlink in issue (Jira)
