### PR TITLE
Clean up English og.globalindex translations.

### DIFF
--- a/opengever/globalindex/locales/en/LC_MESSAGES/opengever.globalindex.po
+++ b/opengever/globalindex/locales/en/LC_MESSAGES/opengever.globalindex.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-01-08 11:40+0000\n"
+"POT-Creation-Date: 2021-01-13 16:44+0000\n"
 "PO-Revision-Date: 2016-07-22 15:25+0000\n"
 "Last-Translator: Philippe Gross <gross.philippe@gmail.com>\n"
 "Language-Team: German <https://translations.onegovgever.ch/projects/onegov-gever/opengever-globalindex/de/>\n"
@@ -30,47 +30,48 @@ msgstr "You have not selected any items."
 #. German translation: Verwaltungseinheit
 #: ./opengever/globalindex/browser/report.py
 msgid "label_admin_unit_id"
-msgstr "label_admin_unit_id"
+msgstr "Tenant"
 
 #. German translation: Erledigt am
 #: ./opengever/globalindex/browser/report.py
 msgid "label_completed"
-msgstr "label_completed"
+msgstr "Completed on"
 
 #. German translation: Zu erledigen bis
 #: ./opengever/globalindex/browser/report.py
 msgid "label_deadline"
-msgstr "label_deadline"
+msgstr "Deadline"
 
 #. German translation: Dossier
 #: ./opengever/globalindex/browser/report.py
 msgid "label_dossier"
-msgstr "label_dossier"
+msgstr "Dossier"
 
 #. German translation: Auftraggeber
 #: ./opengever/globalindex/browser/report.py
 msgid "label_issuer"
-msgstr "label_issuer"
+msgstr "Issuer"
 
 #. German translation: Auftraggeber Mandant
+#. MARKER: double check
 #: ./opengever/globalindex/browser/report.py
 msgid "label_issuing_org_unit"
-msgstr "label_issuing_org_unit"
+msgstr "Issuing organization"
 
 #. German translation: Auftragnehmer
 #: ./opengever/globalindex/browser/report.py
 msgid "label_responsible"
-msgstr "label_responsible"
+msgstr "Responsible"
 
 #. German translation: Laufnummer
 #: ./opengever/globalindex/browser/report.py
 msgid "label_sequence_number"
-msgstr "label_sequence_number"
+msgstr "Sequence number"
 
 #. German translation: Auftragstyp
 #: ./opengever/globalindex/browser/report.py
 msgid "label_task_type"
-msgstr "label_task_type"
+msgstr "Task type"
 
 #. German translation: Tasks
 #. Default: "Tasks"
@@ -81,9 +82,9 @@ msgstr "Tasks"
 #. German translation: Titel
 #: ./opengever/globalindex/browser/report.py
 msgid "label_title"
-msgstr "label_title"
+msgstr "Title"
 
 #. German translation: Status
 #: ./opengever/globalindex/browser/report.py
 msgid "review_state"
-msgstr "review_state"
+msgstr "State"

--- a/opengever/globalindex/tests/test_reporter.py
+++ b/opengever/globalindex/tests/test_reporter.py
@@ -24,11 +24,11 @@ class TestTaskReporter(IntegrationTestCase):
 
         # labels
         self.assertSequenceEqual(
-            [u'label_title', u'review_state',
-             u'label_deadline', u'label_completed',
-             u'label_dossier', u'label_issuer',
-             u'label_issuing_org_unit', u'label_responsible',
-             u'label_task_type', 'label_admin_unit_id', u'label_sequence_number'],
+            [u'Title', u'State',
+             u'Deadline', u'Completed on',
+             u'Dossier', u'Issuer',
+             u'Issuing organization', u'Responsible',
+             u'Task type', 'Tenant', u'Sequence number'],
             [cell.value for cell in list(workbook.active.rows)[0]])
 
         # self.task
@@ -86,10 +86,10 @@ class TestTaskReporter(IntegrationTestCase):
 
         # labels
         self.assertSequenceEqual(
-            [u'label_sequence_number', u'review_state',
-             u'label_responsible', u'label_issuer',
-             u'label_task_type', u'label_title',
-             u'label_dossier'],
+            [u'Sequence number', u'State',
+             u'Responsible', u'Issuer',
+             u'Task type', u'Title',
+             u'Dossier'],
             [cell.value for cell in list(workbook.active.rows)[0]])
 
     @browsing


### PR DESCRIPTION
Clean up English `og.globalindex` translations.

For overall comments on the process, please see PR #6806 

Jira: https://4teamwork.atlassian.net/browse/CA-883