### PR TITLE
Fix typos in the dev-manual of tasks.rst

### DIFF
--- a/docs/public/dev-manual/api/tasks.rst
+++ b/docs/public/dev-manual/api/tasks.rst
@@ -170,7 +170,7 @@ Zusätzliche Metadaten:
 
 Hinweis:
 
-Das Attribut ``responsible`` kann einen kombinierten Wert im Format ``responsible_client:responsible`` enthalten. Z.b. ``fd:hans.muster`` oder ``team:musterteam``. Wird das Feld ``responsible_client`` mit einem kombinierten Wert befüllt, muss das Feld ``responsile_client`` nicht mehr mitgeschickt werden.
+Das Attribut ``responsible`` kann einen kombinierten Wert im Format ``responsible_client:responsible`` enthalten. Z.b. ``fd:hans.muster`` oder ``team:musterteam``. Wird das Feld ``responsible`` mit einem kombinierten Wert befüllt, muss das Feld ``responsible_client`` nicht mehr mitgeschickt werden.
 
 Erledigen
 ~~~~~~~~~


### PR DESCRIPTION
This PR fixes a type on the `tasks.rst` of the `dev-manual` introduced in #6484 
