### PR TITLE
Fix javascript ordering.

### DIFF
--- a/opengever/core/profiles/default/jsregistry.xml
+++ b/opengever/core/profiles/default/jsregistry.xml
@@ -307,9 +307,9 @@
       cookable="True"
       expression=""
       enabled="True"
-      id="++resource++opengever.base/teaser.js"
+      id="++resource++opengever.base/base.js"
       inline="False"
-      insert-before="++resource++opengever.base/base.js"
+      insert-after="++resource++ftw.keywordwidget/js/keywordwidget.js"
       />
 
   <javascript
@@ -318,9 +318,9 @@
       cookable="True"
       expression=""
       enabled="True"
-      id="++resource++opengever.base/base.js"
+      id="++resource++opengever.base/teaser.js"
       inline="False"
-      insert-after="++resource++ftw.keywordwidget/js/keywordwidget.js"
+      insert-before="++resource++opengever.base/base.js"
       />
 
   <javascript


### PR DESCRIPTION
This is a follow-up to In https://github.com/4teamwork/opengever.core/pull/6536

`teaser.js` got inserted at the beginning of the registry instead of just before `opengever.base.js`. This led to new deployments and the testserver being broken. The insertion did not work as expected because `teaser.js` got inserted before `opengever.base.js`, then the `insert-before` dose not find the position of the element it should insert before and defaults to beginning of the registry: https://github.com/plone/Products.ResourceRegistries/blob/master/Products/ResourceRegistries/tools/BaseRegistry.py#L842-L844

Simply making sure `opengever.base.js` appears before `teaser.js` in opengever/core/profiles/default/jsregistry.xml is therefore enough.

For https://4teamwork.atlassian.net/browse/GEVER-552

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry: No changelog entry, as this is in the same version as the commit that introduced the issue
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

