### PR TITLE
Fix sort order within task template folder.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2020.4.0 (unreleased)
 ---------------------
 
+- Fix sort order within task template folder. [mbaechtold]
 - Fix deadline of task templates no longer shown in tabular listing. [mbaechtold]
 - Add API expansion `main-dossier`. [mbaechtold]
 - Make "populate_filename_column_in_favorites" UpgradeStep more robust. [lgraf]

--- a/opengever/tabbedview/catalog_source.py
+++ b/opengever/tabbedview/catalog_source.py
@@ -25,13 +25,17 @@ class GeverCatalogTableSource(FilteredTableSourceMixin, CatalogTableSource):
     """Default catalog tablesource extended with filter functionality.
     """
 
+    @property
+    def use_solr(self):
+        registry = getUtility(IRegistry)
+        settings = registry.forInterface(ISearchSettings)
+        return settings.use_solr
+
     def search_results(self, query):
         """Executes the query and returns a tuple of `results`.
         """
 
-        registry = getUtility(IRegistry)
-        settings = registry.forInterface(ISearchSettings)
-        if settings.use_solr:
+        if self.use_solr:
             return self.solr_results(self.exclude_searchroot_from_query(query))
 
         return super(GeverCatalogTableSource, self).search_results(query)

--- a/opengever/tasktemplates/browser/configure.zcml
+++ b/opengever/tasktemplates/browser/configure.zcml
@@ -46,4 +46,6 @@
       permission="cmf.AddPortalContent"
       />
 
+  <adapter factory=".tasktemplates.TaskTemplatesCatalogTableSource" />
+
 </configure>

--- a/opengever/tasktemplates/browser/tasktemplates.py
+++ b/opengever/tasktemplates/browser/tasktemplates.py
@@ -41,14 +41,36 @@ class ITaskTemplatesCatalogTableSourceConfig(IGeverCatalogTableSourceConfig):
 class TaskTemplatesCatalogTableSource(GeverCatalogTableSource):
 
     def search_results(self, query):
-        # Backup the sort on parameter because it will be gone after the call
-        # to the super class.
+        """
+        After fetching all the task templates we reorder them by their position in
+        the parent. This is needed because the task templates can be ordered manually
+        by the user (drag'n'drop in the table) but Solr does not know about the position
+        of the task templates within their container.
+
+        We also disable batching of the search results by fetching all task templates because
+        it is not very useful to enable batching when the items can be ordered manually (i.e.
+        moving items between) pages is very cumbersome. Otherwise we could not reliably order
+        the items when we only have a batch. Since we don't expect our clients to create lots
+        of task templates, we assume this is a reasonable choice for this special use case.
+        """
+        # Backup the sort parameter because it will be gone after the call to the
+        # the super class and we need it in order to determine if we need to do
+        # the sorting.
         sort_on = query.get('sort_on')
 
+        # Get a lot of task templates on the first try in order to prevent batching.
+        self.config.pagesize = 5000
         search_results = super(TaskTemplatesCatalogTableSource, self).search_results(query)
 
-        # Manually sort the Solr search results by their position in the parent
-        # because Solr does not support `getObjPositionInParent` for sorting.
+        if search_results.actual_result_count > self.config.pagesize:
+            # If there are more task templates than anticipated, we issue a second request to
+            # Solr in order to fetch all task templates. This should be rarely be the case
+            # because we assume not many client will have that many task templates.
+            self.config.pagesize = search_results.actual_result_count
+            search_results = super(TaskTemplatesCatalogTableSource, self).search_results(query)
+
+        # Manually sort the Solr search results by their position in the parent because
+        # Solr does not know about the position of the task templates in their parent.
         if self.use_solr and sort_on == 'getObjPositionInParent':
             parent = api.content.get(query['path']['query'])
             search_results.docs = sorted(

--- a/opengever/tasktemplates/tests/test_tasktemplatefolder.py
+++ b/opengever/tasktemplates/tests/test_tasktemplatefolder.py
@@ -4,7 +4,7 @@ from ftw.testbrowser import browsing
 from ftw.testbrowser import InsufficientPrivileges
 from ftw.testbrowser.pages import factoriesmenu
 from ftw.testbrowser.pages.statusmessages import info_messages
-from opengever.tabbedview import GeverCatalogTableSource
+from opengever.tasktemplates.browser.tasktemplates import TaskTemplatesCatalogTableSource
 from opengever.testing import IntegrationTestCase
 from opengever.testing import SolrIntegrationTestCase
 from plone import api
@@ -112,7 +112,7 @@ class TaskTemplatesOrderingInTabbedView(SolrIntegrationTestCase):
             request=self.request
         )
         self.assertTrue(
-            isinstance(tabbed_view.table_source, GeverCatalogTableSource)
+            isinstance(tabbed_view.table_source, TaskTemplatesCatalogTableSource)
         )
         search_results = tabbed_view.table_source.search_results({
             'path': {'query': '/'.join(self.tasktemplatefolder.getPhysicalPath()), 'depth': -1},
@@ -120,7 +120,7 @@ class TaskTemplatesOrderingInTabbedView(SolrIntegrationTestCase):
             'sort_on': 'getObjPositionInParent',
         })
 
-        # The view does not know about the correct ordering. This is what needs to be fixed.
+        # Make sure the items are sorted.
         self.assertEquals(
             [
                 'task-create-user',

--- a/opengever/tasktemplates/tests/test_tasktemplatefolder.py
+++ b/opengever/tasktemplates/tests/test_tasktemplatefolder.py
@@ -4,7 +4,9 @@ from ftw.testbrowser import browsing
 from ftw.testbrowser import InsufficientPrivileges
 from ftw.testbrowser.pages import factoriesmenu
 from ftw.testbrowser.pages.statusmessages import info_messages
+from opengever.tabbedview import GeverCatalogTableSource
 from opengever.testing import IntegrationTestCase
+from opengever.testing import SolrIntegrationTestCase
 from plone import api
 
 
@@ -61,3 +63,68 @@ class TestTaskTemplateFolder(IntegrationTestCase):
             browser.open(self.templates, view='folder_delete_confirmation',
                          data=self.make_path_param(self.tasktemplatefolder))
             browser.click_on('Delete')
+
+
+class TaskTemplatesOrderingInTabbedView(SolrIntegrationTestCase):
+
+    def test_tasks_are_sorted_by_position_in_parent(self):
+        self.login(self.regular_user)
+
+        # Create an other task template in addition of the existing `self.tasktemplate`
+        # so we can play around with their position in the container.
+        task_create_user = create(Builder('tasktemplate')
+                                  .titled(u'Benutzer erstellen.')
+                                  .having(id='task-create-user',
+                                          issuer='responsible',
+                                          responsible_client='fa',
+                                          responsible='robert.ziegler',
+                                          deadline=10)
+                                  .within(self.tasktemplatefolder))
+
+        # Commit to Solr otherwise Solr does not know about the new task template.
+        self.commit_solr()
+
+        # The new task template has been added at the bottom within the container.
+        self.assertEquals(
+            [
+                'opengever-tasktemplates-tasktemplate',
+                'task-create-user',
+            ],
+            self.tasktemplatefolder.objectIds()
+        )
+
+        # Move the new task template to the top within the container.
+        self.tasktemplatefolder.moveObjectsToTop(task_create_user.id)
+
+        # Make sure the change of position worked in Plone.
+        self.assertEquals(
+            [
+                'task-create-user',
+                'opengever-tasktemplates-tasktemplate',
+            ],
+            self.tasktemplatefolder.objectIds()
+        )
+
+        # Now get the items as the tabbed view would do.
+        tabbed_view = api.content.get_view(
+            name='tabbedview_view-tasktemplates',
+            context=self.tasktemplatefolder,
+            request=self.request
+        )
+        self.assertTrue(
+            isinstance(tabbed_view.table_source, GeverCatalogTableSource)
+        )
+        search_results = tabbed_view.table_source.search_results({
+            'path': {'query': '/'.join(self.tasktemplatefolder.getPhysicalPath()), 'depth': -1},
+            'portal_type': ['opengever.tasktemplates.tasktemplate'],
+            'sort_on': 'getObjPositionInParent',
+        })
+
+        # The view does not know about the correct ordering. This is what needs to be fixed.
+        self.assertEquals(
+            [
+                'task-create-user',
+                'opengever-tasktemplates-tasktemplate',
+            ],
+            [solr_doc['id'] for solr_doc in search_results.docs]
+        )


### PR DESCRIPTION
Until now, reordering the task templates within a task template folder looked to the user like it was not working. Although the items can be ordered with drag'n'drop, the ordering was lost after a browser refresh. 

This was due to the fact that Solr does not have an index for `getObjPositionInParent`. We can fix this by sorting the items by their position in the parent, just like Plone would do.

Belongs to Jira issue https://4teamwork.atlassian.net/browse/GEVER-565

![image](https://user-images.githubusercontent.com/28220/85370153-928c1b00-b52e-11ea-8e4b-a2f9784d5506.png)


## Checklist (Must have)

- [x] Changelog entry
- [x] Documentation updated (notably for API and deployment)
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
