### PR TITLE
Add simple support for meetings in a multi-admin-unit cluster.

### DIFF
--- a/development-multi-admin.cfg
+++ b/development-multi-admin.cfg
@@ -8,6 +8,8 @@ development-packages +=
 ogds-db-name = opengever-multi-admin
 
 [instance]
+zserver-threads = 4
+
 eggs +=
  opengever.hatchery
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 
 - Add @notification-settings API endpoint. [tinagerber]
 - Use UID instead of intId as token in DocumentTemplatesVocabulary. [elioschmutz]
+- Add simple support for meetings in a multi-admin-unit cluster. [deiferni]
 - Fix an encoding error on the local contacts tab. [deiferni]
 - Prevent notification mails being bounced due to blacklisted URL in comment. [deiferni]
 - Enhance policy generator with some more defaults for SaaS GEVER. [deiferni]

--- a/opengever/core/upgrades/20201111125010_add_admin_unit_to_member/upgrade.py
+++ b/opengever/core/upgrades/20201111125010_add_admin_unit_to_member/upgrade.py
@@ -1,0 +1,102 @@
+from opengever.base.sentry import log_msg_to_sentry
+from opengever.core.upgrade import SchemaMigration
+from opengever.ogds.base.utils import get_current_admin_unit
+from plone import api
+from sqlalchemy import Column
+from sqlalchemy import String
+from sqlalchemy.sql import select
+from sqlalchemy.sql.expression import column
+from sqlalchemy.sql.expression import table
+
+
+UNIT_ID_LENGTH = 30
+
+
+members_table = table(
+    "members",
+    column("id"),
+    column("admin_unit_id"),
+)
+
+
+committees_table = table(
+    "committees",
+    column("id"),
+    column("admin_unit_id"),
+    column("int_id"),
+)
+
+
+class AddAdminUnitToMember(SchemaMigration):
+    """Add admin_unit column to Member.
+
+    We apply a graceful strategy in case we find a deployment in invalid state.
+    Instead of failing hard and blocking a potential upgrade path we migrate
+    using a placeholder and notify that manual cleanup is needed. We don't
+    expect any deployments in such state as it is currently not supported.
+    """
+
+    def migrate(self):
+        self.add_admin_unit_column()
+        self.migrate_data()
+        self.make_admin_unit_column_non_nullable()
+
+    def add_admin_unit_column(self):
+        self.op.add_column(
+            'members',
+            Column('admin_unit_id', String(UNIT_ID_LENGTH), nullable=True)
+        )
+
+    def has_committees_for_multiple_admin_units(self):
+        statement = select([committees_table.c.admin_unit_id]).distinct()
+        results = list(self.execute(statement))
+        return len(results) > 1
+
+    def migrate_data(self):
+        nof_members = self.execute(members_table.count()).scalar()
+        # there are no members, this means that either the meeting feature
+        # is not enabled, or not in use. no data migration is needed.
+        if nof_members <= 0:
+            return
+
+        current_admin_unit_id = get_current_admin_unit().id()
+
+        has_meeting_feature = api.portal.get_registry_record(
+            'opengever.meeting.interfaces.IMeetingSettings.is_feature_enabled')
+        # if we don't have the meeting feature active this means that another
+        # admin-unit in the cluster has the meeting feature, but we are not
+        # running schema migrations on that admin-unit.
+        # this should not be the case at the moment as it is not yet officially
+        # supported.
+        # we gracefully continue with the upgrade and notify that manual
+        # cleanup is needed.
+        if not has_meeting_feature:
+            log_msg_to_sentry(
+                'Attempting to migrate members on {}, but meeting feature is '
+                'not enabled. The admin_unit_id for members will be set to '
+                '"FIXME". This MUST be cleaned up manually'.format(
+                    current_admin_unit_id),
+                request=self.portal.REQUEST)
+            current_admin_unit_id = u'FIXME'
+        # if we have committees on multiple admin-units in one cluster we
+        # cannot reliably migrate members.
+        # this should not be the case at the moment as it is not yet officially
+        # supported.
+        # we gracefully continue with the upgrade and notify that manual
+        # cleanup is needed.
+        if self.has_committees_for_multiple_admin_units():
+            log_msg_to_sentry(
+                'Attempting to migrate members, but found committees on '
+                'multiple admin units. The admin_unit_id for members will be '
+                'set to "FIXME". This MUST be cleaned up manually',
+                request=self.portal.REQUEST)
+            current_admin_unit_id = u'FIXME'
+
+        self.execute(
+            members_table.update().values(admin_unit_id=current_admin_unit_id)
+        )
+
+    def make_admin_unit_column_non_nullable(self):
+        self.op.alter_column(
+            'members', 'admin_unit_id', existing_type=String, nullable=False
+        )

--- a/opengever/examplecontent/meeting.py
+++ b/opengever/examplecontent/meeting.py
@@ -6,6 +6,7 @@ from ftw.builder import Builder
 from ftw.builder import create
 from ftw.builder import session
 from opengever.base.model import create_session
+from opengever.ogds.base.utils import get_current_admin_unit
 from opengever.testing import assets
 from opengever.testing import builders  # noqa
 from plone import api
@@ -92,9 +93,11 @@ class MeetingExampleContentCreator(object):
 
     def create_members_and_memberships(self):
         peter = create(Builder('member')
-                       .having(firstname=u'Peter', lastname=u'M\xfcller'))
+                       .having(firstname=u'Peter', lastname=u'M\xfcller',
+                               admin_unit_id=get_current_admin_unit().id()))
         hans = create(Builder('member')
-                      .having(firstname=u'Hans', lastname=u'Meier'))
+                      .having(firstname=u'Hans', lastname=u'Meier',
+                              admin_unit_id=get_current_admin_unit().id()))
 
         for committee in [self.committee_law_model,
                           self.committee_assembly_model]:

--- a/opengever/meeting/committeecontainer.py
+++ b/opengever/meeting/committeecontainer.py
@@ -29,7 +29,8 @@ class CommitteeContainer(Container, TranslatedTitleMixin):
 
         if id_.startswith('member'):
             member_id = int(id_.split('-')[-1])
-            member = Member.query.get(member_id)
+            member = Member.query.by_current_admin_unit().filter_by(
+                member_id=member_id).first()
             if member:
                 return MemberWrapper.wrap(self, member)
 

--- a/opengever/meeting/model/member.py
+++ b/opengever/meeting/model/member.py
@@ -3,12 +3,18 @@ from opengever.base.model import EMAIL_LENGTH
 from opengever.base.model import FIRSTNAME_LENGTH
 from opengever.base.model import LASTNAME_LENGTH
 from opengever.base.model import SQLFormSupport
+from opengever.base.model import UNIT_ID_LENGTH
 from opengever.base.utils import escape_html
+from opengever.ogds.base.utils import get_current_admin_unit
 from sqlalchemy import Column
 from sqlalchemy import Integer
 from sqlalchemy import String
 from sqlalchemy.orm import column_property
 from sqlalchemy.schema import Sequence
+
+
+def member_admin_unit_id_default():
+    return get_current_admin_unit().id()
 
 
 class Member(Base, SQLFormSupport):
@@ -17,6 +23,8 @@ class Member(Base, SQLFormSupport):
 
     member_id = Column("id", Integer, Sequence("member_id_seq"),
                        primary_key=True)
+    admin_unit_id = Column(String(UNIT_ID_LENGTH), nullable=False,
+                           default=member_admin_unit_id_default)
     firstname = Column(String(FIRSTNAME_LENGTH), nullable=False)
     lastname = Column(String(LASTNAME_LENGTH), nullable=False)
     fullname = column_property(lastname + " " + firstname)

--- a/opengever/meeting/model/query.py
+++ b/opengever/meeting/model/query.py
@@ -1,6 +1,7 @@
 from datetime import date
 from opengever.base.date_time import utcnow_tz_aware
 from opengever.base.oguid import Oguid
+from opengever.base.query import BaseQuery
 from opengever.meeting.model.committee import Committee
 from opengever.meeting.model.excerpt import Excerpt
 from opengever.meeting.model.generateddocument import GeneratedDocument
@@ -8,7 +9,7 @@ from opengever.meeting.model.meeting import Meeting
 from opengever.meeting.model.membership import Membership
 from opengever.meeting.model.proposal import Proposal
 from opengever.meeting.model.submitteddocument import SubmittedDocument
-from opengever.base.query import BaseQuery
+from opengever.ogds.base.utils import get_current_admin_unit
 from plone import api
 from sqlalchemy import and_
 from sqlalchemy import or_
@@ -91,6 +92,10 @@ class CommitteeQuery(BaseQuery):
     def active(self):
         return self.filter(
             Committee.workflow_state == Committee.STATE_ACTIVE.name)
+
+    def by_current_admin_unit(self):
+        admin_unit_id = get_current_admin_unit().id()
+        return self.filter_by(admin_unit_id=admin_unit_id)
 
 
 Committee.query_cls = CommitteeQuery

--- a/opengever/meeting/model/query.py
+++ b/opengever/meeting/model/query.py
@@ -6,6 +6,7 @@ from opengever.meeting.model.committee import Committee
 from opengever.meeting.model.excerpt import Excerpt
 from opengever.meeting.model.generateddocument import GeneratedDocument
 from opengever.meeting.model.meeting import Meeting
+from opengever.meeting.model.member import Member
 from opengever.meeting.model.membership import Membership
 from opengever.meeting.model.proposal import Proposal
 from opengever.meeting.model.submitteddocument import SubmittedDocument
@@ -99,6 +100,16 @@ class CommitteeQuery(BaseQuery):
 
 
 Committee.query_cls = CommitteeQuery
+
+
+class MemberQuery(BaseQuery):
+
+    def by_current_admin_unit(self):
+        admin_unit_id = get_current_admin_unit().id()
+        return self.filter_by(admin_unit_id=admin_unit_id)
+
+
+Member.query_cls = MemberQuery
 
 
 class MembershipQuery(BaseQuery):

--- a/opengever/meeting/tabs/memberlisting.py
+++ b/opengever/meeting/tabs/memberlisting.py
@@ -44,7 +44,7 @@ class MemberListingTab(BaseListingTab):
         return item.get_lastname_link(self.context)
 
     def get_base_query(self):
-        return Member.query
+        return Member.query.by_current_admin_unit()
 
 
 @implementer(ITableSource)

--- a/opengever/meeting/tests/test_committee_query.py
+++ b/opengever/meeting/tests/test_committee_query.py
@@ -1,0 +1,34 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from opengever.meeting.model import Committee
+from opengever.testing import FunctionalTestCase
+
+
+class TestCommitteeQuery(FunctionalTestCase):
+
+    def setUp(self):
+        super(TestCommitteeQuery, self).setUp()
+
+        self.local_admin_unit = create(
+            Builder('admin_unit')
+            .having(unit_id=u'local')
+            .as_current_admin_unit()
+        )
+        self.local_committee = create(
+            Builder('committee_model')
+            .having(int_id=5678, admin_unit_id=u'local', title=u'Local')
+        )
+        self.remote_admin_unit = create(
+            Builder('admin_unit')
+            .having(unit_id=u'remote')
+        )
+        self.remote_committee = create(
+            Builder('committee_model')
+            .having(int_id=1234, admin_unit_id=u'remote', title=u'Remote')
+        )
+
+    def test_committee_query_limits_by_current_admin_unit(self):
+        self.assertEqual(
+            self.local_committee,
+            Committee.query.by_current_admin_unit().one()
+        )

--- a/opengever/meeting/tests/test_members.py
+++ b/opengever/meeting/tests/test_members.py
@@ -177,6 +177,14 @@ class TestMemberView(FunctionalTestCase):
             browser.css('table#properties').first.lists())
 
     @browsing
+    def test_cant_open_members_of_foreign_admin_units(self, browser):
+        foreign_member = create(Builder('member').having(
+            admin_unit_id='foreign'))
+
+        with browser.expect_http_error(reason='Not Found'):
+            browser.login().open(foreign_member.get_url(self.container))
+
+    @browsing
     def test_show_message_if_member_has_no_memberships(self, browser):
         member = create(Builder('member').having(
             admin_unit_id=self._admin_unit_id))

--- a/opengever/meeting/tests/test_members.py
+++ b/opengever/meeting/tests/test_members.py
@@ -54,7 +54,8 @@ class TestMemberListing(FunctionalTestCase):
     def setUp(self):
         super(TestMemberListing, self).setUp()
         self.container = create(Builder('committee_container'))
-        self.member = create(Builder('member'))
+        self.member = create(Builder('member').having(
+            admin_unit_id=self._admin_unit_id))
 
         # CommitteeResponsible is assigned globally here for the sake of
         # simplicity
@@ -78,6 +79,7 @@ class TestMemberListing(FunctionalTestCase):
         self.assertEqual(u'Hanspeter', hans.firstname)
         self.assertEqual(u'Hansj\xf6rg', hans.lastname)
         self.assertEqual(u'foo@example.com', hans.email)
+        self.assertEqual(u'admin-unit-1', hans.admin_unit_id)
 
     @browsing
     def test_members_can_be_edited_in_browser(self, browser):
@@ -121,7 +123,8 @@ class TestMemberView(FunctionalTestCase):
 
         self.container = create(Builder('committee_container'))
         self.member = create(Builder('member')
-                             .having(email='p.meier@example.com'))
+                             .having(email='p.meier@example.com',
+                                     admin_unit_id=self._admin_unit_id))
         self.member_wrapper = MemberWrapper.wrap(self.container, self.member)
         self.committee = create(Builder('committee')
                                 .with_default_period()
@@ -160,7 +163,8 @@ class TestMemberView(FunctionalTestCase):
 
     @browsing
     def test_show_message_if_member_has_no_memberships(self, browser):
-        member = create(Builder('member'))
+        member = create(Builder('member').having(
+            admin_unit_id=self._admin_unit_id))
         browser.login().open(member.get_url(self.container))
         self.assertEqual(
             'This member has no memberships.',

--- a/opengever/meeting/tests/test_members.py
+++ b/opengever/meeting/tests/test_members.py
@@ -109,6 +109,21 @@ class TestMemberListing(FunctionalTestCase):
         self.assertEqual(u'M\xfcller Peter', link.get('title'))
         self.assertEqual(u'M\xfcller Peter', link.text)
 
+    @browsing
+    def test_only_local_members_are_listed(self, browser):
+        create(Builder('member').having(
+            admin_unit_id='foreign', firstname=u'Hans', lastname=u'Jakobi')
+        )
+
+        browser.login()
+        browser.open(self.container, view='tabbedview_view-members')
+        items = browser.css('table.listing').first.dicts()
+        self.assertEqual(1, len(items))
+        self.assertEqual(
+            [{'Lastname': u'M\xfcller', 'Firstname': 'Peter', 'E-Mail': ''}],
+            items
+        )
+
 
 class TestMemberView(FunctionalTestCase):
 

--- a/opengever/meeting/tests/test_memberships.py
+++ b/opengever/meeting/tests/test_memberships.py
@@ -39,7 +39,9 @@ class TestMemberships(FunctionalTestCase):
         self.committee = create(Builder('committee')
                                 .with_default_period()
                                 .within(self.container))
-        self.member = create(Builder('member'))
+        self.member = create(Builder('member').having(
+            admin_unit_id=self._admin_unit_id)
+        )
         self.member_wrapper = MemberWrapper.wrap(self.container, self.member)
 
         # CommitteeResponsible is assigned globally here for the sake of

--- a/opengever/meeting/tests/test_proposal.py
+++ b/opengever/meeting/tests/test_proposal.py
@@ -16,7 +16,6 @@ from opengever.meeting.model import SubmittedDocument
 from opengever.meeting.proposal import IProposal
 from opengever.meeting.proposal import ISubmittedProposal
 from opengever.officeconnector.helpers import is_officeconnector_checkout_feature_enabled
-from opengever.testing import index_data_for
 from opengever.testing import IntegrationTestCase
 from opengever.testing import solr_data_for
 from opengever.testing import SolrIntegrationTestCase

--- a/opengever/meeting/tests/test_vocabularies.py
+++ b/opengever/meeting/tests/test_vocabularies.py
@@ -26,8 +26,11 @@ class TestProposalTransitionsVocabulary(IntegrationTestCase):
 
 class TestCommitteeVocabularies(IntegrationTestCase):
 
-    def test_committeee_vocabulary_list_all_committees(self):
+    def test_committeee_vocabulary_list_all_local_committees(self):
         self.login(self.committee_responsible)
+
+        create(Builder('committee_model').having(admin_unit_id='foreign'))
+
         factory = getUtility(IVocabularyFactory,
                              name='opengever.meeting.CommitteeVocabulary')
         self.assertItemsEqual(
@@ -35,8 +38,11 @@ class TestCommitteeVocabularies(IntegrationTestCase):
              self.committee.load_model()],
             [term.value for term in factory(context=None)])
 
-    def test_active_committeee_vocabulary_list_only_active_committees(self):
+    def test_active_committeee_vocabulary_list_only_active_local_committees(self):
         self.login(self.committee_responsible)
+
+        create(Builder('committee_model').having(admin_unit_id='foreign'))
+
         factory = getUtility(IVocabularyFactory,
                              name='opengever.meeting.ActiveCommitteeVocabulary')
         self.assertItemsEqual(

--- a/opengever/meeting/vocabulary.py
+++ b/opengever/meeting/vocabulary.py
@@ -95,11 +95,14 @@ class MemberVocabulary(object):
     def __call__(self, context):
         terms = []
 
-        for member in Member.query.order_by(Member.fullname):
+        for member in self.get_members():
             terms.append(SimpleTerm(value=member,
                                     token=member.member_id,
                                     title=member.fullname))
         return SimpleVocabulary(terms)
+
+    def get_members(self):
+        return Member.query.by_current_admin_unit().order_by(Member.fullname)
 
 
 @provider(IContextSourceBinder)

--- a/opengever/meeting/vocabulary.py
+++ b/opengever/meeting/vocabulary.py
@@ -48,7 +48,7 @@ class CommitteeVocabulary(object):
         ])
 
     def get_committees(self):
-        return Committee.query.order_by('title').all()
+        return Committee.query.by_current_admin_unit().order_by('title').all()
 
 
 @implementer(IVocabularyFactory)
@@ -67,7 +67,7 @@ class ActiveCommitteeVocabulary(object):
         ])
 
     def get_committees(self):
-        return Committee.query.active().order_by('title').all()
+        return Committee.query.by_current_admin_unit().active().order_by('title').all()
 
 
 @implementer(IVocabularyFactory)

--- a/opengever/testing/builders/sql.py
+++ b/opengever/testing/builders/sql.py
@@ -415,6 +415,7 @@ class MemberBuilder(SqlObjectBuilder):
         super(MemberBuilder, self).__init__(session)
         self.arguments['firstname'] = u'Peter'
         self.arguments['lastname'] = u'M\xfcller'
+        self.arguments['admin_unit_id'] = 'foo'
 
 
 builder_registry.register('member', MemberBuilder)

--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -2034,7 +2034,8 @@ class OpengeverContentFixture(object):
     ):
         member = create(
             Builder('member')
-            .having(firstname=firstname, lastname=lastname, email=email)
+            .having(firstname=firstname, lastname=lastname, email=email,
+                    admin_unit_id=self.admin_unit.unit_id)
         )
 
         create(


### PR DESCRIPTION
With this PR we enable support for `opengever.meeting` in a cluster with multiple admin-units. No cross admin-unit communication is supported yet. But multiple separate deployments can now have `opengever.meeting` activated individually in the same cluster.

We make sure that:
- only local committees are selectable, where appropriate
- make sure that members are linked to an admin-unit, and only local members are displayed on each admin-unit

Notes/thoughts about the upgrade to add admin-unit to members:
-  We apply a graceful strategy in case we find a deployment in invalid state. Instead of failing hard and blocking a potential upgrade path we migrate using a placeholder and notify that manual cleanup is needed. We don't expect any deployments in such state as it is currently not supported.
- Sample sentry messages are provided in:
  - https://sentry.4teamwork.ch/organizations/sentry/issues/69805/?project=17
  - https://sentry.4teamwork.ch/organizations/sentry/issues/69804/?project=17
- There is no foreign-key constraint to the admin-unit, this is consistent with `Committee` and purposefully omitted with future servicification in mind. See: https://github.com/4teamwork/opengever.core/blob/73af257f462f1e3268cc7b9a745fd6f870e77222/opengever/meeting/model/committee.py#L55

Jira: https://4teamwork.atlassian.net/browse/CA-1116

- [ ] 🚧 &nbsp; once this PR is merged, remove the sample sentry issues

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


## Checklist (if applicable)

- DB-Schema migration
  - [x] All changes on a model (columns, etc) are included in a DB-schema migration.
  - [x] Constraint names are shorter than 30 characters (`Oracle`)