### PR TITLE
Add missing translations for dossier export.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -24,6 +24,7 @@ Changelog
 - Order groups and teams in User serializer by title. [elioschmutz]
 - Do not allow @tus-replace if document is not checked out by current user. [buchi]
 - Fix workspace workflows: Allow to create new document versions and to trash documents again. [buchi]
+- Add missing translations for dossier export. [2e12]
 
 
 2020.9.0 (2020-09-10)

--- a/opengever/latex/dossiercover.py
+++ b/opengever/latex/dossiercover.py
@@ -6,10 +6,12 @@ from ftw.pdfgenerator.utils import provide_request_layer
 from ftw.pdfgenerator.view import MakoLaTeXView
 from opengever.base.interfaces import IReferenceNumber
 from opengever.dossier.behaviors.dossier import IDossier
+from opengever.latex import _
 from opengever.ogds.base.utils import get_current_admin_unit
 from opengever.repository.repositoryroot import IRepositoryRoot
 from zope.component import adapter
 from zope.component import getAdapter
+from zope.i18n import translate
 from zope.interface import Interface
 
 
@@ -33,24 +35,37 @@ class DossierCoverLaTeXView(MakoLaTeXView):
 
     template_directories = ['templates']
     template_name = 'dossiercover.tex'
+    translatable_labels = {
+        'label_responsible': _('label_responsible', default='Responsible'),
+        'label_repository_version': _('repository_version', default='Repository version'),
+        'label_reference_number': _('label_reference_number', default='Reference number'),
+        'label_description': _('label_description', default='Description'),
+        'label_start': _('label_start', default='Start'),
+        'label_end': _('label_end', default='End'),
+    }
 
     def get_render_arguments(self):
-        args = {
+        args = self.get_dossier_metadata()
+        args.update(self.get_translated_labels())
+        return args
+
+    def get_dossier_metadata(self):
+        return {
             'clienttitle': self.convert_plain(self.get_current_admin_unit_label()),
-            'repositoryversion': self.convert_plain(
-                self.get_repository_version()),
+            'repositoryversion': self.convert_plain(self.get_repository_version()),
             'referencenr': self.convert_plain(self.get_referencenumber()),
             'title': self.convert_plain(self.context.Title()),
             'description': self.convert(self.get_description()),
             'responsible': self.convert_plain(self.get_responsible()),
+            'start': self.convert_plain(self.context.toLocalizedTime(str(IDossier(self.context).start)) or '-'),
+            'end': self.convert_plain(self.context.toLocalizedTime(str(IDossier(self.context).end)) or '-'),
+        }
 
-            'start': self.convert_plain(self.context.toLocalizedTime(
-                    str(IDossier(self.context).start)) or '-'),
-            'end': self.convert_plain(self.context.toLocalizedTime(
-                    str(IDossier(self.context).end)) or '-'),
-            }
-
-        return args
+    def get_translated_labels(self):
+        labels = {}
+        for key, label in self.translatable_labels.items():
+            labels[key] = translate(label, context=self.request)
+        return labels
 
     def get_description(self):
         return self.context.Description().replace('\n', '<br />')

--- a/opengever/latex/dossierdetails.py
+++ b/opengever/latex/dossierdetails.py
@@ -69,6 +69,13 @@ class DossierDetailsLaTeXView(MakoLaTeXView):
                                   ILaTexListing, name='subdossiers')
         args['subdossiers'] = listing.get_listing(self.get_subdossiers())
 
+        # Dossier details title
+        args['label_detailssubdossier'] = translate(
+        _('label_detailssubdossier', default="Details Subdossier"), context=self.request)
+
+        args['label_detailsdossier'] = translate(
+        _('label_detailsdossier', default="Details Dossier"), context=self.request)
+
         # documents
         args['documentstitle'] = translate(
             _('label_documents', default="Documents"), context=self.request)

--- a/opengever/latex/layouts/default.py
+++ b/opengever/latex/layouts/default.py
@@ -1,11 +1,13 @@
 from ftw.pdfgenerator.interfaces import IBuilder
 from ftw.pdfgenerator.layout.customizable import CustomizableLayout
 from opengever.latex.interfaces import ILaTeXSettings
+from opengever.latex import _
 from opengever.ogds.base.utils import get_current_admin_unit
 from plone.registry.interfaces import IRegistry
 from Products.CMFCore.utils import getToolByName
 from zope.component import adapter
 from zope.component import getUtility
+from zope.i18n import translate
 from zope.interface import Interface
 
 
@@ -67,7 +69,9 @@ class DefaultLayout(CustomizableLayout):
             'show_contact': self.show_contact,
             'show_logo': self.show_logo,
             'show_organisation': self.show_organisation,
-            'location': convert(self.get_location())}
+            'location': convert(self.get_location()),
+            'page_label': translate(_('label_page', default='Page'), context=self.request),
+        }
 
     def get_current_admin_unit_label(self):
         return get_current_admin_unit().label()

--- a/opengever/latex/layouts/resources/default_layout.tex
+++ b/opengever/latex/layouts/resources/default_layout.tex
@@ -57,7 +57,7 @@
 \renewcommand{\headrulewidth}{0pt}
 \renewcommand{\footrulewidth}{0pt}
 \fancyhf{}
-\fancyhead[L]{\fontsize{8}{9}\selectfont Seite \thepage/\pageref{LastPage}}
+\fancyhead[L]{\fontsize{8}{9}\selectfont ${page_label} \thepage/\pageref{LastPage}}
 
 %%%% use pagestyle ``myheadings'' for first page
 \fancypagestyle{myheadings}{

--- a/opengever/latex/locales/de/LC_MESSAGES/opengever.latex.po
+++ b/opengever/latex/locales/de/LC_MESSAGES/opengever.latex.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-11-27 12:37+0000\n"
+"POT-Creation-Date: 2020-09-07 05:24+0000\n"
 "PO-Revision-Date: 2013-11-19 16:25+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -30,6 +30,7 @@ msgid "label_delivery_date"
 msgstr "Ausgangsdatum"
 
 #. Default: "Description"
+#: ./opengever/latex/dossiercover.py
 #: ./opengever/latex/listing.py
 msgid "label_description"
 msgstr "Beschreibung"
@@ -60,6 +61,7 @@ msgid "label_dossier_tasks"
 msgstr "Aufgabenliste zu Dossier \"${title} (${reference_number})\""
 
 #. Default: "End"
+#: ./opengever/latex/dossiercover.py
 #: ./opengever/latex/dossierdetails.py
 #: ./opengever/latex/listing.py
 msgid "label_end"
@@ -81,6 +83,7 @@ msgid "label_receipt_date"
 msgstr "Eingangsdatum"
 
 #. Default: "Reference number"
+#: ./opengever/latex/dossiercover.py
 #: ./opengever/latex/dossierdetails.py
 #: ./opengever/latex/listing.py
 msgid "label_reference_number"
@@ -97,6 +100,7 @@ msgid "label_repository_title"
 msgstr "Ordnungsposition"
 
 #. Default: "Responsible"
+#: ./opengever/latex/dossiercover.py
 #: ./opengever/latex/dossierdetails.py
 #: ./opengever/latex/listing.py
 msgid "label_responsible"
@@ -114,6 +118,7 @@ msgid "label_sequence_number"
 msgstr "Laufnummer"
 
 #. Default: "Start"
+#: ./opengever/latex/dossiercover.py
 #: ./opengever/latex/dossierdetails.py
 #: ./opengever/latex/listing.py
 msgid "label_start"
@@ -159,6 +164,11 @@ msgstr "Titel"
 #: ./opengever/latex/listing.py
 msgid "label_transition"
 msgstr "Aktion"
+
+#. Default: "Repository version"
+#: ./opengever/latex/dossiercover.py
+msgid "repository_version"
+msgstr "Version Ordnungssystem"
 
 #. Default: "No."
 #: ./opengever/latex/listing.py

--- a/opengever/latex/locales/de/LC_MESSAGES/opengever.latex.po
+++ b/opengever/latex/locales/de/LC_MESSAGES/opengever.latex.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2020-09-07 05:24+0000\n"
+"POT-Creation-Date: 2020-09-18 11:16+0000\n"
 "PO-Revision-Date: 2013-11-19 16:25+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -34,6 +34,16 @@ msgstr "Ausgangsdatum"
 #: ./opengever/latex/listing.py
 msgid "label_description"
 msgstr "Beschreibung"
+
+#. Default: "Details Dossier"
+#: ./opengever/latex/dossierdetails.py
+msgid "label_detailsdossier"
+msgstr "Details Dossier"
+
+#. Default: "Details Subdossier"
+#: ./opengever/latex/dossierdetails.py
+msgid "label_detailssubdossier"
+msgstr "Details Subdossier"
 
 #. Default: "Document author"
 #: ./opengever/latex/listing.py
@@ -71,6 +81,11 @@ msgstr "Ende"
 #: ./opengever/latex/listing.py
 msgid "label_issuer"
 msgstr "Auftraggeber"
+
+#. Default: "Page"
+#: ./opengever/latex/layouts/default.py
+msgid "label_page"
+msgstr "Seite"
 
 #. Default: "Participants"
 #: ./opengever/latex/dossierdetails.py

--- a/opengever/latex/locales/fr/LC_MESSAGES/opengever.latex.po
+++ b/opengever/latex/locales/fr/LC_MESSAGES/opengever.latex.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-11-27 12:37+0000\n"
+"POT-Creation-Date: 2020-09-07 05:24+0000\n"
 "PO-Revision-Date: 2017-12-03 09:48+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-latex/fr/>\n"
@@ -32,6 +32,7 @@ msgid "label_delivery_date"
 msgstr "Date de remise"
 
 #. Default: "Description"
+#: ./opengever/latex/dossiercover.py
 #: ./opengever/latex/listing.py
 msgid "label_description"
 msgstr "Description"
@@ -62,6 +63,7 @@ msgid "label_dossier_tasks"
 msgstr "Liste des tâches du dossier \"${title} (${reference_number})\""
 
 #. Default: "End"
+#: ./opengever/latex/dossiercover.py
 #: ./opengever/latex/dossierdetails.py
 #: ./opengever/latex/listing.py
 msgid "label_end"
@@ -83,6 +85,7 @@ msgid "label_receipt_date"
 msgstr "Date d'entrée"
 
 #. Default: "Reference number"
+#: ./opengever/latex/dossiercover.py
 #: ./opengever/latex/dossierdetails.py
 #: ./opengever/latex/listing.py
 msgid "label_reference_number"
@@ -99,6 +102,7 @@ msgid "label_repository_title"
 msgstr "Numéro de classement"
 
 #. Default: "Responsible"
+#: ./opengever/latex/dossiercover.py
 #: ./opengever/latex/dossierdetails.py
 #: ./opengever/latex/listing.py
 msgid "label_responsible"
@@ -116,6 +120,7 @@ msgid "label_sequence_number"
 msgstr "Numéro courant"
 
 #. Default: "Start"
+#: ./opengever/latex/dossiercover.py
 #: ./opengever/latex/dossierdetails.py
 #: ./opengever/latex/listing.py
 msgid "label_start"
@@ -161,6 +166,11 @@ msgstr "Titre"
 #: ./opengever/latex/listing.py
 msgid "label_transition"
 msgstr "Action"
+
+#. Default: "Repository version"
+#: ./opengever/latex/dossiercover.py
+msgid "repository_version"
+msgstr "Version du système de classement"
 
 #. Default: "No."
 #: ./opengever/latex/listing.py

--- a/opengever/latex/locales/fr/LC_MESSAGES/opengever.latex.po
+++ b/opengever/latex/locales/fr/LC_MESSAGES/opengever.latex.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2020-09-07 05:24+0000\n"
+"POT-Creation-Date: 2020-09-18 11:16+0000\n"
 "PO-Revision-Date: 2017-12-03 09:48+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-latex/fr/>\n"
@@ -36,6 +36,16 @@ msgstr "Date de remise"
 #: ./opengever/latex/listing.py
 msgid "label_description"
 msgstr "Description"
+
+#. Default: "Details Dossier"
+#: ./opengever/latex/dossierdetails.py
+msgid "label_detailsdossier"
+msgstr "Détails Dossier"
+
+#. Default: "Details Subdossier"
+#: ./opengever/latex/dossierdetails.py
+msgid "label_detailssubdossier"
+msgstr "Détails Sous-Dossier"
 
 #. Default: "Document author"
 #: ./opengever/latex/listing.py
@@ -73,6 +83,11 @@ msgstr "Fin"
 #: ./opengever/latex/listing.py
 msgid "label_issuer"
 msgstr "Mandant"
+
+#. Default: "Page"
+#: ./opengever/latex/layouts/default.py
+msgid "label_page"
+msgstr "Page"
 
 #. Default: "Participants"
 #: ./opengever/latex/dossierdetails.py

--- a/opengever/latex/locales/opengever.latex.pot
+++ b/opengever/latex/locales/opengever.latex.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2020-09-07 05:24+0000\n"
+"POT-Creation-Date: 2020-09-18 11:16+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -36,6 +36,16 @@ msgstr ""
 #: ./opengever/latex/dossiercover.py
 #: ./opengever/latex/listing.py
 msgid "label_description"
+msgstr ""
+
+#. Default: "Details Dossier"
+#: ./opengever/latex/dossierdetails.py
+msgid "label_detailsdossier"
+msgstr ""
+
+#. Default: "Details Subdossier"
+#: ./opengever/latex/dossierdetails.py
+msgid "label_detailssubdossier"
 msgstr ""
 
 #. Default: "Document author"
@@ -73,6 +83,11 @@ msgstr ""
 #. Default: "Issuer"
 #: ./opengever/latex/listing.py
 msgid "label_issuer"
+msgstr ""
+
+#. Default: "Page"
+#: ./opengever/latex/layouts/default.py
+msgid "label_page"
 msgstr ""
 
 #. Default: "Participants"

--- a/opengever/latex/locales/opengever.latex.pot
+++ b/opengever/latex/locales/opengever.latex.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-11-27 12:37+0000\n"
+"POT-Creation-Date: 2020-09-07 05:24+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -33,6 +33,7 @@ msgid "label_delivery_date"
 msgstr ""
 
 #. Default: "Description"
+#: ./opengever/latex/dossiercover.py
 #: ./opengever/latex/listing.py
 msgid "label_description"
 msgstr ""
@@ -63,6 +64,7 @@ msgid "label_dossier_tasks"
 msgstr ""
 
 #. Default: "End"
+#: ./opengever/latex/dossiercover.py
 #: ./opengever/latex/dossierdetails.py
 #: ./opengever/latex/listing.py
 msgid "label_end"
@@ -84,6 +86,7 @@ msgid "label_receipt_date"
 msgstr ""
 
 #. Default: "Reference number"
+#: ./opengever/latex/dossiercover.py
 #: ./opengever/latex/dossierdetails.py
 #: ./opengever/latex/listing.py
 msgid "label_reference_number"
@@ -100,6 +103,7 @@ msgid "label_repository_title"
 msgstr ""
 
 #. Default: "Responsible"
+#: ./opengever/latex/dossiercover.py
 #: ./opengever/latex/dossierdetails.py
 #: ./opengever/latex/listing.py
 msgid "label_responsible"
@@ -117,6 +121,7 @@ msgid "label_sequence_number"
 msgstr ""
 
 #. Default: "Start"
+#: ./opengever/latex/dossiercover.py
 #: ./opengever/latex/dossierdetails.py
 #: ./opengever/latex/listing.py
 msgid "label_start"
@@ -161,6 +166,11 @@ msgstr ""
 #. Default: "Transition"
 #: ./opengever/latex/listing.py
 msgid "label_transition"
+msgstr ""
+
+#. Default: "Repository version"
+#: ./opengever/latex/dossiercover.py
+msgid "repository_version"
 msgstr ""
 
 #. Default: "No."

--- a/opengever/latex/templates/dossiercover.tex
+++ b/opengever/latex/templates/dossiercover.tex
@@ -15,16 +15,16 @@ ${clienttitle}
 %% \end{tabularx}
 \vspace{0.5cm}
 \rule{\linewidth}{.11em}
-Version Ordnungssystem: ${repositoryversion}\newline
-\textbf{Aktenzeichen: ${referencenr}}\newline
+${label_repository_version}: ${repositoryversion}\newline
+\textbf{${label_reference_number}: ${referencenr}}\newline
 \newline
 \normalsize \textbf{${title}} \newline
 
-\scriptsize Beschreibung: ${description} \newline
+\scriptsize ${label_description}: ${description} \newline
 \vspace{0.3cm} \newline
-Federführung: ${responsible}
+${label_responsible}: ${responsible}
 \vspace{0.15cm} \newline
-Beginn: ${start}\hspace{0.15cm}|\hspace{0.15cm}Abschluss: ${end}\hspace{0.15cm} \newline
+${label_start}: ${start}\hspace{0.15cm}|\hspace{0.15cm}${label_end}: ${end}\hspace{0.15cm} \newline
 </%block>
 
 <%block name="client_specific_part">

--- a/opengever/latex/templates/dossierdetails.tex
+++ b/opengever/latex/templates/dossierdetails.tex
@@ -1,9 +1,9 @@
 
 
 % if is_subdossier:
-  {\bf Details Subdossier}\\%%
+  {\bf ${label_detailssubdossier}}\\%%
 % else:
-  {\bf Details Dossier}\\%%
+  {\bf ${label_detailsdossier}}\\%%
 % endif
 \vspace{\baselineskip}
 \renewcommand{\small}{\fontsize{11}{11}\selectfont}

--- a/opengever/latex/tests/test_default_layout.py
+++ b/opengever/latex/tests/test_default_layout.py
@@ -108,7 +108,7 @@ class TestDefaultLayout(MockTestCase):
 
         self.assertEqual(layout.get_render_arguments(), args)
 
-    def test_get_remder_arguments_non_owner(self):
+    def test_get_render_arguments_non_owner(self):
         context = self.mocker.mock()
         request = self.create_dummy()
         builder = self.create_dummy()

--- a/opengever/latex/tests/test_default_layout.py
+++ b/opengever/latex/tests/test_default_layout.py
@@ -1,62 +1,22 @@
-from ftw.testing import MockTestCase
-from mocker import ANY
-from opengever.latex.interfaces import ILaTeXSettings
+from ftw.pdfgenerator.builder import Builder as PDFBuilder
 from opengever.latex.layouts.default import DefaultLayout
-from opengever.latex.testing import LATEX_ZCML_LAYER
-from opengever.ogds.base import utils
-from plone.registry.interfaces import IRegistry
+from opengever.testing import IntegrationTestCase
+from plone import api
 
 
-FAKE_LOCATION = 'fakelocation'
-FAKE_CLIENT_TITLE = 'fakeclienttitle'
-
-
-class TestDefaultLayout(MockTestCase):
-
-    layer = LATEX_ZCML_LAYER
-
-    def setUp(self):
-        super(TestDefaultLayout, self).setUp()
-
-        admin_unit = self.stub()
-
-        self._ori_get_current_admin_unit = utils.get_current_admin_unit
-        get_current_admin_unit = self.mocker.replace(
-            'opengever.ogds.base.utils.get_current_admin_unit')
-        self.expect(get_current_admin_unit()).result(admin_unit).count(0, None)
-        self.expect(admin_unit.label()).result(FAKE_CLIENT_TITLE).count(0, None)
-
-        registry_mock = self.stub()
-        self.expect(
-            registry_mock.forInterface(ILaTeXSettings).location).result(FAKE_LOCATION)
-        self.mock_utility(registry_mock, IRegistry)
-
-        self.portal_membership = self.stub()
-        self.mock_tool(self.portal_membership, 'portal_membership')
-
-    def tearDown(self):
-        super(TestDefaultLayout, self).tearDown()
-        utils.get_current_admin_unit = self._ori_get_current_admin_unit
+class TestDefaultLayout(IntegrationTestCase):
 
     def test_configuration(self):
-        context = self.create_dummy()
-        request = self.create_dummy()
-        builder = self.create_dummy()
-
-        self.replay()
-        layout = DefaultLayout(context, request, builder)
+        self.login(self.regular_user)
+        layout = DefaultLayout(self.dossier, self.request, PDFBuilder())
 
         self.assertEqual(layout.show_contact, False)
         self.assertEqual(layout.show_logo, False)
         self.assertEqual(layout.show_organisation, False)
 
     def test_before_render_hook(self):
-        context = self.create_dummy()
-        request = self.create_dummy()
-        builder = self.mocker.mock()
-
-        self.replay()
-        layout = DefaultLayout(context, request, builder)
+        self.login(self.regular_user)
+        layout = DefaultLayout(self.dossier, self.request, PDFBuilder())
 
         layout.before_render_hook()
 
@@ -83,69 +43,53 @@ class TestDefaultLayout(MockTestCase):
         self.assertEqual(layout.get_packages_latex(), packages)
 
     def test_get_render_arguments(self):
-        context = self.mocker.mock()
-        request = self.create_dummy()
-        builder = self.create_dummy()
+        self.login(self.regular_user)
 
-        member = self.mocker.mock()
-        self.expect(context.Creator()).result('john.doe')
-        self.expect(self.portal_membership.getMemberById('john.doe')).result(
-            member)
-        self.expect(member.getProperty('phone_number', '&nbsp;')).result(
-            '012 345 6789')
+        layout = DefaultLayout(self.dossier, self.request, PDFBuilder())
 
-        self.replay()
-        layout = DefaultLayout(context, request, builder)
+        self.assertEqual(self.dossier.Creator(), 'robert.ziegler')
+
+        portal_membership_tool = api.portal.get_tool('portal_membership')
+
+        member = portal_membership_tool.getMemberById('robert.ziegler')
+        member.phone_number = '012 345 6789'
 
         args = {
-            'client_title': FAKE_CLIENT_TITLE,
-            'member_phone': '012 345 6789',
             'show_contact': False,
-            'show_logo': False,
+            'page_label': 'Page',
+            'client_title': 'Hauptmandant',
+            'location': 'Bern',
             'show_organisation': False,
-            'location': FAKE_LOCATION,
+            'member_phone': '012 345 6789',
+            'show_logo': False
             }
 
-        self.assertEqual(layout.get_render_arguments(), args)
+        self.assertDictEqual(layout.get_render_arguments(), args)
 
     def test_get_render_arguments_non_owner(self):
-        context = self.mocker.mock()
-        request = self.create_dummy()
-        builder = self.create_dummy()
+        self.login(self.regular_user)
+        self.dossier.creators = ('NonExistentUser',)
 
-        self.expect(context.Creator()).result('john.doe')
-        self.expect(
-            self.portal_membership.getMemberById('john.doe')).result(None)
+        layout = DefaultLayout(self.dossier, self.request, PDFBuilder())
 
-        self.replay()
-        layout = DefaultLayout(context, request, builder)
+        self.assertNotEqual(self.dossier.Creator(), 'robert.ziegler')
 
         args = {
-            'client_title': FAKE_CLIENT_TITLE,
-            'member_phone': '',
             'show_contact': False,
-            'show_logo': False,
+            'page_label': 'Page',
+            'client_title': 'Hauptmandant',
+            'location': 'Bern',
             'show_organisation': False,
-            'location': FAKE_LOCATION,
+            'member_phone': '',
+            'show_logo': False
             }
 
         self.assertEqual(layout.get_render_arguments(), args)
 
     def test_rendering(self):
-        context = self.stub()
-        request = self.create_dummy()
-        builder = self.stub()
-        self.expect(builder.add_file('logo.pdf', data=ANY))
+        self.login(self.regular_user)
 
-        member = self.stub()
-        self.expect(context.Creator()).result('john.doe')
-        self.expect(self.portal_membership.getMemberById('john.doe')).result(
-            member)
-        self.expect(member.getProperty('phone_number', '&nbsp;')).result(
-            '012 345 6789')
-
-        self.replay()
-        layout = DefaultLayout(context, request, builder)
+        layout = DefaultLayout(self.dossier, self.request, PDFBuilder())
 
         latex = layout.render_latex('LATEX CONTENT')
         self.assertIn('LATEX CONTENT', latex)
@@ -153,24 +97,15 @@ class TestDefaultLayout(MockTestCase):
         self.assertIn(r'\phantom{foo}\vspace{-2\baselineskip}', latex)
 
     def test_box_sizes_and_positions(self):
-        context = self.stub()
-        request = self.create_dummy()
-        builder = self.stub()
-        self.expect(builder.add_file('logo.pdf', data=ANY))
+        self.login(self.regular_user)
 
-        member = self.stub()
-        self.expect(context.Creator()).result('john.doe')
-        self.expect(self.portal_membership.getMemberById('john.doe')).result(
-            member)
-        self.expect(member.getProperty('phone_number', '&nbsp;')).result(
-            '012 345 6789')
+        builder = PDFBuilder()
 
-        self.replay()
-        layout = DefaultLayout(context, request, builder)
-
+        layout = DefaultLayout(self.dossier, self.request, builder)
         layout.show_organisation = True
 
         latex = layout.render_latex('LATEX CONTENT')
+
         self.assertIn(r'\begin{textblock}{58mm\TPHorizModule} '
                       r'(136mm\TPHorizModule',
                       latex)

--- a/opengever/latex/tests/test_landscape_layout.py
+++ b/opengever/latex/tests/test_landscape_layout.py
@@ -1,97 +1,46 @@
-from ftw.testing import MockTestCase
-from mocker import ANY
+from ftw.pdfgenerator.builder import Builder as PDFBuilder
 from opengever.latex.interfaces import ILandscapeLayer
-from opengever.latex.interfaces import ILaTeXSettings
 from opengever.latex.layouts.landscape import LandscapeLayout
-from opengever.latex.testing import LATEX_ZCML_LAYER
-from opengever.ogds.base import utils
-from plone.registry.interfaces import IRegistry
+from opengever.testing import IntegrationTestCase
 from zope.component import adaptedBy
 
 
-FAKE_CLIENT_TITLE = 'fake_clienttitle'
-FAKE_LOCATION = 'fake_location'
-
-
-class TestLandscapeLayout(MockTestCase):
-
-    layer = LATEX_ZCML_LAYER
-
-    def setUp(self):
-        super(TestLandscapeLayout, self).setUp()
-        self.context = self.stub()
-
-        admin_unit = self.stub()
-        self._ori_get_current_admin_unit = utils.get_current_admin_unit
-        get_current_admin_unit = self.mocker.replace(
-            'opengever.ogds.base.utils.get_current_admin_unit')
-        self.expect(get_current_admin_unit()).result(admin_unit).count(0, None)
-        self.expect(admin_unit.label()).result(FAKE_CLIENT_TITLE).count(0, None)
-
-        self.portal_membership = self.stub()
-        self.mock_tool(self.portal_membership, 'portal_membership')
-
-        registry_mock = self.stub()
-        self.expect(
-            registry_mock.forInterface(ILaTeXSettings).location).result(FAKE_LOCATION)
-
-        self.mock_utility(registry_mock, IRegistry)
-
-        member = self.stub()
-        self.expect(self.context.Creator()).result('john.doe')
-        self.expect(self.portal_membership.getMemberById('john.doe')).result(
-            member)
-        self.expect(member.getProperty('phone_number', '&nbsp;')).result(
-            '012 345 6789')
-
-    def tearDown(self):
-        super(TestLandscapeLayout, self).tearDown()
-        utils.get_current_admin_unit = self._ori_get_current_admin_unit
+class TestLandscapeLayout(IntegrationTestCase):
 
     def test_adapts_landscape_request_layer(self):
-        self.replay()
-
         adapts = adaptedBy(LandscapeLayout)
         self.assertEqual(len(adapts), 3)
         self.assertEqual(adapts[1], ILandscapeLayer)
 
     def test_show_contact(self):
-        request = self.create_dummy()
-        builder = self.stub()
-        self.expect(builder.add_file('logo.pdf', data=ANY))
-
-        self.replay()
-
-        layout = LandscapeLayout(self.context, request, builder)
-
+        self.login(self.regular_user)
+        layout = LandscapeLayout(self.dossier, self.request, PDFBuilder())
         self.assertEqual(layout.get_render_arguments()['show_contact'],
                          False)
 
     def test_rendering(self):
-        request = self.create_dummy()
-        builder = self.stub()
-        self.expect(builder.add_file('logo.pdf', data=ANY))
+        self.login(self.regular_user)
 
-        self.replay()
-        layout = LandscapeLayout(self.context, request, builder)
-
+        layout = LandscapeLayout(self.dossier, self.request, PDFBuilder())
         latex = layout.render_latex('CONTENT LATEX')
+
         self.assertIn('CONTENT LATEX', latex)
         self.assertIn(layout.get_packages_latex(), latex)
         self.assertNotIn(r'T direkt ', latex)
         self.assertNotIn(r'\phantom{foo}\vspace{-2\baselineskip}', latex)
 
     def test_box_sizes_and_positions(self):
-        request = self.create_dummy()
-        builder = self.stub()
-        self.expect(builder.add_file('logo.pdf', data=ANY))
+        self.login(self.regular_user)
 
-        self.replay()
-        layout = LandscapeLayout(self.context, request, builder)
+        builder = PDFBuilder()
+        builder.add_file('logo.pdf', 'Foo\nBar')
+
+        layout = LandscapeLayout(self.dossier, self.request, builder)
         layout.show_contact = True
         layout.show_organisation = True
 
         latex = layout.render_latex('LATEX CONTENT')
+
         self.assertIn(r'begin{textblock}{58mm\TPHorizModule} '
                       r'(220mm\TPHorizModule',
                       latex)


### PR DESCRIPTION
A French translation isn't available when exporting the dossier cover, therefore it is added.

Example files:
[dossiercover.pdf](https://github.com/4teamwork/opengever.core/files/5274165/dossiercover.pdf)
[dossierdetails.pdf](https://github.com/4teamwork/opengever.core/files/5274166/dossierdetails.pdf)

Jira: https://4teamwork.atlassian.net/browse/GEVER-832


Definition of Done: https://4teamwork.atlassian.net/wiki/spaces/CHX4TW/pages/917562/

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


## Checklist (if applicable)

_Only applicable should be left and checked._

- API change:
  - [ ] Documentation is updated
  - If breaking:
    - [ ] api-change label added
    - [ ] Scrum master is informed
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Upgrade steps (changes in profile):
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
- DB-Schema migration
  - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
  - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value
