### PR TITLE
Fix deletion of favorites when object is removed or trashed.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 
 - Allow downloading and sending a document checked out by another user. [elioschmutz]
 - Fix keyword filter for keywords that contain spaces. [tinagerber]
+- Fix deletion of favorites when object is removed or trashed. [njohner]
 - Add feature flag for todos. [tinagerber]
 - Only expose translated title fields for active languages in schema and serialization via API. [deiferni]
 - No longer zip-export empty tasks, prevent creation of empty folders in such cases. [deiferni]

--- a/opengever/base/configure.zcml
+++ b/opengever/base/configure.zcml
@@ -308,7 +308,7 @@
 
   <subscriber
       for="plone.dexterity.interfaces.IDexterityContent
-           zope.lifecycleevent.IObjectRemovedEvent"
+           OFS.interfaces.IObjectWillBeRemovedEvent"
       handler=".handlers.remove_favorites"
       />
 

--- a/opengever/base/handlers.py
+++ b/opengever/base/handlers.py
@@ -116,7 +116,10 @@ def remove_favorites(context, event):
     oguid = Oguid.for_object(context)
 
     stmt = Favorite.__table__.delete().where(Favorite.oguid == oguid)
-    create_session().execute(stmt)
+
+    session = create_session()
+    session.execute(stmt)
+    mark_changed(session)
 
 
 def is_title_changed(descriptions):

--- a/opengever/base/tests/test_favorite.py
+++ b/opengever/base/tests/test_favorite.py
@@ -244,16 +244,20 @@ class TestHandlers(IntegrationTestCase):
         self.login(self.manager)
 
         create(Builder('favorite')
-               .for_object(self.dossier)
+               .for_object(self.subdocument)
+               .for_user(self.administrator))
+
+        create(Builder('favorite')
+               .for_object(self.subdossier)
                .for_user(self.administrator))
 
         create(Builder('favorite')
                .for_object(self.empty_dossier)
                .for_user(self.dossier_responsible))
 
-        self.assertEquals(2, Favorite.query.count())
+        self.assertEquals(3, Favorite.query.count())
 
-        api.content.delete(obj=self.empty_dossier)
+        api.content.delete(obj=self.subdossier)
 
         self.assertEquals(1, Favorite.query.count())
 

--- a/opengever/core/upgrades/20201207113732_clean_up_favorites_for_trashed_and_deleted_objects/upgrade.py
+++ b/opengever/core/upgrades/20201207113732_clean_up_favorites_for_trashed_and_deleted_objects/upgrade.py
@@ -1,0 +1,64 @@
+from opengever.core.upgrade import SQLUpgradeStep
+from plone import api
+from sqlalchemy.sql.expression import column
+from sqlalchemy.sql.expression import select
+from sqlalchemy.sql.expression import table
+from zope.app.intid.interfaces import IIntIds
+from zope.component import getUtility
+import logging
+
+
+LOG = logging.getLogger('ftw.upgrade')
+
+favorites_table = table(
+    'favorites',
+    column('id'),
+    column('plone_uid'),
+    column('admin_unit_id'),
+    column('int_id'),
+)
+
+
+class CleanUpFavoritesForTrashedAndDeletedObjects(SQLUpgradeStep):
+    """Clean up favorites for trashed and deleted objects.
+    """
+
+    deferrable = True
+
+    def migrate(self):
+
+        # We delete all favorites for trashed objects
+        current_admin_unit_id = api.portal.get_registry_record(
+            'opengever.ogds.base.interfaces.IAdminUnitConfiguration.current_unit_id'
+        )
+        rows = self.execute(
+            select([favorites_table.c.plone_uid])
+            .where(favorites_table.c.admin_unit_id == current_admin_unit_id)
+            .distinct()
+        ).fetchall()
+        favorite_uids = [row[0] for row in rows]
+
+        query = {"trashed": True,
+                 "UID": favorite_uids}
+        trashed_uids = [brain.UID for brain in
+                        self.catalog_unrestricted_search(query=query)]
+        self.execute(
+            favorites_table.delete()
+            .where(favorites_table.c.plone_uid.in_(trashed_uids))
+            .where(favorites_table.c.admin_unit_id == current_admin_unit_id))
+
+        # Now we delete all favorites for objects that have been deleted, i.e.
+        # that are not in the catalog
+        intids = getUtility(IIntIds)
+
+        rows = self.execute(
+            select([favorites_table.c.int_id])
+            .where(favorites_table.c.admin_unit_id == current_admin_unit_id)
+            .distinct()
+        ).fetchall()
+
+        favorites_to_delete = [row[0] for row in rows if row[0] not in intids]
+        self.execute(
+            favorites_table.delete()
+            .where(favorites_table.c.int_id.in_(favorites_to_delete))
+            .where(favorites_table.c.admin_unit_id == current_admin_unit_id))


### PR DESCRIPTION
When trashing or deleting an object, the corresponding favorites get deleted by an event handler. This did not work because the session did not get marked as changed and hence the changes were not persisted in the SQL DB. 

Moreover the favorites deletion failed for objects contained in the deleted object: the OGUID of the object removed could not be resolved anymore because its intid had already been removed from the catalog. We fix this by registering the handler earlier (on `ObjectWillBeRemovedEvent` instead of `ObjectRemovedEvent`).

We also add an upgrade step to fix potentially broken favorites for trashed and deleted objects.

For https://4teamwork.atlassian.net/browse/CA-1186

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
- Upgrade steps (changes in profile):
  - [x] Make it deferrable if possible
  - [x] Execute as much as possible conditionally
