### PR TITLE
Clean up English og.workspace translations.

### DIFF
--- a/opengever/workspace/locales/en/LC_MESSAGES/opengever.workspace.po
+++ b/opengever/workspace/locales/en/LC_MESSAGES/opengever.workspace.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-01-15 07:54+0000\n"
+"POT-Creation-Date: 2021-01-17 21:28+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -37,7 +37,7 @@ msgstr "Delete"
 #. German translation: Gelöschter Teamraum
 #: ./opengever/workspace/participation/browser/my_invitations.py
 msgid "Deleted Workspace"
-msgstr "Deleted Workspace"
+msgstr "Deleted workspace"
 
 #. German translation: Einladung
 #: ./opengever/workspace/participation/browser/participants_view.py
@@ -122,7 +122,7 @@ msgstr "Common"
 #. Default: "URL for videoconferencing link"
 #: ./opengever/workspace/workspace.py
 msgid "help_videoconferencing_url"
-msgstr "URL for videoconferencing link"
+msgstr "URL to launch a video conference for this workspace"
 
 #. German translation: Einladung
 #. Default: "Invitation"
@@ -157,7 +157,7 @@ msgstr ""
 "\n"
 "You were invited by ${user} to the workspace \"${title}\" at ${platform}.\n"
 "\n"
-"Please click the following link if you want to accept the invitation:\n"
+"Please click the following link to accept the invitation:\n"
 "${accept_url}"
 
 #. German translation: Erledigt
@@ -255,31 +255,31 @@ msgstr "Title"
 #. Default: "ToDo"
 #: ./opengever/workspace/browser/tabbed.py
 msgid "label_todo"
-msgstr "ToDo"
+msgstr "To-do"
 
 #. German translation: ToDo zugewiesen
 #. Default: "ToDo assigned"
 #: ./opengever/workspace/activities.py
 msgid "label_todo_assigned_activity"
-msgstr "ToDo assigned"
+msgstr "To-do assigned"
 
 #. German translation: ToDo erledigt
 #. Default: "ToDo closed"
 #: ./opengever/workspace/activities.py
 msgid "label_todo_closed_activity"
-msgstr "ToDo closed"
+msgstr "To-do closed"
 
 #. German translation: ToDo kommentiert
 #. Default: "ToDo commented"
 #: ./opengever/workspace/activities.py
 msgid "label_todo_commented_activity"
-msgstr "ToDo commented"
+msgstr "To-do commented"
 
 #. German translation: ToDo wieder eröffnet
 #. Default: "ToDo reopened"
 #: ./opengever/workspace/activities.py
 msgid "label_todo_reopened_activity"
-msgstr "ToDo reopened"
+msgstr "To-do reopened"
 
 #. German translation: Papierkorb
 #. Default: "Trash"
@@ -291,13 +291,13 @@ msgstr "Trash"
 #. Default: "Video Call Link"
 #: ./opengever/workspace/workspace_meeting.py
 msgid "label_video_call_link"
-msgstr "Video Call Link"
+msgstr "Video call link"
 
 #. German translation: Videokonferenz URL
 #. Default: "Videoconferencing URL"
 #: ./opengever/workspace/workspace.py
 msgid "label_videoconferencing_url"
-msgstr "Videoconferencing URL"
+msgstr "Video conferencing URL"
 
 #. German translation: Teamräume
 #. Default: "Workspaces"
@@ -315,7 +315,7 @@ msgstr "Comment"
 #. Default: "Notification to \"${title}\""
 #: ./opengever/workspace/content_sharing_mailer.py
 msgid "share_mail_subject"
-msgstr "Notification to \"${title}\""
+msgstr "Notification for \"${title}\""
 
 #. German translation: ${user} hat einen Hinweis an Sie versendet:
 #. Default: "${user} has sent you a notification:"
@@ -333,7 +333,7 @@ msgstr "Assigned to ${responsible} by ${user}"
 #. Default: "Manage participation of ${workspace}"
 #: ./opengever/workspace/participation/browser/templates/participants-view.pt
 msgid "title_manage_participation"
-msgstr "Manage participation of ${workspace}"
+msgstr "Manage participants of ${workspace}"
 
 #. German translation: Benutzer
 #. Default: "User"


### PR DESCRIPTION
Clean up English `og.workspace` translations.

For overall comments on the process, please see PR #6806 

Jira: https://4teamwork.atlassian.net/browse/CA-883