### PR TITLE
@assign-to-dossier endpoint deserializes combined values for the responsible

### DIFF
--- a/opengever/api/forwarding.py
+++ b/opengever/api/forwarding.py
@@ -1,3 +1,4 @@
+from opengever.api.task import deserialize_responsible
 from opengever.dossier.behaviors.dossier import IDossierMarker
 from plone import api
 from plone.protect.interfaces import IDisableCSRFProtection
@@ -25,6 +26,10 @@ class AssignToDossier(Service):
         transition_params = {'text': comment, 'dossier': IUUID(target)}
 
         if task_payload:
+            responsible = deserialize_responsible(task_payload.get('responsible'))
+            if responsible:
+                task_payload.update(responsible)
+
             transition_params['task'] = task_payload
 
         try:

--- a/opengever/api/tests/test_assign_to_dossier.py
+++ b/opengever/api/tests/test_assign_to_dossier.py
@@ -134,6 +134,35 @@ class TestAssignToDossier(IntegrationTestCase):
         self.assertEqual('2018-12-03', task.get('deadline'))
 
     @browsing
+    def test_combined_values_for_responsible_is_possible(self, browser):
+        self.login(self.secretariat_user, browser=browser)
+
+        task_payload = {
+            "@type": "opengever.task.task",
+            "title": u"Manual t\xf6sk",
+            "task_type": "correction",
+            "deadline": "2018-12-03",
+            "is_private": False,
+            'revoke_permissions': True,
+            "responsible": 'fa:{}'.format(self.regular_user.id),
+            "issuer": self.secretariat_user.id}
+
+        browser.open(
+            self.inbox_forwarding.absolute_url(),
+            view='@assign-to-dossier',
+            method='POST',
+            headers=self.api_headers,
+            data=json.dumps({
+                'target_uid': self.dossier.UID(),
+                'task': task_payload
+            }))
+
+        self.assertEqual(201, browser.status_code)
+        task = browser.json
+
+        self.assertEqual('fa:kathi.barfuss', task.get('responsible').get('token'))
+
+    @browsing
     def test_assign_to_dossier_validates_add_permission(self, browser):
         self.login(self.secretariat_user, browser=browser)
 


### PR DESCRIPTION
Creating a task requires a `responsible` and a `responsible_client`. From the vocabularies, we receive combined values for the responsible field like `fd:username`. Instead of separating this values in the frontend and sending it in separate attributes to the server, we deserialize combined values in the backend and separate it properly: https://github.com/4teamwork/opengever.core/blob/master/opengever/api/task.py#L105

The newly introduced endpoint `@assing-to-dossier` in https://github.com/4teamwork/opengever.core/pull/6767  does not implement this special deserialization of the responsible field.

This PR extends the endpoint to also provide combined values for task responsibles.

Jira: https://4teamwork.atlassian.net/browse/NE-73

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry (⚠️ not required because its a follow-up pr)
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


## Checklist (if applicable)

_Only applicable should be left and checked._

- API change:
  - [ ] Documentation is updated
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Upgrade steps (changes in profile):
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
- DB-Schema migration
  - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
  - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value
