### PR TITLE
Set security related HTTP headers

### DIFF
--- a/changes/GH-6894.change
+++ b/changes/GH-6894.change
@@ -1,0 +1,1 @@
+Set security related HTTP headers. [buchi]

--- a/opengever/base/configure.zcml
+++ b/opengever/base/configure.zcml
@@ -300,6 +300,11 @@
       />
 
   <subscriber
+      for="ZPublisher.interfaces.IPubEnd"
+      handler=".subscribers.set_security_headers"
+      />
+
+  <subscriber
       for="plone.dexterity.interfaces.IDexterityContent
            OFS.interfaces.IObjectWillBeRemovedEvent"
       handler=".handlers.remove_favorites"

--- a/opengever/base/subscribers.py
+++ b/opengever/base/subscribers.py
@@ -142,21 +142,23 @@ def set_security_headers(event):
         # Enable browser protection for reflected XSS attacks
         response.setHeader('X-XSS-Protection', '1; mode=block')
 
-        content_type = response.headers.get('content-type', '')
-        if content_type.startswith('text/html'):
-            # Allow resources from current origin, eval, inline js and css
-            # Allow images from current origin and data urls
-            # Disallow plugins and framing
-            response.setHeader(
-                'Content-Security-Policy',
-                "default-src 'self' 'unsafe-eval' 'unsafe-inline'; "
-                "img-src 'self' data:; "
-                "object-src 'none'; frame-ancestors 'none'")
-        else:
-            # Disallow the loading of any resources and disable framing
-            response.setHeader(
-                'Content-Security-Policy',
-                "default-src 'none'; frame-ancestors 'none'")
+        # Keep existing CSP header to allow browser views to set a custom CSP
+        if response.getHeader('Content-Security-Policy') is None:
+            content_type = response.headers.get('content-type', '')
+            if content_type.startswith('text/html'):
+                # Allow resources from current origin, eval, inline js and css
+                # Allow images from current origin and data urls
+                # Disallow plugins and framing
+                response.setHeader(
+                    'Content-Security-Policy',
+                    "default-src 'self' 'unsafe-eval' 'unsafe-inline'; "
+                    "img-src 'self' data:; "
+                    "object-src 'none'; frame-ancestors 'none'")
+            else:
+                # Disallow the loading of any resources and disable framing
+                response.setHeader(
+                    'Content-Security-Policy',
+                    "default-src 'none'; frame-ancestors 'none'")
 
         # Only send referrer on requests to the same origin
         response.setHeader('Referrer-Policy', 'same-origin')

--- a/opengever/base/subscribers.py
+++ b/opengever/base/subscribers.py
@@ -130,3 +130,33 @@ def scrub_server_version(event):
         if getattr(event.request, 'RESPONSE', None):
             if getattr(event.request.RESPONSE, '_server_version', None):
                 event.request.RESPONSE._server_version = 'Zope'
+
+
+def set_security_headers(event):
+    """Set headers related to security"""
+    response = getattr(getattr(event, 'request', None), 'response', None)
+    if response is not None:
+        # Only load scripts and stylesheets with the correct content type
+        response.setHeader('X-Content-Type-Options', 'nosniff')
+
+        # Enable browser protection for reflected XSS attacks
+        response.setHeader('X-XSS-Protection', '1; mode=block')
+
+        content_type = response.headers.get('content-type', '')
+        if content_type.startswith('text/html'):
+            # Allow resources from current origin, eval, inline js and css
+            # Allow images from current origin and data urls
+            # Disallow plugins and framing
+            response.setHeader(
+                'Content-Security-Policy',
+                "default-src 'self' 'unsafe-eval' 'unsafe-inline'; "
+                "img-src 'self' data:; "
+                "object-src 'none'; frame-ancestors 'none'")
+        else:
+            # Disallow the loading of any resources and disable framing
+            response.setHeader(
+                'Content-Security-Policy',
+                "default-src 'none'; frame-ancestors 'none'")
+
+        # Only send referrer on requests to the same origin
+        response.setHeader('Referrer-Policy', 'same-origin')

--- a/opengever/base/tests/test_security_headers.py
+++ b/opengever/base/tests/test_security_headers.py
@@ -1,5 +1,8 @@
 from ftw.testbrowser import browsing
 from opengever.testing import IntegrationTestCase
+from Products.Five.browser import BrowserView
+from zope.component import getSiteManager
+from zope.interface import Interface
 
 
 class TestSecurityHeaders(IntegrationTestCase):
@@ -14,3 +17,18 @@ class TestSecurityHeaders(IntegrationTestCase):
             "default-src 'self' 'unsafe-eval' 'unsafe-inline'; "
             "img-src 'self' data:; object-src 'none'; frame-ancestors 'none'")
         self.assertEqual(browser.headers['Referrer-Policy'], 'same-origin')
+
+    @browsing
+    def test_browser_view_can_override_csp(self, browser):
+
+        class CSPTestView(BrowserView):
+            def __call__(self):
+                self.request.response.setHeader(
+                    'Content-Security-Policy', 'default-src *')
+
+        getSiteManager().registerAdapter(
+            CSPTestView, (Interface, Interface), Interface, name=u'csp-test')
+
+        self.login(self.regular_user, browser=browser)
+        browser.open(self.portal, view='csp-test')
+        self.assertEqual(browser.headers['Content-Security-Policy'], 'default-src *')

--- a/opengever/base/tests/test_security_headers.py
+++ b/opengever/base/tests/test_security_headers.py
@@ -1,0 +1,16 @@
+from ftw.testbrowser import browsing
+from opengever.testing import IntegrationTestCase
+
+
+class TestSecurityHeaders(IntegrationTestCase):
+
+    @browsing
+    def test_response_contains_security_related_headers(self, browser):
+        browser.open(self.portal, view='login_form')
+        self.assertEqual(browser.headers['X-Content-Type-Options'], 'nosniff')
+        self.assertEqual(browser.headers['X-XSS-Protection'], '1; mode=block')
+        self.assertEqual(
+            browser.headers['Content-Security-Policy'],
+            "default-src 'self' 'unsafe-eval' 'unsafe-inline'; "
+            "img-src 'self' data:; object-src 'none'; frame-ancestors 'none'")
+        self.assertEqual(browser.headers['Referrer-Policy'], 'same-origin')

--- a/opengever/wopi/browser/edit.py
+++ b/opengever/wopi/browser/edit.py
@@ -92,6 +92,13 @@ class EditOnlineView(BrowserView):
         params_with_values.append('WOPISrc={}&'.format(wopi_src))
         self.urlsrc = '?'.join([url, ''.join(params_with_values)])
 
+        # The WOPI edit page loads frames and images from external sources.
+        self.request.response.setHeader(
+            'Content-Security-Policy',
+            "default-src 'self' 'unsafe-eval' 'unsafe-inline'; "
+            "img-src https: data:; frame-src https:; "
+            "object-src 'none'; frame-ancestors 'none'")
+
         return self.index()
 
     def get_WOPI_language_code(self):

--- a/opengever/wopi/tests/test_edit.py
+++ b/opengever/wopi/tests/test_edit.py
@@ -118,3 +118,11 @@ class TestEditView(IntegrationTestCase):
         browser.open(self.document, view="office_online_edit")
         self.assertEqual(self.document.absolute_url(), browser.url)
         self.assertEqual(['Document is locked.'], error_messages())
+
+    @browsing
+    def test_edit_view_allows_frames_and_images_from_external_sources(self, browser):
+        self.login(self.regular_user, browser=browser)
+        browser.open(self.document, view="office_online_edit")
+        csp = browser.headers['Content-Security-Policy']
+        self.assertIn('frame-src https:;', csp)
+        self.assertIn('img-src https: data:;', csp)


### PR DESCRIPTION
Setting these headers is best practice in terms of security.

### No content type sniffing
Only load scripts and stylesheets with the correct content type:
```
X-Content-Type-Options: nosniff
```

### XSS browser protection
Enable browser protection for reflected XSS attacks:
```
X-XSS-Protection: 1; mode=block
```

### No referrer for external links
Only send referrer on requests to the same origin
```
Referrer-Policy: same-origin
```

### Content-Security-Policy
For HTML resources we only allow resources from the same origin, but we have to allow eval and inline js/css. Images are allowed from the same origin and from data urls. We disallow plugins and framing.
```
Content-Security-Policy: default-src 'self' 'unsafe-eval' 'unsafe-inline'; img-src 'self' data:; object-src 'none'; frame-ancestors 'none'
```

For other resources we disallow the loading of any resources and disable framing.
```
Content-Security-Policy: default-src 'none'; frame-ancestors 'none'
```

### Disallow framing (Clickjacking protection)
`X-Frame-Options` header is already set by plone.protect


See also: https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/501907630/Sicherheitsrichtlinien+f+r+Webanwendungen

The content security policy has the potential to break things and needs careful testing.

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [ ] Link to issue (Jira or GitHub) and backlink in issue (Jira)

