### PR TITLE
Make the portal_url configurable through the portal_registry.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2020.7.1 (unreleased)
 ---------------------
 
+- Make the portal_url configurable through the portal_registry. [elioschmutz]
 - Extend the @config endpoint with the current inbox_folder_url. [elioschmutz]
 
 

--- a/opengever/base/casauth.py
+++ b/opengever/base/casauth.py
@@ -1,4 +1,5 @@
 from ftw.casauth.plugin import CASAuthenticationPlugin
+from opengever.base.interfaces import IPortalSettings
 from opengever.ogds.base.utils import get_current_admin_unit
 from plone import api
 from Products.PluggableAuthService.interfaces.plugins import IChallengePlugin
@@ -38,8 +39,10 @@ def get_cluster_base_url():
 def get_gever_portal_url():
     """Get the URL of the GEVER portal.
     """
+    portal_url = api.portal.get_registry_record('portal_url', IPortalSettings, '')
     base_url = get_cluster_base_url()
-    return urljoin(base_url, 'portal')
+
+    return portal_url if portal_url else urljoin(base_url, 'portal')
 
 
 def get_cas_server_url():

--- a/opengever/base/interfaces.py
+++ b/opengever/base/interfaces.py
@@ -431,3 +431,13 @@ class IRoleAssignmentReportsStorage(Interface):
     def delete(report_uid):
         """Delete the corresponding role assignment report.
         """
+
+
+class IPortalSettings(Interface):
+
+    portal_url = schema.TextLine(
+        title=u'Portal url',
+        description=u'This url will be exposed in the @config endpoint and will '
+                    u'be used to generate the workspace invitation url. '
+                    u'Leave it blank to use an auto generated portal url to '
+                    u'[cluster-base-url]/portal')

--- a/opengever/base/tests/test_casauth.py
+++ b/opengever/base/tests/test_casauth.py
@@ -3,8 +3,10 @@ from ftw.builder import create
 from opengever.base.casauth import get_cas_server_url
 from opengever.base.casauth import get_cluster_base_url
 from opengever.base.casauth import get_gever_portal_url
+from opengever.base.interfaces import IPortalSettings
 from opengever.ogds.base.utils import get_current_admin_unit
 from opengever.testing import IntegrationTestCase
+from plone import api
 from plone.app.testing import applyProfile
 
 
@@ -78,3 +80,10 @@ class TestGEVERPortalURL(IntegrationTestCase):
         get_current_admin_unit().public_url = 'http://example.com/foobar'
         self.assertEquals(
             'http://example.com/foobar/portal', get_gever_portal_url())
+
+    def test_use_the_portal_url_in_the_plone_registry_if_set(self):
+        api.portal.set_registry_record(
+            'portal_url', u'http://example.com/my-special-portal', IPortalSettings)
+
+        self.assertEquals(
+            'http://example.com/my-special-portal', get_gever_portal_url())

--- a/opengever/core/profiles/default/registry.xml
+++ b/opengever/core/profiles/default/registry.xml
@@ -11,6 +11,7 @@
   <records interface="opengever.base.behaviors.classification.IClassificationSettings" />
   <records interface="opengever.base.interfaces.IRecentlyTouchedSettings" />
   <records interface="opengever.base.interfaces.IOGMailSettings" />
+  <records interface="opengever.base.interfaces.IPortalSettings" />
 
   <!-- BUMBLEBEE -->
   <records interface="opengever.bumblebee.interfaces.IGeverBumblebeeSettings" />

--- a/opengever/core/upgrades/20200818160702_add_portal_settings_registry/registry.xml
+++ b/opengever/core/upgrades/20200818160702_add_portal_settings_registry/registry.xml
@@ -1,0 +1,6 @@
+<registry>
+
+  <!-- BASE -->
+  <records interface="opengever.base.interfaces.IPortalSettings" />
+
+</registry>

--- a/opengever/core/upgrades/20200818160702_add_portal_settings_registry/upgrade.py
+++ b/opengever/core/upgrades/20200818160702_add_portal_settings_registry/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddPortalSettingsRegistry(UpgradeStep):
+    """Add portal settings registry.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()


### PR DESCRIPTION
This PR adds a new registry entry to define the portal_url.

By default, the portal url refers to `[admin-unit-url]/portal`(i.e. https://mygever.com/portal). In rare cases where the portal is not running under the same domain like the gever, we have to define it separately.

In Jira, there is a suggestion to reuse the cas-auth url from the auth-plugin to guess the portal url. This could have been one possible solution. But guessing will lead once again into problems in the future. So I introduced a new setting to override the default `portal_url`.

Currently, the `portal_url` will be exposed in the @config endpoint and will be used to generate the invitation url for teamraum invitations.

Jira: https://4teamwork.atlassian.net/browse/GEVER-860

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


## Checklist (if applicable)

_Only applicable should be left and checked._

- API change:
  - [ ] Documentation is updated
  - If breaking:
    - [ ] api-change label added
    - [ ] Scrum master is informed
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Upgrade steps (changes in profile):
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
- DB-Schema migration
  - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
  - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value
