### PR TITLE
Deactivate workspace

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -646,6 +646,7 @@ Objects
       - self.todolist_introduction
         - self.assigned_todo
         - self.completed_todo
+      - self.workspace_document
       - self.workspace_folder
 
 .. </fixture:objects>

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -20,6 +20,7 @@ Changelog
 - Consider cookie when figuring out current orgunit in AllUsersInboxesAndTeamsSource. [deiferni]
 - Fix forwarding requiring task_type in API, fix forwarding task_type translations. [deiferni]
 - Add @type to @globalindex items, figure out portal type from task type. [deiferni]
+- Add option to deactivate a workspace. [buchi]
 
 
 2020.8.1 (2020-09-07)

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -524,6 +524,15 @@
       />
 
   <plone:service
+      method="POST"
+      name="@workflow"
+      for="opengever.workspace.interfaces.IWorkspace"
+      factory=".transition.WorkspaceWorkflowTransition"
+      layer="opengever.base.interfaces.IOpengeverBaseLayer"
+      permission="zope2.View"
+      />
+
+  <plone:service
       method="GET"
       name="@invitations"
       for="opengever.workspace.interfaces.IWorkspace"

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -61,6 +61,20 @@
       />
 
   <plone:service
+      method="DELETE"
+      for="opengever.workspace.interfaces.IToDo"
+      factory=".todo.TodoDelete"
+      permission="opengever.workspace.DeleteTodos"
+      />
+
+  <plone:service
+      method="DELETE"
+      for="opengever.workspace.interfaces.IToDoList"
+      factory=".todo.TodoDelete"
+      permission="opengever.workspace.DeleteTodos"
+      />
+
+  <plone:service
       method="POST"
       name="@checkout"
       for="opengever.document.document.IDocumentSchema"

--- a/opengever/api/tests/test_globalindex.py
+++ b/opengever/api/tests/test_globalindex.py
@@ -90,7 +90,7 @@ class TestGlobalIndexGet(IntegrationTestCase):
 
         self.assertEqual(15, browser.json['items_total'])
         self.assertEqual(u'Ein notwendiges \xdcbel', browser.json['items'][0]['title'])
-        self.assertEqual(u'2016-08-31T20:25:33', browser.json['items'][0]['modified'])
+        self.assertEqual(u'2016-08-31T20:27:33', browser.json['items'][0]['modified'])
 
     @browsing
     def test_filter_by_single_value(self, browser):

--- a/opengever/api/todo.py
+++ b/opengever/api/todo.py
@@ -1,3 +1,4 @@
+from Acquisition import aq_parent
 from opengever.api.move import Move
 from opengever.base.response import AutoResponseChangesTracker
 from opengever.base.response import IResponseContainer
@@ -5,8 +6,10 @@ from opengever.base.response import MOVE_RESPONSE_TYPE
 from opengever.base.response import Response
 from opengever.workspace.interfaces import IToDo
 from opengever.workspace.interfaces import IToDoList
+from plone.app.linkintegrity.exceptions import LinkIntegrityNotificationException
 from plone.restapi.deserializer import json_body
 from plone.restapi.deserializer.dxcontent import DeserializeFromJson
+from plone.restapi.services import Service
 from zope.component import adapter
 from zope.interface import Interface
 
@@ -65,3 +68,17 @@ class ToDoMove(Move):
 
     def _get_changes_text(self, obj):
         return obj.title if IToDoList.providedBy(obj) else ''
+
+
+class TodoDelete(Service):
+    """Deletes todos and todo lists."""
+
+    def reply(self):
+
+        parent = aq_parent(self.context)
+        try:
+            parent._delObject(self.context.getId())
+        except LinkIntegrityNotificationException:
+            pass
+
+        return self.reply_no_content()

--- a/opengever/base/tests/test_contentlisting.py
+++ b/opengever/base/tests/test_contentlisting.py
@@ -240,7 +240,7 @@ class TestOpengeverContentListing(IntegrationTestCase):
         self.assertEqual(
             IContentListingObject(obj2brain(
                 self.dossier)).ModificationDate(),
-            '2016-08-31T20:15:33+02:00')
+            '2016-08-31T20:17:33+02:00')
 
     def test_translated_review_state(self):
         self.login(self.regular_user)

--- a/opengever/contentstats/filters.py
+++ b/opengever/contentstats/filters.py
@@ -90,6 +90,8 @@ class ReviewStatesFilter(object):
             for wf_id in wftool.getChainForPortalType(fti.id):
                 wf = wftool[wf_id]
                 states_to_keep.extend(wf.states.objectIds())
+        # Placeful workflows are not covered by the above code.
+        states_to_keep.append('opengever_workspace_document--STATUS--active')
         return states_to_keep
 
     def keep(self, key):

--- a/opengever/contentstats/tests/test_content_stats_integration.py
+++ b/opengever/contentstats/tests/test_content_stats_integration.py
@@ -91,6 +91,7 @@ class TestContentStatsIntegration(IntegrationTestCase):
             'opengever_period_workflow--STATUS--active',
             'opengever_workspace--STATUS--active',
             'opengever_workspace--STATUS--inactive',
+            'opengever_workspace_document--STATUS--active',
             'opengever_workspace_folder--STATUS--active',
             'opengever_workspace_todo--STATUS--active',
             'opengever_workspace_todolist--STATUS--active',

--- a/opengever/contentstats/tests/test_content_stats_integration.py
+++ b/opengever/contentstats/tests/test_content_stats_integration.py
@@ -167,10 +167,10 @@ class TestContentStatsIntegration(IntegrationTestCase):
     def test_checked_out_docs_stats_provider(self):
         self.login(self.regular_user)
         stats_provider = getMultiAdapter((self.portal, self.portal.REQUEST), IStatsProvider, name='checked_out_docs')
-        self.assertEqual({'checked_out': 0, 'checked_in': 40}, stats_provider.get_raw_stats())
+        self.assertEqual({'checked_out': 0, 'checked_in': 41}, stats_provider.get_raw_stats())
 
         self.checkout_document(self.document)
-        self.assertEqual({'checked_out': 1, 'checked_in': 39}, stats_provider.get_raw_stats())
+        self.assertEqual({'checked_out': 1, 'checked_in': 40}, stats_provider.get_raw_stats())
 
     def test_file_mimetypes_provider(self):
         stats_provider = getMultiAdapter((self.portal, self.portal.REQUEST), IStatsProvider, name='file_mimetypes')
@@ -208,12 +208,12 @@ class TestContentStatsIntegration(IntegrationTestCase):
         self.login(self.manager, browser)
         browser.open(view='@@content-stats')
         table = browser.css('#content-stats-checked_out_docs').first
-        self.assertEqual([['', 'checked_in', '40'], ['', 'checked_out', '0']], table.lists())
+        self.assertEqual([['', 'checked_in', '41'], ['', 'checked_out', '0']], table.lists())
 
         self.checkout_document(self.document)
         browser.open(self.portal, view='@@content-stats')
         table = browser.css('#content-stats-checked_out_docs').first
-        self.assertEqual([['', 'checked_in', '39'], ['', 'checked_out', '1']], table.lists())
+        self.assertEqual([['', 'checked_in', '40'], ['', 'checked_out', '1']], table.lists())
 
     def test_gever_portal_types_contains_base_documents(self):
         stats_provider = getMultiAdapter((self.portal, self.portal.REQUEST), IStatsProvider, name='portal_types')

--- a/opengever/contentstats/tests/test_content_stats_integration.py
+++ b/opengever/contentstats/tests/test_content_stats_integration.py
@@ -90,6 +90,7 @@ class TestContentStatsIntegration(IntegrationTestCase):
             'opengever_committee_workflow--STATUS--inactive',
             'opengever_period_workflow--STATUS--active',
             'opengever_workspace--STATUS--active',
+            'opengever_workspace--STATUS--inactive',
             'opengever_workspace_folder--STATUS--active',
             'opengever_workspace_todo--STATUS--active',
             'opengever_workspace_todolist--STATUS--active',

--- a/opengever/core/lawgiver.zcml
+++ b/opengever/core/lawgiver.zcml
@@ -285,6 +285,7 @@
       permissions="
                    opengever.workspace: Update Content Order,
                    opengever.workspace: Modify Workspace,
+                   opengever.workspace: Delete Todos,
                    "
       />
 
@@ -371,6 +372,11 @@
     <lawgiver:map_permissions
         action_group="modify workspace"
         permissions="opengever.workspace: Modify Workspace"
+        />
+
+    <lawgiver:map_permissions
+        action_group="delete todos"
+        permissions="opengever.workspace: Delete Todos"
         />
 
   </lawgiver:workflow>

--- a/opengever/core/lawgiver.zcml
+++ b/opengever/core/lawgiver.zcml
@@ -395,6 +395,8 @@
                      opengever.document: Checkin,
                      opengever.document: Checkout,
                      opengever.document: Force Checkin,
+                     ftw.mail: Add Mail,
+                     ftw.mail: Add Inbound Mail,
                      Add portal content,
                      Modify portal content,
                      "

--- a/opengever/core/lawgiver.zcml
+++ b/opengever/core/lawgiver.zcml
@@ -383,6 +383,14 @@
                      Sharing page: Delegate CommitteeResponsible role,
                      Sharing page: Delegate MeetingUser role,
                      opengever.workspace: Add Workspace,
+                     opengever.workspace: Add WorkspaceFolder,
+                     opengever.document: Add document,
+                     opengever.document: Cancel,
+                     opengever.document: Checkin,
+                     opengever.document: Checkout,
+                     opengever.document: Force Checkin,
+                     Add portal content,
+                     Modify portal content,
                      "
         />
     <lawgiver:map_permissions
@@ -396,10 +404,23 @@
   </lawgiver:workflow>
 
   <lawgiver:workflow name="opengever_workspace_todolist">
+    <lawgiver:ignore
+        permissions="
+                     Add portal content,
+                     Modify portal content,
+                     Delete objects,
+                     "
+        />
 
-    <lawgiver:map_permissions
-        action_group="delete"
-        permissions="Delete objects"
+  </lawgiver:workflow>
+
+  <lawgiver:workflow name="opengever_workspace_todo">
+    <lawgiver:ignore
+        permissions="
+                     Add portal content,
+                     Modify portal content,
+                     Delete objects,
+                     "
         />
 
   </lawgiver:workflow>

--- a/opengever/core/lawgiver.zcml
+++ b/opengever/core/lawgiver.zcml
@@ -397,10 +397,24 @@
         action_group="soft delete"
         permissions="Remove GEVER content"
         />
-    <lawgiver:map_permissions
-        action_group="add"
-        permissions="opengever.workspace: Add WorkspaceFolder"
+
+  </lawgiver:workflow>
+
+  <lawgiver:workflow name="opengever_workspace_document">
+    <lawgiver:ignore
+        permissions="
+                     opengever.document: Cancel,
+                     opengever.document: Checkin,
+                     opengever.document: Checkout,
+                     opengever.document: Force Checkin,
+                     Modify portal content,
+                     "
         />
+    <lawgiver:map_permissions
+        action_group="soft delete"
+        permissions="Remove GEVER content"
+        />
+
   </lawgiver:workflow>
 
   <lawgiver:workflow name="opengever_workspace_todolist">

--- a/opengever/core/lawgiver.zcml
+++ b/opengever/core/lawgiver.zcml
@@ -282,7 +282,10 @@
 
   <!-- Ignore only relevant in workspace workflow-->
   <lawgiver:ignore
-      permissions="opengever.workspace: Update Content Order"
+      permissions="
+                   opengever.workspace: Update Content Order,
+                   opengever.workspace: Modify Workspace,
+                   "
       />
 
   <lawgiver:workflow name="opengever_committeecontainer_workflow">
@@ -363,6 +366,11 @@
     <lawgiver:map_permissions
         action_group="update_order"
         permissions="opengever.workspace: Update Content Order"
+        />
+
+    <lawgiver:map_permissions
+        action_group="modify workspace"
+        permissions="opengever.workspace: Modify Workspace"
         />
 
   </lawgiver:workflow>

--- a/opengever/core/locales/de/LC_MESSAGES/opengever.core.po
+++ b/opengever/core/locales/de/LC_MESSAGES/opengever.core.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2020-09-01 07:50+0000\n"
+"POT-Creation-Date: 2020-09-03 12:37+0000\n"
 "PO-Revision-Date: 2017-09-18 15:21+0200\n"
 "Last-Translator: Philippe Gross <p.gross@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -331,6 +331,7 @@ msgstr "Freigabe von ungebrauchten Aktenzeichen Prefixen."
 
 #: ./opengever/core/profiles/default/types/opengever.workspace.workspace.xml
 #: ./opengever/core/upgrades/20171213174551_add_workspace_content_type/types/opengever.workspace.workspace.xml
+#: ./opengever/core/upgrades/20200827114625_update_workspace_workflow/types/opengever.workspace.workspace.xml
 msgid "Workspace"
 msgstr "Teamraum"
 

--- a/opengever/core/locales/de/LC_MESSAGES/plone.po
+++ b/opengever/core/locales/de/LC_MESSAGES/plone.po
@@ -36,6 +36,7 @@ msgstr "Beispiels-Sitzungsdaten einfüllen"
 
 #. Default: "Inactive"
 #: opengever/core/profiles/default/workflows/opengever_committee_workflow/specification.txt
+#: opengever/core/profiles/default/workflows/opengever_workspace/specification.txt
 msgid "Inactive"
 msgstr "Inaktiv"
 
@@ -44,6 +45,7 @@ msgstr "Reaktivieren"
 
 #. Default: "deactivate"
 #: opengever/core/profiles/default/workflows/opengever_committee_workflow/specification.txt
+#: opengever/core/profiles/default/workflows/opengever_workspace/specification.txt
 msgid "deactivate"
 msgstr "Deaktivieren"
 
@@ -197,6 +199,66 @@ msgstr "Teammitglieder haben lesenden und schreibenden Zugriff auf alle Inhalte.
 msgid "opengever_workspace--STATUS--active"
 msgstr "Aktiv"
 
+#. Default: "Inactive"
+#: opengever/core/profiles/default/workflows/opengever_workspace/specification.txt
+msgid "opengever_workspace--STATUS--inactive"
+msgstr "Inaktiv"
+
+#. Default: "deactivate"
+#: opengever/core/profiles/default/workflows/opengever_workspace/specification.txt
+msgid "opengever_workspace--TRANSITION--deactivate--active_inactive"
+msgstr "Deaktivieren"
+
+#. Default: "reactivate"
+#: opengever/core/profiles/default/workflows/opengever_workspace/specification.txt
+msgid "opengever_workspace--TRANSITION--reactivate--inactive_active"
+msgstr "Reaktivieren"
+
+#. Default: "admin"
+#: opengever/core/profiles/default/workflows/opengever_workspace_document/specification.txt
+msgid "opengever_workspace_document--ROLE--Administrator"
+msgstr "Administrator"
+
+#. Default: "systems administrator"
+#: opengever/core/profiles/default/workflows/opengever_workspace_document/specification.txt
+msgid "opengever_workspace_document--ROLE--Manager"
+msgstr "System Administrator"
+
+#. Default: "workspace admin"
+#: opengever/core/profiles/default/workflows/opengever_workspace_document/specification.txt
+msgid "opengever_workspace_document--ROLE--WorkspaceAdmin"
+msgstr "Admin"
+
+#. Default: "workspace guest"
+#: opengever/core/profiles/default/workflows/opengever_workspace_document/specification.txt
+msgid "opengever_workspace_document--ROLE--WorkspaceGuest"
+msgstr "Gast"
+
+#. Default: "workspace member"
+#: opengever/core/profiles/default/workflows/opengever_workspace_document/specification.txt
+msgid "opengever_workspace_document--ROLE--WorkspaceMember"
+msgstr "Teammitglied"
+
+#. Default: "Workspace admins can manage the team as well as read and modify all contents."
+#: opengever/core/profiles/default/workflows/opengever_workspace_document/specification.txt
+msgid "opengever_workspace_document--ROLE-DESCRIPTION--WorkspaceAdmin"
+msgstr "Admins verwalten die Teammitglieder und haben lesenden und schreibenden Zugriff auf alle Inhalte."
+
+#. Default: "A workspace guest has read access to the content but cannot change anything."
+#: opengever/core/profiles/default/workflows/opengever_workspace_document/specification.txt
+msgid "opengever_workspace_document--ROLE-DESCRIPTION--WorkspaceGuest"
+msgstr "Gäste haben lesenden Zugriff auf alle Inhalten, können aber keine Inhalte verändern."
+
+#. Default: "Workspace members can read and modify all contents of the workspace."
+#: opengever/core/profiles/default/workflows/opengever_workspace_document/specification.txt
+msgid "opengever_workspace_document--ROLE-DESCRIPTION--WorkspaceMember"
+msgstr "Teammitglieder haben lesenden und schreibenden Zugriff auf alle Inhalte."
+
+#. Default: "Active"
+#: opengever/core/profiles/default/workflows/opengever_workspace_document/specification.txt
+msgid "opengever_workspace_document--STATUS--active"
+msgstr "Aktiv"
+
 #. Default: "admin"
 #: opengever/core/profiles/default/workflows/opengever_workspace_folder/specification.txt
 msgid "opengever_workspace_folder--ROLE--Administrator"
@@ -339,6 +401,7 @@ msgstr "Aktiv"
 
 #. Default: "reactivate"
 #: opengever/core/profiles/default/workflows/opengever_committee_workflow/specification.txt
+#: opengever/core/profiles/default/workflows/opengever_workspace/specification.txt
 msgid "reactivate"
 msgstr "reaktivieren"
 

--- a/opengever/core/locales/en/LC_MESSAGES/plone.po
+++ b/opengever/core/locales/en/LC_MESSAGES/plone.po
@@ -20,11 +20,13 @@ msgstr "Active"
 
 #. Default: "Inactive"
 #: opengever/core/profiles/default/workflows/opengever_committee_workflow/specification.txt
+#: opengever/core/profiles/default/workflows/opengever_workspace/specification.txt
 msgid "Inactive"
 msgstr "Inactive"
 
 #. Default: "deactivate"
 #: opengever/core/profiles/default/workflows/opengever_committee_workflow/specification.txt
+#: opengever/core/profiles/default/workflows/opengever_workspace/specification.txt
 msgid "deactivate"
 msgstr "deactivate"
 
@@ -178,6 +180,66 @@ msgstr "Workspace members can read and modify all contents of the workspace."
 msgid "opengever_workspace--STATUS--active"
 msgstr "Active"
 
+#. Default: "Inactive"
+#: opengever/core/profiles/default/workflows/opengever_workspace/specification.txt
+msgid "opengever_workspace--STATUS--inactive"
+msgstr "Inactive"
+
+#. Default: "deactivate"
+#: opengever/core/profiles/default/workflows/opengever_workspace/specification.txt
+msgid "opengever_workspace--TRANSITION--deactivate--active_inactive"
+msgstr "deactivate"
+
+#. Default: "reactivate"
+#: opengever/core/profiles/default/workflows/opengever_workspace/specification.txt
+msgid "opengever_workspace--TRANSITION--reactivate--inactive_active"
+msgstr "reactivate"
+
+#. Default: "admin"
+#: opengever/core/profiles/default/workflows/opengever_workspace_document/specification.txt
+msgid "opengever_workspace_document--ROLE--Administrator"
+msgstr "admin"
+
+#. Default: "systems administrator"
+#: opengever/core/profiles/default/workflows/opengever_workspace_document/specification.txt
+msgid "opengever_workspace_document--ROLE--Manager"
+msgstr "systems administrator"
+
+#. Default: "workspace admin"
+#: opengever/core/profiles/default/workflows/opengever_workspace_document/specification.txt
+msgid "opengever_workspace_document--ROLE--WorkspaceAdmin"
+msgstr "workspace admin"
+
+#. Default: "workspace guest"
+#: opengever/core/profiles/default/workflows/opengever_workspace_document/specification.txt
+msgid "opengever_workspace_document--ROLE--WorkspaceGuest"
+msgstr "workspace guest"
+
+#. Default: "workspace member"
+#: opengever/core/profiles/default/workflows/opengever_workspace_document/specification.txt
+msgid "opengever_workspace_document--ROLE--WorkspaceMember"
+msgstr "workspace member"
+
+#. Default: "Workspace admins can manage the team as well as read and modify all contents."
+#: opengever/core/profiles/default/workflows/opengever_workspace_document/specification.txt
+msgid "opengever_workspace_document--ROLE-DESCRIPTION--WorkspaceAdmin"
+msgstr "Workspace admins can manage the team as well as read and modify all contents."
+
+#. Default: "A workspace guest has read access to the content but cannot change anything."
+#: opengever/core/profiles/default/workflows/opengever_workspace_document/specification.txt
+msgid "opengever_workspace_document--ROLE-DESCRIPTION--WorkspaceGuest"
+msgstr "A workspace guest has read access to the content but cannot change anything."
+
+#. Default: "Workspace members can read and modify all contents of the workspace."
+#: opengever/core/profiles/default/workflows/opengever_workspace_document/specification.txt
+msgid "opengever_workspace_document--ROLE-DESCRIPTION--WorkspaceMember"
+msgstr "Workspace members can read and modify all contents of the workspace."
+
+#. Default: "Active"
+#: opengever/core/profiles/default/workflows/opengever_workspace_document/specification.txt
+msgid "opengever_workspace_document--STATUS--active"
+msgstr "Active"
+
 #. Default: "admin"
 #: opengever/core/profiles/default/workflows/opengever_workspace_folder/specification.txt
 msgid "opengever_workspace_folder--ROLE--Administrator"
@@ -320,5 +382,6 @@ msgstr "Active"
 
 #. Default: "reactivate"
 #: opengever/core/profiles/default/workflows/opengever_committee_workflow/specification.txt
+#: opengever/core/profiles/default/workflows/opengever_workspace/specification.txt
 msgid "reactivate"
 msgstr "reactivate"

--- a/opengever/core/locales/fr/LC_MESSAGES/opengever.core.po
+++ b/opengever/core/locales/fr/LC_MESSAGES/opengever.core.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2020-09-01 07:50+0000\n"
+"POT-Creation-Date: 2020-09-03 12:37+0000\n"
 "PO-Revision-Date: 2013-03-27 10:44+0100\n"
 "Last-Translator: Philippe Gross <p.gross@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -326,6 +326,7 @@ msgstr "Déblocage de préfixes de référence inutilisés."
 
 #: ./opengever/core/profiles/default/types/opengever.workspace.workspace.xml
 #: ./opengever/core/upgrades/20171213174551_add_workspace_content_type/types/opengever.workspace.workspace.xml
+#: ./opengever/core/upgrades/20200827114625_update_workspace_workflow/types/opengever.workspace.workspace.xml
 msgid "Workspace"
 msgstr "Teamraum"
 

--- a/opengever/core/locales/fr/LC_MESSAGES/plone.po
+++ b/opengever/core/locales/fr/LC_MESSAGES/plone.po
@@ -36,6 +36,7 @@ msgstr "Insérer un exemple de données de réunion"
 
 #. Default: "Inactive"
 #: opengever/core/profiles/default/workflows/opengever_committee_workflow/specification.txt
+#: opengever/core/profiles/default/workflows/opengever_workspace/specification.txt
 msgid "Inactive"
 msgstr "Inactif"
 
@@ -44,6 +45,7 @@ msgstr "Reactiver"
 
 #. Default: "deactivate"
 #: opengever/core/profiles/default/workflows/opengever_committee_workflow/specification.txt
+#: opengever/core/profiles/default/workflows/opengever_workspace/specification.txt
 msgid "deactivate"
 msgstr "Déactiver"
 
@@ -197,6 +199,66 @@ msgstr "Les membres d'équipe ont accès en lécture et écriture à tous les co
 msgid "opengever_workspace--STATUS--active"
 msgstr "Actif"
 
+#. Default: "Inactive"
+#: opengever/core/profiles/default/workflows/opengever_workspace/specification.txt
+msgid "opengever_workspace--STATUS--inactive"
+msgstr "Inactif"
+
+#. Default: "deactivate"
+#: opengever/core/profiles/default/workflows/opengever_workspace/specification.txt
+msgid "opengever_workspace--TRANSITION--deactivate--active_inactive"
+msgstr "Déactiver"
+
+#. Default: "reactivate"
+#: opengever/core/profiles/default/workflows/opengever_workspace/specification.txt
+msgid "opengever_workspace--TRANSITION--reactivate--inactive_active"
+msgstr "Reactiver"
+
+#. Default: "admin"
+#: opengever/core/profiles/default/workflows/opengever_workspace_document/specification.txt
+msgid "opengever_workspace_document--ROLE--Administrator"
+msgstr "Administrateur"
+
+#. Default: "systems administrator"
+#: opengever/core/profiles/default/workflows/opengever_workspace_document/specification.txt
+msgid "opengever_workspace_document--ROLE--Manager"
+msgstr "Administrateur système"
+
+#. Default: "workspace admin"
+#: opengever/core/profiles/default/workflows/opengever_workspace_document/specification.txt
+msgid "opengever_workspace_document--ROLE--WorkspaceAdmin"
+msgstr "Admin"
+
+#. Default: "workspace guest"
+#: opengever/core/profiles/default/workflows/opengever_workspace_document/specification.txt
+msgid "opengever_workspace_document--ROLE--WorkspaceGuest"
+msgstr "Invité"
+
+#. Default: "workspace member"
+#: opengever/core/profiles/default/workflows/opengever_workspace_document/specification.txt
+msgid "opengever_workspace_document--ROLE--WorkspaceMember"
+msgstr "Membre d'équipe"
+
+#. Default: "Workspace admins can manage the team as well as read and modify all contents."
+#: opengever/core/profiles/default/workflows/opengever_workspace_document/specification.txt
+msgid "opengever_workspace_document--ROLE-DESCRIPTION--WorkspaceAdmin"
+msgstr "Les Admins administrent les membres d'équipe et ont accès en lécture et écriture à tous les contenus."
+
+#. Default: "A workspace guest has read access to the content but cannot change anything."
+#: opengever/core/profiles/default/workflows/opengever_workspace_document/specification.txt
+msgid "opengever_workspace_document--ROLE-DESCRIPTION--WorkspaceGuest"
+msgstr "Les invités ont accès en lecture à tous les contenus, mais ne peuvent en modifier aucun."
+
+#. Default: "Workspace members can read and modify all contents of the workspace."
+#: opengever/core/profiles/default/workflows/opengever_workspace_document/specification.txt
+msgid "opengever_workspace_document--ROLE-DESCRIPTION--WorkspaceMember"
+msgstr "Les membres d'équipe ont accès en lécture et écriture à tous les contenus."
+
+#. Default: "Active"
+#: opengever/core/profiles/default/workflows/opengever_workspace_document/specification.txt
+msgid "opengever_workspace_document--STATUS--active"
+msgstr "Actif"
+
 #. Default: "admin"
 #: opengever/core/profiles/default/workflows/opengever_workspace_folder/specification.txt
 msgid "opengever_workspace_folder--ROLE--Administrator"
@@ -339,6 +401,7 @@ msgstr "Actif"
 
 #. Default: "reactivate"
 #: opengever/core/profiles/default/workflows/opengever_committee_workflow/specification.txt
+#: opengever/core/profiles/default/workflows/opengever_workspace/specification.txt
 msgid "reactivate"
 msgstr "réactiver"
 

--- a/opengever/core/locales/opengever.core.pot
+++ b/opengever/core/locales/opengever.core.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2020-09-01 07:50+0000\n"
+"POT-Creation-Date: 2020-09-03 12:37+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -329,6 +329,7 @@ msgstr ""
 
 #: ./opengever/core/profiles/default/types/opengever.workspace.workspace.xml
 #: ./opengever/core/upgrades/20171213174551_add_workspace_content_type/types/opengever.workspace.workspace.xml
+#: ./opengever/core/upgrades/20200827114625_update_workspace_workflow/types/opengever.workspace.workspace.xml
 msgid "Workspace"
 msgstr ""
 

--- a/opengever/core/locales/plone.pot
+++ b/opengever/core/locales/plone.pot
@@ -33,6 +33,7 @@ msgstr ""
 
 #. Default: "Inactive"
 #: opengever/core/profiles/default/workflows/opengever_committee_workflow/specification.txt
+#: opengever/core/profiles/default/workflows/opengever_workspace/specification.txt
 msgid "Inactive"
 msgstr ""
 
@@ -41,6 +42,7 @@ msgstr ""
 
 #. Default: "deactivate"
 #: opengever/core/profiles/default/workflows/opengever_committee_workflow/specification.txt
+#: opengever/core/profiles/default/workflows/opengever_workspace/specification.txt
 msgid "deactivate"
 msgstr ""
 
@@ -194,6 +196,66 @@ msgstr ""
 msgid "opengever_workspace--STATUS--active"
 msgstr ""
 
+#. Default: "Inactive"
+#: opengever/core/profiles/default/workflows/opengever_workspace/specification.txt
+msgid "opengever_workspace--STATUS--inactive"
+msgstr ""
+
+#. Default: "deactivate"
+#: opengever/core/profiles/default/workflows/opengever_workspace/specification.txt
+msgid "opengever_workspace--TRANSITION--deactivate--active_inactive"
+msgstr ""
+
+#. Default: "reactivate"
+#: opengever/core/profiles/default/workflows/opengever_workspace/specification.txt
+msgid "opengever_workspace--TRANSITION--reactivate--inactive_active"
+msgstr ""
+
+#. Default: "admin"
+#: opengever/core/profiles/default/workflows/opengever_workspace_document/specification.txt
+msgid "opengever_workspace_document--ROLE--Administrator"
+msgstr ""
+
+#. Default: "systems administrator"
+#: opengever/core/profiles/default/workflows/opengever_workspace_document/specification.txt
+msgid "opengever_workspace_document--ROLE--Manager"
+msgstr ""
+
+#. Default: "workspace admin"
+#: opengever/core/profiles/default/workflows/opengever_workspace_document/specification.txt
+msgid "opengever_workspace_document--ROLE--WorkspaceAdmin"
+msgstr ""
+
+#. Default: "workspace guest"
+#: opengever/core/profiles/default/workflows/opengever_workspace_document/specification.txt
+msgid "opengever_workspace_document--ROLE--WorkspaceGuest"
+msgstr ""
+
+#. Default: "workspace member"
+#: opengever/core/profiles/default/workflows/opengever_workspace_document/specification.txt
+msgid "opengever_workspace_document--ROLE--WorkspaceMember"
+msgstr ""
+
+#. Default: "Workspace admins can manage the team as well as read and modify all contents."
+#: opengever/core/profiles/default/workflows/opengever_workspace_document/specification.txt
+msgid "opengever_workspace_document--ROLE-DESCRIPTION--WorkspaceAdmin"
+msgstr ""
+
+#. Default: "A workspace guest has read access to the content but cannot change anything."
+#: opengever/core/profiles/default/workflows/opengever_workspace_document/specification.txt
+msgid "opengever_workspace_document--ROLE-DESCRIPTION--WorkspaceGuest"
+msgstr ""
+
+#. Default: "Workspace members can read and modify all contents of the workspace."
+#: opengever/core/profiles/default/workflows/opengever_workspace_document/specification.txt
+msgid "opengever_workspace_document--ROLE-DESCRIPTION--WorkspaceMember"
+msgstr ""
+
+#. Default: "Active"
+#: opengever/core/profiles/default/workflows/opengever_workspace_document/specification.txt
+msgid "opengever_workspace_document--STATUS--active"
+msgstr ""
+
 #. Default: "admin"
 #: opengever/core/profiles/default/workflows/opengever_workspace_folder/specification.txt
 msgid "opengever_workspace_folder--ROLE--Administrator"
@@ -336,6 +398,7 @@ msgstr ""
 
 #. Default: "reactivate"
 #: opengever/core/profiles/default/workflows/opengever_committee_workflow/specification.txt
+#: opengever/core/profiles/default/workflows/opengever_workspace/specification.txt
 msgid "reactivate"
 msgstr ""
 

--- a/opengever/core/profiles/default/portal_placeful_workflow.xml
+++ b/opengever/core/profiles/default/portal_placeful_workflow.xml
@@ -1,4 +1,5 @@
 <object name="portal_placeful_workflow" meta_type="Placeful Workflow Tool">
   <object name="opengever_private_policy" meta_type="WorkflowPolicy" />
   <object name="opengever_inbox_policy" meta_type="WorkflowPolicy" />
+  <object name="opengever_workspace_policy" meta_type="WorkflowPolicy" />
 </object>

--- a/opengever/core/profiles/default/portal_placeful_workflow/opengever_workspace_policy.xml
+++ b/opengever/core/profiles/default/portal_placeful_workflow/opengever_workspace_policy.xml
@@ -1,0 +1,25 @@
+<object name="workspace-policy" meta_type="WorkflowPolicy">
+  <property name="title">Workspace Policy</property>
+  <bindings>
+
+    <type type_id="opengever.document.document">
+      <bound-workflow workflow_id="opengever_workspace_document" />
+    </type>
+    <type type_id="opengever.workspace.root">
+      <bound-workflow workflow_id="opengever_workspace_root" />
+    </type>
+    <type type_id="opengever.workspace.workspace">
+      <bound-workflow workflow_id="opengever_workspace" />
+    </type>
+    <type type_id="opengever.workspace.folder">
+      <bound-workflow workflow_id="opengever_workspace_folder" />
+    </type>
+    <type type_id="opengever.workspace.todo">
+      <bound-workflow workflow_id="opengever_workspace_todo" />
+    </type>
+    <type type_id="opengever.workspace.todolist">
+      <bound-workflow workflow_id="opengever_workspace_todolist" />
+    </type>
+
+  </bindings>
+</object>

--- a/opengever/core/profiles/default/types/opengever.workspace.workspace.xml
+++ b/opengever/core/profiles/default/types/opengever.workspace.workspace.xml
@@ -70,7 +70,7 @@
       condition_expr="not:object/@@plone_lock_info/is_locked_for_current_user|python:True"
       url_expr="string:${object_url}/edit"
       visible="True">
-    <permission value="Modify portal content" />
+    <permission value="opengever.workspace: Modify Workspace" />
   </action>
 
   <action

--- a/opengever/core/profiles/default/workflows.xml
+++ b/opengever/core/profiles/default/workflows.xml
@@ -29,6 +29,7 @@
   <object name="opengever_tasktemplatefolder_workflow" meta_type="Workflow" />
   <object name="opengever_templatefolder_workflow" meta_type="Workflow" />
   <object name="opengever_workspace" meta_type="Workflow" />
+  <object name="opengever_workspace_document" meta_type="Workflow" />
   <object name="opengever_workspace_folder" meta_type="Workflow" />
   <object name="opengever_workspace_root" meta_type="Workflow" />
   <object name="opengever_workspace_todo" meta_type="Workflow" />

--- a/opengever/core/profiles/default/workflows/opengever_workspace/definition.xml
+++ b/opengever/core/profiles/default/workflows/opengever_workspace/definition.xml
@@ -88,10 +88,13 @@
   <permission>opengever.trash: Trash content</permission>
   <permission>opengever.trash: Untrash content</permission>
   <permission>opengever.workspace: Add WorkspaceFolder</permission>
+  <permission>opengever.workspace: Delete Todos</permission>
+  <permission>opengever.workspace: Modify Workspace</permission>
   <permission>opengever.workspace: Update Content Order</permission>
   <permission>plone.portlet.collection: Add collection portlet</permission>
   <permission>plone.portlet.static: Add static portlet</permission>
   <state state_id="opengever_workspace--STATUS--active" title="Active">
+    <exit-transition transition_id="opengever_workspace--TRANSITION--deactivate--active_inactive"/>
     <permission-map name="Access contents information" acquired="False">
       <permission-role>Administrator</permission-role>
       <permission-role>Manager</permission-role>
@@ -116,21 +119,25 @@
       <permission-role>Administrator</permission-role>
       <permission-role>Manager</permission-role>
       <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
     </permission-map>
     <permission-map name="CMFEditions: Checkout to location" acquired="False">
       <permission-role>Administrator</permission-role>
       <permission-role>Manager</permission-role>
       <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
     </permission-map>
     <permission-map name="CMFEditions: Revert to previous versions" acquired="False">
       <permission-role>Administrator</permission-role>
       <permission-role>Manager</permission-role>
       <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
     </permission-map>
     <permission-map name="CMFEditions: Save new version" acquired="False">
       <permission-role>Administrator</permission-role>
       <permission-role>Manager</permission-role>
       <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
     </permission-map>
     <permission-map name="Change local roles" acquired="False">
       <permission-role>Administrator</permission-role>
@@ -144,12 +151,14 @@
       <permission-role>Administrator</permission-role>
       <permission-role>Manager</permission-role>
       <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
     </permission-map>
     <permission-map name="Edit date of cassation" acquired="False"/>
     <permission-map name="Edit date of submission" acquired="False">
       <permission-role>Administrator</permission-role>
       <permission-role>Manager</permission-role>
       <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
     </permission-map>
     <permission-map name="List folder contents" acquired="False">
       <permission-role>Manager</permission-role>
@@ -158,6 +167,7 @@
       <permission-role>Administrator</permission-role>
       <permission-role>Manager</permission-role>
       <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
     </permission-map>
     <permission-map name="Modify constrain types" acquired="False">
       <permission-role>Manager</permission-role>
@@ -166,6 +176,7 @@
       <permission-role>Administrator</permission-role>
       <permission-role>Manager</permission-role>
       <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
     </permission-map>
     <permission-map name="Modify view template" acquired="False">
       <permission-role>Manager</permission-role>
@@ -174,41 +185,49 @@
       <permission-role>Administrator</permission-role>
       <permission-role>Manager</permission-role>
       <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
     </permission-map>
     <permission-map name="Poi: Modify issue assignment" acquired="False">
       <permission-role>Administrator</permission-role>
       <permission-role>Manager</permission-role>
       <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
     </permission-map>
     <permission-map name="Poi: Modify issue severity" acquired="False">
       <permission-role>Administrator</permission-role>
       <permission-role>Manager</permission-role>
       <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
     </permission-map>
     <permission-map name="Poi: Modify issue state" acquired="False">
       <permission-role>Administrator</permission-role>
       <permission-role>Manager</permission-role>
       <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
     </permission-map>
     <permission-map name="Poi: Modify issue tags" acquired="False">
       <permission-role>Administrator</permission-role>
       <permission-role>Manager</permission-role>
       <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
     </permission-map>
     <permission-map name="Poi: Modify issue target release" acquired="False">
       <permission-role>Administrator</permission-role>
       <permission-role>Manager</permission-role>
       <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
     </permission-map>
     <permission-map name="Poi: Modify issue watchers" acquired="False">
       <permission-role>Administrator</permission-role>
       <permission-role>Manager</permission-role>
       <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
     </permission-map>
     <permission-map name="Poi: Upload attachment" acquired="False">
       <permission-role>Administrator</permission-role>
       <permission-role>Manager</permission-role>
       <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
     </permission-map>
     <permission-map name="Portlets: Manage portlets" acquired="False">
       <permission-role>Manager</permission-role>
@@ -263,8 +282,8 @@
     <permission-map name="ftw.keywordwidget: Add new term" acquired="False">
       <permission-role>Administrator</permission-role>
       <permission-role>Manager</permission-role>
-      <permission-role>Manager</permission-role>
       <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
       <permission-role>WorkspaceMember</permission-role>
     </permission-map>
     <permission-map name="ftw.mail: Add Inbound Mail" acquired="False">
@@ -283,11 +302,13 @@
       <permission-role>Administrator</permission-role>
       <permission-role>Manager</permission-role>
       <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
     </permission-map>
     <permission-map name="iterate : Check out content" acquired="False">
       <permission-role>Administrator</permission-role>
       <permission-role>Manager</permission-role>
       <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
     </permission-map>
     <permission-map name="opengever.contact: Add contact" acquired="False">
       <permission-role>Administrator</permission-role>
@@ -308,6 +329,7 @@
       <permission-role>Administrator</permission-role>
       <permission-role>Manager</permission-role>
       <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
     </permission-map>
     <permission-map name="opengever.disposition: Add disposition" acquired="False"/>
     <permission-map name="opengever.disposition: Download SIP Package" acquired="False"/>
@@ -315,6 +337,7 @@
       <permission-role>Administrator</permission-role>
       <permission-role>Manager</permission-role>
       <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
     </permission-map>
     <permission-map name="opengever.document: Add document" acquired="False">
       <permission-role>Administrator</permission-role>
@@ -326,21 +349,25 @@
       <permission-role>Administrator</permission-role>
       <permission-role>Manager</permission-role>
       <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
     </permission-map>
     <permission-map name="opengever.document: Checkin" acquired="False">
       <permission-role>Administrator</permission-role>
       <permission-role>Manager</permission-role>
       <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
     </permission-map>
     <permission-map name="opengever.document: Checkout" acquired="False">
       <permission-role>Administrator</permission-role>
       <permission-role>Manager</permission-role>
       <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
     </permission-map>
     <permission-map name="opengever.document: Force Checkin" acquired="False">
       <permission-role>Administrator</permission-role>
       <permission-role>Manager</permission-role>
       <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
     </permission-map>
     <permission-map name="opengever.document: Modify archival file" acquired="False"/>
     <permission-map name="opengever.dossier: Add businesscasedossier" acquired="False">
@@ -456,6 +483,7 @@
       <permission-role>Administrator</permission-role>
       <permission-role>Manager</permission-role>
       <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
     </permission-map>
     <permission-map name="opengever.trash: Trash content" acquired="False">
       <permission-role>Administrator</permission-role>
@@ -475,8 +503,20 @@
       <permission-role>WorkspaceAdmin</permission-role>
       <permission-role>WorkspaceMember</permission-role>
     </permission-map>
+    <permission-map name="opengever.workspace: Delete Todos" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="opengever.workspace: Modify Workspace" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+    </permission-map>
     <permission-map name="opengever.workspace: Update Content Order" acquired="False">
       <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
       <permission-role>WorkspaceAdmin</permission-role>
       <permission-role>WorkspaceMember</permission-role>
     </permission-map>
@@ -487,6 +527,186 @@
       <permission-role>Manager</permission-role>
     </permission-map>
   </state>
+  <state state_id="opengever_workspace--STATUS--inactive" title="Inactive">
+    <exit-transition transition_id="opengever_workspace--TRANSITION--reactivate--inactive_active"/>
+    <permission-map name="Access contents information" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceGuest</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="Add portal content" acquired="False"/>
+    <permission-map name="CMFEditions: Access previous versions" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceGuest</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="CMFEditions: Apply version control" acquired="False"/>
+    <permission-map name="CMFEditions: Checkout to location" acquired="False"/>
+    <permission-map name="CMFEditions: Revert to previous versions" acquired="False"/>
+    <permission-map name="CMFEditions: Save new version" acquired="False"/>
+    <permission-map name="Change local roles" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+    </permission-map>
+    <permission-map name="Delete objects" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="Edit comments" acquired="False"/>
+    <permission-map name="Edit date of cassation" acquired="False"/>
+    <permission-map name="Edit date of submission" acquired="False"/>
+    <permission-map name="List folder contents" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="Manage properties" acquired="False"/>
+    <permission-map name="Modify constrain types" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="Modify portal content" acquired="False"/>
+    <permission-map name="Modify view template" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="Poi: Edit response" acquired="False"/>
+    <permission-map name="Poi: Modify issue assignment" acquired="False"/>
+    <permission-map name="Poi: Modify issue severity" acquired="False"/>
+    <permission-map name="Poi: Modify issue state" acquired="False"/>
+    <permission-map name="Poi: Modify issue tags" acquired="False"/>
+    <permission-map name="Poi: Modify issue target release" acquired="False"/>
+    <permission-map name="Poi: Modify issue watchers" acquired="False"/>
+    <permission-map name="Poi: Upload attachment" acquired="False"/>
+    <permission-map name="Portlets: Manage portlets" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="Remove GEVER content" acquired="False"/>
+    <permission-map name="Sharing page: Delegate Administrator role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate Contributor role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate DossierManager role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate Editor role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate Publisher role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate Reader role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate Reviewer role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate WorkspaceAdmin role" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+    </permission-map>
+    <permission-map name="Sharing page: Delegate WorkspaceGuest role" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+    </permission-map>
+    <permission-map name="Sharing page: Delegate WorkspaceMember role" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+    </permission-map>
+    <permission-map name="Sharing page: Delegate WorkspacesCreator role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate WorkspacesUser role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate roles" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+    </permission-map>
+    <permission-map name="Take ownership" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+    </permission-map>
+    <permission-map name="View" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceGuest</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="ftw.keywordwidget: Add new term" acquired="False"/>
+    <permission-map name="ftw.mail: Add Inbound Mail" acquired="False"/>
+    <permission-map name="ftw.mail: Add Mail" acquired="False"/>
+    <permission-map name="iterate : Check in content" acquired="False"/>
+    <permission-map name="iterate : Check out content" acquired="False"/>
+    <permission-map name="opengever.contact: Add contact" acquired="False"/>
+    <permission-map name="opengever.contact: Add contactfolder" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="opengever.contact: Add person" acquired="False"/>
+    <permission-map name="opengever.contact: Edit person" acquired="False"/>
+    <permission-map name="opengever.disposition: Add disposition" acquired="False"/>
+    <permission-map name="opengever.disposition: Download SIP Package" acquired="False"/>
+    <permission-map name="opengever.disposition: Edit transfer number" acquired="False"/>
+    <permission-map name="opengever.document: Add document" acquired="False"/>
+    <permission-map name="opengever.document: Cancel" acquired="False"/>
+    <permission-map name="opengever.document: Checkin" acquired="False"/>
+    <permission-map name="opengever.document: Checkout" acquired="False"/>
+    <permission-map name="opengever.document: Force Checkin" acquired="False"/>
+    <permission-map name="opengever.document: Modify archival file" acquired="False"/>
+    <permission-map name="opengever.dossier: Add businesscasedossier" acquired="False"/>
+    <permission-map name="opengever.dossier: Add dossiertemplate" acquired="False"/>
+    <permission-map name="opengever.dossier: Add templatefolder" acquired="False"/>
+    <permission-map name="opengever.dossier: Destroy dossier" acquired="False"/>
+    <permission-map name="opengever.dossier: Protect dossier" acquired="False"/>
+    <permission-map name="opengever.inbox: Add Forwarding" acquired="False"/>
+    <permission-map name="opengever.inbox: Add Inbox" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="opengever.inbox: Add Year Folder" acquired="False"/>
+    <permission-map name="opengever.inbox: Scan In" acquired="False"/>
+    <permission-map name="opengever.meeting: Add Committee" acquired="False"/>
+    <permission-map name="opengever.meeting: Add CommitteeContainer" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="opengever.meeting: Add Member" acquired="False"/>
+    <permission-map name="opengever.meeting: Add Period" acquired="False"/>
+    <permission-map name="opengever.meeting: Add Proposal" acquired="False"/>
+    <permission-map name="opengever.meeting: Add Proposal Template" acquired="False"/>
+    <permission-map name="opengever.meeting: Add Sablon Template" acquired="False"/>
+    <permission-map name="opengever.private: Add private dossier" acquired="False"/>
+    <permission-map name="opengever.private: Add private folder" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="opengever.private: Add private root" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="opengever.repository: Add repositoryfolder" acquired="False"/>
+    <permission-map name="opengever.repository: Add repositoryroot" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="opengever.repository: Unlock Reference Prefix" acquired="False"/>
+    <permission-map name="opengever.task: Add task" acquired="False"/>
+    <permission-map name="opengever.task: Add task comment" acquired="False"/>
+    <permission-map name="opengever.task: Edit task" acquired="False"/>
+    <permission-map name="opengever.trash: Trash content" acquired="False"/>
+    <permission-map name="opengever.trash: Untrash content" acquired="False"/>
+    <permission-map name="opengever.workspace: Add WorkspaceFolder" acquired="False"/>
+    <permission-map name="opengever.workspace: Delete Todos" acquired="False"/>
+    <permission-map name="opengever.workspace: Modify Workspace" acquired="False"/>
+    <permission-map name="opengever.workspace: Update Content Order" acquired="False"/>
+    <permission-map name="plone.portlet.collection: Add collection portlet" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="plone.portlet.static: Add static portlet" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+  </state>
+  <transition new_state="opengever_workspace--STATUS--inactive" title="deactivate" transition_id="opengever_workspace--TRANSITION--deactivate--active_inactive" after_script="" before_script="" trigger="USER">
+    <action category="workflow" icon="" url="%(content_url)s/content_status_modify?workflow_action=opengever_workspace--TRANSITION--deactivate--active_inactive">deactivate</action>
+    <guard>
+      <guard-role>Administrator</guard-role>
+      <guard-role>Manager</guard-role>
+      <guard-role>WorkspaceAdmin</guard-role>
+    </guard>
+  </transition>
+  <transition new_state="opengever_workspace--STATUS--active" title="reactivate" transition_id="opengever_workspace--TRANSITION--reactivate--inactive_active" after_script="" before_script="" trigger="USER">
+    <action category="workflow" icon="" url="%(content_url)s/content_status_modify?workflow_action=opengever_workspace--TRANSITION--reactivate--inactive_active">reactivate</action>
+    <guard>
+      <guard-role>Administrator</guard-role>
+      <guard-role>Manager</guard-role>
+      <guard-role>WorkspaceAdmin</guard-role>
+    </guard>
+  </transition>
   <variable variable_id="action" for_catalog="False" for_status="True" update_always="True">
     <description>Previous transition</description>
     <default>

--- a/opengever/core/profiles/default/workflows/opengever_workspace/specification.txt
+++ b/opengever/core/profiles/default/workflows/opengever_workspace/specification.txt
@@ -25,12 +25,9 @@ General:
   A workspace member can perform the same actions as a workspace guest.
   A workspace admin can perform the same actions as a workspace member.
   An admin can always perform the same actions as a workspace admin.
+  A systems administrator can always perform the same actions as an admin.
 
-  A systems administrator can always add.
   A systems administrator can always view.
-  A systems administrator can always edit.
-  A systems administrator can always trash.
-  A systems administrator can always soft delete.
   A systems administrator can always manage security.
   A systems administrator can always use the developer tools.
 
@@ -44,3 +41,12 @@ Status Active:
   A workspace member can soft delete.
   A workspace admin can edit.
   A workspace admin can manage security.
+  A workspace admin can deactivate.
+Status Inactive:
+  A workspace guest can view.
+  A workspace admin can manage security.
+  A workspace admin can reactivate.
+
+Transitions:
+  deactivate (Active => Inactive)
+  reactivate (Inactive => Active)

--- a/opengever/core/profiles/default/workflows/opengever_workspace/specification.txt
+++ b/opengever/core/profiles/default/workflows/opengever_workspace/specification.txt
@@ -40,6 +40,7 @@ Status Active:
   A workspace member can trash.
   A workspace member can update_order.
   A workspace member can soft delete.
+  A workspace member can delete todos.
   A workspace admin can modify workspace.
   A workspace admin can manage security.
   A workspace admin can deactivate.

--- a/opengever/core/profiles/default/workflows/opengever_workspace/specification.txt
+++ b/opengever/core/profiles/default/workflows/opengever_workspace/specification.txt
@@ -36,10 +36,11 @@ Initial Status: Active
 Status Active:
   A workspace guest can view.
   A workspace member can add.
+  A workspace member can edit.
   A workspace member can trash.
   A workspace member can update_order.
   A workspace member can soft delete.
-  A workspace admin can edit.
+  A workspace admin can modify workspace.
   A workspace admin can manage security.
   A workspace admin can deactivate.
 Status Inactive:

--- a/opengever/core/profiles/default/workflows/opengever_workspace_document/.gitignore
+++ b/opengever/core/profiles/default/workflows/opengever_workspace_document/.gitignore
@@ -1,0 +1,1 @@
+/result.xml

--- a/opengever/core/profiles/default/workflows/opengever_workspace_document/definition.xml
+++ b/opengever/core/profiles/default/workflows/opengever_workspace_document/definition.xml
@@ -1,0 +1,287 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<dc-workflow workflow_id="opengever_workspace_document" title="Workspace document workflow" description="" initial_state="opengever_workspace_document--STATUS--active" state_variable="review_state" manager_bypass="True">
+  <permission>Access contents information</permission>
+  <permission>Add portal content</permission>
+  <permission>CMFEditions: Access previous versions</permission>
+  <permission>CMFEditions: Apply version control</permission>
+  <permission>CMFEditions: Checkout to location</permission>
+  <permission>CMFEditions: Revert to previous versions</permission>
+  <permission>CMFEditions: Save new version</permission>
+  <permission>Change local roles</permission>
+  <permission>Delete objects</permission>
+  <permission>Edit comments</permission>
+  <permission>Edit date of cassation</permission>
+  <permission>Edit date of submission</permission>
+  <permission>List folder contents</permission>
+  <permission>Manage properties</permission>
+  <permission>Modify constrain types</permission>
+  <permission>Modify view template</permission>
+  <permission>Poi: Edit response</permission>
+  <permission>Poi: Modify issue assignment</permission>
+  <permission>Poi: Modify issue severity</permission>
+  <permission>Poi: Modify issue state</permission>
+  <permission>Poi: Modify issue tags</permission>
+  <permission>Poi: Modify issue target release</permission>
+  <permission>Poi: Modify issue watchers</permission>
+  <permission>Poi: Upload attachment</permission>
+  <permission>Portlets: Manage portlets</permission>
+  <permission>Remove GEVER content</permission>
+  <permission>Sharing page: Delegate Administrator role</permission>
+  <permission>Sharing page: Delegate CommitteeAdministrator role</permission>
+  <permission>Sharing page: Delegate CommitteeMember role</permission>
+  <permission>Sharing page: Delegate CommitteeResponsible role</permission>
+  <permission>Sharing page: Delegate Contributor role</permission>
+  <permission>Sharing page: Delegate DossierManager role</permission>
+  <permission>Sharing page: Delegate Editor role</permission>
+  <permission>Sharing page: Delegate MeetingUser role</permission>
+  <permission>Sharing page: Delegate Publisher role</permission>
+  <permission>Sharing page: Delegate Reader role</permission>
+  <permission>Sharing page: Delegate Reviewer role</permission>
+  <permission>Sharing page: Delegate WorkspaceAdmin role</permission>
+  <permission>Sharing page: Delegate WorkspaceGuest role</permission>
+  <permission>Sharing page: Delegate WorkspaceMember role</permission>
+  <permission>Sharing page: Delegate WorkspacesCreator role</permission>
+  <permission>Sharing page: Delegate WorkspacesUser role</permission>
+  <permission>Sharing page: Delegate roles</permission>
+  <permission>Take ownership</permission>
+  <permission>View</permission>
+  <permission>ftw.keywordwidget: Add new term</permission>
+  <permission>ftw.mail: Add Inbound Mail</permission>
+  <permission>iterate : Check in content</permission>
+  <permission>iterate : Check out content</permission>
+  <permission>opengever.contact: Add contact</permission>
+  <permission>opengever.contact: Add contactfolder</permission>
+  <permission>opengever.contact: Add person</permission>
+  <permission>opengever.contact: Edit person</permission>
+  <permission>opengever.disposition: Add disposition</permission>
+  <permission>opengever.disposition: Download SIP Package</permission>
+  <permission>opengever.disposition: Edit transfer number</permission>
+  <permission>opengever.document: Add document</permission>
+  <permission>opengever.document: Modify archival file</permission>
+  <permission>opengever.dossier: Add businesscasedossier</permission>
+  <permission>opengever.dossier: Add dossiertemplate</permission>
+  <permission>opengever.dossier: Add templatefolder</permission>
+  <permission>opengever.dossier: Destroy dossier</permission>
+  <permission>opengever.dossier: Protect dossier</permission>
+  <permission>opengever.inbox: Add Forwarding</permission>
+  <permission>opengever.inbox: Add Inbox</permission>
+  <permission>opengever.inbox: Add Year Folder</permission>
+  <permission>opengever.inbox: Scan In</permission>
+  <permission>opengever.meeting: Add Committee</permission>
+  <permission>opengever.meeting: Add CommitteeContainer</permission>
+  <permission>opengever.meeting: Add Member</permission>
+  <permission>opengever.meeting: Add Period</permission>
+  <permission>opengever.meeting: Add Proposal</permission>
+  <permission>opengever.meeting: Add Proposal Template</permission>
+  <permission>opengever.meeting: Add Sablon Template</permission>
+  <permission>opengever.private: Add private dossier</permission>
+  <permission>opengever.private: Add private folder</permission>
+  <permission>opengever.private: Add private root</permission>
+  <permission>opengever.repository: Add repositoryfolder</permission>
+  <permission>opengever.repository: Add repositoryroot</permission>
+  <permission>opengever.repository: Unlock Reference Prefix</permission>
+  <permission>opengever.task: Add task</permission>
+  <permission>opengever.task: Add task comment</permission>
+  <permission>opengever.task: Edit task</permission>
+  <permission>opengever.trash: Trash content</permission>
+  <permission>opengever.trash: Untrash content</permission>
+  <permission>opengever.workspace: Add Workspace</permission>
+  <permission>plone.portlet.collection: Add collection portlet</permission>
+  <permission>plone.portlet.static: Add static portlet</permission>
+  <state state_id="opengever_workspace_document--STATUS--active" title="Active">
+    <permission-map name="Access contents information" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceGuest</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="Add portal content" acquired="False"/>
+    <permission-map name="CMFEditions: Access previous versions" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceGuest</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="CMFEditions: Apply version control" acquired="False"/>
+    <permission-map name="CMFEditions: Checkout to location" acquired="False"/>
+    <permission-map name="CMFEditions: Revert to previous versions" acquired="False"/>
+    <permission-map name="CMFEditions: Save new version" acquired="False"/>
+    <permission-map name="Change local roles" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+    </permission-map>
+    <permission-map name="Delete objects" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="Edit comments" acquired="False"/>
+    <permission-map name="Edit date of cassation" acquired="False"/>
+    <permission-map name="Edit date of submission" acquired="False"/>
+    <permission-map name="List folder contents" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="Manage properties" acquired="False"/>
+    <permission-map name="Modify constrain types" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="Modify view template" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="Poi: Edit response" acquired="False"/>
+    <permission-map name="Poi: Modify issue assignment" acquired="False"/>
+    <permission-map name="Poi: Modify issue severity" acquired="False"/>
+    <permission-map name="Poi: Modify issue state" acquired="False"/>
+    <permission-map name="Poi: Modify issue tags" acquired="False"/>
+    <permission-map name="Poi: Modify issue target release" acquired="False"/>
+    <permission-map name="Poi: Modify issue watchers" acquired="False"/>
+    <permission-map name="Poi: Upload attachment" acquired="False"/>
+    <permission-map name="Portlets: Manage portlets" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="Remove GEVER content" acquired="False"/>
+    <permission-map name="Sharing page: Delegate Administrator role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate CommitteeAdministrator role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate CommitteeMember role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate CommitteeResponsible role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate Contributor role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate DossierManager role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate Editor role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate MeetingUser role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate Publisher role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate Reader role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate Reviewer role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate WorkspaceAdmin role" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+    </permission-map>
+    <permission-map name="Sharing page: Delegate WorkspaceGuest role" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+    </permission-map>
+    <permission-map name="Sharing page: Delegate WorkspaceMember role" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+    </permission-map>
+    <permission-map name="Sharing page: Delegate WorkspacesCreator role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate WorkspacesUser role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate roles" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+    </permission-map>
+    <permission-map name="Take ownership" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+    </permission-map>
+    <permission-map name="View" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceGuest</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="ftw.keywordwidget: Add new term" acquired="False"/>
+    <permission-map name="ftw.mail: Add Inbound Mail" acquired="False"/>
+    <permission-map name="iterate : Check in content" acquired="False"/>
+    <permission-map name="iterate : Check out content" acquired="False"/>
+    <permission-map name="opengever.contact: Add contact" acquired="False"/>
+    <permission-map name="opengever.contact: Add contactfolder" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="opengever.contact: Add person" acquired="False"/>
+    <permission-map name="opengever.contact: Edit person" acquired="False"/>
+    <permission-map name="opengever.disposition: Add disposition" acquired="False"/>
+    <permission-map name="opengever.disposition: Download SIP Package" acquired="False"/>
+    <permission-map name="opengever.disposition: Edit transfer number" acquired="False"/>
+    <permission-map name="opengever.document: Add document" acquired="False"/>
+    <permission-map name="opengever.document: Modify archival file" acquired="False"/>
+    <permission-map name="opengever.dossier: Add businesscasedossier" acquired="False"/>
+    <permission-map name="opengever.dossier: Add dossiertemplate" acquired="False"/>
+    <permission-map name="opengever.dossier: Add templatefolder" acquired="False"/>
+    <permission-map name="opengever.dossier: Destroy dossier" acquired="False"/>
+    <permission-map name="opengever.dossier: Protect dossier" acquired="False"/>
+    <permission-map name="opengever.inbox: Add Forwarding" acquired="False"/>
+    <permission-map name="opengever.inbox: Add Inbox" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="opengever.inbox: Add Year Folder" acquired="False"/>
+    <permission-map name="opengever.inbox: Scan In" acquired="False"/>
+    <permission-map name="opengever.meeting: Add Committee" acquired="False"/>
+    <permission-map name="opengever.meeting: Add CommitteeContainer" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="opengever.meeting: Add Member" acquired="False"/>
+    <permission-map name="opengever.meeting: Add Period" acquired="False"/>
+    <permission-map name="opengever.meeting: Add Proposal" acquired="False"/>
+    <permission-map name="opengever.meeting: Add Proposal Template" acquired="False"/>
+    <permission-map name="opengever.meeting: Add Sablon Template" acquired="False"/>
+    <permission-map name="opengever.private: Add private dossier" acquired="False"/>
+    <permission-map name="opengever.private: Add private folder" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="opengever.private: Add private root" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="opengever.repository: Add repositoryfolder" acquired="False"/>
+    <permission-map name="opengever.repository: Add repositoryroot" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="opengever.repository: Unlock Reference Prefix" acquired="False"/>
+    <permission-map name="opengever.task: Add task" acquired="False"/>
+    <permission-map name="opengever.task: Add task comment" acquired="False"/>
+    <permission-map name="opengever.task: Edit task" acquired="False"/>
+    <permission-map name="opengever.trash: Trash content" acquired="False"/>
+    <permission-map name="opengever.trash: Untrash content" acquired="False"/>
+    <permission-map name="opengever.workspace: Add Workspace" acquired="False"/>
+    <permission-map name="plone.portlet.collection: Add collection portlet" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="plone.portlet.static: Add static portlet" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+  </state>
+  <variable variable_id="action" for_catalog="False" for_status="True" update_always="True">
+    <description>Previous transition</description>
+    <default>
+        <expression>transition/getId|nothing</expression>
+    </default>
+    <guard/>
+</variable>
+  <variable variable_id="actor" for_catalog="False" for_status="True" update_always="True">
+<description>The ID of the user who performed the previous transition</description>
+    <default>
+        <expression>user/getId</expression>
+    </default>
+    <guard/>
+</variable>
+  <variable variable_id="comments" for_catalog="False" for_status="True" update_always="True">
+    <description>Comment about the last transition</description>
+    <default>
+        <expression>python:state_change.kwargs.get('comment', '')</expression>
+    </default>
+    <guard/>
+</variable>
+  <variable variable_id="review_history" for_catalog="False" for_status="False" update_always="False">
+    <description>Provides access to workflow history</description>
+    <default>
+        <expression>state_change/getHistory</expression>
+    </default>
+    <guard>
+        <guard-permission>Request review</guard-permission>
+        <guard-permission>Review portal content</guard-permission>
+    </guard>
+</variable>
+  <variable variable_id="time" for_catalog="False" for_status="True" update_always="True">
+    <description>When the previous transition was performed</description>
+    <default>
+        <expression>state_change/getDateTime</expression>
+    </default>
+    <guard/>
+</variable>
+</dc-workflow>

--- a/opengever/core/profiles/default/workflows/opengever_workspace_document/specification.txt
+++ b/opengever/core/profiles/default/workflows/opengever_workspace_document/specification.txt
@@ -1,0 +1,38 @@
+[Workspace document workflow]
+Role mapping:
+  workspace guest => WorkspaceGuest
+  workspace member => WorkspaceMember
+  workspace admin => WorkspaceAdmin
+  admin => Administrator
+  systems administrator => Manager
+
+workspace guest role description:
+  A workspace guest has read access to the content but cannot change anything.
+
+workspace member role description:
+  Workspace members can read and modify all contents of the workspace.
+
+workspace admin role description:
+  Workspace admins can manage the team as well as read and modify all contents.
+
+
+Visible roles:
+  workspace guest
+  workspace member
+  workspace admin
+
+
+General:
+  A workspace member can perform the same actions as a workspace guest.
+  A workspace admin can perform the same actions as a workspace member.
+  An admin can perform the same actions as a workspace admin.
+
+  A systems administrator can always view.
+  A systems administrator can always manage security.
+  A systems administrator can always use the developer tools.
+
+
+Initial Status: Active
+Status Active:
+  A workspace guest can view.
+  A workspace admin can manage security.

--- a/opengever/core/profiles/default/workflows/opengever_workspace_folder/definition.xml
+++ b/opengever/core/profiles/default/workflows/opengever_workspace_folder/definition.xml
@@ -1,7 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <dc-workflow workflow_id="opengever_workspace_folder" title="Workspace folder workflow" description="" initial_state="opengever_workspace_folder--STATUS--active" state_variable="review_state" manager_bypass="True">
   <permission>Access contents information</permission>
-  <permission>Add portal content</permission>
   <permission>CMFEditions: Access previous versions</permission>
   <permission>CMFEditions: Apply version control</permission>
   <permission>CMFEditions: Checkout to location</permission>
@@ -15,7 +14,6 @@
   <permission>List folder contents</permission>
   <permission>Manage properties</permission>
   <permission>Modify constrain types</permission>
-  <permission>Modify portal content</permission>
   <permission>Modify view template</permission>
   <permission>Poi: Edit response</permission>
   <permission>Poi: Modify issue assignment</permission>
@@ -54,11 +52,6 @@
   <permission>opengever.disposition: Add disposition</permission>
   <permission>opengever.disposition: Download SIP Package</permission>
   <permission>opengever.disposition: Edit transfer number</permission>
-  <permission>opengever.document: Add document</permission>
-  <permission>opengever.document: Cancel</permission>
-  <permission>opengever.document: Checkin</permission>
-  <permission>opengever.document: Checkout</permission>
-  <permission>opengever.document: Force Checkin</permission>
   <permission>opengever.document: Modify archival file</permission>
   <permission>opengever.dossier: Add businesscasedossier</permission>
   <permission>opengever.dossier: Add dossiertemplate</permission>
@@ -87,7 +80,6 @@
   <permission>opengever.task: Edit task</permission>
   <permission>opengever.trash: Trash content</permission>
   <permission>opengever.trash: Untrash content</permission>
-  <permission>opengever.workspace: Add WorkspaceFolder</permission>
   <permission>plone.portlet.collection: Add collection portlet</permission>
   <permission>plone.portlet.static: Add static portlet</permission>
   <state state_id="opengever_workspace_folder--STATUS--active" title="Active">
@@ -98,12 +90,6 @@
       <permission-role>WorkspaceGuest</permission-role>
       <permission-role>WorkspaceMember</permission-role>
     </permission-map>
-    <permission-map name="Add portal content" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
     <permission-map name="CMFEditions: Access previous versions" acquired="False">
       <permission-role>Administrator</permission-role>
       <permission-role>Manager</permission-role>
@@ -111,30 +97,10 @@
       <permission-role>WorkspaceGuest</permission-role>
       <permission-role>WorkspaceMember</permission-role>
     </permission-map>
-    <permission-map name="CMFEditions: Apply version control" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
-    <permission-map name="CMFEditions: Checkout to location" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
-    <permission-map name="CMFEditions: Revert to previous versions" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
-    <permission-map name="CMFEditions: Save new version" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
+    <permission-map name="CMFEditions: Apply version control" acquired="False"/>
+    <permission-map name="CMFEditions: Checkout to location" acquired="False"/>
+    <permission-map name="CMFEditions: Revert to previous versions" acquired="False"/>
+    <permission-map name="CMFEditions: Save new version" acquired="False"/>
     <permission-map name="Change local roles" acquired="False">
       <permission-role>Administrator</permission-role>
       <permission-role>Manager</permission-role>
@@ -143,97 +109,31 @@
     <permission-map name="Delete objects" acquired="False">
       <permission-role>Manager</permission-role>
     </permission-map>
-    <permission-map name="Edit comments" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
+    <permission-map name="Edit comments" acquired="False"/>
     <permission-map name="Edit date of cassation" acquired="False"/>
-    <permission-map name="Edit date of submission" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
+    <permission-map name="Edit date of submission" acquired="False"/>
     <permission-map name="List folder contents" acquired="False">
       <permission-role>Manager</permission-role>
     </permission-map>
-    <permission-map name="Manage properties" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
+    <permission-map name="Manage properties" acquired="False"/>
     <permission-map name="Modify constrain types" acquired="False">
       <permission-role>Manager</permission-role>
-    </permission-map>
-    <permission-map name="Modify portal content" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
     </permission-map>
     <permission-map name="Modify view template" acquired="False">
       <permission-role>Manager</permission-role>
     </permission-map>
-    <permission-map name="Poi: Edit response" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
-    <permission-map name="Poi: Modify issue assignment" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
-    <permission-map name="Poi: Modify issue severity" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
-    <permission-map name="Poi: Modify issue state" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
-    <permission-map name="Poi: Modify issue tags" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
-    <permission-map name="Poi: Modify issue target release" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
-    <permission-map name="Poi: Modify issue watchers" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
-    <permission-map name="Poi: Upload attachment" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
+    <permission-map name="Poi: Edit response" acquired="False"/>
+    <permission-map name="Poi: Modify issue assignment" acquired="False"/>
+    <permission-map name="Poi: Modify issue severity" acquired="False"/>
+    <permission-map name="Poi: Modify issue state" acquired="False"/>
+    <permission-map name="Poi: Modify issue tags" acquired="False"/>
+    <permission-map name="Poi: Modify issue target release" acquired="False"/>
+    <permission-map name="Poi: Modify issue watchers" acquired="False"/>
+    <permission-map name="Poi: Upload attachment" acquired="False"/>
     <permission-map name="Portlets: Manage portlets" acquired="False">
       <permission-role>Manager</permission-role>
     </permission-map>
-    <permission-map name="Remove GEVER content" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
+    <permission-map name="Remove GEVER content" acquired="False"/>
     <permission-map name="Sharing page: Delegate Administrator role" acquired="False"/>
     <permission-map name="Sharing page: Delegate Contributor role" acquired="False"/>
     <permission-map name="Sharing page: Delegate DossierManager role" acquired="False"/>
@@ -275,184 +175,42 @@
       <permission-role>WorkspaceGuest</permission-role>
       <permission-role>WorkspaceMember</permission-role>
     </permission-map>
-    <permission-map name="ftw.keywordwidget: Add new term" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
-    <permission-map name="ftw.mail: Add Inbound Mail" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
-    <permission-map name="ftw.mail: Add Mail" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
-    <permission-map name="iterate : Check in content" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
-    <permission-map name="iterate : Check out content" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
-    <permission-map name="opengever.contact: Add contact" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
+    <permission-map name="ftw.keywordwidget: Add new term" acquired="False"/>
+    <permission-map name="ftw.mail: Add Inbound Mail" acquired="False"/>
+    <permission-map name="ftw.mail: Add Mail" acquired="False"/>
+    <permission-map name="iterate : Check in content" acquired="False"/>
+    <permission-map name="iterate : Check out content" acquired="False"/>
+    <permission-map name="opengever.contact: Add contact" acquired="False"/>
     <permission-map name="opengever.contact: Add contactfolder" acquired="False">
       <permission-role>Manager</permission-role>
     </permission-map>
-    <permission-map name="opengever.contact: Add person" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
-    <permission-map name="opengever.contact: Edit person" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
+    <permission-map name="opengever.contact: Add person" acquired="False"/>
+    <permission-map name="opengever.contact: Edit person" acquired="False"/>
     <permission-map name="opengever.disposition: Add disposition" acquired="False"/>
     <permission-map name="opengever.disposition: Download SIP Package" acquired="False"/>
-    <permission-map name="opengever.disposition: Edit transfer number" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
-    <permission-map name="opengever.document: Add document" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
-    <permission-map name="opengever.document: Cancel" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
-    <permission-map name="opengever.document: Checkin" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
-    <permission-map name="opengever.document: Checkout" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
-    <permission-map name="opengever.document: Force Checkin" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
+    <permission-map name="opengever.disposition: Edit transfer number" acquired="False"/>
     <permission-map name="opengever.document: Modify archival file" acquired="False"/>
-    <permission-map name="opengever.dossier: Add businesscasedossier" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
-    <permission-map name="opengever.dossier: Add dossiertemplate" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
-    <permission-map name="opengever.dossier: Add templatefolder" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
+    <permission-map name="opengever.dossier: Add businesscasedossier" acquired="False"/>
+    <permission-map name="opengever.dossier: Add dossiertemplate" acquired="False"/>
+    <permission-map name="opengever.dossier: Add templatefolder" acquired="False"/>
     <permission-map name="opengever.dossier: Destroy dossier" acquired="False"/>
     <permission-map name="opengever.dossier: Protect dossier" acquired="False"/>
-    <permission-map name="opengever.inbox: Add Forwarding" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
+    <permission-map name="opengever.inbox: Add Forwarding" acquired="False"/>
     <permission-map name="opengever.inbox: Add Inbox" acquired="False">
       <permission-role>Manager</permission-role>
     </permission-map>
-    <permission-map name="opengever.inbox: Add Year Folder" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
-    <permission-map name="opengever.inbox: Scan In" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
-    <permission-map name="opengever.meeting: Add Committee" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
+    <permission-map name="opengever.inbox: Add Year Folder" acquired="False"/>
+    <permission-map name="opengever.inbox: Scan In" acquired="False"/>
+    <permission-map name="opengever.meeting: Add Committee" acquired="False"/>
     <permission-map name="opengever.meeting: Add CommitteeContainer" acquired="False">
       <permission-role>Manager</permission-role>
     </permission-map>
-    <permission-map name="opengever.meeting: Add Member" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
-    <permission-map name="opengever.meeting: Add Period" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
-    <permission-map name="opengever.meeting: Add Proposal" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
-    <permission-map name="opengever.meeting: Add Proposal Template" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
-    <permission-map name="opengever.meeting: Add Sablon Template" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
-    <permission-map name="opengever.private: Add private dossier" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
+    <permission-map name="opengever.meeting: Add Member" acquired="False"/>
+    <permission-map name="opengever.meeting: Add Period" acquired="False"/>
+    <permission-map name="opengever.meeting: Add Proposal" acquired="False"/>
+    <permission-map name="opengever.meeting: Add Proposal Template" acquired="False"/>
+    <permission-map name="opengever.meeting: Add Sablon Template" acquired="False"/>
+    <permission-map name="opengever.private: Add private dossier" acquired="False"/>
     <permission-map name="opengever.private: Add private folder" acquired="False">
       <permission-role>Manager</permission-role>
     </permission-map>
@@ -464,42 +222,11 @@
       <permission-role>Manager</permission-role>
     </permission-map>
     <permission-map name="opengever.repository: Unlock Reference Prefix" acquired="False"/>
-    <permission-map name="opengever.task: Add task" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
-    <permission-map name="opengever.task: Add task comment" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
-    <permission-map name="opengever.task: Edit task" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
-    <permission-map name="opengever.trash: Trash content" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
-    <permission-map name="opengever.trash: Untrash content" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
-    <permission-map name="opengever.workspace: Add WorkspaceFolder" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
+    <permission-map name="opengever.task: Add task" acquired="False"/>
+    <permission-map name="opengever.task: Add task comment" acquired="False"/>
+    <permission-map name="opengever.task: Edit task" acquired="False"/>
+    <permission-map name="opengever.trash: Trash content" acquired="False"/>
+    <permission-map name="opengever.trash: Untrash content" acquired="False"/>
     <permission-map name="plone.portlet.collection: Add collection portlet" acquired="False">
       <permission-role>Manager</permission-role>
     </permission-map>

--- a/opengever/core/profiles/default/workflows/opengever_workspace_folder/definition.xml
+++ b/opengever/core/profiles/default/workflows/opengever_workspace_folder/definition.xml
@@ -41,8 +41,6 @@
   <permission>Take ownership</permission>
   <permission>View</permission>
   <permission>ftw.keywordwidget: Add new term</permission>
-  <permission>ftw.mail: Add Inbound Mail</permission>
-  <permission>ftw.mail: Add Mail</permission>
   <permission>iterate : Check in content</permission>
   <permission>iterate : Check out content</permission>
   <permission>opengever.contact: Add contact</permission>
@@ -176,8 +174,6 @@
       <permission-role>WorkspaceMember</permission-role>
     </permission-map>
     <permission-map name="ftw.keywordwidget: Add new term" acquired="False"/>
-    <permission-map name="ftw.mail: Add Inbound Mail" acquired="False"/>
-    <permission-map name="ftw.mail: Add Mail" acquired="False"/>
     <permission-map name="iterate : Check in content" acquired="False"/>
     <permission-map name="iterate : Check out content" acquired="False"/>
     <permission-map name="opengever.contact: Add contact" acquired="False"/>

--- a/opengever/core/profiles/default/workflows/opengever_workspace_folder/specification.txt
+++ b/opengever/core/profiles/default/workflows/opengever_workspace_folder/specification.txt
@@ -27,11 +27,7 @@ General:
   A workspace admin can perform the same actions as a workspace member.
   An admin can perform the same actions as a workspace admin.
 
-  A systems administrator can always add.
   A systems administrator can always view.
-  A systems administrator can always edit.
-  A systems administrator can always trash.
-  A systems administrator can always soft delete.
   A systems administrator can always manage security.
   A systems administrator can always use the developer tools.
 
@@ -39,8 +35,4 @@ General:
 Initial Status: Active
 Status Active:
   A workspace guest can view.
-  A workspace member can add.
-  A workspace member can edit.
-  A workspace member can trash.
-  A workspace member can soft delete.
   A workspace admin can manage security.

--- a/opengever/core/profiles/default/workflows/opengever_workspace_todo/definition.xml
+++ b/opengever/core/profiles/default/workflows/opengever_workspace_todo/definition.xml
@@ -1,21 +1,18 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <dc-workflow workflow_id="opengever_workspace_todo" title="Workspace todo workflow" description="" initial_state="opengever_workspace_todo--STATUS--active" state_variable="review_state" manager_bypass="True">
   <permission>Access contents information</permission>
-  <permission>Add portal content</permission>
   <permission>CMFEditions: Access previous versions</permission>
   <permission>CMFEditions: Apply version control</permission>
   <permission>CMFEditions: Checkout to location</permission>
   <permission>CMFEditions: Revert to previous versions</permission>
   <permission>CMFEditions: Save new version</permission>
   <permission>Change local roles</permission>
-  <permission>Delete objects</permission>
   <permission>Edit comments</permission>
   <permission>Edit date of cassation</permission>
   <permission>Edit date of submission</permission>
   <permission>List folder contents</permission>
   <permission>Manage properties</permission>
   <permission>Modify constrain types</permission>
-  <permission>Modify portal content</permission>
   <permission>Modify view template</permission>
   <permission>Poi: Edit response</permission>
   <permission>Poi: Modify issue assignment</permission>
@@ -100,12 +97,6 @@
       <permission-role>WorkspaceGuest</permission-role>
       <permission-role>WorkspaceMember</permission-role>
     </permission-map>
-    <permission-map name="Add portal content" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
     <permission-map name="CMFEditions: Access previous versions" acquired="False">
       <permission-role>Administrator</permission-role>
       <permission-role>Manager</permission-role>
@@ -113,174 +104,128 @@
       <permission-role>WorkspaceGuest</permission-role>
       <permission-role>WorkspaceMember</permission-role>
     </permission-map>
-    <permission-map name="CMFEditions: Apply version control" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
-    <permission-map name="CMFEditions: Checkout to location" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
-    <permission-map name="CMFEditions: Revert to previous versions" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
-    <permission-map name="CMFEditions: Save new version" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
+    <permission-map name="CMFEditions: Apply version control" acquired="False"/>
+    <permission-map name="CMFEditions: Checkout to location" acquired="False"/>
+    <permission-map name="CMFEditions: Revert to previous versions" acquired="False"/>
+    <permission-map name="CMFEditions: Save new version" acquired="False"/>
     <permission-map name="Change local roles" acquired="False">
-      <permission-role>Manager</permission-role>
-    </permission-map>
-    <permission-map name="Delete objects" acquired="False">
-      <permission-role>Manager</permission-role>
-    </permission-map>
-    <permission-map name="Edit comments" acquired="False">
       <permission-role>Administrator</permission-role>
       <permission-role>Manager</permission-role>
       <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
     </permission-map>
+    <permission-map name="Edit comments" acquired="False"/>
     <permission-map name="Edit date of cassation" acquired="False"/>
-    <permission-map name="Edit date of submission" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
+    <permission-map name="Edit date of submission" acquired="False"/>
     <permission-map name="List folder contents" acquired="False">
       <permission-role>Manager</permission-role>
     </permission-map>
-    <permission-map name="Manage properties" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
+    <permission-map name="Manage properties" acquired="False"/>
     <permission-map name="Modify constrain types" acquired="False">
       <permission-role>Manager</permission-role>
-    </permission-map>
-    <permission-map name="Modify portal content" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
     </permission-map>
     <permission-map name="Modify view template" acquired="False">
       <permission-role>Manager</permission-role>
     </permission-map>
-    <permission-map name="Poi: Edit response" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
-    <permission-map name="Poi: Modify issue assignment" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
-    <permission-map name="Poi: Modify issue severity" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
-    <permission-map name="Poi: Modify issue state" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
-    <permission-map name="Poi: Modify issue tags" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
-    <permission-map name="Poi: Modify issue target release" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
-    <permission-map name="Poi: Modify issue watchers" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
-    <permission-map name="Poi: Upload attachment" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
+    <permission-map name="Poi: Edit response" acquired="False"/>
+    <permission-map name="Poi: Modify issue assignment" acquired="False"/>
+    <permission-map name="Poi: Modify issue severity" acquired="False"/>
+    <permission-map name="Poi: Modify issue state" acquired="False"/>
+    <permission-map name="Poi: Modify issue tags" acquired="False"/>
+    <permission-map name="Poi: Modify issue target release" acquired="False"/>
+    <permission-map name="Poi: Modify issue watchers" acquired="False"/>
+    <permission-map name="Poi: Upload attachment" acquired="False"/>
     <permission-map name="Portlets: Manage portlets" acquired="False">
       <permission-role>Manager</permission-role>
     </permission-map>
     <permission-map name="Sharing page: Delegate Administrator role" acquired="False">
+      <permission-role>Administrator</permission-role>
       <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
     </permission-map>
     <permission-map name="Sharing page: Delegate CommitteeAdministrator role" acquired="False">
+      <permission-role>Administrator</permission-role>
       <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
     </permission-map>
     <permission-map name="Sharing page: Delegate CommitteeMember role" acquired="False">
+      <permission-role>Administrator</permission-role>
       <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
     </permission-map>
     <permission-map name="Sharing page: Delegate CommitteeResponsible role" acquired="False">
+      <permission-role>Administrator</permission-role>
       <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
     </permission-map>
     <permission-map name="Sharing page: Delegate Contributor role" acquired="False">
+      <permission-role>Administrator</permission-role>
       <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
     </permission-map>
     <permission-map name="Sharing page: Delegate DossierManager role" acquired="False">
+      <permission-role>Administrator</permission-role>
       <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
     </permission-map>
     <permission-map name="Sharing page: Delegate Editor role" acquired="False">
+      <permission-role>Administrator</permission-role>
       <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
     </permission-map>
     <permission-map name="Sharing page: Delegate MeetingUser role" acquired="False">
+      <permission-role>Administrator</permission-role>
       <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
     </permission-map>
     <permission-map name="Sharing page: Delegate Publisher role" acquired="False">
+      <permission-role>Administrator</permission-role>
       <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
     </permission-map>
     <permission-map name="Sharing page: Delegate Reader role" acquired="False">
+      <permission-role>Administrator</permission-role>
       <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
     </permission-map>
     <permission-map name="Sharing page: Delegate Reviewer role" acquired="False">
+      <permission-role>Administrator</permission-role>
       <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
     </permission-map>
     <permission-map name="Sharing page: Delegate WorkspaceAdmin role" acquired="False">
+      <permission-role>Administrator</permission-role>
       <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
     </permission-map>
     <permission-map name="Sharing page: Delegate WorkspaceGuest role" acquired="False">
+      <permission-role>Administrator</permission-role>
       <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
     </permission-map>
     <permission-map name="Sharing page: Delegate WorkspaceMember role" acquired="False">
+      <permission-role>Administrator</permission-role>
       <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
     </permission-map>
     <permission-map name="Sharing page: Delegate WorkspacesCreator role" acquired="False">
+      <permission-role>Administrator</permission-role>
       <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
     </permission-map>
     <permission-map name="Sharing page: Delegate WorkspacesUser role" acquired="False">
+      <permission-role>Administrator</permission-role>
       <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
     </permission-map>
     <permission-map name="Sharing page: Delegate roles" acquired="False">
+      <permission-role>Administrator</permission-role>
       <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
     </permission-map>
     <permission-map name="Take ownership" acquired="False">
+      <permission-role>Administrator</permission-role>
       <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
     </permission-map>
     <permission-map name="View" acquired="False">
       <permission-role>Administrator</permission-role>
@@ -289,178 +234,46 @@
       <permission-role>WorkspaceGuest</permission-role>
       <permission-role>WorkspaceMember</permission-role>
     </permission-map>
-    <permission-map name="ftw.keywordwidget: Add new term" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
-    <permission-map name="ftw.mail: Add Inbound Mail" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
-    <permission-map name="iterate : Check in content" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
-    <permission-map name="iterate : Check out content" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
-    <permission-map name="opengever.contact: Add contact" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
+    <permission-map name="ftw.keywordwidget: Add new term" acquired="False"/>
+    <permission-map name="ftw.mail: Add Inbound Mail" acquired="False"/>
+    <permission-map name="iterate : Check in content" acquired="False"/>
+    <permission-map name="iterate : Check out content" acquired="False"/>
+    <permission-map name="opengever.contact: Add contact" acquired="False"/>
     <permission-map name="opengever.contact: Add contactfolder" acquired="False">
       <permission-role>Manager</permission-role>
     </permission-map>
-    <permission-map name="opengever.contact: Add person" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
-    <permission-map name="opengever.contact: Edit person" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
+    <permission-map name="opengever.contact: Add person" acquired="False"/>
+    <permission-map name="opengever.contact: Edit person" acquired="False"/>
     <permission-map name="opengever.disposition: Add disposition" acquired="False"/>
     <permission-map name="opengever.disposition: Download SIP Package" acquired="False"/>
-    <permission-map name="opengever.disposition: Edit transfer number" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
-    <permission-map name="opengever.document: Add document" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
-    <permission-map name="opengever.document: Cancel" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
-    <permission-map name="opengever.document: Checkin" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
-    <permission-map name="opengever.document: Checkout" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
-    <permission-map name="opengever.document: Force Checkin" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
+    <permission-map name="opengever.disposition: Edit transfer number" acquired="False"/>
+    <permission-map name="opengever.document: Add document" acquired="False"/>
+    <permission-map name="opengever.document: Cancel" acquired="False"/>
+    <permission-map name="opengever.document: Checkin" acquired="False"/>
+    <permission-map name="opengever.document: Checkout" acquired="False"/>
+    <permission-map name="opengever.document: Force Checkin" acquired="False"/>
     <permission-map name="opengever.document: Modify archival file" acquired="False"/>
-    <permission-map name="opengever.dossier: Add businesscasedossier" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
-    <permission-map name="opengever.dossier: Add dossiertemplate" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
-    <permission-map name="opengever.dossier: Add templatefolder" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
+    <permission-map name="opengever.dossier: Add businesscasedossier" acquired="False"/>
+    <permission-map name="opengever.dossier: Add dossiertemplate" acquired="False"/>
+    <permission-map name="opengever.dossier: Add templatefolder" acquired="False"/>
     <permission-map name="opengever.dossier: Destroy dossier" acquired="False"/>
     <permission-map name="opengever.dossier: Protect dossier" acquired="False"/>
-    <permission-map name="opengever.inbox: Add Forwarding" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
+    <permission-map name="opengever.inbox: Add Forwarding" acquired="False"/>
     <permission-map name="opengever.inbox: Add Inbox" acquired="False">
       <permission-role>Manager</permission-role>
     </permission-map>
-    <permission-map name="opengever.inbox: Add Year Folder" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
-    <permission-map name="opengever.inbox: Scan In" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
-    <permission-map name="opengever.meeting: Add Committee" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
+    <permission-map name="opengever.inbox: Add Year Folder" acquired="False"/>
+    <permission-map name="opengever.inbox: Scan In" acquired="False"/>
+    <permission-map name="opengever.meeting: Add Committee" acquired="False"/>
     <permission-map name="opengever.meeting: Add CommitteeContainer" acquired="False">
       <permission-role>Manager</permission-role>
     </permission-map>
-    <permission-map name="opengever.meeting: Add Member" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
-    <permission-map name="opengever.meeting: Add Period" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
-    <permission-map name="opengever.meeting: Add Proposal" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
-    <permission-map name="opengever.meeting: Add Proposal Template" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
-    <permission-map name="opengever.meeting: Add Sablon Template" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
-    <permission-map name="opengever.private: Add private dossier" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
+    <permission-map name="opengever.meeting: Add Member" acquired="False"/>
+    <permission-map name="opengever.meeting: Add Period" acquired="False"/>
+    <permission-map name="opengever.meeting: Add Proposal" acquired="False"/>
+    <permission-map name="opengever.meeting: Add Proposal Template" acquired="False"/>
+    <permission-map name="opengever.meeting: Add Sablon Template" acquired="False"/>
+    <permission-map name="opengever.private: Add private dossier" acquired="False"/>
     <permission-map name="opengever.private: Add private folder" acquired="False">
       <permission-role>Manager</permission-role>
     </permission-map>
@@ -472,32 +285,12 @@
       <permission-role>Manager</permission-role>
     </permission-map>
     <permission-map name="opengever.repository: Unlock Reference Prefix" acquired="False"/>
-    <permission-map name="opengever.task: Add task" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
-    <permission-map name="opengever.task: Add task comment" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
-    <permission-map name="opengever.task: Edit task" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
+    <permission-map name="opengever.task: Add task" acquired="False"/>
+    <permission-map name="opengever.task: Add task comment" acquired="False"/>
+    <permission-map name="opengever.task: Edit task" acquired="False"/>
     <permission-map name="opengever.trash: Trash content" acquired="False"/>
     <permission-map name="opengever.trash: Untrash content" acquired="False"/>
-    <permission-map name="opengever.workspace: Add Workspace" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
+    <permission-map name="opengever.workspace: Add Workspace" acquired="False"/>
     <permission-map name="plone.portlet.collection: Add collection portlet" acquired="False">
       <permission-role>Manager</permission-role>
     </permission-map>

--- a/opengever/core/profiles/default/workflows/opengever_workspace_todo/specification.txt
+++ b/opengever/core/profiles/default/workflows/opengever_workspace_todo/specification.txt
@@ -11,14 +11,11 @@ General:
   A workspace admin can perform the same actions as a workspace member.
   An admin can perform the same actions as a workspace admin.
 
-  A systems administrator can always add.
   A systems administrator can always view.
-  A systems administrator can always edit.
   A systems administrator can always manage security.
   A systems administrator can always use the developer tools.
 
 Initial Status: Active
 Status Active:
   A workspace guest can view.
-  A workspace member can add.
-  A workspace member can edit.
+  A workspace admin can manage security.

--- a/opengever/core/profiles/default/workflows/opengever_workspace_todolist/definition.xml
+++ b/opengever/core/profiles/default/workflows/opengever_workspace_todolist/definition.xml
@@ -1,21 +1,18 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <dc-workflow workflow_id="opengever_workspace_todolist" title="Workspace todolist workflow" description="" initial_state="opengever_workspace_todolist--STATUS--active" state_variable="review_state" manager_bypass="True">
   <permission>Access contents information</permission>
-  <permission>Add portal content</permission>
   <permission>CMFEditions: Access previous versions</permission>
   <permission>CMFEditions: Apply version control</permission>
   <permission>CMFEditions: Checkout to location</permission>
   <permission>CMFEditions: Revert to previous versions</permission>
   <permission>CMFEditions: Save new version</permission>
   <permission>Change local roles</permission>
-  <permission>Delete objects</permission>
   <permission>Edit comments</permission>
   <permission>Edit date of cassation</permission>
   <permission>Edit date of submission</permission>
   <permission>List folder contents</permission>
   <permission>Manage properties</permission>
   <permission>Modify constrain types</permission>
-  <permission>Modify portal content</permission>
   <permission>Modify view template</permission>
   <permission>Poi: Edit response</permission>
   <permission>Poi: Modify issue assignment</permission>
@@ -100,12 +97,6 @@
       <permission-role>WorkspaceGuest</permission-role>
       <permission-role>WorkspaceMember</permission-role>
     </permission-map>
-    <permission-map name="Add portal content" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
     <permission-map name="CMFEditions: Access previous versions" acquired="False">
       <permission-role>Administrator</permission-role>
       <permission-role>Manager</permission-role>
@@ -113,177 +104,128 @@
       <permission-role>WorkspaceGuest</permission-role>
       <permission-role>WorkspaceMember</permission-role>
     </permission-map>
-    <permission-map name="CMFEditions: Apply version control" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
-    <permission-map name="CMFEditions: Checkout to location" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
-    <permission-map name="CMFEditions: Revert to previous versions" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
-    <permission-map name="CMFEditions: Save new version" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
+    <permission-map name="CMFEditions: Apply version control" acquired="False"/>
+    <permission-map name="CMFEditions: Checkout to location" acquired="False"/>
+    <permission-map name="CMFEditions: Revert to previous versions" acquired="False"/>
+    <permission-map name="CMFEditions: Save new version" acquired="False"/>
     <permission-map name="Change local roles" acquired="False">
-      <permission-role>Manager</permission-role>
-    </permission-map>
-    <permission-map name="Delete objects" acquired="False">
       <permission-role>Administrator</permission-role>
       <permission-role>Manager</permission-role>
       <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
     </permission-map>
-    <permission-map name="Edit comments" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
+    <permission-map name="Edit comments" acquired="False"/>
     <permission-map name="Edit date of cassation" acquired="False"/>
-    <permission-map name="Edit date of submission" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
+    <permission-map name="Edit date of submission" acquired="False"/>
     <permission-map name="List folder contents" acquired="False">
       <permission-role>Manager</permission-role>
     </permission-map>
-    <permission-map name="Manage properties" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
+    <permission-map name="Manage properties" acquired="False"/>
     <permission-map name="Modify constrain types" acquired="False">
       <permission-role>Manager</permission-role>
-    </permission-map>
-    <permission-map name="Modify portal content" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
     </permission-map>
     <permission-map name="Modify view template" acquired="False">
       <permission-role>Manager</permission-role>
     </permission-map>
-    <permission-map name="Poi: Edit response" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
-    <permission-map name="Poi: Modify issue assignment" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
-    <permission-map name="Poi: Modify issue severity" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
-    <permission-map name="Poi: Modify issue state" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
-    <permission-map name="Poi: Modify issue tags" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
-    <permission-map name="Poi: Modify issue target release" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
-    <permission-map name="Poi: Modify issue watchers" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
-    <permission-map name="Poi: Upload attachment" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
+    <permission-map name="Poi: Edit response" acquired="False"/>
+    <permission-map name="Poi: Modify issue assignment" acquired="False"/>
+    <permission-map name="Poi: Modify issue severity" acquired="False"/>
+    <permission-map name="Poi: Modify issue state" acquired="False"/>
+    <permission-map name="Poi: Modify issue tags" acquired="False"/>
+    <permission-map name="Poi: Modify issue target release" acquired="False"/>
+    <permission-map name="Poi: Modify issue watchers" acquired="False"/>
+    <permission-map name="Poi: Upload attachment" acquired="False"/>
     <permission-map name="Portlets: Manage portlets" acquired="False">
       <permission-role>Manager</permission-role>
     </permission-map>
     <permission-map name="Sharing page: Delegate Administrator role" acquired="False">
+      <permission-role>Administrator</permission-role>
       <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
     </permission-map>
     <permission-map name="Sharing page: Delegate CommitteeAdministrator role" acquired="False">
+      <permission-role>Administrator</permission-role>
       <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
     </permission-map>
     <permission-map name="Sharing page: Delegate CommitteeMember role" acquired="False">
+      <permission-role>Administrator</permission-role>
       <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
     </permission-map>
     <permission-map name="Sharing page: Delegate CommitteeResponsible role" acquired="False">
+      <permission-role>Administrator</permission-role>
       <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
     </permission-map>
     <permission-map name="Sharing page: Delegate Contributor role" acquired="False">
+      <permission-role>Administrator</permission-role>
       <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
     </permission-map>
     <permission-map name="Sharing page: Delegate DossierManager role" acquired="False">
+      <permission-role>Administrator</permission-role>
       <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
     </permission-map>
     <permission-map name="Sharing page: Delegate Editor role" acquired="False">
+      <permission-role>Administrator</permission-role>
       <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
     </permission-map>
     <permission-map name="Sharing page: Delegate MeetingUser role" acquired="False">
+      <permission-role>Administrator</permission-role>
       <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
     </permission-map>
     <permission-map name="Sharing page: Delegate Publisher role" acquired="False">
+      <permission-role>Administrator</permission-role>
       <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
     </permission-map>
     <permission-map name="Sharing page: Delegate Reader role" acquired="False">
+      <permission-role>Administrator</permission-role>
       <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
     </permission-map>
     <permission-map name="Sharing page: Delegate Reviewer role" acquired="False">
+      <permission-role>Administrator</permission-role>
       <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
     </permission-map>
     <permission-map name="Sharing page: Delegate WorkspaceAdmin role" acquired="False">
+      <permission-role>Administrator</permission-role>
       <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
     </permission-map>
     <permission-map name="Sharing page: Delegate WorkspaceGuest role" acquired="False">
+      <permission-role>Administrator</permission-role>
       <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
     </permission-map>
     <permission-map name="Sharing page: Delegate WorkspaceMember role" acquired="False">
+      <permission-role>Administrator</permission-role>
       <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
     </permission-map>
     <permission-map name="Sharing page: Delegate WorkspacesCreator role" acquired="False">
+      <permission-role>Administrator</permission-role>
       <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
     </permission-map>
     <permission-map name="Sharing page: Delegate WorkspacesUser role" acquired="False">
+      <permission-role>Administrator</permission-role>
       <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
     </permission-map>
     <permission-map name="Sharing page: Delegate roles" acquired="False">
+      <permission-role>Administrator</permission-role>
       <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
     </permission-map>
     <permission-map name="Take ownership" acquired="False">
+      <permission-role>Administrator</permission-role>
       <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
     </permission-map>
     <permission-map name="View" acquired="False">
       <permission-role>Administrator</permission-role>
@@ -292,178 +234,46 @@
       <permission-role>WorkspaceGuest</permission-role>
       <permission-role>WorkspaceMember</permission-role>
     </permission-map>
-    <permission-map name="ftw.keywordwidget: Add new term" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
-    <permission-map name="ftw.mail: Add Inbound Mail" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
-    <permission-map name="iterate : Check in content" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
-    <permission-map name="iterate : Check out content" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
-    <permission-map name="opengever.contact: Add contact" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
+    <permission-map name="ftw.keywordwidget: Add new term" acquired="False"/>
+    <permission-map name="ftw.mail: Add Inbound Mail" acquired="False"/>
+    <permission-map name="iterate : Check in content" acquired="False"/>
+    <permission-map name="iterate : Check out content" acquired="False"/>
+    <permission-map name="opengever.contact: Add contact" acquired="False"/>
     <permission-map name="opengever.contact: Add contactfolder" acquired="False">
       <permission-role>Manager</permission-role>
     </permission-map>
-    <permission-map name="opengever.contact: Add person" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
-    <permission-map name="opengever.contact: Edit person" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
+    <permission-map name="opengever.contact: Add person" acquired="False"/>
+    <permission-map name="opengever.contact: Edit person" acquired="False"/>
     <permission-map name="opengever.disposition: Add disposition" acquired="False"/>
     <permission-map name="opengever.disposition: Download SIP Package" acquired="False"/>
-    <permission-map name="opengever.disposition: Edit transfer number" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
-    <permission-map name="opengever.document: Add document" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
-    <permission-map name="opengever.document: Cancel" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
-    <permission-map name="opengever.document: Checkin" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
-    <permission-map name="opengever.document: Checkout" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
-    <permission-map name="opengever.document: Force Checkin" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
+    <permission-map name="opengever.disposition: Edit transfer number" acquired="False"/>
+    <permission-map name="opengever.document: Add document" acquired="False"/>
+    <permission-map name="opengever.document: Cancel" acquired="False"/>
+    <permission-map name="opengever.document: Checkin" acquired="False"/>
+    <permission-map name="opengever.document: Checkout" acquired="False"/>
+    <permission-map name="opengever.document: Force Checkin" acquired="False"/>
     <permission-map name="opengever.document: Modify archival file" acquired="False"/>
-    <permission-map name="opengever.dossier: Add businesscasedossier" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
-    <permission-map name="opengever.dossier: Add dossiertemplate" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
-    <permission-map name="opengever.dossier: Add templatefolder" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
+    <permission-map name="opengever.dossier: Add businesscasedossier" acquired="False"/>
+    <permission-map name="opengever.dossier: Add dossiertemplate" acquired="False"/>
+    <permission-map name="opengever.dossier: Add templatefolder" acquired="False"/>
     <permission-map name="opengever.dossier: Destroy dossier" acquired="False"/>
     <permission-map name="opengever.dossier: Protect dossier" acquired="False"/>
-    <permission-map name="opengever.inbox: Add Forwarding" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
+    <permission-map name="opengever.inbox: Add Forwarding" acquired="False"/>
     <permission-map name="opengever.inbox: Add Inbox" acquired="False">
       <permission-role>Manager</permission-role>
     </permission-map>
-    <permission-map name="opengever.inbox: Add Year Folder" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
-    <permission-map name="opengever.inbox: Scan In" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
-    <permission-map name="opengever.meeting: Add Committee" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
+    <permission-map name="opengever.inbox: Add Year Folder" acquired="False"/>
+    <permission-map name="opengever.inbox: Scan In" acquired="False"/>
+    <permission-map name="opengever.meeting: Add Committee" acquired="False"/>
     <permission-map name="opengever.meeting: Add CommitteeContainer" acquired="False">
       <permission-role>Manager</permission-role>
     </permission-map>
-    <permission-map name="opengever.meeting: Add Member" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
-    <permission-map name="opengever.meeting: Add Period" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
-    <permission-map name="opengever.meeting: Add Proposal" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
-    <permission-map name="opengever.meeting: Add Proposal Template" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
-    <permission-map name="opengever.meeting: Add Sablon Template" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
-    <permission-map name="opengever.private: Add private dossier" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
+    <permission-map name="opengever.meeting: Add Member" acquired="False"/>
+    <permission-map name="opengever.meeting: Add Period" acquired="False"/>
+    <permission-map name="opengever.meeting: Add Proposal" acquired="False"/>
+    <permission-map name="opengever.meeting: Add Proposal Template" acquired="False"/>
+    <permission-map name="opengever.meeting: Add Sablon Template" acquired="False"/>
+    <permission-map name="opengever.private: Add private dossier" acquired="False"/>
     <permission-map name="opengever.private: Add private folder" acquired="False">
       <permission-role>Manager</permission-role>
     </permission-map>
@@ -475,32 +285,12 @@
       <permission-role>Manager</permission-role>
     </permission-map>
     <permission-map name="opengever.repository: Unlock Reference Prefix" acquired="False"/>
-    <permission-map name="opengever.task: Add task" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
-    <permission-map name="opengever.task: Add task comment" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
-    <permission-map name="opengever.task: Edit task" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
+    <permission-map name="opengever.task: Add task" acquired="False"/>
+    <permission-map name="opengever.task: Add task comment" acquired="False"/>
+    <permission-map name="opengever.task: Edit task" acquired="False"/>
     <permission-map name="opengever.trash: Trash content" acquired="False"/>
     <permission-map name="opengever.trash: Untrash content" acquired="False"/>
-    <permission-map name="opengever.workspace: Add Workspace" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
-    </permission-map>
+    <permission-map name="opengever.workspace: Add Workspace" acquired="False"/>
     <permission-map name="plone.portlet.collection: Add collection portlet" acquired="False">
       <permission-role>Manager</permission-role>
     </permission-map>

--- a/opengever/core/profiles/default/workflows/opengever_workspace_todolist/specification.txt
+++ b/opengever/core/profiles/default/workflows/opengever_workspace_todolist/specification.txt
@@ -11,16 +11,11 @@ General:
   A workspace admin can perform the same actions as a workspace member.
   An admin can perform the same actions as a workspace admin.
 
-  A systems administrator can always add.
   A systems administrator can always view.
-  A systems administrator can always edit.
-  A systems administrator can always delete.
   A systems administrator can always manage security.
   A systems administrator can always use the developer tools.
 
 Initial Status: Active
 Status Active:
   A workspace guest can view.
-  A workspace member can add.
-  A workspace member can edit.
-  A workspace member can delete.
+  A workspace admin can manage security.

--- a/opengever/core/tests/test_lawgiver_workflows.py
+++ b/opengever/core/tests/test_lawgiver_workflows.py
@@ -23,3 +23,7 @@ class TestWorkspaceFolderWorkflow(GeverWorkflowTest):
 
 class TestWorkspaceWorkflow(GeverWorkflowTest):
     workflow_name = 'opengever_workspace'
+
+
+class TestWorkspaceDocumentWorkflow(GeverWorkflowTest):
+    workflow_name = 'opengever_workspace_document'

--- a/opengever/core/upgrades/20200827114625_update_workspace_workflow/portal_placeful_workflow.xml
+++ b/opengever/core/upgrades/20200827114625_update_workspace_workflow/portal_placeful_workflow.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<object name="portal_placeful_workflow" meta_type="Placeful Workflow Tool">
+ <object name="opengever_workspace_policy" meta_type="WorkflowPolicy"/>
+</object>

--- a/opengever/core/upgrades/20200827114625_update_workspace_workflow/portal_placeful_workflow/opengever_workspace_policy.xml
+++ b/opengever/core/upgrades/20200827114625_update_workspace_workflow/portal_placeful_workflow/opengever_workspace_policy.xml
@@ -1,0 +1,25 @@
+<object name="opengever_workspace_policy" meta_type="WorkflowPolicy">
+  <property name="title">Workspace Policy</property>
+  <bindings>
+
+    <type type_id="opengever.document.document">
+      <bound-workflow workflow_id="opengever_workspace_document" />
+    </type>
+    <type type_id="opengever.workspace.root">
+      <bound-workflow workflow_id="opengever_workspace_root" />
+    </type>
+    <type type_id="opengever.workspace.workspace">
+      <bound-workflow workflow_id="opengever_workspace" />
+    </type>
+    <type type_id="opengever.workspace.folder">
+      <bound-workflow workflow_id="opengever_workspace_folder" />
+    </type>
+    <type type_id="opengever.workspace.todo">
+      <bound-workflow workflow_id="opengever_workspace_todo" />
+    </type>
+    <type type_id="opengever.workspace.todolist">
+      <bound-workflow workflow_id="opengever_workspace_todolist" />
+    </type>
+
+  </bindings>
+</object>

--- a/opengever/core/upgrades/20200827114625_update_workspace_workflow/types/opengever.workspace.workspace.xml
+++ b/opengever/core/upgrades/20200827114625_update_workspace_workflow/types/opengever.workspace.workspace.xml
@@ -1,0 +1,86 @@
+<object xmlns:i18n="http://xml.zope.org/namespaces/i18n" name="opengever.workspace.workspace" meta_type="Dexterity FTI" i18n:domain="opengever.core">
+
+  <!-- Basic metadata -->
+  <property name="title" i18n:translate="">Workspace</property>
+  <property name="description" i18n:translate="" />
+  <property name="icon_expr" />
+  <property name="allow_discussion">False</property>
+  <property name="global_allow">False</property>
+  <property name="filter_content_types">True</property>
+  <property name="allowed_content_types">
+    <element value="opengever.document.document" />
+    <element value="ftw.mail.mail" />
+    <element value="opengever.workspace.todo" />
+    <element value="opengever.workspace.todolist" />
+    <element value="opengever.workspace.folder" />
+  </property>
+
+  <!-- Schema interface -->
+  <property name="schema">opengever.workspace.workspace.IWorkspaceSchema</property>
+
+  <!-- Class used for content items -->
+  <property name="klass">opengever.workspace.workspace.Workspace</property>
+
+  <!-- Add permission -->
+  <property name="add_permission">opengever.workspace.AddWorkspace</property>
+
+  <!-- Enabled behaviors -->
+  <property name="behaviors">
+    <element value="opengever.base.behaviors.changed.IChanged" />
+    <element value="collective.dexteritytextindexer.behavior.IDexterityTextIndexer" />
+    <element value="ftw.journal.interfaces.IAnnotationsJournalizable" />
+    <element value="opengever.base.behaviors.base.IOpenGeverBase" />
+    <element value="opengever.base.behaviors.sequence.ISequenceNumberBehavior" />
+    <element value="opengever.workspace.behaviors.namefromtitle.IWorkspaceNameFromTitle" />
+    <element value="opengever.mail.behaviors.ISendableDocsContainer" />
+    <element value="opengever.tabbedview.interfaces.ITabbedViewEnabled" />
+    <element value="opengever.trash.trash.ITrashable" />
+    <element value="plone.app.lockingbehavior.behaviors.ILocking" />
+  </property>
+
+  <!-- View information -->
+  <property name="immediate_view">tabbed_view</property>
+  <property name="default_view">tabbed_view</property>
+  <property name="default_view_fallback">False</property>
+  <property name="view_methods">
+    <element value="tabbed_view" />
+  </property>
+
+  <!-- Method aliases -->
+  <alias from="(Default)" to="(selected layout)" />
+  <alias from="edit" to="@@edit" />
+  <alias from="sharing" to="@@sharing" />
+  <alias from="view" to="@@view" />
+
+  <!-- Actions -->
+  <action
+      title="View"
+      action_id="view"
+      category="object"
+      condition_expr=""
+      url_expr="string:${object_url}"
+      visible="False">
+    <permission value="View" />
+  </action>
+
+  <action
+      title="Edit"
+      action_id="edit"
+      category="object"
+      condition_expr="not:object/@@plone_lock_info/is_locked_for_current_user|python:True"
+      url_expr="string:${object_url}/edit"
+      visible="True">
+      <permission value="opengever.workspace: Modify Workspace" />
+  </action>
+
+  <action
+      action_id="add_invitation"
+      visible="True"
+      title="Add invitation"
+      url_expr="string:${object_url}/@invitations"
+      condition_expr=""
+      category="object_buttons">
+    <permission value="Sharing page: Delegate WorkspaceAdmin role" />
+  </action>
+
+</object>

--- a/opengever/core/upgrades/20200827114625_update_workspace_workflow/upgrade.py
+++ b/opengever/core/upgrades/20200827114625_update_workspace_workflow/upgrade.py
@@ -1,0 +1,101 @@
+from AccessControl.ImplPython import name_trans
+from Acquisition import aq_base
+from ftw.upgrade import ProgressLogger
+from ftw.upgrade import UpgradeStep
+from ftw.upgrade.helpers import update_security_for
+from ftw.upgrade.utils import SavepointIterator
+from ftw.upgrade.utils import SizedGenerator
+from ftw.upgrade.workflow import WorkflowSecurityUpdater
+from Products.CMFCore.utils import getToolByName
+from zope.component.hooks import getSite
+import string
+
+
+def permission_attribute_name(permission):
+    """The attribute name used to store the permission on the object."""
+    return '_' + string.translate(permission, name_trans) + "_Permission"
+
+
+def delete_unmanaged_permission_attributes(obj):
+    """Delete permissions stored on the object that are not managed by the
+       objects workflow.
+    """
+    wftool = getToolByName(getSite(), 'portal_workflow')
+    wf_permissions = [
+        permission_attribute_name(p) for p
+        in wftool.getWorkflowsFor(obj)[0].permissions
+    ]
+    obj_permissions = [p for p in dir(aq_base(obj)) if p.endswith('_Permission')]
+    for permission in obj_permissions:
+        if permission not in wf_permissions:
+            delattr(obj, permission)
+
+
+class WorkflowSecurityUpdater(WorkflowSecurityUpdater):
+    # Customized WorkflowSecurityUpdater that only updates object inside a
+    # workspace root. We want to avoid updating all GEVER documents as the
+    # workflow changes only affect workspaces.
+    def lookup_objects(self, types):
+        portal = getSite()
+        catalog = getToolByName(portal, 'portal_catalog')
+
+        workspace_roots = catalog.unrestrictedSearchResults(
+            portal_type='opengever.workspace.root')
+        query = {
+            'portal_type': types,
+            'path': {
+                'query': [root.getPath() for root in workspace_roots],
+                'depth': -1,
+            },
+        }
+        brains = tuple(catalog.unrestrictedSearchResults(query))
+        generator = SizedGenerator(
+            (brain._unrestrictedGetObject() for brain in brains), len(brains))
+        return ProgressLogger('Update object security', generator)
+
+    # Additionally deletes permissions stored on the object
+    def update(self, changed_workflows, reindex_security=True, savepoints=None):
+        types = self.get_suspected_types(changed_workflows)
+        objects = SavepointIterator.build(self.lookup_objects(types), savepoints)
+        for obj in objects:
+            if self.obj_has_workflow(obj, changed_workflows):
+                update_security_for(obj, reindex_security=reindex_security)
+                delete_unmanaged_permission_attributes(obj)
+
+
+class UpdateWorkspaceWorkflow(UpgradeStep):
+    """Update workspace workflow.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()
+        self.set_workspace_policy()
+        self.update_workflow_security(
+            [
+                'opengever_workspace',
+                'opengever_workspace_folder',
+                'opengever_workspace_todolist',
+                'opengever_workspace_todo',
+                'opengever_workspace_document',
+            ],
+            reindex_security=False, savepoints=None
+        )
+
+    def set_workspace_policy(self):
+        workspace_roots = self.catalog_unrestricted_search(
+            {'portal_type': 'opengever.workspace.root'},
+            full_objects=True,
+        )
+        for root in workspace_roots:
+            if '.wf_policy_config' not in root.objectIds():
+                root.manage_addProduct[
+                    'CMFPlacefulWorkflow'].manage_addWorkflowPolicyConfig()
+            config = root['.wf_policy_config']
+            config.setPolicyIn('workspace-policy')
+            config.setPolicyBelow('workspace-policy')
+
+    def update_workflow_security(self, workflow_names, reindex_security=True,
+                                 savepoints=1000):
+        updater = WorkflowSecurityUpdater()
+        updater.update(workflow_names, reindex_security=reindex_security,
+                       savepoints=savepoints)

--- a/opengever/core/upgrades/20200827114625_update_workspace_workflow/workflows.xml
+++ b/opengever/core/upgrades/20200827114625_update_workspace_workflow/workflows.xml
@@ -1,0 +1,5 @@
+<object name="portal_workflow" meta_type="Plone Workflow Tool">
+
+  <object name="opengever_workspace_document" meta_type="Workflow" />
+
+</object>

--- a/opengever/core/upgrades/20200827114625_update_workspace_workflow/workflows/opengever_document_workflow/definition.xml
+++ b/opengever/core/upgrades/20200827114625_update_workspace_workflow/workflows/opengever_document_workflow/definition.xml
@@ -1,0 +1,596 @@
+<dc-workflow
+    workflow_id="opengever_document_workflow"
+    title="Simple one-state-workflow for OpenGever Documents"
+    description=""
+    state_variable="review_state"
+    initial_state="document-state-draft"
+    manager_bypass="False">
+  <permission>Access contents information</permission>
+  <permission>CMFEditions: Access previous versions</permission>
+  <permission>CMFEditions: Apply version control</permission>
+  <permission>CMFEditions: Checkout to location</permission>
+  <permission>CMFEditions: Manage versioning policies</permission>
+  <permission>CMFEditions: Purge version</permission>
+  <permission>CMFEditions: Revert to previous versions</permission>
+  <permission>Change portal events</permission>
+  <permission>Content rules: Manage rules</permission>
+  <permission>Copy or Move</permission>
+  <permission>Delete objects</permission>
+  <permission>List folder contents</permission>
+  <permission>Modify portal content</permission>
+  <permission>Request review</permission>
+  <permission>Sharing page: Delegate roles</permission>
+  <permission>View</permission>
+  <permission>WebDAV Lock items</permission>
+  <permission>WebDAV Unlock items</permission>
+  <permission>WebDAV access</permission>
+  <permission>opengever.document: Cancel</permission>
+  <permission>opengever.document: Checkin</permission>
+  <permission>opengever.document: Checkout</permission>
+  <state
+      state_id="document-state-draft"
+      title="document-state-draft">
+    <description>one single state</description>
+    <exit-transition transition_id="document-transition-remove" />
+    <permission-map
+        name="Access contents information"
+        acquired="False">
+      <permission-role>Editor</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>Reader</permission-role>
+      <permission-role>Administrator</permission-role>
+      <permission-role>CommitteeAdministrator</permission-role>
+      <permission-role>CommitteeMember</permission-role>
+      <permission-role>CommitteeResponsible</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceGuest</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map
+        name="CMFEditions: Access previous versions"
+        acquired="False">
+      <permission-role>Editor</permission-role>
+      <permission-role>Reader</permission-role>
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>CommitteeAdministrator</permission-role>
+      <permission-role>CommitteeMember</permission-role>
+      <permission-role>CommitteeResponsible</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceGuest</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map
+        name="CMFEditions: Apply version control"
+        acquired="False">
+      <permission-role>Editor</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>CommitteeAdministrator</permission-role>
+      <permission-role>CommitteeResponsible</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map
+        name="CMFEditions: Checkout to location"
+        acquired="False">
+      <permission-role>Editor</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>CommitteeAdministrator</permission-role>
+      <permission-role>CommitteeResponsible</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map
+        name="CMFEditions: Manage versioning policies"
+        acquired="False">
+      <permission-role>Editor</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>CommitteeAdministrator</permission-role>
+      <permission-role>CommitteeResponsible</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map
+        name="CMFEditions: Purge version"
+        acquired="False">
+      <permission-role>Editor</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>CommitteeAdministrator</permission-role>
+      <permission-role>CommitteeResponsible</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map
+        name="CMFEditions: Revert to previous versions"
+        acquired="False">
+      <permission-role>Editor</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>CommitteeAdministrator</permission-role>
+      <permission-role>CommitteeResponsible</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map
+        name="Change portal events"
+        acquired="False">
+      <permission-role>Editor</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>CommitteeAdministrator</permission-role>
+      <permission-role>CommitteeResponsible</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map
+        name="Content rules: Manage rules"
+        acquired="False">
+    </permission-map>
+    <permission-map
+        name="Copy or Move"
+        acquired="True">
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceGuest</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map
+        name="Delete objects"
+        acquired="True">
+    </permission-map>
+    <permission-map
+        name="List folder contents"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map
+        name="Modify portal content"
+        acquired="True">
+    </permission-map>
+    <permission-map
+        name="Request review"
+        acquired="True">
+    </permission-map>
+    <permission-map
+        name="Sharing page: Delegate roles"
+        acquired="False">
+    </permission-map>
+    <permission-map
+        name="View"
+        acquired="False">
+      <permission-role>Editor</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>Reader</permission-role>
+      <permission-role>Administrator</permission-role>
+      <permission-role>CommitteeAdministrator</permission-role>
+      <permission-role>CommitteeMember</permission-role>
+      <permission-role>CommitteeResponsible</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceGuest</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map
+        name="WebDAV Lock items"
+        acquired="False">
+      <permission-role>Editor</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>Administrator</permission-role>
+      <permission-role>CommitteeAdministrator</permission-role>
+      <permission-role>CommitteeResponsible</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map
+        name="WebDAV Unlock items"
+        acquired="False">
+      <permission-role>Editor</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>Administrator</permission-role>
+      <permission-role>CommitteeAdministrator</permission-role>
+      <permission-role>CommitteeResponsible</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map
+        name="WebDAV access"
+        acquired="False">
+      <permission-role>Editor</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>Administrator</permission-role>
+      <permission-role>CommitteeAdministrator</permission-role>
+      <permission-role>CommitteeResponsible</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map
+        name="opengever.document: Cancel"
+        acquired="True">
+    </permission-map>
+    <permission-map
+        name="opengever.document: Checkin"
+        acquired="True">
+    </permission-map>
+    <permission-map
+        name="opengever.document: Checkout"
+        acquired="True">
+    </permission-map>
+  </state>
+  <state
+      state_id="document-state-removed"
+      title="document-state-removed">
+    <description>document-state-removed</description>
+    <exit-transition transition_id="document-transition-restore" />
+    <permission-map
+        name="Access contents information"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map
+        name="CMFEditions: Access previous versions"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map
+        name="CMFEditions: Apply version control"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map
+        name="CMFEditions: Checkout to location"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map
+        name="CMFEditions: Manage versioning policies"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map
+        name="CMFEditions: Purge version"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map
+        name="CMFEditions: Revert to previous versions"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map
+        name="Change portal events"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map
+        name="Content rules: Manage rules"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map
+        name="Copy or Move"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map
+        name="Delete objects"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map
+        name="List folder contents"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map
+        name="Modify portal content"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map
+        name="Request review"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map
+        name="Sharing page: Delegate roles"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map
+        name="View"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map
+        name="WebDAV Lock items"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map
+        name="WebDAV Unlock items"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map
+        name="WebDAV access"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map
+        name="opengever.document: Cancel"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map
+        name="opengever.document: Checkin"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map
+        name="opengever.document: Checkout"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+  </state>
+  <state
+      state_id="document-state-shadow"
+      title="">
+    <exit-transition transition_id="document-transition-initialize" />
+    <permission-map
+        name="Access contents information"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>Owner</permission-role>
+    </permission-map>
+    <permission-map
+        name="CMFEditions: Access previous versions"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>Owner</permission-role>
+    </permission-map>
+    <permission-map
+        name="CMFEditions: Apply version control"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>Owner</permission-role>
+    </permission-map>
+    <permission-map
+        name="CMFEditions: Checkout to location"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>Owner</permission-role>
+    </permission-map>
+    <permission-map
+        name="CMFEditions: Manage versioning policies"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>Owner</permission-role>
+    </permission-map>
+    <permission-map
+        name="CMFEditions: Purge version"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>Owner</permission-role>
+    </permission-map>
+    <permission-map
+        name="CMFEditions: Revert to previous versions"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>Owner</permission-role>
+    </permission-map>
+    <permission-map
+        name="Change portal events"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>Owner</permission-role>
+    </permission-map>
+    <permission-map
+        name="Content rules: Manage rules"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map
+        name="Copy or Move"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>Owner</permission-role>
+    </permission-map>
+    <permission-map
+        name="Delete objects"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>Owner</permission-role>
+    </permission-map>
+    <permission-map
+        name="List folder contents"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map
+        name="Modify portal content"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>Owner</permission-role>
+    </permission-map>
+    <permission-map
+        name="Request review"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map
+        name="Sharing page: Delegate roles"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map
+        name="View"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>Owner</permission-role>
+    </permission-map>
+    <permission-map
+        name="WebDAV Lock items"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>Owner</permission-role>
+    </permission-map>
+    <permission-map
+        name="WebDAV Unlock items"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>Owner</permission-role>
+    </permission-map>
+    <permission-map
+        name="WebDAV access"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>Owner</permission-role>
+    </permission-map>
+    <permission-map
+        name="opengever.document: Cancel"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>Owner</permission-role>
+    </permission-map>
+    <permission-map
+        name="opengever.document: Checkin"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>Owner</permission-role>
+    </permission-map>
+    <permission-map
+        name="opengever.document: Checkout"
+        acquired="False">
+      <permission-role>Manager</permission-role>
+      <permission-role>Owner</permission-role>
+    </permission-map>
+  </state>
+
+  <transition
+      transition_id="document-transition-initialize"
+      title="document-transition-initialize"
+      new_state="document-state-draft"
+      trigger="USER"
+      before_script=""
+      after_script="">
+
+    <guard>
+      <guard-permission>Add portal content</guard-permission>
+    </guard>
+  </transition>
+
+  <transition
+      transition_id="document-transition-remove"
+      title="document-transition-remove"
+      new_state="document-state-removed"
+      trigger="USER"
+      before_script=""
+      after_script="">
+    <description />
+    <action
+        url="%(content_url)s/content_status_modify?workflow_action=document-transition-remove"
+        category="workflow"
+        icon="">document-transition-remove</action>
+    <guard>
+      <guard-expression>here/is_trashed</guard-expression>
+      <guard-permission>Remove GEVER content</guard-permission>
+    </guard>
+  </transition>
+
+  <transition
+      transition_id="document-transition-restore"
+      title="document-transition-restore"
+      new_state="document-state-draft"
+      trigger="USER"
+      before_script=""
+      after_script="">
+    <description />
+    <action
+        url="%(content_url)s/content_status_modify?workflow_action=document-transition-restore"
+        category="workflow"
+        icon="">document-transition-restore</action>
+    <guard>
+      <guard-permission>Manage portal</guard-permission>
+    </guard>
+  </transition>
+
+  <worklist
+      worklist_id="reviewer_queue"
+      title="">
+    <description>Reviewer tasks</description>
+    <action
+        url="%(portal_url)s/search?review_state=document-state-pending"
+        category="global"
+        icon="">Pending (%(count)d)</action>
+    <guard>
+      <guard-permission>Review portal content</guard-permission>
+    </guard>
+    <match
+        name="review_state"
+        values="document-state-pending"
+        />
+  </worklist>
+  <variable
+      variable_id="action"
+      for_catalog="False"
+      for_status="True"
+      update_always="True">
+    <description>Previous transition</description>
+    <default>
+
+      <expression>transition/getId|nothing</expression>
+    </default>
+    <guard>
+    </guard>
+  </variable>
+  <variable
+      variable_id="actor"
+      for_catalog="False"
+      for_status="True"
+      update_always="True">
+    <description>The ID of the user who performed the previous transition</description>
+    <default>
+
+      <expression>user/getUserName</expression>
+    </default>
+    <guard>
+    </guard>
+  </variable>
+  <variable
+      variable_id="comments"
+      for_catalog="False"
+      for_status="True"
+      update_always="True">
+    <description>Comment about the last transition</description>
+    <default>
+
+      <expression>python:state_change.kwargs.get('comment', '')</expression>
+    </default>
+    <guard>
+    </guard>
+  </variable>
+  <variable
+      variable_id="review_history"
+      for_catalog="False"
+      for_status="False"
+      update_always="False">
+    <description>Provides access to workflow history</description>
+    <default>
+
+      <expression>state_change/getHistory</expression>
+    </default>
+    <guard>
+      <guard-permission>Request review</guard-permission>
+      <guard-permission>Review portal content</guard-permission>
+    </guard>
+  </variable>
+  <variable
+      variable_id="time"
+      for_catalog="False"
+      for_status="True"
+      update_always="True">
+    <description>When the previous transition was performed</description>
+    <default>
+
+      <expression>state_change/getDateTime</expression>
+    </default>
+    <guard>
+    </guard>
+  </variable>
+</dc-workflow>

--- a/opengever/core/upgrades/20200827114625_update_workspace_workflow/workflows/opengever_workspace/definition.xml
+++ b/opengever/core/upgrades/20200827114625_update_workspace_workflow/workflows/opengever_workspace/definition.xml
@@ -1,0 +1,748 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<dc-workflow workflow_id="opengever_workspace" title="Workspace workflow" description="" initial_state="opengever_workspace--STATUS--active" state_variable="review_state" manager_bypass="True">
+  <permission>Access contents information</permission>
+  <permission>Add portal content</permission>
+  <permission>CMFEditions: Access previous versions</permission>
+  <permission>CMFEditions: Apply version control</permission>
+  <permission>CMFEditions: Checkout to location</permission>
+  <permission>CMFEditions: Revert to previous versions</permission>
+  <permission>CMFEditions: Save new version</permission>
+  <permission>Change local roles</permission>
+  <permission>Delete objects</permission>
+  <permission>Edit comments</permission>
+  <permission>Edit date of cassation</permission>
+  <permission>Edit date of submission</permission>
+  <permission>List folder contents</permission>
+  <permission>Manage properties</permission>
+  <permission>Modify constrain types</permission>
+  <permission>Modify portal content</permission>
+  <permission>Modify view template</permission>
+  <permission>Poi: Edit response</permission>
+  <permission>Poi: Modify issue assignment</permission>
+  <permission>Poi: Modify issue severity</permission>
+  <permission>Poi: Modify issue state</permission>
+  <permission>Poi: Modify issue tags</permission>
+  <permission>Poi: Modify issue target release</permission>
+  <permission>Poi: Modify issue watchers</permission>
+  <permission>Poi: Upload attachment</permission>
+  <permission>Portlets: Manage portlets</permission>
+  <permission>Remove GEVER content</permission>
+  <permission>Sharing page: Delegate Administrator role</permission>
+  <permission>Sharing page: Delegate Contributor role</permission>
+  <permission>Sharing page: Delegate DossierManager role</permission>
+  <permission>Sharing page: Delegate Editor role</permission>
+  <permission>Sharing page: Delegate Publisher role</permission>
+  <permission>Sharing page: Delegate Reader role</permission>
+  <permission>Sharing page: Delegate Reviewer role</permission>
+  <permission>Sharing page: Delegate WorkspaceAdmin role</permission>
+  <permission>Sharing page: Delegate WorkspaceGuest role</permission>
+  <permission>Sharing page: Delegate WorkspaceMember role</permission>
+  <permission>Sharing page: Delegate WorkspacesCreator role</permission>
+  <permission>Sharing page: Delegate WorkspacesUser role</permission>
+  <permission>Sharing page: Delegate roles</permission>
+  <permission>Take ownership</permission>
+  <permission>View</permission>
+  <permission>ftw.keywordwidget: Add new term</permission>
+  <permission>ftw.mail: Add Inbound Mail</permission>
+  <permission>ftw.mail: Add Mail</permission>
+  <permission>iterate : Check in content</permission>
+  <permission>iterate : Check out content</permission>
+  <permission>opengever.contact: Add contact</permission>
+  <permission>opengever.contact: Add contactfolder</permission>
+  <permission>opengever.contact: Add person</permission>
+  <permission>opengever.contact: Edit person</permission>
+  <permission>opengever.disposition: Add disposition</permission>
+  <permission>opengever.disposition: Download SIP Package</permission>
+  <permission>opengever.disposition: Edit transfer number</permission>
+  <permission>opengever.document: Add document</permission>
+  <permission>opengever.document: Cancel</permission>
+  <permission>opengever.document: Checkin</permission>
+  <permission>opengever.document: Checkout</permission>
+  <permission>opengever.document: Force Checkin</permission>
+  <permission>opengever.document: Modify archival file</permission>
+  <permission>opengever.dossier: Add businesscasedossier</permission>
+  <permission>opengever.dossier: Add dossiertemplate</permission>
+  <permission>opengever.dossier: Add templatefolder</permission>
+  <permission>opengever.dossier: Destroy dossier</permission>
+  <permission>opengever.dossier: Protect dossier</permission>
+  <permission>opengever.inbox: Add Forwarding</permission>
+  <permission>opengever.inbox: Add Inbox</permission>
+  <permission>opengever.inbox: Add Year Folder</permission>
+  <permission>opengever.inbox: Scan In</permission>
+  <permission>opengever.meeting: Add Committee</permission>
+  <permission>opengever.meeting: Add CommitteeContainer</permission>
+  <permission>opengever.meeting: Add Member</permission>
+  <permission>opengever.meeting: Add Period</permission>
+  <permission>opengever.meeting: Add Proposal</permission>
+  <permission>opengever.meeting: Add Proposal Template</permission>
+  <permission>opengever.meeting: Add Sablon Template</permission>
+  <permission>opengever.private: Add private dossier</permission>
+  <permission>opengever.private: Add private folder</permission>
+  <permission>opengever.private: Add private root</permission>
+  <permission>opengever.repository: Add repositoryfolder</permission>
+  <permission>opengever.repository: Add repositoryroot</permission>
+  <permission>opengever.repository: Unlock Reference Prefix</permission>
+  <permission>opengever.task: Add task</permission>
+  <permission>opengever.task: Add task comment</permission>
+  <permission>opengever.task: Edit task</permission>
+  <permission>opengever.trash: Trash content</permission>
+  <permission>opengever.trash: Untrash content</permission>
+  <permission>opengever.workspace: Add WorkspaceFolder</permission>
+  <permission>opengever.workspace: Delete Todos</permission>
+  <permission>opengever.workspace: Modify Workspace</permission>
+  <permission>opengever.workspace: Update Content Order</permission>
+  <permission>plone.portlet.collection: Add collection portlet</permission>
+  <permission>plone.portlet.static: Add static portlet</permission>
+  <state state_id="opengever_workspace--STATUS--active" title="Active">
+    <exit-transition transition_id="opengever_workspace--TRANSITION--deactivate--active_inactive"/>
+    <permission-map name="Access contents information" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceGuest</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="Add portal content" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="CMFEditions: Access previous versions" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceGuest</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="CMFEditions: Apply version control" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="CMFEditions: Checkout to location" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="CMFEditions: Revert to previous versions" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="CMFEditions: Save new version" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="Change local roles" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+    </permission-map>
+    <permission-map name="Delete objects" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="Edit comments" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="Edit date of cassation" acquired="False"/>
+    <permission-map name="Edit date of submission" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="List folder contents" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="Manage properties" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="Modify constrain types" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="Modify portal content" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="Modify view template" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="Poi: Edit response" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="Poi: Modify issue assignment" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="Poi: Modify issue severity" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="Poi: Modify issue state" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="Poi: Modify issue tags" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="Poi: Modify issue target release" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="Poi: Modify issue watchers" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="Poi: Upload attachment" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="Portlets: Manage portlets" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="Remove GEVER content" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="Sharing page: Delegate Administrator role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate Contributor role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate DossierManager role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate Editor role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate Publisher role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate Reader role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate Reviewer role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate WorkspaceAdmin role" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+    </permission-map>
+    <permission-map name="Sharing page: Delegate WorkspaceGuest role" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+    </permission-map>
+    <permission-map name="Sharing page: Delegate WorkspaceMember role" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+    </permission-map>
+    <permission-map name="Sharing page: Delegate WorkspacesCreator role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate WorkspacesUser role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate roles" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+    </permission-map>
+    <permission-map name="Take ownership" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+    </permission-map>
+    <permission-map name="View" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceGuest</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="ftw.keywordwidget: Add new term" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="ftw.mail: Add Inbound Mail" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="ftw.mail: Add Mail" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="iterate : Check in content" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="iterate : Check out content" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="opengever.contact: Add contact" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="opengever.contact: Add contactfolder" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="opengever.contact: Add person" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="opengever.contact: Edit person" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="opengever.disposition: Add disposition" acquired="False"/>
+    <permission-map name="opengever.disposition: Download SIP Package" acquired="False"/>
+    <permission-map name="opengever.disposition: Edit transfer number" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="opengever.document: Add document" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="opengever.document: Cancel" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="opengever.document: Checkin" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="opengever.document: Checkout" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="opengever.document: Force Checkin" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="opengever.document: Modify archival file" acquired="False"/>
+    <permission-map name="opengever.dossier: Add businesscasedossier" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="opengever.dossier: Add dossiertemplate" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="opengever.dossier: Add templatefolder" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="opengever.dossier: Destroy dossier" acquired="False"/>
+    <permission-map name="opengever.dossier: Protect dossier" acquired="False"/>
+    <permission-map name="opengever.inbox: Add Forwarding" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="opengever.inbox: Add Inbox" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="opengever.inbox: Add Year Folder" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="opengever.inbox: Scan In" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="opengever.meeting: Add Committee" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="opengever.meeting: Add CommitteeContainer" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="opengever.meeting: Add Member" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="opengever.meeting: Add Period" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="opengever.meeting: Add Proposal" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="opengever.meeting: Add Proposal Template" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="opengever.meeting: Add Sablon Template" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="opengever.private: Add private dossier" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="opengever.private: Add private folder" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="opengever.private: Add private root" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="opengever.repository: Add repositoryfolder" acquired="False"/>
+    <permission-map name="opengever.repository: Add repositoryroot" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="opengever.repository: Unlock Reference Prefix" acquired="False"/>
+    <permission-map name="opengever.task: Add task" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="opengever.task: Add task comment" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="opengever.task: Edit task" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="opengever.trash: Trash content" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="opengever.trash: Untrash content" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="opengever.workspace: Add WorkspaceFolder" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="opengever.workspace: Delete Todos" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="opengever.workspace: Modify Workspace" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+    </permission-map>
+    <permission-map name="opengever.workspace: Update Content Order" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="plone.portlet.collection: Add collection portlet" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="plone.portlet.static: Add static portlet" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+  </state>
+  <state state_id="opengever_workspace--STATUS--inactive" title="Inactive">
+    <exit-transition transition_id="opengever_workspace--TRANSITION--reactivate--inactive_active"/>
+    <permission-map name="Access contents information" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceGuest</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="Add portal content" acquired="False"/>
+    <permission-map name="CMFEditions: Access previous versions" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceGuest</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="CMFEditions: Apply version control" acquired="False"/>
+    <permission-map name="CMFEditions: Checkout to location" acquired="False"/>
+    <permission-map name="CMFEditions: Revert to previous versions" acquired="False"/>
+    <permission-map name="CMFEditions: Save new version" acquired="False"/>
+    <permission-map name="Change local roles" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+    </permission-map>
+    <permission-map name="Delete objects" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="Edit comments" acquired="False"/>
+    <permission-map name="Edit date of cassation" acquired="False"/>
+    <permission-map name="Edit date of submission" acquired="False"/>
+    <permission-map name="List folder contents" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="Manage properties" acquired="False"/>
+    <permission-map name="Modify constrain types" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="Modify portal content" acquired="False"/>
+    <permission-map name="Modify view template" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="Poi: Edit response" acquired="False"/>
+    <permission-map name="Poi: Modify issue assignment" acquired="False"/>
+    <permission-map name="Poi: Modify issue severity" acquired="False"/>
+    <permission-map name="Poi: Modify issue state" acquired="False"/>
+    <permission-map name="Poi: Modify issue tags" acquired="False"/>
+    <permission-map name="Poi: Modify issue target release" acquired="False"/>
+    <permission-map name="Poi: Modify issue watchers" acquired="False"/>
+    <permission-map name="Poi: Upload attachment" acquired="False"/>
+    <permission-map name="Portlets: Manage portlets" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="Remove GEVER content" acquired="False"/>
+    <permission-map name="Sharing page: Delegate Administrator role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate Contributor role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate DossierManager role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate Editor role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate Publisher role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate Reader role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate Reviewer role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate WorkspaceAdmin role" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+    </permission-map>
+    <permission-map name="Sharing page: Delegate WorkspaceGuest role" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+    </permission-map>
+    <permission-map name="Sharing page: Delegate WorkspaceMember role" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+    </permission-map>
+    <permission-map name="Sharing page: Delegate WorkspacesCreator role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate WorkspacesUser role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate roles" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+    </permission-map>
+    <permission-map name="Take ownership" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+    </permission-map>
+    <permission-map name="View" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceGuest</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="ftw.keywordwidget: Add new term" acquired="False"/>
+    <permission-map name="ftw.mail: Add Inbound Mail" acquired="False"/>
+    <permission-map name="ftw.mail: Add Mail" acquired="False"/>
+    <permission-map name="iterate : Check in content" acquired="False"/>
+    <permission-map name="iterate : Check out content" acquired="False"/>
+    <permission-map name="opengever.contact: Add contact" acquired="False"/>
+    <permission-map name="opengever.contact: Add contactfolder" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="opengever.contact: Add person" acquired="False"/>
+    <permission-map name="opengever.contact: Edit person" acquired="False"/>
+    <permission-map name="opengever.disposition: Add disposition" acquired="False"/>
+    <permission-map name="opengever.disposition: Download SIP Package" acquired="False"/>
+    <permission-map name="opengever.disposition: Edit transfer number" acquired="False"/>
+    <permission-map name="opengever.document: Add document" acquired="False"/>
+    <permission-map name="opengever.document: Cancel" acquired="False"/>
+    <permission-map name="opengever.document: Checkin" acquired="False"/>
+    <permission-map name="opengever.document: Checkout" acquired="False"/>
+    <permission-map name="opengever.document: Force Checkin" acquired="False"/>
+    <permission-map name="opengever.document: Modify archival file" acquired="False"/>
+    <permission-map name="opengever.dossier: Add businesscasedossier" acquired="False"/>
+    <permission-map name="opengever.dossier: Add dossiertemplate" acquired="False"/>
+    <permission-map name="opengever.dossier: Add templatefolder" acquired="False"/>
+    <permission-map name="opengever.dossier: Destroy dossier" acquired="False"/>
+    <permission-map name="opengever.dossier: Protect dossier" acquired="False"/>
+    <permission-map name="opengever.inbox: Add Forwarding" acquired="False"/>
+    <permission-map name="opengever.inbox: Add Inbox" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="opengever.inbox: Add Year Folder" acquired="False"/>
+    <permission-map name="opengever.inbox: Scan In" acquired="False"/>
+    <permission-map name="opengever.meeting: Add Committee" acquired="False"/>
+    <permission-map name="opengever.meeting: Add CommitteeContainer" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="opengever.meeting: Add Member" acquired="False"/>
+    <permission-map name="opengever.meeting: Add Period" acquired="False"/>
+    <permission-map name="opengever.meeting: Add Proposal" acquired="False"/>
+    <permission-map name="opengever.meeting: Add Proposal Template" acquired="False"/>
+    <permission-map name="opengever.meeting: Add Sablon Template" acquired="False"/>
+    <permission-map name="opengever.private: Add private dossier" acquired="False"/>
+    <permission-map name="opengever.private: Add private folder" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="opengever.private: Add private root" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="opengever.repository: Add repositoryfolder" acquired="False"/>
+    <permission-map name="opengever.repository: Add repositoryroot" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="opengever.repository: Unlock Reference Prefix" acquired="False"/>
+    <permission-map name="opengever.task: Add task" acquired="False"/>
+    <permission-map name="opengever.task: Add task comment" acquired="False"/>
+    <permission-map name="opengever.task: Edit task" acquired="False"/>
+    <permission-map name="opengever.trash: Trash content" acquired="False"/>
+    <permission-map name="opengever.trash: Untrash content" acquired="False"/>
+    <permission-map name="opengever.workspace: Add WorkspaceFolder" acquired="False"/>
+    <permission-map name="opengever.workspace: Delete Todos" acquired="False"/>
+    <permission-map name="opengever.workspace: Modify Workspace" acquired="False"/>
+    <permission-map name="opengever.workspace: Update Content Order" acquired="False"/>
+    <permission-map name="plone.portlet.collection: Add collection portlet" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="plone.portlet.static: Add static portlet" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+  </state>
+  <transition new_state="opengever_workspace--STATUS--inactive" title="deactivate" transition_id="opengever_workspace--TRANSITION--deactivate--active_inactive" after_script="" before_script="" trigger="USER">
+    <action category="workflow" icon="" url="%(content_url)s/content_status_modify?workflow_action=opengever_workspace--TRANSITION--deactivate--active_inactive">deactivate</action>
+    <guard>
+      <guard-role>Administrator</guard-role>
+      <guard-role>Manager</guard-role>
+      <guard-role>WorkspaceAdmin</guard-role>
+    </guard>
+  </transition>
+  <transition new_state="opengever_workspace--STATUS--active" title="reactivate" transition_id="opengever_workspace--TRANSITION--reactivate--inactive_active" after_script="" before_script="" trigger="USER">
+    <action category="workflow" icon="" url="%(content_url)s/content_status_modify?workflow_action=opengever_workspace--TRANSITION--reactivate--inactive_active">reactivate</action>
+    <guard>
+      <guard-role>Administrator</guard-role>
+      <guard-role>Manager</guard-role>
+      <guard-role>WorkspaceAdmin</guard-role>
+    </guard>
+  </transition>
+  <variable variable_id="action" for_catalog="False" for_status="True" update_always="True">
+    <description>Previous transition</description>
+    <default>
+        <expression>transition/getId|nothing</expression>
+    </default>
+    <guard/>
+</variable>
+  <variable variable_id="actor" for_catalog="False" for_status="True" update_always="True">
+<description>The ID of the user who performed the previous transition</description>
+    <default>
+        <expression>user/getId</expression>
+    </default>
+    <guard/>
+</variable>
+  <variable variable_id="comments" for_catalog="False" for_status="True" update_always="True">
+    <description>Comment about the last transition</description>
+    <default>
+        <expression>python:state_change.kwargs.get('comment', '')</expression>
+    </default>
+    <guard/>
+</variable>
+  <variable variable_id="review_history" for_catalog="False" for_status="False" update_always="False">
+    <description>Provides access to workflow history</description>
+    <default>
+        <expression>state_change/getHistory</expression>
+    </default>
+    <guard>
+        <guard-permission>Request review</guard-permission>
+        <guard-permission>Review portal content</guard-permission>
+    </guard>
+</variable>
+  <variable variable_id="time" for_catalog="False" for_status="True" update_always="True">
+    <description>When the previous transition was performed</description>
+    <default>
+        <expression>state_change/getDateTime</expression>
+    </default>
+    <guard/>
+</variable>
+</dc-workflow>

--- a/opengever/core/upgrades/20200827114625_update_workspace_workflow/workflows/opengever_workspace_folder/definition.xml
+++ b/opengever/core/upgrades/20200827114625_update_workspace_workflow/workflows/opengever_workspace_folder/definition.xml
@@ -41,8 +41,6 @@
   <permission>Take ownership</permission>
   <permission>View</permission>
   <permission>ftw.keywordwidget: Add new term</permission>
-  <permission>ftw.mail: Add Inbound Mail</permission>
-  <permission>ftw.mail: Add Mail</permission>
   <permission>iterate : Check in content</permission>
   <permission>iterate : Check out content</permission>
   <permission>opengever.contact: Add contact</permission>
@@ -176,8 +174,6 @@
       <permission-role>WorkspaceMember</permission-role>
     </permission-map>
     <permission-map name="ftw.keywordwidget: Add new term" acquired="False"/>
-    <permission-map name="ftw.mail: Add Inbound Mail" acquired="False"/>
-    <permission-map name="ftw.mail: Add Mail" acquired="False"/>
     <permission-map name="iterate : Check in content" acquired="False"/>
     <permission-map name="iterate : Check out content" acquired="False"/>
     <permission-map name="opengever.contact: Add contact" acquired="False"/>

--- a/opengever/core/upgrades/20200827114625_update_workspace_workflow/workflows/opengever_workspace_folder/definition.xml
+++ b/opengever/core/upgrades/20200827114625_update_workspace_workflow/workflows/opengever_workspace_folder/definition.xml
@@ -1,0 +1,275 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<dc-workflow workflow_id="opengever_workspace_folder" title="Workspace folder workflow" description="" initial_state="opengever_workspace_folder--STATUS--active" state_variable="review_state" manager_bypass="True">
+  <permission>Access contents information</permission>
+  <permission>CMFEditions: Access previous versions</permission>
+  <permission>CMFEditions: Apply version control</permission>
+  <permission>CMFEditions: Checkout to location</permission>
+  <permission>CMFEditions: Revert to previous versions</permission>
+  <permission>CMFEditions: Save new version</permission>
+  <permission>Change local roles</permission>
+  <permission>Delete objects</permission>
+  <permission>Edit comments</permission>
+  <permission>Edit date of cassation</permission>
+  <permission>Edit date of submission</permission>
+  <permission>List folder contents</permission>
+  <permission>Manage properties</permission>
+  <permission>Modify constrain types</permission>
+  <permission>Modify view template</permission>
+  <permission>Poi: Edit response</permission>
+  <permission>Poi: Modify issue assignment</permission>
+  <permission>Poi: Modify issue severity</permission>
+  <permission>Poi: Modify issue state</permission>
+  <permission>Poi: Modify issue tags</permission>
+  <permission>Poi: Modify issue target release</permission>
+  <permission>Poi: Modify issue watchers</permission>
+  <permission>Poi: Upload attachment</permission>
+  <permission>Portlets: Manage portlets</permission>
+  <permission>Remove GEVER content</permission>
+  <permission>Sharing page: Delegate Administrator role</permission>
+  <permission>Sharing page: Delegate Contributor role</permission>
+  <permission>Sharing page: Delegate DossierManager role</permission>
+  <permission>Sharing page: Delegate Editor role</permission>
+  <permission>Sharing page: Delegate Publisher role</permission>
+  <permission>Sharing page: Delegate Reader role</permission>
+  <permission>Sharing page: Delegate Reviewer role</permission>
+  <permission>Sharing page: Delegate WorkspaceAdmin role</permission>
+  <permission>Sharing page: Delegate WorkspaceGuest role</permission>
+  <permission>Sharing page: Delegate WorkspaceMember role</permission>
+  <permission>Sharing page: Delegate WorkspacesCreator role</permission>
+  <permission>Sharing page: Delegate WorkspacesUser role</permission>
+  <permission>Sharing page: Delegate roles</permission>
+  <permission>Take ownership</permission>
+  <permission>View</permission>
+  <permission>ftw.keywordwidget: Add new term</permission>
+  <permission>ftw.mail: Add Inbound Mail</permission>
+  <permission>ftw.mail: Add Mail</permission>
+  <permission>iterate : Check in content</permission>
+  <permission>iterate : Check out content</permission>
+  <permission>opengever.contact: Add contact</permission>
+  <permission>opengever.contact: Add contactfolder</permission>
+  <permission>opengever.contact: Add person</permission>
+  <permission>opengever.contact: Edit person</permission>
+  <permission>opengever.disposition: Add disposition</permission>
+  <permission>opengever.disposition: Download SIP Package</permission>
+  <permission>opengever.disposition: Edit transfer number</permission>
+  <permission>opengever.document: Modify archival file</permission>
+  <permission>opengever.dossier: Add businesscasedossier</permission>
+  <permission>opengever.dossier: Add dossiertemplate</permission>
+  <permission>opengever.dossier: Add templatefolder</permission>
+  <permission>opengever.dossier: Destroy dossier</permission>
+  <permission>opengever.dossier: Protect dossier</permission>
+  <permission>opengever.inbox: Add Forwarding</permission>
+  <permission>opengever.inbox: Add Inbox</permission>
+  <permission>opengever.inbox: Add Year Folder</permission>
+  <permission>opengever.inbox: Scan In</permission>
+  <permission>opengever.meeting: Add Committee</permission>
+  <permission>opengever.meeting: Add CommitteeContainer</permission>
+  <permission>opengever.meeting: Add Member</permission>
+  <permission>opengever.meeting: Add Period</permission>
+  <permission>opengever.meeting: Add Proposal</permission>
+  <permission>opengever.meeting: Add Proposal Template</permission>
+  <permission>opengever.meeting: Add Sablon Template</permission>
+  <permission>opengever.private: Add private dossier</permission>
+  <permission>opengever.private: Add private folder</permission>
+  <permission>opengever.private: Add private root</permission>
+  <permission>opengever.repository: Add repositoryfolder</permission>
+  <permission>opengever.repository: Add repositoryroot</permission>
+  <permission>opengever.repository: Unlock Reference Prefix</permission>
+  <permission>opengever.task: Add task</permission>
+  <permission>opengever.task: Add task comment</permission>
+  <permission>opengever.task: Edit task</permission>
+  <permission>opengever.trash: Trash content</permission>
+  <permission>opengever.trash: Untrash content</permission>
+  <permission>plone.portlet.collection: Add collection portlet</permission>
+  <permission>plone.portlet.static: Add static portlet</permission>
+  <state state_id="opengever_workspace_folder--STATUS--active" title="Active">
+    <permission-map name="Access contents information" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceGuest</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="CMFEditions: Access previous versions" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceGuest</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="CMFEditions: Apply version control" acquired="False"/>
+    <permission-map name="CMFEditions: Checkout to location" acquired="False"/>
+    <permission-map name="CMFEditions: Revert to previous versions" acquired="False"/>
+    <permission-map name="CMFEditions: Save new version" acquired="False"/>
+    <permission-map name="Change local roles" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+    </permission-map>
+    <permission-map name="Delete objects" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="Edit comments" acquired="False"/>
+    <permission-map name="Edit date of cassation" acquired="False"/>
+    <permission-map name="Edit date of submission" acquired="False"/>
+    <permission-map name="List folder contents" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="Manage properties" acquired="False"/>
+    <permission-map name="Modify constrain types" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="Modify view template" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="Poi: Edit response" acquired="False"/>
+    <permission-map name="Poi: Modify issue assignment" acquired="False"/>
+    <permission-map name="Poi: Modify issue severity" acquired="False"/>
+    <permission-map name="Poi: Modify issue state" acquired="False"/>
+    <permission-map name="Poi: Modify issue tags" acquired="False"/>
+    <permission-map name="Poi: Modify issue target release" acquired="False"/>
+    <permission-map name="Poi: Modify issue watchers" acquired="False"/>
+    <permission-map name="Poi: Upload attachment" acquired="False"/>
+    <permission-map name="Portlets: Manage portlets" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="Remove GEVER content" acquired="False"/>
+    <permission-map name="Sharing page: Delegate Administrator role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate Contributor role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate DossierManager role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate Editor role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate Publisher role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate Reader role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate Reviewer role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate WorkspaceAdmin role" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+    </permission-map>
+    <permission-map name="Sharing page: Delegate WorkspaceGuest role" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+    </permission-map>
+    <permission-map name="Sharing page: Delegate WorkspaceMember role" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+    </permission-map>
+    <permission-map name="Sharing page: Delegate WorkspacesCreator role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate WorkspacesUser role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate roles" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+    </permission-map>
+    <permission-map name="Take ownership" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+    </permission-map>
+    <permission-map name="View" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceGuest</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="ftw.keywordwidget: Add new term" acquired="False"/>
+    <permission-map name="ftw.mail: Add Inbound Mail" acquired="False"/>
+    <permission-map name="ftw.mail: Add Mail" acquired="False"/>
+    <permission-map name="iterate : Check in content" acquired="False"/>
+    <permission-map name="iterate : Check out content" acquired="False"/>
+    <permission-map name="opengever.contact: Add contact" acquired="False"/>
+    <permission-map name="opengever.contact: Add contactfolder" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="opengever.contact: Add person" acquired="False"/>
+    <permission-map name="opengever.contact: Edit person" acquired="False"/>
+    <permission-map name="opengever.disposition: Add disposition" acquired="False"/>
+    <permission-map name="opengever.disposition: Download SIP Package" acquired="False"/>
+    <permission-map name="opengever.disposition: Edit transfer number" acquired="False"/>
+    <permission-map name="opengever.document: Modify archival file" acquired="False"/>
+    <permission-map name="opengever.dossier: Add businesscasedossier" acquired="False"/>
+    <permission-map name="opengever.dossier: Add dossiertemplate" acquired="False"/>
+    <permission-map name="opengever.dossier: Add templatefolder" acquired="False"/>
+    <permission-map name="opengever.dossier: Destroy dossier" acquired="False"/>
+    <permission-map name="opengever.dossier: Protect dossier" acquired="False"/>
+    <permission-map name="opengever.inbox: Add Forwarding" acquired="False"/>
+    <permission-map name="opengever.inbox: Add Inbox" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="opengever.inbox: Add Year Folder" acquired="False"/>
+    <permission-map name="opengever.inbox: Scan In" acquired="False"/>
+    <permission-map name="opengever.meeting: Add Committee" acquired="False"/>
+    <permission-map name="opengever.meeting: Add CommitteeContainer" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="opengever.meeting: Add Member" acquired="False"/>
+    <permission-map name="opengever.meeting: Add Period" acquired="False"/>
+    <permission-map name="opengever.meeting: Add Proposal" acquired="False"/>
+    <permission-map name="opengever.meeting: Add Proposal Template" acquired="False"/>
+    <permission-map name="opengever.meeting: Add Sablon Template" acquired="False"/>
+    <permission-map name="opengever.private: Add private dossier" acquired="False"/>
+    <permission-map name="opengever.private: Add private folder" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="opengever.private: Add private root" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="opengever.repository: Add repositoryfolder" acquired="False"/>
+    <permission-map name="opengever.repository: Add repositoryroot" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="opengever.repository: Unlock Reference Prefix" acquired="False"/>
+    <permission-map name="opengever.task: Add task" acquired="False"/>
+    <permission-map name="opengever.task: Add task comment" acquired="False"/>
+    <permission-map name="opengever.task: Edit task" acquired="False"/>
+    <permission-map name="opengever.trash: Trash content" acquired="False"/>
+    <permission-map name="opengever.trash: Untrash content" acquired="False"/>
+    <permission-map name="plone.portlet.collection: Add collection portlet" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="plone.portlet.static: Add static portlet" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+  </state>
+  <variable variable_id="action" for_catalog="False" for_status="True" update_always="True">
+    <description>Previous transition</description>
+    <default>
+        <expression>transition/getId|nothing</expression>
+    </default>
+    <guard/>
+</variable>
+  <variable variable_id="actor" for_catalog="False" for_status="True" update_always="True">
+<description>The ID of the user who performed the previous transition</description>
+    <default>
+        <expression>user/getId</expression>
+    </default>
+    <guard/>
+</variable>
+  <variable variable_id="comments" for_catalog="False" for_status="True" update_always="True">
+    <description>Comment about the last transition</description>
+    <default>
+        <expression>python:state_change.kwargs.get('comment', '')</expression>
+    </default>
+    <guard/>
+</variable>
+  <variable variable_id="review_history" for_catalog="False" for_status="False" update_always="False">
+    <description>Provides access to workflow history</description>
+    <default>
+        <expression>state_change/getHistory</expression>
+    </default>
+    <guard>
+        <guard-permission>Request review</guard-permission>
+        <guard-permission>Review portal content</guard-permission>
+    </guard>
+</variable>
+  <variable variable_id="time" for_catalog="False" for_status="True" update_always="True">
+    <description>When the previous transition was performed</description>
+    <default>
+        <expression>state_change/getDateTime</expression>
+    </default>
+    <guard/>
+</variable>
+</dc-workflow>

--- a/opengever/core/upgrades/20200827114625_update_workspace_workflow/workflows/opengever_workspace_todo/definition.xml
+++ b/opengever/core/upgrades/20200827114625_update_workspace_workflow/workflows/opengever_workspace_todo/definition.xml
@@ -1,0 +1,339 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<dc-workflow workflow_id="opengever_workspace_todo" title="Workspace todo workflow" description="" initial_state="opengever_workspace_todo--STATUS--active" state_variable="review_state" manager_bypass="True">
+  <permission>Access contents information</permission>
+  <permission>CMFEditions: Access previous versions</permission>
+  <permission>CMFEditions: Apply version control</permission>
+  <permission>CMFEditions: Checkout to location</permission>
+  <permission>CMFEditions: Revert to previous versions</permission>
+  <permission>CMFEditions: Save new version</permission>
+  <permission>Change local roles</permission>
+  <permission>Edit comments</permission>
+  <permission>Edit date of cassation</permission>
+  <permission>Edit date of submission</permission>
+  <permission>List folder contents</permission>
+  <permission>Manage properties</permission>
+  <permission>Modify constrain types</permission>
+  <permission>Modify view template</permission>
+  <permission>Poi: Edit response</permission>
+  <permission>Poi: Modify issue assignment</permission>
+  <permission>Poi: Modify issue severity</permission>
+  <permission>Poi: Modify issue state</permission>
+  <permission>Poi: Modify issue tags</permission>
+  <permission>Poi: Modify issue target release</permission>
+  <permission>Poi: Modify issue watchers</permission>
+  <permission>Poi: Upload attachment</permission>
+  <permission>Portlets: Manage portlets</permission>
+  <permission>Sharing page: Delegate Administrator role</permission>
+  <permission>Sharing page: Delegate CommitteeAdministrator role</permission>
+  <permission>Sharing page: Delegate CommitteeMember role</permission>
+  <permission>Sharing page: Delegate CommitteeResponsible role</permission>
+  <permission>Sharing page: Delegate Contributor role</permission>
+  <permission>Sharing page: Delegate DossierManager role</permission>
+  <permission>Sharing page: Delegate Editor role</permission>
+  <permission>Sharing page: Delegate MeetingUser role</permission>
+  <permission>Sharing page: Delegate Publisher role</permission>
+  <permission>Sharing page: Delegate Reader role</permission>
+  <permission>Sharing page: Delegate Reviewer role</permission>
+  <permission>Sharing page: Delegate WorkspaceAdmin role</permission>
+  <permission>Sharing page: Delegate WorkspaceGuest role</permission>
+  <permission>Sharing page: Delegate WorkspaceMember role</permission>
+  <permission>Sharing page: Delegate WorkspacesCreator role</permission>
+  <permission>Sharing page: Delegate WorkspacesUser role</permission>
+  <permission>Sharing page: Delegate roles</permission>
+  <permission>Take ownership</permission>
+  <permission>View</permission>
+  <permission>ftw.keywordwidget: Add new term</permission>
+  <permission>ftw.mail: Add Inbound Mail</permission>
+  <permission>iterate : Check in content</permission>
+  <permission>iterate : Check out content</permission>
+  <permission>opengever.contact: Add contact</permission>
+  <permission>opengever.contact: Add contactfolder</permission>
+  <permission>opengever.contact: Add person</permission>
+  <permission>opengever.contact: Edit person</permission>
+  <permission>opengever.disposition: Add disposition</permission>
+  <permission>opengever.disposition: Download SIP Package</permission>
+  <permission>opengever.disposition: Edit transfer number</permission>
+  <permission>opengever.document: Add document</permission>
+  <permission>opengever.document: Cancel</permission>
+  <permission>opengever.document: Checkin</permission>
+  <permission>opengever.document: Checkout</permission>
+  <permission>opengever.document: Force Checkin</permission>
+  <permission>opengever.document: Modify archival file</permission>
+  <permission>opengever.dossier: Add businesscasedossier</permission>
+  <permission>opengever.dossier: Add dossiertemplate</permission>
+  <permission>opengever.dossier: Add templatefolder</permission>
+  <permission>opengever.dossier: Destroy dossier</permission>
+  <permission>opengever.dossier: Protect dossier</permission>
+  <permission>opengever.inbox: Add Forwarding</permission>
+  <permission>opengever.inbox: Add Inbox</permission>
+  <permission>opengever.inbox: Add Year Folder</permission>
+  <permission>opengever.inbox: Scan In</permission>
+  <permission>opengever.meeting: Add Committee</permission>
+  <permission>opengever.meeting: Add CommitteeContainer</permission>
+  <permission>opengever.meeting: Add Member</permission>
+  <permission>opengever.meeting: Add Period</permission>
+  <permission>opengever.meeting: Add Proposal</permission>
+  <permission>opengever.meeting: Add Proposal Template</permission>
+  <permission>opengever.meeting: Add Sablon Template</permission>
+  <permission>opengever.private: Add private dossier</permission>
+  <permission>opengever.private: Add private folder</permission>
+  <permission>opengever.private: Add private root</permission>
+  <permission>opengever.repository: Add repositoryfolder</permission>
+  <permission>opengever.repository: Add repositoryroot</permission>
+  <permission>opengever.repository: Unlock Reference Prefix</permission>
+  <permission>opengever.task: Add task</permission>
+  <permission>opengever.task: Add task comment</permission>
+  <permission>opengever.task: Edit task</permission>
+  <permission>opengever.trash: Trash content</permission>
+  <permission>opengever.trash: Untrash content</permission>
+  <permission>opengever.workspace: Add Workspace</permission>
+  <permission>plone.portlet.collection: Add collection portlet</permission>
+  <permission>plone.portlet.static: Add static portlet</permission>
+  <state state_id="opengever_workspace_todo--STATUS--active" title="Active">
+    <permission-map name="Access contents information" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceGuest</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="CMFEditions: Access previous versions" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceGuest</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="CMFEditions: Apply version control" acquired="False"/>
+    <permission-map name="CMFEditions: Checkout to location" acquired="False"/>
+    <permission-map name="CMFEditions: Revert to previous versions" acquired="False"/>
+    <permission-map name="CMFEditions: Save new version" acquired="False"/>
+    <permission-map name="Change local roles" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+    </permission-map>
+    <permission-map name="Edit comments" acquired="False"/>
+    <permission-map name="Edit date of cassation" acquired="False"/>
+    <permission-map name="Edit date of submission" acquired="False"/>
+    <permission-map name="List folder contents" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="Manage properties" acquired="False"/>
+    <permission-map name="Modify constrain types" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="Modify view template" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="Poi: Edit response" acquired="False"/>
+    <permission-map name="Poi: Modify issue assignment" acquired="False"/>
+    <permission-map name="Poi: Modify issue severity" acquired="False"/>
+    <permission-map name="Poi: Modify issue state" acquired="False"/>
+    <permission-map name="Poi: Modify issue tags" acquired="False"/>
+    <permission-map name="Poi: Modify issue target release" acquired="False"/>
+    <permission-map name="Poi: Modify issue watchers" acquired="False"/>
+    <permission-map name="Poi: Upload attachment" acquired="False"/>
+    <permission-map name="Portlets: Manage portlets" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="Sharing page: Delegate Administrator role" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+    </permission-map>
+    <permission-map name="Sharing page: Delegate CommitteeAdministrator role" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+    </permission-map>
+    <permission-map name="Sharing page: Delegate CommitteeMember role" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+    </permission-map>
+    <permission-map name="Sharing page: Delegate CommitteeResponsible role" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+    </permission-map>
+    <permission-map name="Sharing page: Delegate Contributor role" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+    </permission-map>
+    <permission-map name="Sharing page: Delegate DossierManager role" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+    </permission-map>
+    <permission-map name="Sharing page: Delegate Editor role" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+    </permission-map>
+    <permission-map name="Sharing page: Delegate MeetingUser role" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+    </permission-map>
+    <permission-map name="Sharing page: Delegate Publisher role" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+    </permission-map>
+    <permission-map name="Sharing page: Delegate Reader role" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+    </permission-map>
+    <permission-map name="Sharing page: Delegate Reviewer role" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+    </permission-map>
+    <permission-map name="Sharing page: Delegate WorkspaceAdmin role" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+    </permission-map>
+    <permission-map name="Sharing page: Delegate WorkspaceGuest role" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+    </permission-map>
+    <permission-map name="Sharing page: Delegate WorkspaceMember role" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+    </permission-map>
+    <permission-map name="Sharing page: Delegate WorkspacesCreator role" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+    </permission-map>
+    <permission-map name="Sharing page: Delegate WorkspacesUser role" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+    </permission-map>
+    <permission-map name="Sharing page: Delegate roles" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+    </permission-map>
+    <permission-map name="Take ownership" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+    </permission-map>
+    <permission-map name="View" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceGuest</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="ftw.keywordwidget: Add new term" acquired="False"/>
+    <permission-map name="ftw.mail: Add Inbound Mail" acquired="False"/>
+    <permission-map name="iterate : Check in content" acquired="False"/>
+    <permission-map name="iterate : Check out content" acquired="False"/>
+    <permission-map name="opengever.contact: Add contact" acquired="False"/>
+    <permission-map name="opengever.contact: Add contactfolder" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="opengever.contact: Add person" acquired="False"/>
+    <permission-map name="opengever.contact: Edit person" acquired="False"/>
+    <permission-map name="opengever.disposition: Add disposition" acquired="False"/>
+    <permission-map name="opengever.disposition: Download SIP Package" acquired="False"/>
+    <permission-map name="opengever.disposition: Edit transfer number" acquired="False"/>
+    <permission-map name="opengever.document: Add document" acquired="False"/>
+    <permission-map name="opengever.document: Cancel" acquired="False"/>
+    <permission-map name="opengever.document: Checkin" acquired="False"/>
+    <permission-map name="opengever.document: Checkout" acquired="False"/>
+    <permission-map name="opengever.document: Force Checkin" acquired="False"/>
+    <permission-map name="opengever.document: Modify archival file" acquired="False"/>
+    <permission-map name="opengever.dossier: Add businesscasedossier" acquired="False"/>
+    <permission-map name="opengever.dossier: Add dossiertemplate" acquired="False"/>
+    <permission-map name="opengever.dossier: Add templatefolder" acquired="False"/>
+    <permission-map name="opengever.dossier: Destroy dossier" acquired="False"/>
+    <permission-map name="opengever.dossier: Protect dossier" acquired="False"/>
+    <permission-map name="opengever.inbox: Add Forwarding" acquired="False"/>
+    <permission-map name="opengever.inbox: Add Inbox" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="opengever.inbox: Add Year Folder" acquired="False"/>
+    <permission-map name="opengever.inbox: Scan In" acquired="False"/>
+    <permission-map name="opengever.meeting: Add Committee" acquired="False"/>
+    <permission-map name="opengever.meeting: Add CommitteeContainer" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="opengever.meeting: Add Member" acquired="False"/>
+    <permission-map name="opengever.meeting: Add Period" acquired="False"/>
+    <permission-map name="opengever.meeting: Add Proposal" acquired="False"/>
+    <permission-map name="opengever.meeting: Add Proposal Template" acquired="False"/>
+    <permission-map name="opengever.meeting: Add Sablon Template" acquired="False"/>
+    <permission-map name="opengever.private: Add private dossier" acquired="False"/>
+    <permission-map name="opengever.private: Add private folder" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="opengever.private: Add private root" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="opengever.repository: Add repositoryfolder" acquired="False"/>
+    <permission-map name="opengever.repository: Add repositoryroot" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="opengever.repository: Unlock Reference Prefix" acquired="False"/>
+    <permission-map name="opengever.task: Add task" acquired="False"/>
+    <permission-map name="opengever.task: Add task comment" acquired="False"/>
+    <permission-map name="opengever.task: Edit task" acquired="False"/>
+    <permission-map name="opengever.trash: Trash content" acquired="False"/>
+    <permission-map name="opengever.trash: Untrash content" acquired="False"/>
+    <permission-map name="opengever.workspace: Add Workspace" acquired="False"/>
+    <permission-map name="plone.portlet.collection: Add collection portlet" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="plone.portlet.static: Add static portlet" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+  </state>
+  <variable variable_id="action" for_catalog="False" for_status="True" update_always="True">
+    <description>Previous transition</description>
+    <default>
+        <expression>transition/getId|nothing</expression>
+    </default>
+    <guard/>
+</variable>
+  <variable variable_id="actor" for_catalog="False" for_status="True" update_always="True">
+<description>The ID of the user who performed the previous transition</description>
+    <default>
+        <expression>user/getId</expression>
+    </default>
+    <guard/>
+</variable>
+  <variable variable_id="comments" for_catalog="False" for_status="True" update_always="True">
+    <description>Comment about the last transition</description>
+    <default>
+        <expression>python:state_change.kwargs.get('comment', '')</expression>
+    </default>
+    <guard/>
+</variable>
+  <variable variable_id="review_history" for_catalog="False" for_status="False" update_always="False">
+    <description>Provides access to workflow history</description>
+    <default>
+        <expression>state_change/getHistory</expression>
+    </default>
+    <guard>
+        <guard-permission>Request review</guard-permission>
+        <guard-permission>Review portal content</guard-permission>
+    </guard>
+</variable>
+  <variable variable_id="time" for_catalog="False" for_status="True" update_always="True">
+    <description>When the previous transition was performed</description>
+    <default>
+        <expression>state_change/getDateTime</expression>
+    </default>
+    <guard/>
+</variable>
+</dc-workflow>

--- a/opengever/core/upgrades/20200827114625_update_workspace_workflow/workflows/opengever_workspace_todolist/definition.xml
+++ b/opengever/core/upgrades/20200827114625_update_workspace_workflow/workflows/opengever_workspace_todolist/definition.xml
@@ -1,0 +1,339 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<dc-workflow workflow_id="opengever_workspace_todolist" title="Workspace todolist workflow" description="" initial_state="opengever_workspace_todolist--STATUS--active" state_variable="review_state" manager_bypass="True">
+  <permission>Access contents information</permission>
+  <permission>CMFEditions: Access previous versions</permission>
+  <permission>CMFEditions: Apply version control</permission>
+  <permission>CMFEditions: Checkout to location</permission>
+  <permission>CMFEditions: Revert to previous versions</permission>
+  <permission>CMFEditions: Save new version</permission>
+  <permission>Change local roles</permission>
+  <permission>Edit comments</permission>
+  <permission>Edit date of cassation</permission>
+  <permission>Edit date of submission</permission>
+  <permission>List folder contents</permission>
+  <permission>Manage properties</permission>
+  <permission>Modify constrain types</permission>
+  <permission>Modify view template</permission>
+  <permission>Poi: Edit response</permission>
+  <permission>Poi: Modify issue assignment</permission>
+  <permission>Poi: Modify issue severity</permission>
+  <permission>Poi: Modify issue state</permission>
+  <permission>Poi: Modify issue tags</permission>
+  <permission>Poi: Modify issue target release</permission>
+  <permission>Poi: Modify issue watchers</permission>
+  <permission>Poi: Upload attachment</permission>
+  <permission>Portlets: Manage portlets</permission>
+  <permission>Sharing page: Delegate Administrator role</permission>
+  <permission>Sharing page: Delegate CommitteeAdministrator role</permission>
+  <permission>Sharing page: Delegate CommitteeMember role</permission>
+  <permission>Sharing page: Delegate CommitteeResponsible role</permission>
+  <permission>Sharing page: Delegate Contributor role</permission>
+  <permission>Sharing page: Delegate DossierManager role</permission>
+  <permission>Sharing page: Delegate Editor role</permission>
+  <permission>Sharing page: Delegate MeetingUser role</permission>
+  <permission>Sharing page: Delegate Publisher role</permission>
+  <permission>Sharing page: Delegate Reader role</permission>
+  <permission>Sharing page: Delegate Reviewer role</permission>
+  <permission>Sharing page: Delegate WorkspaceAdmin role</permission>
+  <permission>Sharing page: Delegate WorkspaceGuest role</permission>
+  <permission>Sharing page: Delegate WorkspaceMember role</permission>
+  <permission>Sharing page: Delegate WorkspacesCreator role</permission>
+  <permission>Sharing page: Delegate WorkspacesUser role</permission>
+  <permission>Sharing page: Delegate roles</permission>
+  <permission>Take ownership</permission>
+  <permission>View</permission>
+  <permission>ftw.keywordwidget: Add new term</permission>
+  <permission>ftw.mail: Add Inbound Mail</permission>
+  <permission>iterate : Check in content</permission>
+  <permission>iterate : Check out content</permission>
+  <permission>opengever.contact: Add contact</permission>
+  <permission>opengever.contact: Add contactfolder</permission>
+  <permission>opengever.contact: Add person</permission>
+  <permission>opengever.contact: Edit person</permission>
+  <permission>opengever.disposition: Add disposition</permission>
+  <permission>opengever.disposition: Download SIP Package</permission>
+  <permission>opengever.disposition: Edit transfer number</permission>
+  <permission>opengever.document: Add document</permission>
+  <permission>opengever.document: Cancel</permission>
+  <permission>opengever.document: Checkin</permission>
+  <permission>opengever.document: Checkout</permission>
+  <permission>opengever.document: Force Checkin</permission>
+  <permission>opengever.document: Modify archival file</permission>
+  <permission>opengever.dossier: Add businesscasedossier</permission>
+  <permission>opengever.dossier: Add dossiertemplate</permission>
+  <permission>opengever.dossier: Add templatefolder</permission>
+  <permission>opengever.dossier: Destroy dossier</permission>
+  <permission>opengever.dossier: Protect dossier</permission>
+  <permission>opengever.inbox: Add Forwarding</permission>
+  <permission>opengever.inbox: Add Inbox</permission>
+  <permission>opengever.inbox: Add Year Folder</permission>
+  <permission>opengever.inbox: Scan In</permission>
+  <permission>opengever.meeting: Add Committee</permission>
+  <permission>opengever.meeting: Add CommitteeContainer</permission>
+  <permission>opengever.meeting: Add Member</permission>
+  <permission>opengever.meeting: Add Period</permission>
+  <permission>opengever.meeting: Add Proposal</permission>
+  <permission>opengever.meeting: Add Proposal Template</permission>
+  <permission>opengever.meeting: Add Sablon Template</permission>
+  <permission>opengever.private: Add private dossier</permission>
+  <permission>opengever.private: Add private folder</permission>
+  <permission>opengever.private: Add private root</permission>
+  <permission>opengever.repository: Add repositoryfolder</permission>
+  <permission>opengever.repository: Add repositoryroot</permission>
+  <permission>opengever.repository: Unlock Reference Prefix</permission>
+  <permission>opengever.task: Add task</permission>
+  <permission>opengever.task: Add task comment</permission>
+  <permission>opengever.task: Edit task</permission>
+  <permission>opengever.trash: Trash content</permission>
+  <permission>opengever.trash: Untrash content</permission>
+  <permission>opengever.workspace: Add Workspace</permission>
+  <permission>plone.portlet.collection: Add collection portlet</permission>
+  <permission>plone.portlet.static: Add static portlet</permission>
+  <state state_id="opengever_workspace_todolist--STATUS--active" title="Active">
+    <permission-map name="Access contents information" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceGuest</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="CMFEditions: Access previous versions" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceGuest</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="CMFEditions: Apply version control" acquired="False"/>
+    <permission-map name="CMFEditions: Checkout to location" acquired="False"/>
+    <permission-map name="CMFEditions: Revert to previous versions" acquired="False"/>
+    <permission-map name="CMFEditions: Save new version" acquired="False"/>
+    <permission-map name="Change local roles" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+    </permission-map>
+    <permission-map name="Edit comments" acquired="False"/>
+    <permission-map name="Edit date of cassation" acquired="False"/>
+    <permission-map name="Edit date of submission" acquired="False"/>
+    <permission-map name="List folder contents" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="Manage properties" acquired="False"/>
+    <permission-map name="Modify constrain types" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="Modify view template" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="Poi: Edit response" acquired="False"/>
+    <permission-map name="Poi: Modify issue assignment" acquired="False"/>
+    <permission-map name="Poi: Modify issue severity" acquired="False"/>
+    <permission-map name="Poi: Modify issue state" acquired="False"/>
+    <permission-map name="Poi: Modify issue tags" acquired="False"/>
+    <permission-map name="Poi: Modify issue target release" acquired="False"/>
+    <permission-map name="Poi: Modify issue watchers" acquired="False"/>
+    <permission-map name="Poi: Upload attachment" acquired="False"/>
+    <permission-map name="Portlets: Manage portlets" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="Sharing page: Delegate Administrator role" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+    </permission-map>
+    <permission-map name="Sharing page: Delegate CommitteeAdministrator role" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+    </permission-map>
+    <permission-map name="Sharing page: Delegate CommitteeMember role" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+    </permission-map>
+    <permission-map name="Sharing page: Delegate CommitteeResponsible role" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+    </permission-map>
+    <permission-map name="Sharing page: Delegate Contributor role" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+    </permission-map>
+    <permission-map name="Sharing page: Delegate DossierManager role" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+    </permission-map>
+    <permission-map name="Sharing page: Delegate Editor role" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+    </permission-map>
+    <permission-map name="Sharing page: Delegate MeetingUser role" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+    </permission-map>
+    <permission-map name="Sharing page: Delegate Publisher role" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+    </permission-map>
+    <permission-map name="Sharing page: Delegate Reader role" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+    </permission-map>
+    <permission-map name="Sharing page: Delegate Reviewer role" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+    </permission-map>
+    <permission-map name="Sharing page: Delegate WorkspaceAdmin role" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+    </permission-map>
+    <permission-map name="Sharing page: Delegate WorkspaceGuest role" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+    </permission-map>
+    <permission-map name="Sharing page: Delegate WorkspaceMember role" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+    </permission-map>
+    <permission-map name="Sharing page: Delegate WorkspacesCreator role" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+    </permission-map>
+    <permission-map name="Sharing page: Delegate WorkspacesUser role" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+    </permission-map>
+    <permission-map name="Sharing page: Delegate roles" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+    </permission-map>
+    <permission-map name="Take ownership" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+    </permission-map>
+    <permission-map name="View" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceGuest</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="ftw.keywordwidget: Add new term" acquired="False"/>
+    <permission-map name="ftw.mail: Add Inbound Mail" acquired="False"/>
+    <permission-map name="iterate : Check in content" acquired="False"/>
+    <permission-map name="iterate : Check out content" acquired="False"/>
+    <permission-map name="opengever.contact: Add contact" acquired="False"/>
+    <permission-map name="opengever.contact: Add contactfolder" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="opengever.contact: Add person" acquired="False"/>
+    <permission-map name="opengever.contact: Edit person" acquired="False"/>
+    <permission-map name="opengever.disposition: Add disposition" acquired="False"/>
+    <permission-map name="opengever.disposition: Download SIP Package" acquired="False"/>
+    <permission-map name="opengever.disposition: Edit transfer number" acquired="False"/>
+    <permission-map name="opengever.document: Add document" acquired="False"/>
+    <permission-map name="opengever.document: Cancel" acquired="False"/>
+    <permission-map name="opengever.document: Checkin" acquired="False"/>
+    <permission-map name="opengever.document: Checkout" acquired="False"/>
+    <permission-map name="opengever.document: Force Checkin" acquired="False"/>
+    <permission-map name="opengever.document: Modify archival file" acquired="False"/>
+    <permission-map name="opengever.dossier: Add businesscasedossier" acquired="False"/>
+    <permission-map name="opengever.dossier: Add dossiertemplate" acquired="False"/>
+    <permission-map name="opengever.dossier: Add templatefolder" acquired="False"/>
+    <permission-map name="opengever.dossier: Destroy dossier" acquired="False"/>
+    <permission-map name="opengever.dossier: Protect dossier" acquired="False"/>
+    <permission-map name="opengever.inbox: Add Forwarding" acquired="False"/>
+    <permission-map name="opengever.inbox: Add Inbox" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="opengever.inbox: Add Year Folder" acquired="False"/>
+    <permission-map name="opengever.inbox: Scan In" acquired="False"/>
+    <permission-map name="opengever.meeting: Add Committee" acquired="False"/>
+    <permission-map name="opengever.meeting: Add CommitteeContainer" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="opengever.meeting: Add Member" acquired="False"/>
+    <permission-map name="opengever.meeting: Add Period" acquired="False"/>
+    <permission-map name="opengever.meeting: Add Proposal" acquired="False"/>
+    <permission-map name="opengever.meeting: Add Proposal Template" acquired="False"/>
+    <permission-map name="opengever.meeting: Add Sablon Template" acquired="False"/>
+    <permission-map name="opengever.private: Add private dossier" acquired="False"/>
+    <permission-map name="opengever.private: Add private folder" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="opengever.private: Add private root" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="opengever.repository: Add repositoryfolder" acquired="False"/>
+    <permission-map name="opengever.repository: Add repositoryroot" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="opengever.repository: Unlock Reference Prefix" acquired="False"/>
+    <permission-map name="opengever.task: Add task" acquired="False"/>
+    <permission-map name="opengever.task: Add task comment" acquired="False"/>
+    <permission-map name="opengever.task: Edit task" acquired="False"/>
+    <permission-map name="opengever.trash: Trash content" acquired="False"/>
+    <permission-map name="opengever.trash: Untrash content" acquired="False"/>
+    <permission-map name="opengever.workspace: Add Workspace" acquired="False"/>
+    <permission-map name="plone.portlet.collection: Add collection portlet" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="plone.portlet.static: Add static portlet" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+  </state>
+  <variable variable_id="action" for_catalog="False" for_status="True" update_always="True">
+    <description>Previous transition</description>
+    <default>
+        <expression>transition/getId|nothing</expression>
+    </default>
+    <guard/>
+</variable>
+  <variable variable_id="actor" for_catalog="False" for_status="True" update_always="True">
+<description>The ID of the user who performed the previous transition</description>
+    <default>
+        <expression>user/getId</expression>
+    </default>
+    <guard/>
+</variable>
+  <variable variable_id="comments" for_catalog="False" for_status="True" update_always="True">
+    <description>Comment about the last transition</description>
+    <default>
+        <expression>python:state_change.kwargs.get('comment', '')</expression>
+    </default>
+    <guard/>
+</variable>
+  <variable variable_id="review_history" for_catalog="False" for_status="False" update_always="False">
+    <description>Provides access to workflow history</description>
+    <default>
+        <expression>state_change/getHistory</expression>
+    </default>
+    <guard>
+        <guard-permission>Request review</guard-permission>
+        <guard-permission>Review portal content</guard-permission>
+    </guard>
+</variable>
+  <variable variable_id="time" for_catalog="False" for_status="True" update_always="True">
+    <description>When the previous transition was performed</description>
+    <default>
+        <expression>state_change/getDateTime</expression>
+    </default>
+    <guard/>
+</variable>
+</dc-workflow>

--- a/opengever/document/tests/test_copy_document.py
+++ b/opengever/document/tests/test_copy_document.py
@@ -77,10 +77,10 @@ class TestCopyDocuments(IntegrationTestCase):
         # We expect some of the metadata to get modified during pasting
         modified_metadata = {'UID': copy.UID(),
                              # sequence numbers and such
-                             'sequence_number': 41,
-                             'id': 'document-41',
-                             'getId': 'document-41',
-                             'reference': 'Client1 1.1 / 4 / 41',
+                             'sequence_number': 42,
+                             'id': 'document-42',
+                             'getId': 'document-42',
+                             'reference': 'Client1 1.1 / 4 / 42',
                              # creator
                              'listCreators': (self.regular_user.id,),
                              'Creator': self.regular_user.id,
@@ -195,10 +195,10 @@ class TestCopyDocuments(IntegrationTestCase):
             'path': copy.absolute_url_path(),
 
             # sequence numbers and such
-            'id': 'document-41',
-            'getId': 'document-41',
-            'reference': 'Client1 1.1 / 4 / 41',
-            'sequence_number': 41,
+            'id': 'document-42',
+            'getId': 'document-42',
+            'reference': 'Client1 1.1 / 4 / 42',
+            'sequence_number': 42,
 
             # creator
             'Creator': self.regular_user.id,

--- a/opengever/document/tests/test_document.py
+++ b/opengever/document/tests/test_document.py
@@ -282,7 +282,7 @@ class TestDocumentDefaultValues(IntegrationTestCase):
             factoriesmenu.add('Document')
             browser.fill({'Title': u'My Document'}).save()
 
-        document = self.dossier['document-41']
+        document = self.dossier['document-42']
         self.assertEqual(today, document.document_date)
 
     @browsing
@@ -294,7 +294,7 @@ class TestDocumentDefaultValues(IntegrationTestCase):
         factoriesmenu.add('Document')
         browser.fill({'Title': u'My Document', 'File': ('DATA', 'file.txt', 'text/plain')}).save()
 
-        document = self.dossier['document-41']
+        document = self.dossier['document-42']
         self.assertFalse(document.preserved_as_paper)
 
     @browsing
@@ -306,7 +306,7 @@ class TestDocumentDefaultValues(IntegrationTestCase):
         factoriesmenu.add('Document')
         browser.fill({'Title': u'My Document'}).save()
 
-        document = self.dossier['document-41']
+        document = self.dossier['document-42']
         self.assertTrue(document.preserved_as_paper)
 
 

--- a/opengever/document/tests/test_indexers.py
+++ b/opengever/document/tests/test_indexers.py
@@ -236,7 +236,7 @@ class SolrDocumentIndexer(SolrIntegrationTestCase):
 
         response = solr.search(filters=("UID:{}".format(document.UID())))
         indexed_value = response.docs[0].get('SearchableText')
-        self.assertIn(u'Doc One Hugo Boss Client1 1.1 / 1 / 41 41 foo bar',
+        self.assertIn(u'Doc One Hugo Boss Client1 1.1 / 1 / 42 42 foo bar',
                       indexed_value)
 
 

--- a/opengever/dossier/tests/test_templatefolder.py
+++ b/opengever/dossier/tests/test_templatefolder.py
@@ -218,15 +218,15 @@ class TestDocumentWithTemplateFormWithDocProperties(IntegrationTestCase):
         self.assertEquals(u'Test Docx.docx', document.file.filename)
 
         expected_doc_properties = {
-            'Document.ReferenceNumber': 'Client1 1.1 / 1 / 41',
-            'Document.SequenceNumber': '41',
+            'Document.ReferenceNumber': 'Client1 1.1 / 1 / 42',
+            'Document.SequenceNumber': '42',
             'Dossier.ReferenceNumber': 'Client1 1.1 / 1',
             'Dossier.Title': u'Vertr\xe4ge mit der kantonalen Finanzverwaltung',
             'User.FullName': u'B\xe4rfuss K\xe4thi',
             'User.ID': 'kathi.barfuss',
             'ogg.document.document_date': datetime(2020, 9, 28, 0, 0),
-            'ogg.document.reference_number': 'Client1 1.1 / 1 / 41',
-            'ogg.document.sequence_number': '41',
+            'ogg.document.reference_number': 'Client1 1.1 / 1 / 42',
+            'ogg.document.sequence_number': '42',
             'ogg.document.title': 'Test Docx',
             'ogg.document.version_number': 0,
             'ogg.dossier.external_reference': u'qpr-900-9001-\xf7',
@@ -299,15 +299,15 @@ class TestDocumentWithTemplateFormWithDocProperties(IntegrationTestCase):
         self.assertEquals(u'Test Docx.docx', document.file.filename)
 
         expected_doc_properties = {
-            'Document.ReferenceNumber': 'Client1 1.1 / 1 / 41',
-            'Document.SequenceNumber': '41',
+            'Document.ReferenceNumber': 'Client1 1.1 / 1 / 42',
+            'Document.SequenceNumber': '42',
             'Dossier.ReferenceNumber': 'Client1 1.1 / 1',
             'Dossier.Title': u'Vertr\xe4ge mit der kantonalen Finanzverwaltung',
             'User.FullName': u'B\xe4rfuss K\xe4thi',
             'User.ID': 'kathi.barfuss',
             'ogg.document.document_date': datetime(2020, 10, 28, 0, 0),
-            'ogg.document.reference_number': 'Client1 1.1 / 1 / 41',
-            'ogg.document.sequence_number': '41',
+            'ogg.document.reference_number': 'Client1 1.1 / 1 / 42',
+            'ogg.document.sequence_number': '42',
             'ogg.document.title': 'Test Docx',
             'ogg.document.version_number': 0,
             'ogg.dossier.external_reference': u'qpr-900-9001-\xf7',

--- a/opengever/officeconnector/tests/test_api_dossier_oneoffixx.py
+++ b/opengever/officeconnector/tests/test_api_dossier_oneoffixx.py
@@ -41,7 +41,7 @@ class TestOfficeconnectorDossierAPIWithOneOffixx(OCIntegrationTestCase):
         expected_payloads = [{
             u'connect-xml': u'@@oneoffix_connect_xml',
             u'content-type': u'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-            u'document-url': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/document-38',
+            u'document-url': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/document-39',
             u'filename': None,
             u'uuid': u'createshadowdocument000000000001',
             }]
@@ -88,7 +88,7 @@ class TestOfficeconnectorDossierAPIWithOneOffixx(OCIntegrationTestCase):
             u'checkin': u'@checkin',
             u'checkout': u'@checkout',
             u'content-type': 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-            u'document-url': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/document-38',
+            u'document-url': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/document-39',
             u'download': u'download',
             u'filename': None,
             u'lock': u'@lock',

--- a/opengever/oneoffixx/tests/assets/oneoffixx_connect_xml.txt
+++ b/opengever/oneoffixx/tests/assets/oneoffixx_connect_xml.txt
@@ -14,8 +14,8 @@
       <Function name="CustomInterfaceConnector" id="70E94788-CE84-4460-9698-5663878A295B">
         <Arguments>
           <Interface Name="OneGovGEVER">
-            <Node Id="Document.ReferenceNumber">Client1 1.1 / 1 / 38</Node>
-            <Node Id="Document.SequenceNumber">38</Node>
+            <Node Id="Document.ReferenceNumber">Client1 1.1 / 1 / 39</Node>
+            <Node Id="Document.SequenceNumber">39</Node>
             <Node Id="Dossier.ReferenceNumber">Client1 1.1 / 1</Node>
             <Node Id="Dossier.Title">Verträge mit der kantonalen Finanzverwaltung</Node>
             <Node Id="User.FullName">Ziegler Robert</Node>
@@ -26,8 +26,8 @@
             <Node Id="ogg.document.creator.user.title">Ziegler Robert</Node>
             <Node Id="ogg.document.creator.user.userid">robert.ziegler</Node>
             <Node Id="ogg.document.document_date">Aug 31, 2016</Node>
-            <Node Id="ogg.document.reference_number">Client1 1.1 / 1 / 38</Node>
-            <Node Id="ogg.document.sequence_number">38</Node>
+            <Node Id="ogg.document.reference_number">Client1 1.1 / 1 / 39</Node>
+            <Node Id="ogg.document.sequence_number">39</Node>
             <Node Id="ogg.document.title">Schättengarten</Node>
             <Node Id="ogg.document.version_number">0</Node>
             <Node Id="ogg.dossier.external_reference">qpr-900-9001-÷</Node>
@@ -43,8 +43,8 @@
         </Arguments>
       </Function>
       <Function name="MetaData" id="c364b495-7176-4ce2-9f7c-e71f302b8096">
-        <Value key="Document.ReferenceNumber" type="string">Client1 1.1 / 1 / 38</Value>
-        <Value key="Document.SequenceNumber" type="string">38</Value>
+        <Value key="Document.ReferenceNumber" type="string">Client1 1.1 / 1 / 39</Value>
+        <Value key="Document.SequenceNumber" type="string">39</Value>
         <Value key="Dossier.ReferenceNumber" type="string">Client1 1.1 / 1</Value>
         <Value key="Dossier.Title" type="string">Verträge mit der kantonalen Finanzverwaltung</Value>
         <Value key="User.FullName" type="string">Ziegler Robert</Value>
@@ -55,8 +55,8 @@
         <Value key="ogg.document.creator.user.title" type="string">Ziegler Robert</Value>
         <Value key="ogg.document.creator.user.userid" type="string">robert.ziegler</Value>
         <Value key="ogg.document.document_date" type="string">Aug 31, 2016</Value>
-        <Value key="ogg.document.reference_number" type="string">Client1 1.1 / 1 / 38</Value>
-        <Value key="ogg.document.sequence_number" type="string">38</Value>
+        <Value key="ogg.document.reference_number" type="string">Client1 1.1 / 1 / 39</Value>
+        <Value key="ogg.document.sequence_number" type="string">39</Value>
         <Value key="ogg.document.title" type="string">Schättengarten</Value>
         <Value key="ogg.document.version_number" type="string">0</Value>
         <Value key="ogg.dossier.external_reference" type="string">qpr-900-9001-÷</Value>

--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -2158,6 +2158,13 @@ class OpengeverContentFixture(object):
             .within(self.workspace)
             ))
 
+        self.register('workspace_document', create(
+            Builder('document')
+            .within(self.workspace)
+            .titled(u'Teamraumdokument')
+            .with_asset_file('text.txt')
+            ))
+
     def create_todos(self):
         self.todolist_general = self.register('todolist_general', create(
             Builder('todolist')

--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -2109,6 +2109,16 @@ class OpengeverContentFixture(object):
                 )
             ))
 
+        # Enable placeful workflow policy for workspace root
+        self.workspace_root.manage_addProduct[
+            'CMFPlacefulWorkflow'].manage_addWorkflowPolicyConfig()
+        pwf_tool = api.portal.get_tool('portal_placeful_workflow')
+        policy_config = pwf_tool.getWorkflowPolicyConfig(self.workspace_root)
+        policy_config.setPolicyIn(
+            'opengever_workspace_policy', update_security=False)
+        policy_config.setPolicyBelow(
+            'opengever_workspace_policy', update_security=False)
+
         self.set_roles(
             self.workspace_root, self.workspace_owner.getId(),
             ['WorkspacesUser', 'WorkspacesCreator'])

--- a/opengever/workspace/browser/configure.zcml
+++ b/opengever/workspace/browser/configure.zcml
@@ -55,4 +55,12 @@
       permission="zope2.View"
       />
 
+  <!-- Protect edit form for workspace with custom modify permission -->
+  <browser:page
+      for="opengever.workspace.interfaces.IWorkspace"
+      name="edit"
+      class="plone.dexterity.browser.edit.DefaultEditView"
+      permission="opengever.workspace.ModifyWorkspace"
+      />
+
 </configure>

--- a/opengever/workspace/permissions.zcml
+++ b/opengever/workspace/permissions.zcml
@@ -12,4 +12,6 @@
 
   <permission id="opengever.workspace.UpdateContentOrder" title="opengever.workspace: Update Content Order" />
 
+  <permission id="opengever.workspace.ModifyWorkspace" title="opengever.workspace: Modify Workspace" />
+
 </configure>

--- a/opengever/workspace/permissions.zcml
+++ b/opengever/workspace/permissions.zcml
@@ -14,4 +14,6 @@
 
   <permission id="opengever.workspace.ModifyWorkspace" title="opengever.workspace: Modify Workspace" />
 
+  <permission id="opengever.workspace.DeleteTodos" title="opengever.workspace: Delete Todos" />
+
 </configure>

--- a/opengever/workspace/tests/test_deactivate_workspace.py
+++ b/opengever/workspace/tests/test_deactivate_workspace.py
@@ -1,0 +1,226 @@
+from datetime import datetime
+from ftw.testbrowser import browsing
+from ftw.testing.freezer import freeze
+from opengever.testing import IntegrationTestCase
+import json
+import pytz
+
+
+class TestDeactivateWorkspace(IntegrationTestCase):
+
+    def deactivate_workspace(self, browser):
+        browser.open(
+            '{}/@workflow/{}'.format(
+                self.workspace.absolute_url(),
+                'opengever_workspace--TRANSITION--deactivate--active_inactive',
+            ),
+            method='POST', headers=self.api_headers,
+        )
+
+    def reactivate_workspace(self, browser):
+        browser.open(
+            '{}/@workflow/{}'.format(
+                self.workspace.absolute_url(),
+                'opengever_workspace--TRANSITION--reactivate--inactive_active',
+            ),
+            method='POST', headers=self.api_headers,
+        )
+
+    @browsing
+    def test_admin_can_deactivate_workspace(self, browser):
+        self.login(self.workspace_admin, browser)
+        with freeze(datetime(2020, 9, 4, 10, 30, tzinfo=pytz.UTC)):
+            self.deactivate_workspace(browser)
+        self.assertEqual(browser.status_code, 200)
+        self.assertEqual(
+            browser.json,
+            {
+                u'action': u'opengever_workspace--TRANSITION--deactivate--active_inactive',
+                u'actor': u'fridolin.hugentobler',
+                u'comments': u'',
+                u'review_state': u'opengever_workspace--STATUS--inactive',
+                u'time': u'2020-09-04T10:30:00+00:00',
+                u'title': u'Inactive',
+            }
+        )
+
+    @browsing
+    def test_admin_can_reactivate_workspace(self, browser):
+        self.login(self.workspace_admin, browser)
+        with freeze(datetime(2020, 9, 4, 10, 30, tzinfo=pytz.UTC)):
+            self.deactivate_workspace(browser)
+            self.reactivate_workspace(browser)
+        self.assertEqual(browser.status_code, 200)
+        self.assertEqual(
+            browser.json,
+            {
+                u'action': u'opengever_workspace--TRANSITION--reactivate--inactive_active',
+                u'actor': u'fridolin.hugentobler',
+                u'comments': u'',
+                u'review_state': u'opengever_workspace--STATUS--active',
+                u'time': u'2020-09-04T10:30:00+00:00',
+                u'title': u'Active',
+            }
+        )
+
+    @browsing
+    def test_member_cannot_deactivate_workspace(self, browser):
+        self.login(self.workspace_member, browser)
+        with browser.expect_http_error(400):
+            self.deactivate_workspace(browser)
+        self.assertEqual(
+            browser.json,
+            {
+                u'error': {
+                    u'message': u"Invalid transition 'opengever_workspace--TRA"
+                    "NSITION--deactivate--active_inactive'.\nValid transitions"
+                    " are:\n",
+                    u'type': u'Bad Request',
+                },
+            },
+        )
+
+    @browsing
+    def test_member_cannot_reactivate_workspace(self, browser):
+        self.login(self.workspace_admin, browser)
+        self.deactivate_workspace(browser)
+        self.assertEqual(
+            browser.json[u'review_state'],
+            u'opengever_workspace--STATUS--inactive',
+        )
+
+        self.login(self.workspace_member, browser)
+        with browser.expect_http_error(400):
+            self.reactivate_workspace(browser)
+        self.assertEqual(
+            browser.json,
+            {
+                u'error': {
+                    u'message': u"Invalid transition 'opengever_workspace--TRA"
+                    "NSITION--reactivate--inactive_active'.\nValid transitions"
+                    " are:\n",
+                    u'type': u'Bad Request',
+                },
+            },
+        )
+
+    @browsing
+    def test_cannot_deactivate_workspace_if_checked_out_documents(self, browser):
+        self.login(self.workspace_admin, browser)
+        browser.open(
+            '{}/@checkout'.format(self.workspace_document.absolute_url()),
+            method='POST', headers=self.api_headers,
+        )
+        with browser.expect_http_error(400):
+            self.deactivate_workspace(browser)
+        self.assertEqual(
+            browser.json,
+            {
+                u'error': {
+                    u'message': u'Workspace contains checked out documents.',
+                    u'type': u'PreconditionsViolated',
+                },
+            },
+        )
+
+    @browsing
+    def test_cannot_add_document_in_deactivated_workspace(self, browser):
+        self.login(self.workspace_admin, browser)
+        self.deactivate_workspace(browser)
+        with browser.expect_http_error(401):
+            browser.open(
+                self.workspace, method='POST', headers=self.api_headers,
+                data=json.dumps({'@type': 'opengever.document.document'}),
+            )
+        with browser.expect_http_error(401):
+            browser.open(
+                self.workspace_folder, method='POST', headers=self.api_headers,
+                data=json.dumps({'@type': 'opengever.document.document'}),
+            )
+
+    @browsing
+    def test_cannot_add_folder_in_deactivated_workspace(self, browser):
+        self.login(self.workspace_admin, browser)
+        self.deactivate_workspace(browser)
+        with browser.expect_http_error(401):
+            browser.open(
+                self.workspace, method='POST', headers=self.api_headers,
+                data=json.dumps({'@type': 'opengever.workspace.folder'}),
+            )
+
+    @browsing
+    def test_cannot_add_todo_in_deactivated_workspace(self, browser):
+        self.login(self.workspace_admin, browser)
+        self.deactivate_workspace(browser)
+        with browser.expect_http_error(401):
+            browser.open(
+                self.workspace, method='POST', headers=self.api_headers,
+                data=json.dumps({'@type': 'opengever.workspace.todo'}),
+            )
+
+    @browsing
+    def test_cannot_add_todolist_in_deactivated_workspace(self, browser):
+        self.login(self.workspace_admin, browser)
+        self.deactivate_workspace(browser)
+        with browser.expect_http_error(401):
+            browser.open(
+                self.workspace, method='POST', headers=self.api_headers,
+                data=json.dumps({'@type': 'opengever.workspace.todolist'}),
+            )
+
+    @browsing
+    def test_cannot_modify_document_in_deactivated_workspace(self, browser):
+        self.login(self.workspace_admin, browser)
+        self.deactivate_workspace(browser)
+        with browser.expect_http_error(401):
+            browser.open(
+                self.workspace_document, method='PATCH',
+                headers=self.api_headers, data=json.dumps({'title': 'Foo'}),
+            )
+
+    @browsing
+    def test_cannot_modify_folder_in_deactivated_workspace(self, browser):
+        self.login(self.workspace_admin, browser)
+        self.deactivate_workspace(browser)
+        with browser.expect_http_error(401):
+            browser.open(
+                self.workspace_folder, method='PATCH',
+                headers=self.api_headers, data=json.dumps({'title': 'Foo'}),
+            )
+
+    @browsing
+    def test_cannot_modify_todo_in_deactivated_workspace(self, browser):
+        self.login(self.workspace_admin, browser)
+        self.deactivate_workspace(browser)
+        with browser.expect_http_error(401):
+            browser.open(
+                self.todo, method='PATCH', headers=self.api_headers,
+                data=json.dumps({'title': 'Foo'}),
+            )
+
+    @browsing
+    def test_cannot_modify_todolist_in_deactivated_workspace(self, browser):
+        self.login(self.workspace_admin, browser)
+        self.deactivate_workspace(browser)
+        with browser.expect_http_error(401):
+            browser.open(
+                self.todolist_general, method='PATCH',
+                headers=self.api_headers, data=json.dumps({'title': 'Foo'}),
+            )
+
+    @browsing
+    def test_cannot_delete_todo_in_deactivated_workspace(self, browser):
+        self.login(self.workspace_admin, browser)
+        self.deactivate_workspace(browser)
+        with browser.expect_http_error(401):
+            browser.open(self.todo, method='DELETE', headers=self.api_headers)
+
+    @browsing
+    def test_cannot_delete_todolist_in_deactivated_workspace(self, browser):
+        self.login(self.workspace_admin, browser)
+        self.deactivate_workspace(browser)
+        with browser.expect_http_error(401):
+            browser.open(
+                self.todolist_general, method='DELETE',
+                headers=self.api_headers,
+            )

--- a/opengever/workspace/tests/test_deactivate_workspace.py
+++ b/opengever/workspace/tests/test_deactivate_workspace.py
@@ -169,6 +169,21 @@ class TestDeactivateWorkspace(IntegrationTestCase):
             )
 
     @browsing
+    def test_cannot_add_mail_in_deactivated_workspace(self, browser):
+        self.login(self.workspace_admin, browser)
+        self.deactivate_workspace(browser)
+        with browser.expect_http_error(401):
+            browser.open(
+                self.workspace, method='POST', headers=self.api_headers,
+                data=json.dumps({'@type': 'ftw.mail.mail'}),
+            )
+        with browser.expect_http_error(401):
+            browser.open(
+                self.workspace_folder, method='POST', headers=self.api_headers,
+                data=json.dumps({'@type': 'ftw.mail.mail'}),
+            )
+
+    @browsing
     def test_cannot_modify_document_in_deactivated_workspace(self, browser):
         self.login(self.workspace_admin, browser)
         self.deactivate_workspace(browser)

--- a/opengever/workspace/tests/test_todo.py
+++ b/opengever/workspace/tests/test_todo.py
@@ -196,24 +196,34 @@ class TestAPISupportForTodo(IntegrationTestCase):
             last_response.changes)
 
     @browsing
-    def test_deletion_is_only_possible_for_managers(self, browser):
+    def test_members_can_delete_todos(self, browser):
         self.login(self.workspace_member, browser)
-        with browser.expect_http_error(401):
-            browser.open(self.todo, method='DELETE', headers=self.api_headers)
+        todo_id = self.todo.id
+        browser.open(self.todo, method='DELETE', headers=self.api_headers)
+        self.assertEqual(204, browser.status_code)
+        self.assertNotIn(todo_id, self.workspace.objectIds())
 
+    @browsing
+    def test_admins_can_delete_todos(self, browser):
         self.login(self.workspace_admin, browser)
-        with browser.expect_http_error(401):
-            browser.open(self.todo, method='DELETE', headers=self.api_headers)
+        todo_id = self.todo.id
+        browser.open(self.todo, method='DELETE', headers=self.api_headers)
+        self.assertEqual(204, browser.status_code)
+        self.assertNotIn(todo_id, self.workspace.objectIds())
 
-        self.login(self.workspace_owner, browser)
-        with browser.expect_http_error(401):
-            browser.open(self.todo, method='DELETE', headers=self.api_headers)
-
+    @browsing
+    def test_managers_can_delete_todos(self, browser):
         self.login(self.manager, browser)
         todo_id = self.todo.id
         browser.open(self.todo, method='DELETE', headers=self.api_headers)
         self.assertEqual(204, browser.status_code)
         self.assertNotIn(todo_id, self.workspace.objectIds())
+
+    @browsing
+    def test_guests_cannot_delete_todos(self, browser):
+        self.login(self.workspace_guest, browser)
+        with browser.expect_http_error(401):
+            browser.open(self.todo, method='DELETE', headers=self.api_headers)
 
     @browsing
     def test_move_todo_adds_response_object_with_changes(self, browser):

--- a/opengever/workspace/tests/test_todolist.py
+++ b/opengever/workspace/tests/test_todolist.py
@@ -147,7 +147,7 @@ class TestAPISupportForTodoLists(IntegrationTestCase):
                .within(self.workspace))
 
         self.assertEqual(
-            ['folder-1', 'todolist-1', 'todolist-2',
+            ['folder-1', 'document-38', 'todolist-1', 'todolist-2',
              'todo-1', 'todolist-3', 'todolist-4'],
             self.workspace.objectIds())
 
@@ -162,7 +162,7 @@ class TestAPISupportForTodoLists(IntegrationTestCase):
                      headers=self.api_headers, data=json.dumps(data))
 
         self.assertEqual(
-            ['folder-1', 'todolist-2', 'todolist-3',
+            ['folder-1', 'document-38', 'todolist-2', 'todolist-3',
              'todo-1', 'todolist-1', 'todolist-4'],
             self.workspace.objectIds())
 

--- a/opengever/workspace/workspace.py
+++ b/opengever/workspace/workspace.py
@@ -31,7 +31,7 @@ class WorkspaceContentPatch(ContentPatch):
     def reply(self):
         data = json_body(self.request)
         if data.keys() != ['ordering']:
-            if not api.user.has_permission('Modify portal content',
+            if not api.user.has_permission('opengever.workspace: Modify Workspace',
                                            obj=self.context):
                 raise Unauthorized()
 


### PR DESCRIPTION
Adds the possibility to deactivate workspaces. Deactivation sets a workspace to read-only mode. Any content of a deactivated workspace can no longer be modified or deleted and it's not possible to add new content.

The implementation adds a new workflow state "Inactive" for workspaces. Because of efficiency and different workflows/permissions of the child objects we avoid to recursively change the workflow state of these. Thus children need to inherit the relevant permissions from the workspace.

Because children need to inherit the "Modify portal content" permission from the workspace, a new permission for modifying the workspace itself is introduced. With this we can ensure that only a WorkspaceAdmin can modify the workspace while WorkspaceMembers can modify any content inside the workspace.

A placeful workflow policy is enabled on the workspace root to have a different workflow for documents in workspaces.

To be able to delete todos and todo lists a new permission "Delete Todos" is introduced. This circumvents Plones limited permissions for object deletion which only allows to give permission to delete anything.

The upgrade step only updates objects inside a workspace root. It also ensure that object permissions that are no longer managed by the workflow and are not registered on the object class are removed properly.

Jira: https://4teamwork.atlassian.net/browse/GEVER-82


## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


## Checklist (if applicable)

_Only applicable should be left and checked._

- Upgrade steps (changes in profile):
  - [x] Make it deferrable if possible
  - [x] Execute as much as possible conditionally
- New translations
  - [x] All msg-strings are unicode
