### PR TITLE
Fix createContentInContainer to respect behaviors.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 ---------------------
 
 - Fix id normalization when setting up a repository. [tinagerber]
+- Fix createContentInContainer to respect behaviors. [njohner]
 - Allow workspace members to trash and untrash documents in workspaces. [tinagerber]
 - Handle wildcard in date filters in listing endpoint. [njohner]
 - Handle multiple content interfaces in @navigation endpoint. [njohner]

--- a/opengever/api/scanin.py
+++ b/opengever/api/scanin.py
@@ -78,7 +78,7 @@ class ScanIn(Service):
                 obj = createContentInContainer(
                     private_folder,
                     'opengever.private.dossier',
-                    title='Scaneingang')
+                    title=u'Scaneingang')
                 return obj
 
         return self.error(

--- a/opengever/base/tests/test_command.py
+++ b/opengever/base/tests/test_command.py
@@ -1,6 +1,11 @@
 from opengever.base.command import CreateDocumentCommand
 from opengever.base.command import CreateEmailCommand
+from opengever.document.behaviors.related_docs import IRelatedDocuments
 from opengever.testing import IntegrationTestCase
+from z3c.relationfield.relation import RelationValue
+from zope.annotation.interfaces import IAnnotations
+from zope.component import getUtility
+from zope.intid.interfaces import IIntIds
 
 
 class MockMsg2MimeTransform(object):
@@ -37,3 +42,16 @@ class TestCreateDocumentCommand(IntegrationTestCase):
         self.assertEqual(u'\xdcnicode', document.title)
         self.assertEqual('buh!', document.file.data)
         self.assertEqual('text/plain', document.file.contentType)
+
+    def test_create_document_from_command_respects_behaviors(self):
+        self.login(self.regular_user)
+
+        relation = RelationValue(getUtility(IIntIds).getId(self.subdocument))
+        command = CreateDocumentCommand(
+            self.dossier, 'testm\xc3\xa4il.txt', 'buh!', relatedItems=[relation])
+        document = command.execute()
+
+        self.assertIn(
+            'opengever.document.behaviors.related_docs.IRelatedDocuments.relatedItems',
+            IAnnotations(document))
+        self.assertIn(relation, IRelatedDocuments(document).relatedItems)

--- a/opengever/bundle/sections/constructor.py
+++ b/opengever/bundle/sections/constructor.py
@@ -89,7 +89,7 @@ class ConstructorSection(object):
         title_args = {}
         for key in title_keys:
             value = item.get(key)
-            if value and not isinstance(value, unicode):
+            if value is not None and not isinstance(value, unicode):
                 value = value.decode('utf-8')
 
             title_args[key] = value

--- a/opengever/document/forms.py
+++ b/opengever/document/forms.py
@@ -254,7 +254,7 @@ class SavePDFUnderForm(form.Form):
                 if name in fields_to_skip:
                     continue
                 field_instance = schema_field.bind(self.context)
-                metadata[name] = field_instance.get(self.context)
+                metadata[name] = field_instance.get(field_instance.interface(self.context))
 
         command = CreateDocumentCommand(self.destination, None, None, **metadata)
         destination_document = command.execute()

--- a/opengever/document/tests/test_save_pdf_under.py
+++ b/opengever/document/tests/test_save_pdf_under.py
@@ -3,14 +3,14 @@ from ftw.testbrowser import browsing
 from ftw.testbrowser.pages import statusmessages
 from opengever.base.security import elevated_privileges
 from opengever.document.archival_file import STATE_CONVERTED
-from opengever.document.behaviors.related_docs import IRelatedDocuments
 from opengever.document.behaviors.metadata import IDocumentMetadata
-from opengever.document.versioner import Versioner
+from opengever.document.behaviors.related_docs import IRelatedDocuments
 from opengever.document.browser.save_pdf_document_under import PDF_SAVE_OWNER_ID_KEY
 from opengever.document.browser.save_pdf_document_under import PDF_SAVE_SOURCE_UUID_KEY
 from opengever.document.browser.save_pdf_document_under import PDF_SAVE_STATUS_KEY
 from opengever.document.browser.save_pdf_document_under import PDF_SAVE_TOKEN_KEY
 from opengever.document.browser.save_pdf_document_under import SavePDFDocumentUnder
+from opengever.document.versioner import Versioner
 from opengever.testing import IntegrationTestCase
 from plone.uuid.interfaces import IUUID
 from zope.annotation import IAnnotations


### PR DESCRIPTION
We fix `createContentInContainer` to respect behaviors. This has been fixed in `plone.dexterity` in version 2.2.0 (https://github.com/plone/plone.dexterity/pull/17) but never made its way into our `MonkeyPatch` (see https://github.com/plone/plone.dexterity/pull/17). Note that it was fixed several times in `plone.dexterity`, but never quite correctly. The current implementation (https://github.com/plone/plone.dexterity/blob/master/plone/dexterity/utils.py#L133-L150) is still fragile, relying on `getattr` to decide whether a certain field is part of a given schema. This has two problems:
- This does not really test whether the field is part of a given behavior, but only whether the field exist in the storage of that behavior (so it could be part of another behavior using the same schema)
- If at any point an attribute was persisted in the wrong storage (for example `relatedItems` stored on the object instead of in the annotations), this implementation will think that this is the storage where that field should indeed be saved.

So we actually write our own implementation of `createContentInContainer`, which uses the behaviors themselves (the schemata) as source of truth.

This bug in `createContentInContainer` leads to problems for PHVS and their custom behaviors, which are stored in the annotations (https://github.com/4teamwork/opengever.phvs/blob/master/opengever/phvs/configure.zcml#L87-L94) and which were stored on the newly created object when saving a document as pdf (`SavePDFUnderForm`). This leads to the values not getting indexed correctly.

Moreover there was a second issue this time in `SavePDFUnderForm`, where we did not correctly get the data over the behaviors on the source document. This data is then used to created the new PDF document, which would also lead to missing data on the created document (although not in deployments with no custom behavior).

For https://4teamwork.atlassian.net/browse/GEVER-678

## Checklist (Must have)

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
