### PR TITLE
Rename object and set creator after copying with REST API

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -18,6 +18,7 @@ Changelog
 - Set SameSite=Lax flag for session authentication cookie. [buchi]
 - Add support for Docugate templates. [buchi]
 - Add sortable_reference solr index. [njohner]
+- Rename object and set creator after copying with REST API. [buchi]
 
 
 2021.3.0 (2021-02-03)

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -159,6 +159,15 @@
 
   <plone:service
       method="POST"
+      name="@copy"
+      for="Products.CMFCore.interfaces.IFolderish"
+      factory=".copy_.Copy"
+      permission="zope2.View"
+      layer="opengever.base.interfaces.IOpengeverBaseLayer"
+      />
+
+  <plone:service
+      method="POST"
       name="@move"
       for="Products.CMFCore.interfaces.IFolderish"
       factory=".move.Move"

--- a/opengever/api/copy_.py
+++ b/opengever/api/copy_.py
@@ -1,0 +1,61 @@
+from AccessControl.SecurityManagement import getSecurityManager
+from Acquisition import aq_parent
+from opengever.base import _
+from opengever.document.behaviors import IBaseDocument
+from opengever.document.handlers import DISABLE_DOCPROPERTY_UPDATE_FLAG
+from plone.restapi.services.copymove.copymove import Copy
+from zope.container.interfaces import INameChooser
+from zope.i18n import translate
+
+
+class Copy(Copy):
+    def reply(self):
+        # Do not prepend document titles with 'Copy of'
+        # We will do that after renaming ids, but only for the top level object
+        self.request['prevent-copyname-on-document-copy'] = True
+        # Do not update Doc Properties during copying
+        # We will update them after renaming
+        self.request[DISABLE_DOCPROPERTY_UPDATE_FLAG] = True
+
+        results = super(Copy, self).reply()
+
+        for result in results:
+            target_id = result["target"].split("/")[-1]
+            obj = self.context[target_id]
+            self.recursive_rename_and_fix_creator(obj)
+            result["target"] = obj.absolute_url()
+
+        return results
+
+    def recursive_rename_and_fix_creator(self, obj):
+        for subobj in obj.objectValues():
+            self.recursive_rename_and_fix_creator(subobj)
+
+        old_id = obj.getId()
+        parent = aq_parent(obj)
+        new_id = INameChooser(parent).chooseName(None, obj)
+
+        if new_id != old_id:
+            if IBaseDocument.providedBy(obj):
+                self.request[DISABLE_DOCPROPERTY_UPDATE_FLAG] = False
+            else:
+                self.request[DISABLE_DOCPROPERTY_UPDATE_FLAG] = True
+            parent.manage_renameObject(old_id, new_id)
+
+        if old_id.startswith('copy_of'):
+            obj.title = translate(
+                _('copy_of', default='Copy of ${title}',
+                  mapping=dict(title=obj.title)),
+                context=self.request,
+            )
+            obj.reindexObject(idxs=['Title', 'sortable_title'])
+
+        # Make sure the user who created the copy is listed as first creator
+        # and therefore is the DC Creator of the object.
+        userid = getSecurityManager().getUser().getId()
+        new_creators = list(obj.creators)
+        if userid in obj.creators:
+            new_creators.remove(userid)
+        new_creators.insert(0, userid)
+        obj.creators = tuple(new_creators)
+        obj.reindexObject(idxs=['Creator'])

--- a/opengever/api/tests/test_copy_paste.py
+++ b/opengever/api/tests/test_copy_paste.py
@@ -6,15 +6,36 @@ import json
 class TestCopyPasteAPI(IntegrationTestCase):
 
     @browsing
-    def test_copy_paste_document(self, browser):
+    def test_copy_renames_id(self, browser):
+        self.login(self.regular_user, browser)
+        payload = {
+            u'source': self.subdossier.absolute_url(),
+        }
+
+        browser.open(
+            self.leaf_repofolder.absolute_url() + '/@copy',
+            data=json.dumps(payload),
+            method='POST',
+            headers=self.api_headers,
+        )
+
+        target_id = browser.json[0][u'target'].split('/')[-1]
+        self.assertNotEqual(target_id, 'copy_of_' + self.subdossier.id)
+
+        target = self.leaf_repofolder[target_id]
+        self.assertEqual(
+            set(target.objectIds()) & set(self.subdossier.objectIds()), set())
+
+    @browsing
+    def test_copy_renames_title_if_copied_to_same_container(self, browser):
         self.login(self.regular_user, browser)
         payload = {
             u'source': self.document.absolute_url(),
         }
 
-        with self.observe_children(self.empty_dossier) as children:
+        with self.observe_children(self.dossier) as children:
             browser.open(
-                self.empty_dossier.absolute_url() + '/@copy',
+                self.dossier.absolute_url() + '/@copy',
                 data=json.dumps(payload),
                 method='POST',
                 headers=self.api_headers)
@@ -25,6 +46,23 @@ class TestCopyPasteAPI(IntegrationTestCase):
         self.assertEqual([{u'source': self.document.absolute_url(),
                            u'target': copy.absolute_url()}],
                          browser.json)
+
+    @browsing
+    def test_copy_updates_creator(self, browser):
+        self.login(self.regular_user, browser)
+        payload = {
+            u'source': self.document.absolute_url(),
+        }
+        browser.open(
+            self.dossier.absolute_url() + '/@copy',
+            data=json.dumps(payload),
+            method='POST',
+            headers=self.api_headers,
+        )
+
+        target_id = browser.json[0][u'target'].split('/')[-1]
+        target = self.dossier[target_id]
+        self.assertEqual(target.Creator(), self.regular_user.getId())
 
     @browsing
     def test_copy_paste_checked_out_document_is_forbidden(self, browser):

--- a/opengever/base/locales/de/LC_MESSAGES/opengever.base.po
+++ b/opengever/base/locales/de/LC_MESSAGES/opengever.base.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-01-25 11:32+0000\n"
+"POT-Creation-Date: 2021-02-16 11:20+0000\n"
 "PO-Revision-Date: 2014-09-04 01:03+0200\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: Jonas Baumann <j.baumann@4teamwork.ch>\n"
@@ -96,6 +96,11 @@ msgstr "Geheim"
 #: opengever/repository/classification.py
 msgid "confidential"
 msgstr "Vertraulich"
+
+#. Default "Copy of ${title}"
+#: opengever/api/copy_.py
+msgid "copy_of"
+msgstr "Kopie von ${title}"
 
 #. Default: "Confirm that you'd like to perform this action."
 #: ./opengever/base/browser/confirm.pt

--- a/opengever/base/locales/en/LC_MESSAGES/opengever.base.po
+++ b/opengever/base/locales/en/LC_MESSAGES/opengever.base.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-01-25 11:32+0000\n"
+"POT-Creation-Date: 2021-02-16 11:20+0000\n"
 "PO-Revision-Date: 2014-09-04 01:03+0200\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: Jonas Baumann <j.baumann@4teamwork.ch>\n"
@@ -114,6 +114,11 @@ msgstr "classified"
 #: opengever/repository/classification.py
 msgid "confidential"
 msgstr "confidential"
+
+#. Default "Copy of ${title}"
+#: opengever/api/copy_.py
+msgid "copy_of"
+msgstr "Copy of ${title}"
 
 #. German translation: Bestätigen Sie bitte, dass Sie diese Aktion durchführen möchten.
 #. Default: "Confirm that you'd like to perform this action."

--- a/opengever/base/locales/fr/LC_MESSAGES/opengever.base.po
+++ b/opengever/base/locales/fr/LC_MESSAGES/opengever.base.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-01-25 11:32+0000\n"
+"POT-Creation-Date: 2021-02-16 11:20+0000\n"
 "PO-Revision-Date: 2017-11-29 10:53+0000\n"
 "Last-Translator: Philippe Gross <gross.philippe@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-base/fr/>\n"
@@ -97,6 +97,11 @@ msgstr "Strictement confidentiel"
 #: opengever/repository/classification.py
 msgid "confidential"
 msgstr "Confidentiel"
+
+#. Default "Copy of ${title}"
+#: opengever/api/copy_.py
+msgid "copy_of"
+msgstr "Copie de ${title}"
 
 #. Default: "Confirm that you'd like to perform this action."
 #: ./opengever/base/browser/confirm.pt

--- a/opengever/base/locales/opengever.base-manual.pot
+++ b/opengever/base/locales/opengever.base-manual.pot
@@ -17,6 +17,11 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: opengever.repository\n"
 
+#. Default "Copy of ${title}"
+#: opengever/api/copy_.py
+msgid "copy_of"
+msgstr ""
+
 #. Default: "unprotected"
 #: opengever/repository/classification.py
 msgid "unprotected"

--- a/opengever/base/locales/opengever.base.pot
+++ b/opengever/base/locales/opengever.base.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-01-25 11:32+0000\n"
+"POT-Creation-Date: 2021-02-16 11:20+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -94,6 +94,11 @@ msgstr ""
 #. Default: "confidential"
 #: opengever/repository/classification.py
 msgid "confidential"
+msgstr ""
+
+#. Default "Copy of ${title}"
+#: opengever/api/copy_.py
+msgid "copy_of"
 msgstr ""
 
 #. Default: "Confirm that you'd like to perform this action."


### PR DESCRIPTION
Does basically the same as in `PasteClipboardView`:
- Renames the id of copied objects
- Prepends the title of the top level object with "Copy of" if it was copied to the same location
- Sets the creator to the user making the copy
- Makes sure that Doc Properties are updated only after renaming

The current implementation of renaming an object is highly inefficient as it removes the object from the container and adds it again, which triggers a lot of events. This is what the Plone default implementation does. This could be optimized if necessary.

There's an upgrade step that renames the id of objects that have a wrong one. This is done only for documents and dossiers as these are currently the only types that can be copied using the new frontend. It does not work for closed dossiers.

JIRA: https://4teamwork.atlassian.net/browse/CA-1050

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


## Checklist (if applicable)

- Upgrade steps (changes in profile):
  - [x] Make it deferrable if possible
  - [x] Execute as much as possible conditionally
