### PR TITLE
Clean up English og.contact translations.

### DIFF
--- a/opengever/base/tests/test_default_values_for_types.py
+++ b/opengever/base/tests/test_default_values_for_types.py
@@ -1441,8 +1441,8 @@ class TestContactDefaults(TestDefaultsBase):
             browser.login().open(self.contactfolder)
             factoriesmenu.add(u'Contact')
             browser.fill({
-                u'Firstname': CONTACT_REQUIREDS['firstname'],
-                u'Lastname': CONTACT_REQUIREDS['lastname']}).save()
+                u'First name': CONTACT_REQUIREDS['firstname'],
+                u'Last name': CONTACT_REQUIREDS['lastname']}).save()
             contact = browser.context
 
         persisted_values = get_persisted_values_for_obj(contact)

--- a/opengever/contact/locales/en/LC_MESSAGES/opengever.contact.po
+++ b/opengever/contact/locales/en/LC_MESSAGES/opengever.contact.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2021-01-08 11:40+0000\n"
+"POT-Creation-Date: 2021-01-13 14:31+0000\n"
 "PO-Revision-Date: 2011-01-05 15:15+0100\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -23,7 +23,7 @@ msgstr "Active"
 #. Default: "Add Person"
 #: ./opengever/contact/browser/person.py
 msgid "Add Person"
-msgstr "Add Person"
+msgstr "Add person"
 
 #. German translation: Kontakt
 #: ./opengever/contact/contact.py
@@ -38,17 +38,17 @@ msgstr "Delete"
 #. German translation: E-Mail-Adresse löschen
 #: ./opengever/contact/browser/templates/person_edit.pt
 msgid "Delete mailaddress"
-msgstr "Delete mailaddress"
+msgstr "Delete email address"
 
 #. German translation: E-Mail-Adresse
 #: ./opengever/contact/browser/templates/person_edit.pt
 msgid "Emailadddress"
-msgstr "Emailadddress"
+msgstr "Email address"
 
 #. German translation: E-Mail-Adressen
 #: ./opengever/contact/browser/templates/person_edit.pt
 msgid "Emailaddresses"
-msgstr "Emailaddresses"
+msgstr "Email address"
 
 #. German translation: Label
 #: ./opengever/contact/browser/templates/person_edit.pt
@@ -95,20 +95,20 @@ msgstr "Active"
 #. Default: "Firstname"
 #: ./opengever/contact/browser/person_listing.py
 msgid "column_firstname"
-msgstr "Firstname"
+msgstr "First name"
 
 #. German translation: Frühere Kontakt ID
 #. Default: "Former contact id"
 #: ./opengever/contact/browser/organization_listing.py
 #: ./opengever/contact/browser/person_listing.py
 msgid "column_former_contact_id"
-msgstr "Former contact id"
+msgstr "Former contact ID"
 
 #. German translation: Nachname
 #. Default: "Lastname"
 #: ./opengever/contact/browser/person_listing.py
 msgid "column_lastname"
-msgstr "Lastname"
+msgstr "Last name"
 
 #. German translation: Name
 #. Default: "Name"
@@ -124,6 +124,7 @@ msgstr "Organizations"
 
 #. German translation: Anrede
 #. Default: "Salutation"
+#. MARKER: questionable
 #: ./opengever/contact/browser/person_listing.py
 msgid "column_salutation"
 msgstr "Salutation"
@@ -196,7 +197,7 @@ msgstr "Active"
 #. Default: "Add Participation"
 #: ./opengever/contact/browser/participation_forms.py
 msgid "label_add_participation"
-msgstr "Add Participation"
+msgstr "Add participation"
 
 #. German translation: Adresse (Strasse / Nr.)
 #. Default: "Address 1"
@@ -222,33 +223,33 @@ msgstr "Addresses"
 #: ./opengever/contact/browser/templates/organization.pt
 #: ./opengever/contact/browser/templates/person.pt
 msgid "label_archived_addresses"
-msgstr "Archived Addresses"
+msgstr "Archived addresses"
 
 #. German translation: Archivierte E-Mail-Adressen
 #. Default: "Archived Mail Addresses"
 #: ./opengever/contact/browser/templates/organization.pt
 #: ./opengever/contact/browser/templates/person.pt
 msgid "label_archived_mail"
-msgstr "Archived Mail Addresses"
+msgstr "Archived email addresses"
 
 #. German translation: Archivierte Informationen
 #. Default: "Archived Information"
 #: ./opengever/contact/browser/templates/organization.pt
 msgid "label_archived_organizations"
-msgstr "Archived Information"
+msgstr "Archived information"
 
 #. German translation: Archivierte persönliche Informationen
 #. Default: "Archived Personal Information"
 #: ./opengever/contact/browser/templates/person.pt
 msgid "label_archived_persons"
-msgstr "Archived Personal Information"
+msgstr "Archived personal information"
 
 #. German translation: Archivierte Telefonnummern
 #. Default: "Archived Phone Numbers"
 #: ./opengever/contact/browser/templates/organization.pt
 #: ./opengever/contact/browser/templates/person.pt
 msgid "label_archived_phone_numbers"
-msgstr "Archived Phone Numbers"
+msgstr "Archived phone numbers"
 
 #. German translation: Abbrechen
 #. Default: "Cancel"
@@ -285,7 +286,7 @@ msgstr "Country"
 #. Default: "Are you sure you want to delete this mail address?"
 #: ./opengever/contact/browser/templates/person_edit.pt
 msgid "label_delete_mail_address_confirm_text"
-msgstr "Are you sure you want to delete this mail address?"
+msgstr "Are you sure you want to delete this email address?"
 
 #. German translation: Abteilung
 #. Default: "Department"
@@ -302,6 +303,7 @@ msgstr "Description"
 
 #. German translation: Beteiligung von ${title} bearbeiten
 #. Default: "Edit ${title}"
+#. MARKER: double check
 #: ./opengever/contact/browser/participation_forms.py
 msgid "label_edit_participation"
 msgstr "Edit ${title}"
@@ -311,7 +313,7 @@ msgstr "Edit ${title}"
 #: ./opengever/contact/browser/contacts_tab.py
 #: ./opengever/contact/contact.py
 msgid "label_email"
-msgstr "email"
+msgstr "Email 1"
 
 #. German translation: E-Mail 2
 #. Default: "Email 2"
@@ -331,7 +333,7 @@ msgstr "Fax"
 #: ./opengever/contact/browser/person.py
 #: ./opengever/contact/contact.py
 msgid "label_firstname"
-msgstr "Firstname"
+msgstr "First name"
 
 #. German translation: Frühere Kontakt ID
 #. Default: "Former contact ID"
@@ -357,13 +359,13 @@ msgstr "Inactive"
 #: ./opengever/contact/browser/person.py
 #: ./opengever/contact/contact.py
 msgid "label_lastname"
-msgstr "Lastname"
+msgstr "Last name"
 
 #. German translation: Letzte Beteiligungen
 #. Default: "Latest participations"
 #: ./opengever/contact/browser/templates/latest_participations.pt
 msgid "label_latest_participations"
-msgstr "Latest participations"
+msgstr "Most recent participations"
 
 #. German translation: Lokal
 #. Default: "Local"
@@ -376,7 +378,7 @@ msgstr "Local"
 #: ./opengever/contact/browser/templates/organization.pt
 #: ./opengever/contact/browser/templates/person.pt
 msgid "label_mail"
-msgstr "Mail Addresses"
+msgstr "Email Addresses"
 
 #. German translation: Mobiltelefon
 #. Default: "Mobile"
@@ -407,7 +409,7 @@ msgstr "Office"
 #. Default: "Org Unit"
 #: ./opengever/contact/browser/tabs.py
 msgid "label_org_unit"
-msgstr "Org Unit"
+msgstr "Organizational unit"
 
 #. German translation: Organisationen
 #. Default: "Organizations"
@@ -430,6 +432,7 @@ msgstr "Personal information:"
 
 #. German translation: Personen
 #. Default: "Persons"
+#. MARKER: This might actually be correct here (instead of 'People'). Double check.
 #: ./opengever/contact/browser/tabbed.py
 #: ./opengever/contact/browser/templates/organization.pt
 msgid "label_persons"
@@ -439,13 +442,13 @@ msgstr "Persons"
 #. Default: "Fax"
 #: ./opengever/contact/contact.py
 msgid "label_phone_fax"
-msgstr "Fax"
+msgstr "Fax (work)"
 
 #. German translation: Telefon Privat
 #. Default: "Phone home"
 #: ./opengever/contact/contact.py
 msgid "label_phone_home"
-msgstr "Phone home"
+msgstr "Phone (home)"
 
 #. German translation: Telefon Mobile
 #. Default: "Mobile"
@@ -465,7 +468,7 @@ msgstr "Phone numbers"
 #: ./opengever/contact/browser/contacts_tab.py
 #: ./opengever/contact/contact.py
 msgid "label_phone_office"
-msgstr "Phone office"
+msgstr "Phone (work)"
 
 #. German translation: Bild
 #. Default: "Picture"
@@ -487,6 +490,7 @@ msgstr "Roles"
 
 #. German translation: Anrede
 #. Default: "Salutation"
+#. MARKER: questionable
 #: ./opengever/contact/browser/person.py
 #: ./opengever/contact/browser/templates/person.pt
 #: ./opengever/contact/contact.py
@@ -497,7 +501,7 @@ msgstr "Salutation"
 #. Default: "Sequence Number"
 #: ./opengever/contact/browser/byline.py
 msgid "label_sequence_number"
-msgstr "Sequence Number"
+msgstr "Sequence number"
 
 #. German translation: Alle ${total} Beteiligungen anzeigen
 #. Default: "Show all ${total} participations"
@@ -508,7 +512,7 @@ msgstr "Show all ${total} participations"
 #. German translation: Alle
 #: ./opengever/contact/browser/tabs.py
 msgid "label_tabbedview_filter_all"
-msgstr "label_tabbedview_filter_all"
+msgstr "All"
 
 #. German translation: Teams
 #. Default: "Teams"
@@ -526,7 +530,7 @@ msgstr "Title"
 #. Default: "Url"
 #: ./opengever/contact/contact.py
 msgid "label_url"
-msgstr "Url"
+msgstr "URL"
 
 #. German translation: URLs
 #. Default: "URLs"
@@ -545,7 +549,7 @@ msgstr "Users"
 #. Default: "ZIP"
 #: ./opengever/contact/contact.py
 msgid "label_zip"
-msgstr "ZIP"
+msgstr "ZIP code"
 
 #. German translation: Funktion
 #. Default: "Function"
@@ -557,19 +561,19 @@ msgstr "Function"
 #. Default: "Mailaddress successfully deleted"
 #: ./opengever/contact/browser/mail.py
 msgid "mail_address_deleted"
-msgstr "Mailaddress successfully deleted"
+msgstr "Email address deleted successfully"
 
 #. German translation: Für diesen Kontakt existiert bereits eine Beteiligung.
 #. Default: "There already exists a participation for this contact."
 #: ./opengever/contact/browser/participation_forms.py
 msgid "msg_participation_already_exists"
-msgstr "There already exists a participation for this contact."
+msgstr "A participation already exists for this contact."
 
 #. German translation: Persönliche Angaben
 #. Default: "Personal Stuff"
 #: ./opengever/contact/contact.py
 msgid "personal"
-msgstr "Personal Stuff"
+msgstr "Personal details"
 
 #. German translation: ${amount} Treffer
 #. Default: "${amount} matches"
@@ -581,4 +585,4 @@ msgstr "${amount} matches"
 #. Default: "Telefon"
 #: ./opengever/contact/contact.py
 msgid "telefon"
-msgstr "Telefon"
+msgstr "Phone"

--- a/opengever/contact/tests/test_byline.py
+++ b/opengever/contact/tests/test_byline.py
@@ -19,12 +19,12 @@ class TestContactByline(FunctionalTestCase):
 
         browser.login().open(self.contactfolder, view=person.wrapper_id)
         self.assertEquals(
-            ['Sequence Number: 1'],
+            ['Sequence number: 1'],
             browser.css('#plone-document-byline .sequenceNumber').text)
 
         browser.open(self.contactfolder, view=organization.wrapper_id)
         self.assertEquals(
-            ['Sequence Number: 2'],
+            ['Sequence number: 2'],
             browser.css('#plone-document-byline .sequenceNumber').text)
 
     @browsing

--- a/opengever/contact/tests/test_contact.py
+++ b/opengever/contact/tests/test_contact.py
@@ -32,8 +32,8 @@ class TestContact(SolrIntegrationTestCase):
 
         browser.open(self.contactfolder)
         factoriesmenu.add('Contact')
-        browser.fill({'Firstname': 'Hanspeter',
-                      'Lastname': 'D\xc3\xbcrr'})
+        browser.fill({'First name': 'Hanspeter',
+                      'Last name': 'D\xc3\xbcrr'})
         browser.find('Save').click()
 
         self.assertEqual(
@@ -46,7 +46,7 @@ class TestContact(SolrIntegrationTestCase):
         self.login(self.regular_user)
 
         browser.login().open(self.hanspeter_duerr, view='edit')
-        browser.fill({'Lastname': 'Walter'})
+        browser.fill({'Last name': 'Walter'})
         browser.find('Save').click()
 
         self.assertEqual('Walter Hanspeter', browser.css('h1').first.text)

--- a/opengever/contact/tests/test_contactfolder.py
+++ b/opengever/contact/tests/test_contactfolder.py
@@ -51,7 +51,7 @@ class TestLocalContactListing(SolrIntegrationTestCase):
         browser.open(self.contactfolder, view='tabbedview_view-local')
 
         self.assertEquals(
-            [u'Lastname Firstname email Phone office',
+            [u'Last name First name Email 1 Phone (work)',
              u'D\xfcrr Hanspeter',
              u'Meier Franz meier.f@example.com'],
             browser.css('.listing').first.rows.text)

--- a/opengever/contact/tests/test_mail_addresses_view.py
+++ b/opengever/contact/tests/test_mail_addresses_view.py
@@ -132,7 +132,7 @@ class TestMailAddressesView(FunctionalTestCase):
         browser.login().visit(self.contactfolder, view='contact-1/mails/1/delete')
 
         self.assertDictContainsSubset({
-            'message': 'Mailaddress successfully deleted',
+            'message': 'Email address deleted successfully',
             'messageClass': 'info'},
             browser.json.get('messages')[0])
 

--- a/opengever/contact/tests/test_organization_listing.py
+++ b/opengever/contact/tests/test_organization_listing.py
@@ -28,7 +28,7 @@ class TestOrganizationListing(FunctionalTestCase):
             self.contactfolder, view='tabbedview_view-organizations')
 
         self.assertEquals(
-            [[u'Name', 'Active', 'Former contact id'],
+            [[u'Name', 'Active', 'Former contact ID'],
              [u'AAA Design', 'Yes', '445566'],
              [u'Meier AG', 'Yes', '112233']],
             browser.css('.listing').first.lists())
@@ -51,7 +51,7 @@ class TestOrganizationListing(FunctionalTestCase):
             data={'organization_state_filter': 'filter_all'})
 
         self.assertEquals(
-            [[u'Name', 'Active', 'Former contact id'],
+            [[u'Name', 'Active', 'Former contact ID'],
              [u'AAA Design', 'Yes', '445566'],
              [u'Meier AG', 'Yes', '112233'],
              [u'M\xfcller', 'No', '']],
@@ -74,6 +74,6 @@ class TestOrganizationListing(FunctionalTestCase):
             data={'searchable_text': 'Design'})
 
         self.assertEquals(
-            [[u'Name', 'Active', 'Former contact id'],
+            [[u'Name', 'Active', 'Former contact ID'],
              [u'AAA Design', 'Yes', '445566']],
             browser.css('.listing').first.lists())

--- a/opengever/contact/tests/test_participation.py
+++ b/opengever/contact/tests/test_participation.py
@@ -345,7 +345,7 @@ class TestAddForm(FunctionalTestCase):
 
         self.assertEquals(['There were some errors.'], error_messages())
         self.assertEquals(
-            ['There already exists a participation for this contact.'],
+            ['A participation already exists for this contact.'],
             browser.css('div.error').text),
 
 

--- a/opengever/contact/tests/test_person.py
+++ b/opengever/contact/tests/test_person.py
@@ -31,8 +31,8 @@ class TestPerson(FunctionalTestCase):
 
         browser.fill({'Salutation': u'Sir',
                       'Academic title': u'Dr',
-                      'Firstname': u'Hanspeter',
-                      'Lastname': u'Hansj\xf6rg',
+                      'First name': u'Hanspeter',
+                      'Last name': u'Hansj\xf6rg',
                       'Description': u'Pellentesque posuere.'}).submit()
 
         self.assertEquals([u'Record created'], info_messages())
@@ -59,8 +59,8 @@ class TestPerson(FunctionalTestCase):
 
         browser.fill({'Salutation': u'Sir',
                       'Academic title': u'Dr',
-                      'Firstname': u'Hanspeter',
-                      'Lastname': u'Hansj\xf6rg',
+                      'First name': u'Hanspeter',
+                      'Last name': u'Hansj\xf6rg',
                       'Description': u'Pellentesque posuere.'}).submit()
 
         self.assertEquals([u'Changes saved'], info_messages())

--- a/opengever/contact/tests/test_person_listing.py
+++ b/opengever/contact/tests/test_person_listing.py
@@ -6,8 +6,8 @@ from opengever.testing import FunctionalTestCase
 
 class TestPersonListing(FunctionalTestCase):
 
-    labels = ['Salutation', 'Academic title', 'Firstname',
-              'Lastname', 'Active', 'Organizations', 'Former contact id']
+    labels = ['Salutation', 'Academic title', 'First name',
+              'Last name', 'Active', 'Organizations', 'Former contact ID']
 
     def setUp(self):
         super(TestPersonListing, self).setUp()
@@ -67,7 +67,7 @@ class TestPersonListing(FunctionalTestCase):
         table = browser.css('.listing').first
         self.assertEquals(
             ['Albert', 'Mustermann', u'M\xfcller'],
-            [row.get('Lastname') for row in table.dicts()])
+            [row.get('Last name') for row in table.dicts()])
 
     @browsing
     def test_first_and_lastname_are_linked_to_person_view(self, browser):

--- a/opengever/contact/tests/test_team_listing.py
+++ b/opengever/contact/tests/test_team_listing.py
@@ -14,19 +14,19 @@ class TestTeamListing(IntegrationTestCase):
             {
                 'Active': 'Yes',
                 'Group': 'Projekt A',
-                'Org Unit': u'Finanz\xe4mt',
+                'Organizational unit': u'Finanz\xe4mt',
                 'Title': u'Projekt \xdcberbaung Dorfmatte',
             },
             {
                 'Active': 'Yes',
                 'Group': u'Projekt L\xc3\xa4\xc3\xa4r',
-                'Org Unit': u'Finanz\xe4mt',
+                'Organizational unit': u'Finanz\xe4mt',
                 'Title': 'Sekretariat Abteilung Null',
             },
             {
                 'Active': 'Yes',
                 'Group': 'Projekt B',
-                'Org Unit': u'Finanz\xe4mt',
+                'Organizational unit': u'Finanz\xe4mt',
                 'Title': 'Sekretariat Abteilung XY',
             },
         ]


### PR DESCRIPTION
Clean up English `og.contact` translations.

The unusual plural form `Persons` (instead of "People") is used (at least) for a tab title that sits right next to `Organizations`.

https://www.grammarly.com/blog/persons-people-peoples/ says:
> [...] nowadays, the plural persons is only considered correct in legal contexts and, occasionally, *when deliberately referring to humans individually rather than collectively*.

I think that applies here - we're not referring to a crowd _(of people)_, but individual person records.

For overall comments on the process, please see PR #6806

Jira: https://4teamwork.atlassian.net/browse/CA-883