### PR TITLE
Add UserSnap API key to registry.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -11,6 +11,7 @@ Changelog
 - Add question for `administrator_group` to the policy template. [mbaechtold]
 - Add teaser viewlet to promote the new frontend. [tinagerber]
 - Fix loading of more items in contenttree widget for toplevel items. [buchi]
+- Add UserSnap API key to registry. [njohner]
 
 
 2020.4.0 (2020-07-02)

--- a/docs/public/dev-manual/api/config.rst
+++ b/docs/public/dev-manual/api/config.rst
@@ -22,64 +22,91 @@ GEVER-Mandanten abgefragt werden.
 
       {
           "@id": "http://localhost:8080/fd/@config",
+          "apps_url": "https://dev.onegovgever.ch/portal/api/apps",
           "bumblebee_app_id": "gever_dev",
-          "cas_url": "https://cas.server.net/",
+          "cas_url": "https://dev.onegovgever.ch/portal/cas",
+          "document_preserved_as_paper_default": true,
           "features": {
               "activity": true,
               "archival_file_conversion": false,
+              "archival_file_conversion_blacklist": [],
               "changed_for_end_date": true,
               "contacts": false,
+              "disposition_transport_filesystem": false,
+              "disposition_transport_ftps": false,
               "doc_properties": true,
               "dossier_templates": true,
               "ech0147_export": true,
               "ech0147_import": true,
               "favorites": true,
+              "gever_ui_enabled": false,
               "journal_pdf": false,
-              "tasks_pdf": false,
               "meetings": true,
               "officeatwork": true,
               "officeconnector_attach": true,
               "officeconnector_checkout": true,
               "oneoffixx": false,
-              "preview": false,
+              "optional_task_permissions_revoking": false,
+              "preview": true,
               "preview_auto_refresh": false,
               "preview_open_pdf_in_new_window": false,
+              "private_tasks": true,
               "purge_trash": false,
               "repositoryfolder_documents_tab": true,
+              "repositoryfolder_proposals_tab": true,
               "repositoryfolder_tasks_tab": true,
               "resolver_name": "strict",
               "sablon_date_format": "%d.%m.%Y",
               "solr": true,
-              "workspace": false
+              "tasks_pdf": false,
+              "workspace": false,
+              "workspace_client": false
           },
           "is_admin_menu_visible": false,
           "is_emm_environment": false,
           "max_dossier_levels": 5,
           "max_repositoryfolder_levels": 3,
-          "private_folder_url": "http://localhost:8080/fd/private/kathi.barfuss",
+          "nightly_jobs": {
+              "end_time": "5:00:00",
+              "start_time": "1:00:00"
+          },
+          "oneoffixx_settings": {
+              "cache_timeout": 2592000,
+              "double_encode_bug": true,
+              "fake_sid": "",
+              "scope": "oo_V1WebApi"
+          },
+          "private_folder_url": "http://localhost:8080/fd/private/niklaus.johner",
           "recently_touched_limit": 10,
           "root_url": "http://localhost:8080/fd",
           "sharing_configuration": {
               "black_list_prefix": "^$",
               "white_list_prefix": "^.+"
           },
+          "user_fullname": "Johner Niklaus",
           "user_settings": {
               "notify_inbox_actions": true,
               "notify_own_actions": false,
-              "seen_tours": [],
+              "seen_tours": [
+                  "introduction"
+              ]
           },
-          "version": "2018.4.0.dev0",
+          "userid": "niklaus.johner",
+          "usersnap_api_key": "",
+          "version": "2020.4.0.dev0"
       }
 
 
 Konfigurationsoptionen
 ----------------------
 
-max_repositoryfolder_levels
-    Maximale Verschachtelungstiefe von Ordnungspositionen
+apps_url
 
-max_dossier_levels
-    Maximale Verschachtelungstiefe von Dossiers
+  URL für die Abfrage der verfügbaren Applikationen
+
+cas_url
+
+  CAS server URL
 
 features
     Optional aktivierbare Features:
@@ -87,20 +114,38 @@ features
     activity
         Benachrichtigungen
 
+    archival_file_conversion
+        Dateien beim Dossierabschluss zusätzlich nach PDF-A konvertieren für Archivierung
+
+    changed_for_end_date
+        "changed" als Enddatum für Dossiers verwenden
+
     contacts
         Erweitertes Kontaktmodul
+
+    disposition_transport_filesystem
+        Das SIP Packet bei der Aussonderung zusätzlich über das Dateisystem ausliefern
 
     doc_properties
         Hinzufügen von DocProperties bei aus Vorlagen erstellten Word-Dokumenten
 
     dossier_templates
-        Dossiervorlagen
+        Dossier Vorlagen
 
     ech0147_export
         eCH-0039/eCH-0147 Export von Dossiers und Dokumenten
 
     ech0147_import
         eCH-0039/eCH-0147 Import von Dossiers und Dokumenten
+
+    favorites
+        Favoriten
+
+    gever_ui_enabled
+        Neue Benutzeroberfläche aktiviert
+
+    journal_pdf
+        Journal PDF erstellen beim Abschliessen eines Dossiers
 
     meetings
         Sitzungs- und Protokollverwaltung (SPV)
@@ -114,23 +159,64 @@ features
     officeconnector_checkout
         Checkout und Checkin von Dokumenten über Office Connector
 
+    oneoffixx
+        Unterstützung für Oneoffixx Vorlagen
+
+    optional_task_permissions_revoking
+        Berechtigungsentzug Optional bei Aufgaben
+
     preview
         Dokumentvorschau
 
     preview_open_pdf_in_new_window
         PDF in der Dokumentvorschau werden in einem neuen Fenster geöffnet
 
+    private_tasks
+        Private Aufgaben
+
+    purge_trash
+        Papierkorb leeren beim Dossierabschluss
+
     repositoryfolder_documents_tab
-        Dokumente-Tab bei Ordnungspositionen
+        Dokumente-Tab bei Ordnungspositionen darstellen
+
+    repositoryfolder_proposals_tab
+        Anträge-Tab bei Ordnungspositionen darstellen
 
     repositoryfolder_tasks_tab
-        Aufgaben-Tab bei Ordnungspositionen
+        Aufgaben-Tab bei Ordnungspositionen darstellen
+
+    resolver_name
+        Resolver welcher beim Dossierabschluss verwendet wird
+
+    sablon_date_format
+        Datum Formatierung Spezifikation für Sablon Vorlagen
 
     solr
         Suche über Apache Solr
 
+    tasks_pdf
+        Aufgaben PDF erstellen beim Abschliessen eines Dossier
+
     workspace
         Arbeitsräume
+
+    workspace_client
+        Integration von GEVER mit einem Teamraum
+
+max_repositoryfolder_levels
+    Maximale Verschachtelungstiefe von Ordnungspositionen
+
+max_dossier_levels
+    Maximale Verschachtelungstiefe von Dossiers
+
+nightly_jobs
+
+    start_time
+        Startzeit für NightlyJobs
+
+    end_time
+        Endzeit für NightlyJobs
 
 sharing_configuration
 
@@ -139,6 +225,10 @@ sharing_configuration
 
     black_list_prefix
         regex Muster für Gruppen die in der Freigabe nicht angezeigt werden sollen
+
+recently_touched_limit
+
+    Anzahl Objekte im "Zuletzt bearbeitet" Menu
 
 user_settings
 
@@ -150,3 +240,9 @@ user_settings
 
     seen_tours
         Gesehene Hilfe-Touren
+
+usersnap_api_key
+
+    API Schlüssel für Usersnap Integration im neuen Frontend
+
+

--- a/opengever/api/tests/test_config.py
+++ b/opengever/api/tests/test_config.py
@@ -1,5 +1,6 @@
 from ftw.casauth.plugin import CASAuthenticationPlugin
 from ftw.testbrowser import browsing
+from opengever.base.interfaces import IUserSnapSettings
 from opengever.private import enable_opengever_private
 from opengever.testing import IntegrationTestCase
 from pkg_resources import get_distribution
@@ -222,3 +223,18 @@ class TestConfig(IntegrationTestCase):
             u'http://nohost/plone/private/kathi.barfuss',
             browser.json.get(u'private_folder_url')
         )
+
+    @browsing
+    def test_config_contains_usersnap_api_key(self, browser):
+        self.login(self.regular_user, browser)
+
+        browser.open(self.portal.absolute_url() + '/@config',
+                     headers=self.api_headers)
+        self.assertEqual(browser.status_code, 200)
+        self.assertEqual(browser.json.get(u'usersnap_api_key'), u'')
+
+        api.portal.set_registry_record('api_key', u'some key', interface=IUserSnapSettings)
+        browser.open(self.portal.absolute_url() + '/@config',
+                     headers=self.api_headers)
+        self.assertEqual(browser.status_code, 200)
+        self.assertEqual(browser.json.get(u'usersnap_api_key'), u'some key')

--- a/opengever/base/configuration.py
+++ b/opengever/base/configuration.py
@@ -9,6 +9,7 @@ from opengever.base.interfaces import IGeverSettings
 from opengever.base.interfaces import IGeverUI
 from opengever.base.interfaces import IRecentlyTouchedSettings
 from opengever.base.interfaces import ISearchSettings
+from opengever.base.interfaces import IUserSnapSettings
 from opengever.bumblebee.interfaces import IGeverBumblebeeSettings
 from opengever.contact.interfaces import IContactSettings
 from opengever.disposition.interfaces import IFilesystemTransportSettings
@@ -78,6 +79,7 @@ class GeverSettingsAdpaterV1(object):
         settings['max_repositoryfolder_levels'] = api.portal.get_registry_record('maximum_repository_depth', interface=IRepositoryFolderRecords)  # noqa
         settings['recently_touched_limit'] = api.portal.get_registry_record('limit', interface=IRecentlyTouchedSettings)  # noqa
         settings['document_preserved_as_paper_default'] = api.portal.get_registry_record('preserved_as_paper_default', interface=IDocumentSettings)  # noqa
+        settings['usersnap_api_key'] = api.portal.get_registry_record('api_key', interface=IUserSnapSettings)  # noqa
         settings['nightly_jobs'] = self.get_nightly_jobs_settings()
         settings['oneoffixx_settings'] = self.get_oneoffixx_settings()
         settings['user_settings'] = self.get_user_settings()

--- a/opengever/base/interfaces.py
+++ b/opengever/base/interfaces.py
@@ -372,6 +372,14 @@ class IGeverUI(Interface):
         default=False)
 
 
+class IUserSnapSettings(Interface):
+
+    api_key = schema.TextLine(
+        title=u"API key",
+        description=u"API key for the usersnap widget.",
+        default=u"")
+
+
 class IDocPropertyProvider(Interface):
     """A provider for DocProperties."""
 

--- a/opengever/base/tests/test_configuration_adapter.py
+++ b/opengever/base/tests/test_configuration_adapter.py
@@ -18,6 +18,7 @@ class TestConfigurationAdapter(IntegrationTestCase):
             ('max_repositoryfolder_levels', 3),
             ('recently_touched_limit', 10),
             ('document_preserved_as_paper_default', True),
+            ('usersnap_api_key', ''),
             ('nightly_jobs', OrderedDict([
                 ('start_time', u'1:00:00'),
                 ('end_time', u'5:00:00'),

--- a/opengever/core/profiles/default/registry.xml
+++ b/opengever/core/profiles/default/registry.xml
@@ -174,6 +174,9 @@
   <!-- TASK -->
   <records interface="opengever.task.interfaces.ITaskSettings" />
 
+  <!-- Usersnap -->
+  <records interface="opengever.base.interfaces.IUserSnapSettings" />
+
   <!-- WOPI (Office Online) -->
   <records interface="opengever.wopi.interfaces.IWOPISettings" />
 

--- a/opengever/core/upgrades/20200703163603_add_user_snap_key_to_registry/registry.xml
+++ b/opengever/core/upgrades/20200703163603_add_user_snap_key_to_registry/registry.xml
@@ -1,0 +1,4 @@
+<registry>
+  <!-- Usersnap -->
+  <records interface="opengever.base.interfaces.IUserSnapSettings" />
+</registry>

--- a/opengever/core/upgrades/20200703163603_add_user_snap_key_to_registry/upgrade.py
+++ b/opengever/core/upgrades/20200703163603_add_user_snap_key_to_registry/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddUserSnapKeyToRegistry(UpgradeStep):
+    """Add user snap key to registry.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()


### PR DESCRIPTION
For the integration of Usersnap in the frontend, we add a registry entry with the API key. This also gets returned in the `@config` endpoint and will serve as feature flag (usersnap is shown when the API key is defined).

I took the opportunity to update the API documentation with many of the missing features and configs returned by the `@config` endpoint.

For https://4teamwork.atlassian.net/browse/GEVER-516

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


## Checklist (if applicable)

- API change:
  - [x] Documentation is updated
  - If breaking: It's non breaking!
    - [ ] api-change label added
    - [ ] Scrum master is informed
- Upgrade steps (changes in profile):
  - [x] Make it deferrable if possible
  - [x] Execute as much as possible conditionally