### PR TITLE
fix todo watchers

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2020.15.0 (unreleased)
 ----------------------
 
+- Correct bug with watchers being wrongfully added to ToDos. [njohner]
 - Ignore locking mail when making a copy via Teamraum Connect. [njohner]
 - Allow locking document when making a copy via Teamraum Connect. [njohner]
 

--- a/opengever/api/participations.py
+++ b/opengever/api/participations.py
@@ -197,7 +197,7 @@ class ParticipationsPost(ParticipationTraverseService):
         RoleAssignmentManager(self.context).add_or_update_assignment(assignment)
 
         activity_manager = WorkspaceWatcherManager(self.context)
-        activity_manager.new_participant_added(token, role)
+        activity_manager.new_participant_added(token)
 
         self.request.response.setStatus(201)
         return self.prepare_response_item(self.find_participant(

--- a/opengever/core/upgrades/20201127160828_correct_to_do_watchers/upgrade.py
+++ b/opengever/core/upgrades/20201127160828_correct_to_do_watchers/upgrade.py
@@ -1,0 +1,57 @@
+from ftw.upgrade import UpgradeStep
+from opengever.activity import notification_center
+from opengever.activity.model import Subscription
+from opengever.activity.roles import WORKSPACE_MEMBER_ROLE
+from opengever.base.model import create_session
+from opengever.workspace.participation.browser.manage_participants import ManageParticipants
+from opengever.workspace.todo import ToDo
+from zope.globalrequest import getRequest
+import logging
+
+
+logger = logging.getLogger('ftw.upgrade')
+
+
+class CorrectToDoWatchers(UpgradeStep):
+    """Correct to do watchers.
+    """
+
+    deferrable = True
+
+    def __call__(self):
+        self.center = notification_center()
+        self.session = create_session()
+
+        # Because WorkspaceWatcherManager.new_participant_added not only added
+        # the new participant as watcher to all ToDos but also with the
+        # participants'role in the workspace instead of WORKSPACE_MEMBER_ROLE ,
+        # as role, we can identify the wrongly added subscriptions by their role.
+        roles = ["WorkspaceGuest", "WorkspaceMember", "WorkspaceAdmin"]
+        subscriptions = Subscription.query.filter(Subscription.role.in_(roles))
+
+        todos = set()
+        for subscription in subscriptions:
+            resource = subscription.resource
+            obj = resource.oguid.resolve_object()
+            if not isinstance(obj, ToDo):
+                logger.warning(
+                    'Subscription {} is not on a ToDo. '
+                    'Skipping.'.format(subscription))
+                continue
+            self.session.delete(subscription)
+            todos.add(obj)
+
+        # Now we make sure that all workspace participants are watchers from
+        # the todos in the workspace.
+        for todo in todos:
+            self._add_all_workspace_users_as_watchers(todo)
+
+    def _add_all_workspace_users_as_watchers(self, todo):
+        """Copy from WorkspaceWatcherManager
+        """
+        workspace = todo.get_containing_workspace()
+        manager = ManageParticipants(workspace, getRequest())
+
+        for member in manager.get_participants():
+            self.center.add_watcher_to_resource(
+                todo, member["userid"], WORKSPACE_MEMBER_ROLE)

--- a/opengever/workspace/activities.py
+++ b/opengever/workspace/activities.py
@@ -39,7 +39,7 @@ class WorkspaceWatcherManager(object):
             self.center.add_watcher_to_resource(
                 todo, member["userid"], WORKSPACE_MEMBER_ROLE)
 
-    def new_participant_added(self, participant, role):
+    def new_participant_added(self, participant):
         catalog = api.portal.get_tool("portal_catalog")
 
         todos = catalog.searchResults(
@@ -47,7 +47,8 @@ class WorkspaceWatcherManager(object):
             path='/'.join(self.workspace.getPhysicalPath()))
 
         for todo in todos:
-            self.center.add_watcher_to_resource(todo.getObject(), participant, role)
+            self.center.add_watcher_to_resource(
+                todo.getObject(), participant, WORKSPACE_MEMBER_ROLE)
 
     def participant_removed(self, participant):
         """We remove all subscriptions for participant on objects that are in

--- a/opengever/workspace/activities.py
+++ b/opengever/workspace/activities.py
@@ -41,7 +41,11 @@ class WorkspaceWatcherManager(object):
 
     def new_participant_added(self, participant, role):
         catalog = api.portal.get_tool("portal_catalog")
-        todos = catalog(portal_type="opengever.workspace.todo")
+
+        todos = catalog.searchResults(
+            portal_type="opengever.workspace.todo",
+            path='/'.join(self.workspace.getPhysicalPath()))
+
         for todo in todos:
             self.center.add_watcher_to_resource(todo.getObject(), participant, role)
 

--- a/opengever/workspace/participation/browser/my_invitations.py
+++ b/opengever/workspace/participation/browser/my_invitations.py
@@ -218,7 +218,7 @@ class MyWorkspaceInvitations(BrowserView):
             RoleAssignmentManager(target).add_or_update_assignment(assignment)
             self.storage().mark_invitation_as_accepted(invitation['iid'])
 
-            manager = WorkspaceWatcherManager(self.context)
+            manager = WorkspaceWatcherManager(target)
             manager.new_participant_added(invitation['recipient'], invitation['role'])
 
         self._maybe_create_ogds_entry()

--- a/opengever/workspace/participation/browser/my_invitations.py
+++ b/opengever/workspace/participation/browser/my_invitations.py
@@ -219,7 +219,7 @@ class MyWorkspaceInvitations(BrowserView):
             self.storage().mark_invitation_as_accepted(invitation['iid'])
 
             manager = WorkspaceWatcherManager(target)
-            manager.new_participant_added(invitation['recipient'], invitation['role'])
+            manager.new_participant_added(invitation['recipient'])
 
         self._maybe_create_ogds_entry()
         return target

--- a/opengever/workspace/tests/test_activities.py
+++ b/opengever/workspace/tests/test_activities.py
@@ -122,8 +122,11 @@ class TestToDoWatchers(IntegrationTestCase):
         self.assertEqual([], responsible_watchers)
 
     @browsing
-    def test_new_workspace_member_is_watcher_on_all_todos(self, browser):
+    def test_new_workspace_member_is_watcher_on_all_todos_in_workspace(self, browser):
         self.login(self.workspace_owner, browser)
+
+        workspace2 = create(Builder('workspace').within(self.workspace_root))
+        todo_in_workspace2 = create(Builder('todo').within(workspace2))
 
         getUtility(IInvitationStorage).add_invitation(
             self.workspace,
@@ -151,9 +154,12 @@ class TestToDoWatchers(IntegrationTestCase):
         self.assertIsNotNone(watcher)
 
         self.login(self.workspace_member, browser)
+
+        watched_resources = [resource.oguid.resolve_object() for resource in watcher.resources]
+        self.assertNotIn(todo_in_workspace2, watched_resources)
         self.assertItemsEqual(
             [self.todo, self.assigned_todo, self.completed_todo],
-            [resource.oguid.resolve_object() for resource in watcher.resources])
+            watched_resources)
 
     @browsing
     def test_deleted_workspace_member_is_removed_as_watcher_from_all_todos(self, browser):


### PR DESCRIPTION
With https://github.com/4teamwork/opengever.core/pull/5917 we included ToDos in the Gever notification system so that workspace participants get notified about modifications on ToDos. There was a bug in the implementation, so that the new participant would get added to all ToDos instead (https://github.com/4teamwork/opengever.core/blob/d42390cc1380477d774fd1b32b2e75bc72beb808/opengever/workspace/activities.py#L44), also the ones he had no permission to see when he accepted the invitation over the browser view which uses `elevated_privileges` (https://github.com/4teamwork/opengever.core/blob/4a84462c2872b06db0595ed34ac7908cd1682e40/opengever/workspace/participation/browser/my_invitations.py#L222).

The good news is that there was a second error in the implementation so that the newly added participants were added as watchers with their workspace participation role (so one of  `WorkspaceGuest`, `WorkspaceMember`, `WorkspaceAdmin`) instead of the corresponding activity role `WORKSPACE_MEMBER_ROLE`. This makes the faulty `Subscription`s easy to find and delete.

Also as there is no activity setting for the `WorkspaceGuest`, `WorkspaceMember`, `WorkspaceAdmin` roles, such notifications will never get dispatched in the classic UI, but because the new frontend does not respect the user's activity settings and simply displays all notifications for a given user (the information is not even serialized: https://github.com/4teamwork/opengever.core/blob/master/opengever/activity/model/notification.py#L36-L45), these notifications would show up in the new UI.

So we did the following here:
- Only add a new participant as watcher on the `ToDo`s of the workspace he was added to
- Use correct role when adding a participant as watcher on the `ToDo`s
- Upgrade step to delete the incorrect subscriptions and re-add all current participants of the Workspace as watchers on the `ToDo`s

Follow-up stories:
- For the Problem in the Gever-UI: https://4teamwork.atlassian.net/browse/NE-378
- ActivityCenter should not manage subscriptions IMO: https://4teamwork.atlassian.net/browse/CA-1310

For https://4teamwork.atlassian.net/browse/CA-1297

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
- Upgrade steps (changes in profile):
  - [x] Make it deferrable if possible
  - [x] Execute as much as possible conditionally
