### PR TITLE
Add a new solr-index 'is_folderish'.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2021.3.0 (unreleased)
 ---------------------
 
+- Add a new solr-index 'is_folderish'. [elioschmutz]
 - Return only badge notifications in @notifications endpoint. [tinagerber]
 - Only show create_proposal action on dossiers. [tinagerber]
 - Enable Usersnap by default in SaaS policy template. [lgraf]

--- a/opengever/base/tests/test_indexers.py
+++ b/opengever/base/tests/test_indexers.py
@@ -369,3 +369,50 @@ class TestGetObjPositionInParentIndexer(SolrIntegrationTestCase):
             (self.seq_subtask_2.Title(), 1),
             (u'Neue Aufgabe', 2), (self.seq_subtask_3.Title(), 3)],
             [(item['Title'], item['getObjPositionInParent']) for item in browser.json["items"]])
+
+
+class TestIsFolderishIndexer(SolrIntegrationTestCase):
+
+    @browsing
+    def test_is_folderish_solr_index(self, browser):
+        self.login(self.administrator, browser=browser)
+
+        url = u'{}/@solrsearch?sort=portal_type asc&fl=is_folderish&fq=UID:({})'.format(
+            self.portal.absolute_url(),
+            ' OR '.join([
+                self.leaf_repofolder.UID(),
+                self.dossier.UID(),
+                self.document.UID(),
+                self.task.UID(),
+                self.seq_subtask_2.UID(),
+                self.proposal.UID(),
+                self.tasktemplate.UID(),
+                self.workspace.UID(),
+                self.todolist_general.UID(),
+                self.todo.UID(),
+            ]))
+        browser.open(url, method='GET', headers=self.api_headers)
+        self.maxDiff = None
+
+        self.assertEqual([
+            {u'UID': self.document.UID(),
+             u'is_folderish': False},
+            {u'UID': self.dossier.UID(),
+             u'is_folderish': True},
+            {u'UID': self.proposal.UID(),
+             u'is_folderish': True},
+            {u'UID': self.leaf_repofolder.UID(),
+             u'is_folderish': True},
+            {u'UID': self.task.UID(),
+             u'is_folderish': True},
+            {u'UID': self.seq_subtask_2.UID(),
+             u'is_folderish': True},
+            {u'UID': self.tasktemplate.UID(),
+             u'is_folderish': False},
+            {u'UID': self.todo.UID(),
+             u'is_folderish': True},
+            {u'UID': self.todolist_general.UID(),
+             u'is_folderish': True},
+            {u'UID': self.workspace.UID(),
+             u'is_folderish': True}
+        ], browser.json["items"])

--- a/opengever/base/tests/test_solr.py
+++ b/opengever/base/tests/test_solr.py
@@ -91,7 +91,6 @@ class TestSolr(IntegrationTestCase):
             'date_of_completion',
             'getId',
             'is_default_page',
-            'is_folderish',
             'predecessor',
             'sortable_author',
         ]
@@ -113,7 +112,6 @@ class TestSolr(IntegrationTestCase):
             'getContentType',
             'getId',
             'in_response_to',
-            'is_folderish',
             'listCreators',
             'predecessor',
             'title_de',

--- a/opengever/core/upgrades/20210128112320_index_is_folderish_solr_index/upgrade.py
+++ b/opengever/core/upgrades/20210128112320_index_is_folderish_solr_index/upgrade.py
@@ -1,0 +1,27 @@
+from ftw.solr.interfaces import ISolrConnectionManager
+from ftw.solr.interfaces import ISolrIndexHandler
+from ftw.upgrade import ProgressLogger
+from ftw.upgrade import UpgradeStep
+from plone.dexterity.interfaces import IDexterityContent
+from zope.component import getMultiAdapter
+from zope.component import getUtility
+
+
+class IndexIsFolderishSolrIndex(UpgradeStep):
+    """Index is folderish solr index.
+    """
+
+    deferrable = True
+
+    def __call__(self):
+        self.index_is_folderish()
+
+    def index_is_folderish(self):
+        manager = getUtility(ISolrConnectionManager)
+        contents = self.catalog_unrestricted_search({
+            'object_provides': IDexterityContent.__identifier__,
+        })
+        for content in ProgressLogger('Index is_folderish in Solr', contents):
+            handler = getMultiAdapter((content, manager), ISolrIndexHandler)
+            handler.add(['is_folderish'])
+        manager.connection.commit(soft_commit=False, extract_after_commit=False)

--- a/solr-conf/managed-schema
+++ b/solr-conf/managed-schema
@@ -125,6 +125,7 @@
     <field name="Subject" type="string" indexed="true" stored="true" multiValued="true"/>
     <field name="UID" type="string" indexed="true" stored="true" required="true" multiValued="false" />
     <field name="getObjPositionInParent" type="pint" indexed="true" stored="true" />
+    <field name="is_folderish" type="boolean" indexed="true" stored="true"/>
 
     <!-- GEVER specific fields -->
     <field name="bumblebee_checksum" type="string" indexed="false" stored="false" />


### PR DESCRIPTION
This PR adds the plone `is_folderish` index to the solr.

Jira: https://4teamwork.atlassian.net/browse/NE-281

We reuse the already existing indexer from plone which checks the `isPrincipiaFolderish`, as well as the `INonStructuralFolder` to decide if a content is folderish or not.

See https://github.com/plone/Products.CMFPlone/blob/4.3.18/Products/CMFPlone/CatalogTool.py#L235 for more information about the plone implementation.

⌛ Estimated Time to reindex:
- 80'000: 2 min
- 1'000'000: 25 min

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


## Checklist (if applicable)

_Only applicable should be left and checked._

- API change:
  - [ ] Documentation is updated
  - [ ] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Upgrade steps (changes in profile):
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
- DB-Schema migration
  - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
  - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value
