### PR TITLE
Fix p7m attachment extraction from mails.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2020.3.0rc5 (unreleased)
 ------------------------
 
+- Fix p7m attachment extraction from mails. [deiferni]
 - Fix bug with setting issuer and informed_principals on forwardings. [njohner]
 - Allow notifying users and groups when creating a new task. [njohner]
 - Enable API endpoint `@document-from-template` for tasks. [mbaechtold]

--- a/opengever/base/quickupload.py
+++ b/opengever/base/quickupload.py
@@ -8,6 +8,7 @@ from ftw.tabbedview.interfaces import ITabbedviewUploadable
 from opengever.base.command import CreateDocumentCommand
 from opengever.base.command import CreateEmailCommand
 from opengever.mail.mail import MESSAGE_SOURCE_DRAG_DROP_UPLOAD
+from opengever.mail.utils import is_rfc822_ish_mimetype
 from opengever.quota.exceptions import ForbiddenByQuota
 from plone.protect import createToken
 from plone.protect.interfaces import IDisableCSRFProtection
@@ -100,8 +101,7 @@ class OGQuickUploadCapableFileFactory(object):
     def is_email_upload(self, filename):
         extension = os.path.splitext(filename)[1].lower()
         mimetype = self._get_mimetype(extension)
-        return extension == '.msg' or mimetype in ('message/rfc822',
-                                                   'application/pkcs7-mime')
+        return extension == '.msg' or is_rfc822_ish_mimetype(mimetype)
 
     def _get_mimetype(self, extension):
         return mimetypes.types_map.get(extension)

--- a/opengever/mail/tests/test_ogmail.py
+++ b/opengever/mail/tests/test_ogmail.py
@@ -229,6 +229,14 @@ class TestExtractMailInDossier(FunctionalTestCase):
         self.assertEquals(u'Inneres Testm\xe4il ohne Attachments',
                           extracted.Title().decode('utf-8'))
 
+    def test_extract_p7m_from_mail_creates_mail(self):
+        mail = create(Builder('mail')
+                      .within(self.parent)
+                      .with_asset_message('mail_with_one_p7m_attachment.eml'))
+
+        extracted = mail.extract_attachment_into_parent(position=2)
+        self.assertEqual(extracted.portal_type, 'ftw.mail.mail')
+
     def test_extract_nested_mail_from_mail_with_attachments(self):
         mail = create(Builder('mail')
                       .within(self.parent)

--- a/opengever/mail/utils.py
+++ b/opengever/mail/utils.py
@@ -19,3 +19,7 @@ def make_addr_header(fullname, address, charset='utf-8'):
          (u'<{}>'.format(address), None)])
 
     return header
+
+
+def is_rfc822_ish_mimetype(mimetype):
+    return mimetype in ('message/rfc822', 'application/pkcs7-mime')

--- a/opengever/testing/assets/mail_with_one_p7m_attachment.eml
+++ b/opengever/testing/assets/mail_with_one_p7m_attachment.eml
@@ -1,0 +1,83 @@
+Return-Path: <foo@example.com>
+Received: from [1.2.3.4] (mail.example.com. [1.2.3.4])
+        by mx.example.com with ESMTPSA id ei8sm68862854wjd.32.2015.06.30.05.59.07
+        for <foo@example.com>
+        (version=TLSv1 cipher=ECDHE-RSA-RC4-SHA bits=128/128);
+        Tue, 30 Jun 2015 05:59:07 -0700 (PDT)
+From: Somebody <foo@example.com>
+Content-Type: multipart/mixed; boundary="Apple-Mail=_128924F8-3F55-4C77-A678-0691ABDF392C"
+Subject: =?utf-8?Q?=C3=84usseres_Testm=C3=A4il?=
+Message-Id: <53417074-8D58-4EFE-A94B-637822DB675D@example.com>
+Date: Tue, 30 Jun 2015 14:59:05 +0200
+To: Somebody <foo@example.com>
+Mime-Version: 1.0 (Mac OS X Mail 8.2 \(2098\))
+X-Mailer: Apple Mail (2.2098)
+
+
+--Apple-Mail=_128924F8-3F55-4C77-A678-0691ABDF392C
+Content-Transfer-Encoding: quoted-printable
+Content-Type: text/plain;
+	charset=utf-8
+
+=C3=84usseres Testm=C3=A4il hat ein M=C3=A4il Attachment:
+
+--Apple-Mail=_128924F8-3F55-4C77-A678-0691ABDF392C
+Content-ID:
+MIME-Version: 1.0
+Content-Type: multipart/signed; name="smime.p7m"
+Content-Transfer-Encoding: 8bit
+Content-Disposition: attachment; filename="smime.p7m"
+
+MIME-Version: 1.0
+Content-Type: multipart/signed; protocol="application/x-pkcs7-signature"; micalg="sha1"; boundary="----A93158B83C471711B0FC9D2C93588756"
+
+This is an S/MIME signed message
+
+------A93158B83C471711B0FC9D2C93588756
+Content-Type: multipart/mixed; boundary="===============6640147427061326256=="
+MIME-Version: 1.0
+
+--===============6640147427061326256==
+Content-Type: text/plain; charset="us-ascii"
+MIME-Version: 1.0
+Content-Transfer-Encoding: 7bit
+
+Hello, i'm a signed mail.
+--===============6640147427061326256==--
+
+------A93158B83C471711B0FC9D2C93588756
+Content-Type: application/x-pkcs7-signature; name="smime.p7s"
+Content-Transfer-Encoding: base64
+Content-Disposition: attachment; filename="smime.p7s"
+
+MIIFJQYJKoZIhvcNAQcCoIIFFjCCBRICAQExCzAJBgUrDgMCGgUAMAsGCSqGSIb3
+DQEHAaCCAvAwggLsMIICVaADAgECAgkA7RBtNW52X5cwDQYJKoZIhvcNAQELBQAw
+bzELMAkGA1UEBhMCQ0gxDTALBgNVBAgMBEJlcm4xEDAOBgNVBAoMB0NBIENvcnAx
+GTAXBgNVBAMMEGNlcnQuZXhhbXBsZS5jb20xJDAiBgkqhkiG9w0BCQEWFWNlcnRA
+Y2VydC5leGFtcGxlLmNvbTAeFw0xOTA5MTkxNTUwMDBaFw0yMDA5MTgxNTUwMDBa
+MIGDMQswCQYDVQQGEwJDSDENMAsGA1UECAwEQmVybjENMAsGA1UEBwwEQmVybjEP
+MA0GA1UECgwGTWFpbGVyMRswGQYDVQQDDBJtYWlsZXIuZXhhbXBsZS5vcmcxKDAm
+BgkqhkiG9w0BCQEWGW1haWxlckBtYWlsZXIuZXhhbXBsZS5vcmcwgZ8wDQYJKoZI
+hvcNAQEBBQADgY0AMIGJAoGBAMGa6uCsFqdmr3r77NwhUPnwP0pEiHV3xG2PcOtY
+hG4LPMNC4NwUlGzHMex3FCZfXmOe9BvO6BJJj0mhk2MRF8kY+pwwQm/VTS9CHU4G
+K9DcIAMpmvmQJJH1VxUKg1iGmUSPQQMiwjHmnsGpCe6bWrw2nUdvs3o8gd78smlR
+e9wFAgMBAAGjezB5MAkGA1UdEwQCMAAwLAYJYIZIAYb4QgENBB8WHU9wZW5TU0wg
+R2VuZXJhdGVkIENlcnRpZmljYXRlMB0GA1UdDgQWBBR9wyBAEVcTjzJRT/06EwiU
+8ypA/zAfBgNVHSMEGDAWgBS23o44t1MXnCPW833YJGdEuEl/EDANBgkqhkiG9w0B
+AQsFAAOBgQBu6M2Mv0iLIWFy7ppyD/uoYhgqyqRISj/sVgzAzbiggHXYcr92Fvtx
+eqNLTg34suBe7G5B7602kZbZFntib2OF9WcjzuKAQxlnYyAgu7Am9QhG/Xk3snG3
+ywJMC02Li9864duYedkpXiz5FqoP/qydb4AMN37xzfgRgl5GuVc9XjGCAf0wggH5
+AgEBMHwwbzELMAkGA1UEBhMCQ0gxDTALBgNVBAgMBEJlcm4xEDAOBgNVBAoMB0NB
+IENvcnAxGTAXBgNVBAMMEGNlcnQuZXhhbXBsZS5jb20xJDAiBgkqhkiG9w0BCQEW
+FWNlcnRAY2VydC5leGFtcGxlLmNvbQIJAO0QbTVudl+XMAkGBSsOAwIaBQCggdgw
+GAYJKoZIhvcNAQkDMQsGCSqGSIb3DQEHATAcBgkqhkiG9w0BCQUxDxcNMTkwOTIz
+MDk1MjMxWjAjBgkqhkiG9w0BCQQxFgQULdS2wW0o6qJSAGIThNNR+/a7Yh8weQYJ
+KoZIhvcNAQkPMWwwajALBglghkgBZQMEASowCwYJYIZIAWUDBAEWMAsGCWCGSAFl
+AwQBAjAKBggqhkiG9w0DBzAOBggqhkiG9w0DAgICAIAwDQYIKoZIhvcNAwICAUAw
+BwYFKw4DAgcwDQYIKoZIhvcNAwICASgwDQYJKoZIhvcNAQEBBQAEgYCeeh1eF3pl
+H4VEY93Fr8CxoaHMsZmAVI1k5w/3eIHwilb1pwfkx0fkBML/7cLo42Y0VnfVMuJP
+Am/3ZRTReQuZXoreaCkHWry9xSsP/FvwmcSPJZiLpqyCLw1//Qy1PPUL7p4BpmB1
+rCPMYndwTrRkQAA0oVxbtHtfbcO9XSjw7g==
+
+
+--Apple-Mail=_128924F8-3F55-4C77-A678-0691ABDF392C--


### PR DESCRIPTION
When extracting p7m attachments for mails they were created as a document by mistake. This PR makes sure we use the same special handling when extracting p7ms as during D&D upload and during mail-in unwrapping. We make sure the extracted part is correctly created as another mail and not as a a document.

https://4teamwork.atlassian.net/browse/GEVER-467

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [ ] Documentation updated (notably for API and deployment)
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
