### PR TITLE
Use UID instead of oguid as token in DossierTemplatesVocabulary.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,7 @@ Changelog
 - Agenda-item attachments are now ordered based on the position in the relationField. [elioschmutz]
 - Remove the limit for facets returned in the listing API endpoint. [Kevin Bieri]
 - Use oguid instead of intId as token in DossierTemplatesVocabulary. [tinagerber]
+- Use UID instead of intId as token in DossierTemplatesVocabulary. [tinagerber, elioschmutz]
 - `@@task_report`-view supports task lookup by the ressource-id through the `tasks` parameter. [elioschmutz]
 - Ensure `document_author` and `SearchableText` indices are dropped from catalog. [deiferni]
 - Extend @config endpoint with application type. [tinagerber]

--- a/docs/public/dev-manual/api/dossier_from_template.rst
+++ b/docs/public/dev-manual/api/dossier_from_template.rst
@@ -22,7 +22,7 @@ Zusätzlich können auch die anderen Felder des :ref:`label-dossier-schema`-Sche
        Accept: application/json
 
        {
-        "template": {"token": "fd:12345"},
+        "template": {"token": "1234567890"},
         "description": "Dossier description"
         "responsible": "rolf.ziegler",
         "title": "Dossier title"

--- a/opengever/dossier/dossiertemplate/form.py
+++ b/opengever/dossier/dossiertemplate/form.py
@@ -62,7 +62,7 @@ def get_dossier_templates(context):
     for template in templates:
         terms.append(SimpleVocabulary.createTerm(
             template,
-            Oguid.for_object(template),
+            template.UID(),
             template.title))
 
     return SimpleVocabulary(terms)


### PR DESCRIPTION
This PR is a follow-u pr of #6709 

We want to use the vocabulary in combination with a selection-widget which is based on solr.
Because we don't indexed the OGUID in solr, we're not able to intersect vocabulary items and solr items.

This PR now uses the `UID` instead which is already indexed in solr.

Jira: https://4teamwork.atlassian.net/browse/NE-43

Prediscussed with @njohner: https://4teamwork.atlassian.net/browse/NE-43?focusedCommentId=19007

> While we might want to try to uniformly return OGUIDs everywhere in the future, this is not a realistic option right now. Indexing the OGUID would also be very expensive, as it is not in the catalog, it would require an upgrade step that wakes all the objects from the catalog…

> So for now I advised that we go with the UID. If we ever decide to index the OGUID, and start using it everywhere in the API, we will anyway have to adapt the external applications.
## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [ ] Changelog entry
- [ ] Link to issue (Jira or GitHub) and backlink in issue (Jira)


## Checklist (if applicable)

_Only applicable should be left and checked._

- API change:
  - [x] Documentation is updated
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Upgrade steps (changes in profile):
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
- DB-Schema migration
  - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
  - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value
