### PR TITLE
Docs: Add pointer to new documentation.

### DIFF
--- a/docs/public/release-notes/index.rst
+++ b/docs/public/release-notes/index.rst
@@ -1,8 +1,10 @@
 Release-Notes
 =============
 
-In diesem Bereich finden Sie die Release-Notes zum aktuellen und den vergangenen
-Releases von OneGov GEVER.
+In diesem Bereich finden Sie ältere Release-Notes zu OneGov GEVER Releases bis 2020.2.
+
+    Für Informationen zu aktuellen Releases konsultieren Sie bitte die neue Benutzerdokumentation unter `https://docs.4teamwork.ch/OGG <https://docs.4teamwork.ch/OGG/>`_ .
+
 
 .. toctree::
    :maxdepth: 1


### PR DESCRIPTION
Adds a pointer to new documentation to the release notes section.

_(French docs don't contain the release notes section)_

See [Slack conversation](https://4teamwork.slack.com/archives/C060FEYKA/p1614003424000900).

(No changelog or Jira issue)