### PR TITLE
Add lock expansion, override unlock endpoint and add unlock file action

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 
 - Add invitation_group_dn to teamraum policy template. [njohner]
 - Actions for document templates are properly configured. [elioschmutz]
+- Add @lock expansion. [tinagerber]
 - Allow downloading and sending a document checked out by another user. [elioschmutz]
 - Adding a subtask to a sequential task through the restapi respects the `position` parameter [elioschmutz]
 - Fix keyword filter for keywords that contain spaces. [tinagerber]

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 
 - Add invitation_group_dn to teamraum policy template. [njohner]
 - Actions for document templates are properly configured. [elioschmutz]
+- Add unlock file action. [tinagerber]
 - Allow removal of copied_to_workspace locks via the @unlock API endpoint by users other than the creator. [tinagerber]
 - Add @lock expansion. [tinagerber]
 - Allow downloading and sending a document checked out by another user. [elioschmutz]

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 
 - Add invitation_group_dn to teamraum policy template. [njohner]
 - Actions for document templates are properly configured. [elioschmutz]
+- Allow removal of copied_to_workspace locks via the @unlock API endpoint by users other than the creator. [tinagerber]
 - Add @lock expansion. [tinagerber]
 - Allow downloading and sending a document checked out by another user. [elioschmutz]
 - Adding a subtask to a sequential task through the restapi respects the `position` parameter [elioschmutz]

--- a/docs/public/dev-manual/api/documents.rst
+++ b/docs/public/dev-manual/api/documents.rst
@@ -144,13 +144,17 @@ Lock erstellen mit eigenem Timeout
 Lock entfernen
 ~~~~~~~~~~~~~~
 
-Ein bestehendes Lock kann mittels ``@unlock`` Endpoint entfernt werden.
+Ein bestehendes Lock kann mittels ``@unlock`` Endpoint entfernt werden. Der ``lock_type`` Parameter erlaubt es, den Lock-Typ anzugegeben, der entfernt werden soll. Wenn ``lock_type`` nicht angegeben wird, wird ein Lock vom Typ ``plone.locking.stealable`` entfernt.
 
 
   .. sourcecode:: http
 
     POST /ordnungssystem/dossier-23/document-123/@unlock HTTP/1.1
     Accept: application/json
+
+    {
+        "lock_type": "document.copied_to_workspace.lock"
+    }
 
   .. sourcecode:: http
 

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -1156,4 +1156,9 @@
       permission="zope2.View"
       />
 
+  <adapter
+      factory=".lock.Lock"
+      name="lock"
+      />
+
 </configure>

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -1161,4 +1161,13 @@
       name="lock"
       />
 
+  <plone:service
+      method="POST"
+      name="@unlock"
+      for="Products.CMFCore.interfaces.IContentish"
+      factory=".lock.Unlock"
+      permission="cmf.ModifyPortalContent"
+      layer="opengever.base.interfaces.IOpengeverBaseLayer"
+      />
+
 </configure>

--- a/opengever/api/lock.py
+++ b/opengever/api/lock.py
@@ -1,0 +1,24 @@
+from opengever.base.interfaces import IOpengeverBaseLayer
+from plone.restapi.interfaces import IExpandableElement
+from plone.restapi.services.locking.locking import lock_info
+from zope.component import adapter
+from zope.interface import implementer
+from zope.interface import Interface
+
+
+@implementer(IExpandableElement)
+@adapter(Interface, IOpengeverBaseLayer)
+class Lock(object):
+    def __init__(self, context, request):
+        self.context = context
+        self.request = request
+
+    def __call__(self, expand=False):
+        result = {
+            'lock': {
+                '@id': '/'.join((self.context.absolute_url(), '@lock')),
+            },
+        }
+        if expand:
+            result['lock'].update(lock_info(self.context) or {})
+        return result

--- a/opengever/api/lock.py
+++ b/opengever/api/lock.py
@@ -1,9 +1,15 @@
 from opengever.base.interfaces import IOpengeverBaseLayer
+from plone.locking.interfaces import ILockable
+from plone.locking.interfaces import INonStealableLock
+from plone.protect.interfaces import IDisableCSRFProtection
 from plone.restapi.interfaces import IExpandableElement
+from plone.restapi.services import Service
 from plone.restapi.services.locking.locking import lock_info
 from zope.component import adapter
+from zope.interface import alsoProvides
 from zope.interface import implementer
 from zope.interface import Interface
+from zope.interface import noLongerProvides
 
 
 @implementer(IExpandableElement)
@@ -22,3 +28,20 @@ class Lock(object):
         if expand:
             result['lock'].update(lock_info(self.context) or {})
         return result
+
+
+class Unlock(Service):
+    """Unlock an object"""
+
+    def reply(self):
+        lockable = ILockable(self.context)
+        if lockable.can_safely_unlock():
+            lockable.unlock()
+
+            if INonStealableLock.providedBy(self.context):
+                noLongerProvides(self.context, INonStealableLock)
+
+            # Disable CSRF protection
+            alsoProvides(self.request, IDisableCSRFProtection)
+
+        return lock_info(self.context)

--- a/opengever/api/tests/test_lock.py
+++ b/opengever/api/tests/test_lock.py
@@ -1,0 +1,16 @@
+from ftw.testbrowser import browsing
+from opengever.testing import IntegrationTestCase
+
+
+class TestLock(IntegrationTestCase):
+
+    @browsing
+    def test_lock_is_expandable(self, browser):
+        self.login(self.regular_user, browser)
+        browser.open(self.document.absolute_url() + '?expand=lock',
+                     method='GET', headers=self.api_headers)
+        self.assertEqual({
+            u'stealable': True, u'locked': False,
+            u'@id': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/'
+                    u'dossier-1/document-14/@lock'
+        }, browser.json['@components']['lock'])

--- a/opengever/api/tests/test_lock.py
+++ b/opengever/api/tests/test_lock.py
@@ -1,5 +1,9 @@
 from ftw.testbrowser import browsing
+from opengever.locking.lock import COPIED_TO_WORKSPACE_LOCK
+from opengever.locking.lock import LOCK_TYPE_COPIED_TO_WORKSPACE_LOCK
 from opengever.testing import IntegrationTestCase
+from plone.locking.interfaces import ILockable
+import json
 
 
 class TestLock(IntegrationTestCase):
@@ -14,3 +18,78 @@ class TestLock(IntegrationTestCase):
             u'@id': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/'
                     u'dossier-1/document-14/@lock'
         }, browser.json['@components']['lock'])
+
+
+class TestUnlock(IntegrationTestCase):
+
+    @browsing
+    def test_unlock_without_unlock_type(self, browser):
+        self.login(self.regular_user, browser)
+        ILockable(self.document).lock()
+        self.assertTrue(ILockable(self.document).locked())
+
+        browser.open(self.document, view='/@unlock', method='POST', headers=self.api_headers)
+
+        self.assertFalse(ILockable(self.document).locked())
+        self.assertEqual(200, browser.status_code)
+        self.assertEqual({u'stealable': True, u'locked': False}, browser.json)
+
+    @browsing
+    def test_unlock_not_locked_document_does_not_raise_an_error(self, browser):
+        self.login(self.regular_user, browser)
+
+        browser.open(self.document, view='/@unlock', method='POST', headers=self.api_headers)
+        self.assertEqual(200, browser.status_code)
+        self.assertEqual({u'stealable': True, u'locked': False}, browser.json)
+
+    @browsing
+    def test_unlock_with_invalid_lock_type_does_not_raise_an_error(self, browser):
+        self.login(self.regular_user, browser)
+        ILockable(self.document).lock(COPIED_TO_WORKSPACE_LOCK)
+        browser.open(self.document, view='/@unlock',
+                     method='POST',
+                     headers=self.api_headers,
+                     data=json.dumps({"lock_type": "invalid"}))
+        self.assertEqual(200, browser.status_code)
+        self.assertTrue(browser.json['locked'])
+
+    @browsing
+    def test_user_cannot_remove_lock_of_another_user(self, browser):
+        self.login(self.dossier_responsible, browser)
+        ILockable(self.document).lock()
+
+        self.login(self.regular_user, browser)
+        browser.open(self.document, view='/@unlock',
+                     method='POST', headers=self.api_headers)
+
+        self.assertTrue(ILockable(self.document).locked())
+        self.assertEqual(200, browser.status_code)
+        self.assertTrue(browser.json['locked'])
+        self.assertEqual(self.dossier_responsible.getId(), browser.json['creator'])
+
+    @browsing
+    def test_user_can_remove_workspace_lock_of_another_user(self, browser):
+        self.login(self.dossier_responsible, browser)
+        ILockable(self.document).lock(COPIED_TO_WORKSPACE_LOCK)
+        self.assertTrue(ILockable(self.document).locked())
+
+        self.login(self.regular_user, browser)
+        browser.open(self.document, view='/@unlock',
+                     method='POST', headers=self.api_headers,
+                     data=json.dumps({"lock_type": LOCK_TYPE_COPIED_TO_WORKSPACE_LOCK}))
+        self.assertFalse(ILockable(self.document).locked())
+        self.assertEqual(200, browser.status_code)
+        self.assertEqual({u'stealable': True, u'locked': False}, browser.json)
+
+    @browsing
+    def test_manager_can_remove_lock_of_another_user(self, browser):
+        self.login(self.dossier_responsible, browser)
+        ILockable(self.document).lock()
+
+        self.login(self.manager, browser)
+        browser.open(self.document, view='/@unlock',
+                     method='POST', headers=self.api_headers)
+
+        self.assertFalse(ILockable(self.document).locked())
+        self.assertEqual(200, browser.status_code)
+        self.assertEqual({u'stealable': True, u'locked': False}, browser.json)

--- a/opengever/api/tests/test_repository.py
+++ b/opengever/api/tests/test_repository.py
@@ -22,6 +22,7 @@ class TestRepositoryAPI(IntegrationTestCase):
                 u'actions': {u'@id': u'http://nohost/plone/ordnungssystem/@actions'},
                 u'breadcrumbs': {u'@id': u'http://nohost/plone/ordnungssystem/@breadcrumbs'},
                 u'listing-stats': {u'@id': u'http://nohost/plone/ordnungssystem/@listing-stats'},
+                u'lock': {u'@id': 'http://nohost/plone/ordnungssystem/@lock'},
                 u'main-dossier': None,
                 u'navigation': {u'@id': u'http://nohost/plone/ordnungssystem/@navigation'},
                 u'types': {u'@id': u'http://nohost/plone/ordnungssystem/@types'},

--- a/opengever/core/profiles/default/actions.xml
+++ b/opengever/core/profiles/default/actions.xml
@@ -174,6 +174,15 @@
       <property name="visible">True</property>
     </object>
 
+    <object name="unlock" meta_type="CMF Action" i18n:domain="opengever.document">
+      <property name="title" i18n:translate="label_unlock">Unlock</property>
+      <property name="available_expr">object/@@file_actions_availability/is_unlock_available</property>
+      <property name="permissions">
+        <element value="Modify portal content" />
+      </property>
+      <property name="visible">True</property>
+    </object>
+
   </object>
 
   <!-- SITE ACTIONS -->

--- a/opengever/core/upgrades/20201214150706_add_unlock_action/actions.xml
+++ b/opengever/core/upgrades/20201214150706_add_unlock_action/actions.xml
@@ -1,0 +1,13 @@
+<object xmlns:i18n="http://xml.zope.org/namespaces/i18n" name="portal_actions" meta_type="Plone Actions Tool">
+  <!-- FILE ACTIONS used to list available actions through the actions endpoint-->
+  <object name="file_actions" meta_type="CMF Action Category">
+    <object name="unlock" meta_type="CMF Action" i18n:domain="opengever.document">
+      <property name="title" i18n:translate="label_unlock">Unlock</property>
+      <property name="available_expr">object/@@file_actions_availability/is_unlock_available</property>
+      <property name="permissions">
+        <element value="Modify portal content" />
+      </property>
+      <property name="visible">True</property>
+    </object>
+  </object>
+</object>

--- a/opengever/core/upgrades/20201214150706_add_unlock_action/upgrade.py
+++ b/opengever/core/upgrades/20201214150706_add_unlock_action/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddUnlockAction(UpgradeStep):
+    """Add unlock action.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/document/interfaces.py
+++ b/opengever/document/interfaces.py
@@ -205,3 +205,6 @@ class IFileActions(Interface):
 
     def is_new_task_from_document_available():
         """Return whether the new_task_from_document action is available."""
+
+    def is_unlock_available():
+        """Return whether the unlock action is available."""

--- a/opengever/locking/tests/test_locks.py
+++ b/opengever/locking/tests/test_locks.py
@@ -184,8 +184,12 @@ class TestDocumentsLockedWithMeetingSubmittedLock(IntegrationTestCase, MoveItems
         browser.open(self.document.absolute_url() + '/@actions',
                      method='GET', headers=self.api_headers)
 
-        expected_file_actions.remove(u'oc_direct_checkout')
-        expected_file_actions.remove(u'trash_document')
+        expected_file_actions = [
+            u'download_copy',
+            u'attach_to_email',
+            u'new_task_from_document',
+            u'unlock']
+
         self.assertEqual(
             expected_file_actions,
             [action.get('id') for action in browser.json['file_actions']])


### PR DESCRIPTION
Since it was only possible to remove a `STEALABLE LOCK` as creator with the @unlock endpoint until now, the endpoint had to be overwritten. Now a `lock_type` can be specified to determine which lock should be removed. Furthermore all users can remove the `copied_to_workspace` lock, not only the creator.

Furthermore, a lock expansion was added, so that it can be determined in the frontend with which `lock_type` an object is locked, in order to be able to remove this lock afterwards.

Additionally, an `unlock` file action was added to decide when a user can unlock a document.

Refined with @njohner 

Jira: https://4teamwork.atlassian.net/browse/NE-340


## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


## Checklist (if applicable)

_Only applicable should be left and checked._

- API change:
  - [x] Documentation is updated