### PR TITLE
OGDS self registration

### DIFF
--- a/opengever/workspace/browser/configure.zcml
+++ b/opengever/workspace/browser/configure.zcml
@@ -63,4 +63,11 @@
       permission="opengever.workspace.ModifyWorkspace"
       />
 
+  <browser:page
+      name="user-self-registration"
+      for="Products.CMFPlone.interfaces.IPloneSiteRoot"
+      class=".registration.SelfRegistrationView"
+      permission="zope2.View"
+      />
+
 </configure>

--- a/opengever/workspace/browser/registration.py
+++ b/opengever/workspace/browser/registration.py
@@ -1,0 +1,70 @@
+from Acquisition import aq_base
+from logging import getLogger
+from opengever.base.model import create_session
+from opengever.ogds.models.group import Group
+from opengever.ogds.models.service import ogds_service
+from opengever.ogds.models.user import User
+from plone import api
+from Products.CMFCore.utils import getToolByName
+from Products.Five.browser import BrowserView
+
+logger = getLogger('opengever.workspace.registration')
+
+
+class SelfRegistrationView(BrowserView):
+    """Handles self registration of users
+
+       Creates the user in OGDS and redirects to the site root.
+    """
+
+    def __call__(self):
+        if api.user.is_anonymous():
+            return self.redirect_to_next()
+
+        self.create_ogds_user()
+        self.redirect_to_next()
+
+    def redirect_to_next(self):
+        next_url = self.request.form.get('next')
+        portal_url = api.portal.get().absolute_url()
+        if next_url:
+            if next_url.startswith(portal_url):
+                return self.request.response.redirect(next_url)
+            elif next_url.startswith('/'):
+                return self.request.response.redirect(portal_url + next_url)
+
+        self.request.response.redirect(portal_url)
+
+    def create_ogds_user(self):
+        member = api.user.get_current()
+        userid = member.getId()
+
+        # Already exists?
+        if ogds_service().fetch_user(userid):
+            return
+
+        # Only users in the current site
+        acl_users = getToolByName(self, 'acl_users')
+        user = aq_base(acl_users).getUserById(userid, None)
+        if user is None:
+            return
+
+        session = create_session()
+        firstname = member.getProperty('firstname', '')
+        lastname = member.getProperty('lastname', '')
+        email = member.getProperty('email')
+        ogds_user = User(
+            userid=userid,
+            firstname=firstname,
+            lastname=lastname,
+            email=email)
+        logger.info("Created OGDS entry for user %r" % userid)
+
+        # Assign the intersection of existing OGDS groups and the newly created
+        # user's groups as groups for the new OGDS user entry. This will most
+        # likely be just the OrgUnit's users_group. If there's more, they
+        # will be created and assigned during next sync.
+        groups_of_new_user = member.getUser().getGroupIds()
+        groups = Group.query.filter(Group.groupid.in_(groups_of_new_user)).all()
+        ogds_user.groups = groups
+        session.add(ogds_user)

--- a/opengever/workspace/tests/test_self_registration.py
+++ b/opengever/workspace/tests/test_self_registration.py
@@ -1,0 +1,55 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.testbrowser import browsing
+from opengever.ogds.models.service import ogds_service
+from opengever.testing import IntegrationTestCase
+
+
+class TestSelfRegistration(IntegrationTestCase):
+
+    features = ('workspace',)
+
+    @browsing
+    def test_self_registration_redirects_to_root(self, browser):
+        self.login(self.regular_user, browser=browser)
+        browser.allow_redirects = False
+        browser.open(self.portal.absolute_url() + '/@@user-self-registration')
+        self.assertEqual(browser.headers['Location'], self.portal.absolute_url())
+
+    @browsing
+    def test_self_registration_redirects_to_next(self, browser):
+        self.login(self.regular_user, browser=browser)
+        browser.allow_redirects = False
+        browser.open(
+            self.portal.absolute_url() + '/@@user-self-registration?next=/workspaces')
+        self.assertEqual(
+            browser.headers['Location'],
+            self.portal.absolute_url() + '/workspaces',
+        )
+
+    @browsing
+    def test_self_registration_creates_ogds_user(self, browser):
+        user = create(
+            Builder('user')
+            .having(firstname='Hugo', lastname='Boss')
+            .with_userid('hugo.boss'))
+
+        self.login(user, browser=browser)
+        browser.allow_redirects = False
+        browser.open(self.portal.absolute_url() + '/@@user-self-registration')
+
+        self.assertIsNotNone(ogds_service().fetch_user('hugo.boss'))
+
+    @browsing
+    def test_self_registration_creates_ogds_user_with_groups(self, browser):
+        user = create(Builder('user')
+                      .with_userid('hugo.boss')
+                      .having(firstname='Hugo', lastname='Boss')
+                      .in_groups('fa_users'))
+
+        self.login(user, browser=browser)
+        browser.allow_redirects = False
+        browser.open(self.portal.absolute_url() + '/@@user-self-registration')
+
+        group = ogds_service().fetch_group('fa_users')
+        self.assertIn('hugo.boss', [u.userid for u in group.users])


### PR DESCRIPTION
Add view to handle self registration.
Creates the user in OGDS and redirects to the next URL provided in the query string or to the site root.