### PR TITLE
Extend the @listing endpoint to list `folder_contents`

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -8,6 +8,7 @@ Changelog
 - Patch several login-related events to allow login during readonly mode. [lgraf]
 - Add optional support for WriteOnRead tracing in ReadOnlyError page. [lgraf]
 - Add videoconferencing URL to workspaces. [deiferni]
+- Add a new listing: `folder_contents` to the @listing endpoint. [elioschmutz]
 - Use custom error page for ReadOnlyErrors. [lgraf]
 - Disable GZip compression in p.a.caching. [lgraf]
 - Add viewlet that shows a message to indicate readonly mode. [lgraf]

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -8,6 +8,7 @@ Changelog
 - Patch several login-related events to allow login during readonly mode. [lgraf]
 - Add optional support for WriteOnRead tracing in ReadOnlyError page. [lgraf]
 - Add videoconferencing URL to workspaces. [deiferni]
+- Add a new listing field: creator_fullname. [elioschmutz]
 - Add a new listing: `folder_contents` to the @listing endpoint. [elioschmutz]
 - Use custom error page for ReadOnlyErrors. [lgraf]
 - Disable GZip compression in p.a.caching. [lgraf]

--- a/docs/public/dev-manual/api/listings.rst
+++ b/docs/public/dev-manual/api/listings.rst
@@ -55,6 +55,7 @@ Aktuell werden folgende Auflistungen unterstützt:
 - ``contacts``: Lokale Kontakte
 - ``tasktemplates``: Standardabläufe
 - ``tasktemplate_folders``: Aufgabenvorlagen
+- ``folder_contents``: Alle Inhalte innerhalb des Objektes
 
 
 Für jede Auflistung können verschiedene Felder (Parameter ``columns``) abgefragt

--- a/docs/public/dev-manual/api/listings.rst
+++ b/docs/public/dev-manual/api/listings.rst
@@ -71,6 +71,7 @@ werden. Folgende Felder stehen zur Verfügung:
 - ``containing_subdossier``: Titel des Subdossiers in dem das Dokument enthalten ist
 - ``created``: Erstelldatum
 - ``creator``: Ersteller
+- ``creator_fullname``: Ersteller (Anzeigename)
 - ``deadline``: Aufgabenfrist
 - ``delivery_date``: Ausgangsdatum
 - ``description``: Beschreibung
@@ -146,6 +147,8 @@ siehe Tabelle:
     |``created``               |    ja    |    ja   |      ja      |         ja         |   ja    |   ja    |   ja    |    ja    |        ja       |        ja        |       ja        |
     +--------------------------+----------+---------+--------------+--------------------+---------+---------+---------+----------+-----------------+------------------+-----------------+
     |``creator``               |    ja    |    ja   |      ja      |         ja         |   ja    |   ja    |   ja    |    ja    |        ja       |        ja        |       ja        |
+    +--------------------------+----------+---------+--------------+--------------------+---------+---------+---------+----------+-----------------+------------------+-----------------+
+    |``creator_fullname``      |    ja    |    ja   |      ja      |         ja         |   ja    |   ja    |   ja    |    ja    |        ja       |        ja        |       ja        |
     +--------------------------+----------+---------+--------------+--------------------+---------+---------+---------+----------+-----------------+------------------+-----------------+
     |``deadline``              |   nein   |   nein  |     nein     |        nein        |   ja    |   ja    |  nein   |   nein   |       nein      |       nein       |       nein      |
     +--------------------------+----------+---------+--------------+--------------------+---------+---------+---------+----------+-----------------+------------------+-----------------+

--- a/opengever/api/listing.py
+++ b/opengever/api/listing.py
@@ -84,6 +84,9 @@ FILTERS = {
     ],
     u'tasktemplate_folders': [
         u'object_provides:opengever.tasktemplates.content.templatefoldersschema.ITaskTemplateFolderSchema',
+    ],
+    u'folder_contents': [
+        u'object_provides:plone.dexterity.interfaces.IDexterityContent'
     ]
 }
 

--- a/opengever/api/listing.py
+++ b/opengever/api/listing.py
@@ -162,8 +162,8 @@ class ListingGet(SolrQueryBaseService):
 
     def preprocess_filters(self, filters):
         filters = dict(filters)
-        if 'participations' in filters and ('participants' in filters or
-                                            'participation_roles' in filters):
+        if 'participations' in filters and ('participants' in filters
+                                            or 'participation_roles' in filters):
             raise BadRequest(
                 "Cannot set participations filter together with participants "
                 "or participation_roles filters.")

--- a/opengever/api/solr_query_service.py
+++ b/opengever/api/solr_query_service.py
@@ -285,6 +285,7 @@ FIELDS_WITH_MAPPING = [
     ListingField('checked_out', 'checked_out', transform=display_name),
     ListingField('checked_out_fullname', 'checked_out', 'checked_out_fullname'),
     ListingField('creator', 'Creator', transform=display_name),
+    ListingField('creator_fullname', 'Creator', 'creator_fullname'),
     ListingField('description', 'Description'),
     ListingField('document_type', 'document_type', transform=translate_document_type),
     ListingField('filename', 'filename', filename),

--- a/opengever/api/tests/test_listing.py
+++ b/opengever/api/tests/test_listing.py
@@ -993,6 +993,69 @@ class TestListingWithRealSolr(SolrIntegrationTestCase):
             }
         ], browser.json['items'])
 
+    @browsing
+    def test_folder_contents_listing(self, browser):
+        self.login(self.workspace_member, browser=browser)
+        query_string = '&'.join((
+            'name=folder_contents',
+        ))
+        view = '?'.join(('@listing', query_string))
+        browser.open(self.workspace, view=view, headers=self.api_headers)
+
+        self.assertEqual(
+            [
+                u'http://nohost/plone/workspaces/workspace-1/todolist-2/todo-3',
+                u'http://nohost/plone/workspaces/workspace-1/todolist-2',
+                u'http://nohost/plone/workspaces/workspace-1/todolist-2/todo-2',
+                u'http://nohost/plone/workspaces/workspace-1/todo-1',
+                u'http://nohost/plone/workspaces/workspace-1/todolist-1',
+                u'http://nohost/plone/workspaces/workspace-1/folder-1',
+                u'http://nohost/plone/workspaces/workspace-1/folder-1/document-40',
+                u'http://nohost/plone/workspaces/workspace-1/document-39',
+                u'http://nohost/plone/workspaces/workspace-1/document-38'
+            ],
+            [item.get('@id') for item in browser.json['items']])
+
+    @browsing
+    def test_folder_contents_listing_filtered_by_depth(self, browser):
+        self.login(self.workspace_member, browser=browser)
+        query_string = '&'.join((
+            'name=folder_contents',
+            'depth=1',
+        ))
+        view = '?'.join(('@listing', query_string))
+        browser.open(self.workspace, view=view, headers=self.api_headers)
+
+        self.assertEqual(
+            [
+                u'http://nohost/plone/workspaces/workspace-1/todolist-2',
+                u'http://nohost/plone/workspaces/workspace-1/todo-1',
+                u'http://nohost/plone/workspaces/workspace-1/todolist-1',
+                u'http://nohost/plone/workspaces/workspace-1/folder-1',
+                u'http://nohost/plone/workspaces/workspace-1/document-39',
+                u'http://nohost/plone/workspaces/workspace-1/document-38'
+            ],
+            [item.get('@id') for item in browser.json['items']])
+
+    @browsing
+    def test_filtered_folder_contents_listing(self, browser):
+        self.login(self.workspace_member, browser=browser)
+        query_string = '&'.join((
+            'name=folder_contents',
+            'filters.portal_type:record:list=opengever.workspace.folder',
+            'filters.portal_type:record:list=opengever.document.document',
+        ))
+        view = '?'.join(('@listing', query_string))
+        browser.open(self.workspace, view=view, headers=self.api_headers)
+
+        self.assertEqual(
+            [
+                u'http://nohost/plone/workspaces/workspace-1/folder-1',
+                u'http://nohost/plone/workspaces/workspace-1/folder-1/document-40',
+                u'http://nohost/plone/workspaces/workspace-1/document-38',
+            ],
+            [item.get('@id') for item in browser.json['items']])
+
 
 class TestSQLDossierParticipationsInListingWithRealSolr(SolrIntegrationTestCase):
 

--- a/opengever/api/tests/test_listing.py
+++ b/opengever/api/tests/test_listing.py
@@ -1056,6 +1056,18 @@ class TestListingWithRealSolr(SolrIntegrationTestCase):
             ],
             [item.get('@id') for item in browser.json['items']])
 
+    @browsing
+    def test_folder_contents_listing_works_for_creator_fullname(self, browser):
+        self.login(self.workspace_member, browser=browser)
+        query_string = '&'.join((
+            'name=folder_contents',
+            'columns:list=creator_fullname',
+        ))
+        view = '?'.join(('@listing', query_string))
+        browser.open(self.workspace, view=view, headers=self.api_headers)
+
+        self.assertEqual(u'Fr\xf6hlich G\xfcnther', browser.json['items'][0].get('creator_fullname'))
+
 
 class TestSQLDossierParticipationsInListingWithRealSolr(SolrIntegrationTestCase):
 

--- a/opengever/api/tests/test_listing_stats.py
+++ b/opengever/api/tests/test_listing_stats.py
@@ -68,7 +68,8 @@ class TestListingStats(SolrIntegrationTestCase):
                     {u'count': 0, u'field': u'listing_name', u'value': u'tasktemplates'},
                     {u'count': 0, u'field': u'listing_name', u'value': u'todos'},
                     {u'count': 0, u'field': u'listing_name', u'value': u'workspace_folders'},
-                    {u'count': 0, u'field': u'listing_name', u'value': u'workspaces'}]
+                    {u'count': 0, u'field': u'listing_name', u'value': u'workspaces'},
+                    {u'count': 27, u'field': u'listing_name', u'value': u'folder_contents'}]
 
         self.assertItemsEqual(expected, browser.json['facet_pivot']['listing_name'])
 
@@ -93,9 +94,10 @@ class TestListingStats(SolrIntegrationTestCase):
 
         pivot = self.get_facet_pivot_for(dossier, 'listing_name', browser)
 
-        self.assertEqual(4, sum([facet.get('count') for facet in pivot]))
+        self.assertEqual(8, sum([facet.get('count') for facet in pivot]))
         self.assertEqual(1, self.get_facet_by_value(pivot, 'dossiers').get('count'))
         self.assertEqual(3, self.get_facet_by_value(pivot, 'documents').get('count'))
+        self.assertEqual(4, self.get_facet_by_value(pivot, 'folder_contents').get('count'))
 
     @browsing
     def test_exclude_trashed_content(self, browser):
@@ -181,7 +183,11 @@ class TestListingStats(SolrIntegrationTestCase):
                     {u'count': 0,
                      u'field': u'listing_name',
                      u'queries': {u'responsible:kathi.barfuss': 0},
-                     u'value': u'workspaces'}]
+                     u'value': u'workspaces'},
+                    {u'count': 27,
+                     u'field': u'listing_name',
+                     u'queries': {u'responsible:kathi.barfuss': 9},
+                     u'value': u'folder_contents'}]
         self.assertItemsEqual(expected, browser.json['facet_pivot']['listing_name'])
 
     @browsing

--- a/opengever/base/contentlisting.py
+++ b/opengever/base/contentlisting.py
@@ -197,6 +197,10 @@ class OpengeverCatalogContentListingObject(CatalogContentListingObject):
         userid = getattr(self._brain, "checked_out", None)
         return None if userid is None else display_name(userid)
 
+    def creator_fullname(self):
+        userid = getattr(self._brain, "Creator", None)
+        return None if userid is None else display_name(userid)
+
     def creator(self):
         return self._brain.Creator
 


### PR DESCRIPTION
This PR:

- adds a new listing to list all contents within a context
- adds a new listing-field `creator_fullname`

We need to list contents of a workspaces. Currently `contents` are workspace folders, documents and mails. A generic `folder_contents` listing lets the frontend decide, which types should appear in the `contents` tab.

Jira: https://4teamwork.atlassian.net/browse/NE-124

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

## Checklist (if applicable)

_Only applicable should be left and checked._

- API change:
  - [ ] Documentation is updated
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Upgrade steps (changes in profile):
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
- DB-Schema migration
  - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
  - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value
