### PR TITLE
New API endpoint @save-document-as-pdf

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 ---------------------
 
 - Bump ftw.casauth to 1.3.1. [lgraf]
+- Only allow to save a document as pdf if document isn't checked out. [tinagerber]
 - Update Plone to version 4.3.20. [buchi]
 - Add icons for CAD file types. [buchi]
 - Set SameSite=Lax flag for session authentication cookie. [buchi]

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 ---------------------
 
 - Bump ftw.casauth to 1.3.1. [lgraf]
+- Add @save-document-as-pdf API endpoint. [tinagerber]
 - Only allow to save a document as pdf if document isn't checked out. [tinagerber]
 - Update Plone to version 4.3.20. [buchi]
 - Add icons for CAD file types. [buchi]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -8,7 +8,7 @@ API Changelog
 2021.4.0 (unreleased)
 ---------------------
 
-- Nothing changed yet.
+- A new endpoint ``@save-document-as-pdf`` is added (see :ref:`save-document-as-pdf`).
 
 
 2021.3.0 (2021-02-03)

--- a/docs/public/dev-manual/api/documents.rst
+++ b/docs/public/dev-manual/api/documents.rst
@@ -319,3 +319,25 @@ Versionen auflisten:
             "version": 0
         }
     ]
+
+.. _save-document-as-pdf:
+
+Dokument als PDF speichern
+--------------------------
+
+Mit dem ``@save-document-as-pdf`` kann ein Dokument oder eine Version eines Dokuments als PDF gespeichert werden. Als ``document_uid`` wird die UID des Dokuments erwartet. Wenn keine ``version_id`` mitgegeben wird, wird die aktuelle Version verwendet. Der Endpoint steht auf Stufe Dossier, Teamraum und Teamraum-Ordner zur Verfügung.
+
+  .. sourcecode:: http
+
+    POST /ordnungssystem/dossier-23/@save-document-as-pdf HTTP/1.1
+    Accept: application/json
+
+    {
+      "document_uid": "f923b2321f174b408c3bd483db9bfa66",
+      "version_id": 2
+    }
+
+  .. sourcecode:: http
+
+    HTTP/1.1 201 Created
+    Location: /ordnungssystem/dossier-4/document-1

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -1093,6 +1093,30 @@
       />
 
   <plone:service
+      method="POST"
+      name="@save-document-as-pdf"
+      for="opengever.dossier.behaviors.dossier.IDossierMarker"
+      factory=".save_document_as_pdf.SaveDocumentAsPdfPost"
+      permission="cmf.AddPortalContent"
+      />
+
+  <plone:service
+      method="POST"
+      name="@save-document-as-pdf"
+      for="opengever.workspace.interfaces.IWorkspace"
+      factory=".save_document_as_pdf.SaveDocumentAsPdfPost"
+      permission="cmf.AddPortalContent"
+      />
+
+  <plone:service
+      method="POST"
+      name="@save-document-as-pdf"
+      for="opengever.workspace.interfaces.IWorkspaceFolder"
+      factory=".save_document_as_pdf.SaveDocumentAsPdfPost"
+      permission="cmf.AddPortalContent"
+      />
+
+  <plone:service
       method="GET"
       name="@groups"
       for="Products.CMFCore.interfaces.ISiteRoot"

--- a/opengever/api/save_document_as_pdf.py
+++ b/opengever/api/save_document_as_pdf.py
@@ -1,0 +1,49 @@
+from opengever.document.behaviors import IBaseDocument
+from opengever.document.browser.save_pdf_document_under import trigger_conversion
+from opengever.document.forms import create_destination_document
+from opengever.document.forms import is_version_convertable
+from opengever.document.versioner import Versioner
+from plone import api
+from plone.protect.interfaces import IDisableCSRFProtection
+from plone.restapi.deserializer import json_body
+from plone.restapi.services import Service
+from zExceptions import BadRequest
+from zope.interface import alsoProvides
+
+
+class SaveDocumentAsPdfPost(Service):
+
+    def get_document(self, data):
+        uid = data.get('document_uid', None)
+        if not uid:
+            return
+        catalog = api.portal.get_tool('portal_catalog')
+        brain = catalog(UID=uid, object_provides=[IBaseDocument.__identifier__])
+        if brain:
+            return brain[0].getObject()
+
+    def reply(self):
+        # Disable CSRF protection
+        alsoProvides(self.request, IDisableCSRFProtection)
+
+        data = json_body(self.request)
+        document = self.get_document(data)
+        if not document:
+            raise BadRequest(
+                "Property 'document_uid' is required and should be a UID of a document")
+
+        version_id = data.get('version_id', None)
+        if version_id and not isinstance(version_id, int):
+            raise BadRequest("Property 'version_id' should be an integer.")
+        if version_id == 0 and not Versioner(document).has_initial_version():
+            version_id = None
+
+        if not is_version_convertable(document, self.request, version_id):
+            raise BadRequest("This document is not convertable.")
+
+        destination_document = create_destination_document(
+            document, self.request, version_id, self.context)
+        trigger_conversion(document, destination_document, version_id)
+
+        self.request.response.setHeader("Location", destination_document.absolute_url())
+        self.reply_no_content(201)

--- a/opengever/api/tests/test_save_document_as_pdf.py
+++ b/opengever/api/tests/test_save_document_as_pdf.py
@@ -1,0 +1,195 @@
+from ftw.testbrowser import browsing
+from opengever.document.behaviors.related_docs import IRelatedDocuments
+from opengever.document.browser.save_pdf_document_under import PDF_SAVE_OWNER_ID_KEY
+from opengever.document.browser.save_pdf_document_under import PDF_SAVE_SOURCE_UUID_KEY
+from opengever.document.browser.save_pdf_document_under import PDF_SAVE_SOURCE_VERSION_KEY
+from opengever.document.browser.save_pdf_document_under import PDF_SAVE_STATUS_KEY
+from opengever.document.browser.save_pdf_document_under import PDF_SAVE_TOKEN_KEY
+from opengever.document.interfaces import ICheckinCheckoutManager
+from opengever.document.versioner import Versioner
+from opengever.testing import IntegrationTestCase
+from plone.uuid.interfaces import IUUID
+from zope.annotation import IAnnotations
+from zope.component import getMultiAdapter
+import json
+
+
+class TestSaveDocumentAsPdfPost(IntegrationTestCase):
+
+    features = ('bumblebee', )
+
+    @browsing
+    def test_save_document_as_pdf_post(self, browser):
+        self.login(self.regular_user, browser=browser)
+        Versioner(self.document).create_version('Initial version')
+        with self.observe_children(self.empty_dossier) as children:
+            browser.open(self.empty_dossier, view='@save-document-as-pdf', method='POST',
+                         headers=self.api_headers,
+                         data=json.dumps({"document_uid": self.document.UID()}))
+        self.assertEqual(len(children["added"]), 1)
+        created_document = children["added"].pop()
+
+        self.assertTrue(created_document.is_shadow_document())
+        related_items = IRelatedDocuments(created_document).relatedItems
+        self.assertEqual(len(related_items), 1)
+        self.assertEqual(related_items[0].to_object, self.document)
+        annotations = IAnnotations(created_document)
+        self.assertEqual(IUUID(self.document),
+                         annotations.get(PDF_SAVE_SOURCE_UUID_KEY))
+        self.assertEqual('conversion-demanded',
+                         annotations.get(PDF_SAVE_STATUS_KEY))
+        self.assertIsNotNone(annotations.get(PDF_SAVE_TOKEN_KEY))
+        self.assertEqual(self.regular_user.getId(),
+                         annotations.get(PDF_SAVE_OWNER_ID_KEY))
+
+        self.assertEqual(browser.status_code, 201)
+        self.assertEqual(created_document.absolute_url(), browser.headers['location'])
+
+    @browsing
+    def test_save_document_as_pdf_post_without_document_uid_raises_bad_request(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        with browser.expect_http_error(400):
+            browser.open(self.empty_dossier, view='@save-document-as-pdf', method='POST',
+                         headers=self.api_headers)
+
+        self.assertEqual({
+          "message": "Property 'document_uid' is required and should be a UID of a document",
+          "type": "BadRequest"}, browser.json)
+
+    @browsing
+    def test_save_document_as_pdf_post_with_invalid_document_uid_raises_bad_request(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        with browser.expect_http_error(400):
+            browser.open(self.empty_dossier, view='@save-document-as-pdf', method='POST',
+                         headers=self.api_headers,
+                         data=json.dumps({"document_uid": self.task.UID()}))
+
+        self.assertEqual({
+          "message": "Property 'document_uid' is required and should be a UID of a document",
+          "type": "BadRequest"}, browser.json)
+
+    @browsing
+    def test_save_document_as_pdf_post_is_available_for_mails(self, browser):
+        self.login(self.regular_user, browser)
+        with self.observe_children(self.empty_dossier) as children:
+            browser.open(self.empty_dossier, view='@save-document-as-pdf', method='POST',
+                         headers=self.api_headers,
+                         data=json.dumps({"document_uid": self.mail_eml.UID()}))
+
+        self.assertEqual(len(children["added"]), 1)
+        created_document = children["added"].pop()
+        self.assertEqual(browser.status_code, 201)
+        self.assertEqual(created_document.absolute_url(), browser.headers['location'])
+
+    @browsing
+    def test_save_document_as_pdf_post_is_available_for_workspaces(self, browser):
+        self.login(self.workspace_member, browser)
+        with self.observe_children(self.workspace) as children:
+            browser.open(self.workspace, view='@save-document-as-pdf', method='POST',
+                         headers=self.api_headers,
+                         data=json.dumps({"document_uid": self.workspace_document.UID()}))
+
+        self.assertEqual(len(children["added"]), 1)
+        created_document = children["added"].pop()
+        self.assertEqual(browser.status_code, 201)
+        self.assertEqual(created_document.absolute_url(), browser.headers['location'])
+
+    @browsing
+    def test_save_document_as_pdf_post_is_available_for_workspace_folders(self, browser):
+        self.login(self.workspace_member, browser)
+        with self.observe_children(self.workspace_folder) as children:
+            browser.open(self.workspace_folder, view='@save-document-as-pdf', method='POST',
+                         headers=self.api_headers,
+                         data=json.dumps({"document_uid": self.workspace_document.UID()}))
+
+        self.assertEqual(len(children["added"]), 1)
+        created_document = children["added"].pop()
+        self.assertEqual(browser.status_code, 201)
+        self.assertEqual(created_document.absolute_url(), browser.headers['location'])
+
+    @browsing
+    def test_save_document_as_pdf_post_with_invalid_version_id_raises_bad_request(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        with browser.expect_http_error(400):
+            browser.open(self.empty_dossier, view='@save-document-as-pdf', method='POST',
+                         headers=self.api_headers,
+                         data=json.dumps({"document_uid": self.document.UID(),
+                                          "version_id": "invalid"}))
+
+        self.assertEqual({"message": "Property 'version_id' should be an integer.",
+                          "type": "BadRequest"}, browser.json)
+
+    @browsing
+    def test_save_document_as_pdf_post_asserts_version_is_convertable(self, browser):
+        self.login(self.regular_user, browser)
+        self.document.file.filename = u"test.wav"
+        self.document.file.contentType = "audio/wav"
+        Versioner(self.document).create_version("")
+
+        self.document.file.filename = u"test.txt"
+        self.document.file.contentType = "text/plain"
+        Versioner(self.document).create_version("")
+
+        browser.open(self.empty_dossier, view='@save-document-as-pdf', method='POST',
+                     headers=self.api_headers,
+                     data=json.dumps({"document_uid": self.document.UID(),
+                                      "version_id": 1}))
+        self.assertEqual(browser.status_code, 201)
+
+        with browser.expect_http_error(400):
+            browser.open(self.empty_dossier, view='@save-document-as-pdf', method='POST',
+                         headers=self.api_headers,
+                         data=json.dumps({"document_uid": self.document.UID(),
+                                          "version_id": 0}))
+
+        self.assertEqual({"message": "This document is not convertable.",
+                          "type": "BadRequest"}, browser.json)
+
+    @browsing
+    def test_save_document_as_pdf_post_is_not_allowed_if_document_is_checked_out(self, browser):
+        self.login(self.regular_user, browser)
+        Versioner(self.document).create_version('Initial version')
+
+        manager = getMultiAdapter((self.document, self.request), ICheckinCheckoutManager)
+        manager.checkout()
+
+        with browser.expect_http_error(400):
+            browser.open(self.empty_dossier, view='@save-document-as-pdf', method='POST',
+                         headers=self.api_headers,
+                         data=json.dumps({"document_uid": self.document.UID()}))
+
+        self.assertEqual({"message": "This document is not convertable.",
+                          "type": "BadRequest"}, browser.json)
+
+    @browsing
+    def test_save_document_as_pdf_post_handles_retrieving_initial_version(self, browser):
+        self.login(self.regular_user, browser)
+        self.document.file.filename = u"test.txt"
+        self.document.file.contentType = "text/plain"
+
+        # when the initial version does not yet exist, retrieving version 0
+        # is handled and returns the pdf for the current state of the document
+        with self.observe_children(self.empty_dossier) as children:
+            browser.open(self.empty_dossier, view='@save-document-as-pdf', method='POST',
+                         headers=self.api_headers,
+                         data=json.dumps({"document_uid": self.document.UID(),
+                                          "version_id": 0}))
+
+        self.assertEqual(len(children["added"]), 1)
+        created_document = children["added"].pop()
+        self.assertIsNone(IAnnotations(created_document).get(PDF_SAVE_SOURCE_VERSION_KEY))
+
+        # Once the initial version has been created, we can retrieve version 0
+        Versioner(self.document).create_version("")
+        with self.observe_children(self.empty_dossier) as children:
+            browser.open(self.empty_dossier, view='@save-document-as-pdf', method='POST',
+                         headers=self.api_headers,
+                         data=json.dumps({"document_uid": self.document.UID(),
+                                          "version_id": 0}))
+
+        self.assertEqual(len(children["added"]), 1)
+        created_document = children["added"].pop()
+        self.assertEqual(0, IAnnotations(created_document).get(PDF_SAVE_SOURCE_VERSION_KEY))

--- a/opengever/document/forms.py
+++ b/opengever/document/forms.py
@@ -244,14 +244,11 @@ class SavePDFUnderForm(form.Form):
 
 
 def is_version_convertable(document, request, version_id=None):
-    """ The object action is only available for documents that are convertable,
-    but in the version tab, there is a link for each version and convertability
-    is not checked. We therefore only check if it is convertable for requests
-    with a version_id parameter.
-    """
     if not version_id:
-        return True
-    document = Versioner(document).retrieve(version_id)
+        if document.is_checked_out():
+            return False
+    else:
+        document = Versioner(document).retrieve(version_id)
     return IBumblebeeServiceV3(request).is_convertable(document)
 
 
@@ -321,7 +318,8 @@ class SavePDFUnderFormView(layout.FormWrapper):
         return super(SavePDFUnderFormView, self).render()
 
     def is_save_pdf_under_available(self):
-        return IBumblebeeServiceV3(self.request).is_convertable(self.context)
+        is_convertable = IBumblebeeServiceV3(self.request).is_convertable(self.context)
+        return not self.context.is_checked_out() and is_convertable
 
 
 class NotInContentTypes(Invalid):

--- a/opengever/document/forms.py
+++ b/opengever/document/forms.py
@@ -190,7 +190,7 @@ class SavePDFUnderForm(form.Form):
             # In that case we save the current document as pdf.
             version_id = None
 
-        if not self.check_version_is_convertable(version_id):
+        if not is_version_convertable(self.context, self.request, version_id):
             msg = _(u'unconvertable_document',
                     default=u'This document cannot be converted to PDF.')
             api.portal.show_message(
@@ -202,17 +202,6 @@ class SavePDFUnderForm(form.Form):
 
     def check_has_initial_version(self):
         return Versioner(self.context).has_initial_version()
-
-    def check_version_is_convertable(self, version_id):
-        """ The object action is only available for documents that are convertable,
-        but in the version tab, there is a link for each version and convertability
-        is not checked. We therefore only check if it is convertable for requests
-        with a version_id parameter.
-        """
-        if not version_id:
-            return True
-        document = Versioner(self.context).retrieve(version_id)
-        return IBumblebeeServiceV3(self.request).is_convertable(document)
 
     def updateWidgets(self):
         super(SavePDFUnderForm, self).updateWidgets()
@@ -246,63 +235,80 @@ class SavePDFUnderForm(form.Form):
         return save_pdf_under_url
 
     def create_destination_document(self):
-        # get all the metadata that will be set on the created file.
-        # We blacklist some fields that should not be copied
-        fields_to_skip = set(("file",
-                              "archival_file",
-                              "archival_file_state",
-                              "thumbnail",
-                              "preview",
-                              "digitally_available",
-                              "changeNote",
-                              "changed",
-                              "relatedItems",))
-        metadata = {}
-        for schema in iterSchemataForType(self.context.portal_type):
-            for name, schema_field in getFieldsInOrder(schema):
-                if name in fields_to_skip:
-                    continue
-                field_instance = schema_field.bind(self.context)
-                metadata[name] = field_instance.get(field_instance.interface(self.context))
-
-        command = CreateDocumentCommand(self.destination, None, None, **metadata)
-        destination_document = command.execute()
-
-        # We make it in shadow state until its file is set by the callback view
-        destination_document.as_shadow_document()
-        # Add marker interface. This should be useful in the future for
-        # cleanup jobs, retries if the PDF was not delivered and so on.
-        alsoProvides(destination_document, IDocumentSavedAsPDFMarker)
-        # Add annotations needed for the SavePDFDocumentUnder view.
-        annotations = IAnnotations(destination_document)
-        annotations[PDF_SAVE_SOURCE_UUID_KEY] = IUUID(self.context)
-        annotations[PDF_SAVE_SOURCE_VERSION_KEY] = self.version_id
-
-        # The missing_value attribute of a z3c-form field is used
-        # as soon as an object has no default_value i.e. after creating
-        # an object trough the command-line.
-        #
-        # Because the relatedItems field needs a list as a missing_value,
-        # we will fall into the "mutable keyword argument"-python gotcha.
-        # The relatedItems will be shared between the object-instances.
-        #
-        # Unfortunately the z3c-form field does not provide a
-        # missing_value-factory (like the defaultFactory) which would be
-        # necessary to fix this issue properly.
-        #
-        # As a workaround we make sure that the new document's relatedItems
-        # is different object from the source document's.
-        IRelatedDocuments(destination_document).relatedItems = list(
-            IRelatedDocuments(destination_document).relatedItems)
-
-        IRelatedDocuments(destination_document).relatedItems.append(
-            RelationValue(getUtility(IIntIds).getId(self.context)))
-
+        destination_document = create_destination_document(
+            self.context, self.request, self.version_id, self.destination)
         msg = _(u'Document ${document} was successfully created in ${destination}',
                 mapping={"document": destination_document.title, "destination": self.destination.title})
         api.portal.show_message(msg, self.request, type='info')
-
         return destination_document
+
+
+def is_version_convertable(document, request, version_id=None):
+    """ The object action is only available for documents that are convertable,
+    but in the version tab, there is a link for each version and convertability
+    is not checked. We therefore only check if it is convertable for requests
+    with a version_id parameter.
+    """
+    if not version_id:
+        return True
+    document = Versioner(document).retrieve(version_id)
+    return IBumblebeeServiceV3(request).is_convertable(document)
+
+
+def create_destination_document(context, request, version_id, destination):
+    # get all the metadata that will be set on the created file.
+    # We blacklist some fields that should not be copied
+    fields_to_skip = set(("file",
+                          "archival_file",
+                          "archival_file_state",
+                          "thumbnail",
+                          "preview",
+                          "digitally_available",
+                          "changeNote",
+                          "changed",
+                          "relatedItems",))
+    metadata = {}
+    for schema in iterSchemataForType(context.portal_type):
+        for name, schema_field in getFieldsInOrder(schema):
+            if name in fields_to_skip:
+                continue
+            field_instance = schema_field.bind(context)
+            metadata[name] = field_instance.get(field_instance.interface(context))
+
+    command = CreateDocumentCommand(destination, None, None, **metadata)
+    destination_document = command.execute()
+
+    # We make it in shadow state until its file is set by the callback view
+    destination_document.as_shadow_document()
+    # Add marker interface. This should be useful in the future for
+    # cleanup jobs, retries if the PDF was not delivered and so on.
+    alsoProvides(destination_document, IDocumentSavedAsPDFMarker)
+    # Add annotations needed for the SavePDFDocumentUnder view.
+    annotations = IAnnotations(destination_document)
+    annotations[PDF_SAVE_SOURCE_UUID_KEY] = IUUID(context)
+    annotations[PDF_SAVE_SOURCE_VERSION_KEY] = version_id
+
+    # The missing_value attribute of a z3c-form field is used
+    # as soon as an object has no default_value i.e. after creating
+    # an object trough the command-line.
+    #
+    # Because the relatedItems field needs a list as a missing_value,
+    # we will fall into the "mutable keyword argument"-python gotcha.
+    # The relatedItems will be shared between the object-instances.
+    #
+    # Unfortunately the z3c-form field does not provide a
+    # missing_value-factory (like the defaultFactory) which would be
+    # necessary to fix this issue properly.
+    #
+    # As a workaround we make sure that the new document's relatedItems
+    # is different object from the source document's.
+    IRelatedDocuments(destination_document).relatedItems = list(
+        IRelatedDocuments(destination_document).relatedItems)
+
+    IRelatedDocuments(destination_document).relatedItems.append(
+        RelationValue(getUtility(IIntIds).getId(context)))
+
+    return destination_document
 
 
 class SavePDFUnderFormView(layout.FormWrapper):

--- a/opengever/document/tests/test_save_pdf_under.py
+++ b/opengever/document/tests/test_save_pdf_under.py
@@ -5,6 +5,7 @@ from opengever.base.security import elevated_privileges
 from opengever.document.archival_file import STATE_CONVERTED
 from opengever.document.behaviors.metadata import IDocumentMetadata
 from opengever.document.behaviors.related_docs import IRelatedDocuments
+from opengever.document.browser.save_pdf_document_under import get_callback_url
 from opengever.document.browser.save_pdf_document_under import PDF_SAVE_OWNER_ID_KEY
 from opengever.document.browser.save_pdf_document_under import PDF_SAVE_SOURCE_UUID_KEY
 from opengever.document.browser.save_pdf_document_under import PDF_SAVE_STATUS_KEY
@@ -279,7 +280,7 @@ class TestSavePDFDocumentUnder(IntegrationTestCase):
         self.assertEqual(created_document.absolute_url(), view.destination_document_url())
 
         expected_callback_url = "/".join([created_document.absolute_url(), "save_pdf_under_callback"])
-        self.assertEqual(expected_callback_url, view.get_callback_url())
+        self.assertEqual(expected_callback_url, get_callback_url(created_document))
 
     @browsing
     def test_demand_document_pdf_conversion_status_is_traversable(self, browser):


### PR DESCRIPTION
Changes in this PR:

- Only allow to save a document as pdf if document isn't checked out.  Until now, checked-out documents could also be saved as PDFs.This resulted in the fact that when saving a document, the last version of the document was saved as pdf, but when checking whether the document could be converted, the working copy was used. This could lead to errors.
- New endpoint `@save-document-as-pdf`. In order to be able to offer this function in the new frontend, a new endpoint is needed. For this, some functionalities had to be moved to the global scope in order to reuse them in the endpoint.

Jira: https://4teamwork.atlassian.net/browse/NE-352


## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


## Checklist (if applicable)

_Only applicable should be left and checked._

- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - New functionality:
  - [x] for `document` also works for `mail`