### PR TITLE
Extend the @favorites endpoint to let it return already resolved favorites.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 ---------------------
 
 - Add API endpoint `@trigger-task-template` to create tasks in a dossier from a template. [deiferni]
+- Extend the @favorites endpoint to let it return already resolved favorites. [elioschmutz]
 - Use correct response type for proposal comment responses. [njoher]
 
 

--- a/docs/public/dev-manual/api/favorite.rst
+++ b/docs/public/dev-manual/api/favorite.rst
@@ -39,6 +39,7 @@ Mittels eines GET Request können Favoriten des Benutzers abgefragt werden. Dabe
               "title": "Richtlinien Gesetzesentwürfe",
               "portal_type": "opengever.document.document",
               "position": 1,
+              "resolved": false,
               "review_state": "document-state-draft",
               "target_url": "http://localhost:8080/fd/resolve_oguid/fd:68398212"
           }
@@ -54,10 +55,64 @@ Mittels eines GET Request können Favoriten des Benutzers abgefragt werden. Dabe
               "title": "Anfragen 2018",
               "portal_type": "opengever.dossier.businesscasedossier",
               "position": 2,
+              "resolved": false,
               "review_state": "dossier-state-active",
               "target_url": "http://localhost:8080/fd/resolve_oguid/fd:68336212"
           }
       ]
+
+Favoriten sind standardmässig nicht aufgelöst. D.h. es ist nicht bekannt, wo sich das Favoriten-Objekt genau befindet. Über die ``target_url`` kann das Objekt aufgelöst werden.
+
+Benötigt man die bereits aufgelösten Favoriten, können diese mit dem ``resolve=true`` Query-Parameter abegfragt werden:
+
+**Beispiel-Request**:
+
+   .. sourcecode:: http
+
+       GET /@favorites/peter.mueller?resolve=true HTTP/1.1
+       Accept: application/json
+
+
+**Beispiel-Response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 200 OK
+      Content-Type: application/json
+
+      [
+          {
+              "@id": "http://localhost:8080/fd/@favorites/peter.mueller/3",
+              "favorite_id": 3,
+              "filename": "Richtlinien Gesetzesentwuerfe.docx",
+              "icon_class": "icon-dokument_word",
+              "is_leafnode": null,
+              "oguid": "fd:68398212",
+              "title": "Richtlinien Gesetzesentwürfe",
+              "portal_type": "opengever.document.document",
+              "position": 1,
+              "resolved": true,
+              "review_state": "document-state-draft",
+              "target_url": "http://localhost:8080/fd/document-1"
+          },
+          {
+              "@id": "http://localhost:8080/fd/@favorites/peter.mueller/57",
+              "favorite_id": 57,
+              "filename": null,
+              "icon_class": "contenttype-opengever-dossier-businesscasedossier",
+              "is_leafnode": null,
+              "is_subdossier": false,
+              "oguid": "rk:68336212",
+              "title": "Anfragen 2018",
+              "portal_type": "opengever.dossier.businesscasedossier",
+              "position": 2,
+              "resolved": false,
+              "review_state": "dossier-state-active",
+              "target_url": "http://localhost:8080/fd/resolve_oguid/rk:68336212"
+          }
+      ]
+
+Dabei ist zu beachten, dass ein Mandant immer nur seine eigenen Favoriten auflösen kann. Favoriten von fremden Mandanten werden deshalb immer unaufgelöst zurückgegeben.
 
 Favorit hinzufügen:
 -------------------
@@ -94,6 +149,7 @@ Ein Favorit für ein beliebiges Objekt kann mittels POST Request hinzugefügt we
           "title": "Anfrage 2018",
           "portal_type": "opengever.document.document",
           "position": 1,
+          "resolved": false,
           "review_state": "document-state-draft",
           "target_url": "http://localhost:8080/fd/resolve_oguid/fd:68398212"
       }

--- a/opengever/api/favorites.py
+++ b/opengever/api/favorites.py
@@ -37,6 +37,7 @@ class FavoritesGet(Service):
                 "It's not allowed to access favorites of other users.")
 
         portal_url = api.portal.get().absolute_url()
+        resolve = self.request.form.get("resolve", False)
 
         if fav_id:
             favorite = Favorite.query.by_userid_and_id(fav_id, userid).first()
@@ -44,10 +45,10 @@ class FavoritesGet(Service):
                 # inexistent favorite-id or not ownded by given user
                 raise NotFound
 
-            return favorite.serialize(portal_url)
+            return favorite.serialize(portal_url, resolve=resolve)
         else:
             favorites = FavoriteManager().list_all(userid)
-            return [fav.serialize(portal_url) for fav in favorites]
+            return [fav.serialize(portal_url, resolve=resolve) for fav in favorites]
 
     def read_params(self):
         if len(self.params) not in [1, 2]:

--- a/opengever/api/tests/test_repository_favorites.py
+++ b/opengever/api/tests/test_repository_favorites.py
@@ -191,6 +191,7 @@ class TestRepositoryFavoritesPost(IntegrationTestCase):
             {u'@id': u'http://nohost/plone/@favorites/nicole.kohler/1',
              u'admin_unit': u'Hauptmandant',
              u'favorite_id': 1,
+             u'resolved': False,
              u'filename': u'Vertraegsentwurf.docx',
              u'icon_class': u'icon-docx',
              u'is_leafnode': None,


### PR DESCRIPTION
This PR implements a `resolve` query parameter for the `@favorites` endpoint which will return already resolved favorites if possible.

We need resolved favorites for the new content selector. Navigation and selection of favorite items is not fully provided without this changes.

⚠️ In the spec we defined to only return resolved favorites if we use the `resolve` parameter. But this seems to be wrong and not useful. I introduced a new property on the serialized favorite instead to indicate if the current favorite is resolved or not. The frontend can then filter for resolved favorites if necessary.

Jira: https://4teamwork.atlassian.net/browse/GEVER-473

## Checklist (Must have)

- [x] Changelog entry
- [x] Documentation updated (notably for API and deployment)
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
