### PR TITLE
Implement custom gever localroles migrator.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -14,6 +14,7 @@ Changelog
 - Add batching for ogds team and group serializer. [tinagerber]
 - Extend @sharing endpoint with ogds_summary. [tinagerber]
 - Add @ogds-groups API endpoint. [tinagerber]
+- Implement custom RoleAssignmentManager based local role migration for ftw.usermigration. [deiferni]
 
 
 2020.3.0rc3 (2020-05-22)

--- a/opengever/base/role_assignments.py
+++ b/opengever/base/role_assignments.py
@@ -303,9 +303,9 @@ class RoleAssignmentManager(object):
 
         self._update_local_roles(reindex=reindex)
 
-    def add_or_update(self, principal, roles, cause, reference=None):
+    def add_or_update(self, principal, roles, cause, reference=None, reindex=True):
         self.storage.add_or_update(principal, roles, cause, reference)
-        self._update_local_roles()
+        self._update_local_roles(reindex=reindex)
 
     def get_assignments_by_cause(self, cause):
         return self.storage.get_by_cause(cause)

--- a/opengever/base/role_assignments.py
+++ b/opengever/base/role_assignments.py
@@ -355,7 +355,15 @@ class RoleAssignmentManager(object):
         self._update_local_roles()
 
     def clear(self, cause, principal, reference, reindex=True):
-        item = self.storage.get(principal, cause, Oguid.for_object(reference).id)
+        """Clear one assignment, if it still exists.
+
+        Clear an assignment of the given cause, principal and reference.
+        Reference may either be a plone content object or an oguid string
+        representation.
+        """
+        if reference and not isinstance(reference, basestring):
+            reference = Oguid.for_object(reference).id
+        item = self.storage.get(principal, cause, reference)
         if not item:
             return
 

--- a/opengever/usermigration/__init__.py
+++ b/opengever/usermigration/__init__.py
@@ -1,0 +1,5 @@
+from ftw.usermigration.browser import migration
+from opengever.usermigration.localroles import migrate_localroles
+
+
+migration.BUILTIN_MIGRATIONS['localroles'] = migrate_localroles

--- a/opengever/usermigration/localroles.py
+++ b/opengever/usermigration/localroles.py
@@ -1,0 +1,97 @@
+from opengever.base.role_assignments import RoleAssignmentManager
+from zope.annotation.interfaces import IAnnotatable
+
+
+def migrate_localroles(context, mapping, mode='move', replace=False):
+    """Recursively migrate local roles on the given context.
+
+    This method customizes  ftw.usermigration.localroles.migrate_localroles by
+    changing the way the local roles are updated. Instead of using the
+    manage_<set|del>LocalRoles method we use the corresponding methods from the
+    RoleAssignmentManager.
+    """
+
+    # Statistics
+    moved = []
+    copied = []
+    deleted = []
+
+    # Paths needing reindexing of security
+    reindex_paths = set()
+
+    if replace:
+        raise NotImplementedError(
+            "Local roles migration only supports 'replace=False' as of yet")
+
+    if mode not in ('move', 'copy', 'delete'):
+        raise
+
+    def is_reindexing_ancestor(path):
+        """Determine if an ancestor of the given path is already in
+           reindex_paths."""
+        path_parts = path.split('/')
+        for i, part in enumerate(path_parts):
+            subpath = '/'.join(path_parts[:i + 1])
+            if subpath in reindex_paths:
+                return True
+        return False
+
+    def migrate_and_recurse(context):
+        """This function is based on ftw.usermigration but customized for
+        GEVER as follows:
+
+        - It does not recurse into and handle objects that do not support
+          IAnnotations. IAnnotations are needed by the RoleAssignmentManager.
+          This is mostly an issue when starting at plone-site level and iterate
+          some portal_<name> objects via objectValues.
+        - It uses RoleAssignmentManager instead of the manage_<op>LocalRoles
+          methods to modify local roles as we must do so in GEVER.
+        """
+        if not IAnnotatable.providedBy(context):
+            return
+
+        manager = RoleAssignmentManager(context)
+        path = '/'.join(context.getPhysicalPath())
+
+        for old_id, new_id in mapping.items():
+            assignments = manager.get_assignments_by_principal_id(old_id)
+            if not assignments:
+                continue
+
+            for old_assignment in assignments:
+                if mode in ['move', 'copy']:
+                    manager.add_or_update(
+                        new_id,
+                        old_assignment.roles,
+                        old_assignment.cause,
+                        old_assignment.reference,
+                        reindex=False)
+                    if not is_reindexing_ancestor(path):
+                        reindex_paths.add(path)
+                if mode in ['move', 'delete']:
+                    # Even though the kw argument is named `userids`,
+                    # these are in fact principal IDs (groups or users)
+                    manager.clear(
+                        old_assignment.cause,
+                        old_assignment.principal,
+                        old_assignment.reference,
+                        reindex=False)
+                    if not is_reindexing_ancestor(path):
+                        reindex_paths.add(path)
+            if mode == 'move':
+                moved.append((path, old_id, new_id))
+            elif mode == 'copy':
+                copied.append((path, old_id, new_id))
+            elif mode == 'delete':
+                deleted.append((path, old_id, None))
+
+        for obj in context.objectValues():
+            migrate_and_recurse(obj)
+
+    migrate_and_recurse(context)
+
+    for path in reindex_paths:
+        obj = context.unrestrictedTraverse(path)
+        obj.reindexObjectSecurity()
+
+    return(dict(moved=moved, copied=copied, deleted=deleted))

--- a/opengever/usermigration/tests/test_localroles.py
+++ b/opengever/usermigration/tests/test_localroles.py
@@ -2,9 +2,14 @@ from opengever.base.role_assignments import RoleAssignmentManager
 from opengever.testing import index_data_for
 from opengever.testing import IntegrationTestCase
 from opengever.usermigration.localroles import migrate_localroles
+from ftw.usermigration.browser import migration
 
 
 class TestMigrateLocalRoles(IntegrationTestCase):
+
+    def test_patch_applied(self):
+        self.assertIs(
+            migration.BUILTIN_MIGRATIONS['localroles'], migrate_localroles)
 
     def test_move_inbox_local_roles_of_existing_user(self):
         self.login(self.manager)

--- a/opengever/usermigration/tests/test_localroles.py
+++ b/opengever/usermigration/tests/test_localroles.py
@@ -1,0 +1,182 @@
+from opengever.base.role_assignments import RoleAssignmentManager
+from opengever.testing import index_data_for
+from opengever.testing import IntegrationTestCase
+from opengever.usermigration.localroles import migrate_localroles
+
+
+class TestMigrateLocalRoles(IntegrationTestCase):
+
+    def test_move_inbox_local_roles_of_existing_user(self):
+        self.login(self.manager)
+        old_id = self.secretariat_user.getId()
+        manager = RoleAssignmentManager(self.inbox)
+
+        assignments = manager.get_assignments_by_principal_id(old_id)
+        self.assertEqual(1, len(assignments))
+        self.assertEqual(['Contributor', 'Editor', 'Reader'],
+                         assignments[0].roles)
+        self.assertEqual([], manager.get_assignments_by_principal_id('new_user.id'))
+
+        mapping = {old_id: 'new_user.id'}
+        results = migrate_localroles(self.inbox, mapping, mode='move')
+
+        self.assertEqual(
+            [('/plone/eingangskorb', old_id, 'new_user.id')],
+            results['moved'])
+        self.assertEqual([], results['copied'])
+        self.assertEqual([], results['deleted'])
+
+        self.assertEqual([], manager.get_assignments_by_principal_id(old_id))
+        assignments = manager.get_assignments_by_principal_id('new_user.id')
+        self.assertEqual(1, len(assignments))
+        self.assertEqual(['Contributor', 'Editor', 'Reader'],
+                         assignments[0].roles)
+
+    def test_migrate_local_roles_of_nonexisting_user(self):
+        self.login(self.manager)
+        mapping = {'spam': 'peter'}
+        results = migrate_localroles(self.inbox, mapping)
+        self.assertEquals([], results['moved'])
+        self.assertEquals([], results['copied'])
+        self.assertEquals([], results['deleted'])
+
+    def test_delete_inbox_local_roles(self):
+        self.login(self.manager)
+        old_id = self.secretariat_user.getId()
+        manager = RoleAssignmentManager(self.inbox)
+
+        assignments = manager.get_assignments_by_principal_id(old_id)
+        self.assertEqual(1, len(assignments))
+        self.assertEqual(['Contributor', 'Editor', 'Reader'],
+                         assignments[0].roles)
+        self.assertEqual([], manager.get_assignments_by_principal_id('new_user.id'))
+
+        mapping = {old_id: 'new_user.id'}
+        results = migrate_localroles(self.inbox, mapping, mode='delete')
+
+        self.assertEqual([], results['moved'])
+        self.assertEqual([], results['copied'])
+        self.assertEqual(
+            [('/plone/eingangskorb', old_id, None)],
+            results['deleted'])
+
+        self.assertEqual([], manager.get_assignments_by_principal_id(old_id))
+        self.assertEqual([], manager.get_assignments_by_principal_id('new_user.id'))
+
+    def test_copy_inbox_local_roles(self):
+        self.login(self.manager)
+        old_id = self.secretariat_user.getId()
+        manager = RoleAssignmentManager(self.inbox)
+
+        assignments = manager.get_assignments_by_principal_id(old_id)
+        self.assertEqual(1, len(assignments))
+        self.assertEqual(['Contributor', 'Editor', 'Reader'],
+                         assignments[0].roles)
+        self.assertEqual([], manager.get_assignments_by_principal_id('new_user.id'))
+
+        mapping = {old_id: 'new_user.id'}
+        results = migrate_localroles(self.inbox, mapping, mode='copy')
+
+        self.assertEqual([], results['moved'])
+        self.assertEqual(
+            [('/plone/eingangskorb', old_id, 'new_user.id')],
+            results['copied'])
+        self.assertEqual([], results['deleted'])
+
+        assignments = manager.get_assignments_by_principal_id(old_id)
+        self.assertEqual(1, len(assignments))
+        self.assertEqual(['Contributor', 'Editor', 'Reader'],
+                         assignments[0].roles)
+        assignments = manager.get_assignments_by_principal_id('new_user.id')
+        self.assertEqual(1, len(assignments))
+        self.assertEqual(['Contributor', 'Editor', 'Reader'],
+                         assignments[0].roles)
+
+    def test_migrate_local_roles_of_multiple_users_on_plone_site(self):
+        self.login(self.manager)
+        old_secretariat_id = self.secretariat_user.getId()
+        old_user_id = self.regular_user.getId()
+        old_administrator_id = self.administrator.getId()
+
+        mapping = {
+            old_secretariat_id: 'new_secretariat_id',
+            old_administrator_id: 'new_administrator_id',
+            old_user_id: 'new_user_id'
+        }
+        results = migrate_localroles(self.portal, mapping)
+        self.assertEqual([], results['copied'])
+        self.assertEqual([], results['deleted'])
+        moved = results['moved']
+        self.assertItemsEqual(
+            moved, set(moved),
+            "Items should only appear once in migration statistics.")
+
+        self.assertIn(
+            ('/plone/ordnungssystem', old_secretariat_id, 'new_secretariat_id'),
+            moved)
+        manager = RoleAssignmentManager(self.repository_root)
+        assignments = manager.get_assignments_by_principal_id('new_secretariat_id')
+        self.assertEqual(1, len(assignments))
+        self.assertEqual(['Reviewer', 'Publisher'],
+                         assignments[0].roles)
+
+        self.assertIn(
+            ('/plone/vorlagen', old_administrator_id, 'new_administrator_id'),
+            moved)
+        manager = RoleAssignmentManager(self.templates)
+        assignments = manager.get_assignments_by_principal_id('new_administrator_id')
+        self.assertEqual(1, len(assignments))
+        self.assertEqual(['Reader', 'Contributor', 'Editor'],
+                         assignments[0].roles)
+        self.assertIn(
+            'user:new_administrator_id',
+            index_data_for(self.templates)['allowedRolesAndUsers'])
+
+        self.assertIn(
+            ('/plone/vorlagen/vorlagen-neu', old_administrator_id, 'new_administrator_id'),
+            moved)
+        manager = RoleAssignmentManager(self.subtemplates)
+        assignments = manager.get_assignments_by_principal_id('new_administrator_id')
+        self.assertEqual(1, len(assignments))
+        self.assertEqual(['Reader', 'Contributor', 'Editor'],
+                         assignments[0].roles)
+        self.assertIn(
+            'user:new_administrator_id',
+            index_data_for(self.subtemplates)['allowedRolesAndUsers'])
+
+        self.assertIn(
+            ('/plone/opengever-meeting-committeecontainer', old_administrator_id, 'new_administrator_id'),
+            moved)
+        manager = RoleAssignmentManager(self.committee_container)
+        assignments = manager.get_assignments_by_principal_id('new_administrator_id')
+        self.assertEqual(1, len(assignments))
+        self.assertEqual(['CommitteeAdministrator'],
+                         assignments[0].roles)
+        self.assertIn(
+            'user:new_administrator_id',
+            index_data_for(self.committee_container)['allowedRolesAndUsers'])
+
+        self.assertIn(
+            ('/plone/eingangskorb', old_secretariat_id, 'new_secretariat_id'),
+            moved)
+        manager = RoleAssignmentManager(self.inbox)
+        assignments = manager.get_assignments_by_principal_id('new_secretariat_id')
+        self.assertEqual(1, len(assignments))
+        self.assertEqual(['Contributor', 'Editor', 'Reader'],
+                         assignments[0].roles)
+        self.assertIn(
+            'user:new_secretariat_id',
+            index_data_for(self.inbox)['allowedRolesAndUsers'])
+
+        self.assertIn(
+            ('/plone/private/kathi-barfuss', old_user_id, 'new_user_id'),
+            moved)
+        manager = RoleAssignmentManager(self.private_folder)
+        assignments = manager.get_assignments_by_principal_id('new_user_id')
+        self.assertEqual(1, len(assignments))
+        self.assertEqual(['Publisher', 'Contributor', 'Reader', 'Owner',
+                          'Reviewer', 'Editor'],
+                         assignments[0].roles)
+        self.assertIn(
+            'user:new_user_id',
+            index_data_for(self.private_folder)['allowedRolesAndUsers'])


### PR DESCRIPTION
Wit this PR we customize the local roles migrator from `ftw.usermigration` as implemented in https://github.com/4teamwork/ftw.usermigration/blob/9fc23a52dc6e3c95b10e89e6c2d043663cd650dd/ftw/usermigration/localroles.py#L26-L47.

We only allow setting local roles via `RoleAssignmentManager` as of https://github.com/4teamwork/opengever.core/pull/4551 and no longer allow setting them directly via the management methods of plone/zope. The package `ftw.usermigration` was using these methods, however. This lead to an error when attempting to migrate.

With this PR we adapt the local role migration to migrate all local roles set via `RoleAssignmentManager`. This includes roles assigned via sharing, but also includes automatic roles assigned by the systems. As far as i could see they are not migrated otherwise, on the contrary there is a comment that indicates we are expecting that `ftw.usermigration` is taking care of that for us: https://github.com/4teamwork/opengever.core/blob/5c2f9485d7c83a7f29e79c28d1df06234119de0a/opengever/usermigration/plone_tasks.py#L22-L23

For the implementation i added a customized version of the migration method from `ftw.usermigration` to `opengever.core`, then overriding the simple registry in `ftw.usermigration` with the new method. If we need further customizations we can think about using a proper adapter  in `ftw.usermigration`, overriding if from `opengever.core`. I thought that to be out of scope for now.

https://4teamwork.atlassian.net/browse/GEVER-120 and #5713

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [ ] Documentation updated (notably for API and deployment)
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
