### PR TITLE
Disable the searchbox for document versions.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 ---------------------
 
 - Make "populate_filename_column_in_favorites" UpgradeStep more robust. [lgraf]
+- Disable the searchbox on the tabbed view which lists the versions of a document. [mbaechtold]
 - Include additional data in @responses GET for proposal responses. [njohner]
 - Include additional data in Proposal GET API endpoint. [njohner]
 - Allow `trashed` as field in @listing endpoint. [tinagerber]

--- a/opengever/document/browser/versions_tab.py
+++ b/opengever/document/browser/versions_tab.py
@@ -378,6 +378,7 @@ class VersionsTab(BaseListingTab):
 
     sort_on = 'version'
     sort_reverse = True
+    show_searchform = False
 
     show_selects = False
     enabled_actions = []


### PR DESCRIPTION
Until now, a searchbox was rendered on the document versions tabbed view. As far as we could find out, the searchbox never had any effect on the results shown in table.

The listing of the document versions is lazy and we do not see an easy way to implement the filtering of the versions by a searchable text and keeping this lazyness at the same time.

According to the product owner, we may simply disable the searchbox on the version tab (see screenshot).

There is no test because the searchbox is removed by JavaScript.

Belongs to the Jira issue https://4teamwork.atlassian.net/browse/GEVER-584

![image](https://user-images.githubusercontent.com/28220/85711021-26084c00-b6e7-11ea-8be7-a1e23e078516.png)

## Checklist (Must have)

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)