### PR TITLE
Provides the IVocabularyTokenized interface for elephant vocabularies.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 ----------------------
 
 - Don't resolve or deactivate a dossier if it is linked to an active workspace. [tinagerber]
+- Provides the IVocabularyTokenized interface for elephant vocabularies. [elioschmutz]
 
 
 2020.10.0 (2020-09-25)

--- a/opengever/api/solr_query_service.py
+++ b/opengever/api/solr_query_service.py
@@ -1,4 +1,4 @@
-from collective.elephantvocabulary import wrap_vocabulary
+from opengever.base.vocabulary import wrap_vocabulary
 from copy import copy
 from copy import deepcopy
 from DateTime import DateTime

--- a/opengever/base/vocabulary.py
+++ b/opengever/base/vocabulary.py
@@ -1,5 +1,13 @@
+from collective import elephantvocabulary
+from collective.elephantvocabulary.interfaces import IElephantVocabulary
 from zope.component import getUtility
+from zope.interface import alsoProvides
+from zope.interface import implements
+from zope.schema.interfaces import IIterableSource
+from zope.schema.interfaces import ISource
+from zope.schema.interfaces import IVocabulary
 from zope.schema.interfaces import IVocabularyFactory
+from zope.schema.interfaces import IVocabularyTokenized
 
 
 def voc_term_title(field, value):
@@ -17,3 +25,27 @@ def voc_term_title(field, value):
         voc = factory(None)
         return voc.getTerm(value).title
     return value
+
+
+class WrapperBase(elephantvocabulary.WrapperBase):
+    """This is a customized elephant vocabulary wrapper class which
+    provides the IVocabularyTokenized interfaces if the
+    underlying vocabulary provides it.
+
+    This ensures that a field providing an elephant vocabulary is serialized properly.
+    """
+    implements(IElephantVocabulary, IVocabulary, ISource, IIterableSource)
+
+    def __init__(self, vocab, *args, **kwargs):
+        super(WrapperBase, self).__init__(vocab, *args, **kwargs)
+        if IVocabularyTokenized.providedBy(vocab):
+            alsoProvides(self, IVocabularyTokenized)
+
+
+def wrap_vocabulary(*args, **kwargs):
+    """Customized elephant vocaubulary wrapper function which replaces the
+    default wrapper_class with our own WrapperBase class.
+    """
+    if 'wrapper_class' not in kwargs:
+        kwargs['wrapper_class'] = WrapperBase
+    return elephantvocabulary.VocabularyFactory(*args, **kwargs)

--- a/opengever/contact/browser/participation_forms.py
+++ b/opengever/contact/browser/participation_forms.py
@@ -1,5 +1,5 @@
 from Acquisition import aq_parent
-from collective.elephantvocabulary import wrap_vocabulary
+from opengever.base.vocabulary import wrap_vocabulary
 from ftw.keywordwidget.widget import KeywordWidget
 from opengever.base.browser.modelforms import ModelAddForm
 from opengever.base.browser.modelforms import ModelEditForm

--- a/opengever/document/behaviors/metadata.py
+++ b/opengever/document/behaviors/metadata.py
@@ -1,5 +1,5 @@
 from collective import dexteritytextindexer
-from collective.elephantvocabulary import wrap_vocabulary
+from opengever.base.vocabulary import wrap_vocabulary
 from datetime import date
 from ftw.datepicker.widget import DatePickerFieldWidget
 from ftw.keywordwidget.field import ChoicePlus

--- a/opengever/dossier/archive.py
+++ b/opengever/dossier/archive.py
@@ -1,4 +1,4 @@
-from collective.elephantvocabulary import wrap_vocabulary
+from opengever.base.vocabulary import wrap_vocabulary
 from ftw.datepicker.widget import DatePickerFieldWidget
 from opengever.dossier import _
 from opengever.dossier.behaviors.dossier import IDossier

--- a/opengever/dossier/behaviors/dossier.py
+++ b/opengever/dossier/behaviors/dossier.py
@@ -1,4 +1,4 @@
-from collective.elephantvocabulary import wrap_vocabulary
+from opengever.base.vocabulary import wrap_vocabulary
 from datetime import date
 from ftw.datepicker.widget import DatePickerFieldWidget
 from ftw.keywordwidget.field import ChoicePlus

--- a/opengever/dossier/behaviors/participation.py
+++ b/opengever/dossier/behaviors/participation.py
@@ -1,4 +1,4 @@
-from collective.elephantvocabulary import wrap_vocabulary
+from opengever.base.vocabulary import wrap_vocabulary
 from opengever.dossier import _
 from opengever.dossier import events
 from opengever.ogds.base.sources import UsersContactsInboxesSourceBinder

--- a/opengever/task/util.py
+++ b/opengever/task/util.py
@@ -1,4 +1,4 @@
-from collective.elephantvocabulary import wrap_vocabulary
+from opengever.base.vocabulary import wrap_vocabulary
 from opengever.base.response import IResponseContainer
 from opengever.ogds.base.actor import ActorLookup
 from opengever.ogds.models.team import Team


### PR DESCRIPTION
ℹ️ TO THE REVIEWWER ℹ️ 
This PR is kind of changing the current api because it now handles elephantvocabularies properly. I'm not sure, if this change have to be mentioned as breaking api change or not. It was broken before, but it behaves differently now...

---------

[ElephantVocabularies](https://github.com/collective/collective.elephantvocabulary) are wrapper vocabularies around zope.schema vocabularies to restrict vocabulary entries.

The vocabulary factory for the schema field ([example schema field in gever](https://github.com/4teamwork/opengever.core/blob/485762035774a90c8a76ecda5c6be44901749092/opengever/document/behaviors/metadata.py#L117)) is created by the [`wrap_vocabulary`](https://github.com/collective/collective.elephantvocabulary/blob/master/collective/elephantvocabulary/__init__.py#L7) which creates a [`VocabularyFactory`](https://github.com/collective/collective.elephantvocabulary/blob/master/collective/elephantvocabulary/vocabulary.py#L16).
The factory then creates an instance of the `wrapper_class` which defaults to the [`WrapperBase`](https://github.com/collective/collective.elephantvocabulary/blob/master/collective/elephantvocabulary/base.py#L9) of `collective.elephantvocabulary`.All attribute calls on the wrapper-base instance are proxied to the underlying vocabulary.

This works all fine.

The problem is on the provided interfaces of the `WrapperBase` class. It does not respect the provided interfaces of the underlying vocabulary. Which means, serializing such a field will not serialize properly because it does not provide the right interfaces: [plone.restapi:serializer/dxfields](https://github.com/plone/plone.restapi/blob/master/src/plone/restapi/serializer/dxfields.py#L51)

The serializer just returns the token of the vocabulary:

<img width="307" alt="Bildschirmfoto 2020-09-24 um 21 10 57" src="https://user-images.githubusercontent.com/557005/94189136-a4bd8280-feaa-11ea-9e3d-576eacf94f56.png">

This PR provides a new `wrap_vocabulary` method which changes the default `wrapper_class` to a new customized `WrapperBase` class which also provides the `IVocabularyTokenized` interface if the underlying vocabulary does. 

With this change, elephantvocabulary fields gets serialized properly:

<img width="545" alt="Bildschirmfoto 2020-09-24 um 21 12 09" src="https://user-images.githubusercontent.com/557005/94189156-abe49080-feaa-11ea-9b83-47263366d140.png">

Jira: https://4teamwork.atlassian.net/browse/NE-39

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


## Checklist (if applicable)

_Only applicable should be left and checked._

- API change:
  - [ ] Documentation is updated
  - If breaking:
    - [ ] api-change label added
    - [ ] Scrum master is informed
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Upgrade steps (changes in profile):
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
- DB-Schema migration
  - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
  - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value
