### PR TITLE
Add REST-API endpoints for property sheet schema storage.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,7 @@ Changelog
 - Initialize English translations. [lgraf]
 - Add getObjPositionInParent and preselected field to listing endpoint. [elioschmutz]
 - Add 'en-us' as supported language in example content. [lgraf]
+- Implement API to create, list and delete property sheet schema definitions. [deiferni]
 - Implement storage for property sheet schemas in plone-site annotations. [deiferni]
 
 

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -16,7 +16,7 @@ Breaking Changes
 Other Changes
 ^^^^^^^^^^^^^
 
-- No changes yet
+- A new endpoint ``@propertysheets`` is added (see :ref:`docs <propertysheets>`).
 
 
 2021.1.0 (2021-01-06)

--- a/docs/public/dev-manual/api/index.rst
+++ b/docs/public/dev-manual/api/index.rst
@@ -27,6 +27,7 @@ Inhalt:
    vocabularies.rst
    scanin.rst
    content_types.rst
+   propertysheets.rst
    metadata.rst
    config.rst
    favorite.rst

--- a/docs/public/dev-manual/api/propertysheets.rst
+++ b/docs/public/dev-manual/api/propertysheets.rst
@@ -1,0 +1,125 @@
+.. _propertysheets:
+
+Property Sheets (Benutzerdefinierte Felder)
+===========================================
+
+Mittels Property Sheets ist es möglich benutzerdefinierte Schemata mit einem
+oder mehreren Feldern zu definieren damit zusätzliche Properties in GEVER
+strukturiert erfasst werden können.
+
+Im Moment ist das Definieren der zusätzlichen Property Sheets einem ``Manager``
+vorbehalten. Hierzu steht der Service-Endpoint ``@propertysheets`` zur
+Verfügung. Folgende Aufrufe sind möglich:
+
+Eine Liste aller bestehender Property Sheets:
+
+.. sourcecode:: http
+
+  GET /@propertysheets HTTP/1.1
+
+
+Schema eines Property Sheets:
+
+.. sourcecode:: http
+
+  GET /@propertysheets/<property_sheet_name> HTTP/1.1
+
+
+Hinzufügen eines neuen Property Sheets oder Überschreiben eines bestehenden
+Property Sheets:
+
+.. sourcecode:: http
+
+  POST /@propertysheets/<property_sheet_name> HTTP/1.1
+
+
+Löschen eines bestehenden Property Sheets:
+
+.. sourcecode:: http
+
+  DELETE /@propertysheets/<property_sheet_name> HTTP/1.1
+
+
+Neue Property Sheets erstellen
+------------------------------
+
+Neue Property Sheets können mittels POST Request hinzugefügt werden. Im Moment
+sind keine Inkrementellen Updates der Sheets mittels ``PATCH`` unterstützt.
+Ein Sheet kann immer nur als gesamte Einheit gespeichert werden. Existiert
+schon ein Sheet mit dem verwendeten Namen, so wird dieses überschrieben.
+
+Zum Erstellen eines Property Sheets muss man die gewünschten Felder und
+Assignments angeben.
+
+Der JSON-Attributname des einzelnen Feldes wird als Feld-identifier verwendet.
+Einzelne Felder werden in folgendem Format erwartet:
+
+- ``field_type``: Der Feldtyp, folgende Typen sind unterstützt:
+
+  - ``bool``
+  - ``choice``
+  - ``int``
+  - ``text``
+  - ``textline``
+
+- ``title``: Der Titel des Feldes
+- ``description``: Die Beschreibung des Feldes
+- ``required``: Ob das Feld erforderlich ist
+- ``values``: Auswahlmöglichkeiten für das Feld, nur für ``choice`` Feldtyp
+
+Assignments müssen aus dem Vokabular
+``opengever.propertysheets.PropertySheetAssignmentsVocabulary`` stammen. Zudem
+müssen Assignments eindeutig sein, mehrere Property Sheets für das gleiche
+Assignment sind im Moment nicht unterstützt.
+
+
+**Beispiel-Request**:
+
+.. sourcecode:: http
+
+  POST http://localhost:8080/fd/@propertysheets/question HTTP/1.1
+  Accept: application/json
+
+  {
+    "fields": {
+      "foo": {
+        "field_type": "bool",
+        "title": "Y/N",
+        "description": "yes or no",
+        "required": true
+      }
+    },
+    "assignments": ["IDocumentMetadata.document_type.question"]
+  }
+
+
+**Beispiel-Response**:
+
+.. sourcecode:: http
+
+  HTTP/1.1 201 Created
+  Content-Type: application/json+schema
+  Location: /@propertysheets/question
+
+  {
+      "assignments": ["IDocumentMetadata.document_type.question"],
+      "fieldsets": [
+          {
+              "behavior": "plone",
+              "fields": ["foo"],
+              "id": "default",
+              "title": "Default"
+          }
+      ],
+      "properties": {
+          "foo": {
+              "description": "yes or no",
+              "factory": "Yes/No",
+              "title": "Y/N",
+              "type": "boolean"
+          }
+      },
+      "required": ["foo"],
+      "title": "question",
+      "type": "object"
+  }

--- a/opengever/api/tests/test_vocabularies.py
+++ b/opengever/api/tests/test_vocabularies.py
@@ -49,6 +49,7 @@ NON_SENSITIVE_VOCABUALRIES = [
     'opengever.ogds.base.AssignedClientsVocabulary',
     'opengever.ogds.base.OrgUnitsVocabularyFactory',
     'opengever.ogds.base.OtherAssignedClientsVocabulary',
+    'opengever.propertysheets.PropertySheetAssignmentsVocabulary',
     'opengever.repository.RestrictedAddableDossiersVocabulary',
     'opengever.task.attachable_documents_vocabulary',
     'opengever.task.bidirectional_by_reference',

--- a/opengever/propertysheets/api/configure.zcml
+++ b/opengever/propertysheets/api/configure.zcml
@@ -9,6 +9,15 @@
   <include package="plone.restapi" file="permissions.zcml" />
 
   <plone:service
+      method="GET"
+      for="Products.CMFPlone.interfaces.IPloneSiteRoot"
+      factory=".get.PropertySheetsGet"
+      name="@propertysheets"
+      layer="opengever.base.interfaces.IOpengeverBaseLayer"
+      permission="zope2.View"
+      />
+
+  <plone:service
       method="POST"
       for="Products.CMFPlone.interfaces.IPloneSiteRoot"
       factory=".post.PropertySheetsPost"

--- a/opengever/propertysheets/api/configure.zcml
+++ b/opengever/propertysheets/api/configure.zcml
@@ -17,4 +17,13 @@
       permission="cmf.ManagePortal"
       />
 
+  <plone:service
+      method="DELETE"
+      for="Products.CMFPlone.interfaces.IPloneSiteRoot"
+      factory=".delete.PropertySheetsDelete"
+      name="@propertysheets"
+      layer="opengever.base.interfaces.IOpengeverBaseLayer"
+      permission="cmf.ManagePortal"
+      />
+
 </configure>

--- a/opengever/propertysheets/api/configure.zcml
+++ b/opengever/propertysheets/api/configure.zcml
@@ -1,0 +1,20 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:plone="http://namespaces.plone.org/plone"
+    xmlns:zcml="http://namespaces.zope.org/zcml"
+    xmlns:i18n="http://namespaces.zope.org/i18n"
+    i18n_domain="opengever.propertysheets">
+
+  <include package="plone.rest" file="meta.zcml" />
+  <include package="plone.restapi" file="permissions.zcml" />
+
+  <plone:service
+      method="POST"
+      for="Products.CMFPlone.interfaces.IPloneSiteRoot"
+      factory=".post.PropertySheetsPost"
+      name="@propertysheets"
+      layer="opengever.base.interfaces.IOpengeverBaseLayer"
+      permission="cmf.ManagePortal"
+      />
+
+</configure>

--- a/opengever/propertysheets/api/delete.py
+++ b/opengever/propertysheets/api/delete.py
@@ -1,0 +1,37 @@
+from opengever.propertysheets.storage import PropertySheetSchemaStorage
+from plone.protect.interfaces import IDisableCSRFProtection
+from plone.restapi.services import Service
+from zExceptions import BadRequest
+from zope.interface import alsoProvides
+from zope.interface import implementer
+from zope.publisher.interfaces import IPublishTraverse
+
+
+@implementer(IPublishTraverse)
+class PropertySheetsDelete(Service):
+    """
+    Delete existing property sheets.
+
+    DELETE http://localhost:8080/fd/@propertysheets/<sheet-name> HTTP/1.1
+    """
+    def __init__(self, context, request):
+        super(PropertySheetsDelete, self).__init__(context, request)
+        self.params = []
+        self.storage = PropertySheetSchemaStorage()
+
+    def publishTraverse(self, request, name):
+        self.params.append(name)
+        return self
+
+    def reply(self):
+        if len(self.params) != 1:
+            raise BadRequest(u"Missing parameter sheet_name.")
+
+        alsoProvides(self.request, IDisableCSRFProtection)
+
+        sheet_name = self.params.pop()
+        if sheet_name not in self.storage:
+            raise BadRequest(u"The property sheet '{}' does not exist.".format(sheet_name))
+
+        self.storage.remove(sheet_name)
+        self.reply_no_content()

--- a/opengever/propertysheets/api/get.py
+++ b/opengever/propertysheets/api/get.py
@@ -1,0 +1,66 @@
+from opengever.propertysheets.storage import PropertySheetSchemaStorage
+from plone.restapi.services import Service
+from zExceptions import BadRequest
+from zope.interface import implementer
+from zope.publisher.interfaces import IPublishTraverse
+
+
+@implementer(IPublishTraverse)
+class PropertySheetsGet(Service):
+    """
+    Return a list of all registered sheets or the schema for a single sheet.
+
+    A list of all sheets can be obtained with no additional path segments:
+
+    GET http://localhost:8080/fd/@propertysheets HTTP/1.1
+
+    The schema for a single sheet can be obtained by using the name of the
+    sheet in the request path:
+
+    GET http://localhost:8080/fd/@propertysheets/<sheet-name> HTTP/1.1
+    """
+
+    def __init__(self, context, request):
+        super(PropertySheetsGet, self).__init__(context, request)
+        self.params = []
+
+    def publishTraverse(self, request, name):
+        self.params.append(name)
+        return self
+
+    def reply(self):
+        if not self.params:
+            return self.reply_list_all_sheets()
+
+        elif len(self.params) == 1:
+            return self.reply_for_sheet()
+
+        raise BadRequest(u"Must supply either zero or one parameters.")
+
+    def reply_list_all_sheets(self):
+        storage = PropertySheetSchemaStorage()
+
+        base_url = "{}/@propertysheets".format(self.context.absolute_url())
+        result = {"@id": base_url, "items": []}
+        for schema_definition in storage.list():
+            sheet_definition = {
+                "@id": "{}/{}".format(base_url, schema_definition.name)
+            }
+            result["items"].append(sheet_definition)
+        return result
+
+    def reply_for_sheet(self):
+        sheet_name = self.params.pop()
+        storage = PropertySheetSchemaStorage()
+
+        schema_definition = storage.get(sheet_name)
+        if schema_definition is None:
+            self.request.response.setStatus(404)
+            return {
+                "type": "NotFound",
+                "message": u"Sheet '{}' not found.".format(sheet_name),
+            }
+
+        json_schema = schema_definition.get_json_schema()
+        self.content_type = "application/json+schema"
+        return json_schema

--- a/opengever/propertysheets/assignment.py
+++ b/opengever/propertysheets/assignment.py
@@ -1,0 +1,25 @@
+from zope.component import getUtility
+from zope.interface import implementer
+from zope.schema.interfaces import IVocabularyFactory
+from zope.schema.vocabulary import SimpleTerm
+from zope.schema.vocabulary import SimpleVocabulary
+
+
+@implementer(IVocabularyFactory)
+class PropertySheetAssignmentVocabulary(object):
+    """Return valid property sheet assignments."""
+
+    def __call__(self, context):
+        vocabulary_factory = getUtility(
+            IVocabularyFactory, name="opengever.document.document_types"
+        )
+        document_types_vocabulary = vocabulary_factory(context)
+
+        assignment_terms = []
+        for term in document_types_vocabulary:
+            name = u"IDocumentMetadata.document_type.{}".format(
+                term.value
+            )
+            assignment_terms.append(SimpleTerm(name))
+
+        return SimpleVocabulary(assignment_terms)

--- a/opengever/propertysheets/configure.zcml
+++ b/opengever/propertysheets/configure.zcml
@@ -14,4 +14,9 @@
       name="propertysheets"
       />
 
+  <utility
+      factory=".assignment.PropertySheetAssignmentVocabulary"
+      name="opengever.propertysheets.PropertySheetAssignmentsVocabulary"
+      />
+
 </configure>

--- a/opengever/propertysheets/configure.zcml
+++ b/opengever/propertysheets/configure.zcml
@@ -7,6 +7,8 @@
     xmlns:z3c="http://namespaces.zope.org/z3c"
     i18n_domain="opengever.propertysheets">
 
+  <include package=".api" />
+
   <utility
       factory=".schemapolicy.PropertySheetSchemaPolicy"
       name="propertysheets"

--- a/opengever/propertysheets/definition.py
+++ b/opengever/propertysheets/definition.py
@@ -45,6 +45,7 @@ class PropertySheetSchemaDefinition(object):
 
         class SchemaClass(model.Schema):
             pass
+        SchemaClass.__name__ = name
 
         return cls(name, SchemaClass, assignments=assignments)
 

--- a/opengever/propertysheets/definition.py
+++ b/opengever/propertysheets/definition.py
@@ -1,8 +1,10 @@
 from opengever.base.filename import filenamenormalizer
 from opengever.propertysheets.exceptions import InvalidFieldType
 from opengever.propertysheets.exceptions import InvalidFieldTypeDefinition
+from opengever.propertysheets.schema import get_property_sheet_schema
 from persistent.list import PersistentList
 from persistent.mapping import PersistentMapping
+from plone.restapi.serializer.converters import IJsonCompatible
 from plone.schemaeditor import fields
 from plone.schemaeditor.utils import IEditableSchema
 from plone.supermodel import loadString
@@ -93,6 +95,11 @@ class PropertySheetSchemaDefinition(object):
         field = factory(**properties)
         schema = IEditableSchema(self.schema_class)
         schema.addField(field)
+
+    def get_json_schema(self):
+        schema_info = get_property_sheet_schema(self.schema_class)
+        schema_info["assignments"] = IJsonCompatible(self.assignments)
+        return schema_info
 
     def _save(self, storage):
         serialized_schema = serializeSchema(self.schema_class, name=self.name)

--- a/opengever/propertysheets/schema.py
+++ b/opengever/propertysheets/schema.py
@@ -1,0 +1,36 @@
+from plone.restapi.serializer.converters import IJsonCompatible
+from plone.restapi.types.utils import get_fieldset_infos
+from plone.restapi.types.utils import get_fieldsets
+from plone.restapi.types.utils import get_jsonschema_properties
+from plone.restapi.types.utils import iter_fields
+from zope.globalrequest import getRequest
+
+
+def get_property_sheet_schema(schema_class):
+    context = None
+    request = getRequest()
+
+    fieldsets = get_fieldsets(context, request, schema_class)
+    properties = get_jsonschema_properties(context, request, fieldsets)
+    # sanitize properties, prevent invalid vocabulary/source `@id`s
+    for property in properties.itervalues():
+        property.pop('vocabulary', None)
+        property.pop('querysource', None)
+
+    required = []
+    for field in iter_fields(fieldsets):
+        name = field.field.getName()
+        # Determine required fields
+        if field.field.required:
+            required.append(name)
+
+    schema_info = {
+        "type": "object",
+        "title": schema_class.getName(),
+        "properties": IJsonCompatible(properties),
+        "fieldsets": get_fieldset_infos(fieldsets),
+    }
+    if required:
+        schema_info["required"] = required
+
+    return schema_info

--- a/opengever/propertysheets/storage.py
+++ b/opengever/propertysheets/storage.py
@@ -15,6 +15,12 @@ class PropertySheetSchemaStorage(object):
     def __init__(self):
         self.context = api.portal.get()
 
+    def __contains__(self, name):
+        annotations = IAnnotations(self.context)
+        storage = annotations.get(self.ANNOTATIONS_KEY, {})
+
+        return name in storage
+
     def list(self):
         annotations = IAnnotations(self.context)
 
@@ -62,3 +68,8 @@ class PropertySheetSchemaStorage(object):
                 return self.get(name)
 
         return None
+
+    def remove(self, name):
+        annotations = IAnnotations(self.context)
+        storage = annotations.get(self.ANNOTATIONS_KEY, {})
+        storage.pop(name, None)

--- a/opengever/propertysheets/tests/test_assignment.py
+++ b/opengever/propertysheets/tests/test_assignment.py
@@ -1,0 +1,25 @@
+from opengever.testing.test_case import FunctionalTestCase
+from zope.component import getUtility
+from zope.schema.interfaces import IVocabularyFactory
+
+
+class TestPropertySheetAssignmentVocabulary(FunctionalTestCase):
+    def test_assignemnt_vocabulary_contains_document_types(self):
+        vocabulary = getUtility(
+            IVocabularyFactory,
+            name="opengever.propertysheets.PropertySheetAssignmentsVocabulary",
+        )(self.portal)
+
+        self.assertEqual(
+            [
+                u"IDocumentMetadata.document_type.contract",
+                u"IDocumentMetadata.document_type.directive",
+                u"IDocumentMetadata.document_type.offer",
+                u"IDocumentMetadata.document_type.protocol",
+                u"IDocumentMetadata.document_type.question",
+                u"IDocumentMetadata.document_type.regulations",
+                u"IDocumentMetadata.document_type.report",
+                u"IDocumentMetadata.document_type.request",
+            ],
+            [term.value for term in vocabulary],
+        )

--- a/opengever/propertysheets/tests/test_definition.py
+++ b/opengever/propertysheets/tests/test_definition.py
@@ -60,19 +60,31 @@ class TestSchemaDefinition(FunctionalTestCase):
 
     def test_create_schema_definition_with_one_assignment(self):
         definition = PropertySheetSchemaDefinition.create(
-            "myschema", assignments=[u"foo.bar"]
+            "myschema",
+            assignments=[u"IDocumentMetadata.document_type.contract"]
         )
 
         self.assertEqual("myschema", definition.name)
-        self.assertEqual((u"foo.bar",), definition.assignments)
+        self.assertEqual(
+            (u"IDocumentMetadata.document_type.contract",),
+            definition.assignments
+        )
 
     def test_create_schema_definition_with_mulitple_assignments(self):
         definition = PropertySheetSchemaDefinition.create(
-            "myschema", assignments=[u"foo.bar", u"qux"]
+            "myschema",
+            assignments=[
+                u"IDocumentMetadata.document_type.contract",
+                u"IDocumentMetadata.document_type.question"
+            ]
         )
 
         self.assertEqual("myschema", definition.name)
-        self.assertEqual((u"foo.bar", u"qux"), definition.assignments)
+        self.assertEqual(
+            (u"IDocumentMetadata.document_type.contract",
+             u"IDocumentMetadata.document_type.question"),
+            definition.assignments
+        )
 
     def test_add_field_sets_correct_field_properties(self):
         definition = PropertySheetSchemaDefinition.create("foo")

--- a/opengever/propertysheets/tests/test_definition.py
+++ b/opengever/propertysheets/tests/test_definition.py
@@ -1,3 +1,4 @@
+from opengever.propertysheets.definition import ascii_token
 from opengever.propertysheets.definition import isidentifier
 from opengever.propertysheets.definition import PropertySheetSchemaDefinition
 from opengever.propertysheets.exceptions import InvalidFieldTypeDefinition
@@ -36,6 +37,14 @@ class TestIsIdentifier(TestCase):
         self.assertFalse(isidentifier('def'))
         self.assertFalse(isidentifier('break'))
         self.assertFalse(isidentifier('import'))
+
+
+class TestAsciiToken(TestCase):
+
+    def test_ascii_token(self):
+        self.assertEqual(u'ue', ascii_token(u'\xfc'))
+        self.assertEqual(u'aa bb', ascii_token(u'aa bb'))
+        self.assertEqual(u'ueasd asd', ascii_token(u'\xfcasd//%asd'))
 
 
 class TestSchemaDefinition(FunctionalTestCase):
@@ -98,10 +107,31 @@ class TestSchemaDefinition(FunctionalTestCase):
         self.assertIsInstance(field, schema.Choice)
 
         voc_values = [each.value for each in field.vocabulary]
+        voc_titles = [each.token for each in field.vocabulary]
         voc_tokens = [each.token for each in field.vocabulary]
 
         self.assertEqual(choices, voc_values)
+        self.assertEqual(choices, voc_titles)
         self.assertEqual(choices, voc_tokens)
+
+    def test_add_choice_field_with_unicode_values(self):
+        definition = PropertySheetSchemaDefinition.create("foo")
+        choices = [u"bl\xe4h", u"blub"]
+        definition.add_field(
+            "choice", u"chooseone", u"choose", u"", False, values=choices
+        )
+
+        self.assertEqual(["chooseone"], definition.schema_class.names())
+        field = definition.schema_class["chooseone"]
+        self.assertIsInstance(field, schema.Choice)
+
+        voc_values = [each.value for each in field.vocabulary]
+        voc_titles = [each.title for each in field.vocabulary]
+        voc_tokens = [each.token for each in field.vocabulary]
+
+        self.assertEqual([u"bl\xe4h", u"blub"], voc_values)
+        self.assertEqual([u"bl\xe4h", u"blub"], voc_titles)
+        self.assertEqual([u"blaeh", "blub"], voc_tokens)
 
     def test_add_choice_field_requires_values(self):
         definition = PropertySheetSchemaDefinition.create("foo")
@@ -119,6 +149,15 @@ class TestSchemaDefinition(FunctionalTestCase):
     def test_add_choice_field_prevents_duplicate_values(self):
         definition = PropertySheetSchemaDefinition.create("foo")
         choices = ['duplicate', 'duplicate']
+        with self.assertRaises(ValueError):
+            definition.add_field(
+                "choice", u"chooseone", u"choose", u"", False, values=choices
+            )
+
+    def test_add_choice_field_prevents_duplicate_tokens(self):
+        """Use two different values which are normalized to the same tokens."""
+        definition = PropertySheetSchemaDefinition.create("foo")
+        choices = ['dupli cate', 'dupli\\cate']
         with self.assertRaises(ValueError):
             definition.add_field(
                 "choice", u"chooseone", u"choose", u"", False, values=choices

--- a/opengever/propertysheets/tests/test_schema.py
+++ b/opengever/propertysheets/tests/test_schema.py
@@ -9,7 +9,7 @@ class TestPropertySheetJSONSchema(FunctionalTestCase):
 
     def test_validate_simple_property_sheet_schema_definition(self):
         definition = PropertySheetSchemaDefinition.create(
-            "schema", assignments=[u"foo.bar"]
+            "schema", assignments=[u"IDocumentMetadata.document_type.question"]
         )
         definition.add_field("bool", u"yesorno", u"y/n", u"", False)
         choices = [u"bl\xe4h", u"bl\xfcb"]
@@ -22,7 +22,7 @@ class TestPropertySheetJSONSchema(FunctionalTestCase):
 
         self.assertEqual(
             {
-                u"assignments": [u"foo.bar"],
+                u"assignments": [u"IDocumentMetadata.document_type.question"],
                 u"fieldsets": [
                     {
                         u"behavior": u"plone",
@@ -60,7 +60,7 @@ class TestPropertySheetJSONSchema(FunctionalTestCase):
 
     def test_validate_complex_sheet_schema_with_all_supported_fields(self):
         definition = PropertySheetSchemaDefinition.create(
-            "schema", assignments=[u"foo.bar"]
+            "schema", assignments=[u"IDocumentMetadata.document_type.question"]
         )
         definition.add_field("bool", u"yesorno", u"y/n", u"", False)
         choices = [u"bl\xe4h", u"blub"]

--- a/opengever/propertysheets/tests/test_schema.py
+++ b/opengever/propertysheets/tests/test_schema.py
@@ -1,0 +1,81 @@
+from jsonschema import Draft4Validator
+from opengever.propertysheets.definition import PropertySheetSchemaDefinition
+from opengever.testing import FunctionalTestCase
+
+
+class TestPropertySheetJSONSchema(FunctionalTestCase):
+
+    maxDiff = None
+
+    def test_validate_simple_property_sheet_schema_definition(self):
+        definition = PropertySheetSchemaDefinition.create(
+            "schema", assignments=[u"foo.bar"]
+        )
+        definition.add_field("bool", u"yesorno", u"y/n", u"", False)
+        choices = [u"bl\xe4h", u"bl\xfcb"]
+        definition.add_field(
+            "choice", u"choose", u"Usw\xe4hle", u"", True, values=choices
+        )
+
+        json_schema = definition.get_json_schema()
+        Draft4Validator.check_schema(json_schema)
+
+        self.assertEqual(
+            {
+                u"assignments": [u"foo.bar"],
+                u"fieldsets": [
+                    {
+                        u"behavior": u"plone",
+                        u"fields": [u"yesorno", u"choose"],
+                        u"id": u"default",
+                        u"title": u"Default",
+                    }
+                ],
+                u"properties": {
+                    u"choose": {
+                        u"choices": [
+                            [u"blaeh", u"bl\xe4h"],
+                            [u"blueb", u"bl\xfcb"]
+                        ],
+                        u"description": u"",
+                        u"enum": [u"blaeh", u"blueb"],
+                        u"enumNames": [u"bl\xe4h", u"bl\xfcb"],
+                        u"factory": u"Choice",
+                        u"title": u"Usw\xe4hle",
+                        u"type": u"string",
+                    },
+                    u"yesorno": {
+                        u"description": u"",
+                        u"factory": u"Yes/No",
+                        u"title": u"y/n",
+                        u"type": u"boolean",
+                    },
+                },
+                u"required": [u"choose"],
+                u"title": u"schema",
+                u"type": u"object",
+            },
+            json_schema
+        )
+
+    def test_validate_complex_sheet_schema_with_all_supported_fields(self):
+        definition = PropertySheetSchemaDefinition.create(
+            "schema", assignments=[u"foo.bar"]
+        )
+        definition.add_field("bool", u"yesorno", u"y/n", u"", False)
+        choices = [u"bl\xe4h", u"blub"]
+        definition.add_field(
+            "choice", u"chooseone", u"choose", u"", False, values=choices
+        )
+        definition.add_field(
+            "int", u"num", u"A number", u"Put a number.", True
+        )
+        definition.add_field(
+            "text", u"blabla", u"Text", u"Say something long.", True
+        )
+        definition.add_field(
+            "textline", u"bla", u"Textline", u"Say something short.", True
+        )
+
+        json_schema = definition.get_json_schema()
+        Draft4Validator.check_schema(json_schema)

--- a/opengever/propertysheets/tests/test_schema_definition_delete.py
+++ b/opengever/propertysheets/tests/test_schema_definition_delete.py
@@ -1,0 +1,78 @@
+from ftw.testbrowser import browsing
+from opengever.propertysheets.definition import PropertySheetSchemaDefinition
+from opengever.propertysheets.storage import PropertySheetSchemaStorage
+from opengever.testing import IntegrationTestCase
+
+
+class TestSchemaDefinitionDelete(IntegrationTestCase):
+
+    @browsing
+    def test_property_sheet_schema_definition_delete_existing_schema(self, browser):
+        self.login(self.manager, browser)
+
+        sheet = PropertySheetSchemaDefinition.create("sheet")
+        storage = PropertySheetSchemaStorage()
+        storage.save(sheet)
+
+        browser.open(
+            view="@propertysheets/sheet", method="DELETE", headers=self.api_headers
+        )
+        self.assertEqual(browser.status_code, 204)
+        self.assertEqual([], storage.list())
+
+    @browsing
+    def test_property_sheet_schema_definition_delete_requires_name(
+        self, browser
+    ):
+        self.login(self.manager, browser)
+
+        with browser.expect_http_error(400):
+            browser.open(
+                view="@propertysheets",
+                method="DELETE",
+                headers=self.api_headers,
+            )
+
+        self.assertDictContainsSubset(
+            {
+                u"message": u"Missing parameter sheet_name.",
+                "type": "BadRequest",
+            },
+            browser.json,
+        )
+
+    @browsing
+    def test_property_sheet_schema_definition_delete_requires_valid_sheet(
+        self, browser
+    ):
+        self.login(self.manager, browser)
+
+        with browser.expect_http_error(400):
+            browser.open(
+                view="@propertysheets/idontexist",
+                method="DELETE",
+                headers=self.api_headers,
+            )
+
+        self.assertDictContainsSubset(
+            {
+                u"message": u"The property sheet 'idontexist' does not exist.",
+                "type": "BadRequest",
+            },
+            browser.json,
+        )
+
+    @browsing
+    def test_non_managers_cannot_delete(self, browser):
+        self.login(self.administrator, browser)
+
+        sheet = PropertySheetSchemaDefinition.create("sheet")
+        storage = PropertySheetSchemaStorage()
+        storage.save(sheet)
+
+        with browser.expect_unauthorized():
+            browser.open(
+                view="@propertysheets/sheet",
+                method="DELETE",
+                headers=self.api_headers,
+            )

--- a/opengever/propertysheets/tests/test_schema_definition_get.py
+++ b/opengever/propertysheets/tests/test_schema_definition_get.py
@@ -1,0 +1,158 @@
+from ftw.testbrowser import browsing
+from jsonschema import Draft4Validator
+from opengever.propertysheets.definition import PropertySheetSchemaDefinition
+from opengever.propertysheets.storage import PropertySheetSchemaStorage
+from opengever.testing import IntegrationTestCase
+
+
+class TestSchemaDefinitionGet(IntegrationTestCase):
+
+    maxDiff = None
+
+    @browsing
+    def test_property_sheet_schema_definition_get_empty_list(self, browser):
+        self.login(self.regular_user, browser)
+
+        browser.open(
+            view="@propertysheets", method="GET", headers=self.api_headers
+        )
+        self.assertEqual(
+            {
+                u"items": [],
+                u"@id": u"http://nohost/plone/@propertysheets",
+            },
+            browser.json,
+        )
+
+    @browsing
+    def test_property_sheet_schema_definition_get_list(self, browser):
+        self.login(self.regular_user, browser)
+
+        definition1 = PropertySheetSchemaDefinition.create("schema1")
+        definition2 = PropertySheetSchemaDefinition.create("schema2")
+
+        storage = PropertySheetSchemaStorage()
+        storage.save(definition1)
+        storage.save(definition2)
+
+        browser.open(
+            view="@propertysheets", method="GET", headers=self.api_headers
+        )
+        self.assertEqual(
+            {
+                u"@id": u"http://nohost/plone/@propertysheets",
+                u"items": [
+                    {u"@id": u"http://nohost/plone/@propertysheets/schema1"},
+                    {u"@id": u"http://nohost/plone/@propertysheets/schema2"},
+                ],
+            },
+            browser.json,
+        )
+
+    @browsing
+    def test_property_sheet_schema_definition_get_sheet_schema(self, browser):
+        self.login(self.regular_user, browser)
+
+        definition = PropertySheetSchemaDefinition.create(
+            "schema", assignments=[u"foo.bar"]
+        )
+        definition.add_field("bool", u"yesorno", u"y/n", u"", False)
+        choices = ["one", "two", "three"]
+        definition.add_field(
+            "choice", u"chooseone", u"choose", u"", False, values=choices
+        )
+        storage = PropertySheetSchemaStorage()
+        storage.save(definition)
+
+        browser.open(
+            view="@propertysheets/schema",
+            method="GET",
+            headers=self.api_headers,
+        )
+
+        self.assertEqual(
+            {
+                u"assignments": [u"foo.bar"],
+                u"fieldsets": [
+                    {
+                        u"behavior": u"plone",
+                        u"fields": [u"yesorno", u"chooseone"],
+                        u"id": u"default",
+                        u"title": u"Default",
+                    }
+                ],
+                u"properties": {
+                    u"chooseone": {
+                        u"choices": [
+                            [u"one", u"one"],
+                            [u"two", u"two"],
+                            [u"three", u"three"],
+                        ],
+                        u"description": u"",
+                        u"enum": [u"one", u"two", u"three"],
+                        u"enumNames": [u"one", u"two", u"three"],
+                        u"factory": u"Choice",
+                        u"title": u"choose",
+                        u"type": u"string",
+                    },
+                    u"yesorno": {
+                        u"description": u"",
+                        u"factory": u"Yes/No",
+                        u"title": u"y/n",
+                        u"type": u"boolean",
+                    },
+                },
+                u"title": u"schema",
+                u"type": u"object",
+            },
+            browser.json,
+        )
+        self.assertEqual("application/json+schema", browser.mimetype)
+        Draft4Validator.check_schema(browser.json)
+
+    @browsing
+    def test_property_sheet_schema_definition_get_404(self, browser):
+        self.login(self.regular_user, browser)
+
+        with browser.expect_http_error(404):
+            browser.open(
+                view="@propertysheets/idonotexist",
+                method="GET",
+                headers=self.api_headers
+            )
+
+        self.assertDictContainsSubset(
+            {
+                u"message": u"Sheet 'idonotexist' not found.",
+                "type": "NotFound",
+            },
+            browser.json,
+        )
+
+    @browsing
+    def test_property_sheet_schema_definition_get_too_many_path_segments(self, browser):
+        self.login(self.regular_user, browser)
+
+        with browser.expect_http_error(400):
+            browser.open(
+                view="@propertysheets/foo/bar",
+                method="GET",
+                headers=self.api_headers
+            )
+
+        self.assertDictContainsSubset(
+            {
+                u"message": u"Must supply either zero or one parameters.",
+                "type": "BadRequest",
+            },
+            browser.json,
+        )
+
+    @browsing
+    def test_anonymous_cannot_get_property_sheets(self, browser):
+        with browser.expect_unauthorized():
+            browser.open(
+                view="@propertysheets",
+                method="GET",
+                headers=self.api_headers
+            )

--- a/opengever/propertysheets/tests/test_schema_definition_get.py
+++ b/opengever/propertysheets/tests/test_schema_definition_get.py
@@ -54,7 +54,7 @@ class TestSchemaDefinitionGet(IntegrationTestCase):
         self.login(self.regular_user, browser)
 
         definition = PropertySheetSchemaDefinition.create(
-            "schema", assignments=[u"foo.bar"]
+            "schema", assignments=[u"IDocumentMetadata.document_type.question"]
         )
         definition.add_field("bool", u"yesorno", u"y/n", u"", False)
         choices = ["one", "two", "three"]
@@ -72,7 +72,7 @@ class TestSchemaDefinitionGet(IntegrationTestCase):
 
         self.assertEqual(
             {
-                u"assignments": [u"foo.bar"],
+                u"assignments": [u"IDocumentMetadata.document_type.question"],
                 u"fieldsets": [
                     {
                         u"behavior": u"plone",

--- a/opengever/propertysheets/tests/test_schema_definition_post.py
+++ b/opengever/propertysheets/tests/test_schema_definition_post.py
@@ -1,0 +1,310 @@
+from ftw.testbrowser import browsing
+from opengever.propertysheets.definition import PropertySheetSchemaDefinition
+from opengever.propertysheets.storage import PropertySheetSchemaStorage
+from opengever.testing import IntegrationTestCase
+from zope import schema
+import json
+
+
+class TestSchemaDefinitionPost(IntegrationTestCase):
+
+    maxDiff = None
+
+    @browsing
+    def test_property_sheet_schema_definition_post_defaults(self, browser):
+        self.login(self.manager, browser)
+
+        data = {"fields": {"foo": {"field_type": "text"}}}
+        browser.open(
+            view="@propertysheets/question",
+            method="POST",
+            data=json.dumps(data),
+            headers=self.api_headers,
+        )
+        storage = PropertySheetSchemaStorage()
+        self.assertEqual(1, len(storage.list()))
+        definition = storage.get("question")
+
+        self.assertEqual("question", definition.name)
+        schema_class = definition.schema_class
+
+        self.assertEqual(["foo"], schema_class.names())
+        field = schema_class["foo"]
+        self.assertIsInstance(field, schema.Text)
+        self.assertEqual(
+            u"foo", field.title, "Expected title to default to name"
+        )
+        self.assertEqual(u"", field.description)
+        self.assertFalse(field.required)
+
+    @browsing
+    def test_property_sheet_schema_definition_post(self, browser):
+        self.login(self.manager, browser)
+
+        data = {
+            "fields": {
+                "foo": {
+                    "field_type": "bool",
+                    "title": u"Y/N",
+                    "description": u"yes or no",
+                    "required": True,
+                }
+            },
+            "assignments": ["qux"],
+        }
+        browser.open(
+            view="@propertysheets/question",
+            method="POST",
+            data=json.dumps(data),
+            headers=self.api_headers,
+        )
+
+        self.assertEqual(
+            {
+                u"assignments": [u"qux"],
+                u"fieldsets": [
+                    {
+                        u"behavior": u"plone",
+                        u"fields": [u"foo"],
+                        u"id": u"default",
+                        u"title": u"Default",
+                    }
+                ],
+                u"properties": {
+                    u"foo": {
+                        u"description": u"yes or no",
+                        u"factory": u"Yes/No",
+                        u"title": u"Y/N",
+                        u"type": u"boolean",
+                    },
+                },
+                u"required": [u"foo"],
+                u"title": u"question",
+                u"type": u"object",
+            },
+            browser.json,
+        )
+        self.assertEqual("application/json+schema", browser.mimetype)
+
+        storage = PropertySheetSchemaStorage()
+        self.assertEqual(1, len(storage.list()))
+        definition = storage.get("question")
+
+        self.assertEqual("question", definition.name)
+        self.assertEqual(("qux",), definition.assignments)
+        schema_class = definition.schema_class
+
+        self.assertEqual(["foo"], schema_class.names())
+        field = schema_class["foo"]
+        self.assertIsInstance(field, schema.Bool)
+        self.assertEqual(
+            u"Y/N",
+            field.title,
+        )
+        self.assertEqual(u"yes or no", field.description)
+        self.assertTrue(field.required)
+
+    @browsing
+    def test_property_sheet_schema_definition_post_replaces_existing_schema(self, browser):
+        self.login(self.manager, browser)
+
+        definition = PropertySheetSchemaDefinition.create("question")
+        storage = PropertySheetSchemaStorage()
+        storage.save(definition)
+
+        data = {
+            "fields": {
+                "foo": {
+                    "field_type": "bool",
+                    "title": u"Y/N",
+                    "description": u"yes or no",
+                    "required": True,
+                }
+            },
+        }
+        browser.open(
+            view="@propertysheets/question",
+            method="POST",
+            data=json.dumps(data),
+            headers=self.api_headers,
+        )
+
+        self.assertEqual(1, len(storage.list()))
+        definition = storage.get("question")
+
+        self.assertEqual("question", definition.name)
+        self.assertEqual(["foo"], definition.schema_class.names())
+
+    @browsing
+    def test_property_sheet_schema_definition_post_requires_valid_assignment(
+        self, browser
+    ):
+        self.login(self.manager, browser)
+
+        data = {
+            "fields": {"foo": {"field_type": "bool"}},
+            "assignments": [u"fail"],
+        }
+        with browser.expect_http_error(400):
+            browser.open(
+                view="@propertysheets/invalidassignment",
+                method="POST",
+                data=json.dumps(data),
+                headers=self.api_headers,
+            )
+
+        self.assertDictContainsSubset(
+            {
+                u"message": u"The assignment 'fail' is invalid.",
+                "type": "BadRequest",
+            },
+            browser.json,
+        )
+        storage = PropertySheetSchemaStorage()
+        self.assertEqual([], storage.list())
+
+    @browsing
+    def test_property_sheet_schema_definition_post_requires_unique_assignment(
+        self, browser
+    ):
+        self.login(self.manager, browser)
+        storage = PropertySheetSchemaStorage()
+        fixture = PropertySheetSchemaDefinition.create(
+            "fixture",
+            assignments=[u"IDocumentMetadata.document_type.question"]
+        )
+        storage.save(fixture)
+
+        data = {
+            "fields": {"foo": {"field_type": "bool"}},
+            "assignments": [u"IDocumentMetadata.document_type.question"],
+        }
+        with browser.expect_http_error(400):
+            browser.open(
+                view="@propertysheets/invalidassignment",
+                method="POST",
+                data=json.dumps(data),
+                headers=self.api_headers,
+            )
+
+        self.assertDictContainsSubset(
+            {
+                u"message": u"The assignment 'IDocumentMetadata.document_type."
+                            "question' is already in use.",
+                "type": "BadRequest",
+            },
+            browser.json,
+        )
+        self.assertEqual(1, len(storage.list()))
+
+    @browsing
+    def test_property_sheet_schema_definition_post_requires_name(
+        self, browser
+    ):
+        self.login(self.manager, browser)
+
+        data = {"fields": {"foo": {"field_type": "bool"}}}
+        with browser.expect_http_error(400):
+            browser.open(
+                view="@propertysheets",
+                method="POST",
+                data=json.dumps(data),
+                headers=self.api_headers,
+            )
+
+        self.assertDictContainsSubset(
+            {
+                u"message": u"Missing parameter sheet_name.",
+                "type": "BadRequest",
+            },
+            browser.json,
+        )
+
+        storage = PropertySheetSchemaStorage()
+        self.assertEqual([], storage.list())
+
+    @browsing
+    def test_property_sheet_schema_definition_post_requires_valid_name(
+        self, browser
+    ):
+        self.login(self.manager, browser)
+
+        data = {"fields": {"foo": {"field_type": "bool"}}}
+        with browser.expect_http_error(400):
+            browser.open(
+                view="@propertysheets/in-val.id",
+                method="POST",
+                data=json.dumps(data),
+                headers=self.api_headers,
+            )
+
+        self.assertDictContainsSubset(
+            {
+                u"message": u"The name 'in-val.id' is invalid.",
+                "type": "BadRequest",
+            },
+            browser.json,
+        )
+
+        storage = PropertySheetSchemaStorage()
+        self.assertEqual([], storage.list())
+
+    @browsing
+    def test_property_sheet_schema_definition_post_requires_fields(
+        self, browser
+    ):
+        self.login(self.manager, browser)
+
+        data = {"fields": []}
+        with browser.expect_http_error(400):
+            browser.open(
+                view="@propertysheets/foo",
+                method="POST",
+                data=json.dumps(data),
+                headers=self.api_headers,
+            )
+
+        self.assertDictContainsSubset(
+            {
+                u"message": u"Missing or invalid field definitions.",
+                "type": "BadRequest",
+            },
+            browser.json,
+        )
+
+        storage = PropertySheetSchemaStorage()
+        self.assertEqual([], storage.list())
+
+    @browsing
+    def test_property_sheet_schema_definition_post_invalid_type(self, browser):
+        self.login(self.manager, browser)
+
+        data = {"fields": {"foo": {"field_type": "invalid"}}}
+        with browser.expect_http_error(400):
+            browser.open(
+                view="@propertysheets/question",
+                method="POST",
+                data=json.dumps(data),
+                headers=self.api_headers,
+            )
+        self.assertDictContainsSubset(
+            {
+                "type": "BadRequest",
+            },
+            browser.json,
+        )
+        storage = PropertySheetSchemaStorage()
+        self.assertEqual([], storage.list())
+
+    @browsing
+    def test_non_managers_cannot_post(self, browser):
+        self.login(self.administrator, browser)
+
+        data = {"fields": {"foo": {"field_type": "text"}}}
+        with browser.expect_unauthorized():
+            browser.open(
+                view="@propertysheets/test",
+                method="POST",
+                data=json.dumps(data),
+                headers=self.api_headers,
+            )

--- a/opengever/propertysheets/tests/test_storage.py
+++ b/opengever/propertysheets/tests/test_storage.py
@@ -13,7 +13,8 @@ class TestPropertySheetSchemaStorage(FunctionalTestCase):
 
     def test_save_schema_definition(self):
         definition = PropertySheetSchemaDefinition.create(
-            "myschema", assignments=["qux", "foo.bar"]
+            "myschema",
+            assignments=[u"IDocumentMetadata.document_type.question"]
         )
         definition.add_field("bool", u"yesorno", u"y/n", u"", False)
 
@@ -35,7 +36,8 @@ class TestPropertySheetSchemaStorage(FunctionalTestCase):
             serialized["myschema"]["assignments"], PersistentList
         )
         self.assertEqual(
-            ["qux", "foo.bar"], serialized["myschema"]["assignments"]
+            [u"IDocumentMetadata.document_type.question"],
+            serialized["myschema"]["assignments"]
         )
         deserialized = loadString(serialized["myschema"]["schema"])
         self.assertIn("myschema", deserialized.schemata)
@@ -74,29 +76,39 @@ class TestPropertySheetSchemaStorage(FunctionalTestCase):
     def test_prevents_duplicate_assignments(self):
         storage = PropertySheetSchemaStorage()
         fixture = PropertySheetSchemaDefinition.create(
-            "fixture", assignments=['foo', 'bar', 'qux']
+            "fixture",
+            assignments=[
+                u"IDocumentMetadata.document_type.offer",
+                u"IDocumentMetadata.document_type.report"
+            ]
         )
         storage.save(fixture)
 
         conflict = PropertySheetSchemaDefinition.create(
-            "conflict", assignments=[u'foo']
+            "conflict", assignments=[u"IDocumentMetadata.document_type.report"]
         )
         with self.assertRaises(InvalidSchemaAssignment) as cm:
             storage.save(conflict)
 
         exc = cm.exception
         self.assertEqual(
-            u"The assignment 'foo' is already in use.", exc.message
+            u"The assignment 'IDocumentMetadata.document_type.report' "
+            "is already in use.",
+            exc.message
         )
 
     def test_query_for_schema_by_assignment(self):
         storage = PropertySheetSchemaStorage()
         fixture = PropertySheetSchemaDefinition.create(
-            "fixture", assignments=["foo", "bar"]
+            "fixture",
+            assignments=[
+                u"IDocumentMetadata.document_type.question",
+                u"IDocumentMetadata.document_type.report"
+            ]
         )
         storage.save(fixture)
 
-        schema = storage.query("bar")
+        schema = storage.query(u"IDocumentMetadata.document_type.report")
         self.assertIsNotNone(schema)
         self.assertEqual("fixture", schema.name)
 

--- a/opengever/propertysheets/tests/test_storage.py
+++ b/opengever/propertysheets/tests/test_storage.py
@@ -103,3 +103,28 @@ class TestPropertySheetSchemaStorage(FunctionalTestCase):
     def test_query_for_nonexistent_assignment(self):
         storage = PropertySheetSchemaStorage()
         self.assertIsNone(storage.query("foo"))
+
+    def test_remove_nonexistent_sheet(self):
+        storage = PropertySheetSchemaStorage()
+        self.assertEqual([], storage.list())
+        storage.remove("nix")
+        self.assertEqual([], storage.list())
+
+    def test_remove_sheet(self):
+        storage = PropertySheetSchemaStorage()
+        fixture = PropertySheetSchemaDefinition.create("removeme")
+        storage.save(fixture)
+        self.assertEqual(1, len(storage.list()))
+
+        storage.remove("removeme")
+
+        self.assertEqual([], storage.list())
+
+    def test_containment(self):
+        storage = PropertySheetSchemaStorage()
+        fixture = PropertySheetSchemaDefinition.create("imin")
+        storage.save(fixture)
+
+        self.assertIn('imin', storage)
+        self.assertNotIn(None, storage)
+        self.assertNotIn('foo', storage)


### PR DESCRIPTION
With this PR we add REST-API endpoints to make use of the property sheet storage that was added in https://github.com/4teamwork/opengever.core/pull/6795.

The initial implementation only allows `POST` and `DELETE` for a `Manager`. `GET` is available for anyone with the `View` permission. Incremental edits for schemas are not yet supported, e.g. field removal or reordering.

Property sheets support being represented as JSON Schema as of this Pull-Request. The schema of a single sheet can be retrieved, including the schemas in the `@schema` endpoints for existing types will follow in future Pull-Request when we implement property sheet/custom field support for certain content-types.

We add a new service endpoints `@propertysheets` which is available on the plone-site only. It can be used to manage and list property sheets.

- Retrieve a list of all available sheets or the JSON-schema of a single sheet:
  `GET /@propertysheets`
  `GET /@propertysheets/<property_sheet_name>`

- Create or replace existing property sheets:
  `POST /@propertysheets/<property_sheet_name>`

- Delete existing property sheets:
  `DELETE /@propertysheets/<property_sheet_name>`

We also add the vocabulary `opengever.propertysheets.PropertySheetAssignmentsVocabulary` to validate property sheet assignments. Currently property sheets can only be assigned to potential `document_type` attribute values . We do not actually link the sheet to the `document_type` in any way, this will be implemented in the future.

_The API endpoints are not defined in `opengever.api` but in the `opengever.propertysheets.api` package. I would propose we start adding specific API classes to their corresponding sub-package and start breaking up the large package `opengever.api`._

Jira: https://4teamwork.atlassian.net/browse/CA-1279

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


## Checklist (if applicable)

_Only applicable should be left and checked._

- API change:
  - [x] Documentation is updated