### PR TITLE
Reset value of NamedFileWidget in DocumentAddForm when validation fails.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,7 @@ Changelog
 2021.6.0 (unreleased)
 ---------------------
 
-- Nothing changed yet.
+- Reset value of NamedFileWidget in DocumentAddForm when validation fails. [njohner]
 
 
 2021.5.0 (2021-03-04)

--- a/opengever/document/forms.py
+++ b/opengever/document/forms.py
@@ -55,6 +55,19 @@ class DocumentAddForm(add.DefaultAddForm):
         super(DocumentAddForm, self).updateFields()
         self.groups = omit_custom_properties_group(self.groups)
 
+    @button.buttonAndHandler(_('Save'), name='save')
+    def handleAdd(self, action):
+        """ Reset value of NamedFileWidget when validation fails, to avoid
+        displaying an already uploaded file with "Keep existing file" radio
+        button, which would actually not get set upon form resubmission.
+        """
+        super(DocumentAddForm, self).handleAdd(self, action)
+        if self.status != self.formErrorsMessage:
+            return
+        for group in self.groups:
+            if 'file' in group.widgets:
+                group.widgets.get('file').value = None
+
 
 class DocumentAddView(add.DefaultAddView):
     """Provide a registerable view for the Document file upload form."""

--- a/opengever/document/locales/de/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/de/LC_MESSAGES/opengever.document.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2021-02-09 10:19+0000\n"
+"POT-Creation-Date: 2021-03-01 18:36+0000\n"
 "PO-Revision-Date: 2017-10-13 14:27+0200\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -102,6 +102,10 @@ msgstr "Auswahl exportieren"
 #: ./opengever/document/checkout/revert.py
 msgid "Reverted file to version ${version_id}."
 msgstr "Datei des Dokuments auf Version ${version_id} zurückgesetzt."
+
+#: ./opengever/document/forms.py
+msgid "Save"
+msgstr "Speichern"
 
 #: ./opengever/document/upgrades/profiles/4200/actions.xml
 msgid "Submit additional documents"

--- a/opengever/document/locales/en/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/en/LC_MESSAGES/opengever.document.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2021-02-09 10:19+0000\n"
+"POT-Creation-Date: 2021-03-01 18:36+0000\n"
 "PO-Revision-Date: 2017-10-13 14:27+0200\n"
 "Last-Translator: Jonas Baumann <j.baumann@4teamwork.ch>\n"
 "Language-Team: 4teamwork <info@4teamwork.ch>\n"
@@ -121,6 +121,10 @@ msgstr "Export selection"
 #: ./opengever/document/checkout/revert.py
 msgid "Reverted file to version ${version_id}."
 msgstr "Reverted file to version ${version_id}."
+
+#: ./opengever/document/forms.py
+msgid "Save"
+msgstr "Save"
 
 #. German translation: Zusätzliche Beilagen einreichen
 #: ./opengever/document/upgrades/profiles/4200/actions.xml

--- a/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
+++ b/opengever/document/locales/fr/LC_MESSAGES/opengever.document.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-02-09 10:19+0000\n"
+"POT-Creation-Date: 2021-03-01 18:36+0000\n"
 "PO-Revision-Date: 2017-09-03 08:50+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-document/fr/>\n"
@@ -104,6 +104,10 @@ msgstr "Exporter la sélection"
 #: ./opengever/document/checkout/revert.py
 msgid "Reverted file to version ${version_id}."
 msgstr "Retour à la version ${version_id} du document."
+
+#: ./opengever/document/forms.py
+msgid "Save"
+msgstr "Sauvegarder"
 
 #: ./opengever/document/upgrades/profiles/4200/actions.xml
 msgid "Submit additional documents"

--- a/opengever/document/locales/opengever.document.pot
+++ b/opengever/document/locales/opengever.document.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-02-09 10:19+0000\n"
+"POT-Creation-Date: 2021-03-01 18:36+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -103,6 +103,10 @@ msgstr ""
 #: ./opengever/document/checkout/manager.py
 #: ./opengever/document/checkout/revert.py
 msgid "Reverted file to version ${version_id}."
+msgstr ""
+
+#: ./opengever/document/forms.py
+msgid "Save"
 msgstr ""
 
 #: ./opengever/document/upgrades/profiles/4200/actions.xml


### PR DESCRIPTION
When validation fails when a new file is uploaded over the `NamedFileWidget`, it will then behave as if it already had a value set, but this will not work correctly upon resubmission of the form because the file was not stored server side.
This problem is addressed in newer version of the widget, but it comes with its own set of problems, so [we gave up that path](https://github.com/4teamwork/opengever.core/pull/6910).

Here we propose another fix for the document add form. We reset the value of `NamedFileWidget` in the `DocumentAddForm` when validation fails. This is not ideal, but at least the widget does correctly show that currently no file will be uploaded if the form is submitted again. This covers the most likely scenario when using custom
property sheets in the classic UI.

This does not fix the issue we could have in the edit form, but this is much less likely, as it requires changing the file of the edit metadata form and at the same time changing the document type to one that requires new custom properties. This is an edge case we can live with.

For https://4teamwork.atlassian.net/browse/CA-1507

## Checklist (Must have)

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)