### PR TITLE
Set SameSite=Lax flag for session authentication cookie

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,7 @@ Changelog
 - Bump ftw.casauth to 1.3.1. [lgraf]
 - Update Plone to version 4.3.20. [buchi]
 - Add icons for CAD file types. [buchi]
+- Set SameSite=Lax flag for session authentication cookie. [buchi]
 
 
 2021.3.0 (2021-02-03)

--- a/opengever/base/monkey/patches/__init__.py
+++ b/opengever/base/monkey/patches/__init__.py
@@ -31,6 +31,7 @@ from .readonly import PatchPloneUserGetRolesInContext
 from .resource_registries_url_regex import PatchResourceRegistriesURLRegex
 from .rolemanager import PatchOFSRoleManager
 from .scrub_bobo_exceptions import ScrubBoboExceptions
+from .session import PatchSessionCookie
 from .tz_for_log import PatchZ2LogTimezone
 from .verify_object_paste import PatchCopyContainerVerifyObjectPaste
 from .webdav_lock_timeout import PatchWebDAVLockTimeout
@@ -66,6 +67,7 @@ PatchOFSRoleManager()()
 PatchPlone43RC1Upgrade()()
 PatchPloneProtectOnUserLogsIn()()
 PatchResourceRegistriesURLRegex()()
+PatchSessionCookie()()
 PatchTransmogrifyDXSchemaUpdater()()
 PatchWebDAVLockTimeout()()
 PatchWorkflowTool()()

--- a/opengever/base/monkey/patches/session.py
+++ b/opengever/base/monkey/patches/session.py
@@ -1,0 +1,28 @@
+from App.config import getConfiguration
+from opengever.base.monkey.patching import MonkeyPatch
+from plone.session.plugins.session import cookie_expiration_date
+import binascii
+
+
+class PatchSessionCookie(MonkeyPatch):
+    """Set session authentication cookie with SameSite=Lax flag"""
+
+    def __call__(self):
+
+        def _setCookie(self, cookie, response):
+            cookie = binascii.b2a_base64(cookie).rstrip()
+            # disable secure cookie in development mode, to ease local testing
+            if getConfiguration().debug_mode:
+                secure = False
+            else:
+                secure = self.secure
+            options = dict(path=self.path, secure=secure, http_only=True)
+            if self.cookie_domain:
+                options['domain'] = self.cookie_domain
+            if self.cookie_lifetime:
+                options['expires'] = cookie_expiration_date(self.cookie_lifetime)
+            options['same_site'] = 'Lax'
+            response.setCookie(self.cookie_name, cookie, **options)
+
+        from plone.session.plugins.session import SessionPlugin
+        self.patch_refs(SessionPlugin, "_setCookie", _setCookie)

--- a/opengever/base/tests/test_session_cookie.py
+++ b/opengever/base/tests/test_session_cookie.py
@@ -1,0 +1,21 @@
+from ftw.testbrowser import browsing
+from opengever.testing import IntegrationTestCase
+from plone.app.testing import TEST_USER_NAME
+from plone.app.testing import TEST_USER_PASSWORD
+
+
+class TestSessionCookie(IntegrationTestCase):
+    """Test session cookie flags
+    """
+
+    @browsing
+    def test_session_cookie_flags(self, browser):
+        browser.open(self.portal, view='login_form')
+        browser.fill(
+            {'Login Name': TEST_USER_NAME, 'Password': TEST_USER_PASSWORD})
+        browser.click_on('Log in')
+
+        session_cookie = browser.get_driver().response.cookies['__ac']
+        self.assertEqual(session_cookie.get('same_site'), 'Lax')
+        self.assertTrue(session_cookie.get('secure'))
+        self.assertTrue(session_cookie.get('http_only'))


### PR DESCRIPTION
This is best practice in terms of security.

With `SameSite=Lax` the cookie is only sent if the user is navigating to the site (following a link or submitting a form with GET method). The cookie is not sent when loading images, AJAX requests, Iframes and forms with POST method.

See also:
https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/501907630/Sicherheitsrichtlinien+f+r+Webanwendungen#4.-Restriktive-Cookies

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [ ] Link to issue (Jira or GitHub) and backlink in issue (Jira)

