### PR TITLE
Expose the current logged in users email address in the @config endpoint

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 
 - Fix contact workflow state variable name. [deiferni]
 - Fix contact folder workflow state variable name. [deiferni]
+- Expose the current logged in users'email address in the @config endpoint. [elioschmutz]
 - Improve design and content of workspace invitation e-mail. [mbaechtold]
 - Fix filtering on values containing spaces in listing endpoint. [njohner]
 - Add question for `administrator_group` to the policy template. [mbaechtold]

--- a/docs/public/dev-manual/api/config.rst
+++ b/docs/public/dev-manual/api/config.rst
@@ -84,6 +84,7 @@ GEVER-Mandanten abgefragt werden.
               "white_list_prefix": "^.+"
           },
           "user_fullname": "Johner Niklaus",
+          "user_email": "niklaus.johner@example.com"
           "user_settings": {
               "notify_inbox_actions": true,
               "notify_own_actions": false,

--- a/opengever/api/tests/test_config.py
+++ b/opengever/api/tests/test_config.py
@@ -33,6 +33,7 @@ class TestConfig(IntegrationTestCase):
         self.assertEqual(browser.status_code, 200)
         self.assertEqual(browser.json.get(u'userid'), u'kathi.barfuss')
         self.assertEqual(browser.json.get(u'user_fullname'), u'B\xe4rfuss K\xe4thi')
+        self.assertEqual(browser.json.get(u'user_email'), u'kathi.barfuss@gever.local')
 
     @browsing
     def test_config_contains_features(self, browser):

--- a/opengever/base/configuration.py
+++ b/opengever/base/configuration.py
@@ -67,6 +67,7 @@ class GeverSettingsAdpaterV1(object):
         if user.getId():
             info['userid'] = user.getId()
             info['user_fullname'] = user.getProperty('fullname')
+            info['user_email'] = user.getProperty('email')
         return info
 
     def get_user_settings(self):

--- a/opengever/base/tests/test_configuration_adapter.py
+++ b/opengever/base/tests/test_configuration_adapter.py
@@ -14,6 +14,7 @@ class TestConfigurationAdapter(IntegrationTestCase):
             ('version', get_distribution('opengever.core').version),
             ('userid', 'kathi.barfuss'),
             ('user_fullname', 'B\xc3\xa4rfuss K\xc3\xa4thi'),
+            ('user_email', 'kathi.barfuss@gever.local'),
             ('max_dossier_levels', 2),
             ('max_repositoryfolder_levels', 3),
             ('recently_touched_limit', 10),


### PR DESCRIPTION
This PR exposes the currently logged in users e-mail address in the ``@config`` endpiont.

We need this information for the usersnap plugin.

⚠️ I would like to have the serialized user object here instead of defining each attribute. But this would end in an api change which I wanted to avoid. I opened an enabler to handle this refactoring: https://4teamwork.atlassian.net/browse/GEVER-698

Jira: https://4teamwork.atlassian.net/browse/GEVER-516

## Checklist (Must have)

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

## Checklist (if applicable)

- API change:
  - [x] Documentation is updated
