### PR TITLE
Extend solrsearch endpoint, with breadcrumbs information option.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,7 @@ Changelog
 - Fix rejecting submitted proposal containing mail with extracted trashed attachment. [njohner]
 - Add create_task_from_proposal action. [tinagerber]
 - Also set title_en and title_fr for meetings in policy templates. [njohner]
+- Extend solrsearch endpoint, with breadcrumbs information option. [phgross]
 
 
 2021.4.1 (2021-02-25)

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -8,7 +8,10 @@ API Changelog
 2021.5.0 (unreleased)
 ---------------------
 
-- Nothing changed yet.
+Other Changes
+^^^^^^^^^^^^^
+
+- Add ``breadcrumbs`` option to the ``@solrsearch`` endpoint.
 
 
 2021.4.1 (2021-02-25)

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -11,7 +11,7 @@ API Changelog
 Other Changes
 ^^^^^^^^^^^^^
 
-- Add ``breadcrumbs`` option to the ``@solrsearch`` endpoint.
+- Add ``breadcrumbs`` option to the ``@solrsearch`` endpoint, only available for small batch sizes (max. 50 items).
 
 
 2021.4.1 (2021-02-25)

--- a/docs/public/dev-manual/api/searching.rst
+++ b/docs/public/dev-manual/api/searching.rst
@@ -229,6 +229,10 @@ Batching
 ~~~~~~~~
 Der Endpoint stellt die Standard-Paginierung gem :ref:`Kapitel Paginierung <batching>` zur Verfügung.
 
+Breadcrumbs
+~~~~~~~~~~~
+Wird eine ``@solrsearch`` Anfrage mit ``breadcrumbs=1`` Parameter ergänzt, so werden die einzelnen Suchtreffer unter dem Key ``breadcrumbs`` mit den Breadcrumb Informationen ergänzt.
+
 
 Teamraum Solr Suche
 -------------------

--- a/docs/public/dev-manual/api/searching.rst
+++ b/docs/public/dev-manual/api/searching.rst
@@ -231,7 +231,7 @@ Der Endpoint stellt die Standard-Paginierung gem :ref:`Kapitel Paginierung <batc
 
 Breadcrumbs
 ~~~~~~~~~~~
-Wird eine ``@solrsearch`` Anfrage mit ``breadcrumbs=1`` Parameter ergänzt, so werden die einzelnen Suchtreffer unter dem Key ``breadcrumbs`` mit den Breadcrumb Informationen ergänzt.
+Wird eine ``@solrsearch`` Anfrage mit ``breadcrumbs=1`` Parameter ergänzt, so werden die einzelnen Suchtreffer unter dem Key ``breadcrumbs`` mit den Breadcrumb Informationen ergänzt. Diese Ergänzung ist nur bei kleinen Batchsizes (maximal 50) erlaubt.
 
 
 Teamraum Solr Suche

--- a/opengever/api/solrsearch.py
+++ b/opengever/api/solrsearch.py
@@ -28,8 +28,15 @@ class SolrSearchGet(SolrQueryBaseService):
         self.show_breadcrumbs = self.extract_show_breadcrumb()
 
     def extract_show_breadcrumb(self):
-        """Extract breadcrumbs flag - to enable """
-        return bool(self.request.form.get('breadcrumbs', False))
+        """Extract breadcrumbs flag and checks if the batchsize is
+        not higher than 50 when enabled."""
+
+        show_breadcrumbs = bool(self.request.form.get('breadcrumbs', False))
+        if show_breadcrumbs:
+            if self.request.form.get('b_size', 0) > 50:
+                raise BadRequest('Breadcrumb flag is only allowed for '
+                                 'small batch sizes (max. 50).')
+        return show_breadcrumbs
 
     def extract_query(self, params):
         if 'q' in params:

--- a/opengever/api/tests/test_solrsearch.py
+++ b/opengever/api/tests/test_solrsearch.py
@@ -505,3 +505,17 @@ class TestSolrSearchGet(SolrIntegrationTestCase):
              u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-10',
              u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-10/document-31'],
             [item['@id'] for item in document['breadcrumbs']])
+
+    @browsing
+    def test_raises_badrequest_if_breadcrumb_is_enabled_and_b_size_is_higher_than_50(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        with browser.expect_http_error(400):
+            url = u'{}/@solrsearch?q=Programm&breadcrumbs=1&b_size=100'.format(
+            self.portal.absolute_url())
+            browser.open(url, headers=self.api_headers)
+
+        self.assertEqual(
+            {"message": "Breadcrumb flag is only allowed for small batch sizes (max. 50).",
+             "type": "BadRequest"},
+            browser.json)

--- a/opengever/api/tests/test_solrsearch.py
+++ b/opengever/api/tests/test_solrsearch.py
@@ -472,3 +472,36 @@ class TestSolrSearchGet(SolrIntegrationTestCase):
 
         self.assertEqual(3, len(browser.json['items']))
         self.assertEqual(all_items[0:3], browser.json['items'])
+
+    @browsing
+    def test_breadcrumbs_is_not_included_by_default(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        view = '@solrsearch'
+        browser.open(
+            self.repository_root, view=view, headers=self.api_headers)
+        all_items = browser.json['items']
+
+        self.assertNotIn('breadcrumbs', all_items[0].keys())
+
+    @browsing
+    def test_include_breadcrumbs(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        url = u'{}/@solrsearch?q=Programm&breadcrumbs=1'.format(
+            self.portal.absolute_url())
+        browser.open(url, headers=self.api_headers)
+        document = browser.json['items'][0]
+
+        self.assertIn('breadcrumbs', document.keys())
+        self.assertEqual(
+            [u'description', u'title', u'is_leafnode', u'review_state',
+             u'@id', u'@type'],
+            document['breadcrumbs'][0].keys())
+        self.assertEqual(
+            [u'http://nohost/plone/ordnungssystem',
+             u'http://nohost/plone/ordnungssystem/fuhrung',
+             u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen',
+             u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-10',
+             u'http://nohost/plone/ordnungssystem/fuhrung/vertrage-und-vereinbarungen/dossier-10/document-31'],
+            [item['@id'] for item in document['breadcrumbs']])


### PR DESCRIPTION
Needed by the gever-ui, for displaying the breadcrumbs for each searchresult in the search results page. 

Because we do not have the information currently in SOLR and an indexing would lead to bad updating problems (changing the title of the repositoryfolder), we decide to use the real object for the generation, but introduce a flag and do not add the breadcrumbs by default. So it's only used in the detailed search results page, similar as we do in the classic ui. Discussed with buchi.

i was not sure how to implement the flag, that were my thoughts:
* Why not using the `expansion` functionality: The results is added to each result item not as a main key to the response.
* Why not handling the breadcrumbs as a requested field: the generation leads to longer requests, this would not be visible for the api user, if we would fake it as "solr-index"


JIRA: https://4teamwork.atlassian.net/browse/HG-994

## Checklist (Must have)

- [X] Changelog entry
- [X] Link to issue (Jira or GitHub) and backlink in issue (Jira)


## Checklist (if applicable)
- API change:
  - [X] Documentation is updated
  - [X] API Changelog entry (see [guide]- New functionality:
