### PR TITLE
Fix @workflow when no permissions in target state.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -8,6 +8,7 @@ Changelog
 - Always return @id in navigation endpoint when not expanding. [njohner]
 - Allow deletion of documents only if they are in the trash. [tinagerber]
 - Add portal_url to configuration endpoint and view. [njohner]
+- Fix transitions via @workflow service when executing user has no permission in target state. [tinagerber, deiferni]
 - Fix id normalization when setting up a repository. [tinagerber]
 - Fix createContentInContainer to respect behaviors. [njohner]
 - Add watchers solr field and indexers, currently for tasks only. [deiferni]

--- a/opengever/api/tests/test_workflow.py
+++ b/opengever/api/tests/test_workflow.py
@@ -72,3 +72,40 @@ class TestWorkflowPost(IntegrationTestCase):
              u'review_state': u'document-state-removed'},
             browser.json
         )
+
+    @browsing
+    def test_calling_endpoint_without_transition_gives_400(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        with browser.expect_http_error(code=400):
+            browser.open(
+                self.dossier.absolute_url() + '/@workflow',
+                method='POST', headers=self.api_headers)
+
+        self.assertEqual('Bad Request', browser.json['error']['type'])
+        self.assertIn(u"Invalid transition 'None'",
+                      browser.json['error']['message'])
+
+    @browsing
+    def test_calling_workflow_with_additional_path_segments_results_in_404(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        with browser.expect_http_error(code=404):
+            browser.open(
+                self.dossier.absolute_url() + '/@workflow/dossier-transition-resolve/invalid',
+                method='POST', headers=self.api_headers)
+
+        self.assertEqual('NotFound', browser.json['type'])
+
+    @browsing
+    def test_invalid_transition_results_in_400(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        with browser.expect_http_error(code=400):
+            browser.open(
+                self.dossier.absolute_url() + '/@workflow/invalid-transition',
+                method='POST', headers=self.api_headers)
+
+        self.assertEqual('Bad Request', browser.json['error']['type'])
+        self.assertIn(u"Invalid transition 'invalid-transition'",
+                      browser.json['error']['message'])

--- a/opengever/api/tests/test_workflow.py
+++ b/opengever/api/tests/test_workflow.py
@@ -1,0 +1,74 @@
+from ftw.testbrowser import browsing
+from opengever.testing import IntegrationTestCase
+from opengever.trash.trash import ITrashable
+import json
+
+
+class TestWorkflowPost(IntegrationTestCase):
+
+    @browsing
+    def test_transition_reassigning_task_and_revoking_users_permissions_can_be_executed(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        data = {
+            'responsible': {
+                'token': 'rk:{}'.format(self.dossier_responsible.getId())
+            }
+        }
+        # this reassigns the task so that `regular_user` no longer has access
+        browser.open(
+            self.task_in_protected_dossier.absolute_url() + '/@workflow/task-transition-reassign',
+            json.dumps(data), method='POST', headers=self.api_headers
+        )
+
+        self.assertDictContainsSubset(
+            {u'title': u'task-state-in-progress',
+             u'actor': u'kathi.barfuss',
+             u'action': u'task-transition-reassign',
+             u'review_state': u'task-state-in-progress'},
+            browser.json
+        )
+
+    @browsing
+    def test_transition_close_task_and_revoking_users_permissions_can_be_executed(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        # only direct execution tasks can be closed directly
+        self.task_in_protected_dossier.task_type = 'direct-execution'
+
+        # this closes the task so that `regular_user` no longer has access
+        browser.open(
+            self.task_in_protected_dossier.absolute_url() + '/@workflow/task-transition-in-progress-tested-and-closed',
+            method='POST', headers=self.api_headers
+        )
+
+        self.assertDictContainsSubset(
+            {u'title': u'task-state-tested-and-closed',
+             u'actor': u'kathi.barfuss',
+             u'action': u'task-transition-in-progress-tested-and-closed',
+             u'review_state': u'task-state-tested-and-closed'},
+            browser.json
+        )
+
+    @browsing
+    def test_transition_remove_document_and_revoking_users_permission_can_be_executed(self, browser):
+        self.login(self.manager)
+        # allow `regular_user` to remove gever content
+        self.portal.manage_permission(
+            'Remove GEVER content', roles=['Editor'], acquire=True)
+
+        self.login(self.regular_user, browser=browser)
+        ITrashable(self.document).trash()
+        # this soft-deletes the document so that `regular_user` no longer has
+        # access
+        browser.open(
+            self.document.absolute_url() + '/@workflow/document-transition-remove',
+            method='POST', headers=self.api_headers)
+
+        self.assertDictContainsSubset(
+            {u'title': u'document-state-removed',
+             u'actor': u'kathi.barfuss',
+             u'action': u'document-transition-remove',
+             u'review_state': u'document-state-removed'},
+            browser.json
+        )


### PR DESCRIPTION
Fix executing workflow transitions via @workflow service when the executing user has no permission in target state on the context for which the transition is executed.

This is done by accessing `review_history` with elevated privileges, if necessary.

There is an issue in the `WorkflowTransition` service when the user performs a transition into a state where his access is revoked. The service will raise a `WorkflowException` when attempting to access `review_history` while rendering the response. This will prevent the transition from being executed.

We work around this issue when we catch a `WorkflowException` and attempt to read the history with elevated privileges.

For https://4teamwork.atlassian.net/browse/GEVER-755.

I am of the opinion that this is a `plone.restapi` issue, as the issue surfaces whenever `review_history` is protected with a `guard-permission`, but the executing user no longer has those permission in the target state. Example in https://github.com/4teamwork/opengever.core/blob/47a8673419f7c56ab542a9577c1269fbac7c0195/opengever/document/upgrades/20160914162259_add_shadow_document_state/workflows/opengever_document_workflow/definition.xml#L334-L335. At the moment `plone.restapi` would no longer be able to execute these transitions but instead fail with a traceback.

Sentry: https://sentry.4teamwork.ch/sentry/onegov-gever/issues/53693

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
