### PR TITLE
Update policy templates

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 ---------------------
 
 - Fix inbox document overview for managers. [lgraf]
+- Always set APPS_ENDPOINT_URL and handle sablon, msg_convert and pdflatex as services in policy templates. [njohner]
 - Add 'is_inbox_user' attribute to the @config endpoint [elioschmutz]
 - Rename the attribute 'is_admin_menu_visible' from the @config endpoint to 'is_admin'. [elioschmutz]
 - Fix custom property choice field (de-)serialization. [deiferni]

--- a/opengever/policytemplates/policy_template/.mrbob.ini
+++ b/opengever/policytemplates/policy_template/.mrbob.ini
@@ -27,7 +27,7 @@ base.ogds_db_name.question = OGDS DB Name
 base.ogds_db_name.required = True
 
 base.apps_endpoint_url.question = Apps endpoint url
-base.apps_endpoint_url.required = False
+base.apps_endpoint_url.required = True
 
 base.bumblebee_app_id.question = Bumblebee app id
 base.bumblebee_app_id.required = False

--- a/opengever/policytemplates/policy_template/.mrbob.ini
+++ b/opengever/policytemplates/policy_template/.mrbob.ini
@@ -26,6 +26,11 @@ base.domain.post_ask_question = opengever.policytemplates.hooks:post_base_domain
 base.ogds_db_name.question = OGDS DB Name
 base.ogds_db_name.required = True
 
+base.setup_with_services.question = Sablon, Msg_convert and pdflatex as services?
+base.setup_with_services.required = True
+base.setup_with_services.default = true
+base.setup_with_services.post_ask_question = mrbob.hooks:to_boolean
+
 base.apps_endpoint_url.question = Apps endpoint url
 base.apps_endpoint_url.required = True
 

--- a/opengever/policytemplates/policy_template/opengever.+package.name+/deployment-+base.server_name+-+base.deployment_number+-+base.domain+.cfg.bob
+++ b/opengever/policytemplates/policy_template/opengever.+package.name+/deployment-+base.server_name+-+base.deployment_number+-+base.domain+.cfg.bob
@@ -34,7 +34,7 @@ environment-vars +=
     BUMBLEBEE_INTERNAL_PLONE_URL https://{{{base.domain}}}/
     BUMBLEBEE_PUBLIC_URL https://{{{base.domain}}}/
     BUMBLEBEE_SECRET {{{base.bumblebee_secret}}}
-{{% if is_teamraum %}}
     APPS_ENDPOINT_URL {{{base.apps_endpoint_url}}}
+{{% if is_teamraum %}}
     WORKSPACE_SECRET {{{base.workspace_secret}}}
 {{% endif %}}

--- a/opengever/policytemplates/policy_template/opengever.+package.name+/deployment-+base.server_name+-+base.deployment_number+-+base.domain+.cfg.bob
+++ b/opengever/policytemplates/policy_template/opengever.+package.name+/deployment-+base.server_name+-+base.deployment_number+-+base.domain+.cfg.bob
@@ -26,7 +26,9 @@ supervisor-memmon-instance-size = 1200MB
 supervisor-memmon-options = -p instance1=${buildout:supervisor-memmon-instance-size} -p instance2=${buildout:supervisor-memmon-instance-size} -p instance3=${buildout:supervisor-memmon-instance-size} -p instance4=${buildout:supervisor-memmon-instance-size} -m ${buildout:supervisor-email}
 
 parts -= gems
+{{% if not base.setup_with_services %}}
 sablon-executable = /opt/sablon/bin/sablon
+{{% endif %}}
 
 [instance0]
 environment-vars +=
@@ -35,6 +37,12 @@ environment-vars +=
     BUMBLEBEE_PUBLIC_URL https://{{{base.domain}}}/
     BUMBLEBEE_SECRET {{{base.bumblebee_secret}}}
     APPS_ENDPOINT_URL {{{base.apps_endpoint_url}}}
+{{% if base.setup_with_services %}}
+    MSGCONVERT_URL http://localhost:8090/
+    SABLON_URL http://localhost:8091/
+    PDFLATEX_URL http://localhost:8092/
+{{% endif %}}
+
 {{% if is_teamraum %}}
     WORKSPACE_SECRET {{{base.workspace_secret}}}
 {{% endif %}}


### PR DESCRIPTION
For some reason we were setting the APPS_ENDPOINT_URL only for teamraum deployments. I think all new deployments will have the Gever-UI and need the APPS_ENDPOINT_URL to be set.

Moreover we now setup new deployments (on new servers) with several tools installed as services, notably sablon, msgconvert and pdflatex. I've now added a question that will set the URLs for these services correctly in sich cases.

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

For https://4teamwork.atlassian.net/browse/CA-984
