### PR TITLE
Escape solr queries when building literal queries.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,7 @@ Changelog
 - Adjust the policy generator for easier policy generation. [elioschmutz]
 - Provide create_forwarding action in API for documents in inboxes. [deiferni]
 - Allow to query by token in @querysources API endpoint. [deiferni]
+- Fix escaping solr literal queries. [deiferni]
 
 
 2020.8.0 (2020-08-26)

--- a/opengever/api/tests/test_vocabularies.py
+++ b/opengever/api/tests/test_vocabularies.py
@@ -431,6 +431,23 @@ class TestGetQuerySourcesSolr(SolrIntegrationTestCase):
         self.assertEqual(url, response.get('@id'))
         self.assertEqual(0, response.get('items_total'))
 
+    @browsing
+    def test_get_task_issuer_escaping_for_solr(self, browser):
+        self.login(self.secretariat_user, browser)
+
+        self.franz_meier.firstname = 'Super:franz'
+        self.franz_meier.reindexObject()
+        self.commit_solr()
+
+        url = self.query_source_url(self.task, 'issuer', query=u'Super:fr')
+        response = browser.open(
+            url,
+            method='GET',
+            headers=self.api_headers,
+        ).json
+        self.assertEqual(url, response.get('@id'))
+        self.assertEqual(1, response.get('items_total'))
+
 
 class TestGetSources(IntegrationTestCase):
 

--- a/opengever/ogds/base/sources.py
+++ b/opengever/ogds/base/sources.py
@@ -1,4 +1,5 @@
 from ftw.solr.interfaces import ISolrSearch
+from ftw.solr.query import escape
 from opengever.base.model import create_session
 from opengever.base.query import extend_query_with_textfilter
 from opengever.contact.contact import IContact
@@ -15,6 +16,7 @@ from opengever.ogds.models.user import User
 from opengever.sharing.interfaces import ISharingConfiguration
 from opengever.workspace.utils import get_workspace_user_ids
 from plone import api
+from Products.CMFPlone.utils import safe_unicode
 from sqlalchemy import func
 from sqlalchemy import orm
 from sqlalchemy import sql
@@ -428,9 +430,10 @@ class UsersContactsInboxesSource(AllUsersInboxesAndTeamsSource):
 
     def _extend_terms_with_contacts(self, query_string):
         solr = getUtility(ISolrSearch)
-        resp = solr.search(query=u'SearchableText:{}* AND object_provides:{}'.format(
-            query_string,
-            IContact.__identifier__))
+        query = u'SearchableText:{}* AND object_provides:{}'.format(
+            escape(safe_unicode(query_string)),
+            IContact.__identifier__)
+        resp = solr.search(query=query)
         for result in resp.docs:
             self.terms.append(self.getTerm(solr_doc=result))
 
@@ -713,9 +716,10 @@ class AllEmailContactsAndUsersSource(UsersContactsInboxesSource):
 
     def _extend_terms_with_contacts(self, query_string):
         solr = getUtility(ISolrSearch)
-        resp = solr.search(query=u'SearchableText:{}* AND object_provides:{}'.format(
-            query_string,
-            IContact.__identifier__))
+        query = u'SearchableText:{}* AND object_provides:{}'.format(
+            escape(safe_unicode(query_string)),
+            IContact.__identifier__)
+        resp = solr.search(query=query)
         for result in resp.docs:
             if 'email' in result:
                 self.terms.append(self.getTerm(solr_doc=result))


### PR DESCRIPTION
With this PR we fix escaping special characters when building solr literal queries. This lead to query strings like `Eingangskorb:Blabla` failing and thus the whole request not returning any e.g. issuers for a task in autocomplete.

Jira: https://4teamwork.atlassian.net/browse/PHX-10

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)