### PR TITLE
Clean up English og.activity translations.

### DIFF
--- a/opengever/activity/locales/en/LC_MESSAGES/opengever.activity.po
+++ b/opengever/activity/locales/en/LC_MESSAGES/opengever.activity.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-01-08 11:40+0000\n"
+"POT-Creation-Date: 2021-01-11 15:53+0000\n"
 "PO-Revision-Date: 2015-02-24 08:40+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -39,7 +39,7 @@ msgstr "Cancel"
 #. Default: "Reset"
 #: ./opengever/activity/browser/settings.py
 msgid "btn_reset"
-msgstr "Reset"
+msgstr "Reset to Defaults"
 
 #. German translation: Speichern
 #. Default: "Save"
@@ -96,7 +96,7 @@ msgstr "Disposition appraised"
 #: ./opengever/activity/__init__.py
 #: ./opengever/activity/notification_settings.py
 msgid "disposition-transition-archive"
-msgstr "Disposition archived"
+msgstr "Archival confirmed"
 
 #. German translation: Angebot abgeschlossen
 #. Default: "Disposition closed"
@@ -110,7 +110,7 @@ msgstr "Disposition closed"
 #: ./opengever/activity/__init__.py
 #: ./opengever/activity/notification_settings.py
 msgid "disposition-transition-dispose"
-msgstr "Disposition disposed"
+msgstr "Offered for archival"
 
 #. German translation: Angebot abgelehnt
 #. Default: "Disposition refused"
@@ -226,7 +226,7 @@ msgstr "General"
 #. Default: "Mail"
 #: ./opengever/activity/browser/settings.py
 msgid "label_mail"
-msgstr "Mail"
+msgstr "Email"
 
 #. German translation: Benachrichtigungs-Einstellungen
 #. Default: "Notification settings"
@@ -239,7 +239,7 @@ msgstr "Notification settings"
 #. Default: "All Notifications"
 #: ./opengever/activity/viewlets/notification.pt
 msgid "label_notifications_overview"
-msgstr "All Notifications"
+msgstr "All notifications"
 
 #. German translation: Anträge
 #. Default: "Proposals"
@@ -275,25 +275,25 @@ msgstr "Workspaces"
 #. Default: "A problem has occurred during the notification creation. Notification could not or only partially produced."
 #: ./opengever/activity/error_handling.py
 msgid "msg_error_not_notified"
-msgstr "A problem has occurred during the notification creation. Notification could not or only partially produced."
+msgstr "A problem has occurred when trying to dispatch a notification. The notification therefore was not dispatched (or only partially)."
 
 #. German translation: Alle Benachrichtigungen aufgrund von Eingangskorbberechtigung aktivieren bzw. deaktivieren.
 #. Default: "Activate, respectively deactivate, all notifications due to your inbox permissions."
 #: ./opengever/activity/browser/settings.py
 msgid "notify_inbox_actions_help"
-msgstr "Activate, respectively deactivate, all notifications due to your inbox permissions."
+msgstr "Enabled or disable, respectively, all notifications based on your inbox permissions."
 
 #. German translation: Benachrichtigungen für Eingangskorb aktivieren
 #. Default: "Enable notifications for inbox actions"
 #: ./opengever/activity/browser/settings.py
 msgid "notify_inbox_actions_title"
-msgstr "Enable notifications for inbox actions"
+msgstr "Enable notifications for inbox activities"
 
 #. German translation: Standardmässig werden für selbst ausgeführte Aktionen keine Benachrichtigungen ausgelöst. Mit dieser Option kann dieses Verhalten verändert werden. Persönlich vorgenommene Benachrichtigungseinstellungen pro Aktionstyp gelten dabei nach wie vor.
 #. Default: "By default no notifications are emitted for a users'own actions. This option allows to modify this behavior. Notwithstanding this configuration, user notification settings for each action type will get applied anyway."
 #: ./opengever/activity/browser/settings.py
 msgid "notify_own_actions_help"
-msgstr "By default no notifications are emitted for a users'own actions. This option allows to modify this behavior. Notwithstanding this configuration, user notification settings for each action type will get applied anyway."
+msgstr "By default no notifications are emitted for a user's own actions. This option allows to modify this behavior. Irrespective of this setting, individual settings for specific action types will still get applied."
 
 #. German translation: Benachrichtigung für eigene Aktionen aktivieren
 #. Default: "Enable notifications for own actions"
@@ -303,6 +303,7 @@ msgstr "Enable notifications for own actions"
 
 #. German translation: Zusätzliche Beilagen eingereicht
 #. Default: "Additional documents submitted"
+#. MARKER: supplementary-documents
 #: ./opengever/activity/__init__.py
 #: ./opengever/activity/notification_settings.py
 msgid "proposal-additional-documents-submitted"
@@ -310,6 +311,7 @@ msgstr "Additional documents submitted"
 
 #. German translation: Beilage aktualisiert
 #. Default: "Attachment updated"
+#. MARKER: supplementary-documents
 #: ./opengever/activity/__init__.py
 #: ./opengever/activity/notification_settings.py
 msgid "proposal-attachment-updated"
@@ -496,7 +498,7 @@ msgstr "Task skipped"
 #. Default: "Task reassign"
 #: ./opengever/activity/__init__.py
 msgid "task-transition-reassign"
-msgstr "Task reassign"
+msgstr "Task reassigned"
 
 #. German translation: Aufgabe wieder eröffnet
 #. Default: "Task reopened"
@@ -514,7 +516,7 @@ msgstr "Task skipped"
 #. Default: "Task revision wanted"
 #: ./opengever/activity/__init__.py
 msgid "task-transition-resolved-in-progress"
-msgstr "Task revision wanted"
+msgstr "Task revision requested"
 
 #. German translation: Aufgabe abgeschlossen
 #. Default: "Task closed"
@@ -544,7 +546,7 @@ msgstr "Task issuer"
 #. Default: "Task former responsible"
 #: ./opengever/activity/roles.py
 msgid "task_old_responsible"
-msgstr "Task former responsible"
+msgstr "Former task responsible"
 
 #. German translation: Beobachter
 #. Default: "Watcher"

--- a/opengever/activity/tests/test_plone_center.py
+++ b/opengever/activity/tests/test_plone_center.py
@@ -138,7 +138,7 @@ class TestNotifactionCenterErrorHandling(FunctionalTestCase):
         browser.css('#form-buttons-save').first.click()
 
         self.assertEquals(
-            ['A problem has occurred during the notification creation. '
-             'Notification could not or only partially produced.'],
+            ['A problem has occurred when trying to dispatch a notification. '
+             'The notification therefore was not dispatched (or only partially).'],
             warning_messages())
         self.assertEquals(['Item created'], info_messages())

--- a/opengever/api/tests/test_notification_settings.py
+++ b/opengever/api/tests/test_notification_settings.py
@@ -250,11 +250,10 @@ class TestNotificationSettingsGet(IntegrationTestCase):
         self.assertEqual({
             u'@id': u'http://nohost/plone/@notification-settings/general/notify_inbox_actions',
             u'group': u'general',
-            u'help_text': u'Activate, respectively deactivate, all notifications due to your '
-            u'inbox permissions.',
+            u'help_text': u'Enabled or disable, respectively, all notifications based on your inbox permissions.',
             u'id': u'notify_inbox_actions',
             u'personal': False,
-            u'title': u'Enable notifications for inbox actions',
+            u'title': u'Enable notifications for inbox activities',
             u'value': True
         }, browser.json['general']['items'][-1])
 
@@ -309,10 +308,10 @@ class TestNotificationSettingsGet(IntegrationTestCase):
                 u'items': [{
                     u'@id': u'http://nohost/plone/@notification-settings/general/notify_own_actions',
                     u'group': u'general',
-                    u'help_text': u"By default no notifications are emitted for a users'own "
+                    u'help_text': u"By default no notifications are emitted for a user's own "
                                   u"actions. This option allows to modify this behavior. "
-                                  u"Notwithstanding this configuration, user notification settings "
-                                  u"for each action type will get applied anyway.",
+                                  u"Irrespective of this setting, individual settings for specific "
+                                  u"action types will still get applied.",
                     u'id': u'notify_own_actions',
                     u'personal': False,
                     u'title': u'Enable notifications for own actions',


### PR DESCRIPTION
Clean up English og.activity translations.

The purpose of this is to clean up existing English translations, and fill in missing ones with the following aspects in mind:

- Some very specific modules (SPV, Disposition, ...) with lots of domain specific terminology will have to be looked at more closely at a later point, and translations would need to be changed (if necessary) as a whole, in context, and based on some research.
  For these I will fix obvious, glaring mistakes, but otherwise won't substantially change any core terms.
- I'll leave some `MARKER`s for things that strike me as odd, need to be double checked again later, or otherwise might need revisiting in order to not forget them, but be able to quickly make a decision and move on.
- Title case vs sentence case: It's a [whole debate](https://uxplanet.org/why-letter-casing-is-important-to-consider-during-design-decisions-50402acd0a4e) that I don't care to get into :-/ I decided to mostly stick with sentence case, unless I know the context and it looks weird in the UI.
- Some foreign / manual `.po` files like `ftw.tabbedview.po` contain a ton of translations that are completely irrelevant to us (like Extranet stuff). I tried to avoid touching all those (in order to not cause confusion), and only filled in translations that are effectively used, as much as possible.
- I'd propose to do _one_ changelog entry for the entire cleanup of English translations once this is all done.

Jira: https://4teamwork.atlassian.net/browse/CA-883