### PR TITLE
Add @notification-settings endpoint

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2020.14.0 (unreleased)
 ----------------------
 
+- Add @notification-settings API endpoint. [tinagerber]
 - Fix an encoding error on the local contacts tab. [deiferni]
 - Prevent notification mails being bounced due to blacklisted URL in comment. [deiferni]
 - Enhance policy generator with some more defaults for SaaS GEVER. [deiferni]

--- a/docs/public/dev-manual/api/docs_changelog.rst
+++ b/docs/public/dev-manual/api/docs_changelog.rst
@@ -5,12 +5,17 @@ Changelog
 
 Im Folgenden sind (substantielle) Änderungen an der Dokumentation aufgeführt.
 
-2020-09-01
+2020-11-11
+----------
+
+- Kapitel "Benachrichtigungseinstellungen" hinzugefügt
+
+2020-10-12
 ----------
 
 - Kapitel "Geschäftsdossier ab Vorlage erstellen" hinzugefügt
 
-2020-09-01
+2020-10-01
 ----------
 
 - Kapitel "Beteiligungen" hinzugefügt

--- a/docs/public/dev-manual/api/index.rst
+++ b/docs/public/dev-manual/api/index.rst
@@ -37,6 +37,7 @@ Inhalt:
    users.rst
    actors.rst
    assigned_users.rst
+   notification_settings.rst
    usersettings.rst
    tasks.rst
    globalindex.rst

--- a/docs/public/dev-manual/api/notification_settings.rst
+++ b/docs/public/dev-manual/api/notification_settings.rst
@@ -1,0 +1,170 @@
+.. _notification_settings:
+
+Benachrichtigungseinstellungen
+==============================
+
+Mit dem ``@notification-settings`` Endpoint können die Benachrichtigungseinstellungen des aktuellen Benutzers ausgelesen und angepasst werden. Der Endpoint steht nur auf Stufe PloneSite zur Verfügung.
+
+
+Auslesen (GET)
+--------------
+
+Gibt die Benachrichtigungseinstellungen des aktuellen Benutzers zurück.
+
+ **Request**:
+
+ .. sourcecode:: http
+
+    GET /@notification-settings HTTP/1.1
+    Accept: application/json
+
+ **Response**:
+
+ .. sourcecode:: http
+
+    HTTP/1.1 200 OK
+    Content-Type: application/json
+
+    {
+      "@id": "http://localhost:8080/fd/@notification-settings",
+      "activities": {
+        "@id": "http://localhost:8080/fd/@notification-settings/activities",
+        "items": [
+          {
+            "@id": "http://localhost:8080/fd/@notification-settings/activities/task-added-or-reassigned",
+            "badge": {
+              "regular_watcher": true,
+              "task_issuer": true,
+              "task_responsible": true
+            },
+            "digest": {
+              "regular_watcher": false,
+              "task_issuer": false,
+              "task_responsible": false
+            },
+            "group": "task",
+            "id": "task-added-or-reassigned",
+            "kind": "task-added-or-reassigned",
+            "mail": {
+              "regular_watcher": true,
+              "task_issuer": false,
+              "task_responsible": true
+            },
+            "personal": false,
+            "title": "Aufgabe erstellt / neu zugewiesen"
+          },
+          { "...": "..." },
+        ]
+      },
+      "general": {
+        "@id": "http://localhost:8080/fd/@notification-settings/general",
+        "items": [
+          {
+            "@id": "http://localhost:8080/fd/@notification-settings/general/notify_own_actions",
+            "group": "general",
+            "help_text": "Standardmässig werden für selbst ausgeführte Aktionen keine Benachrichtigungen ausgelöst. Mit dieser Option kann dieses Verhalten verändert werden. Persönlich vorgenommene Benachrichtigungseinstellungen pro Aktionstyp gelten dabei nach wie vor.",
+            "id": "notify_own_actions",
+            "personal": false,
+            "title": "Benachrichtigung für eigene Aktionen aktivieren",
+            "value": false
+          },
+          { "...": "..." },
+        ]
+      },
+      "translations": [
+        {
+          "id": "task_responsible",
+          "title": "Auftragnehmer"
+        },
+        {
+          "id": "task_issuer",
+          "title": "Auftraggeber"
+        },
+        { "...": "..." },
+      ]
+    }
+
+
+Ändern einer Benachrichtigungseinstellung (PATCH)
+-------------------------------------------------
+
+Die Einstellungen für den aktuellen Benutzer können via PATCH Request geändert werden.
+Dabei wird zwischen generellen Benachrichtigungseinstellungen und Einstellungen für Aktivitätsbenachrichtigungen unterschieden.
+
+
+ **Beispiel-Request fürs Ändern einer generellen Benachrichtigungseinstellung**:
+
+ .. sourcecode:: http
+
+    PATCH /@notification-settings/general/notify_own_actions HTTP/1.1
+    Accept: application/json
+    Content-Type: application/json
+
+    {
+      "value": true,
+    }
+
+
+ **Response**:
+
+ .. sourcecode:: http
+
+    HTTP/1.1 204 No Content
+    Content-Type: application/json
+
+
+Bei den Einstellungen für Aktivitätsbenachrichtigungen kann gewählt werden, in welcher Rolle man per GEVER-Benachrichtigung (``badge``) , E-Mail (``mail``) und Tageszusammenfassung (``digest``) benachrichtigt werden will. Dabei müssen pro Benachrichtigungstyp alle Rollen mitgegeben werden, in denen man benachrichtigt werden will:
+
+ **Beispiel-Request fürs Ändern einer Einstellung für Aktivitätsbenachrichtigungen**:
+
+ .. sourcecode:: http
+
+    PATCH /@notification-settings/activity/task-added-or-reassigned HTTP/1.1
+    Accept: application/json
+    Content-Type: application/json
+
+    {
+      "mail": {
+        "task_issuer": true,
+        "regular_watcher": true
+      },
+      "digest": {
+        "regular_watcher": true
+      }
+    }
+
+
+ **Response**:
+
+ .. sourcecode:: http
+
+    HTTP/1.1 204 No Content
+    Content-Type: application/json
+
+Gleich wie bei anderen PATCH Requests ist es auch hier möglich, die Repräsentation als Response zu erhalten, hierzu muss ein ``Prefer`` Header mit dem Wert ``return=representation`` gesetzt werden.
+
+Zurücksetzen einer Benachrichtigungseinstellung (PATCH)
+-------------------------------------------------------
+
+Die Einstellungen für den aktuellen Benutzer können via PATCH Request auf den Standard zurückgesetzt werden.
+
+ **Request**:
+
+ .. sourcecode:: http
+
+    PATCH /@notification-settings/activity/task-added-or-reassigned HTTP/1.1
+    Accept: application/json
+    Content-Type: application/json
+
+    {
+      "reset": true
+    }
+
+
+ **Response**:
+
+ .. sourcecode:: http
+
+    HTTP/1.1 204 No Content
+    Content-Type: application/json
+

--- a/opengever/activity/notification_settings.py
+++ b/opengever/activity/notification_settings.py
@@ -298,11 +298,19 @@ class NotificationSettings(object):
         if setting:
             create_session().delete(setting)
 
-    def set_custom_setting(self, setting_kind, userid,
-                           mail_roles=None, badge_roles=None, digest_roles=None):
+    def set_custom_setting(self, setting_kind, userid, mail_roles=None,
+                           badge_roles=None, digest_roles=None, use_default=False):
         setting = self._get_custom_notification_settings(userid).get(setting_kind)
         if not setting:
-            setting = model.NotificationSetting(kind=setting_kind, userid=userid)
+            if use_default:
+                default_setting = self._get_default_notification_settings().get(setting_kind)
+                setting = model.NotificationSetting(
+                    kind=setting_kind, userid=userid,
+                    _badge_notification_roles=default_setting._badge_notification_roles,
+                    _digest_notification_roles=default_setting._digest_notification_roles,
+                    _mail_notification_roles=default_setting._mail_notification_roles)
+            else:
+                setting = model.NotificationSetting(kind=setting_kind, userid=userid)
             create_session().add(setting)
 
         if mail_roles is not None:

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -767,6 +767,14 @@
       />
 
   <plone:service
+      method="PATCH"
+      name="@notification-settings"
+      for="Products.CMFPlone.interfaces.IPloneSiteRoot"
+      factory=".notification_settings.NotificationSettingsPatch"
+      permission="zope2.View"
+      />
+
+  <plone:service
       method="GET"
       name="@user-settings"
       for="Products.CMFPlone.interfaces.IPloneSiteRoot"

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -760,6 +760,14 @@
 
   <plone:service
       method="GET"
+      name="@notification-settings"
+      for="Products.CMFPlone.interfaces.IPloneSiteRoot"
+      factory=".notification_settings.NotificationSettingsGet"
+      permission="zope2.View"
+      />
+
+  <plone:service
+      method="GET"
       name="@user-settings"
       for="Products.CMFPlone.interfaces.IPloneSiteRoot"
       factory=".user_settings.UserSettingsGet"

--- a/opengever/api/notification_settings.py
+++ b/opengever/api/notification_settings.py
@@ -1,14 +1,23 @@
 from opengever.activity import notification_center
 from opengever.activity.browser.settings import NOTIFICATION_SETTING_TABS
 from opengever.activity.browser.settings import USER_SETTINGS
+from opengever.activity.model.settings import NotificationDefault
 from opengever.activity.notification_settings import NotificationSettings
 from opengever.activity.roles import ROLE_TRANSLATIONS
+from opengever.api.validation import get_validation_errors
 from opengever.meeting import is_meeting_feature_enabled
+from opengever.ogds.models.user import User
 from opengever.ogds.models.user_settings import UserSettings
 from opengever.workspace import is_workspace_feature_enabled
 from plone import api
+from plone.restapi.deserializer import json_body
 from plone.restapi.services import Service
+from zExceptions import BadRequest
+from zope import schema
 from zope.i18n import translate
+from zope.interface import implements
+from zope.interface import Interface
+from zope.publisher.interfaces import IPublishTraverse
 
 
 def serialize_activity_setting(settings, kind, group, userid, url, request):
@@ -93,3 +102,136 @@ class NotificationSettingsGet(Service):
                 'activities': activities, 'general': general,
                 'translations': [{'id': role, 'title': translate(
                     ROLE_TRANSLATIONS[role], context=self.request)} for role in roles]}
+
+
+class IActivityNotificationSetting(Interface):
+
+    badge = schema.Dict(key_type=schema.TextLine(), value_type=schema.Bool(), required=False)
+    digest = schema.Dict(key_type=schema.TextLine(), value_type=schema.Bool(), required=False)
+    mail = schema.Dict(key_type=schema.TextLine(), value_type=schema.Bool(), required=False)
+    reset = schema.Bool(required=False, default=False)
+
+
+class IGeneralNotificationSetting(Interface):
+
+    reset = schema.Bool(required=False, default=False)
+    value = schema.Bool(required=False, default=False)
+
+
+class ActivityNotificationSettingHandler(object):
+    validation_schema = IActivityNotificationSetting
+
+    def __init__(self):
+        self.settings = NotificationSettings()
+
+    def validate_setting_id(self, setting_id):
+        if not NotificationDefault.query.by_kind(setting_id).first():
+            raise BadRequest("'{}' does not exist".format(setting_id))
+
+    def reset_setting(self, setting_id, userid):
+        NotificationSettings().remove_custom_setting(setting_id, userid)
+
+    def update_setting(self, data, setting_id, userid):
+        badge_roles = data.get('badge')
+        digest_roles = data.get('digest')
+        mail_roles = data.get('mail')
+        if badge_roles is None and digest_roles is None and mail_roles is None:
+            raise BadRequest('Missing parameter badge, digest or mail')
+        if badge_roles is not None:
+            badge_roles = [key for key, value in badge_roles.items() if value]
+        if digest_roles is not None:
+            digest_roles = [key for key, value in digest_roles.items() if value]
+        if mail_roles is not None:
+            mail_roles = [key for key, value in mail_roles.items() if value]
+
+        NotificationSettings().set_custom_setting(setting_id, userid,
+                                                  mail_roles=mail_roles,
+                                                  badge_roles=badge_roles,
+                                                  digest_roles=digest_roles,
+                                                  use_default=True)
+
+    def serialize_setting(self, setting_id, userid, url, request):
+        group = filter(lambda group: setting_id in group['settings'], NOTIFICATION_SETTING_TABS)[0]
+        return serialize_activity_setting(self.settings, setting_id, group, userid, url, request)
+
+
+class GeneralNotificationSettingHandler(object):
+    validation_schema = IGeneralNotificationSetting
+
+    def validate_setting_id(self, setting_id):
+        try:
+            getattr(UserSettings, setting_id)
+        except AttributeError:
+            raise BadRequest("'{}' does not exist".format(setting_id))
+
+    def reset_setting(self, setting_id, userid):
+        default = getattr(UserSettings, setting_id).default.arg
+        UserSettings.save_setting_for_user(userid, setting_id, default)
+
+    def update_setting(self, data, setting_id, userid):
+        if data.get('value') is None:
+            raise BadRequest('Missing parameter value')
+        UserSettings.save_setting_for_user(userid, setting_id, data.get('value'))
+
+    def serialize_setting(self, setting_id, userid, url, request):
+        setting = filter(lambda setting: setting.get('id') == setting_id, USER_SETTINGS)[0]
+        return serialize_general_setting(setting, userid, url, request)
+
+
+class NotificationSettingsPatch(Service):
+
+    implements(IPublishTraverse)
+
+    def __init__(self, context, request):
+        super(NotificationSettingsPatch, self).__init__(context, request)
+        self.params = []
+
+    def publishTraverse(self, request, name):
+        # Consume any path segments after /@favorites as parameters
+        self.params.append(name)
+        return self
+
+    def read_params(self):
+        if len(self.params) != 2:
+            raise BadRequest(
+                "Must supply setting category and setting ID as URL path parameters")
+
+        return self.params[0], self.params[1]
+
+    def get_handler(self, setting_category):
+        if setting_category == 'general':
+            return GeneralNotificationSettingHandler()
+        elif setting_category == 'activities':
+            return ActivityNotificationSettingHandler()
+        raise BadRequest("'{}' does not exist".format(setting_category))
+
+    def validate_data(self, data, schema_interface):
+        errors = get_validation_errors(data, schema_interface)
+        if errors:
+            raise BadRequest(errors)
+
+    def reply(self):
+        setting_category, setting_id = self.read_params()
+        userid = api.user.get_current().getId()
+        user = User.query.filter_by(userid=userid).one_or_none()
+        if user is None:
+            raise BadRequest("User {} not found in OGDS".format(userid))
+
+        data = json_body(self.request)
+
+        handler = self.get_handler(setting_category)
+        self.validate_data(data, handler.validation_schema)
+        handler.validate_setting_id(setting_id)
+        if data.get('reset'):
+            handler.reset_setting(setting_id, userid)
+        else:
+            handler.update_setting(data, setting_id, userid)
+
+        prefer = self.request.getHeader('Prefer')
+        if prefer == 'return=representation':
+            url = self.context.absolute_url()
+            self.request.response.setStatus(200)
+            return handler.serialize_setting(setting_id, userid, url, self.request)
+
+        self.request.response.setStatus(204)
+        return None

--- a/opengever/api/notification_settings.py
+++ b/opengever/api/notification_settings.py
@@ -1,0 +1,95 @@
+from opengever.activity import notification_center
+from opengever.activity.browser.settings import NOTIFICATION_SETTING_TABS
+from opengever.activity.browser.settings import USER_SETTINGS
+from opengever.activity.notification_settings import NotificationSettings
+from opengever.activity.roles import ROLE_TRANSLATIONS
+from opengever.meeting import is_meeting_feature_enabled
+from opengever.ogds.models.user_settings import UserSettings
+from opengever.workspace import is_workspace_feature_enabled
+from plone import api
+from plone.restapi.services import Service
+from zope.i18n import translate
+
+
+def serialize_activity_setting(settings, kind, group, userid, url, request):
+    config = settings.get_configuration_by_id(kind)
+    setting = settings.get_setting(kind, userid)
+    item = {
+        '@id': '{}/@notification-settings/activities/{}'.format(url, kind),
+        'id': kind,
+        'kind': kind,
+        'group': group['id'],
+        'personal': settings.is_custom_setting(setting),
+        'title': translate(config['title'], domain='opengever.activity',
+                           context=request)
+    }
+
+    for dispatcher in notification_center().dispatchers:
+        values = getattr(setting, dispatcher.roles_key)
+        item[dispatcher._id] = {role: bool(role in values) for role in group['roles']}
+    return item
+
+
+def serialize_general_setting(setting, userid, url, request):
+    default = getattr(UserSettings, setting['id']).default.arg
+    value = UserSettings.get_setting_for_user(userid, setting.get('id'))
+    return {
+        '@id': '{}/@notification-settings/general/{}'.format(url, setting['id']),
+        'id': setting['id'],
+        'value': value,
+        'group': 'general',
+        'personal': value != default,
+        'title': translate(setting['title'], domain='opengever.activity', context=request),
+        'help_text': translate(setting['help_text'], domain='opengever.activity',
+                               context=request)
+    }
+
+
+class NotificationSettingsGet(Service):
+
+    def group_visibility(self):
+        return {
+            'disposition': api.user.has_permission('opengever.disposition: Add disposition'),
+            'dossier': not is_workspace_feature_enabled(),
+            'proposal': is_meeting_feature_enabled(),
+            'reminder': not is_workspace_feature_enabled(),
+            'task': not is_workspace_feature_enabled(),
+            'watcher': not is_workspace_feature_enabled(),
+            'workspace': is_workspace_feature_enabled(),
+        }
+
+    def general_settings_visibility(self):
+        return {
+            'notify_own_actions': True,
+            'notify_inbox_actions': not is_workspace_feature_enabled()
+        }
+
+    def reply(self):
+        group_visibility = self.group_visibility()
+        general_settings_visibility = self.general_settings_visibility()
+        roles = set()
+        settings = NotificationSettings()
+        userid = api.user.get_current().getId()
+        url = self.context.absolute_url()
+
+        activities = {'@id': '{}/@notification-settings/activities'.format(url),
+                      'items': []}
+        for group in NOTIFICATION_SETTING_TABS:
+            if not group_visibility[group['id']]:
+                continue
+            roles.update(group['roles'])
+            for kind in group['settings']:
+                activities['items'].append(
+                    serialize_activity_setting(settings, kind, group, userid, url, self.request))
+
+        general = {'@id': '{}/@notification-settings/general'.format(url),
+                   'items': []}
+        for setting in USER_SETTINGS:
+            if not general_settings_visibility[setting['id']]:
+                continue
+            general['items'].append(serialize_general_setting(setting, userid, url, self.request))
+
+        return {'@id': '{}/@notification-settings'.format(url),
+                'activities': activities, 'general': general,
+                'translations': [{'id': role, 'title': translate(
+                    ROLE_TRANSLATIONS[role], context=self.request)} for role in roles]}


### PR DESCRIPTION
This PR implements an API endpoint for notification settings so that the notification settings can also be offered in the new front end.

A GET request to @notification-settings returns all notification settings (default and personal).
The settings are divided into two groups, `activities` and `general`.

With a PATCH request a notification setting can be edited as well as reset to the default.

Discussed with @lukasgraf 

Jira: https://4teamwork.atlassian.net/browse/NE-99


## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


## Checklist (if applicable)

_Only applicable should be left and checked._

- API change:
  - [x] Documentation is updated