### PR TITLE
Add sequence_type to task serializer

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 ----------------------
 
 - No longer zip-export empty tasks, prevent creation of empty folders in such cases. [deiferni]
+- Add sequence_type to task serializer. [tinagerber]
 
 
 2020.15.1 (2020-12-03)

--- a/opengever/testing/builders/dx.py
+++ b/opengever/testing/builders/dx.py
@@ -13,6 +13,7 @@ from opengever.mail.mail import OGMail
 from opengever.meeting.committee import ICommittee
 from opengever.task.interfaces import ISuccessorTaskController
 from opengever.tasktemplates import INTERACTIVE_USERS
+from opengever.tasktemplates.interfaces import IFromParallelTasktemplate
 from opengever.tasktemplates.interfaces import IFromSequentialTasktemplate
 from opengever.testing import assets
 from opengever.testing.builders.base import TEST_USER_ID
@@ -186,6 +187,7 @@ class TaskBuilder(DexterityBuilder):
         self.transitions = []
         self.predecessor = None
         self._as_sequential_task = False
+        self._as_parallel_task = False
         self.arguments = {
             'responsible_client': 'org-unit-1',
             'responsible': TEST_USER_ID,
@@ -205,6 +207,9 @@ class TaskBuilder(DexterityBuilder):
 
         if self._as_sequential_task:
             alsoProvides(obj, IFromSequentialTasktemplate)
+
+        if self._as_parallel_task:
+            alsoProvides(obj, IFromParallelTasktemplate)
 
         super(TaskBuilder, self).after_create(obj)
 
@@ -234,6 +239,10 @@ class TaskBuilder(DexterityBuilder):
 
     def as_sequential_task(self):
         self._as_sequential_task = True
+        return self
+
+    def as_parallel_task(self):
+        self._as_parallel_task = True
         return self
 
 


### PR DESCRIPTION
In the frontend we want to show whether a "Standardablauf" is sequential or parallel. Therefore I added the field `sequence_type` to the task serializer.

Jira: https://4teamwork.atlassian.net/browse/NE-314

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)