### PR TITLE
Show culprit traceback on ReadOnlyError page to all users, not just managers

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 ----------------------
 
 - Make is_in_readonly_mode() slightly more robust. [lgraf]
+- Show traceback on ReadOnlyError page to all users, not just managers. [lgraf]
 - Don't create journal entry when downloading file copy in readonly mode. [lgraf]
 - Create Bumblebee user salt on login. [lgraf]
 - Patch several login-related events to allow login during readonly mode. [lgraf]

--- a/opengever/base/browser/templates/error.pt
+++ b/opengever/base/browser/templates/error.pt
@@ -108,7 +108,7 @@
                     tried to perform as well as the error number below.
                 </p>
 
-                <metal:culprit tal:condition="is_manager">
+                <metal:culprit>
                     <div tal:condition="view/get_culprit_traceback">
                         <h3>This seems to be the culprit:</h3>
                         <pre tal:content="view/get_culprit_traceback" />


### PR DESCRIPTION
When debugging user-specific login related writes-on-read, it's desirable to have the **culprit traceback** shown for users other than managers - otherwise, these writes-on-read get quite tricky to hunt down.

Thefore I remove the `is_manager` restriction for write-on-read culprit tracebacks.

I don't really consider this a security risk in terms of information disclosure:
This functionality (_write-on-read tracing_) has to be enabled deliberately by developers, times out, and could only ever be seen by end users during a short period of time, under very specific circumstances (when RO mode is active).

Jira: https://4teamwork.atlassian.net/browse/CA-1

## Checklist (Must have)

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
