### PR TITLE
Revert adding missing value for public_trial_statement.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 
 - Add @successors and @predecessor expansion for tasks. [deiferni]
 - Don't show workspace actions for non-open dossiers or when the user can only view. [deiferni]
+- Revert adding missing value for public_trial_statement. [njohner]
 - Add @share-content endpoint to share content in workspace. [tinagerber]
 - Add @actual-workspace-members endpoint. [tinagerber]
 - Add support for transferring inter-admin-unit tasks. [lgraf]

--- a/docs/schema-dumps/ftw.mail.mail.schema.json
+++ b/docs/schema-dumps/ftw.mail.mail.schema.json
@@ -57,7 +57,8 @@
             "type": "string",
             "title": "Bearbeitungsinformation",
             "description": "Datum Gesuch, Gesuchsteller, Datum Entscheid, Verweis auf GEVER-Gesuchdossier",
-            "_zope_schema_type": "Text"
+            "_zope_schema_type": "Text",
+            "default": ""
         },
         "description": {
             "type": "string",

--- a/docs/schema-dumps/opengever.document.document.schema.json
+++ b/docs/schema-dumps/opengever.document.document.schema.json
@@ -63,7 +63,8 @@
             "type": "string",
             "title": "Bearbeitungsinformation",
             "description": "Datum Gesuch, Gesuchsteller, Datum Entscheid, Verweis auf GEVER-Gesuchdossier",
-            "_zope_schema_type": "Text"
+            "_zope_schema_type": "Text",
+            "default": ""
         },
         "relatedItems": {
             "type": "array",

--- a/docs/schema-dumps/opengever.dossier.businesscasedossier.schema.json
+++ b/docs/schema-dumps/opengever.dossier.businesscasedossier.schema.json
@@ -165,7 +165,8 @@
             "type": "string",
             "title": "Bearbeitungsinformation",
             "description": "Datum Gesuch, Gesuchsteller, Datum Entscheid, Verweis auf GEVER-Gesuchdossier",
-            "_zope_schema_type": "Text"
+            "_zope_schema_type": "Text",
+            "default": ""
         },
         "retention_period": {
             "type": "integer",

--- a/docs/schema-dumps/opengever.repository.repositoryfolder.schema.json
+++ b/docs/schema-dumps/opengever.repository.repositoryfolder.schema.json
@@ -101,7 +101,8 @@
             "type": "string",
             "title": "Bearbeitungsinformation",
             "description": "Datum Gesuch, Gesuchsteller, Datum Entscheid, Verweis auf GEVER-Gesuchdossier",
-            "_zope_schema_type": "Text"
+            "_zope_schema_type": "Text",
+            "default": ""
         },
         "title_de": {
             "type": "string",

--- a/opengever/base/behaviors/classification.py
+++ b/opengever/base/behaviors/classification.py
@@ -94,7 +94,6 @@ class IClassification(model.Schema):
                 default=u'Public trial statement'),
         description=_(u'help_public_trial_statement', default=u''),
         required=False,
-        missing_value=u'',
         default=u'',
     )
 

--- a/opengever/base/tests/test_default_values_for_types.py
+++ b/opengever/base/tests/test_default_values_for_types.py
@@ -709,6 +709,9 @@ class TestRepositoryFolderDefaults(TestDefaultsBase):
         persisted_values = get_persisted_values_for_obj(repofolder)
         expected = self.get_z3c_form_defaults()
 
+        # XXX: Don't know why this happens
+        expected.pop('public_trial_statement')
+
         self.assert_default_values_equal(expected, persisted_values)
 
     @browsing
@@ -802,6 +805,9 @@ class TestDossierDefaults(TestDefaultsBase):
         persisted_values = get_persisted_values_for_obj(dossier)
         expected = self.get_z3c_form_defaults()
 
+        # XXX: Don't know why this happens
+        expected.pop('public_trial_statement')
+
         self.assert_default_values_equal(expected, persisted_values)
 
     @browsing
@@ -855,6 +861,9 @@ class TestDossierDefaults(TestDefaultsBase):
 
         persisted_values = get_persisted_values_for_obj(dossier)
         expected = self.get_z3c_form_defaults()
+
+        # XXX: Don't know why this happens
+        expected.pop('public_trial_statement')
 
         self.assert_default_values_equal(expected, persisted_values)
 
@@ -993,6 +1002,9 @@ class TestDocumentDefaults(TestDefaultsBase):
         persisted_values = get_persisted_values_for_obj(doc)
         expected = self.get_z3c_form_defaults()
         expected['file'] = doc.file
+
+        # XXX: Don't know why this happens
+        expected.pop('public_trial_statement')
 
         self.assert_default_values_equal(expected, persisted_values)
 
@@ -1164,6 +1176,9 @@ class TestMailDefaults(TestDefaultsBase):
         expected = self.get_z3c_form_defaults()
 
         expected['message'] = mail._message
+
+        # XXX: Don't know why this happens
+        expected.pop('public_trial_statement')
 
         self.assert_default_values_equal(expected, persisted_values)
 

--- a/opengever/bundle/schemas/documents.schema.json
+++ b/opengever/bundle/schemas/documents.schema.json
@@ -81,7 +81,8 @@
                     ],
                     "title": "Bearbeitungsinformation",
                     "description": "Datum Gesuch, Gesuchsteller, Datum Entscheid, Verweis auf GEVER-Gesuchdossier",
-                    "_zope_schema_type": "Text"
+                    "_zope_schema_type": "Text",
+                    "default": ""
                 },
                 "relatedItems": {
                     "type": [

--- a/opengever/bundle/schemas/dossiers.schema.json
+++ b/opengever/bundle/schemas/dossiers.schema.json
@@ -233,7 +233,8 @@
                     ],
                     "title": "Bearbeitungsinformation",
                     "description": "Datum Gesuch, Gesuchsteller, Datum Entscheid, Verweis auf GEVER-Gesuchdossier",
-                    "_zope_schema_type": "Text"
+                    "_zope_schema_type": "Text",
+                    "default": ""
                 },
                 "retention_period": {
                     "type": [

--- a/opengever/bundle/schemas/repofolders.schema.json
+++ b/opengever/bundle/schemas/repofolders.schema.json
@@ -149,7 +149,8 @@
                     ],
                     "title": "Bearbeitungsinformation",
                     "description": "Datum Gesuch, Gesuchsteller, Datum Entscheid, Verweis auf GEVER-Gesuchdossier",
-                    "_zope_schema_type": "Text"
+                    "_zope_schema_type": "Text",
+                    "default": ""
                 },
                 "title_de": {
                     "type": [

--- a/opengever/mail/tests/test_mail_classification.py
+++ b/opengever/mail/tests/test_mail_classification.py
@@ -20,7 +20,9 @@ class TestMailMetadata(FunctionalTestCase):
         self.assertEquals(mail.privacy_layer, PRIVACY_LAYER_NO)
         self.assertEquals(mail.public_trial, PUBLIC_TRIAL_UNCHECKED)
 
-        self.assertEqual(u'', mail.public_trial_statement)
+        # XXX: imho this should be a empty string, not None, since the field
+        # has a default value (empty string)
+        self.assertIsNone(mail.public_trial_statement)
 
     def test_public_trial_default_is_configurable(self):
         registry = getUtility(IRegistry)


### PR DESCRIPTION
In this PR we revert part of the changes introduced in https://github.com/4teamwork/opengever.core/pull/6601, namely we remove the `missing_value` for the `public_trial_statement` field. This led to issues when submitting proposals, for which the `public_trial_statement` had a value of `None` (on the proposal document), which was now invalid.

For some unknown reason, the `public_trial_statement` default/missing value does not always get persisted on the object anymore, so that we had to manually fix the default values tests. After discussion with @deiferni and @lukasgraf we deemed this as acceptable for now.

For https://4teamwork.atlassian.net/browse/GEVER-959

This should fix the following sentry issues:
- https://sentry.4teamwork.ch/sentry/onegov-gever/issues/69172
- https://sentry.4teamwork.ch/sentry/onegov-gever/issues/69124

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)