### PR TITLE
Workspace meeting content type

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -650,6 +650,7 @@ Objects
       - self.workspace_folder
         - self.workspace_folder_document
       - self.workspace_mail
+      - self.workspace_meeting
 
 .. </fixture:objects>
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -8,6 +8,7 @@ Changelog
 - Create Bumblebee user salt on login. [lgraf]
 - Patch several login-related events to allow login during readonly mode. [lgraf]
 - Implement `sort_first` parameter in the `@listing` endpoint. [elioschmutz]
+- Add workspace meeting content type. [tinagerber]
 - Add optional support for WriteOnRead tracing in ReadOnlyError page. [lgraf]
 - Add videoconferencing URL to workspaces. [deiferni]
 - Add a new listing field: creator_fullname. [elioschmutz]

--- a/opengever/api/tests/test_listing.py
+++ b/opengever/api/tests/test_listing.py
@@ -1010,6 +1010,7 @@ class TestListingWithRealSolr(SolrIntegrationTestCase):
                 u'http://nohost/plone/workspaces/workspace-1/todolist-2/todo-2',
                 u'http://nohost/plone/workspaces/workspace-1/todo-1',
                 u'http://nohost/plone/workspaces/workspace-1/todolist-1',
+                u'http://nohost/plone/workspaces/workspace-1/meeting-1',
                 u'http://nohost/plone/workspaces/workspace-1/folder-1',
                 u'http://nohost/plone/workspaces/workspace-1/folder-1/document-40',
                 u'http://nohost/plone/workspaces/workspace-1/document-39',
@@ -1032,6 +1033,7 @@ class TestListingWithRealSolr(SolrIntegrationTestCase):
                 u'http://nohost/plone/workspaces/workspace-1/todolist-2',
                 u'http://nohost/plone/workspaces/workspace-1/todo-1',
                 u'http://nohost/plone/workspaces/workspace-1/todolist-1',
+                u'http://nohost/plone/workspaces/workspace-1/meeting-1',
                 u'http://nohost/plone/workspaces/workspace-1/folder-1',
                 u'http://nohost/plone/workspaces/workspace-1/document-39',
                 u'http://nohost/plone/workspaces/workspace-1/document-38'
@@ -1416,6 +1418,7 @@ class TestListingSortFirst(SolrIntegrationTestCase):
              u'opengever.workspace.todo',
              u'opengever.workspace.todo',
              u'opengever.workspace.todolist',
+             u'opengever.workspace.meeting',
              u'opengever.document.document',
              u'ftw.mail.mail',
              u'opengever.document.document'],
@@ -1442,6 +1445,7 @@ class TestListingSortFirst(SolrIntegrationTestCase):
              u'opengever.workspace.todo',
              u'opengever.workspace.todo',
              u'opengever.workspace.todolist',
+             u'opengever.workspace.meeting',
              u'ftw.mail.mail',
              ],
             [item['@type'] for item in browser.json['items']])
@@ -1466,6 +1470,7 @@ class TestListingSortFirst(SolrIntegrationTestCase):
              (u'Teamraumdokument', u'opengever.document.document'),
              (u'WS F\xc3lder', u'opengever.workspace.folder'),
              (u'Allgemeine Informationen', u'opengever.workspace.todolist'),
+             (u'Besprechung Kl\xe4ranlage', u'opengever.workspace.meeting'),
              (u'Cleanup installation', u'opengever.workspace.todo'),
              (u'Die B\xfcrgschaft', u'ftw.mail.mail'),
              (u'Fix user login', u'opengever.workspace.todo'),
@@ -1485,5 +1490,6 @@ class TestListingSortFirst(SolrIntegrationTestCase):
              (u'Fix user login', u'opengever.workspace.todo'),
              (u'Die B\xfcrgschaft', u'ftw.mail.mail'),
              (u'Cleanup installation', u'opengever.workspace.todo'),
+             (u'Besprechung Kl\xe4ranlage', u'opengever.workspace.meeting'),
              (u'Allgemeine Informationen', u'opengever.workspace.todolist')],
             [(item['title'], item['@type']) for item in browser.json['items']])

--- a/opengever/base/tests/test_contentlisting.py
+++ b/opengever/base/tests/test_contentlisting.py
@@ -240,7 +240,7 @@ class TestOpengeverContentListing(IntegrationTestCase):
         self.assertEqual(
             IContentListingObject(obj2brain(
                 self.dossier)).ModificationDate(),
-            '2016-08-31T20:21:33+02:00')
+            '2016-08-31T20:23:33+02:00')
 
     def test_translated_review_state(self):
         self.login(self.regular_user)

--- a/opengever/contentstats/tests/test_content_stats_integration.py
+++ b/opengever/contentstats/tests/test_content_stats_integration.py
@@ -93,6 +93,7 @@ class TestContentStatsIntegration(IntegrationTestCase):
             'opengever_workspace--STATUS--inactive',
             'opengever_workspace_document--STATUS--active',
             'opengever_workspace_folder--STATUS--active',
+            'opengever_workspace_meeting--STATUS--active',
             'opengever_workspace_todo--STATUS--active',
             'opengever_workspace_todolist--STATUS--active',
             'proposal-state-active',

--- a/opengever/core/lawgiver.zcml
+++ b/opengever/core/lawgiver.zcml
@@ -497,6 +497,26 @@
 
   </lawgiver:workflow>
 
+  <lawgiver:workflow name="opengever_workspace_meeting">
+    <lawgiver:ignore
+        permissions="
+                     opengever.trash: Trash content,
+                     opengever.trash: Untrash content,
+                     Add portal content,
+                     Modify portal content,
+                     Delete objects,
+                     Manage properties,
+                     Change local roles,
+                     Sharing page: Delegate WorkspaceAdmin role,
+                     Sharing page: Delegate WorkspaceGuest role,
+                     Sharing page: Delegate WorkspaceMember role,
+                     Sharing page: Delegate roles,
+                     Take ownership,
+                     "
+        />
+
+  </lawgiver:workflow>
+
   <!-- Should be ignored, permission is only granted to manager and admin on site root -->
   <lawgiver:ignore
       permissions="

--- a/opengever/core/locales/de/LC_MESSAGES/opengever.core.po
+++ b/opengever/core/locales/de/LC_MESSAGES/opengever.core.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2020-09-10 09:47+0000\n"
+"POT-Creation-Date: 2020-10-19 15:33+0000\n"
 "PO-Revision-Date: 2017-09-18 15:21+0200\n"
 "Last-Translator: Philippe Gross <p.gross@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -336,7 +336,7 @@ msgstr "Freigabe von ungebrauchten Aktenzeichen Prefixen."
 
 #: ./opengever/core/profiles/default/types/opengever.workspace.workspace.xml
 #: ./opengever/core/upgrades/20171213174551_add_workspace_content_type/types/opengever.workspace.workspace.xml
-#: ./opengever/core/upgrades/20200827114625_update_workspace_workflow/types/opengever.workspace.workspace.xml
+#: ./opengever/core/upgrades/20200909192905_update_workspace_workflow/types/opengever.workspace.workspace.xml
 msgid "Workspace"
 msgstr "Teamraum"
 
@@ -344,6 +344,11 @@ msgstr "Teamraum"
 #: ./opengever/core/upgrades/20171220151710_add_workspace_folder_content_type/types/opengever.workspace.folder.xml
 msgid "WorkspaceFolder"
 msgstr "Ordner"
+
+#: ./opengever/core/profiles/default/types/opengever.workspace.meeting.xml
+#: ./opengever/core/upgrades/20201016095810_install_workspace_meeting_type/types/opengever.workspace.meeting.xml
+msgid "WorkspaceMeeting"
+msgstr "Meeting"
 
 #: ./opengever/core/profiles/default/types/opengever.workspace.root.xml
 msgid "WorkspaceRoot"

--- a/opengever/core/locales/de/LC_MESSAGES/plone.po
+++ b/opengever/core/locales/de/LC_MESSAGES/plone.po
@@ -305,6 +305,36 @@ msgid "opengever_workspace_folder--STATUS--active"
 msgstr "Aktiv"
 
 #. Default: "admin"
+#: opengever/core/profiles/default/workflows/opengever_workspace_meeting/specification.txt
+msgid "opengever_workspace_meeting--ROLE--Administrator"
+msgstr "Administrator"
+
+#. Default: "systems administrator"
+#: opengever/core/profiles/default/workflows/opengever_workspace_meeting/specification.txt
+msgid "opengever_workspace_meeting--ROLE--Manager"
+msgstr "Manager"
+
+#. Default: "workspace admin"
+#: opengever/core/profiles/default/workflows/opengever_workspace_meeting/specification.txt
+msgid "opengever_workspace_meeting--ROLE--WorkspaceAdmin"
+msgstr "Admin"
+
+#. Default: "workspace guest"
+#: opengever/core/profiles/default/workflows/opengever_workspace_meeting/specification.txt
+msgid "opengever_workspace_meeting--ROLE--WorkspaceGuest"
+msgstr "Gast"
+
+#. Default: "workspace member"
+#: opengever/core/profiles/default/workflows/opengever_workspace_meeting/specification.txt
+msgid "opengever_workspace_meeting--ROLE--WorkspaceMember"
+msgstr "Teammitglied"
+
+#. Default: "Active"
+#: opengever/core/profiles/default/workflows/opengever_workspace_meeting/specification.txt
+msgid "opengever_workspace_meeting--STATUS--active"
+msgstr "Aktiv"
+
+#. Default: "admin"
 #: opengever/core/profiles/default/workflows/opengever_workspace_root/specification.txt
 msgid "opengever_workspace_root--ROLE--Administrator"
 msgstr "Administrator"

--- a/opengever/core/locales/en/LC_MESSAGES/plone.po
+++ b/opengever/core/locales/en/LC_MESSAGES/plone.po
@@ -286,6 +286,36 @@ msgid "opengever_workspace_folder--STATUS--active"
 msgstr "Active"
 
 #. Default: "admin"
+#: opengever/core/profiles/default/workflows/opengever_workspace_meeting/specification.txt
+msgid "opengever_workspace_meeting--ROLE--Administrator"
+msgstr "admin"
+
+#. Default: "systems administrator"
+#: opengever/core/profiles/default/workflows/opengever_workspace_meeting/specification.txt
+msgid "opengever_workspace_meeting--ROLE--Manager"
+msgstr "systems administrator"
+
+#. Default: "workspace admin"
+#: opengever/core/profiles/default/workflows/opengever_workspace_meeting/specification.txt
+msgid "opengever_workspace_meeting--ROLE--WorkspaceAdmin"
+msgstr "workspace admin"
+
+#. Default: "workspace guest"
+#: opengever/core/profiles/default/workflows/opengever_workspace_meeting/specification.txt
+msgid "opengever_workspace_meeting--ROLE--WorkspaceGuest"
+msgstr "workspace guest"
+
+#. Default: "workspace member"
+#: opengever/core/profiles/default/workflows/opengever_workspace_meeting/specification.txt
+msgid "opengever_workspace_meeting--ROLE--WorkspaceMember"
+msgstr "workspace member"
+
+#. Default: "Active"
+#: opengever/core/profiles/default/workflows/opengever_workspace_meeting/specification.txt
+msgid "opengever_workspace_meeting--STATUS--active"
+msgstr "Active"
+
+#. Default: "admin"
 #: opengever/core/profiles/default/workflows/opengever_workspace_root/specification.txt
 msgid "opengever_workspace_root--ROLE--Administrator"
 msgstr "admin"

--- a/opengever/core/locales/fr/LC_MESSAGES/opengever.core.po
+++ b/opengever/core/locales/fr/LC_MESSAGES/opengever.core.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2020-09-10 09:47+0000\n"
+"POT-Creation-Date: 2020-10-19 15:33+0000\n"
 "PO-Revision-Date: 2013-03-27 10:44+0100\n"
 "Last-Translator: Philippe Gross <p.gross@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -331,7 +331,7 @@ msgstr "Déblocage de préfixes de référence inutilisés."
 
 #: ./opengever/core/profiles/default/types/opengever.workspace.workspace.xml
 #: ./opengever/core/upgrades/20171213174551_add_workspace_content_type/types/opengever.workspace.workspace.xml
-#: ./opengever/core/upgrades/20200827114625_update_workspace_workflow/types/opengever.workspace.workspace.xml
+#: ./opengever/core/upgrades/20200909192905_update_workspace_workflow/types/opengever.workspace.workspace.xml
 msgid "Workspace"
 msgstr "Teamraum"
 
@@ -339,6 +339,11 @@ msgstr "Teamraum"
 #: ./opengever/core/upgrades/20171220151710_add_workspace_folder_content_type/types/opengever.workspace.folder.xml
 msgid "WorkspaceFolder"
 msgstr "Fichier"
+
+#: ./opengever/core/profiles/default/types/opengever.workspace.meeting.xml
+#: ./opengever/core/upgrades/20201016095810_install_workspace_meeting_type/types/opengever.workspace.meeting.xml
+msgid "WorkspaceMeeting"
+msgstr "Meeting"
 
 #: ./opengever/core/profiles/default/types/opengever.workspace.root.xml
 msgid "WorkspaceRoot"

--- a/opengever/core/locales/fr/LC_MESSAGES/plone.po
+++ b/opengever/core/locales/fr/LC_MESSAGES/plone.po
@@ -305,6 +305,36 @@ msgid "opengever_workspace_folder--STATUS--active"
 msgstr "Actif"
 
 #. Default: "admin"
+#: opengever/core/profiles/default/workflows/opengever_workspace_meeting/specification.txt
+msgid "opengever_workspace_meeting--ROLE--Administrator"
+msgstr "Administrateur"
+
+#. Default: "systems administrator"
+#: opengever/core/profiles/default/workflows/opengever_workspace_meeting/specification.txt
+msgid "opengever_workspace_meeting--ROLE--Manager"
+msgstr "Administrateur système"
+
+#. Default: "workspace admin"
+#: opengever/core/profiles/default/workflows/opengever_workspace_meeting/specification.txt
+msgid "opengever_workspace_meeting--ROLE--WorkspaceAdmin"
+msgstr "Admin"
+
+#. Default: "workspace guest"
+#: opengever/core/profiles/default/workflows/opengever_workspace_meeting/specification.txt
+msgid "opengever_workspace_meeting--ROLE--WorkspaceGuest"
+msgstr "Invité"
+
+#. Default: "workspace member"
+#: opengever/core/profiles/default/workflows/opengever_workspace_meeting/specification.txt
+msgid "opengever_workspace_meeting--ROLE--WorkspaceMember"
+msgstr "Membre d'équipe"
+
+#. Default: "Active"
+#: opengever/core/profiles/default/workflows/opengever_workspace_meeting/specification.txt
+msgid "opengever_workspace_meeting--STATUS--active"
+msgstr "Actif"
+
+#. Default: "admin"
 #: opengever/core/profiles/default/workflows/opengever_workspace_root/specification.txt
 msgid "opengever_workspace_root--ROLE--Administrator"
 msgstr "Administrator"

--- a/opengever/core/locales/opengever.core.pot
+++ b/opengever/core/locales/opengever.core.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2020-09-10 09:47+0000\n"
+"POT-Creation-Date: 2020-10-19 15:33+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -334,13 +334,18 @@ msgstr ""
 
 #: ./opengever/core/profiles/default/types/opengever.workspace.workspace.xml
 #: ./opengever/core/upgrades/20171213174551_add_workspace_content_type/types/opengever.workspace.workspace.xml
-#: ./opengever/core/upgrades/20200827114625_update_workspace_workflow/types/opengever.workspace.workspace.xml
+#: ./opengever/core/upgrades/20200909192905_update_workspace_workflow/types/opengever.workspace.workspace.xml
 msgid "Workspace"
 msgstr ""
 
 #: ./opengever/core/profiles/default/types/opengever.workspace.folder.xml
 #: ./opengever/core/upgrades/20171220151710_add_workspace_folder_content_type/types/opengever.workspace.folder.xml
 msgid "WorkspaceFolder"
+msgstr ""
+
+#: ./opengever/core/profiles/default/types/opengever.workspace.meeting.xml
+#: ./opengever/core/upgrades/20201016095810_install_workspace_meeting_type/types/opengever.workspace.meeting.xml
+msgid "WorkspaceMeeting"
 msgstr ""
 
 #: ./opengever/core/profiles/default/types/opengever.workspace.root.xml

--- a/opengever/core/locales/plone.pot
+++ b/opengever/core/locales/plone.pot
@@ -302,6 +302,36 @@ msgid "opengever_workspace_folder--STATUS--active"
 msgstr ""
 
 #. Default: "admin"
+#: opengever/core/profiles/default/workflows/opengever_workspace_meeting/specification.txt
+msgid "opengever_workspace_meeting--ROLE--Administrator"
+msgstr ""
+
+#. Default: "systems administrator"
+#: opengever/core/profiles/default/workflows/opengever_workspace_meeting/specification.txt
+msgid "opengever_workspace_meeting--ROLE--Manager"
+msgstr ""
+
+#. Default: "workspace admin"
+#: opengever/core/profiles/default/workflows/opengever_workspace_meeting/specification.txt
+msgid "opengever_workspace_meeting--ROLE--WorkspaceAdmin"
+msgstr ""
+
+#. Default: "workspace guest"
+#: opengever/core/profiles/default/workflows/opengever_workspace_meeting/specification.txt
+msgid "opengever_workspace_meeting--ROLE--WorkspaceGuest"
+msgstr ""
+
+#. Default: "workspace member"
+#: opengever/core/profiles/default/workflows/opengever_workspace_meeting/specification.txt
+msgid "opengever_workspace_meeting--ROLE--WorkspaceMember"
+msgstr ""
+
+#. Default: "Active"
+#: opengever/core/profiles/default/workflows/opengever_workspace_meeting/specification.txt
+msgid "opengever_workspace_meeting--STATUS--active"
+msgstr ""
+
+#. Default: "admin"
 #: opengever/core/profiles/default/workflows/opengever_workspace_root/specification.txt
 msgid "opengever_workspace_root--ROLE--Administrator"
 msgstr ""

--- a/opengever/core/profiles/default/types.xml
+++ b/opengever/core/profiles/default/types.xml
@@ -59,6 +59,7 @@
   <object name="opengever.workspace.root" meta_type="Dexterity FTI" />
   <object name="opengever.workspace.workspace" meta_type="Dexterity FTI" />
   <object name="opengever.workspace.folder" meta_type="Dexterity FTI" />
+  <object name="opengever.workspace.meeting" meta_type="Dexterity FTI" />
   <object name="opengever.workspace.todo" meta_type="Dexterity FTI" />
   <object name="opengever.workspace.todolist" meta_type="Dexterity FTI" />
 

--- a/opengever/core/profiles/default/types/opengever.workspace.meeting.xml
+++ b/opengever/core/profiles/default/types/opengever.workspace.meeting.xml
@@ -1,0 +1,65 @@
+<object xmlns:i18n="http://xml.zope.org/namespaces/i18n" name="opengever.workspace.meeting" meta_type="Dexterity FTI" i18n:domain="opengever.core">
+
+  <!-- Basic metadata -->
+  <property name="title" i18n:translate="">WorkspaceMeeting</property>
+  <property name="description" i18n:translate="" />
+  <property name="icon_expr" />
+  <property name="allow_discussion">False</property>
+  <property name="global_allow">True</property>
+
+  <!-- Schema interface -->
+  <property name="schema">opengever.workspace.workspace_meeting.IWorkspaceMeetingSchema</property>
+
+  <!-- Class used for content items -->
+  <property name="klass">opengever.workspace.workspace_meeting.WorkspaceMeeting</property>
+
+  <!-- Add permission -->
+  <property name="add_permission">cmf.AddPortalContent</property>
+
+  <!-- Enabled behaviors -->
+  <property name="behaviors" purge="False">
+    <element value="opengever.base.behaviors.base.IOpenGeverBase" />
+    <element value="opengever.base.behaviors.changed.IChanged" />
+    <element value="collective.dexteritytextindexer.behavior.IDexterityTextIndexer" />
+    <element value="opengever.workspace.behaviors.namefromtitle.IWorkspaceMeetingNameFromTitle" />
+    <element value="opengever.trash.trash.ITrashable" />
+    <element value="opengever.base.behaviors.sequence.ISequenceNumberBehavior" />
+    <element value="plone.app.lockingbehavior.behaviors.ILocking" />
+  </property>
+
+  <!-- View information -->
+  <property name="immediate_view">view</property>
+  <property name="default_view">view</property>
+  <property name="default_view_fallback">False</property>
+  <property name="view_methods">
+    <element value="view" />
+  </property>
+
+  <!-- Method aliases -->
+  <alias from="(Default)" to="(selected layout)" />
+  <alias from="edit" to="@@edit" />
+  <alias from="sharing" to="@@sharing" />
+  <alias from="view" to="@@view" />
+
+  <!-- Actions -->
+  <action
+      title="View"
+      action_id="view"
+      category="object"
+      condition_expr=""
+      url_expr="string:${object_url}"
+      visible="True">
+    <permission value="View" />
+  </action>
+
+  <action
+      title="Edit"
+      action_id="edit"
+      category="object"
+      condition_expr=""
+      url_expr="string:${object_url}/edit"
+      visible="True">
+    <permission value="Modify portal content" />
+  </action>
+
+</object>

--- a/opengever/core/profiles/default/types/opengever.workspace.workspace.xml
+++ b/opengever/core/profiles/default/types/opengever.workspace.workspace.xml
@@ -13,6 +13,7 @@
     <element value="opengever.workspace.todo" />
     <element value="opengever.workspace.todolist" />
     <element value="opengever.workspace.folder" />
+    <element value="opengever.workspace.meeting" />
   </property>
 
   <!-- Schema interface -->

--- a/opengever/core/profiles/default/workflows.xml
+++ b/opengever/core/profiles/default/workflows.xml
@@ -31,6 +31,7 @@
   <object name="opengever_workspace" meta_type="Workflow" />
   <object name="opengever_workspace_document" meta_type="Workflow" />
   <object name="opengever_workspace_folder" meta_type="Workflow" />
+  <object name="opengever_workspace_meeting" meta_type="Workflow" />
   <object name="opengever_workspace_root" meta_type="Workflow" />
   <object name="opengever_workspace_todo" meta_type="Workflow" />
   <object name="opengever_workspace_todolist" meta_type="Workflow" />
@@ -167,6 +168,10 @@
 
     <type type_id="opengever.workspace.folder">
       <bound-workflow workflow_id="opengever_workspace_folder" />
+    </type>
+
+    <type type_id="opengever.workspace.meeting">
+      <bound-workflow workflow_id="opengever_workspace_meeting" />
     </type>
 
     <type type_id="opengever.workspace.todo">

--- a/opengever/core/profiles/default/workflows/opengever_workspace_meeting/.gitignore
+++ b/opengever/core/profiles/default/workflows/opengever_workspace_meeting/.gitignore
@@ -1,0 +1,1 @@
+/result.xml

--- a/opengever/core/profiles/default/workflows/opengever_workspace_meeting/definition.xml
+++ b/opengever/core/profiles/default/workflows/opengever_workspace_meeting/definition.xml
@@ -1,0 +1,245 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<dc-workflow workflow_id="opengever_workspace_meeting" title="Workspace meeting workflow" description="" initial_state="opengever_workspace_meeting--STATUS--active" state_variable="review_state" manager_bypass="True">
+  <permission>Access contents information</permission>
+  <permission>CMFEditions: Access previous versions</permission>
+  <permission>CMFEditions: Apply version control</permission>
+  <permission>CMFEditions: Checkout to location</permission>
+  <permission>CMFEditions: Revert to previous versions</permission>
+  <permission>CMFEditions: Save new version</permission>
+  <permission>Edit comments</permission>
+  <permission>Edit date of cassation</permission>
+  <permission>Edit date of submission</permission>
+  <permission>List folder contents</permission>
+  <permission>Modify constrain types</permission>
+  <permission>Modify view template</permission>
+  <permission>Poi: Edit response</permission>
+  <permission>Poi: Modify issue assignment</permission>
+  <permission>Poi: Modify issue severity</permission>
+  <permission>Poi: Modify issue state</permission>
+  <permission>Poi: Modify issue tags</permission>
+  <permission>Poi: Modify issue target release</permission>
+  <permission>Poi: Modify issue watchers</permission>
+  <permission>Poi: Upload attachment</permission>
+  <permission>Portlets: Manage portlets</permission>
+  <permission>Sharing page: Delegate Administrator role</permission>
+  <permission>Sharing page: Delegate CommitteeAdministrator role</permission>
+  <permission>Sharing page: Delegate CommitteeMember role</permission>
+  <permission>Sharing page: Delegate CommitteeResponsible role</permission>
+  <permission>Sharing page: Delegate Contributor role</permission>
+  <permission>Sharing page: Delegate DossierManager role</permission>
+  <permission>Sharing page: Delegate Editor role</permission>
+  <permission>Sharing page: Delegate MeetingUser role</permission>
+  <permission>Sharing page: Delegate Publisher role</permission>
+  <permission>Sharing page: Delegate Reader role</permission>
+  <permission>Sharing page: Delegate Reviewer role</permission>
+  <permission>Sharing page: Delegate WorkspacesCreator role</permission>
+  <permission>Sharing page: Delegate WorkspacesUser role</permission>
+  <permission>View</permission>
+  <permission>ftw.keywordwidget: Add new term</permission>
+  <permission>ftw.mail: Add Inbound Mail</permission>
+  <permission>iterate : Check in content</permission>
+  <permission>iterate : Check out content</permission>
+  <permission>opengever.contact: Add contact</permission>
+  <permission>opengever.contact: Add contactfolder</permission>
+  <permission>opengever.contact: Add person</permission>
+  <permission>opengever.contact: Edit person</permission>
+  <permission>opengever.disposition: Add disposition</permission>
+  <permission>opengever.disposition: Download SIP Package</permission>
+  <permission>opengever.disposition: Edit transfer number</permission>
+  <permission>opengever.document: Add document</permission>
+  <permission>opengever.document: Cancel</permission>
+  <permission>opengever.document: Checkin</permission>
+  <permission>opengever.document: Checkout</permission>
+  <permission>opengever.document: Force Checkin</permission>
+  <permission>opengever.document: Modify archival file</permission>
+  <permission>opengever.dossier: Add businesscasedossier</permission>
+  <permission>opengever.dossier: Add dossiertemplate</permission>
+  <permission>opengever.dossier: Add templatefolder</permission>
+  <permission>opengever.dossier: Destroy dossier</permission>
+  <permission>opengever.dossier: Protect dossier</permission>
+  <permission>opengever.inbox: Add Forwarding</permission>
+  <permission>opengever.inbox: Add Inbox</permission>
+  <permission>opengever.inbox: Add Year Folder</permission>
+  <permission>opengever.inbox: Scan In</permission>
+  <permission>opengever.meeting: Add Committee</permission>
+  <permission>opengever.meeting: Add CommitteeContainer</permission>
+  <permission>opengever.meeting: Add Member</permission>
+  <permission>opengever.meeting: Add Period</permission>
+  <permission>opengever.meeting: Add Proposal</permission>
+  <permission>opengever.meeting: Add Proposal Template</permission>
+  <permission>opengever.meeting: Add Sablon Template</permission>
+  <permission>opengever.private: Add private dossier</permission>
+  <permission>opengever.private: Add private folder</permission>
+  <permission>opengever.private: Add private root</permission>
+  <permission>opengever.repository: Add repositoryfolder</permission>
+  <permission>opengever.repository: Add repositoryroot</permission>
+  <permission>opengever.repository: Unlock Reference Prefix</permission>
+  <permission>opengever.task: Add task</permission>
+  <permission>opengever.task: Add task comment</permission>
+  <permission>opengever.task: Edit task</permission>
+  <permission>opengever.workspace: Add Workspace</permission>
+  <permission>plone.portlet.collection: Add collection portlet</permission>
+  <permission>plone.portlet.static: Add static portlet</permission>
+  <state state_id="opengever_workspace_meeting--STATUS--active" title="Active">
+    <permission-map name="Access contents information" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceGuest</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="CMFEditions: Access previous versions" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceGuest</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="CMFEditions: Apply version control" acquired="False"/>
+    <permission-map name="CMFEditions: Checkout to location" acquired="False"/>
+    <permission-map name="CMFEditions: Revert to previous versions" acquired="False"/>
+    <permission-map name="CMFEditions: Save new version" acquired="False"/>
+    <permission-map name="Edit comments" acquired="False"/>
+    <permission-map name="Edit date of cassation" acquired="False"/>
+    <permission-map name="Edit date of submission" acquired="False"/>
+    <permission-map name="List folder contents" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="Modify constrain types" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="Modify view template" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="Poi: Edit response" acquired="False"/>
+    <permission-map name="Poi: Modify issue assignment" acquired="False"/>
+    <permission-map name="Poi: Modify issue severity" acquired="False"/>
+    <permission-map name="Poi: Modify issue state" acquired="False"/>
+    <permission-map name="Poi: Modify issue tags" acquired="False"/>
+    <permission-map name="Poi: Modify issue target release" acquired="False"/>
+    <permission-map name="Poi: Modify issue watchers" acquired="False"/>
+    <permission-map name="Poi: Upload attachment" acquired="False"/>
+    <permission-map name="Portlets: Manage portlets" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="Sharing page: Delegate Administrator role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate CommitteeAdministrator role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate CommitteeMember role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate CommitteeResponsible role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate Contributor role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate DossierManager role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate Editor role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate MeetingUser role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate Publisher role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate Reader role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate Reviewer role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate WorkspacesCreator role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate WorkspacesUser role" acquired="False"/>
+    <permission-map name="View" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceGuest</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="ftw.keywordwidget: Add new term" acquired="False"/>
+    <permission-map name="ftw.mail: Add Inbound Mail" acquired="False"/>
+    <permission-map name="iterate : Check in content" acquired="False"/>
+    <permission-map name="iterate : Check out content" acquired="False"/>
+    <permission-map name="opengever.contact: Add contact" acquired="False"/>
+    <permission-map name="opengever.contact: Add contactfolder" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="opengever.contact: Add person" acquired="False"/>
+    <permission-map name="opengever.contact: Edit person" acquired="False"/>
+    <permission-map name="opengever.disposition: Add disposition" acquired="False"/>
+    <permission-map name="opengever.disposition: Download SIP Package" acquired="False"/>
+    <permission-map name="opengever.disposition: Edit transfer number" acquired="False"/>
+    <permission-map name="opengever.document: Add document" acquired="False"/>
+    <permission-map name="opengever.document: Cancel" acquired="False"/>
+    <permission-map name="opengever.document: Checkin" acquired="False"/>
+    <permission-map name="opengever.document: Checkout" acquired="False"/>
+    <permission-map name="opengever.document: Force Checkin" acquired="False"/>
+    <permission-map name="opengever.document: Modify archival file" acquired="False"/>
+    <permission-map name="opengever.dossier: Add businesscasedossier" acquired="False"/>
+    <permission-map name="opengever.dossier: Add dossiertemplate" acquired="False"/>
+    <permission-map name="opengever.dossier: Add templatefolder" acquired="False"/>
+    <permission-map name="opengever.dossier: Destroy dossier" acquired="False"/>
+    <permission-map name="opengever.dossier: Protect dossier" acquired="False"/>
+    <permission-map name="opengever.inbox: Add Forwarding" acquired="False"/>
+    <permission-map name="opengever.inbox: Add Inbox" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="opengever.inbox: Add Year Folder" acquired="False"/>
+    <permission-map name="opengever.inbox: Scan In" acquired="False"/>
+    <permission-map name="opengever.meeting: Add Committee" acquired="False"/>
+    <permission-map name="opengever.meeting: Add CommitteeContainer" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="opengever.meeting: Add Member" acquired="False"/>
+    <permission-map name="opengever.meeting: Add Period" acquired="False"/>
+    <permission-map name="opengever.meeting: Add Proposal" acquired="False"/>
+    <permission-map name="opengever.meeting: Add Proposal Template" acquired="False"/>
+    <permission-map name="opengever.meeting: Add Sablon Template" acquired="False"/>
+    <permission-map name="opengever.private: Add private dossier" acquired="False"/>
+    <permission-map name="opengever.private: Add private folder" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="opengever.private: Add private root" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="opengever.repository: Add repositoryfolder" acquired="False"/>
+    <permission-map name="opengever.repository: Add repositoryroot" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="opengever.repository: Unlock Reference Prefix" acquired="False"/>
+    <permission-map name="opengever.task: Add task" acquired="False"/>
+    <permission-map name="opengever.task: Add task comment" acquired="False"/>
+    <permission-map name="opengever.task: Edit task" acquired="False"/>
+    <permission-map name="opengever.workspace: Add Workspace" acquired="False"/>
+    <permission-map name="plone.portlet.collection: Add collection portlet" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="plone.portlet.static: Add static portlet" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+  </state>
+  <variable variable_id="action" for_catalog="False" for_status="True" update_always="True">
+    <description>Previous transition</description>
+    <default>
+        <expression>transition/getId|nothing</expression>
+    </default>
+    <guard/>
+</variable>
+  <variable variable_id="actor" for_catalog="False" for_status="True" update_always="True">
+<description>The ID of the user who performed the previous transition</description>
+    <default>
+        <expression>user/getId</expression>
+    </default>
+    <guard/>
+</variable>
+  <variable variable_id="comments" for_catalog="False" for_status="True" update_always="True">
+    <description>Comment about the last transition</description>
+    <default>
+        <expression>python:state_change.kwargs.get('comment', '')</expression>
+    </default>
+    <guard/>
+</variable>
+  <variable variable_id="review_history" for_catalog="False" for_status="False" update_always="False">
+    <description>Provides access to workflow history</description>
+    <default>
+        <expression>state_change/getHistory</expression>
+    </default>
+    <guard>
+        <guard-permission>Request review</guard-permission>
+        <guard-permission>Review portal content</guard-permission>
+    </guard>
+</variable>
+  <variable variable_id="time" for_catalog="False" for_status="True" update_always="True">
+    <description>When the previous transition was performed</description>
+    <default>
+        <expression>state_change/getDateTime</expression>
+    </default>
+    <guard/>
+</variable>
+</dc-workflow>

--- a/opengever/core/profiles/default/workflows/opengever_workspace_meeting/specification.txt
+++ b/opengever/core/profiles/default/workflows/opengever_workspace_meeting/specification.txt
@@ -1,0 +1,27 @@
+[Workspace meeting workflow]
+Role mapping:
+  workspace guest => WorkspaceGuest
+  workspace member => WorkspaceMember
+  workspace admin => WorkspaceAdmin
+  admin => Administrator
+  systems administrator => Manager
+
+Visible roles:
+  workspace guest
+  workspace member
+  workspace admin
+
+
+General:
+  A workspace member can perform the same actions as a workspace guest.
+  A workspace admin can perform the same actions as a workspace member.
+  An admin can perform the same actions as a workspace admin.
+
+  A systems administrator can always view.
+  A systems administrator can always manage security.
+  A systems administrator can always use the developer tools.
+
+
+Initial Status: Active
+Status Active:
+  A workspace guest can view.

--- a/opengever/core/upgrades/20201016095810_install_workspace_meeting_type/types.xml
+++ b/opengever/core/upgrades/20201016095810_install_workspace_meeting_type/types.xml
@@ -1,0 +1,4 @@
+<object name="portal_types" meta_type="Plone Types Tool">
+  <!-- WORKSPACE -->
+  <object name="opengever.workspace.meeting" meta_type="Dexterity FTI" />
+</object>

--- a/opengever/core/upgrades/20201016095810_install_workspace_meeting_type/types/opengever.workspace.meeting.xml
+++ b/opengever/core/upgrades/20201016095810_install_workspace_meeting_type/types/opengever.workspace.meeting.xml
@@ -1,0 +1,65 @@
+<object xmlns:i18n="http://xml.zope.org/namespaces/i18n" name="opengever.workspace.meeting" meta_type="Dexterity FTI" i18n:domain="opengever.core">
+
+  <!-- Basic metadata -->
+  <property name="title" i18n:translate="">WorkspaceMeeting</property>
+  <property name="description" i18n:translate="" />
+  <property name="icon_expr" />
+  <property name="allow_discussion">False</property>
+  <property name="global_allow">True</property>
+
+  <!-- Schema interface -->
+  <property name="schema">opengever.workspace.workspace_meeting.IWorkspaceMeetingSchema</property>
+
+  <!-- Class used for content items -->
+  <property name="klass">opengever.workspace.workspace_meeting.WorkspaceMeeting</property>
+
+  <!-- Add permission -->
+  <property name="add_permission">cmf.AddPortalContent</property>
+
+  <!-- Enabled behaviors -->
+  <property name="behaviors" purge="False">
+    <element value="opengever.base.behaviors.base.IOpenGeverBase" />
+    <element value="opengever.base.behaviors.changed.IChanged" />
+    <element value="collective.dexteritytextindexer.behavior.IDexterityTextIndexer" />
+    <element value="opengever.workspace.behaviors.namefromtitle.IWorkspaceMeetingNameFromTitle" />
+    <element value="opengever.trash.trash.ITrashable" />
+    <element value="opengever.base.behaviors.sequence.ISequenceNumberBehavior" />
+    <element value="plone.app.lockingbehavior.behaviors.ILocking" />
+  </property>
+
+  <!-- View information -->
+  <property name="immediate_view">view</property>
+  <property name="default_view">view</property>
+  <property name="default_view_fallback">False</property>
+  <property name="view_methods">
+    <element value="view" />
+  </property>
+
+  <!-- Method aliases -->
+  <alias from="(Default)" to="(selected layout)" />
+  <alias from="edit" to="@@edit" />
+  <alias from="sharing" to="@@sharing" />
+  <alias from="view" to="@@view" />
+
+  <!-- Actions -->
+  <action
+      title="View"
+      action_id="view"
+      category="object"
+      condition_expr=""
+      url_expr="string:${object_url}"
+      visible="True">
+    <permission value="View" />
+  </action>
+
+  <action
+      title="Edit"
+      action_id="edit"
+      category="object"
+      condition_expr=""
+      url_expr="string:${object_url}/edit"
+      visible="True">
+    <permission value="Modify portal content" />
+  </action>
+
+</object>

--- a/opengever/core/upgrades/20201016095810_install_workspace_meeting_type/types/opengever.workspace.workspace.xml
+++ b/opengever/core/upgrades/20201016095810_install_workspace_meeting_type/types/opengever.workspace.workspace.xml
@@ -1,0 +1,7 @@
+<object xmlns:i18n="http://xml.zope.org/namespaces/i18n" name="opengever.workspace.workspace" meta_type="Dexterity FTI" i18n:domain="opengever.core">
+
+  <property name="allowed_content_types" purge="False">
+    <element value="opengever.workspace.meeting" />
+  </property>
+
+</object>

--- a/opengever/core/upgrades/20201016095810_install_workspace_meeting_type/upgrade.py
+++ b/opengever/core/upgrades/20201016095810_install_workspace_meeting_type/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class InstallWorkspaceMeetingType(UpgradeStep):
+    """Install WorkspaceMeeting type.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/core/upgrades/20201016095810_install_workspace_meeting_type/workflows.xml
+++ b/opengever/core/upgrades/20201016095810_install_workspace_meeting_type/workflows.xml
@@ -1,0 +1,13 @@
+<object name="portal_workflow" meta_type="Plone Workflow Tool">
+
+  <object name="opengever_workspace_meeting" meta_type="Workflow" />
+
+  <bindings>
+
+    <type type_id="opengever.workspace.meeting">
+      <bound-workflow workflow_id="opengever_workspace_meeting" />
+    </type>
+
+  </bindings>
+
+</object>

--- a/opengever/core/upgrades/20201016095810_install_workspace_meeting_type/workflows/opengever_workspace_meeting/definition.xml
+++ b/opengever/core/upgrades/20201016095810_install_workspace_meeting_type/workflows/opengever_workspace_meeting/definition.xml
@@ -1,0 +1,245 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<dc-workflow workflow_id="opengever_workspace_meeting" title="Workspace meeting workflow" description="" initial_state="opengever_workspace_meeting--STATUS--active" state_variable="review_state" manager_bypass="True">
+  <permission>Access contents information</permission>
+  <permission>CMFEditions: Access previous versions</permission>
+  <permission>CMFEditions: Apply version control</permission>
+  <permission>CMFEditions: Checkout to location</permission>
+  <permission>CMFEditions: Revert to previous versions</permission>
+  <permission>CMFEditions: Save new version</permission>
+  <permission>Edit comments</permission>
+  <permission>Edit date of cassation</permission>
+  <permission>Edit date of submission</permission>
+  <permission>List folder contents</permission>
+  <permission>Modify constrain types</permission>
+  <permission>Modify view template</permission>
+  <permission>Poi: Edit response</permission>
+  <permission>Poi: Modify issue assignment</permission>
+  <permission>Poi: Modify issue severity</permission>
+  <permission>Poi: Modify issue state</permission>
+  <permission>Poi: Modify issue tags</permission>
+  <permission>Poi: Modify issue target release</permission>
+  <permission>Poi: Modify issue watchers</permission>
+  <permission>Poi: Upload attachment</permission>
+  <permission>Portlets: Manage portlets</permission>
+  <permission>Sharing page: Delegate Administrator role</permission>
+  <permission>Sharing page: Delegate CommitteeAdministrator role</permission>
+  <permission>Sharing page: Delegate CommitteeMember role</permission>
+  <permission>Sharing page: Delegate CommitteeResponsible role</permission>
+  <permission>Sharing page: Delegate Contributor role</permission>
+  <permission>Sharing page: Delegate DossierManager role</permission>
+  <permission>Sharing page: Delegate Editor role</permission>
+  <permission>Sharing page: Delegate MeetingUser role</permission>
+  <permission>Sharing page: Delegate Publisher role</permission>
+  <permission>Sharing page: Delegate Reader role</permission>
+  <permission>Sharing page: Delegate Reviewer role</permission>
+  <permission>Sharing page: Delegate WorkspacesCreator role</permission>
+  <permission>Sharing page: Delegate WorkspacesUser role</permission>
+  <permission>View</permission>
+  <permission>ftw.keywordwidget: Add new term</permission>
+  <permission>ftw.mail: Add Inbound Mail</permission>
+  <permission>iterate : Check in content</permission>
+  <permission>iterate : Check out content</permission>
+  <permission>opengever.contact: Add contact</permission>
+  <permission>opengever.contact: Add contactfolder</permission>
+  <permission>opengever.contact: Add person</permission>
+  <permission>opengever.contact: Edit person</permission>
+  <permission>opengever.disposition: Add disposition</permission>
+  <permission>opengever.disposition: Download SIP Package</permission>
+  <permission>opengever.disposition: Edit transfer number</permission>
+  <permission>opengever.document: Add document</permission>
+  <permission>opengever.document: Cancel</permission>
+  <permission>opengever.document: Checkin</permission>
+  <permission>opengever.document: Checkout</permission>
+  <permission>opengever.document: Force Checkin</permission>
+  <permission>opengever.document: Modify archival file</permission>
+  <permission>opengever.dossier: Add businesscasedossier</permission>
+  <permission>opengever.dossier: Add dossiertemplate</permission>
+  <permission>opengever.dossier: Add templatefolder</permission>
+  <permission>opengever.dossier: Destroy dossier</permission>
+  <permission>opengever.dossier: Protect dossier</permission>
+  <permission>opengever.inbox: Add Forwarding</permission>
+  <permission>opengever.inbox: Add Inbox</permission>
+  <permission>opengever.inbox: Add Year Folder</permission>
+  <permission>opengever.inbox: Scan In</permission>
+  <permission>opengever.meeting: Add Committee</permission>
+  <permission>opengever.meeting: Add CommitteeContainer</permission>
+  <permission>opengever.meeting: Add Member</permission>
+  <permission>opengever.meeting: Add Period</permission>
+  <permission>opengever.meeting: Add Proposal</permission>
+  <permission>opengever.meeting: Add Proposal Template</permission>
+  <permission>opengever.meeting: Add Sablon Template</permission>
+  <permission>opengever.private: Add private dossier</permission>
+  <permission>opengever.private: Add private folder</permission>
+  <permission>opengever.private: Add private root</permission>
+  <permission>opengever.repository: Add repositoryfolder</permission>
+  <permission>opengever.repository: Add repositoryroot</permission>
+  <permission>opengever.repository: Unlock Reference Prefix</permission>
+  <permission>opengever.task: Add task</permission>
+  <permission>opengever.task: Add task comment</permission>
+  <permission>opengever.task: Edit task</permission>
+  <permission>opengever.workspace: Add Workspace</permission>
+  <permission>plone.portlet.collection: Add collection portlet</permission>
+  <permission>plone.portlet.static: Add static portlet</permission>
+  <state state_id="opengever_workspace_meeting--STATUS--active" title="Active">
+    <permission-map name="Access contents information" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceGuest</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="CMFEditions: Access previous versions" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceGuest</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="CMFEditions: Apply version control" acquired="False"/>
+    <permission-map name="CMFEditions: Checkout to location" acquired="False"/>
+    <permission-map name="CMFEditions: Revert to previous versions" acquired="False"/>
+    <permission-map name="CMFEditions: Save new version" acquired="False"/>
+    <permission-map name="Edit comments" acquired="False"/>
+    <permission-map name="Edit date of cassation" acquired="False"/>
+    <permission-map name="Edit date of submission" acquired="False"/>
+    <permission-map name="List folder contents" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="Modify constrain types" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="Modify view template" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="Poi: Edit response" acquired="False"/>
+    <permission-map name="Poi: Modify issue assignment" acquired="False"/>
+    <permission-map name="Poi: Modify issue severity" acquired="False"/>
+    <permission-map name="Poi: Modify issue state" acquired="False"/>
+    <permission-map name="Poi: Modify issue tags" acquired="False"/>
+    <permission-map name="Poi: Modify issue target release" acquired="False"/>
+    <permission-map name="Poi: Modify issue watchers" acquired="False"/>
+    <permission-map name="Poi: Upload attachment" acquired="False"/>
+    <permission-map name="Portlets: Manage portlets" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="Sharing page: Delegate Administrator role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate CommitteeAdministrator role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate CommitteeMember role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate CommitteeResponsible role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate Contributor role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate DossierManager role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate Editor role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate MeetingUser role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate Publisher role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate Reader role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate Reviewer role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate WorkspacesCreator role" acquired="False"/>
+    <permission-map name="Sharing page: Delegate WorkspacesUser role" acquired="False"/>
+    <permission-map name="View" acquired="False">
+      <permission-role>Administrator</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>WorkspaceAdmin</permission-role>
+      <permission-role>WorkspaceGuest</permission-role>
+      <permission-role>WorkspaceMember</permission-role>
+    </permission-map>
+    <permission-map name="ftw.keywordwidget: Add new term" acquired="False"/>
+    <permission-map name="ftw.mail: Add Inbound Mail" acquired="False"/>
+    <permission-map name="iterate : Check in content" acquired="False"/>
+    <permission-map name="iterate : Check out content" acquired="False"/>
+    <permission-map name="opengever.contact: Add contact" acquired="False"/>
+    <permission-map name="opengever.contact: Add contactfolder" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="opengever.contact: Add person" acquired="False"/>
+    <permission-map name="opengever.contact: Edit person" acquired="False"/>
+    <permission-map name="opengever.disposition: Add disposition" acquired="False"/>
+    <permission-map name="opengever.disposition: Download SIP Package" acquired="False"/>
+    <permission-map name="opengever.disposition: Edit transfer number" acquired="False"/>
+    <permission-map name="opengever.document: Add document" acquired="False"/>
+    <permission-map name="opengever.document: Cancel" acquired="False"/>
+    <permission-map name="opengever.document: Checkin" acquired="False"/>
+    <permission-map name="opengever.document: Checkout" acquired="False"/>
+    <permission-map name="opengever.document: Force Checkin" acquired="False"/>
+    <permission-map name="opengever.document: Modify archival file" acquired="False"/>
+    <permission-map name="opengever.dossier: Add businesscasedossier" acquired="False"/>
+    <permission-map name="opengever.dossier: Add dossiertemplate" acquired="False"/>
+    <permission-map name="opengever.dossier: Add templatefolder" acquired="False"/>
+    <permission-map name="opengever.dossier: Destroy dossier" acquired="False"/>
+    <permission-map name="opengever.dossier: Protect dossier" acquired="False"/>
+    <permission-map name="opengever.inbox: Add Forwarding" acquired="False"/>
+    <permission-map name="opengever.inbox: Add Inbox" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="opengever.inbox: Add Year Folder" acquired="False"/>
+    <permission-map name="opengever.inbox: Scan In" acquired="False"/>
+    <permission-map name="opengever.meeting: Add Committee" acquired="False"/>
+    <permission-map name="opengever.meeting: Add CommitteeContainer" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="opengever.meeting: Add Member" acquired="False"/>
+    <permission-map name="opengever.meeting: Add Period" acquired="False"/>
+    <permission-map name="opengever.meeting: Add Proposal" acquired="False"/>
+    <permission-map name="opengever.meeting: Add Proposal Template" acquired="False"/>
+    <permission-map name="opengever.meeting: Add Sablon Template" acquired="False"/>
+    <permission-map name="opengever.private: Add private dossier" acquired="False"/>
+    <permission-map name="opengever.private: Add private folder" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="opengever.private: Add private root" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="opengever.repository: Add repositoryfolder" acquired="False"/>
+    <permission-map name="opengever.repository: Add repositoryroot" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="opengever.repository: Unlock Reference Prefix" acquired="False"/>
+    <permission-map name="opengever.task: Add task" acquired="False"/>
+    <permission-map name="opengever.task: Add task comment" acquired="False"/>
+    <permission-map name="opengever.task: Edit task" acquired="False"/>
+    <permission-map name="opengever.workspace: Add Workspace" acquired="False"/>
+    <permission-map name="plone.portlet.collection: Add collection portlet" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+    <permission-map name="plone.portlet.static: Add static portlet" acquired="False">
+      <permission-role>Manager</permission-role>
+    </permission-map>
+  </state>
+  <variable variable_id="action" for_catalog="False" for_status="True" update_always="True">
+    <description>Previous transition</description>
+    <default>
+        <expression>transition/getId|nothing</expression>
+    </default>
+    <guard/>
+</variable>
+  <variable variable_id="actor" for_catalog="False" for_status="True" update_always="True">
+<description>The ID of the user who performed the previous transition</description>
+    <default>
+        <expression>user/getId</expression>
+    </default>
+    <guard/>
+</variable>
+  <variable variable_id="comments" for_catalog="False" for_status="True" update_always="True">
+    <description>Comment about the last transition</description>
+    <default>
+        <expression>python:state_change.kwargs.get('comment', '')</expression>
+    </default>
+    <guard/>
+</variable>
+  <variable variable_id="review_history" for_catalog="False" for_status="False" update_always="False">
+    <description>Provides access to workflow history</description>
+    <default>
+        <expression>state_change/getHistory</expression>
+    </default>
+    <guard>
+        <guard-permission>Request review</guard-permission>
+        <guard-permission>Review portal content</guard-permission>
+    </guard>
+</variable>
+  <variable variable_id="time" for_catalog="False" for_status="True" update_always="True">
+    <description>When the previous transition was performed</description>
+    <default>
+        <expression>state_change/getDateTime</expression>
+    </default>
+    <guard/>
+</variable>
+</dc-workflow>

--- a/opengever/testing/builders/dx.py
+++ b/opengever/testing/builders/dx.py
@@ -592,6 +592,13 @@ class WorkspaceFolderBuilder(DexterityBuilder):
 builder_registry.register('workspace folder', WorkspaceFolderBuilder)
 
 
+class WorkspaceMeetingBuilder(DexterityBuilder):
+    portal_type = 'opengever.workspace.meeting'
+
+
+builder_registry.register('workspace meeting', WorkspaceMeetingBuilder)
+
+
 class ToDoBuilder(DexterityBuilder):
     portal_type = 'opengever.workspace.todo'
 

--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -2170,6 +2170,15 @@ class OpengeverContentFixture(object):
             .with_asset_file('text.txt')
         ))
 
+        self.register('workspace_meeting', create(
+            Builder('workspace meeting')
+            .within(self.workspace)
+            .titled(u'Besprechung Kl\xe4ranlage')
+            .having(
+                start=datetime(2016, 12, 8),
+                responsible=self.workspace_member.getId())
+        ))
+
     def create_todos(self):
         self.todolist_general = self.register('todolist_general', create(
             Builder('todolist')

--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -207,9 +207,9 @@ class OpengeverContentFixture(object):
                 title=u'Hauptmandant',
                 unit_id=u'plone',
                 public_url='http://nohost/plone',
-                )
-            .as_current_admin_unit()
             )
+            .as_current_admin_unit()
+        )
 
         self.org_unit_fa = create(
             Builder('org_unit')
@@ -217,10 +217,10 @@ class OpengeverContentFixture(object):
             .having(
                 title=u'Finanz\xe4mt',
                 admin_unit=self.admin_unit,
-                )
+            )
             .with_default_groups()
             .as_current_org_unit()
-            )
+        )
 
         self.org_unit_rk = create(
             Builder('org_unit')
@@ -228,7 +228,7 @@ class OpengeverContentFixture(object):
             .having(
                 title=u'Ratskanzl\xc3\xa4i',
                 admin_unit=self.admin_unit,
-                )
+            )
             .with_default_groups()
         )
 
@@ -239,7 +239,7 @@ class OpengeverContentFixture(object):
             u'Kohler',
             ['Administrator', 'APIUser'],
             user_settings={'_seen_tours': '["*"]'},
-            )
+        )
 
         self.member_admin = self.create_user(
             'member_admin',
@@ -247,14 +247,14 @@ class OpengeverContentFixture(object):
             u'Meier',
             ['MemberAreaAdministrator', 'APIUser'],
             user_settings={'_seen_tours': '["*"]'},
-            )
+        )
 
         self.dossier_responsible = self.create_user(
             'dossier_responsible',
             u'Robert',
             u'Ziegler',
             user_settings={'_seen_tours': '["*"]'},
-            )
+        )
 
         self.regular_user = self.create_user(
             'regular_user',
@@ -278,7 +278,7 @@ class OpengeverContentFixture(object):
             url='http://www.example.com',
             zip_code='1234',
             user_settings={'_seen_tours': '["*"]'},
-            )
+        )
 
         self.meeting_user = self.create_user(
             'meeting_user',
@@ -286,7 +286,7 @@ class OpengeverContentFixture(object):
             u'J\xe4ger',
             email='herbert@jager.com',
             user_settings={'_seen_tours': '["*"]'},
-            )
+        )
 
         self.secretariat_user = self.create_user(
             'secretariat_user',
@@ -294,21 +294,21 @@ class OpengeverContentFixture(object):
             u'K\xf6nig',
             group=self.org_unit_fa.inbox_group,
             user_settings={'_seen_tours': '["*"]'},
-            )
+        )
 
         self.committee_responsible = self.create_user(
             'committee_responsible',
             u'Fr\xe4nzi',
             u'M\xfcller',
             user_settings={'_seen_tours': '["*"]'},
-            )
+        )
 
         self.dossier_manager = self.create_user(
             'dossier_manager',
             u'F\xe4ivel',
             u'Fr\xfchling',
             user_settings={'_seen_tours': '["*"]'},
-            )
+        )
 
         self.records_manager = self.create_user(
             'records_manager',
@@ -316,7 +316,7 @@ class OpengeverContentFixture(object):
             u'Flucht',
             ['Records Manager'],
             user_settings={'_seen_tours': '["*"]'},
-            )
+        )
 
         self.workspace_owner = self.create_user(
             'workspace_owner',
@@ -324,7 +324,7 @@ class OpengeverContentFixture(object):
             u'Fr\xf6hlich',
             ['WorkspacesUser', 'WorkspacesCreator'],
             user_settings={'_seen_tours': '["*"]'},
-            )
+        )
 
         self.workspace_admin = self.create_user(
             'workspace_admin',
@@ -332,7 +332,7 @@ class OpengeverContentFixture(object):
             u'Hugentobler',
             ['WorkspacesUser', 'WorkspacesCreator'],
             user_settings={'_seen_tours': '["*"]'},
-            )
+        )
 
         self.workspace_member = self.create_user(
             'workspace_member',
@@ -340,7 +340,7 @@ class OpengeverContentFixture(object):
             u'Schr\xf6dinger',
             ['WorkspacesUser'],
             user_settings={'_seen_tours': '["*"]'},
-            )
+        )
 
         self.workspace_guest = self.create_user(
             'workspace_guest',
@@ -348,7 +348,7 @@ class OpengeverContentFixture(object):
             u'Peter',
             ['WorkspacesUser'],
             user_settings={'_seen_tours': '["*"]'},
-            )
+        )
 
         self.archivist = self.create_user(
             'archivist',
@@ -356,7 +356,7 @@ class OpengeverContentFixture(object):
             u'Fischer',
             ['Archivist'],
             user_settings={'_seen_tours': '["*"]'},
-            )
+        )
 
         self.service_user = self.create_user(
             'service_user',
@@ -368,7 +368,7 @@ class OpengeverContentFixture(object):
                 'Impersonator',
                 'Administrator',
             ],
-            )
+        )
 
         self.webaction_manager = self.create_user(
             'webaction_manager',
@@ -376,7 +376,7 @@ class OpengeverContentFixture(object):
             u'Manager',
             ['WebActionManager'],
             user_settings={'_seen_tours': '["*"]'},
-            )
+        )
 
         # This user is intended to be used in situations where you need a user
         # which has only the 'Reader' role on some context and one has to build
@@ -388,7 +388,7 @@ class OpengeverContentFixture(object):
             Builder('user')
             .named(firstname, lastname)
             .with_roles(['Member'])
-            )
+        )
 
         builder.update_properties()  # updates builder.userid
         email = '{}@gever.local'.format(builder.userid)
@@ -398,7 +398,7 @@ class OpengeverContentFixture(object):
             Builder('ogds_user')
             .id(plone_user.getId())
             .having(firstname=firstname, lastname=lastname, email=email)
-            )
+        )
 
         self._lookup_table['reader_user'] = ('user', plone_user.getId())
 
@@ -433,12 +433,12 @@ class OpengeverContentFixture(object):
         users = [
             ogds_service().find_user(user.getId())
             for user in [self.regular_user, self.dossier_responsible]
-            ]
+        ]
 
         group_a = create(
             Builder('ogds_group')
             .having(groupid='projekt_a', title=u'Projekt A', users=users)
-            )
+        )
 
         self.projekt_a = create(
             Builder('ogds_team')
@@ -446,13 +446,13 @@ class OpengeverContentFixture(object):
                 title=u'Projekt \xdcberbaung Dorfmatte',
                 group=group_a,
                 org_unit=self.org_unit_fa,
-                )
             )
+        )
 
         users = [
             ogds_service().find_user(user.getId())
             for user in [self.committee_responsible, self.meeting_user]
-            ]
+        ]
 
         group_b = create(
             Builder('ogds_group')
@@ -460,8 +460,8 @@ class OpengeverContentFixture(object):
                 groupid='projekt_b',
                 title=u'Projekt B',
                 users=users,
-                )
             )
+        )
 
         self.projekt_b = create(
             Builder('ogds_team')
@@ -469,8 +469,8 @@ class OpengeverContentFixture(object):
                 title=u'Sekretariat Abteilung XY',
                 group=group_b,
                 org_unit=self.org_unit_fa,
-                )
             )
+        )
 
         group_empty = create(
             Builder('ogds_group')
@@ -498,8 +498,8 @@ class OpengeverContentFixture(object):
             .having(
                 title_de=u'Ordnungssystem',
                 title_fr=u'Syst\xe8me de classement',
-                )
-            ))
+            )
+        ))
 
         self.set_roles(
             self.root, self.org_unit_fa.users_group_id,
@@ -520,8 +520,8 @@ class OpengeverContentFixture(object):
                 title_de=u'F\xfchrung',
                 title_fr=u'Direction',
                 description=u'Alles zum Thema F\xfchrung.',
-                )
-            ))
+            )
+        ))
 
         self.set_roles(
             self.repofolder0, self.dossier_manager.getId(),
@@ -535,8 +535,8 @@ class OpengeverContentFixture(object):
             .having(
                 title_de=u'Vertr\xe4ge und Vereinbarungen',
                 title_fr=u'Contrats et accords',
-                )
-            ))
+            )
+        ))
 
         self.repofolder1 = self.register('empty_repofolder', create(
             Builder('repository')
@@ -544,8 +544,8 @@ class OpengeverContentFixture(object):
             .having(
                 title_de=u'Rechnungspr\xfcfungskommission',
                 title_fr=u'Commission de v\xe9rification',
-                )
-            ))
+            )
+        ))
 
         self.set_roles(
             self.repofolder1, self.archivist.getId(),
@@ -557,9 +557,9 @@ class OpengeverContentFixture(object):
             .having(
                 title_de=u'Spinn\xe4nnetzregistrar',
                 title_fr=u"Toile d'araign\xe9e",
-                )
+            )
             .in_state('repositoryfolder-state-inactive')
-            ))
+        ))
 
     @staticuid()
     def create_contacts(self):
@@ -569,8 +569,8 @@ class OpengeverContentFixture(object):
                 id='kontakte',
                 title_de=u'Kontakte',
                 title_en=u'Contacts',
-                )
-            ))
+            )
+        ))
 
         self.set_roles(
             self.contactfolder, self.org_unit_fa.users_group_id,
@@ -588,8 +588,8 @@ class OpengeverContentFixture(object):
             .having(
                 firstname=u'Hanspeter',
                 lastname='D\xc3\xbcrr'.decode('utf-8'),
-                )
-            ))
+            )
+        ))
 
         self.franz_meier = self.register('franz_meier', create(
             Builder('contact')
@@ -598,13 +598,13 @@ class OpengeverContentFixture(object):
                 firstname=u'Franz',
                 lastname=u'Meier',
                 email=u'meier.f@example.com',
-                )
-            ))
+            )
+        ))
 
         self.josef_buehler = create(
             Builder('person')
             .having(firstname=u'Josef', lastname=u'B\xfchler'),
-            )
+        )
 
         self.meier_ag = create(Builder('organization').named(u'Meier AG'))
 
@@ -616,7 +616,7 @@ class OpengeverContentFixture(object):
             Builder('templatefolder')
             .titled(u'Vorlagen')
             .having(id='vorlagen')
-            ))
+        ))
 
         self.set_roles(
             self.templates, self.org_unit_fa.users_group_id, ['Reader'])
@@ -632,20 +632,20 @@ class OpengeverContentFixture(object):
             .titled(u'T\xc3\xb6mpl\xc3\xb6te Ohne')
             .with_asset_file('without_custom_properties.docx')
             .within(self.templates)
-            ))
+        ))
 
         self.register('normal_template', create(
             Builder('document')
             .titled(u'T\xc3\xb6mpl\xc3\xb6te Normal')
             .with_dummy_content()
             .within(self.templates)
-            ))
+        ))
 
         self.register('empty_template', create(
             Builder('document')
             .titled(u'T\xc3\xb6mpl\xc3\xb6te Leer')
             .within(self.templates)
-            ))
+        ))
 
         with self.features('doc-properties'):
             self.register('docprops_template', create(
@@ -654,32 +654,32 @@ class OpengeverContentFixture(object):
                 .with_asset_file('with_custom_properties.docx')
                 .with_modification_date(datetime(2010, 12, 28))
                 .within(self.templates)
-                ))
+            ))
 
         with self.features('meeting'):
             self.meeting_template = self.register('meeting_template', create(
                 Builder('meetingtemplate')
                 .titled(u'Meeting T\xc3\xb6mpl\xc3\xb6te')
                 .within(self.templates)
-                ))
+            ))
             self.register('paragraph_template', create(
                 Builder('paragraphtemplate')
                 .titled(u'Begr\xfcssung')
                 .having(position=1)
                 .within(self.meeting_template)
-                ))
+            ))
             create(
                 Builder('paragraphtemplate')
                 .titled(u'Gesch\xf0fte')
                 .having(position=2)
                 .within(self.meeting_template)
-                )
+            )
             create(
                 Builder('paragraphtemplate')
                 .titled(u'Schlusswort')
                 .having(position=3)
                 .within(self.meeting_template)
-                )
+            )
 
     @staticuid()
     def create_special_templates(self):
@@ -687,7 +687,7 @@ class OpengeverContentFixture(object):
             Builder('sablontemplate')
             .within(self.templates)
             .with_asset_file('sablon_template.docx')
-            ))
+        ))
 
         with self.features('meeting'):
             self.proposal_template = self.register('proposal_template', create(
@@ -695,21 +695,21 @@ class OpengeverContentFixture(object):
                 .titled(u'Geb\xfchren')
                 .with_asset_file(u'vertragsentwurf.docx')
                 .within(self.templates)
-                ))
+            ))
 
             self.register('ad_hoc_agenda_item_template', create(
                 Builder('proposaltemplate')
                 .titled(u'Freitext Traktandum')
                 .with_asset_file(u'freitext_traktandum.docx')
                 .within(self.templates)
-                ))
+            ))
 
             self.register('recurring_agenda_item_template', create(
                 Builder('proposaltemplate')
                 .titled(u'Wiederkehrendes Traktandum')
                 .with_asset_file(u'wiederkehrendes_traktandum.docx')
                 .within(self.templates)
-                ))
+            ))
 
         self.tasktemplatefolder = self.register('tasktemplatefolder', create(
             Builder('tasktemplatefolder')
@@ -727,9 +727,9 @@ class OpengeverContentFixture(object):
                 'responsible_client': 'fa',
                 'responsible': 'robert.ziegler',
                 'deadline': 10,
-                })
+            })
             .within(self.tasktemplatefolder)
-            ))
+        ))
 
         self.dossiertemplate = self.register('dossiertemplate', create(
             Builder('dossiertemplate')
@@ -739,9 +739,9 @@ class OpengeverContentFixture(object):
                 'keywords': (u'secret', u'special'),
                 'comments': 'this is very special',
                 'filing_prefix': 'department',
-                })
+            })
             .within(self.templates)
-            ))
+        ))
 
         # The title of this one should be alphabetically after
         # subdossiertemplatedocument for testing sorting!
@@ -756,7 +756,7 @@ class OpengeverContentFixture(object):
             Builder('dossiertemplate')
             .titled(u'Anfragen')
             .within(self.dossiertemplate)
-            ))
+        ))
 
         self.register('subdossiertemplatedocument', create(
             Builder('document')
@@ -772,7 +772,7 @@ class OpengeverContentFixture(object):
             .titled(u'Vorlagen neu')
             .having(id='vorlagen-neu')
             .within(self.templates)
-            ))
+        ))
 
         self.set_roles(subtemplates, self.org_unit_fa.users_group_id, ['Reader'])
         self.set_roles(subtemplates, self.administrator.getId(),
@@ -786,14 +786,14 @@ class OpengeverContentFixture(object):
             .with_dummy_content()
             .with_modification_date(datetime(2020, 2, 29))
             .within(subtemplates)
-            ))
+        ))
 
     @staticuid()
     def create_committees(self):
         self.committee_container = self.register('committee_container', create(
             Builder('committee_container')
             .titled(u'Sitzungen')
-            ))
+        ))
 
         self.set_roles(
             self.committee_container, self.committee_responsible.getId(),
@@ -814,7 +814,7 @@ class OpengeverContentFixture(object):
             responsibles=[
                 self.administrator,
                 self.committee_responsible,
-                ],
+            ],
             templates={
                 'agendaitem_list_template': self.sablon_template,
                 'protocol_header_template': self.sablon_template,
@@ -822,12 +822,12 @@ class OpengeverContentFixture(object):
                 'excerpt_suffix_template': self.sablon_template,
                 'paragraph_template': self.sablon_template,
             }
-            ))
+        ))
 
         self.register_raw(
             'committee_id',
             self.committee.load_model().committee_id,
-            )
+        )
 
         self.period = self.register('period', api.content.find(
             context=self.committee,
@@ -844,14 +844,14 @@ class OpengeverContentFixture(object):
             email='h.schoeller@example.org',
             date_from=datetime(2014, 1, 1),
             date_to=datetime(2016, 12, 31),
-            )
+        )
 
         self.committee_secretary = create(
             Builder('ogds_user')
             .id('committee.secretary')
             .having(firstname=u'C\xf6mmittee', lastname='Secretary', email='committee.secretary@example.com')
             .assign_to_org_units([self.org_unit_fa])
-            )
+        )
 
         self.committee_participant_1 = self.create_committee_membership(
             self.committee,
@@ -861,7 +861,7 @@ class OpengeverContentFixture(object):
             email='g.woelfl@example.com',
             date_from=datetime(2014, 1, 1),
             date_to=datetime(2016, 12, 31),
-            )
+        )
 
         self.committee_participant_2 = self.create_committee_membership(
             self.committee,
@@ -871,7 +871,7 @@ class OpengeverContentFixture(object):
             email='jens-wendler@example.com',
             date_from=datetime(2014, 1, 1),
             date_to=datetime(2016, 12, 31),
-            )
+        )
 
         self.inactive_committee_participant = self.create_committee_membership(
             self.committee,
@@ -881,7 +881,7 @@ class OpengeverContentFixture(object):
             email='pablo-neruda@example.com',
             date_from=datetime(2010, 1, 1),
             date_to=datetime(2014, 12, 31),
-            )
+        )
 
         self.empty_committee = self.register(
             'empty_committee',
@@ -893,7 +893,7 @@ class OpengeverContentFixture(object):
                 responsibles=[
                     self.administrator,
                     self.committee_responsible,
-                    ],
+                ],
                 templates={
                     'agendaitem_list_template': self.sablon_template,
                     'protocol_header_template': self.sablon_template,
@@ -901,13 +901,13 @@ class OpengeverContentFixture(object):
                     'excerpt_suffix_template': self.sablon_template,
                     'paragraph_template': self.sablon_template,
                 }
-                ),
-            )
+            ),
+        )
 
         self.register_raw(
             'empty_committee_id',
             self.empty_committee.load_model().committee_id,
-            )
+        )
 
         self.set_roles(
             self.empty_committee, self.meeting_user.getId(),
@@ -921,7 +921,7 @@ class OpengeverContentFixture(object):
             Builder('inbox_container')
             .titled(u'Eingangsk\xf6rbli')
             .having(id='eingangskorb')
-            ))
+        ))
 
         # Enable inbox_policy placeful workflow
         inbox_policy_id = 'opengever_inbox_policy'
@@ -946,15 +946,15 @@ class OpengeverContentFixture(object):
                 id='eingangskorb_fa',
                 responsible_org_unit='fa',
                 inbox_group=self.org_unit_fa.inbox_group.groupid,
-                )
-            ))
+            )
+        ))
 
         self.register('inbox_document', create(
             Builder('document')
             .within(self.inbox)
             .titled(u'Dokument im Eingangsk\xf6rbli')
             .with_asset_file('text.txt')
-            ))
+        ))
 
         self.inbox.__ac_local_roles_block__ = True
         self.set_roles(self.inbox, self.secretariat_user.getId(),
@@ -972,8 +972,8 @@ class OpengeverContentFixture(object):
                 responsible_client=self.org_unit_fa.id(),
                 responsible=self.regular_user.getId(),
                 issuer=self.dossier_responsible.getId(),
-                )
-            ))
+            )
+        ))
         self.create_task_subscriptions(inbox_forwarding)
 
         self.register('inbox_forwarding_document', create(
@@ -981,7 +981,7 @@ class OpengeverContentFixture(object):
             .within(inbox_forwarding)
             .titled(u'Dokument im Eingangsk\xf6rbliweiterleitung')
             .with_asset_file('text.txt')
-            ))
+        ))
 
     @staticuid()
     def create_inbox_rk(self):
@@ -993,8 +993,8 @@ class OpengeverContentFixture(object):
                 id='eingangskorb_rk',
                 responsible_org_unit='rk',
                 inbox_group=self.org_unit_fa.inbox_group.groupid,
-                )
-            ))
+            )
+        ))
 
         self.inbox_rk.__ac_local_roles_block__ = True
         self.set_roles(self.inbox_rk, self.secretariat_user.getId(),
@@ -1029,25 +1029,25 @@ class OpengeverContentFixture(object):
             Builder('private_folder')
             .having(id=self.regular_user.getId())
             .within(self.private_root)
-            ))
+        ))
 
         self.private_dossier = self.register('private_dossier', create(
             Builder('private_dossier')
             .having(title=u'Mein Dossier 1')
             .within(self.private_folder)
-            ))
+        ))
 
         create(
             Builder('private_dossier')
             .having(title=u'Mein Dossier 2')
             .within(self.private_folder)
-            )
+        )
 
         self.register('private_document', create(
             Builder('document')
             .within(self.private_dossier)
             .with_asset_file('vertragsentwurf.docx')
-            ))
+        ))
 
         self.register('private_mail', create(
             Builder('mail')
@@ -1078,26 +1078,26 @@ class OpengeverContentFixture(object):
                 keywords=(
                     u'Finanzverwaltung',
                     u'Vertr\xe4ge',
-                    ),
+                ),
                 start=date(2016, 1, 1),
                 responsible=self.dossier_responsible.getId(),
                 external_reference=u'qpr-900-9001-\xf7',
-                )
-            ))
+            )
+        ))
 
         create(
             Builder('contact_participation')
             .for_contact(self.meier_ag)
             .for_dossier(self.dossier)
             .with_roles(['final-drawing'])
-            )
+        )
 
         create(
             Builder('contact_participation')
             .for_contact(self.josef_buehler)
             .for_dossier(self.dossier)
             .with_roles(['final-drawing', 'participation'])
-            )
+        )
 
         self.document = self.register('document', create(
             Builder('document')
@@ -1111,11 +1111,11 @@ class OpengeverContentFixture(object):
                 document_type='contract',
                 receipt_date=datetime(2010, 1, 3),
                 keywords=(u'Wichtig', ),
-                )
+            )
             .attach_file_containing(
                 bumblebee_asset('example.docx').bytes(),
                 u'vertragsentwurf.docx')
-            ))
+        ))
 
         with self.features('meeting'):
             proposal = self.register('proposal', create(
@@ -1126,15 +1126,15 @@ class OpengeverContentFixture(object):
                     committee=self.committee.load_model(),
                     issuer=self.dossier_responsible.getId(),
                     description=u'F\xfcr weitere Bearbeitung bewilligen',
-                    )
+                )
                 .relate_to(self.document)
                 .as_submitted()
-                ))
+            ))
 
             self.register_path(
                 'submitted_proposal',
                 proposal.load_model().submitted_physical_path.encode('utf-8'),
-                )
+            )
 
             self.register('proposaldocument', create(
                 Builder('document')
@@ -1143,8 +1143,8 @@ class OpengeverContentFixture(object):
                 .attach_file_containing(
                     'Komentar text',
                     u'vertr\xe4g sentwurf.docx',
-                    )
-                ))
+                )
+            ))
 
             self.register('draft_proposal', create(
                 Builder('proposal')
@@ -1153,8 +1153,8 @@ class OpengeverContentFixture(object):
                     title=u'Antrag f\xfcr Kreiselbau',
                     committee=self.empty_committee.load_model(),
                     issuer=self.dossier_responsible.getId(),
-                    )
-                ))
+                )
+            ))
 
             self.decided_proposal = create(
                 Builder('proposal')
@@ -1163,16 +1163,16 @@ class OpengeverContentFixture(object):
                     title=u'Initialvertrag f\xfcr Bearbeitung',
                     committee=self.committee.load_model(),
                     issuer=self.dossier_responsible.getId(),
-                    )
-                .as_submitted()
                 )
+                .as_submitted()
+            )
 
             self.register_path(
                 'decided_proposal',
                 self.decided_proposal
                 .load_model()
                 .submitted_physical_path.encode('utf-8'),
-                )
+            )
 
         subdossier = self.register('subdossier', create(
             Builder('dossier')
@@ -1180,14 +1180,14 @@ class OpengeverContentFixture(object):
             .titled(u'2016')
             .having(
                 keywords=(u'Subkeyword', u'Subkeyw\xf6rd'),
-                )
-            ))
+            )
+        ))
 
         self.register('subdossier2', create(
             Builder('dossier')
             .within(self.dossier)
             .titled(u'2015')
-            ))
+        ))
 
         subdocument = self.register('subdocument', create(
             Builder('document')
@@ -1473,9 +1473,9 @@ class OpengeverContentFixture(object):
                 start=date(1995, 1, 1),
                 end=date(2000, 12, 31),
                 responsible=self.dossier_responsible.getId(),
-                )
+            )
             .in_state('dossier-state-resolved')
-            ))
+        ))
 
         self.expired_document = self.register('expired_document', create(
             Builder('document')
@@ -1483,7 +1483,7 @@ class OpengeverContentFixture(object):
             .titled(u'\xdcbersicht der Vertr\xe4ge vor 2000')
             .attach_archival_file_containing('TEST', name=u'test.pdf')
             .with_dummy_content()
-            ))
+        ))
 
     @staticuid()
     def create_inactive_dossier(self):
@@ -1497,16 +1497,16 @@ class OpengeverContentFixture(object):
                 start=date(2016, 1, 1),
                 end=date(2016, 12, 31),
                 responsible=self.dossier_responsible.getId(),
-                )
+            )
             .in_state('dossier-state-inactive')
-            ))
+        ))
 
         self.inactive_document = self.register('inactive_document', create(
             Builder('document')
             .within(self.inactive_dossier)
             .titled(u'\xdcbersicht der Inaktiven Vertr\xe4ge von 2016')
             .attach_file_containing('Excel dummy content', u'tab\xe4lle.xlsx')
-            ))
+        ))
 
     @staticuid()
     def create_offered_dossiers(self):
@@ -1521,9 +1521,9 @@ class OpengeverContentFixture(object):
                 end=date(2000, 1, 31),
                 responsible=self.dossier_responsible.getId(),
                 archival_value=ARCHIVAL_VALUE_WORTHY,
-                )
+            )
             .in_state('dossier-state-resolved')
-            ))
+        ))
 
         self.offered_dossier_for_sip = self.register('offered_dossier_for_sip', create(
             Builder('dossier')
@@ -1534,9 +1534,9 @@ class OpengeverContentFixture(object):
                 end=date(1997, 1, 31),
                 responsible=self.dossier_responsible.getId(),
                 archival_value=ARCHIVAL_VALUE_WORTHY,
-                )
+            )
             .in_state('dossier-state-resolved')
-            ))
+        ))
 
         self.offered_dossier_to_destroy = self.register('offered_dossier_to_destroy', create(
             Builder('dossier')
@@ -1548,9 +1548,9 @@ class OpengeverContentFixture(object):
                 end=date(2000, 1, 15),
                 responsible=self.dossier_responsible.getId(),
                 archival_value=ARCHIVAL_VALUE_UNWORTHY,
-                )
+            )
             .in_state('dossier-state-inactive')
-            ))
+        ))
 
     @staticuid()
     def create_disposition(self):
@@ -1581,7 +1581,7 @@ class OpengeverContentFixture(object):
                 .within(self.dossier)
                 .titled(u'Sch\xe4ttengarten')
                 .as_shadow_document(),
-                ))
+            ))
             shadow_document_annotations = IAnnotations(shadow_document)
             shadow_document_annotations['template-id'] = '2574d08d-95ea-4639-beab-3103fe4c3bc7'
             shadow_document_annotations['languages'] = [2055]
@@ -1630,8 +1630,8 @@ class OpengeverContentFixture(object):
             .having(
                 start=date(2016, 1, 1),
                 responsible=self.dossier_responsible.getId(),
-                )
-            ))
+            )
+        ))
 
     @staticuid()
     def create_protected_dossiers(self):
@@ -1643,8 +1643,8 @@ class OpengeverContentFixture(object):
                 description=u'Lichtbogen-L\xf6schkammern usw.',
                 responsible=self.dossier_responsible.getId(),
                 start=date(2016, 1, 1),
-                )
-            ))
+            )
+        ))
         protected_dossier.__ac_local_roles_block__ = True
         protected_dossier.reindexObjectSecurity()
         protected_dossier.reindexObject(idxs=['blocked_local_roles'])
@@ -1656,11 +1656,11 @@ class OpengeverContentFixture(object):
             .having(
                 document_date=datetime(2010, 1, 3),
                 document_author=TEST_USER_ID,
-                )
+            )
             .attach_file_containing(
                 bumblebee_asset('example.docx').bytes(),
                 u'bauplan.docx')
-            ))
+        ))
 
         protected_dossier_with_task = self.register('protected_dossier_with_task', create(
             Builder('dossier')
@@ -1670,8 +1670,8 @@ class OpengeverContentFixture(object):
                 description=u'Schl\xe4cht',
                 responsible=self.dossier_responsible.getId(),
                 start=date(2016, 1, 1),
-                )
-            ))
+            )
+        ))
         protected_dossier_with_task.__ac_local_roles_block__ = True
         protected_dossier_with_task.reindexObjectSecurity()
         protected_dossier_with_task.reindexObject(idxs=['blocked_local_roles'])
@@ -1683,11 +1683,11 @@ class OpengeverContentFixture(object):
             .having(
                 document_date=datetime(2010, 1, 3),
                 document_author=TEST_USER_ID,
-                )
+            )
             .attach_file_containing(
                 bumblebee_asset('example.docx').bytes(),
                 u'kunststuck.docx')
-            ))
+        ))
 
         task_in_protected_dossier = self.register('task_in_protected_dossier', create(
             Builder('task')
@@ -1699,10 +1699,10 @@ class OpengeverContentFixture(object):
                 issuer=self.dossier_responsible.getId(),
                 task_type='correction',
                 deadline=date(2016, 11, 1),
-                )
+            )
             .in_state('task-state-in-progress')
             .relate_to(protected_document_with_task)
-            ))
+        ))
         self.create_task_subscriptions(task_in_protected_dossier)
 
     @staticuid()
@@ -1711,7 +1711,7 @@ class OpengeverContentFixture(object):
             Builder("mail")
             .with_message(MAIL_DATA)
             .within(self.dossier)
-            ))
+        ))
 
         class MockMsg2MimeTransform(object):
 
@@ -1723,7 +1723,7 @@ class OpengeverContentFixture(object):
             'testm\xc3\xa4il.msg',
             'mock-msg-body',
             transform=MockMsg2MimeTransform(),
-            )
+        )
 
         self.register('mail_msg', command.execute())
 
@@ -1737,22 +1737,22 @@ class OpengeverContentFixture(object):
                 start=date(2016, 9, 12),
                 keywords=(u'Finanzverwaltung', u'Vertr\xe4ge'),
                 responsible=self.committee_responsible.getId(),
-                )
-            ))
+            )
+        ))
 
         create(
             Builder('contact_participation')
             .for_contact(self.meier_ag)
             .for_dossier(self.meeting_dossier)
             .with_roles(['final-drawing'])
-            )
+        )
 
         create(
             Builder('contact_participation')
             .for_contact(self.josef_buehler)
             .for_dossier(self.meeting_dossier)
             .with_roles(['final-drawing', 'participation'])
-            )
+        )
 
         self.meeting_document = self.register('meeting_document', create(
             Builder('document')
@@ -1761,9 +1761,9 @@ class OpengeverContentFixture(object):
             .having(
                 document_date=datetime(2016, 12, 1),
                 document_author=TEST_USER_ID,
-                )
+            )
             .with_asset_file('text.txt')
-            ))
+        ))
 
         self.meeting = create(
             Builder('meeting')
@@ -1778,17 +1778,17 @@ class OpengeverContentFixture(object):
                 participants=[
                     self.committee_participant_1,
                     self.committee_participant_2,
-                    ],
-                )
-            .link_with(self.meeting_dossier)
+                ],
             )
+            .link_with(self.meeting_dossier)
+        )
 
         create_session().flush()  # trigger id generation, part of path
 
         self.register_path(
             'meeting',
             self.meeting.physical_path.encode('utf-8'),
-            )
+        )
 
         decided_meeting_dossier = self.register(
             'decided_meeting_dossier', create(
@@ -1798,8 +1798,8 @@ class OpengeverContentFixture(object):
                 .having(
                     start=date(2016, 8, 17),
                     responsible=self.committee_responsible.getId(),
-                    )
-                ))
+                )
+            ))
 
         self.decided_meeting = create(
             Builder('meeting')
@@ -1814,21 +1814,21 @@ class OpengeverContentFixture(object):
                 participants=[
                     self.committee_participant_1,
                     self.committee_participant_2,
-                    ],
-                )
-            .link_with(decided_meeting_dossier)
+                ],
             )
+            .link_with(decided_meeting_dossier)
+        )
 
         create_session().flush()  # trigger id generation, part of path
 
         self.register_path(
             'decided_meeting',
             self.decided_meeting.physical_path.encode('utf-8'),
-            )
+        )
 
         self.decided_meeting.schedule_proposal(
             self.decided_proposal.load_model(),
-            )
+        )
         create_session().flush()  # trigger workflow state default
         for agenda_item in self.decided_meeting.agenda_items:
             agenda_item.close()
@@ -1847,8 +1847,8 @@ class OpengeverContentFixture(object):
                     start=date(2016, 7, 17),
                     responsible=self.committee_responsible.getId(),
                     relatedDossier=[self.dossier, self.meeting_dossier],
-                    )
-                ))
+                )
+            ))
 
         self.closed_meeting = create(
             Builder('meeting')
@@ -1863,10 +1863,10 @@ class OpengeverContentFixture(object):
                 participants=[
                     self.committee_participant_1,
                     self.committee_participant_2,
-                    ],
-                )
-            .link_with(closed_meeting_dossier)
+                ],
             )
+            .link_with(closed_meeting_dossier)
+        )
 
         create_session().flush()  # trigger id generation, part of path
 
@@ -1878,8 +1878,8 @@ class OpengeverContentFixture(object):
                 .having(
                     start=date(2016, 10, 17),
                     responsible=self.committee_responsible.getId(),
-                    )
-                ))
+                )
+            ))
 
         self.cancelled_meeting = create(
             Builder('meeting')
@@ -1895,17 +1895,17 @@ class OpengeverContentFixture(object):
                 participants=[
                     self.committee_participant_1,
                     self.committee_participant_2,
-                    ],
-                )
-            .link_with(self.cancelled_meeting_dossier)
+                ],
             )
+            .link_with(self.cancelled_meeting_dossier)
+        )
 
         create_session().flush()  # trigger id generation, part of path
 
         self.register_path(
             'cancelled_meeting',
             self.cancelled_meeting.physical_path.encode('utf-8'),
-            )
+        )
 
     @contextmanager
     def freeze_at_hour(self, hour, tick_length=2):
@@ -1998,7 +1998,7 @@ class OpengeverContentFixture(object):
             .named(firstname, lastname)
             .with_roles(*globalroles)
             .in_groups(self.org_unit_fa.users_group_id)
-            )
+        )
 
         builder.update_properties()  # updates builder.userid
         email = '{}@gever.local'.format(builder.userid)
@@ -2012,7 +2012,7 @@ class OpengeverContentFixture(object):
             .in_group(group)
             .having(**kwargs)
             .with_user_settings(**(user_settings or {}))
-            )
+        )
 
         # Use a static bumblebee user salt so that access tokens are predictable
         # when the time is frozen.
@@ -2023,19 +2023,19 @@ class OpengeverContentFixture(object):
         return plone_user
 
     def create_committee_membership(
-            self,
-            committee,
-            member_id_register_name,
-            firstname,
-            lastname,
-            email,
-            date_from,
-            date_to,
-        ):
+        self,
+        committee,
+        member_id_register_name,
+        firstname,
+        lastname,
+        email,
+        date_from,
+        date_to,
+    ):
         member = create(
             Builder('member')
             .having(firstname=firstname, lastname=lastname, email=email)
-            )
+        )
 
         create(
             Builder('membership')
@@ -2044,49 +2044,49 @@ class OpengeverContentFixture(object):
                 member=member,
                 date_from=date_from,
                 date_to=date_to,
-                )
             )
+        )
 
         create_session().flush()  # trigger id generation, part of path
 
         self.register_url(
             member_id_register_name,
             member.get_url(self.committee_container).encode('utf-8'),
-            )
+        )
 
         return member
 
     def create_committee(
-            self,
-            title,
-            repository_folder,
-            group_id,
-            group_title,
-            responsibles,
-            templates=None,
-        ):
+        self,
+        title,
+        repository_folder,
+        group_id,
+        group_title,
+        responsibles,
+        templates=None,
+    ):
         if templates is None:
             templates = {}
         # XXX I would have expected the commitee builder to do all of that.
         ogds_members = map(
             ogds_service().find_user,
             map(methodcaller('getId'), responsibles),
-            )
+        )
 
         create(
             Builder('ogds_group')
             .having(
                 groupid=group_id,
                 users=ogds_members,
-                )
             )
+        )
 
         create(
             Builder('group')
             .with_groupid(group_id)
             .having(title=group_title)
             .with_members(*responsibles)
-            )
+        )
 
         committee = create(
             Builder('committee')
@@ -2098,8 +2098,8 @@ class OpengeverContentFixture(object):
                 repository_folder=repository_folder,
                 group_id=group_id,
                 **templates
-                )
             )
+        )
 
         return committee
 
@@ -2110,8 +2110,8 @@ class OpengeverContentFixture(object):
                 id=u'workspaces',
                 title_de=u'Teamr\xe4ume',
                 title_fr=u'Espace partag\xe9',
-                )
-            ))
+            )
+        ))
 
         # Enable placeful workflow policy for workspace root
         self.workspace_root.manage_addProduct[
@@ -2131,7 +2131,7 @@ class OpengeverContentFixture(object):
             .titled(u'A Workspace')
             .having(description=u'A Workspace description')
             .within(self.workspace_root)
-            ))
+        ))
 
         self.set_roles(
             self.workspace, self.workspace_admin.getId(),
@@ -2148,27 +2148,27 @@ class OpengeverContentFixture(object):
             .titled(u'WS F\xc3lder')
             .having(description=u'A Workspace folder description')
             .within(self.workspace)
-            ))
+        ))
 
         self.register('workspace_document', create(
             Builder('document')
             .within(self.workspace)
             .titled(u'Teamraumdokument')
             .with_asset_file('text.txt')
-            ))
+        ))
 
         self.register('workspace_mail', create(
             Builder("mail")
             .with_message(MAIL_DATA)
             .within(self.workspace)
-            ))
+        ))
 
         self.register('workspace_folder_document', create(
             Builder('document')
             .within(self.workspace_folder)
             .titled(u'Ordnerdokument')
             .with_asset_file('text.txt')
-            ))
+        ))
 
     def create_todos(self):
         self.todolist_general = self.register('todolist_general', create(
@@ -2192,7 +2192,7 @@ class OpengeverContentFixture(object):
                 deadline=date(2016, 9, 1),
                 completed=False)
             .within(self.workspace)
-            ))
+        ))
 
         self.assigned_todo = self.register('assigned_todo', create(
             Builder('todo')
@@ -2202,7 +2202,7 @@ class OpengeverContentFixture(object):
                 responsible=self.workspace_member.getId(),
                 completed=False)
             .within(self.todolist_introduction)
-            ))
+        ))
 
         self.completed_todo = self.register('completed_todo', create(
             Builder('todo')

--- a/opengever/workspace/behaviors/configure.zcml
+++ b/opengever/workspace/behaviors/configure.zcml
@@ -34,4 +34,11 @@
       for="opengever.workspace.interfaces.IToDo"
       />
 
+  <plone:behavior
+      title="workspace meeting name from title"
+      provides=".namefromtitle.IWorkspaceMeetingNameFromTitle"
+      factory=".namefromtitle.WorkspaceMeetingNameFromTitle"
+      for="opengever.workspace.interfaces.IWorkspaceMeeting"
+      />
+
 </configure>

--- a/opengever/workspace/behaviors/namefromtitle.py
+++ b/opengever/workspace/behaviors/namefromtitle.py
@@ -58,3 +58,18 @@ class ToDoNameFromTitle(dossiernamefromtitle.DossierNameFromTitle):
     implements(IToDoNameFromTitle)
 
     format = u'todo-%i'
+
+
+class IWorkspaceMeetingNameFromTitle(INameFromTitle):
+    """Behavior interface for WorkspaceMeetingNameFromTitle.
+    """
+
+
+class WorkspaceMeetingNameFromTitle(dossiernamefromtitle.DossierNameFromTitle):
+    """ The ID of a workspace meeting should be 'meeting-{sequence number}'.
+
+    format = u'meeting-%i'
+    """
+    implements(IWorkspaceMeetingNameFromTitle)
+
+    format = u'meeting-%i'

--- a/opengever/workspace/configure.zcml
+++ b/opengever/workspace/configure.zcml
@@ -15,6 +15,7 @@
   <adapter factory=".sequence.WorkspaceFolderSequenceNumberGenerator" />
   <adapter factory=".sequence.TodoListSequenceNumberGenerator" />
   <adapter factory=".sequence.TodoSequenceNumberGenerator" />
+  <adapter factory=".sequence.WorkspaceMeetingSequenceNumberGenerator" />
 
   <subscriber
       for="opengever.workspace.interfaces.IWorkspace

--- a/opengever/workspace/interfaces.py
+++ b/opengever/workspace/interfaces.py
@@ -43,3 +43,7 @@ class IToDo(Interface):
 
 class IToDoList(Interface):
     """ Marker interface for ToDo lists"""
+
+
+class IWorkspaceMeeting(Interface):
+    """ Marker interface for Workspace Meetings """

--- a/opengever/workspace/locales/de/LC_MESSAGES/opengever.workspace.po
+++ b/opengever/workspace/locales/de/LC_MESSAGES/opengever.workspace.po
@@ -98,6 +98,11 @@ msgstr "Teammitglied"
 msgid "help_videoconferencing_url"
 msgstr "Verwendete URL um eine Videokonferenz für diesen Teamraum zu starten."
 
+#. Default: "Common"
+#: ./opengever/workspace/workspace_meeting.py
+msgid "fieldset_common"
+msgstr "Allgemein"
+
 #. Default: "Invitation"
 #: ./opengever/workspace/participation/__init__.py
 msgid "invitation"
@@ -149,6 +154,11 @@ msgstr "Beschreibung"
 msgid "label_documents"
 msgstr "Dokumente"
 
+#. Default: "End"
+#: ./opengever/workspace/workspace_meeting.py
+msgid "label_end"
+msgstr "Ende"
+
 #. Default: "Folders"
 #: ./opengever/workspace/browser/tabbed.py
 msgid "label_folders"
@@ -159,10 +169,25 @@ msgstr "Ordner"
 msgid "label_journal"
 msgstr "Journal"
 
+#. Default: "Location"
+#: ./opengever/workspace/workspace_meeting.py
+msgid "label_location"
+msgstr "Ort"
+
+#. Default: "Organizer"
+#: ./opengever/workspace/workspace_meeting.py
+msgid "label_organizer"
+msgstr "Organisator"
+
 #. Default: "Responsible"
 #: ./opengever/workspace/todo.py
 msgid "label_responsible"
 msgstr "Verantwortlich"
+
+#. Default: "Start"
+#: ./opengever/workspace/workspace_meeting.py
+msgid "label_start"
+msgstr "Beginn"
 
 #. Default: "Text"
 #: ./opengever/workspace/todo.py
@@ -210,6 +235,11 @@ msgstr "Papierkorb"
 #: ./opengever/workspace/workspace.py
 msgid "label_videoconferencing_url"
 msgstr "Videokonferenz URL"
+
+#. Default: "Video Call Link"
+#: ./opengever/workspace/workspace_meeting.py
+msgid "label_video_call_link"
+msgstr "Video-Call Link"
 
 #. Default: "Workspaces"
 #: ./opengever/workspace/browser/tabbed.py

--- a/opengever/workspace/locales/fr/LC_MESSAGES/opengever.workspace.po
+++ b/opengever/workspace/locales/fr/LC_MESSAGES/opengever.workspace.po
@@ -98,6 +98,11 @@ msgstr "Membre du team"
 msgid "help_videoconferencing_url"
 msgstr "URL utilisée pour lancer une vidéoconférence pour cet espace partagé."
 
+#. Default: "Common"
+#: ./opengever/workspace/workspace_meeting.py
+msgid "fieldset_common"
+msgstr "Général"
+
 #. Default: "Invitation"
 #: ./opengever/workspace/participation/__init__.py
 msgid "invitation"
@@ -149,6 +154,11 @@ msgstr "Description"
 msgid "label_documents"
 msgstr "Documents"
 
+#. Default: "End"
+#: ./opengever/workspace/workspace_meeting.py
+msgid "label_end"
+msgstr "Fin"
+
 #. Default: "Folders"
 #: ./opengever/workspace/browser/tabbed.py
 msgid "label_folders"
@@ -159,10 +169,25 @@ msgstr "Répertoires"
 msgid "label_journal"
 msgstr "Journal"
 
+#. Default: "Location"
+#: ./opengever/workspace/workspace_meeting.py
+msgid "label_location"
+msgstr "Lieu"
+
+#. Default: "Organizer"
+#: ./opengever/workspace/workspace_meeting.py
+msgid "label_organizer"
+msgstr "Organisateur"
+
 #. Default: "Responsible"
 #: ./opengever/workspace/todo.py
 msgid "label_responsible"
 msgstr "Responsable"
+
+#. Default: "Start"
+#: ./opengever/workspace/workspace_meeting.py
+msgid "label_start"
+msgstr "Début"
 
 #. Default: "Text"
 #: ./opengever/workspace/todo.py
@@ -210,6 +235,11 @@ msgstr "Corbeille"
 #: ./opengever/workspace/workspace.py
 msgid "label_videoconferencing_url"
 msgstr "URL de vidéoconférence"
+
+#. Default: "Video Call Link"
+#: ./opengever/workspace/workspace_meeting.py
+msgid "label_video_call_link"
+msgstr "Lien pour la vidéoconférence"
 
 #. Default: "Workspaces"
 #: ./opengever/workspace/browser/tabbed.py

--- a/opengever/workspace/locales/opengever.workspace.pot
+++ b/opengever/workspace/locales/opengever.workspace.pot
@@ -101,6 +101,11 @@ msgstr ""
 msgid "help_videoconferencing_url"
 msgstr ""
 
+#. Default: "Common"
+#: ./opengever/workspace/workspace_meeting.py
+msgid "fieldset_common"
+msgstr ""
+
 #. Default: "Invitation"
 #: ./opengever/workspace/participation/__init__.py
 msgid "invitation"
@@ -146,6 +151,11 @@ msgstr ""
 msgid "label_documents"
 msgstr ""
 
+#. Default: "End"
+#: ./opengever/workspace/workspace_meeting.py
+msgid "label_end"
+msgstr ""
+
 #. Default: "Folders"
 #: ./opengever/workspace/browser/tabbed.py
 msgid "label_folders"
@@ -156,9 +166,24 @@ msgstr ""
 msgid "label_journal"
 msgstr ""
 
+#. Default: "Location"
+#: ./opengever/workspace/workspace_meeting.py
+msgid "label_location"
+msgstr ""
+
+#. Default: "Organizer"
+#: ./opengever/workspace/workspace_meeting.py
+msgid "label_organizer"
+msgstr ""
+
 #. Default: "Responsible"
 #: ./opengever/workspace/todo.py
 msgid "label_responsible"
+msgstr ""
+
+#. Default: "Start"
+#: ./opengever/workspace/workspace_meeting.py
+msgid "label_start"
 msgstr ""
 
 #. Default: "Text"
@@ -206,6 +231,11 @@ msgstr ""
 #. Default: "Videoconferencing URL"
 #: ./opengever/workspace/workspace.py
 msgid "label_videoconferencing_url"
+msgstr ""
+
+#. Default: "Video Call Link"
+#: ./opengever/workspace/workspace_meeting.py
+msgid "label_video_call_link"
 msgstr ""
 
 #. Default: "Workspaces"

--- a/opengever/workspace/sequence.py
+++ b/opengever/workspace/sequence.py
@@ -2,6 +2,7 @@ from opengever.base.sequence import DefaultSequenceNumberGenerator
 from opengever.workspace.interfaces import IToDo
 from opengever.workspace.interfaces import IWorkspace
 from opengever.workspace.interfaces import IWorkspaceFolder
+from opengever.workspace.interfaces import IWorkspaceMeeting
 from opengever.workspace.todolist import IToDoListSchema
 from zope.component import adapter
 
@@ -36,3 +37,11 @@ class TodoSequenceNumberGenerator(DefaultSequenceNumberGenerator):
     """
 
     key = 'ToDoSequenceNumberGenerator'
+
+
+@adapter(IWorkspaceMeeting)
+class WorkspaceMeetingSequenceNumberGenerator(DefaultSequenceNumberGenerator):
+    """Sequence Number generator for workspace meeting, which uses a global counter.
+    """
+
+    key = 'WorkspaceMeetingSequenceNumberGenerator'

--- a/opengever/workspace/tests/test_deactivate_workspace.py
+++ b/opengever/workspace/tests/test_deactivate_workspace.py
@@ -185,6 +185,16 @@ class TestDeactivateWorkspace(IntegrationTestCase):
             )
 
     @browsing
+    def test_cannot_add_workspace_meeting_in_deactivated_workspace(self, browser):
+        self.login(self.workspace_admin, browser)
+        self.deactivate_workspace(browser)
+        with browser.expect_http_error(401):
+            browser.open(
+                self.workspace, method='POST', headers=self.api_headers,
+                data=json.dumps({'@type': 'opengever.workspace.meeting'}),
+            )
+
+    @browsing
     def test_cannot_modify_document_in_deactivated_workspace(self, browser):
         self.login(self.workspace_admin, browser)
         self.deactivate_workspace(browser)
@@ -222,6 +232,16 @@ class TestDeactivateWorkspace(IntegrationTestCase):
             browser.open(
                 self.todolist_general, method='PATCH',
                 headers=self.api_headers, data=json.dumps({'title': 'Foo'}),
+            )
+
+    @browsing
+    def test_cannot_modify_workspace_meeting_in_deactivated_workspace(self, browser):
+        self.login(self.workspace_admin, browser)
+        self.deactivate_workspace(browser)
+        with browser.expect_http_error(401):
+            browser.open(
+                self.workspace_meeting, method='PATCH', headers=self.api_headers,
+                data=json.dumps({'title': 'Foo'}),
             )
 
     @browsing
@@ -275,3 +295,10 @@ class TestDeactivateWorkspace(IntegrationTestCase):
         self.assertTrue(can_manage_member(self.workspace_document))
         self.deactivate_workspace(browser)
         self.assertFalse(can_manage_member(self.workspace_document))
+
+    @browsing
+    def test_cannot_manage_member_of_workspace_meeting_in_deactivated_workspace(self, browser):
+        self.login(self.workspace_admin, browser)
+        self.assertTrue(can_manage_member(self.workspace_meeting))
+        self.deactivate_workspace(browser)
+        self.assertFalse(can_manage_member(self.workspace_meeting))

--- a/opengever/workspace/tests/test_todolist.py
+++ b/opengever/workspace/tests/test_todolist.py
@@ -147,7 +147,7 @@ class TestAPISupportForTodoLists(IntegrationTestCase):
                .within(self.workspace))
 
         self.assertEqual(
-            ['folder-1', 'document-38', 'document-39', 'todolist-1', 'todolist-2',
+            ['folder-1', 'document-38', 'document-39', 'meeting-1', 'todolist-1', 'todolist-2',
              'todo-1', 'todolist-3', 'todolist-4'],
             self.workspace.objectIds())
 
@@ -162,7 +162,7 @@ class TestAPISupportForTodoLists(IntegrationTestCase):
                      headers=self.api_headers, data=json.dumps(data))
 
         self.assertEqual(
-            ['folder-1', 'document-38', 'document-39', 'todolist-2', 'todolist-3',
+            ['folder-1', 'document-38', 'document-39', 'meeting-1', 'todolist-2', 'todolist-3',
              'todo-1', 'todolist-1', 'todolist-4'],
             self.workspace.objectIds())
 

--- a/opengever/workspace/tests/test_workspace_meeting.py
+++ b/opengever/workspace/tests/test_workspace_meeting.py
@@ -1,0 +1,67 @@
+from ftw.testbrowser import browsing
+from ftw.testbrowser.pages import factoriesmenu
+from ftw.testbrowser.pages.statusmessages import assert_no_error_messages
+from opengever.testing import IntegrationTestCase
+import json
+
+
+class TestWorkspaceMeeting(IntegrationTestCase):
+
+    @browsing
+    def test_workspace_meeting_is_addable_in_workspace(self, browser):
+        self.login(self.workspace_member, browser)
+        browser.visit(self.workspace)
+        with self.observe_children(self.workspace) as children:
+            factoriesmenu.add('WorkspaceMeeting')
+            browser.fill({'Title': u'Ein Meeting',
+                          'Start': '10.10.2020 23:56'})
+            form = browser.find_form_by_field('Organizer')
+            form.find_widget('Organizer').fill(self.workspace_member.getId(), auto_org_unit=False)
+            browser.click_on('Save')
+
+        assert_no_error_messages(browser)
+        self.assertEqual(1, len(children['added']))
+        meeting = children['added'].pop()
+        self.assertEqual(meeting.Title(), u'Ein Meeting')
+
+
+class TestAPISupportForWorkspaceMeeting(IntegrationTestCase):
+
+    @browsing
+    def test_create_workspace_meeting_via_api(self, browser):
+        self.login(self.workspace_member, browser)
+        browser.open(
+            self.workspace, method='POST', headers=self.api_headers,
+            data=json.dumps({'title': 'Ein Meeting',
+                             'responsible': self.workspace_member.getId(),
+                             'start': '2020-10-10T23:56:00',
+                             '@type': 'opengever.workspace.meeting'}))
+
+        self.assertEqual(201, browser.status_code)
+        self.assertEqual('Ein Meeting', browser.json['title'])
+        self.assertEqual('meeting-2', browser.json['id'])
+
+    @browsing
+    def test_get_workspace_meeting_via_api(self, browser):
+        self.login(self.workspace_member, browser)
+        browser.open(self.workspace_meeting, method='GET', headers=self.api_headers)
+        self.assertEqual(200, browser.status_code)
+        expected = {
+            u'@id': self.workspace_meeting.absolute_url(),
+            u'@type': u'opengever.workspace.meeting',
+            u'id': u'meeting-1',
+            u'responsible': {u'title': u'Schr\xf6dinger B\xe9atrice',
+                             u'token': u'beatrice.schrodinger'},
+            u'title': u'Besprechung Kl\xe4ranlage'
+        }
+        self.assertDictContainsSubset(expected, browser.json)
+
+    @browsing
+    def test_update_workspace_meeting_via_api(self, browser):
+        self.login(self.workspace_member, browser)
+        browser.open(self.workspace_meeting, method='PATCH',
+                     headers=self.api_headers,
+                     data=json.dumps({'title': u'\xc4 new title'}))
+
+        self.assertEqual(204, browser.status_code)
+        self.assertEqual(u'\xc4 new title', self.workspace_meeting.title)

--- a/opengever/workspace/tests/test_workspace_workspace.py
+++ b/opengever/workspace/tests/test_workspace_workspace.py
@@ -124,6 +124,57 @@ class TestWorkspaceWorkspace(IntegrationTestCase):
                 got[user] = factoriesmenu.visible() \
                     and 'WorkspaceFolder' in factoriesmenu.addable_types()
 
+        self.assertDictEqual(expected, got)
+
+    @browsing
+    def test_security_add_workspace_meetings(self, browser):
+        expected = {self.workspace_owner: True,
+                    self.workspace_admin: True,
+                    self.workspace_member: True,
+                    self.workspace_guest: False}
+
+        got = {}
+        for user in expected.keys():
+            locals()['__traceback_info__'] = user
+            with self.login(user, browser):
+                browser.open(self.workspace)
+                got[user] = factoriesmenu.visible() \
+                    and 'WorkspaceMeeting' in factoriesmenu.addable_types()
+
+        self.assertDictEqual(expected, got)
+
+    @browsing
+    def test_security_edit_workspace_meeting_action(self, browser):
+        expected = {self.workspace_owner: True,
+                    self.workspace_admin: True,
+                    self.workspace_member: True,
+                    self.workspace_guest: False}
+
+        got = {}
+        for user in expected.keys():
+            locals()['__traceback_info__'] = user
+            with self.login(user, browser):
+                browser.open(self.workspace_meeting)
+                got[user] = editbar.visible() and 'Edit' in editbar.contentviews()
+
+        self.maxDiff = None
+        self.assertEquals(expected, got)
+
+    @browsing
+    def test_security_add_workspace_meetings(self, browser):
+        expected = {self.workspace_owner: True,
+                    self.workspace_admin: True,
+                    self.workspace_member: True,
+                    self.workspace_guest: False}
+
+        got = {}
+        for user in expected.keys():
+            locals()['__traceback_info__'] = user
+            with self.login(user, browser):
+                browser.open(self.workspace)
+                got[user] = factoriesmenu.visible() \
+                    and 'WorkspaceMeeting' in factoriesmenu.addable_types()
+
         self.maxDiff = None
         self.assertEquals(expected, got)
 

--- a/opengever/workspace/workspace_meeting.py
+++ b/opengever/workspace/workspace_meeting.py
@@ -1,0 +1,62 @@
+from ftw.keywordwidget.widget import KeywordFieldWidget
+from opengever.ogds.base.sources import ActualWorkspaceMembersSourceBinder
+from opengever.workspace import _
+from opengever.workspace.interfaces import IWorkspaceMeeting
+from plone.autoform import directives as form
+from plone.autoform.interfaces import IFormFieldProvider
+from plone.dexterity.content import Container
+from plone.supermodel import model
+from zope import schema
+from zope.interface import implements
+from zope.interface import provider
+from opengever.base.schema import UTCDatetime
+from ftw.datepicker.widget import DatePickerFieldWidget
+
+
+@provider(IFormFieldProvider)
+class IWorkspaceMeetingSchema(model.Schema):
+
+    model.fieldset(
+        u'common',
+        label=_(u'fieldset_common', default=u'Common'),
+        fields=[
+            u'responsible',
+            u'start',
+            u'end',
+            u'location',
+            u'videoconferencing_url',
+            ],
+        )
+
+    form.widget('responsible', KeywordFieldWidget, async=True)
+    form.order_after(responsible='IOpenGeverBase.description')
+    responsible = schema.Choice(
+        title=_('label_organizer', default='Organizer'),
+        source=ActualWorkspaceMembersSourceBinder(),
+        required=True)
+
+    form.widget('start', DatePickerFieldWidget)
+    form.order_after(start='responsible')
+    start = schema.Datetime(
+        title=_(u'label_start', default='Start'),
+        required=True)
+
+    form.widget('end', DatePickerFieldWidget)
+    form.order_after(end='start')
+    end = schema.Datetime(
+        title=_(u'label_end', default='End'),
+        required=False)
+
+    form.order_after(location='end')
+    location = schema.TextLine(
+        title=_(u'label_location', default=u'Location'),
+        required=False)
+
+    form.order_after(videoconferencing_url='location')
+    videoconferencing_url = schema.TextLine(
+        title=_(u'label_video_call_link', default=u'Video Call Link'),
+        required=False)
+
+
+class WorkspaceMeeting(Container):
+    implements(IWorkspaceMeeting)


### PR DESCRIPTION
With this PR a new content type workspace meeting is implemented.
The meeting has the fields `Titel`, `Beginn`, `Ende`, `Beschreibung`, `Ort`, `Organisator` and `Video-Call Link`.
Meetings can only be created at workspace level.

Jira: https://4teamwork.atlassian.net/browse/NE-127


## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


## Checklist (if applicable)

_Only applicable should be left and checked._

- Upgrade steps (changes in profile):
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
- New translations
  - [x] All msg-strings are unicode