### PR TITLE
Do not manage security in deactivated workspaces

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2020.10.0 (unreleased)
 ----------------------
 
+- Do not allow to manage security in deactivated workspaces. [tinagerber]
 - API change: Add current_user to @config endpoint and remove userid, user_fullname and user_email. [tinagerber]
 - Fix globalindex endpoint for undefined sort orders. [njohner]
 - Fix ogds listing endpoints for undefined sort orders. [njohner]

--- a/opengever/core/lawgiver.zcml
+++ b/opengever/core/lawgiver.zcml
@@ -401,6 +401,12 @@
                      Add portal content,
                      Modify portal content,
                      Manage properties,
+                     Change local roles,
+                     Sharing page: Delegate WorkspaceAdmin role,
+                     Sharing page: Delegate WorkspaceGuest role,
+                     Sharing page: Delegate WorkspaceMember role,
+                     Sharing page: Delegate roles,
+                     Take ownership,
                      "
         />
     <lawgiver:map_permissions
@@ -419,6 +425,12 @@
                      opengever.document: Force Checkin,
                      Modify portal content,
                      Manage properties,
+                     Change local roles,
+                     Sharing page: Delegate WorkspaceAdmin role,
+                     Sharing page: Delegate WorkspaceGuest role,
+                     Sharing page: Delegate WorkspaceMember role,
+                     Sharing page: Delegate roles,
+                     Take ownership,
                      "
         />
     <lawgiver:map_permissions
@@ -435,6 +447,12 @@
                      Modify portal content,
                      Delete objects,
                      Manage properties,
+                     Change local roles,
+                     Sharing page: Delegate WorkspaceAdmin role,
+                     Sharing page: Delegate WorkspaceGuest role,
+                     Sharing page: Delegate WorkspaceMember role,
+                     Sharing page: Delegate roles,
+                     Take ownership,
                      "
         />
 
@@ -447,6 +465,12 @@
                      Modify portal content,
                      Delete objects,
                      Manage properties,
+                     Change local roles,
+                     Sharing page: Delegate WorkspaceAdmin role,
+                     Sharing page: Delegate WorkspaceGuest role,
+                     Sharing page: Delegate WorkspaceMember role,
+                     Sharing page: Delegate roles,
+                     Take ownership,
                      "
         />
 

--- a/opengever/core/profiles/default/workflows/opengever_workspace/definition.xml
+++ b/opengever/core/profiles/default/workflows/opengever_workspace/definition.xml
@@ -542,9 +542,7 @@
     <permission-map name="CMFEditions: Revert to previous versions" acquired="False"/>
     <permission-map name="CMFEditions: Save new version" acquired="False"/>
     <permission-map name="Change local roles" acquired="False">
-      <permission-role>Administrator</permission-role>
       <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
     </permission-map>
     <permission-map name="Delete objects" acquired="False">
       <permission-role>Manager</permission-role>
@@ -582,31 +580,21 @@
     <permission-map name="Sharing page: Delegate Reader role" acquired="False"/>
     <permission-map name="Sharing page: Delegate Reviewer role" acquired="False"/>
     <permission-map name="Sharing page: Delegate WorkspaceAdmin role" acquired="False">
-      <permission-role>Administrator</permission-role>
       <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
     </permission-map>
     <permission-map name="Sharing page: Delegate WorkspaceGuest role" acquired="False">
-      <permission-role>Administrator</permission-role>
       <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
     </permission-map>
     <permission-map name="Sharing page: Delegate WorkspaceMember role" acquired="False">
-      <permission-role>Administrator</permission-role>
       <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
     </permission-map>
     <permission-map name="Sharing page: Delegate WorkspacesCreator role" acquired="False"/>
     <permission-map name="Sharing page: Delegate WorkspacesUser role" acquired="False"/>
     <permission-map name="Sharing page: Delegate roles" acquired="False">
-      <permission-role>Administrator</permission-role>
       <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
     </permission-map>
     <permission-map name="Take ownership" acquired="False">
-      <permission-role>Administrator</permission-role>
       <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
     </permission-map>
     <permission-map name="View" acquired="False">
       <permission-role>Administrator</permission-role>

--- a/opengever/core/profiles/default/workflows/opengever_workspace/specification.txt
+++ b/opengever/core/profiles/default/workflows/opengever_workspace/specification.txt
@@ -46,7 +46,6 @@ Status Active:
   A workspace admin can deactivate.
 Status Inactive:
   A workspace guest can view.
-  A workspace admin can manage security.
   A workspace admin can reactivate.
 
 Transitions:

--- a/opengever/core/profiles/default/workflows/opengever_workspace_document/definition.xml
+++ b/opengever/core/profiles/default/workflows/opengever_workspace_document/definition.xml
@@ -7,7 +7,6 @@
   <permission>CMFEditions: Checkout to location</permission>
   <permission>CMFEditions: Revert to previous versions</permission>
   <permission>CMFEditions: Save new version</permission>
-  <permission>Change local roles</permission>
   <permission>Delete objects</permission>
   <permission>Edit comments</permission>
   <permission>Edit date of cassation</permission>
@@ -36,13 +35,8 @@
   <permission>Sharing page: Delegate Publisher role</permission>
   <permission>Sharing page: Delegate Reader role</permission>
   <permission>Sharing page: Delegate Reviewer role</permission>
-  <permission>Sharing page: Delegate WorkspaceAdmin role</permission>
-  <permission>Sharing page: Delegate WorkspaceGuest role</permission>
-  <permission>Sharing page: Delegate WorkspaceMember role</permission>
   <permission>Sharing page: Delegate WorkspacesCreator role</permission>
   <permission>Sharing page: Delegate WorkspacesUser role</permission>
-  <permission>Sharing page: Delegate roles</permission>
-  <permission>Take ownership</permission>
   <permission>View</permission>
   <permission>ftw.keywordwidget: Add new term</permission>
   <permission>ftw.mail: Add Inbound Mail</permission>
@@ -107,11 +101,6 @@
     <permission-map name="CMFEditions: Checkout to location" acquired="False"/>
     <permission-map name="CMFEditions: Revert to previous versions" acquired="False"/>
     <permission-map name="CMFEditions: Save new version" acquired="False"/>
-    <permission-map name="Change local roles" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-    </permission-map>
     <permission-map name="Delete objects" acquired="False">
       <permission-role>Manager</permission-role>
     </permission-map>
@@ -150,33 +139,8 @@
     <permission-map name="Sharing page: Delegate Publisher role" acquired="False"/>
     <permission-map name="Sharing page: Delegate Reader role" acquired="False"/>
     <permission-map name="Sharing page: Delegate Reviewer role" acquired="False"/>
-    <permission-map name="Sharing page: Delegate WorkspaceAdmin role" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-    </permission-map>
-    <permission-map name="Sharing page: Delegate WorkspaceGuest role" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-    </permission-map>
-    <permission-map name="Sharing page: Delegate WorkspaceMember role" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-    </permission-map>
     <permission-map name="Sharing page: Delegate WorkspacesCreator role" acquired="False"/>
     <permission-map name="Sharing page: Delegate WorkspacesUser role" acquired="False"/>
-    <permission-map name="Sharing page: Delegate roles" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-    </permission-map>
-    <permission-map name="Take ownership" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-    </permission-map>
     <permission-map name="View" acquired="False">
       <permission-role>Administrator</permission-role>
       <permission-role>Manager</permission-role>

--- a/opengever/core/profiles/default/workflows/opengever_workspace_document/specification.txt
+++ b/opengever/core/profiles/default/workflows/opengever_workspace_document/specification.txt
@@ -35,4 +35,3 @@ General:
 Initial Status: Active
 Status Active:
   A workspace guest can view.
-  A workspace admin can manage security.

--- a/opengever/core/profiles/default/workflows/opengever_workspace_folder/definition.xml
+++ b/opengever/core/profiles/default/workflows/opengever_workspace_folder/definition.xml
@@ -6,7 +6,6 @@
   <permission>CMFEditions: Checkout to location</permission>
   <permission>CMFEditions: Revert to previous versions</permission>
   <permission>CMFEditions: Save new version</permission>
-  <permission>Change local roles</permission>
   <permission>Delete objects</permission>
   <permission>Edit comments</permission>
   <permission>Edit date of cassation</permission>
@@ -31,13 +30,8 @@
   <permission>Sharing page: Delegate Publisher role</permission>
   <permission>Sharing page: Delegate Reader role</permission>
   <permission>Sharing page: Delegate Reviewer role</permission>
-  <permission>Sharing page: Delegate WorkspaceAdmin role</permission>
-  <permission>Sharing page: Delegate WorkspaceGuest role</permission>
-  <permission>Sharing page: Delegate WorkspaceMember role</permission>
   <permission>Sharing page: Delegate WorkspacesCreator role</permission>
   <permission>Sharing page: Delegate WorkspacesUser role</permission>
-  <permission>Sharing page: Delegate roles</permission>
-  <permission>Take ownership</permission>
   <permission>View</permission>
   <permission>ftw.keywordwidget: Add new term</permission>
   <permission>iterate : Check in content</permission>
@@ -98,11 +92,6 @@
     <permission-map name="CMFEditions: Checkout to location" acquired="False"/>
     <permission-map name="CMFEditions: Revert to previous versions" acquired="False"/>
     <permission-map name="CMFEditions: Save new version" acquired="False"/>
-    <permission-map name="Change local roles" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-    </permission-map>
     <permission-map name="Delete objects" acquired="False">
       <permission-role>Manager</permission-role>
     </permission-map>
@@ -137,33 +126,8 @@
     <permission-map name="Sharing page: Delegate Publisher role" acquired="False"/>
     <permission-map name="Sharing page: Delegate Reader role" acquired="False"/>
     <permission-map name="Sharing page: Delegate Reviewer role" acquired="False"/>
-    <permission-map name="Sharing page: Delegate WorkspaceAdmin role" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-    </permission-map>
-    <permission-map name="Sharing page: Delegate WorkspaceGuest role" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-    </permission-map>
-    <permission-map name="Sharing page: Delegate WorkspaceMember role" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-    </permission-map>
     <permission-map name="Sharing page: Delegate WorkspacesCreator role" acquired="False"/>
     <permission-map name="Sharing page: Delegate WorkspacesUser role" acquired="False"/>
-    <permission-map name="Sharing page: Delegate roles" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-    </permission-map>
-    <permission-map name="Take ownership" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-    </permission-map>
     <permission-map name="View" acquired="False">
       <permission-role>Administrator</permission-role>
       <permission-role>Manager</permission-role>

--- a/opengever/core/profiles/default/workflows/opengever_workspace_folder/specification.txt
+++ b/opengever/core/profiles/default/workflows/opengever_workspace_folder/specification.txt
@@ -35,4 +35,3 @@ General:
 Initial Status: Active
 Status Active:
   A workspace guest can view.
-  A workspace admin can manage security.

--- a/opengever/core/profiles/default/workflows/opengever_workspace_todo/definition.xml
+++ b/opengever/core/profiles/default/workflows/opengever_workspace_todo/definition.xml
@@ -135,61 +135,17 @@
     <permission-map name="Portlets: Manage portlets" acquired="False">
       <permission-role>Manager</permission-role>
     </permission-map>
-    <permission-map name="Sharing page: Delegate Administrator role" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-    </permission-map>
-    <permission-map name="Sharing page: Delegate CommitteeAdministrator role" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-    </permission-map>
-    <permission-map name="Sharing page: Delegate CommitteeMember role" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-    </permission-map>
-    <permission-map name="Sharing page: Delegate CommitteeResponsible role" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-    </permission-map>
-    <permission-map name="Sharing page: Delegate Contributor role" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-    </permission-map>
-    <permission-map name="Sharing page: Delegate DossierManager role" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-    </permission-map>
-    <permission-map name="Sharing page: Delegate Editor role" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-    </permission-map>
-    <permission-map name="Sharing page: Delegate MeetingUser role" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-    </permission-map>
-    <permission-map name="Sharing page: Delegate Publisher role" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-    </permission-map>
-    <permission-map name="Sharing page: Delegate Reader role" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-    </permission-map>
-    <permission-map name="Sharing page: Delegate Reviewer role" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-    </permission-map>
+    <permission-map name="Sharing page: Delegate Administrator role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate CommitteeAdministrator role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate CommitteeMember role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate CommitteeResponsible role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate Contributor role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate DossierManager role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate Editor role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate MeetingUser role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate Publisher role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate Reader role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate Reviewer role" acquired="False"/>
     <permission-map name="Sharing page: Delegate WorkspaceAdmin role" acquired="False">
       <permission-role>Administrator</permission-role>
       <permission-role>Manager</permission-role>
@@ -205,16 +161,8 @@
       <permission-role>Manager</permission-role>
       <permission-role>WorkspaceAdmin</permission-role>
     </permission-map>
-    <permission-map name="Sharing page: Delegate WorkspacesCreator role" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-    </permission-map>
-    <permission-map name="Sharing page: Delegate WorkspacesUser role" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-    </permission-map>
+    <permission-map name="Sharing page: Delegate WorkspacesCreator role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate WorkspacesUser role" acquired="False"/>
     <permission-map name="Sharing page: Delegate roles" acquired="False">
       <permission-role>Administrator</permission-role>
       <permission-role>Manager</permission-role>

--- a/opengever/core/profiles/default/workflows/opengever_workspace_todo/definition.xml
+++ b/opengever/core/profiles/default/workflows/opengever_workspace_todo/definition.xml
@@ -6,7 +6,6 @@
   <permission>CMFEditions: Checkout to location</permission>
   <permission>CMFEditions: Revert to previous versions</permission>
   <permission>CMFEditions: Save new version</permission>
-  <permission>Change local roles</permission>
   <permission>Edit comments</permission>
   <permission>Edit date of cassation</permission>
   <permission>Edit date of submission</permission>
@@ -33,13 +32,8 @@
   <permission>Sharing page: Delegate Publisher role</permission>
   <permission>Sharing page: Delegate Reader role</permission>
   <permission>Sharing page: Delegate Reviewer role</permission>
-  <permission>Sharing page: Delegate WorkspaceAdmin role</permission>
-  <permission>Sharing page: Delegate WorkspaceGuest role</permission>
-  <permission>Sharing page: Delegate WorkspaceMember role</permission>
   <permission>Sharing page: Delegate WorkspacesCreator role</permission>
   <permission>Sharing page: Delegate WorkspacesUser role</permission>
-  <permission>Sharing page: Delegate roles</permission>
-  <permission>Take ownership</permission>
   <permission>View</permission>
   <permission>ftw.keywordwidget: Add new term</permission>
   <permission>ftw.mail: Add Inbound Mail</permission>
@@ -107,11 +101,6 @@
     <permission-map name="CMFEditions: Checkout to location" acquired="False"/>
     <permission-map name="CMFEditions: Revert to previous versions" acquired="False"/>
     <permission-map name="CMFEditions: Save new version" acquired="False"/>
-    <permission-map name="Change local roles" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-    </permission-map>
     <permission-map name="Edit comments" acquired="False"/>
     <permission-map name="Edit date of cassation" acquired="False"/>
     <permission-map name="Edit date of submission" acquired="False"/>
@@ -146,33 +135,8 @@
     <permission-map name="Sharing page: Delegate Publisher role" acquired="False"/>
     <permission-map name="Sharing page: Delegate Reader role" acquired="False"/>
     <permission-map name="Sharing page: Delegate Reviewer role" acquired="False"/>
-    <permission-map name="Sharing page: Delegate WorkspaceAdmin role" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-    </permission-map>
-    <permission-map name="Sharing page: Delegate WorkspaceGuest role" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-    </permission-map>
-    <permission-map name="Sharing page: Delegate WorkspaceMember role" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-    </permission-map>
     <permission-map name="Sharing page: Delegate WorkspacesCreator role" acquired="False"/>
     <permission-map name="Sharing page: Delegate WorkspacesUser role" acquired="False"/>
-    <permission-map name="Sharing page: Delegate roles" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-    </permission-map>
-    <permission-map name="Take ownership" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-    </permission-map>
     <permission-map name="View" acquired="False">
       <permission-role>Administrator</permission-role>
       <permission-role>Manager</permission-role>

--- a/opengever/core/profiles/default/workflows/opengever_workspace_todo/specification.txt
+++ b/opengever/core/profiles/default/workflows/opengever_workspace_todo/specification.txt
@@ -6,6 +6,11 @@ Role mapping:
   admin => Administrator
   systems administrator => Manager
 
+Visible roles:
+  workspace guest
+  workspace member
+  workspace admin
+
 General:
   A workspace member can perform the same actions as a workspace guest.
   A workspace admin can perform the same actions as a workspace member.

--- a/opengever/core/profiles/default/workflows/opengever_workspace_todo/specification.txt
+++ b/opengever/core/profiles/default/workflows/opengever_workspace_todo/specification.txt
@@ -23,4 +23,3 @@ General:
 Initial Status: Active
 Status Active:
   A workspace guest can view.
-  A workspace admin can manage security.

--- a/opengever/core/profiles/default/workflows/opengever_workspace_todolist/definition.xml
+++ b/opengever/core/profiles/default/workflows/opengever_workspace_todolist/definition.xml
@@ -135,61 +135,17 @@
     <permission-map name="Portlets: Manage portlets" acquired="False">
       <permission-role>Manager</permission-role>
     </permission-map>
-    <permission-map name="Sharing page: Delegate Administrator role" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-    </permission-map>
-    <permission-map name="Sharing page: Delegate CommitteeAdministrator role" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-    </permission-map>
-    <permission-map name="Sharing page: Delegate CommitteeMember role" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-    </permission-map>
-    <permission-map name="Sharing page: Delegate CommitteeResponsible role" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-    </permission-map>
-    <permission-map name="Sharing page: Delegate Contributor role" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-    </permission-map>
-    <permission-map name="Sharing page: Delegate DossierManager role" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-    </permission-map>
-    <permission-map name="Sharing page: Delegate Editor role" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-    </permission-map>
-    <permission-map name="Sharing page: Delegate MeetingUser role" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-    </permission-map>
-    <permission-map name="Sharing page: Delegate Publisher role" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-    </permission-map>
-    <permission-map name="Sharing page: Delegate Reader role" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-    </permission-map>
-    <permission-map name="Sharing page: Delegate Reviewer role" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-    </permission-map>
+    <permission-map name="Sharing page: Delegate Administrator role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate CommitteeAdministrator role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate CommitteeMember role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate CommitteeResponsible role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate Contributor role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate DossierManager role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate Editor role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate MeetingUser role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate Publisher role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate Reader role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate Reviewer role" acquired="False"/>
     <permission-map name="Sharing page: Delegate WorkspaceAdmin role" acquired="False">
       <permission-role>Administrator</permission-role>
       <permission-role>Manager</permission-role>
@@ -205,16 +161,8 @@
       <permission-role>Manager</permission-role>
       <permission-role>WorkspaceAdmin</permission-role>
     </permission-map>
-    <permission-map name="Sharing page: Delegate WorkspacesCreator role" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-    </permission-map>
-    <permission-map name="Sharing page: Delegate WorkspacesUser role" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-    </permission-map>
+    <permission-map name="Sharing page: Delegate WorkspacesCreator role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate WorkspacesUser role" acquired="False"/>
     <permission-map name="Sharing page: Delegate roles" acquired="False">
       <permission-role>Administrator</permission-role>
       <permission-role>Manager</permission-role>

--- a/opengever/core/profiles/default/workflows/opengever_workspace_todolist/definition.xml
+++ b/opengever/core/profiles/default/workflows/opengever_workspace_todolist/definition.xml
@@ -6,7 +6,6 @@
   <permission>CMFEditions: Checkout to location</permission>
   <permission>CMFEditions: Revert to previous versions</permission>
   <permission>CMFEditions: Save new version</permission>
-  <permission>Change local roles</permission>
   <permission>Edit comments</permission>
   <permission>Edit date of cassation</permission>
   <permission>Edit date of submission</permission>
@@ -33,13 +32,8 @@
   <permission>Sharing page: Delegate Publisher role</permission>
   <permission>Sharing page: Delegate Reader role</permission>
   <permission>Sharing page: Delegate Reviewer role</permission>
-  <permission>Sharing page: Delegate WorkspaceAdmin role</permission>
-  <permission>Sharing page: Delegate WorkspaceGuest role</permission>
-  <permission>Sharing page: Delegate WorkspaceMember role</permission>
   <permission>Sharing page: Delegate WorkspacesCreator role</permission>
   <permission>Sharing page: Delegate WorkspacesUser role</permission>
-  <permission>Sharing page: Delegate roles</permission>
-  <permission>Take ownership</permission>
   <permission>View</permission>
   <permission>ftw.keywordwidget: Add new term</permission>
   <permission>ftw.mail: Add Inbound Mail</permission>
@@ -107,11 +101,6 @@
     <permission-map name="CMFEditions: Checkout to location" acquired="False"/>
     <permission-map name="CMFEditions: Revert to previous versions" acquired="False"/>
     <permission-map name="CMFEditions: Save new version" acquired="False"/>
-    <permission-map name="Change local roles" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-    </permission-map>
     <permission-map name="Edit comments" acquired="False"/>
     <permission-map name="Edit date of cassation" acquired="False"/>
     <permission-map name="Edit date of submission" acquired="False"/>
@@ -146,33 +135,8 @@
     <permission-map name="Sharing page: Delegate Publisher role" acquired="False"/>
     <permission-map name="Sharing page: Delegate Reader role" acquired="False"/>
     <permission-map name="Sharing page: Delegate Reviewer role" acquired="False"/>
-    <permission-map name="Sharing page: Delegate WorkspaceAdmin role" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-    </permission-map>
-    <permission-map name="Sharing page: Delegate WorkspaceGuest role" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-    </permission-map>
-    <permission-map name="Sharing page: Delegate WorkspaceMember role" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-    </permission-map>
     <permission-map name="Sharing page: Delegate WorkspacesCreator role" acquired="False"/>
     <permission-map name="Sharing page: Delegate WorkspacesUser role" acquired="False"/>
-    <permission-map name="Sharing page: Delegate roles" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-    </permission-map>
-    <permission-map name="Take ownership" acquired="False">
-      <permission-role>Administrator</permission-role>
-      <permission-role>Manager</permission-role>
-      <permission-role>WorkspaceAdmin</permission-role>
-    </permission-map>
     <permission-map name="View" acquired="False">
       <permission-role>Administrator</permission-role>
       <permission-role>Manager</permission-role>

--- a/opengever/core/profiles/default/workflows/opengever_workspace_todolist/specification.txt
+++ b/opengever/core/profiles/default/workflows/opengever_workspace_todolist/specification.txt
@@ -6,6 +6,11 @@ Role mapping:
   admin => Administrator
   systems administrator => Manager
 
+Visible roles:
+  workspace guest
+  workspace member
+  workspace admin
+
 General:
   A workspace member can perform the same actions as a workspace guest.
   A workspace admin can perform the same actions as a workspace member.

--- a/opengever/core/profiles/default/workflows/opengever_workspace_todolist/specification.txt
+++ b/opengever/core/profiles/default/workflows/opengever_workspace_todolist/specification.txt
@@ -23,4 +23,3 @@ General:
 Initial Status: Active
 Status Active:
   A workspace guest can view.
-  A workspace admin can manage security.

--- a/opengever/core/upgrades/20200917122158_update_workspace_workflows/upgrade.py
+++ b/opengever/core/upgrades/20200917122158_update_workspace_workflows/upgrade.py
@@ -1,0 +1,16 @@
+from ftw.upgrade import UpgradeStep
+
+
+class UpdateWorkflows(UpgradeStep):
+    """Update workflows.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()
+        self.update_workflow_security(
+            ['opengever_workspace',
+             'opengever_workspace_folder',
+             'opengever_workspace_todolist',
+             'opengever_workspace_todo',
+             'opengever_workspace_document'],
+            reindex_security=False)

--- a/opengever/core/upgrades/20200917122158_update_workspace_workflows/workflows/opengever_workspace/definition.xml
+++ b/opengever/core/upgrades/20200917122158_update_workspace_workflows/workflows/opengever_workspace/definition.xml
@@ -1,0 +1,728 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<dc-workflow workflow_id="opengever_workspace" title="Workspace workflow" description="" initial_state="opengever_workspace--STATUS--active" state_variable="review_state" manager_bypass="True">
+  <permission>Access contents information</permission>
+  <permission>Add portal content</permission>
+  <permission>CMFEditions: Access previous versions</permission>
+  <permission>CMFEditions: Apply version control</permission>
+  <permission>CMFEditions: Checkout to location</permission>
+  <permission>CMFEditions: Revert to previous versions</permission>
+  <permission>CMFEditions: Save new version</permission>
+  <permission>Change local roles</permission>
+  <permission>Delete objects</permission>
+  <permission>Edit comments</permission>
+  <permission>Edit date of cassation</permission>
+  <permission>Edit date of submission</permission>
+  <permission>List folder contents</permission>
+  <permission>Modify constrain types</permission>
+  <permission>Modify portal content</permission>
+  <permission>Modify view template</permission>
+  <permission>Poi: Edit response</permission>
+  <permission>Poi: Modify issue assignment</permission>
+  <permission>Poi: Modify issue severity</permission>
+  <permission>Poi: Modify issue state</permission>
+  <permission>Poi: Modify issue tags</permission>
+  <permission>Poi: Modify issue target release</permission>
+  <permission>Poi: Modify issue watchers</permission>
+  <permission>Poi: Upload attachment</permission>
+  <permission>Portlets: Manage portlets</permission>
+  <permission>Remove GEVER content</permission>
+  <permission>Sharing page: Delegate Administrator role</permission>
+  <permission>Sharing page: Delegate Contributor role</permission>
+  <permission>Sharing page: Delegate DossierManager role</permission>
+  <permission>Sharing page: Delegate Editor role</permission>
+  <permission>Sharing page: Delegate Publisher role</permission>
+  <permission>Sharing page: Delegate Reader role</permission>
+  <permission>Sharing page: Delegate Reviewer role</permission>
+  <permission>Sharing page: Delegate WorkspaceAdmin role</permission>
+  <permission>Sharing page: Delegate WorkspaceGuest role</permission>
+  <permission>Sharing page: Delegate WorkspaceMember role</permission>
+  <permission>Sharing page: Delegate WorkspacesCreator role</permission>
+  <permission>Sharing page: Delegate WorkspacesUser role</permission>
+  <permission>Sharing page: Delegate roles</permission>
+  <permission>Take ownership</permission>
+  <permission>View</permission>
+  <permission>ftw.keywordwidget: Add new term</permission>
+  <permission>ftw.mail: Add Inbound Mail</permission>
+  <permission>ftw.mail: Add Mail</permission>
+  <permission>iterate : Check in content</permission>
+  <permission>iterate : Check out content</permission>
+  <permission>opengever.contact: Add contact</permission>
+  <permission>opengever.contact: Add contactfolder</permission>
+  <permission>opengever.contact: Add person</permission>
+  <permission>opengever.contact: Edit person</permission>
+  <permission>opengever.disposition: Add disposition</permission>
+  <permission>opengever.disposition: Download SIP Package</permission>
+  <permission>opengever.disposition: Edit transfer number</permission>
+  <permission>opengever.document: Add document</permission>
+  <permission>opengever.document: Cancel</permission>
+  <permission>opengever.document: Checkin</permission>
+  <permission>opengever.document: Checkout</permission>
+  <permission>opengever.document: Force Checkin</permission>
+  <permission>opengever.document: Modify archival file</permission>
+  <permission>opengever.dossier: Add businesscasedossier</permission>
+  <permission>opengever.dossier: Add dossiertemplate</permission>
+  <permission>opengever.dossier: Add templatefolder</permission>
+  <permission>opengever.dossier: Destroy dossier</permission>
+  <permission>opengever.dossier: Protect dossier</permission>
+  <permission>opengever.inbox: Add Forwarding</permission>
+  <permission>opengever.inbox: Add Inbox</permission>
+  <permission>opengever.inbox: Add Year Folder</permission>
+  <permission>opengever.inbox: Scan In</permission>
+  <permission>opengever.meeting: Add Committee</permission>
+  <permission>opengever.meeting: Add CommitteeContainer</permission>
+  <permission>opengever.meeting: Add Member</permission>
+  <permission>opengever.meeting: Add Period</permission>
+  <permission>opengever.meeting: Add Proposal</permission>
+  <permission>opengever.meeting: Add Proposal Template</permission>
+  <permission>opengever.meeting: Add Sablon Template</permission>
+  <permission>opengever.private: Add private dossier</permission>
+  <permission>opengever.private: Add private folder</permission>
+  <permission>opengever.private: Add private root</permission>
+  <permission>opengever.repository: Add repositoryfolder</permission>
+  <permission>opengever.repository: Add repositoryroot</permission>
+  <permission>opengever.repository: Unlock Reference Prefix</permission>
+  <permission>opengever.task: Add task</permission>
+  <permission>opengever.task: Add task comment</permission>
+  <permission>opengever.task: Edit task</permission>
+  <permission>opengever.trash: Trash content</permission>
+  <permission>opengever.trash: Untrash content</permission>
+  <permission>opengever.workspace: Add WorkspaceFolder</permission>
+  <permission>opengever.workspace: Delete Todos</permission>
+  <permission>opengever.workspace: Modify Workspace</permission>
+  <permission>opengever.workspace: Update Content Order</permission>
+  <permission>plone.portlet.collection: Add collection portlet</permission>
+  <permission>plone.portlet.static: Add static portlet</permission>
+  <state state_id="opengever_workspace--STATUS--active" title="Active">
+    <exit-transition transition_id="opengever_workspace--TRANSITION--deactivate--active_inactive"/>
+    <permission-map name="Access contents information" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceGuest</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="Add portal content" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="CMFEditions: Access previous versions" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceGuest</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="CMFEditions: Apply version control" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="CMFEditions: Checkout to location" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="CMFEditions: Revert to previous versions" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="CMFEditions: Save new version" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="Change local roles" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+    </permission-map>
+    <permission-map name="Delete objects" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="Edit comments" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="Edit date of cassation" acquired="False"/>
+    <permission-map name="Edit date of submission" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="List folder contents" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="Modify constrain types" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="Modify portal content" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="Modify view template" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="Poi: Edit response" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="Poi: Modify issue assignment" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="Poi: Modify issue severity" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="Poi: Modify issue state" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="Poi: Modify issue tags" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="Poi: Modify issue target release" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="Poi: Modify issue watchers" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="Poi: Upload attachment" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="Portlets: Manage portlets" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="Remove GEVER content" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="Sharing page: Delegate Administrator role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate Contributor role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate DossierManager role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate Editor role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate Publisher role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate Reader role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate Reviewer role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate WorkspaceAdmin role" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+    </permission-map>
+    <permission-map name="Sharing page: Delegate WorkspaceGuest role" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+    </permission-map>
+    <permission-map name="Sharing page: Delegate WorkspaceMember role" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+    </permission-map>
+    <permission-map name="Sharing page: Delegate WorkspacesCreator role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate WorkspacesUser role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate roles" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+    </permission-map>
+    <permission-map name="Take ownership" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+    </permission-map>
+    <permission-map name="View" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceGuest</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="ftw.keywordwidget: Add new term" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="ftw.mail: Add Inbound Mail" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="ftw.mail: Add Mail" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="iterate : Check in content" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="iterate : Check out content" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="opengever.contact: Add contact" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="opengever.contact: Add contactfolder" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="opengever.contact: Add person" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="opengever.contact: Edit person" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="opengever.disposition: Add disposition" acquired="False"/>
+    <permission-map name="opengever.disposition: Download SIP Package" acquired="False"/>
+    <permission-map name="opengever.disposition: Edit transfer number" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="opengever.document: Add document" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="opengever.document: Cancel" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="opengever.document: Checkin" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="opengever.document: Checkout" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="opengever.document: Force Checkin" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="opengever.document: Modify archival file" acquired="False"/>
+    <permission-map name="opengever.dossier: Add businesscasedossier" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="opengever.dossier: Add dossiertemplate" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="opengever.dossier: Add templatefolder" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="opengever.dossier: Destroy dossier" acquired="False"/>
+    <permission-map name="opengever.dossier: Protect dossier" acquired="False"/>
+    <permission-map name="opengever.inbox: Add Forwarding" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="opengever.inbox: Add Inbox" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="opengever.inbox: Add Year Folder" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="opengever.inbox: Scan In" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="opengever.meeting: Add Committee" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="opengever.meeting: Add CommitteeContainer" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="opengever.meeting: Add Member" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="opengever.meeting: Add Period" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="opengever.meeting: Add Proposal" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="opengever.meeting: Add Proposal Template" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="opengever.meeting: Add Sablon Template" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="opengever.private: Add private dossier" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="opengever.private: Add private folder" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="opengever.private: Add private root" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="opengever.repository: Add repositoryfolder" acquired="False"/>
+    <permission-map name="opengever.repository: Add repositoryroot" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="opengever.repository: Unlock Reference Prefix" acquired="False"/>
+    <permission-map name="opengever.task: Add task" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="opengever.task: Add task comment" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="opengever.task: Edit task" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="opengever.trash: Trash content" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="opengever.trash: Untrash content" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="opengever.workspace: Add WorkspaceFolder" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="opengever.workspace: Delete Todos" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="opengever.workspace: Modify Workspace" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+    </permission-map>
+    <permission-map name="opengever.workspace: Update Content Order" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="plone.portlet.collection: Add collection portlet" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="plone.portlet.static: Add static portlet" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+  </state>
+  <state state_id="opengever_workspace--STATUS--inactive" title="Inactive">
+    <exit-transition transition_id="opengever_workspace--TRANSITION--reactivate--inactive_active"/>
+    <permission-map name="Access contents information" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceGuest</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="Add portal content" acquired="False"/>
+    <permission-map name="CMFEditions: Access previous versions" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceGuest</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="CMFEditions: Apply version control" acquired="False"/>
+    <permission-map name="CMFEditions: Checkout to location" acquired="False"/>
+    <permission-map name="CMFEditions: Revert to previous versions" acquired="False"/>
+    <permission-map name="CMFEditions: Save new version" acquired="False"/>
+    <permission-map name="Change local roles" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="Delete objects" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="Edit comments" acquired="False"/>
+    <permission-map name="Edit date of cassation" acquired="False"/>
+    <permission-map name="Edit date of submission" acquired="False"/>
+    <permission-map name="List folder contents" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="Modify constrain types" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="Modify portal content" acquired="False"/>
+    <permission-map name="Modify view template" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="Poi: Edit response" acquired="False"/>
+    <permission-map name="Poi: Modify issue assignment" acquired="False"/>
+    <permission-map name="Poi: Modify issue severity" acquired="False"/>
+    <permission-map name="Poi: Modify issue state" acquired="False"/>
+    <permission-map name="Poi: Modify issue tags" acquired="False"/>
+    <permission-map name="Poi: Modify issue target release" acquired="False"/>
+    <permission-map name="Poi: Modify issue watchers" acquired="False"/>
+    <permission-map name="Poi: Upload attachment" acquired="False"/>
+    <permission-map name="Portlets: Manage portlets" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="Remove GEVER content" acquired="False"/>
+    <permission-map name="Sharing page: Delegate Administrator role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate Contributor role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate DossierManager role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate Editor role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate Publisher role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate Reader role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate Reviewer role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate WorkspaceAdmin role" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="Sharing page: Delegate WorkspaceGuest role" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="Sharing page: Delegate WorkspaceMember role" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="Sharing page: Delegate WorkspacesCreator role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate WorkspacesUser role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate roles" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="Take ownership" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="View" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceGuest</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="ftw.keywordwidget: Add new term" acquired="False"/>
+    <permission-map name="ftw.mail: Add Inbound Mail" acquired="False"/>
+    <permission-map name="ftw.mail: Add Mail" acquired="False"/>
+    <permission-map name="iterate : Check in content" acquired="False"/>
+    <permission-map name="iterate : Check out content" acquired="False"/>
+    <permission-map name="opengever.contact: Add contact" acquired="False"/>
+    <permission-map name="opengever.contact: Add contactfolder" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="opengever.contact: Add person" acquired="False"/>
+    <permission-map name="opengever.contact: Edit person" acquired="False"/>
+    <permission-map name="opengever.disposition: Add disposition" acquired="False"/>
+    <permission-map name="opengever.disposition: Download SIP Package" acquired="False"/>
+    <permission-map name="opengever.disposition: Edit transfer number" acquired="False"/>
+    <permission-map name="opengever.document: Add document" acquired="False"/>
+    <permission-map name="opengever.document: Cancel" acquired="False"/>
+    <permission-map name="opengever.document: Checkin" acquired="False"/>
+    <permission-map name="opengever.document: Checkout" acquired="False"/>
+    <permission-map name="opengever.document: Force Checkin" acquired="False"/>
+    <permission-map name="opengever.document: Modify archival file" acquired="False"/>
+    <permission-map name="opengever.dossier: Add businesscasedossier" acquired="False"/>
+    <permission-map name="opengever.dossier: Add dossiertemplate" acquired="False"/>
+    <permission-map name="opengever.dossier: Add templatefolder" acquired="False"/>
+    <permission-map name="opengever.dossier: Destroy dossier" acquired="False"/>
+    <permission-map name="opengever.dossier: Protect dossier" acquired="False"/>
+    <permission-map name="opengever.inbox: Add Forwarding" acquired="False"/>
+    <permission-map name="opengever.inbox: Add Inbox" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="opengever.inbox: Add Year Folder" acquired="False"/>
+    <permission-map name="opengever.inbox: Scan In" acquired="False"/>
+    <permission-map name="opengever.meeting: Add Committee" acquired="False"/>
+    <permission-map name="opengever.meeting: Add CommitteeContainer" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="opengever.meeting: Add Member" acquired="False"/>
+    <permission-map name="opengever.meeting: Add Period" acquired="False"/>
+    <permission-map name="opengever.meeting: Add Proposal" acquired="False"/>
+    <permission-map name="opengever.meeting: Add Proposal Template" acquired="False"/>
+    <permission-map name="opengever.meeting: Add Sablon Template" acquired="False"/>
+    <permission-map name="opengever.private: Add private dossier" acquired="False"/>
+    <permission-map name="opengever.private: Add private folder" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="opengever.private: Add private root" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="opengever.repository: Add repositoryfolder" acquired="False"/>
+    <permission-map name="opengever.repository: Add repositoryroot" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="opengever.repository: Unlock Reference Prefix" acquired="False"/>
+    <permission-map name="opengever.task: Add task" acquired="False"/>
+    <permission-map name="opengever.task: Add task comment" acquired="False"/>
+    <permission-map name="opengever.task: Edit task" acquired="False"/>
+    <permission-map name="opengever.trash: Trash content" acquired="False"/>
+    <permission-map name="opengever.trash: Untrash content" acquired="False"/>
+    <permission-map name="opengever.workspace: Add WorkspaceFolder" acquired="False"/>
+    <permission-map name="opengever.workspace: Delete Todos" acquired="False"/>
+    <permission-map name="opengever.workspace: Modify Workspace" acquired="False"/>
+    <permission-map name="opengever.workspace: Update Content Order" acquired="False"/>
+    <permission-map name="plone.portlet.collection: Add collection portlet" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="plone.portlet.static: Add static portlet" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+  </state>
+  <transition new_state="opengever_workspace--STATUS--inactive" title="deactivate" transition_id="opengever_workspace--TRANSITION--deactivate--active_inactive" after_script="" before_script="" trigger="USER">
+    <action category="workflow" icon="" url="%(content_url)s/content_status_modify?workflow_action=opengever_workspace--TRANSITION--deactivate--active_inactive">deactivate</action>
+    <guard>
+      <guard-role>Administrator</guard-role>
+      <guard-role>Manager</guard-role>
+      <guard-role>WorkspaceAdmin</guard-role>
+    </guard>
+  </transition>
+  <transition new_state="opengever_workspace--STATUS--active" title="reactivate" transition_id="opengever_workspace--TRANSITION--reactivate--inactive_active" after_script="" before_script="" trigger="USER">
+    <action category="workflow" icon="" url="%(content_url)s/content_status_modify?workflow_action=opengever_workspace--TRANSITION--reactivate--inactive_active">reactivate</action>
+    <guard>
+      <guard-role>Administrator</guard-role>
+      <guard-role>Manager</guard-role>
+      <guard-role>WorkspaceAdmin</guard-role>
+    </guard>
+  </transition>
+  <variable variable_id="action" for_catalog="False" for_status="True" update_always="True">
+    <description>Previous transition</description>
+    <default>
+        <expression>transition/getId|nothing</expression>
+    </default>
+    <guard/>
+</variable>
+  <variable variable_id="actor" for_catalog="False" for_status="True" update_always="True">
+<description>The ID of the user who performed the previous transition</description>
+    <default>
+        <expression>user/getId</expression>
+    </default>
+    <guard/>
+</variable>
+  <variable variable_id="comments" for_catalog="False" for_status="True" update_always="True">
+    <description>Comment about the last transition</description>
+    <default>
+        <expression>python:state_change.kwargs.get('comment', '')</expression>
+    </default>
+    <guard/>
+</variable>
+  <variable variable_id="review_history" for_catalog="False" for_status="False" update_always="False">
+    <description>Provides access to workflow history</description>
+    <default>
+        <expression>state_change/getHistory</expression>
+    </default>
+    <guard>
+        <guard-permission>Request review</guard-permission>
+        <guard-permission>Review portal content</guard-permission>
+    </guard>
+</variable>
+  <variable variable_id="time" for_catalog="False" for_status="True" update_always="True">
+    <description>When the previous transition was performed</description>
+    <default>
+        <expression>state_change/getDateTime</expression>
+    </default>
+    <guard/>
+</variable>
+</dc-workflow>

--- a/opengever/core/upgrades/20200917122158_update_workspace_workflows/workflows/opengever_workspace_document/definition.xml
+++ b/opengever/core/upgrades/20200917122158_update_workspace_workflows/workflows/opengever_workspace_document/definition.xml
@@ -1,0 +1,249 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<dc-workflow workflow_id="opengever_workspace_document" title="Workspace document workflow" description="" initial_state="opengever_workspace_document--STATUS--active" state_variable="review_state" manager_bypass="True">
+  <permission>Access contents information</permission>
+  <permission>Add portal content</permission>
+  <permission>CMFEditions: Access previous versions</permission>
+  <permission>CMFEditions: Apply version control</permission>
+  <permission>CMFEditions: Checkout to location</permission>
+  <permission>CMFEditions: Revert to previous versions</permission>
+  <permission>CMFEditions: Save new version</permission>
+  <permission>Delete objects</permission>
+  <permission>Edit comments</permission>
+  <permission>Edit date of cassation</permission>
+  <permission>Edit date of submission</permission>
+  <permission>List folder contents</permission>
+  <permission>Modify constrain types</permission>
+  <permission>Modify view template</permission>
+  <permission>Poi: Edit response</permission>
+  <permission>Poi: Modify issue assignment</permission>
+  <permission>Poi: Modify issue severity</permission>
+  <permission>Poi: Modify issue state</permission>
+  <permission>Poi: Modify issue tags</permission>
+  <permission>Poi: Modify issue target release</permission>
+  <permission>Poi: Modify issue watchers</permission>
+  <permission>Poi: Upload attachment</permission>
+  <permission>Portlets: Manage portlets</permission>
+  <permission>Remove GEVER content</permission>
+  <permission>Sharing page: Delegate Administrator role</permission>
+  <permission>Sharing page: Delegate CommitteeAdministrator role</permission>
+  <permission>Sharing page: Delegate CommitteeMember role</permission>
+  <permission>Sharing page: Delegate CommitteeResponsible role</permission>
+  <permission>Sharing page: Delegate Contributor role</permission>
+  <permission>Sharing page: Delegate DossierManager role</permission>
+  <permission>Sharing page: Delegate Editor role</permission>
+  <permission>Sharing page: Delegate MeetingUser role</permission>
+  <permission>Sharing page: Delegate Publisher role</permission>
+  <permission>Sharing page: Delegate Reader role</permission>
+  <permission>Sharing page: Delegate Reviewer role</permission>
+  <permission>Sharing page: Delegate WorkspacesCreator role</permission>
+  <permission>Sharing page: Delegate WorkspacesUser role</permission>
+  <permission>View</permission>
+  <permission>ftw.keywordwidget: Add new term</permission>
+  <permission>ftw.mail: Add Inbound Mail</permission>
+  <permission>iterate : Check in content</permission>
+  <permission>iterate : Check out content</permission>
+  <permission>opengever.contact: Add contact</permission>
+  <permission>opengever.contact: Add contactfolder</permission>
+  <permission>opengever.contact: Add person</permission>
+  <permission>opengever.contact: Edit person</permission>
+  <permission>opengever.disposition: Add disposition</permission>
+  <permission>opengever.disposition: Download SIP Package</permission>
+  <permission>opengever.disposition: Edit transfer number</permission>
+  <permission>opengever.document: Add document</permission>
+  <permission>opengever.document: Modify archival file</permission>
+  <permission>opengever.dossier: Add businesscasedossier</permission>
+  <permission>opengever.dossier: Add dossiertemplate</permission>
+  <permission>opengever.dossier: Add templatefolder</permission>
+  <permission>opengever.dossier: Destroy dossier</permission>
+  <permission>opengever.dossier: Protect dossier</permission>
+  <permission>opengever.inbox: Add Forwarding</permission>
+  <permission>opengever.inbox: Add Inbox</permission>
+  <permission>opengever.inbox: Add Year Folder</permission>
+  <permission>opengever.inbox: Scan In</permission>
+  <permission>opengever.meeting: Add Committee</permission>
+  <permission>opengever.meeting: Add CommitteeContainer</permission>
+  <permission>opengever.meeting: Add Member</permission>
+  <permission>opengever.meeting: Add Period</permission>
+  <permission>opengever.meeting: Add Proposal</permission>
+  <permission>opengever.meeting: Add Proposal Template</permission>
+  <permission>opengever.meeting: Add Sablon Template</permission>
+  <permission>opengever.private: Add private dossier</permission>
+  <permission>opengever.private: Add private folder</permission>
+  <permission>opengever.private: Add private root</permission>
+  <permission>opengever.repository: Add repositoryfolder</permission>
+  <permission>opengever.repository: Add repositoryroot</permission>
+  <permission>opengever.repository: Unlock Reference Prefix</permission>
+  <permission>opengever.task: Add task</permission>
+  <permission>opengever.task: Add task comment</permission>
+  <permission>opengever.task: Edit task</permission>
+  <permission>opengever.trash: Trash content</permission>
+  <permission>opengever.trash: Untrash content</permission>
+  <permission>opengever.workspace: Add Workspace</permission>
+  <permission>plone.portlet.collection: Add collection portlet</permission>
+  <permission>plone.portlet.static: Add static portlet</permission>
+  <state state_id="opengever_workspace_document--STATUS--active" title="Active">
+    <permission-map name="Access contents information" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceGuest</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="Add portal content" acquired="False"/>
+    <permission-map name="CMFEditions: Access previous versions" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceGuest</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="CMFEditions: Apply version control" acquired="False"/>
+    <permission-map name="CMFEditions: Checkout to location" acquired="False"/>
+    <permission-map name="CMFEditions: Revert to previous versions" acquired="False"/>
+    <permission-map name="CMFEditions: Save new version" acquired="False"/>
+    <permission-map name="Delete objects" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="Edit comments" acquired="False"/>
+    <permission-map name="Edit date of cassation" acquired="False"/>
+    <permission-map name="Edit date of submission" acquired="False"/>
+    <permission-map name="List folder contents" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="Modify constrain types" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="Modify view template" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="Poi: Edit response" acquired="False"/>
+    <permission-map name="Poi: Modify issue assignment" acquired="False"/>
+    <permission-map name="Poi: Modify issue severity" acquired="False"/>
+    <permission-map name="Poi: Modify issue state" acquired="False"/>
+    <permission-map name="Poi: Modify issue tags" acquired="False"/>
+    <permission-map name="Poi: Modify issue target release" acquired="False"/>
+    <permission-map name="Poi: Modify issue watchers" acquired="False"/>
+    <permission-map name="Poi: Upload attachment" acquired="False"/>
+    <permission-map name="Portlets: Manage portlets" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="Remove GEVER content" acquired="False"/>
+    <permission-map name="Sharing page: Delegate Administrator role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate CommitteeAdministrator role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate CommitteeMember role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate CommitteeResponsible role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate Contributor role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate DossierManager role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate Editor role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate MeetingUser role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate Publisher role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate Reader role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate Reviewer role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate WorkspacesCreator role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate WorkspacesUser role" acquired="False"/>
+    <permission-map name="View" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceGuest</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="ftw.keywordwidget: Add new term" acquired="False"/>
+    <permission-map name="ftw.mail: Add Inbound Mail" acquired="False"/>
+    <permission-map name="iterate : Check in content" acquired="False"/>
+    <permission-map name="iterate : Check out content" acquired="False"/>
+    <permission-map name="opengever.contact: Add contact" acquired="False"/>
+    <permission-map name="opengever.contact: Add contactfolder" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="opengever.contact: Add person" acquired="False"/>
+    <permission-map name="opengever.contact: Edit person" acquired="False"/>
+    <permission-map name="opengever.disposition: Add disposition" acquired="False"/>
+    <permission-map name="opengever.disposition: Download SIP Package" acquired="False"/>
+    <permission-map name="opengever.disposition: Edit transfer number" acquired="False"/>
+    <permission-map name="opengever.document: Add document" acquired="False"/>
+    <permission-map name="opengever.document: Modify archival file" acquired="False"/>
+    <permission-map name="opengever.dossier: Add businesscasedossier" acquired="False"/>
+    <permission-map name="opengever.dossier: Add dossiertemplate" acquired="False"/>
+    <permission-map name="opengever.dossier: Add templatefolder" acquired="False"/>
+    <permission-map name="opengever.dossier: Destroy dossier" acquired="False"/>
+    <permission-map name="opengever.dossier: Protect dossier" acquired="False"/>
+    <permission-map name="opengever.inbox: Add Forwarding" acquired="False"/>
+    <permission-map name="opengever.inbox: Add Inbox" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="opengever.inbox: Add Year Folder" acquired="False"/>
+    <permission-map name="opengever.inbox: Scan In" acquired="False"/>
+    <permission-map name="opengever.meeting: Add Committee" acquired="False"/>
+    <permission-map name="opengever.meeting: Add CommitteeContainer" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="opengever.meeting: Add Member" acquired="False"/>
+    <permission-map name="opengever.meeting: Add Period" acquired="False"/>
+    <permission-map name="opengever.meeting: Add Proposal" acquired="False"/>
+    <permission-map name="opengever.meeting: Add Proposal Template" acquired="False"/>
+    <permission-map name="opengever.meeting: Add Sablon Template" acquired="False"/>
+    <permission-map name="opengever.private: Add private dossier" acquired="False"/>
+    <permission-map name="opengever.private: Add private folder" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="opengever.private: Add private root" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="opengever.repository: Add repositoryfolder" acquired="False"/>
+    <permission-map name="opengever.repository: Add repositoryroot" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="opengever.repository: Unlock Reference Prefix" acquired="False"/>
+    <permission-map name="opengever.task: Add task" acquired="False"/>
+    <permission-map name="opengever.task: Add task comment" acquired="False"/>
+    <permission-map name="opengever.task: Edit task" acquired="False"/>
+    <permission-map name="opengever.trash: Trash content" acquired="False"/>
+    <permission-map name="opengever.trash: Untrash content" acquired="False"/>
+    <permission-map name="opengever.workspace: Add Workspace" acquired="False"/>
+    <permission-map name="plone.portlet.collection: Add collection portlet" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="plone.portlet.static: Add static portlet" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+  </state>
+  <variable variable_id="action" for_catalog="False" for_status="True" update_always="True">
+    <description>Previous transition</description>
+    <default>
+        <expression>transition/getId|nothing</expression>
+    </default>
+    <guard/>
+</variable>
+  <variable variable_id="actor" for_catalog="False" for_status="True" update_always="True">
+<description>The ID of the user who performed the previous transition</description>
+    <default>
+        <expression>user/getId</expression>
+    </default>
+    <guard/>
+</variable>
+  <variable variable_id="comments" for_catalog="False" for_status="True" update_always="True">
+    <description>Comment about the last transition</description>
+    <default>
+        <expression>python:state_change.kwargs.get('comment', '')</expression>
+    </default>
+    <guard/>
+</variable>
+  <variable variable_id="review_history" for_catalog="False" for_status="False" update_always="False">
+    <description>Provides access to workflow history</description>
+    <default>
+        <expression>state_change/getHistory</expression>
+    </default>
+    <guard>
+        <guard-permission>Request review</guard-permission>
+        <guard-permission>Review portal content</guard-permission>
+    </guard>
+</variable>
+  <variable variable_id="time" for_catalog="False" for_status="True" update_always="True">
+    <description>When the previous transition was performed</description>
+    <default>
+        <expression>state_change/getDateTime</expression>
+    </default>
+    <guard/>
+</variable>
+</dc-workflow>

--- a/opengever/core/upgrades/20200917122158_update_workspace_workflows/workflows/opengever_workspace_folder/definition.xml
+++ b/opengever/core/upgrades/20200917122158_update_workspace_workflows/workflows/opengever_workspace_folder/definition.xml
@@ -1,0 +1,233 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<dc-workflow workflow_id="opengever_workspace_folder" title="Workspace folder workflow" description="" initial_state="opengever_workspace_folder--STATUS--active" state_variable="review_state" manager_bypass="True">
+  <permission>Access contents information</permission>
+  <permission>CMFEditions: Access previous versions</permission>
+  <permission>CMFEditions: Apply version control</permission>
+  <permission>CMFEditions: Checkout to location</permission>
+  <permission>CMFEditions: Revert to previous versions</permission>
+  <permission>CMFEditions: Save new version</permission>
+  <permission>Delete objects</permission>
+  <permission>Edit comments</permission>
+  <permission>Edit date of cassation</permission>
+  <permission>Edit date of submission</permission>
+  <permission>List folder contents</permission>
+  <permission>Modify constrain types</permission>
+  <permission>Modify view template</permission>
+  <permission>Poi: Edit response</permission>
+  <permission>Poi: Modify issue assignment</permission>
+  <permission>Poi: Modify issue severity</permission>
+  <permission>Poi: Modify issue state</permission>
+  <permission>Poi: Modify issue tags</permission>
+  <permission>Poi: Modify issue target release</permission>
+  <permission>Poi: Modify issue watchers</permission>
+  <permission>Poi: Upload attachment</permission>
+  <permission>Portlets: Manage portlets</permission>
+  <permission>Remove GEVER content</permission>
+  <permission>Sharing page: Delegate Administrator role</permission>
+  <permission>Sharing page: Delegate Contributor role</permission>
+  <permission>Sharing page: Delegate DossierManager role</permission>
+  <permission>Sharing page: Delegate Editor role</permission>
+  <permission>Sharing page: Delegate Publisher role</permission>
+  <permission>Sharing page: Delegate Reader role</permission>
+  <permission>Sharing page: Delegate Reviewer role</permission>
+  <permission>Sharing page: Delegate WorkspacesCreator role</permission>
+  <permission>Sharing page: Delegate WorkspacesUser role</permission>
+  <permission>View</permission>
+  <permission>ftw.keywordwidget: Add new term</permission>
+  <permission>iterate : Check in content</permission>
+  <permission>iterate : Check out content</permission>
+  <permission>opengever.contact: Add contact</permission>
+  <permission>opengever.contact: Add contactfolder</permission>
+  <permission>opengever.contact: Add person</permission>
+  <permission>opengever.contact: Edit person</permission>
+  <permission>opengever.disposition: Add disposition</permission>
+  <permission>opengever.disposition: Download SIP Package</permission>
+  <permission>opengever.disposition: Edit transfer number</permission>
+  <permission>opengever.document: Modify archival file</permission>
+  <permission>opengever.dossier: Add businesscasedossier</permission>
+  <permission>opengever.dossier: Add dossiertemplate</permission>
+  <permission>opengever.dossier: Add templatefolder</permission>
+  <permission>opengever.dossier: Destroy dossier</permission>
+  <permission>opengever.dossier: Protect dossier</permission>
+  <permission>opengever.inbox: Add Forwarding</permission>
+  <permission>opengever.inbox: Add Inbox</permission>
+  <permission>opengever.inbox: Add Year Folder</permission>
+  <permission>opengever.inbox: Scan In</permission>
+  <permission>opengever.meeting: Add Committee</permission>
+  <permission>opengever.meeting: Add CommitteeContainer</permission>
+  <permission>opengever.meeting: Add Member</permission>
+  <permission>opengever.meeting: Add Period</permission>
+  <permission>opengever.meeting: Add Proposal</permission>
+  <permission>opengever.meeting: Add Proposal Template</permission>
+  <permission>opengever.meeting: Add Sablon Template</permission>
+  <permission>opengever.private: Add private dossier</permission>
+  <permission>opengever.private: Add private folder</permission>
+  <permission>opengever.private: Add private root</permission>
+  <permission>opengever.repository: Add repositoryfolder</permission>
+  <permission>opengever.repository: Add repositoryroot</permission>
+  <permission>opengever.repository: Unlock Reference Prefix</permission>
+  <permission>opengever.task: Add task</permission>
+  <permission>opengever.task: Add task comment</permission>
+  <permission>opengever.task: Edit task</permission>
+  <permission>opengever.trash: Trash content</permission>
+  <permission>opengever.trash: Untrash content</permission>
+  <permission>plone.portlet.collection: Add collection portlet</permission>
+  <permission>plone.portlet.static: Add static portlet</permission>
+  <state state_id="opengever_workspace_folder--STATUS--active" title="Active">
+    <permission-map name="Access contents information" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceGuest</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="CMFEditions: Access previous versions" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceGuest</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="CMFEditions: Apply version control" acquired="False"/>
+    <permission-map name="CMFEditions: Checkout to location" acquired="False"/>
+    <permission-map name="CMFEditions: Revert to previous versions" acquired="False"/>
+    <permission-map name="CMFEditions: Save new version" acquired="False"/>
+    <permission-map name="Delete objects" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="Edit comments" acquired="False"/>
+    <permission-map name="Edit date of cassation" acquired="False"/>
+    <permission-map name="Edit date of submission" acquired="False"/>
+    <permission-map name="List folder contents" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="Modify constrain types" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="Modify view template" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="Poi: Edit response" acquired="False"/>
+    <permission-map name="Poi: Modify issue assignment" acquired="False"/>
+    <permission-map name="Poi: Modify issue severity" acquired="False"/>
+    <permission-map name="Poi: Modify issue state" acquired="False"/>
+    <permission-map name="Poi: Modify issue tags" acquired="False"/>
+    <permission-map name="Poi: Modify issue target release" acquired="False"/>
+    <permission-map name="Poi: Modify issue watchers" acquired="False"/>
+    <permission-map name="Poi: Upload attachment" acquired="False"/>
+    <permission-map name="Portlets: Manage portlets" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="Remove GEVER content" acquired="False"/>
+    <permission-map name="Sharing page: Delegate Administrator role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate Contributor role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate DossierManager role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate Editor role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate Publisher role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate Reader role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate Reviewer role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate WorkspacesCreator role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate WorkspacesUser role" acquired="False"/>
+    <permission-map name="View" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceGuest</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="ftw.keywordwidget: Add new term" acquired="False"/>
+    <permission-map name="iterate : Check in content" acquired="False"/>
+    <permission-map name="iterate : Check out content" acquired="False"/>
+    <permission-map name="opengever.contact: Add contact" acquired="False"/>
+    <permission-map name="opengever.contact: Add contactfolder" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="opengever.contact: Add person" acquired="False"/>
+    <permission-map name="opengever.contact: Edit person" acquired="False"/>
+    <permission-map name="opengever.disposition: Add disposition" acquired="False"/>
+    <permission-map name="opengever.disposition: Download SIP Package" acquired="False"/>
+    <permission-map name="opengever.disposition: Edit transfer number" acquired="False"/>
+    <permission-map name="opengever.document: Modify archival file" acquired="False"/>
+    <permission-map name="opengever.dossier: Add businesscasedossier" acquired="False"/>
+    <permission-map name="opengever.dossier: Add dossiertemplate" acquired="False"/>
+    <permission-map name="opengever.dossier: Add templatefolder" acquired="False"/>
+    <permission-map name="opengever.dossier: Destroy dossier" acquired="False"/>
+    <permission-map name="opengever.dossier: Protect dossier" acquired="False"/>
+    <permission-map name="opengever.inbox: Add Forwarding" acquired="False"/>
+    <permission-map name="opengever.inbox: Add Inbox" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="opengever.inbox: Add Year Folder" acquired="False"/>
+    <permission-map name="opengever.inbox: Scan In" acquired="False"/>
+    <permission-map name="opengever.meeting: Add Committee" acquired="False"/>
+    <permission-map name="opengever.meeting: Add CommitteeContainer" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="opengever.meeting: Add Member" acquired="False"/>
+    <permission-map name="opengever.meeting: Add Period" acquired="False"/>
+    <permission-map name="opengever.meeting: Add Proposal" acquired="False"/>
+    <permission-map name="opengever.meeting: Add Proposal Template" acquired="False"/>
+    <permission-map name="opengever.meeting: Add Sablon Template" acquired="False"/>
+    <permission-map name="opengever.private: Add private dossier" acquired="False"/>
+    <permission-map name="opengever.private: Add private folder" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="opengever.private: Add private root" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="opengever.repository: Add repositoryfolder" acquired="False"/>
+    <permission-map name="opengever.repository: Add repositoryroot" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="opengever.repository: Unlock Reference Prefix" acquired="False"/>
+    <permission-map name="opengever.task: Add task" acquired="False"/>
+    <permission-map name="opengever.task: Add task comment" acquired="False"/>
+    <permission-map name="opengever.task: Edit task" acquired="False"/>
+    <permission-map name="opengever.trash: Trash content" acquired="False"/>
+    <permission-map name="opengever.trash: Untrash content" acquired="False"/>
+    <permission-map name="plone.portlet.collection: Add collection portlet" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="plone.portlet.static: Add static portlet" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+  </state>
+  <variable variable_id="action" for_catalog="False" for_status="True" update_always="True">
+    <description>Previous transition</description>
+    <default>
+        <expression>transition/getId|nothing</expression>
+    </default>
+    <guard/>
+</variable>
+  <variable variable_id="actor" for_catalog="False" for_status="True" update_always="True">
+<description>The ID of the user who performed the previous transition</description>
+    <default>
+        <expression>user/getId</expression>
+    </default>
+    <guard/>
+</variable>
+  <variable variable_id="comments" for_catalog="False" for_status="True" update_always="True">
+    <description>Comment about the last transition</description>
+    <default>
+        <expression>python:state_change.kwargs.get('comment', '')</expression>
+    </default>
+    <guard/>
+</variable>
+  <variable variable_id="review_history" for_catalog="False" for_status="False" update_always="False">
+    <description>Provides access to workflow history</description>
+    <default>
+        <expression>state_change/getHistory</expression>
+    </default>
+    <guard>
+        <guard-permission>Request review</guard-permission>
+        <guard-permission>Review portal content</guard-permission>
+    </guard>
+</variable>
+  <variable variable_id="time" for_catalog="False" for_status="True" update_always="True">
+    <description>When the previous transition was performed</description>
+    <default>
+        <expression>state_change/getDateTime</expression>
+    </default>
+    <guard/>
+</variable>
+</dc-workflow>

--- a/opengever/core/upgrades/20200917122158_update_workspace_workflows/workflows/opengever_workspace_root/definition.xml
+++ b/opengever/core/upgrades/20200917122158_update_workspace_workflows/workflows/opengever_workspace_root/definition.xml
@@ -1,0 +1,406 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<dc-workflow workflow_id="opengever_workspace_root" title="Workspace root workflow" description="" initial_state="opengever_workspace_root--STATUS--active" state_variable="review_state" manager_bypass="True">
+  <permission>Access contents information</permission>
+  <permission>Add portal content</permission>
+  <permission>CMFEditions: Access previous versions</permission>
+  <permission>CMFEditions: Apply version control</permission>
+  <permission>CMFEditions: Checkout to location</permission>
+  <permission>CMFEditions: Revert to previous versions</permission>
+  <permission>CMFEditions: Save new version</permission>
+  <permission>Change local roles</permission>
+  <permission>Delete objects</permission>
+  <permission>Edit comments</permission>
+  <permission>Edit date of cassation</permission>
+  <permission>Edit date of submission</permission>
+  <permission>List folder contents</permission>
+  <permission>Manage properties</permission>
+  <permission>Modify constrain types</permission>
+  <permission>Modify portal content</permission>
+  <permission>Modify view template</permission>
+  <permission>Poi: Edit response</permission>
+  <permission>Poi: Modify issue assignment</permission>
+  <permission>Poi: Modify issue severity</permission>
+  <permission>Poi: Modify issue state</permission>
+  <permission>Poi: Modify issue tags</permission>
+  <permission>Poi: Modify issue target release</permission>
+  <permission>Poi: Modify issue watchers</permission>
+  <permission>Poi: Upload attachment</permission>
+  <permission>Portlets: Manage portlets</permission>
+  <permission>Sharing page: Delegate Administrator role</permission>
+  <permission>Sharing page: Delegate Contributor role</permission>
+  <permission>Sharing page: Delegate DossierManager role</permission>
+  <permission>Sharing page: Delegate Editor role</permission>
+  <permission>Sharing page: Delegate Publisher role</permission>
+  <permission>Sharing page: Delegate Reader role</permission>
+  <permission>Sharing page: Delegate Reviewer role</permission>
+  <permission>Sharing page: Delegate WorkspaceAdmin role</permission>
+  <permission>Sharing page: Delegate WorkspaceGuest role</permission>
+  <permission>Sharing page: Delegate WorkspaceMember role</permission>
+  <permission>Sharing page: Delegate WorkspacesCreator role</permission>
+  <permission>Sharing page: Delegate WorkspacesUser role</permission>
+  <permission>Sharing page: Delegate roles</permission>
+  <permission>Take ownership</permission>
+  <permission>View</permission>
+  <permission>ftw.keywordwidget: Add new term</permission>
+  <permission>ftw.mail: Add Inbound Mail</permission>
+  <permission>iterate : Check in content</permission>
+  <permission>iterate : Check out content</permission>
+  <permission>opengever.contact: Add contact</permission>
+  <permission>opengever.contact: Add contactfolder</permission>
+  <permission>opengever.contact: Add person</permission>
+  <permission>opengever.contact: Edit person</permission>
+  <permission>opengever.disposition: Add disposition</permission>
+  <permission>opengever.disposition: Download SIP Package</permission>
+  <permission>opengever.disposition: Edit transfer number</permission>
+  <permission>opengever.document: Add document</permission>
+  <permission>opengever.document: Cancel</permission>
+  <permission>opengever.document: Checkin</permission>
+  <permission>opengever.document: Checkout</permission>
+  <permission>opengever.document: Force Checkin</permission>
+  <permission>opengever.document: Modify archival file</permission>
+  <permission>opengever.dossier: Add businesscasedossier</permission>
+  <permission>opengever.dossier: Add dossiertemplate</permission>
+  <permission>opengever.dossier: Add templatefolder</permission>
+  <permission>opengever.dossier: Destroy dossier</permission>
+  <permission>opengever.dossier: Protect dossier</permission>
+  <permission>opengever.inbox: Add Forwarding</permission>
+  <permission>opengever.inbox: Add Inbox</permission>
+  <permission>opengever.inbox: Add Year Folder</permission>
+  <permission>opengever.inbox: Scan In</permission>
+  <permission>opengever.meeting: Add Committee</permission>
+  <permission>opengever.meeting: Add CommitteeContainer</permission>
+  <permission>opengever.meeting: Add Member</permission>
+  <permission>opengever.meeting: Add Period</permission>
+  <permission>opengever.meeting: Add Proposal</permission>
+  <permission>opengever.meeting: Add Proposal Template</permission>
+  <permission>opengever.meeting: Add Sablon Template</permission>
+  <permission>opengever.private: Add private dossier</permission>
+  <permission>opengever.private: Add private folder</permission>
+  <permission>opengever.private: Add private root</permission>
+  <permission>opengever.repository: Add repositoryfolder</permission>
+  <permission>opengever.repository: Add repositoryroot</permission>
+  <permission>opengever.repository: Unlock Reference Prefix</permission>
+  <permission>opengever.task: Add task</permission>
+  <permission>opengever.task: Add task comment</permission>
+  <permission>opengever.task: Edit task</permission>
+  <permission>opengever.trash: Trash content</permission>
+  <permission>opengever.trash: Untrash content</permission>
+  <permission>opengever.workspace: Add Workspace</permission>
+  <permission>plone.portlet.collection: Add collection portlet</permission>
+  <permission>plone.portlet.static: Add static portlet</permission>
+  <state state_id="opengever_workspace_root--STATUS--active" title="Active">
+    <permission-map name="Access contents information" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspacesUser</permission-role>
+    </permission-map>
+    <permission-map name="Add portal content" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspacesCreator</permission-role>
+    </permission-map>
+    <permission-map name="CMFEditions: Access previous versions" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspacesUser</permission-role>
+    </permission-map>
+    <permission-map name="CMFEditions: Apply version control" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="CMFEditions: Checkout to location" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="CMFEditions: Revert to previous versions" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="CMFEditions: Save new version" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="Change local roles" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="Delete objects" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="Edit comments" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="Edit date of cassation" acquired="False"/>
+    <permission-map name="Edit date of submission" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="List folder contents" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="Manage properties" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="Modify constrain types" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="Modify portal content" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="Modify view template" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="Poi: Edit response" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="Poi: Modify issue assignment" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="Poi: Modify issue severity" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="Poi: Modify issue state" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="Poi: Modify issue tags" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="Poi: Modify issue target release" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="Poi: Modify issue watchers" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="Poi: Upload attachment" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="Portlets: Manage portlets" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="Sharing page: Delegate Administrator role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate Contributor role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate DossierManager role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate Editor role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate Publisher role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate Reader role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate Reviewer role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate WorkspaceAdmin role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate WorkspaceGuest role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate WorkspaceMember role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate WorkspacesCreator role" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="Sharing page: Delegate WorkspacesUser role" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="Sharing page: Delegate roles" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="Take ownership" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="View" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspacesUser</permission-role>
+    </permission-map>
+    <permission-map name="ftw.keywordwidget: Add new term" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspacesCreator</permission-role>
+    </permission-map>
+    <permission-map name="ftw.mail: Add Inbound Mail" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspacesCreator</permission-role>
+    </permission-map>
+    <permission-map name="iterate : Check in content" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="iterate : Check out content" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="opengever.contact: Add contact" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspacesCreator</permission-role>
+    </permission-map>
+    <permission-map name="opengever.contact: Add contactfolder" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="opengever.contact: Add person" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspacesCreator</permission-role>
+    </permission-map>
+    <permission-map name="opengever.contact: Edit person" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="opengever.disposition: Add disposition" acquired="False"/>
+    <permission-map name="opengever.disposition: Download SIP Package" acquired="False"/>
+    <permission-map name="opengever.disposition: Edit transfer number" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="opengever.document: Add document" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspacesCreator</permission-role>
+    </permission-map>
+    <permission-map name="opengever.document: Cancel" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="opengever.document: Checkin" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="opengever.document: Checkout" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="opengever.document: Force Checkin" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="opengever.document: Modify archival file" acquired="False"/>
+    <permission-map name="opengever.dossier: Add businesscasedossier" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspacesCreator</permission-role>
+    </permission-map>
+    <permission-map name="opengever.dossier: Add dossiertemplate" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspacesCreator</permission-role>
+    </permission-map>
+    <permission-map name="opengever.dossier: Add templatefolder" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspacesCreator</permission-role>
+    </permission-map>
+    <permission-map name="opengever.dossier: Destroy dossier" acquired="False"/>
+    <permission-map name="opengever.dossier: Protect dossier" acquired="False"/>
+    <permission-map name="opengever.inbox: Add Forwarding" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspacesCreator</permission-role>
+    </permission-map>
+    <permission-map name="opengever.inbox: Add Inbox" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="opengever.inbox: Add Year Folder" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspacesCreator</permission-role>
+    </permission-map>
+    <permission-map name="opengever.inbox: Scan In" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspacesCreator</permission-role>
+    </permission-map>
+    <permission-map name="opengever.meeting: Add Committee" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspacesCreator</permission-role>
+    </permission-map>
+    <permission-map name="opengever.meeting: Add CommitteeContainer" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="opengever.meeting: Add Member" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspacesCreator</permission-role>
+    </permission-map>
+    <permission-map name="opengever.meeting: Add Period" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspacesCreator</permission-role>
+    </permission-map>
+    <permission-map name="opengever.meeting: Add Proposal" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspacesCreator</permission-role>
+    </permission-map>
+    <permission-map name="opengever.meeting: Add Proposal Template" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspacesCreator</permission-role>
+    </permission-map>
+    <permission-map name="opengever.meeting: Add Sablon Template" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspacesCreator</permission-role>
+    </permission-map>
+    <permission-map name="opengever.private: Add private dossier" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspacesCreator</permission-role>
+    </permission-map>
+    <permission-map name="opengever.private: Add private folder" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="opengever.private: Add private root" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="opengever.repository: Add repositoryfolder" acquired="False"/>
+    <permission-map name="opengever.repository: Add repositoryroot" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="opengever.repository: Unlock Reference Prefix" acquired="False"/>
+    <permission-map name="opengever.task: Add task" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspacesCreator</permission-role>
+    </permission-map>
+    <permission-map name="opengever.task: Add task comment" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspacesCreator</permission-role>
+    </permission-map>
+    <permission-map name="opengever.task: Edit task" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="opengever.trash: Trash content" acquired="False"/>
+    <permission-map name="opengever.trash: Untrash content" acquired="False"/>
+    <permission-map name="opengever.workspace: Add Workspace" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspacesCreator</permission-role>
+    </permission-map>
+    <permission-map name="plone.portlet.collection: Add collection portlet" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="plone.portlet.static: Add static portlet" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+  </state>
+  <variable variable_id="action" for_catalog="False" for_status="True" update_always="True">
+    <description>Previous transition</description>
+    <default>
+        <expression>transition/getId|nothing</expression>
+    </default>
+    <guard/>
+</variable>
+  <variable variable_id="actor" for_catalog="False" for_status="True" update_always="True">
+<description>The ID of the user who performed the previous transition</description>
+    <default>
+        <expression>user/getId</expression>
+    </default>
+    <guard/>
+</variable>
+  <variable variable_id="comments" for_catalog="False" for_status="True" update_always="True">
+    <description>Comment about the last transition</description>
+    <default>
+        <expression>python:state_change.kwargs.get('comment', '')</expression>
+    </default>
+    <guard/>
+</variable>
+  <variable variable_id="review_history" for_catalog="False" for_status="False" update_always="False">
+    <description>Provides access to workflow history</description>
+    <default>
+        <expression>state_change/getHistory</expression>
+    </default>
+    <guard>
+        <guard-permission>Request review</guard-permission>
+        <guard-permission>Review portal content</guard-permission>
+    </guard>
+</variable>
+  <variable variable_id="time" for_catalog="False" for_status="True" update_always="True">
+    <description>When the previous transition was performed</description>
+    <default>
+        <expression>state_change/getDateTime</expression>
+    </default>
+    <guard/>
+</variable>
+</dc-workflow>

--- a/opengever/core/upgrades/20200917122158_update_workspace_workflows/workflows/opengever_workspace_todo/definition.xml
+++ b/opengever/core/upgrades/20200917122158_update_workspace_workflows/workflows/opengever_workspace_todo/definition.xml
@@ -1,0 +1,249 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<dc-workflow workflow_id="opengever_workspace_todo" title="Workspace todo workflow" description="" initial_state="opengever_workspace_todo--STATUS--active" state_variable="review_state" manager_bypass="True">
+  <permission>Access contents information</permission>
+  <permission>CMFEditions: Access previous versions</permission>
+  <permission>CMFEditions: Apply version control</permission>
+  <permission>CMFEditions: Checkout to location</permission>
+  <permission>CMFEditions: Revert to previous versions</permission>
+  <permission>CMFEditions: Save new version</permission>
+  <permission>Edit comments</permission>
+  <permission>Edit date of cassation</permission>
+  <permission>Edit date of submission</permission>
+  <permission>List folder contents</permission>
+  <permission>Modify constrain types</permission>
+  <permission>Modify view template</permission>
+  <permission>Poi: Edit response</permission>
+  <permission>Poi: Modify issue assignment</permission>
+  <permission>Poi: Modify issue severity</permission>
+  <permission>Poi: Modify issue state</permission>
+  <permission>Poi: Modify issue tags</permission>
+  <permission>Poi: Modify issue target release</permission>
+  <permission>Poi: Modify issue watchers</permission>
+  <permission>Poi: Upload attachment</permission>
+  <permission>Portlets: Manage portlets</permission>
+  <permission>Sharing page: Delegate Administrator role</permission>
+  <permission>Sharing page: Delegate CommitteeAdministrator role</permission>
+  <permission>Sharing page: Delegate CommitteeMember role</permission>
+  <permission>Sharing page: Delegate CommitteeResponsible role</permission>
+  <permission>Sharing page: Delegate Contributor role</permission>
+  <permission>Sharing page: Delegate DossierManager role</permission>
+  <permission>Sharing page: Delegate Editor role</permission>
+  <permission>Sharing page: Delegate MeetingUser role</permission>
+  <permission>Sharing page: Delegate Publisher role</permission>
+  <permission>Sharing page: Delegate Reader role</permission>
+  <permission>Sharing page: Delegate Reviewer role</permission>
+  <permission>Sharing page: Delegate WorkspacesCreator role</permission>
+  <permission>Sharing page: Delegate WorkspacesUser role</permission>
+  <permission>View</permission>
+  <permission>ftw.keywordwidget: Add new term</permission>
+  <permission>ftw.mail: Add Inbound Mail</permission>
+  <permission>iterate : Check in content</permission>
+  <permission>iterate : Check out content</permission>
+  <permission>opengever.contact: Add contact</permission>
+  <permission>opengever.contact: Add contactfolder</permission>
+  <permission>opengever.contact: Add person</permission>
+  <permission>opengever.contact: Edit person</permission>
+  <permission>opengever.disposition: Add disposition</permission>
+  <permission>opengever.disposition: Download SIP Package</permission>
+  <permission>opengever.disposition: Edit transfer number</permission>
+  <permission>opengever.document: Add document</permission>
+  <permission>opengever.document: Cancel</permission>
+  <permission>opengever.document: Checkin</permission>
+  <permission>opengever.document: Checkout</permission>
+  <permission>opengever.document: Force Checkin</permission>
+  <permission>opengever.document: Modify archival file</permission>
+  <permission>opengever.dossier: Add businesscasedossier</permission>
+  <permission>opengever.dossier: Add dossiertemplate</permission>
+  <permission>opengever.dossier: Add templatefolder</permission>
+  <permission>opengever.dossier: Destroy dossier</permission>
+  <permission>opengever.dossier: Protect dossier</permission>
+  <permission>opengever.inbox: Add Forwarding</permission>
+  <permission>opengever.inbox: Add Inbox</permission>
+  <permission>opengever.inbox: Add Year Folder</permission>
+  <permission>opengever.inbox: Scan In</permission>
+  <permission>opengever.meeting: Add Committee</permission>
+  <permission>opengever.meeting: Add CommitteeContainer</permission>
+  <permission>opengever.meeting: Add Member</permission>
+  <permission>opengever.meeting: Add Period</permission>
+  <permission>opengever.meeting: Add Proposal</permission>
+  <permission>opengever.meeting: Add Proposal Template</permission>
+  <permission>opengever.meeting: Add Sablon Template</permission>
+  <permission>opengever.private: Add private dossier</permission>
+  <permission>opengever.private: Add private folder</permission>
+  <permission>opengever.private: Add private root</permission>
+  <permission>opengever.repository: Add repositoryfolder</permission>
+  <permission>opengever.repository: Add repositoryroot</permission>
+  <permission>opengever.repository: Unlock Reference Prefix</permission>
+  <permission>opengever.task: Add task</permission>
+  <permission>opengever.task: Add task comment</permission>
+  <permission>opengever.task: Edit task</permission>
+  <permission>opengever.trash: Trash content</permission>
+  <permission>opengever.trash: Untrash content</permission>
+  <permission>opengever.workspace: Add Workspace</permission>
+  <permission>plone.portlet.collection: Add collection portlet</permission>
+  <permission>plone.portlet.static: Add static portlet</permission>
+  <state state_id="opengever_workspace_todo--STATUS--active" title="Active">
+    <permission-map name="Access contents information" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceGuest</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="CMFEditions: Access previous versions" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceGuest</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="CMFEditions: Apply version control" acquired="False"/>
+    <permission-map name="CMFEditions: Checkout to location" acquired="False"/>
+    <permission-map name="CMFEditions: Revert to previous versions" acquired="False"/>
+    <permission-map name="CMFEditions: Save new version" acquired="False"/>
+    <permission-map name="Edit comments" acquired="False"/>
+    <permission-map name="Edit date of cassation" acquired="False"/>
+    <permission-map name="Edit date of submission" acquired="False"/>
+    <permission-map name="List folder contents" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="Modify constrain types" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="Modify view template" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="Poi: Edit response" acquired="False"/>
+    <permission-map name="Poi: Modify issue assignment" acquired="False"/>
+    <permission-map name="Poi: Modify issue severity" acquired="False"/>
+    <permission-map name="Poi: Modify issue state" acquired="False"/>
+    <permission-map name="Poi: Modify issue tags" acquired="False"/>
+    <permission-map name="Poi: Modify issue target release" acquired="False"/>
+    <permission-map name="Poi: Modify issue watchers" acquired="False"/>
+    <permission-map name="Poi: Upload attachment" acquired="False"/>
+    <permission-map name="Portlets: Manage portlets" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="Sharing page: Delegate Administrator role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate CommitteeAdministrator role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate CommitteeMember role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate CommitteeResponsible role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate Contributor role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate DossierManager role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate Editor role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate MeetingUser role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate Publisher role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate Reader role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate Reviewer role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate WorkspacesCreator role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate WorkspacesUser role" acquired="False"/>
+    <permission-map name="View" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceGuest</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="ftw.keywordwidget: Add new term" acquired="False"/>
+    <permission-map name="ftw.mail: Add Inbound Mail" acquired="False"/>
+    <permission-map name="iterate : Check in content" acquired="False"/>
+    <permission-map name="iterate : Check out content" acquired="False"/>
+    <permission-map name="opengever.contact: Add contact" acquired="False"/>
+    <permission-map name="opengever.contact: Add contactfolder" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="opengever.contact: Add person" acquired="False"/>
+    <permission-map name="opengever.contact: Edit person" acquired="False"/>
+    <permission-map name="opengever.disposition: Add disposition" acquired="False"/>
+    <permission-map name="opengever.disposition: Download SIP Package" acquired="False"/>
+    <permission-map name="opengever.disposition: Edit transfer number" acquired="False"/>
+    <permission-map name="opengever.document: Add document" acquired="False"/>
+    <permission-map name="opengever.document: Cancel" acquired="False"/>
+    <permission-map name="opengever.document: Checkin" acquired="False"/>
+    <permission-map name="opengever.document: Checkout" acquired="False"/>
+    <permission-map name="opengever.document: Force Checkin" acquired="False"/>
+    <permission-map name="opengever.document: Modify archival file" acquired="False"/>
+    <permission-map name="opengever.dossier: Add businesscasedossier" acquired="False"/>
+    <permission-map name="opengever.dossier: Add dossiertemplate" acquired="False"/>
+    <permission-map name="opengever.dossier: Add templatefolder" acquired="False"/>
+    <permission-map name="opengever.dossier: Destroy dossier" acquired="False"/>
+    <permission-map name="opengever.dossier: Protect dossier" acquired="False"/>
+    <permission-map name="opengever.inbox: Add Forwarding" acquired="False"/>
+    <permission-map name="opengever.inbox: Add Inbox" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="opengever.inbox: Add Year Folder" acquired="False"/>
+    <permission-map name="opengever.inbox: Scan In" acquired="False"/>
+    <permission-map name="opengever.meeting: Add Committee" acquired="False"/>
+    <permission-map name="opengever.meeting: Add CommitteeContainer" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="opengever.meeting: Add Member" acquired="False"/>
+    <permission-map name="opengever.meeting: Add Period" acquired="False"/>
+    <permission-map name="opengever.meeting: Add Proposal" acquired="False"/>
+    <permission-map name="opengever.meeting: Add Proposal Template" acquired="False"/>
+    <permission-map name="opengever.meeting: Add Sablon Template" acquired="False"/>
+    <permission-map name="opengever.private: Add private dossier" acquired="False"/>
+    <permission-map name="opengever.private: Add private folder" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="opengever.private: Add private root" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="opengever.repository: Add repositoryfolder" acquired="False"/>
+    <permission-map name="opengever.repository: Add repositoryroot" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="opengever.repository: Unlock Reference Prefix" acquired="False"/>
+    <permission-map name="opengever.task: Add task" acquired="False"/>
+    <permission-map name="opengever.task: Add task comment" acquired="False"/>
+    <permission-map name="opengever.task: Edit task" acquired="False"/>
+    <permission-map name="opengever.trash: Trash content" acquired="False"/>
+    <permission-map name="opengever.trash: Untrash content" acquired="False"/>
+    <permission-map name="opengever.workspace: Add Workspace" acquired="False"/>
+    <permission-map name="plone.portlet.collection: Add collection portlet" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="plone.portlet.static: Add static portlet" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+  </state>
+  <variable variable_id="action" for_catalog="False" for_status="True" update_always="True">
+    <description>Previous transition</description>
+    <default>
+        <expression>transition/getId|nothing</expression>
+    </default>
+    <guard/>
+</variable>
+  <variable variable_id="actor" for_catalog="False" for_status="True" update_always="True">
+<description>The ID of the user who performed the previous transition</description>
+    <default>
+        <expression>user/getId</expression>
+    </default>
+    <guard/>
+</variable>
+  <variable variable_id="comments" for_catalog="False" for_status="True" update_always="True">
+    <description>Comment about the last transition</description>
+    <default>
+        <expression>python:state_change.kwargs.get('comment', '')</expression>
+    </default>
+    <guard/>
+</variable>
+  <variable variable_id="review_history" for_catalog="False" for_status="False" update_always="False">
+    <description>Provides access to workflow history</description>
+    <default>
+        <expression>state_change/getHistory</expression>
+    </default>
+    <guard>
+        <guard-permission>Request review</guard-permission>
+        <guard-permission>Review portal content</guard-permission>
+    </guard>
+</variable>
+  <variable variable_id="time" for_catalog="False" for_status="True" update_always="True">
+    <description>When the previous transition was performed</description>
+    <default>
+        <expression>state_change/getDateTime</expression>
+    </default>
+    <guard/>
+</variable>
+</dc-workflow>

--- a/opengever/core/upgrades/20200917122158_update_workspace_workflows/workflows/opengever_workspace_todolist/definition.xml
+++ b/opengever/core/upgrades/20200917122158_update_workspace_workflows/workflows/opengever_workspace_todolist/definition.xml
@@ -1,0 +1,249 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<dc-workflow workflow_id="opengever_workspace_todolist" title="Workspace todolist workflow" description="" initial_state="opengever_workspace_todolist--STATUS--active" state_variable="review_state" manager_bypass="True">
+  <permission>Access contents information</permission>
+  <permission>CMFEditions: Access previous versions</permission>
+  <permission>CMFEditions: Apply version control</permission>
+  <permission>CMFEditions: Checkout to location</permission>
+  <permission>CMFEditions: Revert to previous versions</permission>
+  <permission>CMFEditions: Save new version</permission>
+  <permission>Edit comments</permission>
+  <permission>Edit date of cassation</permission>
+  <permission>Edit date of submission</permission>
+  <permission>List folder contents</permission>
+  <permission>Modify constrain types</permission>
+  <permission>Modify view template</permission>
+  <permission>Poi: Edit response</permission>
+  <permission>Poi: Modify issue assignment</permission>
+  <permission>Poi: Modify issue severity</permission>
+  <permission>Poi: Modify issue state</permission>
+  <permission>Poi: Modify issue tags</permission>
+  <permission>Poi: Modify issue target release</permission>
+  <permission>Poi: Modify issue watchers</permission>
+  <permission>Poi: Upload attachment</permission>
+  <permission>Portlets: Manage portlets</permission>
+  <permission>Sharing page: Delegate Administrator role</permission>
+  <permission>Sharing page: Delegate CommitteeAdministrator role</permission>
+  <permission>Sharing page: Delegate CommitteeMember role</permission>
+  <permission>Sharing page: Delegate CommitteeResponsible role</permission>
+  <permission>Sharing page: Delegate Contributor role</permission>
+  <permission>Sharing page: Delegate DossierManager role</permission>
+  <permission>Sharing page: Delegate Editor role</permission>
+  <permission>Sharing page: Delegate MeetingUser role</permission>
+  <permission>Sharing page: Delegate Publisher role</permission>
+  <permission>Sharing page: Delegate Reader role</permission>
+  <permission>Sharing page: Delegate Reviewer role</permission>
+  <permission>Sharing page: Delegate WorkspacesCreator role</permission>
+  <permission>Sharing page: Delegate WorkspacesUser role</permission>
+  <permission>View</permission>
+  <permission>ftw.keywordwidget: Add new term</permission>
+  <permission>ftw.mail: Add Inbound Mail</permission>
+  <permission>iterate : Check in content</permission>
+  <permission>iterate : Check out content</permission>
+  <permission>opengever.contact: Add contact</permission>
+  <permission>opengever.contact: Add contactfolder</permission>
+  <permission>opengever.contact: Add person</permission>
+  <permission>opengever.contact: Edit person</permission>
+  <permission>opengever.disposition: Add disposition</permission>
+  <permission>opengever.disposition: Download SIP Package</permission>
+  <permission>opengever.disposition: Edit transfer number</permission>
+  <permission>opengever.document: Add document</permission>
+  <permission>opengever.document: Cancel</permission>
+  <permission>opengever.document: Checkin</permission>
+  <permission>opengever.document: Checkout</permission>
+  <permission>opengever.document: Force Checkin</permission>
+  <permission>opengever.document: Modify archival file</permission>
+  <permission>opengever.dossier: Add businesscasedossier</permission>
+  <permission>opengever.dossier: Add dossiertemplate</permission>
+  <permission>opengever.dossier: Add templatefolder</permission>
+  <permission>opengever.dossier: Destroy dossier</permission>
+  <permission>opengever.dossier: Protect dossier</permission>
+  <permission>opengever.inbox: Add Forwarding</permission>
+  <permission>opengever.inbox: Add Inbox</permission>
+  <permission>opengever.inbox: Add Year Folder</permission>
+  <permission>opengever.inbox: Scan In</permission>
+  <permission>opengever.meeting: Add Committee</permission>
+  <permission>opengever.meeting: Add CommitteeContainer</permission>
+  <permission>opengever.meeting: Add Member</permission>
+  <permission>opengever.meeting: Add Period</permission>
+  <permission>opengever.meeting: Add Proposal</permission>
+  <permission>opengever.meeting: Add Proposal Template</permission>
+  <permission>opengever.meeting: Add Sablon Template</permission>
+  <permission>opengever.private: Add private dossier</permission>
+  <permission>opengever.private: Add private folder</permission>
+  <permission>opengever.private: Add private root</permission>
+  <permission>opengever.repository: Add repositoryfolder</permission>
+  <permission>opengever.repository: Add repositoryroot</permission>
+  <permission>opengever.repository: Unlock Reference Prefix</permission>
+  <permission>opengever.task: Add task</permission>
+  <permission>opengever.task: Add task comment</permission>
+  <permission>opengever.task: Edit task</permission>
+  <permission>opengever.trash: Trash content</permission>
+  <permission>opengever.trash: Untrash content</permission>
+  <permission>opengever.workspace: Add Workspace</permission>
+  <permission>plone.portlet.collection: Add collection portlet</permission>
+  <permission>plone.portlet.static: Add static portlet</permission>
+  <state state_id="opengever_workspace_todolist--STATUS--active" title="Active">
+    <permission-map name="Access contents information" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceGuest</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="CMFEditions: Access previous versions" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceGuest</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="CMFEditions: Apply version control" acquired="False"/>
+    <permission-map name="CMFEditions: Checkout to location" acquired="False"/>
+    <permission-map name="CMFEditions: Revert to previous versions" acquired="False"/>
+    <permission-map name="CMFEditions: Save new version" acquired="False"/>
+    <permission-map name="Edit comments" acquired="False"/>
+    <permission-map name="Edit date of cassation" acquired="False"/>
+    <permission-map name="Edit date of submission" acquired="False"/>
+    <permission-map name="List folder contents" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="Modify constrain types" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="Modify view template" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="Poi: Edit response" acquired="False"/>
+    <permission-map name="Poi: Modify issue assignment" acquired="False"/>
+    <permission-map name="Poi: Modify issue severity" acquired="False"/>
+    <permission-map name="Poi: Modify issue state" acquired="False"/>
+    <permission-map name="Poi: Modify issue tags" acquired="False"/>
+    <permission-map name="Poi: Modify issue target release" acquired="False"/>
+    <permission-map name="Poi: Modify issue watchers" acquired="False"/>
+    <permission-map name="Poi: Upload attachment" acquired="False"/>
+    <permission-map name="Portlets: Manage portlets" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="Sharing page: Delegate Administrator role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate CommitteeAdministrator role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate CommitteeMember role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate CommitteeResponsible role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate Contributor role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate DossierManager role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate Editor role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate MeetingUser role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate Publisher role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate Reader role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate Reviewer role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate WorkspacesCreator role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate WorkspacesUser role" acquired="False"/>
+    <permission-map name="View" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceGuest</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="ftw.keywordwidget: Add new term" acquired="False"/>
+    <permission-map name="ftw.mail: Add Inbound Mail" acquired="False"/>
+    <permission-map name="iterate : Check in content" acquired="False"/>
+    <permission-map name="iterate : Check out content" acquired="False"/>
+    <permission-map name="opengever.contact: Add contact" acquired="False"/>
+    <permission-map name="opengever.contact: Add contactfolder" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="opengever.contact: Add person" acquired="False"/>
+    <permission-map name="opengever.contact: Edit person" acquired="False"/>
+    <permission-map name="opengever.disposition: Add disposition" acquired="False"/>
+    <permission-map name="opengever.disposition: Download SIP Package" acquired="False"/>
+    <permission-map name="opengever.disposition: Edit transfer number" acquired="False"/>
+    <permission-map name="opengever.document: Add document" acquired="False"/>
+    <permission-map name="opengever.document: Cancel" acquired="False"/>
+    <permission-map name="opengever.document: Checkin" acquired="False"/>
+    <permission-map name="opengever.document: Checkout" acquired="False"/>
+    <permission-map name="opengever.document: Force Checkin" acquired="False"/>
+    <permission-map name="opengever.document: Modify archival file" acquired="False"/>
+    <permission-map name="opengever.dossier: Add businesscasedossier" acquired="False"/>
+    <permission-map name="opengever.dossier: Add dossiertemplate" acquired="False"/>
+    <permission-map name="opengever.dossier: Add templatefolder" acquired="False"/>
+    <permission-map name="opengever.dossier: Destroy dossier" acquired="False"/>
+    <permission-map name="opengever.dossier: Protect dossier" acquired="False"/>
+    <permission-map name="opengever.inbox: Add Forwarding" acquired="False"/>
+    <permission-map name="opengever.inbox: Add Inbox" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="opengever.inbox: Add Year Folder" acquired="False"/>
+    <permission-map name="opengever.inbox: Scan In" acquired="False"/>
+    <permission-map name="opengever.meeting: Add Committee" acquired="False"/>
+    <permission-map name="opengever.meeting: Add CommitteeContainer" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="opengever.meeting: Add Member" acquired="False"/>
+    <permission-map name="opengever.meeting: Add Period" acquired="False"/>
+    <permission-map name="opengever.meeting: Add Proposal" acquired="False"/>
+    <permission-map name="opengever.meeting: Add Proposal Template" acquired="False"/>
+    <permission-map name="opengever.meeting: Add Sablon Template" acquired="False"/>
+    <permission-map name="opengever.private: Add private dossier" acquired="False"/>
+    <permission-map name="opengever.private: Add private folder" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="opengever.private: Add private root" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="opengever.repository: Add repositoryfolder" acquired="False"/>
+    <permission-map name="opengever.repository: Add repositoryroot" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="opengever.repository: Unlock Reference Prefix" acquired="False"/>
+    <permission-map name="opengever.task: Add task" acquired="False"/>
+    <permission-map name="opengever.task: Add task comment" acquired="False"/>
+    <permission-map name="opengever.task: Edit task" acquired="False"/>
+    <permission-map name="opengever.trash: Trash content" acquired="False"/>
+    <permission-map name="opengever.trash: Untrash content" acquired="False"/>
+    <permission-map name="opengever.workspace: Add Workspace" acquired="False"/>
+    <permission-map name="plone.portlet.collection: Add collection portlet" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="plone.portlet.static: Add static portlet" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+  </state>
+  <variable variable_id="action" for_catalog="False" for_status="True" update_always="True">
+    <description>Previous transition</description>
+    <default>
+        <expression>transition/getId|nothing</expression>
+    </default>
+    <guard/>
+</variable>
+  <variable variable_id="actor" for_catalog="False" for_status="True" update_always="True">
+<description>The ID of the user who performed the previous transition</description>
+    <default>
+        <expression>user/getId</expression>
+    </default>
+    <guard/>
+</variable>
+  <variable variable_id="comments" for_catalog="False" for_status="True" update_always="True">
+    <description>Comment about the last transition</description>
+    <default>
+        <expression>python:state_change.kwargs.get('comment', '')</expression>
+    </default>
+    <guard/>
+</variable>
+  <variable variable_id="review_history" for_catalog="False" for_status="False" update_always="False">
+    <description>Provides access to workflow history</description>
+    <default>
+        <expression>state_change/getHistory</expression>
+    </default>
+    <guard>
+        <guard-permission>Request review</guard-permission>
+        <guard-permission>Review portal content</guard-permission>
+    </guard>
+</variable>
+  <variable variable_id="time" for_catalog="False" for_status="True" update_always="True">
+    <description>When the previous transition was performed</description>
+    <default>
+        <expression>state_change/getDateTime</expression>
+    </default>
+    <guard/>
+</variable>
+</dc-workflow>

--- a/opengever/workspace/tests/test_deactivate_workspace.py
+++ b/opengever/workspace/tests/test_deactivate_workspace.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from ftw.testbrowser import browsing
 from ftw.testing.freezer import freeze
 from opengever.testing import IntegrationTestCase
+from opengever.workspace.participation import can_manage_member
 import json
 import pytz
 
@@ -239,3 +240,38 @@ class TestDeactivateWorkspace(IntegrationTestCase):
                 self.todolist_general, method='DELETE',
                 headers=self.api_headers,
             )
+
+    @browsing
+    def test_cannot_manage_member_in_deactivated_workspace(self, browser):
+        self.login(self.workspace_admin, browser)
+        self.assertTrue(can_manage_member(self.workspace))
+        self.deactivate_workspace(browser)
+        self.assertFalse(can_manage_member(self.workspace))
+
+    @browsing
+    def test_cannot_manage_member_of_workspace_folder_in_deactivated_workspace(self, browser):
+        self.login(self.workspace_admin, browser)
+        self.assertTrue(can_manage_member(self.workspace_folder))
+        self.deactivate_workspace(browser)
+        self.assertFalse(can_manage_member(self.workspace_folder))
+
+    @browsing
+    def test_cannot_manage_member_of_todo_in_deactivated_workspace(self, browser):
+        self.login(self.workspace_admin, browser)
+        self.assertTrue(can_manage_member(self.todo))
+        self.deactivate_workspace(browser)
+        self.assertFalse(can_manage_member(self.todo))
+
+    @browsing
+    def test_cannot_manage_member_of_todolist_in_deactivated_workspace(self, browser):
+        self.login(self.workspace_admin, browser)
+        self.assertTrue(can_manage_member(self.todolist_general))
+        self.deactivate_workspace(browser)
+        self.assertFalse(can_manage_member(self.todolist_general))
+
+    @browsing
+    def test_cannot_manage_member_of_document_in_deactivated_workspace(self, browser):
+        self.login(self.workspace_admin, browser)
+        self.assertTrue(can_manage_member(self.workspace_document))
+        self.deactivate_workspace(browser)
+        self.assertFalse(can_manage_member(self.workspace_document))

--- a/opengever/workspace/tests/test_workspace_workspace.py
+++ b/opengever/workspace/tests/test_workspace_workspace.py
@@ -198,6 +198,16 @@ class TestWorkspaceWorkspaceAPI(IntegrationTestCase):
         self.assertIn(self.EXPECTED_ADD_INVITATION_ACTION, actions)
 
     @browsing
+    def test_workspace_admin_cannot_see_add_invitation_action_in_deactivated_workspace(self, browser):
+        self.login(self.workspace_admin, browser)
+        self.set_workflow_state('opengever_workspace--STATUS--inactive', self.workspace)
+
+        browser.open(self.workspace, view='@actions', headers=self.api_headers)
+        actions = browser.json['object_buttons']
+
+        self.assertNotIn(self.EXPECTED_ADD_INVITATION_ACTION, actions)
+
+    @browsing
     def test_workspace_member_cannot_see_add_invitation_action(self, browser):
         self.login(self.workspace_member, browser)
 


### PR DESCRIPTION
With this PR we achieve that local roles can no longer be changed in deactivated workspaces. This also means that no new members can be invited.

Jira: https://4teamwork.atlassian.net/browse/GEVER-1017

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


## Checklist (if applicable)

_Only applicable should be left and checked._

- Upgrade steps (changes in profile):
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally