### PR TITLE
Only fix subscription on current admin unit.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2020.15.0 (unreleased)
 ----------------------
 
+- Correct upgrade: fix only subscription on ToDos of current admin unit. [njohner]
 - Support transferring documents from workspace back to GEVER as new version. [lgraf]
 - Correct bug with watchers being wrongfully added to ToDos. [njohner]
 - Ignore locking mail when making a copy via Teamraum Connect. [njohner]

--- a/opengever/core/upgrades/20201127160828_correct_to_do_watchers/upgrade.py
+++ b/opengever/core/upgrades/20201127160828_correct_to_do_watchers/upgrade.py
@@ -1,8 +1,10 @@
 from ftw.upgrade import UpgradeStep
 from opengever.activity import notification_center
+from opengever.activity.model import Resource
 from opengever.activity.model import Subscription
 from opengever.activity.roles import WORKSPACE_MEMBER_ROLE
 from opengever.base.model import create_session
+from opengever.ogds.base.utils import get_current_admin_unit
 from opengever.workspace.participation.browser.manage_participants import ManageParticipants
 from opengever.workspace.todo import ToDo
 from zope.globalrequest import getRequest
@@ -28,7 +30,7 @@ class CorrectToDoWatchers(UpgradeStep):
         # as role, we can identify the wrongly added subscriptions by their role.
         roles = ["WorkspaceGuest", "WorkspaceMember", "WorkspaceAdmin"]
         subscriptions = Subscription.query.filter(Subscription.role.in_(roles))
-
+        subscriptions = subscriptions.join(Resource).filter(Resource.admin_unit_id == get_current_admin_unit().id())
         todos = set()
         for subscription in subscriptions:
             resource = subscription.resource


### PR DESCRIPTION
The upgrade step fixing the subscriptions on ToDos was not restricted to the current admin_unit. While it did work correctly because it would end up skipping subscriptions from other admin units, it would also log an unnecessary warning.

For https://4teamwork.atlassian.net/browse/CA-1297

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)