### PR TITLE
Don't send mails with From-Addresses other than our own, and set Reply-To header

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -8,6 +8,7 @@ Changelog
 - Bump ftw.mail to 2.7.0 for signed/multipart handling. [deiferni]
 - Bump ftw.mail to 2.6.2 to get improved email header decoding. [mbaechtold]
 - Fix p7m attachment extraction from mails. [deiferni]
+- Avoid sending mails with From-Addresses other than our own. [lgraf]
 - Fix bug with setting issuer and informed_principals on forwardings. [njohner]
 - Allow notifying users and groups when creating a new task. [njohner]
 - Enable API endpoint `@document-from-template` for tasks. [mbaechtold]

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -8,6 +8,7 @@ Changelog
 - Bump ftw.mail to 2.7.0 for signed/multipart handling. [deiferni]
 - Bump ftw.mail to 2.6.2 to get improved email header decoding. [mbaechtold]
 - Fix p7m attachment extraction from mails. [deiferni]
+- Set Reply-To header from mails sent on behalf of users. [lgraf]
 - Avoid sending mails with From-Addresses other than our own. [lgraf]
 - Fix bug with setting issuer and informed_principals on forwardings. [njohner]
 - Allow notifying users and groups when creating a new task. [njohner]

--- a/opengever/activity/mailer.py
+++ b/opengever/activity/mailer.py
@@ -85,14 +85,20 @@ class Mailer(object):
             data = {}
 
         msg = MIMEMultipart('related')
+
         actor = ogds_service().fetch_user(from_userid) if from_userid else None
+        noreply_gever_address = api.portal.get().email_from_address
 
         if actor:
+            # Set From: header to full name of actor, but 'noreply' address
+            # of the GEVER deployment. Sending mails with the From-address of
+            # the actor would lead to them getting rejected in modern mail
+            # setup, e.g. when DKIM is being used.
             msg['From'] = make_addr_header(actor.fullname(),
-                                           actor.email, 'utf-8')
+                                           noreply_gever_address, 'utf-8')
         else:
             msg['From'] = make_addr_header(
-                self.default_addr_header, api.portal.get().email_from_address, 'utf-8')
+                self.default_addr_header, noreply_gever_address, 'utf-8')
 
         if to_userid:
             to_email = ogds_service().fetch_user(to_userid).email

--- a/opengever/activity/mailer.py
+++ b/opengever/activity/mailer.py
@@ -2,6 +2,7 @@ from email.header import Header
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from opengever.activity.error_handling import NotificationErrorHandler
+from opengever.base.interfaces import IOGMailSettings
 from opengever.base.model import get_locale
 from opengever.mail.utils import make_addr_header
 from opengever.ogds.models.service import ogds_service
@@ -89,16 +90,27 @@ class Mailer(object):
         actor = ogds_service().fetch_user(from_userid) if from_userid else None
         noreply_gever_address = api.portal.get().email_from_address
 
-        if actor:
-            # Set From: header to full name of actor, but 'noreply' address
-            # of the GEVER deployment. Sending mails with the From-address of
-            # the actor would lead to them getting rejected in modern mail
-            # setup, e.g. when DKIM is being used.
-            msg['From'] = make_addr_header(actor.fullname(),
-                                           noreply_gever_address, 'utf-8')
+        send_with_actor_from_address = api.portal.get_registry_record(
+            name='send_with_actor_from_address', interface=IOGMailSettings)
 
-            # Set the Reply-To header to the actual user's address
-            msg['Reply-To'] = make_addr_header(actor.fullname(),
+        if actor:
+            if not send_with_actor_from_address:
+                # Set From: header to full name of actor, but 'noreply' address
+                # of the GEVER deployment. Sending mails with the From-address of
+                # the actor would lead to them getting rejected in modern mail
+                # setup, e.g. when DKIM is being used.
+                msg['From'] = make_addr_header(actor.fullname(),
+                                               noreply_gever_address, 'utf-8')
+
+                # Set the Reply-To header to the actual user's address
+                msg['Reply-To'] = make_addr_header(actor.fullname(),
+                                                   actor.email, 'utf-8')
+            else:
+                # Use the actor's email address for the From: header.
+                # This might be caught in spam filters because it's effectively
+                # sender address spoofing, but is sometimes desired by
+                # customers for compatibility with autoresponders.
+                msg['From'] = make_addr_header(actor.fullname(),
                                                actor.email, 'utf-8')
         else:
             msg['From'] = make_addr_header(

--- a/opengever/activity/mailer.py
+++ b/opengever/activity/mailer.py
@@ -96,6 +96,10 @@ class Mailer(object):
             # setup, e.g. when DKIM is being used.
             msg['From'] = make_addr_header(actor.fullname(),
                                            noreply_gever_address, 'utf-8')
+
+            # Set the Reply-To header to the actual user's address
+            msg['Reply-To'] = make_addr_header(actor.fullname(),
+                                               actor.email, 'utf-8')
         else:
             msg['From'] = make_addr_header(
                 self.default_addr_header, noreply_gever_address, 'utf-8')

--- a/opengever/activity/tests/test_mail.py
+++ b/opengever/activity/tests/test_mail.py
@@ -141,6 +141,7 @@ class TestEmailNotification(IntegrationTestCase):
         mail = email.message_from_string(Mailing(self.portal).pop())
         self.assertEquals('foo@example.com', mail.get('To'))
         self.assertEquals('Ziegler Robert <test@localhost>', get_header(mail, 'From'))
+        self.assertEquals('Ziegler Robert <robert.ziegler@gever.local>', get_header(mail, 'Reply-To'))
 
     @browsing
     def test_task_title_is_linked_to_resolve_notification_view(self, browser):

--- a/opengever/activity/tests/test_mail.py
+++ b/opengever/activity/tests/test_mail.py
@@ -140,7 +140,7 @@ class TestEmailNotification(IntegrationTestCase):
 
         mail = email.message_from_string(Mailing(self.portal).pop())
         self.assertEquals('foo@example.com', mail.get('To'))
-        self.assertEquals('Ziegler Robert <robert.ziegler@gever.local>', get_header(mail, 'From'))
+        self.assertEquals('Ziegler Robert <test@localhost>', get_header(mail, 'From'))
 
     @browsing
     def test_task_title_is_linked_to_resolve_notification_view(self, browser):

--- a/opengever/base/interfaces.py
+++ b/opengever/base/interfaces.py
@@ -352,6 +352,18 @@ class IRecentlyTouchedSettings(Interface):
         default=10)
 
 
+class IOGMailSettings(Interface):
+
+    send_with_actor_from_address = schema.Bool(
+        title=u"Send mails with actor's email address in From: header",
+        description=u"Whether mails sent on behalf of actors (users) should "
+                    u"be sent with the user's email address in the From: "
+                    u"header. The default (False) is to use the system's "
+                    u"'noreply' address instead (to avoid sender address "
+                    u"spoofing).",
+        default=False)
+
+
 class IGeverUI(Interface):
 
     is_feature_enabled = schema.Bool(

--- a/opengever/core/profiles/default/registry.xml
+++ b/opengever/core/profiles/default/registry.xml
@@ -10,6 +10,7 @@
   <records interface="opengever.base.interfaces.IFavoritesSettings" />
   <records interface="opengever.base.behaviors.classification.IClassificationSettings" />
   <records interface="opengever.base.interfaces.IRecentlyTouchedSettings" />
+  <records interface="opengever.base.interfaces.IOGMailSettings" />
 
   <!-- BUMBLEBEE -->
   <records interface="opengever.bumblebee.interfaces.IGeverBumblebeeSettings" />

--- a/opengever/core/upgrades/20200609102902_add_iog_mail_settings_registry_record/registry.xml
+++ b/opengever/core/upgrades/20200609102902_add_iog_mail_settings_registry_record/registry.xml
@@ -1,0 +1,3 @@
+<registry>
+  <records interface="opengever.base.interfaces.IOGMailSettings" />
+</registry>

--- a/opengever/core/upgrades/20200609102902_add_iog_mail_settings_registry_record/upgrade.py
+++ b/opengever/core/upgrades/20200609102902_add_iog_mail_settings_registry_record/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddIOGMailSettingsRegistryRecord(UpgradeStep):
+    """Add IOGMailSettings registry record.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/workspace/tests/test_invitation.py
+++ b/opengever/workspace/tests/test_invitation.py
@@ -76,6 +76,9 @@ class TestInvitationMail(IntegrationTestCase):
 
             self.assertIn('test@localhost', mail.get("From"))
             self.assertEqual(self.regular_user.getProperty('email'), mail.get("To"))
+            self.assertEqual(
+                '=?utf-8?q?Hugentobler_Fridolin?= <fridolin.hugentobler@gever.local>',
+                mail.get("Reply-To"))
 
             payload = {"iid": iid}
             payload = serialize_and_sign_payload(payload)

--- a/opengever/workspace/tests/test_invitation.py
+++ b/opengever/workspace/tests/test_invitation.py
@@ -57,8 +57,9 @@ class TestInvitationMail(IntegrationTestCase):
     def test_adding_invitation_sends_mail(self):
         self.login(self.workspace_admin)
 
-        mailing = Mailing(self.portal)
         process_mail_queue()
+        mailing = Mailing(self.portal)
+        mailing.reset()
         self.assertFalse(mailing.has_messages())
 
         with freeze(datetime(2019, 12, 27)):
@@ -73,7 +74,7 @@ class TestInvitationMail(IntegrationTestCase):
             self.assertEqual(1, len(mails))
             mail = email.message_from_string(mails[0])
 
-            self.assertIn(self.workspace_admin.getProperty('email'), mail.get("From"))
+            self.assertIn('test@localhost', mail.get("From"))
             self.assertEqual(self.regular_user.getProperty('email'), mail.get("To"))
 
             payload = {"iid": iid}


### PR DESCRIPTION
- Don't send mails with `From:` addresses other than our own
- Instead set a `Reply-To:` header containing the human actor's address
- Make this new behavior the default, but configurable

This avoids sending activity mails with `From:` addresses of OGDS users, which would effectively be spoofing, and instead uses the Plone site's sender address as configured in the mail settings.

In addition, a `Reply-To:` header with the user's address is set instead for mails that are triggered based on the action of a human actor (in the hope that out-of-office replies will be sent there, still reaching the human actor).

In contrast to what's been outlined in the story / done before in #6334, I chose to still use the **user's full name** in the `From:` header (just like GitHub does for example), and just not use their email address. From what I can tell, this shouldn't be a problem with DKIM / DMARC.

So, mails triggered by a human actor will contain headers like this:
```
From: Peter Muster <noreply@gever.example.org>
Reply-To: Peter Muster <peter@muster.example.com>
```

This new behavior is the default, but setting the registry flag `IOGMail.send_with_actor_from_address` to `True` the legacy behavior can be enabled, where the actor's email address is directly used in the `From:` header.

---

Unfortunately, the `Reply-To:` header might not be used for out-of-office replies from what I can tell. [RFC 3834](https://tools.ietf.org/html/rfc3834) specifies behavior for auto-responders, and it says

> Use of the From field as the destination for automatic responses has
> some of the same problems as use of Reply-To.  In particular, the
> From field may list multiple addresses, while automatic responses
> should only be sent to a single address.  In general, the From and
> Reply-To addresses are used in a variety of ways according to
> differing circumstances, and for this reason Personal or Group
> Responders **cannot reliably assume that an address in the From or
> Reply-To field is an appropriate destination for the response.  For
> these reasons the From field SHOULD NOT be used as a destination for
> automatic responses.**

The recommendation seems to be for auto-responders to base these sorts of bounces on the Return-Path (so the MAIL FROM from the SMTP envelope, usually), and I've seen examples where this is the behavior seen in the wild ([MS Exchange example](https://stackoverflow.com/questions/3178429/out-of-office-replies-are-sent-to-from-address-not-reply-to))

For this reason, I made the behavior configurable, so we can enable the legacy behavior when desired by the customer.

Jira: https://4teamwork.atlassian.net/browse/GEVER-171

## Checklist (Must have)

- [x] Changelog entry
- [ ] Documentation updated (notably for API and deployment)
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

## Checklist (optional)

- Upgrade steps (changes in profile):
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
