### PR TITLE
Fix tus replace

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -11,6 +11,7 @@ Changelog
 - Not only documents, but also mails in tasks and proposals may not be moved. [tinagerber]
 - Include is_subdossier and review_state in @navigation endpoint nodes. [elioschmutz]
 - Order groups and teams in User serializer by title. [elioschmutz]
+- Do not allow @tus-replace if document is not checked out by current user. [buchi]
 
 
 2020.9.0 (2020-09-10)

--- a/docs/public/dev-manual/api/documents.rst
+++ b/docs/public/dev-manual/api/documents.rst
@@ -206,6 +206,27 @@ Datei uploaden:
     HTTP/1.1 204 No content
     Content-Type: application/json
 
+Wurde das Dokument zuvor mittels Lock gesperrt, muss das Lock Token über den
+`Lock-Token` header mitgegeben werden.
+
+Dateiupload mit Lock Token:
+
+  .. sourcecode:: http
+
+      PATCH /ordnungssystem/dossier-23/document-123/@tus-upload/6cdfc5ddd1844e8cbca32721c4b17b84 HTTP/1.1
+      Accept: application/json
+      Tus-Resumable: 1.0.0
+      Upload-Offset: 0
+      Content-Type: application/offset+octet-stream
+      Lock-Token: 0.684672730996-0.25195226375-00105A989226:1477076400.000
+
+      test data
+
+  .. sourcecode:: http
+
+    HTTP/1.1 204 No content
+    Content-Type: application/json
+
 
 .. _label-api_checkin:
 

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -955,4 +955,12 @@
       layer="opengever.base.interfaces.IOpengeverBaseLayer"
       />
 
+  <plone:service
+      method="PATCH"
+      name="@tus-upload"
+      for="opengever.document.document.IDocumentSchema"
+      factory=".tus.UploadPatch"
+      permission="cmf.ModifyPortalContent"
+      />
+
 </configure>

--- a/opengever/api/tests/test_tus.py
+++ b/opengever/api/tests/test_tus.py
@@ -1,0 +1,131 @@
+from ftw.testbrowser import browsing
+from opengever.testing import IntegrationTestCase
+from six import BytesIO
+
+UPLOAD_DATA = b"abcdefgh"
+UPLOAD_LENGTH = len(UPLOAD_DATA)
+UPLOAD_METADATA = 'filename dGVzdC50eHQ=,content-type dGV4dC9wbGFpbg=='
+
+
+class TestTUSUpload(IntegrationTestCase):
+
+    def setUp(self):
+        super(TestTUSUpload, self).setUp()
+
+    def prepare_tus_replace(self, doc, browser, headers=None):
+        browser.open(
+            doc.absolute_url() + '/@tus-replace',
+            method='POST',
+            headers=dict({
+                "Accept": "application/json",
+                "Tus-Resumable": "1.0.0",
+                "Upload-Length": str(UPLOAD_LENGTH),
+                "Upload-Metadata": UPLOAD_METADATA,
+            }, **headers or {}),
+        )
+        self.assertEqual(browser.status_code, 201)
+        return browser.headers.get('Location')
+
+    def assert_tus_replace_succeeds(self, doc, browser, headers=None):
+        location = self.prepare_tus_replace(doc, browser, headers=headers)
+        browser.open(
+            location,
+            method='PATCH',
+            headers=dict({
+                "Accept": "application/json",
+                "Content-Type": "application/offset+octet-stream",
+                "Upload-Offset": "0",
+                "Tus-Resumable": "1.0.0",
+            }, **headers or {}),
+            data=BytesIO(UPLOAD_DATA),
+        )
+        self.assertEqual(browser.status_code, 204)
+
+    def assert_tus_replace_fails(self, doc, browser, headers=None, code=403,
+                                 reason='Forbidden'):
+        location = self.prepare_tus_replace(doc, browser, headers=headers)
+        with browser.expect_http_error(code=code, reason=reason):
+            browser.open(
+                location,
+                method='PATCH',
+                headers={
+                    "Accept": "application/json",
+                    "Content-Type": "application/offset+octet-stream",
+                    "Upload-Offset": "0",
+                    "Tus-Resumable": "1.0.0",
+                },
+                data=BytesIO(UPLOAD_DATA),
+            )
+
+    def checkout(self, doc, browser):
+        browser.open(
+            doc.absolute_url() + '/@checkout', method='POST',
+            headers={"Accept": "application/json"},
+        )
+        self.assertEqual(browser.status_code, 204)
+
+    def lock(self, doc, browser):
+        browser.open(
+            self.document.absolute_url() + '/@lock', method='POST',
+            headers={"Accept": "application/json"},
+        )
+        self.assertEqual(browser.status_code, 200)
+        return browser.json[u'token']
+
+    @browsing
+    def test_can_replace_document_if_checked_out(self, browser):
+        self.login(self.regular_user, browser)
+        self.checkout(self.document, browser)
+
+        self.assert_tus_replace_succeeds(self.document, browser)
+
+    @browsing
+    def test_can_replace_document_if_checked_out_and_locked(self, browser):
+        self.login(self.regular_user, browser)
+        self.checkout(self.document, browser)
+        token = self.lock(self.document, browser)
+
+        self.assert_tus_replace_succeeds(
+            self.document, browser, headers={'Lock-Token': token})
+
+    @browsing
+    def test_cannot_replace_document_if_not_checked_out(self, browser):
+        self.login(self.regular_user, browser)
+        self.assert_tus_replace_fails(self.document, browser)
+
+    @browsing
+    def test_cannot_replace_document_if_checked_out_by_other(self, browser):
+        self.login(self.dossier_responsible, browser)
+        self.checkout(self.document, browser)
+
+        self.login(self.regular_user, browser)
+        self.assert_tus_replace_fails(self.document, browser)
+
+    @browsing
+    def test_cannot_replace_document_if_lock_token_not_provided(self, browser):
+        self.login(self.regular_user, browser)
+        self.checkout(self.document, browser)
+        self.lock(self.document, browser)
+
+        self.assert_tus_replace_fails(self.document, browser)
+
+    @browsing
+    def test_can_replace_proposal_if_docx(self, browser):
+        self.login(self.administrator, browser)
+        self.checkout(self.proposal_template, browser)
+
+        self.assert_tus_replace_succeeds(
+            self.proposal_template, browser,
+            headers={
+                'Upload-Metadata':
+                    'filename dGVzdC5kb2N4,content-type dGV4dC9wbGFpbg==',
+            },
+        )
+
+    @browsing
+    def test_cannot_replace_proposal_if_not_docx(self, browser):
+        self.login(self.administrator, browser)
+        self.checkout(self.proposal_template, browser)
+
+        self.assert_tus_replace_fails(
+            self.proposal_template, browser, code=400, reason='Bad Request')

--- a/opengever/api/tests/test_tus.py
+++ b/opengever/api/tests/test_tus.py
@@ -1,6 +1,8 @@
+from datetime import datetime
 from ftw.testbrowser import browsing
 from opengever.testing import IntegrationTestCase
 from six import BytesIO
+from unittest import skipIf
 
 UPLOAD_DATA = b"abcdefgh"
 UPLOAD_LENGTH = len(UPLOAD_DATA)
@@ -101,6 +103,11 @@ class TestTUSUpload(IntegrationTestCase):
         self.login(self.regular_user, browser)
         self.assert_tus_replace_fails(self.document, browser)
 
+    @skipIf(
+        datetime.now() < datetime(2021, 9, 11),
+        "Lock verification temporary disabled, because it's not yet supported "
+        "by Office Connector",
+    )
     @browsing
     def test_cannot_replace_document_if_lock_token_not_provided(self, browser):
         self.login(self.regular_user, browser)

--- a/opengever/api/tus.py
+++ b/opengever/api/tus.py
@@ -1,0 +1,52 @@
+from opengever.document import _
+from opengever.document.interfaces import ICheckinCheckoutManager
+from plone.restapi.services.content.tus import UploadPatch
+from opengever.meeting.proposaltemplate import IProposalTemplate
+from zExceptions import BadRequest
+from zExceptions import Forbidden
+from zope.component import getMultiAdapter
+from zope.i18n import translate
+from zope.publisher.interfaces import IPublishTraverse
+from zope.interface import implementer
+
+
+@implementer(IPublishTraverse)
+class UploadPatch(UploadPatch):
+    """TUS upload endpoint for handling PATCH requests"""
+
+    # In addition to checking permissions we perform additional checks:
+    # - The document must be checked out
+    # - If locked, the lock token must be provided in the request
+    # - If it's a proposal, the file must have a .docx extension
+    def check_add_modify_permission(self, mode):
+        super(UploadPatch, self).check_add_modify_permission(mode)
+
+        if mode == 'create':
+            return
+
+        manager = getMultiAdapter((self.context, self.context.REQUEST),
+                                  ICheckinCheckoutManager)
+        if not manager.is_checked_out_by_current_user():
+            raise Forbidden("Document not checked out.")
+
+        if manager.is_locked_by_other():
+            raise Forbidden("Document is locked.")
+
+        if self.is_proposal_upload() or self.is_proposal_template_upload():
+            tus_upload = self.tus_upload()
+            metadata = tus_upload.metadata()
+            filename = metadata.get("filename", "")
+            if not filename.endswith('.docx'):
+                msg = translate(_(
+                    u'error_proposal_document_type',
+                    default=u"It's not possible to have non-.docx documents as"
+                            " proposal documents.",
+                ), context=self.request),
+                raise BadRequest(msg)
+
+    def is_proposal_upload(self):
+        """The upload form context can be, for example, a Dossier."""
+        return getattr(self.context, 'is_inside_a_proposal', lambda: False)()
+
+    def is_proposal_template_upload(self):
+        return IProposalTemplate.providedBy(self.context)

--- a/opengever/api/tus.py
+++ b/opengever/api/tus.py
@@ -29,8 +29,11 @@ class UploadPatch(UploadPatch):
         if not manager.is_checked_out_by_current_user():
             raise Forbidden("Document not checked out.")
 
-        if manager.is_locked_by_other():
-            raise Forbidden("Document is locked.")
+        # XXX: Currently not supported by the latest Office Connector 1.10.0
+        # Enable this after a grace period when OC > 1.10.0 has been rolled out
+        # to customers.
+        # if manager.is_locked_by_other():
+        #     raise Forbidden("Document is locked.")
 
         if self.is_proposal_upload() or self.is_proposal_template_upload():
             tus_upload = self.tus_upload()

--- a/opengever/officeconnector/testing.py
+++ b/opengever/officeconnector/testing.py
@@ -210,6 +210,7 @@ class OCIntegrationTestCase(IntegrationTestCase):
 
         self.assertEquals(200, browser.status_code)
         self.assertTrue(lock_manager.is_locked())
+        return browser.json[u'token']
 
     def download_document(self, browser, raw_token, payload):
         with self.as_officeconnector(browser):
@@ -243,7 +244,8 @@ class OCIntegrationTestCase(IntegrationTestCase):
 
         return file_contents
 
-    def upload_document(self, browser, raw_token, payload, document, new_file):
+    def upload_document(self, browser, raw_token, payload, document, new_file,
+                        lock_token=None):
         with self.as_officeconnector(browser):
             filename = b64encode(basename(new_file.name))
             content_type = b64encode(payload.get('content-type'))
@@ -265,6 +267,8 @@ class OCIntegrationTestCase(IntegrationTestCase):
                 'Upload-Offset': '0',
                 'Content-Type': 'application/offset+octet-stream',
             }
+            if lock_token is not None:
+                headers['Lock-Token'] = lock_token
             browser.open(upload_url, method='PATCH', data=new_file.read(), headers=headers)
             self.assertEquals(204, browser.status_code)
 

--- a/opengever/officeconnector/tests/test_api_dossier_checkout.py
+++ b/opengever/officeconnector/tests/test_api_dossier_checkout.py
@@ -204,14 +204,18 @@ class TestOfficeconnectorDossierAPIWithCheckout(OCIntegrationTestCase):
             self.assertEqual(expected_payload, payload_copy)
 
         self.checkout_document(browser, raw_token, payloads[0], self.document)
-        self.lock_document(browser, raw_token, payloads[0], self.document)
+        lock_token = self.lock_document(
+            browser, raw_token, payloads[0], self.document)
 
         original_checksum = sha256(
             self.download_document(browser, raw_token, payloads[0]),
             ).hexdigest()
 
         with open(path_to_asset('addendum.docx')) as f:
-            self.upload_document(browser, raw_token, payloads[0], self.document, f)
+            self.upload_document(
+                browser, raw_token, payloads[0], self.document, f,
+                lock_token=lock_token,
+            )
 
         new_checksum = sha256(
             self.download_document(browser, raw_token, payloads[0]),
@@ -265,14 +269,18 @@ class TestOfficeconnectorDossierAPIWithCheckout(OCIntegrationTestCase):
             self.assertEqual(expected_payload, payload_copy)
 
         self.checkout_document(browser, raw_token, payloads[0], self.document)
-        self.lock_document(browser, raw_token, payloads[0], self.document)
+        lock_token = self.lock_document(
+            browser, raw_token, payloads[0], self.document)
 
         original_checksum = sha256(
             self.download_document(browser, raw_token, payloads[0]),
             ).hexdigest()
 
         with open(path_to_asset('addendum.docx')) as f:
-            self.upload_document(browser, raw_token, payloads[0], self.document, f)
+            self.upload_document(
+                browser, raw_token, payloads[0], self.document, f,
+                lock_token=lock_token,
+            )
 
         new_checksum = sha256(
             self.download_document(browser, raw_token, payloads[0]),

--- a/opengever/officeconnector/tests/test_api_dossier_oneoffixx.py
+++ b/opengever/officeconnector/tests/test_api_dossier_oneoffixx.py
@@ -110,10 +110,14 @@ class TestOfficeconnectorDossierAPIWithOneOffixx(OCIntegrationTestCase):
 
         self.assertTrue(self.shadow_document.is_shadow_document())
         self.checkout_document(browser, raw_token, payloads[0], self.shadow_document)
-        self.lock_document(browser, raw_token, payloads[0], self.shadow_document)
+        lock_token = self.lock_document(
+            browser, raw_token, payloads[0], self.shadow_document)
 
         with open(path_to_asset('addendum.docx')) as f:
-            self.upload_document(browser, raw_token, payloads[0], self.shadow_document, f)
+            self.upload_document(
+                browser, raw_token, payloads[0], self.shadow_document, f,
+                lock_token=lock_token,
+            )
         self.assertFalse(self.shadow_document.is_shadow_document())
 
         self.unlock_document(browser, raw_token, payloads[0], self.shadow_document)

--- a/opengever/officeconnector/tests/test_api_task_checkout.py
+++ b/opengever/officeconnector/tests/test_api_task_checkout.py
@@ -76,12 +76,14 @@ class TestOfficeconnectorTaskAPIWithCheckoutWithRESTAPI(OCIntegrationTestCase):
             self.assertEqual(expected_payload, payload_copy)
 
         self.checkout_document(browser, raw_token, payloads[0], document)
-        self.lock_document(browser, raw_token, payloads[0], document)
+        lock_token = self.lock_document(
+            browser, raw_token, payloads[0], document)
 
         original_checksum = sha256(self.download_document(browser, raw_token, payloads[0])).hexdigest()
 
         with open(path_to_asset('addendum.docx')) as f:
-            self.upload_document(browser, raw_token, payloads[0], document, f)
+            self.upload_document(
+                browser, raw_token, payloads[0], document, f, lock_token=lock_token)
 
         new_checksum = sha256(self.download_document(browser, raw_token, payloads[0])).hexdigest()
         self.assertNotEqual(new_checksum, original_checksum)

--- a/opengever/officeconnector/tests/test_zopemaster.py
+++ b/opengever/officeconnector/tests/test_zopemaster.py
@@ -102,14 +102,18 @@ class TestOfficeconnectorAsZopemasterDossierAPIWithCheckout(OCIntegrationTestCas
 
         self.checkout_document(browser, raw_token, payloads[0], self.document)
 
-        self.lock_document(browser, raw_token, payloads[0], self.document)
+        lock_token = self.lock_document(
+            browser, raw_token, payloads[0], self.document)
 
         original_checksum = sha256(
             self.download_document(browser, raw_token, payloads[0]),
             ).hexdigest()
 
         with open(path_to_asset('addendum.docx')) as f:
-            self.upload_document(browser, raw_token, payloads[0], self.document, f)
+            self.upload_document(
+                browser, raw_token, payloads[0], self.document, f,
+                lock_token=lock_token,
+            )
 
         new_checksum = sha256(
             self.download_document(browser, raw_token, payloads[0]),


### PR DESCRIPTION
Customize `@tus-replace` endpoint to perform additional checks before replacing a file:
- The document must be checked out by the current user
- If locked, the lock token must be provided in the request
- If it's a proposal, the file must have a .docx extension

The main difference with the implementation in `quick_upload.py` is, that you must be able to upload a file if it's locked by you, because Office Connector always locks the file.

However the current Office Connector release (1.10.0) does not yet send the lock token when replacing a file. :-(
The check for the correct lock token would break uploading files with the current OC release.

As we need some time to ensure a wide rollout of an OC release with lock token support, the lock check is currently disabled. There's a test verifying this functionality which is skipped for one year. In one year we should be ready to enable the lock token check. If not, the test will fail.

Because of that

Jira: https://4teamwork.atlassian.net/browse/GEVER-975

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


## Checklist (if applicable)

_Only applicable should be left and checked._

- API change:
  - [x] Documentation is updated
  - If breaking:
    - [x] api-change label added
    - [x] Scrum master is informed
