### PR TITLE
Bump plone.formwidget.namedfile to version 2.0.6.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2021.5.0 (unreleased)
 ---------------------
 
+- Bump plone.formwidget.namedfile to version 2.0.6 to fix bug with discared file upon validation error. [njohner]
 - Fix rejecting submitted proposal containing mail with extracted trashed attachment. [njohner]
 - Also set title_en and title_fr for meetings in policy templates. [njohner]
 

--- a/opengever/base/locales/plone.pot
+++ b/opengever/base/locales/plone.pot
@@ -431,3 +431,6 @@ msgstr ""
 
 msgid "label_name"
 msgstr ""
+
+msgid "file_already_uploaded"
+msgstr ""

--- a/opengever/document/widgets/no_download_input.pt
+++ b/opengever/document/widgets/no_download_input.pt
@@ -1,5 +1,5 @@
 <span
-    i18n:domain="opengever.document"
+    i18n:domain="plone"
     tal:attributes="id view/id;
                     class view/klass;
                     style view/style;
@@ -24,8 +24,18 @@
     tal:define="download_url string:${context/absolute_url}/file_download_confirmation;
                 exists python: view.value is not None;
                 action view/action;
-                allow_nochange view/allow_nochange;">
-    <span tal:condition="python: exists and action=='nochange'">
+                allow_nochange view/allow_nochange;
+                doc_type view/file_content_type;
+                icon view/file_icon;
+                filename view/filename;">
+    <tal:if tal:define="up_id view/file_upload_id" tal:condition="up_id">
+      <span>
+        <tal:i18n i18n:translate="file_already_uploaded">File already uploaded:</tal:i18n>
+        ${view/value/filename}
+      </span>
+      <input type="hidden" name="${view/name}.file_upload_id" value="${up_id}"/>
+    </tal:if>
+    <span tal:condition="python:exists and download_url and action=='nochange'">
         <span tal:attributes="class context/css_class"></span>
         <a class="link-overlay modal" tal:content="view/filename" tal:attributes="href download_url">Filename</a>
         <span class="discreet"> &mdash;
@@ -40,7 +50,7 @@
             tal:attributes="name string:${view/name}.action;
                             id string:${view/id}-nochange;
                             onclick string:document.getElementById('${view/id}-input').disabled=true;
-                            checked python:(action == 'nochange') and 'checked' or None;"
+                            checked python:'checked' if action == 'nochange' else None"
             />
         <label
             tal:attributes="for string:${view/id}-nochange" i18n:translate="file_keep">Keep existing file</label>
@@ -53,7 +63,7 @@
                 tal:attributes="name string:${view/name}.action;
                                 id string:${view/id}-remove;
                                 onclick string:document.getElementById('${view/id}-input').disabled=true;
-                                checked python:action == 'remove' and 'checked' or None;"
+                                checked python:'checked' if action == 'remove' else None"
                 />
             <label
                 tal:attributes="for string:${view/id}-remove" i18n:translate="file_remove">Remove existing file</label>
@@ -66,7 +76,8 @@
             tal:attributes="name string:${view/name}.action;
                             id string:${view/id}-replace;
                             onclick string:document.getElementById('${view/id}-input').disabled=false;
-                            checked python:action == 'replace' and 'checked' or None;" />
+                            checked python:'checked' if action == 'replace' else None"
+            />
         <label
             tal:attributes="for string:${view/id}-replace" i18n:translate="file_replace">Replace with new file</label>
     </div>

--- a/opengever/document/widgets/widgets.py
+++ b/opengever/document/widgets/widgets.py
@@ -1,0 +1,48 @@
+from datetime import datetime
+from persistent.dict import PersistentDict
+from plone.formwidget.namedfile.interfaces import IFileUploadTemporaryStorage
+from plone.formwidget.namedfile.widget import NamedFileWidget
+from plone.namedfile.interfaces import INamed
+from zope.component.hooks import getSite
+import uuid
+
+
+class GeverNamedFileWidget(NamedFileWidget):
+
+    @property
+    def file_upload_id(self):
+        """Temporary store the uploaded file contents with a file_upload_id key.
+        In case of form validation errors the already uploaded image can then
+        be reused.
+        """
+        if self._file_upload_id:
+            # cache this property for multiple calls within one request.
+            # This avoids storing a file upload multiple times.
+            return self._file_upload_id
+
+        upload_id = None
+        if self.is_uploaded:
+            data = None
+            if INamed.providedBy(self.value):
+                # data = self.value.data
+                # Here we diverge, otherwise we would create a new
+                # copy of the file in the storage for each time we
+                # access the edit form
+                return None
+                # previously uploaded and failed
+
+            else:
+                self.value.seek(0)
+                data = self.value.read()
+
+            upload_id = uuid.uuid4().hex
+            up = IFileUploadTemporaryStorage(getSite())
+            up.cleanup()
+            up.upload_map[upload_id] = PersistentDict(
+                filename=self.value.filename,
+                data=data,
+                dt=datetime.now(),
+            )
+
+        self._file_upload_id = upload_id
+        return upload_id

--- a/opengever/inbox/tests/test_workflow.py
+++ b/opengever/inbox/tests/test_workflow.py
@@ -84,7 +84,7 @@ class TestInboxWorkflow(IntegrationTestCase):
     def test_editors_are_able_to_edit_a_mail(self, browser):
         self.login(self.secretariat_user, browser=browser)
 
-        mail = create(Builder('mail').within(self.inbox))
+        mail = create(Builder('mail').within(self.inbox).with_dummy_message())
 
         browser.open(mail, view='edit')
         browser.fill({'Title': 'Mail Update'})

--- a/versions.cfg
+++ b/versions.cfg
@@ -133,6 +133,7 @@ perfmetrics = 2.0
 plone.app.jquery = 1.11.2
 plone.app.transmogrifier = 1.4.1
 plone.app.versioningbehavior = 1.3.1
+plone.formwidget.namedfile = 2.0.6
 plone.principalsource = 1.0
 plone.protect = 3.1.2
 plone.recipe.command = 1.1


### PR DESCRIPTION
This is to get a fix for a bug where the selected file gets discared upon validation error of the form. This has only become an issue with the introduction of the custom properties, which can lead to validation errors in the document add form.

Note that this is the newest version of the widget we can bump to without needing to bump other dependencies.

Also note that I had to fix one test. The widget for the message field of mails always gets displayed in the NO_DOWNLOAD_DISPLAY_MODE, which leads to an error when there is no message. As a Mail without a message is anyway not valid, this is a problem only in tests, for mails constructed with the builders. I checked that this is not a problem for documents that don't have a file for example.

For https://4teamwork.atlassian.net/browse/CA-1507

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)