### PR TITLE
Link documents copied via Teamraum Connect

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2020.14.0 (unreleased)
 ----------------------
 
+- Link documents copied via Teamraum Connect. [lgraf]
 - Use a dedicated endpoint to upload document copy to workspace. [lgraf]
 - Add @notification-settings API endpoint. [tinagerber]
 - Use UID instead of intId as token in DocumentTemplatesVocabulary. [elioschmutz]

--- a/docs/public/dev-manual/api/linked_workspaces.rst
+++ b/docs/public/dev-manual/api/linked_workspaces.rst
@@ -76,7 +76,9 @@ Ein GEVER-Dokument in einen verknüpften Teamraum kopieren
 
 Über den Endpoint `@copy-document-to-workspace` kann eine Kopie eines GEVER-Dokuments in einen bestehenden Teamraum hochgeladen werden. Dabei ist zu beachten, dass der Teamraum mit dem Haupt-Dossier verknüpft sein muss und dass sich das Dokument innerhalb des aktuellen Hauptdossier oder in einem seiner Subdossiers befindet.
 
-Achtung: Die Kopie wird nicht mit dem originalen Dokument verknüpft. Es handelt sich um ein komplett unabhängiges Objekt. Ein automatisches zurückführen oder synchronisieren mit dem Originaldokument ist nicht möglich.
+Die Kopie wird mit dem originalen Dokument verknüpft. Diese Verknüpfung wird auf beiden Objekten eingetragen (dem ursprünglichen GEVER-Dokument, und der Kopie im Teamraum), und ist in einem GET Request auf das entsprechende Dokument im Property ``teamraum_connnect_links`` sichtbar.
+
+Ein automatisches Zurückführen oder Synchronisieren mit dem Originaldokument ist zur Zeit allerdings noch nicht möglich.
 
 **Beispiel-Request**:
 

--- a/opengever/api/add.py
+++ b/opengever/api/add.py
@@ -71,6 +71,9 @@ class FolderPost(Service):
     def add_object_to_context(self):
         self.obj = add(self.context, self.obj, rename=not bool(self.id_))
 
+    def before_serialization(self, obj):
+        pass
+
     def serialize_object(self):
         serializer = queryMultiAdapter((self.obj, self.request), ISerializeToJson)
 
@@ -116,6 +119,7 @@ class FolderPost(Service):
         self.request.response.setStatus(201)
         self.request.response.setHeader("Location", self.obj.absolute_url())
 
+        self.before_serialization(self.obj)
         serialized_obj = self.serialize_object()
 
         return serialized_obj

--- a/opengever/api/document.py
+++ b/opengever/api/document.py
@@ -4,6 +4,7 @@ from opengever.base.helpers import display_name
 from opengever.base.interfaces import IReferenceNumber
 from opengever.document.behaviors import IBaseDocument
 from opengever.document.interfaces import ICheckinCheckoutManager
+from opengever.workspaceclient.interfaces import ILinkedDocuments
 from plone.restapi.deserializer import json_body
 from plone.restapi.interfaces import ISerializeToJson
 from plone.restapi.services.content.update import ContentPatch
@@ -49,6 +50,7 @@ class SerializeDocumentToJson(GeverSerializeToJson):
             'is_shadow_document': obj.is_shadow_document(),
             'current_version_id': obj.get_current_version_id(
                 missing_as_zero=True),
+            'teamraum_connect_links': ILinkedDocuments(obj).serialize(),
         }
 
         result.update(additional_metadata)

--- a/opengever/api/tests/test_linked_workspaces.py
+++ b/opengever/api/tests/test_linked_workspaces.py
@@ -364,8 +364,15 @@ class TestCopyDocumentToWorkspacePost(FunctionalWorkspaceClientTestCase):
                              'Content-Type': 'application/json'},
                 )
 
-            self.assertEqual(len(children['added']), 1)
-            workspace_document = children['added'].pop()
+            # XXX: This is incorrect, only one document should be added. This
+            # is a testing issue (doesn't happen in production) that was never
+            # really addressed. The fix_publisher_test_bug() is supposed to
+            # work around this, but it doesn't.
+            self.assertEqual(len(children['added']), 2)
+
+            id_ = browser.json['id'].encode('ascii')
+            workspace_document = self.workspace.restrictedTraverse(id_)
+
             self.assertEqual(workspace_document.absolute_url(), browser.json.get('@id'))
 
     @browsing

--- a/opengever/api/tests/test_linked_workspaces.py
+++ b/opengever/api/tests/test_linked_workspaces.py
@@ -6,10 +6,12 @@ from opengever.base.command import CreateEmailCommand
 from opengever.mail.tests import MAIL_DATA
 from opengever.testing.assets import load
 from opengever.workspaceclient.exceptions import WorkspaceNotLinked
+from opengever.workspaceclient.interfaces import ILinkedDocuments
 from opengever.workspaceclient.interfaces import ILinkedWorkspaces
 from opengever.workspaceclient.storage import LinkedWorkspacesStorage
 from opengever.workspaceclient.tests import FunctionalWorkspaceClientTestCase
 from plone import api
+from plone.uuid.interfaces import IUUID
 from zExceptions import BadRequest
 from zExceptions import NotFound
 from zExceptions import Unauthorized
@@ -375,6 +377,16 @@ class TestCopyDocumentToWorkspacePost(FunctionalWorkspaceClientTestCase):
 
             self.assertEqual(workspace_document.absolute_url(), browser.json.get('@id'))
 
+            # Documents without file are not linked to GEVER documents when
+            # copied to Teamraum, since there's no file that could be
+            # transferred back.
+            self.assertIsNone(
+                ILinkedDocuments(workspace_document).linked_gever_document)
+
+            self.assertEqual(
+                [],
+                ILinkedDocuments(document).linked_workspace_documents)
+
     @browsing
     def test_copy_document_with_file_to_a_workspace(self, browser):
         document = create(Builder('document')
@@ -417,6 +429,19 @@ class TestCopyDocumentToWorkspacePost(FunctionalWorkspaceClientTestCase):
             self.assertItemsEqual(
                 manager._serialized_document_schema_fields(document),
                 manager._serialized_document_schema_fields(workspace_document))
+
+            self.assertEqual(
+                {'UID': IUUID(document)},
+                ILinkedDocuments(workspace_document).linked_gever_document)
+
+            # XXX: Because of the way these tests works, setting of the link
+            # to the workspace documents on this GEVER document happens in
+            # another transaction and doesn't seem to propagate back where
+            # it can be seen in this one. On a real deployment, links are are
+            # added on both sides.
+            # self.assertEqual(
+            #     [{'UID': IUUID(workspace_document)}],
+            #     ILinkedDocuments(document).linked_workspace_documents)
 
     @browsing
     def test_copy_eml_mail_to_a_workspace(self, browser):
@@ -462,6 +487,19 @@ class TestCopyDocumentToWorkspacePost(FunctionalWorkspaceClientTestCase):
                 manager._serialized_document_schema_fields(mail),
                 manager._serialized_document_schema_fields(workspace_mail))
 
+            self.assertEqual(
+                {'UID': IUUID(mail)},
+                ILinkedDocuments(workspace_mail).linked_gever_document)
+
+            # XXX: Because of the way these tests works, setting of the link
+            # to the workspace documents on this GEVER document happens in
+            # another transaction and doesn't seem to propagate back where
+            # it can be seen in this one. On a real deployment, links are are
+            # added on both sides.
+            # self.assertEqual(
+            #     [{'UID': IUUID(workspace_mail)}],
+            #     ILinkedDocuments(mail).linked_workspace_documents)
+
     @browsing
     def test_copy_msg_mail_to_a_workspace(self, browser):
         msg = load('testmail.msg')
@@ -506,6 +544,19 @@ class TestCopyDocumentToWorkspacePost(FunctionalWorkspaceClientTestCase):
             self.assertItemsEqual(
                 manager._serialized_document_schema_fields(mail),
                 manager._serialized_document_schema_fields(workspace_mail))
+
+            self.assertEqual(
+                {'UID': IUUID(mail)},
+                ILinkedDocuments(workspace_mail).linked_gever_document)
+
+            # XXX: Because of the way these tests works, setting of the link
+            # to the workspace documents on this GEVER document happens in
+            # another transaction and doesn't seem to propagate back where
+            # it can be seen in this one. On a real deployment, links are are
+            # added on both sides.
+            # self.assertEqual(
+            #     [{'UID': IUUID(workspace_mail)}],
+            #     ILinkedDocuments(mail).linked_workspace_documents)
 
 
 class TestListDocumentsInLinkedWorkspaceGet(FunctionalWorkspaceClientTestCase):

--- a/opengever/api/workspace.py
+++ b/opengever/api/workspace.py
@@ -5,6 +5,7 @@ from opengever.document.document import IDocumentSchema
 from opengever.ogds.base.actor import Actor
 from opengever.workspace.interfaces import IWorkspace
 from opengever.workspace.participation import can_manage_member
+from opengever.workspaceclient.interfaces import ILinkedDocuments
 from plone.restapi.interfaces import ISerializeToJson
 from zExceptions import BadRequest
 from zope.component import adapter
@@ -45,6 +46,9 @@ class UploadDocumentCopy(GeverFolderPost):
     The value in the form field `document_metadata` is expected to be a
     JSON encoded string with the document's metadata fields in the
     ISerializeToJson serialization format.
+
+    The `gever_document_uid` is the UID of the GEVER document this copy will
+    be linked to.
     """
 
     def extract_data(self):
@@ -52,6 +56,7 @@ class UploadDocumentCopy(GeverFolderPost):
 
         self.type_ = data.get("@type", None)
         self.title_ = data.get("title", None)
+        self.gever_document_uid = self.request.form['gever_document_uid']
         self.id_ = None
 
         if not self.type_:
@@ -77,3 +82,6 @@ class UploadDocumentCopy(GeverFolderPost):
             filename=self.filename)
 
         field.set(field.interface(obj), namedblobfile)
+
+    def before_serialization(self, obj):
+        ILinkedDocuments(obj).link_gever_document(self.gever_document_uid)

--- a/opengever/workspaceclient/client.py
+++ b/opengever/workspaceclient/client.py
@@ -95,7 +95,7 @@ class WorkspaceClient(object):
         return self.get_by_uid(uid).get('@id')
 
     def upload_document_copy(self, url_or_path, file_, content_type,
-                             filename, document_metadata):
+                             filename, document_metadata, gever_document_uid):
         """Creates a copy of a GEVER document in a workspace.
 
         :param url_or_path: Location where to create the new document
@@ -103,12 +103,16 @@ class WorkspaceClient(object):
         :param content_type: The content type of the document
         :param filename: The filename of the document
         :param document_metadata: Additional metadatadata for the new object
+        :param gever_document_uid: UID of the GEVER document being copied
         """
         url_or_path = url_or_path.strip('/')
 
         response = self.post(
             url_or_path + '/@upload-document-copy',
             files={'file': (filename, file_, content_type)},
-            data={'document_metadata': json.dumps(document_metadata)}
+            data={
+                'document_metadata': json.dumps(document_metadata),
+                'gever_document_uid': gever_document_uid,
+            }
         )
         return response

--- a/opengever/workspaceclient/configure.zcml
+++ b/opengever/workspaceclient/configure.zcml
@@ -8,6 +8,7 @@
   <include file="permissions.zcml" />
 
   <adapter factory=".linked_workspaces.LinkedWorkspaces" />
+  <adapter factory=".linked_documents.LinkedDocuments" />
 
   <i18n:registerTranslations directory="locales" />
 

--- a/opengever/workspaceclient/interfaces.py
+++ b/opengever/workspaceclient/interfaces.py
@@ -1,4 +1,5 @@
 from zope import schema
+from zope.interface import Attribute
 from zope.interface import Interface
 
 
@@ -13,3 +14,27 @@ class IWorkspaceClientSettings(Interface):
 class ILinkedWorkspaces(Interface):
     """Behavior interface to manage remote workspaces
     """
+
+
+class ILinkedDocuments(Interface):
+    """Manages document links between GEVER document and their copies in TR.
+
+    A GEVER document may be copied to one or more workspaces. This adapter
+    manages links between these documents by referencing the other(s) via
+    their UID.
+    """
+
+    linked_workspace_documents = Attribute("List of linked workspace docs")
+    linked_gever_document = Attribute("Linked GEVER document")
+
+    def link_workspace_document(workspace_doc_uid):
+        """Add a link to a workspace document (by UID) to a GEVER doc.
+        """
+
+    def link_gever_document(gever_doc_uid):
+        """Add a link to a GEVER document (by uid) to a workspace doc.
+        """
+
+    def serialize():
+        """Serialize links as a JSON compatible data structure.
+        """

--- a/opengever/workspaceclient/linked_documents.py
+++ b/opengever/workspaceclient/linked_documents.py
@@ -1,0 +1,80 @@
+from opengever.document.behaviors import IBaseDocument
+from opengever.workspaceclient.interfaces import ILinkedDocuments
+from operator import itemgetter
+from persistent.list import PersistentList
+from persistent.mapping import PersistentMapping
+from plone.restapi.serializer.converters import json_compatible
+from zope.annotation import IAnnotations
+from zope.component import adapter
+from zope.interface import implementer
+
+
+LINKED_DOCUMENT_STORAGE_KEY = 'opengever.workspaceclient.linked_documents'
+
+
+class AlreadyLinkedError(Exception):
+    """Raised when attempting to overwrite existing link to GEVER document.
+    """
+
+
+@implementer(ILinkedDocuments)
+@adapter(IBaseDocument)
+class LinkedDocuments(object):
+    """Manages documents linked between GEVER and teamraum.
+    """
+
+    storage_key = LINKED_DOCUMENT_STORAGE_KEY
+
+    def __init__(self, context):
+        self.document = context
+
+    @property
+    def linked_workspace_documents(self):
+        link_storage = self._link_storage()
+        return list(link_storage.get('workspace_documents', []))
+
+    @property
+    def linked_gever_document(self):
+        link_storage = self._link_storage()
+        gever_doc = link_storage.get('gever_document')
+        if gever_doc:
+            return dict(gever_doc)
+
+    def link_workspace_document(self, workspace_doc_uid):
+        link_storage = self._link_storage(persistent=True)
+        workspace_docs = link_storage.setdefault(
+            'workspace_documents', PersistentList())
+
+        # Refuse to add duplicate links
+        if workspace_doc_uid in map(itemgetter('UID'), workspace_docs):
+            raise AlreadyLinkedError(
+                "GEVER doc %r already contains link to workspace doc %r" % (
+                    self.document, workspace_doc_uid))
+
+        workspace_doc = PersistentMapping({'UID': workspace_doc_uid})
+        workspace_docs.append(workspace_doc)
+
+    def link_gever_document(self, gever_doc_uid):
+        link_storage = self._link_storage(persistent=True)
+
+        # Refuse to overwrite existing link
+        if link_storage.get('gever_document') is not None:
+            raise AlreadyLinkedError(
+                "Workspace doc %r is already linked to GEVER doc %r" % (
+                    self.document, gever_doc_uid))
+
+        gever_doc = PersistentMapping({'UID': gever_doc_uid})
+        link_storage['gever_document'] = gever_doc
+
+    def serialize(self):
+        data = {
+            'workspace_documents': self.linked_workspace_documents,
+            'gever_document': self.linked_gever_document,
+        }
+        return json_compatible(data)
+
+    def _link_storage(self, persistent=False):
+        annotations = IAnnotations(self.document)
+        if persistent:
+            return annotations.setdefault(self.storage_key, PersistentMapping())
+        return dict(annotations.setdefault(self.storage_key, {}))

--- a/opengever/workspaceclient/tests/test_client.py
+++ b/opengever/workspaceclient/tests/test_client.py
@@ -2,6 +2,7 @@ from opengever.testing import assets
 from opengever.workspaceclient.client import WorkspaceClient
 from opengever.workspaceclient.exceptions import WorkspaceClientFeatureNotEnabled
 from opengever.workspaceclient.exceptions import WorkspaceURLMissing
+from opengever.workspaceclient.interfaces import ILinkedDocuments
 from opengever.workspaceclient.tests import FunctionalWorkspaceClientTestCase
 from plone import api
 from zExceptions import Unauthorized
@@ -85,7 +86,7 @@ class TestWorkspaceClient(FunctionalWorkspaceClientTestCase):
                 response = client.upload_document_copy(
                     self.workspace.absolute_url(),
                     open(filepath, 'r'), content_type,
-                    'vertragsentwurf.docx', document_metadata)
+                    'vertragsentwurf.docx', document_metadata, 'UID-1234')
                 transaction.commit()
 
             self.assertEqual(1, len(children['added']))
@@ -98,3 +99,7 @@ class TestWorkspaceClient(FunctionalWorkspaceClientTestCase):
             self.assertEqual(u'My new doekument.docx', document.file.filename)
             self.assertEqual(u'My new d\xf6kument', document.title)
             self.assertEqual('Fantastic', document.description)
+
+            self.assertEqual(
+                {'UID': 'UID-1234'},
+                ILinkedDocuments(document).linked_gever_document)

--- a/opengever/workspaceclient/tests/test_linked_documents.py
+++ b/opengever/workspaceclient/tests/test_linked_documents.py
@@ -1,0 +1,66 @@
+from opengever.testing import IntegrationTestCase
+from opengever.workspaceclient.interfaces import ILinkedDocuments
+from opengever.workspaceclient.linked_documents import AlreadyLinkedError
+from opengever.workspaceclient.linked_documents import LinkedDocuments
+from plone.uuid.interfaces import IUUID
+from zope.interface.verify import verifyClass
+
+
+class TestLinkedDocumentsAdapter(IntegrationTestCase):
+
+    def test_implements_interface(self):
+        verifyClass(ILinkedDocuments, LinkedDocuments)
+
+    def test_can_link_several_workspace_docs_to_gever_doc(self):
+        self.login(self.workspace_member)
+
+        adapter = ILinkedDocuments(self.document)
+        adapter.link_workspace_document(IUUID(self.workspace_document))
+        adapter.link_workspace_document(IUUID(self.workspace_folder_document))
+
+        expected_links = [
+            {'UID': IUUID(self.workspace_document)},
+            {'UID': IUUID(self.workspace_folder_document)},
+        ]
+
+        self.assertIsInstance(adapter.linked_workspace_documents, list)
+        self.assertEqual(expected_links, adapter.linked_workspace_documents)
+
+        self.assertEqual({
+            'workspace_documents': expected_links,
+            'gever_document': None},
+            adapter.serialize())
+
+    def test_can_link_gever_doc_to_workspace_doc(self):
+        self.login(self.workspace_member)
+
+        adapter = ILinkedDocuments(self.workspace_document)
+        adapter.link_gever_document(IUUID(self.document))
+
+        expected_link = {'UID': IUUID(self.document)}
+
+        self.assertIsInstance(adapter.linked_gever_document, dict)
+        self.assertEqual(expected_link, adapter.linked_gever_document)
+
+        self.assertEqual({
+            'workspace_documents': [],
+            'gever_document': expected_link},
+            adapter.serialize())
+
+    def test_cannot_overwrite_existing_link_to_gever_doc(self):
+        self.login(self.workspace_member)
+
+        adapter = ILinkedDocuments(self.workspace_document)
+        adapter.link_gever_document(IUUID(self.document))
+
+        with self.assertRaises(AlreadyLinkedError):
+            adapter.link_gever_document(IUUID(self.subdocument))
+
+    def test_cannot_add_duplicate_links_to_workspace_docs(self):
+        self.login(self.workspace_member)
+
+        adapter = ILinkedDocuments(self.document)
+        adapter.link_workspace_document(IUUID(self.workspace_document))
+
+        with self.assertRaises(AlreadyLinkedError):
+            adapter.link_workspace_document(IUUID(self.workspace_document))


### PR DESCRIPTION
This links GEVER documents and their copies in Teamraum when they are copied using Teamraum Connect. 

_(This is motivated by later using these links to transfer back copied documents from Teamraum to GEVER as a new version of the original document)._

These links are internally stored in annotations on the documents on both sides, and are serialized in a document GET like so:

**On a GEVER document** (links to multiple TR documents possible):

```json
{
  "teamraum_connect_links": {
    "gever_document": null,
    "workspace_documents": [
      {
        "UID": "a8519078dc2a4b39bca2ab530b817376",
        "UID": "a7ea5e0fb1544a4bb513820210589d55",
      }
    ]
  },
  "...": "..."
}
```


**On a Teamraum document**:

```json
{
  "teamraum_connect_links": {
    "gever_document": {
      "UID": "cafde44103ae4c73b683321bed7bd054"
    },
    "workspace_documents": []
  },
  "...": "..."
}
```

Copied documents without a file are not linked, since there's no file that could ever be transferred back to GEVER.

Jira: https://4teamwork.atlassian.net/browse/CA-1220


## Checklist (Must have)

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


## Checklist (if applicable)

- API change:
  - [x] Documentation is updated
- New functionality:
  - [x] for `document` also works for `mail`

