### PR TITLE
The @sharing endpoint returns a batched result set if using the search param.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2021.5.0 (unreleased)
 ---------------------
 
+- The @sharing endpoint now returns a batched result set if using the search param.  [elioschmutz]
 - Cleanup conditionals protecting for changed date not set yet. [njohner]
 - Use changed instead of modified in date range calculation for SIP packages. [njohner]
 - Include mails in SIP package. [njohner]

--- a/docs/public/dev-manual/api/api_changelog.rst
+++ b/docs/public/dev-manual/api/api_changelog.rst
@@ -15,6 +15,11 @@ Other Changes
 - Add new endpoint ``@document_from_oneoffixx`` to add a document from a oneoffixx template
 - Add ``breadcrumbs`` option to the ``@solrsearch`` endpoint, only available for small batch sizes (max. 50 items).
 
+Breaking Changes
+^^^^^^^^^^^^^^^^
+
+- The ``@sharing`` endpoint now returns a batched result set if using the ``search`` param. If using the endpoint with the ``search`` param, it will rename the items key from ``entries`` to the key ``items`` which is the expected key for items in a batched response.
+
 
 2021.4.1 (2021-02-25)
 ---------------------

--- a/docs/public/dev-manual/api/sharing.rst
+++ b/docs/public/dev-manual/api/sharing.rst
@@ -64,3 +64,8 @@ Das ``ogds_summary`` Feld ist überholt und das ``actor`` Feld sollte anstatt ve
         ],
         "inherit": true
       }
+
+
+Paginierung
+~~~~~~~~~~~
+Wird der ``@sharing`` Endpoint mit dem ``search`` parameter verwendet, werden ``items`` Paginiert zurückgegeben. Siehe :ref:`Kapitel Paginierung <batching>`.

--- a/opengever/api/configure.zcml
+++ b/opengever/api/configure.zcml
@@ -53,6 +53,11 @@
   <adapter factory=".serializer.long_converter" />
   <adapter factory=".field_deserializers.PersistentDefaultFieldDeserializer" />
   <adapter factory=".field_deserializers.PersistentDatetimeFieldDeserializer" />
+  <adapter
+      factory=".local_roles.GeverSerializeLocalRolesToJson"
+      name="local_roles"
+      />
+
 
   <adapter factory=".todo.DeserializeToDoFromJson" />
   <adapter factory=".mail.DeserializeMailFromJson" />

--- a/opengever/api/local_roles.py
+++ b/opengever/api/local_roles.py
@@ -1,0 +1,41 @@
+from AccessControl.interfaces import IRoleManager
+from opengever.base.interfaces import IOpengeverBaseLayer
+from plone.restapi.batching import HypermediaBatch
+from plone.restapi.interfaces import ISerializeToJson
+from plone.restapi.serializer.local_roles import SerializeLocalRolesToJson
+from zope.component import adapter
+from zope.interface import implementer
+
+
+@adapter(IRoleManager, IOpengeverBaseLayer)
+@implementer(ISerializeToJson)
+class GeverSerializeLocalRolesToJson(SerializeLocalRolesToJson):
+    """The default local-roles serializer returns all current local roles
+    by default. If we pass a search-param, it will return all available
+    entries which could possibly be added to the local roles. This result
+    set can contain a lot of entries.
+
+    The GEVER-customization of this serializer returns a batched result-set
+    if searching for entries but returns an unbatched result-set
+    if just requesting the current local roles.
+    """
+    def __init__(self, context, request):
+        self.context = context
+        self.request = request
+
+    def __call__(self, search=None):
+        results = super(GeverSerializeLocalRolesToJson, self).__call__(search)
+
+        entries = results.get('entries', [])
+
+        if search is not None:
+            # The structure for batched results is to have a key called
+            # 'items' which contains the results, not 'entries' as it comes from
+            # the default implementation.
+            batch = HypermediaBatch(self.request, results.pop('entries'))
+            results['items'] = [entry for entry in batch]
+            results['items_total'] = len(entries)
+            if batch.links:
+                results['batching'] = batch.links
+
+        return results

--- a/opengever/api/sharing.py
+++ b/opengever/api/sharing.py
@@ -27,7 +27,7 @@ class SharingGet(APISharingGet):
     def reply(self):
         """Disable `plone.DelegateRoles` permission check.
         """
-
+        searchTerm = self.request.form.get('search')
         serializer = queryMultiAdapter((self.context, self.request),
                                        interface=ISerializeToJson,
                                        name='local_roles')
@@ -38,11 +38,16 @@ class SharingGet(APISharingGet):
 
         if self.request.form.get('ignore_permissions'):
             with disabled_permission_check():
-                data = serializer(search=self.request.form.get('search'))
+                data = serializer(search=searchTerm)
         else:
-            data = serializer(search=self.request.form.get('search'))
+            data = serializer(search=searchTerm)
 
-        for item in data.get('entries', []):
+        if searchTerm is None:
+            items = data.get('entries', [])
+        else:
+            items = data.get('items', [])
+
+        for item in items:
             self.extend_item_with_ogds_summary(item)
             self.extend_item_with_actor(item)
 

--- a/opengever/api/tests/test_local_roles.py
+++ b/opengever/api/tests/test_local_roles.py
@@ -1,0 +1,39 @@
+from ftw.testbrowser import browsing
+from opengever.sharing.security import disabled_permission_check
+from opengever.testing import IntegrationTestCase
+from plone.restapi.interfaces import ISerializeToJson
+from zope.component import queryMultiAdapter
+
+
+class TestLocalRolesSerializer(IntegrationTestCase):
+
+    @browsing
+    def test_local_roles_are_batched_if_searching(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        self.request.form['b_size'] = 3
+        serializer = queryMultiAdapter((self.dossier, self.request),
+                                       interface=ISerializeToJson,
+                                       name='local_roles')
+
+        with disabled_permission_check():
+            result = serializer(search="A")
+
+        self.assertEqual(21, result['items_total'])
+        self.assertEqual(3, len(result['items']))
+        self.assertIn('batching', result)
+
+    @browsing
+    def test_local_roles_are_not_batched_if_not_searching(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        self.request.form['b_size'] = 3
+        serializer = queryMultiAdapter((self.dossier, self.request),
+                                       interface=ISerializeToJson,
+                                       name='local_roles')
+
+        with disabled_permission_check():
+            result = serializer()
+
+        self.assertEqual(6, len(result['entries']))
+        self.assertNotIn('batching', result)

--- a/opengever/sharing/browser/resources/sharing.js
+++ b/opengever/sharing/browser/resources/sharing.js
@@ -111,7 +111,7 @@ var sharingApp = {
 
         var current_ids = this.entries.map( function(i) { return i.id})
         this.entries = this.entries.concat(
-          response.data['entries'].filter(function(i) {
+          response.data['items'].filter(function(i) {
             return i.disabled !== false && current_ids.indexOf(i.id) === -1;
           }));
         this.inherit = response.data['inherit'];


### PR DESCRIPTION
The default local-roles serializer returns all current local roles by default. If we pass a search-param, it will return all available entries which could possibly be added to the local roles. This result set can contain a lot of entries:

<img width="1006" alt="Bildschirmfoto 2021-02-26 um 09 57 41" src="https://user-images.githubusercontent.com/557005/109290165-8b3cb000-7827-11eb-8af3-2177b8e81631.png">

Currently, such a response will break the UI.

So this PR customizes the local-roles serializer to return a batched result-set if searching for entries but returns an unbatched result-set if just requesting the current local roles.

<img width="554" alt="Bildschirmfoto 2021-02-26 um 11 47 27" src="https://user-images.githubusercontent.com/557005/109290843-70b70680-7828-11eb-957c-a15ab0e3cf7b.png">

ℹ️ The default batch-size is at 25 which should solve the issue. We do not implement batching in the frontend-sharing-tab, but just display the available entries.

Jira: https://4teamwork.atlassian.net/browse/CA-1831

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


## Checklist (if applicable)

_Only applicable should be left and checked._

- API change:
  - [x] Documentation is updated
  - [x] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [x] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Upgrade steps (changes in profile):
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
- DB-Schema migration
  - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
  - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value
