### PR TITLE
Cleanup conditionals protecting for changed date not set yet.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2021.5.0 (unreleased)
 ---------------------
 
+- Cleanup conditionals protecting for changed date not set yet. [njohner]
 - Fix rejecting submitted proposal containing mail with extracted trashed attachment. [njohner]
 - Also set title_en and title_fr for meetings in policy templates. [njohner]
 

--- a/opengever/base/behaviors/changed.py
+++ b/opengever/base/behaviors/changed.py
@@ -6,8 +6,6 @@ from plone.autoform import directives as form
 from plone.autoform.interfaces import IFormFieldProvider
 from plone.supermodel import model
 from zope import schema
-from zope.annotation import IAnnotations
-from zope.component.hooks import getSite
 from zope.interface import Interface, alsoProvides
 
 
@@ -38,10 +36,6 @@ class Changed(object):
         self.context = context
 
     def _get_changed(self):
-        # XXX Can be deleted once the changed metadata has been filled on all deployments
-        # https://github.com/4teamwork/opengever.core/issues/4988
-        if self.context.changed is None:
-            return as_utc(self.context.modified().asdatetime())
         if isinstance(self.context.changed, DateTime):
             return as_utc(self.context.changed.asdatetime())
         return self.context.changed
@@ -60,17 +54,3 @@ class Changed(object):
         self.context.changed = as_utc(value)
 
     changed = property(_get_changed, _set_changed)
-
-
-# XXX Can be deleted once the changed metadata has been filled on all deployments
-# https://github.com/4teamwork/opengever.core/issues/4988
-METADATA_CHANGED_FILLED_KEY = 'opengever.base.behaviors.changed.filled'
-
-
-def has_metadata_changed_been_filled():
-    site = getSite()
-    annotations = IAnnotations(site)
-    if METADATA_CHANGED_FILLED_KEY not in annotations:
-        # This is a newly setup deployment or one where the first upgrade has not been run.
-        return True
-    return bool(annotations.get(METADATA_CHANGED_FILLED_KEY))

--- a/opengever/dossier/base.py
+++ b/opengever/dossier/base.py
@@ -69,11 +69,6 @@ def as_date(datetime_obj):
     if isinstance(datetime_obj, datetime):
         return datetime_obj.date()
 
-    # XXX Can be deleted once the changed metadata has been filled on all deployments
-    # https://github.com/4teamwork/opengever.core/issues/4988
-    elif isinstance(datetime_obj, DateTime):
-        return as_utc(datetime_obj.asdatetime()).date()
-
     # It is already a date-object
     return datetime_obj
 

--- a/opengever/dossier/tests/test_dossier_helpers.py
+++ b/opengever/dossier/tests/test_dossier_helpers.py
@@ -1,6 +1,5 @@
 from datetime import date
 from datetime import datetime
-from DateTime import DateTime
 from opengever.dossier.base import as_date
 from opengever.dossier.base import max_date
 from unittest import TestCase
@@ -25,14 +24,6 @@ class TestUnitDossierMaxDate(TestCase):
             date(2019, 8, 13), max_date(date(2019, 8, 13), date(2018, 1, 3))
         )
 
-    def test_handles_mixed_types(self):
-        self.assertEquals(
-            date(2017, 9, 19),
-            max_date(datetime(2017, 9, 19, 1, 2, 3),
-                     date(1997, 1, 3),
-                     DateTime(2016, 1, 1, 7, 40))
-        )
-
 
 class TestUnitDossierAsDate(TestCase):
 
@@ -44,6 +35,3 @@ class TestUnitDossierAsDate(TestCase):
 
     def test_converts_datetime_to_date(self):
         self.assertEquals(date(1939, 9, 1), as_date(datetime(1939, 9, 1, 5, 45)))
-
-    def test_converts_zope_datetime_to_date(self):
-        self.assertEquals(date(1989, 9, 9), as_date(DateTime(1989, 9, 9, 7, 3)))

--- a/opengever/tabbedview/browser/tabs.py
+++ b/opengever/tabbedview/browser/tabs.py
@@ -1,8 +1,6 @@
 from datetime import date
 from datetime import timedelta
 from ftw.table import helper
-from opengever.base.behaviors.changed import has_metadata_changed_been_filled
-from opengever.base.interfaces import ISearchSettings
 from opengever.bumblebee import get_preferred_listing_view
 from opengever.bumblebee import is_bumblebee_feature_enabled
 from opengever.bumblebee import set_preferred_listing_view
@@ -23,7 +21,6 @@ from opengever.tabbedview.helper import linked
 from opengever.tabbedview.helper import linked_containing_subdossier
 from opengever.tabbedview.helper import linked_document
 from opengever.tabbedview.helper import linked_subjects
-from opengever.tabbedview.helper import readable_changed_date
 from opengever.tabbedview.helper import readable_date
 from opengever.tabbedview.helper import readable_ogds_author
 from opengever.tabbedview.helper import readable_ogds_user
@@ -124,9 +121,7 @@ class Documents(BaseCatalogListingTab):
 
     types = ['opengever.document.document', 'ftw.mail.mail']
 
-    # XXX Can be set back to 'columns' once the changed metadata has been filled on all deployments
-    # https://github.com/4teamwork/opengever.core/issues/4988
-    _columns = (
+    columns = (
 
         {'column': '',
          'column_title': '',
@@ -153,12 +148,10 @@ class Documents(BaseCatalogListingTab):
          'column_title': _('label_document_date', default="Document Date"),
          'transform': readable_date},
 
-        # XXX transform should be set to readable_date once the changed metadata has been filled on all deployments
-        # https://github.com/4teamwork/opengever.core/issues/4988
         {'column': 'changed',
          'column_title': _('label_modified_date', default="Modification Date"),
          'hidden': True,
-         'transform': readable_changed_date},
+         'transform': readable_date},
 
         {'column': 'created',
          'column_title': _('label_created_date', default="Creation Date"),
@@ -207,16 +200,6 @@ class Documents(BaseCatalogListingTab):
 
     bumblebee_template = ViewPageTemplateFile(
         'generic_with_bumblebee_viewchooser.pt')
-
-    # XXX Can be deleted once the changed metadata has been filled on all deployments
-    # https://github.com/4teamwork/opengever.core/issues/4988
-    @property
-    def columns(self):
-        if (api.portal.get_registry_record('use_solr', interface=ISearchSettings)
-                and not has_metadata_changed_been_filled()):
-            return tuple([column for column in self._columns
-                          if not column.get("column") == "changed"])
-        return self._columns
 
     def __call__(self, *args, **kwargs):
         if is_bumblebee_feature_enabled():

--- a/opengever/tabbedview/catalog_source.py
+++ b/opengever/tabbedview/catalog_source.py
@@ -178,11 +178,8 @@ class GeverCatalogTableSource(FilteredTableSourceMixin, CatalogTableSource):
             else:
                 filters.append(u'{}:{}'.format(key, escape(value)))
 
-        # Todo: modified be removed once the changed metadata is filled on
-        # all deployments.
-        # https://github.com/4teamwork/opengever.core/issues/4988
         fl = ['UID', 'getIcon', 'portal_type', 'path', 'id',
-              'bumblebee_checksum', 'modified']
+              'bumblebee_checksum']
         fl = fl + [c['column'] for c in self.config.columns if c['column']]
         params = {
             'fl': fl,

--- a/opengever/tabbedview/helper.py
+++ b/opengever/tabbedview/helper.py
@@ -254,15 +254,6 @@ def linked_version_preview(item, value):
     """ % data
 
 
-# XXX Can be deleted once the changed metadata has been filled on all deployments
-# https://github.com/4teamwork/opengever.core/issues/4988
-# Defaults to modified date if changed is not set
-def readable_changed_date(item, date):
-    if not date:
-        date = item.modified
-    return readable_date(item, date)
-
-
 # Also handles datetime strings from Solr
 def readable_date(item, date):
     if isinstance(date, str):

--- a/opengever/tabbedview/tests/test_catalog_source.py
+++ b/opengever/tabbedview/tests/test_catalog_source.py
@@ -114,7 +114,7 @@ class TestSolrSearch(IntegrationTestCase):
         self.assertEqual(
             self.solr.search.call_args[1]['fl'],
             ['UID', 'getIcon', 'portal_type', 'path', 'id',
-             'bumblebee_checksum', 'modified', 'reference', 'Title']
+             'bumblebee_checksum', 'reference', 'Title']
             )
 
     def test_solr_start_is_calculated_from_batching_current_page_and_pagesize(self):


### PR DESCRIPTION
The changed date has now been indexed on all deployments and the conditionals protecting against states where it had been introduced but not set yet are no longer needed.

Note that I had to delete two tests, that were actually testing some of the conditionals that were only introduced temporarily as a safeguard for missing changed dates.

For https://4teamwork.atlassian.net/browse/CA-1667

## Checklist (Must have)
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)