### PR TITLE
Synchronize bumblebee checksum to RIS

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,7 @@ Changelog
 2020.16.0 (unreleased)
 ----------------------
 
-- Nothing changed yet.
+- Added a field to the solr sync chain so that PDF documents can be displayed in RIS [sebastianmanger]
 
 
 2020.15.0 (2020-12-03)

--- a/solr-conf/sync-solr.js
+++ b/solr-conf/sync-solr.js
@@ -280,6 +280,7 @@ function processAdd(cmd) {
       "allowedRolesAndUsers",
       true
     );
+    updateDocument = fillPayload(updateDocument, doc, "bumblebee_checksum");
     // end: list of values
 
     if (isObjectEmpty(updateDocument)) {


### PR DESCRIPTION
This additional field is required so that PDF documents can be displayed in RIS. The documents are synchronized to the RIS-Solr since PR https://github.com/4teamwork/opengever.core/pull/6576


## Checklist (Must have)

- [x] Changelog entry
- [x] Link to issue (https://4teamwork.atlassian.net/browse/HG-449 / https://4teamwork.atlassian.net/browse/HG-763) and backlink in issue (Jira)
