### PR TITLE
Fix contenttree.js: IE cannot parse ES6 syntax.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2020.4.0 (unreleased)
 ---------------------
 
+- Fix contenttree.js so that it is also supported by IE. [njohner]
 - Also allow replacing concrete responsibles with interactive responsibles when triggering task templates. [deiferni]
 - Remove cross-tab logout functionality. [lgraf]
 - Add @@logout view to clear Plone session and redirect to CAS logout if necessary. [lgraf]

--- a/opengever/base/browser/resources/contenttree.js
+++ b/opengever/base/browser/resources/contenttree.js
@@ -71,9 +71,9 @@ if(jQuery) (function($){
                 o.multiSelect = false;
             }
 
-            function loadTree(c, t, r, b_start=0) {
+            function loadTree(c, t, r, b_start) {
                 $(c).addClass('wait');
-                $.post(o.script, {href: t, rel: r, b_start: b_start}, function(data) {
+                $.post(o.script, {href: t, rel: r, b_start: b_start || 0}, function(data) {
                     $(c).removeClass('wait').append(data);
                     $(c).find('ul:hidden').slideDown({
                         duration: o.expandSpeed
@@ -113,7 +113,7 @@ if(jQuery) (function($){
                         pli,
                         escape(a.attr('href')),
                         escape(a.attr('rel')),
-                        $(this).data('bstart'),
+                        $(this).data('bstart')
                     );
                     li.remove();
                 } else {


### PR DESCRIPTION
In https://github.com/4teamwork/opengever.core/pull/6461/ we introduced a modified version of the javascript for the contenttree widget, to optimise its use with large amounts of items. This change introduced some ES6 syntax which is not supported by IE. This breaks gever on IE.

For https://4teamwork.atlassian.net/browse/GEVER-621


## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
