### PR TITLE
Add feature flag for todos.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2020.16.0 (unreleased)
 ----------------------
 
+- Add feature flag for todos. [tinagerber]
 - No longer zip-export empty tasks, prevent creation of empty folders in such cases. [deiferni]
 - Add sequence_type to task serializer. [tinagerber]
 

--- a/docs/public/dev-manual/api/config.rst
+++ b/docs/public/dev-manual/api/config.rst
@@ -91,6 +91,7 @@ GEVER-Mandanten abgefragt werden.
               "tasks_pdf": false,
               "workspace": false,
               "workspace_client": false
+              "workspace_todo": false,
           },
           "gever_colorization": "#37C35A",
           "inbox_folder_url": "https://dev.onegovgever.ch/fd/eingangskorb/eingangskorb_afi",
@@ -245,6 +246,10 @@ features
 
     workspace_client
         Integration von GEVER mit einem Teamraum
+
+    workspace_todo
+        ToDo's und ToDo-Listen in einem Teamraum
+
 
 gever_colorization
     Rahmen Farbe

--- a/opengever/activity/browser/settings.py
+++ b/opengever/activity/browser/settings.py
@@ -17,6 +17,7 @@ from opengever.base.json_response import JSONResponse
 from opengever.meeting import is_meeting_feature_enabled
 from opengever.ogds.models.user import User
 from opengever.ogds.models.user_settings import UserSettings
+from opengever.workspace import is_todo_feature_enabled
 from opengever.workspace import is_workspace_feature_enabled
 from path import Path
 from plone import api
@@ -353,4 +354,4 @@ class NotificationSettingsForm(BrowserView):
         return is_meeting_feature_enabled()
 
     def show_workspaces_tab(self):
-        return is_workspace_feature_enabled()
+        return is_workspace_feature_enabled() and is_todo_feature_enabled()

--- a/opengever/api/notification_settings.py
+++ b/opengever/api/notification_settings.py
@@ -8,6 +8,7 @@ from opengever.api.validation import get_validation_errors
 from opengever.meeting import is_meeting_feature_enabled
 from opengever.ogds.models.user import User
 from opengever.ogds.models.user_settings import UserSettings
+from opengever.workspace import is_todo_feature_enabled
 from opengever.workspace import is_workspace_feature_enabled
 from plone import api
 from plone.restapi.deserializer import json_body
@@ -64,7 +65,7 @@ class NotificationSettingsGet(Service):
             'reminder': not is_workspace_feature_enabled(),
             'task': not is_workspace_feature_enabled(),
             'watcher': not is_workspace_feature_enabled(),
-            'workspace': is_workspace_feature_enabled(),
+            'workspace': is_workspace_feature_enabled() and is_todo_feature_enabled(),
         }
 
     def general_settings_visibility(self):

--- a/opengever/api/tests/test_config.py
+++ b/opengever/api/tests/test_config.py
@@ -89,6 +89,7 @@ class TestConfig(IntegrationTestCase):
                 u'tasks_pdf': False,
                 u'workspace': False,
                 u'workspace_client': False,
+                u'workspace_todo': True,
             })
 
     @browsing

--- a/opengever/base/configuration.py
+++ b/opengever/base/configuration.py
@@ -36,6 +36,7 @@ from opengever.repository.interfaces import IRepositoryFolderRecords
 from opengever.sharing.interfaces import ISharingConfiguration
 from opengever.task.interfaces import ITaskSettings
 from opengever.workspace.interfaces import IWorkspaceSettings
+from opengever.workspace.interfaces import IToDoSettings
 from opengever.workspaceclient.interfaces import IWorkspaceClientSettings
 from pkg_resources import get_distribution
 from plone import api
@@ -162,6 +163,7 @@ class GeverSettingsAdpaterV1(object):
         features['solr'] = api.portal.get_registry_record('use_solr', interface=ISearchSettings)
         features['workspace'] = api.portal.get_registry_record('is_feature_enabled', interface=IWorkspaceSettings)
         features['workspace_client'] = api.portal.get_registry_record('is_feature_enabled', interface=IWorkspaceClientSettings)  # noqa
+        features['workspace_todo'] = api.portal.get_registry_record('is_feature_enabled', interface=IToDoSettings)
         features['private_tasks'] = api.portal.get_registry_record('private_task_feature_enabled', interface=ITaskSettings)
         features['optional_task_permissions_revoking'] = api.portal.get_registry_record('optional_task_permissions_revoking_enabled', interface=ITaskSettings)  # noqa
         return features

--- a/opengever/base/tests/test_configuration_adapter.py
+++ b/opengever/base/tests/test_configuration_adapter.py
@@ -89,6 +89,7 @@ class TestConfigurationAdapter(IntegrationTestCase):
                 ('solr', True),
                 ('workspace', False),
                 ('workspace_client', False),
+                ('workspace_todo', True),
                 ('private_tasks', True),
                 ('optional_task_permissions_revoking', False),
                 ])),

--- a/opengever/core/profiles/default/registry.xml
+++ b/opengever/core/profiles/default/registry.xml
@@ -188,6 +188,9 @@
   <!-- Workspace -->
   <records interface="opengever.workspace.interfaces.IWorkspaceSettings" />
 
+  <!-- ToDo -->
+  <records interface="opengever.workspace.interfaces.IToDoSettings" />
+
   <!-- WorkspaceClient-->
   <records interface="opengever.workspaceclient.interfaces.IWorkspaceClientSettings" />
 

--- a/opengever/core/upgrades/20201203113604_add_to_do_feature_flag/registry.xml
+++ b/opengever/core/upgrades/20201203113604_add_to_do_feature_flag/registry.xml
@@ -1,0 +1,5 @@
+<registry>
+  <records interface="opengever.workspace.interfaces.IToDoSettings">
+    <value key="is_feature_enabled">True</value>
+  </records>
+</registry>

--- a/opengever/core/upgrades/20201203113604_add_to_do_feature_flag/upgrade.py
+++ b/opengever/core/upgrades/20201203113604_add_to_do_feature_flag/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddToDoFeatureFlag(UpgradeStep):
+    """Add ToDo feature flag.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/policytemplates/hooks.py
+++ b/opengever/policytemplates/hooks.py
@@ -44,6 +44,7 @@ IGNORED_QUESTIONS = {
         'deployment.workspace_users_group',
         'base.apps_endpoint_url',
         'base.workspace_secret',
+        'setup.enable_todo_feature'
         ]
     }
 

--- a/opengever/policytemplates/policy_template/.mrbob.ini
+++ b/opengever/policytemplates/policy_template/.mrbob.ini
@@ -217,3 +217,8 @@ setup.bumblebee_auto_refresh.question = Enable Bumblebee auto refresh
 setup.bumblebee_auto_refresh.required = True
 setup.bumblebee_auto_refresh.default = true
 setup.bumblebee_auto_refresh.post_ask_question = mrbob.hooks:to_boolean
+
+setup.enable_todo_feature.question = Enable ToDo feature
+setup.enable_todo_feature.required = True
+setup.enable_todo_feature.default = true
+setup.enable_todo_feature.post_ask_question = mrbob.hooks:to_boolean

--- a/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/+adminunit.id+/profiles/default/registry.xml.bob
+++ b/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/+adminunit.id+/profiles/default/registry.xml.bob
@@ -133,5 +133,11 @@
     <value key="is_feature_enabled">True</value>
   </records>
 
+{{% if not setup.enable_todo_feature %}}
+  <records interface="opengever.workspace.interfaces.IToDoSettings">
+    <value key="is_feature_enabled">False</value>
+  </records>
+
+{{% endif %}}
 {{% endif %}}
 </registry>

--- a/opengever/testing/integration_test_case.py
+++ b/opengever/testing/integration_test_case.py
@@ -85,6 +85,7 @@ FEATURE_FLAGS = {
     'repositoryfolder-tasks-tab': 'opengever.repository.interfaces.IRepositoryFolderRecords.show_tasks_tab',
     'workspace': 'opengever.workspace.interfaces.IWorkspaceSettings.is_feature_enabled',
     'workspace_client': 'opengever.workspace.interfaces.IWorkspaceClientSettings.is_feature_enabled',
+    'workspace-todo': 'opengever.workspace.interfaces.IToDoSettings.is_feature_enabled',
     'favorites': 'opengever.base.interfaces.IFavoritesSettings.is_feature_enabled',
     'solr': 'opengever.base.interfaces.ISearchSettings.use_solr',
     'purge-trash': 'opengever.dossier.interfaces.IDossierResolveProperties.purge_trash_enabled',

--- a/opengever/workspace/__init__.py
+++ b/opengever/workspace/__init__.py
@@ -1,3 +1,4 @@
+from opengever.workspace.interfaces import IToDoSettings
 from plone import api
 from zope.i18nmessageid import MessageFactory
 
@@ -8,3 +9,8 @@ def is_workspace_feature_enabled():
     from opengever.workspace.interfaces import IWorkspaceSettings
     return api.portal.get_registry_record(
         'is_feature_enabled', interface=IWorkspaceSettings)
+
+
+def is_todo_feature_enabled():
+    return api.portal.get_registry_record(
+        'is_feature_enabled', interface=IToDoSettings)

--- a/opengever/workspace/interfaces.py
+++ b/opengever/workspace/interfaces.py
@@ -37,6 +37,14 @@ class IWorkspaceSettings(Interface):
     )
 
 
+class IToDoSettings(Interface):
+
+    is_feature_enabled = schema.Bool(
+        title=u'Enable todo feature',
+        description=u'Whether todos integration is enabled',
+        default=True)
+
+
 class IToDo(Interface):
     """ Marker interface for ToDos """
 

--- a/opengever/workspace/tests/test_todo.py
+++ b/opengever/workspace/tests/test_todo.py
@@ -147,6 +147,19 @@ class TestAPISupportForTodo(IntegrationTestCase):
         self.assertEqual('todo-4', browser.json['id'])
 
     @browsing
+    def test_create_with_todo_feature_disabled(self, browser):
+        self.deactivate_feature('workspace-todo')
+        self.login(self.workspace_member, browser)
+        with browser.expect_http_error(code=403, reason='Forbidden'):
+            browser.open(
+                self.workspace, method='POST', headers=self.api_headers,
+                data=json.dumps({'title': 'Ein ToDo',
+                                 '@type': 'opengever.workspace.todo'}))
+
+        self.assertEqual('Disallowed subobject type: opengever.workspace.todo',
+                         browser.json['error']['message'])
+
+    @browsing
     def test_read(self, browser):
         self.login(self.workspace_member, browser)
         browser.open(self.todo, method='GET', headers=self.api_headers)

--- a/opengever/workspace/tests/test_workspace_workspace.py
+++ b/opengever/workspace/tests/test_workspace_workspace.py
@@ -63,6 +63,27 @@ class TestWorkspaceWorkspace(IntegrationTestCase):
         self.login(self.workspace_member)
         self.assertEquals('workspace-1', self.workspace.getId())
 
+    def test_default_addable_types(self):
+        self.login(self.workspace_member)
+        self.assertItemsEqual(
+            ['opengever.document.document',
+             'ftw.mail.mail',
+             'opengever.workspace.todo',
+             'opengever.workspace.todolist',
+             'opengever.workspace.folder',
+             'opengever.workspace.meeting'],
+            [fti.id for fti in self.workspace.allowedContentTypes()])
+
+    def test_addable_types_with_todo_feature_disabled(self):
+        self.deactivate_feature('workspace-todo')
+        self.login(self.workspace_member)
+        self.assertItemsEqual(
+            ['opengever.document.document',
+             'ftw.mail.mail',
+             'opengever.workspace.folder',
+             'opengever.workspace.meeting'],
+            [fti.id for fti in self.workspace.allowedContentTypes()])
+
     @browsing
     def test_security_view_access(self, browser):
         for user in (self.workspace_owner,

--- a/opengever/workspace/workspace.py
+++ b/opengever/workspace/workspace.py
@@ -1,4 +1,5 @@
 from opengever.workspace import _
+from opengever.workspace import is_todo_feature_enabled
 from opengever.workspace.base import WorkspaceBase
 from opengever.workspace.interfaces import IWorkspace
 from opengever.workspace.interfaces import IWorkspaceSettings
@@ -53,6 +54,16 @@ class Workspace(WorkspaceBase):
 
     def get_parent_with_local_roles(self):
         return self
+
+    def allowedContentTypes(self, *args, **kwargs):
+        types = super(Workspace, self).allowedContentTypes(*args, **kwargs)
+
+        def filter_type(fti):
+            if fti.id == "opengever.workspace.todo" or fti.id == "opengever.workspace.todolist":
+                return is_todo_feature_enabled()
+            return True
+
+        return filter(filter_type, types)
 
 
 class WorkspaceContentPatch(ContentPatch):


### PR DESCRIPTION
This PR adds a feature flag for todos. This allows us to enable and disable ToDos and ToDo lists. By default, this feature is enabled so that no additional update steps are required in the policies.
With the policy generator the feature can be enabled and disabled.

Jira: https://4teamwork.atlassian.net/browse/NE-163

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


## Checklist (if applicable)

_Only applicable should be left and checked._

- API change:
  - [x] Documentation is updated