### PR TITLE
Fix forwarding requiring task_type in API, fix forwarding task_type translations

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -10,6 +10,7 @@ Changelog
 - Allow to query by token in @querysources API endpoint. [deiferni]
 - Fix escaping solr literal queries. [deiferni]
 - Consider cookie when figuring out current orgunit in AllUsersInboxesAndTeamsSource. [deiferni]
+- Fix forwarding requiring task_type in API, fix forwarding task_type translations. [deiferni]
 
 
 2020.8.0 (2020-08-26)

--- a/opengever/api/tests/test_forwarding.py
+++ b/opengever/api/tests/test_forwarding.py
@@ -55,6 +55,16 @@ class TestForwardingSerialization(SolrIntegrationTestCase):
             browser.json['containing_dossier']
         )
 
+    @browsing
+    def test_forwarding_task_type_serialization_provides_object(self, browser):
+        self.login(self.secretariat_user, browser=browser)
+        browser.open(self.inbox_forwarding, method="GET", headers=self.api_headers)
+
+        self.assertEqual(
+            {u'token': u'forwarding_task_type', u'title': u'Forwarding'},
+            browser.json['task_type']
+        )
+
 
 class TestForwardingTransitions(IntegrationTestCase):
 

--- a/opengever/api/tests/test_forwarding.py
+++ b/opengever/api/tests/test_forwarding.py
@@ -1,0 +1,97 @@
+from ftw.testbrowser import browsing
+from opengever.testing import IntegrationTestCase
+from opengever.testing import SolrIntegrationTestCase
+import json
+
+
+class TestForwardingSerialization(SolrIntegrationTestCase):
+
+    maxDiff = None
+
+    @browsing
+    def test_fowardings_contains_a_list_of_responses(self, browser):
+        self.login(self.secretariat_user, browser=browser)
+
+        browser.open(
+            self.inbox_forwarding, method="GET", headers=self.api_headers)
+        self.assertEquals(
+            [{u'@id': u'http://nohost/plone/eingangskorb/eingangskorb_fa/forwarding-1/@responses/1472634573000000',
+              u'response_id': 1472634573000000,
+              u'response_type': u'default',
+              u'added_objects': [{
+                u'@id': u'http://nohost/plone/eingangskorb/eingangskorb_fa/forwarding-1/document-13',
+                u'@type': u'opengever.document.document',
+                u'description': u'',
+                u'is_leafnode': None,
+                u'review_state': u'document-state-draft',
+                u'title': u'Dokument im Eingangsk\xf6rbliweiterleitung'}],
+              u'changes': [],
+              u'creator': {
+                  u'token': u'nicole.kohler',
+                  u'title': u'Kohler Nicole'},
+              u'created': u'2016-08-31T11:09:33',
+              u'related_items': [],
+              u'text': u'',
+              u'mimetype': u'',
+              u'successor_oguid': u'',
+              u'rendered_text': u'',
+              u'transition': u'transition-add-document'}],
+            browser.json['responses'])
+
+    @browsing
+    def test_containing_dossier_for_inbox_forwarding(self, browser):
+        self.login(self.secretariat_user, browser=browser)
+        browser.open(self.inbox_forwarding, method="GET", headers=self.api_headers)
+        self.maxDiff = None
+        self.assertDictEqual(
+            {
+                u'@id': u'http://nohost/plone/eingangskorb/eingangskorb_fa',
+                u'@type': u'opengever.inbox.inbox',
+                u'description': u'',
+                u'is_leafnode': None,
+                u'review_state': u'inbox-state-default',
+                u'title': u'Eingangsk\xf6rbli FA',
+            },
+            browser.json['containing_dossier']
+        )
+
+
+class TestForwardingTransitions(IntegrationTestCase):
+
+    @browsing
+    def test_reassign_forwarding_with_combined_responsible_value(self, browser):
+        self.login(self.secretariat_user, browser=browser)
+
+        self.assertEqual('fa', self.inbox_forwarding.responsible_client)
+        self.assertEqual('kathi.barfuss', self.inbox_forwarding.responsible)
+
+        data = {
+            'responsible': {
+                'token': 'rk:james.bond',
+                'title': u'Ratskanzlei: James Bond'
+            }
+        }
+        browser.open(self.inbox_forwarding.absolute_url() + '/@workflow/forwarding-transition-reassign',
+                     json.dumps(data),
+                     method="POST", headers=self.api_headers)
+
+        self.assertEqual('rk', self.inbox_forwarding.responsible_client)
+        self.assertEqual('james.bond', self.inbox_forwarding.responsible)
+
+    @browsing
+    def test_reassign_forwarding_without_combined_responsible_value(self, browser):
+        self.login(self.secretariat_user, browser=browser)
+
+        self.assertEqual('fa', self.inbox_forwarding.responsible_client)
+        self.assertEqual('kathi.barfuss', self.inbox_forwarding.responsible)
+
+        data = {
+            'responsible': 'james.bond',
+            'responsible_client': 'rk',
+        }
+        browser.open(self.inbox_forwarding.absolute_url() + '/@workflow/forwarding-transition-reassign',
+                     json.dumps(data),
+                     method="POST", headers=self.api_headers)
+
+        self.assertEqual('rk', self.inbox_forwarding.responsible_client)
+        self.assertEqual('james.bond', self.inbox_forwarding.responsible)

--- a/opengever/api/tests/test_globalindex.py
+++ b/opengever/api/tests/test_globalindex.py
@@ -146,3 +146,15 @@ class TestGlobalIndexGet(IntegrationTestCase):
         with self.login(self.secretariat_user, browser=browser):
             browser.open(self.portal, view='@globalindex', headers=self.api_headers)
             self.assertEqual(14, browser.json['items_total'])
+
+    @browsing
+    def test_forwarding_task_type_is_translated(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        search_term = u'F\xf6rw\xe4rding'
+        view = u'@globalindex?search={}'.format(search_term)
+        browser.open(self.portal, view=view, headers=self.api_headers)
+
+        self.assertEqual(1, browser.json['items_total'])
+        self.assertEqual(1, len(browser.json['items']))
+        self.assertEqual(u'Forwarding', browser.json['items'][0]['task_type'])

--- a/opengever/api/tests/test_task.py
+++ b/opengever/api/tests/test_task.py
@@ -83,36 +83,6 @@ class TestTaskSerialization(SolrIntegrationTestCase):
         self.assertEquals([], browser.json['responses'])
 
     @browsing
-    def test_fowardings_contains_a_list_of_responses(self, browser):
-        self.login(self.secretariat_user, browser=browser)
-
-        browser.open(
-            self.inbox_forwarding, method="GET", headers=self.api_headers)
-        self.assertEquals(
-            [{u'@id': u'http://nohost/plone/eingangskorb/eingangskorb_fa/forwarding-1/@responses/1472634573000000',
-              u'response_id': 1472634573000000,
-              u'response_type': u'default',
-              u'added_objects': [{
-                u'@id': u'http://nohost/plone/eingangskorb/eingangskorb_fa/forwarding-1/document-13',
-                u'@type': u'opengever.document.document',
-                u'description': u'',
-                u'is_leafnode': None,
-                u'review_state': u'document-state-draft',
-                u'title': u'Dokument im Eingangsk\xf6rbliweiterleitung'}],
-              u'changes': [],
-              u'creator': {
-                  u'token': u'nicole.kohler',
-                  u'title': u'Kohler Nicole'},
-              u'created': u'2016-08-31T11:09:33',
-              u'related_items': [],
-              u'text': u'',
-              u'mimetype': u'',
-              u'successor_oguid': u'',
-              u'rendered_text': u'',
-              u'transition': u'transition-add-document'}],
-            browser.json['responses'])
-
-    @browsing
     def test_adding_a_response_sucessful(self, browser):
         self.login(self.regular_user, browser=browser)
 
@@ -204,23 +174,6 @@ class TestTaskSerialization(SolrIntegrationTestCase):
                 u'is_subdossier': False,
                 u'review_state': u'dossier-state-active',
                 u'title': u'Vertr\xe4ge mit der kantonalen Finanzverwaltung',
-            },
-            browser.json['containing_dossier']
-        )
-
-    @browsing
-    def test_containing_dossier_for_inbox_forwarding(self, browser):
-        self.login(self.secretariat_user, browser=browser)
-        browser.open(self.inbox_forwarding, method="GET", headers=self.api_headers)
-        self.maxDiff = None
-        self.assertDictEqual(
-            {
-                u'@id': u'http://nohost/plone/eingangskorb/eingangskorb_fa',
-                u'@type': u'opengever.inbox.inbox',
-                u'description': u'',
-                u'is_leafnode': None,
-                u'review_state': u'inbox-state-default',
-                u'title': u'Eingangsk\xf6rbli FA',
             },
             browser.json['containing_dossier']
         )
@@ -506,44 +459,6 @@ class TestTaskTransitions(IntegrationTestCase):
 
         self.assertEqual('rk', self.task.responsible_client)
         self.assertEqual('james.bond', self.task.responsible)
-
-    @browsing
-    def test_reassign_forwarding_with_combined_responsible_value(self, browser):
-        self.login(self.secretariat_user, browser=browser)
-
-        self.assertEqual('fa', self.inbox_forwarding.responsible_client)
-        self.assertEqual('kathi.barfuss', self.inbox_forwarding.responsible)
-
-        data = {
-            'responsible': {
-                'token': 'rk:james.bond',
-                'title': u'Ratskanzlei: James Bond'
-            }
-        }
-        browser.open(self.inbox_forwarding.absolute_url() + '/@workflow/forwarding-transition-reassign',
-                     json.dumps(data),
-                     method="POST", headers=self.api_headers)
-
-        self.assertEqual('rk', self.inbox_forwarding.responsible_client)
-        self.assertEqual('james.bond', self.inbox_forwarding.responsible)
-
-    @browsing
-    def test_reassign_forwarding_without_combined_responsible_value(self, browser):
-        self.login(self.secretariat_user, browser=browser)
-
-        self.assertEqual('fa', self.inbox_forwarding.responsible_client)
-        self.assertEqual('kathi.barfuss', self.inbox_forwarding.responsible)
-
-        data = {
-            'responsible': 'james.bond',
-            'responsible_client': 'rk',
-        }
-        browser.open(self.inbox_forwarding.absolute_url() + '/@workflow/forwarding-transition-reassign',
-                     json.dumps(data),
-                     method="POST", headers=self.api_headers)
-
-        self.assertEqual('rk', self.inbox_forwarding.responsible_client)
-        self.assertEqual('james.bond', self.inbox_forwarding.responsible)
 
     @browsing
     def test_delegate_task(self, browser):

--- a/opengever/base/tests/test_default_values_for_types.py
+++ b/opengever/base/tests/test_default_values_for_types.py
@@ -1282,6 +1282,37 @@ class TestTaskDefaults(TestDefaultsBase):
 
         self.assert_default_values_equal(expected, persisted_values)
 
+    @browsing
+    def test_rest_api(self, browser):
+        self.login(self.regular_user, browser)
+
+        payload = {
+            u'@type': self.portal_type,
+            u'title': TASK_REQUIREDS['title'],
+            u'issuer': TASK_REQUIREDS['issuer'],
+            u'task_type': TASK_REQUIREDS['task_type'],
+            u'responsible': TASK_REQUIREDS['responsible'],
+            u'responsible_client': TASK_REQUIREDS['responsible_client'],
+        }
+        with freeze(FROZEN_NOW):
+            response = browser.open(
+                self.dossier.absolute_url(),
+                data=json.dumps(payload),
+                method='POST',
+                headers=self.api_headers)
+
+        self.assertEqual(201, response.status_code)
+
+        new_object_id = str(response.json['id'])
+        task = self.dossier.restrictedTraverse(new_object_id)
+
+        persisted_values = get_persisted_values_for_obj(task)
+        expected = self.get_type_defaults()
+        # when setting issuer via rest api it seems to become unicode
+        expected['issuer'] = expected['issuer'].decode('utf-8')
+
+        self.assert_default_values_equal(expected, persisted_values)
+
 
 class TestForwardingDefaults(TestDefaultsBase):
     """Test forwarding come with expected default values."""

--- a/opengever/core/upgrades/20200901163834_set_task_type_for_forwarding_on_objects/upgrade.py
+++ b/opengever/core/upgrades/20200901163834_set_task_type_for_forwarding_on_objects/upgrade.py
@@ -1,0 +1,20 @@
+from ftw.upgrade import UpgradeStep
+from opengever.inbox.forwarding import IForwarding
+
+
+FORWARDING_TASK_TYPE_ID = u'forwarding_task_type'
+
+
+class SetTaskTypeForForwardingOnObjects(UpgradeStep):
+    """Set task_type for forwarding on objects.
+    """
+
+    deferrable = True
+
+    def __call__(self):
+        query = {'object_provides': IForwarding.__identifier__}
+        for obj in self.objects(query, 'Set task_type on forwarding objects'):
+            # attributestorage, bypass field fallback to default
+            task_type = obj.__dict__.get('task_type', None)
+            if not task_type:
+                obj.task_type = FORWARDING_TASK_TYPE_ID

--- a/opengever/globalindex/browser/report.py
+++ b/opengever/globalindex/browser/report.py
@@ -11,6 +11,7 @@ from opengever.ogds.base.utils import get_current_admin_unit
 from opengever.task.util import getTaskTypeVocabulary
 from Products.statusmessages.interfaces import IStatusMessage
 from zope.component.hooks import getSite
+from zope.globalrequest import getRequest
 from zope.i18n import translate
 
 
@@ -19,7 +20,8 @@ def task_type_helper(value):
     value stored in the vdex files"""
 
     if value == FORWARDING_TASK_TYPE_ID:
-        return _(FORWARDING_TASK_TYPE_ID, default=u'Forwarding')
+        return translate(u'forwarding_task_type', domain='opengever.inbox',
+                         context=getRequest(), default=u'Forwarding')
 
     voc = getTaskTypeVocabulary(getSite())
     try:

--- a/opengever/globalindex/browser/report.py
+++ b/opengever/globalindex/browser/report.py
@@ -6,6 +6,7 @@ from opengever.base.reporter import StringTranslater
 from opengever.base.reporter import XLSReporter
 from opengever.globalindex import _
 from opengever.globalindex.utils import get_selected_items
+from opengever.inbox import FORWARDING_TASK_TYPE_ID
 from opengever.ogds.base.utils import get_current_admin_unit
 from opengever.task.util import getTaskTypeVocabulary
 from Products.statusmessages.interfaces import IStatusMessage
@@ -17,8 +18,8 @@ def task_type_helper(value):
     """XLS Reporter helper method which returns the translated
     value stored in the vdex files"""
 
-    if value == 'forwarding_task_type':
-        return _(u'forwarding_task_type', default=u'Forwarding')
+    if value == FORWARDING_TASK_TYPE_ID:
+        return _(FORWARDING_TASK_TYPE_ID, default=u'Forwarding')
 
     voc = getTaskTypeVocabulary(getSite())
     try:

--- a/opengever/globalindex/locales/de/LC_MESSAGES/opengever.globalindex.po
+++ b/opengever/globalindex/locales/de/LC_MESSAGES/opengever.globalindex.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-05-06 08:45+0000\n"
+"POT-Creation-Date: 2020-09-01 14:23+0000\n"
 "PO-Revision-Date: 2016-07-22 15:25+0000\n"
 "Last-Translator: Philippe Gross <gross.philippe@gmail.com>\n"
 "Language-Team: German <https://translations.onegovgever.ch/projects/onegov-gever/opengever-globalindex/de/>\n"
@@ -24,11 +24,6 @@ msgstr "Auswahl exportieren"
 #: ./opengever/globalindex/browser/report.py
 msgid "error_no_items"
 msgstr "Sie haben keine Objekte ausgewählt."
-
-#. Default: "Forwarding"
-#: ./opengever/globalindex/browser/report.py
-msgid "forwarding_task_type"
-msgstr "Weiterleitung"
 
 #: ./opengever/globalindex/browser/report.py
 msgid "label_admin_unit_id"

--- a/opengever/globalindex/locales/fr/LC_MESSAGES/opengever.globalindex.po
+++ b/opengever/globalindex/locales/fr/LC_MESSAGES/opengever.globalindex.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-05-06 08:45+0000\n"
+"POT-Creation-Date: 2020-09-01 14:23+0000\n"
 "PO-Revision-Date: 2017-12-03 09:48+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-globalindex/fr/>\n"
@@ -24,11 +24,6 @@ msgstr "Exporter la sélection"
 #: ./opengever/globalindex/browser/report.py
 msgid "error_no_items"
 msgstr "Vous n'avez sélectionné aucun élément."
-
-#. Default: "Forwarding"
-#: ./opengever/globalindex/browser/report.py
-msgid "forwarding_task_type"
-msgstr "Transmission"
 
 #: ./opengever/globalindex/browser/report.py
 msgid "label_admin_unit_id"

--- a/opengever/globalindex/locales/opengever.globalindex.pot
+++ b/opengever/globalindex/locales/opengever.globalindex.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-05-06 08:45+0000\n"
+"POT-Creation-Date: 2020-09-01 14:23+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -24,11 +24,6 @@ msgstr ""
 #. Default: "You have not selected any items."
 #: ./opengever/globalindex/browser/report.py
 msgid "error_no_items"
-msgstr ""
-
-#. Default: "Forwarding"
-#: ./opengever/globalindex/browser/report.py
-msgid "forwarding_task_type"
 msgstr ""
 
 #: ./opengever/globalindex/browser/report.py

--- a/opengever/globalindex/model/task.py
+++ b/opengever/globalindex/model/task.py
@@ -12,6 +12,7 @@ from opengever.base.query import BaseQuery
 from opengever.base.types import UnicodeCoercingText
 from opengever.base.utils import escape_html
 from opengever.globalindex.model.reminder_settings import ReminderSetting
+from opengever.inbox import FORWARDING_TASK_TYPE_ID
 from opengever.ogds.base.actor import Actor
 from opengever.ogds.base.utils import get_current_admin_unit
 from opengever.ogds.models.service import ogds_service
@@ -270,7 +271,7 @@ class Task(Base):
 
     @property
     def is_forwarding(self):
-        return self.task_type == 'forwarding_task_type'
+        return self.task_type == FORWARDING_TASK_TYPE_ID
 
     @property
     def is_overdue(self):

--- a/opengever/globalindex/tests/test_sql_task.py
+++ b/opengever/globalindex/tests/test_sql_task.py
@@ -2,6 +2,7 @@ from datetime import date
 from datetime import timedelta
 from ftw.builder import Builder
 from ftw.builder import create
+from opengever.inbox import FORWARDING_TASK_TYPE_ID
 from opengever.ogds.base.actor import InboxActor
 from opengever.testing import FunctionalTestCase
 from opengever.testing import MEMORY_DB_LAYER
@@ -171,7 +172,7 @@ class TestGlobalindexTask(TestCase):
     def test_is_forwarding(self):
         forwarding = create(
             Builder('globalindex_task')
-            .having(int_id=1, task_type='forwarding_task_type')
+            .having(int_id=1, task_type=FORWARDING_TASK_TYPE_ID)
             )
 
         task = create(

--- a/opengever/globalindex/tests/test_task_css_class.py
+++ b/opengever/globalindex/tests/test_task_css_class.py
@@ -1,5 +1,6 @@
 from ftw.builder import Builder
 from ftw.builder import create
+from opengever.inbox import FORWARDING_TASK_TYPE_ID
 from opengever.testing import FunctionalTestCase
 
 
@@ -15,7 +16,7 @@ class TestTaskCssClass(FunctionalTestCase):
     def test_forwarding_class(self):
         forwarding = create(Builder('globalindex_task')
                             .having(int_id=123, sequence_number=123,
-                                    task_type='forwarding_task_type',
+                                    task_type=FORWARDING_TASK_TYPE_ID,
                                     assigned_org_unit='org-unit-1',
                                     issuing_org_unit='org-unit-1',
                                     admin_unit_id='foo'))
@@ -27,7 +28,7 @@ class TestTaskCssClass(FunctionalTestCase):
         remote_forwarding = create(Builder('globalindex_task')
                                    .having(int_id=123, sequence_number=123,
                                            admin_unit_id='admin-unit-1',
-                                           task_type='forwarding_task_type',
+                                           task_type=FORWARDING_TASK_TYPE_ID,
                                            issuing_org_unit='org-unit-1',
                                            assigned_org_unit=u'additional'))
 

--- a/opengever/inbox/__init__.py
+++ b/opengever/inbox/__init__.py
@@ -1,3 +1,6 @@
 from zope.i18nmessageid import MessageFactory
 
 _ = MessageFactory('opengever.inbox')
+
+
+FORWARDING_TASK_TYPE_ID = u'forwarding_task_type'

--- a/opengever/inbox/forwarding.py
+++ b/opengever/inbox/forwarding.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from ftw.keywordwidget.widget import KeywordFieldWidget
 from opengever.base.role_assignments import RoleAssignmentManager
 from opengever.inbox import _
+from opengever.inbox import FORWARDING_TASK_TYPE_ID
 from opengever.ogds.base.sources import AllUsersInboxesAndTeamsSourceBinder
 from opengever.ogds.base.utils import get_current_org_unit
 from opengever.ogds.base.utils import get_ou_selector
@@ -21,6 +22,8 @@ from z3c.form.interfaces import HIDDEN_MODE
 from zope import schema
 from zope.i18n import translate
 from zope.interface import implements
+
+
 
 
 class IForwarding(ITask):
@@ -79,7 +82,7 @@ class Forwarding(Task):
         """Provide a marker string, which will be translated
         in the tabbedview helper method.
         """
-        return 'forwarding_task_type'
+        return FORWARDING_TASK_TYPE_ID
 
     def set_static_task_type(self, value):
         """Marker set function"""
@@ -89,7 +92,7 @@ class Forwarding(Task):
     task_type = property(get_static_task_type, set_static_task_type)
 
     def get_task_type_label(self, language=None):
-        label = _('forwarding_task_type', default=u'Forwarding')
+        label = _(FORWARDING_TASK_TYPE_ID, default=u'Forwarding')
         if language:
             return translate(
                 label,

--- a/opengever/inbox/forwarding.py
+++ b/opengever/inbox/forwarding.py
@@ -22,8 +22,21 @@ from z3c.form.interfaces import HIDDEN_MODE
 from zope import schema
 from zope.i18n import translate
 from zope.interface import implements
+from zope.interface import provider
+from zope.schema.interfaces import IContextSourceBinder
+from zope.schema.vocabulary import SimpleTerm
+from zope.schema.vocabulary import SimpleVocabulary
 
 
+@provider(IContextSourceBinder)
+def forwarding_task_type_vocabulary_factory(context):
+    return SimpleVocabulary([
+        SimpleTerm(
+            FORWARDING_TASK_TYPE_ID,
+            title=_(u'forwarding_task_type',
+                    default=u'Forwarding')
+        )
+    ])
 
 
 class IForwarding(ITask):
@@ -56,6 +69,14 @@ class IForwarding(ITask):
         title=task_mf(u"label_deadline", default=u"Deadline"),
         description=task_mf(u"help_deadline", default=u""),
         required=False,
+    )
+
+    # task type only allows one value, make it not required with a default
+    task_type = schema.Choice(
+        title=task_mf(u'label_task_type', default=u'Task Type'),
+        required=False,
+        default=FORWARDING_TASK_TYPE_ID,
+        source=forwarding_task_type_vocabulary_factory,
     )
 
     form.widget('responsible', KeywordFieldWidget, async=True)
@@ -92,7 +113,7 @@ class Forwarding(Task):
     task_type = property(get_static_task_type, set_static_task_type)
 
     def get_task_type_label(self, language=None):
-        label = _(FORWARDING_TASK_TYPE_ID, default=u'Forwarding')
+        label = _(u'forwarding_task_type', default=u'Forwarding')
         if language:
             return translate(
                 label,

--- a/opengever/inbox/forwarding.py
+++ b/opengever/inbox/forwarding.py
@@ -75,7 +75,9 @@ class IForwarding(ITask):
     task_type = schema.Choice(
         title=task_mf(u'label_task_type', default=u'Task Type'),
         required=False,
+        readonly=False,
         default=FORWARDING_TASK_TYPE_ID,
+        missing_value=None,
         source=forwarding_task_type_vocabulary_factory,
     )
 
@@ -98,19 +100,6 @@ class Forwarding(Task):
     def task_type_category(self):
         """Generates a Property for task categories"""
         return None
-
-    def get_static_task_type(self):
-        """Provide a marker string, which will be translated
-        in the tabbedview helper method.
-        """
-        return FORWARDING_TASK_TYPE_ID
-
-    def set_static_task_type(self, value):
-        """Marker set function"""
-        # do not fail when trying to set the task type - but ignore
-        return
-
-    task_type = property(get_static_task_type, set_static_task_type)
 
     def get_task_type_label(self, language=None):
         label = _(u'forwarding_task_type', default=u'Forwarding')

--- a/opengever/inbox/locales/de/LC_MESSAGES/opengever.inbox.po
+++ b/opengever/inbox/locales/de/LC_MESSAGES/opengever.inbox.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2020-05-18 08:02+0000\n"
+"POT-Creation-Date: 2020-09-01 14:07+0000\n"
 "PO-Revision-Date: 2015-03-30 08:56+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"

--- a/opengever/inbox/locales/fr/LC_MESSAGES/opengever.inbox.po
+++ b/opengever/inbox/locales/fr/LC_MESSAGES/opengever.inbox.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2020-05-18 08:02+0000\n"
+"POT-Creation-Date: 2020-09-01 14:07+0000\n"
 "PO-Revision-Date: 2016-08-10 04:54+0000\n"
 "Last-Translator: Philippe Gross <gross.philippe@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-inbox/fr/>\n"

--- a/opengever/inbox/locales/opengever.inbox.pot
+++ b/opengever/inbox/locales/opengever.inbox.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2020-05-18 08:02+0000\n"
+"POT-Creation-Date: 2020-09-01 14:07+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"

--- a/opengever/task/browser/accept/main.py
+++ b/opengever/task/browser/accept/main.py
@@ -27,6 +27,7 @@ from zope.interface import Invalid
 from zope.interface import provider
 from zope.schema.interfaces import IContextSourceBinder
 from zope.schema.vocabulary import SimpleVocabulary, SimpleTerm
+from opengever.inbox import FORWARDING_TASK_TYPE_ID
 
 
 class AcceptWizardFormMixin(BaseWizardStepForm):
@@ -49,7 +50,7 @@ def method_vocabulary_factory(context):
     org_unit = context.get_responsible_org_unit()
 
     # decision it's a forwarding or a task
-    if context.task_type == 'forwarding_task_type':
+    if context.task_type == FORWARDING_TASK_TYPE_ID:
         return SimpleVocabulary([
                 SimpleTerm(
                     value=u'forwarding_participate',
@@ -136,7 +137,7 @@ class ChooseMethodStepForm(AcceptWizardFormMixin, Form):
 
     @property
     def label(self):
-        if self.context.task_type == 'forwarding_task_type':
+        if self.context.task_type == FORWARDING_TASK_TYPE_ID:
             _(u'title_accept_forwarding', u'Accept forwarding')
 
         return _(u'title_accept_task', u'Accept task')
@@ -150,7 +151,7 @@ class ChooseMethodStepForm(AcceptWizardFormMixin, Form):
             oguid = ISuccessorTaskController(self.context).get_oguid()
 
             # set forwarding flag
-            if self.context.task_type == 'forwarding_task_type':
+            if self.context.task_type == FORWARDING_TASK_TYPE_ID:
                 is_forwarding = True
             else:
                 is_forwarding = False
@@ -225,7 +226,7 @@ class ChooseMethodStepForm(AcceptWizardFormMixin, Form):
                 self.request.set('form.widgets.text', text)
 
         super(ChooseMethodStepForm, self).updateWidgets()
-        if self.context.task_type == 'forwarding_task_type':
+        if self.context.task_type == FORWARDING_TASK_TYPE_ID:
             self.widgets.get('method').label = _(
                 u'label_accept_forwarding_choose_method',
                 default="Accept forwarding and ...")

--- a/opengever/task/helper.py
+++ b/opengever/task/helper.py
@@ -3,6 +3,7 @@ from opengever.task.util import getTaskTypeVocabulary
 from plone.api.portal import get_current_language
 from plone.memoize import ram
 from zope.component.hooks import getSite
+from opengever.inbox import FORWARDING_TASK_TYPE_ID
 
 
 @ram.cache(lambda m, i, value: '{}-{}'.format(value, get_current_language()))
@@ -11,9 +12,9 @@ def task_type_helper(item, value):
     its own translations stored in the vdex files.
     """
     portal = getSite()
-    if value == 'forwarding_task_type':
+    if value == FORWARDING_TASK_TYPE_ID:
         return portal.translate(
-            _(u'forwarding_task_type', default=u'Forwarding'))
+            _(FORWARDING_TASK_TYPE_ID, default=u'Forwarding'))
 
     voc = getTaskTypeVocabulary(portal)
     try:

--- a/opengever/task/helper.py
+++ b/opengever/task/helper.py
@@ -1,9 +1,9 @@
-from opengever.task import _
+from opengever.inbox import FORWARDING_TASK_TYPE_ID
 from opengever.task.util import getTaskTypeVocabulary
 from plone.api.portal import get_current_language
 from plone.memoize import ram
 from zope.component.hooks import getSite
-from opengever.inbox import FORWARDING_TASK_TYPE_ID
+from zope.globalrequest import getRequest
 
 
 @ram.cache(lambda m, i, value: '{}-{}'.format(value, get_current_language()))
@@ -14,7 +14,10 @@ def task_type_helper(item, value):
     portal = getSite()
     if value == FORWARDING_TASK_TYPE_ID:
         return portal.translate(
-            _(FORWARDING_TASK_TYPE_ID, default=u'Forwarding'))
+            u'forwarding_task_type',
+            domain='opengever.inbox',
+            default=u'Forwarding'
+        )
 
     voc = getTaskTypeVocabulary(portal)
     try:

--- a/opengever/task/locales/de/LC_MESSAGES/opengever.task.po
+++ b/opengever/task/locales/de/LC_MESSAGES/opengever.task.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2020-06-29 14:27+0000\n"
+"POT-Creation-Date: 2020-09-01 11:03+0000\n"
 "PO-Revision-Date: 2015-02-17 18:41+0100\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -250,11 +250,6 @@ msgstr "Erweitert"
 #: ./opengever/task/task.py
 msgid "fieldset_common"
 msgstr "Allgemein"
-
-#. Default: "Forwarding"
-#: ./opengever/task/helper.py
-msgid "forwarding_task_type"
-msgstr "Weiterleitung"
 
 #. Default: "Select the target dossier where you like to handle the task."
 #: ./opengever/task/browser/accept/existingdossier.py
@@ -584,7 +579,7 @@ msgid "label_private_task_added"
 msgstr "Neue Aufgabe (persönlich) eröffnet durch ${user}"
 
 #. Default: "Related Items"
-#: ./opengever/task/browser/complete.py
+#: ./opengever/task/browser/complete_utils.py
 #: ./opengever/task/response.py
 #: ./opengever/task/task.py
 msgid "label_related_items"

--- a/opengever/task/locales/fr/LC_MESSAGES/opengever.task.po
+++ b/opengever/task/locales/fr/LC_MESSAGES/opengever.task.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2020-06-29 14:27+0000\n"
+"POT-Creation-Date: 2020-09-01 11:03+0000\n"
 "PO-Revision-Date: 2017-12-03 11:47+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-task/fr/>\n"
@@ -252,11 +252,6 @@ msgstr "Avancé"
 #: ./opengever/task/task.py
 msgid "fieldset_common"
 msgstr "Général"
-
-#. Default: "Forwarding"
-#: ./opengever/task/helper.py
-msgid "forwarding_task_type"
-msgstr "Transmission"
 
 #. Default: "Select the target dossier where you like to handle the task."
 #: ./opengever/task/browser/accept/existingdossier.py
@@ -586,7 +581,7 @@ msgid "label_private_task_added"
 msgstr "Nouvelle tâche (personnelle) ouverte par ${user}"
 
 #. Default: "Related Items"
-#: ./opengever/task/browser/complete.py
+#: ./opengever/task/browser/complete_utils.py
 #: ./opengever/task/response.py
 #: ./opengever/task/task.py
 msgid "label_related_items"

--- a/opengever/task/locales/opengever.task.pot
+++ b/opengever/task/locales/opengever.task.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2020-06-29 14:27+0000\n"
+"POT-Creation-Date: 2020-09-01 11:03+0000\n"
 "PO-Revision-Date: 2009-02-25 14:39+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -250,11 +250,6 @@ msgstr ""
 #. Default: "Common"
 #: ./opengever/task/task.py
 msgid "fieldset_common"
-msgstr ""
-
-#. Default: "Forwarding"
-#: ./opengever/task/helper.py
-msgid "forwarding_task_type"
 msgstr ""
 
 #. Default: "Select the target dossier where you like to handle the task."
@@ -583,7 +578,7 @@ msgid "label_private_task_added"
 msgstr ""
 
 #. Default: "Related Items"
-#: ./opengever/task/browser/complete.py
+#: ./opengever/task/browser/complete_utils.py
 #: ./opengever/task/response.py
 #: ./opengever/task/task.py
 msgid "label_related_items"


### PR DESCRIPTION
With this PR we fix multiple related issues with `opengever.inbox.forwarding` when creating and reading via API:

- forwarding no longer requires a `task_type` to be provided, and will no longer ignore the `task_type` provided via `POST`
- as `task_type` is now a proper field for forwardings we get rid of the property, we also provide a migration to set the `task_type` on existing content to ensure all objects are in the same state
- forwarding `task_type` representation in GET is fixed to be consistent with GET of a task, the task_type is now an object, also providing the translation
- forwarding `task_type` in `@globalindex` is now also translated

I have also amended missing test for forwarding defaults (where possible) and have amended default tests for creating a task via API.

I have not unified the various distributed task_type helpers 😠 .

Jira: https://4teamwork.atlassian.net/browse/PHX-10

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


## Checklist (if applicable)

_Only applicable should be left and checked._

- API change:
  - If breaking:
    - [x] api-change label added
    - [x] Scrum master is informed
- New functionality:
  - [x] for `task` also works for `forwarding`
- Upgrade steps (changes in profile):
  - [x] Make it deferrable if possible
  - [x] Execute as much as possible conditionally
- New translations
  - [x] All msg-strings are unicode
- Change in schema definition:
  - [x] If `missing_value` is specified, then `default` has to be set to the same value
