### PR TITLE
Implement solr indexer getObjPositionInParent for tasktemplates, todos and todolists

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2020.16.0 (unreleased)
 ----------------------
 
+- Introduces a new solr-index 'getObjPositionInParent' for tasktemplates, todolists and todos. [elioschmutz]
 - Prevent attempts to edit locked documents in Office Online. [tinagerber]
 - Add feature flag for workspace meetings. [tinagerber]
 - Do not allow to modify the participations of a dossier via @participations endpoint if dossier cannot be modified. [tinagerber]

--- a/opengever/base/configure.zcml
+++ b/opengever/base/configure.zcml
@@ -422,6 +422,11 @@
       name="participations"
       />
 
+  <adapter
+      factory=".indexes.getObjPositionInParent"
+      name="getObjPositionInParent"
+      />
+
   <utility factory=".sequence.SequenceNumber" />
 
   <adapter factory=".quickupload.OGQuickUploadCapableFileFactory" />

--- a/opengever/base/configure.zcml
+++ b/opengever/base/configure.zcml
@@ -331,6 +331,12 @@
       />
 
   <subscriber
+      for="plone.dexterity.interfaces.IDexterityContent
+           Products.CMFPlone.events.IReorderedEvent"
+      handler=".handlers.contents_reordered"
+      />
+
+  <subscriber
       for="opengever.base.behaviors.changed.IChangedMarker
            zope.lifecycleevent.interfaces.IObjectModifiedEvent"
       handler=".handlers.maybe_update_changed_date"

--- a/opengever/base/ordering.py
+++ b/opengever/base/ordering.py
@@ -1,0 +1,15 @@
+from plone.folder.default import DefaultOrdering
+from Products.CMFPlone.events import ReorderedEvent
+from zope.event import notify
+
+
+class GeverDefaultOrdering(DefaultOrdering):
+
+    def moveObjectsByDelta(self, *args, **kwargs):
+        """In addition to the default implementation it also triggers the
+        ReorderedEvent which is necessary to properly update the getObjPositionInParent
+        index.
+        """
+        counter = super(GeverDefaultOrdering, self).moveObjectsByDelta(*args, **kwargs)
+        notify(ReorderedEvent(self.context))
+        return counter

--- a/opengever/base/overrides.zcml
+++ b/opengever/base/overrides.zcml
@@ -67,4 +67,10 @@
     <adapter factory=".warmup.GEVERWarmupPerformer" />
   </configure>
 
+  <adapter
+      for="plone.folder.interfaces.IOrderableFolder"
+      provides="plone.folder.interfaces.IExplicitOrdering"
+      factory=".ordering.GeverDefaultOrdering"
+      />
+
 </configure>

--- a/opengever/base/tests/test_contents_reordered_handling.py
+++ b/opengever/base/tests/test_contents_reordered_handling.py
@@ -42,3 +42,40 @@ class TestContentsReorderedHandler(SolrIntegrationTestCase):
             {u'UID': tasktemplate_2.UID(),
              u'getObjPositionInParent': 0},
             ], browser.json["items"])
+
+    @browsing
+    def test_reindex_getObjPositionInParent_if_reordering_tasktemplates_through_the_tabbed_view(self, browser):
+        self.login(self.administrator, browser=browser)
+
+        view = u'/@solrsearch?fl=getObjPositionInParent&depth=1&fq=object_provides:{}'.format(
+            ITaskTemplate.__identifier__)
+
+        tasktemplate_1 = self.tasktemplate
+        tasktemplate_2 = create(Builder('tasktemplate').within(self.tasktemplatefolder))
+        self.commit_solr()
+
+        browser.open(self.tasktemplatefolder.absolute_url(), view=view,
+                     method='GET', headers=self.api_headers)
+
+        self.assertItemsEqual([
+            {u'UID': tasktemplate_1.UID(),
+             u'getObjPositionInParent': 0},
+            {u'UID': tasktemplate_2.UID(),
+             u'getObjPositionInParent': 1},
+            ], browser.json["items"])
+
+        browser.open(self.tasktemplatefolder.absolute_url(), view="@@tabbed_view/reorder",
+                     headers={'Content-Type': 'application/x-www-form-urlencoded'},
+                     method="POST",
+                     data={'new_order[]': [tasktemplate_2.id, tasktemplate_1.id]})
+        self.commit_solr()
+
+        browser.open(self.tasktemplatefolder.absolute_url(), view=view,
+                     method='GET', headers=self.api_headers)
+
+        self.assertItemsEqual([
+            {u'UID': tasktemplate_1.UID(),
+             u'getObjPositionInParent': 1},
+            {u'UID': tasktemplate_2.UID(),
+             u'getObjPositionInParent': 0},
+            ], browser.json["items"])

--- a/opengever/base/tests/test_contents_reordered_handling.py
+++ b/opengever/base/tests/test_contents_reordered_handling.py
@@ -1,0 +1,44 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.testbrowser import browsing
+from opengever.tasktemplates.content.tasktemplate import ITaskTemplate
+from opengever.testing import SolrIntegrationTestCase
+
+
+class TestContentsReorderedHandler(SolrIntegrationTestCase):
+
+    @browsing
+    def test_reindex_getObjPositionInParent_if_reordering_contents_through_folder_contents(self, browser):
+        self.login(self.manager, browser=browser)
+
+        view = u'/@solrsearch?fl=getObjPositionInParent&depth=1&fq=object_provides:{}'.format(
+            ITaskTemplate.__identifier__)
+
+        tasktemplate_1 = self.tasktemplate
+        tasktemplate_2 = create(Builder('tasktemplate').within(self.tasktemplatefolder))
+        self.commit_solr()
+
+        browser.open(self.tasktemplatefolder.absolute_url(), view=view,
+                     method='GET', headers=self.api_headers)
+
+        self.assertItemsEqual([
+            {u'UID': tasktemplate_1.UID(),
+             u'getObjPositionInParent': 0},
+            {u'UID': tasktemplate_2.UID(),
+             u'getObjPositionInParent': 1},
+            ], browser.json["items"])
+
+        # 'folder_moveitem' is a skins python script which will be used if ordering
+        # through the contents-tab provided by plone.
+        self.tasktemplatefolder.unrestrictedTraverse('folder_moveitem')(tasktemplate_1.id, 1)
+        self.commit_solr()
+
+        browser.open(self.tasktemplatefolder.absolute_url(), view=view,
+                     method='GET', headers=self.api_headers)
+
+        self.assertItemsEqual([
+            {u'UID': tasktemplate_1.UID(),
+             u'getObjPositionInParent': 1},
+            {u'UID': tasktemplate_2.UID(),
+             u'getObjPositionInParent': 0},
+            ], browser.json["items"])

--- a/opengever/base/tests/test_solr.py
+++ b/opengever/base/tests/test_solr.py
@@ -90,7 +90,6 @@ class TestSolr(IntegrationTestCase):
             'contactid',
             'date_of_completion',
             'getId',
-            'getObjPositionInParent',
             'is_default_page',
             'is_folderish',
             'predecessor',

--- a/opengever/core/upgrades/20201230152803_add_and_index_get_obj_position_in_parent_solr_field/upgrade.py
+++ b/opengever/core/upgrades/20201230152803_add_and_index_get_obj_position_in_parent_solr_field/upgrade.py
@@ -1,0 +1,20 @@
+from ftw.upgrade import UpgradeStep
+from opengever.tasktemplates.content.tasktemplate import ITaskTemplate
+from opengever.workspace.interfaces import IToDo
+from opengever.workspace.interfaces import IToDoList
+
+
+class AddAndIndexGetObjPositionInParentSolrField(UpgradeStep):
+    """Add and index get obj position in parent solr field.
+    """
+    deferrable = True
+
+    def __call__(self):
+        query = {'object_provides': [
+            ITaskTemplate.__identifier__,
+            IToDo.__identifier__,
+            IToDoList.__identifier__
+        ]}
+
+        for obj in self.objects(query, 'Index getObjPositionInParent field in solr.'):
+            obj.reindexObject(idxs=['getObjPositionInParent'])

--- a/opengever/tasktemplates/browser/tasktemplates.py
+++ b/opengever/tasktemplates/browser/tasktemplates.py
@@ -1,6 +1,5 @@
 from ftw.table import helper
 from ftw.table.interfaces import ITableSource
-from opengever.base import ISearchSettings
 from opengever.tabbedview import BaseCatalogListingTab
 from opengever.tabbedview import GeverCatalogTableSource
 from opengever.tabbedview.helper import linked
@@ -12,10 +11,8 @@ from opengever.tasktemplates.browser.helper import interactive_user_helper
 from opengever.tasktemplates.content.tasktemplate import ITaskTemplate
 from plone import api
 from plone.dexterity.browser.view import DefaultView
-from plone.registry.interfaces import IRegistry
 from Products.CMFPlone.utils import safe_unicode
 from zope.component import adapter
-from zope.component._api import getUtility
 from zope.component.hooks import getSite
 from zope.i18n import translate
 from zope.interface import implementer
@@ -42,22 +39,12 @@ class TaskTemplatesCatalogTableSource(GeverCatalogTableSource):
 
     def search_results(self, query):
         """
-        After fetching all the task templates we reorder them by their position in
-        the parent. This is needed because the task templates can be ordered manually
-        by the user (drag'n'drop in the table) but Solr does not know about the position
-        of the task templates within their container.
-
-        We also disable batching of the search results by fetching all task templates because
+        We disable batching of the search results by fetching all task templates because
         it is not very useful to enable batching when the items can be ordered manually (i.e.
         moving items between) pages is very cumbersome. Otherwise we could not reliably order
         the items when we only have a batch. Since we don't expect our clients to create lots
         of task templates, we assume this is a reasonable choice for this special use case.
         """
-        # Backup the sort parameter because it will be gone after the call to the
-        # the super class and we need it in order to determine if we need to do
-        # the sorting.
-        sort_on = query.get('sort_on')
-
         # Get a lot of task templates on the first try in order to prevent batching.
         self.config.pagesize = 5000
         search_results = super(TaskTemplatesCatalogTableSource, self).search_results(query)
@@ -68,15 +55,6 @@ class TaskTemplatesCatalogTableSource(GeverCatalogTableSource):
             # because we assume not many client will have that many task templates.
             self.config.pagesize = search_results.actual_result_count
             search_results = super(TaskTemplatesCatalogTableSource, self).search_results(query)
-
-        # Manually sort the Solr search results by their position in the parent because
-        # Solr does not know about the position of the task templates in their parent.
-        if self.use_solr and sort_on == 'getObjPositionInParent':
-            parent = api.content.get(query['path']['query'])
-            search_results.docs = sorted(
-                search_results.docs,
-                key=lambda doc: parent.objectIds().index(doc['id'])
-            )
 
         return search_results
 

--- a/opengever/tasktemplates/tests/test_tasktemplatefolder.py
+++ b/opengever/tasktemplates/tests/test_tasktemplatefolder.py
@@ -95,6 +95,7 @@ class TaskTemplatesOrderingInTabbedView(SolrIntegrationTestCase):
 
         # Move the new task template to the top within the container.
         self.tasktemplatefolder.moveObjectsToTop(task_create_user.id)
+        self.commit_solr()
 
         # Make sure the change of position worked in Plone.
         self.assertEquals(

--- a/solr-conf/managed-schema
+++ b/solr-conf/managed-schema
@@ -124,6 +124,7 @@
     <field name="Title" type="text" indexed="true" stored="true"/>
     <field name="Subject" type="string" indexed="true" stored="true" multiValued="true"/>
     <field name="UID" type="string" indexed="true" stored="true" required="true" multiValued="false" />
+    <field name="getObjPositionInParent" type="pint" indexed="true" stored="true" />
 
     <!-- GEVER specific fields -->
     <field name="bumblebee_checksum" type="string" indexed="false" stored="false" />


### PR DESCRIPTION
Jira: https://4teamwork.atlassian.net/browse/NE-283

Currently, we don't provide a solr-index for the position of an object within its parent for manually sorted content. This leads to workarounds i.e. for ordering tasktemplates (https://github.com/4teamwork/opengever.core/blob/master/opengever/tasktemplates/browser/tasktemplates.py#L72) or performance issues i.e. for displaying todos and todolists (https://github.com/4teamwork/gever-ui/blob/master/src/components/workspace/ToDoTab.vue#L144).

This PR implements the index `getObjPositionInParent` for solr. The indexer itself will only index the position for some whitelisted types which are `Todos`, `TodoLists` and `Tasktemplates`.

If the `ReorderedEvent` is triggered on an object, all its children will be reindexed. Even here, we do this only for a whitelisted set of containers which are `TodoLists`, `Workspaces` and `Tasktemplatefolders`. This will not unnecessary try to index children of objects we already know, that there will be no indexable children.

### Upgrade-Time
The Upgrade is defferable.

The most expensive task is to activate the objects.
Calculating the position within the parent takes about 3 Seconds for 10'000 objects. But we expect to have < 1000 objects per deployment. So the upgradestep should be blazing fast and there is no need to deffer the upgradestep.

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


## Checklist (if applicable)

_Only applicable should be left and checked._

- API change:
  - [ ] Documentation is updated
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Upgrade steps (changes in profile):
  - [x] Make it deferrable if possible
  - [x] Execute as much as possible conditionally
- DB-Schema migration
  - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
  - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value
