### PR TITLE
Reindex modified containers after bundle import.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -11,6 +11,7 @@ Changelog
 - Fix filtering with exclusion filters if the field has a mapping. [tinagerber]
 - Make the portal_url configurable through the portal_registry. [elioschmutz]
 - Include OGUID in all API content GET responses. [lgraf]
+- Reindex modified containers after bundle import. [njohner]
 - Extend the @config endpoint with the current inbox_folder_url. [elioschmutz]
 - Complement @role-assignment-reports responses with type, principal label, title and referenced roles. [tinagerber]
 - Add another nesting level to simple saas policy templates. [deiferni]

--- a/opengever/bundle/cfgs/oggbundle.cfg
+++ b/opengever/bundle/cfgs/oggbundle.cfg
@@ -29,6 +29,7 @@ pipeline =
     reindexobject
     savepoint
     progress
+    reindex-containers
     commit
     post-import-validation
     report
@@ -78,6 +79,9 @@ every = 500
 
 [progress]
 blueprint = opengever.bundle.progress
+
+[reindex-containers]
+blueprint = opengever.bundle.reindex_containers
 
 [commit]
 blueprint = opengever.bundle.commit

--- a/opengever/bundle/sections/constructor.py
+++ b/opengever/bundle/sections/constructor.py
@@ -70,6 +70,10 @@ class ConstructorSection(object):
         self.bundle.path_by_refnum_cache = {}
         self.bundle.constructed_guids = set()
 
+        # stores containers that will need reindexing at the end of the bundle
+        # import because they were modified by adding children into them.
+        self.bundle.containers_to_reindex = set()
+
     def _has_translated_title(self, fti):
         return ITranslatedTitle.__identifier__ in fti.behaviors
 
@@ -253,6 +257,7 @@ class ConstructorSection(object):
             try:
                 obj = self._construct_object(container, item)
                 self.bundle.constructed_guids.add(item['guid'])
+                self.bundle.containers_to_reindex.add(parent_path)
                 logger.info(u'Constructed %r' % obj)
             except ValueError as e:
                 logger.warning(

--- a/opengever/bundle/sections/reindex_containers.py
+++ b/opengever/bundle/sections/reindex_containers.py
@@ -1,0 +1,48 @@
+from collective.transmogrifier.interfaces import ISection
+from collective.transmogrifier.interfaces import ISectionBlueprint
+from collective.transmogrifier.utils import traverse
+from opengever.bundle.sections.bundlesource import BUNDLE_KEY
+from plone import api
+from zope.annotation import IAnnotations
+from zope.interface import classProvides
+from zope.interface import implements
+import logging
+import transaction
+
+
+log = logging.getLogger('opengever.bundle.reindex_containers')
+log.setLevel(logging.INFO)
+
+
+class ReindexContainersSection(object):
+    """Reindex specific indexes for containers into which objects
+    were added during bundle import.
+    """
+
+    classProvides(ISectionBlueprint)
+    implements(ISection)
+
+    def __init__(self, transmogrifier, name, options, previous):
+        self.previous = previous
+        self.transmogrifier = transmogrifier
+        self.site = api.portal.get()
+        self.bundle = IAnnotations(transmogrifier)[BUNDLE_KEY]
+        self.indexes = ['modified']
+        self.catalog = api.portal.get_tool('portal_catalog')
+
+    def __iter__(self):
+        for item in self.previous:
+            yield item
+
+        n_containers = len(self.bundle.containers_to_reindex)
+        log.info("Reindexing {} containers after bundle import...".format(n_containers))
+
+        for container_path in self.bundle.containers_to_reindex:
+            obj = traverse(self.site, container_path, None)
+            obj.reindexObject(idxs=self.indexes)
+
+        log.info("Committing...")
+
+        transaction.commit()
+
+        log.info("Done reindexing {} containers".format(n_containers))

--- a/opengever/bundle/transmogrifier.zcml
+++ b/opengever/bundle/transmogrifier.zcml
@@ -83,4 +83,9 @@
       name="opengever.bundle.report"
       />
 
+  <utility
+      component=".sections.reindex_containers.ReindexContainersSection"
+      name="opengever.bundle.reindex_containers"
+      />
+
 </configure>

--- a/opengever/core/upgrades/20200817143709_reindex_container_modified_during_bundle_import/upgrade.py
+++ b/opengever/core/upgrades/20200817143709_reindex_container_modified_during_bundle_import/upgrade.py
@@ -1,0 +1,57 @@
+from ftw.solr.browser.maintenance import solr_date
+from ftw.solr.interfaces import ISolrConnectionManager
+from ftw.upgrade import UpgradeStep
+from plone.dexterity.interfaces import IDexterityContainer
+from zope.component import queryUtility
+import logging
+
+LOG = logging.getLogger('ftw.upgrade')
+
+
+class ReindexContainerModifiedDuringBundleImport(UpgradeStep):
+    """Reindex container modified during bundle import.
+
+    The problematic containers are identified by the fact that the modified
+    date on the object is different from the modified date in the catalog.
+    This leads to objects that have a different modified date in solr than in
+    the catalog. We use this to easily identify the problematic objects and
+    avoid reindexing all containers.
+    """
+
+    deferrable = True
+
+    def __call__(self):
+        self.install_upgrade_profile()
+        portal_types = [
+            u'opengever.dossier.businesscasedossier',
+            u'opengever.repository.repositoryfolder',
+            u'opengever.repository.repositoryroot',
+            u'opengever.workspace.folder',
+            u'opengever.workspace.root',
+            u'opengever.workspace.workspace']
+        items = self.catalog_unrestricted_search(
+            {'portal_type': portal_types})
+        catalog_modified = set(
+            [(item.UID, solr_date(item.modified)) for item in items])
+
+        manager = queryUtility(ISolrConnectionManager)
+        conn = manager.connection
+        resp = conn.search({
+            u'query': u'portal_type:({})'.format(u' OR '.join(portal_types)),
+            u'limit': 10000000,
+            u'params': {u'fl': ['UID', 'modified']},
+        })
+        solr_modified = set(
+            [(doc['UID'], doc.get('modified', u'2000-01-01T00:00:00.000Z'))
+             for doc in resp.docs])
+
+        not_in_sync = [item[0] for item in catalog_modified - solr_modified]
+
+        for plone_uid in not_in_sync:
+            brains = self.catalog_unrestricted_search({'UID': plone_uid})
+            if len(brains) != 1:
+                LOG.error(
+                    'Could not find a unique brain for the UID={}'.format(plone_uid)
+                )
+                continue
+            brains[0].getObject().reindexObject(idxs=['modified'])


### PR DESCRIPTION
In the oggbundle import pipeline, object reindexing is deactivated to avoid objects being reindexed several times during the import.
Every object is indexed just once in the pipeline, but containers into wich objects are added were not reindex afterwards, leading to a discrepency in the modified date on the object and in the catalog. This in turn leads to problems with solr diff / sync.

We also add an upgrade step, which identifies the concerned objects by their symptom of having a different modified date in the catalog than on the object, and hence in solr...

For https://4teamwork.atlassian.net/browse/GEVER-190

## Checklist (Must have)

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


## Checklist (if applicable)

- Upgrade steps (changes in profile):
  - [x] Make it deferrable if possible
  - [x] Execute as much as possible conditionally