### PR TITLE
Expose bumblebee notifications url in the config endpoint

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -9,6 +9,7 @@ Changelog
 - Disable write actions during readonly mode. [lgraf]
 - Custom error page: Also log ReadOnlyError culprit traceback to error log (if available). [lgraf]
 - Avoid ftw.casauth write-on-read (last login times) during login. [lgraf]
+- Expose bumblebee notifications url in the config endpoint. [Kevin Bieri]
 - Bump ftw.tabbedview to 4.2.1 to get fix for empty action lists. [lgraf]
 - Add workspacemeetings to @listing endpoint. [tinagerber]
 - Fix order of labels for participations field in the listing endpoint. [njohner]

--- a/docs/public/dev-manual/api/config.rst
+++ b/docs/public/dev-manual/api/config.rst
@@ -26,6 +26,7 @@ GEVER-Mandanten abgefragt werden.
           "application_type": "gever",
           "apps_url": "https://dev.onegovgever.ch/portal/api/apps",
           "bumblebee_app_id": "gever_dev",
+          "bumblebee_notifications_url": "ws://bumblebee.local/notifications",
           "cas_url": "https://dev.onegovgever.ch/portal/cas",
           "current_user": {
               "@id": "http://localhost:8080/fd/@users/john.doe",
@@ -139,6 +140,10 @@ apps_url
 cas_url
 
   CAS server URL
+
+bumblebee_notifications_url
+
+    Websocket URL, um Änderungen über Vorschaubilder zu erhalten
 
 features
     Optional aktivierbare Features:

--- a/opengever/api/tests/test_config.py
+++ b/opengever/api/tests/test_config.py
@@ -6,6 +6,7 @@ from opengever.testing import IntegrationTestCase
 from opengever.testing.readonly import ZODBStorageInReadonlyMode
 from pkg_resources import get_distribution
 from plone import api
+import os
 
 
 class TestConfig(IntegrationTestCase):
@@ -279,3 +280,13 @@ class TestConfig(IntegrationTestCase):
         browser.open(self.config_url, headers=self.api_headers)
         self.assertEqual(browser.status_code, 200)
         self.assertEqual(browser.json.get(u'inbox_folder_url'), u'')
+
+    @browsing
+    def test_config_contains_bumblebee_notification_url(self, browser):
+        os.environ['BUMBLEBEE_PUBLIC_URL'] = 'http://bumblebee.local/'
+
+        self.login(self.regular_user, browser)
+
+        browser.open(self.config_url, headers=self.api_headers)
+        self.assertEqual(browser.status_code, 200)
+        self.assertEqual(browser.json.get(u'bumblebee_notifications_url'), u'http://bumblebee.local/YnVtYmxlYmVl/api/notifications')

--- a/opengever/base/configuration.py
+++ b/opengever/base/configuration.py
@@ -1,6 +1,7 @@
 from AccessControl import getSecurityManager
 from AccessControl.users import nobody
 from collections import OrderedDict
+from ftw import bumblebee
 from opengever.activity.interfaces import IActivitySettings
 from opengever.api.user_settings import serialize_setting
 from opengever.base.casauth import get_cas_server_url
@@ -66,6 +67,7 @@ class GeverSettingsAdpaterV1(object):
         config['cas_url'] = get_cas_server_url()
         config['apps_url'] = os.environ.get('APPS_ENDPOINT_URL')
         config['application_type'] = self.get_application_type()
+        config['bumblebee_notifications_url'] = bumblebee.get_service_v3().get_notifications_url()
         config['is_readonly'] = is_in_readonly_mode()
         return config
 

--- a/opengever/base/tests/test_configuration_adapter.py
+++ b/opengever/base/tests/test_configuration_adapter.py
@@ -96,6 +96,7 @@ class TestConfigurationAdapter(IntegrationTestCase):
             ('cas_url', None),
             ('apps_url', None),
             ('application_type', 'gever'),
+            ('bumblebee_notifications_url', 'http://bumblebee.local/YnVtYmxlYmVl/api/notifications'),
             ('is_readonly', False),
             ])
 
@@ -114,6 +115,7 @@ class TestConfigurationAdapter(IntegrationTestCase):
             ('cas_url', None),
             ('apps_url', None),
             ('application_type', 'gever'),
+            ('bumblebee_notifications_url', 'http://bumblebee.local/YnVtYmxlYmVl/api/notifications'),
             ('is_readonly', False),
             ])
         configuration = IGeverSettings(self.portal).get_config()
@@ -150,6 +152,7 @@ class TestConfigurationAdapter(IntegrationTestCase):
             ('cas_url', None),
             ('apps_url', 'http://example.com/api/apps'),
             ('application_type', 'gever'),
+            ('bumblebee_notifications_url', 'http://bumblebee.local/YnVtYmxlYmVl/api/notifications'),
             ('is_readonly', False),
             ])
 


### PR DESCRIPTION
The bumblebee notifications url is necessary for the gever-ui to open a websocket connection to bumblebee in order to receive updates about newly created previews. With those updates, the gever-ui is able to reload the document's preview images as soon as the preview is available in bumblebee.

See https://4teamwork.atlassian.net/browse/NE-80

Definition of Done: https://4teamwork.atlassian.net/wiki/spaces/CHX4TW/pages/917562/


## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


## Checklist (if applicable)

_Only applicable should be left and checked._

- API change:
  - [x] Documentation is updated
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Upgrade steps (changes in profile):
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
- DB-Schema migration
  - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
  - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value
