### PR TITLE
Make "populate_filename_column_in_favorites" UpgradeStep more robust:

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2020.4.0 (unreleased)
 ---------------------
 
+- Make "populate_filename_column_in_favorites" UpgradeStep more robust. [lgraf]
 - Include additional data in @responses GET for proposal responses. [njohner]
 - Include additional data in Proposal GET API endpoint. [njohner]
 - Allow `trashed` as field in @listing endpoint. [tinagerber]

--- a/opengever/core/upgrades/20200508163417_populate_filename_column_in_favorites/upgrade.py
+++ b/opengever/core/upgrades/20200508163417_populate_filename_column_in_favorites/upgrade.py
@@ -1,4 +1,5 @@
 from opengever.core.upgrade import SQLUpgradeStep
+from os.path import splitext
 from plone import api
 from sqlalchemy.sql.expression import column
 from sqlalchemy.sql.expression import select
@@ -15,6 +16,13 @@ favorites_table = table(
     column('admin_unit_id'),
     column('filename'),
 )
+
+MAX_FILENAME_BASE_LENGTH = 100
+
+
+def safe_unicode(value):
+    if isinstance(value, str):
+        return value.decode('utf-8')
 
 
 class PopulateFilenameColumnInFavorites(SQLUpgradeStep):
@@ -35,7 +43,13 @@ class PopulateFilenameColumnInFavorites(SQLUpgradeStep):
         query = {"object_provides": "opengever.document.behaviors.IBaseDocument",
                  "UID": favorite_uids}
         for brain in self.catalog_unrestricted_search(query=query):
-            filename = brain.filename or u""
+            # Defensively truncate filename to max 105 chars total
+            filename = safe_unicode(brain.filename or u"")
+            if filename:
+                basename, ext = splitext(filename)
+                basename = basename[:MAX_FILENAME_BASE_LENGTH]
+                filename = u''.join((basename, ext))
+
             self.execute(
                 favorites_table.update()
                 .values(filename=filename)


### PR DESCRIPTION
**Background**
This upgrade step attempts to poplate the filename SQL column for favorites, which is limited to 105 characters. If an object (specifically mails) is encountered that for some reason still has a longer filename indexed in the catalog, this upgrade step will fail.

**Fix**
This change makes it more robust by truncating any filename to the max length before attempting to write it to SQL.

**Jira** (related to): https://4teamwork.atlassian.net/browse/GEVER-477

❗ Needs to be backported to `2020.3.x`

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

