### PR TITLE
Use form action URL to re-render specific widget.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 
 - No longer zip-export empty tasks, prevent creation of empty folders in such cases. [deiferni]
 - Add sequence_type to task serializer. [tinagerber]
+- Fix only rendering allowed proposal templates when proposal add form is opened from documents tab. [deiferni]
 
 
 2020.15.1 (2020-12-03)

--- a/opengever/base/browser/resources/TableRadioWidget.js
+++ b/opengever/base/browser/resources/TableRadioWidget.js
@@ -36,8 +36,7 @@ $(function() {
 
     var update_widget = function() {
       var selection = widget.find('input[type=radio]:checked').val();
-      var widget_render_url = [location.protocol, '//', location.host,
-                               location.pathname,
+      var widget_render_url = [form.attr('action'),
                                '/++widget++' + fieldname,
                                '/ajax_render'].join('');
       $.get(widget_render_url,


### PR DESCRIPTION
Instead of using browser location we use the form action to re-render specific widgets. The browser location does not always expose the add form name, for example when opened via POST from a tabbed view action.

The form action however always points to the correct form and is more reliable.

This fixes a bug with only rendering allowed proposal templates for the chosen committee on a proposal add form, when the form was opened with the "add proposal" action on a document tab in the classic ui.

Jira: https://4teamwork.atlassian.net/browse/CA-1234

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
