### PR TITLE
Fix rejecting submitted proposal containing mail with extracted trashed attachment.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2021.5.0 (unreleased)
 ---------------------
 
+- Fix rejecting submitted proposal containing mail with extracted trashed attachment. [njohner]
 - Also set title_en and title_fr for meetings in policy templates. [njohner]
 
 

--- a/opengever/base/utils.py
+++ b/opengever/base/utils.py
@@ -259,3 +259,36 @@ def check_group_plugin_configuration(portal):
         raise IncorrectConfigurationError(
             "Configuration error: source_groups plugin is not active "
             "for the groups plugin.")
+
+
+def unrestrictedUuidToObject(uuid):
+    """Given a UUID, attempt to return a content object. Will return
+    None if the UUID can't be found.
+    This is the unrestricted version of plone.app.uuid.utils.uuidToObject
+    """
+
+    brain = unrestrictedUuidToCatalogBrain(uuid)
+    if brain is None:
+        return None
+
+    return brain.getObject()
+
+
+def unrestrictedUuidToCatalogBrain(uuid):
+    """Given a UUID, attempt to return a catalog brain.
+    This is the unrestricted version of plone.app.uuid.utils.uuidToCatalogBrain
+    """
+
+    site = getSite()
+    if site is None:
+        return None
+
+    catalog = getToolByName(site, 'portal_catalog', None)
+    if catalog is None:
+        return None
+
+    result = catalog.unrestrictedSearchResults(UID=uuid)
+    if len(result) != 1:
+        return None
+
+    return result[0]

--- a/opengever/mail/subscribers.py
+++ b/opengever/mail/subscribers.py
@@ -3,7 +3,7 @@ from opengever.document.subscribers import resolve_document_author
 from opengever.mail.exceptions import SourceMailNotFound
 from opengever.mail.interfaces import IExtractedFromMail
 from opengever.mail.mail import IOGMailMarker
-from plone.app.uuid.utils import uuidToObject
+from opengever.base.utils import unrestrictedUuidToObject
 from plone.uuid.interfaces import IUUID
 from zope.interface import noLongerProvides
 
@@ -47,5 +47,5 @@ def mail_deleted(doc, event):
     for info in doc.get_attachments():
         if not info.get('extracted'):
             continue
-        extracted_doc = uuidToObject(info.get('extracted_document_uid'))
+        extracted_doc = unrestrictedUuidToObject(info.get('extracted_document_uid'))
         noLongerProvides(extracted_doc, IExtractedFromMail)


### PR DESCRIPTION
- When refusing a submitted proposal, it gets deleted (https://github.com/4teamwork/opengever.core/blob/master/opengever/meeting/proposal.py#L411-L412)
- Because an E-mail is deleted, we end up in the `mail_deleted` handler which tries to remove the `IExtractedFromMail` interface from the extracted document.
- This fails because the extracted document is trashed and hence `uuidToObject` returns None because the document is trashed

We simply fix this by using an unrestricted version of `uuidToObject`. 

I did not add tests, because I think the whole scenario is very convoluted and should actually not happen. I actually think it's wrong that attachments from E-mails in a submitted proposal get extracted into the meeting dossier. I've created a follow-up story for that (https://4teamwork.atlassian.net/browse/CA-1822).

For https://4teamwork.atlassian.net/browse/CA-1739

## Checklist (Must have)
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
