### PR TITLE
Expect the solr service not to be running upon the first request

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2020.4.0 (unreleased)
 ---------------------
 
+- Improve check if solr has started to prevent an issue during the testserver startup. [sebastianmanger]
 - Make creating favorites more robust in case of workflow issues. [deiferni]
 - Improve response history for (automatically) opened subtasks in sequential task templates. [mbaechtold]
 - Fix contenttree.js so that it is also supported by IE. [njohner]

--- a/opengever/core/solr_testing.py
+++ b/opengever/core/solr_testing.py
@@ -79,15 +79,10 @@ class SolrServer(object):
         return self
 
     def is_ready(self):
-        """Check whether the solr server has bound the port already.
+        """Check whether the solr server is ready to accept connections.
         """
-        sock = socket.socket()
-        sock.settimeout(0.1)
-        try:
-            result = sock.connect_ex(('127.0.0.1', self.port))
-        finally:
-            sock.close()
-        return result == 0
+        response = requests.get(url='http://localhost:{}/solr/{}/admin/ping'.format(self.port, self.core))
+        return response.ok
 
     def await_ready(self, timeout=60, interval=0.1, verbose=False):
         """Wait until the solr server has bound the port.


### PR DESCRIPTION
The command `bin/testserver` did not succeed due to a `503` during the initial connection (which empties the index) from the testserver to Solr:
```
ftw.testing PATCHING: Products.CMFQuickInstallerTool.events.handleProfileImportedEvent with noop
ftw.testing PATCHING: Products.CMFQuickInstallerTool.events.handleBeforeProfileImportEvent with noop
11:12:33 [ wait ] Starting Zope 2 server
{u'error': {u'msg': u'SolrCore is loading', u'code': 503, u'metadata': [u'error-class', u'org.apache.solr.common.SolrException', u'root-error-class', u'org.apache.solr.common.SolrException']}}
Traceback (most recent call last):
  File "./bin/testserver", line 434, in <module>
    sys.exit(plone.app.robotframework.server.server())
  File "/Users/sebastianmanger/Code/opengever/eggs/plone.app.robotframework-1.2.3-py2.7.egg/plone/app/robotframework/server.py", line 206, in server
    start(args.layer)
  File "/Users/sebastianmanger/Code/opengever/eggs/plone.app.robotframework-1.2.3-py2.7.egg/plone/app/robotframework/server.py", line 44, in start
    zsl.start_zope_server(zope_layer_dotted_name)
  File "/Users/sebastianmanger/Code/opengever/eggs/plone.app.robotframework-1.2.3-py2.7.egg/plone/app/robotframework/server.py", line 259, in start_zope_server
    setup_layer(new_layer)
  File "/Users/sebastianmanger/Code/opengever/eggs/plone.app.robotframework-1.2.3-py2.7.egg/plone/app/robotframework/server.py", line 334, in setup_layer
    setup_layer(base, setup_layers)
  File "/Users/sebastianmanger/Code/opengever/eggs/plone.app.robotframework-1.2.3-py2.7.egg/plone/app/robotframework/server.py", line 343, in setup_layer
    layer.setUp()
  File "/Users/sebastianmanger/Code/opengever/eggs/plone.app.testing-4.2.6-py2.7.egg/plone/app/testing/helpers.py", line 339, in setUp
    self.setUpZope(portal.getPhysicalRoot(), configurationContext)
  File "/Users/sebastianmanger/Code/opengever/opengever/core/testserver.py", line 52, in setUpZope
    SolrReplicationAPIClient.get_instance().clear()
  File "/Users/sebastianmanger/Code/opengever/opengever/core/solr_testing.py", line 177, in clear
    response.raise_for_status()
  File "/Users/sebastianmanger/Code/opengever/eggs/requests-2.18.4-py2.7.egg/requests/models.py", line 935, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 503 Server Error: Service Unavailable for url: http://localhost:55003/solr/testserver/update?commit=true
``` 

The command `./bin/zopepy opengever/core/solr_testing.py` either timed out or delivered the expected response after a long time.

The testserver-mechanism starts the process, and then immediately expects Solr to be ready to accept requests. This PR introduces a change to retry the initial connection. I did not add a test, as the overhead of setting up a system/mocking stuff to reproduce the "slow" behaviour seems over the top.

@deiferni helped debugging/developing this, I'd be glad for @lukasgraf to have a quick look. 

## Checklist (Must have)

- ~[ ] Changelog entry~
- ~[ ] Link to issue (Jira or GitHub) and backlink in issue (Jira)~ Discovered during: https://4teamwork.atlassian.net/browse/DJANGO-398
