### PR TITLE
Also reindex searchable text of dossier when migrating responsible user.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2020.6.1 (unreleased)
 ---------------------
 
+- Also reindex searchable text of dossier when migrating responsible user. [njohner]
 - Bump `ftw.solr` to treat docs with no `created` field as out of sync. [deiferni]
 - Handle search queries in GlobalIndexGet endpoint. [njohner]
 - Add @resolve-oguid endpoint. [deiferni]

--- a/opengever/usermigration/dossier.py
+++ b/opengever/usermigration/dossier.py
@@ -105,7 +105,7 @@ class DossierMigrator(object):
         # (participations don't affect indexes however)
         for obj in self.dossiers_to_reindex:
             logger.info("Reindexing dossier: %r" % obj)
-            obj.reindexObject(idxs=['responsible'])
+            obj.reindexObject(idxs=['responsible', 'SearchableText'])
 
         results = {
             'responsibles': {


### PR DESCRIPTION
`responsible` is part of the searchable text, so the `SearchableText` of dossiers should get updated during a user migration.

I decided not to write an upgrade step here, as I don't know how to identify the dossiers that are concerned by this. Reindexing the `SearchableText` of all dossiers seems a bit of an overkill?

For https://4teamwork.atlassian.net/browse/GEVER-819

## Checklist (Must have)

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

- Upgrade steps (changes in profile):
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
