### PR TITLE
Implement faceting for globalindex endpoint

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -19,6 +19,7 @@ Changelog
 - Fix only rendering allowed proposal templates when proposal add form is opened from documents tab. [deiferni]
 - Add OGDS sync for local groups. [buchi]
 - Fix type of file contentType on eCH0147 import. [buchi]
+- Implement faceting for OGDS based listings in general and for the globalindex endpoint in particular. [buchi]
 
 
 2020.15.1 (2020-12-03)

--- a/docs/public/dev-manual/api/globalindex.rst
+++ b/docs/public/dev-manual/api/globalindex.rst
@@ -19,6 +19,7 @@ Die Felder ``issuer_fullname`` und ``responsible_fullname`` sind überholt und d
 
     {
       "batching": null,
+      "facets": {},
       "items": [
         { "@id": "http://localhost:8080/ordnungssystem/dossier-23/document-123/task-1",
           "@type": "opengever.task.task",
@@ -75,6 +76,10 @@ Filter und Suche
 - ``search``: Filterung nach einem beliebigen Suchbegriff
 - ``filters``: Einschränkung nach einem bestimmten Wert eines Feldes
 
+Facetten
+~~~~~~~~
+- ``facets``: Liste von Feldern für die Facetten Wertebereiche zurückgegeben werden sollen.
+
 
 **Beispiel: Filtern nach erledigten und abgeschlossenen Aufgaben:**
 
@@ -95,4 +100,11 @@ Filter und Suche
   .. sourcecode:: http
 
     GET /@globalindex?search=vertrag HTTP/1.1
+    Accept: application/json
+
+**Beispiel: Wertebereiche des Auftragnehmers und des Aufgabenstatus liefern**
+
+  .. sourcecode:: http
+
+    GET /@globalindex?facets:list=review_state&facets:list=responsible HTTP/1.1
     Accept: application/json

--- a/opengever/api/globalindex.py
+++ b/opengever/api/globalindex.py
@@ -1,13 +1,33 @@
 from opengever.api.ogdslistingbase import OGDSListingBaseService
 from opengever.api.solr_query_service import DEFAULT_SORT_INDEX
+from opengever.base.helpers import display_name
+from opengever.globalindex.browser.report import task_type_helper
 from opengever.globalindex.model.task import Task
 from plone.restapi.interfaces import ISerializeToJson
+from zope.globalrequest import getRequest
+from zope.i18n import translate
+
+
+def translate_review_state(review_state):
+    return translate(review_state, domain='plone', context=getRequest())
 
 
 class GlobalIndexGet(OGDSListingBaseService):
 
     searchable_columns = [Task.title, Task.text,
                           Task.sequence_number, Task.responsible]
+    facet_columns = (
+        Task.issuer,
+        Task.responsible,
+        Task.review_state,
+        Task.task_type,
+    )
+    facet_label_transforms = {
+        'issuer': display_name,
+        'responsible': display_name,
+        'review_state': translate_review_state,
+        'task_type': task_type_helper,
+    }
 
     default_sort_on = DEFAULT_SORT_INDEX
     default_sort_order = 'descending'

--- a/opengever/api/globalindex.py
+++ b/opengever/api/globalindex.py
@@ -36,10 +36,12 @@ class GlobalIndexGet(OGDSListingBaseService):
 
     def extend_query_with_filters(self, query, filters):
         for key, value in filters.items():
-            if isinstance(value, list):
-                query = query.filter(getattr(Task, key).in_(value))
+            if not isinstance(value, list):
+                value = [value]
+            if key.startswith('-'):
+                query = query.filter(getattr(Task, key[1:]).notin_(value))
             else:
-                query = query.filter(getattr(Task, key) == value)
+                query = query.filter(getattr(Task, key).in_(value))
         return query
 
     def get_base_query(self):

--- a/opengever/api/ogdslistingbase.py
+++ b/opengever/api/ogdslistingbase.py
@@ -126,12 +126,15 @@ class OGDSListingBaseService(Service):
 
     def facets(self, search, filters):
         session = create_session()
+        base_filter = self.get_base_query().whereclause
         requested_facets = self.request.form.get('facets', [])
         facets = {}
         for col in self.facet_columns:
             if col.name not in requested_facets:
                 continue
             query = session.query(col, func.count(self.unique_sort_on)).group_by(col)
+            if base_filter is not None:
+                query = query.filter(base_filter)
             query = self.extend_query_with_search(query, search)
             query = self.extend_query_with_filters(query, filters)
 

--- a/opengever/api/ogdslistingbase.py
+++ b/opengever/api/ogdslistingbase.py
@@ -9,6 +9,7 @@ from sqlalchemy import or_
 from sqlalchemy.sql.expression import asc
 from sqlalchemy.sql.expression import column
 from sqlalchemy.sql.expression import desc
+from sqlalchemy import func
 from zope.component import queryMultiAdapter
 from ZPublisher.HTTPRequest import record
 
@@ -23,6 +24,8 @@ class OGDSListingBaseService(Service):
     """
 
     searchable_columns = tuple()
+    facet_columns = tuple()
+    facet_label_transforms = {}
     # unique_sort_on should be set in all subclasses to a unique key to make
     # sure that results are always sorted, otherwise sorting can be undefined.
     # As a separate query is made for every batch and for every item, undefined
@@ -61,6 +64,7 @@ class OGDSListingBaseService(Service):
             result['batching'] = batch.links
         result['b_start'] = batch.b_start
         result['b_size'] = batch.b_size
+        result['facets'] = self.facets(search, filters)
         return result
 
     def extract_params(self):
@@ -119,3 +123,26 @@ class OGDSListingBaseService(Service):
 
     def extend_query_with_filters(self, query, filters):
         return query
+
+    def facets(self, search, filters):
+        session = create_session()
+        requested_facets = self.request.form.get('facets', [])
+        facets = {}
+        for col in self.facet_columns:
+            if col.name not in requested_facets:
+                continue
+            query = session.query(col, func.count(self.unique_sort_on)).group_by(col)
+            query = self.extend_query_with_search(query, search)
+            query = self.extend_query_with_filters(query, filters)
+
+            facets[col.name] = {}
+            transform = self.facet_label_transforms.get(col.name, lambda x: x)
+            for facet_info in query.all():
+                if not facet_info[0]:
+                    continue
+                facets[col.name][facet_info[0]] = {
+                    'count': facet_info[1],
+                    'label': transform(facet_info[0]),
+                }
+
+        return facets

--- a/opengever/api/tests/test_globalindex.py
+++ b/opengever/api/tests/test_globalindex.py
@@ -147,6 +147,28 @@ class TestGlobalIndexGet(IntegrationTestCase):
         self.assertEqual(3, len(browser.json['items']))
 
     @browsing
+    def test_filter_by_date(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        view = '@globalindex?filters.deadline:record=2020-01-01 TO 2020-12-31'
+        browser.open(self.portal, view=view, headers=self.api_headers)
+
+        self.assertEqual(2, browser.json['items_total'])
+        self.assertEqual(2, len(browser.json['items']))
+
+        view = '@globalindex?filters.deadline:record=* TO 2019-01-01'
+        browser.open(self.portal, view=view, headers=self.api_headers)
+
+        self.assertEqual(12, browser.json['items_total'])
+        self.assertEqual(12, len(browser.json['items']))
+
+        view = '@globalindex?filters.deadline:record=2018-01-01 TO *'
+        browser.open(self.portal, view=view, headers=self.api_headers)
+
+        self.assertEqual(2, browser.json['items_total'])
+        self.assertEqual(2, len(browser.json['items']))
+
+    @browsing
     def test_handles_search_queries(self, browser):
         self.login(self.regular_user, browser=browser)
 

--- a/opengever/api/tests/test_globalindex.py
+++ b/opengever/api/tests/test_globalindex.py
@@ -187,3 +187,75 @@ class TestGlobalIndexGet(IntegrationTestCase):
         self.assertEqual(items[0]['@type'], u'opengever.task.task')
         self.assertEqual(items[1]['@type'], u'opengever.inbox.forwarding')
 
+    @browsing
+    def test_returns_requested_facets(self, browser):
+        self.login(self.regular_user, browser=browser)
+        view = (
+            '@globalindex?'
+            'facets:list=review_state&'
+            'facets:list=task_type&'
+            'facets:list=responsible'
+        )
+        headers = self.api_headers.copy()
+        headers.update({'Accept-Language': 'de'})
+        browser.open(self.portal, view=view, headers=headers)
+
+        self.assertEqual(
+            browser.json['facets'],
+            {
+                u'responsible': {
+                    u'inbox:fa': {
+                        u'count': 1,
+                        u'label': u'Eingangskorb: Finanz\xe4mt',
+                    },
+                    u'kathi.barfuss': {
+                        u'count': 12,
+                        u'label': u'B\xe4rfuss K\xe4thi',
+                    },
+                    u'robert.ziegler': {
+                        u'count': 2,
+                        u'label': u'Ziegler Robert',
+                    },
+                },
+                u'review_state': {
+                    u'forwarding-state-open': {
+                        u'count': 1,
+                        u'label': u'Offen',
+                    },
+                    u'task-state-in-progress': {
+                        u'count': 7,
+                        u'label': u'In Arbeit',
+                    },
+                    u'task-state-open': {
+                        u'count': 2,
+                        u'label': u'Offen',
+                    },
+                    u'task-state-planned': {
+                        u'count': 2,
+                        u'label': u'Geplant',
+                    },
+                    u'task-state-resolved': {
+                        u'count': 3,
+                        u'label': u'Erledigt',
+                    },
+                },
+                u'task_type': {
+                    u'correction': {
+                        u'count': 5,
+                        u'label': u'Zur Pr\xfcfung / Korrektur',
+                    },
+                    u'direct-execution': {
+                        u'count': 7,
+                        u'label': u'Zur direkten Erledigung',
+                    },
+                    u'forwarding_task_type': {
+                        u'count': 1,
+                        u'label': u'Weiterleitung',
+                    },
+                    u'information': {
+                        u'count': 1,
+                        u'label': u'Zur Kenntnisnahme',
+                    },
+                },
+            },
+        )

--- a/opengever/api/tests/test_globalindex.py
+++ b/opengever/api/tests/test_globalindex.py
@@ -131,6 +131,22 @@ class TestGlobalIndexGet(IntegrationTestCase):
         self.assertEqual(9, len(browser.json['items']))
 
     @browsing
+    def test_filter_by_excluding_value(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        view = '@globalindex?filters.-responsible:record={}'.format(
+            self.regular_user.id)
+        browser.open(self.portal, view=view, headers=self.api_headers)
+
+        self.assertNotIn(
+            self.regular_user.id,
+            [item['responsible'] for item in browser.json['items']],
+        )
+
+        self.assertEqual(3, browser.json['items_total'])
+        self.assertEqual(3, len(browser.json['items']))
+
+    @browsing
     def test_handles_search_queries(self, browser):
         self.login(self.regular_user, browser=browser)
 


### PR DESCRIPTION
This provides faceting for OGDS based listings in the same way as Solr based listings do.

Facets can be requested on the `@globalindex` endpoint for a predefined set of columns (issuer, responsible, review_state, task_type).

Required for filtering pending task: https://github.com/4teamwork/gever-ui/pull/1469

Jira: https://4teamwork.atlassian.net/browse/CA-1200

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


## Checklist (if applicable)

_Only applicable should be left and checked._

- API change:
  - [x] Documentation is updated

