### PR TITLE
Consider cookie when figuring out current orgunit in AllUsersInboxesAndTeamsSource.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -8,6 +8,7 @@ Changelog
 - Provide create_forwarding action in API for documents in inboxes. [deiferni]
 - Allow to query by token in @querysources API endpoint. [deiferni]
 - Fix escaping solr literal queries. [deiferni]
+- Consider cookie when figuring out current orgunit in AllUsersInboxesAndTeamsSource. [deiferni]
 
 
 2020.8.0 (2020-08-26)

--- a/opengever/latex/tests/test_dossiercover.py
+++ b/opengever/latex/tests/test_dossiercover.py
@@ -23,12 +23,6 @@ class TestDossierCoverRenderArguments(FunctionalTestCase):
     def setUp(self):
         super(TestDossierCoverRenderArguments, self).setUp()
 
-        create(Builder('admin_unit')
-               .having(unit_id=u'OG',
-                       title=u'Department of forest & hunt',
-                       abbreviation=u'DoFH')
-               .as_current_admin_unit())
-
         self.user = create_ogds_user('hugo.boss')
         self.repository = create(
             Builder('repository_root')
@@ -55,12 +49,13 @@ class TestDossierCoverRenderArguments(FunctionalTestCase):
         browser.login().visit(dossier, view='dossier_cover_pdf')
 
     def test_contains_converted_configured_clienttitle(self):
+        get_current_admin_unit().title = u'Department of forest & hunt'
         arguments = self.dossiercover.get_render_arguments()
         self.assertEquals('Department of forest \\& hunt',
                           arguments.get('clienttitle'))
 
     def test_empty_client_title(self):
-        get_current_admin_unit().title = ''
+        get_current_admin_unit().title = u''
 
         arguments = self.dossiercover.get_render_arguments()
         self.assertEquals('', arguments.get('clienttitle'))
@@ -77,6 +72,7 @@ class TestDossierCoverRenderArguments(FunctionalTestCase):
                           arguments.get('repositoryversion'))
 
     def test_contains_referencenr(self):
+        get_current_admin_unit().abbreviation = u'DoFH'
         arguments = self.dossiercover.get_render_arguments()
         self.assertEquals(u'DoFH 1 / 1', arguments.get('referencenr'))
 

--- a/opengever/ogds/base/sources.py
+++ b/opengever/ogds/base/sources.py
@@ -311,6 +311,8 @@ class AllUsersInboxesAndTeamsSource(BaseQuerySoure):
             client_id = request.get('form.widgets.responsible_client')
         if client_id is None:
             client_id = getattr(self.context, 'responsible_client', None)
+        if client_id is None:
+            client_id = get_current_org_unit().id()
 
         if not client_id:
             return None

--- a/opengever/ogds/base/sources.py
+++ b/opengever/ogds/base/sources.py
@@ -8,6 +8,7 @@ from opengever.ogds.base import _
 from opengever.ogds.base.actor import Actor
 from opengever.ogds.base.actor import ActorLookup
 from opengever.ogds.base.utils import get_current_admin_unit
+from opengever.ogds.base.utils import get_current_org_unit
 from opengever.ogds.models.group import Group
 from opengever.ogds.models.group import groups_users
 from opengever.ogds.models.org_unit import OrgUnit
@@ -243,6 +244,7 @@ class AllUsersInboxesAndTeamsSource(BaseQuerySoure):
 
     def search(self, query_string):
         self.terms = []
+
         # Ignore colons to support queries on inboxes-id.
         query_string = query_string.replace(':', ' ')
 
@@ -304,11 +306,11 @@ class AllUsersInboxesAndTeamsSource(BaseQuerySoure):
         """
 
         request = getRequest()
-        client_id = request.get('client',
-                                request.get('form.widgets.responsible_client',
-                                            getattr(self.context,
-                                                    'responsible_client',
-                                                    None)))
+        client_id = request.get('client')
+        if client_id is None:
+            client_id = request.get('form.widgets.responsible_client')
+        if client_id is None:
+            client_id = getattr(self.context, 'responsible_client', None)
 
         if not client_id:
             return None

--- a/opengever/ogds/base/tests/test_sources.py
+++ b/opengever/ogds/base/tests/test_sources.py
@@ -126,7 +126,7 @@ class TestAllUsersInboxesAndTeamsSource(FunctionalTestCase):
     def setUp(self):
         super(TestAllUsersInboxesAndTeamsSource, self).setUp()
 
-        self.admin_unit = create(Builder('admin_unit'))
+        self.admin_unit = create(Builder('admin_unit').as_current_admin_unit())
         self.org_unit1 = create(Builder('org_unit')
                                 .id('org-unit-1')
                                 .having(title=u'Informatik',


### PR DESCRIPTION
This PR adds an additional fallback for the `AllUsersInboxesAndTeamsSource` when attempting to figure out the currently selected orgunit. For requests from the UI via API we don't have the form prefilling that is used to get the current orgunit for the forwarding add-form. Instead we must consider the cookie value for the orgunit currently selected.

The current mechanism only considers request form parameters https://github.com/4teamwork/opengever.core/blob/2f2f92f4dc4576ffe254195a79e94d59c440dd82/opengever/ogds/base/sources.py#L301-L318, but the cookie, which is always provided by the UI, is not considered. I have added the fallback last to avoid it from shadowing the edit form, when the value must be retrieved from `context`.

I have also fixed a related issue that popped up in some functional tests by using a better functional fixture (separate commits for clarity).

Jira: https://4teamwork.atlassian.net/browse/PHX-10


## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)