### PR TITLE
List informed principals in TaskAddedActivity description.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 ---------------------
 
 - Respect active languages languages in WorkspaceRoot and PrivateRoot forms. [njohner]
+- List informed principals in TaskAddedActivity description. [njohner]
 - Fix deactivating committees with canceled meetings. [deiferni]
 - Include custom properties in JSON schema for documents and mails in the `@schema` endpoint. [deiferni]
 - Index getObjPositionInParent for sequential tasks and sort them on getObjPositionInParent in @tasktree endpoint. [tinagerber]

--- a/opengever/activity/tests/test_mail.py
+++ b/opengever/activity/tests/test_mail.py
@@ -121,7 +121,7 @@ class TestEmailNotification(IntegrationTestCase):
         mail = raw_mail.decode("quopri")
 
         self.assertIn(
-            '<tr><td class="label">Info at</td>'
+            '<tr><td valign="top" class="label">Info at</td>'
             '<td>Kohler Nicole (nicole.kohler), '
             'B\xc3\xa4rfuss K\xc3\xa4thi (kathi.barfuss)</td></tr>',
             mail)

--- a/opengever/activity/tests/test_mail.py
+++ b/opengever/activity/tests/test_mail.py
@@ -39,7 +39,7 @@ class TestEmailNotification(IntegrationTestCase):
         # The secretariat user is a part of the inbox group
         create(Builder('watcher').having(actorid=self.secretariat_user.id))
 
-    def create_task_via_browser(self, browser, inbox=False, description=None):
+    def create_task_via_browser(self, browser, inbox=False, description=None, info_at=[]):
         browser.open(self.dossier, view='++add++opengever.task.task')
         browser.fill({'Title': 'Test Task', 'Task type': 'comment'})
         if description is not None:
@@ -51,6 +51,7 @@ class TestEmailNotification(IntegrationTestCase):
             org_unit_id = u'fa'
             inbox_id = u':'.join(('inbox', org_unit_id, ))
             form.find_widget('Issuer').fill(inbox_id)
+        form.find_widget('Info at').fill(info_at)
         browser.css('#form-buttons-save').first.click()
 
     @browsing
@@ -107,6 +108,23 @@ class TestEmailNotification(IntegrationTestCase):
         self.assertIn('<td>Multi<br />', mail)
         self.assertIn('line<br />', mail)
         self.assertIn('comment</td>', mail)
+
+    @browsing
+    def test_add_task_notification_mail_includes_info_at(self, browser):
+        self.login(self.dossier_responsible, browser)
+        self.create_task_via_browser(browser, info_at=['nicole.kohler', 'kathi.barfuss'])
+        process_mail_queue()
+
+        mails = Mailing(self.portal).get_messages()
+        self.assertEqual(len(mails), 2)
+        raw_mail = mails[0]
+        mail = raw_mail.decode("quopri")
+
+        self.assertIn(
+            '<tr><td class="label">Info at</td>'
+            '<td>Kohler Nicole (nicole.kohler), '
+            'B\xc3\xa4rfuss K\xc3\xa4thi (kathi.barfuss)</td></tr>',
+            mail)
 
     @browsing
     def test_notification_mailer_handle_empty_activity_description(self, browser):

--- a/opengever/task/activities.py
+++ b/opengever/task/activities.py
@@ -103,6 +103,8 @@ class TaskAddedActivity(BaseTaskActivity):
     def collect_description_data(self, language):
         """Returns a list with [label, value] pairs.
         """
+        informed_principals = [Actor.lookup(actorid).get_label() for actorid in
+                               self.context.informed_principals]
         data = [
             [_('label_task_title', u'Task title'), self.context.title],
             [_('label_deadline', u'Deadline'),
@@ -116,7 +118,9 @@ class TaskAddedActivity(BaseTaskActivity):
             [_('label_responsible', u'Responsible'),
              self.context.get_responsible_actor().get_label()],
             [_('label_issuer', u'Issuer'),
-             self.context.get_issuer_actor().get_label()]
+             self.context.get_issuer_actor().get_label()],
+            [_('label_informed_principals', u'Info at'),
+             ", ".join(informed_principals) or '-'],
             ]
         if self.context.get_is_subtask():
             parent = aq_parent(aq_inner(self.context))

--- a/opengever/task/activities.py
+++ b/opengever/task/activities.py
@@ -92,7 +92,7 @@ class TaskAddedActivity(BaseTaskActivity):
     def render_description_markup(self, data, language):
         msg = u'<table><tbody>'
         for label, value in data:
-            msg = u'{}<tr><td class="label">{}</td><td>'.format(
+            msg = u'{}<tr><td valign="top" class="label">{}</td><td>'.format(
                 msg, self.translate(label, language))
             # Break lines correctly in the table rows
             if value:

--- a/opengever/task/locales/de/LC_MESSAGES/opengever.task.po
+++ b/opengever/task/locales/de/LC_MESSAGES/opengever.task.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2021-01-08 11:40+0000\n"
+"POT-Creation-Date: 2021-01-19 15:20+0000\n"
 "PO-Revision-Date: 2015-02-17 18:41+0100\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -506,6 +506,7 @@ msgid "label_expectedStartOfWork"
 msgstr "Beginn der Arbeit"
 
 #. Default: "Info at"
+#: ./opengever/task/activities.py
 #: ./opengever/task/task.py
 msgid "label_informed_principals"
 msgstr "Info an"

--- a/opengever/task/locales/en/LC_MESSAGES/opengever.task.po
+++ b/opengever/task/locales/en/LC_MESSAGES/opengever.task.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2021-01-16 18:45+0000\n"
+"POT-Creation-Date: 2021-01-19 15:20+0000\n"
 "PO-Revision-Date: 2015-02-17 18:41+0100\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -610,6 +610,7 @@ msgstr "Start of work"
 #. German translation: Info an
 #. Default: "Info at"
 #. MARKER: double check
+#: ./opengever/task/activities.py
 #: ./opengever/task/task.py
 msgid "label_informed_principals"
 msgstr "Info at"

--- a/opengever/task/locales/fr/LC_MESSAGES/opengever.task.po
+++ b/opengever/task/locales/fr/LC_MESSAGES/opengever.task.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-01-08 11:40+0000\n"
+"POT-Creation-Date: 2021-01-19 15:20+0000\n"
 "PO-Revision-Date: 2017-12-03 11:47+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-task/fr/>\n"
@@ -508,6 +508,7 @@ msgid "label_expectedStartOfWork"
 msgstr "Début du travail"
 
 #. Default: "Info at"
+#: ./opengever/task/activities.py
 #: ./opengever/task/task.py
 msgid "label_informed_principals"
 msgstr "Info à"

--- a/opengever/task/locales/opengever.task.pot
+++ b/opengever/task/locales/opengever.task.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2021-01-08 11:40+0000\n"
+"POT-Creation-Date: 2021-01-19 15:20+0000\n"
 "PO-Revision-Date: 2009-02-25 14:39+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -506,6 +506,7 @@ msgid "label_expectedStartOfWork"
 msgstr ""
 
 #. Default: "Info at"
+#: ./opengever/task/activities.py
 #: ./opengever/task/task.py
 msgid "label_informed_principals"
 msgstr ""

--- a/opengever/task/tests/test_activities.py
+++ b/opengever/task/tests/test_activities.py
@@ -53,6 +53,16 @@ class TestTaskActivites(FunctionalTestCase):
 
     @browsing
     def test_task_added(self, browser):
+        create(Builder('ogds_user').id('watcher.user')
+                                   .assign_to_org_units([self.org_unit])
+                                   .having(firstname=u'Watcher',
+                                           lastname=u'User'))
+
+        create(Builder('ogds_user').id('another.watcher')
+                                   .assign_to_org_units([self.org_unit])
+                                   .having(firstname=u'Watcher',
+                                           lastname=u'Another'))
+
         browser.login().open(self.dossier, view='++add++opengever.task.task')
         browser.fill({'Title': u'Abkl\xe4rung Fall Meier',
                       'Responsible': u'hugo.boss',
@@ -62,6 +72,7 @@ class TestTaskActivites(FunctionalTestCase):
 
         form = browser.find_form_by_field('Responsible')
         form.find_widget('Responsible').fill('hugo.boss')
+        form.find_widget('Info at').fill(['watcher.user', 'another.watcher'])
 
         browser.css('#form-buttons-save').first.click()
 
@@ -70,7 +81,7 @@ class TestTaskActivites(FunctionalTestCase):
         self.assertEquals(
           u'Dossier XY - Abkl\xe4rung Fall Meier', activity.title)
         self.assertEquals(u'New task opened by Test User', activity.summary)
-        self.assertEqual(1, len(activity.notifications))
+        self.assertEqual(3, len(activity.notifications))
 
         browser.open_html(activity.description)
         rows = browser.css('table').first.rows
@@ -82,7 +93,8 @@ class TestTaskActivites(FunctionalTestCase):
              ['Dossier title', 'Dossier XY'],
              ['Text', 'Lorem ipsum'],
              ['Responsible', 'Boss Hugo (hugo.boss)'],
-             ['Issuer', 'Test User (test_user_1_)']],
+             ['Issuer', 'Test User (test_user_1_)'],
+             ['Info at', 'User Watcher (watcher.user), Another Watcher (another.watcher)']],
             [row.css('td').text for row in rows])
 
     @browsing
@@ -403,7 +415,8 @@ class TestTaskActivites(FunctionalTestCase):
              ['Main task', u'Abkl\xe4rung Fall Meier'],
              ['Text', 'Lorem ipsum'],
              ['Responsible', 'Boss Hugo (hugo.boss)'],
-             ['Issuer', 'Boss Hugo (hugo.boss)']],
+             ['Issuer', 'Boss Hugo (hugo.boss)'],
+             ['Info at', '-']],
             [row.css('td').text for row in rows])
 
     @browsing


### PR DESCRIPTION
We add the list of informed principals to the description of the `TaskAddedActivity`.
I also decided to align the labels to the top of the cells, which makes it much more readable IMHO. 
The screenshot below shows the E-mail for a created Task with a long title, description and several informed principals:

<img width="641" alt="Screenshot 2021-01-19 at 16 36 33" src="https://user-images.githubusercontent.com/7374243/105056495-8dfff480-5a74-11eb-9d81-55d98d0b10cf.png">

Definition of Done: https://4teamwork.atlassian.net/wiki/spaces/CHX4TW/pages/917562/

For https://4teamwork.atlassian.net/browse/CA-1227

## Checklist (Must have)
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)