### PR TITLE
Clean up English og.webactions translations.

### DIFF
--- a/opengever/webactions/locales/en/LC_MESSAGES/opengever.webactions.po
+++ b/opengever/webactions/locales/en/LC_MESSAGES/opengever.webactions.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-01-08 11:40+0000\n"
+"POT-Creation-Date: 2021-01-14 11:32+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -38,7 +38,7 @@ msgstr "Edit"
 #. German translation: Webaktion bearbeiten
 #: ./opengever/webactions/browser/forms.py
 msgid "Edit Webaction"
-msgstr "Edit Webaction"
+msgstr "Edit webaction"
 
 #. German translation: Bearbeitung abgebrochen
 #: ./opengever/webactions/browser/forms.py

--- a/opengever/webactions/tests/test_manage_webactions_view.py
+++ b/opengever/webactions/tests/test_manage_webactions_view.py
@@ -207,7 +207,7 @@ class TestWebactionsManagementView(IntegrationTestCase):
                          [action.find("Edit").get("href") for action in webactions])
 
         webactions[0].find("Edit").click()
-        self.assertEqual('Edit Webaction',
+        self.assertEqual('Edit webaction',
                          browser.css(".documentFirstHeading").first.text)
 
         form = browser.find_form_by_field("Title")


### PR DESCRIPTION
Clean up English `og.webactions` translations.

For overall comments on the process, please see PR #6806 

Jira: https://4teamwork.atlassian.net/browse/CA-883