### PR TITLE
Add new endpoints @assigned-users and @transfer-task

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -11,6 +11,7 @@ Changelog
 - Handle depth filter in solrsearch endpoint. [njohner]
 - Add OGDSGroupActor class. [njohner]
 - Explicitly log to sentry for two `ftw.solr` modules we want to monitor well at the moment. [deiferni]
+- Add @transfer-task endpoint to change issuer and responsible of a task. [tinagerber]
 - Add possibility to suppress notification with X-GEVER-SuppressNotifications header. [tinagerber]
 - Add @assigned-users endpoint to get all active users of the client. [tinagerber]
 - Set Reply-To header from mails sent on behalf of users. [lgraf]

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -11,6 +11,7 @@ Changelog
 - Handle depth filter in solrsearch endpoint. [njohner]
 - Add OGDSGroupActor class. [njohner]
 - Explicitly log to sentry for two `ftw.solr` modules we want to monitor well at the moment. [deiferni]
+- Add possibility to suppress notification with X-GEVER-SuppressNotifications header. [tinagerber]
 - Add @assigned-users endpoint to get all active users of the client. [tinagerber]
 - Set Reply-To header from mails sent on behalf of users. [lgraf]
 - Avoid sending mails with From-Addresses other than our own. [lgraf]

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -11,6 +11,7 @@ Changelog
 - Handle depth filter in solrsearch endpoint. [njohner]
 - Add OGDSGroupActor class. [njohner]
 - Explicitly log to sentry for two `ftw.solr` modules we want to monitor well at the moment. [deiferni]
+- Add @assigned-users endpoint to get all active users of the client. [tinagerber]
 - Set Reply-To header from mails sent on behalf of users. [lgraf]
 - Avoid sending mails with From-Addresses other than our own. [lgraf]
 - Fix bug with setting issuer and informed_principals on forwardings. [njohner]

--- a/docs/public/dev-manual/api/assigned_users.rst
+++ b/docs/public/dev-manual/api/assigned_users.rst
@@ -1,0 +1,45 @@
+Zugeordnete Benutzer
+====================
+
+Der ``@assigned-users`` Endpoint liefert ein Vokabular aller aktiven Benutzer, die dem entsprechenden Mandanten zugeordnet sind. Der Endpoint steht nur auf Stufe PloneSite zur Verfügung.
+
+
+**Beispiel-Request**:
+
+   .. sourcecode:: http
+
+       GET /@assigned-users?b_size=3 HTTP/1.1
+       Accept: application/json
+
+**Beispiel-Response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 200 OK
+      Content-Type: application/json
+
+        {
+          "@id": "http://localhost:8080/fd/@assigned-users",
+          "batching": {
+            "@id": "http://localhost:8080/fd/@assigned-users?b_size=3",
+            "first": "http://localhost:8080/fd/@assigned-users?b_start=0&b_size=3",
+            "last": "http://localhost:8080/fd/@assigned-users?b_start=9&b_size=3",
+            "next": "http://localhost:8080/fd/@assigned-users?b_start=3&b_size=3"
+          },
+          "items": [
+            {
+              "title": "Baerfuss Kaethi (kathi.barfuss)",
+              "token": "kathi.barfuss"
+            },
+            {
+              "title": "Kohler Nicole (nicole.kohler)",
+              "token": "nicole.kohler"
+            },
+            {
+              "title": "Ziegler Robert (robert.ziegler)",
+              "token": "robert.ziegler"
+            }
+          ],
+          "items_total": 12
+        }
+

--- a/docs/public/dev-manual/api/docs_changelog.rst
+++ b/docs/public/dev-manual/api/docs_changelog.rst
@@ -5,6 +5,12 @@ Changelog
 
 Im Folgenden sind (substantielle) Änderungen an der Dokumentation aufgeführt.
 
+2020-06-11
+----------
+
+- Kapitel "Zugeordnete Benutzer" hinzugefügt
+
+
 2020-05-26
 ----------
 

--- a/docs/public/dev-manual/api/index.rst
+++ b/docs/public/dev-manual/api/index.rst
@@ -32,6 +32,7 @@ Inhalt:
    preview.rst
    webactions.rst
    users.rst
+   assigned_users.rst
    usersettings.rst
    tasks.rst
    globalindex.rst

--- a/docs/public/dev-manual/api/notifications.rst
+++ b/docs/public/dev-manual/api/notifications.rst
@@ -112,3 +112,22 @@ Durch einen PATCH-Request kann eine Benachrichtigung als gelesen markiert werden
    .. sourcecode:: http
 
       HTTP/1.1 204 No Content
+
+
+Benachrichtigungen unterdrücken
+-------------------------------
+Viele Aktionen lösen Benachrichtigungen aus, beispielsweise das Kommentieren einer Aufgabe. Um Benachrichtigungen zu unterdrücken, kann der ``X-GEVER-SuppressNotifications``-Header mitgeschickt werden. Akzeptiert werden folgende Werte (case insensitive): ``yes, y, true, t, 1``
+
+
+**Beispiel-Request**:
+
+   .. sourcecode:: http
+
+      POST /task-1/@responses HTTP/1.1
+      Accept: application/json
+      Content-Type: application/json
+      X-GEVER-SuppressNotifications: true
+
+      {
+        "text": "Bitte rasch anschauen. Danke.",
+      }

--- a/docs/public/dev-manual/api/tasks.rst
+++ b/docs/public/dev-manual/api/tasks.rst
@@ -305,6 +305,32 @@ Zusätzliche Metadaten:
 
        :Datentyp: ``Text``
 
+Aufgabe übertragen
+------------------
+
+Sowohl Auftraggeber, als auch Auftragnehmer können mit dem ``@transfer-task`` Endpoint gewechselt werden. Dabei wird überprüft, ob ``old_userid`` der User-ID des Auftraggebers und/oder des Auftragnehmers entspricht. Ist dies der Fall, wird der Benutzer mit der User-ID ``new_userid`` als Auftraggeber und/oder Auftragnehmer gesetzt. Benachrichtigungen, die normalerweise bei einer Änderung ausgelöst werden, werden unterdrückt. Dieser Endpoint wird mit einer Berechtigung beschützt: ``opengever.api.TransferAssignment``
+Die Berechtigung ist standardmässig den Rollen `Administrator` und `Manager` zugewiesen.
+
+
+**Beispiel-Request**:
+
+   .. sourcecode:: http
+
+      POST /task-1/@transfer-task HTTP/1.1
+      Accept: application/json
+      Content-Type: application/json
+
+      {
+        "old_userid": "john.doe",
+        "new_userid": "robert.ziegler"
+      }
+
+
+**Beispiel-Response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 204 No content
 
 Aufgabe kommentieren
 --------------------

--- a/opengever/api/assigned_users.py
+++ b/opengever/api/assigned_users.py
@@ -1,0 +1,32 @@
+from opengever.ogds.base.sources import AssignedUsersSource
+from plone.restapi.batching import HypermediaBatch
+from plone.restapi.interfaces import ISerializeToJson
+from plone.restapi.services import Service
+from Products.CMFPlone.utils import safe_unicode
+from zope.component import getMultiAdapter
+
+
+class AssignedUsersGet(Service):
+    def reply(self):
+        source = AssignedUsersSource(self.context)
+        query = safe_unicode(self.request.form.get('query', ''))
+        results = source.search(query)
+
+        batch = HypermediaBatch(self.request, results)
+
+        serialized_terms = []
+        for term in batch:
+            serializer = getMultiAdapter(
+                (term, self.request), interface=ISerializeToJson
+            )
+            serialized_terms.append(serializer())
+
+        result = {
+            "@id": batch.canonical_url,
+            "items": serialized_terms,
+            "items_total": batch.items_total,
+        }
+        links = batch.links
+        if links:
+            result["batching"] = links
+        return result

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -723,6 +723,14 @@
 
   <plone:service
       method="GET"
+      name="@assigned-users"
+      for="Products.CMFPlone.interfaces.IPloneSiteRoot"
+      factory=".assigned_users.AssignedUsersGet"
+      permission="zope2.View"
+      />
+
+  <plone:service
+      method="GET"
       name="@watchers"
       for="opengever.task.task.ITask"
       factory=".watchers.WatchersGet"

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -289,6 +289,14 @@
       />
 
   <plone:service
+      method="POST"
+      name="@transfer-task"
+      for="opengever.task.task.ITask"
+      factory=".transfer.TransferTaskPost"
+      permission="opengever.api.TransferAssignment"
+      />
+
+  <plone:service
       method="GET"
       name="@notifications"
       for="Products.CMFPlone.interfaces.IPloneSiteRoot"

--- a/opengever/api/permissions.zcml
+++ b/opengever/api/permissions.zcml
@@ -3,5 +3,6 @@
     i18n_domain="opengever.api">
 
   <permission id="opengever.api.ViewAllowedRolesAndPrincipals" title="opengever.api: View AllowedRolesAndPrincipals" />
+  <permission id="opengever.api.TransferAssignment" title="opengever.api: Transfer Assignment" />
 
 </configure>

--- a/opengever/api/tests/test_assigned_users.py
+++ b/opengever/api/tests/test_assigned_users.py
@@ -1,0 +1,33 @@
+from opengever.testing import IntegrationTestCase
+from ftw.testbrowser import browsing
+
+
+class TestAssignedUsers(IntegrationTestCase):
+
+    @browsing
+    def test_get_assigned_users(self, browser):
+        self.login(self.regular_user, browser=browser)
+        url = self.portal.absolute_url() + '/@assigned-users?query=Fri'
+
+        browser.open(url, method='GET', headers=self.api_headers)
+
+        expected_json = {
+            u'@id': url,
+            u'items': [{
+                u'title': u'Hugentobler Fridolin (fridolin.hugentobler)',
+                u'token': u'fridolin.hugentobler'
+                }],
+            u'items_total': 1}
+
+        self.assertEqual(expected_json, browser.json)
+
+    @browsing
+    def test_response_is_batched(self, browser):
+        self.login(self.regular_user, browser=browser)
+        url = self.portal.absolute_url() + '/@assigned-users?b_size=5'
+
+        browser.open(url, method='GET', headers=self.api_headers)
+
+        self.assertEqual(5, len(browser.json.get('items')))
+        self.assertEqual(18, browser.json.get('items_total'))
+        self.assertIn('batching', browser.json)

--- a/opengever/api/tests/test_transfer_task.py
+++ b/opengever/api/tests/test_transfer_task.py
@@ -1,0 +1,224 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.testbrowser import browsing
+from opengever.activity.model import Activity
+from opengever.activity.model import Notification
+from opengever.testing import IntegrationTestCase
+import json
+
+
+class TestTransferTaskPost(IntegrationTestCase):
+    features = ('activity', )
+    maxDiff = None
+
+    @browsing
+    def test_task_transfer_changes_responsible(self, browser):
+        self.login(self.administrator, browser=browser)
+        browser.open(self.task.absolute_url() + '/@transfer-task', method='POST',
+                     headers=self.api_headers, data=json.dumps(
+                        {"old_userid": self.task.responsible,
+                         "new_userid": self.meeting_user.getId()}))
+
+        self.assertEqual(self.meeting_user.getId(), self.task.responsible)
+
+        sql_task = self.task.get_sql_object()
+        self.assertEqual(self.meeting_user.getId(), sql_task.responsible)
+        activity = Activity.query.one()
+        self.assertEqual('task-transition-reassign', activity.kind)
+
+    @browsing
+    def test_task_transfer_for_forwarding_changes_responsible(self, browser):
+        self.login(self.administrator, browser=browser)
+        browser.open(self.inbox_forwarding.absolute_url() + '/@transfer-task', method='POST',
+                     headers=self.api_headers, data=json.dumps(
+                        {"old_userid": self.inbox_forwarding.responsible,
+                         "new_userid": self.meeting_user.getId()}))
+
+        self.assertEqual(self.meeting_user.getId(), self.inbox_forwarding.responsible)
+
+        sql_forwarding = self.inbox_forwarding.get_sql_object()
+        self.assertEqual(self.meeting_user.getId(), sql_forwarding.responsible)
+        activity = Activity.query.one()
+        self.assertEqual('forwarding-transition-reassign', activity.kind)
+
+    @browsing
+    def test_task_transfer_changes_issuer(self, browser):
+        self.login(self.administrator, browser=browser)
+        browser.open(self.task.absolute_url() + '/@transfer-task', method='POST',
+                     headers=self.api_headers, data=json.dumps(
+                        {"old_userid": self.task.issuer,
+                         "new_userid": self.meeting_user.getId()}))
+
+        self.assertEqual(self.meeting_user.getId(), self.task.issuer)
+
+        sql_task = self.task.get_sql_object()
+        self.assertEqual(self.meeting_user.getId(), sql_task.issuer)
+        activity = Activity.query.one()
+        self.assertEqual('task-transition-change-issuer', activity.kind)
+
+    @browsing
+    def test_task_transfer_for_forwarding_changes_issuer(self, browser):
+        self.login(self.administrator, browser=browser)
+        browser.open(self.inbox_forwarding.absolute_url() + '/@transfer-task', method='POST',
+                     headers=self.api_headers, data=json.dumps(
+                        {"old_userid": self.inbox_forwarding.issuer,
+                         "new_userid": self.meeting_user.getId()}))
+
+        self.assertEqual(self.meeting_user.getId(), self.inbox_forwarding.issuer)
+
+        sql_forwarding = self.inbox_forwarding.get_sql_object()
+        self.assertEqual(self.meeting_user.getId(), sql_forwarding.issuer)
+        activity = Activity.query.one()
+        self.assertEqual('forwarding-transition-change-issuer', activity.kind)
+
+    @browsing
+    def test_task_transfer_changes_issuer_and_responsible(self, browser):
+        self.login(self.administrator, browser=browser)
+        self.task.responsible = self.task.issuer
+        new_userid = self.meeting_user.getId()
+        self.assertNotEqual(self.task.issuer, new_userid)
+        browser.open(self.task.absolute_url() + '/@transfer-task', method='POST',
+                     headers=self.api_headers, data=json.dumps(
+                        {"old_userid": self.task.issuer,
+                         "new_userid": new_userid}))
+
+        self.assertEqual(self.task.issuer, new_userid)
+        self.assertEqual(self.task.responsible, new_userid)
+
+        sql_task = self.task.get_sql_object()
+        self.assertEqual(sql_task.issuer, new_userid)
+        self.assertEqual(sql_task.responsible, new_userid)
+
+        activities = Activity.query.all()
+        self.assertItemsEqual(['task-transition-reassign', 'task-transition-change-issuer'],
+                              [activity.kind for activity in activities])
+
+    @browsing
+    def test_task_transfer_for_forwarding_changes_issuer_and_responsible(self, browser):
+        self.login(self.administrator, browser=browser)
+        self.inbox_forwarding.responsible = self.inbox_forwarding.issuer
+        new_userid = self.meeting_user.getId()
+        self.assertNotEqual(self.inbox_forwarding.issuer, new_userid)
+        browser.open(self.inbox_forwarding.absolute_url() + '/@transfer-task', method='POST',
+                     headers=self.api_headers, data=json.dumps(
+                        {"old_userid": self.inbox_forwarding.issuer,
+                         "new_userid": new_userid}))
+
+        self.assertEqual(self.inbox_forwarding.issuer, new_userid)
+        self.assertEqual(self.inbox_forwarding.responsible, new_userid)
+
+        sql_forwarding = self.inbox_forwarding.get_sql_object()
+        self.assertEqual(sql_forwarding.issuer, new_userid)
+        self.assertEqual(sql_forwarding.responsible, new_userid)
+
+        activities = Activity.query.all()
+        self.assertItemsEqual(
+            ['forwarding-transition-reassign', 'forwarding-transition-change-issuer'],
+            [activity.kind for activity in activities])
+
+    @browsing
+    def test_task_transfer_does_not_trigger_notifications(self, browser):
+        self.login(self.administrator, browser=browser)
+        notifications_before = Notification.query.all()
+
+        browser.open(self.task.absolute_url() + '/@transfer-task', method='POST',
+                     headers=self.api_headers, data=json.dumps(
+                        {"old_userid": self.task.responsible,
+                         "new_userid": self.meeting_user.getId()})
+                     )
+
+        notifications_after = Notification.query.all()
+        self.assertEqual(notifications_before, notifications_after)
+
+    @browsing
+    def test_transfer_task_without_new_userid_raises_bad_request(self, browser):
+        self.login(self.administrator, browser=browser)
+        with browser.expect_http_error(400):
+            browser.open(self.task.absolute_url() + '/@transfer-task', method='POST',
+                         headers=self.api_headers,
+                         data=json.dumps({"old_userid": "kathi.barfuss"}))
+        self.assertEqual(
+            {"message": "Property 'new_userid' is required",
+             "type": "BadRequest"},
+            browser.json)
+
+    @browsing
+    def test_transfer_task_without_old_userid_raises_bad_request(self, browser):
+        self.login(self.administrator, browser=browser)
+        with browser.expect_http_error(400):
+            browser.open(self.task.absolute_url() + '/@transfer-task', method='POST',
+                         headers=self.api_headers,
+                         data=json.dumps({"new_userid": "kathi.barfuss"}))
+        self.assertEqual(
+            {"message": "Property 'old_userid' is required",
+             "type": "BadRequest"},
+            browser.json)
+
+    @browsing
+    def test_transfer_task_with_invalid_new_userid_raises_bad_request(self, browser):
+        self.login(self.administrator, browser=browser)
+        with browser.expect_http_error(400):
+            browser.open(self.task.absolute_url() + '/@transfer-task', method='POST',
+                         headers=self.api_headers, data=json.dumps(
+                            {"old_userid": self.regular_user.getId(), "new_userid": "chaosqueen"}))
+        self.assertEqual(
+            {"message": "userid 'chaosqueen' does not exist",
+             "type": "BadRequest"},
+            browser.json)
+
+    @browsing
+    def test_transfer_task_with_invalid_old_userid_raises_bad_request(self, browser):
+        self.login(self.administrator, browser=browser)
+        with browser.expect_http_error(400):
+            browser.open(self.task.absolute_url() + '/@transfer-task', method='POST',
+                         headers=self.api_headers, data=json.dumps(
+                            {"new_userid": "kathi.barfuss", "old_userid": "chaosqueen"})
+                         )
+        self.assertEqual(
+            {"message": "userid 'chaosqueen' does not exist",
+             "type": "BadRequest"},
+            browser.json)
+
+    @browsing
+    def test_transfer_task_raises_unauthorized(self, browser):
+        self.login(self.regular_user, browser)
+        with browser.expect_unauthorized():
+            browser.open(self.task.absolute_url() + '/@transfer-task', method='POST',
+                         headers=self.api_headers, data=json.dumps(
+                        {"old_userid": self.task.responsible,
+                         "new_userid": self.meeting_user.getId()}))
+
+        self.assertEqual(401, browser.status_code)
+
+    @browsing
+    def test_transfer_task_with_identical_userids_raises_bad_request(self, browser):
+        self.login(self.administrator, browser=browser)
+        with browser.expect_http_error(400):
+            browser.open(self.task.absolute_url() + '/@transfer-task', method='POST',
+                         headers=self.api_headers, data=json.dumps(
+                            {"new_userid": "kathi.barfuss", "old_userid": "kathi.barfuss"})
+                         )
+        self.assertEqual(
+            {"message": "'old_userid' and 'new_userid' should not be the same",
+             "type": "BadRequest"},
+            browser.json)
+
+    @browsing
+    def test_transfer_task_from_inactive_user_works(self, browser):
+        self.login(self.administrator, browser=browser)
+
+        fired_employee = create(Builder('ogds_user').id(u'fired.employee').having(active=False))
+        self.task.issuer = fired_employee.userid
+        sql_task = self.task.get_sql_object()
+        sql_task.issuer = fired_employee.userid
+
+        browser.open(self.task.absolute_url() + '/@transfer-task', method='POST',
+                     headers=self.api_headers, data=json.dumps(
+                        {"old_userid": fired_employee.userid,
+                         "new_userid": self.meeting_user.getId()}))
+
+        self.assertEqual(self.meeting_user.getId(), self.task.issuer)
+        sql_task = self.task.get_sql_object()
+        self.assertEqual(self.meeting_user.getId(), sql_task.issuer)
+        activity = Activity.query.one()
+        self.assertEqual('task-transition-change-issuer', activity.kind)

--- a/opengever/api/transfer.py
+++ b/opengever/api/transfer.py
@@ -1,0 +1,89 @@
+from opengever.inbox.forwarding import IForwarding
+from opengever.ogds.models.user import User
+from opengever.task.activities import TaskChangeIssuerActivity
+from opengever.task.activities import TaskReassignActivity
+from opengever.task.interfaces import ISuccessorTaskController
+from opengever.task.localroles import LocalRolesSetter
+from opengever.task.task import ITask
+from opengever.task.util import add_simple_response
+from plone.protect.interfaces import IDisableCSRFProtection
+from plone.restapi.deserializer import json_body
+from plone.restapi.services import Service
+from zExceptions import BadRequest
+from zope.event import notify
+from zope.interface import alsoProvides
+from zope.lifecycleevent import ObjectModifiedEvent
+
+
+class TransferTaskPost(Service):
+
+    def extract_data(self):
+        data = json_body(self.request)
+        self.old_userid = data.get("old_userid")
+        self.new_userid = data.get("new_userid")
+
+        if not self.old_userid:
+            raise BadRequest("Property 'old_userid' is required")
+        if not self.new_userid:
+            raise BadRequest("Property 'new_userid' is required")
+        if not User.query.get_by_userid(self.old_userid):
+            raise BadRequest("userid '{}' does not exist".format(self.old_userid))
+        if not User.query.get_by_userid(self.new_userid):
+            raise BadRequest("userid '{}' does not exist".format(self.new_userid))
+        if self.old_userid == self.new_userid:
+            raise BadRequest("'old_userid' and 'new_userid' should not be the same")
+
+    def reply(self):
+
+        self.extract_data()
+
+        # Disable CSRF protection
+        alsoProvides(self.request, IDisableCSRFProtection)
+
+        task_controller = ISuccessorTaskController(self.context)
+        if task_controller.get_predecessor() or task_controller.get_successors():
+            raise BadRequest("Cross-client tasks cannot be transferred")
+
+        self.request.environ['HTTP_X_GEVER_SUPPRESSNOTIFICATIONS'] = 'True'
+
+        if IForwarding.providedBy(self.context):
+            responsible_transition = 'forwarding-transition-reassign'
+            issuer_transition = 'forwarding-transition-change-issuer'
+        else:
+            responsible_transition = 'task-transition-reassign'
+            issuer_transition = 'task-transition-change-issuer'
+
+        if self.context.revoke_permissions:
+            LocalRolesSetter(self.context).revoke_roles()
+
+        self.context.clear_reminder(self.old_userid)
+
+        issuer_changed = self.old_userid == self.context.issuer
+        responsible_changed = self.old_userid == self.context.responsible
+
+        if issuer_changed:
+            issuer_changes = [(ITask['issuer'], self.new_userid)]
+            issuer_response = add_simple_response(
+                        self.context, transition=issuer_transition,
+                        field_changes=issuer_changes,
+                        supress_events=True)
+            self.context.issuer = self.new_userid
+
+        if responsible_changed:
+            responsible_changes = [(ITask['responsible'], self.new_userid)]
+            responsible_response = add_simple_response(
+                        self.context, transition=responsible_transition,
+                        field_changes=responsible_changes,
+                        supress_events=True)
+            self.context.responsible = self.new_userid
+
+        if issuer_changed or responsible_changed:
+            notify(ObjectModifiedEvent(self.context))
+
+        if issuer_changed:
+            TaskChangeIssuerActivity(self.context, self.context.REQUEST, issuer_response).record()
+        if responsible_changed:
+            TaskReassignActivity(self.context, self.context.REQUEST, responsible_response).record()
+
+        self.request.response.setStatus(204)
+        return super(TransferTaskPost, self).reply()

--- a/opengever/core/lawgiver.zcml
+++ b/opengever/core/lawgiver.zcml
@@ -227,6 +227,13 @@
                    "
       />
 
+  <!-- Transfer Assignment is only managed globally in rolemap.xml. -->
+  <lawgiver:ignore
+      permissions="
+                   opengever.api: Transfer Assignment,
+                   "
+      />
+
   <!-- Ignore default Plone permissions. This means we are not managing in the
        workflows. This does not mean that the permissions are disabled: disabling
        can be done in the rolemap.xml. -->

--- a/opengever/core/profiles/default/rolemap.xml
+++ b/opengever/core/profiles/default/rolemap.xml
@@ -58,6 +58,11 @@
       <role name="ServiceKeyUser" />
     </permission>
 
+    <permission name="opengever.api: Transfer Assignment" acquire="False">
+      <role name="Manager" />
+      <role name="Administrator" />
+    </permission>
+
     <!-- CMFEDITIONS -->
     <permission name="CMFEditions: Save new version" acquire="True">
       <role name="Administrator" />

--- a/opengever/core/upgrades/20200605095549_assign_transfer_permission/rolemap.xml
+++ b/opengever/core/upgrades/20200605095549_assign_transfer_permission/rolemap.xml
@@ -1,0 +1,8 @@
+<rolemap>
+  <permissions>
+    <permission name="opengever.api: Transfer Assignment" acquire="False">
+      <role name="Manager" />
+      <role name="Administrator" />
+    </permission>
+  </permissions>
+</rolemap>

--- a/opengever/core/upgrades/20200605095549_assign_transfer_permission/upgrade.py
+++ b/opengever/core/upgrades/20200605095549_assign_transfer_permission/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AssignTransferPermission(UpgradeStep):
+    """Assign transfer permission.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/task/activities.py
+++ b/opengever/task/activities.py
@@ -213,8 +213,10 @@ class TaskTransitionActivity(BaseTaskResponseActivity):
     IGNORED_TRANSITIONS = [
         'transition-add-subtask',
         'task-transition-reassign',
+        'task-transition-change-issuer',
         'forwarding-transition-reassign',
         'forwarding-transition-reassign-refused',
+        'forwarding-transition-change-issuer',
     ]
 
     @property
@@ -229,6 +231,20 @@ class TaskTransitionActivity(BaseTaskResponseActivity):
 
     def _is_ignored_transition(self):
         return self.response.transition in self.IGNORED_TRANSITIONS
+
+
+class TaskChangeIssuerActivity(TaskTransitionActivity):
+
+    def before_recording(self):
+        change = ResponseDescription.get(response=self.response).get_change('issuer')
+        if not change or change.get('before') == self.context.issuer:
+            return
+
+        self.center.add_task_issuer(self.context, self.context.issuer)
+        self.center.remove_task_issuer(self.context, change.get('before'))
+
+    def _is_ignored_transition(self):
+        return False
 
 
 class TaskReassignActivity(TaskTransitionActivity):

--- a/opengever/task/locales/de/LC_MESSAGES/opengever.task.po
+++ b/opengever/task/locales/de/LC_MESSAGES/opengever.task.po
@@ -956,6 +956,11 @@ msgstr "Weiterleitung zu einem Dossier hinzugefügt"
 msgid "transition_label_cancelled"
 msgstr "Aufgabe abgebrochen"
 
+#. Default: "Issuer of task changed"
+#: ./opengever/task/response_description.py
+msgid "transition_label_change_issuer"
+msgstr "Auftraggeber der Aufgabe gewechselt"
+
 #. Default: "Task closed"
 #: ./opengever/task/response_description.py
 msgid "transition_label_close"
@@ -1042,6 +1047,11 @@ msgstr "Einem Dossier zugewiesen durch ${user} Nachfolgeaufgabe=${successor}"
 msgid "transition_msg_cancel"
 msgstr "Abgebrochen durch ${user}"
 
+#. Default: "Issuer changed from ${issuer_old} to ${issuer_new}"
+#: ./opengever/task/response_description.py
+msgid "transition_msg_change_issuer"
+msgstr "Auftraggeber gewechselt von ${issuer_old} zu ${issuer_new}"
+
 #. Default: "Closed by ${user}"
 #: ./opengever/task/response_description.py
 msgid "transition_msg_close"
@@ -1051,6 +1061,11 @@ msgstr "Abgeschlossen durch ${user}"
 #: ./opengever/task/response_description.py
 msgid "transition_msg_default"
 msgstr "Antwort hinzugefügt"
+
+#. Default: "Issuer changed from ${issuer_old} to ${issuer_new} by ${user}"
+#: ./opengever/task/response_description.py
+msgid "transition_msg_delegated_change_issuer"
+msgstr "Auftraggeber gewechselt von ${issuer_old} zu ${issuer_new} durch ${user}"
 
 #. Default: "Reassigned from ${responsible_old} to ${responsible_new} by ${user}"
 #: ./opengever/task/response_description.py

--- a/opengever/task/locales/fr/LC_MESSAGES/opengever.task.po
+++ b/opengever/task/locales/fr/LC_MESSAGES/opengever.task.po
@@ -958,6 +958,11 @@ msgstr "Transmission assignée au dossier"
 msgid "transition_label_cancelled"
 msgstr "Tâche annulée"
 
+#. Default: "Issuer of task changed"
+#: ./opengever/task/response_description.py
+msgid "transition_label_change_issuer"
+msgstr ""
+
 #. Default: "Task closed"
 #: ./opengever/task/response_description.py
 msgid "transition_label_close"
@@ -1044,6 +1049,11 @@ msgstr "Attribué à un dossier par ${user} Tâche suivante=${successor}"
 msgid "transition_msg_cancel"
 msgstr "Annulé par ${user}"
 
+#. Default: "Issuer changed from ${issuer_old} to ${issuer_new}"
+#: ./opengever/task/response_description.py
+msgid "transition_msg_change_issuer"
+msgstr ""
+
 #. Default: "Closed by ${user}"
 #: ./opengever/task/response_description.py
 msgid "transition_msg_close"
@@ -1053,6 +1063,11 @@ msgstr "Clôturé par ${user}"
 #: ./opengever/task/response_description.py
 msgid "transition_msg_default"
 msgstr "Réponse ajouté"
+
+#. Default: "Issuer changed from ${issuer_old} to ${issuer_new} by ${user}"
+#: ./opengever/task/response_description.py
+msgid "transition_msg_delegated_change_issuer"
+msgstr ""
 
 #. Default: "Reassigned from ${responsible_old} to ${responsible_new} by ${user}"
 #: ./opengever/task/response_description.py

--- a/opengever/task/locales/opengever.task.pot
+++ b/opengever/task/locales/opengever.task.pot
@@ -954,6 +954,11 @@ msgstr ""
 msgid "transition_label_cancelled"
 msgstr ""
 
+#. Default: "Issuer of task changed"
+#: ./opengever/task/response_description.py
+msgid "transition_label_change_issuer"
+msgstr ""
+
 #. Default: "Task closed"
 #: ./opengever/task/response_description.py
 msgid "transition_label_close"
@@ -1040,6 +1045,11 @@ msgstr ""
 msgid "transition_msg_cancel"
 msgstr ""
 
+#. Default: "Issuer changed from ${issuer_old} to ${issuer_new}"
+#: ./opengever/task/response_description.py
+msgid "transition_msg_change_issuer"
+msgstr ""
+
 #. Default: "Closed by ${user}"
 #: ./opengever/task/response_description.py
 msgid "transition_msg_close"
@@ -1048,6 +1058,11 @@ msgstr ""
 #. Default: "Response added"
 #: ./opengever/task/response_description.py
 msgid "transition_msg_default"
+msgstr ""
+
+#. Default: "Issuer changed from ${issuer_old} to ${issuer_new} by ${user}"
+#: ./opengever/task/response_description.py
+msgid "transition_msg_delegated_change_issuer"
 msgstr ""
 
 #. Default: "Reassigned from ${responsible_old} to ${responsible_new} by ${user}"

--- a/opengever/task/response_description.py
+++ b/opengever/task/response_description.py
@@ -307,6 +307,39 @@ class Reassign(ResponseDescription):
 ResponseDescription.add_description(Reassign)
 
 
+class ChangeIssuer(ResponseDescription):
+    # fake transitions to generate a response for TaskChangeIssuerActivity
+    transitions = ['task-transition-change-issuer',
+                   'forwarding-transition-change-issuer']
+
+    css_class = 'reassign'
+
+    def msg(self):
+        change = self.get_change('issuer')
+        issuer_new = Actor.lookup(change.get('after')).get_link()
+        issuer_old = Actor.lookup(change.get('before')).get_link()
+
+        if not change.get('before') == self.response.creator:
+            return _('transition_msg_delegated_change_issuer',
+                     u'Issuer changed from ${issuer_old} to '
+                     u'${issuer_new} by ${user}',
+                     mapping={'user': self.creator_link(),
+                              'issuer_new': issuer_new,
+                              'issuer_old': issuer_old})
+
+        return _('transition_msg_change_issuer',
+                 u'Issuer changed from ${issuer_old} to '
+                 u'${issuer_new}',
+                 mapping={'issuer_new': issuer_new,
+                          'issuer_old': issuer_old})
+
+    def label(self):
+        return _('transition_label_change_issuer', u'Issuer of task changed')
+
+
+ResponseDescription.add_description(ChangeIssuer)
+
+
 class ModifyDeadline(ResponseDescription):
 
     transition = 'task-transition-modify-deadline'


### PR DESCRIPTION
The possibility should be created to transfer all tasks of one user to another. This means all tasks where the user is the responsible and/or the issuer.

This required some backend work:
- The new endpoint `@assigned-users` provides a vocabulary of all users of the current admin unit. The frontend needs this list to get all possible users to which the task could be transferred.
- To transfer a task, the new endpoint `@transfer-task` is required. The endpoint is protected by a new permission `opengever.api.TransferAssignment`, which allows only administrators and managers to use the endpoint.
- A new header `X-GEVER-SuppressNotifications` is introduced, with which it is possible to suppress the triggering of a notification.

Currently, only local tasks can be transferred, not cross-client tasks.

Jira: https://4teamwork.atlassian.net/browse/GEVER-35

Definition of Done: https://4teamwork.atlassian.net/wiki/spaces/CHX4TW/pages/917562/

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Documentation updated (notably for API and deployment)
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


## Checklist (optional)

_Only applicable should be left and checked._

- [x] New functionality  for `task` also works for `forwarding`
- New translations
  - [x] All msg-strings are unicode
  - [x] Correct i18n-domain was used (Copy-Paste errors are common here)