### PR TITLE
Separate conditions for links from document to proposal/submitted proposal/meeting.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -11,6 +11,7 @@ Changelog
 - Add @@logout view to clear Plone session and redirect to CAS logout if necessary. [lgraf]
 - Introduce a new property `touched` on dossiers. [mbaechtold]
 - Add support for metadata_fields in OpengeverRealContentListingObject. [njohner]
+- Fix linking to proposal/submitted proposal from documents in various places. [deiferni]
 - Fix sort order within task template folder. [mbaechtold]
 - Fix deadline of task templates no longer shown in tabular listing. [mbaechtold]
 - Fix permission issue with resolving subtask of tasktemplates. [njohner]

--- a/opengever/document/base.py
+++ b/opengever/document/base.py
@@ -262,6 +262,7 @@ class BaseDocumentMixin(object):
 
         return dossier.title
 
+
 def mimetype_lookup(mtr, contenttype):
     """Reimplemented as case insensitive from Products.MimetypesRegistry."""
     __traceback_info__ = (repr(contenttype), str(contenttype))

--- a/opengever/document/browser/overview.py
+++ b/opengever/document/browser/overview.py
@@ -225,28 +225,36 @@ class Overview(DefaultView, GeverTabMixin, VisibleActionButtonRendererMixin):
             yield data
 
     def get_meeting_links(self):
+        proposal_model = None
 
         proposal = self.context.get_proposal()
-        if proposal is None:
-            return
+        if proposal:
+            proposal_model = proposal.load_model()
+            proposal_link = proposal_model.get_link()
+            if proposal_link:
+                yield {
+                    'label': _('label_proposal', default='Proposal'),
+                    'content': proposal_link,
+                }
 
-        proposal_model = proposal.load_model()
+        submitted_proposal = self.context.get_submitted_proposal()
+        if submitted_proposal:
+            proposal_model = submitted_proposal.load_model()
+            submitted_proposal_link = proposal_model.get_submitted_link()
+            if submitted_proposal_link:
+                yield {
+                    'label': _('label_submitted_proposal',
+                               default='Submitted Proposal'),
+                    'content': submitted_proposal_link,
+                }
 
-        proposal_link = proposal_model.get_link()
-        if proposal_link:
-            yield {
-                'label': _('label_proposal', default='Proposal'),
-                'content': proposal_link,
-            }
-        else:
-            return
-
-        meeting_link = proposal_model.get_meeting_link()
-        if meeting_link:
-            yield {
-                'label': _('label_meeting', default='Meeting'),
-                'content': meeting_link,
-            }
+        if proposal_model:
+            meeting_link = proposal_model.get_meeting_link()
+            if meeting_link:
+                yield {
+                    'label': _('label_meeting', default='Meeting'),
+                    'content': meeting_link,
+                }
 
     def submitted_documents(self):
         return SubmittedDocument.query.by_source(self.context).all()

--- a/opengever/document/browser/templates/overview.pt
+++ b/opengever/document/browser/templates/overview.pt
@@ -11,7 +11,7 @@
                     <th tal:content="row/label">Label</th>
                     <td tal:content="structure row/content">Content</td>
                 </tr>
-                <tr tal:repeat="row view/get_meeting_links">
+                <tr tal:repeat="row view/get_meeting_links" class="meetinglink">
                     <th tal:content="row/label">Label</th>
                     <td tal:content="structure row/content">Content</td>
                 </tr>

--- a/opengever/document/locales/de/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/de/LC_MESSAGES/opengever.document.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2020-03-22 12:27+0000\n"
+"POT-Creation-Date: 2020-06-29 10:52+0000\n"
 "PO-Revision-Date: 2017-10-13 14:27+0200\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -620,6 +620,11 @@ msgstr "Laufnummer"
 #: ./opengever/document/viewlets/byline.py
 msgid "label_start_byline"
 msgstr "Dokumentdatum"
+
+#. Default: "Submitted Proposal"
+#: ./opengever/document/browser/overview.py
+msgid "label_submitted_proposal"
+msgstr "Eingereichter Antrag"
 
 #. Default: "Thumbnail"
 #: ./opengever/document/behaviors/metadata.py

--- a/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2020-03-22 12:27+0000\n"
+"POT-Creation-Date: 2020-06-29 10:52+0000\n"
 "PO-Revision-Date: 2017-09-03 08:50+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-document/fr/>\n"
@@ -617,6 +617,11 @@ msgstr "Numéro courant"
 #: ./opengever/document/viewlets/byline.py
 msgid "label_start_byline"
 msgstr "Date du document"
+
+#. Default: "Submitted Proposal"
+#: ./opengever/document/browser/overview.py
+msgid "label_submitted_proposal"
+msgstr "Requête soumise"
 
 #. Default: "Thumbnail"
 #: ./opengever/document/behaviors/metadata.py

--- a/opengever/document/locales/opengever.document.pot
+++ b/opengever/document/locales/opengever.document.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2020-03-22 12:27+0000\n"
+"POT-Creation-Date: 2020-06-29 10:52+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -614,6 +614,11 @@ msgstr ""
 #. Default: "from"
 #: ./opengever/document/viewlets/byline.py
 msgid "label_start_byline"
+msgstr ""
+
+#. Default: "Submitted Proposal"
+#: ./opengever/document/browser/overview.py
+msgid "label_submitted_proposal"
 msgstr ""
 
 #. Default: "Thumbnail"

--- a/opengever/document/tests/test_document_word.py
+++ b/opengever/document/tests/test_document_word.py
@@ -18,7 +18,7 @@ class TestDocumentProposal(IntegrationTestCase):
         proposal = self.submitted_proposal
         self.assertEquals(proposal, proposal.get_proposal_document().get_proposal())
 
-    def test_get_proposal_of_excerpt_document_in_committee(self):
+    def test_get_submitted_proposal_of_excerpt_document_in_committee(self):
         self.login(self.committee_responsible)
         agenda_item = self.schedule_proposal(self.meeting, self.submitted_proposal)
         agenda_item.decide()
@@ -26,7 +26,8 @@ class TestDocumentProposal(IntegrationTestCase):
             agenda_item.generate_excerpt(title='Excerpt \xc3\x84nderungen')
 
         excerpt_document, = children['added']
-        self.assertEquals(self.submitted_proposal, excerpt_document.get_proposal())
+        self.assertEquals(self.submitted_proposal,
+                          excerpt_document.get_submitted_proposal())
 
     def test_get_proposal_of_excerpt_document_in_case_dossier(self):
         self.login(self.committee_responsible)

--- a/opengever/meeting/tests/test_excerpt.py
+++ b/opengever/meeting/tests/test_excerpt.py
@@ -8,11 +8,19 @@ from opengever.testing import IntegrationTestCase
 from opengever.trash.remover import Remover
 from opengever.trash.trash import ITrashable
 from opengever.trash.trash import TrashError
-from operator import attrgetter
+from z3c.relationfield.event import _relations
 from zope.component import getMultiAdapter
 from zope.event import notify
 from zope.lifecycleevent import ObjectModifiedEvent
-from z3c.relationfield.event import _relations
+
+
+def meeting_fields(browser):
+    result = {}
+    for row in browser.css('tr.meetinglink'):
+        label = row.css('th')[0].text
+        node = row.css('td')[0]
+        result[label] = node
+    return result
 
 
 class TestTrashReturnedExcerpt(IntegrationTestCase):
@@ -154,7 +162,7 @@ class TestExcerptOverview(IntegrationTestCase):
     maxDiff = None
 
     @browsing
-    def test_excerpt_overview_displays_link_to_proposal(self, browser):
+    def test_excerpt_overview_displays_link_to_proposal_and_submitted_proposal(self, browser):
         self.login(self.committee_responsible, browser)
         agenda_item = self.schedule_proposal(self.meeting, self.submitted_proposal)
         agenda_item.decide()
@@ -162,88 +170,63 @@ class TestExcerptOverview(IntegrationTestCase):
         agenda_item.return_excerpt(excerpt1)
 
         expected_fields = [
-            'Title',
-            'Document Date',
-            'Document Type',
-            'Author',
-            'creator',
-            'Description',
-            'Foreign Reference',
-            'Keywords',
-            'Checked out',
-            'File',
-            'Digital Available',
-            'Preserved as paper',
-            'Date of receipt',
-            'Date of delivery',
-            'Related Documents',
-            'Classification',
-            'Privacy layer',
-            'Public Trial',
-            'Public trial statement',
-            'Submitted with',
-            'Created',
-            'Modified',
+            'Submitted Proposal',
             'Proposal',
             'Meeting'
         ]
         browser.open(excerpt1, view='tabbedview_view-overview')
-        fields = dict(zip(
-            browser.css('.documentMetadata th').text,
-            map(attrgetter('innerHTML'), browser.css('.documentMetadata td')),
-        ))
-        self.assertItemsEqual(expected_fields, fields.keys())
+        fields = meeting_fields(browser)
+        self.assertItemsEqual(expected_fields, fields.keys(),
+            msg='The committee responsible can view the meeting and the case '
+                'dossier thus all links should appear')
 
-        self.assertEquals(
-            u'<a href="http://nohost/plone/opengever-meeting-committeecontainer'
-            u'/committee-1/meeting-1/view" title="9. Sitzung der '
-            u'Rechnungspr\xfcfungskommission" class="'
-            u'contenttype-opengever-meeting-meeting">9. Sitzung der '
-            u'Rechnungspr\xfcfungskommission</a>',
-            fields['Meeting'],
-            )
-        self.assertEquals(
-            u'<a href="http://nohost/plone/ordnungssystem/fuhrung/'
-            u'vertrage-und-vereinbarungen/dossier-1/proposal-1" title="Vertr\xe4ge"'
-            u' class="contenttype-opengever-meeting-proposal">Vertr\xe4ge</a>',
-            fields['Proposal'])
+        self.assertEqual(u'Vertr\xe4ge', fields['Submitted Proposal'].text)
+        self.assertEqual(
+            self.submitted_proposal.absolute_url(),
+            fields['Submitted Proposal'].css('a').first.get('href'))
+
+        self.assertEqual(
+            u'9. Sitzung der Rechnungspr\xfcfungskommission',
+            fields['Meeting'].text)
+        self.assertEqual(
+            self.meeting.model.get_url(),
+            fields['Meeting'].css('a').first.get('href'))
+
+        self.assertEqual(u'Vertr\xe4ge', fields['Proposal'].text)
+        self.assertEqual(
+            self.proposal.absolute_url(),
+            fields['Proposal'].css('a').first.get('href'))
 
     @browsing
-    def test_excerpt_overview_hides_link_to_proposal_when_insufficient_privileges(self, browser):
+    def test_no_link_to_proposal_visible_if_no_access_to_dossier(self, browser):
         self.login(self.committee_responsible, browser)
         agenda_item = self.schedule_proposal(self.meeting, self.submitted_proposal)
         agenda_item.decide()
         excerpt1 = agenda_item.generate_excerpt('excerpt 1')
         agenda_item.return_excerpt(excerpt1)
 
+        # block access to `proposal` for `regular_user`
+        self.dossier.__ac_local_roles_block__ = True
+
         expected_fields = [
-            'Title',
-            'Document Date',
-            'Document Type',
-            'Author',
-            'creator',
-            'Description',
-            'Foreign Reference',
-            'Keywords',
-            'Checked out',
-            'File',
-            'Digital Available',
-            'Preserved as paper',
-            'Date of receipt',
-            'Date of delivery',
-            'Related Documents',
-            'Classification',
-            'Privacy layer',
-            'Public Trial',
-            'Public trial statement',
-            'Submitted with',
-            'Created',
-            'Modified'
+            'Submitted Proposal',
+            'Meeting'
         ]
         self.login(self.regular_user, browser)
         browser.open(excerpt1, view='tabbedview_view-overview')
-        fields = dict(zip(
-            browser.css('.documentMetadata th').text,
-            map(attrgetter('innerHTML'), browser.css('.documentMetadata td')),
-        ))
-        self.assertItemsEqual(expected_fields, fields.keys())
+        fields = meeting_fields(browser)
+        self.assertItemsEqual(expected_fields, fields.keys(),
+            msg='The user we test with should see a link to submitted '
+                'proposal and meeting, but not to the proposal')
+
+        self.assertEqual(u'Vertr\xe4ge', fields['Submitted Proposal'].text)
+        self.assertEqual(
+            self.submitted_proposal.absolute_url(),
+            fields['Submitted Proposal'].css('a').first.get('href'))
+
+        self.assertEqual(
+            u'9. Sitzung der Rechnungspr\xfcfungskommission',
+            fields['Meeting'].text)
+        self.assertEqual([], fields['Meeting'].css('a'),
+            'The meeting is not visible to dossier_responsible and thus not '
+            'linked')

--- a/opengever/trash/trash.py
+++ b/opengever/trash/trash.py
@@ -151,5 +151,9 @@ class Trasher(object):
         return False
 
     def is_returned_excerpt(self):
-        return (self.context.get_proposal() is not None
-                and self.context.get_proposal().get_excerpt() == self.context)
+        submitted_proposal = self.context.get_submitted_proposal(
+            check_security=False)
+        if not submitted_proposal:
+            return False
+
+        return submitted_proposal.get_excerpt() == self.context


### PR DESCRIPTION
Add separate conditions to display the link from a document to its proposal, submitted proposal and meeting (if any). The visibility of these items can be different depending on how gever is setup. We now check separately if the user can view the proposal or the submitted proposal. In both cases we display link to the proposal/submitted porposal and the meeting.

I have added displaying a link to the submitted proposal, so this is not strictly a bugfix. I think it may be the best approach and help the user to navigate to all the different content that is generated automatically. The following cases are displayed differently _(sorry about screenshot alignment)_:

- User can only see meeting, not case dossier
![Screenshot 2020-06-30 at 12 21 08](https://user-images.githubusercontent.com/736583/86115684-97237700-bacc-11ea-8aa3-ac2c293e1d26.png)
- User can see case dossier and meeting
![Screenshot 2020-06-30 at 12 20 10](https://user-images.githubusercontent.com/736583/86115689-97bc0d80-bacc-11ea-9e0e-405db323cc0c.png)
- User can only see case dossier (meeting is not linked, only name appears)
![Screenshot 2020-06-30 at 12 19 42](https://user-images.githubusercontent.com/736583/86115691-9854a400-bacc-11ea-943b-629ddc6adcfc.png)
- if the user can se neither, we don't display any links (as before)

For https://4teamwork.atlassian.net/browse/GEVER-590

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
