### PR TITLE
Fix handling of Missing.Value in `@navigation` endpoint.

### DIFF
--- a/opengever/api/navigation.py
+++ b/opengever/api/navigation.py
@@ -6,6 +6,7 @@ from opengever.repository.repositoryfolder import REPOSITORY_FOLDER_STATE_INACTI
 from opengever.repository.repositoryroot import IRepositoryRoot
 from plone import api
 from plone.restapi.interfaces import IExpandableElement
+from plone.restapi.serializer.converters import json_compatible
 from plone.restapi.services import Service
 from Products.CMFPlone.interfaces.siteroot import IPloneSiteRoot
 from zExceptions import BadRequest
@@ -135,7 +136,7 @@ class Navigation(object):
         }
         if brain.portal_type == 'opengever.repository.repositoryfolder':
             node['is_leafnode'] = not brain.has_sametype_children
-        return node
+        return json_compatible(node)
 
 
 class NavigationGet(Service):


### PR DESCRIPTION
This fixes serialization of possible `Missing.Value`s in the `@navigation` endpoint by running its `node` dict through plone.restapi's `json_compatible` helper function.

Jira: https://4teamwork.atlassian.net/browse/GEVER-1023

## Checklist (Must have)

- [ ] Changelog entry
  _Not needed, bug is being fixed in same release as it was introduced_ (#6632) 
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
