### PR TITLE
Allow any authenticated users to use the REST API.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2021.5.0 (unreleased)
 ---------------------
 
+- Allow any authenticated users to use the REST API. [phgross]
 - The @sharing endpoint now returns a batched result set if using the search param.  [elioschmutz]
 - Cleanup conditionals protecting for changed date not set yet. [njohner]
 - Use changed instead of modified in date range calculation for SIP packages. [njohner]

--- a/opengever/core/profiles/default/rolemap.xml
+++ b/opengever/core/profiles/default/rolemap.xml
@@ -203,6 +203,7 @@
       <role name="Contributor" />
       <role name="Manager" />
       <role name="Member" />
+      <role name="Authenticated" />
     </permission>
 
     <permission name="List folder contents" acquire="True">

--- a/opengever/core/upgrades/20210304141056_allow_authenticated_users_to_use_the_api/rolemap.xml
+++ b/opengever/core/upgrades/20210304141056_allow_authenticated_users_to_use_the_api/rolemap.xml
@@ -1,0 +1,14 @@
+<rolemap>
+
+  <permissions>
+
+    <permission name="plone.restapi: Use REST API" acquire="True">
+      <role name="Contributor" />
+      <role name="Manager" />
+      <role name="Member" />
+      <role name="Authenticated" />
+    </permission>
+
+  </permissions>
+
+</rolemap>

--- a/opengever/core/upgrades/20210304141056_allow_authenticated_users_to_use_the_api/upgrade.py
+++ b/opengever/core/upgrades/20210304141056_allow_authenticated_users_to_use_the_api/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AllowAuthenticatedUsersToUseTheAPI(UpgradeStep):
+    """Allow Authenticated Users to use the API.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()


### PR DESCRIPTION
This PR solves the problem that if a user in the new frontend, i.e. via API, wants to access a foreign task in a foreign admin unit.

With the current implementation, the task responsible is allowed to access the task on the foreign admin_unit, but not to use the API on PloneSite root level, wich leads in Unauthorized Exceptions when using the new frontend and clicking on a foreign task.

https://4teamwork.atlassian.net/browse/CA-1859

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

_Only applicable should be left and checked._

- Upgrade steps (changes in profile)

