### PR TITLE
Don't resolve or deactivate a dossier if it is linked to an active workspace

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,7 @@ Changelog
 2020.11.0 (unreleased)
 ----------------------
 
-- Nothing changed yet.
+- Don't resolve or deactivate a dossier if it is linked to an active workspace. [tinagerber]
 
 
 2020.10.0 (2020-09-25)

--- a/opengever/dossier/base.py
+++ b/opengever/dossier/base.py
@@ -8,6 +8,7 @@ from opengever.base.date_time import as_utc
 from opengever.base.interfaces import IReferenceNumber
 from opengever.base.interfaces import ISequenceNumber
 from opengever.base.oguid import Oguid
+from opengever.base.security import elevated_privileges
 from opengever.contact.models import Participation
 from opengever.contact.participation import ParticipationWrapper
 from opengever.document.behaviors import IBaseDocument
@@ -24,6 +25,8 @@ from opengever.meeting import OPEN_PROPOSAL_STATES
 from opengever.ogds.base.actor import Actor
 from opengever.task import OPEN_TASK_STATES
 from opengever.task.task import ITask
+from opengever.workspaceclient import is_workspace_client_feature_enabled
+from opengever.workspaceclient.interfaces import ILinkedWorkspaces
 from plone import api
 from plone.dexterity.content import Container
 from plone.dexterity.interfaces import IDexterityFTI
@@ -299,6 +302,13 @@ class DossierContainer(Container):
             )
 
         return bool(active_proposals)
+
+    def is_linked_to_active_workspaces(self):
+        if not is_workspace_client_feature_enabled():
+            return False
+        params = {'review_state': 'opengever_workspace--STATUS--active'}
+        with elevated_privileges():
+            return bool(ILinkedWorkspaces(self).list_non_cached(**params)['items_total'])
 
     def is_all_checked_in(self):
         """Check if all documents in this path are checked in."""

--- a/opengever/dossier/deactivate.py
+++ b/opengever/dossier/deactivate.py
@@ -15,6 +15,9 @@ CONTAINS_ACTIVE_PROPOSAL = _(u"The Dossier can't be deactivated, it contains"
 CONTAINS_ACTIVE_TASK = _(u"The Dossier can't be deactivated, not all contained"
                          " tasks are in a closed state.")
 
+CONTAINS_ACTIVE_WORKSPACE = _(u"The Dossier can't be deactivated, not all linked"
+                              " workspaces are deactivated.")
+
 
 class DossierDeactivator(object):
     """Recursively deactivate the dossier and its subdossiers.
@@ -58,6 +61,8 @@ class DossierDeactivator(object):
 
         if self.context.has_active_proposals():
             errors.append(CONTAINS_ACTIVE_PROPOSAL)
+        if self.context.is_linked_to_active_workspaces():
+            errors.append(CONTAINS_ACTIVE_WORKSPACE)
 
         # Check for subdossiers the user cannot deactivate
         for subdossier in self.context.get_subdossiers(unrestricted=True):

--- a/opengever/dossier/locales/de/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/de/LC_MESSAGES/opengever.dossier.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2020-09-11 06:27+0000\n"
+"POT-Creation-Date: 2020-09-22 14:48+0000\n"
 "PO-Revision-Date: 2017-05-23 04:53+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: German <https://translations.onegovgever.ch/projects/onegov-gever/opengever-dossier/de/>\n"
@@ -118,6 +118,10 @@ msgstr "Neuste Aufgaben"
 msgid "No Subdossiers"
 msgstr "Keine Subdossiers"
 
+#: ./opengever/dossier/resolve.py
+msgid "Not all linked workspaces are deactivated."
+msgstr "Nicht alle verlinkten Teamräume sind deaktiviert."
+
 #: ./opengever/dossier/archive.py
 msgid "Not all required fields are filled."
 msgstr "Nicht alle benötigten Felder wurden ausgefüllt."
@@ -174,6 +178,10 @@ msgstr "Das Dossier kann nicht storniert werden, da nicht alle enthaltenen Dokum
 #: ./opengever/dossier/deactivate.py
 msgid "The Dossier can't be deactivated, not all contained tasks are in a closed state."
 msgstr "Das Dossier kann nicht storniert werden, da nicht alle enthaltenen Aufgaben abgeschlossen sind."
+
+#: ./opengever/dossier/deactivate.py
+msgid "The Dossier can't be deactivated, not all linked workspaces are deactivated."
+msgstr "Das Dossier kann nicht storniert werden, da nicht alle verlinkten Teamräume deaktiviert sind."
 
 #: ./opengever/dossier/deactivate.py
 msgid "The Dossier can't be deactivated, the subdossier ${dossier} is already resolved."

--- a/opengever/dossier/locales/fr/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/fr/LC_MESSAGES/opengever.dossier.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2020-09-11 06:27+0000\n"
+"POT-Creation-Date: 2020-09-22 14:48+0000\n"
 "PO-Revision-Date: 2017-12-03 11:16+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-dossier/fr/>\n"
@@ -117,6 +117,10 @@ msgstr "Dernières tâches"
 msgid "No Subdossiers"
 msgstr "Aucun sous-dossier"
 
+#: ./opengever/dossier/resolve.py
+msgid "Not all linked workspaces are deactivated."
+msgstr ""
+
 #: ./opengever/dossier/archive.py
 msgid "Not all required fields are filled."
 msgstr "Un ou plusieurs des champs requis n'ont pas été remplis."
@@ -172,6 +176,10 @@ msgstr "Ce dossier ne peut pas être annulé, parce qu'il contient des documents
 #: ./opengever/dossier/deactivate.py
 msgid "The Dossier can't be deactivated, not all contained tasks are in a closed state."
 msgstr "Ce dossier ne peut pas être annulé, il contient encore des tâches non accomplies."
+
+#: ./opengever/dossier/deactivate.py
+msgid "The Dossier can't be deactivated, not all linked workspaces are deactivated."
+msgstr ""
 
 #: ./opengever/dossier/deactivate.py
 msgid "The Dossier can't be deactivated, the subdossier ${dossier} is already resolved."

--- a/opengever/dossier/locales/opengever.dossier.pot
+++ b/opengever/dossier/locales/opengever.dossier.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2020-09-11 06:27+0000\n"
+"POT-Creation-Date: 2020-09-22 14:48+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -118,6 +118,10 @@ msgstr ""
 msgid "No Subdossiers"
 msgstr ""
 
+#: ./opengever/dossier/resolve.py
+msgid "Not all linked workspaces are deactivated."
+msgstr ""
+
 #: ./opengever/dossier/archive.py
 msgid "Not all required fields are filled."
 msgstr ""
@@ -172,6 +176,10 @@ msgstr ""
 
 #: ./opengever/dossier/deactivate.py
 msgid "The Dossier can't be deactivated, not all contained tasks are in a closed state."
+msgstr ""
+
+#: ./opengever/dossier/deactivate.py
+msgid "The Dossier can't be deactivated, not all linked workspaces are deactivated."
 msgstr ""
 
 #: ./opengever/dossier/deactivate.py

--- a/opengever/dossier/resolve.py
+++ b/opengever/dossier/resolve.py
@@ -40,6 +40,7 @@ NOT_CHECKED_IN_DOCS = _("not all documents are checked in")
 NOT_CLOSED_TASKS = _("not all task are closed")
 NO_START_DATE = _("the dossier start date is missing.")
 MSG_ACTIVE_PROPOSALS = _("The dossier contains active proposals.")
+MSG_ACTIVE_WORKSPACES = _("Not all linked workspaces are deactivated.")
 MSG_ALREADY_BEING_RESOLVED = _("Dossier is already being resolved")
 
 AFTER_RESOLVE_JOBS_PENDING_KEY = 'opengever.dossier.resolve.after_resolve_jobs_pending'
@@ -613,6 +614,8 @@ class ResolveConditions(object):
             errors.append(NOT_CLOSED_TASKS)
         if self.context.has_active_proposals():
             errors.append(MSG_ACTIVE_PROPOSALS)
+        if self.context.is_linked_to_active_workspaces():
+            errors.append(MSG_ACTIVE_WORKSPACES)
         if not self.context.has_valid_startdate():
             errors.append(NO_START_DATE)
 

--- a/opengever/workspaceclient/linked_workspaces.py
+++ b/opengever/workspaceclient/linked_workspaces.py
@@ -93,6 +93,9 @@ class LinkedWorkspaces(object):
         This means, unauthorized objects or not existing UIDs will be skipped
         automatically.
         """
+        return self.list_non_cached(**kwargs)
+
+    def list_non_cached(self, **kwargs):
         uids = self.storage.list()
         if not uids:
             return {'items': [], 'items_total': 0}


### PR DESCRIPTION
With this PR a dossier can no longer be resolved or deactivated if it is linked to an active workspace.
To have access to the WorkspaceClient you need the permission `opengever.workspaceclient: Use Workspace Client`. I have achieved this with the `elevated_privileges` context manager. Maybe there is a better way to do this?

Jira: https://4teamwork.atlassian.net/browse/CA-995

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


## Checklist (if applicable)

_Only applicable should be left and checked._

- New translations
  - [x] All msg-strings are unicode