### PR TITLE
Use a vocabulary for an instant users-list in the frontend for workspace meetings

### DIFF
--- a/opengever/api/tests/test_vocabularies.py
+++ b/opengever/api/tests/test_vocabularies.py
@@ -60,6 +60,7 @@ NON_SENSITIVE_VOCABUALRIES = [
     'opengever.tasktemplates.active_tasktemplatefolders',
     'opengever.tasktemplates.ResponsibleOrgUnitVocabulary',
     'opengever.tasktemplates.tasktemplates',
+    'opengever.workspace.ActualWorkspaceMembersVocabulary',
     'opengever.workspace.PossibleWorkspaceFolderParticipantsVocabulary',
     'opengever.workspace.RolesVocabulary',
     'plone.app.content.ValidAddableTypes',

--- a/opengever/workspace/configure.zcml
+++ b/opengever/workspace/configure.zcml
@@ -63,6 +63,11 @@
       name="opengever.workspace.PossibleWorkspaceFolderParticipantsVocabulary"
       />
 
+  <utility
+      factory=".vocabularies.ActualWorkspaceMembersVocabulary"
+      name="opengever.workspace.ActualWorkspaceMembersVocabulary"
+      />
+
   <adapter
       factory=".indexers.external_reference"
       name="external_reference"

--- a/opengever/workspace/tests/test_workspace_meeting.py
+++ b/opengever/workspace/tests/test_workspace_meeting.py
@@ -14,9 +14,8 @@ class TestWorkspaceMeeting(IntegrationTestCase):
         with self.observe_children(self.workspace) as children:
             factoriesmenu.add('Workspace Meeting')
             browser.fill({'Title': u'Ein Meeting',
-                          'Start': '10.10.2020 23:56'})
-            form = browser.find_form_by_field('Organizer')
-            form.find_widget('Organizer').fill(self.workspace_member.getId(), auto_org_unit=False)
+                          'Start': '10.10.2020 23:56',
+                          'Organizer': self.workspace_member.getId()})
             browser.click_on('Save')
 
         assert_no_error_messages(browser)

--- a/opengever/workspace/vocabularies.py
+++ b/opengever/workspace/vocabularies.py
@@ -1,7 +1,11 @@
+from opengever.ogds.base.sources import ActualWorkspaceMembersSource
+from opengever.ogds.models.user import User
 from opengever.workspace.interfaces import IWorkspaceFolder
 from opengever.workspace.participation import PARTICIPATION_ROLES
 from opengever.workspace.participation.browser.manage_participants import ManageParticipants
 from Products.CMFPlone.utils import safe_unicode
+from sqlalchemy import func
+from sqlalchemy.sql.expression import asc
 from zope.globalrequest import getRequest
 from zope.interface import implementer
 from zope.schema.interfaces import IVocabularyFactory
@@ -54,5 +58,22 @@ class PossibleWorkspaceFolderParticipantsVocabulary(object):
                                     token=participant.get('token'),
                                     title=safe_unicode(
                                         participant.get('name'))))
+
+        return SimpleVocabulary(terms)
+
+
+@implementer(IVocabularyFactory)
+class ActualWorkspaceMembersVocabulary(object):
+    def __call__(self, context):
+        terms = []
+        query = ActualWorkspaceMembersSource(context).search_query
+        query = query.filter_by(active=True)
+        query = query.order_by(asc(func.lower(User.lastname)),
+                               asc(func.lower(User.firstname)))
+
+        for member in query.all():
+            terms.append(SimpleTerm(value=member.userid,
+                                    token=member.userid,
+                                    title=member.fullname()))
 
         return SimpleVocabulary(terms)

--- a/opengever/workspace/workspace_meeting.py
+++ b/opengever/workspace/workspace_meeting.py
@@ -30,11 +30,10 @@ class IWorkspaceMeetingSchema(model.Schema):
             ],
         )
 
-    form.widget('responsible', KeywordFieldWidget, async=True)
     form.order_after(responsible='IOpenGeverBase.description')
     responsible = schema.Choice(
         title=_('label_organizer', default='Organizer'),
-        source=ActualWorkspaceMembersSourceBinder(),
+        vocabulary='opengever.workspace.ActualWorkspaceMembersVocabulary',
         required=True)
 
     form.widget('start', DatePickerFieldWidget)
@@ -59,11 +58,10 @@ class IWorkspaceMeetingSchema(model.Schema):
         title=_(u'label_video_call_link', default=u'Video Call Link'),
         required=False)
 
-    form.widget('participants', KeywordFieldWidget, async=True)
     participants = schema.List(
         title=_(u"label_participants", default=u"Participants"),
         value_type=schema.Choice(
-            source=ActualWorkspaceMembersSourceBinder(),
+            vocabulary='opengever.workspace.ActualWorkspaceMembersVocabulary',
         ),
         required=False,
         missing_value=list(),


### PR DESCRIPTION
Because we do not expect a lot of workspace users, we use a vocabulary instead of a query-source for the possible meeting participants.
This allows us to instantly display all possible users in a list in the frontend for selecting participants.