### PR TITLE
Fix ScriptUpdateProcessor

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2020.15.0 (unreleased)
 ----------------------
 
+- Fix StatelessScriptUpdateProcessor for documents. [Kevin Bieri]
 - Ignore locking mail when making a copy via Teamraum Connect. [njohner]
 - Allow locking document when making a copy via Teamraum Connect. [njohner]
 

--- a/solr-conf/sync-solr.js
+++ b/solr-conf/sync-solr.js
@@ -88,13 +88,12 @@ function extractValueFromDoc(doc, key) {
   if (value.indexOf("{") === 0 && value.indexOf("}") === value.length - 1) {
     value = value.substring(1, value.length - 1);
     var modifierSplit = value.split("=");
-    var modifier = modifierSplit[0];
-    var data = modifierSplit.splice(1);
+    var modifier = modifierSplit.shift();
     if (atomicUpdateModifiers.indexOf(modifier) > -1) {
       return {
         isAtomic: true,
         modifier: modifier,
-        value: data.join(""),
+        value: modifierSplit.join(""),
       };
     }
   }


### PR DESCRIPTION
The Processor did not work for atomic commits. This PR fixes the bug.
We want to pop the first element and keep the rest, so shift is the correct method to use here.

Issue: https://4teamwork.atlassian.net/browse/CA-1214

Definition of Done: https://4teamwork.atlassian.net/wiki/spaces/CHX4TW/pages/917562/


## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


## Checklist (if applicable)

_Only applicable should be left and checked._

- API change:
  - [ ] Documentation is updated
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Upgrade steps (changes in profile):
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
- DB-Schema migration
  - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
  - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value
