### PR TITLE
Robustify adding favorites with invalid workflows.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2020.4.0 (unreleased)
 ---------------------
 
+- Make creating favorites more robust in case of workflow issues. [deiferni]
 - Improve response history for (automatically) opened subtasks in sequential task templates. [mbaechtold]
 - Fix contenttree.js so that it is also supported by IE. [njohner]
 - Also allow replacing concrete responsibles with interactive responsibles when triggering task templates. [deiferni]

--- a/opengever/core/upgrades/20200501143003_populate_additional_metadata_of_favorites/upgrade.py
+++ b/opengever/core/upgrades/20200501143003_populate_additional_metadata_of_favorites/upgrade.py
@@ -46,6 +46,9 @@ class PopulateAdditionalMetadataOfFavorites(SQLUpgradeStep):
             obj = self.catalog_unrestricted_get_object(brain)
 
             review_state = brain.review_state
+            # avoid storing empty string or Missing.Value
+            if not review_state:
+                review_state = None
 
             is_subdossier = None
             if hasattr(aq_base(obj), 'is_subdossier'):


### PR DESCRIPTION
When for some reason workflow state cannot be retrieved we still want to be able to create the favorite. Thus make the code a bit more robust for this non-critical information.

Also fix an upgrade that would attempt to write `Missing.Value` from the catalog into an sql column which won't work due to missing serializers.

- ✅   i have manually verified that favorites can now be added
- ✅   i have run an upgrade from https://github.com/4teamwork/opengever.core/commit/91a89d17b (the commit before https://github.com/4teamwork/opengever.core/commit/04fcdf52cae62e3ccacfa6c0ff3b3d5a4d9c9ebf was merged to https://github.com/4teamwork/opengever.core/tree/deif/617-fix-favorites-workflow-state to make sure the upgrade would now pass and doesn't break other things

Sample sentry message from my local machine: https://sentry.4teamwork.ch/sentry/onegov-gever/issues/68240/

For https://4teamwork.atlassian.net/browse/GEVER-617

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)