### PR TITLE
Clean up English og.dossier translations.

### DIFF
--- a/opengever/api/tests/test_listing.py
+++ b/opengever/api/tests/test_listing.py
@@ -1150,19 +1150,19 @@ class TestSQLDossierParticipationsInListingWithRealSolr(SolrIntegrationTestCase)
         self.assertEqual(self.dossier.absolute_url(), item['@id'])
         self.assertEqual(IUUID(self.dossier), item['UID'])
         self.assertItemsEqual(
-            [u'B\xfchler Josef', u'Meier AG', u'any_participant'],
+            [u'B\xfchler Josef', u'Meier AG', u'Any participant'],
             item['participants'])
         self.assertItemsEqual(
-            [u'any_role', u'Participation', u'Final drawing'],
+            [u'Any role', u'Participation', u'Final drawing'],
             item['participation_roles'])
         self.assertItemsEqual(
-            [u'B\xfchler Josef|any_role',
+            [u'B\xfchler Josef|Any role',
              u'B\xfchler Josef|Final drawing',
-             u'any_participant|Participation',
-             u'Meier AG|any_role',
+             u'Any participant|Participation',
+             u'Meier AG|Any role',
              u'B\xfchler Josef|Participation',
              u'Meier AG|Final drawing',
-             u'any_participant|Final drawing'],
+             u'Any participant|Final drawing'],
             item['participations'])
 
 
@@ -1209,21 +1209,21 @@ class TestPloneDossierParticipationsInListingWithRealSolr(SolrIntegrationTestCas
         self.assertItemsEqual(
             [u'Ziegler Robert (robert.ziegler)',
              u'B\xe4rfuss K\xe4thi (kathi.barfuss)',
-             u'any_participant'],
+             u'Any participant'],
             item['participants'])
         self.assertItemsEqual(
-            [u'any_role', u'Regard', u'Participation', u'Final drawing'],
+            [u'Any role', u'Regard', u'Participation', u'Final drawing'],
             item['participation_roles'])
         self.assertItemsEqual(
             [u'Ziegler Robert (robert.ziegler)|Regard',
-             u'Ziegler Robert (robert.ziegler)|any_role',
-             u'any_participant|Regard',
+             u'Ziegler Robert (robert.ziegler)|Any role',
+             u'Any participant|Regard',
              u'B\xe4rfuss K\xe4thi (kathi.barfuss)|Participation',
              u'B\xe4rfuss K\xe4thi (kathi.barfuss)|Regard',
-             u'any_participant|Participation',
-             u'B\xe4rfuss K\xe4thi (kathi.barfuss)|any_role',
+             u'Any participant|Participation',
+             u'B\xe4rfuss K\xe4thi (kathi.barfuss)|Any role',
              u'B\xe4rfuss K\xe4thi (kathi.barfuss)|Final drawing',
-             u'any_participant|Final drawing'],
+             u'Any participant|Final drawing'],
             item['participations'])
 
     @browsing

--- a/opengever/base/tests/test_ploneform_macros.py
+++ b/opengever/base/tests/test_ploneform_macros.py
@@ -30,7 +30,7 @@ class TestRegressionPloneformMacros(IntegrationTestCase):
         factoriesmenu.add(u'Business Case Dossier')
 
         # fill invalid
-        browser.fill({'Title': 'foo', 'Opening Date': 'invalid'})
+        browser.fill({'Title': 'foo', 'Start date': 'invalid'})
         browser.find('Save').click()
         self.assertEqual([], info_messages())
         self.assertEqual(['There were some errors.'], error_messages())

--- a/opengever/base/tests/test_relations.py
+++ b/opengever/base/tests/test_relations.py
@@ -14,7 +14,7 @@ class TestRelations(IntegrationTestCase):
         browser.open(self.leaf_repofolder,
                      view='++add++opengever.dossier.businesscasedossier')
         browser.fill({'Title': 'Dossier B with relations',
-                      'Related Dossier': [self.dossier]})
+                      'Related dossiers': [self.dossier]})
         browser.find('Save').click()
 
         rel_catalog = getUtility(ICatalog)
@@ -34,7 +34,7 @@ class TestRelations(IntegrationTestCase):
 
         browser.open(self.empty_dossier, view='edit')
         browser.fill({'Title': 'Dossier B with relations',
-                      'Related Dossier': [self.dossier]})
+                      'Related dossiers': [self.dossier]})
         browser.find('Save').click()
 
         rel_catalog = getUtility(ICatalog)

--- a/opengever/disposition/tests/test_excel_export.py
+++ b/opengever/disposition/tests/test_excel_export.py
@@ -20,7 +20,7 @@ class TestDispositionExcelExport(IntegrationTestCase):
             workbook = load_workbook(tmpfile.name)
 
             self.assertEquals(
-                [u'Reference Number', u'Title', u'Start date',
+                [u'Reference number', u'Title', u'Start date',
                  u'End date', u'Public access level', u'Archival value',
                  u'Comment about archival value assessment', u'Appraisal'],
                 [cell.value for cell in list(workbook.active.rows)[0]])

--- a/opengever/disposition/tests/test_excel_export.py
+++ b/opengever/disposition/tests/test_excel_export.py
@@ -20,8 +20,8 @@ class TestDispositionExcelExport(IntegrationTestCase):
             workbook = load_workbook(tmpfile.name)
 
             self.assertEquals(
-                [u'Reference Number', u'Title', u'Opening Date',
-                 u'Closing Date', u'Public access level', u'Archival value',
+                [u'Reference Number', u'Title', u'Start date',
+                 u'End date', u'Public access level', u'Archival value',
                  u'Comment about archival value assessment', u'Appraisal'],
                 [cell.value for cell in list(workbook.active.rows)[0]])
             self.assertTrue(workbook.active['A1'].font.bold)

--- a/opengever/dossier/locales/en/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/en/LC_MESSAGES/opengever.dossier.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2021-01-08 11:40+0000\n"
+"POT-Creation-Date: 2021-01-13 22:26+0000\n"
 "PO-Revision-Date: 2017-05-23 04:53+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: German <https://translations.onegovgever.ch/projects/onegov-gever/opengever-dossier/de/>\n"
@@ -19,7 +19,7 @@ msgstr ""
 #. German translation:  (nächtliche Abschlussarbeiten ausstehend)
 #: ./opengever/dossier/viewlets/byline.py
 msgid " (after resolve jobs pending)"
-msgstr " (after resolve jobs pending)"
+msgstr " (nightly post-resolve jobs pending)"
 
 #. German translation:  (wird gerade abgeschlossen)
 #: ./opengever/dossier/viewlets/byline.py
@@ -39,7 +39,7 @@ msgstr "A dossier manager must be selected  when protecting a dossier"
 #. German translation: Geschäftsdossier hinzufügen
 #. Default: "Geschäftsdossier"
 msgid "Add Business Case Dossier"
-msgstr "Geschäftsdossier"
+msgstr "Add business case dossier"
 
 #. German translation: Subdossier hinzufügen
 #: ./opengever/dossier/browser/forms.py
@@ -95,7 +95,7 @@ msgstr "Dossier template"
 #. German translation: Das Dossier wurde erfolgreich wieder eröffnet.
 #: ./opengever/dossier/reactivate.py
 msgid "Dossiers successfully reactivated."
-msgstr "Dossiers successfully reactivated."
+msgstr "Dossier successfully reactivated."
 
 #. German translation: Subdossier bearbeiten
 #: ./opengever/dossier/browser/forms.py
@@ -111,22 +111,22 @@ msgstr "Export selection"
 #. German translation: Folgende Elemente konnten nicht verschoben werden: ${failed_objects}
 #: ./opengever/dossier/move_items.py
 msgid "Failed to move following objects: ${failed_objects}"
-msgstr "Failed to move following objects: ${failed_objects}"
+msgstr "Unable to move the following objects: ${failed_objects}"
 
 #. German translation: Folgende Elemente konnten nicht verschoben werden: ${failed_objects}. Sie werden zurzeit im Office Connector bearbeitet.
 #: ./opengever/dossier/move_items.py
 msgid "Failed to move following objects: ${failed_objects}. They are currently being edited in the Office Connector."
-msgstr "Failed to move following objects: ${failed_objects}. They are currently being edited in the Office Connector."
+msgstr "Unable to move the following objects: ${failed_objects}. They are currently being edited in Office Connector."
 
 #. German translation: Sie dürfen dieses Objekt nicht an den Zielort verschieben.
 #: ./opengever/dossier/move_items.py
 msgid "It isn't allowed to add such items there."
-msgstr "It isn't allowed to add such items there."
+msgstr "This object may not be moved to the target container."
 
 #. German translation: Es ist nicht möglich das Subdossier wieder zu eröffnen, das Hauptdossier muss wieder eröffnet werden.
 #: ./opengever/dossier/reactivate.py
 msgid "It isn't possible to reactivate a sub dossier."
-msgstr "It isn't possible to reactivate a sub dossier."
+msgstr "A subdossier may not be reopened on its own. Please reopen the main dossier."
 
 #. German translation: Neuste Dokumente
 #: ./opengever/dossier/browser/overview.py
@@ -151,7 +151,7 @@ msgstr "Not all linked workspaces are deactivated."
 #. German translation: Nicht alle benötigten Felder wurden ausgefüllt.
 #: ./opengever/dossier/archive.py
 msgid "Not all required fields are filled."
-msgstr "Not all required fields are filled."
+msgstr "Some required fields are missing."
 
 #. German translation: Beteiligungen
 #: ./opengever/dossier/browser/overview.py
@@ -171,7 +171,7 @@ msgstr "Select document"
 #. German translation: Vorlage auswählen
 #: ./opengever/dossier/dossiertemplate/form.py
 msgid "Select dossiertemplate"
-msgstr "Select dossiertemplate"
+msgstr "Select dossier template"
 
 #. German translation: Empfänger-Adresse auswählen
 #: ./opengever/dossier/templatefolder/form.py
@@ -187,44 +187,50 @@ msgstr "Subdossier"
 #. German translation: Vorlagenordner
 #: ./opengever/dossier/upgrades/20170214083741_rename_template_dossier_to_template_folder/types/opengever.dossier.templatefolder.xml
 msgid "Template Folder"
-msgstr "Template Folder"
+msgstr "Template folder"
 
 #. German translation: Vorlagen
 #. Default: "expired"
 msgid "Templates"
-msgstr "expired"
+msgstr "Templates"
 
 #. German translation: Der Benutzer darf das Dossier ${dossier} nicht stornieren.
 #: ./opengever/dossier/deactivate.py
 msgid "The Dossier ${dossier} can't be deactivated by the user."
-msgstr "The Dossier ${dossier} can't be deactivated by the user."
+msgstr "Dossier ${dossier} may not by the user."
 
 #. German translation: Das Dossier ${dossier} enthält ein Subdossier welches der Benutzer nicht stornieren darf.
+#. MARKER: used-in-api-response
 #: ./opengever/dossier/deactivate.py
 msgid "The Dossier ${dossier} contains a subdossier which can't be deactivated by the user."
 msgstr "The Dossier ${dossier} contains a subdossier which can't be deactivated by the user."
 
 #. German translation: Das Dossier kann nicht storniert werden, es enthält aktive Anträge.
+#. MARKER: used-in-api-response
 #: ./opengever/dossier/deactivate.py
 msgid "The Dossier can't be deactivated, it contains active proposals."
 msgstr "The Dossier can't be deactivated, it contains active proposals."
 
 #. German translation: Das Dossier kann nicht storniert werden, da nicht alle enthaltenen Dokumente eingecheckt sind.
+#. MARKER: used-in-api-response
 #: ./opengever/dossier/deactivate.py
 msgid "The Dossier can't be deactivated, not all contained documents are checked in."
 msgstr "The Dossier can't be deactivated, not all contained documents are checked in."
 
 #. German translation: Das Dossier kann nicht storniert werden, da nicht alle enthaltenen Aufgaben abgeschlossen sind.
+#. MARKER: used-in-api-response
 #: ./opengever/dossier/deactivate.py
 msgid "The Dossier can't be deactivated, not all contained tasks are in a closed state."
 msgstr "The Dossier can't be deactivated, not all contained tasks are in a closed state."
 
 #. German translation: Das Dossier kann nicht storniert werden, da nicht alle verlinkten Teamräume deaktiviert sind.
+#. MARKER: used-in-api-response
 #: ./opengever/dossier/deactivate.py
 msgid "The Dossier can't be deactivated, not all linked workspaces are deactivated."
 msgstr "The Dossier can't be deactivated, not all linked workspaces are deactivated."
 
 #. German translation: Das Dossier konnte nicht storniert werden, da das Subdossier ${dossier} bereits abgeschlossen ist. Das Subdossier muss vorgängig wieder eröffnet werden.
+#. MARKER: used-in-api-response
 #: ./opengever/dossier/deactivate.py
 msgid "The Dossier can't be deactivated, the subdossier ${dossier} is already resolved."
 msgstr "The Dossier can't be deactivated, the subdossier ${dossier} is already resolved."
@@ -232,19 +238,20 @@ msgstr "The Dossier can't be deactivated, the subdossier ${dossier} is already r
 #. German translation: Das Dossier wurde aktiviert.
 #: ./opengever/dossier/activate.py
 msgid "The Dossier has been activated"
-msgstr "The Dossier has been activated"
+msgstr "Dossier has been activated"
 
 #. German translation: Das Dossier wurde storniert.
 #: ./opengever/dossier/deactivate.py
 msgid "The Dossier has been deactivated"
-msgstr "The Dossier has been deactivated"
+msgstr "Dossier has been deactivated"
 
 #. German translation: Das Dossier wurde erfolgreich abgeschlossen
 #: ./opengever/dossier/archive.py
 msgid "The Dossier has been resolved"
-msgstr "The Dossier has been resolved"
+msgstr "Dossier has been resolved"
 
 #. German translation: Das Dossier ${dossier} hat ein ungültiges Enddatum.
+#. MARKER: used-in-api-response
 #: ./opengever/dossier/resolve.py
 msgid "The dossier ${dossier} has a invalid end_date"
 msgstr "The dossier ${dossier} has a invalid end_date"
@@ -252,37 +259,37 @@ msgstr "The dossier ${dossier} has a invalid end_date"
 #. German translation: Das Dossier enthält aktive Anträge.
 #: ./opengever/dossier/resolve.py
 msgid "The dossier contains active proposals."
-msgstr "The dossier contains active proposals."
+msgstr "Dossier contains active proposals."
 
 #. German translation: Das Dossier wurde erfolgreich abgeschlossen.
 #: ./opengever/dossier/resolve.py
 msgid "The dossier has been succesfully resolved."
-msgstr "The dossier has been succesfully resolved."
+msgstr "Dossier has been resolved succesfully."
 
 #. German translation: Die Ablagenummer wurde vergeben.
 #: ./opengever/dossier/archive.py
 msgid "The filing number has been given."
-msgstr "The filing number has been given."
+msgstr "Filing number issued."
 
 #. German translation: Das Ende-Datum ist ungültig, es muss jünger oder gleich sein wie das Datum des jüngsten enthaltenen Dokuments (${date}).
 #: ./opengever/dossier/archive.py
 msgid "The given end date is not valid, it needs to be younger or                  equal than ${date} (the youngest contained object)."
-msgstr "The given end date is not valid, it needs to be younger or                  equal than ${date} (the youngest contained object)."
+msgstr "The given end date is not valid. It needs to be more recent or equal to the most recent contained object's date (${date})."
 
 #. German translation: Das angegeben Ablagejahr ist ungültig.
 #: ./opengever/dossier/archive.py
 msgid "The given value is not a valid Year."
-msgstr "The given value is not a valid Year."
+msgstr "The given filing year value is not valid."
 
 #. German translation: Die selektierten Objekte konnten nicht gefunden werden, bitte versuchen Sie es erneut.
 #: ./opengever/dossier/move_items.py
 msgid "The selected objects can't be found, please try it again."
-msgstr "The selected objects can't be found, please try it again."
+msgstr "The selected objects can't be found, please try again."
 
 #. German translation: Das Beginn-Datum muss vor dem Ende-Datum liegen.
 #: ./opengever/dossier/behaviors/dossier.py
 msgid "The start date must be before the end date."
-msgstr "The start date must be before the end date."
+msgstr "Start date must be before end date."
 
 #. German translation: Das Beginn- oder Ende-Datum ist ungültig.
 #: ./opengever/dossier/behaviors/dossier.py
@@ -292,9 +299,10 @@ msgstr "The start or end date is invalid"
 #. German translation: Das Subdossier wurde erfolgreich abgeschlossen.
 #: ./opengever/dossier/resolve.py
 msgid "The subdossier has been succesfully resolved."
-msgstr "The subdossier has been succesfully resolved."
+msgstr "Subdossier has been resolved succesfully."
 
 #. German translation: Dieses Subdossier kann nicht wieder aktiviert werden, da das Hauptdossier nicht aktiv ist.
+#. MARKER: used-in-api-response
 #: ./opengever/dossier/activate.py
 msgid "This subdossier can't be activated, because the main dossiers is not active"
 msgstr "This subdossier can't be activated, because the main dossiers is not active"
@@ -302,31 +310,31 @@ msgstr "This subdossier can't be activated, because the main dossiers is not act
 #. German translation: Mit einer neuen Version des Dossiers ${title} aktualisiert.
 #: ./opengever/dossier/resolve.py
 msgid "Updated with a newer generated version from dossier ${title}."
-msgstr "Updated with a newer generated version from dossier ${title}."
+msgstr "Updated with a fresh version generated from dossier ${title}."
 
 #. German translation: Für die Vergabe der Ablagenummer, werden alle Felder benötigt.
 #: ./opengever/dossier/archive.py
 msgid "When the Action give filing number is selected,                         all fields are required."
-msgstr "When the Action give filing number is selected,                         all fields are required."
+msgstr "All fields are required when issuing a filing number."
 
 #. German translation: Sie haben kein Element ausgewählt
 #: ./opengever/dossier/move_items.py
 msgid "You have not selected any items"
-msgstr "You have not selected any items"
+msgstr "No items selected"
 
 #. German translation: Zusatzattribute
 msgid "additional_attributes"
-msgstr "additional_attributes"
+msgstr "Additional attributes"
 
 #. German translation: Alle
 #: ./opengever/dossier/indexers.py
 msgid "any_participant"
-msgstr "any_participant"
+msgstr "Any participant"
 
 #. German translation: Alle
 #: ./opengever/dossier/indexers.py
 msgid "any_role"
-msgstr "any_role"
+msgstr "Any role"
 
 #. German translation: Erstellen
 #. Default: "Add"
@@ -335,6 +343,7 @@ msgid "button_add"
 msgstr "Add"
 
 #. German translation: Speichern
+#. MARKER: check in context
 #. Default: "Archive"
 #: ./opengever/dossier/archive.py
 msgid "button_archive"
@@ -376,7 +385,7 @@ msgstr "Contact"
 #. Default: "role_list"
 #: ./opengever/dossier/browser/participants.py
 msgid "column_rolelist"
-msgstr "role_list"
+msgstr "Role"
 
 #. German translation: Dokument aus Vorlage erstellen
 #. Default: "Create document from template"
@@ -394,31 +403,31 @@ msgstr "Create dossier from template"
 #. Default: "This user or group will get the dossier manager role after protecting the dossier."
 #: ./opengever/dossier/behaviors/protect_dossier.py
 msgid "description_dossier_manager"
-msgstr "This user or group will get the dossier manager role after protecting the dossier."
+msgstr "The user or group selected here will be able to modify or disable dossier protection, once enabled. Usually you'd want to at least include yourself here."
 
 #. German translation: Durch Aktivieren dieser Option werden bei der Erstellung des Dossiers ab Vorlage die angegebenen Schlagwörter bereits vorausgefüllt.
 #. Default: "The defined keywords will be preselected for new dossies from template."
 #: ./opengever/dossier/dossiertemplate/behaviors.py
 msgid "description_predefined_keywords"
-msgstr "The defined keywords will be preselected for new dossies from template."
+msgstr "The defined keywords will be preselected for new dossiers created from this template."
 
 #. German translation: Wählen Sie Benutzer und Gruppen aus, welche im Dossier ausschliesslich lesend Zugriff erhalten sollen.
 #. Default: "Choose users and groups which have only readable access to the dossier"
 #: ./opengever/dossier/behaviors/protect_dossier.py
 msgid "description_reading"
-msgstr "Choose users and groups which have only readable access to the dossier"
+msgstr "Select users and/or groups that should get read-only access to this dossier."
 
 #. German translation: Wählen Sie Benutzer und Gruppen aus, welche im Dossier lesend und schreibend Zugriff erhalten sollen. Die Benutzer dieser Gruppe werden dazu berechtigt, das Dossier zu bearbeiten, Inhalte zu erstellen und zu bearbeiten.
 #. Default: "Choose users and groups which have readable and writing access to the dossier"
 #: ./opengever/dossier/behaviors/protect_dossier.py
 msgid "description_reading_and_writing"
-msgstr "Choose users and groups which have readable and writing access to the dossier"
+msgstr "Select users and/or groups that should get read/write access to this dossier. These users will be able to modify the dossier itself, and add as well as edit content in it."
 
 #. German translation: Durch Aktivieren dieser Option stehen bei der Erstellung des Dossiers ab Vorlage nur noch die in der Vorlage angegebenen Schlagwörter zur Auswahl.<br>Der Benutzer kann dadurch auch keine neuen Schlagwörter erfassen.
 #. Default: "The user can choose only from the defined keywords in a new dossier from template. It also prevents the user for creating new keywords"
 #: ./opengever/dossier/dossiertemplate/behaviors.py
 msgid "description_restrict_keywords"
-msgstr "The user can choose only from the defined keywords in a new dossier from template. It also prevents the user for creating new keywords"
+msgstr "Prevent users from adding their own keywords when creating a dossier from this template. Only keywords defined in this template will be allowed."
 
 #. German translation: Dokumente
 msgid "documents"
@@ -428,31 +437,31 @@ msgstr "documents"
 #. Default: "The local roles do not match with the current dossier protection settings. If you save this form, the local roles will be overridden."
 #: ./opengever/dossier/browser/protect_dossier.py
 msgid "dossier_protection_inconsistency_warning"
-msgstr "The local roles do not match with the current dossier protection settings. If you save this form, the local roles will be overridden."
+msgstr "Local roles do not match with current dossier protection settings. If you save this form, local roles will be overridden with the roles specified in protection settings."
 
 #. German translation: Es wurden keine Objekte verschoben. Folgende Objekte dürfen nicht in den Zielordner eingefügt werden: ${failed_objects}
 #. Default: "It isn't allowed to add such items there: ${failed_objects}"
 #: ./opengever/dossier/move_items.py
 msgid "error_NotInContentTypes ${failed_objects}"
-msgstr "It isn't allowed to add such items there: ${failed_objects}"
+msgstr "No objects were moved. The following items are not allowed in the target container because of their type: ${failed_objects}"
 
 #. German translation: Enddatum erforderlich
 #. Default: "The enddate is required."
 #: ./opengever/dossier/archive.py
 msgid "error_enddate"
-msgstr "The enddate is required."
+msgstr "End date is required."
 
 #. German translation: Sie haben keine Objekte ausgewählt.
 #. Default: "You have not selected any items."
 #: ./opengever/dossier/browser/report.py
 msgid "error_no_items"
-msgstr "You have not selected any items."
+msgstr "No items selected."
 
 #. German translation: Für diesen Kontakt existiert bereits eine Beteiligung.
 #. Default: "There is already a participation for this contact."
 #: ./opengever/dossier/browser/forms.py
 msgid "error_participant_already_exists"
-msgstr "There is already a participation for this contact."
+msgstr "A participation already exists for this contact."
 
 #. German translation: ${item} konnte nicht verschoben werden.
 #. Default: "Failed to move ${item}."
@@ -496,21 +505,21 @@ msgstr "Filing number"
 #. German translation: Ablage
 #: ./opengever/dossier/filing/report.py
 msgid "filing_no_filing"
-msgstr "filing_no_filing"
+msgstr "Filing"
 
 #. German translation: Ablagenummer
 #: ./opengever/dossier/filing/report.py
 msgid "filing_no_number"
-msgstr "filing_no_number"
+msgstr "Filing number"
 
 #. German translation: Ablagejahr
 #: ./opengever/dossier/filing/report.py
 msgid "filing_no_year"
-msgstr "filing_no_year"
+msgstr "Filing year"
 
 #. German translation: Ablagenummer vergeben
 msgid "filing_nr"
-msgstr "filing_nr"
+msgstr "Issue filing number"
 
 #. German translation: Ablagenummer
 #. Default: "Filing Number"
@@ -524,7 +533,7 @@ msgstr "Filing Number"
 #: ./opengever/dossier/behaviors/dossier.py
 #: ./opengever/dossier/browser/overview.py
 msgid "filing_prefix"
-msgstr "filing prefix"
+msgstr "Filing number prefix"
 
 #. German translation: Ablage Jahr
 #. Default: "filing Year"
@@ -536,13 +545,13 @@ msgstr "filing Year"
 #. Default: "Archive Dossier"
 #: ./opengever/dossier/archive.py
 msgid "heading_archive_form"
-msgstr "Archive Dossier"
+msgstr "File dossier"
 
 #. German translation: Kommentar zu Dossier `${title}`
 #. Default: "${title} notes / comments"
 #: ./opengever/dossier/viewlets/templates/note.pt
 msgid "heading_dossier_note"
-msgstr "${title} notes / comments"
+msgstr "Notes for dossier `${title}`"
 
 #. German translation: Element verschieben
 #. Default: "Move Item"
@@ -559,51 +568,53 @@ msgstr "Move Items"
 #. German translation: Wählen Sie einen Benutzer oder einen Kontakt aus.
 #: ./opengever/dossier/behaviors/participation.py
 msgid "help_contact"
-msgstr "help_contact"
+msgstr "Choose a user or contact."
 
 #. German translation: Standortangabe des Behälters, in dem ein Dossier in Papierform abgelegt ist
 #: ./opengever/dossier/behaviors/dossier.py
 msgid "help_container_location"
-msgstr "help_container_location"
+msgstr "Location hint for the physical container in which the files are kept."
 
 #. German translation: Art des Behälters, in dem ein Dossier in Papierform abgelegt ist
 #: ./opengever/dossier/behaviors/dossier.py
 msgid "help_container_type"
-msgstr "help_container_type"
+msgstr "Type of physical container the files are kept in."
 
 #. German translation: Live Search: Durchsuchen Sie diesen Mandanten
 #. Default: "Live Search: search the Plone Site"
 #: ./opengever/dossier/move_items.py
 msgid "help_destination"
-msgstr "Live Search: search the Plone Site"
+msgstr "Live search: Search this site"
 
 #. German translation: Geben Sie die vollständige Ablagenummer an.
 #: ./opengever/dossier/filing/advanced_search.py
 msgid "help_filing_number"
-msgstr "help_filing_number"
+msgstr "Exact filling number"
 
 #. German translation: Schlagwörter zur Umschreibung eines Dossiers. Nicht zu verwechseln mit der Ordnungsposition.\nACHTUNG: Beachten Sie bei der Verwendung von Schlagwörter die Datenschutzvorgaben (z.B. keine Eigennamen).
 #: ./opengever/dossier/behaviors/dossier.py
 #: ./opengever/dossier/dossiertemplate/behaviors.py
 msgid "help_keywords"
-msgstr "help_keywords"
+msgstr ""
+"Keywords that describe this dossier.\n"
+"Important: Keep privacy concerns in mind when choosing keywords (e.g. avoid personal data)."
 
 #. German translation: Anzahl Behälter, die ein (grosses) Dossier in Papierform enthalten
 #: ./opengever/dossier/behaviors/dossier.py
 msgid "help_number_of_containers"
-msgstr "help_number_of_containers"
+msgstr "Number of physical containers (for large files)"
 
 #. German translation: Neuen Kommentar erfassen.
 #. Default: "Create a new note"
 #: ./opengever/dossier/viewlets/templates/note.pt
 msgid "help_text_add_note"
-msgstr "Create a new note"
+msgstr "Add a new note"
 
 #. German translation: Es wurde ein Kommentar erfasst!
 #. Default: "There is a note"
 #: ./opengever/dossier/viewlets/templates/note.pt
 msgid "help_text_edit_note"
-msgstr "There is a note"
+msgstr "Note added."
 
 #. German translation: Kommentar anzeigen.
 #. Default: "View note"
@@ -615,7 +626,7 @@ msgstr "View note"
 #. Default: "Recommendation for the title. Will be displayed as a help text if you create a dossier from template"
 #: ./opengever/dossier/dossiertemplate/behaviors.py
 msgid "help_title_help"
-msgstr "Recommendation for the title. Will be displayed as a help text if you create a dossier from template"
+msgstr "Recommendation for the title. Will be displayed as a help text when creating a dossier from this template."
 
 #. German translation: Die Beteiligung wurde gespeichert.
 #. Default: "Participation created."
@@ -663,7 +674,7 @@ msgstr "Protected Objects"
 #. Default: "by ${author}"
 #: ./opengever/dossier/project_templates/byline.pt
 msgid "label_by_author"
-msgstr "by ${author}"
+msgstr "Responsible: ${author}"
 
 #. German translation: Abbrechen
 #. Default: "Cancel"
@@ -687,21 +698,22 @@ msgstr "Comments"
 
 #. German translation: Person
 #. Default: "Contact"
+#. MARKER: check in context
 #: ./opengever/dossier/behaviors/participation.py
 msgid "label_contact"
-msgstr "Contact"
+msgstr "Person"
 
 #. German translation: Behältnis-Standort
 #. Default: "Container Location"
 #: ./opengever/dossier/behaviors/dossier.py
 msgid "label_container_location"
-msgstr "Container Location"
+msgstr "Physical container location"
 
 #. German translation: Behältnis-Art
 #. Default: "Container Type"
 #: ./opengever/dossier/behaviors/dossier.py
 msgid "label_container_type"
-msgstr "Container Type"
+msgstr "Physical container Type"
 
 #. German translation: Erstellt von
 #. Default: "Creator"
@@ -739,7 +751,7 @@ msgstr "Dossier manager"
 #. Default: "Create Dossier note"
 #: ./opengever/dossier/viewlets/templates/note.pt
 msgid "label_dossier_note_placeholder"
-msgstr "Create Dossier note"
+msgstr "Add dossier note"
 
 #. German translation: Dossier überfällig
 #. Default: "Overdue dossier"
@@ -769,7 +781,7 @@ msgstr "Edit Note"
 #. Default: "E-Mail"
 #: ./opengever/dossier/viewlets/byline.py
 msgid "label_email_address"
-msgstr "E-Mail"
+msgstr "Email"
 
 #. German translation: Ende
 #. Default: "Closing Date"
@@ -777,14 +789,15 @@ msgstr "E-Mail"
 #: ./opengever/dossier/behaviors/dossier.py
 #: ./opengever/dossier/browser/report.py
 msgid "label_end"
-msgstr "Closing Date"
+msgstr "End date"
 
 #. German translation: Ende
 #. Default: "to"
+#. MARKER: check in context
 #: ./opengever/dossier/project_templates/byline.pt
 #: ./opengever/dossier/viewlets/byline.py
 msgid "label_end_byline"
-msgstr "to"
+msgstr "End"
 
 #. German translation: Externe Referenz
 #. Default: "External Reference"
@@ -809,7 +822,7 @@ msgstr "Filing number"
 #. Default: "Reference Number"
 #: ./opengever/dossier/behaviors/dossier.py
 msgid "label_former_reference_number"
-msgstr "Reference Number"
+msgstr "Former reference number"
 
 #. German translation: Info
 #. Default: "Info"
@@ -847,7 +860,7 @@ msgstr "Linked Dossiers"
 #. Default: "Mail-Address"
 #: ./opengever/dossier/templatefolder/form.py
 msgid "label_mail_address"
-msgstr "Mail-Address"
+msgstr "Email address"
 
 #. German translation: Sitzungsvorlagen
 #. Default: "Meeting Templates"
@@ -866,19 +879,19 @@ msgstr "Modified"
 #. Default: "Reference Number will be generated                 after content creation"
 #: ./opengever/dossier/widget.py
 msgid "label_no_reference_number"
-msgstr "Reference Number will be generated                 after content creation"
+msgstr "Reference number will be generated after creation."
 
 #. German translation: Das Dokument «${name}» befindet sich in einem Antrag und ist nicht verschiebbar. Verschieben sie den Antrag.
 #. Default: "Document ${name} is inside a proposal and therefore not movable. Move the proposal instead"
 #: ./opengever/dossier/move_items.py
 msgid "label_not_movable_since_inside_proposal"
-msgstr "Document ${name} is inside a proposal and therefore not movable. Move the proposal instead"
+msgstr "Document ${name} is inside a proposal and therefore not movable. Please move the proposal instead."
 
 #. German translation: Das Dokument «${name}» befindet sich in einer Aufgabe und ist nicht verschiebbar. Verschieben Sie die Aufgabe.
 #. Default: "Document ${name} is inside a task and therefore not movable. Move the task instead"
 #: ./opengever/dossier/move_items.py
 msgid "label_not_movable_since_inside_task"
-msgstr "Document ${name} is inside a task and therefore not movable. Move the task instead"
+msgstr "Document ${name} is inside a task and therefore not movable. Please move the task instead."
 
 #. German translation: Das Dokument «${name}» ist gesperrt und ist nicht verschiebbar.
 #. Default: "Document ${name} is locked and therefore not movable."
@@ -890,7 +903,7 @@ msgstr "Document ${name} is locked and therefore not movable."
 #. Default: "Number of Containers"
 #: ./opengever/dossier/behaviors/dossier.py
 msgid "label_number_of_containers"
-msgstr "Number of Containers"
+msgstr "Number of physical containers"
 
 #. German translation: OneOffixx
 #. Default: "OneOffixx"
@@ -926,13 +939,13 @@ msgstr "Participations"
 #. Default: "Phonenumber"
 #: ./opengever/dossier/templatefolder/form.py
 msgid "label_phonenumber"
-msgstr "Phonenumber"
+msgstr "Phone number"
 
 #. German translation: Schlagwörter vorausfüllen
 #. Default: "Predefined Keywords"
 #: ./opengever/dossier/dossiertemplate/behaviors.py
 msgid "label_predefined_keywords"
-msgstr "Predefined Keywords"
+msgstr "Prefill keywords"
 
 #. German translation: Antragsvorlagen
 #. Default: "Proposal Templates"
@@ -950,13 +963,13 @@ msgstr "Proposals"
 #. Default: "Reading"
 #: ./opengever/dossier/behaviors/protect_dossier.py
 msgid "label_reading"
-msgstr "Reading"
+msgstr "Read only access"
 
 #. German translation: Lesend & schreibend
 #. Default: "Reading and writing"
 #: ./opengever/dossier/behaviors/protect_dossier.py
 msgid "label_reading_and_writing"
-msgstr "Reading and writing"
+msgstr "Read/Write access"
 
 #. German translation: Empfänger
 #. Default: "Recipient"
@@ -1020,27 +1033,28 @@ msgstr "Save"
 #. Default: "Sequence Number"
 #: ./opengever/dossier/viewlets/byline.py
 msgid "label_sequence_number"
-msgstr "Sequence Number"
+msgstr "Sequence number"
 
 #. German translation: Anzeigen
 #. Default: "Show Note"
 #: ./opengever/dossier/viewlets/templates/note.pt
 msgid "label_show_note"
-msgstr "Show Note"
+msgstr "Show note"
 
 #. German translation: Beginn
 #. Default: "Opening Date"
 #: ./opengever/dossier/behaviors/dossier.py
 #: ./opengever/dossier/browser/report.py
 msgid "label_start"
-msgstr "Opening Date"
+msgstr "Start date"
 
 #. German translation: Beginn
 #. Default: "from"
+#. MARKER: check in context
 #: ./opengever/dossier/project_templates/byline.pt
 #: ./opengever/dossier/viewlets/byline.py
 msgid "label_start_byline"
-msgstr "from"
+msgstr "Start"
 
 #. German translation: Subdossiers
 #. Default: "Subdossiers"
@@ -1058,7 +1072,7 @@ msgstr "Tasks"
 #. Default: "Tasktemplate Folders"
 #: ./opengever/dossier/browser/tabbed.py
 msgid "label_tasktemplate_folders"
-msgstr "Tasktemplate Folders"
+msgstr "Task template folders"
 
 #. German translation: Vorlage
 #. Default: "Template"
@@ -1085,13 +1099,13 @@ msgstr "Title"
 #. Default: "Title help"
 #: ./opengever/dossier/dossiertemplate/behaviors.py
 msgid "label_title_help"
-msgstr "Title help"
+msgstr "Title hint"
 
 #. German translation: Änderungsdatum des Dossiers oder seines Inhalts
 #. Default: "Date of modification of the dossier or its content"
 #: ./opengever/dossier/behaviors/dossier.py
 msgid "label_touched"
-msgstr "Date of modification of the dossier or its content"
+msgstr "Modification date of dossier or its content"
 
 #. German translation: Papierkorb
 #. Default: "Trash"
@@ -1128,17 +1142,17 @@ msgstr "Changes saved"
 #. Default: "The object `${title}` is not stored inside a dossier."
 #: ./opengever/dossier/browser/redirect_to_maindossier.py
 msgid "msg_main_dossier_not_found"
-msgstr "The object `${title}` is not stored inside a dossier."
+msgstr "Object `${title}` is not stored inside a dossier."
 
 #. German translation: Es sind nicht alle Dokumente und Aufgaben in Subdossiers abgelegt.
 #: ./opengever/dossier/resolve.py
 msgid "not all documents and tasks are stored in a subdossier."
-msgstr "not all documents and tasks are stored in a subdossier."
+msgstr "Not all documents and tasks have been filed into subdossiers."
 
 #. German translation: Es sind nicht alle Dokumente eingecheckt
 #: ./opengever/dossier/resolve.py
 msgid "not all documents are checked in"
-msgstr "not all documents are checked in"
+msgstr "Not all documents have been checked in yet."
 
 #. German translation: Es sind nicht alle Aufgaben abgeschlossen
 #: ./opengever/dossier/resolve.py
@@ -1149,36 +1163,36 @@ msgstr "not all task are closed"
 #. Default: "Confirm abbord"
 #: ./opengever/dossier/viewlets/comment.py
 msgid "note_text_confirm_abord"
-msgstr "Confirm abbord"
+msgstr "You have unsaved changes. Do you really want to cancel?"
 
 #. German translation: Nur abschliessen (keine Ablagenummer vergeben)
 #: ./opengever/dossier/archive.py
 msgid "only resolve, set filing no later"
-msgstr "only resolve, set filing no later"
+msgstr "Just resolve, don't issue a filing number yet"
 
 #. German translation: Abschliessen und Ablagenummer neu vergeben
 #: ./opengever/dossier/archive.py
 msgid "resolve and set a new filing no"
-msgstr "resolve and set a new filing no"
+msgstr "Resolve and issue a new filing number"
 
 #. German translation: Abschliessen und Ablagenummer vergeben
 #: ./opengever/dossier/archive.py
 msgid "resolve and set filing no"
-msgstr "resolve and set filing no"
+msgstr "Resolve and issue filing number"
 
 #. German translation: Abschliessen und die existierende Ablagenummer verwenden
 #: ./opengever/dossier/archive.py
 msgid "resolve and take the existing filing no"
-msgstr "resolve and take the existing filing no"
+msgstr "Resolve and reuse existing filing number"
 
 #. German translation: Ablagenummer vergeben
 #: ./opengever/dossier/archive.py
 msgid "set a filing no"
-msgstr "set a filing no"
+msgstr "Issue filing number"
 
 #. German translation: Beteiligungen
 msgid "sharing"
-msgstr "sharing"
+msgstr "Participations"
 
 #. German translation: Subdossiers
 msgid "subdossiers"
@@ -1188,7 +1202,7 @@ msgstr "subdossiers"
 #. Default: "The dossier is still open after exceeding its end date."
 #: ./opengever/dossier/activities.py
 msgid "summary_dossier_overdue_activity"
-msgstr "The dossier is still open after exceeding its end date."
+msgstr "Dossier is past its end date. Please check whether it can be resolved."
 
 #. German translation: Aufgaben
 msgid "tasks"
@@ -1203,12 +1217,12 @@ msgstr "Temporary former reference number"
 #. German translation: Kommentar löschen (Löscht den Kommentar und schliesst das Overlay).
 #: ./opengever/dossier/viewlets/templates/note.pt
 msgid "text_delete_note"
-msgstr "text_delete_note"
+msgstr "Delete note (removes the note and closes the overlay)"
 
 #. German translation: Es wurde kein Beginn-Datum gesetzt.
 #: ./opengever/dossier/resolve.py
 msgid "the dossier start date is missing."
-msgstr "the dossier start date is missing."
+msgstr "Start date is missing."
 
 #. German translation: abgelaufen
 #. Default: "expired"
@@ -1232,4 +1246,4 @@ msgstr "Task list of dossier ${title}, ${timestamp}"
 #. Default: "You didn't select any participants."
 #: ./opengever/dossier/browser/forms.py
 msgid "warning_no_participants_selected"
-msgstr "You didn't select any participants."
+msgstr "No participants selected."

--- a/opengever/dossier/locales/en/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/en/LC_MESSAGES/opengever.dossier.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2021-01-13 22:26+0000\n"
+"POT-Creation-Date: 2021-01-13 23:16+0000\n"
 "PO-Revision-Date: 2017-05-23 04:53+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: German <https://translations.onegovgever.ch/projects/onegov-gever/opengever-dossier/de/>\n"
@@ -29,12 +29,12 @@ msgstr " (currently being resolved)"
 #. German translation: ${copied_items} Elemente wurden erfolgreich verschoben
 #: ./opengever/dossier/move_items.py
 msgid "${copied_items} Elements were moved successfully"
-msgstr "${copied_items} Elements were moved successfully"
+msgstr "${copied_items} elements were moved successfully"
 
 #. German translation: Ein Dossier-Verwalter muss ausgewählt werden um das Dossier schützen zu können.
 #: ./opengever/dossier/behaviors/protect_dossier.py
 msgid "A dossier manager must be selected  when protecting a dossier"
-msgstr "A dossier manager must be selected  when protecting a dossier"
+msgstr "A dossier manager must be selected when protecting a dossier"
 
 #. German translation: Geschäftsdossier hinzufügen
 #. Default: "Geschäftsdossier"
@@ -45,7 +45,7 @@ msgstr "Add business case dossier"
 #: ./opengever/dossier/browser/forms.py
 #: ./opengever/dossier/dossiertemplate/dossiertemplate.py
 msgid "Add Subdossier"
-msgstr "Add Subdossier"
+msgstr "Add subdossier"
 
 #. German translation: Dossier hinzufügen
 #: ./opengever/dossier/dossiertemplate/form.py
@@ -101,7 +101,7 @@ msgstr "Dossier successfully reactivated."
 #: ./opengever/dossier/browser/forms.py
 #: ./opengever/dossier/dossiertemplate/dossiertemplate.py
 msgid "Edit Subdossier"
-msgstr "Edit Subdossier"
+msgstr "Edit subdossier"
 
 #. German translation: Auswahl exportieren
 #: ./opengever/dossier/upgrades/profiles/2601/actions.xml
@@ -141,7 +141,7 @@ msgstr "Newest tasks"
 #. German translation: Keine Subdossiers
 #: ./opengever/dossier/browser/templates/overview.pt
 msgid "No Subdossiers"
-msgstr "No Subdossiers"
+msgstr "No subdossiers"
 
 #. German translation: Nicht alle verlinkten Teamräume sind deaktiviert.
 #: ./opengever/dossier/resolve.py
@@ -431,7 +431,7 @@ msgstr "Prevent users from adding their own keywords when creating a dossier fro
 
 #. German translation: Dokumente
 msgid "documents"
-msgstr "documents"
+msgstr "Documents"
 
 #. German translation: Die lokalen Berechtigungen stimmen nicht mit den Dossier-Schutz Einstellungen überein. Wenn Sie dieses Formular speichern, werden die aktuellen lokalen Berechtigungen mit den Dossier-Schutz Einstellungen überschrieben.
 #. Default: "The local roles do not match with the current dossier protection settings. If you save this form, the local roles will be overridden."
@@ -525,7 +525,7 @@ msgstr "Issue filing number"
 #. Default: "Filing Number"
 #: ./opengever/dossier/filing/tabs.py
 msgid "filing_number"
-msgstr "Filing Number"
+msgstr "Filing number"
 
 #. German translation: Ablage Präfix
 #. Default: "filing prefix"
@@ -539,7 +539,7 @@ msgstr "Filing number prefix"
 #. Default: "filing Year"
 #: ./opengever/dossier/archive.py
 msgid "filing_year"
-msgstr "filing Year"
+msgstr "Filing year"
 
 #. German translation: Dossier ablegen
 #. Default: "Archive Dossier"
@@ -557,13 +557,13 @@ msgstr "Notes for dossier `${title}`"
 #. Default: "Move Item"
 #: ./opengever/dossier/move_items.py
 msgid "heading_move_item"
-msgstr "Move Item"
+msgstr "Move item"
 
 #. German translation: Elemente verschieben
 #. Default: "Move Items"
 #: ./opengever/dossier/move_items.py
 msgid "heading_move_items"
-msgstr "Move Items"
+msgstr "Move items"
 
 #. German translation: Wählen Sie einen Benutzer oder einen Kontakt aus.
 #: ./opengever/dossier/behaviors/participation.py
@@ -650,7 +650,7 @@ msgstr "${item} was moved."
 #. Default: "Add Note"
 #: ./opengever/dossier/viewlets/templates/note.pt
 msgid "label_add_note"
-msgstr "Add Note"
+msgstr "Add note"
 
 #. German translation: Erlaubte Dossiervorlagen
 #. Default: "Addable dossier templates"
@@ -668,7 +668,7 @@ msgstr "Address"
 #. Default: "Protected Objects"
 #: ./opengever/dossier/browser/tabbed.py
 msgid "label_blocked_local_roles"
-msgstr "Protected Objects"
+msgstr "Protected objects"
 
 #. German translation: Federführend: ${author}
 #. Default: "by ${author}"
@@ -775,7 +775,7 @@ msgstr "Edit after creation"
 #. Default: "Edit Note"
 #: ./opengever/dossier/viewlets/templates/note.pt
 msgid "label_edit_note"
-msgstr "Edit Note"
+msgstr "Edit note"
 
 #. German translation: E-Mail
 #. Default: "E-Mail"
@@ -804,13 +804,13 @@ msgstr "End"
 #: ./opengever/dossier/behaviors/dossier.py
 #: ./opengever/dossier/viewlets/byline.py
 msgid "label_external_reference"
-msgstr "External Reference"
+msgstr "External reference"
 
 #. German translation: Ablagenummer
 #. Default: "Filing Number"
 #: ./opengever/dossier/filing/byline.py
 msgid "label_filing_no"
-msgstr "Filing Number"
+msgstr "Filing number"
 
 #. German translation: Ablagenummer
 #. Default: "Filing number"
@@ -854,7 +854,7 @@ msgstr "Label"
 #. Default: "Linked Dossiers"
 #: ./opengever/dossier/browser/overview.py
 msgid "label_linked_dossiers"
-msgstr "Linked Dossiers"
+msgstr "Linked dossiers"
 
 #. German translation: Mail Addresse
 #. Default: "Mail-Address"
@@ -866,7 +866,7 @@ msgstr "Email address"
 #. Default: "Meeting Templates"
 #: ./opengever/dossier/browser/tabbed.py
 msgid "label_meeting_templates"
-msgstr "Meeting Templates"
+msgstr "Meeting templates"
 
 #. German translation: Zuletzt Bearbeitet
 #. Default: "Modified"
@@ -951,7 +951,7 @@ msgstr "Prefill keywords"
 #. Default: "Proposal Templates"
 #: ./opengever/dossier/browser/tabbed.py
 msgid "label_proposal_templates"
-msgstr "Proposal Templates"
+msgstr "Proposal templates"
 
 #. German translation: Anträge
 #. Default: "Proposals"
@@ -983,13 +983,13 @@ msgstr "Recipient"
 #: ./opengever/dossier/browser/report.py
 #: ./opengever/dossier/viewlets/byline.py
 msgid "label_reference_number"
-msgstr "Reference Number"
+msgstr "Reference number"
 
 #. German translation: Verwandte Dossiers
 #. Default: "Related Dossier"
 #: ./opengever/dossier/behaviors/dossier.py
 msgid "label_related_dossier"
-msgstr "Related Dossier"
+msgstr "Related dossiers"
 
 #. German translation: Federführend
 #. Default: "Responsible"
@@ -1003,7 +1003,7 @@ msgstr "Responsible"
 #. Default: "Restrict Keywords"
 #: ./opengever/dossier/dossiertemplate/behaviors.py
 msgid "label_restrict_keywords"
-msgstr "Restrict Keywords"
+msgstr "Restrict keywords"
 
 #. German translation: Status
 #. Default: "Review state"
@@ -1021,7 +1021,7 @@ msgstr "Roles"
 #. Default: "Sablon Templates"
 #: ./opengever/dossier/browser/tabbed.py
 msgid "label_sablon_templates"
-msgstr "Sablon Templates"
+msgstr "Sablon templates"
 
 #. German translation: Speichern
 #. Default: "Save"
@@ -1155,6 +1155,7 @@ msgid "not all documents are checked in"
 msgstr "Not all documents have been checked in yet."
 
 #. German translation: Es sind nicht alle Aufgaben abgeschlossen
+#. MARKER: used-in-api-response
 #: ./opengever/dossier/resolve.py
 msgid "not all task are closed"
 msgstr "not all task are closed"
@@ -1196,7 +1197,7 @@ msgstr "Participations"
 
 #. German translation: Subdossiers
 msgid "subdossiers"
-msgstr "subdossiers"
+msgstr "Subdossiers"
 
 #. German translation: Das Dossier hat sein Enddatum überschritten und ist somit überfällig.<br>Bitte überprüfen Sie ob das Dossier abgeschlossen werden kann.
 #. Default: "The dossier is still open after exceeding its end date."
@@ -1206,7 +1207,7 @@ msgstr "Dossier is past its end date. Please check whether it can be resolved."
 
 #. German translation: Aufgaben
 msgid "tasks"
-msgstr "tasks"
+msgstr "Tasks"
 
 #. German translation: Temporäres früheres Aktenzeichen
 #. Default: "Temporary former reference number"

--- a/opengever/dossier/locales/en/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/en/LC_MESSAGES/opengever.dossier.po
@@ -197,7 +197,7 @@ msgstr "Templates"
 #. German translation: Der Benutzer darf das Dossier ${dossier} nicht stornieren.
 #: ./opengever/dossier/deactivate.py
 msgid "The Dossier ${dossier} can't be deactivated by the user."
-msgstr "Dossier ${dossier} may not by the user."
+msgstr "Dossier ${dossier} may not be deactivated by the user."
 
 #. German translation: Das Dossier ${dossier} enthält ein Subdossier welches der Benutzer nicht stornieren darf.
 #. MARKER: used-in-api-response
@@ -589,7 +589,7 @@ msgstr "Live search: Search this site"
 #. German translation: Geben Sie die vollständige Ablagenummer an.
 #: ./opengever/dossier/filing/advanced_search.py
 msgid "help_filing_number"
-msgstr "Exact filling number"
+msgstr "Complete filling number"
 
 #. German translation: Schlagwörter zur Umschreibung eines Dossiers. Nicht zu verwechseln mit der Ordnungsposition.\nACHTUNG: Beachten Sie bei der Verwendung von Schlagwörter die Datenschutzvorgaben (z.B. keine Eigennamen).
 #: ./opengever/dossier/behaviors/dossier.py
@@ -606,6 +606,7 @@ msgstr "Number of physical containers (for large files)"
 
 #. German translation: Neuen Kommentar erfassen.
 #. Default: "Create a new note"
+#. MARKER: Check whether "Notiz" would be more appropriate in German
 #: ./opengever/dossier/viewlets/templates/note.pt
 msgid "help_text_add_note"
 msgstr "Add a new note"

--- a/opengever/dossier/tests/test_activate.py
+++ b/opengever/dossier/tests/test_activate.py
@@ -45,7 +45,7 @@ class TestDossierActivation(IntegrationTestCase):
 
         self.activate(self.dossier, browser, use_editbar=True)
         self.assert_success(self.dossier, browser,
-                            ['The Dossier has been activated'])
+                            ['Dossier has been activated'])
 
         self.assert_workflow_state('dossier-state-active', self.dossier)
         self.assert_workflow_state('dossier-state-active', self.subdossier)

--- a/opengever/dossier/tests/test_archiver.py
+++ b/opengever/dossier/tests/test_archiver.py
@@ -299,7 +299,7 @@ class TestArchiveForm(IntegrationTestCase):
         browser.open(self.empty_dossier, view='transition-archive')
 
         browser.fill({'Filing number prefix': 'Government',
-                      'filing Year': u'2017',
+                      'Filing year': u'2017',
                       'Action': 'resolve and set filing no'})
         browser.click_on('Archive')
 
@@ -318,7 +318,7 @@ class TestArchiveForm(IntegrationTestCase):
         browser.open(self.empty_dossier, view='transition-archive')
 
         browser.fill({'Filing number prefix': 'Government',
-                      'filing Year': u'2017',
+                      'Filing year': u'2017',
                       'Action': 'resolve and take the existing filing no'})
         browser.click_on('Archive')
 
@@ -337,7 +337,7 @@ class TestArchiveForm(IntegrationTestCase):
         browser.open(self.empty_dossier, view='transition-archive')
 
         browser.fill({'Filing number prefix': 'Government',
-                      'filing Year': u'2017',
+                      'Filing year': u'2017',
                       'Action': 'resolve and take the existing filing no'})
         browser.click_on('Archive')
 
@@ -356,7 +356,7 @@ class TestArchiveForm(IntegrationTestCase):
         browser.open(self.empty_dossier, view='transition-archive')
 
         browser.fill({'Filing number prefix': 'Government',
-                      'filing Year': u'2017',
+                      'Filing year': u'2017',
                       'Action': 'resolve and set a new filing no'})
         browser.click_on('Archive')
 
@@ -373,7 +373,7 @@ class TestArchiveForm(IntegrationTestCase):
         browser.open(self.empty_dossier, view='transition-archive')
 
         browser.fill({'Filing number prefix': 'Government',
-                      'filing Year': u'2017',
+                      'Filing year': u'2017',
                       'Action': 'set a filing no'})
         browser.click_on('Archive')
 
@@ -430,7 +430,7 @@ class TestArchiveForm(IntegrationTestCase):
         browser.open(self.empty_dossier, view='transition-archive')
 
         browser.fill({'Filing number prefix': 'Government',
-                      'filing Year': u'2017',
+                      'Filing year': u'2017',
                       'Action': 'resolve and set filing no'})
         browser.click_on('Archive')
 

--- a/opengever/dossier/tests/test_archiver.py
+++ b/opengever/dossier/tests/test_archiver.py
@@ -298,14 +298,14 @@ class TestArchiveForm(IntegrationTestCase):
         self.login(self.secretariat_user, browser)
         browser.open(self.empty_dossier, view='transition-archive')
 
-        browser.fill({'filing prefix': 'Government',
+        browser.fill({'Filing number prefix': 'Government',
                       'filing Year': u'2017',
                       'Action': 'resolve and set filing no'})
         browser.click_on('Archive')
 
         self.assert_workflow_state(
             'dossier-state-resolved', self.empty_dossier)
-        statusmessages.assert_message('The Dossier has been resolved')
+        statusmessages.assert_message('Dossier has been resolved')
         self.assertEquals('Hauptmandant-Government-2017-1',
                           IFilingNumber(self.empty_dossier).filing_no)
 
@@ -317,14 +317,14 @@ class TestArchiveForm(IntegrationTestCase):
         IFilingNumber(self.empty_dossier).filing_no = former_filing_number
         browser.open(self.empty_dossier, view='transition-archive')
 
-        browser.fill({'filing prefix': 'Government',
+        browser.fill({'Filing number prefix': 'Government',
                       'filing Year': u'2017',
                       'Action': 'resolve and take the existing filing no'})
         browser.click_on('Archive')
 
         self.assert_workflow_state(
             'dossier-state-resolved', self.empty_dossier)
-        statusmessages.assert_message('The Dossier has been resolved')
+        statusmessages.assert_message('Dossier has been resolved')
         self.assertEquals(former_filing_number,
                           IFilingNumber(self.empty_dossier).filing_no)
 
@@ -336,14 +336,14 @@ class TestArchiveForm(IntegrationTestCase):
         IFilingNumber(self.empty_dossier).filing_no = former_filing_number
         browser.open(self.empty_dossier, view='transition-archive')
 
-        browser.fill({'filing prefix': 'Government',
+        browser.fill({'Filing number prefix': 'Government',
                       'filing Year': u'2017',
                       'Action': 'resolve and take the existing filing no'})
         browser.click_on('Archive')
 
         self.assert_workflow_state(
             'dossier-state-resolved', self.empty_dossier)
-        statusmessages.assert_message('The Dossier has been resolved')
+        statusmessages.assert_message('Dossier has been resolved')
         self.assertEquals(former_filing_number,
                           IFilingNumber(self.empty_dossier).filing_no)
 
@@ -355,14 +355,14 @@ class TestArchiveForm(IntegrationTestCase):
         IFilingNumber(self.empty_dossier).filing_no = former_filing_number
         browser.open(self.empty_dossier, view='transition-archive')
 
-        browser.fill({'filing prefix': 'Government',
+        browser.fill({'Filing number prefix': 'Government',
                       'filing Year': u'2017',
                       'Action': 'resolve and set a new filing no'})
         browser.click_on('Archive')
 
         self.assert_workflow_state(
             'dossier-state-resolved', self.empty_dossier)
-        statusmessages.assert_message('The Dossier has been resolved')
+        statusmessages.assert_message('Dossier has been resolved')
         self.assertEquals('Hauptmandant-Government-2017-1',
                           IFilingNumber(self.empty_dossier).filing_no)
 
@@ -372,14 +372,14 @@ class TestArchiveForm(IntegrationTestCase):
         self.set_workflow_state('dossier-state-resolved', self.empty_dossier)
         browser.open(self.empty_dossier, view='transition-archive')
 
-        browser.fill({'filing prefix': 'Government',
+        browser.fill({'Filing number prefix': 'Government',
                       'filing Year': u'2017',
                       'Action': 'set a filing no'})
         browser.click_on('Archive')
 
         self.assert_workflow_state(
             'dossier-state-resolved', self.empty_dossier)
-        statusmessages.assert_message('The filing number has been given.')
+        statusmessages.assert_message('Filing number issued.')
         self.assertEquals('Hauptmandant-Government-2017-1',
                           IFilingNumber(self.empty_dossier).filing_no)
 
@@ -429,7 +429,7 @@ class TestArchiveForm(IntegrationTestCase):
 
         browser.open(self.empty_dossier, view='transition-archive')
 
-        browser.fill({'filing prefix': 'Government',
+        browser.fill({'Filing number prefix': 'Government',
                       'filing Year': u'2017',
                       'Action': 'resolve and set filing no'})
         browser.click_on('Archive')

--- a/opengever/dossier/tests/test_base.py
+++ b/opengever/dossier/tests/test_base.py
@@ -252,7 +252,7 @@ class TestDateCalculations(IntegrationTestCase):
         with freeze(datetime(2015, 12, 22)):
             browser.open(self.leaf_repofolder)
             factoriesmenu.add('Business Case Dossier')
-            self.assertEquals('22.12.2015', browser.find('Opening Date').value)
+            self.assertEquals('22.12.2015', browser.find('Start date').value)
 
     def test_earliest_possible_is_none_for_empty_dossiers(self):
         self.login(self.dossier_responsible)

--- a/opengever/dossier/tests/test_deactivate.py
+++ b/opengever/dossier/tests/test_deactivate.py
@@ -245,7 +245,7 @@ class TestDossierDeactivationWithWorkspaceClientFeatureEnabled(FunctionalWorkspa
             self.deactivate_dossier(self.dossier, browser)
             self.assert_deactivated(self.dossier)
             self.assert_success(self.dossier, browser,
-                                ['The Dossier has been deactivated'])
+                                ['Dossier has been deactivated'])
 
     @browsing
     def test_dossier_is_deactivated_when_deactivated_workspace_is_linked(self, browser):
@@ -261,7 +261,7 @@ class TestDossierDeactivationWithWorkspaceClientFeatureEnabled(FunctionalWorkspa
             self.deactivate_dossier(self.dossier, browser)
             self.assert_deactivated(self.dossier)
             self.assert_success(self.dossier, browser,
-                                ['The Dossier has been deactivated'])
+                                ['Dossier has been deactivated'])
 
 
 class TestDossierDeactivationWithWorkspaceClientFeatureEnabledRESTAPI(

--- a/opengever/dossier/tests/test_dossier.py
+++ b/opengever/dossier/tests/test_dossier.py
@@ -112,7 +112,7 @@ class TestDossier(IntegrationTestCase):
 
         browser.open(self.subdossier, view='edit')
 
-        self.assertEqual('Edit Subdossier', browser.css('h1').first.text)
+        self.assertEqual('Edit subdossier', browser.css('h1').first.text)
 
     def test_nested_subdossiers_is_not_possible_by_default(self):
         self.login(self.dossier_responsible)

--- a/opengever/dossier/tests/test_dossier_byline.py
+++ b/opengever/dossier/tests/test_dossier_byline.py
@@ -54,7 +54,7 @@ class TestDossierByline(TestDossierBylineBase):
         self.login(self.regular_user, browser=browser)
         browser.open(self.dossier)
 
-        start_date = self.get_byline_value_by_label('from:')
+        start_date = self.get_byline_value_by_label('Start:')
         self.assertEquals('Jan 01, 2016', start_date.text)
 
     @browsing
@@ -62,7 +62,7 @@ class TestDossierByline(TestDossierBylineBase):
         self.login(self.regular_user, browser=browser)
         browser.open(self.dossier)
 
-        seq_number = self.get_byline_value_by_label('Sequence Number:')
+        seq_number = self.get_byline_value_by_label('Sequence number:')
         self.assertEquals('1', seq_number.text)
 
     @browsing
@@ -78,7 +78,7 @@ class TestDossierByline(TestDossierBylineBase):
         self.login(self.regular_user, browser=browser)
         browser.open(self.dossier)
 
-        mail_to_link = self.get_byline_value_by_label('E-Mail:')
+        mail_to_link = self.get_byline_value_by_label('Email:')
         self.assertEquals('1014013300@example.org', mail_to_link.text)
         self.assertEquals(
             'mailto:1014013300@example.org', mail_to_link.get('href'))

--- a/opengever/dossier/tests/test_dossier_byline.py
+++ b/opengever/dossier/tests/test_dossier_byline.py
@@ -70,7 +70,7 @@ class TestDossierByline(TestDossierBylineBase):
         self.login(self.regular_user, browser=browser)
         browser.open(self.dossier)
 
-        ref_number = self.get_byline_value_by_label('Reference Number:')
+        ref_number = self.get_byline_value_by_label('Reference number:')
         self.assertEquals('Client1 1.1 / 1', ref_number.text)
 
     @browsing
@@ -97,7 +97,7 @@ class TestDossierByline(TestDossierBylineBase):
         browser.open(self.dossier)
 
         external_reference = self.get_byline_value_by_label(
-                'External Reference:')
+                'External reference:')
         self.assertEquals(u'qpr-900-9001-\xf7', external_reference.text)
 
     @browsing
@@ -112,14 +112,14 @@ class TestDossierByline(TestDossierBylineBase):
         transaction.commit()
         browser.login().open(self.dossier)
         external_reference = self.get_byline_value_by_label(
-                'External Reference:')
+                'External reference:')
         self.assertIsNone(external_reference.node.find("a"))
 
         IDossier(self.dossier).external_reference = valid_url
         transaction.commit()
         browser.login().open(self.dossier)
         external_reference = self.get_byline_value_by_label(
-                'External Reference:')
+                'External reference:')
         self.assertEquals(valid_url, external_reference.node.find("a").get("href"))
 
 
@@ -134,5 +134,5 @@ class TestFilingBusinessCaseByline(TestBylineBase):
 
         browser.open(self.dossier)
 
-        filing_number = self.get_byline_value_by_label('Filing Number:')
+        filing_number = self.get_byline_value_by_label('Filing number:')
         self.assertEquals('OG-Amt-2013-5', filing_number.text)

--- a/opengever/dossier/tests/test_dossier_template.py
+++ b/opengever/dossier/tests/test_dossier_template.py
@@ -171,14 +171,14 @@ class TestDossierTemplate(IntegrationTestCase):
         factoriesmenu.add('Dossier template')
 
         self.assertEqual([
-            u'Title help',
+            u'Title hint',
             u'Title',
             u'Description',
             u'Keywords',
-            u'Predefined Keywords',
+            u'Prefill keywords',
             u'Restrict Keywords',
             u'Comments',
-            u'filing prefix'],
+            u'Filing number prefix'],
             browser.css('#content fieldset label').text
         )
 
@@ -188,14 +188,14 @@ class TestDossierTemplate(IntegrationTestCase):
         self.login(self.administrator, browser=browser)
         browser.open(self.dossiertemplate, view="edit")
         self.assertEqual([
-            u'Title help',
+            u'Title hint',
             u'Title',
             u'Description',
             u'Keywords',
-            u'Predefined Keywords',
+            u'Prefill keywords',
             u'Restrict Keywords',
             u'Comments',
-            u'filing prefix'],
+            u'Filing number prefix'],
             browser.css('#content fieldset label').text
         )
 
@@ -204,13 +204,13 @@ class TestDossierTemplate(IntegrationTestCase):
         self.login(self.administrator, browser=browser)
         browser.open(self.dossiertemplate, view="edit")
 
-        self.assertTrue(browser.find_field_by_text('Predefined Keywords'),
-                        'Expect the "Predefined Keywords" field')
+        self.assertTrue(browser.find_field_by_text('Prefill keywords'),
+                        'Expect the "Prefill keywords" field')
 
         form_labels = browser.form_field_labels
-        self.assertGreater(form_labels.index('Predefined Keywords'),
+        self.assertGreater(form_labels.index('Prefill keywords'),
                            form_labels.index('Keywords'),
-                           '"Predefined Keywords" should be after "Keywords"')
+                           '"Prefill keywords" should be after "Keywords"')
 
     @browsing
     def test_dossiertemplate_restrict_keywords_is_there(self, browser):
@@ -222,7 +222,7 @@ class TestDossierTemplate(IntegrationTestCase):
 
         form_labels = browser.form_field_labels
         self.assertGreater(form_labels.index('Restrict Keywords'),
-                           form_labels.index('Predefined Keywords'),
+                           form_labels.index('Prefill keywords'),
                            '"Restrict Keywords" should be after "Predefined '
                            'Keywords"')
 

--- a/opengever/dossier/tests/test_dossier_template.py
+++ b/opengever/dossier/tests/test_dossier_template.py
@@ -140,7 +140,7 @@ class TestDossierTemplate(IntegrationTestCase):
         factoriesmenu.add('Subdossier')
 
         self.assertEqual(
-            'Add Subdossier',
+            'Add subdossier',
             browser.css('#content h1').first.text)
 
     @browsing
@@ -160,7 +160,7 @@ class TestDossierTemplate(IntegrationTestCase):
         browser.open(self.subdossiertemplate, view="edit")
 
         self.assertEqual(
-            'Edit Subdossier',
+            'Edit subdossier',
             browser.css('#content h1').first.text)
 
     @browsing
@@ -176,7 +176,7 @@ class TestDossierTemplate(IntegrationTestCase):
             u'Description',
             u'Keywords',
             u'Prefill keywords',
-            u'Restrict Keywords',
+            u'Restrict keywords',
             u'Comments',
             u'Filing number prefix'],
             browser.css('#content fieldset label').text
@@ -193,7 +193,7 @@ class TestDossierTemplate(IntegrationTestCase):
             u'Description',
             u'Keywords',
             u'Prefill keywords',
-            u'Restrict Keywords',
+            u'Restrict keywords',
             u'Comments',
             u'Filing number prefix'],
             browser.css('#content fieldset label').text
@@ -217,13 +217,13 @@ class TestDossierTemplate(IntegrationTestCase):
         self.login(self.administrator, browser=browser)
         browser.open(self.dossiertemplate, view="edit")
 
-        self.assertTrue(browser.find_field_by_text('Restrict Keywords'),
-                        'Expect the "Restrict Keywords" field')
+        self.assertTrue(browser.find_field_by_text('Restrict keywords'),
+                        'Expect the "Restrict keywords" field')
 
         form_labels = browser.form_field_labels
-        self.assertGreater(form_labels.index('Restrict Keywords'),
+        self.assertGreater(form_labels.index('Restrict keywords'),
                            form_labels.index('Prefill keywords'),
-                           '"Restrict Keywords" should be after "Predefined '
+                           '"Restrict keywords" should be after "Predefined '
                            'Keywords"')
 
 

--- a/opengever/dossier/tests/test_move_items.py
+++ b/opengever/dossier/tests/test_move_items.py
@@ -799,7 +799,7 @@ class TestMoveItemsWithTestbrowser(IntegrationTestCase):
         """
         self.login(self.regular_user, browser)
         browser.open(self.empty_dossier)
-        self.assertEquals('Reference Number: Client1 1.1 / 4',
+        self.assertEquals('Reference number: Client1 1.1 / 4',
                           browser.css('.reference_number').first.text,
                           'Unexpected reference number. Test fixture changed?')
         dossier_intid = getUtility(IIntIds).getId(self.empty_dossier)
@@ -813,7 +813,7 @@ class TestMoveItemsWithTestbrowser(IntegrationTestCase):
         # transaction.begin()  # sync
         dossier = getUtility(IIntIds).getObject(dossier_intid)
         browser.open(dossier)
-        self.assertEquals('Reference Number: Client1 1.1 / 4',
+        self.assertEquals('Reference number: Client1 1.1 / 4',
                           browser.css('.reference_number').first.text,
                           'Moving to the current parent should not change'
                           ' the reference number because the location does'
@@ -826,7 +826,7 @@ class TestMoveItemsWithTestbrowser(IntegrationTestCase):
         """
         self.login(self.regular_user, browser)
         browser.open(self.empty_dossier)
-        self.assertEquals('Reference Number: Client1 1.1 / 4',
+        self.assertEquals('Reference number: Client1 1.1 / 4',
                           browser.css('.reference_number').first.text,
                           'Unexpected reference number. Test fixture changed?')
         dossier_intid = getUtility(IIntIds).getId(self.empty_dossier)
@@ -840,7 +840,7 @@ class TestMoveItemsWithTestbrowser(IntegrationTestCase):
         dossier = getUtility(IIntIds).getObject(dossier_intid)
         browser.open(dossier)
 
-        self.assertEquals('Reference Number: Client1 2 / 1',
+        self.assertEquals('Reference number: Client1 2 / 1',
                           browser.css('.reference_number').first.text,
                           'Unexpected reference number after moving.')
 
@@ -853,7 +853,7 @@ class TestMoveItemsWithTestbrowser(IntegrationTestCase):
 
         dossier = getUtility(IIntIds).getObject(dossier_intid)
         browser.open(dossier)
-        self.assertEquals('Reference Number: Client1 1.1 / 4',
+        self.assertEquals('Reference number: Client1 1.1 / 4',
                           browser.css('.reference_number').first.text,
                           'When moving back, the old reference_number should be'
                           ' recycled.')

--- a/opengever/dossier/tests/test_move_items.py
+++ b/opengever/dossier/tests/test_move_items.py
@@ -650,7 +650,7 @@ class TestMoveItemsWithTestbrowser(IntegrationTestCase):
 
         self.assertEqual(self.dossier.absolute_url(), browser.url)
         self.assertEqual(
-            "The selected objects can't be found, please try it again.",
+            "The selected objects can't be found, please try again.",
             error_messages()[0])
 
     @browsing
@@ -661,7 +661,7 @@ class TestMoveItemsWithTestbrowser(IntegrationTestCase):
             obj=self.taskdocument, target=self.empty_dossier)
 
         self.assertEqual(
-            'Document {} is inside a task and therefore not movable. Move the task instead'.format(self.taskdocument.title),
+            'Document {} is inside a task and therefore not movable. Please move the task instead.'.format(self.taskdocument.title),
             error_messages()[0])
         self.assertIn(self.taskdocument, self.task.objectValues())
         self.assertNotIn(self.taskdocument, self.empty_dossier.objectValues())
@@ -672,8 +672,8 @@ class TestMoveItemsWithTestbrowser(IntegrationTestCase):
         mail = create(Builder('mail').titled('Good news').within(self.task))
         self.move_items(browser, src=self.task, obj=mail, target=self.empty_dossier)
 
-        self.assertEqual('Document {} is inside a task and therefore not movable. Move the task'
-                         ' instead'.format(mail.title), error_messages()[0])
+        self.assertEqual('Document {} is inside a task and therefore not movable. Please move the task'
+                         ' instead.'.format(mail.title), error_messages()[0])
         self.assertIn(mail, self.task.objectValues())
         self.assertNotIn(mail, self.empty_dossier.objectValues())
 

--- a/opengever/dossier/tests/test_overview.py
+++ b/opengever/dossier/tests/test_overview.py
@@ -279,7 +279,7 @@ class TestOverview(SolrIntegrationTestCase):
 
         browser.open(self.tested_dossier)
 
-        self.assertEqual('Show Note', browser.css('.editNoteLink').first.text)
+        self.assertEqual('Show note', browser.css('.editNoteLink').first.text)
 
     @browsing
     def test_dossier_editlink_for_comments(self, browser):

--- a/opengever/dossier/tests/test_overview.py
+++ b/opengever/dossier/tests/test_overview.py
@@ -288,7 +288,7 @@ class TestOverview(SolrIntegrationTestCase):
         browser.open(self.tested_dossier)
 
         # There are both labels (show/hide by css/js)
-        self.assertEquals(['Edit Note', 'Add Note'],
+        self.assertEquals(['Edit note', 'Add note'],
                           browser.css('.editNoteLink .linkLabel').text)
 
     @browsing
@@ -315,7 +315,7 @@ class TestOverview(SolrIntegrationTestCase):
         # No comments
         self.assertEquals(dict, type(json.loads(link.attrib['data-i18n'])))
         self.assertEquals('', link.attrib['data-notecache'])
-        self.assertEquals('Add Note', link.css('.add .linkLabel').first.text)
+        self.assertEquals('Add note', link.css('.add .linkLabel').first.text)
 
         # With comments
         IDossier(self.tested_dossier).comments = u'This is a comment'
@@ -324,7 +324,7 @@ class TestOverview(SolrIntegrationTestCase):
         link = browser.css('.editNoteWrapper').first
         self.assertEquals(
             str(u'This is a comment'), link.attrib['data-notecache'])
-        self.assertEquals('Edit Note', link.css('.edit .linkLabel').first.text)
+        self.assertEquals('Edit note', link.css('.edit .linkLabel').first.text)
 
     @browsing
     def test_dossier_save_comments_endpoint(self, browser):

--- a/opengever/dossier/tests/test_participation.py
+++ b/opengever/dossier/tests/test_participation.py
@@ -188,8 +188,8 @@ class TestParticipationAddForm(IntegrationTestCase):
         browser.visit(self.dossier)
         factoriesmenu.add('Participant')
         browser.fill({'Roles': roles})
-        form = browser.find_form_by_field('Contact')
-        form.find_widget('Contact').fill(contact_id)
+        form = browser.find_form_by_field('Person')
+        form.find_widget('Person').fill(contact_id)
         browser.find('Add').click()
 
     @browsing
@@ -201,6 +201,6 @@ class TestParticipationAddForm(IntegrationTestCase):
         self.assertEqual([], error_messages())
 
         self.add_participation_to_dossier(self.regular_user.getId(), ['Participation'], browser)
-        self.assertEqual(['There is already a participation for this contact.'], error_messages())
+        self.assertEqual(['A participation already exists for this contact.'], error_messages())
         self.assertEqual('http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/'
                          'dossier-1/add-plone-participation', browser.url)

--- a/opengever/dossier/tests/test_protect_dossier.py
+++ b/opengever/dossier/tests/test_protect_dossier.py
@@ -69,8 +69,8 @@ class TestProtectDossier(IntegrationTestCase):
         browser.open(self.leaf_repofolder)
         factoriesmenu.add(u'Business Case Dossier')
         browser.fill({'Title': 'My Dossier'})
-        form = browser.find_form_by_field('Reading')
-        form.find_widget('Reading and writing').fill([self.regular_user.getId()])
+        form = browser.find_form_by_field('Read only access')
+        form.find_widget('Read/Write access').fill([self.regular_user.getId()])
         browser.click_on('Save')
         new_dossier = browser.context
 
@@ -99,8 +99,8 @@ class TestProtectDossier(IntegrationTestCase):
         browser.open(self.leaf_repofolder)
         factoriesmenu.add(u'Business Case Dossier')
         browser.fill({'Title': 'My Dossier'})
-        form = browser.find_form_by_field('Reading')
-        form.find_widget('Reading and writing').fill(self.regular_user.getId())
+        form = browser.find_form_by_field('Read only access')
+        form.find_widget('Read/Write access').fill(self.regular_user.getId())
         browser.click_on('Save')
 
         new_dossier = browser.context
@@ -115,9 +115,9 @@ class TestProtectDossier(IntegrationTestCase):
 
         browser.open(new_dossier, view="@@edit")
         browser.fill({'Title': 'My new Dossier'})
-        form = browser.find_form_by_field('Reading')
-        form.find_widget('Reading and writing').fill([])
-        form.find_widget('Reading').fill([self.regular_user.getId()])
+        form = browser.find_form_by_field('Read only access')
+        form.find_widget('Read/Write access').fill([])
+        form.find_widget('Read only access').fill([self.regular_user.getId()])
         browser.click_on('Save')
 
         self.assert_local_roles(
@@ -159,9 +159,9 @@ class TestProtectDossier(IntegrationTestCase):
         self.login(self.dossier_manager, browser)
 
         browser.open(self.dossier, view="@@edit")
-        form = browser.find_form_by_field('Reading')
-        form.find_widget('Reading').fill('projekt_a')
-        form.find_widget('Reading and writing').fill('projekt_b')
+        form = browser.find_form_by_field('Read only access')
+        form.find_widget('Read only access').fill('projekt_a')
+        form.find_widget('Read/Write access').fill('projekt_b')
         form.find_widget('Dossier manager').fill(self.dossier_manager.getId())
         browser.click_on('Save')
 
@@ -215,7 +215,7 @@ class TestProtectDossier(IntegrationTestCase):
         browser.open(self.leaf_repofolder)
         factoriesmenu.add(u'Business Case Dossier')
         browser.fill({'Title': 'My Dossier'})
-        form = browser.find_form_by_field('Reading')
+        form = browser.find_form_by_field('Read only access')
 
         # Guard assertion - make sure the widget's value has been prefilled
         dossier_manager_widget = form.find_widget('Dossier manager')
@@ -238,8 +238,8 @@ class TestProtectDossier(IntegrationTestCase):
         browser.open(self.leaf_repofolder)
         factoriesmenu.add(u'Business Case Dossier')
         browser.fill({'Title': 'My Dossier'})
-        form = browser.find_form_by_field('Reading')
-        form.find_widget('Reading').fill(self.regular_user.getId())
+        form = browser.find_form_by_field('Read only access')
+        form.find_widget('Read only access').fill(self.regular_user.getId())
         browser.click_on('Save')
 
         self.assert_local_roles(
@@ -251,8 +251,8 @@ class TestProtectDossier(IntegrationTestCase):
         self.login(self.dossier_manager, browser)
 
         browser.open(self.dossier, view="@@edit")
-        form = browser.find_form_by_field('Reading')
-        form.find_widget('Reading').fill(self.regular_user.getId())
+        form = browser.find_form_by_field('Read only access')
+        form.find_widget('Read only access').fill(self.regular_user.getId())
         form.find_widget('Dossier manager').fill(self.dossier_manager.getId())
         browser.click_on('Save')
 
@@ -407,7 +407,7 @@ class TestProtectDossier(IntegrationTestCase):
         browser.open(self.leaf_repofolder)
         factoriesmenu.add(u'Business Case Dossier')
         browser.fill({'Title': 'My Dossier'})
-        form = browser.find_form_by_field('Reading')
+        form = browser.find_form_by_field('Read only access')
         form.find_widget('Dossier manager').fill('')
         browser.click_on('Save')
 
@@ -421,12 +421,12 @@ class TestProtectDossier(IntegrationTestCase):
         factoriesmenu.add(u'Business Case Dossier')
         browser.fill({'Title': 'My Dossier'})
 
-        form = browser.find_form_by_field('Reading')
-        form.find_widget('Reading').fill(self.regular_user.getId())
+        form = browser.find_form_by_field('Read only access')
+        form.find_widget('Read only access').fill(self.regular_user.getId())
         form.find_widget('Dossier manager').fill('')
         browser.click_on('Save')
         self.assertIn('There were some errors.', error_messages())
-        form = browser.find_form_by_fields("Reading")
+        form = browser.find_form_by_fields("Read only access")
         self.assertIn('A dossier manager must be selected when protecting a dossier',
                       form.text)
 
@@ -438,11 +438,11 @@ class TestProtectDossier(IntegrationTestCase):
         factoriesmenu.add(u'Business Case Dossier')
         browser.fill({'Title': 'My Dossier'})
 
-        form = browser.find_form_by_field('Reading')
-        form.find_widget('Reading and writing').fill(self.regular_user.getId())
+        form = browser.find_form_by_field('Read only access')
+        form.find_widget('Read/Write access').fill(self.regular_user.getId())
         form.find_widget('Dossier manager').fill('')
         browser.click_on('Save')
         self.assertIn('There were some errors.', error_messages())
-        form = browser.find_form_by_fields("Reading")
+        form = browser.find_form_by_fields("Read only access")
         self.assertIn('A dossier manager must be selected when protecting a dossier',
                       form.text)

--- a/opengever/dossier/tests/test_reactivate.py
+++ b/opengever/dossier/tests/test_reactivate.py
@@ -42,7 +42,7 @@ class TestReactivating(IntegrationTestCase):
 
         self.assert_workflow_state('dossier-state-active', self.resolvable_subdossier)
         self.assert_success(self.resolvable_subdossier, browser,
-                            ['Dossiers successfully reactivated.'])
+                            ['Dossier successfully reactivated.'])
 
     @browsing
     def test_reactivating_a_main_dossier_reactivates_subdossiers_recursively(self, browser):
@@ -92,7 +92,7 @@ class TestReactivating(IntegrationTestCase):
         self.reactivate(self.resolvable_subdossier, browser)
 
         self.assert_errors(self.resolvable_subdossier, browser,
-                           ["It isn't possible to reactivate a sub dossier."])
+                           ["A subdossier may not be reopened on its own. Please reopen the main dossier."])
         self.assert_workflow_state('dossier-state-resolved',
                                    self.resolvable_subdossier)
 

--- a/opengever/dossier/tests/test_redirect_to_maindossier.py
+++ b/opengever/dossier/tests/test_redirect_to_maindossier.py
@@ -24,7 +24,7 @@ class TestRedirectToMainDossier(IntegrationTestCase):
 
         self.assertEquals(self.leaf_repofolder, browser.context)
         self.assertEquals(
-            [u'The object `1.1. Vertr\xe4ge und Vereinbarungen` is not stored inside a dossier.'],
+            [u'Object `1.1. Vertr\xe4ge und Vereinbarungen` is not stored inside a dossier.'],
             error_messages())
 
     @browsing

--- a/opengever/dossier/tests/test_reporter.py
+++ b/opengever/dossier/tests/test_reporter.py
@@ -112,7 +112,7 @@ class TestDossierReporter(IntegrationTestCase):
 
         rows = list(workbook.active.rows)
         self.assertSequenceEqual(
-            [u'Title', u'Review state', u'Reference Number', u'End date',
+            [u'Title', u'Review state', u'Reference number', u'End date',
              u'Responsible'],
             [cell.value for cell in rows[0]])
 

--- a/opengever/dossier/tests/test_reporter.py
+++ b/opengever/dossier/tests/test_reporter.py
@@ -112,7 +112,7 @@ class TestDossierReporter(IntegrationTestCase):
 
         rows = list(workbook.active.rows)
         self.assertSequenceEqual(
-            [u'Title', u'Review state', u'Reference Number', u'Closing Date',
+            [u'Title', u'Review state', u'Reference Number', u'End date',
              u'Responsible'],
             [cell.value for cell in rows[0]])
 
@@ -134,9 +134,9 @@ class TestDossierReporter(IntegrationTestCase):
             workbook = load_workbook(tmpfile.name)
 
         labels = [cell.value for cell in list(workbook.active.rows)[0]]
-        self.assertIn(u'filing_no_filing', labels)
-        self.assertIn(u'filing_no_year', labels)
-        self.assertIn(u'filing_no_number', labels)
+        self.assertIn(u'Filing', labels)
+        self.assertIn(u'Filing year', labels)
+        self.assertIn(u'Filing number', labels)
         self.assertIn(u'Filing number', labels)
 
         self.assertSequenceEqual(

--- a/opengever/dossier/tests/test_resolve.py
+++ b/opengever/dossier/tests/test_resolve.py
@@ -209,7 +209,7 @@ class TestResolvingDossiers(IntegrationTestCase, ResolveTestHelper):
 
         self.assert_resolved(self.empty_dossier)
         self.assert_success(self.empty_dossier, browser,
-                            ['The dossier has been succesfully resolved.'])
+                            ['Dossier has been resolved succesfully.'])
 
     @browsing
     def test_resolving_subdossier_when_parent_dossier_contains_documents(self, browser):
@@ -222,7 +222,7 @@ class TestResolvingDossiers(IntegrationTestCase, ResolveTestHelper):
 
         self.assert_resolved(self.subdossier)
         self.assert_success(self.subdossier, browser,
-                            ['The subdossier has been succesfully resolved.'])
+                            ['Subdossier has been resolved succesfully.'])
 
     @browsing
     def test_archive_form_is_omitted_when_resolving_subdossiers(self, browser):
@@ -232,7 +232,7 @@ class TestResolvingDossiers(IntegrationTestCase, ResolveTestHelper):
 
         self.assert_resolved(self.subdossier)
         self.assert_success(self.subdossier, browser,
-                            ['The subdossier has been succesfully resolved.'])
+                            ['Subdossier has been resolved succesfully.'])
 
     @browsing
     def test_cant_resolve_already_resolved_dossier(self, browser):
@@ -253,7 +253,7 @@ class TestResolvingDossiers(IntegrationTestCase, ResolveTestHelper):
         self.assert_resolved(self.resolvable_dossier)
         self.assert_resolved(self.resolvable_subdossier)
         self.assert_success(self.resolvable_dossier, browser,
-                            ['The dossier has been succesfully resolved.'])
+                            ['Dossier has been resolved succesfully.'])
 
         self.reactivate(self.resolvable_dossier, browser)
         self.assert_active(self.resolvable_dossier)
@@ -263,7 +263,7 @@ class TestResolvingDossiers(IntegrationTestCase, ResolveTestHelper):
         self.assert_resolved(self.resolvable_dossier)
         self.assert_resolved(self.resolvable_subdossier)
         self.assert_success(self.resolvable_dossier, browser,
-                            ['The dossier has been succesfully resolved.'])
+                            ['Dossier has been resolved succesfully.'])
 
 
 class TestResolvingDossiersRESTAPI(ResolveTestHelperRESTAPI, TestResolvingDossiers):
@@ -1317,7 +1317,7 @@ class TestResolveConditions(IntegrationTestCase, ResolveTestHelper):
 
         self.assert_not_resolved(self.resolvable_dossier)
         self.assert_errors(self.resolvable_dossier, browser,
-                           ['not all documents and tasks are stored in a subdossier.'])
+                           ['Not all documents and tasks have been filed into subdossiers.'])
 
     @browsing
     def test_resolving_is_cancelled_when_documents_are_checked_out(self, browser):
@@ -1329,7 +1329,7 @@ class TestResolveConditions(IntegrationTestCase, ResolveTestHelper):
 
         self.assert_not_resolved(self.resolvable_dossier)
         self.assert_errors(self.resolvable_dossier, browser,
-                           ['not all documents are checked in'])
+                           ['Not all documents have been checked in yet.'])
 
     @browsing
     def test_resolving_is_cancelled_when_documents_in_subsubdossiers_are_checked_out(self, browser):
@@ -1345,7 +1345,7 @@ class TestResolveConditions(IntegrationTestCase, ResolveTestHelper):
 
         self.assert_not_resolved(self.resolvable_dossier)
         self.assert_errors(self.resolvable_dossier, browser,
-                           ['not all documents are checked in'])
+                           ['Not all documents have been checked in yet.'])
 
     @browsing
     def test_resolving_is_cancelled_when_active_tasks_exist(self, browser):
@@ -1376,7 +1376,7 @@ class TestResolveConditions(IntegrationTestCase, ResolveTestHelper):
 
         self.assert_resolved(self.resolvable_dossier)
         self.assert_success(self.resolvable_dossier, browser,
-                            ['The dossier has been succesfully resolved.'])
+                            ['Dossier has been resolved succesfully.'])
 
     @browsing
     def test_resolving_is_cancelled_when_subdossier_has_an_invalid_end_date(self, browser):
@@ -1409,7 +1409,7 @@ class TestResolveConditions(IntegrationTestCase, ResolveTestHelper):
 
         self.assert_resolved(self.resolvable_dossier)
         self.assert_success(self.resolvable_dossier, browser,
-                            ['The dossier has been succesfully resolved.'])
+                            ['Dossier has been resolved succesfully.'])
 
     @browsing
     def test_resolving_is_cancelled_when_dossier_has_active_proposals(self, browser):
@@ -1423,7 +1423,7 @@ class TestResolveConditions(IntegrationTestCase, ResolveTestHelper):
 
         self.assert_not_resolved(self.resolvable_subdossier)
         self.assert_errors(self.resolvable_subdossier, browser,
-                           ['The dossier contains active proposals.'])
+                           ['Dossier contains active proposals.'])
 
     @browsing
     def test_dossier_is_resolved_when_all_tasks_are_closed_and_documents_checked_in(self, browser):
@@ -1443,7 +1443,7 @@ class TestResolveConditions(IntegrationTestCase, ResolveTestHelper):
 
         self.assert_resolved(self.resolvable_dossier)
         self.assert_success(self.resolvable_dossier, browser,
-                            ['The dossier has been succesfully resolved.'])
+                            ['Dossier has been resolved succesfully.'])
 
 
 class TestResolveConditionsRESTAPI(ResolveTestHelperRESTAPI, TestResolveConditions):
@@ -1475,7 +1475,7 @@ class TestResolveConditionsWithWorkspaceClientFeatureEnabled(ResolveTestHelper,
             self.resolve(self.dossier, browser)
             self.assert_resolved(self.dossier)
             self.assert_success(self.dossier, browser,
-                                ['The dossier has been succesfully resolved.'])
+                                ['Dossier has been resolved succesfully.'])
 
     @browsing
     def test_subdossier_is_resolvable_with_activated_workspace_client(self, browser):
@@ -1487,7 +1487,7 @@ class TestResolveConditionsWithWorkspaceClientFeatureEnabled(ResolveTestHelper,
             self.resolve(subdossier, browser)
             self.assert_resolved(subdossier)
             self.assert_success(subdossier, browser,
-                                ['The subdossier has been succesfully resolved.'])
+                                ['Subdossier has been resolved succesfully.'])
 
     @browsing
     def test_dossier_is_resolved_when_deactivated_workspace_is_linked(self, browser):
@@ -1507,7 +1507,7 @@ class TestResolveConditionsWithWorkspaceClientFeatureEnabled(ResolveTestHelper,
             self.resolve(self.dossier, browser)
             self.assert_resolved(self.dossier)
             self.assert_success(self.dossier, browser,
-                                ['The dossier has been succesfully resolved.'])
+                                ['Dossier has been resolved succesfully.'])
 
 
 class TestResolveConditionsWithWorkspaceClientFeatureEnabledRESTAPI(
@@ -1575,7 +1575,7 @@ class TestResolving(IntegrationTestCase, ResolveTestHelper):
         self.assert_resolved(self.resolvable_dossier)
         self.assert_resolved(self.resolvable_subdossier)
         self.assert_success(self.resolvable_dossier, browser,
-                            ['The dossier has been succesfully resolved.'])
+                            ['Dossier has been resolved succesfully.'])
 
     @browsing
     def test_handles_already_resolved_subdossiers(self, browser):

--- a/opengever/dossier/tests/test_templatefolder.py
+++ b/opengever/dossier/tests/test_templatefolder.py
@@ -1052,7 +1052,7 @@ class TestTemplateDocumentTabs(IntegrationTestCase):
     def test_visible_tabs(self, browser):
         self.login(self.regular_user, browser)
         browser.open(self.templates, view='tabbed_view')
-        expected_tabs = ['Documents', 'Tasktemplate Folders']
+        expected_tabs = ['Documents', 'Task template folders']
         self.assertEqual(expected_tabs, browser.css('.tabbedview-tabs span').text)
 
     @browsing
@@ -1103,7 +1103,7 @@ class TestTemplateDocumentTabsWithOneoffixx(IntegrationTestCase):
     def test_visible_tabs(self, browser):
         self.login(self.regular_user, browser)
         browser.open(self.templates, view='tabbed_view')
-        expected_tabs = ['OneOffixx', 'Documents', 'Tasktemplate Folders']
+        expected_tabs = ['OneOffixx', 'Documents', 'Task template folders']
         self.assertEqual(expected_tabs, browser.css('.tabbedview-tabs span').text)
 
 
@@ -1116,7 +1116,7 @@ class TestDossierTemplateFeature(IntegrationTestCase):
     def test_visible_tabs(self, browser):
         self.login(self.regular_user, browser)
         browser.open(self.templates, view='tabbed_view')
-        expected_tabs = ['Documents', 'Dossier templates', 'Tasktemplate Folders']
+        expected_tabs = ['Documents', 'Dossier templates', 'Task template folders']
         self.assertEqual(expected_tabs, browser.css('.tabbedview-tabs span').text)
 
     @browsing

--- a/opengever/dossier/tests/test_validators.py
+++ b/opengever/dossier/tests/test_validators.py
@@ -21,7 +21,7 @@ class TestStardEndValidator(FunctionalTestCase):
         browser.click_on('Save')
 
         self.assertEquals(
-            ['The start date must be before the end date.'],
+            ['Start date must be before end date.'],
             browser.css('div.error').text)
 
     @browsing
@@ -33,7 +33,7 @@ class TestStardEndValidator(FunctionalTestCase):
                                  end=date(2013, 01, 01)))
 
         browser.login().open(dossier, view='edit')
-        browser.fill({'Closing Date': '02.02.2013'})
+        browser.fill({'End date': '02.02.2013'})
         browser.click_on('Save')
 
         self.assertEquals(['Changes saved'], info_messages())

--- a/opengever/meeting/tests/test_move_proposal_items.py
+++ b/opengever/meeting/tests/test_move_proposal_items.py
@@ -22,7 +22,7 @@ class TestMoveProposalItems(SolrIntegrationTestCase):
         browser.fill({'Destination': self.subdossier})
         browser.css('#form-buttons-button_submit').first.click()
 
-        assert_message('1 Elements were moved successfully')
+        assert_message('1 elements were moved successfully')
         self.assertIn(proposal, self.subdossier.objectValues())
 
     @browsing

--- a/opengever/meeting/tests/test_move_proposal_items.py
+++ b/opengever/meeting/tests/test_move_proposal_items.py
@@ -35,7 +35,7 @@ class TestMoveProposalItems(SolrIntegrationTestCase):
         browser.fill({'Destination': self.subdossier})
         browser.css('#form-buttons-button_submit').first.click()
 
-        assert_message("The selected objects can't be found, please try it again.")
+        assert_message("The selected objects can't be found, please try again.")
 
     @browsing
     def test_proposal_inside_closed_dossier_is_not_movable(self, browser):

--- a/opengever/oneoffixx/tests/test_oneoffixx.py
+++ b/opengever/oneoffixx/tests/test_oneoffixx.py
@@ -177,7 +177,7 @@ class TestCreateDocFromOneoffixxTemplate(IntegrationTestCase):
     def test_show_oneoffixx_templates_tab(self, browser):
         self.login(self.regular_user, browser)
         browser.open(self.templates)
-        expected_template_tabs = ['OneOffixx', 'Documents', 'Tasktemplate Folders']
+        expected_template_tabs = ['OneOffixx', 'Documents', 'Task template folders']
         self.assertEqual(expected_template_tabs, browser.css('.formTab').text)
 
     @browsing

--- a/opengever/private/tests/test_dossier.py
+++ b/opengever/private/tests/test_dossier.py
@@ -113,7 +113,7 @@ class TestPrivateDossierTabbedView(IntegrationTestCase):
         browser.open(self.private_dossier, view='tabbedview_view-overview')
 
         self.assertEquals(
-            ['Dossier structure', 'Comments', 'Linked Dossiers',
+            ['Dossier structure', 'Comments', 'Linked dossiers',
              'Newest documents', 'Description', 'Keywords'],
             browser.css('.box h2').text)
 

--- a/opengever/private/tests/test_dossier.py
+++ b/opengever/private/tests/test_dossier.py
@@ -177,7 +177,7 @@ class TestPrivateDossierWorkflow(IntegrationTestCase):
                      {'_authenticator': createToken()},
                      view='transition-resolve')
 
-        self.assertEquals(['The dossier has been succesfully resolved.'],
+        self.assertEquals(['Dossier has been resolved succesfully.'],
                           info_messages())
         self.assertEqual('dossier-state-resolved',
                          api.content.get_state(self.private_dossier))

--- a/opengever/sharing/tests/test_blocked_local_roles_listing.py
+++ b/opengever/sharing/tests/test_blocked_local_roles_listing.py
@@ -211,8 +211,8 @@ class TestBlockedLocalRolesListing(IntegrationTestCase):
         browser.open(self.leaf_repofolder)
         factoriesmenu.add(u'Business Case Dossier')
         browser.fill({'Title': 'My Dossier'})
-        form = browser.find_form_by_field('Reading')
-        form.find_widget('Reading and writing').fill(self.regular_user.getId())
+        form = browser.find_form_by_field('Read only access')
+        form.find_widget('Read/Write access').fill(self.regular_user.getId())
         browser.click_on('Save')
         new_dossier = browser.context
 
@@ -236,8 +236,8 @@ class TestBlockedLocalRolesListing(IntegrationTestCase):
         browser.open(self.leaf_repofolder)
         factoriesmenu.add(u'Business Case Dossier')
         browser.fill({'Title': 'My Dossier'})
-        form = browser.find_form_by_field('Reading')
-        form.find_widget('Reading and writing').fill(self.regular_user.getId())
+        form = browser.find_form_by_field('Read only access')
+        form.find_widget('Read/Write access').fill(self.regular_user.getId())
         browser.click_on('Save')
         new_dossier = browser.context
 


### PR DESCRIPTION
Clean up English `og.dossier` translations.

There's a few messages in `opengever.dossier.po` around resolving and (re)activating dossiers that are quite clunky, but are used in **REST API responses** (error messages for workflow transitions). Found that out the hard way (already changed them, got weird test failures 😭 ).

I aborted those changes and left them untouched, and instead added a cautionary marker. We certainly don't want to push breaking API changes when it's "just" translations that are supposed to be updated.

The second commit is purely casing changes. From "magic eight ball casing" to "sentence casing". Should make it a bit easier to review having those separately.

For overall comments on the process, please see PR #6806 

Jira: https://4teamwork.atlassian.net/browse/CA-883