### PR TITLE
Add @resolve-oguid endpoint, amend @notifications and @globalindex.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,11 @@ Changelog
 2020.6.1 (unreleased)
 ---------------------
 
+- Add @resolve-oguid endpoint. [deiferni]
+- Include oguid in @notifications endpoint. [deiferni]
+- Extend @globalindex endpoint, avoid duplicate tasks, add batching information. [deiferni]
 - Add upgrade to fix docs only partially indexed in solr. [deiferni]
+- Extend @config with admin-unit and org-unit. [njohner]
 
 
 2020.6.0 (2020-07-29)

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2020.6.1 (unreleased)
 ---------------------
 
+- Handle search queries in GlobalIndexGet endpoint. [njohner]
 - Add @resolve-oguid endpoint. [deiferni]
 - Include oguid in @notifications endpoint. [deiferni]
 - Extend @globalindex endpoint, avoid duplicate tasks, add batching information. [deiferni]

--- a/docs/public/dev-manual/api/config.rst
+++ b/docs/public/dev-manual/api/config.rst
@@ -22,6 +22,7 @@ GEVER-Mandanten abgefragt werden.
 
       {
           "@id": "http://localhost:8080/fd/@config",
+          "admin_unit": "fd",
           "apps_url": "https://dev.onegovgever.ch/portal/api/apps",
           "bumblebee_app_id": "gever_dev",
           "cas_url": "https://dev.onegovgever.ch/portal/cas",
@@ -76,6 +77,7 @@ GEVER-Mandanten abgefragt werden.
               "fake_sid": "",
               "scope": "oo_V1WebApi"
           },
+          "org_unit": "afi",
           "portal_url": "https://dev.onegovgever.ch/portal",
           "private_folder_url": "http://localhost:8080/fd/private/niklaus.johner",
           "recently_touched_limit": 10,

--- a/docs/public/dev-manual/api/globalindex.rst
+++ b/docs/public/dev-manual/api/globalindex.rst
@@ -19,22 +19,22 @@ Der globale, also über den ganzen Mandantenverbund verteilte, Aufgabenindex kan
       "batching": null,
       "items": [
         { "@id": "http://localhost:8080//ordnungssystem/dossier-23/document-123/task-1",
-          "title": "re: Direkte Anfrage",
-          "task_type": "direct-execution",
-          "task_id": 14,
+          "assigned_org_unit": "fa",
           "containing_dossier": "Anfragen 2019",
           "created": "2016-08-31T18:27:33",
-          "issuing_org_unit": "fa",
-          "responsible": "inbox:fa",
-          "responsible": "Eingangskorb Finanzamt",
-          "modified": "2016-08-31T18:27:33",
-          "is_subtask": false,
           "deadline": "2020-01-01",
-          "review_state": "task-state-in-progress",
-          "assigned_org_unit": "fa",
           "is_private": true,
+          "is_subtask": false,
+          "issuer": "robert.ziegler",
+          "issuing_org_unit": "fa",
+          "modified": "2016-08-31T18:27:33",
           "predecessor_id": null,
-          "issuer": "robert.ziegler"
+          "responsible": "Eingangskorb Finanzamt",
+          "responsible": "inbox:fa",
+          "review_state": "task-state-in-progress",
+          "task_id": 14,
+          "task_type": "direct-execution",
+          "title": "re: Direkte Anfrage"
         }
       ]
     }

--- a/docs/public/dev-manual/api/globalindex.rst
+++ b/docs/public/dev-manual/api/globalindex.rst
@@ -26,14 +26,16 @@ Der globale, also über den ganzen Mandantenverbund verteilte, Aufgabenindex kan
           "is_private": true,
           "is_subtask": false,
           "issuer": "robert.ziegler",
+          "issuer_fullname": "Ziegler Robert",
           "issuing_org_unit": "fa",
           "modified": "2016-08-31T18:27:33",
+          "oguid": "plone:1016273300",
           "predecessor_id": null,
           "responsible": "Eingangskorb Finanzamt",
           "responsible": "inbox:fa",
           "review_state": "task-state-in-progress",
           "task_id": 14,
-          "task_type": "direct-execution",
+          "task_type": "For direct execution",
           "title": "re: Direkte Anfrage"
         }
       ]

--- a/docs/public/dev-manual/api/globalindex.rst
+++ b/docs/public/dev-manual/api/globalindex.rst
@@ -42,13 +42,28 @@ Der globale, also über den ganzen Mandantenverbund verteilte, Aufgabenindex kan
     }
 
 
+Optionale Parameter:
+--------------------
+
 Paginierung
 ~~~~~~~~~~~
 Die Paginierung funktioniert gleich wie bei anderen Auflistungen auch (siehe :ref:`Kapitel Paginierung <batching>`).
 
+- ``b_start``: Das erste zurückzugebende Element
+- ``b_size``: Die maximale Anzahl der zurückzugebenden Elemente
 
-Filter
-~~~~~~
+Sortierung
+~~~~~~~~~~
+
+- ``sort_on``: Sortierung nach einem indexierten Feld
+- ``sort_order``: Sortierreihenfolge: ``ascending`` (aufsteigend) oder ``descending`` (absteigend)
+
+Filter und Suche
+~~~~~~~~~~~~~~~~
+
+- ``search``: Filterung nach einem beliebigen Suchbegriff
+- ``filters``: Einschränkung nach einem bestimmten Wert eines Feldes
+
 
 **Beispiel: Filtern nach erledigten und abgeschlossenen Aufgaben:**
 
@@ -62,4 +77,11 @@ Filter
   .. sourcecode:: http
 
     GET /@globalindex?filters.responsible:record=peter.muser HTTP/1.1
+    Accept: application/json
+
+**Beispiel: Suche**
+
+  .. sourcecode:: http
+
+    GET /@globalindex?search=vertrag HTTP/1.1
     Accept: application/json

--- a/docs/public/dev-manual/api/index.rst
+++ b/docs/public/dev-manual/api/index.rst
@@ -36,6 +36,7 @@ Inhalt:
    usersettings.rst
    tasks.rst
    globalindex.rst
+   resolve_oguid.rst
    proposals.rst
    reminder.rst
    journal.rst

--- a/docs/public/dev-manual/api/notifications.rst
+++ b/docs/public/dev-manual/api/notifications.rst
@@ -37,6 +37,7 @@ Mittels eines GET-Request können Benachrichtigungen des Benutzers abgefragt wer
               "label": "Task opened",
               "link": "http://nohost/plone/@@resolve_notification?notification_id=3",
               "notification_id": 3,
+              "oguid": "plone:1016273300",
               "read": false,
               "summary": "New task opened by Ziegler Robert",
               "title": "Important task"
@@ -49,6 +50,7 @@ Mittels eines GET-Request können Benachrichtigungen des Benutzers abgefragt wer
               "label": "Task opened",
               "link": "http://nohost/plone/@@resolve_notification?notification_id=1",
               "notification_id": 1,
+              "oguid": "plone:1016273300",
               "read": true,
               "summary": "New task opened by Ziegler Robert",
               "title": "Important task"
@@ -84,6 +86,7 @@ Eine einzelne Benarchrichtigung kann durch hinzufügen der Benachrichtigungs-ID 
           "label": "Task opened",
           "link": "http://nohost/plone/@@resolve_notification?notification_id=3",
           "notification_id": 3,
+          "oguid": "plone:1016273300",
           "read": false,
           "summary": "New task opened by Ziegler Robert",
           "title": "Important task"

--- a/docs/public/dev-manual/api/resolve_oguid.rst
+++ b/docs/public/dev-manual/api/resolve_oguid.rst
@@ -1,0 +1,49 @@
+.. resolve_oguid:
+
+Resolve Oguid
+=============
+
+Mit dem ``@resolve-oguid`` kann die serialisierte Repräsentation eines Inhalts
+im Mandatenverbund abgefragt werden. Der Endpoint leitet den Request an eine
+andere Admin-Unit weiter, sollte sich der Inhalt nicht auf der aktuellen
+Admin-Unit befinden.
+
+Parameter
+---------
+
+Die Oguid muss als Query-String Parameter mitgegeben werden.
+
+================ ===========================================================
+Parameter        Beschreibung
+================ ===========================================================
+``oguid``        Die Oguid des zu serialisierenden Inhalts. Diese setzt sich
+                 aus <admin_unit_id>:<int_id> zusammen.
+================ ===========================================================
+
+Des weiteren sind alle Query-String Parameter erlaubt, die bei einem GET Request
+auf einen einzelnen Inhalt möglich sind.
+
+  .. sourcecode:: http
+
+    GET /@resolve-oguid?oguid=fd:123456789 HTTP/1.1
+    Accept: application/json
+
+  .. sourcecode:: http
+
+    HTTP/1.1 200 OK
+    Content-Type: application/json
+
+    {
+      "@id": "http://localhost:8080/rk/ordnungssystem/uebergeordnete-erlasse/dossier-1/task-1",
+      "@type": "opengever.task.task",
+      "UID": "1546308893054eb8b3c21fc8be129607",
+      "changed": "2020-07-27T12:28:47+00:00",
+       "...": "..."
+    }
+
+
+Remote Requests
+---------------
+
+Wurde der Request intern an eine andere Admin-Unit weitergeleitet so ist dies
+über den Header ``X-GEVER-RemoteRequest`` ersichtlich.

--- a/opengever/activity/browser/resolve.py
+++ b/opengever/activity/browser/resolve.py
@@ -1,5 +1,6 @@
 from opengever.activity import notification_center
 from opengever.base.browser.resolveoguid import ResolveOGUIDView
+from opengever.base.exceptions import InvalidOguidIntIdPart
 from opengever.ogds.models.service import ogds_service
 from plone import api
 from zExceptions import NotFound
@@ -43,7 +44,7 @@ class ResolveNotificationView(ResolveOGUIDView):
         if oguid.is_on_current_admin_unit:
             try:
                 url = oguid.resolve_object().absolute_url()
-            except KeyError:
+            except InvalidOguidIntIdPart:
                 raise NotFound('Requested object has been deleted')
 
         else:

--- a/opengever/activity/model/notification.py
+++ b/opengever/activity/model/notification.py
@@ -40,6 +40,7 @@ class Notification(Base):
             'notification_id': self.notification_id,
             'read': self.is_read,
             'link': self._resolve_notification_link(portal_url),
+            'oguid': str(self.activity.resource.oguid),
             })
         return data
 

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -203,6 +203,14 @@
       permission="zope2.View"
       />
 
+  <plone:service
+      method="GET"
+      name="@resolve-oguid"
+      for="Products.CMFPlone.interfaces.IPloneSiteRoot"
+      factory=".resolve_oguid.ResolveOguidGet"
+      permission="zope2.View"
+      />
+
   <adapter
       factory=".navigation.Navigation"
       name="navigation"

--- a/opengever/api/globalindex.py
+++ b/opengever/api/globalindex.py
@@ -72,5 +72,7 @@ class GlobalIndexGet(Service):
         result['items'] = items
         result['batching'] = batch.links
         result['items_total'] = batch.items_total
+        result['b_start'] = start
+        result['b_size'] = rows
 
         return result

--- a/opengever/api/globalindex.py
+++ b/opengever/api/globalindex.py
@@ -54,6 +54,7 @@ class GlobalIndexGet(Service):
                 query = query.filter(getattr(Task, key).in_(value))
             else:
                 query = query.filter(getattr(Task, key) == value)
+        query = query.avoid_duplicates()
 
         tasks = query
         batch = SQLHypermediaBatch(self.request, tasks)

--- a/opengever/api/globalindex.py
+++ b/opengever/api/globalindex.py
@@ -1,5 +1,6 @@
 from opengever.api.batch import SQLHypermediaBatch
 from opengever.api.solr_query_service import DEFAULT_SORT_INDEX
+from opengever.api.solr_query_service import translate_task_type
 from opengever.base.helpers import display_name
 from opengever.globalindex.model.task import Task
 from plone.restapi.serializer.converters import json_compatible
@@ -12,16 +13,18 @@ class GlobalIndexGet(Service):
 
     METADATA = [
         'task_id', 'title', 'review_state', 'responsible', 'issuer',
-        'task_type', 'is_private', 'is_subtask', 'assigned_org_unit',
+        'is_private', 'is_subtask', 'assigned_org_unit',
         'issuing_org_unit', 'deadline', 'modified', 'created',
         'predecessor_id', 'containing_dossier']
 
     ADDITIONAL_METADATA = {
+        'task_type': lambda task: translate_task_type(task.task_type),
         'responsible_fullname': lambda task: display_name(task.responsible),
+        'issuer_fullname': lambda task: display_name(task.issuer),
+        'oguid': lambda task: str(task.oguid),
         '@id': lambda task: task.absolute_url()}
 
     def reply(self):
-
         sort_on = self.request.form.get('sort_on', DEFAULT_SORT_INDEX)
         if sort_on not in Task.__table__.columns:
             sort_on = DEFAULT_SORT_INDEX

--- a/opengever/api/resolve_oguid.py
+++ b/opengever/api/resolve_oguid.py
@@ -72,6 +72,8 @@ class ResolveOguidGet(Service):
                    'X-OGDS-AUID': get_current_admin_unit().id()}
         url = '/'.join([target_unit.site_url, '@resolve-oguid'])
 
+        self.request.response.setHeader('X-GEVER-RemoteRequest', url)
+
         # we pass all query string parameters to the remote request
         response = requests.get(url, params=params, headers=headers)
         if not response.ok:

--- a/opengever/api/resolve_oguid.py
+++ b/opengever/api/resolve_oguid.py
@@ -1,0 +1,81 @@
+from opengever.base.exceptions import InvalidOguidIntIdPart
+from opengever.base.exceptions import MalformedOguid
+from opengever.base.oguid import Oguid
+from opengever.ogds.base.utils import get_current_admin_unit
+from opengever.ogds.models.service import ogds_service
+from plone import api
+from plone.restapi.interfaces import ISerializeToJson
+from plone.restapi.services import Service
+from zExceptions import Unauthorized
+from zope.component import queryMultiAdapter
+import requests
+
+
+class ResolveOguidGet(Service):
+    """Return serialized content for an object identified by an Oguid.
+
+    GET /@resolve-oguid?oguid=foo:1234 HTTP/1.1
+    """
+
+    def reply(self):
+        params = self.request.form.copy()
+        raw_oguid = params.get('oguid', '').strip()
+
+        if not raw_oguid:
+            return self.request.response.setStatus(
+                400, reason='Missing oguid query string parameter.')
+
+        try:
+            oguid = Oguid.parse(raw_oguid)
+        except MalformedOguid:
+            return self.request.response.setStatus(
+                400, reason='Malformed oguid "{}".'.format(str(raw_oguid)))
+
+        if oguid.is_on_current_admin_unit:
+            return self._serialize_object(oguid)
+        else:
+            return self._get_remote_serialized_object(oguid, params)
+
+    def _serialize_object(self, oguid):
+        try:
+            obj = oguid.resolve_object()
+        except InvalidOguidIntIdPart:
+            obj = None
+        # obj could be `None` due to exception or as returned by resolve
+        if not obj:
+            return self.request.response.setStatus(
+                400, reason='No object found for oguid "{}".'.format(
+                    str(oguid)))
+
+        if not api.user.has_permission('View', obj=obj):
+            raise Unauthorized()
+
+        serializer = queryMultiAdapter((obj, self.request), ISerializeToJson)
+        if serializer is None:
+            return self.request.response.setStatus(501)
+
+        json = serializer()
+        # as we just proxy to the object make sure we use correct @id
+        json['@id'] = obj.absolute_url()
+        return json
+
+    def _get_remote_serialized_object(self, oguid, params):
+        target_unit = ogds_service().fetch_admin_unit(oguid.admin_unit_id)
+        if not target_unit:
+            return self.request.response.setStatus(
+                400, reason='Invalid admin unit id "{}".'.format(
+                    oguid.admin_unit_id))
+
+        headers = {'Accept': 'application/json',
+                   'Content-Type': 'application/json',
+                   'X-OGDS-AC': api.user.get_current().getId(),
+                   'X-OGDS-AUID': get_current_admin_unit().id()}
+        url = '/'.join([target_unit.site_url, '@resolve-oguid'])
+
+        # we pass all query string parameters to the remote request
+        response = requests.get(url, params=params, headers=headers)
+        if not response.ok:
+            # transparently return non-ok responses
+            return self.request.response.setStatus(
+                response.status_code, reason=response.reason)
+        return response.json()

--- a/opengever/api/tests/test_config.py
+++ b/opengever/api/tests/test_config.py
@@ -26,6 +26,15 @@ class TestConfig(IntegrationTestCase):
         self.assertEqual(browser.json.get(u'version'), get_distribution('opengever.core').version)
 
     @browsing
+    def test_config_contains_admin_and_org_unit(self, browser):
+        self.login(self.regular_user, browser)
+        url = self.portal.absolute_url() + '/@config'
+        browser.open(url, headers={'Accept': 'application/json'})
+        self.assertEqual(browser.status_code, 200)
+        self.assertEqual(browser.json.get(u'admin_unit'), 'plone')
+        self.assertEqual(browser.json.get(u'org_unit'), 'fa')
+
+    @browsing
     def test_config_contains_userinfo(self, browser):
         self.login(self.regular_user, browser)
         url = self.portal.absolute_url() + '/@config'

--- a/opengever/api/tests/test_globalindex.py
+++ b/opengever/api/tests/test_globalindex.py
@@ -14,22 +14,23 @@ class TestGlobalIndexGet(IntegrationTestCase):
         self.assertEqual(15, len(browser.json['items']))
         self.assertEqual(
             {u'@id': self.inbox_task.absolute_url(),
-             u'title': u're: Diskr\xe4te Dinge',
-             u'task_type': u'direct-execution',
+             u'assigned_org_unit': u'fa',
              u'containing_dossier': u'Vertr\xe4ge mit der kantonalen Finanzverwaltung',
-             u'task_id': 14,
              u'created': u'2016-08-31T18:27:33',
+             u'deadline': u'2020-01-01',
+             u'is_private': True,
+             u'is_subtask': False,
+             u'issuer': u'robert.ziegler',
              u'issuing_org_unit': u'fa',
+             u'modified': u'2016-08-31T18:27:33',
+             u'predecessor_id': None,
              u'responsible': u'inbox:fa',
              u'responsible_fullname': u'Inbox: Finanz\xe4mt',
-             u'modified': u'2016-08-31T18:27:33',
-             u'is_subtask': False,
-             u'deadline': u'2020-01-01',
              u'review_state': u'task-state-in-progress',
-             u'assigned_org_unit': u'fa',
-             u'is_private': True,
-             u'predecessor_id': None,
-             u'issuer': u'robert.ziegler'},
+             u'task_id': 14,
+             u'task_type': u'direct-execution',
+             u'title': u're: Diskr\xe4te Dinge',
+             },
             browser.json['items'][0])
 
         # default row size is 25

--- a/opengever/api/tests/test_globalindex.py
+++ b/opengever/api/tests/test_globalindex.py
@@ -47,6 +47,8 @@ class TestGlobalIndexGet(IntegrationTestCase):
 
         self.assertEqual(15, browser.json['items_total'])
         self.assertEqual(3, len(browser.json['items']))
+        self.assertEqual(0, browser.json['b_start'])
+        self.assertEqual(3, browser.json['b_size'])
         self.assertEqual(
             {u'@id': u'http://nohost/plone/@globalindex?b_size=3',
              u'first': u'http://nohost/plone/@globalindex?b_start=0&b_size=3',

--- a/opengever/api/tests/test_globalindex.py
+++ b/opengever/api/tests/test_globalindex.py
@@ -1,4 +1,5 @@
 from ftw.testbrowser import browsing
+from opengever.base.oguid import Oguid
 from opengever.testing import IntegrationTestCase
 
 
@@ -21,14 +22,16 @@ class TestGlobalIndexGet(IntegrationTestCase):
              u'is_private': True,
              u'is_subtask': False,
              u'issuer': u'robert.ziegler',
+             u'issuer_fullname': u'Ziegler Robert',
              u'issuing_org_unit': u'fa',
              u'modified': u'2016-08-31T18:27:33',
+             u'oguid': str(Oguid.for_object(self.inbox_task)),
              u'predecessor_id': None,
              u'responsible': u'inbox:fa',
              u'responsible_fullname': u'Inbox: Finanz\xe4mt',
              u'review_state': u'task-state-in-progress',
              u'task_id': 14,
-             u'task_type': u'direct-execution',
+             u'task_type': u'For direct execution',
              u'title': u're: Diskr\xe4te Dinge',
              },
             browser.json['items'][0])

--- a/opengever/api/tests/test_globalindex.py
+++ b/opengever/api/tests/test_globalindex.py
@@ -120,6 +120,23 @@ class TestGlobalIndexGet(IntegrationTestCase):
         self.assertEqual(9, len(browser.json['items']))
 
     @browsing
+    def test_handles_search_queries(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        view = u'@globalindex'
+        browser.open(self.portal, view=view.format(''), headers=self.api_headers)
+        self.assertEqual(15, browser.json['items_total'])
+        all_tasks = browser.json.get('items')
+
+        search_term = u'Vertr\xe4ge'
+        view = u'@globalindex?search={}'.format(search_term)
+        browser.open(self.portal, view=view, headers=self.api_headers)
+        self.assertEqual(1, browser.json['items_total'])
+        self.assertEqual(
+            filter(lambda task: u'Vertr\xe4ge' in task.get('title'), all_tasks),
+            browser.json['items'])
+
+    @browsing
     def test_query_is_restricted(self, browser):
         self.login(self.regular_user, browser=browser)
 

--- a/opengever/api/tests/test_notifications.py
+++ b/opengever/api/tests/test_notifications.py
@@ -3,6 +3,7 @@ from ftw.testbrowser import browsing
 from ftw.testing import freeze
 from opengever.activity import notification_center
 from opengever.activity.model import Notification
+from opengever.base.oguid import Oguid
 from opengever.task.activities import TaskAddedActivity
 from opengever.testing import IntegrationTestCase
 import json
@@ -51,6 +52,7 @@ class TestNotificationsGet(IntegrationTestCase):
               u'label': u'Task opened',
               u'link': u'http://nohost/plone/@@resolve_notification?notification_id=3',
               u'notification_id': 3,
+              u'oguid': str(Oguid.for_object(self.task)),
               u'read': False,
               u'summary': u'New task opened by Ziegler Robert',
               u'title': u'Vertr\xe4ge mit der kantonalen... - Vertragsentwurf \xdcberpr\xfcfen'},
@@ -61,6 +63,7 @@ class TestNotificationsGet(IntegrationTestCase):
               u'label': u'Task opened',
               u'link': u'http://nohost/plone/@@resolve_notification?notification_id=1',
               u'notification_id': 1,
+              u'oguid': str(Oguid.for_object(self.task)),
               u'read': True,
               u'summary': u'New task opened by Ziegler Robert',
               u'title': u'Vertr\xe4ge mit der kantonalen... - Vertragsentwurf \xdcberpr\xfcfen'}],
@@ -123,6 +126,7 @@ class TestNotificationsGet(IntegrationTestCase):
              u'label': u'Task opened',
              u'link': u'http://nohost/plone/@@resolve_notification?notification_id=1',
              u'notification_id': 1,
+             u'oguid': str(Oguid.for_object(self.task)),
              u'read': False,
              u'summary': u'New task opened by Ziegler Robert',
              u'title': u'Vertr\xe4ge mit der kantonalen... - Vertragsentwurf \xdcberpr\xfcfen'},
@@ -153,6 +157,7 @@ class TestNotificationsGet(IntegrationTestCase):
              u'label': u'T\xe2che ouverte',
              u'link': u'http://nohost/plone/@@resolve_notification?notification_id=1',
              u'notification_id': 1,
+             u'oguid': str(Oguid.for_object(self.task)),
              u'read': False,
              u'summary': u'Nouvelle t\xe2che ouverte par Ziegler Robert',
              u'title': u'Vertr\xe4ge mit der kantonalen... - Vertragsentwurf \xdcberpr\xfcfen'},

--- a/opengever/api/tests/test_notifications.py
+++ b/opengever/api/tests/test_notifications.py
@@ -19,7 +19,7 @@ class TestNotificationsGet(IntegrationTestCase):
 
         center = notification_center()
 
-        self.assertEqual(0,  Notification.query.count())
+        self.assertEqual(0, Notification.query.count())
 
         with freeze(datetime(2017, 10, 16, 0, 0, tzinfo=pytz.utc)):
             TaskAddedActivity(self.task, self.request).record()
@@ -33,7 +33,7 @@ class TestNotificationsGet(IntegrationTestCase):
         self.assertEqual(2, len(center.get_watchers(self.task)))
 
         # two notifications for each watcher, the responsible and the issuer
-        self.assertEqual(4,  Notification.query.count())
+        self.assertEqual(4, Notification.query.count())
 
         self.login(self.regular_user, browser=browser)
 
@@ -70,7 +70,7 @@ class TestNotificationsGet(IntegrationTestCase):
     def test_batch_notifications(self, browser):
         self.login(self.administrator, browser=browser)
 
-        self.assertEqual(0,  Notification.query.count())
+        self.assertEqual(0, Notification.query.count())
 
         with freeze(datetime(2017, 10, 16, 0, 0, tzinfo=pytz.utc)):
             for i in range(5):
@@ -102,7 +102,7 @@ class TestNotificationsGet(IntegrationTestCase):
     def test_returns_serialized_notifications_for_the_given_userid_and_notification_id(self, browser):
         self.login(self.dossier_responsible, browser=browser)
 
-        self.assertEqual(0,  Notification.query.count())
+        self.assertEqual(0, Notification.query.count())
 
         with freeze(datetime(2017, 10, 16, 0, 0, tzinfo=pytz.utc)):
             TaskAddedActivity(self.task, self.request).record()
@@ -238,7 +238,7 @@ class TestNotificationsPatch(IntegrationTestCase):
         url = '{}/@notifications/{}/1'.format(self.portal.absolute_url(),
                                               self.dossier_responsible.getId())
 
-        self.assertEqual(0,  Notification.query.count())
+        self.assertEqual(0, Notification.query.count())
 
         with browser.expect_http_error(404):
             browser.open(url, method='PATCH', data=json.dumps({}),

--- a/opengever/api/tests/test_resolve_oguid.py
+++ b/opengever/api/tests/test_resolve_oguid.py
@@ -1,0 +1,193 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.testbrowser import browsing
+from opengever.base.oguid import Oguid
+from opengever.testing import IntegrationTestCase
+from urllib import urlencode
+import json
+import requests_mock
+
+
+class TestResolveOguidGet(IntegrationTestCase):
+
+    maxDiff = None
+
+    def setup_remote_admin_unit(self, remote_admin_unit_name='remote'):
+        create(
+            Builder('admin_unit')
+            .id(remote_admin_unit_name)
+            .having(site_url='http://nohost/{}'.format(remote_admin_unit_name))
+        )
+
+    def get_resolve_urls(self, remote_unit='remote', int_id='1337', **kwargs):
+        oguid = '{}:{}'.format(remote_unit, int_id)
+        params = {
+            'oguid': oguid,
+        }
+        params.update(**kwargs)
+        query_string = urlencode(params)
+
+        remote_url = 'http://nohost/{}/@resolve-oguid?{}'.format(
+            remote_unit, query_string)
+        local_url = '{}/@resolve-oguid?{}'.format(
+            self.portal.absolute_url(), query_string)
+
+        return remote_url, local_url
+
+    @browsing
+    def test_resolve_oguid_returns_serialized_object(self, browser):
+        self.login(self.regular_user, browser)
+
+        browser.open(self.task, method='GET', headers=self.api_headers)
+        expected_task_json = browser.json
+
+        url = '{}/@resolve-oguid?oguid={}'.format(
+            self.portal.absolute_url(), str(Oguid.for_object(self.task)))
+        browser.open(url, method='GET', headers=self.api_headers)
+
+        self.assertEqual(browser.status_code, 200)
+        self.assertEqual(
+            expected_task_json, browser.json,
+            "Response of GET to task url and resolution via @resolve-oguid "
+            "should be equal.")
+
+        self.assertDictContainsSubset(
+            {u'@id': self.task.absolute_url(),
+             u'@type': u'opengever.task.task',
+             },
+            browser.json
+        )
+
+    @browsing
+    def test_resolve_oguid_respects_security(self, browser):
+        self.login(self.administrator)
+        oguid = Oguid.for_object(self.protected_document)
+
+        self.login(self.regular_user, browser)
+        url = '{}/@resolve-oguid?oguid={}'.format(self.portal.absolute_url(), str(oguid))
+
+        with browser.expect_http_error(code=401):
+            browser.open(url, method='GET', headers=self.api_headers)
+
+    @browsing
+    def test_requires_oguid_parameter(self, browser):
+        self.login(self.regular_user, browser)
+        url = '{}/@resolve-oguid'.format(self.portal.absolute_url())
+
+        with browser.expect_http_error(
+                code=400, reason='Missing oguid query string parameter.'):
+            browser.open(url, method='GET', headers=self.api_headers)
+
+    @browsing
+    def test_requires_valid_oguid(self, browser):
+        self.login(self.regular_user, browser)
+        url = '{}/@resolve-oguid?oguid=qux'.format(self.portal.absolute_url())
+
+        with browser.expect_http_error(
+                code=400, reason='Malformed oguid "qux".'):
+            browser.open(url, method='GET', headers=self.api_headers)
+
+    @browsing
+    def test_requires_resolvable_oguid(self, browser):
+        self.login(self.regular_user, browser)
+        url = '{}/@resolve-oguid?oguid=plone:1234'.format(self.portal.absolute_url())
+
+        with browser.expect_http_error(
+                code=400, reason='No object found for oguid "plone:1234".'):
+            browser.open(url, method='GET', headers=self.api_headers)
+
+    @browsing
+    def test_requires_valid_admin_unit_id(self, browser):
+        self.login(self.regular_user, browser)
+        url = '{}/@resolve-oguid?oguid=qux:1234'.format(self.portal.absolute_url())
+
+        with browser.expect_http_error(
+                code=400, reason='Invalid admin unit id "qux".'):
+            browser.open(url, method='GET', headers=self.api_headers)
+
+    @browsing
+    def test_resolve_remote_oguid_proxies_remote_response(self, browser):
+        self.setup_remote_admin_unit()
+        remote_url, local_url = self.get_resolve_urls()
+
+        self.login(self.regular_user, browser)
+        with requests_mock.Mocker() as mocker:
+            response = {'foo': 'bar'}
+            mocker.get(remote_url, text=json.dumps(response))
+
+            browser.open(local_url, method='GET', headers=self.api_headers)
+            self.assertEqual(response, browser.json)
+
+    @browsing
+    def test_resolve_remote_oguid_proxies_query_string_parameteres_to_remote(self, browser):
+        self.setup_remote_admin_unit()
+        remote_url, local_url = self.get_resolve_urls(someparam='foo')
+        self.assertIn('someparam=foo', remote_url)
+
+        self.login(self.regular_user, browser)
+        with requests_mock.Mocker() as mocker:
+            response = {'qux': 1234}
+            mocker.get(remote_url, text=json.dumps(response))
+
+            browser.open(local_url, method='GET', headers=self.api_headers)
+            self.assertEqual(response, browser.json)
+
+    @browsing
+    def test_remote_400_raises_local_400(self, browser):
+        self.setup_remote_admin_unit()
+        remote_url, local_url = self.get_resolve_urls()
+
+        self.login(self.regular_user, browser)
+        with requests_mock.Mocker() as mocker:
+            mocker.get(remote_url, status_code=400)
+
+            with browser.expect_http_error(400):
+                browser.open(local_url, method='GET', headers=self.api_headers)
+
+    @browsing
+    def test_remote_404_raises_local_404(self, browser):
+        self.setup_remote_admin_unit()
+        remote_url, local_url = self.get_resolve_urls()
+
+        self.login(self.regular_user, browser)
+        with requests_mock.Mocker() as mocker:
+            mocker.get(remote_url, status_code=404)
+
+            with browser.expect_http_error(404):
+                browser.open(local_url, method='GET', headers=self.api_headers)
+
+    @browsing
+    def test_remote_500_raises_local_500(self, browser):
+        self.setup_remote_admin_unit()
+        remote_url, local_url = self.get_resolve_urls()
+
+        self.login(self.regular_user, browser)
+        with requests_mock.Mocker() as mocker:
+            mocker.get(remote_url, status_code=500)
+
+            with browser.expect_http_error(500):
+                browser.open(local_url, method='GET', headers=self.api_headers)
+
+    @browsing
+    def test_remote_502_raises_local_502(self, browser):
+        self.setup_remote_admin_unit()
+        remote_url, local_url = self.get_resolve_urls()
+
+        self.login(self.regular_user, browser)
+        with requests_mock.Mocker() as mocker:
+            mocker.get(remote_url, status_code=502)
+
+            with browser.expect_http_error(502):
+                browser.open(local_url, method='GET', headers=self.api_headers)
+
+    @browsing
+    def test_remote_504_raises_local_504(self, browser):
+        self.setup_remote_admin_unit()
+        remote_url, local_url = self.get_resolve_urls()
+
+        self.login(self.regular_user, browser)
+        with requests_mock.Mocker() as mocker:
+            mocker.get(remote_url, status_code=504)
+
+            with browser.expect_http_error(504):
+                browser.open(local_url, method='GET', headers=self.api_headers)

--- a/opengever/api/tests/test_resolve_oguid.py
+++ b/opengever/api/tests/test_resolve_oguid.py
@@ -133,6 +133,22 @@ class TestResolveOguidGet(IntegrationTestCase):
             self.assertEqual(response, browser.json)
 
     @browsing
+    def test_remote_request_sets_http_header(self, browser):
+        self.setup_remote_admin_unit()
+        remote_url, local_url = self.get_resolve_urls()
+
+        self.login(self.regular_user, browser)
+        with requests_mock.Mocker() as mocker:
+            response = {'foo': 'bar'}
+            mocker.get(remote_url, text=json.dumps(response))
+
+            browser.open(local_url, method='GET', headers=self.api_headers)
+            self.assertEqual(
+                'http://nohost/remote/@resolve-oguid',
+                browser.headers.get('x-gever-remoterequest')
+            )
+
+    @browsing
     def test_remote_400_raises_local_400(self, browser):
         self.setup_remote_admin_unit()
         remote_url, local_url = self.get_resolve_urls()

--- a/opengever/base/configuration.py
+++ b/opengever/base/configuration.py
@@ -25,6 +25,8 @@ from opengever.meeting.interfaces import IMeetingSettings
 from opengever.nightlyjobs.interfaces import INightlyJobsSettings
 from opengever.officeatwork.interfaces import IOfficeatworkSettings
 from opengever.officeconnector.interfaces import IOfficeConnectorSettings
+from opengever.ogds.base.utils import get_current_admin_unit
+from opengever.ogds.base.utils import get_current_org_unit
 from opengever.ogds.models.user_settings import UserSettings
 from opengever.oneoffixx.interfaces import IOneoffixxSettings
 from opengever.repository.interfaces import IRepositoryFolderRecords
@@ -65,6 +67,9 @@ class GeverSettingsAdpaterV1(object):
         info = OrderedDict()
         info['@id'] = self.context.absolute_url() + '/@config'
         info['version'] = get_distribution('opengever.core').version
+        info['admin_unit'] = get_current_admin_unit().id()
+        info['org_unit'] = get_current_org_unit().id()
+
         user = api.user.get_current()
         if user.getId():
             info['userid'] = user.getId()

--- a/opengever/base/exceptions.py
+++ b/opengever/base/exceptions.py
@@ -1,3 +1,14 @@
 class TransportationError(Exception):
     """A object could not be transported from or to another client.
     """
+
+
+class MalformedOguid(Exception):
+    """The Oguid is invalid and does not meet the required format of
+    <admin_unit_id>:<int_id>.
+    """
+
+
+class InvalidOguidIntIdPart(Exception):
+    """The int_id part of the oguid is invalid and does not exist.
+    """

--- a/opengever/base/oguid.py
+++ b/opengever/base/oguid.py
@@ -1,3 +1,5 @@
+from opengever.base.exceptions import MalformedOguid
+from opengever.base.exceptions import InvalidOguidIntIdPart
 from opengever.ogds.base.utils import get_current_admin_unit
 from opengever.ogds.models.service import ogds_service
 from zope.component import getUtility
@@ -42,6 +44,8 @@ class Oguid(object):
 
         """
         parts = oguid.split(cls.SEPARATOR)
+        if len(parts) != 2:
+            raise MalformedOguid(oguid)
         admin_unit_id, int_id = parts[0], int(parts[1])
         return cls(admin_unit_id, int_id)
 
@@ -70,7 +74,11 @@ class Oguid(object):
     def resolve_object(self):
         if self.admin_unit_id != get_current_admin_unit().id():
             return None
-        return getUtility(IIntIds).getObject(self.int_id)
+        intids = getUtility(IIntIds)
+        try:
+            return intids.getObject(self.int_id)
+        except KeyError:
+            raise InvalidOguidIntIdPart(self.int_id)
 
     @property
     def is_on_current_admin_unit(self):

--- a/opengever/base/tests/test_configuration_adapter.py
+++ b/opengever/base/tests/test_configuration_adapter.py
@@ -12,6 +12,8 @@ class TestConfigurationAdapter(IntegrationTestCase):
         expected_configuration = OrderedDict([
             ('@id', 'http://nohost/plone/@config'),
             ('version', get_distribution('opengever.core').version),
+            ('admin_unit', 'plone'),
+            ('org_unit', 'fa'),
             ('userid', 'kathi.barfuss'),
             ('user_fullname', 'B\xc3\xa4rfuss K\xc3\xa4thi'),
             ('user_email', 'kathi.barfuss@gever.local'),
@@ -89,6 +91,8 @@ class TestConfigurationAdapter(IntegrationTestCase):
         expected_configuration = OrderedDict([
             ('@id', 'http://nohost/plone/@config'),
             ('version', get_distribution('opengever.core').version),
+            ('admin_unit', 'plone'),
+            ('org_unit', '__dummy_unit_id__'),
             ('root_url', 'http://nohost/plone'),
             ('portal_url', 'http://nohost/portal'),
             ('cas_url', None),
@@ -116,6 +120,8 @@ class TestConfigurationAdapter(IntegrationTestCase):
         expected_configuration = OrderedDict([
             ('@id', 'http://nohost/plone/@config'),
             ('version', get_distribution('opengever.core').version),
+            ('admin_unit', 'plone'),
+            ('org_unit', '__dummy_unit_id__'),
             ('root_url', 'http://nohost/plone'),
             ('portal_url', 'http://nohost/portal'),
             ('cas_url', None),

--- a/opengever/tabbedview/browser/tasklisting.py
+++ b/opengever/tabbedview/browser/tasklisting.py
@@ -147,17 +147,5 @@ class GlobalTaskTableSource(SqlTableSource):
         """
         # initalize config
         query = super(GlobalTaskTableSource, self).build_query()
-
-        query = self.avoid_duplicates(query)
-        return query
-
-    def avoid_duplicates(self, query):
-        """If a task has a successor task, list only one of them.
-
-        List only the one which is assigned to this client.
-        """
-        query = query.filter(
-            or_(
-                and_(Task.predecessor == None, Task.successors == None),  # noqa
-                Task.admin_unit_id == get_current_admin_unit().id()))
+        query = query.avoid_duplicates()
         return query


### PR DESCRIPTION
With this PR we add the endpoint `@resolve-oguid` which allows to get the a serialized object via oguid. Then endpoint will proxy the change to another remote internally, if necessary.

It also includes the following other changes:
- add `oguid` to `@notifications` and `@globalindex` endpoint
- amend `@globalindex` endpoint with the following changes
  - Support search queries
  - translate `task_type`
  - add correct batching information
  - add issuer_fullname
- extend `@config` with admin-unit and org-unit

I have verified that the api-change does not have an impact in https://4teamwork.slack.com/archives/C3RUACNN7/p1595930231095400.

For https://4teamwork.atlassian.net/browse/GEVER-439.

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


## Checklist (if applicable)

_Only applicable should be left and checked._

- API change:
  - [x] Documentation is updated
  - If breaking:
    - [x] api-change label added
    - [x] Scrum master is informed
