### PR TITLE
Add TeasersSettings to registry to allow hiding teasers.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -10,7 +10,7 @@ Changelog
 - Improve design and content of workspace invitation e-mail. [mbaechtold]
 - Fix filtering on values containing spaces in listing endpoint. [njohner]
 - Add question for `administrator_group` to the policy template. [mbaechtold]
-- Add teaser viewlet to promote the new frontend. [tinagerber]
+- Add teaser viewlet to promote the new frontend. [tinagerber, njohner]
 - Fix loading of more items in contenttree widget for toplevel items. [buchi]
 - Add UserSnap API key to registry. [njohner]
 

--- a/opengever/base/interfaces.py
+++ b/opengever/base/interfaces.py
@@ -389,3 +389,16 @@ class IDocPropertyProvider(Interface):
         All keys will be prefixed by the default application prefix, followed
         by the optional prefix argument.
         """
+
+
+class ITeasersSettings(Interface):
+
+    show_teasers = schema.Bool(
+        title=u'Show teasers',
+        description=u'Whether the teasers should be shown',
+        default=True)
+
+    teasers_to_hide = schema.List(title=u"Teasers to hide",
+                                  default=[],
+                                  value_type=schema.TextLine(),
+                                  )

--- a/opengever/base/tests/test_teaser.py
+++ b/opengever/base/tests/test_teaser.py
@@ -1,6 +1,7 @@
 from ftw.testbrowser import browsing
-from opengever.testing import IntegrationTestCase
 from opengever.ogds.models.user_settings import UserSettings
+from opengever.testing import IntegrationTestCase
+from plone import api
 
 
 class TestTeaser(IntegrationTestCase):
@@ -27,6 +28,23 @@ class TestTeaser(IntegrationTestCase):
     @browsing
     def test_new_frontend_teaser_is_not_shown_if_gever_ui_is_disabled(self, browser):
         self.deactivate_feature('gever_ui')
+        self.login(self.regular_user, browser=browser)
+        browser.visit(self.portal)
+        self.assertEqual([], browser.css('#new-frontend-teaser'))
+
+    @browsing
+    def test_new_frontend_teaser_is_not_shown_if_teasers_are_disabled(self, browser):
+        api.portal.set_registry_record(
+            'opengever.base.interfaces.ITeasersSettings.show_teasers', False)
+        self.login(self.regular_user, browser=browser)
+        browser.visit(self.portal)
+        self.assertEqual([], browser.css('#new-frontend-teaser'))
+
+    @browsing
+    def test_new_frontend_teaser_is_not_shown_if_in_teasers_to_hide(self, browser):
+        api.portal.set_registry_record(
+            'opengever.base.interfaces.ITeasersSettings.teasers_to_hide',
+            [u'be_new_frontend_teaser'])
         self.login(self.regular_user, browser=browser)
         browser.visit(self.portal)
         self.assertEqual([], browser.css('#new-frontend-teaser'))

--- a/opengever/base/viewlets/teaser.pt
+++ b/opengever/base/viewlets/teaser.pt
@@ -1,7 +1,7 @@
-<div class="teasers" tal:define="unseen_tours view/unseen_tours" i18n:domain="opengever.base">
+<div class="teasers" tal:define="tours_to_show view/tours_to_show" i18n:domain="opengever.base" tal:condition="view/show_viewlet">
   <tal:teaser define="tourkey string:be_new_frontend_teaser" tal:condition="view/is_ui_feature_enabled">
     <div class="teaser" id="new-frontend-teaser"
-         tal:condition="python:tourkey in unseen_tours"
+         tal:condition="python:tourkey in tours_to_show"
          tal:attributes="data-tourkey tourkey">
         <div class="teaser-content" i18n:translate="new_frontend_teaser">
           Do you already know the new user interface of OneGov GEVER? <a href="javascript:switchUI()">Try it out</a> now.

--- a/opengever/base/viewlets/teaser.py
+++ b/opengever/base/viewlets/teaser.py
@@ -1,4 +1,5 @@
 from opengever.base.interfaces import IGeverUI
+from opengever.base.interfaces import ITeasersSettings
 from opengever.ogds.models.user import User
 from plone import api
 from plone.app.layout.viewlets.common import ViewletBase
@@ -11,16 +12,28 @@ class TeaserViewlet(ViewletBase):
 
     tour_keys = ['be_new_frontend_teaser']
 
-    def unseen_tours(self):
+    def tours_to_show(self):
         userid = api.user.get_current().id
         ogds_user = User.query.filter_by(userid=userid).one_or_none()
-        unseen_tours = []
+
+        tours_to_show = []
         if ogds_user:
             seen_tours = ogds_user.user_settings.seen_tours if ogds_user.user_settings else []
             for key in self.tour_keys:
-                if key not in seen_tours:
-                    unseen_tours.append(key)
-        return unseen_tours
+                if key not in seen_tours and key not in self.teasers_to_hide:
+                    tours_to_show.append(key)
+
+        return tours_to_show
 
     def is_ui_feature_enabled(self):
-        return api.portal.get_registry_record('is_feature_enabled', interface=IGeverUI)
+        return api.portal.get_registry_record(
+            'is_feature_enabled', interface=IGeverUI)
+
+    def show_viewlet(self):
+        return api.portal.get_registry_record(
+            'show_teasers', interface=ITeasersSettings)
+
+    @property
+    def teasers_to_hide(self):
+        return api.portal.get_registry_record(
+            'teasers_to_hide', interface=ITeasersSettings)

--- a/opengever/core/profiles/default/registry.xml
+++ b/opengever/core/profiles/default/registry.xml
@@ -174,6 +174,9 @@
   <!-- TASK -->
   <records interface="opengever.task.interfaces.ITaskSettings" />
 
+  <!-- Teasers -->
+  <records interface="opengever.base.interfaces.ITeasersSettings" />
+
   <!-- Usersnap -->
   <records interface="opengever.base.interfaces.IUserSnapSettings" />
 

--- a/opengever/core/upgrades/20200710080249_add_teaser_settings/registry.xml
+++ b/opengever/core/upgrades/20200710080249_add_teaser_settings/registry.xml
@@ -1,0 +1,4 @@
+<registry>
+  <!-- Teasers -->
+  <records interface="opengever.base.interfaces.ITeasersSettings" />
+</registry>

--- a/opengever/core/upgrades/20200710080249_add_teaser_settings/upgrade.py
+++ b/opengever/core/upgrades/20200710080249_add_teaser_settings/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddTeaserSettings(UpgradeStep):
+    """Add teaser settings.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()


### PR DESCRIPTION
We want to be able to hide the teasers for certain customers. I've added `ITeasersSettings` with a flag to completely hide the teasers and a list of specific teasers to hide.

This is a follow-up PR for https://github.com/4teamwork/opengever.core/pull/6536, https://github.com/4teamwork/opengever.core/pull/6541 and https://github.com/4teamwork/opengever.core/pull/6543

For https://4teamwork.atlassian.net/browse/GEVER-552

## Checklist (Must have)

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

## Checklist (if applicable)

- Upgrade steps (changes in profile):
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
