### PR TITLE
Make is_in_readonly_mode() more robust when getSite() hook returns None

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2020.12.0 (unreleased)
 ----------------------
 
+- Make is_in_readonly_mode() slightly more robust. [lgraf]
 - Don't create journal entry when downloading file copy in readonly mode. [lgraf]
 - Create Bumblebee user salt on login. [lgraf]
 - Patch several login-related events to allow login during readonly mode. [lgraf]

--- a/opengever/readonly/__init__.py
+++ b/opengever/readonly/__init__.py
@@ -8,5 +8,7 @@ def is_in_readonly_mode():
     """Checks whether the current instance is in readonly mode.
     """
     site = getSite()
-    conn = site._p_jar
-    return conn.isReadOnly()
+    if site:
+        conn = site._p_jar
+        return conn.isReadOnly()
+    return False


### PR DESCRIPTION
This might for example happen when a request hits the Zope application root instead of the Plone site.

Returning `False` in this case is incorrect, strictly speaking, but the only safe choice to fall back to (in the sense that in writable production mode, the system must _never_ be considered readonly by accident).

But since 
- the result of this flag has no discernable effect on the Zope App Root
- the worst that could happen as a consequence of False-Negative answers to `is_in_readonly_mode()` is that actions that won't work are shown

this should be fine.

Jira: https://4teamwork.atlassian.net/browse/CA-1

## Checklist (Must have)

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


