### PR TITLE
Fix type of file contentType on eCH0147 import

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -16,6 +16,7 @@ Changelog
 - Add sequence_type to task serializer. [tinagerber]
 - Fix only rendering allowed proposal templates when proposal add form is opened from documents tab. [deiferni]
 - Add OGDS sync for local groups. [buchi]
+- Fix type of file contentType on eCH0147 import. [buchi]
 
 
 2020.15.1 (2020-12-03)

--- a/opengever/ech0147/tests/test_import.py
+++ b/opengever/ech0147/tests/test_import.py
@@ -143,6 +143,9 @@ class TestImport(IntegrationTestCase):
                     if not field.required and value is not None:
                         self.assertEqual(field._type, type(value), 'Wrong type for value of field: {}'.format(name))
 
+            self.assertEqual(type(doc.file.contentType), str)
+            self.assertEqual(type(doc.file.filename), unicode)
+
     @browsing
     def test_import_toplevel_documents_in_repofolder_displays_error(self, browser):
         self.activate_feature('ech0147-import')

--- a/opengever/ech0147/utils.py
+++ b/opengever/ech0147/utils.py
@@ -114,7 +114,7 @@ def create_document(container, document, zipfile):
         filename = os.path.basename(file_.pathFileName)
         obj.file = file_field._type(
             data=zipfile.read(zipinfo),
-            contentType=file_.mimeType,
+            contentType=str(file_.mimeType),
             filename=filename)
 
     # Rename document


### PR DESCRIPTION
contentType was of type `pyxb.binding.datatypes.token` before, which is not JSON serializable.

https://sentry.4teamwork.ch/organizations/sentry/issues/65198/?project=17

I've not added an upgrade step to fix existing documents because it requires to check all documents which is costly and eCH0147 import is rarely used.

I've fixed the affected system with the following script:
```python
from pyxb.binding.datatypes import token
import transaction

site = app.digs
docs = site.portal_catalog.unrestrictedSearchResults(portal_type='opengever.document.document')

for doc in docs:
    obj = doc.getObject()
    if obj.file:
        if type(obj.file.contentType) == token:
            obj.file.contentType = str(obj.file.contentType)
            print "Fixed contenType for %s" % doc.getPath()

transaction.commit()
```

JIRA: https://4teamwork.atlassian.net/browse/CA-1338

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
