### PR TITLE
Implement POST @notifications endpoint to mark notifications as read.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -10,6 +10,7 @@ Changelog
 - Include custom properties in JSON schema for documents and mails in the `@schema` endpoint. [deiferni]
 - Index getObjPositionInParent for sequential tasks and sort them on getObjPositionInParent in @tasktree endpoint. [tinagerber]
 - Add is_task_addable_in_main_task and is_task_addable_before attributes to @tasktree endpoint. [tinagerber]
+- Implement POST @notifications endpoint to mark all notifications as read. [tinagerber]
 
 
 2021.2.0 (2021-01-20)

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -18,6 +18,7 @@ Other Changes
 
 - The field ``custom_properties`` is now included in the ``@schema`` endpoint for Documents and Mails (see :ref:`content-types`).
 - ``@tasktree``: Attributes ``is_task_addable_in_main_task`` and ``is_task_addable_before`` added (see :ref:`docs <tasktree>`).
+- ``@notifications``: request method POST is added to mark all notifications as read (see :ref:`docs <mark-notifications-as-read>`).
 
 
 2021.2.0 (2021-01-20)

--- a/docs/public/dev-manual/api/notifications.rst
+++ b/docs/public/dev-manual/api/notifications.rst
@@ -116,6 +116,32 @@ Durch einen PATCH-Request kann eine Benachrichtigung als gelesen markiert werden
 
       HTTP/1.1 204 No Content
 
+.. _mark-notifications-as-read:
+
+Alle Benachrichtigungen als gelesen markieren
+---------------------------------------------
+Durch einen POST-Request können alle Benachrichtigungen als gelesen markiert werden:
+
+
+**Beispiel-Request**:
+
+   .. sourcecode:: http
+
+       POST /@notifications/peter.mueller/3 HTTP/1.1
+       Accept: application/json
+
+       {
+        "mark_all_notifications_as_read": true,
+        "latest_client_side_notification": 215
+       }
+
+
+**Beispiel-Response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 204 No Content
+
 
 Benachrichtigungen unterdrücken
 -------------------------------

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -397,6 +397,14 @@
       />
 
   <plone:service
+      method="POST"
+      name="@notifications"
+      for="Products.CMFPlone.interfaces.IPloneSiteRoot"
+      factory=".notifications.NotificationsPost"
+      permission="zope2.View"
+      />
+
+  <plone:service
       method="GET"
       for="zope.interface.Interface"
       factory=".listing.ListingGet"


### PR DESCRIPTION
We want to be able to mark all notifications as read in the new frontend. For this purpose, the POST method for the @notifications endpoint is implemented. Specified by @deiferni 

Jira: https://4teamwork.atlassian.net/browse/NE-185

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


## Checklist (if applicable)

_Only applicable should be left and checked._

- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))