### PR TITLE
Update Readme for setting up a multi-admin deplyoment for development.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -365,10 +365,10 @@ Then make sure you can login without cas re-enabling ldap as authentication plug
 - Go to ``{admin-unit}/acl_users/ldap/manage_activateInterfacesForm``
 - Make sure ``Authentication`` is enabled
 
-It is also wise to change the CAS server URL:
+It is also wise to change the CAS server URL. If you want to be able to use the gever-ui, you should set it to empty string, otherwise the frontend will try to login with CAS:
 
 - Go to ``{admin-unit}/acl_users/cas_auth/manage_config``
-- Set ``CAS Server URL`` to e.g. ``https://localhost:1234/portal/cas``
+- Set ``CAS Server URL`` to empty string
 
 Lastly you have to change the admin-unit urls in the database to localhost.
 


### PR DESCRIPTION
The setup of a multi-admin deployment for development didn't work with the new frontend. Setting the `cas_url` to empty string will avoid that the frontend tries to login over CAS. 
Note that the frontend will only work for the `fd` admin_unit, because the `rk` is not included in the default apps that the frontend will use for local development.

## Checklist (Must have)
- [ ] Changelog entry
- [ ] Link to issue (Jira or GitHub) and backlink in issue (Jira)