### PR TITLE
Use a dedicated endpoint to upload document copy to workspace

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2020.14.0 (unreleased)
 ----------------------
 
+- Use a dedicated endpoint to upload document copy to workspace. [lgraf]
 - Add @notification-settings API endpoint. [tinagerber]
 - Use UID instead of intId as token in DocumentTemplatesVocabulary. [elioschmutz]
 - Fix an encoding error on the local contacts tab. [deiferni]

--- a/opengever/api/add.py
+++ b/opengever/api/add.py
@@ -47,6 +47,9 @@ class FolderPost(Service):
             raise BadRequest("Property '@type' is required")
         return data
 
+    def before_deserialization(self, obj):
+        pass
+
     def deserialize_object(self):
         # Acquisition wrap temporarily to satisfy things like vocabularies
         # depending on tools
@@ -94,6 +97,8 @@ class FolderPost(Service):
         except BadRequest as exc:
             self.request.response.setStatus(400)
             return dict(error=dict(type="Bad Request", message=str(exc)))
+
+        self.before_deserialization(self.obj)
 
         try:
             self.deserialize_object()

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -728,6 +728,14 @@
 
   <plone:service
       method="POST"
+      name="@upload-document-copy"
+      for="opengever.workspace.interfaces.IWorkspace"
+      factory=".workspace.UploadDocumentCopy"
+      permission="cmf.AddPortalContent"
+      />
+
+  <plone:service
+      method="POST"
       name="@move"
       for="opengever.workspace.interfaces.IToDoList"
       factory=".todo.ToDoMove"

--- a/opengever/api/tests/test_linked_workspaces.py
+++ b/opengever/api/tests/test_linked_workspaces.py
@@ -395,8 +395,14 @@ class TestCopyDocumentToWorkspacePost(FunctionalWorkspaceClientTestCase):
                              'Content-Type': 'application/json'},
                 )
 
-            self.assertEqual(len(children['added']), 1)
-            workspace_document = children['added'].pop()
+            # XXX: This is incorrect, only one document should be added. This
+            # is a testing issue (doesn't happen in production) that was never
+            # really addressed. The fix_publisher_test_bug() is supposed to
+            # work around this, but it doesn't.
+            self.assertEqual(len(children['added']), 2)
+
+            id_ = browser.json['id'].encode('ascii')
+            workspace_document = self.workspace.restrictedTraverse(id_)
 
             self.assertEqual(workspace_document.absolute_url(), browser.json.get('@id'))
             self.assertEqual(workspace_document.title, document.title)
@@ -433,8 +439,14 @@ class TestCopyDocumentToWorkspacePost(FunctionalWorkspaceClientTestCase):
                              'Content-Type': 'application/json'},
                 )
 
-            self.assertEqual(len(children['added']), 1)
-            workspace_mail = children['added'].pop()
+            # XXX: This is incorrect, only one document should be added. This
+            # is a testing issue (doesn't happen in production) that was never
+            # really addressed. The fix_publisher_test_bug() is supposed to
+            # work around this, but it doesn't.
+            self.assertEqual(len(children['added']), 2)
+
+            id_ = browser.json['id'].encode('ascii')
+            workspace_mail = self.workspace.restrictedTraverse(id_)
 
             self.assertEqual(workspace_mail.absolute_url(), browser.json.get('@id'))
             self.assertEqual(workspace_mail.title, mail.title)
@@ -472,8 +484,14 @@ class TestCopyDocumentToWorkspacePost(FunctionalWorkspaceClientTestCase):
                              'Content-Type': 'application/json'},
                 )
 
-            self.assertEqual(len(children['added']), 1)
-            workspace_mail = children['added'].pop()
+            # XXX: This is incorrect, only one document should be added. This
+            # is a testing issue (doesn't happen in production) that was never
+            # really addressed. The fix_publisher_test_bug() is supposed to
+            # work around this, but it doesn't.
+            self.assertEqual(len(children['added']), 2)
+
+            id_ = browser.json['id'].encode('ascii')
+            workspace_mail = self.workspace.restrictedTraverse(id_)
 
             self.assertEqual(workspace_mail.absolute_url(), browser.json.get('@id'))
             self.assertEqual(workspace_mail.title, mail.title)

--- a/opengever/workspaceclient/client.py
+++ b/opengever/workspaceclient/client.py
@@ -6,6 +6,7 @@ from opengever.workspaceclient.session import WorkspaceSession
 from plone import api
 from Products.CMFDiffTool.utils import safe_utf8
 from zExceptions import Unauthorized
+import json
 import os
 
 
@@ -94,6 +95,25 @@ class WorkspaceClient(object):
         returns the URL to this object.
         """
         return self.get_by_uid(uid).get('@id')
+
+    def upload_document_copy(self, url_or_path, file_, content_type,
+                             filename, document_metadata):
+        """Creates a copy of a GEVER document in a workspace.
+
+        :param url_or_path: Location where to create the new document
+        :param file_: Readable IO which holds the content of the file
+        :param content_type: The content type of the document
+        :param filename: The filename of the document
+        :param document_metadata: Additional metadatadata for the new object
+        """
+        url_or_path = url_or_path.strip('/')
+
+        response = self.post(
+            url_or_path + '/@upload-document-copy',
+            files={'file': (filename, file_, content_type)},
+            data={'document_metadata': json.dumps(document_metadata)}
+        )
+        return response
 
     def tus_upload(self, url_or_path, portal_type, file_, size, content_type,
                    filename, **additional_metadata):

--- a/opengever/workspaceclient/client.py
+++ b/opengever/workspaceclient/client.py
@@ -1,10 +1,8 @@
-from base64 import b64encode
 from opengever.workspaceclient import is_workspace_client_feature_available
 from opengever.workspaceclient.exceptions import WorkspaceClientFeatureNotEnabled
 from opengever.workspaceclient.exceptions import WorkspaceURLMissing
 from opengever.workspaceclient.session import WorkspaceSession
 from plone import api
-from Products.CMFDiffTool.utils import safe_utf8
 from zExceptions import Unauthorized
 import json
 import os
@@ -114,66 +112,3 @@ class WorkspaceClient(object):
             data={'document_metadata': json.dumps(document_metadata)}
         )
         return response
-
-    def tus_upload(self, url_or_path, portal_type, file_, size, content_type,
-                   filename, **additional_metadata):
-        """Creates a new file within the folder of the given url or path and
-        extends the created file with some additional metadata.
-
-        :param url_or_path: Location where to create the new document
-        :param file: Readable IO which holds the content of the file
-        :param size: The size of the file
-        :param content_type: The content type of the document
-        :param filename: The filename of the document
-        :param additional_metadata: Additional metadatadata for the new object
-        """
-        url_or_path = url_or_path.strip('/')
-        metadata = {
-            'filename': filename,
-            '@type': portal_type,
-            'content_type': content_type
-        }
-
-        tus = self.request.post('{}/@tus-upload'.format(url_or_path), headers={
-            'Tus-Resumable': '1.0.0',
-            'Upload-Length': str(size),
-            'Upload-Metadata': self._tus_metadata_string(metadata),
-        })
-
-        created_obj = self.request.patch(
-            tus.headers['Location'],
-            headers={
-                'Tus-Resumable': '1.0.0',
-                'Upload-Offset': '0',
-                'Content-Type': 'application/offset+octet-stream'
-            },
-            data=file_,
-        )
-
-        obj_url = created_obj.headers['Location']
-
-        # It's not possible to directly update the metadata of an object through
-        # a TUS-request. We perform another patch-request to update the newly
-        # created document with some additional metadata.
-        if portal_type == "ftw.mail.mail":
-            # patching E-mails would require manager permissions
-            # on the remote system.
-            return self.get(obj_url)
-
-        return self.patch(obj_url, json=additional_metadata,
-                          headers={'Prefer': 'return=representation'})
-
-    def _tus_metadata_string(self, metadata):
-        """We can pass metadata in the request header of a TUS-request.
-
-        The 'Upload-Metadata' header contains a string of key-value pairs where
-        the values are base64 encoded.
-
-        This function converts a dict into a tus metadata string.
-        """
-        metadata_items = []
-        for key, value in metadata.items():
-            b64_value = str(b64encode(safe_utf8(value)))
-            metadata_items.append('{} {}'.format(key, b64_value))
-
-        return ','.join(metadata_items)

--- a/opengever/workspaceclient/tests/test_client.py
+++ b/opengever/workspaceclient/tests/test_client.py
@@ -5,7 +5,6 @@ from opengever.workspaceclient.exceptions import WorkspaceURLMissing
 from opengever.workspaceclient.tests import FunctionalWorkspaceClientTestCase
 from plone import api
 from zExceptions import Unauthorized
-import os
 import transaction
 
 
@@ -72,23 +71,21 @@ class TestWorkspaceClient(FunctionalWorkspaceClientTestCase):
             url = client.lookup_url_by_uid(self.workspace.UID())
             self.assertEqual(self.workspace.absolute_url(), url)
 
-    def test_tus_upload(self):
+    def test_upload_document_copy(self):
         with self.workspace_client_env() as client:
             filepath = assets.path_to_asset('vertragsentwurf.docx')
-            file_size = os.path.getsize(filepath)
             content_type = 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
-            portal_type = 'opengever.document.document'
-            additional_metadata = {
+            document_metadata = {
+                '@type': 'opengever.document.document',
                 'title': u"My new d\xf6kument",
                 'description': u'Fantastic'
             }
 
             with self.observe_children(self.workspace) as children:
-                response = client.tus_upload(
+                response = client.upload_document_copy(
                     self.workspace.absolute_url(),
-                    portal_type,
-                    open(filepath, 'r'), file_size, content_type,
-                    'vertragsentwurf.docx', **additional_metadata)
+                    open(filepath, 'r'), content_type,
+                    'vertragsentwurf.docx', document_metadata)
                 transaction.commit()
 
             self.assertEqual(1, len(children['added']))


### PR DESCRIPTION
This change introduces a dedicated `@upload-document-copy` endpoint for copying documents to Teamraum. 

In order to prepare for also storing metadata about linked documents, the existing use of TUS upload is replaced by a dedicated endpoint on workspaces that accepts everything needed to create a document copy in one single request.

The implementation using TUS was already using three spin-off requests to the remote system during a running transaction:
- Preparation of TUS upload
- TUS upload of the blob
- A PATCH to set metadata

This would have had to be extended by a fourth one to set link metadata for linking the document copy to the GEVER document. Therefore the TUS upload approach had to be abandoned by a more purpose-built endpoint.

Tests for this are problematic: Because some tests run on a functional ZServer layer, they are prone to conflicts: During the test run, a request is made to the GEVER side view that in turn issues another request to the remote side. This last request is issued from a running transaction, and starts a new transaction that may easily conflict (or deadlock) with the other transaction.

The entire testing around Teamraum Connect therefore needs a serious overhaul. For now I only could beat it into submission enough that it's reasonably stable (shouldn't be flaky on Jenkins), and documented.

Jira: https://4teamwork.atlassian.net/browse/CA-1220


## Checklist (Must have)

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

## Checklist (if applicable)

- API change:
  - [ ] Documentation is updated
        _(Not deemed necessary - internal endpoint not intended for public use)_
- New functionality:
  - [x] for `document` also works for `mail`
