### PR TITLE
PR template: Add note to notify #delivery on breaking API changes.

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -27,6 +27,7 @@ _Only applicable should be left and checked._
   - [ ] Documentation is updated
   - If breaking:
     - [ ] api-change label added
+    - [ ] #delivery channel notified about breaking change
     - [ ] Scrum master is informed
 - New functionality:
   - [ ] for `document` also works for `mail`


### PR DESCRIPTION
PR template: Add note to notify `#delivery` channel on breaking API changes.

As requested by @stefanhaenni