### PR TITLE
Return participant_actor in workspace participations endpoint.

### DIFF
--- a/docs/public/dev-manual/api/workspace/participation.rst
+++ b/docs/public/dev-manual/api/workspace/participation.rst
@@ -14,6 +14,8 @@ Es gibt folgende Beteiligungsrollen:
 - WorkspaceMember
 - WorkspaceGuest
 
+Diese Endpoints liefern zur Zeit sowohl ``participant`` als auch ``participant_actor`` zurück. ``participant`` wird in einer späteren Version jedoch nicht mehr unterstützt werden, und wird durch ``participant_actor`` abgelöst.
+
 
 Beteiligungen abrufen:
 ----------------------
@@ -44,6 +46,10 @@ Ein GET Request gibt die Beteiligungen sowie die aktiven Einladungen eines Inhal
             "title": "Admin",
             "token": "WorkspaceAdmin"
           },
+          "participant_actor": {
+            "@id": "http://localhost:8081/fd/@actors/max.muster",
+            "identifier": "max.muster",
+          },
           "participant": {
             "@id": "http://localhost:8081/fd/@ogds-users/max.muster",
             "@type": "virtual.ogds.user",
@@ -58,6 +64,10 @@ Ein GET Request gibt die Beteiligungen sowie die aktiven Einladungen eines Inhal
           "@id": "http://localhost:8081/fd/workspaces/workspace-41/@participations/afi_benutzer",
           "@type": "virtual.participations.group",
           "is_editable": true,
+          "participant_actor": {
+            "@id": "http://localhost:8081/fd/@actors/afi_benutzer",
+            "identifier": "afi_benutzer",
+          },
           "participant": {
             "@id": "http://localhost:8081/fd/@ogds-groups/afi_benutzer",
             "@type": "virtual.ogds.group",
@@ -102,6 +112,10 @@ Ein GET Request auf die jeweilige Resource gibt die Beteiligungen oder die Einla
       "role": {
         "title": "Admin",
         "token": "WorkspaceAdmin"
+      },
+      "participant_actor": {
+        "@id": "http://localhost:8081/fd/@actors/max.muster",
+        "identifier": "max.muster",
       },
       "participant": {
         "@id": "http://localhost:8081/fd/@ogds-users/max.muster",
@@ -148,7 +162,7 @@ In einem selbst verwalteten Teamraum-Ordner (Vererbung wurde unterbrochen) könn
 
        {
          "participant": "maria.meier",
-         "role": "WorkspaceMember"
+         "role": "WorkspaceAdmin"
        }
 
 **Beispiel-Response**:
@@ -166,13 +180,17 @@ In einem selbst verwalteten Teamraum-Ordner (Vererbung wurde unterbrochen) könn
         "title": "Admin",
         "token": "WorkspaceAdmin"
       },
+      "participant_actor": {
+        "@id": "http://localhost:8081/fd/@actors/maria.meier",
+        "identifier": "maria.meier",
+      },
       "participant": {
-        "@id": "http://localhost:8081/fd/@ogds-users/max.muster",
+        "@id": "http://localhost:8081/fd/@ogds-users/maria.meier",
         "@type": "virtual.ogds.user",
         "active": true,
-        "email": "max.muster@example.com",
-        "title": "Max Muster (max.muster)",
-        "id": "max.muster",
+        "email": "maria.meier@example.com",
+        "title": "Maria Meier (maria.meier)",
+        "id": "maria.meier",
         "is_local": null
     }
 

--- a/opengever/api/participations.py
+++ b/opengever/api/participations.py
@@ -1,3 +1,4 @@
+from opengever.api.actors import serialize_actor_id_to_json_summary
 from opengever.base.role_assignments import RoleAssignmentManager
 from opengever.base.role_assignments import SharingRoleAssignment
 from opengever.ogds.base.actor import Actor
@@ -31,21 +32,15 @@ class ParticipationTraverseService(Service):
         return self
 
     def prepare_response_item(self, participant):
-        actor = Actor.lookup(participant.get('token'))
         role = PARTICIPATION_ROLES.get(participant.get('roles')[0])
         managing_context = self.context.get_context_with_local_roles()
 
         # We manually serialize the actors'representer and extract the desired
         # properties to get a homogeneous json result for different actor types
-        #
-        # We do not use an Actor serializer here because it does not exist
-        # right now and needs more specification before we can implement it
-        # properly.
-        #
-        # The current implementation can be refactored as soon we have
-        # a properly implemented actor serializer.
-        #
-        # This will be tracked in https://4teamwork.atlassian.net/browse/CA-406
+        # XXX deprecated
+        # We should use the participant_actor instead which will also avoid
+        # having to resolve the actor in this endpoint.
+        actor = Actor.lookup(participant.get('token'))
         represented_obj = actor.represents()
         if represented_obj:
             serialized_actor = getMultiAdapter(
@@ -62,6 +57,8 @@ class ParticipationTraverseService(Service):
                 'token': role.id,
                 'title': role.translated_title(self.request),
             },
+            'participant_actor': serialize_actor_id_to_json_summary(
+                    participant.get('token')),
             'participant': {
                 '@id': serialized_actor.get('@id'),
                 '@type': serialized_actor.get('@type'),

--- a/opengever/api/tests/test_participation.py
+++ b/opengever/api/tests/test_participation.py
@@ -65,6 +65,9 @@ class TestParticipationGet(IntegrationTestCase):
             [{u'@id': u'http://nohost/plone/workspaces/workspace-1/@participations/beatrice.schrodinger',
               u'@type': u'virtual.participations.user',
               u'is_editable': True,
+              u'participant_actor': {
+                  u'@id': u'http://nohost/plone/@actors/beatrice.schrodinger',
+                  u'identifier': u'beatrice.schrodinger'},
               u'participant': {u'@id': u'http://nohost/plone/@ogds-users/beatrice.schrodinger',
                                u'@type': u'virtual.ogds.user',
                                u'active': True,
@@ -76,6 +79,9 @@ class TestParticipationGet(IntegrationTestCase):
              {u'@id': u'http://nohost/plone/workspaces/workspace-1/@participations/fridolin.hugentobler',
               u'@type': u'virtual.participations.user',
               u'is_editable': True,
+              u'participant_actor': {
+                  u'@id': u'http://nohost/plone/@actors/fridolin.hugentobler',
+                  u'identifier': u'fridolin.hugentobler'},
               u'participant': {u'@id': u'http://nohost/plone/@ogds-users/fridolin.hugentobler',
                                u'@type': u'virtual.ogds.user',
                                u'active': True,
@@ -87,6 +93,9 @@ class TestParticipationGet(IntegrationTestCase):
              {u'@id': u'http://nohost/plone/workspaces/workspace-1/@participations/gunther.frohlich',
               u'@type': u'virtual.participations.user',
               u'is_editable': False,
+              u'participant_actor': {
+                  u'@id': u'http://nohost/plone/@actors/gunther.frohlich',
+                  u'identifier': u'gunther.frohlich'},
               u'participant': {u'@id': u'http://nohost/plone/@ogds-users/gunther.frohlich',
                                u'@type': u'virtual.ogds.user',
                                u'active': True,
@@ -98,6 +107,9 @@ class TestParticipationGet(IntegrationTestCase):
              {u'@id': u'http://nohost/plone/workspaces/workspace-1/@participations/hans.peter',
               u'@type': u'virtual.participations.user',
               u'is_editable': True,
+              u'participant_actor': {
+                  u'@id': u'http://nohost/plone/@actors/hans.peter',
+                  u'identifier': u'hans.peter'},
               u'participant': {u'@id': u'http://nohost/plone/@ogds-users/hans.peter',
                                u'@type': u'virtual.ogds.user',
                                u'active': True,
@@ -109,6 +121,9 @@ class TestParticipationGet(IntegrationTestCase):
              {u'@id': u'http://nohost/plone/workspaces/workspace-1/@participations/projekt_a',
               u'@type': u'virtual.participations.group',
               u'is_editable': True,
+              u'participant_actor': {
+                  u'@id': u'http://nohost/plone/@actors/projekt_a',
+                  u'identifier': u'projekt_a'},
               u'participant': {u'@id': u'http://nohost/plone/@ogds-groups/projekt_a',
                                u'@type': u'virtual.ogds.group',
                                u'active': True,
@@ -117,7 +132,7 @@ class TestParticipationGet(IntegrationTestCase):
                                u'is_local': False,
                                u'title': u'Projekt A'},
               u'role': {u'title': u'Member', u'token': u'WorkspaceMember'}}],
-             response.get('items'))
+            response.get('items'))
 
     @browsing
     def test_list_all_current_participants_in_folder_lists_participants_of_the_workspace(self, browser):
@@ -189,6 +204,9 @@ class TestParticipationGet(IntegrationTestCase):
             [{u'@id': u'http://nohost/plone/workspaces/workspace-1/@participations/invalid_participant',
               u'@type': u'virtual.participations.null',
               u'is_editable': True,
+              u'participant_actor': {
+                  u'@id': u'http://nohost/plone/@actors/invalid_participant',
+                  u'identifier': u'invalid_participant'},
               u'participant': {u'@id': None,
                                u'@type': None,
                                u'active': None,
@@ -279,6 +297,9 @@ class TestParticipationGet(IntegrationTestCase):
             {u'@id': u'http://nohost/plone/workspaces/workspace-1/@participations/hans.peter',
              u'@type': u'virtual.participations.user',
              u'is_editable': True,
+             u'participant_actor': {
+                  u'@id': u'http://nohost/plone/@actors/hans.peter',
+                  u'identifier': u'hans.peter'},
              u'participant': {u'@id': u'http://nohost/plone/@ogds-users/hans.peter',
                               u'@type': u'virtual.ogds.user',
                               u'active': True,
@@ -305,6 +326,9 @@ class TestParticipationGet(IntegrationTestCase):
             {u'@id': u'http://nohost/plone/workspaces/workspace-1/@participations/projekt_a',
              u'@type': u'virtual.participations.group',
              u'is_editable': True,
+             u'participant_actor': {
+                  u'@id': u'http://nohost/plone/@actors/projekt_a',
+                  u'identifier': u'projekt_a'},
              u'participant': {u'@id': u'http://nohost/plone/@ogds-groups/projekt_a',
                               u'@type': u'virtual.ogds.group',
                               u'active': True,


### PR DESCRIPTION
The workspace `@participations` endpoint got forgotten in https://github.com/4teamwork/opengever.core/pull/6713. We now also return the `participant_actor` in that endpoint, so that in the long run we can remove the custom serialized `participant` from the response.

For  https://4teamwork.atlassian.net/browse/CA-406

Definition of Done: https://4teamwork.atlassian.net/wiki/spaces/CHX4TW/pages/917562/


## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [ ] Changelog entry: No CL needed IMO, this should have been included in the PR adding the `@actors` endpoint
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


## Checklist (if applicable)

_Only applicable should be left and checked._

- API change:
  - [x] Documentation is updated
  - If breaking:
    - [x] api-change label added: as for the other PR part of that story, not breaking but should be announced.
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed