### PR TITLE
Move the ogds groups import logger more up in the script.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2020.3.0rc4 (unreleased)
 ------------------------
 
+- Move the ogds groups import logger more up in the script to make debugging easier. [elioschmutz]
 - Add `bumblebee_app_id` to the `@config` API endpoint. [mbaechtold]
 - @teams: Order team members by last name. [lgraf]
 - @ogds-groups: Order group members by last name. [lgraf]

--- a/opengever/ogds/base/sync/ogds_updater.py
+++ b/opengever/ogds/base/sync/ogds_updater.py
@@ -300,6 +300,8 @@ class OGDSUpdater(object):
                             u"Skipping duplicate group '{}'!".format(groupid))
                         continue
 
+                logger.info(u"Importing group '{}'...".format(groupid))
+
                 # Iterate over all SQL columns and update their values
                 columns = Group.__table__.columns
                 for col in columns:
@@ -315,7 +317,6 @@ class OGDSUpdater(object):
                 contained_users = []
                 group_members = ldap_util.get_group_members(info)
 
-                logger.info(u"Importing group '{}'...".format(groupid))
                 for user_dn in group_members:
                     ldap_user = ldap_util.entry_by_dn(user_dn)
 


### PR DESCRIPTION
The logger should be as early as possible.
If the script fails somewhere we should know which group is affected.

This PR does not fix broken (recursive) groups but it makes debugging much easier.

Jira: https://4teamwork.atlassian.net/browse/GEVER-479