### PR TITLE
Clean up English og.repository translations.

### DIFF
--- a/opengever/repository/locales/en/LC_MESSAGES/opengever.repository.po
+++ b/opengever/repository/locales/en/LC_MESSAGES/opengever.repository.po
@@ -3,7 +3,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2021-01-08 11:40+0000\n"
+"POT-Creation-Date: 2021-01-18 14:10+0000\n"
 "PO-Revision-Date: 2014-11-25 11:31+0100\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: Jonas Baumann <j.baumann@4teamwork.ch>\n"
@@ -20,7 +20,7 @@ msgstr ""
 #. German translation: Rapport konnte nicht generiert werden.
 #: ./opengever/repository/browser/excel_export.py
 msgid "Could not generate the report."
-msgstr "Could not generate the report."
+msgstr "Failed to generate report."
 
 #. German translation: Wird verwendet
 #: ./opengever/repository/browser/templates/referenceprefixmanager.pt
@@ -30,36 +30,36 @@ msgstr "In use"
 #. German translation: Aktenzeichen Präfix Manager
 #: ./opengever/repository/upgrades/profiles/2601/actions.xml
 msgid "Prefix Manager"
-msgstr "Prefix Manager"
+msgstr "Reference number manager"
 
 #. German translation: Freigabe von ungebrauchten Aktenzeichen Prefixen.
 #: ./opengever/repository/upgrades/profiles/2601/actions.xml
 msgid "Unlock unused repository prefixes."
-msgstr "Unlock unused repository prefixes."
+msgstr "Unlock unused repository numbers."
 
 #. German translation: Hinzufügen von Geschäftsdossiers erlauben
 #. Default: "Allow add businesscase dossier"
 #: ./opengever/repository/repositoryfolder.py
 msgid "allow_add_businesscase_dossier"
-msgstr "Allow add businesscase dossier"
+msgstr "Allow creation of regular business case dossiers"
 
 #. German translation: Wählen Sie, ob es in dieser Ordnungsposition erlaubt ist, Geschäftsdossiers hinzuzufügen. Ist diese Option deaktiviert, kann der Benutzer nur Dossiers aus einer Vorlage oder Spezialdossiers erstellen.
 #. Default: "Choose if the user is allowed to add businesscase dossiers or only dossiers from a  dossiertemplate."
 #: ./opengever/repository/repositoryfolder.py
 msgid "description_allow_add_businesscase_dossier"
-msgstr "Choose if the user is allowed to add businesscase dossiers or only dossiers from a  dossiertemplate."
+msgstr "Choose whether the user is allowed to add regular business case dossiers or only dossiers created from a dossier template."
 
 #. German translation: Keine untergeordnete Ordnungspositionen verfügbar.
 #. Default: "No nested repositorys available."
 #: ./opengever/repository/browser/templates/referenceprefixmanager.pt
 msgid "empty_repository"
-msgstr "No nested repositorys available."
+msgstr "No nested repository folders available."
 
 #. German translation: Eine Ordnungsposition mit diesem Aktenzeichen existiert bereits auf gleicher Stufe.
 #. Default: "A Sibling with the same reference number is existing."
 #: ./opengever/repository/behaviors/referenceprefix.py
 msgid "error_sibling_reference_number_existing"
-msgstr "A Sibling with the same reference number is existing."
+msgstr "A repository folder with the same reference number already exists on the same level."
 
 #. German translation: Allgemein
 #. Default: "Common"
@@ -97,7 +97,7 @@ msgstr "Blocked inheritance"
 #. Default: "Protected Objects"
 #: ./opengever/repository/browser/tabbed.py
 msgid "label_blocked_local_roles"
-msgstr "Protected Objects"
+msgstr "Protected objects"
 
 #. German translation: Löschen
 #. Default: "Delete"
@@ -107,9 +107,10 @@ msgstr "Delete"
 
 #. German translation: Ordnungsposition löschen
 #. Default: "Delete repository"
+#. MARKER: double check
 #: ./opengever/repository/browser/templates/deletion.pt
 msgid "label_delete_repository"
-msgstr "Delete repository"
+msgstr "Delete repository folder"
 
 #. German translation: Beschreibung
 #. Default: "Description"
@@ -217,10 +218,11 @@ msgstr "Proposals"
 #. Default: "Reference Prefix"
 #: ./opengever/repository/behaviors/referenceprefix.py
 msgid "label_reference_number_prefix"
-msgstr "Reference Prefix"
+msgstr "Reference number component"
 
 #. German translation: Leistung
 #. Default: "Referenced activity"
+#. MARKER: double check
 #: ./opengever/repository/repositoryfolder.py
 msgid "label_referenced_activity"
 msgstr "Referenced activity"
@@ -251,9 +253,10 @@ msgstr "Repositoryfolder title (French)"
 
 #. German translation: Die Ordnungsposition wurde erfolgreich gelöscht.
 #. Default: "The repository have been successfully deleted."
+#. MARKER: double check
 #: ./opengever/repository/browser/deletion.py
 msgid "label_successfully_deleted"
-msgstr "The repository have been successfully deleted."
+msgstr "The repository folder has been deleted successfully."
 
 #. German translation: Aufgaben
 #. Default: "Tasks"
@@ -301,15 +304,16 @@ msgstr "State"
 
 #. German translation: Möchten Sie die aktuelle Ordnungsposition wirklich löschen?
 #. Default: "Do you really want to delete the current repository?"
+#. MARKER: double check
 #: ./opengever/repository/browser/templates/deletion.pt
 msgid "msg_delete_confirmation"
-msgstr "Do you really want to delete the current repository?"
+msgstr "Do you really want to delete the current repository folder?"
 
 #. German translation: Sie fügen eine Ordnungsposition einem Blattknoten hinzu, der bereits Dossiers enthält. Dies ist nur vorübergehend erlaubt und darin enthaltene Dossiers müssen anschliessend wieder in einen Blattknoten verschoben werden.
 #. Default: "You are adding a repositoryfolder to a leafnode which already contains dossiers. This is only temporarily allowed and all dossiers must be moved into a new leafnode afterwards."
 #: ./opengever/repository/browser/repositoryfolder_forms.py
 msgid "msg_leafnode_warning"
-msgstr "You are adding a repositoryfolder to a leafnode which already contains dossiers. This is only temporarily allowed and all dossiers must be moved into a new leafnode afterwards."
+msgstr "You are adding a repository folder to a leaf node which already contains dossiers. This is only allowed temporarily and all dossiers must be moved into a new leaf node afterwards."
 
 #. German translation: Name
 #. Default: "Name"
@@ -327,43 +331,43 @@ msgstr "Position"
 #. Default: "Reference Prefix Manager"
 #: ./opengever/repository/browser/templates/referenceprefixmanager.pt
 msgid "prefman_title"
-msgstr "Reference Prefix Manager"
+msgstr "Reference number manager"
 
 #. German translation: Federführendes Amt
 #. Default: "Responsible organisation unit"
 #: ./opengever/repository/behaviors/responsibleorg.py
 msgid "responsible_org_unit"
-msgstr "Responsible organisation unit"
+msgstr "Responsible organization / department"
 
 #. German translation: Das Aktenzeichen Präfix wird noch verwendet.
 #. Default: "The reference you try to unlock is still in use."
 #: ./opengever/repository/browser/referenceprefix_manager.py
 msgid "statmsg_prefix_unlock_failure"
-msgstr "The reference you try to unlock is still in use."
+msgstr "The reference number you're trying to unlock is still in use."
 
 #. German translation: Aktenzeichen Präfix wurde freigegeben.
 #. Default: "Reference prefix has been unlocked."
 #: ./opengever/repository/browser/referenceprefix_manager.py
 msgid "statmsg_prefix_unlocked"
-msgstr "Reference prefix has been unlocked."
+msgstr "Reference number has been unlocked."
 
 #. German translation: Dokumente
 #. Default: "Documents:"
 #: ./opengever/repository/browser/templates/repositoryrootoverview.pt
 msgid "th_documents"
-msgstr "Documents:"
+msgstr "Documents"
 
 #. German translation: Dossiers
 #. Default: "Dossiers:"
 #: ./opengever/repository/browser/templates/repositoryrootoverview.pt
 msgid "th_dossiers"
-msgstr "Dossiers:"
+msgstr "Dossiers"
 
 #. German translation: Aufgaben
 #. Default: "Tasks:"
 #: ./opengever/repository/browser/templates/repositoryrootoverview.pt
 msgid "th_task"
-msgstr "Tasks:"
+msgstr "Tasks"
 
 #. German translation: Freigeben
 #. Default: "Unlock"

--- a/opengever/repository/tests/test_deletion.py
+++ b/opengever/repository/tests/test_deletion.py
@@ -179,7 +179,7 @@ class TestRepositoryDeleter(IntegrationTestCase):
         browser.open(self.empty_repofolder, view='delete_repository')
         browser.click_on('Delete')
         statusmessages.assert_message(
-            'The repository have been successfully deleted.')
+            'The repository folder has been deleted successfully.')
         self.assertEquals(self.repository_root, browser.context)
 
     @browsing

--- a/opengever/repository/tests/test_reference_behavior.py
+++ b/opengever/repository/tests/test_reference_behavior.py
@@ -23,7 +23,7 @@ class TestReferenceBehavior(IntegrationTestCase):
         self.login(self.administrator, browser)
         browser.open(self.branch_repofolder)
         factoriesmenu.add('Repository Folder')
-        self.assertEquals('2', browser.find('Reference Prefix').value)
+        self.assertEquals('2', browser.find('Reference number component').value)
 
     @browsing
     def test_using_already_used_prefix_is_not_possible(self, browser):
@@ -32,12 +32,12 @@ class TestReferenceBehavior(IntegrationTestCase):
         factoriesmenu.add('Repository Folder')
         browser.fill({
             'Title': 'Test repository',
-            'Reference Prefix': '1',
+            'Reference number component': '1',
         }).save()
 
         self.assertEquals(
-            {'Reference Prefix': [
-                'A Sibling with the same reference number is existing.']},
+            {'Reference number component': [
+                'A repository folder with the same reference number already exists on the same level.']},
             z3cform.erroneous_fields(browser.forms['form']))
 
     @browsing
@@ -51,7 +51,7 @@ class TestReferenceBehavior(IntegrationTestCase):
         factoriesmenu.add('Repository Folder')
         browser.fill({
             'Title': u'Test repository',
-            'Reference Prefix': '26',
+            'Reference number component': '26',
         }).save()
         statusmessages.assert_no_error_messages()
 
@@ -65,7 +65,7 @@ class TestReferenceBehavior(IntegrationTestCase):
         factoriesmenu.add('Repository Folder')
         browser.fill({
             'Title': u'Test repository',
-            'Reference Prefix': 'a1x10',
+            'Reference number component': 'a1x10',
         }).save()
         statusmessages.assert_no_error_messages()
 

--- a/opengever/repository/tests/test_reference_prefix_manager.py
+++ b/opengever/repository/tests/test_reference_prefix_manager.py
@@ -30,7 +30,7 @@ class TestReferencePrefixManager(IntegrationTestCase):
 
         browser.click_on('Unlock')
         statusmessages.assert_no_error_messages()
-        statusmessages.assert_message('Reference prefix has been unlocked.')
+        statusmessages.assert_message('Reference number has been unlocked.')
         self.assertEquals(
             [['3', u'Vertr\xe4ge und Vereinbarungen', 'In use']],
             browser.css('#reference_prefix_manager_table').first.lists())
@@ -61,7 +61,7 @@ class TestReferencePrefixManager(IntegrationTestCase):
         browser.open(self.leaf_repofolder, view='referenceprefix_manager')
 
         self.assertEquals(
-            'No nested repositorys available.',
+            'No nested repository folders available.',
             browser.css('#reference_prefix_manager_table tbody').first.text)
 
     @browsing
@@ -89,4 +89,4 @@ class TestReferencePrefixManager(IntegrationTestCase):
         browser.open(self.branch_repofolder,
                      view='referenceprefix_manager?prefix=3')
         statusmessages.assert_message(
-            'The reference you try to unlock is still in use.')
+            "The reference number you're trying to unlock is still in use.")

--- a/opengever/repository/tests/test_repositoryfolder.py
+++ b/opengever/repository/tests/test_repositoryfolder.py
@@ -74,10 +74,10 @@ class TestRepositoryFolder(IntegrationTestCase):
         """
         self.login(self.administrator, browser)
 
-        warning = u'You are adding a repositoryfolder to a leafnode ' \
+        warning = u'You are adding a repository folder to a leaf node ' \
                   u'which already contains dossiers. This is only ' \
-                  u'temporarily allowed and all dossiers must be moved into ' \
-                  u'a new leafnode afterwards.'
+                  u'allowed temporarily and all dossiers must be moved into ' \
+                  u'a new leaf node afterwards.'
 
         self.assertTrue(any(filter(IDossierMarker.providedBy,
                                    self.leaf_repofolder.objectValues())),

--- a/opengever/repository/tests/test_repositoryfolder_tabs.py
+++ b/opengever/repository/tests/test_repositoryfolder_tabs.py
@@ -32,7 +32,7 @@ class TestRepositoryFolderTabs(IntegrationTestCase):
             'Documents',
             'Tasks',
             'Info',
-            'Protected Objects',
+            'Protected objects',
             ]
 
         self.assertEquals(expected_tabs, tabbedview.tabs().text)

--- a/opengever/repository/tests/test_subscribers.py
+++ b/opengever/repository/tests/test_subscribers.py
@@ -13,7 +13,7 @@ class TestReferencePrefixUpdating(IntegrationTestCase):
         self.assertEquals('Client1 1.1', obj2brain(self.leaf_repofolder).reference)
 
         browser.open(self.leaf_repofolder, view='edit')
-        browser.fill({'Reference Prefix': u'7'}).save()
+        browser.fill({'Reference number component': u'7'}).save()
         self.assertEquals('Client1 1.7', obj2brain(self.leaf_repofolder).reference)
 
     @browsing
@@ -26,5 +26,5 @@ class TestReferencePrefixUpdating(IntegrationTestCase):
         self.assertEquals('Client1 1.1 / 1', obj2brain(self.dossier).reference)
 
         browser.open(self.leaf_repofolder, view='edit')
-        browser.fill({'Reference Prefix': u'7'}).save()
+        browser.fill({'Reference number component': u'7'}).save()
         self.assertEquals('Client1 1.7 / 1', obj2brain(self.dossier).reference)


### PR DESCRIPTION
Clean up English `og.repository` translations.

I left some translations untouched because they're used in Excel export/import.

For overall comments on the process, please see PR #6806 

Jira: https://4teamwork.atlassian.net/browse/CA-883