### PR TITLE
Fix flaky test that relied on arbitrary order.

### DIFF
--- a/opengever/api/tests/test_templatefolder.py
+++ b/opengever/api/tests/test_templatefolder.py
@@ -153,12 +153,24 @@ class TestDocumentFromTemplatePost(IntegrationTestCase):
 
 class TestTriggerTaskTemplatePost(IntegrationTestCase):
 
-    def _get_task_template_item(self, browser, item=0):
+    def _get_task_template_item(self, browser, title=None):
+        """Return a task template folder vocabulary item.
+
+        Return the first task template folder item from the vocabulary if no
+        title is given, otherwise return the specified item.
+        """
         browser.open(
             '{}/@vocabularies/opengever.tasktemplates.active_tasktemplatefolders'.format(
                 self.portal.absolute_url()),
             headers=self.api_headers)
-        return browser.json['items'][item]
+
+        if title:
+            for item in browser.json['items']:
+                if item['title'] == title:
+                    return item
+            raise ValueError(u'no item with title {} found'.format(title))
+
+        return browser.json['items'][0]
 
     @browsing
     def test_trigger_with_minimal_required_input(self, browser):
@@ -340,7 +352,8 @@ class TestTriggerTaskTemplatePost(IntegrationTestCase):
             )
 
         data = {
-            'tasktemplatefolder': self._get_task_template_item(browser, item=1),
+            'tasktemplatefolder': self._get_task_template_item(
+                browser, title=u'Verfahren Neuanstellung'),
             'tasktemplates': [
                 {
                     '@id': foreign_task_template.absolute_url(),


### PR DESCRIPTION
The test helper to get vocabulary items introduced in https://github.com/4teamwork/opengever.core/pull/6514 relied on vocabulary order. The order seems arbitrary and thus the test became flaky. I have adapted the test helper to filter by a criteria (title in this case) instead of relying on order to get specific items.

This should hopefully fix the flaky tests.

https://4teamwork.atlassian.net/browse/GEVER-101

_sorry about that 😞_ 

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [ ] Changelog entry
- [ ] Documentation updated (notably for API and deployment)
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)