### PR TITLE
Add external_reference field to solr, reindex objects with values.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 ----------------------
 
 - Allow assigning groups as participants to a Teamraum [elioschmutz]
+- Add external_reference field to solr, reindex objects with values. [deiferni]
 
 
 2020.11.0 (2020-10-07)

--- a/docs/public/dev-manual/api/listings.rst
+++ b/docs/public/dev-manual/api/listings.rst
@@ -78,6 +78,7 @@ werden. Folgende Felder stehen zur Verfügung:
 - ``document_type``: Dokumenttyp
 - ``email``: E-Mail Adresse
 - ``end``: Enddatum des Dossiers
+- ``external_reference``: Externe Referenz für Dossiers oder Fremdzeichen für Dokumente
 - ``file_extension``: Datei-Endung
 - ``filename``: Dateiname
 - ``filesize``: Dateigrösse
@@ -155,6 +156,8 @@ siehe Tabelle:
     |``document_type``         |    ja    |   nein  |     nein     |        nein        |  nein   |  nein   |  nein   |   nein   |       nein      |       nein       |       nein      |
     +--------------------------+----------+---------+--------------+--------------------+---------+---------+---------+----------+-----------------+------------------+-----------------+
     |``end``                   |   nein   |    ja   |     nein     |        nein        |  nein   |  nein   |  nein   |   nein   |       nein      |       nein       |       nein      |
+    +--------------------------+----------+---------+--------------+--------------------+---------+---------+---------+----------+-----------------+------------------+-----------------+
+    |``external_reference``    |    ja    |    ja   |     nein     |        nein        |  nein   |  nein   |  nein   |   nein   |       nein      |       nein       |       nein      |
     +--------------------------+----------+---------+--------------+--------------------+---------+---------+---------+----------+-----------------+------------------+-----------------+
     |``file_extension``        |    ja    |   nein  |     nein     |        nein        |  nein   |  nein   |  nein   |   nein   |       nein      |       nein       |       nein      |
     +--------------------------+----------+---------+--------------+--------------------+---------+---------+---------+----------+-----------------+------------------+-----------------+

--- a/opengever/api/listing.py
+++ b/opengever/api/listing.py
@@ -26,6 +26,7 @@ OTHER_ALLOWED_FIELDS = set([
     'document_type',
     'email',
     'end',
+    'external_reference',
     'file_extension',
     'firstname',
     'has_sametype_children',

--- a/opengever/api/tests/test_listing.py
+++ b/opengever/api/tests/test_listing.py
@@ -146,6 +146,8 @@ class TestListingWithRealSolr(SolrIntegrationTestCase):
 
     features = ('bumblebee', 'solr')
 
+    maxDiff = None
+
     @browsing
     def test_dossier_listing_works_for_responsible_fullname(self, browser):
         self.login(self.regular_user, browser=browser)
@@ -167,6 +169,7 @@ class TestListingWithRealSolr(SolrIntegrationTestCase):
         self.login(self.regular_user, browser=browser)
         query_string = '&'.join((
             'name=dossiers',
+            'columns=external_reference',
             'columns=reference',
             'columns=title',
             'columns=review_state',
@@ -192,6 +195,7 @@ class TestListingWithRealSolr(SolrIntegrationTestCase):
             {u'review_state': u'dossier-state-active',
              u'@id': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1',
              u'UID': IUUID(self.dossier),
+             u'external_reference': u'qpr-900-9001-\xf7',
              u'trashed': False,
              u'reference': u'Client1 1.1 / 1',
              u'title': u'Vertr\xe4ge mit der kantonalen Finanzverwaltung',
@@ -203,6 +207,7 @@ class TestListingWithRealSolr(SolrIntegrationTestCase):
         self.login(self.regular_user, browser=browser)
         query_string = '&'.join((
             'name=documents',
+            'columns=external_reference',
             'columns=reference',
             'columns=title',
             'columns=modified',
@@ -220,6 +225,7 @@ class TestListingWithRealSolr(SolrIntegrationTestCase):
             {u'reference': u'Client1 1.1 / 1 / 14',
              u'title': u'Vertr\xe4gsentwurf',
              u'document_author': u'test_user_1_',
+             u'external_reference': None,
              u'@id': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1/document-14',
              u'UID': IUUID(self.document),
              u'trashed': False,

--- a/opengever/api/tests/test_solrsearch.py
+++ b/opengever/api/tests/test_solrsearch.py
@@ -1,4 +1,5 @@
 from ftw.testbrowser import browsing
+from opengever.dossier.behaviors.dossier import IDossier
 from opengever.testing import IntegrationTestCase
 from opengever.testing.integration_test_case import SolrIntegrationTestCase
 from plone.uuid.interfaces import IUUID
@@ -209,6 +210,19 @@ class TestSolrSearchGet(SolrIntegrationTestCase):
         self.assertItemsEqual(
             [{u'Title': item.title, u'UID': IUUID(item)}
              for item in (self.document, self.subdocument, self.offered_dossier_to_archive)],
+            browser.json[u'items'])
+
+    @browsing
+    def test_query_for_external_reference(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        url = u'{}/@solrsearch?fq=external_reference:qpr-900-9001-\xf7&fl=UID,external_reference'.format(
+            self.portal.absolute_url())
+        browser.open(url, method='GET', headers=self.api_headers)
+
+        self.assertItemsEqual(
+            [{u'UID': IUUID(self.dossier),
+              u'external_reference': IDossier(self.dossier).external_reference}],
             browser.json[u'items'])
 
     @skip("Seems this does not behave very consistently in the moment."

--- a/opengever/base/tests/test_solr.py
+++ b/opengever/base/tests/test_solr.py
@@ -84,7 +84,6 @@ class TestSolr(IntegrationTestCase):
             'cmf_uid',
             'contactid',
             'date_of_completion',
-            'external_reference',
             'getId',
             'getObjPositionInParent',
             'is_default_page',

--- a/opengever/core/upgrades/20201006142950_reindex_external_reference_in_solr/upgrade.py
+++ b/opengever/core/upgrades/20201006142950_reindex_external_reference_in_solr/upgrade.py
@@ -1,0 +1,21 @@
+from ftw.upgrade import UpgradeStep
+
+
+class ReindexExternalReferenceInSolr(UpgradeStep):
+    """Reindex external_reference for objects in solr.
+
+    The field IDocumentMetadata.foreign_reference is also indexed into the
+    index external_reference. We include it here to reindex consistently.
+
+    Only objects with an actual value are reindexed, only a mininal amount of
+    objects in production seem to have a value.
+
+    """
+    deferrable = True
+
+    def __call__(self):
+        query = {'external_reference': {'not': [None, '']}}
+
+        for obj in self.objects(
+                query, 'Reindex external_reference in solr'):
+            obj.reindexObject(idxs=['external_reference'])

--- a/solr-conf/managed-schema
+++ b/solr-conf/managed-schema
@@ -141,6 +141,7 @@
     <field name="touched" type="pdate" indexed="true" stored="false" />
     <field name="email" type="string" indexed="true" stored="false" />
     <field name="email2" type="string" indexed="true" stored="false" />
+    <field name="external_reference" type="string" indexed="true" stored="false" />
     <field name="end" type="pdate" indexed="true" stored="false" />
     <field name="file_extension" type="string" indexed="true" stored="false" />
     <field name="filename" type="string" indexed="true" stored="false" />


### PR DESCRIPTION
With this PR we add a field `external_reference` also to Solr. The field can have two sources, it can come from documents or dossiers.

The field `IDocumentMetadata.foreign_reference` is also indexed into the index external_reference:
https://github.com/4teamwork/opengever.core/blob/fe821de8281b88dd16276158d4d7ec7029c59a96/opengever/document/indexers.py#L119-L123
We include it here to reindex consistently and the same way as the field is indexed in the catalog. This will lead to somewhat inconsistent naming of `foreign_reference` v.s. `external_reference`.

I've quickly discussed it with @lukasgraf and we'e decided to leave it as is for now, with the following way out:
- should `foreign_reference` be used, we can reindex documents with a `foreign_reference` into an additional Solr field, also called `foreign_reference`
- we can then re-index affected documents via the `external_reference` catalog index
- we leave the catalog index in place, for potential future migrations
- after those migrations took place we can get rid of the `external_reference` catalog index and keep data in Solr in `external_reference` and `foreign_reference`.

Only objects with an actual value are reindexed, only a mininal amount of objects in production seem to have a value. Nevertheless, the upgrade is `deferrable` as it is not strictly required.

Documentation on searching 

Jira: https://4teamwork.atlassian.net/browse/CA-1062

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


## Checklist (if applicable)

_Only applicable should be left and checked._

- API change:
  - [x] Documentation is updated
- Upgrade steps (changes in profile):
  - [x] Make it deferrable if possible
  - [x] Execute as much as possible conditionally