### PR TITLE
Add @type to @globalindex items.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -13,6 +13,7 @@ Changelog
 - Fix escaping solr literal queries. [deiferni]
 - Consider cookie when figuring out current orgunit in AllUsersInboxesAndTeamsSource. [deiferni]
 - Fix forwarding requiring task_type in API, fix forwarding task_type translations. [deiferni]
+- Add @type to @globalindex items, figure out portal type from task type. [deiferni]
 
 
 2020.8.0 (2020-08-26)

--- a/docs/public/dev-manual/api/globalindex.rst
+++ b/docs/public/dev-manual/api/globalindex.rst
@@ -19,6 +19,7 @@ Der globale, also über den ganzen Mandantenverbund verteilte, Aufgabenindex kan
       "batching": null,
       "items": [
         { "@id": "http://localhost:8080//ordnungssystem/dossier-23/document-123/task-1",
+          "@type": "opengever.task.task",
           "assigned_org_unit": "fa",
           "containing_dossier": "Anfragen 2019",
           "created": "2016-08-31T18:27:33",

--- a/opengever/api/globalindex.py
+++ b/opengever/api/globalindex.py
@@ -3,12 +3,24 @@ from opengever.api.solr_query_service import DEFAULT_SORT_INDEX
 from opengever.api.solr_query_service import translate_task_type
 from opengever.base.helpers import display_name
 from opengever.globalindex.model.task import Task
+from opengever.inbox import FORWARDING_TASK_TYPE_ID
 from opengever.tabbedview.sqlsource import cast_to_string
 from plone.restapi.serializer.converters import json_compatible
 from plone.restapi.services import Service
 from sqlalchemy import asc
 from sqlalchemy import desc
 from sqlalchemy import or_
+
+
+def add_portal_type(task):
+    """Figure out a tasks portal type from the task_type column.
+
+    We don't store the portal_type in globalindex but task_type is distinct
+    and we can use it to figure out the portal type.
+    """
+    if task.task_type == FORWARDING_TASK_TYPE_ID:
+        return 'opengever.inbox.forwarding'
+    return 'opengever.task.task'
 
 
 class GlobalIndexGet(Service):
@@ -24,7 +36,8 @@ class GlobalIndexGet(Service):
         'responsible_fullname': lambda task: display_name(task.responsible),
         'issuer_fullname': lambda task: display_name(task.issuer),
         'oguid': lambda task: str(task.oguid),
-        '@id': lambda task: task.absolute_url()}
+        '@id': lambda task: task.absolute_url(),
+        '@type': add_portal_type}
 
     searchable_columns = [Task.title, Task.text,
                           Task.sequence_number, Task.responsible]

--- a/opengever/api/tests/test_globalindex.py
+++ b/opengever/api/tests/test_globalindex.py
@@ -5,6 +5,8 @@ from opengever.testing import IntegrationTestCase
 
 class TestGlobalIndexGet(IntegrationTestCase):
 
+    maxDiff = None
+
     @browsing
     def test_lists_all_task(self, browser):
         self.login(self.regular_user, browser=browser)
@@ -15,6 +17,7 @@ class TestGlobalIndexGet(IntegrationTestCase):
         self.assertEqual(15, len(browser.json['items']))
         self.assertEqual(
             {u'@id': self.inbox_task.absolute_url(),
+             u'@type': u'opengever.task.task',
              u'assigned_org_unit': u'fa',
              u'containing_dossier': u'Vertr\xe4ge mit der kantonalen Finanzverwaltung',
              u'created': u'2016-08-31T18:27:33',
@@ -158,3 +161,21 @@ class TestGlobalIndexGet(IntegrationTestCase):
         self.assertEqual(1, browser.json['items_total'])
         self.assertEqual(1, len(browser.json['items']))
         self.assertEqual(u'Forwarding', browser.json['items'][0]['task_type'])
+
+    @browsing
+    def test_adds_portal_type_to_globalindex_items(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        view = (
+            '@globalindex?filters.task_type:record:list=information'
+            '&filters.task_type:record:list=forwarding_task_type'
+            '&sort_on=title'
+        )
+        browser.open(self.portal, view=view, headers=self.api_headers)
+
+        self.assertEqual(2, browser.json['items_total'])
+        self.assertEqual(2, len(browser.json['items']))
+        items = browser.json['items']
+        self.assertEqual(items[0]['@type'], u'opengever.task.task')
+        self.assertEqual(items[1]['@type'], u'opengever.inbox.forwarding')
+


### PR DESCRIPTION
With this PR we add the `@type` attribute to items we return. We use the existing `task_type` column to figure out the portal type ss we don't store an e.g. `portal_type` in the tasks table. The `task_type` is distinct and we can use it to figure out the portal type. This helps the UI as it might display forwardings and tasks differently when retrieved from the `@globalindex` API service endpoint.

Jira: https://4teamwork.atlassian.net/browse/PHX-10


## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


## Checklist (if applicable)

_Only applicable should be left and checked._

- API change:
  - [x] Documentation is updated
- New functionality:
  - [x] for `task` also works for `forwarding`
