### PR TITLE
Fix unicode error in meeting overview.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2020.16.0 (unreleased)
 ----------------------
 
+- Fix unicode error in meeting overview. [njohner]
 - Add invitation_group_dn to teamraum policy template. [njohner]
 - Actions for document templates are properly configured. [elioschmutz]
 - Add unlock file action. [tinagerber]

--- a/opengever/meeting/model/meeting.py
+++ b/opengever/meeting/model/meeting.py
@@ -220,7 +220,7 @@ class Meeting(Base, SQLFormSupport):
             return str(self.meeting_number)
 
         title = period.title
-        return '{} / {}'.format(title, self.meeting_number)
+        return u'{} / {}'.format(title, self.meeting_number)
 
     def generate_decision_numbers(self):
         """Generate decision numbers for each agenda item of this meeting.

--- a/opengever/meeting/tests/test_meeting.py
+++ b/opengever/meeting/tests/test_meeting.py
@@ -361,3 +361,13 @@ class TestMeeting(IntegrationTestCase):
 
         self.assertEqual(2, self.meeting.model.meeting_number)
         self.assertEqual(2, self.period.meeting_sequence_number)
+
+    def test_get_meeting_number_supports_unicode_period_title(self):
+        self.login(self.committee_responsible)
+
+        self.assertEqual(
+            u'2016 / 1', self.decided_meeting.model.get_meeting_number())
+
+        self.period.title = u"\xe4 period"
+        self.assertEqual(
+            u'\xe4 period / 1', self.decided_meeting.model.get_meeting_number())


### PR DESCRIPTION
Meeting overview did not support Period titles containing unicode characters.

For https://4teamwork.atlassian.net/browse/CA-1359

Sentry: https://sentry.4teamwork.ch/organizations/sentry/issues/70360

## Checklist (Must have)

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
