### PR TITLE
Implement sort group for the `@listing` endpoint

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,7 @@ Changelog
 - Don't create journal entry when downloading file copy in readonly mode. [lgraf]
 - Create Bumblebee user salt on login. [lgraf]
 - Patch several login-related events to allow login during readonly mode. [lgraf]
+- Implement `sort_first` parameter in the `@listing` endpoint. [elioschmutz]
 - Add optional support for WriteOnRead tracing in ReadOnlyError page. [lgraf]
 - Add videoconferencing URL to workspaces. [deiferni]
 - Add a new listing field: creator_fullname. [elioschmutz]

--- a/docs/public/dev-manual/api/listings.rst
+++ b/docs/public/dev-manual/api/listings.rst
@@ -240,6 +240,7 @@ Optionale Parameter:
 - ``b_size``: Die maximale Anzahl der zurückzugebenden Elemente
 - ``sort_on``: Sortierung nach einem indexierten Feld
 - ``sort_order``: Sortierreihenfolge: ``ascending`` (aufsteigend) oder ``descending`` (absteigend)
+- ``sort_first``: Sortiert die Resultate in zwei Gruppen. Jede Gruppe wird anschließend gem. ``sort_on`` sortiert.
 - ``search``: Filterung nach einem beliebigen Suchbegriff
 - ``columns``: Liste der Felder, die zurückgegeben werden sollen.
 - ``filters``: Einschränkung nach einem bestimmten Wert eines Feldes
@@ -279,6 +280,31 @@ Optionale Parameter:
   .. sourcecode:: http
 
     GET /ordnungssystem/fuehrung/dossier-23/@listing?name=documents&facets:list=creator HTTP/1.1
+    Accept: application/json
+
+
+Bestimmte Inhalte zuerst sortieren:
+-----------------------------------
+Die Resultate können in zwei Gruppen aufgeteilt und anschließend sortiert werden. So können z.B. in einer Auflistung alle Ordner zuoberst angezeigt werden.
+
+Alle Inhalte welche zuerst angezeigt werden sollen bilden eine Gruppe, alle restlichen Inhalte bilden eine zweite Gruppe. Momentan werden nur folgende Felder als `sort_first` unterstütz:
+
+- ``portal_type``
+
+
+**Beispiel: Alle Dossiers zuoberst. Jede Gruppe wird nach Titel sortiert**
+
+  .. sourcecode:: http
+
+    GET /@listing?sort_first.portal_type:record:list=opengever.dossier.businesscasedossier&sort_on=sortable_title HTTP/1.1
+    Accept: application/json
+
+
+**Beispiel: Alle Dokumente und Mails zuoberst**
+
+  .. sourcecode:: http
+
+    GET /@listing?sort_first.portal_type:record:list=opengever.document.document&sort_first.portal_type:record:list=ftw.mail.mail& HTTP/1.1
     Accept: application/json
 
 


### PR DESCRIPTION
This PR implements a new query parameter for the `@listing` endpoint: `sort_first`.

This parameter can be used to order the listing results into two groups. We use this in combination with the `folder_contents` listing to order folderish contents first.

<img width="694" alt="Bildschirmfoto 2020-10-19 um 16 12 42" src="https://user-images.githubusercontent.com/557005/96462531-f517ce00-1225-11eb-8dc1-0479e182a8e8.png">

### Performance
The function query executes in an average time of 200ms on a system with about one million contents. The tested query was:

`if(or(termfreq(portal_type, 'opengever.dossier.businesscasedossier'), termfreq(portal_type, 'opengever.document.document')),1, 0) desc` 


Jira: https://4teamwork.atlassian.net/browse/NE-124

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


## Checklist (if applicable)

_Only applicable should be left and checked._

- API change:
  - [x] Documentation is updated
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Upgrade steps (changes in profile):
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
- DB-Schema migration
  - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
  - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value
