### PR TITLE
Fix filtering with exclusion filters if the field has a mapping.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 ---------------------
 
 - Add policy template for teamraum policies. [njohner]
+- Fix filtering with exclusion filters if the field has a mapping. [tinagerber]
 - Make the portal_url configurable through the portal_registry. [elioschmutz]
 - Include OGUID in all API content GET responses. [lgraf]
 - Extend the @config endpoint with the current inbox_folder_url. [elioschmutz]

--- a/opengever/api/solr_query_service.py
+++ b/opengever/api/solr_query_service.py
@@ -1,5 +1,6 @@
 from collective.elephantvocabulary import wrap_vocabulary
 from copy import copy
+from copy import deepcopy
 from DateTime import DateTime
 from DateTime.interfaces import DateTimeError
 from ftw.solr.converters import to_iso8601
@@ -280,6 +281,16 @@ date_fields = set([
 
 FIELDS_WITH_MAPPING.extend(
     [DateListingField(field_name) for field_name in date_fields])
+
+# Currently, operators and field names are not separated when determining the field.
+# Therefore the correct field is not found when a negating filter is queried (e.g. "-keywords")
+# To get the correct field for negating filters,
+# all fields are copied and a "-" is placed at the beginning of the field name and index.
+copied_fields = deepcopy(FIELDS_WITH_MAPPING)
+for field in copied_fields:
+    field.field_name = '-' + field.field_name
+    field.index = '-' + field.index if field.index else None
+FIELDS_WITH_MAPPING.extend(copied_fields)
 
 
 class SolrQueryBaseService(Service):

--- a/opengever/api/tests/test_listing.py
+++ b/opengever/api/tests/test_listing.py
@@ -434,6 +434,21 @@ class TestListingWithRealSolr(SolrIntegrationTestCase):
         self.assertEqual(5, browser.json['items_total'])
 
     @browsing
+    def test_filter_by_keywords(self, browser):
+        self.login(self.regular_user, browser=browser)
+        view = ('@listing?name=documents')
+        browser.open(self.repository_root, view=view, headers=self.api_headers)
+        self.assertEqual(19, browser.json['items_total'])
+
+        view = ('@listing?name=documents&filters.keywords:record:list=Wichtig')
+        browser.open(self.repository_root, view=view, headers=self.api_headers)
+        self.assertEqual(2, browser.json['items_total'])
+
+        view = ('@listing?name=documents&filters.-keywords:record:list=Wichtig')
+        browser.open(self.repository_root, view=view, headers=self.api_headers)
+        self.assertEqual(17, browser.json['items_total'])
+
+    @browsing
     def test_filter_by_multiple_review_states(self, browser):
         self.login(self.regular_user, browser=browser)
 


### PR DESCRIPTION
If a query was submitted with an excluding filter (e.g. -keywords=bla), the correct ListingField was not found until now, because only the field name "keywords" is known. 

Therefore fields with mapping are now duplicated and the field name and index are preceded by a minus sign, so that the fields can also be used as exclusion filters.

Jira: https://4teamwork.atlassian.net/browse/GEVER-699

Definition of Done: https://4teamwork.atlassian.net/wiki/spaces/CHX4TW/pages/917562/


## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)