### PR TITLE
Allow trashed as field in @listing endpoint.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 
 - Include additional data in @responses GET for proposal responses. [njohner]
 - Include additional data in Proposal GET API endpoint. [njohner]
+- Allow `trashed` as field in @listing endpoint. [tinagerber]
 - Add API endpoint `@trigger-task-template` to create tasks in a dossier from a template. [deiferni]
 - Extend the @favorites endpoint to let it return already resolved favorites. [elioschmutz]
 - Use correct response type for proposal comment responses. [njohner]

--- a/docs/public/dev-manual/api/listings.rst
+++ b/docs/public/dev-manual/api/listings.rst
@@ -99,6 +99,7 @@ werden. Folgende Felder stehen zur Verfügung:
 - ``task_type``: Aufgaben-Typ
 - ``thumbnail_url``: URL für Vorschaubild
 - ``title``: Titel
+- ``trashed``: Ob das Objekt im Papierkorb ist
 - ``type``: Inhaltstyp
 - ``@type``: Inhaltstyp
 - ``UID``: UID des Objektes
@@ -198,6 +199,8 @@ siehe Tabelle:
     |``thumbnail_url``         |    ja    |   nein  |     nein     |        nein        |  nein   |  nein   |  nein   |   nein   |
     +--------------------------+----------+---------+--------------+--------------------+---------+---------+---------+----------+
     |``title``                 |    ja    |    ja   |      ja      |         ja         |   ja    |   ja    |   ja    |    ja    |
+    +--------------------------+----------+---------+--------------+--------------------+---------+---------+---------+----------+
+    |``trashed``               |    ja    |   nein  |     nein     |        nein        |  nein   |  nein   |  nein   |   nein   |
     +--------------------------+----------+---------+--------------+--------------------+---------+---------+---------+----------+
     |``type``                  |    ja    |    ja   |      ja      |         ja         |   ja    |   ja    |   ja    |    ja    |
     +--------------------------+----------+---------+--------------+--------------------+---------+---------+---------+----------+

--- a/opengever/api/listing.py
+++ b/opengever/api/listing.py
@@ -41,6 +41,7 @@ OTHER_ALLOWED_FIELDS = set([
     'receipt_date',
     'created',
     'changed',
+    'trashed',
     'delivery_date'])
 
 

--- a/opengever/api/tests/test_listing.py
+++ b/opengever/api/tests/test_listing.py
@@ -168,6 +168,7 @@ class TestListingWithRealSolr(SolrIntegrationTestCase):
             'columns=review_state',
             'columns=relative_path',
             'columns=UID',
+            'columns=trashed',
             'sort_on=created',
         ))
         view = '?'.join(('@listing', query_string))
@@ -187,6 +188,7 @@ class TestListingWithRealSolr(SolrIntegrationTestCase):
             {u'review_state': u'dossier-state-active',
              u'@id': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1',
              u'UID': IUUID(self.dossier),
+             u'trashed': False,
              u'reference': u'Client1 1.1 / 1',
              u'title': u'Vertr\xe4ge mit der kantonalen Finanzverwaltung',
              u'relative_path': u'ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1'},
@@ -205,6 +207,7 @@ class TestListingWithRealSolr(SolrIntegrationTestCase):
             'columns=bumblebee_checksum',
             'columns=relative_path',
             'columns=UID',
+            'columns=trashed',
             'sort_on=created',
         ))
         view = '?'.join(('@listing', query_string))
@@ -215,11 +218,37 @@ class TestListingWithRealSolr(SolrIntegrationTestCase):
              u'document_author': u'test_user_1_',
              u'@id': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/document-14',
              u'UID': IUUID(self.document),
+             u'trashed': False,
              u'modified': u'2016-08-31T14:07:33+00:00',
              u'containing_dossier': u'Vertr\xe4ge mit der kantonalen Finanzverwaltung',
              u'bumblebee_checksum': DOCX_CHECKSUM,
              u'relative_path': u'ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/document-14'},
             browser.json['items'][-1])
+
+    @browsing
+    def test_mail_listing(self, browser):
+        self.login(self.regular_user, browser=browser)
+        query_string = '&'.join((
+            'name=documents',
+            'columns=reference',
+            'columns=title',
+            'columns=modified',
+            'columns=containing_dossier',
+            'columns=UID',
+            'columns=trashed',
+            'sort_on=created',
+        ))
+        view = '?'.join(('@listing', query_string))
+        browser.open(self.private_dossier, view=view, headers=self.api_headers)
+        self.assertEqual(
+            {u'reference': u'P Client1 kathi-barfuss / 1 / 37',
+             u'title': u'[No Subject]',
+             u'@id': u'http://nohost/plone/private/kathi-barfuss/dossier-14/document-37',
+             u'UID': IUUID(self.private_mail),
+             u'trashed': False,
+             u'modified': u'2016-08-31T17:11:33+00:00',
+             u'containing_dossier': u'Mein Dossier 1'},
+            browser.json['items'][0])
 
     @browsing
     def test_document_listing_preview_url(self, browser):


### PR DESCRIPTION
To decide in the frontend which folderActions are available for documents, you have to know if the documents are in the trash or not. Therefore the listing endpoint must provide this information.

Jira: https://4teamwork.atlassian.net/browse/GEVER-45

Definition of Done: https://4teamwork.atlassian.net/wiki/spaces/CHX4TW/pages/917562/


## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Documentation updated (notably for API and deployment)
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)