### PR TITLE
Add debug patches to hunt for out of sync modified (catalog v.s. objects).

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 ----------------------
 
 - Delete old upgrade steps up to and including 2018.5.7. [njohner]
+- Add monkey-patch to track out of sync modified. [deiferni]
 - Agenda-item attachments are now ordered based on the position in the relationField. [elioschmutz]
 - Remove the limit for facets returned in the listing API endpoint. [Kevin Bieri]
 - `@actions` endpoint also returns available webactions. [elioschmutz]

--- a/opengever/base/monkey/patches/__init__.py
+++ b/opengever/base/monkey/patches/__init__.py
@@ -34,6 +34,8 @@ from .tz_for_log import PatchZ2LogTimezone
 from .verify_object_paste import PatchCopyContainerVerifyObjectPaste
 from .webdav_lock_timeout import PatchWebDAVLockTimeout
 from .workflowtool import PatchWorkflowTool
+from opengever.debug import debug_modified_out_of_sync_env_var_is_set
+from opengever.debug.patches.modified_out_of_sync import PatchConnectionRegister
 from opengever.readonly import readonly_env_var_is_set
 
 
@@ -77,3 +79,8 @@ if readonly_env_var_is_set():
     PatchCheckPermission()()
     PatchPloneUserAllowed()()
     PatchPloneUserGetRolesInContext()()
+
+# This patch helps debugging an issue where modified of objects is out of date
+# with modified in the catalog.
+if debug_modified_out_of_sync_env_var_is_set():
+    PatchConnectionRegister()()

--- a/opengever/debug/__init__.py
+++ b/opengever/debug/__init__.py
@@ -1,0 +1,5 @@
+import os
+
+
+def debug_modified_out_of_sync_env_var_is_set():
+    return bool(os.environ.get('GEVER_DEBUG_MODIFIED_OUF_OF_SYNC'))

--- a/opengever/debug/patches/modified_out_of_sync.py
+++ b/opengever/debug/patches/modified_out_of_sync.py
@@ -1,0 +1,103 @@
+from opengever.base.monkey.patching import MonkeyPatch
+from opengever.base.sentry import log_msg_to_sentry
+from opengever.debug.stacktrace import save_stacktrace
+from opengever.debug.write_on_read_tracing import format_instruction
+from plone import api
+from plone.dexterity.interfaces import IDexterityContent
+from plone.uuid.interfaces import IUUID
+from plone.uuid.interfaces import IUUIDAware
+from ZODB.POSException import ConflictError
+import logging
+import transaction
+
+
+log = logging.getLogger('opengever.debug')
+
+
+def check_modified_in_sync(succeeded, obj, instruction):
+    """Post-commit hook to check that modified is in sync after commit."""
+    if not succeeded:
+        return
+
+    # the object is not aq-wrapped so we query by its UID
+    obj_uid = IUUID(obj)
+    query = {'UID': obj_uid}
+    catalog = api.portal.get_tool('portal_catalog')
+    brains = catalog.unrestrictedSearchResults(query)
+    if len(brains) != 1:
+        log.warn(u'Error when querying for: {} {}'.format(
+            repr(obj), query)
+        )
+
+    brain = brains[0]
+    if brain.modified == obj.modified():
+        # all is well if modified is equal
+        return
+
+    # we have an object where object modification date is out
+    # of sync with the modification date in catalog, we log it
+    # and report the issue to sentry, also providing the
+    # already serialized traceback
+    msg = u'Out of sync modified detected.'
+    formatted_traceback = format_instruction(instruction)
+
+    log.warning(msg)
+    log.warning(formatted_traceback)
+    log.warning(u'object: {}, uid: {}'.format(
+        repr(obj), obj_uid))
+
+    log_msg_to_sentry(
+        msg, context=obj, level='warning',
+        string_max_length=len(formatted_traceback),
+        extra={
+            'stacktrace': formatted_traceback,
+            'object_out_of_sync': repr(obj),
+            'object_out_of_sync_uid': obj_uid,
+        }
+    )
+
+
+class PatchConnectionRegister(MonkeyPatch):
+    """Patched version of ZODB.Connection.Connection.register to track
+    when modified becomes out of sync after an object has been changed.
+
+    Will register an after-commit hook for each dexterity content
+    object thas is changed/added. The hook will verify that modified is
+    in sync with the catalog and log to sentry if it detects an out of
+    sync state.
+
+    CAUTION: This will be called for every change to a persistent object,
+    be very careful here!
+    """
+    def __call__(self):
+        def register_patched_to_check_modified(self, obj):
+            orig_register_func(self, obj)
+
+            # only perform checks for dexterity content objects, skip
+            # everything else
+            if not IDexterityContent.providedBy(obj):
+                return
+
+            # we will get the object's IUUID in the post-commit hook, prevent
+            # registering it and saving the trace for objects that don't
+            # support IUUID for some reason
+            if not IUUIDAware.providedBy(obj):
+                return
+
+            try:
+                instruction = save_stacktrace(obj)
+                # we add a post-commit hook for just this object, each
+                # registered content object will have its own hook with its
+                # own traceback
+                transaction.get().addAfterCommitHook(
+                    check_modified_in_sync, args=[obj, instruction])
+            except ConflictError:
+                raise
+            except Exception, e:
+                log.warn('Error when trying to save stacktrace: {}'.format(
+                    str(e)))
+
+        from ZODB.Connection import Connection
+        locals()['__patch_refs__'] = False
+        orig_register_func = Connection.register
+        self.patch_refs(Connection, 'register', register_patched_to_check_modified)

--- a/opengever/debug/stacktrace.py
+++ b/opengever/debug/stacktrace.py
@@ -1,0 +1,48 @@
+from collections import namedtuple
+from ZODB.utils import u64
+import inspect
+import traceback
+
+
+# Lightweight object to keep a formatted traceback and associated info around
+AnnotatedTraceback = namedtuple(
+    'AnnotatedTraceback', ['oid', 'filename', 'line_no', 'extracted_tb'])
+
+
+def save_stacktrace(obj):
+    """Returns an `AnnotatedTraceback` object that contains a formatted stack
+    trace for the current frame and the OID of the object that has been
+    modified for possible logging at a later point in time.
+    """
+    tb_limit = 20
+    current_frame = inspect.currentframe()
+
+    # Outer two frames are in this module, so they're not interesting
+    frame = current_frame.f_back.f_back
+
+    filename = frame.f_code.co_filename
+    line_no = frame.f_lineno
+    extracted_tb = traceback.extract_stack(frame, limit=tb_limit)
+    oid = hex(u64(obj._p_oid))
+    instruction = AnnotatedTraceback(oid, filename, line_no, extracted_tb)
+
+    # Avoid leaking frames
+    del current_frame
+    del frame
+
+    return instruction
+
+
+def format_instruction(instruction):
+    """Render the information from an `AnnotatedTraceback` object (file name,
+    line number and formatted traceback) and an OID for display.
+    """
+    output = ['\n']
+    msg = 'DB write to obj with OID {oid} from code ' \
+          'in "{filename}", line {line_no}!'
+    msg = msg.format(**instruction._asdict())
+    output.append("=" * len(msg))
+    output.append(msg)
+    output.append("=" * len(msg))
+    output.append(''.join(traceback.format_list(instruction.extracted_tb)))
+    return '\n'.join(output)


### PR DESCRIPTION
With this PR we add patches that help to hunt down the very rarely occurring out of sync modified of catalog v.s. content objects. We suspect there is a missing reindex when the attribute is set. I have not managed to figure it out locally, so best strategy IMO would be to enable the patches on our dev system and wait.

The patches are inactive by default and should only be activated on a non-production system for the moment. They are designed in such a way that they can be activated for a deployment via buildout configuration in the `instance` section:

```
[instance]
environment-vars +=
    GEVER_DEBUG_MODIFIED_OUF_OF_SYNC True
```

We want to activate them on dev for now and as the issue occurs very rarely activation has to be persistent across instance restarts.

- Write on read tracing has already provided functionality for serializing stack-traces in a safe and unobtrusive way. I have extracted the methods into their own module and also and slightly refactored them to enable easier re-use.
- I have opted to put the patch into `opengever.debug` to clarify it's intention as a (potentially temporary) debug tool. 
- I had to change sentry settings as described in https://4teamwork.atlassian.net/browse/CA-190?focusedCommentId=19057.
- A sample sentry issue can be found at https://sentry.4teamwork.ch/organizations/sentry/issues/69656/?project=17.

As we now potentially patch the same method as write on read tracing i had to slightly change how write on read tracing retrieves and stores a reference to the patched methods to avoid side-effects between the two patches. Namely we need to prevent write on read tracing from erroneously unpatching the monkey patches provided in this PR in case they are activated. To achieve this we no store references to the patched method a patch time and not a module load
time:
- We now set the module-global reference to the original method in a deferred way at patch time.
- Some extra paranoia is added in form of additional assertions to make sure we don't set method references to
`None` by mistake.
- Also patching and unpatching is now protected by an additional lock to prevent simultaneous requests in separate threads from making a mess.
- The comparisons/assertions had to be rewritten slightly in order to work with the difference of `unbound method` and `function ` in `python2`, in case of `unbound method` we use `__func__` to compare against the wrapped function instead.
- To clarify entry points for clients the two separate patching and unpatching methods have been inlined into one method each.

I have tested:
- ✅  &nbsp;Reporting/logging modified to sentry works correctly and contains the serialized stacktrace (see above for link).
- ✅  &nbsp;Patching/unpatching write on read tracing still works.
- ✅  &nbsp;Patching/unpatching write on read tracing twice will hit the correct assertions.
- ✅  &nbsp;Patching/unpatching write on read tracing will leave the modified patch in place, should it be active.
- ✅  &nbsp;The write on read report is still correctly written and contains the serialized stacktrace.

_Nevertheless i'd be really glad for an extra careful review here, best for a local test-run to hunt for edge-cases i could not have spotted 😓_

Jira: https://4teamwork.atlassian.net/browse/CA-190

ToDo:
- [x] 🚧  &nbsp;cleanup https://sentry.4teamwork.ch/organizations/sentry/issues/69656/?project=17 once this PR is either merged or closed.
- [ ] 🚧  &nbsp;activate on dev once this is merged (separate PR).

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
