### PR TITLE
Fix translated review state for meeting content

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2020.7.1 (unreleased)
 ---------------------
 
+- Fix translated review state for meeting content. [lgraf]
 - Introduce POST @complete-successor-task on tasks. [lgraf]
 - Introduce POST @accept-remote-task endpoint for dossiers. [lgraf]
 - Introduce POST @remote-workflow endpoint. [lgraf]

--- a/opengever/base/contentlisting.py
+++ b/opengever/base/contentlisting.py
@@ -5,7 +5,6 @@ from opengever.base.browser.helper import get_css_class
 from opengever.base.helpers import display_name
 from opengever.bumblebee import is_bumblebee_feature_enabled
 from opengever.bumblebee import is_bumblebeeable
-from opengever.document.behaviors import IBaseDocument
 from opengever.document.document import Document
 from opengever.document.widgets.document_link import DocumentLinkWidget
 from opengever.mail.mail import OGMail
@@ -174,6 +173,13 @@ class OpengeverCatalogContentListingObject(CatalogContentListingObject):
         return self._render_simplelink()
 
     def translated_review_state(self):
+        if self.portal_type in ('opengever.meeting.proposal',
+                                'opengever.meeting.submittedproposal'):
+            # Some meeting content has a custom workflow implementation
+            state = self.get_state().title
+            return translate(
+                state, domain='opengever.meeting', context=self.request)
+
         review_state = self.review_state()
         if review_state:
             return translate(

--- a/opengever/base/tests/test_contentlisting.py
+++ b/opengever/base/tests/test_contentlisting.py
@@ -2,12 +2,21 @@ from ftw.testbrowser import browsing
 from opengever.document.widgets.document_link import DocumentLinkWidget
 from opengever.testing import IntegrationTestCase
 from opengever.testing import obj2brain
+from opengever.testing import set_preferred_language
 from opengever.trash.trash import Trasher
+from plone import api
 from plone.app.contentlisting.interfaces import IContentListingObject
 
 
 class TestOpengeverContentListing(IntegrationTestCase):
     """Test basic content listing functionality."""
+
+    def setUp(self):
+        super(TestOpengeverContentListing, self).setUp()
+        set_preferred_language(self.portal.REQUEST, 'de-ch')
+        lang_tool = api.portal.get_tool('portal_languages')
+        lang_tool.setDefaultLanguage('de-ch')
+        lang_tool.supported_langs = ['fr-ch', 'de-ch']
 
     def assertCropping(self, size, value):
         self.assertEquals(
@@ -232,6 +241,42 @@ class TestOpengeverContentListing(IntegrationTestCase):
             IContentListingObject(obj2brain(
                 self.dossier)).ModificationDate(),
             '2016-08-31T20:15:33+02:00')
+
+    def test_translated_review_state(self):
+        self.login(self.regular_user)
+
+        self.assertEquals(
+            u'In Bearbeitung',
+            IContentListingObject(obj2brain(self.dossier))
+            .translated_review_state(),
+        )
+
+    def test_translated_review_state_for_proposal(self):
+        self.login(self.meeting_user)
+
+        self.assertEquals(
+            u'Eingereicht',
+            IContentListingObject(obj2brain(self.proposal))
+            .translated_review_state(),
+        )
+
+    def test_translated_review_state_for_submittedproposal(self):
+        self.login(self.meeting_user)
+
+        self.assertEquals(
+            u'Eingereicht',
+            IContentListingObject(obj2brain(self.submitted_proposal))
+            .translated_review_state(),
+        )
+
+    def test_translated_review_state_for_committee(self):
+        self.login(self.meeting_user)
+
+        self.assertEquals(
+            u'Aktiv',
+            IContentListingObject(obj2brain(self.committee))
+            .translated_review_state(),
+        )
 
 
 class TestBrainContentListingRenderLink(IntegrationTestCase):


### PR DESCRIPTION
Some meeting content like proposals have a custom workflow implementation that's layered on top of the Plone workflow.
For these, we need to use `obj.get_state()` to access the real workflow state that's in play, and translate that.

Jira: https://4teamwork.atlassian.net/browse/GEVER-808

## Checklist (Must have)

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
