### PR TITLE
Adapt policy templates for ianus portal.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2021.4.0 (unreleased)
 ---------------------
 
+- Adapt policy templates for ianus portal. [njohner]
 - Fix inbox document overview for managers. [lgraf]
 - Always set APPS_ENDPOINT_URL and handle sablon, msg_convert and pdflatex as services in policy templates. [njohner]
 - Add 'is_inbox_user' attribute to the @config endpoint [elioschmutz]

--- a/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/+adminunit.id+/configure.zcml.bob
+++ b/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/+adminunit.id+/configure.zcml.bob
@@ -71,7 +71,7 @@
       policy_profile="opengever.{{{package.name}}}.{{{adminunit.id}}}:default"
       additional_profiles="opengever.{{{package.name}}}.{{{adminunit.id}}}:units
                            opengever.{{{package.name}}}.{{{adminunit.id}}}:default_content
-                           opengever.setup:casauth
+                           opengever.setup:casauth_ianus_portal
                           "
       admin_unit_id="{{{adminunit.id}}}"
       administrator_group="{{{deployment.administrator_group}}}"
@@ -90,7 +90,7 @@
       policy_profile="opengever.{{{package.name}}}.{{{adminunit.id}}}:default"
       additional_profiles="opengever.{{{package.name}}}.{{{adminunit.id}}}:workspaces_content
                            opengever.{{{package.name}}}.{{{adminunit.id}}}:units
-                           opengever.setup:casauth
+                           opengever.setup:casauth_ianus_portal
                           "
       admin_unit_id="{{{adminunit.id}}}"
       administrator_group="{{{deployment.administrator_group}}}"

--- a/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/+adminunit.id+/profiles/ldap/ldap_plugin.xml.bob
+++ b/opengever/policytemplates/policy_template/opengever.+package.name+/opengever/+package.name+/+adminunit.id+/profiles/ldap/ldap_plugin.xml.bob
@@ -3,7 +3,6 @@
 
         <ldapplugin title="{{{package.name}}} LDAP" id="ldap" meta_type="Plone LDAP plugin" update="False">
             <cache value="RAMCache"/>
-            <interface value="IAuthenticationPlugin"/>
             <interface value="ICredentialsResetPlugin"/>
             <interface value="IGroupEnumerationPlugin"/>
             <interface value="IGroupIntrospection"/>


### PR DESCRIPTION
As we now always use ianus for new deployments, there is no reason to use the `casauth` policy of the old portal in the policy templates. Also Authentication and resetting credentials should not happen over the ldap plugin. Authentication anyway gets deactivated during setup (https://github.com/4teamwork/opengever.core/blob/master/opengever/setup/deploy.py#L138-L141)

For https://4teamwork.atlassian.net/browse/CA-984

## Checklist (Must have)
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
