### PR TITLE
Don't save notification setting with default values as custom notification setting

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2020.14.0 (unreleased)
 ----------------------
 
+- Don't save notification setting with default values as custom notification setting. [tinagerber]
 - Add @notification-settings API endpoint. [tinagerber]
 - Fix an encoding error on the local contacts tab. [deiferni]
 - Prevent notification mails being bounced due to blacklisted URL in comment. [deiferni]

--- a/opengever/activity/notification_settings.py
+++ b/opengever/activity/notification_settings.py
@@ -300,10 +300,10 @@ class NotificationSettings(object):
 
     def set_custom_setting(self, setting_kind, userid, mail_roles=None,
                            badge_roles=None, digest_roles=None, use_default=False):
+        default_setting = self._get_default_notification_settings().get(setting_kind)
         setting = self._get_custom_notification_settings(userid).get(setting_kind)
         if not setting:
             if use_default:
-                default_setting = self._get_default_notification_settings().get(setting_kind)
                 setting = model.NotificationSetting(
                     kind=setting_kind, userid=userid,
                     _badge_notification_roles=default_setting._badge_notification_roles,
@@ -322,6 +322,11 @@ class NotificationSettings(object):
         if digest_roles is not None:
             setting.digest_notification_roles = digest_roles
 
+        if setting.digest_notification_roles == default_setting.digest_notification_roles  \
+           and setting.mail_notification_roles == default_setting.mail_notification_roles  \
+           and setting.badge_notification_roles == default_setting.badge_notification_roles:
+            self.remove_custom_setting(setting_kind, userid)
+            return default_setting
         return setting
 
     def is_custom_setting(self, setting):
@@ -336,7 +341,7 @@ class NotificationSettings(object):
             setattr(self, '_default_notification_settings', {
                 default.kind: default for default
                 in model.NotificationDefault.query
-                })
+            })
 
         return self._default_notification_settings
 

--- a/opengever/api/tests/test_notification_settings.py
+++ b/opengever/api/tests/test_notification_settings.py
@@ -206,6 +206,21 @@ class TestNotificationSettings(IntegrationTestCase):
         self.assertEqual(frozenset([]),
                          setting.digest_notification_roles)
 
+    def test_set_default_as_custom_setting_does_not_add_custom_setting(self):
+        notification_settings = NotificationSettings()
+        userid = self.regular_user.getId()
+
+        default = notification_settings.get_setting('task-added-or-reassigned', userid)
+
+        notification_settings.set_custom_setting(
+            'task-added-or-reassigned', userid,
+            mail_roles=[role for role in default.mail_notification_roles],
+            badge_roles=[role for role in default.badge_notification_roles],
+            digest_roles=[role for role in default.digest_notification_roles])
+
+        new_setting = notification_settings.get_setting('task-added-or-reassigned', userid)
+        self.assertIsInstance(new_setting, model.NotificationDefault)
+
     def test_is_custom_setting_returns_true_if_setting_is_a_custom_setting(self):
         userid = self.regular_user.getId()
         notification_settings = NotificationSettings()


### PR DESCRIPTION
Until now a notification setting with the same values as NotificationDefault could be saved as NotificationSetting. Now the notification setting is deleted if it matches the NotificationDefault.

Jira: https://4teamwork.atlassian.net/browse/NE-99

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)