### PR TITLE
Use Solr for dossier overview

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -25,6 +25,7 @@ Changelog
 - Implement custom RoleAssignmentManager based local role migration for ftw.usermigration. [deiferni]
 - Fix batching in OGDSListingBaseService, properly use SQLHypermediaBatch. [deiferni]
 - Remove various unneeded catalog indexes and metadata columns. [buchi,elioschmutz,mbaechtold]
+- Use Solr to get documents in dossier overview. [buchi]
 
 
 2020.3.0rc3 (2020-05-22)

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -25,7 +25,7 @@ Changelog
 - Implement custom RoleAssignmentManager based local role migration for ftw.usermigration. [deiferni]
 - Fix batching in OGDSListingBaseService, properly use SQLHypermediaBatch. [deiferni]
 - Remove various unneeded catalog indexes and metadata columns. [buchi,elioschmutz,mbaechtold]
-- Use Solr to get documents in dossier overview. [buchi]
+- Use Solr to get documents and dossier navigation in dossier overview. [buchi]
 
 
 2020.3.0rc3 (2020-05-22)

--- a/opengever/dossier/browser/configure.zcml
+++ b/opengever/dossier/browser/configure.zcml
@@ -22,14 +22,14 @@
   <browser:page
       for="opengever.dossier.behaviors.dossier.IDossierMarker"
       name="dossier_navigation.json"
-      class=".navigation.JSONNavigation"
+      class=".navigation.DossierJSONNavigation"
       permission="zope2.View"
       />
 
   <browser:page
       for="opengever.dossier.dossiertemplate.behaviors.IDossierTemplateMarker"
       name="dossier_navigation.json"
-      class=".navigation.JSONNavigation"
+      class=".navigation.DossierTemplateJSONNavigation"
       permission="zope2.View"
       />
 

--- a/opengever/dossier/tests/test_dossier_template.py
+++ b/opengever/dossier/tests/test_dossier_template.py
@@ -658,7 +658,7 @@ DOCUMENTS_LIST_TAB = 'tabbedview_view-documents'
 DOCUMENTS_GALLERY_TAB = 'tabbedview_view-documents-gallery'
 
 
-class TestDossierTemplateOverview(IntegrationTestCase):
+class TestDossierTemplateOverview(SolrIntegrationTestCase):
 
     features = ('dossiertemplate', )
 
@@ -711,6 +711,7 @@ class TestDossierTemplateOverview(IntegrationTestCase):
                    .within(self.dossiertemplate)
                    .titled(u'A Document %s' % i))
 
+        self.commit_solr()
         browser.open(self.dossiertemplate, view=OVERVIEW_TAB)
         expected_titles = [
             'A Document 1',

--- a/opengever/dossier/tests/test_navigation.py
+++ b/opengever/dossier/tests/test_navigation.py
@@ -1,121 +1,88 @@
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.testbrowser import browsing
-from opengever.testing import FunctionalTestCase
+from opengever.testing import SolrIntegrationTestCase
 from plone.uuid.interfaces import IUUID
 
 
-class TestNavigation(FunctionalTestCase):
-
-    def setUp(self):
-        super(TestNavigation, self).setUp()
-        self.root = create(Builder('repository_root'))
-        self.folder = create(Builder('repository').within(self.root))
-        self.main_dossier = create(Builder('dossier')
-                                   .titled(u'Main')
-                                   .having(description=u'The main dossier')
-                                   .within(self.folder))
+class TestNavigation(SolrIntegrationTestCase):
 
     @browsing
     def test_dossier_navigation_json_is_valid(self, browser):
-        subdossier = create(Builder('dossier')
-                            .titled(u'Subdossier')
-                            .having(description=u'The sub-dossier')
-                            .within(self.main_dossier))
+        self.login(self.regular_user, browser=browser)
+        browser.visit(self.subdossier, view='dossier_navigation.json')
 
-        browser.login().visit(self.main_dossier,
-                              view='dossier_navigation.json')
-        self.assert_json_equal(
-            [{"text": "Main",
-              "description": "The main dossier",
-              "uid": IUUID(self.main_dossier),
-              "url": self.main_dossier.absolute_url(),
-              "nodes": [{"text": "Subdossier",
-                         "description": "The sub-dossier",
+        self.assertEqual(
+            [{"text": self.subdossier.Title(),
+              "description": self.subdossier.Description(),
+              "uid": IUUID(self.subdossier),
+              "url": self.subdossier.absolute_url(),
+              "nodes": [{"text": self.subsubdossier.Title(),
+                         "description": self.subsubdossier.Description(),
                          "nodes": [],
-                         "uid": IUUID(subdossier),
-                         "url": subdossier.absolute_url(),
+                         "uid": IUUID(self.subsubdossier),
+                         "url": self.subsubdossier.absolute_url(),
                          }],
               }],
             browser.json)
 
     @browsing
     def test_empty_dossier_navigation(self, browser):
-        browser.login().visit(self.main_dossier, view='dossier_navigation.json')
+        self.login(self.regular_user, browser=browser)
+        browser.visit(self.empty_dossier, view='dossier_navigation.json')
         self.assertEqual([], browser.json)
 
     @browsing
     def test_dossiers_are_sorted_by_title(self, browser):
-        sub1 = create(Builder('dossier')
-                      .titled(u'XXX')
-                      .having(description=u'The XXX sub-dossier')
-                      .within(self.main_dossier))
+        self.login(self.regular_user, browser=browser)
+        browser.visit(self.dossier, view='dossier_navigation.json')
 
-        sub2 = create(Builder('dossier')
-                      .titled(u'AAA')
-                      .having(description=u'The AAA sub-dossier')
-                      .within(self.main_dossier))
-
-        browser.login().visit(self.main_dossier,
-                              view='dossier_navigation.json')
-        self.assert_json_equal(
-            [{"text": "Main",
-              "description": "The main dossier",
-              "uid": IUUID(self.main_dossier),
-              "url": self.main_dossier.absolute_url(),
-              "nodes": [{"text": "AAA",
-                         "description": "The AAA sub-dossier",
-                         "nodes": [],
-                         "uid": IUUID(sub2),
-                         "url": sub2.absolute_url(),
-                         },
-                        {"text": "XXX",
-                         "description": "The XXX sub-dossier",
-                         "nodes": [],
-                         "uid": IUUID(sub1),
-                         "url": sub1.absolute_url(),
-                         }],
-              }],
-            browser.json)
+        nodes = browser.json[0]['nodes']
+        self.assertEqual(
+            [n['text'] for n in nodes], sorted([n['text'] for n in nodes]))
 
     @browsing
     def test_only_show_active_subdossiers(self, browser):
+        self.login(self.regular_user, browser=browser)
+
         sub1 = create(Builder('dossier')
                       .titled(u'active')
                       .having(description=u'The active sub-dossier')
-                      .within(self.main_dossier))
+                      .within(self.empty_dossier))
 
         create(Builder('dossier')
                .titled(u'archived')
                .having(description=u'The archived sub-dossier')
                .in_state('dossier-state-archived')
-               .within(self.main_dossier))
+               .within(self.empty_dossier))
 
         create(Builder('dossier')
                .titled(u'inactive(storniert)')
                .having(description=u'The inactive sub-dossier')
                .in_state('dossier-state-inactive')
-               .within(self.main_dossier))
+               .within(self.empty_dossier))
 
         create(Builder('dossier')
                .titled(u'resolved(abgeschlossen)')
                .having(description=u'The resolved sub-dossier')
                .in_state('dossier-state-resolved')
-               .within(self.main_dossier))
+               .within(self.empty_dossier))
 
-        browser.login().visit(self.main_dossier,
-                              view='dossier_navigation.json')
-        self.assert_json_equal(
-            [{"text": "Main",
-              "description": "The main dossier",
-              "uid": IUUID(self.main_dossier),
-              "url": self.main_dossier.absolute_url(),
-              "nodes": [
-                        {"text": "active",
-                         "description": "The active sub-dossier",
-                         "nodes": [],
-                         "uid": IUUID(sub1),
-                         "url": sub1.absolute_url(),
-                         }]
-              }],
+        self.commit_solr()
+        browser.visit(self.empty_dossier, view='dossier_navigation.json')
+
+        self.assertEqual(
+            [{
+                "text": self.empty_dossier.Title(),
+                "description": self.empty_dossier.Description(),
+                "uid": IUUID(self.empty_dossier),
+                "url": self.empty_dossier.absolute_url(),
+                "nodes": [{
+                    "text": "active",
+                    "description": "The active sub-dossier",
+                    "nodes": [],
+                    "uid": IUUID(sub1),
+                    "url": sub1.absolute_url(),
+                }],
+            }],
             browser.json)

--- a/opengever/dossier/tests/test_navigation.py
+++ b/opengever/dossier/tests/test_navigation.py
@@ -86,3 +86,23 @@ class TestNavigation(SolrIntegrationTestCase):
                 }],
             }],
             browser.json)
+
+    @browsing
+    def test_dossier_navigation_for_dossier_templates(self, browser):
+        self.login(self.regular_user, browser=browser)
+        browser.visit(self.dossiertemplate, view='dossier_navigation.json')
+        self.assertEqual(
+            [{
+                "text": self.dossiertemplate.Title(),
+                "description": self.dossiertemplate.Description(),
+                "uid": IUUID(self.dossiertemplate),
+                "url": self.dossiertemplate.absolute_url(),
+                "nodes": [{
+                    "text": self.subdossiertemplate.Title(),
+                    "description": self.subdossiertemplate.Description(),
+                    "nodes": [],
+                    "uid": IUUID(self.subdossiertemplate),
+                    "url": self.subdossiertemplate.absolute_url(),
+                }],
+            }],
+            browser.json)

--- a/opengever/dossier/tests/test_overview.py
+++ b/opengever/dossier/tests/test_overview.py
@@ -203,6 +203,7 @@ class TestOverview(SolrIntegrationTestCase):
                    .within(self.empty_dossier)
                    .with_modification_date(DateTime(2010, 1, 1) + i)
                    .titled(u'Document %s' % i))
+        self.commit_solr()
 
         browser.open(self.empty_dossier, view='tabbedview_view-overview')
         self.assertSequenceEqual(


### PR DESCRIPTION
Use Solr for dossier overview. This includes getting documents and the dossier navigation.

Jira: https://4teamwork.atlassian.net/browse/GEVER-374

## Checklist (Must have)

- [x] Changelog entry
- [x] Documentation updated (notably for API and deployment)
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
