### PR TITLE
Rename @team API endpoint to @teams.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2020.3.0rc4 (unreleased)
 ------------------------
 
+- Rename @team API endpoint to @teams. [tinagerber]
 - Avoid object lookup in DocumentLinkWidget for catalog brains. [buchi]
 - Improve contenttree widget in handling a large amount of items. [buchi]
 - Rename @ogds-user API endpoint to @ogds-users. [tinagerber]

--- a/docs/public/dev-manual/api/docs_changelog.rst
+++ b/docs/public/dev-manual/api/docs_changelog.rst
@@ -8,6 +8,7 @@ Im Folgenden sind (substantielle) Änderungen an der Dokumentation aufgeführt.
 2020-05-26
 ----------
 
+- ``@team`` Endpunkt umbenannt in ``@teams``
 - ``@ogds-user`` Endpunkt umbenannt in ``@ogds-users``
 
 

--- a/docs/public/dev-manual/api/users.rst
+++ b/docs/public/dev-manual/api/users.rst
@@ -42,7 +42,7 @@ Ein Benutzer wird lediglich durch einen Eintrag in der SQL Datenbank repräsenti
         ],
         "teams": [
             {
-                "@id": "http://example.org/fd/kontakte/@team/90",
+                "@id": "http://example.org/fd/kontakte/@teams/90",
                 "@type": "virtual.ogds.team",
                 "active": true,
                 "groupid": "afi_benutzer",
@@ -61,9 +61,9 @@ Ein Benutzer wird lediglich durch einen Eintrag in der SQL Datenbank repräsenti
 Teams
 =====
 
-Team Daten werden mit dem ``@team`` Endpoint abgefragt. Dieser Endpoint unterstützt nur das GET und erwartet als Pfad-Argument die ID des Teams und wird auf dem Kontakt Folder abgefragt. Die URL setzt sich somit folgendermassen zusammen:
+Team Daten werden mit dem ``@teams`` Endpoint abgefragt. Dieser Endpoint unterstützt nur das GET und erwartet als Pfad-Argument die ID des Teams und wird auf dem Kontakt Folder abgefragt. Die URL setzt sich somit folgendermassen zusammen:
 
-``http://example.org/fd/kontakte/@team/90``
+``http://example.org/fd/kontakte/@teams/90``
 
 Ein Team wird lediglich durch einen Eintrag in der SQL Datenbank repräsentiert und ist kein Plone Inhaltstyp. Deshalb beinhaltet die Response weniger Information als für andere Inhaltstypen.
 
@@ -71,7 +71,7 @@ Ein Team wird lediglich durch einen Eintrag in der SQL Datenbank repräsentiert 
 
    .. sourcecode:: http
 
-      GET /@team/a-team HTTP/1.1
+      GET /@teams/a-team HTTP/1.1
       Accept: application/json
 
 **Beispiel-Response**:
@@ -83,7 +83,7 @@ Ein Team wird lediglich durch einen Eintrag in der SQL Datenbank repräsentiert 
       Content-Type: application/json
 
       {
-        "@id": "http://localhost:8080/fd/kontakte/@team/90",
+        "@id": "http://localhost:8080/fd/kontakte/@teams/90",
         "@type": "virtual.ogds.team",
         "active": true,
         "groupid": "afi_benutzer",

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -343,7 +343,7 @@
       method="GET"
       for="opengever.contact.interfaces.IContactFolder"
       factory=".team.TeamGet"
-      name="@team"
+      name="@teams"
       permission="zope2.View"
       />
 

--- a/opengever/api/serializer.py
+++ b/opengever/api/serializer.py
@@ -238,7 +238,7 @@ class SerializeTeamModelToJsonSummary(SerializeSQLModelToJsonSummaryBase):
 
     content_type = 'virtual.ogds.team'
     id_attribute_name = 'team_id'
-    endpoint_name = '@team'
+    endpoint_name = '@teams'
 
     def add_additional_metadata(self, data):
         data['org_unit_title'] = self.context.org_unit.title

--- a/opengever/api/team.py
+++ b/opengever/api/team.py
@@ -10,7 +10,7 @@ from zope.publisher.interfaces import IPublishTraverse
 class TeamGet(Service):
     """API Endpoint that returns a single team from ogds.
 
-    GET /@team/team.id HTTP/1.1
+    GET /@teams/team.id HTTP/1.1
     """
 
     implements(IPublishTraverse)

--- a/opengever/api/tests/test_ogdsuser.py
+++ b/opengever/api/tests/test_ogdsuser.py
@@ -46,7 +46,7 @@ class TestOGDSUserGet(IntegrationTestCase):
              u'phone_mobile': u'012 34 56 76',
              u'phone_office': u'012 34 56 78',
              u'salutation': u'Prof. Dr.',
-             u'teams': [{u'@id': u'http://nohost/plone/kontakte/@team/1',
+             u'teams': [{u'@id': u'http://nohost/plone/kontakte/@teams/1',
                          u'@type': u'virtual.ogds.team',
                          u'active': True,
                          u'groupid': u'projekt_a',

--- a/opengever/api/tests/test_team.py
+++ b/opengever/api/tests/test_team.py
@@ -15,12 +15,12 @@ class TestTeamGet(IntegrationTestCase):
         self.login(self.regular_user, browser=browser)
 
         browser.open(self.contactfolder,
-                     view='@team/{}'.format(self.team_id),
+                     view='@teams/{}'.format(self.team_id),
                      headers=self.api_headers)
         self.assertEqual(200, browser.status_code)
 
         self.assertEqual(
-            {u'@id': u'http://nohost/plone/kontakte/@team/1',
+            {u'@id': u'http://nohost/plone/kontakte/@teams/1',
              u'@type': u'virtual.ogds.team',
              u'active': True,
              u'group': {u'@id': u'http://nohost/plone/kontakte/@group/projekt_a',
@@ -69,7 +69,7 @@ class TestTeamGet(IntegrationTestCase):
         browser.exception_bubbling = True
         with self.assertRaises(BadRequest):
             browser.open(self.contactfolder,
-                         view='@team',
+                         view='@teams',
                          headers=self.api_headers)
 
     @browsing
@@ -78,5 +78,5 @@ class TestTeamGet(IntegrationTestCase):
         browser.exception_bubbling = True
         with self.assertRaises(BadRequest):
             browser.open(self.contactfolder,
-                         view='@team/{}/foobar'.format(self.team_id),
+                         view='@teams/{}/foobar'.format(self.team_id),
                          headers=self.api_headers)

--- a/opengever/api/tests/test_teamlisting.py
+++ b/opengever/api/tests/test_teamlisting.py
@@ -16,7 +16,7 @@ class TestTeamListingGet(IntegrationTestCase):
         self.assertEqual(200, browser.status_code)
 
         self.assertEqual([
-            {u'@id': u'http://nohost/plone/kontakte/@team/1',
+            {u'@id': u'http://nohost/plone/kontakte/@teams/1',
              u'@type': u'virtual.ogds.team',
              u'active': True,
              u'groupid': u'projekt_a',
@@ -24,7 +24,7 @@ class TestTeamListingGet(IntegrationTestCase):
              u'org_unit_title': u'Finanz\xe4mt',
              u'team_id': 1,
              u'title': u'Projekt \xdcberbaung Dorfmatte'},
-            {u'@id': u'http://nohost/plone/kontakte/@team/3',
+            {u'@id': u'http://nohost/plone/kontakte/@teams/3',
              u'@type': u'virtual.ogds.team',
              u'active': True,
              u'groupid': u'projekt_laeaer',
@@ -32,7 +32,7 @@ class TestTeamListingGet(IntegrationTestCase):
              u'org_unit_title': u'Finanz\xe4mt',
              u'team_id': 3,
              u'title': u'Sekretariat Abteilung Null'},
-            {u'@id': u'http://nohost/plone/kontakte/@team/2',
+            {u'@id': u'http://nohost/plone/kontakte/@teams/2',
              u'@type': u'virtual.ogds.team',
              u'active': True,
              u'groupid': u'projekt_b',
@@ -158,7 +158,7 @@ class TestTeamListingGet(IntegrationTestCase):
 
         self.assertEqual(1, len(browser.json['items']))
         self.assertEqual([
-            {u'@id': u'http://nohost/plone/kontakte/@team/1',
+            {u'@id': u'http://nohost/plone/kontakte/@teams/1',
              u'@type': u'virtual.ogds.team',
              u'active': True,
              u'groupid': u'projekt_a',


### PR DESCRIPTION
There are naming conventions for the REST API that state that the plural should be used for endpoint names.
https://plonerestapi.readthedocs.io/en/latest/conventions.html#singluar-vs-plural
 Therefore the endpoint `@team` is renamed to `@teams`.

Definition of Done: https://4teamwork.atlassian.net/wiki/spaces/CHX4TW/pages/917562/

Jira: https://4teamwork.atlassian.net/browse/GEVER-418

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Documentation updated (notably for API and deployment)
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)