### PR TITLE
Activate custom properties for documents/mails in API (de-)serialization.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,7 @@ Changelog
 - Add new API endpoint @white-labeling-settings. [tinagerber]
 - Add relatedItems field to todo. [tinagerber]
 - Add HubSpot feature flag. [tinagerber]
+- Implement serialization and deserialization of custom properties via API, currently available for documents and mails. [deiferni]
 - Bump docxcompose to version 1.3.1 to add support for dateformats. [njohner]
 - Change key for agenda item list document to "documents" in zip export. [njohner]
 - Bump ftw.solr to 2.9.2 to fix a bug with setting document_type back to None. [njohner]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -18,6 +18,7 @@ Other Changes
 
 - A new endpoint ``@white-labeling-settings`` is added (see :ref:`docs <white-labeling-settings>`).
 - ``@config``: New feature flag ``hubspot`` added (see :ref:`docs <config>`).
+- Documents and Mails now support serialization and deserialization of ``custom_properties`` (see :ref:`docs <propertysheets>`).
 - A new endpoint ``@propertysheets`` is added (see :ref:`docs <propertysheets>`).
 
 

--- a/docs/public/dev-manual/api/propertysheets.rst
+++ b/docs/public/dev-manual/api/propertysheets.rst
@@ -123,3 +123,80 @@ Assignment-Slot zuzuweisen ist im Moment nicht unterstützt.
       "title": "question",
       "type": "object"
   }
+
+
+Serialisierung/Deserialisierung von Custom Properties
+-----------------------------------------------------
+
+Im Moment sind Custom Properties auf Dokumenten und Mails unterstützt. Die
+Auswahl des zu validerenden Property Sheets basiert auf dem Wert des Feldes
+`document_type`. Ist für den Assignment-Slot
+``IDocumentMetadata.document_type.<document_type_value>`` ein Property Sheet
+registriert, so werden Feldwerte dieses Property Sheets validiert. Hat das
+Property Sheet also obligatorische Felder, so müssen die Custom Properties
+zwingend Daten für dieses Property Sheet beinhalten. Serialisierung und
+Deserialisierung der Custom Properties basiert auf folgendem Format:
+
+
+.. sourcecode:: json
+
+  {
+      "<assignment_slot_name>": {
+          "<property_sheet_field_name>": "<field value>"
+      }
+  }
+
+
+Es werden immer alle einmal gespeicherten Custom Properties serialisiert und
+ausgegeben, unabhängig vom Wert des Feldes ``document_type``.
+
+.. sourcecode:: http
+
+  GET /ordnungssystem/dossier-23/document-123 HTTP/1.1
+  Accept: application/json
+
+.. sourcecode:: http
+
+  HTTP/1.1 200 OK
+  Content-Type: application/json
+
+  {
+      "@id": "/ordnungssystem/dossier-23/document-123",
+      "custom_properties": {
+          "IDocumentMetadata.document_type.question": {
+              "yesorno": false
+          },
+          "IDocumentMetadata.document_type.protocol": {
+              "location": "Dammweg 9",
+              "responsible": "Hans Muster"
+          }
+      },
+      "...": "..."
+  }
+
+
+Beim Speichern der Custom Properties können Properties für alle erlaubten
+Assigmnet-Slots angegeben werden. Es werden immer alle angegebenen Custom
+Properties validiert. Das Speichern erfolg kumulativ, wenn man ein Subset
+der möglichen Assignment-Slots verwendet, werden die Custom Propterties anderer
+Slots nicht überschrieben.
+
+  .. sourcecode:: http
+
+    PATCH /ordnungssystem/dossier-23/document-123 HTTP/1.1
+    Accept: application/json
+
+    {
+          "IDocumentMetadata.document_type.question": {
+              "yesorno": true
+          }
+    }
+
+  .. sourcecode:: http
+
+    HTTP/1.1 204 No content
+    Content-Type: application/json
+
+
+
+

--- a/docs/public/dev-manual/api/propertysheets.rst
+++ b/docs/public/dev-manual/api/propertysheets.rst
@@ -1,7 +1,21 @@
 .. _propertysheets:
 
-Property Sheets (Benutzerdefinierte Felder)
-===========================================
+Benutzerdefinierte Felder
+=========================
+
+Das Bearbeiten der Schemas für Benutzerdefinierte Felder und
+Serialisieren/Deserialisieren auf Inhalten verwendet die folgenden Begriffe:
+
+- ``Property Sheet``: Ein Property Sheet definiert ein Schema. Dieses Schema
+                      wird zur Validierung der Custom Properties verwendet.
+- ``Assignment Slot``: Ein Assignment Slot definiert einen Steckplatz dem
+                       maximal ein Property Sheet zugewiesen werden kann.
+- ``Assignment``: Ein Assignment ist die Zuweisung eines Property Sheets an
+                  einen Assignment Slot. Ein Property Sheet kann mehrere
+                  Assignments haben.
+- ``Custom Properties``: Custom Properties sind die konkreten Daten auf den
+                         Inhaltsobjekten. Custom Properties werden gegen ihr
+                         zugehöriges Property Sheet validiert.
 
 Mittels Property Sheets ist es möglich benutzerdefinierte Schemata mit einem
 oder mehreren Feldern zu definieren damit zusätzliche Properties in GEVER

--- a/docs/public/dev-manual/api/propertysheets.rst
+++ b/docs/public/dev-manual/api/propertysheets.rst
@@ -67,10 +67,10 @@ Einzelne Felder werden in folgendem Format erwartet:
 - ``required``: Ob das Feld erforderlich ist
 - ``values``: Auswahlmöglichkeiten für das Feld, nur für ``choice`` Feldtyp
 
-Assignments müssen aus dem Vokabular
+Die für das Assigmnet verwendeten Assignment-Slots müssen aus dem Vokabular
 ``opengever.propertysheets.PropertySheetAssignmentsVocabulary`` stammen. Zudem
-müssen Assignments eindeutig sein, mehrere Property Sheets für das gleiche
-Assignment sind im Moment nicht unterstützt.
+müssen Assignments eindeutig sein, mehrere Property Sheets dem gleichen
+Assignment-Slot zuzuweisen ist im Moment nicht unterstützt.
 
 
 **Beispiel-Request**:

--- a/docs/public/dev-manual/api/propertysheets.rst
+++ b/docs/public/dev-manual/api/propertysheets.rst
@@ -82,7 +82,7 @@ Assignment-Slot zuzuweisen ist im Moment nicht unterstützt.
 
   {
     "fields": {
-      "foo": {
+      "yesorno": {
         "field_type": "bool",
         "title": "Y/N",
         "description": "yes or no",
@@ -106,20 +106,20 @@ Assignment-Slot zuzuweisen ist im Moment nicht unterstützt.
       "fieldsets": [
           {
               "behavior": "plone",
-              "fields": ["foo"],
+              "fields": ["yesorno"],
               "id": "default",
               "title": "Default"
           }
       ],
       "properties": {
-          "foo": {
+          "yesorno": {
               "description": "yes or no",
               "factory": "Yes/No",
               "title": "Y/N",
               "type": "boolean"
           }
       },
-      "required": ["foo"],
+      "required": ["yesorno"],
       "title": "question",
       "type": "object"
   }

--- a/opengever/base/schemadump/config.py
+++ b/opengever/base/schemadump/config.py
@@ -183,6 +183,7 @@ DEFAULT_OVERRIDES = {
 # Dropped from all schema dumps
 IGNORED_FIELDS = [
     'plone.app.versioningbehavior.behaviors.IVersionable.changeNote',
+    'opengever.document.behaviors.customproperties.IDocumentCustomProperties.custom_properties',
     'opengever.document.behaviors.metadata.IDocumentMetadata.digitally_available',
     'opengever.document.behaviors.metadata.IDocumentMetadata.preview',
     'opengever.document.behaviors.metadata.IDocumentMetadata.thumbnail',

--- a/opengever/base/tests/test_default_values_for_types.py
+++ b/opengever/base/tests/test_default_values_for_types.py
@@ -135,6 +135,7 @@ DOCUMENT_REQUIREDS = {
 DOCUMENT_DEFAULTS = {
     'changed': FROZEN_NOW,
     'classification': u'unprotected',
+    'custom_properties': None,
     'description': u'',
     'digitally_available': True,
     'document_date': FROZEN_TODAY,
@@ -165,6 +166,7 @@ MAIL_REQUIREDS = {}
 MAIL_DEFAULTS = {
     'changed': FROZEN_NOW,
     'classification': u'unprotected',
+    'custom_properties': None,
     'description': u'',
     'digitally_available': True,
     'document_author': u'from@example.org',

--- a/opengever/core/profiles/default/types/ftw.mail.mail.xml
+++ b/opengever/core/profiles/default/types/ftw.mail.mail.xml
@@ -33,6 +33,7 @@
     <element value="plone.app.lockingbehavior.behaviors.ILocking" />
     <element value="ftw.bumblebee.interfaces.IBumblebeeable" />
     <element value="opengever.quota.primary.IPrimaryBlobFieldQuota" />
+    <element value="opengever.document.behaviors.customproperties.IDocumentCustomProperties" />
   </property>
 
   <!-- Actions -->

--- a/opengever/core/profiles/default/types/opengever.document.document.xml
+++ b/opengever/core/profiles/default/types/opengever.document.document.xml
@@ -33,6 +33,7 @@
     <element value="opengever.document.behaviors.metadata.IDocumentMetadata" />
     <element value="ftw.bumblebee.interfaces.IBumblebeeable" />
     <element value="opengever.quota.primary.IPrimaryBlobFieldQuota" />
+    <element value="opengever.document.behaviors.customproperties.IDocumentCustomProperties" />
   </property>
 
   <!-- View information -->

--- a/opengever/core/upgrades/20210113175519_enable_custom_properties_for_documents_mails/types/ftw.mail.mail.xml
+++ b/opengever/core/upgrades/20210113175519_enable_custom_properties_for_documents_mails/types/ftw.mail.mail.xml
@@ -1,0 +1,7 @@
+<object name="ftw.mail.mail" meta_type="Dexterity FTI">
+
+  <property name="behaviors" purge="False">
+    <element value="opengever.document.behaviors.customproperties.IDocumentCustomProperties" />
+  </property>
+
+</object>

--- a/opengever/core/upgrades/20210113175519_enable_custom_properties_for_documents_mails/types/opengever.document.document.xml
+++ b/opengever/core/upgrades/20210113175519_enable_custom_properties_for_documents_mails/types/opengever.document.document.xml
@@ -1,0 +1,7 @@
+<object name="opengever.document.document" meta_type="Dexterity FTI">
+
+  <property name="behaviors" purge="False">
+    <element value="opengever.document.behaviors.customproperties.IDocumentCustomProperties" />
+  </property>
+
+</object>

--- a/opengever/core/upgrades/20210113175519_enable_custom_properties_for_documents_mails/upgrade.py
+++ b/opengever/core/upgrades/20210113175519_enable_custom_properties_for_documents_mails/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class EnableCustomPropertiesForDocumentsMails(UpgradeStep):
+    """Enable custom properties for documents/mails.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/document/behaviors/customproperties.py
+++ b/opengever/document/behaviors/customproperties.py
@@ -1,0 +1,31 @@
+from opengever.propertysheets.assignment import get_document_assignment_slots
+from opengever.propertysheets.field import PropertySheetField
+from plone.autoform import directives as form
+from plone.autoform.interfaces import IFormFieldProvider
+from plone.supermodel import model
+from zope.interface import alsoProvides
+
+
+class IDocumentCustomProperties(model.Schema):
+
+    # XXX temporarily omit it from classic UI form rendering
+    form.omitted('custom_properties')
+    custom_properties = PropertySheetField(
+        request_key='form.widgets.IDocumentMetadata.document_type',
+        attribute_name='document_type',
+        assignemnt_prefix='IDocumentMetadata.document_type',
+        title=u'Property sheets with custom properties.',
+        valid_assignment_slots_factory=get_document_assignment_slots,
+        required=False,
+    )
+
+    model.fieldset(
+        u'properties',
+        label=u'Custom properties',
+        fields=[
+            u'custom_properties',
+            ],
+        )
+
+
+alsoProvides(IDocumentCustomProperties, IFormFieldProvider)

--- a/opengever/document/configure.zcml
+++ b/opengever/document/configure.zcml
@@ -91,6 +91,15 @@
       for="*"
       />
 
+  <!-- Property sheet support for documents -->
+  <plone:behavior
+      title="Document property sheet integration"
+      description="Property sheets for document like objects"
+      provides="opengever.document.behaviors.customproperties.IDocumentCustomProperties"
+      for="opengever.document.behaviors.IBaseDocument"
+      factory="opengever.propertysheets.annotation.CustomPropertiesStorage"
+      />
+
   <!-- custom add form for documents -->
   <adapter
       for="Products.CMFCore.interfaces.IFolderish

--- a/opengever/propertysheets/annotation.py
+++ b/opengever/propertysheets/annotation.py
@@ -1,0 +1,81 @@
+from opengever.base.utils import make_persistent
+from opengever.propertysheets.field import IPropertySheetField
+from opengever.propertysheets.exceptions import BadCustomPropertiesFactoryConfiguration
+from persistent.dict import PersistentDict
+from plone.behavior.annotation import AnnotationsFactoryImpl
+from plone.behavior.annotation import AnnotationStorage
+from plone.behavior.interfaces import ISchemaAwareFactory
+from zope.interface import alsoProvides
+
+
+class CustomPropertiesStorageImpl(AnnotationsFactoryImpl):
+    """Storage for custom properties in content annotations.
+
+    Custom properties are actual property values on content for schemas
+    defined in property sheets.
+
+    Does not replace existing property sheet values when they are set, but
+    instead accumulate all values. Values can only be cleared programmatically
+    with the `clear` method.
+    """
+    CUSTOM_PROPERTIES_NAME = 'custom_properties'
+
+    def __init__(self, context, schema):
+        # These are safeguards against bad configuration for the moment.
+        if schema.names() != [self.CUSTOM_PROPERTIES_NAME]:
+            raise BadCustomPropertiesFactoryConfiguration(
+                    u"Custom properties factory must be assigned to a schema "
+                    u"with only a '{}' field.".format(
+                        self.CUSTOM_PROPERTIES_NAME
+                    )
+                )
+
+        field = schema[self.CUSTOM_PROPERTIES_NAME]
+        if not IPropertySheetField.providedBy(field):
+            raise BadCustomPropertiesFactoryConfiguration(
+                    u"The schema must contain a field providing "
+                    u"'IPropertySheetField'"
+                )
+
+        super(CustomPropertiesStorageImpl, self).__init__(context, schema)
+
+    def __setattr__(self, name, value):
+        if name not in self.__dict__['schema']:
+            super(AnnotationsFactoryImpl, self).__setattr__(name, value)
+        else:
+            # early return if the value to `None`
+            if value is None:
+                return
+
+            # for not `None` values always validate type first
+            if not isinstance(value, (dict, PersistentDict)):
+                raise TypeError(
+                    "Only 'dict' or 'PersistentDict' values are allowed."
+                )
+
+            new_value = make_persistent(value)
+            prefixed_name = self.__dict__['prefix'] + name
+
+            value_to_update = self.__dict__['annotations'].get(prefixed_name)
+            # we could have an initial stored value of `None`
+            if value_to_update is None:
+                value_to_update = PersistentDict()
+            value_to_update.update(new_value)
+
+            self.__dict__['annotations'][prefixed_name] = value_to_update
+
+    def clear(self):
+        """Clear all custom properties."""
+        prefixed_name = self.__dict__['prefix'] + self.CUSTOM_PROPERTIES_NAME
+        if prefixed_name in self.__dict__['annotations']:
+            del self.__dict__['annotations'][prefixed_name]
+
+
+class CustomPropertiesStorage(AnnotationStorage):
+    """Behavior adapter factory for storing custom properties."""
+
+    def __call__(self, context):
+        return CustomPropertiesStorageImpl(context, self.schema)
+
+
+alsoProvides(CustomPropertiesStorage, ISchemaAwareFactory)

--- a/opengever/propertysheets/annotation.py
+++ b/opengever/propertysheets/annotation.py
@@ -43,8 +43,13 @@ class CustomPropertiesStorageImpl(AnnotationsFactoryImpl):
         if name not in self.__dict__['schema']:
             super(AnnotationsFactoryImpl, self).__setattr__(name, value)
         else:
-            # early return if the value to `None`
+            prefixed_name = self.__dict__['prefix'] + name
             if value is None:
+                # Early return if the value is `None`, but make sure to
+                # initialize annotations with `None` as this is expected by the
+                # default value patches.
+                if prefixed_name not in self.__dict__['annotations']:
+                    self.__dict__['annotations'][prefixed_name] = value
                 return
 
             # for not `None` values always validate type first
@@ -54,8 +59,6 @@ class CustomPropertiesStorageImpl(AnnotationsFactoryImpl):
                 )
 
             new_value = make_persistent(value)
-            prefixed_name = self.__dict__['prefix'] + name
-
             value_to_update = self.__dict__['annotations'].get(prefixed_name)
             # we could have an initial stored value of `None`
             if value_to_update is None:

--- a/opengever/propertysheets/assignment.py
+++ b/opengever/propertysheets/assignment.py
@@ -5,21 +5,36 @@ from zope.schema.vocabulary import SimpleTerm
 from zope.schema.vocabulary import SimpleVocabulary
 
 
+DOCUMENT_TYPE_ASSIGNMENT_SLOT_PREFIX = "IDocumentMetadata.document_type"
+
+
 @implementer(IVocabularyFactory)
 class PropertySheetAssignmentVocabulary(object):
-    """Return valid property sheet assignments."""
-
+    """Factory for vocabulary of all valid property sheet assignment slots."""
     def __call__(self, context):
-        vocabulary_factory = getUtility(
-            IVocabularyFactory, name="opengever.document.document_types"
-        )
-        document_types_vocabulary = vocabulary_factory(context)
-
         assignment_terms = []
-        for term in document_types_vocabulary:
-            name = u"IDocumentMetadata.document_type.{}".format(
-                term.value
-            )
-            assignment_terms.append(SimpleTerm(name))
-
+        for slot_name in get_document_assignment_slots():
+            assignment_terms.append(SimpleTerm(slot_name))
         return SimpleVocabulary(assignment_terms)
+
+
+def get_document_assignment_slots():
+    """"Return a list of all valid assignment slots for documents.
+
+    Currently this is limited to one slot per possible value of the
+    `document_type` field.
+    """
+    vocabulary_factory = getUtility(
+        IVocabularyFactory, name="opengever.document.document_types"
+    )
+    return [
+        document_type_assignment_slot_name(term.value)
+        for term in vocabulary_factory(None)
+    ]
+
+
+def document_type_assignment_slot_name(value):
+    return u"{}.{}".format(
+        DOCUMENT_TYPE_ASSIGNMENT_SLOT_PREFIX,
+        value
+    )

--- a/opengever/propertysheets/definition.py
+++ b/opengever/propertysheets/definition.py
@@ -63,6 +63,17 @@ class PropertySheetSchemaDefinition(object):
             assignments = tuple()
         self.assignments = assignments
 
+    def __eq__(self, other):
+        if isinstance(other, PropertySheetSchemaDefinition):
+            return other.name == self.name
+        return NotImplemented
+
+    def __ne__(self, other):
+        result = self.__eq__(other)
+        if result is NotImplemented:
+            return result
+        return not result
+
     @property
     def assignments(self):
         return self._assignments

--- a/opengever/propertysheets/definition.py
+++ b/opengever/propertysheets/definition.py
@@ -73,12 +73,12 @@ class PropertySheetSchemaDefinition(object):
             IVocabularyFactory,
             name="opengever.propertysheets.PropertySheetAssignmentsVocabulary"
         )
-        vocabulary = vocabulary_factory(None)
+        assignment_slots = vocabulary_factory(None)
 
         assignments = []
         for token in values:
             try:
-                term = vocabulary.getTermByToken(token)
+                term = assignment_slots.getTermByToken(token)
                 assignments.append(term.value)
             except LookupError:
                 raise InvalidSchemaAssignment(

--- a/opengever/propertysheets/exceptions.py
+++ b/opengever/propertysheets/exceptions.py
@@ -8,3 +8,7 @@ class InvalidFieldTypeDefinition(Exception):
 
 class InvalidSchemaAssignment(Exception):
     pass
+
+
+class BadCustomPropertiesFactoryConfiguration(Exception):
+    pass

--- a/opengever/propertysheets/field.py
+++ b/opengever/propertysheets/field.py
@@ -1,0 +1,129 @@
+from opengever.propertysheets.storage import PropertySheetSchemaStorage
+from plone.schema import IJSONField
+from plone.schema import JSONField
+from zope.globalrequest import getRequest
+from zope.interface import implementer
+from zope.schema import ValidationError
+
+
+class IPropertySheetField(IJSONField):
+    pass
+
+
+@implementer(IPropertySheetField)
+class PropertySheetField(JSONField):
+    """Handle custom properties and validate them against their corresponding
+    property sheet schema.
+
+    Expects custom properties to be provided as a nested data structure of the
+    following format:
+    {
+        "<assignment_slot_name>": {
+            "<field_name>": "<field value>",
+        }
+    }
+
+    It makes the distinction between at most one mandatory property sheet
+    schema and further optional property sheet schemas.
+    A property sheet is considered mandatory when a property sheet is
+    available in storage for the currently active assignment slot.
+
+    - The mandatory property sheet schema is defined by context state.
+      Currently this is coupled to the value of a vocabulary based field, e.g.
+      `document_type`. Each value provides a so called assignment slot.
+      Property sheets can be assigned to those slots. If a property sheet is
+      assigned to such a slot, validation of the sheet is enforced.
+    - The optional property sheet schemas are defines as all sheets that fill
+      one of the slots provided by `valid_assignment_slots_factory`.
+    """
+
+    def __init__(
+        self,
+        request_key,
+        attribute_name,
+        assignemnt_prefix,
+        valid_assignment_slots_factory,
+        **kwargs
+    ):
+        self.request_key = request_key
+        self.attribute_name = attribute_name
+        self.assignemnt_prefix = assignemnt_prefix
+        self.valid_assignment_slots_factory = valid_assignment_slots_factory
+
+        super(PropertySheetField, self).__init__(**kwargs)
+
+    def _validate(self, value):
+        super(PropertySheetField, self)._validate(value)
+
+        active_assignment_slot = self.get_active_assignment_slot()
+        mandatory_sheet = self.get_mandatory_property_sheet(
+            active_assignment_slot
+        )
+        self.validate_mandatory_property_sheet(
+            value, active_assignment_slot, mandatory_sheet
+        )
+        self.validate_optional_property_sheets(
+            value, mandatory_sheet
+        )
+
+    def get_active_assignment_slot(self):
+        """Return assignment slot currently considered active."""
+        request = getRequest()
+
+        value_name = None
+        if self.request_key in request:
+            value_name = request.get(self.request_key)[0]
+        elif self.context:
+            value_name = getattr(self.context, self.attribute_name)
+
+        if not value_name:
+            return None
+
+        return "{}.{}".format(self.assignemnt_prefix, value_name)
+
+    def get_mandatory_property_sheet(self, active_assignment_slot):
+        return PropertySheetSchemaStorage().query(active_assignment_slot)
+
+    def validate_mandatory_property_sheet(
+        self, value, active_assignment_slot, mandatory_sheet
+    ):
+        """Validate mandatory sheet, if available."""
+        if mandatory_sheet is None:
+            return
+        if value is None:
+            value = {}
+
+        data = value.get(active_assignment_slot, {})
+        mandatory_sheet.validate(data)
+
+    def validate_optional_property_sheets(self, value, mandatory_sheet):
+        """Validate schemas for optional sheets."""
+        if value is None:
+            value = {}
+
+        valid_assignment_slots = set(self.valid_assignment_slots_factory())
+
+        for assignment_slot_name in value:
+            optional_sheet = PropertySheetSchemaStorage().query(
+                assignment_slot_name
+            )
+
+            if optional_sheet is None:
+                raise ValidationError(
+                    u"Custom properties for '{}' supplied, but no such "
+                    u"property sheet is defined.".format(assignment_slot_name)
+                )
+
+            if assignment_slot_name not in valid_assignment_slots:
+                raise ValidationError(
+                    u"The property sheet '{}' cannot be used in this "
+                    u"context with assignment '{}'".format(
+                        optional_sheet.name, assignment_slot_name
+                    )
+                )
+
+            # we have already validated this schema, take a shortcut
+            if optional_sheet == mandatory_sheet:
+                continue
+
+            optional_sheet.validate(value.get(assignment_slot_name))

--- a/opengever/propertysheets/storage.py
+++ b/opengever/propertysheets/storage.py
@@ -60,11 +60,11 @@ class PropertySheetSchemaStorage(object):
 
         return PropertySheetSchemaDefinition._load(storage, name)
 
-    def query(self, assignment):
+    def query(self, assignment_slot_name):
         annotations = IAnnotations(self.context)
         storage = annotations.get(self.ANNOTATIONS_KEY, {})
         for name, definition_data in storage.items():
-            if assignment in definition_data['assignments']:
+            if assignment_slot_name in definition_data['assignments']:
                 return self.get(name)
 
         return None

--- a/opengever/propertysheets/tests/test_annotation.py
+++ b/opengever/propertysheets/tests/test_annotation.py
@@ -1,0 +1,158 @@
+from opengever.propertysheets.annotation import CustomPropertiesStorage
+from opengever.propertysheets.annotation import CustomPropertiesStorageImpl
+from opengever.propertysheets.assignment import DOCUMENT_TYPE_ASSIGNMENT_SLOT_PREFIX
+from opengever.propertysheets.exceptions import BadCustomPropertiesFactoryConfiguration
+from opengever.propertysheets.field import PropertySheetField
+from opengever.testing.test_case import FunctionalTestCase
+from persistent.dict import PersistentDict
+from plone.supermodel import model
+from zope import schema
+from zope.annotation.interfaces import IAnnotations
+
+
+def fixture_assignment_factory():
+    return [
+        u"IDocumentMetadata.document_type.contract",
+        u"IDocumentMetadata.document_type.question",
+    ]
+
+
+class ITestFixtureWithCustomProperties(model.Schema):
+
+    custom_properties = PropertySheetField(
+        request_key='some_request_key',
+        attribute_name='some_attribute',
+        assignemnt_prefix=DOCUMENT_TYPE_ASSIGNMENT_SLOT_PREFIX,
+        valid_assignment_slots_factory=fixture_assignment_factory,
+        required=False,
+    )
+
+
+class TestCustomPropertiesStorage(FunctionalTestCase):
+
+    def setUp(self):
+        super(TestCustomPropertiesStorage, self).setUp()
+        self.factory = CustomPropertiesStorage(
+            ITestFixtureWithCustomProperties
+        )
+        # any IAnnotatable will serve as a test-fixture
+        self.context = self.portal
+        self.props = self.factory(self.context)
+        self.annotations = IAnnotations(self.context)
+        self.key = (
+            'opengever.propertysheets.tests.test_annotation.'
+            'ITestFixtureWithCustomProperties.custom_properties'
+        )
+
+    def assert_custom_properties_equal(self, expected):
+        self.assertEqual(expected, self.props.custom_properties)
+        self.assertEqual(expected, self.annotations[self.key])
+
+    def test_custom_property_storage_is_none_per_default(self):
+        self.assertIsNone(self.props.custom_properties)
+
+    def test_custom_property_storage_raises_attribute_error_for_unknowns(self):
+        with self.assertRaises(AttributeError):
+            self.props.foo
+
+    def test_custom_property_storage_converts_values_to_persistent(self):
+        self.props.custom_properties = {"foo": 123}
+        self.assertIsInstance(self.props.custom_properties, PersistentDict)
+
+    def test_custom_property_storage_updates_existing_values(self):
+        self.props.custom_properties = {"foo": 123}
+        self.props.custom_properties = {"bar": "qux"}
+
+        expected = {"foo": 123, "bar": "qux"}
+        self.assert_custom_properties_equal(expected)
+
+    def test_custom_property_storage_keeps_existing_when_set_to_empty(self):
+        self.props.custom_properties = {"foo": 123}
+        self.props.custom_properties = {}
+
+        expected = {"foo": 123}
+        self.assert_custom_properties_equal(expected)
+
+    def test_custom_property_storage_keeps_existing_when_set_to_none(self):
+        self.props.custom_properties = {"foo": 123}
+        self.props.custom_properties = None
+
+        expected = {"foo": 123}
+        self.assert_custom_properties_equal(expected)
+
+    def test_custom_property_storage_allows_clearing(self):
+        self.props.custom_properties = {"foo": 123}
+        self.assertEqual({"foo": 123}, self.props.custom_properties)
+
+        self.props.clear()
+        self.assertIsNone(self.props.custom_properties)
+        self.assertNotIn(self.key, self.annotations)
+
+    def test_custom_property_storage_allows_clearing_of_empty_storage(self):
+        self.assertIsNone(self.props.custom_properties)
+
+        self.props.clear()
+        self.assertIsNone(self.props.custom_properties)
+        self.assertNotIn(self.key, self.annotations)
+
+    def test_custom_property_storage_prevents_setting_wrong_iterable_type(self):
+        with self.assertRaises(TypeError):
+            self.props.custom_properties = []
+
+        with self.assertRaises(TypeError):
+            self.props.custom_properties = ['foo']
+
+        with self.assertRaises(TypeError):
+            self.props.custom_properties = tuple()
+
+        with self.assertRaises(TypeError):
+            self.props.custom_properties = ('foo', 'bar')
+
+    def test_custom_property_storage_prevents_setting_basic_type(self):
+        with self.assertRaises(TypeError):
+            self.props.custom_properties = 0
+
+        with self.assertRaises(TypeError):
+            self.props.custom_properties = ''
+
+        with self.assertRaises(TypeError):
+            self.props.custom_properties = 'blub'
+
+        with self.assertRaises(TypeError):
+            self.props.custom_properties = 123
+
+        with self.assertRaises(TypeError):
+            self.props.custom_properties = 1.3
+
+        with self.assertRaises(TypeError):
+            self.props.custom_properties = True
+
+        with self.assertRaises(TypeError):
+            self.props.custom_properties = False
+
+    def test_factory_validates_schema_field_name(self):
+        class SchemaWithMissingField(model.Schema):
+            pass
+
+        context = None
+        with self.assertRaises(BadCustomPropertiesFactoryConfiguration) as cm:
+            CustomPropertiesStorageImpl(context, SchemaWithMissingField)
+
+        self.assertEqual(
+            u"Custom properties factory must be assigned to a "
+            u"schema with only a 'custom_properties' field.",
+            cm.exception.message
+        )
+
+    def test_factory_validates_schema_field_type(self):
+        class SchemaWithWrongField(model.Schema):
+            custom_properties = schema.Text()
+
+        context = None
+        with self.assertRaises(BadCustomPropertiesFactoryConfiguration) as cm:
+            CustomPropertiesStorageImpl(context, SchemaWithWrongField)
+
+        self.assertEqual(
+            u"The schema must contain a field providing 'IPropertySheetField'",
+            cm.exception.message
+        )

--- a/opengever/propertysheets/tests/test_annotation.py
+++ b/opengever/propertysheets/tests/test_annotation.py
@@ -51,6 +51,23 @@ class TestCustomPropertiesStorage(FunctionalTestCase):
     def test_custom_property_storage_is_none_per_default(self):
         self.assertIsNone(self.props.custom_properties)
 
+    def test_custom_property_storage_initialzes_none_in_annotations(self):
+        self.assertNotIn(self.key, self.annotations)
+
+        self.props.custom_properties = None
+        self.assertIn(self.key, self.annotations)
+        self.assertIsNone(self.annotations[self.key])
+
+        self.assertIsNone(self.props.custom_properties)
+
+    def test_custom_property_storage_initialzes_empty_dict_in_annotations(self):
+        self.assertNotIn(self.key, self.annotations)
+
+        self.props.custom_properties = {}
+        self.assertIn(self.key, self.annotations)
+        self.assertIsInstance(self.annotations[self.key], PersistentDict)
+        self.assertEqual(PersistentDict(), self.annotations[self.key])
+
     def test_custom_property_storage_raises_attribute_error_for_unknowns(self):
         with self.assertRaises(AttributeError):
             self.props.foo

--- a/opengever/propertysheets/tests/test_assignment.py
+++ b/opengever/propertysheets/tests/test_assignment.py
@@ -1,9 +1,23 @@
+from opengever.propertysheets.assignment import get_document_assignment_slots
 from opengever.testing.test_case import FunctionalTestCase
 from zope.component import getUtility
 from zope.schema.interfaces import IVocabularyFactory
 
 
+EXPECTED_DOCUMENT_ASSIGNMENT_SLOTS = [
+    u"IDocumentMetadata.document_type.contract",
+    u"IDocumentMetadata.document_type.directive",
+    u"IDocumentMetadata.document_type.offer",
+    u"IDocumentMetadata.document_type.protocol",
+    u"IDocumentMetadata.document_type.question",
+    u"IDocumentMetadata.document_type.regulations",
+    u"IDocumentMetadata.document_type.report",
+    u"IDocumentMetadata.document_type.request",
+]
+
+
 class TestPropertySheetAssignmentVocabulary(FunctionalTestCase):
+
     def test_assignemnt_vocabulary_contains_document_types(self):
         vocabulary = getUtility(
             IVocabularyFactory,
@@ -11,15 +25,15 @@ class TestPropertySheetAssignmentVocabulary(FunctionalTestCase):
         )(self.portal)
 
         self.assertEqual(
-            [
-                u"IDocumentMetadata.document_type.contract",
-                u"IDocumentMetadata.document_type.directive",
-                u"IDocumentMetadata.document_type.offer",
-                u"IDocumentMetadata.document_type.protocol",
-                u"IDocumentMetadata.document_type.question",
-                u"IDocumentMetadata.document_type.regulations",
-                u"IDocumentMetadata.document_type.report",
-                u"IDocumentMetadata.document_type.request",
-            ],
+            EXPECTED_DOCUMENT_ASSIGNMENT_SLOTS,
             [term.value for term in vocabulary],
+        )
+
+
+class TestPropertySheetDocumentAssignmentSlots(FunctionalTestCase):
+
+    def test_assignemnt_vocabulary_contains_document_types(self):
+        self.assertEqual(
+            EXPECTED_DOCUMENT_ASSIGNMENT_SLOTS,
+            get_document_assignment_slots(),
         )

--- a/opengever/propertysheets/tests/test_definition.py
+++ b/opengever/propertysheets/tests/test_definition.py
@@ -47,6 +47,65 @@ class TestAsciiToken(TestCase):
         self.assertEqual(u'ueasd asd', ascii_token(u'\xfcasd//%asd'))
 
 
+class TestSchemaDefinitionRichComparison(FunctionalTestCase):
+
+    def test_eq_truthy(self):
+        self.assertTrue(
+            PropertySheetSchemaDefinition.create('foo')
+            == PropertySheetSchemaDefinition.create('foo')
+        )
+
+    def test_eq_falsy_other_name(self):
+        self.assertFalse(
+            PropertySheetSchemaDefinition.create('foo')
+            == PropertySheetSchemaDefinition.create('bar')
+        )
+
+    def test_eq_falsy_other_object(self):
+        self.assertFalse(
+            PropertySheetSchemaDefinition.create('foo') == object()
+        )
+
+    def test_eq_falsy_other_primitive(self):
+        self.assertFalse(
+            PropertySheetSchemaDefinition.create('foo') == 123
+        )
+
+    def test_eq_falsy_none(self):
+        val = None  # prevent code style complaints via indirection
+        self.assertFalse(
+            PropertySheetSchemaDefinition.create('foo') == val
+        )
+
+    def test_ne_falsy(self):
+        self.assertFalse(
+            PropertySheetSchemaDefinition.create('foo')
+            != PropertySheetSchemaDefinition.create('foo')
+        )
+
+    def test_ne_truthy_other_name(self):
+        self.assertTrue(
+            PropertySheetSchemaDefinition.create('foo')
+            != PropertySheetSchemaDefinition.create('qux')
+        )
+
+    def test_ne_truthy_other_object(self):
+        self.assertTrue(
+            PropertySheetSchemaDefinition.create('foo') != object()
+        )
+
+    def test_ne_truthy_other_primitive(self):
+        self.assertTrue(
+            PropertySheetSchemaDefinition.create('foo') != 123
+        )
+
+    def test_ne_truthy_none(self):
+        val = None  # prevent code style complaints via indirection
+        self.assertTrue(
+            PropertySheetSchemaDefinition.create('foo') != val
+        )
+
+
 class TestSchemaDefinition(FunctionalTestCase):
 
     def test_create_empty_schema_definition(self):

--- a/opengever/propertysheets/tests/test_definition_validate.py
+++ b/opengever/propertysheets/tests/test_definition_validate.py
@@ -1,0 +1,78 @@
+from opengever.propertysheets.definition import PropertySheetSchemaDefinition
+from opengever.testing.test_case import FunctionalTestCase
+from zope.schema.interfaces import RequiredMissing
+from zope.schema.interfaces import ValidationError
+from zope.schema.interfaces import WrongType
+
+
+class TestSchemaDefinitionValidate(FunctionalTestCase):
+
+    def test_schema_validation_validates_types(self):
+        definition = PropertySheetSchemaDefinition.create("foo")
+        definition.add_field(
+            "bool", u"yesorno", u"Yes or no", u"Say yes or no.", True
+        )
+
+        with self.assertRaises(WrongType):
+            definition.validate({"yesorno": "i will fail"})
+
+    def test_schema_validation_validates_presence(self):
+        definition = PropertySheetSchemaDefinition.create("foo")
+        definition.add_field(
+            "bool", u"yesorno", u"Yes or no", u"Say yes or no.", True
+        )
+
+        with self.assertRaises(RequiredMissing):
+            definition.validate({})
+
+    def test_schema_validation_passes_for_valid_data(self):
+        definition = PropertySheetSchemaDefinition.create("foo")
+        definition.add_field(
+            "bool", u"yesorno", u"Yes or no", u"Say yes or no.", True
+        )
+
+        definition.validate({"yesorno": True})
+
+    def test_schema_validation_allows_empty_when_nothing_required(self):
+        definition = PropertySheetSchemaDefinition.create("foo")
+        definition.add_field(
+            "bool", u"yesorno", u"Yes or no", u"Say yes or no.", False
+        )
+
+        definition.validate({})
+
+    def test_schema_validation_allows_none_when_nothing_required(self):
+        definition = PropertySheetSchemaDefinition.create("foo")
+        definition.add_field(
+            "bool", u"yesorno", u"Yes or no", u"Say yes or no.", False
+        )
+
+        definition.validate(None)
+
+    def test_schema_validation_disallows_wrong_type(self):
+        definition = PropertySheetSchemaDefinition.create("foo")
+
+        with self.assertRaises(WrongType) as cm:
+            definition.validate([])
+
+        self.assertEqual(
+            "Only 'dict' is allowed for properties.", cm.exception.message
+        )
+
+    def test_schema_validation_prevents_setting_extra_properties(self):
+        definition = PropertySheetSchemaDefinition.create("foo")
+        definition.add_field(
+            "bool", u"yesorno", u"Yes or no", u"Say yes or no.", True
+        )
+
+        with self.assertRaises(ValidationError) as cm:
+            definition.validate(
+                {
+                    "yesorno": False,
+                    "extra": "I will fail!",
+                    "blub": 123,
+                }
+            )
+        self.assertEqual(
+            "Cannot set properties 'extra', 'blub'.", cm.exception.message
+        )

--- a/opengever/propertysheets/tests/test_document_custom_properties.py
+++ b/opengever/propertysheets/tests/test_document_custom_properties.py
@@ -1,0 +1,278 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.testbrowser import browsing
+from opengever.document.behaviors.customproperties import IDocumentCustomProperties
+from opengever.testing import IntegrationTestCase
+import json
+
+
+class TestDocumentCustomPropertiesPatch(IntegrationTestCase):
+
+    @browsing
+    def test_does_not_allow_arbitrary_json_in_custom_properties(self, browser):
+        self.login(self.regular_user, browser)
+
+        bad_data = {"custom_properties": {"foo": "bar"}}
+        with browser.expect_http_error(400):
+            browser.open(
+                self.document,
+                method="PATCH",
+                data=json.dumps(bad_data),
+                headers=self.api_headers,
+            )
+        self.assertDictContainsSubset(
+            {
+                "type": "BadRequest",
+            },
+            browser.json,
+        )
+
+    @browsing
+    def test_raises_validation_error_when_selected_assignment_validation_fails(
+        self, browser
+    ):
+        self.login(self.manager, browser)
+
+        create(
+            Builder("property_sheet_schema")
+            .named("schema")
+            .assigned_to_slots(u"IDocumentMetadata.document_type.question")
+            .with_field("text", u"foo", u"some input", u"", True)
+        )
+        self.document.document_type = u"question"
+
+        self.login(self.regular_user, browser)
+        bad_data = {
+            "custom_properties": {
+                "IDocumentMetadata.document_type.question": {"qux": "123"}
+            }
+        }
+        with browser.expect_http_error(400):
+            browser.open(
+                self.document,
+                method="PATCH",
+                data=json.dumps(bad_data),
+                headers=self.api_headers,
+            )
+        self.assertDictContainsSubset(
+            {
+                "type": "BadRequest",
+            },
+            browser.json,
+        )
+
+    @browsing
+    def test_validates_required_field_in_selected_assignment(
+        self, browser
+    ):
+        self.login(self.manager, browser)
+        create(
+            Builder("property_sheet_schema")
+            .named("schema")
+            .assigned_to_slots(u"IDocumentMetadata.document_type.question")
+            .with_field("text", u"foo", u"some input", u"", True)
+        )
+        self.document.document_type = u"question"
+
+        self.login(self.regular_user, browser)
+
+        good_data = {
+            "custom_properties": {
+                "IDocumentMetadata.document_type.question": {"foo": "blabla"}
+            }
+        }
+        browser.open(
+            self.document,
+            method="PATCH",
+            data=json.dumps(good_data),
+            headers=self.api_headers,
+        )
+        self.assertEqual(
+            good_data["custom_properties"],
+            IDocumentCustomProperties(self.document).custom_properties,
+        )
+
+    @browsing
+    def test_allows_empty_data_if_only_non_required_fields_in_selected_assignment(self, browser):
+        self.login(self.manager, browser)
+        create(
+            Builder("property_sheet_schema")
+            .named("schema")
+            .assigned_to_slots(u"IDocumentMetadata.document_type.question")
+            .with_field("text", u"foo", u"some input", u"", False)
+        )
+        self.document.document_type = u"question"
+
+        self.login(self.regular_user, browser)
+        good_data = {"custom_properties": {}}
+        browser.open(
+            self.document,
+            method="PATCH",
+            data=json.dumps(good_data),
+            headers=self.api_headers,
+        )
+        self.assertEqual(
+            {},
+            IDocumentCustomProperties(self.document).custom_properties,
+        )
+
+    @browsing
+    def test_allows_other_valid_property_sheet_fields_next_to_selected_assignment(self, browser):
+        self.login(self.manager, browser)
+
+        create(
+            Builder("property_sheet_schema")
+            .named("schema1")
+            .assigned_to_slots(u"IDocumentMetadata.document_type.question")
+            .with_field("text", u"foo", u"some input", u"", True)
+        )
+        create(
+            Builder("property_sheet_schema")
+            .named("schema2")
+            .assigned_to_slots(u"IDocumentMetadata.document_type.report")
+            .with_field("int", u"num", u"A number", u"Put a number.", True)
+        )
+        self.document.document_type = u"report"
+
+        self.login(self.regular_user, browser)
+        good_data = {
+            "custom_properties": {
+                "IDocumentMetadata.document_type.question": {"foo": "blabla"},
+                "IDocumentMetadata.document_type.report": {"num": 123},
+            }
+        }
+        browser.open(
+            self.document,
+            method="PATCH",
+            data=json.dumps(good_data),
+            headers=self.api_headers,
+        )
+        self.assertEqual(
+            good_data["custom_properties"],
+            IDocumentCustomProperties(self.document).custom_properties,
+        )
+
+
+class TestDocumentCustomPropertiesPost(IntegrationTestCase):
+
+    @browsing
+    def test_stores_custom_properties_when_no_document_type_selected(self, browser):
+        self.login(self.manager, browser)
+        create(
+            Builder("property_sheet_schema")
+            .named("schema")
+            .assigned_to_slots(u"IDocumentMetadata.document_type.question")
+            .with_field("text", u"foo", u"some input", u"", False)
+        )
+
+        self.login(self.regular_user, browser)
+        property_data = {
+            "IDocumentMetadata.document_type.question": {
+                "foo": u"f\xfc"
+            }
+        }
+        data = {
+            "@type": "opengever.document.document",
+            "file": {
+                "data": "foo bar",
+                "filename": "test.txt",
+            },
+            "custom_properties": property_data,
+        }
+
+        with self.observe_children(self.dossier) as children:
+            browser.open(self.dossier, data=json.dumps(data), method="POST",
+                         headers=self.api_headers)
+
+        self.assertEqual(property_data, browser.json['custom_properties'])
+        self.assertEqual(1, len(children['added']))
+        new_document = children['added'].pop()
+        self.assertEqual(
+            property_data,
+            IDocumentCustomProperties(new_document).custom_properties,
+        )
+
+    @browsing
+    def test_validates_custom_properties_when_document_type_selected(self, browser):
+        self.login(self.manager, browser)
+        create(
+            Builder("property_sheet_schema")
+            .named("schema")
+            .assigned_to_slots(u"IDocumentMetadata.document_type.question")
+            .with_field("text", u"foo", u"some input", u"", False)
+        )
+
+        self.login(self.regular_user, browser)
+        bad_data = {
+            "IDocumentMetadata.document_type.question": {
+                "qux": u"i am invalid"
+            }
+        }
+        data = {
+            "@type": "opengever.document.document",
+            "file": {
+                "data": "foo bar",
+                "filename": "test.txt",
+            },
+            "document_type": "question",
+            "custom_properties": bad_data,
+        }
+
+        with browser.expect_http_error(400):
+            browser.open(self.dossier, data=json.dumps(data), method="POST",
+                         headers=self.api_headers)
+
+        self.assertIn("'field': 'custom_properties'", browser.json["message"])
+        self.assertDictContainsSubset({u"type": u"BadRequest"}, browser.json)
+
+    @browsing
+    def test_validates_custom_properties_when_no_document_type_selected(self, browser):
+        self.login(self.manager, browser)
+        create(
+            Builder("property_sheet_schema")
+            .named("schema")
+            .assigned_to_slots(u"IDocumentMetadata.document_type.question")
+            .with_field("text", u"foo", u"some input", u"", False)
+        )
+
+        self.login(self.regular_user, browser)
+        bad_data = {
+            "IDocumentMetadata.document_type.question": {
+                "qux": u"i am invalid"
+            }
+        }
+        data = {
+            "@type": "opengever.document.document",
+            "file": {
+                "data": "foo bar",
+                "filename": "test.txt",
+            },
+            "custom_properties": bad_data,
+        }
+
+        with browser.expect_http_error(400):
+            browser.open(self.dossier, data=json.dumps(data), method="POST",
+                         headers=self.api_headers)
+
+        self.assertIn("'field': 'custom_properties'", browser.json["message"])
+        self.assertDictContainsSubset({u"type": u"BadRequest"}, browser.json)
+
+
+class TestDocumentCustomPropertiesGet(IntegrationTestCase):
+
+    @browsing
+    def test_always_returns_all_custom_property_data(self, browser):
+        self.login(self.regular_user, browser)
+
+        props_data = {
+            "IDocumentMetadata.document_type.question": {
+                "foo": u"f\xfc",
+            },
+            "something": {
+                "else": 123,
+            }
+        }
+        IDocumentCustomProperties(self.document).custom_properties = props_data
+
+        browser.open(self.document, method="GET", headers=self.api_headers)
+        self.assertEqual(props_data, browser.json['custom_properties'])

--- a/opengever/propertysheets/tests/test_document_custom_properties.py
+++ b/opengever/propertysheets/tests/test_document_custom_properties.py
@@ -9,6 +9,46 @@ import json
 class TestDocumentCustomPropertiesPatch(IntegrationTestCase):
 
     @browsing
+    def test_correctly_stores_custom_properties_with_all_field_types(self, browser):
+        self.login(self.manager, browser)
+
+        choices = ["one", "two", "three"]
+        create(
+            Builder("property_sheet_schema")
+            .named("schema1")
+            .assigned_to_slots(u"IDocumentMetadata.document_type.question")
+            .with_field("bool", u"yesorno", u"Yes or no", u"", True)
+            .with_field("choice", u"choose", u"Choose", u"", True, values=choices)
+            .with_field("int", u"num", u"Number", u"", True)
+            .with_field("text", u"text", u"Some lines of text", u"", True)
+            .with_field("textline", u"textline", u"A line of text", u"", True)
+        )
+        self.document.document_type = u"question"
+
+        self.login(self.regular_user, browser)
+        good_data = {
+            "custom_properties": {
+                "IDocumentMetadata.document_type.question": {
+                    "yesorno": False,
+                    "choose": "two",
+                    "num": 123,
+                    "text": u"bl\xe4\nblub",
+                    "textline": u"bl\xe4",
+                },
+            }
+        }
+        browser.open(
+            self.document,
+            method="PATCH",
+            data=json.dumps(good_data),
+            headers=self.api_headers,
+        )
+        self.assertEqual(
+            good_data["custom_properties"],
+            IDocumentCustomProperties(self.document).custom_properties,
+        )
+
+    @browsing
     def test_does_not_allow_arbitrary_json_in_custom_properties(self, browser):
         self.login(self.regular_user, browser)
 
@@ -116,6 +156,7 @@ class TestDocumentCustomPropertiesPatch(IntegrationTestCase):
             IDocumentCustomProperties(self.document).custom_properties,
         )
 
+
     @browsing
     def test_allows_other_valid_property_sheet_fields_next_to_selected_assignment(self, browser):
         self.login(self.manager, browser)
@@ -151,7 +192,6 @@ class TestDocumentCustomPropertiesPatch(IntegrationTestCase):
             good_data["custom_properties"],
             IDocumentCustomProperties(self.document).custom_properties,
         )
-
 
 class TestDocumentCustomPropertiesPost(IntegrationTestCase):
 

--- a/opengever/propertysheets/tests/test_field.py
+++ b/opengever/propertysheets/tests/test_field.py
@@ -1,0 +1,211 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from mock import Mock
+from opengever.propertysheets.assignment import DOCUMENT_TYPE_ASSIGNMENT_SLOT_PREFIX
+from opengever.propertysheets.field import PropertySheetField
+from opengever.testing import FunctionalTestCase
+from zope.schema import ValidationError
+from zope.schema.interfaces import RequiredMissing
+from zope.schema.interfaces import WrongType
+
+
+def fixture_assignment_factory():
+    return [
+        u"IDocumentMetadata.document_type.contract",
+        u"IDocumentMetadata.document_type.question",
+    ]
+
+
+class TestPropertySheetField(FunctionalTestCase):
+
+    def setUp(self):
+        super(TestPropertySheetField, self).setUp()
+
+        self.field = PropertySheetField(
+            "some_request_key",
+            "some_attribute",
+            DOCUMENT_TYPE_ASSIGNMENT_SLOT_PREFIX,
+            fixture_assignment_factory,
+        )
+
+    def test_validation_fails_when_required_field_of_mandatory_sheet_is_not_provided(
+        self,
+    ):
+        create(
+            Builder("property_sheet_schema")
+            .named("schema")
+            .assigned_to_slots(u"IDocumentMetadata.document_type.question")
+            .with_simple_boolean_field()
+        )
+
+        self.request["some_request_key"] = [u"question"]
+
+        with self.assertRaises(RequiredMissing):
+            self.field.validate({})
+
+    def test_validation_fails_when_field_of_mandatory_sheet_is_of_wrong_type(
+        self,
+    ):
+        create(
+            Builder("property_sheet_schema")
+            .named("schema")
+            .assigned_to_slots(u"IDocumentMetadata.document_type.question")
+            .with_simple_boolean_field()
+        )
+
+        self.request["some_request_key"] = [u"question"]
+
+        with self.assertRaises(WrongType):
+            self.field.validate(
+                {"IDocumentMetadata.document_type.question": {"yesorno": "X"}}
+            )
+
+    def test_validation_fails_when_providing_extra_fields_to_mandatory_sheet(
+        self,
+    ):
+        create(
+            Builder("property_sheet_schema")
+            .named("schema")
+            .assigned_to_slots(u"IDocumentMetadata.document_type.question")
+            .with_simple_boolean_field()
+        )
+
+        self.request["some_request_key"] = [u"question"]
+
+        with self.assertRaises(ValidationError) as cm:
+            self.field.validate(
+                {
+                    "IDocumentMetadata.document_type.question": {
+                        "yesorno": True,
+                        "qux": "i should fail",
+                    }
+                }
+            )
+        self.assertEqual("Cannot set properties 'qux'.", cm.exception.message)
+
+    def test_validation_fails_when_required_field_of_optional_sheet_is_not_provided(
+        self,
+    ):
+        create(
+            Builder("property_sheet_schema")
+            .named("schema")
+            .assigned_to_slots(u"IDocumentMetadata.document_type.contract")
+            .with_simple_boolean_field()
+        )
+
+        with self.assertRaises(RequiredMissing):
+            self.field.validate(
+                {u"IDocumentMetadata.document_type.contract": {}}
+            )
+
+    def test_validation_fails_when_field_of_optional_sheet_is_of_wrong_type(
+        self,
+    ):
+        create(
+            Builder("property_sheet_schema")
+            .named("schema")
+            .assigned_to_slots(u"IDocumentMetadata.document_type.contract")
+            .with_simple_boolean_field()
+        )
+
+        with self.assertRaises(WrongType):
+            self.field.validate(
+                {"IDocumentMetadata.document_type.contract": {"yesorno": "X"}}
+            )
+
+    def test_validation_fails_when_providing_extra_fields_to_optional_sheet(
+        self,
+    ):
+        create(
+            Builder("property_sheet_schema")
+            .named("schema")
+            .assigned_to_slots(u"IDocumentMetadata.document_type.contract")
+            .with_simple_boolean_field()
+        )
+
+        with self.assertRaises(ValidationError) as cm:
+            self.field.validate(
+                {
+                    "IDocumentMetadata.document_type.contract": {
+                        "yesorno": True,
+                        "qux": "i should fail",
+                    }
+                }
+            )
+        self.assertEqual("Cannot set properties 'qux'.", cm.exception.message)
+
+    def test_validation_fails_when_providing_nonexisting_sheets(
+        self,
+    ):
+        with self.assertRaises(ValidationError) as cm:
+            self.field.validate(
+                {
+                    "some.inexisting.sheet": {
+                        "yesorno": True,
+                    }
+                }
+            )
+        self.assertEqual(
+            u"Custom properties for 'some.inexisting.sheet' supplied, but no "
+            u"such property sheet is defined.",
+            cm.exception.message,
+        )
+
+    def test_validation_fails_when_providing_sheets_not_available_on_context(
+        self,
+    ):
+        create(
+            Builder("property_sheet_schema")
+            .named("somename")
+            .assigned_to_slots(u"IDocumentMetadata.document_type.regulations")
+            .with_simple_boolean_field()
+        )
+
+        with self.assertRaises(ValidationError) as cm:
+            self.field.validate(
+                {
+                    "IDocumentMetadata.document_type.regulations": {
+                        "yesorno": True,
+                    }
+                }
+            )
+        self.assertEqual(
+            u"The property sheet 'somename' cannot be used in this "
+            u"context with assignment "
+            u"'IDocumentMetadata.document_type.regulations'",
+            cm.exception.message,
+        )
+
+    def test_successful_field_validation_with_active_slot_from_request_key(
+        self,
+    ):
+        create(
+            Builder("property_sheet_schema")
+            .named("schema")
+            .assigned_to_slots(u"IDocumentMetadata.document_type.question")
+            .with_simple_boolean_field()
+        )
+
+        self.request["some_request_key"] = [u"question"]
+
+        self.field.validate(
+            {"IDocumentMetadata.document_type.question": {"yesorno": True}}
+        )
+
+    def test_successful_field_validation_with_active_slot_from_context_attribute(
+        self,
+    ):
+        create(
+            Builder("property_sheet_schema")
+            .named("schema")
+            .assigned_to_slots(u"IDocumentMetadata.document_type.question")
+            .with_simple_boolean_field()
+        )
+
+        context = Mock()
+        context.some_attribute = u"question"
+        field = self.field.bind(context)
+
+        field.validate(
+            {"IDocumentMetadata.document_type.question": {"yesorno": True}}
+        )

--- a/opengever/propertysheets/tests/test_mail_custom_properties.py
+++ b/opengever/propertysheets/tests/test_mail_custom_properties.py
@@ -1,0 +1,278 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.testbrowser import browsing
+from opengever.document.behaviors.customproperties import IDocumentCustomProperties
+from opengever.testing import IntegrationTestCase
+import json
+
+
+class TestMailCustomPropertiesPatch(IntegrationTestCase):
+
+    @browsing
+    def test_does_not_allow_arbitrary_json_in_custom_properties(self, browser):
+        self.login(self.regular_user, browser)
+
+        bad_data = {"custom_properties": {"foo": "bar"}}
+        with browser.expect_http_error(400):
+            browser.open(
+                self.mail_eml,
+                method="PATCH",
+                data=json.dumps(bad_data),
+                headers=self.api_headers,
+            )
+        self.assertDictContainsSubset(
+            {
+                "type": "BadRequest",
+            },
+            browser.json,
+        )
+
+    @browsing
+    def test_raises_validation_error_when_selected_assignment_validation_fails(
+        self, browser
+    ):
+        self.login(self.manager, browser)
+
+        create(
+            Builder("property_sheet_schema")
+            .named("schema")
+            .assigned_to_slots(u"IDocumentMetadata.document_type.question")
+            .with_field("text", u"foo", u"some input", u"", True)
+        )
+        self.mail_eml.document_type = u"question"
+
+        self.login(self.regular_user, browser)
+        bad_data = {
+            "custom_properties": {
+                "IDocumentMetadata.document_type.question": {"qux": "123"}
+            }
+        }
+        with browser.expect_http_error(400):
+            browser.open(
+                self.mail_eml,
+                method="PATCH",
+                data=json.dumps(bad_data),
+                headers=self.api_headers,
+            )
+        self.assertDictContainsSubset(
+            {
+                "type": "BadRequest",
+            },
+            browser.json,
+        )
+
+    @browsing
+    def test_validates_required_field_in_selected_assignment(
+        self, browser
+    ):
+        self.login(self.manager, browser)
+        create(
+            Builder("property_sheet_schema")
+            .named("schema")
+            .assigned_to_slots(u"IDocumentMetadata.document_type.question")
+            .with_field("text", u"foo", u"some input", u"", True)
+        )
+        self.mail_eml.document_type = u"question"
+
+        self.login(self.regular_user, browser)
+
+        good_data = {
+            "custom_properties": {
+                "IDocumentMetadata.document_type.question": {"foo": "blabla"}
+            }
+        }
+        browser.open(
+            self.mail_eml,
+            method="PATCH",
+            data=json.dumps(good_data),
+            headers=self.api_headers,
+        )
+        self.assertEqual(
+            good_data["custom_properties"],
+            IDocumentCustomProperties(self.mail_eml).custom_properties,
+        )
+
+    @browsing
+    def test_allows_empty_data_if_only_non_required_fields_in_selected_assignment(self, browser):
+        self.login(self.manager, browser)
+        create(
+            Builder("property_sheet_schema")
+            .named("schema")
+            .assigned_to_slots(u"IDocumentMetadata.document_type.question")
+            .with_field("text", u"foo", u"some input", u"", False)
+        )
+        self.mail_eml.document_type = u"question"
+
+        self.login(self.regular_user, browser)
+        good_data = {"custom_properties": {}}
+        browser.open(
+            self.mail_eml,
+            method="PATCH",
+            data=json.dumps(good_data),
+            headers=self.api_headers,
+        )
+        self.assertEqual(
+            {},
+            IDocumentCustomProperties(self.mail_eml).custom_properties,
+        )
+
+    @browsing
+    def test_allows_other_valid_property_sheet_fields_next_to_selected_assignment(self, browser):
+        self.login(self.manager, browser)
+
+        create(
+            Builder("property_sheet_schema")
+            .named("schema1")
+            .assigned_to_slots(u"IDocumentMetadata.document_type.question")
+            .with_field("text", u"foo", u"some input", u"", True)
+        )
+        create(
+            Builder("property_sheet_schema")
+            .named("schema2")
+            .assigned_to_slots(u"IDocumentMetadata.document_type.report")
+            .with_field("int", u"num", u"A number", u"Put a number.", True)
+        )
+        self.mail_eml.document_type = u"report"
+
+        self.login(self.regular_user, browser)
+        good_data = {
+            "custom_properties": {
+                "IDocumentMetadata.document_type.question": {"foo": "blabla"},
+                "IDocumentMetadata.document_type.report": {"num": 123},
+            }
+        }
+        browser.open(
+            self.mail_eml,
+            method="PATCH",
+            data=json.dumps(good_data),
+            headers=self.api_headers,
+        )
+        self.assertEqual(
+            good_data["custom_properties"],
+            IDocumentCustomProperties(self.mail_eml).custom_properties,
+        )
+
+
+class TestMailCustomPropertiesPost(IntegrationTestCase):
+
+    @browsing
+    def test_stores_custom_properties_when_no_document_type_selected(self, browser):
+        self.login(self.manager, browser)
+        create(
+            Builder("property_sheet_schema")
+            .named("schema")
+            .assigned_to_slots(u"IDocumentMetadata.document_type.question")
+            .with_field("text", u"foo", u"some input", u"", False)
+        )
+
+        self.login(self.regular_user, browser)
+        property_data = {
+            "IDocumentMetadata.document_type.question": {
+                "foo": u"f\xfc"
+            }
+        }
+        data = {
+            "@type": "opengever.document.document",
+            "file": {
+                "data": "foo bar",
+                "filename": "test.txt",
+            },
+            "custom_properties": property_data,
+        }
+
+        with self.observe_children(self.dossier) as children:
+            browser.open(self.dossier, data=json.dumps(data), method="POST",
+                         headers=self.api_headers)
+
+        self.assertEqual(property_data, browser.json['custom_properties'])
+        self.assertEqual(1, len(children['added']))
+        new_document = children['added'].pop()
+        self.assertEqual(
+            property_data,
+            IDocumentCustomProperties(new_document).custom_properties,
+        )
+
+    @browsing
+    def test_validates_custom_properties_when_document_type_selected(self, browser):
+        self.login(self.manager, browser)
+        create(
+            Builder("property_sheet_schema")
+            .named("schema")
+            .assigned_to_slots(u"IDocumentMetadata.document_type.question")
+            .with_field("text", u"foo", u"some input", u"", False)
+        )
+
+        self.login(self.regular_user, browser)
+        bad_data = {
+            "IDocumentMetadata.document_type.question": {
+                "qux": u"i am invalid"
+            }
+        }
+        data = {
+            "@type": "ftw.mail.mail",
+            "file": {
+                "data": "foo bar",
+                "filename": "test.eml",
+            },
+            "document_type": "question",
+            "custom_properties": bad_data,
+        }
+
+        with browser.expect_http_error(400):
+            browser.open(self.dossier, data=json.dumps(data), method="POST",
+                         headers=self.api_headers)
+
+        self.assertIn("'field': 'custom_properties'", browser.json["message"])
+        self.assertDictContainsSubset({u"type": u"BadRequest"}, browser.json)
+
+    @browsing
+    def test_validates_custom_properties_when_no_document_type_selected(self, browser):
+        self.login(self.manager, browser)
+        create(
+            Builder("property_sheet_schema")
+            .named("schema")
+            .assigned_to_slots(u"IDocumentMetadata.document_type.question")
+            .with_field("text", u"foo", u"some input", u"", False)
+        )
+
+        self.login(self.regular_user, browser)
+        bad_data = {
+            "IDocumentMetadata.document_type.question": {
+                "qux": u"i am invalid"
+            }
+        }
+        data = {
+            "@type": "ftw.mail.mail",
+            "file": {
+                "data": "foo bar",
+                "filename": "test.eml",
+            },
+            "custom_properties": bad_data,
+        }
+
+        with browser.expect_http_error(400):
+            browser.open(self.dossier, data=json.dumps(data), method="POST",
+                         headers=self.api_headers)
+
+        self.assertIn("'field': 'custom_properties'", browser.json["message"])
+        self.assertDictContainsSubset({u"type": u"BadRequest"}, browser.json)
+
+
+class TestMailCustomPropertiesGet(IntegrationTestCase):
+
+    @browsing
+    def test_always_returns_all_custom_property_data(self, browser):
+        self.login(self.regular_user, browser)
+
+        props_data = {
+            "IDocumentMetadata.document_type.question": {
+                "foo": u"f\xfc",
+            },
+            "something": {
+                "else": 123,
+            }
+        }
+        IDocumentCustomProperties(self.mail_eml).custom_properties = props_data
+
+        browser.open(self.mail_eml, method="GET", headers=self.api_headers)
+        self.assertEqual(props_data, browser.json['custom_properties'])

--- a/opengever/propertysheets/tests/test_schema_definition_delete.py
+++ b/opengever/propertysheets/tests/test_schema_definition_delete.py
@@ -1,5 +1,6 @@
+from ftw.builder import Builder
+from ftw.builder import create
 from ftw.testbrowser import browsing
-from opengever.propertysheets.definition import PropertySheetSchemaDefinition
 from opengever.propertysheets.storage import PropertySheetSchemaStorage
 from opengever.testing import IntegrationTestCase
 
@@ -9,16 +10,13 @@ class TestSchemaDefinitionDelete(IntegrationTestCase):
     @browsing
     def test_property_sheet_schema_definition_delete_existing_schema(self, browser):
         self.login(self.manager, browser)
-
-        sheet = PropertySheetSchemaDefinition.create("sheet")
-        storage = PropertySheetSchemaStorage()
-        storage.save(sheet)
+        create(Builder("property_sheet_schema").named("sheet"))
 
         browser.open(
             view="@propertysheets/sheet", method="DELETE", headers=self.api_headers
         )
         self.assertEqual(browser.status_code, 204)
-        self.assertEqual([], storage.list())
+        self.assertEqual([], PropertySheetSchemaStorage().list())
 
     @browsing
     def test_property_sheet_schema_definition_delete_requires_name(
@@ -65,10 +63,7 @@ class TestSchemaDefinitionDelete(IntegrationTestCase):
     @browsing
     def test_non_managers_cannot_delete(self, browser):
         self.login(self.administrator, browser)
-
-        sheet = PropertySheetSchemaDefinition.create("sheet")
-        storage = PropertySheetSchemaStorage()
-        storage.save(sheet)
+        create(Builder("property_sheet_schema").named("sheet"))
 
         with browser.expect_unauthorized():
             browser.open(

--- a/opengever/propertysheets/tests/test_schema_definition_get.py
+++ b/opengever/propertysheets/tests/test_schema_definition_get.py
@@ -1,7 +1,7 @@
+from ftw.builder import Builder
+from ftw.builder import create
 from ftw.testbrowser import browsing
 from jsonschema import Draft4Validator
-from opengever.propertysheets.definition import PropertySheetSchemaDefinition
-from opengever.propertysheets.storage import PropertySheetSchemaStorage
 from opengever.testing import IntegrationTestCase
 
 
@@ -28,12 +28,8 @@ class TestSchemaDefinitionGet(IntegrationTestCase):
     def test_property_sheet_schema_definition_get_list(self, browser):
         self.login(self.regular_user, browser)
 
-        definition1 = PropertySheetSchemaDefinition.create("schema1")
-        definition2 = PropertySheetSchemaDefinition.create("schema2")
-
-        storage = PropertySheetSchemaStorage()
-        storage.save(definition1)
-        storage.save(definition2)
+        create(Builder("property_sheet_schema").named("schema1"))
+        create(Builder("property_sheet_schema").named("schema2"))
 
         browser.open(
             view="@propertysheets", method="GET", headers=self.api_headers
@@ -53,16 +49,16 @@ class TestSchemaDefinitionGet(IntegrationTestCase):
     def test_property_sheet_schema_definition_get_sheet_schema(self, browser):
         self.login(self.regular_user, browser)
 
-        definition = PropertySheetSchemaDefinition.create(
-            "schema", assignments=[u"IDocumentMetadata.document_type.question"]
-        )
-        definition.add_field("bool", u"yesorno", u"y/n", u"", False)
         choices = ["one", "two", "three"]
-        definition.add_field(
-            "choice", u"chooseone", u"choose", u"", False, values=choices
+        create(
+            Builder("property_sheet_schema")
+            .named("schema")
+            .assigned_to_slots(u"IDocumentMetadata.document_type.question")
+            .with_field("bool", u"yesorno", u"y/n", u"", False)
+            .with_field(
+                "choice", u"chooseone", u"choose", u"", False, values=choices
+            )
         )
-        storage = PropertySheetSchemaStorage()
-        storage.save(definition)
 
         browser.open(
             view="@propertysheets/schema",

--- a/opengever/propertysheets/tests/test_schema_definition_post.py
+++ b/opengever/propertysheets/tests/test_schema_definition_post.py
@@ -1,5 +1,6 @@
+from ftw.builder import Builder
+from ftw.builder import create
 from ftw.testbrowser import browsing
-from opengever.propertysheets.definition import PropertySheetSchemaDefinition
 from opengever.propertysheets.storage import PropertySheetSchemaStorage
 from opengever.testing import IntegrationTestCase
 from zope import schema
@@ -108,10 +109,7 @@ class TestSchemaDefinitionPost(IntegrationTestCase):
     @browsing
     def test_property_sheet_schema_definition_post_replaces_existing_schema(self, browser):
         self.login(self.manager, browser)
-
-        definition = PropertySheetSchemaDefinition.create("question")
-        storage = PropertySheetSchemaStorage()
-        storage.save(definition)
+        create(Builder("property_sheet_schema").named("question"))
 
         data = {
             "fields": {
@@ -130,6 +128,7 @@ class TestSchemaDefinitionPost(IntegrationTestCase):
             headers=self.api_headers,
         )
 
+        storage = PropertySheetSchemaStorage()
         self.assertEqual(1, len(storage.list()))
         definition = storage.get("question")
 
@@ -170,12 +169,11 @@ class TestSchemaDefinitionPost(IntegrationTestCase):
         self, browser
     ):
         self.login(self.manager, browser)
-        storage = PropertySheetSchemaStorage()
-        fixture = PropertySheetSchemaDefinition.create(
-            "fixture",
-            assignments=[u"IDocumentMetadata.document_type.question"]
+        create(
+            Builder("property_sheet_schema")
+            .named("fixture")
+            .assigned_to_slots(u"IDocumentMetadata.document_type.question")
         )
-        storage.save(fixture)
 
         data = {
             "fields": {"foo": {"field_type": "bool"}},
@@ -197,6 +195,7 @@ class TestSchemaDefinitionPost(IntegrationTestCase):
             },
             browser.json,
         )
+        storage = PropertySheetSchemaStorage()
         self.assertEqual(1, len(storage.list()))
 
     @browsing

--- a/opengever/propertysheets/tests/test_schema_definition_post.py
+++ b/opengever/propertysheets/tests/test_schema_definition_post.py
@@ -197,41 +197,6 @@ class TestSchemaDefinitionPost(IntegrationTestCase):
             },
             browser.json,
         )
-        storage = PropertySheetSchemaStorage()
-        self.assertEqual([], storage.list())
-
-    @browsing
-    def test_property_sheet_schema_definition_post_requires_unique_assignment(
-        self, browser
-    ):
-        self.login(self.manager, browser)
-        storage = PropertySheetSchemaStorage()
-        fixture = PropertySheetSchemaDefinition.create(
-            "fixture",
-            assignments=[u"IDocumentMetadata.document_type.question"]
-        )
-        storage.save(fixture)
-
-        data = {
-            "fields": {"foo": {"field_type": "bool"}},
-            "assignments": [u"IDocumentMetadata.document_type.question"],
-        }
-        with browser.expect_http_error(400):
-            browser.open(
-                view="@propertysheets/invalidassignment",
-                method="POST",
-                data=json.dumps(data),
-                headers=self.api_headers,
-            )
-
-        self.assertDictContainsSubset(
-            {
-                u"message": u"The assignment 'IDocumentMetadata.document_type."
-                            "question' is already in use.",
-                "type": "BadRequest",
-            },
-            browser.json,
-        )
         self.assertEqual(1, len(storage.list()))
 
     @browsing

--- a/opengever/testing/builders/__init__.py
+++ b/opengever/testing/builders/__init__.py
@@ -3,6 +3,7 @@ from opengever.testing.builders.dx import *
 from opengever.testing.builders.fixture import *
 from opengever.testing.builders.ldap import *
 from opengever.testing.builders.portlets import *
+from opengever.testing.builders.propertysheets import *
 from opengever.testing.builders.qickupload import *
 from opengever.testing.builders.repositorytree import *
 from opengever.testing.builders.sql import *

--- a/opengever/testing/builders/propertysheets.py
+++ b/opengever/testing/builders/propertysheets.py
@@ -1,0 +1,49 @@
+from ftw.builder import builder_registry
+from opengever.propertysheets.storage import PropertySheetSchemaStorage
+from opengever.propertysheets.definition import PropertySheetSchemaDefinition
+
+
+class PropertySheetSchemaBuilder(object):
+    """Create a property sheet schema definition and persist it in storage."""
+    def __init__(self, session):
+        self.session = session
+        self.arguments = {
+            'name': 'schema',
+            'assignments': None
+        }
+        self.field_defs = []
+        self.storage = PropertySheetSchemaStorage()
+
+    def having(self, **kwargs):
+        self.arguments.update(kwargs)
+        return self
+
+    def named(self, name):
+        self.arguments['name'] = name
+        return self
+
+    def assigned_to_slots(self, *args):
+        self.arguments['assignments'] = args
+        return self
+
+    def with_simple_boolean_field(self):
+        return self.with_field("bool", u"yesorno", u"y/n", u"", True)
+
+    def with_field(self, field_type, name, title, description, required, values=None):
+        self.field_defs.append(
+            (field_type, name, title, description, required, values)
+        )
+        return self
+
+    def create(self, **kwargs):
+        definition = PropertySheetSchemaDefinition.create(
+            self.arguments['name'],
+            self.arguments['assignments']
+        )
+        for field_def in self.field_defs:
+            definition.add_field(*field_def)
+        self.storage.save(definition)
+        return self.storage.get(definition.name)
+
+
+builder_registry.register('property_sheet_schema', PropertySheetSchemaBuilder)


### PR DESCRIPTION
With this PR we introduce a `Behavior` enabling custom properties for content. We activate the behavior for document and mail content types. It is based on functionality introduced in earlier Pull-Requests https://github.com/4teamwork/opengever.core/pull/6795 and https://github.com/4teamwork/opengever.core/pull/6800.

Jira: https://4teamwork.atlassian.net/browse/CA-1284

With this PR the following concepts/terms are introduced:
- `Assignment Slot`: A content type defines assignment slots. A property sheet can be assigned to such an assignment slot. Currently there is one slot for each document type. If a document type is selected and a sheet is registered for its slot, the sheets schema is enforced/validated.
- `Custom Property`: The actual data stored on content and validated against the property sheet.

Some comments about the implementation:
- Custom properties are stored in context annotations. The storage is implemented in a cumulative way, so that when setting data for one assignment slots, data of other slots is not overwritten. This is to prevent deleting data when the user switches the document type back and forth.
- There is only soft validation in place on the storage layer, only the type of the stored value is validated. 
- Most of the strict validation is implemented in the corresponding `PropertySheetField`.
- The behavior is mostly used to configure the other components (Setup the field, and configure correct storage). If we want to activate custom properties for e.g. dossiers, we will need a new dossier-specific behavior.

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

## Checklist (if applicable)

_Only applicable should be left and checked._

- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
- New functionality:
  - [x] for `document` also works for `mail`
