### PR TITLE
Filter out owner role

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,11 +4,12 @@ Changelog
 2020.7.1 (unreleased)
 ---------------------
 
+- Filter out owner role in role assignment reports. [tinagerber]
 - Fix translated review state for meeting content. [lgraf]
 - Introduce POST @complete-successor-task on tasks. [lgraf]
 - Introduce POST @accept-remote-task endpoint for dossiers. [lgraf]
 - Introduce POST @remote-workflow endpoint. [lgraf]
-- Role Assignment Reports: Ensure stable sort order for report items. [lgraf] 
+- Role Assignment Reports: Ensure stable sort order for report items. [lgraf]
 - Fix dossier template description, ensure unicode. [deiferni]
 - Add policy template for teamraum policies. [njohner]
 - Fix filtering with exclusion filters if the field has a mapping. [tinagerber]

--- a/docs/public/dev-manual/api/docs_changelog.rst
+++ b/docs/public/dev-manual/api/docs_changelog.rst
@@ -8,7 +8,7 @@ Im Folgenden sind (substantielle) Änderungen an der Dokumentation aufgeführt.
 2020-07-10
 ----------
 
-- Kapitel "Rollenzuweisungs-Berichte" hinzugefügt
+- Kapitel "Berechtigungsreports" hinzugefügt
 
 
 2020-06-11

--- a/docs/public/dev-manual/api/role_assignment_reports.rst
+++ b/docs/public/dev-manual/api/role_assignment_reports.rst
@@ -1,7 +1,7 @@
-Rollenzuweisungs-Berichte
-=========================
+Berechtigungsreports
+====================
 
-Der ``@role-assignment-reports`` bietet Funktionen für die Auflistung, das Erstellen und das Löschen von Rollenzuweisungs-Berichten. Der Endpoint steht nur auf Stufe PloneSite zur Verfügung und ist mit einer Berechtigung geschützt: ``opengever.api.ManageRoleAssignmentReports``
+Der ``@role-assignment-reports`` bietet Funktionen für die Auflistung, das Erstellen und das Löschen von Berechtigungsreports. Der Endpoint steht nur auf Stufe PloneSite zur Verfügung und ist mit einer Berechtigung geschützt: ``opengever.api.ManageRoleAssignmentReports``
 Die Berechtigung ist standardmässig den Rollen `Administrator` und `Manager` zugewiesen.
 
 

--- a/opengever/base/nightly_role_assignment_reports.py
+++ b/opengever/base/nightly_role_assignment_reports.py
@@ -77,7 +77,9 @@ class NightlyRoleAssignmentReports(object):
             sharing_assignments = [assignment for assignment in assignments
                                    if assignment.cause == ASSIGNMENT_VIA_SHARING]
             if sharing_assignments:
-                items.append({'UID': obj.UID(), 'roles': sharing_assignments[0].roles})
+                roles = filter(lambda r: r != 'Owner', sharing_assignments[0].roles)
+                if roles:
+                    items.append({'UID': obj.UID(), 'roles': roles})
 
         report_data = {'state': STATE_READY, 'items': items}
         self.storage.update(reportid, report_data)


### PR DESCRIPTION
In this PR, the owner role is filtered out of the role assignment reports and "Rollenzuweisungsbericht" is renamed to "Berechtigungsreport" in the API documentation.

Jira: https://4teamwork.atlassian.net/browse/GEVER-547

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)