### PR TITLE
Translate task types in GEVER api.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -27,6 +27,7 @@ Changelog
 - Support combined notation for task responsible in workflow transitions. [elioschmutz]
 - Bump docxcompose to 1.1.2 to fix issues with external image references and drawing properties. [buchi]
 - Always use configured solr port in tests. [2e12]
+- Fix translations of task types in API GET. [2e12]
 
 
 2020.3.0rc4 (2020-06-05)

--- a/opengever/api/solr_query_service.py
+++ b/opengever/api/solr_query_service.py
@@ -232,7 +232,7 @@ FIELDS_WITH_MAPPING = [
                  transform=lambda state: translate(
                     state, domain='plone', context=getRequest())),
     ListingField('review_state_label', 'review_state', 'translated_review_state'),
-    ListingField('task_type', 'task_type', translated_task_type),
+    ListingField('task_type', 'task_type', accessor=translated_task_type, transform=translate_task_type),
     ListingField('thumbnail_url', None, 'preview_image_url', DEFAULT_SORT_INDEX,
                  additional_required_fields=['bumblebee_checksum', 'path']),
     ListingField('title', 'Title', translated_title, 'sortable_title'),

--- a/opengever/api/tests/test_listing.py
+++ b/opengever/api/tests/test_listing.py
@@ -549,6 +549,26 @@ class TestListingWithRealSolr(SolrIntegrationTestCase):
             item)
 
     @browsing
+    def test_task_type_facets_are_translated(self, browser):
+        self.enable_languages()
+
+        self.login(self.workspace_member, browser=browser)
+        browser.open(self.dossier, view='@listing?name=tasks&facets:list=task_type',
+                     headers={'Accept': 'application/json',
+                              'Accept-Language': 'de-ch'})
+
+        self.assertDictEqual(
+            {u'task_type':
+                 {
+                     u'information': {u'count': 1, u'label': u'Zur Kenntnisnahme'},
+                     u'correction': {u'count': 2, u'label': u'Zur Pr\xfcfung / Korrektur'},
+                     u'direct-execution': {u'count': 6, u'label': u'Zur direkten Erledigung'}
+                 }
+            },
+            browser.json['facets']
+        )
+
+    @browsing
     def test_filter_by_is_subtask(self, browser):
         self.login(self.regular_user, browser=browser)
 


### PR DESCRIPTION
Due an error in the GEVER api the task types in the listing endpoint weren't translated. This is fixed in this commit.

Jira Issue: https://4teamwork.atlassian.net/browse/GEVER-462

<img width="647" alt="Bildschirmfoto 2020-06-09 um 13 15 23" src="https://user-images.githubusercontent.com/38817441/84141623-bee66880-aa53-11ea-9931-02f50d0c0637.png">



Definition of Done: https://4teamwork.atlassian.net/wiki/spaces/CHX4TW/pages/917562/


## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)