### PR TITLE
Activate the groups plugin for source_groups.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 ----------------------
 
 - Add @dossier-from-template endpoint. [tinagerber]
+- Activate the groups plugin for source_groups. [elioschmutz]
 - Also provide main_dossier for dossiertemplates [elioschmutz]
 - Allow assigning groups as participants to a Teamraum [elioschmutz]
 - Add external_reference field to solr, reindex objects with values. [deiferni]

--- a/opengever/api/tests/test_group.py
+++ b/opengever/api/tests/test_group.py
@@ -12,6 +12,7 @@ from Products.PloneLDAP.factory import manage_addPloneLDAPMultiPlugin
 from Products.PlonePAS.interfaces.group import IGroupIntrospection
 from Products.PlonePAS.interfaces.group import IGroupManagement
 from Products.PluggableAuthService.interfaces.plugins import IGroupEnumerationPlugin
+from Products.PluggableAuthService.interfaces.plugins import IGroupsPlugin
 import json
 
 
@@ -31,6 +32,22 @@ class TestCheckGroupPluginConfiguration(IntegrationTestCase):
         self.assertEqual(
             'Configuration error: source_groups plugin is not active '
             'for group management.',
+            exc.exception.message)
+
+    def test_raises_if_source_group_not_in_groups_plugin(self):
+        self.login(self.regular_user)
+        check_group_plugin_configuration(self.portal)
+
+        acl_users = getToolByName(self.portal, 'acl_users')
+        plugins = acl_users.plugins
+        plugins.deactivatePlugin(IGroupsPlugin, 'source_groups')
+
+        with self.assertRaises(IncorrectConfigurationError) as exc:
+            check_group_plugin_configuration(self.portal)
+
+        self.assertEqual(
+            'Configuration error: source_groups plugin is not active '
+            'for the groups plugin.',
             exc.exception.message)
 
     def test_raises_if_source_group_not_first_group_management_plugin(self):

--- a/opengever/base/utils.py
+++ b/opengever/base/utils.py
@@ -249,8 +249,13 @@ def check_group_plugin_configuration(portal):
             "for group enumeration.")
 
     group_introspection_plugins = plugins.getAllPlugins('IGroupIntrospection')
-
     if 'source_groups' not in group_introspection_plugins.get('active'):
         raise IncorrectConfigurationError(
             "Configuration error: source_groups plugin is not active "
             "for group introspection.")
+
+    groups_plugins = plugins.getAllPlugins('IGroupsPlugin')
+    if 'source_groups' not in groups_plugins.get('active'):
+        raise IncorrectConfigurationError(
+            "Configuration error: source_groups plugin is not active "
+            "for the groups plugin.")

--- a/opengever/core/upgrades/20201012191434_activate_groups_plugin_for_source_groups/upgrade.py
+++ b/opengever/core/upgrades/20201012191434_activate_groups_plugin_for_source_groups/upgrade.py
@@ -1,0 +1,33 @@
+from ftw.upgrade import UpgradeStep
+from Products.CMFPlone.utils import getToolByName
+from Products.PluggableAuthService.interfaces.plugins import IGroupsPlugin
+import logging
+
+LOG = logging.getLogger('ftw.upgrade')
+
+
+class ActivateGroupsPluginForSourceGroups(UpgradeStep):
+    """Activate groups plugin for source groups.
+
+    The groups plugin determines the groups to which a user belongs. This is
+    mandatory to make permission lookups through groups possible.
+
+    Since an admin can manage local groups, we need to activate this plugin
+    for the source_groups.
+    """
+
+    def __call__(self):
+        acl_users = getToolByName(self.portal, 'acl_users')
+        plugins = acl_users.plugins
+
+        # Make sure that source_groups is activated for groups plugin
+        groups_plugin = plugins.getAllPlugins('IGroupsPlugin')
+        if 'source_groups' in groups_plugin.get('available'):
+            plugins.activatePlugin(IGroupsPlugin, 'source_groups')
+        elif 'source_groups' not in groups_plugin.get('active'):
+            LOG.error('Source groups is not available for group introspection')
+
+        # move source_groups plugin up. 3 times...
+        plugins.movePluginsUp(IGroupsPlugin, ('source_groups',))
+        plugins.movePluginsUp(IGroupsPlugin, ('source_groups',))
+        plugins.movePluginsUp(IGroupsPlugin, ('source_groups',))

--- a/opengever/setup/deploy.py
+++ b/opengever/setup/deploy.py
@@ -105,10 +105,12 @@ class GeverDeployment(object):
         plugins = acl_users.plugins
 
         # disable source_groups when using ldap except for group management,
-        # enumeration and introspection which are used to create groups over
-        # the @groups endpoint.
+        # enumeration, introspection and groups lookup which are used to create
+        # groups over the @groups endpoint and use it for local roles.
         for ptype in plugins.listPluginTypeInfo():
-            if ptype['id'] in ['IGroupEnumerationPlugin', 'IGroupIntrospection']:
+            if ptype['id'] in ['IGroupEnumerationPlugin',
+                               'IGroupIntrospection',
+                               'IGroupsPlugin']:
                 continue
             if ptype['id'] == 'IGroupManagement':
                 to_deactivate = 'ldap'


### PR DESCRIPTION
Activates the `IGroupsPlugin` for `source_groups`. The groups plugins determines the groups to which a user belongs. This is mandatory to make permission lookups through groups possible. Since an admin can manage local groups, we need to activate this plugin for the source_groups.

<img width="1416" alt="Bildschirmfoto 2020-10-12 um 20 12 22" src="https://user-images.githubusercontent.com/557005/95777876-53ddc480-0cc7-11eb-89de-1a841b1fc669.png">

The implementation is leaned on: https://github.com/4teamwork/opengever.core/pull/6631

Jira: https://4teamwork.atlassian.net/browse/NE-71

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


## Checklist (if applicable)

_Only applicable should be left and checked._

- API change:
  - [ ] Documentation is updated
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Upgrade steps (changes in profile):
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
- DB-Schema migration
  - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
  - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value
