### PR TITLE
Download checked out document also respect the init version 0

### DIFF
--- a/opengever/api/tests/test_actions.py
+++ b/opengever/api/tests/test_actions.py
@@ -7,6 +7,7 @@ from opengever.trash.trash import ITrashable
 from opengever.workspaceclient.interfaces import ILinkedWorkspaces
 from opengever.workspaceclient.tests import FunctionalWorkspaceClientTestCase
 from plone import api
+from plone.namedfile.file import NamedBlobFile
 from plone.protect import createToken
 import transaction
 
@@ -188,6 +189,34 @@ class TestFileActionsGetForDocuments(FileActionsTestBase):
         self.login(self.regular_user, browser)
 
         expected_file_actions = [
+            {u'id': u'open_as_pdf',
+             u'title': u'Open as PDF',
+             u'icon': u''},
+            {u'id': u'new_task_from_document',
+             u'title': u'New task from document',
+             u'icon': u''},
+            ]
+        self.assertEqual(expected_file_actions,
+                         self.get_file_actions(browser, self.document))
+
+    @browsing
+    def test_available_file_actions_if_document_checked_out_by_another_user_with_an_init_version(self, browser):
+        self.login(self.dossier_manager, browser)
+        self.checkout_document(self.document)
+
+        # The file setter of a document will automatically create an init version
+        self.document.file = NamedBlobFile(
+            data='TEST DATA', filename=self.document.file.filename)
+
+        self.login(self.regular_user, browser)
+
+        expected_file_actions = [
+            {u'id': u'download_copy',
+             u'title': u'Download copy',
+             u'icon': u''},
+            {u'id': u'attach_to_email',
+             u'title': u'Attach to email',
+             u'icon': u''},
             {u'id': u'open_as_pdf',
              u'title': u'Open as PDF',
              u'icon': u''},

--- a/opengever/document/browser/download.py
+++ b/opengever/document/browser/download.py
@@ -40,7 +40,7 @@ class DocumentishDownload(Download):
     def __call__(self):
         if self.is_checked_out_by_another_user():
             current_version_id = self.context.get_current_version_id()
-            if not current_version_id:
+            if current_version_id is None:
                 raise BadRequest('The document is checked out by another user '
                                  'and there is no current version to download.')
 

--- a/opengever/document/fileactions.py
+++ b/opengever/document/fileactions.py
@@ -205,7 +205,7 @@ class DocumentFileActions(BaseDocumentFileActions):
         manager = getMultiAdapter(
             (self.context, self.request), ICheckinCheckoutManager)
 
-        has_version = self.context.get_current_version_id(missing_as_zero=True) > 0
+        has_version = self.context.get_current_version_id() is not None
 
         return (
             super(DocumentFileActions, self).is_download_copy_action_available()
@@ -218,7 +218,8 @@ class DocumentFileActions(BaseDocumentFileActions):
         manager = getMultiAdapter(
             (self.context, self.request), ICheckinCheckoutManager)
 
-        has_version = self.context.get_current_version_id(missing_as_zero=True) > 0
+        has_version = self.context.get_current_version_id() is not None
+
         return (
             super(DocumentFileActions, self).is_attach_to_email_action_available()
             and not (manager.is_checked_out_by_another_user() and not has_version))


### PR DESCRIPTION
Jira: https://4teamwork.atlassian.net/browse/NE-49
This is a follow-up PR of https://github.com/4teamwork/opengever.core/pull/6755

I assumed, that the first version will be created as soon as the user is checking in a document the first time.

But that's not right. There is a file-setter on the document model which is creating an initial version 0 if the file-field is updated the first time. Means, if a user creates a new document, there will be no version at all. If the user checks out the document and saves it with some changes without checking it in, an initial version 0 will be created by the file-setter: https://github.com/4teamwork/opengever.core/blob/master/opengever/document/document.py#L263

I handled the version 0 like there is no version.

This PR updates the implementation of the base-PR to also respect the version 0 as a version. 

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry (ℹ️  not necessary because it's a follow-up PR within the same version)
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


## Checklist (if applicable)

_Only applicable should be left and checked._

- API change:
  - [ ] Documentation is updated
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Upgrade steps (changes in profile):
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
- DB-Schema migration
  - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
  - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value
