### PR TITLE
Add @transfer-dossier Endpoint

### DIFF
--- a/docs/public/dev-manual/api/dossiers.rst
+++ b/docs/public/dev-manual/api/dossiers.rst
@@ -1,0 +1,65 @@
+.. _dossiers:
+
+Dossiers
+========
+
+Dossiers können über die REST-API gem. Kapitel :ref:`operations` bedient werden. Zusätzlich stehen folgende Funktionen für Dossiers zur Verfügung.
+
+
+Dossier übertragen
+------------------
+
+Der Dossier-Verantwortliche kann über den Endpoint ``@transfer-dossier`` an eine neue Person übertragen werden. Dabei wird überprüft, ob ``old_userid`` der aktuelle Dossier-Verantwortliche ist. Ist dies der Fall, wird der Benutzer mit der User-ID ``new_userid`` als neuer Verantwortlicher gesetzt.
+Benachrichtigungen, die normalerweise bei einer Änderung ausgelöst werden, werden unterdrückt. Dieser Endpoint wird mit einer Berechtigung geschützt: ``opengever.api.TransferAssignment``
+Die Berechtigung ist standardmässig den Rollen `Administrator` und `Manager` zugewiesen.
+
+Standardmässig werden auch Subossiers, welche explizit auf den früheren Benutzer gesetzt waren, auf den neuen Verantwortlichen übertragen.
+
+**Beispiel-Request**:
+
+   .. sourcecode:: http
+
+      POST /dossier-1/@transfer-dossier HTTP/1.1
+      Accept: application/json
+      Content-Type: application/json
+
+      {
+        "old_userid": "john.doe",
+        "new_userid": "robert.ziegler"
+      }
+
+
+**Beispiel-Response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 204 No content
+
+Übertragen von Subdossiers unterbinden
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Über die Option ``recursive`` kann gesteuert werden, ob Subdossiers auch übertragen werden sollen, oder nicht.
+
+Standardmässig ist diese Option aktiviert.
+
+
+**Beispiel-Request**:
+
+   .. sourcecode:: http
+
+      POST /dossier-1/@transfer-dossier HTTP/1.1
+      Accept: application/json
+      Content-Type: application/json
+
+      {
+        "old_userid": "john.doe",
+        "new_userid": "robert.ziegler",
+        "recursive": false
+      }
+
+
+**Beispiel-Response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 204 No content

--- a/docs/public/dev-manual/api/index.rst
+++ b/docs/public/dev-manual/api/index.rst
@@ -18,6 +18,7 @@ Inhalt:
    navigation.rst
    breadcrumbs.rst
    searching.rst
+   dossiers.rst
    documents.rst
    extract_attachments.rst
    trash.rst

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -308,6 +308,14 @@
       />
 
   <plone:service
+      method="POST"
+      name="@transfer-dossier"
+      for="opengever.dossier.behaviors.dossier.IDossierMarker"
+      factory=".transfer.TransferDossierPost"
+      permission="opengever.api.TransferAssignment"
+      />
+
+  <plone:service
       method="GET"
       name="@role-assignment-reports"
       for="Products.CMFPlone.interfaces.IPloneSiteRoot"

--- a/opengever/api/tests/test_transfer_dossier.py
+++ b/opengever/api/tests/test_transfer_dossier.py
@@ -1,0 +1,95 @@
+from ftw.testbrowser import browsing
+from opengever.activity.model import Notification
+from opengever.dossier.behaviors.dossier import IDossier
+from opengever.testing import IntegrationTestCase
+import json
+
+
+class TestTransferDossierPost(IntegrationTestCase):
+
+    @browsing
+    def test_dossier_transfer_does_not_trigger_notifications(self, browser):
+        self.login(self.administrator, browser=browser)
+        notifications_before = Notification.query.all()
+
+        browser.open(self.dossier.absolute_url() + '/@transfer-dossier', method='POST',
+                     headers=self.api_headers, data=json.dumps(
+                         {"old_userid": IDossier(self.dossier).responsible,
+                          "new_userid": self.meeting_user.getId()})
+                     )
+
+        notifications_after = Notification.query.all()
+        self.assertEqual(notifications_before, notifications_after)
+
+    @browsing
+    def test_transfer_dossier_without_new_userid_raises_bad_request(self, browser):
+        self.login(self.administrator, browser=browser)
+        with browser.expect_http_error(400):
+            browser.open(self.dossier.absolute_url() + '/@transfer-dossier', method='POST',
+                         headers=self.api_headers,
+                         data=json.dumps({"old_userid": "kathi.barfuss"}))
+        self.assertEqual(
+            {"message": "Property 'new_userid' is required",
+             "type": "BadRequest"},
+            browser.json)
+
+    @browsing
+    def test_transfer_dossier_without_old_userid_raises_bad_request(self, browser):
+        self.login(self.administrator, browser=browser)
+        with browser.expect_http_error(400):
+            browser.open(self.dossier.absolute_url() + '/@transfer-dossier', method='POST',
+                         headers=self.api_headers,
+                         data=json.dumps({"new_userid": "kathi.barfuss"}))
+        self.assertEqual(
+            {"message": "Property 'old_userid' is required",
+             "type": "BadRequest"},
+            browser.json)
+
+    @browsing
+    def test_transfer_dossier_with_invalid_new_userid_raises_bad_request(self, browser):
+        self.login(self.administrator, browser=browser)
+        with browser.expect_http_error(400):
+            browser.open(self.dossier.absolute_url() + '/@transfer-dossier', method='POST',
+                         headers=self.api_headers, data=json.dumps(
+                             {"old_userid": self.regular_user.getId(), "new_userid": "chaosqueen"}))
+        self.assertEqual(
+            {"message": "userid 'chaosqueen' does not exist",
+             "type": "BadRequest"},
+            browser.json)
+
+    @browsing
+    def test_transfer_dossier_with_invalid_old_userid_raises_bad_request(self, browser):
+        self.login(self.administrator, browser=browser)
+        with browser.expect_http_error(400):
+            browser.open(self.dossier.absolute_url() + '/@transfer-dossier', method='POST',
+                         headers=self.api_headers, data=json.dumps(
+                             {"new_userid": "kathi.barfuss", "old_userid": "chaosqueen"})
+                         )
+        self.assertEqual(
+            {"message": "userid 'chaosqueen' does not exist",
+             "type": "BadRequest"},
+            browser.json)
+
+    @browsing
+    def test_transfer_dossier_raises_unauthorized(self, browser):
+        self.login(self.regular_user, browser)
+        with browser.expect_unauthorized():
+            browser.open(self.dossier.absolute_url() + '/@transfer-dossier', method='POST',
+                         headers=self.api_headers, data=json.dumps(
+                         {"old_userid": self.dossier.responsible,
+                          "new_userid": self.meeting_user.getId()}))
+
+        self.assertEqual(401, browser.status_code)
+
+    @browsing
+    def test_transfer_dossier_with_identical_userids_raises_bad_request(self, browser):
+        self.login(self.administrator, browser=browser)
+        with browser.expect_http_error(400):
+            browser.open(self.dossier.absolute_url() + '/@transfer-dossier', method='POST',
+                         headers=self.api_headers, data=json.dumps(
+                             {"new_userid": "kathi.barfuss", "old_userid": "kathi.barfuss"})
+                         )
+        self.assertEqual(
+            {"message": "'old_userid' and 'new_userid' should not be the same",
+             "type": "BadRequest"},
+            browser.json)

--- a/opengever/api/transfer.py
+++ b/opengever/api/transfer.py
@@ -92,3 +92,17 @@ class TransferTaskPost(ExtractOldNewUserMixin, Service):
 
         self.request.response.setStatus(204)
         return super(TransferTaskPost, self).reply()
+
+
+class TransferDossierPost(ExtractOldNewUserMixin, Service):
+
+    def reply(self):
+        self.old_userid, self.new_userid = self.extract_userids()
+
+        # Disable CSRF protection
+        alsoProvides(self.request, IDisableCSRFProtection)
+
+        self.request.environ['HTTP_X_GEVER_SUPPRESSNOTIFICATIONS'] = 'True'
+
+        self.request.response.setStatus(204)
+        return super(TransferDossierPost, self).reply()


### PR DESCRIPTION
This PR implements the `@transfer-dossier` endpoint.

This endpoint provides the functionality to transfer the responsible of a user to another user. With the option: `include_subdossiers`, all subdossiers of the specified user will also be transfered.

Jira: https://4teamwork.atlassian.net/browse/PHX-14

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


## Checklist (if applicable)

_Only applicable should be left and checked._

- API change:
  - [x] Documentation is updated
  - If breaking:
    - [ ] api-change label added
    - [ ] Scrum master is informed
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Upgrade steps (changes in profile):
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
- DB-Schema migration
  - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
  - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value
