### PR TITLE
Add support for pivot queries in listing-stats endpoint.

### DIFF
--- a/docs/public/dev-manual/api/listing_stats.rst
+++ b/docs/public/dev-manual/api/listing_stats.rst
@@ -3,7 +3,7 @@
 Statistik zu Auflistungen
 =========================
 
-Mit dem ``@listing-stats`` Endpoint können Statistiken zu Auflistungen unter :ref:`listings` abgefragt werden.
+Mit dem ``@listing-stats`` Endpoint können Statistiken zu Auflistungen unter :ref:`listings` abgefragt werden. Spezifische Statistiken können mit dem ``queries`` Parameter abgefragt werden.
 
 
 **Beispiel-Request**:
@@ -43,6 +43,46 @@ Mit dem ``@listing-stats`` Endpoint können Statistiken zu Auflistungen unter :r
         ]
       }
     }
+
+
+**Beispiel-Request mit queries**:
+
+  .. sourcecode:: http
+
+    GET /dossier-1/@listing-stats?queries=responsible:hugo.boss&queries=depth:1 HTTP/1.1
+    Accept: application/json
+
+**Beispiel-Response**:
+
+  .. sourcecode:: http
+
+    HTTP/1.1 200 OK
+    Content-Type: application/json
+
+    {
+      "@id": "http://localhost:8080/fd/ordnungssystem/dossier-1/@listing-stats",
+      "facet_pivot": {
+        "listing_name": [
+          {
+            "field": "listing_name",
+            "value": "dossiers",
+            "count": 10,
+            "queries": {"responsible:hugo.boss": 1,
+                        "depth:1": 4}
+          },
+          {
+            "field": "listing_name",
+            "value": "documents",
+            "count": 5,
+            "queries": {"responsible:hugo.boss": 0,
+                        "depth:1": 2}
+          },
+          "..."
+        ]
+      }
+    }
+
+
 
 Statistik als erweiterbare Komponente
 -------------------------------------

--- a/opengever/api/listing_stats.py
+++ b/opengever/api/listing_stats.py
@@ -143,7 +143,7 @@ class ListingStats(object):
         return self.solr.search(filters=fq, **params)
 
     def _to_solr_facet_query(self, query):
-        if query.startswith("depth:"):
+        if query.startswith(u"depth:"):
             try:
                 depth = int(query.rsplit(":", 1)[1])
             except (ValueError, IndexError):
@@ -151,12 +151,12 @@ class ListingStats(object):
 
             context_depth = get_path_depth(self.context)
             max_path_depth = context_depth + depth
-            return "{{!tag=q1}}path_depth:[* TO {}]".format(max_path_depth)
-        return "{{!tag=q1}}{}".format(query)
+            return u"{{!tag=q1}}path_depth:[* TO {}]".format(max_path_depth)
+        return u"{{!tag=q1}}{}".format(query)
 
     @staticmethod
     def _add_query_to_pivot(pivot):
-        return "{{!query=q1}}{}".format(pivot)
+        return u"{{!query=q1}}{}".format(pivot)
 
     def _create_listing_name_pivot(self, solr_response, pivot):
         """Processes solr_response to extract the statistics and format them

--- a/opengever/api/listing_stats.py
+++ b/opengever/api/listing_stats.py
@@ -36,6 +36,12 @@ class ListingStats(object):
     def __init__(self, context, request):
         self.context = context
         self.request = request
+
+        queries = self.request.form.get("queries", [])
+        if isinstance(queries, basestring):
+            queries = [queries]
+        self.facet_queries = queries
+
         self.solr = getUtility(ISolrSearch)
 
     def __call__(self, expand=False):
@@ -60,7 +66,7 @@ class ListingStats(object):
         return pivots
 
     def _get_listing_name_pivot(self):
-        """Reurns the `listing_name` pivot section which depends on the FILTER
+        """Returns the `listing_name` pivot section which depends on the FILTER
         values of the @listing endpoint.
         """
         solr_pivot = 'object_provides'
@@ -86,11 +92,17 @@ class ListingStats(object):
                   "field":"object_provides",
                   "value":"opengever.document.behaviors.IBaseDocument",
                   "count":310,
+                  "queries": {
+                    "{!tag=q1}responsible:hugo.boss":1
+                  },
                   "pivot":[
                     {
                       "field":"review_state",
                       "value":"document-state-draft",
-                      "count":310
+                      "count":310,
+                      "queries": {
+                        "{!tag=q1}responsible:hugo.boss":1
+                      },
                     }
                   ]
                 }
@@ -116,7 +128,20 @@ class ListingStats(object):
             'facet.pivot': pivot,
         }
 
+        if self.facet_queries:
+            facet_queries = [self._to_solr_facet_query(query)
+                             for query in self.facet_queries]
+            params['facet.pivot'] = self._add_query_to_pivot(pivot)
+            params['facet.query'] = facet_queries
         return self.solr.search(filters=fq, **params)
+
+    @staticmethod
+    def _to_solr_facet_query(query):
+        return "{{!tag=q1}}{}".format(query)
+
+    @staticmethod
+    def _add_query_to_pivot(pivot):
+        return "{{!query=q1}}{}".format(pivot)
 
     def _create_listing_name_pivot(self, solr_response, pivot):
         """Processes solr_response to extract the statistics and format them
@@ -131,6 +156,9 @@ class ListingStats(object):
                   "field":"object_provides",
                   "value":"opengever.document.behaviors.IBaseDocument",
                   "count":310,
+                  "queries": {
+                    "{!tag=q1}responsible:hugo.boss":1
+                  },
                 },
               ]
             }
@@ -145,6 +173,9 @@ class ListingStats(object):
                 "field":"documents",
                 "value":"opengever.document.behaviors.IBaseDocument",
                 "count":310,
+                "queries":{
+                  "responsible:hugo.boss":1,
+                },
               }
             ]
           }
@@ -167,6 +198,15 @@ class ListingStats(object):
             pivot = pivot_by_value.get(pivot_value, {})
             if not pivot:
                 pivot = {'count': 0}
+
+            if self.facet_queries:
+                # Remove the tag from the facet query names:
+                # {!tag=q1}responsible:hugo.boss -> responsible:hugo.boss
+                pivot['queries'] = {
+                    facet_query: pivot.get('queries', {}).get(
+                        self._to_solr_facet_query(facet_query), 0)
+                    for facet_query in self.facet_queries
+                }
 
             pivot['field'] = 'listing_name'
             pivot['value'] = listing_name

--- a/opengever/api/listing_stats.py
+++ b/opengever/api/listing_stats.py
@@ -5,6 +5,7 @@ from opengever.api.listing import get_path_depth
 from opengever.base.interfaces import IOpengeverBaseLayer
 from plone.restapi.interfaces import IExpandableElement
 from plone.restapi.services import Service
+from Products.CMFPlone.utils import safe_unicode
 from zExceptions import BadRequest
 from zope.component import adapter
 from zope.component import getUtility
@@ -42,9 +43,13 @@ class ListingStats(object):
         queries = self.request.form.get("queries", [])
         if isinstance(queries, basestring):
             queries = [queries]
-        self.facet_queries = queries
+        self.facet_queries = [self._escape_query(query) for query in queries]
 
         self.solr = getUtility(ISolrSearch)
+
+    @staticmethod
+    def _escape_query(query):
+        return u":".join(escape(safe_unicode(el)) for el in query.split(":"))
 
     def __call__(self, expand=False):
         result = {

--- a/opengever/api/solr_query_service.py
+++ b/opengever/api/solr_query_service.py
@@ -125,7 +125,7 @@ class SimpleListingField(object):
             value = map(safe_unicode, value)
             value = u' OR '.join(value)
         else:
-            value = escape(value)
+            value = escape(safe_unicode(value))
         return u'{}:({})'.format(escape(self.index), value)
 
     def index_value_to_label(self, value):

--- a/opengever/api/tests/test_listing.py
+++ b/opengever/api/tests/test_listing.py
@@ -418,6 +418,24 @@ class TestListingWithRealSolr(SolrIntegrationTestCase):
         self.assertEqual('2016-09-05T00:00:00Z', deadlines[0])
 
     @browsing
+    def test_filter_supports_unicode(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        view = (u'@listing?name=dossiers&columns:list=title'
+                u'&filters.title:record=Vertr\xe4ge')
+        browser.open(self.repository_root, view=view,
+                     headers=self.api_headers)
+
+        items = browser.json['items']
+        titles = map(lambda x: x['title'], items)
+        self.assertEqual(3, len(titles))
+        self.assertItemsEqual(
+            [u'Vertr\xe4ge mit der kantonalen Finanzverwaltung',
+             u'Inaktive Vertr\xe4ge',
+             u'Abgeschlossene Vertr\xe4ge'],
+            titles)
+
+    @browsing
     def test_workspaces_listing(self, browser):
         self.login(self.workspace_member, browser=browser)
         query_string = '&'.join((

--- a/opengever/api/tests/test_listing_stats.py
+++ b/opengever/api/tests/test_listing_stats.py
@@ -127,3 +127,53 @@ class TestListingStats(SolrIntegrationTestCase):
 
         pivot = self.get_facet_pivot_for(dossier, 'listing_name', browser)
         self.assertEqual(0, self.get_facet_by_value(pivot, 'documents').get('count'))
+
+    @browsing
+    def test_listing_stats_pivot_queries_support(self, browser):
+        self.login(self.regular_user, browser)
+        browser.open(
+            '{}/@listing-stats?queries=responsible:{}'.format(
+                self.dossier.absolute_url(), self.regular_user.id),
+            headers={'Accept': 'application/json'},
+        )
+
+        self.assertDictEqual(
+            {
+                u'@id': u'{}/@listing-stats'.format(self.dossier.absolute_url()),
+                u'facet_pivot': {
+                    u'listing_name': [
+                        {u'count': 12, u'field':
+                         u'listing_name',
+                         u'value': u'documents',
+                         u'queries': {u'responsible:kathi.barfuss': 1}},
+                        {u'count': 0,
+                         u'field': u'listing_name',
+                         u'value': u'workspaces',
+                         u'queries': {u'responsible:kathi.barfuss': 0}},
+                        {u'count': 3,
+                         u'field': u'listing_name',
+                         u'value': u'dossiers',
+                         u'queries': {u'responsible:kathi.barfuss': 0}},
+                        {u'count': 0,
+                         u'field': u'listing_name',
+                         u'value': u'contacts',
+                         u'queries': {u'responsible:kathi.barfuss': 0}},
+                        {u'count': 9,
+                         u'field': u'listing_name',
+                         u'value': u'tasks',
+                         u'queries': {u'responsible:kathi.barfuss': 8}},
+                        {u'count': 0,
+                         u'field': u'listing_name',
+                         u'value': u'workspace_folders',
+                         u'queries': {u'responsible:kathi.barfuss': 0}},
+                        {u'count': 3,
+                         u'field': u'listing_name',
+                         u'value': u'proposals',
+                         u'queries': {u'responsible:kathi.barfuss': 0}},
+                        {u'count': 0,
+                         u'field': u'listing_name',
+                         u'value': u'todos',
+                         u'queries': {u'responsible:kathi.barfuss': 0}},
+                    ]
+                }
+            }, browser.json)

--- a/opengever/api/tests/test_listing_stats.py
+++ b/opengever/api/tests/test_listing_stats.py
@@ -129,7 +129,7 @@ class TestListingStats(SolrIntegrationTestCase):
         self.assertEqual(0, self.get_facet_by_value(pivot, 'documents').get('count'))
 
     @browsing
-    def test_listing_stats_pivot_queries_support(self, browser):
+    def test_listing_stats_pivot_queries_full_response(self, browser):
         self.login(self.regular_user, browser)
         browser.open(
             '{}/@listing-stats?queries=responsible:{}'.format(
@@ -177,3 +177,35 @@ class TestListingStats(SolrIntegrationTestCase):
                     ]
                 }
             }, browser.json)
+
+    @browsing
+    def test_listing_stats_pivot_queries_supports_depth(self, browser):
+        self.login(self.regular_user, browser)
+        browser.open(
+            '{}/@listing-stats?queries=depth:1'.format(self.dossier.absolute_url()),
+            headers={'Accept': 'application/json'},
+        )
+        self.assertDictEqual(
+            {u'count': 12,
+             u'field': u'listing_name',
+             u'value': u'documents',
+             u'queries': {u'depth:1': 4}
+             },
+            browser.json['facet_pivot']['listing_name'][0])
+
+    @browsing
+    def test_listing_stats_pivot_queries_supports_multiple_queries(self, browser):
+        self.login(self.regular_user, browser)
+        browser.open(
+            '{}/@listing-stats?queries=responsible:{}&queries=depth:1'.format(
+                self.dossier.absolute_url(), self.regular_user.id),
+            headers={'Accept': 'application/json'},
+        )
+        self.assertDictEqual(
+            {u'count': 12,
+             u'field': u'listing_name',
+             u'value': u'documents',
+             u'queries': {u'responsible:kathi.barfuss': 1,
+                          u'depth:1': 4}
+             },
+            browser.json['facet_pivot']['listing_name'][0])

--- a/opengever/api/tests/test_listing_stats.py
+++ b/opengever/api/tests/test_listing_stats.py
@@ -194,7 +194,7 @@ class TestListingStats(SolrIntegrationTestCase):
             browser.json['facet_pivot']['listing_name'][0])
 
     @browsing
-    def test_listing_stats_pivot_queries_supports_multiple_queries(self, browser):
+    def test_listing_stats_pivot_queries_supports_unicode(self, browser):
         self.login(self.regular_user, browser)
         browser.open(
             '{}/@listing-stats?queries=responsible:{}&queries=depth:1'.format(
@@ -207,5 +207,22 @@ class TestListingStats(SolrIntegrationTestCase):
              u'value': u'documents',
              u'queries': {u'responsible:kathi.barfuss': 1,
                           u'depth:1': 4}
+             },
+            browser.json['facet_pivot']['listing_name'][0])
+
+    @browsing
+    def test_listing_stats_pivot_queries_supports_special_characters(self, browser):
+        self.login(self.regular_user, browser)
+        browser.open(
+            u'{}/@listing-stats?queries=Title:Vertr\xe4ge'.format(
+                self.dossier.absolute_url()),
+            headers={'Accept': 'application/json'},
+        )
+
+        self.assertDictEqual(
+            {u'count': 12,
+             u'field': u'listing_name',
+             u'value': u'documents',
+             u'queries': {u'Title:Vertr\xe4ge': 3}
              },
             browser.json['facet_pivot']['listing_name'][0])


### PR DESCRIPTION
In the new frontend, we use the `listing-stats` endpoint to show the total number of items in the different tabs, without having to query the corresponding listing. But there are several places where we have hidden filters, for example:
- only show dossiers for current responsible on the dashboard
- only show `opengever.document.document` in template folder and not all `BaseDocument`
- only count main dossiers and tasks in the respective tabs... 

So to get be able to display the correct total item counts in such situations, we add support for pivot queries in the `listing-stats` endpoint. This allows to define queries as request parameter for which statistics will be calculated for each pivot. I also added support for `depth`, which we will need to get the correct counts for main dossiers and tasks.

For https://4teamwork.atlassian.net/browse/GEVER-456, https://4teamwork.atlassian.net/browse/GEVER-91 and https://4teamwork.atlassian.net/browse/GEVER-216

## Checklist (Must have)

- [x] Changelog entry
- [x] Documentation updated (notably for API and deployment)
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
