### PR TITLE
Add a usersnap-api key question to the policy-generator

### DIFF
--- a/opengever/policytemplates/policy_template/.mrbob.ini
+++ b/opengever/policytemplates/policy_template/.mrbob.ini
@@ -100,6 +100,10 @@ deployment.records_manager_group.required = True
 deployment.archivist_group.question = Archivist group
 deployment.archivist_group.required = True
 
+setup.usersnap_api_key.question = Usersnap API Key
+setup.usersnap_api_key.help = Enter a usersnap API key to enable usersnap.
+setup.usersnap_api_Key.required = False
+
 setup.enable_activity_feature.question = Enable activity feature
 setup.enable_activity_feature.required = True
 setup.enable_activity_feature.default = true

--- a/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/+adminunit.id+/profiles/default/registry.xml.bob
+++ b/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/+adminunit.id+/profiles/default/registry.xml.bob
@@ -42,6 +42,12 @@
   </records>
 
 {{% endif %}}
+{{% if setup.usersnap_api_key %}}
+  <records interface="opengever.base.interfaces.IUserSnapSettings">
+    <value key="api_key">{{{setup.usersnap_api_key}}}</value>
+  </records>
+
+{{% endif %}}
 {{% if is_gever %}}
 {{% if setup.enable_meeting_feature %}}
   <record interface="opengever.meeting.interfaces.IMeetingSettings" field="is_feature_enabled">


### PR DESCRIPTION
This PR extends the policy generator with adds a question to add a Usersnap API key to the policy.

Adding a key will automatically enable usersnap on the deployment.