### PR TITLE
Add missing inboxes for multi orgunit setups in the examplecontent fd profile and testing fixture

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -552,10 +552,12 @@ Objects
   - self.contactfolder
     - self.franz_meier
     - self.hanspeter_duerr
-  - self.inbox
-    - self.inbox_document
-    - self.inbox_forwarding
-      - self.inbox_forwarding_document
+  - self.inbox_container
+    - self.inbox
+      - self.inbox_document
+      - self.inbox_forwarding
+        - self.inbox_forwarding_document
+    - self.inbox_rk
   - self.private_root
     - self.private_folder
       - self.private_dossier

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -8,6 +8,7 @@ Changelog
 - Extend the @config endpoint with the current inbox_folder_url. [elioschmutz]
 - Complement @role-assignment-reports responses with type, principal label, title and referenced roles. [tinagerber]
 - Add another nesting level to simple saas policy templates. [deiferni]
+- Add missing inboxes for multi orgunit setups in the examplecontent fd profile and testing fixture [elioschmutz]
 
 
 2020.7.0 (2020-08-12)

--- a/opengever/api/tests/test_config.py
+++ b/opengever/api/tests/test_config.py
@@ -265,7 +265,7 @@ class TestConfig(IntegrationTestCase):
         browser.open(self.portal.absolute_url() + '/@config',
                      headers=self.api_headers)
         self.assertEqual(browser.status_code, 200)
-        self.assertEqual(browser.json.get(u'inbox_folder_url'), u'http://nohost/plone/eingangskorb')
+        self.assertEqual(browser.json.get(u'inbox_folder_url'), u'http://nohost/plone/eingangskorb/eingangskorb_fa')
 
         self.login(self.regular_user, browser)
 

--- a/opengever/api/tests/test_serializer.py
+++ b/opengever/api/tests/test_serializer.py
@@ -156,7 +156,7 @@ class TestInboxSerializer(IntegrationTestCase):
         self.login(self.secretariat_user, browser)
         browser.open(self.inbox, headers=self.api_headers)
         self.assertEqual(browser.status_code, 200)
-        self.assertEqual(browser.json.get(u'email'), u'1011013300@example.org')
+        self.assertEqual(browser.json.get(u'email'), u'1011033300@example.org')
 
     @browsing
     def test_inbox_serialization_contains_inbox_id(self, browser):

--- a/opengever/api/tests/test_task.py
+++ b/opengever/api/tests/test_task.py
@@ -89,11 +89,11 @@ class TestTaskSerialization(SolrIntegrationTestCase):
         browser.open(
             self.inbox_forwarding, method="GET", headers=self.api_headers)
         self.assertEquals(
-            [{u'@id': u'http://nohost/plone/eingangskorb/forwarding-1/@responses/1472634453000000',
-              u'response_id': 1472634453000000,
+            [{u'@id': u'http://nohost/plone/eingangskorb/eingangskorb_fa/forwarding-1/@responses/1472634573000000',
+              u'response_id': 1472634573000000,
               u'response_type': u'default',
               u'added_objects': [{
-                u'@id': u'http://nohost/plone/eingangskorb/forwarding-1/document-13',
+                u'@id': u'http://nohost/plone/eingangskorb/eingangskorb_fa/forwarding-1/document-13',
                 u'@type': u'opengever.document.document',
                 u'description': u'',
                 u'is_leafnode': None,
@@ -103,7 +103,7 @@ class TestTaskSerialization(SolrIntegrationTestCase):
               u'creator': {
                   u'token': u'nicole.kohler',
                   u'title': u'Kohler Nicole'},
-              u'created': u'2016-08-31T11:07:33',
+              u'created': u'2016-08-31T11:09:33',
               u'related_items': [],
               u'text': u'',
               u'mimetype': u'',
@@ -215,12 +215,12 @@ class TestTaskSerialization(SolrIntegrationTestCase):
         self.maxDiff = None
         self.assertDictEqual(
             {
-                u'@id': u'http://nohost/plone/eingangskorb',
+                u'@id': u'http://nohost/plone/eingangskorb/eingangskorb_fa',
                 u'@type': u'opengever.inbox.inbox',
                 u'description': u'',
                 u'is_leafnode': None,
                 u'review_state': u'inbox-state-default',
-                u'title': u'Eingangsk\xf6rbli',
+                u'title': u'Eingangsk\xf6rbli FA',
             },
             browser.json['containing_dossier']
         )

--- a/opengever/api/tests/test_watchers.py
+++ b/opengever/api/tests/test_watchers.py
@@ -77,7 +77,7 @@ class TestWatchersGet(SolrIntegrationTestCase):
                      method='GET', headers=self.api_headers)
 
         expected_json = {
-            u'@id': u'http://nohost/plone/eingangskorb/forwarding-1/@watchers',
+            u'@id': u'http://nohost/plone/eingangskorb/eingangskorb_fa/forwarding-1/@watchers',
             u'referenced_users': [
                 {
                     u'@id': u'http://nohost/plone/@users/kathi.barfuss',
@@ -114,7 +114,7 @@ class TestWatchersGet(SolrIntegrationTestCase):
 
         browser.open(self.inbox_forwarding, method='GET', headers=self.api_headers)
 
-        self.assertEqual({u'@id': u'http://nohost/plone/eingangskorb/forwarding-1/@watchers'},
+        self.assertEqual({u'@id': u'http://nohost/plone/eingangskorb/eingangskorb_fa/forwarding-1/@watchers'},
                          browser.json['@components']['watchers'])
         browser.open(self.inbox_forwarding.absolute_url() + '?expand=watchers',
                      method='GET', headers=self.api_headers)

--- a/opengever/examplecontent/configure.zcml
+++ b/opengever/examplecontent/configure.zcml
@@ -13,7 +13,7 @@
   <opengever:registerDeployment
       title="Development with examplecontent (FD)"
       policy_profile="opengever.examplecontent:default"
-      additional_profiles="opengever.setup:default_content
+      additional_profiles="opengever.examplecontent:default_content
                            opengever.examplecontent:empty_templates
                            opengever.examplecontent:repository_minimal
                            opengever.examplecontent:municipality_content
@@ -57,6 +57,13 @@
       name="default-ska"
       title="opengever.examplecontent: default-ska"
       directory="profiles/default-ska"
+      provides="Products.GenericSetup.interfaces.EXTENSION"
+      />
+
+  <genericsetup:registerProfile
+      name="default_content"
+      title="opengever.examplecontent: default_content"
+      directory="profiles/default_content"
       provides="Products.GenericSetup.interfaces.EXTENSION"
       />
 

--- a/opengever/examplecontent/profiles/default_content/content_creation/01_default_content.json
+++ b/opengever/examplecontent/profiles/default_content/content_creation/01_default_content.json
@@ -1,0 +1,42 @@
+[
+    {
+        "_path": "private",
+        "_type": "opengever.private.root",
+        "title_de": "Meine Ablage",
+        "title_fr": "Mon dépôt",
+        "_placefulworkflow": ["opengever_private_policy",
+                              "opengever_private_policy"]
+    },
+    {
+        "_path": "eingangskorb",
+        "_type": "opengever.inbox.container",
+        "title_de": "Eingangskorb",
+        "title_fr": "Boîte de réception",
+        "_placefulworkflow": ["opengever_inbox_policy",
+                              "opengever_inbox_policy"],
+        "_ac_local_roles": {
+            "og_demo-ftw_users": [
+                "Reader"
+            ]
+        }
+    },
+    {
+        "_path": "vorlagen",
+        "_type": "opengever.dossier.templatefolder",
+        "title_de": "Vorlagen",
+        "title_fr": "Modèles"
+    },
+    {
+        "_path": "kontakte",
+        "_type": "opengever.contact.contactfolder",
+        "title_de": "Kontakte",
+        "title_fr": "Contacts",
+        "_transitions": "publish"
+    },
+    {
+        "_path": "workspaces",
+        "_type": "opengever.workspace.root",
+        "title_de": "Teamräume",
+        "title_fr": "Espace partagé"
+    }
+]

--- a/opengever/examplecontent/profiles/default_content/content_creation/02_inboxes.json
+++ b/opengever/examplecontent/profiles/default_content/content_creation/02_inboxes.json
@@ -1,0 +1,34 @@
+[
+    {
+        "_path": "eingangskorb/eingangskorb_afi",
+        "responsible_org_unit": "afi",
+        "_type": "opengever.inbox.inbox",
+        "inbox_group": "og_demo-ftw_users",
+        "title_de": "Eingangskorb AFI",
+        "title_fr": "Boîte de réception AFI",
+        "_block-local-roles": true,
+        "_ac_local_roles": {
+            "og_demo-ftw_users": [
+                "Contributor",
+                "Editor",
+                "Reader"
+            ]
+        }
+    },
+    {
+        "_path": "eingangskorb/eingangskorb_stv",
+        "responsible_org_unit": "stv",
+        "_type": "opengever.inbox.inbox",
+        "inbox_group": "og_demo-ftw_users",
+        "title_de": "Eingangskorb STV",
+        "title_fr": "Boîte de réception STV",
+        "_block-local-roles": true,
+        "_ac_local_roles": {
+            "og_demo-ftw_users": [
+                "Contributor",
+                "Editor",
+                "Reader"
+            ]
+        }
+    }
+]

--- a/opengever/examplecontent/profiles/default_content/metadata.xml
+++ b/opengever/examplecontent/profiles/default_content/metadata.xml
@@ -1,0 +1,3 @@
+<metadata>
+  <version>1</version>
+</metadata>

--- a/opengever/officeconnector/tests/test_api_forwarding_attach.py
+++ b/opengever/officeconnector/tests/test_api_forwarding_attach.py
@@ -36,7 +36,7 @@ class TestOfficeconnectorForwardingAPIWithAttach(OCIntegrationTestCase):
 
         expected_token = {
             u'action': u'attach',
-            u'documents': [u'createinbox000000000000000000004'],
+            u'documents': [u'createinboxfa0000000000000000004'],
             u'exp': 4121033100,
             u'sub': u'jurgen.konig',
             u'url': u'http://nohost/plone/oc_attach',
@@ -48,11 +48,11 @@ class TestOfficeconnectorForwardingAPIWithAttach(OCIntegrationTestCase):
         expected_payloads = [{
             u'content-type': u'text/plain',
             u'csrf-token': u'86ecf9b4135514f8c94c61ce336a4b98b4aaed8a',
-            u'document-url': u'http://nohost/plone/eingangskorb/forwarding-1/document-13',
+            u'document-url': u'http://nohost/plone/eingangskorb/eingangskorb_fa/forwarding-1/document-13',
             u'download': u'download',
             u'filename': u'Dokument im Eingangskoerbliweiterleitung.txt',
             u'title': u'Dokument im Eingangsk\xf6rbliweiterleitung',
-            u'uuid': u'createinbox000000000000000000004',
+            u'uuid': u'createinboxfa0000000000000000004',
             }]
         payloads = self.fetch_document_attach_payloads(browser, raw_token, token)
         self.assertEquals(200, browser.status_code)

--- a/opengever/usermigration/tests/test_localroles.py
+++ b/opengever/usermigration/tests/test_localroles.py
@@ -26,7 +26,7 @@ class TestMigrateLocalRoles(IntegrationTestCase):
         results = migrate_localroles(self.inbox, mapping, mode='move')
 
         self.assertEqual(
-            [('/plone/eingangskorb', old_id, 'new_user.id')],
+            [('/plone/eingangskorb/eingangskorb_fa', old_id, 'new_user.id')],
             results['moved'])
         self.assertEqual([], results['copied'])
         self.assertEqual([], results['deleted'])
@@ -62,7 +62,7 @@ class TestMigrateLocalRoles(IntegrationTestCase):
         self.assertEqual([], results['moved'])
         self.assertEqual([], results['copied'])
         self.assertEqual(
-            [('/plone/eingangskorb', old_id, None)],
+            [('/plone/eingangskorb/eingangskorb_fa', old_id, None)],
             results['deleted'])
 
         self.assertEqual([], manager.get_assignments_by_principal_id(old_id))
@@ -84,7 +84,7 @@ class TestMigrateLocalRoles(IntegrationTestCase):
 
         self.assertEqual([], results['moved'])
         self.assertEqual(
-            [('/plone/eingangskorb', old_id, 'new_user.id')],
+            [('/plone/eingangskorb/eingangskorb_fa', old_id, 'new_user.id')],
             results['copied'])
         self.assertEqual([], results['deleted'])
 


### PR DESCRIPTION
This PR updates the example content profile and the testing fixture to add separate inboxes for each org-unit within an inbox container.

This is the expected setup for a multi-orgunit setup.

Jira: https://4teamwork.atlassian.net/browse/GEVER-490

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
