### PR TITLE
Add is_task_addable_in_main_task and is_task_addable_before attributes to @tasktree endpoint, sort on getObjPositionInParent

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,8 @@ Changelog
 - Respect active languages languages in WorkspaceRoot and PrivateRoot forms. [njohner]
 - Fix deactivating committees with canceled meetings. [deiferni]
 - Include custom properties in JSON schema for documents and mails in the `@schema` endpoint. [deiferni]
+- Index getObjPositionInParent for sequential tasks and sort them on getObjPositionInParent in @tasktree endpoint. [tinagerber]
+- Add is_task_addable_in_main_task and is_task_addable_before attributes to @tasktree endpoint. [tinagerber]
 
 
 2021.2.0 (2021-01-20)

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -10,13 +10,14 @@ API Changelog
 Breaking Changes
 ^^^^^^^^^^^^^^^^
 
-- No changes yet
+- ``@tasktree``: Sequential tasks are now sorted on ``getObjPositionInParent`` (see :ref:`docs <tasktree>`).
 
 
 Other Changes
 ^^^^^^^^^^^^^
 
 - The field ``custom_properties`` is now included in the ``@schema`` endpoint for Documents and Mails (see :ref:`content-types`).
+- ``@tasktree``: Attributes ``is_task_addable_in_main_task`` and ``is_task_addable_before`` added (see :ref:`docs <tasktree>`).
 
 
 2021.2.0 (2021-01-20)

--- a/docs/public/dev-manual/api/tasks.rst
+++ b/docs/public/dev-manual/api/tasks.rst
@@ -484,6 +484,8 @@ Angaben zum übergeordneten Dossier einer Aufgabe ist in der GET Repräsentation
       }
 
 
+.. _tasktree:
+
 Aufgabenhierarchie
 -------------------
 Zu einer Aufgabe kann die Aufgabenhierarchie bestehend aus Hauptaufgabe und allen Unteraufgaben abgefragt werden.

--- a/docs/public/dev-manual/api/tasks.rst
+++ b/docs/public/dev-manual/api/tasks.rst
@@ -487,7 +487,7 @@ Angaben zum übergeordneten Dossier einer Aufgabe ist in der GET Repräsentation
 Aufgabenhierarchie
 -------------------
 Zu einer Aufgabe kann die Aufgabenhierarchie bestehend aus Hauptaufgabe und allen Unteraufgaben abgefragt werden.
-Dazu steht ein spezifischer Endpoint `@tasktree` zur Verfügung.
+Dazu steht ein spezifischer Endpoint `@tasktree` zur Verfügung. Die Aufgaben werden nach Erstelldatum sortiert zurückgeliefert. Bei sequenziellen Aufgabenabläufen werden die Aufgaben nach Aufgabenfolge sortiert.
 
 **Beispiel-Request**:
 

--- a/docs/public/dev-manual/api/tasks.rst
+++ b/docs/public/dev-manual/api/tasks.rst
@@ -521,7 +521,8 @@ Dazu steht ein spezifischer Endpoint `@tasktree` zur Verfügung.
             "review_state": "task-state-in-progress",
             "title": "Eine Aufgabe"
           }
-        ]
+        ],
+        "is_task_addable_in_main_task": true
       }
 
 Die Aufgabenhierarchie kann auch direkt über den GET-Request eines Tasks mittels Expansion angefordert werden.

--- a/docs/public/dev-manual/api/tasks.rst
+++ b/docs/public/dev-manual/api/tasks.rst
@@ -532,6 +532,8 @@ Die Aufgabenhierarchie kann auch direkt über den GET-Request eines Tasks mittel
      GET http://example.org/ordnungssystem/fuehrung/dossier-1/task-1?expand=tasktree HTTP/1.1
      Accept: application/json
 
+Für sequenzielle Aufgabenabläufe steht zusätzlich das Feld ``is_task_addable_before`` zur Verfügung.
+
 
 Ursprüngliche Aufgabe
 ---------------------

--- a/opengever/api/tasktree.py
+++ b/opengever/api/tasktree.py
@@ -30,7 +30,15 @@ class TaskTree(object):
         if not expand:
             return result
         result['tasktree']['children'] = self.task_tree()
+        result['tasktree']['is_task_addable_in_main_task'] = self.is_task_addable_in_main_task()
         return result
+
+    def is_task_addable_in_main_task(self):
+        main_task = self.get_main_task()
+        for fti in main_task.allowedContentTypes():
+            if fti.id == main_task.portal_type:
+                return True
+        return False
 
     def get_main_task(self):
         main_task = self.context

--- a/opengever/api/tasktree.py
+++ b/opengever/api/tasktree.py
@@ -32,13 +32,16 @@ class TaskTree(object):
         result['tasktree']['children'] = self.task_tree()
         return result
 
-    def task_tree(self):
+    def get_main_task(self):
         main_task = self.context
         parent = aq_parent(main_task)
         while ITask.providedBy(parent):
             main_task = parent
             parent = aq_parent(main_task)
+        return main_task
 
+    def task_tree(self):
+        main_task = self.get_main_task()
         solr = getUtility(ISolrSearch)
         filters = make_filters(
             path={

--- a/opengever/api/tasktree.py
+++ b/opengever/api/tasktree.py
@@ -65,8 +65,9 @@ class TaskTree(object):
             object_provides=ITask.__identifier__,
         )
         fieldlist = ['Title', 'portal_type', 'path', 'review_state']
+        sort = 'getObjPositionInParent asc' if is_sequential else 'created asc'
         resp = solr.search(
-            filters=filters, start=0, rows=1000, sort='created asc',
+            filters=filters, start=0, rows=1000, sort=sort,
             fl=fieldlist)
 
         nodes = []

--- a/opengever/api/tests/test_tasktree.py
+++ b/opengever/api/tests/test_tasktree.py
@@ -42,6 +42,13 @@ class TestTaskTree(SolrIntegrationTestCase):
         self.assertFalse(browser.json['is_task_addable_in_main_task'])
 
     @browsing
+    def test_is_task_addable_before(self, browser):
+        self.login(self.regular_user, browser=browser)
+        browser.open(self.sequential_task, view="@tasktree", method="GET", headers=self.api_headers)
+        self.assertFalse(browser.json['children'][0]['children'][0]['is_task_addable_before'])
+        self.assertTrue(browser.json['children'][0]['children'][1]['is_task_addable_before'])
+
+    @browsing
     def test_get_task_with_tasktree_expansion(self, browser):
         self.login(self.regular_user, browser=browser)
         browser.open(

--- a/opengever/api/tests/test_tasktree.py
+++ b/opengever/api/tests/test_tasktree.py
@@ -49,6 +49,20 @@ class TestTaskTree(SolrIntegrationTestCase):
         self.assertTrue(browser.json['children'][0]['children'][1]['is_task_addable_before'])
 
     @browsing
+    def test_sequential_tasks_are_sorted_on_obj_position_in_parent(self, browser):
+        self.login(self.regular_user, browser=browser)
+        subtasks = [self.seq_subtask_3, self.seq_subtask_1, self.seq_subtask_2]
+        self.sequential_task.set_tasktemplate_order(subtasks)
+        self.commit_solr()
+
+        browser.open(self.sequential_task, view='@tasktree', method='GET', headers=self.api_headers)
+        self.assertEqual(
+            [self.seq_subtask_3.absolute_url(),
+             self.seq_subtask_1.absolute_url(),
+             self.seq_subtask_2.absolute_url()],
+            [item['@id'] for item in browser.json['children'][0]['children']])
+
+    @browsing
     def test_get_task_with_tasktree_expansion(self, browser):
         self.login(self.regular_user, browser=browser)
         browser.open(

--- a/opengever/api/tests/test_tasktree.py
+++ b/opengever/api/tests/test_tasktree.py
@@ -29,6 +29,17 @@ class TestTaskTree(SolrIntegrationTestCase):
                 },
             ]
         )
+        self.assertEqual(True, browser.json['is_task_addable_in_main_task'])
+
+    @browsing
+    def test_is_task_addable_in_main_task(self, browser):
+        self.login(self.regular_user, browser=browser)
+        browser.open(self.seq_subtask_2, view="@tasktree", method="GET", headers=self.api_headers)
+        self.assertTrue(browser.json['is_task_addable_in_main_task'])
+
+        self.set_workflow_state('task-state-resolved', self.sequential_task)
+        browser.open(self.seq_subtask_2, view="@tasktree", method="GET", headers=self.api_headers)
+        self.assertFalse(browser.json['is_task_addable_in_main_task'])
 
     @browsing
     def test_get_task_with_tasktree_expansion(self, browser):

--- a/opengever/base/tests/test_indexers.py
+++ b/opengever/base/tests/test_indexers.py
@@ -335,7 +335,7 @@ class TestGetObjPositionInParentIndexer(SolrIntegrationTestCase):
         ], browser.json["items"])
 
     @browsing
-    def test_getObjPositionInParent_if_sequential_subtask_is_added(self, browser):
+    def test_get_obj_position_in_parent_if_sequential_subtask_is_added(self, browser):
         self.login(self.administrator, browser=browser)
 
         url = '{}/@solrsearch?sort=getObjPositionInParent asc&fl=Title,UID,getObjPositionInParent'\

--- a/opengever/core/upgrades/20210119134941_index_get_obj_position_in_parent_solr_field_for_tasks/upgrade.py
+++ b/opengever/core/upgrades/20210119134941_index_get_obj_position_in_parent_solr_field_for_tasks/upgrade.py
@@ -1,0 +1,15 @@
+from ftw.upgrade import UpgradeStep
+from opengever.tasktemplates.interfaces import IFromSequentialTasktemplate
+
+
+class IndexGetObjPositionInParentSolrFieldForTasks(UpgradeStep):
+    """Index getObjPositionInParent solr field for tasks.
+    """
+
+    def __call__(self):
+        query = {'object_provides': [
+            IFromSequentialTasktemplate.__identifier__,
+        ]}
+
+        for obj in self.objects(query, 'Index getObjPositionInParent field in solr.'):
+            obj.reindexObject(idxs=['getObjPositionInParent'])

--- a/opengever/task/task.py
+++ b/opengever/task/task.py
@@ -623,6 +623,7 @@ class Task(Container, TaskReminderSupport):
         annotations[TASK_PROCESS_ORDER_KEY] = oguids
 
         for task in subtasks:
+            task.reindexObject(idxs=['UID', 'getObjPositionInParent'])
             task.sync()
 
     def get_tasktemplate_order(self):


### PR DESCRIPTION
In the new frontend, it should be possible to create new subtasks in a sequential process between the subtasks. Therefore, each subtask must know whether new subtasks can be added to the main task.

- To decide whether a subtask can be added at the end, the field `is_task_addable_in_main_task` is required.
- To decide whether a subtask can be added before another subtask, the field `is_task_addable_before` is required.
- Until now, the @tasktree endpoint returned the task sorted by creation date. Since this means that those created later do not appear in the correct position for sequential tasks, they are now sorted according to getObjPositionInParent for sequential tasks. This first had to be indexed.

Jira: https://4teamwork.atlassian.net/browse/NE-315

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


## Checklist (if applicable)

_Only applicable should be left and checked._

- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [x] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed