### PR TITLE
Protect dossier participations endpoints with modify permission.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 ----------------------
 
 - Add feature flag for workspace meetings. [tinagerber]
+- Do not allow to modify the participations of a dossier via @participations endpoint if dossier cannot be modified. [tinagerber]
 - Fix unicode error in meeting overview. [njohner]
 - Disable grouping on Subject column. [njohner]
 - Add invitation_group_dn to teamraum policy template. [njohner]

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -1124,7 +1124,7 @@
       name="@participations"
       for="opengever.dossier.behaviors.participation.IParticipationAwareMarker"
       factory=".dossier_participations.ParticipationsPost"
-      permission="zope2.View"
+      permission="cmf.ModifyPortalContent"
       />
 
   <plone:service
@@ -1132,7 +1132,7 @@
       name="@participations"
       for="opengever.dossier.behaviors.participation.IParticipationAwareMarker"
       factory=".dossier_participations.ParticipationsPatch"
-      permission="zope2.View"
+      permission="cmf.ModifyPortalContent"
       />
 
   <plone:service
@@ -1140,7 +1140,7 @@
       name="@participations"
       for="opengever.dossier.behaviors.participation.IParticipationAwareMarker"
       factory=".dossier_participations.ParticipationsDelete"
-      permission="zope2.View"
+      permission="cmf.ModifyPortalContent"
       />
 
   <adapter

--- a/opengever/api/tests/test_dossier_participations.py
+++ b/opengever/api/tests/test_dossier_participations.py
@@ -254,6 +254,32 @@ class TestParticipationsPost(IntegrationTestCase):
              "type": "BadRequest"},
             browser.json)
 
+    @browsing
+    def test_post_participation_for_resolved_dossier_raises_unauthorized(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        with browser.expect_http_error(401):
+            browser.open(self.expired_dossier, view='/@participations',
+                         method='POST',
+                         headers=self.api_headers,
+                         data=json.dumps({'participant_id': self.valid_participant_id,
+                                          'roles': ['regard']}))
+        self.assertEqual({"message": "You are not authorized to access this resource.",
+                          "type": "Unauthorized"}, browser.json)
+
+    @browsing
+    def test_post_participation_for_inactive_dossier_raises_unauthorized(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        with browser.expect_http_error(401):
+            browser.open(self.inactive_dossier, view='/@participations',
+                         method='POST',
+                         headers=self.api_headers,
+                         data=json.dumps({'participant_id': self.valid_participant_id,
+                                          'roles': ['regard']}))
+        self.assertEqual({"message": "You are not authorized to access this resource.",
+                          "type": "Unauthorized"}, browser.json)
+
 
 class TestParticipationsPostWithContactFeatureEnabled(TestParticipationsPost):
 
@@ -370,6 +396,32 @@ class TestParticipationsPatch(IntegrationTestCase):
         self.assertEqual({"message": "Role 'invalid' does not exist",
                           "type": "BadRequest"}, browser.json)
 
+    @browsing
+    def test_patch_participation_for_resolved_dossier_raises_unauthorized(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        with browser.expect_http_error(401):
+            browser.open(self.expired_dossier, view='/@participations',
+                         method='PATCH',
+                         headers=self.api_headers,
+                         data=json.dumps({'roles': ['participation', 'final-drawing']}))
+
+        self.assertEqual({"message": "You are not authorized to access this resource.",
+                          "type": "Unauthorized"}, browser.json)
+
+    @browsing
+    def test_patch_participation_for_inactive_dossier_raises_unauthorized(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        with browser.expect_http_error(401):
+            browser.open(self.inactive_dossier, view='/@participations',
+                         method='PATCH',
+                         headers=self.api_headers,
+                         data=json.dumps({'roles': ['participation', 'final-drawing']}))
+
+        self.assertEqual({"message": "You are not authorized to access this resource.",
+                          "type": "Unauthorized"}, browser.json)
+
 
 class TestParticipationsPatchWithContactFeatureEnabled(TestParticipationsPatch):
 
@@ -424,6 +476,30 @@ class TestParticipationsDelete(IntegrationTestCase):
                          method='DELETE', headers=self.api_headers)
         self.assertEqual({"message": "chaosqueen is not a valid id",
                           "type": "BadRequest"}, browser.json)
+
+    @browsing
+    def test_delete_participation_for_resolved_dossier_raises_unauthorized(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        with browser.expect_http_error(401):
+            browser.open(self.expired_dossier,
+                         view='/@participations/' + self.participant_id,
+                         method='DELETE', headers=self.api_headers)
+
+        self.assertEqual({"message": "You are not authorized to access this resource.",
+                          "type": "Unauthorized"}, browser.json)
+
+    @browsing
+    def test_delete_participation_for_inactive_dossier_raises_unauthorized(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        with browser.expect_http_error(401):
+            browser.open(self.inactive_dossier,
+                         view='/@participations/' + self.participant_id,
+                         method='DELETE', headers=self.api_headers)
+
+        self.assertEqual({"message": "You are not authorized to access this resource.",
+                          "type": "Unauthorized"}, browser.json)
 
 
 class TestParticipationsDeleteWithContactFeatureEnabled(TestParticipationsDelete):


### PR DESCRIPTION
Participations should not be able to be modified if a dossier cannot be modified.

Jira: https://4teamwork.atlassian.net/browse/NE-219

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)