### PR TITLE
No longer show warning about failed notification deliveries if recipient user doesn't have an email address

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -10,6 +10,7 @@ Changelog
 2021.4.0 (2021-02-18)
 ---------------------
 
+- No longer show warning about failed notification deliveries if recipient user doesn't have an email address. [lgraf]
 - Adapt policy templates for ianus portal. [njohner]
 - Fix inbox document overview for managers. [lgraf]
 - Always set APPS_ENDPOINT_URL and handle sablon, msg_convert and pdflatex as services in policy templates. [njohner]

--- a/opengever/activity/error_handling.py
+++ b/opengever/activity/error_handling.py
@@ -1,3 +1,4 @@
+from opengever.base.sentry import maybe_report_exception
 from plone import api
 from ZODB.POSException import ConflictError
 from zope.globalrequest import getRequest
@@ -27,6 +28,7 @@ class NotificationErrorHandler(object):
 
             tb = ''.join(traceback.format_exception(_type, exc, _traceback))
             logger.error('Exception while adding an activity:\n{}'.format(tb))
+            maybe_report_exception(api.portal.get(), getRequest(), _type, exc, _traceback)
             return True
 
     def show_not_notified_message(self):

--- a/opengever/activity/tests/test_plone_center.py
+++ b/opengever/activity/tests/test_plone_center.py
@@ -122,7 +122,7 @@ class TestNotifactionCenterErrorHandling(FunctionalTestCase):
         self.assertEquals(['Item created'], info_messages())
 
     @browsing
-    def test_shows_message_if_dispatchers_raise_an_exception(self, member):
+    def test_missing_email_address_for_notification_recipient_doesnt_produce_warning(self, member):
         create(Builder('ogds_user')
                .having(userid='hugo.boss', email=None)
                .in_group(self.org_unit.users_group))
@@ -137,8 +137,5 @@ class TestNotifactionCenterErrorHandling(FunctionalTestCase):
 
         browser.css('#form-buttons-save').first.click()
 
-        self.assertEquals(
-            ['A problem has occurred when trying to dispatch a notification. '
-             'The notification therefore was not dispatched (or only partially).'],
-            warning_messages())
+        self.assertEquals([], warning_messages())
         self.assertEquals(['Item created'], info_messages())


### PR DESCRIPTION
A user might have some notifications enabled for the "E-Mail" channel, but not have an email address tied to their account / OGDS user.

Before this change, this resulted in the actor that triggered the notification getting an unhelpful warning message saying that one or more notifications could not be dispatched (because an attempt was made to have the Mailhost send an email with a recipient of `None`).

This PR changes this behavior so that this case is silently ignored (except for a warning that gets logged).

In addition, exceptions that happen during notification dispatching will now be logged to Sentry.

Follow-Up Story: [CA-1829](https://4teamwork.atlassian.net/browse/CA-1829) _(Benachrichtigungseinstellungen: Channels ausgrauen falls keine E-Mail Adresse hinterlegt)_

Jira: https://4teamwork.atlassian.net/browse/CA-1661

## Checklist (Must have)

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
