### PR TITLE
Refactor participations, index them and add them to the listing endpoint

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -11,6 +11,7 @@ Changelog
 - Add @dossier-from-template endpoint. [tinagerber]
 - Activate the groups plugin for source_groups. [elioschmutz]
 - Add @possible-participants endpoint. [tinagerber]
+- Add support for participations in listing endpoint. [njohner]
 - Also provide main_dossier for dossiertemplates [elioschmutz]
 - Allow assigning groups as participants to a Teamraum [elioschmutz]
 - Add external_reference field to solr, reindex objects with values. [deiferni]

--- a/docs/public/dev-manual/api/listings.rst
+++ b/docs/public/dev-manual/api/listings.rst
@@ -92,6 +92,9 @@ werden. Folgende Felder stehen zur Verfügung:
 - ``lastname``: Nachname
 - ``mimetype``: Mimetype
 - ``modified``: Modifikationsdatum
+- ``participants``: Beteiligte
+- ``participation_roles``: Beteiligungsrollen
+- ``participations``: Beteiligungen
 - ``pdf_url``: URL für Vorschau-PDF
 - ``phone_office``: Telefonnummer
 - ``preview_url``: URL für Vorschau
@@ -178,6 +181,12 @@ siehe Tabelle:
     |``mimetype``              |    ja    |   nein  |     nein     |        nein        |  nein   |  nein   |  nein   |   nein   |       nein      |       nein       |       nein      |
     +--------------------------+----------+---------+--------------+--------------------+---------+---------+---------+----------+-----------------+------------------+-----------------+
     |``modified``              |    ja    |    ja   |      ja      |         ja         |   ja    |   ja    |   ja    |    ja    |        ja       |        ja        |       ja        |
+    +--------------------------+----------+---------+--------------+--------------------+---------+---------+---------+----------+-----------------+------------------+-----------------+
+    |``participants``          |   nein   |    ja   |     nein     |        nein        |  nein   |  nein   |  nein   |   nein   |       nein      |       nein       |       nein      |
+    +--------------------------+----------+---------+--------------+--------------------+---------+---------+---------+----------+-----------------+------------------+-----------------+
+    |``participation_roles``   |   nein   |    ja   |     nein     |        nein        |  nein   |  nein   |  nein   |   nein   |       nein      |       nein       |       nein      |
+    +--------------------------+----------+---------+--------------+--------------------+---------+---------+---------+----------+-----------------+------------------+-----------------+
+    |``participations``        |   nein   |    ja   |     nein     |        nein        |  nein   |  nein   |  nein   |   nein   |       nein      |       nein       |       nein      |
     +--------------------------+----------+---------+--------------+--------------------+---------+---------+---------+----------+-----------------+------------------+-----------------+
     |``pdf_url``               |    ja    |   nein  |     nein     |        nein        |  nein   |  nein   |  nein   |   nein   |       nein      |       nein       |       nein      |
     +--------------------------+----------+---------+--------------+--------------------+---------+---------+---------+----------+-----------------+------------------+-----------------+

--- a/opengever/api/dossier_participations.py
+++ b/opengever/api/dossier_participations.py
@@ -3,8 +3,8 @@ from opengever.base.interfaces import IOpengeverBaseLayer
 from opengever.contact import is_contact_feature_enabled
 from opengever.contact.models import Participation
 from opengever.contact.sources import ContactsSource
-from opengever.dossier.behaviors.dossier import IDossierMarker
 from opengever.dossier.behaviors.participation import IParticipationAware
+from opengever.dossier.behaviors.participation import IParticipationAwareMarker
 from opengever.ogds.base.actor import ActorLookup
 from opengever.ogds.base.actor import ContactActor
 from opengever.ogds.base.actor import InboxActor
@@ -60,7 +60,7 @@ def get_plone_actor(participant_id):
 
 
 @implementer(IExpandableElement)
-@adapter(IDossierMarker, IOpengeverBaseLayer)
+@adapter(IParticipationAwareMarker, IOpengeverBaseLayer)
 class Participations(object):
     def __init__(self, context, request):
         self.context = context

--- a/opengever/api/dossier_participations.py
+++ b/opengever/api/dossier_participations.py
@@ -153,8 +153,7 @@ class ParticipationsPost(Service):
         if existing_participation:
             raise BadRequest("There is already a participation for {}".format(participant_id))
 
-        participation = handler.create_participation(**{"contact": participant_id, "roles": roles})
-        handler.append_participation(participation)
+        handler.add_participation(participant_id, roles)
 
     def add_sql_participation(self, participant_id, roles):
         participant = get_sql_participant(self.context, participant_id)

--- a/opengever/api/dossier_participations.py
+++ b/opengever/api/dossier_participations.py
@@ -158,7 +158,8 @@ class ParticipationsPost(ParticipationBaseService):
         return participant_id, roles
 
     def add_plone_participation(self, participant_id, roles):
-        get_plone_actor(participant_id)
+        with self.handle_errors():
+            self.handler.validate_participant(participant_id)
         if self.handler.has_participation(participant_id):
             raise BadRequest("There is already a participation for {}".format(
                 participant_id))
@@ -217,7 +218,8 @@ class ParticipationsPatch(ParticipationBaseService):
         return roles
 
     def update_plone_participation(self, participant_id, new_roles):
-        get_plone_actor(participant_id)
+        with self.handle_errors():
+            self.handler.validate_participant(participant_id)
         if not self.handler.has_participation(participant_id):
             raise BadRequest("{} has no participations on this context".format(
                 participant_id))
@@ -266,7 +268,8 @@ class ParticipationsDelete(ParticipationBaseService):
         return self.params[0]
 
     def delete_plone_participation(self, participant_id):
-        get_plone_actor(participant_id)
+        with self.handle_errors():
+            self.handler.validate_participant(participant_id)
         if not self.handler.has_participation(participant_id):
             raise BadRequest("{} has no participations on this context".format(
                 participant_id))

--- a/opengever/api/dossier_participations.py
+++ b/opengever/api/dossier_participations.py
@@ -115,6 +115,13 @@ class Participations(object):
         return result
 
 
+class ParticipationBaseService(Service):
+
+    def __init__(self, context, request):
+        super(ParticipationBaseService, self).__init__(context, request)
+        self.handler = IParticipationAware(self.context)
+
+
 class ParticipationsGet(Service):
     """API Endpoint which returns a list of all participations for the current
     dossier.
@@ -127,7 +134,7 @@ class ParticipationsGet(Service):
         return participations(expand=True)["participations"]
 
 
-class ParticipationsPost(Service):
+class ParticipationsPost(ParticipationBaseService):
     """API Endpoint to update an existing participation.
 
     POST /@participations HTTP/1.1
@@ -148,12 +155,11 @@ class ParticipationsPost(Service):
 
     def add_plone_participation(self, participant_id, roles):
         get_plone_actor(participant_id)
-        handler = IParticipationAware(self.context)
-        if handler.has_participation(participant_id):
+        if self.handler.has_participation(participant_id):
             raise BadRequest("There is already a participation for {}".format(
                 participant_id))
 
-        handler.add_participation(participant_id, roles)
+        self.handler.add_participation(participant_id, roles)
 
     def add_sql_participation(self, participant_id, roles):
         participant = get_sql_participant(self.context, participant_id)
@@ -178,7 +184,7 @@ class ParticipationsPost(Service):
         return None
 
 
-class ParticipationsPatch(Service):
+class ParticipationsPatch(ParticipationBaseService):
     """API Endpoint to update an existing participation.
 
     PATCH /@participations/peter.mueller HTTP/1.1
@@ -214,11 +220,10 @@ class ParticipationsPatch(Service):
 
     def update_plone_participation(self, participant_id, new_roles):
         get_plone_actor(participant_id)
-        handler = IParticipationAware(self.context)
-        if not handler.has_participation(participant_id):
+        if not self.handler.has_participation(participant_id):
             raise BadRequest("{} has no participations on this context".format(
                 participant_id))
-        handler.update_participation(participant_id, new_roles)
+        self.handler.update_participation(participant_id, new_roles)
 
     def update_sql_participation(self, participant_id, new_roles):
         participant = get_sql_participant(self.context, participant_id)
@@ -243,7 +248,7 @@ class ParticipationsPatch(Service):
         return None
 
 
-class ParticipationsDelete(Service):
+class ParticipationsDelete(ParticipationBaseService):
     """API Endpoint to update an existing participation.
 
     DELETE /@participations/peter.mueller HTTP/1.1
@@ -269,11 +274,10 @@ class ParticipationsDelete(Service):
 
     def delete_plone_participation(self, participant_id):
         get_plone_actor(participant_id)
-        handler = IParticipationAware(self.context)
-        if not handler.has_participation(participant_id):
+        if not self.handler.has_participation(participant_id):
             raise BadRequest("{} has no participations on this context".format(
                 participant_id))
-        handler.remove_participation(participant_id)
+        self.handler.remove_participation(participant_id)
 
     def delete_sql_participation(self, participant_id):
         participant = get_sql_participant(self.context, participant_id)

--- a/opengever/api/dossier_participations.py
+++ b/opengever/api/dossier_participations.py
@@ -157,27 +157,12 @@ class ParticipationsPost(ParticipationBaseService):
         validate_roles(self.context, roles)
         return participant_id, roles
 
-    def add_plone_participation(self, participant_id, roles):
-        with self.handle_errors():
-            self.handler.validate_participant(participant_id)
-        if self.handler.has_participation(participant_id):
-            raise BadRequest("There is already a participation for {}".format(
-                participant_id))
-
-        self.handler.add_participation(participant_id, roles)
-
-    def add_sql_participation(self, participant_id, roles):
-        with self.handle_errors():
-            self.handler.add_participation(participant_id, roles)
-
     def reply(self):
         # Disable CSRF protection
         alsoProvides(self.request, IDisableCSRFProtection)
         participant_id, roles = self.extract_data()
-        if is_contact_feature_enabled():
-            self.add_sql_participation(participant_id, roles)
-        else:
-            self.add_plone_participation(participant_id, roles)
+        with self.handle_errors():
+            self.handler.add_participation(participant_id, roles)
 
         self.request.response.setStatus(204)
         return None

--- a/opengever/api/dossier_participations.py
+++ b/opengever/api/dossier_participations.py
@@ -255,10 +255,7 @@ class ParticipationsDelete(ParticipationBaseService):
     def delete_plone_participation(self, participant_id):
         with self.handle_errors():
             self.handler.validate_participant(participant_id)
-        if not self.handler.has_participation(participant_id):
-            raise BadRequest("{} has no participations on this context".format(
-                participant_id))
-        self.handler.remove_participation(participant_id)
+            self.handler.remove_participation(participant_id)
 
     def delete_sql_participation(self, participant_id):
         with self.handle_errors():

--- a/opengever/api/dossier_participations.py
+++ b/opengever/api/dossier_participations.py
@@ -196,10 +196,7 @@ class ParticipationsPatch(ParticipationBaseService):
     def update_plone_participation(self, participant_id, new_roles):
         with self.handle_errors():
             self.handler.validate_participant(participant_id)
-        if not self.handler.has_participation(participant_id):
-            raise BadRequest("{} has no participations on this context".format(
-                participant_id))
-        self.handler.update_participation(participant_id, new_roles)
+            self.handler.update_participation(participant_id, new_roles)
 
     def update_sql_participation(self, participant_id, new_roles):
         with self.handle_errors():

--- a/opengever/api/dossier_participations.py
+++ b/opengever/api/dossier_participations.py
@@ -154,7 +154,7 @@ class ParticipationsPost(Service):
             raise BadRequest("There is already a participation for {}".format(participant_id))
 
         participation = handler.create_participation(**{"contact": participant_id, "roles": roles})
-        handler.append_participiation(participation)
+        handler.append_participation(participation)
 
     def add_sql_participation(self, participant_id, roles):
         participant = get_sql_participant(self.context, participant_id)

--- a/opengever/api/dossier_participations.py
+++ b/opengever/api/dossier_participations.py
@@ -195,7 +195,6 @@ class ParticipationsPatch(ParticipationBaseService):
 
     def update_plone_participation(self, participant_id, new_roles):
         with self.handle_errors():
-            self.handler.validate_participant(participant_id)
             self.handler.update_participation(participant_id, new_roles)
 
     def update_sql_participation(self, participant_id, new_roles):
@@ -242,7 +241,6 @@ class ParticipationsDelete(ParticipationBaseService):
 
     def delete_plone_participation(self, participant_id):
         with self.handle_errors():
-            self.handler.validate_participant(participant_id)
             self.handler.remove_participation(participant_id)
 
     def delete_sql_participation(self, participant_id):

--- a/opengever/api/dossier_participations.py
+++ b/opengever/api/dossier_participations.py
@@ -149,9 +149,9 @@ class ParticipationsPost(Service):
     def add_plone_participation(self, participant_id, roles):
         get_plone_actor(participant_id)
         handler = IParticipationAware(self.context)
-        existing_participation = handler.get_participation_by_contact_id(participant_id)
-        if existing_participation:
-            raise BadRequest("There is already a participation for {}".format(participant_id))
+        if handler.has_participation(participant_id):
+            raise BadRequest("There is already a participation for {}".format(
+                participant_id))
 
         handler.add_participation(participant_id, roles)
 
@@ -160,7 +160,8 @@ class ParticipationsPost(Service):
         query = participant.participation_class.query.by_participant(
             participant).by_dossier(self.context)
         if query.count():
-            raise BadRequest("There is already a participation for {}".format(participant_id))
+            raise BadRequest("There is already a participation for {}".format(
+                participant_id))
         participant.participation_class.create(
             participant=participant, dossier=self.context, roles=roles)
 
@@ -214,17 +215,18 @@ class ParticipationsPatch(Service):
     def update_plone_participation(self, participant_id, new_roles):
         get_plone_actor(participant_id)
         handler = IParticipationAware(self.context)
-        participation = handler.get_participation_by_contact_id(participant_id)
-        if not participation:
-            raise BadRequest("{} has no participations on this context".format(participant_id))
-        handler.update_participation(participation, new_roles)
+        if not handler.has_participation(participant_id):
+            raise BadRequest("{} has no participations on this context".format(
+                participant_id))
+        handler.update_participation(participant_id, new_roles)
 
     def update_sql_participation(self, participant_id, new_roles):
         participant = get_sql_participant(self.context, participant_id)
         participation = participant.participation_class.query.by_participant(
             participant).by_dossier(self.context).first()
         if not participation:
-            raise BadRequest("{} has no participations on this context".format(participant_id))
+            raise BadRequest("{} has no participations on this context".format(
+                participant_id))
         participation.update_roles(new_roles)
 
     def reply(self):
@@ -268,17 +270,18 @@ class ParticipationsDelete(Service):
     def delete_plone_participation(self, participant_id):
         get_plone_actor(participant_id)
         handler = IParticipationAware(self.context)
-        participation = handler.get_participation_by_contact_id(participant_id)
-        if not participation:
-            raise BadRequest("{} has no participations on this context".format(participant_id))
-        participation = handler.remove_participation(participation)
+        if not handler.has_participation(participant_id):
+            raise BadRequest("{} has no participations on this context".format(
+                participant_id))
+        handler.remove_participation(participant_id)
 
     def delete_sql_participation(self, participant_id):
         participant = get_sql_participant(self.context, participant_id)
         participation = participant.participation_class.query.by_participant(
             participant).by_dossier(self.context).first()
         if not participation:
-            raise BadRequest("{} has no participations on this context".format(participant_id))
+            raise BadRequest("{} has no participations on this context".format(
+                participant_id))
         participation.delete()
 
     def reply(self):

--- a/opengever/api/listing.py
+++ b/opengever/api/listing.py
@@ -159,6 +159,12 @@ class ListingGet(SolrQueryBaseService):
 
     def preprocess_filters(self, filters):
         filters = dict(filters)
+        if 'participations' in filters and ('participants' in filters or
+                                            'participation_roles' in filters):
+            raise BadRequest(
+                "Cannot set participations filter together with participants "
+                "or participation_roles filters.")
+
         if 'participants' in filters and 'participation_roles' in filters:
             helper = ParticipationIndexHelper()
             participant_id_filters = filters.pop('participants')

--- a/opengever/api/solr_query_service.py
+++ b/opengever/api/solr_query_service.py
@@ -164,6 +164,9 @@ class SimpleListingField(object):
     def index_value_to_label(self, value):
         return value
 
+    def hide_facet(self, facet):
+        return False
+
 
 class ListingField(SimpleListingField):
 
@@ -248,6 +251,9 @@ class ParticipantIdField(ParticipationsField):
         participant_id = self.helper.index_value_to_participant_id(value)
         return self.helper.participant_id_to_label(participant_id)
 
+    def hide_facet(self, facet):
+        return self.helper.index_value_to_role(facet) != self.helper.any_role_marker
+
 
 class ParticipationRoleField(ParticipationsField):
 
@@ -256,6 +262,9 @@ class ParticipationRoleField(ParticipationsField):
     def index_value_to_label(self, value):
         role = self.helper.index_value_to_role(value)
         return self.helper.role_to_label(role)
+
+    def hide_facet(self, facet):
+        return self.helper.index_value_to_participant_id(facet) != self.helper.any_participant_marker
 
 
 DEFAULT_SORT_INDEX = 'modified'
@@ -409,6 +418,8 @@ class SolrQueryBaseService(Service):
 
             facet_counts[facet_name] = {}
             for facet, count in solr_facet.items():
+                if field.hide_facet(facet):
+                    continue
                 facet_counts[field.field_name][facet] = {
                     "count": count,
                     "label": field.index_value_to_label(facet)

--- a/opengever/api/solr_query_service.py
+++ b/opengever/api/solr_query_service.py
@@ -1,4 +1,3 @@
-from opengever.base.vocabulary import wrap_vocabulary
 from copy import copy
 from copy import deepcopy
 from DateTime import DateTime
@@ -11,6 +10,8 @@ from opengever.base.helpers import display_name
 from opengever.base.solr import OGSolrContentListing
 from opengever.base.utils import get_preferred_language_code
 from opengever.base.utils import safe_int
+from opengever.base.vocabulary import wrap_vocabulary
+from opengever.dossier.indexers import ParticipationIndexHelper
 from opengever.globalindex.browser.report import task_type_helper as task_type_value_helper
 from opengever.task.helper import task_type_helper
 from plone import api
@@ -219,6 +220,44 @@ class DateListingField(SimpleListingField):
         return u'{}:({})'.format(filter_escape(self.index), value)
 
 
+class ParticipationsField(ListingField):
+
+    field_name = 'participations'
+
+    def __init__(self):
+        self.index = 'participations'
+        self.sort_index = self.index
+        self.additional_required_fields = []
+        self.helper = ParticipationIndexHelper()
+
+    def accessor(self, doc):
+        if not doc.get('participations'):
+            return
+        return list({self.index_value_to_label(participation)
+                     for participation in doc.get('participations')})
+
+    def index_value_to_label(self, value):
+        return self.helper.index_value_to_label(value)
+
+
+class ParticipantIdField(ParticipationsField):
+
+    field_name = 'participants'
+
+    def index_value_to_label(self, value):
+        participant_id = self.helper.index_value_to_participant_id(value)
+        return self.helper.participant_id_to_label(participant_id)
+
+
+class ParticipationRoleField(ParticipationsField):
+
+    field_name = 'participation_roles'
+
+    def index_value_to_label(self, value):
+        role = self.helper.index_value_to_role(value)
+        return self.helper.role_to_label(role)
+
+
 DEFAULT_SORT_INDEX = 'modified'
 
 DEFAULT_FIELDS = set([
@@ -244,6 +283,9 @@ FIELDS_WITH_MAPPING = [
     ListingField('issuer_fullname', 'issuer', 'issuer_fullname'),
     ListingField('keywords', 'Subject'),
     ListingField('mimetype', 'getContentType', sort_index='mimetype'),
+    ParticipationsField(),
+    ParticipantIdField(),
+    ParticipationRoleField(),
     ListingField('pdf_url', None, 'preview_pdf_url', DEFAULT_SORT_INDEX,
                  additional_required_fields=['bumblebee_checksum', 'path']),
     ListingField('preview_url', None, 'get_preview_frame_url', DEFAULT_SORT_INDEX,

--- a/opengever/api/tests/test_dossier_participations.py
+++ b/opengever/api/tests/test_dossier_participations.py
@@ -13,8 +13,7 @@ class PloneParticipationsHelper(object):
 
     def add_participation(self, context, participant_id, roles, browser=None):
         handler = IParticipationAware(context)
-        participation = handler.create_participation(**{"contact": participant_id, "roles": roles})
-        handler.append_participation(participation)
+        handler.add_participation(participant_id, roles)
 
 
 class SQLParticipationsHelper(object):

--- a/opengever/api/tests/test_dossier_participations.py
+++ b/opengever/api/tests/test_dossier_participations.py
@@ -1,12 +1,12 @@
 from ftw.builder.builder import Builder
 from ftw.builder.builder import create
 from ftw.testbrowser import browsing
+from opengever.base.model import create_session
 from opengever.dossier.behaviors.participation import IParticipationAware
 from opengever.ogds.base.actor import ActorLookup
 from opengever.testing import IntegrationTestCase
 from opengever.testing import SolrIntegrationTestCase
 import json
-import transaction
 
 
 class PloneParticipationsHelper(object):
@@ -248,7 +248,7 @@ class TestParticipationsPostWithContactFeatureEnabled(TestParticipationsPost):
         self.organization = create(Builder('organization').named('4teamwork AG'))
         self.org_role = create(Builder('org_role').having(
             person=self.person, organization=self.organization, function=u'Gute Fee'))
-        transaction.commit()
+        create_session().flush()
         self.valid_participant_id = 'person:{}'.format(self.person.id)
 
     @browsing
@@ -424,7 +424,7 @@ class TestParticipationsPatchWithContactFeatureEnabled(SQLParticipationsHelper,
         super(TestParticipationsPatchWithContactFeatureEnabled, self).setUp()
         self.person = create(Builder('person').having(
             firstname=u'Hans', lastname=u'M\xfcller'))
-        transaction.commit()
+        create_session().flush()
         self.participant_id = 'person:{}'.format(self.person.id)
         self.participant_title = self.person.get_title()
 
@@ -484,7 +484,7 @@ class TestParticipationsDeleteWithContactFeatureEnabled(SQLParticipationsHelper,
         super(TestParticipationsDeleteWithContactFeatureEnabled, self).setUp()
         self.person = create(Builder('person').having(
             firstname=u'Hans', lastname=u'M\xfcller'))
-        transaction.commit()
+        create_session().flush()
         self.participant_id = 'person:{}'.format(self.person.id)
         self.participant_title = self.person.get_title()
 

--- a/opengever/api/tests/test_dossier_participations.py
+++ b/opengever/api/tests/test_dossier_participations.py
@@ -406,7 +406,10 @@ class TestParticipationsPatch(IntegrationTestCase, PloneParticipationsHelper):
     @browsing
     def test_patch_participations_with_invalid_role_raises_bad_request(self, browser):
         self.login(self.regular_user, browser=browser)
-        url = u'{}/@participations/{}'.format(self.dossier.absolute_url(), self.participant_id)
+        url = u'{}/@participations/{}'.format(
+            self.dossier.absolute_url(), self.participant_id)
+        self.add_participation(
+            self.dossier, self.participant_id, ['regard'], browser=browser)
         with browser.expect_http_error(400):
             browser.open(url, method='PATCH', headers=self.api_headers,
                          data=json.dumps({'roles': ['regard', 'invalid']}))

--- a/opengever/api/tests/test_dossier_participations.py
+++ b/opengever/api/tests/test_dossier_participations.py
@@ -14,7 +14,7 @@ class PloneParticipationsHelper(object):
     def add_participation(self, context, participant_id, roles, browser=None):
         handler = IParticipationAware(context)
         participation = handler.create_participation(**{"contact": participant_id, "roles": roles})
-        handler.append_participiation(participation)
+        handler.append_participation(participation)
 
 
 class SQLParticipationsHelper(object):

--- a/opengever/api/tests/test_listing.py
+++ b/opengever/api/tests/test_listing.py
@@ -1147,3 +1147,29 @@ class TestPloneDossierParticipationsInListingWithRealSolr(SolrIntegrationTestCas
             [IUUID(self.dossier), IUUID(self.subdossier), IUUID(self.empty_dossier)],
             [item['UID'] for item in browser.json['items']])
 
+    @browsing
+    def test_dossier_participant_and_roles_filters_combine_with_and(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        role_filter = 'filters.participation_roles:record:list=any-participant|{}'
+        participant_filter = 'filters.participants:record:list={}|any-role'
+        query_string = '&'.join((
+            'name=dossiers',
+            participant_filter.format(self.dossier_responsible.getId()),
+        ))
+        view = '@listing?{}'.format(query_string)
+        browser.open(self.repository_root, view=view, headers=self.api_headers)
+
+        self.assertEqual(3, browser.json['items_total'])
+        self.assertItemsEqual(
+            [IUUID(self.dossier), IUUID(self.subdossier), IUUID(self.empty_dossier)],
+            [item['UID'] for item in browser.json['items']])
+
+        view = view + '&' + role_filter.format('regard')
+        browser.open(self.repository_root, view=view, headers=self.api_headers)
+
+        self.assertEqual(2, browser.json['items_total'])
+        self.assertItemsEqual(
+            [IUUID(self.dossier), IUUID(self.empty_dossier)],
+            [item['UID'] for item in browser.json['items']])
+

--- a/opengever/base/configure.zcml
+++ b/opengever/base/configure.zcml
@@ -417,6 +417,11 @@
       name="watchers"
       />
 
+  <adapter
+      factory=".indexes.participations"
+      name="participations"
+      />
+
   <utility factory=".sequence.SequenceNumber" />
 
   <adapter factory=".quickupload.OGQuickUploadCapableFileFactory" />

--- a/opengever/base/indexes.py
+++ b/opengever/base/indexes.py
@@ -101,3 +101,8 @@ def is_subdossier(obj):
 @indexer(IDexterityContent)
 def watchers(obj):
     return []
+
+
+@indexer(IDexterityContent)
+def participations(obj):
+    return []

--- a/opengever/contact/browser/configure.zcml
+++ b/opengever/contact/browser/configure.zcml
@@ -104,7 +104,7 @@
   <browser:page
       name="tabbedview_view-participations"
       for="*"
-      class=".participations.ParticpationTab"
+      class=".participations.ParticipationTab"
       permission="zope2.View"
       />
 

--- a/opengever/contact/browser/participation_forms.py
+++ b/opengever/contact/browser/participation_forms.py
@@ -70,6 +70,10 @@ class ParticipationAddForm(ModelAddForm):
                                        dossier=self.context,
                                        roles=data.pop('roles'))
 
+    def add(self, obj):
+        super(ParticipationAddForm, self).add(obj)
+        self.context.reindexObject(idxs=["participations", "UID"])
+
     def nextURL(self):
         return '{}#participations'.format(self.context.absolute_url())
 
@@ -102,6 +106,7 @@ class ParticipationEditForm(ModelEditForm):
 
     def applyChanges(self, data):
         self.model.update_roles(data.get('roles'))
+        self.model.resolve_dossier().reindexObject(idxs=["participations", "UID"])
 
     def nextURL(self):
         """Returns the url to the dossiers participation tab."""
@@ -129,6 +134,7 @@ class ParticipationRemoveForm(z3c.form.form.Form):
             return
 
         self.model.delete()
+        self.model.resolve_dossier().reindexObject(idxs=["participations", "UID"])
 
         api.portal.show_message(
             _(u'info_participation_removed', u'Participation removed'),

--- a/opengever/contact/browser/participations.py
+++ b/opengever/contact/browser/participations.py
@@ -67,7 +67,7 @@ class PersonParticipationsView(ParticipationsView):
         return Participation.query.by_person(self.context.model)
 
 
-class ParticpationTab(BrowserView, GeverTabMixin):
+class ParticipationTab(BrowserView, GeverTabMixin):
 
     show_searchform = False
 

--- a/opengever/contact/sources.py
+++ b/opengever/contact/sources.py
@@ -48,7 +48,11 @@ class ContactsSource(object):
         if not token:
             raise LookupError
 
-        term_type, term_id = token.split(':')
+        try:
+            term_type, term_id = token.split(':')
+        except ValueError:
+            raise LookupError
+
         term_id = term_id
         clazz = self.by_type[term_type]
         contact = clazz.query.get(term_id)

--- a/opengever/core/upgrades/20200925090651_migrate_participations/upgrade.py
+++ b/opengever/core/upgrades/20200925090651_migrate_participations/upgrade.py
@@ -33,6 +33,6 @@ class MigrateParticipations(UpgradeStep):
                 else:
                     contacts_and_roles[participation.contact] = set(participation.roles)
 
-            lst = PersistentList([handler.create_participation(contact=key, roles=value)
+            lst = PersistentList([handler.create_participation(participant_id=key, roles=value)
                                   for key, value in contacts_and_roles.items()])
             annotations[self.annotation_key] = lst

--- a/opengever/core/upgrades/20200925090651_migrate_participations/upgrade.py
+++ b/opengever/core/upgrades/20200925090651_migrate_participations/upgrade.py
@@ -3,6 +3,7 @@ from opengever.contact import is_contact_feature_enabled
 from opengever.dossier.behaviors.participation import IParticipationAware
 from opengever.dossier.behaviors.participation import IParticipationAwareMarker
 from persistent.list import PersistentList
+from zope.annotation.interfaces import IAnnotations
 
 
 class MigrateParticipations(UpgradeStep):
@@ -10,13 +11,19 @@ class MigrateParticipations(UpgradeStep):
     """
     deferrable = True
 
+    annotation_key = 'participations'
+
     def __call__(self):
         if is_contact_feature_enabled():
             return
         query = {'object_provides': IParticipationAwareMarker.__identifier__}
         for dossier in self.objects(query, 'Merge participations.'):
             handler = IParticipationAware(dossier)
-            old_participations = handler.get_participations()
+
+            annotations = IAnnotations(dossier)
+            old_participations = annotations.get(self.annotation_key,
+                                                 PersistentList())
+
             if not old_participations:
                 continue
             contacts_and_roles = dict()
@@ -28,4 +35,4 @@ class MigrateParticipations(UpgradeStep):
 
             lst = PersistentList([handler.create_participation(contact=key, roles=value)
                                   for key, value in contacts_and_roles.items()])
-            handler.set_participations(lst)
+            annotations[self.annotation_key] = lst

--- a/opengever/core/upgrades/20201008143927_store_plone_participations_in_persistent_dict/upgrade.py
+++ b/opengever/core/upgrades/20201008143927_store_plone_participations_in_persistent_dict/upgrade.py
@@ -1,0 +1,34 @@
+from ftw.upgrade import UpgradeStep
+from opengever.dossier.behaviors.participation import IParticipationAwareMarker
+from persistent.dict import PersistentDict
+from zope.annotation.interfaces import IAnnotations
+
+
+class StorePloneParticipationsInPersistentDict(UpgradeStep):
+    """Store plone participations in persistent dict.
+    """
+    deferrable = True
+    annotation_key = 'participations'
+
+    def __call__(self):
+        """We migrate all plone participations from PersistentList to
+        PersistenDict. We do not restrict the upgrade step to deployments
+        with the contact feature disabled, as it seems we did not migrate
+        the data when we switched STABS to the new contact implementation
+        and I don't want to leave unmigrated data behind
+        """
+        query = {'object_provides': IParticipationAwareMarker.__identifier__}
+        for dossier in self.objects(query, 'Merge participations.'):
+            annotations = IAnnotations(dossier)
+            if self.annotation_key not in annotations:
+                continue
+
+            participation_list = annotations.pop(self.annotation_key)
+            if not participation_list:
+                # No need to store an empty dictionnary
+                continue
+
+            participation_dict = PersistentDict()
+            for participation in participation_list:
+                participation_dict[participation.contact] = participation
+            annotations[self.annotation_key] = participation_dict

--- a/opengever/core/upgrades/20201008152233_add_and_index_participations_solr_field/upgrade.py
+++ b/opengever/core/upgrades/20201008152233_add_and_index_participations_solr_field/upgrade.py
@@ -1,0 +1,15 @@
+from ftw.upgrade import UpgradeStep
+from opengever.dossier.behaviors.participation import IParticipationAwareMarker
+
+
+class AddAndIndexParticipationsSolrField(UpgradeStep):
+    """Add and index participations solr field.
+    """
+    deferrable = True
+
+    def __call__(self):
+        query = {'object_provides': IParticipationAwareMarker.__identifier__}
+        for dossier in self.objects(query, 'Index participations field in solr.'):
+            # participations is only in solr, prevent reindexing all catalog
+            # indexes by picking a cheap catalog index `UID`.
+            dossier.reindexObject(idxs=['UID', 'participations'])

--- a/opengever/dossier/behaviors.zcml
+++ b/opengever/dossier/behaviors.zcml
@@ -20,7 +20,7 @@
       title="OpenGever Participation Aware"
       description="Enables participation support"
       provides=".behaviors.participation.IParticipationAware"
-      factory=".behaviors.participation.ParticipationHandler"
+      factory=".participations.ParticipationHandler"
       marker=".behaviors.participation.IParticipationAwareMarker"
       for="plone.dexterity.interfaces.IDexterityContent"
       />

--- a/opengever/dossier/behaviors/participation.py
+++ b/opengever/dossier/behaviors/participation.py
@@ -39,8 +39,13 @@ class PloneParticipationHandler(object):
         self.context = context
         self.annotations = IAnnotations(self.context)
 
-    def create_participation(self, *args, **kwargs):
-        p = Participation(*args, **kwargs)
+    def add_participation(self, participant_id, roles):
+        participation = self.create_participation(participant_id, roles)
+        self.append_participation(participation)
+        return participation
+
+    def create_participation(self, participant_id, roles):
+        p = Participation(participant_id, roles)
         return p
 
     def get_participations(self):

--- a/opengever/dossier/behaviors/participation.py
+++ b/opengever/dossier/behaviors/participation.py
@@ -8,7 +8,8 @@ from plone.supermodel import model
 from zope import schema
 from zope.annotation.interfaces import IAnnotations
 from zope.event import notify
-from zope.interface import Interface, implements
+from zope.interface import implements
+from zope.interface import Interface
 
 
 _marker = object()
@@ -29,10 +30,9 @@ class IParticipationAwareMarker(Interface):
     """
 
 
-class ParticipationHandler(object):
+class PloneParticipationHandler(object):
     """ IParticipationAware behavior / adpter factory
     """
-    implements(IParticipationAware)
     annotation_key = 'participations'
 
     def __init__(self, context):

--- a/opengever/dossier/behaviors/participation.py
+++ b/opengever/dossier/behaviors/participation.py
@@ -1,14 +1,10 @@
 from opengever.base.vocabulary import wrap_vocabulary
 from opengever.dossier import _
-from opengever.dossier import events
 from opengever.ogds.base.sources import UsersContactsInboxesSourceBinder
 from persistent import Persistent
-from persistent.dict import PersistentDict
 from persistent.list import PersistentList
 from plone.supermodel import model
 from zope import schema
-from zope.annotation.interfaces import IAnnotations
-from zope.event import notify
 from zope.interface import implements
 from zope.interface import Interface
 
@@ -30,72 +26,8 @@ class IParticipationAwareMarker(Interface):
     """ Marker interface for IParticipationAware behavior
     """
 
-
-class PloneParticipationHandler(object):
-    """ IParticipationAware behavior / adpter factory
-    """
-    annotation_key = 'participations'
-
-    def __init__(self, context):
-        self.context = context
-        self.annotations = IAnnotations(self.context)
-
-    def add_participation(self, participant_id, roles):
-        participation = self.create_participation(participant_id, roles)
-        self.append_participation(participation)
-        return participation
-
-    def create_participation(self, participant_id, roles):
-        p = Participation(participant_id, roles)
-        return p
-
-    @property
-    def _participations(self):
-        return self.annotations.get(self.annotation_key)
-
-    @_participations.setter
-    def _participations(self, value):
-        self.annotations[self.annotation_key] = value
-
-    def get_participations(self):
-        participations = self._participations or PersistentDict()
-        return participations.values()
-
-    def get_participation(self, participant_id):
-        return self._participations and self._participations.get(participant_id)
-
-    def update_participation(self, participant_id, roles):
-        if not self.has_participation(participant_id):
-            raise ValueError("{} has no participations on this context".format(
-                participant_id))
-        self._participations[participant_id].roles = roles
-        notify(events.ParticipationModified(
-            self.context, self._participations[participant_id]))
-
-    def append_participation(self, value):
-        if not IParticipation.providedBy(value):
-            raise TypeError('Excpected IParticipation object')
-
-        if self.has_participation(value.contact):
-            raise ValueError("There is already a participation for {}".format(
-                value.contact))
-
-        if self._participations is None:
-            self._participations = PersistentDict()
-        self._participations[value.contact] = value
-        notify(events.ParticipationCreated(self.context, value))
-
-    def has_participation(self, participant_id):
-        return self._participations and participant_id in self._participations
-
-    def remove_participation(self, participant_id, quiet=True):
-        if not quiet and not self.has_participation(participant_id):
-            raise ValueError('No participation for {}'.format(participant_id))
-        participation = self._participations.pop(participant_id)
-        notify(events.ParticipationRemoved(self.context, participation))
-
-
 # -------- model --------
+
 
 class IParticipation(model.Schema):
     """ Participation Form schema
@@ -120,8 +52,6 @@ class IParticipation(model.Schema):
         missing_value=[],
         default=[],
         )
-
-# --------- model class --------
 
 
 class Participation(Persistent):

--- a/opengever/dossier/behaviors/participation.py
+++ b/opengever/dossier/behaviors/participation.py
@@ -62,7 +62,7 @@ class ParticipationHandler(object):
             raise TypeError('Excpected PersistentList instance')
         self.annotations[self.annotation_key] = value
 
-    def append_participiation(self, value):
+    def append_participation(self, value):
         if not IParticipation.providedBy(value):
             raise TypeError('Excpected IParticipation object')
         if not self.has_participation(value):

--- a/opengever/dossier/behaviors/participation.py
+++ b/opengever/dossier/behaviors/participation.py
@@ -70,11 +70,15 @@ class PloneParticipationHandler(object):
     def append_participation(self, value):
         if not IParticipation.providedBy(value):
             raise TypeError('Excpected IParticipation object')
-        if not self.has_participation(value):
-            lst = self.get_participations()
-            lst.append(value)
-            self.set_participations(lst)
-            notify(events.ParticipationCreated(self.context, value))
+
+        if self.get_participation_by_contact_id(value.contact):
+            raise ValueError("There is already a participation for {}".format(
+                value.contact))
+
+        lst = self.get_participations()
+        lst.append(value)
+        self.set_participations(lst)
+        notify(events.ParticipationCreated(self.context, value))
 
     def has_participation(self, value):
         return value in self.get_participations()

--- a/opengever/dossier/browser/forms.py
+++ b/opengever/dossier/browser/forms.py
@@ -178,7 +178,7 @@ class ParticipationAddForm(Form):
                 status.addStatusMessage(msg, type='error')
             else:
                 part = phandler.create_participation(**data)
-                phandler.append_participiation(part)
+                phandler.append_participation(part)
                 msg = _(u'info_participation_create',
                         u'Participation created.')
                 status.addStatusMessage(msg, type='info')

--- a/opengever/dossier/browser/forms.py
+++ b/opengever/dossier/browser/forms.py
@@ -172,7 +172,7 @@ class ParticipationAddForm(Form):
         if not errors:
             phandler = IParticipationAware(self.context)
             status = IStatusMessage(self.request)
-            if phandler.get_participation_by_contact_id(data.get('contact')):
+            if phandler.has_participation(data.get('contact')):
                 msg = _(u'error_participant_already_exists',
                         default=u'There is already a participation for this contact.')
                 status.addStatusMessage(msg, type='error')
@@ -210,7 +210,7 @@ class DeleteParticipants(BrowserView):
         for a in oids:
             oid = base64.decodestring(a)
             obj = self.context._p_jar[oid]
-            phandler.remove_participation(obj)
+            phandler.remove_participation(obj.contact)
         status = IStatusMessage(self.request)
         msg = _(u'info_removed_participations',
                 'Removed participations.')

--- a/opengever/dossier/browser/forms.py
+++ b/opengever/dossier/browser/forms.py
@@ -177,8 +177,7 @@ class ParticipationAddForm(Form):
                         default=u'There is already a participation for this contact.')
                 status.addStatusMessage(msg, type='error')
             else:
-                part = phandler.create_participation(**data)
-                phandler.append_participation(part)
+                phandler.add_participation(data.get('contact'), data.get('roles'))
                 msg = _(u'info_participation_create',
                         u'Participation created.')
                 status.addStatusMessage(msg, type='info')

--- a/opengever/dossier/browser/overview.py
+++ b/opengever/dossier/browser/overview.py
@@ -127,9 +127,16 @@ class DossierOverview(BoxesViewMixin, BrowserView, GeverTabMixin):
             fl=fieldlist)
         return OGSolrContentListing(resp)
 
+    def _get_participations(self):
+        if not self.context.has_participation_support():
+            return []
+
+        phandler = IParticipationAware(self.context)
+        return phandler.get_participations()
+
     def sql_participations(self):
         participations = []
-        for participation in Participation.query.by_dossier(self.context):
+        for participation in self._get_participations():
             participant = participation.participant
             participations.append({
                 'getURL': participant.get_url(),
@@ -141,12 +148,7 @@ class DossierOverview(BoxesViewMixin, BrowserView, GeverTabMixin):
                       key=lambda participation: participation.get('Title'))
 
     def plone_participations(self):
-        if not self.context.has_participation_support():
-            return []
-
-        # get the participants
-        phandler = IParticipationAware(self.context)
-        results = list(phandler.get_participations())
+        results = list(self._get_participations())
 
         # also append the responsible
         class ResponsibleParticipant(object):

--- a/opengever/dossier/configure.zcml
+++ b/opengever/dossier/configure.zcml
@@ -184,6 +184,11 @@
       name="touched"
       />
 
+  <adapter
+      factory=".indexers.participations"
+      name="participations"
+      />
+
   <subscriber
       for="plone.dexterity.interfaces.IDexterityContent
            zope.lifecycleevent.interfaces.IObjectModifiedEvent"

--- a/opengever/dossier/configure.zcml
+++ b/opengever/dossier/configure.zcml
@@ -307,4 +307,7 @@
       name="execute-after-resolve-jobs"
       />
 
+  <adapter factory=".participations.PloneParticipationData" />
+  <adapter factory=".participations.SQLParticipationData" />
+
 </configure>

--- a/opengever/dossier/dossiertemplate/indexers.py
+++ b/opengever/dossier/dossiertemplate/indexers.py
@@ -1,11 +1,9 @@
 from collective import dexteritytextindexer
-from opengever.base.interfaces import IReferenceNumber
 from opengever.base.interfaces import ISequenceNumber
 from opengever.dossier.dossiertemplate.behaviors import IDossierTemplate
 from opengever.dossier.dossiertemplate.behaviors import IDossierTemplateMarker
 from plone.indexer import indexer
 from zope.component import adapter
-from zope.component import getAdapter
 from zope.component import getUtility
 from zope.interface import implementer
 

--- a/opengever/dossier/indexers.py
+++ b/opengever/dossier/indexers.py
@@ -262,6 +262,20 @@ class ParticipationIndexHelper(object):
             participant_id = self.any_participant_marker
         return u"{}|{}".format(participant_id, role)
 
+    def participations_to_index_value_list(self, participations):
+        index_value = set()
+
+        for participation in participations:
+            data = IParticipationData(participation)
+            index_value.add(self.participant_id_and_role_to_index_value(
+                participant_id=data.participant_id))
+            for role in data.roles:
+                index_value.add(self.participant_id_and_role_to_index_value(
+                    role=role))
+                index_value.add(self.participant_id_and_role_to_index_value(
+                    participant_id=data.participant_id, role=role))
+        return list(index_value)
+
     def role_to_label(self, role):
         if role == self.any_role_marker:
             return translate(_(u'any_role'), context=getRequest())
@@ -290,15 +304,4 @@ def participations(obj):
     phandler = IParticipationAware(obj)
     helper = ParticipationIndexHelper()
     participations = phandler.get_participations()
-    index_value = set()
-
-    for participation in participations:
-        data = IParticipationData(participation)
-        index_value.add(helper.participant_id_and_role_to_index_value(
-            participant_id=data.participant_id))
-        for role in data.roles:
-            index_value.add(helper.participant_id_and_role_to_index_value(
-                role=role))
-            index_value.add(helper.participant_id_and_role_to_index_value(
-                participant_id=data.participant_id, role=role))
-    return list(index_value)
+    return helper.participations_to_index_value_list(participations)

--- a/opengever/dossier/locales/de/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/de/LC_MESSAGES/opengever.dossier.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2020-09-29 16:20+0000\n"
+"POT-Creation-Date: 2020-10-12 14:36+0000\n"
 "PO-Revision-Date: 2017-05-23 04:53+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: German <https://translations.onegovgever.ch/projects/onegov-gever/opengever-dossier/de/>\n"
@@ -258,6 +258,14 @@ msgstr "Sie haben kein Element ausgewählt"
 msgid "additional_attributes"
 msgstr "Zusatzattribute"
 
+#: ./opengever/dossier/indexers.py
+msgid "any_participant"
+msgstr "Alle"
+
+#: ./opengever/dossier/indexers.py
+msgid "any_role"
+msgstr "Alle"
+
 #. Default: "Add"
 #: ./opengever/dossier/browser/forms.py
 msgid "button_add"
@@ -376,6 +384,7 @@ msgstr "Allgemein"
 #. Default: "Filing"
 #: ./opengever/dossier/behaviors/dossier.py
 #: ./opengever/dossier/behaviors/filing.py
+#: ./opengever/dossier/dossiertemplate/behaviors.py
 msgid "fieldset_filing"
 msgstr "Ablage"
 
@@ -469,6 +478,7 @@ msgid "help_filing_number"
 msgstr "Geben Sie die vollständige Ablagenummer an."
 
 #: ./opengever/dossier/behaviors/dossier.py
+#: ./opengever/dossier/dossiertemplate/behaviors.py
 msgid "help_keywords"
 msgstr ""
 "Schlagwörter zur Umschreibung eines Dossiers. Nicht zu verwechseln mit der Ordnungsposition.\n"
@@ -551,6 +561,7 @@ msgstr "Schliessen"
 #. Default: "Comments"
 #: ./opengever/dossier/behaviors/dossier.py
 #: ./opengever/dossier/browser/overview.py
+#: ./opengever/dossier/dossiertemplate/behaviors.py
 msgid "label_comments"
 msgstr "Kommentar"
 
@@ -673,6 +684,7 @@ msgstr "Journal"
 #. Default: "Keywords"
 #: ./opengever/dossier/behaviors/dossier.py
 #: ./opengever/dossier/browser/overview.py
+#: ./opengever/dossier/dossiertemplate/behaviors.py
 msgid "label_keywords"
 msgstr "Schlagwörter"
 

--- a/opengever/dossier/locales/fr/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/fr/LC_MESSAGES/opengever.dossier.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2020-09-29 16:20+0000\n"
+"POT-Creation-Date: 2020-10-12 14:36+0000\n"
 "PO-Revision-Date: 2017-12-03 11:16+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-dossier/fr/>\n"
@@ -256,6 +256,14 @@ msgstr "Aucun élément n'a été sélectionné"
 msgid "additional_attributes"
 msgstr "Attributs supplémentaires"
 
+#: ./opengever/dossier/indexers.py
+msgid "any_participant"
+msgstr "Tous"
+
+#: ./opengever/dossier/indexers.py
+msgid "any_role"
+msgstr "Tous"
+
 #. Default: "Add"
 #: ./opengever/dossier/browser/forms.py
 msgid "button_add"
@@ -374,6 +382,7 @@ msgstr "Général"
 #. Default: "Filing"
 #: ./opengever/dossier/behaviors/dossier.py
 #: ./opengever/dossier/behaviors/filing.py
+#: ./opengever/dossier/dossiertemplate/behaviors.py
 msgid "fieldset_filing"
 msgstr "Stockage"
 
@@ -467,6 +476,7 @@ msgid "help_filing_number"
 msgstr "Saisir le numéro d'inventaire complet."
 
 #: ./opengever/dossier/behaviors/dossier.py
+#: ./opengever/dossier/dossiertemplate/behaviors.py
 msgid "help_keywords"
 msgstr ""
 "Mots-clés pour la description du dossier. Ne pas confondre avec le numéro de classement.\n"
@@ -549,6 +559,7 @@ msgstr "Clôturer"
 #. Default: "Comments"
 #: ./opengever/dossier/behaviors/dossier.py
 #: ./opengever/dossier/browser/overview.py
+#: ./opengever/dossier/dossiertemplate/behaviors.py
 msgid "label_comments"
 msgstr "Commentaire"
 
@@ -671,6 +682,7 @@ msgstr "Historique"
 #. Default: "Keywords"
 #: ./opengever/dossier/behaviors/dossier.py
 #: ./opengever/dossier/browser/overview.py
+#: ./opengever/dossier/dossiertemplate/behaviors.py
 msgid "label_keywords"
 msgstr "Mots-clés"
 

--- a/opengever/dossier/locales/opengever.dossier.pot
+++ b/opengever/dossier/locales/opengever.dossier.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2020-09-29 16:20+0000\n"
+"POT-Creation-Date: 2020-10-12 14:36+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -257,6 +257,14 @@ msgstr ""
 msgid "additional_attributes"
 msgstr ""
 
+#: ./opengever/dossier/indexers.py
+msgid "any_participant"
+msgstr ""
+
+#: ./opengever/dossier/indexers.py
+msgid "any_role"
+msgstr ""
+
 #. Default: "Add"
 #: ./opengever/dossier/browser/forms.py
 msgid "button_add"
@@ -375,6 +383,7 @@ msgstr ""
 #. Default: "Filing"
 #: ./opengever/dossier/behaviors/dossier.py
 #: ./opengever/dossier/behaviors/filing.py
+#: ./opengever/dossier/dossiertemplate/behaviors.py
 msgid "fieldset_filing"
 msgstr ""
 
@@ -468,6 +477,7 @@ msgid "help_filing_number"
 msgstr ""
 
 #: ./opengever/dossier/behaviors/dossier.py
+#: ./opengever/dossier/dossiertemplate/behaviors.py
 msgid "help_keywords"
 msgstr ""
 
@@ -548,6 +558,7 @@ msgstr ""
 #. Default: "Comments"
 #: ./opengever/dossier/behaviors/dossier.py
 #: ./opengever/dossier/browser/overview.py
+#: ./opengever/dossier/dossiertemplate/behaviors.py
 msgid "label_comments"
 msgstr ""
 
@@ -670,6 +681,7 @@ msgstr ""
 #. Default: "Keywords"
 #: ./opengever/dossier/behaviors/dossier.py
 #: ./opengever/dossier/browser/overview.py
+#: ./opengever/dossier/dossiertemplate/behaviors.py
 msgid "label_keywords"
 msgstr ""
 

--- a/opengever/dossier/participations.py
+++ b/opengever/dossier/participations.py
@@ -112,6 +112,7 @@ class PloneParticipationHandler(ParticipationHandlerBase):
         return self._participations and self._participations.get(participant_id)
 
     def update_participation(self, participant_id, roles):
+        self.validate_participant(participant_id)
         self.validate_roles(roles)
         if not self.has_participation(participant_id):
             raise MissingParticipation(
@@ -137,6 +138,7 @@ class PloneParticipationHandler(ParticipationHandlerBase):
         return self._participations and participant_id in self._participations
 
     def remove_participation(self, participant_id):
+        self.validate_participant(participant_id)
         if not self.has_participation(participant_id):
             raise MissingParticipation(
                 "{} has no participations on this context".format(participant_id))

--- a/opengever/dossier/participations.py
+++ b/opengever/dossier/participations.py
@@ -5,6 +5,7 @@ from opengever.dossier import events
 from opengever.dossier.behaviors.participation import IParticipation
 from opengever.dossier.behaviors.participation import IParticipationAware
 from opengever.dossier.behaviors.participation import Participation
+from opengever.ogds.base.actor import ActorLookup
 from opengever.ogds.base.sources import UsersContactsInboxesSourceBinder
 from persistent.dict import PersistentDict
 from zope.annotation.interfaces import IAnnotations
@@ -155,8 +156,7 @@ class SQLParticipationHandler(ParticipationHandlerBase):
 
     def get_participations(self):
         query = SQLParticipation.query.by_dossier(self.context)
-        for participation in query:
-            yield participation
+        return query
 
     def get_participation(self, participant_id):
         participant = self.get_participant(participant_id)
@@ -217,6 +217,10 @@ class IParticipationData(Interface):
         """ Property returning the participant_id.
         """
 
+    def participant_title(self):
+        """ Property returning the participant title.
+        """
+
 
 @implementer(IParticipationData)
 @adapter(IParticipation)
@@ -232,6 +236,11 @@ class PloneParticipationData(object):
     @property
     def participant_id(self):
         return self._participation.contact
+
+    @property
+    def participant_title(self):
+        actor = ActorLookup(self._participation.contact).lookup()
+        return actor.get_label()
 
 
 @implementer(IParticipationData)
@@ -249,3 +258,7 @@ class SQLParticipationData(object):
     def participant_id(self):
         source = ContactsSource(self._participation.resolve_dossier())
         return source.getTerm(self._participation.participant).token
+
+    @property
+    def participant_title(self):
+        return self._participation.participant.get_title()

--- a/opengever/dossier/participations.py
+++ b/opengever/dossier/participations.py
@@ -65,6 +65,10 @@ class PloneParticipationHandler(object):
                 "{} is not a valid id".format(participant_id))
 
     def add_participation(self, participant_id, roles):
+        self.validate_participant(participant_id)
+        if self.has_participation(participant_id):
+            raise DupplicateParticipation(
+                "There is already a participation for {}".format(participant_id))
         participation = self.create_participation(participant_id, roles)
         self.append_participation(participation)
         return participation

--- a/opengever/dossier/participations.py
+++ b/opengever/dossier/participations.py
@@ -1,5 +1,10 @@
+from opengever.dossier import events
+from opengever.dossier.behaviors.participation import IParticipation
 from opengever.dossier.behaviors.participation import IParticipationAware
-from opengever.dossier.behaviors.participation import PloneParticipationHandler
+from opengever.dossier.behaviors.participation import Participation
+from persistent.dict import PersistentDict
+from zope.annotation.interfaces import IAnnotations
+from zope.event import notify
 from zope.interface import implements
 
 
@@ -12,3 +17,67 @@ class ParticipationHandler(object):
 
     def __getattr__(self, name):
         return getattr(self.handler, name)
+
+
+class PloneParticipationHandler(object):
+    """ IParticipationAware behavior / adapter factory.
+    """
+    annotation_key = 'participations'
+
+    def __init__(self, context):
+        self.context = context
+        self.annotations = IAnnotations(self.context)
+
+    def add_participation(self, participant_id, roles):
+        participation = self.create_participation(participant_id, roles)
+        self.append_participation(participation)
+        return participation
+
+    def create_participation(self, participant_id, roles):
+        p = Participation(participant_id, roles)
+        return p
+
+    @property
+    def _participations(self):
+        return self.annotations.get(self.annotation_key)
+
+    @_participations.setter
+    def _participations(self, value):
+        self.annotations[self.annotation_key] = value
+
+    def get_participations(self):
+        participations = self._participations or PersistentDict()
+        return participations.values()
+
+    def get_participation(self, participant_id):
+        return self._participations and self._participations.get(participant_id)
+
+    def update_participation(self, participant_id, roles):
+        if not self.has_participation(participant_id):
+            raise ValueError("{} has no participations on this context".format(
+                participant_id))
+        self._participations[participant_id].roles = roles
+        notify(events.ParticipationModified(
+            self.context, self._participations[participant_id]))
+
+    def append_participation(self, value):
+        if not IParticipation.providedBy(value):
+            raise TypeError('Excpected IParticipation object')
+
+        if self.has_participation(value.contact):
+            raise ValueError("There is already a participation for {}".format(
+                value.contact))
+
+        if self._participations is None:
+            self._participations = PersistentDict()
+        self._participations[value.contact] = value
+        notify(events.ParticipationCreated(self.context, value))
+
+    def has_participation(self, participant_id):
+        return self._participations and participant_id in self._participations
+
+    def remove_participation(self, participant_id, quiet=True):
+        if not quiet and not self.has_participation(participant_id):
+            raise ValueError('No participation for {}'.format(participant_id))
+        participation = self._participations.pop(participant_id)
+        notify(events.ParticipationRemoved(self.context, participation))

--- a/opengever/dossier/participations.py
+++ b/opengever/dossier/participations.py
@@ -1,0 +1,14 @@
+from opengever.dossier.behaviors.participation import IParticipationAware
+from opengever.dossier.behaviors.participation import PloneParticipationHandler
+from zope.interface import implements
+
+
+class ParticipationHandler(object):
+    implements(IParticipationAware)
+
+    def __init__(self, context):
+        self.context = context
+        self.handler = PloneParticipationHandler(context)
+
+    def __getattr__(self, name):
+        return getattr(self.handler, name)

--- a/opengever/dossier/participations.py
+++ b/opengever/dossier/participations.py
@@ -231,7 +231,8 @@ class PloneParticipationData(object):
 
     @property
     def roles(self):
-        return self._participation.roles
+        # persistent list cannot be json serialized
+        return list(self._participation.roles)
 
     @property
     def participant_id(self):

--- a/opengever/dossier/participations.py
+++ b/opengever/dossier/participations.py
@@ -5,6 +5,8 @@ from opengever.dossier import events
 from opengever.dossier.behaviors.participation import IParticipation
 from opengever.dossier.behaviors.participation import IParticipationAware
 from opengever.dossier.behaviors.participation import Participation
+from opengever.ogds.base.actor import ActorLookup
+from opengever.ogds.base.sources import UsersContactsInboxesSourceBinder
 from persistent.dict import PersistentDict
 from zope.annotation.interfaces import IAnnotations
 from zope.component import adapter
@@ -53,6 +55,14 @@ class PloneParticipationHandler(object):
     def __init__(self, context):
         self.context = context
         self.annotations = IAnnotations(self.context)
+
+    def validate_participant(self, participant_id):
+        source = UsersContactsInboxesSourceBinder()(self.context)
+        try:
+            source.getTermByToken(participant_id)
+        except LookupError:
+            raise InvalidParticipantId(
+                "{} is not a valid id".format(participant_id))
 
     def add_participation(self, participant_id, roles):
         participation = self.create_participation(participant_id, roles)

--- a/opengever/dossier/participations.py
+++ b/opengever/dossier/participations.py
@@ -116,9 +116,10 @@ class PloneParticipationHandler(object):
     def has_participation(self, participant_id):
         return self._participations and participant_id in self._participations
 
-    def remove_participation(self, participant_id, quiet=True):
-        if not quiet and not self.has_participation(participant_id):
-            raise ValueError('No participation for {}'.format(participant_id))
+    def remove_participation(self, participant_id):
+        if not self.has_participation(participant_id):
+            raise MissingParticipation(
+                "{} has no participations on this context".format(participant_id))
         participation = self._participations.pop(participant_id)
         notify(events.ParticipationRemoved(self.context, participation))
 

--- a/opengever/dossier/participations.py
+++ b/opengever/dossier/participations.py
@@ -95,8 +95,7 @@ class PloneParticipationHandler(ParticipationHandlerBase):
         return participation
 
     def create_participation(self, participant_id, roles):
-        p = Participation(participant_id, roles)
-        return p
+        return Participation(participant_id, roles)
 
     @property
     def _participations(self):
@@ -111,7 +110,9 @@ class PloneParticipationHandler(ParticipationHandlerBase):
         return participations.values()
 
     def get_participation(self, participant_id):
-        return self._participations and self._participations.get(participant_id)
+        if not self._participations:
+            return None
+        return self._participations.get(participant_id)
 
     def update_participation(self, participant_id, roles):
         self.validate_participant(participant_id)

--- a/opengever/dossier/participations.py
+++ b/opengever/dossier/participations.py
@@ -63,7 +63,7 @@ class ParticipationHandlerBase(object):
         available_roles = getVocabularyRegistry().get(context, "opengever.dossier.participation_roles")
         for role in roles:
             if role not in available_roles:
-                raise InvalidRole("Role '{}' does not exist".format(role))
+                raise InvalidRole(u"Role '{}' does not exist".format(role))
 
 
 class PloneParticipationHandler(ParticipationHandlerBase):
@@ -81,14 +81,14 @@ class PloneParticipationHandler(ParticipationHandlerBase):
             source.getTermByToken(participant_id)
         except LookupError:
             raise InvalidParticipantId(
-                "{} is not a valid id".format(participant_id))
+                u"{} is not a valid id".format(participant_id))
 
     def add_participation(self, participant_id, roles):
         self.validate_participant(participant_id)
         self.validate_roles(roles)
         if self.has_participation(participant_id):
             raise DupplicateParticipation(
-                "There is already a participation for {}".format(participant_id))
+                u"There is already a participation for {}".format(participant_id))
         participation = self.create_participation(participant_id, roles)
         self.append_participation(participation)
         self.context.reindexObject(idxs=["participations", "UID"])
@@ -118,7 +118,7 @@ class PloneParticipationHandler(ParticipationHandlerBase):
         self.validate_roles(roles)
         if not self.has_participation(participant_id):
             raise MissingParticipation(
-                "{} has no participations on this context".format(participant_id))
+                u"{} has no participations on this context".format(participant_id))
         self._participations[participant_id].roles = roles
         self.context.reindexObject(idxs=["participations", "UID"])
         notify(events.ParticipationModified(
@@ -130,7 +130,7 @@ class PloneParticipationHandler(ParticipationHandlerBase):
 
         if self.has_participation(value.contact):
             raise DupplicateParticipation(
-                "There is already a participation for {}".format(value.contact))
+                u"There is already a participation for {}".format(value.contact))
 
         if self._participations is None:
             self._participations = PersistentDict()
@@ -144,7 +144,7 @@ class PloneParticipationHandler(ParticipationHandlerBase):
         self.validate_participant(participant_id)
         if not self.has_participation(participant_id):
             raise MissingParticipation(
-                "{} has no participations on this context".format(participant_id))
+                u"{} has no participations on this context".format(participant_id))
         participation = self._participations.pop(participant_id)
         self.context.reindexObject(idxs=["participations", "UID"])
         notify(events.ParticipationRemoved(self.context, participation))
@@ -168,7 +168,7 @@ class SQLParticipationHandler(ParticipationHandlerBase):
         participation = query.one_or_none()
         if not participation:
             raise MissingParticipation(
-                "{} has no participations on this context".format(participant_id))
+                u"{} has no participations on this context".format(participant_id))
         return query.one_or_none()
 
     def has_participation(self, participant_id):
@@ -184,14 +184,14 @@ class SQLParticipationHandler(ParticipationHandlerBase):
             term = source.getTermByToken(participant_id)
         except LookupError:
             raise InvalidParticipantId(
-                "{} is not a valid id".format(participant_id))
+                u"{} is not a valid id".format(participant_id))
         return term.value
 
     def add_participation(self, participant_id, roles):
         self.validate_roles(roles)
         if self.has_participation(participant_id):
             raise DupplicateParticipation(
-                "There is already a participation for {}".format(participant_id))
+                u"There is already a participation for {}".format(participant_id))
 
         participant = self.get_participant(participant_id)
         participation = participant.participation_class.create(

--- a/opengever/dossier/participations.py
+++ b/opengever/dossier/participations.py
@@ -94,8 +94,8 @@ class PloneParticipationHandler(object):
 
     def update_participation(self, participant_id, roles):
         if not self.has_participation(participant_id):
-            raise ValueError("{} has no participations on this context".format(
-                participant_id))
+            raise MissingParticipation(
+                "{} has no participations on this context".format(participant_id))
         self._participations[participant_id].roles = roles
         notify(events.ParticipationModified(
             self.context, self._participations[participant_id]))
@@ -105,8 +105,8 @@ class PloneParticipationHandler(object):
             raise TypeError('Excpected IParticipation object')
 
         if self.has_participation(value.contact):
-            raise ValueError("There is already a participation for {}".format(
-                value.contact))
+            raise DupplicateParticipation(
+                "There is already a participation for {}".format(value.contact))
 
         if self._participations is None:
             self._participations = PersistentDict()

--- a/opengever/dossier/participations.py
+++ b/opengever/dossier/participations.py
@@ -91,6 +91,7 @@ class PloneParticipationHandler(ParticipationHandlerBase):
                 "There is already a participation for {}".format(participant_id))
         participation = self.create_participation(participant_id, roles)
         self.append_participation(participation)
+        self.context.reindexObject(idxs=["participations", "UID"])
         return participation
 
     def create_participation(self, participant_id, roles):
@@ -119,6 +120,7 @@ class PloneParticipationHandler(ParticipationHandlerBase):
             raise MissingParticipation(
                 "{} has no participations on this context".format(participant_id))
         self._participations[participant_id].roles = roles
+        self.context.reindexObject(idxs=["participations", "UID"])
         notify(events.ParticipationModified(
             self.context, self._participations[participant_id]))
 
@@ -144,6 +146,7 @@ class PloneParticipationHandler(ParticipationHandlerBase):
             raise MissingParticipation(
                 "{} has no participations on this context".format(participant_id))
         participation = self._participations.pop(participant_id)
+        self.context.reindexObject(idxs=["participations", "UID"])
         notify(events.ParticipationRemoved(self.context, participation))
 
 
@@ -191,17 +194,21 @@ class SQLParticipationHandler(ParticipationHandlerBase):
                 "There is already a participation for {}".format(participant_id))
 
         participant = self.get_participant(participant_id)
-        return participant.participation_class.create(
+        participation = participant.participation_class.create(
             participant=participant, dossier=self.context, roles=roles)
+        self.context.reindexObject(idxs=["participations", "UID"])
+        return participation
 
     def update_participation(self, participant_id, roles):
         self.validate_roles(roles)
         participation = self.get_participation(participant_id)
         participation.update_roles(roles)
+        self.context.reindexObject(idxs=["participations", "UID"])
 
     def remove_participation(self, participant_id):
         participation = self.get_participation(participant_id)
         participation.delete()
+        self.context.reindexObject(idxs=["participations", "UID"])
 
 
 class IParticipationData(Interface):

--- a/opengever/dossier/tests/test_overview.py
+++ b/opengever/dossier/tests/test_overview.py
@@ -145,7 +145,7 @@ class TestOverview(SolrIntegrationTestCase):
         handler = IParticipationAware(self.tested_dossier)
         participation = handler.create_participation(
             contact='kathi.barfuss', roles=['regard'])
-        handler.append_participiation(participation)
+        handler.append_participation(participation)
 
         browser.open(self.tested_dossier,
                      view='tabbedview_view-overview')

--- a/opengever/dossier/tests/test_overview.py
+++ b/opengever/dossier/tests/test_overview.py
@@ -143,9 +143,7 @@ class TestOverview(SolrIntegrationTestCase):
         self.login(self.regular_user, browser=browser)
 
         handler = IParticipationAware(self.tested_dossier)
-        participation = handler.create_participation(
-            contact='kathi.barfuss', roles=['regard'])
-        handler.append_participation(participation)
+        handler.add_participation('kathi.barfuss', ['regard'])
 
         browser.open(self.tested_dossier,
                      view='tabbedview_view-overview')

--- a/opengever/dossier/tests/test_participation.py
+++ b/opengever/dossier/tests/test_participation.py
@@ -43,21 +43,23 @@ class TestPloneParticipationHanlder(MockTestCase):
 
         # creation
         peter = handler.create_participation(
-            {'contact': 'peter', 'roles': ['Reader', ], })
-        sepp = handler.create_participation(
-            {'contact': 'sepp', 'roles': ['Reader', 'Editor'], })
+            participant_id='peter', roles=['Reader'])
         hugo = handler.create_participation(
-            {'contact': 'hugo'})
+            participant_id='hugo', roles=['Reader'])
+        self.assertEquals(handler.get_participations(), [])
 
         # test appending
         handler.append_participation(peter)
-        self.assertEquals(handler.get_participations(), [peter, ])
+        self.assertEquals(handler.get_participations(), [peter])
 
-        handler.append_participation(sepp)
+        # test adding
+        sepp = handler.add_participation(
+            participant_id='sepp', roles=['Reader', 'Editor'])
         self.assertEquals(handler.get_participations(), [peter, sepp])
 
         # an existing participation should not be addable multiple time
-        self.assertEquals(handler.append_participation(peter), None)
+        handler.append_participation(peter)
+        self.assertEquals(handler.get_participations(), [peter, sepp])
 
         # test has participation
         self.assertEquals(handler.has_participation(peter), True)
@@ -65,7 +67,7 @@ class TestPloneParticipationHanlder(MockTestCase):
 
         # test removing
         handler.remove_participation(peter)
-        self.assertEquals(handler.get_participations(), [sepp, ])
+        self.assertEquals(handler.get_participations(), [sepp])
 
 
 class TestParticipationAddForm(IntegrationTestCase):

--- a/opengever/dossier/tests/test_participation.py
+++ b/opengever/dossier/tests/test_participation.py
@@ -44,7 +44,7 @@ class TestPloneParticipationHanlder(MockTestCase):
         # creation
         peter = handler.create_participation(
             participant_id='peter', roles=['Reader'])
-        hugo = handler.create_participation(
+        handler.create_participation(
             participant_id='hugo', roles=['Reader'])
         self.assertEquals(handler.get_participations(), [])
 
@@ -55,20 +55,20 @@ class TestPloneParticipationHanlder(MockTestCase):
         # test adding
         sepp = handler.add_participation(
             participant_id='sepp', roles=['Reader', 'Editor'])
-        self.assertEquals(handler.get_participations(), [peter, sepp])
+        self.assertItemsEqual(handler.get_participations(), [peter, sepp])
 
         # adding a participation for a contact already having one is not allowed
         with self.assertRaises(ValueError):
             handler.add_participation(participant_id='peter', roles=['Editor'])
-        self.assertEquals(handler.get_participations(), [peter, sepp])
+        self.assertItemsEqual(handler.get_participations(), [peter, sepp])
 
         # test has participation
-        self.assertEquals(handler.has_participation(peter), True)
-        self.assertEquals(handler.has_participation(hugo), False)
+        self.assertEquals(handler.has_participation('peter'), True)
+        self.assertEquals(handler.has_participation('hugo'), False)
 
         # test removing
-        handler.remove_participation(peter)
-        self.assertEquals(handler.get_participations(), [sepp])
+        handler.remove_participation('peter')
+        self.assertItemsEqual(handler.get_participations(), [sepp])
 
 
 class TestParticipationAddForm(IntegrationTestCase):

--- a/opengever/dossier/tests/test_participation.py
+++ b/opengever/dossier/tests/test_participation.py
@@ -50,14 +50,14 @@ class TestParticipationHanlder(MockTestCase):
             {'contact': 'hugo'})
 
         # test appending
-        handler.append_participiation(peter)
+        handler.append_participation(peter)
         self.assertEquals(handler.get_participations(), [peter, ])
 
-        handler.append_participiation(sepp)
+        handler.append_participation(sepp)
         self.assertEquals(handler.get_participations(), [peter, sepp])
 
         # an existing participation should not be addable multiple time
-        self.assertEquals(handler.append_participiation(peter), None)
+        self.assertEquals(handler.append_participation(peter), None)
 
         # test has participation
         self.assertEquals(handler.has_participation(peter), True)

--- a/opengever/dossier/tests/test_participation.py
+++ b/opengever/dossier/tests/test_participation.py
@@ -57,8 +57,9 @@ class TestPloneParticipationHanlder(MockTestCase):
             participant_id='sepp', roles=['Reader', 'Editor'])
         self.assertEquals(handler.get_participations(), [peter, sepp])
 
-        # an existing participation should not be addable multiple time
-        handler.append_participation(peter)
+        # adding a participation for a contact already having one is not allowed
+        with self.assertRaises(ValueError):
+            handler.add_participation(participant_id='peter', roles=['Editor'])
         self.assertEquals(handler.get_participations(), [peter, sepp])
 
         # test has participation

--- a/opengever/dossier/tests/test_participation.py
+++ b/opengever/dossier/tests/test_participation.py
@@ -5,7 +5,7 @@ from ftw.testbrowser.pages.statusmessages import info_messages
 from ftw.testing import MockTestCase
 from mocker import ANY
 from opengever.core.testing import COMPONENT_UNIT_TESTING
-from opengever.dossier.behaviors.participation import PloneParticipationHandler
+from opengever.dossier.participations import PloneParticipationHandler
 from opengever.dossier.interfaces import IParticipationCreated
 from opengever.dossier.interfaces import IParticipationRemoved
 from opengever.testing import IntegrationTestCase

--- a/opengever/dossier/tests/test_participation.py
+++ b/opengever/dossier/tests/test_participation.py
@@ -5,7 +5,7 @@ from ftw.testbrowser.pages.statusmessages import info_messages
 from ftw.testing import MockTestCase
 from mocker import ANY
 from opengever.core.testing import COMPONENT_UNIT_TESTING
-from opengever.dossier.behaviors.participation import ParticipationHandler
+from opengever.dossier.behaviors.participation import PloneParticipationHandler
 from opengever.dossier.interfaces import IParticipationCreated
 from opengever.dossier.interfaces import IParticipationRemoved
 from opengever.testing import IntegrationTestCase
@@ -13,11 +13,11 @@ from zope.annotation.interfaces import IAnnotations
 from zope.interface import Interface
 
 
-class TestParticipationHanlder(MockTestCase):
+class TestPloneParticipationHanlder(MockTestCase):
     layer = COMPONENT_UNIT_TESTING
 
     def setUp(self):
-        super(TestParticipationHanlder, self).setUp()
+        super(TestPloneParticipationHanlder, self).setUp()
         self.context = self.mocker.mock()
 
         annonation_storage = {}
@@ -39,7 +39,7 @@ class TestParticipationHanlder(MockTestCase):
 
     def test_participation_with_handler(self):
         self.replay()
-        handler = ParticipationHandler(self.context)
+        handler = PloneParticipationHandler(self.context)
 
         # creation
         peter = handler.create_participation(

--- a/opengever/dossier/tests/test_participation_tab.py
+++ b/opengever/dossier/tests/test_participation_tab.py
@@ -2,7 +2,7 @@ from ftw.builder import Builder
 from ftw.builder import create
 from opengever.testing import FunctionalTestCase
 from plone.app.testing import TEST_USER_ID
-from opengever.dossier.behaviors.participation import ParticipationHandler
+from opengever.dossier.behaviors.participation import PloneParticipationHandler
 
 
 class TestParticipationTabbedview(FunctionalTestCase):
@@ -27,7 +27,7 @@ class TestParticipationTabbedview(FunctionalTestCase):
     def test_participants_text_filter(self):
         self.portal.REQUEST['searchable_text'] = 'sepp'
 
-        handler = ParticipationHandler(self.dossier)
+        handler = PloneParticipationHandler(self.dossier)
         sepp = handler.create_participation(
             contact='sepp', roles=['Reader', 'Editor'])
         handler.append_participation(sepp)

--- a/opengever/dossier/tests/test_participation_tab.py
+++ b/opengever/dossier/tests/test_participation_tab.py
@@ -2,7 +2,7 @@ from ftw.builder import Builder
 from ftw.builder import create
 from opengever.testing import FunctionalTestCase
 from plone.app.testing import TEST_USER_ID
-from opengever.dossier.behaviors.participation import PloneParticipationHandler
+from opengever.dossier.participations import PloneParticipationHandler
 
 
 class TestParticipationTabbedview(FunctionalTestCase):

--- a/opengever/dossier/tests/test_participation_tab.py
+++ b/opengever/dossier/tests/test_participation_tab.py
@@ -1,17 +1,9 @@
-from ftw.builder import Builder
-from ftw.builder import create
-from opengever.testing import FunctionalTestCase
-from plone.app.testing import TEST_USER_ID
-from opengever.dossier.participations import PloneParticipationHandler
+from opengever.dossier.behaviors.dossier import IDossier
+from opengever.dossier.behaviors.participation import IParticipationAware
+from opengever.testing import SolrIntegrationTestCase
 
 
-class TestParticipationTabbedview(FunctionalTestCase):
-
-    def setUp(self):
-        super(TestParticipationTabbedview, self).setUp()
-
-        self.dossier = create(Builder('dossier')
-                              .having(responsible=TEST_USER_ID))
+class TestParticipationTabbedview(SolrIntegrationTestCase):
 
     def get_tabbed_view(self, name):
         view = self.dossier.restrictedTraverse(name)
@@ -19,17 +11,33 @@ class TestParticipationTabbedview(FunctionalTestCase):
         return view
 
     def test_participants_includes_responsible(self):
+        self.login(self.regular_user)
+
+        handler = IParticipationAware(self.dossier)
+        self.assertEqual(0, len(handler.get_participations()))
+
         view = self.get_tabbed_view('tabbedview_view-participants')
         self.assertEqual(1, len(view.contents))
         responsible = view.contents[0]
-        self.assertEqual(TEST_USER_ID, responsible.contact)
+        self.assertEqual(IDossier(self.dossier).responsible, responsible.contact)
 
     def test_participants_text_filter(self):
-        self.portal.REQUEST['searchable_text'] = 'sepp'
-
-        handler = PloneParticipationHandler(self.dossier)
+        self.login(self.regular_user)
+        handler = IParticipationAware(self.dossier)
         handler.add_participation(
-            participant_id='sepp', roles=['Reader', 'Editor'])
+            participant_id=self.regular_user.id, roles=['Reader', 'Editor'])
+        handler.add_participation(
+            participant_id=self.secretariat_user.id, roles=['Reader', 'Editor'])
 
         view = self.get_tabbed_view('tabbedview_view-participants')
+        self.assertEqual(3, len(view.contents))
+        self.assertItemsEqual(
+            [self.regular_user.id, self.secretariat_user.id, self.dossier_responsible.id],
+            [participant.contact for participant in view.contents])
+
+        self.portal.REQUEST['searchable_text'] = 'kathi'
+        view = self.get_tabbed_view('tabbedview_view-participants')
         self.assertEqual(1, len(view.contents))
+        self.assertItemsEqual(
+            [self.regular_user.id],
+            [participant.contact for participant in view.contents])

--- a/opengever/dossier/tests/test_participation_tab.py
+++ b/opengever/dossier/tests/test_participation_tab.py
@@ -30,7 +30,7 @@ class TestParticipationTabbedview(FunctionalTestCase):
         handler = ParticipationHandler(self.dossier)
         sepp = handler.create_participation(
             contact='sepp', roles=['Reader', 'Editor'])
-        handler.append_participiation(sepp)
+        handler.append_participation(sepp)
 
         view = self.get_tabbed_view('tabbedview_view-participants')
         self.assertEqual(1, len(view.contents))

--- a/opengever/dossier/tests/test_participation_tab.py
+++ b/opengever/dossier/tests/test_participation_tab.py
@@ -28,9 +28,8 @@ class TestParticipationTabbedview(FunctionalTestCase):
         self.portal.REQUEST['searchable_text'] = 'sepp'
 
         handler = PloneParticipationHandler(self.dossier)
-        sepp = handler.create_participation(
-            contact='sepp', roles=['Reader', 'Editor'])
-        handler.append_participation(sepp)
+        handler.add_participation(
+            participant_id='sepp', roles=['Reader', 'Editor'])
 
         view = self.get_tabbed_view('tabbedview_view-participants')
         self.assertEqual(1, len(view.contents))

--- a/opengever/dossier/tests/test_participation_tab.py
+++ b/opengever/dossier/tests/test_participation_tab.py
@@ -25,9 +25,11 @@ class TestParticipationTabbedview(SolrIntegrationTestCase):
         self.login(self.regular_user)
         handler = IParticipationAware(self.dossier)
         handler.add_participation(
-            participant_id=self.regular_user.id, roles=['Reader', 'Editor'])
+            participant_id=self.regular_user.id,
+            roles=['participation', 'final-drawing'])
         handler.add_participation(
-            participant_id=self.secretariat_user.id, roles=['Reader', 'Editor'])
+            participant_id=self.secretariat_user.id,
+            roles=['participation', 'final-drawing'])
 
         view = self.get_tabbed_view('tabbedview_view-participants')
         self.assertEqual(3, len(view.contents))

--- a/opengever/testing/builders/sql.py
+++ b/opengever/testing/builders/sql.py
@@ -3,7 +3,6 @@ from datetime import timedelta
 from ftw.builder import Builder
 from ftw.builder import builder_registry
 from ftw.builder import create
-from opengever.base.browser.helper import get_css_class
 from opengever.base.model.favorite import Favorite
 from opengever.base.oguid import Oguid
 from opengever.contact.models import Address
@@ -54,7 +53,6 @@ from opengever.testing.model import TransparentModelLoader
 from plone import api
 from plone.locking.interfaces import ILockable
 from plone.registry.interfaces import IRegistry
-from plone.uuid.interfaces import IUUID
 from zope.component import getUtility
 import transaction
 

--- a/opengever/usermigration/tests/test_dossier_migrator.py
+++ b/opengever/usermigration/tests/test_dossier_migrator.py
@@ -107,8 +107,7 @@ class TestDossierMigratorForParticipants(FunctionalTestCase):
                               .titled(u'Testdossier'))
 
         self.phandler = IParticipationAware(self.dossier)
-        p = self.phandler.create_participation('old.participant', ['regard'])
-        self.phandler.append_participation(p)
+        self.phandler.add_participation('old.participant', ['regard'])
 
     def test_dossier_participation_gets_migrated(self):
 
@@ -127,8 +126,7 @@ class TestDossierMigratorForParticipants(FunctionalTestCase):
                                  lastname='old'))
 
         # Create a participation using that contact
-        p = self.phandler.create_participation(contact.contactid(), ['regard'])
-        self.phandler.append_participation(p)
+        self.phandler.add_participation(contact.contactid(), ['regard'])
 
         migrator = DossierMigrator(self.portal, {contact.id: 'new'}, 'move')
         migrator.migrate()

--- a/opengever/usermigration/tests/test_dossier_migrator.py
+++ b/opengever/usermigration/tests/test_dossier_migrator.py
@@ -108,7 +108,7 @@ class TestDossierMigratorForParticipants(FunctionalTestCase):
 
         self.phandler = IParticipationAware(self.dossier)
         p = self.phandler.create_participation('old.participant', ['regard'])
-        self.phandler.append_participiation(p)
+        self.phandler.append_participation(p)
 
     def test_dossier_participation_gets_migrated(self):
 
@@ -128,7 +128,7 @@ class TestDossierMigratorForParticipants(FunctionalTestCase):
 
         # Create a participation using that contact
         p = self.phandler.create_participation(contact.contactid(), ['regard'])
-        self.phandler.append_participiation(p)
+        self.phandler.append_participation(p)
 
         migrator = DossierMigrator(self.portal, {contact.id: 'new'}, 'move')
         migrator.migrate()

--- a/solr-conf/managed-schema
+++ b/solr-conf/managed-schema
@@ -169,6 +169,7 @@
     <field name="task_type" type="string" indexed="true" stored="false" />
     <field name="trashed" type="boolean" indexed="true" stored="false" />
     <field name="watchers" type="string" indexed="true" stored="false" multiValued="true"/>
+    <field name="participations" type="string" indexed="true" stored="true" multiValued="true"/>
 
     <!-- PHVS specific fields -->
     <field name="language" type="string" indexed="true" stored="true" />


### PR DESCRIPTION
In this PR we add dossier participations to the listing endpoint. To avoid adding even more conditionals to treat SQL and Plone participations separately, we refactor the participations by:
- adding a `ParticipationHandler`, which abstracts the treatment of SQL and Plone participations. 
- adding new `IParticipationData` adapters, harmonising data access on the Plone and SQL participations.
- moving error handling to the `ParticipationHandler`s, trying to ensure that the same validation is done when adding participations TTW or over the REST-API
- Use a `PersistentDict` instead of a `PersistentList` to store Plone participations in the annotations. This allows to simplify access to a given participation and enforce uniqueness.

These refactorings allow us to largely simplify the `@participations` endpoints and tests.

We also correct several other small issues discovered along the way, notably correctly registering the `participations` expansion, which was failing when requested on a private dossier.

We then add a new solr field and index to allow getting the participations in the listing endpoint. Because participations are a combination of `roles` and `participant_id` the index is a multivalued `string` index (allowing exact matches when querying solr) with each string of the form `participant_id|role` (e.g. `ogds_user:elio.schmutz|final-drawing`). As we want to be able to filter for a given `participant_id` or a given `role`, we also add strings of the type `participant_id|any-role` and `any-participant|role`.
Because the index data is rather complex we add a helper class `ParticipationIndexHelper` to transform the index data to human readable labels and to create the index data from `roles` and `participant_id`s

As we do not want the frontend to have to know how participations are indexed, we expose two separate fields in the listing endpoint `participants` and `participation_roles`. These fields will return only relevant facets and can be filtered independently. The filters get combined together in the backend, so that filtering for 2 participants and 2 roles will filter the participations for any combination of the participants and roles, so return dossier where any of the 2 participants has a participation with any of the 2 roles.

We also directly expose the `participations` field. This would allow directly filtering for specific combinations of users and roles.

Note that there is no easy way of only displaying facets for these filters that will return a non-empty result set. This is because the facets are determined from all available roles and participants on the listed dossier, while the filters get then combined with `AND` in the backend.

For https://4teamwork.atlassian.net/browse/CA-17

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


## Checklist (if applicable)

_Only applicable should be left and checked._

- API change:
  - [x] Documentation is updated
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- Upgrade steps (changes in profile):
  - [x] Make it deferrable if possible
  - [x] Execute as much as possible conditionally
- New translations
  - [x] All msg-strings are unicode