### PR TITLE
Allow downloading and sending a document checked out by another user

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2020.16.0 (unreleased)
 ----------------------
 
+- Allow downloading and sending a document checked out by another user. [elioschmutz]
 - Fix keyword filter for keywords that contain spaces. [tinagerber]
 - Add feature flag for todos. [tinagerber]
 - No longer zip-export empty tasks, prevent creation of empty folders in such cases. [deiferni]

--- a/opengever/api/tests/test_actions.py
+++ b/opengever/api/tests/test_actions.py
@@ -147,6 +147,83 @@ class TestFileActionsGetForDocuments(FileActionsTestBase):
                          self.get_file_actions(browser, self.document))
 
     @browsing
+    def test_available_file_actions_if_document_checked_out_by_myself(self, browser):
+        self.login(self.regular_user, browser)
+        self.checkout_document(self.document)
+
+        expected_file_actions = [
+            {u'id': u'oc_direct_edit',
+             u'title': u'Edit',
+             u'icon': u''},
+            {u'id': u'checkin_without_comment',
+             u'title': u'Checkin without comment',
+             u'icon': u''},
+            {u'id': u'checkin_with_comment',
+             u'title': u'Checkin with comment',
+             u'icon': u''},
+            {u'id': u'cancel_checkout',
+             u'title': u'Cancel checkout',
+             u'icon': u''},
+            {u'id': u'download_copy',
+             u'title': u'Download copy',
+             u'icon': u''},
+            {u'id': u'attach_to_email',
+             u'title': u'Attach to email',
+             u'icon': u''},
+            {u'id': u'open_as_pdf',
+             u'title': u'Open as PDF',
+             u'icon': u''},
+            {u'id': u'new_task_from_document',
+             u'title': u'New task from document',
+             u'icon': u''},
+            ]
+        self.assertEqual(expected_file_actions,
+                         self.get_file_actions(browser, self.document))
+
+    @browsing
+    def test_available_file_actions_if_document_checked_out_by_another_user_without_a_version(self, browser):
+        self.login(self.dossier_manager, browser)
+        self.checkout_document(self.document)
+
+        self.login(self.regular_user, browser)
+
+        expected_file_actions = [
+            {u'id': u'open_as_pdf',
+             u'title': u'Open as PDF',
+             u'icon': u''},
+            {u'id': u'new_task_from_document',
+             u'title': u'New task from document',
+             u'icon': u''},
+            ]
+        self.assertEqual(expected_file_actions,
+                         self.get_file_actions(browser, self.document))
+
+    @browsing
+    def test_available_file_actions_if_document_checked_out_by_another_user_with_a_version(self, browser):
+        self.login(self.dossier_manager, browser)
+        self.checkout_document(self.document)
+        self.document.update_file('first version', create_version=True)
+
+        self.login(self.regular_user, browser)
+
+        expected_file_actions = [
+            {u'id': u'download_copy',
+             u'title': u'Download copy',
+             u'icon': u''},
+            {u'id': u'attach_to_email',
+             u'title': u'Attach to email',
+             u'icon': u''},
+            {u'id': u'open_as_pdf',
+             u'title': u'Open as PDF',
+             u'icon': u''},
+            {u'id': u'new_task_from_document',
+             u'title': u'New task from document',
+             u'icon': u''},
+            ]
+        self.assertEqual(expected_file_actions,
+                         self.get_file_actions(browser, self.document))
+
+    @browsing
     def test_oc_zem_checkout_available_if_oc_checkout_deactivated(self, browser):
         self.deactivate_feature('officeconnector-checkout')
         self.login(self.regular_user, browser)

--- a/opengever/document/fileactions.py
+++ b/opengever/document/fileactions.py
@@ -200,21 +200,28 @@ class DocumentFileActions(BaseDocumentFileActions):
 
     def is_download_copy_action_available(self):
         """Disable downloading copies when the document is checked out by
-        another user.
+        another user and document doesn't have any version.
         """
         manager = getMultiAdapter(
             (self.context, self.request), ICheckinCheckoutManager)
+
+        has_version = self.context.get_current_version_id(missing_as_zero=True) > 0
+
         return (
             super(DocumentFileActions, self).is_download_copy_action_available()
-            and not manager.is_checked_out_by_another_user())
+            and not (manager.is_checked_out_by_another_user() and not has_version))
 
     def is_attach_to_email_action_available(self):
+        """Disable attaching documents to email when the document is checked out by
+        another user and mail doesn't have any version.
+        """
         manager = getMultiAdapter(
             (self.context, self.request), ICheckinCheckoutManager)
 
+        has_version = self.context.get_current_version_id(missing_as_zero=True) > 0
         return (
             super(DocumentFileActions, self).is_attach_to_email_action_available()
-            and not manager.is_checked_out_by_another_user())
+            and not (manager.is_checked_out_by_another_user() and not has_version))
 
     def is_oneoffixx_retry_action_available(self):
         return self.context.is_oneoffixx_creatable()


### PR DESCRIPTION
Jira: https://4teamwork.atlassian.net/browse/NE-49

Currently, if another user has checked out a document, the `download_copy` and `attach_to_mail` actions were not shown.

With this PR, the actions will be shown even if the document is checked out by another user. But it have to have at least one version.

If the user who checked out the document downloads the document, the current working copy will be downloaded.
If another user download the document, the latest version will be downloaded.

By default, a newly created document does not have any version. If a user checks out this document and working on it will directly modify the document. That's the reason why we don't provide the download (or attach to mail) action to another user, if there does not exist any version yet.

## Checklist (Must have)

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


## Checklist (if applicable)

_Only applicable should be left and checked._

- API change:
  - [ ] Documentation is updated
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- New functionality:
  - [x] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Upgrade steps (changes in profile):
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
- DB-Schema migration
  - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
  - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value
