### PR TITLE
Do not update touched date of children when moving an object.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2020.16.0 (unreleased)
 ----------------------
 
+- Do not update touched date of children when moving an object. [njohner]
 - Introduces a new solr-index 'getObjPositionInParent' for tasktemplates, todolists and todos. [elioschmutz]
 - Prevent attempts to edit locked documents in Office Online. [tinagerber]
 - Add feature flag for workspace meetings. [tinagerber]

--- a/opengever/dossier/configure.zcml
+++ b/opengever/dossier/configure.zcml
@@ -210,7 +210,7 @@
   <subscriber
       for="plone.dexterity.interfaces.IDexterityContent
            zope.lifecycleevent.interfaces.IObjectMovedEvent"
-      handler=".handlers.update_dossier_touched_date"
+      handler=".handlers.update_dossier_touched_date_for_move_event"
       />
 
   <subscriber

--- a/opengever/dossier/handlers.py
+++ b/opengever/dossier/handlers.py
@@ -159,3 +159,13 @@ def update_dossier_touched_date(obj, event):
             # Prevent reindexing all indexes by indexing `UID` too.
             obj.reindexObject(idxs=['UID', 'touched'])
         obj = aq_parent(aq_inner(obj))
+
+
+def update_dossier_touched_date_for_move_event(obj, event):
+    """ObjectMovedEvent get dispatched to all children of the moved object
+    by OFS.subscribers.dispatchObjectMovedEvent. Because, we do not want
+    to set touched for all children of the moved object, we skip the update for
+    the dispatched events.
+    """
+    if obj == event.object:
+        update_dossier_touched_date(obj, event)


### PR DESCRIPTION
We do not want to update the touched date of the children of an object that is moved. This is both wrong and leads to errors in the indexing, probably because `IObjectMovedEvent` gets dispatched to all children and in the touched handler we propagate the update of touched to all parents...

For https://4teamwork.atlassian.net/browse/CA-1395

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
