### PR TITLE
Add flag to disregard retention period when creating a disposition.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -8,6 +8,7 @@ Changelog
 - Add support for using the sablon service instead of a locally installed sablon. [buchi]
 - Add support for using the pdflatex service instead of a locally installed pdflatex. [buchi]
 - Add GEVER_COLORIZATION to the configuration endpoint. [2e12]
+- Add flag to disregard retention period when creating a disposition. [deiferni]
 
 
 2020.13.0 (2020-11-05)

--- a/docs/public/dev-manual/api/config.rst
+++ b/docs/public/dev-manual/api/config.rst
@@ -61,6 +61,7 @@ GEVER-Mandanten abgefragt werden.
               "archival_file_conversion_blacklist": [],
               "changed_for_end_date": true,
               "contacts": false,
+              "disposition_disregard_retention_period": false,
               "disposition_transport_filesystem": false,
               "disposition_transport_ftps": false,
               "doc_properties": true,
@@ -160,6 +161,9 @@ features
 
     contacts
         Erweitertes Kontaktmodul
+
+    disposition_disregard_retention_period
+        Aufbewahrungsdauer beim Erstellen von Angeboten ignorieren
 
     disposition_transport_filesystem
         Das SIP Packet bei der Aussonderung zusätzlich über das Dateisystem ausliefern

--- a/opengever/api/config.py
+++ b/opengever/api/config.py
@@ -8,7 +8,7 @@ from opengever.private import get_private_folder_url
 from plone.restapi.services import Service
 
 
-class Config(Service):
+class ConfigGet(Service):
     """GEVER configuration"""
 
     def reply(self):

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -161,7 +161,7 @@
       method="GET"
       name="@config"
       for="*"
-      factory=".config.Config"
+      factory=".config.ConfigGet"
       permission="zope.Public"
       />
 

--- a/opengever/api/tests/test_config.py
+++ b/opengever/api/tests/test_config.py
@@ -59,6 +59,7 @@ class TestConfig(IntegrationTestCase):
                 u'archival_file_conversion_blacklist': [],
                 u'changed_for_end_date': True,
                 u'contacts': False,
+                u'disposition_disregard_retention_period': False,
                 u'disposition_transport_filesystem': False,
                 u'disposition_transport_ftps': False,
                 u'doc_properties': False,

--- a/opengever/base/configuration.py
+++ b/opengever/base/configuration.py
@@ -14,6 +14,7 @@ from opengever.base.interfaces import ISearchSettings
 from opengever.base.interfaces import IUserSnapSettings
 from opengever.bumblebee.interfaces import IGeverBumblebeeSettings
 from opengever.contact.interfaces import IContactSettings
+from opengever.disposition.interfaces import IDispositionSettings
 from opengever.disposition.interfaces import IFilesystemTransportSettings
 from opengever.disposition.interfaces import IFTPSTransportSettings
 from opengever.document.interfaces import IDocumentSettings
@@ -133,6 +134,7 @@ class GeverSettingsAdpaterV1(object):
         features['archival_file_conversion_blacklist'] = api.portal.get_registry_record('archival_file_conversion_blacklist', interface=IDossierResolveProperties)  # noqa
         features['changed_for_end_date'] = api.portal.get_registry_record('use_changed_for_end_date', interface=IDossierResolveProperties)  # noqa
         features['contacts'] = api.portal.get_registry_record('is_feature_enabled', interface=IContactSettings)
+        features['disposition_disregard_retention_period'] = api.portal.get_registry_record('disregard_retention_period', interface=IDispositionSettings)  # noqa
         features['disposition_transport_filesystem'] = api.portal.get_registry_record('enabled', interface=IFilesystemTransportSettings)  # noqa
         features['disposition_transport_ftps'] = api.portal.get_registry_record('enabled', interface=IFTPSTransportSettings)  # noqa
         features['doc_properties'] = api.portal.get_registry_record('create_doc_properties', interface=ITemplateFolderProperties)  # noqa

--- a/opengever/base/tests/test_configuration_adapter.py
+++ b/opengever/base/tests/test_configuration_adapter.py
@@ -61,6 +61,7 @@ class TestConfigurationAdapter(IntegrationTestCase):
                 ('archival_file_conversion_blacklist', []),
                 ('changed_for_end_date', True),
                 ('contacts', False),
+                ('disposition_disregard_retention_period', False),
                 ('disposition_transport_filesystem', False),
                 ('disposition_transport_ftps', False),
                 ('doc_properties', False),

--- a/opengever/core/profiles/default/registry.xml
+++ b/opengever/core/profiles/default/registry.xml
@@ -63,6 +63,7 @@
   </record>
 
   <!-- DISPOSITION -->
+  <records interface="opengever.disposition.interfaces.IDispositionSettings" />
   <records interface="opengever.disposition.interfaces.IFilesystemTransportSettings" />
   <records interface="opengever.disposition.interfaces.IFTPSTransportSettings" />
 

--- a/opengever/core/upgrades/20201103154342_add_disposition_setting_to_allow_non_expired_dossiers_for_selection/registry.xml
+++ b/opengever/core/upgrades/20201103154342_add_disposition_setting_to_allow_non_expired_dossiers_for_selection/registry.xml
@@ -1,0 +1,4 @@
+<registry>
+  <record interface="opengever.disposition.interfaces.IDispositionSettings"
+          field="disregard_retention_period" />
+</registry>

--- a/opengever/core/upgrades/20201103154342_add_disposition_setting_to_allow_non_expired_dossiers_for_selection/upgrade.py
+++ b/opengever/core/upgrades/20201103154342_add_disposition_setting_to_allow_non_expired_dossiers_for_selection/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddDispositionSettingToAllowNonExpiredDossiersForSelection(UpgradeStep):
+    """Add disposition setting to allow non-expired dossiers for selection.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/disposition/interfaces.py
+++ b/opengever/disposition/interfaces.py
@@ -54,6 +54,18 @@ class ISIPTransport(Interface):
         """
 
 
+class IDispositionSettings(Interface):
+
+    disregard_retention_period = schema.Bool(
+        title=u'Disregard retention period',
+        description=u'Whether it is only allowed to select expired dossiers '
+                    'for a disposition. If set to False only expired dossiers '
+                    'will be allowed, if set to True non-expired dossiers '
+                    'are allowed as well, disregarding their retention '
+                    'period.',
+        default=False)
+
+
 class IFilesystemTransportSettings(Interface):
 
     enabled = schema.Bool(

--- a/opengever/disposition/tests/test_disposition.py
+++ b/opengever/disposition/tests/test_disposition.py
@@ -115,7 +115,7 @@ class TestDisposition(IntegrationTestCase):
                           browser.css('.fieldErrorBox .error').text)
 
     @browsing
-    def test_only_expired_dossiers_can_be_added(self, browser):
+    def test_only_expired_dossiers_can_be_added_by_default(self, browser):
         self.login(self.records_manager, browser)
 
         data = {'paths:list': obj2paths([self.expired_dossier]),
@@ -136,6 +136,25 @@ class TestDisposition(IntegrationTestCase):
                 browser.css('.fieldErrorBox .error').text)
 
         with freeze(datetime(2021, 1, 1)):
+            browser.open(self.repository_root,
+                         view='++add++opengever.disposition.disposition',
+                         data=data)
+
+            browser.find('Save').click()
+
+            self.assertEquals([], error_messages())
+            self.assertEquals(['Item created'], info_messages())
+
+    @browsing
+    def test_non_expired_dossiers_can_be_added_with_disregard_retention_period(self, browser):
+        self.login(self.records_manager, browser)
+        self.activate_feature('disposition-disregard-retention-period')
+
+        data = {'paths:list': obj2paths([self.expired_dossier]),
+                '_authenticator': createToken()}
+
+        with freeze(datetime(2001, 1, 1)):
+            self.assertFalse(self.expired_dossier.is_retention_period_expired())
             browser.open(self.repository_root,
                          view='++add++opengever.disposition.disposition',
                          data=data)

--- a/opengever/testing/integration_test_case.py
+++ b/opengever/testing/integration_test_case.py
@@ -66,6 +66,7 @@ FEATURE_FLAGS = {
     'bumblebee-auto-refresh': 'opengever.bumblebee.interfaces.IGeverBumblebeeSettings.is_auto_refresh_enabled',
     'changed_for_end_date': 'opengever.dossier.interfaces.IDossierResolveProperties.use_changed_for_end_date',
     'contact': 'opengever.contact.interfaces.IContactSettings.is_feature_enabled',
+    'disposition-disregard-retention-period': 'opengever.disposition.interfaces.IDispositionSettings.disregard_retention_period',  # noqa
     'doc-properties': 'opengever.dossier.interfaces.ITemplateFolderProperties.create_doc_properties',
     'dossiertemplate': 'opengever.dossier.dossiertemplate.interfaces.IDossierTemplateSettings.is_feature_enabled',
     'ech0147-export': 'opengever.ech0147.interfaces.IECH0147Settings.ech0147_export_enabled',


### PR DESCRIPTION
With this PR we add a new new flag we allow to optionally disable the restriction to only add expired dossiers to a disposition. All closed dossiers will be allowed for selection disregarding any retention period setting.

- Add flag to disregard retention period, not enabled by default
- Expose flag in `@config`
- Partially related: follow naming conventions for REST-Api, `Config`->`ConfigGet`

Jira: https://4teamwork.atlassian.net/browse/CA-884

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)