### PR TITLE
Add create_task_from_proposal action

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 ---------------------
 
 - Fix rejecting submitted proposal containing mail with extracted trashed attachment. [njohner]
+- Add create_task_from_proposal action. [tinagerber]
 - Also set title_en and title_fr for meetings in policy templates. [njohner]
 
 

--- a/opengever/api/tests/test_actions.py
+++ b/opengever/api/tests/test_actions.py
@@ -1269,6 +1269,27 @@ class TestObjectButtonsGetForProposalTemplates(ObjectButtonsTestBase):
         )
 
 
+class TestObjectButtonsGetForProposals(ObjectButtonsTestBase):
+
+    features = ('meeting',)
+
+    @browsing
+    def test_available_object_button_actions_for_proposals(self, browser):
+        self.login(self.meeting_user, browser)
+        expected_object_buttons = [
+            {u'icon': u'', u'id': u'create_task_from_proposal',
+             u'title': u'Create task from proposal'},
+            {u'icon': u'', u'id': u'submit_additional_documents',
+             u'title': u'Submit additional documents'},
+            {u'icon': u'', u'id': u'properties', u'title': u'Properties'}
+        ]
+
+        self.assertListEqual(
+            expected_object_buttons,
+            self.get_object_buttons(browser, self.proposal),
+        )
+
+
 class TestFolderButtonsGetForTemplatesFolder(FolderActionsTestBase):
 
     @browsing

--- a/opengever/base/menu.py
+++ b/opengever/base/menu.py
@@ -114,11 +114,8 @@ class OGCombinedActionsWorkflowMenu(CombinedActionsWorkflowMenu):
     def getActionsMenuItems(self, context, request):
         results = super(OGCombinedActionsWorkflowMenu, self).getActionsMenuItems(
             context, request)
-        return filter(
-            lambda item: (item.get('extra', {}).get('id', None)
-                != 'create_forwarding'),
-            results
-        )
+        return filter(lambda item: (item.get('extra', {}).get('id', None) not in
+                                    ['create_forwarding', 'create_task_from_proposal']), results)
 
     def getWorkflowMenuItems(self, context, request):
         """ftw.contentmenu >= 2.2.2 does no longer protect the workflows

--- a/opengever/core/profiles/default/types/opengever.meeting.proposal.xml
+++ b/opengever/core/profiles/default/types/opengever.meeting.proposal.xml
@@ -64,6 +64,16 @@
     <permission value="Modify portal content" />
   </action>
 
+  <action
+      action_id="create_task_from_proposal"
+      visible="True"
+      title="Create task from proposal"
+      url_expr="string:++add++opengever.task.task:method"
+      condition_expr="object/@@tabbedview_view-overview/is_create_task_from_proposal_allowed"
+      category="object_buttons">
+    <permission value="View" />
+  </action>
+
   <!-- Tab Actions -->
   <action
       title="overview"

--- a/opengever/core/upgrades/20210218094100_add_create_task_from_proposal_action/types/opengever.meeting.proposal.xml
+++ b/opengever/core/upgrades/20210218094100_add_create_task_from_proposal_action/types/opengever.meeting.proposal.xml
@@ -1,0 +1,13 @@
+<object xmlns:i18n="http://xml.zope.org/namespaces/i18n" name="opengever.meeting.proposal" meta_type="Dexterity FTI" i18n:domain="opengever.core">
+
+  <action
+      action_id="create_task_from_proposal"
+      visible="True"
+      title="Create task from proposal"
+      url_expr="string:++add++opengever.task.task:method"
+      condition_expr="object/@@tabbedview_view-overview/is_create_task_from_proposal_allowed"
+      category="object_buttons">
+    <permission value="View" />
+  </action>
+
+</object>

--- a/opengever/core/upgrades/20210218094100_add_create_task_from_proposal_action/upgrade.py
+++ b/opengever/core/upgrades/20210218094100_add_create_task_from_proposal_action/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddCreateTaskFromProposalAction(UpgradeStep):
+    """Add create_task_from_proposal action.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()


### PR DESCRIPTION
With this PR we provide an action create_task_from_proposal for proposals. This helps the new frontend to create tasks from the overview of a proposal.

The action is not shown in the classic UI as the "Create task" function already exists there.

Jira: https://4teamwork.atlassian.net/browse/NE-684

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


## Checklist (if applicable)

_Only applicable should be left and checked._

- API change:
  - [ ] Documentation is updated
  - [ ] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))