### PR TITLE
Change key for agenda item list document to "documents" in zip export.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 ---------------------
 
 - Bump docxcompose to version 1.3.1 to add support for dateformats. [njohner]
+- Change key for agenda item list document to "documents" in zip export. [njohner]
 - Initialize English translations. [lgraf]
 - Add getObjPositionInParent and preselected field to listing endpoint. [elioschmutz]
 - Fix workflow transitions for tasktemplatefolders and tasktemplates over the restapi. [elioschmutz]

--- a/opengever/meeting/tests/test_meeting_zipexport.py
+++ b/opengever/meeting/tests/test_meeting_zipexport.py
@@ -55,17 +55,18 @@ class TestMeetingZipExportView(IntegrationTestCase):
         meeting_json = json.loads(zip_file.open('meeting.json').read())
         meeting = meeting_json.get('meetings')[0]
 
-        self.assertIn('agenda_item_list', meeting)
+        self.assertIn('documents', meeting)
 
-        agenda_item_list = meeting.get('agenda_item_list')
+        agenda_item_list = meeting.get('documents')
 
+        self.assertEqual(1, len(agenda_item_list))
         self.assertDictEqual(
             {
-                u'checksum': agenda_item_list.get('checksum'),
+                u'checksum': agenda_item_list[0].get('checksum'),
                 u'file': u'Agendaitem list-9. Sitzung der Rechnungspruefungskommission.docx',
                 u'modified': u'2017-12-13T00:00:00+01:00',
             },
-            agenda_item_list)
+            agenda_item_list[0])
 
     @browsing
     def test_zip_export_agenda_items_attachments(self, browser):
@@ -258,7 +259,7 @@ class TestMeetingZipExportView(IntegrationTestCase):
         # the protocol and agenda_item_list are generated during the tests and
         # their checksums cannot be predicted
         meeting_json['meetings'][0]['protocol']['checksum'] = 'unpredictable'
-        meeting_json['meetings'][0]['agenda_item_list']['checksum'] = 'unpredictable'
+        meeting_json['meetings'][0]['documents'][0]['checksum'] = 'unpredictable'
         meeting_json['meetings'][0].pop('opengever_id')
         for agenda_item in meeting_json['meetings'][0]['agenda_items']:
             agenda_item.pop('opengever_id')
@@ -304,11 +305,11 @@ class TestMeetingZipExportView(IntegrationTestCase):
                     u'file': u'Protokoll-9. Sitzung der Rechnungspruefungskommission- ordentlich.docx',
                     u'modified': u'2017-12-14T00:00:00+01:00',
                 },
-                u'agenda_item_list': {
+                u'documents': [{
                     u'checksum': 'unpredictable',
                     u'file': u'Traktandenliste-9. Sitzung der Rechnungspruefungskommission- ordentlich.docx',
                     u'modified': u'2017-12-14T00:00:00+01:00',
-                },
+                }],
                 u'start': u'2016-09-12T15:30:00+00:00',
                 u'title': u'9. Sitzung der Rechnungspr\xfcfungskommission, ordentlich',
             }],

--- a/opengever/meeting/tests/test_meeting_zipexport.py
+++ b/opengever/meeting/tests/test_meeting_zipexport.py
@@ -65,6 +65,7 @@ class TestMeetingZipExportView(IntegrationTestCase):
                 u'checksum': agenda_item_list[0].get('checksum'),
                 u'file': u'Agendaitem list-9. Sitzung der Rechnungspruefungskommission.docx',
                 u'modified': u'2017-12-13T00:00:00+01:00',
+                u'title': u'Agendaitem list-9. Sitzung der Rechnungspr\xfcfungskommission',
             },
             agenda_item_list[0])
 
@@ -309,6 +310,7 @@ class TestMeetingZipExportView(IntegrationTestCase):
                     u'checksum': 'unpredictable',
                     u'file': u'Traktandenliste-9. Sitzung der Rechnungspruefungskommission- ordentlich.docx',
                     u'modified': u'2017-12-14T00:00:00+01:00',
+                    u'title': u'Traktandenliste-9. Sitzung der Rechnungspr\xfcfungskommission, ordentlich',
                 }],
                 u'start': u'2016-09-12T15:30:00+00:00',
                 u'title': u'9. Sitzung der Rechnungspr\xfcfungskommission, ordentlich',

--- a/opengever/meeting/zipexport.py
+++ b/opengever/meeting/zipexport.py
@@ -170,11 +170,11 @@ class MeetingJSONSerializer(MeetingDocumentWithFileTraverser):
         }
 
     def traverse_agenda_item_list_document(self, document):
-        self.data['agenda_item_list'] = {
+        self.data['documents'] = [{
             'checksum': IBumblebeeDocument(document).get_checksum(),
             'file': self.zipper.get_filename(document),
             'modified': format_modified(document.modified()),
-        }
+        }]
 
     def traverse_agenda_item(self, agenda_item):
         self.current_agenda_item_data = {

--- a/opengever/meeting/zipexport.py
+++ b/opengever/meeting/zipexport.py
@@ -174,6 +174,7 @@ class MeetingJSONSerializer(MeetingDocumentWithFileTraverser):
             'checksum': IBumblebeeDocument(document).get_checksum(),
             'file': self.zipper.get_filename(document),
             'modified': format_modified(document.modified()),
+            'title': safe_unicode(document.Title())
         }]
 
     def traverse_agenda_item(self, agenda_item):


### PR DESCRIPTION
Grimlock wants the agenda item list document under the `documents` key and in a list and not as it is now under the `agenda_item_list` key (see @fguyer 's comment: https://4teamwork.atlassian.net/browse/CA-149?focusedCommentId=14380). This key is already in use in Grimlock for zips generated by RIS, but it's a new key in Gever, so displaying it should work in Grimlock without needing any changes.
Note that Grimlock expects items in the `documents` section to have a `title`, so we also need to add the title of the agenda item list in the Zip file.

Note that I tested the export and import in Grimlock with the new format.

For https://4teamwork.atlassian.net/browse/CA-1401

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)