### PR TITLE
@@task_report-view supports task lookup by the ressource-id through the `tasks` parameter.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 ----------------------
 
 - Use oguid instead of intId as token in DossierTemplatesVocabulary. [tinagerber]
+- `@@task_report`-view supports task lookup by the ressource-id through the `tasks` parameter. [elioschmutz]
 - Extend @config endpoint with application type. [tinagerber]
 - Journalize creation of linked workspace and copying documents to and from it. [njohner]
 - Disable write actions during readonly mode. [lgraf]

--- a/opengever/globalindex/model/task.py
+++ b/opengever/globalindex/model/task.py
@@ -588,6 +588,13 @@ class TaskQuery(BaseQuery):
         return self._extend_with_physical_path(
             query, Task.physical_path, path).first()
 
+    def by_paths(self, paths, admin_unit_id=None):
+        """Returns all tasks whos physical_path is listed in `paths`.
+        """
+        admin_unit_id = admin_unit_id or get_current_admin_unit().id()
+        query = self.restrict().filter_by(admin_unit_id=admin_unit_id)
+        return query.filter(Task.physical_path.in_(paths)).all()
+
     def by_ids(self, task_ids):
         """Returns all tasks whos task_ids are listed in `task_ids`.
         """

--- a/opengever/globalindex/tests/test_query.py
+++ b/opengever/globalindex/tests/test_query.py
@@ -82,6 +82,15 @@ class TestTaskQueries(IntegrationTestCase):
 
         self.assertEquals(None, Task.query.by_path('test/not-existng/', 'plone'))
 
+    def test_by_paths_returns_tasks_wich_match_the_given_paths(self):
+        self.login(self.regular_user)
+
+        tasks = [self.task, self.subtask, self.meeting_subtask]
+
+        self.assertEquals(
+            [task.get_sql_object() for task in tasks],
+            Task.query.by_paths([task.get_sql_object().physical_path for task in tasks]))
+
     def test_by_ids_returns_tasks_wich_match_the_given_id(self):
         self.login(self.regular_user)
 

--- a/opengever/globalindex/tests/test_reporter.py
+++ b/opengever/globalindex/tests/test_reporter.py
@@ -91,3 +91,35 @@ class TestTaskReporter(IntegrationTestCase):
              u'label_task_type', u'label_title',
              u'label_dossier'],
             [cell.value for cell in list(workbook.active.rows)[0]])
+
+    @browsing
+    def test_task_report_by_task_ressource_id(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        browser.open(view='task_report',
+                     data={'view_name': 'mytasks',
+                           'tasks': [self.task.absolute_url(),
+                                     self.meeting_task.absolute_url()]})
+
+        with NamedTemporaryFile(delete=False, suffix='.xlsx') as tmpfile:
+            tmpfile.write(browser.contents)
+            tmpfile.flush()
+            workbook = load_workbook(tmpfile.name)
+
+        # self.task
+        self.assertSequenceEqual(
+            [self.task.title,  u'task-state-in-progress',
+             datetime(2016, 11, 1, 0, 0), None,
+             self.dossier.title, u'Ziegler Robert (robert.ziegler)',
+             u'Finanz\xe4mt', u'B\xe4rfuss K\xe4thi (kathi.barfuss)',
+             u'For confirmation / correction', u'plone', 1],
+            [cell.value for cell in list(workbook.active.rows)[1]])
+
+        # self.meeting_task
+        self.assertSequenceEqual(
+            [self.meeting_task.title, u'task-state-in-progress',
+             datetime(2016, 11, 1, 0, 0), None,
+             self.meeting_dossier.title, u'Ziegler Robert (robert.ziegler)',
+             u'Finanz\xe4mt', u'Ziegler Robert (robert.ziegler)',
+             u'For confirmation / correction', u'plone', 9],
+            [cell.value for cell in list(workbook.active.rows)[2]])

--- a/opengever/globalindex/utils.py
+++ b/opengever/globalindex/utils.py
@@ -1,4 +1,5 @@
 from opengever.globalindex.model.task import Task
+from plone import api
 
 
 def indexed_task_link_helper(item, value):
@@ -9,14 +10,23 @@ def indexed_task_link_helper(item, value):
 
 
 def get_selected_items(context, request):
-    """Returns a set of SQLAlchemy objects, for "task_id:list given
-    in the request"
+    """Returns a set of SQLAlchemy objects, for "task_id:list" or "tasks:list"
+    given in the request"
     """
-    ids = request.get('task_ids', [])
+    ids = request.get('task_ids', [])  # a list of `task_id`s within the ogds
+    tasks = request.get('tasks', [])  # a list of `@id`s of tasks
+
     if ids:
         tasks = Task.query.by_ids(ids)
         keys = ids
         attr = 'task_id'
+
+    elif tasks:
+        portal_url = api.portal.get().absolute_url()
+        paths = [task.replace(portal_url, '').lstrip('/') for task in tasks]
+        tasks = Task.query.by_paths(paths)
+        keys = paths
+        attr = 'physical_path'
 
     else:
         # empty generator


### PR DESCRIPTION
Pre-discussed with @deiferni : https://4teamwork.slack.com/archives/C01BHEGBVU1/p1603707985016500

Jira: https://4teamwork.atlassian.net/browse/NE-56

----- 

The `@@task_report` view is a folder-action which should also work for the gever-ui.

Currently, the view wants a list of `task_ids` which should be included in the report. Unfortunately, we don't have `task_ids` in the `@listing` endpoint of the frontend. Including it would mean, that we have to index the `task_ids` in solr and expose it int the `@listing` endpoint. This was not desired. Thus, we need another way to lookup the tasks.

Because the tasks in a default listing are always within the current admin unit, we can do a task lookup by the resource-id (`@id`)

This PR extends the `@@task_report` view with a new parameter: `tasks`. It provides a list of task resource ids which should be included in the report.

The view now provides two ways to include tasks:

by `task_id`:
`@@task_report?task_ids:list=1&task_ids:list=2`

by the resource id:
`@@task_report?tasks:list=https://example.com/ordnungssystem/dossier-1/task-1&tasks:list=https://example.com/ordnungssystem/dossier-1/task-2`

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

## Checklist (if applicable)

_Only applicable should be left and checked._

- API change:
  - [ ] Documentation is updated
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Upgrade steps (changes in profile):
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
- DB-Schema migration
  - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
  - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value
