### PR TITLE
Overwrite @groups endpoint to handle the OGDS

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 
 - Don't resolve or deactivate a dossier if it is linked to an active workspace. [tinagerber]
 - Provides the IVocabularyTokenized interface for elephant vocabularies. [elioschmutz]
+- Customize @groups endpoints to handle OGDS. [njohner]
 
 
 2020.10.0 (2020-09-25)

--- a/docs/public/dev-manual/api/schemas/ftw.mail.mail.inc
+++ b/docs/public/dev-manual/api/schemas/ftw.mail.mail.inc
@@ -59,7 +59,7 @@
        :Feldname: :field-title:`Bearbeitungsinformation`
        :Datentyp: ``Text``
        
-       
+       :Default: ""
        :Beschreibung: Datum Gesuch, Gesuchsteller, Datum Entscheid, Verweis auf GEVER-Gesuchdossier
        
 

--- a/docs/public/dev-manual/api/schemas/opengever.document.document.inc
+++ b/docs/public/dev-manual/api/schemas/opengever.document.document.inc
@@ -69,7 +69,7 @@
        :Feldname: :field-title:`Bearbeitungsinformation`
        :Datentyp: ``Text``
        
-       
+       :Default: ""
        :Beschreibung: Datum Gesuch, Gesuchsteller, Datum Entscheid, Verweis auf GEVER-Gesuchdossier
        
 

--- a/docs/public/dev-manual/api/schemas/opengever.dossier.businesscasedossier.inc
+++ b/docs/public/dev-manual/api/schemas/opengever.dossier.businesscasedossier.inc
@@ -209,7 +209,7 @@
        :Feldname: :field-title:`Bearbeitungsinformation`
        :Datentyp: ``Text``
        
-       
+       :Default: ""
        :Beschreibung: Datum Gesuch, Gesuchsteller, Datum Entscheid, Verweis auf GEVER-Gesuchdossier
        
 

--- a/docs/public/dev-manual/api/schemas/opengever.repository.repositoryfolder.inc
+++ b/docs/public/dev-manual/api/schemas/opengever.repository.repositoryfolder.inc
@@ -129,7 +129,7 @@
        :Feldname: :field-title:`Bearbeitungsinformation`
        :Datentyp: ``Text``
        
-       
+       :Default: ""
        :Beschreibung: Datum Gesuch, Gesuchsteller, Datum Entscheid, Verweis auf GEVER-Gesuchdossier
        
 

--- a/docs/public/dev-manual/api/users.rst
+++ b/docs/public/dev-manual/api/users.rst
@@ -118,6 +118,9 @@ sortiert zurückgegeben.
 Gruppen
 =======
 
+Gruppendetails
+--------------
+
 Details über Gruppen können mit dem ``@ogds-groups`` Endpoint abgefragt werden. Der Endpoint steht nur auf Stufe Kontaktordner zur Verfügung und erwartet eine Einschränkung auf eine Gruppe via Gruppen-ID. Die URL setzt sich somit folgendermassen zusammen:
 
 ``http://example.org/kontakte/@ogds-groups/stv_benutzer``
@@ -159,3 +162,13 @@ Nachnamen sortiert zurückgegeben.
         ],
         "items_total": 11
       }
+
+Gruppen erstellen, löschen und modifizieren
+-------------------------------------------
+
+Gruppen erstellen, modifizieren und löschen kann über den ``@groups`` Endpoint gemacht werden und ist in der `plone.restapi Dokumentation <https://plonerestapi.readthedocs.io/en/latest/groups.html>`_ beschrieben. Dieser Endpoint wurde für GEVER folgendermassen angepasst:
+
+- Die Gruppen Daten werden korrekt im OGDS abgespiegelt.
+- Er steht auch für Administratoren zur Verfügung.
+- Er wurde eingeschränkt um nur die Administration von gewissen Rollen zu erlauben: ``workspace_guest``, ``workspace_member`` und ``workspace_admin``.
+- Gruppennamen darf nicht länger als 255 Zeichen lang sein

--- a/docs/schema-dumps/_opengever.ogds.models.group.Group.schema.json
+++ b/docs/schema-dumps/_opengever.ogds.models.group.Group.schema.json
@@ -24,6 +24,13 @@
             "maxLength": 255,
             "description": "",
             "_zope_schema_type": "Text"
+        },
+        "is_local": {
+            "type": "boolean",
+            "title": "is_local",
+            "description": "",
+            "_zope_schema_type": "Bool",
+            "default": false
         }
     },
     "required": [
@@ -32,6 +39,7 @@
     "field_order": [
         "groupid",
         "active",
-        "title"
+        "title",
+        "is_local"
     ]
 }

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -963,4 +963,13 @@
       permission="cmf.ModifyPortalContent"
       />
 
+  <plone:service
+      method="POST"
+      name="@groups"
+      for="Products.CMFCore.interfaces.ISiteRoot"
+      factory=".group.GeverGroupsPost"
+      permission="opengever.api.ManageGroups"
+      layer="opengever.base.interfaces.IOpengeverBaseLayer"
+      />
+
 </configure>

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -972,4 +972,13 @@
       layer="opengever.base.interfaces.IOpengeverBaseLayer"
       />
 
+  <plone:service
+      method="PATCH"
+      name="@groups"
+      for="Products.CMFCore.interfaces.ISiteRoot"
+      factory=".group.GeverGroupsPatch"
+      permission="opengever.api.ManageGroups"
+      layer="opengever.base.interfaces.IOpengeverBaseLayer"
+      />
+
 </configure>

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -981,4 +981,13 @@
       layer="opengever.base.interfaces.IOpengeverBaseLayer"
       />
 
+  <plone:service
+      method="DELETE"
+      name="@groups"
+      for="Products.CMFCore.interfaces.ISiteRoot"
+      factory=".group.GeverGroupsDelete"
+      permission="opengever.api.ManageGroups"
+      layer="opengever.base.interfaces.IOpengeverBaseLayer"
+      />
+
 </configure>

--- a/opengever/api/group.py
+++ b/opengever/api/group.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+from plone.restapi.deserializer import json_body
+from plone.restapi.interfaces import ISerializeToJson
+from plone.restapi.services import Service
+from Products.CMFCore.utils import getToolByName
+from zExceptions import BadRequest
+from zope.component import queryMultiAdapter
+from zope.component.hooks import getSite
+from zope.interface import alsoProvides
+
+import plone.protect.interfaces
+
+
+class GeverGroupsPost(Service):
+    """Copy of plone.restapi.services.groups.add.GroupsPost
+    """
+
+    def reply(self):
+        portal = getSite()
+        data = json_body(self.request)
+
+        groupname = data.get("groupname", None)
+
+        if not groupname:
+            raise BadRequest("Property 'groupname' is required")
+
+        email = data.get("email", None)
+        title = data.get("title", None)
+        description = data.get("description", None)
+        roles = data.get("roles", None)
+        groups = data.get("groups", None)
+        users = data.get("users", [])
+
+        properties = {"title": title, "description": description, "email": email}
+
+        gtool = getToolByName(self.context, "portal_groups")
+        regtool = getToolByName(self.context, "portal_registration")
+
+        if not regtool.isMemberIdAllowed(groupname):
+            raise BadRequest("The group name you entered is not valid.")
+
+        already_exists = gtool.getGroupById(groupname)
+        if already_exists:
+            raise BadRequest("The group name you entered already exists.")
+
+        # Disable CSRF protection
+        if "IDisableCSRFProtection" in dir(plone.protect.interfaces):
+            alsoProvides(self.request, plone.protect.interfaces.IDisableCSRFProtection)
+
+        success = gtool.addGroup(
+            groupname,
+            roles,
+            groups,
+            properties=properties,
+            title=title,
+            description=description,
+        )
+        if not success:
+            raise BadRequest(
+                "Error occurred, could not add group {}.".format(groupname)
+            )
+
+        # Add members
+        group = gtool.getGroupById(groupname)
+        for userid in users:
+            group.addMember(userid)
+
+        self.request.response.setStatus(201)
+        self.request.response.setHeader(
+            "Location", portal.absolute_url() + "/@groups/" + groupname
+        )
+        serializer = queryMultiAdapter((group, self.request), ISerializeToJson)
+        return serializer()

--- a/opengever/api/group.py
+++ b/opengever/api/group.py
@@ -1,3 +1,4 @@
+from opengever.base.utils import check_group_plugin_configuration
 from opengever.base.model import create_session
 from opengever.base.model import GROUP_ID_LENGTH
 from opengever.base.security import elevated_privileges
@@ -47,6 +48,8 @@ class GeverGroupsPost(Service):
     """
 
     def check_preconditions(self, groupname, roles):
+        check_group_plugin_configuration(self.context)
+
         if not groupname:
             raise BadRequest("Property 'groupname' is required")
 
@@ -154,6 +157,8 @@ class GeverGroupsPatch(Service):
         return portal_groups.getGroupById(group_id)
 
     def check_preconditions(self):
+        check_group_plugin_configuration(self.context)
+
         if not self.group:
             raise BadRequest("Trying to update a non-existing group.")
         if not self.ogds_group:
@@ -246,6 +251,8 @@ class GeverGroupsDelete(Service):
         return portal_groups.getGroupById(group_id)
 
     def check_preconditions(self):
+        check_group_plugin_configuration(self.context)
+
         if not self.group:
             raise NotFound("Trying to delete a non-existing group.")
         if not self.ogds_group:

--- a/opengever/api/group.py
+++ b/opengever/api/group.py
@@ -9,6 +9,8 @@ from zExceptions import BadRequest
 from zope.component import queryMultiAdapter
 from zope.component.hooks import getSite
 from zope.interface import alsoProvides
+from zope.interface import implementer
+from zope.publisher.interfaces import IPublishTraverse
 import plone.protect.interfaces
 
 
@@ -114,3 +116,75 @@ class GeverGroupsPost(Service):
         )
         serializer = queryMultiAdapter((group, self.request), ISerializeToJson)
         return serializer()
+
+
+@implementer(IPublishTraverse)
+class GeverGroupsPatch(Service):
+    """Copy of plone.restapi.services.groups.update.GroupsPatch
+    """
+
+    def __init__(self, context, request):
+        super(GeverGroupsPatch, self).__init__(context, request)
+        self.params = []
+
+    def publishTraverse(self, request, name):
+        # Consume any path segments after /@groups as parameters
+        self.params.append(name)
+        return self
+
+    @property
+    def _get_group_id(self):
+        if len(self.params) != 1:
+            raise Exception("Must supply exactly one parameter (group id)")
+        return self.params[0]
+
+    def _get_group(self, group_id):
+        portal = getSite()
+        portal_groups = getToolByName(portal, "portal_groups")
+        return portal_groups.getGroupById(group_id)
+
+    def reply(self):
+        data = json_body(self.request)
+        group = self._get_group(self._get_group_id)
+
+        if not group:
+            raise BadRequest("Trying to update a non-existing group.")
+
+        title = data.get("title", None)
+        description = data.get("description", None)
+        roles = data.get("roles", None)
+        groups = data.get("groups", None)
+        users = data.get("users", {})
+
+        # Disable CSRF protection
+        if "IDisableCSRFProtection" in dir(plone.protect.interfaces):
+            alsoProvides(self.request, plone.protect.interfaces.IDisableCSRFProtection)
+
+        portal_groups = getToolByName(self.context, "portal_groups")
+
+        portal_groups.editGroup(
+            self._get_group_id,
+            roles=roles,
+            groups=groups,
+            title=title,
+            description=description,
+        )
+
+        properties = {}
+        for id, property in group.propertyItems():
+            if data.get(id, False):
+                properties[id] = data[id]
+
+        group.setGroupProperties(properties)
+
+        # Add/remove members
+        memberids = group.getGroupMemberIds()
+        for userid, allow in users.items():
+            if allow:
+                if userid not in memberids:
+                    group.addMember(userid)
+            else:
+                if userid in memberids:
+                    group.removeMember(userid)
+
+        return self.reply_no_content()

--- a/opengever/api/group.py
+++ b/opengever/api/group.py
@@ -239,13 +239,16 @@ class GeverGroupsDelete(Service):
         portal_groups = getToolByName(portal, "portal_groups")
         return portal_groups.getGroupById(group_id)
 
+    def check_preconditions(self):
+        if not self.group:
+            raise NotFound("Trying to delete a non-existing group.")
+
     def reply(self):
 
         portal_groups = getToolByName(self.context, "portal_groups")
-        group = self._get_group(self._get_group_id)
+        self.group = self._get_group(self._get_group_id)
 
-        if not group:
-            raise NotFound("Trying to delete a non-existing group.")
+        self.check_preconditions()
 
         delete_successful = portal_groups.removeGroup(self._get_group_id)
         if delete_successful:

--- a/opengever/api/group.py
+++ b/opengever/api/group.py
@@ -1,4 +1,5 @@
 from opengever.base.model import create_session
+from opengever.base.model import GROUP_ID_LENGTH
 from opengever.base.security import elevated_privileges
 from opengever.ogds.models.group import Group
 from opengever.ogds.models.user import User
@@ -58,6 +59,11 @@ class GeverGroupsPost(Service):
         already_exists = gtool.getGroupById(groupname)
         if already_exists:
             raise BadRequest("The group name you entered already exists.")
+
+        if len(groupname) > GROUP_ID_LENGTH:
+            raise BadRequest(
+                "The group name you entered is too long: "
+                "maximal length is {}".format(GROUP_ID_LENGTH))
 
         if Group.query.filter(Group.groupid == groupname).count() != 0:
             raise BadRequest('Group {} already exists in OGDS.'.format(groupname))

--- a/opengever/api/group.py
+++ b/opengever/api/group.py
@@ -7,6 +7,7 @@ from plone.restapi.interfaces import ISerializeToJson
 from plone.restapi.services import Service
 from Products.CMFCore.utils import getToolByName
 from zExceptions import BadRequest
+from zExceptions import NotFound
 from zope.component import queryMultiAdapter
 from zope.component.hooks import getSite
 from zope.interface import alsoProvides
@@ -211,3 +212,43 @@ class GeverGroupsPatch(Service):
         self.update_ogds_group(title, description, self.group.getGroupMemberIds() if users.items() else None)
 
         return self.reply_no_content()
+
+
+@implementer(IPublishTraverse)
+class GeverGroupsDelete(Service):
+    """Copy of plone.restapi.services.groups.delete.GroupsDelete
+    """
+
+    def __init__(self, context, request):
+        super(GeverGroupsDelete, self).__init__(context, request)
+        self.params = []
+
+    def publishTraverse(self, request, name):
+        # Consume any path segments after /@groups as parameters
+        self.params.append(name)
+        return self
+
+    @property
+    def _get_group_id(self):
+        if len(self.params) != 1:
+            raise Exception("Must supply exactly one parameter (group id)")
+        return self.params[0]
+
+    def _get_group(self, group_id):
+        portal = getSite()
+        portal_groups = getToolByName(portal, "portal_groups")
+        return portal_groups.getGroupById(group_id)
+
+    def reply(self):
+
+        portal_groups = getToolByName(self.context, "portal_groups")
+        group = self._get_group(self._get_group_id)
+
+        if not group:
+            raise NotFound("Trying to delete a non-existing group.")
+
+        delete_successful = portal_groups.removeGroup(self._get_group_id)
+        if delete_successful:
+            return self.reply_no_content()
+        else:
+            return self.reply_no_content(status=404)

--- a/opengever/api/permissions.zcml
+++ b/opengever/api/permissions.zcml
@@ -5,5 +5,6 @@
   <permission id="opengever.api.ViewAllowedRolesAndPrincipals" title="opengever.api: View AllowedRolesAndPrincipals" />
   <permission id="opengever.api.TransferAssignment" title="opengever.api: Transfer Assignment" />
   <permission id="opengever.api.ManageRoleAssignmentReports" title="opengever.api: Manage Role Assignment Reports" />
+  <permission id="opengever.api.ManageGroups" title="opengever.api: Manage Groups" />
 
 </configure>

--- a/opengever/api/tests/test_group.py
+++ b/opengever/api/tests/test_group.py
@@ -1,0 +1,44 @@
+from ftw.testbrowser import browsing
+from opengever.testing import IntegrationTestCase
+import json
+
+
+class TestGroupPost(IntegrationTestCase):
+
+    @browsing
+    def test_group_creation_is_allowed_for_administrators(self, browser):
+        self.login(self.workspace_owner, browser)
+        payload = {
+            u'groupname': u'test_group',
+        }
+
+        with browser.expect_unauthorized():
+            browser.open(
+                self.portal,
+                view='@groups',
+                data=json.dumps(payload),
+                method='POST',
+                headers=self.api_headers)
+
+        self.login(self.administrator, browser)
+        response = browser.open(
+            self.portal,
+            view='@groups',
+            data=json.dumps(payload),
+            method='POST',
+            headers=self.api_headers)
+
+        self.assertEqual(201, response.status_code)
+        self.assertDictEqual(
+            {u'@id': u'http://nohost/plone/@groups/test_group',
+             u'description': None,
+             u'email': None,
+             u'groupname': u'test_group',
+             u'id': u'test_group',
+             u'roles': [u'Authenticated'],
+             u'title': None,
+             u'users': {u'@id': u'http://nohost/plone/@groups',
+                        u'items': [],
+                        u'items_total': 0}},
+            response.json
+            )

--- a/opengever/api/tests/test_group.py
+++ b/opengever/api/tests/test_group.py
@@ -154,6 +154,31 @@ class TestGroupPost(IntegrationTestCase):
             "User unknown not found in OGDS.")
         self.assertEqual(browser.json[u'type'], u'BadRequest')
 
+    @browsing
+    def test_group_creation_fails_if_groupname_is_too_long(self, browser):
+        self.login(self.manager, browser)
+        groupid = 256*"a"
+        ogds_group = Group.query.get(groupid)
+        self.assertIsNone(ogds_group)
+
+        payload = {
+            u'groupname': groupid,
+        }
+        with browser.expect_http_error(400):
+            browser.open(
+                self.portal,
+                view='@groups',
+                data=json.dumps(payload),
+                method='POST',
+                headers=self.api_headers)
+
+        self.assertEqual(
+            browser.json[u'message'],
+            u'The group name you entered is too long: maximal length is 255')
+        self.assertEqual(browser.json[u'type'], u'BadRequest')
+        ogds_group = Group.query.get(groupid)
+        self.assertIsNone(ogds_group)
+
 
 class TestGeverGroupsPatch(IntegrationTestCase):
 

--- a/opengever/api/tests/test_ogdsgroups.py
+++ b/opengever/api/tests/test_ogdsgroups.py
@@ -20,6 +20,7 @@ class TestOGDSGroupsGet(IntegrationTestCase):
              u'@type': u'virtual.ogds.group',
              u'active': True,
              u'groupid': u'projekt_a',
+             u'is_local': False,
              u'title': u'Projekt A',
              u'items': [{u'@id': u'http://nohost/plone/kontakte/@ogds-users/kathi.barfuss',
                          u'@type': u'virtual.ogds.user',

--- a/opengever/base/exceptions.py
+++ b/opengever/base/exceptions.py
@@ -24,3 +24,8 @@ class NonRemoteOguid(Exception):
     """An attempt was made to use get_remote_url() on a Oguid for an object
     that is located on the current AdminUnit.
     """
+
+
+class IncorrectConfigurationError(Exception):
+    """Exception raised when Gever is not configured correctly
+    """

--- a/opengever/base/utils.py
+++ b/opengever/base/utils.py
@@ -1,3 +1,4 @@
+from opengever.base.exceptions import IncorrectConfigurationError
 from persistent.dict import PersistentDict
 from persistent.list import PersistentList
 from plone import api
@@ -225,3 +226,25 @@ def is_administrator(user=None):
     if not user:
         user = api.user.get_current()
     return bool(user.has_role('Administrator') or user.has_role('Manager'))
+
+
+def check_group_plugin_configuration(portal):
+    acl_users = getToolByName(portal, 'acl_users')
+    plugins = acl_users.plugins
+    group_management_plugins = plugins.getAllPlugins('IGroupManagement')
+
+    if 'source_groups' not in group_management_plugins.get('active'):
+        raise IncorrectConfigurationError(
+            "Configuration error: source_groups plugin is not active "
+            "for group management.")
+    elif group_management_plugins.get('active')[0] != 'source_groups':
+        raise IncorrectConfigurationError(
+            "Configuration error: source_groups plugin needs to be the "
+            "first group management plugin.")
+
+    group_enumeration_plugins = plugins.getAllPlugins('IGroupEnumerationPlugin')
+    if 'source_groups' not in group_enumeration_plugins.get('active'):
+        raise IncorrectConfigurationError(
+            "Configuration error: source_groups plugin is not active "
+            "for group enumeration.")
+

--- a/opengever/core/lawgiver.zcml
+++ b/opengever/core/lawgiver.zcml
@@ -241,6 +241,13 @@
                    "
       />
 
+  <!-- Manage Groups is only managed globally in rolemap.xml. -->
+  <lawgiver:ignore
+      permissions="
+                   opengever.api: Manage Groups,
+                   "
+      />
+
   <!-- Ignore default Plone permissions. This means we are not managing in the
        workflows. This does not mean that the permissions are disabled: disabling
        can be done in the rolemap.xml. -->

--- a/opengever/core/profiles/default/rolemap.xml
+++ b/opengever/core/profiles/default/rolemap.xml
@@ -68,6 +68,11 @@
       <role name="Administrator" />
     </permission>
 
+    <permission name="opengever.api: Manage Groups" acquire="False">
+      <role name="Manager" />
+      <role name="Administrator" />
+    </permission>
+
     <!-- CMFEDITIONS -->
     <permission name="CMFEditions: Save new version" acquire="True">
       <role name="Administrator" />

--- a/opengever/core/upgrades/20200909150915_add_is_local_column_for_groups/upgrade.py
+++ b/opengever/core/upgrades/20200909150915_add_is_local_column_for_groups/upgrade.py
@@ -1,0 +1,13 @@
+from opengever.core.upgrade import SchemaMigration
+from sqlalchemy import Boolean
+from sqlalchemy import Column
+
+
+class AddIsLocalColumnForGroups(SchemaMigration):
+    """Add is local column for groups.
+    """
+
+    def migrate(self):
+        self.op.add_column(
+            'groups', Column('is_local', Boolean, default=False, nullable=True)
+        )

--- a/opengever/core/upgrades/20200909162246_add_manage_groups_permission/rolemap.xml
+++ b/opengever/core/upgrades/20200909162246_add_manage_groups_permission/rolemap.xml
@@ -1,0 +1,8 @@
+<rolemap>
+  <permissions>
+    <permission name="opengever.api: Manage Groups" acquire="False">
+      <role name="Manager" />
+      <role name="Administrator" />
+    </permission>
+  </permissions>
+</rolemap>

--- a/opengever/core/upgrades/20200909162246_add_manage_groups_permission/upgrade.py
+++ b/opengever/core/upgrades/20200909162246_add_manage_groups_permission/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddManageGroupsPermission(UpgradeStep):
+    """Add manage groups permission.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/core/upgrades/20200921135157_manage_groups_with_source_groups_plugin/upgrade.py
+++ b/opengever/core/upgrades/20200921135157_manage_groups_with_source_groups_plugin/upgrade.py
@@ -1,0 +1,50 @@
+from ftw.upgrade import UpgradeStep
+from Products.CMFPlone.utils import getToolByName
+from Products.PlonePAS.interfaces.group import IGroupManagement
+from Products.PluggableAuthService.interfaces.plugins import IGroupEnumerationPlugin
+import logging
+
+LOG = logging.getLogger('ftw.upgrade')
+
+
+class ManageGroupsWithSourceGroupsPlugin(UpgradeStep):
+    """Manage groups with source groups plugin.
+    """
+
+    def __call__(self):
+        """
+        Manage groups with source groups plugin and not with ldap plugin.
+        As we now overwrite the @groups endpoint allowing also admin to manage
+        groups, we want to avoid mistakingly writing in the ldap. Managed groups
+        should all be source groups. For that we move the source_groups plugin
+        to the top.
+        We now also need to find the created source groups, hence we need to
+        activate enumeration for the source_groups plugin.
+        """
+        acl_users = getToolByName(self.portal, 'acl_users')
+        plugins = acl_users.plugins
+        group_management_plugins = plugins.getAllPlugins('IGroupManagement')
+
+        if 'source_groups' in group_management_plugins.get('available'):
+            plugins.activatePlugin(IGroupManagement, 'source_groups')
+        elif 'source_groups' not in group_management_plugins.get('active'):
+            LOG.error('Source groups is not available for group management')
+
+        # move source_groups plugin up. 3 times... why not!
+        plugins.movePluginsUp(IGroupManagement, ('source_groups',))
+        plugins.movePluginsUp(IGroupManagement, ('source_groups',))
+        plugins.movePluginsUp(IGroupManagement, ('source_groups',))
+
+        # check that source_groups is now in first position for group management
+        group_management_plugins = plugins.getAllPlugins('IGroupManagement')
+        if 'source_groups' in group_management_plugins.get('active') and not \
+           group_management_plugins.get('active')[0] == 'source_groups':
+            LOG.error('Source groups plugin could not be moved to top of group'
+                      ' management plugins')
+
+        # Make sure that source_groups is activated for group enumeration
+        group_enumeration_plugins = plugins.getAllPlugins('IGroupEnumerationPlugin')
+        if 'source_groups' in group_enumeration_plugins.get('available'):
+            plugins.activatePlugin(IGroupEnumerationPlugin, 'source_groups')
+        elif 'source_groups' not in group_enumeration_plugins.get('active'):
+            LOG.error('Source groups is not available for group enumeration')

--- a/opengever/examplecontent/profiles/4teamwork-ldap/ldap_plugin.xml
+++ b/opengever/examplecontent/profiles/4teamwork-ldap/ldap_plugin.xml
@@ -10,7 +10,6 @@
     <interface value="ICredentialsResetPlugin" />
     <interface value="IGroupEnumerationPlugin" />
     <interface value="IGroupIntrospection" />
-    <interface value="IGroupManagement" />
     <interface value="IGroupsPlugin" />
     <interface value="IPropertiesPlugin" />
     <interface value="IUserAdderPlugin" />

--- a/opengever/ogds/base/tests/test_ogds_updater.py
+++ b/opengever/ogds/base/tests/test_ogds_updater.py
@@ -14,7 +14,7 @@ from plone import api
 
 FAKE_LDAP_USERFOLDER = FakeLDAPUserFolder()
 BLACKLISTED_USER_COLUMNS = {'userid', 'last_login'}
-BLACKLISTED_GROUP_COLUMNS = set()
+BLACKLISTED_GROUP_COLUMNS = {'is_local'}
 
 
 class TestOGDSUpdater(FunctionalTestCase):

--- a/opengever/ogds/base/tests/test_ogds_updater.py
+++ b/opengever/ogds/base/tests/test_ogds_updater.py
@@ -211,3 +211,26 @@ class TestOGDSUpdater(FunctionalTestCase):
 
         ogds_group = ogds_service().fetch_group(u'f\xfchrung')
         self.assertEquals(u'f\xfchrung', ogds_group.groupid)
+
+    def test_does_not_overwrite_local_groups(self):
+        groupid = u'local.group'
+        ogds_group = create(Builder('ogds_group').id(groupid))
+        ogds_user = create(Builder('ogds_user').id('john.doe'))
+        ogds_group.users.append(ogds_user)
+
+        ldap_user = create(Builder('ldapuser').named('sk1m1'))
+        FAKE_LDAP_USERFOLDER.users = [ldap_user]
+        FAKE_LDAP_USERFOLDER.groups = [create(
+            Builder('ldapgroup').named(groupid).with_members([ldap_user]))]
+        updater = IOGDSUpdater(self.portal)
+        updater.import_users()
+
+        ogds_group.is_local = True
+        updater.import_groups()
+        self.assertItemsEqual([user.userid for user in ogds_group.users],
+                              [ogds_user.userid])
+
+        ogds_group.is_local = False
+        updater.import_groups()
+        self.assertItemsEqual([user.userid for user in ogds_group.users],
+                              [ldap_user[1]['userid']])

--- a/opengever/ogds/models/group.py
+++ b/opengever/ogds/models/group.py
@@ -42,6 +42,11 @@ class Group(Base):
     active = Column(Boolean, default=True)
     title = Column(String(GROUP_TITLE_LENGTH))
 
+    # is_local is set for groups created over the @groups endpoint
+    # which should always be plone groups and are the only groups
+    # allowed to be managed over the @groups endpoint.
+    is_local = Column(Boolean, default=False, nullable=True)
+
     users = relation(User, secondary=groups_users,
                      backref=backref('groups', order_by='Group.groupid'))
     teams = relationship(Team, back_populates="group")

--- a/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/+adminunit.id+/profiles/ldap/ldap_plugin.xml.bob
+++ b/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/+adminunit.id+/profiles/ldap/ldap_plugin.xml.bob
@@ -7,7 +7,6 @@
             <interface value="ICredentialsResetPlugin"/>
             <interface value="IGroupEnumerationPlugin"/>
             <interface value="IGroupIntrospection"/>
-            <interface value="IGroupManagement"/>
             <interface value="IGroupsPlugin"/>
             <interface value="IPropertiesPlugin"/>
             <interface value="IUserAdderPlugin"/>

--- a/opengever/setup/deploy.py
+++ b/opengever/setup/deploy.py
@@ -104,11 +104,18 @@ class GeverDeployment(object):
         acl_users = getToolByName(self.site, 'acl_users')
         plugins = acl_users.plugins
 
-        # disable source_groups when using ldap
+        # disable source_groups when using ldap except for group management and
+        # enumeration which are used to create groups over the @groups endpoint.
         for ptype in plugins.listPluginTypeInfo():
+            if ptype['id'] == 'IGroupEnumerationPlugin':
+                continue
+            if ptype['id'] == 'IGroupManagement':
+                to_deactivate = 'ldap'
+            else:
+                to_deactivate = 'source_groups'
             try:
                 plugins.deactivatePlugin(ptype['interface'],
-                                         'source_groups')
+                                         to_deactivate)
             except KeyError:
                 pass
 

--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -322,6 +322,7 @@ class OpengeverContentFixture(object):
             'workspace_owner',
             u'G\xfcnther',
             u'Fr\xf6hlich',
+            ['WorkspacesUser', 'WorkspacesCreator'],
             user_settings={'_seen_tours': '["*"]'},
             )
 
@@ -329,6 +330,7 @@ class OpengeverContentFixture(object):
             'workspace_admin',
             u'Fridolin',
             u'Hugentobler',
+            ['WorkspacesUser', 'WorkspacesCreator'],
             user_settings={'_seen_tours': '["*"]'},
             )
 
@@ -336,6 +338,7 @@ class OpengeverContentFixture(object):
             'workspace_member',
             u'B\xe9atrice',
             u'Schr\xf6dinger',
+            ['WorkspacesUser'],
             user_settings={'_seen_tours': '["*"]'},
             )
 
@@ -343,6 +346,7 @@ class OpengeverContentFixture(object):
             'workspace_guest',
             u'Hans',
             u'Peter',
+            ['WorkspacesUser'],
             user_settings={'_seen_tours': '["*"]'},
             )
 
@@ -2119,18 +2123,6 @@ class OpengeverContentFixture(object):
         policy_config.setPolicyBelow(
             'opengever_workspace_policy', update_security=False)
 
-        self.set_roles(
-            self.workspace_root, self.workspace_owner.getId(),
-            ['WorkspacesUser', 'WorkspacesCreator'])
-        self.set_roles(
-            self.workspace_root, self.workspace_admin.getId(),
-            ['WorkspacesUser', 'WorkspacesCreator'])
-        self.set_roles(
-            self.workspace_root, self.workspace_member.getId(),
-            ['WorkspacesUser'])
-        self.set_roles(
-            self.workspace_root, self.workspace_guest.getId(),
-            ['WorkspacesUser'])
         self.workspace_root.reindexObjectSecurity()
 
     def create_workspace(self):


### PR DESCRIPTION
For Teamraum deployments we want to allow administrators to manage groups so that groups can be used to give access to workspaces. Plone already has a `@groups` endpoint, but we needed to extend it to support our OGDS as well as allow Administrators to use the endpoint. For that we:
- Overwrite the `@groups` POST, PATCH and DELETE endpoints
- Customize the endpoints to be allowed for Administrators
- Customize the endpoints to handle the OGDS
- Restrict the endpoints to handle workspace roles
- Restrict the endpoints to only manage local groups (source groups)
- Modify the `sync_ogds` to avoid overwriting the source groups managed by the `@groups` endpoint

Another difficulty that arose in that groups are enumerated and managed over the plugins, so we need to make sure that our deployments are configured correctly to avoid writing to the LDAP. For that we:
- Add a check in the `sync_ogds` to make sure group management happens over the `source_groups` plugin and that this is also enabled for enumeration
- Add upgrade step to setup current deployments accordingly
- Modify policy templates and example content accordingly

Note that we will probably still need to implement a GET or a vocabulary or a listing endpoint in order to be able to implement the frontend part of the story. But this will be done separately and should be driven by the frontend's needs.

For https://4teamwork.atlassian.net/browse/GEVER-530

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

## Checklist (if applicable)

_Only applicable should be left and checked._

- API change:
  - [x] Documentation is updated
  - If breaking: Not sure, whether we want to consider this breaking. I guess we do now allow less things done with the `@groups` endpoint, but on the other hand I'd anyway prefer if nobody was using it before now...
    - [ ] api-change label added
    - [ ] Scrum master is informed
- Upgrade steps (changes in profile):
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
- DB-Schema migration
  - [x] All changes on a model (columns, etc) are included in a DB-schema migration.
  - [x] Constraint names are shorter than 30 characters (`Oracle`)
- [x] Change could impact client installations, client policies need to be adapted:
        I think that with the upgrade step and adaptation of `deploy.py` both already existing and newer installations should be covered
