### PR TITLE
Don't resolve or deactivate a dossier if it has linked workspaces without view permission.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2021.6.0 (unreleased)
 ---------------------
 
+- Don't resolve or deactivate a dossier if it has linked workspaces without view permission. [elioschmutz]
 - Reset value of NamedFileWidget in DocumentAddForm when validation fails. [njohner]
 
 

--- a/opengever/dossier/base.py
+++ b/opengever/dossier/base.py
@@ -300,6 +300,9 @@ class DossierContainer(Container):
         return bool(active_proposals)
 
     def is_linked_to_active_workspaces(self):
+        """Returns all linked active workspaces accessible by the current
+        user.
+        """
         if not is_workspace_client_feature_enabled():
             return False
 
@@ -311,6 +314,22 @@ class DossierContainer(Container):
             params = {'review_state': 'opengever_workspace--STATUS--active'}
             active_workspaces = linked_workspaces_adapter.list_non_cached(**params)['items_total']
             return bool(active_workspaces)
+
+    def has_linked_workspaces_without_view_permission(self):
+        """It's possible that the currently logged in user has no view permission
+        to all linked workspaces. This function returns a boolean to indicate
+        if there are such workspaces linked with the current dossier.
+        """
+        if not is_workspace_client_feature_enabled():
+            return False
+
+        with elevated_privileges():
+            linked_workspaces_adapter = queryAdapter(self, ILinkedWorkspaces)
+            if not linked_workspaces_adapter:
+                return False
+
+            linked_workspaces = linked_workspaces_adapter.list_non_cached()['items_total']
+        return bool(len(linked_workspaces_adapter.storage.list()) - linked_workspaces)
 
     def is_all_checked_in(self):
         """Check if all documents in this path are checked in."""

--- a/opengever/dossier/deactivate.py
+++ b/opengever/dossier/deactivate.py
@@ -18,6 +18,9 @@ CONTAINS_ACTIVE_TASK = _(u"The Dossier can't be deactivated, not all contained"
 CONTAINS_ACTIVE_WORKSPACE = _(u"The Dossier can't be deactivated, not all linked"
                               " workspaces are deactivated.")
 
+CONTAINS_WORKSPACE_WITHOUT_VIEW_PERMISSION = _(
+    u"Not all linked workspaces are accessible by the current user.")
+
 
 class DossierDeactivator(object):
     """Recursively deactivate the dossier and its subdossiers.
@@ -63,6 +66,8 @@ class DossierDeactivator(object):
             errors.append(CONTAINS_ACTIVE_PROPOSAL)
         if self.context.is_linked_to_active_workspaces():
             errors.append(CONTAINS_ACTIVE_WORKSPACE)
+        if self.context.has_linked_workspaces_without_view_permission():
+            errors.append(CONTAINS_WORKSPACE_WITHOUT_VIEW_PERMISSION)
 
         # Check for subdossiers the user cannot deactivate
         for subdossier in self.context.get_subdossiers(unrestricted=True):

--- a/opengever/dossier/locales/de/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/de/LC_MESSAGES/opengever.dossier.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2021-01-08 11:40+0000\n"
+"POT-Creation-Date: 2021-03-02 18:53+0000\n"
 "PO-Revision-Date: 2017-05-23 04:53+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: German <https://translations.onegovgever.ch/projects/onegov-gever/opengever-dossier/de/>\n"
@@ -117,6 +117,11 @@ msgstr "Neuste Aufgaben"
 #: ./opengever/dossier/browser/templates/overview.pt
 msgid "No Subdossiers"
 msgstr "Keine Subdossiers"
+
+#: ./opengever/dossier/deactivate.py
+#: ./opengever/dossier/resolve.py
+msgid "Not all linked workspaces are accessible by the current user."
+msgstr "Es existieren noch Teamräume, auf die Sie keinen Zugriff haben. Das Dossier kann nicht abgeschlossen werden."
 
 #: ./opengever/dossier/resolve.py
 msgid "Not all linked workspaces are deactivated."

--- a/opengever/dossier/locales/en/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/en/LC_MESSAGES/opengever.dossier.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2021-01-13 23:16+0000\n"
+"POT-Creation-Date: 2021-03-02 18:53+0000\n"
 "PO-Revision-Date: 2017-05-23 04:53+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: German <https://translations.onegovgever.ch/projects/onegov-gever/opengever-dossier/de/>\n"
@@ -142,6 +142,11 @@ msgstr "Newest tasks"
 #: ./opengever/dossier/browser/templates/overview.pt
 msgid "No Subdossiers"
 msgstr "No subdossiers"
+
+#: ./opengever/dossier/deactivate.py
+#: ./opengever/dossier/resolve.py
+msgid "Not all linked workspaces are accessible by the current user."
+msgstr ""
 
 #. German translation: Nicht alle verlinkten Teamräume sind deaktiviert.
 #: ./opengever/dossier/resolve.py

--- a/opengever/dossier/locales/fr/LC_MESSAGES/opengever.dossier.po
+++ b/opengever/dossier/locales/fr/LC_MESSAGES/opengever.dossier.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-01-08 11:40+0000\n"
+"POT-Creation-Date: 2021-03-02 18:53+0000\n"
 "PO-Revision-Date: 2017-12-03 11:16+0000\n"
 "Last-Translator: Jacqueline Sposato <jacqueline.sposato@gmail.com>\n"
 "Language-Team: French <https://translations.onegovgever.ch/projects/onegov-gever/opengever-dossier/fr/>\n"
@@ -116,6 +116,11 @@ msgstr "Dernières tâches"
 #: ./opengever/dossier/browser/templates/overview.pt
 msgid "No Subdossiers"
 msgstr "Aucun sous-dossier"
+
+#: ./opengever/dossier/deactivate.py
+#: ./opengever/dossier/resolve.py
+msgid "Not all linked workspaces are accessible by the current user."
+msgstr ""
 
 #: ./opengever/dossier/resolve.py
 msgid "Not all linked workspaces are deactivated."

--- a/opengever/dossier/locales/opengever.dossier.pot
+++ b/opengever/dossier/locales/opengever.dossier.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2021-01-08 11:40+0000\n"
+"POT-Creation-Date: 2021-03-02 18:53+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -116,6 +116,11 @@ msgstr ""
 
 #: ./opengever/dossier/browser/templates/overview.pt
 msgid "No Subdossiers"
+msgstr ""
+
+#: ./opengever/dossier/deactivate.py
+#: ./opengever/dossier/resolve.py
+msgid "Not all linked workspaces are accessible by the current user."
 msgstr ""
 
 #: ./opengever/dossier/resolve.py

--- a/opengever/dossier/resolve.py
+++ b/opengever/dossier/resolve.py
@@ -41,6 +41,8 @@ NOT_CLOSED_TASKS = _("not all task are closed")
 NO_START_DATE = _("the dossier start date is missing.")
 MSG_ACTIVE_PROPOSALS = _("The dossier contains active proposals.")
 MSG_ACTIVE_WORKSPACES = _("Not all linked workspaces are deactivated.")
+MSG_CONTAINS_WORKSPACE_WITHOUT_VIEW_PERMISSION = _(
+    u"Not all linked workspaces are accessible by the current user.")
 MSG_ALREADY_BEING_RESOLVED = _("Dossier is already being resolved")
 
 AFTER_RESOLVE_JOBS_PENDING_KEY = 'opengever.dossier.resolve.after_resolve_jobs_pending'
@@ -616,6 +618,8 @@ class ResolveConditions(object):
             errors.append(MSG_ACTIVE_PROPOSALS)
         if self.context.is_linked_to_active_workspaces():
             errors.append(MSG_ACTIVE_WORKSPACES)
+        if self.context.has_linked_workspaces_without_view_permission():
+            errors.append(MSG_CONTAINS_WORKSPACE_WITHOUT_VIEW_PERMISSION)
         if not self.context.has_valid_startdate():
             errors.append(NO_START_DATE)
 

--- a/opengever/dossier/tests/test_base.py
+++ b/opengever/dossier/tests/test_base.py
@@ -243,6 +243,31 @@ class TestDossierWithWorkspaceClientFeaturesEnabled(FunctionalWorkspaceClientTes
             transaction.commit()
             self.assertTrue(self.dossier.is_linked_to_active_workspaces())
 
+    def test_has_linked_workspaces_without_view_permission_is_false_if_there_are_no_linked_workspaces(self):
+        with self.workspace_client_env():
+            self.login()
+            self.assertFalse(self.dossier.has_linked_workspaces_without_view_permission())
+
+    def test_has_linked_workspaces_without_view_permission_is_false_if_there_are_linked_workspaces_with_view_permission(self):
+        with self.workspace_client_env():
+            self.login()
+            manager = ILinkedWorkspaces(self.dossier)
+            manager.storage.add(self.workspace.UID())
+            transaction.commit()
+            self.assertFalse(self.dossier.has_linked_workspaces_without_view_permission())
+
+    def test_has_linked_workspaces_without_view_permission_is_true_if_there_are_linked_workspaces_without_view_permission(self):
+        self.login(user_id='service.user')
+        workspace_without_view_permission = create(Builder('workspace').within(self.workspace_root))
+        with self.workspace_client_env():
+            manager = ILinkedWorkspaces(self.dossier)
+            manager.storage.add(workspace_without_view_permission.UID())
+            manager.storage.add(self.workspace.UID())
+            transaction.commit()
+            self.login()
+            self.assertFalse(api.user.has_permission('View', obj=workspace_without_view_permission))
+            self.assertTrue(self.dossier.has_linked_workspaces_without_view_permission())
+
 
 class TestDateCalculations(IntegrationTestCase):
 

--- a/opengever/dossier/tests/test_resolve.py
+++ b/opengever/dossier/tests/test_resolve.py
@@ -1468,6 +1468,23 @@ class TestResolveConditionsWithWorkspaceClientFeatureEnabled(ResolveTestHelper,
                                ['Not all linked workspaces are deactivated.'])
 
     @browsing
+    def test_resolving_is_cancelled_when_dossier_is_linked_to_workspaces_without_view_permission(self, browser):
+        self.login(user_id='service.user')
+        workspace_without_view_permission = create(Builder('workspace').within(self.workspace_root))
+        with self.workspace_client_env():
+            manager = ILinkedWorkspaces(self.dossier)
+            manager.storage.add(workspace_without_view_permission.UID())
+            transaction.commit()
+            self.login()
+            browser.login()
+            self.grant('Reviewer', *api.user.get_roles())
+            self.assertFalse(api.user.has_permission('View', obj=workspace_without_view_permission))
+            self.resolve(self.dossier, browser)
+            self.assert_not_resolved(self.dossier)
+            self.assert_errors(self.dossier, browser,
+                               ['Not all linked workspaces are accessible by the current user.'])
+
+    @browsing
     def test_dossier_is_resolved_when_no_workspace_is_linked(self, browser):
         with self.workspace_client_env():
             self.grant('Reviewer', *api.user.get_roles())


### PR DESCRIPTION
This PR is a follow-up PR of: https://github.com/4teamwork/opengever.core/pull/6642

It should not be possible to resolve/deactivate a dossier if there are active linked workspaces. It's possible, that the current user does not see some linked workspaces because he does not have the `View` permission on it. So the check in https://github.com/4teamwork/opengever.core/pull/6642 will not detect such workspaces.

The `elevated_privileges` is only for the GEVER-instance and has no effect on the teamraum instance. So even if we run it with elevated privileges, the request to the teamraum is made with the currently logged in user and the permissions on the source instance, so the teamraum. It just makes sure, that the current user can access the `WorkspaceClient`.

We could refactor this, but that's not part of this bugfix!

To fix the issue, this PR introduces a new method `has_linked_workspaces_without_view_permission` which returns a boolean indicating if there are linked workspaces where the current user does not have the view permission. This allows us to introduce a new check for the resolve/deactivate action with a specific error message.

<img width="1440" alt="Bildschirmfoto 2021-03-04 um 10 13 39" src="https://user-images.githubusercontent.com/557005/109940423-579fd100-7cd2-11eb-91b0-3f2fcd6be74a.png">

Fixes: https://4teamwork.atlassian.net/browse/CA-1851

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)


## Checklist (if applicable)

_Only applicable should be left and checked._

- API change:
  - [ ] Documentation is updated
  - [ ] API Changelog entry (see [guide](https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/451248812/API+Changelog+Guidelines))
  - If breaking:
    - [ ] api-change label added
    - [ ] #delivery channel notified about breaking change
    - [ ] Scrum master is informed
- New functionality:
  - [ ] for `document` also works for `mail`
  - [ ] for `task` also works for `forwarding`
- Upgrade steps (changes in profile):
  - [ ] Make it deferrable if possible
  - [ ] Execute as much as possible conditionally
- DB-Schema migration
  - [ ] All changes on a model (columns, etc) are included in a DB-schema migration.
  - [ ] Constraint names are shorter than 30 characters (`Oracle`)
- [ ] Change could impact client installations, client policies need to be adapted
- New translations
  - [ ] All msg-strings are unicode
- Change in schema definition:
  - [ ] If `missing_value` is specified, then `default` has to be set to the same value
