### PR TITLE
Always return @id in navigation endpoint when not expanding.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2020.6.0 (unreleased)
 ---------------------
 
+- Always return @id in navigation endpoint when not expanding. [njohner]
 - Add portal_url to configuration endpoint and view. [njohner]
 - Fix id normalization when setting up a repository. [tinagerber]
 - Fix createContentInContainer to respect behaviors. [njohner]

--- a/opengever/api/navigation.py
+++ b/opengever/api/navigation.py
@@ -32,6 +32,15 @@ class Navigation(object):
 
         context = self.context
 
+        result = {
+            'navigation': {
+                '@id': '{}/@navigation'.format(context.absolute_url()),
+            },
+        }
+
+        if not expand:
+            return result
+
         if root_interface not in content_interfaces:
             while (not root_interface.providedBy(context)
                    and not IPloneSiteRoot.providedBy(context)):
@@ -57,19 +66,8 @@ class Navigation(object):
             if roots:
                 root = roots[0].getObject()
             else:
-                # when on a teamraum deployment with no repository, no root
-                # is found. As a temporary fix we return no navigation in these
-                # cases.
-                root = None
-                return {'navigation': {}}
-
-        result = {
-            'navigation': {
-                '@id': '{}/@navigation'.format(root.absolute_url()),
-            },
-        }
-        if not expand:
-            return result
+                raise BadRequest("No root found for interface: {}".format(
+                    root_interface.__identifier__))
 
         items = api.content.find(
             object_provides=content_interfaces,


### PR DESCRIPTION
When getting a context over the API, the @id of the navigation endpoint should always be returned, even if no root is found with the default root_interface. Otherwise it would require to always specify the root_interface for every get on every context for a Teamraum deployment.

It did also not make sense to go to the trouble of finding the root when we are not expanding the `navigation`. If the user then makes a request on the `@navigation` endpoint, we will search for the root at that moment anyway. I think it's actually a rather unexpected behavior that in a GET of a context, for example a dossier, we get back the the URL to get the navigation of the root, i.e. the repository root.

For https://4teamwork.atlassian.net/browse/GEVER-532

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

## Checklist (if applicable)

_Only applicable should be left and checked._

- API change:
  - [ ] Documentation is updated
  - If breaking:
    - [ ] api-change label added
    - [ ] Scrum master is informed