### PR TITLE
Fix inbox document overview for managers 

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2021.4.0 (unreleased)
 ---------------------
 
+- Fix inbox document overview for managers. [lgraf]
 - Add 'is_inbox_user' attribute to the @config endpoint [elioschmutz]
 - Rename the attribute 'is_admin_menu_visible' from the @config endpoint to 'is_admin'. [elioschmutz]
 - Fix custom property choice field (de-)serialization. [deiferni]

--- a/opengever/document/browser/overview.py
+++ b/opengever/document/browser/overview.py
@@ -356,8 +356,11 @@ class Overview(DefaultView, GeverTabMixin, VisibleActionButtonRendererMixin):
         except (AssertionError, ValueError):
             return False
 
-        state = api.content.get_state(
-            self.context.get_parent_dossier(), default=None)
+        parent_dossier = self.context.get_parent_dossier()
+        if not parent_dossier:
+            return False
+
+        state = api.content.get_state(parent_dossier, default=None)
         return can_edit and state in DOSSIER_STATES_CLOSED
 
     def get_archival_file_class(self):

--- a/opengever/document/tests/test_overview.py
+++ b/opengever/document/tests/test_overview.py
@@ -656,6 +656,15 @@ class TestDocumentOverviewVanilla(IntegrationTestCase):
             browser.css('#archival_file_edit_link'),
             'Archival file edit link should not be visible.')
 
+        # Same for managers - view should also render properly
+        self.login(self.manager, browser)
+
+        browser.open(self.inbox_document, view='tabbedview_view-overview')
+
+        self.assertFalse(
+            browser.css('#archival_file_edit_link'),
+            'Archival file edit link should not be visible.')
+
     @browsing
     def test_edit_archival_file_link_is_visible_on_closed_dossier_inside_a_task(self, browser):
         self.login(self.manager, browser)


### PR DESCRIPTION
The document overview for documents that are inside an inbox got broken, because the [code for the `show_edit_archival_file_link()`](https://github.com/4teamwork/opengever.core/blob/ad3f7ac1452cc21ae266a5c08100055b149c3f83/opengever/document/browser/overview.py#L352-L361) doesn't deal with the fact that `get_parent_dossier()` might return `None`.

This case is never an issue for regular users because they lack the necessary permissions and the previous condition already terminates the method, but for managers it broke the overview for documents in inboxes.

Fixes https://sentry.4teamwork.ch/organizations/sentry/issues/71907/

## Checklist (Must have)

- [x] Changelog entry
- [ ] Link to issue (Jira or GitHub) and backlink in issue (Jira)
