### PR TITLE
Only show create_proposal action on dossiers.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 ---------------------
 
 - Return only badge notifications in @notifications endpoint. [tinagerber]
+- Only show create_proposal action on dossiers. [tinagerber]
 - Enable Usersnap by default in SaaS policy template. [lgraf]
 - Respect active languages languages in WorkspaceRoot and PrivateRoot forms. [njohner]
 - List informed principals in TaskAddedActivity description. [njohner]

--- a/opengever/api/tests/test_actions.py
+++ b/opengever/api/tests/test_actions.py
@@ -830,7 +830,7 @@ class TestUnlockAction(FileActionsTestBase):
 
 class TestFolderActions(FolderActionsTestBase):
 
-    features = ('bumblebee',)
+    features = ('bumblebee', 'meeting')
     createTaskAction = {
         u'id': u'create_task',
         u'title': u'Create task',
@@ -883,6 +883,13 @@ class TestFolderActions(FolderActionsTestBase):
                          self.get_folder_buttons(browser, self.inactive_dossier))
 
     @browsing
+    def test_create_proposal_not_available_if_meeting_feature_disabled(self, browser):
+        self.deactivate_feature('meeting')
+        self.login(self.secretariat_user, browser)
+        self.assertNotIn({u'icon': u'', u'id': u'create_proposal', u'title': u'Create proposal'},
+                         self.get_folder_buttons(browser, self.resolvable_dossier))
+
+    @browsing
     def test_actions_for_dossier(self, browser):
         self.login(self.regular_user, browser)
 
@@ -895,9 +902,12 @@ class TestFolderActions(FolderActionsTestBase):
             {u'icon': u'', u'id': u'attach_documents', u'title': u'Attach to email'},
             {u'icon': u'', u'id': u'checkout', u'title': u'Check out'},
             {u'icon': u'', u'id': u'create_task', u'title': u'Create task'},
+            {u'icon': u'', u'id': u'create_proposal', u'title': u'Create proposal'},
             {u'icon': u'', u'id': u'cancel', u'title': u'Cancel'},
             {u'icon': u'', u'id': u'checkin_with_comment', u'title': u'Check in with comment'},
             {u'icon': u'', u'id': u'checkin_without_comment', u'title': u'Check in without comment'},
+            {u'icon': u'', u'id': u'submit_additional_documents',
+                u'title': u'Submit additional documents'},
             {u'icon': u'', u'id': u'export_documents', u'title': u'Export selection'},
             {u'icon': u'', u'id': u'delete_participants', u'title': u'Delete'},
             {u'icon': u'', u'id': u'add_participant', u'title': u'Add participant'},

--- a/opengever/base/browser/folder_buttons_availability.py
+++ b/opengever/base/browser/folder_buttons_availability.py
@@ -2,6 +2,7 @@ from Acquisition import aq_chain
 from Acquisition import aq_inner
 from opengever.dossier.behaviors.dossier import IDossierMarker
 from opengever.dossier.templatefolder.interfaces import ITemplateFolder
+from opengever.meeting import is_meeting_feature_enabled
 from opengever.task.task import ITask
 from opengever.workspaceclient import is_workspace_client_feature_available
 from opengever.workspaceclient.interfaces import ILinkedWorkspaces
@@ -24,6 +25,12 @@ class FolderButtonsAvailabilityView(BrowserView):
         may_add_task = api.user.has_permission('opengever.task: Add task',
                                                obj=self.context)
         return (is_dossier or is_task) and may_add_task
+
+    def is_create_proposal_available(self):
+        is_dossier = IDossierMarker.providedBy(self.context)
+        may_add_proposal = api.user.has_permission('opengever.meeting: Add Proposal',
+                                                   obj=self.context)
+        return is_meeting_feature_enabled() and is_dossier and may_add_proposal
 
     def _is_main_dossier(self):
         if not IDossierMarker.providedBy(self.context):

--- a/opengever/core/profiles/default/actions.xml
+++ b/opengever/core/profiles/default/actions.xml
@@ -309,10 +309,7 @@
       <property name="description" i18n:translate="" />
       <property name="url_expr">string:++add++opengever.meeting.proposal:method</property>
       <property name="icon_expr" />
-      <property name="available_expr">object/get_setting/meetings</property>
-      <property name="permissions">
-        <element value="opengever.meeting: Add Proposal" />
-      </property>
+      <property name="available_expr">object/@@folder_buttons_availability/is_create_proposal_available</property>
       <property name="visible">True</property>
     </object>
 

--- a/opengever/core/upgrades/20210126165317_update_create_proposal_action/actions.xml
+++ b/opengever/core/upgrades/20210126165317_update_create_proposal_action/actions.xml
@@ -1,0 +1,16 @@
+<object xmlns:i18n="http://xml.zope.org/namespaces/i18n" name="portal_actions" meta_type="Plone Actions Tool">
+
+  <object name="folder_buttons" meta_type="CMF Action Category">
+
+    <object name="create_proposal" meta_type="CMF Action" i18n:domain="opengever.core">
+      <property name="title" i18n:translate="">Create Proposal</property>
+      <property name="description" i18n:translate="" />
+      <property name="url_expr">string:++add++opengever.meeting.proposal:method</property>
+      <property name="icon_expr" />
+      <property name="available_expr">object/@@folder_buttons_availability/is_create_proposal_available</property>
+      <property name="visible">True</property>
+    </object>
+
+  </object>
+
+</object>

--- a/opengever/core/upgrades/20210126165317_update_create_proposal_action/upgrade.py
+++ b/opengever/core/upgrades/20210126165317_update_create_proposal_action/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class UpdateCreateProposalAction(UpgradeStep):
+    """Update create_proposal action.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/repository/tests/test_repositoryfolder_tabs.py
+++ b/opengever/repository/tests/test_repositoryfolder_tabs.py
@@ -89,12 +89,12 @@ class TestRepositoryFolderDocumentsTab(SolrIntegrationTestCase):
         self.assertEquals([], tabbedview.major_actions().text)
 
     @browsing
-    def test_create_proposal_visible_when_meeting_feature_enabled(self, browser):
+    def test_create_proposal_action_not_visible(self, browser):
         self.activate_feature('meeting')
         self.login(self.manager, browser)
         browser.open(self.branch_repofolder)
         tabbedview.open('Documents')
-        self.assertEquals(['Create proposal'], tabbedview.major_actions().text)
+        self.assertEquals([], tabbedview.major_actions().text)
 
     @browsing
     def test_columns(self, browser):


### PR DESCRIPTION
Until now, the `create_proposal` action has appeared on various contents. But the action should only appear on dossiers.

Jira: https://4teamwork.atlassian.net/browse/NE-313

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)