### PR TITLE
Fix update mail filename upgrade step.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2020.4.0 (2020-07-02)
 ---------------------
 
+- Fix update mail filename upgrade step. [njohner]
 - Improve check if solr has started to prevent an issue during the testserver startup. [sebastianmanger]
 - Make creating favorites more robust in case of workflow issues. [deiferni]
 - Improve response history for (automatically) opened subtasks in sequential task templates. [mbaechtold]

--- a/opengever/core/upgrades/20200508163000_update_filename_of_mails_with_file_extension_msg/upgrade.py
+++ b/opengever/core/upgrades/20200508163000_update_filename_of_mails_with_file_extension_msg/upgrade.py
@@ -6,7 +6,6 @@ class UpdateFilenameOfMailsWithFileExtensionMsg(UpgradeStep):
     """
 
     def __call__(self):
-        self.install_upgrade_profile()
         query = {'portal_type': 'ftw.mail.mail', 'file_extension': '.msg'}
         for mail in self.objects(query, 'Update filename'):
             mail.update_filename()


### PR DESCRIPTION
Filename column has to be added to favorites before fixing mail filenames, i.e. https://github.com/4teamwork/opengever.core/blob/master/opengever/core/upgrades/20200508162410_add_filename_column_to_favorites/upgrade.py should be executed before https://github.com/4teamwork/opengever.core/blob/master/opengever/core/upgrades/20200507073857_update_filename_of_mails_with_file_extension_msg/upgrade.py which should itself be executed (although this is not mandatory) before https://github.com/4teamwork/opengever.core/blob/master/opengever/core/upgrades/20200508163417_populate_filename_column_in_favorites/upgrade.py

For https://4teamwork.atlassian.net/browse/GEVER-168

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


## Checklist (if applicable)

- Upgrade steps (changes in profile):
  - [ ] Make it deferrable if possible: I don't make it deferrable so it gets executed in between the two others
  - [ ] Execute as much as possible conditionally