### PR TITLE
Expose property sheet schemas in `@schema` endpoint.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 ---------------------
 
 - Fix deactivating committees with canceled meetings. [deiferni]
+- Include custom properties in JSON schema for documents and mails in the `@schema` endpoint. [deiferni]
 
 
 2021.2.0 (2021-01-20)

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -16,7 +16,7 @@ Breaking Changes
 Other Changes
 ^^^^^^^^^^^^^
 
-- No changes yet
+- The field ``custom_properties`` is now included in the ``@schema`` endpoint for Documents and Mails (see :ref:`content-types`).
 
 
 2021.2.0 (2021-01-20)

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -25,10 +25,10 @@ Other Changes
 Other Changes
 ^^^^^^^^^^^^^
 
-- A new endpoint ``@white-labeling-settings`` is added (see :ref:`docs <white-labeling-settings>`).
-- ``@config``: New feature flag ``hubspot`` added (see :ref:`docs <config>`).
-- Documents and Mails now support serialization and deserialization of ``custom_properties`` (see :ref:`docs <propertysheets>`).
-- A new endpoint ``@propertysheets`` is added (see :ref:`docs <propertysheets>`).
+- A new endpoint ``@white-labeling-settings`` is added (see :ref:`white-labeling-settings`).
+- ``@config``: New feature flag ``hubspot`` added (see :ref:`config`).
+- Documents and Mails now support serialization and deserialization of ``custom_properties`` (see :ref:`propertysheets`).
+- A new endpoint ``@propertysheets`` is added (see :ref:`propertysheets`).
 
 
 2021.1.0 (2021-01-06)
@@ -37,8 +37,8 @@ Other Changes
 Breaking Changes
 ^^^^^^^^^^^^^^^^
 
-- ``@schema``, ``@types``: Only return ``title_de`` / ``title_fr`` fields if corresponding language is enabled in deployment (see :ref:`docs <translated-titles>`).
+- ``@schema``, ``@types``: Only return ``title_de`` / ``title_fr`` fields if corresponding language is enabled in deployment (see :ref:`translated-titles`).
 
-- Serialization: Only serialize values for ``title_de`` / ``title_fr`` fields if corresponding language is enabled in deployment (see :ref:`docs <translated-titles>`; applies to Dossiers, Repositoryfolders, and Inboxes).
+- Serialization: Only serialize values for ``title_de`` / ``title_fr`` fields if corresponding language is enabled in deployment (see :ref:`translated-titles`; applies to Dossiers, Repositoryfolders, and Inboxes).
 
 .. disqus::

--- a/docs/public/dev-manual/api/content_types.rst
+++ b/docs/public/dev-manual/api/content_types.rst
@@ -22,6 +22,16 @@ Das Erstellen und Modifizieren von Inhalten mittels ``POST`` oder ``PATCH``
 erlaubt immer alle übersetzten Felder.
 
 
+Benutzerdefinierte Felder
+-------------------------
+
+Daten für benutzerdefinierte Felder werden im Feld `custom_properties`
+gespeichert. Eine Abfrage auf den ``@schema`` Endpoint liefert die aktuell
+gültigen Schemas der benutzerdefinierten Felder eines Deployments.
+Weitere Dokumentation über Benutzerdefinierte Felder findet man unter
+:ref:`propertysheets`.
+
+
 Schemas
 -------
 

--- a/docs/public/dev-manual/api/index.rst
+++ b/docs/public/dev-manual/api/index.rst
@@ -6,6 +6,7 @@ Inhalt:
 .. toctree::
    :maxdepth: 2
 
+   api_changelog.rst
    basics.rst
    authentication/index
    operations.rst
@@ -61,6 +62,5 @@ Inhalt:
    accept_remote_task.rst
    complete_successor_task.rst
    examples/index.rst
-   api_changelog.rst
 
 .. disqus::

--- a/docs/public/dev-manual/api/schemas/ftw.mail.mail.inc
+++ b/docs/public/dev-manual/api/schemas/ftw.mail.mail.inc
@@ -202,3 +202,13 @@
        
        
        :Wertebereich: ["mailin", "upload"]
+
+
+   .. py:attribute:: custom_properties
+
+       :Feldname: :field-title:`Benutzerdefinierte Felder`
+       :Datentyp: ``PropertySheetField``
+       
+       
+       :Beschreibung: Enthält die Daten für die benutzerdefinierten Felder.
+       

--- a/docs/public/dev-manual/api/schemas/opengever.document.document.inc
+++ b/docs/public/dev-manual/api/schemas/opengever.document.document.inc
@@ -192,3 +192,13 @@
        
        
        
+
+
+   .. py:attribute:: custom_properties
+
+       :Feldname: :field-title:`Benutzerdefinierte Felder`
+       :Datentyp: ``PropertySheetField``
+       
+       
+       :Beschreibung: Enthält die Daten für die benutzerdefinierten Felder.
+       

--- a/docs/schema-dumps/ftw.mail.mail.schema.json
+++ b/docs/schema-dumps/ftw.mail.mail.schema.json
@@ -163,6 +163,12 @@
                 "mailin",
                 "upload"
             ]
+        },
+        "custom_properties": {
+            "type": "object",
+            "title": "Benutzerdefinierte Felder",
+            "description": "Enth\u00e4lt die Daten f\u00fcr die benutzerdefinierten Felder.",
+            "_zope_schema_type": "PropertySheetField"
         }
     },
     "field_order": [
@@ -185,6 +191,7 @@
         "archival_file_state",
         "title",
         "original_message",
-        "message_source"
+        "message_source",
+        "custom_properties"
     ]
 }

--- a/docs/schema-dumps/opengever.document.document.schema.json
+++ b/docs/schema-dumps/opengever.document.document.schema.json
@@ -154,6 +154,12 @@
             "title": "Status Archivdatei",
             "description": "",
             "_zope_schema_type": "Int"
+        },
+        "custom_properties": {
+            "type": "object",
+            "title": "Benutzerdefinierte Felder",
+            "description": "Enth\u00e4lt die Daten f\u00fcr die benutzerdefinierten Felder.",
+            "_zope_schema_type": "PropertySheetField"
         }
     },
     "field_order": [
@@ -175,6 +181,7 @@
         "document_author",
         "preserved_as_paper",
         "archival_file",
-        "archival_file_state"
+        "archival_file_state",
+        "custom_properties"
     ]
 }

--- a/opengever/api/docsbuilder/schemadocs.py
+++ b/opengever/api/docsbuilder/schemadocs.py
@@ -50,33 +50,33 @@ class SchemaDocsBuilder(DirectoryHelperMixin):
         return sorted(schema['properties'].items(), key=keyfunc)
 
     def _build_docs_for_type(self, portal_type):
-            schema_filename = '{}.schema.json'.format(portal_type)
-            schema_path = pjoin(self.schema_dumps_dir, schema_filename)
+        schema_filename = '{}.schema.json'.format(portal_type)
+        schema_path = pjoin(self.schema_dumps_dir, schema_filename)
 
-            try:
-                json_schema = json.load(open(schema_path))
-            except IOError:
-                self._show_create_schema_dumps_message()
-                raise
+        try:
+            json_schema = json.load(open(schema_path))
+        except IOError:
+            self._show_create_schema_dumps_message()
+            raise
 
-            field_docs = []
+        field_docs = []
 
-            for field_name, field_info in self.ordered_fields(json_schema):
-                required = field_name in json_schema.get('required', [])
-                field_doc = self._build_docs_for_field(
-                    field_name, field_info, required)
-                field_docs.append(field_doc)
+        for field_name, field_info in self.ordered_fields(json_schema):
+            required = field_name in json_schema.get('required', [])
+            field_doc = self._build_docs_for_field(
+                field_name, field_info, required)
+            field_docs.append(field_doc)
 
-            type_template = env.get_template('type.rst')
-            type_doc = type_template.render(
-                dict(
-                    portal_type=portal_type,
-                    title=json_schema['title'],
-                    field_docs=u'\n'.join(field_docs),
-                )
+        type_template = env.get_template('type.rst')
+        type_doc = type_template.render(
+            dict(
+                portal_type=portal_type,
+                title=json_schema['title'],
+                field_docs=u'\n'.join(field_docs),
             )
+        )
 
-            return type_doc
+        return type_doc
 
     def _build_docs_for_field(self, field_name, field_info, required=False):
         field = field_info.copy()

--- a/opengever/base/schemadump/config.py
+++ b/opengever/base/schemadump/config.py
@@ -183,7 +183,6 @@ DEFAULT_OVERRIDES = {
 # Dropped from all schema dumps
 IGNORED_FIELDS = [
     'plone.app.versioningbehavior.behaviors.IVersionable.changeNote',
-    'opengever.document.behaviors.customproperties.IDocumentCustomProperties.custom_properties',
     'opengever.document.behaviors.metadata.IDocumentMetadata.digitally_available',
     'opengever.document.behaviors.metadata.IDocumentMetadata.preview',
     'opengever.document.behaviors.metadata.IDocumentMetadata.thumbnail',
@@ -219,6 +218,8 @@ JSON_SCHEMA_FIELD_TYPES = {
         'type': 'number'},
     'Int': {
         'type': 'integer'},
+    'PropertySheetField': {
+        'type': 'object'},
     'RelationList': {
         'type': 'array'},
     'RelationChoice': {

--- a/opengever/base/schemadump/schema.py
+++ b/opengever/base/schemadump/schema.py
@@ -106,24 +106,24 @@ class TypeDumper(object):
     """
 
     def dump(self, portal_type):
-            log.info("Dumping schemas for portal_type %r" % portal_type)
-            fti = self._get_fti(portal_type)
-            type_title = translate_de(fti.title, domain=fti.i18n_domain)
+        log.info("Dumping schemas for portal_type %r" % portal_type)
+        fti = self._get_fti(portal_type)
+        type_title = translate_de(fti.title, domain=fti.i18n_domain)
 
-            schemas = []
-            schema_dumper = SchemaDumper()
+        schemas = []
+        schema_dumper = SchemaDumper()
 
-            for schema in iterSchemataForType(portal_type):
-                schema_dump = schema_dumper.dump(schema)
-                schemas.append(schema_dump)
+        for schema in iterSchemataForType(portal_type):
+            schema_dump = schema_dumper.dump(schema)
+            schemas.append(schema_dump)
 
-            type_dump = OrderedDict((
-                ('portal_type', portal_type),
-                ('title', type_title),
-                ('schemas', schemas),
-            ))
+        type_dump = OrderedDict((
+            ('portal_type', portal_type),
+            ('title', type_title),
+            ('schemas', schemas),
+        ))
 
-            return type_dump
+        return type_dump
 
     def _get_fti(self, portal_type):
         types_tool = api.portal.get_tool('portal_types')

--- a/opengever/bundle/schemas/documents.schema.json
+++ b/opengever/bundle/schemas/documents.schema.json
@@ -192,6 +192,15 @@
                     "_zope_schema_type": "Bool",
                     "default": true
                 },
+                "custom_properties": {
+                    "type": [
+                        "null",
+                        "object"
+                    ],
+                    "title": "Benutzerdefinierte Felder",
+                    "description": "Enth\u00e4lt die Daten f\u00fcr die benutzerdefinierten Felder.",
+                    "_zope_schema_type": "PropertySheetField"
+                },
                 "review_state": {
                     "type": "string",
                     "enum": [
@@ -278,7 +287,8 @@
                 "document_author",
                 "preserved_as_paper",
                 "archival_file",
-                "archival_file_state"
+                "archival_file_state",
+                "custom_properties"
             ]
         }
     }

--- a/opengever/document/behaviors/customproperties.py
+++ b/opengever/document/behaviors/customproperties.py
@@ -20,7 +20,7 @@ class IDocumentCustomProperties(model.Schema):
     )
 
     model.fieldset(
-        u'properties',
+        u'custom_properties',
         label=u'Custom properties',
         fields=[
             u'custom_properties',

--- a/opengever/document/behaviors/customproperties.py
+++ b/opengever/document/behaviors/customproperties.py
@@ -1,6 +1,5 @@
 from opengever.propertysheets.assignment import get_document_assignment_slots
 from opengever.propertysheets.field import PropertySheetField
-from plone.autoform import directives as form
 from plone.autoform.interfaces import IFormFieldProvider
 from plone.supermodel import model
 from zope.interface import alsoProvides
@@ -8,8 +7,6 @@ from zope.interface import alsoProvides
 
 class IDocumentCustomProperties(model.Schema):
 
-    # XXX temporarily omit it from classic UI form rendering
-    form.omitted('custom_properties')
     custom_properties = PropertySheetField(
         request_key='form.widgets.IDocumentMetadata.document_type',
         attribute_name='document_type',

--- a/opengever/document/behaviors/customproperties.py
+++ b/opengever/document/behaviors/customproperties.py
@@ -11,9 +11,7 @@ class IDocumentCustomProperties(model.Schema):
         request_key='form.widgets.IDocumentMetadata.document_type',
         attribute_name='document_type',
         assignemnt_prefix='IDocumentMetadata.document_type',
-        title=u'Property sheets with custom properties.',
         valid_assignment_slots_factory=get_document_assignment_slots,
-        required=False,
     )
 
     model.fieldset(

--- a/opengever/document/browser/default_view.py
+++ b/opengever/document/browser/default_view.py
@@ -1,5 +1,6 @@
 from opengever.base.browser.default_view import OGDefaultView
 from opengever.document.interfaces import NO_DOWNLOAD_DISPLAY_MODE
+from opengever.propertysheets.form import omit_custom_properties_group
 
 
 class DocumentDefaultView(OGDefaultView):
@@ -9,6 +10,10 @@ class DocumentDefaultView(OGDefaultView):
     because then it's possible to download a possibly private working copy
     of the file.
     """
+
+    def update(self):
+        super(DocumentDefaultView, self).update()
+        self.groups = omit_custom_properties_group(self.groups)
 
     def updateWidgets(self):
         super(DocumentDefaultView, self).updateWidgets()

--- a/opengever/document/forms.py
+++ b/opengever/document/forms.py
@@ -7,12 +7,13 @@ from opengever.document.behaviors.related_docs import IRelatedDocuments
 from opengever.document.browser.save_pdf_document_under import PDF_SAVE_SOURCE_UUID_KEY
 from opengever.document.browser.save_pdf_document_under import PDF_SAVE_SOURCE_VERSION_KEY
 from opengever.document.document import IDocumentSchema
-from opengever.document.versioner import Versioner
 from opengever.document.interfaces import ICheckinCheckoutManager
 from opengever.document.interfaces import IDocumentSavedAsPDFMarker
 from opengever.document.interfaces import NO_DOWNLOAD_DISPLAY_MODE
 from opengever.document.interfaces import NO_DOWNLOAD_INPUT_MODE
+from opengever.document.versioner import Versioner
 from opengever.dossier.base import DOSSIER_STATES_OPEN
+from opengever.propertysheets.form import omit_custom_properties_group
 from plone import api
 from plone.autoform import directives
 from plone.dexterity.browser import add
@@ -21,14 +22,14 @@ from plone.dexterity.events import EditFinishedEvent
 from plone.dexterity.utils import iterSchemataForType
 from plone.uuid.interfaces import IUUID
 from plone.z3cform import layout
-from zope.annotation import IAnnotations
 from z3c.form import button
 from z3c.form import field
 from z3c.form import form
 from z3c.form import validator
 from z3c.form.interfaces import HIDDEN_MODE
-from z3c.relationfield.schema import RelationChoice
 from z3c.relationfield.relation import RelationValue
+from z3c.relationfield.schema import RelationChoice
+from zope.annotation import IAnnotations
 from zope.component import getUtility
 from zope.component import queryMultiAdapter
 from zope.event import notify
@@ -50,6 +51,10 @@ class DocumentAddForm(add.DefaultAddForm):
     # errors for this add form.
     _nullify_file_on_error = True
 
+    def updateFields(self):
+        super(DocumentAddForm, self).updateFields()
+        self.groups = omit_custom_properties_group(self.groups)
+
 
 class DocumentAddView(add.DefaultAddView):
     """Provide a registerable view for the Document file upload form."""
@@ -61,6 +66,10 @@ class DocumentEditForm(DefaultEditForm):
     """Custom edit form for documents, which displays some
     different and customized edit modes.
     """
+
+    def updateFields(self):
+        super(DocumentEditForm, self).updateFields()
+        self.groups = omit_custom_properties_group(self.groups)
 
     def updateWidgets(self):
         """Using document specific formwidget.namedfile modes.

--- a/opengever/propertysheets/annotation.py
+++ b/opengever/propertysheets/annotation.py
@@ -49,7 +49,7 @@ class CustomPropertiesStorageImpl(AnnotationsFactoryImpl):
                 # initialize annotations with `None` as this is expected by the
                 # default value patches.
                 if prefixed_name not in self.__dict__['annotations']:
-                    self.__dict__['annotations'][prefixed_name] = value
+                    self.__dict__['annotations'][prefixed_name] = None
                 return
 
             # for not `None` values always validate type first

--- a/opengever/propertysheets/configure.zcml
+++ b/opengever/propertysheets/configure.zcml
@@ -20,5 +20,6 @@
       />
 
   <adapter factory=".field.PropertySheetFieldSchemaProvider" />
+  <adapter factory=".field.PropertySheetFieldDataConverter" />
 
 </configure>

--- a/opengever/propertysheets/configure.zcml
+++ b/opengever/propertysheets/configure.zcml
@@ -7,6 +7,8 @@
     xmlns:z3c="http://namespaces.zope.org/z3c"
     i18n_domain="opengever.propertysheets">
 
+  <i18n:registerTranslations directory="locales" />
+
   <include package=".api" />
 
   <utility

--- a/opengever/propertysheets/configure.zcml
+++ b/opengever/propertysheets/configure.zcml
@@ -19,4 +19,6 @@
       name="opengever.propertysheets.PropertySheetAssignmentsVocabulary"
       />
 
+  <adapter factory=".field.PropertySheetFieldSchemaProvider" />
+
 </configure>

--- a/opengever/propertysheets/field.py
+++ b/opengever/propertysheets/field.py
@@ -156,15 +156,27 @@ class PropertySheetFieldSchemaProvider(DefaultJsonSchemaProvider):
             field, context, request
         )
 
-    def get_schema(self):
-        sheets_for_portal_type = {}
+        self.sheets_by_slots = {}
         storage = PropertySheetSchemaStorage()
         for slot_name in self.field.valid_assignment_slots_factory():
             definition = storage.query(slot_name)
             if definition is not None:
-                sheets_for_portal_type[slot_name] = definition.get_json_schema()
+                self.sheets_by_slots[slot_name] = definition.get_json_schema()
 
-        return sheets_for_portal_type
+    def additional(self):
+        """Additional info for field."""
+        if not self.sheets_by_slots:
+            return {}
+
+        return {
+            "properties": self.sheets_by_slots
+        }
+
+    def get_type(self):
+        return "object" if self.sheets_by_slots else "null"
+
+    def get_widget_params(self):
+        return None
 
 
 @adapter(IPropertySheetField, IWidget)

--- a/opengever/propertysheets/field.py
+++ b/opengever/propertysheets/field.py
@@ -58,6 +58,16 @@ class PropertySheetField(JSONField):
         self.assignemnt_prefix = assignemnt_prefix
         self.valid_assignment_slots_factory = valid_assignment_slots_factory
 
+        for name in ("title", "required"):
+            if name in kwargs:
+                raise TypeError(
+                    "Static value for argument '{}' cannot be "
+                    "overwritten via keyword argument.".format(name)
+                )
+
+        kwargs["title"] = u'Property sheets with custom properties'
+        kwargs["required"] = False
+
         super(PropertySheetField, self).__init__(**kwargs)
 
     def _validate(self, value):

--- a/opengever/propertysheets/field.py
+++ b/opengever/propertysheets/field.py
@@ -1,3 +1,4 @@
+from opengever.propertysheets import _
 from opengever.propertysheets.storage import PropertySheetSchemaStorage
 from plone.restapi.serializer.converters import json_compatible
 from plone.restapi.types.adapters import DefaultJsonSchemaProvider
@@ -65,7 +66,10 @@ class PropertySheetField(JSONField):
                     "overwritten via keyword argument.".format(name)
                 )
 
-        kwargs["title"] = u'Property sheets with custom properties'
+        kwargs["title"] = _(u"Custom properties")
+        kwargs["description"] = _(
+            u"Contains data for user defined custom properties."
+        )
         kwargs["required"] = False
 
         super(PropertySheetField, self).__init__(**kwargs)

--- a/opengever/propertysheets/field.py
+++ b/opengever/propertysheets/field.py
@@ -1,8 +1,12 @@
 from opengever.propertysheets.storage import PropertySheetSchemaStorage
+from plone.restapi.serializer.converters import json_compatible
 from plone.restapi.types.adapters import DefaultJsonSchemaProvider
 from plone.restapi.types.interfaces import IJsonSchemaProvider
 from plone.schema import IJSONField
 from plone.schema import JSONField
+from plone.schema.browser.jsonfield import JSONDataConverter
+from z3c.form.interfaces import IDataConverter
+from z3c.form.interfaces import IWidget
 from zope.component import adapter
 from zope.globalrequest import getRequest
 from zope.interface import implementer
@@ -151,3 +155,14 @@ class PropertySheetFieldSchemaProvider(DefaultJsonSchemaProvider):
                 sheets_for_portal_type[slot_name] = definition.get_json_schema()
 
         return sheets_for_portal_type
+
+
+@adapter(IPropertySheetField, IWidget)
+@implementer(IDataConverter)
+class PropertySheetFieldDataConverter(JSONDataConverter):
+
+    def toWidgetValue(self, value):
+        """Make sure to convert persistent dicts to json compatible data."""
+
+        value = json_compatible(value)
+        return super(PropertySheetFieldDataConverter, self).toWidgetValue(value)

--- a/opengever/propertysheets/form.py
+++ b/opengever/propertysheets/form.py
@@ -1,0 +1,10 @@
+GROUPNAME = "custom_properties"
+
+
+def omit_custom_properties_group(form_groups):
+    """Filter out the form group `custom_properties`.
+
+    XXX Temporary workaround so we can move forward with custom properties in
+    API `@schema` endpoint without proper classic UI support.
+    """
+    return [group for group in form_groups if group.__name__ != GROUPNAME]

--- a/opengever/propertysheets/locales/de/LC_MESSAGES/opengever.propertysheets.po
+++ b/opengever/propertysheets/locales/de/LC_MESSAGES/opengever.propertysheets.po
@@ -1,0 +1,23 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"POT-Creation-Date: 2021-01-20 09:20+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0\n"
+"Language-Code: en\n"
+"Language-Name: English\n"
+"Preferred-Encodings: utf-8 latin1\n"
+"Domain: DOMAIN\n"
+
+#: ./opengever/propertysheets/field.py
+msgid "Contains data for user defined custom properties."
+msgstr "Enthält die Daten für die benutzerdefinierten Felder."
+
+#: ./opengever/propertysheets/field.py
+msgid "Custom properties"
+msgstr "Benutzerdefinierte Felder"

--- a/opengever/propertysheets/locales/en/LC_MESSAGES/opengever.propertysheets.po
+++ b/opengever/propertysheets/locales/en/LC_MESSAGES/opengever.propertysheets.po
@@ -1,0 +1,23 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"POT-Creation-Date: 2021-01-20 09:20+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0\n"
+"Language-Code: en\n"
+"Language-Name: English\n"
+"Preferred-Encodings: utf-8 latin1\n"
+"Domain: DOMAIN\n"
+
+#: ./opengever/propertysheets/field.py
+msgid "Contains data for user defined custom properties."
+msgstr "Contains data for user defined custom properties."
+
+#: ./opengever/propertysheets/field.py
+msgid "Custom properties"
+msgstr "Custom properties"

--- a/opengever/propertysheets/locales/fr/LC_MESSAGES/opengever.propertysheets.po
+++ b/opengever/propertysheets/locales/fr/LC_MESSAGES/opengever.propertysheets.po
@@ -1,0 +1,23 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"POT-Creation-Date: 2021-01-20 09:20+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0\n"
+"Language-Code: en\n"
+"Language-Name: English\n"
+"Preferred-Encodings: utf-8 latin1\n"
+"Domain: DOMAIN\n"
+
+#: ./opengever/propertysheets/field.py
+msgid "Contains data for user defined custom properties."
+msgstr "Contient les données pour les champ personnalisés."
+
+#: ./opengever/propertysheets/field.py
+msgid "Custom properties"
+msgstr "Champs personnalisés"

--- a/opengever/propertysheets/locales/opengever.propertysheets.pot
+++ b/opengever/propertysheets/locales/opengever.propertysheets.pot
@@ -1,0 +1,26 @@
+# --- PLEASE EDIT THE LINES BELOW CORRECTLY ---
+# SOME DESCRIPTIVE TITLE.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"POT-Creation-Date: 2021-01-20 09:20+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0\n"
+"Language-Code: en\n"
+"Language-Name: English\n"
+"Preferred-Encodings: utf-8 latin1\n"
+"Domain: opengever.propertysheets\n"
+
+#: ./opengever/propertysheets/field.py
+msgid "Contains data for user defined custom properties."
+msgstr ""
+
+#: ./opengever/propertysheets/field.py
+msgid "Custom properties"
+msgstr ""

--- a/opengever/propertysheets/tests/fixture.py
+++ b/opengever/propertysheets/tests/fixture.py
@@ -1,0 +1,5 @@
+def fixture_assignment_factory():
+    return [
+        u"IDocumentMetadata.document_type.contract",
+        u"IDocumentMetadata.document_type.question",
+    ]

--- a/opengever/propertysheets/tests/test_annotation.py
+++ b/opengever/propertysheets/tests/test_annotation.py
@@ -24,7 +24,6 @@ class ITestFixtureWithCustomProperties(model.Schema):
         attribute_name='some_attribute',
         assignemnt_prefix=DOCUMENT_TYPE_ASSIGNMENT_SLOT_PREFIX,
         valid_assignment_slots_factory=fixture_assignment_factory,
-        required=False,
     )
 
 

--- a/opengever/propertysheets/tests/test_document_custom_properties.py
+++ b/opengever/propertysheets/tests/test_document_custom_properties.py
@@ -156,7 +156,6 @@ class TestDocumentCustomPropertiesPatch(IntegrationTestCase):
             IDocumentCustomProperties(self.document).custom_properties,
         )
 
-
     @browsing
     def test_allows_other_valid_property_sheet_fields_next_to_selected_assignment(self, browser):
         self.login(self.manager, browser)
@@ -192,6 +191,7 @@ class TestDocumentCustomPropertiesPatch(IntegrationTestCase):
             good_data["custom_properties"],
             IDocumentCustomProperties(self.document).custom_properties,
         )
+
 
 class TestDocumentCustomPropertiesPost(IntegrationTestCase):
 

--- a/opengever/propertysheets/tests/test_document_overview.py
+++ b/opengever/propertysheets/tests/test_document_overview.py
@@ -1,0 +1,36 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.testbrowser import browsing
+from opengever.document.behaviors.customproperties import IDocumentCustomProperties
+from opengever.testing import IntegrationTestCase
+
+
+class TestDocumentOverviewWithCustomProperties(IntegrationTestCase):
+
+    @browsing
+    def test_document_overview_renders_correctly_when_custom_properties_are_set(
+        self, browser
+    ):
+        self.login(self.manager)
+        create(
+            Builder("property_sheet_schema")
+            .named("schema")
+            .assigned_to_slots(u"IDocumentMetadata.document_type.question")
+            .with_field("text", u"foo", u"some input", u"", True)
+        )
+        self.document.document_type = u"question"
+        IDocumentCustomProperties(self.document).custom_properties = {
+            u"IDocumentMetadata.document_type.question": {u"foo": u"qux"}
+        }
+
+        self.login(self.regular_user, browser)
+        # smoke-test will result in error when data converter raises
+        browser.open(self.document, view="tabbedview_view-overview")
+
+        # double check we have rendered a good page
+        self.assertEqual(
+            u"Inquiry",
+            browser.css(
+                "#form-widgets-IDocumentMetadata-document_type"
+            ).first.text,
+        )

--- a/opengever/propertysheets/tests/test_field.py
+++ b/opengever/propertysheets/tests/test_field.py
@@ -3,17 +3,11 @@ from ftw.builder import create
 from mock import Mock
 from opengever.propertysheets.assignment import DOCUMENT_TYPE_ASSIGNMENT_SLOT_PREFIX
 from opengever.propertysheets.field import PropertySheetField
+from opengever.propertysheets.tests.fixture import fixture_assignment_factory
 from opengever.testing import FunctionalTestCase
 from zope.schema import ValidationError
 from zope.schema.interfaces import RequiredMissing
 from zope.schema.interfaces import WrongType
-
-
-def fixture_assignment_factory():
-    return [
-        u"IDocumentMetadata.document_type.contract",
-        u"IDocumentMetadata.document_type.question",
-    ]
 
 
 class TestPropertySheetField(FunctionalTestCase):

--- a/opengever/propertysheets/tests/test_field.py
+++ b/opengever/propertysheets/tests/test_field.py
@@ -203,3 +203,31 @@ class TestPropertySheetField(FunctionalTestCase):
         field.validate(
             {"IDocumentMetadata.document_type.question": {"yesorno": True}}
         )
+
+    def test_does_not_accept_title_parameter(self):
+        with self.assertRaises(TypeError) as cm:
+            PropertySheetField(
+                "some_request_key",
+                "some_attribute",
+                "some_prefix",
+                lambda: [],
+                title="foo"
+        )
+        self.assertEqual(
+            "Static value for argument 'title' cannot be overwritten via "
+            "keyword argument.",
+            cm.exception.message)
+
+    def test_does_not_accept_required_parameter(self):
+        with self.assertRaises(TypeError) as cm:
+            PropertySheetField(
+                "some_request_key",
+                "some_attribute",
+                "some_prefix",
+                lambda: [],
+                required=True
+        )
+        self.assertEqual(
+            "Static value for argument 'required' cannot be overwritten via "
+            "keyword argument.",
+            cm.exception.message)

--- a/opengever/propertysheets/tests/test_field_schema_provider.py
+++ b/opengever/propertysheets/tests/test_field_schema_provider.py
@@ -49,8 +49,8 @@ class TestPropertySheetFieldSchemaProvider(FunctionalTestCase):
         json_schema = self.schema_provider.get_schema()
         expected = {
             "type": "object",
-            "title": u"Property sheets with custom properties",
-            "description": "",
+            "title": u"Custom properties",
+            "description": u"Contains data for user defined custom properties.",
             "properties": {
                 u"IDocumentMetadata.document_type.question": {
                     "assignments": [
@@ -118,8 +118,8 @@ class TestPropertySheetFieldSchemaProvider(FunctionalTestCase):
         json_schema = self.schema_provider.get_schema()
         self.assertEqual(
             {
-                "description": u"",
-                "title": u"Property sheets with custom properties",
+                "description": u"Contains data for user defined custom properties.",
+                "title": u"Custom properties",
                 "type": "null",
             },
             json_schema,

--- a/opengever/propertysheets/tests/test_field_schema_provider.py
+++ b/opengever/propertysheets/tests/test_field_schema_provider.py
@@ -1,5 +1,6 @@
 from ftw.builder import Builder
 from ftw.builder import create
+from jsonschema import Draft4Validator
 from opengever.propertysheets.assignment import DOCUMENT_TYPE_ASSIGNMENT_SLOT_PREFIX
 from opengever.propertysheets.field import PropertySheetField
 from opengever.propertysheets.tests.fixture import fixture_assignment_factory
@@ -21,7 +22,10 @@ class TestPropertySheetFieldSchemaProvider(FunctionalTestCase):
             DOCUMENT_TYPE_ASSIGNMENT_SLOT_PREFIX,
             fixture_assignment_factory,
         )
-        self.schema_provider = getMultiAdapter(
+
+    @property
+    def schema_provider(self):
+        return getMultiAdapter(
             (self.field, self.portal, self.request), IJsonSchemaProvider
         )
 
@@ -44,34 +48,42 @@ class TestPropertySheetFieldSchemaProvider(FunctionalTestCase):
 
         json_schema = self.schema_provider.get_schema()
         expected = {
-            u"IDocumentMetadata.document_type.question": {
-                "assignments": [
-                    u"IDocumentMetadata.document_type.question",
-                    u"IDocumentMetadata.document_type.offer",
-                ],
-                "fieldsets": [
-                    {
-                        "behavior": "plone",
-                        "fields": ["foo"],
-                        "id": "default",
-                        "title": "Default",
-                    }
-                ],
-                "properties": {
-                    u"foo": {
-                        u"description": u"",
-                        u"factory": u"Text",
-                        u"title": u"some input",
-                        u"type": u"string",
-                        u"widget": u"textarea",
-                    }
-                },
-                "required": ["foo"],
-                "title": "schema",
-                "type": "object",
-            }
+            "type": "object",
+            "title": u"Property sheets with custom properties",
+            "description": "",
+            "properties": {
+                u"IDocumentMetadata.document_type.question": {
+                    "assignments": [
+                        u"IDocumentMetadata.document_type.question",
+                        u"IDocumentMetadata.document_type.offer",
+                    ],
+                    "fieldsets": [
+                        {
+                            "behavior": "plone",
+                            "fields": ["foo"],
+                            "id": "default",
+                            "title": "Default",
+                        }
+                    ],
+                    "properties": {
+                        u"foo": {
+                            u"description": u"",
+                            u"factory": u"Text",
+                            u"title": u"some input",
+                            u"type": u"string",
+                            u"widget": u"textarea",
+                        }
+                    },
+                    "required": ["foo"],
+                    "title": "schema",
+                    "type": "object",
+                }
+            },
         }
         self.assertEqual(expected, json_schema)
+
+        # smoke-test to validate the schema
+        Draft4Validator.check_schema(json_schema)
 
     def test_sheet_assigned_to_multiple_slots_is_serialized_for_each_slot(
         self,
@@ -87,15 +99,31 @@ class TestPropertySheetFieldSchemaProvider(FunctionalTestCase):
         )
 
         json_schema = self.schema_provider.get_schema()
+        schema_properties = json_schema["properties"]
 
-        self.assertIn("IDocumentMetadata.document_type.contract", json_schema)
-        self.assertIn("IDocumentMetadata.document_type.question", json_schema)
+        self.assertIn(
+            "IDocumentMetadata.document_type.contract",
+            schema_properties,
+        )
+        self.assertIn(
+            "IDocumentMetadata.document_type.question",
+            schema_properties,
+        )
         self.assertEqual(
-            json_schema["IDocumentMetadata.document_type.question"],
-            json_schema["IDocumentMetadata.document_type.question"],
+            schema_properties["IDocumentMetadata.document_type.contract"],
+            schema_properties["IDocumentMetadata.document_type.question"],
         )
 
     def test_returns_empty_dict_when_no_schemas_are_available(self):
-
         json_schema = self.schema_provider.get_schema()
-        self.assertEqual({}, json_schema)
+        self.assertEqual(
+            {
+                "description": u"",
+                "title": u"Property sheets with custom properties",
+                "type": "null",
+            },
+            json_schema,
+        )
+
+        # smoke-test to validate the schema
+        Draft4Validator.check_schema(json_schema)

--- a/opengever/propertysheets/tests/test_field_schema_provider.py
+++ b/opengever/propertysheets/tests/test_field_schema_provider.py
@@ -1,0 +1,101 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from opengever.propertysheets.assignment import DOCUMENT_TYPE_ASSIGNMENT_SLOT_PREFIX
+from opengever.propertysheets.field import PropertySheetField
+from opengever.propertysheets.tests.fixture import fixture_assignment_factory
+from opengever.testing import FunctionalTestCase
+from plone.restapi.types.interfaces import IJsonSchemaProvider
+from zope.component import getMultiAdapter
+
+
+class TestPropertySheetFieldSchemaProvider(FunctionalTestCase):
+
+    maxDiff = None
+
+    def setUp(self):
+        super(TestPropertySheetFieldSchemaProvider, self).setUp()
+
+        self.field = PropertySheetField(
+            "unused_request_key",
+            "unused_attribute",
+            DOCUMENT_TYPE_ASSIGNMENT_SLOT_PREFIX,
+            fixture_assignment_factory,
+        )
+        self.schema_provider = getMultiAdapter(
+            (self.field, self.portal, self.request), IJsonSchemaProvider
+        )
+
+    def test_returns_json_schema_only_for_assignment_slots(self):
+        create(
+            Builder("property_sheet_schema")
+            .named("schema")
+            .assigned_to_slots(
+                u"IDocumentMetadata.document_type.question",
+                u"IDocumentMetadata.document_type.offer",  # not in factory
+            )
+            .with_field("text", u"foo", u"some input", u"", True)
+        )
+        create(
+            Builder("property_sheet_schema")
+            .named("not_inlcuded")
+            .assigned_to_slots(u"IDocumentMetadata.document_type.request")
+            .with_field("text", u"bar", u"discard me", u"", False)
+        )
+
+        json_schema = self.schema_provider.get_schema()
+        expected = {
+            u"IDocumentMetadata.document_type.question": {
+                "assignments": [
+                    u"IDocumentMetadata.document_type.question",
+                    u"IDocumentMetadata.document_type.offer",
+                ],
+                "fieldsets": [
+                    {
+                        "behavior": "plone",
+                        "fields": ["foo"],
+                        "id": "default",
+                        "title": "Default",
+                    }
+                ],
+                "properties": {
+                    u"foo": {
+                        u"description": u"",
+                        u"factory": u"Text",
+                        u"title": u"some input",
+                        u"type": u"string",
+                        u"widget": u"textarea",
+                    }
+                },
+                "required": ["foo"],
+                "title": "schema",
+                "type": "object",
+            }
+        }
+        self.assertEqual(expected, json_schema)
+
+    def test_sheet_assigned_to_multiple_slots_is_serialized_for_each_slot(
+        self,
+    ):
+        create(
+            Builder("property_sheet_schema")
+            .named("schema")
+            .assigned_to_slots(
+                u"IDocumentMetadata.document_type.contract",
+                u"IDocumentMetadata.document_type.question",
+            )
+            .with_field("text", u"foo", u"some input", u"", True)
+        )
+
+        json_schema = self.schema_provider.get_schema()
+
+        self.assertIn("IDocumentMetadata.document_type.contract", json_schema)
+        self.assertIn("IDocumentMetadata.document_type.question", json_schema)
+        self.assertEqual(
+            json_schema["IDocumentMetadata.document_type.question"],
+            json_schema["IDocumentMetadata.document_type.question"],
+        )
+
+    def test_returns_empty_dict_when_no_schemas_are_available(self):
+
+        json_schema = self.schema_provider.get_schema()
+        self.assertEqual({}, json_schema)

--- a/opengever/propertysheets/tests/test_mail_overview.py
+++ b/opengever/propertysheets/tests/test_mail_overview.py
@@ -1,0 +1,37 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.testbrowser import browsing
+from opengever.document.behaviors.customproperties import IDocumentCustomProperties
+from opengever.testing import IntegrationTestCase
+
+
+class TestMailOverviewWithCustomProperties(IntegrationTestCase):
+
+    @browsing
+    def test_mail_overview_renders_correctly_when_custom_properties_are_set(
+        self, browser
+    ):
+        self.login(self.manager)
+        create(
+            Builder("property_sheet_schema")
+            .named("schema")
+            .assigned_to_slots(u"IDocumentMetadata.document_type.question")
+            .with_field("text", u"foo", u"some input", u"", True)
+        )
+        self.mail_eml.document_type = u"question"
+        IDocumentCustomProperties(self.mail_eml).custom_properties = {
+            u"IDocumentMetadata.document_type.question": {u"foo": u"qux"}
+        }
+
+        self.login(self.regular_user, browser)
+
+        # smoke-test will result in error when data converter raises
+        browser.open(self.mail_eml, view="tabbedview_view-overview")
+
+        # double check we have rendered a good page
+        self.assertEqual(
+            u"Inquiry",
+            browser.css(
+                "#form-widgets-IDocumentMetadata-document_type"
+            ).first.text,
+        )

--- a/opengever/propertysheets/tests/test_schema_endpoint.py
+++ b/opengever/propertysheets/tests/test_schema_endpoint.py
@@ -1,0 +1,88 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.testbrowser import browsing
+from jsonschema import Draft4Validator
+from opengever.testing import IntegrationTestCase
+
+
+class TestCustomPropertiesFieldSchemaEndpoint(IntegrationTestCase):
+
+    @browsing
+    def test_document_schema_contains_available_property_sheet(self, browser):
+        create(
+            Builder("property_sheet_schema")
+            .named("schema")
+            .assigned_to_slots(u"IDocumentMetadata.document_type.question")
+            .with_field("text", u"foo", u"some input", u"", True)
+        )
+
+        self.login(self.regular_user, browser)
+        schema = browser.open(
+            self.leaf_repofolder,
+            view="@schema/opengever.document.document",
+            method="GET",
+            headers=self.api_headers,
+        ).json
+
+        # we just validate presence of the schema, serialization of the
+        # complete schema is tested in functional tests
+
+        self.assertIsNotNone(browser.json["properties"]["custom_properties"])
+        self.assertIn(
+            "IDocumentMetadata.document_type.question",
+            browser.json["properties"]["custom_properties"],
+        )
+
+        # smoke-test to validate the schema
+        Draft4Validator.check_schema(schema)
+
+    @browsing
+    def test_sheet_assigned_to_multiple_slots_is_serialized_for_each_slot(
+        self, browser
+    ):
+        create(
+            Builder("property_sheet_schema")
+            .named("schema")
+            .assigned_to_slots(
+                u"IDocumentMetadata.document_type.contract",
+                u"IDocumentMetadata.document_type.question",
+            )
+            .with_field("text", u"foo", u"some input", u"", True)
+        )
+
+        self.login(self.regular_user, browser)
+        schema = browser.open(
+            self.leaf_repofolder,
+            view="@schema/opengever.document.document",
+            method="GET",
+            headers=self.api_headers,
+        ).json
+
+        # we just validate presence of the schema, serialization of the
+        # complete schema is tested in functional tests
+
+        self.assertIsNotNone(browser.json["properties"]["custom_properties"])
+        props = browser.json["properties"]["custom_properties"]
+        self.assertIn("IDocumentMetadata.document_type.contract", props)
+        self.assertIn("IDocumentMetadata.document_type.question", props)
+        self.assertEqual(
+            props["IDocumentMetadata.document_type.question"],
+            props["IDocumentMetadata.document_type.question"],
+        )
+
+        # smoke-test to validate the schema
+        Draft4Validator.check_schema(schema)
+
+    @browsing
+    def test_representation_when_no_schemas_are_available(self, browser):
+
+        self.login(self.regular_user, browser)
+        schema = browser.open(
+            self.leaf_repofolder,
+            view="@schema/opengever.document.document",
+            method="GET",
+            headers=self.api_headers,
+        ).json
+
+        # smoke-test to validate the schema
+        Draft4Validator.check_schema(schema)

--- a/opengever/propertysheets/tests/test_schema_endpoint.py
+++ b/opengever/propertysheets/tests/test_schema_endpoint.py
@@ -88,8 +88,8 @@ class TestCustomPropertiesFieldSchemaEndpoint(IntegrationTestCase):
         self.assertEqual(
             {
                 u"behavior": u"opengever.document.behaviors.customproperties.IDocumentCustomProperties",
-                u"description": u"",
-                u"title": u"Property sheets with custom properties",
+                u"description": u'Contains data for user defined custom properties.',
+                u"title": u"Custom properties",
                 u"type": u"null",
             },
             schema["properties"]["custom_properties"],

--- a/opengever/propertysheets/tests/test_schema_endpoint.py
+++ b/opengever/propertysheets/tests/test_schema_endpoint.py
@@ -24,17 +24,17 @@ class TestCustomPropertiesFieldSchemaEndpoint(IntegrationTestCase):
             headers=self.api_headers,
         ).json
 
-        # we just validate presence of the schema, serialization of the
-        # complete schema is tested in functional tests
-
-        self.assertIsNotNone(browser.json["properties"]["custom_properties"])
-        self.assertIn(
-            "IDocumentMetadata.document_type.question",
-            browser.json["properties"]["custom_properties"],
-        )
-
         # smoke-test to validate the schema
         Draft4Validator.check_schema(schema)
+
+        props = schema["properties"]["custom_properties"]["properties"]
+        # we just validate presence of the schema, serialization of the
+        # complete schema is tested in functional tests
+        self.assertIsNotNone(props)
+        self.assertIn(
+            "IDocumentMetadata.document_type.question",
+            props,
+        )
 
     @browsing
     def test_sheet_assigned_to_multiple_slots_is_serialized_for_each_slot(
@@ -58,11 +58,13 @@ class TestCustomPropertiesFieldSchemaEndpoint(IntegrationTestCase):
             headers=self.api_headers,
         ).json
 
+        # smoke-test to validate the schema
+        Draft4Validator.check_schema(schema)
+
+        props = schema["properties"]["custom_properties"]["properties"]
         # we just validate presence of the schema, serialization of the
         # complete schema is tested in functional tests
-
-        self.assertIsNotNone(browser.json["properties"]["custom_properties"])
-        props = browser.json["properties"]["custom_properties"]
+        self.assertIsNotNone(props)
         self.assertIn("IDocumentMetadata.document_type.contract", props)
         self.assertIn("IDocumentMetadata.document_type.question", props)
         self.assertEqual(
@@ -70,12 +72,8 @@ class TestCustomPropertiesFieldSchemaEndpoint(IntegrationTestCase):
             props["IDocumentMetadata.document_type.question"],
         )
 
-        # smoke-test to validate the schema
-        Draft4Validator.check_schema(schema)
-
     @browsing
     def test_representation_when_no_schemas_are_available(self, browser):
-
         self.login(self.regular_user, browser)
         schema = browser.open(
             self.leaf_repofolder,
@@ -86,3 +84,13 @@ class TestCustomPropertiesFieldSchemaEndpoint(IntegrationTestCase):
 
         # smoke-test to validate the schema
         Draft4Validator.check_schema(schema)
+
+        self.assertEqual(
+            {
+                u"behavior": u"opengever.document.behaviors.customproperties.IDocumentCustomProperties",
+                u"description": u"",
+                u"title": u"Property sheets with custom properties",
+                u"type": u"null",
+            },
+            schema["properties"]["custom_properties"],
+        )


### PR DESCRIPTION
With this PR we expose the schemas for user defined property sheets in the `@schema` endpoint. There are two possible representations. When there are no property sheets filling the content types slots, the schema will look as follows:

```JSON
{
   "custom_properties":{
      "description":"Contains data for user defined custom properties.",
      "title":"Custom properties",
      "type":"null"
   }
}
```

When there are property sheets available for one or multiple slots, they will be described in json schema as follows:
```JSON
{
   "custom_properties":{
      "type":"object",
      "title":"Custom properties",
      "description":"Contains data for user defined custom properties.",
      "properties":{
         "IDocumentMetadata.document_type.question":{
            "assignments":[
               "IDocumentMetadata.document_type.question",
               "IDocumentMetadata.document_type.offer"
            ],
            "fieldsets":[
               {
                  "behavior":"plone",
                  "fields":[
                     "foo"
                  ],
                  "id":"default",
                  "title":"Default"
               }
            ],
            "properties":{
               "foo":{
                  "description":"",
                  "factory":"Text",
                  "title":"some input",
                  "type":"string",
                  "widget":"textarea"
               }
            },
            "required":[
               "foo"
            ],
            "title":"schema",
            "type":"object"
         }
      }
   }
}
```

To keep things simple for now we have refrained from using references to schema definitions. If the same schema is used in multiple slots, it will be serialized multiple times.

Unfortunately things were not as straightforward as i was first hoping for. Due to the way `plone.restapi` uses a temporary form to construct FTI schemas i had to get rid of the form hint in the `IDocumentCustomProperties` behavior. To prevent the field from appearing in the forms as plain JSON field i am adding temporary form hints to all affected add and edit forms. We will implement classic UI support with https://4teamwork.atlassian.net/browse/CA-1284 soon, so the hints will be temporary.

The following changes are also included:
- Set up translation machinery and provide proper translations for the `propertysheets` package.
- Make API changelog more prominent in docs and improve link labelling in links from changelog to pages of the documentation. This may be disputable and the separate commits can easily be dropped in case of disagreement.

Jira: https://4teamwork.atlassian.net/browse/CA-1280

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


## Checklist (if applicable)

_Only applicable should be left and checked._

- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
- New functionality:
  - [x] for `document` also works for `mail`
- New translations
  - [x] All msg-strings are unicode
