### PR TITLE
Do not allow to group on Subject column.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 ----------------------
 
 - Fix unicode error in meeting overview. [njohner]
+- Disable grouping on Subject column. [njohner]
 - Add invitation_group_dn to teamraum policy template. [njohner]
 - Actions for document templates are properly configured. [elioschmutz]
 - Add unlock file action. [tinagerber]

--- a/opengever/tabbedview/browser/tabs.py
+++ b/opengever/tabbedview/browser/tabs.py
@@ -196,7 +196,8 @@ class Documents(BaseCatalogListingTab):
         {'column': 'Subject',
          'column_title': _(u'label_keywords', default=u'Keywords'),
          'transform': linked_subjects,
-         'sortable': False},
+         'sortable': False,
+         'groupable': False},
         )
 
     major_actions = [
@@ -298,7 +299,8 @@ class Dossiers(BaseCatalogListingTab):
         {'column': 'Subject',
          'column_title': _(u'label_keywords', default=u'Keywords'),
          'transform': linked_subjects,
-         'sortable': False},
+         'sortable': False,
+         'groupable': False},
         )
 
     search_options = {'is_subdossier': False}


### PR DESCRIPTION
The subject column is not sortable because its values are unordered lists of keywords. As it is not sortable, grouping cannot function correctly either. Currently grouping actually led to an Error, but it anyway does not make sense to allow it.

I did not add a test as this is just a configuration of the table.

For https://4teamwork.atlassian.net/browse/CA-1348 and https://4teamwork.atlassian.net/browse/CA-1349


## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
