### PR TITLE
Clean up English og.workspaceclient translations.

### DIFF
--- a/opengever/api/tests/test_linked_workspaces.py
+++ b/opengever/api/tests/test_linked_workspaces.py
@@ -1098,7 +1098,7 @@ class TestCopyDocumentFromWorkspacePost(FunctionalWorkspaceClientTestCase):
 
             self.assertEqual(new_content, new_version.file.data)
             self.assertEqual(initial_filename, new_version.file.filename)
-            self.assertEqual(u'Document retrieved from teamraum', new_version_md.comment)
+            self.assertEqual(u'Document copied back from teamraum', new_version_md.comment)
 
             self.assertEqual(
                 RETRIEVAL_MODE_VERSION,

--- a/opengever/workspaceclient/locales/en/LC_MESSAGES/opengever.workspaceclient.po
+++ b/opengever/workspaceclient/locales/en/LC_MESSAGES/opengever.workspaceclient.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-01-08 11:40+0000\n"
+"POT-Creation-Date: 2021-01-18 11:06+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,7 +18,7 @@ msgstr ""
 #. Default: "Document retrieved from teamraum"
 #: ./opengever/workspaceclient/linked_workspaces.py
 msgid "document_retrieved_from_teamraum_change_note"
-msgstr "Document retrieved from teamraum"
+msgstr "Document copied back from teamraum"
 
 #. German translation: Dokument ${doc_title} wurde aus teamraum ${workspace_title} kopiert und neu erstellt
 #. Default: "Document ${doc_title} copied from workspace ${workspace_title} as a new document."
@@ -42,7 +42,7 @@ msgstr "Document unlocked - created new version with document from teamraum."
 #. Default: "Document ${doc_title} retrieved from workspace."
 #: ./opengever/workspaceclient/linked_workspaces.py
 msgid "label_document_retrieved_from_workspace"
-msgstr "Document ${doc_title} retrieved from workspace."
+msgstr "Document ${doc_title} copied back from workspace."
 
 #. German translation: Initialversion - Dokument aus teamraum ${workspace_title} kopiert.
 #. Default: "Initial version - Document copied from teamraum ${workspace_title}."

--- a/opengever/workspaceclient/tests/test_linked_workspaces.py
+++ b/opengever/workspaceclient/tests/test_linked_workspaces.py
@@ -567,7 +567,7 @@ class TestLinkedWorkspaces(FunctionalWorkspaceClientTestCase):
 
             self.assertEqual(new_content, new_version.file.data)
             self.assertEqual(initial_filename, new_version.file.filename)
-            self.assertEqual(u'Document retrieved from teamraum', new_version_md.comment)
+            self.assertEqual(u'Document copied back from teamraum', new_version_md.comment)
 
             document_journal = self.get_journal_entries(gever_doc)
             self.assertEqual(2, len(document_journal))
@@ -581,7 +581,7 @@ class TestLinkedWorkspaces(FunctionalWorkspaceClientTestCase):
             self.assert_journal_entry(
                 self.dossier,
                 action_type='Document retrieved from teamraum',
-                title=u'Document Testdokum\xe4nt retrieved from workspace.',
+                title=u'Document Testdokum\xe4nt copied back from workspace.',
             )
 
     def test_copy_document_from_workspace_as_new_version_unlocks_document(self):


### PR DESCRIPTION
Clean up English `og.workspaceclient` translations.

For overall comments on the process, please see PR #6806 

Jira: https://4teamwork.atlassian.net/browse/CA-883