### PR TITLE
Add support for several metadata_fields for real content listing objects 

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 
 - Also allow replacing concrete responsibles with interactive responsibles when triggering task templates. [deiferni]
 - Introduce a new property `touched` on dossiers. [mbaechtold]
+- Add support for metadata_fields in OpengeverRealContentListingObject. [njohner]
 - Fix sort order within task template folder. [mbaechtold]
 - Fix deadline of task templates no longer shown in tabular listing. [mbaechtold]
 - Add API expansion `main-dossier`. [mbaechtold]

--- a/opengever/api/tests/test_summary_serializer.py
+++ b/opengever/api/tests/test_summary_serializer.py
@@ -1,0 +1,85 @@
+from ftw.testbrowser import browsing
+from opengever.testing import IntegrationTestCase
+from plone.restapi.interfaces import ISerializeToJsonSummary
+from zope.component import getMultiAdapter
+
+
+class TestGeverSummarySerializer(IntegrationTestCase):
+
+    @browsing
+    def test_document_summary_supports_filename_filesize_and_mimetype_as_metadata_fields(self, browser):
+        self.login(self.regular_user, browser)
+
+        serializer = getMultiAdapter(
+            (self.document, self.request),
+            ISerializeToJsonSummary)
+        serilized_doc = serializer()
+
+        self.assertNotIn('filename', serilized_doc)
+        self.assertNotIn('filesize', serilized_doc)
+        self.assertNotIn('mimetype', serilized_doc)
+        self.assertNotIn('creator', serilized_doc)
+
+        self.request.form['metadata_fields'] = [
+            'filename', 'filesize', 'mimetype', 'creator']
+        serializer = getMultiAdapter(
+            (self.document, self.request),
+            ISerializeToJsonSummary)
+        serilized_doc = serializer()
+
+        self.assertIn('filename', serilized_doc)
+        self.assertIn('filesize', serilized_doc)
+        self.assertIn('mimetype', serilized_doc)
+        self.assertIn('creator', serilized_doc)
+
+        self.assertDictEqual(
+            {'@id': self.document.absolute_url(),
+             '@type': u'opengever.document.document',
+             'creator': u'robert.ziegler',
+             'description': u'Wichtige Vertr\xe4ge',
+             'filename': u'Vertraegsentwurf.docx',
+             'filesize': 27413,
+             'mimetype': u'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+             'is_leafnode': None,
+             'review_state': u'document-state-draft',
+             'title': u'Vertr\xe4gsentwurf'},
+            serilized_doc)
+
+    @browsing
+    def test_mail_summary_supports_filename_filesize_and_mimetype_as_metadata_fields(self, browser):
+        self.login(self.regular_user, browser)
+
+        serializer = getMultiAdapter(
+            (self.mail_eml, self.request),
+            ISerializeToJsonSummary)
+        serilized_doc = serializer()
+
+        self.assertNotIn('filename', serilized_doc)
+        self.assertNotIn('filesize', serilized_doc)
+        self.assertNotIn('mimetype', serilized_doc)
+        self.assertNotIn('creator', serilized_doc)
+
+        self.request.form['metadata_fields'] = [
+            'filename', 'filesize', 'mimetype', 'creator']
+        serializer = getMultiAdapter(
+            (self.mail_eml, self.request),
+            ISerializeToJsonSummary)
+        serilized_doc = serializer()
+
+        self.assertIn('filename', serilized_doc)
+        self.assertIn('filesize', serilized_doc)
+        self.assertIn('mimetype', serilized_doc)
+        self.assertIn('creator', serilized_doc)
+
+        self.assertDictEqual(
+            {'@id': self.mail_eml.absolute_url(),
+             '@type': u'ftw.mail.mail',
+             'creator': u'robert.ziegler',
+             'description': u'',
+             'filename': u'Die Buergschaft.eml',
+             'filesize': 1108,
+             'mimetype': u'text/plain',
+             'is_leafnode': None,
+             'review_state': u'mail-state-active',
+             'title': u'Die B\xfcrgschaft'},
+            serilized_doc)

--- a/opengever/base/contentlisting.py
+++ b/opengever/base/contentlisting.py
@@ -5,6 +5,7 @@ from opengever.base.browser.helper import get_css_class
 from opengever.base.helpers import display_name
 from opengever.bumblebee import is_bumblebee_feature_enabled
 from opengever.bumblebee import is_bumblebeeable
+from opengever.document.behaviors import IBaseDocument
 from opengever.document.document import Document
 from opengever.document.widgets.document_link import DocumentLinkWidget
 from opengever.mail.mail import OGMail
@@ -239,3 +240,6 @@ class OpengeverRealContentListingObject(RealContentListingObject):
     def translated_review_state(self):
         return translate(
             self.review_state(), domain='plone', context=self.request)
+
+    def creator(self):
+        return self.getObject().Creator()

--- a/opengever/document/contentlisting.py
+++ b/opengever/document/contentlisting.py
@@ -60,3 +60,14 @@ class DocumentContentListingObject(OpengeverRealContentListingObject):
 
     def get_overlay_title(self):
         return self.Title().decode('utf-8')
+
+    def mimetype(self):
+        return self.getObject().content_type()
+
+    def filename(self):
+        return self.getObject().get_filename()
+
+    def filesize(self):
+        file_ = self.getObject().get_file()
+        if file_:
+            return file_.getSize()

--- a/opengever/document/contentlisting.py
+++ b/opengever/document/contentlisting.py
@@ -5,7 +5,6 @@ from opengever.bumblebee import is_bumblebee_feature_enabled
 from opengever.document.document import Document
 from opengever.document.widgets.document_link import DocumentLinkWidget
 from opengever.mail.mail import OGMail
-from opengever.trash.trash import ITrashed
 from plone import api
 from zope.component import getMultiAdapter
 from zope.globalrequest import getRequest


### PR DESCRIPTION
The summary serializer should support the same metadata, whether the object being summarised is a brain or a real object, so that `items` and `related_items` get serialized in the same way. `OpengeverRealContentListingObject` should therefore support the same `metadata_fields` as the `OpengeverCatalogContentListingObject`. As a first step here, we add support for some essential fields, notably `filename` which is essential for correctly representing documents in a relation field (e.g. `relatedItems`) in the frontend, notably documents linked to a subtask, the excerpt or linked documents in a `Proposal`.

For https://4teamwork.atlassian.net/browse/GEVER-313

## Checklist (Must have)

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


## Checklist (if applicable)

- API change:
  - [x] Documentation is updated: does not need updating, this was already promised in the documentation
- New functionality:
  - [x] for `document` also works for `mail`