### PR TITLE
Fix: do no longer expose facet values for zero-count values.

### DIFF
--- a/opengever/api/solr_query_service.py
+++ b/opengever/api/solr_query_service.py
@@ -385,6 +385,11 @@ class SolrQueryBaseService(Service):
         sort = self.extract_sort(params, query)
         field_list = self.extract_field_list(params)
         additional_params = self.prepare_additional_params(params)
+
+        # Using mincount prevent facetting to expose all users if using i.e.
+        # the creator or responsible facet - CROWN
+        additional_params['facet.mincount'] = 1
+
         return query, filters, start, rows, sort, field_list, additional_params
 
     def extract_start(self, params):


### PR DESCRIPTION
This is required to no longer expose all users by facets like creator or responsible.

## Before:
<img width="1086" alt="Bildschirmfoto 2021-01-19 um 09 55 26" src="https://user-images.githubusercontent.com/557005/105010878-8d4b6c00-5a3c-11eb-8450-e3bd8df2d592.png">


## After:
<img width="1090" alt="Bildschirmfoto 2021-01-19 um 09 55 52" src="https://user-images.githubusercontent.com/557005/105010885-8fadc600-5a3c-11eb-8c1d-bc93593ffb42.png">
