### PR TITLE
Add blocked_local_roles field in serialization of dossiers and repofolders, index field in solr

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 ---------------------
 
 - Add a new solr-index 'is_folderish'. [elioschmutz]
+- Include blocked_local_roles in serialization of dossiers and repofolders. [tinagerber]
 - Index blocked_local_roles in solr and allow field in @listing endpoint. [tinagerber]
 - Return only badge notifications in @notifications endpoint. [tinagerber]
 - Only show create_proposal action on dossiers. [tinagerber]

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 ---------------------
 
 - Add a new solr-index 'is_folderish'. [elioschmutz]
+- Index blocked_local_roles in solr and allow field in @listing endpoint. [tinagerber]
 - Return only badge notifications in @notifications endpoint. [tinagerber]
 - Only show create_proposal action on dossiers. [tinagerber]
 - Enable Usersnap by default in SaaS policy template. [lgraf]

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 ---------------------
 
 - Add a new solr-index 'is_folderish'. [elioschmutz]
+- Do not escape boolean filters in solr endpoints. [tinagerber]
 - Include blocked_local_roles in serialization of dossiers and repofolders. [tinagerber]
 - Index blocked_local_roles in solr and allow field in @listing endpoint. [tinagerber]
 - Return only badge notifications in @notifications endpoint. [tinagerber]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -17,6 +17,7 @@ Breaking Changes
 Other Changes
 ^^^^^^^^^^^^^
 
+- The field ``blocked_local_roles`` is now included in the serialization of documents and repository folders.
 - ``@listing``: Add ``blocked_local_roles`` as allowed field (see :ref:`docs <listings>`).
 - Add support for english: new field ``title_en`` is returned wherever appropriate (``@schema``, ``@types`` and simple GET for diverse content types) when English is enabled for the deployment.
 - ``@journal``: Include ``related_documents`` in journal entry serialization (see :ref:`docs <journal>`).

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -17,6 +17,7 @@ Breaking Changes
 Other Changes
 ^^^^^^^^^^^^^
 
+- ``@listing``: Add ``blocked_local_roles`` as allowed field (see :ref:`docs <listings>`).
 - Add support for english: new field ``title_en`` is returned wherever appropriate (``@schema``, ``@types`` and simple GET for diverse content types) when English is enabled for the deployment.
 - ``@journal``: Include ``related_documents`` in journal entry serialization (see :ref:`docs <journal>`).
 - The fields ``checked_out`` and ``file_extension`` are now included in the summary serialization of documents and mails.

--- a/docs/public/dev-manual/api/listings.rst
+++ b/docs/public/dev-manual/api/listings.rst
@@ -63,6 +63,7 @@ Für jede Auflistung können verschiedene Felder (Parameter ``columns``) abgefra
 werden. Folgende Felder stehen zur Verfügung:
 
 - ``@type``: Inhaltstyp
+- ``blocked_local_roles``: Ob Berechtigungen von übergeordneten Ordnern übernommen werden.
 - ``bumblebee_checksum``: SHA-256 Checksumme
 - ``changed``: Änderungsdatum
 - ``checked_out_fullname``: Anzeigename des Benutzers, der das Dokument ausgechecked hat
@@ -131,6 +132,8 @@ siehe Tabelle:
     | Feld                     | Document | Dossier | Arbeitsraume | Arbeitsraum Ordner | Aufgabe |  ToDo   | Anträge | Kontakte | Standardabläufe | Aufgabenvorlagen | Dossiervorlagen | Meetings |
     +==========================+==========+=========+==============+====================+=========+=========+=========+==========+=================+==================+=================+==========+
     |``@type``                 |    ja    |    ja   |      ja      |         ja         |   ja    |   ja    |   ja    |    ja    |        ja       |        ja        |       ja        |    ja    |
+    +--------------------------+----------+---------+--------------+--------------------+---------+---------+---------+----------+-----------------+------------------+-----------------+----------+
+    |``blocked_local_roles``   |   nein   |    ja   |     nein     |        nein        |  nein   |  nein   |  nein   |   nein   |       nein      |       nein       |       nein      |   nein   |
     +--------------------------+----------+---------+--------------+--------------------+---------+---------+---------+----------+-----------------+------------------+-----------------+----------+
     |``bumblebee_checksum``    |    ja    |   nein  |     nein     |        nein        |  nein   |  nein   |  nein   |   nein   |       nein      |       nein       |       nein      |   nein   |
     +--------------------------+----------+---------+--------------+--------------------+---------+---------+---------+----------+-----------------+------------------+-----------------+----------+

--- a/opengever/api/dossier.py
+++ b/opengever/api/dossier.py
@@ -30,6 +30,8 @@ class SerializeDossierToJson(GeverSerializeFolderToJson):
         result[u'reference_number'] = self.context.get_reference_number()
         result[u'email'] = IEmailAddress(self.request).get_email_for_object(
             self.context)
+        result[u'blocked_local_roles'] = bool(
+            getattr(self.context.aq_inner, '__ac_local_roles_block__', False))
 
         return result
 

--- a/opengever/api/listing.py
+++ b/opengever/api/listing.py
@@ -14,6 +14,7 @@ from ZPublisher.HTTPRequest import record
 
 # Fields with no mapping but allowed in the listing endpoint.
 OTHER_ALLOWED_FIELDS = set([
+    'blocked_local_roles',
     'changed',
     'checked_out',
     'completed',

--- a/opengever/api/repositoryfolder.py
+++ b/opengever/api/repositoryfolder.py
@@ -57,5 +57,7 @@ class SerializeRepositoryFolderToJson(GeverSerializeFolderToJson):
 
         ref_num = IReferenceNumber(self.context)
         result[u'reference_number'] = ref_num.get_number()
+        result[u'blocked_local_roles'] = bool(
+            getattr(self.context.aq_inner, '__ac_local_roles_block__', False))
 
         return result

--- a/opengever/api/solr_query_service.py
+++ b/opengever/api/solr_query_service.py
@@ -38,6 +38,8 @@ def filter_escape(term):
     instead of SPECIAL_CHARS, additionally including a white space. For queries,
     whitespaces should not be escaped, but for filters they should be.
     """
+    if isinstance(term, bool):
+        return term
     for char in TO_ESCAPE:
         term = term.replace(char, '\\' + char)
     return term

--- a/opengever/api/tests/test_dossier.py
+++ b/opengever/api/tests/test_dossier.py
@@ -23,6 +23,12 @@ class TestDossierSerializer(IntegrationTestCase):
         )
 
     @browsing
+    def test_dossier_serializer_contains_blocked_local_roles(self, browser):
+        self.login(self.regular_user, browser=browser)
+        browser.open(self.dossier, method="GET", headers=self.api_headers)
+        self.assertIn("blocked_local_roles", browser.json)
+
+    @browsing
     def test_undeterminable_subdossier_within_items(self, browser):
         self.login(self.regular_user, browser=browser)
         browser.open(self.dossier, method="GET", headers=self.api_headers)

--- a/opengever/api/tests/test_listing.py
+++ b/opengever/api/tests/test_listing.py
@@ -185,6 +185,7 @@ class TestListingWithRealSolr(SolrIntegrationTestCase):
         self.login(self.regular_user, browser=browser)
         query_string = '&'.join((
             'name=dossiers',
+            'columns=blocked_local_roles',
             'columns=external_reference',
             'columns=public_trial',
             'columns=reference',
@@ -214,6 +215,7 @@ class TestListingWithRealSolr(SolrIntegrationTestCase):
             {u'review_state': u'dossier-state-active',
              u'@id': u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-1',
              u'UID': IUUID(self.dossier),
+             u'blocked_local_roles': False,
              u'external_reference': u'qpr-900-9001-\xf7',
              u'public_trial': u'Nicht gepr\xfcft',
              u'trashed': False,

--- a/opengever/api/tests/test_listing.py
+++ b/opengever/api/tests/test_listing.py
@@ -440,6 +440,21 @@ class TestListingWithRealSolr(SolrIntegrationTestCase):
         self.assertEqual('dossier-state-active', review_states[0])
 
     @browsing
+    def test_filter_by_is_subdossier(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        view = ('@listing?name=dossiers&columns:list=title'
+                '&columns:list=is_subdossier'
+                '&filters.review_state:record:boolean=true')
+        browser.open(self.portal, view=view,
+                     headers=self.api_headers)
+
+        items = browser.json['items']
+        is_subdossier = list(set(map(lambda x: x['is_subdossier'], items)))
+        self.assertEqual(1, len(is_subdossier))
+        self.assertTrue(is_subdossier[0])
+
+    @browsing
     def test_filter_by_empty_string(self, browser):
         self.login(self.regular_user, browser=browser)
         manager = getMultiAdapter((self.document, self.request), ICheckinCheckoutManager)

--- a/opengever/api/tests/test_serializer.py
+++ b/opengever/api/tests/test_serializer.py
@@ -64,6 +64,13 @@ class TestRepositoryFolderSerializer(IntegrationTestCase):
         self.assertEqual(u'Client1 1.1', browser.json.get(u'reference_number'))
 
     @browsing
+    def test_repofolder_serialization_contains_blocked_local_roles(self, browser):
+        self.login(self.regular_user, browser)
+        browser.open(self.leaf_repofolder, headers=self.api_headers)
+        self.assertEqual(200, browser.status_code)
+        self.assertIn('blocked_local_roles', browser.json)
+
+    @browsing
     def test_repofolder_serialization_contains_is_leafnode(self, browser):
         self.login(self.regular_user, browser)
         browser.open(self.leaf_repofolder, headers=self.api_headers)

--- a/opengever/core/upgrades/20210128083955_index_blocked_local_roles_in_solr_for_repository_folders_and_dossiers/upgrade.py
+++ b/opengever/core/upgrades/20210128083955_index_blocked_local_roles_in_solr_for_repository_folders_and_dossiers/upgrade.py
@@ -1,0 +1,19 @@
+from ftw.upgrade import UpgradeStep
+from opengever.dossier.behaviors.dossier import IDossierMarker
+from opengever.repository.interfaces import IRepositoryFolder
+
+
+class IndexBlockedLocalRolesInSolrForRepositoryFoldersAndDossiers(UpgradeStep):
+    """Index blocked_local_roles in solr for repository folders and dossiers.
+    """
+
+    deferrable = True
+
+    def __call__(self):
+        query = {'object_provides': [
+            IDossierMarker.__identifier__,
+            IRepositoryFolder.__identifier__,
+        ]}
+
+        for obj in self.objects(query, 'Index blocked_local_roles field in solr.'):
+            obj.reindexObject(idxs=['blocked_local_roles'])

--- a/solr-conf/managed-schema
+++ b/solr-conf/managed-schema
@@ -128,6 +128,7 @@
     <field name="is_folderish" type="boolean" indexed="true" stored="true"/>
 
     <!-- GEVER specific fields -->
+    <field name="blocked_local_roles" type="boolean" indexed="true" stored="false" />
     <field name="bumblebee_checksum" type="string" indexed="false" stored="false" />
     <field name="changed" type="pdate" indexed="true" stored="false" />
     <field name="checked_out" type="string" indexed="true" stored="false" />


### PR DESCRIPTION
Changes in this PR:
- Index the field `blocked_local_roles` for dossiers and repofolders in Solr. Indexers for the types already exist, as the index is also in the catalog
- Allow `blocked_local_roles` field in `@listing` endpoint
- Add `blocked_local_roles` to dossier and repofolder serialization
- Allow to filter for a boolean term with `filters.<name>:record:boolean`, until now, such a query threw an exception

Jira: https://4teamwork.atlassian.net/browse/NE-275

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


## Checklist (if applicable)

_Only applicable should be left and checked._

- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))

- Upgrade steps (changes in profile):
  - [x] Make it deferrable if possible
  - [x] Execute as much as possible conditionally