### PR TITLE
Translate activities in @notifications endpoint.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 ---------------------
 
 - Overwrite logout API endpoint to also expire the user's cookies. [njohner]
+- Translate activities in @notifications endpoint. [njohner]
 - Fix contact workflow state variable name. [deiferni]
 - Fix contact folder workflow state variable name. [deiferni]
 - Expose the current logged in users'email address in the @config endpoint. [elioschmutz]

--- a/opengever/activity/digest.py
+++ b/opengever/activity/digest.py
@@ -64,24 +64,16 @@ class DigestMailer(Mailer):
 
     def prepare_data(self, notifications):
         items = []
-        language = self.get_users_language()
         data = self.group_by_resource(notifications).items()
         for resource, notifications in data:
             activities = [
-                self.serialize_activity(notification.activity, language)
+                notification.activity.serialize(with_description=True)
                 for notification in notifications]
             items.append({
                 'title': activities[0]['title'],
                 'url': ResolveOGUIDView.url_for(resource.oguid),
                 'activities': activities})
         return items
-
-    def serialize_activity(self, activity, language):
-        return {
-            'title': activity.translations[language].title,
-            'label': activity.translations[language].label,
-            'summary': activity.translations[language].summary,
-            'description': activity.translations[language].description}
 
     def send_digests(self):
         logger.info('Sending digests...')

--- a/opengever/activity/model/activity.py
+++ b/opengever/activity/model/activity.py
@@ -2,11 +2,14 @@ from opengever.activity.model.notification import Notification
 from opengever.base.date_time import utcnow_tz_aware
 from opengever.base.model import Base
 from opengever.base.model import DEFAULT_LOCALE
+from opengever.base.model import get_locale
 from opengever.base.model import SUPPORTED_LOCALES
 from opengever.base.model import USER_ID_LENGTH
 from opengever.base.model import UTCDateTime
 from opengever.base.types import UnicodeCoercingText
+from opengever.ogds.base.actor import Actor
 from opengever.ogds.models.user_settings import UserSettings
+from plone.restapi.serializer.converters import json_compatible
 from sqlalchemy import Column
 from sqlalchemy import ForeignKey
 from sqlalchemy import Integer
@@ -60,6 +63,20 @@ class Activity(Base, Translatable):
                 Notification(userid=userid, activity=self))
 
         return notifications
+
+    def serialize(self, with_description=False):
+        actor = Actor.lookup(self.actor_id)
+        language = get_locale()
+        data = {
+            'title': self.translations[language].title,
+            'label': self.translations[language].label,
+            'summary': self.translations[language].summary,
+            'created': json_compatible(self.created),
+            'actor_id': self.actor_id,
+            'actor_label': actor.get_label(with_principal=False)}
+        if with_description:
+            data['description'] = self.translations[language].description
+        return data
 
     def get_users_for_watchers(self):
         users = []

--- a/opengever/activity/model/notification.py
+++ b/opengever/activity/model/notification.py
@@ -1,7 +1,5 @@
 from opengever.base.model import Base
 from opengever.base.model import USER_ID_LENGTH
-from opengever.ogds.base.actor import Actor
-from plone.restapi.serializer.converters import json_compatible
 from sqlalchemy import Boolean
 from sqlalchemy import Column
 from sqlalchemy import ForeignKey
@@ -36,19 +34,14 @@ class Notification(Base):
             repr(self.activity.resource))
 
     def serialize(self, portal_url):
-        actor = Actor.lookup(self.activity.actor_id)
-        return {
+        data = self.activity.serialize()
+        data.update({
             '@id': self._api_url(portal_url),
             'notification_id': self.notification_id,
-            'actor_id': self.activity.actor_id,
-            'actor_label': actor.get_label(with_principal=False),
-            'created': json_compatible(self.activity.created),
             'read': self.is_read,
-            'title': self.activity.title,
-            'label': self.activity.label,
             'link': self._resolve_notification_link(portal_url),
-            'summary': self.activity.summary,
-        }
+            })
+        return data
 
     def _resolve_notification_link(self, portal_url):
         return '{}/@@resolve_notification?notification_id={}'.format(


### PR DESCRIPTION
Activities are stored in multiple languages and can therefore be translated. The `@notifications` endpoint nevertheless did not returned the translated activities, so that the new frontend would always display the notifications in German. This is fixed with this PR.

I also removed some code duplication, defining a `serialize` method directly on the `Activity`, also allowing to deal with the translations in one central place.

For https://4teamwork.atlassian.net/browse/GEVER-668

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


## Checklist (if applicable)

_Only applicable should be left and checked._

- API change:
  - [ ] Documentation is updated
  - If breaking:
    - [ ] api-change label added
    - [ ] Scrum master is informed