### PR TITLE
Add API expansion "main-dossier".

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2020.4.0 (unreleased)
 ---------------------
 
+- Add API expansion `main-dossier`. [mbaechtold]
 - Make "populate_filename_column_in_favorites" UpgradeStep more robust. [lgraf]
 - Include additional data in @responses GET for proposal responses. [njohner]
 - Include additional data in Proposal GET API endpoint. [njohner]

--- a/docs/public/dev-manual/api/listing_stats.rst
+++ b/docs/public/dev-manual/api/listing_stats.rst
@@ -1,4 +1,4 @@
-.. listing_stats:
+.. _listing_stats:
 
 Statistik zu Auflistungen
 =========================

--- a/docs/public/dev-manual/api/operations.rst
+++ b/docs/public/dev-manual/api/operations.rst
@@ -114,6 +114,79 @@ children des Objekts).
     .. literalinclude:: examples/example_get.py
 
 
+Erweiterbare Komponente (Expansion)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Eine erweiterbare Komponente (auch "Expansion" genannt) ist ein Mechanismus, um in einem GET-Request
+einer Ressource weitere Information anzufordern, z.B. die Navigation, Breadcrumbs, etc. Damit kann verhindert
+werden, dass ein weiterer Request abgesetzt werden muss, um diese Angaben abzuholen. Weitere Informationen
+zu diesem Mechanismus findet man unter https://plonerestapi.readthedocs.io/en/latest/expansion.html.
+
+Die erweiterbaren Komponenten können über den Parameter `expand` in die Response eingebettet werden.
+
+Folgende erweiterbaren Komponente stehen zur Verfügung und sind in den entsprechenden Kapiteln beschrieben:
+
+- :ref:`navigation`
+- :ref:`breadcrumbs`
+- :ref:`listing_stats`
+
+Eine weitere erweiterbare Komponente erlaubt es, Informationen zum *Hautpdossier* einer Ressource
+abzufragen.
+
+**Beispiel-Request**:
+
+.. sourcecode:: http
+
+  GET /ordnungssystem/dossier/subdossier/document?expand=main-dossier HTTP/1.1
+  Accept: application/json
+
+**Beispiel-Response**:
+
+.. sourcecode:: http
+
+   HTTP/1.1 200 OK
+
+   {
+     "@components": {
+       "main-dossier": {
+         "@id": "https://example.org/ordnungssystem/dossier",
+         "@type": "opengever.dossier.businesscasedossier",
+         "description": "",
+         "is_leafnode": null,
+         "is_subdossier": false,
+         "review_state": "dossier-state-active",
+         "title": "Gesetzesentwürfe"
+       },
+     },
+     "@id": "https://example.org/ordnungssystem/dossier/subdossier/document?expand=main-dossier",
+     "..."
+   }
+
+Falls die Frage, welches das Hauptdossier einer Ressource ist, nicht beantwortet werden kann, dann
+ist der Wert in der Response nicht definiert.
+
+**Beispiel-Request**:
+
+.. sourcecode:: http
+
+   GET /ordnungssystem?expand=main-dossier HTTP/1.1
+   Accept: application/json
+
+**Beispiel-Response**:
+
+.. sourcecode:: http
+
+   HTTP/1.1 200 OK
+
+   {
+     "@components": {
+       "main-dossier": null,
+     },
+     "@id": "https://example.org/ordnungssystem?expand=main-dossier",
+     "..."
+   }
+
+
 .. _content-post:
 
 Inhalte erstellen (POST)

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -805,4 +805,9 @@
       name="tasktree"
       />
 
+  <adapter
+      factory=".dossier.MainDossier"
+      name="main-dossier"
+      />
+
 </configure>

--- a/opengever/api/tests/test_dossier.py
+++ b/opengever/api/tests/test_dossier.py
@@ -65,3 +65,162 @@ class TestDossierSerializer(IntegrationTestCase):
         self.assertFalse(
             browser.json["relatedDossier"][0]["is_subdossier"]
         )
+
+
+class TestMainDossierExpansion(IntegrationTestCase):
+
+    @browsing
+    def test_main_dossier_expansion_on_repository_root(self, browser):
+        self.login(self.regular_user, browser=browser)
+        browser.open(
+            self.repository_root.absolute_url() + '?expansion=main-dossier',
+            method="GET",
+            headers=self.api_headers,
+        )
+        self.assertIsNone(
+            browser.json["@components"]['main-dossier'],
+        )
+
+    @browsing
+    def test_main_dossier_expansion_on_leaf_repofolder(self, browser):
+        self.login(self.regular_user, browser=browser)
+        browser.open(
+            self.leaf_repofolder.absolute_url() + '?expansion=main-dossier',
+            method="GET",
+            headers=self.api_headers,
+        )
+        self.assertIsNone(
+            browser.json["@components"]['main-dossier'],
+        )
+
+    @browsing
+    def test_main_dossier_expansion_on_dossier(self, browser):
+        self.login(self.regular_user, browser=browser)
+        browser.open(
+            self.dossier.absolute_url() + '?expansion=main-dossier',
+            method="GET",
+            headers=self.api_headers,
+        )
+        self.assertEqual(
+            {
+                u'@id': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1',
+                u'@type': u'opengever.dossier.businesscasedossier',
+                u'description': u'Alle aktuellen Vertr\xe4ge mit der kantonalen Finanzverwaltung sind hier '
+                                u'abzulegen. Vertr\xe4ge vor 2016 geh\xf6ren ins Archiv.',
+                u'is_leafnode': None,
+                u'is_subdossier': False,
+                u'review_state': u'dossier-state-active',
+                u'title': u'Vertr\xe4ge mit der kantonalen Finanzverwaltung',
+            },
+            browser.json["@components"]['main-dossier'],
+        )
+
+    @browsing
+    def test_main_dossier_expansion_on_document(self, browser):
+        self.login(self.regular_user, browser=browser)
+        browser.open(
+            self.document.absolute_url() + '?expansion=main-dossier',
+            method="GET",
+            headers=self.api_headers,
+        )
+        self.assertEqual(
+            {
+                u'@id': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1',
+                u'@type': u'opengever.dossier.businesscasedossier',
+                u'description': u'Alle aktuellen Vertr\xe4ge mit der kantonalen Finanzverwaltung sind hier '
+                                u'abzulegen. Vertr\xe4ge vor 2016 geh\xf6ren ins Archiv.',
+                u'is_leafnode': None,
+                u'is_subdossier': False,
+                u'review_state': u'dossier-state-active',
+                u'title': u'Vertr\xe4ge mit der kantonalen Finanzverwaltung',
+            },
+            browser.json["@components"]['main-dossier'],
+        )
+
+    @browsing
+    def test_main_dossier_expansion_on_task(self, browser):
+        self.login(self.regular_user, browser=browser)
+        browser.open(
+            self.task.absolute_url() + '?expansion=main-dossier',
+            method="GET",
+            headers=self.api_headers,
+        )
+        self.assertEqual(
+            {
+                u'@id': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1',
+                u'@type': u'opengever.dossier.businesscasedossier',
+                u'description': u'Alle aktuellen Vertr\xe4ge mit der kantonalen Finanzverwaltung sind hier '
+                                u'abzulegen. Vertr\xe4ge vor 2016 geh\xf6ren ins Archiv.',
+                u'is_leafnode': None,
+                u'is_subdossier': False,
+                u'review_state': u'dossier-state-active',
+                u'title': u'Vertr\xe4ge mit der kantonalen Finanzverwaltung',
+            },
+            browser.json["@components"]['main-dossier'],
+        )
+
+    @browsing
+    def test_main_dossier_expansion_on_subdossier(self, browser):
+        self.login(self.regular_user, browser=browser)
+        browser.open(
+            self.subdossier.absolute_url() + '?expansion=main-dossier',
+            method="GET",
+            headers=self.api_headers,
+        )
+        self.assertEqual(
+            {
+                u'@id': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1',
+                u'@type': u'opengever.dossier.businesscasedossier',
+                u'description': u'Alle aktuellen Vertr\xe4ge mit der kantonalen Finanzverwaltung sind hier '
+                                u'abzulegen. Vertr\xe4ge vor 2016 geh\xf6ren ins Archiv.',
+                u'is_leafnode': None,
+                u'is_subdossier': False,
+                u'review_state': u'dossier-state-active',
+                u'title': u'Vertr\xe4ge mit der kantonalen Finanzverwaltung',
+            },
+            browser.json["@components"]['main-dossier'],
+        )
+
+    @browsing
+    def test_main_dossier_expansion_on_subdocument(self, browser):
+        self.login(self.regular_user, browser=browser)
+        browser.open(
+            self.subdocument.absolute_url() + '?expansion=main-dossier',
+            method="GET",
+            headers=self.api_headers,
+        )
+        self.assertEqual(
+            {
+                u'@id': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1',
+                u'@type': u'opengever.dossier.businesscasedossier',
+                u'description': u'Alle aktuellen Vertr\xe4ge mit der kantonalen Finanzverwaltung sind hier '
+                                u'abzulegen. Vertr\xe4ge vor 2016 geh\xf6ren ins Archiv.',
+                u'is_leafnode': None,
+                u'is_subdossier': False,
+                u'review_state': u'dossier-state-active',
+                u'title': u'Vertr\xe4ge mit der kantonalen Finanzverwaltung',
+            },
+            browser.json["@components"]['main-dossier'],
+        )
+
+    @browsing
+    def test_main_dossier_expansion_on_subsubdossier(self, browser):
+        self.login(self.regular_user, browser=browser)
+        browser.open(
+            self.subsubdossier.absolute_url() + '?expansion=main-dossier',
+            method="GET",
+            headers=self.api_headers,
+        )
+        self.assertEqual(
+            {
+                u'@id': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1',
+                u'@type': u'opengever.dossier.businesscasedossier',
+                u'description': u'Alle aktuellen Vertr\xe4ge mit der kantonalen Finanzverwaltung sind hier '
+                                u'abzulegen. Vertr\xe4ge vor 2016 geh\xf6ren ins Archiv.',
+                u'is_leafnode': None,
+                u'is_subdossier': False,
+                u'review_state': u'dossier-state-active',
+                u'title': u'Vertr\xe4ge mit der kantonalen Finanzverwaltung',
+            },
+            browser.json["@components"]['main-dossier'],
+        )

--- a/opengever/api/tests/test_repository.py
+++ b/opengever/api/tests/test_repository.py
@@ -14,6 +14,7 @@ class TestRepositoryAPI(IntegrationTestCase):
                 u'actions': {u'@id': u'http://nohost/plone/ordnungssystem/@actions'},
                 u'breadcrumbs': {u'@id': u'http://nohost/plone/ordnungssystem/@breadcrumbs'},
                 u'listing-stats': {u'@id': u'http://nohost/plone/ordnungssystem/@listing-stats'},
+                u'main-dossier': None,
                 u'navigation': {u'@id': u'http://nohost/plone/ordnungssystem/@navigation'},
                 u'types': {u'@id': u'http://nohost/plone/ordnungssystem/@types'},
                 u'workflow': {u'@id': u'http://nohost/plone/ordnungssystem/@workflow'},


### PR DESCRIPTION
This API expansion enables us to fetch the data of the main dossier of any given object.

This is required for an enhancement of the new content selector widget in GEVER UI. See https://4teamwork.atlassian.net/browse/GEVER-555 where @elioschmutz, @deiferni any myself discussed possible solutions.

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Documentation updated (notably for API and deployment)
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
