### PR TITLE
Filter out trash and untrash folder buttons in @actions endpoint on repofolders.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,7 @@ Changelog
 - Fixed automatic start of a next task inside a sequential task process. [phgross]
 - Only show "add task to process" link, if next task is not yet started. [phgross]
 - Fix adding sequential task process on first position. [phgross]
+- Filter out trash and untrash folder buttons in @actions on repository root and folders. [njohner]
 - Don't resolve or deactivate a dossier if it has linked workspaces without view permission. [elioschmutz]
 - Reset value of NamedFileWidget in DocumentAddForm when validation fails. [njohner]
 

--- a/opengever/api/tests/test_actions.py
+++ b/opengever/api/tests/test_actions.py
@@ -1018,8 +1018,6 @@ class TestFolderButtons(FolderActionsTestBase):
             {u'icon': u'', u'id': u'move_items', u'title': u'Move items'},
             {u'icon': u'', u'id': u'move_proposal_items', u'title': u'Move items'},
             {u'icon': u'', u'id': u'export_dossiers', u'title': u'Export selection'},
-            {u'icon': u'', u'id': u'trashed', u'title': u'Move to trash'},
-            {u'icon': u'', u'id': u'untrashed', u'title': u'Restore from trash'},
             {u'icon': u'', u'id': u'pdf_dossierlisting', u'title': u'Print selection (PDF)'},
             {u'icon': u'', u'id': u'pdf_taskslisting', u'title': u'Print selection (PDF)'}]
 
@@ -1073,8 +1071,6 @@ class TestFolderButtons(FolderActionsTestBase):
             {u'icon': u'', u'id': u'move_items', u'title': u'Move items'},
             {u'icon': u'', u'id': u'move_proposal_items', u'title': u'Move items'},
             {u'icon': u'', u'id': u'export_dossiers', u'title': u'Export selection'},
-            {u'icon': u'', u'id': u'trashed', u'title': u'Move to trash'},
-            {u'icon': u'', u'id': u'untrashed', u'title': u'Restore from trash'},
             {u'icon': u'', u'id': u'pdf_dossierlisting', u'title': u'Print selection (PDF)'},
             {u'icon': u'', u'id': u'pdf_taskslisting', u'title': u'Print selection (PDF)'}]
 

--- a/opengever/api/tests/test_actions.py
+++ b/opengever/api/tests/test_actions.py
@@ -1028,6 +1028,61 @@ class TestFolderButtons(FolderActionsTestBase):
             self.get_folder_buttons(browser, self.leaf_repofolder),
         )
 
+    @browsing
+    def test_folder_buttons_for_repository_root(self, browser):
+        self.login(self.regular_user, browser)
+
+        expected_folder_buttons = [
+            {u'icon': u'', u'id': u'rename', u'title': u'Rename'},
+            {u'icon': u'', u'id': u'zip_selected', u'title': u'Export as Zip'},
+            {u'icon': u'', u'id': u'export_tasks', u'title': u'Export selection'},
+            {u'icon': u'', u'id': u'copy_items', u'title': u'Copy items'},
+            {u'icon': u'', u'id': u'send_as_email', u'title': u'Send as email'},
+            {u'icon': u'', u'id': u'attach_documents', u'title': u'Attach to email'},
+            {u'icon': u'', u'id': u'submit_additional_documents',
+                u'title': u'Submit additional documents'},
+            {u'icon': u'', u'id': u'export_documents', u'title': u'Export selection'},
+            {u'icon': u'', u'id': u'add_participant', u'title': u'Add participant'},
+            {u'icon': u'', u'id': u'move_items', u'title': u'Move items'},
+            {u'icon': u'', u'id': u'move_proposal_items', u'title': u'Move items'},
+            {u'icon': u'', u'id': u'export_dossiers', u'title': u'Export selection'},
+            {u'icon': u'', u'id': u'pdf_dossierlisting', u'title': u'Print selection (PDF)'},
+            {u'icon': u'', u'id': u'pdf_taskslisting', u'title': u'Print selection (PDF)'}]
+
+        self.assertListEqual(
+            expected_folder_buttons,
+            self.get_folder_buttons(browser, self.repository_root),
+        )
+
+    @browsing
+    def test_folder_buttons_for_repository_root_for_admins(self, browser):
+        self.login(self.administrator, browser)
+
+        expected_folder_buttons = [
+            {u'icon': u'', u'id': u'rename', u'title': u'Rename'},
+            {u'icon': u'', u'id': u'zip_selected', u'title': u'Export as Zip'},
+            {u'icon': u'', u'id': u'export_tasks', u'title': u'Export selection'},
+            {u'icon': u'', u'id': u'copy_items', u'title': u'Copy items'},
+            {u'icon': u'', u'id': u'send_as_email', u'title': u'Send as email'},
+            {u'icon': u'', u'id': u'attach_documents', u'title': u'Attach to email'},
+            {u'icon': u'', u'id': u'submit_additional_documents',
+                u'title': u'Submit additional documents'},
+            {u'icon': u'', u'id': u'export_documents', u'title': u'Export selection'},
+            {u'icon': u'', u'id': u'delete_participants', u'title': u'Delete'},
+            {u'icon': u'', u'id': u'add_participant', u'title': u'Add participant'},
+            {u'icon': u'', u'id': u'move_items', u'title': u'Move items'},
+            {u'icon': u'', u'id': u'move_proposal_items', u'title': u'Move items'},
+            {u'icon': u'', u'id': u'export_dossiers', u'title': u'Export selection'},
+            {u'icon': u'', u'id': u'trashed', u'title': u'Move to trash'},
+            {u'icon': u'', u'id': u'untrashed', u'title': u'Restore from trash'},
+            {u'icon': u'', u'id': u'pdf_dossierlisting', u'title': u'Print selection (PDF)'},
+            {u'icon': u'', u'id': u'pdf_taskslisting', u'title': u'Print selection (PDF)'}]
+
+        self.assertListEqual(
+            expected_folder_buttons,
+            self.get_folder_buttons(browser, self.repository_root),
+        )
+
 
 class TestWorkspaceClientFolderActions(FunctionalWorkspaceClientTestCase):
 

--- a/opengever/api/tests/test_actions.py
+++ b/opengever/api/tests/test_actions.py
@@ -828,13 +828,13 @@ class TestUnlockAction(FileActionsTestBase):
                          self.get_file_actions(browser, self.document))
 
 
-class TestFolderActions(FolderActionsTestBase):
+class TestFolderButtons(FolderActionsTestBase):
 
     features = ('bumblebee', 'meeting')
     createTaskAction = {
         u'id': u'create_task',
         u'title': u'Create task',
-        u'icon': u'',}
+        u'icon': u''}
 
     @browsing
     def test_create_task_available_in_open_dossier(self, browser):
@@ -846,13 +846,13 @@ class TestFolderActions(FolderActionsTestBase):
     def test_create_task_available_in_task(self, browser):
         self.login(self.regular_user, browser)
         self.assertIn(self.createTaskAction,
-                         self.get_folder_buttons(browser, self.task))
+                      self.get_folder_buttons(browser, self.task))
 
     @browsing
     def test_create_task_available_in_meetingdossier(self, browser):
         self.login(self.regular_user, browser)
         self.assertIn(self.createTaskAction,
-                         self.get_folder_buttons(browser, self.meeting_dossier))
+                      self.get_folder_buttons(browser, self.meeting_dossier))
 
     @browsing
     def test_create_task_not_available_in_resolved_dossier(self, browser):
@@ -890,7 +890,7 @@ class TestFolderActions(FolderActionsTestBase):
                          self.get_folder_buttons(browser, self.resolvable_dossier))
 
     @browsing
-    def test_actions_for_dossier(self, browser):
+    def test_folder_buttons_for_dossier(self, browser):
         self.login(self.regular_user, browser)
 
         expected_folder_buttons = [
@@ -925,7 +925,7 @@ class TestFolderActions(FolderActionsTestBase):
         )
 
     @browsing
-    def test_actions_for_inactive_dossier(self, browser):
+    def test_folder_buttons_for_inactive_dossier(self, browser):
         self.login(self.regular_user, browser)
 
         expected_folder_buttons = [
@@ -946,7 +946,7 @@ class TestFolderActions(FolderActionsTestBase):
         )
 
     @browsing
-    def test_actions_for_resolved_dossier(self, browser):
+    def test_folder_buttons_for_resolved_dossier(self, browser):
         self.login(self.secretariat_user, browser)
 
         resolve_manager = LockingResolveManager(self.resolvable_dossier)

--- a/opengever/api/tests/test_actions.py
+++ b/opengever/api/tests/test_actions.py
@@ -971,6 +971,63 @@ class TestFolderButtons(FolderActionsTestBase):
             self.get_folder_buttons(browser, self.resolvable_dossier),
         )
 
+    @browsing
+    def test_folder_buttons_for_repository_folders(self, browser):
+        self.login(self.regular_user, browser)
+
+        expected_folder_buttons = [
+            {u'icon': u'', u'id': u'rename', u'title': u'Rename'},
+            {u'icon': u'', u'id': u'zip_selected', u'title': u'Export as Zip'},
+            {u'icon': u'', u'id': u'export_tasks', u'title': u'Export selection'},
+            {u'icon': u'', u'id': u'copy_items', u'title': u'Copy items'},
+            {u'icon': u'', u'id': u'send_as_email', u'title': u'Send as email'},
+            {u'icon': u'', u'id': u'attach_documents', u'title': u'Attach to email'},
+            {u'icon': u'', u'id': u'submit_additional_documents',
+                u'title': u'Submit additional documents'},
+            {u'icon': u'', u'id': u'export_documents', u'title': u'Export selection'},
+            {u'icon': u'', u'id': u'add_participant', u'title': u'Add participant'},
+            {u'icon': u'', u'id': u'move_items', u'title': u'Move items'},
+            {u'icon': u'', u'id': u'move_proposal_items', u'title': u'Move items'},
+            {u'icon': u'', u'id': u'export_dossiers', u'title': u'Export selection'},
+            {u'icon': u'', u'id': u'pdf_dossierlisting', u'title': u'Print selection (PDF)'},
+            {u'icon': u'', u'id': u'pdf_taskslisting', u'title': u'Print selection (PDF)'}]
+
+        self.assertListEqual(
+            expected_folder_buttons,
+            self.get_folder_buttons(browser, self.leaf_repofolder),
+        )
+
+    @browsing
+    def test_folder_buttons_for_repository_folders_for_admins(self, browser):
+        self.login(self.administrator, browser)
+
+        expected_folder_buttons = [
+            {u'icon': u'', u'id': u'rename', u'title': u'Rename'},
+            {u'icon': u'', u'id': u'delete', u'title': u'Delete'},
+            {u'icon': u'', u'id': u'zip_selected', u'title': u'Export as Zip'},
+            {u'icon': u'', u'id': u'export_tasks', u'title': u'Export selection'},
+            {u'icon': u'', u'id': u'copy_items', u'title': u'Copy items'},
+            {u'icon': u'', u'id': u'send_as_email', u'title': u'Send as email'},
+            {u'icon': u'', u'id': u'attach_documents', u'title': u'Attach to email'},
+            {u'icon': u'', u'id': u'submit_additional_documents',
+                u'title': u'Submit additional documents'},
+            {u'icon': u'', u'id': u'export_documents', u'title': u'Export selection'},
+            {u'icon': u'', u'id': u'folder_delete_confirmation', u'title': u'Delete'},
+            {u'icon': u'', u'id': u'delete_participants', u'title': u'Delete'},
+            {u'icon': u'', u'id': u'add_participant', u'title': u'Add participant'},
+            {u'icon': u'', u'id': u'move_items', u'title': u'Move items'},
+            {u'icon': u'', u'id': u'move_proposal_items', u'title': u'Move items'},
+            {u'icon': u'', u'id': u'export_dossiers', u'title': u'Export selection'},
+            {u'icon': u'', u'id': u'trashed', u'title': u'Move to trash'},
+            {u'icon': u'', u'id': u'untrashed', u'title': u'Restore from trash'},
+            {u'icon': u'', u'id': u'pdf_dossierlisting', u'title': u'Print selection (PDF)'},
+            {u'icon': u'', u'id': u'pdf_taskslisting', u'title': u'Print selection (PDF)'}]
+
+        self.assertListEqual(
+            expected_folder_buttons,
+            self.get_folder_buttons(browser, self.leaf_repofolder),
+        )
+
 
 class TestWorkspaceClientFolderActions(FunctionalWorkspaceClientTestCase):
 

--- a/opengever/base/browser/folder_buttons_availability.py
+++ b/opengever/base/browser/folder_buttons_availability.py
@@ -3,6 +3,8 @@ from Acquisition import aq_inner
 from opengever.dossier.behaviors.dossier import IDossierMarker
 from opengever.dossier.templatefolder.interfaces import ITemplateFolder
 from opengever.meeting import is_meeting_feature_enabled
+from opengever.repository.interfaces import IRepositoryFolder
+from opengever.repository.repositoryroot import IRepositoryRoot
 from opengever.task.task import ITask
 from opengever.workspaceclient import is_workspace_client_feature_available
 from opengever.workspaceclient.interfaces import ILinkedWorkspaces
@@ -55,6 +57,12 @@ class FolderButtonsAvailabilityView(BrowserView):
             if ITemplateFolder.providedBy(obj):
                 return True
         return False
+
+    def _is_repository_folder(self):
+        return IRepositoryFolder.providedBy(self.context)
+
+    def _is_repository_root(self):
+        return IRepositoryRoot.providedBy(self.context)
 
     def _can_modify_dossier(self):
         return api.user.has_permission(
@@ -115,10 +123,22 @@ class FolderButtonsAvailabilityView(BrowserView):
         return not self._is_template_area()
 
     def is_trash_available(self):
-        return not self._is_template_area()
+        """Trash action should only be shown on dossier level, as we otherwise
+        don't know whether the documents can be trashed (they could be in an
+        inactive or resolved dossier).
+        """
+        return (not self._is_repository_folder()
+                and not self._is_repository_root()
+                and not self._is_template_area())
 
     def is_untrash_available(self):
-        return not self._is_template_area()
+        """Untrash action should only be shown on dossier level, as we otherwise
+        don't know whether the documents can be untrashed (they could be in an
+        inactive or resolved dossier).
+        """
+        return (not self._is_repository_folder()
+                and not self._is_repository_root()
+                and not self._is_template_area())
 
     def is_attach_documents_available(self):
         return not self._is_template_area()


### PR DESCRIPTION
In the new frontend, the `trash` action is visible in the documents tab on repository folder level. Because the documents listing shows all documents, even the the ones in resolved / inactive dossiers, the action can fail for certain documents. This failure is not handled by the frontend.
Here we implement the same approach as in the classic UI, i.e. we simply [do not show the action at the repository level](https://github.com/4teamwork/opengever.core/blob/master/opengever/repository/browser/tabs.py#L8-L12). I think this makes sense, I don't really see a use case for trashing documents from different main dossiers at the same time.

For https://4teamwork.atlassian.net/browse/CA-1828

Definition of Done: https://4teamwork.atlassian.net/wiki/spaces/CHX4TW/pages/917562/


## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)