### PR TITLE
Avoid ftw.casauth write-on-read (last login times) during login

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 ----------------------
 
 - Custom error page: Also log ReadOnlyError culprit traceback to error log (if available). [lgraf]
+- Avoid ftw.casauth write-on-read (last login times) during login. [lgraf]
 - Bump ftw.tabbedview to 4.2.1 to get fix for empty action lists. [lgraf]
 - Add workspacemeetings to @listing endpoint. [tinagerber]
 

--- a/opengever/base/monkey/patches/__init__.py
+++ b/opengever/base/monkey/patches/__init__.py
@@ -19,6 +19,7 @@ from .ldap_userfolder_encoding import PatchLDAPUserFolderEncoding
 from .namedfile_data_converter import PatchNamedfileNamedDataConverter
 from .paste_permission import PatchDXContainerPastePermission
 from .plone_43rc1_upgrade import PatchPlone43RC1Upgrade
+from .readonly import PatchCASAuthSetLoginTimes
 from .readonly import PatchContentRulesHandlerOnLogin
 from .readonly import PatchMembershipToolCreateMemberarea
 from .readonly import PatchMembershipToolSetLoginTimes
@@ -35,6 +36,7 @@ from .workflowtool import PatchWorkflowTool
 PatchActionInfo()()
 PatchBaseOrderedViewletManagerExceptions()()
 PatchBuilderCreate()()
+PatchCASAuthSetLoginTimes()()
 PatchCatalogToFilterTrashedDocs()()
 PatchCMFCatalogAware()()
 PatchCMFCatalogAwareHandlers()()

--- a/opengever/base/monkey/patches/readonly.py
+++ b/opengever/base/monkey/patches/readonly.py
@@ -1,3 +1,4 @@
+from ftw.casauth.plugin import CASAuthenticationPlugin
 from opengever.base.monkey.patching import MonkeyPatch
 from opengever.readonly import is_in_readonly_mode
 from plone.app.contentrules import handlers as contentrules_handlers
@@ -30,6 +31,24 @@ class PatchMembershipToolSetLoginTimes(MonkeyPatch):
         original_setLoginTimes = MembershipTool.setLoginTimes
 
         self.patch_refs(MembershipTool, 'setLoginTimes', setLoginTimes)
+
+
+class PatchCASAuthSetLoginTimes(MonkeyPatch):
+    """Same for ftw.casauth - don't update last login times in readonly mode.
+    """
+
+    def __call__(self):
+
+        def set_login_times(self, member):
+            if is_in_readonly_mode():
+                return False
+
+            return original_set_login_times(self, member)
+
+        locals()['__patch_refs__'] = False
+        original_set_login_times = CASAuthenticationPlugin.set_login_times
+
+        self.patch_refs(CASAuthenticationPlugin, 'set_login_times', set_login_times)
 
 
 class PatchContentRulesHandlerOnLogin(MonkeyPatch):


### PR DESCRIPTION
Avoid `ftw.casauth` write-on-read (last login times) during login:

Patch `CASAuthenticationPlugin.set_login_times()` to avoid the write-on-read during login when attempting to set login times.

This is the same issue that's already being patched for the `MembershipTool`, but `ftw.casauth` contains its own copy of `setLoginTimes()` and therefore needs to be patched separately.

Jira: https://4teamwork.atlassian.net/browse/CA-1

## Checklist (Must have)

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
