### PR TITLE
Also provide main_dossier for dossiertemplates

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2020.12.0 (unreleased)
 ----------------------
 
+- Also provide main_dossier for dossiertemplates [elioschmutz]
 - Allow assigning groups as participants to a Teamraum [elioschmutz]
 - Add external_reference field to solr, reindex objects with values. [deiferni]
 

--- a/opengever/api/tests/test_dossier.py
+++ b/opengever/api/tests/test_dossier.py
@@ -242,3 +242,66 @@ class TestMainDossierExpansion(IntegrationTestCase):
             },
             browser.json["@components"]['main-dossier'],
         )
+
+    @browsing
+    def test_main_dossier_expansion_on_dossiertemplate(self, browser):
+        self.login(self.regular_user, browser=browser)
+        browser.open(
+            self.dossiertemplate.absolute_url() + '?expand=main-dossier',
+            method="GET",
+            headers=self.api_headers,
+        )
+        self.assertEqual(
+            {
+                u'@id': u'http://nohost/plone/vorlagen/dossiertemplate-1',
+                u'@type': u'opengever.dossier.dossiertemplate',
+                u'description': u'Lorem ipsum',
+                u'is_leafnode': None,
+                u'is_subdossier': False,
+                u'review_state': None,
+                u'title': u'Bauvorhaben klein',
+            },
+            browser.json["@components"]['main-dossier'],
+        )
+
+    @browsing
+    def test_main_dossier_expansion_on_dossiertemplatedocument(self, browser):
+        self.login(self.regular_user, browser=browser)
+        browser.open(
+            self.dossiertemplatedocument.absolute_url() + '?expand=main-dossier',
+            method="GET",
+            headers=self.api_headers,
+        )
+        self.assertEqual(
+            {
+                u'@id': u'http://nohost/plone/vorlagen/dossiertemplate-1',
+                u'@type': u'opengever.dossier.dossiertemplate',
+                u'description': u'Lorem ipsum',
+                u'is_leafnode': None,
+                u'is_subdossier': False,
+                u'review_state': None,
+                u'title': u'Bauvorhaben klein',
+            },
+            browser.json["@components"]['main-dossier'],
+        )
+
+    @browsing
+    def test_main_dossier_expansion_on_subdossiertemplate(self, browser):
+        self.login(self.regular_user, browser=browser)
+        browser.open(
+            self.subdossiertemplate.absolute_url() + '?expand=main-dossier',
+            method="GET",
+            headers=self.api_headers,
+        )
+        self.assertEqual(
+            {
+                u'@id': u'http://nohost/plone/vorlagen/dossiertemplate-1',
+                u'@type': u'opengever.dossier.dossiertemplate',
+                u'description': u'Lorem ipsum',
+                u'is_leafnode': None,
+                u'is_subdossier': False,
+                u'review_state': None,
+                u'title': u'Bauvorhaben klein',
+            },
+            browser.json["@components"]['main-dossier'],
+        )

--- a/opengever/dossier/utils.py
+++ b/opengever/dossier/utils.py
@@ -2,6 +2,7 @@ from Acquisition import aq_inner
 from Acquisition import aq_parent
 from opengever.dossier.behaviors.dossier import IDossierMarker
 from opengever.dossier.dossiertemplate.behaviors import IDossierTemplateMarker
+from opengever.dossier.dossiertemplate.behaviors import IDossierTemplateSchema
 from opengever.inbox.inbox import IInbox
 from Products.CMFPlone.interfaces.siteroot import IPloneSiteRoot
 from Products.CMFPlone.utils import safe_unicode
@@ -41,7 +42,9 @@ def get_main_dossier(obj):
 
     dossier = None
     while obj and not IPloneSiteRoot.providedBy(obj):
-        if IDossierMarker.providedBy(obj) or IInbox.providedBy(obj):
+        if IDossierMarker.providedBy(obj) or \
+           IInbox.providedBy(obj) or \
+           IDossierTemplateSchema.providedBy(obj):
             dossier = obj
 
         obj = aq_parent(aq_inner(obj))


### PR DESCRIPTION
This PR extends the `get_main_dossier` utility function to also provide it for dossiertemplates.

Jira: https://4teamwork.atlassian.net/browse/NE-57

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


## Checklist (if applicable)

_Only applicable should be left and checked._

- API change:
  - [ ] Documentation is updated
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Upgrade steps (changes in profile):
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
- DB-Schema migration
  - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
  - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value
