### PR TITLE
Fix MergeNotificationSettings upgradestep to use a fixed configuration

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2020.3.0rc4 (unreleased)
 ------------------------
 
+- Fix the upgradestep to merge notification settings from release 2020.3.0rc2 to use it's own configruation copy to not depend on future adjustments. [elioschmutz]
 - Rename @team API endpoint to @teams. [tinagerber]
 - Avoid object lookup in DocumentLinkWidget for Solr documents and catalog brains. [buchi]
 - Improve contenttree widget in handling a large amount of items. [buchi]

--- a/opengever/activity/hooks.py
+++ b/opengever/activity/hooks.py
@@ -18,3 +18,5 @@ def insert_notification_defaults(site):
                 default_settings.get('mail_notification_roles', []))
         setattr(setting, 'badge_notification_roles',
                 default_settings.get('badge_notification_roles', []))
+        setattr(setting, 'digest_notification_roles',
+                default_settings.get('digest_notification_roles', []))

--- a/opengever/core/upgrades/20200430153116_merge_notification_settings/upgrade.py
+++ b/opengever/core/upgrades/20200430153116_merge_notification_settings/upgrade.py
@@ -231,6 +231,8 @@ class MergeNotificationSettings(SchemaMigration):
                     default_settings.get('mail_notification_roles', []))
             setattr(setting, 'badge_notification_roles',
                     default_settings.get('badge_notification_roles', []))
+            setattr(setting, 'digest_notification_roles',
+                    default_settings.get('digest_notification_roles', []))
 
     def migrate_custom_settings(self):
         # Get a list of distinct userids of users that have any settings stored

--- a/opengever/core/upgrades/20200430153116_merge_notification_settings/upgrade.py
+++ b/opengever/core/upgrades/20200430153116_merge_notification_settings/upgrade.py
@@ -1,9 +1,17 @@
-from opengever.activity.model import NotificationSetting
 from opengever.activity.model import NotificationDefault
-from opengever.activity.hooks import insert_notification_defaults
+from opengever.activity.model import NotificationSetting
 from opengever.activity.notification_settings import NotificationSettings
+from opengever.activity.roles import COMMITTEE_RESPONSIBLE_ROLE
+from opengever.activity.roles import DISPOSITION_ARCHIVIST_ROLE
+from opengever.activity.roles import DISPOSITION_RECORDS_MANAGER_ROLE
+from opengever.activity.roles import DOSSIER_RESPONSIBLE_ROLE
+from opengever.activity.roles import PROPOSAL_ISSUER_ROLE
+from opengever.activity.roles import TASK_ISSUER_ROLE
+from opengever.activity.roles import TASK_REMINDER_WATCHER_ROLE
+from opengever.activity.roles import TASK_RESPONSIBLE_ROLE
+from opengever.activity.roles import TODO_RESPONSIBLE_ROLE
+from opengever.activity.roles import WORKSPACE_MEMBER_ROLE
 from opengever.core.upgrade import SchemaMigration
-from plone import api
 
 
 CHANNELS = (
@@ -12,27 +20,225 @@ CHANNELS = (
     'digest_notification_roles',
 )
 
+NOTIFICATION_CONFIGURATION = [
+    {
+        'id': 'task-added-or-reassigned',
+        'activities': ['task-added',
+                       'task-transition-reassign',
+                       'forwarding-added',
+                       'forwarding-transition-reassign',
+                       'forwarding-transition-reassign-refused',
+                       ],
+        'default_settings': {
+            'badge_notification_roles': [TASK_RESPONSIBLE_ROLE, TASK_ISSUER_ROLE],
+            'mail_notification_roles': [TASK_RESPONSIBLE_ROLE],
+        },
+    },
+    {
+        'id': 'task-transition-modify-deadline',
+        'activities': ['task-transition-modify-deadline'],
+        'default_settings': {
+            'badge_notification_roles': [TASK_RESPONSIBLE_ROLE, TASK_ISSUER_ROLE],
+        },
+    },
+    {
+        'id': 'task-commented',
+        'activities': ['task-commented'],
+        'default_settings': {
+            'badge_notification_roles': [TASK_RESPONSIBLE_ROLE, TASK_ISSUER_ROLE],
+        },
+    },
+    {
+        'id': 'task-status-modified',
+        'activities': ['task-transition-cancelled-open',
+                       'task-transition-rejected-open',
+                       'task-transition-skipped-open',
+                       'task-transition-planned-skipped',
+                       'task-transition-delegate',
+                       'task-transition-in-progress-resolved',
+                       'task-transition-open-resolved',
+                       'task-transition-in-progress-tested-and-closed',
+                       'task-transition-open-cancelled',
+                       'task-transition-open-in-progress',
+                       'task-transition-open-rejected',
+                       'task-transition-resolved-in-progress',
+                       'task-transition-open-tested-and-closed',
+                       'task-transition-resolved-tested-and-closed',
+                       'task-transition-rejected-skipped',
+                       'forwarding-transition-accept',
+                       'forwarding-transition-assign-to-dossier',
+                       'forwarding-transition-close',
+                       'forwarding-transition-refuse',
+                       ],
+        'default_settings': {
+            'badge_notification_roles': [TASK_RESPONSIBLE_ROLE, TASK_ISSUER_ROLE],
+        },
+    },
+    {
+        'id': 'proposal-transition-reject',
+        'activities': ['proposal-transition-reject'],
+        'default_settings': {
+            'badge_notification_roles': [PROPOSAL_ISSUER_ROLE],
+        }
+    },
+    {
+        'id': 'proposal-transition-schedule',
+        'activities': ['proposal-transition-schedule'],
+        'default_settings': {
+            'badge_notification_roles': [PROPOSAL_ISSUER_ROLE],
+        }
+    },
+    {
+        'id': 'proposal-transition-pull',
+        'activities': ['proposal-transition-pull'],
+        'default_settings': {
+            'badge_notification_roles': [PROPOSAL_ISSUER_ROLE],
+        }
+    },
+    {
+        'id': 'proposal-transition-decide',
+        'activities': ['proposal-transition-decide'],
+        'default_settings': {
+            'badge_notification_roles': [PROPOSAL_ISSUER_ROLE],
+        }
+    },
+    {
+        'id': 'proposal-transition-submit',
+        'activities': ['proposal-transition-submit'],
+        'default_settings': {
+            'badge_notification_roles': [COMMITTEE_RESPONSIBLE_ROLE],
+        }
+    },
+    {
+        'id': 'proposal-commented',
+        'activities': ['proposal-commented'],
+        'default_settings': {
+            'badge_notification_roles': [PROPOSAL_ISSUER_ROLE,
+                                         COMMITTEE_RESPONSIBLE_ROLE],
+        }
+    },
+    {
+        'id': 'proposal-attachment-updated',
+        'activities': ['proposal-attachment-updated'],
+        'default_settings': {
+            'badge_notification_roles': [COMMITTEE_RESPONSIBLE_ROLE]
+        }
+    },
+    {
+        'id': 'proposal-additional-documents-submitted',
+        'activities': ['proposal-additional-documents-submitted'],
+        'default_settings': {
+            'badge_notification_roles': [COMMITTEE_RESPONSIBLE_ROLE]
+        }
+    },
+    {
+        'id': 'task-reminder',
+        'activities': ['task-reminder'],
+        'default_settings': {
+            'badge_notification_roles': [TASK_REMINDER_WATCHER_ROLE],
+        }
+    },
+    {
+        'id': 'disposition-added',
+        'activities': ['disposition-added'],
+        'default_settings': {
+            'badge_notification_roles': [DISPOSITION_RECORDS_MANAGER_ROLE, DISPOSITION_ARCHIVIST_ROLE],
+            'mail_notification_roles': [DISPOSITION_ARCHIVIST_ROLE],
+        }
+    },
+    {
+        'id': 'disposition-transition-appraise',
+        'activities': ['disposition-transition-appraise'],
+        'default_settings': {
+            'badge_notification_roles': [DISPOSITION_RECORDS_MANAGER_ROLE, DISPOSITION_ARCHIVIST_ROLE],
+        }
+    },
+    {
+        'id': 'disposition-transition-archive',
+        'activities': ['disposition-transition-archive'],
+        'default_settings': {
+            'badge_notification_roles': [DISPOSITION_RECORDS_MANAGER_ROLE, DISPOSITION_ARCHIVIST_ROLE],
+        }
+    },
+    {
+        'id': 'disposition-transition-dispose',
+        'activities': ['disposition-transition-dispose'],
+        'default_settings': {
+            'badge_notification_roles': [DISPOSITION_RECORDS_MANAGER_ROLE, DISPOSITION_ARCHIVIST_ROLE],
+        }
+    },
+    {
+        'id': 'disposition-transition-refuse',
+        'activities': ['disposition-transition-refuse'],
+        'default_settings': {
+            'badge_notification_roles': [DISPOSITION_RECORDS_MANAGER_ROLE, DISPOSITION_ARCHIVIST_ROLE],
+        }
+    },
+    {
+        'id': 'disposition-transition-close',
+        'activities': [
+            'disposition-transition-close',
+            'disposition-transition-appraised-to-closed'],
+        'default_settings': {
+            'badge_notification_roles': [DISPOSITION_RECORDS_MANAGER_ROLE, DISPOSITION_ARCHIVIST_ROLE],
+        }
+    },
+    {
+        'id': 'dossier-overdue',
+        'activities': ['dossier-overdue'],
+        'default_settings': {
+            'badge_notification_roles': [DOSSIER_RESPONSIBLE_ROLE],
+        }
+    },
+    {
+        'id': 'todo-assigned',
+        'activities': ['todo-assigned'],
+        'default_settings': {
+            'badge_notification_roles': [TODO_RESPONSIBLE_ROLE],
+            'digest_notification_roles': [WORKSPACE_MEMBER_ROLE],
+        }
+    },
+    {
+        'id': 'todo-modified',
+        'activities': ['todo-modified'],
+        'default_settings': {
+            'badge_notification_roles': [TODO_RESPONSIBLE_ROLE],
+            'digest_notification_roles': [WORKSPACE_MEMBER_ROLE],
+        }
+    },
+]
+
 
 class MergeNotificationSettings(SchemaMigration):
     """Merge notification settings.
     """
     def migrate(self):
+        self.notification_settings = NotificationSettings(NOTIFICATION_CONFIGURATION)
         self.migrate_default_settings()
         self.migrate_custom_settings()
 
     def migrate_default_settings(self):
+        # Remove all notification defaults
         NotificationDefault.query.delete()
-        insert_notification_defaults(api.portal.get())
+
+        # Re-add the new notification defaults
+        for item in self.notification_settings.configuration:
+            setting = NotificationDefault(kind=item.get('id'))
+            self.session.add(setting)
+
+            default_settings = item.get('default_settings')
+            setattr(setting, 'mail_notification_roles',
+                    default_settings.get('mail_notification_roles', []))
+            setattr(setting, 'badge_notification_roles',
+                    default_settings.get('badge_notification_roles', []))
 
     def migrate_custom_settings(self):
-        notification_settings = NotificationSettings()
-
         # Get a list of distinct userids of users that have any settings stored
         users_with_settings = [
             r[0] for r in self.session.query(NotificationSetting.userid.distinct())
         ]
 
-        for config in notification_settings.configuration:
+        for config in self.notification_settings.configuration:
             notification_setting_kind = config.get('id')
             activities = config.get('activities')
 
@@ -76,7 +282,7 @@ class MergeNotificationSettings(SchemaMigration):
         custom_settings_for_activities.delete(synchronize_session='fetch')
 
         # Add the new setting
-        NotificationSettings().set_custom_setting(
+        self.notification_settings.set_custom_setting(
             notification_setting_kind, userid,
             mail_roles=merged_settings.get('mail_notification_roles', []),
             badge_roles=merged_settings.get('badge_notification_roles', []),


### PR DESCRIPTION
The `MergeNotificationSettings` relies on the main notification configuration which leads to issues when upgrading multiple upgradesteps changing the notification defaults.

This PR uses a static configuration for the `MergeNotificationSettings` upgradestep` to fix this issue.

I manually updated the dev.onegovgever.ch ogds with:

```sql
update notification_defaults set digest_notification_roles='["workspace_member_role"]' where id=173;
update notification_defaults set digest_notification_roles='["workspace_member_role"]' where id=174;
```

to add the missing digest configuration.