### PR TITLE
Fix ogds listing endpoints for undefined sort orders.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,8 @@ Changelog
 2020.10.0 (unreleased)
 ----------------------
 
-- Nothing changed yet.
+- Fix globalindex endpoint for undefined sort orders. [njohner]
+- Fix ogds listing endpoints for undefined sort orders. [njohner]
 
 
 2020.9.0 (2020-09-10)
@@ -13,8 +14,6 @@ Changelog
 - Order groups and teams in User serializer by title. [elioschmutz]
 - Bump ftw.monitor to get bin/dump-perf-metrics script. [lgraf]
 - Correctly handle query strings for oguid on remote admin units in ResolveOGUIDView. [njohner]
-- Fix globalindex endpoint for undefined sort orders. [njohner]
-- Fix ogds listing endpoints for undefined sort orders. [njohner]
 - Add @successors and @predecessor expansion for tasks. [deiferni]
 - Don't show workspace actions for non-open dossiers or when the user can only view. [deiferni]
 - Add @share-content endpoint to share content in workspace. [tinagerber]

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -13,6 +13,7 @@ Changelog
 - Order groups and teams in User serializer by title. [elioschmutz]
 - Bump ftw.monitor to get bin/dump-perf-metrics script. [lgraf]
 - Correctly handle query strings for oguid on remote admin units in ResolveOGUIDView. [njohner]
+- Fix globalindex endpoint for undefined sort orders. [njohner]
 - Fix ogds listing endpoints for undefined sort orders. [njohner]
 - Add @successors and @predecessor expansion for tasks. [deiferni]
 - Don't show workspace actions for non-open dossiers or when the user can only view. [deiferni]

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -13,6 +13,7 @@ Changelog
 - Order groups and teams in User serializer by title. [elioschmutz]
 - Bump ftw.monitor to get bin/dump-perf-metrics script. [lgraf]
 - Correctly handle query strings for oguid on remote admin units in ResolveOGUIDView. [njohner]
+- Fix ogds listing endpoints for undefined sort orders. [njohner]
 - Add @successors and @predecessor expansion for tasks. [deiferni]
 - Don't show workspace actions for non-open dossiers or when the user can only view. [deiferni]
 - Add @share-content endpoint to share content in workspace. [tinagerber]

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -395,7 +395,7 @@
   <plone:service
       method="GET"
       for="opengever.contact.interfaces.IContactFolder"
-      factory=".ogdsuserlisting.OGDDSUserListingGet"
+      factory=".ogdsuserlisting.OGDSUserListingGet"
       name="@ogds-user-listing"
       permission="zope2.View"
       />

--- a/opengever/api/ogdslistingbase.py
+++ b/opengever/api/ogdslistingbase.py
@@ -23,6 +23,12 @@ class OGDSListingBaseService(Service):
     """
 
     searchable_columns = tuple()
+    # unique_sort_on should be set in all subclasses to a unique key to make
+    # sure that results are always sorted, otherwise sorting can be undefined.
+    # As a separate query is made for every batch and for every item, undefined
+    # sort order can lead to problems when iterating over the items and
+    # batching (some items returned more than once and others missing).
+    unique_sort_on = None
     default_sort_on = None
     default_sort_order = 'ascending'
     model_class = None
@@ -31,6 +37,11 @@ class OGDSListingBaseService(Service):
         sort_on, sort_order, search, filters = self.extract_params()
         query = self.get_base_query()
         query = self.extend_query_with_sorting(query, sort_on, sort_order)
+
+        if self.unique_sort_on != sort_on:
+            query = self.extend_query_with_sorting(
+                query, self.unique_sort_on, sort_order)
+
         query = self.extend_query_with_search(query, search)
         query = self.extend_query_with_filters(query, filters)
 

--- a/opengever/api/ogdslistingbase.py
+++ b/opengever/api/ogdslistingbase.py
@@ -32,6 +32,7 @@ class OGDSListingBaseService(Service):
     default_sort_on = None
     default_sort_order = 'ascending'
     model_class = None
+    serializer_interface = ISerializeToJsonSummary
 
     def reply(self):
         sort_on, sort_order, search, filters = self.extract_params()
@@ -49,7 +50,7 @@ class OGDSListingBaseService(Service):
         items = []
         for item in batch:
             serializer = queryMultiAdapter(
-                (item, self.request), ISerializeToJsonSummary)
+                (item, self.request), self.serializer_interface)
             items.append(serializer())
 
         result = {}

--- a/opengever/api/ogdslistingbase.py
+++ b/opengever/api/ogdslistingbase.py
@@ -58,6 +58,8 @@ class OGDSListingBaseService(Service):
         result['items_total'] = batch.items_total
         if batch.links:
             result['batching'] = batch.links
+        result['b_start'] = batch.b_start
+        result['b_size'] = batch.b_size
         return result
 
     def extract_params(self):

--- a/opengever/api/ogdsuserlisting.py
+++ b/opengever/api/ogdsuserlisting.py
@@ -27,6 +27,7 @@ class OGDDSUserListingGet(OGDSListingBaseService):
         User.directorate,
     )
 
+    unique_sort_on = 'userid'
     default_sort_on = 'lastname'
     model_class = User
     default_state_filter = tuple()

--- a/opengever/api/ogdsuserlisting.py
+++ b/opengever/api/ogdsuserlisting.py
@@ -5,7 +5,7 @@ from opengever.ogds.models.user import User
 import re
 
 
-class OGDDSUserListingGet(OGDSListingBaseService):
+class OGDSUserListingGet(OGDSListingBaseService):
     """API Endpoint that returns users from ogds.
 
     GET /@ogds-user-listing HTTP/1.1

--- a/opengever/api/teamlisting.py
+++ b/opengever/api/teamlisting.py
@@ -17,6 +17,7 @@ class TeamListingGet(OGDSListingBaseService):
         Team.org_unit_id,
     )
 
+    unique_sort_on = 'id'
     default_sort_on = 'title'
     model_class = Team
     default_state_filter = tuple()

--- a/opengever/api/tests/test_globalindex.py
+++ b/opengever/api/tests/test_globalindex.py
@@ -40,7 +40,7 @@ class TestGlobalIndexGet(IntegrationTestCase):
             browser.json['items'][0])
 
         # default row size is 25
-        self.assertIsNone(browser.json['batching'])
+        self.assertIsNone(browser.json.get('batching'))
 
     @browsing
     def test_respect_batching_parameters(self, browser):
@@ -83,14 +83,16 @@ class TestGlobalIndexGet(IntegrationTestCase):
             [item['title'] for item in browser.json['items']])
 
     @browsing
-    def test_fallback_to_default_sort_if_sort_on_does_not_exist(self, browser):
+    def test_ignores_sort_on_if_sort_on_does_not_exist(self, browser):
         self.login(self.regular_user, browser=browser)
-        browser.open(self.portal, view='@globalindex?sort_on=notexisting&b_size=3',
+        browser.open(self.portal, view='@globalindex?sort_on=notexisting',
                      headers=self.api_headers)
 
         self.assertEqual(15, browser.json['items_total'])
-        self.assertEqual(u'Ein notwendiges \xdcbel', browser.json['items'][0]['title'])
-        self.assertEqual(u'2016-08-31T20:27:33', browser.json['items'][0]['modified'])
+
+        # items are sorted only by the unique_sort_on in that case
+        task_ids = [item['task_id'] for item in browser.json['items']]
+        self.assertEqual(task_ids, sorted(task_ids, reverse=True))
 
     @browsing
     def test_filter_by_single_value(self, browser):

--- a/opengever/api/tests/test_ogds_listing_base.py
+++ b/opengever/api/tests/test_ogds_listing_base.py
@@ -1,0 +1,19 @@
+from datetime import date
+from ftw.testbrowser import browsing
+from opengever.ogds.models.user import User
+from opengever.testing import IntegrationTestCase
+from zExceptions import BadRequest
+from opengever.api.ogdslistingbase import OGDSListingBaseService
+
+
+class TestOGDSListingBaseService(IntegrationTestCase):
+
+
+    def test_all_subclasses_define_unique_sort_on(self):
+        """We want to make sure that all OGDS listings define unique_sort_on
+        to guarantees consistent responses for successive queries. This is essential
+        to avoid some items being returned multiple times and others missing.
+        """
+        self.assertIsNone(OGDSListingBaseService.unique_sort_on)
+        for subclass in OGDSListingBaseService.__subclasses__():
+            self.assertIsNotNone(subclass.unique_sort_on)

--- a/opengever/api/tests/test_ogdsuserlisting.py
+++ b/opengever/api/tests/test_ogdsuserlisting.py
@@ -245,6 +245,40 @@ class TestOGDSUserListingGet(IntegrationTestCase):
         self.assertEqual(19, browser.json['items_total'])
 
     @browsing
+    def test_listing_always_has_a_secondary_sort_by_userid(self, browser):
+        self.login(self.regular_user, browser=browser)
+        browser.open(self.contactfolder,
+                     view=u'@ogds-user-listing?sort_on=department',
+                     headers=self.api_headers)
+
+        subset = [item['userid'] for item in browser.json['items']
+                  if item['department'] is None]
+        self.assertEqual(18, len(subset))
+        self.assertEqual(19, browser.json['items_total'])
+
+        expected = sorted([item.userid for item in User.query.all()
+                           if item.department is None])
+        self.assertEqual(subset, expected)
+
+    @browsing
+    def test_secondary_sort_by_userid_respects_sort_order(self, browser):
+        self.login(self.regular_user, browser=browser)
+        browser.open(
+            self.contactfolder,
+            view=u'@ogds-user-listing?sort_on=department&sort_order=descending',
+            headers=self.api_headers)
+
+        subset = [item['userid'] for item in browser.json['items']
+                  if item['department'] is None]
+        self.assertEqual(18, len(subset))
+        self.assertEqual(19, browser.json['items_total'])
+
+        expected = sorted(
+            [item.userid for item in User.query.all() if item.department is None],
+            reverse=True)
+        self.assertEqual(subset, expected)
+
+    @browsing
     def test_sort_descending(self, browser):
         self.login(self.regular_user, browser=browser)
         browser.open(self.contactfolder,

--- a/opengever/api/tests/test_teamlisting.py
+++ b/opengever/api/tests/test_teamlisting.py
@@ -171,6 +171,40 @@ class TestTeamListingGet(IntegrationTestCase):
         self.assertEqual(3, browser.json['items_total'])
 
     @browsing
+    def test_listing_always_has_a_secondary_sort_by_team_id(self, browser):
+        self.login(self.regular_user, browser=browser)
+        browser.open(self.contactfolder,
+                     view=u'@team-listing?sort_on=org_unit_id',
+                     headers=self.api_headers)
+
+        self.assertEqual(3, len(browser.json['items']))
+        self.assertEqual(
+            [u'fa', u'fa', u'fa'],
+            [item['org_unit_id'] for item in browser.json['items']])
+
+        expected = sorted(item.team_id for item in Team.query.all())
+        self.assertEqual([item['team_id'] for item in browser.json['items']],
+                         expected)
+
+    @browsing
+    def test_secondary_sort_by_team_id_respects_sort_order(self, browser):
+        self.login(self.regular_user, browser=browser)
+        browser.open(
+            self.contactfolder,
+            view=u'@team-listing?sort_on=org_unit_id&sort_order=descending',
+            headers=self.api_headers)
+
+        self.assertEqual(3, len(browser.json['items']))
+        self.assertEqual(
+            [u'fa', u'fa', u'fa'],
+            [item['org_unit_id'] for item in browser.json['items']])
+
+        expected = sorted((item.team_id for item in Team.query.all()),
+                          reverse=True)
+        self.assertEqual([item['team_id'] for item in browser.json['items']],
+                         expected)
+
+    @browsing
     def test_sort_descending(self, browser):
         self.login(self.regular_user, browser=browser)
         browser.open(self.contactfolder,


### PR DESCRIPTION
When sorting according to a non-unique column, response of ogds listings could contain duplicate items and other items could be missing. This is because the sort order of successive queries is not guaranteed to be identical (except when specifically sorting on a key with a unique value for each item).

With this PR we fix this issue by always having a secondary sort by a unique key for the `OGDSUserListingGet`, `TeamListingGet` and in `GlobalIndexGet`. We also refactor the global index endpoint to use the same base class as the other two OGDS listings.

For https://4teamwork.atlassian.net/browse/GEVER-968

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

API changes are non breaking, except that the ordering of tasks will now be different when an invalid `sort_on` is requested. Documentation does not need to be updated IMHO

**Problem analysis:**
Iteration over items of an `SQLHypermediaBatch` iterates over its batch (https://github.com/plone/plone.restapi/blob/master/src/plone/restapi/batching.py#L24-L26), which corresponds to an `SQLBatch`. Iterating over the items in a batch will simply use the `_getitem_` method of the sequence (see https://github.com/plone/plone.batching/blob/master/plone/batching/batch.py#L154 as `SQLBatch` inherits from `BaseBatch`). In our cases, that sequence is an ORM query, which makes a query for every item we are getting (https://github.com/sqlalchemy/sqlalchemy/blob/rel_1_1_18/lib/sqlalchemy/orm/query.py#L2528-L2552), i.e. a query for every item in the batch when iterating over the batch, changing the `OFFSET` and with a `LIMIT` of 1 (which are set in the `slice` method https://github.com/sqlalchemy/sqlalchemy/blob/rel_1_1_18/lib/sqlalchemy/orm/query.py#L2554-L2594). The queries for example for users in the admin panel sorted by `department` made to the SQL in GEVER look like:
```
2020-09-11 16:48:00,616 INFO sqlalchemy.engine.base.Engine SELECT users.userid AS users_userid, users.active AS users_active, users.firstname AS users_firstname, users.lastname AS users_lastname, users.directorate AS users_directorate, users.directorate_abbr AS users_directorate_abbr, users.department AS users_department, users.department_abbr AS users_department_abbr, users.email AS users_email, users.email2 AS users_email2, users.url AS users_url, users.phone_office AS users_phone_office, users.phone_fax AS users_phone_fax, users.phone_mobile AS users_phone_mobile, users.salutation AS users_salutation, users.description AS users_description, users.address1 AS users_address1, users.address2 AS users_address2, users.zip_code AS users_zip_code, users.city AS users_city, users.country AS users_country, users.last_login AS users_last_login 
FROM users ORDER BY department ASC 
 LIMIT %(param_1)s OFFSET %(param_2)s
2020-09-11 16:48:00,617 INFO sqlalchemy.engine.base.Engine {'param_1': 1, 'param_2': 19}
```

Looking at what such queries to SQL actually give back:
```
opengever=# SELECT users.userid FROM users ORDER BY department ASC LIMIT 1;
    userid     
---------------
 sabine.ammann
(1 row)

opengever=# SELECT users.userid FROM users ORDER BY department ASC LIMIT 1 OFFSET 1;
    userid     
---------------
 sabine.ammann
(1 row)

opengever=# SELECT users.userid FROM users ORDER BY department ASC LIMIT 1 OFFSET 2;
    userid     
---------------
 sabine.ammann
(1 row)
```

That behaviour is rather strange but we also see it clearly when we simply query with a limit:
```
opengever=# SELECT users.userid FROM users ORDER BY department ASC LIMIT 1;
    userid     
---------------
 sabine.ammann
(1 row)

opengever=# SELECT users.userid FROM users ORDER BY department ASC LIMIT 2;
     userid      
-----------------
 martin.saalbach
 sabine.ammann
(2 rows)

opengever=# SELECT users.userid FROM users ORDER BY department ASC LIMIT 3;
     userid      
-----------------
 martin.saalbach
 carmen.albrecht
 sabine.ammann
(3 rows)
```
`sabine.ammann` always comes last, for any `LIMIT` used. This comes from sorting according to a column that is mainly `null` for many items. Probably sorting stops as soon as `LIMIT` items with `null` have been found and somehow (probably because of the sorting algorithm), the first item (here `sabine.ammann`) always ends up at the end of that query's results. So when retrieving with an offset to take the last of the results we always get `sabine.ammann`.