### PR TITLE
Add creator to the document serializer

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2021.5.0 (unreleased)
 ---------------------
 
+- Add creator to the document serializer. [elioschmutz]
 - Fix rejecting submitted proposal containing mail with extracted trashed attachment. [njohner]
 - Add create_task_from_proposal action. [tinagerber]
 - Also set title_en and title_fr for meetings in policy templates. [njohner]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -24,6 +24,7 @@ Breaking Changes
 Other Changes
 ^^^^^^^^^^^^^
 
+- Add ``creator`` to the document serializer.
 - Add ``is_inbox_user`` attribute to the ``@config`` endpoint.
 - A new endpoint ``@save-document-as-pdf`` is added (see :ref:`save-document-as-pdf`).
 

--- a/opengever/api/document.py
+++ b/opengever/api/document.py
@@ -1,4 +1,5 @@
 from ftw import bumblebee
+from opengever.api.actors import serialize_actor_id_to_json_summary
 from opengever.api.serializer import GeverSerializeToJson
 from opengever.base.helpers import display_name
 from opengever.base.interfaces import IReferenceNumber
@@ -51,6 +52,7 @@ class SerializeDocumentToJson(GeverSerializeToJson):
             'current_version_id': obj.get_current_version_id(
                 missing_as_zero=True),
             'teamraum_connect_links': ILinkedDocuments(obj).serialize(),
+            'creator': serialize_actor_id_to_json_summary(obj.Creator()),
         }
 
         result.update(additional_metadata)

--- a/opengever/api/tests/test_document.py
+++ b/opengever/api/tests/test_document.py
@@ -73,6 +73,10 @@ class TestDocumentSerializer(IntegrationTestCase):
         self.assertFalse(browser.json['trashed'])
         self.assertFalse(browser.json['is_shadow_document'])
         self.assertFalse(0, browser.json['current_version_id'])
+        self.assertDictEqual({
+            u'identifier': u'robert.ziegler',
+            u'@id': u'http://nohost/plone/@actors/robert.ziegler',
+        }, browser.json['creator'])
 
     @browsing
     def test_contains_collaborative_checkout_info(self, browser):


### PR DESCRIPTION
This PR adds the `creator` to the document serializer.

We need this for the frontend to be able to properly display the creator of the initial version.

Jira: https://4teamwork.atlassian.net/browse/CA-1812

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


## Checklist (if applicable)

_Only applicable should be left and checked._

- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- New functionality:
  - [x] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Upgrade steps (changes in profile):
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
- DB-Schema migration
  - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
  - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value
