### PR TITLE
Add script to toggle read-only mode in zope.conf

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -10,6 +10,7 @@ Changelog
 - Bump ftw.tabbedview to 4.2.1 to get fix for empty action lists. [lgraf]
 - Add workspacemeetings to @listing endpoint. [tinagerber]
 - Fix order of labels for participations field in the listing endpoint. [njohner]
+- Add script to toggle read-only mode in zope.conf. [buchi]
 
 
 2020.12.0 (2020-10-22)

--- a/opengever/readonly/cli.py
+++ b/opengever/readonly/cli.py
@@ -1,0 +1,124 @@
+import argparse
+import os
+import sys
+
+
+READ_ONLY_ENV_VARIABLE = 'GEVER_READ_ONLY_MODE'
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Toggle read-only mode of all Zope instances except for '
+                    'instance0. Use -i option to toggle instance0 or other '
+                    'specific instances.')
+    parser.add_argument(
+        '-r', '--readonly', action='store_true', default=None,
+        help='enable read-only mode regardless of the current state',
+        dest='readonly')
+    parser.add_argument(
+        '-w', '--readwrite', action='store_false', default=None,
+        help='disable read-only mode regardless of the current state',
+        dest='readonly')
+    parser.add_argument(
+        '-i', '--instance', action='append', default=None,
+        help='toggle read-only mode for the given instance name',
+        metavar='INSTANCE', dest='instances')
+    options = parser.parse_args()
+
+    confs = get_zope_confs(instances=options.instances)
+    if not confs:
+        sys.exit('No instance selected.')
+
+    for conf in confs:
+        if options.readonly is None:
+            if is_readonly(conf):
+                disable_readonly(conf)
+            else:
+                enable_readonly(conf)
+        elif options.readonly:
+            enable_readonly(conf)
+        else:
+            disable_readonly(conf)
+
+
+def is_readonly(conf):
+    with open(conf, 'r') as conf_file:
+        for line in conf_file:
+            if READ_ONLY_ENV_VARIABLE in line:
+                return True
+    return False
+
+
+def enable_readonly(conf):
+    new_conf = []
+    with open(conf, 'r') as conf_file:
+        for line in conf_file:
+            tokens = line.strip().split()
+
+            if tokens:
+                if tokens[0] == READ_ONLY_ENV_VARIABLE:
+                    continue
+                elif tokens[0] == 'read-only':
+                    continue
+
+            new_conf.append(line)
+
+            if line.strip() == '<environment>':
+                new_conf.append('{} true\n'.format(READ_ONLY_ENV_VARIABLE))
+            elif line.strip() == '<filestorage>':
+                new_conf.append('        read-only true\n')
+            elif line.strip() == '<zeoclient>':
+                new_conf.append('      read-only true\n')
+            elif line.strip() == '<relstorage>':
+                new_conf.append('        read-only true\n')
+
+    with open(conf, 'w') as conf_file:
+        conf_file.writelines(new_conf)
+
+    print('Enabled read-only mode in {}.'.format(conf))
+
+
+def disable_readonly(conf):
+    new_conf = []
+    with open(conf, 'r') as conf_file:
+        for line in conf_file:
+            tokens = line.strip().split()
+
+            if tokens:
+                if tokens[0] == READ_ONLY_ENV_VARIABLE:
+                    continue
+                elif tokens[0] == 'read-only':
+                    continue
+
+            new_conf.append(line)
+
+            if line.strip() == '<zeoclient>':
+                new_conf.append('      read-only false\n')
+
+    with open(conf, 'w') as conf_file:
+        conf_file.writelines(new_conf)
+
+    print('Disabled read-only mode in {}.'.format(conf))
+
+
+def get_zope_confs(instances=None):
+    buildout_dir = os.path.dirname(os.path.dirname(
+        os.path.realpath(sys.argv[0])))
+    instance_parts = [
+        part for part in os.listdir(os.path.join(buildout_dir, 'parts'))
+        if part.startswith('instance')
+    ]
+    selected_parts = [
+        part for part in instance_parts
+        if instances is None and part != 'instance0'
+        or instances and part in instances
+    ]
+    zope_confs = [
+        os.path.join(buildout_dir, 'parts', part, 'etc', 'zope.conf')
+        for part in selected_parts
+    ]
+    return zope_confs
+
+
+if __name__ == '__main__':
+    main()

--- a/opengever/readonly/tests/data/filestorage-ro-zope.conf
+++ b/opengever/readonly/tests/data/filestorage-ro-zope.conf
@@ -1,0 +1,75 @@
+%define INSTANCEHOME /apps/opengever.core/parts/instance
+instancehome $INSTANCEHOME
+%define CLIENTHOME /apps/opengever.core/var/instance
+clienthome $CLIENTHOME
+debug-mode on
+security-policy-implementation python
+verbose-security on
+default-zpublisher-encoding utf-8
+http-header-max-length 8192
+zserver-threads 4
+<environment>
+GEVER_READ_ONLY_MODE true
+    zope_i18n_compile_mo_files true
+CHAMELEON_EAGER true
+CHAMELEON_RELOAD true
+FTW_CHAMELEON_RECOOK_WARNING true
+FTW_CHAMELEON_RECOOK_EXCEPTION false
+CHAMELEON_CACHE /apps/opengever.core/var/instance/chameleon-cache
+IS_DEVELOPMENT_MODE True
+SABLON_BIN /apps/opengever.core/parts/gems/bin/sablon
+BUMBLEBEE_APP_ID gever_dev
+BUMBLEBEE_INTERNAL_PLONE_URL http://localhost:8080/fd
+BUMBLEBEE_PUBLIC_URL http://localhost:3000/
+TEAMRAUM_URL http://localhost:8080/fd
+</environment>
+<eventlog>
+  level INFO
+  <logfile>
+    path /apps/opengever.core/var/log/instance.log
+    level INFO
+  </logfile>
+</eventlog>
+<logger access>
+  level WARN
+  <logfile>
+    path /apps/opengever.core/var/log/instance-Z2.log
+    format %(message)s
+  </logfile>
+</logger>
+<http-server>
+  address 8080
+</http-server>
+<zodb_db main>
+    # Main database
+    cache-size 30000
+    # Blob-enabled FileStorage database
+    <blobstorage>
+      blob-dir /apps/opengever.core/var/blobstorage
+      # FileStorage database
+      <filestorage>
+        read-only true
+        path /apps/opengever.core/var/filestorage/Data.fs
+      </filestorage>
+    </blobstorage>
+    mount-point /
+</zodb_db>
+<zodb_db temporary>
+    # Temporary storage database (for sessions)
+    <temporarystorage>
+      name temporary storage for sessioning
+    </temporarystorage>
+    mount-point /temp_folder
+    container-class Products.TemporaryFolder.TemporaryContainer
+</zodb_db>
+pid-filename /apps/opengever.core/var/instance.pid
+lock-filename /apps/opengever.core/var/instance.lock
+python-check-interval 1000
+enable-product-installation off
+datetime-format international
+<product-config opengever.core>
+    ogds_log_file /apps/opengever.core/var/log/ogds-update.log
+</product-config>
+%import collective.taskqueue
+<taskqueue />
+<taskqueue-server />

--- a/opengever/readonly/tests/data/filestorage-rw-zope.conf
+++ b/opengever/readonly/tests/data/filestorage-rw-zope.conf
@@ -1,0 +1,73 @@
+%define INSTANCEHOME /apps/opengever.core/parts/instance
+instancehome $INSTANCEHOME
+%define CLIENTHOME /apps/opengever.core/var/instance
+clienthome $CLIENTHOME
+debug-mode on
+security-policy-implementation python
+verbose-security on
+default-zpublisher-encoding utf-8
+http-header-max-length 8192
+zserver-threads 4
+<environment>
+    zope_i18n_compile_mo_files true
+CHAMELEON_EAGER true
+CHAMELEON_RELOAD true
+FTW_CHAMELEON_RECOOK_WARNING true
+FTW_CHAMELEON_RECOOK_EXCEPTION false
+CHAMELEON_CACHE /apps/opengever.core/var/instance/chameleon-cache
+IS_DEVELOPMENT_MODE True
+SABLON_BIN /apps/opengever.core/parts/gems/bin/sablon
+BUMBLEBEE_APP_ID gever_dev
+BUMBLEBEE_INTERNAL_PLONE_URL http://localhost:8080/fd
+BUMBLEBEE_PUBLIC_URL http://localhost:3000/
+TEAMRAUM_URL http://localhost:8080/fd
+</environment>
+<eventlog>
+  level INFO
+  <logfile>
+    path /apps/opengever.core/var/log/instance.log
+    level INFO
+  </logfile>
+</eventlog>
+<logger access>
+  level WARN
+  <logfile>
+    path /apps/opengever.core/var/log/instance-Z2.log
+    format %(message)s
+  </logfile>
+</logger>
+<http-server>
+  address 8080
+</http-server>
+<zodb_db main>
+    # Main database
+    cache-size 30000
+    # Blob-enabled FileStorage database
+    <blobstorage>
+      blob-dir /apps/opengever.core/var/blobstorage
+      # FileStorage database
+      <filestorage>
+        path /apps/opengever.core/var/filestorage/Data.fs
+      </filestorage>
+    </blobstorage>
+    mount-point /
+</zodb_db>
+<zodb_db temporary>
+    # Temporary storage database (for sessions)
+    <temporarystorage>
+      name temporary storage for sessioning
+    </temporarystorage>
+    mount-point /temp_folder
+    container-class Products.TemporaryFolder.TemporaryContainer
+</zodb_db>
+pid-filename /apps/opengever.core/var/instance.pid
+lock-filename /apps/opengever.core/var/instance.lock
+python-check-interval 1000
+enable-product-installation off
+datetime-format international
+<product-config opengever.core>
+    ogds_log_file /apps/opengever.core/var/log/ogds-update.log
+</product-config>
+%import collective.taskqueue
+<taskqueue />
+<taskqueue-server />

--- a/opengever/readonly/tests/data/relstorage-ro-zope.conf
+++ b/opengever/readonly/tests/data/relstorage-ro-zope.conf
@@ -1,0 +1,88 @@
+%define INSTANCEHOME /apps/01-onegovgever/parts/instance1
+instancehome $INSTANCEHOME
+%define CLIENTHOME /apps/01-onegovgever/var/instance1
+clienthome $CLIENTHOME
+path /apps/01-onegovgever/parts/celery
+debug-mode off
+security-policy-implementation C
+verbose-security off
+default-zpublisher-encoding utf-8
+http-header-max-length 8192
+zserver-threads 1
+<environment>
+GEVER_READ_ONLY_MODE true
+    PTS_LANGUAGES en de fr it
+zope_i18n_allowed_languages en de fr it
+zope_i18n_compile_mo_files true
+CHAMELEON_EAGER true
+CHAMELEON_RELOAD false
+FTW_CHAMELEON_RECOOK_WARNING true
+FTW_CHAMELEON_RECOOK_EXCEPTION false
+CHAMELEON_CACHE /apps/01-onegovgever/var/instance1/chameleon-cache
+SABLON_BIN /apps/01-onegovgever/parts/gems/bin/sablon
+USERNAMELOGGER_AC_COOKIE_NAME __ac_bd_arp
+RAVEN_PROJECT_DIST opengever.core
+RAVEN_TAGS {"cluster": "test.onegovgever.ch"}
+NLS_LANG .AL32UTF8
+REQUESTS_CA_BUNDLE /etc/pki/tls/certs/ca-bundle.crt
+BUMBLEBEE_APP_ID gever_test
+BUMBLEBEE_INTERNAL_PLONE_URL https://test.onegovgever.ch/
+BUMBLEBEE_PUBLIC_URL https://tests.onegovgever.ch/
+BUMBLEBEE_SECRET secret
+</environment>
+<warnfilter>
+  action ignore
+  category exceptions.DeprecationWarning
+</warnfilter>
+<eventlog>
+  level INFO
+  <logfile>
+    path /apps/01-onegovgever/var/log/instance1.log
+    level INFO
+  </logfile>
+</eventlog>
+<logger access>
+  level WARN
+  <logfile>
+    path /apps/01-onegovgever/var/log/instance1-Z2.log
+    format %(message)s
+  </logfile>
+</logger>
+<http-server>
+  address 10200
+</http-server>
+<zodb_db main>
+    # Main database
+    cache-size 250000
+    %import relstorage
+    <relstorage>
+        read-only true
+        blob-dir /apps/01-onegovgever/var/blobcache/instance1
+        blob-cache-size 6gb
+        shared-blob-dir false
+        commit-lock-id 4
+        <oracle>
+            dsn OGPROD
+            user USER
+            password PASSWORD
+        </oracle>
+    </relstorage>
+    mount-point /
+</zodb_db>
+<zodb_db temporary>
+    # Temporary storage database (for sessions)
+    <temporarystorage>
+      name temporary storage for sessioning
+    </temporarystorage>
+    mount-point /temp_folder
+    container-class Products.TemporaryFolder.TemporaryContainer
+</zodb_db>
+pid-filename /apps/01-onegovgever/var/instance1.pid
+lock-filename /apps/01-onegovgever/var/instance1.lock
+python-check-interval 1000
+enable-product-installation off
+datetime-format international
+trusted-proxy 127.0.0.1
+%import collective.taskqueue
+<taskqueue />
+<taskqueue-server />

--- a/opengever/readonly/tests/data/relstorage-rw-zope.conf
+++ b/opengever/readonly/tests/data/relstorage-rw-zope.conf
@@ -1,0 +1,86 @@
+%define INSTANCEHOME /apps/01-onegovgever/parts/instance1
+instancehome $INSTANCEHOME
+%define CLIENTHOME /apps/01-onegovgever/var/instance1
+clienthome $CLIENTHOME
+path /apps/01-onegovgever/parts/celery
+debug-mode off
+security-policy-implementation C
+verbose-security off
+default-zpublisher-encoding utf-8
+http-header-max-length 8192
+zserver-threads 1
+<environment>
+    PTS_LANGUAGES en de fr it
+zope_i18n_allowed_languages en de fr it
+zope_i18n_compile_mo_files true
+CHAMELEON_EAGER true
+CHAMELEON_RELOAD false
+FTW_CHAMELEON_RECOOK_WARNING true
+FTW_CHAMELEON_RECOOK_EXCEPTION false
+CHAMELEON_CACHE /apps/01-onegovgever/var/instance1/chameleon-cache
+SABLON_BIN /apps/01-onegovgever/parts/gems/bin/sablon
+USERNAMELOGGER_AC_COOKIE_NAME __ac_bd_arp
+RAVEN_PROJECT_DIST opengever.core
+RAVEN_TAGS {"cluster": "test.onegovgever.ch"}
+NLS_LANG .AL32UTF8
+REQUESTS_CA_BUNDLE /etc/pki/tls/certs/ca-bundle.crt
+BUMBLEBEE_APP_ID gever_test
+BUMBLEBEE_INTERNAL_PLONE_URL https://test.onegovgever.ch/
+BUMBLEBEE_PUBLIC_URL https://tests.onegovgever.ch/
+BUMBLEBEE_SECRET secret
+</environment>
+<warnfilter>
+  action ignore
+  category exceptions.DeprecationWarning
+</warnfilter>
+<eventlog>
+  level INFO
+  <logfile>
+    path /apps/01-onegovgever/var/log/instance1.log
+    level INFO
+  </logfile>
+</eventlog>
+<logger access>
+  level WARN
+  <logfile>
+    path /apps/01-onegovgever/var/log/instance1-Z2.log
+    format %(message)s
+  </logfile>
+</logger>
+<http-server>
+  address 10200
+</http-server>
+<zodb_db main>
+    # Main database
+    cache-size 250000
+    %import relstorage
+    <relstorage>
+        blob-dir /apps/01-onegovgever/var/blobcache/instance1
+        blob-cache-size 6gb
+        shared-blob-dir false
+        commit-lock-id 4
+        <oracle>
+            dsn OGPROD
+            user USER
+            password PASSWORD
+        </oracle>
+    </relstorage>
+    mount-point /
+</zodb_db>
+<zodb_db temporary>
+    # Temporary storage database (for sessions)
+    <temporarystorage>
+      name temporary storage for sessioning
+    </temporarystorage>
+    mount-point /temp_folder
+    container-class Products.TemporaryFolder.TemporaryContainer
+</zodb_db>
+pid-filename /apps/01-onegovgever/var/instance1.pid
+lock-filename /apps/01-onegovgever/var/instance1.lock
+python-check-interval 1000
+enable-product-installation off
+datetime-format international
+trusted-proxy 127.0.0.1
+%import collective.taskqueue
+<taskqueue />
+<taskqueue-server />

--- a/opengever/readonly/tests/data/zeoclient-ro-zope.conf
+++ b/opengever/readonly/tests/data/zeoclient-ro-zope.conf
@@ -1,0 +1,87 @@
+%define INSTANCEHOME /apps/01-onegovgever/parts/instance1
+instancehome $INSTANCEHOME
+%define CLIENTHOME /apps/01-onegovgever/var/instance1
+clienthome $CLIENTHOME
+debug-mode off
+security-policy-implementation C
+verbose-security off
+default-zpublisher-encoding utf-8
+http-header-max-length 8192
+zserver-threads 2
+<environment>
+GEVER_READ_ONLY_MODE true
+    PTS_LANGUAGES en de fr it
+zope_i18n_allowed_languages en de fr it
+zope_i18n_compile_mo_files true
+CHAMELEON_EAGER true
+CHAMELEON_RELOAD false
+FTW_CHAMELEON_RECOOK_WARNING true
+FTW_CHAMELEON_RECOOK_EXCEPTION false
+CHAMELEON_CACHE /apps/01-onegovgever/var/instance1/chameleon-cache
+WARMUP_BIN /apps/01-onegovgever/bin/warmup
+WARMUP_INI /apps/01-onegovgever/parts/warmup/warmup.ini
+SABLON_BIN /apps/01-onegovgever/parts/gems/bin/sablon
+USERNAMELOGGER_AC_COOKIE_NAME __ac_fd
+RAVEN_PROJECT_DIST opengever.core
+RAVEN_TAGS {"cluster": "test.onegovgever.ch"}
+GEVER_COLORIZATION lightblue
+BUMBLEBEE_APP_ID gever_test
+BUMBLEBEE_INTERNAL_PLONE_URL https://test.onegovgever.ch/
+BUMBLEBEE_PUBLIC_URL https://tests.onegovgever.ch/
+BUMBLEBEE_SECRET secret
+</environment>
+<warnfilter>
+  action ignore
+  category exceptions.DeprecationWarning
+</warnfilter>
+<eventlog>
+  level INFO
+  <logfile>
+    path /apps/01-onegovgever/var/log/instance1.log
+    level INFO
+  </logfile>
+</eventlog>
+<logger access>
+  level WARN
+  <logfile>
+    path /apps/01-onegovgever/var/log/instance1-Z2.log
+    format %(message)s
+  </logfile>
+</logger>
+<http-server>
+  address 10101
+</http-server>
+<zodb_db main>
+    # Main database
+    cache-size 30000
+# Blob-enabled ZEOStorage database
+    <zeoclient>
+      read-only true
+      read-only-fallback false
+      blob-dir /apps/01-onegovgever/var/blobstorage
+      shared-blob-dir on
+      server 127.0.0.1:10120
+      storage 1
+      name zeostorage
+      var /apps/01-onegovgever/parts/instance1/var
+      cache-size 128MB
+    </zeoclient>
+    mount-point /
+</zodb_db>
+<zodb_db temporary>
+    # Temporary storage database (for sessions)
+    <temporarystorage>
+      name temporary storage for sessioning
+    </temporarystorage>
+    mount-point /temp_folder
+    container-class Products.TemporaryFolder.TemporaryContainer
+</zodb_db>
+pid-filename /apps/01-onegovgever/var/instance1.pid
+lock-filename /apps/01-onegovgever/var/instance1.lock
+python-check-interval 1000
+enable-product-installation off
+datetime-format international
+trusted-proxy 127.0.0.1
+%import collective.taskqueue
+<taskqueue />
+<taskqueue-server />

--- a/opengever/readonly/tests/data/zeoclient-rw-zope.conf
+++ b/opengever/readonly/tests/data/zeoclient-rw-zope.conf
@@ -1,0 +1,86 @@
+%define INSTANCEHOME /apps/01-onegovgever/parts/instance1
+instancehome $INSTANCEHOME
+%define CLIENTHOME /apps/01-onegovgever/var/instance1
+clienthome $CLIENTHOME
+debug-mode off
+security-policy-implementation C
+verbose-security off
+default-zpublisher-encoding utf-8
+http-header-max-length 8192
+zserver-threads 2
+<environment>
+    PTS_LANGUAGES en de fr it
+zope_i18n_allowed_languages en de fr it
+zope_i18n_compile_mo_files true
+CHAMELEON_EAGER true
+CHAMELEON_RELOAD false
+FTW_CHAMELEON_RECOOK_WARNING true
+FTW_CHAMELEON_RECOOK_EXCEPTION false
+CHAMELEON_CACHE /apps/01-onegovgever/var/instance1/chameleon-cache
+WARMUP_BIN /apps/01-onegovgever/bin/warmup
+WARMUP_INI /apps/01-onegovgever/parts/warmup/warmup.ini
+SABLON_BIN /apps/01-onegovgever/parts/gems/bin/sablon
+USERNAMELOGGER_AC_COOKIE_NAME __ac_fd
+RAVEN_PROJECT_DIST opengever.core
+RAVEN_TAGS {"cluster": "test.onegovgever.ch"}
+GEVER_COLORIZATION lightblue
+BUMBLEBEE_APP_ID gever_test
+BUMBLEBEE_INTERNAL_PLONE_URL https://test.onegovgever.ch/
+BUMBLEBEE_PUBLIC_URL https://tests.onegovgever.ch/
+BUMBLEBEE_SECRET secret
+</environment>
+<warnfilter>
+  action ignore
+  category exceptions.DeprecationWarning
+</warnfilter>
+<eventlog>
+  level INFO
+  <logfile>
+    path /apps/01-onegovgever/var/log/instance1.log
+    level INFO
+  </logfile>
+</eventlog>
+<logger access>
+  level WARN
+  <logfile>
+    path /apps/01-onegovgever/var/log/instance1-Z2.log
+    format %(message)s
+  </logfile>
+</logger>
+<http-server>
+  address 10101
+</http-server>
+<zodb_db main>
+    # Main database
+    cache-size 30000
+# Blob-enabled ZEOStorage database
+    <zeoclient>
+      read-only false
+      read-only-fallback false
+      blob-dir /apps/01-onegovgever/var/blobstorage
+      shared-blob-dir on
+      server 127.0.0.1:10120
+      storage 1
+      name zeostorage
+      var /apps/01-onegovgever/parts/instance1/var
+      cache-size 128MB
+    </zeoclient>
+    mount-point /
+</zodb_db>
+<zodb_db temporary>
+    # Temporary storage database (for sessions)
+    <temporarystorage>
+      name temporary storage for sessioning
+    </temporarystorage>
+    mount-point /temp_folder
+    container-class Products.TemporaryFolder.TemporaryContainer
+</zodb_db>
+pid-filename /apps/01-onegovgever/var/instance1.pid
+lock-filename /apps/01-onegovgever/var/instance1.lock
+python-check-interval 1000
+enable-product-installation off
+datetime-format international
+trusted-proxy 127.0.0.1
+%import collective.taskqueue
+<taskqueue />
+<taskqueue-server />

--- a/opengever/readonly/tests/test_cli.py
+++ b/opengever/readonly/tests/test_cli.py
@@ -1,0 +1,80 @@
+from contextlib import contextmanager
+from opengever.readonly.cli import disable_readonly
+from opengever.readonly.cli import enable_readonly
+from opengever.readonly.cli import is_readonly
+from unittest import TestCase
+import filecmp
+import os.path
+import shutil
+import tempfile
+
+
+data_dir = os.path.join(os.path.dirname(__file__), 'data')
+
+
+class TestReadOnlyToggle(TestCase):
+
+    def test_is_readonly_returns_true_if_readonly_enabled(self):
+        self.assertTrue(
+            is_readonly(os.path.join(data_dir, 'filestorage-ro-zope.conf')))
+        self.assertTrue(
+            is_readonly(os.path.join(data_dir, 'zeoclient-ro-zope.conf')))
+        self.assertTrue(
+            is_readonly(os.path.join(data_dir, 'relstorage-ro-zope.conf')))
+
+    def test_is_readonly_returns_false_if_readonly_disabled(self):
+        self.assertFalse(
+            is_readonly(os.path.join(data_dir, 'filestorage-rw-zope.conf')))
+        self.assertFalse(
+            is_readonly(os.path.join(data_dir, 'zeoclient-rw-zope.conf')))
+        self.assertFalse(
+            is_readonly(os.path.join(data_dir, 'relstorage-rw-zope.conf')))
+
+    def test_enable_readonly_in_filestorage_zope_conf(self):
+        with self.zope_conf('filestorage-rw-zope.conf') as conf:
+            enable_readonly(conf)
+            expected = os.path.join(data_dir, 'filestorage-ro-zope.conf')
+            self.assertTrue(
+                filecmp.cmp(conf, expected), 'Unexpected content in zope.conf')
+
+    def test_disable_readonly_in_filestorage_zope_conf(self):
+        with self.zope_conf('filestorage-ro-zope.conf') as conf:
+            disable_readonly(conf)
+            expected = os.path.join(data_dir, 'filestorage-rw-zope.conf')
+            self.assertTrue(
+                filecmp.cmp(conf, expected), 'Unexpected content in zope.conf')
+
+    def test_enable_readonly_in_zeoclient_zope_conf(self):
+        with self.zope_conf('zeoclient-rw-zope.conf') as conf:
+            enable_readonly(conf)
+            expected = os.path.join(data_dir, 'zeoclient-ro-zope.conf')
+            self.assertTrue(
+                filecmp.cmp(conf, expected), 'Unexpected content in zope.conf')
+
+    def test_disable_readonly_in_zeoclient_zope_conf(self):
+        with self.zope_conf('zeoclient-ro-zope.conf') as conf:
+            disable_readonly(conf)
+            expected = os.path.join(data_dir, 'zeoclient-rw-zope.conf')
+            self.assertTrue(
+                filecmp.cmp(conf, expected), 'Unexpected content in zope.conf')
+
+    def test_enable_readonly_in_relstorage_zope_conf(self):
+        with self.zope_conf('relstorage-rw-zope.conf') as conf:
+            enable_readonly(conf)
+            expected = os.path.join(data_dir, 'relstorage-ro-zope.conf')
+            self.assertTrue(
+                filecmp.cmp(conf, expected), 'Unexpected content in zope.conf')
+
+    def test_disable_readonly_in_relstorage_zope_conf(self):
+        with self.zope_conf('relstorage-ro-zope.conf') as conf:
+            disable_readonly(conf)
+            expected = os.path.join(data_dir, 'relstorage-rw-zope.conf')
+            self.assertTrue(
+                filecmp.cmp(conf, expected), 'Unexpected content in zope.conf')
+
+    @contextmanager
+    def zope_conf(self, name):
+        tempdir = tempfile.mkdtemp()
+        shutil.copy(os.path.join(data_dir, name), tempdir)
+        yield os.path.join(tempdir, name)
+        shutil.rmtree(tempdir)

--- a/setup.py
+++ b/setup.py
@@ -212,5 +212,6 @@ setup(name='opengever.core',
       create-policy = opengever.policytemplates.cli:main
       pyxbgen = opengever.disposition.ech0160.pyxbgen:main
       create-bundle = opengever.bundle.factory:main
+      toggle-readonly = opengever.readonly.cli:main
       """,
       )


### PR DESCRIPTION
This script allows to enable or disable the read-only mode of all instances in a GEVER deployment without running buildout.
It adds an environment variable `GEVER_READ_ONLY_MODE=true` and sets the ZODB connection to read-only in the `zope.conf` file.

By default all instances except for `instance0` are toggled. If an instance is in read-write mode it's set to read-only and vice versa.

With the command line options `-r` and `-w` it's possible to enable or disable the read-only mode regardless of the current state (see also `bin/toggle-readonly --help`)

After toggling the affected instances needs to be restarted.


JIRA: https://4teamwork.atlassian.net/browse/CA-211


## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

