### PR TITLE
WOPI enhancements

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -16,6 +16,7 @@ Changelog
 - Handle wildcard in date filters in listing endpoint. [njohner]
 - Handle multiple content interfaces in @navigation endpoint. [njohner]
 - Handle errors in solrsearch endpoint. [njohner]
+- Enhance WOPI implementation for Office 365 support. [buchi]
 
 
 2020.5.0 (2020-07-14)

--- a/opengever/core/upgrades/20200720171931_add_additional_wopi_settings/registry.xml
+++ b/opengever/core/upgrades/20200720171931_add_additional_wopi_settings/registry.xml
@@ -1,0 +1,3 @@
+<registry>
+	<records interface="opengever.wopi.interfaces.IWOPISettings" />
+</registry>

--- a/opengever/core/upgrades/20200720171931_add_additional_wopi_settings/upgrade.py
+++ b/opengever/core/upgrades/20200720171931_add_additional_wopi_settings/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddAdditionalWOPISettings(UpgradeStep):
+    """Add additional wopi settings.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/wopi/browser/edit.py
+++ b/opengever/wopi/browser/edit.py
@@ -45,8 +45,8 @@ class EditOnlineView(BrowserView):
         self.access_token_ttl = int(time() + 43200) * 1000
 
         self.params = {
-            'UI_LLCC': 'de-DE',
-            'DC_LLCC': 'de-DE',
+            'UI_LLCC': '',
+            'DC_LLCC': '',
             'DISABLE_CHAT': '1',
             'BUSINESS_USER': '0',
         }

--- a/opengever/wopi/browser/edit.py
+++ b/opengever/wopi/browser/edit.py
@@ -3,6 +3,7 @@ from base64 import urlsafe_b64encode
 from opengever.document.interfaces import ICheckinCheckoutManager
 from opengever.wopi import _
 from opengever.wopi.discovery import actions_by_extension
+from opengever.wopi.interfaces import IWOPISettings
 from opengever.wopi.token import create_access_token
 from plone import api
 from plone.uuid.interfaces import IUUID
@@ -49,6 +50,11 @@ class EditOnlineView(BrowserView):
             'DISABLE_CHAT': '1',
             'BUSINESS_USER': '0',
         }
+
+        if api.portal.get_registry_record(
+            name='business_user', interface=IWOPISettings
+        ):
+            self.params['BUSINESS_USER'] = '1'
 
         url, qs = urlsrc.split('?')
         params = qs.split('><')

--- a/opengever/wopi/browser/edit.py
+++ b/opengever/wopi/browser/edit.py
@@ -66,9 +66,13 @@ class EditOnlineView(BrowserView):
                 params_with_values.append(
                     param.replace(placeholder, self.params[placeholder]))
 
-        portal_state = queryMultiAdapter(
-            (self.context, self.request), name=u'plone_portal_state')
-        wopi_src = '{}/wopi/files/{}'.format(portal_state.portal_url(), uuid)
+        base_url = api.portal.get_registry_record(
+            name='base_url', interface=IWOPISettings)
+        if not base_url:
+            portal_state = queryMultiAdapter(
+                (self.context, self.request), name=u'plone_portal_state')
+            base_url = portal_state.portal_url()
+        wopi_src = '{}/wopi/files/{}'.format(base_url.rstrip('/'), uuid)
         params_with_values.append('WOPISrc={}&'.format(wopi_src))
         self.urlsrc = '?'.join([url, ''.join(params_with_values)])
 

--- a/opengever/wopi/browser/wopi.py
+++ b/opengever/wopi/browser/wopi.py
@@ -3,6 +3,7 @@ from base64 import b64encode
 from base64 import urlsafe_b64decode
 from opengever.base.utils import file_checksum
 from opengever.document.interfaces import ICheckinCheckoutManager
+from opengever.wopi.interfaces import IWOPISettings
 from opengever.wopi.lock import create_lock
 from opengever.wopi.lock import get_lock_token
 from opengever.wopi.lock import refresh_lock
@@ -150,6 +151,7 @@ class WOPIView(BrowserView):
             'UserCanNotWriteRelative': True,
             'UserCanWrite': True,
             'CloseUrl': self.obj.absolute_url(),
+            'HostEditUrl': '{}/office_online_edit'.format(self.obj.absolute_url()),
             'BreadcrumbBrandName': 'OneGov GEVER',
             'BreadcrumbBrandUrl': self.portal_state.portal_url(),
             'BreadcrumbDocName': self.obj.Title(),
@@ -157,6 +159,10 @@ class WOPIView(BrowserView):
             'BreadcrumbFolderUrl': dossier.absolute_url(),
             'LastModifiedTime': modified_iso9601,
         }
+        if api.portal.get_registry_record(
+            name='business_user', interface=IWOPISettings
+        ):
+            data['LicenseCheckForEditIsEnabled'] = True
         return self.render_json(data)
 
     def get_file(self):

--- a/opengever/wopi/browser/wopi.py
+++ b/opengever/wopi/browser/wopi.py
@@ -1,5 +1,7 @@
 from Acquisition import aq_parent
+from base64 import b64encode
 from base64 import urlsafe_b64decode
+from opengever.base.utils import file_checksum
 from opengever.document.interfaces import ICheckinCheckoutManager
 from opengever.wopi.lock import create_lock
 from opengever.wopi.lock import get_lock_token
@@ -132,12 +134,15 @@ class WOPIView(BrowserView):
         modified_iso9601 = (
             modified_dt.replace(tzinfo=None) - modified_dt.utcoffset()
             ).isoformat() + 'Z'
+        _alg, sha256_checksum = file_checksum(
+            self.obj.file._blob.committed(), algorithm=u'SHA256')
         data = {
             'BaseFileName': self.obj.file.filename,
             'OwnerId': self.obj.Creator(),
             'Size': self.obj.file.size,
             'UserId': member.getId(),
             'Version': self._file_version(),
+            'SHA256': b64encode(sha256_checksum.decode('hex')),
             'UserFriendlyName': member.getProperty('fullname') or member.getId(),
             'SupportsUpdate': True,
             'SupportsLocks': True,

--- a/opengever/wopi/interfaces.py
+++ b/opengever/wopi/interfaces.py
@@ -15,3 +15,9 @@ class IWOPISettings(Interface):
         default=u'https://ffc-onenote.officeapps.live.com/hosting/discovery',
         required=False,
     )
+
+    business_user = schema.Bool(
+        title=u"Business User Flow",
+        description=u"Whether the business user flow is enabled.",
+        default=True,
+    )

--- a/opengever/wopi/interfaces.py
+++ b/opengever/wopi/interfaces.py
@@ -21,3 +21,10 @@ class IWOPISettings(Interface):
         description=u"Whether the business user flow is enabled.",
         default=True,
     )
+
+    base_url = schema.TextLine(
+        title=u"WOPI Base URL",
+        description=u"The base URL used for WOPISrc URLs.",
+        default=u'',
+        required=False,
+    )

--- a/opengever/wopi/tests/test_edit.py
+++ b/opengever/wopi/tests/test_edit.py
@@ -19,7 +19,7 @@ class TestEditView(IntegrationTestCase):
         self.assertEqual(
             action,
             "https://FFC-word-edit.officeapps.live.com/we/wordeditorframe.aspx"
-            "?ui=de-DE&rs=de-DE&dchat=1&IsLicensedUser=1&WOPISrc=http://nohost"
+            "?ui=&rs=&dchat=1&IsLicensedUser=1&WOPISrc=http://nohost"
             "/plone/wopi/files/createtreatydossiers000000000002&",
         )
 
@@ -39,7 +39,7 @@ class TestEditView(IntegrationTestCase):
         self.assertEqual(
             action,
             "https://FFC-word-edit.officeapps.live.com/we/wordeditorframe.aspx"
-            "?ui=de-DE&rs=de-DE&dchat=1&IsLicensedUser=0&WOPISrc=http://nohost"
+            "?ui=&rs=&dchat=1&IsLicensedUser=0&WOPISrc=http://nohost"
             "/plone/wopi/files/createtreatydossiers000000000002&",
         )
 

--- a/opengever/wopi/tests/test_edit.py
+++ b/opengever/wopi/tests/test_edit.py
@@ -44,6 +44,19 @@ class TestEditView(IntegrationTestCase):
         )
 
     @browsing
+    def test_edit_view_returns_form_action_with_custom_base_url(self, browser):
+        self.login(self.regular_user, browser=browser)
+        api.portal.set_registry_record(name='base_url', interface=IWOPISettings, value=u'https://wopi.example.org/')
+        browser.open(self.document, view="office_online_edit")
+        action = browser.css("#office_form").first.get("action")
+        self.assertEqual(
+            action,
+            "https://FFC-word-edit.officeapps.live.com/we/wordeditorframe.aspx"
+            "?ui=&rs=&dchat=1&IsLicensedUser=1&WOPISrc=https://wopi.example.org"
+            "/wopi/files/createtreatydossiers000000000002&",
+        )
+
+    @browsing
     def test_edit_view_adds_additional_collaborator_if_needed(self, browser):
         self.login(self.regular_user, browser=browser)
 

--- a/opengever/wopi/tests/test_edit.py
+++ b/opengever/wopi/tests/test_edit.py
@@ -2,7 +2,9 @@ from base64 import urlsafe_b64decode
 from ftw.testbrowser import browsing
 from opengever.document.interfaces import ICheckinCheckoutManager
 from opengever.testing import IntegrationTestCase
+from opengever.wopi.interfaces import IWOPISettings
 from opengever.wopi.token import validate_access_token
+from plone import api
 from zope.component import getMultiAdapter
 
 
@@ -17,7 +19,7 @@ class TestEditView(IntegrationTestCase):
         self.assertEqual(
             action,
             "https://FFC-word-edit.officeapps.live.com/we/wordeditorframe.aspx"
-            "?ui=de-DE&rs=de-DE&dchat=1&IsLicensedUser=0&WOPISrc=http://nohost"
+            "?ui=de-DE&rs=de-DE&dchat=1&IsLicensedUser=1&WOPISrc=http://nohost"
             "/plone/wopi/files/createtreatydossiers000000000002&",
         )
 
@@ -27,6 +29,19 @@ class TestEditView(IntegrationTestCase):
                 urlsafe_b64decode(access_token),
                 'createtreatydossiers000000000002'),
             'kathi.barfuss')
+
+    @browsing
+    def test_edit_view_returns_form_action_for_non_business_users(self, browser):
+        self.login(self.regular_user, browser=browser)
+        api.portal.set_registry_record(name='business_user', interface=IWOPISettings, value=False)
+        browser.open(self.document, view="office_online_edit")
+        action = browser.css("#office_form").first.get("action")
+        self.assertEqual(
+            action,
+            "https://FFC-word-edit.officeapps.live.com/we/wordeditorframe.aspx"
+            "?ui=de-DE&rs=de-DE&dchat=1&IsLicensedUser=0&WOPISrc=http://nohost"
+            "/plone/wopi/files/createtreatydossiers000000000002&",
+        )
 
     @browsing
     def test_edit_view_adds_additional_collaborator_if_needed(self, browser):

--- a/opengever/wopi/tests/test_wopi.py
+++ b/opengever/wopi/tests/test_wopi.py
@@ -1,0 +1,25 @@
+from base64 import urlsafe_b64encode
+from ftw.testbrowser import browsing
+from opengever.testing import IntegrationTestCase
+from opengever.wopi.token import create_access_token
+from plone.uuid.interfaces import IUUID
+
+
+class TestWOPIView(IntegrationTestCase):
+
+    @browsing
+    def test_check_file_info_contains_sha256_checksum(self, browser):
+        with self.login(self.regular_user, browser=browser):
+            uuid = IUUID(self.document)
+
+        access_token = urlsafe_b64encode(
+            create_access_token(self.regular_user.getId(), uuid))
+
+        browser.open('{}/wopi/files/{}?access_token={}'.format(
+            self.portal.absolute_url(), uuid, access_token))
+
+        self.assertIn(u'SHA256', browser.json)
+        self.assertEqual(
+            self.check_file_info()[u'SHA256'],
+            u'UdYxdJTszEpzFUYlpoIMtrUNwUVetM8mOZKZ1PnOd7I=',
+        )

--- a/opengever/wopi/tests/test_wopi.py
+++ b/opengever/wopi/tests/test_wopi.py
@@ -1,14 +1,16 @@
 from base64 import urlsafe_b64encode
 from ftw.testbrowser import browsing
 from opengever.testing import IntegrationTestCase
+from opengever.wopi.interfaces import IWOPISettings
 from opengever.wopi.token import create_access_token
+from plone import api
 from plone.uuid.interfaces import IUUID
 
 
 class TestWOPIView(IntegrationTestCase):
 
     @browsing
-    def test_check_file_info_contains_sha256_checksum(self, browser):
+    def check_file_info(self, browser):
         with self.login(self.regular_user, browser=browser):
             uuid = IUUID(self.document)
 
@@ -17,9 +19,29 @@ class TestWOPIView(IntegrationTestCase):
 
         browser.open('{}/wopi/files/{}?access_token={}'.format(
             self.portal.absolute_url(), uuid, access_token))
+        return browser.json
 
-        self.assertIn(u'SHA256', browser.json)
+    def test_check_file_info_contains_sha256_checksum(self):
+        self.assertIn(u'SHA256', self.check_file_info())
         self.assertEqual(
             self.check_file_info()[u'SHA256'],
             u'UdYxdJTszEpzFUYlpoIMtrUNwUVetM8mOZKZ1PnOd7I=',
+        )
+
+    def test_check_file_info_contains_license_check_flag_if_business_user(self):
+        self.assertIn(u'LicenseCheckForEditIsEnabled', self.check_file_info())
+        self.assertEqual(
+            self.check_file_info()[u'LicenseCheckForEditIsEnabled'],
+            True,
+        )
+
+    def test_check_file_info_has_no_license_check_flag_if_not_business_user(self):
+        api.portal.set_registry_record(name='business_user', interface=IWOPISettings, value=False)
+        self.assertNotIn(u'LicenseCheckForEditIsEnabled', self.check_file_info())
+
+    def test_check_file_info_contains_host_edit_url(self):
+        self.assertIn(u'HostEditUrl', self.check_file_info())
+        self.assertEqual(
+            self.check_file_info()[u'HostEditUrl'],
+            u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/document-14/office_online_edit',
         )


### PR DESCRIPTION
Adds additional functionality which is required to support integration with Office 365:
- SHA256 checksum in CheckFileInfo operation
- Business user flow
- Custom WOPI base URL

The business user flow can be activated in the registry and is enabled by default. If enabled, the user has to sign in with his Office 365 account to be able to edit documents. This is required for commercial uses.

The WOPI base URL can be configured in the registry. This allows to expose the WOPI API on a different URL, e.g. https://wopi.onegovgever.ch/lab instead of https://lab.onegovgever.ch/, which enables us to use a single WOPI domain for all SaaS customers.

The Office user interface language is no longer hardcoded. The parameter is now omitted and thus the language is chosen based on the browser language.

Jira: https://4teamwork.atlassian.net/browse/GEVER-666

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


## Checklist (if applicable)

- Upgrade steps (changes in profile):
  - [x] Make it deferrable if possible
  - [x] Execute as much as possible conditionally

