### PR TITLE
Implement specific task zip representation, no longer export empty tasks.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,7 @@ Changelog
 2020.16.0 (unreleased)
 ----------------------
 
-- Nothing changed yet.
+- No longer zip-export empty tasks, prevent creation of empty folders in such cases. [deiferni]
 
 
 2020.15.1 (2020-12-03)

--- a/opengever/inbox/tests/test_zipexport.py
+++ b/opengever/inbox/tests/test_zipexport.py
@@ -1,0 +1,19 @@
+from ftw.testbrowser import browsing
+from ftw.zipexport.zipfilestream import ZipFile
+from opengever.testing import IntegrationTestCase
+from StringIO import StringIO
+
+
+class TestForwardingZipExport(IntegrationTestCase):
+
+    @browsing
+    def test_forwardings_with_documents_are_exported(self, browser):
+        self.login(self.secretariat_user, browser=browser)
+
+        browser.open(self.inbox_forwarding, view='zip_export')
+        zip_file = ZipFile(StringIO(browser.contents), 'r')
+
+        self.assertEqual(
+            [self.inbox_forwarding_document.get_filename()],
+            zip_file.namelist()
+        )

--- a/opengever/task/configure.zcml
+++ b/opengever/task/configure.zcml
@@ -103,6 +103,7 @@
   <adapter factory=".adapters.ResponseContainer" />
   <adapter factory=".deadline_modifier.DeadlineModifier" />
   <adapter factory=".successor.SuccessorTaskController" />
+  <adapter factory=".ziprepresentation.TaskZipRepresentation" />
 
   <subscriber
       for="plone.dexterity.interfaces.IDexterityContent

--- a/opengever/task/tests/test_overview.py
+++ b/opengever/task/tests/test_overview.py
@@ -85,8 +85,7 @@ class TestTaskOverview(SolrIntegrationTestCase):
         zipfile = ZipFile(StringIO(browser.contents), 'r')
 
         self.assertEquals(
-            [u'Task - Rechtliche Grundlagen in Vertragsentwurf Uberprufen/',
-             'Feedback zum Vertragsentwurf.docx'],
+            ['Feedback zum Vertragsentwurf.docx'],
             zipfile.namelist())
 
         data = {'zip_selected:method': 1,

--- a/opengever/task/tests/test_zipexport.py
+++ b/opengever/task/tests/test_zipexport.py
@@ -1,6 +1,11 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.testbrowser import browsing
 from ftw.zipexport.interfaces import IZipRepresentation
+from ftw.zipexport.zipfilestream import ZipFile
 from opengever.testing import IntegrationTestCase
 from opengever.testing import set_preferred_language
+from StringIO import StringIO
 from zope.component import getMultiAdapter
 
 
@@ -9,27 +14,104 @@ class TestTaskZipExport(IntegrationTestCase):
     def test_task_zip_export_prefix_de(self):
         set_preferred_language(self.request, 'de-ch')
         self.login(self.dossier_responsible)
-        task_zip_adapter = getMultiAdapter((self.task, self.request), interface=IZipRepresentation)
+        task_zip_adapter = getMultiAdapter((self.dossier, self.request), interface=IZipRepresentation)
         paths = [
             path_and_file[0]
             for path_and_file in task_zip_adapter.get_files()
             ]
-        expected_paths = [
-            u'/Aufgabe - Rechtliche Grundlagen in Vertragsentwurf \xdcberpr\xfcfen',
-            u'/Feedback zum Vertragsentwurf.docx',
-            ]
-        self.assertEqual(paths, expected_paths)
+        self.assertIn(
+            u'/Aufgabe - Vertragsentwurf \xdcberpr\xfcfen/Feedback zum Vertragsentwurf.docx',
+            paths)
 
     def test_task_zip_export_prefix_fr(self):
         set_preferred_language(self.request, 'fr-ch')
         self.login(self.dossier_responsible)
-        task_zip_adapter = getMultiAdapter((self.task, self.request), interface=IZipRepresentation)
+        task_zip_adapter = getMultiAdapter((self.dossier, self.request), interface=IZipRepresentation)
         paths = [
             path_and_file[0]
             for path_and_file in task_zip_adapter.get_files()
             ]
-        expected_paths = [
-            u'/T\xe2che - Rechtliche Grundlagen in Vertragsentwurf \xdcberpr\xfcfen',
-            u'/Feedback zum Vertragsentwurf.docx',
-            ]
-        self.assertEqual(paths, expected_paths)
+        self.assertIn(
+            u'/T\xe2che - Vertragsentwurf \xdcberpr\xfcfen/Feedback zum Vertragsentwurf.docx',
+            paths)
+
+    @browsing
+    def test_empty_tasks_are_not_exported(self, browser):
+        self.login(self.dossier_responsible, browser=browser)
+
+        create(Builder('task')
+               .within(self.subsubdossier)
+               .titled(u'I am empty and not in the zip export')
+               .having(responsible_client='fa',
+                       responsible=self.dossier_responsible.getId(),
+                       issuer=self.dossier_responsible.getId(),
+                       task_type='correction')
+               .in_progress())
+
+        browser.open(self.subsubdossier, view='zip_export')
+        zip_file = ZipFile(StringIO(browser.contents), 'r')
+
+        self.assertEqual(
+            [self.subsubdocument.get_filename()],
+            zip_file.namelist()
+        )
+
+    @browsing
+    def test_nested_empty_tasks_are_not_exported(self, browser):
+        self.login(self.dossier_responsible, browser=browser)
+
+        task = create(Builder('task')
+               .within(self.subsubdossier)
+               .titled(u'I am empty and not in the zip export')
+               .having(responsible_client='fa',
+                       responsible=self.dossier_responsible.getId(),
+                       issuer=self.dossier_responsible.getId(),
+                       task_type='correction')
+               .in_progress())
+        create(Builder('task')
+               .within(task)
+               .titled(u'I nested but also empty and not in the zip export')
+               .having(responsible_client='fa',
+                       responsible=self.dossier_responsible.getId(),
+                       issuer=self.dossier_responsible.getId(),
+                       task_type='correction')
+               .in_progress())
+
+        browser.open(self.subsubdossier, view='zip_export')
+        zip_file = ZipFile(StringIO(browser.contents), 'r')
+
+        self.assertEqual(
+            [self.subsubdocument.get_filename()],
+            zip_file.namelist()
+        )
+
+    @browsing
+    def test_tasks_with_documents_are_exported(self, browser):
+        self.login(self.dossier_responsible, browser=browser)
+
+        task = create(Builder('task')
+               .within(self.subsubdossier)
+               .titled(u'I have a document and am in the zip export')
+               .having(responsible_client='fa',
+                       responsible=self.dossier_responsible.getId(),
+                       issuer=self.dossier_responsible.getId(),
+                       task_type='correction')
+               .in_progress())
+        create(
+            Builder('document')
+            .within(task)
+            .titled(u'Feedback zum Vertragsentwurf')
+            .attach_file_containing(
+                'Feedback text',
+                u'vertr\xe4g sentwurf.docx',
+            ))
+
+        browser.open(self.subsubdossier, view='zip_export')
+        zip_file = ZipFile(StringIO(browser.contents), 'r')
+
+        self.assertEqual(
+            [self.subsubdocument.get_filename(),
+             u'Task - I have a document and am in the zip export/Feedback '
+              'zum Vertragsentwurf.docx'],
+            zip_file.namelist()
+        )

--- a/opengever/task/ziprepresentation.py
+++ b/opengever/task/ziprepresentation.py
@@ -1,0 +1,32 @@
+from ftw.zipexport.interfaces import IZipRepresentation
+from ftw.zipexport.representations.archetypes import FolderZipRepresentation
+from opengever.task.task import ITask
+from plone import api
+from zope.component import adapts
+from zope.interface import implements
+from zope.interface import Interface
+
+
+class TaskZipRepresentation(FolderZipRepresentation):
+    """Prevent adding empty tasks to the zip.
+
+    This purposefully disregards `IZipExportSettings.include_empty_folders` and
+    always omits empty tasks.
+
+    If you're confused as to why this extends from
+    `archetypes.FolderZipRepresentation` so am I. But apparently this
+    representation adapter is also the default for dexterity folderish.
+    """
+    implements(IZipRepresentation)
+    adapts(ITask, Interface)
+
+    def get_files(self, path_prefix=u"", recursive=True, toplevel=True):
+        query = {
+            'object_provides': 'opengever.document.behaviors.IBaseDocument',
+            'path': '/'.join(self.context.getPhysicalPath()),
+        }
+        if len(api.portal.get_tool('portal_catalog')(query)) == 0:
+            return []
+
+        return super(TaskZipRepresentation, self).get_files(
+            path_prefix=path_prefix, recursive=recursive, toplevel=toplevel)


### PR DESCRIPTION
We don't export tasks that don't contain any documents to prevent creation of empty folders for such tasks.

Aborting for empty tasks has been implemented as a catalog query for documents. This has proven to be the easiest way to hook into existing functionality of [ftw.zipexport](https://github.com/4teamwork/ftw.zipexport/ ) without breaking/changing the whole zipexport behavior.


Jira: https://4teamwork.atlassian.net/browse/CA-1167

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

## Checklist (if applicable)

_Only applicable should be left and checked._

- New functionality:
  - [x] for `task` also works for `forwarding`