### PR TITLE
Allow customizing group dn for invitations

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -29,6 +29,7 @@ Changelog
 - Bump docxcompose to 1.1.2 to fix issues with external image references and drawing properties. [buchi]
 - Always use configured solr port in tests. [2e12]
 - Fix translations of task types in API GET. [2e12]
+- Allow customizing group dn for invitations. [buchi]
 
 
 2020.3.0rc4 (2020-06-05)

--- a/opengever/core/upgrades/20200616143838_customize_invitation_group_dn/registry.xml
+++ b/opengever/core/upgrades/20200616143838_customize_invitation_group_dn/registry.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<registry>
+  <records interface="opengever.workspace.interfaces.IWorkspaceSettings" />
+</registry>

--- a/opengever/core/upgrades/20200616143838_customize_invitation_group_dn/upgrade.py
+++ b/opengever/core/upgrades/20200616143838_customize_invitation_group_dn/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class CustomizeInvitationGroupDN(UpgradeStep):
+    """Customize invitation group dn.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/workspace/interfaces.py
+++ b/opengever/workspace/interfaces.py
@@ -22,6 +22,12 @@ class IWorkspaceSettings(Interface):
         description=u'Whether workspace integration is enabled',
         default=False)
 
+    invitation_group_dn = schema.TextLine(
+        title=u'Invitation Group DN',
+        description=u'DN of a group where invited users are added on registration',
+        default=None,
+    )
+
 
 class IToDo(Interface):
     """ Marker interface for ToDos """


### PR DESCRIPTION
By default invited users are added to the org unit's users group. This group includes all users that have access to the site. However often invited users need to be put into a dedicated group. This PR allows configuring a dedicated group in the registry. If not configured, it falls back to the org unit's users group.

Jira: https://4teamwork.atlassian.net/browse/GEVER-79

- [x] Changelog entry
- [x] Documentation updated (notably for API and deployment)
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

## Checklist (optional)

- Upgrade steps (changes in profile):
  - [x] Make it deferrable if possible
  - [x] Execute as much as possible conditionally

