### PR TITLE
Enable Usersnap by default in SaaS policy template

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2021.3.0 (unreleased)
 ---------------------
 
+- Enable Usersnap by default in SaaS policy template. [lgraf]
 - Respect active languages languages in WorkspaceRoot and PrivateRoot forms. [njohner]
 - List informed principals in TaskAddedActivity description. [njohner]
 - Fix deactivating committees with canceled meetings. [deiferni]

--- a/opengever/policytemplates/policy_template/.mrbob.ini
+++ b/opengever/policytemplates/policy_template/.mrbob.ini
@@ -100,9 +100,16 @@ deployment.records_manager_group.required = True
 deployment.archivist_group.question = Archivist group
 deployment.archivist_group.required = True
 
+setup.enable_usersnap.question = Enable Usersnap
+setup.enable_usersnap.help = Whether to enable Usersnap integration
+setup.enable_usersnap.required = True
+setup.enable_usersnap.default = true
+setup.enable_usersnap.post_ask_question = mrbob.hooks:to_boolean
+
 setup.usersnap_api_key.question = Usersnap API Key
 setup.usersnap_api_key.help = Enter a usersnap API key to enable usersnap.
-setup.usersnap_api_Key.required = False
+setup.usersnap_api_key.required = False
+setup.usersnap_api_key.pre_ask_question = opengever.policytemplates.hooks:pre_usersnap_api_key
 
 setup.enable_activity_feature.question = Enable activity feature
 setup.enable_activity_feature.required = True

--- a/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/+adminunit.id+/profiles/default/registry.xml.bob
+++ b/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/+adminunit.id+/profiles/default/registry.xml.bob
@@ -42,7 +42,7 @@
   </records>
 
 {{% endif %}}
-{{% if setup.usersnap_api_key %}}
+{{% if setup.enable_usersnap %}}
   <records interface="opengever.base.interfaces.IUserSnapSettings">
     <value key="api_key">{{{setup.usersnap_api_key}}}</value>
   </records>


### PR DESCRIPTION
This splits usersnap settings into separate settings for whether it's enabled at all (boolean, default `True`) and the API key, and prefills the default for the API key from a JSON dotfile on the local machine if present.

The dotfile is looked for in `~/.opengever/policytemplate.json` and expected to have a structure as follows:

```json
{
  "usersnap_api_keys": {
    "gever": "87....",
    "teamraum": "fe...."
  }
}
```

Jira: https://4teamwork.atlassian.net/browse/CA-1245

## Checklist (Must have)

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
