### PR TITLE
Add question for `administrator_group` to the policy template.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,7 @@ Changelog
 2020.5.0 (unreleased)
 ---------------------
 
-- Nothing changed yet.
+- Add question for `administrator_group` to the policy template. [mbaechtold]
 
 
 2020.4.0 (2020-07-02)

--- a/opengever/policytemplates/policy_template/.mrbob.ini
+++ b/opengever/policytemplates/policy_template/.mrbob.ini
@@ -73,6 +73,9 @@ orgunit.users_group.required = True
 orgunit.inbox_group.question = Inbox group
 orgunit.inbox_group.required = True
 
+deployment.administrator_group.question = Administrator group
+deployment.administrator_group.required = True
+
 deployment.rolemanager_group.question = Rolemanager group
 deployment.rolemanager_group.required = True
 

--- a/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/configure.zcml.bob
+++ b/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/configure.zcml.bob
@@ -71,6 +71,7 @@
                            opengever.setup:casauth
                           "
       admin_unit_id="{{{adminunit.id}}}"
+      administrator_group="{{{deployment.administrator_group}}}"
       rolemanager_group="{{{deployment.rolemanager_group}}}"
       records_manager_group="{{{deployment.records_manager_group}}}"
       archivist_group="{{{deployment.archivist_group}}}"
@@ -87,6 +88,7 @@
                            opengever.setup:casauth
                           "
       admin_unit_id="{{{adminunit.id}}}"
+      administrator_group="{{{deployment.administrator_group}}}"
       rolemanager_group="{{{deployment.rolemanager_group}}}"
       records_manager_group="{{{deployment.records_manager_group}}}"
       workspace_creator_group="{{{deployment.workspace_creators_group}}}"


### PR DESCRIPTION
The administrator group was missing from the [configuration of opengever.quarten](https://github.com/4teamwork/opengever.quarten/blob/3034b0e00aeada143497cfed2664b1e7411e7f5a/opengever/quarten/configure.zcml#L57-L71) so our product owner though it would be a good idea to add it to our policy template.

Belongs to the Jira issue https://4teamwork.atlassian.net/browse/GEVER-538

## Checklist (Must have)

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
