### PR TITLE
Add property sheet schema storage.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,7 @@ Changelog
 2021.2.0 (unreleased)
 ---------------------
 
-- Nothing changed yet.
+- Implement storage for property sheet schemas in plone-site annotations. [deiferni]
 
 
 2021.1.0 (2021-01-06)

--- a/opengever/propertysheets/__init__.py
+++ b/opengever/propertysheets/__init__.py
@@ -1,0 +1,4 @@
+from zope.i18nmessageid import MessageFactory
+
+
+_ = MessageFactory('opengever.propertysheets')

--- a/opengever/propertysheets/configure.zcml
+++ b/opengever/propertysheets/configure.zcml
@@ -1,0 +1,15 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:five="http://namespaces.zope.org/five"
+    xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
+    xmlns:i18n="http://namespaces.zope.org/i18n"
+    xmlns:plone="http://namespaces.plone.org/plone"
+    xmlns:z3c="http://namespaces.zope.org/z3c"
+    i18n_domain="opengever.propertysheets">
+
+  <utility
+      factory=".schemapolicy.PropertySheetSchemaPolicy"
+      name="propertysheets"
+      />
+
+</configure>

--- a/opengever/propertysheets/definition.py
+++ b/opengever/propertysheets/definition.py
@@ -2,7 +2,9 @@ from opengever.propertysheets.exceptions import InvalidFieldType
 from opengever.propertysheets.exceptions import InvalidFieldTypeDefinition
 from plone.schemaeditor import fields
 from plone.schemaeditor.utils import IEditableSchema
+from plone.supermodel import loadString
 from plone.supermodel import model
+from plone.supermodel import serializeSchema
 import re
 import tokenize
 import keyword
@@ -71,3 +73,14 @@ class PropertySheetSchemaDefinition(object):
         field = factory(**properties)
         schema = IEditableSchema(self.schema_class)
         schema.addField(field)
+
+    def _save(self, storage):
+        storage[self.name] = serializeSchema(self.schema_class, name=self.name)
+
+    @classmethod
+    def _load(cls, storage, name):
+        serialized_schema = storage[name]
+        model = loadString(serialized_schema, policy=u'propertysheets')
+        schema_class = model.schemata[name]
+
+        return cls(name, schema_class)

--- a/opengever/propertysheets/definition.py
+++ b/opengever/propertysheets/definition.py
@@ -33,21 +33,21 @@ class PropertySheetSchemaDefinition(object):
     }
 
     @classmethod
-    def create(cls, name, identifiers=None):
+    def create(cls, name, assignments=None):
 
         class SchemaClass(model.Schema):
             pass
 
-        return cls(name, SchemaClass, identifiers=identifiers)
+        return cls(name, SchemaClass, assignments=assignments)
 
-    def __init__(self, name, schema_class, identifiers=None):
+    def __init__(self, name, schema_class, assignments=None):
         self.name = name
         self.schema_class = schema_class
-        if identifiers is None:
-            identifiers = tuple()
+        if assignments is None:
+            assignments = tuple()
         else:
-            identifiers = tuple(identifiers)
-        self.identifiers = identifiers
+            assignments = tuple(assignments)
+        self.assignments = assignments
 
     def add_field(self, field_type, name, title, description, required, values=None):
         if field_type not in self.FACTORIES:
@@ -85,15 +85,15 @@ class PropertySheetSchemaDefinition(object):
         serialized_schema = serializeSchema(self.schema_class, name=self.name)
         definition_data = PersistentMapping()
         definition_data['schema'] = serialized_schema
-        definition_data['identifiers'] = PersistentList(self.identifiers)
+        definition_data['assignments'] = PersistentList(self.assignments)
         storage[self.name] = definition_data
 
     @classmethod
     def _load(cls, storage, name):
         definition_data = storage[name]
         serialized_schema = definition_data['schema']
-        identifiers = definition_data['identifiers']
+        assignments = definition_data['assignments']
         model = loadString(serialized_schema, policy=u'propertysheets')
         schema_class = model.schemata[name]
 
-        return cls(name, schema_class, identifiers=identifiers)
+        return cls(name, schema_class, assignments=assignments)

--- a/opengever/propertysheets/definition.py
+++ b/opengever/propertysheets/definition.py
@@ -1,7 +1,15 @@
 from opengever.propertysheets.exceptions import InvalidFieldType
+from opengever.propertysheets.exceptions import InvalidFieldTypeDefinition
 from plone.schemaeditor import fields
 from plone.schemaeditor.utils import IEditableSchema
 from plone.supermodel import model
+import re
+import tokenize
+import keyword
+
+
+def isidentifier(val):
+    return re.match(tokenize.Name + r'\Z', val) and not keyword.iskeyword(val)
 
 
 class PropertySheetSchemaDefinition(object):
@@ -34,6 +42,11 @@ class PropertySheetSchemaDefinition(object):
     def add_field(self, field_type, name, title, description, required, values=None):
         if field_type not in self.FACTORIES:
             raise InvalidFieldType("Field type '{}' is invalid.".format(field_type))
+
+        if not isidentifier(name):
+            raise InvalidFieldTypeDefinition(
+                "The name '{}' is not a valid identifier.".format(name)
+            )
 
         factory = self.FACTORIES[field_type]
         properties = {

--- a/opengever/propertysheets/definition.py
+++ b/opengever/propertysheets/definition.py
@@ -1,0 +1,48 @@
+from opengever.propertysheets.exceptions import InvalidFieldType
+from plone.schemaeditor import fields
+from plone.schemaeditor.utils import IEditableSchema
+from plone.supermodel import model
+
+
+class PropertySheetSchemaDefinition(object):
+    """Wraps a schema definition and handles schema modifications.
+
+    This class represents the schema definition of a property sheet. It allows
+    to add fields to an existing schema.
+    It also handles serialization and deserialization to a dict-like persistent
+    storage.
+    """
+    FACTORIES = {
+        'bool': fields.BoolFactory,
+        'int': fields.IntFactory,
+        'text': fields.TextFactory,
+        'textline': fields.TextLineFactory,
+    }
+
+    @classmethod
+    def create(cls, name):
+
+        class SchemaClass(model.Schema):
+            pass
+
+        return cls(name, SchemaClass)
+
+    def __init__(self, name, schema_class):
+        self.name = name
+        self.schema_class = schema_class
+
+    def add_field(self, field_type, name, title, description, required, values=None):
+        if field_type not in self.FACTORIES:
+            raise InvalidFieldType("Field type '{}' is invalid.".format(field_type))
+
+        factory = self.FACTORIES[field_type]
+        properties = {
+            "title": title,
+            "__name__": name,
+            "description": description,
+            "required": required,
+        }
+
+        field = factory(**properties)
+        schema = IEditableSchema(self.schema_class)
+        schema.addField(field)

--- a/opengever/propertysheets/definition.py
+++ b/opengever/propertysheets/definition.py
@@ -22,6 +22,7 @@ class PropertySheetSchemaDefinition(object):
     """
     FACTORIES = {
         'bool': fields.BoolFactory,
+        'choice': fields.ChoiceFactory,
         'int': fields.IntFactory,
         'text': fields.TextFactory,
         'textline': fields.TextLineFactory,
@@ -55,6 +56,17 @@ class PropertySheetSchemaDefinition(object):
             "description": description,
             "required": required,
         }
+
+        if field_type == 'choice':
+            if not values:
+                raise InvalidFieldTypeDefinition(
+                    "For 'choice' fields types values are required."
+                )
+            properties['values'] = values
+        elif values:
+            raise InvalidFieldTypeDefinition(
+                "The argument 'values' is only valid for 'choice' fields."
+            )
 
         field = factory(**properties)
         schema = IEditableSchema(self.schema_class)

--- a/opengever/propertysheets/exceptions.py
+++ b/opengever/propertysheets/exceptions.py
@@ -4,3 +4,7 @@ class InvalidFieldType(Exception):
 
 class InvalidFieldTypeDefinition(Exception):
     pass
+
+
+class InvalidSchemaIdentifier(Exception):
+    pass

--- a/opengever/propertysheets/exceptions.py
+++ b/opengever/propertysheets/exceptions.py
@@ -6,5 +6,5 @@ class InvalidFieldTypeDefinition(Exception):
     pass
 
 
-class InvalidSchemaIdentifier(Exception):
+class InvalidSchemaAssignment(Exception):
     pass

--- a/opengever/propertysheets/exceptions.py
+++ b/opengever/propertysheets/exceptions.py
@@ -1,0 +1,6 @@
+class InvalidFieldType(Exception):
+    pass
+
+
+class InvalidFieldTypeDefinition(Exception):
+    pass

--- a/opengever/propertysheets/schemapolicy.py
+++ b/opengever/propertysheets/schemapolicy.py
@@ -1,0 +1,19 @@
+from zope.interface import implementer
+from plone.supermodel.parser import ISchemaPolicy
+
+
+@implementer(ISchemaPolicy)
+class PropertySheetSchemaPolicy(object):
+    """Custom schema policy for property sheet schemas.
+
+    Currently used to inject a fake module name to easily identify property
+    sheet schemas.
+    """
+    def module(self, schemaName, tree):
+        return 'opengever.propertysheets.generated'
+
+    def bases(self, schemaName, tree):
+        return ()
+
+    def name(self, schemaName, tree):
+        return schemaName

--- a/opengever/propertysheets/storage.py
+++ b/opengever/propertysheets/storage.py
@@ -52,3 +52,12 @@ class PropertySheetSchemaStorage(object):
             return None
 
         return PropertySheetSchemaDefinition._load(storage, name)
+
+    def query(self, identifier):
+        annotations = IAnnotations(self.context)
+        storage = annotations.get(self.ANNOTATIONS_KEY, {})
+        for name, definition_data in storage.items():
+            if identifier in definition_data['identifiers']:
+                return self.get(name)
+
+        return None

--- a/opengever/propertysheets/storage.py
+++ b/opengever/propertysheets/storage.py
@@ -1,0 +1,41 @@
+from opengever.propertysheets.definition import PropertySheetSchemaDefinition
+from persistent.mapping import PersistentMapping
+from plone import api
+from zope.annotation import IAnnotations
+
+
+class PropertySheetSchemaStorage(object):
+    """Handle storage and lookup of property sheets.
+
+    Property sheets are stored in the annotation of the plone site.
+    """
+    ANNOTATIONS_KEY = 'opengever.propertysheets.schema_definitions'
+
+    def __init__(self, context=None):
+        self.context = context or api.portal.get()
+
+    def list(self):
+        annotations = IAnnotations(self.context)
+
+        result = []
+        for name in annotations.get(self.ANNOTATIONS_KEY, {}):
+            result.append(self.get(name))
+        return result
+
+    def save(self, schema_definition):
+        annotations = IAnnotations(self.context)
+
+        if self.ANNOTATIONS_KEY not in annotations:
+            annotations[self.ANNOTATIONS_KEY] = PersistentMapping()
+
+        storage = annotations[self.ANNOTATIONS_KEY]
+        schema_definition._save(storage)
+
+    def get(self, name):
+        annotations = IAnnotations(self.context)
+        storage = annotations.get(self.ANNOTATIONS_KEY, {})
+
+        if name not in storage:
+            return None
+
+        return PropertySheetSchemaDefinition._load(storage, name)

--- a/opengever/propertysheets/storage.py
+++ b/opengever/propertysheets/storage.py
@@ -1,5 +1,5 @@
 from opengever.propertysheets.definition import PropertySheetSchemaDefinition
-from opengever.propertysheets.exceptions import InvalidSchemaIdentifier
+from opengever.propertysheets.exceptions import InvalidSchemaAssignment
 from persistent.mapping import PersistentMapping
 from plone import api
 from zope.annotation import IAnnotations
@@ -31,16 +31,17 @@ class PropertySheetSchemaStorage(object):
 
         storage = annotations[self.ANNOTATIONS_KEY]
 
-        used_identifiers = set()
+        used_assignments = set()
         for definition_data in storage.values():
-            used_identifiers.update(definition_data['identifiers'])
+            used_assignments.update(definition_data['assignments'])
 
-        for new_identifier in schema_definition.identifiers:
-            if new_identifier in used_identifiers:
-                raise InvalidSchemaIdentifier(
-                    u"The identifier '{}' is already in use.".format(
-                        new_identifier)
+        for new_assignment in schema_definition.assignments:
+            if new_assignment in used_assignments:
+                raise InvalidSchemaAssignment(
+                    u"The assignment '{}' is already in use.".format(
+                        new_assignment)
                 )
+            used_assignments.add(new_assignment)
 
         schema_definition._save(storage)
 
@@ -53,11 +54,11 @@ class PropertySheetSchemaStorage(object):
 
         return PropertySheetSchemaDefinition._load(storage, name)
 
-    def query(self, identifier):
+    def query(self, assignment):
         annotations = IAnnotations(self.context)
         storage = annotations.get(self.ANNOTATIONS_KEY, {})
         for name, definition_data in storage.items():
-            if identifier in definition_data['identifiers']:
+            if assignment in definition_data['assignments']:
                 return self.get(name)
 
         return None

--- a/opengever/propertysheets/storage.py
+++ b/opengever/propertysheets/storage.py
@@ -12,8 +12,8 @@ class PropertySheetSchemaStorage(object):
     """
     ANNOTATIONS_KEY = 'opengever.propertysheets.schema_definitions'
 
-    def __init__(self, context=None):
-        self.context = context or api.portal.get()
+    def __init__(self):
+        self.context = api.portal.get()
 
     def list(self):
         annotations = IAnnotations(self.context)

--- a/opengever/propertysheets/storage.py
+++ b/opengever/propertysheets/storage.py
@@ -1,4 +1,5 @@
 from opengever.propertysheets.definition import PropertySheetSchemaDefinition
+from opengever.propertysheets.exceptions import InvalidSchemaIdentifier
 from persistent.mapping import PersistentMapping
 from plone import api
 from zope.annotation import IAnnotations
@@ -29,6 +30,18 @@ class PropertySheetSchemaStorage(object):
             annotations[self.ANNOTATIONS_KEY] = PersistentMapping()
 
         storage = annotations[self.ANNOTATIONS_KEY]
+
+        used_identifiers = set()
+        for definition_data in storage.values():
+            used_identifiers.update(definition_data['identifiers'])
+
+        for new_identifier in schema_definition.identifiers:
+            if new_identifier in used_identifiers:
+                raise InvalidSchemaIdentifier(
+                    u"The identifier '{}' is already in use.".format(
+                        new_identifier)
+                )
+
         schema_definition._save(storage)
 
     def get(self, name):

--- a/opengever/propertysheets/tests/test_definition.py
+++ b/opengever/propertysheets/tests/test_definition.py
@@ -49,21 +49,21 @@ class TestSchemaDefinition(FunctionalTestCase):
             "No fields should be defined initially"
         )
 
-    def test_create_schema_definition_with_one_identifier(self):
+    def test_create_schema_definition_with_one_assignment(self):
         definition = PropertySheetSchemaDefinition.create(
-            "myschema", identifiers=[u"foo.bar"]
+            "myschema", assignments=[u"foo.bar"]
         )
 
         self.assertEqual("myschema", definition.name)
-        self.assertEqual((u"foo.bar",), definition.identifiers)
+        self.assertEqual((u"foo.bar",), definition.assignments)
 
-    def test_create_schema_definition_with_mulitple_identifiers(self):
+    def test_create_schema_definition_with_mulitple_assignments(self):
         definition = PropertySheetSchemaDefinition.create(
-            "myschema", identifiers=[u"foo.bar", u"qux"]
+            "myschema", assignments=[u"foo.bar", u"qux"]
         )
 
         self.assertEqual("myschema", definition.name)
-        self.assertEqual((u"foo.bar", u"qux"), definition.identifiers)
+        self.assertEqual((u"foo.bar", u"qux"), definition.assignments)
 
     def test_add_field_sets_correct_field_properties(self):
         definition = PropertySheetSchemaDefinition.create("foo")
@@ -161,7 +161,7 @@ class TestSchemaDefinition(FunctionalTestCase):
         field = definition.schema_class['bla']
         self.assertIsInstance(field, schema.TextLine)
 
-    def test_enforces_valid_identifiers_as_fieldnames(self):
+    def test_enforces_valid_assignments_as_fieldnames(self):
         definition = PropertySheetSchemaDefinition.create("foo")
 
         with self.assertRaises(InvalidFieldTypeDefinition):

--- a/opengever/propertysheets/tests/test_definition.py
+++ b/opengever/propertysheets/tests/test_definition.py
@@ -49,6 +49,22 @@ class TestSchemaDefinition(FunctionalTestCase):
             "No fields should be defined initially"
         )
 
+    def test_create_schema_definition_with_one_identifier(self):
+        definition = PropertySheetSchemaDefinition.create(
+            "myschema", identifiers=[u"foo.bar"]
+        )
+
+        self.assertEqual("myschema", definition.name)
+        self.assertEqual((u"foo.bar",), definition.identifiers)
+
+    def test_create_schema_definition_with_mulitple_identifiers(self):
+        definition = PropertySheetSchemaDefinition.create(
+            "myschema", identifiers=[u"foo.bar", u"qux"]
+        )
+
+        self.assertEqual("myschema", definition.name)
+        self.assertEqual((u"foo.bar", u"qux"), definition.identifiers)
+
     def test_add_field_sets_correct_field_properties(self):
         definition = PropertySheetSchemaDefinition.create("foo")
         definition.add_field(

--- a/opengever/propertysheets/tests/test_definition.py
+++ b/opengever/propertysheets/tests/test_definition.py
@@ -1,6 +1,41 @@
+from opengever.propertysheets.definition import isidentifier
 from opengever.propertysheets.definition import PropertySheetSchemaDefinition
+from opengever.propertysheets.exceptions import InvalidFieldTypeDefinition
 from opengever.testing.test_case import FunctionalTestCase
+from opengever.testing.test_case import TestCase
 from zope import schema
+
+
+class TestIsIdentifier(TestCase):
+
+    def test_isidentifier_truthy(self):
+        self.assertTrue(isidentifier('asd'))
+        self.assertTrue(isidentifier('asd12'))
+        self.assertTrue(isidentifier('asd_12'))
+        self.assertTrue(isidentifier('AsdASdd_12_KUX'))
+
+    def test_whitespace_is_invalid_identifier(self):
+        self.assertFalse(isidentifier(' asd'))
+        self.assertFalse(isidentifier('asd '))
+        self.assertFalse(isidentifier('as dd'))
+        self.assertFalse(isidentifier('asd\n'))
+        self.assertFalse(isidentifier('\nasd'))
+        self.assertFalse(isidentifier('\tasd'))
+
+    def test_various_other_chars_are_invalid_identifier(self):
+        self.assertFalse(isidentifier(u'f\xfc\xfc'))
+        self.assertFalse(isidentifier('a%sd'))
+        self.assertFalse(isidentifier('asd*'))
+        self.assertFalse(isidentifier('asd\\x'))
+        self.assertFalse(isidentifier('asd\\as'))
+
+    def test_cant_start_with_number(self):
+        self.assertFalse(isidentifier('1bah'))
+
+    def test_cant_be_keyword(self):
+        self.assertFalse(isidentifier('def'))
+        self.assertFalse(isidentifier('break'))
+        self.assertFalse(isidentifier('import'))
 
 
 class TestSchemaDefinition(FunctionalTestCase):
@@ -64,3 +99,11 @@ class TestSchemaDefinition(FunctionalTestCase):
         self.assertEqual(["bla"], definition.schema_class.names())
         field = definition.schema_class['bla']
         self.assertIsInstance(field, schema.TextLine)
+
+    def test_enforces_valid_identifiers_as_fieldnames(self):
+        definition = PropertySheetSchemaDefinition.create("foo")
+
+        with self.assertRaises(InvalidFieldTypeDefinition):
+            definition.add_field(
+                "bool", u"in val id!", u"", u"", True
+            )

--- a/opengever/propertysheets/tests/test_definition.py
+++ b/opengever/propertysheets/tests/test_definition.py
@@ -70,6 +70,51 @@ class TestSchemaDefinition(FunctionalTestCase):
         field = definition.schema_class['yesorno']
         self.assertIsInstance(field, schema.Bool)
 
+    def test_add_choice_field_with_simple_values(self):
+        definition = PropertySheetSchemaDefinition.create("foo")
+        choices = ['one', 'two', 'three']
+        definition.add_field(
+            "choice", u"chooseone", u"choose", u"", False, values=choices
+        )
+
+        self.assertEqual(["chooseone"], definition.schema_class.names())
+        field = definition.schema_class['chooseone']
+        self.assertIsInstance(field, schema.Choice)
+
+        voc_values = [each.value for each in field.vocabulary]
+        voc_tokens = [each.token for each in field.vocabulary]
+
+        self.assertEqual(choices, voc_values)
+        self.assertEqual(choices, voc_tokens)
+
+    def test_add_choice_field_requires_values(self):
+        definition = PropertySheetSchemaDefinition.create("foo")
+
+        with self.assertRaises(InvalidFieldTypeDefinition):
+            definition.add_field(
+                "choice", u"chooseone", u"choose", u"", False, values=None
+            )
+
+        with self.assertRaises(InvalidFieldTypeDefinition):
+            definition.add_field(
+                "choice", u"chooseone", u"choose", u"", False, values=[]
+            )
+
+    def test_add_choice_field_prevents_duplicate_values(self):
+        definition = PropertySheetSchemaDefinition.create("foo")
+        choices = ['duplicate', 'duplicate']
+        with self.assertRaises(ValueError):
+            definition.add_field(
+                "choice", u"chooseone", u"choose", u"", False, values=choices
+            )
+
+    def test_add_non_choice_field_prevents_adding_values(self):
+        definition = PropertySheetSchemaDefinition.create("foo")
+        with self.assertRaises(InvalidFieldTypeDefinition):
+            definition.add_field(
+                "int", u"num", u"A number", u"Put a number.", True, values=[1]
+            )
+
     def test_add_int_field(self):
         definition = PropertySheetSchemaDefinition.create("foo")
         definition.add_field(

--- a/opengever/propertysheets/tests/test_definition.py
+++ b/opengever/propertysheets/tests/test_definition.py
@@ -1,0 +1,66 @@
+from opengever.propertysheets.definition import PropertySheetSchemaDefinition
+from opengever.testing.test_case import FunctionalTestCase
+from zope import schema
+
+
+class TestSchemaDefinition(FunctionalTestCase):
+
+    def test_create_empty_schema_definition(self):
+        definition = PropertySheetSchemaDefinition.create("myschema")
+
+        self.assertEqual("myschema", definition.name)
+        self.assertEqual(
+            [], definition.schema_class.names(),
+            "No fields should be defined initially"
+        )
+
+    def test_add_field_sets_correct_field_properties(self):
+        definition = PropertySheetSchemaDefinition.create("foo")
+        definition.add_field(
+            "bool", u"yesorno", u"Yes or no", u"Say yes or no.", False
+        )
+
+        self.assertEqual(["yesorno"], definition.schema_class.names())
+        field = definition.schema_class['yesorno']
+
+        self.assertEqual(u'Yes or no', field.title)
+        self.assertEqual(u'Say yes or no.', field.description)
+        self.assertFalse(field.required)
+
+    def test_add_bool_field(self):
+        definition = PropertySheetSchemaDefinition.create("foo")
+        definition.add_field("bool", u"yesorno", u"y/n", u"", False)
+
+        self.assertEqual(["yesorno"], definition.schema_class.names())
+        field = definition.schema_class['yesorno']
+        self.assertIsInstance(field, schema.Bool)
+
+    def test_add_int_field(self):
+        definition = PropertySheetSchemaDefinition.create("foo")
+        definition.add_field(
+            "int", u"num", u"A number", u"Put a number.", True
+        )
+
+        self.assertEqual(["num"], definition.schema_class.names())
+        field = definition.schema_class['num']
+        self.assertIsInstance(field, schema.Int)
+
+    def test_add_text_field(self):
+        definition = PropertySheetSchemaDefinition.create("foo")
+        definition.add_field(
+            "text", u"blabla", u"Text", u"Say something long.", True
+        )
+
+        self.assertEqual(["blabla"], definition.schema_class.names())
+        field = definition.schema_class['blabla']
+        self.assertIsInstance(field, schema.Text)
+
+    def test_add_textline_field(self):
+        definition = PropertySheetSchemaDefinition.create("foo")
+        definition.add_field(
+            "textline", u"bla", u"Textline", u"Say something short.", True
+        )
+
+        self.assertEqual(["bla"], definition.schema_class.names())
+        field = definition.schema_class['bla']
+        self.assertIsInstance(field, schema.TextLine)

--- a/opengever/propertysheets/tests/test_storage.py
+++ b/opengever/propertysheets/tests/test_storage.py
@@ -1,5 +1,5 @@
 from opengever.propertysheets.definition import PropertySheetSchemaDefinition
-from opengever.propertysheets.exceptions import InvalidSchemaIdentifier
+from opengever.propertysheets.exceptions import InvalidSchemaAssignment
 from opengever.propertysheets.storage import PropertySheetSchemaStorage
 from opengever.testing.test_case import FunctionalTestCase
 from persistent.list import PersistentList
@@ -13,7 +13,7 @@ class TestPropertySheetSchemaStorage(FunctionalTestCase):
 
     def test_save_schema_definition(self):
         definition = PropertySheetSchemaDefinition.create(
-            "myschema", identifiers=["qux", "foo.bar"]
+            "myschema", assignments=["qux", "foo.bar"]
         )
         definition.add_field("bool", u"yesorno", u"y/n", u"", False)
 
@@ -32,10 +32,10 @@ class TestPropertySheetSchemaStorage(FunctionalTestCase):
             serializeSchema(definition.schema_class, name="myschema")
         )
         self.assertIsInstance(
-            serialized["myschema"]["identifiers"], PersistentList
+            serialized["myschema"]["assignments"], PersistentList
         )
         self.assertEqual(
-            ["qux", "foo.bar"], serialized["myschema"]["identifiers"]
+            ["qux", "foo.bar"], serialized["myschema"]["assignments"]
         )
         deserialized = loadString(serialized["myschema"]["schema"])
         self.assertIn("myschema", deserialized.schemata)
@@ -71,28 +71,28 @@ class TestPropertySheetSchemaStorage(FunctionalTestCase):
             ["schema1", "schema2"], [each.name for each in storage.list()]
         )
 
-    def test_prevents_duplicate_identifiers(self):
+    def test_prevents_duplicate_assignments(self):
         storage = PropertySheetSchemaStorage(self.portal)
         fixture = PropertySheetSchemaDefinition.create(
-            "fixture", identifiers=['foo', 'bar', 'qux']
+            "fixture", assignments=['foo', 'bar', 'qux']
         )
         storage.save(fixture)
 
         conflict = PropertySheetSchemaDefinition.create(
-            "conflict", identifiers=[u'foo']
+            "conflict", assignments=[u'foo']
         )
-        with self.assertRaises(InvalidSchemaIdentifier) as cm:
+        with self.assertRaises(InvalidSchemaAssignment) as cm:
             storage.save(conflict)
 
         exc = cm.exception
         self.assertEqual(
-            u"The identifier 'foo' is already in use.", exc.message
+            u"The assignment 'foo' is already in use.", exc.message
         )
 
-    def test_query_for_schema_by_identifier(self):
+    def test_query_for_schema_by_assignment(self):
         storage = PropertySheetSchemaStorage(self.portal)
         fixture = PropertySheetSchemaDefinition.create(
-            "fixture", identifiers=["foo", "bar"]
+            "fixture", assignments=["foo", "bar"]
         )
         storage.save(fixture)
 
@@ -100,6 +100,6 @@ class TestPropertySheetSchemaStorage(FunctionalTestCase):
         self.assertIsNotNone(schema)
         self.assertEqual("fixture", schema.name)
 
-    def test_query_for_nonexistent_identifier(self):
+    def test_query_for_nonexistent_assignment(self):
         storage = PropertySheetSchemaStorage(self.portal)
         self.assertIsNone(storage.query("foo"))

--- a/opengever/propertysheets/tests/test_storage.py
+++ b/opengever/propertysheets/tests/test_storage.py
@@ -17,7 +17,7 @@ class TestPropertySheetSchemaStorage(FunctionalTestCase):
         )
         definition.add_field("bool", u"yesorno", u"y/n", u"", False)
 
-        storage = PropertySheetSchemaStorage(self.portal)
+        storage = PropertySheetSchemaStorage()
         storage.save(definition)
 
         annotations = IAnnotations(self.portal)
@@ -41,11 +41,11 @@ class TestPropertySheetSchemaStorage(FunctionalTestCase):
         self.assertIn("myschema", deserialized.schemata)
 
     def test_get_inexistent_schema_definition(self):
-        storage = PropertySheetSchemaStorage(self.portal)
+        storage = PropertySheetSchemaStorage()
         self.assertIsNone(storage.get("idontexist"))
 
     def test_get_schema_definition(self):
-        storage = PropertySheetSchemaStorage(self.portal)
+        storage = PropertySheetSchemaStorage()
         definition = PropertySheetSchemaDefinition.create("myschema")
         storage.save(definition)
 
@@ -53,11 +53,11 @@ class TestPropertySheetSchemaStorage(FunctionalTestCase):
         self.assertEqual("myschema", loaded.name)
 
     def test_list_empty_storage(self):
-        storage = PropertySheetSchemaStorage(self.portal)
+        storage = PropertySheetSchemaStorage()
         self.assertEqual([], storage.list())
 
     def test_list_definitions(self):
-        storage = PropertySheetSchemaStorage(self.portal)
+        storage = PropertySheetSchemaStorage()
         definition1 = PropertySheetSchemaDefinition.create("schema1")
         definition1.add_field("bool", u"yesorno", u"y/n", u"", False)
 
@@ -72,7 +72,7 @@ class TestPropertySheetSchemaStorage(FunctionalTestCase):
         )
 
     def test_prevents_duplicate_assignments(self):
-        storage = PropertySheetSchemaStorage(self.portal)
+        storage = PropertySheetSchemaStorage()
         fixture = PropertySheetSchemaDefinition.create(
             "fixture", assignments=['foo', 'bar', 'qux']
         )
@@ -90,7 +90,7 @@ class TestPropertySheetSchemaStorage(FunctionalTestCase):
         )
 
     def test_query_for_schema_by_assignment(self):
-        storage = PropertySheetSchemaStorage(self.portal)
+        storage = PropertySheetSchemaStorage()
         fixture = PropertySheetSchemaDefinition.create(
             "fixture", assignments=["foo", "bar"]
         )
@@ -101,5 +101,5 @@ class TestPropertySheetSchemaStorage(FunctionalTestCase):
         self.assertEqual("fixture", schema.name)
 
     def test_query_for_nonexistent_assignment(self):
-        storage = PropertySheetSchemaStorage(self.portal)
+        storage = PropertySheetSchemaStorage()
         self.assertIsNone(storage.query("foo"))

--- a/opengever/propertysheets/tests/test_storage.py
+++ b/opengever/propertysheets/tests/test_storage.py
@@ -1,0 +1,60 @@
+from opengever.propertysheets.definition import PropertySheetSchemaDefinition
+from opengever.propertysheets.storage import PropertySheetSchemaStorage
+from opengever.testing.test_case import FunctionalTestCase
+from plone.supermodel import loadString
+from plone.supermodel import serializeSchema
+from zope.annotation import IAnnotations
+
+
+class TestPropertySheetSchemaStorage(FunctionalTestCase):
+
+    def test_save_schema_definition(self):
+        definition = PropertySheetSchemaDefinition.create("myschema")
+        definition.add_field("bool", u"yesorno", u"y/n", u"", False)
+
+        storage = PropertySheetSchemaStorage(self.portal)
+        storage.save(definition)
+
+        annotations = IAnnotations(self.portal)
+        self.assertIn(
+            "opengever.propertysheets.schema_definitions", annotations
+        )
+        storage = annotations["opengever.propertysheets.schema_definitions"]
+        self.assertIn("myschema", storage)
+        self.assertEqual(
+            storage["myschema"],
+            serializeSchema(definition.schema_class, name="myschema"),
+        )
+        deserialized = loadString(storage["myschema"])
+        self.assertIn("myschema", deserialized.schemata)
+
+    def test_get_inexistent_schema_definition(self):
+        storage = PropertySheetSchemaStorage(self.portal)
+        self.assertIsNone(storage.get("idontexist"))
+
+    def test_get_schema_definition(self):
+        storage = PropertySheetSchemaStorage(self.portal)
+        definition = PropertySheetSchemaDefinition.create("myschema")
+        storage.save(definition)
+
+        loaded = storage.get("myschema")
+        self.assertEqual("myschema", loaded.name)
+
+    def test_list_empty_storage(self):
+        storage = PropertySheetSchemaStorage(self.portal)
+        self.assertEqual([], storage.list())
+
+    def test_list_definitions(self):
+        storage = PropertySheetSchemaStorage(self.portal)
+        definition1 = PropertySheetSchemaDefinition.create("schema1")
+        definition1.add_field("bool", u"yesorno", u"y/n", u"", False)
+
+        definition2 = PropertySheetSchemaDefinition.create("schema2")
+        definition2.add_field("bool", u"yesorno", u"y/n", u"", False)
+
+        storage.save(definition1)
+        storage.save(definition2)
+
+        self.assertItemsEqual(
+            ["schema1", "schema2"], [each.name for each in storage.list()]
+        )

--- a/opengever/propertysheets/tests/test_storage.py
+++ b/opengever/propertysheets/tests/test_storage.py
@@ -88,3 +88,18 @@ class TestPropertySheetSchemaStorage(FunctionalTestCase):
         self.assertEqual(
             u"The identifier 'foo' is already in use.", exc.message
         )
+
+    def test_query_for_schema_by_identifier(self):
+        storage = PropertySheetSchemaStorage(self.portal)
+        fixture = PropertySheetSchemaDefinition.create(
+            "fixture", identifiers=["foo", "bar"]
+        )
+        storage.save(fixture)
+
+        schema = storage.query("bar")
+        self.assertIsNotNone(schema)
+        self.assertEqual("fixture", schema.name)
+
+    def test_query_for_nonexistent_identifier(self):
+        storage = PropertySheetSchemaStorage(self.portal)
+        self.assertIsNone(storage.query("foo"))

--- a/opengever/propertysheets/tests/test_storage.py
+++ b/opengever/propertysheets/tests/test_storage.py
@@ -1,4 +1,5 @@
 from opengever.propertysheets.definition import PropertySheetSchemaDefinition
+from opengever.propertysheets.exceptions import InvalidSchemaIdentifier
 from opengever.propertysheets.storage import PropertySheetSchemaStorage
 from opengever.testing.test_case import FunctionalTestCase
 from persistent.list import PersistentList
@@ -68,4 +69,22 @@ class TestPropertySheetSchemaStorage(FunctionalTestCase):
 
         self.assertItemsEqual(
             ["schema1", "schema2"], [each.name for each in storage.list()]
+        )
+
+    def test_prevents_duplicate_identifiers(self):
+        storage = PropertySheetSchemaStorage(self.portal)
+        fixture = PropertySheetSchemaDefinition.create(
+            "fixture", identifiers=['foo', 'bar', 'qux']
+        )
+        storage.save(fixture)
+
+        conflict = PropertySheetSchemaDefinition.create(
+            "conflict", identifiers=[u'foo']
+        )
+        with self.assertRaises(InvalidSchemaIdentifier) as cm:
+            storage.save(conflict)
+
+        exc = cm.exception
+        self.assertEqual(
+            u"The identifier 'foo' is already in use.", exc.message
         )


### PR DESCRIPTION
With this PR we implement the storage for "property sheets" in plone-site annotations and a property sheet definition helper class. Property sheets hold a custom schema definition with custom fields, and optional assignments by which they can be queried.

The initial implementation is written in a basic and simple way, so that initially it will only be usable by a `Manager`. 
Incremental edits for schemas are not yet supported, e.g. field removal or reordering. We reuse `plone.schemaeditor` functionality to provide schema editing, so these features can be amended later should they be desired.

The following features will be added as of this PR:

- Functionality to define property sheets and their schemas 
- For the schemas only a subset of all potential fields is currently supported, namely:
  -   bool
  -   choice
  -   int
  -   text
  -   textline
- Choice fields support user-defined values, but translating them is currently not possible _(This is fine and has been excluded in https://4teamwork.atlassian.net/browse/ROAD-1420)_
- Schema serialization/deserialization is handled via `plone.supermodel` XML serialization/deserialization
- A property sheet has a name, which uniquely identifies the sheet
- A property sheet can have multiple assignments. Assignments can be used to query for a sheet. The idea here is to loosely couple the sheet definition to usage in content types.
Each content type that will support property sheets/custom fields will need to lookup the schemas from the storage based on content-type specific assignents.  The idea would be to link the sheets to e.g. a field value of `IDocumentMetadata.document_type` by generating the sheet assignment based on specific field vocabulary values, for which the sheet should be active. E.g. for a sheet that should be active when the document type "Anfrage" has been selected, we would use the assignment `IDocumentMetadata.document_type.question` and perform a property sheet lookup as prototyped in https://github.com/4teamwork/opengever.core/commit/29d57b47171e8bcc3323c350dd1b1b1979cdd702. _I intitially called them identifiers, but renamed in my last commit._
- Currently assignments must be unique, a property sheet can have multiple assigments, but an assignment can only be used once. This means that in above example, we can only assign one property sheet to the field value "Anfrage", but we could use the same property sheet for multiple field values, or for different content types. Initially we will/might not use multiple assignments but i'd like to keep that option open on the storage layer.

Jira: https://4teamwork.atlassian.net/browse/CA-1304

The implementation is based on findings from a [POC](https://github.com/4teamwork/opengever.core/tree/deif/CA-1277-customfield-poc-behvaior) implementation to support custom fields.

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
