### PR TITLE
Custom error page: Also log ReadOnlyError culprit traceback

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2020.13.0 (unreleased)
 ----------------------
 
+- Custom error page: Also log ReadOnlyError culprit traceback to error log (if available). [lgraf]
 - Bump ftw.tabbedview to 4.2.1 to get fix for empty action lists. [lgraf]
 
 

--- a/opengever/base/browser/errors.py
+++ b/opengever/base/browser/errors.py
@@ -1,4 +1,5 @@
 from Acquisition import aq_acquire
+from logging import getLogger
 from opengever.debug import write_on_read_tracing
 from opengever.debug.write_on_read_tracing import format_instruction
 from plone import api
@@ -11,6 +12,9 @@ from zope.component.hooks import getSite
 from zope.interface import Interface
 import sys
 import traceback
+
+
+logger = getLogger('opengever.base')
 
 
 class ErrorHandlingView(BrowserView):
@@ -29,6 +33,12 @@ class ErrorHandlingView(BrowserView):
             self.portal_state = None
             self.portal_url = ''
             self.language = 'de'
+
+        if self.is_readonly_error():
+            culprit_tb = self.get_culprit_traceback()
+            if culprit_tb:
+                logger.info('Traceback of most recent DB write:')
+                logger.info(culprit_tb)
 
         self.request.response.setHeader('Content-Type', 'text/html')
         return self.template()


### PR DESCRIPTION
Custom error page: Also log `ReadOnlyError` culprit traceback (if one is available) to error log in `var/log/instance?-log`.

This makes debugging easier in situations where the error page contents aren't easily viewable in the browser, like for AJAX requests.

Jira: https://4teamwork.atlassian.net/browse/CA-1

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
