### PR TITLE
Add @possible-participants endpoint.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -10,6 +10,7 @@ Changelog
 - Add is_readonly flag for @config endpoint and @@gever_state view. [lgraf]
 - Add @dossier-from-template endpoint. [tinagerber]
 - Activate the groups plugin for source_groups. [elioschmutz]
+- Add @possible-participants endpoint. [tinagerber]
 - Also provide main_dossier for dossiertemplates [elioschmutz]
 - Allow assigning groups as participants to a Teamraum [elioschmutz]
 - Add external_reference field to solr, reindex objects with values. [deiferni]

--- a/docs/public/dev-manual/api/dossier_participations.rst
+++ b/docs/public/dev-manual/api/dossier_participations.rst
@@ -163,6 +163,42 @@ Mittels DELETE-Requests kann eine Beteiligung wieder entfernt werden.
 
       HTTP/1.1 204 No content
 
+Liste von möglichen Beteiligten
+-------------------------------
+Der ``@possible-participants``-Endpoint liefert eine Liste von Aktoren, welche als Beteiligte für den aktuellen Kontext hinzugefügt werden können. Der Endpoint steht nur für Dossiers zur Verfügung.
+
+**Beispiel-Request:**
+
+
+  .. sourcecode:: http
+
+    GET /dossier-1/@possible-participants HTTP/1.1
+    Accept: application/json
+
+
+**Beispiel-Response:**
+
+   .. sourcecode:: http
+
+      HTTP/1.1 200 OK
+      Content-Type: application/json
+
+      {
+        "@id": "https://example.org/ordnungssystem/fuehrung/dossier-1//@possible-particpants",
+        "items": [
+          {
+            "title": "Bond James (james@example.com)",
+            "token": "contact:james.bond"
+          },
+          {
+            "title": "Ziegler Rolf (rolf.ziegler)",
+            "token": "rolf.ziegler"
+          },
+          { "...": "..." },
+        ],
+        "items_total": 17
+      }
+
 
 Paginierung
 ~~~~~~~~~~~

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -1062,4 +1062,12 @@
       name="participations"
       />
 
+  <plone:service
+      method="GET"
+      name="@possible-participants"
+      for="opengever.dossier.behaviors.participation.IParticipationAwareMarker"
+      factory=".dossier_participations.PossibleParticipantsGet"
+      permission="zope2.View"
+      />
+
 </configure>


### PR DESCRIPTION
In this PR a new API endpoint `@possible-participants` is implemented. The endpoint is used to decide for which users/contacts/mailboxes participations can be added.

Jira: https://4teamwork.atlassian.net/browse/NE-90

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


## Checklist (if applicable)

_Only applicable should be left and checked._

- API change:
  - [x] Documentation is updated