### PR TITLE
Adding a subtask to a sequential task through the restapi respects the `position` parameter.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 ----------------------
 
 - Allow downloading and sending a document checked out by another user. [elioschmutz]
+- Adding a subtask to a sequential task through the restapi respects the `position` parameter [elioschmutz]
 - Fix keyword filter for keywords that contain spaces. [tinagerber]
 - Fix deletion of favorites when object is removed or trashed. [njohner]
 - Add @assign-to-dossier rest-api endpoint to assign a forwarding to a dossier [elioschmutz]

--- a/docs/public/dev-manual/api/tasks.rst
+++ b/docs/public/dev-manual/api/tasks.rst
@@ -610,3 +610,28 @@ Die kopierten Aufgaben können auch direkt über den GET-Request eines Tasks mit
 
      GET http://example.org/ordnungssystem/fuehrung/dossier-1/task-1?expand=successors HTTP/1.1
      Accept: application/json
+
+
+
+Aufgabenliste einer sequenziellen Aufgabe erweitern
+---------------------------------------------------
+Bei sequenziellen Aufgaben ist die Position von Aufgaben relevant. Wird die Aufgabenliste von einer sequenziellen Aufgabe erweitert, kann über den Parameter ``position`` die Position der neuen Aufgabe bestimmt werden.
+
+Wird keine Position angegeben, wird die Aufgabe am Ende der Aufgabenliste hinzugefügt.
+
+**Beispiel-Request**:
+
+   .. sourcecode:: http
+
+      POST /(container) HTTP/1.1
+      Accept: application/json
+      Content-Type: application/json
+
+      {
+        "@type": "opengever.task.task",
+        "title": "Bitte Dokument reviewen",
+        "position": 4,
+        "...": "...",
+      }
+
+Der Parameter steht nur für Aufgaben innerhalb einer sequenziellen Aufgabe zur Verfügung.

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -783,6 +783,13 @@
       />
 
   <plone:service
+      method="POST"
+      for="opengever.task.task.ITask"
+      factory=".task.TaskPost"
+      permission="cmf.AddPortalContent"
+      />
+
+  <plone:service
       method="GET"
       name="@notification-settings"
       for="Products.CMFPlone.interfaces.IPloneSiteRoot"


### PR DESCRIPTION
Jira: https://4teamwork.atlassian.net/browse/NE-338

This PR extends the task POST endpoint to also respect the `positions` parameter if adding a task to a sequential task.

This was already implemented in the current Add form: https://github.com/4teamwork/opengever.core/blob/master/opengever/task/browser/forms.py#L111, but was forgotten for the API.

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


## Checklist (if applicable)

_Only applicable should be left and checked._

- API change:
  - [x] Documentation is updated
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Upgrade steps (changes in profile):
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
- DB-Schema migration
  - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
  - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value
