### PR TITLE
Don't make dossiers expandable with participations.

### DIFF
--- a/docs/public/dev-manual/api/dossier_participations.rst
+++ b/docs/public/dev-manual/api/dossier_participations.rst
@@ -64,39 +64,6 @@ Ein Beteiligter kann in verschiedenen Rollen an einem Dossier beteiligt sein. Mi
       }
 
 
-Beteiligungen als erweiterbare Komponente
------------------------------------------
-
-Die Beteilgungen können als Kompomente eines Dossiers direkt über den ``expand``-Parameter eingebettet werden, so dass keine zusätzliche Abfrage nötig ist.
-
-**Beispiel-Request**:
-
-  .. sourcecode:: http
-
-    GET /dossier-1?expand=participations HTTP/1.1
-    Accept: application/json
-
-**Beispiel-Response**:
-
-  .. sourcecode:: http
-
-    HTTP/1.1 200 OK
-    Content-Type: application/json
-
-    {
-      "@id": "https://example.org/ordnungssystem/fuehrung/dossier-1?expand=participations",
-      "@components": {
-        "participations": {
-          "@id": "https://example.org/ordnungssystem/fuehrung/dossier-1/@participations",
-          "available_roles": ["..."],
-          "items": ["..."],
-          "items_total": 2
-        }
-      },
-      "...": "..."
-    }
-
-
 Beteiligung hinzufügen
 ----------------------
 
@@ -120,6 +87,7 @@ Eine Beteiligung kann mittels POST-Requests hinzugefügt werden.
    .. sourcecode:: http
 
       HTTP/1.1 204 No content
+
 
 Rollen einer Beteiligung bearbeiten
 -----------------------------------

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -1032,9 +1032,4 @@
       permission="zope2.View"
       />
 
-  <adapter
-      factory=".dossier_participations.Participations"
-      name="participations"
-      />
-
 </configure>

--- a/opengever/api/tests/test_dossier_participations.py
+++ b/opengever/api/tests/test_dossier_participations.py
@@ -58,14 +58,6 @@ class TestParticipationsGet(IntegrationTestCase, PloneParticipationsHelper):
             u'items_total': 2}
         self.assertEqual(expected_json, browser.json)
 
-        browser.open(self.dossier, method='GET', headers=self.api_headers)
-        self.assertEqual({u'@id': u'http://nohost/plone/ordnungssystem/fuhrung/'
-                                  u'vertrage-und-vereinbarungen/dossier-1/@participations'},
-                         browser.json['@components']['participations'])
-        browser.open(self.dossier.absolute_url() + '?expand=participations',
-                     method='GET', headers=self.api_headers)
-        self.assertEqual(expected_json, browser.json['@components']['participations'])
-
     @browsing
     def test_response_is_batched(self, browser):
         self.login(self.regular_user, browser=browser)
@@ -111,14 +103,6 @@ class TestParticipationsGetWithContactFeatureEnabled(IntegrationTestCase):
                         u'roles': [u'final-drawing', u'participation']}],
             u'items_total': 2}
         self.assertEqual(expected_json, browser.json)
-
-        browser.open(self.dossier, method='GET', headers=self.api_headers)
-        self.assertEqual({u'@id': u'http://nohost/plone/ordnungssystem/fuhrung/'
-                                  u'vertrage-und-vereinbarungen/dossier-1/@participations'},
-                         browser.json['@components']['participations'])
-        browser.open(self.dossier.absolute_url() + '?expand=participations',
-                     method='GET', headers=self.api_headers)
-        self.assertEqual(expected_json, browser.json['@components']['participations'])
 
     @browsing
     def test_response_is_batched(self, browser):


### PR DESCRIPTION
We do not want dossiers to be expandable with participations, as this is bad for performance.
A changelog entry for the implementation of the @participations endpoint already exists.

Jira: https://4teamwork.atlassian.net/browse/NE-89

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


## Checklist (if applicable)

_Only applicable should be left and checked._

- API change:
  - [x] Documentation is updated