### PR TITLE
Filter out folder_delete folder button in @actions on repofolders.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,7 @@ Changelog
 - Fixed automatic start of a next task inside a sequential task process. [phgross]
 - Only show "add task to process" link, if next task is not yet started. [phgross]
 - Fix adding sequential task process on first position. [phgross]
+- Filter out folder_delete folder button in @actions on repofolders. [njohner]
 - Filter out trash and untrash folder buttons in @actions on repository root and folders. [njohner]
 - Don't resolve or deactivate a dossier if it has linked workspaces without view permission. [elioschmutz]
 - Reset value of NamedFileWidget in DocumentAddForm when validation fails. [njohner]

--- a/opengever/api/tests/test_actions.py
+++ b/opengever/api/tests/test_actions.py
@@ -1012,7 +1012,6 @@ class TestFolderButtons(FolderActionsTestBase):
             {u'icon': u'', u'id': u'submit_additional_documents',
                 u'title': u'Submit additional documents'},
             {u'icon': u'', u'id': u'export_documents', u'title': u'Export selection'},
-            {u'icon': u'', u'id': u'folder_delete_confirmation', u'title': u'Delete'},
             {u'icon': u'', u'id': u'delete_participants', u'title': u'Delete'},
             {u'icon': u'', u'id': u'add_participant', u'title': u'Add participant'},
             {u'icon': u'', u'id': u'move_items', u'title': u'Move items'},

--- a/opengever/base/browser/folder_buttons_availability.py
+++ b/opengever/base/browser/folder_buttons_availability.py
@@ -140,5 +140,8 @@ class FolderButtonsAvailabilityView(BrowserView):
                 and not self._is_repository_root()
                 and not self._is_template_area())
 
+    def is_folder_delete_available(self):
+        return not self._is_repository_folder()
+
     def is_attach_documents_available(self):
         return not self._is_template_area()

--- a/opengever/core/profiles/default/actions.xml
+++ b/opengever/core/profiles/default/actions.xml
@@ -389,7 +389,7 @@
       <property name="url_expr">string:folder_delete_confirmation:method</property>
       <property name="link_target" />
       <property name="icon_expr" />
-      <property name="available_expr" />
+      <property name="available_expr">object/@@folder_buttons_availability/is_folder_delete_available</property>
       <property name="permissions">
         <element value="Delete objects" />
       </property>


### PR DESCRIPTION
`folder_delete` action is available in new frontend for administrators on the repository folder level, but it isn't actually allowed to delete any objects. In the classic UI this action is not enabled on the documents tab of the repository folder. We do the same here and filter it out. 

This was not a requirement of any story, but stumbled upon it while looking at https://4teamwork.atlassian.net/browse/CA-1828

## Checklist (Must have)
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)