### PR TITLE
Fix filtering on values containing spaces in listing endpoint.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,7 @@ Changelog
 - Fix contact workflow state variable name. [deiferni]
 - Fix contact folder workflow state variable name. [deiferni]
 - Improve design and content of workspace invitation e-mail. [mbaechtold]
+- Fix filtering on values containing spaces in listing endpoint. [njohner]
 - Add question for `administrator_group` to the policy template. [mbaechtold]
 - Add teaser viewlet to promote the new frontend. [tinagerber]
 - Fix loading of more items in contenttree widget for toplevel items. [buchi]


### PR DESCRIPTION
Filtering by `document_author` was not working in the new frontend when the author name contained a space. We fix this here by escaping spaces in filters when creating the solr query in the `listing` endpoint. We do not fix this in `ftw.solr` as the `escape` function defined there is used for the search query, for which spaces do not need to be escaped. Instead we implement our own escaping function specifically for filter queries.

For https://4teamwork.atlassian.net/browse/GEVER-649

## Checklist (Must have)

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

## Checklist (if applicable)

_Only applicable should be left and checked._

- API change:
  - [ ] Documentation is updated
  - If breaking:
    - [ ] api-change label added
    - [ ] Scrum master is informed