### PR TITLE
Fix resolving favorites that don't exist.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,7 @@ Changelog
 - Add @share-content endpoint to share content in workspace. [tinagerber]
 - Add @actual-workspace-members endpoint. [tinagerber]
 - Add support for transferring inter-admin-unit tasks. [lgraf]
+- Fix resolving favorites that don't exist. [tinagerber]
 - Prevent deadlock when reassigning inter-admin-unit tasks. [lgraf]
 - Preserves the query string for the redirect_to_parent_dossier view. [elioschmutz]
 - Preserves the query string for the redirect_to_main_dossier view. [elioschmutz]

--- a/opengever/base/model/favorite.py
+++ b/opengever/base/model/favorite.py
@@ -1,5 +1,6 @@
 from opengever.base.browser.helper import get_css_class
 from opengever.base.date_time import utcnow_tz_aware
+from opengever.base.exceptions import InvalidOguidIntIdPart
 from opengever.base.model import Base
 from opengever.base.model import CONTENT_TITLE_LENGTH
 from opengever.base.model import CSS_CLASS_LENGTH
@@ -32,6 +33,10 @@ from sqlalchemy import String
 from sqlalchemy import UniqueConstraint
 from sqlalchemy.orm import composite
 from sqlalchemy.schema import Sequence
+import logging
+
+
+logger = logging.getLogger('opengever.base')
 
 
 class Favorite(Base):
@@ -122,7 +127,12 @@ class Favorite(Base):
         If the favorite cannot be resolved, i.e. because it does not exist on the
         current admin-unit, the unresolved favorite will be returned instead.
         """
-        resolved_obj = self.oguid.resolve_object() if resolve else None
+        resolved_obj = None
+        if resolve:
+            try:
+                resolved_obj = self.oguid.resolve_object()
+            except InvalidOguidIntIdPart:
+                logger.warn('Failed to resolve Oguid %s', self.oguid.id)
 
         return {
             '@id': self.api_url(portal_url),

--- a/opengever/base/tests/test_favorite.py
+++ b/opengever/base/tests/test_favorite.py
@@ -65,6 +65,20 @@ class TestFavoriteModel(IntegrationTestCase):
         self.assertFalse(
             Favorite.query.is_marked_as_favorite(self.dossier, self.regular_user))
 
+    def test_serialize_favorite_returns_unresolved_target_link_if_target_doesnt_exist_anymore(self):
+        self.login(self.manager)
+        favorite = create(Builder('favorite')
+                          .for_user(self.manager)
+                          .for_object(self.document))
+
+        self.assertEqual(self.document.absolute_url(),
+                         favorite.serialize(self.portal.absolute_url(), resolve=True)['target_url'])
+        favorite.serialize(self.portal.absolute_url(), resolve=True)
+
+        api.content.delete(self.document)
+        self.assertEqual(u'http://nohost/plone/resolve_oguid/plone:1014073300',
+                         favorite.serialize(self.portal.absolute_url(), resolve=True)['target_url'])
+
 
 class TestManager(IntegrationTestCase):
 


### PR DESCRIPTION
If an attempt is made to resolve a favorite that does not exist, an exception is raised. This exception has not been handled so far. Now the favorite is returned unresolved.

Jira: https://4teamwork.atlassian.net/browse/GEVER-868

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)