### PR TITLE
Prevent attempts to edit locked documents in Office Online.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2020.16.0 (unreleased)
 ----------------------
 
+- Prevent attempts to edit locked documents in Office Online. [tinagerber]
 - Add feature flag for workspace meetings. [tinagerber]
 - Do not allow to modify the participations of a dossier via @participations endpoint if dossier cannot be modified. [tinagerber]
 - Fix unicode error in meeting overview. [njohner]

--- a/opengever/document/fileactions.py
+++ b/opengever/document/fileactions.py
@@ -254,11 +254,13 @@ class DocumentFileActions(BaseDocumentFileActions):
 
     def _can_edit_with_office_online(self):
         # Office Online allows collaborative editing
-        # Thus a document is editable by Office Online if it's not checked out
+        # Thus a document is editable by Office Online if it's not checked out and not locked
         # or if it's checked out by Office Online.
         if self.context.checked_out_by():
             if get_lock_token(self.context):
                 return True
             else:
                 return False
+        if self.context.is_locked():
+            return False
         return True

--- a/opengever/document/tests/test_fileactions.py
+++ b/opengever/document/tests/test_fileactions.py
@@ -6,9 +6,10 @@ from opengever.document.interfaces import IFileActions
 from opengever.officeconnector.interfaces import IOfficeConnectorSettings
 from opengever.testing import IntegrationTestCase
 from opengever.testing.test_case import TestCase
-from opengever.wopi.testing import mock_wopi_discovery
 from opengever.wopi.lock import create_lock
+from opengever.wopi.testing import mock_wopi_discovery
 from plone import api
+from plone.locking.interfaces import ILockable
 from zope.component import getMultiAdapter
 from zope.interface.verify import verifyClass
 
@@ -83,6 +84,13 @@ class TestOfficeOnlineEditable(IntegrationTestCase):
         manager = getMultiAdapter((self.document, self.request),
                                   ICheckinCheckoutManager)
         manager.checkout()
+        actions = getMultiAdapter((self.document, self.request), IFileActions)
+        self.assertFalse(actions.is_office_online_edit_action_available())
+
+    def test_not_editable_if_locked_by_other(self):
+        mock_wopi_discovery()
+        self.login(self.regular_user)
+        ILockable(self.document).lock()
         actions = getMultiAdapter((self.document, self.request), IFileActions)
         self.assertFalse(actions.is_office_online_edit_action_available())
 

--- a/opengever/wopi/tests/test_edit.py
+++ b/opengever/wopi/tests/test_edit.py
@@ -1,10 +1,12 @@
 from base64 import urlsafe_b64decode
 from ftw.testbrowser import browsing
+from ftw.testbrowser.pages.statusmessages import error_messages
 from opengever.document.interfaces import ICheckinCheckoutManager
 from opengever.testing import IntegrationTestCase
 from opengever.wopi.interfaces import IWOPISettings
 from opengever.wopi.token import validate_access_token
 from plone import api
+from plone.locking.interfaces import ILockable
 from zope.component import getMultiAdapter
 
 
@@ -90,3 +92,11 @@ class TestEditView(IntegrationTestCase):
                                   ICheckinCheckoutManager)
         self.assertFalse(manager.is_collaborative_checkout())
         self.assertEqual([], manager.get_collaborators())
+
+    @browsing
+    def test_edit_view_on_locked_document_redirects_to_document_and_shows_error_message(self, browser):
+        self.login(self.regular_user, browser=browser)
+        ILockable(self.document).lock()
+        browser.open(self.document, view="office_online_edit")
+        self.assertEqual(self.document.absolute_url(), browser.url)
+        self.assertEqual(['Document is locked.'], error_messages())


### PR DESCRIPTION
Until now, a document was editable with Office Online even if it was locked. The office_online_edit action was also available. This is no longer the case with this pr.
Jira: https://4teamwork.atlassian.net/browse/NE-446

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)