### PR TITLE
Add attachments in mail serializer.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 ------------------------
 
 - Fix the upgradestep to merge notification settings from release 2020.3.0rc2 to use it's own configruation copy to not depend on future adjustments. [elioschmutz]
+- Add @extract-attachments endpoint to extract mail attachments. [njohner]
+- Only allow to extract each mail attachment once. [njohner]
+- Do not allow deleting mail attachments anymore. [njohner]
 - Rename @team API endpoint to @teams. [tinagerber]
 - Avoid object lookup in DocumentLinkWidget for Solr documents and catalog brains. [buchi]
 - Improve contenttree widget in handling a large amount of items. [buchi]

--- a/docs/public/dev-manual/api/extract_attachments.rst
+++ b/docs/public/dev-manual/api/extract_attachments.rst
@@ -1,0 +1,37 @@
+
+Anhänge speichern
+=================
+
+E-Mail-Anhänge können in OneGov GEVER als separate Dokumente gespeichert werden (nur einmal pro Anhang). Dies wird in der REST API mit einem ``POST`` Request auf den ``@extract-attachments`` Endpoint ermöglicht. Der ``positions`` Parameter erlaubt auszuwählen, welche Anhänge extrahiert werden sollen und entspricht der ``position``, die in der Response eines ``GET`` Request auf eine E-Mail für jeden Anhang enthalten ist. Wenn ``positions`` nicht angegeben wird, dann werden alle Anhänge extrahiert, welche noch nicht gespeichert wurden. Die Dokumente werden im selben Gefäss erstellt, in welchem sich die E-Mail befindet.
+
+**Beispiel-Request**:
+
+   .. sourcecode:: http
+
+       POST http://localhost:8080/fd/ordnungssystem/bildung/dossier-25/document-78/@extract-attachments HTTP/1.1
+       Accept: application/json
+
+       {
+        "positions": [4, 5]
+       }
+
+
+**Beispiel-Response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 200 OK
+      Content-Type: application/json
+
+      [
+          {
+              "extracted_document_title": "Ein Dokument",
+              "extracted_document_url": "http://localhost:8080/fd/ordnungssystem/bildung/dossier-25/document-79",
+              "position": 4
+          },
+          {
+              "extracted_document_title": "Ein weiteres Dokument",
+              "extracted_document_url": "http://localhost:8080/fd/ordnungssystem/bildung/dossier-25/document-80",
+              "position": 5
+          }
+      ]

--- a/docs/public/dev-manual/api/index.rst
+++ b/docs/public/dev-manual/api/index.rst
@@ -19,6 +19,7 @@ Inhalt:
    breadcrumbs.rst
    searching.rst
    documents.rst
+   extract_attachments.rst
    trash.rst
    workflow.rst
    scanin.rst

--- a/docs/public/user-manual/dokumente/ablegen.rst
+++ b/docs/public/user-manual/dokumente/ablegen.rst
@@ -45,11 +45,8 @@ Mail-Anhänge separat speichern
 
 Öffnet man in OneGov GEVER die E-Mail, werden die Mitteilung
 und eventuelle Anhänge angezeigt. Mit der Aktion *Anhänge speichern* können
-die E-Mail-Anhänge separat als Dokumente gespeichert werden. Wahlweise können
-die Anhänge der E-Mail gelöscht werden.
-
-*(Für signierte E-Mails (Dateiendung *.p7m) können Anhänge nicht gelöscht
-werden, weil dadurch sonst die Signatur invalidiert würde)*
+die E-Mail-Anhänge separat als Dokumente gespeichert werden. Jeder Anhang kann
+nur einmal als separates Dokument gespeichert werden.
 
 |img-dokumente-31|
 

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -32,6 +32,7 @@
   <adapter factory=".repositoryfolder.SerializeRepositoryFolderToJson" />
   <adapter factory=".dossier.SerializeDossierToJson" />
   <adapter factory=".document.SerializeDocumentToJson" />
+  <adapter factory=".mail.SerializeMailToJson" />
   <adapter factory=".workspace.SerializeWorkspaceToJson" />
   <adapter factory=".response.ResponseDefaultFieldSerializer" />
   <adapter factory=".response.SerializeResponseToJson" />

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -741,4 +741,12 @@
       name="watchers"
       />
 
+  <plone:service
+      method="POST"
+      name="@extract-attachments"
+      for="opengever.mail.mail.IOGMailMarker"
+      factory=".mail.ExtractAttachments"
+      permission="opengever.document.AddDocument"
+      />
+
 </configure>

--- a/opengever/api/mail.py
+++ b/opengever/api/mail.py
@@ -1,11 +1,13 @@
 from ftw.mail.mail import IMail
+from opengever.api.document import SerializeDocumentToJson
 from opengever.base.transforms.msg2mime import Msg2MimeTransform
-from opengever.mail.mail import initialize_title
 from opengever.mail.mail import initialize_metadata
+from opengever.mail.mail import initialize_title
 from plone.namedfile.file import NamedBlobFile
 from plone.restapi.deserializer import json_body
 from plone.restapi.deserializer.dxcontent import DeserializeFromJson
 from plone.restapi.interfaces import IDeserializeFromJson
+from plone.restapi.interfaces import ISerializeToJson
 from zope.component import adapter
 from zope.interface import implementer
 from zope.interface import Interface
@@ -42,3 +44,13 @@ class DeserializeMailFromJson(DeserializeFromJson):
             initialize_metadata(context, None)
 
         return context
+
+
+@implementer(ISerializeToJson)
+@adapter(IMail, Interface)
+class SerializeMailToJson(SerializeDocumentToJson):
+
+    def __call__(self, *args, **kwargs):
+        result = super(SerializeMailToJson, self).__call__(*args, **kwargs)
+        result[u'attachments'] = self.context.get_attachments()
+        return result

--- a/opengever/api/mail.py
+++ b/opengever/api/mail.py
@@ -5,6 +5,7 @@ from opengever.mail.exceptions import AlreadyExtractedError
 from opengever.mail.exceptions import InvalidAttachmentPosition
 from opengever.mail.mail import initialize_metadata
 from opengever.mail.mail import initialize_title
+from plone.app.uuid.utils import uuidToURL
 from plone.namedfile.file import NamedBlobFile
 from plone.protect.interfaces import IDisableCSRFProtection
 from plone.restapi.deserializer import json_body
@@ -57,8 +58,16 @@ class SerializeMailToJson(SerializeDocumentToJson):
 
     def __call__(self, *args, **kwargs):
         result = super(SerializeMailToJson, self).__call__(*args, **kwargs)
-        result[u'attachments'] = self.context.get_attachments()
+        result[u'attachments'] = self.get_attachments()
         return result
+
+    def get_attachments(self):
+        attachments = self.context.get_attachments()
+        for attachment in attachments:
+            if attachment.get('extracted'):
+                attachment['extracted_document_url'] = uuidToURL(
+                    attachment.get('extracted_document_uid'))
+        return attachments
 
 
 class ExtractAttachments(Service):

--- a/opengever/api/mail.py
+++ b/opengever/api/mail.py
@@ -4,11 +4,14 @@ from opengever.base.transforms.msg2mime import Msg2MimeTransform
 from opengever.mail.mail import initialize_metadata
 from opengever.mail.mail import initialize_title
 from plone.namedfile.file import NamedBlobFile
+from plone.protect.interfaces import IDisableCSRFProtection
 from plone.restapi.deserializer import json_body
 from plone.restapi.deserializer.dxcontent import DeserializeFromJson
 from plone.restapi.interfaces import IDeserializeFromJson
 from plone.restapi.interfaces import ISerializeToJson
+from plone.restapi.services import Service
 from zope.component import adapter
+from zope.interface import alsoProvides
 from zope.interface import implementer
 from zope.interface import Interface
 
@@ -53,4 +56,27 @@ class SerializeMailToJson(SerializeDocumentToJson):
     def __call__(self, *args, **kwargs):
         result = super(SerializeMailToJson, self).__call__(*args, **kwargs)
         result[u'attachments'] = self.context.get_attachments()
+        return result
+
+
+class ExtractAttachments(Service):
+
+    def reply(self):
+
+        # Disable CSRF protection, as POST requests cannot include the needed
+        # X-CSRF-TOKEN to pass plone's autoprotect.
+        alsoProvides(self.request, IDisableCSRFProtection)
+        data = json_body(self.request)
+        if 'positions' in data:
+            positions = data.get('positions')
+        else:
+            positions = [attachment['position'] for attachment in
+                         self.context.get_attachments(unextracted_only=True)]
+
+        docs = self.context.extract_attachments_into_parent(positions)
+        result = []
+        for position, doc in docs.items():
+            result.append({'position': position,
+                           'extracted_document_url': doc.absolute_url(),
+                           'extracted_document_title': doc.Title()})
         return result

--- a/opengever/api/tests/test_document.py
+++ b/opengever/api/tests/test_document.py
@@ -82,22 +82,6 @@ class TestDocumentSerializer(IntegrationTestCase):
         self.assertTrue(browser.json['is_collaborative_checkout'])
 
     @browsing
-    def test_additional_metadata_for_mails(self, browser):
-        self.login(self.regular_user, browser)
-
-        browser.open(self.mail_eml, headers={'Accept': 'application/json'})
-
-        self.assertIsNone(browser.json['checked_out'])
-        self.assertIsNone(browser.json['checked_out_fullname'])
-        self.assertFalse(browser.json['is_locked'])
-        self.assertEqual(u'Vertr\xe4ge mit der kantonalen Finanzverwaltung',
-                         browser.json['containing_dossier'])
-        self.assertIsNone(browser.json['containing_subdossier'])
-        self.assertFalse(browser.json['trashed'])
-        self.assertFalse(browser.json['is_shadow_document'])
-        self.assertFalse(0, browser.json['current_version_id'])
-
-    @browsing
     def test_respects_version_id_when_traversing_on_older_version(self, browser):
         self.login(self.regular_user, browser)
 

--- a/opengever/api/tests/test_mail.py
+++ b/opengever/api/tests/test_mail.py
@@ -17,7 +17,7 @@ class TestGetMail(IntegrationTestCase):
     def test_additional_metadata_for_mails(self, browser):
         self.login(self.regular_user, browser)
 
-        browser.open(self.mail_eml, headers={'Accept': 'application/json'})
+        browser.open(self.mail_eml, headers=self.api_headers)
 
         self.assertIsNone(browser.json['checked_out'])
         self.assertIsNone(browser.json['checked_out_fullname'])
@@ -37,8 +37,7 @@ class TestGetMail(IntegrationTestCase):
             data='__DATA__', filename=u'testmail.msg')
 
         browser.open(self.mail_eml.absolute_url(), method='GET',
-                     headers={'Accept': 'application/json',
-                              'Content-Type': 'application/json'})
+                     headers=self.api_headers)
         self.assertEqual(200, browser.status_code)
         expected_message = {
             u'content-type': u'application/vnd.ms-outlook',
@@ -58,7 +57,7 @@ class TestGetMail(IntegrationTestCase):
                           'mail_with_multiple_attachments.eml'))
         doc = mail.extract_attachment_into_parent(4)
 
-        browser.open(mail, headers={'Accept': 'application/json'})
+        browser.open(mail, headers=self.api_headers)
         expected = [
             {u'content-type': u'message/rfc822',
              u'filename': u'Inneres Testma\u0308il ohne Attachments.eml',
@@ -92,8 +91,7 @@ class TestCreateMail(IntegrationTestCase):
                      '"message": {"data": "%s", "encoding": "base64", '
                      '"filename": "testmail.msg"}}' % msg,
                 method='POST',
-                headers={'Accept': 'application/json',
-                         'Content-Type': 'application/json'})
+                headers=self.api_headers)
 
         self.assertEqual(browser.status_code, 201)
         self.assertEqual(1, len(children.get('added')))
@@ -116,8 +114,7 @@ class TestCreateMail(IntegrationTestCase):
                      '"message": {"data": "%s", "encoding": "base64", '
                      '"filename": "testmail.eml"}}' % msg,
                 method='POST',
-                headers={'Accept': 'application/json',
-                         'Content-Type': 'application/json'})
+                headers=self.api_headers)
 
         self.assertEqual(browser.status_code, 201)
         self.assertEqual(1, len(children.get('added')))
@@ -139,8 +136,7 @@ class TestCreateMail(IntegrationTestCase):
                      '"message": {"data": "%s", "encoding": "base64", '
                      '"filename": "signed.p7m"}}' % mail_file,
                 method='POST',
-                headers={'Accept': 'application/json',
-                         'Content-Type': 'application/json'})
+                headers=self.api_headers)
 
         self.assertEqual(browser.status_code, 201)
         self.assertEqual(1, len(children.get('added')))
@@ -164,8 +160,7 @@ class TestCreateMail(IntegrationTestCase):
                                              "filename": "testmail.eml"},
                                  "title": "Separate title"}),
                 method='POST',
-                headers={'Accept': 'application/json',
-                         'Content-Type': 'application/json'})
+                headers=self.api_headers)
 
         self.assertEqual(browser.status_code, 201)
         self.assertEqual(1, len(children.get('added')))
@@ -185,8 +180,7 @@ class TestPatchMail(IntegrationTestCase):
             self.mail_eml.absolute_url(),
             data=json.dumps({'title': u'New title'}),
             method='PATCH',
-            headers={'Accept': 'application/json',
-                     'Content-Type': 'application/json'})
+            headers=self.api_headers)
 
         self.assertEqual(browser.status_code, 204)
         self.assertEqual(self.mail_eml.Title(), 'New title')
@@ -199,8 +193,7 @@ class TestPatchMail(IntegrationTestCase):
             self.mail_eml.absolute_url(),
             data=json.dumps({'description': u'Lorem ipsum'}),
             method='PATCH',
-            headers={'Accept': 'application/json',
-                     'Content-Type': 'application/json'})
+            headers=self.api_headers)
 
         self.assertEqual(browser.status_code, 204)
         self.assertEqual(self.mail_eml.title, u'Die B\xfcrgschaft')

--- a/opengever/api/tests/test_mail.py
+++ b/opengever/api/tests/test_mail.py
@@ -227,7 +227,7 @@ class TestExtractAttachments(IntegrationTestCase):
             doc = uuidToObject(info['extracted_document_uid'])
             expected_response.append({
                 'position': info['position'],
-                'extracted_document_url': info['extracted_document_url'],
+                'extracted_document_url': doc.absolute_url(),
                 'extracted_document_title': doc.title})
 
         self.assertItemsEqual(expected_response, browser.json)
@@ -254,7 +254,7 @@ class TestExtractAttachments(IntegrationTestCase):
 
         expected_response = [{
             'position': info['position'],
-            'extracted_document_url': info['extracted_document_url'],
+            'extracted_document_url': doc.absolute_url(),
             'extracted_document_title': doc.title}]
         self.assertEqual(expected_response, browser.json)
 

--- a/opengever/api/tests/test_mail.py
+++ b/opengever/api/tests/test_mail.py
@@ -287,8 +287,7 @@ class TestExtractAttachments(IntegrationTestCase):
                       .with_asset_message(
                           'mail_with_multiple_attachments.eml'))
 
-        info = mail._get_attachment_info(4, write_modus=True)
-        info['extracted'] = True
+        mail._modify_attachment_info(4, extracted=True)
         with self.observe_children(self.dossier) as children:
             with browser.expect_http_error(code=400, reason='Bad Request'):
                 browser.open(

--- a/opengever/api/tests/test_move.py
+++ b/opengever/api/tests/test_move.py
@@ -1,5 +1,4 @@
 from ftw.testbrowser import browsing
-from plone.app.testing import setRoles
 from opengever.testing import IntegrationTestCase
 import json
 

--- a/opengever/journal/configure.zcml
+++ b/opengever/journal/configure.zcml
@@ -124,12 +124,6 @@
       />
 
   <subscriber
-      for="ftw.mail.mail.IMail
-           opengever.mail.interfaces.IAttachmentsDeletedEvent"
-      handler=".handlers.attachments_deleted"
-      />
-
-  <subscriber
       for="opengever.document.behaviors.IBaseDocument
            zope.lifecycleevent.interfaces.IObjectAddedEvent"
       handler=".handlers.document_added"

--- a/opengever/journal/handlers.py
+++ b/opengever/journal/handlers.py
@@ -10,7 +10,6 @@ from opengever.base.oguid import Oguid
 from opengever.document.document import IDocumentSchema
 from opengever.dossier.browser.participants import role_list_helper
 from opengever.journal import _
-from opengever.mail.interfaces import IAttachmentsDeletedEvent
 from opengever.repository.repositoryroot import IRepositoryRoot
 from opengever.sharing.behaviors import IStandard
 from opengever.sharing.browser.sharing import ROLE_MAPPING
@@ -299,21 +298,6 @@ def doc_properties_updated(context):
                                   default=u'DocProperties updated.'))
 
 
-# ----------------------- MAIL -----------------------
-ATTACHMENTS_DELETED_ACTION = 'Attachments deleted'
-
-
-def attachments_deleted(context, event):
-    attachment_names = event.attachments
-    title = _(
-        u'label_attachments_deleted',
-        default=u'Attachments deleted: ${filenames}',
-        mapping={'filenames': ', '.join(attachment_names)})
-
-    journal_entry_factory(context, ATTACHMENTS_DELETED_ACTION, title)
-    return
-
-
 # ----------------------- DOCUMENT -----------------------
 DOCUMENT_ADDED_ACTION = 'Document added'
 
@@ -342,12 +326,6 @@ PUBLIC_TRIAL_MODIFIED_ACTION = 'Public trial modified'
 
 
 def document_modified(context, event):
-
-    if IAttachmentsDeletedEvent.providedBy(event):
-        # AttachmentsDeleted is a special kind of ObjectModified event
-        # and is handled elsewhere - don't journalize it twice.
-        return
-
     # we need to distinguish between "metadata modified"
     # and "public_trial modified"
     metadata_changed = False

--- a/opengever/mail/browser/extract_attachments.py
+++ b/opengever/mail/browser/extract_attachments.py
@@ -149,7 +149,7 @@ class ExtractAttachments(BrowserView):
 
     def extract_attachments(self, positions):
         docs = self.context.extract_attachments_into_parent(positions)
-        for document in docs:
+        for document in docs.values():
             msg = _(u'info_extracted_document',
                     default=u'Created document ${title}',
                     mapping={'title': document.Title().decode('utf-8')})

--- a/opengever/mail/browser/extract_attachments.py
+++ b/opengever/mail/browser/extract_attachments.py
@@ -73,6 +73,12 @@ def human_readable_filesize_helper(context):
     return _helper
 
 
+def extracted_helper(item, extracted):
+    if extracted:
+        return _(u'label_yes', default=u'Yes')
+    return _(u'label_no', default=u'No')
+
+
 class ExtractAttachments(BrowserView):
     """View for extracting attachments from a `ftw.mail` Mail object into
     `opengever.document` Documents in a `IMailInAddressMarker` container.
@@ -86,6 +92,11 @@ class ExtractAttachments(BrowserView):
             {'column': '',
              'transform': attachment_checkbox_helper,
              'width': 30},
+
+            {'column': 'extracted',
+             'column_title': _(u'column_already_extracted',
+                               default=u'Already extracted'),
+             'transform': extracted_helper},
 
             {'column': 'content-type',
              'column_title': _(u'column_attachment_type',

--- a/opengever/mail/browser/extract_attachments.py
+++ b/opengever/mail/browser/extract_attachments.py
@@ -16,8 +16,12 @@ def attachment_checkbox_helper(item, value):
              'id': 'attachment%s' % str(item['position']),
              'value': str(item['position'])}
 
-    return '<input %s />' % ' '.join(['%s="%s"' % (k, v)
-                                      for k, v in attrs.items()])
+    if item.get("extracted"):
+        tag = '<span %s />'
+    else:
+        tag = '<input %s />'
+
+    return tag % ' '.join(['%s="%s"' % (k, v) for k, v in attrs.items()])
 
 
 def content_type_helper(item, content_type):

--- a/opengever/mail/browser/templates/extract_attachments.pt
+++ b/opengever/mail/browser/templates/extract_attachments.pt
@@ -61,47 +61,6 @@
               <table tal:replace="structure view/render_attachment_table" />
             </div>
 
-
-            <div class="field" tal:condition="view/is_delete_attachment_supported">
-              <label i18n:translate="label_delete_action"
-                     class="horizontal">
-                Delete attachments
-              </label>
-
-              <div class="formHelp" i18n:translate="help_delete_action">
-                Select which attachments should be deleted.
-              </div>
-
-              <div>
-                <input type="radio" id="delete_action_nothing"
-                       name="delete_action" value="nothing"
-                       checked="cheked" />
-                <label for="delete_action_nothing"
-                       i18n:translate="label_delete_action_nothing">
-                  Delete nothing
-                </label>
-              </div>
-
-              <div>
-                <input type="radio" id="delete_action_all"
-                       name="delete_action" value="all" />
-                <label for="delete_action_all"
-                       i18n:translate="label_delete_action_all">
-                  Delete all attachments
-                </label>
-              </div>
-
-              <div>
-                <input type="radio" id="delete_action_selected"
-                       name="delete_action" value="selected" />
-                <label for="delete_action_selected"
-                       i18n:translate="label_delete_action_selected">
-                  Delete all selected attachments
-                </label>
-              </div>
-
-            </div>
-
             <div class="formControls">
               <input type="submit" name="form.submitted"
                      value="Save attachments"

--- a/opengever/mail/configure.zcml
+++ b/opengever/mail/configure.zcml
@@ -90,4 +90,11 @@
            zope.lifecycleevent.interfaces.IObjectModifiedEvent"
       handler=".subscribers.resolve_mail_author"
       />
+
+  <subscriber
+      for="opengever.mail.interfaces.IExtractedFromMail
+           zope.lifecycleevent.IObjectMovedEvent"
+      handler=".subscribers.extracted_attachment_moved"
+      />
+
 </configure>

--- a/opengever/mail/configure.zcml
+++ b/opengever/mail/configure.zcml
@@ -97,4 +97,10 @@
       handler=".subscribers.extracted_attachment_moved"
       />
 
+  <subscriber
+      for="opengever.mail.interfaces.IExtractedFromMail
+           zope.lifecycleevent.IObjectRemovedEvent"
+      handler=".subscribers.extracted_attachment_deleted"
+      />
+
 </configure>

--- a/opengever/mail/configure.zcml
+++ b/opengever/mail/configure.zcml
@@ -103,4 +103,10 @@
       handler=".subscribers.extracted_attachment_deleted"
       />
 
+  <subscriber
+      for="opengever.mail.mail.IOGMailMarker
+           zope.lifecycleevent.IObjectRemovedEvent"
+      handler=".subscribers.mail_deleted"
+      />
+
 </configure>

--- a/opengever/mail/configure.zcml
+++ b/opengever/mail/configure.zcml
@@ -93,12 +93,6 @@
 
   <subscriber
       for="opengever.mail.interfaces.IExtractedFromMail
-           zope.lifecycleevent.IObjectMovedEvent"
-      handler=".subscribers.extracted_attachment_moved"
-      />
-
-  <subscriber
-      for="opengever.mail.interfaces.IExtractedFromMail
            zope.lifecycleevent.IObjectRemovedEvent"
       handler=".subscribers.extracted_attachment_deleted"
       />

--- a/opengever/mail/events.py
+++ b/opengever/mail/events.py
@@ -8,13 +8,11 @@ from zope.lifecycleevent import ObjectModifiedEvent
 
 
 class DocumentSent(ObjectEvent):
-    """Local Roles has been modified"""
+    """Document has been sent"""
 
     implements(IDocumentSent)
 
-    def __init__(
-        self, object, sender, receiver, subject, message, attachments):
-        """adf"""
+    def __init__(self, object, sender, receiver, subject, message, attachments):
         self.object = object
         self.sender = sender
         self.receiver = receiver.encode('utf-8')

--- a/opengever/mail/events.py
+++ b/opengever/mail/events.py
@@ -1,10 +1,8 @@
-from opengever.mail.interfaces import IAttachmentsDeletedEvent
 from opengever.mail.interfaces import IDocumentSent
 from zope.component import getUtility
 from zope.component.interfaces import ObjectEvent
 from zope.interface import implements
 from zope.intid.interfaces import IIntIds
-from zope.lifecycleevent import ObjectModifiedEvent
 
 
 class DocumentSent(ObjectEvent):
@@ -23,17 +21,3 @@ class DocumentSent(ObjectEvent):
         for attachment in attachments:
             intids.append(id_util.queryId(attachment))
         self.intids = intids
-
-
-class AttachmentsDeleted(ObjectModifiedEvent):
-    """One or more attachments have been deleted from a ftw.mail.mail message.
-    """
-
-    implements(IAttachmentsDeletedEvent)
-
-    def __init__(self, object, attachments, *descriptions):
-
-        super(AttachmentsDeleted, self).__init__(object, *descriptions)
-
-        # List of filenames (unicode) of attachments that have been deleted
-        self.attachments = attachments

--- a/opengever/mail/exceptions.py
+++ b/opengever/mail/exceptions.py
@@ -8,3 +8,9 @@ class AlreadyExtractedError(Exception):
         super(AlreadyExtractedError, self).__init__(self.message.format(
             info.get('position'), info.get('extracted_document_url')))
         self.info = info
+
+
+class SourceMailNotFound(Exception):
+    """Raised when a document extracted from a Mail is modified and its
+    info cannot be updated in the Mail from which it was extracted because
+    it could not be found"""

--- a/opengever/mail/exceptions.py
+++ b/opengever/mail/exceptions.py
@@ -10,6 +10,16 @@ class AlreadyExtractedError(Exception):
         self.info = info
 
 
+class InvalidAttachmentPosition(Exception):
+    """No attachement found at the given position.
+    """
+    message = "No attachment found at position {}."
+
+    def __init__(self, position):
+        super(InvalidAttachmentPosition, self).__init__(self.message.format(
+            position))
+
+
 class SourceMailNotFound(Exception):
     """Raised when a document extracted from a Mail is modified and its
     info cannot be updated in the Mail from which it was extracted because

--- a/opengever/mail/exceptions.py
+++ b/opengever/mail/exceptions.py
@@ -1,0 +1,10 @@
+
+class AlreadyExtractedError(Exception):
+    """Attachment already extracted from Mail.
+    """
+    message = "Attachment at position {} has already been extracted to {}."
+
+    def __init__(self, info):
+        super(AlreadyExtractedError, self).__init__(self.message.format(
+            info.get('position'), info.get('extracted_document_url')))
+        self.info = info

--- a/opengever/mail/interfaces.py
+++ b/opengever/mail/interfaces.py
@@ -22,7 +22,7 @@ class ISendDocumentConf(Interface):
 
 
 class IDocumentSent(IObjectEvent):
-    """Local Roles has been modified"""
+    """Document has been sent"""
 
     sender = Attribute("The Mailsender")
     receiver = Attribute("The Mailreceiver")

--- a/opengever/mail/interfaces.py
+++ b/opengever/mail/interfaces.py
@@ -36,3 +36,7 @@ class IMailTabbedviewSettings(Interface):
         title=u'Is the preview tab in the mail tabbedview visible',
         default=True,
     )
+
+
+class IExtractedFromMail(Interface):
+    """Used to mark documents extracted from a Mail"""

--- a/opengever/mail/interfaces.py
+++ b/opengever/mail/interfaces.py
@@ -1,7 +1,6 @@
 from zope import schema
 from zope.component.interfaces import IObjectEvent
 from zope.interface import Interface, Attribute
-from zope.lifecycleevent.interfaces import IObjectModifiedEvent
 
 
 DEFAULT_MAIL_MAX_SIZE = 5
@@ -29,13 +28,6 @@ class IDocumentSent(IObjectEvent):
     subject = Attribute("The Mailsubject")
     message = Attribute("The Message")
     attachments = Attribute("The Attachments")
-
-
-class IAttachmentsDeletedEvent(IObjectModifiedEvent):
-    """One or more attachments have been deleted from a ftw.mail.mail message.
-    """
-
-    attachments = Attribute("List of attachments that have been removed")
 
 
 class IMailTabbedviewSettings(Interface):

--- a/opengever/mail/locales/de/LC_MESSAGES/opengever.mail.po
+++ b/opengever/mail/locales/de/LC_MESSAGES/opengever.mail.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-08-14 16:05+0000\n"
+"POT-Creation-Date: 2020-05-26 15:45+0000\n"
 "PO-Revision-Date: 2016-07-22 16:52+0000\n"
 "Last-Translator: Philippe Gross <gross.philippe@gmail.com>\n"
 "Language-Team: German <https://translations.onegovgever.ch/projects/onegov-gever/opengever-mail/de/>\n"
@@ -50,6 +50,11 @@ msgstr "Senden"
 msgid "cancel_back"
 msgstr "Abbrechen"
 
+#. Default: "Already extracted"
+#: ./opengever/mail/browser/extract_attachments.py
+msgid "column_already_extracted"
+msgstr "Schon gespeichert"
+
 #. Default: "Filename"
 #: ./opengever/mail/browser/extract_attachments.py
 msgid "column_attachment_filename"
@@ -95,11 +100,6 @@ msgstr "Dokumente als E-Mail versenden"
 msgid "help_attachments_to_save"
 msgstr "Wählen Sie die Anhänge aus, die gespeichert werden sollen. Aus jedem ausgewähltem Anhang wird ein Dokument im übergeordneten Dossier erzeugt."
 
-#. Default: "Select which attachments should be deleted."
-#: ./opengever/mail/browser/templates/extract_attachments.pt
-msgid "help_delete_action"
-msgstr "Wählen Sie aus, ob und welche Anhänge aus dieser E-Mail gelöscht werden sollen."
-
 #. Default: "email addresses of the receivers. Enter manually the addresses, one per each line."
 #: ./opengever/mail/browser/send_document.py
 msgid "help_extern_receiver"
@@ -129,26 +129,6 @@ msgstr "Interne Empfänger"
 #: ./opengever/mail/browser/templates/extract_attachments.pt
 msgid "label_attachments_to_save"
 msgstr "Zu speichernde Anhänge"
-
-#. Default: "Delete attachments"
-#: ./opengever/mail/browser/templates/extract_attachments.pt
-msgid "label_delete_action"
-msgstr "Anhänge löschen"
-
-#. Default: "Delete all attachments"
-#: ./opengever/mail/browser/templates/extract_attachments.pt
-msgid "label_delete_action_all"
-msgstr "Alle Anhänge in dieser E-Mail löschen"
-
-#. Default: "Delete nothing"
-#: ./opengever/mail/browser/templates/extract_attachments.pt
-msgid "label_delete_action_nothing"
-msgstr "Keine Anhänge löschen"
-
-#. Default: "Delete all selected attachments"
-#: ./opengever/mail/browser/templates/extract_attachments.pt
-msgid "label_delete_action_selected"
-msgstr "Alle oben ausgewählten Anhänge aus dieser E-Mail löschen"
 
 #. Default: "Attachments"
 #: ./opengever/mail/browser/mail.py
@@ -202,6 +182,11 @@ msgstr "Drag & Drop Upload"
 msgid "label_message_source_mailin"
 msgstr "Mail-In"
 
+#. Default: "No"
+#: ./opengever/mail/browser/extract_attachments.py
+msgid "label_no"
+msgstr "Nein"
+
 #. Default: "Message"
 #: ./opengever/mail/browser/mail.py
 msgid "label_org_message"
@@ -241,6 +226,11 @@ msgstr "Info"
 #: ./opengever/mail/browser/send_document.py
 msgid "label_subject"
 msgstr "Betreff"
+
+#. Default: "Yes"
+#: ./opengever/mail/browser/extract_attachments.py
+msgid "label_yes"
+msgstr "Ja"
 
 #: ./opengever/mail/browser/send_document.py
 msgid "mails"

--- a/opengever/mail/locales/fr/LC_MESSAGES/opengever.mail.po
+++ b/opengever/mail/locales/fr/LC_MESSAGES/opengever.mail.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-08-14 16:05+0000\n"
+"POT-Creation-Date: 2020-05-26 15:45+0000\n"
 "PO-Revision-Date: 2017-09-04 06:15+0000\n"
 "Last-Translator: Philippe Gross <gross.philippe@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-mail/fr/>\n"
@@ -50,6 +50,11 @@ msgstr "Envoyer"
 msgid "cancel_back"
 msgstr "Annuler"
 
+#. Default: "Already extracted"
+#: ./opengever/mail/browser/extract_attachments.py
+msgid "column_already_extracted"
+msgstr "Déjà sauvegardé"
+
 #. Default: "Filename"
 #: ./opengever/mail/browser/extract_attachments.py
 msgid "column_attachment_filename"
@@ -95,11 +100,6 @@ msgstr "Envoyer les documents par e-mail"
 msgid "help_attachments_to_save"
 msgstr "Sélectionner les pièces jointes à extraire. De chaque pièce jointe sélectionnée un document sera créé dans le dossier maître."
 
-#. Default: "Select which attachments should be deleted."
-#: ./opengever/mail/browser/templates/extract_attachments.pt
-msgid "help_delete_action"
-msgstr "Sélectionnez les pièces jointes à effacer."
-
 #. Default: "email addresses of the receivers. Enter manually the addresses, one per each line."
 #: ./opengever/mail/browser/send_document.py
 msgid "help_extern_receiver"
@@ -129,26 +129,6 @@ msgstr "Destinataires internes"
 #: ./opengever/mail/browser/templates/extract_attachments.pt
 msgid "label_attachments_to_save"
 msgstr "Fichiers attachés"
-
-#. Default: "Delete attachments"
-#: ./opengever/mail/browser/templates/extract_attachments.pt
-msgid "label_delete_action"
-msgstr "Effacer les fichiers attachés"
-
-#. Default: "Delete all attachments"
-#: ./opengever/mail/browser/templates/extract_attachments.pt
-msgid "label_delete_action_all"
-msgstr "Effacer tous les fichiers attachés à cet e-mail"
-
-#. Default: "Delete nothing"
-#: ./opengever/mail/browser/templates/extract_attachments.pt
-msgid "label_delete_action_nothing"
-msgstr "N'effacer aucun fichier attaché"
-
-#. Default: "Delete all selected attachments"
-#: ./opengever/mail/browser/templates/extract_attachments.pt
-msgid "label_delete_action_selected"
-msgstr "Effacer tous les fichiers attachés séléctionnés"
 
 #. Default: "Attachments"
 #: ./opengever/mail/browser/mail.py
@@ -202,6 +182,11 @@ msgstr "Téléchargement drag & drop"
 msgid "label_message_source_mailin"
 msgstr "Mail-In"
 
+#. Default: "No"
+#: ./opengever/mail/browser/extract_attachments.py
+msgid "label_no"
+msgstr "Non"
+
 #. Default: "Message"
 #: ./opengever/mail/browser/mail.py
 msgid "label_org_message"
@@ -241,6 +226,11 @@ msgstr "Info"
 #: ./opengever/mail/browser/send_document.py
 msgid "label_subject"
 msgstr "Objet"
+
+#. Default: "Yes"
+#: ./opengever/mail/browser/extract_attachments.py
+msgid "label_yes"
+msgstr "Oui"
 
 #: ./opengever/mail/browser/send_document.py
 msgid "mails"

--- a/opengever/mail/locales/opengever.mail.pot
+++ b/opengever/mail/locales/opengever.mail.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-08-14 16:05+0000\n"
+"POT-Creation-Date: 2020-05-26 15:45+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -49,6 +49,11 @@ msgstr ""
 #. Default: "Cancel"
 #: ./opengever/mail/browser/send_document.py
 msgid "cancel_back"
+msgstr ""
+
+#. Default: "Already extracted"
+#: ./opengever/mail/browser/extract_attachments.py
+msgid "column_already_extracted"
 msgstr ""
 
 #. Default: "Filename"
@@ -96,11 +101,6 @@ msgstr ""
 msgid "help_attachments_to_save"
 msgstr ""
 
-#. Default: "Select which attachments should be deleted."
-#: ./opengever/mail/browser/templates/extract_attachments.pt
-msgid "help_delete_action"
-msgstr ""
-
 #. Default: "email addresses of the receivers. Enter manually the addresses, one per each line."
 #: ./opengever/mail/browser/send_document.py
 msgid "help_extern_receiver"
@@ -129,26 +129,6 @@ msgstr ""
 #. Default: "Attachments to save"
 #: ./opengever/mail/browser/templates/extract_attachments.pt
 msgid "label_attachments_to_save"
-msgstr ""
-
-#. Default: "Delete attachments"
-#: ./opengever/mail/browser/templates/extract_attachments.pt
-msgid "label_delete_action"
-msgstr ""
-
-#. Default: "Delete all attachments"
-#: ./opengever/mail/browser/templates/extract_attachments.pt
-msgid "label_delete_action_all"
-msgstr ""
-
-#. Default: "Delete nothing"
-#: ./opengever/mail/browser/templates/extract_attachments.pt
-msgid "label_delete_action_nothing"
-msgstr ""
-
-#. Default: "Delete all selected attachments"
-#: ./opengever/mail/browser/templates/extract_attachments.pt
-msgid "label_delete_action_selected"
 msgstr ""
 
 #. Default: "Attachments"
@@ -203,6 +183,11 @@ msgstr ""
 msgid "label_message_source_mailin"
 msgstr ""
 
+#. Default: "No"
+#: ./opengever/mail/browser/extract_attachments.py
+msgid "label_no"
+msgstr ""
+
 #. Default: "Message"
 #: ./opengever/mail/browser/mail.py
 msgid "label_org_message"
@@ -241,6 +226,11 @@ msgstr ""
 #. Default: "Subject"
 #: ./opengever/mail/browser/send_document.py
 msgid "label_subject"
+msgstr ""
+
+#. Default: "Yes"
+#: ./opengever/mail/browser/extract_attachments.py
+msgid "label_yes"
 msgstr ""
 
 #: ./opengever/mail/browser/send_document.py

--- a/opengever/mail/mail.py
+++ b/opengever/mail/mail.py
@@ -240,7 +240,6 @@ class OGMail(Mail, BaseDocumentMixin):
 
         # mark attachment as extracted
         info['extracted'] = True
-        info['extracted_document_url'] = doc.absolute_url()
         info['extracted_document_uid'] = IUUID(doc)
 
         return doc

--- a/opengever/mail/mail.py
+++ b/opengever/mail/mail.py
@@ -17,6 +17,7 @@ from opengever.document.behaviors.related_docs import IRelatedDocuments
 from opengever.dossier import _ as dossier_mf
 from opengever.mail import _
 from opengever.mail.exceptions import AlreadyExtractedError
+from opengever.mail.interfaces import IExtractedFromMail
 from opengever.ogds.models.user import User
 from plone.app.dexterity.behaviors import metadata
 from plone.autoform import directives as form
@@ -230,6 +231,7 @@ class OGMail(Mail, BaseDocumentMixin):
             iid = intids.getId(self)
 
             IRelatedDocuments(doc).relatedItems = [RelationValue(iid)]
+            alsoProvides(doc, IExtractedFromMail)
             doc.reindexObject()
 
         # mark attachment as extracted

--- a/opengever/mail/mail.py
+++ b/opengever/mail/mail.py
@@ -17,6 +17,7 @@ from opengever.document.behaviors.related_docs import IRelatedDocuments
 from opengever.dossier import _ as dossier_mf
 from opengever.mail import _
 from opengever.mail.exceptions import AlreadyExtractedError
+from opengever.mail.exceptions import InvalidAttachmentPosition
 from opengever.mail.interfaces import IExtractedFromMail
 from opengever.ogds.models.user import User
 from plone.app.dexterity.behaviors import metadata
@@ -201,6 +202,9 @@ class OGMail(Mail, BaseDocumentMixin):
         `get_attachments`.
         """
         info = self._get_attachment_info(position, write_modus=True)
+        if info is None:
+            raise InvalidAttachmentPosition(position)
+
         if info.get('extracted'):
             raise AlreadyExtractedError(info)
 

--- a/opengever/mail/mail.py
+++ b/opengever/mail/mail.py
@@ -185,9 +185,9 @@ class OGMail(Mail, BaseDocumentMixin):
         can be obtained from the attachment description returned by
         `get_attachments`.
         """
-        docs = []
+        docs = {}
         for position in positions:
-            docs.append(self.extract_attachment_into_parent(position))
+            docs[position] = self.extract_attachment_into_parent(position)
         return docs
 
     def extract_attachment_into_parent(self, position):

--- a/opengever/mail/subscribers.py
+++ b/opengever/mail/subscribers.py
@@ -22,7 +22,7 @@ def resolve_mail_author(mail, event):
     resolve_document_author(mail, event)
 
 
-def find_corresponding_mail_info_in_write_modus(doc):
+def extracted_attachment_deleted(doc, event):
     uid = IUUID(doc)
     for related_item in IRelatedDocuments(doc).relatedItems:
         related_obj = related_item.to_object
@@ -31,16 +31,12 @@ def find_corresponding_mail_info_in_write_modus(doc):
 
         for info in related_obj.get_attachments():
             if info.get("extracted_document_uid") == uid:
-                write_info = related_obj._get_attachment_info(
-                    info.get("position"), write_modus=True)
-                return write_info
+                related_obj._modify_attachment_info(
+                     info.get("position"),
+                     extracted=False,
+                     extracted_document_uid=None)
+                return
     raise SourceMailNotFound("Source Mail not found when Extracted attachment moved.")
-
-
-def extracted_attachment_deleted(doc, event):
-    write_info = find_corresponding_mail_info_in_write_modus(doc)
-    write_info.pop('extracted')
-    write_info.pop('extracted_document_uid')
 
 
 def mail_deleted(doc, event):

--- a/opengever/mail/subscribers.py
+++ b/opengever/mail/subscribers.py
@@ -1,4 +1,10 @@
+from opengever.document.behaviors.related_docs import IRelatedDocuments
 from opengever.document.subscribers import resolve_document_author
+from opengever.mail.exceptions import SourceMailNotFound
+from opengever.mail.mail import IOGMailMarker
+from plone.uuid.interfaces import IUUID
+from zope.lifecycleevent.interfaces import IObjectAddedEvent
+from zope.lifecycleevent.interfaces import IObjectRemovedEvent
 
 
 def set_digitally_available(mail, event):
@@ -13,3 +19,35 @@ def resolve_mail_author(mail, event):
     be mapped to user fullname. This is not fired upon mail creation,
     as the author is taken from the sender E-mail address in that case."""
     resolve_document_author(mail, event)
+
+
+def find_corresponding_mail_info_in_write_modus(doc):
+    uid = IUUID(doc)
+    for related_item in IRelatedDocuments(doc).relatedItems:
+        related_obj = related_item.to_object
+        if not IOGMailMarker.providedBy(related_obj):
+            continue
+
+        for info in related_obj.get_attachments():
+            if info.get("extracted_document_uid") == uid:
+                write_info = related_obj._get_attachment_info(
+                    info.get("position"), write_modus=True)
+                return write_info
+    raise SourceMailNotFound("Source Mail not found when Extracted attachment moved.")
+
+
+def extracted_attachment_moved(doc, event):
+    """Mails keep track of their attachments extracted to documents.
+    When such a document is moved, the corresponding information has to
+    be updated on the Mail."""
+
+    # Since IObjectAddedEvent and IObjectRemovedEvent subclasses
+    # IObjectMovedEvent this event handler is also called for
+    # IObjectAddedEvent and IObjectRemovedEvent but we should not
+    # do anything in these cases.
+    if IObjectAddedEvent.providedBy(event) or IObjectRemovedEvent.providedBy(event):
+        return
+
+    write_info = find_corresponding_mail_info_in_write_modus(doc)
+    write_info["extracted_document_url"] = doc.absolute_url()
+

--- a/opengever/mail/subscribers.py
+++ b/opengever/mail/subscribers.py
@@ -51,3 +51,9 @@ def extracted_attachment_moved(doc, event):
     write_info = find_corresponding_mail_info_in_write_modus(doc)
     write_info["extracted_document_url"] = doc.absolute_url()
 
+
+def extracted_attachment_deleted(doc, event):
+    write_info = find_corresponding_mail_info_in_write_modus(doc)
+    write_info.pop('extracted')
+    write_info.pop('extracted_document_url')
+    write_info.pop('extracted_document_uid')

--- a/opengever/mail/subscribers.py
+++ b/opengever/mail/subscribers.py
@@ -6,8 +6,6 @@ from opengever.mail.mail import IOGMailMarker
 from plone.app.uuid.utils import uuidToObject
 from plone.uuid.interfaces import IUUID
 from zope.interface import noLongerProvides
-from zope.lifecycleevent.interfaces import IObjectAddedEvent
-from zope.lifecycleevent.interfaces import IObjectRemovedEvent
 
 
 def set_digitally_available(mail, event):
@@ -39,26 +37,9 @@ def find_corresponding_mail_info_in_write_modus(doc):
     raise SourceMailNotFound("Source Mail not found when Extracted attachment moved.")
 
 
-def extracted_attachment_moved(doc, event):
-    """Mails keep track of their attachments extracted to documents.
-    When such a document is moved, the corresponding information has to
-    be updated on the Mail."""
-
-    # Since IObjectAddedEvent and IObjectRemovedEvent subclasses
-    # IObjectMovedEvent this event handler is also called for
-    # IObjectAddedEvent and IObjectRemovedEvent but we should not
-    # do anything in these cases.
-    if IObjectAddedEvent.providedBy(event) or IObjectRemovedEvent.providedBy(event):
-        return
-
-    write_info = find_corresponding_mail_info_in_write_modus(doc)
-    write_info["extracted_document_url"] = doc.absolute_url()
-
-
 def extracted_attachment_deleted(doc, event):
     write_info = find_corresponding_mail_info_in_write_modus(doc)
     write_info.pop('extracted')
-    write_info.pop('extracted_document_url')
     write_info.pop('extracted_document_uid')
 
 

--- a/opengever/mail/tests/test_extract_attachments.py
+++ b/opengever/mail/tests/test_extract_attachments.py
@@ -1,18 +1,12 @@
 from datetime import date
 from ftw.builder import Builder
 from ftw.builder import create
-from ftw.bumblebee.interfaces import IBumblebeeDocument
-from ftw.journal.config import JOURNAL_ENTRIES_ANNOTATIONS_KEY
-from ftw.mail.utils import get_attachments
 from ftw.testbrowser import browsing
 from ftw.testbrowser.pages import statusmessages
 from opengever.mail.browser.extract_attachments import content_type_helper
 from opengever.testing import FunctionalTestCase
 from opengever.testing import obj2brain
 from pkg_resources import resource_string
-from plone.app.testing import TEST_USER_ID
-from zope.annotation import IAnnotations
-from zope.i18n import translate
 
 
 MESSAGE_TEXT = 'Mime-Version: 1.0\nContent-Type: multipart/mixed; boundary=908752978\nTo: to@example.org\nFrom: from@example.org\nSubject: Attachment Test\nDate: Thu, 01 Jan 1970 01:00:00 +0100\nMessage-Id: <1>\n\n\n--908752978\nContent-Disposition: attachment;\n	filename*=iso-8859-1\'\'B%FCcher.txt\nContent-Type: text/plain;\n	name="=?iso-8859-1?Q?B=FCcher.txt?="\nContent-Transfer-Encoding: base64\n\nw6TDtsOcCg==\n\n--908752978--\n'
@@ -21,9 +15,6 @@ MAIL_DATA_WRONG_MIMETYPE = resource_string(
 
 
 class TestExtractAttachmentView(FunctionalTestCase):
-
-    def get_delete_options(self, browser):
-        return browser.css('[name=delete_action] + label').text
 
     def setUp(self):
         super(TestExtractAttachmentView, self).setUp()
@@ -77,44 +68,6 @@ class TestExtractAttachmentView(FunctionalTestCase):
         self.assertEquals(obj2brain(doc).document_date, date.today())
 
     @browsing
-    def test_deleting_after_extracting(self, browser):
-        browser.login().open(self.mail, view='extract_attachments')
-        browser.fill({'attachments:list': ['1'],
-                      'delete_action': ['all']}).submit()
-
-        self.assertEquals(
-            len(get_attachments(self.mail.msg)), 0,
-            'The attachment deleting after extracting, \
-            does not work correctly.')
-
-    @browsing
-    def test_deleting_after_extracting_updates_checksum(self, browser):
-        browser.login().open(self.mail, view='extract_attachments')
-        old_checksum = IBumblebeeDocument(self.mail).get_checksum()
-        browser.fill({'attachments:list': ['1'],
-                      'delete_action': ['all']}).submit()
-        new_checksum = IBumblebeeDocument(self.mail).get_checksum()
-        self.assertNotEqual(old_checksum, new_checksum)
-
-    @browsing
-    def test_journal_entry_after_deleting_attachments(self, browser):
-        browser.login().open(self.mail, view='extract_attachments')
-        browser.fill({'attachments:list': ['1'],
-                      'delete_action': ['all']}).submit()
-
-        annotations = IAnnotations(self.mail)
-        journal = annotations.get(JOURNAL_ENTRIES_ANNOTATIONS_KEY, {})
-        last_entry = journal[-1]
-
-        self.assertEquals(TEST_USER_ID, last_entry['actor'])
-        self.assertDictContainsSubset(
-            {'type': 'Attachments deleted',
-             'title': u'label_attachments_deleted'},
-            last_entry['action'])
-        self.assertEquals(u'Attachments deleted: B\xfccher.txt',
-                          translate(last_entry['action']['title']))
-
-    @browsing
     def test_extract_attachment_without_docs_shows_warning_message(self, browser):
         mail = create(Builder('mail').within(self.dossier))
         browser.login().open(mail, view='extract_attachments')
@@ -129,51 +82,6 @@ class TestExtractAttachmentView(FunctionalTestCase):
         browser.css('.formControls input.standalone').first.click()
 
         self.assertEquals(self.mail.absolute_url(), browser.url)
-
-    @browsing
-    def test_delete_options_rendered_for_mails(self, browser):
-        browser.login().open(self.mail, view='extract_attachments')
-
-        self.assertEqual(
-            ['Delete nothing',
-             'Delete all attachments',
-             'Delete all selected attachments'],
-            self.get_delete_options(browser)
-        )
-
-    @browsing
-    def test_delete_options_unavailable_for_signed_mails(self, browser):
-        mail_p7m = create(
-            Builder('mail')
-            .with_asset_message('signed.p7m')
-            .within(self.dossier)
-        )
-        browser.login().open(mail_p7m, view='extract_attachments')
-        self.assertEqual([], self.get_delete_options(browser))
-
-
-class TestExtractAttachmentViewForMailWithOriginalMessage(FunctionalTestCase):
-
-    def setUp(self):
-        super(TestExtractAttachmentViewForMailWithOriginalMessage, self).setUp()
-        self.dossier = create(Builder('dossier'))
-        self.mail = create(Builder('mail')
-                           .within(self.dossier)
-                           .with_message(MESSAGE_TEXT)
-                           .with_dummy_original_message())
-
-    @browsing
-    def test_deleting_after_extracting_does_not_update_checksum(self, browser):
-        """ We use the original message for preview but deleting the attachments
-        after extraction modifies the message and not the original_message, hence
-        the checksum nor the preview will be modified.
-        """
-        browser.login().open(self.mail, view='extract_attachments')
-        old_checksum = IBumblebeeDocument(self.mail).get_checksum()
-        browser.fill({'attachments:list': ['1'],
-                      'delete_action': ['all']}).submit()
-        new_checksum = IBumblebeeDocument(self.mail).get_checksum()
-        self.assertEqual(old_checksum, new_checksum)
 
 
 class TestContentTypeHelper(FunctionalTestCase):

--- a/opengever/mail/tests/test_mail.py
+++ b/opengever/mail/tests/test_mail.py
@@ -1,5 +1,3 @@
-from ftw.builder import Builder
-from ftw.builder import create
 from ftw.testbrowser import browsing
 from opengever.document.behaviors.metadata import IDocumentMetadata
 from opengever.testing import IntegrationTestCase
@@ -26,18 +24,3 @@ class TestMail(IntegrationTestCase):
         keywords = browser.find_field_by_text(u'Keywords')
         self.assertItemsEqual(('New Item 2', 'NewItem1', 'N=C3=B6i 3'),
                               tuple(keywords.value))
-
-    def test_eml_supports_deleting_attachments(self):
-        self.login(self.regular_user)
-        self.assertTrue(self.mail_eml.is_delete_attachment_supported())
-
-    def test_p7m_does_not_support_deleting_attachments(self):
-        self.login(self.regular_user)
-
-        mail_p7m = create(
-            Builder("mail")
-            .with_asset_message('signed.p7m')
-            .within(self.dossier)
-            )
-
-        self.assertFalse(mail_p7m.is_delete_attachment_supported())

--- a/opengever/mail/tests/test_ogmail.py
+++ b/opengever/mail/tests/test_ogmail.py
@@ -238,7 +238,7 @@ class TestExtractMailInDossier(FunctionalTestCase):
         positions = [attachment['position'] for attachment in
                      mail.get_attachments()]
 
-        extracted = mail.extract_attachments_into_parent(positions)
+        extracted = mail.extract_attachments_into_parent(positions).values()
         self.assertEqual(6, len(extracted))
 
         outer_mail = extracted[0]
@@ -258,7 +258,7 @@ class TestExtractMailInDossier(FunctionalTestCase):
         positions = [attachment['position'] for attachment in
                      mail.get_attachments()]
 
-        extracted = mail.extract_attachments_into_parent(positions)
+        extracted = mail.extract_attachments_into_parent(positions).values()
         self.assertEqual(3, len(extracted))
         extracted_mail = extracted[0]
         doc = extracted[1]

--- a/opengever/mail/tests/test_ogmail.py
+++ b/opengever/mail/tests/test_ogmail.py
@@ -190,7 +190,6 @@ class TestExtractMail(FunctionalTestCase):
         info = self.mail._get_attachment_info(4)
         expected_info.update({
             'extracted': True,
-            'extracted_document_url': doc.absolute_url(),
             'extracted_document_uid': IUUID(doc)})
         self.assertEqual(info, expected_info)
 

--- a/opengever/mail/tests/test_ogmail.py
+++ b/opengever/mail/tests/test_ogmail.py
@@ -152,25 +152,6 @@ class TestOGMailAddition(FunctionalTestCase):
                       .with_message(MAIL_DATA))
         self.assertFalse(mail.has_attachments())
 
-    def test_delete_all_attachments(self):
-        mail = create(Builder('mail')
-                      .within(self.dossier)
-                      .with_asset_message(
-                          'mail_with_multiple_attachments.eml'))
-
-        mail.delete_all_attachments()
-        self.assertFalse(mail.has_attachments())
-
-    def test_delete_one_attachment(self):
-        mail = create(Builder('mail')
-                      .within(self.dossier)
-                      .with_asset_message(
-                          'mail_with_multiple_attachments.eml'))
-
-        self.assertEqual(3, len(mail.get_attachments()))
-        mail.delete_attachments([2])
-        self.assertEqual(2, len(mail.get_attachments()))
-
     def test_extracting_into_unsupported_container_raises_error(self):
         mail = create(Builder('mail')
                       .with_asset_message('mail_with_one_mail_attachment.eml'))

--- a/opengever/mail/tests/test_subscribers.py
+++ b/opengever/mail/tests/test_subscribers.py
@@ -2,6 +2,7 @@ from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
 from opengever.testing import FunctionalTestCase
+import transaction
 
 
 class TestSubscribers(FunctionalTestCase):
@@ -13,13 +14,32 @@ class TestSubscribers(FunctionalTestCase):
         self.root = create(Builder('repository_root'))
         self.repo = create(Builder('repository').within(self.root))
         self.dossier = create(Builder('dossier').within(self.repo))
+        self.mail = create(Builder('mail')
+                           .within(self.dossier)
+                           .with_asset_message(
+                               'mail_with_multiple_attachments.eml'))
 
     @browsing
     def test_modifying_title_updates_filename(self, browser):
-        mail = create(
-            Builder('mail').within(self.dossier).with_dummy_message())
-
-        browser.login().open(mail, view='edit')
+        browser.login().open(self.mail, view='edit')
         browser.fill({'Title': 'My new mail Title'}).submit()
 
-        self.assertEqual(u'My new mail Title.eml', mail.message.filename)
+        self.assertEqual(u'My new mail Title.eml', self.mail.message.filename)
+
+    def test_attachment_info_is_updated_when_extracted_document_is_moved(self):
+        self.destination_dossier = create(Builder('dossier'))
+        self.login()
+
+        doc = self.mail.extract_attachment_into_parent(4)
+        transaction.commit()
+        doc_url = doc.absolute_url()
+
+        info = self.mail._get_attachment_info(4)
+        self.assertEqual(doc_url, info.get("extracted_document_url"))
+
+        moved_doc = api.content.move(doc, self.destination_dossier)
+
+        info = self.mail._get_attachment_info(4)
+        self.assertNotEqual(doc_url, moved_doc.absolute_url())
+        self.assertEqual(moved_doc.absolute_url(),
+                         info.get("extracted_document_url"))

--- a/opengever/mail/tests/test_subscribers.py
+++ b/opengever/mail/tests/test_subscribers.py
@@ -2,6 +2,7 @@ from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
 from opengever.base.security import elevated_privileges
+from opengever.mail.interfaces import IExtractedFromMail
 from opengever.testing import FunctionalTestCase
 from plone import api
 from plone.uuid.interfaces import IUUID
@@ -65,3 +66,16 @@ class TestSubscribers(FunctionalTestCase):
         self.assertFalse(info.get("extracted"))
         self.assertIsNone(info.get("extracted_document_url"))
         self.assertIsNone(info.get("extracted_document_uid"))
+
+    @browsing
+    def test_extracted_documents_are_unmarked_when_mail_is_deleted(self, browser):
+        self.login()
+        doc = self.mail.extract_attachment_into_parent(4)
+        transaction.commit()
+
+        self.assertTrue(IExtractedFromMail.providedBy(doc))
+
+        with elevated_privileges():
+            api.content.delete(self.mail)
+
+        self.assertFalse(IExtractedFromMail.providedBy(doc))

--- a/opengever/mail/tests/test_subscribers.py
+++ b/opengever/mail/tests/test_subscribers.py
@@ -30,24 +30,6 @@ class TestSubscribers(FunctionalTestCase):
 
         self.assertEqual(u'My new mail Title.eml', self.mail.message.filename)
 
-    def test_attachment_info_is_updated_when_extracted_document_is_moved(self):
-        self.destination_dossier = create(Builder('dossier'))
-        self.login()
-
-        doc = self.mail.extract_attachment_into_parent(4)
-        transaction.commit()
-        doc_url = doc.absolute_url()
-
-        info = self.mail._get_attachment_info(4)
-        self.assertEqual(doc_url, info.get("extracted_document_url"))
-
-        moved_doc = api.content.move(doc, self.destination_dossier)
-
-        info = self.mail._get_attachment_info(4)
-        self.assertNotEqual(doc_url, moved_doc.absolute_url())
-        self.assertEqual(moved_doc.absolute_url(),
-                         info.get("extracted_document_url"))
-
     @browsing
     def test_attachment_info_is_updated_when_extracted_document_is_deleted(self, browser):
         self.login()
@@ -56,7 +38,6 @@ class TestSubscribers(FunctionalTestCase):
 
         info = self.mail._get_attachment_info(4)
         self.assertTrue(info.get("extracted"))
-        self.assertEqual(doc.absolute_url(), info.get("extracted_document_url"))
         self.assertEqual(IUUID(doc), info.get("extracted_document_uid"))
 
         with elevated_privileges():


### PR DESCRIPTION
In order to be able to work with Mails in the GEVER-UI we needed several changes in the backend:
- return the attachments in the GET of `Mail`s, to allow representing attachments in the detailview
- A new endpoint `extract-attachments` to extract the attachments of an `Mail` as a separate document

There are also some new requirements for `Mail`s, that will allow a more modern representation of mails in GEVER:
- Each attachment should only be extracted once
- For each attachment the `Mail` should store a link to the extracted document
- deleting of attachments from the `Mail` itself should not be allowed anymore (mail messages should be immutable)
This allows to represent each attachment as either a link to the extracted document or as a link to extracting the attachment.

On the technical side, information about attachments are already stored on `Mail`s in a dictionary:
- This is sadly not in a `PersistentMapping`, I chose to leave it as is, as otherwise we would need to migrate all existing mails. 
- We now also store the information about the extracted document in that mapping.
- This information now needs to be updated when an extracted document is moved
- I also handle the cases where an extracted document is deleted. The attachment can then be extracted again
- The case where the `Mail` is deleted is partially handled, the `IExtractedFromMail` interface is removed from the document, but the extracted document will still be broken, because the `Mail` is also in the RelatedItems, and these fields do not support object deletion properly. But this is a general problem we have in GEVER, not specific to this situation.

Some more edge-cases and comments:
- When an attachment gets extracted and then moved to a position a user cannot see. @all4manu what happens then in the GEVER-UI? No link?
- E-mails with documents that have been extracted prior to this change will be confusing (documents will not show up the same in the GEVER-UI, and users might extract them again)

For https://4teamwork.atlassian.net/browse/GEVER-198

## Checklist (Must have)
- [x] Changelog entry
- [x] Documentation updated (notably for API and deployment)
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

## Checklist (optional)
- New translations
  - [x] All msg-strings are unicode
  - [x] Correct i18n-domain was used (Copy-Paste errors are common here)
