### PR TITLE
Also sync the group title with the ogds-group when adding a new group

### DIFF
--- a/opengever/api/group.py
+++ b/opengever/api/group.py
@@ -116,7 +116,7 @@ class GeverGroupsPost(Service):
         # Add group to ogds
         session = create_session()
 
-        ogds_group = Group(groupname, is_local=True)
+        ogds_group = Group(groupname, is_local=True, title=title)
         for userid in users:
             user = get_sql_user(userid)
             ogds_group.users.append(user)

--- a/opengever/api/tests/test_group.py
+++ b/opengever/api/tests/test_group.py
@@ -144,6 +144,7 @@ class TestGroupPost(IntegrationTestCase):
 
         payload = {
             u'groupname': u'test_group',
+            u'title': u'Test group',
             u'users': [self.workspace_guest.getId(), self.workspace_member.getId()]
         }
         response = browser.open(
@@ -158,6 +159,7 @@ class TestGroupPost(IntegrationTestCase):
         self.assertIsNotNone(ogds_group)
         self.assertTrue(ogds_group.is_local)
         self.assertTrue(ogds_group.active)
+        self.assertEqual('Test group', ogds_group.title)
         self.assertItemsEqual(
             [User.query.get(self.workspace_guest.getId()),
              User.query.get(self.workspace_member.getId())],


### PR DESCRIPTION
This is a follow-up PR for #6631

This PR fixes an issue where the group title have not been synchronized with the ogds-group when creating a new group with the `@groups` endpoint.

Jira: https://4teamwork.atlassian.net/browse/CA-530

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


## Checklist (if applicable)

_Only applicable should be left and checked._

- API change:
  - [ ] Documentation is updated
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Upgrade steps (changes in profile):
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
- DB-Schema migration
  - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
  - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value
