### PR TITLE
Fix persistence bug in linked documents storage

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2020.15.0 (unreleased)
 ----------------------
 
+- Fix persistence bug in linked documents storage. [lgraf]
 - Cast value of issuer to actor label in listing and search endpoints. [tinagerber]
 - Translate proposal review states. [tinagerber]
 

--- a/opengever/api/tests/test_linked_workspaces.py
+++ b/opengever/api/tests/test_linked_workspaces.py
@@ -368,11 +368,7 @@ class TestCopyDocumentToWorkspacePost(FunctionalWorkspaceClientTestCase):
                              'Content-Type': 'application/json'},
                 )
 
-            # XXX: This is incorrect, only one document should be added. This
-            # is a testing issue (doesn't happen in production) that was never
-            # really addressed. The fix_publisher_test_bug() is supposed to
-            # work around this, but it doesn't.
-            self.assertEqual(len(children['added']), 2)
+            self.assertEqual(len(children['added']), 1)
 
             id_ = browser.json['id'].encode('ascii')
             workspace_document = self.workspace.restrictedTraverse(id_)

--- a/opengever/workspaceclient/linked_documents.py
+++ b/opengever/workspaceclient/linked_documents.py
@@ -77,4 +77,4 @@ class LinkedDocuments(object):
         annotations = IAnnotations(self.document)
         if persistent:
             return annotations.setdefault(self.storage_key, PersistentMapping())
-        return dict(annotations.setdefault(self.storage_key, {}))
+        return dict(annotations.get(self.storage_key, {}))

--- a/opengever/workspaceclient/tests/test_linked_documents.py
+++ b/opengever/workspaceclient/tests/test_linked_documents.py
@@ -3,6 +3,7 @@ from opengever.workspaceclient.interfaces import ILinkedDocuments
 from opengever.workspaceclient.linked_documents import AlreadyLinkedError
 from opengever.workspaceclient.linked_documents import LinkedDocuments
 from plone.uuid.interfaces import IUUID
+from zope.annotation import IAnnotations
 from zope.interface.verify import verifyClass
 
 
@@ -64,3 +65,14 @@ class TestLinkedDocumentsAdapter(IntegrationTestCase):
 
         with self.assertRaises(AlreadyLinkedError):
             adapter.link_workspace_document(IUUID(self.workspace_document))
+
+    def test_reading_properties_does_not_result_in_write_to_annotations(self):
+        self.login(self.workspace_member)
+
+        adapter = ILinkedDocuments(self.document)
+
+        adapter.linked_workspace_documents
+        adapter.linked_gever_document
+
+        annotations = IAnnotations(self.document)
+        self.assertNotIn(adapter.storage_key, annotations.keys())


### PR DESCRIPTION
Before this fix, the following could happen:
- A property like `storage.linked_workspace_documents` was accessed on an uninitialized storage, as part of a display operation
- This lead to a regular, non-persisted dict being added to annotations because of the use of `setdefault`
- That dict then got committed as part of the transaction
- Subsequent write operations on the storage then picked up that non-persistent dict to add to it. Those changes then would never be persisted.

The fix therefore makes sure that `storage._link_storage(persistent=False)` never *stores* the empty, non-persistent dict, but instead just _returns_ it.


Jira: https://4teamwork.atlassian.net/browse/CA-1220

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
