### PR TITLE
Add invitation_group_dn to teamraum policy template.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2020.16.0 (unreleased)
 ----------------------
 
+- Add invitation_group_dn to teamraum policy template. [njohner]
 - Allow downloading and sending a document checked out by another user. [elioschmutz]
 - Adding a subtask to a sequential task through the restapi respects the `position` parameter [elioschmutz]
 - Fix keyword filter for keywords that contain spaces. [tinagerber]

--- a/opengever/policytemplates/hooks.py
+++ b/opengever/policytemplates/hooks.py
@@ -42,6 +42,7 @@ IGNORED_QUESTIONS = {
         'deployment.workspace_administrators_group',
         'deployment.workspace_creators_group',
         'deployment.workspace_users_group',
+        'setup.invitation_group_dn',
         'base.apps_endpoint_url',
         'base.workspace_secret',
         'setup.enable_todo_feature'

--- a/opengever/policytemplates/policy_template/.mrbob.ini
+++ b/opengever/policytemplates/policy_template/.mrbob.ini
@@ -208,6 +208,9 @@ deployment.workspace_users_group.question = Workspace users group
 deployment.workspace_users_group.default = tr_users
 deployment.workspace_users_group.required = False
 
+setup.invitation_group_dn.question = Invitation Group DN
+setup.invitation_group_dn.required = True
+
 setup.geverui.question = Enable new GEVER UI
 setup.geverui.required = True
 setup.geverui.default = true

--- a/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/+adminunit.id+/profiles/default/registry.xml.bob
+++ b/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/+adminunit.id+/profiles/default/registry.xml.bob
@@ -131,6 +131,7 @@
 {{% if is_teamraum %}}
   <records interface="opengever.workspace.interfaces.IWorkspaceSettings">
     <value key="is_feature_enabled">True</value>
+    <value key="invitation_group_dn">{{{setup.invitation_group_dn}}}</value>
   </records>
 
 {{% if not setup.enable_todo_feature %}}


### PR DESCRIPTION
The `invitation_group_dn` was not part of the policy templates for teamraum deployments. It might be unnecessary for certain setups where the LDAP itself adds newly created users to the correct group (as in SG), but IMO, I'd rather have that in the template and delete it from the created policy when necessary. In general this needs to be set for invitations to work correctly.

For https://4teamwork.atlassian.net/browse/CA-12

## Checklist (Must have)
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)