### PR TITLE
Update PR template with creation of follow-up stories

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,15 +11,12 @@ _Screenshot: whenever useful, but only as a visual aid._
 Definition of Done: https://4teamwork.atlassian.net/wiki/spaces/CHX4TW/pages/917562/
 
 
-## Checklist (Must have)
+## Checklist
 
 _Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._
 
 - [ ] Changelog entry
 - [ ] Link to issue (Jira or GitHub) and backlink in issue (Jira)
-
-
-## Checklist (if applicable)
 
 _Only applicable should be left and checked._
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -33,6 +33,8 @@ _Only applicable should be left and checked._
 - New functionality:
   - [ ] for `document` also works for `mail`
   - [ ] for `task` also works for `forwarding`
+- Further improvements needed:
+  - [ ] Create follow-up stories and link them in the PR and Jira issue
 - Upgrade steps (changes in profile):
   - [ ] Make it deferrable if possible
   - [ ] Execute as much as possible conditionally


### PR DESCRIPTION
As discussed in the sprint review, when a PR leaves a state behind that will require further improvements, for example because it leads to some technical debt, does not cover some edge cases, or is simply an incomplete implementation of a feature that we know will lead to support requests, complaints, confusion further down the line, we want to make sure to create follow-up stories to sort these out.
This is added as a reminder in the PR template.

Moreover I propose to simplify the checklist a bit, make it a single checklist with a mandatory and optional part.

## Checklist (Must have)

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._

- [ ] Changelog entry -> no changelog here
- [ ] Link to issue (Jira or GitHub) and backlink in issue (Jira) -> no jira issue, came from sprint review
