### PR TITLE
Consistently use name solr update chain.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -235,10 +235,10 @@ Then run the `activate_solr` maintenance script:
     $ bin/instance run src/opengever.maintenance/opengever/maintenance/scripts/activate_solr.py
 
 
-Activating Solr sync
-~~~~~~~~~~~~~~~~~~~~
+Activating Solr update chain
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The custom Solr sync allows to propagate document updates to another Solr. This can be enabled for specific portal types.
+The custom Solr update chain allows to propagate document updates to another Solr. This can be enabled for specific portal types.
 A StatelessScriptUpdateProcessor with the name ``sync.chain`` provides a script that is using a JavaScript Script to sync the documents.
 
 To activate the ``sync.chain``, provide an overlayconfig using the ``overlayconfig`` option in the ``ftw.recipe.solr``.
@@ -270,7 +270,7 @@ This is done by using the ``jvm-opts`` option:
     [solr]
         jvm-opts = -Xms512m -Xmx512m -Xss256k -DremoteCoreURL=http://localhost:8984/solr/ris -DportalTypes=opengever.document.document,opengever.dossier.businesscasedossier
 
-Notice the other options next to ``-DremoteCoreURL``. These are options from https://github.com/4teamwork/ftw.recipe.solr#supported-options.
+Note the other options next to ``-DremoteCoreURL``. These are options from https://github.com/4teamwork/ftw.recipe.solr#supported-options.
 All the defaults from the ``jvm-opts`` section have to be set here again to not override the defaults.
 
 Testing


### PR DESCRIPTION
We've decided to use an unclamimed identifier for this new thing which makes sure certain fields from a GEVER Solr are also available in a RIS Solr.

- Solr sync is already taken by the (command-line) tool to make sure GEVER and Solr are in sync.
- Replication is already taken for certain deployment styles where Solr/GEVER instances are distributed across multiple servers.

So, `update chain` it is.

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [ ] ~~Changelog entry~~
- [ ] ~~Link to issue (Jira or GitHub) and backlink in issue (Jira)~~