### PR TITLE
Clean up English og.trash translations.

### DIFF
--- a/opengever/locking/tests/test_locks.py
+++ b/opengever/locking/tests/test_locks.py
@@ -245,7 +245,7 @@ class TestDocumentsLockedWithMeetingSubmittedLock(IntegrationTestCase, MoveItems
         browser.open(self.dossier, view="trashed", data=data)
 
         self.assertEqual(
-            [u'could not trash the object {}, it is locked.'.format(
+            [u"Could not move document Vertr\xe4gsentwurf to the trash: it's currently locked.".format(
                 self.document.title)],
             error_messages())
         self.assertFalse(ITrashed.providedBy(self.document))

--- a/opengever/private/tests/test_dossier.py
+++ b/opengever/private/tests/test_dossier.py
@@ -167,7 +167,7 @@ class TestPrivateDossierWorkflow(IntegrationTestCase):
                 '_authenticator': createToken()}
 
         browser.open(self.private_dossier, view="trashed", data=data)
-        self.assertEquals([u'the object Testdokum\xe4nt trashed'],
+        self.assertEquals([u'Object Testdokum\xe4nt has been moved to the trash.'],
                           info_messages())
 
     @browsing

--- a/opengever/trash/locales/en/LC_MESSAGES/opengever.trash.po
+++ b/opengever/trash/locales/en/LC_MESSAGES/opengever.trash.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: opengever.trash 1.0\n"
-"POT-Creation-Date: 2021-01-08 11:40+0000\n"
+"POT-Creation-Date: 2021-01-18 09:44+0000\n"
 "PO-Revision-Date: 2017-05-03 09:38+0200\n"
 "Last-Translator: Julian Infanger <julian.infangner.@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -18,12 +18,12 @@ msgstr ""
 #. German translation: Das Objekt ${title} darf nicht in den Papierkorb verschoben werden.
 #: ./opengever/trash/browser/trash.py
 msgid "Trashing ${title} is forbidden"
-msgstr "Trashing ${title} is forbidden"
+msgstr "Moving object ${title} to trash is not allowed."
 
 #. German translation: Das Objekt ${title} darf nicht aus dem Papierkorb reaktiviert werden.
 #: ./opengever/trash/browser/trash.py
 msgid "Untrashing ${title} is forbidden"
-msgstr "Untrashing ${title} is forbidden"
+msgstr "Restoring object ${title} from trash is not allowed."
 
 #. German translation: Sie haben keine Objekte ausgewählt
 #: ./opengever/trash/browser/trash.py
@@ -33,22 +33,22 @@ msgstr "You have not selected any items."
 #. German translation: Das Objekt ${obj} wurde bereits in den Papierkorb verschoben
 #: ./opengever/trash/browser/trash.py
 msgid "could not trash the object ${obj}, it is already trashed"
-msgstr "could not trash the object ${obj}, it is already trashed"
+msgstr "Object ${obj} is already in the trash."
 
 #. German translation: Das Objekt ${obj} konnte nicht in den Papierkorb verschoben werden, es ist ein Protokollauszug, welcher als Antwort im Ursprungsdossier abgelegt wurde.
 #: ./opengever/trash/browser/trash.py
 msgid "could not trash the object ${obj}, it is an excerpt that has been returned to the proposal."
-msgstr "could not trash the object ${obj}, it is an excerpt that has been returned to the proposal."
+msgstr "Could not move object ${obj} to the trash: it's a protocol excerpt that was returned to the proposal in the originating dossier."
 
 #. German translation: Das Objekt ${obj} konnte nicht in den Papierkorb verschoben werden, es ist ausgecheckt.
 #: ./opengever/trash/browser/trash.py
 msgid "could not trash the object ${obj}, it is checked out."
-msgstr "could not trash the object ${obj}, it is checked out."
+msgstr "Could not move document ${obj} to the trash: it's currently checked out."
 
 #. German translation: Das Objekt ${obj} konnte nicht in den Papierkorb verschoben werden, es ist gesperrt.
 #: ./opengever/trash/browser/trash.py
 msgid "could not trash the object ${obj}, it is locked."
-msgstr "could not trash the object ${obj}, it is locked."
+msgstr "Could not move document ${obj} to the trash: it's currently locked."
 
 #. German translation: Sie haben keine Objekte ausgewählt.
 #. Default: "You have not selected any items."
@@ -102,13 +102,13 @@ msgstr "The selected documents can't be removed, see error messages below."
 #. Default: "The document is referred by ${links}."
 #: ./opengever/trash/remover.py
 msgid "msg_document_has_backreferences"
-msgstr "The document is referred by ${links}."
+msgstr "The document is referred to by ${links}."
 
 #. German translation: Das Dokument referenziert andere Dokumente.
 #. Default: "The document contains relations."
 #: ./opengever/trash/remover.py
 msgid "msg_document_has_relations"
-msgstr "The document contains relations."
+msgstr "The document has outgoing references to other documents."
 
 #. German translation: Das Dokument ist noch ausgecheckt.
 #. Default: "The document is still checked out."
@@ -120,20 +120,20 @@ msgstr "The document is still checked out."
 #. Default: "The document is not trashed."
 #: ./opengever/trash/remover.py
 msgid "msg_is_not_trashed"
-msgstr "The document is not trashed."
+msgstr "The document has not been moved to the trash yet."
 
 #. German translation: Das Dokument ist schon gelöscht
 #. Default: "The document is already removed."
 #: ./opengever/trash/remover.py
 msgid "msg_is_removed"
-msgstr "The document is already removed."
+msgstr "The document has already been removed."
 
 #. German translation: Löschen
 #: ./opengever/trash/upgrades/profiles/4100/actions.xml
 msgid "remove"
-msgstr "remove"
+msgstr "Remove"
 
 #. German translation: Das Objekt ${obj} wurde in den Papierkorb verschoben.
 #: ./opengever/trash/browser/trash.py
 msgid "the object ${obj} trashed"
-msgstr "the object ${obj} trashed"
+msgstr "Object ${obj} has been moved to the trash."

--- a/opengever/trash/tests/test_remove.py
+++ b/opengever/trash/tests/test_remove.py
@@ -74,7 +74,7 @@ class TestRemoveConfirmationView(IntegrationTestCase):
         browser.open(self.dossier, self.make_path_param(self.empty_document), view='remove_confirmation')
 
         error_div = browser.css('div.documents div.error').first
-        self.assertEqual('The document is not trashed.', error_div.text)
+        self.assertEqual('The document has not been moved to the trash yet.', error_div.text)
         self.assertEqual([u'L\xe4\xe4r'], error_div.parent().css('a').text)
 
     @browsing

--- a/opengever/trash/tests/test_remove_conditions.py
+++ b/opengever/trash/tests/test_remove_conditions.py
@@ -25,7 +25,7 @@ class TestRemoveConditionsChecker(IntegrationTestCase):
 
         self.assertFalse(checker.removal_allowed())
         self.assert_error_messages(
-            [u'The document contains relations.'], checker.error_msg)
+            [u'The document has outgoing references to other documents.'], checker.error_msg)
 
     @browsing
     def test_document_must_not_have_backreferences(self, browser):
@@ -40,7 +40,7 @@ class TestRemoveConditionsChecker(IntegrationTestCase):
 
         self.assertFalse(checker.removal_allowed())
         self.assert_error_messages(
-            [u'The document is referred by <a href={}>Document: {}</a>.'.format(
+            [u'The document is referred to by <a href={}>Document: {}</a>.'.format(
                 self.taskdocument.absolute_url(), self.taskdocument.title)],
             checker.error_msg)
 
@@ -69,7 +69,7 @@ class TestRemoveConditionsChecker(IntegrationTestCase):
         checker = RemoveConditionsChecker(self.empty_document)
         self.assertFalse(checker.removal_allowed())
         self.assert_error_messages(
-            [u'The document is not trashed.'], checker.error_msg)
+            [u'The document has not been moved to the trash yet.'], checker.error_msg)
 
     def test_document_must_not_already_be_removed(self):
         self.login(self.manager)
@@ -80,7 +80,7 @@ class TestRemoveConditionsChecker(IntegrationTestCase):
         checker = RemoveConditionsChecker(self.empty_document)
         self.assertFalse(checker.removal_allowed())
         self.assert_error_messages(
-            [u'The document is already removed.'],
+            [u'The document has already been removed.'],
             checker.error_msg)
 
     def test_removal_allowed(self):

--- a/opengever/trash/tests/test_trash.py
+++ b/opengever/trash/tests/test_trash.py
@@ -37,7 +37,7 @@ class TestTrash(IntegrationTestCase):
         browser.open(self.dossier, view="trashed", data=data)
 
         self.assertEquals(
-            [u'the object {} trashed'.format(self.subdocument.title)],
+            [u'Object {} has been moved to the trash.'.format(self.subdocument.title)],
             info_messages())
         self.assertEquals(
             '{}#documents'.format(self.dossier.absolute_url()), browser.url)
@@ -212,7 +212,7 @@ class TestTrash(IntegrationTestCase):
         browser.open(self.dossier, view="trashed", data=data)
 
         self.assertEquals(
-            [u'could not trash the object {}, it is already trashed'.format(
+            [u'Object {} is already in the trash.'.format(
                 self.subdocument.title)],
             error_messages())
         self.assertEquals(
@@ -228,7 +228,7 @@ class TestTrash(IntegrationTestCase):
         browser.open(self.dossier, view="trashed", data=data)
 
         self.assertEquals(
-            [u'could not trash the object {}, it is checked out.'.format(
+            [u"Could not move document {} to the trash: it's currently checked out.".format(
                 self.subdocument.title)],
             error_messages())
         self.assertEquals(
@@ -291,7 +291,7 @@ class TestUntrash(IntegrationTestCase):
         browser.open(self.dossier, view="untrashed", data=data)
 
         self.assertEquals(
-            [u'Untrashing {} is forbidden'.format(self.subdocument.title)],
+            [u'Restoring object {} from trash is not allowed.'.format(self.subdocument.title)],
             error_messages())
 
     @browsing
@@ -309,7 +309,7 @@ class TestUntrash(IntegrationTestCase):
 
         self.assertTrue(ITrashed.providedBy(self.empty_document))
         self.assertEquals(
-            [u'Untrashing {} is forbidden'.format(self.empty_document.title)],
+            [u'Restoring object {} from trash is not allowed.'.format(self.empty_document.title)],
             error_messages())
 
         # When restored, document can be untrashed


### PR DESCRIPTION
Clean up English `og.trash` translations.

For overall comments on the process, please see PR #6806 

Jira: https://4teamwork.atlassian.net/browse/CA-883