### PR TITLE
Fix keyword filter for keywords that contain spaces

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2020.16.0 (unreleased)
 ----------------------
 
+- Fix keyword filter for keywords that contain spaces. [tinagerber]
 - Add feature flag for todos. [tinagerber]
 - No longer zip-export empty tasks, prevent creation of empty folders in such cases. [deiferni]
 - Add sequence_type to task serializer. [tinagerber]

--- a/opengever/tabbedview/catalog_source.py
+++ b/opengever/tabbedview/catalog_source.py
@@ -152,8 +152,8 @@ class GeverCatalogTableSource(FilteredTableSourceMixin, CatalogTableSource):
                 range_ = value.get('range', None)
                 if query and isinstance(_query, (list, tuple)) and operator:
                     operator = ' {} '.format(operator.upper())
-                    filters.append(u'{}:({})'.format(
-                        key, escape(operator.join(_query))))
+                    filter_values = [u'"{}"'.format(escape(val)) for val in _query]
+                    filters.append(u'{}:({})'.format(key, operator.join(filter_values)))
                 elif range_ in ['min', 'max', 'minmax']:
                     if not isinstance(_query, (list, tuple)):
                         _query = [_query]

--- a/opengever/tabbedview/tests/test_dossier_listing.py
+++ b/opengever/tabbedview/tests/test_dossier_listing.py
@@ -275,3 +275,15 @@ class TestDossierListing(SolrIntegrationTestCase):
         self.open_repo_with_filter(
             browser, self.leaf_repofolder, 'filter_all', ['Wichtig'])
         self.assertEqual(1, len(browser.css('.listing tbody tr')))
+
+    @browsing
+    def test_filter_dossiers_by_subject_that_contains_a_space(self, browser):
+        self.login(self.regular_user, browser=browser)
+        self.open_repo_with_filter(browser, self.leaf_repofolder, 'filter_all')
+        self.assertLess(1, len(browser.css('.listing tbody tr')))
+        IDossier(self.dossier).keywords = ('Alpha Beta')
+        self.dossier.reindexObject()
+        self.commit_solr()
+        self.open_repo_with_filter(
+            browser, self.leaf_repofolder, 'filter_all', ['Alpha Beta'])
+        self.assertEqual(1, len(browser.css('.listing tbody tr')))


### PR DESCRIPTION
Until now, the keyword filter did not find dossiers when filtering for keywords containing spaces.
To filter for a keyword that consists of several words, the keyword must be enclosed in quotation marks.

Jira: https://4teamwork.atlassian.net/browse/NE-365

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)