### PR TITLE
Manage groups in teamraum

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,7 @@ Changelog
 2020.12.0 (unreleased)
 ----------------------
 
-- Nothing changed yet.
+- Allow assigning groups as participants to a Teamraum [elioschmutz]
 
 
 2020.11.0 (2020-10-07)

--- a/docs/public/dev-manual/api/workspace/participation.rst
+++ b/docs/public/dev-manual/api/workspace/participation.rst
@@ -5,6 +5,15 @@ Teamraum Beteiligungen
 
 Der ``@participations`` Endpoint behandelt Teamraum Beteiligungen.
 
+Eine Beteiligung an einem Teamraum bedeutet, dass ein bestimmter Benutzer oder
+eine bestimmte Gruppe zugriff auf einen Teaumraum hat. Je nach Beteiligung hat der Benutzer andere Berechtigungen.
+
+Es gibt folgende Beteiligungsrollen:
+
+- WorkspaceAdmin
+- WorkspaceMember
+- WorkspaceGuest
+
 
 Beteiligungen abrufen:
 ----------------------
@@ -31,28 +40,36 @@ Ein GET Request gibt die Beteiligungen sowie die aktiven Einladungen eines Inhal
           "@id": "http://localhost:8080/fd/workspaces/workspace-1/@participations/max.muster",
           "@type": "virtual.participations.user",
           "is_editable": true,
-          "participant_email": "max.muster@example.org",
           "role": {
             "title": "Admin",
             "token": "WorkspaceAdmin"
           },
           "participant": {
+            "@id": "http://localhost:8081/fd/@ogds-users/max.muster",
+            "@type": "virtual.ogds.user",
+            "active": true,
+            "email": "max.muster@example.com",
             "title": "Max Muster (max.muster)",
-            "token": "max.muster"
-          }
+            "id": "max.muster",
+            "is_local": null
+          },
         },
         {
-          "@id": "http://localhost:8080/fd/workspaces/workspace-1/@participations/petra.frohlich",
-          "@type": "virtual.participations.user",
+          "@id": "http://localhost:8081/fd/workspaces/workspace-41/@participations/afi_benutzer",
+          "@type": "virtual.participations.group",
           "is_editable": true,
-          "participant_email": "petra.frohlich@example.org",
-          "role": {
-            "title": "Teammitglied",
-            "token": "WorkspaceMember"
-          },
           "participant": {
-            "title": "Petra Fröhlich (petra.frohlich)",
-            "token": "petra.frohlich"
+            "@id": "http://localhost:8081/fd/@ogds-groups/afi_benutzer",
+            "@type": "virtual.ogds.group",
+            "active": true,
+            "id": "afi_benutzer",
+            "is_local": true,
+            "title": "AFI Benutzer",
+            "email": null
+          },
+          "role": {
+            "title": "Admin",
+            "token": "WorkspaceAdmin"
           }
         }
       ]
@@ -82,15 +99,18 @@ Ein GET Request auf die jeweilige Resource gibt die Beteiligungen oder die Einla
       "@id": "http://localhost:8080/fd/workspaces/workspace-1/@participations/max.muster",
       "@type": "virtual.participations.user",
       "is_editable": true,
-      "participant_email": "max.muster@example.org",
       "role": {
         "title": "Admin",
         "token": "WorkspaceAdmin"
       },
       "participant": {
+        "@id": "http://localhost:8081/fd/@ogds-users/max.muster",
+        "@type": "virtual.ogds.user",
+        "active": true,
+        "email": "max.muster@example.com",
         "title": "Max Muster (max.muster)",
-        "token": "max.muster"
-      }
+        "id": "max.muster",
+        "is_local": null
     }
 
 
@@ -128,7 +148,7 @@ In einem selbst verwalteten Teamraum-Ordner (Vererbung wurde unterbrochen) könn
 
        {
          "participant": "maria.meier",
-         "role": "WorkspaceMember",
+         "role": "WorkspaceMember"
        }
 
 **Beispiel-Response**:
@@ -142,16 +162,18 @@ In einem selbst verwalteten Teamraum-Ordner (Vererbung wurde unterbrochen) könn
       "@id": "http://localhost:8080/fd/workspaces/workspace-1/@participations/max.muster",
       "@type": "virtual.participations.user",
       "is_editable": true,
-      "participant_email": "max.muster@example.org",
-      "participant_fullname": "Max Muster (max.muster)",
       "role": {
         "title": "Admin",
-        "token": "WorkspaceMember"
+        "token": "WorkspaceAdmin"
       },
       "participant": {
+        "@id": "http://localhost:8081/fd/@ogds-users/max.muster",
+        "@type": "virtual.ogds.user",
+        "active": true,
+        "email": "max.muster@example.com",
         "title": "Max Muster (max.muster)",
-        "token": "max.muster"
-      }
+        "id": "max.muster",
+        "is_local": null
     }
 
 

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -591,6 +591,14 @@
       />
 
   <plone:service
+      method="POST"
+      name="@participations"
+      for="opengever.workspace.interfaces.IWorkspace"
+      factory=".participations.ParticipationsPost"
+      permission="plone.DelegateWorkspaceAdminRole"
+      />
+
+  <plone:service
       method="GET"
       name="@participations"
       for="opengever.workspace.interfaces.IWorkspaceFolder"

--- a/opengever/api/participations.py
+++ b/opengever/api/participations.py
@@ -1,17 +1,17 @@
 from opengever.base.role_assignments import RoleAssignmentManager
 from opengever.base.role_assignments import SharingRoleAssignment
 from opengever.ogds.base.actor import Actor
-from opengever.ogds.base.actor import OGDSUserActor
 from opengever.workspace.activities import WorkspaceWatcherManager
 from opengever.workspace.interfaces import IWorkspaceFolder
 from opengever.workspace.participation import PARTICIPATION_ROLES
 from opengever.workspace.participation.browser.manage_participants import ManageParticipants
-from plone import api
 from plone.protect.interfaces import IDisableCSRFProtection
 from plone.restapi.deserializer import json_body
+from plone.restapi.interfaces import ISerializeToJsonSummary
 from plone.restapi.services import Service
 from zExceptions import BadRequest
 from zExceptions import Forbidden
+from zope.component import getMultiAdapter
 from zope.interface import alsoProvides
 from zope.interface import implements
 from zope.publisher.interfaces import IPublishTraverse
@@ -31,23 +31,42 @@ class ParticipationTraverseService(Service):
         return self
 
     def prepare_response_item(self, participant):
-        userid = participant.get('token')
+        actor = Actor.lookup(participant.get('token'))
         role = PARTICIPATION_ROLES.get(participant.get('roles')[0])
-        member = api.user.get(userid=userid)
         managing_context = self.context.get_context_with_local_roles()
+
+        # We manually serialize the actors'representer and extract the desired
+        # properties to get a homogeneous json result for different actor types
+        #
+        # We do not use an Actor serializer here because it does not exist
+        # right now and needs more specification before we can implement it
+        # properly.
+        #
+        # The current implementation can be refactored as soon we have
+        # a properly implemented actor serializer.
+        #
+        # This will be tracked in https://4teamwork.atlassian.net/browse/CA-406
+        serialized_actor = getMultiAdapter(
+            (actor.represents(), self.request),
+            interface=ISerializeToJsonSummary)()
+
         return {
-            '@id': '{}/@participations/{}'.format(managing_context.absolute_url(), userid),
-            '@type': 'virtual.participations.user',
+            '@id': '{}/@participations/{}'.format(managing_context.absolute_url(), actor.identifier),
+            '@type': 'virtual.participations.{}'.format(actor.actor_type),
             'is_editable': managing_context == self.context and participant.get('can_manage'),
             'role': {
                 'token': role.id,
                 'title': role.translated_title(self.request),
             },
             'participant': {
-                "token": userid,
-                "title": participant.get('name'),
-            },
-            'participant_email': member.getProperty('email'),
+                '@id': serialized_actor.get('@id'),
+                '@type': serialized_actor.get('@type'),
+                'id': actor.identifier,
+                'title': actor.get_label(),
+                'email': serialized_actor.get('email'),
+                'is_local': serialized_actor.get('is_local'),
+                'active': serialized_actor.get('active'),
+            }
         }
 
     def participants(self, context):
@@ -62,7 +81,7 @@ class ParticipationTraverseService(Service):
     def is_actor_allowed_to_participate(self, token):
         """Validates the actor token if it' a avalid actor.
         """
-        if not isinstance(Actor.lookup(token), (OGDSUserActor, )):
+        if Actor.lookup(token).actor_type not in ['user', 'group']:
             raise BadRequest('The actor is not allowed')
 
         if self.find_participant(token, self.context.get_context_with_local_roles()):
@@ -129,7 +148,7 @@ class ParticipationsDelete(ParticipationTraverseService):
         """
         if obj.get_context_with_local_roles() == obj and self.find_participant(token, obj):
                 manager = ManageParticipants(obj, self.request)
-                manager._delete('user', token)
+                manager._delete(Actor.lookup(token).actor_type, token)
 
         for folder in obj.listFolderContents(
                 contentFilter={'portal_type': 'opengever.workspace.folder'}):
@@ -150,8 +169,9 @@ class ParticipationsPatch(ParticipationTraverseService):
             self.request.RESPONSE.setStatus(204)
             return None
 
+        actor = Actor.lookup(participant)
         manager = ManageParticipants(self.context, self.request)
-        manager._modify(participant, role, 'user')
+        manager._modify(participant, role, actor.actor_type)
         return None
 
     def read_params(self):

--- a/opengever/api/tests/test_participation.py
+++ b/opengever/api/tests/test_participation.py
@@ -14,9 +14,9 @@ def http_headers():
             'Content-Type': 'application/json'}
 
 
-def get_entry_by_token(entries, token):
+def get_entry_by_id(entries, token):
     for entry in entries:
-        if entry['participant']['token'] == token:
+        if entry['participant']['id'] == token:
             return entry
     return None
 
@@ -37,6 +37,15 @@ def remove_participation(obj, browser, token):
     )
 
 
+def add_participation(obj, browser, token, role):
+    browser.open(
+        obj.absolute_url() + '/@participations/{}'.format(token),
+        method='POST',
+        headers=http_headers(),
+        data=json.dumps({'participant': token, 'role': role})
+    )
+
+
 class TestParticipationGet(IntegrationTestCase):
 
     maxDiff = None
@@ -44,6 +53,7 @@ class TestParticipationGet(IntegrationTestCase):
     @browsing
     def test_list_all_current_participants_and_invitations(self, browser):
         self.login(self.workspace_owner, browser)
+        add_participation(self.workspace, browser, 'projekt_a', 'WorkspaceMember')
 
         response = browser.open(
             self.workspace.absolute_url() + '/@participations',
@@ -52,53 +62,62 @@ class TestParticipationGet(IntegrationTestCase):
         ).json
 
         self.assertItemsEqual(
-            [
-                {
-                    u'@id': u'http://nohost/plone/workspaces/workspace-1/@participations/beatrice.schrodinger',
-                    u'@type': u'virtual.participations.user',
-                    u'is_editable': True,
-                    u'role': {u'token': u'WorkspaceMember',
-                              u'title': u'Member'},
-                    u'participant': {
-                        'token': 'beatrice.schrodinger',
-                        'title': u'Schr\xf6dinger B\xe9atrice (beatrice.schrodinger)',
-                    },
-                    u'participant_email': u'beatrice.schrodinger@gever.local',
-                }, {
-                    u'@id': u'http://nohost/plone/workspaces/workspace-1/@participations/fridolin.hugentobler',
-                    u'@type': u'virtual.participations.user',
-                    u'is_editable': True,
-                    u'role': {u'token': u'WorkspaceAdmin',
-                              u'title': u'Admin'},
-                    u'participant': {
-                        'token': 'fridolin.hugentobler',
-                        'title': u'Hugentobler Fridolin (fridolin.hugentobler)',
-                    },
-                    u'participant_email': u'fridolin.hugentobler@gever.local',
-                }, {
-                    u'@id': u'http://nohost/plone/workspaces/workspace-1/@participations/gunther.frohlich',
-                    u'@type': u'virtual.participations.user',
-                    u'is_editable': False,
-                    u'role': {u'token': u'WorkspaceAdmin',
-                              u'title': u'Admin'},
-                    u'participant': {
-                        'token': 'gunther.frohlich',
-                        'title': u'Fr\xf6hlich G\xfcnther (gunther.frohlich)',
-                    },
-                    u'participant_email': u'gunther.frohlich@gever.local',
-                }, {
-                    u'@id': u'http://nohost/plone/workspaces/workspace-1/@participations/hans.peter',
-                    u'@type': u'virtual.participations.user',
-                    u'is_editable': True,
-                    u'role': {u'token': u'WorkspaceGuest',
-                              u'title': u'Guest'},
-                    u'participant': {
-                        'token': 'hans.peter',
-                        'title': u'Peter Hans (hans.peter)',
-                    },
-                    u'participant_email': u'hans.peter@gever.local',
-                },
-            ], response.get('items'))
+            [{u'@id': u'http://nohost/plone/workspaces/workspace-1/@participations/beatrice.schrodinger',
+              u'@type': u'virtual.participations.user',
+              u'is_editable': True,
+              u'participant': {u'@id': u'http://nohost/plone/@ogds-users/beatrice.schrodinger',
+                               u'@type': u'virtual.ogds.user',
+                               u'active': True,
+                               u'email': u'beatrice.schrodinger@gever.local',
+                               u'id': u'beatrice.schrodinger',
+                               u'is_local': None,
+                               u'title': u'Schr\xf6dinger B\xe9atrice (beatrice.schrodinger)'},
+              u'role': {u'title': u'Member', u'token': u'WorkspaceMember'}},
+             {u'@id': u'http://nohost/plone/workspaces/workspace-1/@participations/fridolin.hugentobler',
+              u'@type': u'virtual.participations.user',
+              u'is_editable': True,
+              u'participant': {u'@id': u'http://nohost/plone/@ogds-users/fridolin.hugentobler',
+                               u'@type': u'virtual.ogds.user',
+                               u'active': True,
+                               u'email': u'fridolin.hugentobler@gever.local',
+                               u'id': u'fridolin.hugentobler',
+                               u'is_local': None,
+                               u'title': u'Hugentobler Fridolin (fridolin.hugentobler)'},
+              u'role': {u'title': u'Admin', u'token': u'WorkspaceAdmin'}},
+             {u'@id': u'http://nohost/plone/workspaces/workspace-1/@participations/gunther.frohlich',
+              u'@type': u'virtual.participations.user',
+              u'is_editable': False,
+              u'participant': {u'@id': u'http://nohost/plone/@ogds-users/gunther.frohlich',
+                               u'@type': u'virtual.ogds.user',
+                               u'active': True,
+                               u'email': u'gunther.frohlich@gever.local',
+                               u'id': u'gunther.frohlich',
+                               u'is_local': None,
+                               u'title': u'Fr\xf6hlich G\xfcnther (gunther.frohlich)'},
+              u'role': {u'title': u'Admin', u'token': u'WorkspaceAdmin'}},
+             {u'@id': u'http://nohost/plone/workspaces/workspace-1/@participations/hans.peter',
+              u'@type': u'virtual.participations.user',
+              u'is_editable': True,
+              u'participant': {u'@id': u'http://nohost/plone/@ogds-users/hans.peter',
+                               u'@type': u'virtual.ogds.user',
+                               u'active': True,
+                               u'email': u'hans.peter@gever.local',
+                               u'id': u'hans.peter',
+                               u'is_local': None,
+                               u'title': u'Peter Hans (hans.peter)'},
+              u'role': {u'title': u'Guest', u'token': u'WorkspaceGuest'}},
+             {u'@id': u'http://nohost/plone/workspaces/workspace-1/@participations/projekt_a',
+              u'@type': u'virtual.participations.group',
+              u'is_editable': True,
+              u'participant': {u'@id': u'http://nohost/plone/@ogds-groups/projekt_a',
+                               u'@type': u'virtual.ogds.group',
+                               u'active': True,
+                               u'email': None,
+                               u'id': u'projekt_a',
+                               u'is_local': False,
+                               u'title': u'Projekt A'},
+              u'role': {u'title': u'Member', u'token': u'WorkspaceMember'}}],
+             response.get('items'))
 
     @browsing
     def test_list_all_current_participants_in_folder_lists_participants_of_the_workspace(self, browser):
@@ -151,7 +170,7 @@ class TestParticipationGet(IntegrationTestCase):
         items = response.get('items')
 
         self.assertFalse(
-            get_entry_by_token(items, self.workspace_owner.id)['is_editable'],
+            get_entry_by_id(items, self.workspace_owner.id)['is_editable'],
             'The admin should not be able to manage himself')
 
     @browsing
@@ -167,11 +186,11 @@ class TestParticipationGet(IntegrationTestCase):
         items = response.get('items')
 
         self.assertFalse(
-            get_entry_by_token(items, self.workspace_admin.id)['is_editable'],
+            get_entry_by_id(items, self.workspace_admin.id)['is_editable'],
             'The admin should not be able to manage himself')
 
         self.assertTrue(
-            get_entry_by_token(items, 'hans.peter')['is_editable'],
+            get_entry_by_id(items, 'hans.peter')['is_editable'],
             'The admin should be able to manage hans.peter')
 
     @browsing
@@ -187,7 +206,7 @@ class TestParticipationGet(IntegrationTestCase):
         items = response.get('items')
 
         self.assertTrue(
-            get_entry_by_token(items, self.workspace_guest.id)['is_editable'],
+            get_entry_by_id(items, self.workspace_guest.id)['is_editable'],
             'The admin should be able to manage {}'.format(self.workspace_guest.id))
 
     @browsing
@@ -203,7 +222,7 @@ class TestParticipationGet(IntegrationTestCase):
         items = response.get('items')
 
         self.assertFalse(
-            get_entry_by_token(items, self.workspace_guest.id)['is_editable'],
+            get_entry_by_id(items, self.workspace_guest.id)['is_editable'],
             'The admin should not be able to manage {}'.format(self.workspace_guest.id))
 
     @browsing
@@ -221,7 +240,7 @@ class TestParticipationGet(IntegrationTestCase):
             'No entry should be editable because the user has no permission')
 
     @browsing
-    def test_get_single_participant(self, browser):
+    def test_get_single_user_participant(self, browser):
         self.login(self.workspace_owner, browser)
 
         response = browser.open(
@@ -231,26 +250,50 @@ class TestParticipationGet(IntegrationTestCase):
         ).json
 
         self.assertDictEqual(
-            {
-                u'@id': u'http://nohost/plone/workspaces/workspace-1/@participations/hans.peter',
-                u'@type': u'virtual.participations.user',
-                u'is_editable': True,
-                u'participant': {
-                    'token': 'hans.peter',
-                    'title': u'Peter Hans (hans.peter)',
-                },
-                u'role': {
-                    'token': 'WorkspaceGuest',
-                    'title': 'Guest',
-                },
-                u'participant_email': 'hans.peter@gever.local',
-            }, response)
+            {u'@id': u'http://nohost/plone/workspaces/workspace-1/@participations/hans.peter',
+             u'@type': u'virtual.participations.user',
+             u'is_editable': True,
+             u'participant': {u'@id': u'http://nohost/plone/@ogds-users/hans.peter',
+                              u'@type': u'virtual.ogds.user',
+                              u'active': True,
+                              u'email': u'hans.peter@gever.local',
+                              u'id': u'hans.peter',
+                              u'is_local': None,
+                              u'title': u'Peter Hans (hans.peter)'},
+             u'role': {u'title': u'Guest', u'token': u'WorkspaceGuest'}},
+            response)
+
+    @browsing
+    def test_get_single_group_participant(self, browser):
+        self.login(self.workspace_owner, browser)
+
+        add_participation(self.workspace, browser, 'projekt_a', 'WorkspaceMember')
+
+        response = browser.open(
+            self.workspace.absolute_url() + '/@participations/projekt_a',
+            method='GET',
+            headers=http_headers(),
+        ).json
+
+        self.assertDictEqual(
+            {u'@id': u'http://nohost/plone/workspaces/workspace-1/@participations/projekt_a',
+             u'@type': u'virtual.participations.group',
+             u'is_editable': True,
+             u'participant': {u'@id': u'http://nohost/plone/@ogds-groups/projekt_a',
+                              u'@type': u'virtual.ogds.group',
+                              u'active': True,
+                              u'email': None,
+                              u'id': u'projekt_a',
+                              u'is_local': False,
+                              u'title': u'Projekt A'},
+             u'role': {u'title': u'Member', u'token': u'WorkspaceMember'}},
+            response)
 
 
 class TestParticipationDelete(IntegrationTestCase):
 
     @browsing
-    def test_delete_local_role(self, browser):
+    def test_delete_user_local_role(self, browser):
         self.login(self.workspace_admin, browser=browser)
 
         browser.open(
@@ -260,7 +303,7 @@ class TestParticipationDelete(IntegrationTestCase):
         )
 
         self.assertIsNotNone(
-            get_entry_by_token(browser.json.get('items'), self.workspace_guest.getId()),
+            get_entry_by_id(browser.json.get('items'), self.workspace_guest.getId()),
             'Expect to have local roles for the user')
 
         browser.open(
@@ -278,8 +321,42 @@ class TestParticipationDelete(IntegrationTestCase):
         )
 
         self.assertIsNone(
-            get_entry_by_token(browser.json.get('items'), self.workspace_guest.getId()),
+            get_entry_by_id(browser.json.get('items'), self.workspace_guest.getId()),
             'Expect to have no local roles anymore for the user')
+
+    @browsing
+    def test_delete_group_local_role(self, browser):
+        self.login(self.workspace_admin, browser=browser)
+
+        add_participation(self.workspace, browser, 'projekt_a', 'WorkspaceGuest')
+
+        browser.open(
+            self.workspace.absolute_url() + '/@participations',
+            method='GET',
+            headers=http_headers(),
+        )
+
+        self.assertIsNotNone(
+            get_entry_by_id(browser.json.get('items'), 'projekt_a'),
+            'Expect to have local roles for the group')
+
+        browser.open(
+            self.workspace.absolute_url() + '/@participations/projekt_a',
+            method='DELETE',
+            headers=http_headers(),
+        )
+
+        self.assertEqual(204, browser.status_code)
+
+        browser.open(
+            self.workspace.absolute_url() + '/@participations',
+            method='GET',
+            headers=http_headers(),
+        )
+
+        self.assertIsNone(
+            get_entry_by_id(browser.json.get('items'), 'projekt_a'),
+            'Expect to have no local roles anymore for the group')
 
     @browsing
     def test_delete_local_role_from_folder(self, browser):
@@ -294,7 +371,7 @@ class TestParticipationDelete(IntegrationTestCase):
         )
 
         self.assertIsNotNone(
-            get_entry_by_token(browser.json.get('items'), self.workspace_guest.getId()),
+            get_entry_by_id(browser.json.get('items'), self.workspace_guest.getId()),
             'Expect to have local roles for the user')
 
         browser.open(
@@ -312,7 +389,7 @@ class TestParticipationDelete(IntegrationTestCase):
         )
 
         self.assertIsNone(
-            get_entry_by_token(browser.json.get('items'), self.workspace_guest.getId()),
+            get_entry_by_id(browser.json.get('items'), self.workspace_guest.getId()),
             'Expect to have no local roles anymore for the user')
 
         browser.open(
@@ -322,7 +399,7 @@ class TestParticipationDelete(IntegrationTestCase):
         )
 
         self.assertIsNotNone(
-            get_entry_by_token(browser.json.get('items'), self.workspace_guest.getId()),
+            get_entry_by_id(browser.json.get('items'), self.workspace_guest.getId()),
             'Expect to still have local roles for the user on the workspace')
 
     @browsing
@@ -377,7 +454,7 @@ class TestParticipationDelete(IntegrationTestCase):
         )
 
         self.assertIsNone(
-            get_entry_by_token(browser.json.get('items'), self.workspace_guest.getId()),
+            get_entry_by_id(browser.json.get('items'), self.workspace_guest.getId()),
             'Expect to have no local roles anymore for the user in the workspace')
 
         browser.open(
@@ -387,14 +464,14 @@ class TestParticipationDelete(IntegrationTestCase):
         )
 
         self.assertIsNone(
-            get_entry_by_token(browser.json.get('items'), self.workspace_guest.getId()),
+            get_entry_by_id(browser.json.get('items'), self.workspace_guest.getId()),
             'Expect to have no local roles anymore for the user in the folder')
 
 
 class TestParticipationPatch(IntegrationTestCase):
 
     @browsing
-    def test_modify_a_users_loca_roles(self, browser):
+    def test_modify_a_users_local_roles(self, browser):
         self.login(self.workspace_admin, browser=browser)
 
         browser.open(
@@ -403,7 +480,7 @@ class TestParticipationPatch(IntegrationTestCase):
             headers=http_headers(),
         )
 
-        entry = get_entry_by_token(browser.json.get('items'), self.workspace_guest.id)
+        entry = get_entry_by_id(browser.json.get('items'), self.workspace_guest.id)
         self.assertEquals(
             {u'token': u'WorkspaceGuest', u'title': u'Guest'},
             entry.get('role'))
@@ -424,7 +501,45 @@ class TestParticipationPatch(IntegrationTestCase):
             headers=http_headers(),
         )
 
-        entry = get_entry_by_token(browser.json.get('items'), self.workspace_guest.id)
+        entry = get_entry_by_id(browser.json.get('items'), self.workspace_guest.id)
+        self.assertEquals(
+            {u'token': u'WorkspaceMember', u'title': u'Member'},
+            entry.get('role'))
+
+    @browsing
+    def test_modify_a_groups_local_roles(self, browser):
+        self.login(self.workspace_admin, browser=browser)
+
+        add_participation(self.workspace, browser, 'projekt_a', 'WorkspaceGuest')
+
+        browser.open(
+            self.workspace.absolute_url() + '/@participations',
+            method='GET',
+            headers=http_headers(),
+        )
+
+        entry = get_entry_by_id(browser.json.get('items'), 'projekt_a')
+        self.assertEquals(
+            {u'token': u'WorkspaceGuest', u'title': u'Guest'},
+            entry.get('role'))
+
+        data = json.dumps(json_compatible({
+            'role': {'token': 'WorkspaceMember'}
+        }))
+        browser.open(
+            entry['@id'],
+            method='PATCH',
+            data=data,
+            headers=http_headers(),
+            )
+
+        browser.open(
+            self.workspace.absolute_url() + '/@participations',
+            method='GET',
+            headers=http_headers(),
+        )
+
+        entry = get_entry_by_id(browser.json.get('items'), 'projekt_a')
         self.assertEquals(
             {u'token': u'WorkspaceMember', u'title': u'Member'},
             entry.get('role'))
@@ -441,7 +556,7 @@ class TestParticipationPatch(IntegrationTestCase):
             headers=http_headers(),
         )
 
-        entry = get_entry_by_token(browser.json.get('items'), self.workspace_guest.id)
+        entry = get_entry_by_id(browser.json.get('items'), self.workspace_guest.id)
         self.assertEquals(
             {u'token': u'WorkspaceGuest', u'title': u'Guest'},
             entry.get('role'))
@@ -462,7 +577,7 @@ class TestParticipationPatch(IntegrationTestCase):
             headers=http_headers(),
         )
 
-        entry = get_entry_by_token(browser.json.get('items'), self.workspace_guest.id)
+        entry = get_entry_by_id(browser.json.get('items'), self.workspace_guest.id)
         self.assertEquals(
             {u'token': u'WorkspaceMember', u'title': u'Member'},
             entry.get('role'),
@@ -474,7 +589,7 @@ class TestParticipationPatch(IntegrationTestCase):
             headers=http_headers(),
         )
 
-        entry = get_entry_by_token(browser.json.get('items'), self.workspace_guest.id)
+        entry = get_entry_by_id(browser.json.get('items'), self.workspace_guest.id)
         self.assertEquals(
             {u'token': u'WorkspaceGuest', u'title': u'Guest'},
             entry.get('role'),
@@ -505,7 +620,7 @@ class TestParticipationPatch(IntegrationTestCase):
             headers=http_headers(),
         )
 
-        entry = get_entry_by_token(browser.json.get('items'), self.workspace_guest.id)
+        entry = get_entry_by_id(browser.json.get('items'), self.workspace_guest.id)
 
         with browser.expect_http_error(401):
             data = json.dumps(json_compatible({
@@ -529,7 +644,7 @@ class TestParticipationPatch(IntegrationTestCase):
             headers=http_headers(),
         )
 
-        entry = get_entry_by_token(browser.json.get('items'), self.workspace_admin.id)
+        entry = get_entry_by_id(browser.json.get('items'), self.workspace_admin.id)
 
         with browser.expect_http_error(401):
             data = json.dumps(json_compatible({
@@ -558,7 +673,7 @@ class TestParticipationPostWorkspace(IntegrationTestCase):
             headers=http_headers(),
         )
 
-        entry = get_entry_by_token(browser.json.get('items'), self.workspace_member.id)
+        entry = get_entry_by_id(browser.json.get('items'), self.workspace_member.id)
         self.assertIsNone(entry)
 
         data = {
@@ -579,7 +694,43 @@ class TestParticipationPostWorkspace(IntegrationTestCase):
             headers=http_headers(),
         )
 
-        entry = get_entry_by_token(browser.json.get('items'), self.workspace_member.id)
+        entry = get_entry_by_id(browser.json.get('items'), self.workspace_member.id)
+        self.assertEquals(
+            {u'token': u'WorkspaceGuest', u'title': u'Guest'},
+            entry.get('role'))
+
+    @browsing
+    def test_let_a_group_participate(self, browser):
+        self.login(self.workspace_admin, browser=browser)
+
+        browser.open(
+            self.workspace.absolute_url() + '/@participations',
+            method='GET',
+            headers=http_headers(),
+        )
+
+        entry = get_entry_by_id(browser.json.get('items'), 'projekt_a')
+        self.assertIsNone(entry)
+
+        data = {
+            "participant": {"token": 'projekt_a'},
+            "role": {"token": 'WorkspaceGuest'},
+        }
+
+        browser.open(
+            self.workspace.absolute_url() + '/@participations',
+            method='POST',
+            data=json.dumps(data),
+            headers=http_headers(),
+            )
+
+        browser.open(
+            self.workspace.absolute_url() + '/@participations',
+            method='GET',
+            headers=http_headers(),
+        )
+
+        entry = get_entry_by_id(browser.json.get('items'), 'projekt_a')
         self.assertEquals(
             {u'token': u'WorkspaceGuest', u'title': u'Guest'},
             entry.get('role'))
@@ -630,7 +781,7 @@ class TestParticipationPostWorkspace(IntegrationTestCase):
             headers=http_headers(),
         )
 
-        entry = get_entry_by_token(browser.json.get('items'), self.workspace_member.id)
+        entry = get_entry_by_id(browser.json.get('items'), self.workspace_member.id)
         self.assertIsNotNone(entry)
 
         data = {
@@ -662,7 +813,7 @@ class TestParticipationPostWorkspaceFolder(IntegrationTestCase):
             headers=http_headers(),
         )
 
-        entry = get_entry_by_token(browser.json.get('items'), self.workspace_member.id)
+        entry = get_entry_by_id(browser.json.get('items'), self.workspace_member.id)
         self.assertIsNone(entry)
 
         data = {
@@ -683,7 +834,7 @@ class TestParticipationPostWorkspaceFolder(IntegrationTestCase):
             headers=http_headers(),
         )
 
-        entry = get_entry_by_token(browser.json.get('items'), self.workspace_member.id)
+        entry = get_entry_by_id(browser.json.get('items'), self.workspace_member.id)
         self.assertEquals(
             {u'token': u'WorkspaceGuest', u'title': u'Guest'},
             entry.get('role'))
@@ -760,7 +911,7 @@ class TestParticipationPostWorkspaceFolder(IntegrationTestCase):
             headers=http_headers(),
         )
 
-        entry = get_entry_by_token(browser.json.get('items'), self.workspace_member.id)
+        entry = get_entry_by_id(browser.json.get('items'), self.workspace_member.id)
         self.assertIsNotNone(entry)
 
         data = {

--- a/opengever/base/role_assignments.py
+++ b/opengever/base/role_assignments.py
@@ -314,6 +314,13 @@ class RoleAssignmentManager(object):
         return [RoleAssignment.get(**data) for data
                 in self.storage.get_by_principal(principal_id)]
 
+    def get_roles_by_principal_id(self, principal_id):
+        roles = set()
+        for assignment_data in self.storage.get_by_principal(principal_id):
+                roles.update(assignment_data.get('roles', []))
+
+        return roles
+
     def reset(self, assignments):
         cause = assignments[0].cause
         if len(set([asg.cause for asg in assignments])) > 1:

--- a/opengever/base/tests/test_role_assignments.py
+++ b/opengever/base/tests/test_role_assignments.py
@@ -186,6 +186,15 @@ class TestRoleAssignmentManager(IntegrationTestCase):
               'reference': Oguid.for_object(task).id}],
             RoleAssignmentManager(self.empty_dossier).storage._storage())
 
+    def test_get_roles_by_principal_id_returns_the_assigned_roles_for_a_principal(self):
+        self.login(self.regular_user)
+
+        manager = RoleAssignmentManager(self.dossier)
+
+        self.assertEquals(
+            set(['Contributor']),
+            manager.get_roles_by_principal_id(self.regular_user.id))
+
 
 class TestManageRoleAssignmentsView(IntegrationTestCase):
 

--- a/opengever/ogds/base/actor.py
+++ b/opengever/ogds/base/actor.py
@@ -128,6 +128,11 @@ class Actor(object):
     def permission_identifier(self):
         raise NotImplementedError()
 
+    def represents(self):
+        """Returns the object this actor is representing.
+        """
+        raise NotImplementedError()
+
     def representatives(self):
         """Returns a list of users which are representative for the current
         actor. Used for example when notifying an actor.
@@ -153,6 +158,9 @@ class NullActor(object):
 
     def get_link(self, with_icon=False):
         return self.identifier or u''
+
+    def represents(self):
+        raise None
 
     def representatives(self):
         return []
@@ -181,6 +189,9 @@ class SystemActor(object):
 
     def get_link(self, with_icon=False):
         return u''
+
+    def represents(self):
+        raise None
 
     def representatives(self):
         return []
@@ -218,6 +229,9 @@ class InboxActor(Actor):
     def representatives(self):
         return self.org_unit.inbox().assigned_users()
 
+    def represents(self):
+        return self.org_unit
+
 
 class TeamActor(Actor):
 
@@ -245,6 +259,9 @@ class TeamActor(Actor):
     def representatives(self):
         return self.team.group.users
 
+    def represents(self):
+        return self.team
+
 
 class CommitteeActor(Actor):
 
@@ -268,6 +285,9 @@ class CommitteeActor(Actor):
         # Avoid circular imports
         from opengever.meeting.activity.helpers import get_users_by_group
         return get_users_by_group(self.committee.group_id)
+
+    def represents(self):
+        return self.committee
 
 
 class ContactActor(Actor):
@@ -300,6 +320,9 @@ class ContactActor(Actor):
     def representatives(self):
         return []
 
+    def represents(self):
+        return self.contact
+
 
 class PloneUserActor(Actor):
 
@@ -326,6 +349,9 @@ class PloneUserActor(Actor):
     def representatives(self):
         return []
 
+    def represents(self):
+        return self.user
+
 
 class OGDSUserActor(Actor):
 
@@ -348,6 +374,9 @@ class OGDSUserActor(Actor):
 
     def representatives(self):
         return [self.user]
+
+    def represents(self):
+        return self.user
 
 
 class OGDSGroupActor(Actor):
@@ -373,6 +402,9 @@ class OGDSGroupActor(Actor):
 
     def representatives(self):
         return self.group.users
+
+    def represents(self):
+        return self.group
 
 
 class ActorLookup(object):

--- a/opengever/ogds/base/actor.py
+++ b/opengever/ogds/base/actor.py
@@ -46,6 +46,7 @@ SYSTEM_ACTOR_ID = '__system__'
 class Actor(object):
 
     css_class = 'actor-user'
+    actor_type = 'user'
 
     def __init__(self, identifier):
         self.identifier = identifier
@@ -136,6 +137,8 @@ class Actor(object):
 
 class NullActor(object):
 
+    actor_type = 'null'
+
     def __init__(self, identifier):
         self.identifier = identifier
 
@@ -158,6 +161,8 @@ class NullActor(object):
 class SystemActor(object):
     """Used for system notifications, using the internal SYSTEM_ACTOR_ID.
     """
+
+    actor_type = 'system'
 
     def __init__(self, identifier):
         if identifier != SYSTEM_ACTOR_ID:
@@ -184,6 +189,7 @@ class SystemActor(object):
 class InboxActor(Actor):
 
     css_class = 'actor-inbox'
+    actor_type = 'inbox'
 
     def __init__(self, identifier, org_unit=None):
         super(InboxActor, self).__init__(identifier)
@@ -216,6 +222,7 @@ class InboxActor(Actor):
 class TeamActor(Actor):
 
     css_class = 'actor-team'
+    actor_type = 'team'
 
     def __init__(self, identifier, team=None):
         super(TeamActor, self).__init__(identifier)
@@ -242,6 +249,7 @@ class TeamActor(Actor):
 class CommitteeActor(Actor):
 
     css_class = 'actor-committee'
+    actor_type = 'committee'
 
     def __init__(self, identifier, committee=None):
         super(CommitteeActor, self).__init__(identifier)
@@ -265,6 +273,7 @@ class CommitteeActor(Actor):
 class ContactActor(Actor):
 
     css_class = 'actor-contact'
+    actor_type = 'contact'
 
     def __init__(self, identifier, contact=None):
         super(ContactActor, self).__init__(identifier)
@@ -342,6 +351,8 @@ class OGDSUserActor(Actor):
 
 
 class OGDSGroupActor(Actor):
+
+    actor_type = 'group'
 
     def __init__(self, identifier, group=None):
         super(OGDSGroupActor, self).__init__(identifier)

--- a/opengever/workspace/participation/__init__.py
+++ b/opengever/workspace/participation/__init__.py
@@ -65,8 +65,8 @@ def get_full_user_info(userid=None, member=None):
     return PloneUserActor(identifier=userid, user=member).get_label()
 
 
-def can_manage_member(context, member=None, roles=None):
-    if member and member.getId() == api.user.get_current().getId():
+def can_manage_member(context, actor=None, roles=None):
+    if actor and actor.identifier == api.user.get_current().getId():
         return False
     else:
         return api.user.has_permission(


### PR DESCRIPTION
Currently, it's only possible to let users participating on a teamraum. 

This PR extends the participation management in a teamraum to also manage groups.

Jira: https://4teamwork.atlassian.net/browse/NE-71

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


## Checklist (if applicable)

_Only applicable should be left and checked._

- API change:
  - [ ] Documentation is updated
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Upgrade steps (changes in profile):
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
- DB-Schema migration
  - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
  - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value
