### PR TITLE
Reindex SearchableText when filing_no is set.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 ---------------------
 
 - Also reindex searchable text of dossier when migrating responsible user. [njohner]
+- Reindex SearchableText when filing number is set. [njohner]
 - Bump `ftw.solr` to treat docs with no `created` field as out of sync. [deiferni]
 - Handle search queries in GlobalIndexGet endpoint. [njohner]
 - Add @resolve-oguid endpoint. [deiferni]

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 ---------------------
 
 - Also reindex searchable text of dossier when migrating responsible user. [njohner]
+- Use filing_no field in advanced search form. [njohner]
 - Reindex SearchableText when filing number is set. [njohner]
 - Bump `ftw.solr` to treat docs with no `created` field as out of sync. [deiferni]
 - Handle search queries in GlobalIndexGet endpoint. [njohner]

--- a/opengever/advancedsearch/tests/test_search.py
+++ b/opengever/advancedsearch/tests/test_search.py
@@ -244,7 +244,7 @@ class TestQueryStrings(SolrIntegrationTestCase):
                       'form.widgets.end_2': "01.04.2010",
                       'form.widgets.reference': "OG 14.2",
                       'form.widgets.sequence_number': "5",
-                      'form.widgets.searchable_filing_no': "14",
+                      'form.widgets.filing_no': "14",
                       'form.widgets.dossier_review_state:list': 'dossier-state-active'})
 
         form = browser.find_form_by_field('Responsible')
@@ -262,7 +262,7 @@ class TestQueryStrings(SolrIntegrationTestCase):
             ('end.query:record:list:date', '2010-04-02'),
             ('reference', 'OG 14.2'),
             ('sequence_number:int', '5'),
-            ('searchable_filing_no', '14'),
+            ('filing_no', '14'),
             ('responsible', self.regular_user.id),
             ('review_state:list', 'dossier-state-active'),
         ])

--- a/opengever/core/upgrades/20200805094934_reindex_searchable_text_to_include_filing_no/upgrade.py
+++ b/opengever/core/upgrades/20200805094934_reindex_searchable_text_to_include_filing_no/upgrade.py
@@ -1,0 +1,18 @@
+from ftw.upgrade import UpgradeStep
+from opengever.dossier.behaviors.filing import IFilingNumberMarker
+from opengever.dossier.behaviors.filing import IFilingNumber
+
+
+class ReindexSearchableTextToIncludeFilingNo(UpgradeStep):
+    """Reindex searchable text to include filing no.
+    """
+
+    deferrable = True
+
+    def __call__(self):
+        query = {'object_provides': IFilingNumberMarker.__identifier__}
+        for dossier in self.objects(query, 'Reindex searchable text to include filing no.'):
+            if IFilingNumber(dossier).filing_no:
+                # SearchableText is not in the catalog, so to avoid reindexing the
+                # full object, we also reindex the UID.
+                dossier.reindexObject(idxs=['UID', 'SearchableText'])

--- a/opengever/dossier/archive.py
+++ b/opengever/dossier/archive.py
@@ -320,7 +320,7 @@ class Archiver(object):
 
     def _recursive_update_prefix(self, dossier, prefix):
         IDossier(dossier).filing_prefix = prefix
-        dossier.reindexObject(idxs=['filing_no', 'searchable_filing_no'])
+        dossier.reindexObject(idxs=['filing_no', 'searchable_filing_no', 'SearchableText'])
         for subdossier in dossier.get_subdossiers(depth=1):
             self._recursive_update_prefix(subdossier.getObject(), prefix)
 
@@ -337,7 +337,7 @@ class Archiver(object):
         IFilingNumber(dossier).filing_no = number
 
         IDossier(self.context).filing_prefix = prefix
-        dossier.reindexObject(idxs=['filing_no', 'searchable_filing_no'])
+        dossier.reindexObject(idxs=['filing_no', 'searchable_filing_no', 'SearchableText'])
 
         for i, subdossier in enumerate(dossier.get_subdossiers(depth=1),
                                        start=1):

--- a/opengever/dossier/filing/advanced_search.py
+++ b/opengever/dossier/filing/advanced_search.py
@@ -8,7 +8,7 @@ from zope import schema
 
 class IFilingnumberSearchAddition(model.Schema):
 
-    searchable_filing_no = schema.TextLine(
+    filing_no = schema.TextLine(
         title=_('label_filing_number', default='Filing number'),
         description=_('help_filing_number', default=''),
         required=False,
@@ -20,7 +20,7 @@ class FilingAdvancedSearchForm(AdvancedSearchForm):
     schemas = (IAdvancedSearch, IFilingnumberSearchAddition)
 
     def move_fields(self):
-        move(self, 'searchable_filing_no', before='responsible')
+        move(self, 'filing_no', before='responsible')
 
     def field_mapping(self):
         """Append searchable_filing_no to default field mappings"""
@@ -29,8 +29,8 @@ class FilingAdvancedSearchForm(AdvancedSearchForm):
         dossier_fields = mapping.get(
             'opengever-dossier-behaviors-dossier-IDossierMarker')
 
-        if 'searchable_filing_no' not in dossier_fields:
+        if 'filing_no' not in dossier_fields:
             dossier_fields.insert(
-                dossier_fields.index('responsible'), 'searchable_filing_no')
+                dossier_fields.index('responsible'), 'filing_no')
 
         return mapping

--- a/opengever/dossier/tests/test_indexer.py
+++ b/opengever/dossier/tests/test_indexer.py
@@ -2,6 +2,7 @@ from opengever.base.behaviors.base import IOpenGeverBase
 from opengever.base.model import CONTENT_TITLE_LENGTH
 from opengever.dossier.behaviors.dossier import IDossier
 from opengever.dossier.behaviors.filing import IFilingNumber
+from opengever.dossier.interfaces import IDossierArchiver
 from opengever.sharing.events import LocalRolesAcquisitionActivated
 from opengever.sharing.events import LocalRolesAcquisitionBlocked
 from opengever.testing import index_data_for
@@ -277,3 +278,16 @@ class TestDossierFilingNumberIndexer(SolrIntegrationTestCase):
         indexed_value = solr_data_for(self.dossier, 'SearchableText')
 
         self.assertIn('SKA ARCH-Administration-2016-11', indexed_value)
+
+    def test_filing_no_is_in_searchable_text_when_dossier_is_archived(self):
+        self.login(self.regular_user)
+
+        IDossierArchiver(self.dossier).archive('administration', '2013')
+        self.commit_solr()
+
+        expected_filing_no = 'Hauptmandant-Administration-2013-1'
+        self.assertEqual(IFilingNumber(self.dossier).filing_no,
+                         expected_filing_no)
+
+        indexed_value = solr_data_for(self.dossier, 'SearchableText')
+        self.assertIn(expected_filing_no, indexed_value)


### PR DESCRIPTION
The `SearchableText` was not reindexed when the `filing_no` is set by the `Archiver`, although the  `filing_no`  is part of the `SearchableText`. Apart from this correction, I also realised that the advanced search did not work for filing numbers, as this referenced the `searchable_filing_number` field, which is not indexed in solr. I therefore now use the `filing_no` in the advanced search form instead.

The upgrade step reindexing the `SearchableText` will find dossiers only for deployments having this behavior (i.e. only Zug), as we query for the `IFilingNumberMarker` interface.

For https://4teamwork.atlassian.net/browse/GEVER-802

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
- Upgrade steps (changes in profile):
  - [x] Make it deferrable if possible
  - [x] Execute as much as possible conditionally