### PR TITLE
Journalize creation of linked workspace and copying documents to and from it.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2020.13.0 (unreleased)
 ----------------------
 
+- Journalize creation of linked workspace and copying documents to and from it. [njohner]
 - Custom error page: Also log ReadOnlyError culprit traceback to error log (if available). [lgraf]
 - Bump ftw.tabbedview to 4.2.1 to get fix for empty action lists. [lgraf]
 - Add workspacemeetings to @listing endpoint. [tinagerber]

--- a/opengever/workspaceclient/__init__.py
+++ b/opengever/workspaceclient/__init__.py
@@ -1,8 +1,10 @@
 from opengever.workspaceclient.interfaces import IWorkspaceClientSettings
 from plone import api
+from zope.i18nmessageid import MessageFactory
 import logging
 
 logger = logging.getLogger('opengever.workspaceclient')
+_ = MessageFactory("opengever.workspaceclient")
 
 
 def is_workspace_client_feature_enabled():

--- a/opengever/workspaceclient/client.py
+++ b/opengever/workspaceclient/client.py
@@ -78,8 +78,6 @@ class WorkspaceClient(object):
     def lookup_url_by_uid(self, uid):
         """Searches on the remote system for an object having the given UID and
         returns the URL to this object.
-
-        If no object is found with the given UID, it returns None.
         """
         items = self.search(UID=uid).get('items')
 
@@ -89,7 +87,7 @@ class WorkspaceClient(object):
         if len(items) > 1:
             raise LookupError("Found multiple objects with the same UID")
 
-        return items[0].get('@id') if items else None
+        return items[0].get('@id')
 
     def tus_upload(self, url_or_path, portal_type, file_, size, content_type,
                    filename, **additional_metadata):

--- a/opengever/workspaceclient/client.py
+++ b/opengever/workspaceclient/client.py
@@ -75,9 +75,9 @@ class WorkspaceClient(object):
 
         return self.request.post('/workspaces', json=payload).json()
 
-    def lookup_url_by_uid(self, uid):
-        """Searches on the remote system for an object having the given UID and
-        returns the URL to this object.
+    def get_by_uid(self, uid):
+        """Searches on the remote system for an object having the given UID
+        and returns it (serialized).
         """
         items = self.search(UID=uid).get('items')
 
@@ -87,7 +87,13 @@ class WorkspaceClient(object):
         if len(items) > 1:
             raise LookupError("Found multiple objects with the same UID")
 
-        return items[0].get('@id')
+        return items[0]
+
+    def lookup_url_by_uid(self, uid):
+        """Searches on the remote system for an object having the given UID and
+        returns the URL to this object.
+        """
+        return self.get_by_uid(uid).get('@id')
 
     def tus_upload(self, url_or_path, portal_type, file_, size, content_type,
                    filename, **additional_metadata):

--- a/opengever/workspaceclient/linked_workspaces.py
+++ b/opengever/workspaceclient/linked_workspaces.py
@@ -115,6 +115,17 @@ class LinkedWorkspaces(object):
         """
         workspace = self.client.create_workspace(**data)
         self.storage.add(workspace.get('UID'))
+
+        # Add journal entry to dossier
+        title = _(
+            u'label_linked_workspace_created',
+            default=u'Linked workspace ${workspace_title} created.',
+            mapping={'workspace_title': workspace.get('title')})
+
+        journal_entry_factory(
+            context=self.context, action='Linked workspace created',
+            title=title)
+
         return workspace
 
     def _get_linked_workspace_url(self, workspace_uid):

--- a/opengever/workspaceclient/linked_workspaces.py
+++ b/opengever/workspaceclient/linked_workspaces.py
@@ -1,5 +1,7 @@
 from opengever.api.add import GeverFolderPost
 from opengever.dossier.behaviors.dossier import IDossierMarker
+from opengever.journal.handlers import journal_entry_factory
+from opengever.workspaceclient import _
 from opengever.workspaceclient.client import WorkspaceClient
 from opengever.workspaceclient.exceptions import WorkspaceNotFound
 from opengever.workspaceclient.exceptions import WorkspaceNotLinked
@@ -142,6 +144,18 @@ class LinkedWorkspaces(object):
 
         filename = document.get_filename()
         size = file_.size
+
+        # Add journal entry to dossier
+        workspace_title = self.client.get_by_uid(workspace_uid).get('title')
+        title = _(
+            u'label_document_copied_to_workspace',
+            default=u'Document ${doc_title} copied to workspace ${workspace_title}.',
+            mapping={'doc_title': document.title_or_id(),
+                     'workspace_title': workspace_title})
+
+        journal_entry_factory(
+            context=self.context, action='Document copied to workspace',
+            title=title, documents=[document])
 
         return self.client.tus_upload(workspace_url, portal_type, file_.open(),
                                       size, content_type, filename,

--- a/opengever/workspaceclient/linked_workspaces.py
+++ b/opengever/workspaceclient/linked_workspaces.py
@@ -209,6 +209,18 @@ class LinkedWorkspaces(object):
         # We should avoid setting the id ourselves, can lead to conflicts
         document_repr = self._blacklisted_dict(document_repr, ['id'])
 
+        # Add journal entry to the dossier before creating the document
+        workspace_title = self.client.get_by_uid(workspace_uid).get('title')
+        title = _(
+            u'label_document_copied_from_workspace',
+            default=u'Document ${doc_title} copied from workspace ${workspace_title}.',
+            mapping={'doc_title': document_repr.get('title'),
+                     'workspace_title': workspace_title})
+
+        journal_entry_factory(
+            context=self.context, action='Document copied from workspace',
+            title=title)
+
         proxy_post = ProxyPost(document_repr)
         proxy_post.context = self.context
         proxy_post.request = getRequest()

--- a/opengever/workspaceclient/locales/de/LC_MESSAGES/opengever.workspaceclient.po
+++ b/opengever/workspaceclient/locales/de/LC_MESSAGES/opengever.workspaceclient.po
@@ -1,0 +1,30 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"POT-Creation-Date: 2020-10-23 13:18+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0\n"
+"Language-Code: en\n"
+"Language-Name: English\n"
+"Preferred-Encodings: utf-8 latin1\n"
+"Domain: DOMAIN\n"
+
+#. Default: "Document ${doc_title} copied from workspace ${workspace_title}."
+#: ./opengever/workspaceclient/linked_workspaces.py
+msgid "label_document_copied_from_workspace"
+msgstr "Dokument ${doc_title} aus Teamraum ${workspace_title} zurückgeführt."
+
+#. Default: "Document ${doc_title} copied to workspace ${workspace_title}."
+#: ./opengever/workspaceclient/linked_workspaces.py
+msgid "label_document_copied_to_workspace"
+msgstr "Dokument ${doc_title} in Teamraum ${workspace_title} kopiert."
+
+#. Default: "Linked workspace ${workspace_title} created."
+#: ./opengever/workspaceclient/linked_workspaces.py
+msgid "label_linked_workspace_created"
+msgstr "Teamraum ${workspace_title} zu diesem Dossier eröffnet."

--- a/opengever/workspaceclient/locales/fr/LC_MESSAGES/opengever.workspaceclient.po
+++ b/opengever/workspaceclient/locales/fr/LC_MESSAGES/opengever.workspaceclient.po
@@ -1,0 +1,30 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"POT-Creation-Date: 2020-10-23 13:18+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0\n"
+"Language-Code: en\n"
+"Language-Name: English\n"
+"Preferred-Encodings: utf-8 latin1\n"
+"Domain: DOMAIN\n"
+
+#. Default: "Document ${doc_title} copied from workspace ${workspace_title}."
+#: ./opengever/workspaceclient/linked_workspaces.py
+msgid "label_document_copied_from_workspace"
+msgstr "Document ${doc_title} rapatrié de l'espace de travail ${workspace_title}."
+
+#. Default: "Document ${doc_title} copied to workspace ${workspace_title}."
+#: ./opengever/workspaceclient/linked_workspaces.py
+msgid "label_document_copied_to_workspace"
+msgstr "Document ${doc_title} copié dans l'espace de travail ${workspace_title}."
+
+#. Default: "Linked workspace ${workspace_title} created."
+#: ./opengever/workspaceclient/linked_workspaces.py
+msgid "label_linked_workspace_created"
+msgstr "Espace de travail ${workspace_title} créé pour ce dossier."

--- a/opengever/workspaceclient/locales/opengever.workspaceclient.pot
+++ b/opengever/workspaceclient/locales/opengever.workspaceclient.pot
@@ -1,0 +1,33 @@
+# --- PLEASE EDIT THE LINES BELOW CORRECTLY ---
+# SOME DESCRIPTIVE TITLE.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"POT-Creation-Date: 2020-10-23 13:18+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0\n"
+"Language-Code: en\n"
+"Language-Name: English\n"
+"Preferred-Encodings: utf-8 latin1\n"
+"Domain: opengever.workspaceclient\n"
+
+#. Default: "Document ${doc_title} copied from workspace ${workspace_title}."
+#: ./opengever/workspaceclient/linked_workspaces.py
+msgid "label_document_copied_from_workspace"
+msgstr ""
+
+#. Default: "Document ${doc_title} copied to workspace ${workspace_title}."
+#: ./opengever/workspaceclient/linked_workspaces.py
+msgid "label_document_copied_to_workspace"
+msgstr ""
+
+#. Default: "Linked workspace ${workspace_title} created."
+#: ./opengever/workspaceclient/linked_workspaces.py
+msgid "label_linked_workspace_created"
+msgstr ""

--- a/opengever/workspaceclient/tests/__init__.py
+++ b/opengever/workspaceclient/tests/__init__.py
@@ -41,7 +41,9 @@ class FunctionalWorkspaceClientTestCase(FunctionalTestCase):
                                      .having(id='workspaces'))
         self.grant('WorkspacesUser', 'WorkspacesCreator', on=self.workspace_root)
 
-        self.workspace = create(Builder('workspace').within(self.workspace_root))
+        self.workspace = create(Builder('workspace')
+                                .having(title=u'Ein Teamraum')
+                                .within(self.workspace_root))
         self.grant('WorkspaceMember', on=self.workspace)
 
         # Grant necessary permissions to use the workspace client

--- a/opengever/workspaceclient/tests/test_linked_workspaces.py
+++ b/opengever/workspaceclient/tests/test_linked_workspaces.py
@@ -71,18 +71,23 @@ class TestLinkedWorkspaces(FunctionalWorkspaceClientTestCase):
 
             self.assertEqual(
                 [workspace2.absolute_url()],
-                [workspace.get('@id') for workspace in manager.list(b_size=1, b_start=1).get('items')])
+                [workspace.get('@id') for workspace in
+                 manager.list(b_size=1, b_start=1).get('items')])
 
     def test_list_skips_workspaces_if_no_view_permission(self):
-        unauthorized_workspace = create(Builder('workspace').within(self.workspace_root))
+        unauthorized_workspace = create(Builder('workspace').within(
+            self.workspace_root))
         self.grant('', on=unauthorized_workspace)
 
-        authorized_workspace = create(Builder('workspace').within(self.workspace_root))
+        authorized_workspace = create(Builder('workspace').within(
+            self.workspace_root))
         self.grant('View', on=unauthorized_workspace)
 
         self.assertTrue(api.user.has_permission('View', obj=self.workspace))
-        self.assertTrue(api.user.has_permission('View', obj=authorized_workspace))
-        self.assertFalse(api.user.has_permission('View', obj=unauthorized_workspace))
+        self.assertTrue(api.user.has_permission(
+            'View', obj=authorized_workspace))
+        self.assertFalse(api.user.has_permission(
+            'View', obj=unauthorized_workspace))
 
         with self.workspace_client_env():
             manager = ILinkedWorkspaces(self.dossier)
@@ -113,22 +118,25 @@ class TestLinkedWorkspaces(FunctionalWorkspaceClientTestCase):
             self.workspace.reindexObject()
             transaction.commit()
 
-            self.assertEqual(['Old title'],
-                             [workspace.get('title') for workspace in manager.list().get('items')])
+            self.assertEqual(
+                ['Old title'],
+                [workspace.get('title') for workspace in manager.list().get('items')])
 
             self.workspace.title = 'New title'
             self.workspace.reindexObject()
             transaction.commit()
 
-            self.assertEqual(['Old title'],
-                             [workspace.get('title') for workspace in manager.list().get('items')])
+            self.assertEqual(
+                ['Old title'],
+                [workspace.get('title') for workspace in manager.list().get('items')])
 
             self.invalidate_cache()
-            self.assertEqual(['New title'],
-                             [workspace.get('title') for workspace in manager.list().get('items')])
+            self.assertEqual(
+                ['New title'],
+                [workspace.get('title') for workspace in manager.list().get('items')])
 
     def test_create_workspace_will_store_workspace_in_the_storage(self):
-        with self.workspace_client_env() as client:
+        with self.workspace_client_env():
             manager = ILinkedWorkspaces(self.dossier)
             self.assertEqual([], manager.list().get('items'))
 
@@ -161,7 +169,8 @@ class TestLinkedWorkspaces(FunctionalWorkspaceClientTestCase):
             manager.storage.add(self.workspace.UID())
 
             with self.observe_children(self.workspace) as children:
-                response = manager.copy_document_to_workspace(document, self.workspace.UID())
+                response = manager.copy_document_to_workspace(
+                    document, self.workspace.UID())
                 transaction.commit()
 
             self.assertEqual(1, len(children['added']))
@@ -209,12 +218,14 @@ class TestLinkedWorkspaces(FunctionalWorkspaceClientTestCase):
 
             with self.observe_children(self.workspace) as children:
                 with auto_commit_after_request(manager.client):
-                    response = manager.copy_document_to_workspace(document, self.workspace.UID())
+                    response = manager.copy_document_to_workspace(
+                        document, self.workspace.UID())
 
             self.assertEqual(1, len(children['added']))
             workspace_document = children['added'].pop()
 
-            self.assertEqual(workspace_document.absolute_url(), response.get('@id'))
+            self.assertEqual(workspace_document.absolute_url(),
+                             response.get('@id'))
             self.assertEqual(workspace_document.title, document.title)
             self.assertEqual(workspace_document.file.open().read(),
                              document.file.open().read())
@@ -236,7 +247,8 @@ class TestLinkedWorkspaces(FunctionalWorkspaceClientTestCase):
 
             with self.observe_children(self.workspace) as children:
                 with auto_commit_after_request(manager.client):
-                    response = manager.copy_document_to_workspace(mail, self.workspace.UID())
+                    response = manager.copy_document_to_workspace(
+                        mail, self.workspace.UID())
 
             self.assertEqual(1, len(children['added']))
             workspace_mail = children['added'].pop()
@@ -265,7 +277,8 @@ class TestLinkedWorkspaces(FunctionalWorkspaceClientTestCase):
 
             with self.observe_children(self.workspace) as children:
                 with auto_commit_after_request(manager.client):
-                    response = manager.copy_document_to_workspace(mail, self.workspace.UID())
+                    response = manager.copy_document_to_workspace(
+                        mail, self.workspace.UID())
 
             self.assertEqual(1, len(children['added']))
             workspace_mail = children['added'].pop()
@@ -313,7 +326,8 @@ class TestLinkedWorkspaces(FunctionalWorkspaceClientTestCase):
             manager = ILinkedWorkspaces(self.dossier)
             manager.storage.add(self.workspace.UID())
 
-            documents = manager.list_documents_in_linked_workspace(self.workspace.UID())
+            documents = manager.list_documents_in_linked_workspace(
+                self.workspace.UID())
             expected_url = (
                 '{}/@search?portal_type=opengever.document.document&'
                 'portal_type=ftw.mail.mail&metadata_fields=UID&'


### PR DESCRIPTION
We add journal entries in the dossier for the following actions:
- Creation of a new linked workspace
- Copy of a document to a linked workspace
- Copy of a document from a linked workspace

This is to guarantee traceability.

I wonder whether we should also add a journal entry on the document itself when it is being copied over to a workspace. 

This is for:
- https://4teamwork.atlassian.net/browse/CA-927
- https://4teamwork.atlassian.net/browse/CA-928
- https://4teamwork.atlassian.net/browse/CA-929

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

## Checklist (if applicable)
- New translations
  - [ ] All msg-strings are unicode
