### PR TITLE
Use oguid instead of intId as token in DossierTemplatesVocabulary

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2020.13.0 (unreleased)
 ----------------------
 
+- Use oguid instead of intId as token in DossierTemplatesVocabulary. [tinagerber]
 - Extend @config endpoint with application type. [tinagerber]
 - Journalize creation of linked workspace and copying documents to and from it. [njohner]
 - Disable write actions during readonly mode. [lgraf]

--- a/docs/public/dev-manual/api/dossier_from_template.rst
+++ b/docs/public/dev-manual/api/dossier_from_template.rst
@@ -22,7 +22,7 @@ Zusätzlich können auch die anderen Felder des :ref:`label-dossier-schema`-Sche
        Accept: application/json
 
        {
-        "template": {"token": "1234567890"},
+        "template": {"token": "fd:12345"},
         "description": "Dossier description"
         "responsible": "rolf.ziegler",
         "title": "Dossier title"

--- a/opengever/dossier/dossiertemplate/form.py
+++ b/opengever/dossier/dossiertemplate/form.py
@@ -13,7 +13,6 @@ from opengever.dossier.behaviors.dossier import IDossier
 from opengever.dossier.command import CreateDocumentFromTemplateCommand
 from opengever.dossier.command import CreateDossierFromTemplateCommand
 from opengever.dossier.dossiertemplate import is_create_dossier_from_template_available
-from opengever.dossier.dossiertemplate import is_dossier_template_feature_enabled
 from opengever.dossier.dossiertemplate.behaviors import IDossierTemplate
 from opengever.dossier.dossiertemplate.behaviors import IDossierTemplateSchema
 from opengever.dossier.dossiertemplate.behaviors import IRestrictAddableDossierTemplates
@@ -32,7 +31,6 @@ from z3c.form.button import buttonAndHandler
 from z3c.form.form import Form
 from z3c.form.interfaces import IDataConverter
 from zExceptions import Unauthorized
-from zope.app.intid.interfaces import IIntIds
 from zope.component import getUtility
 from zope.interface import alsoProvides
 from zope.interface import implementer
@@ -60,12 +58,11 @@ def get_dossier_templates(context):
         })
         templates = [brain.getObject() for brain in brains]
 
-    intids = getUtility(IIntIds)
     terms = []
     for template in templates:
         terms.append(SimpleVocabulary.createTerm(
             template,
-            str(intids.getId(template)),
+            Oguid.for_object(template),
             template.title))
 
     return SimpleVocabulary(terms)


### PR DESCRIPTION
When creating a dossier from a template we need access to the template in the frontend. Since the IntId cannot be resolved by an endpoint, the Oguid is now set as token in the DossierTemplatesVocabulary, because we can resolve the Oguid with the @resolve-oguid endpoint.

Discussed with @deiferni 

Since the vocabulary was only accessible via API since the last release, I do not consider it necessary to notify the channel and the Scrum Master. 

Jira: https://4teamwork.atlassian.net/browse/NE-43

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


## Checklist (if applicable)

_Only applicable should be left and checked._

- API change:
  - [x] Documentation is updated
  - If breaking:
    - [x] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed