### PR TITLE
Respect active languages languages in WorkspaceRoot and PrivateRoot forms.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2021.3.0 (unreleased)
 ---------------------
 
+- Respect active languages languages in WorkspaceRoot and PrivateRoot forms. [njohner]
 - Fix deactivating committees with canceled meetings. [deiferni]
 
 

--- a/opengever/base/tests/test_translated_title.py
+++ b/opengever/base/tests/test_translated_title.py
@@ -100,6 +100,36 @@ class TestTranslatedTitleFieldsInEditForms(IntegrationTestCase):
             browser, ['de', 'fr'])
 
     @browsing
+    def test_modifying_language_fields_in_edit_form(self, browser):
+        self.login(self.manager, browser=browser)
+        lang_tool = api.portal.get_tool('portal_languages')
+        lang_tool.supported_langs = ['de-ch', 'fr-ch']
+
+        browser.open(self.repository_root, view='edit')
+
+        browser.fill({'Title (German)': u'Ordnungssystem',
+                      u'Title (French)': u"syst\xe8me d'ordre"})
+        browser.find('Save').click()
+
+    @browsing
+    def test_label_is_renamed_to_title_for_sites_with_only_one_active_language(self, browser):
+        self.login(self.manager, browser=browser)
+        lang_tool = api.portal.get_tool('portal_languages')
+        lang_tool.supported_langs = ['de-ch', 'fr-ch']
+
+        browser.open(self.repository_root, view='edit')
+        self.assertEquals(
+            'Title (French)',
+            browser.css('label[for=form-widgets-ITranslatedTitle-title_fr]').first.text)
+
+        lang_tool.supported_langs = ['fr-ch']
+
+        browser.open(self.repository_root, view='edit')
+        self.assertEquals(
+            'Title',
+            browser.css('label[for=form-widgets-ITranslatedTitle-title_fr]').first.text)
+
+    @browsing
     def test_inbox_container_edit_form_only_shows_translated_title_fields_for_active_languages(
             self, browser):
         self.login(self.manager, browser=browser)
@@ -356,49 +386,6 @@ class TestTranslatedTitleAddForm(IntegrationTestCase):
         browser.open(self.portal)
         factoriesmenu.add('Repository Root')
 
-        self.assertEquals(
-            'Title',
-            browser.css('label[for=form-widgets-ITranslatedTitle-title_fr]').first.text)
-
-
-class TestTranslatedTitleEditForm(IntegrationTestCase):
-
-    def setUp(self):
-        super(TestTranslatedTitleEditForm, self).setUp()
-        self.enable_languages()
-        self.lang_tool = api.portal.get_tool('portal_languages')
-
-    @browsing
-    def test_language_fields_are_available_by_default(self, browser):
-        self.login(self.manager, browser=browser)
-
-        self.lang_tool.supported_langs = ['de-ch', 'fr-ch']
-
-        browser.open(self.repository_root, view='edit')
-
-        browser.fill({'Title (German)': u'Ordnungssystem',
-                      u'Title (French)': u"syst\xe8me d'ordre"})
-        browser.find('Save').click()
-
-    @browsing
-    def test_language_fields_of_inactive_languages_are_hidden(self, browser):
-        self.login(self.manager, browser=browser)
-
-        self.lang_tool.supported_langs = ['fr-ch']
-
-        browser.open(self.repository_root, view='edit')
-        self.assertEquals([u'Title', 'Valid from', 'Valid until', 'Version'],
-                          browser.forms.get('form').css('label').text)
-        self.assertEquals('form.widgets.ITranslatedTitle.title_fr',
-                          browser.find_field_by_text('Title').get('name'))
-
-    @browsing
-    def test_label_is_renamed_to_title_for_sites_with_only_one_active_language(self, browser):
-        self.login(self.manager, browser=browser)
-
-        self.lang_tool.supported_langs = ['fr-ch']
-
-        browser.open(self.repository_root, view='edit')
         self.assertEquals(
             'Title',
             browser.css('label[for=form-widgets-ITranslatedTitle-title_fr]').first.text)

--- a/opengever/base/tests/test_translated_title.py
+++ b/opengever/base/tests/test_translated_title.py
@@ -57,7 +57,7 @@ class TestTranslatedTitleHasTranslationBehavior(IntegrationTestCase):
             ttool["opengever.contact.contactfolder"]))
 
 
-class TestTranslatedTitleIsOnTop(IntegrationTestCase):
+class TestTranslatedTitleFieldsInEditForms(IntegrationTestCase):
 
     def assert_expected_translated_title_fields_are_displayed_in_browser(
             self, browser, expected_languages):
@@ -81,107 +81,85 @@ class TestTranslatedTitleIsOnTop(IntegrationTestCase):
             actual_fields, first_fields,
             "Translated title fields should come at the top of the form")
 
+    def assert_edit_form_shows_translated_title_fields_only_for_active_languages(
+            self, browser, obj):
+        lang_tool = api.portal.get_tool('portal_languages')
+        self.assertItemsEqual(['en', 'de-ch'], lang_tool.supported_langs)
+        self.assertNotIn('en', TranslatedTitle.SUPPORTED_LANGUAGES)
+
+        browser.open(obj, view='edit')
+        statusmessages.assert_no_error_messages()
+        self.assert_expected_translated_title_fields_are_displayed_in_browser(
+            browser, ['de'])
+
+        lang_tool.addSupportedLanguage('fr-ch')
+
+        browser.open(obj, view='edit')
+        statusmessages.assert_no_error_messages()
+        self.assert_expected_translated_title_fields_are_displayed_in_browser(
+            browser, ['de', 'fr'])
+
     @browsing
-    def test_translated_title_is_on_top_when_editing_the_inbox_container(
+    def test_inbox_container_edit_form_only_shows_translated_title_fields_for_active_languages(
             self, browser):
         self.login(self.manager, browser=browser)
-
-        inbox_container = create(Builder('inbox_container')
-                                 .titled(u'Inboxes')
-                                 .within(self.portal))
-
-        browser.open(inbox_container, view='edit')
-        statusmessages.assert_no_error_messages()
-
-        self.assert_expected_translated_title_fields_are_displayed_in_browser(
-            browser, ['de'])
+        self.assert_edit_form_shows_translated_title_fields_only_for_active_languages(
+            browser, self.inbox_container)
 
     @browsing
-    def test_translated_title_is_on_top_when_editing_the_private_root(
+    def test_private_root_edit_form_only_shows_translated_title_fields_for_active_languages(
             self, browser):
         self.login(self.manager, browser=browser)
-
-        browser.open(self.private_root, view='edit')
-        statusmessages.assert_no_error_messages()
-
-        self.assert_expected_translated_title_fields_are_displayed_in_browser(
-            browser, ['de'])
+        self.assert_edit_form_shows_translated_title_fields_only_for_active_languages(
+            browser, self.private_root)
 
     @browsing
-    def test_translated_title_is_on_top_when_editing_the_inbox(self, browser):
+    def test_inbox_edit_form_only_shows_translated_title_fields_for_active_languages(self, browser):
         self.login(self.manager, browser=browser)
-
-        browser.open(self.inbox, view='edit')
-        statusmessages.assert_no_error_messages()
-
-        self.assert_expected_translated_title_fields_are_displayed_in_browser(
-            browser, ['de'])
+        self.assert_edit_form_shows_translated_title_fields_only_for_active_languages(
+            browser, self.inbox)
 
     @browsing
-    def test_translated_title_is_on_top_when_editing_the_committee_container(
+    def test_committee_container_edit_form_only_shows_translated_title_fields_for_active_languages(
             self, browser):
         self.login(self.manager, browser=browser)
-
-        browser.open(self.committee_container, view='edit')
-        statusmessages.assert_no_error_messages()
-
-        self.assert_expected_translated_title_fields_are_displayed_in_browser(
-            browser, ['de'])
+        self.assert_edit_form_shows_translated_title_fields_only_for_active_languages(
+            browser, self.committee_container)
 
     @browsing
-    def test_translated_title_is_on_top_when_editing_the_templates(
+    def test_template_folder_edit_form_only_shows_translated_title_fields_for_active_languages(
             self, browser):
         self.login(self.manager, browser=browser)
-
-        browser.open(self.templates, view='edit')
-        statusmessages.assert_no_error_messages()
-
-        self.assert_expected_translated_title_fields_are_displayed_in_browser(
-            browser, ['de'])
+        self.assert_edit_form_shows_translated_title_fields_only_for_active_languages(
+            browser, self.templates)
 
     @browsing
-    def test_translated_title_is_on_top_when_editing_the_workspace_root(
+    def test_workspace_root_edit_form_only_shows_translated_title_fields_for_active_languages(
             self, browser):
         self.login(self.manager, browser=browser)
-
-        browser.open(self.workspace_root, view='edit')
-        statusmessages.assert_no_error_messages()
-
-        self.assert_expected_translated_title_fields_are_displayed_in_browser(
-            browser, ['de'])
+        self.assert_edit_form_shows_translated_title_fields_only_for_active_languages(
+            browser, self.workspace_root)
 
     @browsing
-    def test_translated_title_is_on_top_when_editing_the_repository_root(
+    def test_repository_root_edit_form_only_shows_translated_title_fields_for_active_languages(
             self, browser):
         self.login(self.manager, browser=browser)
-
-        browser.open(self.repository_root, view='edit')
-        statusmessages.assert_no_error_messages()
-
-        self.assert_expected_translated_title_fields_are_displayed_in_browser(
-            browser, ['de'])
+        self.assert_edit_form_shows_translated_title_fields_only_for_active_languages(
+            browser, self.repository_root)
 
     @browsing
-    def test_translated_title_is_on_top_when_editing_the_contact_folder(
+    def test_contact_folder_edit_form_only_shows_translated_title_fields_for_active_languages(
             self, browser):
         self.login(self.manager, browser=browser)
-
-        browser.open(self.contactfolder, view='edit')
-        statusmessages.assert_no_error_messages()
-
-        self.assert_expected_translated_title_fields_are_displayed_in_browser(
-            browser, ['de'])
+        self.assert_edit_form_shows_translated_title_fields_only_for_active_languages(
+            browser, self.contactfolder)
 
     @browsing
-    def test_translated_title_is_on_top_when_editing_the_repository_folder(
+    def test_repository_folder_edit_form_only_shows_translated_title_fields_for_active_languages(
             self, browser):
         self.login(self.manager, browser=browser)
-
-        browser.open(self.branch_repofolder, view='edit')
-        statusmessages.assert_no_error_messages()
-
-        self.assert_expected_translated_title_fields_are_displayed_in_browser(
-            browser, ['de'])
+        self.assert_edit_form_shows_translated_title_fields_only_for_active_languages(
+            browser, self.branch_repofolder)
 
 
 class TestTranslatedTitleConfig(TestCase):

--- a/opengever/base/tests/test_translated_title.py
+++ b/opengever/base/tests/test_translated_title.py
@@ -59,18 +59,27 @@ class TestTranslatedTitleHasTranslationBehavior(IntegrationTestCase):
 
 class TestTranslatedTitleIsOnTop(IntegrationTestCase):
 
-    def assert_translated_title_fields_in_browser(self, browser):
-        translated_fields = [
-            'forms.widgets.ITranslatedTitle.title_{}'.format(lang)
-            for lang in api.portal.get_tool('portal_languages').supported_langs
-            if lang in TranslatedTitle.SUPPORTED_LANGUAGES
-        ]
+    def assert_expected_translated_title_fields_are_displayed_in_browser(
+            self, browser, expected_languages):
+        """Make sure that only fields corresponding to the expected languages
+        are shown. We also check that they are displayed at the top of the form.
+        """
+        expected_fields = [
+            'form.widgets.ITranslatedTitle.title_{}'.format(lang)
+            for lang in expected_languages]
 
         first_fields = [
-            _input.name
-            for _input in browser.css("#form input[type!='hidden']")[:len(translated_fields)]
-        ]
-        self.assertEquals(translated_fields, first_fields)
+            _input.name for _input in browser.css(
+                "#form input[type!='hidden']")[:len(expected_fields)]]
+
+        actual_fields = [
+            _input.name for _input in browser.css("#form input[type!='hidden']")
+            if _input.name and 'form.widgets.ITranslatedTitle' in _input.name]
+
+        self.assertEqual(expected_fields, actual_fields)
+        self.assertEqual(
+            actual_fields, first_fields,
+            "Translated title fields should come at the top of the form")
 
     @browsing
     def test_translated_title_is_on_top_when_editing_the_inbox_container(
@@ -84,7 +93,8 @@ class TestTranslatedTitleIsOnTop(IntegrationTestCase):
         browser.open(inbox_container, view='edit')
         statusmessages.assert_no_error_messages()
 
-        self.assert_translated_title_fields_in_browser(browser)
+        self.assert_expected_translated_title_fields_are_displayed_in_browser(
+            browser, ['de'])
 
     @browsing
     def test_translated_title_is_on_top_when_editing_the_private_root(
@@ -94,7 +104,8 @@ class TestTranslatedTitleIsOnTop(IntegrationTestCase):
         browser.open(self.private_root, view='edit')
         statusmessages.assert_no_error_messages()
 
-        self.assert_translated_title_fields_in_browser(browser)
+        self.assert_expected_translated_title_fields_are_displayed_in_browser(
+            browser, ['de'])
 
     @browsing
     def test_translated_title_is_on_top_when_editing_the_inbox(self, browser):
@@ -103,7 +114,8 @@ class TestTranslatedTitleIsOnTop(IntegrationTestCase):
         browser.open(self.inbox, view='edit')
         statusmessages.assert_no_error_messages()
 
-        self.assert_translated_title_fields_in_browser(browser)
+        self.assert_expected_translated_title_fields_are_displayed_in_browser(
+            browser, ['de'])
 
     @browsing
     def test_translated_title_is_on_top_when_editing_the_committee_container(
@@ -113,7 +125,8 @@ class TestTranslatedTitleIsOnTop(IntegrationTestCase):
         browser.open(self.committee_container, view='edit')
         statusmessages.assert_no_error_messages()
 
-        self.assert_translated_title_fields_in_browser(browser)
+        self.assert_expected_translated_title_fields_are_displayed_in_browser(
+            browser, ['de'])
 
     @browsing
     def test_translated_title_is_on_top_when_editing_the_templates(
@@ -123,7 +136,8 @@ class TestTranslatedTitleIsOnTop(IntegrationTestCase):
         browser.open(self.templates, view='edit')
         statusmessages.assert_no_error_messages()
 
-        self.assert_translated_title_fields_in_browser(browser)
+        self.assert_expected_translated_title_fields_are_displayed_in_browser(
+            browser, ['de'])
 
     @browsing
     def test_translated_title_is_on_top_when_editing_the_workspace_root(
@@ -133,7 +147,8 @@ class TestTranslatedTitleIsOnTop(IntegrationTestCase):
         browser.open(self.workspace_root, view='edit')
         statusmessages.assert_no_error_messages()
 
-        self.assert_translated_title_fields_in_browser(browser)
+        self.assert_expected_translated_title_fields_are_displayed_in_browser(
+            browser, ['de'])
 
     @browsing
     def test_translated_title_is_on_top_when_editing_the_repository_root(
@@ -143,7 +158,8 @@ class TestTranslatedTitleIsOnTop(IntegrationTestCase):
         browser.open(self.repository_root, view='edit')
         statusmessages.assert_no_error_messages()
 
-        self.assert_translated_title_fields_in_browser(browser)
+        self.assert_expected_translated_title_fields_are_displayed_in_browser(
+            browser, ['de'])
 
     @browsing
     def test_translated_title_is_on_top_when_editing_the_contact_folder(
@@ -153,7 +169,8 @@ class TestTranslatedTitleIsOnTop(IntegrationTestCase):
         browser.open(self.contactfolder, view='edit')
         statusmessages.assert_no_error_messages()
 
-        self.assert_translated_title_fields_in_browser(browser)
+        self.assert_expected_translated_title_fields_are_displayed_in_browser(
+            browser, ['de'])
 
     @browsing
     def test_translated_title_is_on_top_when_editing_the_repository_folder(
@@ -163,7 +180,8 @@ class TestTranslatedTitleIsOnTop(IntegrationTestCase):
         browser.open(self.branch_repofolder, view='edit')
         statusmessages.assert_no_error_messages()
 
-        self.assert_translated_title_fields_in_browser(browser)
+        self.assert_expected_translated_title_fields_are_displayed_in_browser(
+            browser, ['de'])
 
 
 class TestTranslatedTitleConfig(TestCase):

--- a/opengever/private/browser/configure.zcml
+++ b/opengever/private/browser/configure.zcml
@@ -56,4 +56,13 @@
         />
   </class>
 
+
+  <!-- Only show translated title fields for active languages -->
+  <browser:page
+      for="opengever.private.root.IPrivateRoot"
+      name="edit"
+      class="opengever.base.browser.translated_title.TranslatedTitleEditForm"
+      permission="cmf.ModifyPortalContent"
+      />
+
 </configure>

--- a/opengever/private/browser/configure.zcml
+++ b/opengever/private/browser/configure.zcml
@@ -65,4 +65,11 @@
       permission="cmf.ModifyPortalContent"
       />
 
+  <!-- PrivateRoot add form: only show translated title fields for active languages  -->
+  <adapter
+      factory=".forms.PrivateRootAddView"
+      provides="zope.publisher.interfaces.browser.IBrowserPage"
+      name="opengever.private.root"
+      />
+
 </configure>

--- a/opengever/private/tests/test_root.py
+++ b/opengever/private/tests/test_root.py
@@ -3,14 +3,15 @@ from ftw.builder import create
 from ftw.testbrowser import browsing
 from ftw.testbrowser.pages import factoriesmenu
 from opengever.testing import IntegrationTestCase
-from zExceptions import Unauthorized
 from ftw.testbrowser import InsufficientPrivileges
+
 
 class TestPrivateRoot(IntegrationTestCase):
 
     @browsing
     def test_is_addable_on_plone_site(self, browser):
         self.login(self.manager, browser=browser)
+        self.enable_languages()
 
         browser.open()
         factoriesmenu.add('Private Root')
@@ -23,6 +24,7 @@ class TestPrivateRoot(IntegrationTestCase):
     @browsing
     def test_is_only_addable_by_manager(self, browser):
         self.login(self.regular_user, browser=browser)
+        self.enable_languages()
 
         with self.assertRaises(InsufficientPrivileges):
             browser.open(self.portal, view='++add++opengever.private.root')

--- a/opengever/workspace/browser/configure.zcml
+++ b/opengever/workspace/browser/configure.zcml
@@ -71,4 +71,11 @@
       permission="cmf.ModifyPortalContent"
       />
 
+  <!-- WorkspaceRoot add form: only show translated title fields for active languages  -->
+  <adapter
+      factory=".forms.WorkspaceRootAddView"
+      provides="zope.publisher.interfaces.browser.IBrowserPage"
+      name="opengever.workspace.root"
+      />
+
 </configure>

--- a/opengever/workspace/browser/configure.zcml
+++ b/opengever/workspace/browser/configure.zcml
@@ -63,4 +63,12 @@
       permission="opengever.workspace.ModifyWorkspace"
       />
 
+  <!-- Only show translated title fields for active languages -->
+  <browser:page
+      for="opengever.workspace.interfaces.IWorkspaceRoot"
+      name="edit"
+      class="opengever.base.browser.translated_title.TranslatedTitleEditForm"
+      permission="cmf.ModifyPortalContent"
+      />
+
 </configure>

--- a/opengever/workspace/browser/forms.py
+++ b/opengever/workspace/browser/forms.py
@@ -1,5 +1,4 @@
 from opengever.base.browser.translated_title import TranslatedTitleAddForm
-from opengever.dossier.browser.forms import DossierAddView
 from plone.dexterity.browser.add import DefaultAddView
 from plone.dexterity.interfaces import IDexterityFTI
 from Products.CMFCore.interfaces import IFolderish
@@ -8,10 +7,5 @@ from zope.publisher.interfaces.browser import IDefaultBrowserLayer
 
 
 @adapter(IFolderish, IDefaultBrowserLayer, IDexterityFTI)
-class PrivateRootAddView(DefaultAddView):
+class WorkspaceRootAddView(DefaultAddView):
     form = TranslatedTitleAddForm
-
-
-class PrivateDossierAddView(DossierAddView):
-    """Add view for opengever.private.dossier
-    """

--- a/opengever/workspace/tests/test_workspace_root.py
+++ b/opengever/workspace/tests/test_workspace_root.py
@@ -13,6 +13,7 @@ class TestWorkspaceRoot(IntegrationTestCase):
     @browsing
     def test_can_be_added_as_manager(self, browser):
         self.login(self.manager, browser)
+        self.enable_languages()
         browser.open(view='folder_contents')
         factoriesmenu.add('Workspace Root')
         browser.fill({'Title (German)': u'Teamr\xe4ume',


### PR DESCRIPTION
Some of the tests for the translated titles were not testing anything. Indeed they were asserting equality between empty lists, probably since we started using combined language codes like 'de-ch'.

We also improve the tests by really checking that translated title fields are only shown for the active languages both in the Add and the Edit forms. This led to discovery that both `WorkspaceRoot` and `PrivateRoot` were not handling the translated fields correctly. I therefore also fix this with this PR.

For https://4teamwork.atlassian.net/browse/CA-1040

## Checklist (Must have)
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)