### PR TITLE
Provide create_forwarding action in API for documents in inboxes.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 ---------------------
 
 - Adjust the policy generator for easier policy generation. [elioschmutz]
+- Provide create_forwarding action in API for documents in inboxes. [deiferni]
 
 
 2020.8.0 (2020-08-26)

--- a/opengever/api/tests/test_actions.py
+++ b/opengever/api/tests/test_actions.py
@@ -721,6 +721,20 @@ class TestObjectButtonsGetForDocuments(ObjectButtonsTestBase):
             self.get_object_buttons(browser, self.document),
         )
 
+    @browsing
+    def test_document_in_inbox_has_create_forwarding_button(self, browser):
+        self.login(self.secretariat_user, browser)
+        expected_object_buttons = [
+            {u'icon': u'', u'id': u'checkout_document', u'title': u'Checkout'},
+            {u'icon': u'', u'id': u'create_forwarding', u'title': u'Forward'},
+            {u'icon': u'', u'id': u'copy_item', u'title': u'Copy Item'},
+            {u'icon': u'', u'id': u'properties', u'title': u'Properties'},
+        ]
+        self.assertListEqual(
+            expected_object_buttons,
+            self.get_object_buttons(browser, self.inbox_document),
+        )
+
 
 class TestObjectButtonsGetForTemplates(ObjectButtonsTestBase):
 

--- a/opengever/base/menu.py
+++ b/opengever/base/menu.py
@@ -110,6 +110,15 @@ class PloneSitePostFactoryMenu(FilteredPostFactoryMenu):
 
 class OGCombinedActionsWorkflowMenu(CombinedActionsWorkflowMenu):
 
+    def getActionsMenuItems(self, context, request):
+        results = super(OGCombinedActionsWorkflowMenu, self).getActionsMenuItems(
+            context, request)
+        return filter(
+            lambda item: (item.get('extra', {}).get('id', None)
+                != 'create_forwarding'),
+            results
+        )
+
     def getWorkflowMenuItems(self, context, request):
         """ftw.contentmenu >= 2.2.2 does no longer protect the workflows
         "Advanced..." action with "Manage portal".

--- a/opengever/core/profiles/default/types/opengever.document.document.xml
+++ b/opengever/core/profiles/default/types/opengever.document.document.xml
@@ -160,4 +160,14 @@
     <permission value="View" />
   </action>
 
+  <action
+      action_id="create_forwarding"
+      visible="True"
+      title="Forward"
+      url_expr="string:++add++opengever.inbox.forwarding:method"
+      condition_expr=""
+      category="object_buttons">
+    <permission value="opengever.inbox: Add Forwarding" />
+  </action>
+
 </object>

--- a/opengever/core/upgrades/20200827131106_provide_action_to_create_forwarding_on_document/types/opengever.document.document.xml
+++ b/opengever/core/upgrades/20200827131106_provide_action_to_create_forwarding_on_document/types/opengever.document.document.xml
@@ -1,0 +1,13 @@
+<object xmlns:i18n="http://xml.zope.org/namespaces/i18n" name="opengever.document.document" meta_type="Dexterity FTI" i18n:domain="opengever.core">
+
+  <action
+      action_id="create_forwarding"
+      visible="True"
+      title="Forward"
+      url_expr="string:++add++opengever.inbox.forwarding:method"
+      condition_expr=""
+      category="object_buttons">
+    <permission value="opengever.inbox: Add Forwarding" />
+  </action>
+
+</object>

--- a/opengever/core/upgrades/20200827131106_provide_action_to_create_forwarding_on_document/upgrade.py
+++ b/opengever/core/upgrades/20200827131106_provide_action_to_create_forwarding_on_document/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class ProvideActionToCreateForwardingOnDocument(UpgradeStep):
+    """Provide action to create forwarding on document.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()


### PR DESCRIPTION
With this PR we provide an action `create_forwarding` for documents in inboxes. This helps the UI to create forwardings not only from listing but from the overview of a single document.

- The action will only appear in inboxes as only they manage the `opengever.inbox: Add Forwarding` permission.
- The action is only exposed via rest-API but not in the classic ui as that would require a custom JS-Integration and is out of scope for this issue.

Jira: https://4teamwork.atlassian.net/browse/PHX-10

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
