### PR TITLE
Handle multiple content interfaces in @navigation endpoint.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 
 - Allow workspace members to trash and untrash documents in workspaces. [tinagerber]
 - Handle wildcard in date filters in listing endpoint. [njohner]
+- Handle multiple content interfaces in @navigation endpoint. [njohner]
 
 
 2020.5.0 (2020-07-14)

--- a/opengever/api/navigation.py
+++ b/opengever/api/navigation.py
@@ -104,16 +104,22 @@ class Navigation(object):
         The interfaces provided in `content_interfaces` are used as navigation
         items.
         """
-        interface = self.request.form.get('content_interfaces')
-        try:
-            content_interfaces = self._lookup_iface_by_identifier(
-                interface) or IRepositoryFolder
-        except ImportError:
-            raise BadRequest("The provided `content_interfaces` could not be "
-                             "looked up: {}".format(interface))
+        interfaces = self.request.form.get('content_interfaces')
+        if not interfaces:
+            return [IRepositoryFolder]
 
-        return content_interfaces if isinstance(content_interfaces, list) \
-            else [content_interfaces]
+        if not isinstance(interfaces, list):
+            interfaces = [interfaces]
+
+        content_interfaces = []
+        for interface in interfaces:
+            try:
+                content_interfaces.append(
+                    self._lookup_iface_by_identifier(interface))
+            except ImportError:
+                raise BadRequest("The provided `content_interfaces` could not be "
+                                 "looked up: {}".format(interface))
+        return content_interfaces
 
     def brain_to_node(self, brain):
         node = {

--- a/opengever/api/tests/test_navigation.py
+++ b/opengever/api/tests/test_navigation.py
@@ -111,6 +111,26 @@ class TestNavigation(IntegrationTestCase):
             [item.get('uid') for item in items])
 
     @browsing
+    def test_navigation_handles_multiple_content_interfaces(self, browser):
+        self.login(self.workspace_member, browser)
+        params = [
+            ('root_interface', 'opengever.workspace.interfaces.IWorkspaceRoot'),
+            ('content_interfaces', 'opengever.workspace.interfaces.IWorkspace'),
+            ('content_interfaces', 'opengever.workspace.interfaces.IWorkspaceFolder')
+        ]
+        browser.open(
+            self.workspace.absolute_url() + '/@navigation?{}'.format(urlencode(params)),
+            headers={'Accept': 'application/json'},
+        )
+        self.assertEqual(browser.status_code, 200)
+
+        items = flatten_tree(browser.json.get('tree'))
+
+        self.assertEqual(
+            [self.workspace.UID(), self.workspace_folder.UID()],
+            [item.get('uid') for item in items])
+
+    @browsing
     def test_lookup_propper_root_if_root_interface_is_within_content_interfaces(self, browser):
         self.login(self.workspace_member, browser)
         params = [


### PR DESCRIPTION
The `@navigation` endpoint should allow to specify a list of interfaces used to query for the contents to display (`content interfaces`). The current implementation only handled the case of a single interface. We now extend the endpoint to correctly handle  multiple `content_interfaces`.

This will allow to also display the `WorkspaceFolder`s in the navigation for workspaces in the the new UI.

For: https://4teamwork.atlassian.net/browse/GEVER-532

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

## Checklist (if applicable)

_Only applicable should be left and checked._

- API change:
  - [ ] Documentation is updated