### PR TITLE
Avoid object lookup in DocumentLinkWidget for catalog brains

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,7 @@ Changelog
 2020.3.0rc4 (unreleased)
 ------------------------
 
-- Nothing changed yet.
+- Avoid object lookup in DocumentLinkWidget for catalog brains. [buchi]
 
 
 2020.3.0rc3 (2020-05-22)

--- a/opengever/document/widgets/document_link.py
+++ b/opengever/document/widgets/document_link.py
@@ -1,5 +1,6 @@
 from plone import api
 from plone.app.contentlisting.interfaces import IContentListingObject
+from Products.ZCatalog.interfaces import ICatalogBrain
 from zope.browserpage.viewpagetemplatefile import ViewPageTemplateFile
 from zope.globalrequest import getRequest
 
@@ -39,4 +40,8 @@ class DocumentLinkWidget(object):
         return self.template(self, self.request)
 
     def is_view_allowed(self):
+        # Avoid object lookup for catalog brains as catalog searches are
+        # security aware anyway.
+        if ICatalogBrain.providedBy(self.context.getDataOrigin()):
+            return True
         return api.user.has_permission('View', obj=self.context.getObject())


### PR DESCRIPTION
Doing a permission check for catalog brains is needless as catalog
searches are security aware anyway.

This improves the performance of the documents tab.

Jira: https://4teamwork.atlassian.net/browse/GEVER-374


Definition of Done: https://4teamwork.atlassian.net/wiki/spaces/CHX4TW/pages/917562/


## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Documentation updated (notably for API and deployment)
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

