### PR TITLE
Bring @resolve-oguid error responses in line with REST API style

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 ---------------------
 
 - Fix translated review state for meeting content. [lgraf]
+- Bring @resolve-oguid error responses in line with REST API style. [lgraf]
 - Introduce POST @complete-successor-task on tasks. [lgraf]
 - Introduce POST @accept-remote-task endpoint for dossiers. [lgraf]
 - Introduce POST @remote-workflow endpoint. [lgraf]

--- a/opengever/api/proxy_base.py
+++ b/opengever/api/proxy_base.py
@@ -1,0 +1,52 @@
+from opengever.ogds.base.utils import get_current_admin_unit
+from plone import api
+from plone.restapi.services import Service
+from urlparse import parse_qs
+from zExceptions import InternalError
+import requests
+
+
+class ProxyingEndpointBase(Service):
+    """Base class for endpoints that proxy request to remote admin units.
+    """
+
+    def extract_query_string_params(self):
+        parsed = parse_qs(self.request['QUERY_STRING'])
+        qs_params = dict((k, v if len(v) > 1 else v[0])
+                         for k, v in parsed.iteritems())
+        return qs_params
+
+    def detect_proxying_cycles(self, remote_url):
+        proxied_from = self.request.getHeader('X-GEVER-RemoteRequestFrom')
+        if proxied_from:
+            err_msg = (
+                "Trying to proxy a request to {}, although the request was "
+                "already proxied from {}".format(remote_url, proxied_from))
+            raise InternalError(err_msg)
+
+    def prepare_proxying_headers(self):
+        headers = {'Accept': 'application/json',
+                   'Content-Type': 'application/json',
+                   'X-OGDS-AC': api.user.get_current().getId(),
+                   'X-OGDS-AUID': get_current_admin_unit().id(),
+                   'X-GEVER-RemoteRequestFrom': self.request.URL}
+        return headers
+
+    def remote_request(self, method, remote_url, **kwargs):
+        self.request.response.setHeader('X-GEVER-RemoteRequest', remote_url)
+        return requests.request(method, remote_url, **kwargs)
+
+    def stream_back(self, response):
+        # Transparently proxy back response status line and body
+        self.request.response.setStatus(
+            response.status_code, reason=response.reason)
+
+        try:
+            response_json = response.json()
+        except ValueError:
+            response_json = {
+                u'type': u'ValueError',
+                u'message': u'Remote side returned a non-JSON response',
+                u'remote_response_body': response.text,
+            }
+        return response_json

--- a/opengever/api/remote_workflow.py
+++ b/opengever/api/remote_workflow.py
@@ -107,4 +107,13 @@ class RemoteWorkflowPost(Service):
         self.request.response.setStatus(
             response.status_code, reason=response.reason)
 
-        return response.json()
+        try:
+            response_json = response.json()
+        except ValueError:
+            response_json = {
+                u'type': u'ValueError',
+                u'message': u'Remote side returned a non-JSON response',
+                u'remote_response_body': response.text,
+            }
+
+        return response_json

--- a/opengever/api/resolve_oguid.py
+++ b/opengever/api/resolve_oguid.py
@@ -1,27 +1,24 @@
+from opengever.api.proxy_base import ProxyingEndpointBase
 from opengever.base.exceptions import InvalidOguidIntIdPart
 from opengever.base.exceptions import MalformedOguid
 from opengever.base.oguid import Oguid
-from opengever.ogds.base.utils import get_current_admin_unit
 from opengever.ogds.models.service import ogds_service
 from plone import api
 from plone.restapi.interfaces import ISerializeToJson
-from plone.restapi.services import Service
 from zExceptions import BadRequest
-from zExceptions import InternalError
 from zExceptions import Unauthorized
 from zope.component import queryMultiAdapter
-import requests
 
 
-class ResolveOguidGet(Service):
+class ResolveOguidGet(ProxyingEndpointBase):
     """Return serialized content for an object identified by an Oguid.
 
     GET /@resolve-oguid?oguid=foo:1234 HTTP/1.1
     """
 
     def reply(self):
-        params = self.request.form.copy()
-        raw_oguid = params.get('oguid', '').strip()
+        qs_params = self.extract_query_string_params()
+        raw_oguid = qs_params.get('oguid', '').strip()
 
         if not raw_oguid:
             raise BadRequest('Missing oguid query string parameter.')
@@ -34,7 +31,7 @@ class ResolveOguidGet(Service):
         if oguid.is_on_current_admin_unit:
             return self._serialize_object(oguid)
         else:
-            return self._get_remote_serialized_object(oguid, params)
+            return self._get_remote_serialized_object(oguid, qs_params)
 
     def _serialize_object(self, oguid):
         try:
@@ -58,42 +55,26 @@ class ResolveOguidGet(Service):
         json['@id'] = obj.absolute_url()
         return json
 
-    def _get_remote_serialized_object(self, oguid, params):
+    def _get_remote_serialized_object(self, oguid, qs_params):
         target_unit = ogds_service().fetch_admin_unit(oguid.admin_unit_id)
         if not target_unit:
             raise BadRequest('Invalid admin unit id "{}".'.format(
                 oguid.admin_unit_id))
 
-        url = '/'.join([target_unit.site_url, '@resolve-oguid'])
+        remote_url = '/'.join([target_unit.site_url, '@resolve-oguid'])
 
-        proxied_from = self.request.getHeader('X-GEVER-RemoteRequestFrom')
-        if proxied_from:
-            err_msg = "Trying to proxy a request to {}, although the request"\
-                      " was already proxied from {}".format(url, proxied_from)
-            raise InternalError(err_msg)
+        # Detect and break proxying cycles
+        self.detect_proxying_cycles(remote_url)
 
-        headers = {'Accept': 'application/json',
-                   'Content-Type': 'application/json',
-                   'X-OGDS-AC': api.user.get_current().getId(),
-                   'X-OGDS-AUID': get_current_admin_unit().id(),
-                   'X-GEVER-RemoteRequestFrom': self.request.URL}
+        # Set up authentication and proxy request to the remote admin unit
+        headers = self.prepare_proxying_headers()
 
-        self.request.response.setHeader('X-GEVER-RemoteRequest', url)
-
-        # we pass all query string parameters to the remote request
-        response = requests.get(url, params=params, headers=headers)
+        # Proxy the request
+        response = self.remote_request(
+            'GET',
+            remote_url,
+            params=qs_params,
+            headers=headers)
 
         # Transparently proxy back response status line and body
-        self.request.response.setStatus(
-            response.status_code, reason=response.reason)
-
-        try:
-            response_json = response.json()
-        except ValueError:
-            response_json = {
-                u'type': u'ValueError',
-                u'message': u'Remote side returned a non-JSON response',
-                u'remote_response_body': response.text,
-            }
-
-        return response_json
+        return self.stream_back(response)

--- a/opengever/api/tests/test_resolve_oguid.py
+++ b/opengever/api/tests/test_resolve_oguid.py
@@ -75,36 +75,52 @@ class TestResolveOguidGet(IntegrationTestCase):
         self.login(self.regular_user, browser)
         url = '{}/@resolve-oguid'.format(self.portal.absolute_url())
 
-        with browser.expect_http_error(
-                code=400, reason='Missing oguid query string parameter.'):
+        with browser.expect_http_error(code=400):
             browser.open(url, method='GET', headers=self.api_headers)
+
+        self.assertEqual(
+            {u'type': u'BadRequest',
+             u'message': u'Missing oguid query string parameter.'},
+            browser.json)
 
     @browsing
     def test_requires_valid_oguid(self, browser):
         self.login(self.regular_user, browser)
         url = '{}/@resolve-oguid?oguid=qux'.format(self.portal.absolute_url())
 
-        with browser.expect_http_error(
-                code=400, reason='Malformed oguid "qux".'):
+        with browser.expect_http_error(code=400):
             browser.open(url, method='GET', headers=self.api_headers)
+
+        self.assertEqual(
+            {u'type': u'BadRequest',
+             u'message': u'Malformed oguid "qux".'},
+            browser.json)
 
     @browsing
     def test_requires_resolvable_oguid(self, browser):
         self.login(self.regular_user, browser)
         url = '{}/@resolve-oguid?oguid=plone:1234'.format(self.portal.absolute_url())
 
-        with browser.expect_http_error(
-                code=400, reason='No object found for oguid "plone:1234".'):
+        with browser.expect_http_error(code=400):
             browser.open(url, method='GET', headers=self.api_headers)
+
+        self.assertEqual(
+            {u'type': u'BadRequest',
+             u'message': u'No object found for oguid "plone:1234".'},
+            browser.json)
 
     @browsing
     def test_requires_valid_admin_unit_id(self, browser):
         self.login(self.regular_user, browser)
         url = '{}/@resolve-oguid?oguid=qux:1234'.format(self.portal.absolute_url())
 
-        with browser.expect_http_error(
-                code=400, reason='Invalid admin unit id "qux".'):
+        with browser.expect_http_error(code=400):
             browser.open(url, method='GET', headers=self.api_headers)
+
+        self.assertEqual(
+            {u'type': u'BadRequest',
+             u'message': u'Invalid admin unit id "qux".'},
+            browser.json)
 
     @browsing
     def test_resolve_remote_oguid_proxies_remote_response(self, browser):


### PR DESCRIPTION
This brings the format of error responses for the `@resolve-oguid` endpoint in the line with the response format used in the other parts of the REST API:

Return `400 Bad Request` with a JSON body including error details, instead of returning `400` with a custom status line reason text.

In addition, this allowed to also homogenize some details about how the two proxying endpoints `@resolve-oguid` and `@remote-workflow` behave, and factor out their commonalities into a base class.  

Follow up to: https://github.com/4teamwork/opengever.core/pull/6595

Jira: https://4teamwork.atlassian.net/browse/GEVER-270

## Checklist (Must have)

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

## Checklist (if applicable)

- API change:
  - If breaking:
    - [x] api-change label added
    - [ ] Scrum master is informed
    *(deemed unnecessary, will coordinate with frontend guys directly)*