### PR TITLE
Prevent checked out documents from being copied to or from a teamraum

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2020.14.0 (unreleased)
 ----------------------
 
+- Prevent documents from being copied to workspace when checked out. [lgraf]
 - Link documents copied via Teamraum Connect. [lgraf]
 - Use a dedicated endpoint to upload document copy to workspace. [lgraf]
 - Add @notification-settings API endpoint. [tinagerber]

--- a/opengever/api/linked_workspaces.py
+++ b/opengever/api/linked_workspaces.py
@@ -2,6 +2,7 @@ from functools import wraps
 from opengever.base.sentry import maybe_report_exception
 from opengever.document.behaviors import IBaseDocument
 from opengever.workspaceclient import is_workspace_client_feature_available
+from opengever.workspaceclient.exceptions import CopyFromWorkspaceForbidden
 from opengever.workspaceclient.interfaces import ILinkedWorkspaces
 from plone import api
 from plone.app.uuid.utils import uuidToObject
@@ -241,8 +242,14 @@ class CopyDocumentFromWorkspacePost(LinkedWorkspacesService):
         alsoProvides(self.request, IDisableCSRFProtection)
 
         workspace_uid, document_uid = self.validate_data(json_body(self.request))
-        document = ILinkedWorkspaces(self.context).copy_document_from_workspace(
-            workspace_uid, document_uid)
+        try:
+            document = ILinkedWorkspaces(self.context).copy_document_from_workspace(
+                workspace_uid, document_uid)
+        except CopyFromWorkspaceForbidden:
+            raise BadRequest(
+                "Document can't be copied from workspace because it's "
+                "currently checked out")
+
         return self.serialize_object(document)
 
     def serialize_object(self, obj):

--- a/opengever/api/linked_workspaces.py
+++ b/opengever/api/linked_workspaces.py
@@ -181,6 +181,11 @@ class CopyDocumentToWorkspacePost(LinkedWorkspacesService):
         if not document or not IBaseDocument.providedBy(document):
             raise BadRequest("The document does not exist")
 
+        if document.is_checked_out():
+            raise BadRequest(
+                "Document can't be copied to a workspace because it's "
+                "currently checked out")
+
         if not self.obj_contained_in(document, self.context):
             raise BadRequest(
                 "Only documents within the current main dossier are allowed")

--- a/opengever/api/tests/test_linked_workspaces.py
+++ b/opengever/api/tests/test_linked_workspaces.py
@@ -3,6 +3,7 @@ from ftw.builder import create
 from ftw.testbrowser import browsing
 from ftw.testbrowser.exceptions import HTTPServerError
 from opengever.base.command import CreateEmailCommand
+from opengever.document.interfaces import ICheckinCheckoutManager
 from opengever.mail.tests import MAIL_DATA
 from opengever.testing.assets import load
 from opengever.workspaceclient.exceptions import WorkspaceNotLinked
@@ -15,6 +16,7 @@ from plone.uuid.interfaces import IUUID
 from zExceptions import BadRequest
 from zExceptions import NotFound
 from zExceptions import Unauthorized
+from zope.component import getMultiAdapter
 import json
 import requests_mock
 import transaction
@@ -557,6 +559,44 @@ class TestCopyDocumentToWorkspacePost(FunctionalWorkspaceClientTestCase):
             # self.assertEqual(
             #     [{'UID': IUUID(workspace_mail)}],
             #     ILinkedDocuments(mail).linked_workspace_documents)
+
+    @browsing
+    def test_copy_document_to_workspace_is_prevented_if_checked_out(self, browser):
+        document = create(Builder('document')
+                          .within(self.dossier)
+                          .with_dummy_content())
+
+        manager = getMultiAdapter((document, self.request), ICheckinCheckoutManager)
+        manager.checkout()
+
+        payload = {
+            'document_uid': document.UID(),
+            'workspace_uid': self.workspace.UID(),
+        }
+
+        with self.workspace_client_env():
+            manager = ILinkedWorkspaces(self.dossier)
+            manager.storage.add(self.workspace.UID())
+            transaction.commit()
+
+            browser.login()
+            fix_publisher_test_bug(browser, document)
+            with self.observe_children(self.workspace) as children:
+                with browser.expect_http_error(code=400):
+                    browser.open(
+                        self.dossier.absolute_url() + '/@copy-document-to-workspace',
+                        data=json.dumps(payload),
+                        method='POST',
+                        headers={'Accept': 'application/json',
+                                 'Content-Type': 'application/json'},
+                    )
+
+            self.assertEqual(len(children['added']), 0)
+            self.assertEqual(
+                {u'type': u'BadRequest',
+                 u'message': u"Document can't be copied to a workspace "
+                             u"because it's currently checked out"},
+                browser.json)
 
 
 class TestListDocumentsInLinkedWorkspaceGet(FunctionalWorkspaceClientTestCase):

--- a/opengever/workspaceclient/exceptions.py
+++ b/opengever/workspaceclient/exceptions.py
@@ -37,3 +37,9 @@ class WorkspaceNotFound(Exception):
     def __init__(self):
         super(WorkspaceNotFound, self).__init__(
             'No workspace found.')
+
+
+class CopyToWorkspaceForbidden(Exception):
+    """Raised if copying a document to a workspace is not permitted for
+    business logic reasons.
+    """

--- a/opengever/workspaceclient/exceptions.py
+++ b/opengever/workspaceclient/exceptions.py
@@ -43,3 +43,9 @@ class CopyToWorkspaceForbidden(Exception):
     """Raised if copying a document to a workspace is not permitted for
     business logic reasons.
     """
+
+
+class CopyFromWorkspaceForbidden(Exception):
+    """Raised if copying a document from a workspace is not permitted for
+    business logic reasons.
+    """

--- a/opengever/workspaceclient/linked_workspaces.py
+++ b/opengever/workspaceclient/linked_workspaces.py
@@ -3,6 +3,7 @@ from opengever.dossier.behaviors.dossier import IDossierMarker
 from opengever.journal.handlers import journal_entry_factory
 from opengever.workspaceclient import _
 from opengever.workspaceclient.client import WorkspaceClient
+from opengever.workspaceclient.exceptions import CopyFromWorkspaceForbidden
 from opengever.workspaceclient.exceptions import CopyToWorkspaceForbidden
 from opengever.workspaceclient.exceptions import WorkspaceNotFound
 from opengever.workspaceclient.exceptions import WorkspaceNotLinked
@@ -198,6 +199,11 @@ class LinkedWorkspaces(object):
         if not document:
             raise LookupError("Document not in linked workspace")
 
+        if bool(document['checked_out']):
+            raise CopyFromWorkspaceForbidden(
+                "Document %r can't be copied from workspace because it's "
+                "currently checked out" % document_uid)
+
         document_url = document.get("@id")
         document_repr = self.client.get(url_or_path=document_url)
 
@@ -247,7 +253,7 @@ class LinkedWorkspaces(object):
         return self.client.search(
             url_or_path=workspace_url,
             portal_type=["opengever.document.document", "ftw.mail.mail"],
-            metadata_fields=["UID", "filename"],
+            metadata_fields=["UID", "filename", "checked_out"],
             **kwargs)
 
     def has_linked_workspaces(self):

--- a/opengever/workspaceclient/linked_workspaces.py
+++ b/opengever/workspaceclient/linked_workspaces.py
@@ -3,6 +3,7 @@ from opengever.dossier.behaviors.dossier import IDossierMarker
 from opengever.journal.handlers import journal_entry_factory
 from opengever.workspaceclient import _
 from opengever.workspaceclient.client import WorkspaceClient
+from opengever.workspaceclient.exceptions import CopyToWorkspaceForbidden
 from opengever.workspaceclient.exceptions import WorkspaceNotFound
 from opengever.workspaceclient.exceptions import WorkspaceNotLinked
 from opengever.workspaceclient.interfaces import ILinkedDocuments
@@ -142,6 +143,11 @@ class LinkedWorkspaces(object):
     def copy_document_to_workspace(self, document, workspace_uid):
         """Will upload a copy of a document to a linked workspace.
         """
+        if document.is_checked_out():
+            raise CopyToWorkspaceForbidden(
+                "Document %r can't be copied to a workspace because it's "
+                "currently checked out" % document)
+
         workspace_url = self._get_linked_workspace_url(workspace_uid)
 
         file_ = document.get_file()

--- a/opengever/workspaceclient/tests/test_linked_workspaces.py
+++ b/opengever/workspaceclient/tests/test_linked_workspaces.py
@@ -4,14 +4,17 @@ from ftw.builder import create
 from ftw.journal.config import JOURNAL_ENTRIES_ANNOTATIONS_KEY
 from opengever.base.command import CreateEmailCommand
 from opengever.base.oguid import Oguid
+from opengever.document.interfaces import ICheckinCheckoutManager
 from opengever.mail.tests import MAIL_DATA
 from opengever.testing.assets import load
+from opengever.workspaceclient.exceptions import CopyToWorkspaceForbidden
 from opengever.workspaceclient.exceptions import WorkspaceNotLinked
 from opengever.workspaceclient.interfaces import ILinkedWorkspaces
 from opengever.workspaceclient.tests import FunctionalWorkspaceClientTestCase
 from plone import api
 from zope.annotation.interfaces import IAnnotations
 from zope.component import getAdapter
+from zope.component import getMultiAdapter
 from zope.component.interfaces import ComponentLookupError
 from zope.i18n import translate
 import transaction
@@ -296,6 +299,26 @@ class TestLinkedWorkspaces(FunctionalWorkspaceClientTestCase):
             self.assertItemsEqual(
                 manager._serialized_document_schema_fields(mail),
                 manager._serialized_document_schema_fields(workspace_mail))
+
+    def test_copy_checked_out_doc_to_workspace_is_prevented(self):
+        document = create(Builder('document')
+                          .within(self.dossier)
+                          .with_dummy_content())
+
+        manager = getMultiAdapter((document, self.request), ICheckinCheckoutManager)
+        manager.checkout()
+
+        with self.workspace_client_env():
+            manager = ILinkedWorkspaces(self.dossier)
+            manager.storage.add(self.workspace.UID())
+
+            with self.observe_children(self.workspace) as children:
+                with auto_commit_after_request(manager.client):
+                    with self.assertRaises(CopyToWorkspaceForbidden):
+                        manager.copy_document_to_workspace(
+                            document, self.workspace.UID())
+
+            self.assertEqual(0, len(children['added']))
 
     def test_has_linked_workspaces(self):
         with self.workspace_client_env():


### PR DESCRIPTION
This will prevent checked out documents from being copied _to_ a Teamraum, or _copied back_ from Teamraum to GEVER.

The individual requests for the respective documents will be answered with 400 Bad Request, and the document will therefore be flagged as "failed" in the document operation queue  (bottom right) by the frontend.

Jira: https://4teamwork.atlassian.net/browse/CA-1218

## Checklist (Must have)

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

## Checklist (if applicable)

- New functionality:
  - [x] for `document` also works for `mail`