### PR TITLE
Add support for transferring inter-admin-unit tasks.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 
 - Add @share-content endpoint to share content in workspace. [tinagerber]
 - Add @actual-workspace-members endpoint. [tinagerber]
+- Add support for transferring inter-admin-unit tasks. [lgraf]
 - Prevent deadlock when reassigning inter-admin-unit tasks. [lgraf]
 - Preserves the query string for the redirect_to_parent_dossier view. [elioschmutz]
 - Preserves the query string for the redirect_to_main_dossier view. [elioschmutz]

--- a/opengever/api/tests/test_transfer_task.py
+++ b/opengever/api/tests/test_transfer_task.py
@@ -3,7 +3,12 @@ from ftw.builder import create
 from ftw.testbrowser import browsing
 from opengever.activity.model import Activity
 from opengever.activity.model import Notification
+from opengever.base.role_assignments import ASSIGNMENT_VIA_TASK
+from opengever.base.role_assignments import RoleAssignmentManager
+from opengever.task.browser.accept.utils import accept_task_with_successor
+from opengever.task.reminder import ReminderOneDayBefore
 from opengever.testing import IntegrationTestCase
+from opengever.testing.helpers import obj2brain
 import json
 
 
@@ -222,3 +227,180 @@ class TestTransferTaskPost(IntegrationTestCase):
         self.assertEqual(self.meeting_user.getId(), sql_task.issuer)
         activity = Activity.query.one()
         self.assertEqual('task-transition-change-issuer', activity.kind)
+
+
+class TestTransferTaskInterAdminUnit(IntegrationTestCase):
+
+    features = ('activity', )
+    maxDiff = None
+
+    def prepare_accepted_task_pair(self):
+        issuer_id = self.dossier_responsible.id
+        responsible_id = self.regular_user.id
+
+        predecessor = create(
+            Builder('task')
+            .within(self.dossier)
+            .having(issuer=issuer_id,
+                    responsible=responsible_id,
+                    responsible_client='fa',
+                    task_type='correction')
+            .in_state('task-state-open')
+            .titled(u'Inquiry from a concerned citizen'))
+        
+        successor = accept_task_with_successor(
+            self.dossier,
+            str(predecessor.oguid),
+            u'I accept this task',
+        )
+
+        # Set four reminders for both task side and both users 
+        for user_id in (issuer_id, responsible_id):
+            for task in (predecessor, successor):
+                task.set_reminder(ReminderOneDayBefore(), user_id=user_id)
+
+        return predecessor, successor
+
+    @browsing
+    def test_transfer_responsible_when_invoked_on_predecessor(self, browser):
+        self.login(self.regular_user, browser)
+
+        predecessor, successor = self.prepare_accepted_task_pair()
+        self.assert_transferred_properly(
+            browser,
+            fieldname='responsible',
+            local_task=predecessor,
+            remote_task=successor,
+        )
+
+    @browsing
+    def test_transfer_responsible_when_invoked_on_successor(self, browser):
+        self.login(self.regular_user, browser)
+
+        predecessor, successor = self.prepare_accepted_task_pair()
+        self.assert_transferred_properly(
+            browser,
+            fieldname='responsible',
+            local_task=successor,
+            remote_task=predecessor,
+        )
+
+    @browsing
+    def test_transfer_issuer_when_invoked_on_predecessor(self, browser):
+        self.login(self.regular_user, browser)
+
+        predecessor, successor = self.prepare_accepted_task_pair()
+        self.assert_transferred_properly(
+            browser,
+            fieldname='issuer',
+            local_task=predecessor,
+            remote_task=successor,
+        )
+
+    @browsing
+    def test_transfer_issuer_when_invoked_on_successor(self, browser):
+        self.login(self.regular_user, browser)
+
+        predecessor, successor = self.prepare_accepted_task_pair()
+        self.assert_transferred_properly(
+            browser,
+            fieldname='issuer',
+            local_task=successor,
+            remote_task=predecessor,
+        )
+
+    def assert_transferred_properly(self, browser, fieldname,
+                                    local_task, remote_task):
+        """This is the core for the test cases above.
+
+        Built with more abstract local and remote tasks that are passed in,
+        and a `fieldname` that refers to either 'responsible' or 'issuer',
+        so we can test different permutations (invocation from both sides
+        of a task pair, responsible vs. issuer).
+        """
+        self.login(self.administrator, browser)
+
+        new_userid = self.meeting_user.getId()
+        old_userid = getattr(local_task, fieldname)
+
+        with self.observe_notifications() as notifications, \
+                self.observe_reminders(local_task) as local_reminders, \
+                self.observe_reminders(remote_task) as remote_reminders, \
+                self.observe_responses(local_task) as local_responses, \
+                self.observe_responses(remote_task) as remote_responses:
+
+            browser.open(local_task.absolute_url() + '/@transfer-task',
+                         method='POST', headers=self.api_headers,
+                         data=json.dumps({
+                             "old_userid": old_userid,
+                             "new_userid": new_userid}
+            ))
+
+        # Verify that transfer happened on both sides of the task pair
+        for task in (local_task, remote_task):
+
+            # Field on dexterity object got updated
+            self.assertEqual(new_userid, getattr(task, fieldname))
+
+            # Metadata in catalog got updated
+            self.assertEqual(new_userid, getattr(obj2brain(task), fieldname))
+
+            # Attribute on SQL entity got updated
+            self.assertEqual(new_userid, getattr(task.get_sql_object(), fieldname))
+
+            # Local role assignments got transferred if responsible changed
+            if fieldname == 'responsible':
+                mgr = RoleAssignmentManager(task)
+                old_user_assignments = mgr.get_assignments_by_principal_id(old_userid)
+                new_user_assignments = mgr.get_assignments_by_principal_id(new_userid)
+                self.assertEqual(0, len(old_user_assignments))
+                self.assertEqual(1, len(new_user_assignments))
+
+                new_user_assignment = new_user_assignments[0]
+                self.assertEqual({
+                    'cause': {
+                        'id': ASSIGNMENT_VIA_TASK,
+                        'title': u'By task',
+                    },
+                    'principal': new_userid,
+                    'reference': {
+                        'title': task.title,
+                        'url': task.absolute_url(),
+                    },
+                    'roles': ['Editor']},
+                    new_user_assignment.serialize())
+
+        # Both sides contain appropriate responses
+        for responses in (local_responses, remote_responses):
+
+            # Exactly one new response got added
+            self.assertEqual(1, len(responses['added']))
+            response = responses['added'][0]
+
+            # With a change for the expected field, from old to new user
+            expected_changes = [{
+                'field_id': fieldname,
+                'field_title': u'label_%s' % fieldname,
+                'before': old_userid,
+                'after': new_userid,
+            }]
+            self.assertEqual(expected_changes, response.changes)
+
+            # Marked with the appropriate transition
+            if fieldname == 'responsible':
+                expected_transition = 'task-transition-reassign'
+
+            elif fieldname == 'issuer':
+                expected_transition = 'task-transition-change-issuer'
+
+            self.assertEqual(expected_transition, response.transition)
+
+            # Created by the Admin that performed the transfer
+            self.assertEqual(self.administrator.id, response.creator)
+
+        # Reminders for old user got removed, on both sides
+        for reminders in (local_reminders, remote_reminders):
+            self.assertEqual([old_userid], reminders['removed'])
+
+        # No notifications have been generated
+        self.assertEqual([], notifications['added'])

--- a/opengever/task/response_syncer/configure.zcml
+++ b/opengever/task/response_syncer/configure.zcml
@@ -25,6 +25,13 @@
       class=".deadline.ModifyDeadlineResponseSyncerReceiver"
       />
 
+  <browser:page
+      name="sync-task-issuer-change-response"
+      for="opengever.task.task.ITask"
+      permission="zope.Public"
+      class=".issuer_change.IssuerChangeResponseSyncerReceiver"
+      />
+
   <adapter
       factory=".comment.CommentResponseSyncerSender"
       for="opengever.task.task.ITask *"
@@ -43,6 +50,13 @@
       factory=".deadline.ModifyDeadlineResponseSyncerSender"
       for="opengever.task.task.ITask *"
       name="deadline"
+      provides="opengever.task.interfaces.IResponseSyncerSender"
+      />
+
+  <adapter
+      factory=".issuer_change.IssuerChangeResponseSyncerSender"
+      for="opengever.task.task.ITask *"
+      name="issuer-change"
       provides="opengever.task.interfaces.IResponseSyncerSender"
       />
 </configure>

--- a/opengever/task/response_syncer/issuer_change.py
+++ b/opengever/task/response_syncer/issuer_change.py
@@ -1,0 +1,79 @@
+from opengever.base.utils import ok_response
+from opengever.task.activities import TaskChangeIssuerActivity
+from opengever.task.response_syncer import BaseResponseSyncerReceiver
+from opengever.task.response_syncer import BaseResponseSyncerSender
+from opengever.task.response_syncer import ResponseSyncerSenderException
+from opengever.task.task import ITask
+from opengever.task.util import add_simple_response
+from zope.event import notify
+from zope.lifecycleevent import ObjectModifiedEvent
+
+
+class IssuerChangeResponseSyncerSender(BaseResponseSyncerSender):
+
+    TARGET_SYNC_VIEW_NAME = '@@sync-task-issuer-change-response'
+
+    def get_related_tasks_to_sync(self, transition):
+        if not self._is_synced_transition(transition):
+            return []
+
+        tasks = super(IssuerChangeResponseSyncerSender, self).get_related_tasks_to_sync(
+            transition)
+
+        # Skip forwardings. Issuer changes should never be synced to the
+        # predecessor forwarding, because a forwarding predecessor
+        # is always closed and stored in the yearfolder.
+        return [task for task in tasks if not task.is_forwarding]
+
+    def raise_sync_exception(self, task, transition, text, **kwargs):
+        raise ResponseSyncerSenderException(
+            'Could not transfer issuer for task on remote '
+            'admin unit {} ({})'.format(
+                task.admin_unit_id,
+                task.physical_path))
+
+    def _is_synced_transition(self, transition):
+        return transition in [
+            'task-transition-change-issuer',
+        ]
+
+
+class IssuerChangeResponseSyncerReceiver(BaseResponseSyncerReceiver):
+    """This view receives a @@sync-task-issuer-change-response request from
+    another admin unit after the issuer was changed on a successor or
+    predecessor task.
+    """
+
+    def __call__(self):
+        self._check_internal_request()
+
+        # This is a pseudo-transition. It's not an actual workflow transition,
+        # but just a translated string that is used to make it look like a
+        # state transition in the response timeline of the task.
+        transition = self.request.get('transition')
+        new_issuer = self.request.get('new_issuer')
+        text = self.request.get('text')
+
+        if self._is_already_done(transition, text):
+            return ok_response(self.request)
+
+        self._update(transition, new_issuer, text)
+        return ok_response(self.request)
+
+    def _update(self, transition, new_issuer, text):
+        """Updates the current task with the received data (new issuer).
+        """
+        self.context.clear_reminder(self.context.issuer)
+
+        changes = [(ITask['issuer'], new_issuer)]
+
+        issuer_response = add_simple_response(
+            self.context, transition=transition,
+            text=text, field_changes=changes,
+            supress_events=True)
+
+        self.context.issuer = new_issuer
+        notify(ObjectModifiedEvent(self.context))
+        TaskChangeIssuerActivity(self.context, self.context.REQUEST, issuer_response).record()
+
+        return issuer_response


### PR DESCRIPTION
This adds support for also transferring inter-admin-unit tasks using the `@transfer-tasks` endpoint.

For changing the `responsible`, the existing "reassign task" mechanism, which involves an actual workflow transition, is reused. For changing the `issuer`, that mechanism is emulated, and supported by a new `IssuerChangeResponseSyncerSender` that syncs the change to the remote side (without triggering an actual WF transition though, because there is none).

The situation for forwardings doesn't really change with the support for inter-admin-unit tasks, because forwardings can never be in a state where the predecessor forwarding is still open - therefore, no syncing of changes is required. 

## Checklist (Must have)

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

Jira: https://4teamwork.atlassian.net/browse/GEVER-541

## Checklist (if applicable)

- API change:
  - [x] Documentation is updated
  _(Not needed, checked)_

- New functionality:
  - [x] for `task` also works for `forwarding`

