### PR TITLE
Add mail-in address to inbox serializer.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -14,6 +14,7 @@ Changelog
 - Extend @globalindex endpoint, avoid duplicate tasks, add batching information. [deiferni]
 - Add upgrade to fix docs only partially indexed in solr. [deiferni]
 - Extend @config with admin-unit and org-unit. [njohner]
+- Add mail-in address to inbox serializer. [njohner]
 
 
 2020.6.0 (2020-07-29)

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -14,7 +14,7 @@ Changelog
 - Extend @globalindex endpoint, avoid duplicate tasks, add batching information. [deiferni]
 - Add upgrade to fix docs only partially indexed in solr. [deiferni]
 - Extend @config with admin-unit and org-unit. [njohner]
-- Add mail-in address to inbox serializer. [njohner]
+- Add mail-in address and inbox_id to inbox serializer. [njohner]
 
 
 2020.6.0 (2020-07-29)

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -30,6 +30,7 @@
   <adapter factory=".serializer.SerializeBrainToJsonSummary" />
 
   <adapter factory=".repositoryfolder.SerializeRepositoryFolderToJson" />
+  <adapter factory=".inbox.SerializeInboxToJson" />
   <adapter factory=".dossier.SerializeDossierToJson" />
   <adapter factory=".document.SerializeDocumentToJson" />
   <adapter factory=".mail.SerializeMailToJson" />

--- a/opengever/api/inbox.py
+++ b/opengever/api/inbox.py
@@ -1,0 +1,18 @@
+from ftw.mail.interfaces import IEmailAddress
+from opengever.api.serializer import GeverSerializeFolderToJson
+from opengever.inbox.inbox import IInbox
+from plone.restapi.interfaces import ISerializeToJson
+from zope.component import adapter
+from zope.interface import implementer
+from zope.interface import Interface
+
+
+@implementer(ISerializeToJson)
+@adapter(IInbox, Interface)
+class SerializeInboxToJson(GeverSerializeFolderToJson):
+
+    def __call__(self, *args, **kwargs):
+        result = super(SerializeInboxToJson, self).__call__(*args, **kwargs)
+        result[u'email'] = IEmailAddress(self.request).get_email_for_object(
+            self.context)
+        return result

--- a/opengever/api/inbox.py
+++ b/opengever/api/inbox.py
@@ -1,6 +1,7 @@
 from ftw.mail.interfaces import IEmailAddress
 from opengever.api.serializer import GeverSerializeFolderToJson
 from opengever.inbox.inbox import IInbox
+from opengever.ogds.base.utils import get_current_org_unit
 from plone.restapi.interfaces import ISerializeToJson
 from zope.component import adapter
 from zope.interface import implementer
@@ -15,4 +16,9 @@ class SerializeInboxToJson(GeverSerializeFolderToJson):
         result = super(SerializeInboxToJson, self).__call__(*args, **kwargs)
         result[u'email'] = IEmailAddress(self.request).get_email_for_object(
             self.context)
+
+        # org_unit does not have to be configured on an inbox. If it isn't
+        # we default to the current org_unit.
+        orgunit = self.context.get_responsible_org_unit() or get_current_org_unit()
+        result[u'inbox_id'] = orgunit.inbox().id()
         return result

--- a/opengever/api/tests/test_serializer.py
+++ b/opengever/api/tests/test_serializer.py
@@ -1,6 +1,7 @@
 from ftw.bumblebee.interfaces import IBumblebeeDocument
 from ftw.bumblebee.tests.helpers import DOCX_CHECKSUM
 from ftw.testbrowser import browsing
+from opengever.repository.behaviors.responsibleorg import IResponsibleOrgUnit
 from opengever.testing import IntegrationTestCase
 from plone import api
 
@@ -156,3 +157,27 @@ class TestInboxSerializer(IntegrationTestCase):
         browser.open(self.inbox, headers=self.api_headers)
         self.assertEqual(browser.status_code, 200)
         self.assertEqual(browser.json.get(u'email'), u'1011013300@example.org')
+
+    @browsing
+    def test_inbox_serialization_contains_inbox_id(self, browser):
+        self.login(self.secretariat_user, browser)
+        browser.open(self.inbox, headers=self.api_headers)
+        self.assertEqual(browser.status_code, 200)
+        self.assertEqual(browser.json.get(u'inbox_id'), u'inbox:fa')
+
+    @browsing
+    def test_inbox_id_defaults_to_current_orgunit(self, browser):
+        self.login(self.manager, browser)
+        IResponsibleOrgUnit(self.inbox).responsible_org_unit = None
+
+        browser.open(self.inbox, headers=self.api_headers)
+        self.assertEqual(browser.status_code, 200)
+        self.assertEqual(browser.json.get(u'inbox_id'), u'inbox:fa')
+
+        # change orgunit
+        browser.open(self.repository_root)
+        browser.css('.orgunitMenuContent a')[0].click()
+
+        browser.open(self.inbox, headers=self.api_headers)
+        self.assertEqual(browser.status_code, 200)
+        self.assertEqual(browser.json.get(u'inbox_id'), u'inbox:rk')

--- a/opengever/api/tests/test_serializer.py
+++ b/opengever/api/tests/test_serializer.py
@@ -146,3 +146,13 @@ class TestDocumentSerializer(IntegrationTestCase):
             browser.json.get(u'relative_path'),
             u'ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/{}'.format(
                 self.mail_eml.getId()))
+
+
+class TestInboxSerializer(IntegrationTestCase):
+
+    @browsing
+    def test_inbox_serialization_contains_email(self, browser):
+        self.login(self.secretariat_user, browser)
+        browser.open(self.inbox, headers=self.api_headers)
+        self.assertEqual(browser.status_code, 200)
+        self.assertEqual(browser.json.get(u'email'), u'1011013300@example.org')

--- a/opengever/inbox/browser/overview.py
+++ b/opengever/inbox/browser/overview.py
@@ -68,8 +68,7 @@ class InboxOverview(BoxesViewMixin, BrowserView, GeverTabMixin):
 
         catalog = api.portal.get_tool(name='portal_catalog')
 
-        query = {'isWorkingCopy': 0,
-                 'path': {'depth': 1,
+        query = {'path': {'depth': 1,
                           'query': '/'.join(self.context.getPhysicalPath())},
                  'object_provides': [
                      'opengever.document.behaviors.IBaseDocument', ],

--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -917,7 +917,7 @@ class OpengeverContentFixture(object):
             .having(
                 id='eingangskorb',
                 responsible_org_unit='fa',
-                inbox_group=self.org_unit_fd.inbox_group,
+                inbox_group=self.org_unit_fd.inbox_group.groupid,
                 )
             ))
 


### PR DESCRIPTION
With this PR we:
- Add the mail-in address to the inbox serializer. 
- Add the inbox_id to the inbox serializer. 
- We also clean-up the query for inbox documents which still used an outdated filter `isWorkingCopy` which is not used in gever anymore (https://github.com/4teamwork/opengever.core/commit/1e7c8a1140247d2c65919925d9e715362ff92c50)

For https://4teamwork.atlassian.net/browse/GEVER-463
## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

## Checklist (if applicable)

_Only applicable should be left and checked._

- API change:
  - [ ] Documentation is updated
  - If breaking:
    - [ ] api-change label added
    - [ ] Scrum master is informed