### PR TITLE
Fix empty bytestring overriding unicode in some cases. Fix existing content.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -8,6 +8,7 @@ Changelog
 - Introduce POST @accept-remote-task endpoint for dossiers. [lgraf]
 - Introduce POST @remote-workflow endpoint. [lgraf]
 - Role Assignment Reports: Ensure stable sort order for report items. [lgraf] 
+- Fix dossier template description, ensure unicode. [deiferni]
 - Add policy template for teamraum policies. [njohner]
 - Fix filtering with exclusion filters if the field has a mapping. [tinagerber]
 - Make the portal_url configurable through the portal_registry. [elioschmutz]

--- a/docs/schema-dumps/ftw.mail.mail.schema.json
+++ b/docs/schema-dumps/ftw.mail.mail.schema.json
@@ -57,8 +57,7 @@
             "type": "string",
             "title": "Bearbeitungsinformation",
             "description": "Datum Gesuch, Gesuchsteller, Datum Entscheid, Verweis auf GEVER-Gesuchdossier",
-            "_zope_schema_type": "Text",
-            "default": ""
+            "_zope_schema_type": "Text"
         },
         "description": {
             "type": "string",

--- a/docs/schema-dumps/opengever.document.document.schema.json
+++ b/docs/schema-dumps/opengever.document.document.schema.json
@@ -63,8 +63,7 @@
             "type": "string",
             "title": "Bearbeitungsinformation",
             "description": "Datum Gesuch, Gesuchsteller, Datum Entscheid, Verweis auf GEVER-Gesuchdossier",
-            "_zope_schema_type": "Text",
-            "default": ""
+            "_zope_schema_type": "Text"
         },
         "relatedItems": {
             "type": "array",

--- a/docs/schema-dumps/opengever.dossier.businesscasedossier.schema.json
+++ b/docs/schema-dumps/opengever.dossier.businesscasedossier.schema.json
@@ -165,8 +165,7 @@
             "type": "string",
             "title": "Bearbeitungsinformation",
             "description": "Datum Gesuch, Gesuchsteller, Datum Entscheid, Verweis auf GEVER-Gesuchdossier",
-            "_zope_schema_type": "Text",
-            "default": ""
+            "_zope_schema_type": "Text"
         },
         "retention_period": {
             "type": "integer",

--- a/docs/schema-dumps/opengever.repository.repositoryfolder.schema.json
+++ b/docs/schema-dumps/opengever.repository.repositoryfolder.schema.json
@@ -8,8 +8,7 @@
             "type": "string",
             "title": "Beschreibung",
             "description": "Eine kurze Beschreibung des Inhalts.",
-            "_zope_schema_type": "Text",
-            "default": null
+            "_zope_schema_type": "Text"
         },
         "valid_from": {
             "type": "string",
@@ -102,8 +101,7 @@
             "type": "string",
             "title": "Bearbeitungsinformation",
             "description": "Datum Gesuch, Gesuchsteller, Datum Entscheid, Verweis auf GEVER-Gesuchdossier",
-            "_zope_schema_type": "Text",
-            "default": ""
+            "_zope_schema_type": "Text"
         },
         "title_de": {
             "type": "string",

--- a/opengever/base/behaviors/classification.py
+++ b/opengever/base/behaviors/classification.py
@@ -94,6 +94,7 @@ class IClassification(model.Schema):
                 default=u'Public trial statement'),
         description=_(u'help_public_trial_statement', default=u''),
         required=False,
+        missing_value=u'',
         default=u'',
     )
 

--- a/opengever/base/monkey/patches/default_values.py
+++ b/opengever/base/monkey/patches/default_values.py
@@ -230,6 +230,7 @@ class PatchZ3CFormChangedField(MonkeyPatch):
             """Figure if a field's value changed
 
             Comparing the value of the context attribute and the given value"""
+
             if context is None:
                 context = field.context
             if context is None:
@@ -268,6 +269,14 @@ class PatchZ3CFormChangedField(MonkeyPatch):
 
             if stored_value != value:
                 return True
+
+            # Work around the fact that unicode and bytestrings are considered
+            # equal in python 2 for emtpy default values u'' and '' by also
+            # checking if the type changed for all basestrings. If the type
+            # changes we consider the field to have changed.
+            if isinstance(value, basestring):
+                if not isinstance(stored_value, type(value)):
+                    return True
 
             return False
 

--- a/opengever/base/tests/test_default_values_for_types.py
+++ b/opengever/base/tests/test_default_values_for_types.py
@@ -194,7 +194,7 @@ TASK_REQUIREDS = {
     'issuer': 'kathi.barfuss',
     'responsible': u'kathi.barfuss',
     'responsible_client': DEFAULT_CLIENT,
-    'task_type': u'information',
+    'task_type': 'information',
     'title': DEFAULT_TITLE,
 }
 TASK_DEFAULTS = {

--- a/opengever/base/tests/test_default_values_for_types.py
+++ b/opengever/base/tests/test_default_values_for_types.py
@@ -62,7 +62,7 @@ REPOFOLDER_DEFAULTS = {
     'description': u'',
     'privacy_layer': u'privacy_layer_no',
     'public_trial': u'unchecked',
-    'public_trial_statement': '',
+    'public_trial_statement': u'',
     'reference_number_prefix': u'1',
     'retention_period': 5,
 }
@@ -140,7 +140,7 @@ DOCUMENT_DEFAULTS = {
     'preserved_as_paper': True,
     'privacy_layer': u'privacy_layer_no',
     'public_trial': u'unchecked',
-    'public_trial_statement': '',
+    'public_trial_statement': u'',
     'relatedItems': [],
 }
 DOCUMENT_FORM_DEFAULTS = {}
@@ -170,7 +170,7 @@ MAIL_DEFAULTS = {
     'preserved_as_paper': True,
     'privacy_layer': u'privacy_layer_no',
     'public_trial': u'unchecked',
-    'public_trial_statement': '',
+    'public_trial_statement': u'',
     'receipt_date': FROZEN_TODAY,
     'title': 'Lorem Ipsum',
 }
@@ -647,9 +647,6 @@ class TestRepositoryFolderDefaults(TestDefaultsBase):
         persisted_values = get_persisted_values_for_obj(repofolder)
         expected = self.get_z3c_form_defaults()
 
-        # XXX: Don't know why this happens
-        expected['public_trial_statement'] = None
-
         self.assert_default_values_equal(expected, persisted_values)
 
     @browsing
@@ -741,9 +738,6 @@ class TestDossierDefaults(TestDefaultsBase):
         persisted_values = get_persisted_values_for_obj(dossier)
         expected = self.get_z3c_form_defaults()
 
-        # XXX: Don't know why this happens
-        expected['public_trial_statement'] = None
-
         self.assert_default_values_equal(expected, persisted_values)
 
     @browsing
@@ -794,9 +788,6 @@ class TestDossierDefaults(TestDefaultsBase):
 
         persisted_values = get_persisted_values_for_obj(dossier)
         expected = self.get_z3c_form_defaults()
-
-        # XXX: Don't know why this happens
-        expected['public_trial_statement'] = None
 
         self.assert_default_values_equal(expected, persisted_values)
 
@@ -935,9 +926,6 @@ class TestDocumentDefaults(TestDefaultsBase):
         persisted_values = get_persisted_values_for_obj(doc)
         expected = self.get_z3c_form_defaults()
         expected['file'] = doc.file
-
-        # XXX: Don't know why this happens
-        expected['public_trial_statement'] = None
 
         self.assert_default_values_equal(expected, persisted_values)
 
@@ -1109,9 +1097,6 @@ class TestMailDefaults(TestDefaultsBase):
         expected = self.get_z3c_form_defaults()
 
         expected['message'] = mail._message
-
-        # XXX: Don't know why this happens
-        expected['public_trial_statement'] = None
 
         self.assert_default_values_equal(expected, persisted_values)
 

--- a/opengever/base/tests/test_default_values_for_types.py
+++ b/opengever/base/tests/test_default_values_for_types.py
@@ -674,6 +674,8 @@ class TestRepositoryFolderDefaults(TestDefaultsBase):
         expected = self.get_type_defaults()
         expected['addable_dossier_types'] = None
         expected['title_fr'] = u'French Title'
+        # when setting description via rest api it seems to become a bytestring
+        expected['description'] = ''
 
         self.assert_default_values_equal(expected, persisted_values)
 
@@ -763,7 +765,10 @@ class TestDossierDefaults(TestDefaultsBase):
 
         persisted_values = get_persisted_values_for_obj(dossier)
         expected = self.get_type_defaults()
-        expected['responsible'] = DOSSIER_FORM_DEFAULTS['responsible']
+        # when setting responsible via rest api it seems to become unicode
+        expected['responsible'] = DOSSIER_FORM_DEFAULTS['responsible'].decode('utf-8')
+        # when setting description via rest api it seems to become a bytestring
+        expected['description'] = ''
 
         self.assert_default_values_equal(expected, persisted_values)
 

--- a/opengever/base/tests/test_default_values_for_types.py
+++ b/opengever/base/tests/test_default_values_for_types.py
@@ -260,7 +260,7 @@ PROPOSAL_DEFAULTS = {
     'changed': FROZEN_NOW,
     'description': u'',
     'title': u'Containing Dossier Title',
-    'language': 'en',
+    'language': u'en',
 }
 PROPOSAL_FORM_DEFAULTS = {
     'description': u''
@@ -280,7 +280,7 @@ SUBMITTED_PROPOSAL_DEFAULTS = {
     'changed': FROZEN_NOW,
     'description': u'',
     'title': u'',
-    'language': 'en',
+    'language': u'en',
 }
 SUBMITTED_PROPOSAL_MISSING_VALUES = {
     'date_of_submission': None,

--- a/opengever/base/tests/test_default_values_for_types.py
+++ b/opengever/base/tests/test_default_values_for_types.py
@@ -485,6 +485,16 @@ class TestDefaultsBase(IntegrationTestCase):
                     field_value_from_widget, missing_value,
                     widget, obj.portal_type))
 
+    def assert_default_values_equal(self, expected, actual):
+        expected_with_type = dict(
+            (key, (val, type(val))) for key, val in expected.items()
+        )
+        actual_with_type = dict(
+            (key, (val, type(val))) for key, val in actual.items()
+        )
+
+        self.assertDictEqual(expected_with_type, actual_with_type)
+
 
 class TestRepositoryRootDefaults(TestDefaultsBase):
     """Test our repository roots come with expected default values."""
@@ -512,7 +522,7 @@ class TestRepositoryRootDefaults(TestDefaultsBase):
         persisted_values = get_persisted_values_for_obj(reporoot)
         expected = self.get_type_defaults()
 
-        self.assertDictEqual(expected, persisted_values)
+        self.assert_default_values_equal(expected, persisted_values)
 
     def test_invoke_factory(self):
         self.login(self.manager)
@@ -528,7 +538,7 @@ class TestRepositoryRootDefaults(TestDefaultsBase):
         persisted_values = get_persisted_values_for_obj(reporoot)
         expected = self.get_type_defaults()
 
-        self.assertDictEqual(expected, persisted_values)
+        self.assert_default_values_equal(expected, persisted_values)
 
     @browsing
     def test_z3c_add_form(self, browser):
@@ -544,7 +554,7 @@ class TestRepositoryRootDefaults(TestDefaultsBase):
         persisted_values = get_persisted_values_for_obj(reporoot)
         expected = self.get_z3c_form_defaults()
 
-        self.assertDictEqual(expected, persisted_values)
+        self.assert_default_values_equal(expected, persisted_values)
 
     @browsing
     def test_rest_api(self, browser):
@@ -571,7 +581,7 @@ class TestRepositoryRootDefaults(TestDefaultsBase):
         expected = self.get_type_defaults()
         expected['title_fr'] = u'French Title'
 
-        self.assertDictEqual(expected, persisted_values)
+        self.assert_default_values_equal(expected, persisted_values)
 
 
 class TestRepositoryFolderDefaults(TestDefaultsBase):
@@ -602,7 +612,7 @@ class TestRepositoryFolderDefaults(TestDefaultsBase):
         # XXX: Don't know why this happens
         expected['addable_dossier_types'] = None
 
-        self.assertDictEqual(expected, persisted_values)
+        self.assert_default_values_equal(expected, persisted_values)
 
     def test_invoke_factory(self):
         self.login(self.administrator)
@@ -621,7 +631,7 @@ class TestRepositoryFolderDefaults(TestDefaultsBase):
         # XXX: Don't know why this happens
         expected['addable_dossier_types'] = None
 
-        self.assertDictEqual(expected, persisted_values)
+        self.assert_default_values_equal(expected, persisted_values)
 
     @browsing
     def test_z3c_add_form(self, browser):
@@ -640,7 +650,7 @@ class TestRepositoryFolderDefaults(TestDefaultsBase):
         # XXX: Don't know why this happens
         expected['public_trial_statement'] = None
 
-        self.assertDictEqual(expected, persisted_values)
+        self.assert_default_values_equal(expected, persisted_values)
 
     @browsing
     def test_rest_api(self, browser):
@@ -668,7 +678,7 @@ class TestRepositoryFolderDefaults(TestDefaultsBase):
         expected['addable_dossier_types'] = None
         expected['title_fr'] = u'French Title'
 
-        self.assertDictEqual(expected, persisted_values)
+        self.assert_default_values_equal(expected, persisted_values)
 
 
 class TestDossierDefaults(TestDefaultsBase):
@@ -699,7 +709,7 @@ class TestDossierDefaults(TestDefaultsBase):
         persisted_values = get_persisted_values_for_obj(dossier)
         expected = self.get_type_defaults()
 
-        self.assertDictEqual(expected, persisted_values)
+        self.assert_default_values_equal(expected, persisted_values)
 
     def test_invoke_factory(self):
         self.login(self.regular_user)
@@ -715,7 +725,7 @@ class TestDossierDefaults(TestDefaultsBase):
         persisted_values = get_persisted_values_for_obj(dossier)
         expected = self.get_type_defaults()
 
-        self.assertDictEqual(expected, persisted_values)
+        self.assert_default_values_equal(expected, persisted_values)
 
     @browsing
     def test_z3c_add_form(self, browser):
@@ -734,7 +744,7 @@ class TestDossierDefaults(TestDefaultsBase):
         # XXX: Don't know why this happens
         expected['public_trial_statement'] = None
 
-        self.assertDictEqual(expected, persisted_values)
+        self.assert_default_values_equal(expected, persisted_values)
 
     @browsing
     def test_rest_api(self, browser):
@@ -761,7 +771,7 @@ class TestDossierDefaults(TestDefaultsBase):
         expected = self.get_type_defaults()
         expected['responsible'] = DOSSIER_FORM_DEFAULTS['responsible']
 
-        self.assertDictEqual(expected, persisted_values)
+        self.assert_default_values_equal(expected, persisted_values)
 
     @browsing
     def test_dossier_from_template(self, browser):
@@ -788,7 +798,7 @@ class TestDossierDefaults(TestDefaultsBase):
         # XXX: Don't know why this happens
         expected['public_trial_statement'] = None
 
-        self.assertDictEqual(expected, persisted_values)
+        self.assert_default_values_equal(expected, persisted_values)
 
     @browsing
     def test_subdossier_from_template(self, browser):
@@ -819,7 +829,7 @@ class TestDossierDefaults(TestDefaultsBase):
         # A subdossier has the type_defaults with addiional form_defaults
         expected.update(self.form_defaults)
 
-        self.assertDictEqual(expected, persisted_values)
+        self.assert_default_values_equal(expected, persisted_values)
 
 
 class TestDocumentDefaults(TestDefaultsBase):
@@ -875,7 +885,7 @@ class TestDocumentDefaults(TestDefaultsBase):
         expected = self.get_type_defaults()
         expected['file'] = doc.file
 
-        self.assertDictEqual(expected, persisted_values)
+        self.assert_default_values_equal(expected, persisted_values)
 
     def test_invoke_factory(self):
         self.login(self.regular_user)
@@ -899,7 +909,7 @@ class TestDocumentDefaults(TestDefaultsBase):
         expected = self.get_type_defaults()
         expected['file'] = doc.file
 
-        self.assertDictEqual(expected, persisted_values)
+        self.assert_default_values_equal(expected, persisted_values)
 
     @browsing
     def test_z3c_add_form(self, browser):
@@ -929,7 +939,7 @@ class TestDocumentDefaults(TestDefaultsBase):
         # XXX: Don't know why this happens
         expected['public_trial_statement'] = None
 
-        self.assertDictEqual(expected, persisted_values)
+        self.assert_default_values_equal(expected, persisted_values)
 
     @browsing
     def test_rest_api(self, browser):
@@ -965,7 +975,7 @@ class TestDocumentDefaults(TestDefaultsBase):
         expected = self.get_type_defaults()
         expected['file'] = doc.file
 
-        self.assertDictEqual(expected, persisted_values)
+        self.assert_default_values_equal(expected, persisted_values)
 
     @browsing
     def test_document_from_dossiertemplate(self, browser):
@@ -996,7 +1006,7 @@ class TestDocumentDefaults(TestDefaultsBase):
         expected['digitally_available'] = True
         expected['file'] = doc.file
 
-        self.assertDictEqual(expected, persisted_values)
+        self.assert_default_values_equal(expected, persisted_values)
 
 
 class TestMailDefaults(TestDefaultsBase):
@@ -1052,7 +1062,7 @@ class TestMailDefaults(TestDefaultsBase):
 
         expected['message'] = mail._message
 
-        self.assertDictEqual(expected, persisted_values)
+        self.assert_default_values_equal(expected, persisted_values)
 
     def test_invoke_factory(self):
         self.login(self.regular_user)
@@ -1075,7 +1085,7 @@ class TestMailDefaults(TestDefaultsBase):
 
         expected['message'] = mail._message
 
-        self.assertDictEqual(expected, persisted_values)
+        self.assert_default_values_equal(expected, persisted_values)
 
     @browsing
     def test_z3c_add_form(self, browser):
@@ -1103,7 +1113,7 @@ class TestMailDefaults(TestDefaultsBase):
         # XXX: Don't know why this happens
         expected['public_trial_statement'] = None
 
-        self.assertDictEqual(expected, persisted_values)
+        self.assert_default_values_equal(expected, persisted_values)
 
     @browsing
     def test_rest_api(self, browser):
@@ -1139,7 +1149,7 @@ class TestMailDefaults(TestDefaultsBase):
 
         expected['message'] = mail._message
 
-        self.assertDictEqual(expected, persisted_values)
+        self.assert_default_values_equal(expected, persisted_values)
 
 
 class TestTaskDefaults(TestDefaultsBase):
@@ -1172,7 +1182,7 @@ class TestTaskDefaults(TestDefaultsBase):
         persisted_values = get_persisted_values_for_obj(task)
         expected = self.get_type_defaults()
 
-        self.assertDictEqual(expected, persisted_values)
+        self.assert_default_values_equal(expected, persisted_values)
 
     def test_invoke_factory(self):
         self.login(self.regular_user)
@@ -1193,7 +1203,7 @@ class TestTaskDefaults(TestDefaultsBase):
         persisted_values = get_persisted_values_for_obj(task)
         expected = self.get_type_defaults()
 
-        self.assertDictEqual(expected, persisted_values)
+        self.assert_default_values_equal(expected, persisted_values)
 
     @browsing
     def test_z3c_add_form(self, browser):
@@ -1218,7 +1228,7 @@ class TestTaskDefaults(TestDefaultsBase):
         persisted_values = get_persisted_values_for_obj(task)
         expected = self.get_z3c_form_defaults()
 
-        self.assertDictEqual(expected, persisted_values)
+        self.assert_default_values_equal(expected, persisted_values)
 
 
 class TestContactDefaults(TestDefaultsBase):
@@ -1248,7 +1258,7 @@ class TestContactDefaults(TestDefaultsBase):
         persisted_values = get_persisted_values_for_obj(contact)
         expected = self.get_type_defaults()
 
-        self.assertDictEqual(expected, persisted_values)
+        self.assert_default_values_equal(expected, persisted_values)
 
     def test_invoke_factory(self):
         self.login(self.regular_user)
@@ -1265,7 +1275,7 @@ class TestContactDefaults(TestDefaultsBase):
         persisted_values = get_persisted_values_for_obj(contact)
         expected = self.get_type_defaults()
 
-        self.assertDictEqual(expected, persisted_values)
+        self.assert_default_values_equal(expected, persisted_values)
 
     @browsing
     def test_z3c_add_form(self, browser):
@@ -1282,7 +1292,7 @@ class TestContactDefaults(TestDefaultsBase):
         persisted_values = get_persisted_values_for_obj(contact)
         expected = self.get_z3c_form_defaults()
 
-        self.assertDictEqual(expected, persisted_values)
+        self.assert_default_values_equal(expected, persisted_values)
 
     @browsing
     def test_rest_api(self, browser):
@@ -1308,7 +1318,7 @@ class TestContactDefaults(TestDefaultsBase):
         persisted_values = get_persisted_values_for_obj(contact)
         expected = self.get_type_defaults()
 
-        self.assertDictEqual(expected, persisted_values)
+        self.assert_default_values_equal(expected, persisted_values)
 
 
 class TestProposalDefaults(TestDefaultsBase):
@@ -1345,7 +1355,7 @@ class TestProposalDefaults(TestDefaultsBase):
         persisted_values = get_persisted_values_for_obj(proposal)
         expected = self.get_type_defaults()
 
-        self.assertDictEqual(expected, persisted_values)
+        self.assert_default_values_equal(expected, persisted_values)
 
     def test_invoke_factory(self):
         self.login(self.meeting_user)
@@ -1362,7 +1372,7 @@ class TestProposalDefaults(TestDefaultsBase):
         persisted_values = get_persisted_values_for_obj(proposal)
         expected = self.get_type_defaults()
 
-        self.assertDictEqual(expected, persisted_values)
+        self.assert_default_values_equal(expected, persisted_values)
 
     @browsing
     def test_z3c_add_form(self, browser):
@@ -1381,7 +1391,7 @@ class TestProposalDefaults(TestDefaultsBase):
         expected = self.get_z3c_form_defaults()
         expected['committee_oguid'] = Oguid.for_object(self.committee).id
 
-        self.assertDictEqual(expected, persisted_values)
+        self.assert_default_values_equal(expected, persisted_values)
 
 
 class TestSubmittedProposalDefaults(TestDefaultsBase):
@@ -1412,7 +1422,7 @@ class TestSubmittedProposalDefaults(TestDefaultsBase):
         persisted_values = get_persisted_values_for_obj(proposal)
         expected = self.get_type_defaults()
 
-        self.assertDictEqual(expected, persisted_values)
+        self.assert_default_values_equal(expected, persisted_values)
 
     def test_invoke_factory(self):
         self.login(self.manager)
@@ -1428,7 +1438,7 @@ class TestSubmittedProposalDefaults(TestDefaultsBase):
         persisted_values = get_persisted_values_for_obj(proposal)
         expected = self.get_type_defaults()
 
-        self.assertDictEqual(expected, persisted_values)
+        self.assert_default_values_equal(expected, persisted_values)
 
     def get_obj_of_own_type(self):
         pass
@@ -1467,7 +1477,7 @@ class TestPrivateFolderDefaults(TestDefaultsBase):
         persisted_values = get_persisted_values_for_obj(private_folder)
         expected = self.get_type_defaults()
 
-        self.assertDictEqual(expected, persisted_values)
+        self.assert_default_values_equal(expected, persisted_values)
 
 
 class TestPeriodDefaults(TestDefaultsBase):
@@ -1497,7 +1507,7 @@ class TestPeriodDefaults(TestDefaultsBase):
         persisted_values = get_persisted_values_for_obj(period)
         expected = self.get_type_defaults()
 
-        self.assertDictEqual(expected, persisted_values)
+        self.assert_default_values_equal(expected, persisted_values)
 
     def test_invoke_factory(self):
         self.login(self.committee_responsible)
@@ -1512,7 +1522,7 @@ class TestPeriodDefaults(TestDefaultsBase):
         persisted_values = get_persisted_values_for_obj(period)
         expected = self.get_type_defaults()
 
-        self.assertDictEqual(expected, persisted_values)
+        self.assert_default_values_equal(expected, persisted_values)
 
     @browsing
     def test_z3c_add_form(self, browser):
@@ -1529,4 +1539,4 @@ class TestPeriodDefaults(TestDefaultsBase):
         persisted_values = get_persisted_values_for_obj(period)
         expected = self.get_z3c_form_defaults()
 
-        self.assertDictEqual(expected, persisted_values)
+        self.assert_default_values_equal(expected, persisted_values)

--- a/opengever/base/tests/test_default_values_for_types.py
+++ b/opengever/base/tests/test_default_values_for_types.py
@@ -320,6 +320,35 @@ PERIOD_FORM_DEFAULTS = {
 PERIOD_MISSING_VALUES = {
 }
 
+DOSSIER_TEMPLATE_REQUIREDS = {
+    'title': DEFAULT_TITLE,
+}
+DOSSIER_TEMPLATE_DEFAULTS = {
+    'changed': FROZEN_NOW,
+    'description': u'',
+    'keywords': (),
+    'predefined_keywords': True,
+    'relatedDossier': [],
+    'restrict_keywords': False,
+    'start': FROZEN_TODAY,
+    'title_help': u'',
+}
+DOSSIER_TEMPLATE_FORM_DEFAULTS = {
+}
+DOSSIER_TEMPLATE_MISSING_VALUES = {
+    'comments': None,
+    'container_location': None,
+    'container_type': None,
+    'end': None,
+    'external_reference': None,
+    'filing_prefix': None,
+    'former_reference_number': None,
+    'number_of_containers': None,
+    'responsible': None,
+    'temporary_former_reference_number': None,
+    'touched': None,
+}
+
 
 class TestDefaultsBase(IntegrationTestCase):
     """Test our base classes have expected default values."""
@@ -1528,5 +1557,110 @@ class TestPeriodDefaults(TestDefaultsBase):
 
         persisted_values = get_persisted_values_for_obj(period)
         expected = self.get_z3c_form_defaults()
+
+        self.assert_default_values_equal(expected, persisted_values)
+
+
+class TestDossierTemplateDefaults(TestDefaultsBase):
+    """Test dossiertemplates come with expected default values."""
+
+    portal_type = 'opengever.dossier.dossiertemplate'
+
+    requireds = DOSSIER_TEMPLATE_REQUIREDS
+    type_defaults = DOSSIER_TEMPLATE_DEFAULTS
+    form_defaults = DOSSIER_TEMPLATE_FORM_DEFAULTS
+    missing_values = DOSSIER_TEMPLATE_MISSING_VALUES
+
+    features = ('dossiertemplate', )
+
+    def get_obj_of_own_type(self):
+        return self.dossiertemplate
+
+    def test_create_content_in_container(self):
+        self.login(self.administrator)
+
+        with freeze(FROZEN_NOW):
+            dossier = createContentInContainer(
+                self.templates,
+                self.portal_type,
+                title=DOSSIER_TEMPLATE_REQUIREDS['title'],
+            )
+
+        persisted_values = get_persisted_values_for_obj(dossier)
+        expected = self.get_type_defaults()
+        # we don't set that field for dossier templates, it seems
+        del expected['touched']
+
+        self.assert_default_values_equal(expected, persisted_values)
+
+    def test_invoke_factory(self):
+        self.login(self.administrator)
+
+        with freeze(FROZEN_NOW):
+            new_id = self.templates.invokeFactory(
+                self.portal_type,
+                'dossiertemplate-999',
+                title=DOSSIER_TEMPLATE_REQUIREDS['title'],
+            )
+        dossier = self.templates[new_id]
+
+        persisted_values = get_persisted_values_for_obj(dossier)
+        expected = self.get_type_defaults()
+        # we don't set that field for dossier templates, it seems
+        del expected['touched']
+
+        self.assert_default_values_equal(expected, persisted_values)
+
+    @browsing
+    def test_z3c_add_form(self, browser):
+        self.login(self.administrator, browser)
+
+        with freeze(FROZEN_NOW):
+            browser.open(self.templates)
+            factoriesmenu.add(u'Dossier template')
+            browser.fill({u'Title': DOSSIER_TEMPLATE_REQUIREDS['title']}).save()
+
+        dossier = browser.context
+
+        persisted_values = get_persisted_values_for_obj(dossier)
+        expected = self.get_z3c_form_defaults()
+        # we don't set that field for dossier templates, it seems
+        del expected['touched']
+
+        self.assert_default_values_equal(expected, persisted_values)
+
+    @browsing
+    def test_rest_api(self, browser):
+        self.login(self.administrator, browser)
+
+        payload = {
+            u'@type': self.portal_type,
+            u'title': DOSSIER_TEMPLATE_REQUIREDS['title'],
+            # the dossier template expects a responsible, even though unused
+            # in the form. we just give it the one from dossier
+            u'responsible': DOSSIER_FORM_DEFAULTS['responsible'],
+        }
+        with freeze(FROZEN_NOW):
+            response = browser.open(
+                self.templates.absolute_url(),
+                data=json.dumps(payload),
+                method='POST',
+                headers=self.api_headers)
+
+        self.assertEqual(201, response.status_code)
+
+        new_object_id = str(response.json['id'])
+        dossier = self.templates.restrictedTraverse(new_object_id)
+
+        persisted_values = get_persisted_values_for_obj(dossier)
+        expected = self.get_type_defaults()
+        # we don't set that field for dossier templates, it seems
+        del expected['touched']
+        # the dossier template expects a responsible, even though unused
+        # in the form. we just give it the one from dossier
+        # when setting responsible via rest api it seems to become unicode
+        expected['responsible'] = DOSSIER_FORM_DEFAULTS['responsible'].decode('utf-8')
+        # when setting description via rest api it seems to become a bytestring
+        expected['description'] = ''
 
         self.assert_default_values_equal(expected, persisted_values)

--- a/opengever/base/tests/test_default_values_for_types.py
+++ b/opengever/base/tests/test_default_values_for_types.py
@@ -172,7 +172,7 @@ MAIL_DEFAULTS = {
     'public_trial': u'unchecked',
     'public_trial_statement': u'',
     'receipt_date': FROZEN_TODAY,
-    'title': 'Lorem Ipsum',
+    'title': u'Lorem Ipsum',
 }
 MAIL_FORM_DEFAULTS = {}
 MAIL_MISSING_VALUES = {
@@ -192,7 +192,7 @@ MAIL_MISSING_VALUES = {
 TASK_REQUIREDS = {
     'changed': FROZEN_NOW,
     'issuer': 'kathi.barfuss',
-    'responsible': 'kathi.barfuss',
+    'responsible': u'kathi.barfuss',
     'responsible_client': DEFAULT_CLIENT,
     'task_type': u'information',
     'title': DEFAULT_TITLE,
@@ -205,7 +205,7 @@ TASK_DEFAULTS = {
     'revoke_permissions': True
 }
 TASK_FORM_DEFAULTS = {
-    'issuer': 'kathi.barfuss',
+    'issuer': u'kathi.barfuss',
     'responsible_client': DEFAULT_CLIENT,
 }
 TASK_MISSING_VALUES = {

--- a/opengever/base/utils.py
+++ b/opengever/base/utils.py
@@ -2,6 +2,7 @@ from persistent.dict import PersistentDict
 from persistent.list import PersistentList
 from plone import api
 from Products.CMFCore.utils import getToolByName
+from Products.CMFPlone.utils import safe_unicode
 from xml.sax.saxutils import escape
 from zope.component import getMultiAdapter
 from zope.component.hooks import getSite
@@ -73,7 +74,7 @@ def get_preferred_language_code():
     language_code = ltool.getPreferredLanguage()
 
     # Special handling for combined languages, but works for regular ones too.
-    return language_code.split('-')[0]
+    return safe_unicode(language_code.split('-')[0])
 
 
 def get_hostname(request):

--- a/opengever/bundle/schemas/documents.schema.json
+++ b/opengever/bundle/schemas/documents.schema.json
@@ -81,8 +81,7 @@
                     ],
                     "title": "Bearbeitungsinformation",
                     "description": "Datum Gesuch, Gesuchsteller, Datum Entscheid, Verweis auf GEVER-Gesuchdossier",
-                    "_zope_schema_type": "Text",
-                    "default": ""
+                    "_zope_schema_type": "Text"
                 },
                 "relatedItems": {
                     "type": [

--- a/opengever/bundle/schemas/dossiers.schema.json
+++ b/opengever/bundle/schemas/dossiers.schema.json
@@ -233,8 +233,7 @@
                     ],
                     "title": "Bearbeitungsinformation",
                     "description": "Datum Gesuch, Gesuchsteller, Datum Entscheid, Verweis auf GEVER-Gesuchdossier",
-                    "_zope_schema_type": "Text",
-                    "default": ""
+                    "_zope_schema_type": "Text"
                 },
                 "retention_period": {
                     "type": [

--- a/opengever/bundle/schemas/repofolders.schema.json
+++ b/opengever/bundle/schemas/repofolders.schema.json
@@ -17,8 +17,7 @@
                     ],
                     "title": "Beschreibung",
                     "description": "Eine kurze Beschreibung des Inhalts.",
-                    "_zope_schema_type": "Text",
-                    "default": null
+                    "_zope_schema_type": "Text"
                 },
                 "valid_from": {
                     "type": [
@@ -150,8 +149,7 @@
                     ],
                     "title": "Bearbeitungsinformation",
                     "description": "Datum Gesuch, Gesuchsteller, Datum Entscheid, Verweis auf GEVER-Gesuchdossier",
-                    "_zope_schema_type": "Text",
-                    "default": ""
+                    "_zope_schema_type": "Text"
                 },
                 "title_de": {
                     "type": [

--- a/opengever/core/upgrades/20200825130823_fix_description_type_for_dossier_templates/upgrade.py
+++ b/opengever/core/upgrades/20200825130823_fix_description_type_for_dossier_templates/upgrade.py
@@ -1,0 +1,14 @@
+from ftw.upgrade import UpgradeStep
+from opengever.dossier.dossiertemplate.behaviors import IDossierTemplateMarker
+from Products.CMFPlone.utils import safe_unicode
+
+
+class FixDescriptionTypeForDossierTemplates(UpgradeStep):
+    """Fix description type for dossier templates.
+    """
+
+    def __call__(self):
+        query = {'object_provides': IDossierTemplateMarker.__identifier__}
+        for obj in self.objects(query, 'Fix dossier template description'):
+            description = getattr(obj, 'description', u'')
+            obj.description = safe_unicode(description)

--- a/opengever/dossier/dossiertemplate/behaviors.py
+++ b/opengever/dossier/dossiertemplate/behaviors.py
@@ -38,6 +38,8 @@ class IDossierTemplateSchema(model.Schema):
                               u'displayed as a help text if you create '
                               u'a dossier from template'),
         required=False,
+        missing_value=u'',
+        default=u'',
     )
 
     form.order_after(predefined_keywords='IDossierTemplate.keywords')

--- a/opengever/mail/tests/test_mail_classification.py
+++ b/opengever/mail/tests/test_mail_classification.py
@@ -20,9 +20,7 @@ class TestMailMetadata(FunctionalTestCase):
         self.assertEquals(mail.privacy_layer, PRIVACY_LAYER_NO)
         self.assertEquals(mail.public_trial, PUBLIC_TRIAL_UNCHECKED)
 
-        # XXX: imho this should be a empty string, not None, since the field
-        # has a default value (empty string)
-        self.assertIsNone(mail.public_trial_statement)
+        self.assertEqual(u'', mail.public_trial_statement)
 
     def test_public_trial_default_is_configurable(self):
         registry = getUtility(IRegistry)

--- a/opengever/repository/repositoryfolder.py
+++ b/opengever/repository/repositoryfolder.py
@@ -43,6 +43,7 @@ class IRepositoryFolderSchema(model.Schema):
             u'help_description',
             default=u'A short summary of the content.'),
         required=False,
+        default=u'',
         missing_value=u'',
         )
 


### PR DESCRIPTION
With this PR we fix our default_value patches not correctly detecting the difference between `''` and `u''` in some cases. The issue has surfaced due to the change introduced in https://github.com/4teamwork/opengever.core/pull/6563/ where we set values via their field during `createContentInContainer`. This will perform a type-check and fail if the type is not correct.

The issue appeared in production when creating a dossier from a templatedossiers with a sub-template dossiers with only the description default value. See https://sentry.4teamwork.ch/sentry/onegov-gever/issues/68884/ for corresponding sentry issue. See https://4teamwork.atlassian.net/browse/GEVER-895 for steps to reproduce.

**To tackle the issue i have:**
- added type checks to our default value tests
- fixed where the schema interfaces did not specify `default` and `missing_value`
- fixed some cases where we use incorrect types in our business logic
- changed defaults used in our default value tests, so that they document which type is used
- in some cases inconsistent types are still used when creating content via `plone.restapi`, but the tests now document where this happens
- i could get rid of some existing workarounds in tests which indicates the changes go the right way 🎉 

**To fix the issues in production:**
- there is an upgrade-step making sure dossier templates now use the correct type for description
- i have not provided an upgrade step for all other potentially affected types as the risk to touch almost all content exceeds the value of having consistent types. it should™️  not be an issue in production in general.
- i have manually tested the upgrade and confirmed it eliminates the issue for affected content
- i have verified that our existing tests would be able to pick up the issue in https://github.com/4teamwork/opengever.core/blob/396fb99a13cb241a650c21dcf163cb0026da7505/opengever/dossier/tests/test_dossier_template.py#L434-L461 ⚠️ this change is not in this PR as we will fix the affected data instead

**Know problems:**
- when creating content via `plone.restapi` the description is still incorrectly set to a bytestring: https://4teamwork.atlassian.net/browse/GEVER-918
- `IDossierTemplate` seems to inherit unused fields from `IDossier`, namely `touched` and `responsible`, this may become an issue when we implement dossier templates in the new ui: https://4teamwork.atlassian.net/browse/GEVER-917

_The PR contains very granular commits, where i change tests so that the issue surfaces, then attempt to fix a single issue with a single commit. I can squash, if desired._

Jira: https://4teamwork.atlassian.net/browse/GEVER-895

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
