### PR TITLE
Add feature flag for workspace meetings.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2020.16.0 (unreleased)
 ----------------------
 
+- Add feature flag for workspace meetings. [tinagerber]
 - Fix unicode error in meeting overview. [njohner]
 - Disable grouping on Subject column. [njohner]
 - Add invitation_group_dn to teamraum policy template. [njohner]

--- a/docs/public/dev-manual/api/config.rst
+++ b/docs/public/dev-manual/api/config.rst
@@ -90,7 +90,8 @@ GEVER-Mandanten abgefragt werden.
               "solr": true,
               "tasks_pdf": false,
               "workspace": false,
-              "workspace_client": false
+              "workspace_client": false,
+              "workspace_meetings": false,
               "workspace_todo": false,
           },
           "gever_colorization": "#37C35A",
@@ -246,6 +247,9 @@ features
 
     workspace_client
         Integration von GEVER mit einem Teamraum
+
+    workspace_meetings
+        Meetings in einem Teamraum
 
     workspace_todo
         ToDo's und ToDo-Listen in einem Teamraum

--- a/opengever/api/tests/test_config.py
+++ b/opengever/api/tests/test_config.py
@@ -89,6 +89,7 @@ class TestConfig(IntegrationTestCase):
                 u'tasks_pdf': False,
                 u'workspace': False,
                 u'workspace_client': False,
+                u'workspace_meetings': True,
                 u'workspace_todo': True,
             })
 

--- a/opengever/base/configuration.py
+++ b/opengever/base/configuration.py
@@ -36,6 +36,7 @@ from opengever.repository.interfaces import IRepositoryFolderRecords
 from opengever.sharing.interfaces import ISharingConfiguration
 from opengever.task.interfaces import ITaskSettings
 from opengever.workspace.interfaces import IWorkspaceSettings
+from opengever.workspace.interfaces import IWorkspaceMeetingSettings
 from opengever.workspace.interfaces import IToDoSettings
 from opengever.workspaceclient.interfaces import IWorkspaceClientSettings
 from pkg_resources import get_distribution
@@ -163,6 +164,7 @@ class GeverSettingsAdpaterV1(object):
         features['solr'] = api.portal.get_registry_record('use_solr', interface=ISearchSettings)
         features['workspace'] = api.portal.get_registry_record('is_feature_enabled', interface=IWorkspaceSettings)
         features['workspace_client'] = api.portal.get_registry_record('is_feature_enabled', interface=IWorkspaceClientSettings)  # noqa
+        features['workspace_meetings'] = api.portal.get_registry_record('is_feature_enabled', interface=IWorkspaceMeetingSettings)  # noqa
         features['workspace_todo'] = api.portal.get_registry_record('is_feature_enabled', interface=IToDoSettings)
         features['private_tasks'] = api.portal.get_registry_record('private_task_feature_enabled', interface=ITaskSettings)
         features['optional_task_permissions_revoking'] = api.portal.get_registry_record('optional_task_permissions_revoking_enabled', interface=ITaskSettings)  # noqa

--- a/opengever/base/tests/test_configuration_adapter.py
+++ b/opengever/base/tests/test_configuration_adapter.py
@@ -89,6 +89,7 @@ class TestConfigurationAdapter(IntegrationTestCase):
                 ('solr', True),
                 ('workspace', False),
                 ('workspace_client', False),
+                ('workspace_meetings', True),
                 ('workspace_todo', True),
                 ('private_tasks', True),
                 ('optional_task_permissions_revoking', False),

--- a/opengever/core/profiles/default/registry.xml
+++ b/opengever/core/profiles/default/registry.xml
@@ -188,6 +188,9 @@
   <!-- Workspace -->
   <records interface="opengever.workspace.interfaces.IWorkspaceSettings" />
 
+  <!-- WorkspaceMeeting -->
+  <records interface="opengever.workspace.interfaces.IWorkspaceMeetingSettings" />
+
   <!-- ToDo -->
   <records interface="opengever.workspace.interfaces.IToDoSettings" />
 

--- a/opengever/core/upgrades/20201216155007_add_workspace_meeting_feature_flag/registry.xml
+++ b/opengever/core/upgrades/20201216155007_add_workspace_meeting_feature_flag/registry.xml
@@ -1,0 +1,7 @@
+<registry>
+  <!-- WorkspaceMeeting -->
+  <records interface="opengever.workspace.interfaces.IWorkspaceMeetingSettings">
+    <value key="is_feature_enabled">True</value>
+  </records>
+
+</registry>

--- a/opengever/core/upgrades/20201216155007_add_workspace_meeting_feature_flag/upgrade.py
+++ b/opengever/core/upgrades/20201216155007_add_workspace_meeting_feature_flag/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddWorkspaceMeetingFeatureFlag(UpgradeStep):
+    """Add workspace meeting feature flag.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/policytemplates/hooks.py
+++ b/opengever/policytemplates/hooks.py
@@ -45,6 +45,7 @@ IGNORED_QUESTIONS = {
         'setup.invitation_group_dn',
         'base.apps_endpoint_url',
         'base.workspace_secret',
+        'setup.enable_workspace_meeting_feature',
         'setup.enable_todo_feature'
         ]
     }

--- a/opengever/policytemplates/policy_template/.mrbob.ini
+++ b/opengever/policytemplates/policy_template/.mrbob.ini
@@ -221,6 +221,11 @@ setup.bumblebee_auto_refresh.required = True
 setup.bumblebee_auto_refresh.default = true
 setup.bumblebee_auto_refresh.post_ask_question = mrbob.hooks:to_boolean
 
+setup.enable_workspace_meeting_feature.question = Enable Workspace meeting feature
+setup.enable_workspace_meeting_feature.required = True
+setup.enable_workspace_meeting_feature.default = true
+setup.enable_workspace_meeting_feature.post_ask_question = mrbob.hooks:to_boolean
+
 setup.enable_todo_feature.question = Enable ToDo feature
 setup.enable_todo_feature.required = True
 setup.enable_todo_feature.default = true

--- a/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/+adminunit.id+/profiles/default/registry.xml.bob
+++ b/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/+adminunit.id+/profiles/default/registry.xml.bob
@@ -134,6 +134,13 @@
     <value key="invitation_group_dn">{{{setup.invitation_group_dn}}}</value>
   </records>
 
+{{% if not setup.enable_workspace_meeting_feature %}}
+  <records interface="opengever.workspace.interfaces.IWorkspaceMeetingSettings">
+    <value key="is_feature_enabled">False</value>
+  </records>
+
+{{% endif %}}
+
 {{% if not setup.enable_todo_feature %}}
   <records interface="opengever.workspace.interfaces.IToDoSettings">
     <value key="is_feature_enabled">False</value>

--- a/opengever/testing/integration_test_case.py
+++ b/opengever/testing/integration_test_case.py
@@ -85,6 +85,7 @@ FEATURE_FLAGS = {
     'repositoryfolder-tasks-tab': 'opengever.repository.interfaces.IRepositoryFolderRecords.show_tasks_tab',
     'workspace': 'opengever.workspace.interfaces.IWorkspaceSettings.is_feature_enabled',
     'workspace_client': 'opengever.workspace.interfaces.IWorkspaceClientSettings.is_feature_enabled',
+    'workspace-meeting': 'opengever.workspace.interfaces.IWorkspaceMeetingSettings.is_feature_enabled',
     'workspace-todo': 'opengever.workspace.interfaces.IToDoSettings.is_feature_enabled',
     'favorites': 'opengever.base.interfaces.IFavoritesSettings.is_feature_enabled',
     'solr': 'opengever.base.interfaces.ISearchSettings.use_solr',

--- a/opengever/workspace/__init__.py
+++ b/opengever/workspace/__init__.py
@@ -1,4 +1,5 @@
 from opengever.workspace.interfaces import IToDoSettings
+from opengever.workspace.interfaces import IWorkspaceMeetingSettings
 from plone import api
 from zope.i18nmessageid import MessageFactory
 
@@ -9,6 +10,11 @@ def is_workspace_feature_enabled():
     from opengever.workspace.interfaces import IWorkspaceSettings
     return api.portal.get_registry_record(
         'is_feature_enabled', interface=IWorkspaceSettings)
+
+
+def is_workspace_meeting_feature_enabled():
+    return api.portal.get_registry_record(
+        'is_feature_enabled', interface=IWorkspaceMeetingSettings)
 
 
 def is_todo_feature_enabled():

--- a/opengever/workspace/interfaces.py
+++ b/opengever/workspace/interfaces.py
@@ -37,6 +37,14 @@ class IWorkspaceSettings(Interface):
     )
 
 
+class IWorkspaceMeetingSettings(Interface):
+
+    is_feature_enabled = schema.Bool(
+        title=u'Enable workspace meeting feature',
+        description=u'Whether workspace meeting integration is enabled',
+        default=True)
+
+
 class IToDoSettings(Interface):
 
     is_feature_enabled = schema.Bool(

--- a/opengever/workspace/tests/test_workspace_meeting.py
+++ b/opengever/workspace/tests/test_workspace_meeting.py
@@ -42,6 +42,21 @@ class TestAPISupportForWorkspaceMeeting(IntegrationTestCase):
         self.assertEqual('meeting-2', browser.json['id'])
 
     @browsing
+    def test_create_with_workspace_meeting_feature_disabled(self, browser):
+        self.deactivate_feature('workspace-meeting')
+        self.login(self.workspace_member, browser)
+        with browser.expect_http_error(code=403, reason='Forbidden'):
+            browser.open(
+                self.workspace, method='POST', headers=self.api_headers,
+                data=json.dumps({'title': 'Ein Meeting',
+                                 'responsible': self.workspace_member.getId(),
+                                 'start': '2020-10-10T23:56:00',
+                                 '@type': 'opengever.workspace.meeting'}))
+
+        self.assertEqual('Disallowed subobject type: opengever.workspace.meeting',
+                         browser.json['error']['message'])
+
+    @browsing
     def test_get_workspace_meeting_via_api(self, browser):
         self.login(self.workspace_member, browser)
         browser.open(self.workspace_meeting, method='GET', headers=self.api_headers)

--- a/opengever/workspace/tests/test_workspace_workspace.py
+++ b/opengever/workspace/tests/test_workspace_workspace.py
@@ -84,6 +84,17 @@ class TestWorkspaceWorkspace(IntegrationTestCase):
              'opengever.workspace.meeting'],
             [fti.id for fti in self.workspace.allowedContentTypes()])
 
+    def test_addable_types_with_workspace_meeting_feature_disabled(self):
+        self.deactivate_feature('workspace-meeting')
+        self.login(self.workspace_member)
+        self.assertItemsEqual(
+            ['opengever.document.document',
+             'ftw.mail.mail',
+             'opengever.workspace.folder',
+             'opengever.workspace.todo',
+             'opengever.workspace.todolist'],
+            [fti.id for fti in self.workspace.allowedContentTypes()])
+
     @browsing
     def test_security_view_access(self, browser):
         for user in (self.workspace_owner,

--- a/opengever/workspace/workspace.py
+++ b/opengever/workspace/workspace.py
@@ -1,5 +1,6 @@
 from opengever.workspace import _
 from opengever.workspace import is_todo_feature_enabled
+from opengever.workspace import is_workspace_meeting_feature_enabled
 from opengever.workspace.base import WorkspaceBase
 from opengever.workspace.interfaces import IWorkspace
 from opengever.workspace.interfaces import IWorkspaceSettings
@@ -61,6 +62,8 @@ class Workspace(WorkspaceBase):
         def filter_type(fti):
             if fti.id == "opengever.workspace.todo" or fti.id == "opengever.workspace.todolist":
                 return is_todo_feature_enabled()
+            if fti.id == "opengever.workspace.meeting":
+                return is_workspace_meeting_feature_enabled()
             return True
 
         return filter(filter_type, types)


### PR DESCRIPTION
This PR adds a feature flag for workspace meetings. This allows us to enable and disable WorkspaceMeetings. By default, this feature is enabled so that no additional update steps are required in the policies.
With the policy generator the feature can be enabled and disabled.

Jira: https://4teamwork.atlassian.net/browse/NE-290

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


## Checklist (if applicable)

_Only applicable should be left and checked._

- API change:
  - [x] Documentation is updated