### PR TITLE
Correctly handle query strings for oguid on remote admin units in ResolveOGUIDView.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 ---------------------
 
 - Bump ftw.monitor to get bin/dump-perf-metrics script. [lgraf]
+- Correctly handle query strings for oguid on remote admin units in ResolveOGUIDView. [njohner]
 - Add @successors and @predecessor expansion for tasks. [deiferni]
 - Don't show workspace actions for non-open dossiers or when the user can only view. [deiferni]
 - Add @share-content endpoint to share content in workspace. [tinagerber]

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-2020.8.1 (unreleased)
+2020.9.0 (unreleased)
 ---------------------
 
 - Bump ftw.monitor to get bin/dump-perf-metrics script. [lgraf]

--- a/opengever/base/browser/resolveoguid.py
+++ b/opengever/base/browser/resolveoguid.py
@@ -57,6 +57,10 @@ class ResolveOGUIDView(BrowserView):
         """
         if url.endswith('?'):
             return ''.join((url, qs))
+        elif '?' in url:
+            # In the url_for method we add a new query string parameter so
+            # url might already contain a query string.
+            return '&'.join((url, qs))
         return '?'.join((url, qs))
 
     @classmethod

--- a/opengever/base/tests/test_resolve_oguid.py
+++ b/opengever/base/tests/test_resolve_oguid.py
@@ -118,7 +118,7 @@ class TestResolveOGUIDView(IntegrationTestCase):
         browser.raise_http_errors = False
         browser.open(url)
         self.assertEqual(
-            'http://nohost/remote-au/@@resolve_oguid?oguid=remote-admin-unit:12345?foo=bar&key=value',  # noqa
+            'http://nohost/remote-au/@@resolve_oguid?oguid=remote-admin-unit:12345&foo=bar&key=value',  # noqa
             browser.url)
 
     @browsing
@@ -132,7 +132,7 @@ class TestResolveOGUIDView(IntegrationTestCase):
         browser.raise_http_errors = False
         browser.open(url)
         self.assertEqual(
-            'http://nohost/remote-au/@@resolve_oguid?oguid=remote-admin-unit:12345?foo=bar&key=value',  # noqa
+            'http://nohost/remote-au/@@resolve_oguid?oguid=remote-admin-unit:12345&foo=bar&key=value',  # noqa
             browser.url)
 
     @browsing

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 import os
 
 
-version = '2020.8.1.dev0'
+version = '2020.9.0.dev0'
 maintainer = '4teamwork AG'
 
 


### PR DESCRIPTION
In the `resolve_oguid` view we constructed invalid urls when trying to resolve an OGUID on a remote client with query string parameters. This typically happened when the portal appends a ticket to the url (see https://sentry.4teamwork.ch/sentry/onegov-gever/issues/13998/), so that the view was called with an URL of the type `.../adminunit/@@resolve_oguid/remote-adminunit:intid?ticket=myticket`. In that case it would redirect to `.../remote-adminunit/@@resolve_oguid?oguid=remote-adminunit:intid?ticket=myticket`. The second query string separator `?` is interpreted as literal question mark and the view tries to resolve the oguid `remote-adminunit:intid?ticket=myticket`.

For https://4teamwork.atlassian.net/browse/GEVER-888

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
