### PR TITLE
Add "bumblebee_app_id" to the @config API endpoint.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2020.3.0rc4 (unreleased)
 ------------------------
 
+- Add `bumblebee_app_id` to the `@config` API endpoint. [mbaechtold]
 - Bump ftw.solr to 2.8.6 to get logging improvements and filter helpers. [lgraf]
 - Support placeholders in the target url of the webactions. [mbaechtold]
 - Fix the upgradestep to merge notification settings from release 2020.3.0rc2 to use it's own configruation copy to not depend on future adjustments. [elioschmutz]

--- a/docs/public/dev-manual/api/config.rst
+++ b/docs/public/dev-manual/api/config.rst
@@ -22,6 +22,7 @@ GEVER-Mandanten abgefragt werden.
 
       {
           "@id": "http://localhost:8080/fd/@config",
+          "bumblebee_app_id": "gever_dev",
           "cas_url": "https://cas.server.net/",
           "features": {
               "activity": true,

--- a/opengever/api/config.py
+++ b/opengever/api/config.py
@@ -1,3 +1,4 @@
+from ftw.bumblebee.config import bumblebee_config
 from opengever.base import utils
 from opengever.base.interfaces import IGeverSettings
 from opengever.officeconnector.helpers import is_client_ip_in_office_connector_disallowed_ip_ranges
@@ -23,3 +24,4 @@ class Config(Service):
         """
         config['is_emm_environment'] = is_client_ip_in_office_connector_disallowed_ip_ranges()
         config['is_admin_menu_visible'] = utils.is_administrator()
+        config['bumblebee_app_id'] = bumblebee_config.app_id

--- a/opengever/api/tests/test_config.py
+++ b/opengever/api/tests/test_config.py
@@ -188,3 +188,14 @@ class TestConfig(IntegrationTestCase):
         browser.open(url, headers=self.api_headers)
         self.assertEqual(browser.status_code, 200)
         self.assertFalse(browser.json.get(u'is_admin_menu_visible'))
+
+    @browsing
+    def test_config_contains_bumblebee_app_id(self, browser):
+        self.login(self.regular_user, browser)
+        url = self.portal.absolute_url() + '/@config'
+        browser.open(url, headers=self.api_headers)
+        self.assertEqual(browser.status_code, 200)
+        self.assertEqual(
+            'local',
+            browser.json.get(u'bumblebee_app_id')
+        )


### PR DESCRIPTION
Right now, the Bumblebee preview does not work in the new GEVER UI, if two GEVER are deployed under the same domain because it fetches the Bumblebee cookie only when no cookie is present. The cookie it got from the first deployment is not respected by the second deployment causing the preview to fail (a "missing" image is rendered instead).

See the Jira issue for a detailed explanation of the problem.

⚠️ Requires https://github.com/4teamwork/gever-ui/pull/1116

Belongs to Jira Issue [GEVER-427](https://4teamwork.atlassian.net/browse/GEVER-427)

## Checklist (Must have)

- [x] Changelog entry
- [x] Documentation updated (notably for API and deployment)
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)