### PR TITLE
Allow filtering for all checked out documents.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2020.3.0rc5 (unreleased)
 ------------------------
 
+- Allow negation of a filter query in @listing endpoint. [tinagerber]
 - Implement batching for the @solrsearch endpoint. [elioschmutz]
 - Make available the delete action for templates. [mbaechtold]
 - Drop import_stamp column from user model. [tinagerber]

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2020.3.0rc5 (unreleased)
 ------------------------
 
+- Allow filtering for empty strings in @listing endpoint. [tinagerber]
 - Allow negation of a filter query in @listing endpoint. [tinagerber]
 - Implement batching for the @solrsearch endpoint. [elioschmutz]
 - Make available the delete action for templates. [mbaechtold]

--- a/opengever/api/solr_query_service.py
+++ b/opengever/api/solr_query_service.py
@@ -196,7 +196,6 @@ DEFAULT_FIELDS = set([
 REQUIRED_RESPONSE_FIELDS = set(['UID'])
 
 FIELDS_WITH_MAPPING = [
-    ListingField('checked_out', 'checked_out', transform=display_name),
     ListingField('bumblebee_checksum', 'bumblebee_checksum', sort_index=DEFAULT_SORT_INDEX),
     ListingField('checked_out', 'checked_out', transform=display_name),
     ListingField('checked_out_fullname', 'checked_out', 'checked_out_fullname'),

--- a/opengever/api/solr_query_service.py
+++ b/opengever/api/solr_query_service.py
@@ -129,7 +129,17 @@ class SimpleListingField(object):
             value = u' OR '.join(value)
         else:
             value = escape(safe_unicode(value))
-        return u'{}:({})'.format(escape(self.index), value)
+
+
+        # Escaping the Solr field name is done for security reasons
+        # (to prevent attempts to circumvent the security filter by injection
+        # of a maliciously crafted field name)
+        key = escape(self.index)
+        # Don't escape the '-' at the beginning as it's used to negate a filter query
+        if key.startswith('\\-'):
+            key = key[1:]
+
+        return u'{}:({})'.format(key, value)
 
     def index_value_to_label(self, value):
         return value

--- a/opengever/api/solr_query_service.py
+++ b/opengever/api/solr_query_service.py
@@ -130,6 +130,9 @@ class SimpleListingField(object):
         else:
             value = escape(safe_unicode(value))
 
+        # Convert python empty string to solr empty string
+        if value == u'':
+            value = u'""'
 
         # Escaping the Solr field name is done for security reasons
         # (to prevent attempts to circumvent the security filter by injection

--- a/opengever/api/tests/test_listing.py
+++ b/opengever/api/tests/test_listing.py
@@ -364,6 +364,23 @@ class TestListingWithRealSolr(SolrIntegrationTestCase):
         self.assertEqual('dossier-state-active', review_states[0])
 
     @browsing
+    def test_negate_filter_query(self, browser):
+        self.login(self.regular_user, browser=browser)
+        view = ('@listing?name=dossiers')
+        browser.open(self.repository_root, view=view, headers=self.api_headers)
+        self.assertEqual(17, browser.json['items_total'])
+
+        view = ('@listing?name=dossiers&facets:list=review_state'
+                '&filters.review_state:record:list=dossier-state-active')
+        browser.open(self.repository_root, view=view, headers=self.api_headers)
+        self.assertEqual(12, browser.json['items_total'])
+
+        view = ('@listing?name=dossiers&facets:list=review_state'
+                '&filters.-review_state:record:list=dossier-state-active')
+        browser.open(self.repository_root, view=view, headers=self.api_headers)
+        self.assertEqual(5, browser.json['items_total'])
+
+    @browsing
     def test_filter_by_multiple_review_states(self, browser):
         self.login(self.regular_user, browser=browser)
 

--- a/opengever/api/tests/test_listing.py
+++ b/opengever/api/tests/test_listing.py
@@ -5,9 +5,11 @@ from opengever.api.solr_query_service import filename
 from opengever.api.solr_query_service import filesize
 from opengever.base.solr import OGSolrContentListingObject
 from opengever.base.solr import OGSolrDocument
+from opengever.document.interfaces import ICheckinCheckoutManager
 from opengever.testing import IntegrationTestCase
 from opengever.testing.integration_test_case import SolrIntegrationTestCase
 from plone.uuid.interfaces import IUUID
+from zope.component import getMultiAdapter
 
 
 class TestListingEndpointWithoutSolr(IntegrationTestCase):
@@ -362,6 +364,24 @@ class TestListingWithRealSolr(SolrIntegrationTestCase):
         review_states = list(set(map(lambda x: x['review_state'], items)))
         self.assertEqual(1, len(review_states))
         self.assertEqual('dossier-state-active', review_states[0])
+
+    @browsing
+    def test_filter_by_empty_string(self, browser):
+        self.login(self.regular_user, browser=browser)
+        manager = getMultiAdapter((self.document, self.request), ICheckinCheckoutManager)
+        manager.checkout()
+        self.document.reindexObject()
+        self.commit_solr()
+        view = ('@listing?name=documents&facets:list=checked_out')
+        browser.open(self.repository_root, view=view, headers=self.api_headers)
+        self.assertEqual(19, browser.json['items_total'])
+        self.assertEqual(18, browser.json['facets']['checked_out']['']['count'])
+
+        view = ('@listing?name=documents&facets:list=checked_out'
+                '&filters.checked_out:record=')
+        browser.open(self.repository_root, view=view, headers=self.api_headers)
+        self.assertEqual(18, browser.json['items_total'])
+        self.assertEqual(18, browser.json['facets']['checked_out']['']['count'])
 
     @browsing
     def test_negate_filter_query(self, browser):


### PR DESCRIPTION
We want to be able to filter for all checked out documents. For this we must be able to make a query of this type: `http://localhost:8080/fd/@listing?name=documents&facets:list=checked_out&filters.-checked_out:record=`
Therefore the following two things had to be implemented:
- Ability to filter for empty strings
- Possibility to negate a filter query

Jira: https://4teamwork.atlassian.net/browse/GEVER-41
Definition of Done: https://4teamwork.atlassian.net/wiki/spaces/CHX4TW/pages/917562/


## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [ ] Documentation updated (notably for API and deployment)
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)