### PR TITLE
Makes the GET @groups endpoint available with the `opengever.api.ManageGroups` permission.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2020.11.0 (unreleased)
 ----------------------
 
+- GET @groups endpoint is now available with the `opengever.api.ManageGroups` permission. [elioschmutz]
 - Bump docxcompose to 1.3.0 to support updating complex properties with no existing value. [deiferni]
 - @ogds-users, @ogds-groups, @ogds-user-listing and @ogds-group-listing are now registered on the plone siteroot instead the contact-folder. [elioschmutz]
 - Add dossiertemplates, tasktemplates and tasktemplatefolders to @listing endpoint. [tinagerber]

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -974,6 +974,15 @@
       />
 
   <plone:service
+      method="GET"
+      name="@groups"
+      for="Products.CMFCore.interfaces.ISiteRoot"
+      factory="plone.restapi.services.groups.get.GroupsGet"
+      permission="opengever.api.ManageGroups"
+      layer="opengever.base.interfaces.IOpengeverBaseLayer"
+      />
+
+  <plone:service
       method="POST"
       name="@groups"
       for="Products.CMFCore.interfaces.ISiteRoot"

--- a/opengever/api/tests/test_group.py
+++ b/opengever/api/tests/test_group.py
@@ -87,6 +87,29 @@ class TestCheckGroupPluginConfiguration(IntegrationTestCase):
             exc.exception.message)
 
 
+class TestGroupGet(IntegrationTestCase):
+
+    @browsing
+    def test_fetch_groups_is_allowed_for_administrators(self, browser):
+        self.login(self.workspace_owner, browser)
+
+        with browser.expect_unauthorized():
+            browser.open(
+                self.portal,
+                view='@groups',
+                method='GET',
+                headers=self.api_headers)
+
+        self.login(self.administrator, browser)
+        response = browser.open(
+            self.portal,
+            view='@groups',
+            method='GET',
+            headers=self.api_headers)
+
+        self.assertEqual(200, response.status_code)
+
+
 class TestGroupPost(IntegrationTestCase):
 
     @browsing


### PR DESCRIPTION
The `POST`, `PATCH` and `DELETE` verbs vor the `@groups` endpoint are already using the `opengever.api.ManageGroups` permission. We also need this permission for the `GET` verb to make sure, an administrator can manage groups properly.

The default permission assiged by the `plone.restapi` is `cmf.ManagePortal`

Issuer: https://4teamwork.atlassian.net/browse/NE-83

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


## Checklist (if applicable)

_Only applicable should be left and checked._

- API change:
  - [ ] Documentation is updated
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Upgrade steps (changes in profile):
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
- DB-Schema migration
  - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
  - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value
