### PR TITLE
Handle errors in solrsearch endpoint.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -8,6 +8,7 @@ Changelog
 - Allow workspace members to trash and untrash documents in workspaces. [tinagerber]
 - Handle wildcard in date filters in listing endpoint. [njohner]
 - Handle multiple content interfaces in @navigation endpoint. [njohner]
+- Handle errors in solrsearch endpoint. [njohner]
 
 
 2020.5.0 (2020-07-14)

--- a/opengever/api/solrsearch.py
+++ b/opengever/api/solrsearch.py
@@ -4,6 +4,7 @@ from opengever.api.solr_query_service import SolrQueryBaseService
 from opengever.base.interfaces import ISearchSettings
 from plone import api
 from zExceptions import BadRequest
+from zExceptions import InternalError
 
 BLACKLISTED_ATTRIBUTES = set([
     'getDataOrigin',
@@ -99,6 +100,9 @@ class SolrSearchGet(SolrQueryBaseService):
         resp = self.solr.search(
             query=query, filters=filters, start=start, rows=rows, sort=sort,
             fl=field_list, **params)
+
+        if not resp.is_ok():
+            raise InternalError(resp.error_msg())
 
         res = {
             "items": self.prepare_response_items(resp),

--- a/opengever/api/tests/test_solrsearch.py
+++ b/opengever/api/tests/test_solrsearch.py
@@ -47,6 +47,15 @@ class TestSolrSearchGet(SolrIntegrationTestCase):
              u'type': u'BadRequest'}, browser.json)
 
     @browsing
+    def test_raises_internal_error_for_invalid_queries(self, browser):
+        self.login(self.regular_user, browser=browser)
+        with browser.expect_http_error(500):
+            url = u'{}/@solrsearch?q=OR'.format(self.portal.absolute_url())
+            browser.open(url, method='GET', headers=self.api_headers)
+
+        self.assertEqual(u'InternalError', browser.json['type'])
+
+    @browsing
     def test_simple_search_query(self, browser):
         self.login(self.regular_user, browser=browser)
 


### PR DESCRIPTION
Since https://github.com/4teamwork/opengever.core/pull/6499, errors when querying solr will be logged to sentry.
This notably happens for invalid queries that solr cannot parse. While it would be better to avoid actually sending invalid queries to solr, it is complex and would first need us to establish what is the behaviour we expect and what type of user queries we want to support. This will be done in a further step (https://4teamwork.atlassian.net/browse/GEVER-752)

For now, when the search fails on the solr side, we need to at least raise an error in the solrsearch endpoint, so that
the gever-ui can handle such errors. This changes the behaviour of when a query becomes invalid in the `LiveSearch`. Before it would suddenly show no results when a query becomes invalid (try typing "test OR" on dev.onegovgever.ch/fd), now it will keep the last set of results when the query becomes invalid (see https://github.com/4teamwork/gever-ui/blob/master/src/components/Livesearch.vue#L104-L109).

For https://4teamwork.atlassian.net/browse/GEVER-687

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
