### PR TITLE
Fix and polish new info at feature.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2020.3.0rc5 (unreleased)
 ------------------------
 
+- Add OGDSGroupActor class. [njohner]
 - Set Reply-To header from mails sent on behalf of users. [lgraf]
 - Avoid sending mails with From-Addresses other than our own. [lgraf]
 - Fix bug with setting issuer and informed_principals on forwardings. [njohner]

--- a/opengever/activity/model/watcher.py
+++ b/opengever/activity/model/watcher.py
@@ -34,7 +34,7 @@ class Watcher(Base):
         representatives = [user.userid for user in
                            actor_lookup.lookup().representatives()]
 
-        if actor_lookup.is_inbox() or actor_lookup.is_team():
+        if actor_lookup.is_inbox():
             return [userid for userid in representatives
                     if UserSettings.get_setting_for_user(
                         userid, 'notify_inbox_actions')]

--- a/opengever/activity/model/watcher.py
+++ b/opengever/activity/model/watcher.py
@@ -1,6 +1,5 @@
 from opengever.base.model import Base
 from opengever.base.model import USER_ID_LENGTH
-from opengever.ogds.base.actor import Actor
 from opengever.ogds.base.actor import ActorLookup
 from opengever.ogds.models.user_settings import UserSettings
 from sqlalchemy import Column
@@ -27,15 +26,16 @@ class Watcher(Base):
     def get_user_ids(self):
         """Returns a list of userids which represents the given watcher:
 
-        Means for a single user, a list with the user_id and for a inbox
+        Means for a single user, a list with the user_id and for an inbox
         watcher, a list of the userids of all inbox_group users who have
         notify_inbox_actions set to True.
         """
         actor_lookup = ActorLookup(self.actorid)
-        if actor_lookup.is_inbox() or actor_lookup.is_team():
-            return [user.userid for user in
-                    Actor.lookup(self.actorid).representatives()
-                    if UserSettings.get_setting_for_user(
-                        user.userid, 'notify_inbox_actions')]
+        representatives = [user.userid for user in
+                           actor_lookup.lookup().representatives()]
 
-        return [self.actorid]
+        if actor_lookup.is_inbox() or actor_lookup.is_team():
+            return [userid for userid in representatives
+                    if UserSettings.get_setting_for_user(
+                        userid, 'notify_inbox_actions')]
+        return representatives

--- a/opengever/activity/notification_settings.py
+++ b/opengever/activity/notification_settings.py
@@ -36,7 +36,7 @@ NOTIFICATION_CONFIGURATION = [
                        ],
         'default_settings': {
             'badge_notification_roles': [TASK_RESPONSIBLE_ROLE, TASK_ISSUER_ROLE, WATCHER_ROLE],
-            'mail_notification_roles': [TASK_RESPONSIBLE_ROLE],
+            'mail_notification_roles': [TASK_RESPONSIBLE_ROLE, WATCHER_ROLE],
         },
     },
     {

--- a/opengever/activity/tests/test_hooks.py
+++ b/opengever/activity/tests/test_hooks.py
@@ -7,6 +7,9 @@ class TestNotificationDefaultsHook(IntegrationTestCase):
     def test_notification_default(self):
         # only check task-added default as a sample
         default = NotificationDefault.query.by_kind('task-added-or-reassigned').first()
-        expected_notifications = frozenset([u'regular_watcher', u'task_issuer', u'task_responsible'])
-        self.assertEquals(expected_notifications, default.badge_notification_roles)
-        self.assertEquals(frozenset([u'task_responsible']), default.mail_notification_roles)
+        expected_notifications = frozenset(
+            [u'regular_watcher', u'task_issuer', u'task_responsible'])
+        self.assertEquals(expected_notifications,
+                          default.badge_notification_roles)
+        self.assertEquals(frozenset([u'regular_watcher', u'task_responsible']),
+                          default.mail_notification_roles)

--- a/opengever/activity/tests/test_model.py
+++ b/opengever/activity/tests/test_model.py
@@ -31,6 +31,8 @@ class TestNotification(ActivityTestCase):
         activity = create(Builder('activity').having(
             title=u'Bitte \xc4nderungen nachvollziehen', resource=resource))
 
+        create(Builder('ogds_user').id(u'h\xfcgo'))
+        create(Builder('ogds_user').id('peter'))
         hugo = create(Builder('watcher').having(actorid=u'h\xfcgo'))
         peter = create(Builder('watcher').having(actorid=u'peter'))
 

--- a/opengever/activity/tests/test_notification_center.py
+++ b/opengever/activity/tests/test_notification_center.py
@@ -241,6 +241,8 @@ class TestAddActivity(ActivityTestCase):
         self.assertEquals(123, resource.int_id)
 
     def test_creates_notifications_for_each_resource_watcher(self):
+        create(Builder('ogds_user').id(u'peter'))
+        create(Builder('ogds_user').id(u'hugo'))
         peter = create(Builder('watcher').having(actorid='peter'))
         hugo = create(Builder('watcher').having(actorid='hugo'))
 
@@ -501,6 +503,8 @@ class TestDispatchers(ActivityTestCase):
         self.center = NotificationCenter(
             [self.dispatcher, BadgeIconDispatcher(), DigestDispatcher()])
 
+        create(Builder('ogds_user').id(u'hugo'))
+        create(Builder('ogds_user').id(u'peter'))
         hugo = create(Builder('watcher').having(actorid='hugo'))
         peter = create(Builder('watcher').having(actorid='peter'))
         resource = create(Builder('resource').oguid('fd:123'))
@@ -520,7 +524,6 @@ class TestDispatchers(ActivityTestCase):
         create(Builder('notification_setting')
                .having(kind='task-added-or-reassigned', userid='hugo'))
 
-
         self.center.add_activity(
             Oguid('fd', '123'),
             'task-added',
@@ -536,10 +539,10 @@ class TestDispatchers(ActivityTestCase):
             [note.userid for note in self.dispatcher.notified])
 
     def test_uses_notification_default_as_fallback(self):
-        setting = create(Builder('notification_default_setting')
-                         .having(kind='task-added-or-reassigned',
-                                 mail_notification_roles=[
-                                     WATCHER_ROLE, TASK_RESPONSIBLE_ROLE]))
+        create(Builder('notification_default_setting')
+               .having(kind='task-added-or-reassigned',
+                       mail_notification_roles=[
+                        WATCHER_ROLE, TASK_RESPONSIBLE_ROLE]))
 
         self.center.add_activity(
             Oguid('fd', '123'),
@@ -553,9 +556,9 @@ class TestDispatchers(ActivityTestCase):
         self.assertEquals(2, len(self.dispatcher.notified))
 
     def test_only_watchers_with_configured_roles_are_dispatched(self):
-        setting = create(Builder('notification_default_setting')
-                         .having(kind='task-added-or-reassigned',
-                                 mail_notification_roles=[WATCHER_ROLE]))
+        create(Builder('notification_default_setting')
+               .having(kind='task-added-or-reassigned',
+                       mail_notification_roles=[WATCHER_ROLE]))
 
         self.center.add_activity(
             Oguid('fd', '123'),
@@ -579,13 +582,12 @@ class TestDispatchers(ActivityTestCase):
             'hugo.boss',
             {'en': None})
 
-
         self.assertEquals(0, len(self.dispatcher.notified))
 
     def test_badge_dispatcher_sets_badge_flag_depending_on_the_setting(self):
-        setting = create(Builder('notification_default_setting')
-                         .having(kind='task-added-or-reassigned',
-                                 badge_notification_roles=[TASK_RESPONSIBLE_ROLE]))
+        create(Builder('notification_default_setting')
+               .having(kind='task-added-or-reassigned',
+                       badge_notification_roles=[TASK_RESPONSIBLE_ROLE]))
 
         self.center.add_activity(
             Oguid('fd', '123'),

--- a/opengever/activity/tests/test_settings.py
+++ b/opengever/activity/tests/test_settings.py
@@ -31,7 +31,7 @@ class TestListSettings(IntegrationTestCase):
 
         task_added = [item for item in activities if item.get('kind') == 'task-added-or-reassigned'][0]
         self.assertEquals(
-            {u'regular_watcher': False, u'task_issuer': False, u'task_responsible': True},
+            {u'regular_watcher': True, u'task_issuer': False, u'task_responsible': True},
             task_added['mail'])
         self.assertEquals({u'regular_watcher': True, u'task_issuer': True, u'task_responsible': True},
                           task_added['badge'])

--- a/opengever/activity/tests/test_watcher.py
+++ b/opengever/activity/tests/test_watcher.py
@@ -49,3 +49,15 @@ class TestWatcher(FunctionalTestCase):
         watcher = create(Builder('watcher').having(actorid=u'inbox:fd'))
         self.assertEqual(['hugo.boss', 'james.bond'],
                          watcher.get_user_ids())
+
+    def test_get_user_ids_returns_userids_of_group_users_for_group_watcher(self):
+        group_id = 'informed_users'
+        group = create(Builder('ogds_group').having(groupid=group_id))
+
+        create(Builder('ogds_user').id(u'hugo.boss').in_group(group))
+        create(Builder('ogds_user').id(u'peter.michel').in_group(group))
+        create(Builder('ogds_user').id(u'james.bond'))
+
+        watcher = create(Builder('watcher').having(actorid=group_id))
+        self.assertEqual(['hugo.boss', 'peter.michel'],
+                         watcher.get_user_ids())

--- a/opengever/activity/tests/test_watcher.py
+++ b/opengever/activity/tests/test_watcher.py
@@ -61,3 +61,26 @@ class TestWatcher(FunctionalTestCase):
         watcher = create(Builder('watcher').having(actorid=group_id))
         self.assertEqual(['hugo.boss', 'peter.michel'],
                          watcher.get_user_ids())
+
+    def test_get_user_ids_returns_userids_of_team_users_for_team_watcher(self):
+        create(Builder('admin_unit').id('fd'))
+
+        orgunit = create(Builder('org_unit').id('fd').having(
+          admin_unit_id='fd'))
+
+        group = create(Builder('ogds_group').having(
+          groupid='informed_users'))
+
+        team = create(Builder('ogds_team').having(
+          group=group,
+          title='Test Team',
+          org_unit=orgunit))
+
+        create(Builder('ogds_user').id(u'hugo.boss').in_group(group))
+        create(Builder('ogds_user').id(u'peter.michel').in_group(group))
+        create(Builder('ogds_user').id(u'james.bond'))
+
+        actorid = 'team:{}'.format(team.team_id)
+        watcher = create(Builder('watcher').having(actorid=actorid))
+        self.assertEqual(['hugo.boss', 'peter.michel'],
+                         watcher.get_user_ids())

--- a/opengever/core/upgrades/20200608170947_add_watcher_role_to_task_added_mail_notification_settings/upgrade.py
+++ b/opengever/core/upgrades/20200608170947_add_watcher_role_to_task_added_mail_notification_settings/upgrade.py
@@ -1,0 +1,54 @@
+from opengever.core.upgrade import SchemaMigration
+from opengever.activity.roles import TASK_RESPONSIBLE_ROLE
+from opengever.activity.roles import WATCHER_ROLE
+from sqlalchemy.sql.expression import column
+from sqlalchemy.sql.expression import table
+from opengever.activity.model import NotificationSetting
+import json
+
+DEFAULT_SETTINGS = [
+    {
+        'kind': 'task-added-or-reassigned',
+        'mail_notification_roles': [TASK_RESPONSIBLE_ROLE, WATCHER_ROLE]
+    },
+]
+
+defaults_table = table(
+    "notification_defaults",
+    column("id"),
+    column("kind"),
+    column("mail_notification_roles"))
+
+
+class AddWatcherRoleToTaskAddedMailNotificationSettings(SchemaMigration):
+    """Add watcher role to task added mail notification settings.
+    """
+
+    def migrate(self):
+        self.update_notification_defaults()
+        self.migrate_user_settings()
+
+    def update_notification_defaults(self):
+        for item in DEFAULT_SETTINGS:
+
+            self.execute(
+                defaults_table.update()
+                .values(mail_notification_roles=json.dumps(item['mail_notification_roles']))
+                .where(defaults_table.columns.kind == item.get('kind'))
+            )
+
+    def migrate_user_settings(self):
+        kinds = [default_setting.get('kind') for default_setting in DEFAULT_SETTINGS]
+        settings = NotificationSetting.query.filter(NotificationSetting.kind.in_(kinds))
+        for setting in settings:
+            notification_roles = [role for role in setting.mail_notification_roles]
+            if TASK_RESPONSIBLE_ROLE not in notification_roles:
+                # as TASK_RESPONSIBLE user explicitely did not want mails when
+                # a task is created, accordingly we use that same default for
+                # created tasks as watcher
+                continue
+            if WATCHER_ROLE in notification_roles:
+                # user has already modified his settings
+                continue
+            notification_roles.append(WATCHER_ROLE)
+            setting.mail_notification_roles = notification_roles

--- a/opengever/ogds/base/browser/userdetails.py
+++ b/opengever/ogds/base/browser/userdetails.py
@@ -1,9 +1,9 @@
 from opengever.contact.utils import get_contactfolder_url
-from opengever.ogds.models.service import ogds_service
+from opengever.ogds.base.utils import groupmembers_url
 from opengever.ogds.models.exceptions import RecordNotFound
+from opengever.ogds.models.service import ogds_service
 from Products.Five import BrowserView
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
-from urllib import urlencode
 from zExceptions import NotFound
 from zope.component.hooks import getSite
 from zope.interface import implementer
@@ -49,6 +49,4 @@ class UserDetails(BrowserView):
         return get_contactfolder_url()
 
     def groupmembers_url(self, groupid):
-        portal = getSite()
-        qs = urlencode({'group': groupid})
-        return '/'.join((portal.portal_url(), '@@list_groupmembers?%s' % qs))
+        return groupmembers_url(groupid)

--- a/opengever/ogds/base/utils.py
+++ b/opengever/ogds/base/utils.py
@@ -9,6 +9,7 @@ from plone import api
 from plone.registry.interfaces import IRegistry
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.interfaces import IPloneSiteRoot
+from urllib import urlencode
 from UserDict import DictMixin
 from zope.component import getUtility
 from zope.component.hooks import getSite
@@ -210,3 +211,9 @@ def encode_after_json(value):
     # other types
     else:
         return value
+
+
+def groupmembers_url(groupid):
+    portal = getSite()
+    qs = urlencode({'group': groupid})
+    return '/'.join((portal.portal_url(), '@@list_groupmembers?%s' % qs))

--- a/opengever/sharing/browser/sharing.py
+++ b/opengever/sharing/browser/sharing.py
@@ -10,6 +10,7 @@ from opengever.base.handlebars import get_handlebars_template
 from opengever.base.role_assignments import ASSIGNMENT_VIA_SHARING
 from opengever.base.role_assignments import RoleAssignmentManager
 from opengever.base.role_assignments import SharingRoleAssignment
+from opengever.ogds.base.utils import groupmembers_url
 from opengever.ogds.base.interfaces import IOGDSSyncConfiguration
 from opengever.ogds.base.utils import get_current_admin_unit
 from opengever.ogds.models.service import ogds_service
@@ -452,9 +453,7 @@ class OpengeverSharingView(SharingView):
         return results
 
     def groupmembers_url(self, groupid):
-        portal = api.portal.get()
-        qs = urlencode({'group': groupid})
-        return '/'.join((portal.portal_url(), '@@list_groupmembers?%s' % qs))
+        return groupmembers_url(groupid)
 
 
 class WorkspaceSharingView(OpengeverSharingView):

--- a/opengever/task/handlers.py
+++ b/opengever/task/handlers.py
@@ -146,8 +146,8 @@ def set_roles_after_modifying(context, event):
 
 
 def record_added_activity(task, event):
-    """Record task added activity, which also sets wathcers and
-    create notifications.
+    """Record task added activity, which also sets watchers and
+    creates notifications.
     """
     # Skip tasks created during successor creation, those are handled manually
     if getRequest().get('X-CREATING-SUCCESSOR', None):

--- a/opengever/task/locales/de/LC_MESSAGES/opengever.task.po
+++ b/opengever/task/locales/de/LC_MESSAGES/opengever.task.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2020-05-29 14:07+0000\n"
+"POT-Creation-Date: 2020-06-09 10:06+0000\n"
 "PO-Revision-Date: 2015-02-17 18:41+0100\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -961,10 +961,15 @@ msgstr "Aufgabe abgebrochen"
 msgid "transition_label_close"
 msgstr "Aufgabe abgeschlossen"
 
-#. Default: "Created by ${user}"
+#. Default: "Created by ${user}."
 #: ./opengever/task/viewlets/response.py
 msgid "transition_label_created"
-msgstr "Erstellt durch ${user}"
+msgstr "Erstellt durch ${user}."
+
+#. Default: "Created by ${user}. Info at ${informed_principals}."
+#: ./opengever/task/viewlets/response.py
+msgid "transition_label_created_info_an"
+msgstr "Erstellt durch ${user}. Info an ${informed_principals}."
 
 #. Default: "Task opened"
 #: ./opengever/task/activities.py

--- a/opengever/task/locales/fr/LC_MESSAGES/opengever.task.po
+++ b/opengever/task/locales/fr/LC_MESSAGES/opengever.task.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2020-05-29 14:07+0000\n"
+"POT-Creation-Date: 2020-06-09 10:06+0000\n"
 "PO-Revision-Date: 2017-12-03 11:47+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-task/fr/>\n"
@@ -963,10 +963,15 @@ msgstr "Tâche annulée"
 msgid "transition_label_close"
 msgstr "Tâche clôturée"
 
-#. Default: "Created by ${user}"
+#. Default: "Created by ${user}."
 #: ./opengever/task/viewlets/response.py
 msgid "transition_label_created"
-msgstr "Créé par ${user}"
+msgstr "Créé par ${user}."
+
+#. Default: "Created by ${user}. Info at ${informed_principals}."
+#: ./opengever/task/viewlets/response.py
+msgid "transition_label_created_info_an"
+msgstr "Créé par ${user}. Info à ${informed_principals}."
 
 #. Default: "Task opened"
 #: ./opengever/task/activities.py

--- a/opengever/task/locales/opengever.task.pot
+++ b/opengever/task/locales/opengever.task.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2020-05-29 14:07+0000\n"
+"POT-Creation-Date: 2020-06-09 10:06+0000\n"
 "PO-Revision-Date: 2009-02-25 14:39+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -959,9 +959,14 @@ msgstr ""
 msgid "transition_label_close"
 msgstr ""
 
-#. Default: "Created by ${user}"
+#. Default: "Created by ${user}."
 #: ./opengever/task/viewlets/response.py
 msgid "transition_label_created"
+msgstr ""
+
+#. Default: "Created by ${user}. Info at ${informed_principals}."
+#: ./opengever/task/viewlets/response.py
+msgid "transition_label_created_info_an"
 msgstr ""
 
 #. Default: "Task opened"

--- a/opengever/task/task.py
+++ b/opengever/task/task.py
@@ -93,12 +93,12 @@ class ITask(model.Schema):
             u'task_type',
             u'responsible_client',
             u'responsible',
+            u'informed_principals',
             u'is_private',
             u'revoke_permissions',
             u'deadline',
             u'text',
             u'relatedItems',
-            u'informed_principals'
             ],
         )
 

--- a/opengever/task/tests/test_response_viewlet.py
+++ b/opengever/task/tests/test_response_viewlet.py
@@ -28,7 +28,7 @@ class TestResponseViewlet(IntegrationTestCase):
         browser.open(self.subtask, view='tabbedview_view-overview')
 
         answer = browser.css('div.answers .answer').first
-        self.assertEqual('Created by Ziegler Robert (robert.ziegler)',
+        self.assertEqual('Created by Ziegler Robert (robert.ziegler).',
                          answer.css('h3').first.text)
         self.assertEqual('http://nohost/plone/@@user-details/robert.ziegler',
                          answer.css('h3 a').first.get('href'))

--- a/opengever/task/viewlets/response.py
+++ b/opengever/task/viewlets/response.py
@@ -68,9 +68,19 @@ class ResponseView(ViewletBase, Base):
             self.context.absolute_url(), id)
 
     def get_created_header(self):
-        return _('transition_label_created', 'Created by ${user}',
-                 mapping={
-                     'user': Actor.lookup(self.context.Creator()).get_link()})
+        creator = Actor.lookup(self.context.Creator()).get_link()
+        informed_principals = [
+            Actor.lookup(principal).get_link()
+            for principal in self.context.informed_principals]
+        if informed_principals:
+            return _('transition_label_created_info_an',
+                     'Created by ${user}. Info at ${informed_principals}.',
+                     mapping={
+                         'user': creator,
+                         'informed_principals': ", ".join(informed_principals)})
+        return _('transition_label_created',
+                 'Created by ${user}.',
+                 mapping={'user': creator})
 
     def get_created_date(self):
         adapter = getMultiAdapter((self.context, self.request), name="plone")


### PR DESCRIPTION
This is a followup PR to https://github.com/4teamwork/opengever.core/pull/6475. In this PR we fix a bug and add some polish according to feedback from the PO.

**Bugfix:**
- We fix a bug with groups selected in the `informed_principals` field. Groups were not handled correctly in the activities. Specifically we had to:
  - Add `OGDSGroupActor` class.
  - Make sure that `Watcher.get_user_ids` returns the representatives for a group, so that all representatives of the group get notified when a task is added

**Polish:**
- Reorder fields in task add form.
- Show informed principals in task added history.
- Add watcher role to task added mail notification settings, so that by default users get notified by mail of a task creation when they are in the `informed_principals`. For this upgrade, we only add the `WATCHER_ROLE` if the user hadn't changed the setting for `TASK_RESPONSIBLE_ROLE`. If the user does not want to be informed as `TASK_RESPONSIBLE_ROLE, he probably does not want to be informed as `WATCHER_ROLE` either...

**task added history when `informed_principals` is set**
<img width="1004" alt="Screenshot 2020-06-09 at 11 51 50" src="https://user-images.githubusercontent.com/7374243/84135321-20a1d500-aa4a-11ea-8b1d-f3bb80c530df.png">


For https://4teamwork.atlassian.net/browse/GEVER-31
Frontend PR: https://github.com/4teamwork/gever-ui/pull/1129

## Checklist (Must have)

- [x] Changelog entry: No changelog necessary, in the same release as original implementation https://github.com/4teamwork/opengever.core/pull/6475
- [x] Documentation updated (notably for API and deployment).
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

## Checklist (optional)

_Only applicable should be left and checked._
- DB-Schema migration
  - [x] All changes on a model (columns, etc) are included in a DB-schema migration.
  - [x] Constraint names are shorter than 30 characters (`Oracle`)
- New translations
  - [x] All msg-strings are unicode
  - [x] Correct i18n-domain was used (Copy-Paste errors are common here)