### PR TITLE
Add second language to the testservers by default.

### DIFF
--- a/opengever/core/testserver.py
+++ b/opengever/core/testserver.py
@@ -105,7 +105,7 @@ class TestserverLayer(OpengeverFixture):
     def setupLanguageTool(self, portal):
         lang_tool = api.portal.get_tool('portal_languages')
         lang_tool.setDefaultLanguage('de')
-        lang_tool.supported_langs = ['de-ch']
+        lang_tool.supported_langs = ['de-ch', 'fr-ch']
 
     def get_fixture_class(self):
         """The fixture of the testserver should be replaceable from the outside.


### PR DESCRIPTION
For testing language switcher in UI @all4manu would like to have a second language which is always enabled. This seems to work with all existing tests in the backend.

Jira: https://4teamwork.atlassian.net/browse/HG-995

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [ ] ~~Changelog entry~~
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)