### PR TITLE
Agenda-item attachments are now ordered based on the position in the relationField.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2020.13.0 (unreleased)
 ----------------------
 
+- Agenda-item attachments are now ordered based on the position in the relationField. [elioschmutz]
 - Use oguid instead of intId as token in DossierTemplatesVocabulary. [tinagerber]
 - `@@task_report`-view supports task lookup by the ressource-id through the `tasks` parameter. [elioschmutz]
 - Ensure `document_author` and `SearchableText` indices are dropped from catalog. [deiferni]

--- a/opengever/meeting/browser/meetings/agendaitem.py
+++ b/opengever/meeting/browser/meetings/agendaitem.py
@@ -189,8 +189,9 @@ class AgendaItemsView(BrowserView):
         if not item.has_proposal:
             return []
 
-        docs = IContentListing(item.proposal.resolve_submitted_documents())
-        return [doc.render_link() for doc in sorted(docs, key=lambda doc: doc.title_or_id().lower())]
+        submitted_proposal = item.proposal.resolve_submitted_proposal()
+        docs = IContentListing(submitted_proposal.get_documents())
+        return [doc.render_link() for doc in docs]
 
     def _serialize_submitted_excerpt(self, item):
         if not item.has_proposal:

--- a/opengever/meeting/browser/sablontemplate.py
+++ b/opengever/meeting/browser/sablontemplate.py
@@ -21,10 +21,10 @@ SAMPLE_MEETING_DATA = {
             "title": u'Beweisaufn\xe4hme',
             "filename": u"Beweisaufnaehme.txt"
             }, {
+            "title": "Strafbefehl"
+            }, {
             "title": u"L\xf6rem",
             "filename": u"Loerem.eml"
-            }, {
-            "title": "Strafbefehl"
             }]
     }, {
         'description': u'R\xfccktritt Grund',

--- a/opengever/meeting/proposal.py
+++ b/opengever/meeting/proposal.py
@@ -382,7 +382,7 @@ class SubmittedProposal(ModelContainer, ProposalBase):
         documents = catalog(
             portal_type=['opengever.document.document', 'ftw.mail.mail'],
             path=dict(query='/'.join(self.getPhysicalPath())),
-            sort_on='sortable_title'
+            sort_on='getObjPositionInParent'
             )
 
         ignored_documents = [self.get_excerpt()]
@@ -522,10 +522,7 @@ class Proposal(Container, ProposalBase):
         return api.user.has_permission('opengever.meeting: Add Proposal Comment', obj=self)
 
     def get_documents(self):
-        return sorted(
-            [relation.to_object for relation in self.relatedItems],
-            key=lambda document: document.title_or_id(),
-            )
+        return [relation.to_object for relation in self.relatedItems]
 
     def get_excerpt(self):
         return self.load_model().resolve_excerpt_document()

--- a/opengever/meeting/tests/test_agendaitem.py
+++ b/opengever/meeting/tests/test_agendaitem.py
@@ -39,14 +39,18 @@ class TestDisplayAgendaItems(IntegrationTestCase):
         self.assertTrue(item.get('has_documents'))
 
     @browsing
-    def test_agendaitem_attachements_are_sorted(self, browser):
+    def test_agendaitem_attachements_are_sorted_by_position_in_relation_field(self, browser):
         self.login(self.committee_responsible, browser)
         documents = [
             create(Builder('document')
                    .within(self.dossier)
                    .titled(title))
-            for title in ('XXX', 'aBd', 'abc',)
+            for title in ('Doc 1', 'Doc 4', 'Doc 2', 'Doc 3')
         ]
+        documents.reverse()
+
+        self.dossier.moveObjectToPosition(documents[1].getId(), 0)
+
         proposal, submitted_proposal = create(Builder('proposal')
                           .within(self.dossier)
                           .having(committee=self.committee.load_model())
@@ -60,7 +64,8 @@ class TestDisplayAgendaItems(IntegrationTestCase):
 
         pattern = re.compile('<a class="document_link.*?>(.*?)</a>')
         browser_titles = [pattern.search(el).groups()[0] for el in item.get('documents')]
-        self.assertEquals([u'abc', u'aBd', u'XXX'], browser_titles)
+        self.assertEquals([u'Doc 3', 'Doc 2', 'Doc 4', 'Doc 1'],
+                          browser_titles)
 
     @browsing
     def test_agendaitem_with_excerpts_and_documents_has_documents(self, browser):


### PR DESCRIPTION
Jira: https://4teamwork.atlassian.net/browse/NE-108

A user should be able to order agena-item attachments in the new UI. This is already possible through the restapi with unsubmitted proposals. While submitting the proposal, the related documents gets sorted by the title. The old ui meeting view which displays submitted proposals will now show the attachments ordered by title as well.

By removing the ordering, we get the documents in the order as they where created. And this is the user defined order, exactly what we want to display. 

<img width="660" alt="Bildschirmfoto 2020-10-28 um 17 23 23" src="https://user-images.githubusercontent.com/557005/97465421-4de01880-1942-11eb-8163-aad33df512d0.png">

This PR no longer orders the agenda-item attachments by name but by the position in the relationItem field instead:

<img width="634" alt="Bildschirmfoto 2020-10-28 um 17 23 13" src="https://user-images.githubusercontent.com/557005/97465591-7ec04d80-1942-11eb-9ea1-66f313484280.png">

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


## Checklist (if applicable)

_Only applicable should be left and checked._

- API change:
  - [ ] Documentation is updated
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Upgrade steps (changes in profile):
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
- DB-Schema migration
  - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
  - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value
