### PR TITLE
Fix the Workspace `@participations` endpoint for NullActors

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2020.13.0 (unreleased)
 ----------------------
 
+- Fix the Workspace `@participations` endpoint for NullActors. [njohner]
 - Delete old upgrade steps up to and including 2018.5.7. [njohner]
 - Add monkey-patch to track out of sync modified. [deiferni]
 - Agenda-item attachments are now ordered based on the position in the relationField. [elioschmutz]

--- a/opengever/api/participations.py
+++ b/opengever/api/participations.py
@@ -46,9 +46,13 @@ class ParticipationTraverseService(Service):
         # a properly implemented actor serializer.
         #
         # This will be tracked in https://4teamwork.atlassian.net/browse/CA-406
-        serialized_actor = getMultiAdapter(
-            (actor.represents(), self.request),
-            interface=ISerializeToJsonSummary)()
+        represented_obj = actor.represents()
+        if represented_obj:
+            serialized_actor = getMultiAdapter(
+                (represented_obj, self.request),
+                interface=ISerializeToJsonSummary)()
+        else:
+            serialized_actor = {}
 
         return {
             '@id': '{}/@participations/{}'.format(managing_context.absolute_url(), actor.identifier),

--- a/opengever/api/tests/test_participation.py
+++ b/opengever/api/tests/test_participation.py
@@ -174,6 +174,32 @@ class TestParticipationGet(IntegrationTestCase):
             'The admin should not be able to manage himself')
 
     @browsing
+    def test_manages_invalid_participant(self, browser):
+        self.login(self.manager, browser)
+
+        self.workspace.__ac_local_roles__ = {'invalid_participant': ['WorkspaceAdmin']}
+
+        response = browser.open(
+            self.workspace.absolute_url() + '/@participations',
+            method='GET',
+            headers=http_headers(),
+        ).json
+
+        self.assertItemsEqual(
+            [{u'@id': u'http://nohost/plone/workspaces/workspace-1/@participations/invalid_participant',
+              u'@type': u'virtual.participations.null',
+              u'is_editable': True,
+              u'participant': {u'@id': None,
+                               u'@type': None,
+                               u'active': None,
+                               u'email': None,
+                               u'id': u'invalid_participant',
+                               u'is_local': None,
+                               u'title': u'invalid_participant'},
+              u'role': {u'title': u'Admin', u'token': u'WorkspaceAdmin'}}],
+            response.get('items'))
+
+    @browsing
     def test_current_logged_in_admin_cannot_edit_himself(self, browser):
         self.login(self.workspace_admin, browser)
 

--- a/opengever/ogds/base/actor.py
+++ b/opengever/ogds/base/actor.py
@@ -163,7 +163,7 @@ class NullActor(object):
         return self.identifier or u''
 
     def represents(self):
-        raise None
+        return None
 
     def representatives(self):
         return []
@@ -198,7 +198,7 @@ class SystemActor(object):
         return u''
 
     def represents(self):
-        raise None
+        return None
 
     def representatives(self):
         return []


### PR DESCRIPTION
`@participations` endpoint was failing for participations with a `participant_id` that could not be resolved to an actor. This is because the `represents` from the `NullActor` was broken. It now returns `None`, as it probably was intended to, which also has to be handled in the `@participations` endpoint.

With this PR we fix this issue, but we should probably remove the `represents` from the `Actor` and simply return an actor in this `@participations` endpoint. This endpoint was forgotten in https://github.com/4teamwork/opengever.core/pull/6713. I will either make a PR for this adaptation or open a new story.

For https://4teamwork.atlassian.net/browse/CA-1185

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)