### PR TITLE
Support placeholders in the target url of the webactions.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2020.3.0rc4 (unreleased)
 ------------------------
 
+- Support placeholders in the target url of the webactions. [mbaechtold]
 - Fix the upgradestep to merge notification settings from release 2020.3.0rc2 to use it's own configruation copy to not depend on future adjustments. [elioschmutz]
 - Add @extract-attachments endpoint to extract mail attachments. [njohner]
 - Only allow to extract each mail attachment once. [njohner]

--- a/docs/public/dev-manual/api/webactions.rst
+++ b/docs/public/dev-manual/api/webactions.rst
@@ -311,7 +311,8 @@ Folgend ist eine Auflistung aller von Webaktionen unterstützten Felder und dere
 | ``unique_name`` | String, optional              | Eindeutiger, vom Ersteller der Webaktion kontrollierter Name                |
 |                 |                               | (siehe :ref:`Eindeutiger Name <webactions-unique-name>` )                   |
 +-----------------+-------------------------------+-----------------------------------------------------------------------------+
-| ``target_url``  | String, obligatorisch         | Ziel-URL auf den Endpoint der Drittanwendung                                |
+| ``target_url``  | String, obligatorisch         | Ziel-URL auf den Endpoint der Drittanwendung mit optionalen Platzhaltern    |
+|                 |                               | für die Querystring-Parameter (siehe :ref:`Ziel-URL <target-url>` )         |
 +-----------------+-------------------------------+-----------------------------------------------------------------------------+
 | ``enabled``     | Boolean, optional             | Kann verwendet werden, um registrierte WebActions temporär zu deaktivieren, |
 |                 |                               | i.e. wenn kein Wert gesetzt ist, wird die Webaktion als aktiviert behandelt.|
@@ -499,3 +500,49 @@ antwortet der Server mit ``400 Bad Request``:
      "type": "BadRequest",
      "message": "[('unique_name', ActionAlreadyExists(\"An action with the unique_name u'existing-unique-name' already exists\",))]"
    }
+
+
+.. _target-url:
+
+Ziel-URL
+--------
+
+Wenn die Webaktionen an ihrem Darstellungsort in GEVER angezeigt werden, werden
+der Ziel-URL zwei Querystring-Parameter angehängt:
+
+- `context`: Die URL des Inhaltsobjekts, auf welchem die Webaktion angezeigt wird
+- `orgunit`: Die ID (Kürzel) der aktuellen Organisationseinheit
+
+Beim Anlegen oder Aktualisieren von Webactions können in der Ziel-URL weitere
+Querystring-Parameter definiert werden, deren Wert als ein Platzhalter
+betrachtet wird, welcher bei der Anzeige der Webaktion durch die richtigen
+Werte ersetzt werden.
+
+**Request**:
+
+.. sourcecode:: http
+
+  POST /@webactions HTTP/1.1
+  Accept: application/json
+  Content-Type: application/json
+
+  {
+    "title": "Open in ExternalApp",
+    "target_url": "http://example.org/endpoint?geverid={uid}",
+    "display": "actions-menu",
+    "mode": "self",
+    "order": 0,
+    "scope": "global"
+  }
+
+Bei der Anzeige der Webaktion im Menu «Aktionen» auf dem Inhaltsobjekt
+`http://gever/dossier1` wird der Platzhalter `{uid}` durch den richtigen Wert
+ersetzt und die standardmässigen Querystring-Parameter angehängt. Der Link der
+Webaction wäre in diesem Fall also
+`http://example.org/endpoint?geverid=0d12c12a9d4f43e78eba39da93c0080c&context=http://gever/dossier1&orgunit=direktion`.
+
+Unterstützte Platzhalter (case-sensitiv):
+
+- `{intid}`: Die GEVER-interne numerische ID eines Inhaltsobjekts
+- `{uid}`: Die GEVER-interne UID eines Inhaltsobjekts
+- `{path}`: Der Pfad eines Inhaltsobjekts im GEVER-Objektbaum

--- a/opengever/webactions/exceptions.py
+++ b/opengever/webactions/exceptions.py
@@ -15,3 +15,14 @@ class UnknownField(ValidationError):
 class InvalidBase64DataURI(InvalidURI):
     """The given URI is not a valid data URI using Base64 encoding.
     """
+
+
+class ForbiddenTargetUrlParam(ValidationError):
+    """The target url contains an invalid query parameter, e.g. a query
+    parameter which is already appended to the target url by default.
+    """
+
+
+class UnsupportedTargetUrlPlaceholder(ValidationError):
+    """The target url contains unsupported placeholders in the querystring.
+    """

--- a/opengever/webactions/tests/test_webactions_renderer.py
+++ b/opengever/webactions/tests/test_webactions_renderer.py
@@ -2,7 +2,13 @@ from ftw.builder import Builder
 from ftw.builder import create
 from opengever.testing import IntegrationTestCase
 from opengever.webactions.interfaces import IWebActionsRenderer
+from opengever.webactions.renderer import WebActionsSafeDataGetter
+from opengever.webactions.storage import ALLOWED_QUERY_PLACEHOLDERS
+from opengever.webactions.storage import DEFAULT_QUERY_PARAMS
+from plone.uuid.interfaces import IUUID
 from urllib import urlencode
+from urlparse import parse_qs
+from urlparse import urlparse
 from zope.component import getMultiAdapter
 
 
@@ -62,3 +68,124 @@ class TestWebActionRendererActionButtons(TestWebActionRendererTitleButtons):
             'class="webaction_button fa fa-helicopter">'
             '<span class="subMenuTitle actionText">Action 2</span></a>'.format(
               urlencode(params))]
+
+
+class TestWebActionRendererTargetUrl(IntegrationTestCase):
+    display = 'actions-menu'
+
+    def _get_querystring_params(self):
+        data_getter = WebActionsSafeDataGetter(self.dossier, self.request,
+                                               self.display)
+
+        data = data_getter.get_webactions_data()
+        target_url = data['actions-menu'][0]['target_url']
+        return parse_qs(urlparse(target_url).query)
+
+    def test_default_querystring_parameter(self):
+        create(Builder('webaction')
+               .having(display=self.display))
+        self.login(self.regular_user)
+        query = self._get_querystring_params()
+        self.assertEqual(2, len(query))
+        self.assertEqual(
+            ['fa'],
+            query['orgunit']
+        )
+        self.assertEqual(
+            [self.dossier.absolute_url()],
+            query['context']
+        )
+
+    def test_target_url_querystring_placeholder_uid(self):
+        create(Builder('webaction')
+               .having(target_url='http://localhost/foo?geverid={uid}'), display=self.display)
+        self.login(self.regular_user)
+        query = self._get_querystring_params()
+        self.assertEqual(
+            [IUUID(self.dossier)],
+            query['geverid']
+        )
+
+    def test_target_url_querystring_placeholder_path(self):
+        create(Builder('webaction')
+               .having(target_url='http://localhost/foo?location={path}'), display=self.display)
+        self.login(self.regular_user)
+        query = self._get_querystring_params()
+        self.assertEqual(
+            ['/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1'],
+            query['location']
+        )
+
+    def test_target_url_querystring_placeholder_intid(self):
+        create(Builder('webaction')
+               .having(target_url='http://localhost/foo?geverid={intid}'), display=self.display)
+        self.login(self.regular_user)
+        query = self._get_querystring_params()
+        self.assertEqual(
+            ['1014013300'],
+            query['geverid']
+        )
+
+    def test_target_url_query_param_escapes_html(self):
+        create(Builder('webaction')
+               .having(target_url='http://localhost/foo?some<html>thing={intid}&evil=<script>'), display=self.display)
+        self.login(self.regular_user)
+        data_getter = WebActionsSafeDataGetter(
+            self.dossier, self.request, self.display
+        )
+
+        data = data_getter.get_webactions_data()
+        target_url = data['actions-menu'][0]['target_url']
+
+        self.assertEqual(
+            'http://localhost/foo'
+            '?some%26lt%3Bhtml%26gt%3Bthing=1014013300'
+            '&evil=%26lt%3Bscript%26gt%3B'
+            '&context=http%3A%2F%2Fnohost%2Fplone%2Fordnungssystem%2Ffuhrung%2Fvertrage-und-vereinbarungen%2Fdossier-1'
+            '&orgunit=fa',
+            target_url
+        )
+
+    def test_target_url_renderer_knows_all_default_query_params(self):
+        """
+        This test makes sure that a developer does not forget to update the
+        implementation when new default query parameters are added (and vice
+        versa).
+        """
+        self.login(self.regular_user)
+        data_getter = WebActionsSafeDataGetter(
+            self.dossier, self.request, self.display
+        )
+        self.assertEqual(
+            DEFAULT_QUERY_PARAMS,
+            data_getter._get_default_webaction_parameters().keys(),
+            msg='The config "DEFAULT_QUERY_PARAMS" is out of sync with the implementation.',
+        )
+
+    def test_adding_webaction_with_all_allowed_params(self):
+        """
+        This test makes sure that a developer does not forget to update the
+        implementation when new allowed query placeholder are added (and vice
+        versa).
+        """
+        params = ["{}={}".format(name, value) for name, value in enumerate(ALLOWED_QUERY_PLACEHOLDERS, 1)]
+        create(Builder('webaction')
+               .having(target_url='http://localhost/foo?' + '&'.join(params)), display=self.display)
+        self.login(self.regular_user)
+        data_getter = WebActionsSafeDataGetter(
+            self.dossier, self.request, self.display
+        )
+
+        data = data_getter.get_webactions_data()
+        target_url = data['actions-menu'][0]['target_url']
+
+        self.assertEqual(
+            'http://localhost/foo'
+            '?1=1014013300'  # intid
+            '&3=createtreatydossiers000000000001'  # uid
+            '&2=%2Fplone%2Fordnungssystem%2Ffuhrung%2Fvertrage-und-vereinbarungen%2Fdossier-1'  # path
+            '&context=http%3A%2F%2Fnohost%2Fplone%2Fordnungssystem%2Ffuhrung%2Fvertrage-und-vereinbarungen%2Fdossier-1'
+            '&orgunit=fa',
+            target_url,
+            msg='The config "ALLOWED_QUERY_PLACEHOLDERS" is out of sync with the implementation.',
+        )


### PR DESCRIPTION
This pull request adds support for placeholder in the target urls of the webactions. The placeholders will be replaced with their actual value when the target url is rendered in GEVER.

Until now, the two query params `context` and `orgunit` were appended to the target url unconditionally. This feature is kept, but the creators of the webaction may chose to request more data (`uid`, `intid` and `path`).

Belongs to Jira issue [GEVER-147](https://4teamwork.atlassian.net/browse/GEVER-147).

## Checklist

- [x] Changelog entry
- [x] Documentation updated (notably for API and deployment)
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)