### PR TITLE
Improve workspace invitation e-mail.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2020.5.0 (unreleased)
 ---------------------
 
+- Improve design and content of workspace invitation e-mail. [mbaechtold]
 - Add question for `administrator_group` to the policy template. [mbaechtold]
 - Add teaser viewlet to promote the new frontend. [tinagerber]
 

--- a/opengever/activity/browser/configure.zcml
+++ b/opengever/activity/browser/configure.zcml
@@ -43,7 +43,6 @@
       for="*"
       permission="zope2.View"
       template="templates/notification_mail_macros.pt"
-      class=".notification_mail_macros.View"
       />
 
   <adapter factory=".listing.NotificationTableSource" />

--- a/opengever/activity/browser/notification_mail_macros.py
+++ b/opengever/activity/browser/notification_mail_macros.py
@@ -1,7 +1,0 @@
-from Products.Five.browser import BrowserView
-from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
-
-
-class View(BrowserView):
-
-    template = ViewPageTemplateFile('templates/notification_mail_macros.pt')

--- a/opengever/workspace/locales/de/LC_MESSAGES/opengever.workspace.po
+++ b/opengever/workspace/locales/de/LC_MESSAGES/opengever.workspace.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-12-30 15:00+0000\n"
+"POT-Creation-Date: 2020-07-06 14:45+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -98,20 +98,25 @@ msgstr "Teammitglied"
 msgid "invitation"
 msgstr "Einladung"
 
-#. Default: "Accept: ${accept_link}"
-#: ./opengever/workspace/participation/invitation_mailer.py
-msgid "invitation_accept"
-msgstr "Annehmen: ${accept_link}"
-
 #. Default: "You were invited by ${user} to the workspace \"${title}\"."
 #: ./opengever/workspace/participation/invitation_mailer.py
 msgid "invitation_mail_description"
 msgstr "Sie wurden von ${user} in den Teamraum \"${title}\" eingeladen."
 
+#. Default: "Message from ${user}:"
+#: ./opengever/workspace/participation/invitation_mailer.py
+msgid "invitation_mail_message_title"
+msgstr "Nachricht von ${user}:"
+
 #. Default: "Invitation to workspace \"${title}\""
 #: ./opengever/workspace/participation/invitation_mailer.py
 msgid "invitation_mail_subject"
 msgstr "Einladung zum Teamraum \"${title}\""
+
+#. Default: "Hello,\n\nYou were invited by ${user} to the workspace \"${title}\" at ${platform}.\n\nPlease click the following link if you want to accept the invitation:\n${accept_url}"
+#: ./opengever/workspace/participation/invitation_mailer.py
+msgid "invitation_mail_summary"
+msgstr "Guten Tag,\n\n${user} hat Sie eingeladen, an \"${title}\" auf der Plattform ${platform} teilzunehmen.\n\nWenn Sie die Einladung annehmen möchten, klicken Sie auf folgenden Link:\n${accept_url}"
 
 #. Default: "Completed"
 #: ./opengever/workspace/todo.py

--- a/opengever/workspace/locales/fr/LC_MESSAGES/opengever.workspace.po
+++ b/opengever/workspace/locales/fr/LC_MESSAGES/opengever.workspace.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-12-30 15:00+0000\n"
+"POT-Creation-Date: 2020-07-06 14:45+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -98,20 +98,25 @@ msgstr "Membre du team"
 msgid "invitation"
 msgstr "Invitation"
 
-#. Default: "Accept: ${accept_link}"
-#: ./opengever/workspace/participation/invitation_mailer.py
-msgid "invitation_accept"
-msgstr "Accepter: ${accept_link}"
-
 #. Default: "You were invited by ${user} to the workspace \"${title}\"."
 #: ./opengever/workspace/participation/invitation_mailer.py
 msgid "invitation_mail_description"
 msgstr "Vous avez été invité par ${user} pour le teamraum \"${title}\"."
 
+#. Default: "Message from ${user}:"
+#: ./opengever/workspace/participation/invitation_mailer.py
+msgid "invitation_mail_message_title"
+msgstr "Message de ${user}:"
+
 #. Default: "Invitation to workspace \"${title}\""
 #: ./opengever/workspace/participation/invitation_mailer.py
 msgid "invitation_mail_subject"
 msgstr "Invitation pour le teamraum \"${title}\""
+
+#. Default: "Hello,\n\nYou were invited by ${user} to the workspace \"${title}\" at ${platform}.\n\nPlease click the following link if you want to accept the invitation:\n${accept_url}"
+#: ./opengever/workspace/participation/invitation_mailer.py
+msgid "invitation_mail_summary"
+msgstr "Bonjour,\n\n${user} vous a invité, à participer à \"${title}\", sur la plateforme ${platform}.\n\nPour accepter cette invitation, veuillez cliquer sur le lien suivant:\n${accept_url}"
 
 #. Default: "Completed"
 #: ./opengever/workspace/todo.py

--- a/opengever/workspace/locales/opengever.workspace.pot
+++ b/opengever/workspace/locales/opengever.workspace.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-12-30 15:00+0000\n"
+"POT-Creation-Date: 2020-07-06 14:45+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -101,19 +101,24 @@ msgstr ""
 msgid "invitation"
 msgstr ""
 
-#. Default: "Accept: ${accept_link}"
-#: ./opengever/workspace/participation/invitation_mailer.py
-msgid "invitation_accept"
-msgstr ""
-
 #. Default: "You were invited by ${user} to the workspace \"${title}\"."
 #: ./opengever/workspace/participation/invitation_mailer.py
 msgid "invitation_mail_description"
 msgstr ""
 
+#. Default: "Message from ${user}:"
+#: ./opengever/workspace/participation/invitation_mailer.py
+msgid "invitation_mail_message_title"
+msgstr ""
+
 #. Default: "Invitation to workspace \"${title}\""
 #: ./opengever/workspace/participation/invitation_mailer.py
 msgid "invitation_mail_subject"
+msgstr ""
+
+#. Default: "Hello,\n\nYou were invited by ${user} to the workspace \"${title}\" at ${platform}.\n\nPlease click the following link if you want to accept the invitation:\n${accept_url}"
+#: ./opengever/workspace/participation/invitation_mailer.py
+msgid "invitation_mail_summary"
 msgstr ""
 
 #. Default: "Completed"

--- a/opengever/workspace/participation/invitation_mailer.py
+++ b/opengever/workspace/participation/invitation_mailer.py
@@ -1,10 +1,12 @@
 from opengever.activity.mailer import Mailer
 from opengever.ogds.base.actor import ActorLookup
+from opengever.ogds.base.utils import get_current_admin_unit
 from opengever.workspace.participation import serialize_and_sign_payload
 from plone.app.uuid.utils import uuidToObject
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from zope.i18n import translate
 from zope.i18nmessageid import MessageFactory
+
 
 _ = MessageFactory("opengever.workspace")
 
@@ -17,35 +19,60 @@ class InvitationMailer(Mailer):
     def send_invitation(self, invitation):
         target_workspace = uuidToObject(invitation['target_uuid'])
 
-        data = {}
         subject = translate(
             _(u'invitation_mail_subject',
               default=u'Invitation to workspace "${title}"',
               mapping={'title': target_workspace.title}),
             context=self.request
-            )
+        )
 
         payload = serialize_and_sign_payload({'iid': invitation['iid']})
-        accept_link = "{}/@@my-invitations/accept?invitation={}".format(
+        accept_url = "{}/@@my-invitations/accept?invitation={}".format(
             target_workspace.absolute_url(), payload)
 
         inviter = ActorLookup(invitation['inviter']).lookup()
 
         title = translate(
-            _(u'invitation_mail_description',
-              default=u'You were invited by ${user} to the workspace "${title}".',
-              mapping={'title': target_workspace.title,
-                       'user': inviter.get_label()}),
+            _(
+                u'invitation_mail_description',
+                default=u'You were invited by ${user} to the workspace "${title}".',
+                mapping={'title': target_workspace.title,
+                         'user': inviter.get_label()}
+            ),
             context=self.request
-            )
-        accept = translate(
-            _(u'invitation_accept',
-              default=u'Accept: ${accept_link}',
-              mapping={'accept_link': accept_link})
-            )
-        data['title'] = title
-        data['description'] = invitation['comment']
-        data['accept'] = accept
+        )
+        content = translate(
+            _(
+                u'invitation_mail_summary',
+                default=u'Hello,\n'
+                        u'\n'
+                        u'You were invited by ${user} to the workspace "${title}" at ${platform}.\n'
+                        u'\n'
+                        u'Please click the following link if you want to accept the invitation:\n'
+                        u'${accept_url}',
+                mapping={'title': target_workspace.title,
+                         'user': inviter.get_label(with_principal=False),
+                         'platform': get_current_admin_unit().public_url,
+                         'accept_url': accept_url}
+            ),
+            context=self.request
+        )
+        comment_title = translate(
+            _(
+                u'invitation_mail_message_title',
+                default=u'Message from ${user}:',
+                mapping={'user': inviter.get_label(with_principal=False)}
+            ),
+            context=self.request
+        )
+
+        data = {
+            'title': title,
+            'content': content.splitlines(),
+            'comment_title': comment_title,
+            'comment': invitation['comment'].splitlines(),
+            'public_url': get_current_admin_unit().public_url,
+        }
         msg = self.prepare_mail(subject=subject, to_email=invitation['recipient_email'],
                                 from_userid=invitation['inviter'], data=data)
 

--- a/opengever/workspace/participation/templates/invitation_mail.pt
+++ b/opengever/workspace/participation/templates/invitation_mail.pt
@@ -2,17 +2,35 @@
     xmlns="http://www.w3.org/1999/xhtml"
     xmlns:tal="http://xml.zope.org/namespaces/tal"
     xmlns:i18n="http://xml.zope.org/namespaces/i18n"
-    i18n:domain="opengever.workspace">
+    i18n:domain="opengever.workspace"
+    metal:use-macro="context/notification_mail_macros/macros/mail_template">
 
-    <h1 style="text-align: center; margin: 0 0 10px 0; font-family: Arial, sans-serif; font-size: 24px; line-height: 125%; color: #333333; font-weight: normal;" tal:content="options/title">
-    </h1>
+    <metal:styles metal:fill-slot="style_slot">
+      <style>
+        .email-content table {
+          width: 100%;
+        }
+      </style>
+    </metal:styles>
 
-    <tal:block tal:condition="options/description">
-      <tal:block tal:repeat="paragraph options/description">
-        <p tal:content="structure paragraph" />
-      </tal:block>
-    </tal:block>
+    <metal:title metal:fill-slot="title">
+        <p tal:content="options/title" />
+    </metal:title>
 
-    <p tal:content="options/accept" />
+    <metal:content metal:fill-slot="content">
+      <p>
+        <tal:summary tal:repeat="line options/content">
+          <tal:last tal:define="is_last repeat/line/end">
+            <tal:line tal:replace="line" /><br tal:condition="not: is_last" />
+          </tal:last>
+        </tal:summary>
+      </p>
+      <tal:comment tal:condition="options/comment">
+          <p><strong tal:content="options/comment_title"/></p>
+        <tal:block tal:repeat="line options/comment">
+          <p tal:content="line" />
+        </tal:block>
+      </tal:comment>
 
+    </metal:content>
 </html>


### PR DESCRIPTION
We improve the design of the workspace invitation e-mail by reusing the macro defined for the activity notifications. Furthermore, the content of the e-mail has been changed as requested in https://4teamwork.atlassian.net/browse/GEVER-536

![image](https://user-images.githubusercontent.com/28220/86607587-bbd68d80-bfa9-11ea-8cc7-36b3fc942955.png)


## Checklist (Must have)

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


## Checklist (if applicable)

- New translations
  - [x] All msg-strings are unicode

