### PR TITLE
No longer exclude trashed documents in @listing-stats endpoint

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 ----------------------
 
 - Use a dedicated endpoint to upload document copy to workspace. [lgraf]
+- No longer exclude trashed documents in @listing-stats endpoint. [tinagerber]
 - Add @notification-settings API endpoint. [tinagerber]
 - Use UID instead of intId as token in DocumentTemplatesVocabulary. [elioschmutz]
 - Add simple support for meetings in a multi-admin-unit cluster. [deiferni]

--- a/opengever/api/listing_stats.py
+++ b/opengever/api/listing_stats.py
@@ -128,7 +128,6 @@ class ListingStats(object):
         already takes care of this future improvement.
         """
         fq = [
-            'trashed:false',
             'path_parent:{}/*'.format(escape(
                 '/'.join(self.context.getPhysicalPath())))
         ]

--- a/opengever/api/tests/test_listing_stats.py
+++ b/opengever/api/tests/test_listing_stats.py
@@ -101,7 +101,7 @@ class TestListingStats(SolrIntegrationTestCase):
         self.assertEqual(4, self.get_facet_by_value(pivot, 'folder_contents').get('count'))
 
     @browsing
-    def test_exclude_trashed_content(self, browser):
+    def test_include_trashed_content(self, browser):
         self.login(self.regular_user, browser)
 
         dossier = create(Builder('dossier').within(self.leaf_repofolder))
@@ -128,7 +128,7 @@ class TestListingStats(SolrIntegrationTestCase):
         )
 
         pivot = self.get_facet_pivot_for(dossier, 'listing_name', browser)
-        self.assertEqual(0, self.get_facet_by_value(pivot, 'documents').get('count'))
+        self.assertEqual(1, self.get_facet_by_value(pivot, 'documents').get('count'))
 
     @browsing
     def test_listing_stats_pivot_queries_full_response(self, browser):


### PR DESCRIPTION
In order for the frontend to show how many documents are in the trash, it must be possible to query this. Therefore, the default filter "trashed:false" must no longer be used in @listing-stats endpoint.

Jira: https://4teamwork.atlassian.net/browse/NE-60

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


## Checklist (if applicable)

_Only applicable should be left and checked._

- API change:
  - [ ] Documentation is updated
  - If breaking:
    - [x] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed