### PR TITLE
Convert bytestring values for IOpengeverBase.description field to unicode instead of raising an error.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2020.13.0 (unreleased)
 ----------------------
 
+- Convert bytestring values for IOpengeverBase.description field to unicode instead of raising an error. [elioschmutz]
 - Fix the Workspace `@participations` endpoint for NullActors. [njohner]
 - Delete old upgrade steps up to and including 2018.5.7. [njohner]
 - Add monkey-patch to track out of sync modified. [deiferni]

--- a/opengever/base/behaviors/base.py
+++ b/opengever/base/behaviors/base.py
@@ -3,6 +3,7 @@ from opengever.base import _
 from plone.app.dexterity.behaviors import metadata
 from plone.autoform.interfaces import IFormFieldProvider
 from plone.supermodel import model
+from Products.CMFPlone.utils import safe_unicode
 from zope import schema
 from zope.interface import Interface, alsoProvides
 
@@ -58,8 +59,16 @@ class OpenGeverBase(metadata.MetadataBase):
         return self.context.description
 
     def _set_description(self, value):
-        if isinstance(value, str):
-            raise ValueError('Description must be unicode.')
-        self.context.description = value
+        # Quickfix for: https://4teamwork.atlassian.net/browse/NE-247
+        #
+        # Content created through the plone.restapi without a description
+        # will have an empty bytestring as the default description. This
+        # We convert the value to unicode instead of raising an error.
+        #
+        # This means, we'll no longer detect bad data-types. So
+        # this fix will be reverted through the story
+        # https://4teamwork.atlassian.net/browse/CA-918 which will fix the
+        # main issue.
+        self.context.description = safe_unicode(value)
 
     description = property(_get_description, _set_description)

--- a/opengever/base/tests/test_base_behavior.py
+++ b/opengever/base/tests/test_base_behavior.py
@@ -1,5 +1,6 @@
 from ftw.testbrowser import browsing
 from ftw.testbrowser.pages import factoriesmenu
+from opengever.base.behaviors.base import IOpenGeverBase
 from opengever.testing import IntegrationTestCase
 
 
@@ -29,3 +30,13 @@ class TestBaseBehavior(IntegrationTestCase):
 
         common_fieldset = browser.css('fieldset').first
         self.assertEquals(['Common'], common_fieldset.css('legend').text)
+
+    def test_set_bytestring_for_descriptions_will_convert_it_to_unicode(self):
+        self.login(self.regular_user)
+        IOpenGeverBase(self.dossier).description = ''
+        self.assertIsInstance(IOpenGeverBase(self.dossier).description, unicode)
+
+    def test_set_bytestring_for_title_will_raise_an_error(self):
+        self.login(self.regular_user)
+        with self.assertRaises(ValueError):
+            IOpenGeverBase(self.dossier).title = ''


### PR DESCRIPTION
Jira: https://4teamwork.atlassian.net/browse/NE-247

This PR quick-fixes an issue where it is not possible to create content with an empty bytestring as the description. Currently, every plone content created through the `plone.restapi` without a description will have an empty bytestring instead an empty unicode string as the default value. 

Setting the description directly is possible. That's what the `plone.restapi` does. But setting it though the behavior will fail due to a guard in the `IBaseBehavior`. When creating a dossier form a dossier-template, the main dossier will be created through the `restapi` which works fine. But the subdossiers are created with the `createContentInContainer` method which will then raise an error.

The story https://4teamwork.atlassian.net/browse/CA-918 would fix the main issue by patching the `plone.restapi` and migrating the bad data-types of existing contents.

Because we need a quickfix, we decided to just remove our behavior field guard and transform bytestrings to unicode strings if necessary.

This quick-fix gets reverted in the scope of the story: https://4teamwork.atlassian.net/browse/CA-918

Full discussion: https://4teamwork.slack.com/archives/C060FEYKA/p1604433964032600

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


## Checklist (if applicable)

_Only applicable should be left and checked._

- API change:
  - [ ] Documentation is updated
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Upgrade steps (changes in profile):
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
- DB-Schema migration
  - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
  - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value
