### PR TITLE
Prevent deadlock when reassigning inter-admin-unit tasks

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2020.8.1 (unreleased)
 ---------------------
 
+- Prevent deadlock when reassigning inter-admin-unit tasks. [lgraf]
 - Adjust the policy generator for easier policy generation. [elioschmutz]
 - Provide create_forwarding action in API for documents in inboxes. [deiferni]
 

--- a/opengever/base/txnutils.py
+++ b/opengever/base/txnutils.py
@@ -1,0 +1,23 @@
+from zope.globalrequest import getRequest
+import itertools
+
+
+def txn_is_dirty():
+    """Determines whether the current transaction has changes or not.
+    """
+    return bool(registered_objects())
+
+
+def registered_objects():
+    """Returns a list of objects changed in this transaction.
+
+    Lifted from plone.protect.auto.
+    """
+    app = getRequest().PARENTS[-1]
+    return list(itertools.chain.from_iterable([
+        conn._registered_objects
+        # skip the 'temporary' connection since it stores session objects
+        # which get written all the time
+        for name, conn in app._p_jar.connections.items()
+        if name != 'temporary'
+    ]))


### PR DESCRIPTION
This solves an edge case which can lead to a deadlock when reassigning inter-admin-unit tasks. If the new responsible doesn't have an entry in the `watchers` SQL table yet, both the predecessor and successor sides would try to add it for the first time, and therefore **deadlock on the to-be-inserted row for the new watcher**.

This is prevented by creating the new watcher (if required) at the very beginning of this process, immediately committing the transaction, and starting a new one.

For a more detailed description of the problem, please see the Jira issue linked below.

Testing the effect of this change unfortunately is near impossible - it's not enough to fake a sort-of-inter-admin-unit scenario, because actual HTTP requests, across multiple real Zope instances were responsible for creating the deadlock in the first place.

Jira: https://4teamwork.atlassian.net/browse/GEVER-946

## Checklist (Must have)

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
