### PR TITLE
Add @participations endpoints for dossiers

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -11,6 +11,7 @@ Changelog
 - Customize the group_data serializer to return summarized users instead of only userids. [elioschmutz]
 - Extend the ogds-group serializer with a `groupurl` property. [elioschmutz]
 - Implement new api endpoint @ogds-group-listing. [elioschmutz]
+- Add @participations API endpoint for dossiers to CRUD participations. [tinagerber]
 - Do not allow to add multiple participations for one contact. [tinagerber]
 - Don't resolve or deactivate a dossier if it is linked to an active workspace. [tinagerber]
 - Provides the IVocabularyTokenized interface for elephant vocabularies. [elioschmutz]

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -11,6 +11,7 @@ Changelog
 - Customize the group_data serializer to return summarized users instead of only userids. [elioschmutz]
 - Extend the ogds-group serializer with a `groupurl` property. [elioschmutz]
 - Implement new api endpoint @ogds-group-listing. [elioschmutz]
+- Do not allow to add multiple participations for one contact. [tinagerber]
 - Don't resolve or deactivate a dossier if it is linked to an active workspace. [tinagerber]
 - Provides the IVocabularyTokenized interface for elephant vocabularies. [elioschmutz]
 - Customize @groups endpoints to handle OGDS. [njohner]

--- a/docs/public/dev-manual/api/docs_changelog.rst
+++ b/docs/public/dev-manual/api/docs_changelog.rst
@@ -8,6 +8,12 @@ Im Folgenden sind (substantielle) Änderungen an der Dokumentation aufgeführt.
 2020-09-01
 ----------
 
+- Kapitel "Beteiligungen" hinzugefügt
+
+
+2020-09-01
+----------
+
 - Kapitel "Teamraum-Mitglieder" hinzugefügt
 - Kapitel "Inhalte teilen" hinzugefügt
 

--- a/docs/public/dev-manual/api/dossier_participations.rst
+++ b/docs/public/dev-manual/api/dossier_participations.rst
@@ -1,0 +1,169 @@
+Beteiligungen
+=============
+
+Der ``@participations`` Endpoint behandelt Dossierbeteiligungen.
+
+
+Auflistung
+----------
+
+Ein Beteiligter kann in verschiedenen Rollen an einem Dossier beteiligt sein. Mittels eines GET-Requests können alle Beteiligten eines Dossiers und ihre Rollen abgefragt werden.
+
+**Beispiel-Request**:
+
+   .. sourcecode:: http
+
+       GET /dossier-1/@participations HTTP/1.1
+       Accept: application/json
+
+
+**Beispiel-Response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 200 OK
+      Content-Type: application/json
+
+
+      {
+        "@id": "https://example.org/ordnungssystem/fuehrung/dossier-1/@participations",
+        "available_roles": [
+          {
+            "title": "Kenntnisnahme",
+            "token": "regard"
+          },
+          {
+            "title": "Mitwirkung",
+            "token": "participation"
+          },
+          {
+            "title": "Schlusszeichnung",
+            "token": "final-drawing"
+          }
+        ],
+        "items": [
+          {
+            "@id": "https://example.org/ordnungssystem/fuehrung/dossier-1/@participations/rolf.ziegler",
+            "participant_id": "rolf.ziegler",
+            "participant_title": "Ziegler Rolf (rolf.ziegler)",
+            "roles": [
+              "regard",
+              "participation"
+            ]
+          },
+          {
+            "@id": "https://example.org/ordnungssystem/fuehrung/dossier-1/@participations/contact:james-bond",
+            "participant_id": "contact:james-bond",
+            "participant_title": "Bond James (james@example.com)",
+            "roles": [
+              "final-drawing"
+            ]
+          }
+        ],
+        "items_total": 2
+      }
+
+
+Beteiligungen als erweiterbare Komponente
+-----------------------------------------
+
+Die Beteilgungen können als Kompomente eines Dossiers direkt über den ``expand``-Parameter eingebettet werden, so dass keine zusätzliche Abfrage nötig ist.
+
+**Beispiel-Request**:
+
+  .. sourcecode:: http
+
+    GET /dossier-1?expand=participations HTTP/1.1
+    Accept: application/json
+
+**Beispiel-Response**:
+
+  .. sourcecode:: http
+
+    HTTP/1.1 200 OK
+    Content-Type: application/json
+
+    {
+      "@id": "https://example.org/ordnungssystem/fuehrung/dossier-1?expand=participations",
+      "@components": {
+        "participations": {
+          "@id": "https://example.org/ordnungssystem/fuehrung/dossier-1/@participations",
+          "available_roles": ["..."],
+          "items": ["..."],
+          "items_total": 2
+        }
+      },
+      "...": "..."
+    }
+
+
+Beteiligung hinzufügen
+----------------------
+
+Eine Beteiligung kann mittels POST-Requests hinzugefügt werden.
+
+
+**Beispiel-Request**:
+
+   .. sourcecode:: http
+
+       POST /dossier-1/@participations HTTP/1.1
+       Accept: application/json
+
+       {
+         "participant_id": "peter.mueller"
+         "roles": ["regard"]
+       }
+
+**Beispiel-Response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 204 No content
+
+Rollen einer Beteiligung bearbeiten
+-----------------------------------
+
+Rollen einer Beteiligung können mittels PATCH-Requests bearbeitet werden.
+
+
+**Beispiel-Request**:
+
+   .. sourcecode:: http
+
+       POST /dossier-1/@participations/rolf.ziegler HTTP/1.1
+       Accept: application/json
+
+       {
+         "roles": ["regard", "final-drawing"]
+       }
+
+**Beispiel-Response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 204 No content
+
+
+Beteiligung entfernen
+---------------------
+
+Mittels DELETE-Requests kann eine Beteiligung wieder entfernt werden.
+
+**Beispiel-Request**:
+
+   .. sourcecode:: http
+
+       DELETE /dossier-1/@participations/rolf.ziegler HTTP/1.1
+       Accept: application/json
+
+**Beispiel-Response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 204 No content
+
+
+Paginierung
+~~~~~~~~~~~
+Die Paginierung funktioniert gleich wie bei anderen Auflistungen auch (siehe :ref:`Kapitel Paginierung <batching>`).

--- a/docs/public/dev-manual/api/index.rst
+++ b/docs/public/dev-manual/api/index.rst
@@ -19,6 +19,7 @@ Inhalt:
    breadcrumbs.rst
    searching.rst
    dossiers.rst
+   dossier_participations.rst
    documents.rst
    extract_attachments.rst
    trash.rst

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -1000,4 +1000,41 @@
       layer="opengever.base.interfaces.IOpengeverBaseLayer"
       />
 
+  <plone:service
+      method="GET"
+      name="@participations"
+      for="opengever.dossier.behaviors.participation.IParticipationAwareMarker"
+      factory=".dossier_participations.ParticipationsGet"
+      permission="zope2.View"
+      />
+
+  <plone:service
+      method="POST"
+      name="@participations"
+      for="opengever.dossier.behaviors.participation.IParticipationAwareMarker"
+      factory=".dossier_participations.ParticipationsPost"
+      permission="zope2.View"
+      />
+
+  <plone:service
+      method="PATCH"
+      name="@participations"
+      for="opengever.dossier.behaviors.participation.IParticipationAwareMarker"
+      factory=".dossier_participations.ParticipationsPatch"
+      permission="zope2.View"
+      />
+
+  <plone:service
+      method="DELETE"
+      name="@participations"
+      for="opengever.dossier.behaviors.participation.IParticipationAwareMarker"
+      factory=".dossier_participations.ParticipationsDelete"
+      permission="zope2.View"
+      />
+
+  <adapter
+      factory=".dossier_participations.Participations"
+      name="participations"
+      />
+
 </configure>

--- a/opengever/api/dossier_participations.py
+++ b/opengever/api/dossier_participations.py
@@ -1,0 +1,289 @@
+from opengever.api.batch import SQLHypermediaBatch
+from opengever.base.interfaces import IOpengeverBaseLayer
+from opengever.contact import is_contact_feature_enabled
+from opengever.contact.models import Participation
+from opengever.contact.sources import ContactsSource
+from opengever.dossier.behaviors.dossier import IDossierMarker
+from opengever.dossier.behaviors.participation import IParticipationAware
+from opengever.ogds.base.actor import ActorLookup
+from opengever.ogds.base.actor import ContactActor
+from opengever.ogds.base.actor import InboxActor
+from opengever.ogds.base.actor import OGDSUserActor
+from opengever.ogds.base.actor import PloneUserActor
+from plone.protect.interfaces import IDisableCSRFProtection
+from plone.restapi.batching import HypermediaBatch
+from plone.restapi.deserializer import json_body
+from plone.restapi.interfaces import IExpandableElement
+from plone.restapi.services import Service
+from zExceptions import BadRequest
+from zope.component import adapter
+from zope.interface import alsoProvides
+from zope.interface import implementer
+from zope.interface import implements
+from zope.publisher.interfaces import IPublishTraverse
+from zope.schema.vocabulary import getVocabularyRegistry
+
+
+def available_roles(context):
+
+    vocabulary = getVocabularyRegistry().get(context, "opengever.dossier.participation_roles")
+    return [{"token": term.token, "title": term.title} for term in vocabulary]
+
+
+def validate_roles(context, roles):
+    if not roles:
+        raise BadRequest("A list of roles is required")
+    available_roles = getVocabularyRegistry().get(context, "opengever.dossier.participation_roles")
+    for role in roles:
+        if role not in available_roles:
+            raise BadRequest("Role '{}' does not exist".format(role))
+
+
+def get_sql_participant(context, participant_id):
+    source = ContactsSource(context)
+    try:
+        term = source.getTermByToken(participant_id)
+    except Exception:
+        raise BadRequest("{} is not a valid id".format(participant_id))
+    return term.value
+
+
+def get_plone_actor(participant_id):
+    actor = ActorLookup(participant_id).lookup()
+    if not isinstance(actor, (ContactActor, InboxActor, OGDSUserActor, PloneUserActor)):
+        raise BadRequest("{} is not a valid id".format(participant_id))
+    return actor
+
+
+@implementer(IExpandableElement)
+@adapter(IDossierMarker, IOpengeverBaseLayer)
+class Participations(object):
+    def __init__(self, context, request):
+        self.context = context
+        self.request = request
+
+    def get_sql_participations(self):
+        query = Participation.query.by_dossier(self.context)
+        batch = SQLHypermediaBatch(self.request, query)
+        items = []
+        source = ContactsSource(self.context)
+        for participation in batch:
+            participant_id = source.getTerm(participation.participant).token
+            items.append({
+                "@id": "{}/@participations/{}".format(self.context.absolute_url(), participant_id),
+                "participant_id": participant_id,
+                "participant_title": participation.participant.get_title(),
+                "roles": [role.role for role in participation.roles]})
+        return batch, items
+
+    def get_plone_participations(self):
+        handler = IParticipationAware(self.context)
+        participations = list(handler.get_participations())
+
+        batch = HypermediaBatch(self.request, participations)
+        items = []
+        for participation in batch:
+            actor = ActorLookup(participation.contact).lookup()
+            items.append({
+                "@id": '{}/@participations/{}'.format(self.context.absolute_url(),
+                                                      participation.contact),
+                "participant_id": participation.contact,
+                "participant_title": actor.get_label(),
+                "roles": list(participation.roles)})
+        return batch, items
+
+    def __call__(self, expand=False):
+        result = {'participations': {
+            '@id': '/'.join((self.context.absolute_url(), '@participations'))}}
+        if not expand:
+            return result
+
+        if is_contact_feature_enabled():
+            batch, items = self.get_sql_participations()
+        else:
+            batch, items = self.get_plone_participations()
+
+        result["participations"]["available_roles"] = available_roles(self.context)
+        result["participations"]["items"] = items
+        result["participations"]["items_total"] = batch.items_total
+        if batch.links:
+            result["participations"]["batching"] = batch.links
+        return result
+
+
+class ParticipationsGet(Service):
+    """API Endpoint which returns a list of all participations for the current
+    dossier.
+
+    GET /@participations HTTP/1.1
+    """
+
+    def reply(self):
+        participations = Participations(self.context, self.request)
+        return participations(expand=True)["participations"]
+
+
+class ParticipationsPost(Service):
+    """API Endpoint to update an existing participation.
+
+    POST /@participations HTTP/1.1
+    {
+        "participant_id": "peter.mueller",
+        "roles": ["regard", "final-drawing"]
+    }
+    """
+
+    def extract_data(self):
+        data = json_body(self.request)
+        participant_id = data.get("participant_id", None)
+        roles = data.get("roles", None)
+        if not participant_id:
+            raise BadRequest("Property 'participant_id' is required")
+        validate_roles(self.context, roles)
+        return participant_id, roles
+
+    def add_plone_participation(self, participant_id, roles):
+        get_plone_actor(participant_id)
+        handler = IParticipationAware(self.context)
+        existing_participation = handler.get_participation_by_contact_id(participant_id)
+        if existing_participation:
+            raise BadRequest("There is already a participation for {}".format(participant_id))
+
+        participation = handler.create_participation(**{"contact": participant_id, "roles": roles})
+        handler.append_participiation(participation)
+
+    def add_sql_participation(self, participant_id, roles):
+        participant = get_sql_participant(self.context, participant_id)
+        query = participant.participation_class.query.by_participant(
+            participant).by_dossier(self.context)
+        if query.count():
+            raise BadRequest("There is already a participation for {}".format(participant_id))
+        participant.participation_class.create(
+            participant=participant, dossier=self.context, roles=roles)
+
+    def reply(self):
+        # Disable CSRF protection
+        alsoProvides(self.request, IDisableCSRFProtection)
+        participant_id, roles = self.extract_data()
+        if is_contact_feature_enabled():
+            self.add_sql_participation(participant_id, roles)
+        else:
+            self.add_plone_participation(participant_id, roles)
+
+        self.request.response.setStatus(204)
+        return None
+
+
+class ParticipationsPatch(Service):
+    """API Endpoint to update an existing participation.
+
+    PATCH /@participations/peter.mueller HTTP/1.1
+    {
+        "roles": ["regard", "final-drawing"]
+    }
+    """
+
+    implements(IPublishTraverse)
+
+    def __init__(self, context, request):
+        super(ParticipationsPatch, self).__init__(context, request)
+        self.params = []
+
+    def publishTraverse(self, request, name):
+        # Consume any path segments after /@participations as parameters
+        self.params.append(name)
+        return self
+
+    def read_params(self):
+        """Returns principal_id, passed in via traversal parameters.
+        """
+        if len(self.params) != 1:
+            raise BadRequest(
+                "Must supply participant as URL path parameter.")
+        return self.params[0]
+
+    def extract_roles(self):
+        data = json_body(self.request)
+        roles = data.get("roles", None)
+        validate_roles(self.context, roles)
+        return roles
+
+    def update_plone_participation(self, participant_id, new_roles):
+        get_plone_actor(participant_id)
+        handler = IParticipationAware(self.context)
+        participation = handler.get_participation_by_contact_id(participant_id)
+        if not participation:
+            raise BadRequest("{} has no participations on this context".format(participant_id))
+        handler.update_participation(participation, new_roles)
+
+    def update_sql_participation(self, participant_id, new_roles):
+        participant = get_sql_participant(self.context, participant_id)
+        participation = participant.participation_class.query.by_participant(
+            participant).by_dossier(self.context).first()
+        if not participation:
+            raise BadRequest("{} has no participations on this context".format(participant_id))
+        participation.update_roles(new_roles)
+
+    def reply(self):
+        # Disable CSRF protection
+        alsoProvides(self.request, IDisableCSRFProtection)
+        new_roles = self.extract_roles()
+        participant_id = self.read_params()
+        if is_contact_feature_enabled():
+            self.update_sql_participation(participant_id, new_roles)
+        else:
+            self.update_plone_participation(participant_id, new_roles)
+
+        self.request.response.setStatus(204)
+        return None
+
+
+class ParticipationsDelete(Service):
+    """API Endpoint to update an existing participation.
+
+    DELETE /@participations/peter.mueller HTTP/1.1
+    """
+    implements(IPublishTraverse)
+
+    def __init__(self, context, request):
+        super(ParticipationsDelete, self).__init__(context, request)
+        self.params = []
+
+    def publishTraverse(self, request, name):
+        # Consume any path segments after /@participations as parameters
+        self.params.append(name)
+        return self
+
+    def read_params(self):
+        """Returns principal_id, passed in via traversal parameters.
+        """
+        if len(self.params) != 1:
+            raise BadRequest(
+                "Must supply participant as URL path parameter.")
+        return self.params[0]
+
+    def delete_plone_participation(self, participant_id):
+        get_plone_actor(participant_id)
+        handler = IParticipationAware(self.context)
+        participation = handler.get_participation_by_contact_id(participant_id)
+        if not participation:
+            raise BadRequest("{} has no participations on this context".format(participant_id))
+        participation = handler.remove_participation(participation)
+
+    def delete_sql_participation(self, participant_id):
+        participant = get_sql_participant(self.context, participant_id)
+        participation = participant.participation_class.query.by_participant(
+            participant).by_dossier(self.context).first()
+        if not participation:
+            raise BadRequest("{} has no participations on this context".format(participant_id))
+        participation.delete()
+
+    def reply(self):
+        participant_id = self.read_params()
+        if is_contact_feature_enabled():
+            self.delete_sql_participation(participant_id)
+        else:
+            self.delete_plone_participation(participant_id)
+
+        self.request.response.setStatus(204)
+        return None

--- a/opengever/api/tests/test_dossier_participations.py
+++ b/opengever/api/tests/test_dossier_participations.py
@@ -1,0 +1,488 @@
+from ftw.builder.builder import Builder
+from ftw.builder.builder import create
+from ftw.testbrowser import browsing
+from opengever.dossier.behaviors.participation import IParticipationAware
+from opengever.ogds.base.actor import ActorLookup
+from opengever.testing import IntegrationTestCase
+import json
+import transaction
+
+
+class PloneParticipationsHelper(object):
+
+    def add_participation(self, context, participant_id, roles, browser=None):
+        handler = IParticipationAware(context)
+        participation = handler.create_participation(**{"contact": participant_id, "roles": roles})
+        handler.append_participiation(participation)
+
+
+class SQLParticipationsHelper(object):
+
+    def add_participation(self, context, participant_id, roles, browser):
+        browser.open(context.absolute_url() + '/@participations',
+                     method='POST',
+                     headers=self.api_headers,
+                     data=json.dumps({'participant_id': participant_id,
+                                      'roles': roles}))
+
+
+class TestParticipationsGet(IntegrationTestCase, PloneParticipationsHelper):
+
+    @browsing
+    def test_get_participations(self, browser):
+        self.login(self.regular_user, browser=browser)
+        self.add_participation(self.dossier, self.regular_user.getId(),
+                               ['regard', 'participation', 'final-drawing'])
+        self.add_participation(self.dossier, self.dossier_responsible.getId(), ['regard'])
+        browser.open(self.dossier.absolute_url() + '/@participations',
+                     method='GET', headers=self.api_headers)
+
+        expected_json = {
+            u'@id': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen'
+                    u'/dossier-1/@participations',
+            u'available_roles': [{u'title': u'Final drawing',
+                                  u'token': u'final-drawing'},
+                                 {u'title': u'Participation',
+                                  u'token': u'participation'},
+                                 {u'title': u'Regard', u'token': u'regard'}],
+            u'items': [{u'@id': u'http://nohost/plone/ordnungssystem/fuhrung/'
+                        u'vertrage-und-vereinbarungen/dossier-1/@participations/kathi.barfuss',
+                        u'participant_id': u'kathi.barfuss',
+                        u'participant_title': u'B\xe4rfuss K\xe4thi (kathi.barfuss)',
+                        u'roles': [u'regard', u'participation', u'final-drawing']},
+                       {u'@id': u'http://nohost/plone/ordnungssystem/fuhrung/'
+                        u'vertrage-und-vereinbarungen/dossier-1/@participations/robert.ziegler',
+                        u'participant_id': u'robert.ziegler',
+                        u'participant_title': u'Ziegler Robert (robert.ziegler)',
+                        u'roles': [u'regard']}],
+            u'items_total': 2}
+        self.assertEqual(expected_json, browser.json)
+
+        browser.open(self.dossier, method='GET', headers=self.api_headers)
+        self.assertEqual({u'@id': u'http://nohost/plone/ordnungssystem/fuhrung/'
+                                  u'vertrage-und-vereinbarungen/dossier-1/@participations'},
+                         browser.json['@components']['participations'])
+        browser.open(self.dossier.absolute_url() + '?expand=participations',
+                     method='GET', headers=self.api_headers)
+        self.assertEqual(expected_json, browser.json['@components']['participations'])
+
+    @browsing
+    def test_response_is_batched(self, browser):
+        self.login(self.regular_user, browser=browser)
+        self.add_participation(self.dossier, self.regular_user.getId(),
+                               ['regard', 'participation', 'final-drawing'])
+        self.add_participation(self.dossier, self.dossier_responsible.getId(), ['regard'])
+        browser.open(self.dossier.absolute_url() + '/@participations?b_size=1',
+                     method='GET', headers=self.api_headers)
+
+        self.assertEqual(1, len(browser.json['items']))
+        self.assertEqual(2, browser.json['items_total'])
+        self.assertEqual(3, len(browser.json['available_roles']))
+        self.assertIn('batching', browser.json)
+
+
+class TestParticipationsGetWithContactFeatureEnabled(IntegrationTestCase):
+
+    features = ('contact', )
+
+    @browsing
+    def test_get_participations(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        browser.open(self.dossier.absolute_url() + '/@participations',
+                     method='GET', headers=self.api_headers)
+        expected_json = {
+            u'@id': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/'
+                    u'dossier-1/@participations',
+            u'available_roles': [{u'title': u'Final drawing',
+                                  u'token': u'final-drawing'},
+                                 {u'title': u'Participation',
+                                  u'token': u'participation'},
+                                 {u'title': u'Regard', u'token': u'regard'}],
+            u'items': [{u'@id': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-'
+                                u'vereinbarungen/dossier-1/@participations/organization:2',
+                        u'participant_id': u'organization:2',
+                        u'participant_title': u'Meier AG',
+                        u'roles': [u'final-drawing']},
+                       {u'@id': u'http://nohost/plone/ordnungssystem/fuhrung/'
+                                u'vertrage-und-vereinbarungen/dossier-1/@participations/person:1',
+                        u'participant_id': u'person:1',
+                        u'participant_title': u'B\xfchler Josef',
+                        u'roles': [u'final-drawing', u'participation']}],
+            u'items_total': 2}
+        self.assertEqual(expected_json, browser.json)
+
+        browser.open(self.dossier, method='GET', headers=self.api_headers)
+        self.assertEqual({u'@id': u'http://nohost/plone/ordnungssystem/fuhrung/'
+                                  u'vertrage-und-vereinbarungen/dossier-1/@participations'},
+                         browser.json['@components']['participations'])
+        browser.open(self.dossier.absolute_url() + '?expand=participations',
+                     method='GET', headers=self.api_headers)
+        self.assertEqual(expected_json, browser.json['@components']['participations'])
+
+    @browsing
+    def test_response_is_batched(self, browser):
+        self.login(self.regular_user, browser=browser)
+        browser.open(self.dossier.absolute_url() + '/@participations?b_size=1',
+                     method='GET', headers=self.api_headers)
+
+        self.assertEqual(1, len(browser.json['items']))
+        self.assertEqual(2, browser.json['items_total'])
+        self.assertEqual(3, len(browser.json['available_roles']))
+        self.assertIn('batching', browser.json)
+
+
+class TestParticipationsPost(IntegrationTestCase):
+
+    def setUp(self):
+        super(TestParticipationsPost, self).setUp()
+        self.valid_participant_id = self.regular_user.getId()
+
+    @browsing
+    def test_post_participation(self, browser):
+        self.login(self.regular_user, browser=browser)
+        browser.open(self.dossier.absolute_url() + '/@participations',
+                     method='POST',
+                     headers=self.api_headers,
+                     data=json.dumps({'participant_id': self.regular_user.getId(),
+                                      'roles': ['regard', 'final-drawing']}))
+        self.assertEqual(browser.status_code, 204)
+        contact_id = 'contact:{}'.format(self.franz_meier.getId())
+        browser.open(self.dossier.absolute_url() + '/@participations',
+                     method='POST',
+                     headers=self.api_headers,
+                     data=json.dumps({'participant_id': contact_id,
+                                      'roles': ['participation']}))
+        self.assertEqual(browser.status_code, 204)
+
+        browser.open(self.dossier.absolute_url() + '/@participations', method='GET',
+                     headers=self.api_headers)
+        self.assertEqual([
+            {u'@id': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/'
+             u'dossier-1/@participations/kathi.barfuss',
+             u'participant_id': u'kathi.barfuss',
+             u'participant_title': u'B\xe4rfuss K\xe4thi (kathi.barfuss)',
+             u'roles': [u'regard', u'final-drawing']},
+            {u'@id': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/'
+             u'dossier-1/@participations/contact:meier-franz',
+             u'participant_id': u'contact:meier-franz',
+             u'participant_title': u'Meier Franz (meier.f@example.com)',
+             u'roles': [u'participation']}],
+            browser.json['items'])
+
+    @browsing
+    def test_post_participations_without_roles_raises_bad_request(self, browser):
+        self.login(self.regular_user, browser=browser)
+        error = {"message": "A list of roles is required", "type": "BadRequest"}
+        with browser.expect_http_error(400):
+            browser.open(self.dossier.absolute_url() + '/@participations', method='POST',
+                         headers=self.api_headers,
+                         data=json.dumps({'participant_id': self.valid_participant_id}))
+        self.assertEqual(error, browser.json)
+        with browser.expect_http_error(400):
+            browser.open(self.dossier.absolute_url() + '/@participations', method='POST',
+                         headers=self.api_headers,
+                         data=json.dumps({'participant_id': self.valid_participant_id,
+                                          'roles': []}))
+        self.assertEqual(error, browser.json)
+
+    @browsing
+    def test_post_participations_with_invalid_role_raises_bad_request(self, browser):
+        self.login(self.regular_user, browser=browser)
+        with browser.expect_http_error(400):
+            browser.open(self.dossier.absolute_url() + '/@participations', method='POST',
+                         headers=self.api_headers,
+                         data=json.dumps({'participant_id': self.valid_participant_id,
+                                          'roles': ['regard', 'invalid']}))
+        self.assertEqual({"message": "Role 'invalid' does not exist",
+                          "type": "BadRequest"}, browser.json)
+
+    @browsing
+    def test_post_participations_without_participant_id_raises_bad_request(self, browser):
+        self.login(self.regular_user, browser=browser)
+        with browser.expect_http_error(400):
+            browser.open(self.dossier.absolute_url() + '/@participations', method='POST',
+                         headers=self.api_headers,
+                         data=json.dumps({'roles': ['regard']}))
+        self.assertEqual({"message": "Property 'participant_id' is required",
+                          "type": "BadRequest"}, browser.json)
+
+    @browsing
+    def test_post_participations_with_invalid_participant_id_raises_bad_request(self, browser):
+        self.login(self.regular_user, browser=browser)
+        with browser.expect_http_error(400):
+            browser.open(self.dossier.absolute_url() + '/@participations', method='POST',
+                         headers=self.api_headers,
+                         data=json.dumps({'participant_id': 'chaosqueen',
+                                          'roles': ['regard']}))
+        self.assertEqual({"message": "chaosqueen is not a valid id",
+                          "type": "BadRequest"}, browser.json)
+
+    @browsing
+    def test_post_participation_with_existing_participant_raises_bad_request(self, browser):
+        self.login(self.regular_user, browser=browser)
+        browser.open(self.dossier.absolute_url() + '/@participations',
+                     method='POST',
+                     headers=self.api_headers,
+                     data=json.dumps({'participant_id': self.valid_participant_id,
+                                      'roles': ['regard']}))
+        with browser.expect_http_error(400):
+            browser.open(self.dossier.absolute_url() + '/@participations',
+                         method='POST',
+                         headers=self.api_headers,
+                         data=json.dumps({'participant_id': self.valid_participant_id,
+                                          'roles': ['final-drawing']}))
+        self.assertEqual({"message": "There is already a participation for {}".format(
+            self.valid_participant_id), "type": "BadRequest"}, browser.json)
+
+
+class TestParticipationsPostWithContactFeatureEnabled(TestParticipationsPost):
+
+    features = ('contact', )
+
+    def setUp(self):
+        super(TestParticipationsPostWithContactFeatureEnabled, self).setUp()
+        self.person = create(Builder('person').having(
+            firstname=u'Hans', lastname=u'M\xfcller'))
+        self.organization = create(Builder('organization').named('4teamwork AG'))
+        self.org_role = create(Builder('org_role').having(
+            person=self.person, organization=self.organization, function=u'Gute Fee'))
+        transaction.commit()
+        self.valid_participant_id = 'person:{}'.format(self.person.id)
+
+    @browsing
+    def test_post_participation(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        browser.open(self.dossier.absolute_url() + '/@participations',
+                     method='POST',
+                     headers=self.api_headers,
+                     data=json.dumps({'participant_id': self.valid_participant_id,
+                                      'roles': ['regard']}))
+        self.assertEqual(browser.status_code, 204)
+
+        organization_id = 'organization:{}'.format(self.organization.id)
+        browser.open(self.dossier.absolute_url() + '/@participations',
+                     method='POST',
+                     headers=self.api_headers,
+                     data=json.dumps({'participant_id': organization_id,
+                                      'roles': ['participation', 'final-drawing']}))
+        self.assertEqual(browser.status_code, 204)
+
+        org_role_id = 'org_role:{}'.format(self.org_role.id)
+        browser.open(self.dossier.absolute_url() + '/@participations',
+                     method='POST',
+                     headers=self.api_headers,
+                     data=json.dumps({'participant_id': org_role_id,
+                                      'roles': ['regard', 'final-drawing']}))
+        self.assertEqual(browser.status_code, 204)
+
+        ogds_user_id = 'ogds_user:{}'.format(self.regular_user.getId())
+        browser.open(self.dossier.absolute_url() + '/@participations',
+                     method='POST',
+                     headers=self.api_headers,
+                     data=json.dumps({'participant_id': ogds_user_id,
+                                      'roles': ['regard', 'participation', 'final-drawing']}))
+        self.assertEqual(browser.status_code, 204)
+
+        browser.open(self.dossier.absolute_url() + '/@participations', method='GET',
+                     headers=self.api_headers)
+
+        self.assertEqual([
+            {u'@id': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/'
+             u'dossier-1/@participations/organization:2',
+             u'participant_id': u'organization:2',
+             u'participant_title': u'Meier AG',
+             u'roles': [u'final-drawing']},
+            {u'@id': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/'
+             u'dossier-1/@participations/person:1',
+             u'participant_id': u'person:1',
+             u'participant_title': u'B\xfchler Josef',
+             u'roles': [u'final-drawing', u'participation']},
+            {u'@id': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/'
+             u'dossier-1/@participations/person:3',
+             u'participant_id': self.valid_participant_id,
+             u'participant_title': self.person.get_title(),
+             u'roles': [u'regard']},
+            {u'@id': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/'
+             u'dossier-1/@participations/organization:4',
+             u'participant_id': organization_id,
+             u'participant_title': self.organization.get_title(),
+             u'roles': [u'participation', u'final-drawing']},
+            {u'@id': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/'
+             u'dossier-1/@participations/org_role:1',
+             u'participant_id': org_role_id,
+             u'participant_title': self.org_role.get_title(),
+             u'roles': [u'regard', u'final-drawing']},
+            {u'@id': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/'
+             u'dossier-1/@participations/ogds_user:kathi.barfuss',
+             u'participant_id': ogds_user_id,
+             u'participant_title': u'B\xe4rfuss K\xe4thi (kathi.barfuss)',
+             u'roles': [u'regard', u'participation', u'final-drawing']}],
+            browser.json['items'])
+
+
+class TestParticipationsPatch(IntegrationTestCase, PloneParticipationsHelper):
+
+    def setUp(self):
+        super(TestParticipationsPatch, self).setUp()
+        self.participant_id = self.regular_user.getId()
+        self.participant_title = ActorLookup(self.regular_user.getId()).lookup().get_label()
+
+    @browsing
+    def test_patch_participation(self, browser):
+        self.login(self.regular_user, browser=browser)
+        self.add_participation(self.dossier, self.participant_id, ['regard'], browser=browser)
+        browser.open(self.dossier.absolute_url() + '/@participations',
+                     method='GET', headers=self.api_headers)
+        url = u'{}/@participations/{}'.format(self.dossier.absolute_url(), self.participant_id)
+        self.assertIn({
+            u'@id': url,
+            u'participant_id': self.participant_id,
+            u'participant_title': self.participant_title,
+            u'roles': [u'regard']}, browser.json['items'])
+
+        browser.open(self.dossier.absolute_url() + '/@participations/' + self.participant_id,
+                     method='PATCH',
+                     headers=self.api_headers,
+                     data=json.dumps({'roles': ['participation', 'final-drawing']}))
+        self.assertEqual(browser.status_code, 204)
+
+        browser.open(self.dossier.absolute_url() + '/@participations', method='GET',
+                     headers=self.api_headers)
+        self.assertIn({
+            u'@id': url,
+            u'participant_id': self.participant_id,
+            u'participant_title': self.participant_title,
+            u'roles': [u'participation', u'final-drawing']}, browser.json['items'])
+
+    @browsing
+    def test_patch_participation_without_participant_id_raises_bad_request(self, browser):
+        self.login(self.regular_user, browser=browser)
+        with browser.expect_http_error(400):
+            browser.open(self.dossier.absolute_url() + '/@participations',
+                         method='PATCH',
+                         headers=self.api_headers,
+                         data=json.dumps({'roles': ['participation', 'final-drawing']}))
+        self.assertEqual({"message": "Must supply participant as URL path parameter.",
+                          "type": "BadRequest"}, browser.json)
+
+    @browsing
+    def test_patch_participation_when_particpant_has_no_participation_raises_bad_request(self,
+                                                                                         browser):
+        self.login(self.regular_user, browser=browser)
+        with browser.expect_http_error(400):
+            url = self.dossier.absolute_url() + '/@participations/' + self.participant_id
+            browser.open(url, method='PATCH', headers=self.api_headers,
+                         data=json.dumps({'roles': ['participation', 'final-drawing']}))
+        self.assertEqual({"message": "{} has no participations on this context".format(
+            self.participant_id), "type": "BadRequest"}, browser.json)
+
+    @browsing
+    def test_patch_participations_with_invalid_participant_id_raises_bad_request(self, browser):
+        self.login(self.regular_user, browser=browser)
+        with browser.expect_http_error(400):
+            browser.open(self.dossier.absolute_url() + '/@participations/chaosqueen',
+                         method='PATCH',
+                         headers=self.api_headers,
+                         data=json.dumps({'roles': ['regard']}))
+        self.assertEqual({"message": "chaosqueen is not a valid id",
+                          "type": "BadRequest"}, browser.json)
+
+    @browsing
+    def test_patch_participations_without_roles_raises_bad_request(self, browser):
+        self.login(self.regular_user, browser=browser)
+        error = {"message": "A list of roles is required", "type": "BadRequest"}
+        self.add_participation(self.dossier, self.participant_id, ['regard'], browser=browser)
+        url = u'{}/@participations/{}'.format(self.dossier.absolute_url(), self.participant_id)
+        with browser.expect_http_error(400):
+            browser.open(url, method='PATCH', headers=self.api_headers)
+        self.assertEqual(error, browser.json)
+        with browser.expect_http_error(400):
+            browser.open(url, method='PATCH', headers=self.api_headers,
+                         data=json.dumps({'roles': []}))
+        self.assertEqual(error, browser.json)
+
+    @browsing
+    def test_patch_participations_with_invalid_role_raises_bad_request(self, browser):
+        self.login(self.regular_user, browser=browser)
+        url = u'{}/@participations/{}'.format(self.dossier.absolute_url(), self.participant_id)
+        with browser.expect_http_error(400):
+            browser.open(url, method='PATCH', headers=self.api_headers,
+                         data=json.dumps({'roles': ['regard', 'invalid']}))
+        self.assertEqual({"message": "Role 'invalid' does not exist",
+                          "type": "BadRequest"}, browser.json)
+
+
+class TestParticipationsPatchWithContactFeatureEnabled(SQLParticipationsHelper,
+                                                       TestParticipationsPatch):
+
+    features = ('contact', )
+
+    def setUp(self):
+        super(TestParticipationsPatchWithContactFeatureEnabled, self).setUp()
+        self.person = create(Builder('person').having(
+            firstname=u'Hans', lastname=u'M\xfcller'))
+        transaction.commit()
+        self.participant_id = 'person:{}'.format(self.person.id)
+        self.participant_title = self.person.get_title()
+
+
+class TestParticipationsDelete(IntegrationTestCase, PloneParticipationsHelper):
+
+    def setUp(self):
+        super(TestParticipationsDelete, self).setUp()
+        self.participant_id = self.regular_user.getId()
+        self.participant_title = ActorLookup(self.regular_user.getId()).lookup().get_label()
+
+    @browsing
+    def test_delete_participation(self, browser):
+        self.login(self.regular_user, browser=browser)
+        self.add_participation(self.dossier, self.participant_id, ['regard'], browser=browser)
+        browser.open(self.dossier.absolute_url() + '/@participations',
+                     method='GET', headers=self.api_headers)
+        self.assertIn(self.participant_id, [item['participant_id']
+                                            for item in browser.json['items']])
+
+        browser.open(self.dossier.absolute_url() + '/@participations/' + self.participant_id,
+                     method='DELETE',
+                     headers=self.api_headers)
+        self.assertEqual(browser.status_code, 204)
+
+        browser.open(self.dossier.absolute_url() + '/@participations', method='GET',
+                     headers=self.api_headers)
+        self.assertNotIn(self.participant_id, [item['participant_id']
+                                               for item in browser.json['items']])
+
+    @browsing
+    def test_delete_participation_when_particpant_has_no_participation_raises_bad_request(self,
+                                                                                          browser):
+        self.login(self.regular_user, browser=browser)
+        with browser.expect_http_error(400):
+            url = self.dossier.absolute_url() + '/@participations/' + self.participant_id
+            browser.open(url, method='DELETE', headers=self.api_headers)
+        self.assertEqual({"message": "{} has no participations on this context".format(
+            self.participant_id), "type": "BadRequest"}, browser.json)
+
+    @browsing
+    def test_delete_participations_with_invalid_participant_id_raises_bad_request(self, browser):
+        self.login(self.regular_user, browser=browser)
+        with browser.expect_http_error(400):
+            browser.open(self.dossier.absolute_url() + '/@participations/chaosqueen',
+                         method='DELETE', headers=self.api_headers)
+        self.assertEqual({"message": "chaosqueen is not a valid id",
+                          "type": "BadRequest"}, browser.json)
+
+
+class TestParticipationsDeleteWithContactFeatureEnabled(SQLParticipationsHelper,
+                                                        TestParticipationsDelete):
+
+    features = ('contact', )
+
+    def setUp(self):
+        super(TestParticipationsDeleteWithContactFeatureEnabled, self).setUp()
+        self.person = create(Builder('person').having(
+            firstname=u'Hans', lastname=u'M\xfcller'))
+        transaction.commit()
+        self.participant_id = 'person:{}'.format(self.person.id)
+        self.participant_title = self.person.get_title()

--- a/opengever/core/upgrades/20200925090651_migrate_participations/upgrade.py
+++ b/opengever/core/upgrades/20200925090651_migrate_participations/upgrade.py
@@ -1,0 +1,31 @@
+from ftw.upgrade import UpgradeStep
+from opengever.contact import is_contact_feature_enabled
+from opengever.dossier.behaviors.participation import IParticipationAware
+from opengever.dossier.behaviors.participation import IParticipationAwareMarker
+from persistent.list import PersistentList
+
+
+class MigrateParticipations(UpgradeStep):
+    """Migrate participations.
+    """
+    deferrable = True
+
+    def __call__(self):
+        if is_contact_feature_enabled():
+            return
+        query = {'object_provides': IParticipationAwareMarker.__identifier__}
+        for dossier in self.objects(query, 'Merge participations.'):
+            handler = IParticipationAware(dossier)
+            old_participations = handler.get_participations()
+            if not old_participations:
+                continue
+            contacts_and_roles = dict()
+            for participation in old_participations:
+                if participation.contact in contacts_and_roles:
+                    contacts_and_roles[participation.contact].update(participation.roles)
+                else:
+                    contacts_and_roles[participation.contact] = set(participation.roles)
+
+            lst = PersistentList([handler.create_participation(contact=key, roles=value)
+                                  for key, value in contacts_and_roles.items()])
+            handler.set_participations(lst)

--- a/opengever/dossier/behaviors/participation.py
+++ b/opengever/dossier/behaviors/participation.py
@@ -53,6 +53,10 @@ class ParticipationHandler(object):
             if participation.contact == contact_id:
                 return participation
 
+    def update_participation(self, value, roles):
+        value.roles = roles
+        notify(events.ParticipationModified(self.context, value))
+
     def set_participations(self, value):
         if not isinstance(value, PersistentList):
             raise TypeError('Excpected PersistentList instance')

--- a/opengever/dossier/behaviors/participation.py
+++ b/opengever/dossier/behaviors/participation.py
@@ -47,6 +47,12 @@ class ParticipationHandler(object):
         return self.annotations.get(self.annotation_key,
                                     PersistentList())
 
+    def get_participation_by_contact_id(self, contact_id):
+        participations = list(self.get_participations())
+        for participation in participations:
+            if participation.contact == contact_id:
+                return participation
+
     def set_participations(self, value):
         if not isinstance(value, PersistentList):
             raise TypeError('Excpected PersistentList instance')

--- a/opengever/dossier/browser/forms.py
+++ b/opengever/dossier/browser/forms.py
@@ -171,13 +171,18 @@ class ParticipationAddForm(Form):
         data, errors = self.extractData()
         if not errors:
             phandler = IParticipationAware(self.context)
-            part = phandler.create_participation(**data)
-            phandler.append_participiation(part)
             status = IStatusMessage(self.request)
-            msg = _(u'info_participation_create',
-                    u'Participation created.')
-            status.addStatusMessage(msg, type='info')
-            return self._redirect_to_participants_tab()
+            if phandler.get_participation_by_contact_id(data.get('contact')):
+                msg = _(u'error_participant_already_exists',
+                        default=u'There is already a participation for this contact.')
+                status.addStatusMessage(msg, type='error')
+            else:
+                part = phandler.create_participation(**data)
+                phandler.append_participiation(part)
+                msg = _(u'info_participation_create',
+                        u'Participation created.')
+                status.addStatusMessage(msg, type='info')
+                return self._redirect_to_participants_tab()
 
     @button.buttonAndHandler(_(u'button_cancel', default=u'Cancel'))
     def handle_cancel(self, action):

--- a/opengever/dossier/events.py
+++ b/opengever/dossier/events.py
@@ -15,6 +15,18 @@ class ParticipationCreated(ObjectEvent):
         self.participant = participant
 
 
+class ParticipationModified(ObjectEvent):
+    """The `ParticipationModified` is fired after a
+    participation is modified.
+    """
+
+    implements(interfaces.IParticipationModified)
+
+    def __init__(self, obj, participant):
+        self.object = obj
+        self.participant = participant
+
+
 class ParticipationRemoved(ObjectEvent):
     """The `ParticipationRemoved` is fired before a participation is removed.
     """

--- a/opengever/dossier/interfaces.py
+++ b/opengever/dossier/interfaces.py
@@ -99,6 +99,11 @@ class IParticipationCreated(IObjectEvent):
     """
 
 
+class IParticipationModified(IObjectEvent):
+    """Interface for participation modified event.
+    """
+
+
 class IParticipationRemoved(IObjectEvent):
     """Interface for participation removed event.
     """

--- a/opengever/dossier/locales/de/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/de/LC_MESSAGES/opengever.dossier.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2020-09-22 14:48+0000\n"
+"POT-Creation-Date: 2020-09-29 16:20+0000\n"
 "PO-Revision-Date: 2017-05-23 04:53+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: German <https://translations.onegovgever.ch/projects/onegov-gever/opengever-dossier/de/>\n"
@@ -357,6 +357,11 @@ msgstr "Enddatum erforderlich"
 #: ./opengever/dossier/browser/report.py
 msgid "error_no_items"
 msgstr "Sie haben keine Objekte ausgewählt."
+
+#. Default: "There is already a participation for this contact."
+#: ./opengever/dossier/browser/forms.py
+msgid "error_participant_already_exists"
+msgstr "Für diesen Kontakt existiert bereits eine Beteiligung."
 
 #. Default: "Failed to move ${item}."
 #: ./opengever/dossier/move_items.py

--- a/opengever/dossier/locales/fr/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/fr/LC_MESSAGES/opengever.dossier.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2020-09-22 14:48+0000\n"
+"POT-Creation-Date: 2020-09-29 16:20+0000\n"
 "PO-Revision-Date: 2017-12-03 11:16+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-dossier/fr/>\n"
@@ -355,6 +355,11 @@ msgstr "Date de clôture requise"
 #: ./opengever/dossier/browser/report.py
 msgid "error_no_items"
 msgstr "Vous n'avez sélectionné aucun élément."
+
+#. Default: "There is already a participation for this contact."
+#: ./opengever/dossier/browser/forms.py
+msgid "error_participant_already_exists"
+msgstr ""
 
 #. Default: "Failed to move ${item}."
 #: ./opengever/dossier/move_items.py

--- a/opengever/dossier/locales/opengever.dossier.pot
+++ b/opengever/dossier/locales/opengever.dossier.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2020-09-22 14:48+0000\n"
+"POT-Creation-Date: 2020-09-29 16:20+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -355,6 +355,11 @@ msgstr ""
 #. Default: "You have not selected any items."
 #: ./opengever/dossier/browser/report.py
 msgid "error_no_items"
+msgstr ""
+
+#. Default: "There is already a participation for this contact."
+#: ./opengever/dossier/browser/forms.py
+msgid "error_participant_already_exists"
 msgstr ""
 
 #. Default: "Failed to move ${item}."

--- a/opengever/journal/configure.zcml
+++ b/opengever/journal/configure.zcml
@@ -221,6 +221,12 @@
 
   <subscriber
       for="opengever.dossier.behaviors.dossier.IDossierMarker
+           opengever.dossier.interfaces.IParticipationModified"
+      handler=".handlers.participation_modified"
+      />
+
+  <subscriber
+      for="opengever.dossier.behaviors.dossier.IDossierMarker
            opengever.dossier.interfaces.IParticipationRemoved"
       handler=".handlers.participation_removed"
       />

--- a/opengever/journal/handlers.py
+++ b/opengever/journal/handlers.py
@@ -637,6 +637,21 @@ def participation_created(context, event):
     journal_entry_factory(context, PARTICIPANT_ADDED, title)
 
 
+PARTICIPANT_MODIFIED = 'Participant modified'
+
+
+def participation_modified(context, event):
+    title = _(
+        u'label_participant_modified',
+        default=u'Participant modified: ${contact}',
+        mapping={
+            'contact': readable_ogds_author(
+                event.participant,
+                event.participant.contact),
+            })
+    journal_entry_factory(context, PARTICIPANT_MODIFIED, title)
+
+
 PARTICIPANT_REMOVED = 'Participant removed'
 
 

--- a/opengever/journal/locales/de/LC_MESSAGES/opengever.journal.po
+++ b/opengever/journal/locales/de/LC_MESSAGES/opengever.journal.po
@@ -30,11 +30,6 @@ msgstr "Geändert von"
 msgid "label_add_journal_entry"
 msgstr "Journaleintrag hinzufügen"
 
-#. Default: "Attachments deleted: ${filenames}"
-#: ./opengever/journal/handlers.py
-msgid "label_attachments_deleted"
-msgstr "Attachments gelöscht: ${filenames}"
-
 #. Default: "Category"
 #: ./opengever/journal/form.py
 msgid "label_category"

--- a/opengever/journal/locales/de/LC_MESSAGES/opengever.journal.po
+++ b/opengever/journal/locales/de/LC_MESSAGES/opengever.journal.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2019-11-13 15:05+0000\n"
+"POT-Creation-Date: 2020-09-28 13:04+0000\n"
 "PO-Revision-Date: 2014-11-19 12:25+0100\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -220,6 +220,11 @@ msgstr "Objekt eingefügt: ${title}"
 #: ./opengever/journal/handlers.py
 msgid "label_participant_added"
 msgstr "Beteiligung hinzugefügt für ${contact} als ${roles}"
+
+#. Default: "Participant modified: ${contact}"
+#: ./opengever/journal/handlers.py
+msgid "label_participant_modified"
+msgstr "Beteiligung von ${contact} modifiziert"
 
 #. Default: "Participant removed: ${contact}"
 #: ./opengever/journal/handlers.py

--- a/opengever/journal/locales/fr/LC_MESSAGES/opengever.journal.po
+++ b/opengever/journal/locales/fr/LC_MESSAGES/opengever.journal.po
@@ -32,11 +32,6 @@ msgstr "Modifié par"
 msgid "label_add_journal_entry"
 msgstr "Ajouter une entrée à l'historique"
 
-#. Default: "Attachments deleted: ${filenames}"
-#: ./opengever/journal/handlers.py
-msgid "label_attachments_deleted"
-msgstr "Fichiers attachés effacés: ${filenames}"
-
 #. Default: "Category"
 #: ./opengever/journal/form.py
 msgid "label_category"

--- a/opengever/journal/locales/fr/LC_MESSAGES/opengever.journal.po
+++ b/opengever/journal/locales/fr/LC_MESSAGES/opengever.journal.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-11-13 15:05+0000\n"
+"POT-Creation-Date: 2020-09-28 13:04+0000\n"
 "PO-Revision-Date: 2018-05-22 10:09+0000\n"
 "Last-Translator: Niklaus Johner <Niklaus.johner@4teamwork.ch>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-journal/fr/>\n"
@@ -222,6 +222,11 @@ msgstr "Objet collé: ${title}"
 #: ./opengever/journal/handlers.py
 msgid "label_participant_added"
 msgstr "Participation ajoutée pour ${contact} comme ${roles}"
+
+#. Default: "Participant modified: ${contact}"
+#: ./opengever/journal/handlers.py
+msgid "label_participant_modified"
+msgstr ""
 
 #. Default: "Participant removed: ${contact}"
 #: ./opengever/journal/handlers.py

--- a/opengever/journal/locales/opengever.journal.pot
+++ b/opengever/journal/locales/opengever.journal.pot
@@ -33,11 +33,6 @@ msgstr ""
 msgid "label_add_journal_entry"
 msgstr ""
 
-#. Default: "Attachments deleted: ${filenames}"
-#: ./opengever/journal/handlers.py
-msgid "label_attachments_deleted"
-msgstr ""
-
 #. Default: "Category"
 #: ./opengever/journal/form.py
 msgid "label_category"

--- a/opengever/journal/locales/opengever.journal.pot
+++ b/opengever/journal/locales/opengever.journal.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-11-13 15:05+0000\n"
+"POT-Creation-Date: 2020-09-28 13:04+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -222,6 +222,11 @@ msgstr ""
 #. Default: "Participant added: ${contact} with roles ${roles}"
 #: ./opengever/journal/handlers.py
 msgid "label_participant_added"
+msgstr ""
+
+#. Default: "Participant modified: ${contact}"
+#: ./opengever/journal/handlers.py
+msgid "label_participant_modified"
 msgstr ""
 
 #. Default: "Participant removed: ${contact}"


### PR DESCRIPTION
In this PR some changes are implemented:
- CRUD endpoints are implemented for dossier participations
- Previously it was possible to have several participations per participant. This is now prevented by not being able to create a participation for a user if the user already has a participation on the dossier.
- Since it is possible that multiple participations exist for users, all participations had to be migrated.
- Since participations can now be modified via the API endpoint, a journal entry must be created for the modification of a participation.

About the upgrade step: maybe it should be deferrable, because it goes over all dossiers. Also, the endpoints will not be used as long as the frontend part is not implemented. Probably it would make sense to use the same upgrade step in the issue https://4teamwork.atlassian.net/browse/CA-17, because it must also touch all dossiers.

Jira: https://4teamwork.atlassian.net/browse/NE-98

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


## Checklist (if applicable)

_Only applicable should be left and checked._

- Upgrade steps (changes in profile):
  - [ ] Make it deferrable if possible
  - [x] Execute as much as possible conditionally
- New translations
  - [x] All msg-strings are unicode