### PR TITLE
Support combined notation for task responsible in workflow transitions.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 ------------------------
 
 - Enable API endpoint `@document-from-template` for tasks. [mbaechtold]
+- Support combined notation for task responsible in workflow transitions. [elioschmutz]
 
 
 2020.3.0rc4 (2020-06-05)

--- a/docs/public/dev-manual/api/tasks.rst
+++ b/docs/public/dev-manual/api/tasks.rst
@@ -166,8 +166,11 @@ Zusätzliche Metadaten:
    .. py:attribute:: responsible_client
 
        :Datentyp: ``Choice``
-       :Pflichtfeld: Ja :required:`(*)`
+       :Pflichtfeld: Nur wenn ``responsible`` den Client nicht bereits enthält. :required:`(*)`
 
+Hinweis:
+
+Das Attribut ``responsible`` kann einen kombinierten Wert im Format ``responsible_client:responsible`` enthalten. Z.b. ``fd:hans.muster`` oder ``team:musterteam``. Wird das Feld ``responsible_client`` mit einem kombinierten Wert befüllt, muss das Feld ``responsile_client`` nicht mehr mitgeschickt werden.
 
 Erledigen
 ~~~~~~~~~

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -448,6 +448,15 @@
       />
 
   <plone:service
+      method="POST"
+      name="@workflow"
+      for="opengever.task.task.ITask"
+      factory=".transition.GEVERTaskWorkflowTransition"
+      layer="opengever.base.interfaces.IOpengeverBaseLayer"
+      permission="zope2.View"
+      />
+
+  <plone:service
       method="GET"
       name="@invitations"
       for="opengever.workspace.interfaces.IWorkspace"

--- a/opengever/api/tests/test_task.py
+++ b/opengever/api/tests/test_task.py
@@ -462,3 +462,82 @@ class TestTaskPatch(IntegrationTestCase):
 
         self.assertEqual('rk', self.task.responsible_client)
         self.assertEqual('james.bond', self.task.responsible)
+
+
+class TestTaskTransitions(IntegrationTestCase):
+
+    @browsing
+    def test_reassign_task_with_combined_responsible_value(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        self.assertEqual('fa', self.task.responsible_client)
+        self.assertEqual('kathi.barfuss', self.task.responsible)
+
+        data = {
+            'responsible': {
+                'token': 'rk:james.bond',
+                'title': u'Ratskanzlei: James Bond'
+            }
+        }
+        browser.open(self.task.absolute_url() + '/@workflow/task-transition-reassign',
+                     json.dumps(data),
+                     method="POST", headers=self.api_headers)
+
+        self.assertEqual('rk', self.task.responsible_client)
+        self.assertEqual('james.bond', self.task.responsible)
+
+    @browsing
+    def test_reassign_task_without_combined_responsible_value(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        self.assertEqual('fa', self.task.responsible_client)
+        self.assertEqual('kathi.barfuss', self.task.responsible)
+
+        data = {
+            'responsible': 'james.bond',
+            'responsible_client': 'rk',
+        }
+        browser.open(self.task.absolute_url() + '/@workflow/task-transition-reassign',
+                     json.dumps(data),
+                     method="POST", headers=self.api_headers)
+
+        self.assertEqual('rk', self.task.responsible_client)
+        self.assertEqual('james.bond', self.task.responsible)
+
+    @browsing
+    def test_reassign_forwarding_with_combined_responsible_value(self, browser):
+        self.login(self.secretariat_user, browser=browser)
+
+        self.assertEqual('fa', self.inbox_forwarding.responsible_client)
+        self.assertEqual('kathi.barfuss', self.inbox_forwarding.responsible)
+
+        data = {
+            'responsible': {
+                'token': 'rk:james.bond',
+                'title': u'Ratskanzlei: James Bond'
+            }
+        }
+        browser.open(self.inbox_forwarding.absolute_url() + '/@workflow/forwarding-transition-reassign',
+                     json.dumps(data),
+                     method="POST", headers=self.api_headers)
+
+        self.assertEqual('rk', self.inbox_forwarding.responsible_client)
+        self.assertEqual('james.bond', self.inbox_forwarding.responsible)
+
+    @browsing
+    def test_reassign_forwarding_without_combined_responsible_value(self, browser):
+        self.login(self.secretariat_user, browser=browser)
+
+        self.assertEqual('fa', self.inbox_forwarding.responsible_client)
+        self.assertEqual('kathi.barfuss', self.inbox_forwarding.responsible)
+
+        data = {
+            'responsible': 'james.bond',
+            'responsible_client': 'rk',
+        }
+        browser.open(self.inbox_forwarding.absolute_url() + '/@workflow/forwarding-transition-reassign',
+                     json.dumps(data),
+                     method="POST", headers=self.api_headers)
+
+        self.assertEqual('rk', self.inbox_forwarding.responsible_client)
+        self.assertEqual('james.bond', self.inbox_forwarding.responsible)

--- a/opengever/api/transition.py
+++ b/opengever/api/transition.py
@@ -50,7 +50,7 @@ class GEVERWorkflowTransition(WorkflowTransition):
     def recurse_transition(self, objs, comment, publication_dates,
                            include_children=False):
 
-        data = json_body(self.request)
+        data = self.request_data()
 
         for obj in objs:
             if publication_dates:
@@ -71,6 +71,9 @@ class GEVERWorkflowTransition(WorkflowTransition):
                 self.recurse_transition(
                     obj.objectValues(), comment, publication_dates,
                     include_children)
+
+    def request_data(self):
+        return json_body(self.request)
 
 
 class GEVERDossierWorkflowTransition(GEVERWorkflowTransition):
@@ -253,3 +256,19 @@ class GEVERDossierWorkflowTransition(GEVERWorkflowTransition):
         if 'expirationDate' in data:
             publication_dates['expirationDate'] = data['expirationDate']
         return publication_dates
+
+
+class GEVERTaskWorkflowTransition(GEVERWorkflowTransition):
+    """This endpoint handles workflow transitions for tasks.
+    """
+    def request_data(self):
+        """Extract responsible_client when a combined value is used (client,
+        responsible separated by a colon) in the responsible field
+        """
+        data = super(GEVERTaskWorkflowTransition, self).request_data()
+        task_deserializer = queryMultiAdapter((self.context, self.request),
+                                              IDeserializeFromJson)
+
+        task_deserializer.update_reponsible_field_data(data)
+
+        return data


### PR DESCRIPTION
This PR updates the `@workflow` endpoint for tasks to allow the use of a combined responsible value.

The ``@querysource`` of the responsible Field returns combined token values:

```json
{
  "@id": "task-4/@querysources/opengever.task.task/responsible?query=L",
  "items": [
    {
      "title": "DEIFS_LAUTE_GRUPPE (Steuerverwaltung)",
      "token": "team:427"
    },
    {
      "title": "rk_leitung (Amt für Informatik)",
      "token": "team:420"
    }
  ]
}
```

We want to directly reuse this tokens to reassign a new task.

Jira: https://4teamwork.atlassian.net/browse/GEVER-71

## Checklist (Must have)

- [x] Changelog entry
- [x] Documentation updated (notably for API and deployment)
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


## Checklist (optional)

- [x] New functionality  for `task` also works for `forwarding`
