### PR TITLE
Add 'en-us' as supported language in example content.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2021.2.0 (unreleased)
 ---------------------
 
+- Add 'en-us' as supported language in example content. [lgraf]
 - Implement storage for property sheet schemas in plone-site annotations. [deiferni]
 
 

--- a/opengever/base/__init__.py
+++ b/opengever/base/__init__.py
@@ -38,3 +38,4 @@ csv.register_dialect(u'OpenGeverCSV', OpenGeverCSVDialect)
 # file.
 languages._combinedlanguagelist['de-ch']['native'] = u'Deutsch'
 languages._combinedlanguagelist['fr-ch']['native'] = u'Français'
+languages._combinedlanguagelist['en-us']['native'] = u'English'

--- a/opengever/base/language.py
+++ b/opengever/base/language.py
@@ -19,6 +19,7 @@ class NegotiateLanguage(object):
     SIMPLE_TO_COMBINED_MAPPING = {
         'de': 'de-ch',
         'fr': 'fr-ch',
+        'en': 'en-us',
     }
 
     def getMappedRequestLanguages(self, tool):

--- a/opengever/examplecontent/profiles/default/portal_languages.xml
+++ b/opengever/examplecontent/profiles/default/portal_languages.xml
@@ -2,5 +2,6 @@
   <supported_langs>
     <element value="fr-ch" />
     <element value="de-ch" />
+    <element value="en-us" />
   </supported_langs>
 </object>


### PR DESCRIPTION
These is the minimal set of changes to **enable picking English as a UI language** (in the classic UI):

- Add it as a supported language in the portal language too (makes it available for selection)
- Set its `native` name (required to provide the display title used in the [personal bar viewlet](https://github.com/4teamwork/opengever.core/blob/master/opengever/base/viewlets/personal_bar.py#L37))
- Add it to `SIMPLE_TO_COMBINED_MAPPING` (required for robust HTTP language negotiation)

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

Jira: https://4teamwork.atlassian.net/browse/CA-883
