### PR TITLE
Don't create journal entry when downloading file copy in readonly mode.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2020.12.0 (unreleased)
 ----------------------
 
+- Don't create journal entry when downloading file copy in readonly mode. [lgraf]
 - Create Bumblebee user salt on login. [lgraf]
 - Patch several login-related events to allow login during readonly mode. [lgraf]
 - Add optional support for WriteOnRead tracing in ReadOnlyError page. [lgraf]

--- a/opengever/journal/handlers.py
+++ b/opengever/journal/handlers.py
@@ -10,6 +10,7 @@ from opengever.base.oguid import Oguid
 from opengever.document.document import IDocumentSchema
 from opengever.dossier.browser.participants import role_list_helper
 from opengever.journal import _
+from opengever.readonly import is_in_readonly_mode
 from opengever.repository.repositoryroot import IRepositoryRoot
 from opengever.sharing.behaviors import IStandard
 from opengever.sharing.browser.sharing import ROLE_MAPPING
@@ -431,6 +432,8 @@ FILE_COPY_DOWNLOADED = 'File copy downloaded'
 
 
 def file_copy_downloaded(context, event):
+    if is_in_readonly_mode():
+        return
 
     title_unversioned = _(u'label_file_copy_downloaded',
                           default=u'Download copy')
@@ -462,6 +465,9 @@ PDF_DOWNLOADED = 'PDF downloaded'
 
 
 def pdf_downloaded(context, event):
+    if is_in_readonly_mode():
+        return
+
     title = _(u'label_pdf_downloaded', default=u'PDF downloaded')
     journal_entry_factory(context, PDF_DOWNLOADED, title)
 

--- a/opengever/readonly/tests/test_file_download.py
+++ b/opengever/readonly/tests/test_file_download.py
@@ -1,0 +1,64 @@
+from ftw.testbrowser import browsing
+from opengever.bumblebee.events import PDFDownloadedEvent
+from opengever.journal.handlers import DOCUMENT_ADDED_ACTION
+from opengever.testing import IntegrationTestCase
+from opengever.testing.readonly import ZODBStorageInReadonlyMode
+from zope.event import notify
+import transaction
+
+
+class TestFileDownloadInReadOnly(IntegrationTestCase):
+
+    features = ('bumblebee', )
+
+    @browsing
+    def test_file_download_journaling_doesnt_cause_readonly_error(self, browser):
+        self.login(self.regular_user, browser)
+
+        # Get other potential writes-on-read out of the way.
+        # Those are not what we're testing here.
+        browser.open(self.document,
+                     view='tabbed_view/listing',
+                     data={'view_name': 'overview'})
+        transaction.commit()
+
+        with ZODBStorageInReadonlyMode():
+            browser.find('Download copy').click()
+            browser.find('label_download').click()
+            transaction.commit()
+
+        self.assertEqual(200, browser.status_code)
+        self.assertEqual(self.document.file._data, browser.contents)
+
+        self.assertEqual(
+            len(self.document.file._data),
+            int(browser.headers['Content-Length']))
+
+        self.assertEqual(
+            'application/vnd.openxmlformats-officedocument.'
+            'wordprocessingml.document',
+            browser.headers['Content-Type'])
+
+    @browsing
+    def test_downloading_doc_pdf_journaling_doesnt_cause_readonly_error(self, browser):
+        self.login(self.regular_user, browser)
+
+        with ZODBStorageInReadonlyMode():
+            notify(PDFDownloadedEvent(self.document))
+            transaction.commit()
+
+        # Last journal entry should be document added, not 'PDF downloaded'
+        msg = u'Document added: Vertr\xe4gsentwurf'
+        self.assert_journal_entry(self.document, DOCUMENT_ADDED_ACTION, msg)
+
+    @browsing
+    def test_downloading_mail_pdf_journaling_doesnt_cause_readonly_error(self, browser):
+        self.login(self.regular_user, browser)
+
+        with ZODBStorageInReadonlyMode():
+            notify(PDFDownloadedEvent(self.mail_eml))
+            transaction.commit()
+
+        # Last journal entry should be document added, not 'PDF downloaded'
+        msg = u'Document added: Die B\xfcrgschaft'
+        self.assert_journal_entry(self.mail_eml, DOCUMENT_ADDED_ACTION, msg)


### PR DESCRIPTION
Don't create journal entry when downloading file copy in readonly mode (original documents or PDF previews from bumblebee).

This is to **prevent the write-on-read** that would otherwise happen during journaling of the file download in readonly mode.

Jira: https://4teamwork.atlassian.net/browse/CA-1

## Checklist (Must have)

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

## Checklist (if applicable)

- New functionality:
  - [x] for `document` also works for `mail`
