### PR TITLE
Fix custom property choice field (de-)serialization.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2021.4.0 (unreleased)
 ---------------------
 
+- Fix custom property choice field (de-)serialization. [deiferni]
 - Bump ftw.casauth to 1.3.1. [lgraf]
 - Add @save-document-as-pdf API endpoint. [tinagerber]
 - Only allow to save a document as pdf if document isn't checked out. [tinagerber]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -8,6 +8,15 @@ API Changelog
 2021.4.0 (unreleased)
 ---------------------
 
+Breaking Changes
+^^^^^^^^^^^^^^^^
+
+- (De-)serialization of choice fields for ``custom_properties`` has been changed to support a nested object containing token and title for each term (see :ref:`propertysheets` for updated examples).
+
+
+Other Changes
+^^^^^^^^^^^^^
+
 - A new endpoint ``@save-document-as-pdf`` is added (see :ref:`save-document-as-pdf`).
 
 

--- a/docs/public/dev-manual/api/propertysheets.rst
+++ b/docs/public/dev-manual/api/propertysheets.rst
@@ -184,7 +184,11 @@ ausgegeben, unabhängig vom Wert des Feldes ``document_type``.
           },
           "IDocumentMetadata.document_type.protocol": {
               "location": "Dammweg 9",
-              "responsible": "Hans Muster"
+              "responsible": "Hans Muster",
+              "protocol_type": {
+                  "title": "Kurzprotokoll",
+                  "token": "Kurzprotokoll"
+              }
           }
       },
       "...": "..."
@@ -204,8 +208,13 @@ Slots nicht überschrieben.
 
     {
         "custom_properties": {
-            "IDocumentMetadata.document_type.question": {
-                "yesorno": true
+            "IDocumentMetadata.document_type.protocol": {
+                "location": "Dammweg 9",
+                "responsible": "Hans Muster",
+                "protocol_type": {
+                    "title": "Kurzprotokoll",
+                    "token": "Kurzprotokoll"
+                }
             }
         }
     }

--- a/opengever/propertysheets/configure.zcml
+++ b/opengever/propertysheets/configure.zcml
@@ -23,6 +23,8 @@
 
   <adapter factory=".field.PropertySheetFieldSchemaProvider" />
   <adapter factory=".widgets.PropertySheetFieldDataConverter" />
+  <adapter factory=".deserializer.PropertySheetFieldDeserializer" />
+  <adapter factory=".serializer.PropertySheetFieldSerializer" />
 
   <adapter
       factory=".widgets.PropertySheetFieldWiget"

--- a/opengever/propertysheets/deserializer.py
+++ b/opengever/propertysheets/deserializer.py
@@ -1,0 +1,49 @@
+from opengever.propertysheets.field import IPropertySheetField
+from opengever.propertysheets.storage import PropertySheetSchemaStorage
+from plone.dexterity.interfaces import IDexterityContent
+from plone.restapi.deserializer.dxfields import DefaultFieldDeserializer
+from plone.restapi.interfaces import IFieldDeserializer
+from zope.component import adapter
+from zope.component import getMultiAdapter
+from zope.interface import implementer
+from zope.publisher.interfaces.browser import IBrowserRequest
+
+
+@implementer(IFieldDeserializer)
+@adapter(IPropertySheetField, IDexterityContent, IBrowserRequest)
+class PropertySheetFieldDeserializer(DefaultFieldDeserializer):
+    """Delegate deserialization to property sheet fields."""
+
+    def __call__(self, value):
+        value = self.deserialize_custom_properties(value)
+        return super(PropertySheetFieldDeserializer, self).__call__(value)
+
+    def deserialize_custom_properties(self, value):
+        """Use property sheet schema fields for deserialization, if a property
+        sheet is found.
+
+        Deserialization is very permissive with unknown values, but they will
+        cause validation errors later in field validation.
+        """
+        if not isinstance(value, dict):
+            return value
+
+        for slot_name, data in value.items():
+            definition = PropertySheetSchemaStorage().query(slot_name)
+            if not definition:
+                continue
+
+            if not isinstance(data, dict):
+                continue
+
+            for name, field in definition.get_fields():
+                if name not in data:
+                    continue
+
+                field_value = data[name]
+                deserializer = getMultiAdapter(
+                    (field, self.context, self.request), IFieldDeserializer
+                )
+                data[name] = deserializer(field_value)
+
+        return value

--- a/opengever/propertysheets/serializer.py
+++ b/opengever/propertysheets/serializer.py
@@ -1,0 +1,65 @@
+from opengever.propertysheets.field import IPropertySheetField
+from opengever.propertysheets.storage import PropertySheetSchemaStorage
+from plone.dexterity.interfaces import IDexterityContent
+from plone.restapi.interfaces import IFieldSerializer
+from plone.restapi.serializer.dxfields import DefaultFieldSerializer
+from zope.component import adapter
+from zope.interface import implementer
+from zope.interface import Interface
+from zope.schema.interfaces import IChoice
+
+
+@implementer(IFieldSerializer)
+@adapter(IPropertySheetField, IDexterityContent, Interface)
+class PropertySheetFieldSerializer(DefaultFieldSerializer):
+    """Make sure choice fields are serialized correctly.
+
+    We can't reuse `IFieldSerializer` adapters for the property sheet schema as
+    they attempt to retrieve the current value from context.
+    Instead we directly implement support for choice fields and provide correct
+    serialization of terms by duplicating the `ChoiceFieldSerializer` term
+    serialization.
+    Serialization for all other permitted field types is already handled
+    correctly by the call to `json_compatible` in `DefaultFieldSerializer`.
+    """
+    def get_value(self, default=None):
+        value = super(PropertySheetFieldSerializer, self).get_value(
+            default=default
+        )
+        return self.serialize_custom_properties(value)
+
+    def serialize_custom_properties(self, value):
+        """Serialize nested custom property field data structure to JSON.
+
+        Handles invalid data grafecully and returns it, whenever possible.
+        """
+        # something is weird, be grafecul
+        if not isinstance(value, dict):
+            return value
+
+        for slot_name, data in value.items():
+            definition = PropertySheetSchemaStorage().query(slot_name)
+            # the sheet definition no longer exist, be graceful
+            if not definition:
+                continue
+
+            # the value is not a dict, be graceful
+            if not isinstance(data, dict):
+                continue
+
+            for name, field in definition.get_fields():
+                if name not in data:
+                    continue
+                if not IChoice.providedBy(field):
+                    continue
+
+                field_value = data[name]
+                try:
+                    term = field.vocabulary.getTerm(field_value)
+                    data[name] = {"token": term.token, "title": term.title}
+                except LookupError:
+                    # in case of invalid terms we pretend that there is no
+                    # value in storage and drop the field from serialization
+                    del data[name]
+
+        return value

--- a/opengever/propertysheets/tests/test_definition.py
+++ b/opengever/propertysheets/tests/test_definition.py
@@ -1,4 +1,3 @@
-from opengever.propertysheets.definition import ascii_token
 from opengever.propertysheets.definition import isidentifier
 from opengever.propertysheets.definition import PropertySheetSchemaDefinition
 from opengever.propertysheets.exceptions import InvalidFieldTypeDefinition
@@ -37,14 +36,6 @@ class TestIsIdentifier(TestCase):
         self.assertFalse(isidentifier('def'))
         self.assertFalse(isidentifier('break'))
         self.assertFalse(isidentifier('import'))
-
-
-class TestAsciiToken(TestCase):
-
-    def test_ascii_token(self):
-        self.assertEqual(u'ue', ascii_token(u'\xfc'))
-        self.assertEqual(u'aa bb', ascii_token(u'aa bb'))
-        self.assertEqual(u'ueasd asd', ascii_token(u'\xfcasd//%asd'))
 
 
 class TestSchemaDefinitionRichComparison(FunctionalTestCase):
@@ -202,7 +193,9 @@ class TestSchemaDefinition(FunctionalTestCase):
 
         self.assertEqual([u"bl\xe4h", u"blub"], voc_values)
         self.assertEqual([u"bl\xe4h", u"blub"], voc_titles)
-        self.assertEqual([u"blaeh", "blub"], voc_tokens)
+        self.assertEqual(
+            [u"bl\xe4h".encode("unicode_escape"), "blub"], voc_tokens
+        )
 
     def test_add_choice_field_requires_values(self):
         definition = PropertySheetSchemaDefinition.create("foo")
@@ -220,15 +213,6 @@ class TestSchemaDefinition(FunctionalTestCase):
     def test_add_choice_field_prevents_duplicate_values(self):
         definition = PropertySheetSchemaDefinition.create("foo")
         choices = ['duplicate', 'duplicate']
-        with self.assertRaises(ValueError):
-            definition.add_field(
-                "choice", u"chooseone", u"choose", u"", False, values=choices
-            )
-
-    def test_add_choice_field_prevents_duplicate_tokens(self):
-        """Use two different values which are normalized to the same tokens."""
-        definition = PropertySheetSchemaDefinition.create("foo")
-        choices = ['dupli cate', 'dupli\\cate']
         with self.assertRaises(ValueError):
             definition.add_field(
                 "choice", u"chooseone", u"choose", u"", False, values=choices

--- a/opengever/propertysheets/tests/test_deserializer.py
+++ b/opengever/propertysheets/tests/test_deserializer.py
@@ -1,0 +1,74 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from opengever.document.behaviors.customproperties import IDocumentCustomProperties
+from opengever.testing import IntegrationTestCase
+from plone.restapi.interfaces import IFieldDeserializer
+from zope.annotation.interfaces import IAnnotations
+from zope.component import getMultiAdapter
+
+
+class TestPropertySheetFieldDeserializer(IntegrationTestCase):
+
+    def setUp(self):
+        super(TestPropertySheetFieldDeserializer, self).setUp()
+
+        with self.login(self.regular_user):
+            self.annotations = IAnnotations(self.document)
+            field = IDocumentCustomProperties["custom_properties"]
+            self.deserializer = getMultiAdapter(
+                (field, self.document, self.request), IFieldDeserializer
+            )
+
+    def test_deserializes_choice_fields_from_token_to_value(self):
+        self.login(self.regular_user)
+
+        choices = ["one", "two", "five"]
+        create(
+            Builder("property_sheet_schema")
+            .named("schema1")
+            .assigned_to_slots(u"IDocumentMetadata.document_type.question")
+            .with_field(
+                "choice", u"choose", u"Choose", u"", True, values=choices
+            )
+        )
+
+        deserialized_data = self.deserializer(
+            {
+                "IDocumentMetadata.document_type.question": {
+                    "choose": {"title": "two", "token": "two"}
+                }
+            }
+        )
+        self.assertEqual(
+            {
+                "IDocumentMetadata.document_type.question": {
+                    "choose": "two",
+                },
+            },
+            deserialized_data,
+        )
+
+    def test_deserializes_flat_choice_fields(self):
+        self.login(self.regular_user)
+
+        choices = ["one", "two", "five"]
+        create(
+            Builder("property_sheet_schema")
+            .named("schema1")
+            .assigned_to_slots(u"IDocumentMetadata.document_type.question")
+            .with_field(
+                "choice", u"choose", u"Choose", u"", True, values=choices
+            )
+        )
+
+        deserialized_data = self.deserializer(
+            {"IDocumentMetadata.document_type.question": {"choose": "two"}}
+        )
+        self.assertEqual(
+            {
+                "IDocumentMetadata.document_type.question": {
+                    "choose": "two",
+                },
+            },
+            deserialized_data,
+        )

--- a/opengever/propertysheets/tests/test_field.py
+++ b/opengever/propertysheets/tests/test_field.py
@@ -170,6 +170,63 @@ class TestPropertySheetField(FunctionalTestCase):
             cm.exception.message,
         )
 
+    def test_choice_validation_fails_for_invalid_field_data(self):
+        create(
+            Builder("property_sheet_schema")
+            .named("schema")
+            .assigned_to_slots(u"IDocumentMetadata.document_type.question")
+            .with_field(
+                "choice", "choose", u"Choose", u"", False, values=['xx']
+            )
+        )
+        self.request["some_request_key"] = [u"question"]
+
+        with self.assertRaises(ValidationError):
+            self.field.validate(
+                {
+                    "IDocumentMetadata.document_type.question": {
+                        "choose": 'yy',
+                    }
+                }
+            )
+
+    def test_choice_validation_fails_for_missing_field_data(self):
+        create(
+            Builder("property_sheet_schema")
+            .named("schema")
+            .assigned_to_slots(u"IDocumentMetadata.document_type.question")
+            .with_field(
+                "choice", "choose", u"Choose", u"", True, values=['xx']
+            )
+        )
+        self.request["some_request_key"] = [u"question"]
+
+        with self.assertRaises(RequiredMissing):
+            self.field.validate(
+                {
+                    "IDocumentMetadata.document_type.question": {
+                    }
+                }
+            )
+
+    def test_choice_validation_with_good_data(self):
+        create(
+            Builder("property_sheet_schema")
+            .named("schema")
+            .assigned_to_slots(u"IDocumentMetadata.document_type.question")
+            .with_field(
+                "choice", "choose", u"Choose", u"", True, values=['xx']
+            )
+        )
+        self.request["some_request_key"] = [u"question"]
+        self.field.validate(
+            {
+                "IDocumentMetadata.document_type.question": {
+                    "choose": 'xx',
+                }
+            }
+        )
+
     def test_successful_field_validation_with_active_slot_from_request_key(
         self,
     ):

--- a/opengever/propertysheets/tests/test_mail_forms.py
+++ b/opengever/propertysheets/tests/test_mail_forms.py
@@ -1,5 +1,3 @@
-from ftw.builder import Builder
-from ftw.builder import create
 from ftw.testbrowser import browsing
 from opengever.propertysheets.storage import PropertySheetSchemaStorage
 from opengever.testing import IntegrationTestCase

--- a/opengever/propertysheets/tests/test_schema.py
+++ b/opengever/propertysheets/tests/test_schema.py
@@ -34,11 +34,14 @@ class TestPropertySheetJSONSchema(FunctionalTestCase):
                 u"properties": {
                     u"choose": {
                         u"choices": [
-                            [u"blaeh", u"bl\xe4h"],
-                            [u"blueb", u"bl\xfcb"]
+                            [u"bl\xe4h".encode("unicode_escape"), u"bl\xe4h"],
+                            [u"bl\xfcb".encode("unicode_escape"), u"bl\xfcb"]
                         ],
                         u"description": u"",
-                        u"enum": [u"blaeh", u"blueb"],
+                        u"enum": [
+                            u"bl\xe4h".encode("unicode_escape"),
+                            u"bl\xfcb".encode("unicode_escape")
+                        ],
                         u"enumNames": [u"bl\xe4h", u"bl\xfcb"],
                         u"factory": u"Choice",
                         u"title": u"Usw\xe4hle",

--- a/opengever/propertysheets/tests/test_schema_definition_post.py
+++ b/opengever/propertysheets/tests/test_schema_definition_post.py
@@ -122,7 +122,7 @@ class TestSchemaDefinitionPost(IntegrationTestCase):
                     "name": "wahl",
                     "field_type": u"choice",
                     "title": u"w\xe4hl was",
-                    "values": [u"eins", u"zwei"]
+                    "values": [u"\xf6ins", u"zwei"]
                 },
                 {
                     "name": "nummer",

--- a/opengever/propertysheets/tests/test_serializer.py
+++ b/opengever/propertysheets/tests/test_serializer.py
@@ -1,0 +1,109 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from opengever.document.behaviors.customproperties import IDocumentCustomProperties
+from opengever.testing import IntegrationTestCase
+from plone.restapi.interfaces import IFieldSerializer
+from zope.annotation.interfaces import IAnnotations
+from zope.component import getMultiAdapter
+
+
+class TestPropertySheetFieldSerializer(IntegrationTestCase):
+
+    ANNOTATION_KEY = (
+        "opengever.document.behaviors.customproperties"
+        ".IDocumentCustomProperties.custom_properties"
+    )
+
+    def setUp(self):
+        super(TestPropertySheetFieldSerializer, self).setUp()
+
+        with self.login(self.regular_user):
+            self.annotations = IAnnotations(self.document)
+            field = IDocumentCustomProperties["custom_properties"]
+            self.serializer = getMultiAdapter(
+                (field, self.document, self.request), IFieldSerializer
+            )
+
+    def test_serializes_choice_fields_as_token_title_object(self):
+        self.login(self.regular_user)
+
+        choices = ["one", "two", "three"]
+        create(
+            Builder("property_sheet_schema")
+            .named("schema1")
+            .assigned_to_slots(u"IDocumentMetadata.document_type.question")
+            .with_field(
+                "choice", u"choose", u"Choose", u"", True, values=choices
+            )
+        )
+        self.document.document_type = u"question"
+        IDocumentCustomProperties(self.document).custom_properties = {
+            "IDocumentMetadata.document_type.question": {
+                "choose": "two",
+            }
+        }
+
+        self.assertEqual(
+            {
+                "IDocumentMetadata.document_type.question": {
+                    "choose": {"title": "two", "token": "two"}
+                }
+            },
+            self.serializer(),
+        )
+
+    def test_skips_invalid_vocabulary_values_during_serialization(self):
+        self.login(self.regular_user)
+
+        choices = ["just one"]
+        create(
+            Builder("property_sheet_schema")
+            .named("schema1")
+            .assigned_to_slots(u"IDocumentMetadata.document_type.question")
+            .with_field(
+                "choice", u"choose", u"Choose", u"", True, values=choices
+            )
+        )
+        self.document.document_type = u"question"
+        IDocumentCustomProperties(self.document).custom_properties = {
+            "IDocumentMetadata.document_type.question": {
+                "choose": "invalid choice",
+            }
+        }
+
+        self.assertEqual(
+            {"IDocumentMetadata.document_type.question": {}}, self.serializer()
+        )
+
+    def test_greafcully_returns_incorrect_toplevel_data_structure(self):
+        self.login(self.regular_user)
+
+        self.annotations[self.ANNOTATION_KEY] = ["broken", "data"]
+        self.assertEqual(["broken", "data"], self.serializer())
+
+    def test_greafcully_returns_data_for_no_longer_existing_property_sheets(
+        self,
+    ):
+        self.login(self.regular_user)
+
+        data = {"deleted_sheet": {"attr": "value"}}
+        self.annotations[self.ANNOTATION_KEY] = data
+
+        self.assertEqual(data, self.serializer())
+
+    def test_greafcully_returns_incorrect_sheet_data(self):
+        self.login(self.regular_user)
+
+        create(
+            Builder("property_sheet_schema")
+            .named("schema1")
+            .assigned_to_slots(u"IDocumentMetadata.document_type.question")
+            .with_field("text", u"text", u"Text", u"", True)
+        )
+        self.document.document_type = u"question"
+        data = {
+            "IDocumentMetadata.document_type.question": "invalid, not a dict"
+        }
+        self.annotations[self.ANNOTATION_KEY] = data
+
+        self.assertEqual(data, self.serializer())

--- a/opengever/propertysheets/tests/test_serializer.py
+++ b/opengever/propertysheets/tests/test_serializer.py
@@ -27,7 +27,7 @@ class TestPropertySheetFieldSerializer(IntegrationTestCase):
     def test_serializes_choice_fields_as_token_title_object(self):
         self.login(self.regular_user)
 
-        choices = ["one", "two", "three"]
+        choices = [u"one", u"two", u"dr\xfc\xfc"]
         create(
             Builder("property_sheet_schema")
             .named("schema1")
@@ -39,14 +39,17 @@ class TestPropertySheetFieldSerializer(IntegrationTestCase):
         self.document.document_type = u"question"
         IDocumentCustomProperties(self.document).custom_properties = {
             "IDocumentMetadata.document_type.question": {
-                "choose": "two",
+                "choose": u"dr\xfc\xfc",
             }
         }
 
         self.assertEqual(
             {
                 "IDocumentMetadata.document_type.question": {
-                    "choose": {"title": "two", "token": "two"}
+                    "choose": {
+                        "title": u"dr\xfc\xfc",
+                        "token": u"dr\xfc\xfc".encode("unicode_escape")
+                    }
                 }
             },
             self.serializer(),

--- a/opengever/propertysheets/tests/test_widget.py
+++ b/opengever/propertysheets/tests/test_widget.py
@@ -16,7 +16,7 @@ class TestPropertySheetWidget(IntegrationTestCase):
     ):
         self.login(self.manager, browser)
 
-        choices = ["one", "two", "three"]
+        choices = ["one", u"zw\xf6i", "three"]
         create(
             Builder("property_sheet_schema")
             .named("schema1")
@@ -54,7 +54,7 @@ class TestPropertySheetWidget(IntegrationTestCase):
         browser.fill(
             {
                 "Yes or no": True,
-                "Choose": "two",
+                "Choose": u"zw\xf6i",
                 "Number": "3",
                 "Some lines of text": "Foo\nbar",
                 "A line of text": u"b\xe4\xe4",
@@ -68,7 +68,7 @@ class TestPropertySheetWidget(IntegrationTestCase):
                     "text": u"Foo\nbar",
                     "num": 3,
                     "yesorno": True,
-                    "choose": u"two",
+                    "choose": u"zw\xf6i",
                     "textline": u"b\xe4\xe4",
                 }
             },


### PR DESCRIPTION
This PR fixes some issues that surfaced due to `Choice` fields not being initialized correctly and thus skipping validation.

- Choice fields have a special condition in their validate method, skipping validation during field initialization https://github.com/zopefoundation/zope.schema/blob/bdc8935158e287549e671ee14a6f17174b9c6aa7/src/zope/schema/_field.py#L486-L488
- Our version of `plone.supermodel` has a bug which never unsets the value https://github.com/plone/plone.supermodel/blob/20812f8162ac549bad6898047c53f8dc8e3d1780/plone/supermodel/exportimport.py#L164, this is only fixed in https://github.com/plone/plone.supermodel/pull/12

We also change how `Choice` field values are represented in the API. Choice fields should be serialized and deserialized consistently with vocabulary based choice fields. They should accept a nested dict with token and title, and also be serialized in that format.
_I'm tracking this as a breaking change, because in theory it is. In practice we don't use this functionality anywhere outside the UI and the change will have no impact as the UI already works against the branch to be merged with this PR._

We also fix serializing/deserializing choice values with special characters while defining the property sheet and storing/reading it from XML. We amend integration tests to use non-ascii characters.

Jira: https://4teamwork.atlassian.net/browse/NE-367

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


## Checklist (if applicable)

_Only applicable should be left and checked._

- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry (see [guide]
