### PR TITLE
Don't prevent adding document with docprop issues.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,8 @@ Changelog
 
 - @ogds-users, @ogds-groups, @ogds-user-listing and @ogds-group-listing are now registered on the plone siteroot instead the contact-folder. [elioschmutz]
 - Add dossiertemplates, tasktemplates and tasktemplatefolders to @listing endpoint. [tinagerber]
+- No longer prevent adding documents with doc-property update issues. [deiferni]
+- Add tasktemplates and tasktemplatefolders to @listing endpoint. [tinagerber]
 - Bump `ftw.catalogdoctor` to `1.1.0` which provides fixes for additional health problems. [deiferni]
 - Prevent setting invalid reference prefix number via API. [deiferni]
 - Remove IDossier baseclass from IDossierTemplate to fix API for dossier templates. [njohner]

--- a/opengever/document/handlers.py
+++ b/opengever/document/handlers.py
@@ -50,7 +50,7 @@ def document_moved_or_added(context, event):
     if IObjectAddedEvent.providedBy(event):
         # Be strict when adding new documents to GEVER, lenient on moving
         # ones that already made it into the system
-        _update_docproperties(context, raise_on_error=True)
+        _update_docproperties(context, raise_on_error=False)
     else:
         _update_docproperties(context, raise_on_error=False)
 

--- a/opengever/document/tests/test_handlers.py
+++ b/opengever/document/tests/test_handlers.py
@@ -1,6 +1,5 @@
 from datetime import datetime
 from docx import Document
-from docx.opc.exceptions import PackageNotFoundError
 from docxcompose.properties import CustomProperties
 from ftw.builder import Builder
 from ftw.builder import create
@@ -293,16 +292,14 @@ class TestHandlers(FunctionalTestCase):
         moved_doc = self.target_dossier.getFirstChild()
         self.assertEqual('Invalid DOCX', moved_doc.title)
 
-    def test_failure_to_update_docprops_does_block_creation_of_new_doc(self):
-        with self.assertRaises(PackageNotFoundError):
-            create(
-                Builder('document')
-                .within(self.dossier)
-                .titled("Invalid DOCX")
-                .attach_file_containing('foo', u'invalid.docx'))
-
-    def test_failure_to_update_docprops_does_block_copying(self):
+    def test_failure_to_update_docprops_doesnt_block_creation_of_new_doc(self):
         invalid_docx = self.create_invalid_docx()
-        with self.assertRaises(PackageNotFoundError):
-            api.content.copy(source=invalid_docx,
-                             target=self.target_dossier)
+        self.assertEqual('Invalid DOCX', invalid_docx.title)
+
+    def test_failure_to_update_docprops_doesnt_block_copying(self):
+        invalid_docx = self.create_invalid_docx()
+        copied = api.content.copy(source=invalid_docx,
+                                  target=self.target_dossier)
+
+        self.assertEqual('copy of Invalid DOCX', copied.title)
+


### PR DESCRIPTION
No longer prevent adding documents with doc-property update issues. There are currently problems with python-docx when it attempts to parse bookmark references, which seem to be valid in word but will cause an error when the document is parsed. It will fail with the following traceback:

```
  File "/Users/deif/Files/workspaces/opengever.core/opengever/document/handlers.py", line 60, in _update_docproperties
    DocPropertyWriter(document).update()
  File "/Users/deif/Files/workspaces/opengever.core/opengever/document/docprops.py", line 95, in update
    if self.update_doc_properties(only_existing=True):
  File "/Users/deif/Files/workspaces/opengever.core/opengever/document/docprops.py", line 118, in update_doc_properties
    return self.write_properties(only_existing, self.get_properties())
  File "/Users/deif/Files/workspaces/opengever.core/opengever/document/docprops.py", line 124, in write_properties
    doc = Document(tmpfile.path)
  File "/usr/local/lib/python2.7/site-packages/docx/api.py", line 25, in Document
    document_part = Package.open(docx).main_document_part
  File "/usr/local/lib/python2.7/site-packages/docx/opc/package.py", line 128, in open
    pkg_reader = PackageReader.from_file(pkg_file)
  File "/usr/local/lib/python2.7/site-packages/docx/opc/pkgreader.py", line 36, in from_file
    phys_reader, pkg_srels, content_types
  File "/usr/local/lib/python2.7/site-packages/docx/opc/pkgreader.py", line 69, in _load_serialized_parts
    for partname, blob, reltype, srels in part_walker:
  File "/usr/local/lib/python2.7/site-packages/docx/opc/pkgreader.py", line 110, in _walk_phys_parts
    for partname, blob, reltype, srels in next_walker:
  File "/usr/local/lib/python2.7/site-packages/docx/opc/pkgreader.py", line 105, in _walk_phys_parts
    blob = phys_reader.blob_for(partname)
  File "/usr/local/lib/python2.7/site-packages/docx/opc/phys_pkg.py", line 108, in blob_for
    return self._zipf.read(pack_uri.membername)
  File "/usr/local/Cellar/python@2/2.7.18/Frameworks/Python.framework/Versions/2.7/lib/python2.7/zipfile.py", line 958, in read
    return self.open(name, "r", pwd).read()
  File "/usr/local/Cellar/python@2/2.7.18/Frameworks/Python.framework/Versions/2.7/lib/python2.7/zipfile.py", line 984, in open
    zinfo = self.getinfo(name)
  File "/usr/local/Cellar/python@2/2.7.18/Frameworks/Python.framework/Versions/2.7/lib/python2.7/zipfile.py", line 932, in getinfo
    'There is no item named %r in the archive' % name)
KeyError: "There is no item named 'word/#INFONeueUebersichtZiele' in the archive"
```

The cause of that error seem to be references to bookmarks in `document.xml.rels`, e.g:

```
<Relationship Id="rId18" Target="#INFONeueUebersichtZiele" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink"/>
```

They reference bookmarks in `document.xml`, e.g:
```
<w:bookmarkStart w:id="14" w:name="INFONeueUebersichtZiele"/>
```

IMO that is a valid reference, but https://github.com/python-openxml/python-docx seems to fail when attempting to load a document containing such references. As a fix in the package is out of our hands and there is an ongoing discussion related to bookmakrs since 2017 in https://github.com/python-openxml/python-docx/issues/425 instead i suggest in this PR to allow adding such documents.

In any case the check we perform can easily be side-stepped by adding an empty word and then replacing its contents when in checked out state.

This change will cause issues to be logged to sentry. We can always decide to re-enable the restriction if errors get out of hand.

Jira: https://4teamwork.atlassian.net/browse/CA-770

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
