### PR TITLE
Ensure remaining indices are dropped from catalog.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 
 - Use oguid instead of intId as token in DossierTemplatesVocabulary. [tinagerber]
 - `@@task_report`-view supports task lookup by the ressource-id through the `tasks` parameter. [elioschmutz]
+- Ensure `document_author` and `SearchableText` indices are dropped from catalog. [deiferni]
 - Extend @config endpoint with application type. [tinagerber]
 - Journalize creation of linked workspace and copying documents to and from it. [njohner]
 - Disable write actions during readonly mode. [lgraf]

--- a/opengever/core/upgrades/20201028100049_ensure_solr_only_indices_dropped_from_catalog/upgrade.py
+++ b/opengever/core/upgrades/20201028100049_ensure_solr_only_indices_dropped_from_catalog/upgrade.py
@@ -1,0 +1,92 @@
+from ftw.upgrade import UpgradeStep
+from ftw.upgrade.progresslogger import ProgressLogger
+import logging
+
+
+logger = logging.getLogger('ftw.upgrade')
+
+
+ZCTEXT_INDEXES_TO_REMOVE = [
+    'document_author',
+    'SearchableText',
+]
+
+INDEXES_TO_REMOVE = [
+    'total_comments',
+]
+
+
+class EnsureSolrOnlyIndicesDroppedFromCatalog(UpgradeStep):
+    """Ensure solr only indices dropped from catalog.
+
+    We seem to have different indexes still around for different deployments.
+    The following states exist:
+
+    - Neither `document_author` nor `SearchableText`:
+      This happened when solr was activated with the `activate_solr.py` script
+      from `opengever.maintenance`. It deleted the `document_author` index
+      which was still present in `opengever.core`.
+
+    - Only `document_author`:
+      This is the state for all new deployments where `activate_solr.py` has
+      not been run as the `document_author` index was still present in
+      `opengever.core`.
+
+    - Indices `document_author`, `SearchableText` and `total_comments`:
+      The upgrade step to delete indices was faulty and did not correctly
+      remove `SearchableText` and `total_comments` due to a missing comma.
+
+    This upgrade makes sure that the remaining indices are dropped
+    consistently for all deployments. It also conditionally clears the lexicon
+    and rebuilds the remaining ZCTextIndex indices to ensure minimal catalog
+    size.
+
+    Note that the `document_author` metadata is left in place as it is still
+    used by the `ILaTexListing` for documents.
+    """
+    deferrable = True
+
+    def __call__(self):
+        self.found_zctext_index_to_remove = False
+        self.remove_indexes()
+        self.reindex_zc_text_indices()
+
+    def remove_indexes(self):
+        catalog = self.getToolByName('portal_catalog')
+        for index in ZCTEXT_INDEXES_TO_REMOVE:
+            if index in catalog._catalog.indexes:
+                self.found_zctext_index_to_remove = True
+                catalog._catalog.delIndex(index)
+                logger.info('Removed catalog index {}.'.format(index))
+        for index in INDEXES_TO_REMOVE:
+            if index in catalog._catalog.indexes:
+                catalog._catalog.delIndex(index)
+                logger.info('Removed catalog index {}.'.format(index))
+
+    def reindex_zc_text_indices(self):
+        if not self.found_zctext_index_to_remove:
+            return
+
+        catalog = self.getToolByName('portal_catalog')
+
+        title_index = catalog._catalog.getIndex('Title')
+        catalog.clearIndex('Title')
+        logger.info('Cleared Title index.')
+
+        if 'searchable_filing_no' in catalog._catalog.indexes:
+            searchable_filing_no_index = catalog._catalog.getIndex(
+                'searchable_filing_no')
+            catalog.clearIndex('searchable_filing_no')
+            logger.info('Cleared searchable_filing_no index.')
+        else:
+            searchable_filing_no_index = None
+
+        lexicon = catalog['plone_lexicon']
+        lexicon.clear()
+        logger.info('Cleared plone_lexicon.')
+
+        items = catalog.unrestrictedSearchResults()
+        for item in ProgressLogger('Reindexing ZCTextIndex indices.', items):
+            title_index.index_object(item.getRID(), item)
+            if searchable_filing_no_index:
+                searchable_filing_no_index.index_object(item.getRID(), item)

--- a/opengever/document/config.py
+++ b/opengever/document/config.py
@@ -1,8 +1,5 @@
 INDEXES = (
     ('delivery_date', 'DateIndex'),
-    ('document_author', 'ZCTextIndex',
-        {'index_type': 'Okapi BM25 Rank',
-         'lexicon_id': 'plone_lexicon'}),
     ('checked_out', 'FieldIndex'),
     ('document_date', 'DateIndex'),
     ('document_type', 'FieldIndex'),

--- a/opengever/document/tests/test_catalog.py
+++ b/opengever/document/tests/test_catalog.py
@@ -11,9 +11,6 @@ class TestCatalog(FunctionalTestCase):
     def test_delivery_date_index_registered(self):
         self.assertIn('delivery_date', self.catalog.indexes())
 
-    def test_document_author_index_registered(self):
-        self.assertIn('document_author', self.catalog.indexes())
-
     def test_cchecked_out_index_registered(self):
         self.assertIn('checked_out', self.catalog.indexes())
 

--- a/opengever/document/tests/test_copy_document.py
+++ b/opengever/document/tests/test_copy_document.py
@@ -230,7 +230,6 @@ class TestCopyDocuments(IntegrationTestCase):
                                'date_of_completion',
                                'deadline',
                                'delivery_date',
-                               'document_author',
                                'document_date',
                                'document_type',
                                'email',

--- a/opengever/dossier/tests/test_move_items.py
+++ b/opengever/dossier/tests/test_move_items.py
@@ -287,7 +287,6 @@ class TestMoveItemsUpdatesIndexAndMetadata(IntegrationTestCase, MoveItemsHelper)
                                'date_of_completion',
                                'deadline',
                                'delivery_date',
-                               'document_author',
                                'document_date',
                                'document_type',
                                'email',


### PR DESCRIPTION
We seem to have different indexes still around for different deployments regarding the catalog indices `document_author`, `SearchableText` and `total_comments`. The following states exist:

- Neither `document_author` nor `SearchableText`:
  This happened when solr was activated with the `activate_solr.py` script
  from `opengever.maintenance` https://github.com/4teamwork/opengever.maintenance/blob/a05f10627dd8729db13128d7a767d98d7696b508/opengever/maintenance/scripts/activate_solr.py. It deleted the `document_author` index which was still present in `opengever.core`.
- Only `document_author`:
  This is the state for all new deployments where `activate_solr.py` has not been run as the `document_author` index was still present in `opengever.core`.
- Indices `document_author`, `SearchableText` and `total_comments`:      
  The upgrade step to delete indices was faulty and did not correctly remove `SearchableText` and `total_comments` due to a missing comma:https://github.com/4teamwork/opengever.core/blob/aa2e84c93894f5ed9876b760c18cd16edf2f4a10/opengever/core/upgrades/20200518084137_cleanup_catalog_indexes_and_metadata/upgrade.py#L17-L18

With this PR we make sure that the remaining two indexes are dropped consistently for all deployments. It also conditionally clears the lexicon and rebuilds the remaining ZCTextIndex indices to ensure minimal catalog size.

Note that the `document_author` metadata is left in place as it is still used by the `ILaTexListing` for documents.

I have locally tested the following permutations:
- ✅ &nbsp; A deployment with `SearchableText`, `document_author` and `total_comments`.
- ✅ &nbsp; A deployment with `document_author` only.
- ✅ &nbsp; A deployment with `document_author` and `searchable_filing_no` from the `opengever.dossier:filing` profile.
- ✅ &nbsp; A fresh deployment contains the correct indices.

Jira: https://4teamwork.atlassian.net/browse/CA-1141

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


## Checklist (if applicable)

_Only applicable should be left and checked._

- Upgrade steps (changes in profile):
  - [x] Make it deferrable if possible
  - [x] Execute as much as possible conditionally