### PR TITLE
Register new translations directory in opengever.workspaceclient.

### DIFF
--- a/opengever/workspaceclient/configure.zcml
+++ b/opengever/workspaceclient/configure.zcml
@@ -2,10 +2,13 @@
     xmlns="http://namespaces.zope.org/zope"
     xmlns:five="http://namespaces.zope.org/five"
     xmlns:plone="http://namespaces.plone.org/plone"
+    xmlns:i18n="http://namespaces.zope.org/i18n"
     i18n_domain="opengever.workspaceclient">
 
   <include file="permissions.zcml" />
 
   <adapter factory=".linked_workspaces.LinkedWorkspaces" />
+
+  <i18n:registerTranslations directory="locales" />
 
 </configure>


### PR DESCRIPTION
Seems I forgot to register the new `locales` directory introduced in https://github.com/4teamwork/opengever.core/pull/6701 for the new journal entries for workspace client actions (create from a dossier, copy document back and forth between dossier and workspace).

For
- https://4teamwork.atlassian.net/browse/CA-927
- https://4teamwork.atlassian.net/browse/CA-928
- https://4teamwork.atlassian.net/browse/CA-929

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [ ] Changelog entry: None necessary
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
