### PR TITLE
Don't show workspace actions for non-open dossiers or when the user can only view.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 ---------------------
 
 - Add @successors and @predecessor expansion for tasks. [deiferni]
+- Don't show workspace actions for non-open dossiers or when the user can only view. [deiferni]
 - Add @share-content endpoint to share content in workspace. [tinagerber]
 - Add @actual-workspace-members endpoint. [tinagerber]
 - Add support for transferring inter-admin-unit tasks. [lgraf]

--- a/opengever/api/tests/test_actions.py
+++ b/opengever/api/tests/test_actions.py
@@ -698,7 +698,7 @@ class TestWorkspaceClientFolderActions(FunctionalWorkspaceClientTestCase):
             self.assert_workspace_actions_not_available(browser, self.dossier)
 
     @browsing
-    def test_workspaces_actions_only_available_if_user_has_permission(self, browser):
+    def test_workspaces_actions_only_available_if_user_has_permission_to_use_workspace_client(self, browser):
         browser.login()
         with self.workspace_client_env():
             self.link_workspace(self.dossier)
@@ -710,6 +710,37 @@ class TestWorkspaceClientFolderActions(FunctionalWorkspaceClientTestCase):
             self.grant(*roles)
 
             self.assert_workspace_actions_not_available(browser, self.dossier)
+
+    @browsing
+    def test_workspaces_actions_not_available_if_user_has_no_permission(self, browser):
+        browser.login()
+        with self.workspace_client_env():
+            self.link_workspace(self.dossier)
+
+            self.assert_workspace_actions_available(browser, self.dossier)
+
+            # global permissions are setup in a weird way
+            self.grant('WorkspaceClientUser', 'Member')
+            self.dossier.__ac_local_roles_block__ = True
+            self.grant('Reader', on=self.dossier)
+
+            self.assert_workspace_actions(browser, self.dossier,
+                                          [self.list_workspaces_action])
+
+    @browsing
+    def test_workspaces_actions_not_available_if_dossier_is_not_open(self, browser):
+        browser.login()
+        with self.workspace_client_env():
+            self.link_workspace(self.dossier)
+
+            #self.assert_workspace_actions_available(browser, self.dossier)
+
+            api.content.transition(obj=self.dossier,
+                                   transition='dossier-transition-deactivate')
+            transaction.commit()
+
+            self.assert_workspace_actions(browser, self.dossier,
+                                          [self.list_workspaces_action])
 
 
 class TestObjectButtonsGetForDocuments(ObjectButtonsTestBase):

--- a/opengever/api/tests/test_actions.py
+++ b/opengever/api/tests/test_actions.py
@@ -632,15 +632,21 @@ class TestWorkspaceClientFolderActions(FunctionalWorkspaceClientTestCase):
         manager.storage.add(self.workspace.UID())
         transaction.commit()
 
-    def assert_workspace_actions_available(self, browser, dossier):
-        actions = self.get_actions(browser, dossier)
-        for action in self.workspace_actions:
-            self.assertIn(action, actions)
+    def assert_workspace_actions(self, browser, context, expected):
+        all_actions = self.get_actions(browser, context)
+        workspace_action_ids = {each['id'] for each in self.workspace_actions}
+        available = [
+            action for action in all_actions
+            if action['id'] in workspace_action_ids
+        ]
 
-    def assert_workspace_actions_not_available(self, browser, dossier):
-        actions = self.get_actions(browser, dossier)
-        for action in self.workspace_actions:
-            self.assertNotIn(action, actions)
+        self.assertEqual(sorted(available), sorted(expected))
+
+    def assert_workspace_actions_available(self, browser, context):
+        self.assert_workspace_actions(browser, context, self.workspace_actions)
+
+    def assert_workspace_actions_not_available(self, browser, context):
+        self.assert_workspace_actions(browser, context, [])
 
     @browsing
     def test_copy_documents_actions_available_in_dossier_with_linked_workspaces(self, browser):

--- a/opengever/base/browser/folder_buttons_availability.py
+++ b/opengever/base/browser/folder_buttons_availability.py
@@ -31,6 +31,20 @@ class FolderButtonsAvailabilityView(BrowserView):
 
         return True
 
+    def _is_open_dossier(self):
+        if not IDossierMarker.providedBy(self.context):
+            return False
+
+        return self.context.is_open()
+
+    def _can_modify_dossier(self):
+        return api.user.has_permission(
+            'Modify portal content', obj=self.context)
+
+    def _can_add_content_to_dossier(self):
+        return api.user.has_permission(
+            'Add portal content', obj=self.context)
+
     def _can_use_workspace_client(self):
         return (is_workspace_client_feature_available()
                 and api.user.has_permission('opengever.workspaceclient: '
@@ -43,6 +57,9 @@ class FolderButtonsAvailabilityView(BrowserView):
         if not self._is_main_dossier():
             return False
 
+        if not self._is_open_dossier():
+            return False
+
         if not self._can_use_workspace_client():
             return False
 
@@ -53,7 +70,13 @@ class FolderButtonsAvailabilityView(BrowserView):
         return self._is_main_dossier() and self._can_use_workspace_client()
 
     def is_copy_documents_to_workspace_available(self):
-        return self._can_copy_between_workspace_and_dossier()
+        return (
+            self._can_copy_between_workspace_and_dossier()
+            and self._can_modify_dossier()
+        )
 
     def is_copy_documents_from_workspace_available(self):
-        return self._can_copy_between_workspace_and_dossier()
+        return (
+            self._can_copy_between_workspace_and_dossier()
+            and self._can_add_content_to_dossier()
+        )


### PR DESCRIPTION
Don't display actions to transfer documents from and to a teamraum when the dossier is not open or when the user does not have permissions to modify the dossier or add content to the dossier.

Jira: https://4teamwork.atlassian.net/browse/GEVER-953


## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
