### PR TITLE
Synchronize the path to the RIS-Solr

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2021.3.0 (unreleased)
 ---------------------
 
+- Include path in the data submitted by the Solr update chain. [sebastianmanger]
 - Harmonize translations for document sent and received dates. [lgraf]
 - Add a new solr-index 'is_folderish'. [elioschmutz]
 - Do not escape boolean filters in solr endpoints. [tinagerber]

--- a/solr-conf/sync-solr.js
+++ b/solr-conf/sync-solr.js
@@ -274,6 +274,7 @@ function processAdd(cmd) {
     updateDocument = fillPayload(updateDocument, doc, "Title");
     updateDocument = fillPayload(updateDocument, doc, "portal_type");
     updateDocument = fillPayload(updateDocument, doc, "trashed");
+    updateDocument = fillPayload(updateDocument, doc, "path");
     updateDocument = fillPayload(
       updateDocument,
       doc,


### PR DESCRIPTION
This is required so that RIS can do subsequent API request to a path.

RIS provides a "global search" where users can search in the RIS metadata and GEVER documents. The search is handled by the "RIS-Solr", and documents are synced into this Solr by GEVER with the update chain (#6576).
We must now display the `history` of the documents that are on display in the search result - so an API request to GEVER based on the information available in the Solr index must be made.

Together with @deiferni we evaluated several options and simply passing the path to the RIS solr seemed the least painful one (rejected alternatives: store the oguid, add an api view to resolve an element by the UID). RIS knows the GEVER base URL, and the `path` attribute is already stored for RIS-elements in the solr.

## Checklist (Must have)

- [x] Changelog entry
- [x] Link to issue https://4teamwork.atlassian.net/browse/HG-603
