### PR TITLE
Prevent setting invalid reference prefix number via API.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 ----------------------
 
 - Bump `ftw.catalogdoctor` to `1.1.0` which provides fixes for additional health problems. [deiferni]
+- Prevent setting invalid reference prefix number via API. [deiferni]
 - Don't resolve or deactivate a dossier if it is linked to an active workspace. [tinagerber]
 - Provides the IVocabularyTokenized interface for elephant vocabularies. [elioschmutz]
 - Customize @groups endpoints to handle OGDS. [njohner]

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -29,6 +29,7 @@
   <adapter factory=".serializer.SerializeGroupModelToJsonSummary" />
   <adapter factory=".serializer.SerializeBrainToJsonSummary" />
 
+  <adapter factory=".repositoryfolder.DeserializeRepositoryFolderFromJson" />
   <adapter factory=".repositoryfolder.SerializeRepositoryFolderToJson" />
   <adapter factory=".inbox.SerializeInboxToJson" />
   <adapter factory=".dossier.SerializeDossierToJson" />

--- a/opengever/api/repositoryfolder.py
+++ b/opengever/api/repositoryfolder.py
@@ -1,10 +1,49 @@
+from Acquisition import aq_inner
+from Acquisition import aq_parent
 from opengever.api.serializer import GeverSerializeFolderToJson
 from opengever.base.interfaces import IReferenceNumber
+from opengever.base.interfaces import IReferenceNumberPrefix as PrefixAdapter
 from opengever.repository.interfaces import IRepositoryFolder
+from plone.restapi.deserializer import json_body
+from plone.restapi.deserializer.dxcontent import DeserializeFromJson
+from plone.restapi.interfaces import IDeserializeFromJson
 from plone.restapi.interfaces import ISerializeToJson
+from zExceptions import BadRequest
 from zope.component import adapter
 from zope.interface import implementer
 from zope.interface import Interface
+
+
+@implementer(IDeserializeFromJson)
+@adapter(IRepositoryFolder, Interface)
+class DeserializeRepositoryFolderFromJson(DeserializeFromJson):
+
+    def __call__(self, validate_all=False, data=None, create=False):
+        if data is None:
+            data = json_body(self.request)
+
+        number = data.get('reference_number_prefix')
+        if number:
+            self.validate_reference_number(number, create=create)
+
+        return super(DeserializeRepositoryFolderFromJson, self).__call__(
+            validate_all=validate_all, data=data, create=create)
+
+    def validate_reference_number(self, number, create=False):
+        parent = aq_parent(aq_inner(self.context))
+        if create:
+            is_valid = PrefixAdapter(parent).is_valid_number(number)
+        else:
+            is_valid = PrefixAdapter(parent).is_valid_number(number,
+                                                             self.context)
+        if not is_valid:
+            msg = "The reference_number {} is already in use.".format(number)
+            error = {
+                "message": msg,
+                "field": "reference_number",
+                "error": "ValidationError"
+            }
+            raise BadRequest([error])
 
 
 @implementer(ISerializeToJson)

--- a/opengever/api/tests/test_repository_folder.py
+++ b/opengever/api/tests/test_repository_folder.py
@@ -1,0 +1,70 @@
+from ftw.testbrowser import browsing
+from opengever.base.interfaces import IReferenceNumberPrefix as PrefixAdapter
+from opengever.repository.behaviors.referenceprefix import IReferenceNumberPrefix
+from opengever.testing import IntegrationTestCase
+import json
+
+
+class TestRepositoryFolderPost(IntegrationTestCase):
+
+    @browsing
+    def test_post_validates_reference_number_prefix(self, browser):
+        self.login(self.administrator, browser)
+        self.assertFalse(PrefixAdapter(
+            self.repository_root).is_valid_number("1"))
+
+        data = {
+            "@type": "opengever.repository.repositoryfolder",
+            "title_de": "Folder",
+            "title_fr": u"F\xf6lder",
+            "reference_number_prefix": "1"
+        }
+        with browser.expect_http_error(code=400, reason='Bad Request'):
+            browser.open(self.repository_root, data=json.dumps(data),
+                         method='POST', headers=self.api_headers)
+
+        self.assertEqual(
+            u"[{'field': 'reference_number', "
+            "'message': 'The reference_number 1 is already in use.', "
+            "'error': 'ValidationError'}]",
+            browser.json['message'])
+
+
+class TestRepositoryFolderPatch(IntegrationTestCase):
+
+    @browsing
+    def test_patch_validates_changed_reference_number_prefix(self, browser):
+        self.login(self.administrator, browser)
+        self.assertFalse(PrefixAdapter(self.repository_root)
+                         .is_valid_number("1"))
+
+        data = {
+            "reference_number_prefix": "1"
+        }
+        with browser.expect_http_error(code=400, reason='Bad Request'):
+            browser.open(self.empty_repofolder, data=json.dumps(data),
+                         method='PATCH', headers=self.api_headers)
+
+        self.assertEqual(
+            u"[{'field': 'reference_number', "
+            "'message': 'The reference_number 1 is already in use.', "
+            "'error': 'ValidationError'}]",
+            browser.json['message'])
+
+    @browsing
+    def test_patch_allows_unchanged_reference_number_prefix(self, browser):
+        self.login(self.administrator, browser)
+
+        current_number = IReferenceNumberPrefix(
+            self.empty_repofolder).reference_number_prefix
+        self.assertTrue(PrefixAdapter(self.repository_root).is_valid_number(
+            current_number, self.empty_repofolder))
+        data = {
+            "reference_number_prefix": current_number
+        }
+        browser.open(self.empty_repofolder, data=json.dumps(data),
+                     method='PATCH', headers=self.api_headers)
+
+        self.assertEqual(204, browser.status_code)
+        self.assertEqual(current_number, IReferenceNumberPrefix(
+            self.empty_repofolder).reference_number_prefix)

--- a/opengever/repository/behaviors/referenceprefix.py
+++ b/opengever/repository/behaviors/referenceprefix.py
@@ -1,5 +1,5 @@
-from zope.container.interfaces import IContainerModifiedEvent
-from Acquisition import aq_parent, aq_inner
+from Acquisition import aq_inner
+from Acquisition import aq_parent
 from opengever.base.interfaces import IReferenceNumberPrefix as PrefixAdapter
 from opengever.repository import _
 from plone.autoform.interfaces import IFormFieldProvider
@@ -7,6 +7,7 @@ from plone.supermodel import model
 from z3c.form import validator, error
 from z3c.form.interfaces import IAddForm
 from zope import schema
+from zope.container.interfaces import IContainerModifiedEvent
 from zope.interface import alsoProvides
 from zope.interface import Interface
 from zope.interface import provider


### PR DESCRIPTION
When creating repository folders via API so far the `reference_number_prefix` was not validated. Theoretically users could have chosen duplicate prefixes. This PR adds validation when creating repository folders via API.

I've decided to implement validation in the deserializer as it has all the information necessary.

- It knows whether we are adding or editing
- It has all the data, context and parent can be accessed easily

Unfortunately an invariant cannot be used as it does not know whether we are adding or editing. Also the add form does provide different data during add than the rest api. In the form context is unavailable while adding, while in the rest API the object to be validated is already created and passed as as context.

We also we leave validation via `WidgetValidatorDiscriminators` in place for now to have validation in the form.

I have not added an upgrade to fix potentially broken content as we don't expect such content to actually have been created.

_I could not find a way to consistently use the same validation path for forms and API. If anyone can provide insights here, please do enlighten me!_

Jira: https://4teamwork.atlassian.net/browse/CA-1080

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)