### PR TITLE
Allow notifying users and groups when creating a new task.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2020.3.0rc5 (unreleased)
 ------------------------
 
+- Allow notifying users and groups when creating a new task. [njohner]
 - Enable API endpoint `@document-from-template` for tasks. [mbaechtold]
 
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2020.3.0rc5 (unreleased)
 ------------------------
 
+- Fix bug with setting issuer and informed_principals on forwardings. [njohner]
 - Allow notifying users and groups when creating a new task. [njohner]
 - Enable API endpoint `@document-from-template` for tasks. [mbaechtold]
 

--- a/docs/public/user-manual/aufgaben/erstellen.rst
+++ b/docs/public/user-manual/aufgaben/erstellen.rst
@@ -72,6 +72,10 @@ Reiter Allgemein
    *Dokumente* erzeugt, sind die ausgewählten Dokumente bereits als
    Verweise aufgeführt.
 
+8. **Info an:** Die ausgewählten Benutzer und Gruppen werden über die
+   Erstellung dieser Aufgabe benachrichtigt.
+
+
 Reiter Erweitert
 ~~~~~~~~~~~~~~~~
 

--- a/docs/schema-dumps/opengever.task.task.schema.json
+++ b/docs/schema-dumps/opengever.task.task.schema.json
@@ -47,6 +47,13 @@
             "_zope_schema_type": "Choice",
             "_vocabulary": "<User-ID eines g\u00fcltigen Auftragnehmers>"
         },
+        "informed_principals": {
+            "type": "array",
+            "title": "Info an",
+            "description": "Die ausgew\u00e4hlten Benutzer und Gruppen werden \u00fcber die Erstellung dieser Aufgabe benachrichtigt.",
+            "_zope_schema_type": "List",
+            "default": []
+        },
         "is_private": {
             "type": "boolean",
             "title": "Pers\u00f6nliche Aufgabe",
@@ -146,6 +153,7 @@
         "task_type",
         "responsible_client",
         "responsible",
+        "informed_principals",
         "is_private",
         "revoke_permissions",
         "deadline",

--- a/opengever/activity/center.py
+++ b/opengever/activity/center.py
@@ -58,12 +58,15 @@ class NotificationCenter(object):
     def fetch_watcher(self, actorid):
         return Watcher.query.get_by_actorid(actorid)
 
-    def add_watcher_to_resource(self, oguid, userid, role=WATCHER_ROLE):
+    def add_watcher_to_resource(self, oguid, userid, role=WATCHER_ROLE,
+                                omit_watcher_added_event=False):
         resource = self.fetch_resource(oguid)
         if not resource:
             resource = self.add_resource(oguid)
 
         resource.add_watcher(userid, role)
+        if role == WATCHER_ROLE and not omit_watcher_added_event:
+            notify(WatcherAddedEvent(oguid, userid))
 
     def remove_watcher_from_resource(self, oguid, userid, role):
         watcher = self.fetch_watcher(userid)
@@ -230,9 +233,7 @@ class PloneNotificationCenter(NotificationCenter):
         """The WatcherAddedEvent is fired to prevent circular dependencies."""
         oguid = self._get_oguid_for(obj)
         super(PloneNotificationCenter, self).add_watcher_to_resource(
-            oguid, actorid, role)
-        if role == WATCHER_ROLE and not omit_watcher_added_event:
-            notify(WatcherAddedEvent(oguid, actorid))
+            oguid, actorid, role, omit_watcher_added_event)
 
     def remove_watcher_from_resource(self, obj, userid, role):
         oguid = self._get_oguid_for(obj)

--- a/opengever/activity/center.py
+++ b/opengever/activity/center.py
@@ -225,12 +225,13 @@ class PloneNotificationCenter(NotificationCenter):
             return Oguid.for_object(item)
         return item
 
-    def add_watcher_to_resource(self, obj, actorid, role=WATCHER_ROLE):
+    def add_watcher_to_resource(self, obj, actorid, role=WATCHER_ROLE,
+                                omit_watcher_added_event=False):
         """The WatcherAddedEvent is fired to prevent circular dependencies."""
         oguid = self._get_oguid_for(obj)
         super(PloneNotificationCenter, self).add_watcher_to_resource(
             oguid, actorid, role)
-        if role == WATCHER_ROLE:
+        if role == WATCHER_ROLE and not omit_watcher_added_event:
             notify(WatcherAddedEvent(oguid, actorid))
 
     def remove_watcher_from_resource(self, obj, userid, role):

--- a/opengever/activity/center.py
+++ b/opengever/activity/center.py
@@ -307,7 +307,8 @@ class DisabledNotificationCenter(NotificationCenter):
     def fetch_watcher(self, actorid):
         return None
 
-    def add_watcher_to_resource(self, obj, userid, role):
+    def add_watcher_to_resource(self, obj, userid, role=WATCHER_ROLE,
+                                omit_watcher_added_event=False):
         pass
 
     def remove_watcher_from_resource(self, obj, userid, role):

--- a/opengever/activity/handlers.py
+++ b/opengever/activity/handlers.py
@@ -1,9 +1,9 @@
 from opengever.activity import is_activity_feature_enabled
 from opengever.activity import notification_center
-from opengever.activity.roles import WATCHER_ROLE
-from opengever.inbox.forwarding import IForwarding
 from opengever.inbox.activities import ForwardingWatcherAddedActivity
+from opengever.inbox.forwarding import IForwarding
 from opengever.task.activities import TaskWatcherAddedActivity
+from opengever.task.task import ITask
 from zope.globalrequest import getRequest
 
 
@@ -25,6 +25,6 @@ def log_activity(task, event):
 def notify_watcher(obj, event):
     if IForwarding.providedBy(obj):
         activity = ForwardingWatcherAddedActivity(obj, getRequest(), event.watcherid)
-    else:
+    elif ITask.providedBy(obj):
         activity = TaskWatcherAddedActivity(obj, getRequest(), event.watcherid)
     activity.record()

--- a/opengever/activity/tests/test_notification_center.py
+++ b/opengever/activity/tests/test_notification_center.py
@@ -90,7 +90,8 @@ class TestWatcherHandling(ActivityTestCase):
         peter = create(Builder('watcher').having(actorid='peter'))
         resource = create(Builder('resource').oguid('fd:123'))
 
-        self.center.add_watcher_to_resource(Oguid('fd', '123'), 'peter')
+        self.center.add_watcher_to_resource(
+            Oguid('fd', '123'), 'peter', omit_watcher_added_event=True)
 
         self.assertEquals([peter], list(resource.watchers))
 
@@ -98,23 +99,27 @@ class TestWatcherHandling(ActivityTestCase):
         peter = create(Builder('watcher').having(actorid='peter'))
         resource = create(Builder('resource').oguid('fd:123'))
 
-        self.center.add_watcher_to_resource(Oguid('fd', '123'), 'peter')
-        self.center.add_watcher_to_resource(Oguid('fd', '123'), 'peter')
+        self.center.add_watcher_to_resource(
+            Oguid('fd', '123'), 'peter', omit_watcher_added_event=True)
+        self.center.add_watcher_to_resource(
+            Oguid('fd', '123'), 'peter', omit_watcher_added_event=True)
 
         self.assertEquals([peter], list(resource.watchers))
 
-    def test_add_watcher_to_resource_creates_resource_when_not_exitst(self):
+    def test_add_watcher_to_resource_creates_resource_when_not_exists(self):
         peter = create(Builder('watcher').having(actorid='peter'))
 
-        self.center.add_watcher_to_resource(Oguid('fd', '123'), 'peter')
+        self.center.add_watcher_to_resource(
+            Oguid('fd', '123'), 'peter', omit_watcher_added_event=True)
 
         resource = peter.resources[0]
         self.assertEquals('fd:123', resource.oguid)
 
-    def test_add_watcher_to_resource_creates_watcher_when_not_exitst(self):
+    def test_add_watcher_to_resource_creates_watcher_when_not_exists(self):
         resource = create(Builder('resource').oguid('fd:123'))
 
-        self.center.add_watcher_to_resource(Oguid('fd', '123'), 'peter')
+        self.center.add_watcher_to_resource(
+            Oguid('fd', '123'), 'peter', omit_watcher_added_event=True)
 
         watcher = list(resource.watchers)[0]
         self.assertEquals('peter', watcher.actorid)

--- a/opengever/base/tests/test_default_values_for_types.py
+++ b/opengever/base/tests/test_default_values_for_types.py
@@ -199,6 +199,7 @@ TASK_REQUIREDS = {
 TASK_DEFAULTS = {
     'deadline': FROZEN_TODAY + timedelta(days=5),
     'relatedItems': [],
+    'informed_principals': [],
     'is_private': False,
     'revoke_permissions': True
 }

--- a/opengever/inbox/forwarding.py
+++ b/opengever/inbox/forwarding.py
@@ -9,6 +9,7 @@ from opengever.ogds.base.utils import get_current_org_unit
 from opengever.ogds.base.utils import get_ou_selector
 from opengever.task import _ as task_mf
 from opengever.task.browser.forms import hide_feature_flagged_fields
+from opengever.task.browser.forms import omit_informed_principals
 from opengever.task.task import ITask
 from opengever.task.task import Task
 from opengever.task.util import update_reponsible_field_data
@@ -194,6 +195,7 @@ class ForwardingEditForm(DefaultEditForm):
         _drop_empty_additional_fieldset(self.groups)
 
         hide_feature_flagged_fields(self.groups)
+        omit_informed_principals(self.groups)
 
     def applyChanges(self, data):
         """Records reassign activity when the responsible has changed.

--- a/opengever/inbox/forwarding.py
+++ b/opengever/inbox/forwarding.py
@@ -117,16 +117,16 @@ class ForwardingAddForm(add.DefaultAddForm):
         """
         paths = self.request.get('paths', [])
 
-        search_endpoint = (
-            '++widget++form.widgets.responsible/search'
-            in self.request.get('ACTUAL_URL', '')
-            )
+        search_endpoints = ('++widget++form.widgets.responsible/search',
+                            '++widget++form.widgets.issuer/search',
+                            '++widget++form.widgets.informed_principals/search')
+        is_search_endpoint = any(
+            endpoint in self.request.get('ACTUAL_URL', '') for endpoint in search_endpoints)
 
         if not (
-                search_endpoint
+                is_search_endpoint
                 or paths
-                or self.request.form.get('form.widgets.relatedItems', [])
-            ):
+                or self.request.form.get('form.widgets.relatedItems', [])):
             # add status message and redirect current window back to inbox
             # but ONLY if we're not in a z3cform_inline_validation.
             IStatusMessage(self.request).addStatusMessage(

--- a/opengever/inbox/tests/test_forwarding.py
+++ b/opengever/inbox/tests/test_forwarding.py
@@ -3,7 +3,6 @@ from ftw.builder import create
 from ftw.testbrowser import browsing
 from ftw.testbrowser.pages import statusmessages
 from ftw.testbrowser.pages.factoriesmenu import addable_types
-from ftw.testbrowser.pages.statusmessages import error_messages
 from opengever.ogds.base.utils import get_current_org_unit
 from opengever.testing import IntegrationTestCase
 
@@ -190,3 +189,21 @@ class TestForwarding(IntegrationTestCase):
         self.deactivate_feature('private-tasks')
         browser.open(self.inbox, data, view='++add++opengever.inbox.forwarding')
         self.assertNotIn('Private task', browser.forms['form'].field_labels)
+
+    @browsing
+    def test_informed_principals_is_only_shown_in_add_form_with_activity_enabled(self, browser):
+        self.login(self.manager, browser=browser)
+        data = {'paths': ['/'.join(self.inbox_document.getPhysicalPath())]}
+
+        browser.open(self.inbox, data, view='++add++opengever.inbox.forwarding')
+        self.assertEqual(0, len(browser.css('select#form-widgets-informed_principals')))
+
+        browser.open(self.inbox_forwarding, view='edit')
+        self.assertEqual(0, len(browser.css('select#form-widgets-informed_principals')))
+
+        self.activate_feature('activity')
+        browser.open(self.inbox, data, view='++add++opengever.inbox.forwarding')
+        self.assertEqual(1, len(browser.css('select#form-widgets-informed_principals')))
+
+        browser.open(self.inbox_forwarding, view='edit')
+        self.assertEqual(0, len(browser.css('select#form-widgets-informed_principals')))

--- a/opengever/ogds/base/sources.py
+++ b/opengever/ogds/base/sources.py
@@ -52,6 +52,9 @@ class BaseQuerySoure(object):
     def __len__(self):
         return len(self.terms)
 
+    def __nonzero__(self):
+        return True
+
     def search(self):
         raise NotImplementedError()
 

--- a/opengever/task/activities.py
+++ b/opengever/task/activities.py
@@ -6,6 +6,7 @@ from opengever.activity.base import BaseActivity
 from opengever.activity.model.notification import Notification
 from opengever.activity.roles import TASK_OLD_RESPONSIBLE_ROLE
 from opengever.activity.roles import TASK_REMINDER_WATCHER_ROLE
+from opengever.activity.roles import WATCHER_ROLE
 from opengever.base.model import get_locale
 from opengever.ogds.base.actor import Actor
 from opengever.ogds.base.actor import SYSTEM_ACTOR_ID
@@ -128,6 +129,14 @@ class TaskAddedActivity(BaseTaskActivity):
         self.center.add_task_responsible(self.context,
                                          self.context.responsible)
         self.center.add_task_issuer(self.context, self.context.issuer)
+        for principal in self.context.informed_principals:
+            self.center.add_watcher_to_resource(
+                self.context, principal, omit_watcher_added_event=True)
+
+    def after_recording(self):
+        for principal in self.context.informed_principals:
+            self.center.remove_watcher_from_resource(
+                self.context, principal, WATCHER_ROLE)
 
 
 class TaskWatcherAddedActivity(BaseTaskActivity):

--- a/opengever/task/browser/forms.py
+++ b/opengever/task/browser/forms.py
@@ -38,6 +38,12 @@ def hide_feature_flagged_fields(groups):
         common_group.fields = common_group.fields.omit('revoke_permissions')
 
 
+def omit_informed_principals(groups):
+    common_group = next(
+        group for group in groups if group.__name__ == u'common')
+    common_group.fields = common_group.fields.omit('informed_principals')
+
+
 class TaskAddForm(DefaultAddForm):
 
     def __init__(self, *args, **kwargs):
@@ -165,6 +171,7 @@ class TaskEditForm(DefaultEditForm):
         super(TaskEditForm, self).updateFieldsFromSchemata()
 
         hide_feature_flagged_fields(self.groups)
+        omit_informed_principals(self.groups)
 
     def applyChanges(self, data):
         """Records reassign activity when the responsible has changed.

--- a/opengever/task/browser/forms.py
+++ b/opengever/task/browser/forms.py
@@ -1,11 +1,11 @@
-from opengever.task import is_private_task_feature_enabled
+from opengever.activity import is_activity_feature_enabled
 from opengever.task import is_optional_task_permissions_revoking_enabled
+from opengever.task import is_private_task_feature_enabled
 from opengever.task.activities import TaskReassignActivity
 from opengever.task.task import IAddTaskSchema
 from opengever.task.task import ITask
 from opengever.task.util import add_simple_response
 from opengever.task.util import update_reponsible_field_data
-from opengever.tasktemplates.interfaces import IFromSequentialTasktemplate
 from plone.dexterity.browser.add import DefaultAddForm
 from plone.dexterity.browser.add import DefaultAddView
 from plone.dexterity.browser.edit import DefaultEditForm
@@ -26,6 +26,12 @@ REASSIGN_TRANSITION = 'task-transition-reassign'
 # thus we use an add form hack by injecting the values into the request.
 
 
+def omit_informed_principals(groups):
+    common_group = next(
+        group for group in groups if group.__name__ == u'common')
+    common_group.fields = common_group.fields.omit('informed_principals')
+
+
 def hide_feature_flagged_fields(groups):
     if not is_private_task_feature_enabled():
         common_group = next(
@@ -37,11 +43,8 @@ def hide_feature_flagged_fields(groups):
             group for group in groups if group.__name__ == u'common')
         common_group.fields = common_group.fields.omit('revoke_permissions')
 
-
-def omit_informed_principals(groups):
-    common_group = next(
-        group for group in groups if group.__name__ == u'common')
-    common_group.fields = common_group.fields.omit('informed_principals')
+    if not is_activity_feature_enabled():
+        omit_informed_principals(groups)
 
 
 class TaskAddForm(DefaultAddForm):

--- a/opengever/task/locales/de/LC_MESSAGES/opengever.task.po
+++ b/opengever/task/locales/de/LC_MESSAGES/opengever.task.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2020-05-05 13:15+0000\n"
+"POT-Creation-Date: 2020-05-29 14:07+0000\n"
 "PO-Revision-Date: 2015-02-17 18:41+0100\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -333,6 +333,10 @@ msgstr "Kosten in CHF"
 msgid "help_expectedDuration"
 msgstr "Dauer in h"
 
+#: ./opengever/task/task.py
+msgid "help_informed_principals"
+msgstr "Die ausgewählten Benutzer und Gruppen werden über die Erstellung dieser Aufgabe benachrichtigt."
+
 #. Default: "Deactivates the inbox-group permission."
 #: ./opengever/task/task.py
 msgid "help_is_private"
@@ -505,6 +509,11 @@ msgstr "Geschätzte Dauer (h)"
 #: ./opengever/task/task.py
 msgid "label_expectedStartOfWork"
 msgstr "Beginn der Arbeit"
+
+#. Default: "Info at"
+#: ./opengever/task/task.py
+msgid "label_informed_principals"
+msgstr "Info an"
 
 #. Default: "Private task"
 #: ./opengever/task/task.py

--- a/opengever/task/locales/fr/LC_MESSAGES/opengever.task.po
+++ b/opengever/task/locales/fr/LC_MESSAGES/opengever.task.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2020-05-05 13:15+0000\n"
+"POT-Creation-Date: 2020-05-29 14:07+0000\n"
 "PO-Revision-Date: 2017-12-03 11:47+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-task/fr/>\n"
@@ -334,6 +334,10 @@ msgstr "Coûts effectifs en CHF"
 msgid "help_expectedDuration"
 msgstr "Durée effective en h"
 
+#: ./opengever/task/task.py
+msgid "help_informed_principals"
+msgstr "Les utilisateurs et les groupes séléctionnés seront notifiés de la création de cette tâche."
+
 #. Default: "Deactivates the inbox-group permission."
 #: ./opengever/task/task.py
 msgid "help_is_private"
@@ -507,6 +511,11 @@ msgstr "Durée estimée (h)"
 #: ./opengever/task/task.py
 msgid "label_expectedStartOfWork"
 msgstr "Début du travail"
+
+#. Default: "Info at"
+#: ./opengever/task/task.py
+msgid "label_informed_principals"
+msgstr "Info à"
 
 #. Default: "Private task"
 #: ./opengever/task/task.py

--- a/opengever/task/locales/opengever.task.pot
+++ b/opengever/task/locales/opengever.task.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2020-05-05 13:15+0000\n"
+"POT-Creation-Date: 2020-05-29 14:07+0000\n"
 "PO-Revision-Date: 2009-02-25 14:39+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -333,6 +333,10 @@ msgstr ""
 msgid "help_expectedDuration"
 msgstr ""
 
+#: ./opengever/task/task.py
+msgid "help_informed_principals"
+msgstr ""
+
 #. Default: "Deactivates the inbox-group permission."
 #: ./opengever/task/task.py
 msgid "help_is_private"
@@ -504,6 +508,11 @@ msgstr ""
 #. Default: "Start with work"
 #: ./opengever/task/task.py
 msgid "label_expectedStartOfWork"
+msgstr ""
+
+#. Default: "Info at"
+#: ./opengever/task/task.py
+msgid "label_informed_principals"
 msgstr ""
 
 #. Default: "Private task"

--- a/opengever/task/task.py
+++ b/opengever/task/task.py
@@ -19,6 +19,7 @@ from opengever.dossier.utils import get_main_dossier
 from opengever.globalindex.model.task import Task as TaskModel
 from opengever.ogds.base.actor import Actor
 from opengever.ogds.base.actor import ActorLookup
+from opengever.ogds.base.sources import AllUsersAndGroupsSourceBinder
 from opengever.ogds.base.sources import AllUsersInboxesAndTeamsSourceBinder
 from opengever.ogds.base.sources import UsersContactsInboxesSourceBinder
 from opengever.ogds.base.utils import get_current_admin_unit
@@ -97,6 +98,7 @@ class ITask(model.Schema):
             u'deadline',
             u'text',
             u'relatedItems',
+            u'informed_principals'
             ],
         )
 
@@ -164,6 +166,25 @@ class ITask(model.Schema):
         description=_(u"help_responsible", default=""),
         source=AllUsersInboxesAndTeamsSourceBinder(include_teams=True),
         required=True,
+        )
+
+    form.widget(
+        'informed_principals',
+        KeywordFieldWidget,
+        async=True,
+        template_selection='usersAndGroups',
+        template_result='usersAndGroups',
+    )
+
+    informed_principals = schema.List(
+        title=_(u"label_informed_principals", default=u"Info at"),
+        description=_(u"help_informed_principals", default=u""),
+        value_type=schema.Choice(
+            source=AllUsersAndGroupsSourceBinder(),
+            ),
+        required=False,
+        missing_value=[],
+        default=[]
         )
 
     form.widget(deadline=DatePickerFieldWidget)

--- a/opengever/task/tests/test_forms.py
+++ b/opengever/task/tests/test_forms.py
@@ -11,22 +11,17 @@ from zope.lifecycleevent.interfaces import IObjectModifiedEvent
 class TestFormFields(IntegrationTestCase):
 
     @browsing
-    def test_show_date_of_completion_field_in_edit_form(self, browser):
+    def test_date_of_completion_field_is_only_shown_in_edit_form(self, browser):
         self.login(self.dossier_responsible, browser=browser)
 
-        # seq_subtask_1 is a task with state 'open' and allows editing
-        browser.visit(self.seq_subtask_1, view="edit")
-
-        self.assertNotEqual(
+        browser.open(self.dossier, view='++add++opengever.task.task')
+        self.assertEqual(
             'hidden',
             browser.css('input#form-widgets-date_of_completion').first.type)
 
-    @browsing
-    def test_hide_date_of_completion_field_in_add_form(self, browser):
-        self.login(self.regular_user, browser=browser)
-        browser.open(self.dossier, view='++add++opengever.task.task')
-
-        self.assertEqual(
+        # seq_subtask_1 is a task with state 'open' and allows editing
+        browser.visit(self.seq_subtask_1, view="edit")
+        self.assertNotEqual(
             'hidden',
             browser.css('input#form-widgets-date_of_completion').first.type)
 

--- a/opengever/task/tests/test_forms.py
+++ b/opengever/task/tests/test_forms.py
@@ -26,9 +26,16 @@ class TestFormFields(IntegrationTestCase):
             browser.css('input#form-widgets-date_of_completion').first.type)
 
     @browsing
-    def test_informed_principals_is_only_shown_in_add_form(self, browser):
+    def test_informed_principals_is_only_shown_in_add_form_with_activity_enabled(self, browser):
         self.login(self.dossier_responsible, browser=browser)
 
+        browser.open(self.dossier, view='++add++opengever.task.task')
+        self.assertEqual(0, len(browser.css('select#form-widgets-informed_principals')))
+
+        browser.open(self.seq_subtask_1, view='edit')
+        self.assertEqual(0, len(browser.css('select#form-widgets-informed_principals')))
+
+        self.activate_feature('activity')
         browser.open(self.dossier, view='++add++opengever.task.task')
         self.assertEqual(1, len(browser.css('select#form-widgets-informed_principals')))
 

--- a/opengever/task/tests/test_forms.py
+++ b/opengever/task/tests/test_forms.py
@@ -1,5 +1,4 @@
 from ftw.testbrowser import browsing
-from opengever.activity import notification_center
 from opengever.activity.model import Activity
 from opengever.activity.model import Subscription
 from opengever.testing import IntegrationTestCase
@@ -7,6 +6,29 @@ from opengever.testing.event_recorder import get_recorded_events
 from opengever.testing.event_recorder import register_event_recorder
 from requests_toolbelt.utils import formdata
 from zope.lifecycleevent.interfaces import IObjectModifiedEvent
+
+
+class TestFormFields(IntegrationTestCase):
+
+    @browsing
+    def test_show_date_of_completion_field_in_edit_form(self, browser):
+        self.login(self.dossier_responsible, browser=browser)
+
+        # seq_subtask_1 is a task with state 'open' and allows editing
+        browser.visit(self.seq_subtask_1, view="edit")
+
+        self.assertNotEqual(
+            'hidden',
+            browser.css('input#form-widgets-date_of_completion').first.type)
+
+    @browsing
+    def test_hide_date_of_completion_field_in_add_form(self, browser):
+        self.login(self.regular_user, browser=browser)
+        browser.open(self.dossier, view='++add++opengever.task.task')
+
+        self.assertEqual(
+            'hidden',
+            browser.css('input#form-widgets-date_of_completion').first.type)
 
 
 class TestTaskAddForm(IntegrationTestCase):

--- a/opengever/task/tests/test_forms.py
+++ b/opengever/task/tests/test_forms.py
@@ -25,6 +25,16 @@ class TestFormFields(IntegrationTestCase):
             'hidden',
             browser.css('input#form-widgets-date_of_completion').first.type)
 
+    @browsing
+    def test_informed_principals_is_only_shown_in_add_form(self, browser):
+        self.login(self.dossier_responsible, browser=browser)
+
+        browser.open(self.dossier, view='++add++opengever.task.task')
+        self.assertEqual(1, len(browser.css('select#form-widgets-informed_principals')))
+
+        browser.open(self.seq_subtask_1, view='edit')
+        self.assertEqual(0, len(browser.css('select#form-widgets-informed_principals')))
+
 
 class TestTaskAddForm(IntegrationTestCase):
 

--- a/opengever/task/tests/test_task.py
+++ b/opengever/task/tests/test_task.py
@@ -102,26 +102,6 @@ class TestTaskIntegration(SolrIntegrationTestCase):
         self.assertTrue(len(self.dossier.objectValues()),
                         'Expect one item in dossier')
 
-    @browsing
-    def test_hide_date_of_completion_field_in_add_form(self, browser):
-        self.login(self.regular_user, browser=browser)
-        browser.open(self.dossier, view='++add++opengever.task.task')
-
-        self.assertEqual(
-            'hidden',
-            browser.css('input#form-widgets-date_of_completion').first.type)
-
-    @browsing
-    def test_show_date_of_completion_field_in_edit_form(self, browser):
-        self.login(self.dossier_responsible, browser=browser)
-
-        # seq_subtask_1 is a task with state 'open' and allows editing
-        browser.visit(self.seq_subtask_1, view="edit")
-
-        self.assertNotEqual(
-            'hidden',
-            browser.css('input#form-widgets-date_of_completion').first.type)
-
     def test_relateddocuments(self):
         self.login(self.dossier_responsible)
 
@@ -166,7 +146,7 @@ class TestTaskIntegration(SolrIntegrationTestCase):
             u'bidirectional_by_reference', self.task.task_type_category)
 
     @browsing
-    def test_task_with_invalid_unicode_character_charakter_in_text_is_displayed(self, browser):
+    def test_task_with_invalid_unicode_character_in_text_is_displayed(self, browser):
         self.login(self.dossier_responsible, browser=browser)
 
         task = self.task.get_sql_object()


### PR DESCRIPTION
We add a new `informed_principals` field to the `TaskAddForm`, listing principals that will receive a notification for the newly created `Task`. This allows avoiding having to create separate `Task`s just to inform certain users about a new `Task`.

This is implemented by temporarily adding watchers to the `Task` before creation and removing them directly after, so that they just get informed of the creation itself. As they get added in the `WATCHER_ROLE` we need to avoid generating a `WatcherAddedActivity`. Note that we refactor the generation of the `WatcherAddedActivity` a bit, as I found it a bit confusing that they such an activity only gets generated when I add the watcher through the `PloneNotificationCenter` but not if I used the `NotificationCenter`. 

We also only show the field when the `activity` feature is enabled, as it otherwise does not make much sense.

Finally there was a bug, preventing to set the issuer and informed_principals when adding a forwarding.

This is for https://4teamwork.atlassian.net/browse/GEVER-31
Frontend PR: https://github.com/4teamwork/gever-ui/pull/1120

## Checklist (Must have)

- [x] Changelog entry
- [x] Documentation updated (notably for API and deployment): Screenshot would need an update
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

## Checklist (optional)

_Only applicable should be left and checked._

- [x] New functionality  for `task` also works for `forwarding`
- New translations
  - [x] All msg-strings are unicode
  - [x] Correct i18n-domain was used (Copy-Paste errors are common here)
- Change in schema definition:
  - [x] If `missing_value` is specified, then `default` has to be set to the same value
