### PR TITLE
Fix contact query sources for contacts without an E-mail

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 ------------------------
 
 - Implement batching for the @solrsearch endpoint. [elioschmutz]
+- Fix contact query sources for contacts without an E-mail. [njohner]
 - Make available the delete action for templates. [mbaechtold]
 - Drop import_stamp column from user model. [tinagerber]
 - Define a set of columns that get synchronized in user and group model. [tinagerber]

--- a/opengever/ogds/base/sources.py
+++ b/opengever/ogds/base/sources.py
@@ -737,10 +737,13 @@ class AllEmailContactsAndUsersSourceBinder(object):
 class ContactsSource(UsersContactsInboxesSource):
 
     def getTerm(self, value=None, brain=None, solr_doc=None):
-
         if solr_doc is not None:
             value = u'contact:{}'.format(solr_doc[u'id'])
-            title = u'{} ({})'.format(solr_doc[u'Title'], solr_doc[u'email'])
+            email = solr_doc.get(u'email')
+            if email:
+                title = u'{} ({})'.format(solr_doc[u'Title'], email)
+            else:
+                title = u'{}'.format(solr_doc[u'Title'])
             return SimpleTerm(value, title=title)
 
         if not ActorLookup(value).is_contact():

--- a/opengever/ogds/base/sources.py
+++ b/opengever/ogds/base/sources.py
@@ -352,7 +352,11 @@ class UsersContactsInboxesSource(AllUsersInboxesAndTeamsSource):
 
         if solr_doc is not None:
             value = u'contact:{}'.format(solr_doc[u'id'])
-            title = u'{} ({})'.format(solr_doc[u'Title'], solr_doc[u'email'])
+            email = solr_doc.get(u'email')
+            if email:
+                title = u'{} ({})'.format(solr_doc[u'Title'], email)
+            else:
+                title = u'{}'.format(solr_doc[u'Title'])
             return SimpleTerm(value, title=title)
 
         # Contacts

--- a/opengever/ogds/base/tests/test_sources.py
+++ b/opengever/ogds/base/tests/test_sources.py
@@ -884,8 +884,7 @@ class TestContactsSource(SolrIntegrationTestCase):
                .having(firstname=u'Lara', lastname=u'Croft',
                        email=u'lara.croft@example.com'))
         create(Builder('contact')
-               .having(firstname=u'Super', lastname=u'M\xe4n',
-                       email='superman@example.com'))
+               .having(firstname=u'Super', lastname=u'M\xe4n'))
 
         self.commit_solr()
         self.source = ContactsSource(self.portal)
@@ -901,10 +900,10 @@ class TestContactsSource(SolrIntegrationTestCase):
         self.assertNotIn('contact:not-existing', self.source)
 
     def test_get_term_by_token(self):
-        term = self.source.getTermByToken('contact:man-super')
-        self.assertEquals('contact:man-super', term.token)
-        self.assertEquals('contact:man-super', term.value)
-        self.assertEquals(u'M\xe4n Super (superman@example.com)', term.title)
+        term = self.source.getTermByToken('contact:croft-lara')
+        self.assertEquals('contact:croft-lara', term.token)
+        self.assertEquals('contact:croft-lara', term.value)
+        self.assertEquals(u'Croft Lara (lara.croft@example.com)', term.title)
 
     def test_search_contacts(self):
         self.login(self.administrator)
@@ -915,6 +914,16 @@ class TestContactsSource(SolrIntegrationTestCase):
         self.assertEquals('contact:croft-lara', result[0].token)
         self.assertEquals('contact:croft-lara', result[0].value)
         self.assertEquals('Croft Lara (lara.croft@example.com)', result[0].title)
+
+    def test_search_contact_without_email(self):
+        self.login(self.administrator)
+        result = self.source.search("super")
+
+        self.assertEqual(1, len(result))
+        term = result.pop()
+        self.assertEqual('contact:man-super', term.value)
+        self.assertEqual('contact:man-super', term.token)
+        self.assertEqual(u'M\xe4n Super', term.title)
 
     def test_search_ogds_users_is_empty(self):
         self.assertEquals([], self.source.search('Hugo'))

--- a/opengever/ogds/base/tests/test_sources.py
+++ b/opengever/ogds/base/tests/test_sources.py
@@ -791,7 +791,7 @@ class TestAllEmailContactsAndUsersSource(SolrIntegrationTestCase):
         create(Builder('contact')
                .having(firstname=u'Super', lastname=u'M\xe4n',
                        email='superman@example.com',
-                       email2='superman@example.com'))
+                       email2='superman2@example.com'))
 
         self.commit_solr()
         self.source = AllEmailContactsAndUsersSource(self.portal)
@@ -823,7 +823,7 @@ class TestAllEmailContactsAndUsersSource(SolrIntegrationTestCase):
         self.assertIn('lara.croft@example.com:croft-lara', self.source)
 
         self.assertIn('superman@example.com:man-super', self.source)
-        self.assertIn('superman@example.com:man-super', self.source)
+        self.assertIn('superman2@example.com:man-super', self.source)
 
     def test_invalid_contact_tokens(self):
         self.assertNotIn('lara.croft@example.com:lara-croft', self.source)
@@ -860,9 +860,9 @@ class TestAllEmailContactsAndUsersSource(SolrIntegrationTestCase):
         self.assertEquals(u'M\xe4n Super (superman@example.com)',
                           person_result[0].title)
 
-        self.assertEquals('superman@example.com:man-super', person_result[1].token)
-        self.assertEquals('superman@example.com:man-super', person_result[1].value)
-        self.assertEquals(u'M\xe4n Super (superman@example.com)',
+        self.assertEquals('superman2@example.com:man-super', person_result[1].token)
+        self.assertEquals('superman2@example.com:man-super', person_result[1].value)
+        self.assertEquals(u'M\xe4n Super (superman2@example.com)',
                           person_result[1].title)
 
 

--- a/opengever/ogds/base/tests/test_sources.py
+++ b/opengever/ogds/base/tests/test_sources.py
@@ -454,8 +454,7 @@ class TestUsersContactsInboxesSource(SolrIntegrationTestCase):
                .having(firstname=u'Lara', lastname=u'Croft',
                        email=u'lara.croft@example.com'))
         create(Builder('contact')
-               .having(firstname=u'Super', lastname=u'M\xe4n',
-                       email='superman@example.com'))
+               .having(firstname=u'Super', lastname=u'M\xe4n'))
 
         self.commit_solr()
         self.source = UsersContactsInboxesSource(self.portal)
@@ -483,6 +482,16 @@ class TestUsersContactsInboxesSource(SolrIntegrationTestCase):
         self.assertEquals('hugo.boss', term.token)
         self.assertEquals('hugo.boss', term.value)
         self.assertEquals('Boss Hugo (hugo.boss)', term.title)
+
+    def test_search_contact_without_email(self):
+        self.login(self.administrator)
+        result = self.source.search("super")
+
+        self.assertEqual(1, len(result))
+        term = result.pop()
+        self.assertEqual('contact:man-super', term.value)
+        self.assertEqual('contact:man-super', term.token)
+        self.assertEqual(u'M\xe4n Super', term.title)
 
     def test_inboxes_are_valid(self):
         self.assertIn('inbox:org-unit-1', self.source)


### PR DESCRIPTION
Quering `ContactsSource` and `UsersContactsInboxesSource` failed for contacts without an E-mail. There are two corresponding sentry issues:
- https://sentry.4teamwork.ch/sentry/onegov-gever/issues/67485
- https://sentry.4teamwork.ch/sentry/onegov-gever/issues/67921

For https://4teamwork.atlassian.net/browse/GEVER-367

## Checklist (Must have)

- [x] Changelog entry
- [ ] Documentation updated (notably for API and deployment)
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
