### PR TITLE
Handle depth filter in solrsearch endpoint.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,7 @@ Changelog
 - Make available the delete action for templates. [mbaechtold]
 - Drop import_stamp column from user model. [tinagerber]
 - Define a set of columns that get synchronized in user and group model. [tinagerber]
+- Handle depth filter in solrsearch endpoint. [njohner]
 - Add OGDSGroupActor class. [njohner]
 - Explicitly log to sentry for two `ftw.solr` modules we want to monitor well at the moment. [deiferni]
 - Set Reply-To header from mails sent on behalf of users. [lgraf]

--- a/docs/public/dev-manual/api/searching.rst
+++ b/docs/public/dev-manual/api/searching.rst
@@ -214,4 +214,12 @@ Beispiel für ein Suchabfrage mit Facetten für ``responsible`` und ``portal_typ
       "start": 0
     }
 
+Pfadtiefe
+~~~~~~~~~
+``depth``: Limitierung der maximalen Pfadtiefe, relativ zum Kontext oder angegebener Pfad (mit ``fq=path:/path/to/container``)
+
+.. sourcecode:: http
+
+  GET /plone/@solrsearch?depth=1 HTTP/1.1
+
 .. disqus::

--- a/opengever/api/listing_stats.py
+++ b/opengever/api/listing_stats.py
@@ -1,7 +1,6 @@
 from ftw.solr.interfaces import ISolrSearch
 from ftw.solr.query import escape
 from opengever.api.listing import FILTERS
-from opengever.api.listing import get_path_depth
 from opengever.base.interfaces import IOpengeverBaseLayer
 from plone.restapi.interfaces import IExpandableElement
 from plone.restapi.services import Service
@@ -11,6 +10,11 @@ from zope.component import adapter
 from zope.component import getUtility
 from zope.interface import implementer
 from zope.interface import Interface
+
+
+def get_path_depth(context):
+    # This mirrors the implementation in ftw.solr
+    return len(context.getPhysicalPath()) - 1
 
 
 @implementer(IExpandableElement)

--- a/opengever/api/solr_query_service.py
+++ b/opengever/api/solr_query_service.py
@@ -16,6 +16,7 @@ from plone.restapi.serializer.converters import json_compatible
 from plone.restapi.services import Service
 from plone.rfc822.interfaces import IPrimaryFieldInfo
 from Products.CMFPlone.utils import safe_unicode
+from zExceptions import BadRequest
 from zope.component import getUtility
 from zope.component.hooks import getSite
 from zope.globalrequest import getRequest
@@ -350,6 +351,17 @@ class SolrQueryBaseService(Service):
             # certain fields require data from other solr fields to be computed.
             requested_solr_fields.update(set(field.additional_required_fields))
         return list(requested_solr_fields & self.solr_fields)
+
+    def extract_depth(self, params):
+        """If depth is not specified we search recursively
+        """
+        # By default search recursively
+        depth = params.get('depth', -1)
+        try:
+            depth = int(depth)
+        except ValueError:
+            raise BadRequest("Could not parse depth: {}".format(depth))
+        return depth
 
     def prepare_additional_params(self, params):
         return params

--- a/opengever/api/tests/test_listing.py
+++ b/opengever/api/tests/test_listing.py
@@ -602,6 +602,14 @@ class TestListingWithRealSolr(SolrIntegrationTestCase):
             [u'2015', u'2016'],
             [item['title'] for item in browser.json['items']])
 
+        # depth 0 does not return anything as the context itself is excluded
+        view = ('@listing?name=dossiers&'
+                'columns:list=title'
+                '&depth=0')
+        browser.open(self.dossier, view=view, headers=self.api_headers)
+        self.assertEqual(0, browser.json['items_total'])
+        self.assertEqual(0, len(browser.json['items']))
+
     @browsing
     def test_filter_by_is_subdossier(self, browser):
         self.login(self.regular_user, browser=browser)


### PR DESCRIPTION
For the new Widget to choose objects from a tree like structure (https://4teamwork.atlassian.net/browse/GEVER-472) we need to be able to search for subdossiers directly contained in given dossier (we want to load items only one level at a time when the user actually clicks a given container). The `solrsearch` endpoint did not handle the `depth` parameter, and hence did not allow for any convenient way to search inside a given container. Moreover the `solrsearch` did not take into account the `context` on which it was called, but always search on the root, except if the `path` filter was specified. The new behavior is:
- search recursively when `depth` is not specified
- search on context when `path` filter is not specified
- search in given `path` when `path` filter is specified

**This is a breaking change of the API.**

For https://4teamwork.atlassian.net/browse/GEVER-472

## Checklist (Must have)

- [x] Changelog entry
- [x] Documentation updated (notably for API and deployment)
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
