### PR TITLE
Interpolate target_url for webactions exposed in the @actions endpoint

### DIFF
--- a/opengever/api/actions.py
+++ b/opengever/api/actions.py
@@ -1,5 +1,6 @@
 from opengever.base.interfaces import IOpengeverBaseLayer
 from opengever.webactions.interfaces import IWebActionsProvider
+from opengever.webactions.renderer import WebActionsSafeDataGetter
 from plone.restapi.interfaces import IExpandableElement
 from plone.restapi.serializer.converters import json_compatible
 from plone.restapi.services.actions.get import Actions
@@ -40,14 +41,10 @@ class GeverActions(Actions):
         environment (context, user, permissions, webaction-settings) in a flat
         structure.
         """
-        provider = queryMultiAdapter((self.context, self.request), IWebActionsProvider)
-
-        if not provider:
-            return
-
+        data_getter = WebActionsSafeDataGetter(self.context, self.request, None)
         webactions = [
             {key: webaction.get(key) for key in WEBACTION_ATTRIBUTE_WHITELIST}
-            for webaction in provider.get_webactions(flat=True)]
+            for webaction in data_getter.get_webactions_data(flat=True)]
 
         if webactions:
             actions['webactions'] = json_compatible(webactions)

--- a/opengever/api/actions.py
+++ b/opengever/api/actions.py
@@ -1,23 +1,12 @@
 from opengever.base.interfaces import IOpengeverBaseLayer
-from opengever.webactions.interfaces import IWebActionsProvider
 from opengever.webactions.renderer import WebActionsSafeDataGetter
 from plone.restapi.interfaces import IExpandableElement
 from plone.restapi.serializer.converters import json_compatible
 from plone.restapi.services.actions.get import Actions
 from plone.restapi.services.actions.get import ActionsGet
 from zope.component import adapter
-from zope.component import queryMultiAdapter
 from zope.interface import implementer
 from zope.interface import Interface
-
-
-WEBACTION_ATTRIBUTE_WHITELIST = [
-    'action_id',
-    'title',
-    'target_url',
-    'display',
-    'mode',
-]
 
 
 @implementer(IExpandableElement)
@@ -42,9 +31,7 @@ class GeverActions(Actions):
         structure.
         """
         data_getter = WebActionsSafeDataGetter(self.context, self.request, None)
-        webactions = [
-            {key: webaction.get(key) for key in WEBACTION_ATTRIBUTE_WHITELIST}
-            for webaction in data_getter.get_webactions_data(flat=True)]
+        webactions = data_getter.get_webactions_data(flat=True)
 
         if webactions:
             actions['webactions'] = json_compatible(webactions)

--- a/opengever/api/tests/test_actions.py
+++ b/opengever/api/tests/test_actions.py
@@ -869,6 +869,8 @@ class TestWebActionsIntegration(IntegrationTestCase):
                 u'action_id': 0,
                 u'display': u'actions-menu',
                 u'mode': u'self',
+                u'icon_data': None,
+                u'icon_name': None,
                 u'target_url': u'http://localhost/foo?location=%2Fplone%2Fordnungssystem%2Ffuhrung%2Fvertrage-und-vereinbarungen%2Fdossier-1&context=http%3A%2F%2Fnohost%2Fplone%2Fordnungssystem%2Ffuhrung%2Fvertrage-und-vereinbarungen%2Fdossier-1&orgunit=fa',
                 u'title': u'Open in ExternalApp'
             }],

--- a/opengever/api/tests/test_actions.py
+++ b/opengever/api/tests/test_actions.py
@@ -857,7 +857,8 @@ class TestWebActionsIntegration(IntegrationTestCase):
     @browsing
     def test_webaction_serialization_in_actions_endpoint(self, browser):
         self.login(self.webaction_manager, browser=browser)
-        create(Builder('webaction'))
+        create(Builder('webaction').having(
+            target_url='http://localhost/foo?location={path}'))
 
         self.login(self.regular_user, browser)
         browser.open(self.dossier, view='/@actions',
@@ -868,7 +869,7 @@ class TestWebActionsIntegration(IntegrationTestCase):
                 u'action_id': 0,
                 u'display': u'actions-menu',
                 u'mode': u'self',
-                u'target_url': u'http://example.org/endpoint',
+                u'target_url': u'http://localhost/foo?location=%2Fplone%2Fordnungssystem%2Ffuhrung%2Fvertrage-und-vereinbarungen%2Fdossier-1&context=http%3A%2F%2Fnohost%2Fplone%2Fordnungssystem%2Ffuhrung%2Fvertrage-und-vereinbarungen%2Fdossier-1&orgunit=fa',
                 u'title': u'Open in ExternalApp'
             }],
             browser.json.get('webactions'))

--- a/opengever/webactions/provider.py
+++ b/opengever/webactions/provider.py
@@ -35,7 +35,7 @@ class WebActionsProvider(object):
     """
 
     _attributes_to_keep = ("title", "target_url", "mode", "action_id",
-                           "icon_name", "icon_data")
+                           "icon_name", "icon_data", "display")
 
     def __init__(self, context, request):
         self.context = context
@@ -133,7 +133,7 @@ class WebActionsProvider(object):
         webactions = self._sort(self._filter_for_user(webactions))
 
         if flat:
-            return webactions
+            return map(self._filter_action_data, webactions)
 
         webactions_dict = defaultdict(list)
         for webaction in webactions:

--- a/opengever/webactions/renderer.py
+++ b/opengever/webactions/renderer.py
@@ -25,18 +25,20 @@ class WebActionsSafeDataGetter(object):
         self.request = request
         self.display = display
 
-    def get_webactions_data(self):
+    def get_webactions_data(self, flat=False):
         provider = queryMultiAdapter((self.context, self.request),
                                      IWebActionsProvider)
         if provider is None:
-            return dict()
+            return list() if flat else dict()
 
-        webactions_dict = provider.get_webactions(self.display)
-        return self._pre_formatting(webactions_dict)
+        webactions = provider.get_webactions(self.display, flat)
+        return self._pre_formatting(webactions)
 
-    def _pre_formatting(self, webactions_dict):
+    def _pre_formatting(self, webactions):
+        if isinstance(webactions, list):
+            return map(self._prepare_webaction_data, webactions)
         return dict((display, map(self._prepare_webaction_data, webactions))
-                    for display, webactions in webactions_dict.items())
+                    for display, webactions in webactions.items())
 
     def _prepare_webaction_data(self, action):
         data = {key: value if key in self._attributes_not_to_escape else escape_html(value)

--- a/opengever/webactions/tests/test_webactions_provider.py
+++ b/opengever/webactions/tests/test_webactions_provider.py
@@ -42,6 +42,7 @@ class TestWebActionProvider(TestWebActionBase):
                              'icon_name': None,
                              'mode': 'self',
                              'icon_data': None,
+                             'display': 'actions-menu',
                              'action_id': 0}
 
         self.action2_data = {'target_url': 'http://example.org/endpoint',
@@ -49,6 +50,7 @@ class TestWebActionProvider(TestWebActionBase):
                              'icon_name': None,
                              'mode': 'self',
                              'icon_data': None,
+                             'display': 'actions-menu',
                              'action_id': 1}
 
         self.action3_data = {'target_url': 'http://example.org/endpoint',
@@ -56,6 +58,7 @@ class TestWebActionProvider(TestWebActionBase):
                              'icon_name': None,
                              'mode': 'self',
                              'icon_data': None,
+                             'display': 'actions-menu',
                              'action_id': 2}
 
     def test_data_returned_by_webaction_provider(self):
@@ -79,6 +82,9 @@ class TestWebActionProvider(TestWebActionBase):
         storage = get_storage()
         storage.update(1, {"display": "action-buttons"})
         storage.update(2, {"display": "user-menu"})
+
+        self.action2_data['display'] = 'action-buttons'
+        self.action3_data['display'] = 'user-menu'
 
         expected_data = {'actions-menu': [self.action1_data],
                          'action-buttons': [self.action2_data],


### PR DESCRIPTION
This PR now uses the `WebActionsSafeDataGetter` instead directly the `IWebActionsProvider` adapter to lookup webactions in the `@actions` endpoint. This ensures, that the webaction target urls are interpolated properly and the fields are sanitized.

Currently, not flattened webactions from the `IWebActionsProvider` where filtered through: `_filter_action_data`. But not flattened. That's why we use `_filter_action_data` for flattened webactions now to get the same response for each type of representation. We have to whitelist the `display` attribute within the `IWebActionsProvider`. We need the `display` attribute in the serialized webactions for the `@actions` endpoint.

Jira: https://4teamwork.atlassian.net/browse/NE-65

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry (already exists from #6712 
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


## Checklist (if applicable)

_Only applicable should be left and checked._

- API change:
  - [ ] Documentation is updated
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Upgrade steps (changes in profile):
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
- DB-Schema migration
  - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
  - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value
