### PR TITLE
Extend the @config endpoint with the inbox_folder_url.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2020.6.1 (unreleased)
 ---------------------
 
+- Extend the @config endpoint with the current inbox_folder_url. [elioschmutz]
 - Add support for importing teamraum bundles. [lgraf]
 - Also reindex searchable text of dossier when migrating responsible user. [njohner]
 - Use filing_no field in advanced search form. [njohner]

--- a/docs/public/dev-manual/api/config.rst
+++ b/docs/public/dev-manual/api/config.rst
@@ -63,6 +63,7 @@ GEVER-Mandanten abgefragt werden.
               "workspace": false,
               "workspace_client": false
           },
+          "inbox_folder_url": "https://dev.onegovgever.ch/fd/eingangskorb/eingangskorb_afi"
           "is_admin_menu_visible": false,
           "is_emm_environment": false,
           "max_dossier_levels": 5,

--- a/opengever/api/config.py
+++ b/opengever/api/config.py
@@ -1,6 +1,7 @@
 from ftw.bumblebee.config import bumblebee_config
 from opengever.base import utils
 from opengever.base.interfaces import IGeverSettings
+from opengever.inbox.utils import get_current_inbox
 from opengever.officeconnector.helpers import is_client_ip_in_office_connector_disallowed_ip_ranges
 from opengever.private import get_private_folder_url
 from plone.restapi.services import Service
@@ -34,3 +35,6 @@ class Config(Service):
         config['is_admin_menu_visible'] = utils.is_administrator()
         config['bumblebee_app_id'] = bumblebee_config.app_id
         config['private_folder_url'] = get_private_folder_url()
+
+        inbox = get_current_inbox(self.context)
+        config['inbox_folder_url'] = inbox.absolute_url() if inbox else ''

--- a/opengever/api/tests/test_config.py
+++ b/opengever/api/tests/test_config.py
@@ -257,3 +257,19 @@ class TestConfig(IntegrationTestCase):
                      headers=self.api_headers)
         self.assertEqual(browser.status_code, 200)
         self.assertEqual(browser.json.get(u'usersnap_api_key'), u'some key')
+
+    @browsing
+    def test_config_contains_current_inbox_url_if_available(self, browser):
+        self.login(self.secretariat_user, browser)
+
+        browser.open(self.portal.absolute_url() + '/@config',
+                     headers=self.api_headers)
+        self.assertEqual(browser.status_code, 200)
+        self.assertEqual(browser.json.get(u'inbox_folder_url'), u'http://nohost/plone/eingangskorb')
+
+        self.login(self.regular_user, browser)
+
+        browser.open(self.portal.absolute_url() + '/@config',
+                     headers=self.api_headers)
+        self.assertEqual(browser.status_code, 200)
+        self.assertEqual(browser.json.get(u'inbox_folder_url'), u'')

--- a/opengever/inbox/utils.py
+++ b/opengever/inbox/utils.py
@@ -10,5 +10,7 @@ def get_current_inbox(context):
     if inbox_container:
         return inbox_container[0].get_current_inbox()
 
-    return portal.listFolderContents(
-        contentFilter={'portal_type': 'opengever.inbox.inbox'})[0]
+    inbox = portal.listFolderContents(
+        contentFilter={'portal_type': 'opengever.inbox.inbox'})
+
+    return inbox[0] if inbox else None


### PR DESCRIPTION
Deployments having multiple org-units will have multiple inboxes within an inbox container. The user will be redirected automatically to the currently active inbox depending on his active org-unit.

To be able to implement this functionality in the new ui, we need the url to the current inbox.

This PR extends the `@config` endpoint with the `inbox_folder_url`.

Jira: https://4teamwork.atlassian.net/browse/GEVER-490

## Checklist (Must have)

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


## Checklist (if applicable)

_Only applicable should be left and checked._

- API change:
  - [x] Documentation is updated
  - If breaking:
    - [ ] api-change label added
    - [ ] Scrum master is informed
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Upgrade steps (changes in profile):
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
- DB-Schema migration
  - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
  - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value
