### PR TITLE
Fix an encoding error on the local contacts tab.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2020.14.0 (unreleased)
 ----------------------
 
+- Fix an encoding error on the local contacts tab. [deiferni]
 - Prevent notification mails being bounced due to blacklisted URL in comment. [deiferni]
 - Enhance policy generator with some more defaults for SaaS GEVER. [deiferni]
 - Add support for using the msgconvert service instead of a locally installed msgconvert. [buchi]

--- a/opengever/contact/tests/test_contact_tab_helpers.py
+++ b/opengever/contact/tests/test_contact_tab_helpers.py
@@ -1,0 +1,71 @@
+from unittest import TestCase
+from opengever.contact.browser.contacts_tab import linked
+from opengever.contact.browser.contacts_tab import linked_no_icon
+from mock import Mock
+
+
+class MockItem(object):
+    pass
+
+
+class TestUnitLinked(TestCase):
+
+    def test_linked_with_unicode_value(self):
+        self.assertEqual(
+            u'<span class="linkWrapper"><a href="#">f\xfc\xfc</a></span>',
+            linked(None, u'f\xfc\xfc')
+        )
+
+    def test_linked_with_bytestring_value(self):
+        self.assertEqual(
+            u'<span class="linkWrapper"><a href="#">f\xfc\xfc</a></span>',
+            linked(None, u'f\xfc\xfc'.encode('utf-8'))
+        )
+
+    def test_linked_with_bytestring_url(self):
+        item = MockItem()
+        item.getURL = Mock(return_value=u'http://example.com/fo\xfc'.encode('utf-8'))
+        item.css_icon_class = 'bar'
+        self.assertEqual(
+            u'<span class="linkWrapper bar"><a href="http://example.com/fo\xfc">qux</a></span>',
+            linked(item, u'qux')
+        )
+
+    def test_linked_with_unicode_url(self):
+        item = MockItem()
+        item.getURL = Mock(return_value=u'http://example.com/fo\xfc')
+        self.assertEqual(
+            u'<span class="linkWrapper"><a href="http://example.com/fo\xfc">bar</a></span>',
+            linked(item, u'bar')
+        )
+
+
+class TestUnitLinkedNoIcon(TestCase):
+
+    def test_linked_no_icon_with_unicode_value(self):
+        self.assertEqual(
+            u'<span class="linkWrapper"><a href="#">f\xfc\xfc</a></span>',
+            linked_no_icon(None, u'f\xfc\xfc')
+        )
+
+    def test_linked_no_icon_with_bytestring_value(self):
+        self.assertEqual(
+            u'<span class="linkWrapper"><a href="#">f\xfc\xfc</a></span>',
+            linked_no_icon(None, u'f\xfc\xfc'.encode('utf-8'))
+        )
+
+    def test_linked_no_icon_with_bytestring_url(self):
+        item = MockItem()
+        item.getURL = Mock(return_value=u'http://example.com/fo\xfc'.encode('utf-8'))
+        self.assertEqual(
+            u'<span class="linkWrapper"><a href="http://example.com/fo\xfc">quux</a></span>',
+            linked_no_icon(item, 'quux')
+        )
+
+    def test_linked_no_icon_with_unicode_url(self):
+        item = MockItem()
+        item.getURL = Mock(return_value=u'http://example.com/fo\xfc')
+        self.assertEqual(
+            u'<span class="linkWrapper"><a href="http://example.com/fo\xfc">baz</a></span>',
+            linked_no_icon(item, u'baz')
+        )


### PR DESCRIPTION
We fix an encoding issue that arose due to inconsistent handling of unicode vs bytestrings.

Items passed to the helper methods can be anything from a brain to a solr-document and those do not gurantee unicode strings. Thus we consider these methods to be at the application boundary and make sure we work with unicode internally.

We also refactore the two nearly identical methods and merge them into one method with two shallow wrapper methods setting correct parameters.

Jira: https://4teamwork.atlassian.net/browse/CA-1208

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
