### PR TITLE
Remove limit for Subject facet

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 ----------------------
 
 - Agenda-item attachments are now ordered based on the position in the relationField. [elioschmutz]
+- Remove the limit for facets returned in the listing API endpoint. [Kevin Bieri]
 - Use oguid instead of intId as token in DossierTemplatesVocabulary. [tinagerber]
 - `@@task_report`-view supports task lookup by the ressource-id through the `tasks` parameter. [elioschmutz]
 - Ensure `document_author` and `SearchableText` indices are dropped from catalog. [deiferni]

--- a/opengever/api/listing.py
+++ b/opengever/api/listing.py
@@ -307,6 +307,7 @@ class ListingGet(SolrQueryBaseService):
             additional_params["facet"] = "true"
             additional_params["facet.mincount"] = 1
             additional_params["facet.field"] = facet_fields
+            additional_params['facet.limit'] = -1
         return additional_params
 
     @with_active_solr_only

--- a/opengever/api/tests/test_listing.py
+++ b/opengever/api/tests/test_listing.py
@@ -88,6 +88,18 @@ class TestListingEndpointWithSolr(IntegrationTestCase):
         self.assertEqual(['start'], params['facet.field'])
 
     @browsing
+    def test_does_not_limit_facets(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        view = ('@listing?name=documents&columns:list=title'
+                '&facets:list=creator')
+        browser.open(self.repository_root, view=view,
+                     headers=self.api_headers)
+        params = self.solr.search.call_args[1]
+        self.assertEqual(-1, params['facet.limit'],
+                        msg="Facets must not be limited")
+
+    @browsing
     def test_excludes_searchroot(self, browser):
         self.login(self.regular_user, browser=browser)
 


### PR DESCRIPTION
In https://4teamwork.atlassian.net/browse/NE-173, the user reported an issue, where not all facets are listed in the dossier listing.
This is becuase the default facet limit is 100 in solr 8.4: https://lucene.apache.org/solr/guide/8_4/faceting.html#field-value-faceting-parameters.
So, remove the limit of the Subject facets by including f.Subject.facet.limit=-1 in the solr query.

Definition of Done: https://4teamwork.atlassian.net/wiki/spaces/CHX4TW/pages/917562/


## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)