### PR TITLE
Drop URL to blacklisted hosts in notifications.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2020.14.0 (unreleased)
 ----------------------
 
+- Prevent notification mails being bounced due to blacklisted URL in comment. [deiferni]
 - Add support for using the msgconvert service instead of a locally installed msgconvert. [buchi]
 - Add support for using the sablon service instead of a locally installed sablon. [buchi]
 - Add support for using the pdflatex service instead of a locally installed pdflatex. [buchi]

--- a/opengever/activity/browser/templates/notification_mail_macros.pt
+++ b/opengever/activity/browser/templates/notification_mail_macros.pt
@@ -24,7 +24,7 @@
         </style>
     <![endif]-->
 
-    <!-- All other clients get the webfont reference; some will render the font and others will silently fail to the fallbacks. More on that here: http://stylecampaign.com/blog/2015/02/webfont-support-in-email/ -->
+    <!-- All other clients get the webfont reference; some will render the font and others will silently fail to the fallbacks. -->
     <!--[if !mso]><!-->
     <!--<![endif]-->
 


### PR DESCRIPTION
The URL in the comment seems to have caused some mail servers to bounce the message as the domain seems to be in a blacklist. Also the blog post that was linked does no longer exists.

Jira: https://4teamwork.atlassian.net/browse/CA-1209

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)