### PR TITLE
Fix missing solr config for multi-admin setup

### DIFF
--- a/development-multi-admin.cfg
+++ b/development-multi-admin.cfg
@@ -14,7 +14,8 @@ eggs +=
 zcml-additional =
    <configure
        xmlns="http://namespaces.zope.org/zope"
-       xmlns:db="http://namespaces.zope.org/db">
+       xmlns:db="http://namespaces.zope.org/db"
+       xmlns:solr="http://namespaces.plone.org/solr">
 
        <include package="z3c.saconfig" file="meta.zcml" />
 
@@ -24,4 +25,6 @@ zcml-additional =
        <db:engine name="opengever.db"
          url="${buildout:ogds-dsn}" pool_recycle="3600" />
        <db:session name="opengever" engine="opengever.db" />
+
+       ${buildout:solr-zcml}
    </configure>


### PR DESCRIPTION
Because we override the `zcml-additional` variable in the `development-multi-admin.cfg` we have to manually include the solr-configuration to get a working solr-config.

How to reproduce:

Run a multi-admin unit instance with the `development-multi-admin.cfg` and try to activate solr. 