### PR TITLE
Return only badge notifications in @notifications endpoint.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2021.3.0 (unreleased)
 ---------------------
 
+- Return only badge notifications in @notifications endpoint. [tinagerber]
 - Enable Usersnap by default in SaaS policy template. [lgraf]
 - Respect active languages languages in WorkspaceRoot and PrivateRoot forms. [njohner]
 - List informed principals in TaskAddedActivity description. [njohner]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -10,6 +10,7 @@ API Changelog
 Breaking Changes
 ^^^^^^^^^^^^^^^^
 
+- ``@notifications``: Only badge notifications are returned (see :ref:`docs <notifications>`).
 - ``@tasktree``: Sequential tasks are now sorted on ``getObjPositionInParent`` (see :ref:`docs <tasktree>`).
 
 

--- a/docs/public/dev-manual/api/notifications.rst
+++ b/docs/public/dev-manual/api/notifications.rst
@@ -10,7 +10,7 @@ Der ``@notifications`` Endpoint stellt Funktionen für die Benachrichtigungen zu
 
 Auflistung:
 -----------
-Mittels eines GET-Request können Benachrichtigungen des Benutzers abgefragt werden.
+Mittels eines GET-Request können alle GEVER Benachrichtigungen des Benutzers abgefragt werden.
 
 
 **Beispiel-Request**:

--- a/opengever/activity/center.py
+++ b/opengever/activity/center.py
@@ -139,10 +139,12 @@ class NotificationCenter(object):
 
         return errors
 
-    def get_users_notifications(self, userid, only_unread=False, limit=None):
+    def get_users_notifications(self, userid, only_unread=False, limit=None, badge_only=False):
         query = Notification.query.by_user(userid)
         if only_unread:
             query = query.filter(Notification.is_read == false())
+        if badge_only:
+            query = query.filter(Notification.is_badge == true())
 
         query = query.join(
             Notification.activity).order_by(desc(Activity.created))
@@ -308,11 +310,12 @@ class PloneNotificationCenter(NotificationCenter):
         return super(PloneNotificationCenter, self).count_users_unread_notifications(
             api.user.get_current().getId(), badge_only)
 
-    def get_current_users_notifications(self, only_unread=False, limit=None):
+    def get_current_users_notifications(self, only_unread=False, limit=None, badge_only=False):
         return super(PloneNotificationCenter, self).get_users_notifications(
             api.user.get_current().getId(),
             only_unread=only_unread,
-            limit=limit)
+            limit=limit,
+            badge_only=badge_only)
 
 
 class DisabledNotificationCenter(NotificationCenter):
@@ -364,11 +367,11 @@ class DisabledNotificationCenter(NotificationCenter):
                      notification_recipients=None):
         pass
 
-    def get_users_notifications(self, userid, only_unread=False, limit=None):
+    def get_users_notifications(self, userid, only_unread=False, limit=None, badge_only=False):
         return []
 
     def mark_notification_as_read(self, notification_id):
         pass
 
-    def get_current_users_notifications(self, only_unread=False, limit=None):
+    def get_current_users_notifications(self, only_unread=False, limit=None, badge_only=False):
         return []

--- a/opengever/api/notifications.py
+++ b/opengever/api/notifications.py
@@ -55,7 +55,7 @@ class NotificationsGet(Service):
         return self.serialize(notification)
 
     def get_user_notifications(self):
-        notifications = self.center.get_current_users_notifications()
+        notifications = self.center.get_current_users_notifications(badge_only=True)
         batch = HypermediaBatch(self.request, notifications)
 
         result = {

--- a/opengever/api/tests/test_notifications.py
+++ b/opengever/api/tests/test_notifications.py
@@ -70,6 +70,25 @@ class TestNotificationsGet(IntegrationTestCase):
             browser.json.get('items'))
 
     @browsing
+    def test_list_only_badge_notifications(self, browser):
+        self.login(self.dossier_responsible, browser=browser)
+        TaskAddedActivity(self.task, self.request).record()
+        TaskAddedActivity(self.task, self.request).record()
+        TaskAddedActivity(self.task, self.request).record()
+
+        self.login(self.regular_user, browser=browser)
+        url = '{}/@notifications/{}'.format(self.portal.absolute_url(),
+                                            self.regular_user.getId())
+
+        browser.open(url, method='GET', headers=self.api_headers)
+        self.assertEqual(3, browser.json['items_total'])
+        notification_id = browser.json['items'][1]['notification_id']
+        Notification.query.filter(Notification.notification_id ==
+                                  notification_id).one().is_badge = False
+        browser.open(url, method='GET', headers=self.api_headers)
+        self.assertEqual(2, browser.json['items_total'])
+
+    @browsing
     def test_batch_notifications(self, browser):
         self.login(self.administrator, browser=browser)
 


### PR DESCRIPTION
In the new frontend, all notifications returned by the @notifications endpoint are displayed as badge notifications. This meant that notifications that were not badge notifications were also displayed.
With the changes in this PR, the @notifications endpoint only returns badge notifications.

It would also have been possible to introduce an is_badge field and filter by it in the frontend, but I think the chosen method is better, as it gives the backend control over which notifications are displayed in the frontend.

Jira: https://4teamwork.atlassian.net/browse/NE-378


## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


## Checklist (if applicable)

_Only applicable should be left and checked._

- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [x] api-change label added
    - [x] #delivery channel notified about breaking change
    - [x] Scrum master is informed