### PR TITLE
Handle when connection is None in readonly.

### DIFF
--- a/opengever/readonly/__init__.py
+++ b/opengever/readonly/__init__.py
@@ -15,5 +15,6 @@ def is_in_readonly_mode():
     site = getSite()
     if site:
         conn = site._p_jar
-        return conn.isReadOnly()
+        if conn:
+            return conn.isReadOnly()
     return False


### PR DESCRIPTION
During a local setup the connection can be `None` at some point. A setup would fail with the following trace:

```
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module opengever.setup.browser.admin, line 132, in __call__
  Module opengever.setup.browser.admin, line 176, in install_with_ajax_stream
  Module opengever.setup.browser.admin, line 147, in _install
  Module opengever.setup.deploy, line 61, in create
  Module opengever.setup.deploy, line 149, in sync_ogds
  Module opengever.ogds.base.sync.ogds_updater, line 77, in sync_ogds
  Module opengever.ogds.base.sync.import_stamp, line 38, in set_remote_import_stamp
  Module opengever.ogds.base.sync.import_stamp, line 29, in update_sync_stamp
  Module opengever.core.dictstorage, line 21, in set
  Module ftw.dictstorage.base, line 33, in __setitem__
  Module ftw.dictstorage.base, line 21, in storage
  Module zope.component._api, line 107, in getMultiAdapter
  Module zope.component._api, line 120, in queryMultiAdapter
  Module zope.component.registry, line 238, in queryMultiAdapter
  Module zope.interface.adapter, line 532, in queryMultiAdapter
  Module opengever.readonly.dictstorage, line 14, in __init__
  Module opengever.readonly, line 18, in is_in_readonly_mode
AttributeError: 'NoneType' object has no attribute 'isReadOnly'
```

I've added a simple `if` to handle such cases. But I'm not absolutely certain wheter we want to assume non-readonly for
such cases. However it seems consistent with handling when no site is available, so I'm proposing the solution.

Jira: https://4teamwork.atlassian.net/browse/CA-1141.

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [ ] ~~Changelog entry~~ _IMO not necessary here_
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
