### PR TITLE
Update PR template to include API breaking changes.

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,27 +16,29 @@ Definition of Done: https://4teamwork.atlassian.net/wiki/spaces/CHX4TW/pages/917
 _Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._
 
 - [ ] Changelog entry
-- [ ] Documentation updated (notably for API and deployment)
 - [ ] Link to issue (Jira or GitHub) and backlink in issue (Jira)
 
 
-## Checklist (optional)
+## Checklist (if applicable)
 
 _Only applicable should be left and checked._
 
-- [ ] New functionality  for `document` also works for `mail`
-- [ ] New functionality  for `task` also works for `forwarding`
+- API change:
+  - [ ] Documentation is updated
+  - If breaking:
+    - [ ] api-change label added
+    - [ ] Scrum master is informed
+- New functionality:
+  - [ ] for `document` also works for `mail`
+  - [ ] for `task` also works for `forwarding`
 - Upgrade steps (changes in profile):
   - [ ] Make it deferrable if possible
   - [ ] Execute as much as possible conditionally
 - DB-Schema migration
   - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
   - [ ] Constraint names are shorter than 30 characters (`Oracle`)
-- New feature flag:
-  - [ ] Tests with activated and deactivated feature
 - [ ] Change could impact client installations, client policies need to be adapted
 - New translations
   - [ ] All msg-strings are unicode
-  - [ ] Correct i18n-domain was used (Copy-Paste errors are common here)
 - Change in schema definition:
   - [ ] If `missing_value` is specified, then `default` has to be set to the same value


### PR DESCRIPTION
Following the discussion in https://4teamwork.slack.com/archives/C062G6FGT/p1592497331009400?thread_ts=1592466050.000300&cid=C062G6FGT, `api-change` label is not enough to track breaking changes made to the API. I propose to add a new checkbox in the PR checklist, so that we at least inform the SM.

I also took the liberty to clean the PR checklist up a bit, so that it does not become longer than it already is...

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Documentation updated (notably for API and deployment)
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
