### PR TITLE
Fix deadline of task templates no longer shown in tabular listing.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2020.4.0 (unreleased)
 ---------------------
 
+- Fix deadline of task templates no longer shown in tabular listing. [mbaechtold]
 - Add API expansion `main-dossier`. [mbaechtold]
 - Make "populate_filename_column_in_favorites" UpgradeStep more robust. [lgraf]
 - Disable the searchbox on the tabbed view which lists the versions of a document. [mbaechtold]

--- a/opengever/core/upgrades/20200623100315_index_task_template_deadline_as_period/upgrade.py
+++ b/opengever/core/upgrades/20200623100315_index_task_template_deadline_as_period/upgrade.py
@@ -1,0 +1,18 @@
+from ftw.upgrade import UpgradeStep
+
+
+class IndexTaskTemplateDeadlineAsPeriod(UpgradeStep):
+    """Index task template deadline as period (Solr only).
+    """
+    deferrable = True
+
+    def __call__(self):
+        self.install_upgrade_profile()
+
+        # `period` is not an index in the catalog, only a field in Solr. In order
+        # avoid reindexing the whole objects, we must pick any index that exists
+        # for all objects and is fast to compute, `UID` in this case.
+        self.catalog_reindex_objects(
+            {"portal_type": "opengever.tasktemplates.tasktemplate"},
+            idxs=["UID", "period"]
+        )

--- a/opengever/tasktemplates/browser/tasktemplates.py
+++ b/opengever/tasktemplates/browser/tasktemplates.py
@@ -59,7 +59,7 @@ class TaskTemplates(BaseCatalogListingTab):
          'sortable': False,
          'transform': interactive_user_helper},
 
-        {'column': 'deadline',
+        {'column': 'period',
          'sortable': False,
          'column_title': _(u"label_deadline", default=u"Deadline in Days")},
 

--- a/opengever/tasktemplates/configure.zcml
+++ b/opengever/tasktemplates/configure.zcml
@@ -41,4 +41,10 @@
            zope.lifecycleevent.interfaces.IObjectModifiedEvent"
       handler=".handlers.update_deadline"
       />
+
+  <adapter
+      factory=".indexers.period"
+      name="period"
+      />
+
 </configure>

--- a/opengever/tasktemplates/indexers.py
+++ b/opengever/tasktemplates/indexers.py
@@ -1,0 +1,7 @@
+from opengever.tasktemplates.content.tasktemplate import ITaskTemplate
+from plone.indexer import indexer
+
+
+@indexer(ITaskTemplate)
+def period(obj):
+    return obj.deadline

--- a/opengever/tasktemplates/tests/test_tasktemplate.py
+++ b/opengever/tasktemplates/tests/test_tasktemplate.py
@@ -185,3 +185,19 @@ class TestTaskTemplates(SolrIntegrationTestCase):
         tasktemplate = self.tasktemplatefolder.listFolderContents()[-1]
         self.assertEquals(u'Arbeitsplatz einrichten.', tasktemplate.title)
         self.assertEquals(None, tasktemplate.responsible)
+
+    @browsing
+    def test_view_displays_deadline(self, browser):
+        self.login(self.administrator, browser=browser)
+
+        browser.open(self.tasktemplate)
+
+        # Get the cells in the column "deadline".
+        cells = [row.css('td').first
+                 for row in browser.css('.task-listing tr')
+                 if len(row.css('th')) and row.css('th').first.text == 'Deadline in Days']
+
+        self.assertEquals(
+            ["10"],
+            [cell.text for cell in cells]
+        )

--- a/solr-conf/managed-schema
+++ b/solr-conf/managed-schema
@@ -153,6 +153,7 @@
     <field name="lastname" type="string" indexed="true" stored="false" />
     <field name="metadata" type="text" indexed="true" stored="true"/>
     <field name="object_provides" type="string" indexed="true" stored="false" multiValued="true"/>
+    <field name="period" type="pint" indexed="true" stored="false" />
     <field name="phone_office" type="string" indexed="true" stored="false" />
     <field name="preselected" type="boolean" indexed="true" stored="false" />
     <field name="public_trial" type="string" indexed="true" stored="false" />


### PR DESCRIPTION
Since we switched the tabular listing view to Solr, the deadline of task templates was no longer shown. There is already a Solr field called `deadline`, which is a `pdate`. But the deadline of the task templates is an integer. So we store the value in a Solr field called `period` and render it in the tabular listing.

Belongs to the Jira issue https://4teamwork.atlassian.net/browse/GEVER-561

The screenshot depicts the affected column in the table listing of task templates.

![image](https://user-images.githubusercontent.com/28220/85388596-8d3aca80-b546-11ea-9f8e-f2a087985270.png)


## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Documentation updated (notably for API and deployment)
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)