### PR TITLE
Enhance "@config" with "private_folder_url".

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,7 @@ Changelog
 - Make creating favorites more robust in case of workflow issues. [deiferni]
 - Improve response history for (automatically) opened subtasks in sequential task templates. [mbaechtold]
 - Fix contenttree.js so that it is also supported by IE. [njohner]
+- Expose the url to the user's private folder in the `@config` API endpoint. Serves as feature flag too. [mbaechtold]
 - Also allow replacing concrete responsibles with interactive responsibles when triggering task templates. [deiferni]
 - Remove cross-tab logout functionality. [lgraf]
 - Add @@logout view to clear Plone session and redirect to CAS logout if necessary. [lgraf]

--- a/docs/public/dev-manual/api/config.rst
+++ b/docs/public/dev-manual/api/config.rst
@@ -56,6 +56,7 @@ GEVER-Mandanten abgefragt werden.
           "is_emm_environment": false,
           "max_dossier_levels": 5,
           "max_repositoryfolder_levels": 3,
+          "private_folder_url": "http://localhost:8080/fd/private/kathi.barfuss",
           "recently_touched_limit": 10,
           "root_url": "http://localhost:8080/fd",
           "sharing_configuration": {

--- a/opengever/api/config.py
+++ b/opengever/api/config.py
@@ -2,6 +2,7 @@ from ftw.bumblebee.config import bumblebee_config
 from opengever.base import utils
 from opengever.base.interfaces import IGeverSettings
 from opengever.officeconnector.helpers import is_client_ip_in_office_connector_disallowed_ip_ranges
+from opengever.private import get_private_folder_url
 from plone.restapi.services import Service
 
 
@@ -18,10 +19,18 @@ class Config(Service):
 
     def add_additional_infos(self, config):
         """
-        Injects additional configuration information.
+        Injects additional configuration information:
+
         - is_admin_menu_visible: Indication for the GEVER UI if it should display
           the menu item "Verwaltung" in the navigation drawer.
+
+        - bumblebee_app_id: The Bumblebee app id as configured in Plone (a string).
+
+        - private_folder_url: The url to the private folder of the current
+          user (a string). If the value is `None`, the user does not have
+          a private folder or the feature is disabled in Plone.
         """
         config['is_emm_environment'] = is_client_ip_in_office_connector_disallowed_ip_ranges()
         config['is_admin_menu_visible'] = utils.is_administrator()
         config['bumblebee_app_id'] = bumblebee_config.app_id
+        config['private_folder_url'] = get_private_folder_url()

--- a/opengever/private/__init__.py
+++ b/opengever/private/__init__.py
@@ -1,6 +1,7 @@
 from plone import api
 from zope.i18nmessageid import MessageFactory
 
+
 _ = MessageFactory('opengever.private')
 
 MEMBERSFOLDER_ID = 'private'
@@ -10,3 +11,16 @@ def enable_opengever_private():
     mtool = api.portal.get_tool('portal_membership')
     if not mtool.getMemberareaCreationFlag():
         mtool.setMemberareaCreationFlag()
+
+
+def get_private_folder():
+    membership_tool = api.portal.get_tool('portal_membership')
+    home_folder = membership_tool.getHomeFolder()
+    return home_folder
+
+
+def get_private_folder_url():
+    home_folder = get_private_folder()
+    if not home_folder:
+        return None
+    return home_folder.absolute_url()


### PR DESCRIPTION
Expose the path to the user's private folder in the `@config` API endpoint. This serves as a feature flag for the GEVER UI too.

The reason for this addition is the fact, that the GEVER UI does not get the path to the private folder right in every case. Especially when the user id is an e-mail address, the id of the private folder is normalized (see the tests for an example).

Belongs to the Jira issue https://4teamwork.atlassian.net/browse/GEVER-611

## Checklist (Must have)
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

## Checklist (if applicable)

- API change:
  - [x] Documentation is updated