### PR TITLE
Pass query string to location url on maindossier and parentdossier redirect

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 ---------------------
 
 - Prevent deadlock when reassigning inter-admin-unit tasks. [lgraf]
+- Preserves the query string for the redirect_to_main_dossier view. [elioschmutz]
 - Adjust the policy generator for easier policy generation. [elioschmutz]
 - Provide create_forwarding action in API for documents in inboxes. [deiferni]
 - Allow to query by token in @querysources API endpoint. [deiferni]

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 ---------------------
 
 - Prevent deadlock when reassigning inter-admin-unit tasks. [lgraf]
+- Preserves the query string for the redirect_to_parent_dossier view. [elioschmutz]
 - Preserves the query string for the redirect_to_main_dossier view. [elioschmutz]
 - Adjust the policy generator for easier policy generation. [elioschmutz]
 - Provide create_forwarding action in API for documents in inboxes. [deiferni]

--- a/opengever/document/browser/redirect_to_parent_dossier.py
+++ b/opengever/document/browser/redirect_to_parent_dossier.py
@@ -3,10 +3,18 @@ from Products.Five import BrowserView
 
 class RedirectToParentDossier(BrowserView):
     """Redirects to the containing subdossier of a document.
+
+    Caution: this view will be used by GEVER-UI/RIS/VM
     """
     def __call__(self):
         dossier = self.context.get_parent_dossier()
         assert dossier, ('the redirect view should only be called when a '
                          'parent dossier is available')
 
-        return self.request.RESPONSE.redirect(dossier.absolute_url())
+        url_parts = [dossier.absolute_url()]
+        qs = self.request['QUERY_STRING']
+        if qs:
+            url_parts.append(qs)
+        redirect_url = '?'.join(url_parts)
+
+        return self.request.RESPONSE.redirect(redirect_url)

--- a/opengever/dossier/browser/redirect_to_maindossier.py
+++ b/opengever/dossier/browser/redirect_to_maindossier.py
@@ -5,7 +5,10 @@ from Products.Five.browser import BrowserView
 
 
 class RedirectToMainDossier(BrowserView):
+    """Redirects to the main dossier of any content.
 
+    Caution: this view will be used by GEVER-UI/RIS/VM
+    """
     def __call__(self):
         main_dossier = get_main_dossier(self.context)
         if not main_dossier:
@@ -15,4 +18,9 @@ class RedirectToMainDossier(BrowserView):
             api.portal.show_message(msg, request=self.request, type='error')
             return self.request.RESPONSE.redirect(self.context.absolute_url())
 
-        return self.request.RESPONSE.redirect(main_dossier.absolute_url())
+        url_parts = [main_dossier.absolute_url()]
+        qs = self.request['QUERY_STRING']
+        if qs:
+            url_parts.append(qs)
+        redirect_url = '?'.join(url_parts)
+        return self.request.RESPONSE.redirect(redirect_url)

--- a/opengever/dossier/tests/test_redirect_to_maindossier.py
+++ b/opengever/dossier/tests/test_redirect_to_maindossier.py
@@ -32,3 +32,10 @@ class TestRedirectToMainDossier(IntegrationTestCase):
         self.login(self.regular_user, browser)
         browser.login().open(self.subsubdocument, view='redirect_to_main_dossier')
         self.assertEquals(self.dossier, browser.context)
+
+    @browsing
+    def test_redirect_preserves_the_query_string(self, browser):
+        self.login(self.regular_user, browser)
+        browser.login().open(self.subdossier, view='redirect_to_main_dossier?foo=bar')
+
+        self.assertEqual('foo=bar', browser.url.split('?')[1])

--- a/opengever/dossier/tests/test_redirect_to_maindossier.py
+++ b/opengever/dossier/tests/test_redirect_to_maindossier.py
@@ -1,49 +1,34 @@
-from ftw.builder import Builder
-from ftw.builder import create
 from ftw.testbrowser import browsing
 from ftw.testbrowser.pages.statusmessages import error_messages
-from opengever.testing import FunctionalTestCase
+from opengever.testing import IntegrationTestCase
 
 
-class TestRedirectToMainDossier(FunctionalTestCase):
-
-    def setUp(self):
-        super(TestRedirectToMainDossier, self).setUp()
-        self.repo_root = create(Builder('repository_root'))
-        self.repo = create(Builder('repository_root')
-                           .titled(u'F\xfchrung')
-                           .within(self.repo_root))
-        self.dossier = create(Builder('dossier').within(self.repo))
+class TestRedirectToMainDossier(IntegrationTestCase):
 
     @browsing
     def test_redirects_to_main_dossier(self, browser):
-        subdossier = create(Builder('dossier').within(self.dossier))
-        task = create(Builder('task').within(self.dossier))
-        document = create(Builder('document').within(self.dossier))
-
-        browser.login().open(subdossier, view='redirect_to_main_dossier')
+        self.login(self.regular_user, browser)
+        browser.open(self.subdossier, view='redirect_to_main_dossier')
         self.assertEquals(self.dossier, browser.context)
 
-        browser.open(task, view='redirect_to_main_dossier')
+        browser.open(self.task, view='redirect_to_main_dossier')
         self.assertEquals(self.dossier, browser.context)
 
-        browser.open(document, view='redirect_to_main_dossier')
+        browser.open(self.document, view='redirect_to_main_dossier')
         self.assertEquals(self.dossier, browser.context)
 
     @browsing
     def test_redirects_to_context_and_show_message_when_no_main_dossier_exists(self, browser):
-        browser.login().open(self.repo, view='redirect_to_main_dossier')
+        self.login(self.regular_user, browser)
+        browser.open(self.leaf_repofolder, view='redirect_to_main_dossier')
 
-        self.assertEquals(self.repo, browser.context)
+        self.assertEquals(self.leaf_repofolder, browser.context)
         self.assertEquals(
-            [u'The object `F\xfchrung` is not stored inside a dossier.'],
+            [u'The object `1.1. Vertr\xe4ge und Vereinbarungen` is not stored inside a dossier.'],
             error_messages())
 
     @browsing
     def test_handles_content_inside_a_subdossier_correctly(self, browser):
-        subdossier = create(Builder('dossier').within(self.dossier))
-        subsubdossier = create(Builder('dossier').within(subdossier))
-        document = create(Builder('document').within(subsubdossier))
-
-        browser.login().open(document, view='redirect_to_main_dossier')
+        self.login(self.regular_user, browser)
+        browser.login().open(self.subsubdocument, view='redirect_to_main_dossier')
         self.assertEquals(self.dossier, browser.context)

--- a/opengever/task/browser/redirector.py
+++ b/opengever/task/browser/redirector.py
@@ -35,5 +35,10 @@ class RedirectToContainingDossier(BrowserView):
     """Redirects the user to the containing dossier.
     """
     def __call__(self):
-        self.request.RESPONSE.redirect(
-            self.context.get_containing_dossier().absolute_url())
+        url_parts = [self.context.get_containing_dossier().absolute_url()]
+        qs = self.request['QUERY_STRING']
+        if qs:
+            url_parts.append(qs)
+        redirect_url = '?'.join(url_parts)
+
+        return self.request.RESPONSE.redirect(redirect_url)

--- a/opengever/task/browser/redirector.py
+++ b/opengever/task/browser/redirector.py
@@ -24,7 +24,11 @@ class RedirectToContainingMainDossier(BrowserView):
     """
     def __call__(self):
         self.request.RESPONSE.redirect(
-            get_main_dossier(self.context).absolute_url())
+            "?".join([
+                get_main_dossier(self.context).absolute_url(),
+                self.request["QUERY_STRING"]
+            ])
+        )
 
 
 class RedirectToContainingDossier(BrowserView):

--- a/opengever/task/tests/test_redirector.py
+++ b/opengever/task/tests/test_redirector.py
@@ -3,6 +3,8 @@ from ftw.builder import create
 from ftw.testbrowser import browsing
 from ftw.testbrowser.pages import factoriesmenu
 from opengever.testing import FunctionalTestCase
+from opengever.testing import IntegrationTestCase
+from plone import api
 from plone.app.testing import TEST_USER_ID
 
 
@@ -51,27 +53,26 @@ class TestTaskRedirector(FunctionalTestCase):
                           browser.url)
 
 
-class TestRedirectToContainingMainDossier(FunctionalTestCase):
+class TestRedirectToContainingMainDossier(IntegrationTestCase):
 
     @browsing
     def test_redirect_to_the_containing_main_dossier(self, browser):
-        dossier = create(Builder('dossier'))
-        subdossier = create(Builder('dossier').within(dossier))
-        task = create(Builder('task').within(subdossier))
+        self.login(self.dossier_responsible, browser)
+        task = api.content.move(self.task, self.subdossier)
 
-        browser.login().open(task, view='redirect_to_main_dossier')
+        browser.open(task, view='redirect_to_main_dossier')
 
-        self.assertEqual(dossier, browser.context)
+        self.assertEqual(self.dossier, browser.context)
 
 
-class TestRedirectToContainingDossier(FunctionalTestCase):
+class TestRedirectToContainingDossier(IntegrationTestCase):
 
     @browsing
     def test_redirect_to_the_containing_dossier(self, browser):
-        dossier = create(Builder('dossier'))
-        subdossier = create(Builder('dossier').within(dossier))
-        task = create(Builder('task').within(subdossier))
+        self.login(self.dossier_responsible, browser)
+        task = api.content.move(self.task, self.subdossier)
 
-        browser.login().open(task, view='redirect_to_parent_dossier')
+        browser.open(task, view='redirect_to_parent_dossier')
 
-        self.assertEqual(subdossier, browser.context)
+        self.assertEqual(self.subdossier, browser.context)
+

--- a/opengever/task/tests/test_redirector.py
+++ b/opengever/task/tests/test_redirector.py
@@ -83,3 +83,9 @@ class TestRedirectToContainingDossier(IntegrationTestCase):
 
         self.assertEqual(self.subdossier, browser.context)
 
+    @browsing
+    def test_redirect_preserves_the_query_string(self, browser):
+        self.login(self.regular_user, browser)
+        browser.open(self.subdocument, view='redirect_to_parent_dossier?foo=bar')
+
+        self.assertEqual('foo=bar', browser.url.split('?')[1])

--- a/opengever/task/tests/test_redirector.py
+++ b/opengever/task/tests/test_redirector.py
@@ -64,6 +64,13 @@ class TestRedirectToContainingMainDossier(IntegrationTestCase):
 
         self.assertEqual(self.dossier, browser.context)
 
+    @browsing
+    def test_redirect_preserves_the_query_string(self, browser):
+        self.login(self.regular_user, browser)
+        browser.open(self.task, view='redirect_to_main_dossier?foo=bar')
+
+        self.assertEqual('foo=bar', browser.url.split('?')[1])
+
 
 class TestRedirectToContainingDossier(IntegrationTestCase):
 


### PR DESCRIPTION
This PR preserves the query string for the `redirect_to_parent_dossier` and `redirect_to_main_dossier` view.

The GEVER-UI needs to redirect to parent contents. The business-logic should come from the backend. Because we need this paths in listings, we would have to index all the possible paths in the solr catalog and return it when needed. We can't do/don't want to do this.

Instead, we can just use the redirect views on a context to get the new parent context. Because the GEVER-UI adds a lot of query parameters to get all required information form the backend, we have to preserve the query string on redirection.

<img width="1190" alt="Bildschirmfoto 2020-08-31 um 10 37 14" src="https://user-images.githubusercontent.com/557005/91700287-f574e080-eb75-11ea-8210-96c552e345b2.png">

Jira: https://4teamwork.atlassian.net/browse/PHX-1

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


## Checklist (if applicable)

_Only applicable should be left and checked._

- API change:
  - [ ] Documentation is updated
  - If breaking:
    - [ ] api-change label added
    - [ ] Scrum master is informed
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Upgrade steps (changes in profile):
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
- DB-Schema migration
  - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
  - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value
