### PR TITLE
Add minimalistic log handler for sentry.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -8,6 +8,7 @@ Changelog
 - Drop import_stamp column from user model. [tinagerber]
 - Define a set of columns that get synchronized in user and group model. [tinagerber]
 - Add OGDSGroupActor class. [njohner]
+- Explicitly log to sentry for two `ftw.solr` modules we want to monitor well at the moment. [deiferni]
 - Set Reply-To header from mails sent on behalf of users. [lgraf]
 - Avoid sending mails with From-Addresses other than our own. [lgraf]
 - Fix bug with setting issuer and informed_principals on forwardings. [njohner]


### PR DESCRIPTION
Explicitly log to sentry for two `ftw.solr` modules we want to monitor well at the moment.

The package `ftw.solr` currently only logs potentially critical issues in https://github.com/4teamwork/ftw.solr/blob/6f1db34678b4271e3b2640b85e4f11b6c8795fa3/ftw/solr/connection.py and https://github.com/4teamwork/ftw.solr/blob/6f1db34678b4271e3b2640b85e4f11b6c8795fa3/ftw/solr/handlers.py. With our currenty sentry integration only exceptions end up in sentry.

With this PR we add a very simple log-handler and specifically register it for the two modules. It also logs the messages (for certain levels) to sentry. Some examples:
- https://sentry.4teamwork.ch/sentry/onegov-gever/issues/68017
- https://sentry.4teamwork.ch/sentry/onegov-gever/issues/67593
- https://sentry.4teamwork.ch/sentry/onegov-gever/issues/67556
- https://sentry.4teamwork.ch/sentry/onegov-gever/issues/68016 _(for this one i hacked `ftw.solr` to also consider 200 repsones non-ok. wont' appear in production like this, of course)_

I have decided to write my first suggestion based on a log-handler integration as that way we do not have to modify `ftw.solr` yet.

This can be considered a stopgap measure for the moment as we are moving many things to solr and thus want to be specially aware of certain problems we might encounter. Not intended to stay around for long but rather a quick way to get logging to sentry for potentially critical solr errors. Should go away again once we have proper logging for non-exceptions to sentry.

I have not found a good way to easily write a test for this functionality. Input welcome. I have decided not to invest much time into maybe being able to also log a stack trace. If we switch to another sentry integration soon that will come for free. For now it provides awareness of certain issues which should hopefully be good enough for now.

For https://4teamwork.atlassian.net/browse/GEVER-182

Todo:
- [ ] delete sentry errors again once the PR is merged

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [ ] Documentation updated (notably for API and deployment)
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
