### PR TITLE
Add task `@predecessor` and  @`successors` expansion.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2020.8.1 (unreleased)
 ---------------------
 
+- Add @successors and @predecessor expansion for tasks. [deiferni]
 - Add @share-content endpoint to share content in workspace. [tinagerber]
 - Add @actual-workspace-members endpoint. [tinagerber]
 - Add support for transferring inter-admin-unit tasks. [lgraf]

--- a/docs/public/dev-manual/api/tasks.rst
+++ b/docs/public/dev-manual/api/tasks.rst
@@ -530,3 +530,83 @@ Die Aufgabenhierarchie kann auch direkt über den GET-Request eines Tasks mittel
 
      GET http://example.org/ordnungssystem/fuehrung/dossier-1/task-1?expand=tasktree HTTP/1.1
      Accept: application/json
+
+
+Ursprüngliche Aufgabe
+---------------------
+Bei mandantenübergreifenden Aufgaben kann bei einer Aufgabe die ursprüngliche Aufgabe
+(Vorgänger) abgefragt werden. Dazu steht ein spezifischer Endpoint `@predecessor` zur Verfügung.
+
+**Beispiel-Request**:
+
+   .. sourcecode:: http
+
+      GET http://example.org/ordnungssystem/fuehrung/dossier-1/task-2/@predecessor HTTP/1.1
+      Accept: application/json
+
+**Beispiel-Response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 200 OK
+      Content-Type: application/json
+
+      {
+        "@id": "http://example.org/ordnungssystem/fuehrung/dossier-1/task-2/@predecessor",
+        "item": {
+          "@id": "http://example.org/ordnungssystem/fuehrung/dossier-1/task-1",
+          "@type": "opengever.task.task",
+          "oguid": "fd:1234",
+          "review_state": "task-state-in-progress",
+          "task_id": 1234,
+          "task_type": "Zum Bericht / Antrag",
+          "title": "Eine Aufgabe"
+        }
+      }
+
+Die ursprüngliche Aufgabe kann auch direkt über den GET-Request eines Tasks mittels Expansion angefordert werden.
+
+  .. sourcecode:: http
+
+     GET http://example.org/ordnungssystem/fuehrung/dossier-1/task-2?expand=predecessor HTTP/1.1
+     Accept: application/json
+
+
+Kopierte Aufgabe
+----------------
+Bei mandantenübergreifenden Aufgaben können bei einer Aufgabe die kopierten Aufgaben
+(Nachfolger) abgefragt werden. Dazu steht ein spezifischer Endpoint `@successors` zur Verfügung.
+
+**Beispiel-Request**:
+
+   .. sourcecode:: http
+
+      GET http://example.org/ordnungssystem/fuehrung/dossier-1/task-1/@successors HTTP/1.1
+      Accept: application/json
+
+**Beispiel-Response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 200 OK
+      Content-Type: application/json
+
+      {
+        "@id": "http://example.org/ordnungssystem/fuehrung/dossier-1/task-1/@successors",
+        "items": [{
+          "@id": "http://example.org/ordnungssystem/fuehrung/dossier-1/task-2",
+          "@type": "opengever.task.task",
+          "oguid": "fd:2345",
+          "review_state": "task-state-in-progress",
+          "task_id": 2345,
+          "task_type": "Zum Bericht / Antrag",
+          "title": "Eine Aufgabe"
+        }]
+      }
+
+Die kopierten Aufgaben können auch direkt über den GET-Request eines Tasks mittels Expansion angefordert werden.
+
+  .. sourcecode:: http
+
+     GET http://example.org/ordnungssystem/fuehrung/dossier-1/task-1?expand=successors HTTP/1.1
+     Accept: application/json

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -40,6 +40,7 @@
   <adapter factory=".task.SerializeTaskToJson" />
   <adapter factory=".task.SerializeTaskResponseToJson" />
   <adapter factory=".task.TaskDeserializeFromJson" />
+  <adapter factory=".task.SerializeTaskModelToJson" />
   <adapter factory=".users.SerializeUserToJson" />
   <adapter factory=".proposal.SerializeProposalResponseToJson" />
   <adapter factory=".proposal.SerializeProposalToJson" />

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -869,6 +869,19 @@
       name="predecessor"
       />
 
+  <plone:service
+      method="GET"
+      name="@successors"
+      for="opengever.task.task.ITask"
+      factory=".task.TaskSuccessorsGet"
+      permission="zope2.View"
+      />
+
+  <adapter
+      factory=".task.TaskSuccessors"
+      name="successors"
+      />
+
   <adapter
       factory=".dossier.MainDossier"
       name="main-dossier"

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -41,6 +41,7 @@
   <adapter factory=".task.SerializeTaskResponseToJson" />
   <adapter factory=".task.TaskDeserializeFromJson" />
   <adapter factory=".task.SerializeTaskModelToJson" />
+  <adapter factory=".task.SerializeTaskModelToJsonSummary" />
   <adapter factory=".users.SerializeUserToJson" />
   <adapter factory=".proposal.SerializeProposalResponseToJson" />
   <adapter factory=".proposal.SerializeProposalToJson" />

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -856,6 +856,19 @@
       name="tasktree"
       />
 
+  <plone:service
+      method="GET"
+      name="@predecessor"
+      for="opengever.task.task.ITask"
+      factory=".task.TaskPredecessorGet"
+      permission="zope2.View"
+      />
+
+  <adapter
+      factory=".task.TaskPredecessor"
+      name="predecessor"
+      />
+
   <adapter
       factory=".dossier.MainDossier"
       name="main-dossier"

--- a/opengever/api/tests/test_task_predecessor.py
+++ b/opengever/api/tests/test_task_predecessor.py
@@ -1,0 +1,96 @@
+from ftw.testbrowser import browsing
+from opengever.base.oguid import Oguid
+from opengever.testing import IntegrationTestCase
+
+
+class TestTaskPredecessorGet(IntegrationTestCase):
+
+    maxDiff = None
+
+    @browsing
+    def test_get_predecessor_for_task(self, browser):
+        self.login(self.regular_user, browser=browser)
+        self.register_successor(self.task, self.expired_task)
+        browser.open(
+            self.expired_task, view="@predecessor", method="GET",
+            headers=self.api_headers
+        )
+        expected = {
+            '@id': u'{}/@predecessor'.format(self.expired_task.absolute_url()),
+            'item': {
+                u'@id': self.task.absolute_url(),
+                u'@type': u'opengever.task.task',
+                u'oguid': Oguid.for_object(self.task).id,
+                u'review_state': u'task-state-in-progress',
+                u'task_type': u'For confirmation / correction',
+                u'title': u'Vertragsentwurf \xdcberpr\xfcfen',
+            }
+        }
+        actual = browser.json
+        self.assertIn('task_id', actual['item'])
+        del actual['item']['task_id']
+        self.assertEqual(expected, actual)
+
+    @browsing
+    def test_get_predecessor_for_forwarding(self, browser):
+        self.login(self.secretariat_user, browser=browser)
+        self.register_successor(self.task, self.inbox_forwarding)
+        browser.open(
+            self.inbox_forwarding, view="@predecessor", method="GET",
+            headers=self.api_headers
+        )
+        expected = {
+            '@id': u'{}/@predecessor'.format(self.inbox_forwarding.absolute_url()),
+            'item': {
+                u'@id': self.task.absolute_url(),
+                u'@type': u'opengever.task.task',
+                u'oguid': Oguid.for_object(self.task).id,
+                u'review_state': u'task-state-in-progress',
+                u'task_type': u'For confirmation / correction',
+                u'title': u'Vertragsentwurf \xdcberpr\xfcfen',
+            }
+        }
+        actual = browser.json
+        self.assertIn('task_id', actual['item'])
+        del actual['item']['task_id']
+        self.assertEqual(expected, actual)
+
+    @browsing
+    def test_get_predecessor_for_task_without_predecessor(self, browser):
+        self.login(self.regular_user, browser=browser)
+        browser.open(
+            self.expired_task, view="@predecessor", method="GET",
+            headers=self.api_headers
+        )
+        expected = {
+            '@id': u'{}/@predecessor'.format(self.expired_task.absolute_url()),
+            'item': None,
+        }
+        actual = browser.json
+        self.assertEqual(expected, actual)
+
+    @browsing
+    def test_get_task_with_predecessor_expansion(self, browser):
+        self.login(self.regular_user, browser=browser)
+        self.register_successor(self.task, self.expired_task)
+        browser.open(
+            self.expired_task, view="?expand=predecessor", method="GET",
+            headers=self.api_headers
+        )
+
+        self.assertIn('predecessor', browser.json['@components'])
+        expected = {
+            '@id': u'{}/@predecessor'.format(self.expired_task.absolute_url()),
+            'item': {
+                u'@id': self.task.absolute_url(),
+                u'@type': u'opengever.task.task',
+                u'oguid': Oguid.for_object(self.task).id,
+                u'review_state': u'task-state-in-progress',
+                u'task_type': u'For confirmation / correction',
+                u'title': u'Vertragsentwurf \xdcberpr\xfcfen',
+            }
+        }
+        actual = browser.json['@components']['predecessor']
+        self.assertIn('task_id', actual['item'])
+        del actual['item']['task_id']
+        self.assertEqual(expected, actual)

--- a/opengever/api/tests/test_task_successor.py
+++ b/opengever/api/tests/test_task_successor.py
@@ -1,0 +1,99 @@
+from ftw.testbrowser import browsing
+from opengever.base.oguid import Oguid
+from opengever.testing import IntegrationTestCase
+
+
+class TestTaskSuccessorsGet(IntegrationTestCase):
+
+    maxDiff = None
+
+    @browsing
+    def test_get_successors_for_task(self, browser):
+        self.login(self.regular_user, browser=browser)
+        self.register_successor(self.task, self.expired_task)
+        browser.open(
+            self.task, view="@successors", method="GET",
+            headers=self.api_headers
+        )
+
+        expected = {
+            '@id': u'{}/@successors'.format(self.task.absolute_url()),
+            'items': [{
+                u'@id': self.expired_task.absolute_url(),
+                u'@type': u'opengever.task.task',
+                u'oguid': Oguid.for_object(self.expired_task).id,
+                u'review_state': u'task-state-resolved',
+                u'task_type': u'For confirmation / correction',
+                u'title': u'Vertr\xe4ge abschliessen',
+            }]
+        }
+        actual = browser.json
+        self.assertIn('task_id', actual['items'][0])
+        del actual['items'][0]['task_id']
+        self.assertEqual(expected, actual)
+
+    @browsing
+    def test_get_successors_for_forwarding(self, browser):
+        self.login(self.secretariat_user, browser=browser)
+        self.register_successor(self.inbox_forwarding, self.expired_task)
+        browser.open(
+            self.inbox_forwarding, view="@successors", method="GET",
+            headers=self.api_headers
+        )
+
+        expected = {
+            '@id': u'{}/@successors'.format(self.inbox_forwarding.absolute_url()),
+            'items': [{
+                u'@id': self.expired_task.absolute_url(),
+                u'@type': u'opengever.task.task',
+                u'oguid': Oguid.for_object(self.expired_task).id,
+                u'review_state': u'task-state-resolved',
+                u'task_type': u'For confirmation / correction',
+                u'title': u'Vertr\xe4ge abschliessen',
+            }]
+        }
+        actual = browser.json
+        self.assertIn('task_id', actual['items'][0])
+        del actual['items'][0]['task_id']
+        self.assertEqual(expected, actual)
+
+    @browsing
+    def test_get_successors_for_task_without_successors(self, browser):
+        self.login(self.regular_user, browser=browser)
+        browser.open(
+            self.task, view="@successors", method="GET",
+            headers=self.api_headers
+        )
+
+        expected = {
+            '@id': u'{}/@successors'.format(self.task.absolute_url()),
+            'items': [],
+        }
+        actual = browser.json
+        self.assertEqual(expected, actual)
+
+    @browsing
+    def test_get_task_with_successors_expansion(self, browser):
+        self.login(self.regular_user, browser=browser)
+        self.register_successor(self.task, self.expired_task)
+        browser.open(
+            self.task, view="?expand=successors", method="GET",
+            headers=self.api_headers
+        )
+
+        self.assertIn('successors', browser.json['@components'])
+        expected = {
+            '@id': u'{}/@successors'.format(self.task.absolute_url()),
+            'items': [{
+                u'@id': self.expired_task.absolute_url(),
+                u'@type': u'opengever.task.task',
+                u'oguid': Oguid.for_object(self.expired_task).id,
+                u'review_state': u'task-state-resolved',
+                u'task_type': u'For confirmation / correction',
+                u'title': u'Vertr\xe4ge abschliessen',
+            }]
+        }
+        actual = browser.json['@components']['successors']
+        self.assertIn('task_id', actual['items'][0])
+        del actual['items'][0]['task_id']
+        self.assertEqual(expected, actual)

--- a/opengever/globalindex/model/task.py
+++ b/opengever/globalindex/model/task.py
@@ -175,6 +175,17 @@ class Task(Base):
     def issuing_org_unit_label(self):
         return self.get_issuing_org_unit().label()
 
+    @property
+    def content_type(self):
+        """Figure out a tasks content type from the task_type column.
+
+        We don't store the content type in globalindex but task_type is
+        distinct and we can use it to figure out the content type.
+        """
+        if self.task_type == FORWARDING_TASK_TYPE_ID:
+            return 'opengever.inbox.forwarding'
+        return 'opengever.task.task'
+
     def get_admin_unit(self):
         return ogds_service().fetch_admin_unit(self.admin_unit_id)
 


### PR DESCRIPTION
With this PR we add `@predecessor` and  @`successors` expansion to tasks. This helps the UI to display predecessors/successors for inter-admin-unit tasks.

I've seen that currenlty the `@globalindex` endpoint had implemented its own serialization, bypassing the `ISerializeToJson` and `ISerializeToJsonSummary` adapters introduced by `plone.restapi`. With this PR i have refactored the existing functionality to provide such adapters.

Decisions/thoughts:
- After some back and forth i've decided to put all functionality into `opengever.api.task` but of course that can be changed.
- After some more back and forth i've decided to nest the tasks as `items` and `item` respectively. This could be changed to the explicit `successors` and `predecessors` but i did not like the repetition.
- Task serialization as used by `@globalindex` was not changed, this means that some columns are deliberately not exposed. I'm not sure why that is the case in the first place, but to keep this a pure refactoring I kept the behavior.

Jira: https://4teamwork.atlassian.net/browse/PHX-9


## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


## Checklist (if applicable)

_Only applicable should be left and checked._

- API change:
  - [x] Documentation is updated
- New functionality:
  - [x] for `task` also works for `forwarding`
