### PR TITLE
Enable nightly jobs in policy templates.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2020.16.0 (unreleased)
 ----------------------
 
+- Enable nightly jobs in teamraum policy templates. [njohner]
 - Add invitation_group_dn to teamraum policy template. [njohner]
 - Allow downloading and sending a document checked out by another user. [elioschmutz]
 - Adding a subtask to a sequential task through the restapi respects the `position` parameter [elioschmutz]

--- a/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/+adminunit.id+/profiles/default/registry.xml.bob
+++ b/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/+adminunit.id+/profiles/default/registry.xml.bob
@@ -12,6 +12,11 @@
   <records interface="opengever.base.interfaces.ISearchSettings">
     <value key="use_solr">True</value>
   </records>
+
+  <records interface="opengever.nightlyjobs.interfaces.INightlyJobsSettings">
+    <value key="is_feature_enabled">True</value>
+  </records>
+
 {{% if not setup.enable_activity_feature %}}
   <record interface="opengever.activity.interfaces.IActivitySettings" field="is_feature_enabled">
     <field type="plone.registry.field.Bool" />


### PR DESCRIPTION
This is necessary for all deployments with the gever-ui activated, because of the `NightlyRoleAssignmentReports`. so basically all new deployments...

For https://4teamwork.atlassian.net/browse/CA-12

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)