### PR TITLE
Avoid object lookup in DocumentLinkWidget for Solr documents

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 ------------------------
 
 - Rename @team API endpoint to @teams. [tinagerber]
-- Avoid object lookup in DocumentLinkWidget for catalog brains. [buchi]
+- Avoid object lookup in DocumentLinkWidget for Solr documents and catalog brains. [buchi]
 - Improve contenttree widget in handling a large amount of items. [buchi]
 - Rename @ogds-user API endpoint to @ogds-users. [tinagerber]
 

--- a/opengever/document/widgets/document_link.py
+++ b/opengever/document/widgets/document_link.py
@@ -1,3 +1,4 @@
+from opengever.base.interfaces import IOGSolrDocument
 from plone import api
 from plone.app.contentlisting.interfaces import IContentListingObject
 from Products.ZCatalog.interfaces import ICatalogBrain
@@ -40,8 +41,9 @@ class DocumentLinkWidget(object):
         return self.template(self, self.request)
 
     def is_view_allowed(self):
-        # Avoid object lookup for catalog brains as catalog searches are
-        # security aware anyway.
-        if ICatalogBrain.providedBy(self.context.getDataOrigin()):
+        # Avoid object lookup for Solr documents and catalog brains as those
+        # are security aware anyway.
+        origin = self.context.getDataOrigin()
+        if IOGSolrDocument.providedBy(origin) or ICatalogBrain.providedBy(origin):
             return True
         return api.user.has_permission('View', obj=self.context.getObject())


### PR DESCRIPTION
Related to #6458

Doing a permission check for Solr documents is needless as Solr searches are security aware anyway.

This improves the performance of the documents tab.

Jira: https://4teamwork.atlassian.net/browse/GEVER-374

## Checklist (Must have)
- [x] Changelog entry
- [x] Documentation updated (notably for API and deployment)
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
