### PR TITLE
Fix loading next batch in gallery view

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -18,6 +18,7 @@ Changelog
 - Add 'en-us' as supported language in example content. [lgraf]
 - Implement API to create, list and delete property sheet schema definitions. [deiferni]
 - Implement storage for property sheet schemas in plone-site annotations. [deiferni]
+- Fix loading next batch in gallery view. [buchi]
 
 
 2021.1.0 (2021-01-06)

--- a/opengever/tabbedview/browser/bumblebee_gallery.py
+++ b/opengever/tabbedview/browser/bumblebee_gallery.py
@@ -56,6 +56,12 @@ class BumblebeeGalleryMixin(object):
         if isinstance(query, dict) and 'sort_on' not in query:
             query['sort_on'] = 'modified'
             query['sort_order'] = 'descending'
+
+        doc_pointer = int(self.request.get('documentPointer', 0))
+        if doc_pointer > 0:
+            page_number = doc_pointer / self.table_source.config.pagesize
+            self.table_source.config.batching_current_page = page_number + 1
+
         return self.table_source.search_results(query)
 
     def fetch(self):

--- a/opengever/tabbedview/tests/test_bumblebee_gallery.py
+++ b/opengever/tabbedview/tests/test_bumblebee_gallery.py
@@ -236,6 +236,19 @@ class TestBumblebeeGalleryMixinFetch(SolrIntegrationTestCase):
 
         self.assertEqual('', view.fetch())
 
+    @browsing
+    def test_fetch_next_batch(self, browser):
+        self.login(self.regular_user)
+
+        self.request.set('documentPointer', 10)
+
+        view = getMultiAdapter(
+            (self.dossier, self.request), name="tabbedview_view-documents-gallery")
+        view.table_source.config.pagesize = 10
+
+        browser.open_html(view.fetch())
+        self.assertEqual(2, len(browser.css('.imageContainer')))
+
 
 class TestBumblebeeGalleryViewChooserWithoutFeature(SolrIntegrationTestCase):
 


### PR DESCRIPTION
We need to configure the current page in the table source as Solr only fetches the requested batch. Before with portal catalog we were able to access all results.

JIRA: https://4teamwork.atlassian.net/browse/CA-1160

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

