### PR TITLE
Fix jinxed favorite filename upgrade step.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 
 - Fix globalindex endpoint for undefined sort orders. [njohner]
 - Fix ogds listing endpoints for undefined sort orders. [njohner]
+- Populate filename for favorites where previous upgrades failed. [deiferni]
 
 
 2020.9.0 (2020-09-10)

--- a/opengever/core/upgrades/20200910171300_fix_populate_filename_column_in_favorites/upgrade.py
+++ b/opengever/core/upgrades/20200910171300_fix_populate_filename_column_in_favorites/upgrade.py
@@ -1,0 +1,69 @@
+from opengever.core.upgrade import SQLUpgradeStep
+from os.path import splitext
+from plone import api
+from sqlalchemy.sql.expression import column
+from sqlalchemy.sql.expression import select
+from sqlalchemy.sql.expression import table
+import logging
+
+
+LOG = logging.getLogger('ftw.upgrade')
+
+favorites_table = table(
+    'favorites',
+    column('id'),
+    column('plone_uid'),
+    column('admin_unit_id'),
+    column('filename'),
+)
+
+MAX_FILENAME_BASE_LENGTH = 100
+
+
+def safe_unicode(value):
+    if isinstance(value, str):
+        return value.decode('utf-8')
+    return value
+
+
+class FixPopulateFilenameColumnInFavorites(SQLUpgradeStep):
+    """Fix populate filename column in favorites.
+
+    This fixes populating filename for certain records where the migration
+    has been run in version `2020.3.0` without the fix added later in version
+    `2020.4.0`, or where the fix added in version `2020.4.0` failed due to a
+    bug.
+
+    Mostly a copy of `PopulateFilenameColumnInFavorites` but limiting the
+    query to columns where filename is `null`.
+    Combined with the catalog query for only `IBaseDocument` this should only
+    touch the affected set of records.
+    """
+
+    def migrate(self):
+        current_admin_unit_id = api.portal.get_registry_record(
+            'opengever.ogds.base.interfaces.IAdminUnitConfiguration.current_unit_id'
+        )
+        rows = self.execute(
+            select([favorites_table.c.plone_uid])
+            .where(favorites_table.c.admin_unit_id == current_admin_unit_id)
+            .where(favorites_table.c.filename.is_(None))
+            .distinct()
+        ).fetchall()
+        favorite_uids = [row[0] for row in rows]
+
+        query = {"object_provides": "opengever.document.behaviors.IBaseDocument",
+                 "UID": favorite_uids}
+        for brain in self.catalog_unrestricted_search(query=query):
+            # Defensively truncate filename to max 105 chars total
+            filename = safe_unicode(brain.filename or u"")
+            if filename:
+                basename, ext = splitext(filename)
+                basename = basename[:MAX_FILENAME_BASE_LENGTH]
+                filename = u''.join((basename, ext))
+
+            self.execute(
+                favorites_table.update()
+                .values(filename=filename)
+                .where(favorites_table.c.plone_uid == brain.UID)
+                .where(favorites_table.c.admin_unit_id == current_admin_unit_id))


### PR DESCRIPTION
**Analysis**

The `PopulateFilenameColumnInFavorites` already underwent several iterations of fixes, unfortunately all of them were flawed.

- the upgrade was introduced in https://github.com/4teamwork/opengever.core/commit/c139e6fda08a5a06b3c0c07606397e3b7bab6d9b
- then patched in https://github.com/4teamwork/opengever.core/commit/b4101303c8c38dc9230b3c8fe80c8ef2e2d5ce88
- and https://github.com/4teamwork/opengever.core/commit/0e7d08693f2a29e11a3a5a0477d60db0bcb2e26b

The last fix unfortunately introduced another issue where `filename` would be skipped (set to `u''` default) when already unicode due to a missing `return` in https://github.com/4teamwork/opengever.core/commit/0e7d08693f2a29e11a3a5a0477d60db0bcb2e26b#diff-46eb5b96923b2d90aaff51c8c66fc964R23-R25. None of the fixes `touch`-ed the upgrade, as they most likely should have 😞 .

**Proposed fix**

Here we provide the hopefully last fix as a copy of the old upgrade. The new upgrade provides the following changes:

- add missing return for values already unicode to `safe_unicode`
- only query for rows where `filename` is `null` to avoid populating favorites twice where they are already correctly set (this seem to be most records)

**Up for discussion**

- I've decided against touching the old upgrade again, but instead have created a copy and modified it to limit the query to rows where filename is `null`. Combined with the catalog query for only `IBaseDocument` this should only touch the affected set of records. That way deployments that already have the old fix won't need to re-run the upgrade for all favorites.
- I have not made the upgrade deferrable as the old one wasn't either.

Jira: https://4teamwork.atlassian.net/browse/GEVER-980

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


## Checklist (if applicable)

_Only applicable should be left and checked._

- Upgrade steps (changes in profile):
  - [ ] ~~Make it deferrable if possible~~
  - [x] Execute as much as possible conditionally
