### PR TITLE
Improve contenttree widget in handling a large amount of items

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 ------------------------
 
 - Avoid object lookup in DocumentLinkWidget for catalog brains. [buchi]
+- Improve contenttree widget in handling a large amount of items. [buchi]
 
 
 2020.3.0rc3 (2020-05-22)

--- a/opengever/base/browser/configure.zcml
+++ b/opengever/base/browser/configure.zcml
@@ -270,4 +270,12 @@
       permission="zope2.View"
       />
 
+  <browser:page
+      name="contenttree-fetch"
+      for="plone.formwidget.contenttree.interfaces.IContentTreeWidget"
+      permission="zope.Public"
+      class=".contenttree.Fetch"
+      layer="opengever.base.interfaces.IOpengeverBaseLayer"
+      />
+
 </configure>

--- a/opengever/base/browser/contenttree.py
+++ b/opengever/base/browser/contenttree.py
@@ -1,0 +1,84 @@
+from plone.app.layout.navigation.interfaces import INavtreeStrategy
+from plone.formwidget.contenttree.utils import closest_content
+from plone.formwidget.contenttree.widget import Fetch
+from Products.CMFCore.utils import getToolByName
+from zope.browserpage.viewpagetemplatefile import ViewPageTemplateFile
+from zope.component import getMultiAdapter
+import urllib
+
+
+# Customization of p.formwidget.contenttree:
+# Does the same as the original but only returns a maximum of 100 children and
+# supports a b_start parameter for fetching further batches.
+class Fetch(Fetch):
+
+    fragment_template = ViewPageTemplateFile('templates/fragment.pt')
+
+    def __call__(self):
+        # We want to check that the user was indeed allowed to access the
+        # form for this widget. We can only this now, since security isn't
+        # applied yet during traversal.
+        self.validate_access()
+
+        widget = self.context
+        context = widget.context
+
+        # Update the widget before accessing the source.
+        # The source was only bound without security applied
+        # during traversal before.
+        widget.update()
+        source = widget.bound_source
+
+        # Convert token from request to the path to the object
+        token = self.request.form.get('href', None)
+        if token is not None:
+            token = urllib.unquote(token)
+        directory = self.context.bound_source.tokenToPath(token)
+        level = self.request.form.get('rel', 0)
+
+        b_start = self.request.form.get('b_start', 0)
+        try:
+            b_start = int(b_start)
+        except ValueError:
+            b_start = 0
+        b_size = 100
+
+        navtree_query = source.navigation_tree_query.copy()
+
+        if widget.show_all_content_types and 'portal_type' in navtree_query:
+            del navtree_query['portal_type']
+
+        if directory is not None:
+            navtree_query['path'] = {'depth': 1, 'query': directory}
+
+        if 'is_default_page' not in navtree_query:
+            navtree_query['is_default_page'] = False
+
+        content = closest_content(context)
+
+        strategy = getMultiAdapter((content, widget), INavtreeStrategy)
+        catalog = getToolByName(content, 'portal_catalog')
+
+        results = catalog(navtree_query)
+        if len(results) > b_start + b_size + 1:
+            has_more = True
+        else:
+            has_more = False
+
+        children = []
+        for brain in results[b_start:b_start + b_size]:
+            newNode = {'item': brain,
+                       'depth': -1,  # not needed here
+                       'currentItem': False,
+                       'currentParent': False,
+                       'children': []}
+            if strategy.nodeFilter(newNode):
+                newNode = strategy.decoratorFactory(newNode)
+                children.append(newNode)
+
+        self.request.response.setHeader('X-Theme-Disabled', 'True')
+
+        return self.fragment_template(
+            children=children, level=int(level), b_start=b_start + b_size,
+            has_more=has_more,
+        )

--- a/opengever/base/browser/resources/contenttree.js
+++ b/opengever/base/browser/resources/contenttree.js
@@ -1,0 +1,178 @@
+// This is based on jQueryFileTree by   Cory S.N. LaViska
+if(jQuery) (function($){
+
+    $.extend($.fn, {
+        showDialog: function() {
+            $(document.body)
+                .append($(document.createElement("div"))
+                .addClass("contenttreeWindowBlocker"));
+            // store old parent element
+            this[0].oldparent = $(this).parent()[0];
+            $(".contenttreeWindowBlocker").before(this);
+            $(this).show();
+            $(this).width($(window).width() * 0.75);
+            $(this).height($(window).height() * 0.75);
+            $(this).css({
+                'left': $(window).width() * 0.125,
+                'top': $(window).height() * 0.125
+            });
+        },
+
+        contentTreeAdd: function() {
+            var contenttree_window = (this).parents(".contenttreeWindow");
+            var input_box = $('#'+ contenttree_window[0].id
+                .replace(/-contenttree-window$/,"-widgets-query"));
+            contenttree_window.find('.navTreeCurrentItem > a').each(function () {
+                formwidget_autocomplete_new_value(
+                    input_box,
+                    $(this).attr('href'),
+                    $.trim($(this).text())
+                );
+            });
+            $(this).contentTreeCancel();
+            input_box.parents('.datagridwidget-cell').triggerHandler('change');
+        },
+
+        contentTreeCancel: function() {
+            $(".contenttreeWindowBlocker").remove();
+            var popup = $(this).parents(".contenttreeWindow");
+            popup.hide();
+            $(popup[0].oldparent).append(popup);
+            popup[0].oldparent = null;
+        },
+
+        contentTree: function(o, h) {
+            // Defaults
+            if (!o) {
+                var o = {};
+            }
+            if (o.script == undefined) {
+                o.script = 'fetch';
+            }
+
+            if (o.folderEvent == undefined) {
+                o.folderEvent = 'click';
+            }
+            if (o.selectEvent == undefined) {
+                o.selectEvent = 'click';
+            }
+
+            if (o.expandSpeed == undefined) {
+                o.expandSpeed = -1;
+            }
+            if (o.collapseSpeed == undefined) {
+                o.collapseSpeed = -1;
+            }
+
+            if (o.multiFolder == undefined) {
+                o.multiFolder = true;
+            }
+            if (o.multiSelect == undefined) {
+                o.multiSelect = false;
+            }
+
+            function loadTree(c, t, r, b_start=0) {
+                $(c).addClass('wait');
+                $.post(o.script, {href: t, rel: r, b_start: b_start}, function(data) {
+                    $(c).removeClass('wait').append(data);
+                    $(c).find('ul:hidden').slideDown({
+                        duration: o.expandSpeed
+                    });
+                    bindTree(c);
+                });
+            }
+
+            function handleFolderEvent() {
+                var li = $(this).parent();
+                if (li.hasClass('collapsed')) {
+                    if (!o.multiFolder) {
+                        li.parent().find('ul:visible').slideUp({
+                            duration: o.collapseSpeed
+                        });
+                        li.parent().find('li.navTreeFolderish')
+                            .removeClass('expanded')
+                            .addClass('collapsed');
+                    }
+
+                    if (li.find('ul').length == 0) {
+                        loadTree(
+                            li,
+                            escape($(this).attr('href')),
+                            escape($(this).attr('rel'))
+                        );
+                    }
+                    else
+                        li.find('ul:hidden').slideDown({
+                            duration: o.expandSpeed
+                        });
+                    li.removeClass('collapsed').addClass('expanded');
+                } else if (li.hasClass('loadMore')) {
+                    var pli = li.parent().closest('li');
+                    var a = pli.find('a');
+                    loadTree(
+                        pli,
+                        escape(a.attr('href')),
+                        escape(a.attr('rel')),
+                        $(this).data('bstart'),
+                    );
+                    li.remove();
+                } else {
+                    li.find('ul').slideUp({
+                        duration: o.collapseSpeed
+                    });
+                    li.removeClass('expanded').addClass('collapsed');
+                }
+                return false;
+            }
+
+            function handleSelectEvent(event) {
+                var li = $(this).parent();
+                var selected = true;
+                var root = $(this).parents('ul.navTree');
+                if (!li.hasClass('navTreeCurrentItem')) {
+                    var multi_key = (
+                        (event.ctrlKey) ||
+                        (navigator.userAgent.toLowerCase()
+                            .indexOf('macintosh') != -1 && event.metaKey));
+
+                    if (!o.multiSelect || !multi_key) {
+                        root.find('li.navTreeCurrentItem')
+                            .removeClass('navTreeCurrentItem');
+                    }
+
+                    li.addClass('navTreeCurrentItem');
+                    selected = true;
+                } else {
+                    li.removeClass('navTreeCurrentItem');
+                    selected = false;
+                }
+
+                h(event, true, $(this).attr('href'), $.trim($(this).text()));
+            }
+
+            function bindTree(t) {
+                $(t).find('li.navTreeFolderish a').unbind(o.folderEvent);
+                $(t).find('li.selectable a').unbind(o.selectEvent);
+                $(t).find('li a').bind('click', function() {
+                    return false;
+                });
+                $(t).find('li.navTreeFolderish a').bind(
+                    o.folderEvent,
+                    handleFolderEvent
+                );
+                $(t).find('li.selectable a').bind(
+                    o.selectEvent,
+                    handleSelectEvent
+                );
+            }
+
+            if ($(this).children('ul.navTree').length <= 0) {
+                $(this).each(function() {
+                    loadTree(this, o.rootUrl, 0);
+                });
+            }
+
+        }
+    });
+
+})(jQuery);

--- a/opengever/base/browser/templates/fragment.pt
+++ b/opengever/base/browser/templates/fragment.pt
@@ -1,0 +1,9 @@
+<ul i18n:domain="opengever.base" style="display:none"
+    tal:define="level options/level|python:0; children options/children|nothing"
+    tal:attributes="class python:'navTree navTreeLevel'+str(level)"
+    tal:condition="python: len(children) > 0">
+    <span tal:replace="structure python:view.recurse_template(children=children, level=level+1)" />
+    <li tal:condition="options/has_more" class="navTreeFolderish loadMore">
+    	<a href="#" tal:attributes="data-bstart options/b_start" i18n:translate="label_load_more">Load more entries…</a>
+    </li>
+</ul>

--- a/opengever/base/locales/de/LC_MESSAGES/opengever.base.po
+++ b/opengever/base/locales/de/LC_MESSAGES/opengever.base.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-09-05 09:16+0000\n"
+"POT-Creation-Date: 2020-05-25 15:04+0000\n"
 "PO-Revision-Date: 2014-09-04 01:03+0200\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: Jonas Baumann <j.baumann@4teamwork.ch>\n"
@@ -296,6 +296,11 @@ msgstr "Dossier:"
 msgid "label_last_modified"
 msgstr "Zuletzt verändert"
 
+#. Default: "Load more entries…"
+#: ./opengever/base/browser/templates/fragment.pt
+msgid "label_load_more"
+msgstr "Weitere Einträge laden…"
+
 #. Default: "No checked out documents"
 #: ./opengever/base/viewlets/recently_touched_menu.py
 msgid "label_no_checked_out_docs"
@@ -317,7 +322,7 @@ msgid "label_none"
 msgstr "Keine Werte"
 
 #. Default: "Null"
-#: ./opengever/base/helper.py
+#: ./opengever/base/helpers.py
 msgid "label_null"
 msgstr "Kein Wert"
 

--- a/opengever/base/locales/fr/LC_MESSAGES/opengever.base.po
+++ b/opengever/base/locales/fr/LC_MESSAGES/opengever.base.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-09-05 09:16+0000\n"
+"POT-Creation-Date: 2020-05-25 15:04+0000\n"
 "PO-Revision-Date: 2017-11-29 10:53+0000\n"
 "Last-Translator: Philippe Gross <gross.philippe@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-base/fr/>\n"
@@ -295,6 +295,11 @@ msgstr "Dossier:"
 msgid "label_last_modified"
 msgstr "Dernière modification"
 
+#. Default: "Load more entries…"
+#: ./opengever/base/browser/templates/fragment.pt
+msgid "label_load_more"
+msgstr "Charger plus…"
+
 #. Default: "No checked out documents"
 #: ./opengever/base/viewlets/recently_touched_menu.py
 msgid "label_no_checked_out_docs"
@@ -316,7 +321,7 @@ msgid "label_none"
 msgstr "Aucune valeur"
 
 #. Default: "Null"
-#: ./opengever/base/helper.py
+#: ./opengever/base/helpers.py
 msgid "label_null"
 msgstr "Aucune valeur"
 

--- a/opengever/base/locales/opengever.base.pot
+++ b/opengever/base/locales/opengever.base.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-09-05 09:16+0000\n"
+"POT-Creation-Date: 2020-05-25 15:04+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -293,6 +293,11 @@ msgstr ""
 msgid "label_last_modified"
 msgstr ""
 
+#. Default: "Load more entries…"
+#: ./opengever/base/browser/templates/fragment.pt
+msgid "label_load_more"
+msgstr ""
+
 #. Default: "No checked out documents"
 #: ./opengever/base/viewlets/recently_touched_menu.py
 msgid "label_no_checked_out_docs"
@@ -314,7 +319,7 @@ msgid "label_none"
 msgstr ""
 
 #. Default: "Null"
-#: ./opengever/base/helper.py
+#: ./opengever/base/helpers.py
 msgid "label_null"
 msgstr ""
 

--- a/opengever/base/tests/test_contenttree.py
+++ b/opengever/base/tests/test_contenttree.py
@@ -1,0 +1,69 @@
+from ftw.testbrowser import browsing
+from mock import patch
+from opengever.testing import IntegrationTestCase
+import itertools
+
+
+class TestContenttreeFetch(IntegrationTestCase):
+
+    @patch('Products.ZCatalog.ZCatalog.ZCatalog.searchResults')
+    @browsing
+    def test_contenttree_fetch_returns_max_100_items(
+        self, mocked_searchResults, browser
+    ):
+        self.login(self.regular_user, browser=browser)
+
+        # Repeat the first item 200 times to have more than 100 results.
+        def results(self, *args, **kwargs):
+            results = self._catalog.searchResults(*args, **kwargs)
+            return list(results) + list(itertools.repeat(results[0], 200))
+        mocked_searchResults.side_effect = results
+
+        url = (
+            '{}/@@edit/++widget++form.widgets.IRelatedDocuments.relatedItems/'
+            '@@contenttree-fetch'.format(self.document.absolute_url())
+        )
+        browser.open(
+            url,
+            method='POST',
+            data={
+                'href': '/'.join(self.repository_root.getPhysicalPath()),
+                'rel': '0',
+                'b_start': '0',
+            },
+        )
+        self.assertEqual(len(browser.css('li.navTreeItem')), 100)
+
+    @patch('Products.ZCatalog.ZCatalog.ZCatalog.searchResults')
+    @browsing
+    def test_contenttree_fetch_returns_items_from_b_start(
+        self, mocked_searchResults, browser
+    ):
+        self.login(self.regular_user, browser=browser)
+
+        # Repeat the first item 100 times for the first batch and the second
+        # item 10 times for the second batch.
+        def results(self, *args, **kwargs):
+            results = self._catalog.searchResults(*args, **kwargs)
+            return (
+                list(itertools.repeat(results[0], 100))
+                + list(itertools.repeat(results[1], 10))
+            )
+        mocked_searchResults.side_effect = results
+
+        url = (
+            '{}/@@edit/++widget++form.widgets.IRelatedDocuments.relatedItems/'
+            '@@contenttree-fetch'.format(self.document.absolute_url())
+        )
+        browser.open(
+            url,
+            method='POST',
+            data={
+                'href': '/'.join(self.repository_root.getPhysicalPath()),
+                'rel': '0',
+                'b_start': '100',
+            },
+        )
+        self.assertEqual(len(browser.css('li.navTreeItem')), 10)
+        self.assertEqual(
+            browser.css('li>a>span').first.text, 'rechnungsprufungskommission')

--- a/opengever/core/profiles/default/jsregistry.xml
+++ b/opengever/core/profiles/default/jsregistry.xml
@@ -632,4 +632,20 @@
       inline="False"
       />
 
+  <!-- Replace Plone's contenttree.js with our own -->
+  <javascript
+      id="++resource++opengever.base/contenttree.js"
+      insert-after="++resource++plone.formwidget.contenttree/contenttree.js"
+      cacheable="True"
+      compression="none"
+      cookable="True"
+      enabled="True"
+      expression=""
+      inline="False"
+      />
+  <javascript
+      id="++resource++plone.formwidget.contenttree/contenttree.js"
+      remove="True"
+      />
+
 </object>

--- a/opengever/core/tests/test_view_security.py
+++ b/opengever/core/tests/test_view_security.py
@@ -25,6 +25,7 @@ WHITELIST = (
     'opengever.base.widgets.GeverRenderWidget',
     'opengever.base.browser.jsvariables.GeverJSVariables',
     'opengever.base.browser.ploneview.GeverPloneView',
+    'opengever.base.browser.contenttree.Fetch',
 
     # The bumblebee token is verified in these views:
     'opengever.bumblebee.browser.callback.ReceiveDocumentPDF',

--- a/opengever/core/upgrades/20200525170008_handle_large_contenttrees/jsregistry.xml
+++ b/opengever/core/upgrades/20200525170008_handle_large_contenttrees/jsregistry.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<object name="portal_javascripts">
+
+  <javascript id="++resource++opengever.base/contenttree.js"
+  	  insert-after="++resource++plone.formwidget.contenttree/contenttree.js"
+      cacheable="True" compression="none" cookable="True" enabled="True"
+      expression="" inline="False" />
+  <javascript id="++resource++plone.formwidget.contenttree/contenttree.js"
+      remove="True" />
+
+</object>

--- a/opengever/core/upgrades/20200525170008_handle_large_contenttrees/upgrade.py
+++ b/opengever/core/upgrades/20200525170008_handle_large_contenttrees/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class HandleLargeContenttrees(UpgradeStep):
+    """Handle large contenttrees.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()


### PR DESCRIPTION
No longer load all children but limit the maximum number to 100 when browsing related items using the content tree widget. Provide a "load more" link to load the next batch.

This fixes performance issues when having items with a large amount of children.

https://4teamwork.atlassian.net/browse/GEVER-374

![contenttree](https://user-images.githubusercontent.com/270502/82836722-68abee00-9ec7-11ea-99f7-86e2514e8b7f.gif)


## Checklist (Must have)

- [x] Changelog entry
- [x] Documentation updated (notably for API and deployment)
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


## Checklist (optional)

- [x] Upgrade steps (changes in profile):
- New translations
  - [x] Correct i18n-domain was used (Copy-Paste errors are common here)

