### PR TITLE
Fix resolving subdossiers when Teamraum Connect feature is enabled.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 ----------------------
 
 - Convert bytestring values for IOpengeverBase.description field to unicode instead of raising an error. [elioschmutz]
+- Fix resolving subdossiers when Teamraum Connect feature is enabled. [lgraf]
 - Fix the Workspace `@participations` endpoint for NullActors. [njohner]
 - Delete old upgrade steps up to and including 2018.5.7. [njohner]
 - Add monkey-patch to track out of sync modified. [deiferni]

--- a/opengever/dossier/base.py
+++ b/opengever/dossier/base.py
@@ -34,6 +34,7 @@ from Products.CMFPlone.interfaces.siteroot import IPloneSiteRoot
 from zExceptions import Unauthorized
 from zope.component import adapter
 from zope.component import getUtility
+from zope.component import queryAdapter
 from zope.component import queryMultiAdapter
 from zope.interface import implementer
 from zope.interface import Interface
@@ -306,9 +307,15 @@ class DossierContainer(Container):
     def is_linked_to_active_workspaces(self):
         if not is_workspace_client_feature_enabled():
             return False
-        params = {'review_state': 'opengever_workspace--STATUS--active'}
+
         with elevated_privileges():
-            return bool(ILinkedWorkspaces(self).list_non_cached(**params)['items_total'])
+            linked_workspaces_adapter = queryAdapter(self, ILinkedWorkspaces)
+            if not linked_workspaces_adapter:
+                return False
+
+            params = {'review_state': 'opengever_workspace--STATUS--active'}
+            active_workspaces = linked_workspaces_adapter.list_non_cached(**params)['items_total']
+            return bool(active_workspaces)
 
     def is_all_checked_in(self):
         """Check if all documents in this path are checked in."""

--- a/opengever/dossier/tests/test_resolve.py
+++ b/opengever/dossier/tests/test_resolve.py
@@ -1478,6 +1478,18 @@ class TestResolveConditionsWithWorkspaceClientFeatureEnabled(ResolveTestHelper,
                                 ['The dossier has been succesfully resolved.'])
 
     @browsing
+    def test_subdossier_is_resolvable_with_activated_workspace_client(self, browser):
+        subdossier = create(Builder('dossier').within(self.dossier))
+
+        with self.workspace_client_env():
+            self.grant('Reviewer', *api.user.get_roles())
+            browser.login()
+            self.resolve(subdossier, browser)
+            self.assert_resolved(subdossier)
+            self.assert_success(subdossier, browser,
+                                ['The subdossier has been succesfully resolved.'])
+
+    @browsing
     def test_dossier_is_resolved_when_deactivated_workspace_is_linked(self, browser):
         with self.workspace_client_env():
             browser.exception_bubbling = True


### PR DESCRIPTION
This fixes resolving subdossiers when the Teamraum Connect feature is enabled.

Subdossiers are not supposed to have linked workspaces (only main dossiers may). But because the `ILinkedWorkspace` adapter [deliberately raises a `ComponentLookupError`](https://github.com/4teamwork/opengever.core/blob/master/opengever/workspaceclient/linked_workspaces.py#L83-L84) when instantiated for a dossier, which would otherwise be adaptable just fine, that lead to a failure when checking dossier resolution preconditions.

This is a quick fix in order to still get it in before we cut the release. Overall, I would really question the approach of raising `ComponentLookupError` there instead of just returning empty lists etc.. But for now I fixed it in the most local way possible, in order to not destabilize the code base any more with an emergency fix.  

Jira: https://4teamwork.atlassian.net/browse/CA-1129


## Checklist (Must have)

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
