### PR TITLE
Fix changelog after backporting

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,11 +4,15 @@ Changelog
 2021.5.0 (unreleased)
 ---------------------
 
-- Add creator to the document serializer. [elioschmutz]
 - Fix rejecting submitted proposal containing mail with extracted trashed attachment. [njohner]
 - Add create_task_from_proposal action. [tinagerber]
 - Also set title_en and title_fr for meetings in policy templates. [njohner]
 
+
+2021.4.1 (2021-02-25)
+---------------------
+
+- Add creator to the document serializer. [elioschmutz]
 
 2021.4.0 (2021-02-18)
 ---------------------

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -11,6 +11,15 @@ API Changelog
 - Nothing changed yet.
 
 
+2021.4.1 (2021-02-25)
+---------------------
+
+Other Changes
+^^^^^^^^^^^^^
+
+- Add ``creator`` to the document serializer.
+
+
 2021.4.0 (2021-02-18)
 ---------------------
 
@@ -24,7 +33,6 @@ Breaking Changes
 Other Changes
 ^^^^^^^^^^^^^
 
-- Add ``creator`` to the document serializer.
 - Add ``is_inbox_user`` attribute to the ``@config`` endpoint.
 - A new endpoint ``@save-document-as-pdf`` is added (see :ref:`save-document-as-pdf`).
 


### PR DESCRIPTION
This PR fixes the CL after backporting commits to release 2020.4.1