### PR TITLE
Only show new frontend teaser if gever ui is enabled.

### DIFF
--- a/opengever/base/tests/test_teaser.py
+++ b/opengever/base/tests/test_teaser.py
@@ -5,6 +5,8 @@ from opengever.ogds.models.user_settings import UserSettings
 
 class TestTeaser(IntegrationTestCase):
 
+    features = ('gever_ui',)
+
     @browsing
     def test_new_frontend_teaser_is_shown(self, browser):
         self.login(self.regular_user, browser=browser)
@@ -19,5 +21,12 @@ class TestTeaser(IntegrationTestCase):
         setting.seen_tours = ['be_new_frontend_teaser']
         self.login(self.regular_user, browser=browser)
 
+        browser.visit(self.portal)
+        self.assertEqual([], browser.css('#new-frontend-teaser'))
+
+    @browsing
+    def test_new_frontend_teaser_is_not_shown_if_gever_ui_is_disabled(self, browser):
+        self.deactivate_feature('gever_ui')
+        self.login(self.regular_user, browser=browser)
         browser.visit(self.portal)
         self.assertEqual([], browser.css('#new-frontend-teaser'))

--- a/opengever/base/viewlets/teaser.pt
+++ b/opengever/base/viewlets/teaser.pt
@@ -1,5 +1,5 @@
 <div class="teasers" tal:define="unseen_tours view/unseen_tours" i18n:domain="opengever.base">
-  <tal:teaser define="tourkey string:be_new_frontend_teaser">
+  <tal:teaser define="tourkey string:be_new_frontend_teaser" tal:condition="view/is_ui_feature_enabled">
     <div class="teaser" id="new-frontend-teaser"
          tal:condition="python:tourkey in unseen_tours"
          tal:attributes="data-tourkey tourkey">

--- a/opengever/base/viewlets/teaser.py
+++ b/opengever/base/viewlets/teaser.py
@@ -1,3 +1,4 @@
+from opengever.base.interfaces import IGeverUI
 from opengever.ogds.models.user import User
 from plone import api
 from plone.app.layout.viewlets.common import ViewletBase
@@ -20,3 +21,6 @@ class TeaserViewlet(ViewletBase):
                 if key not in seen_tours:
                     unseen_tours.append(key)
         return unseen_tours
+
+    def is_ui_feature_enabled(self):
+        return api.portal.get_registry_record('is_feature_enabled', interface=IGeverUI)


### PR DESCRIPTION
This is a followup PR to #6536
The frontend teaser is now only showed if the GEVER-UI feature is enabled.

Jira: https://4teamwork.atlassian.net/browse/GEVER-552

Definition of Done: https://4teamwork.atlassian.net/wiki/spaces/CHX4TW/pages/917562/

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [ ] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)