### PR TITLE
Fix loading of more items in contenttree widget

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 
 - Add question for `administrator_group` to the policy template. [mbaechtold]
 - Add teaser viewlet to promote the new frontend. [tinagerber]
+- Fix loading of more items in contenttree widget for toplevel items. [buchi]
 
 
 2020.4.0 (2020-07-02)

--- a/opengever/base/browser/resources/contenttree.js
+++ b/opengever/base/browser/resources/contenttree.js
@@ -71,10 +71,14 @@ if(jQuery) (function($){
                 o.multiSelect = false;
             }
 
-            function loadTree(c, t, r, b_start) {
+            function loadTree(c, t, r, b_start, extend) {
                 $(c).addClass('wait');
                 $.post(o.script, {href: t, rel: r, b_start: b_start || 0}, function(data) {
-                    $(c).removeClass('wait').append(data);
+                    if (extend) {
+                        $(c).removeClass('wait').append($(data).contents());
+                    } else {
+                        $(c).removeClass('wait').append(data);
+                    }
                     $(c).find('ul:hidden').slideDown({
                         duration: o.expandSpeed
                     });
@@ -107,14 +111,25 @@ if(jQuery) (function($){
                         });
                     li.removeClass('collapsed').addClass('expanded');
                 } else if (li.hasClass('loadMore')) {
-                    var pli = li.parent().closest('li');
-                    var a = pli.find('a');
-                    loadTree(
-                        pli,
-                        escape(a.attr('href')),
-                        escape(a.attr('rel')),
-                        $(this).data('bstart')
-                    );
+                    var a = li.parent().closest('li').find('a');
+                    var ul = li.parent();
+                    if (a.length > 0) {
+                        loadTree(
+                            ul,
+                            escape(a.attr('href')),
+                            escape(a.attr('rel')),
+                            $(this).data('bstart'),
+                            true
+                        );
+                    } else {
+                        loadTree(
+                            ul,
+                            escape(o.rootUrl),
+                            '0',
+                            $(this).data('bstart'),
+                            true
+                        );
+                    }
                     li.remove();
                 } else {
                     li.find('ul').slideUp({


### PR DESCRIPTION
Loading more items did not work for top level items. E.g. when selecting related items in a task and if there are more than 100 items. The problem was that top level items do not have a parent and the previous implementation simply appended the additionally loaded items to the parents children.

JIRA: https://4teamwork.atlassian.net/browse/GEVER-655

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


## Checklist (if applicable)

- [x] JS tested with IE9

