### PR TITLE
Support transferring documents from workspace back to GEVER as new version.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2020.15.0 (unreleased)
 ----------------------
 
+- Support transferring documents from workspace back to GEVER as new version. [lgraf]
 - Correct bug with watchers being wrongfully added to ToDos. [njohner]
 - Ignore locking mail when making a copy via Teamraum Connect. [njohner]
 - Allow locking document when making a copy via Teamraum Connect. [njohner]

--- a/docs/public/dev-manual/api/linked_workspaces.rst
+++ b/docs/public/dev-manual/api/linked_workspaces.rst
@@ -160,9 +160,14 @@ Dokumente in einem verknüpften Teamraum auflisten
 Ein GEVER-Dokument von einem verknüpften Teamraum zurückführen
 --------------------------------------------------------------
 
-Über den Endpoint ``@copy-document-from-workspace`` kann eine Kopie eines Dokuments aus einem verknüpften Teamraum in GEVER zurückgeführt werden.
+Über den Endpoint ``@copy-document-from-workspace`` kann ein Dokument aus einem verknüpften Teamraum in GEVER zurückgeführt werden.
 
-Achtung: Auch wenn das Dokument ursprünglich von GEVER in den Teamraum kopiert wurde, wird beim Zurückführen ein neues, komplett unabhängiges Dokument in GEVER erstellt.
+Abhängig vom Boolean-Parameter ``as_new_version`` kann bestimmt werden, ob das Dokument als neue Version des Ursprungsdokuments zurückgeführt werden soll (falls möglich), oder als Kopie (als neues GEVER-Dokument).
+
+In gewissen Fällen ist es nicht möglich, ein Dokument als neue Version zurückzuführen. Z.B. wenn das Teamraum-Dokument nicht mit einem GEVER-Dokument verlinkt ist, das Dokument keine Datei hat, oder es sich um ein E-Mail handelt.
+
+Wenn mit ``"as_new_version": true`` in solchen Fällen trotzdem eine neue Version gewünscht wird, erstellt das Backend automatisch eine Kopie statt einer Version. Die Entscheidung, welchen Rückführungsmechanismus das Backend schlussendlich gewählt und durchgeführt hat, wird in der Response im Attribut ``teamraum_connect_retrieval_mode`` zurückgegeben: Entweder ``copy`` oder ``version``.
+
 
 **Beispiel-Request**:
 
@@ -173,8 +178,9 @@ Achtung: Auch wenn das Dokument ursprünglich von GEVER in den Teamraum kopiert 
     Content-Type: application/json
 
     {
-      "workspace_uid": "c11627f492b6447fb61617bb06b9a21a"
-      "document_uid": "c2ae40cf41c84493ac4b7618d75ee7f7"
+      "workspace_uid": "c11627f492b6447fb61617bb06b9a21a",
+      "document_uid": "c2ae40cf41c84493ac4b7618d75ee7f7",
+      "as_new_version": true
     }
 
 
@@ -189,5 +195,6 @@ Achtung: Auch wenn das Dokument ursprünglich von GEVER in den Teamraum kopiert 
       "@id": ".../dossier-23/document-1",
       "@type": "opengever.document.document",
       "title": "Ein Dokument",
+      "teamraum_connect_retrieval_mode": "version",
        "...": "..."
     }

--- a/opengever/api/linked_workspaces.py
+++ b/opengever/api/linked_workspaces.py
@@ -245,14 +245,17 @@ class CopyDocumentFromWorkspacePost(LinkedWorkspacesService):
         workspace_uid, document_uid, as_new_version = self.validate_data(
             json_body(self.request))
         try:
-            document = ILinkedWorkspaces(self.context).copy_document_from_workspace(
-                workspace_uid, document_uid, as_new_version)
+            destination_document, retrieval_mode = ILinkedWorkspaces(
+                self.context).copy_document_from_workspace(
+                    workspace_uid, document_uid, as_new_version)
         except CopyFromWorkspaceForbidden:
             raise BadRequest(
                 "Document can't be copied from workspace because it's "
                 "currently checked out")
 
-        return self.serialize_object(document)
+        serialized = self.serialize_object(destination_document)
+        serialized['teamraum_connect_retrieval_mode'] = retrieval_mode
+        return serialized
 
     def serialize_object(self, obj):
         serializer = queryMultiAdapter((obj, self.request), ISerializeToJson)

--- a/opengever/api/linked_workspaces.py
+++ b/opengever/api/linked_workspaces.py
@@ -242,10 +242,11 @@ class CopyDocumentFromWorkspacePost(LinkedWorkspacesService):
         # Disable CSRF protection
         alsoProvides(self.request, IDisableCSRFProtection)
 
-        workspace_uid, document_uid = self.validate_data(json_body(self.request))
+        workspace_uid, document_uid, as_new_version = self.validate_data(
+            json_body(self.request))
         try:
             document = ILinkedWorkspaces(self.context).copy_document_from_workspace(
-                workspace_uid, document_uid)
+                workspace_uid, document_uid, as_new_version)
         except CopyFromWorkspaceForbidden:
             raise BadRequest(
                 "Document can't be copied from workspace because it's "
@@ -265,4 +266,5 @@ class CopyDocumentFromWorkspacePost(LinkedWorkspacesService):
         document_uid = data.get('document_uid')
         if not document_uid:
             raise BadRequest("Property 'document_uid' is required")
-        return workspace_uid, document_uid
+        as_new_version = bool(data.get('as_new_version', False))
+        return workspace_uid, document_uid, as_new_version

--- a/opengever/api/tests/test_linked_workspaces.py
+++ b/opengever/api/tests/test_linked_workspaces.py
@@ -11,6 +11,8 @@ from opengever.testing.assets import load
 from opengever.workspaceclient.exceptions import WorkspaceNotLinked
 from opengever.workspaceclient.interfaces import ILinkedDocuments
 from opengever.workspaceclient.interfaces import ILinkedWorkspaces
+from opengever.workspaceclient.linked_workspaces import RETRIEVAL_MODE_COPY
+from opengever.workspaceclient.linked_workspaces import RETRIEVAL_MODE_VERSION
 from opengever.workspaceclient.storage import LinkedWorkspacesStorage
 from opengever.workspaceclient.tests import FunctionalWorkspaceClientTestCase
 from plone import api
@@ -886,6 +888,9 @@ class TestCopyDocumentFromWorkspacePost(FunctionalWorkspaceClientTestCase):
             self.assertEqual(len(children['added']), 1)
             document_copy = children['added'].pop()
             self.assertEqual(document_copy.absolute_url(), browser.json.get('@id'))
+            self.assertEqual(
+                RETRIEVAL_MODE_COPY,
+                browser.json.get('teamraum_connect_retrieval_mode'))
 
     @browsing
     def test_copy_document_with_file_from_a_workspace(self, browser):
@@ -923,6 +928,10 @@ class TestCopyDocumentFromWorkspacePost(FunctionalWorkspaceClientTestCase):
             self.assertItemsEqual(
                 manager._serialized_document_schema_fields(document),
                 manager._serialized_document_schema_fields(document_copy))
+
+            self.assertEqual(
+                RETRIEVAL_MODE_COPY,
+                browser.json.get('teamraum_connect_retrieval_mode'))
 
     @browsing
     def test_copy_document_from_workspace_as_new_version(self, browser):
@@ -993,6 +1002,10 @@ class TestCopyDocumentFromWorkspacePost(FunctionalWorkspaceClientTestCase):
             self.assertEqual(initial_filename, new_version.file.filename)
             self.assertEqual(u'Document retrieved from teamraum', new_version_md.comment)
 
+            self.assertEqual(
+                RETRIEVAL_MODE_VERSION,
+                browser.json.get('teamraum_connect_retrieval_mode'))
+
     @browsing
     def test_copy_eml_mail_from_a_workspace(self, browser):
         mail = create(Builder("mail")
@@ -1030,6 +1043,10 @@ class TestCopyDocumentFromWorkspacePost(FunctionalWorkspaceClientTestCase):
             self.assertItemsEqual(
                 manager._serialized_document_schema_fields(mail),
                 manager._serialized_document_schema_fields(mail_copy))
+
+            self.assertEqual(
+                RETRIEVAL_MODE_COPY,
+                browser.json.get('teamraum_connect_retrieval_mode'))
 
     @browsing
     def test_copy_msg_mail_from_a_workspace(self, browser):
@@ -1072,6 +1089,10 @@ class TestCopyDocumentFromWorkspacePost(FunctionalWorkspaceClientTestCase):
             self.assertItemsEqual(
                 manager._serialized_document_schema_fields(mail),
                 manager._serialized_document_schema_fields(mail_copy))
+
+            self.assertEqual(
+                RETRIEVAL_MODE_COPY,
+                browser.json.get('teamraum_connect_retrieval_mode'))
 
     @browsing
     def test_copying_document_from_workspace_is_prevented_if_checked_out(self, browser):

--- a/opengever/api/tests/test_linked_workspaces.py
+++ b/opengever/api/tests/test_linked_workspaces.py
@@ -4,6 +4,7 @@ from ftw.testbrowser import browsing
 from ftw.testbrowser.exceptions import HTTPServerError
 from opengever.base.command import CreateEmailCommand
 from opengever.document.interfaces import ICheckinCheckoutManager
+from opengever.document.versioner import Versioner
 from opengever.locking.lock import LOCK_TYPE_COPIED_TO_WORKSPACE_LOCK
 from opengever.mail.tests import MAIL_DATA
 from opengever.testing.assets import load
@@ -922,6 +923,75 @@ class TestCopyDocumentFromWorkspacePost(FunctionalWorkspaceClientTestCase):
             self.assertItemsEqual(
                 manager._serialized_document_schema_fields(document),
                 manager._serialized_document_schema_fields(document_copy))
+
+    @browsing
+    def test_copy_document_from_workspace_as_new_version(self, browser):
+        gever_doc = create(Builder('document')
+                           .within(self.dossier)
+                           .with_dummy_content())
+
+        self.assertIsNone(Versioner(gever_doc).get_current_version_id())
+        self.assertFalse(Versioner(gever_doc).has_initial_version())
+
+        initial_content = gever_doc.file.data
+        initial_filename = gever_doc.file.filename
+
+        self.assertEqual('Test data', initial_content)
+        self.assertEqual(u'Testdokumaent.doc', initial_filename)
+
+        new_content = 'Content produced in Workspace'
+        new_filename = u'workspace.doc'
+
+        workspace_doc = create(Builder('document')
+                               .within(self.workspace)
+                               .attach_file_containing(new_content,
+                                                       name=new_filename))
+
+        ILinkedDocuments(workspace_doc).link_gever_document(IUUID(gever_doc))
+        ILinkedDocuments(gever_doc).link_workspace_document(IUUID(workspace_doc))
+
+        payload = {
+            'workspace_uid': IUUID(self.workspace),
+            'document_uid': IUUID(workspace_doc),
+            'as_new_version': True,
+        }
+
+        with self.workspace_client_env():
+            manager = ILinkedWorkspaces(self.dossier)
+            manager.storage.add(self.workspace.UID())
+            transaction.commit()
+
+            browser.login()
+            fix_publisher_test_bug(browser, workspace_doc)
+            with self.observe_children(self.dossier) as children:
+                browser.open(
+                    self.dossier.absolute_url() + '/@copy-document-from-workspace',
+                    data=json.dumps(payload),
+                    method='POST',
+                    headers={'Accept': 'application/json',
+                             'Content-Type': 'application/json'},
+                )
+
+            self.assertEqual(len(children['added']), 0)
+
+            self.assertTrue(Versioner(gever_doc).has_initial_version())
+            self.assertEqual(1, Versioner(gever_doc).get_current_version_id())
+
+            self.assertEqual(new_content, gever_doc.file.data)
+            self.assertEqual(initial_filename, gever_doc.file.filename)
+
+            initial_version = Versioner(gever_doc).retrieve(0)
+            initial_version_md = Versioner(gever_doc).retrieve_version(0)
+            new_version = Versioner(gever_doc).retrieve(1)
+            new_version_md = Versioner(gever_doc).retrieve_version(1)
+
+            self.assertEqual(initial_content, initial_version.file.data)
+            self.assertEqual(initial_filename, initial_version.file.filename)
+            self.assertEqual(u'Initial version', initial_version_md.comment)
+
+            self.assertEqual(new_content, new_version.file.data)
+            self.assertEqual(initial_filename, new_version.file.filename)
+            self.assertEqual(u'Document retrieved from teamraum', new_version_md.comment)
 
     @browsing
     def test_copy_eml_mail_from_a_workspace(self, browser):

--- a/opengever/testing/test_case.py
+++ b/opengever/testing/test_case.py
@@ -2,6 +2,7 @@ from AccessControl import getSecurityManager
 from contextlib import contextmanager
 from ftw.builder import Builder
 from ftw.builder import create
+from ftw.journal.config import JOURNAL_ENTRIES_ANNOTATIONS_KEY
 from ftw.keywordwidget.tests import widget  # keep!
 from opengever.activity.model import Notification
 from opengever.base.interfaces import IOpengeverBaseLayer
@@ -28,6 +29,7 @@ from plone.portlets.interfaces import ILocalPortletAssignmentManager
 from plone.portlets.interfaces import IPortletManager
 from plone.registry.interfaces import IRegistry
 from Products.CMFCore.utils import getToolByName
+from zope.annotation.interfaces import IAnnotations
 from zope.component import getMultiAdapter
 from zope.component import getUtility
 from zope.i18n import translate
@@ -245,6 +247,14 @@ class FunctionalTestCase(TestCase):
     """
     Journal assert helpers
     """
+
+    def get_journal_entry(self, obj, entry=-1):
+        return get_journal_entry(obj, entry)
+
+    def get_journal_entries(self, obj):
+        annotations = IAnnotations(obj)
+        data = annotations.get(JOURNAL_ENTRIES_ANNOTATIONS_KEY, [])
+        return data
 
     def assert_journal_entry(self, obj, action_type, title, entry=-1):
         entry = get_journal_entry(obj, entry)

--- a/opengever/workspaceclient/linked_workspaces.py
+++ b/opengever/workspaceclient/linked_workspaces.py
@@ -269,29 +269,29 @@ class LinkedWorkspaces(object):
         return gever_doc, retrieval_mode
 
     def _retrieve_as_version(self, document_repr, gever_doc_uid):
-            catalog = api.portal.get_tool('portal_catalog')
-            gever_doc = catalog(UID=gever_doc_uid)[0].getObject()
+        catalog = api.portal.get_tool('portal_catalog')
+        gever_doc = catalog(UID=gever_doc_uid)[0].getObject()
 
-            # Make sure the previous working copy is saved as an initial
-            # version. This MUST happen before updating the file.
-            Versioner(gever_doc).create_initial_version()
+        # Make sure the previous working copy is saved as an initial
+        # version. This MUST happen before updating the file.
+        Versioner(gever_doc).create_initial_version()
 
-            version_comment = _(u'document_retrieved_from_teamraum_change_note',
-                                default=u'Document retrieved from teamraum')
-            gever_doc.update_file(
-                document_repr['file']['data'],
-                create_version=True,
-                comment=translate(version_comment, context=getRequest()))
+        version_comment = _(u'document_retrieved_from_teamraum_change_note',
+                            default=u'Document retrieved from teamraum')
+        gever_doc.update_file(
+            document_repr['file']['data'],
+            create_version=True,
+            comment=translate(version_comment, context=getRequest()))
 
-            ILockable(gever_doc).unlock(COPIED_TO_WORKSPACE_LOCK)
-            return gever_doc
+        ILockable(gever_doc).unlock(COPIED_TO_WORKSPACE_LOCK)
+        return gever_doc
 
     def _retrieve_as_copy(self, document_repr):
-            proxy_post = ProxyPost(document_repr)
-            proxy_post.context = self.context
-            proxy_post.request = getRequest()
-            gever_doc = proxy_post.reply()
-            return gever_doc
+        proxy_post = ProxyPost(document_repr)
+        proxy_post.context = self.context
+        proxy_post.request = getRequest()
+        gever_doc = proxy_post.reply()
+        return gever_doc
 
     def list_documents_in_linked_workspace(self, workspace_uid, **kwargs):
         """List documents contained in a linked workspace

--- a/opengever/workspaceclient/linked_workspaces.py
+++ b/opengever/workspaceclient/linked_workspaces.py
@@ -250,11 +250,16 @@ class LinkedWorkspaces(object):
             title=title)
 
         # If the workspace document doesn't have a link to a GEVER document,
+        # or is not a regular document with a file,
         # always create a copy instead of attempting to create a version.
         gever_doc_link = document_repr.get('teamraum_connect_links', {}).get('gever_document')
         gever_doc_uid = gever_doc_link.get('UID') if gever_doc_link else None
 
-        if as_new_version and gever_doc_uid:
+        is_document_with_file = all((
+            document_repr['@type'] == u'opengever.document.document',
+            document_repr.get('file')))
+
+        if as_new_version and gever_doc_uid and is_document_with_file:
             retrieval_mode = RETRIEVAL_MODE_VERSION
             gever_doc = self._retrieve_as_version(document_repr, gever_doc_uid)
         else:

--- a/opengever/workspaceclient/linked_workspaces.py
+++ b/opengever/workspaceclient/linked_workspaces.py
@@ -27,6 +27,9 @@ from zope.interface import implementer
 
 CACHE_TIMEOUT = 24 * 60 * 60
 
+RETRIEVAL_MODE_COPY = 'copy'
+RETRIEVAL_MODE_VERSION = 'version'
+
 
 def list_cache_key(linked_workspaces_instance, **kwargs):
     """Cache key builder for linked workspaces list.
@@ -252,11 +255,13 @@ class LinkedWorkspaces(object):
         gever_doc_uid = gever_doc_link.get('UID') if gever_doc_link else None
 
         if as_new_version and gever_doc_uid:
+            retrieval_mode = RETRIEVAL_MODE_VERSION
             gever_doc = self._retrieve_as_version(document_repr, gever_doc_uid)
         else:
+            retrieval_mode = RETRIEVAL_MODE_COPY
             gever_doc = self._retrieve_as_copy(document_repr)
 
-        return gever_doc
+        return gever_doc, retrieval_mode
 
     def _retrieve_as_version(self, document_repr, gever_doc_uid):
             catalog = api.portal.get_tool('portal_catalog')

--- a/opengever/workspaceclient/linked_workspaces.py
+++ b/opengever/workspaceclient/linked_workspaces.py
@@ -237,17 +237,7 @@ class LinkedWorkspaces(object):
         # We should avoid setting the id ourselves, can lead to conflicts
         document_repr = self._blacklisted_dict(document_repr, ['id'])
 
-        # Add journal entry to the dossier before creating the document
         workspace_title = self.client.get_by_uid(workspace_uid).get('title')
-        title = _(
-            u'label_document_copied_from_workspace',
-            default=u'Document ${doc_title} copied from workspace ${workspace_title}.',
-            mapping={'doc_title': document_repr.get('title'),
-                     'workspace_title': workspace_title})
-
-        journal_entry_factory(
-            context=self.context, action='Document copied from workspace',
-            title=title)
 
         # If the workspace document doesn't have a link to a GEVER document,
         # or is not a regular document with a file,
@@ -261,14 +251,14 @@ class LinkedWorkspaces(object):
 
         if as_new_version and gever_doc_uid and is_document_with_file:
             retrieval_mode = RETRIEVAL_MODE_VERSION
-            gever_doc = self._retrieve_as_version(document_repr, gever_doc_uid)
+            gever_doc = self._retrieve_as_version(document_repr, gever_doc_uid, workspace_title)
         else:
             retrieval_mode = RETRIEVAL_MODE_COPY
-            gever_doc = self._retrieve_as_copy(document_repr)
+            gever_doc = self._retrieve_as_copy(document_repr, workspace_title)
 
         return gever_doc, retrieval_mode
 
-    def _retrieve_as_version(self, document_repr, gever_doc_uid):
+    def _retrieve_as_version(self, document_repr, gever_doc_uid, workspace_title):
         catalog = api.portal.get_tool('portal_catalog')
         gever_doc = catalog(UID=gever_doc_uid)[0].getObject()
 
@@ -283,14 +273,58 @@ class LinkedWorkspaces(object):
             create_version=True,
             comment=translate(version_comment, context=getRequest()))
 
+        # Dossier
+        journal_entry_factory(
+            context=self.context,
+            action='Document retrieved from teamraum',
+            title=_(
+                u'label_document_retrieved_from_workspace',
+                default=u'Document ${doc_title} retrieved from workspace.',
+                mapping={'doc_title': document_repr.get('title')})
+        )
+
+        # Document
+        journal_entry_factory(
+            context=gever_doc,
+            action='Document retrieved as new version from teamraum',
+            title=_(
+                u'label_document_retrieved_as_new_version_from_teamraum',
+                default=u'Document unlocked - created new version with '
+                        u'document from teamraum.')
+        )
+
         ILockable(gever_doc).unlock(COPIED_TO_WORKSPACE_LOCK)
         return gever_doc
 
-    def _retrieve_as_copy(self, document_repr):
+    def _retrieve_as_copy(self, document_repr, workspace_title):
         proxy_post = ProxyPost(document_repr)
         proxy_post.context = self.context
         proxy_post.request = getRequest()
         gever_doc = proxy_post.reply()
+
+        # Dossier
+        journal_entry_factory(
+            context=self.context,
+            action='Document copied from workspace',
+            title=_(
+                u'label_document_copied_from_workspace',
+                default=u'Document ${doc_title} copied from workspace '
+                        u'${workspace_title} as a new document.',
+                mapping={'doc_title': document_repr.get('title'),
+                         'workspace_title': workspace_title})
+        )
+
+        # Document
+        journal_entry_factory(
+            context=gever_doc,
+            action='Document created via copy from teamraum',
+            title=_(
+                u'label_initial_version_document_copied_from_teamraum',
+                default=u'Initial version - Document copied from teamraum '
+                        u'${workspace_title}.',
+                mapping={'workspace_title': workspace_title})
+        )
+
         return gever_doc
 
     def list_documents_in_linked_workspace(self, workspace_uid, **kwargs):

--- a/opengever/workspaceclient/linked_workspaces.py
+++ b/opengever/workspaceclient/linked_workspaces.py
@@ -252,6 +252,13 @@ class LinkedWorkspaces(object):
         gever_doc_uid = gever_doc_link.get('UID') if gever_doc_link else None
 
         if as_new_version and gever_doc_uid:
+            gever_doc = self._retrieve_as_version(document_repr, gever_doc_uid)
+        else:
+            gever_doc = self._retrieve_as_copy(document_repr)
+
+        return gever_doc
+
+    def _retrieve_as_version(self, document_repr, gever_doc_uid):
             catalog = api.portal.get_tool('portal_catalog')
             gever_doc = catalog(UID=gever_doc_uid)[0].getObject()
 
@@ -265,10 +272,9 @@ class LinkedWorkspaces(object):
                 document_repr['file']['data'],
                 create_version=True,
                 comment=translate(version_comment, context=getRequest()))
-
             return gever_doc
 
-        else:
+    def _retrieve_as_copy(self, document_repr):
             proxy_post = ProxyPost(document_repr)
             proxy_post.context = self.context
             proxy_post.request = getRequest()

--- a/opengever/workspaceclient/linked_workspaces.py
+++ b/opengever/workspaceclient/linked_workspaces.py
@@ -246,8 +246,12 @@ class LinkedWorkspaces(object):
             context=self.context, action='Document copied from workspace',
             title=title)
 
-        if as_new_version:
-            gever_doc_uid = document_repr['teamraum_connect_links']['gever_document']['UID']
+        # If the workspace document doesn't have a link to a GEVER document,
+        # always create a copy instead of attempting to create a version.
+        gever_doc_link = document_repr.get('teamraum_connect_links', {}).get('gever_document')
+        gever_doc_uid = gever_doc_link.get('UID') if gever_doc_link else None
+
+        if as_new_version and gever_doc_uid:
             catalog = api.portal.get_tool('portal_catalog')
             gever_doc = catalog(UID=gever_doc_uid)[0].getObject()
 

--- a/opengever/workspaceclient/linked_workspaces.py
+++ b/opengever/workspaceclient/linked_workspaces.py
@@ -282,6 +282,8 @@ class LinkedWorkspaces(object):
                 document_repr['file']['data'],
                 create_version=True,
                 comment=translate(version_comment, context=getRequest()))
+
+            ILockable(gever_doc).unlock(COPIED_TO_WORKSPACE_LOCK)
             return gever_doc
 
     def _retrieve_as_copy(self, document_repr):

--- a/opengever/workspaceclient/locales/de/LC_MESSAGES/opengever.workspaceclient.po
+++ b/opengever/workspaceclient/locales/de/LC_MESSAGES/opengever.workspaceclient.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2020-11-29 17:10+0000\n"
+"POT-Creation-Date: 2020-11-30 01:04+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,15 +19,30 @@ msgstr ""
 msgid "document_retrieved_from_teamraum_change_note"
 msgstr "Dokument aus Teamraum zurückgeführt."
 
-#. Default: "Document ${doc_title} copied from workspace ${workspace_title}."
+#. Default: "Document ${doc_title} copied from workspace ${workspace_title} as a new document."
 #: ./opengever/workspaceclient/linked_workspaces.py
 msgid "label_document_copied_from_workspace"
-msgstr "Dokument ${doc_title} aus Teamraum ${workspace_title} zurückgeführt."
+msgstr "Dokument ${doc_title} wurde aus teamraum ${workspace_title} kopiert und neu erstellt"
 
 #. Default: "Document ${doc_title} copied to workspace ${workspace_title}."
 #: ./opengever/workspaceclient/linked_workspaces.py
 msgid "label_document_copied_to_workspace"
 msgstr "Dokument ${doc_title} in Teamraum ${workspace_title} kopiert."
+
+#. Default: "Document unlocked - created new version with document from teamraum."
+#: ./opengever/workspaceclient/linked_workspaces.py
+msgid "label_document_retrieved_as_new_version_from_teamraum"
+msgstr "Dokument freigegeben - Neue Version mit Dokument aus teamraum erstellt."
+
+#. Default: "Document ${doc_title} retrieved from workspace."
+#: ./opengever/workspaceclient/linked_workspaces.py
+msgid "label_document_retrieved_from_workspace"
+msgstr "Dokument ${doc_title} wurde aus teamraum zurückgeführt."
+
+#. Default: "Initial version - Document copied from teamraum ${workspace_title}."
+#: ./opengever/workspaceclient/linked_workspaces.py
+msgid "label_initial_version_document_copied_from_teamraum"
+msgstr "Initialversion - Dokument aus teamraum ${workspace_title} kopiert."
 
 #. Default: "Linked workspace ${workspace_title} created."
 #: ./opengever/workspaceclient/linked_workspaces.py

--- a/opengever/workspaceclient/locales/de/LC_MESSAGES/opengever.workspaceclient.po
+++ b/opengever/workspaceclient/locales/de/LC_MESSAGES/opengever.workspaceclient.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2020-10-23 13:18+0000\n"
+"POT-Creation-Date: 2020-11-29 17:10+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -13,6 +13,11 @@ msgstr ""
 "Language-Name: English\n"
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
+
+#. Default: "Document retrieved from teamraum"
+#: ./opengever/workspaceclient/linked_workspaces.py
+msgid "document_retrieved_from_teamraum_change_note"
+msgstr "Dokument aus Teamraum zurückgeführt."
 
 #. Default: "Document ${doc_title} copied from workspace ${workspace_title}."
 #: ./opengever/workspaceclient/linked_workspaces.py

--- a/opengever/workspaceclient/locales/fr/LC_MESSAGES/opengever.workspaceclient.po
+++ b/opengever/workspaceclient/locales/fr/LC_MESSAGES/opengever.workspaceclient.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2020-10-23 13:18+0000\n"
+"POT-Creation-Date: 2020-11-29 17:10+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -13,6 +13,11 @@ msgstr ""
 "Language-Name: English\n"
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
+
+#. Default: "Document retrieved from teamraum"
+#: ./opengever/workspaceclient/linked_workspaces.py
+msgid "document_retrieved_from_teamraum_change_note"
+msgstr ""
 
 #. Default: "Document ${doc_title} copied from workspace ${workspace_title}."
 #: ./opengever/workspaceclient/linked_workspaces.py

--- a/opengever/workspaceclient/locales/fr/LC_MESSAGES/opengever.workspaceclient.po
+++ b/opengever/workspaceclient/locales/fr/LC_MESSAGES/opengever.workspaceclient.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2020-11-29 17:10+0000\n"
+"POT-Creation-Date: 2020-11-30 01:04+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,15 +19,30 @@ msgstr ""
 msgid "document_retrieved_from_teamraum_change_note"
 msgstr ""
 
-#. Default: "Document ${doc_title} copied from workspace ${workspace_title}."
+#. Default: "Document ${doc_title} copied from workspace ${workspace_title} as a new document."
 #: ./opengever/workspaceclient/linked_workspaces.py
 msgid "label_document_copied_from_workspace"
-msgstr "Document ${doc_title} rapatrié de l'espace de travail ${workspace_title}."
+msgstr ""
 
 #. Default: "Document ${doc_title} copied to workspace ${workspace_title}."
 #: ./opengever/workspaceclient/linked_workspaces.py
 msgid "label_document_copied_to_workspace"
 msgstr "Document ${doc_title} copié dans l'espace de travail ${workspace_title}."
+
+#. Default: "Document unlocked - created new version with document from teamraum."
+#: ./opengever/workspaceclient/linked_workspaces.py
+msgid "label_document_retrieved_as_new_version_from_teamraum"
+msgstr ""
+
+#. Default: "Document ${doc_title} retrieved from workspace."
+#: ./opengever/workspaceclient/linked_workspaces.py
+msgid "label_document_retrieved_from_workspace"
+msgstr ""
+
+#. Default: "Initial version - Document copied from teamraum ${workspace_title}."
+#: ./opengever/workspaceclient/linked_workspaces.py
+msgid "label_initial_version_document_copied_from_teamraum"
+msgstr ""
 
 #. Default: "Linked workspace ${workspace_title} created."
 #: ./opengever/workspaceclient/linked_workspaces.py

--- a/opengever/workspaceclient/locales/opengever.workspaceclient.pot
+++ b/opengever/workspaceclient/locales/opengever.workspaceclient.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2020-11-29 17:10+0000\n"
+"POT-Creation-Date: 2020-11-30 01:04+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -22,7 +22,7 @@ msgstr ""
 msgid "document_retrieved_from_teamraum_change_note"
 msgstr ""
 
-#. Default: "Document ${doc_title} copied from workspace ${workspace_title}."
+#. Default: "Document ${doc_title} copied from workspace ${workspace_title} as a new document."
 #: ./opengever/workspaceclient/linked_workspaces.py
 msgid "label_document_copied_from_workspace"
 msgstr ""
@@ -30,6 +30,21 @@ msgstr ""
 #. Default: "Document ${doc_title} copied to workspace ${workspace_title}."
 #: ./opengever/workspaceclient/linked_workspaces.py
 msgid "label_document_copied_to_workspace"
+msgstr ""
+
+#. Default: "Document unlocked - created new version with document from teamraum."
+#: ./opengever/workspaceclient/linked_workspaces.py
+msgid "label_document_retrieved_as_new_version_from_teamraum"
+msgstr ""
+
+#. Default: "Document ${doc_title} retrieved from workspace."
+#: ./opengever/workspaceclient/linked_workspaces.py
+msgid "label_document_retrieved_from_workspace"
+msgstr ""
+
+#. Default: "Initial version - Document copied from teamraum ${workspace_title}."
+#: ./opengever/workspaceclient/linked_workspaces.py
+msgid "label_initial_version_document_copied_from_teamraum"
 msgstr ""
 
 #. Default: "Linked workspace ${workspace_title} created."

--- a/opengever/workspaceclient/locales/opengever.workspaceclient.pot
+++ b/opengever/workspaceclient/locales/opengever.workspaceclient.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2020-10-23 13:18+0000\n"
+"POT-Creation-Date: 2020-11-29 17:10+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,6 +16,11 @@ msgstr ""
 "Language-Name: English\n"
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: opengever.workspaceclient\n"
+
+#. Default: "Document retrieved from teamraum"
+#: ./opengever/workspaceclient/linked_workspaces.py
+msgid "document_retrieved_from_teamraum_change_note"
+msgstr ""
 
 #. Default: "Document ${doc_title} copied from workspace ${workspace_title}."
 #: ./opengever/workspaceclient/linked_workspaces.py

--- a/opengever/workspaceclient/tests/test_linked_workspaces.py
+++ b/opengever/workspaceclient/tests/test_linked_workspaces.py
@@ -477,6 +477,15 @@ class TestLinkedWorkspaces(FunctionalWorkspaceClientTestCase):
                 manager._serialized_document_schema_fields(document),
                 manager._serialized_document_schema_fields(workspace_document))
 
+            document_journal = self.get_journal_entries(workspace_document)
+            self.assertEqual(2, len(document_journal))
+
+            self.assert_journal_entry(
+                workspace_document,
+                action_type='Document created via copy from teamraum',
+                title=u'Initial version - Document copied from teamraum %s.' % self.workspace.title,
+            )
+
     def test_copy_document_from_workspace_as_new_version(self):
         gever_doc = create(Builder('document')
                            .within(self.dossier)
@@ -535,6 +544,21 @@ class TestLinkedWorkspaces(FunctionalWorkspaceClientTestCase):
             self.assertEqual(new_content, new_version.file.data)
             self.assertEqual(initial_filename, new_version.file.filename)
             self.assertEqual(u'Document retrieved from teamraum', new_version_md.comment)
+
+            document_journal = self.get_journal_entries(gever_doc)
+            self.assertEqual(2, len(document_journal))
+
+            self.assert_journal_entry(
+                gever_doc,
+                action_type='Document retrieved as new version from teamraum',
+                title=u'Document unlocked - created new version with document from teamraum.',
+            )
+
+            self.assert_journal_entry(
+                self.dossier,
+                action_type='Document retrieved from teamraum',
+                title=u'Document Testdokum\xe4nt retrieved from workspace.',
+            )
 
     def test_copy_document_from_workspace_as_new_version_unlocks_document(self):
         gever_doc = create(Builder('document')
@@ -814,11 +838,11 @@ class TestLinkedWorkspacesJournalization(FunctionalWorkspaceClientTestCase):
         self.assert_journal_entry(
             self.dossier,
             'Document copied from workspace',
-            u'Document Testdokum\xe4nt copied from workspace Ein Teamraum.',
-            entry=-2)
+            u'Document Testdokum\xe4nt copied from workspace Ein Teamraum as a new document.',
+            entry=-1)
 
         self.assert_journal_entry(
             self.dossier,
             'Document added',
             u'Document added: Testdokum\xe4nt',
-            entry=-1)
+            entry=-2)

--- a/opengever/workspaceclient/tests/test_linked_workspaces.py
+++ b/opengever/workspaceclient/tests/test_linked_workspaces.py
@@ -460,11 +460,13 @@ class TestLinkedWorkspaces(FunctionalWorkspaceClientTestCase):
 
             with self.observe_children(self.dossier) as children:
                 with auto_commit_after_request(manager.client):
-                    manager.copy_document_from_workspace(
+                    dst_doc, retrieval_mode = manager.copy_document_from_workspace(
                         self.workspace.UID(), document.UID())
 
             self.assertEqual(1, len(children['added']))
             workspace_document = children['added'].pop()
+            self.assertEqual(workspace_document, dst_doc)
+
             self.assertEqual(document.title, workspace_document.title)
             self.assertEqual(document.description, workspace_document.description)
             self.assertEqual(document.file.open().read(),
@@ -507,11 +509,12 @@ class TestLinkedWorkspaces(FunctionalWorkspaceClientTestCase):
 
             with self.observe_children(self.dossier) as children:
                 with auto_commit_after_request(manager.client):
-                    manager.copy_document_from_workspace(
+                    dst_doc, retrieval_mode = manager.copy_document_from_workspace(
                         self.workspace.UID(), workspace_doc.UID(),
                         as_new_version=True)
 
             self.assertEqual(0, len(children['added']))
+            self.assertEqual(gever_doc, dst_doc)
 
             self.assertTrue(Versioner(gever_doc).has_initial_version())
             self.assertEqual(1, Versioner(gever_doc).get_current_version_id())
@@ -547,12 +550,13 @@ class TestLinkedWorkspaces(FunctionalWorkspaceClientTestCase):
 
             with self.observe_children(self.dossier) as children:
                 with auto_commit_after_request(manager.client):
-                    manager.copy_document_from_workspace(
+                    dst_doc, retrieval_mode = manager.copy_document_from_workspace(
                         self.workspace.UID(), workspace_doc.UID(),
                         as_new_version=True)
 
             self.assertEqual(1, len(children['added']))
             new_gever_doc = children['added'].pop()
+            self.assertEqual(new_gever_doc, dst_doc)
             self.assertEqual(workspace_doc.title, new_gever_doc.title)
 
     def test_copy_document_without_file_from_a_workspace(self):
@@ -566,11 +570,13 @@ class TestLinkedWorkspaces(FunctionalWorkspaceClientTestCase):
 
             with self.observe_children(self.dossier) as children:
                 with auto_commit_after_request(manager.client):
-                    manager.copy_document_from_workspace(
+                    dst_doc, retrieval_mode = manager.copy_document_from_workspace(
                         self.workspace.UID(), document.UID())
 
             self.assertEqual(1, len(children['added']))
             workspace_document = children['added'].pop()
+            self.assertEqual(workspace_document, dst_doc)
+
             self.assertEqual(document.title, workspace_document.title)
             self.assertEqual(document.description, workspace_document.description)
 
@@ -590,11 +596,13 @@ class TestLinkedWorkspaces(FunctionalWorkspaceClientTestCase):
 
             with self.observe_children(self.dossier) as children:
                 with auto_commit_after_request(manager.client):
-                    manager.copy_document_from_workspace(
+                    dst_doc, retrieval_mode = manager.copy_document_from_workspace(
                         self.workspace.UID(), mail.UID())
 
             self.assertEqual(1, len(children['added']))
             workspace_mail = children['added'].pop()
+            self.assertEqual(workspace_mail, dst_doc)
+
             self.assertEqual(mail.title, workspace_mail.title)
             self.assertEqual(mail.description, workspace_mail.description)
             self.assertEqual(workspace_mail.get_file().open().read(),
@@ -616,11 +624,13 @@ class TestLinkedWorkspaces(FunctionalWorkspaceClientTestCase):
 
             with self.observe_children(self.dossier) as children:
                 with auto_commit_after_request(manager.client):
-                    manager.copy_document_from_workspace(
+                    dst_doc, retrieval_mode = manager.copy_document_from_workspace(
                         self.workspace.UID(), mail.UID())
 
             self.assertEqual(1, len(children['added']))
             workspace_mail = children['added'].pop()
+            self.assertEqual(workspace_mail, dst_doc)
+
             self.assertEqual(mail.title, workspace_mail.title)
             self.assertEqual(mail.description, workspace_mail.description)
             self.assertEqual(workspace_mail.get_file().open().read(),
@@ -647,7 +657,7 @@ class TestLinkedWorkspaces(FunctionalWorkspaceClientTestCase):
             with self.observe_children(self.dossier) as children:
                 with auto_commit_after_request(manager.client):
                     with self.assertRaises(CopyFromWorkspaceForbidden):
-                        manager.copy_document_from_workspace(
+                        dst_doc, retrieval_mode = manager.copy_document_from_workspace(
                             self.workspace.UID(), document.UID())
 
             self.assertEqual(0, len(children['added']))
@@ -707,7 +717,7 @@ class TestLinkedWorkspacesJournalization(FunctionalWorkspaceClientTestCase):
             self.assertEqual(1, len(self.get_journal_entries(self.dossier)))
 
             with auto_commit_after_request(manager.client):
-                manager.copy_document_from_workspace(
+                dst_doc, retrieval_mode = manager.copy_document_from_workspace(
                     self.workspace.UID(), document.UID())
 
         self.assertEqual(3, len(self.get_journal_entries(self.dossier)))


### PR DESCRIPTION
This adds support for transferring documents from teamraum back to GEVER **as a new version**.

The `@copy-document-from-workspace` endpoint accepts a new flag `as_new_version` (default: False), which will retrieve the document as a new version of the linked document, if possible. If not possible (e.g. if the document wasn't linked, doesn't have a file or is a mail), it will pick to create a _copy_ instead though). The endpoint will return the creation mode it picked as a property `teamraum_connect_retrieval_mode`(`copy` or `version`) in the serialized object in the response.

When retrieving a document as a new version, the original document will be **unlocked** (if locked). When retrieving as a copy, it **won't**.

Jira: https://4teamwork.atlassian.net/browse/CA-1222

## Checklist (Must have)

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

## Checklist (if applicable)

- API change:
  - [x] Documentation is updated
- New functionality:
  - [x] for `document` also works for `mail`

- New translations
  - [x] All msg-strings are unicode
