### PR TITLE
Use correct client-policy in production template.

### DIFF
--- a/opengever/policytemplates/policy_template/opengever.+package.name+/deployment-+base.server_name+-+base.deployment_number+-+base.domain+.cfg.bob
+++ b/opengever/policytemplates/policy_template/opengever.+package.name+/deployment-+base.server_name+-+base.deployment_number+-+base.domain+.cfg.bob
@@ -12,7 +12,7 @@ extends =
 
 deployment-number = {{{base.deployment_number}}}
 ogds-db-name = ogds_{{{package.name}}}
-client-policy = opengever.{{{package.name}}}
+client-policy = opengever.{{{package.name}}}.{{{adminunit.id}}}
 usernamelogger_ac_cookie_name = __ac_{{{adminunit.ac_cookie_name}}}
 instance-eggs += opengever.{{{package.name}}}
 solr-core-name = {{{package.name}}}


### PR DESCRIPTION
This is a follow-up for https://github.com/4teamwork/opengever.core/pull/6582. The `client-policy` used in the production `buildout.cfg` was not correct yet and is fixed with this PR to also include the additional nesting level.

✅   &nbsp;I have manually tested that the new policy is now correct.

Jira: https://4teamwork.atlassian.net/browse/GEVER-751

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [ ] ~~Changelog entry~~
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)