### PR TITLE
Add vocabulary for attachable documents when delegating a task.

### DIFF
--- a/opengever/api/tests/test_vocabularies.py
+++ b/opengever/api/tests/test_vocabularies.py
@@ -46,6 +46,7 @@ NON_SENSITIVE_VOCABUALRIES = [
     'opengever.ogds.base.OrgUnitsVocabularyFactory',
     'opengever.ogds.base.OtherAssignedClientsVocabulary',
     'opengever.repository.RestrictedAddableDossiersVocabulary',
+    'opengever.task.attachable_documents_vocabulary',
     'opengever.task.bidirectional_by_reference',
     'opengever.task.bidirectional_by_value',
     'opengever.task.reminder.TaskReminderOptionsVocabulary',
@@ -95,7 +96,7 @@ NON_SENSITIVE_VOCABUALRIES = [
     'wicked.vocabularies.CacheConfigurationsOptions',
 ]
 
-# This vocabularies are listet by the @vocabularies endpoint but should not be
+# These vocabularies are listed by the @vocabularies endpoint but should not be
 # tested if they are accessable by the user or not.
 IGNORED_VOCABULARIES = [
     'Behaviors',

--- a/opengever/task/browser/delegate/configure.zcml
+++ b/opengever/task/browser/delegate/configure.zcml
@@ -16,4 +16,9 @@
       permission="opengever.task.AddTask"
       />
 
+  <utility
+      factory=".vocabulary.AttachableDocumentsVocabularyFactory"
+      name="opengever.task.attachable_documents_vocabulary"
+      />
+
 </configure>

--- a/opengever/task/browser/delegate/vocabulary.py
+++ b/opengever/task/browser/delegate/vocabulary.py
@@ -1,7 +1,10 @@
+from opengever.task.task import ITask
 from zope.app.intid.interfaces import IIntIds
 from zope.component import getUtility
+from zope.interface import implementer
 from zope.interface import provider
 from zope.schema.interfaces import IContextSourceBinder
+from zope.schema.interfaces import IVocabularyFactory
 from zope.schema.vocabulary import SimpleVocabulary
 import AccessControl
 
@@ -37,3 +40,13 @@ def attachable_documents_vocabulary(context):
         terms.append(SimpleVocabulary.createTerm(key, key, label))
 
     return SimpleVocabulary(terms)
+
+
+@implementer(IVocabularyFactory)
+class AttachableDocumentsVocabularyFactory(object):
+
+    def __call__(self, context):
+        if not ITask.providedBy(context):
+            return SimpleVocabulary([])
+
+        return attachable_documents_vocabulary(context)

--- a/opengever/task/tests/test_delegate.py
+++ b/opengever/task/tests/test_delegate.py
@@ -1,8 +1,11 @@
 from ftw.testbrowser import browsing
 from ftw.testbrowser.pages import statusmessages
 from opengever.ogds.base.utils import get_current_org_unit
+from opengever.task.browser.delegate.vocabulary import attachable_documents_vocabulary
 from opengever.testing import IntegrationTestCase
 from plone import api
+from zope.app.intid.interfaces import IIntIds
+from zope.component import getUtility
 
 
 class TestDelegateTaskToInbox(IntegrationTestCase):
@@ -94,3 +97,15 @@ class TestDelegateTaskForm(IntegrationTestCase):
 
         self.assertEqual(
             ['1 subtasks were create.'], statusmessages.info_messages())
+
+
+class TestAttachableDocumentsVocabulary(IntegrationTestCase):
+
+    def test_attachable_documents_vocabulary_lists_contained_and_related_documents(self):
+        self.login(self.regular_user)
+        intids = getUtility(IIntIds)
+        terms = attachable_documents_vocabulary(self.task)
+
+        self.assertItemsEqual(
+            [str(intids.getId(el)) for el in [self.document, self.taskdocument]],
+            [term.value for term in terms])


### PR DESCRIPTION
We introduce a vocabulary factory for the `attachable_documents_vocabulary` source binder, so that it can be accessed over the REST-API.

For https://4teamwork.atlassian.net/browse/GEVER-430

## Checklist (Must have)
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

## Checklist (if applicable)

- API change:
  - [ ] Documentation is updated
  - If breaking:
    - [ ] api-change label added
    - [ ] Scrum master is informed