### PR TITLE
Improve response history for opened subtasks.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2020.4.0 (unreleased)
 ---------------------
 
+- Improve response history for (automatically) opened subtasks in sequential task templates. [mbaechtold]
 - Fix contenttree.js so that it is also supported by IE. [njohner]
 - Also allow replacing concrete responsibles with interactive responsibles when triggering task templates. [deiferni]
 - Remove cross-tab logout functionality. [lgraf]

--- a/opengever/task/locales/de/LC_MESSAGES/opengever.task.po
+++ b/opengever/task/locales/de/LC_MESSAGES/opengever.task.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2020-06-09 10:06+0000\n"
+"POT-Creation-Date: 2020-06-29 14:27+0000\n"
 "PO-Revision-Date: 2015-02-17 18:41+0100\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -987,6 +987,11 @@ msgstr "Aufgabe eröffnet"
 msgid "transition_label_modify_deadline"
 msgstr "Aufgabenfrist verändert"
 
+#. Default: "Task opened automatically"
+#: ./opengever/task/response_description.py
+msgid "transition_label_opened"
+msgstr "Aufgabe automatisch gestartet"
+
 #. Default: "Task reactivated"
 #: ./opengever/task/response_description.py
 msgid "transition_label_reactivate"
@@ -1076,6 +1081,11 @@ msgstr "Neu zugewiesen von ${responsible_old} an ${responsible_new} durch ${user
 #: ./opengever/task/response_description.py
 msgid "transition_msg_modify_deadline"
 msgstr "Frist geändert von ${deadline_old} zu ${deadline_new} durch ${user}"
+
+#. Default: "Task opened automatically"
+#: ./opengever/task/response_description.py
+msgid "transition_msg_opened"
+msgstr "Aufgabe automatisch gestartet"
 
 #. Default: "Reactivate by ${user}"
 #: ./opengever/task/response_description.py

--- a/opengever/task/locales/fr/LC_MESSAGES/opengever.task.po
+++ b/opengever/task/locales/fr/LC_MESSAGES/opengever.task.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2020-06-09 10:06+0000\n"
+"POT-Creation-Date: 2020-06-29 14:27+0000\n"
 "PO-Revision-Date: 2017-12-03 11:47+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-task/fr/>\n"
@@ -989,6 +989,11 @@ msgstr "Tâche ouverte"
 msgid "transition_label_modify_deadline"
 msgstr "Délai de la tâche modifié"
 
+#. Default: "Task opened automatically"
+#: ./opengever/task/response_description.py
+msgid "transition_label_opened"
+msgstr ""
+
 #. Default: "Task reactivated"
 #: ./opengever/task/response_description.py
 msgid "transition_label_reactivate"
@@ -1078,6 +1083,11 @@ msgstr "Attribué à nouveau de ${responsible_old} à ${responsible_new} par ${u
 #: ./opengever/task/response_description.py
 msgid "transition_msg_modify_deadline"
 msgstr "Délai modifié de ${deadline_old} à ${deadline_new} par ${user}"
+
+#. Default: "Task opened automatically"
+#: ./opengever/task/response_description.py
+msgid "transition_msg_opened"
+msgstr ""
 
 #. Default: "Reactivate by ${user}"
 #: ./opengever/task/response_description.py

--- a/opengever/task/locales/opengever.task.pot
+++ b/opengever/task/locales/opengever.task.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2020-06-09 10:06+0000\n"
+"POT-Creation-Date: 2020-06-29 14:27+0000\n"
 "PO-Revision-Date: 2009-02-25 14:39+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -985,6 +985,11 @@ msgstr ""
 msgid "transition_label_modify_deadline"
 msgstr ""
 
+#. Default: "Task opened automatically"
+#: ./opengever/task/response_description.py
+msgid "transition_label_opened"
+msgstr ""
+
 #. Default: "Task reactivated"
 #: ./opengever/task/response_description.py
 msgid "transition_label_reactivate"
@@ -1073,6 +1078,11 @@ msgstr ""
 #. Default: "Deadline modified from ${deadline_old} to ${deadline_new} by ${user}"
 #: ./opengever/task/response_description.py
 msgid "transition_msg_modify_deadline"
+msgstr ""
+
+#. Default: "Task opened automatically"
+#: ./opengever/task/response_description.py
+msgid "transition_msg_opened"
 msgstr ""
 
 #. Default: "Reactivate by ${user}"

--- a/opengever/task/response_description.py
+++ b/opengever/task/response_description.py
@@ -244,6 +244,21 @@ class Accept(ResponseDescription):
 ResponseDescription.add_description(Accept)
 
 
+class Open(ResponseDescription):
+    transition = 'task-transition-planned-open'
+    css_class = 'open'
+
+    def msg(self):
+        return _('transition_msg_opened', u'Task opened automatically',
+                 mapping=self._msg_mapping)
+
+    def label(self):
+        return _('transition_label_opened', u'Task opened automatically')
+
+
+ResponseDescription.add_description(Open)
+
+
 class Reopen(ResponseDescription):
     transition = 'task-transition-rejected-open'
     css_class = 'reopen'

--- a/plonetheme/teamraum/resources/css/gever/gever.css
+++ b/plonetheme/teamraum/resources/css/gever/gever.css
@@ -3069,6 +3069,8 @@ div.answer.reactivated div.answerType:before { content: ""; }
 
 div.answer.skip div.answerType:before { font-family: 'Font Awesome 5 Free'; content: "\f051"; font-weight: 900; }
 
+div.answer.open div.answerType:before { font-family: 'Font Awesome 5 Free'; content: "\f04b"; font-weight: 900; }
+
 /* @group language selector in personaltools */
 #portal-personaltools.actionMenu dd ul li.category-language.currentLanguage a:before { font-family: "opengever"; content: ""; }
 


### PR DESCRIPTION
Subtasks generated from a task template change their state from "planned" to "open", when the previous subtask is completed.

The resulting item in the response history of the subtask was missing a proper icon and a message.

Belongs to the Jira issue https://4teamwork.atlassian.net/browse/GEVER-607

## Before
<img width="1050" alt="image" src="https://user-images.githubusercontent.com/28220/86016921-af8b8700-ba23-11ea-8644-0b315e5cef54.png">


## After
![image](https://user-images.githubusercontent.com/28220/86018558-d1860900-ba25-11ea-8f57-84aab6b73a00.png)


## Checklist (Must have)

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


## Checklist (if applicable)

- New translations
  - [x] All msg-strings are unicode