### PR TITLE
Add and index PHVS specific fields in solr.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2020.12.0 (unreleased)
 ----------------------
 
+- Add and index PHVS specific fields in solr. [njohner]
 - Allow assigning groups as participants to a Teamraum [elioschmutz]
 - Add external_reference field to solr, reindex objects with values. [deiferni]
 

--- a/opengever/api/listing.py
+++ b/opengever/api/listing.py
@@ -34,6 +34,8 @@ OTHER_ALLOWED_FIELDS = set([
     'is_subtask',
     'issuer',
     'lastname',
+    'language',
+    'location',
     'modified',
     'phone_office',
     'receipt_date',

--- a/opengever/core/upgrades/20201009110640_add_phvs_special_fields_to_solr/upgrade.py
+++ b/opengever/core/upgrades/20201009110640_add_phvs_special_fields_to_solr/upgrade.py
@@ -1,0 +1,15 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddPhvsSpecialFieldsToSolr(UpgradeStep):
+    """Add phvs special fields to solr.
+    """
+
+    deferrable = True
+
+    marker_interface = "opengever.phvs.behaviors.IPHVSAdditionalBehaviorMarker"
+
+    def __call__(self):
+        query = {'object_provides': self.marker_interface}
+        for obj in self.objects(query, 'Index phvs special fields in solr.'):
+            obj.reindexObject(idxs=['language', 'location'])

--- a/solr-conf/managed-schema
+++ b/solr-conf/managed-schema
@@ -170,6 +170,10 @@
     <field name="trashed" type="boolean" indexed="true" stored="false" />
     <field name="watchers" type="string" indexed="true" stored="false" multiValued="true"/>
 
+    <!-- PHVS specific fields -->
+    <field name="language" type="string" indexed="true" stored="true" />
+    <field name="location" type="string" indexed="true" stored="true" />
+
     <copyField source="path" dest="path_parent"/>
     <copyField source="sequence_number" dest="sequence_number_string"/>
 


### PR DESCRIPTION
As listings have been switched to always using solr, we now need the PHVS specific fields to be indexed in solr in order to be able to display them in the listings. We therefore add the fields to the solr `managed-schema`. The upgrade step will only reindex object on the PHVS deployment as it queries for the interface supporting the PHVS specific fields.

I have tested this locally with the PHVS policy for the listings in the classic UI and made sure that indexing also works properly when modifying the fields (edit form in the classic and new UI).

For https://4teamwork.atlassian.net/browse/CA-950

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

- Upgrade steps (changes in profile):
  - [x] Make it deferrable if possible
  - [x] Execute as much as possible conditionally
