### PR TITLE
Handle wildcard in date filters in listing endpoint.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,7 @@ Changelog
 2020.6.0 (unreleased)
 ---------------------
 
-- Nothing changed yet.
+- Handle wildcard in date filters in listing endpoint. [njohner]
 
 
 2020.5.0 (2020-07-14)

--- a/docs/public/dev-manual/api/listings.rst
+++ b/docs/public/dev-manual/api/listings.rst
@@ -363,3 +363,9 @@ Mit ``filters.last_login:record:list`` kann nach dem Zeitpunkt des letzten Login
     GET /kontakte/@ogds-user-listing?filters.last_login:record:list=2020-05-27%20TO%202020-06-02 HTTP/1.1
     Accept: application/json
 
+**Beispiel: Filtern nach Benutzer mit Datum des letzten Logins nach dem 27.5.2020**
+
+  .. sourcecode:: http
+
+    GET /kontakte/@ogds-user-listing?filters.last_login:record:list=2020-05-27%20TO%20* HTTP/1.1
+    Accept: application/json


### PR DESCRIPTION
Date filters in the `@listing` endpoint did not handle wildcards. We now correctly handle wildcards in these filters.
Note that we have also changed the error handling. The status before was that:
- If no range was provided the code would simply fail with `UnboundLocalError` (https://sentry.4teamwork.ch/sentry/onegov-gever/?query=is%3Aunresolved+UnboundLocalError%3A+local+variable+%27date_from%27+referenced+before+assignment)
- if parsing failed, it would be silently ignored and return no results.

Now when parsing fails it will return an appropriate `Bad Request` error

Not sure whether we should consider that braking. It feels more like fixing a bug to me.

For https://4teamwork.atlassian.net/browse/GEVER-624

## Checklist (Must have)

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

## Checklist (if applicable)

_Only applicable should be left and checked._

- API change:
  - [x] Documentation is updated
  - If breaking:
    - [ ] api-change label added
    - [ ] Scrum master is informed