### PR TITLE
Add link_to_workspace folder action, protect @create-linked-workspaces and @link-to-workspace endpoints

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -8,6 +8,7 @@ Changelog
 - Do not escape boolean filters in solr endpoints. [tinagerber]
 - Include blocked_local_roles in serialization of dossiers and repofolders. [tinagerber]
 - Index blocked_local_roles in solr and allow field in @listing endpoint. [tinagerber]
+- Only allow to create linked workspace and link to workspace if dossier is open. [tinagerber]
 - Add link_to_workspace folder action. [tinagerber]
 - Return only badge notifications in @notifications endpoint. [tinagerber]
 - Only show create_proposal action on dossiers. [tinagerber]

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -8,6 +8,7 @@ Changelog
 - Do not escape boolean filters in solr endpoints. [tinagerber]
 - Include blocked_local_roles in serialization of dossiers and repofolders. [tinagerber]
 - Index blocked_local_roles in solr and allow field in @listing endpoint. [tinagerber]
+- Add link_to_workspace folder action. [tinagerber]
 - Return only badge notifications in @notifications endpoint. [tinagerber]
 - Only show create_proposal action on dossiers. [tinagerber]
 - Enable Usersnap by default in SaaS policy template. [lgraf]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -10,6 +10,7 @@ API Changelog
 Breaking Changes
 ^^^^^^^^^^^^^^^^
 
+- ``@create-linked-workspace``, ``@link-to-workspace``: Only available if dossier is open.
 - ``@notifications``: Only badge notifications are returned (see :ref:`docs <notifications>`).
 - ``@tasktree``: Sequential tasks are now sorted on ``getObjPositionInParent`` (see :ref:`docs <tasktree>`).
 

--- a/opengever/api/linked_workspaces.py
+++ b/opengever/api/linked_workspaces.py
@@ -15,6 +15,7 @@ from requests import HTTPError
 from requests import Timeout
 from zExceptions import BadRequest
 from zExceptions import NotFound
+from zExceptions import Unauthorized
 from zope.component import queryMultiAdapter
 from zope.interface import alsoProvides
 from zope.interface import implements
@@ -145,11 +146,15 @@ class LinkedWorkspacesPost(LinkedWorkspacesService):
     """API Endpoint to add a new linked workspace.
     """
 
+    def render(self):
+        if not self.context.is_open():
+            raise Unauthorized
+        return super(LinkedWorkspacesPost, self).render()
+
     @request_error_handler
     def reply(self):
         # Disable CSRF protection
         alsoProvides(self.request, IDisableCSRFProtection)
-
         # Validation will be done on the remote system
         data = json_body(self.request)
 
@@ -159,6 +164,12 @@ class LinkedWorkspacesPost(LinkedWorkspacesService):
 class LinkToWorkspacePost(LinkedWorkspacesService):
     """API Endpoint to link a dossier to an existing workspace.
     """
+
+    def render(self):
+        if not self.context.is_open():
+            raise Unauthorized
+        return super(LinkToWorkspacePost, self).render()
+
     @request_error_handler
     def reply(self):
         # Disable CSRF protection

--- a/opengever/api/tests/test_actions.py
+++ b/opengever/api/tests/test_actions.py
@@ -979,6 +979,11 @@ class TestWorkspaceClientFolderActions(FunctionalWorkspaceClientTestCase):
         u'title': u'List workspaces',
         u'icon': u''}
 
+    link_to_workspace_action = {
+        u'id': u'link_to_workspace',
+        u'title': u'Link to workspace',
+        u'icon': u''}
+
     copy_documents_to_workspace_action = {
         u'id': u'copy_documents_to_workspace',
         u'title': u'Copy documents to workspace',
@@ -990,6 +995,7 @@ class TestWorkspaceClientFolderActions(FunctionalWorkspaceClientTestCase):
         u'icon': u''}
 
     workspace_actions = [list_workspaces_action,
+                         link_to_workspace_action,
                          copy_documents_to_workspace_action,
                          copy_documents_from_workspace_action]
 

--- a/opengever/api/tests/test_linked_workspaces.py
+++ b/opengever/api/tests/test_linked_workspaces.py
@@ -95,6 +95,17 @@ class TestLinkedWorkspacesPost(FunctionalWorkspaceClientTestCase):
             )
 
     @browsing
+    def test_create_linked_workspace_raises_unauthorized_if_dossier_is_closed(self, browser):
+        browser.login()
+        browser.exception_bubbling = True
+        with self.assertRaises(Unauthorized):
+            browser.open(self.expired_dossier, view='/@create-linked-workspace',
+                         data=json.dumps({"title": "My linked workspace"}),
+                         method='POST',
+                         headers={'Accept': 'application/json',
+                                  'Content-Type': 'application/json'})
+
+    @browsing
     def test_only_workspace_client_users_can_use_the_api(self, browser):
         browser.exception_bubbling = True
         browser.login()
@@ -166,6 +177,17 @@ class TestLinkToWorkspacesPost(FunctionalWorkspaceClientTestCase):
                 method='POST',
                 headers={'Accept': 'application/json',
                          'Content-Type': 'application/json'})
+
+    @browsing
+    def test_link_to_workspace_raises_unauthorized_if_dossier_is_closed(self, browser):
+        browser.login()
+        browser.exception_bubbling = True
+        with self.assertRaises(Unauthorized):
+            browser.open(self.expired_dossier, view='/@link-to-workspace',
+                         data=json.dumps({"workspace_uid": self.workspace.UID()}),
+                         method='POST',
+                         headers={'Accept': 'application/json',
+                                  'Content-Type': 'application/json'})
 
     @browsing
     def test_missing_workspace_uid_raises_bad_request(self, browser):

--- a/opengever/base/browser/folder_buttons_availability.py
+++ b/opengever/base/browser/folder_buttons_availability.py
@@ -100,6 +100,12 @@ class FolderButtonsAvailabilityView(BrowserView):
             and self._can_add_content_to_dossier()
         )
 
+    def is_link_to_workspace_available(self):
+        return (self._is_main_dossier()
+                and self._is_open_dossier()
+                and self._can_use_workspace_client()
+                and self._can_modify_dossier())
+
     def is_move_items_available(self):
         if self._is_dossier() and not self._is_open_dossier():
             return False

--- a/opengever/core/locales/de/LC_MESSAGES/opengever.core.po
+++ b/opengever/core/locales/de/LC_MESSAGES/opengever.core.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2021-01-08 11:40+0000\n"
+"POT-Creation-Date: 2021-01-29 08:14+0000\n"
 "PO-Revision-Date: 2017-09-18 15:21+0200\n"
 "Last-Translator: Philippe Gross <p.gross@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -94,6 +94,7 @@ msgid "Create Disposition"
 msgstr "Aussonderungsangebot erstellen"
 
 #: ./opengever/core/profiles/default/actions.xml
+#: ./opengever/core/upgrades/20210126165317_update_create_proposal_action/actions.xml
 msgid "Create Proposal"
 msgstr "Antrag erstellen"
 
@@ -149,6 +150,11 @@ msgstr "Eingangskorb"
 #: ./opengever/core/profiles/default/types/opengever.inbox.container.xml
 msgid "Inbox Container"
 msgstr "Eingangskorb Ordner"
+
+#: ./opengever/core/profiles/default/actions.xml
+#: ./opengever/core/upgrades/20210129083214_add_link_to_workspace_action/actions.xml
+msgid "Link to workspace"
+msgstr "Mit Teamraum verknüpfen"
 
 #: ./opengever/core/profiles/default/actions.xml
 #: ./opengever/core/upgrades/20200310081410_add_list_workspaces_action/actions.xml

--- a/opengever/core/locales/en/LC_MESSAGES/opengever.core.po
+++ b/opengever/core/locales/en/LC_MESSAGES/opengever.core.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2021-01-17 16:16+0000\n"
+"POT-Creation-Date: 2021-01-29 08:14+0000\n"
 "PO-Revision-Date: 2017-09-18 15:21+0200\n"
 "Last-Translator: Philippe Gross <p.gross@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -114,6 +114,7 @@ msgstr "Create disposition"
 
 #. German translation: Antrag erstellen
 #: ./opengever/core/profiles/default/actions.xml
+#: ./opengever/core/upgrades/20210126165317_update_create_proposal_action/actions.xml
 msgid "Create Proposal"
 msgstr "Create proposal"
 
@@ -182,6 +183,11 @@ msgstr "Inbox"
 #: ./opengever/core/profiles/default/types/opengever.inbox.container.xml
 msgid "Inbox Container"
 msgstr "Inbox Container"
+
+#: ./opengever/core/profiles/default/actions.xml
+#: ./opengever/core/upgrades/20210129083214_add_link_to_workspace_action/actions.xml
+msgid "Link to workspace"
+msgstr "Link to workspace"
 
 #. German translation: Teamräume auflisten
 #: ./opengever/core/profiles/default/actions.xml

--- a/opengever/core/locales/fr/LC_MESSAGES/opengever.core.po
+++ b/opengever/core/locales/fr/LC_MESSAGES/opengever.core.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2021-01-08 11:40+0000\n"
+"POT-Creation-Date: 2021-01-29 08:14+0000\n"
 "PO-Revision-Date: 2013-03-27 10:44+0100\n"
 "Last-Translator: Philippe Gross <p.gross@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -91,6 +91,7 @@ msgid "Create Disposition"
 msgstr "Créer une offre d'archivage"
 
 #: ./opengever/core/profiles/default/actions.xml
+#: ./opengever/core/upgrades/20210126165317_update_create_proposal_action/actions.xml
 msgid "Create Proposal"
 msgstr "Créer une requête"
 
@@ -146,6 +147,11 @@ msgstr "Boîte de réception"
 #: ./opengever/core/profiles/default/types/opengever.inbox.container.xml
 msgid "Inbox Container"
 msgstr "Conteneur de la boîte de réception"
+
+#: ./opengever/core/profiles/default/actions.xml
+#: ./opengever/core/upgrades/20210129083214_add_link_to_workspace_action/actions.xml
+msgid "Link to workspace"
+msgstr ""
 
 #: ./opengever/core/profiles/default/actions.xml
 #: ./opengever/core/upgrades/20200310081410_add_list_workspaces_action/actions.xml

--- a/opengever/core/locales/opengever.core.pot
+++ b/opengever/core/locales/opengever.core.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-01-08 11:40+0000\n"
+"POT-Creation-Date: 2021-01-29 08:14+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -94,6 +94,7 @@ msgid "Create Disposition"
 msgstr ""
 
 #: ./opengever/core/profiles/default/actions.xml
+#: ./opengever/core/upgrades/20210126165317_update_create_proposal_action/actions.xml
 msgid "Create Proposal"
 msgstr ""
 
@@ -148,6 +149,11 @@ msgstr ""
 
 #: ./opengever/core/profiles/default/types/opengever.inbox.container.xml
 msgid "Inbox Container"
+msgstr ""
+
+#: ./opengever/core/profiles/default/actions.xml
+#: ./opengever/core/upgrades/20210129083214_add_link_to_workspace_action/actions.xml
+msgid "Link to workspace"
 msgstr ""
 
 #: ./opengever/core/profiles/default/actions.xml

--- a/opengever/core/profiles/default/actions.xml
+++ b/opengever/core/profiles/default/actions.xml
@@ -574,6 +574,15 @@
       <property name="visible">True</property>
     </object>
 
+    <object name="link_to_workspace" meta_type="CMF Action" i18n:domain="opengever.core">
+      <property name="title" i18n:translate="">Link to workspace</property>
+      <property name="description">Gever-UI action</property>
+      <property name="url_expr" />
+      <property name="icon_expr" />
+      <property name="available_expr">object/@@folder_buttons_availability/is_link_to_workspace_available</property>
+      <property name="visible">True</property>
+    </object>
+
   </object>
 
   <!-- OBJECT -->

--- a/opengever/core/upgrades/20210129083214_add_link_to_workspace_action/actions.xml
+++ b/opengever/core/upgrades/20210129083214_add_link_to_workspace_action/actions.xml
@@ -1,0 +1,16 @@
+<object xmlns:i18n="http://xml.zope.org/namespaces/i18n" name="portal_actions" meta_type="Plone Actions Tool">
+
+  <object name="folder_actions" meta_type="CMF Action Category">
+
+    <object name="link_to_workspace" meta_type="CMF Action" i18n:domain="opengever.core">
+      <property name="title" i18n:translate="">Link to workspace</property>
+      <property name="description">Gever-UI action</property>
+      <property name="url_expr" />
+      <property name="icon_expr" />
+      <property name="available_expr">object/@@folder_buttons_availability/is_link_to_workspace_available</property>
+      <property name="visible">True</property>
+    </object>
+
+  </object>
+
+</object>

--- a/opengever/core/upgrades/20210129083214_add_link_to_workspace_action/upgrade.py
+++ b/opengever/core/upgrades/20210129083214_add_link_to_workspace_action/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddLinkToWorkspaceAction(UpgradeStep):
+    """Add link_to_workspace action.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/opengever/workspaceclient/tests/__init__.py
+++ b/opengever/workspaceclient/tests/__init__.py
@@ -35,6 +35,8 @@ class FunctionalWorkspaceClientTestCase(FunctionalTestCase):
         self.repository_root = create(Builder('repository_root'))
         self.leaf_repofolder = create(Builder('repository').within(self.repository_root))
         self.dossier = create(Builder('dossier').within(self.leaf_repofolder))
+        self.expired_dossier = create(Builder('dossier').within(
+            self.leaf_repofolder).in_state('dossier-state-resolved'))
 
         # Teamraum setup
         self.workspace_root = create(Builder('workspace_root')


### PR DESCRIPTION
Until now, it was decided in the frontend when a dossier could be linked to a workspace. This also made it possible to link a dossier to a workspace when the dossier was already closed. Now there is an action.

Jira: https://4teamwork.atlassian.net/browse/NE-522

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

## Checklist (if applicable)

_Only applicable should be left and checked._

- API change:
  - [ ] Documentation is updated
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [x] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed