### PR TITLE
Extend @config endpoint with application type.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2020.13.0 (unreleased)
 ----------------------
 
+- Extend @config endpoint with application type. [tinagerber]
 - Journalize creation of linked workspace and copying documents to and from it. [njohner]
 - Custom error page: Also log ReadOnlyError culprit traceback to error log (if available). [lgraf]
 - Avoid ftw.casauth write-on-read (last login times) during login. [lgraf]

--- a/docs/public/dev-manual/api/config.rst
+++ b/docs/public/dev-manual/api/config.rst
@@ -23,6 +23,7 @@ GEVER-Mandanten abgefragt werden.
       {
           "@id": "http://localhost:8080/fd/@config",
           "admin_unit": "fd",
+          "application_type": "gever",
           "apps_url": "https://dev.onegovgever.ch/portal/api/apps",
           "bumblebee_app_id": "gever_dev",
           "cas_url": "https://dev.onegovgever.ch/portal/cas",
@@ -127,6 +128,9 @@ GEVER-Mandanten abgefragt werden.
 
 Konfigurationsoptionen
 ----------------------
+
+application_type
+  Applikationstyp, entweder "gever" oder "teamraum"
 
 apps_url
 

--- a/opengever/api/tests/test_config.py
+++ b/opengever/api/tests/test_config.py
@@ -139,6 +139,14 @@ class TestConfig(IntegrationTestCase):
             browser.json.get(u'portal_url'), 'http://nohost/portal')
 
     @browsing
+    def test_config_contains_application_type(self, browser):
+        self.login(self.regular_user, browser)
+        browser.open(self.config_url, headers=self.api_headers)
+        self.assertEqual(browser.status_code, 200)
+        self.assertEqual(
+            browser.json.get(u'application_type'), 'gever')
+
+    @browsing
     def test_config_contains_is_readonly_flag(self, browser):
         self.login(self.regular_user, browser)
 

--- a/opengever/base/configuration.py
+++ b/opengever/base/configuration.py
@@ -65,6 +65,7 @@ class GeverSettingsAdpaterV1(object):
         config['portal_url'] = get_gever_portal_url()
         config['cas_url'] = get_cas_server_url()
         config['apps_url'] = os.environ.get('APPS_ENDPOINT_URL')
+        config['application_type'] = self.get_application_type()
         config['is_readonly'] = is_in_readonly_mode()
         return config
 
@@ -80,6 +81,11 @@ class GeverSettingsAdpaterV1(object):
             serializer = queryMultiAdapter((user, getRequest()), ISerializeToJson)
             info['current_user'] = OrderedDict(serializer())
         return info
+
+    def get_application_type(self):
+        if api.portal.get_registry_record('is_feature_enabled', interface=IWorkspaceSettings):
+            return 'teamraum'
+        return 'gever'
 
     def get_user_settings(self):
         setting = UserSettings.query.filter_by(userid=api.user.get_current().id).one_or_none()

--- a/opengever/base/tests/test_configuration_adapter.py
+++ b/opengever/base/tests/test_configuration_adapter.py
@@ -95,6 +95,7 @@ class TestConfigurationAdapter(IntegrationTestCase):
             ('portal_url', 'http://nohost/portal'),
             ('cas_url', None),
             ('apps_url', None),
+            ('application_type', 'gever'),
             ('is_readonly', False),
             ])
 
@@ -112,10 +113,16 @@ class TestConfigurationAdapter(IntegrationTestCase):
             ('portal_url', 'http://nohost/portal'),
             ('cas_url', None),
             ('apps_url', None),
+            ('application_type', 'gever'),
             ('is_readonly', False),
             ])
         configuration = IGeverSettings(self.portal).get_config()
         self.assertEqual(configuration, expected_configuration)
+
+    def test_application_type_is_teamraum_if_workspace_feature_enabled(self):
+        self.activate_feature('workspace')
+        application_type = IGeverSettings(self.portal).get_application_type()
+        self.assertEqual('teamraum', application_type)
 
     def test_apps_url_can_be_set_through_env_variable(self):
 
@@ -142,6 +149,7 @@ class TestConfigurationAdapter(IntegrationTestCase):
             ('portal_url', 'http://nohost/portal'),
             ('cas_url', None),
             ('apps_url', 'http://example.com/api/apps'),
+            ('application_type', 'gever'),
             ('is_readonly', False),
             ])
 


### PR DESCRIPTION
This PR adds the application type to the @config endpoint. This allows the frontend to decide which app should be loaded independently from the portal.

Jira: https://4teamwork.atlassian.net/browse/NE-97

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


## Checklist (if applicable)

_Only applicable should be left and checked._

- API change:
  - [x] Documentation is updated