### PR TITLE
Bump six to most recent version.

### DIFF
--- a/versions.cfg
+++ b/versions.cfg
@@ -175,6 +175,7 @@ requests-mock = 1.5.2
 requests-toolbelt = 0.8.0
 rfc6266 = 0.0.4
 setuptools = 44.1.1
+six = 1.15.0
 snowballstemmer = 1.2.1
 souper = 1.0.2
 sourcecodegen = 0.6.14


### PR DESCRIPTION
The package six is pinned to 1.11.0 by plone pinnings, ftw.builder however requires at least 1.12.0. I have double-checked the six changelog and have not found anything preventing us from going to the most recent release.

Without this change policy tests against current master fail with the following version constraint error:

```
Version and requirements information containing six:
  [versions] constraint on six: 1.11.0
  Requirement of zope.testrunner==4.8.1: six
  Requirement of ftw.builder: six>=1.12.0
  Requirement of z3c.form: six
  Requirement of requests_mock: six
  Requirement of sqlalchemy-i18n: six>=1.4.1
  Requirement of plone.protect>=3.0.15: six
  Requirement of plone.api>=1.4.11: six
  Requirement of mr.bob: six>=1.2.0
  Requirement of docxcompose>=1.0.0a17: six
  Requirement of cryptography: six>=1.4.1
While:
  Updating test.
Error: The requirement ('six>=1.12.0') is not allowed by your [versions] constraint (1.11.0)
```

Jira: https://4teamwork.atlassian.net/browse/CA-1242

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [ ] ~~Changelog entry~~
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)