### PR TITLE
Add public_trial field to listing endpoint.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -8,6 +8,7 @@ Changelog
 - Fix keyword filter for keywords that contain spaces. [tinagerber]
 - Fix deletion of favorites when object is removed or trashed. [njohner]
 - Add @assign-to-dossier rest-api endpoint to assign a forwarding to a dossier [elioschmutz]
+- Add public_trial field to listing endpoint. [tinagerber]
 - Add feature flag for todos. [tinagerber]
 - Only expose translated title fields for active languages in schema and serialization via API. [deiferni]
 - No longer zip-export empty tasks, prevent creation of empty folders in such cases. [deiferni]

--- a/docs/public/dev-manual/api/listings.rst
+++ b/docs/public/dev-manual/api/listings.rst
@@ -101,6 +101,7 @@ werden. Folgende Felder stehen zur Verfügung:
 - ``pdf_url``: URL für Vorschau-PDF
 - ``phone_office``: Telefonnummer
 - ``preview_url``: URL für Vorschau
+- ``public_trial``: Öffentlichkeitsstatus
 - ``receipt_date``: Eingangsdatum
 - ``reference_number``: Aktenzeichen
 - ``reference``: Referenz
@@ -196,6 +197,8 @@ siehe Tabelle:
     |``pdf_url``               |    ja    |   nein  |     nein     |        nein        |  nein   |  nein   |  nein   |   nein   |       nein      |       nein       |       nein      |   nein   |
     +--------------------------+----------+---------+--------------+--------------------+---------+---------+---------+----------+-----------------+------------------+-----------------+----------+
     |``preview_url``           |    ja    |   nein  |     nein     |        nein        |  nein   |  nein   |  nein   |   nein   |       nein      |       nein       |       nein      |   nein   |
+    +--------------------------+----------+---------+--------------+--------------------+---------+---------+---------+----------+-----------------+------------------+-----------------+----------+
+    |``public_trial``          |    ja    |   ja    |     nein     |        nein        |  nein   |  nein   |  nein   |   nein   |       nein      |       nein       |       nein      |   nein   |
     +--------------------------+----------+---------+--------------+--------------------+---------+---------+---------+----------+-----------------+------------------+-----------------+----------+
     |``receipt_date``          |    ja    |   nein  |     nein     |        nein        |  nein   |  nein   |  nein   |   nein   |       nein      |       nein       |       nein      |   nein   |
     +--------------------------+----------+---------+--------------+--------------------+---------+---------+---------+----------+-----------------+------------------+-----------------+----------+

--- a/opengever/api/solr_query_service.py
+++ b/opengever/api/solr_query_service.py
@@ -61,6 +61,10 @@ def translate_document_type(document_type):
         return term.title
 
 
+def translate_public_trial(public_trial):
+    return translate(public_trial, context=getRequest(), domain="opengever.base")
+
+
 def filesize(obj):
     try:
         filesize = obj.filesize
@@ -103,6 +107,13 @@ def translated_title(obj):
 
 def translated_task_type(obj):
     return task_type_helper(obj, obj.get("task_type"))
+
+
+def translated_public_trial(obj):
+    try:
+        return translate(obj.public_trial, context=getRequest(), domain="opengever.base")
+    except AttributeError:
+        return None
 
 
 def to_relative_path(value):
@@ -301,6 +312,8 @@ FIELDS_WITH_MAPPING = [
                  additional_required_fields=['bumblebee_checksum', 'path']),
     ListingField('preview_url', None, 'get_preview_frame_url', DEFAULT_SORT_INDEX,
                  additional_required_fields=['bumblebee_checksum', 'path']),
+    ListingField('public_trial', 'public_trial', accessor=translated_public_trial,
+                 transform=translate_public_trial),
     ListingField('reference_number', 'reference'),
     ListingField('relative_path', 'path', relative_path, transform=to_relative_path),
     ListingField('responsible', 'responsible', transform=display_name),

--- a/opengever/testing/fixtures.py
+++ b/opengever/testing/fixtures.py
@@ -18,6 +18,7 @@ from ftw.tokenauth.pas.storage import CredentialStorage
 from opengever.activity.model import Watcher
 from opengever.activity.roles import TASK_ISSUER_ROLE
 from opengever.activity.roles import TASK_RESPONSIBLE_ROLE
+from opengever.base.behaviors.classification import PUBLIC_TRIAL_PRIVATE
 from opengever.base.behaviors.lifecycle import ARCHIVAL_VALUE_UNWORTHY
 from opengever.base.behaviors.lifecycle import ARCHIVAL_VALUE_WORTHY
 from opengever.base.command import CreateEmailCommand
@@ -1630,6 +1631,7 @@ class OpengeverContentFixture(object):
             .having(
                 start=date(2016, 1, 1),
                 responsible=self.dossier_responsible.getId(),
+                public_trial=PUBLIC_TRIAL_PRIVATE,
             )
         ))
 


### PR DESCRIPTION
In order to display the `public_trial` in a document listing, it must be allowed in the listing endpoint.

Jira: https://4teamwork.atlassian.net/browse/NE-147

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


## Checklist (if applicable)

_Only applicable should be left and checked._

- API change:
  - [x] Documentation is updated