### PR TITLE
Docker services

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -71,6 +71,9 @@ is required for Tika).
 LaTeX
 ^^^^^
 
+Note: Use the pdflatex Docker image instead of installing LaTeX locally. See
+`Services`_ for more details.
+
 A LaTeX distribution and the ``pdflatex`` binary are required for generating
 dossier covers, dossier details and dossier listing PDFs as well as open task
 reports and task listing PDFs.
@@ -122,6 +125,9 @@ README for details on how to configure Mail-In.
 Perl and ``Email::Outlook::Message`` module
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Note: Use the msgconvert Docker image instead of installing msgconvert locally.
+See `Services`_ for more details.
+
 In order to convert Outlook ``*.msg`` messages to RFC822 ``*.eml`` when using
 Drag&Drop upload, we use the `msgconvert.pl <http://www.matijs.net/software/msgconv/>`_
 script. This script requires Perl and the ``Email::Outlook::Message`` module.
@@ -145,6 +151,9 @@ In the end, GEVER will look for the ``msgconvert`` executable in ``$PATH``.
 
 Sablon
 ^^^^^^
+
+Note: Use the sablon Docker image instead of installing sablon locally. See
+`Services`_ for more details.
 
 If ``opengever.meeting`` is activated (which it is for the default development
 installation), the Ruby gem `Sablon <https://github.com/senny/sablon/>`_ is
@@ -301,6 +310,47 @@ PostgreSQL-Example:
 .. code:: postgresql
 
     UPDATE admin_units SET site_url = replace("site_url", 'https://dev.onegovgever.ch', 'http://localhost:8080'), public_url = replace("public_url", 'https://dev.onegovgever.ch', 'http://localhost:8080');
+
+
+Services
+--------
+
+In preparation for dockerizing ``opengever.core``, parts of the application are
+extracted into dockerized services.
+
+Currently the following services are available as Docker images and are used
+for local development by default:
+
+- `msgconvert <https://github.com/4teamwork/msgconvert>`_
+- `pdflatex <https://github.com/4teamwork/pdflatex>`_
+- `sablon <https://github.com/4teamwork/sablon>`_
+
+To run these services, Docker is required.
+See `Get Docker <https://docs.docker.com/get-docker/>`_ for how to install
+Docker on your local machine.
+
+A `Docker Compose <https://docs.docker.com/compose/>`_ file is provided in this
+repo to easily run the services.
+
+To start the services simply run:
+
+.. code::
+
+  docker-compose up
+
+
+``opengever.core`` will use the services if the service URL is configured
+through environment variables. The ``development.cfg`` buildout configuration
+defines these variables by default:
+
+.. code::
+
+  MSGCONVERT_URL=http://localhost:8090/
+  SABLON_URL=http://localhost:8091/
+  PDFLATEX_URL=http://localhost:8092/
+
+To disable the use of a service, simply remove the according environment
+variable or set it to an empty value.
 
 
 OGDS synchronization

--- a/development.cfg
+++ b/development.cfg
@@ -39,6 +39,9 @@ parts +=
     ${buildout:code-audit-parts}
     ${buildout:i18n-parts}
 
+parts -=
+    gems
+
 # example mysql configuration
 #ogds-db-name = opengever
 #ogds-db-user = opengever
@@ -56,6 +59,8 @@ environment-vars +=
     BUMBLEBEE_INTERNAL_PLONE_URL http://localhost:${instance:http-address}/fd
     BUMBLEBEE_PUBLIC_URL http://localhost:3000/
     TEAMRAUM_URL http://localhost:8080/fd
+    MSGCONVERT_URL http://localhost:8090/
+    SABLON_URL http://localhost:8091/
 
 zcml +=
   opengever.core
@@ -65,7 +70,8 @@ cores = ${solr:gever-cores}
 
 [test]
 initialization +=
-    os.environ['SABLON_BIN'] = '${buildout:sablon-executable}'
+    os.environ['MSGCONVERT_URL'] = 'http://localhost:8090/'
+    os.environ['SABLON_URL'] = 'http://localhost:8091/'
 
 [docxcompose]
 recipe = zc.recipe.egg:script

--- a/development.cfg
+++ b/development.cfg
@@ -61,6 +61,7 @@ environment-vars +=
     TEAMRAUM_URL http://localhost:8080/fd
     MSGCONVERT_URL http://localhost:8090/
     SABLON_URL http://localhost:8091/
+    PDFLATEX_URL http://localhost:8092/
 
 zcml +=
   opengever.core
@@ -72,6 +73,7 @@ cores = ${solr:gever-cores}
 initialization +=
     os.environ['MSGCONVERT_URL'] = 'http://localhost:8090/'
     os.environ['SABLON_URL'] = 'http://localhost:8091/'
+    os.environ['PDFLATEX_URL'] = 'http://localhost:8092/'
 
 [docxcompose]
 recipe = zc.recipe.egg:script

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: "3.8"
+
+services:
+  msgconvert:
+    image: 4teamwork/msgconvert:latest
+    ports:
+      - 8090:8080
+  sablon:
+    image: 4teamwork/sablon:latest
+    ports:
+      - 8091:8080
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,4 +9,8 @@ services:
     image: 4teamwork/sablon:latest
     ports:
       - 8091:8080
+  pdflatex:
+    image: 4teamwork/pdflatex:latest
+    ports:
+      - 8092:8080
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 ----------------------
 
 - Add support for using the msgconvert service instead of a locally installed msgconvert. [buchi]
+- Add support for using the sablon service instead of a locally installed sablon. [buchi]
 
 
 2020.13.0 (2020-11-05)

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 
 - Add support for using the msgconvert service instead of a locally installed msgconvert. [buchi]
 - Add support for using the sablon service instead of a locally installed sablon. [buchi]
+- Add support for using the pdflatex service instead of a locally installed pdflatex. [buchi]
 
 
 2020.13.0 (2020-11-05)

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,7 @@ Changelog
 2020.14.0 (unreleased)
 ----------------------
 
-- Nothing changed yet.
+- Add support for using the msgconvert service instead of a locally installed msgconvert. [buchi]
 
 
 2020.13.0 (2020-11-05)

--- a/opengever/base/tests/test_msg_transform.py
+++ b/opengever/base/tests/test_msg_transform.py
@@ -1,0 +1,37 @@
+from distutils.spawn import find_executable
+from opengever.base.transforms.msg2mime import Msg2MimeTransform
+from opengever.core.testing import MSGCONVERT_SERVICE_INTEGRATION_TESTING
+from opengever.core.testing import OPENGEVER_INTEGRATION_TESTING
+from opengever.testing import assets
+from opengever.testing import IntegrationTestCase
+from unittest import skipIf
+
+
+HAS_MSGCONVERT = find_executable('msgconvert')
+
+
+class TestMSGTransformUsingService(IntegrationTestCase):
+
+    layer = MSGCONVERT_SERVICE_INTEGRATION_TESTING
+
+    def test_msg_transform_produces_eml_using_service(self):
+        msg_filename = assets.path_to_asset('testmail.msg')
+        with open(msg_filename, 'rb') as msg_file:
+            msg_data = msg_file.read()
+        transform = Msg2MimeTransform()
+        eml = transform.transform(msg_data)
+        self.assertIn('MIME-Version: 1.0', eml)
+
+
+@skipIf(not HAS_MSGCONVERT, 'msgconvert is required')
+class TestMSGTransformUsingExecutable(IntegrationTestCase):
+
+    layer = OPENGEVER_INTEGRATION_TESTING
+
+    def test_msg_transform_produces_eml_using_executable(self):
+        msg_filename = assets.path_to_asset('testmail.msg')
+        with open(msg_filename, 'rb') as msg_file:
+            msg_data = msg_file.read()
+        transform = Msg2MimeTransform()
+        eml = transform.transform(msg_data)
+        self.assertIn('MIME-Version: 1.0', eml)

--- a/opengever/core/testing.py
+++ b/opengever/core/testing.py
@@ -25,6 +25,8 @@ from opengever.dossier.dossiertemplate.interfaces import IDossierTemplateSetting
 from opengever.meeting.interfaces import IMeetingSettings
 from opengever.officeatwork.interfaces import IOfficeatworkSettings
 from opengever.private import enable_opengever_private
+from opengever.testing.docker import MSGCONVERT_SERVICE_FIXTURE
+from opengever.testing.docker import PDFLATEX_SERVICE_FIXTURE
 from plone import api
 from plone.app.testing import applyProfile
 from plone.app.testing import FunctionalTesting
@@ -665,3 +667,11 @@ OPENGEVER_SOLR_INTEGRATION_TESTING = GEVERIntegrationTesting(
     # See docstring of ContentFixtureLayer.
     bases=(ContentFixtureWithSolrLayer(), TRAVERSAL_BROWSER_FIXTURE),
     name="opengever.core:integration:solr")
+
+PDFLATEX_SERVICE_INTEGRATION_TESTING = GEVERIntegrationTesting(
+    bases=(PDFLATEX_SERVICE_FIXTURE, OPENGEVER_FIXTURE),
+    name="opengever.core:pdflatex-service-integration")
+
+MSGCONVERT_SERVICE_INTEGRATION_TESTING = GEVERIntegrationTesting(
+    bases=(MSGCONVERT_SERVICE_FIXTURE, OPENGEVER_FIXTURE),
+    name="opengever.core:msgconvert-service-integration")

--- a/opengever/latex/builder.py
+++ b/opengever/latex/builder.py
@@ -1,0 +1,53 @@
+from ftw.pdfgenerator.builder import Builder
+from ftw.pdfgenerator.exceptions import BuildTerminated
+from ftw.pdfgenerator.exceptions import PDFBuildFailed
+from StringIO import StringIO
+import logging
+import os
+import requests
+
+
+logger = logging.getLogger('opengever.latex.builder')
+
+
+class Builder(Builder):
+
+    def build(self, latex):
+        pdflatex_url = os.environ.get('PDFLATEX_URL')
+        if pdflatex_url:
+            return self.build_using_service(pdflatex_url, latex)
+        else:
+            return super(Builder, self).build(latex)
+
+    def build_zip(self, latex):
+        pdflatex_url = os.environ.get('PDFLATEX_URL')
+        if pdflatex_url:
+            return StringIO(self.build_using_service(
+                pdflatex_url, latex, zip_archive=True))
+        else:
+            return super(Builder, self).build_zip(latex)
+
+    def build_using_service(self, url, latex, zip_archive=False):
+        if self._terminated:
+            raise BuildTerminated('The build is already terminated.')
+
+        params = {'zip': '1' if zip_archive else '0'}
+        files = {'latex': ('export.tex', latex)}
+        for filename in os.listdir(self.build_directory):
+            key = 'file.{}'.format(filename)
+            files[key] = os.path.join(self.build_directory, filename)
+
+        resp = None
+        try:
+            resp = requests.post(url, params=params, files=files)
+            resp.raise_for_status()
+        except requests.exceptions.RequestException:
+            details = resp.content[:200] if resp is not None else ''
+            logger.exception('PDF generation failed. %s', details)
+            raise PDFBuildFailed()
+        else:
+            return resp.content
+
+
+def builder_factory():
+    return Builder()

--- a/opengever/latex/overrides.zcml
+++ b/opengever/latex/overrides.zcml
@@ -1,0 +1,8 @@
+<configure xmlns="http://namespaces.zope.org/zope">
+
+  <utility
+      component="opengever.latex.builder.builder_factory"
+      provides="ftw.pdfgenerator.interfaces.IBuilderFactory"
+      />
+
+</configure>

--- a/opengever/latex/tests/test_builder.py
+++ b/opengever/latex/tests/test_builder.py
@@ -1,0 +1,49 @@
+from distutils.spawn import find_executable
+from ftw.pdfgenerator.interfaces import IBuilderFactory
+from opengever.core.testing import OPENGEVER_INTEGRATION_TESTING
+from opengever.core.testing import PDFLATEX_SERVICE_INTEGRATION_TESTING
+from opengever.testing import IntegrationTestCase
+from unittest import skipIf
+from zope.component import getUtility
+
+
+HAS_PDFLATEX = find_executable('pdflatex')
+
+
+class TestPDFBuilderUsingService(IntegrationTestCase):
+
+    layer = PDFLATEX_SERVICE_INTEGRATION_TESTING
+
+    def test_pdfbuilder_produces_pdf_using_service(self):
+        builder = getUtility(IBuilderFactory)()
+        latex = r'\documentclass{article}\begin{document}Hello LaTeX\end{document}'
+        pdf = builder.build(latex)
+        self.assertTrue(
+            pdf.startswith('%PDF-1.'), 'Does not look like a PDF document')
+
+    def test_pdfbuilder_produces_zip_using_service(self):
+        builder = getUtility(IBuilderFactory)()
+        latex = r'\documentclass{article}\begin{document}Hello LaTeX\end{document}'
+        archive = builder.build_zip(latex).read()
+        self.assertTrue(
+            archive.startswith('PK\x03\x04'), 'Does not look like a ZIP archive')
+
+
+@skipIf(not HAS_PDFLATEX, 'pdflatex is required')
+class TestPDFBuilderUsingExecutable(IntegrationTestCase):
+
+    layer = OPENGEVER_INTEGRATION_TESTING
+
+    def test_pdfbuilder_produces_pdf_using_executable(self):
+        builder = getUtility(IBuilderFactory)()
+        latex = r'\documentclass{article}\begin{document}Hello LaTeX\end{document}'
+        pdf = builder.build(latex)
+        self.assertTrue(
+            pdf.startswith('%PDF-1.'), 'Does not look like a PDF document')
+
+    def test_pdfbuilder_produces_zip_using_executable(self):
+        builder = getUtility(IBuilderFactory)()
+        latex = r'\documentclass{article}\begin{document}Hello LaTeX\end{document}'
+        archive = builder.build_zip(latex).read()
+        self.assertTrue(
+            archive.startswith('PK\x03\x04'), 'Does not look like a ZIP archive')

--- a/opengever/testing/docker.py
+++ b/opengever/testing/docker.py
@@ -1,0 +1,87 @@
+from plone.testing import Layer
+import os
+import requests
+import shlex
+import socket
+import subprocess
+import time
+
+
+class DockerServiceLayer(Layer):
+    """A base class for layers that starts a Docker container on setup and
+       stops it on teardown.
+       Subclass this layer for specific services.
+    """
+
+    port_env = None
+    image_name = None
+    service_url_env = None
+
+    def setUp(self):
+        self.port = os.environ.get(self.port_env, self.find_free_port())
+        base_name = self.image_name.split(':')[0].replace('/', '_')
+        self.container_name = '{}_{}'.format(base_name, self.port)
+        self.run(
+            'docker run -d -p {}:8080 --name {} {}'.format(
+                self.port, self.container_name, self.image_name))
+        self.wait_until_ready('http://localhost:{}/healthcheck'.format(self.port))
+        os.environ[self.service_url_env] = 'http://localhost:{}/'.format(self.port)
+
+    def tearDown(self):
+        self.run('docker stop {}'.format(self.container_name))
+        self.run('docker rm {}'.format(self.container_name))
+        del os.environ[self.service_url_env]
+
+    def wait_until_ready(self, url, timeout=10):
+        start = now = time.time()
+        while now - start < timeout:
+            try:
+                requests.get(url)
+            except requests.ConnectionError:
+                pass
+            else:
+                return True
+            time.sleep(0.1)
+            now = time.time()
+        return False
+
+    def run(self, cmd):
+        args = shlex.split(cmd)
+        proc = subprocess.Popen(
+            args, stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        out, err = proc.communicate()
+        if proc.returncode != 0:
+            assert False, "Running '{}' failed. Command returned: {}".format(cmd, err)
+
+    def find_free_port(self):
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        s.bind(("127.0.0.1", 0))
+        port = s.getsockname()[1]
+        s.close()
+        return port
+
+
+class MSGConvertServiceLayer(DockerServiceLayer):
+    port_env = 'PORT5'
+    image_name = '4teamwork/msgconvert:latest'
+    service_url_env = 'MSGCONVERT_URL'
+
+
+class PDFLatexServiceLayer(DockerServiceLayer):
+    port_env = 'PORT6'
+    image_name = '4teamwork/pdflatex:latest'
+    service_url_env = 'PDFLATEX_URL'
+
+
+class SablonServiceLayer(DockerServiceLayer):
+    port_env = 'PORT7'
+    image_name = '4teamwork/sablon:latest'
+    service_url_env = 'SABLON_URL'
+
+
+MSGCONVERT_SERVICE_FIXTURE = MSGConvertServiceLayer()
+PDFLATEX_SERVICE_FIXTURE = PDFLatexServiceLayer()
+SABLON_SERVICE_FIXTURE = SablonServiceLayer()


### PR DESCRIPTION
Adds support for using web-based services instead of locally installed executables for `msgconvert`, `sablon` and `pdflatex`.

This is a first step towards running `opengever.core` with Docker and turning into a service oriented architecture.

The services are provided as Docker images on [Docker Hub](https://hub.docker.com/search?q=4teamwork&type=image&sort=updated_at&order=desc):
- [msgconvert](https://hub.docker.com/r/4teamwork/msgconvert)
- [pdflatex](https://hub.docker.com/r/4teamwork/pdflatex)
- [sablon](https://hub.docker.com/r/4teamwork/sablon)

To use a specific service, its service URL has to be defined in an environment variable. It not defined, it falls back to use the executable. For local development the service URLs are defines as follows:

```
MSGCONVERT_URL=http://localhost:8090/
SABLON_URL=http://localhost:8091/
PDFLATEX_URL=http://localhost:8092/
```

This means that from now on, the services are used for local development by default. They can be started by executing `docker-compose up`. See also the [README](https://github.com/4teamwork/opengever.core/pull/6687/commits/af6e2a64c35b4a189eaafd04db28b8166211d790#diff-7b3ed02bc73dc06b7db906cf97aa91dec2b2eb21f2d92bc5caa761df5bbc168fR315)

Tests on CI currently default to use the executables as this is still what we use in production. However there are testing layers  for each service that provide fixtures for testing using the Docker services. Once we roll out the services in production, the default can be easily switched by adding these layers to the bases of the integration testing layer.

Jira: https://4teamwork.atlassian.net/browse/CA-1148
Architecture: https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/295534663/GEVER+Zielarchitektur

## Checklist (Must have)

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
