### PR TITLE
Backport filing number search fix (#6578)

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,8 @@ Changelog
 2019.6.5 (unreleased)
 ---------------------
 
-- Nothing changed yet.
+- Use filing_no field in advanced search form. [njohner]
+- Reindex SearchableText when filing number is set. [njohner]
 
 
 2019.6.4 (2020-04-02)

--- a/opengever/advancedsearch/tests/test_search.py
+++ b/opengever/advancedsearch/tests/test_search.py
@@ -239,7 +239,7 @@ class TestQueryStrings(IntegrationTestCase):
                       'form.widgets.end_2': "01.04.2010",
                       'form.widgets.reference': "OG 14.2",
                       'form.widgets.sequence_number': "5",
-                      'form.widgets.searchable_filing_no': "14",
+                      'form.widgets.filing_no': "14",
                       'form.widgets.dossier_review_state:list': 'dossier-state-active'})
 
         form = browser.find_form_by_field('Responsible')
@@ -257,7 +257,7 @@ class TestQueryStrings(IntegrationTestCase):
             ('end.query:record:list:date', '2010-04-02'),
             ('reference', 'OG 14.2'),
             ('sequence_number:int', '5'),
-            ('searchable_filing_no', '14'),
+            ('filing_no', '14'),
             ('responsible', self.regular_user.id),
             ('review_state:list', 'dossier-state-active'),
         ])

--- a/opengever/core/upgrades/20200805094934_reindex_searchable_text_to_include_filing_no/upgrade.py
+++ b/opengever/core/upgrades/20200805094934_reindex_searchable_text_to_include_filing_no/upgrade.py
@@ -1,0 +1,18 @@
+from ftw.upgrade import UpgradeStep
+from opengever.dossier.behaviors.filing import IFilingNumberMarker
+from opengever.dossier.behaviors.filing import IFilingNumber
+
+
+class ReindexSearchableTextToIncludeFilingNo(UpgradeStep):
+    """Reindex searchable text to include filing no.
+    """
+
+    deferrable = True
+
+    def __call__(self):
+        query = {'object_provides': IFilingNumberMarker.__identifier__}
+        for dossier in self.objects(query, 'Reindex searchable text to include filing no.'):
+            if IFilingNumber(dossier).filing_no:
+                # SearchableText is not in the catalog, so to avoid reindexing the
+                # full object, we also reindex the UID.
+                dossier.reindexObject(idxs=['UID', 'SearchableText'])

--- a/opengever/dossier/archive.py
+++ b/opengever/dossier/archive.py
@@ -320,7 +320,7 @@ class Archiver(object):
 
     def _recursive_update_prefix(self, dossier, prefix):
         IDossier(dossier).filing_prefix = prefix
-        dossier.reindexObject(idxs=['filing_no', 'searchable_filing_no'])
+        dossier.reindexObject(idxs=['filing_no', 'searchable_filing_no', 'SearchableText'])
         for subdossier in dossier.get_subdossiers(depth=1):
             self._recursive_update_prefix(subdossier.getObject(), prefix)
 
@@ -337,7 +337,7 @@ class Archiver(object):
         IFilingNumber(dossier).filing_no = number
 
         IDossier(self.context).filing_prefix = prefix
-        dossier.reindexObject(idxs=['filing_no', 'searchable_filing_no'])
+        dossier.reindexObject(idxs=['filing_no', 'searchable_filing_no', 'SearchableText'])
 
         for i, subdossier in enumerate(dossier.get_subdossiers(depth=1),
                                        start=1):

--- a/opengever/dossier/filing/advanced_search.py
+++ b/opengever/dossier/filing/advanced_search.py
@@ -8,7 +8,7 @@ from zope import schema
 
 class IFilingnumberSearchAddition(model.Schema):
 
-    searchable_filing_no = schema.TextLine(
+    filing_no = schema.TextLine(
         title=_('label_filing_number', default='Filing number'),
         description=_('help_filing_number', default=''),
         required=False,
@@ -20,7 +20,7 @@ class FilingAdvancedSearchForm(AdvancedSearchForm):
     schemas = (IAdvancedSearch, IFilingnumberSearchAddition)
 
     def move_fields(self):
-        move(self, 'searchable_filing_no', before='responsible')
+        move(self, 'filing_no', before='responsible')
 
     def field_mapping(self):
         """Append searchable_filing_no to default field mappings"""
@@ -29,8 +29,8 @@ class FilingAdvancedSearchForm(AdvancedSearchForm):
         dossier_fields = mapping.get(
             'opengever-dossier-behaviors-dossier-IDossierMarker')
 
-        if 'searchable_filing_no' not in dossier_fields:
+        if 'filing_no' not in dossier_fields:
             dossier_fields.insert(
-                dossier_fields.index('responsible'), 'searchable_filing_no')
+                dossier_fields.index('responsible'), 'filing_no')
 
         return mapping


### PR DESCRIPTION
This is a backport of #6578 to `2019.6-stable`.

I had to drop the new test from this fix when backporting, because the test requires the `SolrIntegrationTestCase`, which wasn't around yet in `2019.6`.

Tests against this branch are still failing though, because the boostrap invocation on Jenkins with `--setuptools-version` would require an updated `bootstrap.py` (and possibly newer versions of `setuptools` and `zc.buildout`), which we don't want to bump for this branch as part of a backport.

I tested the fix locally - I was able to reproduce the issue, the fix + upgrade step worked and fixed it 👍 

Runtime for the upgrade step (as tested locally) is around `8 reindexed dossiers / s`.

Jira: https://4teamwork.atlassian.net/browse/CA-1247

