### PR TITLE
Also support interactive responsibles when triggering a task template.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2020.4.0 (unreleased)
 ---------------------
 
+- Also allow replacing concrete responsibles with interactive responsibles when triggering task templates. [deiferni]
 - Introduce a new property `touched` on dossiers. [mbaechtold]
 - Fix sort order within task template folder. [mbaechtold]
 - Fix deadline of task templates no longer shown in tabular listing. [mbaechtold]

--- a/docs/public/dev-manual/api/trigger_task_template.rst
+++ b/docs/public/dev-manual/api/trigger_task_template.rst
@@ -40,3 +40,33 @@ Der Endpoint erwartet folgende Parameter:
 
 Als Response wird die JSON-Repräsentation der neu erstellten Aufgabe geliefert,
 siehe :ref:`Inhaltstypen <content-types>`.
+
+
+Interaktive Auftragnehmer
+-------------------------
+
+Bei jeder ausgewählten Aufgabenvorlage kann der Auftragnehmer überschrieben
+werden. Der Auftragnehmer kann durch einen interaktiven Benutzer ersetzt
+werden. Es gibt dabei folgende Möglichkeiten:
+
+- ``interactive_users:current_user``: Der aktuelle Benutzer
+- ``interactive_users:responsible``:  Die Federführende Person des Dossiers, in dem die Aufgabe erstellt wird
+
+
+**Beispiel-Request**:
+
+   .. sourcecode:: http
+
+        POST /ordnungssystem/fuehrung/dossier-23/@trigger-task-template HTTP/1.1
+        Accept: application/json
+
+        {
+            "tasktemplatefolder": "67a25fc941354568950439f08f7af3ed",
+            "tasktemplates": [
+                {
+                    "@id": "http://localhost:8080/fd/vorlagen/tasktemplatefolder-1/tasktemplate-1",
+                    "responsible": "interactive_users:current_user"
+                }
+            ],
+            "start_immediately": false
+        }

--- a/opengever/api/templatefolder.py
+++ b/opengever/api/templatefolder.py
@@ -3,7 +3,7 @@ from opengever.api.validation import get_validation_errors
 from opengever.base.source import DossierPathSourceBinder
 from opengever.base.source import SolrObjPathSourceBinder
 from opengever.dossier.command import CreateDocumentFromTemplateCommand
-from opengever.ogds.base.sources import AllUsersInboxesAndTeamsSourceBinder
+from opengever.tasktemplates.sources import TaskResponsibleSourceBinder
 from plone import api
 from plone.protect.interfaces import IDisableCSRFProtection
 from plone.restapi.deserializer import json_body
@@ -94,7 +94,7 @@ class ITriggerTaskTemplateSources(model.Schema):
     )
 
     responsible = schema.Choice(
-        source=AllUsersInboxesAndTeamsSourceBinder(include_teams=True),
+        source=TaskResponsibleSourceBinder(include_teams=True),
         required=True,
         )
 


### PR DESCRIPTION
We also want to support interactive responsibles for the tasks created via `@trigger_task_template`. Not only should the existing defaults from a task-template be used, we also want to support to replace a concrete default value with an interactive one.

For https://4teamwork.atlassian.net/browse/GEVER-101.

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
