### PR TITLE
Add API endpoint `@trigger-task-template` to create tasks in a dossier from a template.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2020.4.0 (unreleased)
 ---------------------
 
+- Add API endpoint `@trigger-task-template` to create tasks in a dossier from a template. [deiferni]
 - Use correct response type for proposal comment responses. [njoher]
 
 

--- a/docs/public/dev-manual/api/index.rst
+++ b/docs/public/dev-manual/api/index.rst
@@ -45,6 +45,7 @@ Inhalt:
    workspace/index
    linked_workspaces.rst
    templatefolder.rst
+   trigger_task_template.rst
    examples/index.rst
    docs_changelog.rst
 

--- a/docs/public/dev-manual/api/trigger_task_template.rst
+++ b/docs/public/dev-manual/api/trigger_task_template.rst
@@ -1,0 +1,42 @@
+.. _trigger_task_template:
+
+Standardabläufe auslösen
+========================
+
+In einem Dossier kann mit dem Endpoint ``@trigger-task-template`` ein
+bestehender Standardablauf ausgelöst werden.
+
+Der Endpoint erwartet folgende Parameter:
+
+- ``tasktemplatefolder``: Das zu verwendende Template aus dem Vokabular ``opengever.dossier.DocumentTemplatesVocabulary``
+- ``tasktemplates``: zu verwendende Aufgabenvorlagen und optional Auftragnehmer der zu erstellenden Aufgabe
+- ``related_documents``: Optionale Verweise auf Dokumente/Mails
+- ``start_immediately``: Erste Aufgabe nach Erstellung sofort starten
+
+
+**Beispiel-Request**:
+
+   .. sourcecode:: http
+
+        POST /ordnungssystem/fuehrung/dossier-23/@trigger-task-template HTTP/1.1
+        Accept: application/json
+
+        {
+            "tasktemplatefolder": "67a25fc941354568950439f08f7af3ed",
+            "tasktemplates": [
+                {
+                    "@id": "http://localhost:8080/fd/vorlagen/tasktemplatefolder-1/tasktemplate-1",
+                    "responsible": "stv:david.erni"
+                }
+            ],
+            "related_documents": [
+                {
+                    "@id": "http://localhost:8080/fd/ordnungssystem/fuehrung/dossier-23/document-23515"
+                }
+            ],
+            "start_immediately": true
+        }
+
+
+Als Response wird die JSON-Repräsentation der neu erstellten Aufgabe geliefert,
+siehe :ref:`Inhaltstypen <content-types>`.

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -706,6 +706,14 @@
       />
 
   <plone:service
+      method="POST"
+      name="@trigger-task-template"
+      for="opengever.dossier.behaviors.dossier.IDossierMarker"
+      factory=".templatefolder.TriggerTaskTemplatePost"
+      permission="cmf.AddPortalContent"
+      />
+
+  <plone:service
       method="GET"
       name="@list-documents-in-linked-workspace"
       for="opengever.dossier.behaviors.dossier.IDossierMarker"

--- a/opengever/api/templatefolder.py
+++ b/opengever/api/templatefolder.py
@@ -162,8 +162,15 @@ class TriggerTaskTemplatePost(Service):
         task = tasktemplatefolder.trigger(
             self.context, tasktemplates, related_documents, responsibles,
             start_immediately)
+
         serializer = queryMultiAdapter((task, self.request), ISerializeToJson)
-        return serializer()
+        result = serializer()
+        # the folder serializer uses the current url to display the @id. this
+        # wont work as we are using the serializer outside a request to the
+        # actual item, we are in the @trigger-task-template service. thus we
+        # have to make sure to return the correct id.
+        result['@id'] = task.absolute_url()
+        return result
 
     def _get_tasktemplatefolder(self, token):
         return api.content.get(UID=token)

--- a/opengever/api/templatefolder.py
+++ b/opengever/api/templatefolder.py
@@ -188,6 +188,8 @@ class TriggerTaskTemplatePost(Service):
         if not data:
             errors.append('At least one tasktemplate is required')
 
+        valid_templates = tasktemplatefolder.objectValues()
+
         for template_data in data:
             raw_responsible = template_data.pop('responsible', None)
 
@@ -197,7 +199,12 @@ class TriggerTaskTemplatePost(Service):
                 errors.append(
                     u'The tasktemplate {} is invalid'.format(template))
             else:
-                tasktemplates.append(template)
+                if template not in valid_templates:
+                    errors.append(
+                        u'The tasktemplate {} is outside the selected '
+                        'template folder'.format(template.absolute_url()))
+                else:
+                    tasktemplates.append(template)
 
                 # prefill defaults. the users can be interactive but need to
                 # be present.

--- a/opengever/api/tests/test_templatefolder.py
+++ b/opengever/api/tests/test_templatefolder.py
@@ -186,6 +186,8 @@ class TestTriggerTaskTemplatePost(IntegrationTestCase):
         self.assertEqual(1, len(children['added']))
         main_task = children['added'].pop()
 
+        self.assertEqual(browser.json['@id'], main_task.absolute_url())
+
         self.assertEqual(u'Verfahren Neuanstellung', main_task.title)
         self.assertEqual(self.regular_user.getId(), main_task.issuer)
         self.assertEqual(self.regular_user.getId(), main_task.responsible)

--- a/opengever/api/tests/test_templatefolder.py
+++ b/opengever/api/tests/test_templatefolder.py
@@ -1,10 +1,20 @@
 from datetime import date
+from datetime import datetime
+from datetime import timedelta
+from ftw.builder import Builder
+from ftw.builder import create
 from ftw.testbrowser import browsing
+from ftw.testing import freeze
 from opengever.base.role_assignments import RoleAssignmentManager
 from opengever.base.role_assignments import SharingRoleAssignment
+from opengever.ogds.models.team import Team
+from opengever.tasktemplates.interfaces import IFromParallelTasktemplate
+from opengever.tasktemplates.interfaces import IFromSequentialTasktemplate
 from opengever.testing import IntegrationTestCase
+from plone import api
 from zExceptions import BadRequest
 import json
+import pytz
 
 
 class TestDocumentFromTemplatePost(IntegrationTestCase):
@@ -32,7 +42,7 @@ class TestDocumentFromTemplatePost(IntegrationTestCase):
         document = children['added'].pop()
 
         self.assertEqual(u'New d\xf6cument', document.title)
-        self.assertEquals(date.today(), document.document_date)
+        self.assertEqual(date.today(), document.document_date)
 
     @browsing
     def test_creates_document_from_template_within_task(self, browser):
@@ -57,7 +67,7 @@ class TestDocumentFromTemplatePost(IntegrationTestCase):
         document = children['added'].pop()
 
         self.assertEqual(u'New d\xf6cument', document.title)
-        self.assertEquals(date.today(), document.document_date)
+        self.assertEqual(date.today(), document.document_date)
 
     @browsing
     def test_creates_document_from_template_within_forwarding(self, browser):
@@ -82,7 +92,7 @@ class TestDocumentFromTemplatePost(IntegrationTestCase):
         document = children['added'].pop()
 
         self.assertEqual(u'New d\xf6cument', document.title)
-        self.assertEquals(date.today(), document.document_date)
+        self.assertEqual(date.today(), document.document_date)
 
     @browsing
     def test_requires_title(self, browser):
@@ -139,3 +149,377 @@ class TestDocumentFromTemplatePost(IntegrationTestCase):
                          self.dossier.absolute_url()),
                          data=json.dumps(data),
                          headers=self.api_headers)
+
+
+class TestTriggerTaskTemplatePost(IntegrationTestCase):
+
+    def _get_task_template_item(self, browser):
+        browser.open(
+            '{}/@vocabularies/opengever.tasktemplates.active_tasktemplatefolders'.format(
+                self.portal.absolute_url()),
+            headers=self.api_headers)
+        return browser.json['items'][0]
+
+    @browsing
+    def test_trigger_with_minimal_required_input(self, browser):
+        self.login(self.regular_user, browser)
+
+        folder_data = self._get_task_template_item(browser)
+        folder_data.pop('title')
+
+        data = {
+            'tasktemplatefolder': folder_data,
+            'tasktemplates': [
+                {
+                    '@id': self.tasktemplate.absolute_url(),
+                }
+            ],
+            'start_immediately': True
+        }
+
+        with self.observe_children(self.dossier) as children:
+            browser.open('{}/@trigger-task-template'.format(
+                         self.dossier.absolute_url()),
+                         data=json.dumps(data),
+                         headers=self.api_headers)
+
+        self.assertEqual(1, len(children['added']))
+        main_task = children['added'].pop()
+
+        self.assertEqual(u'Verfahren Neuanstellung', main_task.title)
+        self.assertEqual(self.regular_user.getId(), main_task.issuer)
+        self.assertEqual(self.regular_user.getId(), main_task.responsible)
+        self.assertEqual('fa', main_task.responsible_client)
+        self.assertEqual('direct-execution', main_task.task_type)
+        self.assertEqual('task-state-in-progress',
+                          api.content.get_state(main_task))
+
+        subtasks = main_task.listFolderContents()
+        self.assertEqual(1, len(subtasks))
+        subtask = subtasks.pop()
+        self.assertEqual(u'Arbeitsplatz einrichten.', subtask.title)
+        self.assertEqual('robert.ziegler', subtask.issuer)
+        self.assertEqual('robert.ziegler', subtask.responsible)
+        self.assertEqual('fa', subtask.responsible_client)
+        self.assertEqual('task-state-open',
+                          api.content.get_state(subtask))
+
+    @browsing
+    def test_trigger_with_non_nested_task_template_folder_input(self, browser):
+        self.login(self.regular_user, browser)
+
+        folder_data = self._get_task_template_item(browser)
+        folder_data.pop('title')
+
+        data = {
+            'tasktemplatefolder': folder_data['token'],
+            'tasktemplates': [
+                {
+                    '@id': self.tasktemplate.absolute_url(),
+                }
+            ],
+            'start_immediately': True
+        }
+
+        with self.observe_children(self.dossier) as children:
+            browser.open('{}/@trigger-task-template'.format(
+                         self.dossier.absolute_url()),
+                         data=json.dumps(data),
+                         headers=self.api_headers)
+
+        self.assertEqual(1, len(children['added']))
+
+    @browsing
+    def test_selecting_no_tasktemplates_raises_badrequest(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        data = {
+            'tasktemplatefolder': self._get_task_template_item(browser),
+            'tasktemplates': [],
+            'start_immediately': True
+        }
+
+        with browser.expect_http_error(400):
+            browser.open('{}/@trigger-task-template'.format(
+                         self.dossier.absolute_url()),
+                         data=json.dumps(data),
+                         headers=self.api_headers)
+        self.assertEqual(
+            {"message": "At least one tasktemplate is required",
+             "type": "BadRequest"},
+            browser.json)
+
+    @browsing
+    def test_providing_no_tasktemplates_raises_badrequest(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        data = {
+            'tasktemplatefolder': self._get_task_template_item(browser),
+            'start_immediately': True
+        }
+
+        with browser.expect_http_error(400):
+            browser.open('{}/@trigger-task-template'.format(
+                         self.dossier.absolute_url()),
+                         data=json.dumps(data),
+                         headers=self.api_headers)
+        self.assertEqual(
+            {"message": "At least one tasktemplate is required",
+             "type": "BadRequest"},
+            browser.json)
+
+    @browsing
+    def test_providing_no_templatefolder_raises_badrequest(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        data = {
+            'tasktemplates': [
+                {
+                    '@id': self.tasktemplate.absolute_url(),
+                }
+            ],
+            'start_immediately': True
+        }
+
+        with browser.expect_http_error(400):
+            browser.open('{}/@trigger-task-template'.format(
+                         self.dossier.absolute_url()),
+                         data=json.dumps(data),
+                         headers=self.api_headers)
+        self.assertEqual(
+            {"message": "[('tasktemplatefolder', RequiredMissing('tasktemplatefolder'))]",
+             "type": "BadRequest"},
+            browser.json)
+
+    @browsing
+    def test_omitting_start_immediately_raises_badrequest(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        data = {
+            'tasktemplatefolder': self._get_task_template_item(browser),
+            'tasktemplates': [
+                {
+                    '@id': self.tasktemplate.absolute_url(),
+                }
+            ]
+        }
+
+        with browser.expect_http_error(400):
+            browser.open('{}/@trigger-task-template'.format(
+                         self.dossier.absolute_url()),
+                         data=json.dumps(data),
+                         headers=self.api_headers)
+        self.assertEqual(
+            {"message": "[('start_immediately', RequiredMissing('start_immediately'))]",
+             "type": "BadRequest"},
+            browser.json)
+
+    @browsing
+    def test_main_task_deadline_is_the_highest_template_deadline_plus_five(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        data = {
+            'tasktemplatefolder': self._get_task_template_item(browser),
+            'tasktemplates': [
+                {
+                    '@id': self.tasktemplate.absolute_url(),
+                }
+            ],
+            'start_immediately': True
+        }
+        with freeze(datetime(2018, 10, 18, 7, 33, tzinfo=pytz.utc)):
+            with self.observe_children(self.dossier) as children:
+                browser.open('{}/@trigger-task-template'.format(
+                             self.dossier.absolute_url()),
+                             data=json.dumps(data),
+                             headers=self.api_headers)
+
+            main_task = children['added'].pop()
+            self.assertEqual(
+                date.today() + timedelta(days=10 + 5), main_task.deadline)
+
+    @browsing
+    def test_create_parallel_tasks(self, browser):
+        self.login(self.regular_user, browser)
+        self.tasktemplatefolder.sequence_type = u'parallel'
+
+        data = {
+            'tasktemplatefolder': self._get_task_template_item(browser),
+            'tasktemplates': [
+                {
+                    '@id': self.tasktemplate.absolute_url(),
+                }
+            ],
+            'start_immediately': False
+        }
+
+        with self.observe_children(self.dossier) as children:
+            browser.open('{}/@trigger-task-template'.format(
+                         self.dossier.absolute_url()),
+                         data=json.dumps(data),
+                         headers=self.api_headers)
+
+        main_task = children['added'].pop()
+        self.assertTrue(IFromParallelTasktemplate.providedBy(main_task))
+        self.assertEqual('task-state-in-progress',
+                          api.content.get_state(main_task))
+        for subtask in main_task.listFolderContents():
+            self.assertTrue(IFromParallelTasktemplate.providedBy(subtask))
+            self.assertEqual('task-state-open',
+                              api.content.get_state(subtask))
+
+    @browsing
+    def test_create_sequential_tasks(self, browser):
+        self.login(self.regular_user, browser)
+        self.tasktemplatefolder.sequence_type = u'sequential'
+
+        data = {
+            'tasktemplatefolder': self._get_task_template_item(browser),
+            'tasktemplates': [
+                {
+                    '@id': self.tasktemplate.absolute_url(),
+                }
+            ],
+            'start_immediately': False
+        }
+
+        with self.observe_children(self.dossier) as children:
+            browser.open('{}/@trigger-task-template'.format(
+                         self.dossier.absolute_url()),
+                         data=json.dumps(data),
+                         headers=self.api_headers)
+
+        main_task = children['added'].pop()
+        self.assertTrue(IFromSequentialTasktemplate.providedBy(main_task))
+        self.assertEqual('task-state-in-progress',
+                          api.content.get_state(main_task))
+        for subtask in main_task.listFolderContents():
+            self.assertTrue(IFromSequentialTasktemplate.providedBy(subtask))
+            self.assertEqual('task-state-planned',
+                              api.content.get_state(subtask))
+
+    @browsing
+    def test_respects_start_immediately_flag(self, browser):
+        self.login(self.regular_user, browser)
+        self.tasktemplatefolder.sequence_type = u'sequential'
+
+        template_2 = create(Builder('tasktemplate')
+               .titled(u'Noch was.')
+               .having(issuer='responsible',
+                       responsible_client='fa',
+                       responsible='robert.ziegler',
+                       deadline=10,)
+               .within(self.tasktemplatefolder))
+
+        data = {
+            'tasktemplatefolder': self._get_task_template_item(browser),
+            'tasktemplates': [
+                {
+                    '@id': self.tasktemplate.absolute_url()
+                },
+                {
+                    '@id': template_2.absolute_url()
+                }
+            ],
+            'start_immediately': True
+        }
+
+        with self.observe_children(self.dossier) as children:
+            browser.open('{}/@trigger-task-template'.format(
+                         self.dossier.absolute_url()),
+                         data=json.dumps(data),
+                         headers=self.api_headers)
+
+        main_task = children['added'].pop()
+        self.assertEquals('task-state-in-progress',
+                          api.content.get_state(main_task))
+
+        subtask_1, subtask_2 = main_task.listFolderContents()
+        self.assertEquals('task-state-open',
+                          api.content.get_state(subtask_1))
+        self.assertEquals('task-state-planned',
+                          api.content.get_state(subtask_2))
+
+    @browsing
+    def test_creates_subtasks_for_selected_task_templates(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        notebook = create(Builder('tasktemplate')
+               .titled(u'Notebook einrichten.')
+               .having(issuer='responsible',
+                       responsible_client='fa',
+                       responsible='robert.ziegler',
+                       deadline=10)
+        .within(self.tasktemplatefolder))
+
+        user_accounts = create(Builder('tasktemplate')
+               .titled(u'User Accounts erstellen.')
+               .having(issuer='responsible',
+                       responsible_client='fa',
+                       responsible='robert.ziegler',
+                       deadline=10)
+        .within(self.tasktemplatefolder))
+
+        data = {
+            'tasktemplatefolder': self._get_task_template_item(browser),
+            'tasktemplates': [
+                {
+                    '@id': notebook.absolute_url(),
+                },
+                {
+                    '@id': user_accounts.absolute_url(),
+                }
+            ],
+            'start_immediately': False
+        }
+
+        with self.observe_children(self.dossier) as children:
+            browser.open('{}/@trigger-task-template'.format(
+                         self.dossier.absolute_url()),
+                         data=json.dumps(data),
+                         headers=self.api_headers)
+
+        main_task = children['added'].pop()
+        self.assertEqual(2, len(main_task.listFolderContents()))
+
+        self.assertItemsEqual(
+            [u'Notebook einrichten.', u'User Accounts erstellen.'],
+            [item.title for item in main_task.listFolderContents()])
+
+    @browsing
+    def test_sets_task_templatefolder_predecessor(self, browser):
+        self.login(self.regular_user, browser=browser)
+        self.tasktemplatefolder.sequence_type = u'sequential'
+
+        template_2 = create(Builder('tasktemplate')
+               .titled(u'Notebook einrichten.')
+               .having(issuer='responsible',
+                       responsible_client='fa',
+                       responsible='robert.ziegler',
+                       deadline=10,)
+        .within(self.tasktemplatefolder))
+
+        data = {
+            'tasktemplatefolder': self._get_task_template_item(browser),
+            'tasktemplates': [
+                {
+                    '@id': self.tasktemplate.absolute_url()
+                },
+                {
+                    '@id': template_2.absolute_url()
+                }
+            ],
+            'start_immediately': True
+        }
+
+        with self.observe_children(self.dossier) as children:
+            browser.open('{}/@trigger-task-template'.format(
+                         self.dossier.absolute_url()),
+                         data=json.dumps(data),
+                         headers=self.api_headers)
+
+        main_task = children['added'].pop()
+        task1, task2 = main_task.listFolderContents()
+
+        self.assertEquals(task1.get_sql_object(),
+                          task2.get_sql_object().get_previous_task())

--- a/opengever/tasktemplates/tasktemplatefolder.py
+++ b/opengever/tasktemplates/tasktemplatefolder.py
@@ -37,7 +37,7 @@ class TaskTemplateFolder(Container):
         trigger = TaskTemplateFolderTrigger(
             self, dossier, templates, related_documents,
             values, start_immediately)
-        trigger.generate()
+        return trigger.generate()
 
 
 class TaskTemplateFolderTrigger(object):
@@ -57,6 +57,7 @@ class TaskTemplateFolderTrigger(object):
         alsoProvides(self.request, IDuringTaskTemplateFolderTriggering)
         self.create_subtasks(main_task)
         noLongerProvides(self.request, IDuringTaskTemplateFolderTriggering)
+        return main_task
 
     def add_task(self, container, data):
         task = createContent('opengever.task.task', **data)


### PR DESCRIPTION
The endpoint `@trigger-task-template` allows the user to create tasks from task-templates. The tasks are created in a dossier.

The main goal of this PR is to expose triggering task templates via API so we can re-implement the classic UI wizard in the new ui. We won't implement it as a wizard though so all data can be passed to the endpoint at once.

Challenges i had:
- `plone.restapi` does not help me validate arbitrary schema based input, as far as i could see i have to do some manual validation. if someone has a better idea about how this should be done please let me know.
- i had to split the schema in two, one part is "automatically" validated via `get_validation_errors`, the other part is only used for its sources and for manual validation.
- the vocabulary returning selectable template folders is not so useful for the UI as it only returns UIDs as tokens, we might wanna swap that out against a listing/solr query thing eventually. we have left it in for now.
- the existing wizard and the task template vocabulary are strongly coupled (the vocabulary only works inside of the wizard) so i have decided against reusing it for the moment.
- some of the tests are copied from existing functionality and adapted to the endpoint. the method names are not the best but i'd like to keep them so we can easily cross-reference in the future.

Jira: https://4teamwork.atlassian.net/browse/GEVER-101

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Documentation updated (notably for API and deployment)
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
