### PR TITLE
Fix id normalization when setting up a repository.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2020.6.0 (unreleased)
 ---------------------
 
+- Fix id normalization when setting up a repository. [tinagerber]
 - Allow workspace members to trash and untrash documents in workspaces. [tinagerber]
 - Handle wildcard in date filters in listing endpoint. [njohner]
 

--- a/opengever/setup/sections/reference.py
+++ b/opengever/setup/sections/reference.py
@@ -125,10 +125,10 @@ class PathFromReferenceNumberSection(object):
         # Avoid id conflicts
         parent = traverse(self.context, parent_path)
         chooser = INameChooser(parent)
-        if not chooser.checkName(title.encode('utf-8'), parent):
+        if not chooser.checkName(normalized_id, parent):
             # namechooser expect the object itself as second paremter, but it's
             # only used for getting the request, therefore we use the parent.
-            normalized_id = INameChooser(parent).chooseName(
+            normalized_id = chooser.chooseName(
                 normalized_id, parent)
 
         return normalized_id


### PR DESCRIPTION
When setting up a repository, the system incorrectly checked whether the title of an item already exists instead of checking whether the normalized title already exists.

Jira: https://4teamwork.atlassian.net/browse/GEVER-460

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)