### PR TITLE
Add API endpoints for accepting and completing remote tasks

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 2020.7.1 (unreleased)
 ---------------------
 
+- Introduce POST @complete-successor-task on tasks. [lgraf]
+- Introduce POST @accept-remote-task endpoint for dossiers. [lgraf]
+- Introduce POST @remote-workflow endpoint. [lgraf]
 - Add policy template for teamraum policies. [njohner]
 - Fix filtering with exclusion filters if the field has a mapping. [tinagerber]
 - Make the portal_url configurable through the portal_registry. [elioschmutz]

--- a/docs/public/dev-manual/api/accept_remote_task.rst
+++ b/docs/public/dev-manual/api/accept_remote_task.rst
@@ -1,0 +1,58 @@
+.. _accept_remote_task:
+
+Remote-Task akzeptieren
+=======================
+
+Der ``@accept-remote-task`` Endpoint auf Dossiers erlaubt es, eine mandantenübergreifende Aufgbe in dieses Dossier zu akzeptieren (es wird eine Kopie der Aufgabe im Dossier erstellt, auf welchem der Endpoint aufgerufen wird).
+
+Der Remote-Task wird über den Parameter ``task_oguid`` im JSON Body angegeben (der Task *muss* sich auf einem anderen Mandanten befinden), und optional kann im Parameter ``text`` ein Kommentar zum Akzeptieren der Aufgabe angegeben werden.
+
+Im untenstehenden Beispiel ist ``fd`` der Remote-Mandant, und der Benutzer, hugo.boss, will auf seinem lokalen Mandanten, ``rk``, eine Aufgabe auf dem ``fd`` akzeptieren, und eine Kopie der Aufgabe im ``dossier-17`` auf seinem Mandanten erstellen. Die Aufgabe ist durch die *task_oguid* ``fd:12345`` identifiziert.
+
+**Beispiel-Request**:
+
+   .. sourcecode:: http
+
+       POST /rk/dossier-17/@accept-remote-task HTTP/1.1
+       Content-Type: application/json
+       Accept: application/json
+
+       {
+         "task_oguid": "fd:12345",
+         "text": "Ich akzeptiere diese Aufgabe via Kopie in meinem Dossier"
+       }
+
+Die Response enthält das serialisierte Objekt (die soeben erstellte lokale Aufgabenkopie), so wie sie für einen regulären GET request aussehen würde:
+
+**Beispiel-Response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 201 Created
+      Content-Type: application/json
+
+      {
+        "@id": "http://.../dossier-17/task-42",
+        "@type": "opengever.task.task",
+        "oguid": "plone:1451484829",
+        "...": "...",
+        "predecessor": "plone:1451484827",
+        "responses": [
+          {"...": "..."},
+          {
+            "@id": "http://.../dossier-17/task-42/@responses/1598198218402585",
+            "...": "...",
+            "text": "Ich akzeptiere diese Aufgabe via Kopie in meinem Dossier",
+            "transition": "task-transition-open-in-progress"
+          }
+        ],
+        "responsible": {
+          "title": "Ratskanzlei: Boss Hugo (hugo.boss)",
+          "token": "rk:hugo.boss"
+        },
+        "responsible_client": {
+          "title": "Ratskanzlei",
+          "token": "rk"
+        },
+        "review_state": "task-state-in-progress"
+      }

--- a/docs/public/dev-manual/api/complete_successor_task.rst
+++ b/docs/public/dev-manual/api/complete_successor_task.rst
@@ -1,0 +1,73 @@
+.. _complete_successor_task:
+
+Successor-Task abschliessen
+===========================
+
+Der ``@complete-successor-task`` Endpoint auf Aufgaben erlaubt es, eine mandantenübergreifende Nachfolgeaufgabe abzuschliessen.
+
+Durch das Abschliessen der Nachfolgeaufgabe wird das Backend auch die Vorgänger-Aufgabe auf dem Remote-Mandanten abschliessen, und ggf. die angegebenen Dokumente an die Vorgängeraufgabe zurück übermitteln.
+
+Dokumente, welche zurück übermittelt werden sollen, können über den Parameter ``documents`` angegeben werden. Dieser Parameter erlaubt die Referenzierung von Dokumenten (im selben Dossier wie die Nachfolgeaufgabe) über IntId (``1423795951``), OGUID (``rk:1423795951``) oder Pfad (``/rk/dossier-17/document-23``). 
+
+Optional kann im Parameter ``text`` ein Kommentar zum Abschliessen der Aufgabe angegeben werden.
+
+Im untenstehenden Beispiel ist ``fd`` der Remote-Mandant, und der Benutzer, hugo.boss, will auf seinem lokalen Mandanten, ``rk``, die Aufgabe ``task-42`` abschliessen.
+
+**Beispiel-Request**:
+
+   .. sourcecode:: http
+
+       POST /rk/task-42/@complete-successor-task HTTP/1.1
+       Content-Type: application/json
+       Accept: application/json
+
+       {
+         "transition": "task-transition-in-progress-resolved",
+         "documents": [1423795951],
+         "text": "Ich schliesse diese Aufgabe ab."
+       }
+
+Die Response enthält das serialisierte Objekt (die soeben abgeschlossene Nachfolgeaufgabe), so wie sie für einen regulären GET request aussehen würde:
+
+**Beispiel-Response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 200 OK
+      Content-Type: application/json
+
+      {
+        "@id": "http://.../dossier-17/task-42",
+        "@type": "opengever.task.task",
+        "oguid": "plone:2118709190",
+        "...": "...",
+        "predecessor": "plone:2118709189",
+        "responses": [
+          {"...": "..."},
+          {
+            "@id": "http://.../dossier-17/task-42/@responses/1598221249104420",
+            "...": "...",
+            "added_objects": [
+              {
+                "@id": "http://...(dossier-17/task-42/document-77",
+                "@type": "opengever.document.document",
+                "description": "",
+                "is_leafnode": null,
+                "review_state": "document-state-draft",
+                "title": "Statement in response to inquiry"
+              }
+            ],
+            "text": "Ich schliesse diese Aufgabe ab.",
+            "transition": "task-transition-in-progress-resolved"
+          }
+        ],
+        "responsible": {
+          "title": "Ratskanzlei: Boss Hugo (hugo.boss)",
+          "token": "rk:hugo.boss"
+        },
+        "responsible_client": {
+          "title": "Ratskanzlei",
+          "token": "rk"
+        },
+        "review_state": "task-state-resolved"
+      }

--- a/docs/public/dev-manual/api/index.rst
+++ b/docs/public/dev-manual/api/index.rst
@@ -48,6 +48,7 @@ Inhalt:
    linked_workspaces.rst
    templatefolder.rst
    trigger_task_template.rst
+   remote_workflow.rst
    examples/index.rst
    docs_changelog.rst
 

--- a/docs/public/dev-manual/api/index.rst
+++ b/docs/public/dev-manual/api/index.rst
@@ -49,6 +49,7 @@ Inhalt:
    templatefolder.rst
    trigger_task_template.rst
    remote_workflow.rst
+   accept_remote_task.rst
    examples/index.rst
    docs_changelog.rst
 

--- a/docs/public/dev-manual/api/index.rst
+++ b/docs/public/dev-manual/api/index.rst
@@ -50,6 +50,7 @@ Inhalt:
    trigger_task_template.rst
    remote_workflow.rst
    accept_remote_task.rst
+   complete_successor_task.rst
    examples/index.rst
    docs_changelog.rst
 

--- a/docs/public/dev-manual/api/remote_workflow.rst
+++ b/docs/public/dev-manual/api/remote_workflow.rst
@@ -1,0 +1,43 @@
+.. _remote_workflow:
+
+Remote Workflow-Transitionen
+============================
+
+Der ``@remote-workflow`` Endpoint erlaubt es, eine Workflow-Transition mandantenübergreifend auszulösen.
+
+Der Aufruf erfolgt genau gleich wie ein Aufrauf des :ref:`regulären @workflow Endpoints <workflow>`, mit dem einzigen Unterschied, dass das Objekt über eine ``remote_oguid`` (im JSON body des Requests) spezifiziert wird, statt über den Pfad auf welchem der Endpoint aufgerufen wird.
+
+Das über die ``remote_oguid`` identifizierte Objekt *muss* sich auf einem anderen Mandant befinden, und muss von einem Typ sein, dessen OGUID im GlobalIndex indexiert ist (dies sind zur Zeit nur Aufgaben).
+
+Das Backend bestimmt dann den entsprechenden Mandanten, leitet den Request an diesen weiter (im Security-Kontext des Benutzers), und leitet die Response wieder an den Client zurück. Wenn der Benutzer auf dem remote-Mandanten die nötigen Berechtigungen hat, wird dadurch die entsprechende Workflow-Transition durchgeführt.
+
+Im untenstehenden Beispiel ist ``fd`` der Remote-Mandant, und der Benutzer will via seinem lokalen Mandanten, ``rk``, eine Aufgabe auf dem ``fd`` akzeptieren. Diese Aufgabe ist durch die *remote_oguid* ``fd:12345`` identifiziert.
+
+**Beispiel-Request**:
+
+   .. sourcecode:: http
+
+       POST /rk/@remote-workflow/task-transition-open-in-progress HTTP/1.1
+       Content-Type: application/json
+       Accept: application/json
+
+       {
+         "remote_oguid": "fd:12345",
+         "text": "Ich akzeptiere diese Aufgabe"
+       }
+
+**Beispiel-Response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 200 OK
+      Content-Type: application/json
+
+      {
+        "action": "task-transition-open-in-progress",
+        "actor": "hugo.boss",
+        "comments": "",
+        "review_state": "task-state-in-progress",
+        "time": "2020-08-17T13:28:04+00:00",
+        "title": "In Arbeit"
+      }

--- a/opengever/api/accept_remote_task.py
+++ b/opengever/api/accept_remote_task.py
@@ -1,0 +1,93 @@
+from opengever.base.exceptions import MalformedOguid
+from opengever.base.oguid import Oguid
+from opengever.task.browser.accept.utils import accept_task_with_successor
+from plone.protect.interfaces import IDisableCSRFProtection
+from plone.restapi.deserializer import json_body
+from plone.restapi.interfaces import ISerializeToJson
+from plone.restapi.services import Service
+from zExceptions import BadRequest
+from zope.component import queryMultiAdapter
+from zope.interface import alsoProvides
+import json
+
+
+class AcceptRemoteTaskPost(Service):
+    """Accepts a task on a remote admin unit by creating a successor copy
+    in the dossier the endpoint was invoked on.
+
+    POST /dossier-17/@accept-remote-task
+
+    {
+      "task_oguid": "fd:12345",
+      "text": "I'm accepting this task into this dossier."
+    }
+
+    This endpoint will accept a remote task (a task that is assigned to the
+    current user, but physically is located on a different admin unit) by
+    creating a successor copy in the local dossier, and linking the successor
+    task with its predecessor on the remote admin unit.
+
+    Documents attached to the remote task get copied to the local task copy
+    as well.
+
+    The remote task is identified via the "task_oguid" in the JSON body, and
+    *must* be on a different admin unit than the current one.
+    """
+
+    def _format_exception(self, exc):
+        return '%s: %s' % (exc.__class__.__name__, str(exc))
+
+    def is_remote(self, oguid):
+        return not oguid.is_on_current_admin_unit
+
+    def reply(self):
+        # Disable CSRF protection
+        alsoProvides(self.request, IDisableCSRFProtection)
+
+        # Extract and validate parameters
+        json_data = json_body(self.request)
+
+        raw_task_oguid = json_data.pop('task_oguid', None)
+        if not raw_task_oguid:
+            raise BadRequest(
+                'Required parameter "task_oguid" is missing in body')
+
+        response_text = json_data.pop('text', u'')
+
+        # Reject any unexpected parameters
+        unexpected_params = json_data.keys()
+        if unexpected_params:
+            raise BadRequest(
+                'Unexpected parameter(s) in JSON '
+                'body: %s. Supported parameters are: '
+                '["task_oguid", "text"]' % json.dumps(unexpected_params))
+
+        # Validate that Oguid is well-formed and refers to a task that is
+        # actually remote. Turn any Python exceptions into proper
+        # 400 Bad Request responses with details in the JSON body.
+        try:
+            task_oguid = Oguid.parse(raw_task_oguid)
+        except MalformedOguid as exc:
+            raise BadRequest(self._format_exception(exc))
+
+        if not self.is_remote(task_oguid):
+            raise BadRequest(
+                'Task must be on remote admin unit. '
+                'Oguid %s refers to a local task, however.' % raw_task_oguid)
+
+        # dispatch remote request to accept task in given dossier,
+        # creating a copy of the task and its attached documents
+        dossier_to_accept_in = self.context
+        successor = accept_task_with_successor(
+            dossier_to_accept_in,
+            raw_task_oguid,
+            response_text,
+        )
+
+        self.request.response.setStatus(201)
+        self.request.response.setHeader("Location", successor.absolute_url())
+
+        serializer = queryMultiAdapter((successor, self.request), ISerializeToJson)
+        serialized_successor = serializer()
+        serialized_successor["@id"] = successor.absolute_url()
+        return serialized_successor

--- a/opengever/api/complete_successor_task.py
+++ b/opengever/api/complete_successor_task.py
@@ -1,0 +1,113 @@
+from opengever.base.oguid import Oguid
+from opengever.globalindex.model.task import Task
+from opengever.task.browser.complete_utils import complete_task_and_deliver_documents
+from plone import api
+from plone.protect.interfaces import IDisableCSRFProtection
+from plone.restapi.deserializer import json_body
+from plone.restapi.interfaces import ISerializeToJson
+from plone.restapi.services import Service
+from Products.CMFDiffTool.utils import safe_utf8
+from zExceptions import BadRequest
+from zope.component import getUtility
+from zope.component import queryMultiAdapter
+from zope.interface import alsoProvides
+from zope.intid import IIntIds
+import json
+
+
+class CompleteSuccessorTaskPost(Service):
+    """Completes a successor task, its remote predecessor and optionally
+    delivers back documents to the remote predecessor task.
+
+    POST /task-42/@complete-successor-task
+
+    {
+      "transition": "task-transition-in-progress-resolved",
+      "documents": [1423795951],
+      "text": "I finished this task."
+    }
+
+    This endpoint will complete a successor task linked to a remote
+    predecessor, by executing the given `transition` for both the local
+    task (the one which this endpoint is invoked on) and the remote
+    predecessor.
+
+    Optionally, the specified `documents` from the containing dossier will be
+    transported back to the remote predecessor task.
+    """
+
+    def _format_exception(self, exc):
+        return '%s: %s' % (exc.__class__.__name__, str(exc))
+
+    @staticmethod
+    def _resolve_doc_ref_to_intid(doc_ref):
+        if isinstance(doc_ref, int):
+            # Already an IntId
+            return doc_ref
+
+        if isinstance(doc_ref, basestring) and '/' in doc_ref:
+            # Path
+            path = safe_utf8(doc_ref)
+            portal = api.portal.get()
+            obj = portal.restrictedTraverse(path)
+            return getUtility(IIntIds).getId(obj)
+
+        if isinstance(doc_ref, basestring) and ':' in doc_ref:
+            # Oguid
+            oguid = Oguid.parse(doc_ref)
+            return oguid.int_id
+
+        raise BadRequest('Unknown document reference: %r' % doc_ref)
+
+    def reply(self):
+        # Disable CSRF protection
+        alsoProvides(self.request, IDisableCSRFProtection)
+
+        # Extract and validate parameters
+        json_data = json_body(self.request)
+
+        transition = json_data.pop('transition', None)
+        if not transition:
+            raise BadRequest(
+                'Required parameter "transition" is missing in body')
+
+        docs_to_deliver = json_data.pop('documents', [])
+        response_text = json_data.pop('text', u'')
+
+        # Reject any unexpected parameters
+        unexpected_params = json_data.keys()
+        if unexpected_params:
+            raise BadRequest(
+                'Unexpected parameter(s) in JSON '
+                'body: %s. Supported parameters are: '
+                '["transition", "documents", "text"]'
+                % json.dumps(unexpected_params))
+
+        # Map any supported document reference type to an IntId
+        docs_to_deliver = map(self._resolve_doc_ref_to_intid, docs_to_deliver)
+
+        # Validate that this is actually a successor task
+        successor_task = self.context
+        if successor_task.predecessor is None:
+            raise BadRequest(
+                '@complete-successor-task only supports successor tasks. '
+                'This task has no predecessor.')
+
+        # Locate predecessor, and dispatch remote request to close them
+        # both, and deliver any documents if necessary
+        predecessor = Task.query.by_oguid(successor_task.predecessor)
+        remote_response = complete_task_and_deliver_documents(
+            successor_task, transition,
+            docs_to_deliver=docs_to_deliver,
+            response_text=response_text)
+
+        remote_response_body = remote_response.read()
+        if remote_response_body.strip() != 'OK':
+            raise Exception('Delivering documents and updating task failed '
+                            'on remote client %s.' % predecessor.admin_unit_id)
+
+        serializer = queryMultiAdapter(
+            (successor_task, self.request), ISerializeToJson)
+        serialized_successor = serializer()
+        serialized_successor["@id"] = successor_task.absolute_url()
+        return serialized_successor

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -861,4 +861,13 @@
       layer="opengever.base.interfaces.IOpengeverBaseLayer"
       />
 
+  <plone:service
+      method="POST"
+      name="@accept-remote-task"
+      for="opengever.dossier.behaviors.dossier.IDossierMarker"
+      factory=".accept_remote_task.AcceptRemoteTaskPost"
+      permission="cmf.AddPortalContent"
+      layer="opengever.base.interfaces.IOpengeverBaseLayer"
+      />
+
 </configure>

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -852,4 +852,13 @@
       layer="opengever.base.interfaces.IOpengeverBaseLayer"
       />
 
+  <plone:service
+      method="POST"
+      name="@remote-workflow"
+      for="Products.CMFPlone.interfaces.IPloneSiteRoot"
+      factory=".remote_workflow.RemoteWorkflowPost"
+      permission="zope2.View"
+      layer="opengever.base.interfaces.IOpengeverBaseLayer"
+      />
+
 </configure>

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -870,4 +870,13 @@
       layer="opengever.base.interfaces.IOpengeverBaseLayer"
       />
 
+  <plone:service
+      method="POST"
+      name="@complete-successor-task"
+      for="opengever.task.task.ITask"
+      factory=".complete_successor_task.CompleteSuccessorTaskPost"
+      permission="cmf.ModifyPortalContent"
+      layer="opengever.base.interfaces.IOpengeverBaseLayer"
+      />
+
 </configure>

--- a/opengever/api/remote_task_base.py
+++ b/opengever/api/remote_task_base.py
@@ -1,0 +1,61 @@
+from plone.restapi.deserializer import json_body
+from plone.restapi.interfaces import ISerializeToJson
+from plone.restapi.services import Service
+from zExceptions import BadRequest
+from zope.component import queryMultiAdapter
+import json
+
+
+class RemoteTaskBaseService(Service):
+    """Base class for REST API endpoints invoking remote task operations.
+    """
+
+    required_params = ()
+    optional_params = ()
+
+    required_params = ('transition', )
+    optional_params = ('documents', 'text')
+
+    def extract_params(self):
+        """Extract and validate required and optional parameters.
+
+        Reject any unknown parameters.
+        """
+        json_data = json_body(self.request)
+        params = {}
+
+        # Required
+        for req_name in self.required_params:
+            if req_name not in json_data:
+                raise BadRequest(
+                    'Required parameter "%s" is missing in body' % req_name)
+
+            value = json_data.pop(req_name)
+            params[req_name] = value
+
+        # Optional
+        for opt_name in self.optional_params:
+            if opt_name in json_data:
+                params[opt_name] = json_data.pop(opt_name)
+
+        # Reject any left over unexpected parameters
+        unexpected_params = json_data.keys()
+        if unexpected_params:
+            supported_params = self.required_params + self.optional_params
+            raise BadRequest(
+                'Unexpected parameter(s) in JSON body: %s. '
+                'Supported parameters are: %s' % (
+                    json.dumps(unexpected_params),
+                    json.dumps(supported_params)))
+
+        return params
+
+    def format_exception(self, exc):
+        return '%s: %s' % (exc.__class__.__name__, str(exc))
+
+    def serialize(self, obj):
+        serializer = queryMultiAdapter(
+            (obj, self.request), ISerializeToJson)
+        serialized_obj = serializer()
+        serialized_obj["@id"] = obj.absolute_url()
+        return serialized_obj

--- a/opengever/api/remote_workflow.py
+++ b/opengever/api/remote_workflow.py
@@ -1,0 +1,110 @@
+from opengever.base.exceptions import MalformedOguid
+from opengever.base.exceptions import NonRemoteOguid
+from opengever.base.exceptions import UnsupportedTypeForRemoteURL
+from opengever.base.oguid import Oguid
+from opengever.ogds.base.utils import get_current_admin_unit
+from plone import api
+from plone.restapi.deserializer import json_body
+from plone.restapi.services import Service
+from urlparse import parse_qs
+from zExceptions import BadRequest
+from zExceptions import InternalError
+from zope.interface import implements
+from zope.publisher.interfaces import IPublishTraverse
+import requests
+
+
+class RemoteWorkflowPost(Service):
+    """Proxies operations on the @workflow endpoint to a remote admin unit.
+
+    POST /plone/@remote-workflow/some-transition
+
+    {
+      "remote_oguid": "fd:12345",
+      "text": "I accept this task"
+    }
+
+    This endpoint will transparently proxy operations intended for the
+    @workflow endpoint on a remote admin unit.
+
+    Since the object in question is on a remote admin unit by definition, this
+    endpoint is invoked on the Plone site root of the AU doing the proxying,
+    instead of the actual context's path. The object in question is instead
+    identified by a "remote_oguid" that must be supplied in the JSON body.
+    """
+
+    implements(IPublishTraverse)
+
+    def __init__(self, context, request):
+        super(RemoteWorkflowPost, self).__init__(context, request)
+        self.path_params = []
+
+    def publishTraverse(self, request, name):
+        # Consume any path segments after /@remote-workflow as parameters
+        self.path_params.append(name)
+        return self
+
+    def extract_query_string_params(self):
+        return parse_qs(self.request['QUERY_STRING'])
+
+    def _format_exception(self, exc):
+        return '%s: %s' % (exc.__class__.__name__, str(exc))
+
+    def reply(self):
+        qs_params = self.extract_query_string_params()
+        json_data = json_body(self.request)
+
+        # Pop the remote_oguid from the JSON body, since it's not supposed to
+        # be forwarded to the remote side.
+        raw_remote_obj_oguid = json_data.pop('remote_oguid', None)
+        if not raw_remote_obj_oguid:
+            raise BadRequest(
+                'Required parameter "remote_oguid" is missing in body')
+
+        # Validate that Oguid is well-formed and refers to an object that is
+        # actually remote, and of the supported type (tasks). Turn any Python
+        # exceptions into proper 400 Bad Request responses with details in the
+        # JSON body.
+
+        try:
+            remote_obj_oguid = Oguid.parse(raw_remote_obj_oguid)
+        except MalformedOguid as exc:
+            raise BadRequest(self._format_exception(exc))
+
+        try:
+            remote_obj_url = remote_obj_oguid.get_remote_url()
+        except (UnsupportedTypeForRemoteURL, NonRemoteOguid) as exc:
+            raise BadRequest(self._format_exception(exc))
+
+        # Extract and forward path parameters (i.e., the transition)
+        path_params = '/'.join(self.path_params)
+        remote_url = '/'.join([remote_obj_url, '@workflow', path_params])
+
+        # Detect and break proxying cycles
+        proxied_from = self.request.getHeader('X-GEVER-RemoteRequestFrom')
+        if proxied_from:
+            err_msg = (
+                "Trying to proxy a request to {}, although the request was "
+                "already proxied from {}".format(remote_url, proxied_from))
+            raise InternalError(err_msg)
+
+        # Set up authentication and proxy request to the remote admin unit
+        headers = {'Accept': 'application/json',
+                   'Content-Type': 'application/json',
+                   'X-OGDS-AC': api.user.get_current().getId(),
+                   'X-OGDS-AUID': get_current_admin_unit().id(),
+                   'X-GEVER-RemoteRequestFrom': self.request.URL}
+
+        self.request.response.setHeader('X-GEVER-RemoteRequest', remote_url)
+
+        response = requests.post(
+            remote_url,
+            json=json_data,
+            params=qs_params,
+            headers=headers)
+
+        # Transparently proxy back response status line and body
+        self.request.response.setStatus(
+            response.status_code, reason=response.reason)
+
+        return response.json()

--- a/opengever/api/tests/test_accept_remote_task.py
+++ b/opengever/api/tests/test_accept_remote_task.py
@@ -1,0 +1,221 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.testbrowser import browsing
+from mock import patch
+from opengever.base.oguid import Oguid
+from opengever.base.response import IResponseContainer
+from opengever.testing import IntegrationTestCase
+from plone import api
+import json
+
+
+class TestAcceptRemoteTaskPost(IntegrationTestCase):
+
+    def last_response(self, obj):
+        return IResponseContainer(obj).list()[-1]
+
+    @browsing
+    def test_invoking_accept_remote_task_requires_add_portal_content(self, browser):
+        self.login(self.regular_user)
+        url = '{}/@accept-remote-task'.format(self.dossier.absolute_url())
+        self.logout()
+
+        # Merely invoking the endpoint requires Add Portal Content.
+        # The required permission checks on the remote side will then
+        # be performed as usual, the endpoint just proxies the request
+        # in the security context of the user.
+        with browser.expect_http_error(code=401):
+            browser.open(url, method='POST', headers=self.api_headers)
+
+    @browsing
+    def test_requires_task_oguid_parameter(self, browser):
+        self.login(self.regular_user, browser)
+        url = '{}/@accept-remote-task'.format(self.dossier.absolute_url())
+
+        with browser.expect_http_error(code=400):
+            browser.open(url, method='POST', headers=self.api_headers)
+
+        self.assertEqual(
+            {u'type': u'BadRequest',
+             u'message': u'Required parameter "task_oguid" is missing in body'},
+            browser.json)
+
+    @browsing
+    def test_rejects_unexpected_parameters(self, browser):
+        self.login(self.regular_user, browser)
+        url = '{}/@accept-remote-task'.format(self.dossier.absolute_url())
+
+        with browser.expect_http_error(code=400):
+            browser.open(
+                url, method='POST',
+                data=json.dumps({
+                    'task_oguid': 'fa:12345',
+                    'unexpected': 'garbage',
+                }),
+                headers=self.api_headers)
+
+        self.assertEqual(
+            {u'type': u'BadRequest',
+             u'message': u'Unexpected parameter(s) in JSON body: ["unexpected"]. '
+                         u'Supported parameters are: ["task_oguid", "text"]'},
+            browser.json)
+
+    @browsing
+    def test_requires_valid_task_oguid(self, browser):
+        self.login(self.regular_user, browser)
+        url = '{}/@accept-remote-task'.format(self.dossier.absolute_url())
+
+        with browser.expect_http_error(code=400):
+            browser.open(
+                url, method='POST',
+                data=json.dumps({'task_oguid': 'i_am_malformed'}),
+                headers=self.api_headers)
+
+        self.assertEqual(
+            {u'type': u'BadRequest',
+             u'message': u'MalformedOguid: i_am_malformed'},
+            browser.json)
+
+    @browsing
+    def test_requires_oguid_that_refers_to_remote_object(self, browser):
+        self.login(self.regular_user, browser)
+        url = '{}/@accept-remote-task'.format(self.dossier.absolute_url())
+
+        with browser.expect_http_error(code=400):
+            browser.open(
+                url, method='POST',
+                data=json.dumps({'task_oguid': 'plone:1234'}),
+                headers=self.api_headers)
+
+        self.assertEqual(
+            {u'type': u'BadRequest',
+             u'message': u'Task must be on remote admin unit. '
+                         u'Oguid plone:1234 refers to a local task, however.'},
+            browser.json)
+
+    @browsing
+    def test_accept_remote_task_creates_successor(self, browser):
+        self.login(self.regular_user, browser)
+
+        predecessor = create(
+            Builder('task')
+            .within(self.dossier)
+            .having(issuer=self.dossier_responsible.id,
+                    responsible=self.regular_user.id,
+                    responsible_client='fa',
+                    task_type='correction')
+            .in_state('task-state-open')
+            .titled(u'Task x'))
+
+        doc_in_task = create(Builder('document')
+                             .within(predecessor)
+                             .titled(u'Feedback zum Vertragsentwurf')
+                             .attach_file_containing(
+                                 'Feedback text',
+                                 u'vertr\xe4g sentwurf.docx'))
+
+        sql_task = predecessor.get_sql_object()
+
+        local_url = '/'.join((self.dossier.absolute_url(), '@accept-remote-task'))
+
+        # Need to trick @accept-remote-task into thinking it's a remote task
+        # so that the corresponding check can be bypassed.
+        #
+        # Any further remote / local distinction then is handled by
+        # dispatch_request(), which will just dispatch these requests
+        # internally using restrictedTraverse, but otherwise the
+        # transporting / serialization aspects behave largely the same and
+        # still get exercised.
+        with patch('opengever.api.accept_remote_task.'
+                   'AcceptRemoteTaskPost.is_remote') as mock_is_remote:
+            mock_is_remote.return_value = True
+
+            request_body = json.dumps({
+                'task_oguid': u'plone:%s' % sql_task.int_id,
+                'text': u'I hereby accept this task.',
+            })
+
+            browser.open(
+                local_url, method='POST',
+                data=request_body,
+                headers=self.api_headers)
+
+        response = browser.json
+        successor = Oguid.parse(response['oguid']).resolve_object()
+
+        # Predecessor should be accepted
+        self.assertEqual(
+            'task-state-in-progress',
+            api.content.get_state(predecessor))
+
+        # Successor should also be accepted
+        self.assertEqual('task-state-in-progress', api.content.get_state(successor))
+        self.assertEqual(u'task-state-in-progress', response['review_state'])
+
+        # Successor should be linked to predecessor
+        self.assertEqual(str(predecessor.oguid), successor.predecessor)
+
+        # Response text should be on both successor and predecessor
+        self.assertEqual(
+            u'I hereby accept this task.',
+            self.last_response(predecessor).text)
+        self.assertEqual(
+            u'I hereby accept this task.',
+            self.last_response(successor).text)
+
+        # Responsible should match the responsible of the predecessor
+        self.assertEqual(predecessor.responsible, successor.responsible)
+        self.assertDictContainsSubset(
+            {u'token': u'fa:kathi.barfuss'},
+            response['responsible'])
+
+        # Documents should have been copied
+        self.assertEqual(1, len(successor.objectIds()))
+        self.assertEqual(1, len(response['items']))
+
+        doc_in_successor_task = successor.objectValues()[0]
+        self.assertEqual(doc_in_task.title, doc_in_successor_task.title)
+
+        # Response body should contain serialized successor task, including
+        # responses and copied documents
+        self.assertDictContainsSubset({
+            u'@id': successor.absolute_url(),
+            u'@type': u'opengever.task.task',
+            u'UID': successor.UID(),
+            u'issuer': {u'title': u'Ziegler Robert (robert.ziegler)',
+                        u'token': u'robert.ziegler'},
+            u'oguid': str(successor.oguid),
+            u'predecessor': str(predecessor.oguid),
+            u'responsible': {u'title': u'Finanz\xe4mt: B\xe4rfuss K\xe4thi (kathi.barfuss)',
+                             u'token': u'fa:kathi.barfuss'},
+            u'responsible_client': {u'title': u'Finanz\xe4mt',
+                                    u'token': u'fa'},
+            u'review_state': u'task-state-in-progress',
+            u'revoke_permissions': True,
+            u'task_type': {u'title': u'For confirmation / correction',
+                           u'token': u'correction'},
+            u'title': u'Task x'},
+            browser.json)
+
+        self.assertEqual([{
+            u'@id': doc_in_successor_task.absolute_url(),
+            u'@type': u'opengever.document.document',
+            u'description': u'',
+            u'is_leafnode': None,
+            u'review_state': u'document-state-draft',
+            u'title': doc_in_successor_task.title}],
+            response['items'])
+
+        self.assertDictContainsSubset({
+            u'added_objects': [],
+            u'changes': [],
+            u'creator': {u'title': u'B\xe4rfuss K\xe4thi',
+                         u'token': u'kathi.barfuss'},
+            u'mimetype': u'',
+            u'related_items': [],
+            u'rendered_text': u'',
+            u'response_type': u'default',
+            u'successor_oguid': u'',
+            u'text': u'I hereby accept this task.',
+            u'transition': u'task-transition-open-in-progress'},
+            response['responses'][-1])

--- a/opengever/api/tests/test_complete_successor_task.py
+++ b/opengever/api/tests/test_complete_successor_task.py
@@ -1,0 +1,224 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.testbrowser import browsing
+from mock import patch
+from mock import PropertyMock
+from opengever.api.complete_successor_task import CompleteSuccessorTaskPost
+from opengever.base.oguid import Oguid
+from opengever.base.response import IResponseContainer
+from opengever.task.browser.accept.utils import accept_task_with_successor
+from opengever.testing import IntegrationTestCase
+from plone import api
+from zExceptions import BadRequest
+from zope.component import getUtility
+from zope.intid import IIntIds
+import json
+
+
+class TestCompleteSuccessorTaskPost(IntegrationTestCase):
+
+    def prepare_accepted_task_pair(self):
+        predecessor = create(
+            Builder('task')
+            .within(self.dossier)
+            .having(issuer=self.dossier_responsible.id,
+                    responsible=self.regular_user.id,
+                    responsible_client='fa',
+                    task_type='correction')
+            .in_state('task-state-open')
+            .titled(u'Inquiry from a concerned citizen'))
+
+        sql_task = predecessor.get_sql_object()
+
+        successor = accept_task_with_successor(
+            self.dossier,
+            'plone:%s' % sql_task.int_id,
+            u'I accept this task',
+        )
+        return predecessor, successor
+
+    def last_response(self, obj):
+        return IResponseContainer(obj).list()[-1]
+
+    @browsing
+    def test_invoking_complete_successor_task_requires_modify_portal_content(self, browser):
+        self.login(self.regular_user)
+        url = '{}/@complete-successor-task'.format(self.task.absolute_url())
+        self.logout()
+
+        # Merely invoking the endpoint requires Modify Portal Content.
+        # The required permission checks on the remote side will then
+        # be performed as usual, the endpoint just proxies the request
+        # in the security context of the user.
+        with browser.expect_http_error(code=401):
+            browser.open(url, method='POST', headers=self.api_headers)
+
+    @browsing
+    def test_requires_transition_parameter(self, browser):
+        self.login(self.regular_user, browser)
+        url = '{}/@complete-successor-task'.format(self.task.absolute_url())
+
+        with browser.expect_http_error(code=400):
+            browser.open(url, method='POST', headers=self.api_headers)
+
+        self.assertEqual(
+            {u'type': u'BadRequest',
+             u'message': u'Required parameter "transition" is missing in body'},
+            browser.json)
+
+    @browsing
+    def test_rejects_unexpected_parameters(self, browser):
+        self.login(self.regular_user, browser)
+        url = '{}/@complete-successor-task'.format(self.task.absolute_url())
+
+        with browser.expect_http_error(code=400):
+            browser.open(
+                url, method='POST',
+                data=json.dumps({
+                    'transition': '<irrelevant>',
+                    'unexpected': 'garbage',
+                }),
+                headers=self.api_headers)
+
+        self.assertEqual(
+            {u'type': u'BadRequest',
+             u'message': u'Unexpected parameter(s) in JSON body: ["unexpected"]. '
+                         u'Supported parameters are: ["transition", "documents", "text"]'},
+            browser.json)
+
+    @browsing
+    def test_requires_task_with_predecessor(self, browser):
+        self.login(self.regular_user, browser)
+        url = '{}/@complete-successor-task'.format(self.task.absolute_url())
+
+        with browser.expect_http_error(code=400):
+            browser.open(
+                url, method='POST',
+                data=json.dumps({'transition': '<irrelevant>'}),
+                headers=self.api_headers)
+
+        self.assertEqual(
+            {u'type': u'BadRequest',
+             u'message': u'@complete-successor-task only supports successor '
+                         u'tasks. This task has no predecessor.'},
+            browser.json)
+
+    @browsing
+    def test_complete_successor_task_closes_predecessor(self, browser):
+        self.login(self.regular_user, browser)
+
+        # Test setup - create predecessor and accepted successor task pair
+        predecessor, successor = self.prepare_accepted_task_pair()
+
+        # Add a document in successor that is supposed to be delivered back
+        produced_doc = create(Builder('document')
+                              .within(successor)
+                              .titled(u'Statement in response to inquiry')
+                              .attach_file_containing(
+                                  'Statement text',
+                                  u'statement.docx'))
+
+        int_ids = getUtility(IIntIds)
+        produced_doc_intid = int_ids.getId(produced_doc)
+
+        # Need to trick the transition controller into thinking its a remote
+        # request so that it allows the resolve transition on the predecessor
+        with patch('opengever.task.browser.transitioncontroller.'
+                   'RequestChecker.is_remote',
+                   new_callable=PropertyMock) as mock_is_remote:
+            mock_is_remote.return_value = True
+
+            request_body = json.dumps({
+                'transition': 'task-transition-in-progress-resolved',
+                'text': 'I finished this task.',
+                'documents': [produced_doc_intid]
+            })
+            browser.open(
+                successor.absolute_url() + '/@complete-successor-task',
+                method='POST',
+                data=request_body,
+                headers=self.api_headers)
+
+        # Predecessor and successor should have been closed
+        self.assertEqual('task-state-resolved', api.content.get_state(predecessor))
+        self.assertEqual('task-state-resolved', api.content.get_state(successor))
+
+        # Response text should be on predecessor and successor
+        self.assertEqual(u'I finished this task.', self.last_response(predecessor).text)
+        self.assertEqual(u'I finished this task.', self.last_response(successor).text)
+
+        # Delivered document was copied to predecessor
+        self.assertEqual(1, len(predecessor.objectValues()))
+        self.assertEquals(
+            u'RE: Statement in response to inquiry',
+            predecessor.objectValues()[-1].title)
+
+        # Delivered document is referenced from response on successor
+        self.assertEqual(1, len(self.last_response(successor).added_objects))
+        self.assertEqual(produced_doc, self.last_response(successor).added_objects[0].to_object)
+
+        # Response body should contain serialized successor task, including
+        # responses and copied documents
+
+        response = browser.json
+
+        self.assertDictContainsSubset({
+            u'@id': successor.absolute_url(),
+            u'@type': u'opengever.task.task',
+            u'UID': successor.UID(),
+            u'issuer': {u'title': u'Ziegler Robert (robert.ziegler)',
+                        u'token': u'robert.ziegler'},
+            u'oguid': str(successor.oguid),
+            u'predecessor': str(predecessor.oguid),
+            u'responsible': {u'title': u'Finanz\xe4mt: B\xe4rfuss K\xe4thi (kathi.barfuss)',
+                             u'token': u'fa:kathi.barfuss'},
+            u'responsible_client': {u'title': u'Finanz\xe4mt', u'token': u'fa'},
+            u'review_state': u'task-state-resolved',
+            u'revoke_permissions': True,
+            u'task_type': {u'title': u'For confirmation / correction',
+                           u'token': u'correction'},
+            u'title': u'Inquiry from a concerned citizen'},
+            response)
+
+        self.assertEqual([{
+            u'@id': produced_doc.absolute_url(),
+            u'@type': u'opengever.document.document',
+            u'description': u'',
+            u'is_leafnode': None,
+            u'review_state': u'document-state-draft',
+            u'title': produced_doc.title}],
+            response['items'])
+
+        self.assertDictContainsSubset({
+            u'added_objects': [{u'@id': produced_doc.absolute_url(),
+                                u'@type': u'opengever.document.document',
+                                u'description': u'',
+                                u'is_leafnode': None,
+                                u'review_state': u'document-state-draft',
+                                u'title': u'Statement in response to inquiry'}],
+            u'changes': [],
+            u'creator': {u'title': u'B\xe4rfuss K\xe4thi',
+                         u'token': u'kathi.barfuss'},
+            u'mimetype': u'',
+            u'related_items': [],
+            u'rendered_text': u'',
+            u'response_type': u'default',
+            u'successor_oguid': u'',
+            u'text': u'I finished this task.',
+            u'transition': u'task-transition-in-progress-resolved'},
+            response['responses'][-1])
+
+    def test_parses_intids_paths_and_oguids_as_doc_references(self):
+        self.login(self.regular_user)
+
+        resolve = CompleteSuccessorTaskPost._resolve_doc_ref_to_intid
+        int_id = getUtility(IIntIds).getId(self.document)
+
+        self.assertEqual(int_id, resolve(int_id))
+        self.assertEqual(int_id, resolve(str(Oguid.for_object(self.document))))
+        self.assertEqual(int_id, resolve('/'.join(self.document.getPhysicalPath())))
+
+        with self.assertRaises(BadRequest) as cm:
+            resolve('garbage')
+        self.assertEqual(
+            "Unknown document reference: 'garbage'", str(cm.exception))

--- a/opengever/api/tests/test_remote_workflow.py
+++ b/opengever/api/tests/test_remote_workflow.py
@@ -1,0 +1,211 @@
+from copy import copy
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.testbrowser import browsing
+from opengever.testing import IntegrationTestCase
+from urllib import urlencode
+import json
+import requests_mock
+
+
+class TestRemoteWorkflowPost(IntegrationTestCase):
+
+    def setup_remote_admin_unit(self, remote_admin_unit_name='remote'):
+        create(
+            Builder('admin_unit')
+            .id(remote_admin_unit_name)
+            .having(site_url='http://nohost/{}'.format(remote_admin_unit_name))
+        )
+
+    def prep_remote_task(self):
+        """Prepare the SQL task corresponding to self.task in a way that
+        tricks the @remote-workflow endpoint into thinking it's remote, and
+        therefore doing a remote request.
+        """
+        sql_task = self.task.get_sql_object()
+        sql_task.admin_unit_id = u'remote'
+        return sql_task
+
+    def construct_url_pair(self, sql_task, **kwargs):
+        query_string = urlencode(kwargs, doseq=True)
+        remote_url = '/'.join((
+            'http://nohost',
+            sql_task.admin_unit_id,
+            sql_task.physical_path,
+            '@workflow', 'some-transition'))
+
+        local_url = '/'.join((
+            self.portal.absolute_url(),
+            '@remote-workflow', 'some-transition'))
+
+        if query_string:
+            remote_url = '?'.join((remote_url, query_string))
+            local_url = '?'.join((local_url, query_string))
+
+        return remote_url, local_url
+
+    @browsing
+    def test_invoking_remote_workflow_requires_view_permisson(self, browser):
+        url = '{}/@remote-workflow'.format(self.portal.absolute_url())
+
+        # Merely invoking the endpoint requires View on the site root.
+        # The required permission checks on the remote side will then
+        # be performed as usual, the endpoint just proxies the request
+        # in the security context of the user.
+        with browser.expect_http_error(code=401):
+            browser.open(url, method='POST', headers=self.api_headers)
+
+    @browsing
+    def test_requires_remote_oguid_parameter(self, browser):
+        self.login(self.regular_user, browser)
+        url = '{}/@remote-workflow'.format(self.portal.absolute_url())
+
+        with browser.expect_http_error(code=400):
+            browser.open(url, method='POST', headers=self.api_headers)
+
+        self.assertEqual(
+            {u'type': u'BadRequest',
+             u'message': u'Required parameter "remote_oguid" is missing in body'},
+            browser.json)
+
+    @browsing
+    def test_requires_valid_remote_oguid(self, browser):
+        self.login(self.regular_user, browser)
+        url = '{}/@remote-workflow'.format(self.portal.absolute_url())
+
+        with browser.expect_http_error(code=400):
+            browser.open(
+                url, method='POST',
+                data=json.dumps({'remote_oguid': 'i_am_malformed'}),
+                headers=self.api_headers)
+
+        self.assertEqual(
+            {u'type': u'BadRequest',
+             u'message': u'MalformedOguid: i_am_malformed'},
+            browser.json)
+
+    @browsing
+    def test_requires_oguid_that_refers_to_remote_object(self, browser):
+        self.login(self.regular_user, browser)
+        url = '{}/@remote-workflow'.format(self.portal.absolute_url())
+
+        with browser.expect_http_error(code=400):
+            browser.open(
+                url, method='POST',
+                data=json.dumps({'remote_oguid': 'plone:1234'}),
+                headers=self.api_headers)
+
+        self.assertEqual(
+            {u'type': u'BadRequest',
+             u'message': u'NonRemoteOguid: Not a remote OGUID. Use get_url() instead'},
+            browser.json)
+
+    @browsing
+    def test_remote_workflow_proxies_query_string_parameteres_to_remote(self, browser):
+        self.setup_remote_admin_unit()
+        self.login(self.regular_user, browser)
+        sql_task = self.prep_remote_task()
+
+        expected_response = {'this would be': 'the proxied response data'}
+        expected_remote_url, local_url = self.construct_url_pair(
+            sql_task, someparam=['foo', 'bar'])
+
+        self.assertIn('someparam=foo&someparam=bar', expected_remote_url)
+
+        with requests_mock.Mocker() as remote_server_mock:
+            remote_server_mock.register_uri(
+                'POST',
+                expected_remote_url,
+                status_code=200,
+                json=expected_response)
+
+            browser.open(
+                local_url, method='POST',
+                data=json.dumps({'remote_oguid': 'remote:%s' % sql_task.int_id}),
+                headers=self.api_headers)
+
+            self.assertEqual(expected_response, browser.json)
+
+    @browsing
+    def test_remote_workflow_proxies_remote_response(self, browser):
+        self.setup_remote_admin_unit()
+        self.login(self.regular_user, browser)
+        sql_task = self.prep_remote_task()
+
+        expected_remote_url, local_url = self.construct_url_pair(sql_task)
+        expected_response = {'this would be': 'the proxied response data'}
+
+        with requests_mock.Mocker() as remote_server_mock:
+            remote_server_mock.register_uri(
+                'POST',
+                expected_remote_url,
+                status_code=200,
+                json=expected_response)
+
+            browser.open(
+                local_url, method='POST',
+                data=json.dumps({'remote_oguid': 'remote:%s' % sql_task.int_id}),
+                headers=self.api_headers)
+
+        self.assertEqual(200, browser.status_code)
+        self.assertEqual(expected_response, browser.json)
+        self.assertEqual(
+            expected_remote_url,
+            browser.headers['X-GEVER-RemoteRequest'])
+
+    @browsing
+    def test_remote_workflow_proxies_status_line_and_body(self, browser):
+        self.setup_remote_admin_unit()
+        self.login(self.regular_user, browser)
+        sql_task = self.prep_remote_task()
+
+        expected_remote_url, local_url = self.construct_url_pair(sql_task)
+        expected_status = 507
+        expected_reason = 'Boom'
+        expected_body = {'justification': 'Something went wrong'}
+
+        with requests_mock.Mocker() as remote_server_mock:
+            remote_server_mock.register_uri(
+                'POST',
+                expected_remote_url,
+                status_code=expected_status,
+                reason=expected_reason,
+                json=expected_body)
+
+            with browser.expect_http_error(expected_status):
+                browser.open(
+                    local_url, method='POST',
+                    data=json.dumps({'remote_oguid': 'remote:%s' % sql_task.int_id}),
+                    headers=self.api_headers)
+
+        self.assertEqual(expected_status, browser.status_code)
+        self.assertEqual(expected_reason, browser.status_reason)
+        self.assertEqual(expected_body, browser.json)
+        self.assertEqual(
+            expected_remote_url,
+            browser.headers['X-GEVER-RemoteRequest'])
+
+    @browsing
+    def test_remote_workflow_breaks_proxying_cycles(self, browser):
+        self.setup_remote_admin_unit()
+        self.login(self.regular_user, browser)
+        sql_task = self.prep_remote_task()
+
+        expected_remote_url, local_url = self.construct_url_pair(sql_task)
+
+        with browser.expect_http_error(500):
+            headers = copy(self.api_headers)
+            headers['X-GEVER-RemoteRequestFrom'] = 'http://nohost/foo/'
+
+            browser.open(
+                local_url, method='POST',
+                data=json.dumps({'remote_oguid': 'remote:%s' % sql_task.int_id}),
+                headers=headers)
+
+        self.assertEqual(500, browser.status_code)
+        self.assertEqual(
+            {u'message': u'Trying to proxy a request to %s, although the '
+                         u'request was already proxied '
+                         u'from http://nohost/foo/' % expected_remote_url,
+             u'type': u'InternalError'},
+            browser.json)

--- a/opengever/base/exceptions.py
+++ b/opengever/base/exceptions.py
@@ -12,3 +12,15 @@ class MalformedOguid(Exception):
 class InvalidOguidIntIdPart(Exception):
     """The int_id part of the oguid is invalid and does not exist.
     """
+
+
+class UnsupportedTypeForRemoteURL(Exception):
+    """The Oguid does not refer to one of the types that get_remote_url() is
+    supported for.
+    """
+
+
+class NonRemoteOguid(Exception):
+    """An attempt was made to use get_remote_url() on a Oguid for an object
+    that is located on the current AdminUnit.
+    """

--- a/opengever/task/browser/complete_utils.py
+++ b/opengever/task/browser/complete_utils.py
@@ -1,0 +1,114 @@
+from Acquisition import aq_inner
+from Acquisition import aq_parent
+from opengever.base.request import dispatch_request
+from opengever.base.response import IResponseContainer
+from opengever.base.transport import Transporter
+from opengever.globalindex.model.task import Task
+from opengever.tabbedview.helper import linked
+from opengever.task import _
+from opengever.task import util
+from z3c.relationfield import RelationValue
+from zope.app.intid.interfaces import IIntIds
+from zope.component import getUtility
+import json
+
+# XXX: This module is supposed to be temporary. The function below, as
+# well as the code in opengever.task.accept.browser.utils should be moved
+# to a common location.
+#
+# Ideally onto the Task class or a mixin for it,
+# but this isn't straightforward since some of these functions operate on
+# dossiers instead of tasks, or even other contexts that would need to be
+# evaluated carefully before refactoring.
+#
+# Maybe a InterUnitSupport class with static methods to group them together
+# could work. Either way, this should probably be done once the code related
+# to accepting forwardings is gets wired up in API endpoints. Because
+# forwardings aren't being touched in this change, moving just part of the
+# code would rip apart functionality that is closely related, doing more
+# harm than good.
+
+
+def complete_task_and_deliver_documents(task, transition,
+                                        docs_to_deliver=None,
+                                        response_text=None):
+    """Delivers the selected documents to the predecesser task and
+    complete the task:
+
+    - Copy the documents to the predecessor task (no new responses)
+    - Execute workflow transition (no new response)
+    - Add a new response indicating the workflow transition, the added
+    documents and containing the entered response text.
+    """
+    # Syncing the workflow change is done during document delivery
+    # (see below) therefore we skip the workflow syncing.
+    util.change_task_workflow_state(task,
+                                    transition,
+                                    disable_sync=True,
+                                    text=response_text)
+
+    response_obj = IResponseContainer(task).list()[-1]
+
+    if docs_to_deliver is None:
+        docs_to_deliver = []
+
+    predecessor = Task.query.by_oguid(task.predecessor)
+
+    transporter = Transporter()
+    intids = getUtility(IIntIds)
+
+    data = {'documents': [],
+            'text': response_text,
+            'transition': transition}
+
+    related_ids = []
+    if getattr(task, 'relatedItems'):
+        related_ids = [item.to_id for item in task.relatedItems]
+
+    for doc_intid in docs_to_deliver:
+        doc = intids.getObject(int(doc_intid))
+        data['documents'].append(transporter.extract(doc))
+
+        # add a releation when a document from the dossier was selected
+        if int(doc_intid) not in related_ids:
+            # check if its a relation
+            if aq_parent(aq_inner(doc)) != task:
+                # add relation to doc on task
+                if task.relatedItems:
+                    task.relatedItems.append(
+                        RelationValue(int(doc_intid)))
+                else:
+                    task.relatedItems = [
+                        RelationValue(int(doc_intid))]
+
+                # add response change entry for this relation
+                response_obj.add_related_item(RelationValue(int(doc_intid)))
+
+                # set relation flag
+                doc._v__is_relation = True
+                response_obj.add_change(
+                    'related_items',
+                    '',
+                    linked(doc, doc.Title()),
+                    _(u'label_related_items', default=u"Related Items"))
+
+            else:
+                # add entry to the response for this document
+                response_obj.added_objects.append(RelationValue(int(doc_intid)))
+        else:
+            # append only the relation on the response
+            doc._v__is_relation = True
+            response_obj.add_change(
+                'related_items',
+                '',
+                linked(doc, doc.Title()),
+                _(u'label_related_items', default=u"Related Items"))
+
+    request_data = {'data': json.dumps(data)}
+    response = dispatch_request(
+        predecessor.admin_unit_id,
+        '@@complete_successor_task-receive_delivery',
+        predecessor.physical_path,
+        data=request_data)
+
+    return response


### PR DESCRIPTION
This change introduces three new endpoints:

- `POST @remote-workflow` on the Plone site root
- `POST @accept-remote-task` on dossiers
- `POST @complete-successor-task` on tasks

These are endpoints required in the backend to facilitate the process of accepting inter-admin-unit tasks, and finally resolving them, via the new frontend.

The underlying idea is that the frontend should need to know as little as possible about the detailed mechanics of inter-admin-unit processes, remote requests, and authenticating to non-local admin units.

These endpoints therefore proxy or internally dispatch (via server-to-server requests) the necessary actions, allowing the frontend to perform all actions from a single, current admin unit.

Using these endpoints, the processes of accepting and completing inter-admin-unit tasks can be implemented as follows.

*(In these examples, `rk` is always considered the current, local admin unit, and `fd` the remote AU, where a task has been assigned to us)*

### Accepting a task

-----
![accept_choices](https://user-images.githubusercontent.com/405124/90991572-7e09e480-e5aa-11ea-88ee-c3966c7be5e6.png)

*(Refresher what this looks like in the classic UI)*

-----


#### 1) Accepting the task on the remote unit where it physically resides.

This is the simplest case. In this case the `@remote-workflow` endpoint can be used to invoke a **workflow transition on a remote object** (referenced by `remote_oguid`) from the current admin unit in order to accept that task remotely.

```http
    POST /rk/@remote-workflow/some-transition

    {
      "remote_oguid": "fd:12345",
      "text": "I accept this task"
    }
```

#### 2) Accept the remote task into an existing local dossier.

This can be accomplished using the `@accept-remote-task` endpoint on the local target dossier where the successor task should be copied to (including the documents attached to the remot predecessor task).

```http
    POST /rk/dossier-17/@accept-remote-task

    {
      "task_oguid": "fd:12345",
      "text": "I'm accepting this task into this dossier."
    }
```

#### 3) Accept the remote task into a new local dossier

Since the frontend will handle the creation of the new dossier, this case can simply be reduced to case 2) from a backend perspective.

### Completing the successor task

For cases 2) and 3), where a successor task is created locally, the completion of that successor will involve also completing the predecessor on the remote side, and optionally delivering selected documents. This can be done using the `@complete-successor-task` on the local successor task:

```http
    POST /rk/task-42/@complete-successor-task

    {
      "transition": "task-transition-in-progress-resolved",
      "documents": [1423795951],
      "text": "I finished this task."
    }

```

Jira: https://4teamwork.atlassian.net/browse/GEVER-270

(Also: https://4teamwork.atlassian.net/browse/GEVER-269)

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

## Checklist (if applicable)

- API change:
  - [x] Documentation is updated
- New functionality:
  - [x] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
     (out of scope, separate story for forwardings)

