### PR TITLE
Always use configured solr port

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -20,6 +20,7 @@ Changelog
 - Enable API endpoint `@document-from-template` for tasks. [mbaechtold]
 - Support combined notation for task responsible in workflow transitions. [elioschmutz]
 - Bump docxcompose to 1.1.2 to fix issues with external image references and drawing properties. [buchi]
+- Always use configured solr port in tests. [2e12]
 
 
 2020.3.0rc4 (2020-06-05)

--- a/opengever/core/solr_testing.py
+++ b/opengever/core/solr_testing.py
@@ -115,7 +115,7 @@ class SolrServer(object):
     def _run_server_process(self):
         command = [BUILDOUT_DIR.joinpath('bin/solr'), 'fg']
         env = os.environ.copy()
-        env.setdefault('SOLR_PORT', str(self.port))
+        env['SOLR_PORT'] = str(self.port)
         self._stdout = io.StringIO()
         self._process = subprocess.Popen(command, stdout=subprocess.PIPE, env=env)
         while True:


### PR DESCRIPTION
In case 'SOLR_PORT' is already set in env it can't be overwritten by the configured port and in order to fix this setdefault() is replaced.

**Background**
For some reason I have defined a Solr port as env variable global. This had the consequence that my Solr did not work in the tests. In an exhausting debugging session we found out that "setdefault" was used to set the correct port. But here the value is only set if the value is not yet available. This had the consequence that a completely wrong port was used.

Was solved as part of https://4teamwork.atlassian.net/browse/GEVER-462.

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [ ] Documentation updated (notably for API and deployment)
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)