### PR TITLE
Fix tabbedview's upload container position for latest chrome versions.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -9,6 +9,7 @@ Changelog
 - Fix adding sequential task process on first position. [phgross]
 - Filter out folder_delete folder button in @actions on repofolders. [njohner]
 - Filter out trash and untrash folder buttons in @actions on repository root and folders. [njohner]
+- Fix tabbedview's upload container position for latest chrome versions. [phgross]
 - Don't resolve or deactivate a dossier if it has linked workspaces without view permission. [elioschmutz]
 - Reset value of NamedFileWidget in DocumentAddForm when validation fails. [njohner]
 

--- a/plonetheme/teamraum/resources/css/main.css
+++ b/plonetheme/teamraum/resources/css/main.css
@@ -3028,7 +3028,6 @@ span.address {
 }
 
 .uploaderContainer {
-  float: left;
   width: 100%;
   margin: 1em 0;
 }


### PR DESCRIPTION
Since the latest chrome version (89.*) the upload box was displayed incorrectly - behind the title area, so that no upload was possible anymore.

See <img width="1353" alt="Bildschirmfoto 2021-03-05 um 15 37 14" src="https://user-images.githubusercontent.com/485755/110129969-cf502780-7dc8-11eb-8395-50ccaee97d43.png">

The `float:left` statement, seems not necessary, no side effects detected. Also discussed it with Kevin, who implemented the styling 5 years ago.

https://4teamwork.atlassian.net/browse/CA-1857

## Checklist

_Everything has to be done/checked. Checked but not present means the author deemed it unnecessary._
- [x] Changelog entry
- [x] Link to issue (Jira or GitHub) and backlink in issue (Jira)