### PR TITLE
Add additional data in GET of Proposals and ProposalResponses

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,9 +4,11 @@ Changelog
 2020.4.0 (unreleased)
 ---------------------
 
+
+- Include additional data in Proposal GET API endpoint. [njohner]
 - Add API endpoint `@trigger-task-template` to create tasks in a dossier from a template. [deiferni]
 - Extend the @favorites endpoint to let it return already resolved favorites. [elioschmutz]
-- Use correct response type for proposal comment responses. [njoher]
+- Use correct response type for proposal comment responses. [njohner]
 - Add expandable endpoint @tasktree for getting task hierarchy. [buchi]
 
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,7 @@ Changelog
 2020.4.0 (unreleased)
 ---------------------
 
-
+- Include additional data in @responses GET for proposal responses. [njohner]
 - Include additional data in Proposal GET API endpoint. [njohner]
 - Add API endpoint `@trigger-task-template` to create tasks in a dossier from a template. [deiferni]
 - Extend the @favorites endpoint to let it return already resolved favorites. [elioschmutz]

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -41,6 +41,7 @@
   <adapter factory=".task.TaskDeserializeFromJson" />
   <adapter factory=".users.SerializeUserToJson" />
   <adapter factory=".proposal.SerializeProposalResponseToJson" />
+  <adapter factory=".proposal.SerializeProposalToJson" />
   <adapter factory=".serializer.long_converter" />
   <adapter factory=".field_deserializers.PersistentDefaultFieldDeserializer" />
   <adapter factory=".field_deserializers.PersistentDatetimeFieldDeserializer" />

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -42,6 +42,7 @@
   <adapter factory=".users.SerializeUserToJson" />
   <adapter factory=".proposal.SerializeProposalResponseToJson" />
   <adapter factory=".proposal.SerializeProposalToJson" />
+  <adapter factory=".proposal.SerializeSubmittedProposalToJson" />
   <adapter factory=".serializer.long_converter" />
   <adapter factory=".field_deserializers.PersistentDefaultFieldDeserializer" />
   <adapter factory=".field_deserializers.PersistentDatetimeFieldDeserializer" />

--- a/opengever/api/proposal.py
+++ b/opengever/api/proposal.py
@@ -1,9 +1,13 @@
 from opengever.api.response import SerializeResponseToJson
+from opengever.api.serializer import GeverSerializeFolderToJson
+from opengever.meeting.proposal import IBaseProposal
+from opengever.meeting.proposalhistory import IProposalResponse
 from plone.restapi.interfaces import ISerializeToJson
+from plone.restapi.interfaces import ISerializeToJsonSummary
 from zope.component import adapter
+from zope.component import getMultiAdapter
 from zope.interface import implementer
 from zope.interface import Interface
-from opengever.meeting.proposalhistory import IProposalResponse
 
 
 @implementer(ISerializeToJson)
@@ -11,3 +15,33 @@ from opengever.meeting.proposalhistory import IProposalResponse
 class SerializeProposalResponseToJson(SerializeResponseToJson):
 
     model = IProposalResponse
+
+
+@implementer(ISerializeToJson)
+@adapter(IBaseProposal, Interface)
+class SerializeProposalToJson(GeverSerializeFolderToJson):
+
+    def __call__(self, *args, **kwargs):
+        result = super(SerializeProposalToJson, self).__call__(*args, **kwargs)
+
+        excerpt = self.context.get_excerpt()
+        if excerpt:
+            serializer = getMultiAdapter(
+                 (excerpt, self.request), interface=ISerializeToJsonSummary
+            )
+            result[u'excerpt'] = serializer()
+        else:
+            result[u'excerpt'] = None
+
+        meeting = self.context.load_model().get_meeting()
+        if meeting:
+            result[u'meeting'] = {
+                'title': meeting.title,
+                '@id': meeting.get_url(view=None)
+                }
+        else:
+            result[u'meeting'] = None
+
+        result[u'decision_number'] = self.context.load_model().get_decision_number()
+
+        return result

--- a/opengever/api/proposal.py
+++ b/opengever/api/proposal.py
@@ -1,9 +1,12 @@
 from opengever.api.response import SerializeResponseToJson
 from opengever.api.serializer import GeverSerializeFolderToJson
+from opengever.base.oguid import Oguid
+from opengever.meeting.model import Meeting
 from opengever.meeting.proposal import IBaseProposal
 from opengever.meeting.proposalhistory import IProposalResponse
 from plone.restapi.interfaces import ISerializeToJson
 from plone.restapi.interfaces import ISerializeToJsonSummary
+from plone.restapi.serializer.converters import json_compatible
 from zope.component import adapter
 from zope.component import getMultiAdapter
 from zope.interface import implementer
@@ -15,6 +18,25 @@ from zope.interface import Interface
 class SerializeProposalResponseToJson(SerializeResponseToJson):
 
     model = IProposalResponse
+
+    def __call__(self, *args, **kwargs):
+        resp = super(SerializeProposalResponseToJson, self).__call__(*args, **kwargs)
+
+        additional_data = resp['additional_data']
+        if 'successor_oguid' in additional_data:
+            successor = Oguid.parse(self.context.successor_oguid).resolve_object()
+            model = successor.load_model()
+            additional_data['successor_title'] = model.title
+            if model.display_proposal_link():
+                additional_data['successor_url'] = model.get_url()
+
+        if 'meeting_id' in additional_data:
+            meeting = Meeting.query.get(self.context.meeting_id)
+            additional_data['meeting_title'] = json_compatible(
+                meeting.get_title() if meeting else u'')
+            if meeting.can_view():
+                additional_data['meeting_url'] = meeting.get_url()
+        return resp
 
 
 @implementer(ISerializeToJson)

--- a/opengever/api/tests/test_proposal.py
+++ b/opengever/api/tests/test_proposal.py
@@ -51,6 +51,21 @@ class TestProposalSerialization(IntegrationTestCase):
             browser.json)
 
     @browsing
+    def test_scheduled_response_contains_meeting_title_and_url(self, browser):
+        self.login(self.meeting_user, browser=browser)
+        response_id = 1472649453000000
+        url = pjoin(self.decided_proposal.absolute_url(), '@responses', str(response_id))
+        browser.open(url, method="GET", headers=self.api_headers)
+
+        self.maxDiff = None
+        self.assertEqual(u'scheduled', browser.json['response_type'])
+        self.assertDictEqual(
+            {u'meeting_id': self.decided_meeting.model.meeting_id,
+             u'meeting_title': self.decided_meeting.get_title(),
+             u'meeting_url': self.decided_meeting.absolute_url()},
+            browser.json['additional_data'])
+
+    @browsing
     def test_submitted_proposal_contains_a_list_of_responses(self, browser):
         self.login(self.meeting_user, browser=browser)
         browser.open(self.submitted_proposal, method="GET", headers=self.api_headers)

--- a/opengever/api/tests/test_proposal.py
+++ b/opengever/api/tests/test_proposal.py
@@ -73,3 +73,27 @@ class TestProposalSerialization(IntegrationTestCase):
              u'response_type': u'submitted',
              u'text': u''},
             responses[0])
+
+    @browsing
+    def test_decided_proposal_contains_meeting_decision_number_and_excerpt(self, browser):
+        self.login(self.meeting_user, browser=browser)
+        browser.open(self.decided_proposal, method="GET", headers=self.api_headers)
+
+        self.assertIn(u'meeting', browser.json)
+        self.assertDictEqual(
+            {u'@id': self.decided_meeting.absolute_url(),
+             u'title': self.decided_meeting.get_title()},
+            browser.json[u'meeting'])
+
+        self.assertIn(u'decision_number', browser.json)
+        self.assertEqual(u'2016 / 1', browser.json[u'decision_number'])
+
+        excerpt = self.decided_proposal.get_excerpt()
+        self.assertDictEqual(
+            {u'@id': excerpt.absolute_url(),
+             u'@type': u'opengever.document.document',
+             u'description': u'',
+             u'is_leafnode': None,
+             u'review_state': u'document-state-draft',
+             u'title': excerpt.title},
+            browser.json[u'excerpt'])

--- a/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
+++ b/opengever/meeting/locales/fr/LC_MESSAGES/opengever.meeting.po
@@ -1737,7 +1737,7 @@ msgstr "Document ${title} soumis par ${user} en version ${version}."
 #. Default: "Submitted document ${title} permanently unlocked by ${user}"
 #: ./opengever/meeting/proposalhistory.py
 msgid "proposal_history_label_document_unlocked"
-msgstr ""
+msgstr "Document soumis ${title} découplé par ${user}"
 
 #. Default: "Submitted document ${title} updated to version ${version} by ${user}"
 #: ./opengever/meeting/proposalhistory.py

--- a/opengever/meeting/model/meeting.py
+++ b/opengever/meeting/model/meeting.py
@@ -507,10 +507,13 @@ class Meeting(Base, SQLFormSupport):
         return self._get_link(self.get_submitted_admin_unit(),
                               self.submitted_physical_path)
 
+    def can_view(self):
+        return api.user.has_permission(
+            'View', obj=self.committee.resolve_committee())
+
     def get_link(self):
-        url = self.get_url()
-        if api.user.has_permission('View',
-                                   obj=self.committee.resolve_committee()):
+        if self.can_view():
+            url = self.get_url()
             link = u'<a href="{0}" title="{1}" class="{2}">{1}</a>'.format(
                 url, escape_html(self.get_title()), self.css_class)
         else:

--- a/opengever/meeting/model/proposal.py
+++ b/opengever/meeting/model/proposal.py
@@ -227,13 +227,25 @@ class Proposal(Base):
             return ''
         return '/'.join((admin_unit.public_url, physical_path))
 
-    def get_link(self, include_icon=True):
+    def display_proposal_link(self):
         proposal_ = self.resolve_proposal()
-        as_link = proposal_ is None or api.user.has_permission('View', obj=proposal_)
+        # The proposal cannot be resolved when it is on another
+        # client, in that case we cannot determine whether the user has
+        # permission to see it and hence default to displaying the link.
+        return proposal_ is None or api.user.has_permission('View', obj=proposal_)
+
+    def display_submitted_proposal_link(self):
+        proposal_ = self.resolve_submitted_proposal()
+        # The submitted proposal cannot be resolved when it is on another
+        # client, in that case we cannot determine whether the user has
+        # permission to see it and hence default to displaying the link.
+        return proposal_ is None or api.user.has_permission('View', obj=proposal_)
+
+    def get_link(self, include_icon=True):
         return self._get_link(self.get_url(),
                               self.title,
                               include_icon=include_icon,
-                              as_link=as_link)
+                              as_link=self.display_proposal_link())
 
     def get_description(self):
         proposal_ = self.resolve_proposal()
@@ -245,11 +257,10 @@ class Proposal(Base):
 
     def get_submitted_link(self, include_icon=True):
         proposal_ = self.resolve_submitted_proposal()
-        as_link = proposal_ is None or api.user.has_permission('View', obj=proposal_)
         return self._get_link(self.get_submitted_url(),
                               proposal_.title,
                               include_icon=include_icon,
-                              as_link=as_link)
+                              as_link=self.display_submitted_proposal_link())
 
     def _get_link(self, url, title, include_icon=True, as_link=True):
         title = escape_html(title)

--- a/opengever/meeting/model/proposal.py
+++ b/opengever/meeting/model/proposal.py
@@ -455,9 +455,13 @@ class Proposal(Base):
             self.physical_path).execute()
         return response['intid']
 
-    def get_meeting_link(self):
+    def get_meeting(self):
         agenda_item = self.agenda_item
-        if not agenda_item:
-            return u''
+        if agenda_item:
+            return agenda_item.meeting
 
-        return agenda_item.meeting.get_link()
+    def get_meeting_link(self):
+        meeting = self.get_meeting()
+        if meeting is not None:
+            return meeting.get_link()
+        return u''

--- a/opengever/meeting/proposal.py
+++ b/opengever/meeting/proposal.py
@@ -617,6 +617,14 @@ class Proposal(Container, ProposalBase):
 
         ProposalSubmittedActivity(self, self.REQUEST).record()
 
+    def get_successor_proposals(self):
+        catalog = getUtility(ICatalog)
+        doc_id = getUtility(IIntIds).getId(aq_inner(self))
+        relations = catalog.findRelations({
+            'to_id': doc_id,
+            'from_attribute': 'predecessor_proposal'})
+        return [relation.from_object for relation in relations]
+
     def get_overview_attributes(self):
         data = super(Proposal, self).get_overview_attributes()
 
@@ -627,14 +635,10 @@ class Proposal(Container, ProposalBase):
                 'value': predecessor_model.get_link(),
                 'is_html': True})
 
-        catalog = getUtility(ICatalog)
-        doc_id = getUtility(IIntIds).getId(aq_inner(self))
         successor_html_items = []
-        for relation in catalog.findRelations({
-                'to_id': doc_id,
-                'from_attribute': 'predecessor_proposal'}):
+        for successor in self.get_successor_proposals():
             successor_html_items.append(u'<li>{}</li>'.format(
-                relation.from_object.load_model().get_link()))
+                successor.load_model().get_link()))
         if successor_html_items:
             data.append({
                 'label': _('label_successors', default=u'Successors'),


### PR DESCRIPTION
In this PR we add some additional data in the GET of proposals and proposal responses. `Proposal`s indeed include important data depending on their status which is not part of their Schema (the meeting it is scheduled in, the excerpt and the decision number). Similarly additional data is required to represent certain `ProposalResponse`s correctly, which is not in the response schema (titles and urls of meeting and successor proposal).

For https://4teamwork.atlassian.net/browse/GEVER-313

## Checklist (Must have)
- [x] Changelog entry
- [x] Documentation updated (notably for API and deployment)
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
