### PR TITLE
Setup placeful workflow for workspace root in default content

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -23,6 +23,7 @@ Changelog
 - Add OGDS sync for local groups. [buchi]
 - Fix type of file contentType on eCH0147 import. [buchi]
 - Implement faceting for OGDS based listings in general and for the globalindex endpoint in particular. [buchi]
+- Setup placeful workflow for workspace root in default content. [buchi]
 
 
 2020.15.1 (2020-12-03)

--- a/opengever/examplecontent/profiles/default_content/content_creation/01_default_content.json
+++ b/opengever/examplecontent/profiles/default_content/content_creation/01_default_content.json
@@ -37,6 +37,8 @@
         "_path": "workspaces",
         "_type": "opengever.workspace.root",
         "title_de": "Teamräume",
-        "title_fr": "Espace partagé"
+        "title_fr": "Espace partagé",
+        "_placefulworkflow": ["opengever_workspace_policy",
+                              "opengever_workspace_policy"]
     }
 ]

--- a/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/+adminunit.id+/profiles/workspaces_content/opengever_content/01-initial-structure.json
+++ b/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/+adminunit.id+/profiles/workspaces_content/opengever_content/01-initial-structure.json
@@ -3,6 +3,8 @@
         "_path": "workspaces",
         "_type": "opengever.workspace.root",
         "title_de": "Teamräume",
-        "title_fr": "Espaces partagés"
+        "title_fr": "Espaces partagés",
+        "_placefulworkflow": ["opengever_workspace_policy",
+                              "opengever_workspace_policy"]
     }
 ]

--- a/opengever/setup/profiles/default_content/content_creation/01_default_content.json
+++ b/opengever/setup/profiles/default_content/content_creation/01_default_content.json
@@ -33,6 +33,8 @@
         "_path": "workspaces",
         "_type": "opengever.workspace.root",
         "title_de": "Teamräume",
-        "title_fr": "Espace partagé"
+        "title_fr": "Espace partagé",
+        "_placefulworkflow": ["opengever_workspace_policy",
+                              "opengever_workspace_policy"]
     }
 ]


### PR DESCRIPTION
The workspace root must have the `opengever_workspace_policy` placeful workflow policy .
There's an upgrade step that enables it for existing installations, but currently it's not activated in default content for new setups.

https://4teamwork.atlassian.net/browse/CA-1358

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
