### PR TITLE
Add API endpoint to logout current user.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2020.5.0 (unreleased)
 ---------------------
 
+- Overwrite logout API endpoint to also expire the user's cookies. [njohner]
 - Fix contact workflow state variable name. [deiferni]
 - Fix contact folder workflow state variable name. [deiferni]
 - Expose the current logged in users'email address in the @config endpoint. [elioschmutz]

--- a/docs/public/dev-manual/api/authentication/index.rst
+++ b/docs/public/dev-manual/api/authentication/index.rst
@@ -22,7 +22,8 @@ von OneGov GEVER unterstützt werden.
    :maxdepth: 1
 
    basic_auth
-   jwt
    oauth2_token_auth
+   jwt
+   logout
 
 .. disqus::

--- a/docs/public/dev-manual/api/authentication/jwt.rst
+++ b/docs/public/dev-manual/api/authentication/jwt.rst
@@ -64,6 +64,8 @@ Der Server antwortet mit einem JSON-Objekt welches das neue Token enthält:
    :language: http
 
 
+.. _label-invalidate-jwt:
+
 Invalidieren
 ^^^^^^^^^^^^
 

--- a/docs/public/dev-manual/api/authentication/logout.rst
+++ b/docs/public/dev-manual/api/authentication/logout.rst
@@ -1,0 +1,8 @@
+Ausloggen
+^^^^^^^^^
+
+Der ``@logout`` Endpoint kann verwendet werden, um ein Token zu invalidieren, wie in :ref:`label-invalidate-jwt` beschrieben.
+
+Dieser Endpoint invalidiert zusätzlich auch alle andere Session-Cookies des Users.
+
+.. disqus::

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -810,4 +810,13 @@
       name="main-dossier"
       />
 
+  <plone:service
+      method="POST"
+      name="@logout"
+      for="Products.CMFPlone.interfaces.IPloneSiteRoot"
+      factory=".logout.GeverLogout"
+      permission="zope.Public"
+      layer="opengever.base.interfaces.IOpengeverBaseLayer"
+      />
+
 </configure>

--- a/opengever/api/logout.py
+++ b/opengever/api/logout.py
@@ -1,0 +1,34 @@
+from Products.CMFCore.utils import getToolByName
+from plone.restapi.services.auth.logout import Logout
+
+
+class GeverLogout(Logout):
+    """Log out current user by trying to invalidate the JWT and expiring
+    his cookies (__ac and deployment specific cookie, e.g. __ac_fd).
+    This is necessary because logout in the frontend should also log the user
+    out of the backend.
+    """
+
+    def reply(self):
+        # Handles logout by invalidating the JWT
+        # This sets the response status accordingly if it fails
+        resp = super(GeverLogout, self).reply()
+
+        # Now we try to expire the user's cookies
+
+        # We do not use logout of PAS here, as it redirects to logout view.
+        pas = getToolByName(self.context, 'acl_users')
+        pas.resetCredentials(self.request, self.request['RESPONSE'])
+
+        # Also expire any __ac cookie that might have been issued by the
+        # CookieAuthHelper on the Zope root (e.g. for zopemaster)
+        self.request.response.expireCookie('__ac', path='/')
+
+        # if either the JWT token was invalidated or any cookie was deleted
+        # logout is considered successful, otherwise we return the error
+        # from the JWT logout.
+        for cookie_name, cookie in self.request.response.cookies.items():
+            if cookie.get('value') == 'deleted' and cookie_name in self.request.cookies:
+                self.request.response.setStatus(204)
+                return
+        return resp

--- a/opengever/api/tests/test_logout.py
+++ b/opengever/api/tests/test_logout.py
@@ -1,0 +1,207 @@
+from ftw.testbrowser import browsing
+from opengever.setup.casauth import install_cas_auth_plugin
+from opengever.testing import IntegrationTestCase
+from plone import api
+
+
+class TestLogoutUserEndpointWithoutCAS(IntegrationTestCase):
+
+    @browsing
+    def test_logout_deletes_ac_cookie(self, browser):
+        driver = browser.get_driver()
+
+        with self.login(self.regular_user, browser=browser):
+            dossier_url = self.dossier.absolute_url()
+            portal_url = self.portal.absolute_url()
+
+        # Check that we cannot access the dossier
+        with browser.expect_unauthorized():
+            browser.open(dossier_url, headers=self.api_headers)
+
+        # set __ac cookie
+        with self.login(self.regular_user, browser=browser):
+            self.portal.acl_users.credentials_cookie_auth.login()
+            driver.requests_session.cookies.set(
+                '__ac', self.request.response.cookies['__ac'].get('value'))
+
+        # Check that we can access the dossier
+        browser.open(dossier_url, headers=self.api_headers)
+        self.assertEqual(200, self.request.response.getStatus())
+
+        # logout
+        browser.open(portal_url + '/@logout',
+                     method='POST', headers=self.api_headers)
+        self.assertEqual(200, self.request.response.getStatus())
+
+        # check that cookie gets invalidated
+        self.assertEqual(
+            {'__ac': {
+                'expires': 'Wed, 31-Dec-97 23:59:59 GMT',
+                'max_age': 0,
+                'path': '/',
+                'quoted': True,
+                'value': 'deleted'}},
+            driver.response.cookies)
+
+        # Check that we cannot access the dossier anymore once the cookie is deleted
+        driver.requests_session.cookies.set(
+            '__ac', driver.response.cookies['__ac'].get('value'))
+        with browser.expect_unauthorized():
+            browser.open(dossier_url, headers=self.api_headers)
+
+
+class TestLogoutUserEndpointWithCASAuth(IntegrationTestCase):
+
+    def setUp(self):
+        super(TestLogoutUserEndpointWithCASAuth, self).setUp()
+        install_cas_auth_plugin('portal')
+
+    def tearDown(self):
+        super(TestLogoutUserEndpointWithCASAuth, self).tearDown()
+        acl_users = api.portal.get_tool('acl_users')
+        acl_users.plugins.removePluginById('cas_auth')
+
+    @browsing
+    def test_logout_deletes_ac_cookie(self, browser):
+        driver = browser.get_driver()
+
+        with self.login(self.regular_user, browser=browser):
+            dossier_url = self.dossier.absolute_url()
+            portal_url = self.portal.absolute_url()
+
+        # Check that we cannot access the dossier
+        with browser.expect_unauthorized():
+            browser.open(dossier_url, headers=self.api_headers)
+
+        # set __ac cookie
+        with self.login(self.regular_user, browser=browser):
+            self.portal.acl_users.credentials_cookie_auth.login()
+            driver.requests_session.cookies.set(
+                '__ac', self.request.response.cookies['__ac'].get('value'))
+
+        # Check that we can access the dossier
+        browser.open(dossier_url, headers=self.api_headers)
+        self.assertEqual(200, self.request.response.getStatus())
+
+        # logout
+        browser.open(portal_url + '/@logout',
+                     method='POST', headers=self.api_headers)
+        self.assertEqual(200, self.request.response.getStatus())
+
+        # check that cookie gets invalidated
+        self.assertEqual(
+            {'__ac': {
+                'expires': 'Wed, 31-Dec-97 23:59:59 GMT',
+                'max_age': 0,
+                'path': '/',
+                'quoted': True,
+                'value': 'deleted'}},
+            driver.response.cookies)
+
+        # Check that we cannot access the dossier anymore once the cookie is deleted
+        driver.requests_session.cookies.set(
+            '__ac', driver.response.cookies['__ac'].get('value'))
+        with browser.expect_unauthorized():
+            browser.open(dossier_url, headers=self.api_headers)
+
+    @browsing
+    def test_logout_deletes_all_ac_cookies_when_using_custom_cookie_name(self, browser):
+        driver = browser.get_driver()
+
+        with self.login(self.regular_user, browser=browser):
+            dossier_url = self.dossier.absolute_url()
+            portal_url = self.portal.absolute_url()
+
+        # Check that we cannot access the dossier
+        with browser.expect_unauthorized():
+            browser.open(dossier_url, headers=self.api_headers)
+
+        # Customize cookie name, like we do in production
+        self.portal.acl_users.session.cookie_name = '__ac_fd'
+
+        # set custom __ac_fd cookie
+        with self.login(self.regular_user, browser=browser):
+            self.portal.acl_users.credentials_cookie_auth.login()
+            driver.requests_session.cookies.set(
+                '__ac_fd', self.request.response.cookies['__ac_fd'].get('value'))
+
+        # Check that we can access the dossier
+        browser.open(dossier_url, headers=self.api_headers)
+        self.assertEqual(200, self.request.response.getStatus())
+
+        # logout
+        browser.open(portal_url + '/@logout',
+                     method='POST', headers=self.api_headers)
+        self.assertEqual(200, self.request.response.getStatus())
+
+        # check that cookies gets invalidated
+        self.assertEqual(
+            {'__ac': {
+                'expires': 'Wed, 31-Dec-97 23:59:59 GMT',
+                'max_age': 0,
+                'path': '/',
+                'quoted': True,
+                'value': 'deleted'},
+             '__ac_fd': {
+                'expires': 'Wed, 31-Dec-97 23:59:59 GMT',
+                'max_age': 0,
+                'path': '/',
+                'quoted': True,
+                'value': 'deleted'}},
+            driver.response.cookies)
+
+        # Check that we cannot access the dossier anymore once the cookie is deleted
+        driver.requests_session.cookies.set(
+            '__ac_fd', driver.response.cookies['__ac'].get('value'))
+        with browser.expect_unauthorized():
+            browser.open(dossier_url, headers=self.api_headers)
+
+
+class TestLogoutUserEndpointWithJWTToken(IntegrationTestCase):
+
+    @browsing
+    def test_logout_succeeds(self, browser):
+        with self.login(self.regular_user, browser=browser):
+            dossier_url = self.dossier.absolute_url()
+            portal_url = self.portal.absolute_url()
+
+        # Check that we cannot access the dossier
+        with browser.expect_unauthorized():
+            browser.open(dossier_url, headers=self.api_headers)
+
+        # Authorize with JWT token
+        self.portal.acl_users.jwt_auth.store_tokens = True
+        token = self.portal.acl_users.jwt_auth.create_token(self.regular_user.id)
+        browser.append_request_header('Authorization', "Bearer {}".format(token))
+
+        # Check that we can access the dossier
+        browser.open(dossier_url, headers=self.api_headers)
+        self.assertEqual(200, self.request.response.getStatus())
+
+        # logout
+        browser.open(portal_url + '/@logout',
+                     method='POST', headers=self.api_headers)
+        self.assertEqual(200, self.request.response.getStatus())
+
+        # Check that we cannot access the dossier anymore
+        with browser.expect_unauthorized():
+            browser.open(dossier_url, headers=self.api_headers)
+
+    @browsing
+    def test_logout_raises_error_when_tokens_are_not_stored_on_server(self, browser):
+        with self.login(self.regular_user, browser=browser):
+            dossier_url = self.dossier.absolute_url()
+            portal_url = self.portal.absolute_url()
+
+        # Authorize with JWT token
+        token = self.portal.acl_users.jwt_auth.create_token(self.regular_user.id)
+        browser.append_request_header('Authorization', "Bearer {}".format(token))
+
+        # logout
+        with browser.expect_http_error(501):
+            browser.open(portal_url + '/@logout',
+                         method='POST', headers=self.api_headers)
+
+        # Check that we can still access the dossier
+        browser.open(dossier_url, headers=self.api_headers)
+        self.assertEqual(200, self.request.response.getStatus())


### PR DESCRIPTION
We add an API endpoint to log out the current user by expiring his cookies (__ac and deployment specific cookie, e.g. __ac_fd). This is necessary because logout in the frontend should also log the user out of the backend.

I'm actually really not sure this is the right approach. It works, but maybe that should be the job of the portal or something?
I haven't added the documentation yet, as I'm more and more doubtful that this is a good solution.

For https://4teamwork.atlassian.net/browse/GEVER-558
PR in the frontend: https://github.com/4teamwork/gever-ui/pull/1186

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


## Checklist (if applicable)

- API change:
  - [ ] Documentation is updated
