### PR TITLE
Webactions integration in @actions endpoint

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 
 - Agenda-item attachments are now ordered based on the position in the relationField. [elioschmutz]
 - Remove the limit for facets returned in the listing API endpoint. [Kevin Bieri]
+- `@actions` endpoint also returns available webactions. [elioschmutz]
 - Use oguid instead of intId as token in DossierTemplatesVocabulary. [tinagerber]
 - `@@task_report`-view supports task lookup by the ressource-id through the `tasks` parameter. [elioschmutz]
 - Ensure `document_author` and `SearchableText` indices are dropped from catalog. [deiferni]

--- a/docs/public/dev-manual/api/webactions.rst
+++ b/docs/public/dev-manual/api/webactions.rst
@@ -3,10 +3,50 @@
 Webactions
 ==========
 
-Der ``/@webactions`` Endpoint auf dem Root des Mandanten ermöglicht das
-Verwalten von sogenannten WebActions in GEVER.
+Eine Webaktion wird von einer Drittanwendung in GEVER registriert. Mit Webaktionen können Knöpfe, Links und Icons direkt an gewissen Stellen in GEVER platziert werden, mit welchen der Benutzer dann Aktionen in einer Drittanwendung auslösen kann.
 
 .. contents::
+
+Registrierte Webaktionen anzeigen (GET)
+---------------------------------------
+
+Webaktionen werden im ``@actions``-Endpoint in einer eigenen Kategorie ``webactions`` angezeigt, sofern diese für den aktuellen Kontext und Benutzer verfügbar sind.
+
+**Request**:
+
+.. sourcecode:: http
+
+  GET /@actions HTTP/1.1
+  Accept: application/json
+
+**Response**:
+
+.. sourcecode:: http
+
+  HTTP/1.1 200 OK
+  Content-Type: application/json
+
+  {
+    "object_buttons": ["..."],
+    "user": ["..."],
+    "webactions": [
+      {
+        "action_id": 0,
+        "title": "Open in ExternalApp",
+        "target_url": "http://example.org/endpoint",
+        "mode": "self",
+        "display": "actions-menu"
+      }
+    ]
+  }
+
+Weitere Informationen über die Verwendung des ``@actions``-Endpoints befinden sich in der `plone.restapi Dokumentation  <https://plonerestapi.readthedocs.io/en/latest/actions.html#listing-available-actions>`_.
+
+Webactions verwalten
+--------------------
+
+Der ``/@webactions`` Endpoint auf dem Root des Mandanten ermöglicht das
+Verwalten von sogenannten WebActions in GEVER.
 
 Solche Webaktionen können z.B. für oder von Drittanwendungen (mit den nötigen
 :ref:`Berechtigungen <webactions-mgmt-permissions>`) registriert werden, um
@@ -19,7 +59,7 @@ auslösen kann.
 .. _webactions-mgmt-permissions:
 
 Berechtigungen für das Verwalten von Webaktionen
-------------------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Für das Verwalten von Webaktionen über die REST API wird die permission
 ``opengever.webactions: Manage own WebActions`` benötigt. Diese ist in GEVER
@@ -31,7 +71,7 @@ löschen).
 
 
 Erstellen (POST)
-----------------
+~~~~~~~~~~~~~~~~
 
 .. http:post:: /@webactions
 
@@ -101,7 +141,7 @@ Webaktion, welche für weitere Requests verwendet werden kann.
 
 
 Auslesen (GET)
---------------
+~~~~~~~~~~~~~~
 
 .. http:get:: /@webactions/(action_id)
 
@@ -149,7 +189,7 @@ Auslesen (GET)
 
 
 Auflisten (GET)
----------------
+~~~~~~~~~~~~~~~
 
 
 .. http:get:: /@webactions
@@ -215,7 +255,7 @@ Auflisten (GET)
 
 
 Aktualisieren (PATCH)
----------------------
+~~~~~~~~~~~~~~~~~~~~~
 
 
 .. http:patch:: /@webactions/(action_id)
@@ -261,7 +301,7 @@ Aktualisieren (PATCH)
 
 
 Löschen (DELETE)
-----------------
+~~~~~~~~~~~~~~~~
 
 
 .. http:delete:: /@webactions/(action_id)
@@ -299,7 +339,7 @@ Löschen (DELETE)
 .. _webactions-fields:
 
 Eigenschaften von Webaktionen
------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Folgend ist eine Auflistung aller von Webaktionen unterstützten Felder und deren Typ und Bedeutung.
 
@@ -351,7 +391,7 @@ Folgend ist eine Auflistung aller von Webaktionen unterstützten Felder und dere
 .. _webactions-mode:
 
 Zielfenster
------------
+~~~~~~~~~~~
 
 Über das Feld ``mode`` kann gesteuert werden, wie der Link geöffnet wird.
 
@@ -372,7 +412,7 @@ Erlaubte Werte:
 .. _webactions-scope:
 
 Scope
------
+~~~~~
 
 Über das Feld ``scope`` kann gesteuert werden, bei welchen Objekten die
 Webaktion angeboten wird.
@@ -391,7 +431,7 @@ Webaktion angeboten wird.
 .. _webactions-server-metadata:
 
 Vom Server vergebene Metadaten
-------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 +---------------+-------------+-------------------------------------------------------------------+
 | Feld          | Typ         | Beschreibung                                                      |
@@ -408,7 +448,7 @@ Vom Server vergebene Metadaten
 .. _webactions-display:
 
 Darstellungsorte
-----------------
+~~~~~~~~~~~~~~~~
 
 Die Webaktionen können an verschiedenen Orten dargestellt werden.
 
@@ -445,7 +485,7 @@ Folgende Darstellungsorte sind als Werte für das Feld ``display`` erlaubt:
 .. _webactions-permissions:
 
 Berechtigungsabhängige Aktionen
--------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Aktionen können eingeschränkt werden, so dass sie nur dann angezeigt werden,
 wenn der Benutzer mindestens eine der angegebenen Berechtigungen auf dem
@@ -474,7 +514,7 @@ Folgende Werte können für das Feld ``permissions`` angegeben werden:
 .. _webactions-unique-name:
 
 Eindeutiger Name
-----------------
+~~~~~~~~~~~~~~~~
 
 Das optionale Feld ``unique_name`` kann verwendet werden, um sicherzustellen,
 dass eine Webaktion nicht aus versehen mehrmals erstellt wird.
@@ -505,7 +545,7 @@ antwortet der Server mit ``400 Bad Request``:
 .. _target-url:
 
 Ziel-URL
---------
+~~~~~~~~
 
 Wenn die Webaktionen an ihrem Darstellungsort in GEVER angezeigt werden, werden
 der Ziel-URL zwei Querystring-Parameter angehängt:

--- a/opengever/api/actions.py
+++ b/opengever/api/actions.py
@@ -1,0 +1,59 @@
+from opengever.base.interfaces import IOpengeverBaseLayer
+from opengever.webactions.interfaces import IWebActionsProvider
+from plone.restapi.interfaces import IExpandableElement
+from plone.restapi.serializer.converters import json_compatible
+from plone.restapi.services.actions.get import Actions
+from plone.restapi.services.actions.get import ActionsGet
+from zope.component import adapter
+from zope.component import queryMultiAdapter
+from zope.interface import implementer
+from zope.interface import Interface
+
+
+WEBACTION_ATTRIBUTE_WHITELIST = [
+    'action_id',
+    'title',
+    'target_url',
+    'display',
+    'mode',
+]
+
+
+@implementer(IExpandableElement)
+@adapter(Interface, IOpengeverBaseLayer)
+class GeverActions(Actions):
+
+    def __call__(self, expand=False):
+        actions = super(GeverActions, self).__call__(expand=expand)
+
+        if not expand:
+            return actions
+
+        self.extend_with_webactions(actions.get('actions'))
+
+        return actions
+
+    def extend_with_webactions(self, actions):
+        """Extends the plone actions with a new category called `webactions`.
+
+        This category includes all available webactions for the current
+        environment (context, user, permissions, webaction-settings) in a flat
+        structure.
+        """
+        provider = queryMultiAdapter((self.context, self.request), IWebActionsProvider)
+
+        if not provider:
+            return
+
+        webactions = [
+            {key: webaction.get(key) for key in WEBACTION_ATTRIBUTE_WHITELIST}
+            for webaction in provider.get_webactions(flat=True)]
+
+        if webactions:
+            actions['webactions'] = json_compatible(webactions)
+
+
+class GeverActionsGet(ActionsGet):
+    def reply(self):
+        actions = GeverActions(self.context, self.request)
+        return actions(expand=True)["actions"]

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -55,6 +55,20 @@
   <adapter factory=".todo.DeserializeToDoFromJson" />
   <adapter factory=".mail.DeserializeMailFromJson" />
 
+  <adapter
+      factory=".actions.GeverActions"
+      name="actions"
+      />
+
+  <plone:service
+      method="GET"
+      for="zope.interface.Interface"
+      factory=".actions.GeverActionsGet"
+      name="@actions"
+      layer="opengever.base.interfaces.IOpengeverBaseLayer"
+      permission="zope2.View"
+      />
+
   <plone:service
       method="PATCH"
       for="opengever.document.document.IDocumentSchema"

--- a/opengever/webactions/interfaces.py
+++ b/opengever/webactions/interfaces.py
@@ -63,11 +63,14 @@ class IWebActionsProvider(Interface):
     webactions for a given user on a given context.
     """
 
-    def get_webactions(self, display=None):
+    def get_webactions(self, display=None, flat=False):
         """Returns a dictionary of all available webactions per display location
         ('display' location as key and list of webactions for that location as
         values). If display is passed, only webactions for that display type are
         returned.
+
+        If flat is true, it will return a list of the available webactions
+        instead a dictionary.
         """
 
 

--- a/opengever/webactions/provider.py
+++ b/opengever/webactions/provider.py
@@ -126,11 +126,15 @@ class WebActionsProvider(object):
     def _filter_action_data(self, action):
         return dict((key, action.get(key)) for key in self._attributes_to_keep)
 
-    def get_webactions(self, display=None):
+    def get_webactions(self, display=None, flat=False):
         webactions = self._get_webactions_for_context()
         if display is not None:
             webactions = self._filter_for_display(display, webactions)
         webactions = self._sort(self._filter_for_user(webactions))
+
+        if flat:
+            return webactions
+
         webactions_dict = defaultdict(list)
         for webaction in webactions:
             webactions_dict[webaction["display"]].append(

--- a/opengever/webactions/tests/test_webactions_provider.py
+++ b/opengever/webactions/tests/test_webactions_provider.py
@@ -88,6 +88,15 @@ class TestWebActionProvider(TestWebActionBase):
 
         self.assertDictEqual(expected_data, webactions)
 
+    def test_webaction_provider_returns_a_list_if_requesting_flat_structure(self):
+        self.login(self.regular_user)
+        provider = getMultiAdapter((self.dossier, self.request), IWebActionsProvider)
+
+        webactions = provider.get_webactions(flat=True)
+
+        self.assertEqual(['Action 1', 'Action 2', 'Action 3'],
+                         [action.get('title') for action in webactions])
+
     def test_webaction_provider_only_returns_enabled_actions(self):
         self.login(self.regular_user)
         provider = getMultiAdapter((self.dossier, self.request), IWebActionsProvider)


### PR DESCRIPTION
Currently, webactions are only manageable. To be able to display registered webactions in the UI, we have to expose registered webactions somewhere. We decided to integrate them into the `@actions` endpoint in a new category `webactions`.

This PR overrides the `@actions` endpoint for GEVER and extends the result with `webactions`. If there are no webactions available, it will return an empty list for the `webactions`-category.

Because a webaction consist of many attributes we don't want to expose to the end-user, we white-list the desired attributes for the serialized `webactions` in the `@actions` endpiont.

<img width="394" alt="Bildschirmfoto 2020-10-30 um 13 44 06" src="https://user-images.githubusercontent.com/557005/97706449-011d4e80-1ab6-11eb-896d-010d3e905fc1.png">

Pre-Discussion: https://4teamwork.slack.com/archives/C01BHEGBVU1/p1603815306027700

Jira: https://4teamwork.atlassian.net/browse/NE-65


## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


## Checklist (if applicable)

_Only applicable should be left and checked._

- API change:
  - [x] Documentation is updated
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Upgrade steps (changes in profile):
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
- DB-Schema migration
  - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
  - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value
