### PR TITLE
Fix meeting pdf generation if there are no agenda_items.

### DIFF
--- a/opengever/workspace/browser/meeting_pdf.py
+++ b/opengever/workspace/browser/meeting_pdf.py
@@ -43,7 +43,7 @@ class MeetingMinutesPDFView(BrowserView):
         data['generator'] = portal_state.portal_title()
         data['print_date'] = DateTime()
         data['responsible'] = display_name(self.context.responsible)
-        data['agenda_items'] = self.context.agenda_items.get('items', [])
+        data['agenda_items'] = (self.context.agenda_items or {}).get('items', [])
         for i, agenda_item in enumerate(data['agenda_items']):
             agenda_item[u'number'] = '{}. '.format(i + 1)
         return self.template(self, **data)


### PR DESCRIPTION
The JSONField does not provide a default value. So there is potentially a `None` value coming from context.agenda_items if the field have not been initialized yet. We have to take care of this.
