### PR TITLE
Add Cadwork mimetypes

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -17,6 +17,7 @@ Changelog
 - Don't resolve or deactivate a dossier if it is linked to an active workspace. [tinagerber]
 - Provides the IVocabularyTokenized interface for elephant vocabularies. [elioschmutz]
 - Customize @groups endpoints to handle OGDS. [njohner]
+- Add Cadwork mimetypes and enable editing with Office Connector. [buchi]
 
 
 2020.10.0 (2020-09-25)

--- a/opengever/core/upgrades/20200930131957_add_cadwork_mime_types/mimetypes.xml
+++ b/opengever/core/upgrades/20200930131957_add_cadwork_mime_types/mimetypes.xml
@@ -1,0 +1,91 @@
+<object name="mimetypes_registry" meta_type="MimeTypes Registry">
+  <mimetype
+      name="Cadwork 2d"
+      binary="True"
+      extensions="2d"
+      globs="*.2d"
+      icon_path="application.png"
+      mimetypes="application/x-cadwork-2d"
+      />
+
+  <mimetype
+      name="Cadwork catalog 2d"
+      binary="True"
+      extensions="2dc"
+      globs="*.2dc"
+      icon_path="application.png"
+      mimetypes="application/x-cadwork-catalog-2d"
+      />
+
+  <mimetype
+      name="Cadwork 2dl lines"
+      binary="True"
+      extensions="2dl"
+      globs="*.2dl"
+      icon_path="application.png"
+      mimetypes="application/x-cadwork-2d-lines"
+      />
+
+  <mimetype
+      name="Cadwork 2dm"
+      binary="True"
+      extensions="2dm"
+      globs="*.2dm"
+      icon_path="application.png"
+      mimetypes="application/x-cadwork-2dm"
+      />
+
+  <mimetype
+      name="Cadwork 2dr"
+      binary="True"
+      extensions="2dr"
+      globs="*.2dr"
+      icon_path="application.png"
+      mimetypes="application/x-cadwork-2dr"
+      />
+
+  <mimetype
+      name="Cadwork 3d"
+      binary="True"
+      extensions="3d"
+      globs="*.3d"
+      icon_path="application.png"
+      mimetypes="application/x-cadwork-3d"
+      />
+
+  <mimetype
+      name="Cadwork catalog 3d"
+      binary="True"
+      extensions="3dc"
+      globs="*.3dc"
+      icon_path="application.png"
+      mimetypes="application/x-cadwork-catalog-3d"
+      />
+
+  <mimetype
+      name="Cadwork Lexoview"
+      binary="True"
+      extensions="iv ivx ivz"
+      globs="*.iv *.ivx *.ivz"
+      icon_path="application.png"
+      mimetypes="application/x-cadwork-lexoview"
+      />
+
+  <mimetype
+      name="Cadwork Lexo2D"
+      binary="True"
+      extensions="l2d lx2d"
+      globs="*.l2d *.lx2d"
+      icon_path="application.png"
+      mimetypes="application/x-cadwork-lexo2d"
+      />
+
+  <mimetype
+      name="Cadwork Lexocad"
+      binary="True"
+      extensions="lxz"
+      globs="*.lxz"
+      icon_path="application.png"
+      mimetypes="application/x-cadwork-lexocad"
+      />
+</object>

--- a/opengever/core/upgrades/20200930131957_add_cadwork_mime_types/upgrade.py
+++ b/opengever/core/upgrades/20200930131957_add_cadwork_mime_types/upgrade.py
@@ -1,0 +1,39 @@
+from ftw.upgrade import UpgradeStep
+
+CADWORK_EXTENSIONS = [
+    '.2d',
+    '.2dc',
+    '.2dl',
+    '.2dm',
+    '.2dr',
+    '.3d',
+    '.3dc',
+    '.iv',
+    '.ivx',
+    '.ivz',
+    '.l2d',
+    '.lx2d',
+    '.lxz',
+]
+
+
+class AddCadworkMimeTypes(UpgradeStep):
+    """Add cadwork mime types.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()
+
+        mtr = self.getToolByName('mimetypes_registry')
+
+        for obj in self.objects(
+            {
+                'portal_type': 'opengever.document.document',
+                'file_extension': CADWORK_EXTENSIONS,
+            },
+            'Set Cadwork mimetypes'
+        ):
+            mt = mtr.lookupExtension(obj.file.filename)
+            obj.file.contentType = mt.mimetypes[0]
+            # Update catalog metadata (getContentType)
+            obj.reindexObject(idxs=['filename'])

--- a/opengever/officeconnector/mimetypes.py
+++ b/opengever/officeconnector/mimetypes.py
@@ -14,6 +14,17 @@ EDITABLE_TYPES = [
     'application/x-iwork-numbers-sffnumbers',
     # Apple Pages
     'application/x-iwork-pages-sffpages',
+    # CADwork
+    'application/x-cadwork-2d-lines',
+    'application/x-cadwork-2d',
+    'application/x-cadwork-2dm',
+    'application/x-cadwork-2dr',
+    'application/x-cadwork-3d',
+    'application/x-cadwork-catalog-2d',
+    'application/x-cadwork-catalog-3d',
+    'application/x-cadwork-lexo2d',
+    'application/x-cadwork-lexocad',
+    'application/x-cadwork-lexoview',
     # Images - MS Paint or Adobe Photoshop
     'image/bmp',
     'image/gif',

--- a/opengever/policy/base/profiles/mimetype/mimetypes.xml
+++ b/opengever/policy/base/profiles/mimetype/mimetypes.xml
@@ -677,6 +677,97 @@
       mimetypes="application/x-iwork-pages-sffpages"
       />
 
+  <!-- Cadwork -->
+  <mimetype
+      name="Cadwork 2d"
+      binary="True"
+      extensions="2d"
+      globs="*.2d"
+      icon_path="application.png"
+      mimetypes="application/x-cadwork-2d"
+      />
+
+  <mimetype
+      name="Cadwork catalog 2d"
+      binary="True"
+      extensions="2dc"
+      globs="*.2dc"
+      icon_path="application.png"
+      mimetypes="application/x-cadwork-catalog-2d"
+      />
+
+  <mimetype
+      name="Cadwork 2dl lines"
+      binary="True"
+      extensions="2dl"
+      globs="*.2dl"
+      icon_path="application.png"
+      mimetypes="application/x-cadwork-2d-lines"
+      />
+
+  <mimetype
+      name="Cadwork 2dm"
+      binary="True"
+      extensions="2dm"
+      globs="*.2dm"
+      icon_path="application.png"
+      mimetypes="application/x-cadwork-2dm"
+      />
+
+  <mimetype
+      name="Cadwork 2dr"
+      binary="True"
+      extensions="2dr"
+      globs="*.2dr"
+      icon_path="application.png"
+      mimetypes="application/x-cadwork-2dr"
+      />
+
+  <mimetype
+      name="Cadwork 3d"
+      binary="True"
+      extensions="3d"
+      globs="*.3d"
+      icon_path="application.png"
+      mimetypes="application/x-cadwork-3d"
+      />
+
+  <mimetype
+      name="Cadwork catalog 3d"
+      binary="True"
+      extensions="3dc"
+      globs="*.3dc"
+      icon_path="application.png"
+      mimetypes="application/x-cadwork-catalog-3d"
+      />
+
+  <mimetype
+      name="Cadwork Lexoview"
+      binary="True"
+      extensions="iv ivx ivz"
+      globs="*.iv *.ivx *.ivz"
+      icon_path="application.png"
+      mimetypes="application/x-cadwork-lexoview"
+      />
+
+  <mimetype
+      name="Cadwork Lexo2D"
+      binary="True"
+      extensions="l2d lx2d"
+      globs="*.l2d *.lx2d"
+      icon_path="application.png"
+      mimetypes="application/x-cadwork-lexo2d"
+      />
+
+  <mimetype
+      name="Cadwork Lexocad"
+      binary="True"
+      extensions="lxz"
+      globs="*.lxz"
+      icon_path="application.png"
+      mimetypes="application/x-cadwork-lexocad"
+      />
+
   <!-- Various other file formats -->
 
   <mimetype


### PR DESCRIPTION
Register mimetypes for Cadwork in mimetypes registry and add them to the editable types of Office Connector.

These are not official IANA mimetypes.

JIRA: https://4teamwork.atlassian.net/browse/CA-974


## Checklist (Must have)

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
