### PR TITLE
Add @dossier-from-template endpoint

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2020.12.0 (unreleased)
 ----------------------
 
+- Add @dossier-from-template endpoint. [tinagerber]
 - Also provide main_dossier for dossiertemplates [elioschmutz]
 - Allow assigning groups as participants to a Teamraum [elioschmutz]
 - Add external_reference field to solr, reindex objects with values. [deiferni]

--- a/docs/public/dev-manual/api/content_types.rst
+++ b/docs/public/dev-manual/api/content_types.rst
@@ -32,6 +32,7 @@ Ordnungsposition
 --------------------
 
 
+.. _label-dossier-schema:
 
 Geschäftsdossier
 ^^^^^^^^^^^^^^^^

--- a/docs/public/dev-manual/api/docs_changelog.rst
+++ b/docs/public/dev-manual/api/docs_changelog.rst
@@ -8,6 +8,11 @@ Im Folgenden sind (substantielle) Änderungen an der Dokumentation aufgeführt.
 2020-09-01
 ----------
 
+- Kapitel "Geschäftsdossier ab Vorlage erstellen" hinzugefügt
+
+2020-09-01
+----------
+
 - Kapitel "Beteiligungen" hinzugefügt
 
 

--- a/docs/public/dev-manual/api/dossier_from_template.rst
+++ b/docs/public/dev-manual/api/dossier_from_template.rst
@@ -1,0 +1,33 @@
+.. _dossier_from_template:
+
+Geschäftsdossier ab Vorlage erstellen
+=====================================
+
+In einer Ordnungsposition kann über den Endpoint ``@dossier-from-template`` ein neues
+Geschäftsdossier ab Vorlage erstellt werden.
+
+Der Endpoint erwartet mindestens folgende Parameter:
+
+- ``template``: Das zu verwendende Template aus dem Vokabular ``opengever.dossier.DossierTemplatesVocabulary``
+- ``responsible``: Der Federführende des zu erstellenden Dossiers
+- ``title``: Der Titel des zu erstellenden Dossiers
+
+Zusätzlich können auch die anderen Felder des :ref:`label-dossier-schema`-Schemas gesetzt werden.
+
+**Beispiel-Request**:
+
+   .. sourcecode:: http
+
+       POST /ordnungssystem/fuehrung/@dossier-from-template HTTP/1.1
+       Accept: application/json
+
+       {
+        "template": {"token": "1234567890"},
+        "description": "Dossier description"
+        "responsible": "rolf.ziegler",
+        "title": "Dossier title"
+       }
+
+
+Als Response wird die JSON-Repräsentation des neu erstellten Dossiers geliefert,
+siehe :ref:`Inhaltstypen <content-types>`.

--- a/docs/public/dev-manual/api/index.rst
+++ b/docs/public/dev-manual/api/index.rst
@@ -50,6 +50,7 @@ Inhalt:
    workspace/index
    linked_workspaces.rst
    templatefolder.rst
+   dossier_from_template.rst
    trigger_task_template.rst
    remote_workflow.rst
    accept_remote_task.rst

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -793,6 +793,14 @@
 
   <plone:service
       method="POST"
+      name="@dossier-from-template"
+      for="opengever.repository.interfaces.IRepositoryFolder"
+      factory=".templatefolder.DossierFromTemplatePost"
+      permission="cmf.AddPortalContent"
+      />
+
+  <plone:service
+      method="POST"
       name="@trigger-task-template"
       for="opengever.dossier.behaviors.dossier.IDossierMarker"
       factory=".templatefolder.TriggerTaskTemplatePost"

--- a/opengever/api/templatefolder.py
+++ b/opengever/api/templatefolder.py
@@ -44,7 +44,7 @@ class DocumentFromTemplatePost(Service):
             raise BadRequest('Missing parameter template')
 
         vocabulary = getUtility(IVocabularyFactory,
-                             name='opengever.dossier.DocumentTemplatesVocabulary')
+                                name='opengever.dossier.DocumentTemplatesVocabulary')
         term = vocabulary(self.context).getTermByToken(token)
         template = term.value
 
@@ -88,15 +88,15 @@ class ITriggerTaskTemplateSources(model.Schema):
                          'opengever.tasktemplates.content.templatefoldersschema.ITaskTemplateFolderSchema',
                          'opengever.tasktemplates.content.tasktemplate.ITaskTemplate',
                          ]
-                    }
-                )
+                }
+            )
         )
     )
 
     responsible = schema.Choice(
         source=TaskResponsibleSourceBinder(include_teams=True),
         required=True,
-        )
+    )
 
     related_documents = RelationList(
         required=False,
@@ -113,7 +113,7 @@ class ITriggerTaskTemplateSources(model.Schema):
                      'opengever.task.task.ITask',
                      'ftw.mail.mail.IMail', ],
                 }),
-            )
+        )
     )
 
 
@@ -183,7 +183,7 @@ class TriggerTaskTemplatePost(Service):
             IFieldDeserializer)
 
         responsible_field = Fields(
-                ITriggerTaskTemplateSources)['responsible'].field
+            ITriggerTaskTemplateSources)['responsible'].field
         responsible_deserializer = queryMultiAdapter(
             (responsible_field, self.context, self.request),
             IFieldDeserializer)
@@ -227,7 +227,7 @@ class TriggerTaskTemplatePost(Service):
                 except (RequiredMissing, ConstraintNotSatisfied):
                     errors.append(
                         u'invalid responsible {} for template {}'.format(
-                        raw_responsible, template))
+                            raw_responsible, template))
                 else:
                     by_template['responsible'] = responsible
 

--- a/opengever/api/templatefolder.py
+++ b/opengever/api/templatefolder.py
@@ -1,8 +1,13 @@
+from opengever.api.add import FolderPost
 from opengever.api.task import deserialize_responsible
 from opengever.api.validation import get_validation_errors
 from opengever.base.source import DossierPathSourceBinder
 from opengever.base.source import SolrObjPathSourceBinder
+from opengever.dossier.behaviors.dossier import IDossier
 from opengever.dossier.command import CreateDocumentFromTemplateCommand
+from opengever.dossier.dossiertemplate.behaviors import IDossierTemplate
+from opengever.dossier.dossiertemplate.form import CreateDossierContentFromTemplateMixin
+from opengever.dossier.dossiertemplate import is_create_dossier_from_template_available
 from opengever.tasktemplates.sources import TaskResponsibleSourceBinder
 from plone import api
 from plone.protect.interfaces import IDisableCSRFProtection
@@ -16,6 +21,7 @@ from z3c.relationfield.relation import RelationValue
 from z3c.relationfield.schema import RelationChoice
 from z3c.relationfield.schema import RelationList
 from zExceptions import BadRequest
+from zExceptions import Unauthorized
 from zope import schema
 from zope.component import getUtility
 from zope.component import queryMultiAdapter
@@ -58,6 +64,48 @@ class DocumentFromTemplatePost(Service):
 
         serializer = queryMultiAdapter((document, self.request), ISerializeToJson)
         return serializer()
+
+
+class DossierFromTemplatePost(FolderPost, CreateDossierContentFromTemplateMixin):
+    """API Endpoint to create a dossier from a template.
+    """
+    def extract_data(self):
+        data = self.request_data
+        self.type_ = 'opengever.dossier.businesscasedossier'
+        self.id_ = data.get("id", None)
+        self.title_ = data.get('title', None)
+
+        token = data.get('template')
+        if isinstance(token, dict):
+            token = token.get('token')
+        if not token:
+            raise BadRequest('Missing parameter template')
+        vocabulary = getUtility(IVocabularyFactory,
+                                name='opengever.dossier.DossierTemplatesVocabulary')
+        try:
+            self.dossier_template = vocabulary(self.context).getTermByToken(token).value
+        except LookupError:
+            raise BadRequest("Invalid token '{}'".format(token))
+        return data
+
+    def reply(self):
+        if not is_create_dossier_from_template_available(self.context):
+            raise Unauthorized
+
+        serialized_dossier = super(DossierFromTemplatePost, self).reply()
+        self.validate_keywords(self.dossier_template, self.request_data.get('keywords'))
+        self.create_dossier_content_from_template(self.obj, self.dossier_template)
+        return serialized_dossier
+
+    def validate_keywords(self, dossier_template, keywords_data):
+        if dossier_template.restrict_keywords and keywords_data:
+            allowed_keywords = IDossierTemplate(dossier_template).keywords
+            deserializer = queryMultiAdapter(
+                (IDossier['keywords'], self.obj, self.request), IFieldDeserializer)
+            keywords = deserializer(keywords_data)
+            for keyword in keywords:
+                if keyword not in allowed_keywords:
+                    raise BadRequest("Keyword '{}' is not allowed".format(keyword))
 
 
 class ITriggerTaskTemplate(model.Schema):

--- a/opengever/api/tests/test_templatefolder.py
+++ b/opengever/api/tests/test_templatefolder.py
@@ -208,7 +208,7 @@ class TestTriggerTaskTemplatePost(IntegrationTestCase):
         self.assertEqual('fa', main_task.responsible_client)
         self.assertEqual('direct-execution', main_task.task_type)
         self.assertEqual('task-state-in-progress',
-                          api.content.get_state(main_task))
+                         api.content.get_state(main_task))
 
         subtasks = main_task.listFolderContents()
         self.assertEqual(1, len(subtasks))
@@ -218,7 +218,7 @@ class TestTriggerTaskTemplatePost(IntegrationTestCase):
         self.assertEqual('robert.ziegler', subtask.responsible)
         self.assertEqual('fa', subtask.responsible_client)
         self.assertEqual('task-state-open',
-                          api.content.get_state(subtask))
+                         api.content.get_state(subtask))
 
     @browsing
     def test_trigger_with_non_nested_task_template_folder_input(self, browser):
@@ -349,9 +349,9 @@ class TestTriggerTaskTemplatePost(IntegrationTestCase):
                 'responsible_client': 'fa',
                 'responsible': 'robert.ziegler',
                 'deadline': 10,
-                })
+            })
             .within(foreign_task_template_folder)
-            )
+        )
 
         data = {
             'tasktemplatefolder': self._get_task_template_item(
@@ -424,11 +424,11 @@ class TestTriggerTaskTemplatePost(IntegrationTestCase):
         main_task = children['added'].pop()
         self.assertTrue(IFromParallelTasktemplate.providedBy(main_task))
         self.assertEqual('task-state-in-progress',
-                          api.content.get_state(main_task))
+                         api.content.get_state(main_task))
         for subtask in main_task.listFolderContents():
             self.assertTrue(IFromParallelTasktemplate.providedBy(subtask))
             self.assertEqual('task-state-open',
-                              api.content.get_state(subtask))
+                             api.content.get_state(subtask))
 
     @browsing
     def test_create_sequential_tasks(self, browser):
@@ -454,11 +454,11 @@ class TestTriggerTaskTemplatePost(IntegrationTestCase):
         main_task = children['added'].pop()
         self.assertTrue(IFromSequentialTasktemplate.providedBy(main_task))
         self.assertEqual('task-state-in-progress',
-                          api.content.get_state(main_task))
+                         api.content.get_state(main_task))
         for subtask in main_task.listFolderContents():
             self.assertTrue(IFromSequentialTasktemplate.providedBy(subtask))
             self.assertEqual('task-state-planned',
-                              api.content.get_state(subtask))
+                             api.content.get_state(subtask))
 
     @browsing
     def test_respects_start_immediately_flag(self, browser):
@@ -466,12 +466,12 @@ class TestTriggerTaskTemplatePost(IntegrationTestCase):
         self.tasktemplatefolder.sequence_type = u'sequential'
 
         template_2 = create(Builder('tasktemplate')
-               .titled(u'Noch was.')
-               .having(issuer='responsible',
-                       responsible_client='fa',
-                       responsible='robert.ziegler',
-                       deadline=10,)
-               .within(self.tasktemplatefolder))
+                            .titled(u'Noch was.')
+                            .having(issuer='responsible',
+                                    responsible_client='fa',
+                                    responsible='robert.ziegler',
+                                    deadline=10,)
+                            .within(self.tasktemplatefolder))
 
         data = {
             'tasktemplatefolder': self._get_task_template_item(browser),
@@ -507,20 +507,20 @@ class TestTriggerTaskTemplatePost(IntegrationTestCase):
         self.login(self.regular_user, browser=browser)
 
         notebook = create(Builder('tasktemplate')
-               .titled(u'Notebook einrichten.')
-               .having(issuer='responsible',
-                       responsible_client='fa',
-                       responsible='robert.ziegler',
-                       deadline=10)
-        .within(self.tasktemplatefolder))
+                          .titled(u'Notebook einrichten.')
+                          .having(issuer='responsible',
+                                  responsible_client='fa',
+                                  responsible='robert.ziegler',
+                                  deadline=10)
+                          .within(self.tasktemplatefolder))
 
         user_accounts = create(Builder('tasktemplate')
-               .titled(u'User Accounts erstellen.')
-               .having(issuer='responsible',
-                       responsible_client='fa',
-                       responsible='robert.ziegler',
-                       deadline=10)
-        .within(self.tasktemplatefolder))
+                               .titled(u'User Accounts erstellen.')
+                               .having(issuer='responsible',
+                                       responsible_client='fa',
+                                       responsible='robert.ziegler',
+                                       deadline=10)
+                               .within(self.tasktemplatefolder))
 
         data = {
             'tasktemplatefolder': self._get_task_template_item(browser),
@@ -791,12 +791,12 @@ class TestTriggerTaskTemplatePost(IntegrationTestCase):
         self.tasktemplatefolder.sequence_type = u'sequential'
 
         template_2 = create(Builder('tasktemplate')
-               .titled(u'Notebook einrichten.')
-               .having(issuer='responsible',
-                       responsible_client='fa',
-                       responsible='robert.ziegler',
-                       deadline=10,)
-        .within(self.tasktemplatefolder))
+                            .titled(u'Notebook einrichten.')
+                            .having(issuer='responsible',
+                                    responsible_client='fa',
+                                    responsible='robert.ziegler',
+                                    deadline=10,)
+                            .within(self.tasktemplatefolder))
 
         data = {
             'tasktemplatefolder': self._get_task_template_item(browser),

--- a/opengever/api/tests/test_vocabularies.py
+++ b/opengever/api/tests/test_vocabularies.py
@@ -33,6 +33,7 @@ NON_SENSITIVE_VOCABUALRIES = [
     'opengever.document.document_types',
     'opengever.dossier.container_types',
     'opengever.dossier.DocumentTemplatesVocabulary',
+    'opengever.dossier.DossierTemplatesVocabulary',
     'opengever.dossier.participation_roles',
     'opengever.dossier.type_prefixes',
     'opengever.dossier.ValidResolverNamesVocabulary',

--- a/opengever/core/profiles/default/actions.xml
+++ b/opengever/core/profiles/default/actions.xml
@@ -1,5 +1,7 @@
 <object xmlns:i18n="http://xml.zope.org/namespaces/i18n" name="portal_actions" meta_type="Plone Actions Tool">
 
+  <object name="folder_factories" meta_type="CMF Action Category" />
+
   <!-- DOCUMENT ACTIONS -->
   <object name="document_actions" meta_type="CMF Action Category">
 

--- a/opengever/core/upgrades/20201008174028_add_folder_factories_to_portal_actions/actions.xml
+++ b/opengever/core/upgrades/20201008174028_add_folder_factories_to_portal_actions/actions.xml
@@ -1,0 +1,5 @@
+<object xmlns:i18n="http://xml.zope.org/namespaces/i18n" name="portal_actions" meta_type="Plone Actions Tool">
+
+  <object name="folder_factories" meta_type="CMF Action Category" />
+
+</object>

--- a/opengever/core/upgrades/20201008174028_add_folder_factories_to_portal_actions/upgrade.py
+++ b/opengever/core/upgrades/20201008174028_add_folder_factories_to_portal_actions/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddFolderFactoriesToPortalActions(UpgradeStep):
+    """Add folder_factories to portal_actions.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/dossier/dossiertemplate/__init__.py
+++ b/opengever/dossier/dossiertemplate/__init__.py
@@ -5,3 +5,9 @@ from plone import api
 def is_dossier_template_feature_enabled():
     return api.portal.get_registry_record(
         'is_feature_enabled', interface=IDossierTemplateSettings)
+
+
+def is_create_dossier_from_template_available(context):
+    return is_dossier_template_feature_enabled() and context.is_leaf_node() and \
+            api.user.has_permission('opengever.dossier: Add businesscasedossier', obj=context) and \
+            (context.allow_add_businesscase_dossier or context.addable_dossier_templates)

--- a/opengever/dossier/dossiertemplate/configure.zcml
+++ b/opengever/dossier/dossiertemplate/configure.zcml
@@ -86,4 +86,9 @@
       permission="cmf.ModifyPortalContent"
       />
 
+  <utility
+      factory=".form.DossierTemplatesVocabulary"
+      name="opengever.dossier.DossierTemplatesVocabulary"
+      />
+
 </configure>

--- a/opengever/dossier/dossiertemplate/form.py
+++ b/opengever/dossier/dossiertemplate/form.py
@@ -34,8 +34,10 @@ from zExceptions import Unauthorized
 from zope.app.intid.interfaces import IIntIds
 from zope.component import getUtility
 from zope.interface import alsoProvides
+from zope.interface import implementer
 from zope.interface import provider
 from zope.schema.interfaces import IContextSourceBinder
+from zope.schema.interfaces import IVocabularyFactory
 from zope.schema.vocabulary import SimpleVocabulary
 import json
 
@@ -66,6 +68,15 @@ def get_dossier_templates(context):
             template.title))
 
     return SimpleVocabulary(terms)
+
+
+@implementer(IVocabularyFactory)
+class DossierTemplatesVocabulary(object):
+
+    def __call__(self, context):
+        if not IRestrictAddableDossierTemplates.providedBy(context):
+            return SimpleVocabulary([])
+        return get_dossier_templates(context)
 
 
 def get_wizard_storage_key(context):

--- a/opengever/dossier/dossiertemplate/form.py
+++ b/opengever/dossier/dossiertemplate/form.py
@@ -12,6 +12,7 @@ from opengever.dossier import _
 from opengever.dossier.behaviors.dossier import IDossier
 from opengever.dossier.command import CreateDocumentFromTemplateCommand
 from opengever.dossier.command import CreateDossierFromTemplateCommand
+from opengever.dossier.dossiertemplate import is_create_dossier_from_template_available
 from opengever.dossier.dossiertemplate import is_dossier_template_feature_enabled
 from opengever.dossier.dossiertemplate.behaviors import IDossierTemplate
 from opengever.dossier.dossiertemplate.behaviors import IDossierTemplateSchema
@@ -362,7 +363,4 @@ class SelectDossierTemplateView(FormWrapper):
         """Checks if it is allowed to add a 'dossier from template'
         at the current context.
         """
-        return is_dossier_template_feature_enabled() and \
-            self.context.is_leaf_node() and \
-            api.user.has_permission('opengever.dossier: Add businesscasedossier', obj=self.context) and \
-            (self.context.allow_add_businesscase_dossier or self.context.addable_dossier_templates)
+        return is_create_dossier_from_template_available(self.context)


### PR DESCRIPTION
Changes in this PR:

- Add `folder_factories` to `portal_actions`. This way the folder_factories appear by default when the @actions endpoint is requested and we don't have to define, which categories are needed. With this information we can then find out where the dossiers, documents and tasks can be created from template.
- Implement `opengever.dossier.DossierTemplatesVocabulary`.
- Move some functions to a helper class to make them reusable. I'm not sure if it's pythonic to have a mixin class or if I copied that from frontend development. 🤔
- Add `@dossier-from-template` endpoint. The endpoint inherits from the class used to create content using POST requests to create the dossier. The remaining content is then created using the methods I moved to the mixin helper class.

Jira: https://4teamwork.atlassian.net/browse/NE-92

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


## Checklist (if applicable)

_Only applicable should be left and checked._

- API change:
  - [x] Documentation is updated