### PR TITLE
Add @role-assignment-reports endpoint to list, add and delete role assignment reports.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2020.5.0 (unreleased)
 ---------------------
 
+- Add @role-assignment-reports endpoint to list, add and delete role assignment reports. [tinagerber]
 - Overwrite logout API endpoint to also expire the user's cookies. [njohner]
 - Translate activities in @notifications endpoint. [njohner]
 - Fix contact workflow state variable name. [deiferni]

--- a/docs/public/dev-manual/api/docs_changelog.rst
+++ b/docs/public/dev-manual/api/docs_changelog.rst
@@ -5,6 +5,12 @@ Changelog
 
 Im Folgenden sind (substantielle) Änderungen an der Dokumentation aufgeführt.
 
+2020-07-10
+----------
+
+- Kapitel "Rollenzuweisungs-Berichte" hinzugefügt
+
+
 2020-06-11
 ----------
 

--- a/docs/public/dev-manual/api/index.rst
+++ b/docs/public/dev-manual/api/index.rst
@@ -40,6 +40,7 @@ Inhalt:
    reminder.rst
    journal.rst
    sharing.rst
+   role_assignment_reports.rst
    allowed_roles_and_principals.rst
    watchers.rst
    workspace/index

--- a/docs/public/dev-manual/api/role_assignment_reports.rst
+++ b/docs/public/dev-manual/api/role_assignment_reports.rst
@@ -1,0 +1,161 @@
+Rollenzuweisungs-Berichte
+=========================
+
+Der ``@role-assignment-reports`` bietet Funktionen für die Auflistung, das Erstellen und das Löschen von Rollenzuweisungs-Berichten. Der Endpoint steht nur auf Stufe PloneSite zur Verfügung und ist mit einer Berechtigung geschützt: ``opengever.api.ManageRoleAssignmentReports``
+Die Berechtigung ist standardmässig den Rollen `Administrator` und `Manager` zugewiesen.
+
+
+Auflistung
+----------
+
+Mittels eines GET-Requests können alle Berichte abgefragt werden.
+
+**Beispiel-Request**:
+
+   .. sourcecode:: http
+
+       GET /@role-assignment-reports HTTP/1.1
+       Accept: application/json
+
+
+**Beispiel-Response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 200 OK
+      Content-Type: application/json
+
+      {
+        "items": [
+          {
+            "@id": "http://localhost:8080/fd/@role-assignment-reports/report_2",
+            "modified": "2020-07-08T14:17:30+00:00",
+            "principal_type": "user",
+            "principalid": "robert.ziegler",
+            "reportid": "report_2",
+            "state": "in progress"
+          },
+          {
+            "@id": "http://localhost:8080/fd/@role-assignment-reports/report_1",
+            "modified": "2020-04-03T01:34:27+00:00",
+            "principal_type": "group",
+            "principalid": "afi_benutzer",
+            "reportid": "report_1",
+            "state": "ready"
+          }
+        ],
+        "items_total": 2
+      }
+
+Mittels eines GET-Requests können auch einzelne Berichte abgefragt werden.
+
+**Beispiel-Request**:
+
+   .. sourcecode:: http
+
+       GET /@role-assignment-reports/report_1 HTTP/1.1
+       Accept: application/json
+
+
+**Beispiel-Response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 200 OK
+      Content-Type: application/json
+
+      {
+        "@id": "http://localhost:8080/fd/@role-assignment-reports/report_1",
+        "items": [
+          {
+            "UID": "ea02348a43fd4c9ebcf86f0a1f739923",
+            "roles": [
+              "Editor"
+            ],
+            "url": "http://localhost:8080/fd/ordnungssystem/bevoelkerung-und-sicherheit/einwohnerkontrolle/dossier-1/dossier-2"
+          },
+          {
+            "UID": "63bf84e9e07b4702abaf3bd78ca45326",
+            "roles": [
+              "Contributor",
+              "Reader"
+            ],
+            "url": "http://localhost:8080/fd/ordnungssystem/fuehrung/interne-organisation/planung-und-organisatorisches/dossier-3"
+          },
+          {
+            "UID": "3761453132dc4ced9b0a758c3b978802",
+            "roles": [
+              "Contributor",
+              "Reviewer",
+              "Editor"
+            ],
+            "url": "http://localhost:8080/fd/ordnungssystem/bevoelkerung-und-sicherheit/einbuergerungen"
+          }
+        ],
+        "items_total": 3,
+        "modified": "2020-04-03T01:34:27+00:00",
+        "principal_type": "group",
+        "principalid": "afi_benutzer",
+        "reportid": "report_1",
+        "state": "ready"
+      }
+
+
+Bericht erstellen
+---------------------
+
+Ein Bericht kann mittels POST-Requests angefordert werden. Danach erscheint der Bericht im Status ``in progress``. In einem Nightly-Job werden die Rollenzuweisungen zusammengetragen und der Bericht damit ergänzt. Sobald dies erledigt ist, wird der Status auf ``ready`` gesetzt. Berichte können für Benutzer und für Gruppen angefordert werden.
+
+
+**Beispiel-Request**:
+
+   .. sourcecode:: http
+
+       POST /@role-assignment-reports HTTP/1.1
+       Accept: application/json
+
+       {
+         "principalid": "robert.ziegler"
+       }
+
+**Beispiel-Response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 200 OK
+      Content-Type: application/json
+
+      {
+        "@id": "http://localhost:8080/fd/@role-assignment-reports/report_7",
+        "items": [],
+        "items_total": 0,
+        "modified": "2020-07-13T11:43:18+00:00",
+        "principal_type": "user",
+        "principalid": "robert.ziegler",
+        "reportid": "report_7",
+        "state": "in progress"
+      }
+
+
+Bericht löschen
+--------------------
+
+Mittels DELETE-Requests kann ein Bericht gelöscht werden.
+
+**Beispiel-Request**:
+
+   .. sourcecode:: http
+
+       DELETE /@role-assignment-reports/report_0 HTTP/1.1
+       Accept: application/json
+
+**Beispiel-Response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 204 No content
+
+
+Paginierung
+~~~~~~~~~~~
+Die Paginierung funktioniert gleich wie bei anderen Auflistungen auch (siehe :ref:`Kapitel Paginierung <batching>`).

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -300,6 +300,30 @@
 
   <plone:service
       method="GET"
+      name="@role-assignment-reports"
+      for="Products.CMFPlone.interfaces.IPloneSiteRoot"
+      factory=".role_assignment_reports.RoleAssignmentReportsGet"
+      permission="opengever.api.ManageRoleAssignmentReports"
+      />
+
+  <plone:service
+      method="POST"
+      name="@role-assignment-reports"
+      for="Products.CMFPlone.interfaces.IPloneSiteRoot"
+      factory=".role_assignment_reports.RoleAssignmentReportsPost"
+      permission="opengever.api.ManageRoleAssignmentReports"
+      />
+
+  <plone:service
+      method="DELETE"
+      name="@role-assignment-reports"
+      for="Products.CMFPlone.interfaces.IPloneSiteRoot"
+      factory=".role_assignment_reports.RoleAssignmentReportsDelete"
+      permission="opengever.api.ManageRoleAssignmentReports"
+      />
+
+  <plone:service
+      method="GET"
       name="@notifications"
       for="Products.CMFPlone.interfaces.IPloneSiteRoot"
       factory=".notifications.NotificationsGet"

--- a/opengever/api/permissions.zcml
+++ b/opengever/api/permissions.zcml
@@ -4,5 +4,6 @@
 
   <permission id="opengever.api.ViewAllowedRolesAndPrincipals" title="opengever.api: View AllowedRolesAndPrincipals" />
   <permission id="opengever.api.TransferAssignment" title="opengever.api: Transfer Assignment" />
+  <permission id="opengever.api.ManageRoleAssignmentReports" title="opengever.api: Manage Role Assignment Reports" />
 
 </configure>

--- a/opengever/api/role_assignment_reports.py
+++ b/opengever/api/role_assignment_reports.py
@@ -1,0 +1,113 @@
+from opengever.base.interfaces import IRoleAssignmentReportsStorage
+from plone.app.uuid.utils import uuidToObject
+from plone.protect.interfaces import IDisableCSRFProtection
+from plone.restapi.batching import HypermediaBatch
+from plone.restapi.deserializer import json_body
+from plone.restapi.services import Service
+from zExceptions import BadRequest
+from zope.interface import alsoProvides
+from zope.interface import implements
+from zope.publisher.interfaces import IPublishTraverse
+
+
+class RoleAssignmentReportsGet(Service):
+    """API Endpoint which returns a list of all role assignment reports
+
+    GET /@role-assignment-reports HTTP/1.1
+
+    or a single report
+
+    GET /@role-assignment-reports/report_1 HTTP/1.1
+    """
+
+    implements(IPublishTraverse)
+
+    def __init__(self, context, request):
+        super(RoleAssignmentReportsGet, self).__init__(context, request)
+        self.params = []
+
+    def publishTraverse(self, request, name):
+        # Consume any path segments after /@role-assignment-reports as parameters
+        self.params.append(name)
+        return self
+
+    def reply(self):
+        storage = IRoleAssignmentReportsStorage(self.context)
+        # a single report
+        if len(self.params) == 1:
+            reportid = self.params[0]
+            try:
+                result = storage.get(reportid)
+            except KeyError:
+                raise BadRequest("Invalid reportid '{}'".format(reportid))
+            for item in result['items']:
+                item['url'] = uuidToObject(item['UID']).absolute_url()
+        # all reports
+        elif len(self.params) == 0:
+            result = {'items': storage.list()}
+            for report in result['items']:
+                del report['items']
+                report['@id'] = '/'.join([self.context.absolute_url(), '@role-assignment-reports',
+                                          report['reportid']])
+        else:
+            raise BadRequest("Too many parameters. Only principalid is allowed.")
+
+        batch = HypermediaBatch(self.request, result['items'])
+        result['items'] = [item for item in batch]
+        result['items_total'] = batch.items_total
+        result['@id'] = batch.canonical_url
+        if batch.links:
+            result['batching'] = batch.links
+        return result
+
+
+class RoleAssignmentReportsPost(Service):
+
+    def reply(self):
+        self.extract_data()
+        # Disable CSRF protection
+        alsoProvides(self.request, IDisableCSRFProtection)
+        storage = IRoleAssignmentReportsStorage(self.context)
+        reportid = storage.add(self.principalid)
+        report = storage.get(reportid)
+        report['@id'] = '/'.join([self.context.absolute_url(), '@role-assignment-reports',
+                                  reportid])
+        report['items_total'] = 0
+        return report
+
+    def extract_data(self):
+        data = json_body(self.request)
+        self.principalid = data.get("principalid", None)
+        if not self.principalid:
+            raise BadRequest("Property 'principalid' is required")
+
+
+class RoleAssignmentReportsDelete(Service):
+    implements(IPublishTraverse)
+
+    def __init__(self, context, request):
+        super(RoleAssignmentReportsDelete, self).__init__(context, request)
+        self.params = []
+
+    def publishTraverse(self, request, name):
+        # Consume any path segments after /@favorites as parameters
+        self.params.append(name)
+        return self
+
+    def reply(self):
+        if len(self.params) != 1:
+            raise BadRequest("reportid is required")
+        reportid = self.params[0]
+        storage = IRoleAssignmentReportsStorage(self.context)
+        try:
+            storage.get(reportid)
+        except KeyError:
+            raise BadRequest("Invalid reportid '{}'".format(reportid))
+
+        # Disable CSRF protection
+        alsoProvides(self.request, IDisableCSRFProtection)
+
+        storage = IRoleAssignmentReportsStorage(self.context)
+        storage.delete(reportid)
+        self.request.response.setStatus(204)
+        return super(RoleAssignmentReportsDelete, self).reply()

--- a/opengever/api/tests/test_allowed_roles_and_principals.py
+++ b/opengever/api/tests/test_allowed_roles_and_principals.py
@@ -5,6 +5,7 @@ from opengever.testing import IntegrationTestCase
 
 
 class TestAllowedRolesAndPrincipalsAPI(IntegrationTestCase):
+    maxDiff = None
 
     @browsing
     def test_raises_unauthorized_when_user_accessing_allowed_roles_and_principals(self, browser):
@@ -29,7 +30,8 @@ class TestAllowedRolesAndPrincipalsAPI(IntegrationTestCase):
                 u'Manager',
                 u'Editor',
                 u'Reader',
-                u'Contributor'],
+                u'Contributor',
+                u'principal:jurgen.fischer'],
             u'@id': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen'
                     u'/dossier-1/@allowed-roles-and-principals'}
 

--- a/opengever/api/tests/test_role_assignment_reports.py
+++ b/opengever/api/tests/test_role_assignment_reports.py
@@ -1,0 +1,208 @@
+from datetime import datetime
+from ftw.testbrowser import browsing
+from ftw.testing import freeze
+from opengever.testing import IntegrationTestCase
+import json
+
+
+class TestRoleAssignmentReportsGet(IntegrationTestCase):
+    maxDiff = None
+
+    @browsing
+    def test_get_role_assignment_reports(self, browser):
+        self.login(self.administrator, browser=browser)
+        browser.open(self.portal.absolute_url() + '/@role-assignment-reports',
+                     method='GET', headers=self.api_headers)
+
+        self.assertEqual(
+            {u'@id': u'http://nohost/plone/@role-assignment-reports',
+             u'items': [
+                {u'@id': u'http://nohost/plone/@role-assignment-reports/report_1',
+                 u'modified': u'2016-08-31T20:01:33+00:00',
+                 u'principal_type': u'user',
+                 u'principalid': u'kathi.barfuss',
+                 u'reportid': u'report_1',
+                 u'state': u'in progress'},
+                {u'@id': u'http://nohost/plone/@role-assignment-reports/report_0',
+                 u'modified': u'2016-08-31T20:01:33+00:00',
+                 u'principal_type': u'user',
+                 u'principalid': u'jurgen.fischer',
+                 u'reportid': u'report_0',
+                 u'state': u'ready'}],
+             u'items_total': 2}, browser.json)
+
+    @browsing
+    def test_get_role_assignment_report(self, browser):
+        self.login(self.administrator, browser=browser)
+        browser.open(self.portal.absolute_url() + '/@role-assignment-reports/report_0',
+                     method='GET', headers=self.api_headers)
+
+        self.assertEqual(
+            {u'@id': u'http://nohost/plone/@role-assignment-reports/report_0',
+             u'items': [{u'UID': u'createrepositorytree000000000001',
+                         u'roles': [u'Contributor'],
+                         u'url': u'http://nohost/plone/ordnungssystem'},
+                        {u'UID': u'createrepositorytree000000000004',
+                         u'roles': [u'Contributor', u'Publisher'],
+                         u'url': u'http://nohost/plone/ordnungssystem/rechnungsprufungskommission'},
+                        {u'UID': u'createtreatydossiers000000000018',
+                         u'roles': [u'Reader', u'Editor', u'Reviewer'],
+                         u'url': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-'
+                                 u'vereinbarungen/dossier-1/dossier-2/dossier-4'}],
+             u'items_total': 3,
+             u'modified': u'2016-08-31T20:01:33+00:00',
+             u'principal_type': u'user',
+             u'principalid': u'jurgen.fischer',
+             u'reportid': u'report_0',
+             u'state': u'ready'}, browser.json)
+
+    @browsing
+    def test_get_role_assignment_report_with_invalid_reportid_raises_bad_request(self, browser):
+        self.login(self.administrator, browser=browser)
+        with browser.expect_http_error(400):
+            browser.open(self.portal.absolute_url() + '/@role-assignment-reports/bla',
+                         method='GET', headers=self.api_headers)
+        self.assertEqual(
+            {"message": "Invalid reportid 'bla'",
+             "type": "BadRequest"},
+            browser.json)
+
+    @browsing
+    def test_get_role_assignment_reports_raises_unauthorized(self, browser):
+        self.login(self.regular_user, browser)
+        with browser.expect_unauthorized():
+            browser.open(self.portal.absolute_url() + '/@role-assignment-reports',
+                         method='GET', headers=self.api_headers)
+
+        self.assertEqual(401, browser.status_code)
+
+
+class TestRoleAssignmentReportsPost(IntegrationTestCase):
+
+    @browsing
+    def test_post_role_assignment_reports(self, browser):
+        self.login(self.administrator, browser=browser)
+        with freeze(datetime(2020, 4, 18)):
+            browser.open(self.portal.absolute_url() + '/@role-assignment-reports',
+                         method='POST',
+                         headers=self.api_headers,
+                         data=json.dumps({"principalid": self.meeting_user.getId()}))
+
+        self.assertEqual(browser.status_code, 200)
+        self.assertEqual({u'@id': u'http://nohost/plone/@role-assignment-reports/report_2',
+                          u'items': [],
+                          u'items_total': 0,
+                          u'modified': u'2020-04-18T00:00:00+00:00',
+                          u'principal_type': 'user',
+                          u'principalid': self.meeting_user.getId(),
+                          u'reportid': u'report_2',
+                          u'state': u'in progress'}, browser.json)
+
+    @browsing
+    def test_post_role_assignment_reports_with_group(self, browser):
+        self.login(self.administrator, browser=browser)
+        with freeze(datetime(2020, 4, 18)):
+            browser.open(self.portal.absolute_url() + '/@role-assignment-reports',
+                         method='POST',
+                         headers=self.api_headers,
+                         data=json.dumps({"principalid": 'projekt_a'}))
+
+        self.assertEqual(browser.status_code, 200)
+        self.assertEqual({u'@id': u'http://nohost/plone/@role-assignment-reports/report_2',
+                          u'items': [],
+                          u'items_total': 0,
+                          u'modified': u'2020-04-18T00:00:00+00:00',
+                          u'principal_type': u'group',
+                          u'principalid': u'projekt_a',
+                          u'reportid': u'report_2',
+                          u'state': u'in progress'}, browser.json)
+
+    @browsing
+    def test_post_role_assignment_reports_with_invalid_principalid(self, browser):
+        self.login(self.administrator, browser=browser)
+        with freeze(datetime(2020, 4, 18)):
+            browser.open(self.portal.absolute_url() + '/@role-assignment-reports',
+                         method='POST',
+                         headers=self.api_headers,
+                         data=json.dumps({"principalid": 'chaosqueen'}))
+
+        self.assertEqual(browser.status_code, 200)
+        self.assertEqual({u'@id': u'http://nohost/plone/@role-assignment-reports/report_2',
+                          u'items': [],
+                          u'items_total': 0,
+                          u'modified': u'2020-04-18T00:00:00+00:00',
+                          u'principal_type': u'unknown principal',
+                          u'principalid': u'chaosqueen',
+                          u'reportid': u'report_2',
+                          u'state': u'in progress'}, browser.json)
+
+    @browsing
+    def test_post_role_assignment_reports_without_principalid_raises_bad_request(self, browser):
+        self.login(self.administrator, browser=browser)
+        with browser.expect_http_error(400):
+            browser.open(self.portal.absolute_url() + '/@role-assignment-reports',
+                         method='POST', headers=self.api_headers)
+        self.assertEqual(
+            {"message": "Property 'principalid' is required",
+             "type": "BadRequest"},
+            browser.json)
+
+    @browsing
+    def test_post_role_assignment_reports_raises_unauthorized(self, browser):
+        self.login(self.regular_user, browser)
+        with browser.expect_unauthorized():
+            browser.open(self.portal.absolute_url() + '/@role-assignment-reports',
+                         method='POST', headers=self.api_headers,
+                         data=json.dumps({"principalid": self.regular_user.getId()}))
+
+        self.assertEqual(401, browser.status_code)
+
+
+class TestRoleAssignmentReportsDelete(IntegrationTestCase):
+
+    @browsing
+    def test_delete_role_assignment_report(self, browser):
+        self.login(self.administrator, browser=browser)
+        browser.open(self.portal.absolute_url() + '/@role-assignment-reports/report_0',
+                     method='GET', headers=self.api_headers)
+        browser.open(self.portal.absolute_url() + '/@role-assignment-reports/report_0',
+                     method='DELETE', headers=self.api_headers)
+        with browser.expect_http_error(400):
+            browser.open(self.portal.absolute_url() + '/@role-assignment-reports/report_0',
+                         method='GET', headers=self.api_headers)
+
+        self.assertEqual(
+            {"message": "Invalid reportid 'report_0'",
+             "type": "BadRequest"},
+            browser.json)
+
+    @browsing
+    def test_delete_role_assignment_reports_without_principalid_raises_bad_request(self, browser):
+        self.login(self.administrator, browser=browser)
+        with browser.expect_http_error(400):
+            browser.open(self.portal.absolute_url() + '/@role-assignment-reports',
+                         method='DELETE', headers=self.api_headers)
+        self.assertEqual(
+            {"message": "reportid is required",
+             "type": "BadRequest"},
+            browser.json)
+
+    @browsing
+    def test_delete_role_assignment_report_with_invalid_reportid_raises_bad_request(self, browser):
+        self.login(self.administrator, browser=browser)
+        with browser.expect_http_error(400):
+            browser.open(self.portal.absolute_url() + '/@role-assignment-reports/bla',
+                         method='DELETE', headers=self.api_headers)
+        self.assertEqual(
+            {"message": "Invalid reportid 'bla'",
+             "type": "BadRequest"},
+            browser.json)
+
+    @browsing
+    def test_delete_role_assignment_reports_raises_unauthorized(self, browser):
+        self.login(self.regular_user, browser)
+        with browser.expect_unauthorized():
+            browser.open(self.portal.absolute_url() + '/@role-assignment-reports/report_1',
+                         method='DELETE', headers=self.api_headers)
+
+        self.assertEqual(401, browser.status_code)

--- a/opengever/base/configure.zcml
+++ b/opengever/base/configure.zcml
@@ -52,6 +52,8 @@
     <implements interface="opengever.base.interfaces.IOpengeverCatalogBrain" />
   </class>
 
+  <adapter factory=".storage.RoleAssignmentReportsStorage" />
+
   <adapter
       factory=".contentlisting.OpengeverCatalogContentListingObject"
       for="opengever.base.interfaces.IOpengeverCatalogBrain"

--- a/opengever/base/configure.zcml
+++ b/opengever/base/configure.zcml
@@ -84,6 +84,11 @@
       for="* opengever.base.interfaces.IOpengeverBaseLayer"
       />
 
+  <adapter
+      factory=".nightly_role_assignment_reports.NightlyRoleAssignmentReports"
+      name="complete-role-assignment-reports"
+      />
+
   <configure package="collective.quickupload.browser">
     <browser:page
         class="opengever.base.quickupload.OGQuickUploadView"

--- a/opengever/base/interfaces.py
+++ b/opengever/base/interfaces.py
@@ -402,3 +402,32 @@ class ITeasersSettings(Interface):
                                   default=[],
                                   value_type=schema.TextLine(),
                                   )
+
+
+class IRoleAssignmentReportsStorage(Interface):
+    """Storage abstraction for role assignment reports.
+    """
+
+    def initialize_storage():
+        """If not present already, initialize internal storage data structures.
+        """
+
+    def add(principal_id):
+        """Add a role assignment report for the given principal_id.
+        """
+
+    def get(report_uid):
+        """Return the corresponding role assignment report.
+        """
+
+    def update(report_uid, report_data):
+        """Update the corresponding role assignment report.
+        """
+
+    def list():
+        """List all role assignment reports in storage.
+        """
+
+    def delete(report_uid):
+        """Delete the corresponding role assignment report.
+        """

--- a/opengever/base/nightly_role_assignment_reports.py
+++ b/opengever/base/nightly_role_assignment_reports.py
@@ -1,0 +1,82 @@
+from opengever.base.interfaces import IRoleAssignmentReportsStorage
+from opengever.base.role_assignments import ASSIGNMENT_VIA_SHARING
+from opengever.base.role_assignments import RoleAssignmentManager
+from opengever.base.storage import STATE_IN_PROGRESS
+from opengever.base.storage import STATE_READY
+from opengever.nightlyjobs.interfaces import INightlyJobProvider
+from plone import api
+from Products.CMFPlone.interfaces import IPloneSiteRoot
+from zope.component import adapter
+from zope.component.hooks import getSite
+from zope.component.hooks import setSite
+from zope.interface import implementer
+from zope.publisher.interfaces.browser import IBrowserRequest
+import gc
+import logging
+
+
+@implementer(INightlyJobProvider)
+@adapter(IPloneSiteRoot, IBrowserRequest, logging.Logger)
+class NightlyRoleAssignmentReports(object):
+
+    def __init__(self, context, request, logger):
+        self.context = context
+        self.request = request
+        self.logger = logger
+
+        self.storage = IRoleAssignmentReportsStorage(self.context)
+        self.catalog = api.portal.get_tool('portal_catalog')
+
+    def __iter__(self):
+        return iter([el for el in self.storage.list() if el['state'] == STATE_IN_PROGRESS])
+
+    def __len__(self):
+        return len([el for el in self.storage.list() if el['state'] == STATE_IN_PROGRESS])
+
+    def collect_garbage(self, site):
+        # In order to get rid of leaking references, the Plone site needs to be
+        # re-set in regular intervals using the setSite() hook. This reassigns
+        # it to the SiteInfo() module global in zope.component.hooks, and
+        # therefore allows the Python garbage collector to cut loose references
+        # it was previously holding on to.
+        setSite(getSite())
+
+        # Trigger garbage collection for the cPickleCache
+        site._p_jar.cacheGC()
+
+        # Also trigger Python garbage collection.
+        gc.collect()
+
+        # (These two don't seem to affect the memory high-water-mark a lot,
+        # but result in a more stable / predictable growth over time.
+        #
+        # But should this cause problems at some point, it's safe
+        # to remove these without affecting the max memory consumed too much.)
+
+    def run_job(self, job, interrupt_if_necessary):
+        principalid = job['principalid']
+        reportid = job['reportid']
+        items = []
+
+        # if Anonymous or Authenticated have View permission,
+        # no other users are set in allowedRolesAndUsers
+        brains = self.catalog.unrestrictedSearchResults(
+            portal_type=['opengever.dossier.businesscasedossier',
+                         'opengever.repository.repositoryfolder',
+                         'opengever.repository.repositoryroot'],
+            allowedRolesAndUsers=[u'user:{}'.format(principalid), 'Authenticated', 'Anonymous'])
+
+        self.logger.info("Complete report %r" % reportid)
+
+        for i, brain in enumerate(brains):
+            if i % 5000 == 0:
+                self.collect_garbage(self.context)
+            obj = brain.getObject()
+            assignments = RoleAssignmentManager(obj).get_assignments_by_principal_id(principalid)
+            sharing_assignments = [assignment for assignment in assignments
+                                   if assignment.cause == ASSIGNMENT_VIA_SHARING]
+            if sharing_assignments:
+                items.append({'UID': obj.UID(), 'roles': sharing_assignments[0].roles})
+
+        report_data = {'state': STATE_READY, 'items': items}
+        self.storage.update(reportid, report_data)

--- a/opengever/base/storage.py
+++ b/opengever/base/storage.py
@@ -1,0 +1,101 @@
+from copy import deepcopy
+from DateTime import DateTime
+from opengever.base.date_time import utcnow_tz_aware
+from opengever.base.interfaces import IRoleAssignmentReportsStorage
+from opengever.ogds.base.actor import ActorLookup
+from opengever.ogds.base.actor import OGDSGroupActor
+from opengever.ogds.base.actor import OGDSUserActor
+from opengever.ogds.base.actor import PloneUserActor
+from persistent.mapping import PersistentMapping
+from plone.restapi.serializer.converters import json_compatible
+from Products.CMFPlone.interfaces import IPloneSiteRoot
+from zope.annotation import IAnnotations
+from zope.component import adapter
+from zope.interface import implementer
+
+PRINCIPAL_TYPE_GROUP = 'group'
+PRINCIPAL_TYPE_UNKNOWN = 'unknown principal'
+PRINCIPAL_TYPE_USER = 'user'
+STATE_IN_PROGRESS = 'in progress'
+STATE_READY = 'ready'
+
+
+@implementer(IRoleAssignmentReportsStorage)
+@adapter(IPloneSiteRoot)
+class RoleAssignmentReportsStorage(object):
+    """Default IRoleAssignmentReportsStorage implementation.
+
+    Stores role assignment reports in annotations on the Plone site. See interface for
+    detailed documentation.
+    """
+
+    ANNOTATIONS_KEY = 'opengever.base.role_assignment_reports'
+    STORAGE_REPORTS_KEY = 'reports'
+    STORAGE_NEXT_ID_KEY = 'next_id'
+
+    def __init__(self, context):
+        self.context = context
+
+        self._storage = None
+        self.initialize_storage()
+
+    def initialize_storage(self):
+        annotations = IAnnotations(self.context)
+        if self.ANNOTATIONS_KEY not in annotations:
+            annotations[self.ANNOTATIONS_KEY] = PersistentMapping()
+
+        self._storage = annotations[self.ANNOTATIONS_KEY]
+
+        if self.STORAGE_REPORTS_KEY not in self._storage:
+            self._storage[self.STORAGE_REPORTS_KEY] = PersistentMapping()
+        self._reports = self._storage[self.STORAGE_REPORTS_KEY]
+
+        # Counter for the next 'report_id'
+        if self.STORAGE_NEXT_ID_KEY not in self._storage:
+            self._storage[self.STORAGE_NEXT_ID_KEY] = 0
+
+    @staticmethod
+    def _get_principal_type(principalid):
+        principal = ActorLookup(principalid).lookup()
+        if isinstance(principal, (OGDSUserActor, PloneUserActor)):
+            return PRINCIPAL_TYPE_USER
+        elif isinstance(principal, OGDSGroupActor):
+            return PRINCIPAL_TYPE_GROUP
+        else:
+            return PRINCIPAL_TYPE_UNKNOWN
+
+    def add(self, principalid):
+        report_id = self._generate_report_id()
+        self._reports[report_id] = PersistentMapping({
+            'items': [],
+            'modified': json_compatible(utcnow_tz_aware()),
+            'principalid': principalid,
+            'principal_type': self._get_principal_type(principalid),
+            'reportid': report_id,
+            'state': STATE_IN_PROGRESS
+        })
+        return report_id
+
+    def update(self, report_id, report_data):
+        self._reports[report_id].update(report_data)
+        self._reports[report_id]['modified'] = json_compatible(utcnow_tz_aware())
+
+    @staticmethod
+    def _copy_report(report):
+        return deepcopy(dict(report))
+
+    def get(self, report_id):
+        # get copy of a report
+        return self._copy_report(self._reports[report_id])
+
+    def list(self):
+        reports = [self._copy_report(report) for report in self._reports.values()]
+        return sorted(reports, key=lambda k: DateTime(k['modified']), reverse=True)
+
+    def delete(self, report_id):
+        del self._reports[report_id]
+
+    def _generate_report_id(self):
+        new_id = self._storage[self.STORAGE_NEXT_ID_KEY]
+        self._storage[self.STORAGE_NEXT_ID_KEY] += 1
+        return 'report_' + str(new_id)

--- a/opengever/base/tests/test_copy_paste.py
+++ b/opengever/base/tests/test_copy_paste.py
@@ -574,6 +574,8 @@ class TestCopyPastePermissionHandling(IntegrationTestCase):
         assignment_class = RoleAssignment.registry[assignment_type]
 
         self.login(self.administrator, browser=browser)
+        manager = RoleAssignmentManager(self.subsubdossier)
+        assignments = manager.clear_all()
 
         browser.open(self.dossier,
                      data=self.make_path_param(self.subdossier), view="copy_items")
@@ -606,6 +608,8 @@ class TestCopyPastePermissionHandling(IntegrationTestCase):
         assignment_class = RoleAssignment.registry[assignment_type]
 
         self.login(self.administrator, browser=browser)
+        manager = RoleAssignmentManager(self.subsubdossier)
+        assignments = manager.clear_all()
 
         browser.open(self.dossier,
                      data=self.make_path_param(self.subdossier), view="copy_items")

--- a/opengever/base/tests/test_nightly_role_assignment_reports.py
+++ b/opengever/base/tests/test_nightly_role_assignment_reports.py
@@ -1,0 +1,66 @@
+from opengever.base.interfaces import IRoleAssignmentReportsStorage
+from opengever.base.nightly_role_assignment_reports import NightlyRoleAssignmentReports
+from opengever.base.role_assignments import ASSIGNMENT_VIA_SHARING
+from opengever.base.role_assignments import RoleAssignmentManager
+from opengever.base.storage import STATE_IN_PROGRESS
+from opengever.base.storage import STATE_READY
+from opengever.testing import IntegrationTestCase
+from opengever.testing.helpers import CapturingLogHandler
+from plone.uuid.interfaces import IUUID
+import logging
+
+
+class TestNightlyRoleAssignmentReports(IntegrationTestCase):
+
+    features = ('nightly-jobs', )
+
+    def execute_nightly_jobs(self):
+
+        # Create a logging setup similar to cronjob scenario
+        nightly_logger = logging.getLogger('opengever.nightlyjobs')
+        nightly_logger.setLevel(logging.INFO)
+        nightly_log_handler = CapturingLogHandler()
+        nightly_logger.addHandler(nightly_log_handler)
+
+        nightly_job_provider = NightlyRoleAssignmentReports(
+            self.portal, self.request, nightly_logger)
+
+        jobs = list(nightly_job_provider)
+
+        for job in jobs:
+            nightly_job_provider.run_job(job, None)
+        return [(r.name, r.msg) for r in nightly_log_handler.records]
+
+    def test_nightly_role_assignment_reports(self):
+        self.login(self.administrator)
+
+        manager = RoleAssignmentManager(self.empty_dossier)
+        manager.add_or_update(self.meeting_user.getId(), ['Editor', 'Contributor', 'Reader'],
+                              ASSIGNMENT_VIA_SHARING)
+        manager = RoleAssignmentManager(self.repository_root)
+        manager.add_or_update(self.meeting_user.getId(), ['Contributor', 'Reader', 'Publisher'],
+                              ASSIGNMENT_VIA_SHARING)
+        manager = RoleAssignmentManager(self.leaf_repofolder)
+        manager.add_or_update(self.meeting_user.getId(), ['Reviewer'],
+                              ASSIGNMENT_VIA_SHARING)
+
+        storage = IRoleAssignmentReportsStorage(self.portal)
+
+        reportid = storage.add(self.meeting_user.getId())
+        report = storage.get(reportid)
+        self.assertEqual(STATE_IN_PROGRESS, report['state'])
+        self.assertEqual([], report['items'])
+
+        logrecords = self.execute_nightly_jobs()
+        self.assertIn(('opengever.nightlyjobs', "Complete report '{}'".format(reportid)),
+                      logrecords)
+
+        report = storage.get('report_2')
+        self.assertEqual(STATE_READY, report['state'])
+        self.assertEqual(
+            [{'UID': IUUID(self.repository_root),
+              'roles': ['Contributor', 'Reader', 'Publisher']},
+             {'UID': IUUID(self.leaf_repofolder),
+              'roles': ['Reviewer']},
+             {'UID': IUUID(self.empty_dossier),
+              'roles': ['Editor', 'Contributor', 'Reader']}], report['items'])

--- a/opengever/base/tests/test_storage.py
+++ b/opengever/base/tests/test_storage.py
@@ -1,0 +1,122 @@
+from datetime import datetime
+from ftw.testing import freeze
+from opengever.base.interfaces import IRoleAssignmentReportsStorage
+from opengever.base.storage import PRINCIPAL_TYPE_USER
+from opengever.base.storage import STATE_IN_PROGRESS
+from opengever.base.storage import STATE_READY
+from opengever.testing import IntegrationTestCase
+from plone.uuid.interfaces import IUUID
+
+
+class TestRoleAssignmentReportsStorage(IntegrationTestCase):
+    maxDiff = None
+
+    def setUp(self):
+        super(TestRoleAssignmentReportsStorage, self).setUp()
+        self.storage = IRoleAssignmentReportsStorage(self.portal)
+        self.login(self.administrator.getId())
+
+    def test_list_reports(self):
+        self.assertEqual(
+            [{'items': [],
+              'modified': u'2016-08-31T20:01:33+00:00',
+              'principal_type': PRINCIPAL_TYPE_USER,
+              'principalid': self.regular_user.getId(),
+              'reportid': 'report_1',
+              'state': STATE_IN_PROGRESS},
+             {'items': [{'UID': IUUID(self.repository_root),
+                         'roles': ['Contributor']},
+                        {'UID': IUUID(self.empty_repofolder),
+                         'roles': ['Contributor', 'Publisher']},
+                        {'UID': IUUID(self.subsubdossier),
+                         'roles': ['Reader', 'Editor', 'Reviewer']}],
+              'modified': u'2016-08-31T20:01:33+00:00',
+              'principal_type': PRINCIPAL_TYPE_USER,
+              'principalid': self.archivist.getId(),
+              'reportid': 'report_0',
+              'state': STATE_READY}], self.storage.list())
+
+    def test_get_report(self):
+        report = self.storage.get('report_0')
+        self.assertEqual(
+            {'items': [{'UID': IUUID(self.repository_root),
+                        'roles': ['Contributor']},
+                       {'UID': IUUID(self.empty_repofolder),
+                        'roles': ['Contributor', 'Publisher']},
+                       {'UID': IUUID(self.subsubdossier),
+                        'roles': ['Reader', 'Editor', 'Reviewer']}],
+             'modified': u'2016-08-31T20:01:33+00:00',
+             'principal_type': PRINCIPAL_TYPE_USER,
+             'principalid': self.archivist.getId(),
+             'reportid': 'report_0',
+             'state': STATE_READY}, report)
+
+        report = self.storage.get('report_1')
+        self.assertEqual(
+            {'items': [],
+             'modified': u'2016-08-31T20:01:33+00:00',
+             'principal_type': PRINCIPAL_TYPE_USER,
+             'principalid': self.regular_user.getId(),
+             'reportid': 'report_1',
+             'state': STATE_IN_PROGRESS}, report)
+
+    def test_delete_report(self):
+        self.storage.get('report_1')
+        self.storage.delete('report_1')
+
+        with self.assertRaises(KeyError):
+            self.storage.get('report_1')
+
+    def test_add_report(self):
+        with freeze(datetime(2018, 4, 30)):
+            reportid = self.storage.add(self.administrator.getId())
+
+        self.assertEqual(
+            {'items': [],
+             'state': STATE_IN_PROGRESS,
+             'modified': '2018-04-30T00:00:00+00:00',
+             'principal_type': PRINCIPAL_TYPE_USER,
+             'principalid': self.administrator.getId(),
+             'reportid': reportid}, self.storage.get(reportid))
+
+    def test_add_two_reports_for_the_same_principal(self):
+        with freeze(datetime(2018, 4, 30)) as clock:
+            reportid_1 = self.storage.add(self.administrator.getId())
+            clock.forward(days=2)
+            reportid_2 = self.storage.add(self.administrator.getId())
+
+        self.assertEqual(
+            [{'items': [],
+              'modified': u'2018-05-02T00:00:00+00:00',
+              'principal_type': PRINCIPAL_TYPE_USER,
+              'principalid': self.administrator.getId(),
+              'reportid': reportid_2,
+              'state': STATE_IN_PROGRESS},
+             {'items': [],
+              'modified': u'2018-04-30T00:00:00+00:00',
+              'principal_type': PRINCIPAL_TYPE_USER,
+              'principalid': self.administrator.getId(),
+              'reportid': reportid_1,
+              'state': STATE_IN_PROGRESS}], self.storage.list()[:2])
+
+    def test_update_report(self):
+        with freeze(datetime(2018, 4, 30)):
+            self.storage.update('report_1', {
+                'state': STATE_READY,
+                'items': [{
+                    'UID': IUUID(self.repository_root),
+                    'roles': ['Contributor']}]})
+
+        self.assertEqual(
+            {'items': [{'UID': IUUID(self.repository_root),
+                        'roles': ['Contributor']}],
+             'modified': u'2018-04-30T00:00:00+00:00',
+             'principal_type': PRINCIPAL_TYPE_USER,
+             'principalid': self.regular_user.getId(),
+             'reportid': 'report_1',
+             'state': STATE_READY}, self.storage.get('report_1'))
+
+    def test_new_reportid_is_based_on_a_counter_in_storage(self):
+        self.storage._storage['next_id'] = 42
+        self.storage.add(self.administrator.getId())
+        self.assertEqual(43, self.storage._storage['next_id'])

--- a/opengever/core/lawgiver.zcml
+++ b/opengever/core/lawgiver.zcml
@@ -234,6 +234,13 @@
                    "
       />
 
+  <!-- Manage Role Assignment Reports is only managed globally in rolemap.xml. -->
+  <lawgiver:ignore
+      permissions="
+                   opengever.api: Manage Role Assignment Reports,
+                   "
+      />
+
   <!-- Ignore default Plone permissions. This means we are not managing in the
        workflows. This does not mean that the permissions are disabled: disabling
        can be done in the rolemap.xml. -->

--- a/opengever/core/profiles/default/rolemap.xml
+++ b/opengever/core/profiles/default/rolemap.xml
@@ -63,6 +63,11 @@
       <role name="Administrator" />
     </permission>
 
+    <permission name="opengever.api: Manage Role Assignment Reports" acquire="False">
+      <role name="Manager" />
+      <role name="Administrator" />
+    </permission>
+
     <!-- CMFEDITIONS -->
     <permission name="CMFEditions: Save new version" acquire="True">
       <role name="Administrator" />

--- a/opengever/core/upgrades/20200702172053_assign_role_assignment_reports_permission/rolemap.xml
+++ b/opengever/core/upgrades/20200702172053_assign_role_assignment_reports_permission/rolemap.xml
@@ -1,0 +1,8 @@
+<rolemap>
+  <permissions>
+    <permission name="opengever.api: Manage Role Assignment Reports" acquire="False">
+      <role name="Manager" />
+      <role name="Administrator" />
+    </permission>
+  </permissions>
+</rolemap>

--- a/opengever/core/upgrades/20200702172053_assign_role_assignment_reports_permission/upgrade.py
+++ b/opengever/core/upgrades/20200702172053_assign_role_assignment_reports_permission/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AssignRoleAssignmentReportsPermission(UpgradeStep):
+    """Assign role assignment reports permission.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/dossier/tests/test_protect_dossier.py
+++ b/opengever/dossier/tests/test_protect_dossier.py
@@ -349,7 +349,7 @@ class TestProtectDossier(IntegrationTestCase):
         self.assertItemsEqual(
             ['Administrator', 'Contributor', 'Editor', 'Manager', 'Reader',
              'user:fa_users', 'user:{}'.format(self.regular_user.getId()),
-             'user:fa_inbox_users'],
+             'user:fa_inbox_users', 'user:{}'.format(self.archivist)],
             self.get_allowed_roles_and_users_for(self.dossier))
 
         dossier_protector = IProtectDossier(self.dossier)

--- a/opengever/repository/tests/test_excel_export.py
+++ b/opengever/repository/tests/test_excel_export.py
@@ -26,7 +26,7 @@ class TestRepositoryRootExcelExport(IntegrationTestCase):
                 '_type': u'opengever.repository.repositoryroot',
                 u'Blocked inheritance': u'No',
                 u'Close dossiers': u'jurgen.konig',
-                u'Create dossiers': u'fa_users',
+                u'Create dossiers': u'jurgen.fischer,fa_users',
                 u'Edit dossiers': u'fa_users',
                 u'label_archival_value_annotation': u'',
                 u'label_archival_value': u'',


### PR DESCRIPTION
An administrator wants to know what local roles a user or group has.
This PR makes it possible to create role assignment reports.

With the API endpoint `@role-assignment-reports` a report can be created. This is stored in the `RoleAsssignmentReportsStorage` with the status "in progress".
In a nightly job, all local roles of a Principal are collected and the report is completed with them. The report then has the status "ready".

Definition of Done: https://4teamwork.atlassian.net/wiki/spaces/CHX4TW/pages/917562/

Jira: https://4teamwork.atlassian.net/browse/GEVER-33

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


## Checklist (if applicable)

_Only applicable should be left and checked._

- API change:
  - [x] Documentation is updated