### PR TITLE
Add relatedItems field to todo

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 ---------------------
 
 - Add new API endpoint @white-labeling-settings. [tinagerber]
+- Add relatedItems field to todo. [tinagerber]
 - Bump docxcompose to version 1.3.1 to add support for dateformats. [njohner]
 - Change key for agenda item list document to "documents" in zip export. [njohner]
 - Bump ftw.solr to 2.9.2 to fix a bug with setting document_type back to None. [njohner]

--- a/opengever/core/tests/test_relations.py
+++ b/opengever/core/tests/test_relations.py
@@ -150,6 +150,7 @@ EXPECTED_TYPES_WITH_RELATIONS = [
     'opengever.meeting.proposaltemplate',
     'opengever.private.dossier',
     'opengever.disposition.disposition',
+    'opengever.workspace.todo',
 ]
 
 

--- a/opengever/workspace/locales/de/LC_MESSAGES/opengever.workspace.po
+++ b/opengever/workspace/locales/de/LC_MESSAGES/opengever.workspace.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-01-08 11:40+0000\n"
+"POT-Creation-Date: 2021-01-15 07:54+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -183,6 +183,11 @@ msgstr "Ort"
 #: ./opengever/workspace/workspace_meeting.py
 msgid "label_organizer"
 msgstr "Organisator"
+
+#. Default: "Related items"
+#: ./opengever/workspace/todo.py
+msgid "label_related_items"
+msgstr "Verweise"
 
 #. Default: "Responsible"
 #: ./opengever/workspace/todo.py

--- a/opengever/workspace/locales/en/LC_MESSAGES/opengever.workspace.po
+++ b/opengever/workspace/locales/en/LC_MESSAGES/opengever.workspace.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-01-08 16:38+0000\n"
+"POT-Creation-Date: 2021-01-15 07:54+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -219,6 +219,11 @@ msgstr "Location"
 #: ./opengever/workspace/workspace_meeting.py
 msgid "label_organizer"
 msgstr "Organizer"
+
+#. Default: "Related items"
+#: ./opengever/workspace/todo.py
+msgid "label_related_items"
+msgstr "Related items"
 
 #. German translation: Verantwortlich
 #. Default: "Responsible"

--- a/opengever/workspace/locales/fr/LC_MESSAGES/opengever.workspace.po
+++ b/opengever/workspace/locales/fr/LC_MESSAGES/opengever.workspace.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-01-08 11:40+0000\n"
+"POT-Creation-Date: 2021-01-15 07:54+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -183,6 +183,11 @@ msgstr "Lieu"
 #: ./opengever/workspace/workspace_meeting.py
 msgid "label_organizer"
 msgstr "Organisateur"
+
+#. Default: "Related items"
+#: ./opengever/workspace/todo.py
+msgid "label_related_items"
+msgstr "Renvois"
 
 #. Default: "Responsible"
 #: ./opengever/workspace/todo.py

--- a/opengever/workspace/locales/opengever.workspace.pot
+++ b/opengever/workspace/locales/opengever.workspace.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-01-08 11:40+0000\n"
+"POT-Creation-Date: 2021-01-15 07:54+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -179,6 +179,11 @@ msgstr ""
 #. Default: "Organizer"
 #: ./opengever/workspace/workspace_meeting.py
 msgid "label_organizer"
+msgstr ""
+
+#. Default: "Related items"
+#: ./opengever/workspace/todo.py
+msgid "label_related_items"
 msgstr ""
 
 #. Default: "Responsible"

--- a/opengever/workspace/todo.py
+++ b/opengever/workspace/todo.py
@@ -3,6 +3,7 @@ from Acquisition import aq_parent
 from collective import dexteritytextindexer
 from ftw.keywordwidget.widget import KeywordFieldWidget
 from opengever.base.response import IResponseSupported
+from opengever.base.source import WorkspacePathSourceBinder
 from opengever.ogds.base.sources import ActualWorkspaceMembersSourceBinder
 from opengever.workspace import _
 from opengever.workspace.interfaces import IToDo
@@ -12,6 +13,8 @@ from plone.autoform.interfaces import IFormFieldProvider
 from plone.dexterity.content import Container
 from plone.supermodel import model
 from Products.CMFPlone.interfaces.siteroot import IPloneSiteRoot
+from z3c.relationfield.schema import RelationChoice
+from z3c.relationfield.schema import RelationList
 from zope import schema
 from zope.interface import implements
 from zope.interface import provider
@@ -45,6 +48,22 @@ class IToDoSchema(model.Schema):
         title=_(u'label_completed', default='Completed'),
         default=False,
         required=False)
+
+    relatedItems = RelationList(
+        title=_(u'label_related_items', default=u'Related items'),
+        default=[],
+        missing_value=[],
+        value_type=RelationChoice(
+            title=u"Related",
+            source=WorkspacePathSourceBinder(
+                portal_type=("opengever.document.document", "ftw.mail.mail"),
+                navigation_tree_query={
+                    'review_state': {'not': 'document-state-shadow'},
+                },
+            ),
+        ),
+        required=False,
+    )
 
 
 class ToDo(Container):


### PR DESCRIPTION
ToDo now has a `relatedItems` field that can be used to refer to existing documents in the workspace.

Jira: https://4teamwork.atlassian.net/browse/NE-61

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


## Checklist (if applicable)

_Only applicable should be left and checked._

- New translations
  - [x] All msg-strings are unicode
