### PR TITLE
Implement OneOffixx REST-Endpoints

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -9,6 +9,7 @@ Changelog
 - Include mails in SIP package. [njohner]
 - Fix rejecting submitted proposal containing mail with extracted trashed attachment. [njohner]
 - Add create_task_from_proposal action. [tinagerber]
+- Implement GET @oneoffixx-templates to provide oneoffixx templates over the restapi. [elioschmutz]
 - Implement POST @document_from_oneoffixx endpoint to create a document from a oneoffixx template. [elioschmutz]
 - Also set title_en and title_fr for meetings in policy templates. [njohner]
 - Extend solrsearch endpoint, with breadcrumbs information option. [phgross]

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,7 @@ Changelog
 - Cleanup conditionals protecting for changed date not set yet. [njohner]
 - Use changed instead of modified in date range calculation for SIP packages. [njohner]
 - Include mails in SIP package. [njohner]
+- Fix creating documents from docugate over the restapi in private, inbox and workspace areas. [elioschmutz]
 - Fix rejecting submitted proposal containing mail with extracted trashed attachment. [njohner]
 - Add create_task_from_proposal action. [tinagerber]
 - Implement GET @oneoffixx-templates to provide oneoffixx templates over the restapi. [elioschmutz]

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -9,6 +9,7 @@ Changelog
 - Include mails in SIP package. [njohner]
 - Fix rejecting submitted proposal containing mail with extracted trashed attachment. [njohner]
 - Add create_task_from_proposal action. [tinagerber]
+- Implement POST @document_from_oneoffixx endpoint to create a document from a oneoffixx template. [elioschmutz]
 - Also set title_en and title_fr for meetings in policy templates. [njohner]
 - Extend solrsearch endpoint, with breadcrumbs information option. [phgross]
 

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -11,6 +11,7 @@ API Changelog
 Other Changes
 ^^^^^^^^^^^^^
 
+- Add new endpoint ``@document_from_oneoffixx`` to add a document from a oneoffixx template
 - Add ``breadcrumbs`` option to the ``@solrsearch`` endpoint, only available for small batch sizes (max. 50 items).
 
 

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -11,6 +11,7 @@ API Changelog
 Other Changes
 ^^^^^^^^^^^^^
 
+- Add new endpoint ``@oneoffixx-templates`` to provide oneoffixx templates over the restapi
 - Add new endpoint ``@document_from_oneoffixx`` to add a document from a oneoffixx template
 - Add ``breadcrumbs`` option to the ``@solrsearch`` endpoint, only available for small batch sizes (max. 50 items).
 

--- a/docs/public/dev-manual/api/documents_from_template.rst
+++ b/docs/public/dev-manual/api/documents_from_template.rst
@@ -39,3 +39,71 @@ Als Antwort erhält der Konsument eine Office-Connector URL welche im Browser au
         "@id": "http://nohost/plone/ordnungssystem/dossier-23/document-44",
         "url": "oc:token"
       }
+
+OneOffixx Vorlagen auflisten
+----------------------------
+
+OneOffixx Vorlagen, Gruppen und Favoriten können über den Endpoint `@oneoffixx-templates` abgefragt werden:
+
+
+**Beispiel-Request:**
+
+  .. sourcecode:: http
+
+    GET /ordnungssystem/dossier-23/@oneoffixx-templates HTTP/1.1
+    Accept: application/json
+
+**Beispiel-Response:**
+
+   .. sourcecode:: http
+
+      HTTP/1.1 200 OK
+      Content-Type: application/json
+
+      {
+        "favorites": [
+            {
+                "content_type": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+                "filename": "3 Example Word file.docx",
+                "template_id": "2574d08d-95ea-4639-beab-3103fe4c3bc7",
+                "title": "3 Example Word file"
+            }
+        ],
+        "groups": [
+            {
+                "group_id": "c2ddc01a-befd-4e0d-b15f-f67025f532be",
+                "templates": ["2574d08d-95ea-4639-beab-3103fe4c3bc7"],
+                "title": "Word templates"
+            },
+            {
+                "group_id": "c2ddc01a-befd-4e0d-b15f-f67025f532bf",
+                "templates": ["2574d08d-95ea-4639-beab-3103fe4c3bc8"],
+                "title": "Excel templates"
+            },
+            {
+                "group_id": "c2ddc01a-befd-4e0d-b15f-f67025f532c0",
+                "templates": ["2574d08d-95ea-4639-beab-3103fe4c3bc9"],
+                "title": "Powerpoint template folder"
+            }
+        ],
+        "templates": [
+            {
+                "content_type": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+                "filename": "3 Example Word file.docx",
+                "template_id": "2574d08d-95ea-4639-beab-3103fe4c3bc7",
+                "title": "3 Example Word file"
+            },
+            {
+                "content_type": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                "filename": "2 Example Excel file.xlsx",
+                "template_id": "2574d08d-95ea-4639-beab-3103fe4c3bc8",
+                "title": "2 Example Excel file"
+            },
+            {
+                "content_type": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+                "filename": "1 Example Powerpoint presentation.pptx",
+                "template_id": "2574d08d-95ea-4639-beab-3103fe4c3bc9",
+                "title": "1 Example Powerpoint presentation"
+            }
+        ]
+      }

--- a/docs/public/dev-manual/api/documents_from_template.rst
+++ b/docs/public/dev-manual/api/documents_from_template.rst
@@ -1,0 +1,41 @@
+Dokumente aus Vorlagen
+======================
+
+Gever unterstützt diverse Vorlagensysteme.
+
+OneOffix
+========
+
+Das OneOffixx Vorlagensystem muss korrekt angebunden werden und das Feauture ``oneoffixx`` muss aktiviert sein.
+
+Erstellen eines Dokuments von einer OneOffixx Vorlage
+-----------------------------------------------------
+
+Ein Dokument aus einer OneOffixx Vorlage wird in zwei Schritten erstellt. In einem ersten Schritt wird das Dokument mit allen Metadaten und einen Verweis auf eine OneOffixx-Vorlage über ein ``POST`` auf den ``@document_from_oneoffixx`` Endpoint erstellt. Der Endpoint unterstützt alle Metadaten, die ein normales Dokument auch unterstützt.
+
+**Beispiel-Request:**
+
+  .. sourcecode:: http
+
+    POST /ordnungssystem/dossier-23/@document_from_oneoffixx HTTP/1.1
+    Accept: application/json
+
+    {
+    "document": {"title": "My OneOffixx Document"},
+     "template_id": "xyz"
+    }
+
+
+Als Antwort erhält der Konsument eine Office-Connector URL welche im Browser aufgerufen werden kann. Der Office-Connector öffnet nun die vorher referenzierte Vorlage.
+
+**Beispiel-Response:**
+
+   .. sourcecode:: http
+
+      HTTP/1.1 200 OK
+      Content-Type: application/json
+
+      {
+        "@id": "http://nohost/plone/ordnungssystem/dossier-23/document-44",
+        "url": "oc:token"
+      }

--- a/docs/public/dev-manual/api/index.rst
+++ b/docs/public/dev-manual/api/index.rst
@@ -22,6 +22,7 @@ Inhalt:
    dossiers.rst
    dossier_participations.rst
    documents.rst
+   documents_from_template.rst
    extract_attachments.rst
    trash.rst
    workflow.rst

--- a/opengever/docugate/service.py
+++ b/opengever/docugate/service.py
@@ -77,8 +77,16 @@ class CreateDocumentFromDocugateTemplate(FolderPost):
         self.title_ = self.request_data.get("title", None)
 
     def before_deserialization(self, obj):
-        obj.as_shadow_document()
         alsoProvides(obj, IDocumentFromDocugate)
+
+    def add_object_to_context(self):
+        super(CreateDocumentFromDocugateTemplate, self).add_object_to_context()
+
+        # The workflow needs to be set after the object has been added to the
+        # context. If we do it earlier, it will reset the state if we add the
+        # object to a context providing a placeful workflow. This is the case
+        # if we add it i.e. to a private dossier, inbox or workspace.
+        self.obj.as_shadow_document()
 
     def serialize_object(self):
         return {

--- a/opengever/docugate/tests/test_service.py
+++ b/opengever/docugate/tests/test_service.py
@@ -87,3 +87,22 @@ class TestCreateDocumentFromDocugateTemplate(IntegrationTestCase):
         doc = self.dossier[browser.json['@id'].split('/')[-1]]
         self.assertTrue(doc.is_shadow_document())
         self.assertEqual(doc.Title(), 'My Docugate document')
+
+    @browsing
+    def test_can_create_document_in_private_dossier(self, browser):
+        self.login(self.regular_user, browser)
+
+        headers = {
+            'Accept': 'application/json',
+            'Content-Type': 'application/json',
+        }
+        browser.open(
+            self.private_dossier,
+            method='POST',
+            data=json.dumps({'title': 'My Docugate document'}),
+            headers=headers,
+            view='@document_from_docugate',
+        )
+        self.assertEqual(browser.status_code, 201)
+        self.assertIn('url', browser.json)
+        self.assertTrue(browser.json['url'].startswith('oc:'))

--- a/opengever/officeconnector/helpers.py
+++ b/opengever/officeconnector/helpers.py
@@ -60,7 +60,7 @@ def parse_documents(request, context, action):
             or request['REQUEST_METHOD'] == 'POST'
             and ('BODY' not in request
                  or isinstance(json.loads(request['BODY']), list)
-                 or action == 'docugate')
+                 or action in ['docugate', 'oneoffixx'])
         ):
         # Feature enabled for the wrong content type
         if not IBaseDocument.providedBy(context):

--- a/opengever/oneoffixx/configure.zcml
+++ b/opengever/oneoffixx/configure.zcml
@@ -1,10 +1,29 @@
 <configure
     xmlns="http://namespaces.zope.org/zope"
     xmlns:i18n="http://namespaces.zope.org/i18n"
+    xmlns:plone="http://namespaces.plone.org/plone"
     i18n_domain="opengever.oneoffixx">
 
   <include package=".browser" />
 
   <i18n:registerTranslations directory="locales" />
+
+  <plone:service
+      method="POST"
+      for="opengever.dossier.behaviors.dossier.IDossierMarker"
+      accept="application/json"
+      factory=".service.CreateDocumentFromOneOffixxTemplate"
+      name="@document_from_oneoffixx"
+      permission="opengever.document.AddDocument"
+      />
+
+  <plone:service
+      method="POST"
+      for="opengever.task.task.ITask"
+      accept="application/json"
+      factory=".service.CreateDocumentFromOneOffixxTemplate"
+      name="@document_from_oneoffixx"
+      permission="opengever.document.AddDocument"
+      />
 
 </configure>

--- a/opengever/oneoffixx/configure.zcml
+++ b/opengever/oneoffixx/configure.zcml
@@ -26,4 +26,13 @@
       permission="opengever.document.AddDocument"
       />
 
+  <plone:service
+      method="GET"
+      for="*"
+      accept="application/json"
+      factory=".service.OneOffixxTemplatesGet"
+      name="@oneoffixx-templates"
+      permission="opengever.document.AddDocument"
+      />
+
 </configure>

--- a/opengever/oneoffixx/service.py
+++ b/opengever/oneoffixx/service.py
@@ -1,0 +1,67 @@
+from opengever.api.add import GeverFolderPost
+from opengever.officeconnector.helpers import create_oc_url
+from opengever.oneoffixx import is_oneoffixx_feature_enabled
+from opengever.oneoffixx.api_client import OneoffixxAPIClient
+from opengever.oneoffixx.templates import get_whitelisted_oneoffixx_templates
+from zExceptions import BadRequest
+from zExceptions import NotFound
+from zope.annotation.interfaces import IAnnotations
+
+
+class CreateDocumentFromOneOffixxTemplate(GeverFolderPost):
+    """API Endpoint to create a document from a OneOffixx template.
+
+    The document is created in the shadow state and the endpoint returns the
+    @id of the newly created document and the OfficeConnector URL.
+    """
+    def reply(self):
+        if not is_oneoffixx_feature_enabled():
+            raise NotFound
+        return super(CreateDocumentFromOneOffixxTemplate, self).reply()
+
+    def extract_data(self):
+        self.type_ = 'opengever.document.document'
+        self.id_ = None
+        self.data = self.request_data.get('document', {})
+        self.title_ = self.data.get('title', None)
+
+        template_id = self.request_data.get('template_id')
+
+        if not template_id:
+            raise BadRequest("Property 'template_id' is required.")
+
+        self.template = self.lookup_template(template_id)
+
+        if not self.template:
+            raise BadRequest('The requested template_id does not exist.')
+
+    def lookup_template(self, template_id):
+        api_client = OneoffixxAPIClient()
+        templates_by_id = {
+            template.template_id: template for template
+            in get_whitelisted_oneoffixx_templates(api_client)
+        }
+        return templates_by_id.get(template_id, None)
+
+    def before_deserialization(self, obj):
+        annotations = IAnnotations(obj)
+        annotations["template-id"] = self.template.template_id
+        annotations["languages"] = self.template.languages
+        annotations["filename"] = self.template.filename
+        annotations["content-type"] = self.template.content_type
+
+    def add_object_to_context(self):
+        super(CreateDocumentFromOneOffixxTemplate, self).add_object_to_context()
+
+        # The workflow needs to be set after the object has been added to the
+        # context. If we do it earlier, it will reset the state if we add the
+        # object to a context providing a placeful workflow. This is the case
+        # if we add it i.e. to a private dossier, inbox or workspace.
+        self.obj.as_shadow_document()
+
+    def serialize_object(self):
+        return {
+            '@id': self.obj.absolute_url(),
+            'url': create_oc_url(
+                self.request, self.obj, dict(action='oneoffixx'),),
+        }

--- a/opengever/oneoffixx/service.py
+++ b/opengever/oneoffixx/service.py
@@ -2,7 +2,10 @@ from opengever.api.add import GeverFolderPost
 from opengever.officeconnector.helpers import create_oc_url
 from opengever.oneoffixx import is_oneoffixx_feature_enabled
 from opengever.oneoffixx.api_client import OneoffixxAPIClient
+from opengever.oneoffixx.templates import get_oneoffixx_favorites
+from opengever.oneoffixx.templates import get_oneoffixx_template_groups
 from opengever.oneoffixx.templates import get_whitelisted_oneoffixx_templates
+from plone.restapi.services import Service
 from zExceptions import BadRequest
 from zExceptions import NotFound
 from zope.annotation.interfaces import IAnnotations
@@ -64,4 +67,27 @@ class CreateDocumentFromOneOffixxTemplate(GeverFolderPost):
             '@id': self.obj.absolute_url(),
             'url': create_oc_url(
                 self.request, self.obj, dict(action='oneoffixx'),),
+        }
+
+
+class OneOffixxTemplatesGet(Service):
+    """API Endpoint that returns the data for oneoffix templates.
+
+    GET /@oneoffix-templates HTTP/1.1
+    """
+
+    def reply(self):
+        if not is_oneoffixx_feature_enabled():
+            raise NotFound
+
+        api_client = OneoffixxAPIClient()
+
+        templates = get_whitelisted_oneoffixx_templates(api_client)
+        favorites = get_oneoffixx_favorites(api_client)
+        groups = get_oneoffixx_template_groups(api_client)
+
+        return {
+            "templates": [template.json() for template in templates],
+            "favorites": [template.json() for template in favorites],
+            "groups": [template.json() for template in groups],
         }

--- a/opengever/oneoffixx/templates.py
+++ b/opengever/oneoffixx/templates.py
@@ -12,9 +12,22 @@ def get_whitelisted_oneoffixx_templates(api_client):
     ]
 
 
+def get_oneoffixx_favorites(api_client):
+    return [
+        OneOffixxTemplate(template) for template in
+        api_client.get_oneoffixx_favorites()]
+
+
+def get_oneoffixx_template_groups(api_client):
+    return [
+        OneOffixxTemplateGroup(group) for group in
+        api_client.get_oneoffixx_template_groups()
+    ]
+
+
 class OneOffixxTemplate(object):
 
-    def __init__(self, template, groupname):
+    def __init__(self, template, groupname=''):
         self.title = template.get("localizedName")
         self.template_id = template.get("id")
         self.group = template.get('templateGroupId')
@@ -31,3 +44,26 @@ class OneOffixxTemplate(object):
         if type(other) == type(self):
             return self.template_id == other.template_id
         return False
+
+    def json(self):
+        return {
+            "title": self.title,
+            "template_id": self.template_id,
+            "content_type": self.content_type,
+            "filename": self.filename,
+        }
+
+
+class OneOffixxTemplateGroup(object):
+
+    def __init__(self, group):
+        self.title = group.get('localizedName')
+        self.group_id = group.get('id')
+        self.templates = [template.get('id') for template in group.get('templates')]
+
+    def json(self):
+        return {
+            "title": self.title,
+            "group_id": self.group_id,
+            "templates": self.templates,
+        }

--- a/opengever/oneoffixx/templates.py
+++ b/opengever/oneoffixx/templates.py
@@ -1,0 +1,33 @@
+from plone.i18n.normalizer.interfaces import IFileNameNormalizer
+from zope.component import getUtility
+from opengever.oneoffixx.utils import whitelisted_template_types
+
+
+def get_whitelisted_oneoffixx_templates(api_client):
+    return [
+        OneOffixxTemplate(template, template_group.get('localizedName', ''))
+        for template_group in api_client.get_oneoffixx_template_groups()
+        for template in template_group.get("templates")
+        if template.get('metaTemplateId') in whitelisted_template_types
+    ]
+
+
+class OneOffixxTemplate(object):
+
+    def __init__(self, template, groupname):
+        self.title = template.get("localizedName")
+        self.template_id = template.get("id")
+        self.group = template.get('templateGroupId')
+        self.groupname = groupname
+        template_type = template['metaTemplateId']
+        template_type_info = whitelisted_template_types[template_type]
+        self.content_type = template_type_info['content-type']
+        filename = template.get("localizedName")
+        normalizer = getUtility(IFileNameNormalizer, name='gever_filename_normalizer')
+        self.filename = normalizer.normalize(filename, extension=template_type_info['extension'])
+        self.languages = template.get("languages")
+
+    def __eq__(self, other):
+        if type(other) == type(self):
+            return self.template_id == other.template_id
+        return False

--- a/opengever/oneoffixx/tests/__init__.py
+++ b/opengever/oneoffixx/tests/__init__.py
@@ -1,0 +1,75 @@
+from opengever.oneoffixx.api_client import OneoffixxAPIClient
+from opengever.oneoffixx.interfaces import IOneoffixxSettings
+from opengever.testing import IntegrationTestCase
+from plone import api
+import json
+import requests
+import requests_mock
+
+
+class BaseOneOffixxTestCase(IntegrationTestCase):
+
+    features = ("officeconnector-checkout", "oneoffixx")
+
+    template_word = {
+        'id': '2574d08d-95ea-4639-beab-3103fe4c3bc7',
+        'metaTemplateId': '275af32e-bc40-45c2-85b7-afb1c0382653',
+        'languages': ['2055'],
+        'localizedName': '3 Example Word file',
+        'templateGroupId': 1,
+    }
+    template_excel = {
+        'id': '2574d08d-95ea-4639-beab-3103fe4c3bc8',
+        'metaTemplateId': 'e31ca353-2ab1-4408-921b-a70ae2f57ad1',
+        'languages': ['2055'],
+        'localizedName': '2 Example Excel file',
+        'templateGroupId': 2,
+    }
+    template_powerpoint = {
+        'id': '2574d08d-95ea-4639-beab-3103fe4c3bc9',
+        'metaTemplateId': 'a2c9b700-86cd-4481-a17f-533fe9c504a2',
+        'languages': ['2055'],
+        'localizedName': '1 Example Powerpoint presentation',
+        'templateGroupId': 3,
+    }
+
+    def tearDown(self):
+        # Tear down the singleton
+        OneoffixxAPIClient.__metaclass__._instances.pop(OneoffixxAPIClient, None)
+        super(BaseOneOffixxTestCase, self).tearDown()
+
+    def mock_oneoffixx_api_client(self, template_groups=[], favorites=[]):
+        api.portal.set_registry_record('protocol', u'mock', IOneoffixxSettings)
+        api.portal.set_registry_record('hostname', u'nohost', IOneoffixxSettings)
+        api.portal.set_registry_record('path_prefix', u'/foo', IOneoffixxSettings)
+        api.portal.set_registry_record('fake_sid', u'foobar', IOneoffixxSettings)
+
+        access_token = {'access_token': 'all_may_enter'}
+        template_library = {'datasources': [{'id': 1, 'isPrimary': True}]}
+        organization_units = [{'id': 'fake-org-id'}]
+
+        session = requests.Session()
+        adapter = requests_mock.Adapter()
+        adapter.register_uri('POST', 'mock://nohost/foo/ids/connect/token', text=json.dumps(access_token))
+        adapter.register_uri('GET', 'mock://nohost/foo/webapi/api/v1/TenantInfo', text=json.dumps(template_library))
+        adapter.register_uri('GET', 'mock://nohost/foo/webapi/api/v1/1/OrganizationUnits',
+                             text=json.dumps(organization_units))
+        adapter.register_uri(
+            'GET',
+            'mock://nohost/foo/webapi/api/v1/1/TemplateLibrary/TemplateGroups',
+            text=json.dumps(template_groups),
+        )
+        adapter.register_uri(
+            'GET',
+            'mock://nohost/foo/webapi/api/v1/1/TemplateLibrary/TemplateFavorites',
+            text=json.dumps(favorites),
+        )
+        session.mount('mock', adapter)
+
+        credentials = {
+            'client_id': 'foo',
+            'client_secret': 'topsecret',
+            'preshared_key': 'horribletruth',
+        }
+
+        return OneoffixxAPIClient(session, credentials)

--- a/opengever/oneoffixx/tests/test_service.py
+++ b/opengever/oneoffixx/tests/test_service.py
@@ -1,0 +1,148 @@
+from ftw.testbrowser import browsing
+from opengever.oneoffixx.tests import BaseOneOffixxTestCase
+from opengever.oneoffixx.utils import whitelisted_template_types
+from zExceptions import BadRequest
+from zope.annotation.interfaces import IAnnotations
+import json
+
+
+class TestCreateDocumentFromOneOffixxTemplate(BaseOneOffixxTestCase):
+
+    def setUp(self):
+        super(TestCreateDocumentFromOneOffixxTemplate, self).setUp()
+
+        template_groups = [
+            {
+                'id': 'c2ddc01a-befd-4e0d-b15f-f67025f532be',
+                'localizedName': 'Word templates',
+                'templates': [self.template_word],
+            },
+        ]
+        self.mock_oneoffixx_api_client(template_groups=template_groups)
+
+    @browsing
+    def test_raises_bad_request_if_no_template_id_is_provided(self, browser):
+        self.login(self.dossier_responsible, browser)
+
+        payload = {
+            'document': {'title': 'My Oneoffixx document'},
+        }
+
+        browser.exception_bubbling = True
+        with self.assertRaises(BadRequest) as cm:
+            browser.open(
+                self.dossier,
+                method='POST',
+                data=json.dumps(payload),
+                headers=self.api_headers,
+                view='@document_from_oneoffixx')
+
+        self.assertEqual("Property 'template_id' is required.",
+                         str(cm.exception))
+
+    @browsing
+    def test_raises_bad_request_if_template_id_does_not_exist(self, browser):
+        self.login(self.dossier_responsible, browser)
+
+        payload = {
+            'document': {'title': 'My Oneoffixx document'},
+            'template_id': 'not-existing-id'
+        }
+
+        browser.exception_bubbling = True
+        with self.assertRaises(BadRequest) as cm:
+            browser.open(
+                self.dossier,
+                method='POST',
+                data=json.dumps(payload),
+                headers=self.api_headers,
+                view='@document_from_oneoffixx')
+
+        self.assertEqual('The requested template_id does not exist.',
+                         str(cm.exception))
+
+    @browsing
+    def test_creates_shadow_document_and_returns_oc_url(self, browser):
+        self.login(self.dossier_responsible, browser)
+
+        payload = {
+            'document': {'title': 'My Oneoffixx document'},
+            'template_id': self.template_word.get('id')
+        }
+
+        browser.open(
+            self.dossier,
+            method='POST',
+            data=json.dumps(payload),
+            headers=self.api_headers,
+            view='@document_from_oneoffixx',
+        )
+        self.assertEqual(201, browser.status_code)
+        self.assertIn('url', browser.json)
+        self.assertTrue(browser.json['url'].startswith('oc:'))
+
+        doc = self.dossier[browser.json['@id'].split('/')[-1]]
+        self.assertTrue(doc.is_shadow_document())
+        self.assertEqual('My Oneoffixx document', doc.Title())
+
+        annotations = IAnnotations(doc)
+        self.assertEqual(self.template_word['id'], annotations['template-id'])
+        self.assertEqual(
+            self.template_word['languages'], annotations['languages'])
+        self.assertIn(
+            self.template_word['localizedName'], annotations['filename'])
+        self.assertEqual('3 Example Word file.docx', annotations['filename'])
+        self.assertEqual(
+            'application/vnd.openxmlformats-officedocument.wordprocessingml'
+            '.document',
+            annotations['content-type'],
+        )
+
+        whitelisted_content_types = [
+            template['content-type']
+            for template in whitelisted_template_types.values()
+        ]
+        self.assertIn(annotations['content-type'], whitelisted_content_types)
+
+    @browsing
+    def test_can_create_document_in_private_dossier(self, browser):
+        self.login(self.regular_user, browser)
+
+        payload = {
+            'document': {'title': 'My Oneoffixx document'},
+            'template_id': self.template_word.get('id')
+        }
+
+        browser.open(
+            self.private_dossier,
+            method='POST',
+            data=json.dumps(payload),
+            headers=self.api_headers,
+            view='@document_from_oneoffixx',
+        )
+        self.assertEqual(201, browser.status_code)
+        self.assertIn('url', browser.json)
+        self.assertTrue(browser.json['url'].startswith('oc:'))
+
+    @browsing
+    def test_stores_additional_metadata(self, browser):
+        self.login(self.dossier_responsible, browser)
+
+        payload = {
+            'document': {
+                'title': 'My Oneoffixx document',
+                'description': 'This is a description',
+            },
+            'template_id': self.template_word.get('id')
+        }
+
+        browser.open(
+            self.dossier,
+            method='POST',
+            data=json.dumps(payload),
+            headers=self.api_headers,
+            view='@document_from_oneoffixx',
+        )
+        self.assertEqual(201, browser.status_code)
+        doc = self.dossier[browser.json['@id'].split('/')[-1]]
+        self.assertEqual('This is a description', doc.description)

--- a/opengever/oneoffixx/tests/test_service.py
+++ b/opengever/oneoffixx/tests/test_service.py
@@ -146,3 +146,89 @@ class TestCreateDocumentFromOneOffixxTemplate(BaseOneOffixxTestCase):
         self.assertEqual(201, browser.status_code)
         doc = self.dossier[browser.json['@id'].split('/')[-1]]
         self.assertEqual('This is a description', doc.description)
+
+
+class TestGetOffixxTemplates(BaseOneOffixxTestCase):
+
+    def setUp(self):
+        super(TestGetOffixxTemplates, self).setUp()
+
+        template_groups = [
+            {
+                'id': 'c2ddc01a-befd-4e0d-b15f-f67025f532be',
+                'localizedName': 'Word templates',
+                'templates': [self.template_word],
+            },
+            {
+                'id': 'c2ddc01a-befd-4e0d-b15f-f67025f532bf',
+                'localizedName': 'Excel templates',
+                'templates': [self.template_excel],
+            },
+            {
+                'id': 'c2ddc01a-befd-4e0d-b15f-f67025f532c0',
+                'localizedName': 'Powerpoint template folder',
+                'templates': [self.template_powerpoint],
+            },
+        ]
+        favorites = [self.template_word, ]
+        self.mock_oneoffixx_api_client(template_groups=template_groups, favorites=favorites)
+
+    @browsing
+    def test_get_oneoffixx_templates(self, browser):
+        self.login(self.dossier_responsible, browser)
+
+        browser.open(
+            self.dossier,
+            method='GET',
+            headers=self.api_headers,
+            view='@oneoffixx-templates',
+        )
+
+        self.assertEqual(200, browser.status_code)
+        self.assertDictEqual({
+            u'favorites': [
+                {
+                    u'content_type': u'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+                    u'filename': u'3 Example Word file.docx',
+                    u'template_id': u'2574d08d-95ea-4639-beab-3103fe4c3bc7',
+                    u'title': u'3 Example Word file'
+                }
+            ],
+            u'groups': [
+                {
+                    u'group_id': u'c2ddc01a-befd-4e0d-b15f-f67025f532be',
+                    u'templates': [u'2574d08d-95ea-4639-beab-3103fe4c3bc7'],
+                    u'title': u'Word templates'
+                },
+                {
+                    u'group_id': u'c2ddc01a-befd-4e0d-b15f-f67025f532bf',
+                    u'templates': [u'2574d08d-95ea-4639-beab-3103fe4c3bc8'],
+                    u'title': u'Excel templates'
+                },
+                {
+                    u'group_id': u'c2ddc01a-befd-4e0d-b15f-f67025f532c0',
+                    u'templates': [u'2574d08d-95ea-4639-beab-3103fe4c3bc9'],
+                    u'title': u'Powerpoint template folder'
+                }
+            ],
+            u'templates': [
+                {
+                    u'content_type': u'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+                    u'filename': u'3 Example Word file.docx',
+                    u'template_id': u'2574d08d-95ea-4639-beab-3103fe4c3bc7',
+                    u'title': u'3 Example Word file'
+                },
+                {
+                    u'content_type': u'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+                    u'filename': u'2 Example Excel file.xlsx',
+                    u'template_id': u'2574d08d-95ea-4639-beab-3103fe4c3bc8',
+                    u'title': u'2 Example Excel file'
+                },
+                {
+                    u'content_type': u'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+                    u'filename': u'1 Example Powerpoint presentation.pptx',
+                    u'template_id': u'2574d08d-95ea-4639-beab-3103fe4c3bc9',
+                    u'title': u'1 Example Powerpoint presentation'
+                }
+            ]
+        }, browser.json)


### PR DESCRIPTION
This PR implements the following endpoints:
- POST @document_from_oneoffixx endpoint to create a document form a oneoffixx template
- GET @oneoffixx-templates endpoint to get all  oneoffixx groups, templates and favorites

Jira: https://4teamwork.atlassian.net/browse/CA-1388

ℹ️ because I don't know the exactly oneoffixx-api behavior and I can't test it properly due to a missing test-env, I had to make assumptions for the rest-api by reading the existing tests and the current implementation for the old UI. 

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


## Checklist (if applicable)

_Only applicable should be left and checked._

- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Upgrade steps (changes in profile):
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
- DB-Schema migration
  - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
  - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value
