### PR TITLE
Create and persist Bumblebee user salt on login.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2020.12.0 (unreleased)
 ----------------------
 
+- Create Bumblebee user salt on login. [lgraf]
 - Patch several login-related events to allow login during readonly mode. [lgraf]
 - Add optional support for WriteOnRead tracing in ReadOnlyError page. [lgraf]
 - Use custom error page for ReadOnlyErrors. [lgraf]

--- a/opengever/readonly/bumblebee.py
+++ b/opengever/readonly/bumblebee.py
@@ -1,0 +1,31 @@
+from ftw.bumblebee.interfaces import IBumblebeeUserSaltStore
+from opengever.readonly import is_in_readonly_mode
+from plone import api
+from Products.PluggableAuthService.interfaces.events import IUserLoggedInEvent
+from zope.component import adapter
+
+
+@adapter(IUserLoggedInEvent)
+def create_user_salt_on_login(event):
+    """Create the user's bumblebee salt during login, if one doesn't exist yet.
+
+    This will make sure it's available when needed, and doesn't have to be
+    calculated and persisted as part of an ad-hoc write-on-read.
+
+    Like this we can ensure that users that have already logged in at least
+    once have their salt ready, and will be able to see Bumblebee previews
+    in read-only mode.
+
+    (On a login during read-only mode this needs to be suppressed - the whole
+    idea is that we won't have to generate any salts while in read-only mode)
+    """
+    if is_in_readonly_mode():
+        return
+
+    salt_store = IBumblebeeUserSaltStore(api.portal.get())
+    storage = salt_store._get_storage()
+    user_id = event.principal.getId()
+
+    if user_id not in storage:
+        # This will create the user salt (lazy init on get)
+        salt_store.get_user_salt(user_id)

--- a/opengever/readonly/configure.zcml
+++ b/opengever/readonly/configure.zcml
@@ -7,5 +7,6 @@
   <i18n:registerTranslations directory="locales" />
 
   <include package=".viewlets" />
+  <subscriber handler=".bumblebee.create_user_salt_on_login" />
 
 </configure>

--- a/opengever/readonly/tests/test_bumblebee_readonly_support.py
+++ b/opengever/readonly/tests/test_bumblebee_readonly_support.py
@@ -1,0 +1,21 @@
+from ftw.bumblebee.interfaces import IBumblebeeUserSaltStore
+from opengever.testing import IntegrationTestCase
+from plone import api
+
+
+class TestBumblebeeReadonlySupport(IntegrationTestCase):
+
+    features = ('bumblebee', )
+
+    def test_bumblebee_user_salt_created_on_login(self):
+        salt_store = IBumblebeeUserSaltStore(api.portal.get())
+        storage = salt_store._get_storage()
+
+        storage.pop(self.regular_user.getId(), None)
+        self.assertNotIn(self.regular_user.getId(), storage)
+
+        self.login(self.regular_user)
+        membership_tool = api.portal.get_tool('portal_membership')
+        membership_tool.loginUser()
+
+        self.assertIn(self.regular_user.getId(), storage)


### PR DESCRIPTION
Create and persist the user's bumblebee salt during login, if one doesn't exist yet.

This will make sure it's available when needed, and doesn't have to be calculated and persisted as part of an ad-hoc write-on-read. Since several writes already happen during login _(when the connection is in read-write mode)_, and the login request is whitelisted by `plone.protect` itself, this shouldn't have any adverse effects.

By doing this we can ensure that users that have already logged in at least once have their salt ready, and will be able to see Bumblebee previews in read-only mode.

_(On a login during read-only mode this needs to be suppressed - the whole idea is that we won't have to generate any salts while in read-only mode)_

Jira: https://4teamwork.atlassian.net/browse/CA-1

## Checklist (Must have)

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
