### PR TITLE
Define a set of columns that get synchronized in user and group model and remove import_stamp

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 ------------------------
 
 - Make available the delete action for templates. [mbaechtold]
+- Define a set of columns that get synchronized in user and group model. [tinagerber]
 - Add OGDSGroupActor class. [njohner]
 - Set Reply-To header from mails sent on behalf of users. [lgraf]
 - Avoid sending mails with From-Addresses other than our own. [lgraf]

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 ------------------------
 
 - Make available the delete action for templates. [mbaechtold]
+- Drop import_stamp column from user model. [tinagerber]
 - Define a set of columns that get synchronized in user and group model. [tinagerber]
 - Add OGDSGroupActor class. [njohner]
 - Set Reply-To header from mails sent on behalf of users. [lgraf]

--- a/docs/schema-dumps/_opengever.ogds.models.user.User.schema.json
+++ b/docs/schema-dumps/_opengever.ogds.models.user.User.schema.json
@@ -150,13 +150,6 @@
             "description": "",
             "_zope_schema_type": "Text"
         },
-        "import_stamp": {
-            "type": "string",
-            "title": "import_stamp",
-            "maxLength": 26,
-            "description": "",
-            "_zope_schema_type": "Text"
-        },
         "last_login": {
             "type": "string",
             "title": "last_login",
@@ -190,7 +183,6 @@
         "zip_code",
         "city",
         "country",
-        "import_stamp",
         "last_login"
     ]
 }

--- a/opengever/api/tests/test_ogdsuser.py
+++ b/opengever/api/tests/test_ogdsuser.py
@@ -40,7 +40,6 @@ class TestOGDSUserGet(IntegrationTestCase):
                           u'active': True,
                           u'groupid': u'projekt_a',
                           u'title': u'Projekt A'}],
-             u'import_stamp': None,
              u'lastname': u'B\xe4rfuss',
              u'phone_fax': u'012 34 56 77',
              u'phone_mobile': u'012 34 56 76',

--- a/opengever/core/upgrades/20200610151807_drop_import_stamp_column_from_user_model/upgrade.py
+++ b/opengever/core/upgrades/20200610151807_drop_import_stamp_column_from_user_model/upgrade.py
@@ -1,0 +1,9 @@
+from opengever.core.upgrade import SchemaMigration
+
+
+class DropImportStampColumnFromUserModel(SchemaMigration):
+    """Drop import_stamp column from user model.
+    """
+
+    def migrate(self):
+        self.op.drop_column('users', 'import_stamp')

--- a/opengever/ogds/base/sync/ogds_updater.py
+++ b/opengever/ogds/base/sync/ogds_updater.py
@@ -203,9 +203,8 @@ class OGDSUpdater(object):
                             u"Skipping duplicate user '{}'!".format(userid))
                         continue
 
-                # Iterate over all SQL columns and update their values
-                columns = User.__table__.columns
-                for col in columns:
+                # Iterate over all SQL columns to be synchronized and update their values
+                for col in user.columns_to_sync:
                     if col.name == 'userid':
                         # We already set the userid when creating the user
                         # object, and it may not be called the same in LDAP as
@@ -302,9 +301,8 @@ class OGDSUpdater(object):
 
                 logger.info(u"Importing group '{}'...".format(groupid))
 
-                # Iterate over all SQL columns and update their values
-                columns = Group.__table__.columns
-                for col in columns:
+                # Iterate over all SQL columns to be synchronized and update their values
+                for col in group.columns_to_sync:
                     setattr(group, col.name,
                             self._convert_value(info.get(col.name)))
 

--- a/opengever/ogds/models/group.py
+++ b/opengever/ogds/models/group.py
@@ -46,6 +46,8 @@ class Group(Base):
                      backref=backref('groups', order_by='Group.groupid'))
     teams = relationship(Team, back_populates="group")
 
+    column_names_to_sync = {'groupid', 'active', 'title'}
+
     def __init__(self, groupid, **kwargs):
         self.groupid = groupid
         super(Group, self).__init__(**kwargs)
@@ -63,6 +65,10 @@ class Group(Base):
         if result is NotImplemented:
             return result
         return not result
+
+    @property
+    def columns_to_sync(self):
+        return {col for col in self.__table__.columns if col.name in self.column_names_to_sync}
 
     def id(self):
         return self.groupid

--- a/opengever/ogds/models/tests/test_user.py
+++ b/opengever/ogds/models/tests/test_user.py
@@ -60,7 +60,6 @@ class TestUserModel(OGDSTestCase):
             'zip_code': '1234',
             'city': 'Bossingen',
             'country': 'Schweiz',
-            'import_stamp': 'stamp',
         }
 
         user = User(**attrs)

--- a/opengever/ogds/models/user.py
+++ b/opengever/ogds/models/user.py
@@ -53,7 +53,6 @@ class User(Base):
 
     country = Column(String(20))
 
-    import_stamp = Column(String(26))
     last_login = Column(Date, index=True)
 
     column_names_to_sync = {'active', 'firstname', 'lastname', 'directorate',

--- a/opengever/ogds/models/user.py
+++ b/opengever/ogds/models/user.py
@@ -56,6 +56,12 @@ class User(Base):
     import_stamp = Column(String(26))
     last_login = Column(Date, index=True)
 
+    column_names_to_sync = {'active', 'firstname', 'lastname', 'directorate',
+                            'directorate_abbr', 'department', 'department_abbr',
+                            'email', 'email2', 'url', 'phone_office', 'phone_fax',
+                            'phone_mobile', 'salutation', 'description', 'address1',
+                            'address2', 'zip_code', 'city', 'country'}
+
     def __init__(self, userid, **kwargs):
         self.userid = userid
         super(User, self).__init__(**kwargs)
@@ -73,6 +79,10 @@ class User(Base):
         if result is NotImplemented:
             return result
         return not result
+
+    @property
+    def columns_to_sync(self):
+        return {col for col in self.__table__.columns if col.name in self.column_names_to_sync}
 
     def label(self, with_principal=True):
         if not with_principal:


### PR DESCRIPTION
This is a followup PR to #6477 

Currently the last_login field is overwritten with None every time the LDAP is synchronized, because the field is not mapped to LDAP.

This has been corrected by the OGDSUpdater no longer synchronizing all fields of the user models, but only those that are in a set (column_names_to_sync). The same applies to the group model.

Furthermore the column import_stamp of the user model was deleted, because it is not used anymore.

Jira: https://4teamwork.atlassian.net/browse/GEVER-39

Definition of Done: https://4teamwork.atlassian.net/wiki/spaces/CHX4TW/pages/917562/

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Documentation updated (notably for API and deployment)
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
