### PR TITLE
Fix testserver setup for local development

### DIFF
--- a/development.cfg
+++ b/development.cfg
@@ -75,6 +75,12 @@ initialization +=
     os.environ['SABLON_URL'] = 'http://localhost:8091/'
     os.environ['PDFLATEX_URL'] = 'http://localhost:8092/'
 
+[testserver]
+initialization +=
+    os.environ.setdefault('MSGCONVERT_URL', 'http://localhost:8090/')
+    os.environ.setdefault('SABLON_URL', 'http://localhost:8091/')
+    os.environ.setdefault('PDFLATEX_URL', 'http://localhost:8092/')
+
 [docxcompose]
 recipe = zc.recipe.egg:script
 eggs = docxcompose


### PR DESCRIPTION
For local development, third party executables such as sablon are disabled and since require a web service.
In order for the testserver to work locally, the locations of those services have to be configured, otherwise the testserver tries to look for missing executables.

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [ ] Changelog entry
- [ ] Link to issue (Jira or GitHub) and backlink in issue (Jira)