### PR TITLE
Add @assign-to-dossier endpoint for forwardings

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,7 @@ Changelog
 - Allow downloading and sending a document checked out by another user. [elioschmutz]
 - Fix keyword filter for keywords that contain spaces. [tinagerber]
 - Fix deletion of favorites when object is removed or trashed. [njohner]
+- Add @assign-to-dossier rest-api endpoint to assign a forwarding to a dossier [elioschmutz]
 - Add feature flag for todos. [tinagerber]
 - Only expose translated title fields for active languages in schema and serialization via API. [deiferni]
 - No longer zip-export empty tasks, prevent creation of empty folders in such cases. [deiferni]

--- a/docs/public/dev-manual/api/inbox.rst
+++ b/docs/public/dev-manual/api/inbox.rst
@@ -1,0 +1,86 @@
+.. _inbox:
+
+Eingangskorb
+============
+
+Weiterleitungen einem Dossier zuweisen
+--------------------------------------
+
+Eine Weiterleitung kann über eine Workflow-Transition einem Dossier zugewiesen werden.
+
+Für das Zuweisen kann sowohl der ``@workflow`` Endpoint oder aber auch der ``@assign-to-dossier`` Endpoint verwendet werden.
+
+Der Vorteil vom ``@assign-to-dossier`` gegenüber dem ``@worfklow`` Endpoint ist, dass dieser nach erfolgreichem Zuweisen den neu erstellten Task zurück gibt. Zudem werden Fehler im Payload besser behandelt als im generischen ``@worfklow`` Endpoint.
+
+Die Verwendung des ``@workflow``-Endpoints kann im Kapitel :ref:`Workflow <workflow>` nachgeschaut werden. Die zu verwendende Transition ist ``forwarding-transition-assign-to-dossier``.
+
+Beim Zuweisen einer Weiterleitung an ein Dossier wird eine neue Aufgabe im angegebenen Dossier erstellt und mit der Weiterleitung verknüpft. Die Weiterleitung wird erledigt und in den aktuellen Jahresordner der Inbox verschoben.
+
+**Beispiel-Request**:
+
+   .. sourcecode:: http
+
+      POST /inbox/forwarding-1/@assign-to-dossier HTTP/1.1
+      Accept: application/json
+      Content-Type: application/json
+
+      {
+        "target_uid": "123",
+        "comment": "Bitte anschauen"
+      }
+
+
+**Beispiel-Response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 201 Created
+      Content-Type: application/json
+
+      {
+        "@id": "http://example.org/ordnungssystem/dossier-1/task-1",
+        "...": "..."
+      }
+
+
+Aufgabeneigenschaften ändern
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Standardmässig wird beim Zuweisen einer Weiterleitung an ein Dossier eine Aufgabe erstellt, welche den Titel und weitere Attribute von der Weiterleitung erben.
+
+Die Aufgabe kann jedoch über den Endpoint komplett selber definiert werden. Dazu kann der Parameter ``task`` im Payload des Requests verwendet werden.
+
+**Beispiel-Request**:
+
+   .. sourcecode:: http
+
+      POST /inbox/forwarding-1/@assign-to-dossier HTTP/1.1
+      Accept: application/json
+      Content-Type: application/json
+
+      {
+        "target_uid": "123",
+        "task": {
+          "title": "Wichtige Aufgabe aus einer Weiterleitung",
+          "task_type": "information",
+          "deadline": "2016-11-01",
+          "is_private": false,
+          "responsible": "robert.ziegler",
+          "responsible_client": "fa",
+          "revoke_permissions": true,
+          "issuer": "robert.ziegler"
+        }
+      }
+
+
+**Beispiel-Response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 201 Created
+      Content-Type: application/json
+
+      {
+        "@id": "http://example.org/ordnungssystem/dossier-1/task-1",
+        "title": "Wichtige Aufgabe aus einer Weiterleitung",
+        "...": "..."
+      }

--- a/docs/public/dev-manual/api/index.rst
+++ b/docs/public/dev-manual/api/index.rst
@@ -49,6 +49,7 @@ Inhalt:
    role_assignment_reports.rst
    allowed_roles_and_principals.rst
    watchers.rst
+   inbox.rst
    workspace/index
    linked_workspaces.rst
    templatefolder.rst

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -93,6 +93,14 @@
 
   <plone:service
       method="POST"
+      name="@assign-to-dossier"
+      for="opengever.inbox.forwarding.IForwarding"
+      factory=".forwarding.AssignToDossier"
+      permission="cmf.AddPortalContent"
+      />
+
+  <plone:service
+      method="POST"
       name="@checkout"
       for="opengever.document.document.IDocumentSchema"
       factory=".checkout.Checkout"

--- a/opengever/api/forwarding.py
+++ b/opengever/api/forwarding.py
@@ -1,0 +1,71 @@
+from opengever.dossier.behaviors.dossier import IDossierMarker
+from plone import api
+from plone.protect.interfaces import IDisableCSRFProtection
+from plone.restapi.deserializer import json_body
+from plone.restapi.interfaces import ISerializeToJson
+from plone.restapi.services import Service
+from plone.uuid.interfaces import IUUID
+from zExceptions import BadRequest
+from zope.component import queryMultiAdapter
+from zope.interface import alsoProvides
+from zope.schema.interfaces import ValidationError
+
+
+class AssignToDossier(Service):
+    """Assigns a forwarding to a dossier.
+    """
+
+    def reply(self):
+        # Disable CSRF protection
+        alsoProvides(self.request, IDisableCSRFProtection)
+
+        # Extract and validate parameters
+        task_payload, target, comment = self.extract_params()
+
+        transition_params = {'text': comment, 'dossier': IUUID(target)}
+
+        if task_payload:
+            transition_params['task'] = task_payload
+
+        try:
+            task = api.portal.get_tool('portal_workflow').doActionFor(
+                self.context,
+                'forwarding-transition-assign-to-dossier',
+                text=comment,
+                transition_params=transition_params)
+        except ValidationError as exc:
+            raise BadRequest(
+                "The task schema is invalid. Field: {}, Message: {}".format(
+                    str(exc), exc.doc()))
+
+        self.request.response.setStatus(201)
+        self.request.response.setHeader("Location", task.absolute_url())
+
+        return self.serialize(task)
+
+    def extract_params(self):
+        json_data = json_body(self.request)
+
+        task_payload = json_data.get("task")
+        target_uid = json_data.get("target_uid")
+        comment = json_data.get("comment", u'')
+
+        if not target_uid:
+            raise BadRequest('Required parameter "target_uid" is missing in body')
+
+        target = api.content.get(UID=target_uid)
+
+        if not target:
+            raise BadRequest('target_uid: "{}" does not exist'.format(target_uid))
+
+        if not IDossierMarker.providedBy(target):
+            raise BadRequest('target_uid: "{}" is not a dossier'.format(target_uid))
+
+        return task_payload, target, comment
+
+    def serialize(self, obj):
+        serializer = queryMultiAdapter(
+            (obj, self.request), ISerializeToJson)
+        serialized_obj = serializer()
+        serialized_obj["@id"] = obj.absolute_url()
+        return serialized_obj

--- a/opengever/api/tests/test_assign_to_dossier.py
+++ b/opengever/api/tests/test_assign_to_dossier.py
@@ -1,0 +1,266 @@
+from datetime import date
+from ftw.testbrowser import browsing
+from opengever.base.oguid import Oguid
+from opengever.base.role_assignments import RoleAssignmentManager
+from opengever.base.role_assignments import SharingRoleAssignment
+from opengever.inbox.yearfolder import get_current_yearfolder
+from opengever.testing import IntegrationTestCase
+from plone import api
+from zExceptions import BadRequest
+import json
+
+
+class TestAssignToDossier(IntegrationTestCase):
+
+    @browsing
+    def test_assign_forwarding_to_dossier_creates_a_new_task_from_the_forwarding_attributes(self, browser):
+        self.login(self.secretariat_user, browser=browser)
+
+        forwarding = self.inbox_forwarding
+
+        browser.open(
+            self.inbox_forwarding.absolute_url(),
+            view='@assign-to-dossier',
+            method='POST',
+            headers=self.api_headers,
+            data=json.dumps({
+                'target_uid': self.dossier.UID(),
+            }))
+
+        self.assertEqual(201, browser.status_code)
+        task = browser.json
+
+        self.assertEqual(forwarding.title, task.get('title'))
+        self.assertEqual(
+            '{}:{}'.format(forwarding.responsible_client, forwarding.responsible),
+            task.get('responsible').get('token'),)
+
+        self.assertEquals('inbox:fa', task.get('issuer').get('token'))
+
+    @browsing
+    def test_assign_forwarding_to_dossier_moves_the_forwarding_into_the_yearfolder(self, browser):
+        self.login(self.secretariat_user, browser=browser)
+
+        forwarding = self.inbox_forwarding
+
+        browser.open(
+            self.inbox_forwarding.absolute_url(),
+            view='@assign-to-dossier',
+            method='POST',
+            headers=self.api_headers,
+            data=json.dumps({
+                'target_uid': self.dossier.UID(),
+            }))
+
+        self.assertEqual(201, browser.status_code)
+
+        yearfolder = self.inbox.get(str(date.today().year))
+        self.assertEquals(
+            forwarding, yearfolder.get('forwarding-1'),
+            'The forwarding was not correctly moved in to the actual yearfolder')
+
+    @browsing
+    def test_assign_forwarding_to_dossier_creates_the_task_within_the_given_dossier(self, browser):
+        self.login(self.secretariat_user, browser=browser)
+
+        browser.open(
+            self.inbox_forwarding.absolute_url(),
+            view='@assign-to-dossier',
+            method='POST',
+            headers=self.api_headers,
+            data=json.dumps({
+                'target_uid': self.dossier.UID(),
+            }))
+
+        self.assertEqual(201, browser.status_code)
+        task = browser.json
+
+        self.assertEquals(self.dossier.absolute_url(), task.get('parent').get('@id'))
+
+    @browsing
+    def test_assign_forwarding_to_dossier_copies_all_documents_to_the_task(self, browser):
+        self.login(self.secretariat_user, browser=browser)
+
+        document = self.inbox_forwarding_document
+
+        browser.open(
+            self.inbox_forwarding.absolute_url(),
+            view='@assign-to-dossier',
+            method='POST',
+            headers=self.api_headers,
+            data=json.dumps({
+                'target_uid': self.dossier.UID(),
+            }))
+
+        self.assertEqual(201, browser.status_code)
+        task = browser.json
+
+        self.assertEquals(document.title,
+                          task.get('items')[0].get('title'),
+                          'The forwarded document is not copied to the task')
+
+    @browsing
+    def test_can_pass_task_payload_to_directly_create_a_user_defined_task_while_assigning(self, browser):
+        self.login(self.secretariat_user, browser=browser)
+
+        task_payload = {
+            "@type": "opengever.task.task",
+            "title": u"Manual t\xf6sk",
+            "task_type": "correction",
+            "deadline": "2018-12-03",
+            "is_private": False,
+            'revoke_permissions': True,
+            "responsible": self.regular_user.id,
+            "issuer": self.secretariat_user.id,
+            "responsible_client": "fa"}
+
+        browser.open(
+            self.inbox_forwarding.absolute_url(),
+            view='@assign-to-dossier',
+            method='POST',
+            headers=self.api_headers,
+            data=json.dumps({
+                'target_uid': self.dossier.UID(),
+                'task': task_payload
+            }))
+
+        self.assertEqual(201, browser.status_code)
+        task = browser.json
+
+        self.assertEqual(u"Manual t\xf6sk", task.get('title'))
+        self.assertEqual('fa:kathi.barfuss', task.get('responsible').get('token'))
+
+        self.assertEquals('jurgen.konig', task.get('issuer').get('token'))
+        self.assertEqual('2018-12-03', task.get('deadline'))
+
+    @browsing
+    def test_assign_to_dossier_validates_add_permission(self, browser):
+        self.login(self.secretariat_user, browser=browser)
+
+        self.dossier.__ac_local_roles_block__ = True
+        RoleAssignmentManager(self.dossier).add_or_update_assignment(
+            SharingRoleAssignment(api.user.get_current().getId(), ['Reader']))
+
+        self.assertFalse(api.user.has_permission('opengever.task: Add task', obj=self.dossier))
+        with browser.expect_http_error(401):
+            browser.open(
+                self.inbox_forwarding.absolute_url(),
+                view='@assign-to-dossier',
+                method='POST',
+                headers=self.api_headers,
+                data=json.dumps({
+                    'target_uid': self.dossier.UID(),
+                }))
+
+    @browsing
+    def test_assign_to_dossier_validates_addable_types(self, browser):
+        self.login(self.secretariat_user, browser=browser)
+
+        self.assertTrue(api.user.has_permission('opengever.task: Add task', obj=self.dossier))
+
+        with browser.expect_http_error(401):
+            browser.open(
+                self.inbox_forwarding.absolute_url(),
+                view='@assign-to-dossier',
+                method='POST',
+                headers=self.api_headers,
+                data=json.dumps({
+                    'target_uid': self.inactive_dossier.UID(),
+                }))
+
+    @browsing
+    def test_assign_to_dossier_links_the_forwarding_with_the_task(self, browser):
+        self.login(self.secretariat_user, browser=browser)
+
+        browser.open(
+            self.inbox_forwarding.absolute_url(),
+            view='@assign-to-dossier',
+            method='POST',
+            data=json.dumps({'target_uid': self.dossier.UID()}),
+            headers=self.api_headers)
+
+        task = browser.json
+        predecessor = Oguid.parse(task.get('predecessor')).resolve_object()
+
+        yearfolder = get_current_yearfolder(context=self.inbox)
+        forwarding = yearfolder.objectValues()[0]
+
+        self.assertEqual(predecessor, forwarding)
+
+    @browsing
+    def test_raises_bad_request_when_target_uid_parameter_is_missing(self, browser):
+        self.login(self.secretariat_user, browser=browser)
+
+        browser.exception_bubbling = True
+        with self.assertRaises(BadRequest) as cm:
+            browser.open(
+                self.inbox_forwarding.absolute_url(),
+                view='@assign-to-dossier',
+                method='POST',
+                data=json.dumps({}),
+                headers=self.api_headers)
+
+        self.assertEqual('Required parameter "target_uid" is missing in body',
+                         str(cm.exception))
+
+    @browsing
+    def test_raises_bad_request_when_target_uid_does_not_exist(self, browser):
+        self.login(self.secretariat_user, browser=browser)
+
+        browser.exception_bubbling = True
+        with self.assertRaises(BadRequest) as cm:
+            browser.open(
+                self.inbox_forwarding.absolute_url(),
+                view='@assign-to-dossier',
+                method='POST',
+                data=json.dumps({'target_uid': 'not-existing'}),
+                headers=self.api_headers)
+
+        self.assertEqual('target_uid: "not-existing" does not exist', str(cm.exception))
+
+    @browsing
+    def test_raises_bad_request_when_target_uid_is_not_a_dossier(self, browser):
+        self.login(self.secretariat_user, browser=browser)
+
+        browser.exception_bubbling = True
+        with self.assertRaises(BadRequest) as cm:
+            browser.open(
+                self.inbox_forwarding.absolute_url(),
+                view='@assign-to-dossier',
+                method='POST',
+                data=json.dumps({'target_uid': self.document.UID()}),
+                headers=self.api_headers)
+
+        self.assertEqual(
+            'target_uid: "createtreatydossiers000000000002" is not a dossier',
+            str(cm.exception))
+
+    @browsing
+    def test_raises_bad_request_when_task_schema_is_invalid(self, browser):
+        self.login(self.secretariat_user, browser=browser)
+
+        task_payload = {
+            "@type": "opengever.task.task",
+            "title": u"Manual t\xf6sk",
+            "deadline": "2018-12-03",
+            "is_private": False,
+            'revoke_permissions': True,
+            "responsible": self.regular_user.id,
+            "issuer": self.secretariat_user.id,
+            "responsible_client": "fa"}
+
+        browser.exception_bubbling = True
+        with self.assertRaises(BadRequest) as cm:
+            browser.open(
+                self.inbox_forwarding.absolute_url(),
+                view='@assign-to-dossier',
+                method='POST',
+                data=json.dumps({
+                    'target_uid': self.dossier.UID(),
+                    'task': task_payload
+                }),
+                headers=self.api_headers)
+
+        self.assertEqual(
+            'The task schema is invalid. Field: task_type, Message: Required input is missing.',
+            str(cm.exception))

--- a/opengever/base/transition.py
+++ b/opengever/base/transition.py
@@ -61,61 +61,68 @@ class TransitionExtender(object):
         """Deserialize and validates the defined schema returns a values and
         a list of errors.
         """
-        schema_data = {}
         errors = []
         values = {}
 
-        for schemata in self.schemas:
-            for name, field in getFields(schemata).items():
-                field_data = schema_data.setdefault(schemata, {})
-
-                if name in transition_params:
-                    # Deserialize to field value
-                    deserializer = queryMultiAdapter(
-                        (field, self.context, getRequest()), IFieldDeserializer)
-                    if deserializer is None:
-                        continue
-
-                    try:
-                        value = deserializer(transition_params[name])
-                        validator = queryMultiAdapter(
-                            (self.context, self.request, None, field, None), IValidator)
-                        if validator:
-                            validator.validate(value)
-
-                    except (ValueError, Invalid) as e:
-                        if not collect_errors:
-                            raise
-                        errors.append({'message': e.message, 'field': name, 'error': e})
-
-                    except ValidationError as e:
-                        if not collect_errors:
-                            raise
-                        errors.append({'message': e.doc(), 'field': name, 'error': e})
-                    else:
-                        field_data[name] = value
-
-                else:
-                    field_data[name] = field.missing_value
-
-                    try:
-                        field.validate(field_data.get(name))
-                    except ValidationError as e:
-                        if not collect_errors:
-                            raise
-                        errors.append({'message': e.doc(), 'field': name, 'error': e})
-
-            values.update(field_data)
-
-        # Validate schemata
-        for schemata, field_data in schema_data.items():
-            validator = queryMultiAdapter(
-                (self.context, getRequest(), None, schemata, None),
-                IManagerValidator)
-            for error in validator.validate(field_data):
-                if not collect_errors:
-                    raise ValueError(error.message)
-
-                errors.append({'error': error, 'message': error.message})
+        for schema in self.schemas:
+            schema_data, errors = self._deserialize_schema(schema, transition_params, collect_errors)
+            errors.extend(errors)
+            values.update(schema_data)
 
         return values, errors
+
+    def _validate_schema(self, schema, schema_data, collect_errors=False):
+        errors = []
+        validator = queryMultiAdapter(
+            (self.context, getRequest(), None, schema, None),
+            IManagerValidator)
+
+        for error in validator.validate(schema_data):
+            if not collect_errors:
+                raise ValueError(error.message)
+
+            errors.append({'error': error, 'message': error.message})
+        return errors
+
+    def _deserialize_schema(self, schema, transition_params, collect_errors=False):
+        field_data = {}
+        errors = []
+        for name, field in getFields(schema).items():
+            if name in transition_params:
+                # Deserialize to field value
+                deserializer = queryMultiAdapter(
+                    (field, self.context, getRequest()), IFieldDeserializer)
+                if deserializer is None:
+                    continue
+
+                try:
+                    value = deserializer(transition_params[name])
+                    validator = queryMultiAdapter(
+                        (self.context, self.request, None, field, None), IValidator)
+                    if validator:
+                        validator.validate(value)
+
+                except (ValueError, Invalid) as e:
+                    if not collect_errors:
+                        raise
+                    errors.append({'message': e.message, 'field': name, 'error': e})
+
+                except ValidationError as e:
+                    if not collect_errors:
+                        raise
+                    errors.append({'message': e.doc(), 'field': name, 'error': e})
+                else:
+                    field_data[name] = value
+
+            else:
+                field_data[name] = field.missing_value
+
+                try:
+                    field.validate(field_data.get(name))
+                except ValidationError as e:
+                    if not collect_errors:
+                        raise
+                    errors.append({'message': e.doc(), 'field': name, 'error': e})
+
+        errors.extend(self._validate_schema(schema, field_data))
+        return field_data, errors

--- a/opengever/inbox/tests/test_api_support.py
+++ b/opengever/inbox/tests/test_api_support.py
@@ -117,6 +117,35 @@ class TestAPITransitions(IntegrationTestCase):
         self.assertEqual(u'F\xf6rw\xe4rding', task.title)
 
     @browsing
+    def test_assign_to_dossier_allows_to_pass_task_data_which_will_be_used_to_create_the_new_task(self, browser):
+        self.login(self.secretariat_user, browser=browser)
+
+        url = '{}/@workflow/forwarding-transition-assign-to-dossier'.format(
+            self.inbox_forwarding.absolute_url())
+
+        dossier_uid = obj2brain(self.empty_dossier).UID
+        data = {
+            'dossier': dossier_uid,
+            'task': {
+                u'title': u'My custom task',
+                u'task_type': u'information',
+                u'deadline': u'2016-11-01',
+                u'is_private': False,
+                u'responsible': u'robert.ziegler',
+                u'responsible_client': u'fa',
+                u'revoke_permissions': True,
+                u'issuer': u'robert.ziegler'}}
+
+        browser.open(url, method='POST',
+                     data=json.dumps(data), headers=self.api_headers)
+
+        task = self.empty_dossier.objectValues()[-1]
+
+        self.assertEqual(FORWARDING_SUCCESSOR_TYPE, task.task_type)
+        self.assertEqual(u'robert.ziegler', task.issuer)
+        self.assertEqual(u'My custom task', task.title)
+
+    @browsing
     def test_reassign_forwarding(self, browser):
         self.login(self.administrator, browser=browser)
 

--- a/opengever/inbox/transition.py
+++ b/opengever/inbox/transition.py
@@ -74,7 +74,7 @@ class ForwardingAssignToDossierTransitionExtender(ForwardingDefaultTransitionExt
     schemas = [IResponse, IChooseDossierSchema]
 
     def after_transition_hook(self, transition, disable_sync, transition_params):
-        successor_task = self.create_successor_task(transition_params['dossier'])
+        successor_task = self.create_successor_task(transition_params['dossier'], transition_params.get('task'))
 
         add_simple_response(
             self.context, transition=transition, text=transition_params.get('text'),
@@ -87,18 +87,26 @@ class ForwardingAssignToDossierTransitionExtender(ForwardingDefaultTransitionExt
         IYearfolderStorer(self.context).store_in_yearfolder()
         return successor_task
 
-    def create_successor_task(self, dossier):
+    def create_successor_task(self, dossier, task_data=None):
         # we need all task field values from the forwarding
         fielddata = {}
-        for fieldname in ITask.names():
-            value = ITask.get(fieldname).get(self.context)
-            fielddata[fieldname] = value
 
-        # Reset issuer to the current inbox
-        fielddata['issuer'] = get_current_org_unit().inbox().id()
+        if task_data:
+            # We use the given task data if available. This allows us to create
+            # a new task with predefined values directly on executing the transition.
+            fielddata = task_data
+        else:
+            # Uses default values for the new task if no task-data is provided.
+            # This is uses for the old UI.
+            for fieldname in ITask.names():
+                value = ITask.get(fieldname).get(self.context)
+                fielddata[fieldname] = value
 
-        # Predefine the task_type to avoid tasks with an invalid task_type
-        fielddata['task_type'] = FORWARDING_SUCCESSOR_TYPE
+            # Reset issuer to the current inbox
+            fielddata['issuer'] = get_current_org_unit().inbox().id()
+
+            # Predefine the task_type to avoid tasks with an invalid task_type
+            fielddata['task_type'] = FORWARDING_SUCCESSOR_TYPE
 
         # lets create a new task - the successor task
         task = createContentInContainer(
@@ -120,6 +128,20 @@ class ForwardingAssignToDossierTransitionExtender(ForwardingDefaultTransitionExt
             intids_mapping=intids_mapping)
 
         return task
+
+    def _deserialize_values(self, transition_params, collect_errors=False):
+        """Also deserializes the `task` data from the transition_params. This allows
+        us to directly create a specific task through the workflow transition.
+        """
+        values, errors = super(ForwardingAssignToDossierTransitionExtender, self)._deserialize_values(
+            transition_params, collect_errors)
+        task = transition_params.get('task')
+        if task:
+            schema_data, errors = self._deserialize_schema(ITask, task, collect_errors)
+            errors.extend(errors)
+            values['task'] = schema_data
+
+        return values, errors
 
 
 class INewForwardingResponsibleSchema(Schema):


### PR DESCRIPTION
This PR introduces a new endpoint `@assign-to-dossier` for forwardings.

## `@workflow` vs `@assign-to-dossier`
A forwarding can be assigned to a dossier through the workflow transition: `forwarding-transition-assign-to-dossier`.

Executing this transition will perform several steps:
- creating a new task
- linking the newly created task with the forwarding
- moving the forwarding into the years-folder of the inbox

Just calling the transition through the `@worflow` endpoint would be possible but comes with some disadvantages. The `@workflow` endpoint is a generic endpoint for performing workflow transitions on an object. The UI would not know anything about the newly created task nor about the moved forwarding.

The `@assign-to-dossier` endpoint takes care of it and will return the newly created task as the response.

## task-creation

The old UI was not able to directly create a task defined by the user. So the UI created the task with defaults taken from the forwarding (like the title) and showed up the edit-form of the already created task to the user.

The new ui should be able to collect all the user inputs and then assing the forwarding to a dossier with the user defined task attributes.

So this PR introduced a new parameter: `task` for the endpoint which allows us to directly pass a task-payload which will then be used for creating the task.

Jira: https://4teamwork.atlassian.net/browse/NE-73

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


## Checklist (if applicable)

_Only applicable should be left and checked._

- API change:
  - [x] Documentation is updated
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Upgrade steps (changes in profile):
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
- DB-Schema migration
  - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
  - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value
