### PR TITLE
Fix deactivating committees with canceled meeting.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,7 @@ Changelog
 2021.3.0 (unreleased)
 ---------------------
 
-- Nothing changed yet.
+- Fix deactivating committees with canceled meetings. [deiferni]
 
 
 2021.2.0 (2021-01-20)

--- a/opengever/meeting/model/query.py
+++ b/opengever/meeting/model/query.py
@@ -231,7 +231,10 @@ class MeetingQuery(BaseQuery):
 
     def pending_meetings(self, committee):
         query = self._committee_meetings(committee)
-        query = query.filter(Meeting.workflow_state != Meeting.STATE_CLOSED.name)
+        query = query.filter(
+            Meeting.workflow_state != Meeting.STATE_CLOSED.name,
+            Meeting.workflow_state != Meeting.STATE_CANCELLED.name
+        )
         query = query.order_by(Meeting.start.desc())
         return query
 


### PR DESCRIPTION
With this PR we fix deactivating committees with canceled meetings inside.

The query used in the guard to detect if the committee can be deactivated did not consider canceled meetings.

Jira: https://4teamwork.atlassian.net/browse/CA-1397

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
