### PR TITLE
Use UID instead of intId as token in DocumentTemplatesVocabulary

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 ----------------------
 
 - Add @notification-settings API endpoint. [tinagerber]
+- Use UID instead of intId as token in DocumentTemplatesVocabulary. [elioschmutz]
 - Fix an encoding error on the local contacts tab. [deiferni]
 - Prevent notification mails being bounced due to blacklisted URL in comment. [deiferni]
 - Enhance policy generator with some more defaults for SaaS GEVER. [deiferni]

--- a/opengever/dossier/templatefolder/form.py
+++ b/opengever/dossier/templatefolder/form.py
@@ -23,7 +23,6 @@ from z3c.form import button
 from z3c.form.browser.checkbox import SingleCheckBoxFieldWidget
 from z3c.form.form import Form
 from zope import schema
-from zope.app.intid.interfaces import IIntIds
 from zope.component import getUtility
 from zope.interface import provider
 from zope.schema.interfaces import IContextSourceBinder
@@ -52,14 +51,13 @@ def get_templates(context):
                 sort_on='sortable_title', sort_order='ascending'))
     templates.sort(key=lambda template: template.Title.lower())
 
-    intids = getUtility(IIntIds)
     terms = []
     for brain in templates:
         template = brain.getObject()
         if IDocumentMetadata(template).digitally_available:
             terms.append(SimpleVocabulary.createTerm(
                 template,
-                str(intids.getId(template)),
+                str(template.UID()),
                 template.title))
     return SimpleVocabulary(terms)
 

--- a/opengever/dossier/tests/test_templatefolder.py
+++ b/opengever/dossier/tests/test_templatefolder.py
@@ -103,7 +103,7 @@ class TestDocumentWithTemplateFormPlain(IntegrationTestCase):
         browser.open(self.dossier, view='document_with_template')
 
         browser.fill({
-            'form.widgets.template': str(getUtility(IIntIds).getId(self.normal_template)),
+            'form.widgets.template': self.normal_template.UID(),
             'Title': 'Test Document',
             'Edit after creation': False,
             }).save()
@@ -116,7 +116,7 @@ class TestDocumentWithTemplateFormPlain(IntegrationTestCase):
         self.login(self.regular_user, browser)
         browser.open(self.dossier, view='document_with_template')
         browser.fill({
-            'form.widgets.template': str(getUtility(IIntIds).getId(self.normal_template)),
+            'form.widgets.template': self.normal_template.UID(),
             'Title': 'Test Document',
             }).save()
 
@@ -128,7 +128,7 @@ class TestDocumentWithTemplateFormPlain(IntegrationTestCase):
         self.login(self.regular_user, browser)
         browser.open(self.dossier, view='document_with_template')
         browser.fill({
-            'form.widgets.template': str(getUtility(IIntIds).getId(self.normal_template)),
+            'form.widgets.template': self.normal_template.UID(),
             'Title': 'Test Document',
             }).save()
 
@@ -141,7 +141,7 @@ class TestDocumentWithTemplateFormPlain(IntegrationTestCase):
         self.login(self.regular_user, browser)
         browser.open(self.dossier, view='document_with_template')
         browser.fill({
-            'form.widgets.template': str(getUtility(IIntIds).getId(self.normal_template)),
+            'form.widgets.template': self.normal_template.UID(),
             'Title': 'Test Document',
             }).save()
 
@@ -157,7 +157,7 @@ class TestDocumentWithTemplateFormPlain(IntegrationTestCase):
         with freeze(datetime(2020, 10, 28, 0, 0)):
             browser.open(self.dossier, view='document_with_template')
             browser.fill({
-                'form.widgets.template': str(getUtility(IIntIds).getId(self.asset_template)),
+                'form.widgets.template': self.asset_template.UID(),
                 'Title': 'Test Docx',
                 }).save()
 
@@ -210,7 +210,7 @@ class TestDocumentWithTemplateFormWithDocProperties(IntegrationTestCase):
         with freeze(datetime(2020, 9, 28, 0, 0)):
             browser.open(self.dossier, view='document_with_template')
             browser.fill({
-                'form.widgets.template': str(getUtility(IIntIds).getId(self.docprops_template)),
+                'form.widgets.template': self.docprops_template.UID(),
                 'Title': 'Test Docx',
                 }).save()
 
@@ -291,7 +291,7 @@ class TestDocumentWithTemplateFormWithDocProperties(IntegrationTestCase):
         with freeze(datetime(2020, 10, 28, 0, 0)):
             browser.open(self.dossier, view='document_with_template')
             browser.fill({
-                'form.widgets.template': str(getUtility(IIntIds).getId(self.asset_template)),
+                'form.widgets.template': self.asset_template.UID(),
                 'Title': 'Test Docx',
                 }).save()
 
@@ -422,11 +422,6 @@ class TestDocumentWithTemplateFormWithContacts(FunctionalTestCase):
         self.assertEqual(TEST_USER_ID, entry['actor'])
         self.assertEqual('', entry['comments'])
 
-    @staticmethod
-    def _make_token(document):
-        intids = getUtility(IIntIds)
-        return str(intids.getId(document))
-
     @browsing
     def test_contact_recipient_properties_are_added(self, browser):
         address1 = create(
@@ -473,7 +468,7 @@ class TestDocumentWithTemplateFormWithContacts(FunctionalTestCase):
             # submit first wizard step
             browser.login().open(self.dossier, view='document_with_template')
             browser.fill({
-                'form.widgets.template': self._make_token(self.template_word),
+                'form.widgets.template': self.template_word.UID(),
                 'Title': 'Test Docx',
                 })
             form = browser.find_form_by_field('Recipient')
@@ -561,7 +556,7 @@ class TestDocumentWithTemplateFormWithContacts(FunctionalTestCase):
             # submit first wizard step
             browser.login().open(self.dossier, view='document_with_template')
             browser.fill({
-                'form.widgets.template': self._make_token(self.template_word),
+                'form.widgets.template': self.template_word.UID(),
                 'Title': 'Test Docx',
                 })
             form = browser.find_form_by_field('Recipient')
@@ -611,7 +606,7 @@ class TestDocumentWithTemplateFormWithContacts(FunctionalTestCase):
             # submit first wizard step
             browser.login().open(self.dossier, view='document_with_template')
             browser.fill({
-                'form.widgets.template': self._make_token(self.template_word),
+                'form.widgets.template': self.template_word.UID(),
                 'Title': 'Test Docx',
                 })
             form = browser.find_form_by_field('Recipient')
@@ -660,7 +655,7 @@ class TestDocumentWithTemplateFormWithOfficeConnector(IntegrationTestCase):
         self.login(self.regular_user, browser)
         browser.open(self.dossier, view='document_with_template')
         browser.fill({
-            'form.widgets.template': str(getUtility(IIntIds).getId(self.normal_template)),
+            'form.widgets.template': self.normal_template.UID(),
             'Title': 'Test OfficeConnector',
             }).save()
 


### PR DESCRIPTION
Jira: https://4teamwork.atlassian.net/browse/NE-164

We want to use the vocabulary in combination with a selection-widget which is based on solr.
Because we don't indexed the OGUID in solr, we're not able to intersect vocabulary items and solr items.

This PR now uses the UID instead which is already indexed in solr.

Implemented according to https://github.com/4teamwork/opengever.core/pull/6716 where we already changed the vocabulary-token for the `DossierTemplateVocabulary`.

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


## Checklist (if applicable)

_Only applicable should be left and checked._

- API change:
  - [ ] Documentation is updated
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Upgrade steps (changes in profile):
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
- DB-Schema migration
  - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
  - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value
