### PR TITLE
Improve policy generator dynamic defaults.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 ----------------------
 
 - Prevent notification mails being bounced due to blacklisted URL in comment. [deiferni]
+- Enhance policy generator with some more defaults for SaaS GEVER. [deiferni]
 - Add support for using the msgconvert service instead of a locally installed msgconvert. [buchi]
 - Add support for using the sablon service instead of a locally installed sablon. [buchi]
 - Add support for using the pdflatex service instead of a locally installed pdflatex. [buchi]

--- a/opengever/policytemplates/hooks.py
+++ b/opengever/policytemplates/hooks.py
@@ -144,12 +144,18 @@ def post_package_name(configurator, question, answer):
         answer,
         'onegovgever' if configurator.variables['is_gever'] else 'teamraum'
         )
+    bumblebee_app_id_default = u'{}_{}'.format(
+        'gever' if configurator.variables['is_gever'] else 'teamraum',
+        answer
+        )
     new_defaults = {
         'package.url': 'https://github.com/4teamwork/opengever.{}'.format(
             answer),
         'adminunit.abbreviation': answer,
         'adminunit.id': answer,
         'base.domain': domain_default,
+        'base.ogds_db_name': u'ogds_{}'.format(answer),
+        'base.bumblebee_app_id': bumblebee_app_id_default,
     }
     update_defaults(configurator, new_defaults)
     configurator.variables['package.name_capitalized'] = answer.capitalize()
@@ -183,6 +189,7 @@ def post_adminunit_abbreviation(configurator, question, answer):
         'deployment.rolemanager_group': '{}_admins'.format(answer),
         'deployment.records_manager_group': '{}_admins'.format(answer),
         'deployment.archivist_group': '{}_admins'.format(answer),
+        'deployment.administrator_group': '{}_admins'.format(answer),
         'orgunit.users_group': '{}_users'.format(answer),
         'orgunit.inbox_group': '{}_inbox'.format(answer),
         'orgunit.id': answer.lower()

--- a/opengever/policytemplates/hooks.py
+++ b/opengever/policytemplates/hooks.py
@@ -183,9 +183,8 @@ def post_adminunit_title(configurator, question, answer):
     return answer
 
 
-def post_adminunit_abbreviation(configurator, question, answer):
+def post_adminunit_id(configurator, question, answer):
     new_defaults = {
-        'adminunit.id': answer.lower(),
         'deployment.rolemanager_group': '{}_admins'.format(answer),
         'deployment.records_manager_group': '{}_admins'.format(answer),
         'deployment.archivist_group': '{}_admins'.format(answer),
@@ -201,10 +200,6 @@ def post_adminunit_abbreviation(configurator, question, answer):
         configurator.variables.update({
             'orgunit.id': answer.lower()
             })
-    return answer
-
-
-def post_adminunit_id(configurator, question, answer):
     configurator.variables['adminunit.ac_cookie_name'] = answer.replace('-', '_')
     configurator.variables['adminunit.id_capitalized'] = answer.capitalize()
     configurator.variables['adminunit.id_upper'] = answer.upper()

--- a/opengever/policytemplates/policy_template/.mrbob.ini
+++ b/opengever/policytemplates/policy_template/.mrbob.ini
@@ -56,13 +56,12 @@ adminunit.title.question = AdminUnit title
 adminunit.title.required = True
 adminunit.title.post_ask_question = opengever.policytemplates.hooks:post_adminunit_title
 
-adminunit.abbreviation.question = AdminUnit abbreviation / reference number prefix
-adminunit.abbreviation.required = True
-adminunit.abbreviation.post_ask_question = opengever.policytemplates.hooks:post_adminunit_abbreviation
-
 adminunit.id.question = AdminUnit id
 adminunit.id.required = True
 adminunit.id.post_ask_question = opengever.policytemplates.hooks:post_adminunit_id
+
+adminunit.abbreviation.question = AdminUnit abbreviation / reference number prefix
+adminunit.abbreviation.required = True
 
 adminunit.public_url.question = AdminUnit public_url
 adminunit.public_url.required = True


### PR DESCRIPTION
With this PR we make another baby-step towards improving the policy generator a bit.

We add new defaults that can be guessed from previous input for the following questions:
- bumblebee app id
- ogds db name
- administrator group

We also switch question order, and ask for admin unit id first to generate defaults from the technical admin unit identifier instead from of from the user visible abbreviation. The questions for which defaults are generated are also asking for technical identifier, so that IMO makes more sense.

Jira: https://4teamwork.atlassian.net/browse/CA-1107

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
