### PR TITLE
Fix order of labels for participations field in the listing endpoint.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,7 @@ Changelog
 - Custom error page: Also log ReadOnlyError culprit traceback to error log (if available). [lgraf]
 - Bump ftw.tabbedview to 4.2.1 to get fix for empty action lists. [lgraf]
 - Add workspacemeetings to @listing endpoint. [tinagerber]
+- Fix order of labels for participations field in the listing endpoint. [njohner]
 
 
 2020.12.0 (2020-10-22)

--- a/opengever/api/tests/test_listing.py
+++ b/opengever/api/tests/test_listing.py
@@ -1126,13 +1126,13 @@ class TestSQLDossierParticipationsInListingWithRealSolr(SolrIntegrationTestCase)
             [u'any_role', u'Participation', u'Final drawing'],
             item['participation_roles'])
         self.assertItemsEqual(
-            [u'any_role|B\xfchler Josef',
-             u'Final drawing|B\xfchler Josef',
-             u'Participation|any_participant',
-             u'any_role|Meier AG',
-             u'Participation|B\xfchler Josef',
-             u'Final drawing|Meier AG',
-             u'Final drawing|any_participant'],
+            [u'B\xfchler Josef|any_role',
+             u'B\xfchler Josef|Final drawing',
+             u'any_participant|Participation',
+             u'Meier AG|any_role',
+             u'B\xfchler Josef|Participation',
+             u'Meier AG|Final drawing',
+             u'any_participant|Final drawing'],
             item['participations'])
 
 
@@ -1185,15 +1185,15 @@ class TestPloneDossierParticipationsInListingWithRealSolr(SolrIntegrationTestCas
             [u'any_role', u'Regard', u'Participation', u'Final drawing'],
             item['participation_roles'])
         self.assertItemsEqual(
-            [u'Regard|Ziegler Robert (robert.ziegler)',
-             u'any_role|Ziegler Robert (robert.ziegler)',
-             u'Regard|any_participant',
-             u'Participation|B\xe4rfuss K\xe4thi (kathi.barfuss)',
-             u'Regard|B\xe4rfuss K\xe4thi (kathi.barfuss)',
-             u'Participation|any_participant',
-             u'any_role|B\xe4rfuss K\xe4thi (kathi.barfuss)',
-             u'Final drawing|B\xe4rfuss K\xe4thi (kathi.barfuss)',
-             u'Final drawing|any_participant'],
+            [u'Ziegler Robert (robert.ziegler)|Regard',
+             u'Ziegler Robert (robert.ziegler)|any_role',
+             u'any_participant|Regard',
+             u'B\xe4rfuss K\xe4thi (kathi.barfuss)|Participation',
+             u'B\xe4rfuss K\xe4thi (kathi.barfuss)|Regard',
+             u'any_participant|Participation',
+             u'B\xe4rfuss K\xe4thi (kathi.barfuss)|any_role',
+             u'B\xe4rfuss K\xe4thi (kathi.barfuss)|Final drawing',
+             u'any_participant|Final drawing'],
             item['participations'])
 
     @browsing

--- a/opengever/dossier/indexers.py
+++ b/opengever/dossier/indexers.py
@@ -333,7 +333,7 @@ class ParticipationIndexHelper(object):
         participant_id, role = self.index_value_to_participant_id_and_role(value)
         role_label = self.role_to_label(role)
         participant_label = self.participant_id_to_label(participant_id)
-        return u"{}|{}".format(role_label, participant_label)
+        return u"{}|{}".format(participant_label, role_label)
 
 
 @indexer(IParticipationAwareMarker)


### PR DESCRIPTION
It seems that I messed up the label order for the `participations` field in the API endpoint. We were returning `role label|participant label` instead of `participant label|role label`.

For https://4teamwork.atlassian.net/browse/CA-17
## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

- API change: Documentation is still ok, and it's not a breaking change as such as it's just the returned labels that change
  - [ ] Documentation is updated
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed