### PR TITLE
Fix support in TransitionExtender for RelationChoice fields.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 2021.5.0 (unreleased)
 ---------------------
 
+- Fix support in TransitionExtender for RelationChoice fields. [phgross]
 - Allow any authenticated users to use the REST API. [phgross]
 - The @sharing endpoint now returns a batched result set if using the search param.  [elioschmutz]
 - Cleanup conditionals protecting for changed date not set yet. [njohner]

--- a/opengever/api/transition.py
+++ b/opengever/api/transition.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from opengever.base.security import elevated_privileges
 from opengever.base.transition import ITransitionExtender
 from opengever.dossier.activate import DossierActivator
@@ -118,7 +119,7 @@ class GEVERWorkflowTransition(WorkflowTransition):
             adapter = queryMultiAdapter(
                 (obj, getRequest()), ITransitionExtender, name=self.transition)
             if adapter:
-                errors = adapter.validate_schema(data)
+                errors = adapter.validate_schema(deepcopy(data))
                 if errors:
                     raise BadRequest(errors)
 

--- a/opengever/task/tests/test_api_support.py
+++ b/opengever/task/tests/test_api_support.py
@@ -242,7 +242,8 @@ class TestAPITransitions(IntegrationTestCase):
 
         url = '{}/@workflow/task-transition-in-progress-resolved'.format(self.subtask.absolute_url())
 
-        data = {'text': 'Erledigt, siehe Anhang.'}
+        data = {'text': 'Erledigt, siehe Anhang.',
+                'relatedItems': [self.mail_eml.absolute_url()]}
         browser.open(url, method='POST', data=json.dumps(data),
                      headers=self.api_headers)
 


### PR DESCRIPTION
The RelationChoice validator from the plone.restapi, make changes on the passed in data, so its necessary to pass in a deepcopy. Otherwise we pass in a list of objects instead of paths to the `doActionFor` call, which leads to an error in restapi's deserializer.

https://4teamwork.atlassian.net/browse/CA-1693

## Checklist
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)

