### PR TITLE
Allow to query by token in @querysources API endpoint.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 
 - Adjust the policy generator for easier policy generation. [elioschmutz]
 - Provide create_forwarding action in API for documents in inboxes. [deiferni]
+- Allow to query by token in @querysources API endpoint. [deiferni]
 
 
 2020.8.0 (2020-08-26)

--- a/docs/public/dev-manual/api/index.rst
+++ b/docs/public/dev-manual/api/index.rst
@@ -23,6 +23,7 @@ Inhalt:
    extract_attachments.rst
    trash.rst
    workflow.rst
+   vocabularies.rst
    scanin.rst
    content_types.rst
    metadata.rst

--- a/docs/public/dev-manual/api/schemas/ftw.mail.mail.inc
+++ b/docs/public/dev-manual/api/schemas/ftw.mail.mail.inc
@@ -59,7 +59,7 @@
        :Feldname: :field-title:`Bearbeitungsinformation`
        :Datentyp: ``Text``
        
-       :Default: ""
+       
        :Beschreibung: Datum Gesuch, Gesuchsteller, Datum Entscheid, Verweis auf GEVER-Gesuchdossier
        
 

--- a/docs/public/dev-manual/api/schemas/opengever.document.document.inc
+++ b/docs/public/dev-manual/api/schemas/opengever.document.document.inc
@@ -69,7 +69,7 @@
        :Feldname: :field-title:`Bearbeitungsinformation`
        :Datentyp: ``Text``
        
-       :Default: ""
+       
        :Beschreibung: Datum Gesuch, Gesuchsteller, Datum Entscheid, Verweis auf GEVER-Gesuchdossier
        
 

--- a/docs/public/dev-manual/api/schemas/opengever.dossier.businesscasedossier.inc
+++ b/docs/public/dev-manual/api/schemas/opengever.dossier.businesscasedossier.inc
@@ -209,7 +209,7 @@
        :Feldname: :field-title:`Bearbeitungsinformation`
        :Datentyp: ``Text``
        
-       :Default: ""
+       
        :Beschreibung: Datum Gesuch, Gesuchsteller, Datum Entscheid, Verweis auf GEVER-Gesuchdossier
        
 

--- a/docs/public/dev-manual/api/schemas/opengever.repository.repositoryfolder.inc
+++ b/docs/public/dev-manual/api/schemas/opengever.repository.repositoryfolder.inc
@@ -9,7 +9,7 @@
        :Feldname: :field-title:`Beschreibung`
        :Datentyp: ``Text``
        
-       :Default: null
+       
        :Beschreibung: Eine kurze Beschreibung des Inhalts.
        
 
@@ -129,7 +129,7 @@
        :Feldname: :field-title:`Bearbeitungsinformation`
        :Datentyp: ``Text``
        
-       :Default: ""
+       
        :Beschreibung: Datum Gesuch, Gesuchsteller, Datum Entscheid, Verweis auf GEVER-Gesuchdossier
        
 

--- a/docs/public/dev-manual/api/vocabularies.rst
+++ b/docs/public/dev-manual/api/vocabularies.rst
@@ -38,3 +38,39 @@ oder Vocabulary geholt wird, unterschiedlich bestimmt werden:
 
 - Edit - es soll der ``portal_type`` des context ausgelesen werden
 - Add - es soll der ``portal_type`` Pfad-Parameter verwendet werden
+
+
+Eine Query-Source nach token abfragen
+-------------------------------------
+
+Zusätzlich zum schon in ``plone.restapi`` zur Verfügung gestellten Paremeter
+``query`` lässt sich eine ``@querysource`` in GEVER auch nach einem bereits
+bekannten ``token`` abfragen. Dieses muss als Query-String Paremeter angegeben
+werden. Es darf nur entweder ``token`` oder ``query`` verwendet werden, nicht
+beides zugleich.
+
+**Beispiel-Request**:
+
+.. sourcecode:: http
+
+   GET /dossier-15/@querysources/responsible?token=hans.muster HTTP/1.1
+   Accept: application/json
+
+
+**Beispiel-Response**:
+
+.. sourcecode:: http
+
+   HTTP/1.1 200 OK
+   Content-Type: application/json
+
+   {
+     "@id": "/dossier-15/@querysources/responsible?token=hans.muster",
+     "items": [
+       {
+         "title": "Hans Muster (hans.muster)",
+         "token": "hans.muster"
+       }
+     ],
+     "items_total": 1
+   }

--- a/docs/public/dev-manual/api/vocabularies.rst
+++ b/docs/public/dev-manual/api/vocabularies.rst
@@ -1,0 +1,40 @@
+.. _vocabularies:
+
+Vokabulare
+==========
+
+Die Grundlagen für den Umgang mit Vokabularen und Sourcen findet man in der
+`plone.restapi Dokumentation Vocabularies and Sources <https://plonerestapi.readthedocs.io/en/latest/vocabularies.html>`_.
+
+In ``plone.restapi`` wird jedoch nur das Editieren bestehender Inhalte
+abgebildet. GEVER erweitert dies um eine weitere Aufruf-Syntax für ``@sources``,
+`@querysources`` und ``@vocabularies``. Für diese drei Endpoints wird eine neue
+Aufruf-Syntax eingeführt, welche die Add-Semantik wiederspiegelt.
+
+.. sourcecode:: http
+
+   GET (container)/@sources/(portal_type)/(field_name) HTTP/1.1
+
+
+.. sourcecode:: http
+
+   GET (container)/@querysources/(portal_type)/(field_name) HTTP/1.1
+
+
+.. sourcecode:: http
+
+   GET (container)/@vocabularies/(portal_type)/(field_name) HTTP/1.1
+
+
+Die Endpoints wurden überschrieben und so umgebaut, dass sie entweder einenn
+oder zwei Pfad-Parameter akzeptieren:
+
+- 1 Parameter: Der parameter ist ``field_name``. Dies impliziert Edit intent.
+- 2 Parameter: Die Parameter sind ``portal_type`` und ``field_name``, in dieser
+  Reihenfolge. Dies impliziert Add intent.
+
+Abhängig von der Aufruf-Syntax soll das Schema, von dem die Source, Querysource
+oder Vocabulary geholt wird, unterschiedlich bestimmt werden:
+
+- Edit - es soll der ``portal_type`` des context ausgelesen werden
+- Add - es soll der ``portal_type`` Pfad-Parameter verwendet werden

--- a/opengever/api/tests/test_vocabularies.py
+++ b/opengever/api/tests/test_vocabularies.py
@@ -3,7 +3,6 @@ from opengever.base.behaviors.classification import IClassification
 from opengever.testing import IntegrationTestCase
 from opengever.testing import SolrIntegrationTestCase
 from plone import api
-from urllib import urlencode
 
 
 NON_SENSITIVE_VOCABUALRIES = [
@@ -266,7 +265,8 @@ class TestGetQuerySources(IntegrationTestCase):
     @browsing
     def test_get_querysource_for_edit(self, browser):
         self.login(self.regular_user, browser)
-        url = self.empty_dossier.absolute_url() + '/@querysources/responsible?query=nicole'
+        url = self.query_source_url(
+            self.empty_dossier, 'responsible', query='nicole')
         response = browser.open(
             url,
             method='GET',
@@ -281,7 +281,12 @@ class TestGetQuerySources(IntegrationTestCase):
     @browsing
     def test_get_vocabulary_for_add(self, browser):
         self.login(self.regular_user, browser)
-        url = self.leaf_repofolder.absolute_url() + '/@querysources/opengever.dossier.businesscasedossier/responsible?query=nicole'
+        url = self.query_source_url(
+            self.leaf_repofolder,
+            'responsible',
+            add='opengever.dossier.businesscasedossier',
+            query='nicole',
+        )
         response = browser.open(
             url,
             method='GET',
@@ -296,7 +301,8 @@ class TestGetQuerySources(IntegrationTestCase):
     @browsing
     def test_get_keywords_querysource_for_edit(self, browser):
         self.login(self.regular_user, browser)
-        url = self.empty_dossier.absolute_url() + '/@querysources/keywords?query=secret'
+        url = self.query_source_url(
+            self.empty_dossier, 'keywords', query='secret')
         response = browser.open(
             url,
             method='GET',
@@ -314,8 +320,7 @@ class TestGetQuerySourcesSolr(SolrIntegrationTestCase):
     @browsing
     def test_get_task_issuer_non_ascii_char_handling(self, browser):
         self.login(self.regular_user, browser)
-        url = self.task.absolute_url() + '/@querysources/issuer?{}'.format(
-            urlencode({'query': u'k\xf6vin'.encode('utf-8')}))
+        url = self.query_source_url(self.task, 'issuer', query=u'k\xf6vin')
         response = browser.open(
             url,
             method='GET',

--- a/opengever/testing/integration_test_case.py
+++ b/opengever/testing/integration_test_case.py
@@ -26,8 +26,8 @@ from opengever.meeting.model.agendaitem import AgendaItem
 from opengever.meeting.wrapper import MeetingWrapper
 from opengever.ogds.base.utils import get_current_admin_unit
 from opengever.ogds.base.utils import get_current_org_unit
-from opengever.ogds.models.service import ogds_service
 from opengever.ogds.models.org_unit import OrgUnit
+from opengever.ogds.models.service import ogds_service
 from opengever.private import enable_opengever_private
 from opengever.task.interfaces import ISuccessorTaskController
 from opengever.task.task import ITask
@@ -47,7 +47,9 @@ from plone.namedfile.file import NamedBlobFile
 from plone.portlets.constants import CONTEXT_CATEGORY
 from plone.portlets.interfaces import ILocalPortletAssignmentManager
 from plone.portlets.interfaces import IPortletManager
+from Products.CMFDiffTool.utils import safe_utf8
 from sqlalchemy.sql.expression import desc
+from urllib import urlencode
 from z3c.relationfield.relation import RelationValue
 from zope.component import getMultiAdapter
 from zope.component import getUtility
@@ -641,6 +643,19 @@ class IntegrationTestCase(TestCase):
             agenda_item.meeting.get_url(view=None),
             agenda_item.agenda_item_id,
             endpoint)
+
+    def query_source_url(self, context, field, add=None, **kwargs):
+        base_url = context.absolute_url()
+        if add:
+            components = [base_url, '@querysources', add, field]
+        else:
+            components = [base_url, '@querysources', field]
+
+        params = {key: safe_utf8(value) for key, value in kwargs.items()}
+        url = '/'.join(components)
+        if params:
+            return '{}?{}'.format(url, urlencode(params))
+        return url
 
     def get_ogds_user(self, user):
         return ogds_service().fetch_user(user.getId())


### PR DESCRIPTION
With this PR we allow the `@querysources` API endpoint to be queried by a `token` parameter in addition to the existing `query` parameter. The token can be used to retrieve the representation of one already known token. It will return an empty list if no such token exists.

- I have added some very basic docs for our customizations to vocabularies and sources as specified in https://plonerestapi.readthedocs.io/en/latest/vocabularies.html
- I mostly used the description i found in https://github.com/4teamwork/opengever.core/issues/5973 and https://github.com/4teamwork/opengever.core/issues/5968 for this
- I have amended tests so they also cover the possible error-states (no or too many query string parameters provided)
- I have also update the schema docs. this is a leftover of https://github.com/4teamwork/opengever.core/pull/6601 and a should have done it there 😓 

Jira: https://4teamwork.atlassian.net/browse/PHX-10

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
