### PR TITLE
Also normalise filename of original_message when present.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -10,6 +10,7 @@ Changelog
 - Extend the @favorites endpoint to let it return already resolved favorites. [elioschmutz]
 - Use correct response type for proposal comment responses. [njohner]
 - Add expandable endpoint @tasktree for getting task hierarchy. [buchi]
+- Also normalise filename of original_message when present. [tinagerber]
 
 
 2020.3.0 (2020-06-18)

--- a/opengever/base/tests/test_command.py
+++ b/opengever/base/tests/test_command.py
@@ -21,7 +21,7 @@ class TestCreateEmailCommand(IntegrationTestCase):
         self.assertEqual('message/rfc822', mail.message.contentType)
         self.assertEqual('No Subject.eml', mail.message.filename)
 
-        self.assertEqual(u'testm\xe4il.msg', mail.original_message.filename)
+        self.assertEqual(u'No Subject.msg', mail.original_message.filename)
         self.assertEqual('mock-msg-body', mail.original_message.data)
 
 

--- a/opengever/bumblebee/tests/test_document_adapter.py
+++ b/opengever/bumblebee/tests/test_document_adapter.py
@@ -28,7 +28,7 @@ class TestMailDocumentAdapter(FunctionalTestCase):
 
         bumblebee_document = IBumblebeeDocument(mail_with_original_message)
         self.assertEqual(
-            'dummy.msg',
+            'No Subject.msg',
             bumblebee_document.get_primary_field().filename)
 
     def test_use_default_primary_field_without_original_message_available(self):

--- a/opengever/bundle/tests/test_section_fileloader.py
+++ b/opengever/bundle/tests/test_section_fileloader.py
@@ -162,7 +162,7 @@ class TestFileLoader(FunctionalTestCase):
         list(section)
 
         self.assertEqual(
-            u'sample.msg', IOGMail(mail).original_message.filename)
+            u'Lorem Ipsum.msg', IOGMail(mail).original_message.filename)
         self.assertEqual(13824, len(IOGMail(mail).original_message.data))
         self.assertEqual(u'Lorem Ipsum', mail.title)
 
@@ -180,7 +180,7 @@ class TestFileLoader(FunctionalTestCase):
         list(section)
 
         self.assertEqual(
-            u'sample.msg', IOGMail(mail).original_message.filename)
+            u'Test attachment.msg', IOGMail(mail).original_message.filename)
         self.assertEqual(13824, len(IOGMail(mail).original_message.data))
 
         self.assertEqual('message/rfc822', mail.message.contentType)

--- a/opengever/core/upgrades/20200507073857_update_filename_of_mails_with_file_extension_msg/upgrade.py
+++ b/opengever/core/upgrades/20200507073857_update_filename_of_mails_with_file_extension_msg/upgrade.py
@@ -1,0 +1,13 @@
+from ftw.upgrade import UpgradeStep
+
+
+class UpdateFilenameOfMailsWithFileExtensionMsg(UpgradeStep):
+    """Update filename of mails with file extension msg.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()
+        query = {'portal_type': 'ftw.mail.mail', 'file_extension': '.msg'}
+        for mail in self.objects(query, 'Update filename'):
+            mail.update_filename()
+            mail.reindexObject(idxs=['UID', 'filename'])

--- a/opengever/ech0147/tests/test_model.py
+++ b/opengever/ech0147/tests/test_model.py
@@ -73,7 +73,7 @@ class TestMessageModel(IntegrationTestCase):
             u'files/dossier-1/dossier-2/Uebersicht der Vertraege von 2016.xlsx',
             u'files/dossier-1/Vertraegsentwurf.docx',
             u'files/dossier-1/Die Buergschaft.eml',
-            u'files/dossier-1/testm\xe4il.msg',
+            u'files/dossier-1/No Subject.msg',
             u'files/dossier-1/Initialvertrag fuer Bearbeitung.docx',
             u'files/Vertraegsentwurf.docx',
         ]

--- a/opengever/mail/mail.py
+++ b/opengever/mail/mail.py
@@ -338,6 +338,9 @@ class OGMail(Mail, BaseDocumentMixin):
 
         new_filename = u'{}{}'.format(normalized_subject, ext)
         if self.message.filename != new_filename:
+            if self.original_message:
+                ext = os.path.splitext(self.original_message.filename)[-1]
+                self.original_message.filename = u'{}{}'.format(normalized_subject, ext)
             self.message.filename = new_filename
             Favorite.query.update_filename(self)
 

--- a/opengever/mail/tests/test_mail_download_copy.py
+++ b/opengever/mail/tests/test_mail_download_copy.py
@@ -128,7 +128,7 @@ class TestMailDownloadCopy(FunctionalTestCase):
             'status': '200 Ok',
             'content-length': str(len(browser.contents)),
             'content-type': 'application/vnd.ms-outlook',
-            'content-disposition': 'attachment; filename="testm\xc3\xa4il.msg"',
+            'content-disposition': 'attachment; filename="No Subject.msg"',
             },
             browser.headers)
 

--- a/opengever/mail/tests/test_ogmail.py
+++ b/opengever/mail/tests/test_ogmail.py
@@ -122,6 +122,19 @@ class TestOGMailAddition(FunctionalTestCase):
         mail.update_filename()
         self.assertEqual(u'Foo Baer.eml', mail.message.filename)
 
+    def test_update_filename_sets_normalized_filename_for_msg_mails(self):
+        very_long_filename = u'Dies ist ein wahnsinnig langer Name f\xfcr eine Mail, der ' \
+                             u'l\xe4nger ist als 100 Zeichen und gek\xfcrzt werden muss.msg'
+
+        mail = create(Builder('mail').with_dummy_message().with_dummy_original_message())
+        mail.title = very_long_filename
+        mail.update_filename()
+
+        self.assertEqual('Dies ist ein wahnsinnig langer Name fuer eine Mail, der laenger '
+                         'ist als 100 Zeichen und gekuerzt wer.msg', mail.original_message.filename)
+        self.assertEqual('Dies ist ein wahnsinnig langer Name fuer eine Mail, der laenger '
+                         'ist als 100 Zeichen und gekuerzt wer.eml', mail.message.filename)
+
     def test_get_attachments_returns_correct_descriptor_dict(self):
         mail = create(Builder('mail')
                       .within(self.dossier)

--- a/opengever/mail/tests/test_senddocument.py
+++ b/opengever/mail/tests/test_senddocument.py
@@ -175,7 +175,7 @@ f\xc3\xbcr Ernst Franz\r\n\r\nBesten Dank im Voraus"""
 
         mail = self.send_documents(dossier, [mail])
 
-        self.assert_attachment(mail, 'dummy.msg', 'application/vnd.ms-outlook')
+        self.assert_attachment(mail, 'No Subject.msg', 'application/vnd.ms-outlook')
 
 
     @browsing

--- a/opengever/mail/tests/test_zip_export.py
+++ b/opengever/mail/tests/test_zip_export.py
@@ -20,6 +20,6 @@ class TestMailZipExport(IntegrationTestCase):
                                          interface=IZipRepresentation)
 
         path, file_ = tuple(representation.get_files())[0]
-        self.assertEquals(u'/testm\xe4il.msg', path)
+        self.assertEquals(u'/No Subject.msg', path)
         self.assertEquals(self.mail_msg.original_message.open().read(),
                           file_.read())

--- a/opengever/officeconnector/tests/test_api_mail_attach.py
+++ b/opengever/officeconnector/tests/test_api_mail_attach.py
@@ -77,7 +77,7 @@ class TestOfficeconnectorMailAPIWithAttach(OCIntegrationTestCase):
             u"document-url": u"http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/"
                              u"document-30",
             u"download": u"@@download/original_message",
-            u"filename": u"testm\xe4il.msg",
+            u"filename": u"No Subject.msg",
             u"title": u"[No Subject]",
             u"uuid": u"createemails00000000000000000002",
         }]
@@ -136,7 +136,7 @@ class TestOfficeconnectorMailAPIWithAttach(OCIntegrationTestCase):
                 u"document-url": u"http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/"
                                  u"document-30",
                 u"download": u"@@download/original_message",
-                u"filename": u"testm\xe4il.msg",
+                u"filename": u"No Subject.msg",
                 u"title": u"[No Subject]",
                 u"uuid": u"createemails00000000000000000002",
             },


### PR DESCRIPTION
When an e-mail with the file extension "msg" is uploaded, two blob files are created, one with the original file, one that has been converted to "eml".

If the file name of an email has been changed, only the file name of the converted message has been changed, but not the file name of the original message. 

However, when the email is added as a favorite, the filename of the original message is written to the database.
This can cause errors because the filename of the original message was not truncated.

Now the filename of the original message is also truncated when the filename of an email changes, this solves the problem.

Jira: https://4teamwork.atlassian.net/browse/GEVER-477

Definition of Done: https://4teamwork.atlassian.net/wiki/spaces/CHX4TW/pages/917562/


## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [ ] Documentation updated (notably for API and deployment)
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)