### PR TITLE
Fix permission issue with tasktemplates.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -11,6 +11,7 @@ Changelog
 - Add support for metadata_fields in OpengeverRealContentListingObject. [njohner]
 - Fix sort order within task template folder. [mbaechtold]
 - Fix deadline of task templates no longer shown in tabular listing. [mbaechtold]
+- Fix permission issue with resolving subtask of tasktemplates. [njohner]
 - Add API expansion `main-dossier`. [mbaechtold]
 - Make "populate_filename_column_in_favorites" UpgradeStep more robust. [lgraf]
 - Disable the searchbox on the tabbed view which lists the versions of a document. [mbaechtold]


### PR DESCRIPTION
When resolving a subtask of a sequential `TaskTemplate`, the next`Task` is opened. The problem is that there is no guarantee that the current user has any permissions on that next `Task`, especially for cross-client `Task`s. We therefore need to use `elevated_privileges` to trigger that transition.

For https://4teamwork.atlassian.net/browse/GEVER-583
This should also solve https://sentry.4teamwork.ch/sentry/onegov-gever/issues/9715/

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
