### PR TITLE
Add new endpoints @actual-workspace-members and @share-content endpoint

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2020.8.1 (unreleased)
 ---------------------
 
+- Add @share-content endpoint to share content in workspace. [tinagerber]
 - Add @actual-workspace-members endpoint. [tinagerber]
 - Prevent deadlock when reassigning inter-admin-unit tasks. [lgraf]
 - Preserves the query string for the redirect_to_parent_dossier view. [elioschmutz]

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2020.8.1 (unreleased)
 ---------------------
 
+- Add @actual-workspace-members endpoint. [tinagerber]
 - Prevent deadlock when reassigning inter-admin-unit tasks. [lgraf]
 - Preserves the query string for the redirect_to_parent_dossier view. [elioschmutz]
 - Preserves the query string for the redirect_to_main_dossier view. [elioschmutz]

--- a/docs/public/dev-manual/api/docs_changelog.rst
+++ b/docs/public/dev-manual/api/docs_changelog.rst
@@ -9,6 +9,7 @@ Im Folgenden sind (substantielle) Änderungen an der Dokumentation aufgeführt.
 ----------
 
 - Kapitel "Teamraum-Mitglieder" hinzugefügt
+- Kapitel "Inhalte teilen" hinzugefügt
 
 
 2020-07-10

--- a/docs/public/dev-manual/api/docs_changelog.rst
+++ b/docs/public/dev-manual/api/docs_changelog.rst
@@ -5,6 +5,12 @@ Changelog
 
 Im Folgenden sind (substantielle) Änderungen an der Dokumentation aufgeführt.
 
+2020-09-01
+----------
+
+- Kapitel "Teamraum-Mitglieder" hinzugefügt
+
+
 2020-07-10
 ----------
 

--- a/docs/public/dev-manual/api/workspace/actual_workspace_members.rst
+++ b/docs/public/dev-manual/api/workspace/actual_workspace_members.rst
@@ -1,0 +1,44 @@
+Teamraum-Mitglieder
+===================
+
+Der ``@actual-workspace-members`` Endpoint liefert ein Vokabular aller Mitglieder eines Teamraums.
+
+**Beispiel-Request**:
+
+   .. sourcecode:: http
+
+       GET /workspace-1/@actual-workspace-members?b_size=3 HTTP/1.1
+       Accept: application/json
+
+**Beispiel-Response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 200 OK
+      Content-Type: application/json
+
+        {
+          "@id": "http://localhost:8080/fd/workspaces/workspace-1/@actual-workspace-members",
+          "batching": {
+            "@id": "http://localhost:8080/fd/workspaces/workspace-1/@actual-workspace-members?b_size=3",
+            "first": "http://localhost:8080/fd/workspaces/workspace-1/@actual-workspace-members?b_start=0&b_size=3",
+            "last": "http://localhost:8080/fd/workspaces/workspace-1/@actual-workspace-members?b_start=9&b_size=3",
+            "next": "http://localhost:8080/fd/workspaces/workspace-1/@actual-workspace-members?b_start=3&b_size=3"
+          },
+          "items": [
+            {
+              "title": "Baerfuss Kaethi (kathi.barfuss)",
+              "token": "kathi.barfuss"
+            },
+            {
+              "title": "Kohler Nicole (nicole.kohler)",
+              "token": "nicole.kohler"
+            },
+            {
+              "title": "Ziegler Robert (robert.ziegler)",
+              "token": "robert.ziegler"
+            }
+          ],
+          "items_total": 12
+        }
+

--- a/docs/public/dev-manual/api/workspace/index.rst
+++ b/docs/public/dev-manual/api/workspace/index.rst
@@ -15,5 +15,6 @@ Hier werden alle Teamraum-Schnittstellen beschrieben, welche von OneGov GEVER un
    todos
    todolists
    actual_workspace_members
+   share_content
 
 .. disqus::

--- a/docs/public/dev-manual/api/workspace/index.rst
+++ b/docs/public/dev-manual/api/workspace/index.rst
@@ -14,5 +14,6 @@ Hier werden alle Teamraum-Schnittstellen beschrieben, welche von OneGov GEVER un
    role_inheritance
    todos
    todolists
+   actual_workspace_members
 
 .. disqus::

--- a/docs/public/dev-manual/api/workspace/share_content.rst
+++ b/docs/public/dev-manual/api/workspace/share_content.rst
@@ -1,0 +1,36 @@
+Inhalte teilen
+==============
+Mit dem ``@share-content`` Endpoint können Teamräume und Inhalte von Teamräumen mit anderen Mitgliedern geteilt werden. Die ausgewählten Mitglieder erhalten eine E-Mail mit einem Hinweis zum geteilten Inhalt.
+
+**Beispiel-Request**:
+
+  .. sourcecode:: http
+
+    POST /workspaces/workspace-1/todo-1/@share-content HTTP/1.1
+    Accept: application/json
+
+    {
+      "users_to": [
+        {
+          "title": "Baerfuss Kaethi (kathi.barfuss)",
+          "token": "kathi.barfuss"
+        },
+        {
+          "title": "Kohler Nicole (nicole.kohler)",
+          "token": "nicole.kohler"
+        },
+      ],
+      "users_cc": [
+        {
+          "title": "Ziegler Robert (robert.ziegler)",
+          "token": "robert.ziegler"
+        }
+      ],
+      "comment": "Have you seen this ToDo yet?"
+    }
+
+**Beispiel-Response**:
+
+  .. sourcecode:: http
+
+    HTTP/1.1 204 No Content

--- a/opengever/activity/mailer.py
+++ b/opengever/activity/mailer.py
@@ -81,7 +81,7 @@ class Mailer(object):
         mail_queue.put(msg)
 
     def prepare_mail(self, subject=u'', to_userid=None, to_email=None,
-                     from_userid=None, data=None):
+                     cc_email=None, from_userid=None, data=None):
         if data is None:
             data = {}
 
@@ -119,6 +119,8 @@ class Mailer(object):
         if to_userid:
             to_email = ogds_service().fetch_user(to_userid).email
         msg['To'] = to_email
+        if cc_email:
+            msg['Cc'] = cc_email
         msg['Subject'] = Header(subject, 'utf-8')
 
         # Break (potential) description out into a list element per newline

--- a/opengever/api/actual_workspace_members.py
+++ b/opengever/api/actual_workspace_members.py
@@ -1,0 +1,36 @@
+from opengever.ogds.base.sources import ActualWorkspaceMembersSource
+from opengever.workspace.utils import is_within_workspace
+from plone.restapi.batching import HypermediaBatch
+from plone.restapi.interfaces import ISerializeToJson
+from plone.restapi.services import Service
+from Products.CMFPlone.utils import safe_unicode
+from zExceptions import BadRequest
+from zope.component import getMultiAdapter
+
+
+class ActualWorkspaceMembersGet(Service):
+    def reply(self):
+        if not is_within_workspace(self.context):
+            raise BadRequest("'{}' is not within a workspace".format(self.context.getId()))
+        source = ActualWorkspaceMembersSource(self.context)
+        query = safe_unicode(self.request.form.get('query', ''))
+        results = source.search(query)
+
+        batch = HypermediaBatch(self.request, results)
+
+        serialized_terms = []
+        for term in batch:
+            serializer = getMultiAdapter(
+                (term, self.request), interface=ISerializeToJson
+            )
+            serialized_terms.append(serializer())
+
+        result = {
+            "@id": batch.canonical_url,
+            "items": serialized_terms,
+            "items_total": batch.items_total,
+        }
+        links = batch.links
+        if links:
+            result["batching"] = links
+        return result

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -790,6 +790,14 @@
 
   <plone:service
       method="GET"
+      name="@actual-workspace-members"
+      for="*"
+      factory=".actual_workspace_members.ActualWorkspaceMembersGet"
+      permission="zope2.View"
+      />
+
+  <plone:service
+      method="GET"
       name="@watchers"
       for="opengever.task.task.ITask"
       factory=".watchers.WatchersGet"

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -879,6 +879,15 @@
 
   <plone:service
       method="POST"
+      name="@share-content"
+      for="*"
+      factory=".share_content.ShareContentPost"
+      permission="zope2.View"
+      layer="opengever.base.interfaces.IOpengeverBaseLayer"
+      />
+
+  <plone:service
+      method="POST"
       name="@accept-remote-task"
       for="opengever.dossier.behaviors.dossier.IDossierMarker"
       factory=".accept_remote_task.AcceptRemoteTaskPost"

--- a/opengever/api/share_content.py
+++ b/opengever/api/share_content.py
@@ -1,0 +1,43 @@
+from opengever.ogds.base.utils import ogds_service
+from opengever.workspace.content_sharing_mailer import ContentSharingMailer
+from opengever.workspace.utils import is_within_workspace
+from plone import api
+from plone.protect.interfaces import IDisableCSRFProtection
+from plone.restapi.deserializer import json_body
+from plone.restapi.services import Service
+from zExceptions import BadRequest
+from zope.interface import alsoProvides
+
+
+class ShareContentPost(Service):
+
+    def get_email_adresses(self, users):
+        service = ogds_service()
+        emails = []
+        for user in users:
+            emails.append(service.fetch_user(user['token']).email)
+        return ', '.join(emails)
+
+    def extract_data(self):
+        data = json_body(self.request)
+        self.comment = data.get('comment', u'')
+        self.users_to = data.get('users_to', [])
+        if not self.users_to:
+            raise BadRequest("Property 'users_to' is required")
+        self.users_cc = data.get('users_cc', [])
+
+    def reply(self):
+        if not is_within_workspace(self.context):
+            raise BadRequest("'{}' is not within a workspace".format(self.context.getId()))
+        # Disable CSRF protection
+        alsoProvides(self.request, IDisableCSRFProtection)
+        self.extract_data()
+        emails_to = self.get_email_adresses(self.users_to)
+        emails_cc = self.get_email_adresses(self.users_cc)
+
+        sender_id = api.user.get_current().getId()
+        mailer = ContentSharingMailer()
+        mailer.share_content(self.context, sender_id, emails_to, emails_cc, self.comment)
+
+        self.request.response.setStatus(204)
+        return super(ShareContentPost, self).reply()

--- a/opengever/api/tests/test_actual_workspace_members.py
+++ b/opengever/api/tests/test_actual_workspace_members.py
@@ -1,0 +1,60 @@
+from ftw.testbrowser import browsing
+from opengever.testing import IntegrationTestCase
+
+
+class TestActualWorkspaceMembersGet(IntegrationTestCase):
+
+    @browsing
+    def test_get_actual_workspace_members(self, browser):
+        self.login(self.workspace_member, browser=browser)
+        url = self.workspace.absolute_url() + '/@actual-workspace-members'
+        browser.open(url, method='GET', headers=self.api_headers)
+
+        expected_json = {
+            u'@id': u'http://nohost/plone/workspaces/workspace-1/@actual-workspace-members',
+            u'items': [{u'title': u'Fr\xf6hlich G\xfcnther',
+                        u'token': u'gunther.frohlich'},
+                       {u'title': u'Hugentobler Fridolin',
+                        u'token': u'fridolin.hugentobler'},
+                       {u'title': u'Peter Hans',
+                        u'token': u'hans.peter'},
+                       {u'title': u'Schr\xf6dinger B\xe9atrice',
+                        u'token': u'beatrice.schrodinger'}],
+            u'items_total': 4}
+        self.assertEqual(expected_json, browser.json)
+
+    @browsing
+    def test_get_actual_workspace_members_with_query(self, browser):
+        self.login(self.workspace_member, browser=browser)
+        url = self.workspace.absolute_url() + '/@actual-workspace-members?query=bea'
+        browser.open(url, method='GET', headers=self.api_headers)
+
+        expected_json = {
+            u'@id': u'http://nohost/plone/workspaces/workspace-1/@actual-workspace-members?query=bea',
+            u'items': [{u'title': u'Schr\xf6dinger B\xe9atrice',
+                        u'token': u'beatrice.schrodinger'}],
+            u'items_total': 1}
+        self.assertEqual(expected_json, browser.json)
+
+    @browsing
+    def test_get_actual_workspace_members_outside_a_workspace(self, browser):
+        self.login(self.regular_user, browser=browser)
+        url = self.document.absolute_url() + '/@actual-workspace-members'
+        with browser.expect_http_error(400):
+            browser.open(url, method='GET', headers=self.api_headers)
+
+        self.assertEqual(
+            {"message": "'{}' is not within a workspace".format(self.document.getId()),
+             "type": "BadRequest"},
+            browser.json)
+
+    @browsing
+    def test_response_is_batched(self, browser):
+        self.login(self.workspace_member, browser=browser)
+        url = self.workspace.absolute_url() + '/@actual-workspace-members?b_size=2'
+
+        browser.open(url, method='GET', headers=self.api_headers)
+
+        self.assertEqual(2, len(browser.json.get('items')))
+        self.assertEqual(4, browser.json.get('items_total'))
+        self.assertIn('batching', browser.json)

--- a/opengever/api/tests/test_share_content.py
+++ b/opengever/api/tests/test_share_content.py
@@ -1,0 +1,143 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.testbrowser import browsing
+from ftw.testing.mailing import Mailing
+from opengever.activity.mailer import process_mail_queue
+from opengever.testing import IntegrationTestCase
+import email
+import json
+
+
+class TestShareContentPost(IntegrationTestCase):
+    features = ('workspace', 'activity')
+
+    @browsing
+    def test_share_workspace(self, browser):
+        self.login(self.workspace_member, browser=browser)
+        process_mail_queue()
+        mailing = Mailing(self.portal)
+        mailing.reset()
+
+        url = '{}/@share-content'.format(self.workspace.absolute_url())
+        data = json.dumps({
+            'users_to': [{'token': self.archivist.getId()}],
+            'users_cc': [{'token': self.workspace_admin.getId()}],
+            'comment': u'Check out this fantastic w\xf6rkspace!'
+        })
+
+        browser.open(url, method='POST', headers=self.api_headers,
+                     data=data)
+
+        process_mail_queue()
+        self.assertEqual(1, len(mailing.get_messages()))
+        mail = email.message_from_string(Mailing(self.portal).pop())
+        self.assertEqual(self.archivist.getProperty('email'), mail['To'])
+        self.assertEqual(self.workspace_admin.getProperty('email'), mail['Cc'])
+        self.assertEqual('=?utf-8?q?Schr=C3=B6dinger_B=C3=A9atrice?= <test@localhost>',
+                         mail['From'])
+        self.assertIn('Check out this fantastic w=C3=B6rkspace!', mail.as_string())
+
+    @browsing
+    def test_share_workspace_folder_with_multiple_recipients(self, browser):
+        self.login(self.workspace_member, browser=browser)
+        process_mail_queue()
+        mailing = Mailing(self.portal)
+        mailing.reset()
+
+        url = '{}/@share-content'.format(self.workspace_folder.absolute_url())
+        data = json.dumps({
+            'users_to': [{'token': self.archivist.getId()},
+                         {'token': self.workspace_guest.getId()}],
+            'users_cc': [{'token': self.workspace_admin.getId()},
+                         {'token': self.workspace_owner.getId()}],
+            'comment': u'Check out this fantastic w\xf6rkspace!'
+        })
+
+        browser.open(url, method='POST', headers=self.api_headers,
+                     data=data)
+        expected_to = ', '.join((self.archivist.getProperty('email'),
+                                 self.workspace_guest.getProperty('email')))
+        expected_cc = ', '.join((self.workspace_admin.getProperty('email'),
+                                 self.workspace_owner.getProperty('email')))
+
+        process_mail_queue()
+        self.assertEqual(1, len(mailing.get_messages()))
+        mail = email.message_from_string(Mailing(self.portal).pop())
+        self.assertEqual(expected_to, mail['To'])
+        self.assertEqual(expected_cc, mail['Cc'])
+        self.assertEqual('=?utf-8?q?Schr=C3=B6dinger_B=C3=A9atrice?= <test@localhost>',
+                         mail['From'])
+        self.assertIn('Check out this fantastic w=C3=B6rkspace!', mail.as_string())
+
+    @browsing
+    def test_share_todo_without_cc_recipients_and_comment(self, browser):
+        self.login(self.workspace_member, browser=browser)
+        process_mail_queue()
+        mailing = Mailing(self.portal)
+        mailing.reset()
+
+        url = '{}/@share-content'.format(self.workspace.absolute_url())
+        data = json.dumps({
+            'users_to': [{'token': self.archivist.getId()}],
+        })
+
+        browser.open(url, method='POST', headers=self.api_headers,
+                     data=data)
+
+        process_mail_queue()
+        self.assertEqual(1, len(mailing.get_messages()))
+        mail = email.message_from_string(Mailing(self.portal).pop())
+        self.assertEqual(self.archivist.getProperty('email'), mail['To'])
+        self.assertIsNone(mail.get('Cc'))
+        self.assertEqual('=?utf-8?q?Schr=C3=B6dinger_B=C3=A9atrice?= <test@localhost>',
+                         mail['From'])
+
+    @browsing
+    def test_share_document_outside_a_workspace_raises_bad_request(self, browser):
+        self.login(self.workspace_member, browser=browser)
+        doc_in_workspace = create(Builder('document').within(self.workspace))
+        process_mail_queue()
+        mailing = Mailing(self.portal)
+        mailing.reset()
+
+        url = '{}/@share-content'.format(doc_in_workspace.absolute_url())
+        data = json.dumps({
+            'users_to': [{'token': self.workspace_admin.getId()}],
+        })
+        browser.open(url, method='POST', headers=self.api_headers,
+                     data=data)
+        process_mail_queue()
+        self.assertEqual(1, len(mailing.get_messages()))
+
+        url = '{}/@share-content'.format(self.document.absolute_url())
+        with browser.expect_http_error(400):
+            browser.open(url, method='POST', headers=self.api_headers,
+                         data=data)
+
+        self.assertEqual(
+            {"message": "'{}' is not within a workspace".format(self.document.getId()),
+             "type": "BadRequest"},
+            browser.json)
+
+    @browsing
+    def test_share_content_without_users_to_raises_bad_request(self, browser):
+        self.login(self.workspace_member, browser=browser)
+        process_mail_queue()
+        mailing = Mailing(self.portal)
+        mailing.reset()
+
+        url = '{}/@share-content'.format(self.workspace.absolute_url())
+        comment = u'Check out this fantastic w\xf6rkspace!'
+        data = json.dumps({
+            'users_cc': [{'token': self.workspace_admin.getId()}],
+            'comment': comment
+        })
+
+        with browser.expect_http_error(400):
+            browser.open(url, method='POST', headers=self.api_headers,
+                         data=data)
+
+        self.assertEqual(
+            {"message": "Property 'users_to' is required",
+             "type": "BadRequest"},
+            browser.json)

--- a/opengever/core/locales/de/LC_MESSAGES/opengever.core.po
+++ b/opengever/core/locales/de/LC_MESSAGES/opengever.core.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2020-03-10 07:31+0000\n"
+"POT-Creation-Date: 2020-09-01 07:50+0000\n"
 "PO-Revision-Date: 2017-09-18 15:21+0200\n"
 "Last-Translator: Philippe Gross <p.gross@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -78,6 +78,7 @@ msgstr "Kopieren"
 
 #: ./opengever/core/profiles/default/actions.xml
 #: ./opengever/core/upgrades/20200309163442_add_copy_documents_from_workspace_action/actions.xml
+#: ./opengever/core/upgrades/20200311140946_move_copy_documents_from_workspace_to_folder_actions/actions.xml
 msgid "Copy documents from workspace"
 msgstr "Dokumente aus Arbeitsraum zurückführen"
 
@@ -275,6 +276,11 @@ msgstr "Sablon Vorlage"
 #: ./opengever/core/profiles/default/actions.xml
 msgid "Send as email"
 msgstr "Als E-Mail versenden"
+
+#: ./opengever/core/profiles/default/actions.xml
+#: ./opengever/core/upgrades/20200827160546_add_share_content_action/actions.xml
+msgid "Share content"
+msgstr "Teilen"
 
 #: ./opengever/core/profiles/default/actions.xml
 msgid "Submit additional documents"

--- a/opengever/core/locales/fr/LC_MESSAGES/opengever.core.po
+++ b/opengever/core/locales/fr/LC_MESSAGES/opengever.core.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2020-03-10 07:31+0000\n"
+"POT-Creation-Date: 2020-09-01 07:50+0000\n"
 "PO-Revision-Date: 2013-03-27 10:44+0100\n"
 "Last-Translator: Philippe Gross <p.gross@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -75,6 +75,7 @@ msgstr "Copier"
 
 #: ./opengever/core/profiles/default/actions.xml
 #: ./opengever/core/upgrades/20200309163442_add_copy_documents_from_workspace_action/actions.xml
+#: ./opengever/core/upgrades/20200311140946_move_copy_documents_from_workspace_to_folder_actions/actions.xml
 msgid "Copy documents from workspace"
 msgstr ""
 
@@ -270,6 +271,11 @@ msgstr "Modèle Sablon"
 #: ./opengever/core/profiles/default/actions.xml
 msgid "Send as email"
 msgstr "Envoyer par E-Mail"
+
+#: ./opengever/core/profiles/default/actions.xml
+#: ./opengever/core/upgrades/20200827160546_add_share_content_action/actions.xml
+msgid "Share content"
+msgstr ""
 
 #: ./opengever/core/profiles/default/actions.xml
 msgid "Submit additional documents"

--- a/opengever/core/locales/opengever.core.pot
+++ b/opengever/core/locales/opengever.core.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2020-03-10 07:31+0000\n"
+"POT-Creation-Date: 2020-09-01 07:50+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -78,6 +78,7 @@ msgstr ""
 
 #: ./opengever/core/profiles/default/actions.xml
 #: ./opengever/core/upgrades/20200309163442_add_copy_documents_from_workspace_action/actions.xml
+#: ./opengever/core/upgrades/20200311140946_move_copy_documents_from_workspace_to_folder_actions/actions.xml
 msgid "Copy documents from workspace"
 msgstr ""
 
@@ -272,6 +273,11 @@ msgstr ""
 
 #: ./opengever/core/profiles/default/actions.xml
 msgid "Send as email"
+msgstr ""
+
+#: ./opengever/core/profiles/default/actions.xml
+#: ./opengever/core/upgrades/20200827160546_add_share_content_action/actions.xml
+msgid "Share content"
 msgstr ""
 
 #: ./opengever/core/profiles/default/actions.xml

--- a/opengever/core/profiles/default/actions.xml
+++ b/opengever/core/profiles/default/actions.xml
@@ -876,6 +876,15 @@
       <property name="visible">True</property>
     </object>
 
+    <object name="share_content" meta_type="CMF Action" i18n:domain="opengever.core">
+      <property name="title" i18n:translate="">Share content</property>
+      <property name="description" i18n:translate="" />
+      <property name="url_expr">string:${object_url}/@share-content</property>
+      <property name="icon_expr" />
+      <property name="available_expr">object/is_within_workspace</property>
+      <property name="visible">True</property>
+    </object>
+
   </object>
 
 

--- a/opengever/core/upgrades/20200827160546_add_share_content_action/actions.xml
+++ b/opengever/core/upgrades/20200827160546_add_share_content_action/actions.xml
@@ -1,0 +1,13 @@
+<object xmlns:i18n="http://xml.zope.org/namespaces/i18n" name="portal_actions" meta_type="Plone Actions Tool">
+  <!-- OBJECT BUTTONS -->
+  <object name="object_buttons" meta_type="CMF Action Category">
+    <object name="share_content" meta_type="CMF Action" i18n:domain="opengever.core">
+      <property name="title" i18n:translate="">Share content</property>
+      <property name="description" i18n:translate="" />
+      <property name="url_expr">string:${object_url}/@share-content</property>
+      <property name="icon_expr" />
+      <property name="available_expr">object/is_within_workspace</property>
+      <property name="visible">True</property>
+    </object>
+  </object>
+</object>

--- a/opengever/core/upgrades/20200827160546_add_share_content_action/upgrade.py
+++ b/opengever/core/upgrades/20200827160546_add_share_content_action/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddShareContentAction(UpgradeStep):
+    """Add share_content action.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/workspace/browser/configure.zcml
+++ b/opengever/workspace/browser/configure.zcml
@@ -48,4 +48,11 @@
       permission="zope2.View"
       />
 
+  <browser:page
+      for="*"
+      name="is_within_workspace"
+      class=".is_within_workspace.IsWithinWorkspaceView"
+      permission="zope2.View"
+      />
+
 </configure>

--- a/opengever/workspace/browser/is_within_workspace.py
+++ b/opengever/workspace/browser/is_within_workspace.py
@@ -1,0 +1,7 @@
+from opengever.workspace.utils import is_within_workspace
+from Products.Five import BrowserView
+
+
+class IsWithinWorkspaceView(BrowserView):
+    def __call__(self):
+        return is_within_workspace(self.context)

--- a/opengever/workspace/content_sharing_mail.pt
+++ b/opengever/workspace/content_sharing_mail.pt
@@ -1,0 +1,38 @@
+<html
+    xmlns="http://www.w3.org/1999/xhtml"
+    xmlns:tal="http://xml.zope.org/namespaces/tal"
+    xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+    i18n:domain="opengever.workspace"
+    metal:use-macro="context/notification_mail_macros/macros/mail_template">
+
+    <metal:styles metal:fill-slot="style_slot">
+      <style>
+        .email-content table {
+          width: 100%;
+        }
+      </style>
+    </metal:styles>
+
+    <metal:title metal:fill-slot="title">
+        <p><a href="" tal:content="options/title" tal:attributes="href options/link"></a></p>
+    </metal:title>
+
+    <metal:content metal:fill-slot="content">
+      <p>
+        <tal:summary tal:repeat="line options/content">
+          <tal:last tal:define="is_last repeat/line/end">
+            <tal:line tal:replace="line" /><br tal:condition="not: is_last" />
+          </tal:last>
+        </tal:summary>
+      </p>
+      <tal:comment tal:condition="options/comment">
+          <p><strong tal:content="options/comment_title"/></p>
+        <tal:block tal:repeat="line options/comment">
+          <p tal:content="line" />
+        </tal:block>
+      </tal:comment>
+
+    </metal:content>
+
+    <metal:footer metal:fill-slot="footer" />
+</html>

--- a/opengever/workspace/content_sharing_mailer.py
+++ b/opengever/workspace/content_sharing_mailer.py
@@ -1,0 +1,54 @@
+from opengever.activity.mailer import Mailer
+from opengever.ogds.base.actor import ActorLookup
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+from zope.i18n import translate
+from zope.i18nmessageid import MessageFactory
+
+
+_ = MessageFactory("opengever.workspace")
+
+
+class ContentSharingMailer(Mailer):
+
+    template = ViewPageTemplateFile("content_sharing_mail.pt")
+    default_addr_header = u'Teamraum'
+
+    def share_content(self, target_object, sender_id, to_email, cc_email=None, comment=u''):
+
+        subject = translate(
+            _(u'share_mail_subject',
+              default=u'Notification to "${title}"',
+              mapping={'title': target_object.title}),
+            context=self.request
+        )
+
+        sharer = ActorLookup(sender_id).lookup()
+
+        content = translate(
+            _(
+                u'share_mail_summary',
+                default=u'${user} has sent you a notification:',
+                mapping={'user': sharer.get_label()}
+            ),
+            context=self.request
+        )
+
+        comment_title = translate(
+            _(
+                u'share_mail_comment_title',
+                default=u'Comment'
+            ),
+            context=self.request
+        )
+
+        data = {
+            'title': target_object.title,
+            'link': target_object.absolute_url(),
+            'content': content.splitlines(),
+            'comment_title': comment_title,
+            'comment': comment.splitlines(),
+        }
+        msg = self.prepare_mail(subject=subject, to_email=to_email, cc_email=cc_email,
+                                from_userid=sender_id, data=data)
+
+        self.send_mail(msg)

--- a/opengever/workspace/locales/de/LC_MESSAGES/opengever.workspace.po
+++ b/opengever/workspace/locales/de/LC_MESSAGES/opengever.workspace.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2020-07-06 14:45+0000\n"
+"POT-Creation-Date: 2020-09-01 07:29+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -199,6 +199,21 @@ msgstr "Papierkorb"
 #: ./opengever/workspace/browser/tabbed.py
 msgid "label_workspaces"
 msgstr "Teamräume"
+
+#. Default: "Comment"
+#: ./opengever/workspace/content_sharing_mailer.py
+msgid "share_mail_comment_title"
+msgstr "Kommentar"
+
+#. Default: "Notification to \"${title}\""
+#: ./opengever/workspace/content_sharing_mailer.py
+msgid "share_mail_subject"
+msgstr "Hinweis zu \"${title}\""
+
+#. Default: "${user} has sent you a notification:"
+#: ./opengever/workspace/content_sharing_mailer.py
+msgid "share_mail_summary"
+msgstr "${user} hat einen Hinweis an Sie versendet:"
 
 #. Default: "Assigned to ${responsible} by ${user}"
 #: ./opengever/workspace/activities.py

--- a/opengever/workspace/locales/fr/LC_MESSAGES/opengever.workspace.po
+++ b/opengever/workspace/locales/fr/LC_MESSAGES/opengever.workspace.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2020-07-06 14:45+0000\n"
+"POT-Creation-Date: 2020-09-01 07:29+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -199,6 +199,21 @@ msgstr "Corbeille"
 #: ./opengever/workspace/browser/tabbed.py
 msgid "label_workspaces"
 msgstr "Teamraüme"
+
+#. Default: "Comment"
+#: ./opengever/workspace/content_sharing_mailer.py
+msgid "share_mail_comment_title"
+msgstr ""
+
+#. Default: "Notification to \"${title}\""
+#: ./opengever/workspace/content_sharing_mailer.py
+msgid "share_mail_subject"
+msgstr ""
+
+#. Default: "${user} has sent you a notification:"
+#: ./opengever/workspace/content_sharing_mailer.py
+msgid "share_mail_summary"
+msgstr ""
 
 #. Default: "Assigned to ${responsible} by ${user}"
 #: ./opengever/workspace/activities.py

--- a/opengever/workspace/locales/opengever.workspace.pot
+++ b/opengever/workspace/locales/opengever.workspace.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2020-07-06 14:45+0000\n"
+"POT-Creation-Date: 2020-09-01 07:29+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -201,6 +201,21 @@ msgstr ""
 #. Default: "Workspaces"
 #: ./opengever/workspace/browser/tabbed.py
 msgid "label_workspaces"
+msgstr ""
+
+#. Default: "Comment"
+#: ./opengever/workspace/content_sharing_mailer.py
+msgid "share_mail_comment_title"
+msgstr ""
+
+#. Default: "Notification to \"${title}\""
+#: ./opengever/workspace/content_sharing_mailer.py
+msgid "share_mail_subject"
+msgstr ""
+
+#. Default: "${user} has sent you a notification:"
+#: ./opengever/workspace/content_sharing_mailer.py
+msgid "share_mail_summary"
 msgstr ""
 
 #. Default: "Assigned to ${responsible} by ${user}"

--- a/opengever/workspace/tests/test_content_sharing_mail.py
+++ b/opengever/workspace/tests/test_content_sharing_mail.py
@@ -1,0 +1,29 @@
+from ftw.testing.mailing import Mailing
+from opengever.activity.mailer import process_mail_queue
+from opengever.testing import IntegrationTestCase
+from opengever.workspace.content_sharing_mailer import ContentSharingMailer
+import email
+
+
+class TestContentSharingMail(IntegrationTestCase):
+    features = ('workspace', 'activity')
+
+    def test_content_sharing_mail(self):
+        self.login(self.workspace_member)
+        process_mail_queue()
+        mailing = Mailing(self.portal)
+        mailing.reset()
+
+        mailer = ContentSharingMailer()
+        sender_id = self.workspace_member.getId()
+        emails_to = self.workspace_guest.getProperty('email')
+        emails_cc = self.workspace_admin.getProperty('email')
+        comment = u'Check out this interesting w\xf6rkspace!'
+        mailer.share_content(self.workspace, sender_id, emails_to, emails_cc, comment)
+        process_mail_queue()
+        mail = email.message_from_string(Mailing(self.portal).pop())
+        self.assertEqual(emails_to, mail['To'])
+        self.assertEqual(emails_cc, mail['Cc'])
+        self.assertEqual('=?utf-8?q?Schr=C3=B6dinger_B=C3=A9atrice?= <test@localhost>',
+                         mail['From'])
+        self.assertIn('Check out this interesting w=C3=B6rkspace!', mail.as_string())


### PR DESCRIPTION
With this PR it becomes possible to share workspace content with other members.

- The `@actual-workspace-members` endpoint provides a vocabulary with all members of a workspace. This allows the frontend to select with whom a content can be shared.
- With the `@share-content endpoint`, an e-mail can be sent to the selected members.
- The e-mail is created and sent using the `ContentSharingMailer`.
- A new action `share_content` is provided on workspace content and workspaces.

<img width="916" alt="Bildschirmfoto 2020-09-01 um 14 34 25" src="https://user-images.githubusercontent.com/50165195/91851909-45c86d00-ec60-11ea-8c0f-d6a848216f9a.png">

Jira: https://4teamwork.atlassian.net/browse/GEVER-697

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


## Checklist (if applicable)

_Only applicable should be left and checked._

- Upgrade steps (changes in profile):
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
- New translations
  - [x] All msg-strings are unicode