### PR TITLE
Do not manage the "Manage properties" permission

### DIFF
--- a/opengever/core/lawgiver.zcml
+++ b/opengever/core/lawgiver.zcml
@@ -353,6 +353,7 @@
                      Sharing page: Delegate CommitteeResponsible role,
                      Sharing page: Delegate MeetingUser role,
                      opengever.workspace: Add Workspace,
+                     Manage properties,
                      "
         />
     <lawgiver:map_permissions
@@ -399,6 +400,7 @@
                      ftw.mail: Add Inbound Mail,
                      Add portal content,
                      Modify portal content,
+                     Manage properties,
                      "
         />
     <lawgiver:map_permissions
@@ -416,6 +418,7 @@
                      opengever.document: Checkout,
                      opengever.document: Force Checkin,
                      Modify portal content,
+                     Manage properties,
                      "
         />
     <lawgiver:map_permissions
@@ -431,6 +434,7 @@
                      Add portal content,
                      Modify portal content,
                      Delete objects,
+                     Manage properties,
                      "
         />
 
@@ -442,6 +446,7 @@
                      Add portal content,
                      Modify portal content,
                      Delete objects,
+                     Manage properties,
                      "
         />
 

--- a/opengever/core/profiles/default/workflows/opengever_workspace/definition.xml
+++ b/opengever/core/profiles/default/workflows/opengever_workspace/definition.xml
@@ -13,7 +13,6 @@
   <permission>Edit date of cassation</permission>
   <permission>Edit date of submission</permission>
   <permission>List folder contents</permission>
-  <permission>Manage properties</permission>
   <permission>Modify constrain types</permission>
   <permission>Modify portal content</permission>
   <permission>Modify view template</permission>
@@ -162,12 +161,6 @@
     </permission-map>
     <permission-map name="List folder contents" acquired="False">
       <permission-role>Manager</permission-role>
-    </permission-map>
-    <permission-map name="Manage properties" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
     </permission-map>
     <permission-map name="Modify constrain types" acquired="False">
       <permission-role>Manager</permission-role>
@@ -562,7 +555,6 @@
     <permission-map name="List folder contents" acquired="False">
       <permission-role>Manager</permission-role>
     </permission-map>
-    <permission-map name="Manage properties" acquired="False"/>
     <permission-map name="Modify constrain types" acquired="False">
       <permission-role>Manager</permission-role>
     </permission-map>

--- a/opengever/core/profiles/default/workflows/opengever_workspace_document/definition.xml
+++ b/opengever/core/profiles/default/workflows/opengever_workspace_document/definition.xml
@@ -13,7 +13,6 @@
   <permission>Edit date of cassation</permission>
   <permission>Edit date of submission</permission>
   <permission>List folder contents</permission>
-  <permission>Manage properties</permission>
   <permission>Modify constrain types</permission>
   <permission>Modify view template</permission>
   <permission>Poi: Edit response</permission>
@@ -122,7 +121,6 @@
     <permission-map name="List folder contents" acquired="False">
       <permission-role>Manager</permission-role>
     </permission-map>
-    <permission-map name="Manage properties" acquired="False"/>
     <permission-map name="Modify constrain types" acquired="False">
       <permission-role>Manager</permission-role>
     </permission-map>

--- a/opengever/core/profiles/default/workflows/opengever_workspace_folder/definition.xml
+++ b/opengever/core/profiles/default/workflows/opengever_workspace_folder/definition.xml
@@ -12,7 +12,6 @@
   <permission>Edit date of cassation</permission>
   <permission>Edit date of submission</permission>
   <permission>List folder contents</permission>
-  <permission>Manage properties</permission>
   <permission>Modify constrain types</permission>
   <permission>Modify view template</permission>
   <permission>Poi: Edit response</permission>
@@ -113,7 +112,6 @@
     <permission-map name="List folder contents" acquired="False">
       <permission-role>Manager</permission-role>
     </permission-map>
-    <permission-map name="Manage properties" acquired="False"/>
     <permission-map name="Modify constrain types" acquired="False">
       <permission-role>Manager</permission-role>
     </permission-map>

--- a/opengever/core/profiles/default/workflows/opengever_workspace_todo/definition.xml
+++ b/opengever/core/profiles/default/workflows/opengever_workspace_todo/definition.xml
@@ -11,7 +11,6 @@
   <permission>Edit date of cassation</permission>
   <permission>Edit date of submission</permission>
   <permission>List folder contents</permission>
-  <permission>Manage properties</permission>
   <permission>Modify constrain types</permission>
   <permission>Modify view template</permission>
   <permission>Poi: Edit response</permission>
@@ -119,7 +118,6 @@
     <permission-map name="List folder contents" acquired="False">
       <permission-role>Manager</permission-role>
     </permission-map>
-    <permission-map name="Manage properties" acquired="False"/>
     <permission-map name="Modify constrain types" acquired="False">
       <permission-role>Manager</permission-role>
     </permission-map>

--- a/opengever/core/profiles/default/workflows/opengever_workspace_todolist/definition.xml
+++ b/opengever/core/profiles/default/workflows/opengever_workspace_todolist/definition.xml
@@ -11,7 +11,6 @@
   <permission>Edit date of cassation</permission>
   <permission>Edit date of submission</permission>
   <permission>List folder contents</permission>
-  <permission>Manage properties</permission>
   <permission>Modify constrain types</permission>
   <permission>Modify view template</permission>
   <permission>Poi: Edit response</permission>
@@ -119,7 +118,6 @@
     <permission-map name="List folder contents" acquired="False">
       <permission-role>Manager</permission-role>
     </permission-map>
-    <permission-map name="Manage properties" acquired="False"/>
     <permission-map name="Modify constrain types" acquired="False">
       <permission-role>Manager</permission-role>
     </permission-map>

--- a/opengever/core/upgrades/20200909192905_update_workspace_workflow/workflows/opengever_workspace/definition.xml
+++ b/opengever/core/upgrades/20200909192905_update_workspace_workflow/workflows/opengever_workspace/definition.xml
@@ -13,7 +13,6 @@
   <permission>Edit date of cassation</permission>
   <permission>Edit date of submission</permission>
   <permission>List folder contents</permission>
-  <permission>Manage properties</permission>
   <permission>Modify constrain types</permission>
   <permission>Modify portal content</permission>
   <permission>Modify view template</permission>
@@ -162,12 +161,6 @@
     </permission-map>
     <permission-map name="List folder contents" acquired="False">
       <permission-role>Manager</permission-role>
-    </permission-map>
-    <permission-map name="Manage properties" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-      <permission-role>WorkspaceMember</permission-role>
     </permission-map>
     <permission-map name="Modify constrain types" acquired="False">
       <permission-role>Manager</permission-role>
@@ -562,7 +555,6 @@
     <permission-map name="List folder contents" acquired="False">
       <permission-role>Manager</permission-role>
     </permission-map>
-    <permission-map name="Manage properties" acquired="False"/>
     <permission-map name="Modify constrain types" acquired="False">
       <permission-role>Manager</permission-role>
     </permission-map>

--- a/opengever/core/upgrades/20200909192905_update_workspace_workflow/workflows/opengever_workspace_document/definition.xml
+++ b/opengever/core/upgrades/20200909192905_update_workspace_workflow/workflows/opengever_workspace_document/definition.xml
@@ -13,7 +13,6 @@
   <permission>Edit date of cassation</permission>
   <permission>Edit date of submission</permission>
   <permission>List folder contents</permission>
-  <permission>Manage properties</permission>
   <permission>Modify constrain types</permission>
   <permission>Modify view template</permission>
   <permission>Poi: Edit response</permission>
@@ -122,7 +121,6 @@
     <permission-map name="List folder contents" acquired="False">
       <permission-role>Manager</permission-role>
     </permission-map>
-    <permission-map name="Manage properties" acquired="False"/>
     <permission-map name="Modify constrain types" acquired="False">
       <permission-role>Manager</permission-role>
     </permission-map>

--- a/opengever/core/upgrades/20200909192905_update_workspace_workflow/workflows/opengever_workspace_folder/definition.xml
+++ b/opengever/core/upgrades/20200909192905_update_workspace_workflow/workflows/opengever_workspace_folder/definition.xml
@@ -12,7 +12,6 @@
   <permission>Edit date of cassation</permission>
   <permission>Edit date of submission</permission>
   <permission>List folder contents</permission>
-  <permission>Manage properties</permission>
   <permission>Modify constrain types</permission>
   <permission>Modify view template</permission>
   <permission>Poi: Edit response</permission>
@@ -113,7 +112,6 @@
     <permission-map name="List folder contents" acquired="False">
       <permission-role>Manager</permission-role>
     </permission-map>
-    <permission-map name="Manage properties" acquired="False"/>
     <permission-map name="Modify constrain types" acquired="False">
       <permission-role>Manager</permission-role>
     </permission-map>

--- a/opengever/core/upgrades/20200909192905_update_workspace_workflow/workflows/opengever_workspace_todo/definition.xml
+++ b/opengever/core/upgrades/20200909192905_update_workspace_workflow/workflows/opengever_workspace_todo/definition.xml
@@ -11,7 +11,6 @@
   <permission>Edit date of cassation</permission>
   <permission>Edit date of submission</permission>
   <permission>List folder contents</permission>
-  <permission>Manage properties</permission>
   <permission>Modify constrain types</permission>
   <permission>Modify view template</permission>
   <permission>Poi: Edit response</permission>
@@ -119,7 +118,6 @@
     <permission-map name="List folder contents" acquired="False">
       <permission-role>Manager</permission-role>
     </permission-map>
-    <permission-map name="Manage properties" acquired="False"/>
     <permission-map name="Modify constrain types" acquired="False">
       <permission-role>Manager</permission-role>
     </permission-map>

--- a/opengever/core/upgrades/20200909192905_update_workspace_workflow/workflows/opengever_workspace_todolist/definition.xml
+++ b/opengever/core/upgrades/20200909192905_update_workspace_workflow/workflows/opengever_workspace_todolist/definition.xml
@@ -11,7 +11,6 @@
   <permission>Edit date of cassation</permission>
   <permission>Edit date of submission</permission>
   <permission>List folder contents</permission>
-  <permission>Manage properties</permission>
   <permission>Modify constrain types</permission>
   <permission>Modify view template</permission>
   <permission>Poi: Edit response</permission>
@@ -119,7 +118,6 @@
     <permission-map name="List folder contents" acquired="False">
       <permission-role>Manager</permission-role>
     </permission-map>
-    <permission-map name="Manage properties" acquired="False"/>
     <permission-map name="Modify constrain types" acquired="False">
       <permission-role>Manager</permission-role>
     </permission-map>


### PR DESCRIPTION
Fixes ZMI access to the Properties tab.

By default the "Manage properties" permission is assigned to the "edit" action group.
As we do not manage the "edit" action group in workspace workflows we have to inherit the "Manage properties" permission.

Jira: https://4teamwork.atlassian.net/browse/GEVER-82

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

