### PR TITLE
Sequential task fixes

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -13,6 +13,7 @@ Changelog
 
 - Fix support in TransitionExtender for RelationChoice fields. [phgross]
 - Allow any authenticated users to use the REST API. [phgross]
+- Fix adding sequential task process on first position. [phgross]
 - The @sharing endpoint now returns a batched result set if using the search param.  [elioschmutz]
 - Cleanup conditionals protecting for changed date not set yet. [njohner]
 - Use changed instead of modified in date range calculation for SIP packages. [njohner]

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 2021.6.0 (unreleased)
 ---------------------
 
+- Fixed automatic start of a next task inside a sequential task process. [phgross]
+- Only show "add task to process" link, if next task is not yet started. [phgross]
+- Fix adding sequential task process on first position. [phgross]
 - Don't resolve or deactivate a dossier if it has linked workspaces without view permission. [elioschmutz]
 - Reset value of NamedFileWidget in DocumentAddForm when validation fails. [njohner]
 
@@ -13,9 +16,6 @@ Changelog
 
 - Fix support in TransitionExtender for RelationChoice fields. [phgross]
 - Allow any authenticated users to use the REST API. [phgross]
-- Fixed automatic start of a next task inside a sequential task process. [phgross]
-- Only show "add task to process" link, if next task is not yet started. [phgross]
-- Fix adding sequential task process on first position. [phgross]
 - The @sharing endpoint now returns a batched result set if using the search param.  [elioschmutz]
 - Cleanup conditionals protecting for changed date not set yet. [njohner]
 - Use changed instead of modified in date range calculation for SIP packages. [njohner]

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -13,6 +13,7 @@ Changelog
 
 - Fix support in TransitionExtender for RelationChoice fields. [phgross]
 - Allow any authenticated users to use the REST API. [phgross]
+- Fixed automatic start of a next task inside a sequential task process. [phgross]
 - Only show "add task to process" link, if next task is not yet started. [phgross]
 - Fix adding sequential task process on first position. [phgross]
 - The @sharing endpoint now returns a batched result set if using the search param.  [elioschmutz]

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -13,6 +13,7 @@ Changelog
 
 - Fix support in TransitionExtender for RelationChoice fields. [phgross]
 - Allow any authenticated users to use the REST API. [phgross]
+- Only show "add task to process" link, if next task is not yet started. [phgross]
 - Fix adding sequential task process on first position. [phgross]
 - The @sharing endpoint now returns a batched result set if using the search param.  [elioschmutz]
 - Cleanup conditionals protecting for changed date not set yet. [njohner]

--- a/opengever/globalindex/model/task.py
+++ b/opengever/globalindex/model/task.py
@@ -355,11 +355,11 @@ class Task(Base):
 
         return self.tasktemplate_successor
 
-    def adding_next_task_possible(self):
-        """Check if adding a new task inside the process is possible.
-        It checks it the previous task is still in progress or planed state.
+    def adding_a_previous_task_is_possible(self):
+        """Check if adding a new task as previous task to the process is possible.
+        It checks if the current task is not yet started.
         """
-        return self.review_state in ['task-state-open', 'task-state-planned']
+        return self.review_state == 'task-state-planned'
 
     def get_css_class(self):
         """Returns css_class for the special task icons:

--- a/opengever/task/__init__.py
+++ b/opengever/task/__init__.py
@@ -27,6 +27,8 @@ FINISHED_TASK_STATES = [
 
 TASK_STATE_PLANNED = 'task-state-planned'
 
+TASK_STATE_SKIPPED = 'task-state-skipped'
+
 FINAL_TASK_STATES = [
     'task-state-tested-and-closed',
     'task-state-cancelled',

--- a/opengever/task/browser/forms.py
+++ b/opengever/task/browser/forms.py
@@ -109,7 +109,7 @@ class TaskAddForm(DefaultAddForm):
         # of a sequential process
         if ITask.providedBy(self.context) and self.context.is_sequential_main_task():
             position = data['tasktemplate_position']
-            if not position:
+            if position is None:
                 position = len(self.context.get_tasktemplate_order())
 
             for task in created:

--- a/opengever/task/browser/templates/overview.pt
+++ b/opengever/task/browser/templates/overview.pt
@@ -105,7 +105,7 @@
                   <a href="#" class="add-task"
                      title="Add task to sequence"
                      i18n:attributes="title label_add_task_to_sequence"
-                     tal:condition="python: task.adding_next_task_possible()"
+                     tal:condition="python: task.adding_a_previous_task_is_possible()"
                      tal:attributes="href string:${context/absolute_url}/++add++opengever.task.task?position=${position}" />
 
                   <div class="task"

--- a/opengever/task/configure.zcml
+++ b/opengever/task/configure.zcml
@@ -299,6 +299,11 @@
       />
 
   <adapter
+      factory=".transition.DefaultTransitionExtender"
+      name="task-transition-skipped-open"
+      />
+
+  <adapter
       factory=".transition.OpenPlannedTransitionExtender"
       name="task-transition-planned-open"
       />

--- a/opengever/task/handlers.py
+++ b/opengever/task/handlers.py
@@ -92,13 +92,11 @@ def cancel_subtasks(task, event):
 
 
 def start_next_task(task, event):
-    # todo also handle skipped tasks
     if event.action not in ['task-transition-open-resolved',
                             'task-transition-open-tested-and-closed',
                             'task-transition-in-progress-resolved',
                             'task-transition-in-progress-tested-and-closed',
-                            'task-transition-rejected-skipped',
-                            'task-transition-planned-skipped']:
+                            'task-transition-rejected-skipped']:
         return
 
     if task.is_from_sequential_tasktemplate:

--- a/opengever/task/tests/test_api_support.py
+++ b/opengever/task/tests/test_api_support.py
@@ -499,7 +499,7 @@ class TestAPITransitions(IntegrationTestCase):
         self.assertEqual(
             'task-state-skipped', api.content.get_state(self.seq_subtask_2))
         self.assertEqual(
-            'task-state-open', api.content.get_state(self.seq_subtask_3))
+            'task-state-planned', api.content.get_state(self.seq_subtask_3))
 
         response = IResponseContainer(self.seq_subtask_2).list()[-1]
         self.assertEqual(u'Ist nicht notwendig.', response.text)

--- a/opengever/task/tests/test_overview.py
+++ b/opengever/task/tests/test_overview.py
@@ -356,6 +356,8 @@ class TestSequentialTaskSubtask(IntegrationTestCase):
         task_add_form = '{}/++add++opengever.task.task'.format(
             self.sequential_task.absolute_url())
 
+        self.set_workflow_state('task-state-planned', self.seq_subtask_1)
+
         browser.open(self.sequential_task, view='tabbedview_view-overview')
         self.assertEqual(
             ['{}?position=0'.format(task_add_form),

--- a/opengever/task/tests/test_sequential_task_process.py
+++ b/opengever/task/tests/test_sequential_task_process.py
@@ -9,6 +9,7 @@ from opengever.base.oguid import Oguid
 from opengever.tasktemplates.interfaces import IFromSequentialTasktemplate
 from opengever.testing import IntegrationTestCase
 from plone import api
+from urlparse import urlparse
 from zope.interface import alsoProvides
 
 
@@ -294,6 +295,24 @@ class TestInitialStateForSubtasks(IntegrationTestCase):
 
 
 class TestAddingAdditionalTaskToSequentialProcess(IntegrationTestCase):
+
+    @browsing
+    def test_add_previous_task_buttons_is_only_visible_if_next_task_is_not_yet_started(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        # First task is already started - so position 0 button is not available
+        browser.open(self.sequential_task, view='tabbedview_view-overview')
+        self.assertEquals(
+            ['position=1', 'position=2', ''],
+            [urlparse(link.get('href')).query for link in browser.css('.add-task')])
+
+        # Second task is also started - so position 0 and 1 button aren't available
+        self.set_workflow_state('task-state-tested-and-closed', self.seq_subtask_1)
+        self.set_workflow_state('task-state-open', self.seq_subtask_2)
+        browser.open(self.sequential_task, view='tabbedview_view-overview')
+        self.assertEquals(
+            ['position=2', ''],
+            [urlparse(link.get('href')).query for link in browser.css('.add-task')])
 
     @browsing
     def test_position_field_is_not_visible(self, browser):

--- a/opengever/task/tests/test_sequential_task_process.py
+++ b/opengever/task/tests/test_sequential_task_process.py
@@ -360,6 +360,24 @@ class TestAddingAdditionalTaskToSequentialProcess(IntegrationTestCase):
              u'Subtask'],
             [oguid.resolve_object().title for oguid in oguids])
 
+    @browsing
+    def test_zero_position_is_handled_correctly(self, browser):
+        self.login(self.regular_user, browser=browser)
+
+        browser.open(self.sequential_task, view='++add++opengever.task.task?position=0')
+        browser.fill({'Title': 'Subtask', 'Task type': 'comment'})
+        form = browser.find_form_by_field('Responsible')
+        form.find_widget('Responsible').fill(self.secretariat_user)
+        browser.click_on('Save')
+
+        oguids = self.sequential_task.get_tasktemplate_order()
+        self.assertEquals(
+            [u'Subtask',
+             u'Mitarbeiter Dossier generieren',
+             u'Arbeitsplatz vorbereiten',
+             u'Vorstellungsrunde bei anderen Mitarbeitern'],
+            [oguid.resolve_object().title for oguid in oguids])
+
 
 class TestAddingSubtaskToSequentialSubtask(IntegrationTestCase):
 


### PR DESCRIPTION
This PR provides some fixes for the sequential task process feature:
- Fixed automatic start of a next task inside a sequential task process.
- Only show "add task to process" link, if next task is not yet started.
- Fix adding sequential task process on first position.

This ensures that only one task is open in a process.

For https://4teamwork.atlassian.net/browse/CA-1429

## Checklist (Must have)
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)
- [x] Works also for the new UI
