### PR TITLE
Enable API endpoint @document-from-template for tasks.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,7 @@ Changelog
 2020.3.0rc5 (unreleased)
 ------------------------
 
-- Nothing changed yet.
+- Enable API endpoint `@document-from-template` for tasks. [mbaechtold]
 
 
 2020.3.0rc4 (2020-06-05)

--- a/docs/public/dev-manual/api/templatefolder.rst
+++ b/docs/public/dev-manual/api/templatefolder.rst
@@ -3,17 +3,17 @@
 Dokumente ab Vorlage erstellen
 ==============================
 
-In einem Dosser kann über den Endpoint ``@document-from-template`` ein neues
+In einem Dossier oder einer Aufgabe kann über den Endpoint ``@document-from-template`` ein neues
 Dokument ab Vorlage erstellt werden.
 
-Der Endpoint steht auf einem Dossier zur Verfügung. Der Endpoint ist mit der
-Berechtigung ``opengever.document: Add document`` geschützt, kann also verwendet
-werden wenn der Benutzer Dokumente hinzufügen kann.
+Der Endpoint steht auf Dossiers und Aufgaben zur Verfügung und ist mit der
+Berechtigung ``opengever.document: Add document`` geschützt. Er kann also nur verwendet
+werden, wenn der Benutzer Dokumente hinzufügen kann.
 
 Der Endpoint erwartet zwei Parameter:
 
-- ``template`` das zu verwendende template aus dem Vokabular ``opengever.dossier.DocumentTemplatesVocabulary``
-- ``title`` Titel des zu erstellenden Dokumentes
+- ``template``: Das zu verwendende Template aus dem Vokabular ``opengever.dossier.DocumentTemplatesVocabulary``
+- ``title``: Der Titel des zu erstellenden Dokumentes
 
 
 **Beispiel-Request**:
@@ -29,5 +29,5 @@ Der Endpoint erwartet zwei Parameter:
        }
 
 
-Als Reponse wird die JSON-Repräsentation des neu erstellen Dokuments geliefert,
+Als Response wird die JSON-Repräsentation des neu erstellten Dokuments geliefert,
 siehe :ref:`Inhaltstypen <content-types>`.

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -681,6 +681,14 @@
       />
 
   <plone:service
+      method="POST"
+      name="@document-from-template"
+      for="opengever.task.task.ITask"
+      factory=".templatefolder.DocumentFromTemplatePost"
+      permission="opengever.document.AddDocument"
+      />
+
+  <plone:service
       method="GET"
       name="@list-documents-in-linked-workspace"
       for="opengever.dossier.behaviors.dossier.IDossierMarker"

--- a/opengever/api/tests/test_templatefolder.py
+++ b/opengever/api/tests/test_templatefolder.py
@@ -10,7 +10,7 @@ import json
 class TestDocumentFromTemplatePost(IntegrationTestCase):
 
     @browsing
-    def test_creates_document_from_template(self, browser):
+    def test_creates_document_from_template_within_dossier(self, browser):
         self.login(self.regular_user, browser)
 
         browser.open(
@@ -25,6 +25,56 @@ class TestDocumentFromTemplatePost(IntegrationTestCase):
         with self.observe_children(self.dossier) as children:
             browser.open('{}/@document-from-template'.format(
                          self.dossier.absolute_url()),
+                         data=json.dumps(data),
+                         headers=self.api_headers)
+
+        self.assertEqual(1, len(children['added']))
+        document = children['added'].pop()
+
+        self.assertEqual(u'New d\xf6cument', document.title)
+        self.assertEquals(date.today(), document.document_date)
+
+    @browsing
+    def test_creates_document_from_template_within_task(self, browser):
+        self.login(self.regular_user, browser)
+
+        browser.open(
+            '{}/@vocabularies/opengever.dossier.DocumentTemplatesVocabulary'.format(
+                self.portal.absolute_url()),
+            headers=self.api_headers)
+        template = browser.json['items'][0]
+
+        data = {'template': template,
+                'title': u'New d\xf6cument'}
+
+        with self.observe_children(self.task) as children:
+            browser.open('{}/@document-from-template'.format(
+                         self.task.absolute_url()),
+                         data=json.dumps(data),
+                         headers=self.api_headers)
+
+        self.assertEqual(1, len(children['added']))
+        document = children['added'].pop()
+
+        self.assertEqual(u'New d\xf6cument', document.title)
+        self.assertEquals(date.today(), document.document_date)
+
+    @browsing
+    def test_creates_document_from_template_within_forwarding(self, browser):
+        self.login(self.secretariat_user, browser)
+
+        browser.open(
+            '{}/@vocabularies/opengever.dossier.DocumentTemplatesVocabulary'.format(
+                self.portal.absolute_url()),
+            headers=self.api_headers)
+        template = browser.json['items'][0]
+
+        data = {'template': template,
+                'title': u'New d\xf6cument'}
+
+        with self.observe_children(self.inbox_forwarding) as children:
+            browser.open('{}/@document-from-template'.format(
+                         self.inbox_forwarding.absolute_url()),
                          data=json.dumps(data),
                          headers=self.api_headers)
 


### PR DESCRIPTION
As requested in the Jira issue, the user must be able to create documents (from templates) within tasks too. So we need to register the API endpoint for the content type "Task" too.

Belongs to Jira issue https://4teamwork.atlassian.net/browse/GEVER-435

## Checklist (Must have)

- [x] Changelog entry
- [x] Documentation updated (notably for API and deployment)
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


## Checklist (optional)

- [x] New functionality  for `task` also works for `forwarding`
