### PR TITLE
Rename the attribute 'is_admin_menu_visible' from the @config endpoint to 'is_admin'.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2021.4.0 (unreleased)
 ---------------------
 
+- Rename the attribute 'is_admin_menu_visible' from the @config endpoint to 'is_admin'. [elioschmutz]
 - Fix custom property choice field (de-)serialization. [deiferni]
 - Bump ftw.casauth to 1.3.1. [lgraf]
 - Add @save-document-as-pdf API endpoint. [tinagerber]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -11,6 +11,7 @@ API Changelog
 Breaking Changes
 ^^^^^^^^^^^^^^^^
 
+- Rename the attribute ``is_admin_menu_visible`` from the ``@config`` endpoint to ``is_admin``.
 - (De-)serialization of choice fields for ``custom_properties`` has been changed to support a nested object containing token and title for each term (see :ref:`propertysheets` for updated examples).
 
 

--- a/docs/public/dev-manual/api/config.rst
+++ b/docs/public/dev-manual/api/config.rst
@@ -97,7 +97,7 @@ GEVER-Mandanten abgefragt werden.
           },
           "gever_colorization": "#37C35A",
           "inbox_folder_url": "https://dev.onegovgever.ch/fd/eingangskorb/eingangskorb_afi",
-          "is_admin_menu_visible": false,
+          "is_admin": false,
           "is_emm_environment": false,
           "max_dossier_levels": 5,
           "max_repositoryfolder_levels": 3,

--- a/opengever/api/config.py
+++ b/opengever/api/config.py
@@ -23,9 +23,7 @@ class ConfigGet(Service):
         """
         Injects additional configuration information:
 
-        - is_admin_menu_visible: Indication for the GEVER UI if it should display
-          the menu item "Verwaltung" in the navigation drawer.
-
+        - is_admin: If the current user is a GEVER Admin or not
         - bumblebee_app_id: The Bumblebee app id as configured in Plone (a string).
 
         - private_folder_url: The url to the private folder of the current
@@ -33,7 +31,7 @@ class ConfigGet(Service):
           a private folder or the feature is disabled in Plone.
         """
         config['is_emm_environment'] = is_client_ip_in_office_connector_disallowed_ip_ranges()
-        config['is_admin_menu_visible'] = utils.is_administrator()
+        config['is_admin'] = utils.is_administrator()
         config['bumblebee_app_id'] = bumblebee_config.app_id
         config['private_folder_url'] = get_private_folder_url()
         config['gever_colorization'] = get_color()

--- a/opengever/api/tests/test_config.py
+++ b/opengever/api/tests/test_config.py
@@ -215,18 +215,18 @@ class TestConfig(IntegrationTestCase):
         self.assertIn(u'is_emm_environment', browser.json)
 
     @browsing
-    def test_is_admin_menu_visible_is_true_for_administrators(self, browser):
+    def test_is_admin_is_true_for_administrators(self, browser):
         self.login(self.administrator, browser)
         browser.open(self.config_url, headers=self.api_headers)
         self.assertEqual(browser.status_code, 200)
-        self.assertTrue(browser.json.get(u'is_admin_menu_visible'))
+        self.assertTrue(browser.json.get(u'is_admin'))
 
     @browsing
-    def test_is_admin_menu_visible_is_false_for_regular_user(self, browser):
+    def test_is_admin_is_false_for_regular_user(self, browser):
         self.login(self.regular_user, browser)
         browser.open(self.config_url, headers=self.api_headers)
         self.assertEqual(browser.status_code, 200)
-        self.assertFalse(browser.json.get(u'is_admin_menu_visible'))
+        self.assertFalse(browser.json.get(u'is_admin'))
 
     @browsing
     def test_config_contains_bumblebee_app_id(self, browser):


### PR DESCRIPTION
The `@config`-Endpint exposes an attribute called `is_admin_menu_visible` which was introduced for the GEVER-UI to indicate, if the management-area in the frontend should be visible or not. Since the introduction of this attribute, the frontend has changed and is now providing a management-area for every gever user, not only for admins. The frontend decides depending on attributes value, which cards should be shown in the management area. In addition, it protects special management routes with the value of this attribute.

In general, the frontend just needs to know if the current user is an admin or not. So we rename this attribute in the `@config` endpoint to make it semantically correct.

Slack-Discussion: https://4teamwork.slack.com/archives/C01BHEGBVU1/p1613382646011400?thread_ts=1613380520.009300&cid=C01BHEGBVU1

Jira: https://4teamwork.atlassian.net/browse/NE-366

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


## Checklist (if applicable)

_Only applicable should be left and checked._

- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [x] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Upgrade steps (changes in profile):
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
- DB-Schema migration
  - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
  - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value
