### PR TITLE
Implement support for custom properties in the classic UI.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -10,6 +10,7 @@ Changelog
 - Index blocked_local_roles in solr and allow field in @listing endpoint. [tinagerber]
 - Only allow to create linked workspace and link to workspace if dossier is open. [tinagerber]
 - Add link_to_workspace folder action. [tinagerber]
+- Implement custom properties in classic UI, currently available for documents and mails. [deiferni]
 - Return only badge notifications in @notifications endpoint. [tinagerber]
 - Only show create_proposal action on dossiers. [tinagerber]
 - Enable Usersnap by default in SaaS policy template. [lgraf]

--- a/docs/public/dev-manual/api/propertysheets.rst
+++ b/docs/public/dev-manual/api/propertysheets.rst
@@ -95,14 +95,15 @@ Assignment-Slot zuzuweisen ist im Moment nicht unterstützt.
   Accept: application/json
 
   {
-    "fields": {
-      "yesorno": {
+    "fields": [
+      {
+        "name": "yesorno",
         "field_type": "bool",
         "title": "Y/N",
         "description": "yes or no",
         "required": true
       }
-    },
+    ],
     "assignments": ["IDocumentMetadata.document_type.question"]
   }
 

--- a/opengever/document/behaviors/customproperties.py
+++ b/opengever/document/behaviors/customproperties.py
@@ -1,3 +1,4 @@
+from opengever.document import _
 from opengever.propertysheets.assignment import get_document_assignment_slots
 from opengever.propertysheets.field import PropertySheetField
 from plone.autoform.interfaces import IFormFieldProvider
@@ -16,7 +17,7 @@ class IDocumentCustomProperties(model.Schema):
 
     model.fieldset(
         u'custom_properties',
-        label=u'Custom properties',
+        label=_(u'Custom properties'),
         fields=[
             u'custom_properties',
             ],

--- a/opengever/document/locales/de/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/de/LC_MESSAGES/opengever.document.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2021-01-08 17:25+0000\n"
+"POT-Creation-Date: 2021-01-28 09:13+0000\n"
 "PO-Revision-Date: 2017-10-13 14:27+0200\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -81,6 +81,10 @@ msgstr "${title} ist kein Dokument und konnte deshalb nicht ausgecheckt werden."
 #: ./opengever/document/browser/overview.py
 msgid "Current version: ${version}"
 msgstr "Aktuelle Version: ${version}"
+
+#: ./opengever/document/behaviors/customproperties.py
+msgid "Custom properties"
+msgstr "Benutzerdefinierte Felder"
 
 #: ./opengever/document/forms.py
 msgid "Document ${document} was successfully created in ${destination}"

--- a/opengever/document/locales/en/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/en/LC_MESSAGES/opengever.document.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2021-01-15 17:46+0000\n"
+"POT-Creation-Date: 2021-01-28 09:13+0000\n"
 "PO-Revision-Date: 2017-10-13 14:27+0200\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -96,6 +96,10 @@ msgstr "Could not check out object: ${title}, it is not a document."
 #: ./opengever/document/browser/overview.py
 msgid "Current version: ${version}"
 msgstr "Current version: ${version}"
+
+#: ./opengever/document/behaviors/customproperties.py
+msgid "Custom properties"
+msgstr "Custom properties"
 
 #. German translation: Das Dokument ${document} wurde in ${destination} erstellt
 #: ./opengever/document/forms.py

--- a/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-01-08 17:25+0000\n"
+"POT-Creation-Date: 2021-01-28 09:13+0000\n"
 "PO-Revision-Date: 2017-09-03 08:50+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-document/fr/>\n"
@@ -83,6 +83,10 @@ msgstr "${title} n'est pas un document, par consequent checkout n'a pas abouti."
 #: ./opengever/document/browser/overview.py
 msgid "Current version: ${version}"
 msgstr "Version actuelle: ${version}"
+
+#: ./opengever/document/behaviors/customproperties.py
+msgid "Custom properties"
+msgstr "Champs personnalisés"
 
 #: ./opengever/document/forms.py
 msgid "Document ${document} was successfully created in ${destination}"

--- a/opengever/document/locales/opengever.document.pot
+++ b/opengever/document/locales/opengever.document.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-01-08 17:25+0000\n"
+"POT-Creation-Date: 2021-01-28 09:13+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -82,6 +82,10 @@ msgstr ""
 
 #: ./opengever/document/browser/overview.py
 msgid "Current version: ${version}"
+msgstr ""
+
+#: ./opengever/document/behaviors/customproperties.py
+msgid "Custom properties"
 msgstr ""
 
 #: ./opengever/document/forms.py

--- a/opengever/mail/browser/default_view.py
+++ b/opengever/mail/browser/default_view.py
@@ -1,5 +1,6 @@
 from opengever.base.browser.default_view import OGDefaultView
 from opengever.document.interfaces import NO_DOWNLOAD_DISPLAY_MODE
+from opengever.propertysheets.form import omit_custom_properties_group
 
 
 class MailDefaultView(OGDefaultView):
@@ -9,6 +10,10 @@ class MailDefaultView(OGDefaultView):
     because then it's possible to download a possibly private working copy
     of the message.
     """
+
+    def update(self):
+        super(MailDefaultView, self).update()
+        self.groups = omit_custom_properties_group(self.groups)
 
     def updateWidgets(self):
         super(MailDefaultView, self).updateWidgets()

--- a/opengever/mail/browser/edit.py
+++ b/opengever/mail/browser/edit.py
@@ -1,4 +1,5 @@
 from opengever.document.interfaces import NO_DOWNLOAD_DISPLAY_MODE
+from opengever.propertysheets.form import omit_custom_properties_group
 from plone.dexterity.browser.edit import DefaultEditForm
 from plone.z3cform import layout
 
@@ -14,6 +15,10 @@ class MailEditForm(DefaultEditForm):
         field = self.groups[0].fields.get('message')
         if field:
             field.mode = NO_DOWNLOAD_DISPLAY_MODE
+
+    def updateFields(self):
+        super(MailEditForm, self).updateFields()
+        self.groups = omit_custom_properties_group(self.groups)
 
 
 MailEditView = layout.wrap_form(MailEditForm)

--- a/opengever/propertysheets/api/post.py
+++ b/opengever/propertysheets/api/post.py
@@ -84,6 +84,17 @@ class PropertySheetsPost(Service):
         if errors:
             raise BadRequest(errors)
 
+        seen = set()
+        duplicates = []
+        for name in [each["name"] for each in fields]:
+            if name in seen:
+                duplicates.append(name)
+            seen.add(name)
+        if duplicates:
+            raise BadRequest(
+                u"Duplicate fields '{}'.".format("', '".join(duplicates))
+            )
+
         assignments = data.get("assignments")
         if assignments is not None:
             assignments = tuple(assignments)

--- a/opengever/propertysheets/api/post.py
+++ b/opengever/propertysheets/api/post.py
@@ -32,6 +32,11 @@ class IFieldDefinition(model.Schema):
     title = schema.TextLine(required=False)
     description = schema.TextLine(required=False)
     required = schema.Bool(required=False)
+    values = schema.List(
+        default=None,
+        value_type=schema.TextLine(),
+        required=False,
+    )
 
 
 @implementer(IPublishTraverse)
@@ -105,8 +110,9 @@ class PropertySheetsPost(Service):
             title = field_data.get("title", name)
             description = field_data.get("description", u"")
             required = field_data.get("required", False)
+            values = field_data.get("values", None)
             schema_definition.add_field(
-                field_type, name, title, description, required
+                field_type, name, title, description, required, values
             )
 
         self.storage.save(schema_definition)

--- a/opengever/propertysheets/configure.zcml
+++ b/opengever/propertysheets/configure.zcml
@@ -44,4 +44,18 @@
       template="templates/propertysheet.pt"
       />
 
+  <z3c:widgetTemplate
+      mode="display"
+      widget=".widgets.IPropertySheetWiget"
+      layer="z3c.form.interfaces.IFormLayer"
+      template="templates/propertysheet_display.pt"
+      />
+
+  <z3c:widgetTemplate
+      mode="hidden"
+      widget=".widgets.IPropertySheetWiget"
+      layer="z3c.form.interfaces.IFormLayer"
+      template="templates/propertysheet.pt"
+      />
+
 </configure>

--- a/opengever/propertysheets/configure.zcml
+++ b/opengever/propertysheets/configure.zcml
@@ -24,4 +24,24 @@
   <adapter factory=".field.PropertySheetFieldSchemaProvider" />
   <adapter factory=".widgets.PropertySheetFieldDataConverter" />
 
+  <adapter
+      factory=".widgets.PropertySheetFieldWiget"
+      for="opengever.propertysheets.field.IPropertySheetField
+           z3c.form.interfaces.IFormLayer"
+      />
+
+  <class class=".widgets.PropertySheetFieldWiget">
+    <require
+        permission="zope.Public"
+        interface=".widgets.IPropertySheetWiget"
+        />
+  </class>
+
+  <z3c:widgetTemplate
+      mode="input"
+      widget=".widgets.IPropertySheetWiget"
+      layer="z3c.form.interfaces.IFormLayer"
+      template="templates/propertysheet.pt"
+      />
+
 </configure>

--- a/opengever/propertysheets/configure.zcml
+++ b/opengever/propertysheets/configure.zcml
@@ -22,6 +22,6 @@
       />
 
   <adapter factory=".field.PropertySheetFieldSchemaProvider" />
-  <adapter factory=".field.PropertySheetFieldDataConverter" />
+  <adapter factory=".widgets.PropertySheetFieldDataConverter" />
 
 </configure>

--- a/opengever/propertysheets/definition.py
+++ b/opengever/propertysheets/definition.py
@@ -13,6 +13,7 @@ from plone.supermodel import loadString
 from plone.supermodel import model
 from plone.supermodel import serializeSchema
 from zope.component import getUtility
+from zope.schema import getFieldNamesInOrder
 from zope.schema import getFieldsInOrder
 from zope.schema import ValidationError
 from zope.schema.interfaces import IVocabularyFactory
@@ -137,6 +138,14 @@ class PropertySheetSchemaDefinition(object):
         schema = IEditableSchema(self.schema_class)
         schema.addField(field)
 
+    def get_fields(self):
+        """Return a list of (name, field) tuples in native schema order."""
+        return getFieldsInOrder(self.schema_class)
+
+    def get_fieldnames(self):
+        """Return a list of fieldnames in native schema order."""
+        return getFieldNamesInOrder(self.schema_class)
+
     def get_json_schema(self):
         schema_info = get_property_sheet_schema(self.schema_class)
         schema_info["assignments"] = IJsonCompatible(self.assignments)
@@ -159,7 +168,7 @@ class PropertySheetSchemaDefinition(object):
                 raise WrongType("Only 'dict' is allowed for properties.")
             data_to_validate = deepcopy(data)
 
-        for name, field in getFieldsInOrder(self.schema_class):
+        for name, field in self.get_fields():
             value = data_to_validate.pop(name, None)
             field.validate(value)
 

--- a/opengever/propertysheets/field.py
+++ b/opengever/propertysheets/field.py
@@ -1,13 +1,9 @@
 from opengever.propertysheets import _
 from opengever.propertysheets.storage import PropertySheetSchemaStorage
-from plone.restapi.serializer.converters import json_compatible
 from plone.restapi.types.adapters import DefaultJsonSchemaProvider
 from plone.restapi.types.interfaces import IJsonSchemaProvider
 from plone.schema import IJSONField
 from plone.schema import JSONField
-from plone.schema.browser.jsonfield import JSONDataConverter
-from z3c.form.interfaces import IDataConverter
-from z3c.form.interfaces import IWidget
 from zope.component import adapter
 from zope.globalrequest import getRequest
 from zope.interface import implementer
@@ -181,14 +177,3 @@ class PropertySheetFieldSchemaProvider(DefaultJsonSchemaProvider):
 
     def get_widget_params(self):
         return None
-
-
-@adapter(IPropertySheetField, IWidget)
-@implementer(IDataConverter)
-class PropertySheetFieldDataConverter(JSONDataConverter):
-
-    def toWidgetValue(self, value):
-        """Make sure to convert persistent dicts to json compatible data."""
-
-        value = json_compatible(value)
-        return super(PropertySheetFieldDataConverter, self).toWidgetValue(value)

--- a/opengever/propertysheets/field.py
+++ b/opengever/propertysheets/field.py
@@ -2,21 +2,21 @@ from opengever.propertysheets import _
 from opengever.propertysheets.storage import PropertySheetSchemaStorage
 from plone.restapi.types.adapters import DefaultJsonSchemaProvider
 from plone.restapi.types.interfaces import IJsonSchemaProvider
-from plone.schema import IJSONField
-from plone.schema import JSONField
 from zope.component import adapter
 from zope.globalrequest import getRequest
 from zope.interface import implementer
 from zope.interface import Interface
+from zope.schema import Field
 from zope.schema import ValidationError
+from zope.schema.interfaces import IField
 
 
-class IPropertySheetField(IJSONField):
+class IPropertySheetField(IField):
     pass
 
 
 @implementer(IPropertySheetField)
-class PropertySheetField(JSONField):
+class PropertySheetField(Field):
     """Handle custom properties and validate them against their corresponding
     property sheet schema.
 

--- a/opengever/propertysheets/field.py
+++ b/opengever/propertysheets/field.py
@@ -84,15 +84,16 @@ class PropertySheetField(Field):
             value, mandatory_sheet
         )
 
-    def get_active_assignment_slot(self):
+    def get_active_assignment_slot(self, context=None):
         """Return assignment slot currently considered active."""
         request = getRequest()
 
         value_name = None
+        context = context or self.context
         if self.request_key in request:
             value_name = request.get(self.request_key)[0]
-        elif self.context:
-            value_name = getattr(self.context, self.attribute_name)
+        elif context:
+            value_name = getattr(context, self.attribute_name, None)
 
         if not value_name:
             return None

--- a/opengever/propertysheets/form.py
+++ b/opengever/propertysheets/form.py
@@ -1,10 +1,13 @@
+from opengever.propertysheets.storage import PropertySheetSchemaStorage
+
+
 GROUPNAME = "custom_properties"
 
 
 def omit_custom_properties_group(form_groups):
-    """Filter out the form group `custom_properties`.
+    """Omit form group `custom_properties` if no schemas are defined."""
 
-    XXX Temporary workaround so we can move forward with custom properties in
-    API `@schema` endpoint without proper classic UI support.
-    """
-    return [group for group in form_groups if group.__name__ != GROUPNAME]
+    if not PropertySheetSchemaStorage():
+        return [group for group in form_groups if group.__name__ != GROUPNAME]
+
+    return form_groups

--- a/opengever/propertysheets/locales/de/LC_MESSAGES/opengever.propertysheets.po
+++ b/opengever/propertysheets/locales/de/LC_MESSAGES/opengever.propertysheets.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-01-20 09:20+0000\n"
+"POT-Creation-Date: 2021-01-27 15:57+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,3 +21,11 @@ msgstr "Enthält die Daten für die benutzerdefinierten Felder."
 #: ./opengever/propertysheets/field.py
 msgid "Custom properties"
 msgstr "Benutzerdefinierte Felder"
+
+#: ./opengever/propertysheets/widgets.py
+msgid "Custom properties contain some errors."
+msgstr "Die benutzerdefinierten Felder beinhalten Fehler."
+
+#: ./opengever/propertysheets/templates/propertysheet.pt
+msgid "No custom properties are available."
+msgstr "Es sind keine benutzerdefinierten Felder verfügbar."

--- a/opengever/propertysheets/locales/en/LC_MESSAGES/opengever.propertysheets.po
+++ b/opengever/propertysheets/locales/en/LC_MESSAGES/opengever.propertysheets.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-01-20 09:20+0000\n"
+"POT-Creation-Date: 2021-01-27 15:57+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,3 +21,11 @@ msgstr "Contains data for user defined custom properties."
 #: ./opengever/propertysheets/field.py
 msgid "Custom properties"
 msgstr "Custom properties"
+
+#: ./opengever/propertysheets/widgets.py
+msgid "Custom properties contain some errors."
+msgstr "Custom properties contain some errors."
+
+#: ./opengever/propertysheets/templates/propertysheet.pt
+msgid "No custom properties are available."
+msgstr "No custom properties are available."

--- a/opengever/propertysheets/locales/fr/LC_MESSAGES/opengever.propertysheets.po
+++ b/opengever/propertysheets/locales/fr/LC_MESSAGES/opengever.propertysheets.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-01-20 09:20+0000\n"
+"POT-Creation-Date: 2021-01-27 15:57+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,3 +21,11 @@ msgstr "Contient les données pour les champ personnalisés."
 #: ./opengever/propertysheets/field.py
 msgid "Custom properties"
 msgstr "Champs personnalisés"
+
+#: ./opengever/propertysheets/widgets.py
+msgid "Custom properties contain some errors."
+msgstr "Les champs personnalisés contiennent des erreurs."
+
+#: ./opengever/propertysheets/templates/propertysheet.pt
+msgid "No custom properties are available."
+msgstr "Aucun champ personnalisé disponible."

--- a/opengever/propertysheets/locales/opengever.propertysheets.pot
+++ b/opengever/propertysheets/locales/opengever.propertysheets.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-01-20 09:20+0000\n"
+"POT-Creation-Date: 2021-01-27 15:57+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -23,4 +23,12 @@ msgstr ""
 
 #: ./opengever/propertysheets/field.py
 msgid "Custom properties"
+msgstr ""
+
+#: ./opengever/propertysheets/widgets.py
+msgid "Custom properties contain some errors."
+msgstr ""
+
+#: ./opengever/propertysheets/templates/propertysheet.pt
+msgid "No custom properties are available."
 msgstr ""

--- a/opengever/propertysheets/storage.py
+++ b/opengever/propertysheets/storage.py
@@ -21,6 +21,13 @@ class PropertySheetSchemaStorage(object):
 
         return name in storage
 
+    def __len__(self):
+        annotations = IAnnotations(self.context)
+        return len(annotations.get(self.ANNOTATIONS_KEY, {}))
+
+    def __nonzero__(self):
+        return bool(len(self))
+
     def list(self):
         annotations = IAnnotations(self.context)
 

--- a/opengever/propertysheets/templates/propertysheet.pt
+++ b/opengever/propertysheets/templates/propertysheet.pt
@@ -8,39 +8,7 @@
   </div>
 
   <tal:block repeat="widget view/widgets" i18n:domain="plone">
-    <div tal:define="hidden python:widget.mode == 'hidden';
-                     error widget/error;
-                     error_class python:error and ' error' or '';
-                     fieldname_class string:kssattr-fieldname-${widget/name};"
-         tal:attributes="class string:custom-field object-widget-field field z3cformInlineValidation ${fieldname_class}${error_class};
-                         data-fieldname widget/name;
-                         id string:formfield-${widget/id};">
-
-      <label class="horizontal"
-          tal:attributes="for widget/id"
-          tal:condition="not:hidden">
-        <span i18n:translate="" tal:replace="widget/label">label</span>
-
-        <span class="required horizontal" title="Required"
-              tal:condition="python:widget.required and not hidden"
-              i18n:attributes="title title_required;">&nbsp;</span>
-
-        <span class="formHelp"
-            tal:define="description widget/field/description"
-            i18n:translate=""
-            tal:content="description"
-            tal:condition="python:description and not hidden"
-            >field description
-        </span>
-      </label>
-
-      <div class="fieldErrorBox"
-          tal:content="structure error/render|nothing">
-          Error
-      </div>
-
-      <input type="text" tal:replace="structure widget/render" />
-    </div>
+    <tal:widget tal:replace="structure widget/@@ploneform-render-widget"/>
   </tal:block>
 
 </html>

--- a/opengever/propertysheets/templates/propertysheet.pt
+++ b/opengever/propertysheets/templates/propertysheet.pt
@@ -1,0 +1,42 @@
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      tal:omit-tag="">
+
+  <tal:block repeat="widget view/widgets" i18n:domain="plone">
+    <div tal:define="hidden python:widget.mode == 'hidden';
+                     error widget/error;
+                     error_class python:error and ' error' or '';
+                     fieldname_class string:kssattr-fieldname-${widget/name};"
+         tal:attributes="class string:custom-field object-widget-field field z3cformInlineValidation ${fieldname_class}${error_class};
+                         data-fieldname widget/name;
+                         id string:formfield-${widget/id};">
+
+      <label class="horizontal"
+          tal:attributes="for widget/id"
+          tal:condition="not:hidden">
+        <span i18n:translate="" tal:replace="widget/label">label</span>
+
+        <span class="required horizontal" title="Required"
+              tal:condition="python:widget.required and not hidden"
+              i18n:attributes="title title_required;">&nbsp;</span>
+
+        <span class="formHelp"
+            tal:define="description widget/field/description"
+            i18n:translate=""
+            tal:content="description"
+            tal:condition="python:description and not hidden"
+            >field description
+        </span>
+      </label>
+
+      <div class="fieldErrorBox"
+          tal:content="structure error/render|nothing">
+          Error
+      </div>
+
+      <input type="text" tal:replace="structure widget/render" />
+    </div>
+  </tal:block>
+
+</html>
+

--- a/opengever/propertysheets/templates/propertysheet.pt
+++ b/opengever/propertysheets/templates/propertysheet.pt
@@ -1,6 +1,11 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:tal="http://xml.zope.org/namespaces/tal"
+      i18n:domain="opengever.propertysheets"
       tal:omit-tag="">
+
+  <div class="noCustomPropertyFields" tal:condition="not: view/widgets" i18n:translate="">
+    No custom properties are available.
+  </div>
 
   <tal:block repeat="widget view/widgets" i18n:domain="plone">
     <div tal:define="hidden python:widget.mode == 'hidden';

--- a/opengever/propertysheets/templates/propertysheet_display.pt
+++ b/opengever/propertysheets/templates/propertysheet_display.pt
@@ -1,0 +1,28 @@
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      i18n:domain="opengever.propertysheets"
+      tal:omit-tag="">
+
+  <div class="noCustomPropertyFields" tal:condition="not: view/widgets" i18n:translate="">
+    No custom properties are available.
+  </div>
+
+  <tal:block repeat="widget view/widgets" i18n:domain="plone">
+
+    <div
+       i18n:domain="plone"
+       tal:define="fieldname_class string:kssattr-fieldname-${widget/name};"
+       tal:attributes="class string:field z3cformInlineValidation ${fieldname_class};
+                       data-fieldname widget/name;
+                       id string:formfield-${widget/id};">
+
+        <label class="horizontal" for="${widget/id}" tal:content="widget/label">
+        </label>
+        <div tal:content="structure widget/render" id="${widget/id}">
+        </div>
+
+    </div>
+  </tal:block>
+
+</html>
+

--- a/opengever/propertysheets/tests/test_document_default_view.py
+++ b/opengever/propertysheets/tests/test_document_default_view.py
@@ -1,0 +1,71 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.testbrowser import browsing
+from opengever.document.behaviors.customproperties import IDocumentCustomProperties
+from opengever.testing import IntegrationTestCase
+
+
+class TestDocumentDefaultViewWithCustomProperties(IntegrationTestCase):
+
+    CUSTOM_PROPERTIES_LABEL = u"Custom properties"
+
+    @browsing
+    def test_document_default_view_displays_custom_properties(self, browser):
+        self.login(self.manager)
+        create(
+            Builder("property_sheet_schema")
+            .named("schema")
+            .assigned_to_slots(u"IDocumentMetadata.document_type.question")
+            .with_field("text", u"foo", u"some input", u"", True)
+        )
+        self.document.document_type = u"question"
+        IDocumentCustomProperties(self.document).custom_properties = {
+            u"IDocumentMetadata.document_type.question": {u"foo": u"qux"}
+        }
+
+        self.login(self.regular_user, browser)
+        browser.open(self.document, view="view")
+
+        table = browser.css(".dossier-detail-listing").first
+        self.assertIsNotNone(table.find(self.CUSTOM_PROPERTIES_LABEL))
+        data_row = table.lists()[-1]
+        self.assertEqual(
+            [self.CUSTOM_PROPERTIES_LABEL, "some input qux"], data_row
+        )
+
+    @browsing
+    def test_document_default_view_displays_no_properties_label(self, browser):
+        self.login(self.manager)
+        create(
+            Builder("property_sheet_schema")
+            .named("schema")
+            .assigned_to_slots(u"IDocumentMetadata.document_type.question")
+            .with_field("text", u"foo", u"some input", u"", True)
+        )
+        self.document.document_type = u"contract"
+
+        self.login(self.regular_user, browser)
+        browser.open(self.document, view="view")
+
+        table = browser.css(".dossier-detail-listing").first
+        self.assertIsNotNone(table.find(self.CUSTOM_PROPERTIES_LABEL))
+        data_row = table.lists()[-1]
+        self.assertEqual(
+            [
+                self.CUSTOM_PROPERTIES_LABEL,
+                "No custom properties are available.",
+            ],
+            data_row,
+        )
+
+    @browsing
+    def test_document_default_view_hides_properties_when_no_sheet_is_defined(
+        self, browser
+    ):
+        self.login(self.manager)
+
+        self.login(self.regular_user, browser)
+        browser.open(self.document, view="view")
+
+        table = browser.css(".dossier-detail-listing").first
+        self.assertIsNone(table.find(self.CUSTOM_PROPERTIES_LABEL))

--- a/opengever/propertysheets/tests/test_document_forms.py
+++ b/opengever/propertysheets/tests/test_document_forms.py
@@ -1,0 +1,62 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.testbrowser import browsing
+from opengever.testing import IntegrationTestCase
+
+
+class TestCustomPropertiesFieldsetForDocumentEditForm(IntegrationTestCase):
+
+    @browsing
+    def test_group_is_hidden_when_no_property_sheets_are_defined(self, browser):
+        self.login(self.regular_user, browser)
+        browser.open(self.document, view="@@edit")
+
+        self.assertEqual(
+            ['Common', 'Classification'], browser.css('legend').text
+        )
+
+    @browsing
+    def test_group_is_visible_when_property_sheets_are_defined(self, browser):
+        self.login(self.manager, browser)
+        create(
+            Builder("property_sheet_schema")
+            .named("schema")
+            .with_field("text", u"foo", u"some input", u"", True)
+        )
+
+        self.login(self.regular_user, browser)
+        browser.open(self.document, view="@@edit")
+
+        self.assertEqual(
+            ['Common', 'Classification', 'Custom properties'],
+            browser.css('legend').text,
+        )
+
+
+class TestCustomPropertiesFieldsetForDocumentAddForm(IntegrationTestCase):
+
+    @browsing
+    def test_group_is_hidden_when_no_property_sheets_are_defined(self, browser):
+        self.login(self.regular_user, browser)
+        browser.open(self.dossier, view="++add++opengever.document.document")
+
+        self.assertEqual(
+            ['Common', 'Classification'], browser.css('legend').text
+        )
+
+    @browsing
+    def test_group_is_visible_when_property_sheets_are_defined(self, browser):
+        self.login(self.manager, browser)
+        create(
+            Builder("property_sheet_schema")
+            .named("schema")
+            .with_field("text", u"foo", u"some input", u"", True)
+        )
+
+        self.login(self.regular_user, browser)
+        browser.open(self.dossier, view="++add++opengever.document.document")
+
+        self.assertEqual(
+            ['Common', 'Classification', 'Custom properties'],
+            browser.css('legend').text,
+        )

--- a/opengever/propertysheets/tests/test_mail_default_view.py
+++ b/opengever/propertysheets/tests/test_mail_default_view.py
@@ -1,0 +1,71 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.testbrowser import browsing
+from opengever.document.behaviors.customproperties import IDocumentCustomProperties
+from opengever.testing import IntegrationTestCase
+
+
+class TestMailDefaultViewWithCustomProperties(IntegrationTestCase):
+
+    CUSTOM_PROPERTIES_LABEL = u"Custom properties"
+
+    @browsing
+    def test_document_default_view_displays_custom_properties(self, browser):
+        self.login(self.manager)
+        create(
+            Builder("property_sheet_schema")
+            .named("schema")
+            .assigned_to_slots(u"IDocumentMetadata.document_type.question")
+            .with_field("text", u"foo", u"some input", u"", True)
+        )
+        self.mail_eml.document_type = u"question"
+        IDocumentCustomProperties(self.mail_eml).custom_properties = {
+            u"IDocumentMetadata.document_type.question": {u"foo": u"qux"}
+        }
+
+        self.login(self.regular_user, browser)
+        browser.open(self.mail_eml, view="view")
+
+        table = browser.css(".dossier-detail-listing").first
+        self.assertIsNotNone(table.find(self.CUSTOM_PROPERTIES_LABEL))
+        data_row = table.lists()[-1]
+        self.assertEqual(
+            [self.CUSTOM_PROPERTIES_LABEL, "some input qux"], data_row
+        )
+
+    @browsing
+    def test_document_default_view_displays_no_properties_label(self, browser):
+        self.login(self.manager)
+        create(
+            Builder("property_sheet_schema")
+            .named("schema")
+            .assigned_to_slots(u"IDocumentMetadata.document_type.question")
+            .with_field("text", u"foo", u"some input", u"", True)
+        )
+        self.mail_eml.document_type = u"contract"
+
+        self.login(self.regular_user, browser)
+        browser.open(self.mail_eml, view="view")
+
+        table = browser.css(".dossier-detail-listing").first
+        self.assertIsNotNone(table.find(self.CUSTOM_PROPERTIES_LABEL))
+        data_row = table.lists()[-1]
+        self.assertEqual(
+            [
+                self.CUSTOM_PROPERTIES_LABEL,
+                "No custom properties are available.",
+            ],
+            data_row,
+        )
+
+    @browsing
+    def test_document_default_view_hides_properties_when_no_sheet_is_defined(
+        self, browser
+    ):
+        self.login(self.manager)
+
+        self.login(self.regular_user, browser)
+        browser.open(self.mail_eml, view="view")
+
+        table = browser.css(".dossier-detail-listing").first
+        self.assertIsNone(table.find(self.CUSTOM_PROPERTIES_LABEL))

--- a/opengever/propertysheets/tests/test_mail_forms.py
+++ b/opengever/propertysheets/tests/test_mail_forms.py
@@ -1,0 +1,33 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.testbrowser import browsing
+from opengever.testing import IntegrationTestCase
+
+
+class TestCustomPropertiesFieldsetForMailEditForm(IntegrationTestCase):
+
+    @browsing
+    def test_group_is_hidden_when_no_property_sheets_are_defined(self, browser):
+        self.login(self.regular_user, browser)
+        browser.open(self.mail_eml, view="@@edit")
+
+        self.assertEqual(
+            ['Common', 'Classification'], browser.css('legend').text
+        )
+
+    @browsing
+    def test_group_is_visible_when_property_sheets_are_defined(self, browser):
+        self.login(self.manager, browser)
+        create(
+            Builder("property_sheet_schema")
+            .named("schema")
+            .with_field("text", u"foo", u"some input", u"", True)
+        )
+
+        self.login(self.regular_user, browser)
+        browser.open(self.mail_eml, view="@@edit")
+
+        self.assertEqual(
+            ['Common', 'Classification', 'Custom properties'],
+            browser.css('legend').text,
+        )

--- a/opengever/propertysheets/tests/test_schema_definition_post.py
+++ b/opengever/propertysheets/tests/test_schema_definition_post.py
@@ -157,7 +157,7 @@ class TestSchemaDefinitionPost(IntegrationTestCase):
 
         self.assertEqual(
             ["yn", "wahl", "nummer", "text", "zeiletext"],
-            getFieldNamesInOrder(definition.schema_class)
+            definition.get_fieldnames()
         )
 
     @browsing

--- a/opengever/propertysheets/tests/test_schema_definition_post.py
+++ b/opengever/propertysheets/tests/test_schema_definition_post.py
@@ -358,6 +358,34 @@ class TestSchemaDefinitionPost(IntegrationTestCase):
         self.assertEqual([], storage.list())
 
     @browsing
+    def test_property_sheet_schema_definition_post_prevents_duplicate_field_name(
+        self, browser
+    ):
+        self.login(self.manager, browser)
+
+        dupe1 = {"name": "dupe", "field_type": "text"}
+        dupe2 = {"name": "foo", "field_type": "text"}
+        data = {"fields": [dupe1, dupe1, dupe2, dupe2]}
+        with browser.expect_http_error(400):
+            browser.open(
+                view="@propertysheets/foo",
+                method="POST",
+                data=json.dumps(data),
+                headers=self.api_headers,
+            )
+
+        self.assertDictContainsSubset(
+            {
+                u"message": u"Duplicate fields 'dupe', 'foo'.",
+                "type": "BadRequest",
+            },
+            browser.json,
+        )
+
+        storage = PropertySheetSchemaStorage()
+        self.assertEqual([], storage.list())
+
+    @browsing
     def test_property_sheet_schema_definition_post_invalid_type(self, browser):
         self.login(self.manager, browser)
 

--- a/opengever/propertysheets/tests/test_storage.py
+++ b/opengever/propertysheets/tests/test_storage.py
@@ -73,6 +73,34 @@ class TestPropertySheetSchemaStorage(FunctionalTestCase):
             ["schema1", "schema2"], [each.name for each in storage.list()]
         )
 
+    def test_storage_len_empty(self):
+        storage = PropertySheetSchemaStorage()
+        self.assertEqual(0, len(storage))
+
+    def test_storage_len_with_definitions(self):
+        storage = PropertySheetSchemaStorage()
+        definition1 = PropertySheetSchemaDefinition.create("schema1")
+        storage.save(definition1)
+
+        self.assertEqual(1, len(storage))
+
+        storage = PropertySheetSchemaStorage()
+        definition2 = PropertySheetSchemaDefinition.create("schema2")
+        storage.save(definition2)
+
+        self.assertEqual(2, len(storage))
+
+    def test_storage_is_falsy_when_empty(self):
+        storage = PropertySheetSchemaStorage()
+        self.assertFalse(storage)
+
+    def test_storage_is_truthy_when_not_empty(self):
+        storage = PropertySheetSchemaStorage()
+        definition1 = PropertySheetSchemaDefinition.create("schema1")
+        storage.save(definition1)
+
+        self.assertTrue(storage)
+
     def test_prevents_duplicate_assignments(self):
         storage = PropertySheetSchemaStorage()
         fixture = PropertySheetSchemaDefinition.create(

--- a/opengever/propertysheets/tests/test_widget.py
+++ b/opengever/propertysheets/tests/test_widget.py
@@ -147,6 +147,28 @@ class TestPropertySheetWidget(IntegrationTestCase):
         )
 
     @browsing
+    def test_render_info_message_when_no_fields_available(self, browser):
+        self.login(self.manager, browser)
+        create(
+            Builder("property_sheet_schema")
+            .named("schema1")
+            .assigned_to_slots(u"IDocumentMetadata.document_type.contract")
+            .with_field(
+                "textline", u"textline", u"Textline", u"A line of text", True
+            )
+        )
+        self.document.document_type = u"question"
+
+        self.login(self.regular_user, browser)
+        browser.open(self.document, view="@@edit")
+
+        node = browser.css(
+            "#formfield-form-widgets-IDocumentCustomProperties-"
+            "custom_properties .noCustomPropertyFields"
+        ).first
+        self.assertEqual("No custom properties are available.", node.text)
+
+    @browsing
     def test_edit_required_textline_rendering_and_error_message(self, browser):
         self.login(self.manager, browser)
 

--- a/opengever/propertysheets/tests/test_widget.py
+++ b/opengever/propertysheets/tests/test_widget.py
@@ -38,11 +38,11 @@ class TestPropertySheetWidget(IntegrationTestCase):
             "#formfield-form-widgets-"
             "IDocumentCustomProperties-custom_properties"
         ).first
-        input_labels = fieldset.css(".custom-field label").text
+        input_labels = fieldset.css(".field label").text
         self.assertEqual(
             [
-                u"",  # checkbox labels are rendered next to input
-                "Yes or no",
+                u"Custom properties",  # the composite fiel label
+                u"Yes or no",
                 u"Choose",
                 u"Number",
                 u"Some lines of text",

--- a/opengever/propertysheets/tests/test_widget.py
+++ b/opengever/propertysheets/tests/test_widget.py
@@ -1,0 +1,242 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.testbrowser import browsing
+from ftw.testbrowser.pages.dexterity import erroneous_fields
+from ftw.testbrowser.pages.statusmessages import error_messages
+from ftw.testbrowser.pages.statusmessages import info_messages
+from opengever.document.behaviors.customproperties import IDocumentCustomProperties
+from opengever.testing import IntegrationTestCase
+
+
+class TestPropertySheetWidget(IntegrationTestCase):
+
+    @browsing
+    def test_edit_field_rendering_and_submission_all_field_types(
+        self, browser
+    ):
+        self.login(self.manager, browser)
+
+        choices = ["one", "two", "three"]
+        create(
+            Builder("property_sheet_schema")
+            .named("schema1")
+            .assigned_to_slots(u"IDocumentMetadata.document_type.question")
+            .with_field("bool", u"yesorno", u"Yes or no", u"", True)
+            .with_field(
+                "choice", u"choose", u"Choose", u"", True, values=choices
+            )
+            .with_field("int", u"num", u"Number", u"", True)
+            .with_field("text", u"text", u"Some lines of text", u"", True)
+            .with_field("textline", u"textline", u"A line of text", u"", True)
+        )
+        self.document.document_type = u"question"
+
+        self.login(self.regular_user, browser)
+        browser.open(self.document, view="@@edit")
+
+        fieldset = browser.css(
+            "#formfield-form-widgets-"
+            "IDocumentCustomProperties-custom_properties"
+        ).first
+        input_labels = fieldset.css(".custom-field label").text
+        self.assertEqual(
+            [
+                u"",  # checkbox labels are rendered next to input
+                "Yes or no",
+                u"Choose",
+                u"Number",
+                u"Some lines of text",
+                u"A line of text",
+            ],
+            input_labels,
+        )
+
+        browser.fill(
+            {
+                "Yes or no": True,
+                "Choose": "two",
+                "Number": "3",
+                "Some lines of text": "Foo\nbar",
+                "A line of text": u"b\xe4\xe4",
+            }
+        )
+        browser.click_on("Save")
+        self.assertEquals(["Changes saved"], info_messages())
+        self.assertEqual(
+            {
+                "IDocumentMetadata.document_type.question": {
+                    "text": u"Foo\nbar",
+                    "num": 3,
+                    "yesorno": True,
+                    "choose": u"two",
+                    "textline": u"b\xe4\xe4",
+                }
+            },
+            IDocumentCustomProperties(self.document).custom_properties,
+        )
+
+    @browsing
+    def test_add_rendering_and_submission_all_field_types(self, browser):
+        self.login(self.manager, browser)
+
+        choices = ["one", "two", "three"]
+        create(
+            Builder("property_sheet_schema")
+            .named("schema1")
+            .assigned_to_slots(u"IDocumentMetadata.document_type.question")
+            .with_field("bool", u"yesorno", u"Yes or no", u"", True)
+            .with_field(
+                "choice", u"choose", u"Choose", u"", True, values=choices
+            )
+            .with_field("int", u"num", u"Number", u"", True)
+            .with_field("text", u"text", u"Some lines of text", u"", True)
+            .with_field("textline", u"textline", u"A line of text", u"", True)
+        )
+
+        self.login(self.regular_user, browser)
+        browser.open(self.dossier, view="++add++opengever.document.document")
+
+        # initially no fields for custom properties are rendered as we do not
+        # know the document_type yet
+        fieldset = browser.css(
+            "#formfield-form-widgets-"
+            "IDocumentCustomProperties-custom_properties"
+        ).first
+        input_labels = fieldset.css(".custom-field label").text
+        self.assertEqual(0, len(input_labels))
+
+        browser.fill({"Title": "foo", "Document type": "Inquiry"}).save()
+
+        # the initial save will produce errors as we now have a document_type
+        # which requires some mandatory custom properties.
+        self.assertEqual(["There were some errors."], error_messages())
+        errors = erroneous_fields()
+        self.assertIn("Custom properties", errors)
+        self.assertIn(
+            "Custom properties contain some errors.",
+            errors["Custom properties"],
+        )
+
+        # when we provide the custom properties, saving will succeed
+        with self.observe_children(self.dossier) as children:
+            browser.fill(
+                {
+                    "Yes or no": True,
+                    "Choose": "two",
+                    "Number": "3",
+                    "Some lines of text": "Foo\nbar",
+                    "A line of text": u"b\xe4\xe4",
+                }
+            ).save()
+
+        self.assertEqual(1, len(children["added"]))
+        document = children["added"].pop()
+
+        self.assertEquals(["Item created"], info_messages())
+        self.assertEqual(
+            {
+                "IDocumentMetadata.document_type.question": {
+                    "text": u"Foo\nbar",
+                    "num": 3,
+                    "yesorno": True,
+                    "choose": u"two",
+                    "textline": u"b\xe4\xe4",
+                }
+            },
+            IDocumentCustomProperties(document).custom_properties,
+        )
+
+    @browsing
+    def test_edit_required_textline_rendering_and_error_message(self, browser):
+        self.login(self.manager, browser)
+
+        create(
+            Builder("property_sheet_schema")
+            .named("schema1")
+            .assigned_to_slots(u"IDocumentMetadata.document_type.question")
+            .with_field(
+                "textline", u"textline", u"Textline", u"A line of text", True
+            )
+        )
+        self.document.document_type = u"question"
+
+        self.login(self.regular_user, browser)
+        browser.open(self.document, view="@@edit")
+
+        browser.fill({"Textline": None})
+        browser.click_on("Save")
+
+        self.assertEqual(["There were some errors."], error_messages())
+        # check rendering and chosen id
+        field = browser.css(
+            "#formfield-custom_property-IDocumentMetadata_document_type_question-textline"
+        ).first
+        self.assertEqual("Textline", field.css("label").first.raw_text.strip())
+        self.assertEqual("A line of text", field.css(".formHelp").first.text)
+        # check field error message
+        self.assertEqual(
+            "Required input is missing.",
+            field.css(".fieldErrorBox").first.text,
+        )
+
+    @browsing
+    def test_edit_required_text_rendering_and_error_message(self, browser):
+        self.login(self.manager, browser)
+
+        create(
+            Builder("property_sheet_schema")
+            .named("schema1")
+            .assigned_to_slots(u"IDocumentMetadata.document_type.question")
+            .with_field("text", u"text", u"Text", u"A lot of text", True)
+        )
+        self.document.document_type = u"question"
+
+        self.login(self.regular_user, browser)
+        browser.open(self.document, view="@@edit")
+
+        browser.fill({"Text": None})
+        browser.click_on("Save")
+
+        self.assertEqual(["There were some errors."], error_messages())
+        # check rendering and chosen id
+        field = browser.css(
+            "#formfield-custom_property-IDocumentMetadata_document_type_question-text"
+        ).first
+        self.assertEqual("Text", field.css("label").first.raw_text.strip())
+        self.assertEqual("A lot of text", field.css(".formHelp").first.text)
+        # check field error message
+        self.assertEqual(
+            "Required input is missing.",
+            field.css(".fieldErrorBox").first.text,
+        )
+
+    @browsing
+    def test_edit_required_number_rendering_and_error_message(self, browser):
+        self.login(self.manager, browser)
+
+        create(
+            Builder("property_sheet_schema")
+            .named("schema1")
+            .assigned_to_slots(u"IDocumentMetadata.document_type.question")
+            .with_field("int", u"num", u"Number", u"A Number", True)
+        )
+        self.document.document_type = u"question"
+
+        self.login(self.regular_user, browser)
+        browser.open(self.document, view="@@edit")
+
+        browser.fill({"Number": None})
+        browser.click_on("Save")
+
+        self.assertEqual(["There were some errors."], error_messages())
+        # check rendering and chosen id
+        field = browser.css(
+            "#formfield-custom_property-IDocumentMetadata_document_type_question-num"
+        ).first
+        self.assertEqual("Number", field.css("label").first.raw_text.strip())
+        self.assertEqual("A Number", field.css(".formHelp").first.text)
+        # check field error message
+        self.assertEqual(
+            "Required input is missing.",
+            field.css(".fieldErrorBox").first.text,
+        )

--- a/opengever/propertysheets/widgets.py
+++ b/opengever/propertysheets/widgets.py
@@ -1,6 +1,5 @@
 from opengever.propertysheets.field import IPropertySheetField
 from plone.restapi.serializer.converters import json_compatible
-from plone.schema.browser.jsonfield import JSONDataConverter
 from z3c.form.interfaces import IDataConverter
 from z3c.form.interfaces import IWidget
 from zope.component import adapter
@@ -9,10 +8,22 @@ from zope.interface import implementer
 
 @adapter(IPropertySheetField, IWidget)
 @implementer(IDataConverter)
-class PropertySheetFieldDataConverter(JSONDataConverter):
+class PropertySheetFieldDataConverter(object):
+
+    def __init__(self, field, widget):
+        self.field = field
+        self.widget = widget
 
     def toWidgetValue(self, value):
         """Make sure to convert persistent dicts to json compatible data."""
 
-        value = json_compatible(value)
-        return super(PropertySheetFieldDataConverter, self).toWidgetValue(value)
+        return json_compatible(value)
+
+    def toFieldValue(self, value):
+        """See interfaces.IDataConverter"""
+
+        if not value:
+            return self.field.missing_value
+
+        self.field.validate(value)
+        return value

--- a/opengever/propertysheets/widgets.py
+++ b/opengever/propertysheets/widgets.py
@@ -60,6 +60,7 @@ class PropertySheetWiget(Widget):
             identifier = self._make_widget_identifier(slot_name, name)
             widget.name = identifier
             widget.id = identifier
+            widget.mode = self.mode
             widget.update()  # update is required to set up terms for sequences
             self.widgets.append(widget)
 

--- a/opengever/propertysheets/widgets.py
+++ b/opengever/propertysheets/widgets.py
@@ -16,7 +16,6 @@ from zope.interface import implementer
 from zope.interface import implementsOnly
 from zope.interface import Invalid
 from zope.schema import getFieldNamesInOrder
-from zope.schema import getFieldsInOrder
 
 
 class IPropertySheetWiget(IWidget):
@@ -53,9 +52,7 @@ class PropertySheetWiget(Widget):
         if definition is None:
             return
 
-        schema_class = definition.schema_class
-
-        for name, field in getFieldsInOrder(schema_class):
+        for name, field in definition.get_fields():
             widget = getMultiAdapter((field, self.request), IFieldWidget)
             identifier = self._make_widget_identifier(slot_name, name)
             widget.name = identifier
@@ -93,14 +90,11 @@ class PropertySheetWiget(Widget):
         if definition is None:
             return default
 
-        schema_class = definition.schema_class
         errors = ()
         sheet_values = {}
         found_request_value = False
 
-        for name, widget in zip(
-            getFieldNamesInOrder(schema_class), self.widgets
-        ):
+        for name, widget in zip(definition.get_fieldnames(), self.widgets):
             value = widget.field.missing_value
             try:
                 widget.setErrors = self.setErrors

--- a/opengever/propertysheets/widgets.py
+++ b/opengever/propertysheets/widgets.py
@@ -1,29 +1,174 @@
+from opengever.propertysheets import _
 from opengever.propertysheets.field import IPropertySheetField
+from opengever.propertysheets.storage import PropertySheetSchemaStorage
 from plone.restapi.serializer.converters import json_compatible
+from z3c.form import interfaces
+from z3c.form.error import MultipleErrors
 from z3c.form.interfaces import IDataConverter
+from z3c.form.interfaces import IFieldWidget
+from z3c.form.interfaces import IFormLayer
 from z3c.form.interfaces import IWidget
+from z3c.form.widget import FieldWidget
+from z3c.form.widget import Widget
 from zope.component import adapter
+from zope.component import getMultiAdapter
 from zope.interface import implementer
+from zope.interface import implementsOnly
+from zope.interface import Invalid
+from zope.schema import getFieldNamesInOrder
+from zope.schema import getFieldsInOrder
+
+
+class IPropertySheetWiget(IWidget):
+    pass
+
+
+class PropertySheetWiget(Widget):
+    """Composite widget rendering all fields for the active assignment slot.
+
+    Extra care has to be taken when extracting values as `extract` will be
+    called on various occasions. We only want to raise errors when the instance
+    variable `setErrors` has ben set to `True` externally by the manager.
+
+    Implementation has been inspired by existing widget managers that already
+    render a list of widgets:
+    - `z3c.form.field.FieldWidgets`
+    - `z3c.form.contentprovider.FieldWidgetsAndProviders`
+    """
+    implementsOnly(IPropertySheetWiget)
+
+    def __init__(self, request):
+        super(PropertySheetWiget, self).__init__(request)
+        self.widgets = []
+
+    def _make_widget_identifier(self, slot_name, name):
+        slot_name = slot_name.replace(".", "_")
+        return "custom_property-{}-{}".format(slot_name, name)
+
+    def initialize_widgets(self):
+        self.widgets = []
+
+        slot_name = self.field.get_active_assignment_slot(context=self.context)
+        definition = PropertySheetSchemaStorage().query(slot_name)
+        if definition is None:
+            return
+
+        schema_class = definition.schema_class
+
+        for name, field in getFieldsInOrder(schema_class):
+            widget = getMultiAdapter((field, self.request), IFieldWidget)
+            identifier = self._make_widget_identifier(slot_name, name)
+            widget.name = identifier
+            widget.id = identifier
+            widget.update()  # update is required to set up terms for sequences
+            self.widgets.append(widget)
+
+    def update(self):
+        super(PropertySheetWiget, self).update()
+        self.initialize_widgets()
+
+        slot_name = self.field.get_active_assignment_slot(context=self.context)
+        definition = PropertySheetSchemaStorage().query(slot_name)
+        if definition is None:
+            return
+
+        schema_class = definition.schema_class
+        obj = self.value or dict()
+        sheet_values = obj.get(slot_name, {})
+
+        for name, widget in zip(
+            getFieldNamesInOrder(schema_class), self.widgets
+        ):
+            converter = IDataConverter(widget)
+            sheet_value = sheet_values.get(name, None)
+            widget.value = converter.toWidgetValue(sheet_value)
+            widget.update()
+
+    def extract(self, default=interfaces.NO_VALUE):
+        self.initialize_widgets()
+
+        slot_name = self.field.get_active_assignment_slot(context=self.context)
+        definition = PropertySheetSchemaStorage().query(slot_name)
+        if definition is None:
+            return default
+
+        schema_class = definition.schema_class
+        errors = ()
+        sheet_values = {}
+        found_request_value = False
+
+        for name, widget in zip(
+            getFieldNamesInOrder(schema_class), self.widgets
+        ):
+            value = widget.field.missing_value
+            try:
+                widget.setErrors = self.setErrors
+                raw = widget.extract(default=default)
+                if raw is not default:
+                    found_request_value = True
+                    value = IDataConverter(widget).toFieldValue(raw)
+                validator = getMultiAdapter(
+                    (
+                        self.context,
+                        self.request,
+                        self.form,
+                        getattr(widget, "field", None),
+                        widget,
+                    ),
+                    interfaces.IValidator,
+                )
+                validator.validate(value)
+            except (Invalid, ValueError, MultipleErrors) as error:
+                view = getMultiAdapter(
+                    (
+                        error,
+                        self.request,
+                        widget,
+                        widget.field,
+                        self.form,
+                        self.context,
+                    ),
+                    interfaces.IErrorViewSnippet,
+                )
+                view.update()
+                if self.setErrors:
+                    widget.error = view
+                errors += (view,)
+            else:
+                sheet_values[name] = value
+
+        if self.setErrors and errors:
+            # raise an error if one of our contained widgets has found an
+            # error. No details are necessary, they will be rendered next
+            # to the failing widget.
+            raise Invalid(_(u"Custom properties contain some errors."))
+
+        # Be careful not to return the dict we have created in case of no
+        # actual request value. We only want to return the nested data
+        # structure when data is in the request.
+        if not found_request_value:
+            return default
+
+        return {slot_name: sheet_values}
+
+
+@adapter(IPropertySheetField, IFormLayer)
+@implementer(IFieldWidget)
+def PropertySheetFieldWiget(field, request):
+    return FieldWidget(field, PropertySheetWiget(request))
 
 
 @adapter(IPropertySheetField, IWidget)
 @implementer(IDataConverter)
 class PropertySheetFieldDataConverter(object):
-
     def __init__(self, field, widget):
         self.field = field
         self.widget = widget
 
     def toWidgetValue(self, value):
-        """Make sure to convert persistent dicts to json compatible data."""
-
+        """Make sure to convert Persistent to json compatible data."""
         return json_compatible(value)
 
     def toFieldValue(self, value):
-        """See interfaces.IDataConverter"""
-
-        if not value:
-            return self.field.missing_value
-
         self.field.validate(value)
         return value

--- a/opengever/propertysheets/widgets.py
+++ b/opengever/propertysheets/widgets.py
@@ -1,0 +1,18 @@
+from opengever.propertysheets.field import IPropertySheetField
+from plone.restapi.serializer.converters import json_compatible
+from plone.schema.browser.jsonfield import JSONDataConverter
+from z3c.form.interfaces import IDataConverter
+from z3c.form.interfaces import IWidget
+from zope.component import adapter
+from zope.interface import implementer
+
+
+@adapter(IPropertySheetField, IWidget)
+@implementer(IDataConverter)
+class PropertySheetFieldDataConverter(JSONDataConverter):
+
+    def toWidgetValue(self, value):
+        """Make sure to convert persistent dicts to json compatible data."""
+
+        value = json_compatible(value)
+        return super(PropertySheetFieldDataConverter, self).toWidgetValue(value)


### PR DESCRIPTION
With this PR we add support for custom properties in the classic UI. Custom properties have previously been enabled for mails and documents via API in https://github.com/4teamwork/opengever.core/pull/6823, but so far they were not visible in any way in the classic UI. The properties are shown/rendered as follows:

- when no property sheets are defined, no custom property forms/fieldsets are show
- when propety sheets are available in the plone site but none is active based on the current value of `document_type`, the fieldsets are rendered empty <img width="730" alt="Screenshot 2021-01-28 at 10 53 39" src="https://user-images.githubusercontent.com/736583/106120802-1d816380-6157-11eb-85ea-0de9fb6a839d.png">
- when property sheets are available and there is an active sheet, fields are rendered in add and edit forms ![Screenshot 2021-01-28 at 10 48 22](https://user-images.githubusercontent.com/736583/106120274-78ff2180-6156-11eb-8d58-53a3216dbc71.png) Currently the property sheet to be rendered will be selected based on the chosen document type. The sheet will only be refreshed when the form is saved and submitted.
- custom properties are displayed in the default metadata view (Aktionen -> Metadaten anzeigen) of documents and mails, when they are available and set.
<img width="573" alt="Screenshot 2021-01-28 at 11 21 29" src="https://user-images.githubusercontent.com/736583/106124081-ff1d6700-615a-11eb-8c47-eb7ad6f90a52.png">


The custom fields are implemented as a composite widget renderer for the `custom_properties` field. Handling of composite widgets/fields has been inspired by existing widget managers like  [z3c.form.field.FieldWidgets](https://github.com/zopefoundation/z3c.form/blob/440eb18c541b88f64e88be9b66fbc27748f75af2/src/z3c/form/field.py#L167-L168) and [z3c.form.contentprovider.FieldWidgetsAndProviders](https://github.com/zopefoundation/z3c.form/blob/440eb18c541b88f64e88be9b66fbc27748f75af2/src/z3c/form/contentprovider.py#L48-L49).


With this PR we also provide the following changes:
- Fix not accepting values argument in schema definition `POST`
- Add proper support for field order in schema definition `POST`
- Don't inherit from JSON fields any more as the value conversion implementation stands in our way. We do not store JSON but nested data in a dictionary and extraction from the request needs to be implemented differently as we render a schema and don't accept arbitrary JSON.

Jira: https://4teamwork.atlassian.net/browse/CA-1284

_I think reviewing the whole diff rather than the individual commits may be easier here as in the end i did refactor and improve some things. I have decided to keep the individual commits, but can try a fixup if desired._

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


## Checklist (if applicable)

_Only applicable should be left and checked._

- API change:
  - [x] Documentation is updated
  - [ ] ~~API Changelog entry (see [guide]~~ _IMO not necessary as we change a recently introduced, unused endpoint_
- New functionality:
  - [x] for `document` also works for `mail`
- New translations
  - [x] All msg-strings are unicode
