### PR TITLE
Implement OGDS sync for local groups

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -15,6 +15,7 @@ Changelog
 - No longer zip-export empty tasks, prevent creation of empty folders in such cases. [deiferni]
 - Add sequence_type to task serializer. [tinagerber]
 - Fix only rendering allowed proposal templates when proposal add form is opened from documents tab. [deiferni]
+- Add OGDS sync for local groups. [buchi]
 
 
 2020.15.1 (2020-12-03)

--- a/opengever/ogds/base/__init__.py
+++ b/opengever/ogds/base/__init__.py
@@ -1,6 +1,7 @@
 from opengever.core.debughelpers import get_first_plone_site
 from opengever.core.debughelpers import setup_plone
 from opengever.ogds.base.sync.ogds_updater import sync_ogds
+from opengever.workspace import is_workspace_feature_enabled
 from zope.i18nmessageid import MessageFactory
 import logging
 import transaction
@@ -17,5 +18,5 @@ def sync_ogds_zopectl_handler(app, args):
     stream_handler.setLevel(logging.INFO)
 
     plone = setup_plone(get_first_plone_site(app))
-    sync_ogds(plone)
+    sync_ogds(plone, local_groups=is_workspace_feature_enabled())
     transaction.commit()

--- a/opengever/ogds/base/browser/configure.zcml
+++ b/opengever/ogds/base/browser/configure.zcml
@@ -41,6 +41,13 @@
 
   <browser:page
       for="Products.CMFPlone.interfaces.IPloneSiteRoot"
+      name="sync_local_groups"
+      class=".ldapcontrolpanel.LocalGroupSyncView"
+      permission="cmf.ManagePortal"
+      />
+
+  <browser:page
+      for="Products.CMFPlone.interfaces.IPloneSiteRoot"
       name="reset_syncstamp"
       class=".ldapcontrolpanel.ResetSyncStampView"
       permission="cmf.ManagePortal"

--- a/opengever/ogds/base/browser/ldapcontrolpanel.py
+++ b/opengever/ogds/base/browser/ldapcontrolpanel.py
@@ -69,6 +69,14 @@ class GroupSyncView(LDAPSyncView):
         self.run_update(users=False)
 
 
+class LocalGroupSyncView(LDAPSyncView):
+    """Browser view that starts a local group import.
+    """
+
+    def __call__(self):
+        self.run_update(users=False, groups=False, local_groups=True)
+
+
 class ResetSyncStampView(BrowserView):
     """A view that resets the current sync stamp with a new stamp
     on every client registered in the OGDS.

--- a/opengever/ogds/base/browser/templates/ldapcontrolpanel.pt
+++ b/opengever/ogds/base/browser/templates/ldapcontrolpanel.pt
@@ -21,12 +21,14 @@
                 <tr>
                     <td>User</td>
                     <td>Group</td>
+                    <td>Local Group</td>
                 <tr>
             </thead>
             <tbody>
                 <tr>
                     <td><a tal:attributes="href string:${portal_url}/@@sync_users" href="">Start import</a></td>
                     <td><a tal:attributes="href string:${portal_url}/@@sync_groups" href="">Start import</a></td>
+                    <td><a tal:attributes="href string:${portal_url}/@@sync_local_groups" href="">Start import</a></td>
                 <tr>
             </tbody>
         </table>


### PR DESCRIPTION
OGDS sync for local groups is needed for teamraum to reflect changes that can be done in various places (e.g. ZMI or import of groups) in OGDS.

By default sync of local groups is only enabled for installations with enabled workspace feature.
It can be executed on any site using the control panel.

JIRA: https://4teamwork.atlassian.net/browse/CA-1332


## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

