### PR TITLE
Fix prefilling widgets when active sheet changes.

### DIFF
--- a/opengever/propertysheets/annotation.py
+++ b/opengever/propertysheets/annotation.py
@@ -41,7 +41,7 @@ class CustomPropertiesStorageImpl(AnnotationsFactoryImpl):
 
     def __setattr__(self, name, value):
         if name not in self.__dict__['schema']:
-            super(AnnotationsFactoryImpl, self).__setattr__(name, value)
+            super(CustomPropertiesStorageImpl, self).__setattr__(name, value)
         else:
             prefixed_name = self.__dict__['prefix'] + name
             if value is None:

--- a/opengever/propertysheets/annotation.py
+++ b/opengever/propertysheets/annotation.py
@@ -1,10 +1,11 @@
 from opengever.base.utils import make_persistent
-from opengever.propertysheets.field import IPropertySheetField
 from opengever.propertysheets.exceptions import BadCustomPropertiesFactoryConfiguration
+from opengever.propertysheets.field import IPropertySheetField
 from persistent.dict import PersistentDict
 from plone.behavior.annotation import AnnotationsFactoryImpl
 from plone.behavior.annotation import AnnotationStorage
 from plone.behavior.interfaces import ISchemaAwareFactory
+from plone.restapi.serializer.converters import json_compatible
 from zope.interface import alsoProvides
 
 
@@ -38,6 +39,12 @@ class CustomPropertiesStorageImpl(AnnotationsFactoryImpl):
                 )
 
         super(CustomPropertiesStorageImpl, self).__init__(context, schema)
+
+    def __getattr__(self, name):
+        """Make sure to convert Persistent to json compatible data."""
+        return json_compatible(
+            super(CustomPropertiesStorageImpl, self).__getattr__(name)
+        )
 
     def __setattr__(self, name, value):
         if name not in self.__dict__['schema']:

--- a/opengever/propertysheets/tests/test_annotation.py
+++ b/opengever/propertysheets/tests/test_annotation.py
@@ -73,7 +73,7 @@ class TestCustomPropertiesStorage(FunctionalTestCase):
 
     def test_custom_property_storage_converts_values_to_persistent(self):
         self.props.custom_properties = {"foo": 123}
-        self.assertIsInstance(self.props.custom_properties, PersistentDict)
+        self.assertIsInstance(self.annotations[self.key], PersistentDict)
 
     def test_custom_property_storage_updates_existing_values(self):
         self.props.custom_properties = {"foo": 123}

--- a/opengever/propertysheets/tests/test_transporter.py
+++ b/opengever/propertysheets/tests/test_transporter.py
@@ -1,0 +1,29 @@
+from opengever.base.transport import Transporter
+from opengever.document.behaviors.customproperties import IDocumentCustomProperties
+from opengever.testing import IntegrationTestCase
+
+
+class TestTransporterWithCustomProperties(IntegrationTestCase):
+    """Test transporter works with custom properties. This guarantees that
+    documents with custom properties can be used in tasks and in meeting.
+    """
+    def test_custom_properties_are_transported(self):
+        self.login(self.regular_user)
+
+        properties = {
+            "IDocumentMetadata.document_type.question": {
+                "textline": u"b\xe4\xe4",
+                "iwasremoved": 123,
+                "choose": "inolongerexist",
+            }
+        }
+
+        IDocumentCustomProperties(self.document).custom_properties = properties
+
+        transported_doc = Transporter().transport_from(
+            self.empty_dossier, 'plone', '/'.join(self.document.getPhysicalPath()))
+
+        self.assertEqual(
+            properties,
+            IDocumentCustomProperties(transported_doc).custom_properties,
+        )

--- a/opengever/propertysheets/tests/test_widget.py
+++ b/opengever/propertysheets/tests/test_widget.py
@@ -188,17 +188,22 @@ class TestPropertySheetWidget(IntegrationTestCase):
     @browsing
     def test_switch_to_previously_set_fields_handles_changes_to_schema(self, browser):
         self.login(self.manager, browser)
+        choices = ["two", "three"]
         create(
             Builder("property_sheet_schema")
             .named("schema1")
             .assigned_to_slots(u"IDocumentMetadata.document_type.question")
             .with_field("int", u"num", u"Number", u"", True)
             .with_field("textline", u"textline", u"A line of text", u"", True)
+            .with_field(
+                "choice", u"choose", u"Choose", u"", True, values=choices
+            )
         )
         IDocumentCustomProperties(self.document).custom_properties = {
                 "IDocumentMetadata.document_type.question": {
                     "textline": u"b\xe4\xe4",
                     "iwasremoved": 123,
+                    "choose": "inolongerexist",
                 }
             }
         self.document.document_type = u"contract"
@@ -231,7 +236,7 @@ class TestPropertySheetWidget(IntegrationTestCase):
         self.assertEqual('', field.css(".fieldErrorBox").first.text)
         self.assertEqual(u"b\xe4\xe4", field.css("input").first.value)
 
-        browser.fill({"Number": "4"}).save()
+        browser.fill({"Number": "4", "Choose": "two"}).save()
 
         # the custom properties should be set accoring to the currently active
         # property sheet
@@ -240,6 +245,7 @@ class TestPropertySheetWidget(IntegrationTestCase):
                 "IDocumentMetadata.document_type.question": {
                     "num": 4,
                     "textline": u"b\xe4\xe4",
+                    "choose": "two",
                 }
             },
             IDocumentCustomProperties(self.document).custom_properties,

--- a/opengever/propertysheets/widgets.py
+++ b/opengever/propertysheets/widgets.py
@@ -57,6 +57,7 @@ class PropertySheetWiget(Widget):
             widget.name = identifier
             widget.id = identifier
             widget.mode = self.mode
+
             widget.update()  # update is required to set up terms for sequences
             self.widgets.append(widget)
 
@@ -90,6 +91,9 @@ class PropertySheetWiget(Widget):
         sheet_values = {}
         found_request_value = False
 
+        obj = self.value or dict()
+        sheet_values = obj.get(slot_name, {})
+
         for name, widget in zip(definition.get_fieldnames(), self.widgets):
             value = widget.field.missing_value
             try:
@@ -98,6 +102,10 @@ class PropertySheetWiget(Widget):
                 if raw is not default:
                     found_request_value = True
                     value = IDataConverter(widget).toFieldValue(raw)
+                else:
+                    # if there is no request value try falling back to the
+                    # existing value or then the default missing value
+                    value = sheet_values.get(name, widget.field.missing_value)
                 validator = getMultiAdapter(
                     (
                         self.context,
@@ -126,6 +134,7 @@ class PropertySheetWiget(Widget):
                     widget.error = view
                 errors += (view,)
             else:
+                widget.value = IDataConverter(widget).toWidgetValue(value)
                 sheet_values[name] = value
 
         if self.setErrors and errors:

--- a/opengever/propertysheets/widgets.py
+++ b/opengever/propertysheets/widgets.py
@@ -15,7 +15,6 @@ from zope.component import getMultiAdapter
 from zope.interface import implementer
 from zope.interface import implementsOnly
 from zope.interface import Invalid
-from zope.schema import getFieldNamesInOrder
 
 
 class IPropertySheetWiget(IWidget):
@@ -70,13 +69,10 @@ class PropertySheetWiget(Widget):
         if definition is None:
             return
 
-        schema_class = definition.schema_class
         obj = self.value or dict()
         sheet_values = obj.get(slot_name, {})
 
-        for name, widget in zip(
-            getFieldNamesInOrder(schema_class), self.widgets
-        ):
+        for name, widget in zip(definition.get_fieldnames(), self.widgets):
             converter = IDataConverter(widget)
             sheet_value = sheet_values.get(name, None)
             widget.value = converter.toWidgetValue(sheet_value)


### PR DESCRIPTION
Fix prefilling values of an old property sheet when it becomes active again and loads previously stored values. Improve tests so they cover two possibilities of partial and complete property sheets.

Jira: https://4teamwork.atlassian.net/browse/CA-1284


## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [ ] ~~Changelog entry~~ _Fix for recently merged https://github.com/4teamwork/opengever.core/pull/6871_
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
