### PR TITLE
Ignore locking mail when making a copy via Teamraum Connect.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2020.15.0 (unreleased)
 ----------------------
 
+- Ignore locking mail when making a copy via Teamraum Connect. [njohner]
 - Allow locking document when making a copy via Teamraum Connect. [njohner]
 
 

--- a/opengever/workspaceclient/linked_workspaces.py
+++ b/opengever/workspaceclient/linked_workspaces.py
@@ -186,7 +186,7 @@ class LinkedWorkspaces(object):
         workspace_document_uid = response['UID']
         ILinkedDocuments(document).link_workspace_document(workspace_document_uid)
 
-        if lock:
+        if lock and not document.is_mail:
             ILockable(document).lock(COPIED_TO_WORKSPACE_LOCK)
         return response
 


### PR DESCRIPTION
This is a follow-up to https://github.com/4teamwork/opengever.core/pull/6742. As it had already been reviewed twice, I did not want to add more functionality in that PR, and it also makes it clearer how we decided to treat mails with regard to locking them when copying them to a Workspace. 

I decided to simply ingnore the `lock=True` argument when copying a Mail to a workspace, as it does not make sense to lock an E-mail, which anyway can't be updated when copying the Mail back from the workspace. Raising an Error is not an option IMO, as this is a FolderButton, so the user can select a mix of documents and mails to copy to the Workspace and selects the `lock` flag for all items being copied. It would not make sense to fail for the E-mails just because the user clicked the `lock` checkbox.

For https://4teamwork.atlassian.net/browse/CA-1221

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

- New functionality:
  - [x] for `document` also works for `mail`