### PR TITLE
Correct main-dossier expansion tests.

### DIFF
--- a/opengever/api/tests/test_dossier.py
+++ b/opengever/api/tests/test_dossier.py
@@ -91,7 +91,7 @@ class TestMainDossierExpansion(IntegrationTestCase):
     def test_main_dossier_expansion_on_repository_root(self, browser):
         self.login(self.regular_user, browser=browser)
         browser.open(
-            self.repository_root.absolute_url() + '?expansion=main-dossier',
+            self.repository_root.absolute_url() + '?expand=main-dossier',
             method="GET",
             headers=self.api_headers,
         )
@@ -103,7 +103,7 @@ class TestMainDossierExpansion(IntegrationTestCase):
     def test_main_dossier_expansion_on_leaf_repofolder(self, browser):
         self.login(self.regular_user, browser=browser)
         browser.open(
-            self.leaf_repofolder.absolute_url() + '?expansion=main-dossier',
+            self.leaf_repofolder.absolute_url() + '?expand=main-dossier',
             method="GET",
             headers=self.api_headers,
         )
@@ -115,7 +115,7 @@ class TestMainDossierExpansion(IntegrationTestCase):
     def test_main_dossier_expansion_on_dossier(self, browser):
         self.login(self.regular_user, browser=browser)
         browser.open(
-            self.dossier.absolute_url() + '?expansion=main-dossier',
+            self.dossier.absolute_url() + '?expand=main-dossier',
             method="GET",
             headers=self.api_headers,
         )
@@ -137,7 +137,7 @@ class TestMainDossierExpansion(IntegrationTestCase):
     def test_main_dossier_expansion_on_document(self, browser):
         self.login(self.regular_user, browser=browser)
         browser.open(
-            self.document.absolute_url() + '?expansion=main-dossier',
+            self.document.absolute_url() + '?expand=main-dossier',
             method="GET",
             headers=self.api_headers,
         )
@@ -159,7 +159,7 @@ class TestMainDossierExpansion(IntegrationTestCase):
     def test_main_dossier_expansion_on_task(self, browser):
         self.login(self.regular_user, browser=browser)
         browser.open(
-            self.task.absolute_url() + '?expansion=main-dossier',
+            self.task.absolute_url() + '?expand=main-dossier',
             method="GET",
             headers=self.api_headers,
         )
@@ -181,7 +181,7 @@ class TestMainDossierExpansion(IntegrationTestCase):
     def test_main_dossier_expansion_on_subdossier(self, browser):
         self.login(self.regular_user, browser=browser)
         browser.open(
-            self.subdossier.absolute_url() + '?expansion=main-dossier',
+            self.subdossier.absolute_url() + '?expand=main-dossier',
             method="GET",
             headers=self.api_headers,
         )
@@ -203,7 +203,7 @@ class TestMainDossierExpansion(IntegrationTestCase):
     def test_main_dossier_expansion_on_subdocument(self, browser):
         self.login(self.regular_user, browser=browser)
         browser.open(
-            self.subdocument.absolute_url() + '?expansion=main-dossier',
+            self.subdocument.absolute_url() + '?expand=main-dossier',
             method="GET",
             headers=self.api_headers,
         )
@@ -225,7 +225,7 @@ class TestMainDossierExpansion(IntegrationTestCase):
     def test_main_dossier_expansion_on_subsubdossier(self, browser):
         self.login(self.regular_user, browser=browser)
         browser.open(
-            self.subsubdossier.absolute_url() + '?expansion=main-dossier',
+            self.subsubdossier.absolute_url() + '?expand=main-dossier',
             method="GET",
             headers=self.api_headers,
         )


### PR DESCRIPTION
The correct parameter name is "expand" and not "expansion" for requiring expansions over the REST-API. Tests were not failing because the main-dossier expansion gets expanded by default.

This is not for any jira issue, and I think does not deserve a changelog entry.

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [ ] Changelog entry
- [ ] Link to issue (Jira or GitHub) and backlink in issue (Jira)
