### PR TITLE
Add 'is_inbox_user' attribute to the @config endpoint

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2021.4.0 (unreleased)
 ---------------------
 
+- Add 'is_inbox_user' attribute to the @config endpoint [elioschmutz]
 - Rename the attribute 'is_admin_menu_visible' from the @config endpoint to 'is_admin'. [elioschmutz]
 - Fix custom property choice field (de-)serialization. [deiferni]
 - Bump ftw.casauth to 1.3.1. [lgraf]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -18,6 +18,7 @@ Breaking Changes
 Other Changes
 ^^^^^^^^^^^^^
 
+- Add ``is_inbox_user`` attribute to the ``@config`` endpoint.
 - A new endpoint ``@save-document-as-pdf`` is added (see :ref:`save-document-as-pdf`).
 
 

--- a/docs/public/dev-manual/api/config.rst
+++ b/docs/public/dev-manual/api/config.rst
@@ -98,6 +98,7 @@ GEVER-Mandanten abgefragt werden.
           "gever_colorization": "#37C35A",
           "inbox_folder_url": "https://dev.onegovgever.ch/fd/eingangskorb/eingangskorb_afi",
           "is_admin": false,
+          "is_inbox_user": false,
           "is_emm_environment": false,
           "max_dossier_levels": 5,
           "max_repositoryfolder_levels": 3,

--- a/opengever/api/config.py
+++ b/opengever/api/config.py
@@ -4,6 +4,8 @@ from opengever.base.colorization import get_color
 from opengever.base.interfaces import IGeverSettings
 from opengever.inbox.utils import get_current_inbox
 from opengever.officeconnector.helpers import is_client_ip_in_office_connector_disallowed_ip_ranges
+from opengever.ogds.base.utils import get_current_org_unit
+from opengever.ogds.models.service import ogds_service
 from opengever.private import get_private_folder_url
 from plone.restapi.services import Service
 
@@ -36,5 +38,9 @@ class ConfigGet(Service):
         config['private_folder_url'] = get_private_folder_url()
         config['gever_colorization'] = get_color()
 
-        inbox = get_current_inbox(self.context)
-        config['inbox_folder_url'] = inbox.absolute_url() if inbox else ''
+        plone_inbox = get_current_inbox(self.context)
+        config['inbox_folder_url'] = plone_inbox.absolute_url() if plone_inbox else ''
+
+        ogds_inbox = get_current_org_unit().inbox()
+        current_user = ogds_service().fetch_current_user()
+        config['is_inbox_user'] = current_user in ogds_inbox.assigned_users()

--- a/opengever/api/tests/test_config.py
+++ b/opengever/api/tests/test_config.py
@@ -229,6 +229,20 @@ class TestConfig(IntegrationTestCase):
         self.assertFalse(browser.json.get(u'is_admin'))
 
     @browsing
+    def test_is_inbox_user_is_true_for_users_assigned_to_the_inbox_group(self, browser):
+        self.login(self.secretariat_user, browser)
+        browser.open(self.config_url, headers=self.api_headers)
+        self.assertEqual(browser.status_code, 200)
+        self.assertTrue(browser.json.get(u'is_inbox_user'))
+
+    @browsing
+    def test_is_inbox_user_is_false_for_regular_user(self, browser):
+        self.login(self.regular_user, browser)
+        browser.open(self.config_url, headers=self.api_headers)
+        self.assertEqual(browser.status_code, 200)
+        self.assertFalse(browser.json.get(u'is_inbox_user'))
+
+    @browsing
     def test_config_contains_bumblebee_app_id(self, browser):
         self.login(self.regular_user, browser)
         browser.open(self.config_url, headers=self.api_headers)


### PR DESCRIPTION
This PR introduces a new `@config` attribute: `is_inbox_user` which is required for the frontend to decide if inbox specific dashboard cards should be visible for the current user or not.

The condition for the `is_inbox_user` is taken from the old implementation: https://github.com/4teamwork/opengever.core/blob/ffe96663f855bcf81f7359b8817827f4bf9918a1/opengever/tabbedview/browser/personal_overview.py#L140

I think it makes no sense to refactor the old implementation to a reusable function. So I just reimplemented the required part directly in the `@config` endpoint. The decision who can see the tabs/cards is made in the frontend based on the newly `is_inbox_user` and `is_admin`(https://github.com/4teamwork/opengever.core/pull/6898)

Slack-Discussion: https://4teamwork.slack.com/archives/C01BHEGBVU1/p1613380520009300
Jira: https://4teamwork.atlassian.net/browse/NE-366

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


## Checklist (if applicable)

_Only applicable should be left and checked._

- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Upgrade steps (changes in profile):
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
- DB-Schema migration
  - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
  - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value
