### PR TITLE
Only expose translated title fields for active languages in schema and serialization via API.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 ----------------------
 
 - Add feature flag for todos. [tinagerber]
+- Only expose translated title fields for active languages in schema and serialization via API. [deiferni]
 - No longer zip-export empty tasks, prevent creation of empty folders in such cases. [deiferni]
 - Add sequence_type to task serializer. [tinagerber]
 - Fix only rendering allowed proposal templates when proposal add form is opened from documents tab. [deiferni]

--- a/docs/public/dev-manual/api/content_types.rst
+++ b/docs/public/dev-manual/api/content_types.rst
@@ -8,6 +8,18 @@ Inhaltstypen
    :backlinks: none
 
 
+Übersetzte Titel
+----------------
+
+Die Felder für übersetzte Titel der Inhalte sind der Vollständigkeit halber
+in der Dokumentation alle aufgeführt. Je nach konfigurierter Sprache auf den
+Systemen stehen sie aber nicht alle zur Verfügung. Betroffen davon sind die
+Felder ``title_de`` und ``title_fr``. Eine Abfrage auf den ``@schema`` Endpoint
+liefert die aktuell gültigen Schemas eines Deployments.
+Das Erstellen und Modifizieren von Inhalten mittels ``POST`` oder ``PATCH``
+erlaubt immer alle übersetzten Felder.
+
+
 Schemas
 -------
 

--- a/docs/public/dev-manual/api/schemas/opengever.repository.repositoryfolder.inc
+++ b/docs/public/dev-manual/api/schemas/opengever.repository.repositoryfolder.inc
@@ -137,7 +137,7 @@
    .. py:attribute:: title_de
 
        :Feldname: :field-title:`Titel (deutsch)`
-       :Datentyp: ``TextLine``
+       :Datentyp: ``TranslatedTextLine``
        
        
        
@@ -147,7 +147,7 @@
    .. py:attribute:: title_fr
 
        :Feldname: :field-title:`Titel (französisch)`
-       :Datentyp: ``TextLine``
+       :Datentyp: ``TranslatedTextLine``
        
        
        

--- a/docs/public/dev-manual/api/schemas/opengever.repository.repositoryroot.inc
+++ b/docs/public/dev-manual/api/schemas/opengever.repository.repositoryroot.inc
@@ -37,7 +37,7 @@
    .. py:attribute:: title_de
 
        :Feldname: :field-title:`Titel (deutsch)`
-       :Datentyp: ``TextLine``
+       :Datentyp: ``TranslatedTextLine``
        
        
        
@@ -47,7 +47,7 @@
    .. py:attribute:: title_fr
 
        :Feldname: :field-title:`Titel (französisch)`
-       :Datentyp: ``TextLine``
+       :Datentyp: ``TranslatedTextLine``
        
        
        

--- a/docs/public/dev-manual/api/schemas/opengever.workspace.root.inc
+++ b/docs/public/dev-manual/api/schemas/opengever.workspace.root.inc
@@ -7,7 +7,7 @@
    .. py:attribute:: title_de
 
        :Feldname: :field-title:`Titel (deutsch)`
-       :Datentyp: ``TextLine``
+       :Datentyp: ``TranslatedTextLine``
        
        
        
@@ -17,7 +17,7 @@
    .. py:attribute:: title_fr
 
        :Feldname: :field-title:`Titel (französisch)`
-       :Datentyp: ``TextLine``
+       :Datentyp: ``TranslatedTextLine``
        
        
        

--- a/docs/schema-dumps/opengever.repository.repositoryfolder.schema.json
+++ b/docs/schema-dumps/opengever.repository.repositoryfolder.schema.json
@@ -108,13 +108,13 @@
             "type": "string",
             "title": "Titel (deutsch)",
             "description": "",
-            "_zope_schema_type": "TextLine"
+            "_zope_schema_type": "TranslatedTextLine"
         },
         "title_fr": {
             "type": "string",
             "title": "Titel (franz\u00f6sisch)",
             "description": "",
-            "_zope_schema_type": "TextLine"
+            "_zope_schema_type": "TranslatedTextLine"
         },
         "retention_period": {
             "type": "integer",

--- a/docs/schema-dumps/opengever.repository.repositoryroot.schema.json
+++ b/docs/schema-dumps/opengever.repository.repositoryroot.schema.json
@@ -28,13 +28,13 @@
             "type": "string",
             "title": "Titel (deutsch)",
             "description": "",
-            "_zope_schema_type": "TextLine"
+            "_zope_schema_type": "TranslatedTextLine"
         },
         "title_fr": {
             "type": "string",
             "title": "Titel (franz\u00f6sisch)",
             "description": "",
-            "_zope_schema_type": "TextLine"
+            "_zope_schema_type": "TranslatedTextLine"
         }
     },
     "allOf": [

--- a/docs/schema-dumps/opengever.workspace.root.schema.json
+++ b/docs/schema-dumps/opengever.workspace.root.schema.json
@@ -8,13 +8,13 @@
             "type": "string",
             "title": "Titel (deutsch)",
             "description": "",
-            "_zope_schema_type": "TextLine"
+            "_zope_schema_type": "TranslatedTextLine"
         },
         "title_fr": {
             "type": "string",
             "title": "Titel (franz\u00f6sisch)",
             "description": "",
-            "_zope_schema_type": "TextLine"
+            "_zope_schema_type": "TranslatedTextLine"
         }
     },
     "allOf": [

--- a/opengever/api/serializer.py
+++ b/opengever/api/serializer.py
@@ -2,6 +2,7 @@ from ftw.bumblebee.interfaces import IBumblebeeable
 from ftw.bumblebee.interfaces import IBumblebeeDocument
 from Missing import Value as MissingValue
 from opengever.api.batch import SQLHypermediaBatch
+from opengever.base.behaviors.translated_title import get_inactive_languages
 from opengever.base.interfaces import IOpengeverBaseLayer
 from opengever.base.oguid import Oguid
 from opengever.base.response import IResponseContainer
@@ -86,6 +87,13 @@ def extend_with_groupurl(result, context, request):
         api.portal.get().absolute_url(), context.groupid)
 
 
+def drop_inactive_language_fields(result):
+    for lang in get_inactive_languages():
+        field_name = 'title_{}'.format(lang)
+        if field_name in result:
+            del result[field_name]
+
+
 @adapter(IDexterityContent, IOpengeverBaseLayer)
 class GeverSerializeToJson(SerializeToJson):
 
@@ -97,6 +105,7 @@ class GeverSerializeToJson(SerializeToJson):
         extend_with_relative_path(result, self.context)
         extend_with_responses(result, self.context, self.request)
 
+        drop_inactive_language_fields(result)
         return result
 
 
@@ -111,6 +120,7 @@ class GeverSerializeFolderToJson(SerializeFolderToJson):
         extend_with_responses(result, self.context, self.request)
         extend_with_is_subdossier(result, self.context, self.request)
 
+        drop_inactive_language_fields(result)
         return result
 
 

--- a/opengever/api/tests/test_contactfolder.py
+++ b/opengever/api/tests/test_contactfolder.py
@@ -17,7 +17,6 @@ class TestContactFolderGet(IntegrationTestCase):
                 u'id': u'kontakte',
                 u'relative_path': u'kontakte',
                 u'title_de': u'Kontakte',
-                u'title_fr': None,
             },
             browser.json
         )

--- a/opengever/api/tests/test_repository.py
+++ b/opengever/api/tests/test_repository.py
@@ -1,5 +1,6 @@
 from ftw.testbrowser import browsing
 from opengever.testing import IntegrationTestCase
+from plone import api
 from zope.component import getUtility
 from zope.intid.interfaces import IIntIds
 
@@ -8,6 +9,9 @@ class TestRepositoryAPI(IntegrationTestCase):
 
     @browsing
     def test_can_get_repository_root(self, browser):
+        language_tool = api.portal.get_tool('portal_languages')
+        language_tool.addSupportedLanguage('fr-ch')
+
         self.login(self.regular_user, browser=browser)
         browser.open(self.repository_root, method="GET", headers={"Accept": "application/json"})
         self.assertEqual(200, browser.status_code)

--- a/opengever/api/tests/test_schema.py
+++ b/opengever/api/tests/test_schema.py
@@ -1,5 +1,6 @@
 from ftw.testbrowser import browsing
 from opengever.testing import IntegrationTestCase
+from plone import api
 
 
 class TestSchemaEndpoint(IntegrationTestCase):
@@ -37,3 +38,87 @@ class TestSchemaEndpoint(IntegrationTestCase):
             expected_url,
             response['properties']['keywords']['items']['querysource']['@id']
             )
+
+    @browsing
+    def test_add_schema_only_contains_title_de_by_default(self, browser):
+        self.login(self.regular_user, browser)
+        response = browser.open(
+            self.leaf_repofolder, view='@schema/opengever.repository.repositoryfolder',
+            method='GET',
+            headers=self.api_headers,
+        ).json
+
+        self.assertIn('title_de', response['required'])
+        self.assertNotIn('title_fr', response['required'])
+        self.assertIn('title_de', response['properties'])
+        self.assertNotIn('title_fr', response['properties'])
+
+        fieldset = self._get_schema_fieldset(response, "plone")
+        self.assertIn('title_de', fieldset['fields'])
+        self.assertNotIn('title_fr', fieldset['fields'])
+
+    @browsing
+    def test_edit_schema_only_contains_title_de_by_default(self, browser):
+        self.login(self.regular_user, browser)
+        response = browser.open(
+            self.leaf_repofolder, view='@schema',
+            method='GET',
+            headers=self.api_headers,
+        ).json
+
+        self.assertIn('title_de', response['required'])
+        self.assertNotIn('title_fr', response['required'])
+        self.assertIn('title_de', response['properties'])
+        self.assertNotIn('title_fr', response['properties'])
+
+        fieldset = self._get_schema_fieldset(response, "plone")
+        self.assertIn('title_de', fieldset['fields'])
+        self.assertNotIn('title_fr', fieldset['fields'])
+
+    @browsing
+    def test_add_schema_also_contains_title_fr_when_lang_is_enabled(self, browser):
+        language_tool = api.portal.get_tool('portal_languages')
+        language_tool.addSupportedLanguage('fr-ch')
+
+        self.login(self.regular_user, browser)
+        response = browser.open(
+            self.leaf_repofolder, view='@schema/opengever.repository.repositoryfolder',
+            method='GET',
+            headers=self.api_headers,
+        ).json
+
+        self.assertIn('title_de', response['required'])
+        self.assertIn('title_fr', response['required'])
+        self.assertIn('title_de', response['properties'])
+        self.assertIn('title_fr', response['properties'])
+
+        fieldset = self._get_schema_fieldset(response, "plone")
+        self.assertIn('title_de', fieldset['fields'])
+        self.assertIn('title_fr', fieldset['fields'])
+
+    @browsing
+    def test_edit_schema_also_contains_title_fr_when_lang_is_enabled(self, browser):
+        language_tool = api.portal.get_tool('portal_languages')
+        language_tool.addSupportedLanguage('fr-ch')
+
+        self.login(self.regular_user, browser)
+        response = browser.open(
+            self.leaf_repofolder, view='@schema',
+            method='GET',
+            headers=self.api_headers,
+        ).json
+
+        self.assertIn('title_de', response['required'])
+        self.assertIn('title_fr', response['required'])
+        self.assertIn('title_de', response['properties'])
+        self.assertIn('title_fr', response['properties'])
+
+        fieldset = self._get_schema_fieldset(response, "plone")
+        self.assertIn('title_de', fieldset['fields'])
+        self.assertIn('title_fr', fieldset['fields'])
+
+    def _get_schema_fieldset(self, schema, name):
+        for item in schema['fieldsets']:
+            if item['behavior'] == name:
+                return item
+        return None

--- a/opengever/api/tests/test_translated_title.py
+++ b/opengever/api/tests/test_translated_title.py
@@ -1,0 +1,66 @@
+from ftw.testbrowser import browsing
+from opengever.testing import IntegrationTestCase
+from plone import api
+import json
+
+
+class TestTranslatedTitlePost(IntegrationTestCase):
+
+    @browsing
+    def test_can_post_translated_title_for_inactive_lang(self, browser):
+        language_tool = api.portal.get_tool('portal_languages')
+        self.assertEqual(['en', 'de-ch'], language_tool.getSupportedLanguages())
+
+        self.login(self.administrator, browser)
+        data = {
+            "@type": "opengever.repository.repositoryfolder",
+            "title_de": "Folder",
+            "title_fr": u"F\xf6lder",
+        }
+
+        with self.observe_children(self.repository_root) as children:
+            browser.open(self.repository_root, json.dumps(data),
+                         method="POST", headers=self.api_headers)
+
+        self.assertEqual(1, len(children['added']))
+        folder = children['added'].pop()
+        self.assertEqual(u'F\xf6lder', folder.title_fr)
+
+    @browsing
+    def test_title_in_all_enabled_languages_is_required(self, browser):
+        language_tool = api.portal.get_tool('portal_languages')
+        language_tool.addSupportedLanguage('fr-ch')
+
+        self.login(self.administrator, browser)
+        data = {
+            "@type": "opengever.repository.repositoryfolder",
+            "title_de": "Folder",
+        }
+
+        with browser.expect_http_error(code=400, reason='Bad Request'):
+            browser.open(self.repository_root, data=json.dumps(data),
+                         method='POST', headers=self.api_headers)
+
+        self.assertEqual(
+            u"[{'field': 'title_fr', "
+            "'message': u'Required input is missing.', "
+            "'error': 'ValidationError'}]",
+            browser.json['message'])
+
+
+class TestTranslatedTitlePatch(IntegrationTestCase):
+
+    @browsing
+    def test_can_patch_translated_title_for_inactive_lang(self, browser):
+        language_tool = api.portal.get_tool('portal_languages')
+        self.assertEqual(['en', 'de-ch'], language_tool.getSupportedLanguages())
+
+        self.login(self.administrator, browser)
+        data = {
+            "title_fr": u"F\xf6lder",
+        }
+
+        browser.open(self.empty_repofolder, json.dumps(data),
+                     method="PATCH", headers=self.api_headers)
+
+        self.assertEqual(u'F\xf6lder', self.empty_repofolder.title_fr)

--- a/opengever/base/behaviors/translated_title.py
+++ b/opengever/base/behaviors/translated_title.py
@@ -51,6 +51,21 @@ class TranslatedTitleMixin(object):
         return title or ''
 
 
+class TranslatedTextLine(TextLine):
+
+    @property
+    def required(self):
+        if not self._required:
+            return False
+
+        lang_code = self.getName().split('_')[-1]
+        return lang_code in get_active_languages()
+
+    @required.setter
+    def required(self, val):
+        self._required = val
+
+
 class ITranslatedTitle(model.Schema):
     """Behavior schema adding translated title fields to dexterity
     content.
@@ -70,7 +85,7 @@ class ITranslatedTitle(model.Schema):
     form.order_before(title_de='valid_from')
     form.order_before(title_de='description')
     searchable('title_de')
-    title_de = TextLine(
+    title_de = TranslatedTextLine(
         title=_(u'label_title_de', default=u'Title (German)'),
         required=True)
 
@@ -79,7 +94,7 @@ class ITranslatedTitle(model.Schema):
     form.order_before(title_fr='valid_from')
     form.order_before(title_fr='description')
     searchable('title_fr')
-    title_fr = TextLine(
+    title_fr = TranslatedTextLine(
         title=_(u'label_title_fr', default=u'Title (French)'),
         required=True)
 

--- a/opengever/base/behaviors/translated_title.py
+++ b/opengever/base/behaviors/translated_title.py
@@ -1,6 +1,7 @@
 from collective.dexteritytextindexer import searchable
 from opengever.base import _
 from opengever.base.utils import get_preferred_language_code
+from plone import api
 from plone.autoform import directives as form
 from plone.autoform.interfaces import IFormFieldProvider
 from plone.supermodel import model
@@ -10,6 +11,21 @@ from zope.schema import TextLine
 
 
 TRANSLATED_TITLE_NAMES = ('title_de', 'title_fr')
+
+
+def get_active_languages():
+    lang_tool = api.portal.get_tool('portal_languages')
+    return [lang.split('-')[0] for lang in lang_tool.supported_langs]
+
+
+def get_inactive_languages():
+    active_languages = get_active_languages()
+    inactive = []
+
+    for lang in TranslatedTitle.SUPPORTED_LANGUAGES:
+        if lang not in active_languages:
+            inactive.append(lang)
+    return inactive
 
 
 class ITranslatedTitleSupport(Interface):

--- a/opengever/base/behaviors/translated_title.py
+++ b/opengever/base/behaviors/translated_title.py
@@ -28,6 +28,13 @@ def get_inactive_languages():
     return inactive
 
 
+def has_translation_behavior(fti):
+    if not hasattr(fti, 'behaviors'):
+        return False
+
+    return ITranslatedTitle.__identifier__ in fti.behaviors
+
+
 class ITranslatedTitleSupport(Interface):
     """Mark objects with translated title support."""
 

--- a/opengever/base/browser/translated_title.py
+++ b/opengever/base/browser/translated_title.py
@@ -1,28 +1,22 @@
 from opengever.base import _
+from opengever.base.behaviors.translated_title import get_active_languages
+from opengever.base.behaviors.translated_title import get_inactive_languages
 from opengever.base.behaviors.translated_title import TranslatedTitle
-from plone import api
 from plone.dexterity.browser.add import DefaultAddForm
 from plone.dexterity.browser.edit import DefaultEditForm
 
 
 class TranslatedTitleFormMixin(object):
 
-    def get_active_languages(self):
-        """Returns a list of the current languages
-        """
-        lang_tool = api.portal.get_tool('portal_languages')
-        return [lang.split('-')[0] for lang in lang_tool.supported_langs]
-
     def get_title_fieldname(self, lang):
         return 'ITranslatedTitle.title_{}'.format(lang)
 
     def omit_non_active_language_fields(self):
         fields_to_remove = []
-        for lang in TranslatedTitle.SUPPORTED_LANGUAGES:
-            if lang not in self.get_active_languages():
-                fieldname = self.get_title_fieldname(lang)
-                self.fields = self.fields.omit(fieldname)
-                fields_to_remove.append(fieldname)
+        for lang in get_inactive_languages():
+            fieldname = self.get_title_fieldname(lang)
+            self.fields = self.fields.omit(fieldname)
+            fields_to_remove.append(fieldname)
 
         for group in self.groups:
             for fieldname in fields_to_remove:
@@ -35,7 +29,7 @@ class TranslatedTitleFormMixin(object):
         """
         supported_languages = set(TranslatedTitle.SUPPORTED_LANGUAGES)
         supported_active_languages = supported_languages.intersection(
-            set(self.get_active_languages()))
+            set(get_active_languages()))
 
         if len(supported_active_languages) == 1:
             fieldname = self.get_title_fieldname(
@@ -49,7 +43,7 @@ class TranslatedTitleFormMixin(object):
         """
         supported_languages = set(TranslatedTitle.SUPPORTED_LANGUAGES)
         supported_active_languages = supported_languages.intersection(
-            set(self.get_active_languages()))
+            set(get_active_languages()))
 
         if len(supported_active_languages) == 1:
             fieldname = self.get_title_fieldname(

--- a/opengever/base/monkey/patches/__init__.py
+++ b/opengever/base/monkey/patches/__init__.py
@@ -15,6 +15,7 @@ from .exception_formatter import PatchExceptionFormatter
 from .extendedpathindex import PatchExtendedPathIndex
 from .filter_trashed_from_catalog import PatchCatalogToFilterTrashedDocs
 from .history_handler_tool import PatchCMFEditonsHistoryHandlerTool
+from .jsonschema_for_portal_type import PatchGetJsonschemaForPortalType
 from .ldap_userfolder_encoding import PatchLDAPUserFolderEncoding
 from .namedfile_data_converter import PatchNamedfileNamedDataConverter
 from .paste_permission import PatchDXContainerPastePermission
@@ -72,6 +73,7 @@ PatchZ2LogTimezone()()
 PatchZ3CFormChangedField()()
 PatchZ3CFormWidgetUpdate()()
 ScrubBoboExceptions()()
+PatchGetJsonschemaForPortalType()()
 
 # These three patches implement role and permission filtering during RO mode.
 # We only apply these conditionally when RO mode actually is active.

--- a/opengever/base/monkey/patches/jsonschema_for_portal_type.py
+++ b/opengever/base/monkey/patches/jsonschema_for_portal_type.py
@@ -1,0 +1,42 @@
+from opengever.base.behaviors.translated_title import get_inactive_languages
+from opengever.base.behaviors.translated_title import has_translation_behavior
+from opengever.base.monkey.patching import MonkeyPatch
+from plone.restapi.types import utils
+from Products.CMFCore.utils import getToolByName
+
+
+class PatchGetJsonschemaForPortalType(MonkeyPatch):
+    def __call__(self):
+        original_get_jsonschema_for_portal_type = utils.get_jsonschema_for_portal_type
+
+        def get_jsonschema_for_portal_type(portal_type, context, request, excluded_fields=None):
+            excluded_fields = list(excluded_fields or [])
+
+            ttool = getToolByName(context, "portal_types")
+            fti = ttool[portal_type]
+
+            if has_translation_behavior(fti):
+                for lang in get_inactive_languages():
+                    fieldname = 'title_{}'.format(lang)
+                    excluded_fields.append(fieldname)
+
+            schema = original_get_jsonschema_for_portal_type(
+                portal_type, context, request, excluded_fields=excluded_fields)
+
+            # exclude only excludes from some parts. sanitize output before
+            # returning the schema.
+            for field in excluded_fields:
+                if schema.get('required') and field in schema['required']:
+                    schema['required'].remove(field)
+                for fieldset in schema.get('fieldsets', []):
+                    if field in fieldset.get('fields', []):
+                        fieldset['fields'].remove(field)
+
+            return schema
+
+        locals()['__patch_refs__'] = False
+
+        self.patch_refs(
+            utils, 'get_jsonschema_for_portal_type',
+            get_jsonschema_for_portal_type
+        )

--- a/opengever/base/schemadump/config.py
+++ b/opengever/base/schemadump/config.py
@@ -204,6 +204,8 @@ JSON_SCHEMA_FIELD_TYPES = {
     # Ugly, but need to wrap this because pycodestyle ignores noqa for E241
     'TextLine': {
         'type': 'string'},
+    'TranslatedTextLine': {
+        'type': 'string'},
     'Text': {
         'type': 'string'},
     'Tuple': {

--- a/opengever/base/tests/test_translated_title.py
+++ b/opengever/base/tests/test_translated_title.py
@@ -5,6 +5,8 @@ from ftw.builder import create
 from ftw.testbrowser import browsing
 from ftw.testbrowser.pages import factoriesmenu
 from ftw.testbrowser.pages import statusmessages
+from opengever.base.behaviors.translated_title import get_active_languages
+from opengever.base.behaviors.translated_title import get_inactive_languages
 from opengever.base.behaviors.translated_title import ITranslatedTitle
 from opengever.base.behaviors.translated_title import TRANSLATED_TITLE_NAMES
 from opengever.base.behaviors.translated_title import TranslatedTitle
@@ -14,6 +16,28 @@ from opengever.testing import obj2brain
 from opengever.testing import set_preferred_language
 from opengever.testing import TestCase
 from plone import api
+
+
+class TestTranslatedTitleActiveLanguages(IntegrationTestCase):
+
+    def test_get_active_languages_default(self):
+        self.assertEqual(['en', 'de'], get_active_languages())
+
+    def test_get_active_languages_all_supported_enabled(self):
+        language_tool = api.portal.get_tool('portal_languages')
+        language_tool.addSupportedLanguage('fr-ch')
+        self.assertEqual(['en', 'de', 'fr'], get_active_languages())
+
+
+class TestTranslatedTitleInactiveLanguages(IntegrationTestCase):
+
+    def test_get_active_languages_default(self):
+        self.assertEqual(['fr'], get_inactive_languages())
+
+    def test_get_active_languages_all_supported_enabled(self):
+        language_tool = api.portal.get_tool('portal_languages')
+        language_tool.addSupportedLanguage('fr-ch')
+        self.assertEqual([], get_inactive_languages())
 
 
 class TestTranslatedTitleIsOnTop(IntegrationTestCase):

--- a/opengever/base/tests/test_translated_title.py
+++ b/opengever/base/tests/test_translated_title.py
@@ -7,6 +7,7 @@ from ftw.testbrowser.pages import factoriesmenu
 from ftw.testbrowser.pages import statusmessages
 from opengever.base.behaviors.translated_title import get_active_languages
 from opengever.base.behaviors.translated_title import get_inactive_languages
+from opengever.base.behaviors.translated_title import has_translation_behavior
 from opengever.base.behaviors.translated_title import ITranslatedTitle
 from opengever.base.behaviors.translated_title import TRANSLATED_TITLE_NAMES
 from opengever.base.behaviors.translated_title import TranslatedTitle
@@ -38,6 +39,22 @@ class TestTranslatedTitleInactiveLanguages(IntegrationTestCase):
         language_tool = api.portal.get_tool('portal_languages')
         language_tool.addSupportedLanguage('fr-ch')
         self.assertEqual([], get_inactive_languages())
+
+
+class TestTranslatedTitleHasTranslationBehavior(IntegrationTestCase):
+
+    def test_has_translation_behavior(self):
+        ttool = api.portal.get_tool("portal_types")
+
+        self.assertFalse(has_translation_behavior(
+            ttool["Plone Site"]))
+        self.assertFalse(has_translation_behavior(
+            ttool["opengever.document.document"]))
+
+        self.assertTrue(has_translation_behavior(
+            ttool["opengever.repository.repositoryfolder"]))
+        self.assertTrue(has_translation_behavior(
+            ttool["opengever.contact.contactfolder"]))
 
 
 class TestTranslatedTitleIsOnTop(IntegrationTestCase):

--- a/opengever/bundle/schemas/repofolders.schema.json
+++ b/opengever/bundle/schemas/repofolders.schema.json
@@ -159,7 +159,7 @@
                     ],
                     "title": "Titel (deutsch)",
                     "description": "",
-                    "_zope_schema_type": "TextLine"
+                    "_zope_schema_type": "TranslatedTextLine"
                 },
                 "title_fr": {
                     "type": [
@@ -168,7 +168,7 @@
                     ],
                     "title": "Titel (franz\u00f6sisch)",
                     "description": "",
-                    "_zope_schema_type": "TextLine"
+                    "_zope_schema_type": "TranslatedTextLine"
                 },
                 "retention_period": {
                     "type": [

--- a/opengever/bundle/schemas/reporoots.schema.json
+++ b/opengever/bundle/schemas/reporoots.schema.json
@@ -46,7 +46,7 @@
                     ],
                     "title": "Titel (deutsch)",
                     "description": "",
-                    "_zope_schema_type": "TextLine"
+                    "_zope_schema_type": "TranslatedTextLine"
                 },
                 "title_fr": {
                     "type": [
@@ -55,7 +55,7 @@
                     ],
                     "title": "Titel (franz\u00f6sisch)",
                     "description": "",
-                    "_zope_schema_type": "TextLine"
+                    "_zope_schema_type": "TranslatedTextLine"
                 },
                 "review_state": {
                     "type": "string",

--- a/opengever/bundle/schemas/workspaceroots.schema.json
+++ b/opengever/bundle/schemas/workspaceroots.schema.json
@@ -17,7 +17,7 @@
                     ],
                     "title": "Titel (deutsch)",
                     "description": "",
-                    "_zope_schema_type": "TextLine"
+                    "_zope_schema_type": "TranslatedTextLine"
                 },
                 "title_fr": {
                     "type": [
@@ -26,7 +26,7 @@
                     ],
                     "title": "Titel (franz\u00f6sisch)",
                     "description": "",
-                    "_zope_schema_type": "TextLine"
+                    "_zope_schema_type": "TranslatedTextLine"
                 },
                 "review_state": {
                     "type": "string",


### PR DESCRIPTION
With this PR we change the API behavior with translated title fields to appear dynamically according to deployments currently active languages. The following changes are made:
- The fields `title_de` and `title_fr` will only appear in the `@schema` and `@types` endpoints if their corresponding lanugage has been set to active on the plone site.
- The fields `title_de` and `title_fr` will also only be serialized if their corresponding language is active.
- Deserialization (`POST`ing or `PATCH`ing via API) will be a bit more permissive and also accept inactive language fields.

I have attempted to implement the changes in a generic and, if possible, non-intrusive way.

Unfortunately schema serialization in `plone.restapi` [has been implemented in a function](https://github.com/plone/plone.restapi/blob/1fb8709402d0f33ac530dd8969f817bbb9aacb4c/src/plone/restapi/types/utils.py#L250-L256), so a monkey patch was necessary. I have implemented it in such a way that it performs inspection and checks for the `ITranslatedTitle` behavior on the FTI. That way it should automatically work for all translated types and is also active for our `@schema` endpoint and for the `@types` endpoint of `plone.restapi`.

Being permissive with deserialization has been guided by the following thoughts:
- The field/storage is always available in code, it is just hidden when serializing content and schema
- No harm is done when the field is set even if not displayed, on the contrary:
  - it might help to prepare a potential migration
  - if the UI (or another client) decides to send the data (for whatever reason) we will still be able to accept it and store it correctly
- It was less intrusive to implement than [overriding the whole `get_schema_data` method](https://github.com/plone/plone.restapi/blob/1fb8709402d0f33ac530dd8969f817bbb9aacb4c/src/plone/restapi/deserializer/dxcontent.py#L79-L154) in `plone.restapi`

Potential discussion points for the review:
- I've introduced a new field type `TranslatedTextLine` as a helper class, should this technical detail be hidden from the docs (let it appear as `TextLine` only)?
- Currently there will be no way to retrieve language fields for inactive languages via API. As an alternative we could also refrain from omitting it from serialization, but we might need to see how the new UI form implementation looks like to be certain here.


Jira: https://4teamwork.atlassian.net/browse/CA-1226

_This needs to be shipped together with corresponding UI changes in https://github.com/4teamwork/gever-ui/pull/1448._

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


## Checklist (if applicable)

_Only applicable should be left and checked._

- API change:
  - [x] Documentation is updated
  - If breaking:
    - [x] api-change label added
    - [x] #delivery channel notified about breaking change
    - [x] Scrum master is informed
