### PR TITLE
Fix mimetype for quickupload with custom mimetypes

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -27,6 +27,7 @@ Changelog
 - Allow assigning groups as participants to a Teamraum [elioschmutz]
 - Add external_reference field to solr, reindex objects with values. [deiferni]
 - Provide empty MS Office templates for new deployments. [2e12]
+- Fix mimetype for quickupload with custom mimetypes. [buchi]
 
 
 2020.11.1 (2020-10-09)

--- a/opengever/base/quickupload.py
+++ b/opengever/base/quickupload.py
@@ -84,7 +84,8 @@ class OGQuickUploadCapableFileFactory(object):
                 self.context, filename, data,
                 message_source=MESSAGE_SOURCE_DRAG_DROP_UPLOAD)
         else:
-            command = CreateDocumentCommand(self.context, filename, data)
+            command = CreateDocumentCommand(
+                self.context, filename, data, content_type=content_type)
 
         try:
             obj = command.execute()

--- a/opengever/base/tests/test_quickupload.py
+++ b/opengever/base/tests/test_quickupload.py
@@ -56,3 +56,12 @@ class TestOGQuickupload(IntegrationTestCase):
         self.assertEquals(u'Document added: document',
                           translate(history.data()[0]['action']['title']),
                           'Expected the document title in the action title')
+
+    def test_uses_mimetype_from_mimetype_registry(self):
+        content = create(Builder('quickuploaded_document')
+                         .within(self.dossier)
+                         .with_data(
+                            'Cadwork 2d Dummy document',
+                            filename='test.2d',
+                            content_type='application/x-cadwork-2d'))
+        self.assertEqual(content.file.contentType, 'application/x-cadwork-2d')


### PR DESCRIPTION
c.quickupload correctly determines the mimetype from Plone's mimetypes registry. However our quick upload adapter doesn't pass the mimetype to the `CreateDocumentCommand`. Because of this plone.namedfile determines the mimetype using Python's mimetypes module, which doesn't work for custom mimetypes.

JIRA: https://4teamwork.atlassian.net/browse/CA-1143


## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

